### PR TITLE
[Hold Until RancherOS Release] Use RancherOS to run Rancher Vagrant environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,65 +1,47 @@
 # -*- mode: ruby -*-
-# # vi: set ft=ruby :
+# vi: set ft=ruby :
 
-# This is fork of https://github.com/coreos/coreos-vagrant
+require_relative 'vagrant_rancheros_guest_plugin.rb'
 
-require 'fileutils'
-
-Vagrant.require_version ">= 1.6.0"
-
-CONFIG = File.join(File.dirname(__FILE__), "vagrant", "config.rb")
-
-# Defaults for config options defined in CONFIG
-$update_channel = "alpha"
-$expose_rancher_ui = 8080
+# To enable rsync folder share change to false
+$rancher_ui_port = 8080
 $vb_gui = false
-$vb_memory = 1024
-$vb_cpus = 1
-$private_ip = "172.17.8.100"
+$rsync_folder_disabled = true
+$number_of_nodes = 1
+$vm_mem = "1024"
+$host_ip = "172.19.8.100"
 
-if File.exist?(CONFIG)
-  require CONFIG
-end
 
-Vagrant.configure("2") do |config|
-  config.vm.box = "coreos-%s" % $update_channel
-  config.vm.box_version = ">= 308.0.1"
-  config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  config.vm.box   = "rancherio/rancheros"
+  config.vm.box_version = ">=0.1.2"
 
-  config.vm.provider :vmware_fusion do |vb, override|
-    override.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json" % $update_channel
-  end
 
-  config.vm.provider :virtualbox do |v|
-    # On VirtualBox, we don't have guest additions or a functional vboxsf
-    # in CoreOS, so tell Vagrant that so it can be smarter.
-    v.check_guest_additions = false
-    v.functional_vboxsf     = false
-  end
-
-  # plugin conflict
-  if Vagrant.has_plugin?("vagrant-vbguest") then
-    config.vbguest.auto_update = false
-  end
-
-  config.vm.define vm_name = "rancher" do |config|
-    config.vm.hostname = vm_name
-
-    config.vm.network "forwarded_port", guest: 8080, host: $expose_rancher_ui, auto_correct: true
-
-    config.vm.provider :vmware_fusion do |vb|
-      vb.gui = $vb_gui
+  config.vm.define "rancher" do |config|
+    config.vm.provider "virtualbox" do |vb|
+        vb.memory = $vm_mem
+        vb.gui = $vb_gui
     end
 
-    config.vm.provider :virtualbox do |vb|
-      vb.gui = $vb_gui
-      vb.memory = $vb_memory
-      vb.cpus = $vb_cpus
-    end
+    config.vm.network "private_network", ip: $host_ip
 
-    config.vm.network :private_network, ip: $private_ip
+    # Disabling compression because OS X has an ancient version of rsync installed.
+    # Add -z or remove rsync__args below if you have a newer version of rsync on your machine.
+    config.vm.synced_folder ".", "/opt/rancher", type: "rsync",
+        rsync__exclude: ".git/", rsync__args: ["--verbose", "--archive", "--delete", "--copy-links"],
+        disabled: $rsync_folder_disabled
 
-    config.vm.provision :shell, :inline => "docker run -d -p 8080:8080 rancher/server:latest", :privileged => true
-    config.vm.provision :shell, :inline => "docker run -e CATTLE_AGENT_IP=%s -e WAIT=true -v /var/run/docker.sock:/var/run/docker.sock rancher/agent:latest http://localhost:8080" % $private_ip, :privileged => true
+
+    config.vm.provision :shell,
+        :inline => "docker run -d -p 8080:8080 rancher/server",
+        :privileged => true
+
+    config.vm.provision :shell,
+        :inline => "docker run -e CATTLE_AGENT_IP=%s -e WAIT=true -v /var/run/docker.sock:/var/run/docker.sock rancher/agent http://localhost:8080" % $host_ip,
+        :privileged => true
   end
 end

--- a/vagrant_rancheros_guest_plugin.rb
+++ b/vagrant_rancheros_guest_plugin.rb
@@ -1,0 +1,50 @@
+require 'ipaddr'
+
+## Hacking this until we get a real plugin
+
+# Borrowing from http://stackoverflow.com/questions/1825928/netmask-to-cidr-in-ruby
+IPAddr.class_eval do
+  def to_cidr
+    self.to_i.to_s(2).count("1")
+  end
+end
+
+module VagrantPlugins
+    module GuestLinux
+        class Plugin < Vagrant.plugin("2")
+            guest_capability("linux", "configure_networks") do
+                Cap::ConfigureNetworks
+            end
+        end
+
+        module Cap
+            class ConfigureNetworks
+
+                def self.configure_networks(machine, networks)
+                    machine.communicate.tap do |comm|
+                        interfaces = []
+                        comm.sudo("ip link show|grep eth[1-9]|awk -e '{print $2}'|sed -e 's/:$//'") do |_, result|
+                            interfaces = result.split("\n")
+                        end
+
+                        networks.each do |network|
+                            dhcp = "true"
+                            iface = interfaces[network[:interface].to_i - 1]
+
+                            if network[:type] == :static
+                                cidr = IPAddr.new(network[:netmask]).to_cidr
+                                comm.sudo("rancherctl config set network.interfaces.#{iface}.address #{network[:ip]}/#{cidr}")
+                                comm.sudo("rancherctl config set network.interfaces.#{iface}.match #{iface}")
+
+                                dhcp = "false"
+                            end
+                            comm.sudo("rancherctl config set network.interfaces.#{iface}.dhcp #{dhcp}")
+                        end
+
+                        comm.sudo("system-docker restart network")
+                    end
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
Swaps out previous Vagrant configuration for one based on RancherOS. Still a simple 1 node setup.