### PR TITLE
System project

### DIFF
--- a/pkg/controllers/user/rbac/handler_base.go
+++ b/pkg/controllers/user/rbac/handler_base.go
@@ -81,6 +81,7 @@ func Register(workload *config.UserContext) {
 		crLister:      workload.RBAC.ClusterRoles("").Controller().Lister(),
 		nsLister:      workload.Core.Namespaces("").Controller().Lister(),
 		clusterLister: workload.Management.Management.Clusters("").Controller().Lister(),
+		projectLister: workload.Management.Management.Projects("").Controller().Lister(),
 		clusterName:   workload.ClusterName,
 	}
 	workload.Management.Management.Projects("").AddClusterScopedLifecycle("project-namespace-auth", workload.ClusterName, newProjectLifecycle(r))
@@ -115,6 +116,7 @@ type manager struct {
 	rbLister      typesrbacv1.RoleBindingLister
 	nsLister      typescorev1.NamespaceLister
 	clusterLister v3.ClusterLister
+	projectLister v3.ProjectLister
 	clusterName   string
 }
 

--- a/pkg/controllers/user/rbac/namespace_handler.go
+++ b/pkg/controllers/user/rbac/namespace_handler.go
@@ -44,6 +44,9 @@ func (n *nsLifecycle) Create(obj *v1.Namespace) (*v1.Namespace, error) {
 	}
 
 	setRolesPopulatedCondition(obj, 0)
+	if err := n.assignToSystemProject(obj); err != nil {
+		return obj, err
+	}
 	go updateStatusAnnotation(hasPRTBs, obj, n.m)
 
 	return obj, err
@@ -70,6 +73,44 @@ func (n *nsLifecycle) syncNS(obj *v1.Namespace) (bool, error) {
 	}
 
 	return hasPRTBs, nil
+}
+
+func (n *nsLifecycle) assignToSystemProject(ns *v1.Namespace) error {
+	defaultProjectsToNamespaces, err := GetDefaultProjectsToNamespaces()
+	if err != nil {
+		return err
+	}
+	for projectDisplayName, namespaces := range defaultProjectsToNamespaces {
+		for _, nsToCheck := range namespaces {
+			if nsToCheck == ns.Name {
+				projects, err := n.m.projectLister.List(n.m.clusterName, labels.NewSelector())
+				if err != nil {
+					return err
+				}
+				var project *v3.Project
+				for _, p := range projects {
+					if p.Spec.DisplayName == projectDisplayName {
+						project = p
+						break
+					}
+				}
+				if project == nil {
+					continue
+				}
+
+				projectID := ns.Annotations[projectIDAnnotation]
+				if projectID != "" {
+					return nil
+				}
+
+				if ns.Annotations == nil {
+					ns.Annotations = map[string]string{}
+				}
+				ns.Annotations[projectIDAnnotation] = fmt.Sprintf("%v:%v", n.m.clusterName, project.Name)
+			}
+		}
+	}
+	return nil
 }
 
 func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {

--- a/pkg/controllers/user/rbac/project_handler.go
+++ b/pkg/controllers/user/rbac/project_handler.go
@@ -3,7 +3,10 @@ package rbac
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/pkg/errors"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -34,7 +37,7 @@ func (p *pLifecycle) Create(project *v3.Project) (*v3.Project, error) {
 
 	}
 
-	err := p.ensureDefaultNamespaceAssigned(project)
+	err := p.ensureNamespacesAssigned(project)
 	return project, err
 }
 
@@ -80,16 +83,9 @@ func (p *pLifecycle) Remove(project *v3.Project) (*v3.Project, error) {
 	return nil, nil
 }
 
