### PR TITLE
Adding filtering for k8s versions in aks version endpoint

### DIFF
--- a/server/capabilities/aks_version_endpoint.go
+++ b/server/capabilities/aks_version_endpoint.go
@@ -75,7 +75,7 @@ func (g *AKSVersionHandler) ServeHTTP(writer http.ResponseWriter, req *http.Requ
 	client := containerservice.NewContainerServicesClient(subscriptionID)
 	client.Authorizer = authorizer
 
-	orchestrators, err := client.ListOrchestrators(context.Background(), region, "")
+	orchestrators, err := client.ListOrchestrators(context.Background(), region, "managedClusters")
 	if err != nil {
 		writer.WriteHeader(http.StatusBadRequest)
 		handleErr(writer, fmt.Errorf("failed to get orchestrators: %v", err))


### PR DESCRIPTION
This change adds a filter for the k8s version that come back from the AKS version endpoint.  Before all versions were being returned instead of just the list that is valid for AKS.

Issue:
https://github.com/rancher/rancher/issues/13387