### PR TITLE
Ingress endpoint fix

### DIFF
--- a/pkg/controllers/user/endpoints/endpoints.go
+++ b/pkg/controllers/user/endpoints/endpoints.go
@@ -90,11 +90,13 @@ func Register(ctx context.Context, workload *config.UserContext) {
 	w.WorkloadController = workloadUtil.NewWorkloadController(workload.UserOnlyContext(), w.UpdateEndpoints)
 
 	i := &IngressEndpointsController{
-		workloadController: workloadUtil.NewWorkloadController(workload.UserOnlyContext(), nil),
-		ingressInterface:   workload.Extensions.Ingresses(""),
-		machinesLister:     workload.Management.Management.Nodes(workload.ClusterName).Controller().Lister(),
-		isRKE:              isRKE,
-		clusterName:        workload.ClusterName,
+		ingressInterface:  workload.Extensions.Ingresses(""),
+		ingressLister:     workload.Extensions.Ingresses("").Controller().Lister(),
+		serviceLister:     workload.Core.Services("").Controller().Lister(),
+		serviceController: workload.Core.Services("").Controller(),
+		machinesLister:    workload.Management.Management.Nodes(workload.ClusterName).Controller().Lister(),
+		isRKE:             isRKE,
+		clusterName:       workload.ClusterName,
 	}
 	workload.Extensions.Ingresses("").AddHandler("ingressEndpointsController", i.sync)
 }

--- a/pkg/controllers/user/endpoints/service_endpoints.go
+++ b/pkg/controllers/user/endpoints/service_endpoints.go
@@ -48,23 +48,41 @@ func (s *ServicesController) sync(key string, obj *corev1.Service) error {
 
 func (s *ServicesController) reconcileEndpointsForService(svc *corev1.Service) (bool, error) {
 	// 1. update service with endpoints
+	if err := s.updateServiceEndpoint(svc); err != nil {
+		return false, err
+	}
+
+	// 2. Push changes for pods behind the service
+	if err := s.notifyRelatedPods(svc); err != nil {
+		return false, err
+	}
+
+	// 3. Push changes to workload behind the service
+	if err := s.notifyRelatedWorloads(svc); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (s *ServicesController) updateServiceEndpoint(svc *corev1.Service) error {
 	allNodesIP, err := getAllNodesPublicEndpointIP(s.machinesLister, s.clusterName)
 	if err != nil {
-		return false, err
+		return err
 	}
 	newPublicEps, err := convertServiceToPublicEndpoints(svc, "", nil, allNodesIP)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	existingPublicEps := getPublicEndpointsFromAnnotations(svc.Annotations)
 	if areEqualEndpoints(existingPublicEps, newPublicEps) {
-		return false, nil
+		return nil
 	}
 	toUpdate := svc.DeepCopy()
 	epsToUpdate, err := publicEndpointsToString(newPublicEps)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	logrus.Infof("Updating service [%s] with public endpoints [%v]", svc.Name, epsToUpdate)
@@ -74,31 +92,34 @@ func (s *ServicesController) reconcileEndpointsForService(svc *corev1.Service) (
 	toUpdate.Annotations[endpointsAnnotation] = epsToUpdate
 	_, err = s.services.Update(toUpdate)
 	if err != nil {
-		return false, err
+		return err
 	}
+	return nil
+}
 
-	// 2. Push changes for pods behind the service
+func (s *ServicesController) notifyRelatedPods(svc *corev1.Service) error {
 	var pods []*corev1.Pod
 	set := labels.Set{}
 	for key, val := range svc.Spec.Selector {
 		set[key] = val
 	}
-	pods, err = s.podLister.List(svc.Namespace, labels.SelectorFromSet(set))
+	pods, err := s.podLister.List(svc.Namespace, labels.SelectorFromSet(set))
 	if err != nil {
-		return false, err
+		return err
 	}
 	for _, pod := range pods {
 		s.podController.Enqueue(pod.Namespace, pod.Name)
 	}
+	return nil
+}
 
-	// 3. Push changes to workload behind the service
+func (s *ServicesController) notifyRelatedWorloads(svc *corev1.Service) error {
 	workloads, err := s.workloadController.GetWorkloadsMatchingSelector(svc.Namespace, svc.Spec.Selector)
 	if err != nil {
-		return false, err
+		return err
 	}
 	for _, w := range workloads {
 		s.workloadController.EnqueueWorkload(w)
 	}
-
-	return true, nil
+	return nil
 }


### PR DESCRIPTION
For now, the ingress endpoint controller will notify all workloads to reconcile their public endpoints. There is tons of it. To reduce the workload enqueue process, the ingress endpoint controller will only notify the related service to reconcile endpoint. And those services will only notify the related pods and workloads to reconcile. 