### PR TITLE
pipeline cleanup

### DIFF
--- a/pkg/api/customization/pipeline/cluster_pipeline.go
+++ b/pkg/api/customization/pipeline/cluster_pipeline.go
@@ -180,7 +180,7 @@ func (h *ClusterPipelineHandler) authapp(apiContext *types.APIContext) error {
 		return err
 	}
 
-	go refreshReposByCredential(h.SourceCodeRepositories, h.SourceCodeRepositoryLister, sourceCodeCredential)
+	go refreshReposByCredential(h.SourceCodeRepositories, h.SourceCodeRepositoryLister, sourceCodeCredential, clusterPipeline)
 
 	apiContext.WriteResponse(http.StatusOK, data)
 	return nil
@@ -225,7 +225,7 @@ func (h *ClusterPipelineHandler) authuser(apiContext *types.APIContext) error {
 		return err
 	}
 
-	go refreshReposByCredential(h.SourceCodeRepositories, h.SourceCodeRepositoryLister, account)
+	go refreshReposByCredential(h.SourceCodeRepositories, h.SourceCodeRepositoryLister, account, clusterPipeline)
 
 	apiContext.WriteResponse(http.StatusOK, data)
 	return nil

--- a/pkg/api/customization/pipeline/source_code_credential.go
+++ b/pkg/api/customization/pipeline/source_code_credential.go
@@ -12,6 +12,7 @@ import (
 )
 
 type SourceCodeCredentialHandler struct {
+	ClusterPipelineLister      v3.ClusterPipelineLister
 	SourceCodeCredentials      v3.SourceCodeCredentialInterface
 	SourceCodeCredentialLister v3.SourceCodeCredentialLister
 	SourceCodeRepositories     v3.SourceCodeRepositoryInterface
@@ -69,7 +70,11 @@ func (h *SourceCodeCredentialHandler) refreshrepos(apiContext *types.APIContext)
 	if err != nil {
 		return err
 	}
-	if _, err := refreshReposByCredential(h.SourceCodeRepositories, h.SourceCodeRepositoryLister, credential); err != nil {
+	clusterPipeline, err := h.ClusterPipelineLister.Get(credential.Spec.ClusterName, credential.Spec.ClusterName)
+	if err != nil {
+		return err
+	}
+	if _, err := refreshReposByCredential(h.SourceCodeRepositories, h.SourceCodeRepositoryLister, credential, clusterPipeline); err != nil {
 		return err
 	}
 	data := []map[string]interface{}{}

--- a/pkg/api/customization/pipeline/utils.go
+++ b/pkg/api/customization/pipeline/utils.go
@@ -14,18 +14,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func refreshReposByCredential(sourceCodeRepositories v3.SourceCodeRepositoryInterface, sourceCodeRepositoryLister v3.SourceCodeRepositoryLister, credential *v3.SourceCodeCredential) ([]*v3.SourceCodeRepository, error) {
+func refreshReposByCredential(sourceCodeRepositories v3.SourceCodeRepositoryInterface, sourceCodeRepositoryLister v3.SourceCodeRepositoryLister, credential *v3.SourceCodeCredential, clusterPipeline *v3.ClusterPipeline) ([]*v3.SourceCodeRepository, error) {
 
 	remoteType := credential.Spec.SourceCodeType
 	namespace := credential.Namespace
 	credentialID := ref.Ref(credential)
 
-	mockConfig := v3.ClusterPipeline{
-		Spec: v3.ClusterPipelineSpec{
-			GithubConfig: &v3.GithubClusterConfig{},
-		},
-	}
-	remote, err := remote.New(mockConfig, remoteType)
+	remote, err := remote.New(*clusterPipeline, remoteType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -364,6 +364,7 @@ func Pipeline(schemas *types.Schemas, management *config.ScaledContext) {
 	schema.ActionHandler = pipelineExecutionHandler.ActionHandler
 
 	sourceCodeCredentialHandler := &pipeline.SourceCodeCredentialHandler{
+		ClusterPipelineLister:      management.Management.ClusterPipelines("").Controller().Lister(),
 		SourceCodeCredentials:      management.Management.SourceCodeCredentials(""),
 		SourceCodeCredentialLister: management.Management.SourceCodeCredentials("").Controller().Lister(),
 		SourceCodeRepositories:     management.Management.SourceCodeRepositories(""),

--- a/pkg/controllers/user/pipeline/controller/clusterpipeline/clusterpipelinesyncer.go
+++ b/pkg/controllers/user/pipeline/controller/clusterpipeline/clusterpipelinesyncer.go
@@ -144,11 +144,6 @@ func (s *Syncer) deploy() error {
 		return errors.Wrapf(err, "Error create service")
 	}
 
-	agentservice := getJenkinsAgentService()
-	if _, err := s.services.Create(agentservice); err != nil && !apierrors.IsAlreadyExists(err) {
-		return errors.Wrapf(err, "Error create service")
-	}
-
 	sa := getServiceAccount()
 	if _, err := s.serviceAccounts.Create(sa); err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "Error create service account")

--- a/pkg/controllers/user/pipeline/controller/clusterpipeline/deploy.go
+++ b/pkg/controllers/user/pipeline/controller/clusterpipeline/deploy.go
@@ -39,7 +39,6 @@ func getJenkinsService() *corev1.Service {
 			Name:      "jenkins",
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeNodePort,
 			Selector: map[string]string{
 				"app": "jenkins",
 			},
@@ -48,23 +47,6 @@ func getJenkinsService() *corev1.Service {
 					Name: "http",
 					Port: 8080,
 				},
-			},
-		},
-	}
-}
-
-func getJenkinsAgentService() *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: utils.PipelineNamespace,
-			Name:      "jenkins-agent",
-		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeNodePort,
-			Selector: map[string]string{
-				"app": "jenkins",
-			},
-			Ports: []corev1.ServicePort{
 				{
 					Name: "agent",
 					Port: 50000,
@@ -303,7 +285,7 @@ const JenkinsConfig = `<?xml version='1.0' encoding='UTF-8'?>
       <skipTlsVerify>false</skipTlsVerify>
       <namespace>cattle-pipeline</namespace>
       <jenkinsUrl>http://jenkins:8080</jenkinsUrl>
-      <jenkinsTunnel>jenkins-agent:50000</jenkinsTunnel>
+      <jenkinsTunnel>jenkins:50000</jenkinsTunnel>
       <containerCap>10</containerCap>
       <retentionTimeout>5</retentionTimeout>
       <connectTimeout>0</connectTimeout>

--- a/pkg/controllers/user/pipeline/controller/pipelineexecution/pipelineexecution.go
+++ b/pkg/controllers/user/pipeline/controller/pipelineexecution/pipelineexecution.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -74,6 +75,9 @@ func (l *Lifecycle) Create(obj *v3.PipelineExecution) (*v3.PipelineExecution, er
 		return obj, nil
 	}
 	if err := l.initLogs(obj); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return obj, nil
+		}
 		return obj, err
 	}
 


### PR DESCRIPTION
1. remove NodePort for Jenkins. we don't need it since we're using dialer for connection. 
2. Merge two Jenkins services to one service with two ports(8080 & 50000).
3. filter out `AlreadyExists` error to avoid polluting logs.
4. use clusterpipeline config of the cluster instead of misuse of mockconfig, we need the config for example when connecting a private github.