### PR TITLE
print catalog info

### DIFF
--- a/scripts/print-tags.sh
+++ b/scripts/print-tags.sh
@@ -35,3 +35,5 @@ while read -r l; do
 
 done < <(curl -s https://raw.githubusercontent.com/rancher/cattle/$CATTLE_VER/resources/content/cattle-global.properties)
 
+echo -e "\n\nCatalog item versions: (Pulling image may take several minutes)"
+docker run --rm -it rancher/server:$tag bash -c 'for i in /var/lib/cattle/cache/global/*; do git -C $i remote -vv; git -C $i rev-parse HEAD; for j in $i/infra-templates/*; do A=$(grep version $j/config.yml 2>/dev/null | cut -d" " -f2); echo $(basename $j): $A; for x in $(grep -Irl --exclude=config.yml $A $j 2>/dev/null); do grep -rh --include="docker-compose.*" -e "^[ \t]*image: " $(dirname $x) 2>/dev/null; done; done; echo -e "\n"; done' 2>/dev/null


### PR DESCRIPTION
Unfortunately, this only works for v1.5.0 and greater because the structure was different before then and I didn't want to figure it out
Sample output:
```
rancher$ ./scripts/print-tags.sh v1.5.0

Printing project/service tag information for Rancher tag v1.5.0. 

Cattle Tag: v0.177.7

Other project tags:
          agent.package.python.agent.url          v0.9.2 https://github.com/rancher/agent/releases/download/v0.9.2/go-agent.tar.gz
              agent.package.host.api.url         v0.38.1 https://github.com/rancher/host-api/releases/download/v0.38.1/host-api.tar.gz
               rancher.compose.linux.url          v0.1.0 https://github.com/rancher/rancher-compose/releases/download/v0.1.0/rancher-compose_linux-amd64
              rancher.compose.darwin.url          v0.1.0 https://github.com/rancher/rancher-compose/releases/download/v0.1.0/rancher-compose_darwin-amd64
             rancher.compose.windows.url          v0.1.0 https://github.com/rancher/rancher-compose/releases/download/v0.1.0/rancher-compose_windows-386.exe
             service.package.catalog.url         v0.16.8 https://github.com/rancher/catalog-service/releases/download/v0.16.8/rancher-catalog-service.tar.xz
    service.package.compose.executor.url         v0.13.0 https://github.com/rancher/rancher-compose-executor/releases/download/v0.13.0/rancher-compose.gz
     service.package.websocket.proxy.url         v0.20.2 https://github.com/rancher/websocket-proxy/releases/download/v0.20.2/websocket-proxy.tar.xz
  service.package.go.machine.service.url         v0.36.1 https://github.com/rancher/go-machine-service/releases/download/v0.36.1/go-machine-service.tar.xz
      service.package.docker.machine.url    v0.10.0-pre1 https://github.com/rancher/machine-package/releases/download/v0.10.0-pre1/docker-machine.tar.gz
                service.package.govc.url          v0.2.0 https://github.com/vmware/govmomi/releases/download/v0.2.0/govc_linux_amd64.gz
           service.package.telemetry.url          v0.4.0 https://github.com/rancher/telemetry/releases/download/v0.4.0/telemetry.tar.xz
        service.package.auth.service.url          v0.2.0 https://github.com/rancher/rancher-auth-service/releases/download/v0.2.0/rancher-auth-service.tar.xz
     service.package.webhook.service.url          v0.9.7 https://github.com/rancher/webhook-service/releases/download/v0.9.7/webhook-service.tar.xz
         service.package.secrets.api.url          v0.0.5 https://github.com/rancher/secrets-api/releases/download/v0.0.5/secrets-api
                   machine.driver.packet          v0.1.2 https://github.com/packethost/docker-machine-driver-packet/releases/download/v0.1.2/docker-machine-driver-packet_linux-amd64.zip
                 machine.driver.ubiquity          v0.0.2 https://github.com/ubiquityhosting/docker-machine-driver-ubiquity/releases/download/v0.0.2/docker-machine-driver-ubiquity_linux-amd64


Catalog item versions: (Pulling image may take several minutes)
origin  https://git.rancher.io/community-catalog.git (fetch)
origin  https://git.rancher.io/community-catalog.git (push)
bd99e979e869655503033de07040118dcf4379b6
bind9: v1.0.0-rancher1
  image: digitallumberjack/docker-bind9:v1.2.0
cloudflare: v0.6.0-rancher1
  image: rancher/external-dns:v0.6.0
digitalocean-dns: v0.6.2-rancher1
  image: rancher/external-dns:v0.6.2
dnsimple: v0.6.0-rancher1
  image: rancher/external-dns:v0.6.0
dnsupdate-rfc2136: v0.6.2-rancher1
  image: rancher/external-dns:v0.6.2
mesos: v0.28.1
  image: rancher/zookeeper:3.4.8
  image: busybox
  image: rancher/mesos-master:latest
  image: rancher/mesos-slave:latest
pointhq: v0.2.1-rancher1
  image: rancher/external-dns:v0.2.1
portainer: 1.11.4
  image: rancher/portainer-agent:v0.1.0
  image: portainer/portainer:pr572
powerdns-external-dns: v0.5.0-rancher1
  image: rancher/external-dns:v0.5.0
swarm: v1.13.0-beta.1
    image: rancher/swarmkit:v1.13.0-beta.1
    image: rancher/swarmkit:v1.13.0-beta.1


origin  https://git.rancher.io/rancher-catalog.git (fetch)
origin  https://git.rancher.io/rancher-catalog.git (push)
a0689f2cd82b860e81045293ea9007942a296909
container-crontab: v0.1.0-rancher1
    image: rancher/container-crontab:v0.1.0
ebs: 0.2.2
    image: rancher/storage-ebs:v0.6.0
    image: rancher/storage-ebs:v0.6.5
    image: rancher/storage-ebs:v0.6.0
    image: rancher/storage-ebs:v0.6.5
efs: 0.2.2
    image: rancher/storage-efs:v0.6.5
    image: rancher/storage-efs:v0.6.0
    image: rancher/storage-efs:v0.6.5
    image: rancher/storage-efs:v0.6.0
healthcheck: v0.2.3
    image: rancher/healthcheck:v0.2.3
    image: rancher/healthcheck:v0.2.3
ipsec: 0.0.5
    image: rancher/net:holder
    image: rancher/net:v0.9.4
    image: rancher/net:v0.9.4
k8s: v1.5.2-rancher1-3
    image: rancher/k8s:v1.5.2-rancher1-3
    image: rancher/k8s:v1.5.2-rancher1-3
    image: rancher/etcd:v2.3.7-11
    image: busybox
    image: rancher/k8s:v1.5.2-rancher1-3
    image: rancher/etc-host-updater:v0.0.2
    image: rancher/kubectld:v0.5.4
    image: rancher/k8s:v1.5.2-rancher1-3
    image: rancher/k8s:v1.5.2-rancher1-3
    image: rancher/kubernetes-agent:v0.5.4
    image: rancher/lb-service-rancher:v0.6.1
    image: rancher/k8s:v1.5.2-rancher1-3
    image: rancher/k8s:v1.5.2-rancher1-3
    image: rancher/k8s:v1.5.2-rancher1-3
    image: rancher/etcd:v2.3.7-11
    image: busybox
    image: rancher/k8s:v1.5.2-rancher1-3
    image: rancher/etc-host-updater:v0.0.2
    image: rancher/kubectld:v0.5.4
    image: rancher/k8s:v1.5.2-rancher1-3
    image: rancher/k8s:v1.5.2-rancher1-3
    image: rancher/kubernetes-agent:v0.5.4
    image: rancher/lb-service-rancher:v0.6.1
    image: rancher/k8s:v1.5.2-rancher1-3
netapp-eseries: 1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
netapp-ontap-nas: 1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
netapp-ontap-san: 1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
netapp-solidfire: 1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
  image: netapp/ndvp:1.3.3
network-policy-manager: v0.0.2
    image: rancher/network-policy-manager:v0.2.4
network-services: v0.1.0
    image: rancher/network-manager:v0.4.8
    image: rancher/metadata:v0.8.11
    image: rancher/dns:v0.14.1
nfs: 0.2.2
    image: rancher/storage-nfs:v0.6.5
    image: rancher/storage-nfs:v0.6.0
    image: rancher/storage-nfs:v0.6.5
    image: rancher/storage-nfs:v0.6.0
route53: v0.6.2-rancher1
  image: rancher/external-dns:v0.6.2
scheduler: v0.5.0
    image: rancher/scheduler:v0.5.0
    image: rancher/scheduler:v0.7.4
secrets: v0.0.2
    image: rancher/storage-secrets:v0.6.8
vxlan: v0.0.5
    image: rancher/net:v0.9.4
    image: rancher/net:v0.9.4
windows: "v0.0.1"
        image: rancher/none
        image: rancher/none
```