### PR TITLE
Add --privileged by default

### DIFF
--- a/pkg/api/customization/clusterregistrationtokens/formatter.go
+++ b/pkg/api/customization/clusterregistrationtokens/formatter.go
@@ -12,7 +12,7 @@ import (
 const (
 	commandFormat         = "kubectl apply -f %s"
 	insecureCommandFormat = "curl --insecure -sfL %s | kubectl apply -f -"
-	nodeCommandFormat     = "sudo docker run -d --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run %s --server %s --token %s%s"
+	nodeCommandFormat     = "sudo docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run %s --server %s --token %s%s"
 )
 
 func Formatter(request *types.APIContext, resource *types.RawResource) {


### PR DESCRIPTION
SELinux (well really RHELs configuration of SELinux) will not let
containers talk to docker.sock.  Adding the privileged flag will work
around that.