### PR TITLE
Improve how we build rancher from source

### DIFF
--- a/server/artifacts/cattle.sh
+++ b/server/artifacts/cattle.sh
@@ -216,7 +216,7 @@ extract()
     rm ../*.war
 }
 
-master()
+from_source()
 {
     unset CATTLE_API_UI_URL
     unset CATTLE_CATTLE_VERSION
@@ -226,6 +226,7 @@ master()
     unset DEFAULT_CATTLE_API_UI_CSS_URL
     unset DEFAULT_CATTLE_API_UI_INDEX
     unset DEFAULT_CATTLE_API_UI_JS_URL
+    unset DEFAULT_CATTLE_CATALOG_URL
 
     export HASH=none
     export CATTLE_IDEMPOTENT_CHECKS=false
@@ -240,7 +241,7 @@ master()
 
     mkdir -p /source
     cd /source
-    get_source
+    get_source $1
 
     cd cattle
     cattle-binary-pull ./resources/content/cattle-global.properties /usr/bin >/tmp/download.log 2>&1 &
@@ -261,7 +262,7 @@ master()
 get_source()
 {
     if [[ ! -e cattle || -e .cattle.default ]] && ! echo "$REPOS" | grep -q cattle; then
-        REPOS="$REPOS cattle"
+        REPOS="$REPOS cattle,$1"
         touch .cattle.default
     fi
     for r in $REPOS; do
@@ -315,8 +316,8 @@ update-rancher-ssl
 
 if [ "$1" = "extract" ]; then
     extract
-elif [ "$CATTLE_MASTER" = true ]; then
-    master
+elif [ -n "$CATTLE_BRANCH" ]; then
+    from_source $CATTLE_BRANCH
 else
     run
 fi

--- a/server/build-image.sh
+++ b/server/build-image.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 set -e
 
+build_from_source_image() {
+    local branch=$1
+    local version=$2
+
+    cat > Dockerfile.$version << EOF
+FROM ${IMAGE}
+ENV CATTLE_BRANCH origin/$branch
+EOF
+
+    docker build -t "${REPO}:$version" -f Dockerfile.$version .
+    rm Dockerfile.$version
+}
+
 cd "$(dirname "$0")"
 
 if [ ! -e target/.done ]; then
@@ -15,12 +28,7 @@ IMAGE=${REPO}:${TAG}
 
 docker build -t "${IMAGE}" .
 
-cat > Dockerfile.master << EOF
-FROM ${IMAGE}
-ENV CATTLE_MASTER true
-EOF
-trap "rm Dockerfile.master" EXIT
+build_from_source_image master master
+build_from_source_image v1.6 v1.6-dev
 
-docker build -t "${REPO}:master" -f Dockerfile.master .
-
-echo Done building "${IMAGE}"
+echo -e "Done building:\n ${REPO}:master\n ${REPO}:v1.6-dev\n ${IMAGE}"


### PR DESCRIPTION
unset the DEFAULT_CATTLE_CATALOG_URL env variable when building from
source so that the catalog.url property set in cattle is used instead

Parameterize the build so that we can produce a v1.6 development image
in addition to the master image