### PR TITLE
Don't set netPol annotation on upgrade

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -84,12 +84,7 @@ func (cd *clusterDeploy) doSync(cluster *v3.Cluster) error {
 	if err != nil {
 		return err
 	}
-	err = cd.deployAgent(cluster)
-	if err != nil {
-		return err
-	}
-
-	return cd.setNetworkPolicyAnn(cluster)
+	return cd.deployAgent(cluster)
 }
 
 func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
@@ -141,18 +136,6 @@ func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
 	}
 
 	return err
-}
-
-func (cd *clusterDeploy) setNetworkPolicyAnn(cluster *v3.Cluster) error {
-	if cluster.Spec.EnableNetworkPolicy != nil {
-		return nil
-	}
-	// set current state for upgraded canal clusters
-	if cluster.Spec.RancherKubernetesEngineConfig != nil &&
-		cluster.Spec.RancherKubernetesEngineConfig.Network.CanalNetworkProvider != nil {
-		cluster.Annotations["networking.management.cattle.io/enable-network-policy"] = "true"
-	}
-	return nil
 }
 
 func (cd *clusterDeploy) getKubeConfig(cluster *v3.Cluster) (*clientcmdapi.Config, error) {

--- a/pkg/controllers/user/networkpolicy/utils.go
+++ b/pkg/controllers/user/networkpolicy/utils.go
@@ -13,7 +13,14 @@ func isNetworkPolicyDisabled(clusterNamespace string, clusterLister v3.ClusterLi
 	if err != nil {
 		return false, fmt.Errorf("error getting cluster %v", err)
 	}
-	return !convert.ToBool(cluster.Annotations[netPolAnnotation]), nil
+	if cluster.Spec.EnableNetworkPolicy != nil {
+		return !convert.ToBool(cluster.Annotations[netPolAnnotation]), nil
+	}
+	if cluster.Spec.RancherKubernetesEngineConfig != nil &&
+		cluster.Spec.RancherKubernetesEngineConfig.Network.CanalNetworkProvider != nil {
+		return false, nil
+	}
+	return true, nil
 }
 
 func nodePortService(service *corev1.Service) bool {


### PR DESCRIPTION
Problem: Setting network policy annotation for upgraded canal clusters causes the cluster to update.
Solution: Don't set the annotation value, instead return the desired value based on config.