### PR TITLE
set the right role for worker

### DIFF
--- a/pkg/controllers/user/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/user/nodesyncer/nodessyncer.go
@@ -466,6 +466,9 @@ func (m *NodesSyncer) convertNodeToNode(node *corev1.Node, existing *v3.Node, po
 		}
 		_, worker := node.Labels["node-role.kubernetes.io/worker"]
 		machine.Spec.Worker = worker
+		if !machine.Spec.Worker && !machine.Spec.ControlPlane && !machine.Spec.Etcd {
+			machine.Spec.Worker = true
+		}
 	}
 
 	machine.Status.NodeAnnotations = node.Annotations


### PR DESCRIPTION
we have to assert the correct role for worker nodes, as we rely on the
role to collect stats only when node has worker role. But for nodes that
belongs to cloud provider cluster, all three roles are set to false, so
we have to take it as a worker. Otherwise the stats collected to cluster
won't be correct.