### PR TITLE
Prevent deletion of PSPTs assigned to a cluster/project

### DIFF
--- a/pkg/api/customization/podsecuritypolicytemplate/podsecuritypolicytemplate.go
+++ b/pkg/api/customization/podsecuritypolicytemplate/podsecuritypolicytemplate.go
@@ -1,0 +1,135 @@
+package podsecuritypolicytemplate
+
+import (
+	"fmt"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/apis/management.cattle.io/v3/schema"
+	"github.com/rancher/types/client/management/v3"
+	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+)
+
+type Store struct {
+	types.Store
+}
+
+func (s *Store) Delete(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
+	projectHasPSPT, err := projectHasPSPTAssigned(apiContext)
+	if err != nil {
+		return nil, fmt.Errorf("error checking if PSPT is assigned to projects: %v", err)
+	}
+
+	if projectHasPSPT {
+		return nil, errors.NewBadRequest("PSPT is assigned to one or more projects, remove PSPT from those " +
+			"projects before deleting")
+	}
+
+	clusterHasPSPT, err := clusterHasPSPTAssigned(apiContext)
+	if err != nil {
+		return nil, fmt.Errorf("error checking if PSPT is assigned to clusters: %v", err)
+	}
+
+	if clusterHasPSPT {
+		return nil, errors.NewBadRequest("PSPT is assigned to one or more clusters, remove PSPT from those " +
+			"clusters before deleting")
+	}
+
+	return s.Store.Delete(apiContext, schema, id)
+}
+
+const clusterByPSPTKey = "clusterByPSPT"
+const projectByPSPTKey = "projectByPSPT"
+
+func NewFormatter(management *config.ScaledContext) types.Formatter {
+	clusterInformer := management.Management.Clusters("").Controller().Informer()
+	clusterInformer.AddIndexers(map[string]cache.IndexFunc{
+		clusterByPSPTKey: clusterByPSPT,
+	})
+
+	projectInformer := management.Management.Projects("").Controller().Informer()
+	projectInformer.AddIndexers(map[string]cache.IndexFunc{
+		projectByPSPTKey: projectByPSPT,
+	})
+
+	format := Format{
+		ClusterIndexer: clusterInformer.GetIndexer(),
+		ProjectIndexer: projectInformer.GetIndexer(),
+	}
+	return format.Formatter
+}
+
+func clusterByPSPT(obj interface{}) ([]string, error) {
+	cluster, ok := obj.(*v3.Cluster)
+	if !ok {
+		return []string{}, nil
+	}
+
+	return []string{cluster.Spec.DefaultPodSecurityPolicyTemplateName}, nil
+}
+
+func projectByPSPT(obj interface{}) ([]string, error) {
+	project, ok := obj.(*v3.Project)
+	if !ok {
+		return []string{}, nil
+	}
+
+	return []string{project.Status.PodSecurityPolicyTemplateName}, nil
+}
+
+type Format struct {
+	ClusterIndexer cache.Indexer
+	ProjectIndexer cache.Indexer
+}
+
+func (f *Format) Formatter(apiContext *types.APIContext, resource *types.RawResource) {
+	// check if PSPT is assigned to a cluster or project
+	projectsWithPSPT, err := f.ProjectIndexer.ByIndex(projectByPSPTKey, apiContext.ID)
+	if err != nil {
+		logrus.Warn("failed to determine if PSPT was assigned to a project: %v", err)
+		return
+	}
+
+	if len(projectsWithPSPT) != 0 {
+		// remove delete link
+		delete(resource.Links, "remove")
+		return
+	}
+
+	clustersWithPSPT, err := f.ClusterIndexer.ByIndex(clusterByPSPTKey, apiContext.ID)
+	if err != nil {
+		logrus.Warnf("failed to determine if a PSPT was assigned to a cluster: %v", err)
+		return
+	}
+
+	if len(clustersWithPSPT) != 0 {
+		// remove delete link
+		delete(resource.Links, "remove")
+		return
+	}
+}
+
+func projectHasPSPTAssigned(apiContext *types.APIContext) (bool, error) {
+	projectSchema := apiContext.Schemas.Schema(&schema.Version, client.ProjectType)
+	projects, err := projectSchema.Store.List(apiContext, projectSchema, &types.QueryOptions{
+		Conditions: []*types.QueryCondition{
+			types.NewConditionFromString(client.ProjectFieldPodSecurityPolicyTemplateName, types.ModifierEQ,
+				apiContext.ID),
+		},
+	})
+	return len(projects) != 0, err
+}
+
+func clusterHasPSPTAssigned(apiContext *types.APIContext) (bool, error) {
+	clusterSchema := apiContext.Schemas.Schema(&schema.Version, client.ClusterType)
+	clusters, err := clusterSchema.Store.List(apiContext, clusterSchema, &types.QueryOptions{
+		Conditions: []*types.QueryCondition{
+			types.NewConditionFromString(client.ClusterFieldDefaultPodSecurityPolicyTemplateId, types.ModifierEQ,
+				apiContext.ID),
+		},
+	})
+	return len(clusters) != 0, err
+}

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/customization/node"
 	"github.com/rancher/rancher/pkg/api/customization/nodetemplate"
 	"github.com/rancher/rancher/pkg/api/customization/pipeline"
+	"github.com/rancher/rancher/pkg/api/customization/podsecuritypolicytemplate"
 	projectaction "github.com/rancher/rancher/pkg/api/customization/project"
 	"github.com/rancher/rancher/pkg/api/customization/setting"
 	"github.com/rancher/rancher/pkg/api/store/cert"
@@ -112,6 +113,7 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	Pipeline(schemas, apiContext)
 	Project(schemas, apiContext)
 	TemplateContent(schemas)
+	PodSecurityPolicyTemplate(schemas, apiContext)
 
 	if err := NodeTypes(schemas, apiContext); err != nil {
 		return err
@@ -394,4 +396,13 @@ func Project(schemas *types.Schemas, management *config.ScaledContext) {
 		ProjectLister: management.Management.Projects("").Controller().Lister(),
 	}
 	schema.ActionHandler = handler.Actions
+}
+
+func PodSecurityPolicyTemplate(schemas *types.Schemas, management *config.ScaledContext) {
+
+	schema := schemas.Schema(&managementschema.Version, client.PodSecurityPolicyTemplateType)
+	schema.Formatter = podsecuritypolicytemplate.NewFormatter(management)
+	schema.Store = &podsecuritypolicytemplate.Store{
+		Store: schema.Store,
+	}
 }


### PR DESCRIPTION
This change prevents the deletion of PSPTs assigend to a cluster or
project.  It accomplishes that in 2 ways: 1) by removing the delete link
on the API and 2) by verifying that no projects or clusters have a
rerefence to a given PSPT before allowing it to be deleted, and throwing
an error if that is not the case.

Issues:
#12367
#12368