### PR TITLE
vagrant: forbid replacing insecure key

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,10 @@ if File.exist?(CONFIG)
 end
 
 Vagrant.configure("2") do |config|
+  # vagrant fails to replace key properly, which leads to inability to control
+  # VM after second start
+  config.ssh.insert_key = false
+
   config.vm.box = "coreos-%s" % $update_channel
   config.vm.box_version = ">= 308.0.1"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel


### PR DESCRIPTION
This is a workaround for #161.

Applying this wouldn't make things worse then they were in vagrang-1.6 days, but it is not a proper secure solution.