### PR TITLE
Removing deprecated gke cap endpoint

### DIFF
--- a/server/capabilities/gke_capabilities.go
+++ b/server/capabilities/gke_capabilities.go
@@ -1,0 +1,114 @@
+package capabilities
+
+import (
+	"github.com/rancher/kontainer-engine/drivers/gke"
+	"os"
+	"strings"
+	"golang.org/x/oauth2/google"
+	"context"
+	"net/http"
+	"io/ioutil"
+	"io"
+	"google.golang.org/api/container/v1"
+	"golang.org/x/oauth2"
+	"github.com/sirupsen/logrus"
+	"encoding/json"
+	"fmt"
+)
+
+type capabilitiesRequestBody struct {
+	Credentials string `json:"credentials"`
+	ProjectId   string `json:"projectId"`
+}
+
+func validateRequestBody(writer http.ResponseWriter, body *capabilitiesRequestBody) error {
+	credentials := body.Credentials
+	projectID := body.ProjectId
+
+	if projectID == "" {
+		writer.WriteHeader(http.StatusBadRequest)
+		return fmt.Errorf("invalid projectId")
+	}
+
+	if credentials == "" {
+		writer.WriteHeader(http.StatusBadRequest)
+		return fmt.Errorf("invalid credentials")
+	}
+
+	return nil
+}
+
+func extractRequestBody(writer http.ResponseWriter, req *http.Request, body interface{}) error {
+	raw, err := ioutil.ReadAll(req.Body)
+
+	if err != nil {
+		writer.WriteHeader(http.StatusBadRequest)
+		return fmt.Errorf("cannot read request body: " + err.Error())
+	}
+
+	err = json.Unmarshal(raw, &body)
+
+	if err != nil {
+		writer.WriteHeader(http.StatusBadRequest)
+		return fmt.Errorf("cannot parse request body: " + err.Error())
+	}
+
+	return nil
+}
+
+func getOAuthClient(ctx context.Context, credentialContent string) (*http.Client, error) {
+	// The google SDK has no sane way to pass in a TokenSource give all the different types (user, service account, etc)
+	// So we actually set an environment variable and then unset it
+	gke.EnvMutex.Lock()
+	locked := true
+	setEnv := false
+	cleanup := func() {
+		if setEnv {
+			os.Unsetenv(defaultCredentialEnv)
+		}
+
+		if locked {
+			gke.EnvMutex.Unlock()
+			locked = false
+		}
+	}
+	defer cleanup()
+
+	file, err := ioutil.TempFile("", "credential-file")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	if _, err := io.Copy(file, strings.NewReader(credentialContent)); err != nil {
+		return nil, err
+	}
+
+	setEnv = true
+	os.Setenv(defaultCredentialEnv, file.Name())
+
+	ts, err := google.DefaultTokenSource(ctx, container.CloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unlocks
+	cleanup()
+
+	return oauth2.NewClient(ctx, ts), nil
+}
+
+func handleErr(writer http.ResponseWriter, originalErr error) {
+	resp := errorResponse{originalErr.Error()}
+
+	asJSON, err := json.Marshal(resp)
+
+	if err != nil {
+		logrus.Error("error while marshalling error message '" + originalErr.Error() + "' error was '" + err.Error() + "'")
+		writer.Write([]byte(err.Error()))
+		return
+	}
+
+	writer.Write([]byte(asJSON))
+}

--- a/server/capabilities/gke_machine_types_endpoint.go
+++ b/server/capabilities/gke_machine_types_endpoint.go
@@ -1,44 +1,37 @@
 package capabilities
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
-
-	"github.com/rancher/kontainer-engine/drivers/gke"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"context"
+	"github.com/sirupsen/logrus"
+	"github.com/rancher/kontainer-engine/drivers/gke"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
+	"io/ioutil"
+	"io"
+	"encoding/json"
+	"fmt"
 )
 
