### PR TITLE
Add Selector for ingress services when create

### DIFF
--- a/pkg/controllers/user/endpoints/workload_endpoints.go
+++ b/pkg/controllers/user/endpoints/workload_endpoints.go
@@ -103,7 +103,7 @@ func (c *WorkloadEndpointsController) UpdateEndpoints(key string, obj *workloadu
 			}
 			selector := labels.SelectorFromSet(set)
 			found := false
-			if selector.Matches(labels.Set(w.SelectorLabels)) {
+			if selector.Matches(labels.Set(w.SelectorLabels)) && !selector.Empty() {
 				// direct selector match
 				found = true
 			} else {

--- a/pkg/controllers/user/ingress/ingress.go
+++ b/pkg/controllers/user/ingress/ingress.go
@@ -3,9 +3,7 @@ package ingress
 import (
 	"context"
 	"encoding/json"
-
 	"strconv"
-
 	"strings"
 
 	"github.com/rancher/norman/types/convert"


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/13365
Add the service selector in its creation instead of
let `workloadServiceController` to add it.
This will make the service works more faster.