### PR TITLE
openssh client package to server image to support git clone over ssh

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                     openssh-client \
                     iptables \
                     git \
+                    openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # In Zulu these two JAR files are built directly from OpenJDK source,


### PR DESCRIPTION
This commit is designed to provide support for git clones over ssh, especially in case where an ssh key is needed to authenticate. This should help address #3248. It assumes the following:

1. You pass the following environment variable when running `rancher/server`: `-e GIT_SSH_COMMAND="ssh -i /path/to/sshkey"` where "/path/to/sshkey" is substituted for some user defined path where they can bind mount the needed ssh key. 
2. You bind mount a the path containing the ssh key when running the container. For instance for the above example you would pass `-v /localpath/to/sshkey:/path/to/sshkey`