### PR TITLE
Preventing inappropriate role binding deletion

### DIFF
--- a/pkg/controllers/user/rbac/podsecuritypolicy/binding.go
+++ b/pkg/controllers/user/rbac/podsecuritypolicy/binding.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const namespaceByProjectNameIndex = "something.something.namespace/by-project-name"
+const namespaceByProjectNameIndex = "podsecuritypolicy.rbac.user.cattle.io/by-project-name"
 
 // RegisterBindings updates the pod security policy for this binding if it has been changed.  Also resync service
 // accounts so they pick up the change.  If no policy exists then exits without doing anything.

--- a/pkg/controllers/user/rbac/podsecuritypolicy/template.go
+++ b/pkg/controllers/user/rbac/podsecuritypolicy/template.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const policyByPSPTParentAnnotationIndex = "something.something.pspt/parent-annotation"
-const clusterRoleByPSPTNameIndex = "something.something.psptpb/pspt-name"
+const policyByPSPTParentAnnotationIndex = "podsecuritypolicy.rbac.user.cattle.io/parent-annotation"
+const clusterRoleByPSPTNameIndex = "podsecuritypolicy.rbac.user.cattle.io/pspt-name"
 
 // RegisterTemplate propagates updates to pod security policy templates to their associated pod security policies.
 // Ignores pod security policy templates not assigned to a cluster or project.


### PR DESCRIPTION
This change prevents role bindings from being inappropriately deleted
when the logic to clean up PSPT related role bindings run.  Right now all existing role bindings are deleted, now only role bindings marked with a PSP annotation will be deleted.

Also cleaned up some bad annotation names.

Issue:
https://github.com/rancher/rancher/issues/12872