### PR TITLE
Default RBAC permissions for resource quota template

### DIFF
--- a/app/role_data.go
+++ b/app/role_data.go
@@ -33,6 +33,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 	rb.addRole("Manage Authentication", "authn-manage").addRule().apiGroups("management.cattle.io").resources("authconfigs").verbs("get", "list", "watch", "update")
 	rb.addRole("Manage Settings", "settings-manage").addRule().apiGroups("management.cattle.io").resources("settings").verbs("*")
 	rb.addRole("Manage PodSecurityPolicy Templates", "podsecuritypolicytemplates-manage").addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("*")
+	rb.addRole("Manage ResourceQuota Templates", "resourcequotatemplates-manage").addRule().apiGroups("management.cattle.io").resources("resourcequotatemplates").verbs("*")
 
 	rb.addRole("Admin", "admin").addRule().apiGroups("*").resources("*").verbs("*").
 		addRule().apiGroups().nonResourceURLs("*").verbs("*")
@@ -47,7 +48,8 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("nodetemplates").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("sourcecodecredentials").verbs("*").
-		addRule().apiGroups("management.cattle.io").resources("sourcecoderepositories").verbs("*")
+		addRule().apiGroups("management.cattle.io").resources("sourcecoderepositories").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("resourcequotatemplates").verbs("get", "list", "watch")
 
 	rb.addRole("User Base", "user-base").addRule().apiGroups("management.cattle.io").resources("principals", "roletemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("users").verbs("get", "list", "watch").
@@ -87,7 +89,8 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("management.cattle.io").resources("clusterpipelines").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("clusterloggings").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("clusteralerts").verbs("get", "list", "watch").
-		addRule().apiGroups("management.cattle.io").resources("notifiers").verbs("get", "list", "watch")
+		addRule().apiGroups("management.cattle.io").resources("notifiers").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("resourcequotatemplates").verbs("*")
 
 	rb.addRoleTemplate("Create Projects", "projects-create", "cluster", true, false, false).
 		addRule().apiGroups("management.cattle.io").resources("projects").verbs("create")
@@ -101,6 +104,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("*").resources("storageclasses").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("persistentvolumeclaims").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("resourcequotatemplates").verbs("get", "list", "watch").
 		setRoleTemplateNames("view")
 
 	rb.addRoleTemplate("Manage Nodes", "nodes-manage", "cluster", true, false, false).
@@ -138,6 +142,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("management.cattle.io").resources("notifiers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectalerts").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("projectloggings").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("resourcequotatemplates").verbs("get", "list", "watch").
 		setRoleTemplateNames("admin")
 
 	rb.addRoleTemplate("Project Member", "project-member", "project", true, false, false).
@@ -155,6 +160,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("management.cattle.io").resources("notifiers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectalerts").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("projectloggings").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("resourcequotatemplates").verbs("get", "list", "watch").
 		setRoleTemplateNames("edit")
 
 	rb.addRoleTemplate("Read-only", "read-only", "project", true, false, false).
@@ -171,6 +177,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("management.cattle.io").resources("notifiers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectalerts").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectloggings").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("resourcequotatemplates").verbs("get", "list", "watch").
 		setRoleTemplateNames("view")
 
 	rb.addRoleTemplate("Create Namespaces", "create-ns", "project", true, false, false).

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -23,7 +23,7 @@ const (
 
 var clusterManagmentPlaneResources = []string{"clusterroletemplatebindings", "nodes", "nodepools", "clusterevents",
 	"projects", "clusterregistrationtokens", "clusterpipelines", "clusterloggings", "notifiers", "clusteralerts",
-	"podsecuritypolicytemplateprojectbindings"}
+	"podsecuritypolicytemplateprojectbindings", "resourcequotatemplates"}
 
 type crtbLifecycle struct {
 	mgr           *manager


### PR DESCRIPTION
The purpose of this PR is to define RBAC permissions for `resourceQuotaTemplate` type, so ClusterOwner/ClusterMember can do anything, and other roles can only View.