### PR TITLE
Add user enabled check for saml

### DIFF
--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -312,7 +312,13 @@ func (s *Provider) HandleSamlAssertion(w http.ResponseWriter, r *http.Request, a
 	}
 	user, err := s.userMGR.EnsureUser(userPrincipal.Name, displayName)
 	if err != nil {
-		log.Errorf("SAML: User does not have access %v", err)
+		log.Errorf("SAML: Failed getting user with error: %v", err)
+		http.Redirect(w, r, redirectURL+"/login?errorCode=500", http.StatusFound)
+		return
+	}
+
+	if user.Enabled != nil && !*user.Enabled {
+		log.Errorf("SAML: User %v permission denied", user.Name)
 		http.Redirect(w, r, redirectURL+"/login?errorCode=403", http.StatusFound)
 		return
 	}


### PR DESCRIPTION
Problem:
When attempting to login with a user which is not enabled no error is
presented in the UI.

Solution:
Add a check on the user for enabled and redirect with an error.
Previously this was being caught on the token so the UI would not
show/redirect an error.

Issue: rancher/rancher/issues/10646