### PR TITLE
Add label to rancher-agent-state container.

### DIFF
--- a/agent/run.sh
+++ b/agent/run.sh
@@ -58,6 +58,7 @@ launch_volume()
 
     docker run \
         --name rancher-agent-state \
+        --label io.rancher.container.start_once=true \
         -v /var/lib/cattle \
         -v /var/log/rancher:/var/log/rancher \
         ${opts} ${RANCHER_AGENT_IMAGE} state


### PR DESCRIPTION
In the admin panel the rancher-agent-state docker shows up in red. So i have add the `io.rancher.container.start_once=true` label to it.