### PR TITLE
Private registry support and system images to setting

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -1,22 +1,30 @@
 package settings
 
+import (
+	"encoding/json"
+
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+)
+
 var (
 	settings = map[string]Setting{}
 	provider Provider
 
-	AgentImage           = newSetting("agent-image", "rancher/agent:v2.0.2-rc1")
-	CACerts              = newSetting("cacerts", "")
-	EngineInstallURL     = newSetting("engine-install-url", "https://releases.rancher.com/install-docker/17.03.sh")
-	EngineNewestVersion  = newSetting("engine-newest-version", "v17.03.0")
-	EngineSupportedRange = newSetting("engine-supported-range", "~v17.03.0")
-	MachineVersion       = newSetting("machine-version", "dev")
-	HelmVersion          = newSetting("helm-version", "dev")
-	ServerImage          = newSetting("server-image", "rancher/server")
-	ServerVersion        = newSetting("server-version", "dev")
-	TelemetryOpt         = newSetting("telemetry-opt", "")
-	UIFeedBackForm       = newSetting("ui-feedback-form", "")
-	UIIndex              = newSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
-	UIPL                 = newSetting("ui-pl", "rancher")
+	AgentImage                      = newSetting("agent-image", "rancher/agent:v2.0.2-rc1")
+	CACerts                         = newSetting("cacerts", "")
+	EngineInstallURL                = newSetting("engine-install-url", "https://releases.rancher.com/install-docker/17.03.sh")
+	EngineNewestVersion             = newSetting("engine-newest-version", "v17.03.0")
+	EngineSupportedRange            = newSetting("engine-supported-range", "~v17.03.0")
+	MachineVersion                  = newSetting("machine-version", "dev")
+	HelmVersion                     = newSetting("helm-version", "dev")
+	ServerImage                     = newSetting("server-image", "rancher/server")
+	ServerVersion                   = newSetting("server-version", "dev")
+	TelemetryOpt                    = newSetting("telemetry-opt", "")
+	UIFeedBackForm                  = newSetting("ui-feedback-form", "")
+	UIIndex                         = newSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
+	UIPL                            = newSetting("ui-pl", "rancher")
+	KubernetesVersionToSystemImages = newSetting("k8s-version-to-images", getSystemImages())
+	KubernetesVersion               = newSetting("k8s-version", "v1.8.7-rancher1-1")
 )
 
 type Provider interface {
@@ -67,4 +75,40 @@ func newSetting(name, def string) Setting {
 	}
 	settings[s.Name] = s
 	return s
+}
+
+func getSystemImages() string {
+	v1SystemImages := v3.RKESystemImages{
+		Etcd:                      "rancher/coreos-etcd:v3.0.17",
+		Kubernetes:                "rancher/k8s:v1.8.7-rancher1-1",
+		Alpine:                    "alpine:latest",
+		NginxProxy:                "rancher/rke-nginx-proxy:v0.1.1",
+		CertDownloader:            "rancher/rke-cert-deployer:v0.1.1",
+		KubernetesServicesSidecar: "rancher/rke-service-sidekick:v0.1.0",
+		KubeDNS:                   "rancher/k8s-dns-kube-dns-amd64:1.14.5",
+		DNSmasq:                   "rancher/k8s-dns-dnsmasq-nanny-amd64:1.14.5",
+		KubeDNSSidecar:            "rancher/k8s-dns-sidecar-amd64:1.14.5",
+		KubeDNSAutoscaler:         "rancher/cluster-proportional-autoscaler-amd64:1.0.0",
+		Flannel:                   "rancher/coreos-flannel:v0.9.1",
+		FlannelCNI:                "rancher/coreos-flannel-cni:v0.2.0",
+		CalicoNode:                "rancher/calico-node:v2.6.2",
+		CalicoCNI:                 "rancher/calico-cni:v1.11.0",
+		CalicoControllers:         "rancher/calico-kube-controllers:v1.0.0",
+		CalicoCtl:                 "rancher/calico-ctl:v1.6.2",
+		CanalNode:                 "rancher/calico-node:v2.6.2",
+		CanalCNI:                  "rancher/calico-cni:v1.11.0",
+		CanalFlannel:              "rancher/coreos-flannel:v0.9.1",
+		WeaveNode:                 "weaveworks/weave-kube:2.1.2",
+		WeaveCNI:                  "weaveworks/weave-npc:2.1.2",
+		PodInfraContainer:         "rancher/pause-amd64:3.0",
+	}
+	versionToSystemImages := map[string]v3.RKESystemImages{
+		"v1.8.7-rancher1-1": v1SystemImages,
+	}
+
+	data, err := json.Marshal(versionToSystemImages)
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -24,7 +24,7 @@ google.golang.org/grpc                        v1.9.0
 gopkg.in/check.v1                             20d25e2804050c1cd24a7eea1e7a6447dd0e74ec
 
 github.com/rancher/norman                     339468f1194f6da7152013577597763ff0b8cd3c
-github.com/rancher/types                      fe5996ceb52c855b0537bffbd289d936ae416c80
+github.com/rancher/types                      af7045b760563e7d9609d72dd7db4545881ef9c4
 github.com/rancher/kontainer-engine           3c45ae8a06a0048516aded816ca3a4f4ba78de3e
-github.com/rancher/rke                        6cc50c08dcfb98dc4f6261dada7c1c68ba3c22e4
+github.com/rancher/rke                        ecd9395d213f10e34f08ac23a471189acd87d234
 github.com/rancher/netes                      ff6fb7d4e0bd45c2a3f961c6b8bc4bef31238bec

--- a/vendor/github.com/rancher/rke/cluster.yml
+++ b/vendor/github.com/rancher/rke/cluster.yml
@@ -17,11 +17,20 @@ auth:
 # 'calico_cloud_provider: aws'
 # or
 # 'calico_cloud_provider: gce'
+# network:
+#   plugin: calico
+#   options:
+#     calico_cloud_provider: aws
+#
+# To specify flannel interface, you can use the 'flannel_iface' option:
+# network:
+#   plugin: flannel
+#   options:
+#     flannel_iface: eth1
+
 network:
   plugin: flannel
   options:
-    flannel_image: quay.io/coreos/flannel:v0.9.1
-    flannel_cni_image: quay.io/coreos/flannel-cni:v0.2.0
 
 ssh_key_path: ~/.ssh/test
 enforce_docker_version: false

--- a/vendor/github.com/rancher/rke/cluster/defaults.go
+++ b/vendor/github.com/rancher/rke/cluster/defaults.go
@@ -25,7 +25,7 @@ const (
 	DefaultNetworkPlugin        = "flannel"
 	DefaultNetworkCloudProvider = "none"
 
-	DefaultInfraContainerImage            = "gcr.io/google_containers/pause-amd64:3.0"
+	DefaultInfraContainerImage            = "rancher/pause-amd64:3.0"
 	DefaultAplineImage                    = "alpine:latest"
 	DefaultNginxProxyImage                = "rancher/rke-nginx-proxy:v0.1.1"
 	DefaultCertDownloaderImage            = "rancher/rke-cert-deployer:v0.1.1"
@@ -35,20 +35,20 @@ const (
 	DefaultEtcdImage = "rancher/etcd:v3.0.17"
 	DefaultK8sImage  = "rancher/k8s:v1.8.5-rancher4"
 
-	DefaultFlannelImage    = "quay.io/coreos/flannel:v0.9.1"
-	DefaultFlannelCNIImage = "quay.io/coreos/flannel-cni:v0.2.0"
+	DefaultFlannelImage    = "rancher/coreos-flannel:v0.9.1"
+	DefaultFlannelCNIImage = "rancher/coreos-flannel-cni:v0.2.0"
 
-	DefaultCalicoNodeImage        = "quay.io/calico/node:v2.6.2"
-	DefaultCalicoCNIImage         = "quay.io/calico/cni:v1.11.0"
-	DefaultCalicoControllersImage = "quay.io/calico/kube-controllers:v1.0.0"
-	DefaultCalicoctlImage         = "quay.io/calico/ctl:v1.6.2"
+	DefaultCalicoNodeImage        = "rancher/calico-node:v2.6.2"
+	DefaultCalicoCNIImage         = "rancher/calico-cni:v1.11.0"
+	DefaultCalicoControllersImage = "rancher/calico-kube-controllers:v1.0.0"
+	DefaultCalicoctlImage         = "rancher/calico-ctl:v1.6.2"
 
 	DefaultWeaveImage    = "weaveworks/weave-kube:2.1.2"
 	DefaultWeaveCNIImage = "weaveworks/weave-npc:2.1.2"
 
-	DefaultCanalNodeImage    = "quay.io/calico/node:v2.6.2"
-	DefaultCanalCNIImage     = "quay.io/calico/cni:v1.11.0"
-	DefaultCanalFlannelImage = "quay.io/coreos/flannel:v0.9.1"
+	DefaultCanalNodeImage    = "rancher/calico-node:v2.6.2"
+	DefaultCanalCNIImage     = "rancher/calico-cni:v1.11.0"
+	DefaultCanalFlannelImage = "rancher/coreos-flannel:v0.9.1"
 
 	DefaultKubeDNSImage           = "rancher/k8s-dns-kube-dns-amd64:1.14.5"
 	DefaultDNSmasqImage           = "rancher/k8s-dns-dnsmasq-nanny-amd64:1.14.5"
@@ -123,7 +123,7 @@ func (c *Cluster) setClusterServicesDefaults() {
 		&c.Services.KubeController.ClusterCIDR:           DefaultClusterCIDR,
 		&c.Services.Kubelet.ClusterDNSServer:             DefaultClusterDNSService,
 		&c.Services.Kubelet.ClusterDomain:                DefaultClusterDomain,
-		&c.Services.Kubelet.InfraContainerImage:          DefaultInfraContainerImage,
+		&c.Services.Kubelet.InfraContainerImage:          c.SystemImages.PodInfraContainer,
 		&c.Authentication.Strategy:                       DefaultAuthStrategy,
 		&c.Services.KubeAPI.Image:                        c.SystemImages.Kubernetes,
 		&c.Services.Scheduler.Image:                      c.SystemImages.Kubernetes,
@@ -150,8 +150,41 @@ func (c *Cluster) setClusterImageDefaults() {
 		&c.SystemImages.KubernetesServicesSidecar: DefaultKubernetesServicesSidecarImage,
 		&c.SystemImages.Etcd:                      DefaultEtcdImage,
 		&c.SystemImages.Kubernetes:                DefaultK8sImage,
+		&c.SystemImages.PodInfraContainer:         DefaultInfraContainerImage,
+		&c.SystemImages.Flannel:                   DefaultFlannelImage,
+		&c.SystemImages.FlannelCNI:                DefaultFlannelCNIImage,
+		&c.SystemImages.CalicoNode:                DefaultCalicoNodeImage,
+		&c.SystemImages.CalicoCNI:                 DefaultCalicoCNIImage,
+		&c.SystemImages.CalicoControllers:         DefaultCalicoControllersImage,
+		&c.SystemImages.CalicoCtl:                 DefaultCalicoctlImage,
+		&c.SystemImages.CanalNode:                 DefaultCanalNodeImage,
+		&c.SystemImages.CanalCNI:                  DefaultCanalCNIImage,
+		&c.SystemImages.CanalFlannel:              DefaultCanalFlannelImage,
+		&c.SystemImages.WeaveNode:                 DefaultWeaveImage,
+		&c.SystemImages.WeaveCNI:                  DefaultWeaveCNIImage,
 	}
 	for k, v := range systemImagesDefaultsMap {
 		setDefaultIfEmpty(k, v)
 	}
+}
+
+func (c *Cluster) setClusterNetworkDefaults() {
+	setDefaultIfEmpty(&c.Network.Plugin, DefaultNetworkPlugin)
+
+	if c.Network.Options == nil {
+		// don't break if the user didn't define options
+		c.Network.Options = make(map[string]string)
+	}
+	networkPluginConfigDefaultsMap := make(map[string]string)
+	switch c.Network.Plugin {
+
+	case CalicoNetworkPlugin:
+		networkPluginConfigDefaultsMap = map[string]string{
+			CalicoCloudProvider: DefaultNetworkCloudProvider,
+		}
+	}
+	for k, v := range networkPluginConfigDefaultsMap {
+		setDefaultIfEmptyMapValue(c.Network.Options, k, v)
+	}
+
 }

--- a/vendor/github.com/rancher/rke/vendor.conf
+++ b/vendor/github.com/rancher/rke/vendor.conf
@@ -24,4 +24,4 @@ github.com/coreos/go-semver              e214231b295a8ea9479f11b70b35d5acf3556d9
 github.com/ugorji/go/codec               ccfe18359b55b97855cee1d3f74e5efbda4869dc
 
 github.com/rancher/norman                151aa66e3e99de7e0d195e2d5ca96b1f95544555
-github.com/rancher/types                 bfd6a6afc4202269a90d2621f5a7f7593b250f91
+github.com/rancher/types                 af7045b760563e7d9609d72dd7db4545881ef9c4

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
@@ -57,6 +57,30 @@ type RKESystemImages struct {
 	KubeDNSAutoscaler string `yaml:"kubedns_autoscaler" json:"kubednsAutoscaler,omitempty" norman:"default=gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0"`
 	// Kubernetes image
 	Kubernetes string `yaml:"kubernetes" json:"kubernetes,omitempty" norman:"default=rancher/k8s:v1.8.5-rancher4"`
+	// Flannel image
+	Flannel string `yaml:"flannel" json:"flannel,omitempty"`
+	// Flannel CNI image
+	FlannelCNI string `yaml:"flannel_cni" json:"flannelCni,omitempty"`
+	// Calico Node image
+	CalicoNode string `yaml:"calico_node" json:"calicoNode,omitempty"`
+	// Calico CNI image
+	CalicoCNI string `yaml:"calico_cni" json:"calicoCni,omitempty"`
+	// Calico Controllers image
+	CalicoControllers string `yaml:"calico_controllers" json:"calicoControllers,omitempty"`
+	// Calicoctl image
+	CalicoCtl string `yaml:"calico_ctl" json:"calicoCtl,omitempty"`
+	// Canal Node Image
+	CanalNode string `yaml:"canal_node" json:"canalNode,omitempty"`
+	// Canal CNI image
+	CanalCNI string `yaml:"canal_cni" json:"canalCni,omitempty"`
+	//CanalFlannel image
+	CanalFlannel string `yaml:"canal_flannel" json:"canalFlannel,omitempty"`
+	// Weave Node image
+	WeaveNode string `yaml:"wave_node" json:"weaveNode,omitempty"`
+	// Weave CNI image
+	WeaveCNI string `yaml:"weave_cni" json:"weaveCni,omitempty"`
+	// Pod infra container image
+	PodInfraContainer string `yaml:"pod_infra_container" json:"podInfraContainer,omitempty"`
 }
 
 type RKEConfigNode struct {

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_rke_system_images.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_rke_system_images.go
@@ -3,26 +3,50 @@ package client
 const (
 	RKESystemImagesType                           = "rkeSystemImages"
 	RKESystemImagesFieldAlpine                    = "alpine"
+	RKESystemImagesFieldCalicoCNI                 = "calicoCni"
+	RKESystemImagesFieldCalicoControllers         = "calicoControllers"
+	RKESystemImagesFieldCalicoCtl                 = "calicoCtl"
+	RKESystemImagesFieldCalicoNode                = "calicoNode"
+	RKESystemImagesFieldCanalCNI                  = "canalCni"
+	RKESystemImagesFieldCanalFlannel              = "canalFlannel"
+	RKESystemImagesFieldCanalNode                 = "canalNode"
 	RKESystemImagesFieldCertDownloader            = "certDownloader"
 	RKESystemImagesFieldDNSmasq                   = "dnsmasq"
 	RKESystemImagesFieldEtcd                      = "etcd"
+	RKESystemImagesFieldFlannel                   = "flannel"
+	RKESystemImagesFieldFlannelCNI                = "flannelCni"
 	RKESystemImagesFieldKubeDNS                   = "kubedns"
 	RKESystemImagesFieldKubeDNSAutoscaler         = "kubednsAutoscaler"
 	RKESystemImagesFieldKubeDNSSidecar            = "kubednsSidecar"
 	RKESystemImagesFieldKubernetes                = "kubernetes"
 	RKESystemImagesFieldKubernetesServicesSidecar = "kubernetesServicesSidecar"
 	RKESystemImagesFieldNginxProxy                = "nginxProxy"
+	RKESystemImagesFieldPodInfraContainer         = "podInfraContainer"
+	RKESystemImagesFieldWeaveCNI                  = "weaveCni"
+	RKESystemImagesFieldWeaveNode                 = "weaveNode"
 )
 
 type RKESystemImages struct {
 	Alpine                    string `json:"alpine,omitempty"`
+	CalicoCNI                 string `json:"calicoCni,omitempty"`
+	CalicoControllers         string `json:"calicoControllers,omitempty"`
+	CalicoCtl                 string `json:"calicoCtl,omitempty"`
+	CalicoNode                string `json:"calicoNode,omitempty"`
+	CanalCNI                  string `json:"canalCni,omitempty"`
+	CanalFlannel              string `json:"canalFlannel,omitempty"`
+	CanalNode                 string `json:"canalNode,omitempty"`
 	CertDownloader            string `json:"certDownloader,omitempty"`
 	DNSmasq                   string `json:"dnsmasq,omitempty"`
 	Etcd                      string `json:"etcd,omitempty"`
+	Flannel                   string `json:"flannel,omitempty"`
+	FlannelCNI                string `json:"flannelCni,omitempty"`
 	KubeDNS                   string `json:"kubedns,omitempty"`
 	KubeDNSAutoscaler         string `json:"kubednsAutoscaler,omitempty"`
 	KubeDNSSidecar            string `json:"kubednsSidecar,omitempty"`
 	Kubernetes                string `json:"kubernetes,omitempty"`
 	KubernetesServicesSidecar string `json:"kubernetesServicesSidecar,omitempty"`
 	NginxProxy                string `json:"nginxProxy,omitempty"`
+	PodInfraContainer         string `json:"podInfraContainer,omitempty"`
+	WeaveCNI                  string `json:"weaveCni,omitempty"`
+	WeaveNode                 string `json:"weaveNode,omitempty"`
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/11231
https://github.com/rancher/rancher/issues/11232

This PR introduces 2 settings:

* `k8s-version`, default is v1.8.5-rancher4"
* `k8s-version-to-images`, default is json map of k8s version to system images

Cluster provisioner would read `k8s-version-to-images` based on cluster.version (default to `k8s-version` if not passed), and set `cluster.Spec.RancherKubernetesConfig.SystemImages` before passing cluster spec to RKE. If privateRegistry is specified, it will be prepended to every system image.

WIP as do not merge till a) we move all rke system images to rancher repo on dockerhub and b) until https://github.com/rancher/types/pull/175 is merged

@deniseschannon 