### PR TITLE
Update vendor for GKE Option rename

### DIFF
--- a/pkg/api/customization/cluster/formatter.go
+++ b/pkg/api/customization/cluster/formatter.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/types/client/management/v3"
+	"github.com/sirupsen/logrus"
 )
 
 func Formatter(request *types.APIContext, resource *types.RawResource) {
@@ -18,4 +20,24 @@ func Formatter(request *types.APIContext, resource *types.RawResource) {
 	resource.AddAction(request, "generateKubeconfig")
 	resource.AddAction(request, "importYaml")
 	resource.AddAction(request, "exportYaml")
+
+	if gkeConfig, ok := resource.Values[client.ClusterSpecFieldGoogleKubernetesEngineConfig]; ok {
+		configMap, ok := gkeConfig.(map[string]interface{})
+		if !ok {
+			logrus.Errorf("could not convert gke config to map")
+			return
+		}
+
+		setTrueIfNil(configMap, client.GoogleKubernetesEngineConfigFieldEnableStackdriverLogging)
+		setTrueIfNil(configMap, client.GoogleKubernetesEngineConfigFieldEnableStackdriverMonitoring)
+		setTrueIfNil(configMap, client.GoogleKubernetesEngineConfigFieldEnableHorizontalPodAutoscaling)
+		setTrueIfNil(configMap, client.GoogleKubernetesEngineConfigFieldEnableHTTPLoadBalancing)
+		setTrueIfNil(configMap, client.GoogleKubernetesEngineConfigFieldEnableNetworkPolicyConfig)
+	}
+}
+
+func setTrueIfNil(configMap map[string]interface{}, fieldName string) {
+	if configMap[fieldName] == nil {
+		configMap[fieldName] = true
+	}
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -33,11 +33,11 @@ github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c6
 github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d7567c5b0b
 
 github.com/rancher/rdns-server                f79428ee317c10fa75f6bf2846aa6b88bff081ef
-github.com/rancher/types                      42c4836915c23ee2da3918421ba0593879caad6c
+github.com/rancher/types                      d919b35add8a4421882b9b9f1a8b1bd467ed4654
 
 
 github.com/rancher/norman                     33b13aaf9d5a785f82eac3ef9e5d9a9fdf8a19c1
-github.com/rancher/kontainer-engine           fe10d279078894f84b8faf71a8f9cb43cdb53cfb
+github.com/rancher/kontainer-engine           2b4ed633b1aa73a109db704264513bfe9210f52b
 github.com/rancher/rke                        16e63092f9ed3608fe41bbf77604b08610db628c
 
 gopkg.in/ldap.v2     v2.5.0

--- a/vendor/github.com/rancher/kontainer-engine/drivers/aks/aks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/aks/aks_driver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
+	"github.com/rancher/kontainer-engine/drivers/options"
 	"github.com/rancher/kontainer-engine/drivers/util"
 	"github.com/rancher/kontainer-engine/types"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
@@ -181,29 +182,29 @@ func (d *Driver) GetDriverUpdateOptions(ctx context.Context) (*types.DriverFlags
 // SetDriverOptions implements driver interface
 func getStateFromOptions(driverOptions *types.DriverOptions) (state, error) {
 	state := state{}
-	state.Name = getValueFromDriverOptions(driverOptions, types.StringType, "name").(string)
-	state.DisplayName = getValueFromDriverOptions(driverOptions, types.StringType, "display-name", "displayName").(string)
-	state.AgentDNSPrefix = getValueFromDriverOptions(driverOptions, types.StringType, "node-dns-prefix", "agentDnsPrefix").(string)
-	state.AgentVMSize = getValueFromDriverOptions(driverOptions, types.StringType, "node-vm-size", "agentVmSize").(string)
-	state.Count = getValueFromDriverOptions(driverOptions, types.IntType, "node-count", "count").(int64)
-	state.KubernetesVersion = getValueFromDriverOptions(driverOptions, types.StringType, "kubernetes-version", "kubernetesVersion").(string)
-	state.Location = getValueFromDriverOptions(driverOptions, types.StringType, "location").(string)
-	state.OsDiskSizeGB = getValueFromDriverOptions(driverOptions, types.IntType, "os-disk-size", "osDiskSizeGb").(int64)
-	state.SubscriptionID = getValueFromDriverOptions(driverOptions, types.StringType, "subscription-id", "subscriptionId").(string)
-	state.ResourceGroup = getValueFromDriverOptions(driverOptions, types.StringType, "resource-group", "resourceGroup").(string)
-	state.AgentPoolName = getValueFromDriverOptions(driverOptions, types.StringType, "node-pool-name", "agentPoolName").(string)
-	state.MasterDNSPrefix = getValueFromDriverOptions(driverOptions, types.StringType, "master-dns-prefix", "masterDnsPrefix").(string)
-	state.SSHPublicKeyPath = getValueFromDriverOptions(driverOptions, types.StringType, "public-key").(string)
-	state.SSHPublicKeyContents = getValueFromDriverOptions(driverOptions, types.StringType, "sshPublicKeyContents").(string)
-	state.AdminUsername = getValueFromDriverOptions(driverOptions, types.StringType, "admin-username", "adminUsername").(string)
-	state.BaseURL = getValueFromDriverOptions(driverOptions, types.StringType, "base-url").(string)
-	state.ClientID = getValueFromDriverOptions(driverOptions, types.StringType, "client-id", "clientId").(string)
-	state.TenantID = getValueFromDriverOptions(driverOptions, types.StringType, "tenant-id", "tenantId").(string)
-	state.ClientSecret = getValueFromDriverOptions(driverOptions, types.StringType, "client-secret", "clientSecret").(string)
-	state.VirtualNetwork = getValueFromDriverOptions(driverOptions, types.StringType, "virtualNetwork", "virtual-network").(string)
-	state.Subnet = getValueFromDriverOptions(driverOptions, types.StringType, "subnet").(string)
-	state.VirtualNetworkResourceGroup = getValueFromDriverOptions(driverOptions, types.StringType, "virtualNetworkResourceGroup", "virtual-network-resource-group").(string)
-	tagValues := getValueFromDriverOptions(driverOptions, types.StringSliceType).(*types.StringSlice)
+	state.Name = options.GetValueFromDriverOptions(driverOptions, types.StringType, "name").(string)
+	state.DisplayName = options.GetValueFromDriverOptions(driverOptions, types.StringType, "display-name", "displayName").(string)
+	state.AgentDNSPrefix = options.GetValueFromDriverOptions(driverOptions, types.StringType, "node-dns-prefix", "agentDnsPrefix").(string)
+	state.AgentVMSize = options.GetValueFromDriverOptions(driverOptions, types.StringType, "node-vm-size", "agentVmSize").(string)
+	state.Count = options.GetValueFromDriverOptions(driverOptions, types.IntType, "node-count", "count").(int64)
+	state.KubernetesVersion = options.GetValueFromDriverOptions(driverOptions, types.StringType, "kubernetes-version", "kubernetesVersion").(string)
+	state.Location = options.GetValueFromDriverOptions(driverOptions, types.StringType, "location").(string)
+	state.OsDiskSizeGB = options.GetValueFromDriverOptions(driverOptions, types.IntType, "os-disk-size", "osDiskSizeGb").(int64)
+	state.SubscriptionID = options.GetValueFromDriverOptions(driverOptions, types.StringType, "subscription-id", "subscriptionId").(string)
+	state.ResourceGroup = options.GetValueFromDriverOptions(driverOptions, types.StringType, "resource-group", "resourceGroup").(string)
+	state.AgentPoolName = options.GetValueFromDriverOptions(driverOptions, types.StringType, "node-pool-name", "agentPoolName").(string)
+	state.MasterDNSPrefix = options.GetValueFromDriverOptions(driverOptions, types.StringType, "master-dns-prefix", "masterDnsPrefix").(string)
+	state.SSHPublicKeyPath = options.GetValueFromDriverOptions(driverOptions, types.StringType, "public-key").(string)
+	state.SSHPublicKeyContents = options.GetValueFromDriverOptions(driverOptions, types.StringType, "sshPublicKeyContents").(string)
+	state.AdminUsername = options.GetValueFromDriverOptions(driverOptions, types.StringType, "admin-username", "adminUsername").(string)
+	state.BaseURL = options.GetValueFromDriverOptions(driverOptions, types.StringType, "base-url").(string)
+	state.ClientID = options.GetValueFromDriverOptions(driverOptions, types.StringType, "client-id", "clientId").(string)
+	state.TenantID = options.GetValueFromDriverOptions(driverOptions, types.StringType, "tenant-id", "tenantId").(string)
+	state.ClientSecret = options.GetValueFromDriverOptions(driverOptions, types.StringType, "client-secret", "clientSecret").(string)
+	state.VirtualNetwork = options.GetValueFromDriverOptions(driverOptions, types.StringType, "virtualNetwork", "virtual-network").(string)
+	state.Subnet = options.GetValueFromDriverOptions(driverOptions, types.StringType, "subnet").(string)
+	state.VirtualNetworkResourceGroup = options.GetValueFromDriverOptions(driverOptions, types.StringType, "virtualNetworkResourceGroup", "virtual-network-resource-group").(string)
+	tagValues := options.GetValueFromDriverOptions(driverOptions, types.StringSliceType).(*types.StringSlice)
 	for _, part := range tagValues.Value {
 		kv := strings.Split(part, "=")
 		if len(kv) == 2 {
@@ -211,40 +212,6 @@ func getStateFromOptions(driverOptions *types.DriverOptions) (state, error) {
 		}
 	}
 	return state, state.validate()
-}
-
-func getValueFromDriverOptions(driverOptions *types.DriverOptions, optionType string, keys ...string) interface{} {
-	switch optionType {
-	case types.IntType:
-		for _, key := range keys {
-			if value, ok := driverOptions.IntOptions[key]; ok {
-				return value
-			}
-		}
-		return int64(0)
-	case types.StringType:
-		for _, key := range keys {
-			if value, ok := driverOptions.StringOptions[key]; ok {
-				return value
-			}
-		}
-		return ""
-	case types.BoolType:
-		for _, key := range keys {
-			if value, ok := driverOptions.BoolOptions[key]; ok {
-				return value
-			}
-		}
-		return false
-	case types.StringSliceType:
-		for _, key := range keys {
-			if value, ok := driverOptions.StringSliceOptions[key]; ok {
-				return value
-			}
-		}
-		return &types.StringSlice{}
-	}
-	return nil
 }
 
 func (state *state) validate() error {

--- a/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	heptio "github.com/heptio/authenticator/pkg/token"
+	"github.com/rancher/kontainer-engine/drivers/options"
 	"github.com/rancher/kontainer-engine/drivers/util"
 	"github.com/rancher/kontainer-engine/types"
 	"github.com/sirupsen/logrus"
@@ -177,55 +178,21 @@ func (d *Driver) GetDriverUpdateOptions(ctx context.Context) (*types.DriverFlags
 
 func getStateFromOptions(driverOptions *types.DriverOptions) (state, error) {
 	state := state{}
-	state.ClusterName = getValueFromDriverOptions(driverOptions, types.StringType, "name").(string)
-	state.DisplayName = getValueFromDriverOptions(driverOptions, types.StringType, "display-name", "displayName").(string)
-	state.ClientID = getValueFromDriverOptions(driverOptions, types.StringType, "client-id", "accessKey").(string)
-	state.ClientSecret = getValueFromDriverOptions(driverOptions, types.StringType, "client-secret", "secretKey").(string)
+	state.ClusterName = options.GetValueFromDriverOptions(driverOptions, types.StringType, "name").(string)
+	state.DisplayName = options.GetValueFromDriverOptions(driverOptions, types.StringType, "display-name", "displayName").(string)
+	state.ClientID = options.GetValueFromDriverOptions(driverOptions, types.StringType, "client-id", "accessKey").(string)
+	state.ClientSecret = options.GetValueFromDriverOptions(driverOptions, types.StringType, "client-secret", "secretKey").(string)
 
-	state.Region = getValueFromDriverOptions(driverOptions, types.StringType, "region").(string)
-	state.InstanceType = getValueFromDriverOptions(driverOptions, types.StringType, "instance-type", "instanceType").(string)
-	state.MinimumASGSize = getValueFromDriverOptions(driverOptions, types.IntType, "minimum-nodes", "minimumNodes").(int64)
-	state.MaximumASGSize = getValueFromDriverOptions(driverOptions, types.IntType, "maximum-nodes", "maximumNodes").(int64)
-	state.VirtualNetwork = getValueFromDriverOptions(driverOptions, types.StringType, "virtual-network", "virtualNetwork").(string)
-	state.Subnets = getValueFromDriverOptions(driverOptions, types.StringSliceType, "subnets").(*types.StringSlice).Value
-	state.ServiceRole = getValueFromDriverOptions(driverOptions, types.StringType, "service-role", "serviceRole").(string)
-	state.SecurityGroups = getValueFromDriverOptions(driverOptions, types.StringSliceType, "security-groups", "securityGroups").(*types.StringSlice).Value
+	state.Region = options.GetValueFromDriverOptions(driverOptions, types.StringType, "region").(string)
+	state.InstanceType = options.GetValueFromDriverOptions(driverOptions, types.StringType, "instance-type", "instanceType").(string)
+	state.MinimumASGSize = options.GetValueFromDriverOptions(driverOptions, types.IntType, "minimum-nodes", "minimumNodes").(int64)
+	state.MaximumASGSize = options.GetValueFromDriverOptions(driverOptions, types.IntType, "maximum-nodes", "maximumNodes").(int64)
+	state.VirtualNetwork = options.GetValueFromDriverOptions(driverOptions, types.StringType, "virtual-network", "virtualNetwork").(string)
+	state.Subnets = options.GetValueFromDriverOptions(driverOptions, types.StringSliceType, "subnets").(*types.StringSlice).Value
+	state.ServiceRole = options.GetValueFromDriverOptions(driverOptions, types.StringType, "service-role", "serviceRole").(string)
+	state.SecurityGroups = options.GetValueFromDriverOptions(driverOptions, types.StringSliceType, "security-groups", "securityGroups").(*types.StringSlice).Value
 
 	return state, state.validate()
-}
-
-func getValueFromDriverOptions(driverOptions *types.DriverOptions, optionType string, keys ...string) interface{} {
-	switch optionType {
-	case types.IntType:
-		for _, key := range keys {
-			if value, ok := driverOptions.IntOptions[key]; ok {
-				return value
-			}
-		}
-		return int64(0)
-	case types.StringType:
-		for _, key := range keys {
-			if value, ok := driverOptions.StringOptions[key]; ok {
-				return value
-			}
-		}
-		return ""
-	case types.BoolType:
-		for _, key := range keys {
-			if value, ok := driverOptions.BoolOptions[key]; ok {
-				return value
-			}
-		}
-		return false
-	case types.StringSliceType:
-		for _, key := range keys {
-			if value, ok := driverOptions.StringSliceOptions[key]; ok {
-				return value
-			}
-		}
-		return &types.StringSlice{}
-	}
-	return nil
 }
 
 func (state *state) validate() error {

--- a/vendor/github.com/rancher/kontainer-engine/drivers/options/options.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/options/options.go
@@ -1,0 +1,44 @@
+package options
+
+import "github.com/rancher/kontainer-engine/types"
+
+func GetValueFromDriverOptions(driverOptions *types.DriverOptions, optionType string, keys ...string) interface{} {
+	switch optionType {
+	case types.IntType:
+		for _, key := range keys {
+			if value, ok := driverOptions.IntOptions[key]; ok {
+				return value
+			}
+		}
+		return int64(0)
+	case types.StringType:
+		for _, key := range keys {
+			if value, ok := driverOptions.StringOptions[key]; ok {
+				return value
+			}
+		}
+		return ""
+	case types.BoolType:
+		for _, key := range keys {
+			if value, ok := driverOptions.BoolOptions[key]; ok {
+				return value
+			}
+		}
+		return false
+	case types.BoolPointerType:
+		for _, key := range keys {
+			if value, ok := driverOptions.BoolOptions[key]; ok {
+				return &value
+			}
+		}
+		return nil
+	case types.StringSliceType:
+		for _, key := range keys {
+			if value, ok := driverOptions.StringSliceOptions[key]; ok {
+				return value
+			}
+		}
+		return &types.StringSlice{}
+	}
+	return nil
+}

--- a/vendor/github.com/rancher/kontainer-engine/types/types.go
+++ b/vendor/github.com/rancher/kontainer-engine/types/types.go
@@ -7,8 +7,10 @@ import (
 const (
 	// StringType is the type for string flag
 	StringType = "string"
-	// BoolType is the type for bool flag
+	// BoolType is the type for bool flag. It should be used if the bool value should be false if missing
 	BoolType = "bool"
+	// BoolPointerType flag should be used if the bool value can be nil
+	BoolPointerType = "boolPtr"
 	// IntType is the type for int flag
 	IntType = "int"
 	// StringSliceType is the type for stringSlice flag

--- a/vendor/github.com/rancher/kontainer-engine/vendor.conf
+++ b/vendor/github.com/rancher/kontainer-engine/vendor.conf
@@ -32,4 +32,4 @@ github.com/smartystreets/go-aws-auth 8ef1316913ee4f44bc48c2456e44a5c1c68ea53b
 
 github.com/rancher/rke               2e82c18d4b6fe3afbb3970cbf518b5c0a811bcaa
 github.com/rancher/norman            57e8282a33f04091e30df7700bd328f3205c1189   
-github.com/rancher/types             ccab1aee47e4774adbe45c0424baeee904b1e820
+github.com/rancher/types             d919b35add8a4421882b9b9f1a8b1bd467ed4654

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -147,13 +147,13 @@ type GoogleKubernetesEngineConfig struct {
 	// Enable alpha feature
 	EnableAlphaFeature bool `json:"enableAlphaFeature,omitempty"`
 	// Configuration for the HTTP (L7) load balancing controller addon
-	DisableHTTPLoadBalancing bool `json:"disableHttpLoadBalancing,omitempty"`
+	EnableHTTPLoadBalancing *bool `json:"enableHttpLoadBalancing,omitempty" norman:"default=true"`
 	// Configuration for the horizontal pod autoscaling feature, which increases or decreases the number of replica pods a replication controller has based on the resource usage of the existing pods
-	DisableHorizontalPodAutoscaling bool `json:"disableHorizontalPodAutoscaling,omitempty"`
+	EnableHorizontalPodAutoscaling *bool `json:"enableHorizontalPodAutoscaling,omitempty" norman:"default=true"`
 	// Configuration for the Kubernetes Dashboard
 	EnableKubernetesDashboard bool `json:"enableKubernetesDashboard,omitempty"`
 	// Configuration for NetworkPolicy
-	DisableNetworkPolicyConfig bool `json:"disableNetworkPolicyConfig,omitempty"`
+	EnableNetworkPolicyConfig *bool `json:"enableNetworkPolicyConfig,omitempty" norman:"default=true"`
 	// The list of Google Compute Engine locations in which the cluster's nodes should be located
 	Locations []string `json:"locations,omitempty"`
 	// Image Type
@@ -163,11 +163,10 @@ type GoogleKubernetesEngineConfig struct {
 	// Sub Network
 	SubNetwork string `json:"subNetwork,omitempty"`
 	// Configuration for LegacyAbac
-	EnableLegacyAbac        bool   `json:"enableLegacyAbac,omitempty"`
-	NoStackdriverLogging    bool   `json:"noStackdriverLogging"`
-	NoStackdriverMonitoring bool   `json:"noStackdriverMonitoring"`
-	NoNetworkPolicy         bool   `json:"noNetworkPolicy"`
-	MaintenanceWindow       string `json:"maintenanceWindow"`
+	EnableLegacyAbac            bool   `json:"enableLegacyAbac,omitempty"`
+	EnableStackdriverLogging    *bool  `json:"enableStackdriverLogging,omitempty" norman:"default=true"`
+	EnableStackdriverMonitoring *bool  `json:"enableStackdriverMonitoring,omitempty" norman:"default=true"`
+	MaintenanceWindow           string `json:"maintenanceWindow"`
 }
 
 type AzureKubernetesServiceConfig struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
@@ -92,6 +92,7 @@ var (
 			WeaveCNI:                  m("weaveworks/weave-npc:2.1.2"),
 			PodInfraContainer:         m("gcr.io/google_containers/pause-amd64:3.0"),
 			Ingress:                   m("rancher/nginx-ingress-controller:0.10.2-rancher3"),
+			IngressBackend:            m("k8s.gcr.io/defaultbackend:1.4"),
 		},
 		"v1.8.11-rancher1": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.0.17"),
@@ -140,7 +141,7 @@ var (
 			WeaveNode:                 m("weaveworks/weave-kube:2.1.2"),
 			WeaveCNI:                  m("weaveworks/weave-npc:2.1.2"),
 			PodInfraContainer:         m("gcr.io/google_containers/pause-amd64:3.0"),
-			Ingress:                   m("rancher/nginx-ingress-controller:0.10.2-rancher2"),
+			Ingress:                   m("rancher/nginx-ingress-controller:0.10.2-rancher3"),
 			IngressBackend:            m("k8s.gcr.io/defaultbackend:1.4"),
 		},
 		"v1.9.5-rancher1-1": {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -2305,10 +2305,55 @@ func (in *GoogleKubernetesEngineConfig) DeepCopyInto(out *GoogleKubernetesEngine
 			(*out)[key] = val
 		}
 	}
+	if in.EnableHTTPLoadBalancing != nil {
+		in, out := &in.EnableHTTPLoadBalancing, &out.EnableHTTPLoadBalancing
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
+	if in.EnableHorizontalPodAutoscaling != nil {
+		in, out := &in.EnableHorizontalPodAutoscaling, &out.EnableHorizontalPodAutoscaling
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
+	if in.EnableNetworkPolicyConfig != nil {
+		in, out := &in.EnableNetworkPolicyConfig, &out.EnableNetworkPolicyConfig
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	if in.Locations != nil {
 		in, out := &in.Locations, &out.Locations
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.EnableStackdriverLogging != nil {
+		in, out := &in.EnableStackdriverLogging, &out.EnableStackdriverLogging
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
+	if in.EnableStackdriverMonitoring != nil {
+		in, out := &in.EnableStackdriverMonitoring, &out.EnableStackdriverMonitoring
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
 	}
 	return
 }

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_google_kubernetes_engine_config.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_google_kubernetes_engine_config.go
@@ -1,58 +1,56 @@
 package client
 
 const (
-	GoogleKubernetesEngineConfigType                                 = "googleKubernetesEngineConfig"
-	GoogleKubernetesEngineConfigFieldClusterIpv4Cidr                 = "clusterIpv4Cidr"
-	GoogleKubernetesEngineConfigFieldCredential                      = "credential"
-	GoogleKubernetesEngineConfigFieldDescription                     = "description"
-	GoogleKubernetesEngineConfigFieldDisableHTTPLoadBalancing        = "disableHttpLoadBalancing"
-	GoogleKubernetesEngineConfigFieldDisableHorizontalPodAutoscaling = "disableHorizontalPodAutoscaling"
-	GoogleKubernetesEngineConfigFieldDisableNetworkPolicyConfig      = "disableNetworkPolicyConfig"
-	GoogleKubernetesEngineConfigFieldDiskSizeGb                      = "diskSizeGb"
-	GoogleKubernetesEngineConfigFieldEnableAlphaFeature              = "enableAlphaFeature"
-	GoogleKubernetesEngineConfigFieldEnableKubernetesDashboard       = "enableKubernetesDashboard"
-	GoogleKubernetesEngineConfigFieldEnableLegacyAbac                = "enableLegacyAbac"
-	GoogleKubernetesEngineConfigFieldImageType                       = "imageType"
-	GoogleKubernetesEngineConfigFieldLabels                          = "labels"
-	GoogleKubernetesEngineConfigFieldLocations                       = "locations"
-	GoogleKubernetesEngineConfigFieldMachineType                     = "machineType"
-	GoogleKubernetesEngineConfigFieldMaintenanceWindow               = "maintenanceWindow"
-	GoogleKubernetesEngineConfigFieldMasterVersion                   = "masterVersion"
-	GoogleKubernetesEngineConfigFieldNetwork                         = "network"
-	GoogleKubernetesEngineConfigFieldNoNetworkPolicy                 = "noNetworkPolicy"
-	GoogleKubernetesEngineConfigFieldNoStackdriverLogging            = "noStackdriverLogging"
-	GoogleKubernetesEngineConfigFieldNoStackdriverMonitoring         = "noStackdriverMonitoring"
-	GoogleKubernetesEngineConfigFieldNodeCount                       = "nodeCount"
-	GoogleKubernetesEngineConfigFieldNodeVersion                     = "nodeVersion"
-	GoogleKubernetesEngineConfigFieldProjectID                       = "projectId"
-	GoogleKubernetesEngineConfigFieldSubNetwork                      = "subNetwork"
-	GoogleKubernetesEngineConfigFieldZone                            = "zone"
+	GoogleKubernetesEngineConfigType                                = "googleKubernetesEngineConfig"
+	GoogleKubernetesEngineConfigFieldClusterIpv4Cidr                = "clusterIpv4Cidr"
+	GoogleKubernetesEngineConfigFieldCredential                     = "credential"
+	GoogleKubernetesEngineConfigFieldDescription                    = "description"
+	GoogleKubernetesEngineConfigFieldDiskSizeGb                     = "diskSizeGb"
+	GoogleKubernetesEngineConfigFieldEnableAlphaFeature             = "enableAlphaFeature"
+	GoogleKubernetesEngineConfigFieldEnableHTTPLoadBalancing        = "enableHttpLoadBalancing"
+	GoogleKubernetesEngineConfigFieldEnableHorizontalPodAutoscaling = "enableHorizontalPodAutoscaling"
+	GoogleKubernetesEngineConfigFieldEnableKubernetesDashboard      = "enableKubernetesDashboard"
+	GoogleKubernetesEngineConfigFieldEnableLegacyAbac               = "enableLegacyAbac"
+	GoogleKubernetesEngineConfigFieldEnableNetworkPolicyConfig      = "enableNetworkPolicyConfig"
+	GoogleKubernetesEngineConfigFieldEnableStackdriverLogging       = "enableStackdriverLogging"
+	GoogleKubernetesEngineConfigFieldEnableStackdriverMonitoring    = "enableStackdriverMonitoring"
+	GoogleKubernetesEngineConfigFieldImageType                      = "imageType"
+	GoogleKubernetesEngineConfigFieldLabels                         = "labels"
+	GoogleKubernetesEngineConfigFieldLocations                      = "locations"
+	GoogleKubernetesEngineConfigFieldMachineType                    = "machineType"
+	GoogleKubernetesEngineConfigFieldMaintenanceWindow              = "maintenanceWindow"
+	GoogleKubernetesEngineConfigFieldMasterVersion                  = "masterVersion"
+	GoogleKubernetesEngineConfigFieldNetwork                        = "network"
+	GoogleKubernetesEngineConfigFieldNodeCount                      = "nodeCount"
+	GoogleKubernetesEngineConfigFieldNodeVersion                    = "nodeVersion"
+	GoogleKubernetesEngineConfigFieldProjectID                      = "projectId"
+	GoogleKubernetesEngineConfigFieldSubNetwork                     = "subNetwork"
+	GoogleKubernetesEngineConfigFieldZone                           = "zone"
 )
 
 type GoogleKubernetesEngineConfig struct {
-	ClusterIpv4Cidr                 string            `json:"clusterIpv4Cidr,omitempty" yaml:"clusterIpv4Cidr,omitempty"`
-	Credential                      string            `json:"credential,omitempty" yaml:"credential,omitempty"`
-	Description                     string            `json:"description,omitempty" yaml:"description,omitempty"`
-	DisableHTTPLoadBalancing        bool              `json:"disableHttpLoadBalancing,omitempty" yaml:"disableHttpLoadBalancing,omitempty"`
-	DisableHorizontalPodAutoscaling bool              `json:"disableHorizontalPodAutoscaling,omitempty" yaml:"disableHorizontalPodAutoscaling,omitempty"`
-	DisableNetworkPolicyConfig      bool              `json:"disableNetworkPolicyConfig,omitempty" yaml:"disableNetworkPolicyConfig,omitempty"`
-	DiskSizeGb                      int64             `json:"diskSizeGb,omitempty" yaml:"diskSizeGb,omitempty"`
-	EnableAlphaFeature              bool              `json:"enableAlphaFeature,omitempty" yaml:"enableAlphaFeature,omitempty"`
-	EnableKubernetesDashboard       bool              `json:"enableKubernetesDashboard,omitempty" yaml:"enableKubernetesDashboard,omitempty"`
-	EnableLegacyAbac                bool              `json:"enableLegacyAbac,omitempty" yaml:"enableLegacyAbac,omitempty"`
-	ImageType                       string            `json:"imageType,omitempty" yaml:"imageType,omitempty"`
-	Labels                          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Locations                       []string          `json:"locations,omitempty" yaml:"locations,omitempty"`
-	MachineType                     string            `json:"machineType,omitempty" yaml:"machineType,omitempty"`
-	MaintenanceWindow               string            `json:"maintenanceWindow,omitempty" yaml:"maintenanceWindow,omitempty"`
-	MasterVersion                   string            `json:"masterVersion,omitempty" yaml:"masterVersion,omitempty"`
-	Network                         string            `json:"network,omitempty" yaml:"network,omitempty"`
-	NoNetworkPolicy                 bool              `json:"noNetworkPolicy,omitempty" yaml:"noNetworkPolicy,omitempty"`
-	NoStackdriverLogging            bool              `json:"noStackdriverLogging,omitempty" yaml:"noStackdriverLogging,omitempty"`
-	NoStackdriverMonitoring         bool              `json:"noStackdriverMonitoring,omitempty" yaml:"noStackdriverMonitoring,omitempty"`
-	NodeCount                       int64             `json:"nodeCount,omitempty" yaml:"nodeCount,omitempty"`
-	NodeVersion                     string            `json:"nodeVersion,omitempty" yaml:"nodeVersion,omitempty"`
-	ProjectID                       string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
-	SubNetwork                      string            `json:"subNetwork,omitempty" yaml:"subNetwork,omitempty"`
-	Zone                            string            `json:"zone,omitempty" yaml:"zone,omitempty"`
+	ClusterIpv4Cidr                string            `json:"clusterIpv4Cidr,omitempty" yaml:"clusterIpv4Cidr,omitempty"`
+	Credential                     string            `json:"credential,omitempty" yaml:"credential,omitempty"`
+	Description                    string            `json:"description,omitempty" yaml:"description,omitempty"`
+	DiskSizeGb                     int64             `json:"diskSizeGb,omitempty" yaml:"diskSizeGb,omitempty"`
+	EnableAlphaFeature             bool              `json:"enableAlphaFeature,omitempty" yaml:"enableAlphaFeature,omitempty"`
+	EnableHTTPLoadBalancing        *bool             `json:"enableHttpLoadBalancing,omitempty" yaml:"enableHttpLoadBalancing,omitempty"`
+	EnableHorizontalPodAutoscaling *bool             `json:"enableHorizontalPodAutoscaling,omitempty" yaml:"enableHorizontalPodAutoscaling,omitempty"`
+	EnableKubernetesDashboard      bool              `json:"enableKubernetesDashboard,omitempty" yaml:"enableKubernetesDashboard,omitempty"`
+	EnableLegacyAbac               bool              `json:"enableLegacyAbac,omitempty" yaml:"enableLegacyAbac,omitempty"`
+	EnableNetworkPolicyConfig      *bool             `json:"enableNetworkPolicyConfig,omitempty" yaml:"enableNetworkPolicyConfig,omitempty"`
+	EnableStackdriverLogging       *bool             `json:"enableStackdriverLogging,omitempty" yaml:"enableStackdriverLogging,omitempty"`
+	EnableStackdriverMonitoring    *bool             `json:"enableStackdriverMonitoring,omitempty" yaml:"enableStackdriverMonitoring,omitempty"`
+	ImageType                      string            `json:"imageType,omitempty" yaml:"imageType,omitempty"`
+	Labels                         map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Locations                      []string          `json:"locations,omitempty" yaml:"locations,omitempty"`
+	MachineType                    string            `json:"machineType,omitempty" yaml:"machineType,omitempty"`
+	MaintenanceWindow              string            `json:"maintenanceWindow,omitempty" yaml:"maintenanceWindow,omitempty"`
+	MasterVersion                  string            `json:"masterVersion,omitempty" yaml:"masterVersion,omitempty"`
+	Network                        string            `json:"network,omitempty" yaml:"network,omitempty"`
+	NodeCount                      int64             `json:"nodeCount,omitempty" yaml:"nodeCount,omitempty"`
+	NodeVersion                    string            `json:"nodeVersion,omitempty" yaml:"nodeVersion,omitempty"`
+	ProjectID                      string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
+	SubNetwork                     string            `json:"subNetwork,omitempty" yaml:"subNetwork,omitempty"`
+	Zone                           string            `json:"zone,omitempty" yaml:"zone,omitempty"`
 }


### PR DESCRIPTION
This change adds logic to the cluster formatter to show certain nil
fields as true when they are returned from the api.  This is so that the
fields are persisted correctly after the cluster is updated.

Issue:
https://github.com/rancher/rancher/issues/13789

Depends on:
https://github.com/rancher/kontainer-engine/pull/77
https://github.com/rancher/types/pull/531