### PR TITLE
Validate response codes in tests

### DIFF
--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -14,7 +14,6 @@ urllib3.disable_warnings()
 
 BASE_URL = 'https://localhost:8443/v3'
 AUTH_URL = BASE_URL + '-public/localproviders/local?action=login'
-CHNG_PWD_URL = BASE_URL + '/users/admin?action=changepassword'
 DEFAULT_TIMEOUT = 45
 
 
@@ -55,10 +54,6 @@ class ProjectContext:
 @pytest.fixture(scope="session")
 def admin_mc():
     """Returns a ManagementContext for the default global admin user."""
-    r = requests.post(CHNG_PWD_URL, json={
-        'newPassword': 'admin',
-    }, verify=False)
-    protect_response(r)
     r = requests.post(AUTH_URL, json={
         'username': 'admin',
         'password': 'admin',

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -264,6 +264,8 @@ def kubernetes_api_client(rancher_client, cluster_name):
     k8s_client = ApiClient(configuration=client_configuration)
     return k8s_client
 
-def protect_response(r): 
+
+def protect_response(r):
     if r.status_code >= 300:
-        raise ValueError(f'Server responded with {r.status_code}\nbody:\n{r.text}')
+        message = f'Server responded with {r.status_code}\nbody:\n{r.text}'
+        raise ValueError(message)


### PR DESCRIPTION
when a test fails due to a failed request (for example not being able to auth), the code just continues on until it hits a miscellaneous runtime error (like a response dict not having a token)

This just adds a function to validate that a response yielded a 2XX status code, otherwise it errors out with the code and response body