### PR TITLE
MySQL updates to logs and innodb files

### DIFF
--- a/server/artifacts/mysql.sh
+++ b/server/artifacts/mysql.sh
@@ -57,6 +57,7 @@ config_mysql()
     sed -i 's/^\(bind-address.*\)$/#\1/' /etc/mysql/my.cnf
     sed -i 's/^#\(max_connections.*\)/\1/;s/100$/1000/' /etc/mysql/my.cnf
     sed -i 's/^key_buffer[[:space:]]/key_buffer_size/' /etc/mysql/my.cnf
+    sed -i 's/^\(expire_logs_days.*\)/\1/;s/10$/2/' /etc/mysql/my.cnf
 
     # setup to be a master
     if [ "$(grep ^#server-id /etc/mysql/my.cnf)" ]; then
@@ -64,6 +65,10 @@ config_mysql()
         sed -i 's/^#\(log_bin.*\)/\1/' /etc/mysql/my.cnf
         sed -i '/^log_bin.*$/a innodb_flush_log_at_trx_commit = 1' /etc/mysql/my.cnf
         sed -i '/^log_bin.*$/a sync_binlog           = 1' /etc/mysql/my.cnf
+    fi
+
+    if [ ! "$(grep innodb_file_per_table /etc/mysql/my.cnf)" ]; then
+        sed -i '/^# \* InnoDB.*$/a innodb_file_per_table = 1' /etc/mysql/my.cnf
     fi
 }
 


### PR DESCRIPTION
This is to address issue #2087 the single innodb file gets very large while running rancher. The innodb_file_per_table setting has been set, and is the default setting in newer versions of MySQL.

Also, to address  #2136 the binlog rotation has been shortend down to two days.

After starting a rancher server the my.cnf file should have the following entries:
expire_logs_days = 2
innodb_files_per_table = 1

This should be verified to work in the following scenarios
 * container restart (my.cnf should not have changed after restart)
 * Bind mounted to a host. (new and upgrade)
 * Upgrade with volumes from
