### PR TITLE
Added support for non-default docker sock via HOST_DOCKER_SOCK

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -23,3 +23,4 @@ COPY register.py resolve_url.py agent.sh run.sh /
 ENTRYPOINT ["/run.sh"]
 LABEL "io.rancher.container.system"="rancher-agent"
 ENV RANCHER_AGENT_IMAGE rancher/agent:v0.8.2
+ENV HOST_DOCKER_SOCK /var/run/docker.sock

--- a/agent/run.sh
+++ b/agent/run.sh
@@ -100,7 +100,7 @@ launch_agent()
         -e CATTLE_URL \
         -e CATTLE_HOST_LABELS \
         -e CATTLE_VOLMGR_ENABLED \
-        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v $HOST_DOCKER_SOCK:/var/run/docker.sock \
         -v /lib/modules:/lib/modules:ro \
         -v ${var_lib_docker}:${var_lib_docker} \
         -v /proc:/host/proc \

--- a/agent/run.sh
+++ b/agent/run.sh
@@ -100,6 +100,7 @@ launch_agent()
         -e CATTLE_URL \
         -e CATTLE_HOST_LABELS \
         -e CATTLE_VOLMGR_ENABLED \
+        -e HOST_DOCKER_SOCK \
         -v $HOST_DOCKER_SOCK:/var/run/docker.sock \
         -v /lib/modules:/lib/modules:ro \
         -v ${var_lib_docker}:${var_lib_docker} \


### PR DESCRIPTION
Support for non-default docker socket via environment variable `HOST_DOCKER_SOCK`, which defaults to `/var/run/docker.sock`

Example:

`docker run -d --privileged -e HOST_DOCKER_SOCK=/var/run/docker-test.sock -v /var/run/docker-test.sock:/var/run/docker.sock rancher/agent:v0.8.2 <server-end-point>`
