### PR TITLE
set enableNetworkPolicy of cluster spec=true for upgraded canal clusters

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -150,6 +150,8 @@ func (cd *clusterDeploy) setNetworkPolicyAnn(cluster *v3.Cluster) error {
 	// set current state for upgraded canal clusters
 	if cluster.Spec.RancherKubernetesEngineConfig != nil &&
 		cluster.Spec.RancherKubernetesEngineConfig.Network.CanalNetworkProvider != nil {
+		enableNetworkPolicy := true
+		cluster.Spec.EnableNetworkPolicy = &enableNetworkPolicy
 		cluster.Annotations["networking.management.cattle.io/enable-network-policy"] = "true"
 	}
 	return nil


### PR DESCRIPTION
This will result into controller syncing up network policies, and setting status
to true.
https://github.com/rancher/rancher/issues/14851 