### PR TITLE
Add Validator for RoleTemplate

### DIFF
--- a/pkg/api/customization/roletemplate/roletemplate.go
+++ b/pkg/api/customization/roletemplate/roletemplate.go
@@ -1,0 +1,85 @@
+package roletemplate
+
+import (
+	"net/http"
+	"reflect"
+
+	"github.com/rancher/norman/httperror"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+)
+
+type Wrapper struct {
+	RoleTemplateLister v3.RoleTemplateLister
+}
+
+func (w Wrapper) Validator(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
+	if request.Method != http.MethodPut {
+		return nil
+	}
+
+	rt, err := w.RoleTemplateLister.Get("", request.ID)
+	if err != nil {
+		return err
+	}
+
+	if rt.Builtin == true {
+		var newRT *v3.RoleTemplate
+		err = convert.ToObj(data, &newRT)
+		if err != nil {
+			return err
+		}
+
+		e := httperror.NewAPIError(httperror.InvalidBodyContent, "Only field 'locked' can be updated on builtin roleTemplate")
+
+		if newRT.External != rt.External ||
+			newRT.Hidden != rt.Hidden ||
+			newRT.Description != rt.Description ||
+			newRT.Context != rt.Context {
+			return e
+		}
+
+		if len(newRT.Rules) != len(rt.Rules) {
+			return e
+		} else if len(newRT.Rules) > 0 {
+			if !reflect.DeepEqual(newRT.Rules, rt.Rules) {
+				return e
+			}
+		}
+
+		if len(newRT.RoleTemplateNames) != len(rt.RoleTemplateNames) {
+			return e
+		} else if len(newRT.RoleTemplateNames) > 0 {
+			if !reflect.DeepEqual(newRT.RoleTemplateNames, rt.RoleTemplateNames) {
+				return e
+			}
+		}
+
+		annotations, ok := data["annotations"]
+		if ok {
+			anno := mapConvert(annotations)
+			if !reflect.DeepEqual(anno, rt.Annotations) {
+				return e
+			}
+		}
+
+		labels, ok := data["labels"]
+		if ok {
+			l := mapConvert(labels)
+			if !reflect.DeepEqual(l, rt.Labels) {
+				return e
+			}
+		}
+	}
+	return nil
+}
+
+func mapConvert(m interface{}) map[string]string {
+	newMap := make(map[string]string)
+	a := m.(map[string]interface{})
+	for key, value := range a {
+		newMap[key] = value.(string)
+	}
+	return newMap
+}

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/customization/pipeline"
 	"github.com/rancher/rancher/pkg/api/customization/podsecuritypolicytemplate"
 	projectaction "github.com/rancher/rancher/pkg/api/customization/project"
+	"github.com/rancher/rancher/pkg/api/customization/roletemplate"
 	"github.com/rancher/rancher/pkg/api/customization/roletemplatebinding"
 	"github.com/rancher/rancher/pkg/api/customization/setting"
 	"github.com/rancher/rancher/pkg/api/store/cert"
@@ -117,6 +118,7 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	ProjectRoleTemplateBinding(schemas, apiContext)
 	TemplateContent(schemas)
 	PodSecurityPolicyTemplate(schemas, apiContext)
+	RoleTemplate(schemas, apiContext)
 
 	if err := NodeTypes(schemas, apiContext); err != nil {
 		return err
@@ -429,4 +431,12 @@ func ClusterRoleTemplateBinding(schemas *types.Schemas, management *config.Scale
 func ProjectRoleTemplateBinding(schemas *types.Schemas, management *config.ScaledContext) {
 	schema := schemas.Schema(&managementschema.Version, client.ProjectRoleTemplateBindingType)
 	schema.Validator = roletemplatebinding.NewPRTBValidator(management)
+}
+
+func RoleTemplate(schemas *types.Schemas, management *config.ScaledContext) {
+	rt := roletemplate.Wrapper{
+		RoleTemplateLister: management.Management.RoleTemplates("").Controller().Lister(),
+	}
+	schema := schemas.Schema(&managementschema.Version, client.RoleTemplateType)
+	schema.Validator = rt.Validator
 }


### PR DESCRIPTION
Problem:
Builtin RoleTemplates can be updated through the API

Solution:
Add a Validator to ensure the only field that can be changed on a
builtin RoleTemplate is 'locked'

Issue: https://github.com/rancher/rancher/issues/13595