### PR TITLE
Save REGISTRY var and load tar.gz directly into `docker load`

### DIFF
--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -63,8 +63,9 @@ if [ -z "$1" ]; then
 fi
 
 set -e -x
+REGISTRY=$1
 
-tar xvzf rancher-images.tar.gz | docker load
+docker load --input rancher-images.tar.gz
 
 `)
 


### PR DESCRIPTION
Seen this error too many times when using `tar xvzf | docker load`, while not seen when using `--input`

```
Error processing tar file(exit status 1): archive/tar: invalid tar header
```