### PR TITLE
Adding ability for cluster owner to set project PSPT

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -18,7 +18,9 @@ const (
 	rbByRoleAndSubjectIndex   = "auth.management.cattle.io/crb-by-role-and-subject"
 )
 
-var clusterManagmentPlaneResources = []string{"clusterroletemplatebindings", "nodes", "nodepools", "clusterevents", "projects", "clusterregistrationtokens", "clusterpipelines", "clusterloggings", "notifiers", "clusteralerts"}
+var clusterManagmentPlaneResources = []string{"clusterroletemplatebindings", "nodes", "nodepools", "clusterevents",
+	"projects", "clusterregistrationtokens", "clusterpipelines", "clusterloggings", "notifiers", "clusteralerts",
+	"podsecuritypolicytemplateprojectbindings"}
 
 type crtbLifecycle struct {
 	mgr           *manager


### PR DESCRIPTION
This change gives cluster owners the ability to set the project level PSPT for a given project in a cluster they are assigned to.  It accomplishes this by moving the PSPTPB into the cluster management plane where teh cluster owner already has * permissions.

Issue:
https://github.com/rancher/rancher/issues/12160
