### PR TITLE
Keep namespace/project ownership in cache

### DIFF
--- a/pkg/api/customization/namespace/namespace.go
+++ b/pkg/api/customization/namespace/namespace.go
@@ -1,22 +1,46 @@
 package namespace
 
 import (
+	"time"
+
 	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/types/apis/cluster.cattle.io/v3/schema"
 	"github.com/rancher/types/client/cluster/v3"
+	"k8s.io/apimachinery/pkg/util/cache"
 )
 
-func ProjectMap(apiContext *types.APIContext) (map[string]string, error) {
+var (
+	namespaceOwnerMap = cache.NewLRUExpireCache(1000)
+)
+
+func updateNamespaceOwnerMap(apiContext *types.APIContext) error {
 	var namespaces []client.Namespace
 	if err := access.List(apiContext, &schema.Version, client.NamespaceType, &types.QueryOptions{}, &namespaces); err != nil {
-		return nil, err
+		return err
 	}
 
-	result := map[string]string{}
 	for _, namespace := range namespaces {
-		result[namespace.Name] = namespace.ProjectID
+		namespaceOwnerMap.Add(namespace.Name, namespace.ProjectID, time.Hour)
 	}
 
-	return result, nil
+	return nil
+}
+
+func ProjectMap(apiContext *types.APIContext, refresh bool) (map[string]string, error) {
+	if refresh {
+		err := updateNamespaceOwnerMap(apiContext)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	data := map[string]string{}
+	for _, key := range namespaceOwnerMap.Keys() {
+		if val, ok := namespaceOwnerMap.Get(key); ok {
+			data[key.(string)] = val.(string)
+		}
+	}
+
+	return data, nil
 }


### PR DESCRIPTION
so updated data can be fetched when namespace gets created from project context; and change event won't be filtered out https://github.com/rancher/rancher/issues/11957