### PR TITLE
vagrant configuration changes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ CONFIG = File.join(File.dirname(__FILE__), "vagrant", "config.rb")
 $update_channel = "alpha"
 $expose_rancher_ui = 8080
 $vb_gui = false
-$vb_memory = 1024
+$vb_memory = 2048
 $vb_cpus = 1
 $private_ip = "172.17.8.100"
 
@@ -22,6 +22,7 @@ if File.exist?(CONFIG)
 end
 
 Vagrant.configure("2") do |config|
+  config.ssh.insert_key = false
   config.vm.box = "coreos-%s" % $update_channel
   config.vm.box_version = ">= 308.0.1"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
@@ -59,7 +60,7 @@ Vagrant.configure("2") do |config|
 
     config.vm.network :private_network, ip: $private_ip
 
-    config.vm.provision :shell, :inline => "docker run -d -p 8080:8080 rancher/server:latest", :privileged => true
+    config.vm.provision :shell, :inline => "docker run -d --restart=always -p 8080:8080 rancher/server:latest", :privileged => true
     config.vm.provision :shell, :inline => "docker run -e CATTLE_AGENT_IP=%s -e WAIT=true -v /var/run/docker.sock:/var/run/docker.sock rancher/agent:latest http://localhost:8080" % $private_ip, :privileged => true
   end
 end


### PR DESCRIPTION
Had some issues with the vagrant set up.

* Memory at 1Gb was too low and causing rancher to crash.
* config.ssh.insert_key = false to always use the vagrant insecure key for managing rancher.