### PR TITLE
fix project member access to notifier/clusterPipeline

### DIFF
--- a/app/role_data.go
+++ b/app/role_data.go
@@ -126,6 +126,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("*").resources("storageclasses").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("persistentvolumeclaims").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("clusterpipelines").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("pipelines").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("pipelineexecutions").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("pipelineexecutionlogs").verbs("*").
@@ -142,6 +143,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("*").resources("storageclasses").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("persistentvolumeclaims").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("clusterpipelines").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("pipelines").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("pipelineexecutions").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("pipelineexecutionlogs").verbs("*").
@@ -157,6 +159,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("*").resources("storageclasses").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("persistentvolumeclaims").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("clusterpipelines").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("pipelines").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("pipelineexecutions").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("pipelineexecutionlogs").verbs("get", "list", "watch").

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -14,6 +14,7 @@ const (
 	clusterResource           = "clusters"
 	membershipBindingOwner    = "memberhsip-binding-owner"
 	crtbInProjectBindingOwner = "crtb-in-project-binding-owner"
+	prtbInClusterBindingOwner = "prtb-in-cluster-binding-owner"
 	rbByOwnerIndex            = "auth.management.cattle.io/rb-by-owner"
 	rbByRoleAndSubjectIndex   = "auth.management.cattle.io/crb-by-role-and-subject"
 )

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -13,6 +13,7 @@ const (
 )
 
 var projectManagmentPlaneResources = []string{"projectroletemplatebindings", "apps", "secrets", "pipelines", "pipelineexecutions", "pipelineexecutionlogs", "projectloggings", "projectalerts"}
+var prtbClusterManagmentPlaneResources = []string{"notifiers", "clusterpipelines"}
 
 type prtbLifecycle struct {
 	mgr           *manager
@@ -123,6 +124,8 @@ func (p *prtbLifecycle) reconcileBindings(binding *v3.ProjectRoleTemplateBinding
 	if err := p.mgr.ensureClusterMembershipBinding(roleName, string(binding.UID), cluster, false, subject); err != nil {
 		return err
 	}
-
+	if err := p.mgr.grantManagementProjectScopedPrivilegesInClusterNamespace(binding.RoleTemplateName, proj.Namespace, prtbClusterManagmentPlaneResources, subject, binding); err != nil {
+		return err
+	}
 	return p.mgr.grantManagementPlanePrivileges(binding.RoleTemplateName, projectManagmentPlaneResources, subject, binding)
 }


### PR DESCRIPTION
Add support to grant project-scoped privileges in cluster namespace.
For certain resources(notifier,clusterpipeline), they exist in cluster namespace but want to be shared in projects.
Fix: 
https://github.com/rancher/rancher/issues/13543
https://github.com/rancher/rancher/issues/13643