### PR TITLE
Always set token cookie as secure

### DIFF
--- a/pkg/auth/tokens/route_handlers.go
+++ b/pkg/auth/tokens/route_handlers.go
@@ -86,16 +86,11 @@ func (s *tokenAPIServer) login(actionName string, action *types.Action, request 
 		return httperror.NewAPIErrorLong(status, util.GetHTTPErrorCode(status), fmt.Sprintf("%v", err))
 	}
 
-	isSecure := false
-	if r.URL.Scheme == "https" {
-		isSecure = true
-	}
-
 	if jsonInput.ResponseType == "cookie" {
 		tokenCookie := &http.Cookie{
 			Name:     CookieName,
 			Value:    token.ObjectMeta.Name + ":" + token.Token,
-			Secure:   isSecure,
+			Secure:   true,
 			Path:     "/",
 			HttpOnly: true,
 		}


### PR DESCRIPTION
Previous method for deciding whether the request was secure (and
setting the secure flag on the cookie accordingly) doesn't work
because the URL on the request is relative and thus the scheme is
not set.

Rancher will always have TLS enabled, so always setting the secure
cookie flag to true is acceptable.