### PR TITLE
Update azure secret type

### DIFF
--- a/pkg/auth/providers/azure/azure_client.go
+++ b/pkg/auth/providers/azure/azure_client.go
@@ -87,7 +87,7 @@ func newClientToken(token v3.Token, config *v3.AzureADConfig) (*azureClient, err
 		return nil, err
 	}
 
-	secret := &adal.ServicePrincipalTokenSecret{
+	secret := &adal.ServicePrincipalAuthorizationCodeSecret{
 		ClientSecret: config.ApplicationSecret,
 	}
 


### PR DESCRIPTION
Problem:
The secret being used doesn't trigger the refresh to add the
client_secret to the request

Solution:
Change the secret type being used so refresh attaches the client_secret
to requests