### PR TITLE
Restrict users permissions

### DIFF
--- a/app/role_data.go
+++ b/app/role_data.go
@@ -39,7 +39,6 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups().nonResourceURLs("*").verbs("*")
 
 	rb.addRole("User", "user").addRule().apiGroups("management.cattle.io").resources("principals", "roletemplates").verbs("get", "list", "watch").
-		addRule().apiGroups("management.cattle.io").resources("users").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("preferences").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("settings").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("clusters").verbs("create").
@@ -51,9 +50,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("management.cattle.io").resources("sourcecoderepositories").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("resourcequotatemplates").verbs("get", "list", "watch")
 
-	rb.addRole("User Base", "user-base").addRule().apiGroups("management.cattle.io").resources("principals", "roletemplates").verbs("get", "list", "watch").
-		addRule().apiGroups("management.cattle.io").resources("users").verbs("get", "list", "watch").
-		addRule().apiGroups("management.cattle.io").resources("preferences").verbs("*").
+	rb.addRole("User Base", "user-base").addRule().apiGroups("management.cattle.io").resources("preferences").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("settings").verbs("get", "list", "watch")
 
 	// TODO user should be dynamically authorized to only see herself

--- a/tests/core/test_rbac.py
+++ b/tests/core/test_rbac.py
@@ -164,3 +164,35 @@ def test_removing_user_from_cluster(admin_pc, admin_mc, user_mc, admin_cc,
         assert cluster is None
     except ApiError as e:
         assert e.error.status == 403
+
+
+def test_user_role_permissions(admin_mc, user_factory, remove_resource):
+    """Test that a standard user can only see themselves """
+    admin_client = admin_mc.client
+
+    # Create 4 new users, one with user-base
+    user1 = user_factory()
+    user2 = user_factory(globalRoleId='user-base')
+    user_factory()
+    user_factory()
+
+    users = admin_client.list_user()
+    # Admin should see at least 5 users
+    assert len(users.data) >= 5
+
+    # user1 should only see themselves in the user list
+    users1 = user1.client.list_user()
+    assert len(users1.data) == 1, "user should only see themselves"
+
+    # user1 can see all roleTemplates
+    role_templates = user1.client.list_role_template()
+    assert len(role_templates.data) > 0, ("user should be able to see all " +
+                                          "roleTemplates")
+
+    # user2 should only see themselves in the user list
+    users2 = user2.client.list_user()
+    assert len(users2.data) == 1, "user should only see themselves"
+    # user2 should not see any role templates
+    role_templates = user2.client.list_role_template()
+    assert len(role_templates.data) == 0, ("user2 does not have permission " +
+                                           "to view roleTemplates")

--- a/vendor.conf
+++ b/vendor.conf
@@ -33,7 +33,7 @@ github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c6
 github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d7567c5b0b
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
-github.com/rancher/types                      eebbe779936337f6baf7f38b16529450c027e62f
+github.com/rancher/types                      38a6850257921f6cff13584b4459dcfdcd78bf19
 
 
 github.com/rancher/norman                     58f46da75435d71681aedacf588a60dc282da310

--- a/vendor/github.com/rancher/types/mapper/container_status.go
+++ b/vendor/github.com/rancher/types/mapper/container_status.go
@@ -48,8 +48,14 @@ func checkStatus(containerStates map[string]containerState, containerStatus []ma
 					s.transitioning = "error"
 				}
 			case "running":
-				s.state = "running"
-				s.transitioning = "no"
+				ready := convert.ToBool(status["ready"])
+				if ready {
+					s.state = "running"
+					s.transitioning = "no"
+				} else {
+					s.state = "notready"
+					s.transitioning = "yes"
+				}
 			case "waiting":
 				s.state = "waiting"
 				s.transitioning = "yes"

--- a/vendor/github.com/rancher/types/user/manager.go
+++ b/vendor/github.com/rancher/types/user/manager.go
@@ -3,6 +3,7 @@ package user
 import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
+	apitypes "k8s.io/apimachinery/pkg/types"
 )
 
 type Manager interface {
@@ -12,4 +13,5 @@ type Manager interface {
 	EnsureUser(principalName, displayName string) (*v3.User, error)
 	CheckAccess(accessMode string, allowedPrincipalIDs []string, user v3.Principal, groups []v3.Principal) (bool, error)
 	SetPrincipalOnCurrentUserByUserID(userID string, principal v3.Principal) (*v3.User, error)
+	CreateNewUserClusterRoleBinding(userName string, userUID apitypes.UID) error
 }


### PR DESCRIPTION
Problem:
A user has too much permission to view resources such as users and
principles
User secret is not being deleted

Solution:
Remove permissions and add a clusterRoleBinding to the user so they are
still able to see themselves. This is required for login/UI and general
QOL.
Update user secret delete to be namespaced

Issue: rancher/rancher#15061
Issue: rancher/rancher#15067