### PR TITLE
Dont mark ns as active until roles populated

### DIFF
--- a/pkg/api/store/namespace/store.go
+++ b/pkg/api/store/namespace/store.go
@@ -3,10 +3,11 @@ package namespace
 import (
 	"github.com/rancher/norman/store/transform"
 	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/values"
 )
 
 func New(store types.Store) types.Store {
-	return &transform.Store{
+	t := &transform.Store{
 		Store: store,
 		Transformer: func(apiContext *types.APIContext, data map[string]interface{}, opt *types.QueryOptions) (map[string]interface{}, error) {
 			anns, _ := data["annotations"].(map[string]interface{})
@@ -16,4 +17,18 @@ func New(store types.Store) types.Store {
 			return data, nil
 		},
 	}
+
+	return &Store{
+		Store: t,
+	}
+}
+
+type Store struct {
+	types.Store
+}
+
+func (p *Store) Create(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}) (map[string]interface{}, error) {
+	values.PutValue(data, "{\"conditions\": [{\"type\": \"InitialRolesPopulated\", \"status\": \"False\", \"message\": \"Populating initial roles\"}]}",
+		"annotations", "cattle.io/status")
+	return p.Store.Create(apiContext, schema, data)
 }


### PR DESCRIPTION
This change adds a status condition to namespace that indicates
its initial roles have been populated from rancher.

Namespaces do not natively support adding conditions. This change
puts a status type object into an annotation so that we can control
the rancher state.

Addresses https://github.com/rancher/rancher/issues/11350