### PR TITLE
Update isEqual method to handle nil empty maps as the same

### DIFF
--- a/pkg/controllers/management/node/utils.go
+++ b/pkg/controllers/management/node/utils.go
@@ -231,11 +231,7 @@ func deleteNode(nodeDir string, node *v3.Node) error {
 		return err
 	}
 
-	if err := command.Wait(); err != nil {
-		return err
-	}
-
-	return nil
+	return command.Wait()
 }
 
 func getSSHPrivateKey(nodeDir string, node *v3.Node) (string, error) {


### PR DESCRIPTION
The node objects were constantly being updated when one of the objects
had a an empty map {} vs a nil map. This comparison takes that into account
and treats them the same. Also, if the objects are not equal a debug
statement was added to see which comparison test was false.

Tracked this down to cause of #14402 