### PR TITLE
Update roleTemplates to not use locked ones if set as default

### DIFF
--- a/pkg/api/customization/project/project_store.go
+++ b/pkg/api/customization/project/project_store.go
@@ -45,7 +45,7 @@ func (s *projectStore) createProjectAnnotation() (string, error) {
 	annoMap := make(map[string][]string)
 
 	for _, role := range rt {
-		if role.ProjectCreatorDefault {
+		if role.ProjectCreatorDefault && !role.Locked {
 			annoMap["required"] = append(annoMap["required"], role.Name)
 		}
 	}

--- a/pkg/controllers/management/auth/project_cluster_handler.go
+++ b/pkg/controllers/management/auth/project_cluster_handler.go
@@ -463,13 +463,13 @@ func (m *mgr) addRTAnnotation(obj runtime.Object, context string) (runtime.Objec
 	switch context {
 	case "project":
 		for _, role := range rt {
-			if role.ProjectCreatorDefault {
+			if role.ProjectCreatorDefault && !role.Locked {
 				annoMap["required"] = append(annoMap["required"], role.Name)
 			}
 		}
 	case "cluster":
 		for _, role := range rt {
-			if role.ClusterCreatorDefault {
+			if role.ClusterCreatorDefault && !role.Locked {
 				annoMap["required"] = append(annoMap["required"], role.Name)
 			}
 		}


### PR DESCRIPTION
Problem:
A roleTemplate set to both locked and default is being applied when a
new cluster or project is created

Solution:
Verify a roleTemplate is not locked before using it as a default

Issue: https://github.com/rancher/rancher/issues/14788