### PR TITLE
Don't unset userPrincipalName

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -13,8 +13,6 @@ const (
 	membershipBindingOwner  = "memberhsip-binding-owner"
 	rbByOwnerIndex          = "auth.management.cattle.io/rb-by-owner"
 	rbByRoleAndSubjectIndex = "auth.management.cattle.io/crb-by-role-and-subject"
-	prtbByPrincipalIndex    = "auth.management.cattle.io/prtb-by-principal"
-	crtbByPrincipalIndex    = "auth.management.cattle.io/crtb-by-principal"
 )
 
 var clusterManagmentPlaneResources = []string{"clusterroletemplatebindings", "nodes", "nodepools", "clusterevents", "projects", "clusterregistrationtokens"}
@@ -52,13 +50,12 @@ func (c *crtbLifecycle) reconcileSubject(binding *v3.ClusterRoleTemplateBinding)
 		return binding, nil
 	}
 
-	if binding.UserPrincipalName != "" {
+	if binding.UserPrincipalName != "" && binding.UserName == "" {
 		user, err := c.mgr.userMGR.EnsureUser(binding.UserPrincipalName, "")
 		if err != nil {
 			return binding, err
 		}
 
-		binding.UserPrincipalName = ""
 		binding.UserName = user.Name
 		return binding, nil
 	}

--- a/pkg/controllers/management/auth/indexes.go
+++ b/pkg/controllers/management/auth/indexes.go
@@ -1,43 +1,8 @@
 package auth
 
 import (
-	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"k8s.io/api/rbac/v1"
 )
-
-func crtbByPrincipal(obj interface{}) ([]string, error) {
-	crtb, ok := obj.(*v3.ClusterRoleTemplateBinding)
-	if !ok {
-		return []string{}, nil
-	}
-
-	var principals []string
-	if crtb.UserPrincipalName != "" {
-		principals = append(principals, crtb.UserPrincipalName)
-	}
-	if crtb.GroupPrincipalName != "" {
-		principals = append(principals, crtb.GroupPrincipalName)
-	}
-
-	return principals, nil
-}
-
-func prtbByPrincipal(obj interface{}) ([]string, error) {
-	prtb, ok := obj.(*v3.ProjectRoleTemplateBinding)
-	if !ok {
-		return []string{}, nil
-	}
-
-	var principals []string
-	if prtb.UserPrincipalName != "" {
-		principals = append(principals, prtb.UserPrincipalName)
-	}
-	if prtb.GroupPrincipalName != "" {
-		principals = append(principals, prtb.GroupPrincipalName)
-	}
-
-	return principals, nil
-}
 
 func rbByOwner(obj interface{}) ([]string, error) {
 	rb, ok := obj.(*v1.RoleBinding)

--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -34,31 +34,17 @@ func newRTBLifecycles(management *config.ManagementContext) (*prtbLifecycle, *cr
 	}
 	rbInformer.AddIndexers(rbIndexers)
 
-	prtbInformer := management.Management.ProjectRoleTemplateBindings("").Controller().Informer()
-	prtbIndexers := map[string]cache.IndexFunc{
-		prtbByPrincipalIndex: prtbByPrincipal,
-	}
-	prtbInformer.AddIndexers(prtbIndexers)
-
-	crtbInformer := management.Management.ClusterRoleTemplateBindings("").Controller().Informer()
-	crtbIndexers := map[string]cache.IndexFunc{
-		crtbByPrincipalIndex: crtbByPrincipal,
-	}
-	crtbInformer.AddIndexers(crtbIndexers)
-
 	mgr := &manager{
-		mgmt:        management,
-		crbLister:   management.RBAC.ClusterRoleBindings("").Controller().Lister(),
-		crLister:    management.RBAC.ClusterRoles("").Controller().Lister(),
-		rLister:     management.RBAC.Roles("").Controller().Lister(),
-		rbLister:    management.RBAC.RoleBindings("").Controller().Lister(),
-		rtLister:    management.Management.RoleTemplates("").Controller().Lister(),
-		nsLister:    management.Core.Namespaces("").Controller().Lister(),
-		rbIndexer:   rbInformer.GetIndexer(),
-		crbIndexer:  crbInformer.GetIndexer(),
-		prtbIndexer: prtbInformer.GetIndexer(),
-		crtbIndexer: crtbInformer.GetIndexer(),
-		userMGR:     management.UserManager,
+		mgmt:       management,
+		crbLister:  management.RBAC.ClusterRoleBindings("").Controller().Lister(),
+		crLister:   management.RBAC.ClusterRoles("").Controller().Lister(),
+		rLister:    management.RBAC.Roles("").Controller().Lister(),
+		rbLister:   management.RBAC.RoleBindings("").Controller().Lister(),
+		rtLister:   management.Management.RoleTemplates("").Controller().Lister(),
+		nsLister:   management.Core.Namespaces("").Controller().Lister(),
+		rbIndexer:  rbInformer.GetIndexer(),
+		crbIndexer: crbInformer.GetIndexer(),
+		userMGR:    management.UserManager,
 	}
 	prtb := &prtbLifecycle{
 		mgr:           mgr,
@@ -73,18 +59,16 @@ func newRTBLifecycles(management *config.ManagementContext) (*prtbLifecycle, *cr
 }
 
 type manager struct {
-	crLister    typesrbacv1.ClusterRoleLister
-	rLister     typesrbacv1.RoleLister
-	rbLister    typesrbacv1.RoleBindingLister
-	crbLister   typesrbacv1.ClusterRoleBindingLister
-	rtLister    v3.RoleTemplateLister
-	nsLister    v13.NamespaceLister
-	rbIndexer   cache.Indexer
-	crbIndexer  cache.Indexer
-	prtbIndexer cache.Indexer
-	crtbIndexer cache.Indexer
-	mgmt        *config.ManagementContext
-	userMGR     user.Manager
+	crLister   typesrbacv1.ClusterRoleLister
+	rLister    typesrbacv1.RoleLister
+	rbLister   typesrbacv1.RoleBindingLister
+	crbLister  typesrbacv1.ClusterRoleBindingLister
+	rtLister   v3.RoleTemplateLister
+	nsLister   v13.NamespaceLister
+	rbIndexer  cache.Indexer
+	crbIndexer cache.Indexer
+	mgmt       *config.ManagementContext
+	userMGR    user.Manager
 }
 
 // When a CRTB is created that gives a subject some permissions in a project or cluster, we need to create a "membership" binding

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -57,13 +57,12 @@ func (p *prtbLifecycle) reconcileSubject(binding *v3.ProjectRoleTemplateBinding)
 		return binding, nil
 	}
 
-	if binding.UserPrincipalName != "" {
+	if binding.UserPrincipalName != "" && binding.UserName == "" {
 		user, err := p.mgr.userMGR.EnsureUser(binding.UserPrincipalName, "")
 		if err != nil {
 			return binding, err
 		}
 
-		binding.UserPrincipalName = ""
 		binding.UserName = user.Name
 		return binding, nil
 	}


### PR DESCRIPTION
When a PRTB/CRTB is created with userPrincipalId set, we translate
that to a userId on the backend. Previously, we were unsetting
userPrincipalId on the backend, but if it is unset, the UI has
now way to display details about the associated user. So, we'll
keep it set so that UI can continue to load the principal.