### PR TITLE
Change SamlConfig field names to match json tags

### DIFF
--- a/pkg/api/controllers/samlconfig/samlconfig.go
+++ b/pkg/api/controllers/samlconfig/samlconfig.go
@@ -52,7 +52,7 @@ func (a *authProvider) sync(key string, config *v3.AuthConfig) error {
 		return fmt.Errorf("failed to retrieve SamlConfig, cannot read k8s Unstructured data")
 	}
 	storedSamlConfigMap := u.UnstructuredContent()
-	decode(storedSamlConfigMap, samlConfig)
+	mapstructure.Decode(storedSamlConfigMap, samlConfig)
 
 	metadataMap, ok := storedSamlConfigMap["metadata"].(map[string]interface{})
 	if !ok {
@@ -64,19 +64,4 @@ func (a *authProvider) sync(key string, config *v3.AuthConfig) error {
 	samlConfig.ObjectMeta = *typemeta
 
 	return saml.InitializeSamlServiceProvider(samlConfig, config.Name)
-}
-
-func decode(m interface{}, rawVal interface{}) error {
-	config := &mapstructure.DecoderConfig{
-		Metadata: nil,
-		Result:   rawVal,
-		TagName:  "json",
-	}
-
-	decoder, err := mapstructure.NewDecoder(config)
-	if err != nil {
-		return err
-	}
-
-	return decoder.Decode(m)
 }

--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -51,18 +51,18 @@ func InitializeSamlServiceProvider(configToSet *v3.SamlConfig, name string) erro
 		return fmt.Errorf("SAML: Cannot initialize saml SP properly, missing IDP URL/metadata in the config %v", configToSet)
 	}
 
