### PR TITLE
client-go caches tlsconfigs across clients causing collisions

### DIFF
--- a/pkg/clusterrouter/factory.go
+++ b/pkg/clusterrouter/factory.go
@@ -14,17 +14,19 @@ import (
 type factory struct {
 	dialerFactory dialer.Factory
 	clusterLookup ClusterLookup
+	clusterLister v3.ClusterLister
 	clusters      sync.Map
 	serverLock    *locker.Locker
 	servers       sync.Map
 	localConfig   *rest.Config
 }
 
-func newFactory(localConfig *rest.Config, dialer dialer.Factory, lookup ClusterLookup) *factory {
+func newFactory(localConfig *rest.Config, dialer dialer.Factory, lookup ClusterLookup, clusterLister v3.ClusterLister) *factory {
 	return &factory{
 		dialerFactory: dialer,
 		serverLock:    locker.New(),
 		clusterLookup: lookup,
+		clusterLister: clusterLister,
 		localConfig:   localConfig,
 	}
 }
@@ -71,5 +73,5 @@ func (s *factory) get(req *http.Request) (*v3.Cluster, http.Handler, error) {
 }
 
 func (s *factory) newServer(c *v3.Cluster) (server, error) {
-	return proxy.New(s.localConfig, c, s.dialerFactory)
+	return proxy.New(s.localConfig, c, s.clusterLister, s.dialerFactory)
 }

--- a/pkg/clusterrouter/router.go
+++ b/pkg/clusterrouter/router.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/rancher/norman/httperror"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config/dialer"
 	"k8s.io/client-go/rest"
 )
@@ -14,8 +15,8 @@ type Router struct {
 	serverFactory *factory
 }
 
-func New(localConfig *rest.Config, lookup ClusterLookup, dialer dialer.Factory) http.Handler {
-	serverFactory := newFactory(localConfig, dialer, lookup)
+func New(localConfig *rest.Config, lookup ClusterLookup, dialer dialer.Factory, clusterLister v3.ClusterLister) http.Handler {
+	serverFactory := newFactory(localConfig, dialer, lookup, clusterLister)
 	return &Router{
 		serverFactory: serverFactory,
 	}


### PR DESCRIPTION
The custom verify method was incorrectly be assigned to different clusters
because of tlsconfig caching that client-go uses.  Instead we will just
use DialTLS.