### PR TITLE
Performance improvements in nodesyncer and netpolicy

### DIFF
--- a/pkg/controllers/user/networkpolicy/nodehandler.go
+++ b/pkg/controllers/user/networkpolicy/nodehandler.go
@@ -10,7 +10,6 @@ import (
 
 type nodeHandler struct {
 	npmgr            *netpolMgr
-	machines         rmgmtv3.NodeInterface
 	clusterNamespace string
 }
 

--- a/pkg/controllers/user/networkpolicy/nssyncer.go
+++ b/pkg/controllers/user/networkpolicy/nssyncer.go
@@ -1,6 +1,8 @@
 package networkpolicy
 
 import (
+	"fmt"
+
 	"github.com/rancher/rancher/pkg/controllers/user/nslabels"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -21,8 +23,8 @@ func (nss *nsSyncer) Sync(key string, ns *corev1.Namespace) error {
 	projectID, ok := ns.Labels[nslabels.ProjectIDFieldLabel]
 	if ok {
 		logrus.Debugf("nsSyncer: Sync: ns=%v projectID=%v", ns.Name, projectID)
-		if err := nss.npmgr.programNetworkPolicy(projectID); err != nil {
-			logrus.Errorf("nsSyncer: Sync: error programming network policy: %v (ns=%v, projectID=%v), ", err, ns.Name, projectID)
+		if err := nss.npmgr.programProjectNetworkPolicy(projectID); err != nil {
+			return fmt.Errorf("nsSyncer: Sync: error programming network policy: %v (ns=%v, projectID=%v), ", err, ns.Name, projectID)
 		}
 	}
 

--- a/pkg/controllers/user/networkpolicy/pnpsyncer.go
+++ b/pkg/controllers/user/networkpolicy/pnpsyncer.go
@@ -15,5 +15,5 @@ func (pnps *projectNetworkPolicySyncer) Sync(key string, pnp *v3.ProjectNetworkP
 		return nil
 	}
 	logrus.Debugf("projectNetworkPolicySyncer: Sync: pnp=%+v", pnp)
-	return pnps.npmgr.programNetworkPolicy(pnp.Namespace)
+	return pnps.npmgr.programProjectNetworkPolicy(pnp.Namespace)
 }

--- a/pkg/controllers/user/networkpolicy/podhandler.go
+++ b/pkg/controllers/user/networkpolicy/podhandler.go
@@ -1,9 +1,14 @@
 package networkpolicy
 
 import (
+	"sort"
+
 	"github.com/rancher/types/apis/core/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	knetworkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -26,15 +31,17 @@ func (ph *podHandler) Sync(key string, pod *corev1.Pod) error {
 	if err := ph.addLabelIfHostPortsPresent(pod); err != nil {
 		return err
 	}
-	return ph.npmgr.hostPortsUpdateHandler(pod)
+	return ph.hostPortsUpdateHandler(pod)
 }
 
 // k8s native network policy can select pods only using labels,
 // hence need to add a label which can be used to select this pod
 // which has hostPorts
 func (ph *podHandler) addLabelIfHostPortsPresent(pod *corev1.Pod) error {
-	if pod == nil {
-		return nil
+	if pod.Labels != nil {
+		if _, ok := pod.Labels[PodNameFieldLabel]; ok {
+			return nil
+		}
 	}
 	hasHostPorts := false
 Loop:
@@ -48,17 +55,74 @@ Loop:
 	}
 	if hasHostPorts {
 		logrus.Debugf("podHandler: addLabelIfHostPortsPresent: pod=%+v has HostPort", *pod)
-		if _, ok := pod.Labels[PodNameFieldLabel]; !ok {
-			podCopy := pod.DeepCopy()
-			if podCopy.Labels == nil {
-				podCopy.Labels = map[string]string{}
-			}
-			podCopy.Labels[PodNameFieldLabel] = podCopy.Name
-			_, err := ph.pods.Update(podCopy)
-			if err != nil {
-				return err
-			}
+		podCopy := pod.DeepCopy()
+		if podCopy.Labels == nil {
+			podCopy.Labels = map[string]string{}
+		}
+		podCopy.Labels[PodNameFieldLabel] = podCopy.Name
+		_, err := ph.pods.Update(podCopy)
+		if err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+func (ph *podHandler) hostPortsUpdateHandler(pod *corev1.Pod) error {
+	np := generatePodNetworkPolicy(pod)
+	hasHostPorts := false
+	for _, c := range pod.Spec.Containers {
+		for _, port := range c.Ports {
+			if port.HostPort != 0 {
+				hp := intstr.FromInt(int(port.ContainerPort))
+				proto := corev1.Protocol(port.Protocol)
+				p := knetworkingv1.NetworkPolicyPort{
+					Protocol: &proto,
+					Port:     &hp,
+				}
+				np.Spec.Ingress[0].Ports = append(np.Spec.Ingress[0].Ports, p)
+				hasHostPorts = true
+			}
+		}
+	}
+	if !hasHostPorts {
+		return nil
+	}
+
+	// sort ports so it always appears in a certain order
+	sort.Slice(np.Spec.Ingress[0].Ports, func(i, j int) bool {
+		return portToString(np.Spec.Ingress[0].Ports[i]) < portToString(np.Spec.Ingress[0].Ports[j])
+	})
+
+	logrus.Debugf("netpolMgr: hostPortsUpdateHandler: pod=%+v has host ports, hence programming np=%+v", *pod, *np)
+	return ph.npmgr.program(np)
+}
+
+func generatePodNetworkPolicy(pod *corev1.Pod) *knetworkingv1.NetworkPolicy {
+	np := &knetworkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hp-" + pod.Name,
+			Namespace: pod.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					UID:        pod.UID,
+					Name:       pod.Name,
+				},
+			},
+		},
+		Spec: knetworkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{PodNameFieldLabel: pod.Name},
+			},
+			Ingress: []knetworkingv1.NetworkPolicyIngressRule{
+				{
+					From:  []knetworkingv1.NetworkPolicyPeer{},
+					Ports: []knetworkingv1.NetworkPolicyPort{},
+				},
+			},
+		},
+	}
+	return np
 }

