### PR TITLE
Adding quotes for globbing

### DIFF
--- a/server/build-image.sh
+++ b/server/build-image.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 set -e -x
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 if [ ! -e target/.done ]; then
     mkdir -p target
-    docker run -it -v $(pwd)/target:/output rancher/s6-builder:v0.1.0 /opt/build.sh
+    docker run -it -v "$(pwd)/target:/output" rancher/s6-builder:v0.1.0 /opt/build.sh
     touch target/.done
 fi
 
 TAG=${TAG:-$(awk '/CATTLE_RANCHER_SERVER_IMAGE/{print $3}' Dockerfile)}
 IMAGE=rancher/server:${TAG}
 
-docker build -t ${IMAGE} .
+docker build -t "${IMAGE}" .
 
-echo Done building ${IMAGE}
+echo Done building "${IMAGE}"


### PR DESCRIPTION
Added quotes to vars to prevent word splitting in case of spaces or special chars in dir names.

Ref: https://github.com/koalaman/shellcheck/wiki/SC2086