### PR TITLE
Return given address if not dynamic

### DIFF
--- a/package/run.sh
+++ b/package/run.sh
@@ -25,7 +25,7 @@ get_address()
     # If given address is a network interface on the system, retrieve configured IP on that interface (only the first configured IP is taken)
     elif [ -n "$(find /sys/devices -name $address)" ]; then
         echo $(ip addr show dev $address | grep -w inet | awk '{print $2}' | cut -f1 -d/ | head -1)
-    # Loop through cloud provider options to get IP from metadata
+    # Loop through cloud provider options to get IP from metadata, if not found return given value
     else
         case $address in
             awslocal)
@@ -62,7 +62,7 @@ get_address()
                 echo $(curl -s https://api.ipify.org)
                 ;;
             *)
-                echo ""
+                echo $address
                 ;;
         esac
     fi


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/13495

Tested using:

```
--address 167.99.215.47 --internal-address 10.133.50.236 --etcd --controlplane --worker --debug

time="2018-05-15T19:07:55Z" level=info msg="Option customConfig=map[address:167.99.215.47 internalAddress:10.133.50.236 roles:[etcd worker controlplane]]"
```

```
--address eth0 --internal-address eth1 --etcd --controlplane --worker --debug

time="2018-05-15T19:09:19Z" level=info msg="Option customConfig=map[address:167.99.215.37 internalAddress:10.133.50.211 roles:[etcd worker controlplane]]"
```

```
--address dopublic --internal-address doprivate --etcd --controlplane --worker --debug

time="2018-05-15T19:10:44Z" level=info msg="Option customConfig=map[address:167.99.215.16 internalAddress:10.133.50.145 roles:[etcd worker controlplane]]"
```

```
No addresses configured

time="2018-05-15T19:13:56Z" level=info msg="Option customConfig=map[roles:[etcd worker controlplane] address:167.99.219.186 internalAddress:]"
```