### PR TITLE
Windows Agent Upgrade Enhancement

### DIFF
--- a/agent-windows/Dockerfile
+++ b/agent-windows/Dockerfile
@@ -1,8 +1,12 @@
 FROM microsoft/nanoserver:10.0.14393.1593
-ENV RANCHER_AGENT_WINDOWS_IMAGE rancher/agent-windows:v0.1.0
+ENV RANCHER_AGENT_WINDOWS_IMAGE rancher/agent-windows:v0.2.0
+ENV TOOLS_LIST "devcon.exe,startup.ps1,cleanup.ps1,rancher-tools.psm1"
 RUN mkdir "c:/program files/rancher"
 VOLUME [ "c:/program files/rancher" ]
-ADD [ "devcon.exe","c:/program files/" ]
-ADD [ "run.ps1","c:/program files/" ]
+ADD [ "tools/devcon.exe","c:/program files/" ]
+ADD [ "tools/startup.ps1","c:/program files/" ]
+ADD [ "tools/cleanup.ps1","c:/program files/" ]
+ADD [ "tools/run.ps1","c:/program files/" ]
+ADD [ "tools/rancher-tools.psm1","c:/program files/" ]
 WORKDIR "c:/program files/"
 ENTRYPOINT [ "powershell","-file","c:/program files/run.ps1" ]

--- a/agent-windows/README.md
+++ b/agent-windows/README.md
@@ -1,0 +1,14 @@
+# Building Rancher Windows Bootstrap Agent Image
+
+The Rancher Windows Bootstrap Agent is for collecting tools binaries from Rancher Server and copying them into the host.
+
+There are two ways to build this image. But both of them will need a Windows Server 2016 host with Docker engine(>= 1.12.2).
+
+* Build it from *nix
+  - Need Docker(>= 1.12.6)
+  - Docker engine in Windows Server needs to expose port 2375(Set `"hosts":["tcp://0.0.0.0:2375","npipe://"]` in daemon.json)
+  - Execute `DOCKER_TLS_VERIFY= DOCKER_HOST=tcp://<Server_IP>:2375 ./build-image.sh`
+* Build it in Windows Server 2016
+  - Execute `./build-images.ps1` in Powershell
+
+And then, this image will be built in the Windows Server host.

--- a/agent-windows/build-image.ps1
+++ b/agent-windows/build-image.ps1
@@ -1,13 +1,10 @@
 $IMAGE=$(get-item env:IMAGE -ErrorAction Ignore)
 
