### PR TITLE
bump RancherOS version and settings

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 require_relative 'vagrant_ros_guest_plugin.rb'
 
-$number_of_nodes = 1
+$number_of_nodes = 2
 # DO NOT USE 172.17.*, 172.18.*, 10.0.2 as these are used on other NICs: routing will get screwed!
 $private_ip_prefix = '172.19.8' # rancher-server will be on 172.19.8.100, other nodes will start from 172.19.8.101
 $expose_rancher_ui = 8080
@@ -21,7 +21,7 @@ end
 
 Vagrant.configure(2) do |config|
   config.vm.box         = 'rancherio/rancheros'
-  config.vm.box_version = '>=0.3.3'
+  config.vm.box_version = '0.4.1'
 
   config.vm.provider 'virtualbox' do |vb|
     vb.gui = $vb_gui

--- a/vagrant_ros_guest_plugin.rb
+++ b/vagrant_ros_guest_plugin.rb
@@ -40,12 +40,12 @@ module VagrantPlugins
 
                             if network[:type] == :static
                                 cidr = IPAddr.new(network[:netmask]).to_cidr
-                                comm.sudo("ros config set network.interfaces.#{iface}.address #{network[:ip]}/#{cidr}")
-                                comm.sudo("ros config set network.interfaces.#{iface}.match #{iface}")
+                                comm.sudo("ros config set rancher.network.interfaces.#{iface}.address #{network[:ip]}/#{cidr}")
+                                comm.sudo("ros config set rancher.network.interfaces.#{iface}.match #{iface}")
 
                                 dhcp = "false"
                             end
-                            comm.sudo("ros config set network.interfaces.#{iface}.dhcp #{dhcp}")
+                            comm.sudo("ros config set rancher.network.interfaces.#{iface}.dhcp #{dhcp}")
                         end
 
                         comm.sudo("system-docker restart network")


### PR DESCRIPTION
and pin RancherOS version. 

Also, the setup is now 2 nodes (1024MB RAM each), by default. There are a couple reasons for this:
 - Rancher Server leaves very little memory for containers
 - the hosts page looks way cooler with more than one node ;)