### PR TITLE
Fix method signature for the non-embedded verison

### DIFF
--- a/k8s/embedded_none.go
+++ b/k8s/embedded_none.go
@@ -9,6 +9,6 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func getEmbedded(ctx context.Context) (context.Context, *rest.Config, error) {
-	return ctx, nil, fmt.Errorf("embedded support is not compiled in, rebuild with -tags k8s")
+func getEmbedded(ctx context.Context) (bool, context.Context, *rest.Config, error) {
+	return false, ctx, nil, fmt.Errorf("embedded support is not compiled in, rebuild with -tags k8s")
 }


### PR DESCRIPTION
building without the k8s build tag is resulting in this error:
```
rancher)rancher$ go build
# github.com/rancher/rancher/k8s
k8s/config.go:21:3: not enough arguments to return
	have (context.Context, *rest.Config, error)
	want (bool, context.Context, *rest.Config, error)
k8s/config.go:41:2: not enough arguments to return
	have (context.Context, *rest.Config, error)
	want (bool, context.Context, *rest.Config, error)

```