### PR TITLE
set pipeline RBAC rules

### DIFF
--- a/app/role_data.go
+++ b/app/role_data.go
@@ -40,7 +40,9 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("management.cattle.io").resources("templates", "templateversions").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("get", "list", "watch").
-		addRule().apiGroups("management.cattle.io").resources("nodetemplates").verbs("*")
+		addRule().apiGroups("management.cattle.io").resources("nodetemplates").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("sourcecodecredentials").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("sourcecoderepositories").verbs("*")
 
 	rb.addRole("User Base", "user-base").addRule().apiGroups("management.cattle.io").resources("principals", "roletemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("users").verbs("get", "list", "watch").
@@ -76,7 +78,8 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("*").resources("nodes").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("persistentvolumes").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("storageclasses").verbs("get", "list", "watch").
-		addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch")
+		addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("clusterpipelines").verbs("get", "list", "watch")
 
 	rb.addRoleTemplate("Create Projects", "projects-create", "cluster", true, false, false).
 		addRule().apiGroups("management.cattle.io").resources("projects").verbs("create")
@@ -130,6 +133,9 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("*").resources("storageclasses").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("persistentvolumeclaims").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("pipelines").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("pipelineexecutions").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("pipelineexecutionlogs").verbs("*").
 		setRoleTemplateNames("edit")
 
 	rb.addRoleTemplate("Read-only", "read-only", "project", true, false, false).
@@ -139,6 +145,9 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("*").resources("storageclasses").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("persistentvolumeclaims").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("pipelines").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("pipelineexecutions").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("pipelineexecutionlogs").verbs("get", "list", "watch").
 		setRoleTemplateNames("view")
 
 	rb.addRoleTemplate("Create Namespaces", "create-ns", "project", true, false, false).

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -317,6 +317,8 @@ func Pipeline(schemas *types.Schemas, management *config.ScaledContext) {
 		SourceCodeCredentialLister: management.Management.SourceCodeCredentials("").Controller().Lister(),
 		SourceCodeRepositories:     management.Management.SourceCodeRepositories(""),
 		SourceCodeRepositoryLister: management.Management.SourceCodeRepositories("").Controller().Lister(),
+		Secrets:                    management.Core.Secrets(""),
+		SecretLister:               management.Core.Secrets("").Controller().Lister(),
 		AuthConfigs:                management.Management.AuthConfigs(""),
 	}
 	schema := schemas.Schema(&managementschema.Version, client.ClusterPipelineType)

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -18,7 +18,7 @@ const (
 	rbByRoleAndSubjectIndex   = "auth.management.cattle.io/crb-by-role-and-subject"
 )
 
-var clusterManagmentPlaneResources = []string{"clusterroletemplatebindings", "nodes", "nodepools", "clusterevents", "projects", "clusterregistrationtokens"}
+var clusterManagmentPlaneResources = []string{"clusterroletemplatebindings", "nodes", "nodepools", "clusterevents", "projects", "clusterregistrationtokens", "clusterpipelines"}
 
 type crtbLifecycle struct {
 	mgr           *manager

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -12,7 +12,7 @@ const (
 	projectResource = "projects"
 )
 
-var projectManagmentPlanResources = []string{"projectroletemplatebindings", "apps", "secrets"}
+var projectManagmentPlanResources = []string{"projectroletemplatebindings", "apps", "secrets", "pipelines", "pipelineexecutions", "pipelineexecutionlogs"}
 
 type prtbLifecycle struct {
 	mgr           *manager


### PR DESCRIPTION
Add rbac rules for pipeline resources. As `clusterpipelines` are visible to all cluster members now, store the clientSecret of oauthapp in secrets instead to avoid leaking the credentials. https://github.com/rancher/rancher/issues/12180