### PR TITLE
add flag to control whether enable detect cloud provider, default is true

### DIFF
--- a/agent/run.sh
+++ b/agent/run.sh
@@ -176,6 +176,7 @@ launch_agent()
         -e CATTLE_MEMORY_OVERRIDE \
         -e CATTLE_MILLI_CPU_OVERRIDE \
         -e CATTLE_LOCAL_STORAGE_MB_OVERRIDE \
+        -e CATTLE_DETECT_CLOUD_PROVIDER \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v /var/run/rancher/storage:/var/run/rancher/storage \
         -v /lib/modules:/lib/modules:ro \


### PR DESCRIPTION
Related Issue: https://github.com/rancher/rancher/issues/9936
Description: We get the host info like zone and region in rancher agent, and we implement this for the different cloud provider. The flag is for control whether we enable the detect cloud provider or not.

@yasker  Could you please help to review the PR?