### PR TITLE
Fix: https:/ to https:// rewriting for httpproxy

### DIFF
--- a/pkg/httpproxy/proxy.go
+++ b/pkg/httpproxy/proxy.go
@@ -68,14 +68,14 @@ func (p *proxy) proxy(req *http.Request) error {
 	index := strings.Index(path, p.prefix)
 	destPath := path[index+len(p.prefix):]
 
-	if strings.HasPrefix(destPath, "http") {
-		dest := httpStart.ReplaceAll([]byte(destPath), []byte("http://$1"))
-		dest = httpStart.ReplaceAll(dest, []byte("https://$1"))
+	if strings.HasPrefix(destPath, "https") {
+		dest := httpsStart.ReplaceAll([]byte(destPath), []byte("http://$1"))
+		dest = httpsStart.ReplaceAll(dest, []byte("https://$1"))
 		destPath = string(dest)
-	}
-
-	if !strings.HasPrefix(destPath, "http") {
-		destPath = "https://" + destPath
+	} else {
+		dest := httpStart.ReplaceAll([]byte(destPath), []byte("http://$1"))
+		dest = httpStart.ReplaceAll(dest, []byte("http://$1"))
+		destPath = string(dest)
 	}
 
 	destURL, err := url.Parse(destPath)

--- a/pkg/httpproxy/proxy.go
+++ b/pkg/httpproxy/proxy.go
@@ -68,14 +68,10 @@ func (p *proxy) proxy(req *http.Request) error {
 	index := strings.Index(path, p.prefix)
 	destPath := path[index+len(p.prefix):]
 
-	if strings.HasPrefix(destPath, "https") {
-		dest := httpsStart.ReplaceAll([]byte(destPath), []byte("http://$1"))
-		dest = httpsStart.ReplaceAll(dest, []byte("https://$1"))
-		destPath = string(dest)
-	} else {
-		dest := httpStart.ReplaceAll([]byte(destPath), []byte("http://$1"))
-		dest = httpStart.ReplaceAll(dest, []byte("http://$1"))
-		destPath = string(dest)
+	if httpsStart.Match([]byte(destPath)) {
+		destPath = httpsStart.ReplaceAllString(destPath, "https://$1")
+	} else if httpStart.Match([]byte(destPath)) {
+		destPath = httpStart.ReplaceAllString(destPath, "http://$1")
 	}
 
 	destURL, err := url.Parse(destPath)

--- a/pkg/httpproxy/proxy.go
+++ b/pkg/httpproxy/proxy.go
@@ -68,9 +68,9 @@ func (p *proxy) proxy(req *http.Request) error {
 	index := strings.Index(path, p.prefix)
 	destPath := path[index+len(p.prefix):]
 
-	if httpsStart.Match([]byte(destPath)) {
+	if httpsStart.MatchString(destPath) {
 		destPath = httpsStart.ReplaceAllString(destPath, "https://$1")
-	} else if httpStart.Match([]byte(destPath)) {
+	} else if httpStart.MatchString(destPath) {
 		destPath = httpStart.ReplaceAllString(destPath, "http://$1")
 	} else {
 		destPath = "https://" + destPath

--- a/pkg/httpproxy/proxy.go
+++ b/pkg/httpproxy/proxy.go
@@ -72,6 +72,8 @@ func (p *proxy) proxy(req *http.Request) error {
 		destPath = httpsStart.ReplaceAllString(destPath, "https://$1")
 	} else if httpStart.Match([]byte(destPath)) {
 		destPath = httpStart.ReplaceAllString(destPath, "http://$1")
+	} else {
+		destPath = "https://" + destPath
 	}
 
 	destURL, err := url.Parse(destPath)


### PR DESCRIPTION
Fixes the rewriting e.g.
from: `https:/storage.googleapis.com/hcloud-rancher-v2-ui-driver/component.js`
to: `https://storage.googleapis.com/hcloud-rancher-v2-ui-driver/component.js`

So that the `https:/` will be correctly rewritten to `https://`.

I tested three test cases as the ui driver URL:
- http://[...]
- https://[...]
- hostname.tld/component.js

all are working fine. :smile: 

Currently `http` links will work, but `https` links won't work as URL. They will get an 502 internal server error with "invalid host" message. That's because he could not parse the URL correctly with https.