### PR TITLE
Default PSPTs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -137,5 +137,9 @@ func addData(management *config.ManagementContext, cfg Config) error {
 		return err
 	}
 
+	if err := addDefaultPodSecurityPolicyTemplates(management); err != nil {
+		return err
+	}
+
 	return addMachineDrivers(management)
 }

--- a/app/podsecuritypolicytemplate_data.go
+++ b/app/podsecuritypolicytemplate_data.go
@@ -1,0 +1,113 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const runAsAny = "RunAsAny"
+const mustRunAs = "MustRunAs"
+
+func addDefaultPodSecurityPolicyTemplates(management *config.ManagementContext) error {
+	pspts := management.Management.PodSecurityPolicyTemplates("")
+	policies := []*v3.PodSecurityPolicyTemplate{
+		{
+			ObjectMeta: v12.ObjectMeta{
+				Name: "unrestricted",
+			},
+			Spec: v1beta1.PodSecurityPolicySpec{
+				Privileged:               true,
+				AllowPrivilegeEscalation: toBoolPtr(true),
+				AllowedCapabilities: []v1.Capability{
+					"*",
+				},
+				Volumes: []v1beta1.FSType{
+					"*",
+				},
+				HostNetwork: true,
+				HostPorts: []v1beta1.HostPortRange{
+					{Min: 0, Max: 65535},
+				},
+				HostIPC: true,
+				HostPID: true,
+				RunAsUser: v1beta1.RunAsUserStrategyOptions{
+					Rule: runAsAny,
+				},
+				SELinux: v1beta1.SELinuxStrategyOptions{
+					Rule: runAsAny,
+				},
+				SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{
+					Rule: runAsAny,
+				},
+				FSGroup: v1beta1.FSGroupStrategyOptions{
+					Rule: runAsAny,
+				},
+			},
+			Description: "This is the default unrestricted Pod Security Policy Template.  It is the most permissive " +
+				"Pod Security Policy that can be created in Kubernetes and is equivalent to running Kubernetes " +
+				"without Pod Security Policies enabled.",
+		},
+		{
+			ObjectMeta: v12.ObjectMeta{
+				Name: "restricted",
+			},
+			Spec: v1beta1.PodSecurityPolicySpec{
+				Privileged:               false,
+				AllowPrivilegeEscalation: toBoolPtr(false),
+				RequiredDropCapabilities: []v1.Capability{
+					"ALL",
+				},
+				Volumes: []v1beta1.FSType{
+					"configMap",
+					"emptyDir",
+					"projected",
+					"secret",
+					"downwardAPI",
+					"persistentVolumeClaim",
+				},
+				HostNetwork: false,
+				HostIPC:     false,
+				HostPID:     false,
+				RunAsUser: v1beta1.RunAsUserStrategyOptions{
+					Rule: runAsAny,
+				},
+				SELinux: v1beta1.SELinuxStrategyOptions{
+					Rule: runAsAny,
+				},
+				SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{
+					Rule: mustRunAs,
+					Ranges: []v1beta1.IDRange{
+						{Min: 1, Max: 65535},
+					},
+				},
+				FSGroup: v1beta1.FSGroupStrategyOptions{
+					Rule: mustRunAs,
+					Ranges: []v1beta1.IDRange{
+						{Min: 1, Max: 65535},
+					},
+				},
+				ReadOnlyRootFilesystem: false,
+			},
+			Description: "This is the default restricted Pod Security Policy Template.  It restricts many user " +
+				"actions and does not allow privilege escalation.",
+		},
+	}
+	for _, policy := range policies {
+		_, err := pspts.Create(policy)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("error creating default pspt: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func toBoolPtr(boolean bool) *bool {
+	return &boolean
+}


### PR DESCRIPTION
This change adds default PSPTs for rancher.  It includes a "restricted"
and "unrestricted" PSPT.  The unrestricted PSPT is effectively the same
as having no PSP admissions controller enabled, while the "restricted"
PSPT prevents priviledge escalation and various other user actions.

Issue:
#12832