### PR TITLE
Adds graphite_prometheus exporter

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -54,13 +54,14 @@ EXPOSE 3306
 ENV CATTLE_CATTLE_VERSION v0.177.8
 ADD https://github.com/rancherio/cattle/releases/download/${CATTLE_CATTLE_VERSION}/cattle.jar /usr/share/cattle/
 
-RUN cd / && for i in $(ls /s6-statics/*static.tar.gz);do tar -zxvf $i;done && rm -rf /s6-statics/*static.tar.gz && \
+RUN cd / && for i in $(ls /s6-statics/*static.tar.gz);do tar -C /usr -zxvf $i;done && rm -rf /s6-statics/*static.tar.gz && \
     mkdir -p $CATTLE_HOME && \
     /usr/share/cattle/cattle.sh extract && \
     curl -sL https:${DEFAULT_CATTLE_API_UI_INDEX}.tar.gz | tar xvzf - -C /usr/share/cattle/war --strip-components=1 && \
     mkdir -p /usr/share/cattle/war/api-ui && \
     curl -sL https:${CATTLE_API_UI_URL}.tar.gz | tar xvzf - -C /usr/share/cattle/war/api-ui --strip-components=1 && \
     /usr/share/cattle/install_cattle_binaries && \
+    curl -sL https://github.com/prometheus/graphite_exporter/releases/download/v0.2.0/graphite_exporter-0.2.0.linux-amd64.tar.gz | tar -xzv -C /usr/bin/ --strip-components=1 && \
     cd $CATTLE_HOME && export IFS="," && \
     echo "$DEFAULT_CATTLE_CATALOG_URL" > repo.json && \
     cat repo.json && \

--- a/server/artifacts/cattle.sh
+++ b/server/artifacts/cattle.sh
@@ -36,6 +36,16 @@ setup_graphite()
     export CATTLE_GRAPHITE_PORT=${CATTLE_GRAPHITE_PORT:-$GRAPHITE_PORT_2003_TCP_PORT}
 }
 
+setup_prometheus()
+{
+    # Setup Prometheus Graphite exporter
+    if [ "${CATTLE_PROMETHEUS_EXPORTER}" == "true" ]; then
+        s6-svc -u ${S6_SERVICE_DIR}/graphite_exporter
+        export DEFAULT_CATTLE_GRAPHITE_HOST=127.0.0.1
+        export DEFAULT_CATTLE_GRAPHITE_PORT=9109
+    fi
+}
+
 setup_gelf()
 {
     # Setup GELF
@@ -163,6 +173,7 @@ setup_proxy()
 run() {
     setup_local_agents
     setup_graphite
+    setup_prometheus
     setup_gelf
     setup_mysql
     setup_redis

--- a/server/build-image.sh
+++ b/server/build-image.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 
 if [ ! -e target/.done ]; then
     mkdir -p target
-    docker run -it -v "$(pwd)/target:/output" rancher/s6-builder:v0.1.0 /opt/build.sh
+    curl -sL -o target/s6-overlay-x86-static.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v1.19.1.1/s6-overlay-x86.tar.gz
     touch target/.done
 fi
 

--- a/server/service/graphite_exporter/finish
+++ b/server/service/graphite_exporter/finish
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/s6-svscanctl -t /service

--- a/server/service/graphite_exporter/run
+++ b/server/service/graphite_exporter/run
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+exec 2>&1
+exec /usr/bin/graphite_exporter


### PR DESCRIPTION
This PR does 2 things.
1. ) Updates S6 to a much newer version based on the same work we
originally had pulled from.

2. ) Adds the prom/graphite_exporter binary and s6 scripts to start.
The overall process is that the user now sets
`-e CATTLE_PROMETHEUS_EXPORTER=true` variable on launch and expose the port
9108 inside the container to some place Prometheus can scrape.