### PR TITLE
fix workload yaml link

### DIFF
--- a/pkg/api/customization/workload/workload.go
+++ b/pkg/api/customization/workload/workload.go
@@ -109,6 +109,7 @@ func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 	resource.Links["self"] = apiContext.URLBuilder.ResourceLinkByID(workloadSchema, workloadID)
 	resource.Links["remove"] = apiContext.URLBuilder.ResourceLinkByID(workloadSchema, workloadID)
 	resource.Links["update"] = apiContext.URLBuilder.ResourceLinkByID(workloadSchema, workloadID)
+	resource.Links["yaml"] = apiContext.URLBuilder.ResourceLinkByID(workloadSchema, workloadID) + "/yaml"
 }
 
 func DeploymentFormatter(apiContext *types.APIContext, resource *types.RawResource) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5697937/38241603-3fd8492c-3765-11e8-9079-007d968cb08d.png)
generated yaml link for workloads is in the format 
```
/v3/project/local:project-mjzw6/deployments/deployment:default:ngx/yaml
```
expected format is
```
/v3/project/local:project-mjzw6/workloads/deployment:default:ngx/yaml
```

Related to issue: https://github.com/rancher/rancher/issues/12371
