### PR TITLE
 Adding action drain on node

### DIFF
--- a/pkg/controllers/user/controllers.go
+++ b/pkg/controllers/user/controllers.go
@@ -36,7 +36,7 @@ func Register(ctx context.Context, cluster *config.UserContext, kubeConfigGetter
 	logging.Register(ctx, cluster)
 	networkpolicy.Register(cluster)
 	noderemove.Register(cluster)
-	nodesyncer.Register(cluster, kubeConfigGetter)
+	nodesyncer.Register(ctx, cluster, kubeConfigGetter)
 	nslabels.Register(cluster)
 	pipeline.Register(ctx, cluster)
 	podsecuritypolicy.RegisterCluster(cluster)

--- a/pkg/controllers/user/controllers.go
+++ b/pkg/controllers/user/controllers.go
@@ -36,7 +36,7 @@ func Register(ctx context.Context, cluster *config.UserContext, kubeConfigGetter
 	logging.Register(ctx, cluster)
 	networkpolicy.Register(cluster)
 	noderemove.Register(cluster)
-	nodesyncer.Register(cluster)
+	nodesyncer.Register(cluster, kubeConfigGetter)
 	nslabels.Register(cluster)
 	pipeline.Register(ctx, cluster)
 	podsecuritypolicy.RegisterCluster(cluster)

--- a/pkg/controllers/user/nodesyncer/cordonfieldssyncer.go
+++ b/pkg/controllers/user/nodesyncer/cordonfieldssyncer.go
@@ -1,13 +1,25 @@
 package nodesyncer
 
 import (
+	"fmt"
+
+	"strings"
+
 	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/rancher/pkg/kubectl"
 	nodehelper "github.com/rancher/rancher/pkg/node"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+const (
+	drainTokenPrefix = "drain-node-"
+	description      = "token for drain"
 )
 
 func (m *NodesSyncer) syncCordonFields(key string, obj *v3.Node) error {
-	if obj == nil || obj.DeletionTimestamp != nil || obj.Spec.DesiredNodeUnschedulable == "" {
+	if obj == nil || obj.DeletionTimestamp != nil || obj.Spec.DesiredNodeUnschedulable == "" || obj.Spec.DesiredNodeUnschedulable == "drain" {
 		return nil
 	}
 	node, err := nodehelper.GetNodeForMachine(obj, m.nodeLister)
@@ -23,9 +35,123 @@ func (m *NodesSyncer) syncCordonFields(key string, obj *v3.Node) error {
 		}
 	}
 	nodeCopy := obj.DeepCopy()
+	if !desiredValue {
+		removeDrainCondition(nodeCopy)
+	}
 	nodeCopy.Spec.DesiredNodeUnschedulable = ""
-	if _, err := m.machines.Update(nodeCopy); err != nil {
+	_, err = m.machines.Update(nodeCopy)
+	if err != nil {
 		return err
 	}
 	return nil
+}
+
+func (d *NodeDrain) drainNode(key string, obj *v3.Node) error {
+	if obj == nil || obj.DeletionTimestamp != nil || obj.Spec.DesiredNodeUnschedulable != "drain" {
+		return nil
+	}
+	kubeConfig, err := d.getKubeConfig()
+	if err != nil {
+		return err
+	}
+	nodeName := obj.Spec.RequestedHostname
+	updatedObj, err := v3.NodeConditionDrained.DoUntilTrue(obj, func() (runtime.Object, error) {
+		_, msg, err := kubectl.Drain(kubeConfig, nodeName, getFlags(obj.Spec.NodeDrainInput))
+		if err != nil {
+			errMsg := filterErrorMsg(msg, nodeName)
+			return obj, fmt.Errorf("%s", errMsg)
+		}
+		return obj, nil
+	})
+	nodeCopy := updatedObj.(*v3.Node).DeepCopy()
+	if err == nil {
+		nodeCopy.Spec.DesiredNodeUnschedulable = ""
+	}
+	if _, err := d.machines.Update(nodeCopy); err != nil {
+		return err
+	}
+	if err != nil {
+		return fmt.Errorf("Error draining node [%s] in cluster [%s] : %s", nodeName, d.clusterName, err)
+	}
+	return nil
+}
+
+func (d *NodeDrain) getKubeConfig() (*clientcmdapi.Config, error) {
+	cluster, err := d.clusterLister.Get("", d.clusterName)
+	if err != nil {
+		return nil, err
+	}
+	user, err := d.systemAccountManager.GetSystemUser(cluster)
+	if err != nil {
+		return nil, err
+	}
+	token, err := d.userManager.EnsureToken(drainTokenPrefix+user.Name, description, user.Name)
+	if err != nil {
+		return nil, err
+	}
+	kubeConfig := d.kubeConfigGetter.KubeConfig(d.clusterName, token)
+	for k := range kubeConfig.Clusters {
+		kubeConfig.Clusters[k].InsecureSkipTLSVerify = true
+	}
+	return kubeConfig, nil
+}
+
+func getFlags(input *v3.NodeDrainInput) []string {
+	return []string{
+		fmt.Sprintf("--delete-local-data=%v", input.DeleteLocalData),
+		fmt.Sprintf("--force=%v", input.Force),
+		fmt.Sprintf("--grace-period=%v", input.GracePeriod),
+		fmt.Sprintf("--ignore-daemonsets=%v", input.IgnoreDaemonSets),
+		fmt.Sprintf("--timeout=%s", convert.ToString(input.Timeout)+"s")}
+}
+
+func filterErrorMsg(msg string, nodeName string) string {
+	upd := []string{}
+	lines := strings.Split(msg, "\n")
+	for _, line := range lines[1:] {
+		if strings.HasPrefix(line, "WARNING") || strings.HasPrefix(line, nodeName) {
+			continue
+		}
+		if strings.Contains(line, "aborting") {
+			continue
+		}
+		if strings.HasPrefix(line, "There are pending nodes ") {
+			// for only one node in our case
+			continue
+		}
+		if strings.HasPrefix(line, "There are pending pods ") {
+			// already considered error
+			continue
+		}
+		if strings.HasPrefix(line, "error") && strings.Contains(line, "unable to drain node") {
+			// actual reason at end
+			continue
+		}
+		if strings.HasPrefix(line, "pod") && strings.Contains(line, "evicted") {
+			// evicted successfully
+			continue
+		}
+		upd = append(upd, line)
+	}
+	return strings.Join(upd, "\n")
+}
+
+func removeDrainCondition(obj *v3.Node) {
+	exists := false
+	for _, condition := range obj.Status.Conditions {
+		if condition.Type == "Drained" {
+			exists = true
+			break
+		}
+	}
+	if exists {
+		var conditions []v3.NodeCondition
+		for _, condition := range obj.Status.Conditions {
+			if condition.Type == "Drained" {
+				continue
+			}
+			conditions = append(conditions, condition)
+		}
+		obj.Status.Conditions = conditions
+	}
 }

--- a/pkg/controllers/user/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/user/nodesyncer/nodessyncer.go
@@ -5,10 +5,13 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
+	"github.com/rancher/rancher/pkg/controllers/management/compose/common"
 	nodehelper "github.com/rancher/rancher/pkg/node"
+	"github.com/rancher/rancher/pkg/systemaccount"
 	"github.com/rancher/types/apis/core/v1"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
+	"github.com/rancher/types/user"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -43,7 +46,18 @@ type NodesSyncer struct {
 	clusterLister    v3.ClusterLister
 }
 
-func Register(cluster *config.UserContext) {
+type NodeDrain struct {
+	userManager          user.Manager
+	tokenClient          v3.TokenInterface
+	userClient           v3.UserInterface
+	kubeConfigGetter     common.KubeConfigGetter
+	clusterName          string
+	systemAccountManager *systemaccount.Manager
+	clusterLister        v3.ClusterLister
+	machines             v3.NodeInterface
+}
+
+func Register(cluster *config.UserContext, kubeConfigGetter common.KubeConfigGetter) {
 	m := &NodesSyncer{
 		clusterNamespace: cluster.ClusterName,
 		machines:         cluster.Management.Management.Nodes(cluster.ClusterName),
@@ -60,10 +74,22 @@ func Register(cluster *config.UserContext) {
 		nodesSyncer:      m,
 	}
 
+	d := &NodeDrain{
+		userManager:          cluster.Management.UserManager,
+		tokenClient:          cluster.Management.Management.Tokens(""),
+		userClient:           cluster.Management.Management.Users(""),
+		kubeConfigGetter:     kubeConfigGetter,
+		clusterName:          cluster.ClusterName,
+		systemAccountManager: systemaccount.NewManager(cluster.Management),
+		clusterLister:        cluster.Management.Management.Clusters("").Controller().Lister(),
+		machines:             cluster.Management.Management.Nodes(cluster.ClusterName),
+	}
+
 	cluster.Core.Nodes("").Controller().AddHandler("nodesSyncer", n.sync)
 	cluster.Management.Management.Nodes(cluster.ClusterName).Controller().AddHandler("machinesSyncer", m.sync)
 	cluster.Management.Management.Nodes(cluster.ClusterName).Controller().AddHandler("machinesLabelSyncer", m.syncLabels)
 	cluster.Management.Management.Nodes(cluster.ClusterName).Controller().AddHandler("cordonFieldsSyncer", m.syncCordonFields)
+	cluster.Management.Management.Nodes(cluster.ClusterName).Controller().AddHandler("drainNodeSyncer", d.drainNode)
 }
 
 func (n *NodeSyncer) sync(key string, node *corev1.Node) error {

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -1,6 +1,7 @@
 package kubectl
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -46,7 +47,7 @@ func Apply(yaml []byte, kubeConfig *clientcmdapi.Config) ([]byte, error) {
 	return runWithHTTP2(cmd)
 }
 
-func Drain(kubeConfig *clientcmdapi.Config, nodeName string, args []string) ([]byte, string, error) {
+func Drain(ctx context.Context, kubeConfig *clientcmdapi.Config, nodeName string, args []string) ([]byte, string, error) {
 	kubeConfigFile, err := tempFile("kubeconfig-")
 	if err != nil {
 		return nil, "", err
@@ -57,7 +58,7 @@ func Drain(kubeConfig *clientcmdapi.Config, nodeName string, args []string) ([]b
 		return nil, "", err
 	}
 
-	cmd := exec.Command("kubectl",
+	cmd := exec.CommandContext(ctx, "kubectl",
 		"--kubeconfig",
 		kubeConfigFile.Name(),
 		"drain",

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"strings"
 
+	"fmt"
+
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -42,6 +44,36 @@ func Apply(yaml []byte, kubeConfig *clientcmdapi.Config) ([]byte, error) {
 		"-f",
 		yamlFile.Name())
 	return runWithHTTP2(cmd)
+}
+
+func Drain(kubeConfig *clientcmdapi.Config, nodeName string, args []string) ([]byte, string, error) {
+	kubeConfigFile, err := tempFile("kubeconfig-")
+	if err != nil {
+		return nil, "", err
+	}
+	defer os.Remove(kubeConfigFile.Name())
+
+	if err := clientcmd.WriteToFile(*kubeConfig, kubeConfigFile.Name()); err != nil {
+		return nil, "", err
+	}
+
+	cmd := exec.Command("kubectl",
+		"--kubeconfig",
+		kubeConfigFile.Name(),
+		"drain",
+		nodeName)
+	cmd.Args = append(cmd.Args, args...)
+
+	var newEnv []string
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, "DISABLE_HTTP2") {
+			continue
+		}
+		newEnv = append(newEnv, env)
+	}
+	cmd.Env = newEnv
+	output, err := cmd.CombinedOutput()
+	return output, fmt.Sprint(cmd.Stderr), err
 }
 
 func tempFile(prefix string) (*os.File, error) {


### PR DESCRIPTION
Feature: Ability to drain node 

- `drain` action available on node 

- if drained successfully, state should show `drained`, else it'll stay in `draining` state and error message would be displayed in logs, UI and under conditions (NodeCondition `Drained`) 

- to stop the draining process, use the `stopDrain` action. 

- to call `drain` from API, the input would look like - 
```
curl -u $token --insecure -H 'Content-Type: application/json' https://localhost:8443/v3/nodes/local:machine-k6ct9?action=drain-X POST -d '{"deleteLocalData":"true","force":"false","gracePeriod":"-1","ignoreDaemonSets":"true","timeout":"20"
``` 
- Information about the params and default values - 
```
type NodeDrainInput struct {
	// Drain node even if there are pods not managed by a ReplicationController, Job, or DaemonSet
	// Drain will not proceed without Force set to true if there are such pods
	Force bool `json:"force,omitempty"`
	// If there are DaemonSet-managed pods, drain will not proceed without IgnoreDaemonSets set to true
	// (even when set to true, kubectl won't delete pods - so setting default to true)
	IgnoreDaemonSets bool `json:"ignoreDaemonSets,omitempty" norman:"default=true"`
	// Continue even if there are pods using emptyDir
	DeleteLocalData bool `json:"deleteLocalData,omitempty"`
	//Period of time in seconds given to each pod to terminate gracefully.
	// If negative, the default value specified in the pod will be used
	GracePeriod int `json:"gracePeriod,omitempty" norman:"default=-1"`
	// Time to wait (in seconds) before giving up for one try
	Timeout int `json:"timeout" norman:"min=1,max=10800,default=60"`
}
``` 

https://github.com/rancher/rancher/issues/14265 
https://github.com/rancher/types/pull/498 
https://github.com/rancher/types/pull/539