### PR TITLE
Fix logging issue

### DIFF
--- a/pkg/controllers/user/logging/generator/cluster_template.go
+++ b/pkg/controllers/user/logging/generator/cluster_template.go
@@ -1,6 +1,6 @@
 package generator
 
-var ClusterTemplate = `{{ if ne .clusterTarget.CurrentTarget "none" }}
+var ClusterTemplate = `{{ if .clusterTarget.CurrentTarget }}
 
 <source>
   @type  tail

--- a/pkg/controllers/user/logging/generator/project_template.go
+++ b/pkg/controllers/user/logging/generator/project_template.go
@@ -1,6 +1,7 @@
 package generator
 
 var ProjectTemplate = `{{range $i, $store := .projectTargets -}}
+{{ if $store.CurrentTarget }}
 <source>
    @type  tail
    path  /var/log/containers/*.log
@@ -43,7 +44,6 @@ var ProjectTemplate = `{{range $i, $store := .projectTargets -}}
   remove_keys namespace
 </filter>
 
-{{ if $store.CurrentTarget }}
 <match  {{$store.ProjectName}}.** project-custom.{{$store.ProjectName}}.**> 
     {{ if eq $store.CurrentTarget "elasticsearch"}}
     @type elasticsearch

--- a/pkg/controllers/user/logging/utils/wrap.go
+++ b/pkg/controllers/user/logging/utils/wrap.go
@@ -60,26 +60,13 @@ type WrapSyslog struct {
 }
 
 func (w *WrapClusterLogging) Validate() error {
-	wrapLogging, _, err := getWrapConfig(w.ElasticsearchConfig, w.SplunkConfig, w.SyslogConfig, w.KafkaConfig, w.EmbeddedConfig)
-	if err != nil {
-		return err
-	}
-
-	if wrapLogging.CurrentTarget == "" {
-		return fmt.Errorf("one of the target must set")
-	}
-	return nil
+	_, _, err := GetWrapConfig(w.ElasticsearchConfig, w.SplunkConfig, w.SyslogConfig, w.KafkaConfig, w.EmbeddedConfig)
+	return err
 }
 
 func (w *WrapProjectLogging) Validate() error {
-	wrapLogging, _, err := getWrapConfig(w.ElasticsearchConfig, w.SplunkConfig, w.SyslogConfig, w.KafkaConfig, nil)
-	if err != nil {
-		return err
-	}
-	if wrapLogging.CurrentTarget == "" {
-		return fmt.Errorf("one of the target must set")
-	}
-	return nil
+	_, _, err := GetWrapConfig(w.ElasticsearchConfig, w.SplunkConfig, w.SyslogConfig, w.KafkaConfig, nil)
+	return err
 }
 
 func ToWrapClusterLogging(clusterLogging v3.ClusterLoggingSpec) (*WrapClusterLogging, error) {
@@ -87,7 +74,7 @@ func ToWrapClusterLogging(clusterLogging v3.ClusterLoggingSpec) (*WrapClusterLog
 		ClusterLoggingSpec: clusterLogging,
 	}
 
-	wrapLogging, wem, err := getWrapConfig(clusterLogging.ElasticsearchConfig, clusterLogging.SplunkConfig, clusterLogging.SyslogConfig, clusterLogging.KafkaConfig, clusterLogging.EmbeddedConfig)
+	wrapLogging, wem, err := GetWrapConfig(clusterLogging.ElasticsearchConfig, clusterLogging.SplunkConfig, clusterLogging.SyslogConfig, clusterLogging.KafkaConfig, clusterLogging.EmbeddedConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +90,7 @@ func ToWrapProjectLogging(grepNamespace string, projectLogging v3.ProjectLogging
 		GrepNamespace:      grepNamespace,
 	}
 
-	wrapLogging, _, err := getWrapConfig(projectLogging.ElasticsearchConfig, projectLogging.SplunkConfig, projectLogging.SyslogConfig, projectLogging.KafkaConfig, nil)
+	wrapLogging, _, err := GetWrapConfig(projectLogging.ElasticsearchConfig, projectLogging.SplunkConfig, projectLogging.SyslogConfig, projectLogging.KafkaConfig, nil)
 
 	if err != nil {
 		return nil, err
@@ -112,7 +99,7 @@ func ToWrapProjectLogging(grepNamespace string, projectLogging v3.ProjectLogging
 	return &wp, nil
 }
 
-func getWrapConfig(es *v3.ElasticsearchConfig, sp *v3.SplunkConfig, sl *v3.SyslogConfig, kf *v3.KafkaConfig, em *v3.EmbeddedConfig) (wrapLogging WrapLogging, wem WrapEmbedded, err error) {
+func GetWrapConfig(es *v3.ElasticsearchConfig, sp *v3.SplunkConfig, sl *v3.SyslogConfig, kf *v3.KafkaConfig, em *v3.EmbeddedConfig) (wrapLogging WrapLogging, wem WrapEmbedded, err error) {
 	if es != nil {
 		var h, s string
 		h, s, err = parseEndpoint(es.Endpoint)
@@ -261,6 +248,19 @@ func GetClusterTarget(spec v3.ClusterLoggingSpec) string {
 	if spec.EmbeddedConfig != nil {
 		return "embedded"
 	} else if spec.ElasticsearchConfig != nil {
+		return "elasticsearch"
+	} else if spec.SplunkConfig != nil {
+		return "splunk"
+	} else if spec.KafkaConfig != nil {
+		return "kafka"
+	} else if spec.SyslogConfig != nil {
+		return "syslog"
+	}
+	return "none"
+}
+
+func GetProjectTarget(spec v3.ProjectLoggingSpec) string {
+	if spec.ElasticsearchConfig != nil {
 		return "elasticsearch"
 	} else if spec.SplunkConfig != nil {
 		return "splunk"

--- a/vendor.conf
+++ b/vendor.conf
@@ -28,7 +28,7 @@ github.com/aws/aws-sdk-go                     6755a29e78026d7435884fe490e08cc250
 github.com/heptio/authenticator               d282f87a19728018b67d80754bcb3e9b0457403f
 github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c68ea53b
 
-github.com/rancher/types                      71878a13b6cb20eac2f160c8927bc570119618fb
+github.com/rancher/types                      61843eab661836f692ac8423b25f1d7cd9b2bc07
 github.com/rancher/norman                     bde68141b66fc4607b224eebfd54555659926459
 github.com/rancher/kontainer-engine           ada765779be8019fdeafb034757c35885cd78dfa
 github.com/rancher/rke                        ff6c6dab2e0f3e2474aa59039758b18cea72f859

--- a/vendor/github.com/prometheus/client_model/.project
+++ b/vendor/github.com/prometheus/client_model/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>model</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/vendor/github.com/prometheus/client_model/bin/.project
+++ b/vendor/github.com/prometheus/client_model/bin/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>model</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema/schema.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema/schema.go
@@ -355,6 +355,7 @@ func projectNetworkPolicyTypes(schema *types.Schemas) *types.Schemas {
 func logTypes(schema *types.Schemas) *types.Schemas {
 	return schema.
 		AddMapperForType(&Version, v3.ClusterLogging{},
+			&m.Embed{Field: "status"},
 			m.DisplayName{}).
 		AddMapperForType(&Version, v3.ProjectLogging{},
 			m.DisplayName{}).

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_logging.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_logging.go
@@ -7,7 +7,9 @@ import (
 const (
 	ClusterLoggingType                      = "clusterLogging"
 	ClusterLoggingFieldAnnotations          = "annotations"
+	ClusterLoggingFieldAppliedSpec          = "appliedSpec"
 	ClusterLoggingFieldClusterId            = "clusterId"
+	ClusterLoggingFieldConditions           = "conditions"
 	ClusterLoggingFieldCreated              = "created"
 	ClusterLoggingFieldCreatorID            = "creatorId"
 	ClusterLoggingFieldElasticsearchConfig  = "elasticsearchConfig"
@@ -22,7 +24,6 @@ const (
 	ClusterLoggingFieldRemoved              = "removed"
 	ClusterLoggingFieldSplunkConfig         = "splunkConfig"
 	ClusterLoggingFieldState                = "state"
-	ClusterLoggingFieldStatus               = "status"
 	ClusterLoggingFieldSyslogConfig         = "syslogConfig"
 	ClusterLoggingFieldTransitioning        = "transitioning"
 	ClusterLoggingFieldTransitioningMessage = "transitioningMessage"
@@ -31,27 +32,28 @@ const (
 
 type ClusterLogging struct {
 	types.Resource
-	Annotations          map[string]string     `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	ClusterId            string                `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
-	Created              string                `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID            string                `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	ElasticsearchConfig  *ElasticsearchConfig  `json:"elasticsearchConfig,omitempty" yaml:"elasticsearchConfig,omitempty"`
-	EmbeddedConfig       *EmbeddedConfig       `json:"embeddedConfig,omitempty" yaml:"embeddedConfig,omitempty"`
-	KafkaConfig          *KafkaConfig          `json:"kafkaConfig,omitempty" yaml:"kafkaConfig,omitempty"`
-	Labels               map[string]string     `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Name                 string                `json:"name,omitempty" yaml:"name,omitempty"`
-	NamespaceId          string                `json:"namespaceId,omitempty" yaml:"namespaceId,omitempty"`
-	OutputFlushInterval  int64                 `json:"outputFlushInterval,omitempty" yaml:"outputFlushInterval,omitempty"`
-	OutputTags           map[string]string     `json:"outputTags,omitempty" yaml:"outputTags,omitempty"`
-	OwnerReferences      []OwnerReference      `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	Removed              string                `json:"removed,omitempty" yaml:"removed,omitempty"`
-	SplunkConfig         *SplunkConfig         `json:"splunkConfig,omitempty" yaml:"splunkConfig,omitempty"`
-	State                string                `json:"state,omitempty" yaml:"state,omitempty"`
-	Status               *ClusterLoggingStatus `json:"status,omitempty" yaml:"status,omitempty"`
-	SyslogConfig         *SyslogConfig         `json:"syslogConfig,omitempty" yaml:"syslogConfig,omitempty"`
-	Transitioning        string                `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
-	TransitioningMessage string                `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
-	Uuid                 string                `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Annotations          map[string]string    `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	AppliedSpec          *ClusterLoggingSpec  `json:"appliedSpec,omitempty" yaml:"appliedSpec,omitempty"`
+	ClusterId            string               `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
+	Conditions           []LoggingCondition   `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	Created              string               `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID            string               `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	ElasticsearchConfig  *ElasticsearchConfig `json:"elasticsearchConfig,omitempty" yaml:"elasticsearchConfig,omitempty"`
+	EmbeddedConfig       *EmbeddedConfig      `json:"embeddedConfig,omitempty" yaml:"embeddedConfig,omitempty"`
+	KafkaConfig          *KafkaConfig         `json:"kafkaConfig,omitempty" yaml:"kafkaConfig,omitempty"`
+	Labels               map[string]string    `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name                 string               `json:"name,omitempty" yaml:"name,omitempty"`
+	NamespaceId          string               `json:"namespaceId,omitempty" yaml:"namespaceId,omitempty"`
+	OutputFlushInterval  int64                `json:"outputFlushInterval,omitempty" yaml:"outputFlushInterval,omitempty"`
+	OutputTags           map[string]string    `json:"outputTags,omitempty" yaml:"outputTags,omitempty"`
+	OwnerReferences      []OwnerReference     `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Removed              string               `json:"removed,omitempty" yaml:"removed,omitempty"`
+	SplunkConfig         *SplunkConfig        `json:"splunkConfig,omitempty" yaml:"splunkConfig,omitempty"`
+	State                string               `json:"state,omitempty" yaml:"state,omitempty"`
+	SyslogConfig         *SyslogConfig        `json:"syslogConfig,omitempty" yaml:"syslogConfig,omitempty"`
+	Transitioning        string               `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+	TransitioningMessage string               `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
+	Uuid                 string               `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }
 type ClusterLoggingCollection struct {
 	types.Collection


### PR DESCRIPTION
Related issue： https://github.com/rancher/rancher/issues/13039
Roll back to use sync reason: we got problem when delete logging, it take time to do the finalized, and in the UI user could still see this CRD, so we change to When user want to disable just set all target to none, so we need to when whether we need to clean the fluent both in update and delete, use sync make it simple, so I roll back to sync and change logic allowed UI set all target to null
 Types https://github.com/rancher/types/pull/403