### PR TITLE
Ignore docker inspect on state run

### DIFF
--- a/agent/run.sh
+++ b/agent/run.sh
@@ -34,7 +34,7 @@ if [ "$1" = "run" ]; then
     CONTAINER="rancher-agent"
 fi
 
-if [[ "$1" != "inspect-host" && $1 != "--" ]]; then
+if [[ "$1" != "inspect-host" && $1 != "--" && "$1" != "state" ]]; then
     RUNNING_IMAGE="$(docker inspect -f '{{.Config.Image}}' ${CONTAINER})"
 fi
 


### PR DESCRIPTION
Fixes the docker error appearing in the rancher-agent-state container.