### PR TITLE
Fix the /var/run/docker.sock too many open files issue

### DIFF
--- a/pkg/remotedialer/client.go
+++ b/pkg/remotedialer/client.go
@@ -29,6 +29,7 @@ func connectToProxy(proxyURL string, headers http.Header, auth ConnectAuthorizer
 		logrus.WithError(err).Error("Failed to connect to proxy")
 		return err
 	}
+	defer ws.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Close the domain socket connection to prevent from hitting the open files limit which results in ruining the whole cluster.