### PR TITLE
Protect role templates

### DIFF
--- a/pkg/api/customization/roletemplatebinding/validator.go
+++ b/pkg/api/customization/roletemplatebinding/validator.go
@@ -1,0 +1,54 @@
+package roletemplatebinding
+
+import (
+	"fmt"
+	"github.com/rancher/norman/httperror"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/client/management/v3"
+	"github.com/rancher/types/config"
+)
+
+func NewPRTBValidator(management *config.ScaledContext) types.Validator {
+	return newValidator(management, client.ProjectRoleTemplateBindingFieldRoleTemplateId)
+}
+
+func NewCRTBValidator(management *config.ScaledContext) types.Validator {
+	return newValidator(management, client.ClusterRoleTemplateBindingFieldRoleTemplateId)
+}
+
+func newValidator(management *config.ScaledContext, field string) types.Validator {
+	validator := &Validator{
+		roleTemplateLister: management.Management.RoleTemplates("").Controller().Lister(),
+		field:              field,
+	}
+
+	return validator.Validator
+}
+
+type Validator struct {
+	roleTemplateLister v3.RoleTemplateLister
+	field              string
+}
+
+func (v *Validator) Validator(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
+	return v.ValidateRoleTemplateBinding(data[v.field])
+}
+
+func (v *Validator) ValidateRoleTemplateBinding(obj interface{}) error {
+	roleTemplateID, ok := obj.(string)
+	if !ok {
+		return httperror.NewAPIError(httperror.MissingRequired, "Request does not have a valid roleTemplateId")
+	}
+
+	roleTemplate, err := v.roleTemplateLister.Get("", roleTemplateID)
+	if err != nil {
+		return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf("Error getting role template: %v", err))
+	}
+
+	if roleTemplate.Enabled != nil && !*roleTemplate.Enabled {
+		return httperror.NewAPIError(httperror.InvalidState, "Role is disabled and cannot be assigned")
+	}
+
+	return nil
+}

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/customization/pipeline"
 	"github.com/rancher/rancher/pkg/api/customization/podsecuritypolicytemplate"
 	projectaction "github.com/rancher/rancher/pkg/api/customization/project"
+	"github.com/rancher/rancher/pkg/api/customization/roletemplatebinding"
 	"github.com/rancher/rancher/pkg/api/customization/setting"
 	"github.com/rancher/rancher/pkg/api/store/cert"
 	"github.com/rancher/rancher/pkg/api/store/cluster"
@@ -98,6 +99,7 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	wg.Wait()
 
 	Clusters(schemas, apiContext, clusterManager, k8sProxy)
+	ClusterRoleTemplateBinding(schemas, apiContext)
 	Templates(schemas, apiContext)
 	TemplateVersion(schemas, apiContext)
 	User(schemas, apiContext)
@@ -112,6 +114,7 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	Alert(schemas, apiContext)
 	Pipeline(schemas, apiContext)
 	Project(schemas, apiContext)
+	ProjectRoleTemplateBinding(schemas, apiContext)
 	TemplateContent(schemas)
 	PodSecurityPolicyTemplate(schemas, apiContext)
 
