### PR TITLE
increse get build info timeout

### DIFF
--- a/pkg/controllers/user/pipeline/engine/jenkins/engine.go
+++ b/pkg/controllers/user/pipeline/engine/jenkins/engine.go
@@ -269,10 +269,10 @@ func (j *Engine) SyncExecution(execution *v3.PipelineExecution) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		if time.Now().Before(startTime.Add(15 * time.Second)) {
+		if time.Now().Before(startTime.Add(60 * time.Second)) {
 			return false, nil
 		}
-		return false, ErrGetBuildInfoFail
+		return false, errors.New("timeout get build info")
 	}
 	if err != nil {
 		return false, err


### PR DESCRIPTION
15s timeout may not be sufficient before build info is ready.
Related issue: https://github.com/rancher/rancher/issues/12578