-	if configToSet.SPSelfSignedCert == "" {
-		return fmt.Errorf("SAML: Cannot initialize saml SP properly, missing SPSelfSignedCert in the config %v", configToSet)
+	if configToSet.SpCert == "" {
+		return fmt.Errorf("SAML: Cannot initialize saml SP properly, missing SpCert in the config %v", configToSet)
 	}
 
-	if configToSet.SPSelfSignedKey == "" {
-		return fmt.Errorf("SAML: Cannot initialize saml SP properly, missing SPSelfSignedKey in the config %v", configToSet)
+	if configToSet.SpKey == "" {
+		return fmt.Errorf("SAML: Cannot initialize saml SP properly, missing SpKey in the config %v", configToSet)
 	}
 
-	if configToSet.SPSelfSignedKey != "" {
+	if configToSet.SpKey != "" {
 		// used from ssh.ParseRawPrivateKey
 
-		block, _ := pem.Decode([]byte(configToSet.SPSelfSignedKey))
+		block, _ := pem.Decode([]byte(configToSet.SpKey))
 		if block == nil {
 			return fmt.Errorf("SAML: no key found")
 		}
@@ -91,8 +91,8 @@ func InitializeSamlServiceProvider(configToSet *v3.SamlConfig, name string) erro
 		}
 	}
 
-	if configToSet.SPSelfSignedCert != "" {
-		block, _ := pem.Decode([]byte(configToSet.SPSelfSignedCert))
+	if configToSet.SpCert != "" {
+		block, _ := pem.Decode([]byte(configToSet.SpCert))
 		if block == nil {
 			return fmt.Errorf("SAML: failed to parse PEM block containing the private key")
 		}

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -120,7 +120,7 @@ func (s *Provider) getSamlConfig() (*v3.SamlConfig, error) {
 	storedSamlConfigMap := u.UnstructuredContent()
 
 	storedSamlConfig := &v3.SamlConfig{}
-	decode(storedSamlConfigMap, storedSamlConfig)
+	mapstructure.Decode(storedSamlConfigMap, storedSamlConfig)
 
 	if enabled, ok := storedSamlConfigMap["enabled"].(bool); ok {
 		storedSamlConfig.Enabled = enabled
@@ -245,19 +245,4 @@ func formSamlRedirectURLFromMap(config map[string]interface{}, name string) stri
 
 	path := hostname + "/v1-saml/" + name + "/login"
 	return path
-}
-
-func decode(m interface{}, rawVal interface{}) error {
-	config := &mapstructure.DecoderConfig{
-		Metadata: nil,
-		Result:   rawVal,
-		TagName:  "json",
-	}
-
-	decoder, err := mapstructure.NewDecoder(config)
-	if err != nil {
-		return err
-	}
-
-	return decoder.Decode(m)
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -33,7 +33,7 @@ github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c6
 github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d7567c5b0b
 
 github.com/rancher/rdns-server                f79428ee317c10fa75f6bf2846aa6b88bff081ef
-github.com/rancher/types                      e17524f5bb0f070314ebdce675201e1a36e0ac6a
+github.com/rancher/types                      61b3cb0386fbb9495ff79e41f5397d711aac28b4
 github.com/rancher/norman                     2af274f9535b97b635bd15ae67de462665c45ffc
 github.com/rancher/kontainer-engine           fe10d279078894f84b8faf71a8f9cb43cdb53cfb
 github.com/rancher/rke                        25018afe3527d9c45c13e9320abdfb3669076a0e

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authn_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authn_types.go
@@ -276,8 +276,8 @@ type SamlConfig struct {
 	AuthConfig        `json:",inline" mapstructure:",squash"`
 
 	IDPMetadataContent string `json:"idpMetadataContent" norman:"required"`
-	SPSelfSignedCert   string `json:"spCert"             norman:"required"`
-	SPSelfSignedKey    string `json:"spKey"              norman:"required"`
+	SpCert             string `json:"spCert"             norman:"required"`
+	SpKey              string `json:"spKey"              norman:"required"`
 	GroupsField        string `json:"groupsField"        norman:"required"`
 	DisplayNameField   string `json:"displayNameField"   norman:"required"`
 	UserNameField      string `json:"userNameField"      norman:"required"`

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
@@ -9,6 +9,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const RancherCreatedLabel = "creator.cattle.io/rancher-created"
+
 var (
 	NamespaceBackedResource               condition.Cond = "BackingNamespaceCreated"
 	CreatorMadeOwner                      condition.Cond = "CreatorMadeOwner"

--- a/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_binding_controller.go
+++ b/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_binding_controller.go
@@ -187,6 +187,11 @@ func (s *clusterRoleBindingClient) ObjectClient() *objectclient.ObjectClient {
 }
 
 func (s *clusterRoleBindingClient) Create(o *v1.ClusterRoleBinding) (*v1.ClusterRoleBinding, error) {
+	if o.Labels == nil {
+		labels := make(map[string]string)
+		o.Labels = labels
+	}
+	o.Labels["creator.cattle.io/rancher-created"] = "true"
 	obj, err := s.objectClient.Create(o)
 	return obj.(*v1.ClusterRoleBinding), err
 }
@@ -202,6 +207,11 @@ func (s *clusterRoleBindingClient) GetNamespaced(namespace, name string, opts me
 }
 
 func (s *clusterRoleBindingClient) Update(o *v1.ClusterRoleBinding) (*v1.ClusterRoleBinding, error) {
+	if o.Labels == nil {
+		labels := make(map[string]string)
+		o.Labels = labels
+	}
+	o.Labels["creator.cattle.io/rancher-created"] = "true"
 	obj, err := s.objectClient.Update(o.Name, o)
 	return obj.(*v1.ClusterRoleBinding), err
 }

--- a/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_controller.go
+++ b/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_controller.go
@@ -187,6 +187,11 @@ func (s *clusterRoleClient) ObjectClient() *objectclient.ObjectClient {
 }
 
 func (s *clusterRoleClient) Create(o *v1.ClusterRole) (*v1.ClusterRole, error) {
+	if o.Labels == nil {
+		labels := make(map[string]string)
+		o.Labels = labels
+	}
+	o.Labels["creator.cattle.io/rancher-created"] = "true"
 	obj, err := s.objectClient.Create(o)
 	return obj.(*v1.ClusterRole), err
 }
@@ -202,6 +207,11 @@ func (s *clusterRoleClient) GetNamespaced(namespace, name string, opts metav1.Ge
 }
 
 func (s *clusterRoleClient) Update(o *v1.ClusterRole) (*v1.ClusterRole, error) {
+	if o.Labels == nil {
+		labels := make(map[string]string)
+		o.Labels = labels
+	}
+	o.Labels["creator.cattle.io/rancher-created"] = "true"
 	obj, err := s.objectClient.Update(o.Name, o)
 	return obj.(*v1.ClusterRole), err
 }

--- a/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_role_binding_controller.go
+++ b/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_role_binding_controller.go
@@ -188,6 +188,11 @@ func (s *roleBindingClient) ObjectClient() *objectclient.ObjectClient {
 }
 
 func (s *roleBindingClient) Create(o *v1.RoleBinding) (*v1.RoleBinding, error) {
+	if o.Labels == nil {
+		labels := make(map[string]string)
+		o.Labels = labels
+	}
+	o.Labels["creator.cattle.io/rancher-created"] = "true"
 	obj, err := s.objectClient.Create(o)
 	return obj.(*v1.RoleBinding), err
 }
@@ -203,6 +208,11 @@ func (s *roleBindingClient) GetNamespaced(namespace, name string, opts metav1.Ge
 }
 
 func (s *roleBindingClient) Update(o *v1.RoleBinding) (*v1.RoleBinding, error) {
+	if o.Labels == nil {
+		labels := make(map[string]string)
+		o.Labels = labels
+	}
+	o.Labels["creator.cattle.io/rancher-created"] = "true"
 	obj, err := s.objectClient.Update(o.Name, o)
 	return obj.(*v1.RoleBinding), err
 }

--- a/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_role_controller.go
+++ b/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_role_controller.go
@@ -188,6 +188,11 @@ func (s *roleClient) ObjectClient() *objectclient.ObjectClient {
 }
 
 func (s *roleClient) Create(o *v1.Role) (*v1.Role, error) {
+	if o.Labels == nil {
+		labels := make(map[string]string)
+		o.Labels = labels
+	}
+	o.Labels["creator.cattle.io/rancher-created"] = "true"
 	obj, err := s.objectClient.Create(o)
 	return obj.(*v1.Role), err
 }
@@ -203,6 +208,11 @@ func (s *roleClient) GetNamespaced(namespace, name string, opts metav1.GetOption
 }
 
 func (s *roleClient) Update(o *v1.Role) (*v1.Role, error) {
+	if o.Labels == nil {
+		labels := make(map[string]string)
+		o.Labels = labels
+	}
+	o.Labels["creator.cattle.io/rancher-created"] = "true"
 	obj, err := s.objectClient.Update(o.Name, o)
 	return obj.(*v1.Role), err
 }

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_adfs_config.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_adfs_config.go
@@ -16,8 +16,8 @@ const (
 	ADFSConfigFieldOwnerReferences     = "ownerReferences"
 	ADFSConfigFieldRancherAPIHost      = "rancherApiHost"
 	ADFSConfigFieldRemoved             = "removed"
-	ADFSConfigFieldSPSelfSignedCert    = "spCert"
-	ADFSConfigFieldSPSelfSignedKey     = "spKey"
+	ADFSConfigFieldSpCert              = "spCert"
+	ADFSConfigFieldSpKey               = "spKey"
 	ADFSConfigFieldType                = "type"
 	ADFSConfigFieldUIDField            = "uidField"
 	ADFSConfigFieldUUID                = "uuid"
@@ -39,8 +39,8 @@ type ADFSConfig struct {
 	OwnerReferences     []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
 	RancherAPIHost      string            `json:"rancherApiHost,omitempty" yaml:"rancherApiHost,omitempty"`
 	Removed             string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	SPSelfSignedCert    string            `json:"spCert,omitempty" yaml:"spCert,omitempty"`
-	SPSelfSignedKey     string            `json:"spKey,omitempty" yaml:"spKey,omitempty"`
+	SpCert              string            `json:"spCert,omitempty" yaml:"spCert,omitempty"`
+	SpKey               string            `json:"spKey,omitempty" yaml:"spKey,omitempty"`
 	Type                string            `json:"type,omitempty" yaml:"type,omitempty"`
 	UIDField            string            `json:"uidField,omitempty" yaml:"uidField,omitempty"`
 	UUID                string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_ping_config.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_ping_config.go
@@ -16,8 +16,8 @@ const (
 	PingConfigFieldOwnerReferences     = "ownerReferences"
 	PingConfigFieldRancherAPIHost      = "rancherApiHost"
 	PingConfigFieldRemoved             = "removed"
-	PingConfigFieldSPSelfSignedCert    = "spCert"
-	PingConfigFieldSPSelfSignedKey     = "spKey"
+	PingConfigFieldSpCert              = "spCert"
+	PingConfigFieldSpKey               = "spKey"
 	PingConfigFieldType                = "type"
 	PingConfigFieldUIDField            = "uidField"
 	PingConfigFieldUUID                = "uuid"
@@ -39,8 +39,8 @@ type PingConfig struct {
 	OwnerReferences     []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
 	RancherAPIHost      string            `json:"rancherApiHost,omitempty" yaml:"rancherApiHost,omitempty"`
 	Removed             string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	SPSelfSignedCert    string            `json:"spCert,omitempty" yaml:"spCert,omitempty"`
-	SPSelfSignedKey     string            `json:"spKey,omitempty" yaml:"spKey,omitempty"`
+	SpCert              string            `json:"spCert,omitempty" yaml:"spCert,omitempty"`
+	SpKey               string            `json:"spKey,omitempty" yaml:"spKey,omitempty"`
 	Type                string            `json:"type,omitempty" yaml:"type,omitempty"`
 	UIDField            string            `json:"uidField,omitempty" yaml:"uidField,omitempty"`
 	UUID                string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`

--- a/vendor/github.com/rancher/types/vendor.conf
+++ b/vendor/github.com/rancher/types/vendor.conf
@@ -5,4 +5,4 @@ k8s.io/kubernetes                             v1.10.5                           
 bitbucket.org/ww/goautoneg                    a547fc61f48d567d5b4ec6f8aee5573d8efce11d  https://github.com/rancher/goautoneg.git
 golang.org/x/sync                             fd80eb99c8f653c847d294a001bdf2a3a6f768f5
 
-github.com/rancher/norman                     c032c4611f2eec1652ef37d254f0e8ccf90c80aa
+github.com/rancher/norman                     0953e9e976f1038bb3e93e81d164a69d6fbe9873


### PR DESCRIPTION
Two of the current SamlConfig's fields (SPSelfSignedCert and SPSelfSignedKey) don't match their json tags (spCert and spKey respectively). Because of this, mapstructure.Decode wasn't decoding them correctly, and so we were using a custom decoder. But that is causing problems with the fields like AccessMode on the embedded AuthConfig type. So this PR changes the field names to match the json tags, so there's no need to use the custom decoder, and we can switch to mapstructure.Decode

https://github.com/rancher/rancher/issues/14762