### PR TITLE
Refector ingress service controller logic

### DIFF
--- a/pkg/controllers/user/controllers.go
+++ b/pkg/controllers/user/controllers.go
@@ -50,7 +50,7 @@ func Register(ctx context.Context, cluster *config.UserContext, kubeConfigGetter
 	userOnlyContext := cluster.UserOnlyContext()
 	dnsrecord.Register(ctx, userOnlyContext)
 	externalservice.Register(ctx, userOnlyContext)
-	ingress.Register(ctx, userOnlyContext)
+	ingress.Register(ctx, userOnlyContext, cluster)
 	ingresshostgen.Register(userOnlyContext)
 	targetworkloadservice.Register(ctx, userOnlyContext)
 	workload.Register(ctx, userOnlyContext)

--- a/pkg/controllers/user/ingress/ingress_common.go
+++ b/pkg/controllers/user/ingress/ingress_common.go
@@ -7,8 +7,13 @@ import (
 	"strings"
 
 	"github.com/rancher/norman/types/convert"
+	util "github.com/rancher/rancher/pkg/controllers/user/workload"
 	"github.com/rancher/rancher/pkg/settings"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -35,4 +40,67 @@ func GetIngressState(obj *v1beta1.Ingress) map[string]string {
 		return state
 	}
 	return nil
+}
+
+type ingressService struct {
+	serviceName string
+	servicePort int32
+	workloadIDs string
+}
+
+func generateIngressService(name string, port int32, workloadIDs string) (ingressService, error) {
+	rtn := ingressService{
+		serviceName: name,
+		servicePort: port,
+	}
+	if workloadIDs != "" {
+		b, err := json.Marshal(strings.Split(workloadIDs, "/"))
+		if err != nil {
+			logrus.WithError(err).Warnf("marshal workload ids %s string error", workloadIDs)
+			return rtn, err
+		}
+		rtn.workloadIDs = string(b)
+	}
+	return rtn, nil
+}
+
+func (i *ingressService) generateNewService(obj *v1beta1.Ingress, serviceType string) *corev1.Service {
+	controller := true
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: i.serviceName,
+			OwnerReferences: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					Name:       obj.Name,
+					APIVersion: "v1beta1/extensions",
+					UID:        obj.UID,
+					Kind:       "Ingress",
+					Controller: &controller,
+				},
+			},
+			Namespace: obj.Namespace,
+			Annotations: map[string]string{
+				util.WorkloadAnnotation: i.workloadIDs,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: "ClusterIP",
+			Ports: []corev1.ServicePort{
+				{
+					Port:       i.servicePort,
+					TargetPort: intstr.FromInt(int(i.servicePort)),
+					Protocol:   "TCP",
+				},
+			},
+		},
+	}
+}
+
+func IsServiceOwnedByIngress(ingress *v1beta1.Ingress, service *corev1.Service) bool {
+	for i, owners := 0, service.GetOwnerReferences(); owners != nil && i < len(owners); i++ {
+		if owners[i].UID == ingress.UID && owners[i].Kind == ingress.Kind {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
1. Fixed issue for https://github.com/rancher/rancher/issues/13717.
We will only create node port service for ingress in GKE cluster.
If there is a node port service for non-GKE cluster, we will recreate it
2. Make ingress services controller's logic more clean.