### PR TITLE
Modified `rancher/server:latest` in README

### DIFF
--- a/README_1_6.md
+++ b/README_1_6.md
@@ -8,9 +8,11 @@ Rancher is an open source project that provides a complete platform for operatin
 
 ## Latest Release
 
-* Beta - v1.6.17 - `rancher/server:latest` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v1.6.17).
+* Release candidate - v1.6.18-rc1 - `rancher/server:v1.6.18-rc1` - This is a release candidate, thus not suitable for a production environment.
 
-* Stable - v1.6.17 - `rancher/server:stable` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v1.6.17).
+* Stable - v1.6.17 - `rancher/server:v1.6.17` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v1.6.17).
+
+* ! Latest - v2.0.0 - `rancher/server:latest` - This version of Rancher is not backwards compatible. One should not carelessly upgrade their Rancher server from `v1.6` to `latest`. Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.0.0).
 
 To get automated notifications of our latest release, you can watch the announcements category in our [forums](http://forums.rancher.com/c/announcements), or subscribe to the RSS feed `https://forums.rancher.com/c/announcements.rss`.
 


### PR DESCRIPTION
The README file stated that `rancher/server:latest` is `v1.6.17` but this actually is `v2.0.0`.