### PR TITLE
deploy alertmanager on demand

### DIFF
--- a/pkg/controllers/user/alert/configsyncer/configsyncer.go
+++ b/pkg/controllers/user/alert/configsyncer/configsyncer.go
@@ -54,6 +54,11 @@ func (d *ConfigSyncer) NotifierSync(key string, alert *v3.Notifier) error {
 }
 
 func (d *ConfigSyncer) sync() error {
+
+	if d.alertManager.IsDeploy == false {
+		return nil
+	}
+
 	notifiers, err := d.notifierLister.List("", labels.NewSelector())
 	if err != nil {
 		return errors.Wrapf(err, "List notifiers")

--- a/pkg/controllers/user/alert/manager/manager.go
+++ b/pkg/controllers/user/alert/manager/manager.go
@@ -84,6 +84,7 @@ type Manager struct {
 	nodeLister v1.NodeLister
 	svcLister  v1.ServiceLister
 	podLister  v1.PodLister
+	IsDeploy   bool
 }
 
 func NewManager(cluster *config.UserContext) *Manager {
@@ -91,6 +92,7 @@ func NewManager(cluster *config.UserContext) *Manager {
 		nodeLister: cluster.Core.Nodes("").Controller().Lister(),
 		svcLister:  cluster.Core.Services("").Controller().Lister(),
 		podLister:  cluster.Core.Pods("").Controller().Lister(),
+		IsDeploy:   false,
 	}
 }
 

--- a/pkg/controllers/user/alert/statesyncer/statesyncer.go
+++ b/pkg/controllers/user/alert/statesyncer/statesyncer.go
@@ -25,10 +25,7 @@ func StartStateSyncer(ctx context.Context, cluster *config.UserContext, manager 
 
 func (s *StateSyncer) watch(ctx context.Context, interval time.Duration) {
 	for range ticker.Context(ctx, interval) {
-		err := s.syncState()
-		if err != nil {
-			logrus.Infof("Failed to sync alert state", err)
-		}
+		s.syncState()
 	}
 }
 
@@ -40,6 +37,10 @@ type StateSyncer struct {
 }
 
 func (s *StateSyncer) syncState() error {
+
+	if s.alertManager.IsDeploy == false {
+		return nil
+	}
 
 	apiAlerts, err := s.alertManager.GetAlertList()
 	if err == nil {

--- a/pkg/controllers/user/alert/watcher/daemonset.go
+++ b/pkg/controllers/user/alert/watcher/daemonset.go
@@ -53,6 +53,10 @@ func (w *DaemonsetWatcher) watch(ctx context.Context, interval time.Duration) {
 }
 
 func (w *DaemonsetWatcher) watchRule() error {
+	if w.alertManager.IsDeploy == false {
+		return nil
+	}
+
 	projectAlerts, err := w.projectAlertLister.List("", labels.NewSelector())
 	if err != nil {
 		return err

--- a/pkg/controllers/user/alert/watcher/deployment.go
+++ b/pkg/controllers/user/alert/watcher/deployment.go
@@ -49,6 +49,9 @@ func (w *DeploymentWatcher) watch(ctx context.Context, interval time.Duration) {
 }
 
 func (w *DeploymentWatcher) watchRule() error {
+	if w.alertManager.IsDeploy == false {
+		return nil
+	}
 
 	projectAlerts, err := w.projectAlertLister.List("", labels.NewSelector())
 	if err != nil {

--- a/pkg/controllers/user/alert/watcher/event.go
+++ b/pkg/controllers/user/alert/watcher/event.go
@@ -32,6 +32,10 @@ func StartEventWatcher(cluster *config.UserContext, manager *manager.Manager) {
 }
 
 func (l *EventWatcher) Sync(key string, obj *v3.ClusterEvent) error {
+	if l.alertManager.IsDeploy == false {
+		return nil
+	}
+
 	clusterAlerts, err := l.clusterAlertLister.List("", labels.NewSelector())
 	if err != nil {
 		return err

--- a/pkg/controllers/user/alert/watcher/node.go
+++ b/pkg/controllers/user/alert/watcher/node.go
@@ -48,6 +48,9 @@ func (w *NodeWatcher) watch(ctx context.Context, interval time.Duration) {
 }
 
 func (w *NodeWatcher) watchRule() error {
+	if w.alertManager.IsDeploy == false {
+		return nil
+	}
 
 	clusterAlerts, err := w.clusterAlertLister.List("", labels.NewSelector())
 	if err != nil {

--- a/pkg/controllers/user/alert/watcher/pod.go
+++ b/pkg/controllers/user/alert/watcher/pod.go
@@ -78,6 +78,9 @@ func (l *ProjectAlertLifecycle) Remove(obj *v3.ProjectAlert) (*v3.ProjectAlert, 
 }
 
 func (w *PodWatcher) watchRule() error {
+	if w.alertManager.IsDeploy == false {
+		return nil
+	}
 	projectAlerts, err := w.projectAlertLister.List("", labels.NewSelector())
 	if err != nil {
 		return err

--- a/pkg/controllers/user/alert/watcher/statefulset.go
+++ b/pkg/controllers/user/alert/watcher/statefulset.go
@@ -48,6 +48,9 @@ func (w *StatefulsetWatcher) watch(ctx context.Context, interval time.Duration) 
 }
 
 func (w *StatefulsetWatcher) watchRule() error {
+	if w.alertManager.IsDeploy == false {
+		return nil
+	}
 	projectAlerts, err := w.projectAlertLister.List("", labels.NewSelector())
 	if err != nil {
 		return err

--- a/pkg/controllers/user/alert/watcher/syscomponent.go
+++ b/pkg/controllers/user/alert/watcher/syscomponent.go
@@ -46,6 +46,10 @@ func (w *SysComponentWatcher) watch(ctx context.Context, interval time.Duration)
 }
 
 func (w *SysComponentWatcher) watchRule() error {
+	if w.alertManager.IsDeploy == false {
+		return nil
+	}
+
 	clusterAlerts, err := w.clusterAlertLister.List("", labels.NewSelector())
 	if err != nil {
 		return err


### PR DESCRIPTION
1. only deploy alertmanager when notifier is configured and alert is using it.
2. if alertmanager is not deployed, all watchers and controllers just return.