### PR TITLE
good detection for server version and client version

### DIFF
--- a/agent/run.sh
+++ b/agent/run.sh
@@ -161,8 +161,9 @@ resolve_var_lib_docker()
 verify_docker_client_server_version()
 {
     local client_version=$(docker version --format '{{.Client.Version}}')
+    local server_version=$(docker version --format '{{.Server.Version}}')
     info "Checking for Docker version >=" $client_version
-    docker version 2>&1 | grep Server\ version >/dev/null || {
+    docker version 2>&1 | grep $server_version >/dev/null || {
         echo "Please ensure Host Docker version is >=${client_version} and container has r/w permissions to docker.sock" 1>&2
         exit 1
     }

--- a/agent/run.sh
+++ b/agent/run.sh
@@ -160,13 +160,13 @@ resolve_var_lib_docker()
 
 verify_docker_client_server_version()
 {
-    local client_version=$(docker version |grep Client\ version | cut -d":" -f2)
+    local client_version=$(docker version --format '{{.Client.Version}}')
     info "Checking for Docker version >=" $client_version
     docker version 2>&1 | grep Server\ version >/dev/null || {
         echo "Please ensure Host Docker version is >=${client_version} and container has r/w permissions to docker.sock" 1>&2
         exit 1
     }
-    info Found $(docker version 2>&1 | grep Server\ version)
+    info Found $(docker version --format '{{.Server.Version}}')
     for i in version info; do
         docker $i | while read LINE; do
             info "docker $i:" $LINE

--- a/agent/run.sh
+++ b/agent/run.sh
@@ -167,7 +167,7 @@ verify_docker_client_server_version()
         echo "Please ensure Host Docker version is >=${client_version} and container has r/w permissions to docker.sock" 1>&2
         exit 1
     }
-    info Found $(docker version --format '{{.Server.Version}}')
+    info Found $server_version
     for i in version info; do
         docker $i | while read LINE; do
             info "docker $i:" $LINE


### PR DESCRIPTION
When you use this strings

```
docker version |grep Client\ version | cut -d":" -f2
docker version 2>&1 | grep Server\ version)
```

to detect Client or Server version you always see an EMPTY string.
