### PR TITLE
Update norman dependency

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -34,7 +34,7 @@ github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d756
 
 github.com/rancher/rdns-server                f79428ee317c10fa75f6bf2846aa6b88bff081ef
 github.com/rancher/types                      61b3cb0386fbb9495ff79e41f5397d711aac28b4
-github.com/rancher/norman                     2af274f9535b97b635bd15ae67de462665c45ffc
+github.com/rancher/norman                     de9510b9408d5c2ac914775ec81a1bf4c1745825
 github.com/rancher/kontainer-engine           fe10d279078894f84b8faf71a8f9cb43cdb53cfb
 github.com/rancher/rke                        25018afe3527d9c45c13e9320abdfb3669076a0e
 

--- a/vendor/github.com/rancher/norman/controller/generic_controller.go
+++ b/vendor/github.com/rancher/norman/controller/generic_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -22,9 +23,18 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
+const MetricsEnv = "NORMAN_QUEUE_METRICS"
+
 var (
 	resyncPeriod = 2 * time.Hour
 )
+
+// Override the metrics providers
+func init() {
+	if os.Getenv(MetricsEnv) != "true" {
+		DisableAllControllerMetrics()
+	}
+}
 
 type HandlerFunc func(key string) error
 

--- a/vendor/github.com/rancher/norman/controller/noop_metrics.go
+++ b/vendor/github.com/rancher/norman/controller/noop_metrics.go
@@ -1,0 +1,71 @@
+package controller
+
+import (
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type noopMetric struct{}
+
+func (noopMetric) Inc()            {}
+func (noopMetric) Dec()            {}
+func (noopMetric) Observe(float64) {}
+func (noopMetric) Set(float64)     {}
+
+type noopWorkqueueMetricsProvider struct{}
+
+func (noopWorkqueueMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
+	return noopMetric{}
+}
+
+func (noopWorkqueueMetricsProvider) NewAddsMetric(name string) workqueue.CounterMetric {
+	return noopMetric{}
+}
+
+func (noopWorkqueueMetricsProvider) NewLatencyMetric(name string) workqueue.SummaryMetric {
+	return noopMetric{}
+}
+
+func (noopWorkqueueMetricsProvider) NewWorkDurationMetric(name string) workqueue.SummaryMetric {
+	return noopMetric{}
+}
+
+func (noopWorkqueueMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
+	return noopMetric{}
+}
+
+type noopCacheMetricsProvider struct{}
+
+func (noopCacheMetricsProvider) NewListsMetric(name string) cache.CounterMetric { return noopMetric{} }
+func (noopCacheMetricsProvider) NewListDurationMetric(name string) cache.SummaryMetric {
+	return noopMetric{}
+}
+func (noopCacheMetricsProvider) NewItemsInListMetric(name string) cache.SummaryMetric {
+	return noopMetric{}
+}
+func (noopCacheMetricsProvider) NewWatchesMetric(name string) cache.CounterMetric { return noopMetric{} }
+func (noopCacheMetricsProvider) NewShortWatchesMetric(name string) cache.CounterMetric {
+	return noopMetric{}
+}
+func (noopCacheMetricsProvider) NewWatchDurationMetric(name string) cache.SummaryMetric {
+	return noopMetric{}
+}
+func (noopCacheMetricsProvider) NewItemsInWatchMetric(name string) cache.SummaryMetric {
+	return noopMetric{}
+}
+func (noopCacheMetricsProvider) NewLastResourceVersionMetric(name string) cache.GaugeMetric {
+	return noopMetric{}
+}
+
+func DisableAllControllerMetrics() {
+	DisableControllerReflectorMetrics()
+	DisableControllerWorkqueuMetrics()
+}
+
+func DisableControllerWorkqueuMetrics() {
+	workqueue.SetProvider(noopWorkqueueMetricsProvider{})
+}
+
+func DisableControllerReflectorMetrics() {
+	cache.SetReflectorMetricsProvider(noopCacheMetricsProvider{})
+}


### PR DESCRIPTION
related to #14356 

Metrics are created and never deregistered whenever controllers are removed. These metrics are very large. Since we are not currently exposing a metrics endpoint, we are disabling them for now.