### PR TITLE
Fix usermod error UID 0 already exists.

### DIFF
--- a/server/artifacts/mysql.sh
+++ b/server/artifacts/mysql.sh
@@ -90,7 +90,7 @@ EOF
 }
 
 ## Boot2docker hack
-if [ "$(lsmod | grep vboxguest)" ]; then
+if [ "$(grep /var/lib/mysql /proc/mounts|cut -d' ' -f3)" = "vboxsf" ]; then
     echo "Running in VBox change mysql UID"
     uid=$(stat -c "%u" ${DATADIR})
     usermod -u ${uid} mysql


### PR DESCRIPTION
This bug prevented rancher/server from starting when a non-vboxfs
directory was used as the mount point for /var/lib/mysql. In the
case of docker-machine/boot2docker any directory outside of /Users
on a Mac or non rancher/server container volumes from meet this
criteria. VBoxFS mounts do not allow changing UID/GID or permissions
of the directory. To address we change the UID of the MySQL user
to the directory owner UID.
