### PR TITLE
Role not found fix

### DIFF
--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
-	"github.com/rancher/norman/clientbase"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/types/slice"
 	v13 "github.com/rancher/types/apis/core/v1"
@@ -545,7 +544,7 @@ func (m *manager) checkForManagementPlaneRules(role *v3.RoleTemplate, managmentP
 	var rules []v1.PolicyRule
 	if role.External {
 		externalRole, err := m.crLister.Get("", role.Name)
-		if err != nil && !clientbase.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			// dont error if it doesnt exist
 			return nil, err
 		}

--- a/pkg/controllers/user/rbac/prtb_handler.go
+++ b/pkg/controllers/user/rbac/prtb_handler.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/rancher/norman/clientbase"
 	"github.com/rancher/norman/types/slice"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
@@ -279,7 +278,7 @@ func (m *manager) checkForGlobalResourceRules(role *v3.RoleTemplate, resource st
 	var rules []rbacv1.PolicyRule
 	if role.External {
 		externalRole, err := m.crLister.Get("", role.Name)
-		if err != nil && !clientbase.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			// dont error if it doesnt exist
 			return nil, err
 		}

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -21,7 +21,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: cattle
+  name: cattle-admin-binding
   namespace: cattle-system
 subjects:
 - kind: ServiceAccount
@@ -29,7 +29,7 @@ subjects:
   namespace: cattle-system
 roleRef:
   kind: ClusterRole
-  name: cluster-admin
+  name: cattle-admin
   apiGroup: rbac.authorization.k8s.io
 
 ---
@@ -43,6 +43,24 @@ type: Opaque
 data:
   url: "{{.URL}}"
   token: "{{.Token}}"
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cattle-admin
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'
 
 ---
 


### PR DESCRIPTION
This change corrects an incorrect expression that was supposed to check
if a role was not found but was not, and caused an error to appear in the
logs.

It also adds a new `cattle-admin` role to the default import template so clusters without `cluster-admin` can be imported successfully.

Issue:
https://github.com/rancher/rancher/issues/13196
https://github.com/rancher/rancher/issues/13642
