### PR TITLE
remove init namespace and configmap data, only create on demand

### DIFF
--- a/pkg/controllers/user/logging/controller.go
+++ b/pkg/controllers/user/logging/controller.go
@@ -1,26 +1,10 @@
 package logging
 
 import (
-	rv1 "github.com/rancher/types/apis/core/v1"
 	"github.com/rancher/types/config"
-	"github.com/sirupsen/logrus"
-
-	"github.com/rancher/rancher/pkg/controllers/user/logging/utils"
 )
 
 func Register(cluster *config.UserContext) {
 	registerClusterLogging(cluster)
 	registerProjectLogging(cluster)
-
-	if err := initData(cluster.Core.Namespaces(""), cluster.Core.ConfigMaps("")); err != nil {
-		logrus.Errorf("init logging data error, %v", err)
-	}
-}
-
-func initData(ns rv1.NamespaceInterface, cm rv1.ConfigMapInterface) error {
-	if err := utils.IniteNamespace(ns); err != nil {
-		return err
-	}
-
-	return utils.InitConfigMap(cm)
 }

--- a/pkg/controllers/user/logging/utils/namespace.go
+++ b/pkg/controllers/user/logging/utils/namespace.go
@@ -9,13 +9,20 @@ import (
 )
 
 func IniteNamespace(ns rv1.NamespaceInterface) error {
-	initNamespace := v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: loggingconfig.LoggingNamespace,
-		},
-	}
-	if _, err := ns.Create(&initNamespace); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
+	if _, err := ns.Controller().Lister().Get(loggingconfig.LoggingNamespace, loggingconfig.LoggingNamespace); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+
+		initNamespace := v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: loggingconfig.LoggingNamespace,
+			},
+		}
+
+		if _, err := ns.Create(&initNamespace); err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/11426
Removing init cattle-logging and configmap, only create them on demand
@alena1108 @ibuildthecloud could you help review?