### PR TITLE
Update vendor for kontainer-engine panic

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -30,7 +30,7 @@ github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c6
 
 github.com/rancher/types                      0189352f3ba9ae7b79adeda739aca3f768af1f48
 github.com/rancher/norman                     6a363d8e93fe7e566fa3506b6023866177d4ad7f
-github.com/rancher/kontainer-engine           f2ebaa027a6f5342f9735b9b8cf344f6c963046d
+github.com/rancher/kontainer-engine           6db89419e94a67a9e74913ac5fdc8b5164197a81
 github.com/rancher/rke                        80b88f9d32613cf76b56504b75c58b642ede620e
 
 gopkg.in/ldap.v2     v2.5.0

--- a/vendor/github.com/rancher/kontainer-engine/types/rpc_client.go
+++ b/vendor/github.com/rancher/kontainer-engine/types/rpc_client.go
@@ -36,7 +36,7 @@ func (rpc *grpcClient) Create(ctx context.Context, opts *DriverOptions, clusterI
 		ClusterInfo:   clusterInfo,
 	})
 	err = handlErr(err)
-	if o.CreateError != "" && err == nil {
+	if err == nil && o.CreateError != "" {
 		err = errors.New(o.CreateError)
 	}
 	return o, err


### PR DESCRIPTION
Update vendor for PR: https://github.com/rancher/kontainer-engine/pull/63