### PR TITLE
Delete user access

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -28,8 +28,6 @@ type Config struct {
 	ListenConfig    *v3.ListenConfig
 }
 
-var defaultAdminLabel = map[string]string{"authz.management.cattle.io/bootstrapping": "admin-user"}
-
 func buildScaledContext(ctx context.Context, kubeConfig rest.Config, cfg *Config) (*config.ScaledContext, *clustermanager.Manager, error) {
 	scaledContext, err := config.NewScaledContext(kubeConfig)
 	if err != nil {

--- a/app/role_data.go
+++ b/app/role_data.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+var defaultAdminLabel = map[string]string{"authz.management.cattle.io/bootstrapping": "admin-user"}
+
 func addRoles(management *config.ManagementContext) (string, error) {
 	rb := newRoleBuilder()
 
@@ -219,11 +221,6 @@ func addRoles(management *config.ManagementContext) (string, error) {
 
 	} else {
 		admin = &admins.Items[0]
-	}
-
-	if len(admin.PrincipalIDs) == 0 {
-		admin.PrincipalIDs = []string{"local://" + admin.Name}
-		management.Management.Users("").Update(admin)
 	}
 
 	bindings, err := management.Management.GlobalRoleBindings("").List(v1.ListOptions{LabelSelector: set.String()})

--- a/pkg/controllers/management/auth/register.go
+++ b/pkg/controllers/management/auth/register.go
@@ -11,6 +11,7 @@ func RegisterEarly(ctx context.Context, management *config.ManagementContext) {
 	gr := newGlobalRoleLifecycle(management)
 	grb := newGlobalRoleBindingLifecycle(management)
 	p, c := newPandCLifecycles(management)
+	u := newUserLifecycle(management)
 
 	management.Management.ProjectRoleTemplateBindings("").AddLifecycle("mgmt-auth-prtb-controller", prtb)
 	management.Management.ClusterRoleTemplateBindings("").AddLifecycle("mgmt-auth-crtb-controller", crtb)
@@ -18,6 +19,7 @@ func RegisterEarly(ctx context.Context, management *config.ManagementContext) {
 	management.Management.GlobalRoleBindings("").AddLifecycle("mgmt-auth-grb-controller", grb)
 	management.Management.Projects("").AddHandler("mgmt-project-rbac-create", p.sync)
 	management.Management.Clusters("").AddHandler("mgmt-cluster-rbac-delete", c.sync)
+	management.Management.Users("").AddLifecycle("mgmt-auth-users-controller", u)
 }
 
 func RegisterLate(ctx context.Context, management *config.ManagementContext) {

--- a/pkg/controllers/management/auth/user.go
+++ b/pkg/controllers/management/auth/user.go
@@ -1,0 +1,250 @@
+package auth
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type userLifecycle struct {
+	prtb        v3.ProjectRoleTemplateBindingInterface
+	crtb        v3.ClusterRoleTemplateBindingInterface
+	grb         v3.GlobalRoleBindingInterface
+	users       v3.UserInterface
+	prtbLister  v3.ProjectRoleTemplateBindingLister
+	crtbLister  v3.ClusterRoleTemplateBindingLister
+	grbLister   v3.GlobalRoleBindingLister
+	prtbIndexer cache.Indexer
+	crtbIndexer cache.Indexer
+	grbIndexer  cache.Indexer
+}
+
+const crtbByUserRefKey = "auth.management.cattle.io/crtb-by-user-ref"
+const prtbByUserRefKey = "auth.management.cattle.io/prtb-by-user-ref"
+const grbByUserRefKey = "auth.management.cattle.io/grb-by-user-ref"
+
+func newUserLifecycle(management *config.ManagementContext) *userLifecycle {
+	lfc := &userLifecycle{
+		prtb:       management.Management.ProjectRoleTemplateBindings(""),
+		crtb:       management.Management.ClusterRoleTemplateBindings(""),
+		grb:        management.Management.GlobalRoleBindings(""),
+		users:      management.Management.Users(""),
+		prtbLister: management.Management.ProjectRoleTemplateBindings("").Controller().Lister(),
+		crtbLister: management.Management.ClusterRoleTemplateBindings("").Controller().Lister(),
+		grbLister:  management.Management.GlobalRoleBindings("").Controller().Lister(),
+	}
+
+	prtbInformer := management.Management.ProjectRoleTemplateBindings("").Controller().Informer()
+	prtbInformer.AddIndexers(map[string]cache.IndexFunc{
+		prtbByUserRefKey: prtbByUserRefFunc,
+	})
+
+	lfc.prtbIndexer = prtbInformer.GetIndexer()
+
+	crtbInformer := management.Management.ClusterRoleTemplateBindings("").Controller().Informer()
+	crtbInformer.AddIndexers(map[string]cache.IndexFunc{
+		crtbByUserRefKey: crtbByUserRefFunc,
+	})
+
+	lfc.crtbIndexer = crtbInformer.GetIndexer()
+
+	grbInformer := management.Management.GlobalRoleBindings("").Controller().Informer()
+	grbInformer.AddIndexers(map[string]cache.IndexFunc{
+		grbByUserRefKey: grbByUserRefFunc,
+	})
+
+	lfc.grbIndexer = grbInformer.GetIndexer()
+
+	return lfc
+}
+
+func grbByUserRefFunc(obj interface{}) ([]string, error) {
+	globalRoleBinding, ok := obj.(*v3.GlobalRoleBinding)
+	if !ok {
+		return []string{}, nil
+	}
+
+	return []string{globalRoleBinding.UserName}, nil
+}
+
+func prtbByUserRefFunc(obj interface{}) ([]string, error) {
+	projectRoleBinding, ok := obj.(*v3.ProjectRoleTemplateBinding)
+	if !ok || projectRoleBinding.UserName == "" {
+		return []string{}, nil
+	}
+
+	return []string{projectRoleBinding.UserName}, nil
+}
+
+func crtbByUserRefFunc(obj interface{}) ([]string, error) {
+	clusterRoleBinding, ok := obj.(*v3.ClusterRoleTemplateBinding)
+	if !ok || clusterRoleBinding.UserName == "" {
+		return []string{}, nil
+	}
+
+	return []string{clusterRoleBinding.UserName}, nil
+}
+
+func (l *userLifecycle) Create(user *v3.User) (*v3.User, error) {
+	var match = false
+	for _, id := range user.PrincipalIDs {
+		if strings.HasPrefix(id, "local://") {
+			match = true
+			break
+		}
+	}
+
+	if !match {
+		user.PrincipalIDs = append(user.PrincipalIDs, "local://"+user.Name)
+	}
+
+	return user, nil
+}
+
+func (l *userLifecycle) Updated(user *v3.User) (*v3.User, error) {
+	return user, nil
+}
+
+func (l *userLifecycle) Remove(user *v3.User) (*v3.User, error) {
+	clusterRoles, err := l.getCRTBByUserName(user.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	err = l.deleteAllCRTB(clusterRoles)
+	if err != nil {
+		return nil, err
+	}
+
+	projectRoles, err := l.getPRTBByUserName(user.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	err = l.deleteAllPRTB(projectRoles)
+	if err != nil {
+		return nil, err
+	}
+
+	globalRoles, err := l.getGRBByUserName(user.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	err = l.deleteAllGRB(globalRoles)
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
+}
+
+func (l *userLifecycle) getCRTBByUserName(username string) ([]*v3.ClusterRoleTemplateBinding, error) {
+	obj, err := l.crtbIndexer.ByIndex(crtbByUserRefKey, username)
+	if err != nil {
+		return nil, fmt.Errorf("error getting cluster roles: %v", err)
+	}
+
+	var crtbs []*v3.ClusterRoleTemplateBinding
+	for _, o := range obj {
+		crtb, ok := o.(*v3.ClusterRoleTemplateBinding)
+		if !ok {
+			return nil, fmt.Errorf("error converting obj to cluster role template binding: %v", o)
+		}
+
+		crtbs = append(crtbs, crtb)
+	}
+
+	return crtbs, nil
+}
+
+func (l *userLifecycle) getPRTBByUserName(username string) ([]*v3.ProjectRoleTemplateBinding, error) {
+	objs, err := l.prtbIndexer.ByIndex(prtbByUserRefKey, username)
+	if err != nil {
+		return nil, fmt.Errorf("error getting indexed project roles: %v", err)
+	}
+
+	var prtbs []*v3.ProjectRoleTemplateBinding
+	for _, obj := range objs {
+		prtb, ok := obj.(*v3.ProjectRoleTemplateBinding)
+		if !ok {
+			return nil, fmt.Errorf("could not convert obj to v3.ProjectRoleTemplateBinding")
+		}
+
+		prtbs = append(prtbs, prtb)
+	}
+
+	return prtbs, nil
+}
+
+func (l *userLifecycle) getGRBByUserName(username string) ([]*v3.GlobalRoleBinding, error) {
+	objs, err := l.grbIndexer.ByIndex(grbByUserRefKey, username)
+	if err != nil {
+		return nil, fmt.Errorf("error getting indexed global roles: %v", err)
+	}
+
+	var grbs []*v3.GlobalRoleBinding
+	for _, obj := range objs {
+		grb, ok := obj.(*v3.GlobalRoleBinding)
+		if !ok {
+			return nil, fmt.Errorf("could not convert obj to v3.GlobalRoleBinding")
+		}
+
+		grbs = append(grbs, grb)
+	}
+
+	return grbs, nil
+}
+
+func (l *userLifecycle) deleteAllCRTB(crtbs []*v3.ClusterRoleTemplateBinding) error {
+	for _, crtb := range crtbs {
+		var err error
+		if crtb.Namespace == "" {
+			err = l.crtb.Delete(crtb.Name, &metav1.DeleteOptions{})
+		} else {
+			err = l.crtb.DeleteNamespaced(crtb.Namespace, crtb.Name, &metav1.DeleteOptions{})
+		}
+		if err != nil {
+			return fmt.Errorf("error deleting cluster role: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (l *userLifecycle) deleteAllPRTB(prtbs []*v3.ProjectRoleTemplateBinding) error {
+	for _, prtb := range prtbs {
+		var err error
+		if prtb.Namespace == "" {
+			err = l.prtb.Delete(prtb.Name, &metav1.DeleteOptions{})
+		} else {
+			err = l.prtb.DeleteNamespaced(prtb.Namespace, prtb.Name, &metav1.DeleteOptions{})
+		}
+		if err != nil {
+			return fmt.Errorf("error deleting projet role: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (l *userLifecycle) deleteAllGRB(grbs []*v3.GlobalRoleBinding) error {
+	for _, grb := range grbs {
+		var err error
+		if grb.Namespace == "" {
+			err = l.grb.Delete(grb.Name, &metav1.DeleteOptions{})
+		} else {
+			err = l.grb.DeleteNamespaced(grb.Namespace, grb.Name, &metav1.DeleteOptions{})
+		}
+		if err != nil {
+			return fmt.Errorf("error deleting global role template %v: %v", grb.Name, err)
+
+		}
+	}
+
+	return nil
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -26,6 +26,7 @@ google.golang.org/grpc                        v1.9.0
 gopkg.in/check.v1                             20d25e2804050c1cd24a7eea1e7a6447dd0e74ec
 
 github.com/rancher/norman                     723fdccf807b136113105b96294d1b074c262ab0
+github.com/rancher/norman                     0ada2dfa7944a8379ac2ca944709b5cb38832f5c
 github.com/rancher/kontainer-engine           190897d8a5ce548fe978edde7c4dd62e965d5d5b
 github.com/rancher/types                      63d8960ab3b2fbebdb3932f358cf7cc5525985b6
 github.com/rancher/rke                        7b2e20941209155d694b70f16fcacd1f11ad9b19

--- a/vendor/github.com/rancher/norman/httperror/error.go
+++ b/vendor/github.com/rancher/norman/httperror/error.go
@@ -103,3 +103,11 @@ func IsAPIError(err error) bool {
 	_, ok := err.(*APIError)
 	return ok
 }
+
+func IsConflict(err error) bool {
+	if apiError, ok := err.(*APIError); ok {
+		return apiError.code.Status == 409
+	}
+
+	return false
+}


### PR DESCRIPTION
This PR adds a user lifecycle to properly clean up cluster, global, and
project role bindings after a user is deleted from rancher.  This is to
prevent a user from still having access to a k8s cluster after
they have been deleted.

It also adds retry logic to user_store so that the system will retry
creating a user if it fails due to the user lifecycle updating the user
with annotations after it is created.

Also fixed a bug where the admin user would fail to be created on
cluster startup.

Issue:
#11378

Depends on:
https://github.com/rancher/norman/pull/113