### PR TITLE
Workload endpoints fixes

### DIFF
--- a/pkg/controllers/user/workload/workload.go
+++ b/pkg/controllers/user/workload/workload.go
@@ -91,8 +91,11 @@ func (c *Controller) CreateServiceForWorkload(workload *Workload) error {
 		Kind:       workload.Kind,
 		Controller: &controller,
 	}
+	// we use workload annotation instead of service.selector (based off workload.labels)
+	// to avoid service recreate on user label change
 	serviceAnnotations := map[string]string{}
 	serviceAnnotations[WorkloadAnnotation] = workload.getKey()
+	// labels are used so it is easy to filter out the service when query from cache
 	serviceLabels := map[string]string{}
 	serviceLabels[WorkloadLabel] = workload.Namespace
 
@@ -108,6 +111,7 @@ func (c *Controller) CreateServiceForWorkload(workload *Workload) error {
 		serviceType := toCreate.Type
 		if toCreate.ClusterIP == "None" {
 			serviceType = "Headless"
+			serviceAnnotations[WorkloadAnnotation] = workload.getKey()
 		}
 		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/user/workload/workload_common.go
+++ b/pkg/controllers/user/workload/workload_common.go
@@ -118,13 +118,10 @@ func (c *CommonController) syncDeployments(key string, obj *corev1beta2.Deployme
 	if obj == nil || obj.DeletionTimestamp != nil {
 		return nil
 	}
-	var w *Workload
-	var err error
-	if key != AllWorkloads {
-		w, err = c.getWorkload(key, DeploymentType)
-		if err != nil || w == nil {
-			return err
-		}
+
+	w, err := c.getWorkload(key, DeploymentType)
+	if err != nil || w == nil {
+		return err
 	}
 
 	return c.Sync(key, w)
@@ -535,6 +532,11 @@ func getWorkloadID(objectType string, namespace string, name string) string {
 }
 
 func (c CommonController) UpdateWorkload(w *Workload) error {
+	for _, o := range w.OwnerReferences {
+		if *o.Controller {
+			return nil
+		}
+	}
 	// only annotations updates are supported
 	switch w.Kind {
 	case DeploymentType:


### PR DESCRIPTION
* do not update endpoints on workloads that are created by controllers
* determine if service mapped to the workload, using service.targetWorkloadIds (in addition to a regular selector based check)