### PR TITLE
Fixing Pod Security Policy

### DIFF
--- a/pkg/controllers/user/authz/podsecuritypolicy/namespace.go
+++ b/pkg/controllers/user/authz/podsecuritypolicy/namespace.go
@@ -1,0 +1,36 @@
+package podsecuritypolicy
+
+import (
+	v12 "github.com/rancher/types/apis/core/v1"
+	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+)
+
+type namespaceManager struct {
+	serviceAccountsController v12.ServiceAccountController
+	serviceAccountLister      v12.ServiceAccountLister
+}
+
+// RegisterNamespace resyncs the current namespace's service accounts.  This is necessary because service accounts
+// determine their parent project via an annotation on the namespace, and the namespace is not always present when the
+// service account handler is triggered.  So we have this handler to retrigger the serviceaccount handler once the
+// annotation has been added.
+func RegisterNamespace(context *config.UserContext) {
+	logrus.Infof("registering podsecuritypolicy namespace handler for cluster %v", context.ClusterName)
+
+	m := &namespaceManager{
+		serviceAccountLister:      context.Core.ServiceAccounts("").Controller().Lister(),
+		serviceAccountsController: context.Core.ServiceAccounts("").Controller(),
+	}
+
+	context.Core.Namespaces("").AddHandler("NamespaceSyncHandler", m.sync)
+}
+
+func (m *namespaceManager) sync(key string, obj *v1.Namespace) error {
+	if obj == nil {
+		return nil
+	}
+
+	return resyncServiceAccounts(m.serviceAccountLister, m.serviceAccountsController, obj.Namespace)
+}

--- a/pkg/controllers/user/authz/podsecuritypolicy/project.go
+++ b/pkg/controllers/user/authz/podsecuritypolicy/project.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rancher/types/apis/core/v1"
 	"github.com/rancher/types/apis/extensions/v1beta1"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
@@ -11,27 +12,40 @@ import (
 	v1beta13 "k8s.io/api/extensions/v1beta1"
 )
 
+// RegisterProject updates the pod security policy for this project if it has been changed.  Also resync service
+// accounts so they pick up the change.  If no policy exists then exits without doing anything.
 func RegisterProject(context *config.UserContext) {
+	logrus.Infof("registering podsecuritypolicy project handler for cluster %v", context.ClusterName)
+
 	m := &projectManager{
-		policyLister:   context.Extensions.PodSecurityPolicies("").Controller().Lister(),
-		policies:       context.Extensions.PodSecurityPolicies(""),
-		templateLister: context.Management.Management.PodSecurityPolicyTemplates("").Controller().Lister(),
-		projectLister:  context.Management.Management.Projects("").Controller().Lister(),
-		clusterLister:  context.Management.Management.Clusters("").Controller().Lister(),
+		policyLister: context.Extensions.PodSecurityPolicies("").Controller().Lister(),
+		policies:     context.Extensions.PodSecurityPolicies(""),
+		templateLister: context.Management.Management.PodSecurityPolicyTemplates("").Controller().
+			Lister(),
+		projectLister:        context.Management.Management.Projects("").Controller().Lister(),
+		clusterLister:        context.Management.Management.Clusters("").Controller().Lister(),
+		serviceAccountLister: context.Core.ServiceAccounts("").Controller().Lister(),
+		serviceAccounts:      context.Core.ServiceAccounts("").Controller(),
 	}
 
 	context.Management.Management.Projects("").AddHandler("ProjectSyncHandler", m.sync)
 }
 
 type projectManager struct {
-	clusterLister  v3.ClusterLister
-	projectLister  v3.ProjectLister
-	policyLister   v1beta1.PodSecurityPolicyLister
-	policies       v1beta1.PodSecurityPolicyInterface
-	templateLister v3.PodSecurityPolicyTemplateLister
+	clusterLister        v3.ClusterLister
+	projectLister        v3.ProjectLister
+	policyLister         v1beta1.PodSecurityPolicyLister
+	policies             v1beta1.PodSecurityPolicyInterface
+	templateLister       v3.PodSecurityPolicyTemplateLister
+	serviceAccountLister v1.ServiceAccountLister
+	serviceAccounts      v1.ServiceAccountController
 }
 
 func (m *projectManager) sync(key string, obj *v3.Project) error {
+	if obj == nil {
+		return nil
+	}
+
 	split := strings.Split(key, "/")
 
 	if len(split) != 2 {
@@ -40,7 +54,7 @@ func (m *projectManager) sync(key string, obj *v3.Project) error {
 
 	clusterName, projectID := split[0], split[1]
 
-	podSecurityPolicyTemplateID, err := GetPodSecurityPolicyTemplateID(m.projectLister, m.clusterLister, projectID,
+	podSecurityPolicyTemplateID, err := getPodSecurityPolicyTemplateID(m.projectLister, m.clusterLister, projectID,
 		clusterName)
 	if err != nil {
 		return err
@@ -58,24 +72,26 @@ func (m *projectManager) sync(key string, obj *v3.Project) error {
 
 	var policy *v1beta13.PodSecurityPolicy
 
-	if !DoesPolicyExist(m.policyLister, KeyToPolicyName(key)) {
-		policy, err = FromTemplate(m.policies, m.policyLister, key, template)
-
-		return err
-	}
-
-	policy, err = m.policyLister.Get("", KeyToPolicyName(key))
-	if err != nil {
-		return fmt.Errorf("error getting pod security policy: %v", err)
-	}
-
-	if template.ResourceVersion != policy.Annotations[podSecurityVersionAnnotation] {
-		_, err := FromTemplate(m.policies, m.policyLister, key, template)
+	if !doesPolicyExist(m.policyLister, keyToPolicyName(key)) {
+		policy, err = fromTemplate(m.policies, m.policyLister, key, template)
 
 		if err != nil {
 			return err
 		}
 	}
 
-	return nil
+	policy, err = m.policyLister.Get("", keyToPolicyName(key))
+	if err != nil {
+		return fmt.Errorf("error getting pod security policy: %v", err)
+	}
+
+	if template.ResourceVersion != policy.Annotations[podSecurityVersionAnnotation] {
+		_, err := fromTemplate(m.policies, m.policyLister, key, template)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return resyncServiceAccounts(m.serviceAccountLister, m.serviceAccounts, obj.Namespace)
 }

--- a/pkg/controllers/user/controllers.go
+++ b/pkg/controllers/user/controllers.go
@@ -37,6 +37,7 @@ func Register(ctx context.Context, cluster *config.UserContext) error {
 	podsecuritypolicy.RegisterTemplate(cluster)
 	podsecuritypolicy.RegisterCluster(cluster)
 	podsecuritypolicy.RegisterProject(cluster)
+	podsecuritypolicy.RegisterNamespace(cluster)
 	networkpolicy.Register(cluster)
 
 	userOnlyContext := cluster.UserOnlyContext()


### PR DESCRIPTION
Fixing the issue where pod security was not being reliable applied for clusters created before the pod security policy template was created.

Also added guards against panics when handler `obj` is nil.

https://github.com/rancher/rancher/issues/11159