### PR TITLE
Fixing missing removal links

### DIFF
--- a/pkg/api/customization/podsecuritypolicytemplate/podsecuritypolicytemplate.go
+++ b/pkg/api/customization/podsecuritypolicytemplate/podsecuritypolicytemplate.go
@@ -87,7 +87,7 @@ type Format struct {
 
 func (f *Format) Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 	// check if PSPT is assigned to a cluster or project
-	projectsWithPSPT, err := f.ProjectIndexer.ByIndex(projectByPSPTKey, apiContext.ID)
+	projectsWithPSPT, err := f.ProjectIndexer.ByIndex(projectByPSPTKey, resource.ID)
 	if err != nil {
 		logrus.Warn("failed to determine if PSPT was assigned to a project: %v", err)
 		return
@@ -99,7 +99,7 @@ func (f *Format) Formatter(apiContext *types.APIContext, resource *types.RawReso
 		return
 	}
 
-	clustersWithPSPT, err := f.ClusterIndexer.ByIndex(clusterByPSPTKey, apiContext.ID)
+	clustersWithPSPT, err := f.ClusterIndexer.ByIndex(clusterByPSPTKey, resource.ID)
 	if err != nil {
 		logrus.Warnf("failed to determine if a PSPT was assigned to a cluster: %v", err)
 		return


### PR DESCRIPTION
This change fixes the missing remove links for PSPTs when all PSPTs are
queried at once.  Because the formatter was using the ID from the
apiContext argument instread of the resource argument, the formatter was
incorrectly showing PSPTs as being assigned to clusters and projects
that did not have PSPTs assigned.  This change fixes the formatter to use
the resource.ID instead.

Issue:
https://github.com/rancher/rancher/issues/12926