### PR TITLE
Compare Host Registration URL to input URL

### DIFF
--- a/agent/run.sh
+++ b/agent/run.sh
@@ -369,7 +369,7 @@ setup_env()
 {
     if [ "$1" != "upgrade" ]; then
         local env="$(./resolve_url.py $CATTLE_URL)"
-        if ! load "$env"; then
+        if ! load "$env" || [ "$(print_url $CATTLE_URL)" != "$(print_url $env)" ]; then
             error Failed to load registration env from CATTLE_URL=$(print_url $CATTLE_URL) ENV_URL=$(print_url $env)
             error Please ensure the proper value for the Host Registration URL is set
             exit 1


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher/issues/9464

```
INFO: Running Agent Registration Process, CATTLE_URL=http://192.168.99.100:8080/v1                                                                            
INFO: Attempting to connect to: http://192.168.99.100:8080/v1                  
INFO: http://192.168.99.100:8080/v1 is accessible                              
ERROR: Failed to load registration env from CATTLE_URL=http://127.0.0.1/v1 ENV_URL=http://192.168.99.100:8080/v1                                              
ERROR: Please ensure the proper value for the Host Registration URL is set
```