### PR TITLE
Updated fluentd deps

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -29,7 +29,7 @@ github.com/heptio/authenticator               d282f87a19728018b67d80754bcb3e9b04
 github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c68ea53b
 github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d7567c5b0b
 github.com/rancher/rdns-server                f79428ee317c10fa75f6bf2846aa6b88bff081ef
-github.com/rancher/types                      1da9edd2cc7257f7d96ea77aae061d65150da500
+github.com/rancher/types                      249cb1de53b05673a7a096218e4632d80e244198
 github.com/rancher/norman                     aecae32b4ae6b73b9945cdedef5a5b0dafa11973
 github.com/rancher/kontainer-engine           111ab41f43c979578f02d86667c8e5a821fc045e
 github.com/rancher/rke                        74b81a8766b7316c70f1d6dadcf794263539e60e

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
@@ -300,7 +300,7 @@ var (
 			PluginsDocker: m("plugins/docker:17.12"),
 		},
 		LoggingSystemImages: LoggingSystemImages{
-			Fluentd:                       m("rancher/fluentd:v0.1.8"),
+			Fluentd:                       m("rancher/fluentd:v0.1.9"),
 			FluentdHelper:                 m("rancher/fluentd-helper:v0.1.2"),
 			LogAggregatorFlexVolumeDriver: m("rancher/log-aggregator:v0.1.3"),
 			Elaticsearch:                  m("quay.io/pires/docker-elasticsearch-kubernetes:5.6.2"),


### PR DESCRIPTION
This just bumps the fluentd image to the latest v0.1.9 from v0.1.8