### PR TITLE
Don't print empty certificate-authority-data in kubeconfig

### DIFF
--- a/pkg/kubeconfig/templates.go
+++ b/pkg/kubeconfig/templates.go
@@ -10,7 +10,9 @@ clusters:
   cluster:
     server: "https://{{.Host}}/k8s/clusters/{{.ClusterID}}"
     api-version: v1
+{{- if ne .Cert "" }}
     certificate-authority-data: "{{.Cert}}"
+{{- end }}
 
 users:
 - name: "{{.User}}"


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/14488