### PR TITLE
add namespace export support

### DIFF
--- a/pkg/api/customization/namespace/link.go
+++ b/pkg/api/customization/namespace/link.go
@@ -1,0 +1,134 @@
+package namespace
+
+import (
+	"github.com/rancher/norman/httperror"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/pkg/clustermanager"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/kubernetes/pkg/printers"
+	"strings"
+)
+
+var ExportResourcePrefixMappings = map[string]string{
+	"pods":                   "api/v1",
+	"configmaps":             "api/v1",
+	"services":               "api/v1",
+	"replicationcontrollers": "api/v1",
+	"deployments":            "apis/extensions/v1beta1",
+	"daemonsets":             "apis/extensions/v1beta1",
+	"replicasets":            "apis/extensions/v1beta1",
+	"statefulsets":           "apis/apps/v1beta1",
+	"jobs":                   "apis/batch/v1",
+	"cronjobs":               "apis/batch/v1beta1",
+}
+
+var ExportPrinters = map[string]printers.ResourcePrinter{
+	"json": &printers.JSONPrinter{},
+	"yaml": &printers.YAMLPrinter{},
+}
+
+func NewLinkHandler(next types.RequestHandler, manager *clustermanager.Manager) types.RequestHandler {
+
+	lh := &yamlLinkHandler{
+		next:              next,
+		clusterManagement: manager,
+	}
+
+	return lh.LinkHandler
+}
+
+type yamlLinkHandler struct {
+	next              types.RequestHandler
+	clusterManagement *clustermanager.Manager
+}
+
+func (s *yamlLinkHandler) callNext(apiContext *types.APIContext, next types.RequestHandler) error {
+	if s.next != nil {
+		return s.next(apiContext, next)
+	} else if next != nil {
+		return next(apiContext, nil)
+	}
+
+	return httperror.NewAPIError(httperror.NotFound, "link not found")
+}
+
+func (s *yamlLinkHandler) LinkHandler(apiContext *types.APIContext, next types.RequestHandler) error {
+	if apiContext.Link != "yaml" {
+		return s.callNext(apiContext, next)
+	}
+
+	clusterName := s.clusterManagement.ClusterName(apiContext)
+
+	userContext, err := s.clusterManagement.UserContext(clusterName)
+	if err != nil {
+		return err
+	}
+
+	ns := apiContext.ID
+	result := &unstructured.UnstructuredList{}
+	result.SetAPIVersion("v1")
+	result.SetKind("List")
+
+	resources := apiContext.Request.URL.Query()["resource"]
+	toExportResourceMappings := getResourcePrefixMap(resources)
+
+	for kind, prefix := range toExportResourceMappings {
+
+		req := userContext.UnversionedClient.Get().Prefix(prefix).Namespace(ns).Resource(kind)
+		for k, v := range apiContext.Request.URL.Query() {
+			req.Param(k, strings.Join(v, ","))
+		}
+		for k, v := range apiContext.Request.Header {
+			if k == "Authorization" {
+				continue
+			}
+			req.SetHeader(k, v...)
+		}
+		req.SetHeader("Accept", "*/*")
+
+		r, err := req.Do().Get()
+		if err != nil {
+			if e, ok := err.(*apierrors.StatusError); ok && e.Status().Code == 403 {
+				continue
+			}
+			return err
+		}
+
+		if list, ok := r.(*unstructured.UnstructuredList); ok {
+			for _, item := range list.Items {
+				if len(item.GetOwnerReferences()) == 0 {
+					result.Items = append(result.Items, item)
+				}
+			}
+		}
+	}
+
+	printer := ExportPrinters["json"]
+	apiContext.Response.Header().Set("content-type", "application/json")
+
+	if apiContext.Request.Header.Get("Accept") == "application/yaml" {
+		printer = ExportPrinters["yaml"]
+		apiContext.Response.Header().Set("content-type", "application/yaml")
+	}
+
+	return printer.PrintObj(result, apiContext.Response)
+}
+
+//getResourcePrefixMap converts resource path like `/api/v1/pods` to kind-prefix mappings
+func getResourcePrefixMap(resources []string) map[string]string {
+	if len(resources) == 0 {
+		return ExportResourcePrefixMappings
+	}
+	m := map[string]string{}
+	for _, r := range resources {
+		idx := strings.LastIndex(r, "/")
+		if idx == -1 {
+			m[r] = ""
+		} else {
+			m[r[idx+1:]] = r[:idx]
+		}
+
+	}
+	return m
+}

--- a/pkg/api/server/userstored/setup.go
+++ b/pkg/api/server/userstored/setup.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rancher/norman/store/subtype"
 	"github.com/rancher/norman/types"
+	namespacecustom "github.com/rancher/rancher/pkg/api/customization/namespace"
 	"github.com/rancher/rancher/pkg/api/customization/yaml"
 	"github.com/rancher/rancher/pkg/api/store/cert"
 	"github.com/rancher/rancher/pkg/api/store/ingress"
@@ -16,6 +17,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/store/service"
 	"github.com/rancher/rancher/pkg/api/store/workload"
 	"github.com/rancher/rancher/pkg/clustermanager"
+	clusterschema "github.com/rancher/types/apis/cluster.cattle.io/v3/schema"
 	"github.com/rancher/types/apis/project.cattle.io/v3/schema"
 	clusterClient "github.com/rancher/types/client/cluster/v3"
 	"github.com/rancher/types/client/project/v3"
@@ -48,6 +50,7 @@ func Setup(ctx context.Context, mgmt *config.ScaledContext, clusterManager *clus
 	Secret(mgmt, schemas)
 	Service(schemas)
 	Workload(schemas, clusterManager)
+	Namespace(schemas, clusterManager)
 
 	SetProjectID(schemas, clusterManager, k8sProxy)
 
@@ -76,6 +79,12 @@ func SetProjectID(schemas *types.Schemas, clusterManager *clustermanager.Manager
 		schema.Formatter = yaml.NewFormatter(schema.Formatter)
 		schema.LinkHandler = yaml.NewLinkHandler(k8sProxy, clusterManager, schema.LinkHandler)
 	}
+}
+
+func Namespace(schemas *types.Schemas, manager *clustermanager.Manager) {
+	namespaceSchema := schemas.Schema(&clusterschema.Version, "namespace")
+	namespaceSchema.LinkHandler = namespacecustom.NewLinkHandler(namespaceSchema.LinkHandler, manager)
+	namespaceSchema.Formatter = yaml.NewFormatter(namespaceSchema.Formatter)
 }
 
 func Workload(schemas *types.Schemas, clusterManager *clustermanager.Manager) {


### PR DESCRIPTION
Add yaml link to namespace
It returns yaml representation of workloads/services in the namespace given `Accept: application/yaml`, similar to service.export/workload.export
Workloads with OwnerReferences are filtered.

Related to the issue: https://github.com/rancher/rancher/issues/12371