### PR TITLE
Ingress endpoints: read address from ingress

### DIFF
--- a/pkg/controllers/user/endpoints/ingress_endpoints.go
+++ b/pkg/controllers/user/endpoints/ingress_endpoints.go
@@ -34,11 +34,7 @@ func (c *IngressEndpointsController) sync(key string, obj *extensionsv1beta1.Ing
 }
 
 func (c *IngressEndpointsController) reconcileEndpointsForIngress(obj *extensionsv1beta1.Ingress) (bool, error) {
-	allNodesIP, err := getAllNodesPublicEndpointIP(c.machinesLister, c.clusterName)
-	if err != nil {
-		return false, err
-	}
-	fromObj := convertIngressToPublicEndpoints(obj, c.isRKE, allNodesIP)
+	fromObj := convertIngressToPublicEndpoints(obj, c.isRKE)
 	fromAnnotation := getPublicEndpointsFromAnnotations(obj.Annotations)
 
 	if areEqualEndpoints(fromAnnotation, fromObj) {

--- a/pkg/controllers/user/endpoints/workload_endpoints.go
+++ b/pkg/controllers/user/endpoints/workload_endpoints.go
@@ -87,7 +87,7 @@ func (c *WorkloadEndpointsController) UpdateEndpoints(key string, obj *workloadu
 	// get ingress endpoint group by service
 	serviceToIngressEndpoints := make(map[string][]v3.PublicEndpoint)
 	for _, ingress := range ingresses {
-		epsMap := convertIngressToServicePublicEndpointsMap(ingress, c.isRKE, allNodesIP)
+		epsMap := convertIngressToServicePublicEndpointsMap(ingress, c.isRKE)
 		for k, v := range epsMap {
 			serviceToIngressEndpoints[k] = append(serviceToIngressEndpoints[k], v...)
 		}


### PR DESCRIPTION
This PR gets rid of fetching single ip address in the cluster. It's done by 2 reasons:

* we derive allNodes=true based on cluster being rke, but even then nginx ingress controller might not be deployed on every node (you can pass node labels now via cluster yml config in the UI)
* nginx-ingress is supposed to populate `ingress.addresses` the same way we do derive address for the node with allNodes=true case.

https://github.com/rancher/rancher/issues/14052

WIP as we might need to revise the corresponding code in ingress-nginx @orangedeng. 
