### PR TITLE
Added --advertise-address "awslocal"

### DIFF
--- a/server/bin/entry
+++ b/server/bin/entry
@@ -26,6 +26,8 @@ Clustering Options:
    --advertise-address     IP Address to which other servers will connect for full active/active HA.
                            This address does not need to be locally bound.  Full HA requires inbound
                            port 9345 to be open.  This setting is required for HA to be enabled.
+                           You may use either "ipify" for fetching global IP, "awslocal" for getting an AWS local IP, 
+                           a network interface (eg: eth0), or an ip address itself (eg: 172.10.11.12)
    --advertise-http-port   The published HTTP port on which other servers can connect to this one.
                            This should be the published port of the Docker container and not the port
                            of the load balancer in front of Rancher. (default: 8080)
@@ -69,6 +71,8 @@ while [ "$#" -gt 0 ]; do
             export DEFAULT_CATTLE_TRAEFIK_EXECUTE=true
             if [ -e "/sys/class/net/$1" ]; then
                 export CATTLE_CLUSTER_ADVERTISE_ADDRESS=$(ip addr show dev wlan0 | grep -w inet | awk '{print $2}' | cut -f1 -d/)
+            elif [ "$1" = "awslocal" ]; then
+                export CATTLE_CLUSTER_ADVERTISE_ADDRESS=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
             elif [ "$1" = "ipify" ]; then
                 export CATTLE_CLUSTER_ADVERTISE_ADDRESS=$(curl -s https://api.ipify.org)
             else


### PR DESCRIPTION
Add support --advertise-address "awslocal". 

This can be used to automatically detect AWS instance local host IP addresses, within an AWS host / ECS cluster.

A local host IP is useful, as users may have different security address or host binding for local IP's, and external IP's for security reasons.

Also added more details into help documentation command.

The sister issue posted is : #7343