-Invoke-WebRequest -Uri "https://github.com/rancher/windows-binaries/releases/download/v0.0.1/devcon.exe" -OutFile devcon.exe
-Invoke-WebRequest -Uri "https://github.com/rancher/windows-binaries/releases/download/v0.0.1/MD5SUM" -OutFile "MD5SUM"
-
-$md5 = New-Object -TypeName System.Security.Cryptography.MD5CryptoServiceProvider
-$hashBuilder = New-Object System.Text.StringBuilder
-$md5.ComputeHash([System.IO.File]::ReadAllBytes($pwd.Path+"/devcon.exe")) | ForEach-Object { [void]$hashBuilder.Append($_.ToString("x2")) }
-$targetHash = Get-Content -Path "$($pwd.Path)/MD5SUM"
-if($hashBuilder.ToString() -ne "$targetHash"){
+Invoke-WebRequest -Uri "https://github.com/rancher/windows-binaries/releases/download/v0.0.1/devcon.exe" -OutFile "tools/devcon.exe"
+$byteArray=(Invoke-WebRequest -Uri "https://github.com/rancher/windows-binaries/releases/download/v0.0.1/MD5SUM").Content
+$tarMD5=[System.Text.Encoding]::ASCII.GetString($byteArray).ToUpper()
+$fileHash=(Get-FileHash -Path "tools/devcon.exe" -Algorithm MD5).Hash
+if("$fileHash" -ne "$tarMD5"){
     Write-Host "MD5SUM of devcon.exe mismatch between local and remote storage."
     Exit 1
 }
@@ -19,5 +16,4 @@ if($IMAGE -eq $null){
 write-host "Building $IMAGE"
 docker build -t ${IMAGE} .
 
-remove-item -Path "$($pwd.Path)/devcon.exe"
-remove-item -Path "$($pwd.Path)/MD5SUM"
+remove-item -Path "$pwd/tools/devcon.exe"

--- a/agent-windows/build-image.sh
+++ b/agent-windows/build-image.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+cleanup(){
+    rm ./tools/devcon.exe
+}
+
+trap cleanup INT
+curl -L https://github.com/rancher/windows-binaries/releases/download/v0.0.1/devcon.exe > ./tools/devcon.exe
+MD5=$(wget -q -O- https://github.com/rancher/windows-binaries/releases/download/v0.0.1/MD5SUM)
+MD5CHECK=$(md5sum devcon.exe  | awk '{print $1}')
+if [ $MD5 -ne $MD5CHECK ]; then
+    echo "download devcon.exe error, md5 not match"
+fi
+
+if [ -z "$IMAGE" ]; then
+    IMAGE=$(grep RANCHER_AGENT_WINDOWS_IMAGE Dockerfile | awk '{print $3}')
+fi
+
+echo Building $IMAGE
+docker build -t ${IMAGE} .
+
+cleanup

--- a/agent-windows/tools/cleanup.ps1
+++ b/agent-windows/tools/cleanup.ps1
@@ -1,0 +1,29 @@
+Import-Module -Name ./rancher-tools.psm1 -Verbose
+
+Stop-Service rancher-agent
+Stop-Service rancher-per-host-subnet
+
+$routerIpKey="io.rancher.network.per_host_subnet.router_ip"
+$SubnetKey="io.rancher.network.per_host_subnet.subnet"
+$defaultNetworkName="transparent"
+$routerIp=Get-RancherLabel "$routerIpKey"
+$subnet=Get-RancherLabel "$SubnetKey"
+if("$subnet" -ne ""){
+    if($(Test-RancherNetwork "$subnet")){
+        $output=docker network rm $defaultNetworkName 2>$null
+        if("$output" -eq "$defaultNetworkName"){
+            Write-Host "Clean up transaprent success"
+        }
+    }
+}
+
+## reset nat
+netsh routing ip nat uninstall > $null
+netsh routing ip nat install > $null
+
+## remove net device
+& "c:\program files\rancher\devcon.exe" remove *MSLOOP > $null
+
+## remove net route
+Get-NetIPAddress -IPAddress "$routerIp" | get-netroute | Where-Object {$_.NextHop -ne "0.0.0.0" -and $_.NextHop -ne "::"} | remove-netroute -Confirm:$false
+

--- a/agent-windows/tools/rancher-tools.psm1
+++ b/agent-windows/tools/rancher-tools.psm1
@@ -1,0 +1,40 @@
+[Reflection.Assembly]::LoadWithPartialName("System.Web") | Out-Null
+
+function Get-RancherLabel {
+    Param(
+        # Parameter help description
+        [string]$LabelKey
+    )
+    $RancherLabelKey="CATTLE_HOST_LABELS"
+    try{
+        $labels= [System.Environment]::GetEnvironmentVariable("$RancherLabelKey","Machine")
+        if($labels -eq ""){
+            return ""
+        }
+        $qs=[System.Web.HttpUtility]::ParseQueryString($LabelKey)
+        return $qs["$Key"]
+    }
+    catch{
+     return ""
+    }
+}
+
+function Test-RancherNetwork {
+    param(
+        [string]$Subnet
+    )
+    $defaultNetworkName = "transparent"
+    $output=docker network inspect $defaultNetworkName 2>$null
+    if ("$output" -eq "[]"){
+        return $false
+    }
+    $Network= ConvertFrom-Json "$output"
+    if("$Subnet" -ne $network.IPAM.Config.subnet){
+        return $false
+    }
+    return $true
+}
+
+Export-ModuleMember -function Get-RancherLabel
+Export-ModuleMember -Function Test-RancherNetwork
+

--- a/agent-windows/tools/run.ps1
+++ b/agent-windows/tools/run.ps1
@@ -4,6 +4,11 @@ param(
     [string]$AgentIp
 )
 
+$downloadFolder="download"
+$downloadNames=@{"windows-agent"="go-agent.zip";"per-host-subnet"="rancher-per-host-subnet.zip"}
+$rancherBaseDir="rancher"
+$tools=[System.Environment]::GetEnvironmentVariable("TOOLS_LIST").Split(",")
+
 function register {
     param(
         [string]$RegisterUrl
@@ -100,14 +105,18 @@ function getBinary{
     }
 }
 
-$downloadNames=@{"windows-agent"="go-agent.zip";"per-host-subnet"="rancher-per-host-subnet.zip"}
-$rancherBaseDir="rancher"
+
 $key,$secret,$url,$this_ip=$(register $RegisterUrl)
 if ($AgentIp -ne $null) { $this_ip=$AgentIp}
+Remove-Item -Path "$rancherBaseDir/$downloadFolder" -Confirm:$false -Recurse
+New-Item -ItemType Directory -Path "$rancherBaseDir/$downloadFolder" > $null
 getBinary $key $secret $url
 
 foreach($zipFile in $downloadNames.Values){
-    Expand-Archive "$zipFile" -DestinationPath .
+    Expand-Archive "$zipFile" -DestinationPath "./$rancherBaseDir/$downloadFolder"
 }
-Copy-item -Path "c:/program files/devcon.exe" -Destination "c:/program files/$rancherBaseDir/devcon.exe"
+
+foreach ($copyTarget in $tools) {
+    Copy-item -Path "c:/program files/$copyTarget" -Destination "c:/program files/$rancherBaseDir/$copyTarget"
+}
 Write-Output "`"$RegisterUrl`",`"$HostLabels`",`"$AgentIp`""

--- a/agent-windows/tools/startup.ps1
+++ b/agent-windows/tools/startup.ps1
@@ -1,0 +1,105 @@
+param(
+    [Parameter(ValueFromPipeline=$true)]
+    [string]$inputStr
+)
+
+$downloadFolder="download"
+$rancherBaseDir="rancher"
+$BasicLocation="c:\program files\$rancherBaseDir"
+$AgentBinary="agent"
+$PerHostSubnetBinary="per-host-subnet"
+$rancherCompomentList="$PerHostSubnetBinary","$AgentBinary"
+$strs=$inputStr.Split(",")
+$HostLabels=$strs[1].Trim("`"")
+$AgentIp=$strs[2].Trim("`"")
+if($HostLabels -ne $null){
+    [System.Environment]::SetEnvironmentVariable("CATTLE_HOST_LABELS",$HostLabels,"Machine")
+}
+if ($AgentIp -ne $null){
+    [System.Environment]::SetEnvironmentVariable("CATTLE_AGENT_IP",$AgentIp,"Machine")
+}
+function Test-Updates {
+    param(
+        [string]$target=""
+    )
+    $rtn=$true
+    for($i=0;$i -lt $rancherCompomentList.Count;$i++){ 
+        $listTar=$rancherCompomentList[$i]
+        if(("$target" -eq "$listTar") -or ("$target" -eq "")){
+            $downloadHash=(Get-FileHash -Algorithm MD5 -Path "$pwd/$downloadFolder/$rancherBaseDir/$listTar.exe").Hash
+            $downloadScriptHash=(Get-FileHash -Algorithm MD5 -Path "$pwd/$downloadFolder/$rancherBaseDir/startup_$listTar.ps1").Hash
+            $currentHash=(Get-FileHash -Algorithm MD5 -Path "$pwd/$listTar.exe").Hash
+            $currentScriptHash=(Get-FileHash -Algorithm MD5 -Path "$pwd/startup_$listTar.ps1").Hash
+            if(("$downloadHash" -ne "$currentHash") -or ("$downloadScriptHash" -ne "$currentScriptHash")){
+                $rtn = $rtn -and $true
+            } else {
+                $rtn = $false
+            }
+        }
+    }
+    return $rtn
+}
+
+function Update-Binaries  {
+    param(
+        [string]$target=""
+    )
+    for($i=0;$i -lt $rancherCompomentList.Count;$i++){ 
+        $listTar=$rancherCompomentList[$i]
+        if(("$target" -eq "$listTar") -or ("$target" -eq "")){
+            Copy-Item -Path "$pwd/$downloadFolder/$rancherBaseDir/$listTar.exe" -Destination "$pwd/$listTar.exe"
+            Copy-Item -Path "$pwd/$downloadFolder/$rancherBaseDir/startup_$listTar.ps1" -Destination "$pwd/startup_$listTar.ps1"
+        }
+    }
+}
+
+function Test-RancherComponent {
+    param(
+        [string]$target=""
+    )
+    $rtn=$true
+    for($i=0;$i -lt $rancherCompomentList.Count;$i++){ 
+        $listTar=$rancherCompomentList[$i]
+        if(("$target" -eq "$listTar") -or ("$target" -eq "")){
+            if($(Test-Path "$pwd/startup_$listTar.ps1") -and $(Test-Path "$pwd/$listTar.exe")){
+                $rtn = $rtn -and $true
+                
+            } else {
+                $rtn = $false
+            }
+        }
+    }
+    return $rtn
+}
+
+function Stop-RancherServices  {
+    Stop-Service rancher-agent
+    Stop-Service rancher-per-host-subnet
+    Write-Host "Stop Services Success"
+}
+
+function Start-RancherServices  {
+    Start-Service rancher-agent
+    sleep 5
+    Start-Service rancher-per-host-subnet
+    Write-Host "Start Services Success"
+}
+
+try {
+    Set-Location -Path $BasicLocation
+    for($i=0;$i -lt $rancherCompomentList.Count;$i++){
+        $listTar=$rancherCompomentList[$i]
+        Write-Host "checking $listTar update"
+        if(-not $(Test-RancherComponent "$listTar") -or $(Test-Updates "$listTar")){
+            Update-Binaries "$listTar"
+            Invoke-Expression "'$inputStr' | ./startup_$listTar.ps1"
+            Write-Host "create or update $listTar success"
+        } else{
+            Write-Host "version of $listTar is the same, do nothing"
+        }
+    }  
+}
+catch {
+    Write-Host $Error[0]
+    Write-Host "Get error while running startup.ps1"
+}


### PR DESCRIPTION
Related issue https://github.com/rancher/rancher/issues/10662

Add new rancher tools for common use.
Add clean up script.
Add startup script for the main entry. And Upgrading logic is in it.
The run.ps1 now will download the binaries into download folder instead of base dir for upgrading purpose.
Add a build-image.sh script for *nix to build a Windows from *nix os.