### PR TITLE
Set display name annotation on PRTB/CRTB

### DIFF
--- a/pkg/api/customization/authn/rtb_store.go
+++ b/pkg/api/customization/authn/rtb_store.go
@@ -3,15 +3,21 @@ package authn
 import (
 	"strings"
 
+	"context"
+
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/store/transform"
 	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/values"
+	"github.com/rancher/rancher/pkg/auth/providers"
+	"github.com/rancher/rancher/pkg/auth/requests"
 	"github.com/rancher/types/client/management/v3"
 	"github.com/rancher/types/config"
 	"github.com/sirupsen/logrus"
 )
 
-func SetRTBStore(schema *types.Schema, mgmt *config.ScaledContext) {
+func SetRTBStore(ctx context.Context, schema *types.Schema, mgmt *config.ScaledContext) {
+	providers.Configure(ctx, mgmt)
 	userLister := mgmt.Management.Users("").Controller().Lister()
 
 	t := &transform.Store{
@@ -37,5 +43,33 @@ func SetRTBStore(schema *types.Schema, mgmt *config.ScaledContext) {
 		},
 	}
 
-	schema.Store = t
+	s := &Store{
+		Store: t,
+		auth:  requests.NewAuthenticator(ctx, mgmt),
+	}
+
+	schema.Store = s
+}
+
+type Store struct {
+	types.Store
+	auth requests.Authenticator
+}
+
+func (s *Store) Create(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}) (map[string]interface{}, error) {
+	if principalID, ok := data[client.ClusterRoleTemplateBindingFieldUserPrincipalId].(string); ok && principalID != "" && !strings.HasPrefix(principalID, "local://") {
+		token, err := s.auth.TokenFromRequest(apiContext.Request)
+		if err != nil {
+			return nil, err
+		}
+		princ, err := providers.GetPrincipal(principalID, *token)
+		if err != nil {
+			return nil, err
+		}
+		if princ.DisplayName != "" {
+			values.PutValue(data, princ.DisplayName, "annotations", "auth.cattle.io/principal-display-name")
+		}
+	}
+
+	return s.Store.Create(apiContext, schema, data)
 }

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -110,8 +110,8 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	principals.Schema(ctx, apiContext, schemas)
 	providers.SetupAuthConfig(ctx, apiContext, schemas)
 	authn.SetUserStore(schemas.Schema(&managementschema.Version, client.UserType), apiContext)
-	authn.SetRTBStore(schemas.Schema(&managementschema.Version, client.ClusterRoleTemplateBindingType), apiContext)
-	authn.SetRTBStore(schemas.Schema(&managementschema.Version, client.ProjectRoleTemplateBindingType), apiContext)
+	authn.SetRTBStore(ctx, schemas.Schema(&managementschema.Version, client.ClusterRoleTemplateBindingType), apiContext)
+	authn.SetRTBStore(ctx, schemas.Schema(&managementschema.Version, client.ProjectRoleTemplateBindingType), apiContext)
 	nodeStore.SetupStore(schemas.Schema(&managementschema.Version, client.NodeType))
 
 	setupScopedTypes(schemas)

--- a/pkg/auth/providers/github/github_client.go
+++ b/pkg/auth/providers/github/github_client.go
@@ -74,7 +74,7 @@ func (g *GClient) getUser(githubAccessToken string, config *v3.GithubConfig) (Ac
 	url := g.getURL("USER_INFO", config)
 	resp, err := g.getFromGithub(githubAccessToken, url)
 	if err != nil {
-		logrus.Errorf("Github getGithubUser: GET url %v received error from github, err: %v", url, err)
+		// returns an error on searches with no match. ignore
 		return Account{}, err
 	}
 	defer resp.Body.Close()

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -51,7 +51,8 @@ func (c *crtbLifecycle) reconcileSubject(binding *v3.ClusterRoleTemplateBinding)
 	}
 
 	if binding.UserPrincipalName != "" && binding.UserName == "" {
-		user, err := c.mgr.userMGR.EnsureUser(binding.UserPrincipalName, "")
+		displayName := binding.Annotations["auth.cattle.io/principal-display-name"]
+		user, err := c.mgr.userMGR.EnsureUser(binding.UserPrincipalName, displayName)
 		if err != nil {
 			return binding, err
 		}

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -58,7 +58,8 @@ func (p *prtbLifecycle) reconcileSubject(binding *v3.ProjectRoleTemplateBinding)
 	}
 
 	if binding.UserPrincipalName != "" && binding.UserName == "" {
-		user, err := p.mgr.userMGR.EnsureUser(binding.UserPrincipalName, "")
+		displayName := binding.Annotations["auth.cattle.io/principal-display-name"]
+		user, err := p.mgr.userMGR.EnsureUser(binding.UserPrincipalName, displayName)
 		if err != nil {
 			return binding, err
 		}


### PR DESCRIPTION
If a PRTB/CRTB is created with the userPrincipalId set, we will
ultimately need to ensure that the user exists in rancher. This
is done in a controller, which does not have access to the principals
API. So, set the principal's display name as an annotation on the
RTB during the API request (where we do have access to the principals
API) so that it can be used to ensure the user in the controller.

addresses https://github.com/rancher/rancher/issues/11691