### PR TITLE
Use logrus for logging http server panics

### DIFF
--- a/pkg/dynamiclistener/server.go
+++ b/pkg/dynamiclistener/server.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"reflect"
@@ -354,7 +355,8 @@ func (s *server) serveHTTPS(config *v3.ListenConfig) error {
 	}
 
 	server := &http.Server{
-		Handler: s.Handler(),
+		Handler:  s.Handler(),
+		ErrorLog: log.New(logrus.StandardLogger().Writer(), "", log.LstdFlags),
 	}
 
 	if s.activeConfig == nil {
@@ -370,7 +372,8 @@ func (s *server) serveHTTPS(config *v3.ListenConfig) error {
 	}
 
 	httpServer := &http.Server{
-		Handler: httpRedirect(s.Handler()),
+		Handler:  httpRedirect(s.Handler()),
+		ErrorLog: log.New(logrus.StandardLogger().Writer(), "", log.LstdFlags),
 	}
 
 	if s.activeConfig == nil {
@@ -475,7 +478,8 @@ func (s *server) serveACME(config *v3.ListenConfig) error {
 	}
 
 	httpServer := &http.Server{
-		Handler: manager.HTTPHandler(nil),
+		Handler:  manager.HTTPHandler(nil),
+		ErrorLog: log.New(logrus.StandardLogger().Writer(), "", log.LstdFlags),
 	}
 	s.servers = append(s.servers, httpServer)
 	go func() {
@@ -485,7 +489,8 @@ func (s *server) serveACME(config *v3.ListenConfig) error {
 	}()
 
 	httpsServer := &http.Server{
-		Handler: s.Handler(),
+		Handler:  s.Handler(),
+		ErrorLog: log.New(logrus.StandardLogger().Writer(), "", log.LstdFlags),
 	}
 	s.servers = append(s.servers, httpsServer)
 	go func() {

--- a/vendor.conf
+++ b/vendor.conf
@@ -30,7 +30,7 @@ github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c6
 github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d7567c5b0b
 github.com/rancher/rdns-server                f79428ee317c10fa75f6bf2846aa6b88bff081ef
 github.com/rancher/types                      e2ad869a982b4ec65bf961324a419a93624b2297
-github.com/rancher/norman                     e03c72e8551d1c8f51270da0faa40b1235d03e1c
+github.com/rancher/norman                     388faeb89eac2636101af8e279fb6a36967a192a
 github.com/rancher/kontainer-engine           111ab41f43c979578f02d86667c8e5a821fc045e
 github.com/rancher/rke                        a75e3d693cd4395d74b2f92da47b1c1e17124342
 

--- a/vendor/github.com/rancher/norman/controller/generic_controller.go
+++ b/vendor/github.com/rancher/norman/controller/generic_controller.go
@@ -201,7 +201,7 @@ func (g *genericController) processNextWorkItem() bool {
 	}
 
 	if err := filterConflictsError(err); err != nil {
-		utilruntime.HandleError(fmt.Errorf("%v %v %v", g.name, key, err))
+		logrus.Errorf("%v %v %v", g.name, key, err)
 	}
 
 	g.queue.AddRateLimited(key)


### PR DESCRIPTION
http.Server will recover from panics and log the panic's goroutine
dump to its ErrorLogger. By default, the error logger uses the
log package's builtin logger, which typically just logs to stderr.
However, when running rancher in "embedded" mode, kubernetes code
runs which reconfigures the builtin logger to use glog. In this case,
glog is just writing to a file in the /tmp dir, which was causing us
to not print panics.