### PR TITLE
Telemetry setting values

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -32,7 +32,7 @@ var (
 	ServerVersion                   = NewSetting("server-version", "dev")
 	SystemDefaultRegistry           = NewSetting("system-default-registry", "")
 	SystemNamespaces                = NewSetting("system-namespaces", "kube-system,kube-public,cattle-system,cattle-alerting,cattle-logging,cattle-pipeline,ingress-nginx")
-	TelemetryOpt                    = NewSetting("telemetry-opt", "false")
+	TelemetryOpt                    = NewSetting("telemetry-opt", "prompt")
 	UIFeedBackForm                  = NewSetting("ui-feedback-form", "")
 	UIIndex                         = NewSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
 	UIPath                          = NewSetting("ui-path", "")

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -52,7 +52,7 @@ func Start(ctx context.Context, httpsPort int, management *config.ScaledContext)
 	// have two go routines running. One is to run telemetry if setting is true, one is to kill telemetry if setting is false
 	go func() {
 		for range ticker.Context(ctx, time.Second*5) {
-			if settings.TelemetryOpt.Get() == "true" && management.Leader {
+			if settings.TelemetryOpt.Get() == "in" && management.Leader {
 				if !p.running {
 					token, err := createToken(management)
 					if err != nil {
@@ -78,7 +78,7 @@ func Start(ctx context.Context, httpsPort int, management *config.ScaledContext)
 
 	go func() {
 		for range ticker.Context(ctx, time.Second*5) {
-			if settings.TelemetryOpt.Get() == "false" || !management.Leader {
+			if settings.TelemetryOpt.Get() != "in" || !management.Leader {
 				if p.getRunningState() {
 					p.kill()
 					p.setRunningState(false)


### PR DESCRIPTION
- The three supported values for `telemetry-opt` are `prompt`, `in`, and `out`.
- The default setting value should be `prompt`, which makes the UI ask on login.
- The server should run only when the value is exactly `in`.
- The server should be stopped when the value is NOT exactly `in` (this is not the same as `== "false"` (or `"in"`)).