### PR TITLE
Refactor to use new lock

### DIFF
--- a/pkg/api/customization/roletemplatebinding/validator.go
+++ b/pkg/api/customization/roletemplatebinding/validator.go
@@ -46,8 +46,8 @@ func (v *Validator) ValidateRoleTemplateBinding(obj interface{}) error {
 		return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf("Error getting role template: %v", err))
 	}
 
-	if roleTemplate.Enabled != nil && !*roleTemplate.Enabled {
-		return httperror.NewAPIError(httperror.InvalidState, "Role is disabled and cannot be assigned")
+	if roleTemplate.Locked {
+		return httperror.NewAPIError(httperror.InvalidState, "Role is locked and cannot be assigned")
 	}
 
 	return nil

--- a/vendor.conf
+++ b/vendor.conf
@@ -28,7 +28,7 @@ github.com/aws/aws-sdk-go                     6755a29e78026d7435884fe490e08cc250
 github.com/heptio/authenticator               d282f87a19728018b67d80754bcb3e9b0457403f
 github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c68ea53b
 
-github.com/rancher/types                      e4d6a30f09245d89624f95f08fc5458fe22aa766
+github.com/rancher/types                      099a69bb5a2f7051c2343c0d95b5bbe61e9f2d23
 github.com/rancher/norman                     6a363d8e93fe7e566fa3506b6023866177d4ad7f
 github.com/rancher/kontainer-engine           6db89419e94a67a9e74913ac5fdc8b5164197a81
 github.com/rancher/rke                        c3ba406fdd9a5f3a07ea89c4e5e211f145def2b6

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
@@ -73,18 +73,15 @@ type RoleTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	DisplayName string              `json:"displayName,omitempty" norman:"required"`
-	Description string              `json:"description"`
-	Rules       []rbacv1.PolicyRule `json:"rules,omitempty"`
-	Builtin     bool                `json:"builtin" norman:"nocreate,noupdate"`
-	External    bool                `json:"external"`
-	Hidden      bool                `json:"hidden"`
-	// Enabled is a bool pointer so that it will be backwards compatible with previous versions of rancher. This field
-	// did not always exist. If it were a normal bool, old resources would default to false. With a pointer we can
-	// interpret the absence (nil) of the field to mean true.
-	Enabled           *bool    `json:"enabled,omitempty" norman:"type=boolean,default=true"`
-	Context           string   `json:"context" norman:"type=string,options=project|cluster"`
-	RoleTemplateNames []string `json:"roleTemplateNames,omitempty" norman:"type=array[reference[roleTemplate]]"`
+	DisplayName       string              `json:"displayName,omitempty" norman:"required"`
+	Description       string              `json:"description"`
+	Rules             []rbacv1.PolicyRule `json:"rules,omitempty"`
+	Builtin           bool                `json:"builtin" norman:"nocreate,noupdate"`
+	External          bool                `json:"external"`
+	Hidden            bool                `json:"hidden"`
+	Locked            bool                `json:"locked,omitempty" norman:"type=boolean"`
+	Context           string              `json:"context" norman:"type=string,options=project|cluster"`
+	RoleTemplateNames []string            `json:"roleTemplateNames,omitempty" norman:"type=array[reference[roleTemplate]]"`
 }
 
 type PodSecurityPolicyTemplate struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -6058,15 +6058,6 @@ func (in *RoleTemplate) DeepCopyInto(out *RoleTemplate) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Enabled != nil {
-		in, out := &in.Enabled, &out.Enabled
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
-	}
 	if in.RoleTemplateNames != nil {
 		in, out := &in.RoleTemplateNames, &out.RoleTemplateNames
 		*out = make([]string, len(*in))

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_role_template.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_role_template.go
@@ -12,10 +12,10 @@ const (
 	RoleTemplateFieldCreated         = "created"
 	RoleTemplateFieldCreatorID       = "creatorId"
 	RoleTemplateFieldDescription     = "description"
-	RoleTemplateFieldEnabled         = "enabled"
 	RoleTemplateFieldExternal        = "external"
 	RoleTemplateFieldHidden          = "hidden"
 	RoleTemplateFieldLabels          = "labels"
+	RoleTemplateFieldLocked          = "locked"
 	RoleTemplateFieldName            = "name"
 	RoleTemplateFieldOwnerReferences = "ownerReferences"
 	RoleTemplateFieldRemoved         = "removed"
@@ -32,10 +32,10 @@ type RoleTemplate struct {
 	Created         string            `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID       string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	Description     string            `json:"description,omitempty" yaml:"description,omitempty"`
-	Enabled         *bool             `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	External        bool              `json:"external,omitempty" yaml:"external,omitempty"`
 	Hidden          bool              `json:"hidden,omitempty" yaml:"hidden,omitempty"`
 	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Locked          bool              `json:"locked,omitempty" yaml:"locked,omitempty"`
 	Name            string            `json:"name,omitempty" yaml:"name,omitempty"`
 	OwnerReferences []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
 	Removed         string            `json:"removed,omitempty" yaml:"removed,omitempty"`


### PR DESCRIPTION
Refactor to use new `lock` over `enabled` for protection of role templates.

Issue:
https://github.com/rancher/rancher/issues/13574