### PR TITLE
Add SaltStack installation option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Rancher is deployed as a set of Docker containers.  Running Rancher is as simple
 * [Manually](#launching-management-server)
 * [Puppet](https://github.com/nickschuch/puppet-rancher) (Thanks @nickschuch) 
 * [Ansible](https://github.com/joshuacox/ansibleplaybook-rancher)
+* [SaltStack](https://github.com/komljen/rancher-salt)
 
 ### Requirements
 


### PR DESCRIPTION
I created a Salt states for Rancher installation, right now with support for Vagrant, single Rancher server with external MySQL DB and auto provisioned agents. I'm planning to add more options and also to update a documentation for installation on other providers.