### PR TITLE
Change principal type to user or group

### DIFF
--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -186,7 +186,7 @@ func (s *Provider) getSamlPrincipals(config *v3.SamlConfig, samlData map[string]
 		userPrincipal = v3.Principal{
 			ObjectMeta:    metav1.ObjectMeta{Name: s.userType + "://" + uid[0]},
 			Provider:      s.name,
-			PrincipalType: s.userType,
+			PrincipalType: "user",
 			Me:            true,
 		}
 
@@ -207,7 +207,7 @@ func (s *Provider) getSamlPrincipals(config *v3.SamlConfig, samlData map[string]
 					ObjectMeta:    metav1.ObjectMeta{Name: s.groupType + "://" + group},
 					DisplayName:   group,
 					Provider:      s.name,
-					PrincipalType: s.groupType,
+					PrincipalType: "group",
 					MemberOf:      true,
 				}
 				groupPrincipals = append(groupPrincipals, group)

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -170,6 +170,7 @@ func (s *Provider) saveSamlConfig(config *v3.SamlConfig) error {
 
 func (s *Provider) toPrincipal(principalType string, princ v3.Principal, token *v3.Token) v3.Principal {
 	if principalType == s.userType {
+		princ.PrincipalType = "user"
 		if token != nil {
 			princ.Me = s.isThisUserMe(token.UserPrincipal, princ)
 			if princ.Me {
@@ -178,6 +179,7 @@ func (s *Provider) toPrincipal(principalType string, princ v3.Principal, token *
 			}
 		}
 	} else {
+		princ.PrincipalType = "group"
 		if token != nil {
 			princ.MemberOf = s.tokenMGR.IsMemberOf(*token, princ)
 		}
@@ -190,7 +192,7 @@ func (s *Provider) SearchPrincipals(searchKey, principalType string, token v3.To
 	var principals []v3.Principal
 
 	if principalType == "" {
-		principalType = s.userType
+		principalType = "user"
 	}
 
 	p := v3.Principal{
@@ -215,11 +217,10 @@ func (s *Provider) GetPrincipal(principalID string, token v3.Token) (v3.Principa
 	externalID := strings.TrimPrefix(parts[1], "//")
 
 	p := v3.Principal{
-		ObjectMeta:    metav1.ObjectMeta{Name: principalType + "://" + externalID},
-		DisplayName:   externalID,
-		LoginName:     externalID,
-		PrincipalType: principalType,
-		Provider:      s.name,
+		ObjectMeta:  metav1.ObjectMeta{Name: principalType + "://" + externalID},
+		DisplayName: externalID,
+		LoginName:   externalID,
+		Provider:    s.name,
 	}
 
 	p = s.toPrincipal(principalType, p, &token)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/14797
https://github.com/rancher/rancher/issues/14798
https://github.com/rancher/rancher/issues/14805

GetPrincipal and SearchPrincipals for all auth providers other than Ping set the principalType to "user" or "group". And Ping was setting it to ping_user/ping_group, that's why, when a member was added to a project/cluster, since the principal type would not be "user", no user would get created, unlike for any other providers like AD. This resulted in appropriate role bindings not getting created