### PR TITLE
Fix subject comparison on clusterRoleBinding

### DIFF
--- a/pkg/controllers/management/auth/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalrolebinding_handler.go
@@ -54,8 +54,9 @@ func (grb *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBind
 		crbName = crbNamePrefix + globalRoleBinding.Name
 	}
 	subject := v1.Subject{
-		Kind: "User",
-		Name: globalRoleBinding.UserName,
+		Kind:     "User",
+		Name:     globalRoleBinding.UserName,
+		APIGroup: rbacv1.GroupName,
 	}
 	crb, _ := grb.crbLister.Get("", crbName)
 	if crb != nil {


### PR DESCRIPTION
When the controller for a globalRoleBinding runs, we determine if we
need to create, update, or delete a corresponding clusterRoleBinding.

For update, if we find an existing clusterRoleBinding, we then do a
deepEquals on the binding's actual subject (that represents the user)
against the expected subject (constructed from the globalRoleBinding).

This comparison was flawed because we were not setting the APIGroup
field and so we were always performing an update on the clusterRoleBinding.

The was no user impact because the update is effectively a no-op but
it is inefficent to be performing these updates all the time. This bug
is primarily observable by multiple log entries like this on startup:
```
2018/06/20 17:13:48 [INFO] [mgmt-auth-grb-controller] Updating clusterRoleBinding cattle-globalrolebinding-globalrolebinding-5hfmf for globalRoleBinding globalrolebinding-5hfmf user user-mxrq6
```

addresses https://github.com/rancher/rancher/issues/14119