### PR TITLE
GlobalRole support

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -7,11 +7,11 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/pkg/errors"
 	managementController "github.com/rancher/cluster-controller/controller"
 	"github.com/rancher/norman/signal"
 	"github.com/rancher/rancher/server"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
-	v12 "github.com/rancher/types/apis/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/types/config"
 	"golang.org/x/crypto/bcrypt"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -62,25 +62,6 @@ func addData(management *config.ManagementContext) error {
 		},
 	})
 
-	rbac, err := v12.NewForConfig(management.RESTConfig)
-	if err != nil {
-		return err
-	}
-	rbac.ClusterRoleBindings("").Create(&rbacv1.ClusterRoleBinding{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "rancher-admin",
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind: "User",
-				Name: "admin",
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			Kind: "ClusterRole",
-			Name: "cluster-admin",
-		},
-	})
 	hash, _ := bcrypt.GenerateFromPassword([]byte("admin"), bcrypt.DefaultCost)
 	admin, err := management.Management.Users("").Create(&v3.User{
 		ObjectMeta: v1.ObjectMeta{
@@ -98,6 +79,27 @@ func addData(management *config.ManagementContext) error {
 		admin.PrincipalIDs = []string{"local://" + admin.Name}
 		management.Management.Users("").Update(admin)
 	}
+
+	rb := newRoleBuilder()
+	rb.addRole("admin").addRule().apiGroups("*").verbs("*").resources("*").
+		addRule().apiGroups().nonResourceURLs("*").verbs("*")
+	rb.addRole("user").
+		addRule().apiGroups("management.cattle.io").resources("clusters").verbs("create")
+	if err := rb.reconcileGlobalRoles(management); err != nil {
+		return errors.Wrap(err, "problem reconciling globl roles")
+	}
+
+	management.Management.GlobalRoleBindings("").Create(
+		&v3.GlobalRoleBinding{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "admin",
+			},
+			Subject: rbacv1.Subject{
+				Kind: "User",
+				Name: "admin",
+			},
+			GlobalRoleName: "admin",
+		})
 
 	return nil
 }

--- a/app/rolebuilder.go
+++ b/app/rolebuilder.go
@@ -1,0 +1,197 @@
+package app
+
+import (
+	"fmt"
+
+	"reflect"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var roleBootstrapLabel = map[string]string{"management.cattle.io/bootstrapping": "rbac-defaults"}
+
+type roleBuilder struct {
+	previous *roleBuilder
+	next     *roleBuilder
+	name     string
+	rules    []*ruleBuilder
+}
+
+func (rb *roleBuilder) String() string {
+	return fmt.Sprintf("%s: %s", rb.name, rb.rules)
+}
+
+type ruleBuilder struct {
+	name           string
+	rb             *roleBuilder
+	_verbs         []string
+	_resources     []string
+	_resourceNames []string
+	_apiGroups     []string
+	_urls          []string
+}
+
+func (r *ruleBuilder) String() string {
+	return fmt.Sprintf("apigroups: %v, resource: %v, resourceNames: %v, nonResourceURLs %v, verbs: %v", r._apiGroups, r._resources, r._resourceNames, r._urls, r._verbs)
+}
+
+func (r *ruleBuilder) verbs(v ...string) *ruleBuilder {
+	r._verbs = append(r._verbs, v...)
+	return r
+}
+
+func (r *ruleBuilder) resources(rc ...string) *ruleBuilder {
+	r._resources = append(r._resources, rc...)
+	return r
+}
+
+func (r *ruleBuilder) resourceNames(rn ...string) *ruleBuilder {
+	r._resourceNames = append(r._resourceNames, rn...)
+	return r
+}
+
+func (r *ruleBuilder) apiGroups(a ...string) *ruleBuilder {
+	r._apiGroups = append(r._apiGroups, a...)
+	return r
+}
+
+func (r *ruleBuilder) nonResourceURLs(u ...string) *ruleBuilder {
+	r._urls = append(r._urls, u...)
+	return r
+}
+
+func (r *ruleBuilder) addRole(name string) *roleBuilder {
+	return r.rb.addRole(name)
+}
+
+func (r *ruleBuilder) addRule() *ruleBuilder {
+	return r.rb.addRule()
+}
+
+func (r *ruleBuilder) reconcileGlobalRoles(mgmt *config.ManagementContext) error {
+	return r.rb.reconcileGlobalRoles(mgmt)
+}
+
+func (r *ruleBuilder) reconcileRoleTemplates(mgmt *config.ManagementContext) error {
+	return r.rb.reconcileRoleTemplates(mgmt)
+}
+
+func (r *ruleBuilder) toPolicyRule() rbacv1.PolicyRule {
+	return rbacv1.PolicyRule{
+		APIGroups:       r._apiGroups,
+		Resources:       r._resources,
+		ResourceNames:   r._resourceNames,
+		NonResourceURLs: r._urls,
+		Verbs:           r._verbs,
+	}
+}
+func newRoleBuilder() *roleBuilder {
+	return &roleBuilder{}
+}
+
+func (rb *roleBuilder) addRole(name string) *roleBuilder {
+	if rb.name == "" {
+		rb.name = name
+		return rb
+	}
+
+	if rb.next != nil {
+		return rb.next.addRole(name)
+	}
+	rb.next = &roleBuilder{
+		name:     name,
+		previous: rb,
+	}
+	return rb.next
+}
+
+func (rb *roleBuilder) addRule() *ruleBuilder {
+	r := &ruleBuilder{
+		rb: rb,
+	}
+	rb.rules = append(rb.rules, r)
+	return r
+}
+
+func (rb *roleBuilder) reconcileGlobalRoles(mgmt *config.ManagementContext) error {
+	logrus.Info("Reconciling GlobalRoles")
+	globalRoles := map[string]*v3.GlobalRole{}
+	current := rb.first()
+	for current != nil {
+		logrus.Debugf("Converting role %s to GlobalRole", current)
+		cr := &v3.GlobalRole{
+			ObjectMeta: v1.ObjectMeta{
+				Name:   current.name,
+				Labels: roleBootstrapLabel,
+			},
+			Rules: current.policyRules(),
+		}
+		globalRoles[cr.Name] = cr
+		current = current.next
+	}
+
+	grCli := mgmt.Management.GlobalRoles("")
+	set := labels.Set(roleBootstrapLabel)
+	existingList, err := grCli.List(v1.ListOptions{LabelSelector: set.String()})
+	if err != nil {
+		return errors.Wrapf(err, "couldn't list bootstrap clusterRoles with selector %s", set)
+	}
+	existing := map[string]v3.GlobalRole{}
+	for _, cr := range existingList.Items {
+		existing[cr.Name] = cr
+	}
+
+	for name := range existing {
+		if _, ok := globalRoles[name]; !ok {
+			logrus.Infof("Remvoing GlobalRole %v", name)
+			if err := grCli.Delete(name, &v1.DeleteOptions{}); err != nil {
+				return errors.Wrapf(err, "couldn't delete GlobalRole %v", name)
+			}
+			delete(existing, name)
+		}
+	}
+
+	for name, gr := range globalRoles {
+		if existingCR, ok := existing[name]; ok {
+			if !reflect.DeepEqual(gr.Rules, existingCR.Rules) {
+				logrus.Infof("Updating GlobalRole %v. Rules have changed. Have: %+v. Want: %+v", name, existingCR.Rules, gr.Rules)
+				existingCR.Rules = gr.Rules
+				if _, err := grCli.Update(&existingCR); err != nil {
+					return errors.Wrapf(err, "couldn't update GlobalRole %v", name)
+				}
+			}
+			continue
+		}
+		logrus.Infof("Creating new GlobalRole %v", name)
+		if _, err := grCli.Create(gr); err != nil {
+			return errors.Wrapf(err, "couldn't create GlobalRole %v", name)
+		}
+	}
+
+	return nil
+}
+
+func (rb *roleBuilder) policyRules() []rbacv1.PolicyRule {
+	prs := []rbacv1.PolicyRule{}
+	for _, r := range rb.rules {
+		prs = append(prs, r.toPolicyRule())
+	}
+	return prs
+}
+
+func (rb *roleBuilder) reconcileRoleTemplates(mgmt *config.ManagementContext) error {
+	return nil
+}
+
+func (rb *roleBuilder) first() *roleBuilder {
+	if rb.previous == nil {
+		return rb
+	}
+	return rb.previous.first()
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -26,5 +26,5 @@ github.com/rancher/machine-controller         623c0e13c406cd97301b0f7452ff6c9b6e
 github.com/rancher/management-api             c640584a698b8555c089530554a1fdc40f58b44f
 github.com/rancher/rke                        e7e28daf234dcfecfb8bae0d993ccc628b4f1f9d
 github.com/rancher/auth                       abfe91a542a48c6e6670e5a4eea33d88935acf33
-github.com/rancher/management-auth-controller 6734f6f8c9121b61432dba1b8247dc0d09be455c
+github.com/rancher/management-auth-controller 248e37a9f918d6d1f512ca483113c207808b882f
 github.com/rancher/workload-controller        9cef9105d0ebe9e4fc04d55dd1b3ab5d04ca04df

--- a/vendor/github.com/rancher/management-auth-controller/controller/globalrole_handler.go
+++ b/vendor/github.com/rancher/management-auth-controller/controller/globalrole_handler.go
@@ -1,0 +1,99 @@
+package controller
+
+import (
+	"reflect"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	rbacv1 "github.com/rancher/types/apis/rbac.authorization.k8s.io/v1"
+	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	globalRoleLabel  = map[string]string{"authz.management.cattle.io/globalrole": "true"}
+	crNameAnnotation = "authz.management.cattle.io/cr-name"
+	clusterRoleKind  = "ClusterRole"
+)
+
+func newGlobalRoleLifecycle(management *config.ManagementContext) *globalRoleLifecycle {
+	return &globalRoleLifecycle{
+		crLister: management.RBAC.ClusterRoles("").Controller().Lister(),
+		crClient: management.RBAC.ClusterRoles(""),
+	}
+}
+
+type globalRoleLifecycle struct {
+	crLister rbacv1.ClusterRoleLister
+	crClient rbacv1.ClusterRoleInterface
+}
+
+func (gr *globalRoleLifecycle) Create(obj *v3.GlobalRole) (*v3.GlobalRole, error) {
+	err := gr.reconcileGlobalRole(obj)
+	return obj, err
+}
+
+func (gr *globalRoleLifecycle) Updated(obj *v3.GlobalRole) (*v3.GlobalRole, error) {
+	err := gr.reconcileGlobalRole(obj)
+	return nil, err
+}
+
+func (gr *globalRoleLifecycle) Remove(obj *v3.GlobalRole) (*v3.GlobalRole, error) {
+	// Don't need to delete the created ClusterRole because owner reference will take care of that
+	return nil, nil
+}
+
+func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole) error {
+	crName := getCRName(globalRole)
+
+	clusterRole, _ := gr.crLister.Get("", crName)
+	if clusterRole != nil {
+		if !reflect.DeepEqual(globalRole.Rules, clusterRole.Rules) {
+			logrus.Infof("Updating ClusterRole %v. GlobalRole rules have changed. Have: %+v. Want: %+v", clusterRole.Name, clusterRole.Rules, globalRole.Rules)
+			clusterRole.Rules = globalRole.Rules
+			if _, err := gr.crClient.Update(clusterRole); err != nil {
+				return errors.Wrapf(err, "couldn't update ClusterRole %v", clusterRole.Name)
+			}
+		}
+		return nil
+	}
+
+	logrus.Infof("Creating new ClusterRole %v for corresponding GlobalRole", crName)
+	_, err := gr.crClient.Create(&v1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crName,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: globalRole.TypeMeta.APIVersion,
+					Kind:       globalRole.TypeMeta.Kind,
+					Name:       globalRole.Name,
+					UID:        globalRole.UID,
+				},
+			},
+			Labels: globalRoleLabel,
+		},
+		Rules: globalRole.Rules,
+	})
+	if err != nil {
+		return err
+	}
+	// Add an annotation to the globalrole indicating the name we used for future updates
+	if globalRole.Annotations == nil {
+		globalRole.Annotations = map[string]string{}
+	}
+	globalRole.Annotations[crNameAnnotation] = crName
+	return nil
+
+}
+func getCRName(globalRole *v3.GlobalRole) string {
+	if crName, ok := globalRole.Annotations[crNameAnnotation]; ok {
+		return crName
+	}
+	return generateCRName(globalRole.Name)
+}
+
+func generateCRName(name string) string {
+	return "cattle-globalrole-" + name
+}

