### PR TITLE
Make RBAC resource type comparison case-insensitive

### DIFF
--- a/pkg/rbac/permission_index.go
+++ b/pkg/rbac/permission_index.go
@@ -1,6 +1,8 @@
 package rbac
 
 import (
+	"strings"
+
 	"github.com/rancher/norman/types/slice"
 	"github.com/rancher/types/apis/rbac.authorization.k8s.io/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -193,7 +195,7 @@ func matches(parts []string, val string) bool {
 		if value == "*" {
 			return true
 		}
-		if value == val {
+		if strings.EqualFold(value, val) {
 			return true
 		}
 	}


### PR DESCRIPTION
So, for example, an RBAC rule for statefulsets is properly recognized
as authorizing statefulSets.

Addresses https://github.com/rancher/rancher/issues/11930