### PR TITLE
skip when externalId is empty

### DIFF
--- a/pkg/api/customization/app/app.go
+++ b/pkg/api/customization/app/app.go
@@ -66,6 +66,9 @@ func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 
 func (w Wrapper) Validator(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
 	externalID := convert.ToString(data["externalId"])
+	if externalID == "" {
+		return nil
+	}
 	templateVersionID, err := hcommon.ParseExternalID(externalID)
 	if err != nil {
 		return err


### PR DESCRIPTION
we should skip validating externalId if it is empty. When you install a
chart locally from cli, there is no externalId and template files are
derived from local files