### PR TITLE
Update vendor for AKS update

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -30,7 +30,7 @@ github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c6
 
 github.com/rancher/types                      a9d03a296696dd6d5bfdea562d34782c93321044
 github.com/rancher/norman                     79b91ea33c9ce18094018b26e86fa2577cac2bdd
-github.com/rancher/kontainer-engine           6db89419e94a67a9e74913ac5fdc8b5164197a81
+github.com/rancher/kontainer-engine           032917c69ba22ff22031caa50a6eedbca4439d09
 github.com/rancher/rke                        d909253640f2f524fbe234f60085ccafa2b716a4
 
 gopkg.in/ldap.v2     v2.5.0

--- a/vendor/github.com/rancher/kontainer-engine/drivers/aks/aks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/aks/aks_driver.go
@@ -333,8 +333,15 @@ const updatingStatus = "Updating"
 
 const pollInterval = 30
 
-// Create implements driver interface
 func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *types.ClusterInfo) (*types.ClusterInfo, error) {
+	return d.createOrUpdate(ctx, options)
+}
+
+func (d *Driver) Update(ctx context.Context, info *types.ClusterInfo, options *types.DriverOptions) (*types.ClusterInfo, error) {
+	return d.createOrUpdate(ctx, options)
+}
+
+func (d *Driver) createOrUpdate(ctx context.Context, options *types.DriverOptions) (*types.ClusterInfo, error) {
 	driverState, err := getStateFromOptions(options)
 	if err != nil {
 		return nil, err
@@ -519,12 +526,6 @@ func getState(info *types.ClusterInfo) (state, error) {
 	}
 
 	return state, err
-}
-
-// Update implements driver interface
-func (d *Driver) Update(ctx context.Context, info *types.ClusterInfo, options *types.DriverOptions) (*types.ClusterInfo, error) {
-	// todo: implement
-	return nil, fmt.Errorf("not implemented")
 }
 
 func (d *Driver) GetVersion(ctx context.Context, info *types.ClusterInfo) (*types.KubernetesVersion, error) {
@@ -781,7 +782,6 @@ func (d *Driver) PostCheck(ctx context.Context, info *types.ClusterInfo) (*types
 	return info, nil
 }
 
-// Remove implements driver interface
 func (d *Driver) Remove(ctx context.Context, info *types.ClusterInfo) error {
 	state, err := getState(info)
 


### PR DESCRIPTION
Update vendor for adding AKS update capability.

Depends on:
https://github.com/rancher/kontainer-engine/pull/64

Issue:
https://github.com/rancher/rancher/issues/13199