### PR TITLE
Add script to print tags of all sub-projects

### DIFF
--- a/scripts/print-tags.sh
+++ b/scripts/print-tags.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]; then
+    master="(Rancher tag not specified)"
+    tag='master'
+else
+    tag=$1
+fi
+
+CATTLE_VER=$(curl https://raw.githubusercontent.com/rancher/rancher/$tag/server/Dockerfile 2>/dev/null | grep 'ENV CATTLE_CATTLE_VERSION' | awk '{print $3}')
+
+echo -e "\nPrinting project/service tag information for Rancher tag $tag. $master"
+
+echo -e "\nCattle Tag: $CATTLE_VER\n"
+
+echo "Other project tags:"
+while read -r l; do 
+    PROP=$(echo "$l" | awk -F= '{print $1}')
+    URL=$(echo "$l" | awk -F= '{print $2}')
+    IFS=', ' read -r -a array <<< "$(echo $l | awk -F= '{print $2}')"
+    for element in "${array[@]}"
+    do
+        if [[ $element == http* ]]; then
+            URL=$element
+        fi
+    done
+
+    VER_AND_FILE=$(echo "$l" | grep "releases/download" | sed  "s/^.*download\///g")
+    #echo $VER_AND_FILE
+    VER=$(echo "$VER_AND_FILE" | awk -F/ '{print $1}')
+    FILE=$(echo "$VER_AND_FILE" | awk -F/ '{print $2}')
+    if [[ -n "$VER" ]]; then
+        printf "%40s %15s %s\n" "$PROP" "$VER" "$URL"
+    fi
+
+done < <(curl -s https://raw.githubusercontent.com/rancher/cattle/$CATTLE_VER/resources/content/cattle-global.properties)
+


### PR DESCRIPTION
sample output:
```
./scripts/print-tags.sh

Printing project/service tag information for Rancher tag master. (Rancher tag not specified)

Cattle Tag: v0.169.5

Other project tags:
          agent.package.python.agent.url         v0.85.1 https://github.com/rancher/python-agent/releases/download/v0.85.1/python-agent.tar.gz
        agent.package.agent.binaries.url          v0.1.2 https://github.com/rancher/agent-binaries/releases/download/v0.1.2/agent-binaries.tar.gz
            agent.package.node.agent.url          v0.1.0 https://github.com/rancher/node-agent/releases/download/v0.1.0/node-agent.tar.gz
           agent.package.rancher.dns.url          v0.9.2 https://github.com/rancher/rancher-dns/releases/download/v0.9.2/rancher-dns.tar.gz
      agent.package.rancher.metadata.url          v0.5.1 https://github.com/rancher/rancher-metadata/releases/download/v0.5.1/rancher-metadata.tar.gz
              agent.package.host.api.url         v0.35.0 https://github.com/rancher/host-api/releases/download/v0.35.0/host-api.tar.gz
           agent.package.rancher.net.url          v0.5.0 https://github.com/rancher/rancher-net/releases/download/v0.5.0/rancher-net.tar.gz
              agent.package.cadvisor.url         v0.23.4 https://github.com/rancher/cadvisor-package/releases/download/v0.23.4/cadvisor.tar.gz
               rancher.compose.linux.url          v0.1.0 https://github.com/rancher/rancher-compose/releases/download/v0.1.0/rancher-compose_linux-amd64
              rancher.compose.darwin.url          v0.1.0 https://github.com/rancher/rancher-compose/releases/download/v0.1.0/rancher-compose_darwin-amd64
             rancher.compose.windows.url          v0.1.0 https://github.com/rancher/rancher-compose/releases/download/v0.1.0/rancher-compose_windows-386.exe
             service.package.catalog.url          v0.9.1 https://github.com/rancher/rancher-catalog-service/releases/download/v0.9.1/rancher-catalog-service.tar.xz
     service.package.websocket.proxy.url         v0.17.0 https://github.com/rancher/websocket-proxy/releases/download/v0.17.0/websocket-proxy.tar.xz
  service.package.go.machine.service.url         v0.32.0 https://github.com/rancher/go-machine-service/releases/download/v0.32.0/go-machine-service.tar.xz
      service.package.docker.machine.url     v0.9.0-pre3 https://github.com/rancher/machine-package/releases/download/v0.9.0-pre3/docker-machine.tar.gz
                service.package.govc.url          v0.2.0 https://github.com/vmware/govmomi/releases/download/v0.2.0/govc_linux_amd64.gz
           service.package.telemetry.url          v0.2.0 https://github.com/rancher/telemetry/releases/download/v0.2.0/telemetry.tar.xz
                   machine.driver.packet          v0.1.2 https://github.com/packethost/docker-machine-driver-packet/releases/download/v0.1.2/docker-machine-driver-packet_linux-amd64.zip
                 machine.driver.ubiquity          v0.0.2 https://github.com/ubiquityhosting/docker-machine-driver-ubiquity/releases/download/v0.0.2/docker-machine-driver-ubiquity_linux-amd64
```