### PR TITLE
Added more resilient comparison of CATTLE_URL and Host Registration URL

### DIFF
--- a/agent/run.sh
+++ b/agent/run.sh
@@ -369,8 +369,14 @@ setup_env()
 {
     if [ "$1" != "upgrade" ]; then
         local env="$(./resolve_url.py $CATTLE_URL)"
-        if ! load "$env" || [ "$(print_url $CATTLE_URL)" != "$(print_url $env)" ]; then
+        info Configured Host Registration URL info: CATTLE_URL=$(print_url $CATTLE_URL) ENV_URL=$(print_url $env)
+        if ! load "$env"; then
             error Failed to load registration env from CATTLE_URL=$(print_url $CATTLE_URL) ENV_URL=$(print_url $env)
+            exit 1
+        fi
+
+        if echo "$(print_url $env)" | grep -q "/v1$" && [ "$(print_url $CATTLE_URL)" != "$(print_url $env)" ]; then
+            error Configured Host Registration URL does not match given URL: CATTLE_URL=$(print_url $CATTLE_URL) ENV_URL=$(print_url $env)
             error Please ensure the proper value for the Host Registration URL is set
             exit 1
         fi


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/12028

Discovered that if the host registration URL is not set, the current comparison will fail and this is breaking.

When Host Registration URL is set, the value ends with `/v1`. Added the check if the URL ends with `/v1`, and if true, do the comparison. Otherwise, ignore (as current behavior).

If this is not solid enough, I suggest we revert the previous change.