--- a/vendor/github.com/rancher/management-auth-controller/controller/globalrolebinding_handler.go
+++ b/vendor/github.com/rancher/management-auth-controller/controller/globalrolebinding_handler.go
@@ -1,0 +1,123 @@
+package controller
+
+import (
+	"reflect"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	rbacv1 "github.com/rancher/types/apis/rbac.authorization.k8s.io/v1"
+	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	globalRoleBindingLabel = map[string]string{"authz.management.cattle.io/globalrolebinding": "true"}
+	crbNameAnnotation      = "authz.management.cattle.io/crb-name"
+	crbNamePrefix          = "cattle-globalrolebinding-"
+)
+
+func newGlobalRoleBindingLifecycle(management *config.ManagementContext) *globalRoleBindingLifecycle {
+	return &globalRoleBindingLifecycle{
+		crbLister: management.RBAC.ClusterRoleBindings("").Controller().Lister(),
+		crbClient: management.RBAC.ClusterRoleBindings(""),
+		grLister:  management.Management.GlobalRoles("").Controller().Lister(),
+	}
+}
+
+type globalRoleBindingLifecycle struct {
+	crbLister rbacv1.ClusterRoleBindingLister
+	grLister  v3.GlobalRoleLister
+	crbClient rbacv1.ClusterRoleBindingInterface
+}
+
+func (grb *globalRoleBindingLifecycle) Create(obj *v3.GlobalRoleBinding) (*v3.GlobalRoleBinding, error) {
+	err := grb.reconcileGlobalRoleBinding(obj)
+	return obj, err
+}
+
+func (grb *globalRoleBindingLifecycle) Updated(obj *v3.GlobalRoleBinding) (*v3.GlobalRoleBinding, error) {
+	err := grb.reconcileGlobalRoleBinding(obj)
+	return nil, err
+}
+
+func (grb *globalRoleBindingLifecycle) Remove(obj *v3.GlobalRoleBinding) (*v3.GlobalRoleBinding, error) {
+	// Don't need to delete the created ClusterRole because owner reference will take care of that
+	return nil, nil
+}
+
+func (grb *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBinding *v3.GlobalRoleBinding) error {
+	crbName, ok := globalRoleBinding.Annotations[crbNameAnnotation]
+	if !ok {
+		crbName = crbNamePrefix + globalRoleBinding.Name
+	}
+	crb, _ := grb.crbLister.Get("", crbName)
+	if crb != nil {
+		subjects := []v1.Subject{globalRoleBinding.Subject}
+		updateSubject := !reflect.DeepEqual(subjects, crb.Subjects)
+
+		updateRoleRef := false
+		var roleRef v1.RoleRef
+		gr, _ := grb.grLister.Get("", globalRoleBinding.GlobalRoleName)
+		if gr != nil {
+			crNameFromGR := getCRName(gr)
+			if crNameFromGR != crb.RoleRef.Name {
+				updateRoleRef = true
+				roleRef = v1.RoleRef{
+					Name: crNameFromGR,
+					Kind: clusterRoleKind,
+				}
+			}
+		}
+		if updateSubject || updateRoleRef {
+			crb = crb.DeepCopy()
+			if updateRoleRef {
+				crb.RoleRef = roleRef
+			}
+			crb.Subjects = subjects
+			if _, err := grb.crbClient.Update(crb); err != nil {
+				return errors.Wrapf(err, "couldn't update ClusterRoleBinding %v", crb.Name)
+			}
+		}
+		return nil
+	}
+
+	logrus.Infof("Creating new GlobalRoleBinding for GlobalRoleBinding %v", globalRoleBinding.Name)
+	gr, _ := grb.grLister.Get("", globalRoleBinding.GlobalRoleName)
+	var crName string
+	if gr != nil {
+		crName = getCRName(gr)
+	} else {
+		crName = generateCRName(globalRoleBinding.GlobalRoleName)
+	}
+	_, err := grb.crbClient.Create(&v1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crbName,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: globalRoleBinding.TypeMeta.APIVersion,
+					Kind:       globalRoleBinding.TypeMeta.Kind,
+					Name:       globalRoleBinding.Name,
+					UID:        globalRoleBinding.UID,
+				},
+			},
+			Labels: globalRoleBindingLabel,
+		},
+		Subjects: []v1.Subject{globalRoleBinding.Subject},
+		RoleRef: v1.RoleRef{
+			Name: crName,
+			Kind: clusterRoleKind,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	// Add an annotation to the globalrole indicating the name we used for future updates
+	if globalRoleBinding.Annotations == nil {
+		globalRoleBinding.Annotations = map[string]string{}
+	}
+	globalRoleBinding.Annotations[crbNameAnnotation] = crbName
+
+	return nil
+}

