### PR TITLE
LB svc/ingress: generate endpoint when address is not empty

### DIFF
--- a/pkg/controllers/user/endpoints/service_endpoints.go
+++ b/pkg/controllers/user/endpoints/service_endpoints.go
@@ -64,7 +64,7 @@ func (s *ServicesController) reconcileEndpointsForService(svc *corev1.Service) (
 
 	logrus.Infof("Updating service [%s] with public endpoints [%v]", svc.Name, epsToUpdate)
 	if toUpdate.Annotations == nil {
-		toUpdate.Annotations = make(map[string]string)
+		toUpdate.Annotations = map[string]string{}
 	}
 	toUpdate.Annotations[endpointsAnnotation] = epsToUpdate
 	_, err = s.services.Update(toUpdate)


### PR DESCRIPTION
@ibuildthecloud fixes part of the issue happening on your setup - when Load Balancer service didn't get address assigned on k8s side, but Rancher generated a public endpoint for it with empty ip address. With this fix, no endpoint will be generated unless address is set on the load balancer service.