### PR TITLE
Update golang version to fix golang TLS issue for AD

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -12,7 +12,7 @@ RUN apt-get update && \
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.9.2.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN wget -O - https://storage.googleapis.com/golang/go1.10.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get github.com/golang/lint/golint
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \

--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -65,9 +65,8 @@ fi
 set -e -x
 REGISTRY=$1
 
-docker load --input rancher-images.tar.gz
-
-`)
+docker load --input rancher-images.tar.gz`)
+	fmt.Fprint(load, "\n\n")
 
 	for _, saveImage := range saveImages(targetImages) {
 		fmt.Fprintf(load, "docker tag %s ${REGISTRY}/%s\n", saveImage, saveImage)

--- a/scripts/build-server
+++ b/scripts/build-server
@@ -7,4 +7,4 @@ cd $(dirname $0)/..
 
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
-CGO_ENABLED=0 go build -i -tags k8s -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/rancher
+go build -i -tags k8s -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/rancher


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/14502

After updating to go1.10.3, the CGO_ENABLED=0 part of build command
in build-server script threw this error "loadinternal: cannot find runtime/cgo"
and then that would eventually lead to a segmentation fault. The build
would just freeze without running any tests. This commit removes CGO_ENABLED=0,
since cgo is disabled by default when cross compiling, as per https://golang.org/cmd/cgo/
f164240