### PR TITLE
[WIP] Add support to download and run local agents

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends openjdk-7-jre-h
 ENV CATTLE_HOME /var/lib/cattle
 ENV DEFAULT_CATTLE_API_UI_INDEX //releases.rancher.com/ui/0.40.0
 ENV CATTLE_DB_CATTLE_DATABASE mysql
+ENV CATTLE_USE_LOCAL_ARTIFACTS true
 ADD artifacts /usr/share/cattle
 
 ADD service /service

--- a/server/artifacts/cattle.sh
+++ b/server/artifacts/cattle.sh
@@ -19,6 +19,15 @@ if [ -e $DEBUG_JAR ]; then
     JAR=$DEBUG_JAR
 fi
 
+setup_local_agents()
+{
+    if [ "${CATTLE_USE_LOCAL_ARTIFACTS}" == "true" ]; then
+        if [ -f /usr/share/cattle/env_vars ]; then
+            source /usr/share/cattle/env_vars
+        fi
+    fi
+}
+
 setup_graphite()
 {
     # Setup Graphite
@@ -132,12 +141,14 @@ setup_proxy()
     fi
 }
 
+setup_local_agents
 setup_graphite
 setup_gelf
 setup_mysql
 setup_redis
 setup_zk
 setup_proxy
+
 
 env | grep CATTLE | grep -v PASS | sort
 

--- a/server/artifacts/install_cattle_binaries
+++ b/server/artifacts/install_cattle_binaries
@@ -7,7 +7,7 @@ cd /tmp/extracted_cattle
 
 install_build_tools()
 {
-    BUILD_TOOLS_VERSION="0.1.0"
+    BUILD_TOOLS_VERSION="0.2.0"
     tmpdir=$(mktemp -d)
     pushd $tmpdir
     curl -sSL -o build-tools.tar.gz https://github.com/rancherio/build-tools/archive/v${BUILD_TOOLS_VERSION}.tar.gz
@@ -30,6 +30,18 @@ clean_up()
     rm -rf ./extracted_cattle
 }
 
+local_agents()
+{
+    mkdir -p /usr/share/cattle/artifacts
+    echo "# Autopopulated by cattle_binary_pull">/usr/share/cattle/env_vars
+    for i in $(grep agent\.package ./cattle-global.properties); do
+        env_var_name=$(echo $i | cut -d'=' -f1 | sed 's/^\(.*\)/CATTLE_\1/;s/\./_/g' | tr [a-z] [A-Z])
+        url=$(echo $i| cut -d'=' -f2)
+        file_name=$(echo ${url##*/})
+        echo export ${env_var_name}=/usr/share/cattle/artifacts/${file_name} >> /usr/share/cattle/env_vars
+    done
+}
+
 trap clean_up EXIT SIGINT SIGTERM
 
 install_build_tools
@@ -37,4 +49,6 @@ install_build_tools
 if [ -f "/usr/share/cattle/cattle.jar" ]; then
     unpack_jar
     /usr/bin/cattle-binary-pull ./cattle-global.properties /usr/bin
+    local_agents
+    /usr/bin/cattle-binary-pull ./cattle-global.properties /usr/share/cattle/artifacts agent
 fi


### PR DESCRIPTION
To support networks that may not have access to CDN the agents
are now downloaded into the rancher/server container. They are
compressed and accessed through the CATTLE_ settings. The default
behavior will now be to use the local agents. If a user wants to
leverage the CDN versions a `-e USE_LOCAL_AGENTS=false` must be
passed when starting the container.