### PR TITLE
FirstLogin settings. Reset on changePassword/setPassword and authConfig PUT

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -31,6 +31,7 @@ var (
 	UIPath                          = newSetting("ui-path", "")
 	UIPL                            = newSetting("ui-pl", "rancher")
 	WhitelistDomain                 = newSetting("whitelist-domain", "forums.rancher.com")
+	FirstLogin                      = newSetting("first-login", "true")
 )
 
 type Provider interface {

--- a/server/server.go
+++ b/server/server.go
@@ -73,6 +73,7 @@ func Start(ctx context.Context, httpPort, httpsPort int, apiContext *config.Scal
 	root.Handle("/v3/connect/register", connectHandler)
 	root.Handle("/v3/connect/config", connectConfigHandler)
 	root.Handle("/v3/settings/cacerts", rawAuthedAPIs).Methods(http.MethodGet)
+	root.Handle("/v3/settings/first-login", rawAuthedAPIs).Methods(http.MethodGet)
 	root.PathPrefix("/v3").Handler(authedHandler)
 	root.PathPrefix("/hooks").Handler(webhookHandler)
 	root.PathPrefix("/k8s/clusters/").Handler(authedHandler)


### PR DESCRIPTION
Based on discussion with @cjellick, we are:

1) Adding a new setting `first-login` (true by default). 
2) UI reads this field, and automatically logs in user if the value is true.
3) Rancher code resets the value to false on ChangePassword call.

The only part that is left is, exposing settings via v3-public API. @cjellick mentioned that there might be some work done for it by @ibuildthecloud already, so we might need to change this pr to expose first-login to v3-public.


https://github.com/rancher/rancher/issues/11880