### PR TITLE
Bootstrap default roles

### DIFF
--- a/app/rolebuilder.go
+++ b/app/rolebuilder.go
@@ -1,0 +1,322 @@
+package app
+
+import (
+	"fmt"
+
+	"reflect"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/norman/clientbase"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var defaultGRLabel = map[string]string{"authz.management.cattle.io/bootstrapping": "default-globalrole"}
+var defaultRTLabel = map[string]string{"authz.management.cattle.io/bootstrapping": "default-roletemplate"}
+
+type roleBuilder struct {
+	previous          *roleBuilder
+	next              *roleBuilder
+	name              string
+	displayName       string
+	builtin           bool
+	external          bool
+	hidden            bool
+	roleTemplateNames []string
+	rules             []*ruleBuilder
+}
+
+func (rb *roleBuilder) String() string {
+	return fmt.Sprintf("%s (%s): %s", rb.displayName, rb.name, rb.rules)
+}
+
+func newRoleBuilder() *roleBuilder {
+	return &roleBuilder{}
+}
+
+func (rb *roleBuilder) addRoleTemplate(displayName, name string, builtin, external, hidden bool) *roleBuilder {
+	r := rb.addRole(displayName, name)
+	r.builtin = builtin
+	r.external = external
+	r.hidden = hidden
+	return r
+}
+
+func (rb *roleBuilder) addRole(displayName, name string) *roleBuilder {
+	if rb.name == "" {
+		rb.name = name
+		rb.displayName = displayName
+		return rb
+	}
+
+	if rb.next != nil {
+		return rb.next.addRole(displayName, name)
+	}
+	rb.next = &roleBuilder{
+		name:        name,
+		displayName: displayName,
+		previous:    rb,
+	}
+	return rb.next
+}
+
+func (rb *roleBuilder) addRule() *ruleBuilder {
+	r := &ruleBuilder{
+		rb: rb,
+	}
+	rb.rules = append(rb.rules, r)
+	return r
+}
+
+func (rb *roleBuilder) setRoleTemplateNames(names ...string) *roleBuilder {
+	rb.roleTemplateNames = names
+	return rb
+}
+
+func (rb *roleBuilder) first() *roleBuilder {
+	if rb.previous == nil {
+		return rb
+	}
+	return rb.previous.first()
+}
+
+func (rb *roleBuilder) policyRules() []rbacv1.PolicyRule {
+	prs := []rbacv1.PolicyRule{}
+	for _, r := range rb.rules {
+		prs = append(prs, r.toPolicyRule())
+	}
+	return prs
+}
+
+type ruleBuilder struct {
+	rb             *roleBuilder
+	_verbs         []string
+	_resources     []string
+	_resourceNames []string
+	_apiGroups     []string
+	_urls          []string
+}
+
+func (r *ruleBuilder) String() string {
+	return fmt.Sprintf("apigroups: %v, resource: %v, resourceNames: %v, nonResourceURLs %v, verbs: %v", r._apiGroups, r._resources, r._resourceNames, r._urls, r._verbs)
+}
+
+func (r *ruleBuilder) verbs(v ...string) *ruleBuilder {
+	r._verbs = append(r._verbs, v...)
+	return r
+}
+
+func (r *ruleBuilder) resources(rc ...string) *ruleBuilder {
+	r._resources = append(r._resources, rc...)
+	return r
+}
+
+func (r *ruleBuilder) resourceNames(rn ...string) *ruleBuilder {
+	r._resourceNames = append(r._resourceNames, rn...)
+	return r
+}
+
+func (r *ruleBuilder) apiGroups(a ...string) *ruleBuilder {
+	r._apiGroups = append(r._apiGroups, a...)
+	return r
+}
+
+func (r *ruleBuilder) nonResourceURLs(u ...string) *ruleBuilder {
+	r._urls = append(r._urls, u...)
+	return r
+}
+
+func (r *ruleBuilder) addRoleTemplate(diplsayName, name string, builtin, external, hidden bool) *roleBuilder {
+	return r.rb.addRoleTemplate(diplsayName, name, builtin, external, hidden)
+}
+
+func (r *ruleBuilder) addRole(diplsayName, name string) *roleBuilder {
+	return r.rb.addRole(diplsayName, name)
+}
+
+func (r *ruleBuilder) addRule() *ruleBuilder {
+	return r.rb.addRule()
+}
+
+func (r *ruleBuilder) setRoleTemplateNames(names ...string) *roleBuilder {
+	return r.rb.setRoleTemplateNames(names...)
+}
+
+func (r *ruleBuilder) reconcileGlobalRoles(mgmt *config.ManagementContext) error {
+	return r.rb.reconcileGlobalRoles(mgmt)
+}
+
+func (r *ruleBuilder) reconcileRoleTemplates(mgmt *config.ManagementContext) error {
+	return r.rb.reconcileRoleTemplates(mgmt)
+}
+
+func (r *ruleBuilder) toPolicyRule() rbacv1.PolicyRule {
+	return rbacv1.PolicyRule{
+		APIGroups:       r._apiGroups,
+		Resources:       r._resources,
+		ResourceNames:   r._resourceNames,
+		NonResourceURLs: r._urls,
+		Verbs:           r._verbs,
+	}
+}
+
+type buildFnc func(thisRB *roleBuilder) (string, runtime.Object)
+type compareAndModifyFnc func(have runtime.Object, want runtime.Object) (bool, runtime.Object, error)
+type gatherExistingFnc func() (map[string]runtime.Object, error)
+
+func (rb *roleBuilder) reconcile(build buildFnc, gatherExisting gatherExistingFnc, compareAndModify compareAndModifyFnc, client *clientbase.ObjectClient) error {
+	current := rb.first()
+	builtRoles := map[string]runtime.Object{}
+	for current != nil {
+		name, role := build(current)
+		builtRoles[name] = role
+		current = current.next
+	}
+
+	existing, err := gatherExisting()
+	if err != nil {
+		return err
+	}
+
+	for name := range existing {
+		if _, ok := builtRoles[name]; !ok {
+			logrus.Infof("Remvoing %v", name)
+			if err := client.Delete(name, &v1.DeleteOptions{}); err != nil {
+				return errors.Wrapf(err, "couldn't delete %v", name)
+			}
+			delete(existing, name)
+		}
+	}
+
+	for name, gr := range builtRoles {
+		if existingCR, ok := existing[name]; ok {
+			equal, modified, err := compareAndModify(existingCR, gr)
+			if err != nil {
+				return err
+			}
+			if !equal {
+				if _, err := client.Update(name, modified); err != nil {
+					return errors.Wrapf(err, "couldn't update %v", name)
+				}
+			}
+			continue
+		}
+
+		logrus.Infof("Creating %v", name)
+		if _, err := client.Create(gr); err != nil {
+			return errors.Wrapf(err, "couldn't create %v", name)
+		}
+	}
+
+	return nil
+}
+
+func (rb *roleBuilder) reconcileGlobalRoles(mgmt *config.ManagementContext) error {
+	logrus.Info("Reconciling GlobalRoles")
+
+	build := func(current *roleBuilder) (string, runtime.Object) {
+		gr := &v3.GlobalRole{
+			ObjectMeta: v1.ObjectMeta{
+				Name:   current.name,
+				Labels: defaultGRLabel,
+			},
+			DisplayName: current.displayName,
+			Rules:       current.policyRules(),
+		}
+		return gr.Name, gr
+	}
+
+	grCli := mgmt.Management.GlobalRoles("")
+	gather := func() (map[string]runtime.Object, error) {
+		set := labels.Set(defaultGRLabel)
+		existingList, err := grCli.List(v1.ListOptions{LabelSelector: set.String()})
+		if err != nil {
+			return nil, errors.Wrapf(err, "couldn't list globalRoles with selector %s", set)
+		}
+
+		existing := map[string]runtime.Object{}
+		for _, e := range existingList.Items {
+			existing[e.Name] = e.DeepCopy()
+		}
+
+		return existing, nil
+	}
+
+	compareAndMod := func(have runtime.Object, want runtime.Object) (bool, runtime.Object, error) {
+		haveGR, ok := have.(*v3.GlobalRole)
+		wantGR, ok2 := want.(*v3.GlobalRole)
+		if !ok || !ok2 {
+			return false, nil, errors.Errorf("unexpected type comparing %v and %v", have, want)
+		}
+
+		equal := haveGR.DisplayName == wantGR.DisplayName && reflect.DeepEqual(haveGR.Rules, wantGR.Rules)
+
+		haveGR.DisplayName = wantGR.DisplayName
+		haveGR.Rules = wantGR.Rules
+
+		return equal, haveGR, nil
+	}
+
+	return rb.reconcile(build, gather, compareAndMod, grCli.ObjectClient())
+}
+
+func (rb *roleBuilder) reconcileRoleTemplates(mgmt *config.ManagementContext) error {
+	logrus.Info("Reconciling RoleTemplates")
+
+	build := func(current *roleBuilder) (string, runtime.Object) {
+		role := &v3.RoleTemplate{
+			ObjectMeta: v1.ObjectMeta{
+				Name:   current.name,
+				Labels: defaultRTLabel,
+			},
+			DisplayName: current.displayName,
+			Builtin:     current.builtin,
+			External:    current.builtin,
+			Hidden:      current.hidden,
+			Rules:       current.policyRules(),
+		}
+		return role.Name, role
+	}
+
+	client := mgmt.Management.RoleTemplates("")
+	gather := func() (map[string]runtime.Object, error) {
+		set := labels.Set(defaultRTLabel)
+		existingList, err := client.List(v1.ListOptions{LabelSelector: set.String()})
+		if err != nil {
+			return nil, errors.Wrapf(err, "couldn't list roleTemplate with selector %s", set)
+		}
+
+		existing := map[string]runtime.Object{}
+		for _, e := range existingList.Items {
+			existing[e.Name] = e.DeepCopy()
+		}
+
+		return existing, nil
+	}
+
+	compareAndMod := func(have runtime.Object, want runtime.Object) (bool, runtime.Object, error) {
+		haveRT, ok := have.(*v3.RoleTemplate)
+		wantRT, ok2 := want.(*v3.RoleTemplate)
+		if !ok || !ok2 {
+			return false, nil, errors.Errorf("unexpected type comparing %v and %v", have, want)
+		}
+
+		equal := haveRT.DisplayName == wantRT.DisplayName && reflect.DeepEqual(haveRT.Rules, wantRT.Rules) && haveRT.Builtin != wantRT.Builtin &&
+			haveRT.External && wantRT.External && haveRT.Hidden && wantRT.Hidden
+
+		haveRT.DisplayName = wantRT.DisplayName
+		haveRT.Rules = wantRT.Rules
+		haveRT.Builtin = wantRT.Builtin
+		haveRT.External = wantRT.External
+		haveRT.Hidden = wantRT.Hidden
+
+		return equal, haveRT, nil
+	}
+
+	return rb.reconcile(build, gather, compareAndMod, client.ObjectClient())
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -16,7 +16,7 @@ github.com/dgrijalva/jwt-go            v3.0.0-6-g63734ea
 
 github.com/rancher/norman                     62fcd651339bd03b48e20d898a9130008d7b7140
 github.com/rancher/norman-rbac                1c90ab3e23a29ee5eff73f5b045f7b59da13ad9e
-github.com/rancher/types                      9a687d27b1a4a344879690de1c36f1ac0f3701a4
+github.com/rancher/types                      ed80832abc847784b4a01c8d43c6343d0c5c7b1f
 github.com/rancher/catalog-controller         20ceb6facc6149743c0e36e98191bd46e26dc37f
 github.com/rancher/cluster-agent              1796ff709edeec8380012bb44a9d5c88b8e68216
 github.com/rancher/cluster-api                3fb9f46869bb9ca63f6f90958c6f2537533abce8

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
@@ -23,8 +23,9 @@ type GlobalRole struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Rules   []rbacv1.PolicyRule `json:"rules,omitempty"`
-	Builtin bool                `json:"builtin"`
+	DisplayName string              `json:"displayName,omitempty" norman:"required"`
+	Rules       []rbacv1.PolicyRule `json:"rules,omitempty"`
+	Builtin     bool                `json:"builtin"`
 }
 
 type GlobalRoleBinding struct {
@@ -39,6 +40,7 @@ type RoleTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	DisplayName       string              `json:"displayName,omitempty" norman:"required"`
 	Rules             []rbacv1.PolicyRule `json:"rules,omitempty"`
 	Builtin           bool                `json:"builtin"`
 	External          bool                `json:"external"`

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/catalog_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/catalog_types.go
@@ -77,6 +77,7 @@ type TemplateVersion struct {
 }
 
 type TemplateVersionSpec struct {
+	ExternalID            string            `json:"externalId,omitempty"`
 	Revision              *int              `json:"revision,omitempty"`
 	Version               string            `json:"version,omitempty"`
 	MinimumRancherVersion string            `json:"minimumRancherVersion,omitempty" yaml:"minimum_rancher_version,omitempty"`

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
@@ -23,7 +23,7 @@ type RancherKubernetesEngineConfig struct {
 
 type RKEConfigNode struct {
 	// Name of the host provisioned via docker machine
-	MachineName string `yaml:"machine_name" json:"machineName, omitempty"`
+	MachineName string `yaml:"machine_name,omitempty" json:"machineName,omitempty"`
 	// IP or FQDN that is fully resolvable and used for SSH communication
 	Address string `yaml:"address" json:"address,omitempty"`
 	// Optional - Internal address that will be used for components communication

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema/schema.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema/schema.go
@@ -87,9 +87,9 @@ func clusterTypes(schemas *types.Schemas) *types.Schemas {
 
 func authzTypes(schemas *types.Schemas) *types.Schemas {
 	return schemas.
-		AddMapperForType(&Version, v3.Project{},
-			m.DisplayName{},
-		).
+		AddMapperForType(&Version, v3.Project{}, m.DisplayName{}).
+		AddMapperForType(&Version, v3.GlobalRole{}, m.DisplayName{}).
+		AddMapperForType(&Version, v3.RoleTemplate{}, m.DisplayName{}).
 		AddMapperForType(&Version, v3.ProjectRoleTemplateBinding{},
 			&m.Move{From: "subject/name", To: "subjectName"},
 			&m.Move{From: "subject/kind", To: "subjectKind"},

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_global_role.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_global_role.go
@@ -10,6 +10,7 @@ const (
 	GlobalRoleFieldBuiltin         = "builtin"
 	GlobalRoleFieldCreated         = "created"
 	GlobalRoleFieldFinalizers      = "finalizers"
+	GlobalRoleFieldId              = "id"
 	GlobalRoleFieldLabels          = "labels"
 	GlobalRoleFieldName            = "name"
 	GlobalRoleFieldOwnerReferences = "ownerReferences"
@@ -25,6 +26,7 @@ type GlobalRole struct {
 	Builtin         *bool             `json:"builtin,omitempty"`
 	Created         string            `json:"created,omitempty"`
 	Finalizers      []string          `json:"finalizers,omitempty"`
+	Id              string            `json:"id,omitempty"`
 	Labels          map[string]string `json:"labels,omitempty"`
 	Name            string            `json:"name,omitempty"`
 	OwnerReferences []OwnerReference  `json:"ownerReferences,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_role_template.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_role_template.go
@@ -12,6 +12,7 @@ const (
 	RoleTemplateFieldExternal        = "external"
 	RoleTemplateFieldFinalizers      = "finalizers"
 	RoleTemplateFieldHidden          = "hidden"
+	RoleTemplateFieldId              = "id"
 	RoleTemplateFieldLabels          = "labels"
 	RoleTemplateFieldName            = "name"
 	RoleTemplateFieldOwnerReferences = "ownerReferences"
@@ -30,6 +31,7 @@ type RoleTemplate struct {
 	External        *bool             `json:"external,omitempty"`
 	Finalizers      []string          `json:"finalizers,omitempty"`
 	Hidden          *bool             `json:"hidden,omitempty"`
+	Id              string            `json:"id,omitempty"`
 	Labels          map[string]string `json:"labels,omitempty"`
 	Name            string            `json:"name,omitempty"`
 	OwnerReferences []OwnerReference  `json:"ownerReferences,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_template_version.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_template_version.go
@@ -8,6 +8,7 @@ const (
 	TemplateVersionType                       = "templateVersion"
 	TemplateVersionFieldAnnotations           = "annotations"
 	TemplateVersionFieldCreated               = "created"
+	TemplateVersionFieldExternalID            = "externalId"
 	TemplateVersionFieldFiles                 = "files"
 	TemplateVersionFieldFinalizers            = "finalizers"
 	TemplateVersionFieldLabels                = "labels"
@@ -34,6 +35,7 @@ type TemplateVersion struct {
 	types.Resource
 	Annotations           map[string]string      `json:"annotations,omitempty"`
 	Created               string                 `json:"created,omitempty"`
+	ExternalID            string                 `json:"externalId,omitempty"`
 	Files                 []File                 `json:"files,omitempty"`
 	Finalizers            []string               `json:"finalizers,omitempty"`
 	Labels                map[string]string      `json:"labels,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_template_version_spec.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_template_version_spec.go
@@ -2,6 +2,7 @@ package client
 
 const (
 	TemplateVersionSpecType                       = "templateVersionSpec"
+	TemplateVersionSpecFieldExternalID            = "externalId"
 	TemplateVersionSpecFieldFiles                 = "files"
 	TemplateVersionSpecFieldMaximumRancherVersion = "maximumRancherVersion"
 	TemplateVersionSpecFieldMinimumRancherVersion = "minimumRancherVersion"
@@ -14,6 +15,7 @@ const (
 )
 
 type TemplateVersionSpec struct {
+	ExternalID            string            `json:"externalId,omitempty"`
 	Files                 []File            `json:"files,omitempty"`
 	MaximumRancherVersion string            `json:"maximumRancherVersion,omitempty"`
 	MinimumRancherVersion string            `json:"minimumRancherVersion,omitempty"`


### PR DESCRIPTION
This will bootstrap in:
- 2 GlobalRoles: Admin and User
- RoleTemplates for the k8s builtin roles and expected rancher cluster/project roles: Cluster Owner, Project Owner, Member, Read Only

It also changes the bootstrapped Admin user to use the admin GlobalRole (and binding) instead of the builtin k8s cluster-admin role