### PR TITLE
use new transport instead of existing cache transport

### DIFF
--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -192,12 +192,13 @@ func (m *Manager) toRESTConfig(cluster *v3.Cluster) (*rest.Config, error) {
 		}
 	}
 
+	// adding suffix to make tlsConfig hashkey unique
+	suffix := []byte("\n" + cluster.Name)
 	rc := &rest.Config{
 		Host:        u.String(),
 		BearerToken: cluster.Status.ServiceAccountToken,
 		TLSClientConfig: rest.TLSClientConfig{
-			ServerName: u.Hostname(),
-			CAData:     caBytes,
+			CAData: append(caBytes, suffix...),
 		},
 		Timeout: 30 * time.Second,
 		WrapTransport: func(rt http.RoundTripper) http.RoundTripper {


### PR DESCRIPTION
By default k8s client libray will cache transport based on the hash key
of tlsConfig. This will reuse the previous transport if we have the same
tls config. By making a new tranport for each rest.config so that we
don't reuse any of the cache transport.