### PR TITLE
Add the --no-cacerts flag to recognizedCA templates

### DIFF
--- a/rke-templates/3-node-certificate-recognizedca.yml
+++ b/rke-templates/3-node-certificate-recognizedca.yml
@@ -106,6 +106,8 @@ addons: |-
         serviceAccountName: cattle-admin
         containers:
         - image: rancher/rancher:latest
+          args:
+          - --no-cacerts
           imagePullPolicy: Always
           name: cattle-server
           ports:

--- a/rke-templates/3-node-externalssl-recognizedca.yml
+++ b/rke-templates/3-node-externalssl-recognizedca.yml
@@ -89,6 +89,8 @@ addons: |-
         serviceAccountName: cattle-admin
         containers:
         - image: rancher/rancher:latest
+          args:
+          - --no-cacerts
           imagePullPolicy: Always
           name: cattle-server
           ports:


### PR DESCRIPTION
Without this flag, when an external load balancer is used with a certificate signed by a recognized CA, the ca-cert is not cleared up upon installation/upgrade. It leads to issues with getting correct kubectl configuration files in the UI and incorrect command lines generated to add nodes to custom clusters (and may lead to new nodes in other kind of clusters to fail being provisioned)