### PR TITLE
Update vendor for AKS option update

### DIFF
--- a/pkg/controllers/management/test/e2e/authz_test.go
+++ b/pkg/controllers/management/test/e2e/authz_test.go
@@ -291,7 +291,7 @@ func (s *AuthzSuite) createCRTBinding(bindingName string, subject rbacv1.Subject
 		ObjectMeta: metav1.ObjectMeta{
 			Name: bindingName,
 		},
-		Subject:          subject,
+		UserName:         subject.Name,
 		RoleTemplateName: rtName,
 	})
 
@@ -309,7 +309,7 @@ func (s *AuthzSuite) createPRTBinding(bindingName string, subject rbacv1.Subject
 		ObjectMeta: metav1.ObjectMeta{
 			Name: bindingName,
 		},
-		Subject:          subject,
+		UserName:         subject.Name,
 		ProjectName:      projectName,
 		RoleTemplateName: rtName,
 	})

--- a/vendor.conf
+++ b/vendor.conf
@@ -28,9 +28,9 @@ github.com/aws/aws-sdk-go                     6755a29e78026d7435884fe490e08cc250
 github.com/heptio/authenticator               d282f87a19728018b67d80754bcb3e9b0457403f
 github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c68ea53b
 github.com/rancher/rdns-server                de2b06e01b956b30aa078609bd6efa65081fae0e
-github.com/rancher/types                      c9dc486e63edbbd8d6571bac87ee9ad7992e6af8
+github.com/rancher/types                      3a24fe3cadbc76bf67c1e419c15d6dce94416240
 github.com/rancher/norman                     d70f95a3d6fc13a9f4554e74b838771ea7c928b2 
-github.com/rancher/kontainer-engine           f06e0d4731d41ae2f88dfe6da526dc836b90bbe9
+github.com/rancher/kontainer-engine           006d76b9a3e8e546cf43823336378a7cc254c1e4
 github.com/rancher/rke                        4c30f1a28d790fb0faa2e268644323af7beb8113
 
 gopkg.in/ldap.v2     v2.5.0

--- a/vendor/github.com/rancher/kontainer-engine/vendor.conf
+++ b/vendor/github.com/rancher/kontainer-engine/vendor.conf
@@ -30,6 +30,6 @@ github.com/jmespath/go-jmespath      c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5
 github.com/heptio/authenticator      d282f87a19728018b67d80754bcb3e9b0457403f
 github.com/smartystreets/go-aws-auth 8ef1316913ee4f44bc48c2456e44a5c1c68ea53b
 
-github.com/rancher/rke               ad64f7a29554582bb1eaae7f30f007dff8c91631
+github.com/rancher/rke               94862fa2e2b5fb1df658a97b387c83e5c27ec1f1
 github.com/rancher/norman            ff60298f31f081b06d198815b4c178a578664f7d
-github.com/rancher/types             7d989d829e7b08c619fe3816513f442790344b30
+github.com/rancher/types             3a24fe3cadbc76bf67c1e419c15d6dce94416240

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -196,6 +196,10 @@ type AzureKubernetesServiceConfig struct {
 	TenantID string `json:"tenantId,omitempty" norman:"required"`
 	// Secret associated with the Client ID
 	ClientSecret string `json:"clientSecret,omitempty" norman:"required,type=password"`
+	// Virtual network to use for the AKS cluster
+	VirtualNetwork string `json:"virtualNetwork,omitempty"`
+	// Subnet to use for the AKS Cluster (must be within the virtual network)
+	Subnet string `json:"subnet,omitempty"`
 }
 
 type AmazonElasticContainerServiceConfig struct {

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_azure_kubernetes_service_config.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_azure_kubernetes_service_config.go
@@ -16,9 +16,11 @@ const (
 	AzureKubernetesServiceConfigFieldOsDiskSizeGB         = "osDiskSizeGb"
 	AzureKubernetesServiceConfigFieldResourceGroup        = "resourceGroup"
 	AzureKubernetesServiceConfigFieldSSHPublicKeyContents = "sshPublicKeyContents"
+	AzureKubernetesServiceConfigFieldSubnet               = "subnet"
 	AzureKubernetesServiceConfigFieldSubscriptionID       = "subscriptionId"
 	AzureKubernetesServiceConfigFieldTag                  = "tags"
 	AzureKubernetesServiceConfigFieldTenantID             = "tenantId"
+	AzureKubernetesServiceConfigFieldVirtualNetwork       = "virtualNetwork"
 )
 
 type AzureKubernetesServiceConfig struct {
@@ -36,7 +38,9 @@ type AzureKubernetesServiceConfig struct {
 	OsDiskSizeGB         int64             `json:"osDiskSizeGb,omitempty" yaml:"osDiskSizeGb,omitempty"`
 	ResourceGroup        string            `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
 	SSHPublicKeyContents string            `json:"sshPublicKeyContents,omitempty" yaml:"sshPublicKeyContents,omitempty"`
+	Subnet               string            `json:"subnet,omitempty" yaml:"subnet,omitempty"`
 	SubscriptionID       string            `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
 	Tag                  map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 	TenantID             string            `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
+	VirtualNetwork       string            `json:"virtualNetwork,omitempty" yaml:"virtualNetwork,omitempty"`
 }


### PR DESCRIPTION
This change adds support for specifying a virtual network and subnet to
an AKS cluster. Both a virtual network and a subnet must be specified
together or the option will be ignored.

Depends on:
https://github.com/rancher/kontainer-engine/pull/67
https://github.com/rancher/types/pull/469

Issue:
https://github.com/rancher/rancher/issues/13395