### PR TITLE
Cleanup imported cluster on delete

### DIFF
--- a/package/run.sh
+++ b/package/run.sh
@@ -6,6 +6,7 @@ info()
 {
     echo "INFO:" "$@" 1>&2
 }
+
 error()
 {
     echo "ERROR:" "$@" 1>&2
@@ -23,6 +24,10 @@ fi
 if [ "$1" = "--" ]; then
     shift 1
     exec "$@"
+fi
+
+if [ "$CLUSTER_CLEANUP" = true ]; then
+    exec agent
 fi
 
 get_address()

--- a/pkg/agent/clean/clean.go
+++ b/pkg/agent/clean/clean.go
@@ -1,0 +1,360 @@
+/*
+The cleanup is designed to get a cluster that was imported to Rancher disconnected
+and cleanup some objects
+
+Remove the cattle-system namespace which houses the agent used to talk
+to Rancher
+
+Remove Rancher labels, finalizers and annotations from all namespaces
+
+If the cluster was imported to Rancher 2.1 or later cleanup roles, rolebindings,
+clusterRoles and clusterRoleBindings
+*/
+
+package clean
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/rancher/rancher/pkg/controllers/user/nslabels"
+	"github.com/sirupsen/logrus"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+var (
+	// List of namespace labels that will be removed
+	nsLabels = []string{
+		nslabels.ProjectIDFieldLabel,
+	}
+
+	// List of namespace annotations that will be removed
+	nsAnnotations = []string{
+		"cattle.io/status",
+		"field.cattle.io/creatorId",
+		"lifecycle.cattle.io/create.namespace-auth",
+		nslabels.ProjectIDFieldLabel,
+	}
+
+	dryRun bool
+)
+
+func Cluster() error {
+	if os.Getenv("DRY_RUN") == "true" {
+		dryRun = true
+	}
+
+	if os.Getenv("SLEEP_FIRST") == "true" {
+		// The sleep allows Rancher server time to finish updating ownerReferences
+		// and close the connection.
+		logrus.Info("Starting sleep for 1 min to allow server time to disconnect....")
+		time.Sleep(time.Duration(1) * time.Minute)
+	}
+
+	logrus.Info("Starting cluster cleanup")
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return err
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	var errors []error
+
+	err = removeCattleNamespace(client)
+	if err != nil {
+		errors = append(errors, err)
+	}
+
+	nsErr := cleanupNamespaces(client)
+	if len(nsErr) > 0 {
+		errors = append(errors, nsErr...)
+	}
+
+	crbErr := cleanupClusterRoleBindings(client)
+	if len(crbErr) > 0 {
+		errors = append(errors, crbErr...)
+	}
+
+	cbErr := cleanupRoleBindings(client)
+	if len(cbErr) > 0 {
+		errors = append(errors, cbErr...)
+	}
+
+	crErr := cleanupClusterRoles(client)
+	if len(crErr) > 0 {
+		errors = append(errors, crErr...)
+	}
+
+	rErr := cleanupRoles(client)
+	if len(rErr) > 0 {
+		errors = append(errors, rErr...)
+	}
+
+	if len(errors) > 0 {
+		return processErrors(errors)
+	}
+
+	return deleteJob(client)
+}
+
+func removeCattleNamespace(client *kubernetes.Clientset) error {
+	logrus.Info("Attempting to remove cattle-system namespace")
+	return tryUpdate(func() error {
+		ns, err := client.CoreV1().Namespaces().Get("cattle-system", metav1.GetOptions{})
+		if err != nil {
+			if apierror.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if len(ns.Finalizers) > 0 {
+			ns.Finalizers = []string{}
+		}
+
+		logrus.Infof("Updating namespace: %v", ns.Name)
+		if !dryRun {
+			ns, err = client.CoreV1().Namespaces().Update(ns)
+			if err != nil {
+				return err
+			}
+		}
+
+		logrus.Infof("Deleting namespace: %v", ns.Name)
+		if !dryRun {
+			err = client.CoreV1().Namespaces().Delete("cattle-system", &metav1.DeleteOptions{})
+			if err != nil {
+				if !apierror.IsNotFound(err) {
+					return err
+				}
+			}
+		}
+
+		return nil
+	})
+}
+
+var listOptions metav1.ListOptions = metav1.ListOptions{
+	LabelSelector: "cattle.io/creator=norman",
+}
+
+func cleanupNamespaces(client *kubernetes.Clientset) []error {
+	logrus.Info("Starting cleanup of namespaces")
+	namespaces, err := client.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		return []error{err}
+	}
+
+	var errs []error
+
+	for _, ns := range namespaces.Items {
+		err = tryUpdate(func() error {
+			nameSpace, err := client.CoreV1().Namespaces().Get(ns.Name, metav1.GetOptions{})
+			if err != nil {
+				if apierror.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+
+			var updated bool
+
+			// Cleanup finalizers
+			if len(nameSpace.Finalizers) > 0 {
+				finalizers := []string{}
+				for _, finalizer := range nameSpace.Finalizers {
+					if finalizer != "controller.cattle.io/namespace-auth" {
+						finalizers = append(finalizers, finalizer)
+					}
+				}
+				if len(nameSpace.Finalizers) != len(finalizers) {
+					updated = true
+					nameSpace.Finalizers = finalizers
+				}
+			}
+
+			// Cleanup labels
+			for _, label := range nsLabels {
+				if _, ok := nameSpace.Labels[label]; ok {
+					updated = ok
+					delete(nameSpace.Labels, label)
+				}
+			}
+
+			// Cleanup annotations
+			for _, anno := range nsAnnotations {
+				if _, ok := nameSpace.Annotations[anno]; ok {
+					updated = ok
+					delete(nameSpace.Annotations, anno)
+				}
+			}
+
+			if updated {
+				logrus.Infof("Updating namespace: %v", nameSpace.Name)
+				if !dryRun {
+					_, err = client.CoreV1().Namespaces().Update(nameSpace)
+					if err != nil {
+						return err
+					}
+				}
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errs
+
+}
+
+func cleanupClusterRoleBindings(client *kubernetes.Clientset) []error {
+	logrus.Info("Starting cleanup of clusterRoleBindings")
+	crbs, err := client.RbacV1().ClusterRoleBindings().List(listOptions)
+	if err != nil {
+		return []error{err}
+	}
+
+	var errs []error
+
+	for _, crb := range crbs.Items {
+		logrus.Infof("Deleting clusterRoleBinding: %v", crb.Name)
+		if !dryRun {
+			err = client.RbacV1().ClusterRoleBindings().Delete(crb.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+func cleanupRoleBindings(client *kubernetes.Clientset) []error {
+	logrus.Info("Starting cleanup of roleBindings")
+	rbs, err := client.RbacV1().RoleBindings("").List(listOptions)
+	if err != nil {
+		return []error{err}
+	}
+
+	var errs []error
+
+	for _, rb := range rbs.Items {
+		logrus.Infof("Deleting roleBinding: %v", rb.Name)
+		if !dryRun {
+			err = client.RbacV1().RoleBindings(rb.Namespace).Delete(rb.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+func cleanupClusterRoles(client *kubernetes.Clientset) []error {
+	logrus.Info("Starting cleanup of clusterRoles")
+	crs, err := client.RbacV1().ClusterRoles().List(listOptions)
+	if err != nil {
+		return []error{err}
+	}
+
+	var errs []error
+
+	for _, cr := range crs.Items {
+		logrus.Infof("Deleting clusterRole: %v", cr.Name)
+		if !dryRun {
+			err = client.RbacV1().ClusterRoles().Delete(cr.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+func cleanupRoles(client *kubernetes.Clientset) []error {
+	logrus.Info("Starting cleanup of roles")
+	rs, err := client.RbacV1().Roles("").List(listOptions)
+	if err != nil {
+		return []error{err}
+	}
+
+	var errs []error
+
+	for _, r := range rs.Items {
+		logrus.Infof("Deleting role: %v", r.Name)
+		if !dryRun {
+			err = client.RbacV1().Roles(r.Namespace).Delete(r.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+func deleteJob(client *kubernetes.Clientset) error {
+	logrus.Info("Starting cleanup of jobs")
+	jobs, err := client.BatchV1().Jobs("default").List(listOptions)
+	if err != nil {
+		return err
+	}
+
+	for _, job := range jobs.Items {
+		prop := metav1.DeletePropagationBackground
+		if strings.HasPrefix(job.Name, "cattle-cleanup") {
+			logrus.Infof("Deleting job: %v", job.Name)
+			if !dryRun {
+				err = client.BatchV1().Jobs("default").Delete(job.Name, &metav1.DeleteOptions{
+					PropagationPolicy: &prop,
+				})
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// tryUpdate runs the input func and if the error returned is a conflict error
+// from k8s it will sleep and attempt to run the func again. This is useful
+// when attempting to update an object.
+func tryUpdate(f func() error) error {
+	sleepTime := 100
+	tries := 0
+	var err error
+	for tries <= 3 {
+		err = f()
+		if err != nil {
+			if apierror.IsConflict(err) {
+				time.Sleep(time.Duration(sleepTime) * time.Millisecond)
+				sleepTime *= 2
+				tries++
+				continue
+			}
+			return err
+		}
+		break
+	}
+	return err
+}
+
+func processErrors(errs []error) error {
+	errorString := "Errors: "
+	for _, err := range errs {
+		errorString += fmt.Sprintf("%s ", err)
+	}
+	return errors.New(errorString)
+}

--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
+	"github.com/rancher/rancher/pkg/agent/clean"
 	"github.com/rancher/rancher/pkg/agent/cluster"
 	"github.com/rancher/rancher/pkg/agent/node"
 	"github.com/rancher/rancher/pkg/logserver"
@@ -41,7 +42,15 @@ func main() {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
-	if err := run(); err != nil {
+	var err error
+
+	if os.Getenv("CLUSTER_CLEANUP") == "true" {
+		err = clean.Cluster()
+	} else {
+		err = run()
+	}
+
+	if err != nil {
 		log.Fatal(err)
 	}
 }

--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -2,10 +2,18 @@ package usercontrollers
 
 import (
 	"context"
+	"time"
 
+	"github.com/rancher/norman/httperror"
 	"github.com/rancher/rancher/pkg/clustermanager"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
+	batchV1 "k8s.io/api/batch/v1"
+	coreV1 "k8s.io/api/core/v1"
+	rbacV1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 /*
@@ -63,10 +71,272 @@ func (c *ClusterLifecycleCleanup) Create(obj *v3.Cluster) (*v3.Cluster, error) {
 }
 
 func (c *ClusterLifecycleCleanup) Remove(obj *v3.Cluster) (*v3.Cluster, error) {
+	if obj.Status.Driver == v3.ClusterDriverImported {
+		err := c.cleanupImportedCluster(obj)
+		if err != nil {
+			apiError, ok := err.(*httperror.APIError)
+			// If it's not an API error give it back
+			if !ok {
+				return nil, err
+			}
+			// If it's anything but clusterUnavailable give it back
+			if apiError.Code != httperror.ClusterUnavailable {
+				return nil, err
+			}
+		}
+	}
+
 	c.Manager.Stop(obj)
 	return nil, nil
 }
 
 func (c *ClusterLifecycleCleanup) Updated(obj *v3.Cluster) (*v3.Cluster, error) {
 	return nil, nil
+}
+
+func (c *ClusterLifecycleCleanup) cleanupImportedCluster(cluster *v3.Cluster) error {
+	userContext, err := c.Manager.UserContext(cluster.Name)
+	if err != nil {
+		return err
+	}
+
+	role, err := c.createCleanupClusterRole(userContext)
+	if err != nil {
+		return err
+	}
+
+	sa, err := c.createCleanupServiceAccount(userContext)
+	if err != nil {
+		return err
+	}
+
+	crb, err := c.createCleanupClusterRoleBinding(userContext, role.Name, sa.Name)
+	if err != nil {
+		return err
+	}
+
+	job, err := c.createCleanupJob(userContext, sa.Name)
+	if err != nil {
+		return err
+	}
+
+	or := []metav1.OwnerReference{
+		metav1.OwnerReference{
+			APIVersion: "batch/v1",
+			Kind:       "Job",
+			Name:       job.Name,
+			UID:        job.UID,
+		},
+	}
+
+	// These resouces need the ownerReference added so they get cleaned up after
+	// the job deletes itself.
+
+	err = c.updateClusterRoleOwner(userContext, role, or)
+	if err != nil {
+		return err
+	}
+
+	err = c.updateServiceAccountOwner(userContext, sa, or)
+	if err != nil {
+		return err
+	}
+
+	err = c.updateClusterRoleBindingOwner(userContext, crb, or)
+	if err != nil {
+		return err
+	}
+
+	err = userContext.Core.Namespaces("").Delete("cattle-system", &metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *ClusterLifecycleCleanup) createCleanupClusterRole(userContext *config.UserContext) (*rbacV1.ClusterRole, error) {
+	meta := metav1.ObjectMeta{
+		GenerateName: "cattle-cleanup-",
+	}
+
+	rules := []rbacV1.PolicyRule{
+		// This is needed to check for cattle-system, remove finalizers and delete
+		rbacV1.PolicyRule{
+			Verbs:     []string{"list", "get", "update", "delete"},
+			APIGroups: []string{""},
+			Resources: []string{"namespaces"},
+		},
+		rbacV1.PolicyRule{
+			Verbs:     []string{"list", "get", "delete"},
+			APIGroups: []string{"rbac.authorization.k8s.io"},
+			Resources: []string{"roles", "rolebindings", "clusterroles", "clusterrolebindings"},
+		},
+		// The job is going to delete itself after running to trigger ownerReference
+		// cleanup of the clusterRole, serviceAccount and clusterRoleBinding
+		rbacV1.PolicyRule{
+			Verbs:     []string{"list", "get", "delete"},
+			APIGroups: []string{"batch"},
+			Resources: []string{"jobs"},
+		},
+	}
+	clusterRole := rbacV1.ClusterRole{
+		ObjectMeta: meta,
+		Rules:      rules,
+	}
+	return userContext.K8sClient.RbacV1().ClusterRoles().Create(&clusterRole)
+}
+
+func (c *ClusterLifecycleCleanup) createCleanupServiceAccount(userContext *config.UserContext) (*coreV1.ServiceAccount, error) {
+	meta := metav1.ObjectMeta{
+		GenerateName: "cattle-cleanup-",
+		Namespace:    "default",
+	}
+	serviceAccount := coreV1.ServiceAccount{
+		ObjectMeta: meta,
+	}
+	return userContext.K8sClient.CoreV1().ServiceAccounts("default").Create(&serviceAccount)
+}
+
+func (c *ClusterLifecycleCleanup) createCleanupClusterRoleBinding(
+	userContext *config.UserContext,
+	role, sa string,
+) (*rbacV1.ClusterRoleBinding, error) {
+	meta := metav1.ObjectMeta{
+		GenerateName: "cattle-cleanup-",
+		Namespace:    "default",
+	}
+	clusterRoleBinding := rbacV1.ClusterRoleBinding{
+		ObjectMeta: meta,
+		Subjects: []rbacV1.Subject{
+			rbacV1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      sa,
+				Namespace: "default",
+			},
+		},
+		RoleRef: rbacV1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     role,
+		},
+	}
+	return userContext.K8sClient.RbacV1().ClusterRoleBindings().Create(&clusterRoleBinding)
+}
+
+func (c *ClusterLifecycleCleanup) createCleanupJob(userContext *config.UserContext, sa string) (*batchV1.Job, error) {
+	meta := metav1.ObjectMeta{
+		GenerateName: "cattle-cleanup-",
+		Namespace:    "default",
+		Labels:       map[string]string{"cattle.io/creator": "norman"},
+	}
+
+	job := batchV1.Job{
+		ObjectMeta: meta,
+		Spec: batchV1.JobSpec{
+			Template: coreV1.PodTemplateSpec{
+				Spec: coreV1.PodSpec{
+					ServiceAccountName: sa,
+					Containers: []coreV1.Container{
+						coreV1.Container{
+							Name:  "cleanup-agent",
+							Image: settings.AgentImage.Get(),
+							Env: []coreV1.EnvVar{
+								coreV1.EnvVar{
+									Name:  "CLUSTER_CLEANUP",
+									Value: "true",
+								},
+								coreV1.EnvVar{
+									Name:  "SLEEP_FIRST",
+									Value: "true",
+								},
+							},
+							ImagePullPolicy: coreV1.PullAlways,
+						},
+					},
+					RestartPolicy: "OnFailure",
+				},
+			},
+		},
+	}
+	return userContext.K8sClient.BatchV1().Jobs("default").Create(&job)
+}
+
+func (c *ClusterLifecycleCleanup) updateClusterRoleOwner(
+	userContext *config.UserContext,
+	role *rbacV1.ClusterRole,
+	or []metav1.OwnerReference,
+) error {
+	return tryUpdate(func() error {
+		role, err := userContext.K8sClient.RbacV1().ClusterRoles().Get(role.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		role.OwnerReferences = or
+
+		_, err = userContext.K8sClient.RbacV1().ClusterRoles().Update(role)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (c *ClusterLifecycleCleanup) updateServiceAccountOwner(
+	userContext *config.UserContext,
+	sa *coreV1.ServiceAccount,
+	or []metav1.OwnerReference,
+) error {
+	return tryUpdate(func() error {
+		sa, err := userContext.K8sClient.CoreV1().ServiceAccounts("default").Get(sa.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		sa.OwnerReferences = or
+
+		_, err = userContext.K8sClient.CoreV1().ServiceAccounts("default").Update(sa)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (c *ClusterLifecycleCleanup) updateClusterRoleBindingOwner(
+	userContext *config.UserContext,
+	crb *rbacV1.ClusterRoleBinding,
+	or []metav1.OwnerReference,
+) error {
+	return tryUpdate(func() error {
+		crb, err := userContext.K8sClient.RbacV1().ClusterRoleBindings().Get(crb.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		crb.OwnerReferences = or
+
+		_, err = userContext.K8sClient.RbacV1().ClusterRoleBindings().Update(crb)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// tryUpdate runs the input func and if the error returned is a conflict error
+// from k8s it will sleep and attempt to run the func again. This is useful
+// when attempting to update an object.
+func tryUpdate(f func() error) error {
+	timeout := 100
+	for i := 0; i <= 3; i++ {
+		err := f()
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				time.Sleep(time.Duration(timeout) * time.Millisecond)
+				timeout *= 2
+				continue
+			}
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/controllers/user/rbac/crtb_handler.go
+++ b/pkg/controllers/user/rbac/crtb_handler.go
@@ -65,7 +65,7 @@ func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding) error {
 
 func (c *crtbLifecycle) ensureCRTBDelete(binding *v3.ClusterRoleTemplateBinding) error {
 	set := labels.Set(map[string]string{rtbOwnerLabel: string(binding.UID)})
-	bindingCli := c.m.workload.K8sClient.RbacV1().ClusterRoleBindings()
+	bindingCli := c.m.workload.RBAC.ClusterRoleBindings("")
 	rbs, err := c.m.crbLister.List("", set.AsSelector())
 	if err != nil {
 		return errors.Wrapf(err, "couldn't list clusterrolebindings with selector %s", set.AsSelector())

--- a/pkg/controllers/user/rbac/namespace_handler.go
+++ b/pkg/controllers/user/rbac/namespace_handler.go
@@ -245,7 +245,7 @@ func (n *nsLifecycle) reconcileNamespaceProjectClusterRole(ns *v1.Namespace) err
 			return err
 		}
 
-		roleCli := n.m.workload.K8sClient.RbacV1().ClusterRoles()
+		roleCli := n.m.workload.RBAC.ClusterRoles("")
 		nsInDesiredRole := false
 		for _, c := range clusterRoles {
 			cr, ok := c.(*rbacv1.ClusterRole)
@@ -353,7 +353,7 @@ func (n *nsLifecycle) reconcileNamespaceProjectClusterRole(ns *v1.Namespace) err
 }
 
 func (m *manager) createProjectNSRole(roleName, verb, ns string) error {
-	roleCli := m.workload.K8sClient.RbacV1().ClusterRoles()
+	roleCli := m.workload.RBAC.ClusterRoles("")
 
 	cr := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/user/rbac/prtb_handler.go
+++ b/pkg/controllers/user/rbac/prtb_handler.go
@@ -91,7 +91,7 @@ func (p *prtbLifecycle) ensurePRTBDelete(binding *v3.ProjectRoleTemplateBinding)
 	set := labels.Set(map[string]string{rtbOwnerLabel: string(binding.UID)})
 	for _, n := range namespaces {
 		ns := n.(*v1.Namespace)
-		bindingCli := p.m.workload.K8sClient.RbacV1().RoleBindings(ns.Name)
+		bindingCli := p.m.workload.RBAC.RoleBindings(ns.Name)
 		rbs, err := p.m.rbLister.List(ns.Name, set.AsSelector())
 		if err != nil {
 			return errors.Wrapf(err, "couldn't list rolebindings with selector %s", set.AsSelector())
@@ -156,7 +156,7 @@ func (p *prtbLifecycle) reconcileProjectAccessToGlobalResources(binding *v3.Proj
 		return nil
 	}
 
-	bindingCli := p.m.workload.K8sClient.RbacV1().ClusterRoleBindings()
+	bindingCli := p.m.workload.RBAC.ClusterRoleBindings("")
 
 	if createNSPerms {
 		roles = append(roles, "create-ns")
@@ -242,7 +242,7 @@ func (p *prtbLifecycle) reconcileProjectAccessToGlobalResourcesForDelete(binding
 		}
 	}
 
-	bindingCli := p.m.workload.K8sClient.RbacV1().ClusterRoleBindings()
+	bindingCli := p.m.workload.RBAC.ClusterRoleBindings("")
 	rtbUID := string(binding.UID)
 	set := labels.Set(map[string]string{rtbUID: owner})
 	crbs, err := p.m.crbLister.List("", set.AsSelector())

--- a/pkg/controllers/user/rbac/roletemplate_handler.go
+++ b/pkg/controllers/user/rbac/roletemplate_handler.go
@@ -86,7 +86,7 @@ func (c *rtLifecycle) syncRT(template *v3.RoleTemplate, usedInProjects bool) err
 }
 
 func (c *rtLifecycle) ensureRTDelete(template *v3.RoleTemplate) error {
-	roleCli := c.m.workload.K8sClient.RbacV1().ClusterRoles()
+	roleCli := c.m.workload.RBAC.ClusterRoles("")
 	if err := roleCli.Delete(template.Name, &metav1.DeleteOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return errors.Wrapf(err, "error deleting clusterrole %v", template.Name)

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -23,6 +23,8 @@ kind: ClusterRoleBinding
 metadata:
   name: cattle-admin-binding
   namespace: cattle-system
+  labels:
+    cattle.io/creator: "norman"
 subjects:
 - kind: ServiceAccount
   name: cattle
@@ -50,6 +52,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cattle-admin
+  labels:
+    cattle.io/creator: "norman"
 rules:
 - apiGroups:
   - '*'


### PR DESCRIPTION
rancher/rancher#14207
rancher/rancher#14848
rancher/rancher#13512

Docs: https://github.com/rancher/docs/issues/742

(copied from issue 14207)
The solution for this is to create a job that runs in the user cluster and cleans up.

To start, rancher server will create a clusterRole, clusterRoleBinding, serviceAccount and job in the user cluster that is being removed. These are all tied together with an ownerReference back to the job. The job will run the agent image with an env var that is specific to cleanup duty. Starting with the version this is released in (2.1 at this point) the job will perform additional cleanup compared to older versions. If the job runs successfully it will delete itself which in turn deletes the clusterRole, clusterRoleBinding and serviceAccount. If the job fails it will log all errors from the run and start again.

Starting in 2.1 the label `cattle.io/creator=norman' will be added to every resource in a cluster that is created by norman. Prior to 2.1 there is not a deterministic way to tell if we created anything or simply updated it to add our info.

All versions:
Remove the cattle-system namespace.
Cleanup all other namespaces - remove finalizers, annotations and labels

2.1+
Remove roles, roleBindings, clusterRoles and clusterRoleBindings that rancher created