### PR TITLE
WIP: Fix rbac issue for notifer

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -122,7 +122,7 @@ func (c *crtbLifecycle) reconcilBindings(binding *v3.ClusterRoleTemplateBinding)
 		return err
 	}
 
-	err = c.mgr.grantManagementPlanePrivileges(binding.RoleTemplateName, clusterManagmentPlaneResources, subject, binding)
+	err = c.mgr.grantManagementPlanePrivileges(binding.RoleTemplateName, clusterManagmentPlaneResources, subject, binding, binding.Namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -366,7 +366,7 @@ func (m *manager) reconcileMembershipBindingForDelete(namespace, roleToKeep, rtb
 // Certain resources (projects, machines, prtbs, crtbs, clusterevents, etc) exist in the mangement plane but are scoped to clusters or
 // projects. They need special RBAC handling because the need to be authorized just inside of the namespace that backs the project
 // or cluster they belong to.
-func (m *manager) grantManagementPlanePrivileges(roleTemplateName string, resources []string, subject v1.Subject, binding interface{}) error {
+func (m *manager) grantManagementPlanePrivileges(roleTemplateName string, resources []string, subject v1.Subject, binding interface{}, namespace string) error {
 	bindingMeta, err := meta.Accessor(binding)
 	if err != nil {
 		return err
@@ -375,7 +375,6 @@ func (m *manager) grantManagementPlanePrivileges(roleTemplateName string, resour
 	if err != nil {
 		return err
 	}
-	namespace := bindingMeta.GetNamespace()
 
 	roles, err := m.gatherAndDedupeRoles(roleTemplateName)
 	if err != nil {


### PR DESCRIPTION
The notifier is cluster-scoped resource in mgmt server, and it should be accessed by user with project own. Addition logic is required to take case of this case. We will create a role and rolebinding in cluster
namespace for notifier.

Relate issues: https://github.com/rancher/rancher/issues/13066