### PR TITLE
Init resource quota in rbac lifecycle

### DIFF
--- a/pkg/controllers/user/namespace/namespace_utils.go
+++ b/pkg/controllers/user/namespace/namespace_utils.go
@@ -1,0 +1,105 @@
+package namespace
+
+import (
+	"encoding/json"
+	"time"
+
+	"k8s.io/api/core/v1"
+)
+
+const (
+	statusAnn = "cattle.io/status"
+)
+
+func SetNamespaceCondition(namespace *v1.Namespace, d time.Duration, conditionType string, conditionStatus bool, message string) error {
+	if namespace.ObjectMeta.Annotations == nil {
+		namespace.ObjectMeta.Annotations = map[string]string{}
+	}
+
+	ann := namespace.ObjectMeta.Annotations[statusAnn]
+	status := &status{}
+	if ann != "" {
+		err := json.Unmarshal([]byte(ann), status)
+		if err != nil {
+			return err
+		}
+	}
+	if status.Conditions == nil {
+		status.Conditions = []condition{}
+	}
+
+	var idx int
+	found := false
+	for i, c := range status.Conditions {
+		if c.Type == conditionType {
+			idx = i
+			found = true
+			break
+		}
+	}
+
+	conditionStatusStr := "False"
+	conditionMessage := ""
+	if conditionStatus {
+		conditionStatusStr = "True"
+	} else {
+		conditionMessage = message
+	}
+
+	cond := condition{
+		Type:           conditionType,
+		Status:         conditionStatusStr,
+		Message:        conditionMessage,
+		LastUpdateTime: time.Now().Add(d).Format(time.RFC3339),
+	}
+
+	if found {
+		status.Conditions[idx] = cond
+	} else {
+		status.Conditions = append(status.Conditions, cond)
+	}
+
+	bAnn, err := json.Marshal(status)
+	if err != nil {
+		return err
+	}
+	namespace.ObjectMeta.Annotations[statusAnn] = string(bAnn)
+
+	return nil
+}
+
+func IsNamespaceConditionSet(namespace *v1.Namespace, conditionType string, conditionStatus bool) (bool, error) {
+	if namespace.ObjectMeta.Annotations == nil {
+		return false, nil
+	}
+	ann := namespace.ObjectMeta.Annotations[statusAnn]
+	if ann == "" {
+		return false, nil
+	}
+	status := &status{}
+	err := json.Unmarshal([]byte(ann), status)
+	if err != nil {
+		return false, err
+	}
+	conditionStatusStr := "False"
+	if conditionStatus {
+		conditionStatusStr = "True"
+	}
+	for _, c := range status.Conditions {
+		if c.Type == conditionType && c.Status == conditionStatusStr {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+type status struct {
+	Conditions []condition
+}
+
+type condition struct {
+	Type           string
+	Status         string
+	Message        string
+	LastUpdateTime string
+}

--- a/pkg/controllers/user/resourcequota/register.go
+++ b/pkg/controllers/user/resourcequota/register.go
@@ -13,17 +13,17 @@ const (
 )
 
 func Register(ctx context.Context, cluster *config.UserContext) {
-	sync := &syncController{
-		namespaces:                  cluster.Core.Namespaces(""),
-		namespaceLister:             cluster.Core.Namespaces("").Controller().Lister(),
-		resourceQuotas:              cluster.Core.ResourceQuotas(""),
-		resourceQuotaLister:         cluster.Core.ResourceQuotas("").Controller().Lister(),
-		resourceQuotaTemplateLister: cluster.Management.Management.ResourceQuotaTemplates(cluster.ClusterName).Controller().Lister(),
-		projectLister:               cluster.Management.Management.Projects(cluster.ClusterName).Controller().Lister(),
+	sync := &SyncController{
+		Namespaces:                  cluster.Core.Namespaces(""),
+		NamespaceLister:             cluster.Core.Namespaces("").Controller().Lister(),
+		ResourceQuotas:              cluster.Core.ResourceQuotas(""),
+		ResourceQuotaLister:         cluster.Core.ResourceQuotas("").Controller().Lister(),
+		ResourceQuotaTemplateLister: cluster.Management.Management.ResourceQuotaTemplates(cluster.ClusterName).Controller().Lister(),
+		ProjectLister:               cluster.Management.Management.Projects(cluster.ClusterName).Controller().Lister(),
 	}
 	cluster.Core.Namespaces("").AddHandler("resourceQuotaSyncController", sync.syncResourceQuota)
 
-	// Index for looking up namespaces by projectID annotation
+	// Index for looking up Namespaces by projectID annotation
 	nsInformer := cluster.Core.Namespaces("").Controller().Informer()
 	nsIndexers := map[string]cache.IndexFunc{
 		nsByProjectIndex: nsByProjectID,

--- a/pkg/controllers/user/resourcequota/resource_quota_calculate_used.go
+++ b/pkg/controllers/user/resourcequota/resource_quota_calculate_used.go
@@ -13,7 +13,7 @@ import (
 )
 
 /*
-collectController is responsible for calculate the combined limit set on the project's namespaces,
+collectController is responsible for calculate the combined limit set on the project's Namespaces,
 and setting this information in the project
 */
 type calculateLimitController struct {

--- a/pkg/controllers/user/resourcequota/resource_quota_validate.go
+++ b/pkg/controllers/user/resourcequota/resource_quota_validate.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/rancher/norman/types/convert"
-	"github.com/rancher/rancher/pkg/controllers/user/rbac"
+	namespaceutil "github.com/rancher/rancher/pkg/controllers/user/namespace"
 	"github.com/rancher/types/apis/core/v1"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	corev1 "k8s.io/api/core/v1"
@@ -63,17 +63,16 @@ func (c *validationController) validateTemplate(key string, ns *corev1.Namespace
 	if err != nil {
 		return err
 	}
-
 	if isFit {
 		return nil
 	}
-	set, err := rbac.IsNamespaceConditionSet(ns, resourceQuotaValidatedCondition, false)
+	set, err := namespaceutil.IsNamespaceConditionSet(ns, resourceQuotaValidatedCondition, false)
 	if set || err != nil {
 		return err
 	}
 
 	toUpdate := ns.DeepCopy()
-	err = rbac.SetNamespaceCondition(toUpdate, time.Second*1, resourceQuotaValidatedCondition, false, msg)
+	err = namespaceutil.SetNamespaceCondition(toUpdate, time.Second*1, resourceQuotaValidatedCondition, false, msg)
 	if err != nil {
 		return err
 	}
@@ -179,7 +178,7 @@ func (c *validationController) isQuotaFit(ns *corev1.Namespace, projectID string
 	}
 	nssResourceList = quota.Add(nssResourceList, nsResourceList)
 
-	// get other namespaces
+	// get other Namespaces
 	namespaces, err := c.nsIndexer.ByIndex(nsByProjectIndex, projectID)
 	if err != nil {
 		return false, "", err


### PR DESCRIPTION
As we can't set rbac before init resource quota is created, it would
make sence to call the code in rbac controller, rather than make it fail
while waiting for the other controller to do the init (given rbac is a
lifecycle controller, it will always be invoked first, and fail on wait
for the first time)Init resource quota in rbac lifecycle

@dramich to address the `waiting for resource quota init` issue you've noticed