### PR TITLE
Move update ssl script in server

### DIFF
--- a/server/artifacts/cattle.sh
+++ b/server/artifacts/cattle.sh
@@ -171,8 +171,6 @@ run() {
 
     env | grep CATTLE | grep -v PASS | sort
 
-    update-rancher-ssl
-
     local ram=$(free -g --si | awk '/^Mem:/{print $2}')
     if [ ${ram} -gt 6 ]; then
         MX="4g"
@@ -259,6 +257,8 @@ master()
     JAR=$(readlink -f code/packaging/app/target/cattle-app-*.war)
     run
 }
+
+update-rancher-ssl
 
 if [ "$1" = "extract" ]; then
     extract

--- a/server/bin/update-rancher-ssl
+++ b/server/bin/update-rancher-ssl
@@ -16,7 +16,7 @@ if [ -f "$CA_ROOT" ]; then
 
   if [ -n "$CATTLE_RANCHER_SERVER_VERSION" ]; then 
     # Remove the key if it exists
-    if keytool -list -keystore $JKS_STORE -alias rancher_ca -storepass $JAVA_STORE_PASS ; then
+    if keytool -list -keystore $JKS_STORE -alias rancher_ca -storepass $JAVA_STORE_PASS 2>&1 > /dev/null ; then
         keytool -delete -alias rancher_ca -storepass $JAVA_STORE_PASS -keystore $JKS_STORE -noprompt
     fi
 


### PR DESCRIPTION
When running master, if you want to use a self signed cert you have to manually add to keystore. This change now always runs the update-rancher-ssl script.

Also, this addresses issue #7232 by redirecting the keystore list output to /dev/null