### PR TITLE
Update node access pieces

### DIFF
--- a/pkg/api/customization/node/node.go
+++ b/pkg/api/customization/node/node.go
@@ -1,13 +1,22 @@
 package node
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
 	"fmt"
+	"io"
+	"strconv"
+	"strings"
 
 	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/types/values"
+	"github.com/rancher/rancher/pkg/encryptedstore"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	managementschema "github.com/rancher/types/apis/management.cattle.io/v3/schema"
 	"github.com/rancher/types/client/management/v3"
@@ -24,7 +33,7 @@ func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 	}
 
 	// add nodeConfig link
-	if err := apiContext.AccessControl.CanDo(v3.NodeDriverGroupVersionKind.Group, v3.NodeDriverResource.Name, "update", apiContext, resource.Values, apiContext.Schema); err == nil {
+	if err := apiContext.AccessControl.CanDo(v3.NodeGroupVersionKind.Group, v3.NodeResource.Name, "update", apiContext, resource.Values, apiContext.Schema); err == nil {
 		resource.Links["nodeConfig"] = apiContext.URLBuilder.Link("nodeConfig", resource)
 	}
 
@@ -73,6 +82,88 @@ func cordonUncordonNode(actionName string, apiContext *types.APIContext, cordon 
 	values.PutValue(node, convert.ToString(!unschedulable), "desiredNodeUnschedulable")
 	if _, err := schema.Store.Update(apiContext, schema, node, apiContext.ID); err != nil && apierrors.IsNotFound(err) {
 		return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf("Error updating node %s by %s : %s", apiContext.ID, actionName, err.Error()))
+	}
+	return nil
+}
+
+type Handler struct {
+	SecretStore *encryptedstore.GenericEncryptedStore
+}
+
+func (h Handler) LinkHandler(apiContext *types.APIContext, next types.RequestHandler) error {
+	var node map[string]interface{}
+	if err := access.ByID(apiContext, apiContext.Version, apiContext.Type, apiContext.ID, &node); err != nil {
+		return err
+	}
+
+	if err := apiContext.AccessControl.CanDo(v3.NodeGroupVersionKind.Group, v3.NodeResource.Name, "update", apiContext, node, apiContext.Schema); err != nil {
+		return err
+	}
+
+	nID, _ := node["id"].(string)
+	nodeID := strings.Split(nID, ":")[1]
+	secret, err := h.SecretStore.Get(nodeID)
+	if err != nil {
+		return err
+	}
+	data, err := base64.StdEncoding.DecodeString(secret[configKey])
+	if err != nil {
+		return err
+	}
+
+	gzipReader, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	tarReader := tar.NewReader(gzipReader)
+
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("error reinitializing config (tarRead.Next): %v", err)
+		}
+		parts := strings.Split(header.Name, "/")
+		if len(parts) != 4 {
+			continue
+		}
+
+		if parts[3] == "config.json" {
+			continue
+		}
+		fh := &zip.FileHeader{}
+		fh.Name = fmt.Sprintf("%s/%s", parts[2], parts[3])
+		fh.SetMode(0400)
+		file, err := w.CreateHeader(fh)
+		if err != nil {
+			return err
+		}
+		buf := &bytes.Buffer{}
+		_, err = io.Copy(buf, tarReader)
+		if err != nil {
+			return err
+		}
+		_, err = file.Write(buf.Bytes())
+		if err != nil {
+			return err
+		}
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	apiContext.Response.Header().Set("Content-Length", strconv.Itoa(len(buf.Bytes())))
+	apiContext.Response.Header().Set("Content-Type", "application/octet-stream")
+	apiContext.Response.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.zip", node[client.NodeSpecFieldRequestedHostname]))
+	apiContext.Response.Header().Set("Cache-Control", "private")
+	apiContext.Response.Header().Set("Pragma", "private")
+	apiContext.Response.Header().Set("Expires", "Wed 24 Feb 1982 18:42:00 GMT")
+	_, err = apiContext.Response.Write(buf.Bytes())
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/api/customization/node/node_driver.go
+++ b/pkg/api/customization/node/node_driver.go
@@ -1,16 +1,8 @@
 package node
 
 import (
-	"archive/tar"
-	"archive/zip"
 	"bytes"
-	"compress/gzip"
-	"encoding/base64"
-	"fmt"
-	"io"
 	"net/http"
-	"strconv"
-	"strings"
 	"time"
 
 	"encoding/json"
@@ -19,7 +11,6 @@ import (
 	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
-	"github.com/rancher/rancher/pkg/encryptedstore"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/client/management/v3"
 	"github.com/rancher/types/compose"
@@ -75,88 +66,6 @@ func (h *DriverHandlers) Formatter(apiContext *types.APIContext, resource *types
 		resource.AddAction(apiContext, "deactivate")
 	}
 	resource.Links["exportYaml"] = apiContext.URLBuilder.Link("exportYaml", resource)
-}
-
-type DriverHandler struct {
-	SecretStore *encryptedstore.GenericEncryptedStore
-}
-
-func (h DriverHandler) LinkHandler(apiContext *types.APIContext, next types.RequestHandler) error {
-	var node map[string]interface{}
-	if err := access.ByID(apiContext, apiContext.Version, apiContext.Type, apiContext.ID, &node); err != nil {
-		return err
-	}
-
-	if err := apiContext.AccessControl.CanDo(v3.NodeDriverGroupVersionKind.Group, v3.NodeDriverResource.Name, "update", apiContext, node, apiContext.Schema); err != nil {
-		return err
-	}
-
-	nID, _ := node["id"].(string)
-	nodeID := strings.Split(nID, ":")[1]
-	secret, err := h.SecretStore.Get(nodeID)
-	if err != nil {
-		return err
-	}
-	data, err := base64.StdEncoding.DecodeString(secret[configKey])
-	if err != nil {
-		return err
-	}
-
-	gzipReader, err := gzip.NewReader(bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-	tarReader := tar.NewReader(gzipReader)
-
-	buf := new(bytes.Buffer)
-	w := zip.NewWriter(buf)
-	for {
-		header, err := tarReader.Next()
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return fmt.Errorf("error reinitializing config (tarRead.Next): %v", err)
-		}
-		parts := strings.Split(header.Name, "/")
-		if len(parts) != 4 {
-			continue
-		}
-
-		if parts[3] == "config.json" {
-			continue
-		}
-		fh := &zip.FileHeader{}
-		fh.Name = fmt.Sprintf("%s/%s", parts[2], parts[3])
-		fh.SetMode(0400)
-		file, err := w.CreateHeader(fh)
-		if err != nil {
-			return err
-		}
-		buf := &bytes.Buffer{}
-		_, err = io.Copy(buf, tarReader)
-		if err != nil {
-			return err
-		}
-		_, err = file.Write(buf.Bytes())
-		if err != nil {
-			return err
-		}
-	}
-	if err := w.Close(); err != nil {
-		return err
-	}
-	apiContext.Response.Header().Set("Content-Length", strconv.Itoa(len(buf.Bytes())))
-	apiContext.Response.Header().Set("Content-Type", "application/octet-stream")
-	apiContext.Response.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.zip", node[client.NodeSpecFieldRequestedHostname]))
-	apiContext.Response.Header().Set("Cache-Control", "private")
-	apiContext.Response.Header().Set("Pragma", "private")
-	apiContext.Response.Header().Set("Expires", "Wed 24 Feb 1982 18:42:00 GMT")
-	_, err = apiContext.Response.Write(buf.Bytes())
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func (h DriverHandlers) ExportYamlHandler(apiContext *types.APIContext, next types.RequestHandler) error {

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -280,7 +280,7 @@ func NodeTypes(schemas *types.Schemas, management *config.ScaledContext) error {
 	schema.ActionHandler = machineDriverHandlers.ActionHandler
 	schema.LinkHandler = machineDriverHandlers.ExportYamlHandler
 
-	machineHandler := &node.DriverHandler{
+	machineHandler := &node.Handler{
 		SecretStore: secretStore,
 	}
 

--- a/pkg/rbac/access_control.go
+++ b/pkg/rbac/access_control.go
@@ -49,13 +49,22 @@ func (a *AccessControl) Filter(apiContext *types.APIContext, schema *types.Schem
 }
 
 func (a *AccessControl) canAccess(obj map[string]interface{}, permset ListPermissionSet) bool {
-	namespace, _ := obj["namespaceId"].(string)
 	var id string
+	var namespace string
+
 	if obj != nil {
 		id, _ = obj["id"].(string)
+		namespace, _ = obj["namespaceId"].(string)
+		if namespace == "" {
+			pieces := strings.Split(id, ":")
+			if len(pieces) == 2 {
+				namespace = pieces[0]
+			}
+		}
 	} else {
 		id = "*"
 	}
+
 	if permset.HasAccess(namespace, "*") || permset.HasAccess("*", "*") {
 		return true
 	}


### PR DESCRIPTION
Problem:
Cluster owners not able to see node keys

Solution:
Update types being used to check access
Refactor access check to use ID if a namcespaceID is not available
Move node code out of node driver file

Issue: https://github.com/rancher/rancher/issues/14024