--- a/pkg/controllers/user/networkpolicy/register.go
+++ b/pkg/controllers/user/networkpolicy/register.go
@@ -10,22 +10,21 @@ func Register(cluster *config.UserContext) {
 	logrus.Infof("Registering project network policy")
 
 	pnpLister := cluster.Management.Management.ProjectNetworkPolicies("").Controller().Lister()
-	pnpClient := cluster.Management.Management.ProjectNetworkPolicies("").ObjectClient()
-	projClient := cluster.Management.Management.Projects("").ObjectClient()
+	pnpClient := cluster.Management.Management.ProjectNetworkPolicies("")
+	projClient := cluster.Management.Management.Projects("")
 	nodeLister := cluster.Core.Nodes("").Controller().Lister()
 	nsLister := cluster.Core.Namespaces("").Controller().Lister()
 	pods := cluster.Core.Pods("")
-	machines := cluster.Management.Management.Nodes(cluster.ClusterName)
 	npClient := cluster.Networking
 	npLister := cluster.Networking.NetworkPolicies("").Controller().Lister()
 
-	npmgr := &netpolMgr{nsLister, nodeLister, pods, npLister, npClient}
+	npmgr := &netpolMgr{nsLister, nodeLister, npLister, npClient}
 	ps := &projectSyncer{pnpLister, pnpClient, projClient}
 	nss := &nsSyncer{npmgr}
 	pnps := &projectNetworkPolicySyncer{npmgr}
 	podHandler := &podHandler{npmgr, pods}
 	serviceHandler := &serviceHandler{npmgr}
-	nodeHandler := &nodeHandler{npmgr, machines, cluster.ClusterName}
+	nodeHandler := &nodeHandler{npmgr, cluster.ClusterName}
 
 	cluster.Management.Management.Projects("").Controller().AddClusterScopedHandler("projectSyncer", cluster.ClusterName, ps.Sync)
 	cluster.Management.Management.ProjectNetworkPolicies("").AddClusterScopedHandler("projectNetworkPolicySyncer", cluster.ClusterName, pnps.Sync)

--- a/pkg/controllers/user/networkpolicy/servicehandler.go
+++ b/pkg/controllers/user/networkpolicy/servicehandler.go
@@ -1,8 +1,12 @@
 package networkpolicy
 
 import (
+	"sort"
+
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	knetworkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type serviceHandler struct {
@@ -14,5 +18,62 @@ func (sh *serviceHandler) Sync(key string, service *corev1.Service) error {
 		return nil
 	}
 	logrus.Debugf("serviceHandler: Sync: %+v", *service)
-	return sh.npmgr.nodePortsUpdateHandler(service)
+	return sh.nodePortsUpdateHandler(service)
+}
+
+func (sh *serviceHandler) nodePortsUpdateHandler(service *corev1.Service) error {
+	np := getServiceNetworkPolicy(service)
+	hasNodePorts := false
+	for _, port := range service.Spec.Ports {
+		if port.NodePort != 0 {
+			tp := port.TargetPort
+			proto := corev1.Protocol(port.Protocol)
+			p := knetworkingv1.NetworkPolicyPort{
+				Protocol: &proto,
+				Port:     &tp,
+			}
+			np.Spec.Ingress[0].Ports = append(np.Spec.Ingress[0].Ports, p)
+			hasNodePorts = true
+		}
+	}
+
+	// sort ports so it always appears in a certain order
+	sort.Slice(np.Spec.Ingress[0].Ports, func(i, j int) bool {
+		return portToString(np.Spec.Ingress[0].Ports[i]) < portToString(np.Spec.Ingress[0].Ports[j])
+	})
+	if hasNodePorts {
+		logrus.Debugf("netpolMgr: nodePortsUpdateHandler: service=%+v has node ports, hence programming np=%+v", *service, *np)
+		return sh.npmgr.program(np)
+	}
+
+	return nil
+}
+
+func getServiceNetworkPolicy(service *corev1.Service) *knetworkingv1.NetworkPolicy {
+	np := &knetworkingv1.NetworkPolicy{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "np-" + service.Name,
+			Namespace: service.Namespace,
+			OwnerReferences: []v1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Service",
+					UID:        service.UID,
+					Name:       service.Name,
+				},
+			},
+		},
+		Spec: knetworkingv1.NetworkPolicySpec{
+			PodSelector: v1.LabelSelector{
+				MatchLabels: service.Spec.Selector,
+			},
+			Ingress: []knetworkingv1.NetworkPolicyIngressRule{
+				{
+					From:  []knetworkingv1.NetworkPolicyPeer{},
+					Ports: []knetworkingv1.NetworkPolicyPort{},
+				},
+			},
+		},
+	}
+	return np
 }


### PR DESCRIPTION
* reduce the amount of v3.node updates by not processing pod events as k8s syncs up nodes every 5 seconds anyway
* minor performance fixes to network policy code to eliminate unnecessary updates.
* network policy fixes to return error instead of logging it, so the framework would retry the update

https://github.com/rancher/rancher/issues/14372
https://github.com/rancher/rancher/issues/14402