### PR TITLE
Added documentation for developers. Initial commit: debugging rancher 2.

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,4 @@
+# Developing for Rancher 2.x
+
+Here you will find information about how to develop for **Rancher 2.x**. We'd like to invite you all to contribute to the documentation for developers.
+

--- a/documentation/debugging/README.md
+++ b/documentation/debugging/README.md
@@ -1,0 +1,225 @@
+# How to set up a debugging environment for Rancher 2.x
+It took me some time to find out, how a good debugging workflow for rancher 2.x would look like.
+
+I had several problems: At first I tried to create a debug session with Visual Studio Code: I had lots of performance issues with that.
+
+Also I had the problem that after the first successful connection to delve, it was unresponsive, after I restarted the debug session. I had to write scripts which kill delve and the rancher process before a new delve process could be started. And so on...
+
+But this process here should work rather good. Give me feedback, if you find errors or have improvement tips for me, please.
+
+## Content
+1 [Prerequisites](#prerequisites)<br>
+2 [Install GOLAND IDE](#install-goland-ide)<br>
+3 [Create build settings and build with GOLAND](#create-build-settings-and-build-rancher-with-goland)<br>
+4 [Create debug container](#create-debug-container)<br>
+5 [Configure GOLAND for remote debugging](#configure-goland-for-remote-debugging)<br>
+6 [Remote debug Rancher 2.x](#remote-debug-rancher-2.x-in-goland)<br>
+7 [Watch stdout output of Rancher 2.x](#watch-stdout-output-of-rancher-2.x)<br>
+8 [Optional: Make new docker debug image](#optional:-make-a-new-docker-debug-image)
+
+## Prerequisites
+* Virtual machine with Ubuntu 18.04 desktop
+    * Virtualbox
+    * as much as CPU cores and RAM you can spend for it (I love my AMD Ryzen system for that)
+    * Harddisk 40 GByte 
+    * Network Interface set to bridged mode
+    * Ubuntu-18.04-desktop-amd64 ISO image
+* Docker 
+  * At the time of this writing Docker is not available as stable for Ubuntu 18.04
+  * Install docker from the Ubuntu repository instead:
+    
+      ```bash
+    sudo apt-get update
+    sudo apt-get install docker.io
+    docker -v
+    ```
+  * The docker version should be around 17.12.x. Compilation of  some rancher projects will ned higher versions of Docker because they use multi stage Dockerfiles
+  * Add your user to the docker group:
+
+      ```bash
+      sudo usermod -aG docker <your username>
+      ```
+
+    Logout / Login afterwards
+  * Test docker:
+    
+      ```bash
+      docker images
+      ```
+  * The output should give no errors but an empty list of docker images.
+* Git
+
+    ```bash
+    sudo apt-get install git
+    ```
+
+* Go compiler
+  * Download and install it like described here:<br>
+    https://golang.org/dl/
+  * Logout / Login afterwards
+  * Test go:
+
+      ```bash
+      go -v
+      ```
+  * You should see Version _1.10.3_ or higher.
+  * Set _GOPATH_ and _GOBIN_ environment variables in your _.profile_ file to...:
+
+      ```bash
+      export GOPATH=/go
+      export GOBIN=/go/bin
+      ```
+     
+      Reason for not setting _GOPATH_ to your home directory: <br>
+      Later we will debug your Rancher binary in a docker container. The _GOPATH_ in the docker container and the _GOPATH_ of the environment outside of it should be the same to get the debugger working.
+  * Create directories /go and /go/bin:
+
+      ```bash
+      sudo mkdir -p /go/bin
+      sudo chown -R <username>:<groupname> /go
+      ```
+
+      To find out your username and groupname type:
+
+          ```bash
+          id -un   # prints your user name
+          id -gn   # prints your group name
+          ```
+
+  * Add /go/bin to your _PATH_ environment variable in your _~/.profile_ file.
+
+      ```bash
+      export PATH=$PATH:/go/bin
+      ```
+
+      Logout / Login afterwards
+* Delve debugger
+  * Install delve debugger:
+
+      ```bash
+      go get -u github.com/derekparker/delve/cmd/dlv
+      ```
+  * Test debugger:
+
+      ```bash
+      dlv version
+      ```
+
+      You should see a version _1.0.0_ or higher.
+* Install rancher sources:
+  * Create directory structure for rancher in your _GOPATH_:
+
+      ```bash
+      mkdir -p $GOPATH/src/github.com/rancher
+      ```
+
+  * Clone rancher's Git repository:
+
+      ```bash
+      cd $GOPATH/src/github.com/rancher
+      git clone https://github.com/rancher/rancher.git
+      ```
+
+  * Build rancher on the command line interface:
+
+      ```bash
+      cd $GOPATH/src/github.com/rancher/rancher
+      make
+      ```
+
+      This will take a few minutes.
+
+## Install _GOLAND_ IDE
+
+### Why not using Visual Studio Code?
+At first I tried to set up a build environment with _Visual Studio Code_. I was able to compile and debug but for some reason (the _GO_ plugin of VSCode maybe?) the debugging experience was not good. _Rancher_ is a rather big go project and I often had problems with _VSCode_ getting very slow.
+
+I switched to the [_Goland_](https://www.jetbrains.com/go/) development environment therefore. It also is the only supported debugger by the Rancher dev team.
+
+### Download, install and start _GOLAND_
+
+* Download _GOLAND_ from https://www.jetbrains.com/go/
+* (In my case I got _GOLAND_ Version _2018.1.4_)
+* Untar it somewhere:
+
+    ```bash
+    tar xvf Goland-...tar.gz
+    cd Goland-.../bin
+    ./goland.sh
+    ```
+* Press **Open Project**
+* Navigate to the directory _/go/src/github.com/rancher/rancher_ and press **Ok**
+
+## Create build settings and build rancher with _GOLAND_
+* File -> Settings -> Tools -> File Watchers : Press the **+** button :
+  * Name: **Auto compile on Save**
+  * Files to Watch -> Filetype: **Go**
+  * Files to Watch -> Scope: **All places**
+  * Tool to Run on Changes -> Program: **go**
+  * Tool to Run on Changes -> Arguments: **build -gcflags "all=-N -l" -tags k8s -o debug**
+  * Tool to Run on Changes -> Output paths to refresh: 
+  * Tool to Run on Changes -> Working directory: **/go/src/github.com/rancher/rancher**
+  * Tool to Run on Changes -> Environment variables: <empty>
+  * Keep all other settings on their defaults and press **OK** button.
+* Press **OK** button in File -> Settings dialog.
+* Open the file **main.go** in the root folder of **$GOPATH/src/github.com/rancher/rancher** and modify it a little bit (enter a space somewhere) and save the file.<br>You should see Goland starting the **Auto compile on Save** task because the files has changed. After a while the compilation ends and there should be the binary 
+
+    ```bash
+    $GOPATH/src/github.com/rancher/rancher/debug
+    ```
+
+## Create debug container 
+
+* Create debug container:
+
+    ```bash
+    cd $GOPATH/src/github.com/rancher/rancher
+    ./scripts/package-debugger.sh
+    ```
+
+    The result is a docker image named _rancher/rancher:debug_
+
+    GOLAND will create a container from this image at the start of each debug session and volume binds the binary _debug_ we created earlier into this container. Then the debugger _delve_ will be started and _GOLAND_ remote controls it.
+
+## Configure _GOLAND_ for remote debugging
+
+Perform this steps to create a debug configuration in _GOLAND_:
+
+* Run -> Edit Configurations... -> + (Add New Configuration) -> Go Remote:
+    * Name: **Remote Debug Rancher**
+    * Host: **<IP Address of your Debug Container, in my case 172.17.0.1>**
+    * Before launch: Activate tool windows: Press + button (Add) -> Run External tool -> Press + (Add)
+        * Tool Settings -> Name: **Start debug container**
+        * Tool Settings -> Program: **/go/src/github.com/rancher/rancher/scripts/start-debug-container.sh**
+        * Tool Settings -> Working directory: **/go/src/github.com/rancher/rancher/scripts**
+        * Press **OK** button
+    * External Tools: Press **OK** button
+* Run/Debug Configurations: Press **OK** button
+
+## Remote debug rancher 2.x in _GOLAND_
+* Select the configuration _Remote Debug Rancher_
+* Set a breakpoint in the code (e.g. the first line in _main.go:main()_ )
+* Press the debug button ...
+  * if previously a debug container was started, the debugger in it will be killed and the container will be removed.
+  * a new debug container will be started in the background
+  * delve will be started and load the volume binded binary **_debug_**
+  * _GOLAND_ connects to the delve debugger in the container and remote controls it
+* If you change code, save the file and in the background the compilation task will automatically start, creating a new version of the binary **_debug_**
+* Restart the debugger and the new binary will be debugged.
+
+## Watch stdout output of rancher 2.x 
+If you want to see the log messages of rancher, you must call:
+
+```bash
+docker logs debugger
+```
+
+## Optional: Make a new Docker debug image
+* Make your changes
+* Build a new version of the docker debug image:
+
+    ```bash
+    ./scripts/package-debugger.sh
+    ```
+
+

--- a/documentation/debugging/package/debugger/Dockerfile.agent
+++ b/documentation/debugging/package/debugger/Dockerfile.agent
@@ -1,0 +1,18 @@
+FROM rancher/k8s:v1.8.9-rancher1-1 as k8s
+
+FROM ubuntu:18.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates jq iproute2 vim-tiny less bash-completion && \
+    curl -sLf https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 > /usr/bin/docker && \
+    chmod +x /usr/bin/docker && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN curl -sL https://github.com/rancher/share-mnt/releases/download/v1.0.3/share-mnt.tar.gz | tar xvzf - -C /usr/bin
+COPY --from=k8s /usr/bin/kubectl /usr/bin/
+ARG VERSION=dev
+LABEL io.cattle.agent true
+ENV DOCKER_API_VERSION 1.24
+ENV AGENT_IMAGE rancher/rancher-agent:${VERSION}
+ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
+COPY agent run.sh kubectl-shell.sh shell-setup.sh share-root.sh /usr/bin/
+ENTRYPOINT ["run.sh"]

--- a/documentation/debugging/package/debugger/Dockerfile.debugger
+++ b/documentation/debugging/package/debugger/Dockerfile.debugger
@@ -1,0 +1,57 @@
+FROM ubuntu:18.04
+RUN apt-get update && apt-get install -y git curl gcc ca-certificates unzip xz-utils iputils-ping net-tools && \
+    useradd rancher && \
+    mkdir -p /var/lib/rancher/etcd /var/lib/cattle && \
+    chown -R rancher /var/lib/rancher /var/lib/cattle /usr/local/bin
+
+RUN apt-get install -y wget vim less file xz-utils unzip && \
+    rm -f /bin/sh && ln -s /bin/bash /bin/sh
+
+ENV DAPPER_HOST_ARCH=
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
+
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+    GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
+
+RUN wget -O - https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz | tar -xzf - -C /usr/local && \
+    go get github.com/rancher/trash && go get github.com/golang/lint/golint
+
+
+
+RUN curl -sLf https://github.com/rancher/machine-package/releases/download/v0.14.0-rancher3-1/docker-machine.tar.gz | tar xvzf - -C /usr/bin && \
+    curl -sLf https://github.com/leodotcloud/loglevel/releases/download/v0.1/loglevel-amd64-v0.1.tar.gz | tar xvzf - -C /usr/bin && \
+    curl -sLf https://github.com/rancher/helm/releases/download/v2.8.0-rancher3/helm > /usr/bin/helm && \
+    chmod +x /usr/bin/helm
+RUN mkdir /root/.kube && \
+    ln -s /usr/bin/rancher /usr/bin/kubectl && \
+    ln -s /var/lib/rancher/kube_config_cluster.yml /root/.kube/config && \
+    ln -s /usr/bin/rancher /usr/bin/reset-password && \
+    ln -s /go/src/github.com/rancher/rancher/debug /usr/bin/rancher
+
+
+WORKDIR /var/lib/rancher
+
+ENV CATTLE_UI_PATH /usr/share/rancher/ui
+ENV CATTLE_UI_VERSION 2.0.48
+ENV CATTLE_CLI_VERSION v2.0.1
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
+
+
+RUN mkdir -p /usr/share/rancher/ui && \
+    cd /usr/share/rancher/ui && \
+    curl -sL https://releases.rancher.com/ui/${CATTLE_UI_VERSION}.tar.gz | tar xvzf - --strip-components=1 && \
+    cd /var/lib/rancher
+
+ENV CATTLE_CLI_URL_DARWIN  https://releases.rancher.com/cli/${CATTLE_CLI_VERSION}/rancher-darwin-amd64-${CATTLE_CLI_VERSION}.tar.gz
+ENV CATTLE_CLI_URL_LINUX   https://releases.rancher.com/cli/${CATTLE_CLI_VERSION}/rancher-linux-amd64-${CATTLE_CLI_VERSION}.tar.gz
+ENV CATTLE_CLI_URL_WINDOWS https://releases.rancher.com/cli/${CATTLE_CLI_VERSION}/rancher-windows-386-${CATTLE_CLI_VERSION}.zip
+
+ARG VERSION=dev
+ENV CATTLE_SERVER_VERSION ${VERSION}
+COPY start-debugger.sh /usr/bin
+COPY kill-debugger.sh /usr/bin
+
+ENV CATTLE_AGENT_IMAGE rancher/rancher-agent:${VERSION}
+ENV CATTLE_SERVER_IMAGE rancher/rancher
+VOLUME /var/lib/rancher
+#ENTRYPOINT ["rancher", "--http-listen-port=80", "--https-listen-port=443"]

--- a/documentation/debugging/package/debugger/kill-debugger.sh
+++ b/documentation/debugging/package/debugger/kill-debugger.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+debugger=rancher/rancher/debug
+pids=$(pgrep -f $debugger)
+
+if [[ ! -z $pids ]]; then
+   pgrep -f $debugger | xargs kill
+fi
+

--- a/documentation/debugging/package/debugger/kubectl-shell.sh
+++ b/documentation/debugging/package/debugger/kubectl-shell.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+token=$1
+cluster=$2
+
+if [ -z "${token}" ]; then
+    echo No token provided
+    exit 1
+fi
+
+if [ -z "${cluster}" ]; then
+    echo No cluster provided
+    exit 1
+fi
+
+echo "# Run kubectl commands inside here"
+echo "# e.g. kubectl get all"
+export TERM=screen-256color
+
+unshare --fork --pid --mount-proc --mount shell-setup.sh ${token} ${cluster}

--- a/documentation/debugging/package/debugger/run.sh
+++ b/documentation/debugging/package/debugger/run.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+set -e
+
+if [ "$1" = "--" ]; then
+    shift 1
+    exec "$@"
+fi
+
+error()
+{
+    echo "ERROR:" "$@" 1>&2
+}
+
+warn()
+{
+    echo "WARN :" "$@" 1>&2
+}
+
+get_address()
+{
+    local address=$1
+    # If nothing is given, return empty (it will be automatically determined later if empty)
+    if [ -z $address ]; then
+        echo ""
+    # If given address is a network interface on the system, retrieve configured IP on that interface (only the first configured IP is taken)
+    elif [ -n "$(find /sys/devices -name $address)" ]; then
+        echo $(ip addr show dev $address | grep -w inet | awk '{print $2}' | cut -f1 -d/ | head -1)
+    # Loop through cloud provider options to get IP from metadata, if not found return given value
+    else
+        case $address in
+            awslocal)
+                echo $(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+                ;;
+            awspublic)
+                echo $(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+                ;;
+            doprivate)
+                echo $(curl -s http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
+                ;;
+            dopublic)
+                echo $(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+                ;;
+            azprivate)
+                echo $(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-08-01&format=text")
+                ;;
+            azpublic)
+                echo $(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text")
+                ;;
+            gceinternal)
+                echo $(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip)
+                ;;
+            gceexternal)
+                echo $(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
+                ;;
+            packetlocal)
+                echo $(curl -s https://metadata.packet.net/2009-04-04/meta-data/local-ipv4)
+                ;;
+            packetpublic)
+                echo $(curl -s https://metadata.packet.net/2009-04-04/meta-data/public-ipv4)
+                ;;
+            ipify)
+                echo $(curl -s https://api.ipify.org)
+                ;;
+            *)
+                echo $address
+                ;;
+        esac
+    fi
+}
+
+AGENT_IMAGE=${AGENT_IMAGE:-ubuntu:14.04}
+
+export CATTLE_ADDRESS
+export CATTLE_AGENT_CONNECT
+export CATTLE_INTERNAL_ADDRESS
+export CATTLE_NODE_NAME
+export CATTLE_ROLE
+export CATTLE_SERVER
+export CATTLE_TOKEN
+export CATTLE_NODE_LABEL
+
+while true; do
+    case "$1" in
+        -d | --debug)                   DEBUG=true                  ;;
+        -s | --server)           shift; CATTLE_SERVER=$1            ;;
+        -t | --token)            shift; CATTLE_TOKEN=$1             ;;
+        -c | --ca-checksum)      shift; CATTLE_CA_CHECKSUM=$1       ;;
+        -a | --all-roles)               ALL=true                    ;;
+        -e | --etcd)                    ETCD=true                   ;;
+        -w | --worker)                  WORKER=true                 ;;
+        -p | --controlplane)            CONTROL=true                ;;
+        -n | --node-name)        shift; CATTLE_NODE_NAME=$1         ;;
+        -r | --no-register)             CATTLE_AGENT_CONNECT=true   ;;
+        -a | --address)          shift; CATTLE_ADDRESS=$1           ;;
+        -i | --internal-address) shift; CATTLE_INTERNAL_ADDRESS=$1  ;;
+        -l | --label)            shift; CATTLE_NODE_LABEL+=",$1"    ;;
+        *) break;
+    esac
+    shift
+done
+
+if [ "$DEBUG" = true ]; then
+    set -x
+fi
+
+if [ "$CATTLE_CLUSTER" != "true" ]; then
+    if [ ! -w /var/run/docker.sock ] || [ ! -S /var/run/docker.sock ]; then
+        error Please bind mount in the docker socket to /var/run/docker.sock
+        error example:  docker run -v /var/run/docker.sock:/var/run/docker.sock ...
+        exit 1
+    fi
+fi
+
+if [ -z "$CATTLE_NODE_NAME" ]; then
+    CATTLE_NODE_NAME=$(hostname -s)
+fi
+
+export CATTLE_ADDRESS=$(get_address $CATTLE_ADDRESS)
+export CATTLE_INTERNAL_ADDRESS=$(get_address $CATTLE_INTERNAL_ADDRESS)
+
+if [ -z "$CATTLE_ADDRESS" ]; then
+    # Example output: '8.8.8.8 via 10.128.0.1 dev ens4 src 10.128.0.34 uid 0'
+    CATTLE_ADDRESS=$(ip -o route get 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
+fi
+
+if [ "$ALL" = true ]; then
+    CATTLE_ROLE="etcd,worker,controlplane"
+else
+    if [ "$ETCD" = true ]; then
+        CATTLE_ROLE="${CATTLE_ROLE},etcd"
+    fi
+    if [ "$WORKER" = true ]; then
+        CATTLE_ROLE="${CATTLE_ROLE},worker"
+    fi
+    if [ "$CONTROL" = true ]; then
+        CATTLE_ROLE="${CATTLE_ROLE},controlplane"
+    fi
+fi
+
+if [ -n "$CATTLE_CA_CHECKSUM" ]; then
+    temp=$(mktemp)
+    curl --insecure -s -fL $CATTLE_SERVER/v3/settings/cacerts | jq -r .value > $temp
+    cat $temp
+    if [ ! -s $temp ]; then
+      error "Failed to pull the cacert from the rancher server settings at $CATTLE_SERVER/v3/settings/cacerts"
+      exit 1
+    fi
+    CATTLE_SERVER_CHECKSUM=$(sha256sum $temp | awk '{print $1}')
+    if [ $CATTLE_SERVER_CHECKSUM != $CATTLE_CA_CHECKSUM ]; then
+        rm -f $temp
+        error "Configured cacerts checksum ($CATTLE_SERVER_CHECKSUM) does not match given --ca-checksum ($CATTLE_CA_CHECKSUM)"
+        error "Please check if the correct certificate is configured at $CATTLE_SERVER/v3/settings/cacerts"
+        exit 1
+    else
+        mkdir -p /etc/kubernetes/ssl/certs
+        mv $temp /etc/kubernetes/ssl/certs/serverca
+    fi
+fi
+
+if [ -z "$CATTLE_SERVER" ]; then
+    error -- --server is a required option
+    exit 1
+fi
+
+if [ "$CATTLE_K8S_MANAGED" != "true" ]; then
+    if [ -z "$CATTLE_TOKEN" ]; then
+        error -- --token is a required option
+        exit 1
+    fi
+
+    if [ -z "$CATTLE_ADDRESS" ]; then
+        error -- --address is a required option
+        exit 1
+    fi
+fi
+
+exec agent

--- a/documentation/debugging/package/debugger/share-root.sh
+++ b/documentation/debugging/package/debugger/share-root.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+ID=$(grep :devices: /proc/self/cgroup | head -n1 | awk -F/ '{print $NF}' | sed -e 's/docker-\(.*\)\.scope/\1/')
+IMAGE=$(docker inspect -f '{{.Config.Image}}' $ID)
+
+docker run --privileged --net host --pid host -v /:/host --rm --entrypoint /usr/bin/share-mnt $IMAGE "$@" -- norun
+while ! docker start kubelet; do
+    sleep 2
+done
+docker kill $ID

--- a/documentation/debugging/package/debugger/shell-setup.sh
+++ b/documentation/debugging/package/debugger/shell-setup.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+token=$1
+cluster=$2
+
+mkdir -p /nonexistent
+mount -t tmpfs tmpfs /nonexistent
+cd /nonexistent
+
+mkdir -p .kube/certs
+
+SERVER="${CATTLE_SERVER}/k8s/clusters/${cluster}"
+
+if [ -f /etc/kubernetes/ssl/certs/serverca ]; then
+    cp /etc/kubernetes/ssl/certs/serverca .kube/certs/ca.crt
+    chmod 666 .kube/certs/ca.crt
+    if ! curl -s $SERVER > /dev/null; then
+        CERT="    certificate-authority: /nonexistent/.kube/certs/ca.crt"
+    fi
+fi
+
+for i in /run /var/run /etc/kubernetes; do
+    mount -t tmpfs tmpfs $i
+done
+
+cat <<EOF > .kube/config
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    api-version: v1
+    server: "${CATTLE_SERVER}/k8s/clusters/${cluster}"
+${CERT}
+  name: "Default"
+contexts:
+- context:
+    cluster: "Default"
+    user: "Default"
+  name: "Default"
+current-context: "Default"
+users:
+- name: "Default"
+  user:
+    token: "${token}"
+EOF
+
+cp /etc/skel/.bashrc .
+cat >> .bashrc <<EOF
+PS1="> "
+. /etc/bash_completion
+alias k="kubectl"
+alias ks="kubectl -n kube-system"
+EOF
+
+chmod 777 .kube .bashrc
+chmod 666 .kube/config
+
+for i in $(env | cut -d "=" -f 1 | grep "CATTLE\|RANCHER"); do
+    unset $i
+done
+
+exec su -s /bin/bash nobody

--- a/documentation/debugging/package/debugger/start-debugger.sh
+++ b/documentation/debugging/package/debugger/start-debugger.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+#log=--log
+
+/go/bin2/dlv exec /go/src/github.com/rancher/rancher/debug --build-flags "-tags k8s -gcflags 'all=-N -l'" -l 0.0.0.0:2345 --api-version=2 --headless $log -- --http-listen-port=80 --https-listen-port=443
+

--- a/documentation/debugging/scripts/package-debugger.sh
+++ b/documentation/debugging/scripts/package-debugger.sh
@@ -1,0 +1,40 @@
+###############################################################
+# TDOO: I have done NOTHING up to now for debugging the agent !
+###############################################################
+
+#!/bin/bash
+set -e
+
+source $(dirname $0)/version
+
+ARCH=${ARCH:-"amd64"}
+SUFFIX=""
+[ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
+
+cd $(dirname $0)/../package/debugger
+
+TAG=${TAG:-${VERSION}${SUFFIX}}
+REPO=${REPO:-rancher}
+
+#if echo $TAG | grep -q dirty; then
+    TAG=debug
+#fi
+
+#if [ -n "$DRONE_TAG" ]; then
+#    TAG=$DRONE_TAG
+#fi
+
+cp ../../bin/agent .
+
+IMAGE=${REPO}/rancher:${TAG}
+AGENT_IMAGE=${REPO}/rancher-agent:${TAG}
+docker build --build-arg VERSION=${TAG} -t ${IMAGE} -f Dockerfile.debugger .
+docker build --build-arg VERSION=${TAG} -t ${AGENT_IMAGE} -f Dockerfile.agent .
+echo ${IMAGE} > ../../dist/images
+echo ${AGENT_IMAGE} >> ../../dist/images
+echo Built ${IMAGE} #${AGENT_IMAGE}
+echo
+
+cd ../../bin
+go run ../pkg/image/export/main.go $IMAGE $AGENT_IMAGE
+

--- a/documentation/debugging/scripts/start-debug-container.sh
+++ b/documentation/debugging/scripts/start-debug-container.sh
@@ -1,0 +1,12 @@
+# If there is already a debugger container running, stop and remove it.
+debuggerId=$(docker ps -aqf "name=debugger")
+
+if [ ! -z $debuggerId ]; then
+        docker exec $debuggerId kill-debugger.sh
+	docker stop $debuggerId
+	docker rm $debuggerId
+fi
+
+# Start new debug container. Mount a few directories of the $GOPATH into the container so we don't have to copy 
+# things around.
+docker run -d -p 80:80 -p 443:443 -p 2345:2345 --name debugger --privileged -v /go/bin:/go/bin2 -v /go/src/github.com/rancher/rancher/:/go/src/github.com/rancher/rancher -v /go/src/github.com/rancher/rancher/debug:/usr/bin/rancher rancher/rancher:debug start-debugger.sh

--- a/package/debugger/Dockerfile.agent
+++ b/package/debugger/Dockerfile.agent
@@ -1,0 +1,18 @@
+FROM rancher/k8s:v1.8.9-rancher1-1 as k8s
+
+FROM ubuntu:18.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates jq iproute2 vim-tiny less bash-completion && \
+    curl -sLf https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 > /usr/bin/docker && \
+    chmod +x /usr/bin/docker && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN curl -sL https://github.com/rancher/share-mnt/releases/download/v1.0.3/share-mnt.tar.gz | tar xvzf - -C /usr/bin
+COPY --from=k8s /usr/bin/kubectl /usr/bin/
+ARG VERSION=dev
+LABEL io.cattle.agent true
+ENV DOCKER_API_VERSION 1.24
+ENV AGENT_IMAGE rancher/rancher-agent:${VERSION}
+ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
+COPY agent run.sh kubectl-shell.sh shell-setup.sh share-root.sh /usr/bin/
+ENTRYPOINT ["run.sh"]

--- a/package/debugger/Dockerfile.debugger
+++ b/package/debugger/Dockerfile.debugger
@@ -1,0 +1,57 @@
+FROM ubuntu:18.04
+RUN apt-get update && apt-get install -y git curl gcc ca-certificates unzip xz-utils iputils-ping net-tools && \
+    useradd rancher && \
+    mkdir -p /var/lib/rancher/etcd /var/lib/cattle && \
+    chown -R rancher /var/lib/rancher /var/lib/cattle /usr/local/bin
+
+RUN apt-get install -y wget vim less file xz-utils unzip && \
+    rm -f /bin/sh && ln -s /bin/bash /bin/sh
+
+ENV DAPPER_HOST_ARCH=
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
+
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+    GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
+
+RUN wget -O - https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz | tar -xzf - -C /usr/local && \
+    go get github.com/rancher/trash && go get github.com/golang/lint/golint
+
+
+
+RUN curl -sLf https://github.com/rancher/machine-package/releases/download/v0.14.0-rancher3-1/docker-machine.tar.gz | tar xvzf - -C /usr/bin && \
+    curl -sLf https://github.com/leodotcloud/loglevel/releases/download/v0.1/loglevel-amd64-v0.1.tar.gz | tar xvzf - -C /usr/bin && \
+    curl -sLf https://github.com/rancher/helm/releases/download/v2.8.0-rancher3/helm > /usr/bin/helm && \
+    chmod +x /usr/bin/helm
+RUN mkdir /root/.kube && \
+    ln -s /usr/bin/rancher /usr/bin/kubectl && \
+    ln -s /var/lib/rancher/kube_config_cluster.yml /root/.kube/config && \
+    ln -s /usr/bin/rancher /usr/bin/reset-password && \
+    ln -s /go/src/github.com/rancher/rancher/debug /usr/bin/rancher
+
+
+WORKDIR /var/lib/rancher
+
+ENV CATTLE_UI_PATH /usr/share/rancher/ui
+ENV CATTLE_UI_VERSION 2.0.48
+ENV CATTLE_CLI_VERSION v2.0.1
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
+
+
+RUN mkdir -p /usr/share/rancher/ui && \
+    cd /usr/share/rancher/ui && \
+    curl -sL https://releases.rancher.com/ui/${CATTLE_UI_VERSION}.tar.gz | tar xvzf - --strip-components=1 && \
+    cd /var/lib/rancher
+
+ENV CATTLE_CLI_URL_DARWIN  https://releases.rancher.com/cli/${CATTLE_CLI_VERSION}/rancher-darwin-amd64-${CATTLE_CLI_VERSION}.tar.gz
+ENV CATTLE_CLI_URL_LINUX   https://releases.rancher.com/cli/${CATTLE_CLI_VERSION}/rancher-linux-amd64-${CATTLE_CLI_VERSION}.tar.gz
+ENV CATTLE_CLI_URL_WINDOWS https://releases.rancher.com/cli/${CATTLE_CLI_VERSION}/rancher-windows-386-${CATTLE_CLI_VERSION}.zip
+
+ARG VERSION=dev
+ENV CATTLE_SERVER_VERSION ${VERSION}
+COPY start-debugger.sh /usr/bin
+COPY kill-debugger.sh /usr/bin
+
+ENV CATTLE_AGENT_IMAGE rancher/rancher-agent:${VERSION}
+ENV CATTLE_SERVER_IMAGE rancher/rancher
+VOLUME /var/lib/rancher
+#ENTRYPOINT ["rancher", "--http-listen-port=80", "--https-listen-port=443"]

--- a/package/debugger/kill-debugger.sh
+++ b/package/debugger/kill-debugger.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+debugger=rancher/rancher/debug
+pids=$(pgrep -f $debugger)
+
+if [[ ! -z $pids ]]; then
+   pgrep -f $debugger | xargs kill
+fi
+

--- a/package/debugger/kubectl-shell.sh
+++ b/package/debugger/kubectl-shell.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+token=$1
+cluster=$2
+
+if [ -z "${token}" ]; then
+    echo No token provided
+    exit 1
+fi
+
+if [ -z "${cluster}" ]; then
+    echo No cluster provided
+    exit 1
+fi
+
+echo "# Run kubectl commands inside here"
+echo "# e.g. kubectl get all"
+export TERM=screen-256color
+
+unshare --fork --pid --mount-proc --mount shell-setup.sh ${token} ${cluster}

--- a/package/debugger/run.sh
+++ b/package/debugger/run.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+set -e
+
+if [ "$1" = "--" ]; then
+    shift 1
+    exec "$@"
+fi
+
+error()
+{
+    echo "ERROR:" "$@" 1>&2
+}
+
+warn()
+{
+    echo "WARN :" "$@" 1>&2
+}
+
+get_address()
+{
+    local address=$1
+    # If nothing is given, return empty (it will be automatically determined later if empty)
+    if [ -z $address ]; then
+        echo ""
+    # If given address is a network interface on the system, retrieve configured IP on that interface (only the first configured IP is taken)
+    elif [ -n "$(find /sys/devices -name $address)" ]; then
+        echo $(ip addr show dev $address | grep -w inet | awk '{print $2}' | cut -f1 -d/ | head -1)
+    # Loop through cloud provider options to get IP from metadata, if not found return given value
+    else
+        case $address in
+            awslocal)
+                echo $(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+                ;;
+            awspublic)
+                echo $(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+                ;;
+            doprivate)
+                echo $(curl -s http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
+                ;;
+            dopublic)
+                echo $(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+                ;;
+            azprivate)
+                echo $(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-08-01&format=text")
+                ;;
+            azpublic)
+                echo $(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text")
+                ;;
+            gceinternal)
+                echo $(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip)
+                ;;
+            gceexternal)
+                echo $(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
+                ;;
+            packetlocal)
+                echo $(curl -s https://metadata.packet.net/2009-04-04/meta-data/local-ipv4)
+                ;;
+            packetpublic)
+                echo $(curl -s https://metadata.packet.net/2009-04-04/meta-data/public-ipv4)
+                ;;
+            ipify)
+                echo $(curl -s https://api.ipify.org)
+                ;;
+            *)
+                echo $address
+                ;;
+        esac
+    fi
+}
+
+AGENT_IMAGE=${AGENT_IMAGE:-ubuntu:14.04}
+
+export CATTLE_ADDRESS
+export CATTLE_AGENT_CONNECT
+export CATTLE_INTERNAL_ADDRESS
+export CATTLE_NODE_NAME
+export CATTLE_ROLE
+export CATTLE_SERVER
+export CATTLE_TOKEN
+export CATTLE_NODE_LABEL
+
+while true; do
+    case "$1" in
+        -d | --debug)                   DEBUG=true                  ;;
+        -s | --server)           shift; CATTLE_SERVER=$1            ;;
+        -t | --token)            shift; CATTLE_TOKEN=$1             ;;
+        -c | --ca-checksum)      shift; CATTLE_CA_CHECKSUM=$1       ;;
+        -a | --all-roles)               ALL=true                    ;;
+        -e | --etcd)                    ETCD=true                   ;;
+        -w | --worker)                  WORKER=true                 ;;
+        -p | --controlplane)            CONTROL=true                ;;
+        -n | --node-name)        shift; CATTLE_NODE_NAME=$1         ;;
+        -r | --no-register)             CATTLE_AGENT_CONNECT=true   ;;
+        -a | --address)          shift; CATTLE_ADDRESS=$1           ;;
+        -i | --internal-address) shift; CATTLE_INTERNAL_ADDRESS=$1  ;;
+        -l | --label)            shift; CATTLE_NODE_LABEL+=",$1"    ;;
+        *) break;
+    esac
+    shift
+done
+
+if [ "$DEBUG" = true ]; then
+    set -x
+fi
+
+if [ "$CATTLE_CLUSTER" != "true" ]; then
+    if [ ! -w /var/run/docker.sock ] || [ ! -S /var/run/docker.sock ]; then
+        error Please bind mount in the docker socket to /var/run/docker.sock
+        error example:  docker run -v /var/run/docker.sock:/var/run/docker.sock ...
+        exit 1
+    fi
+fi
+
+if [ -z "$CATTLE_NODE_NAME" ]; then
+    CATTLE_NODE_NAME=$(hostname -s)
+fi
+
+export CATTLE_ADDRESS=$(get_address $CATTLE_ADDRESS)
+export CATTLE_INTERNAL_ADDRESS=$(get_address $CATTLE_INTERNAL_ADDRESS)
+
+if [ -z "$CATTLE_ADDRESS" ]; then
+    # Example output: '8.8.8.8 via 10.128.0.1 dev ens4 src 10.128.0.34 uid 0'
+    CATTLE_ADDRESS=$(ip -o route get 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
+fi
+
+if [ "$ALL" = true ]; then
+    CATTLE_ROLE="etcd,worker,controlplane"
+else
+    if [ "$ETCD" = true ]; then
+        CATTLE_ROLE="${CATTLE_ROLE},etcd"
+    fi
+    if [ "$WORKER" = true ]; then
+        CATTLE_ROLE="${CATTLE_ROLE},worker"
+    fi
+    if [ "$CONTROL" = true ]; then
+        CATTLE_ROLE="${CATTLE_ROLE},controlplane"
+    fi
+fi
+
+if [ -n "$CATTLE_CA_CHECKSUM" ]; then
+    temp=$(mktemp)
+    curl --insecure -s -fL $CATTLE_SERVER/v3/settings/cacerts | jq -r .value > $temp
+    cat $temp
+    if [ ! -s $temp ]; then
+      error "Failed to pull the cacert from the rancher server settings at $CATTLE_SERVER/v3/settings/cacerts"
+      exit 1
+    fi
+    CATTLE_SERVER_CHECKSUM=$(sha256sum $temp | awk '{print $1}')
+    if [ $CATTLE_SERVER_CHECKSUM != $CATTLE_CA_CHECKSUM ]; then
+        rm -f $temp
+        error "Configured cacerts checksum ($CATTLE_SERVER_CHECKSUM) does not match given --ca-checksum ($CATTLE_CA_CHECKSUM)"
+        error "Please check if the correct certificate is configured at $CATTLE_SERVER/v3/settings/cacerts"
+        exit 1
+    else
+        mkdir -p /etc/kubernetes/ssl/certs
+        mv $temp /etc/kubernetes/ssl/certs/serverca
+    fi
+fi
+
+if [ -z "$CATTLE_SERVER" ]; then
+    error -- --server is a required option
+    exit 1
+fi
+
+if [ "$CATTLE_K8S_MANAGED" != "true" ]; then
+    if [ -z "$CATTLE_TOKEN" ]; then
+        error -- --token is a required option
+        exit 1
+    fi
+
+    if [ -z "$CATTLE_ADDRESS" ]; then
+        error -- --address is a required option
+        exit 1
+    fi
+fi
+
+exec agent

--- a/package/debugger/share-root.sh
+++ b/package/debugger/share-root.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+ID=$(grep :devices: /proc/self/cgroup | head -n1 | awk -F/ '{print $NF}' | sed -e 's/docker-\(.*\)\.scope/\1/')
+IMAGE=$(docker inspect -f '{{.Config.Image}}' $ID)
+
+docker run --privileged --net host --pid host -v /:/host --rm --entrypoint /usr/bin/share-mnt $IMAGE "$@" -- norun
+while ! docker start kubelet; do
+    sleep 2
+done
+docker kill $ID

--- a/package/debugger/shell-setup.sh
+++ b/package/debugger/shell-setup.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+token=$1
+cluster=$2
+
+mkdir -p /nonexistent
+mount -t tmpfs tmpfs /nonexistent
+cd /nonexistent
+
+mkdir -p .kube/certs
+
+SERVER="${CATTLE_SERVER}/k8s/clusters/${cluster}"
+
+if [ -f /etc/kubernetes/ssl/certs/serverca ]; then
+    cp /etc/kubernetes/ssl/certs/serverca .kube/certs/ca.crt
+    chmod 666 .kube/certs/ca.crt
+    if ! curl -s $SERVER > /dev/null; then
+        CERT="    certificate-authority: /nonexistent/.kube/certs/ca.crt"
+    fi
+fi
+
+for i in /run /var/run /etc/kubernetes; do
+    mount -t tmpfs tmpfs $i
+done
+
+cat <<EOF > .kube/config
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    api-version: v1
+    server: "${CATTLE_SERVER}/k8s/clusters/${cluster}"
+${CERT}
+  name: "Default"
+contexts:
+- context:
+    cluster: "Default"
+    user: "Default"
+  name: "Default"
+current-context: "Default"
+users:
+- name: "Default"
+  user:
+    token: "${token}"
+EOF
+
+cp /etc/skel/.bashrc .
+cat >> .bashrc <<EOF
+PS1="> "
+. /etc/bash_completion
+alias k="kubectl"
+alias ks="kubectl -n kube-system"
+EOF
+
+chmod 777 .kube .bashrc
+chmod 666 .kube/config
+
+for i in $(env | cut -d "=" -f 1 | grep "CATTLE\|RANCHER"); do
+    unset $i
+done
+
+exec su -s /bin/bash nobody

--- a/package/debugger/start-debugger.sh
+++ b/package/debugger/start-debugger.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+#log=--log
+
+/go/bin2/dlv exec /go/src/github.com/rancher/rancher/debug --build-flags "-tags k8s -gcflags 'all=-N -l'" -l 0.0.0.0:2345 --api-version=2 --headless $log -- --http-listen-port=80 --https-listen-port=443
+

--- a/scripts/package-debugger.sh
+++ b/scripts/package-debugger.sh
@@ -1,0 +1,40 @@
+###############################################################
+# TDOO: I have done NOTHING up to now for debugging the agent !
+###############################################################
+
+#!/bin/bash
+set -e
+
+source $(dirname $0)/version
+
+ARCH=${ARCH:-"amd64"}
+SUFFIX=""
+[ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
+
+cd $(dirname $0)/../package/debugger
+
+TAG=${TAG:-${VERSION}${SUFFIX}}
+REPO=${REPO:-rancher}
+
+#if echo $TAG | grep -q dirty; then
+    TAG=debug
+#fi
+
+#if [ -n "$DRONE_TAG" ]; then
+#    TAG=$DRONE_TAG
+#fi
+
+cp ../../bin/agent .
+
+IMAGE=${REPO}/rancher:${TAG}
+AGENT_IMAGE=${REPO}/rancher-agent:${TAG}
+docker build --build-arg VERSION=${TAG} -t ${IMAGE} -f Dockerfile.debugger .
+docker build --build-arg VERSION=${TAG} -t ${AGENT_IMAGE} -f Dockerfile.agent .
+echo ${IMAGE} > ../../dist/images
+echo ${AGENT_IMAGE} >> ../../dist/images
+echo Built ${IMAGE} #${AGENT_IMAGE}
+echo
+
+cd ../../bin
+go run ../pkg/image/export/main.go $IMAGE $AGENT_IMAGE
+

--- a/scripts/start-debug-container.sh
+++ b/scripts/start-debug-container.sh
@@ -1,0 +1,12 @@
+# If there is already a debugger container running, stop and remove it.
+debuggerId=$(docker ps -aqf "name=debugger")
+
+if [ ! -z $debuggerId ]; then
+        docker exec $debuggerId kill-debugger.sh
+	docker stop $debuggerId
+	docker rm $debuggerId
+fi
+
+# Start new debug container. Mount a few directories of the $GOPATH into the container so we don't have to copy 
+# things around.
+docker run -d -p 80:80 -p 443:443 -p 2345:2345 --name debugger --privileged -v /go/bin:/go/bin2 -v /go/src/github.com/rancher/rancher/:/go/src/github.com/rancher/rancher -v /go/src/github.com/rancher/rancher/debug:/usr/bin/rancher rancher/rancher:debug start-debugger.sh


### PR DESCRIPTION
Hi,

today I created documentation and scripts for a debugging workflow with GOLAND.
- creates a docker container with volume bound source code and compiled binary
- delve is also volume bound into this container
- GOLAND starts this container, starts a script which starts delve loading the rancher binary
- the rancher binary compiled outside of the container is volume bound to /usr/bin/rancher
- after a restart of the debug session, GOLAND kills delve in the container and restarts the container and delve, reconnects itself to delve.


I'm able to edit code, compile and debug rancher without leaving the GOLAND IDE. That makes me very happe. Hopefully it will do so for you :-)

This should also work together with Visual Studio Code but yesterday as I tried it out, I had severe performance issues with the current GO plugin for VSCode. Therefore I switched to GOLAND.

Most of the scripts (at least in /rancher/packages/debugger) are copy/paste because the Dockerfiles need scripts from rancher/packages and I saw no need to not reuse them for the debugger container.

Rancher Agent debugging currently is not addressed by this pull request. This is tbd.

The developer community must be supported with more documentation about this project.

I'm eager to get feedback from you.

Greetz,

Josef