### PR TITLE
Cluster config: validate as top level field

### DIFF
--- a/pkg/api/management/api/cluster/validator.go
+++ b/pkg/api/management/api/cluster/validator.go
@@ -8,20 +8,9 @@ import (
 	"github.com/rancher/norman/types/convert"
 )
 
-const (
-	specField = "spec"
-)
-
 func Validator(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
-	spec, ok := data[specField]
-	if !ok {
-		return nil
-	}
-
-	specData, _ := convert.EncodeToMap(spec)
-
 	found := false
-	for k, v := range specData {
+	for k, v := range data {
 		if strings.HasSuffix(k, "Config") && !convert.IsEmpty(v) {
 			found = true
 			break


### PR DESCRIPTION
As cluster.spec is not exposed in norman api; driver configs are top level fields.