### PR TITLE
Fix role creation for mgmt plane resources

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -35,16 +35,18 @@ func (c *crtbLifecycle) Create(obj *v3.ClusterRoleTemplateBinding) (*v3.ClusterR
 	}
 	err = c.reconcilBindings(obj)
 
-	if obj.Annotations[creatorOwnerBindingAnnotation] == "true" {
-		cluster, err := c.clusterLister.Get("", obj.ClusterName)
-		if err != nil {
-			return nil, err
-		}
-		if !v3.ClusterConditionInitialRolesPopulated.IsTrue(cluster) {
-			cluster = cluster.DeepCopy()
-			v3.ClusterConditionInitialRolesPopulated.True(cluster)
-			if _, err := c.mgr.mgmt.Management.Clusters("").Update(cluster); err != nil {
-				return nil, err
+	if err == nil {
+		if obj.Annotations[creatorOwnerBindingAnnotation] == "true" {
+			cluster, err := c.clusterLister.Get("", obj.ClusterName)
+			if err != nil {
+				return obj, err
+			}
+			if !v3.ClusterConditionInitialRolesPopulated.IsTrue(cluster) {
+				cluster = cluster.DeepCopy()
+				v3.ClusterConditionInitialRolesPopulated.True(cluster)
+				if _, err := c.mgr.mgmt.Management.Clusters("").Update(cluster); err != nil {
+					return obj, err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- An annotation is set on the cluster when the initial creator role is
populated, but the logic was setting the annotation regardless of whether
or not the roles were populated without error. Changed this such that we
check for an error before setting the annotation on the cluster.

- The logic that created/updated the role was updating the role in a tight
loop and erroring out because of verion conflicts. Changed this such that
the role is only updated once after the loop is exited.A

addresses https://github.com/rancher/rancher/issues/12532