### PR TITLE
Endpoints: Read labels from template spec, not deployment

### DIFF
--- a/pkg/controllers/user/endpoints/endpoints.go
+++ b/pkg/controllers/user/endpoints/endpoints.go
@@ -288,7 +288,7 @@ func getAllNodesPublicEndpointIP(machineLister managementv3.NodeLister, clusterN
 	return addresses[0].String(), nil
 }
 
-func convertIngressToServicePublicEndpointsMap(obj *extensionsv1beta1.Ingress, allNodes bool, allNodesIP string) (map[string][]v3.PublicEndpoint, error) {
+func convertIngressToServicePublicEndpointsMap(obj *extensionsv1beta1.Ingress, allNodes bool, allNodesIP string) map[string][]v3.PublicEndpoint {
 	var addresses []string
 	epsMap := map[string][]v3.PublicEndpoint{}
 	if !allNodes {
@@ -303,7 +303,7 @@ func convertIngressToServicePublicEndpointsMap(obj *extensionsv1beta1.Ingress, a
 	}
 
 	if len(addresses) == 0 {
-		return epsMap, nil
+		return epsMap
 	}
 
 	ports := map[int32]string{80: "HTTP", 443: "HTTPS"}
@@ -320,22 +320,18 @@ func convertIngressToServicePublicEndpointsMap(obj *extensionsv1beta1.Ingress, a
 					AllNodes:    allNodes,
 					IngressName: fmt.Sprintf("%s:%s", obj.Namespace, obj.Name),
 				}
-				v := epsMap[path.Backend.ServiceName]
-				epsMap[path.Backend.ServiceName] = append(v, p)
+				epsMap[path.Backend.ServiceName] = append(epsMap[path.Backend.ServiceName], p)
 			}
 		}
 	}
-	return epsMap, nil
+	return epsMap
 }
 
-func convertIngressToPublicEndpoints(obj *extensionsv1beta1.Ingress, isRKE bool, allNodesIP string) ([]v3.PublicEndpoint, error) {
-	epsMap, err := convertIngressToServicePublicEndpointsMap(obj, isRKE, allNodesIP)
-	if err != nil {
-		return nil, err
-	}
+func convertIngressToPublicEndpoints(obj *extensionsv1beta1.Ingress, isRKE bool, allNodesIP string) []v3.PublicEndpoint {
+	epsMap := convertIngressToServicePublicEndpointsMap(obj, isRKE, allNodesIP)
 	var eps []v3.PublicEndpoint
 	for _, v := range epsMap {
 		eps = append(eps, v...)
 	}
-	return eps, nil
+	return eps
 }

--- a/pkg/controllers/user/endpoints/ingress_endpoints.go
+++ b/pkg/controllers/user/endpoints/ingress_endpoints.go
@@ -38,14 +38,10 @@ func (c *IngressEndpointsController) reconcileEndpointsForIngress(obj *extension
 	if err != nil {
 		return false, err
 	}
-	fromObj, err := convertIngressToPublicEndpoints(obj, c.isRKE, allNodesIP)
-	if err != nil {
-		return false, err
-	}
+	fromObj := convertIngressToPublicEndpoints(obj, c.isRKE, allNodesIP)
+	fromAnnotation := getPublicEndpointsFromAnnotations(obj.Annotations)
 
-	fromAnnontation := getPublicEndpointsFromAnnotations(obj.Annotations)
-
-	if areEqualEndpoints(fromAnnontation, fromObj) {
+	if areEqualEndpoints(fromAnnotation, fromObj) {
 		return false, nil
 	}
 

--- a/pkg/controllers/user/endpoints/workload_endpoints.go
+++ b/pkg/controllers/user/endpoints/workload_endpoints.go
@@ -87,13 +87,9 @@ func (c *WorkloadEndpointsController) UpdateEndpoints(key string, obj *workloadu
 	// get ingress endpoint group by service
 	serviceToIngressEndpoints := make(map[string][]v3.PublicEndpoint)
 	for _, ingress := range ingresses {
-		epsMap, err := convertIngressToServicePublicEndpointsMap(ingress, c.isRKE, allNodesIP)
-		if err != nil {
-			return err
-		}
+		epsMap := convertIngressToServicePublicEndpointsMap(ingress, c.isRKE, allNodesIP)
 		for k, v := range epsMap {
-			eps := serviceToIngressEndpoints[k]
-			serviceToIngressEndpoints[k] = append(eps, v...)
+			serviceToIngressEndpoints[k] = append(serviceToIngressEndpoints[k], v...)
 		}
 	}
 
@@ -107,7 +103,7 @@ func (c *WorkloadEndpointsController) UpdateEndpoints(key string, obj *workloadu
 			}
 			selector := labels.SelectorFromSet(set)
 			found := false
-			if selector.Matches(labels.Set(w.Labels)) {
+			if selector.Matches(labels.Set(w.SelectorLabels)) {
 				// direct selector match
 				found = true
 			} else {


### PR DESCRIPTION
when match service to workload. Also some cleanup fixes for ingress