### PR TITLE
Fix login error

### DIFF
--- a/pkg/auth/providers/common/usermanager.go
+++ b/pkg/auth/providers/common/usermanager.go
@@ -232,12 +232,6 @@ func (m *userManager) EnsureUser(principalName, displayName string) (*v3.User, e
 		return nil, err
 	}
 
-	localPrincipal := "local://" + created.Name
-	if !slice.ContainsString(created.PrincipalIDs, localPrincipal) {
-		created.PrincipalIDs = append(created.PrincipalIDs, localPrincipal)
-		return m.users.Update(created)
-	}
-
 	return created, nil
 }
 


### PR DESCRIPTION
There are now two places that set the local principal on a user:
a controller and the api handler for when a user first logs in.
This leads to a scenario where the api creates the user, but the
controller is first to update the user with the principal and then
the api handler tries and gets a conflict error. This causes the
login to fail.

Solution is to remove the logic from the api handler so that it
is only performed in the controller.

Addresses https://github.com/rancher/rancher/issues/12524