### PR TITLE
Pipeline fix

### DIFF
--- a/pkg/api/customization/pipeline/cluster_pipeline.go
+++ b/pkg/api/customization/pipeline/cluster_pipeline.go
@@ -260,6 +260,7 @@ func (h *ClusterPipelineHandler) authAddAccount(clusterPipeline *v3.ClusterPipel
 	if err != nil {
 		return nil, err
 	}
+	account.Name = fmt.Sprintf("%s-%s-%s", clusterPipeline.Spec.ClusterName, remoteType, account.Spec.LoginName)
 	account.Spec.UserName = userID
 	account.Spec.ClusterName = clusterPipeline.Spec.ClusterName
 	account, err = h.SourceCodeCredentials.Create(account)

--- a/pkg/controllers/user/pipeline/controller/clusterpipeline/clusterpipelinesyncer.go
+++ b/pkg/controllers/user/pipeline/controller/clusterpipeline/clusterpipelinesyncer.go
@@ -92,6 +92,9 @@ func Register(cluster *config.UserContext) {
 }
 
 func (s *Syncer) Sync(key string, obj *v3.ClusterPipeline) error {
+	if obj == nil || obj.Spec.ClusterName != obj.Name {
+		return nil
+	}
 	//ensure clusterpipeline singleton in the cluster
 	utils.InitClusterPipeline(s.clusterPipelines, obj.Spec.ClusterName)
 

--- a/pkg/controllers/user/pipeline/controller/pipelineexecution/pipelineexecution.go
+++ b/pkg/controllers/user/pipeline/controller/pipelineexecution/pipelineexecution.go
@@ -108,7 +108,7 @@ func (l *Lifecycle) initLogs(obj *v3.PipelineExecution) error {
 				},
 				Spec: v3.PipelineExecutionLogSpec{
 					ProjectName:           pipeline.Spec.ProjectName,
-					PipelineExecutionName: obj.Name,
+					PipelineExecutionName: obj.Namespace + ":" + obj.Name,
 					Stage: j,
 					Step:  k,
 				},

--- a/pkg/controllers/user/pipeline/controller/pipelineexecution/statesyncer.go
+++ b/pkg/controllers/user/pipeline/controller/pipelineexecution/statesyncer.go
@@ -73,7 +73,7 @@ func (s *ExecutionStateSyncer) syncState() {
 					logrus.Errorf("Error get pipeline - %v", err)
 					continue
 				}
-				if p.Status.LastExecutionID == e.Name {
+				if p.Status.LastExecutionID == e.Namespace+":"+e.Name {
 					p.Status.LastRunState = e.Status.ExecutionState
 					if _, err := s.pipelines.Update(p); err != nil {
 						logrus.Errorf("Error update pipeline - %v", err)

--- a/pkg/controllers/user/pipeline/remote/github/github.go
+++ b/pkg/controllers/user/pipeline/remote/github/github.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strings"
 )
 
 const (
@@ -183,7 +182,6 @@ func convertAccount(gitaccount *github.User) *v3.SourceCodeCredential {
 	}
 	if gitaccount.Name != nil {
 		account.Spec.DisplayName = *gitaccount.Name
-		account.Name = strings.ToLower(*gitaccount.Login)
 	}
 	return account
 

--- a/pkg/controllers/user/pipeline/utils/utils.go
+++ b/pkg/controllers/user/pipeline/utils/utils.go
@@ -54,7 +54,7 @@ func InitExecution(p *v3.Pipeline, triggerType string) *v3.PipelineExecution {
 		},
 		Spec: v3.PipelineExecutionSpec{
 			ProjectName:  p.Spec.ProjectName,
-			PipelineName: p.Name,
+			PipelineName: p.Namespace + ":" + p.Name,
 			Run:          p.Status.NextRun,
 			TriggeredBy:  triggerType,
 			Pipeline:     *p,
@@ -129,7 +129,7 @@ func GenerateExecution(pipelines v3.PipelineInterface, executions v3.PipelineExe
 
 	//update pipeline status
 	pipeline.Status.NextRun++
-	pipeline.Status.LastExecutionID = execution.Name
+	pipeline.Status.LastExecutionID = pipeline.Namespace + ":" + execution.Name
 	pipeline.Status.LastStarted = time.Now().Format(time.RFC3339)
 
 	_, err = pipelines.Update(pipeline)


### PR DESCRIPTION
1. Change sourcecodecredential name to avoid conflicts between clusters, fix https://github.com/rancher/rancher/issues/11669
2. Fix clusterpipeline panic on cluster deletion, partially fix https://github.com/rancher/rancher/issues/11648
3. Fix reference id with namespace so that pipeline/execution links can list correctly