--- a/vendor/github.com/rancher/management-auth-controller/controller/handler.go
+++ b/vendor/github.com/rancher/management-auth-controller/controller/handler.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -18,25 +17,22 @@ const (
 	clusterResource = "clusters"
 )
 
-func Register(ctx context.Context, management *config.ManagementContext) {
+func newRTBLifecycles(management *config.ManagementContext) (*prtbLifecycle, *crtbLifecycle) {
 	mgr := &manager{
 		mgmt:      management,
-		ctx:       ctx,
 		crbLister: management.RBAC.ClusterRoleBindings("").Controller().Lister(),
 		crLister:  management.RBAC.ClusterRoles("").Controller().Lister(),
 	}
-	prtbLifecycle := &prtbLifecycle{
+	prtb := &prtbLifecycle{
 		mgr:           mgr,
 		projectLister: management.Management.Projects("").Controller().Lister(),
 		clusterLister: management.Management.Clusters("").Controller().Lister(),
 	}
-	crtbLifecycle := &crtbLifecycle{
+	crtb := &crtbLifecycle{
 		mgr:           mgr,
 		clusterLister: management.Management.Clusters("").Controller().Lister(),
 	}
-
-	management.Management.ProjectRoleTemplateBindings("").AddLifecycle("management-auth-prtb-controller", prtbLifecycle)
-	management.Management.ClusterRoleTemplateBindings("").AddLifecycle("management-auth-crtb-controller", crtbLifecycle)
+	return prtb, crtb
 }
 
 type prtbLifecycle struct {
@@ -127,7 +123,6 @@ func (c *crtbLifecycle) ensureBindings(binding *v3.ClusterRoleTemplateBinding) e
 }
 
 type manager struct {
-	ctx       context.Context
 	crLister  typesrbacv1.ClusterRoleLister
 	crbLister typesrbacv1.ClusterRoleBindingLister
 	mgmt      *config.ManagementContext

--- a/vendor/github.com/rancher/management-auth-controller/controller/register.go
+++ b/vendor/github.com/rancher/management-auth-controller/controller/register.go
@@ -1,0 +1,18 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/rancher/types/config"
+)
+
+func Register(ctx context.Context, management *config.ManagementContext) {
+	prtb, crtb := newRTBLifecycles(management)
+	gr := newGlobalRoleLifecycle(management)
+	grb := newGlobalRoleBindingLifecycle(management)
+
+	management.Management.ProjectRoleTemplateBindings("").AddLifecycle("mgmt-auth-prtb-controller", prtb)
+	management.Management.ClusterRoleTemplateBindings("").AddLifecycle("mgmt-auth-crtb-controller", crtb)
+	management.Management.GlobalRoles("").AddLifecycle("mgmt-auth-gr-controller", gr)
+	management.Management.GlobalRoleBindings("").AddLifecycle("mgmt-auth-grb-controller", grb)
+}


### PR DESCRIPTION
- Bootstrap in two default GlobalRoles and use the admin one for the bootstrapped admin user
- Pulls in the controlller that reconciles management cluster roles and bindings with global roles

Note that the role builder is right in the app package. If you dont like that and have a better place in mind, let me know. One idea i had was a subpackage of app called data. So, 'github.com/rancher/rancher/app/data"