### PR TITLE
Make rancher server work in ubuntu:16.04 based container

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.4
+FROM ubuntu:16.04
 RUN apt-get update && \
      apt-get install --no-install-recommends -y \
      arptables \
@@ -6,22 +6,21 @@ RUN apt-get update && \
      ca-certificates \
      curl \
      iptables \
+     iproute2 \
      libssl-dev \
      libffi-dev \
      gcc \
      make \
      conntrack \
+     python-dev \
+     jq \
      libaio1 && \
-    curl -s https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz | tar -zxv -C /tmp/ && \
-    cd /tmp/Python-2.7.11 && ./configure && make && make install && \
     curl -s https://bootstrap.pypa.io/get-pip.py | python && \
     pip install eventlet cattle docker-py && \
     pip install --upgrade requests[security]==2.9.1 &&\
     apt-get remove -y --purge make libffi-dev libssl-dev gcc && apt-get autoremove -y && \
-    rm -rf /tmp/Python-2.7.11 && \
-    curl -s http://stedolan.github.io/jq/download/linux64/jq > /usr/bin/jq; chmod +x /usr/bin/jq && \
-    curl -s -L https://get.docker.com/builds/Linux/x86_64/docker-1.6.0 > /usr/bin/docker; chmod +x /usr/bin/docker && \
-    curl -s -L https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker-1.9; chmod +x /usr/bin/docker-1.9
+    curl -s -L https://get.docker.com/builds/Linux/x86_64/docker-1.6.0 > /usr/bin/docker && chmod +x /usr/bin/docker && \
+    curl -s -L https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker-1.9 && chmod +x /usr/bin/docker-1.9
 
 RUN mkdir -p /var/lib/cattle /var/lib/rancher
 COPY register.py resolve_url.py run.sh /

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:14.04.4
+FROM ubuntu:16.04
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends openjdk-7-jre-headless \
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-8-jre-headless \
                     curl \
                     mysql-server \
                     xz-utils \
@@ -9,10 +9,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends openjdk-7-jre-h
                     unzip \
                     openssh-client \
                     iptables \
+                    iproute2 \
                     git \
                     redis-server \
                     zookeeper \
                     spiped
+RUN mkdir -p /var/run/mysqld && chmod -R 777 /var/run/mysqld
 
 ADD https://github.com/cloudnautique/giddyup/releases/download/v0.10.0/giddyup /usr/bin/
 ADD https://github.com/rancher/cluster-manager/releases/download/v0.1.4/cluster-manager /usr/bin/


### PR DESCRIPTION
ubuntu:16.04 bumps to openjdk-8 and has an annoying mysql issue, but otherwise is fine