### PR TITLE
use waiting state instead of ready

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -140,11 +140,11 @@ func (p *Provisioner) Create(cluster *v3.Cluster) (*v3.Cluster, error) {
 	v3.ClusterConditionPending.CreateUnknownIfNotExists(cluster)
 	v3.ClusterConditionProvisioned.CreateUnknownIfNotExists(cluster)
 
-	if v3.ClusterConditionReady.GetStatus(cluster) == "" {
-		v3.ClusterConditionReady.False(cluster)
+	if v3.ClusterConditionWaiting.GetStatus(cluster) == "" {
+		v3.ClusterConditionWaiting.Unknown(cluster)
 	}
-	if v3.ClusterConditionReady.GetMessage(cluster) == "" {
-		v3.ClusterConditionReady.Message(cluster, "Waiting for API to be available")
+	if v3.ClusterConditionWaiting.GetMessage(cluster) == "" {
+		v3.ClusterConditionWaiting.Message(cluster, "Waiting for API to be available")
 	}
 
 	cluster, err = p.pending(cluster)

--- a/pkg/controllers/user/healthsyncer/healthsyncer.go
+++ b/pkg/controllers/user/healthsyncer/healthsyncer.go
@@ -44,7 +44,7 @@ func (h *HealthSyncer) syncHealth(ctx context.Context, syncHealth time.Duration)
 	for range ticker.Context(ctx, syncHealth) {
 		err := h.updateClusterHealth()
 		if err != nil && !apierrors.IsConflict(err) {
-			logrus.Info(err)
+			logrus.Error(err)
 		}
 	}
 }
@@ -75,6 +75,11 @@ func (h *HealthSyncer) updateClusterHealth() error {
 		}
 		return cluster, nil
 	})
+	if err != nil {
+		return err
+	}
+	v3.ClusterConditionWaiting.True(newObj)
+	v3.ClusterConditionWaiting.Message(newObj, "")
 
 	_, err = h.clusters.Update(newObj.(*v3.Cluster))
 	if err != nil {

--- a/vendor.conf
+++ b/vendor.conf
@@ -27,7 +27,7 @@ gopkg.in/check.v1                             20d25e2804050c1cd24a7eea1e7a6447dd
 
 github.com/rancher/norman                     bcb8076caaa81b42baa7b496204bb6ef998fc088
 github.com/rancher/kontainer-engine           3e5cd74cc7035aaad0b9b7378625692da64782a5
-github.com/rancher/types                      6a5483fe8acdbf5ec09027ff8d4318c7cbd1e298
+github.com/rancher/types                      5097ab8e1e9e6f606073ae476aa2357e9bec4958
 github.com/rancher/rke                        2f6ead9cf2b5e198f9916b836142dccc9b766f09
 
 gopkg.in/ldap.v2     v2.5.0

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -16,6 +16,7 @@ const (
 	// ClusterConditionProvisioned Cluster is provisioned
 	ClusterConditionProvisioned condition.Cond = "Provisioned"
 	ClusterConditionUpdated     condition.Cond = "Updated"
+	ClusterConditionWaiting     condition.Cond = "Waiting"
 	ClusterConditionRemoved     condition.Cond = "Removed"
 	// ClusterConditionNoDiskPressure true when all cluster nodes have sufficient disk
 	ClusterConditionNoDiskPressure condition.Cond = "NoDiskPressure"

--- a/vendor/github.com/rancher/types/status/status.go
+++ b/vendor/github.com/rancher/types/status/status.go
@@ -51,6 +51,7 @@ var transitioningMap = map[string]string{
 	"Saved":                       "saving",
 	"Updated":                     "updating",
 	"Updating":                    "updating",
+	"Waiting":                     "waiting",
 	"InitialRolesPopulated":       "activating",
 }
 


### PR DESCRIPTION
make world better by not showing error msg when provisioning. At the
time when creating a cluster, set its initial condition to Waiting and
wait for the first healthcheck check to pass to set it to true so that
once the cluster finish provisioning it will show a transition msg
instead error.