### PR TITLE
Add a remote init DB script

### DIFF
--- a/server/bin/mysql-remote-init.sh
+++ b/server/bin/mysql-remote-init.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+
+export MYSQL_HOST=${CATTLE_DB_CATTLE_MYSQL_HOST:-127.0.0.1}
+export MYSQL_PORT=${CATTLE_DB_CATTLE_MYSQL_PORT:-3306}
+
+setup_cattle_db()
+{
+    local db_admin_password=$DB_ROOT_PASSWORD
+
+    local db_user=$CATTLE_DB_CATTLE_USERNAME
+    local db_pass=$CATTLE_DB_CATTLE_PASSWORD
+    local db_name=$CATTLE_DB_CATTLE_MYSQL_NAME
+
+    echo "Setting up database"
+    mysql -uroot -p${db_admin_password} -h${MYSQL_HOST} -P${MYSQL_PORT}<< EOF
+CREATE DATABASE IF NOT EXISTS ${db_name} COLLATE = 'utf8_general_ci' CHARACTER SET = 'utf8';
+GRANT ALL ON ${db_name}.* TO "${db_user}"@'%' IDENTIFIED BY "${db_pass}";
+GRANT ALL ON ${db_name}.* TO "${db_user}"@'localhost' IDENTIFIED BY "${db_pass}";
+EOF
+}
+
+add_db_change_log()
+{
+    local db_user=$CATTLE_DB_CATTLE_USERNAME
+    local db_pass=$CATTLE_DB_CATTLE_PASSWORD
+    local db_name=$CATTLE_DB_CATTLE_MYSQL_NAME
+
+    mysql -u${db_user} -p${db_pass} -h${MYSQL_HOST} -P${MYSQL_PORT} ${db_name}<< EOF 
+CREATE TABLE IF NOT EXISTS \`DATABASECHANGELOG\` (
+  \`ID\` varchar(255) NOT NULL,
+  \`AUTHOR\` varchar(255) NOT NULL,
+  \`FILENAME\` varchar(255) NOT NULL,
+  \`DATEEXECUTED\` datetime NOT NULL,
+  \`ORDEREXECUTED\` int(11) NOT NULL,
+  \`EXECTYPE\` varchar(10) NOT NULL,
+  \`MD5SUM\` varchar(35) DEFAULT NULL,
+  \`DESCRIPTION\` varchar(255) DEFAULT NULL,
+  \`COMMENTS\` varchar(255) DEFAULT NULL,
+  \`TAG\` varchar(255) DEFAULT NULL,
+  \`LIQUIBASE\` varchar(20) DEFAULT NULL,
+  \`PKID\` int NOT NULL AUTO_INCREMENT PRIMARY KEY
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+EOF
+}
+
+setup_cattle_db
+
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    --strict-enforce)
+        shift 1
+        add_db_change_log
+        ;;
+    *)
+      break
+      ;;
+  esac
+done


### PR DESCRIPTION
This remote init script is able to initialize a rancher DB. It also can create the `DATABASECHANGELOG` table with a primary key for use in strict enforcing MySQL clusters like PXC. The reason for running this out of band for startup is to prevent having DB admin password in the running Rancher server container.  

In order to create a remote DB run:
```
docker run -it -e DB_ROOT_PASSWORD=<database_admin_password> rancher/server:v1.6.11-rc4 --db-host 192.168.42.213 --db-name cattle --db-user cattle --db-pass cattle mysql-remote-init.sh
```
*Note*: the mysql-remote-init.sh position needs to come after the `--db-*` variables.

In order to use a DB that has strict_mode=enforcing like Percona PCX clusters:
```
docker run -it -e DB_ROOT_PASSWORD=<database_admin_password> rancher/server:v1.6.11-rc4 --db-host 192.168.42.213 --db-name cattle --db-user cattle --db-pass cattle mysql-remote-init.sh --strict-enforce
```

Once this command has been run, the container should be removed from Rancher.

To test:
Create a db server:
`docker run -d -p 3306:3306 -e MYSQL_ROOT_PASSWORD=test -e CLUSTER_NAME=rtest percona/percona-xtradb-cluster`

This DB will setup will fail to migrate using just the init script:
```
docker run -it -e DB_ROOT_PASSWORD=<database_admin_password> rancher/server:v1.6.11-rc4 --db-host 192.168.42.213 --db-name cattle --db-user cattle --db-pass cattle mysql-remote-init.sh
```

Then start a rancher server container as usual pointing to this DB. Should fail. If you were using a normal MySQL 5.7 or RDS instance this would work fine. The reason this is failing is because of the strict enforcing.

Now delete the database:
`database drop cattle`
on the db server.

Then run with `--strict-enforce` appended to the script above:
```
docker run -it -e DB_ROOT_PASSWORD=<database_admin_password> rancher/server:v1.6.11-rc4 --db-host 192.168.42.213 --db-name cattle --db-user cattle --db-pass cattle mysql-remote-init.sh --strict-enforce
```

Now start the rancher server container using this fresh db. Things should start working as normal.


