### PR TITLE
Add dynamic DNS

### DIFF
--- a/pkg/controllers/user/approuter/approuter.go
+++ b/pkg/controllers/user/approuter/approuter.go
@@ -1,0 +1,21 @@
+package approuter
+
+import (
+	"context"
+	"github.com/rancher/types/config"
+)
+
+func Register(ctx context.Context, cluster *config.UserContext) {
+	secrets := cluster.Management.Core.Secrets("")
+	secretLister := cluster.Management.Core.Secrets("").Controller().Lister()
+	workload := cluster.UserOnlyContext()
+	c := &Controller{
+		ingressInterface:       workload.Extensions.Ingresses(""),
+		ingressLister:          workload.Extensions.Ingresses("").Controller().Lister(),
+		dnsClient:              NewClient(secrets, secretLister, workload.ClusterName),
+		clusterName:            workload.ClusterName,
+		managementSecretLister: secretLister,
+	}
+	workload.Extensions.Ingresses("").AddHandler("approuterController", c.sync)
+	go c.renew(ctx)
+}

--- a/pkg/controllers/user/approuter/core_dns_client.go
+++ b/pkg/controllers/user/approuter/core_dns_client.go
@@ -1,0 +1,290 @@
+package approuter
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"sort"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/rdns-server/model"
+	"github.com/rancher/types/apis/core/v1"
+	"github.com/sirupsen/logrus"
+	k8scorev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	contentType     = "Content-Type"
+	jsonContentType = "application/json"
+	secretKey       = "rdns-token"
+)
+
+func jsonBody(payload interface{}) (io.Reader, error) {
+	buf := &bytes.Buffer{}
+	err := json.NewEncoder(buf).Encode(payload)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+type Client struct {
+	httpClient             *http.Client
+	base                   string
+	lock                   *sync.RWMutex
+	managementSecretLister v1.SecretLister
+	secrets                v1.SecretInterface
+	clusterName            string
+}
+
+func (c *Client) request(method string, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add(contentType, jsonContentType)
+
+	return req, nil
+}
+
+func (c *Client) do(req *http.Request) (model.Response, error) {
+	var data model.Response
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return data, err
+	}
+	// when err is nil, resp contains a non-nil resp.Body which must be closed
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return data, errors.Wrap(err, "Read response body error")
+	}
+
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return data, errors.Wrap(err, "Decode response error")
+	}
+	logrus.Debugf("Got response entry: %+v", data)
+	if code := resp.StatusCode; code < 200 || code > 300 {
+		if data.Message != "" {
+			return data, errors.Errorf("Got request error: %s", data.Message)
+		}
+	}
+
+	return data, nil
+}
+
+func (c *Client) ApplyDomain(hosts []string) (string, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	d, err := c.GetDomain()
+	if err != nil {
+		return "", err
+	}
+
+	if d == nil {
+		logrus.Debugf("Fqdn configuration has not been exist, need to create a new one")
+		return c.CreateDomain(hosts)
+	}
+
+	sort.Strings(d.Hosts)
+	sort.Strings(hosts)
+	if !reflect.DeepEqual(d.Hosts, hosts) {
+		logrus.Debugf("Fqdn %s has some changes, need to update", d.Fqdn)
+		return c.UpdateDomain(hosts)
+	}
+	logrus.Debugf("Fqdn %s has no changes, no need to update", d.Fqdn)
+
+	return "", nil
+}
+
+func (c *Client) GetDomain() (d *model.Domain, err error) {
+	fqdn, _, err := c.getSecret()
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "GetDomain: fail to get stored secret")
+	}
+
+	url := fmt.Sprintf("%s/domain/%s", c.base, fqdn)
+	req, err := c.request(http.MethodGet, url, nil)
+	if err != nil {
+		return d, errors.Wrap(err, "GetDomain: failed to build a request")
+	}
+
+	o, err := c.do(req)
+	if err != nil {
+		return d, errors.Wrap(err, "GetDomain: failed to execute a request")
+	}
+
+	return &o.Data, nil
+}
+
+func (c *Client) CreateDomain(hosts []string) (string, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	url := fmt.Sprintf("%s/domain", c.base)
+	body, err := jsonBody(&model.DomainOptions{Hosts: hosts})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := c.request(http.MethodPost, url, body)
+	if err != nil {
+		return "", errors.Wrap(err, "CreateDomain: failed to build a request")
+	}
+
+	resp, err := c.do(req)
+	if err != nil {
+		return "", errors.Wrap(err, "CreateDomain: failed to execute a request")
+	}
+
+	//to find token in management cluster namespace
+	if _, _, err = c.getSecret(); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return "", err
+		}
+		//if token not found, create a new one
+		if err = c.setSecret(&resp); err != nil {
+			return "", err
+		}
+	}
+
+	return resp.Data.Fqdn, err
+}
+
+func (c *Client) UpdateDomain(hosts []string) (string, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	fqdn, token, err := c.getSecret()
+	if err != nil {
+		return "", errors.Wrap(err, "DeleteDomain: fail to get stored secret")
+	}
+
+	url := fmt.Sprintf("%s/domain/%s", c.base, fqdn)
+	body, err := jsonBody(&model.DomainOptions{Hosts: hosts})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := c.request(http.MethodPut, url, body)
+	if err != nil {
+		return "", errors.Wrap(err, "UpdateDomain: failed to build a request")
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	_, err = c.do(req)
+	if err != nil {
+		return "", errors.Wrap(err, "UpdateDomain: failed to execute a request")
+	}
+
+	return fqdn, nil
+}
+
+func (c *Client) DeleteDomain() (string, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	fqdn, token, err := c.getSecret()
+	if err != nil {
+		return "", errors.Wrap(err, "DeleteDomain: fail to get stored secret")
+	}
+
+	url := fmt.Sprintf("%s/domain/%s", c.base, fqdn)
+	req, err := c.request(http.MethodDelete, url, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "DeleteDomain: failed to build a request")
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	_, err = c.do(req)
+	if err != nil {
+		return "", errors.Wrap(err, "DeleteDomain: failed to execute a request")
+	}
+
+	return fqdn, err
+}
+
+func (c *Client) RenewDomain() (string, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	fqdn, token, err := c.getSecret()
+	if err != nil {
+		return "", errors.Wrap(err, "RenewDomain: fail to get stored secret")
+	}
+
+	url := fmt.Sprintf("%s/domain/%s/renew", c.base, fqdn)
+	req, err := c.request(http.MethodPut, url, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "RenewDomain: failed to build a request")
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	_, err = c.do(req)
+	if err != nil {
+		return "", errors.Wrap(err, "RenewDomain: failed to execute a request")
+	}
+
+	return fqdn, err
+}
+
+func (c *Client) GetBaseURL() string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.base
+}
+
+func (c *Client) SetBaseURL(base string) {
+	c.base = base
+}
+
+func (c *Client) setSecret(resp *model.Response) error {
+	_, err := c.secrets.Create(&k8scorev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretKey,
+			Namespace: c.clusterName,
+		},
+		Type: k8scorev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			"token": resp.Token,
+			"fqdn":  resp.Data.Fqdn,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//getSecret return token and fqdn
+func (c *Client) getSecret() (string, string, error) {
+	sec, err := c.managementSecretLister.Get(c.clusterName, secretKey)
+	if err != nil {
+		return "", "", err
+	}
+	return string(sec.Data["fqdn"]), string(sec.Data["token"]), nil
+}
+
+func NewClient(secrets v1.SecretInterface, secretLister v1.SecretLister, clusterName string) *Client {
+	return &Client{
+		httpClient:             http.DefaultClient,
+		lock:                   &sync.RWMutex{},
+		secrets:                secrets,
+		managementSecretLister: secretLister,
+		clusterName:            clusterName,
+	}
+}

--- a/pkg/controllers/user/approuter/ingress_controller.go
+++ b/pkg/controllers/user/approuter/ingress_controller.go
@@ -1,0 +1,175 @@
+package approuter
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/rancher/pkg/ticker"
+	"github.com/rancher/types/apis/core/v1"
+	"github.com/rancher/types/apis/extensions/v1beta1"
+	"github.com/sirupsen/logrus"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"strings"
+)
+
+const (
+	annotationHostname        = "rdns.cattle.io/hostname"
+	annotationIngressClass    = "kubernetes.io/ingress.class"
+	ingressClassNginx         = "nginx"
+	refreshIngressHostnameKey = "_refreshRDNSHostname_"
+	RdnsIPDomain              = "lb.rancher.cloud"
+)
+
+var (
+	renewInterval = 24 * time.Hour
+	ips           []string
+)
+
+type Controller struct {
+	ctx                    context.Context
+	ingressInterface       v1beta1.IngressInterface
+	ingressLister          v1beta1.IngressLister
+	managementSecretLister v1.SecretLister
+	clusterName            string
+	dnsClient              *Client
+}
+
+func isGeneratedDomain(obj *extensionsv1beta1.Ingress, host, domain string) bool {
+	parts := strings.Split(host, ".")
+	return strings.HasSuffix(host, "."+domain) && len(parts) == 6 && parts[1] == obj.Namespace
+}
+
+func (c *Controller) sync(key string, obj *extensionsv1beta1.Ingress) error {
+	//will not do clean if domain setting is cleaned
+	serverURL := settings.RDNSServerBaseURL.Get()
+	if serverURL == "" {
+		logrus.Warnf("settings.baseRDNSServerURL is not set, dns name might not be reachable")
+	}
+
+	for _, status := range obj.Status.LoadBalancer.Ingress {
+		if status.IP != "" {
+			ips = append(ips, status.IP)
+		}
+	}
+
+	if serverURL != c.dnsClient.GetBaseURL() {
+		c.dnsClient.SetBaseURL(serverURL)
+	}
+
+	fqdn, err := c.dnsClient.ApplyDomain(ips)
+	if err != nil {
+		logrus.WithError(err).Errorf("update fqdn [%s] to server [%s] error", fqdn, serverURL)
+		return err
+	}
+
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+
+	if key == refreshIngressHostnameKey {
+		return c.refreshAll(fqdn)
+	}
+	return c.refresh(fqdn, obj)
+
+}
+
+func (c *Controller) refresh(rootDomain string, obj *extensionsv1beta1.Ingress) error {
+	if obj.ObjectMeta.DeletionTimestamp != nil {
+		return nil
+	}
+	if obj.Annotations == nil {
+		obj.Annotations = make(map[string]string)
+	}
+	hostname := obj.Annotations[annotationHostname]
+	targetHostname := ""
+	switch obj.Annotations[annotationIngressClass] {
+	case "": // nginx as default
+		fallthrough
+	case ingressClassNginx:
+		targetHostname = c.getRdnsHostname(obj, rootDomain)
+	default:
+		return nil
+	}
+	if hostname == targetHostname {
+		return nil
+	}
+
+	ipDomain := settings.IngressIPDomain.Get()
+	if ipDomain == "" {
+		return nil
+	}
+
+	changed := false
+	for _, rule := range obj.Spec.Rules {
+		if isGeneratedDomain(obj, rule.Host, ipDomain) || rule.Host == ipDomain && ipDomain == RdnsIPDomain {
+			changed = true
+			break
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	newObj := obj.DeepCopy()
+	newObj.Annotations[annotationHostname] = targetHostname
+
+	// Also need to update rules for hostname when using nginx
+	for i, rule := range newObj.Spec.Rules {
+		logrus.Debugf("Got ingress resource hostname: %s", rule.Host)
+		if strings.HasSuffix(rule.Host, ipDomain) {
+			newObj.Spec.Rules[i].Host = targetHostname
+		}
+	}
+
+	if _, err := c.ingressInterface.Update(newObj); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Controller) refreshAll(rootDomain string) error {
+	ingresses, err := c.ingressLister.List("", labels.NewSelector())
+	if err != nil {
+		return err
+	}
+	for _, obj := range ingresses {
+		if err = c.refresh(rootDomain, obj); err != nil {
+			logrus.WithError(err).Errorf("refresh ingress %s:%s hostname annotation error", obj.Namespace, obj.Name)
+		}
+	}
+	return nil
+}
+
+func (c *Controller) getRdnsHostname(obj *extensionsv1beta1.Ingress, rootDomain string) string {
+	return fmt.Sprintf("%s.%s.%s", obj.Name, obj.Namespace, rootDomain)
+}
+
+//getSecret return token and fqdn
+func (c *Controller) getSecret() (string, string, error) {
+	sec, err := c.managementSecretLister.Get(c.clusterName, secretKey)
+	if err != nil {
+		return "", "", err
+	}
+	return string(sec.Data["token"]), string(sec.Data["fqdn"]), nil
+}
+
+func (c *Controller) renew(ctx context.Context) {
+	for range ticker.Context(ctx, renewInterval) {
+		serverURL := settings.RDNSServerBaseURL.Get()
+		if serverURL == "" { //rootDomain and serverURL need to be set when enable rdns controller
+			return
+		}
+		if serverURL != c.dnsClient.GetBaseURL() {
+			c.dnsClient.SetBaseURL(serverURL)
+		}
+		if fqdn, err := c.dnsClient.RenewDomain(); err != nil {
+			logrus.WithError(err).Errorf("renew fqdn [%s] to server [%s] error", fqdn, serverURL)
+		}
+	}
+}

--- a/pkg/controllers/user/controllers.go
+++ b/pkg/controllers/user/controllers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rancher/rancher/pkg/controllers/management/compose/common"
 	"github.com/rancher/rancher/pkg/controllers/user/alert"
+	"github.com/rancher/rancher/pkg/controllers/user/approuter"
 	"github.com/rancher/rancher/pkg/controllers/user/dnsrecord"
 	"github.com/rancher/rancher/pkg/controllers/user/endpoints"
 	"github.com/rancher/rancher/pkg/controllers/user/externalservice"
@@ -48,6 +49,7 @@ func Register(ctx context.Context, cluster *config.UserContext, kubeConfigGetter
 	endpoints.Register(ctx, cluster)
 	usercompose.Register(cluster, kubeConfigGetter)
 	namespacecompose.Register(cluster, kubeConfigGetter)
+	approuter.Register(ctx, cluster)
 
 	userOnlyContext := cluster.UserOnlyContext()
 	dnsrecord.Register(ctx, userOnlyContext)

--- a/pkg/controllers/user/ingresshostgen/ingresshostgen.go
+++ b/pkg/controllers/user/ingresshostgen/ingresshostgen.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rancher/rancher/pkg/controllers/user/approuter"
 	"github.com/rancher/rancher/pkg/settings"
 	v1beta12 "github.com/rancher/types/apis/extensions/v1beta1"
 	"github.com/rancher/types/config"
@@ -50,7 +51,7 @@ func (i *IngressHostGen) sync(key string, obj *v1beta1.Ingress) error {
 
 	changed := false
 	for _, rule := range obj.Spec.Rules {
-		if (isGeneratedDomain(obj, rule.Host, ipDomain) || rule.Host == ipDomain) && rule.Host != xipHost {
+		if (isGeneratedDomain(obj, rule.Host, ipDomain) || rule.Host == ipDomain) && rule.Host != xipHost && ipDomain != approuter.RdnsIPDomain {
 			changed = true
 			break
 		}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -37,6 +37,7 @@ var (
 	UIPath                          = newSetting("ui-path", "")
 	UIPL                            = newSetting("ui-pl", "rancher")
 	WhitelistDomain                 = newSetting("whitelist-domain", "forums.rancher.com")
+	RDNSServerBaseURL               = newSetting("rdns-base-url", "http://api.lb.rancher.cloud/v1")
 )
 
 type Provider interface {


### PR DESCRIPTION
Automatically acquire node-ip and achieve ingress controller load balance.
Regular synchronize ingress resource which takes "lb.rancher.cloud" as "rule.Host" suffix.