### PR TITLE
Update public endpoints for rancher workloads only

### DIFF
--- a/pkg/controllers/user/endpoints/workload_endpoints.go
+++ b/pkg/controllers/user/endpoints/workload_endpoints.go
@@ -36,6 +36,14 @@ func (c *WorkloadEndpointsController) UpdateEndpoints(key string, obj *workloadu
 		}
 	}
 
+	if obj.Annotations == nil {
+		return nil
+	}
+
+	if _, ok := obj.Annotations[workloadutil.CreatorIDAnnotation]; !ok {
+		return nil
+	}
+
 	var workloads []*workloadutil.Workload
 	var services []*corev1.Service
 	var err error

--- a/pkg/controllers/user/workload/workload.go
+++ b/pkg/controllers/user/workload/workload.go
@@ -21,10 +21,6 @@ import (
 // a) when rancher ports annotation is present, create service based on annotation ports
 // b) when annotation is missing, create a headless service
 
-const (
-	creatorIDAnnotation = "field.cattle.io/creatorId"
-)
-
 type Controller struct {
 	workloadController CommonController
 	serviceLister      v1.ServiceLister
@@ -54,7 +50,11 @@ func (c *Controller) CreateService(key string, w *Workload) error {
 		}
 	}
 
-	if _, ok := w.Annotations[creatorIDAnnotation]; !ok {
+	if w.Annotations == nil {
+		return nil
+	}
+
+	if _, ok := w.Annotations[CreatorIDAnnotation]; !ok {
 		return nil
 	}
 

--- a/pkg/controllers/user/workload/workload_common.go
+++ b/pkg/controllers/user/workload/workload_common.go
@@ -40,6 +40,7 @@ const (
 	JobType                   = "job"
 	CronJobType               = "cronJob"
 	WorkloadAnnotatioNoop     = "targetWorkloadIdNoop"
+	CreatorIDAnnotation       = "field.cattle.io/creatorId"
 )
 
 var WorkloadKinds = map[string]bool{


### PR DESCRIPTION
@ibuildthecloud on the fence with this PR - should we update workloads for rancher workloads only, or do it for workloads started natively too