### PR TITLE
Promote rules from project roles to cluster

### DIFF
--- a/pkg/controllers/user/rbac/namespace_handler.go
+++ b/pkg/controllers/user/rbac/namespace_handler.go
@@ -114,7 +114,7 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 			return false, errors.Wrap(err, "couldn't ensure roles")
 		}
 
-		if err := n.m.ensureRoleBindings(ns.Name, roles, prtb); err != nil {
+		if err := n.m.ensureProjectRoleBindings(ns.Name, roles, prtb); err != nil {
 			return false, errors.Wrapf(err, "couldn't ensure binding %v in %v", prtb.Name, ns.Name)
 		}
 	}

--- a/pkg/controllers/user/rbac/prtb_handler.go
+++ b/pkg/controllers/user/rbac/prtb_handler.go
@@ -70,7 +70,7 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 
 	for _, n := range namespaces {
 		ns := n.(*v1.Namespace)
-		if err := p.m.ensureRoleBindings(ns.Name, roles, binding); err != nil {
+		if err := p.m.ensureProjectRoleBindings(ns.Name, roles, binding); err != nil {
 			return errors.Wrapf(err, "couldn't ensure binding %v in %v", binding.Name, ns.Name)
 		}
 	}


### PR DESCRIPTION
Some resources (right now PVs and storageClasses) are globally scoped but
need to be viewable by project members in ordered to be used by project
members. Therefore, the rules for these resources are defined in
project-scoped roles.

This logic creates clusterRoles and clusterRoleBindings for such situations
so that project members can properly use these resources.

Addresses https://github.com/rancher/rancher/issues/12231