-const (
-	defaultCredentialEnv = "GOOGLE_APPLICATION_CREDENTIALS"
-)
-
-func NewGKECapabilitiesHandler() *GKEVersionHandler {
-	return &GKEVersionHandler{}
+func NewGKEMachineTypesHandler() *gkeMachineTypesHandler {
+	return &gkeMachineTypesHandler{}
 }
 
-type GKEVersionHandler struct {
+type gkeMachineTypesHandler struct {
+	Field string
 }
 
-type errorResponse struct {
-	Error string `json:"error"`
-}
-
-type versionsRequestBody struct {
+type machineTypesRequestBody struct {
 	Credentials string `json:"credentials"`
+	ProjectId   string `json:"projectId"`
 	Zone        string `json:"zone"`
-	ProjectID   string `json:"projectId"`
 }
 
-func (g *gkeVersionHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
+func (g *gkeMachineTypesHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		writer.WriteHeader(http.StatusMethodNotAllowed)
 		return
@@ -48,7 +41,7 @@ func (g *gkeVersionHandler) ServeHTTP(writer http.ResponseWriter, req *http.Requ
 
 	raw, err := ioutil.ReadAll(req.Body)
 
-	var body versionsRequestBody
+	var body machineTypesRequestBody
 	err = json.Unmarshal(raw, &body)
 
 	if err != nil {
@@ -58,7 +51,7 @@ func (g *gkeVersionHandler) ServeHTTP(writer http.ResponseWriter, req *http.Requ
 	}
 
 	credentials := body.Credentials
-	projectID := body.ProjectID
+	projectID := body.ProjectId
 	zone := body.Zone
 
 	if projectID == "" {
@@ -87,7 +80,7 @@ func (g *gkeVersionHandler) ServeHTTP(writer http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	result, err := client.Projects.Zones.GetServerconfig(projectID, zone).Do()
+	result, err := client.MachineTypes.List(projectID, zone).Do()
 
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
@@ -106,7 +99,7 @@ func (g *gkeVersionHandler) ServeHTTP(writer http.ResponseWriter, req *http.Requ
 	writer.Write(serialized)
 }
 
-func (g *GKEVersionHandler) handleErr(writer http.ResponseWriter, originalErr error) {
+func (g *gkeMachineTypesHandler) handleErr(writer http.ResponseWriter, originalErr error) {
 	resp := errorResponse{originalErr.Error()}
 
 	asJSON, err := json.Marshal(resp)
@@ -120,7 +113,7 @@ func (g *GKEVersionHandler) handleErr(writer http.ResponseWriter, originalErr er
 	writer.Write([]byte(asJSON))
 }
 
-func (g *GKEVersionHandler) getServiceClient(ctx context.Context, credentialContent string) (*container.Service, error) {
+func (g *gkeMachineTypesHandler) getServiceClient(ctx context.Context, credentialContent string) (*compute.Service, error) {
 	// The google SDK has no sane way to pass in a TokenSource give all the different types (user, service account, etc)
 	// So we actually set an environment variable and then unset it
 	gke.EnvMutex.Lock()
@@ -161,7 +154,7 @@ func (g *GKEVersionHandler) getServiceClient(ctx context.Context, credentialCont
 	cleanup()
 
 	client := oauth2.NewClient(ctx, ts)
-	service, err := container.New(client)
+	service, err := compute.New(client)
 
 	if err != nil {
 		return nil, err

--- a/server/capabilities/gke_machine_types_endpoint.go
+++ b/server/capabilities/gke_machine_types_endpoint.go
@@ -2,17 +2,8 @@ package capabilities
 
 import (
 	"net/http"
-	"os"
-	"strings"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 	"context"
-	"github.com/sirupsen/logrus"
-	"github.com/rancher/kontainer-engine/drivers/gke"
 	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/container/v1"
-	"io/ioutil"
-	"io"
 	"encoding/json"
 	"fmt"
 )
@@ -25,12 +16,6 @@ type gkeMachineTypesHandler struct {
 	Field string
 }
 
-type machineTypesRequestBody struct {
-	Credentials string `json:"credentials"`
-	ProjectId   string `json:"projectId"`
-	Zone        string `json:"zone"`
-}
-
 func (g *gkeMachineTypesHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		writer.WriteHeader(http.StatusMethodNotAllowed)
@@ -39,52 +24,40 @@ func (g *gkeMachineTypesHandler) ServeHTTP(writer http.ResponseWriter, req *http
 
 	writer.Header().Set("Content-Type", "application/json")
 
-	raw, err := ioutil.ReadAll(req.Body)
-
-	var body machineTypesRequestBody
-	err = json.Unmarshal(raw, &body)
+	var body zoneCapabilitiesRequestBody
+	err := extractRequestBody(writer, req, &body)
 
 	if err != nil {
-		writer.WriteHeader(http.StatusBadRequest)
-		g.handleErr(writer, fmt.Errorf("cannot parse request body: "+err.Error()))
+		handleErr(writer, err)
 		return
 	}
 
-	credentials := body.Credentials
-	projectID := body.ProjectId
-	zone := body.Zone
+	err = validateRequestBody(writer, &body.capabilitiesRequestBody)
 
-	if projectID == "" {
-		writer.WriteHeader(http.StatusBadRequest)
-		g.handleErr(writer, fmt.Errorf("invalid projectId"))
+	if err != nil {
+		handleErr(writer, err)
 		return
 	}
 
-	if zone == "" {
+	if body.Credentials == "" {
 		writer.WriteHeader(http.StatusBadRequest)
-		g.handleErr(writer, fmt.Errorf("invalid zone"))
+		handleErr(writer, fmt.Errorf("invalid credentials"))
 		return
 	}
 
-	if credentials == "" {
-		writer.WriteHeader(http.StatusBadRequest)
-		g.handleErr(writer, fmt.Errorf("invalid credentials"))
-		return
-	}
-
-	client, err := g.getServiceClient(context.Background(), credentials)
+	client, err := g.getServiceClient(context.Background(), body.Credentials)
 
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
-		g.handleErr(writer, err)
+		handleErr(writer, err)
 		return
 	}
 
-	result, err := client.MachineTypes.List(projectID, zone).Do()
+	result, err := client.MachineTypes.List(body.ProjectId, body.Zone).Do()
 
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
-		g.handleErr(writer, err)
+		handleErr(writer, err)
 		return
 	}
 
@@ -92,68 +65,20 @@ func (g *gkeMachineTypesHandler) ServeHTTP(writer http.ResponseWriter, req *http
 
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
-		g.handleErr(writer, err)
+		handleErr(writer, err)
 		return
 	}
 
 	writer.Write(serialized)
 }
 
-func (g *gkeMachineTypesHandler) handleErr(writer http.ResponseWriter, originalErr error) {
-	resp := errorResponse{originalErr.Error()}
-
-	asJSON, err := json.Marshal(resp)
-
-	if err != nil {
-		logrus.Error("error while marshalling error message '" + originalErr.Error() + "' error was '" + err.Error() + "'")
-		writer.Write([]byte(err.Error()))
-		return
-	}
-
-	writer.Write([]byte(asJSON))
-}
-
 func (g *gkeMachineTypesHandler) getServiceClient(ctx context.Context, credentialContent string) (*compute.Service, error) {
-	// The google SDK has no sane way to pass in a TokenSource give all the different types (user, service account, etc)
-	// So we actually set an environment variable and then unset it
-	gke.EnvMutex.Lock()
-	locked := true
-	setEnv := false
-	cleanup := func() {
-		if setEnv {
-			os.Unsetenv(defaultCredentialEnv)
-		}
+	client, err := getOAuthClient(ctx, credentialContent)
 
-		if locked {
-			gke.EnvMutex.Unlock()
-			locked = false
-		}
-	}
-	defer cleanup()
-
-	file, err := ioutil.TempFile("", "credential-file")
-	if err != nil {
-		return nil, err
-	}
-	defer os.Remove(file.Name())
-	defer file.Close()
-
-	if _, err := io.Copy(file, strings.NewReader(credentialContent)); err != nil {
-		return nil, err
-	}
-
-	setEnv = true
-	os.Setenv(defaultCredentialEnv, file.Name())
-
-	ts, err := google.DefaultTokenSource(ctx, container.CloudPlatformScope)
 	if err != nil {
 		return nil, err
 	}
 
-	// Unlocks
-	cleanup()
-
-	client := oauth2.NewClient(ctx, ts)
 	service, err := compute.New(client)
 
 	if err != nil {

--- a/server/capabilities/gke_version_endpoint.go
+++ b/server/capabilities/gke_version_endpoint.go
@@ -1,41 +1,26 @@
 package capabilities
 
 import (
+	"net/http"
 	"context"
+	"google.golang.org/api/container/v1"
 	"encoding/json"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"strings"
-
-	"github.com/rancher/kontainer-engine/drivers/gke"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
-	"google.golang.org/api/container/v1"
 )
 
 const (
 	defaultCredentialEnv = "GOOGLE_APPLICATION_CREDENTIALS"
 )
 
-func NewGKECapabilitiesHandler() *GKEVersionHandler {
-	return &GKEVersionHandler{}
+func NewGKEVersionsHandler() *gkeVersionHandler {
+	return &gkeVersionHandler{}
 }
 
-type GKEVersionHandler struct {
+type gkeVersionHandler struct {
 }
 
 type errorResponse struct {
 	Error string `json:"error"`
-}
-
-type versionsRequestBody struct {
-	Credentials string `json:"credentials"`
-	Zone        string `json:"zone"`
-	ProjectID   string `json:"projectId"`
 }
 
 func (g *gkeVersionHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
@@ -46,52 +31,41 @@ func (g *gkeVersionHandler) ServeHTTP(writer http.ResponseWriter, req *http.Requ
 
 	writer.Header().Set("Content-Type", "application/json")
 
-	raw, err := ioutil.ReadAll(req.Body)
-
-	var body versionsRequestBody
-	err = json.Unmarshal(raw, &body)
+	var body zoneCapabilitiesRequestBody
+	err := extractRequestBody(writer, req, &body)
 
 	if err != nil {
-		writer.WriteHeader(http.StatusBadRequest)
-		g.handleErr(writer, fmt.Errorf("cannot parse request body: "+err.Error()))
+		handleErr(writer, err)
 		return
 	}
 
-	credentials := body.Credentials
-	projectID := body.ProjectID
+	err = validateRequestBody(writer, &body.capabilitiesRequestBody)
+
+	if err != nil {
+		handleErr(writer, err)
+		return
+	}
+
 	zone := body.Zone
-
-	if projectID == "" {
-		writer.WriteHeader(http.StatusBadRequest)
-		g.handleErr(writer, fmt.Errorf("invalid projectId"))
-		return
-	}
-
 	if zone == "" {
 		writer.WriteHeader(http.StatusBadRequest)
-		g.handleErr(writer, fmt.Errorf("invalid zone"))
+		handleErr(writer, fmt.Errorf("invalid zone"))
 		return
 	}
 
-	if credentials == "" {
-		writer.WriteHeader(http.StatusBadRequest)
-		g.handleErr(writer, fmt.Errorf("invalid credentials"))
-		return
-	}
-
-	client, err := g.getServiceClient(context.Background(), credentials)
+	client, err := g.getServiceClient(context.Background(), body.Credentials)
 
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
-		g.handleErr(writer, err)
+		handleErr(writer, err)
 		return
 	}
 
-	result, err := client.Projects.Zones.GetServerconfig(projectID, zone).Do()
+	result, err := client.Projects.Zones.GetServerconfig(body.ProjectId, zone).Do()
 
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
-		g.handleErr(writer, err)
+		handleErr(writer, err)
 		return
 	}
 
@@ -99,68 +73,20 @@ func (g *gkeVersionHandler) ServeHTTP(writer http.ResponseWriter, req *http.Requ
 
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
-		g.handleErr(writer, err)
+		handleErr(writer, err)
 		return
 	}
 
 	writer.Write(serialized)
 }
 
-func (g *GKEVersionHandler) handleErr(writer http.ResponseWriter, originalErr error) {
-	resp := errorResponse{originalErr.Error()}
+func (g *gkeVersionHandler) getServiceClient(ctx context.Context, credentialContent string) (*container.Service, error) {
+	client, err := getOAuthClient(ctx, credentialContent)
 
-	asJSON, err := json.Marshal(resp)
-
-	if err != nil {
-		logrus.Error("error while marshalling error message '" + originalErr.Error() + "' error was '" + err.Error() + "'")
-		writer.Write([]byte(err.Error()))
-		return
-	}
-
-	writer.Write([]byte(asJSON))
-}
-
-func (g *GKEVersionHandler) getServiceClient(ctx context.Context, credentialContent string) (*container.Service, error) {
-	// The google SDK has no sane way to pass in a TokenSource give all the different types (user, service account, etc)
-	// So we actually set an environment variable and then unset it
-	gke.EnvMutex.Lock()
-	locked := true
-	setEnv := false
-	cleanup := func() {
-		if setEnv {
-			os.Unsetenv(defaultCredentialEnv)
-		}
-
-		if locked {
-			gke.EnvMutex.Unlock()
-			locked = false
-		}
-	}
-	defer cleanup()
-
-	file, err := ioutil.TempFile("", "credential-file")
-	if err != nil {
-		return nil, err
-	}
-	defer os.Remove(file.Name())
-	defer file.Close()
-
-	if _, err := io.Copy(file, strings.NewReader(credentialContent)); err != nil {
-		return nil, err
-	}
-
-	setEnv = true
-	os.Setenv(defaultCredentialEnv, file.Name())
-
-	ts, err := google.DefaultTokenSource(ctx, container.CloudPlatformScope)
 	if err != nil {
 		return nil, err
 	}
 
-	// Unlocks
-	cleanup()
-
-	client := oauth2.NewClient(ctx, ts)
 	service, err := container.New(client)
 
 	if err != nil {

--- a/server/capabilities/gke_zones_endpoint.go
+++ b/server/capabilities/gke_zones_endpoint.go
@@ -2,19 +2,9 @@ package capabilities
 
 import (
 	"net/http"
-	"os"
-	"strings"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 	"context"
-	"github.com/sirupsen/logrus"
-	"github.com/rancher/kontainer-engine/drivers/gke"
 	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/container/v1"
-	"io/ioutil"
-	"io"
 	"encoding/json"
-	"fmt"
 )
 
 func NewGKEZonesHandler() *gkeZonesHandler {
@@ -25,9 +15,9 @@ type gkeZonesHandler struct {
 	Field string
 }
 
-type zonesRequestBody struct {
-	Credentials string `json:"credentials"`
-	ProjectId   string `json:"projectId"`
+type zoneCapabilitiesRequestBody struct {
+	capabilitiesRequestBody
+	Zone string `json:"zone"`
 }
 
 func (g *gkeZonesHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
@@ -38,45 +28,34 @@ func (g *gkeZonesHandler) ServeHTTP(writer http.ResponseWriter, req *http.Reques
 
 	writer.Header().Set("Content-Type", "application/json")
 
-	raw, err := ioutil.ReadAll(req.Body)
-
-	var body zonesRequestBody
-	err = json.Unmarshal(raw, &body)
+	var body zoneCapabilitiesRequestBody
+	err := extractRequestBody(writer, req, &body)
 
 	if err != nil {
-		writer.WriteHeader(http.StatusBadRequest)
-		g.handleErr(writer, fmt.Errorf("cannot parse request body: "+err.Error()))
+		handleErr(writer, err)
 		return
 	}
 
-	credentials := body.Credentials
-	projectID := body.ProjectId
+	err = validateRequestBody(writer, &body.capabilitiesRequestBody)
 
-	if projectID == "" {
-		writer.WriteHeader(http.StatusBadRequest)
-		g.handleErr(writer, fmt.Errorf("invalid projectId"))
+	if err != nil {
+		handleErr(writer, err)
 		return
 	}
 
-	if credentials == "" {
-		writer.WriteHeader(http.StatusBadRequest)
-		g.handleErr(writer, fmt.Errorf("invalid credentials"))
-		return
-	}
-
-	client, err := g.getServiceClient(context.Background(), credentials)
+	client, err := g.getServiceClient(context.Background(), body.Credentials)
 
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
-		g.handleErr(writer, err)
+		handleErr(writer, err)
 		return
 	}
 
-	result, err := client.Zones.List(projectID).Do()
+	result, err := client.Zones.List(body.ProjectId).Do()
 
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
-		g.handleErr(writer, err)
+		handleErr(writer, err)
 		return
 	}
 
@@ -84,68 +63,20 @@ func (g *gkeZonesHandler) ServeHTTP(writer http.ResponseWriter, req *http.Reques
 
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
-		g.handleErr(writer, err)
+		handleErr(writer, err)
 		return
 	}
 
 	writer.Write(serialized)
 }
 
-func (g *gkeZonesHandler) handleErr(writer http.ResponseWriter, originalErr error) {
-	resp := errorResponse{originalErr.Error()}
-
-	asJSON, err := json.Marshal(resp)
-
-	if err != nil {
-		logrus.Error("error while marshalling error message '" + originalErr.Error() + "' error was '" + err.Error() + "'")
-		writer.Write([]byte(err.Error()))
-		return
-	}
-
-	writer.Write([]byte(asJSON))
-}
-
 func (g *gkeZonesHandler) getServiceClient(ctx context.Context, credentialContent string) (*compute.Service, error) {
-	// The google SDK has no sane way to pass in a TokenSource give all the different types (user, service account, etc)
-	// So we actually set an environment variable and then unset it
-	gke.EnvMutex.Lock()
-	locked := true
-	setEnv := false
-	cleanup := func() {
-		if setEnv {
-			os.Unsetenv(defaultCredentialEnv)
-		}
+	client, err := getOAuthClient(ctx, credentialContent)
 
-		if locked {
-			gke.EnvMutex.Unlock()
-			locked = false
-		}
-	}
-	defer cleanup()
-
-	file, err := ioutil.TempFile("", "credential-file")
-	if err != nil {
-		return nil, err
-	}
-	defer os.Remove(file.Name())
-	defer file.Close()
-
-	if _, err := io.Copy(file, strings.NewReader(credentialContent)); err != nil {
-		return nil, err
-	}
-
-	setEnv = true
-	os.Setenv(defaultCredentialEnv, file.Name())
-
-	ts, err := google.DefaultTokenSource(ctx, container.CloudPlatformScope)
 	if err != nil {
 		return nil, err
 	}
 
-	// Unlocks
-	cleanup()
-
-	client := oauth2.NewClient(ctx, ts)
 	service, err := compute.New(client)
 
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -61,7 +61,10 @@ func newAuthed(tokenAPI http.Handler, managementAPI http.Handler) *mux.Router {
 	authed.PathPrefix("/v3/token").Handler(tokenAPI)
 	authed.PathPrefix("/v3/identit").Handler(tokenAPI)
 	authed.PathPrefix("/meta").Handler(managementAPI)
-	authed.PathPrefix("/v3/gkeCapabilities").Handler(capabilities.NewGKECapabilitiesHandler())
+	authed.PathPrefix("/v3/gkeCapabilities").Handler(capabilities.NewGKEVersionsHandler())
+	authed.PathPrefix("/v3/gkeVersions").Handler(capabilities.NewGKEVersionsHandler())
+	authed.PathPrefix("/v3/gkeMachineTypes").Handler(capabilities.NewGKEMachineTypesHandler())
+	authed.PathPrefix("/v3/gkeZones").Handler(capabilities.NewGKEZonesHandler())
 	authed.PathPrefix(managementSchema.Version.Path).Handler(managementAPI)
 
 	return authed

--- a/server/server.go
+++ b/server/server.go
@@ -61,7 +61,6 @@ func newAuthed(tokenAPI http.Handler, managementAPI http.Handler) *mux.Router {
 	authed.PathPrefix("/v3/token").Handler(tokenAPI)
 	authed.PathPrefix("/v3/identit").Handler(tokenAPI)
 	authed.PathPrefix("/meta").Handler(managementAPI)
-	authed.PathPrefix("/v3/gkeCapabilities").Handler(capabilities.NewGKEVersionsHandler())
 	authed.PathPrefix("/v3/gkeVersions").Handler(capabilities.NewGKEVersionsHandler())
 	authed.PathPrefix("/v3/gkeMachineTypes").Handler(capabilities.NewGKEMachineTypesHandler())
 	authed.PathPrefix("/v3/gkeZones").Handler(capabilities.NewGKEZonesHandler())


### PR DESCRIPTION
DON'T MERGE UNTIL GUI IS UPDATED TO USE NEW ENDPOINT

Removing the old gkeCapabilities endpoint.