### PR TITLE
Fix connectivity check between agent and server

### DIFF
--- a/agent/run.sh
+++ b/agent/run.sh
@@ -298,7 +298,7 @@ wait_for()
     local url="$(print_url $CATTLE_URL)"
     info "Attempting to connect to: ${url}"
     for ((i=0; i < 300; i++)); do
-        if ! curl -f -L -s ${CATTLE_URL} >/dev/null 2>&1; then
+        if ! curl -f -L -s ${url} >/dev/null 2>&1; then
             error ${url} is not accessible
             sleep 2
             if [ "$i" -eq "299" ]; then


### PR DESCRIPTION
`CATTLE_URL` var is `http://rancher-server:8080/v1/scripts/A9FB52823FF03A706E90:1480636800000:KQM8CcOkslALKB9esPGVsGLNbzk` and it's not valid URL (HTTP 404), which is why cURL exits with non-zero status. I believe `url` var was meant to be used instead.

---

Before fix:

```
ERROR: http://rancher-server:8080/v1 is not accessible
```

After fix:
```
INFO: http://rancher-server:8080/v1 is accessible
...
INFO: Launched Rancher Agent: 4ac6d5327c7f6078bff737d2a09af5133eadb3a4f37b854c0a52ecde99fe3045
```