### PR TITLE
Compare env correctly

### DIFF
--- a/pkg/rkeworker/docker.go
+++ b/pkg/rkeworker/docker.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-	"github.com/rancher/norman/types/slice"
 	"github.com/rancher/rke/services"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
@@ -185,15 +184,11 @@ func changed(ctx context.Context, c *client.Client, p v3.Process, container type
 				continue
 			}
 		} else if f.Name == "Env" {
-			changed := false
-			for _, v := range p.Env {
-				if !slice.ContainsString(newProcess.Env, v) {
-					changed = true
-					break
-				}
-			}
-
-			if !changed {
+			// all env
+			allEnv := append(p.Env, imageInspect.Config.Env...)
+			leftMap := sliceToMap(allEnv)
+			rightMap := sliceToMap(newProcess.Env)
+			if reflect.DeepEqual(leftMap, rightMap) {
 				continue
 			}
 		} else if f.Name == "Labels" {

--- a/vendor.conf
+++ b/vendor.conf
@@ -36,7 +36,7 @@ github.com/rancher/rdns-server                f79428ee317c10fa75f6bf2846aa6b88bf
 github.com/rancher/types                      9898f6e9aa967559963ddf13e411e665456d1870
 github.com/rancher/norman                     2af274f9535b97b635bd15ae67de462665c45ffc
 github.com/rancher/kontainer-engine           fe10d279078894f84b8faf71a8f9cb43cdb53cfb
-github.com/rancher/rke                        b483981539d2b638babc2c66364c1fa00ae27fb6
+github.com/rancher/rke                        25018afe3527d9c45c13e9320abdfb3669076a0e
 
 gopkg.in/ldap.v2     v2.5.0
 gopkg.in/asn1-ber.v1 v1.1

--- a/vendor/github.com/rancher/rke/cluster/certificates.go
+++ b/vendor/github.com/rancher/rke/cluster/certificates.go
@@ -319,7 +319,7 @@ func regenerateAPIAggregationCerts(c *Cluster, certificates map[string]pki.Certi
 	certificates[pki.RequestHeaderCACertName] = pki.ToCertObject(pki.RequestHeaderCACertName, "", "", requestHeaderCACrt, requestHeaderCAKey)
 
 	//generate API server proxy client key and certs
-	logrus.Debugf("[certificates] Regenerating Kubernetes API server porxy client certificates")
+	logrus.Debugf("[certificates] Regenerating Kubernetes API server proxy client certificates")
 	apiserverProxyClientCrt, apiserverProxyClientKey, err := pki.GenerateSignedCertAndKey(requestHeaderCACrt, requestHeaderCAKey, true, pki.APIProxyClientCertName, nil, nil, nil)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/rancher/rke/cmd/config.go
+++ b/vendor/github.com/rancher/rke/cmd/config.go
@@ -209,7 +209,7 @@ func getHostConfig(reader *bufio.Reader, index int, clusterSSHKeyPath string) (*
 	}
 	host.User = sshUser
 
-	isControlHost, err := getConfig(reader, fmt.Sprintf("Is host (%s) a control host (y/n)?", address), "y")
+	isControlHost, err := getConfig(reader, fmt.Sprintf("Is host (%s) a Control Plane host (y/n)?", address), "y")
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +217,7 @@ func getHostConfig(reader *bufio.Reader, index int, clusterSSHKeyPath string) (*
 		host.Role = append(host.Role, services.ControlRole)
 	}
 
-	isWorkerHost, err := getConfig(reader, fmt.Sprintf("Is host (%s) a worker host (y/n)?", address), "n")
+	isWorkerHost, err := getConfig(reader, fmt.Sprintf("Is host (%s) a Worker host (y/n)?", address), "n")
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func getHostConfig(reader *bufio.Reader, index int, clusterSSHKeyPath string) (*
 		host.Role = append(host.Role, services.WorkerRole)
 	}
 
-	isEtcdHost, err := getConfig(reader, fmt.Sprintf("Is host (%s) an Etcd host (y/n)?", address), "n")
+	isEtcdHost, err := getConfig(reader, fmt.Sprintf("Is host (%s) an etcd host (y/n)?", address), "n")
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +352,7 @@ func getAddonManifests(reader *bufio.Reader) ([]string, error) {
 	var addonSlice []string
 	var resume = true
 
-	includeAddons, err := getConfig(reader, "Add addon manifest urls or yaml files", "no")
+	includeAddons, err := getConfig(reader, "Add addon manifest URLs or YAML files", "no")
 
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/rancher/rke/hosts/dialer.go
+++ b/vendor/github.com/rancher/rke/hosts/dialer.go
@@ -125,7 +125,12 @@ func (d *dialer) Dial(network, addr string) (net.Conn, error) {
 
 	remote, err := conn.Dial(network, addr)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to access the Docker socket (%s). Please check if the configured user can execute `docker ps` on the node, and if the SSH server version is at least version 6.7 or higher. If you are using RedHat/CentOS, you can't use the user `root`. Please refer to the documentation for more instructions. Error: %v", addr, err)
+		if strings.Contains(err.Error(), "connect failed") {
+			return nil, fmt.Errorf("Unable to access the service on %s. The service might be still starting up. Error: %v", addr, err)
+		} else if strings.Contains(err.Error(), "administratively prohibited") {
+			return nil, fmt.Errorf("Unable to access the Docker socket (%s). Please check if the configured user can execute `docker ps` on the node, and if the SSH server version is at least version 6.7 or higher. If you are using RedHat/CentOS, you can't use the user `root`. Please refer to the documentation for more instructions. Error: %v", addr, err)
+		}
+		return nil, fmt.Errorf("Failed to dial to %s: %v", addr, err)
 	}
 	return remote, err
 }

--- a/vendor/github.com/rancher/rke/services/controlplane.go
+++ b/vendor/github.com/rancher/rke/services/controlplane.go
@@ -19,7 +19,7 @@ func RunControlPlane(ctx context.Context, controlHosts []*hosts.Host, localConnD
 			continue
 		}
 		errgrp.Go(func() error {
-			return doDeployControlHost(ctx, runHost, localConnDialerFactory, prsMap, cpNodePlanMap[host.Address].Processes, alpineImage, certMap)
+			return doDeployControlHost(ctx, runHost, localConnDialerFactory, prsMap, cpNodePlanMap[runHost.Address].Processes, alpineImage, certMap)
 		})
 	}
 	if err := errgrp.Wait(); err != nil {

--- a/vendor/github.com/rancher/rke/vendor.conf
+++ b/vendor/github.com/rancher/rke/vendor.conf
@@ -25,4 +25,4 @@ github.com/Microsoft/go-winio            ab35fc04b6365e8fcb18e6e9e41ea4a02b10b17
 github.com/go-ini/ini                    06f5f3d67269ccec1fe5fe4134ba6e982984f7f5
 
 github.com/rancher/norman                c032c4611f2eec1652ef37d254f0e8ccf90c80aa
-github.com/rancher/types                 556fa1f61dfa7fb20b449a0fadf8d45e341acb9b
+github.com/rancher/types                 9898f6e9aa967559963ddf13e411e665456d1870


### PR DESCRIPTION
This fix compares the process env by appending Dockerfile env and process env and compares it by the docker inspect env. the fix should make sure that when delete env it will be reflected in the k8s component 
https://github.com/rancher/rancher/issues/14471