### PR TITLE
Compare node roles correctly

### DIFF
--- a/pkg/controllers/management/nodepool/nodepool.go
+++ b/pkg/controllers/management/nodepool/nodepool.go
@@ -291,9 +291,9 @@ func needRoleUpdate(node *v3.Node, nodePool *v3.NodePool) bool {
 	}
 
 	poolRolesMap := map[string]bool{}
-	nodeRolesMap[services.ETCDRole] = nodePool.Spec.Etcd
-	nodeRolesMap[services.ControlRole] = nodePool.Spec.ControlPlane
-	nodeRolesMap[services.WorkerRole] = nodePool.Spec.Worker
+	poolRolesMap[services.ETCDRole] = nodePool.Spec.Etcd
+	poolRolesMap[services.ControlRole] = nodePool.Spec.ControlPlane
+	poolRolesMap[services.WorkerRole] = nodePool.Spec.Worker
 	return !reflect.DeepEqual(nodeRolesMap, poolRolesMap)
 }
 


### PR DESCRIPTION
Comparing roles against empty map causes node roles to update on upgrade,
which changes role order causing spec to unnecessarily change.

Resolves: #14914