### PR TITLE
don't return conflict error

### DIFF
--- a/pkg/controllers/user/networkpolicy/clusterHandler.go
+++ b/pkg/controllers/user/networkpolicy/clusterHandler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -68,7 +69,7 @@ func (ch *clusterHandler) Sync(key string, cluster *v3.Cluster) error {
 	cluster.Status.AppliedEnableNetworkPolicy = toEnable
 
 	_, err = ch.clusters.Update(cluster)
-	if err != nil {
+	if err != nil && !errors.IsConflict(err) {
 		return err
 	}
 


### PR DESCRIPTION
I recently added two cluster controllers, to handler network policy flag change. First one just updates the annotation based on flag value. Second handles stuff and updates status, second always gets called after first. I saw this error only twice, but both times, it was second controller trying to update the old object. Think second controller shouldn't return error on conflict, since it'll anyway keep retrying. 