@@ -404,10 +407,19 @@ func Project(schemas *types.Schemas, management *config.ScaledContext) {
 }
 
 func PodSecurityPolicyTemplate(schemas *types.Schemas, management *config.ScaledContext) {
-
 	schema := schemas.Schema(&managementschema.Version, client.PodSecurityPolicyTemplateType)
 	schema.Formatter = podsecuritypolicytemplate.NewFormatter(management)
 	schema.Store = &podsecuritypolicytemplate.Store{
 		Store: schema.Store,
 	}
+}
+
+func ClusterRoleTemplateBinding(schemas *types.Schemas, management *config.ScaledContext) {
+	schema := schemas.Schema(&managementschema.Version, client.ClusterRoleTemplateBindingType)
+	schema.Validator = roletemplatebinding.NewCRTBValidator(management)
+}
+
+func ProjectRoleTemplateBinding(schemas *types.Schemas, management *config.ScaledContext) {
+	schema := schemas.Schema(&managementschema.Version, client.ProjectRoleTemplateBindingType)
+	schema.Validator = roletemplatebinding.NewPRTBValidator(management)
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -28,7 +28,7 @@ github.com/aws/aws-sdk-go                     6755a29e78026d7435884fe490e08cc250
 github.com/heptio/authenticator               d282f87a19728018b67d80754bcb3e9b0457403f
 github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c68ea53b
 
-github.com/rancher/types                      43ea779caf23f6c56a29758d25ee92675a296926
+github.com/rancher/types                      d38912329a9f3f064101199fd89c80d73a2442cf
 github.com/rancher/norman                     b480586cfc8c714e399323d5cd00eb1bad2e400e
 github.com/rancher/kontainer-engine           f2ebaa027a6f5342f9735b9b8cf344f6c963046d
 github.com/rancher/rke                        2c64afeb3ebe0bf195ea0989c6767c27e52da295

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
@@ -73,14 +73,18 @@ type RoleTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	DisplayName       string              `json:"displayName,omitempty" norman:"required"`
-	Description       string              `json:"description"`
-	Rules             []rbacv1.PolicyRule `json:"rules,omitempty"`
-	Builtin           bool                `json:"builtin" norman:"nocreate,noupdate"`
-	External          bool                `json:"external"`
-	Hidden            bool                `json:"hidden"`
-	Context           string              `json:"context" norman:"type=string,options=project|cluster"`
-	RoleTemplateNames []string            `json:"roleTemplateNames,omitempty" norman:"type=array[reference[roleTemplate]]"`
+	DisplayName string              `json:"displayName,omitempty" norman:"required"`
+	Description string              `json:"description"`
+	Rules       []rbacv1.PolicyRule `json:"rules,omitempty"`
+	Builtin     bool                `json:"builtin" norman:"nocreate,noupdate"`
+	External    bool                `json:"external"`
+	Hidden      bool                `json:"hidden"`
+	// Enabled is a bool pointer so that it will be backwards compatible with previous versions of rancher. This field
+	// did not always exist. If it were a normal bool, old resources would default to false. With a pointer we can
+	// interpret the absence (nil) of the field to mean true.
+	Enabled           *bool    `json:"enabled,omitempty" norman:"type=boolean,default=true"`
+	Context           string   `json:"context" norman:"type=string,options=project|cluster"`
+	RoleTemplateNames []string `json:"roleTemplateNames,omitempty" norman:"type=array[reference[roleTemplate]]"`
 }
 
 type PodSecurityPolicyTemplate struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -5996,6 +5996,15 @@ func (in *RoleTemplate) DeepCopyInto(out *RoleTemplate) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Enabled != nil {
+		in, out := &in.Enabled, &out.Enabled
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	if in.RoleTemplateNames != nil {
 		in, out := &in.RoleTemplateNames, &out.RoleTemplateNames
 		*out = make([]string, len(*in))

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_role_template.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_role_template.go
@@ -12,6 +12,7 @@ const (
 	RoleTemplateFieldCreated         = "created"
 	RoleTemplateFieldCreatorID       = "creatorId"
 	RoleTemplateFieldDescription     = "description"
+	RoleTemplateFieldEnabled         = "enabled"
 	RoleTemplateFieldExternal        = "external"
 	RoleTemplateFieldHidden          = "hidden"
 	RoleTemplateFieldLabels          = "labels"
@@ -31,6 +32,7 @@ type RoleTemplate struct {
 	Created         string            `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID       string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	Description     string            `json:"description,omitempty" yaml:"description,omitempty"`
+	Enabled         *bool             `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	External        bool              `json:"external,omitempty" yaml:"external,omitempty"`
 	Hidden          bool              `json:"hidden,omitempty" yaml:"hidden,omitempty"`
 	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`


### PR DESCRIPTION
This change prevents any roles from being assigned via a CRTB or PRTB
when their parent roletemplate has the disabled field set to true.

Issue:
https://github.com/rancher/rancher/issues/13418

Depends on:
https://github.com/rancher/types/pull/425