-func (p *pLifecycle) ensureDefaultNamespaceAssigned(project *v3.Project) error {
+func (p *pLifecycle) ensureNamespacesAssigned(project *v3.Project) error {
 	if _, ok := project.Labels["authz.management.cattle.io/default-project"]; !ok {
 		return nil
-	}
-	ns, err := p.m.nsLister.Get("", "default")
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
 	}
 
 	cluster, err := p.m.clusterLister.Get("", p.m.clusterName)
@@ -100,12 +96,50 @@ func (p *pLifecycle) ensureDefaultNamespaceAssigned(project *v3.Project) error {
 		return errors.Errorf("couldn't find cluster %v", p.m.clusterName)
 	}
 
-	updateCluster := false
-	c, err := v3.ClusterConditionDefaultNamespaceAssigned.DoUntilTrue(cluster.DeepCopy(), func() (runtime.Object, error) {
-		updateCluster = true
+	switch projectName := project.Spec.DisplayName; projectName {
+	case "Default":
+		if err = p.ensureDefaultNamespaceAssigned(cluster, project); err != nil {
+			return err
+		}
+	case "System":
+		if err = p.ensureDefaultNamespaceAssigned(cluster, project); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *pLifecycle) ensureDefaultNamespaceAssigned(cluster *v3.Cluster, project *v3.Project) error {
+	_, err := v3.ClusterConditionDefaultNamespaceAssigned.DoUntilTrue(cluster.DeepCopy(), func() (runtime.Object, error) {
+		return nil, p.assignNamespacesToProject(project)
+	})
+	return err
+}
+
+func (p *pLifecycle) ensureSystemNamespaceAssigned(cluster *v3.Cluster, project *v3.Project) error {
+	_, err := v3.ClusterConditionSystemNamespacesAssigned.DoUntilTrue(cluster.DeepCopy(), func() (runtime.Object, error) {
+		return nil, p.assignNamespacesToProject(project)
+	})
+	return err
+}
+
+func (p *pLifecycle) assignNamespacesToProject(project *v3.Project) error {
+	defaultProjectsToNamespaces, err := GetDefaultProjectsToNamespaces()
+	if err != nil {
+		return err
+	}
+	for _, nsName := range defaultProjectsToNamespaces[project.Spec.DisplayName] {
+		ns, err := p.m.nsLister.Get("", nsName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
 		projectID := ns.Annotations[projectIDAnnotation]
 		if projectID != "" {
-			return nil, nil
+			return nil
 		}
 
 		ns = ns.DeepCopy()
@@ -114,15 +148,26 @@ func (p *pLifecycle) ensureDefaultNamespaceAssigned(project *v3.Project) error {
 		}
 		ns.Annotations[projectIDAnnotation] = fmt.Sprintf("%v:%v", p.m.clusterName, project.Name)
 		if _, err := p.m.workload.Core.Namespaces(p.m.clusterName).Update(ns); err != nil {
-			return nil, err
-		}
-
-		return nil, nil
-	})
-	if updateCluster {
-		if _, err := p.m.workload.Management.Management.Clusters("").ObjectClient().Update(cluster.Name, c); err != nil {
 			return err
 		}
 	}
-	return err
+	return nil
+}
+
+func GetDefaultProjectsToNamespaces() (map[string][]string, error) {
+	systemNamespacesStr := settings.SystemNamespaces.Get()
+	var systemNamespaces []string
+	if systemNamespacesStr == "" {
+		return nil, fmt.Errorf("failed to load setting %s", settings.SystemNamespaces)
+	}
+
+	splitted := strings.Split(systemNamespacesStr, ",")
+	for _, s := range splitted {
+		systemNamespaces = append(systemNamespaces, strings.TrimSpace(s))
+	}
+
+	return map[string][]string{
+		"Default": {"default"},
+		"System":  systemNamespaces,
+	}, nil
 }

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -34,6 +34,8 @@ var (
 	WhitelistDomain                 = newSetting("whitelist-domain", "forums.rancher.com")
 	FirstLogin                      = newSetting("first-login", "true")
 	InstallUUID                     = newSetting("install-uuid", "")
+	SystemNamespaces                = newSetting("system-namespaces", "kube-system,kube-public,cattle-system,"+
+		"cattle-alerting,cattle-logging, cattle-pipeline")
 )
 
 type Provider interface {


### PR DESCRIPTION
Create system project similarly to default project, and assign system namespaces to it (list of system namespaces is configurable).
A couple of notes:

* Utilized the same Cluster condition `DefaultProjectCreated` to signal that default/system projects are created.
* Introduced new Cluster condition `SystemNamespacesAssigned` as could not used the existing one (`DefaultNamespaceAssigned`) - it is designed to be on per project basis. This condition is used to assign existing namespaces in cluster, to a system project (cattle-system, kube-system, kube-public)
* There are a couple of namespaces that get created after cluster is setup (`cattle-alerting, cattle-logging", cattle-pipeline`). For those, assignment to a system project is invoked as a part of namespace create lifecycle 

https://github.com/rancher/types/pull/373

https://github.com/rancher/rancher/issues/12706