### PR TITLE
add disablekeepalive to avoid remotedialer connection hangs

### DIFF
--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -159,7 +159,7 @@ func (m *Manager) toRESTConfig(cluster *v3.Cluster) (*rest.Config, error) {
 		return nil, err
 	}
 
-	dialer, err := m.dialer.ClusterDialer(cluster.Name)
+	dialer, err := m.dialer.ClusterDialer(cluster.Name, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -73,7 +73,7 @@ func NewRemote(cluster *v3.Cluster, factory dialer.Factory) (*RemoteService, err
 	transport := &http.Transport{}
 
 	if factory != nil {
-		d, err := factory.ClusterDialer(cluster.Name)
+		d, err := factory.ClusterDialer(cluster.Name, false)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controllers/user/alert/manager/manager.go
+++ b/pkg/controllers/user/alert/manager/manager.go
@@ -90,7 +90,7 @@ type Manager struct {
 
 func NewManager(cluster *config.UserContext) *Manager {
 
-	dial, err := cluster.Management.Dialer.ClusterDialer(cluster.ClusterName)
+	dial, err := cluster.Management.Dialer.ClusterDialer(cluster.ClusterName, false)
 	if err != nil {
 		logrus.Warnf("Failed to get cluster dialer: %v", err)
 	}

--- a/pkg/controllers/user/pipeline/engine/jenkins/engine.go
+++ b/pkg/controllers/user/pipeline/engine/jenkins/engine.go
@@ -64,7 +64,7 @@ func (j *Engine) PreCheck() error {
 	token := string(secret.Data["jenkins-admin-password"])
 
 	if j.Client == nil {
-		dial, err := j.Dialer.ClusterDialer(j.ClusterName)
+		dial, err := j.Dialer.ClusterDialer(j.ClusterName, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/dialer/local.go
+++ b/pkg/dialer/local.go
@@ -56,7 +56,7 @@ func (f *Factory) dialLocal(network, address string) (net.Conn, error) {
 
 	for _, obj := range objs {
 		if node, ok := obj.(*v3.Node); ok {
-			return f.TunnelServer.Dial(node.Name, 15*time.Second, network, address)
+			return f.TunnelServer.Dial(node.Name, 15*time.Second, network, address, false)
 		}
 	}
 

--- a/pkg/remotedialer/connection.go
+++ b/pkg/remotedialer/connection.go
@@ -11,24 +11,26 @@ import (
 type connection struct {
 	sync.Mutex
 
-	err           error
-	writeDeadline time.Time
-	buf           chan []byte
-	readBuf       []byte
-	addr          addr
-	session       *session
-	connID        int64
+	err               error
+	writeDeadline     time.Time
+	buf               chan []byte
+	readBuf           []byte
+	addr              addr
+	session           *session
+	connID            int64
+	disableKeepAlives bool
 }
 
-func newConnection(connID int64, session *session, proto, address string) *connection {
+func newConnection(connID int64, session *session, proto, address string, disableKeepAlives bool) *connection {
 	c := &connection{
 		addr: addr{
 			proto:   proto,
 			address: address,
 		},
-		connID:  connID,
-		session: session,
-		buf:     make(chan []byte, 1024),
+		connID:            connID,
+		session:           session,
+		buf:               make(chan []byte, 1024),
+		disableKeepAlives: disableKeepAlives,
 	}
 	return c
 }

--- a/pkg/remotedialer/dialer.go
+++ b/pkg/remotedialer/dialer.go
@@ -12,17 +12,17 @@ func (s *Server) HasSession(clientKey string) bool {
 	return err == nil
 }
 
-func (s *Server) Dial(clientKey string, deadline time.Duration, proto, address string) (net.Conn, error) {
+func (s *Server) Dial(clientKey string, deadline time.Duration, proto, address string, disableKeepAlives bool) (net.Conn, error) {
 	session, err := s.sessions.getByClient(clientKey)
 	if err != nil {
 		return nil, err
 	}
 
-	return session.serverConnect(deadline, proto, address)
+	return session.serverConnect(deadline, proto, address, disableKeepAlives)
 }
 
-func (s *Server) Dialer(clientKey string, deadline time.Duration) dialer.Dialer {
+func (s *Server) Dialer(clientKey string, deadline time.Duration, disableKeepAlives bool) dialer.Dialer {
 	return func(proto, address string) (net.Conn, error) {
-		return s.Dial(clientKey, deadline, proto, address)
+		return s.Dial(clientKey, deadline, proto, address, disableKeepAlives)
 	}
 }

--- a/vendor/github.com/rancher/types/config/dialer/dialer.go
+++ b/vendor/github.com/rancher/types/config/dialer/dialer.go
@@ -6,7 +6,7 @@ type Dialer func(network, address string) (net.Conn, error)
 
 type Factory interface {
 	LocalClusterDialer() Dialer
-	ClusterDialer(clusterName string) (Dialer, error)
+	ClusterDialer(clusterName string,disableKeepAlives bool) (Dialer, error)
 	DockerDialer(clusterName, machineName string) (Dialer, error)
 	NodeDialer(clusterName, machineName string) (Dialer, error)
 }


### PR DESCRIPTION
Found that it might get stuck using clusterDialer in HttpClient to do Http requests.
 In https://github.com/rancher/rancher/blob/master/pkg/remotedialer/connection.go#L88
The connection.Read() returns io.EOF only when the channel is closed.
And the chance is that when an error occurs in https://github.com/rancher/rancher/blob/master/pkg/remotedialer/session.go#L139
So the connection hangs waiting to get expected EOF.

I would like to add a `disableKeepAlives` field to the connection. If it is set close the connection when message is sent. I'm not sure if it's a reasonable change in the framework so this PR is to provide the basic idea. Interface types or other dialer types are not tweaked considerately.

Related issue: https://github.com/rancher/rancher/issues/11872