### PR TITLE
Use proper index when determing if binding exists

### DIFF
--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -193,7 +193,7 @@ func (m *manager) ensureProjectMembershipBinding(roleName, rtbUID, namespace str
 		return nil
 	}
 
-	objs, err := m.crbIndexer.ByIndex(rbByRoleAndSubjectIndex, key)
+	objs, err := m.rbIndexer.ByIndex(rbByRoleAndSubjectIndex, key)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When resolving roleBindings for a project, we check to see if a
binding exists. If none exists, then we create one. However, this
code has two indexes: one for clusterRoleBindings and one for
roleBindings. This code was incorrectly using the clusterRoleBinding
index while operating on roleBindings. This resulted in the controller
never finding the roleBinding and thus ALWAYS creating a new roleBinding,
which results in many duplicate roleBindings existing.

Addresses https://github.com/rancher/rancher/issues/14115