### PR TITLE
Fix PSP not working in non-default namespaces/projects

### DIFF
--- a/pkg/controllers/user/authz/podsecuritypolicy/serviceaccount.go
+++ b/pkg/controllers/user/authz/podsecuritypolicy/serviceaccount.go
@@ -182,7 +182,10 @@ func createBindingIfNotExists(bindings2 v12.RoleBindingInterface, bindingLister 
 	bindingExists := false
 
 	for _, binding := range bindings {
-		if binding.Annotations[podSecurityTemplateParentAnnotation] == policyName {
+		if binding.Annotations[podSecurityTemplateParentAnnotation] == policyName &&
+			len(binding.Subjects) > 0 && // guard against panic
+			binding.Subjects[0].Name == serviceAccount.Name &&
+			binding.Subjects[0].Namespace == serviceAccount.Namespace {
 			bindingExists = true
 		}
 	}


### PR DESCRIPTION
When a new namespace is created and assigned to a project and that
project has a pod security policy, the pod security policy is not binding
correctly.  This is because when the service account handler looks to see
if a binding exists for a given service account in a given namespace, it
only looks for the first binding with a matching parent template
annotation and then exits.

This fixes the issue by making it compare the
name and namespace of the subject in the clusterrole and then creating
the role binding it if does not exist.

Issue:
https://github.com/rancher/rancher/issues/11887
https://github.com/rancher/rancher/issues/11971
https://github.com/rancher/rancher/issues/11973