### PR TITLE
Add capability to use agent from private registry

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -15,11 +15,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends libssl-dev pyth
     pip install --upgrade requests[security]==2.7.0 &&\
     apt-get remove -y --purge python-dev libffi-dev libssl-dev gcc && apt-get autoremove -y
 RUN curl -s http://stedolan.github.io/jq/download/linux64/jq > /usr/bin/jq; chmod +x /usr/bin/jq
-RUN curl -s https://get.docker.io/builds/Linux/x86_64/docker-1.6.0 > /usr/bin/docker; chmod +x /usr/bin/docker
+RUN curl -s -L https://get.docker.com/builds/Linux/x86_64/docker-1.6.0 > /usr/bin/docker; chmod +x /usr/bin/docker
 RUN curl -s -L https://github.com/rancherio/thin-provisioning-tools/releases/download/rancher-v0.1/pdata_tools > /usr/bin/pdata_tools; chmod +x /usr/bin/pdata_tools
 RUN apt-get update && apt-get install -y --no-install-recommends conntrack
 RUN mkdir -p /var/lib/cattle /var/lib/rancher
 COPY register.py resolve_url.py agent.sh run.sh /
 ENTRYPOINT ["/run.sh"]
 LABEL "io.rancher.container.system"="rancher-agent"
-ENV RANCHER_AGENT_IMAGE rancher/agent:v0.7.11
+ENV RANCHER_AGENT_IMAGE rancher/agent:v0.8.0

--- a/agent/run.sh
+++ b/agent/run.sh
@@ -29,6 +29,19 @@ export CATTLE_HOME=${CATTLE_HOME:-/var/lib/cattle}
 
 check_debug
 
+CONTAINER="$(hostname)"
+if [ "$1" = "run" ]; then
+    CONTAINER="rancher-agent"
+fi
+
+if [ "$1" != "inspect-host" ]; then
+    RUNNING_IMAGE="$(docker inspect -f '{{.Config.Image}}' ${CONTAINER})"
+fi
+
+if [[ -n ${RUNNING_IMAGE} && ${RUNNING_IMAGE} != ${RANCHER_AGENT_IMAGE} ]]; then
+    export RANCHER_AGENT_IMAGE=${RUNNING_IMAGE}
+fi
+
 launch_volume()
 {
     if docker inspect rancher-agent-state >/dev/null 2>&1; then


### PR DESCRIPTION
This part of the process allows the agent to register and passes along what it needs to. Need to update cattle upgrade script to pass along the variable.

The variable name may need to be changed.

Also, Fixes docker redirect for binaries. New images will have an empty file for /usr/bin/docker.
