### PR TITLE
Error out when reference to localhost is found in CATTLE_URL

### DIFF
--- a/agent/run.sh
+++ b/agent/run.sh
@@ -411,9 +411,9 @@ setup_cattle_url()
         CATTLE_URL="$1"
     fi
 
-    if echo $CATTLE_URL | grep -qE '127.0.0.1|localhost'; then
-        local gateway=$(docker run --rm --net=host $RANCHER_AGENT_IMAGE -- ip route get 8.8.8.8 | grep via | awk '{print $7}')
-        CATTLE_URL=$(echo $CATTLE_URL | sed -e 's/127.0.0.1/'$gateway'/' -e 's/localhost/'$gateway'/')
+    if echo $CATTLE_URL | grep -qE '(http|https)://(127\.0\.0\.1|localhost)([:/]|$)'; then
+        error CATTLE_URL cannot contain localhost or 127.0.0.1, please check the Host Registration URL.
+        exit 1
     fi
 
     export CATTLE_URL


### PR DESCRIPTION
Discussion after https://github.com/rancher/rancher/pull/9186 and https://github.com/rancher/rancher/issues/9176:

Using `127.0.0.1` or `localhost` is not how it's done, and the debate was on wether to protect the user from this behavior or bail out with a proper error message. Taking it out of the users hand and fix it is not the way to go.

```sudo docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/rancher:/var/lib/rancher superseb/agent:v1.2.5-localhost http://127.0.0.1:8080/v1/blabla                                                                                         
Status: Downloaded newer image for superseb/agent:v1.2.5-localhost             

ERROR: CATTLE_URL cannot contain localhost or 127.0.0.1, please check the Host Registration URL.
```