### PR TITLE
Fix get data from github is not working while building Windows agent

### DIFF
--- a/agent-windows/Dockerfile
+++ b/agent-windows/Dockerfile
@@ -1,5 +1,5 @@
 FROM microsoft/nanoserver:10.0.14393.1593
-ENV RANCHER_AGENT_WINDOWS_IMAGE rancher/agent-windows:v0.2.0-rc3
+ENV RANCHER_AGENT_WINDOWS_IMAGE rancher/agent-windows:v0.2.0-rc4
 ENV TOOLS_LIST "devcon.exe,startup.ps1,cleanup.ps1,rancher-tools.psm1,crash-loop.ps1"
 RUN mkdir "c:/program files/rancher"
 VOLUME [ "c:/program files/rancher" ]

--- a/agent-windows/build-image.ps1
+++ b/agent-windows/build-image.ps1
@@ -1,5 +1,6 @@
 $IMAGE=$(get-item env:IMAGE -ErrorAction Ignore)
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-WebRequest -Uri "https://github.com/rancher/windows-binaries/releases/download/v0.0.1/devcon.exe" -OutFile "tools/devcon.exe"
 $byteArray=(Invoke-WebRequest -Uri "https://github.com/rancher/windows-binaries/releases/download/v0.0.1/MD5SUM").Content
 $tarMD5=[System.Text.Encoding]::ASCII.GetString($byteArray).ToUpper()


### PR DESCRIPTION
Because github update tls protocal from 1.0 to 1.2, we need to set the protocal Tls1.2.