### PR TITLE
Fixing nil svc act panic

### DIFF
--- a/pkg/controllers/user/authz/podsecuritypolicy/serviceaccount.go
+++ b/pkg/controllers/user/authz/podsecuritypolicy/serviceaccount.go
@@ -107,6 +107,11 @@ type serviceAccountManager struct {
 }
 
 func (m *serviceAccountManager) sync(key string, obj *v1.ServiceAccount) error {
+	if obj == nil {
+		// do nothing
+		return nil
+	}
+
 	namespace, err := m.namespaceLister.Get("", obj.Namespace)
 	if err != nil {
 		return fmt.Errorf("error getting projects: %v", err)


### PR DESCRIPTION
When service account is nil in the sync handler (like when it is deleted)
the sync handler panics when a field on the svc act struct is accessed.
This fixes it by adding logic to immediately exit the handler when the
svc act is nil.

Issue:
https://github.com/rancher/rancher/issues/12351