### PR TITLE
Fixing race conditions in PSP

### DIFF
--- a/pkg/controllers/user/authz/podsecuritypolicy/cluster.go
+++ b/pkg/controllers/user/authz/podsecuritypolicy/cluster.go
@@ -55,5 +55,5 @@ func (m *clusterManager) sync(key string, obj *v3.Cluster) error {
 		return err
 	}
 
-	return resyncServiceAccounts(m.serviceAccountLister, m.serviceAccountsController, obj.Namespace)
+	return resyncServiceAccounts(m.serviceAccountLister, m.serviceAccountsController, "")
 }

--- a/pkg/controllers/user/authz/podsecuritypolicy/namespace.go
+++ b/pkg/controllers/user/authz/podsecuritypolicy/namespace.go
@@ -32,5 +32,5 @@ func (m *namespaceManager) sync(key string, obj *v1.Namespace) error {
 		return nil
 	}
 
-	return resyncServiceAccounts(m.serviceAccountLister, m.serviceAccountsController, obj.Namespace)
+	return resyncServiceAccounts(m.serviceAccountLister, m.serviceAccountsController, obj.Name)
 }

--- a/pkg/controllers/user/authz/podsecuritypolicy/project.go
+++ b/pkg/controllers/user/authz/podsecuritypolicy/project.go
@@ -74,24 +74,22 @@ func (m *projectManager) sync(key string, obj *v3.Project) error {
 
 	if !doesPolicyExist(m.policyLister, keyToPolicyName(key)) {
 		policy, err = fromTemplate(m.policies, m.policyLister, key, template)
-
 		if err != nil {
 			return err
 		}
-	}
-
-	policy, err = m.policyLister.Get("", keyToPolicyName(key))
-	if err != nil {
-		return fmt.Errorf("error getting pod security policy: %v", err)
+	} else {
+		policy, err = m.policyLister.Get("", keyToPolicyName(key))
+		if err != nil {
+			return fmt.Errorf("error getting pod security policy: %v", err)
+		}
 	}
 
 	if template.ResourceVersion != policy.Annotations[podSecurityVersionAnnotation] {
 		_, err := fromTemplate(m.policies, m.policyLister, key, template)
-
 		if err != nil {
 			return err
 		}
 	}
 
-	return resyncServiceAccounts(m.serviceAccountLister, m.serviceAccounts, obj.Namespace)
+	return resyncServiceAccounts(m.serviceAccountLister, m.serviceAccounts, "")
 }


### PR DESCRIPTION
This fixes 3 issues:

1) When the project handler runs, it doesn't enqueue the correct service accounts to be resynced.  The namespace handlers picks up the slack most of the time, but generally not when a cluster is created with a PSPT attached, so clusterroles and rolebindings can fail to be created.
2) Changed logic in the project handler so a pod security policy did not need to be retrieved immediately after being created (sometimes causes errors if the cache(?) hasn't synced yet)
3) Optimized the namespace handler so it only syncs service accounts in its own namespace and not enqueing all of them
4) Changed confusing `cluster.Namespace` (which resolved to "" all namespaces) to "" explicitly.

Issue:
#11622