### PR TITLE
Dont immediately set namespace to active

### DIFF
--- a/pkg/controllers/user/rbac/namespace_handler.go
+++ b/pkg/controllers/user/rbac/namespace_handler.go
@@ -56,8 +56,6 @@ func (n *nsLifecycle) Create(obj *v1.Namespace) (*v1.Namespace, error) {
 		return obj, err
 	}
 
-	namespaceutil.SetNamespaceCondition(obj, 0, initialRoleCondition, true, "")
-
 	if err := n.assignToInitialProject(obj); err != nil {
 		return obj, err
 	}


### PR DESCRIPTION
The InitialRolesPopulated condition was  getting set to true
prematurely. This fixes that. Also, change the initial value
of the condition from False to Unknown because False is interpertted
as an error state in rancher.

This was previously fix but reintroduced in 2b6779719115fd4ede7ab4ec19eca19c97e4e4cb
as a result of a rebase conflict.

Addresses https://github.com/rancher/rancher/issues/13703