### PR TITLE
Better error handling for auth providers

### DIFF
--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -64,9 +64,14 @@ func AuthenticateUser(input interface{}, providerName string) (v3.Principal, []v
 
 func GetPrincipal(principalID string, myToken v3.Token) (v3.Principal, error) {
 	principal, err := providers[myToken.AuthProvider].GetPrincipal(principalID, myToken)
+
 	if err != nil && myToken.AuthProvider != localProvider {
-		principal, err = providers[localProvider].GetPrincipal(principalID, myToken)
+		p2, e2 := providers[localProvider].GetPrincipal(principalID, myToken)
+		if e2 == nil {
+			return p2, nil
+		}
 	}
+
 	return principal, err
 }
 


### PR DESCRIPTION
- Don't swallow error returned by auth provider when looking up principal
- Return a 404 when principal not found by AD
- Return a 500 APIError for all non-404 error responses so that the user sees
a generic error message but a detailed error is logged

Doesnt fully address https://github.com/rancher/rancher/issues/12622 but will give us better error logging to get to the bottom of the problem