### PR TITLE
Nil check in cluster manager

### DIFF
--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -241,8 +241,12 @@ func (m *Manager) UserContext(clusterName string) (*config.UserContext, error) {
 	}
 
 	record, err := m.start(context.Background(), cluster)
-	if err != nil {
-		return nil, httperror.NewAPIError(httperror.ClusterUnavailable, err.Error())
+	if err != nil || record == nil {
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		return nil, httperror.NewAPIError(httperror.ClusterUnavailable, msg)
 	}
 
 	return record.cluster, nil


### PR DESCRIPTION
start() method returns nil object when either underlying controller is nil, or error != nil (https://github.com/rancher/rancher/blob/master/pkg/clustermanager/manager.go#L88). Have to handle the first condition in the caller method.

https://github.com/rancher/rancher/issues/12354