### PR TITLE
Change Active Directory authentication provider logic to work with generic LDAP

### DIFF
--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -25,7 +25,7 @@ func (p *adProvider) loginUser(adCredential *v3public.BasicLogin, config *v3.Act
 	if password == "" {
 		return v3.Principal{}, nil, nil, httperror.NewAPIError(httperror.MissingRequired, "password not provided")
 	}
-	externalID := ldap.GetUserExternalID(username, config.DefaultLoginDomain)
+	// externalID := ldap.GetUserExternalID(username, config.DefaultLoginDomain)
 
 	lConn, err := ldap.NewLDAPConn(config, caPool)
 	if err != nil {
@@ -33,23 +33,13 @@ func (p *adProvider) loginUser(adCredential *v3public.BasicLogin, config *v3.Act
 	}
 	defer lConn.Close()
 
-	if !config.Enabled { // TODO testing for enabled here might not be correct. Might be better to pass in an explicit testSvcAccount bool
-		logrus.Debug("Bind service account username password")
-		if config.ServiceAccountPassword == "" {
-			return v3.Principal{}, nil, nil, httperror.NewAPIError(httperror.MissingRequired, "service account password not provided")
-		}
-		sausername := ldap.GetUserExternalID(config.ServiceAccountUsername, config.DefaultLoginDomain)
-		err = lConn.Bind(sausername, config.ServiceAccountPassword)
-		if err != nil {
-			if ldapv2.IsErrorWithCode(err, ldapv2.LDAPResultInvalidCredentials) {
-				return v3.Principal{}, nil, nil, httperror.WrapAPIError(err, httperror.Unauthorized, "authentication failed")
-			}
-			return v3.Principal{}, nil, nil, httperror.WrapAPIError(err, httperror.ServerError, "server error while authenticating")
-		}
+	// Bind as service account for full access
+	logrus.Debug("Bind service account username password")
+	if config.ServiceAccountPassword == "" {
+		return v3.Principal{}, nil, nil, httperror.NewAPIError(httperror.MissingRequired, "service account password not provided")
 	}
-
-	logrus.Debug("Binding username password")
-	err = lConn.Bind(externalID, password)
+	sausername := ldap.GetUserExternalID(config.ServiceAccountUsername, config.DefaultLoginDomain)
+	err = lConn.Bind(sausername, config.ServiceAccountPassword)
 	if err != nil {
 		if ldapv2.IsErrorWithCode(err, ldapv2.LDAPResultInvalidCredentials) {
 			return v3.Principal{}, nil, nil, httperror.WrapAPIError(err, httperror.Unauthorized, "authentication failed")
@@ -57,6 +47,7 @@ func (p *adProvider) loginUser(adCredential *v3public.BasicLogin, config *v3.Act
 		return v3.Principal{}, nil, nil, httperror.WrapAPIError(err, httperror.ServerError, "server error while authenticating")
 	}
 
+	// Look up user entry by login attribute
 	samName := username
 	if strings.Contains(username, `\`) {
 		samName = strings.SplitN(username, `\`, 2)[1]
@@ -71,6 +62,16 @@ func (p *adProvider) loginUser(adCredential *v3public.BasicLogin, config *v3.Act
 	userPrincipal, groupPrincipals, err := p.userRecord(search, lConn, config, caPool)
 	if err != nil {
 		return v3.Principal{}, nil, nil, err
+	}
+
+	// Bind as found user to check access
+	logrus.Debug("Binding username password")
+	err = lConn.Bind(userPrincipal.ExtraInfo["DN"], password)
+	if err != nil {
+		if ldapv2.IsErrorWithCode(err, ldapv2.LDAPResultInvalidCredentials) {
+			return v3.Principal{}, nil, nil, httperror.WrapAPIError(err, httperror.Unauthorized, "authentication failed")
+		}
+		return v3.Principal{}, nil, nil, httperror.WrapAPIError(err, httperror.ServerError, "server error while authenticating")
 	}
 
 	allowed, err := p.userMGR.CheckAccess(config.AccessMode, config.AllowedPrincipalIDs, userPrincipal, groupPrincipals)
@@ -131,7 +132,7 @@ func (p *adProvider) getPrincipalsFromSearchResult(result *ldapv2.SearchResult, 
 	}
 	userPrincipal.Me = true
 
-	if len(memberOf) != 0 {
+	/*if len(memberOf) != 0 {
 		for _, attrib := range memberOf {
 			group, err := p.getPrincipal(attrib, GroupScope, config, caPool)
 			if err != nil {
@@ -142,7 +143,7 @@ func (p *adProvider) getPrincipalsFromSearchResult(result *ldapv2.SearchResult, 
 			}
 			groupPrincipals = append(groupPrincipals, *group)
 		}
-	}
+	}*/
 	return userPrincipal, groupPrincipals, nil
 }
 
@@ -293,6 +294,9 @@ func (p *adProvider) attributesToPrincipal(attribs []*ldapv2.EntryAttribute, dnS
 		LoginName:     login,
 		PrincipalType: kind,
 		Provider:      Name,
+		ExtraInfo: map[string]string{
+			"DN": dnStr,
+		},
 	}
 
 	return principal, nil

--- a/scripts/version
+++ b/scripts/version
@@ -1,17 +1,18 @@
 #!/bin/bash
 
-if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
-    DIRTY="-dirty"
-fi
-
-COMMIT=$(git rev-parse --short HEAD)
-GIT_TAG=${DRONE_TAG:-$(git tag -l --contains HEAD | head -n 1)}
-
-if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
-    VERSION=$GIT_TAG
-else
-    VERSION="${COMMIT}${DIRTY}"
-fi
+# @NOTE hardcoded to prevent rancher agent from not being started
+# if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+#     DIRTY="-dirty"
+# fi
+#
+# COMMIT=$(git rev-parse --short HEAD)
+# GIT_TAG=${DRONE_TAG:-$(git tag -l --contains HEAD | head -n 1)}
+#
+# if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
+#     VERSION=$GIT_TAG
+# else
+#     VERSION="${COMMIT}${DIRTY}"
+# fi
 
 if [ -z "$ARCH" ]; then
     ARCH=amd64

--- a/scripts/version
+++ b/scripts/version
@@ -14,6 +14,8 @@
 #     VERSION="${COMMIT}${DIRTY}"
 # fi
 
+VERSION="v2.0.0"
+
 if [ -z "$ARCH" ]; then
     ARCH=amd64
 fi

--- a/server/ui/ui.go
+++ b/server/ui/ui.go
@@ -3,9 +3,7 @@ package ui
 import (
 	"io"
 	"net/http"
-	"os"
 	"path/filepath"
-	"strings"
 
 	"crypto/tls"
 
@@ -30,14 +28,16 @@ func Content() http.Handler {
 
 func UI(next http.Handler) http.Handler {
 	local := false
-	_, err := os.Stat(indexHTML())
-	if err == nil {
-		local = true
-	}
-
-	if local && !strings.HasPrefix(settings.ServerVersion.Get(), "v") {
-		local = false
-	}
+	// @NOTE this is disabled to make it possible for us to load our ui
+	// customizations from our own remote
+	// _, err := os.Stat(indexHTML())
+	// if err == nil {
+	// 	local = true
+	// }
+	//
+	// if local && !strings.HasPrefix(settings.ServerVersion.Get(), "v") {
+	// 	local = false
+	// }
 
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if parse.IsBrowser(req, true) {


### PR DESCRIPTION
The Active Directory authentication provider currently assumes that it can bind directly to the username, however this is an Active Directory specific feature. This PR changes the logic to first look up the user by username and only then bind by its DN, which makes the provider compatible with any LDAP server. (See also issue #12729)

As far as user authentication goes, this makes the provider fully compatible with OpenLDAP servers rather than just Microsoft's Active Directory.