### PR TITLE
clean up debug logs for netpolmgr

### DIFF
--- a/pkg/controllers/user/networkpolicy/netpol.go
+++ b/pkg/controllers/user/networkpolicy/netpol.go
@@ -267,17 +267,17 @@ func (npmgr *netpolMgr) handleHostNetwork() error {
 	if err != nil {
 		return fmt.Errorf("couldn't list nodes err=%v", err)
 	}
-	logrus.Debugf("netpolMgr: handleHostNetwork: nodes=%+v", nodes)
+	logrus.Debugf("netpolMgr: handleHostNetwork: processing %d nodes", len(nodes))
 
 	for _, node := range nodes {
-		logrus.Debugf("netpolMgr: handleHostNetwork: node=%+v", node)
 		if _, ok := node.Annotations[FlannelPresenceLabel]; !ok {
 			logrus.Debugf("netpolMgr: handleHostNetwork: node=%v doesn't have flannel label, skipping", node.Name)
 			continue
 		}
 		podCIDRFirstIP, _, err := net.ParseCIDR(node.Spec.PodCIDR)
 		if err != nil {
-			logrus.Errorf("netpolMgr: handleHostNetwork: couldn't parse PodCIDR(%v) err=%v", node.Spec.PodCIDR, err)
+			logrus.Debugf("netpolMgr: handleHostNetwork: node=%+v", node)
+			logrus.Errorf("netpolMgr: handleHostNetwork: couldn't parse PodCIDR(%v) for node %v err=%v", node.Spec.PodCIDR, node.Name, err)
 			continue
 		}
 		ipBlock := knetworkingv1.IPBlock{


### PR DESCRIPTION
Currently, in debug, we are logging the entire array of nodes then printing them one by one. The array is unnecessary to view and in larger clusters is difficult to grok at all and is duplicated.

So this just now outputs the length of the array as that seems like it could be correlated to cluster node count. 

I also removed the entire node output except in the case where there is an error. I also added node name to the pod error when the cidr fails just for clarity. 