### PR TITLE
Fix an issue where members could not be resolved

### DIFF
--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -47,6 +47,7 @@ func newRTBLifecycles(management *config.ManagementContext) (*prtbLifecycle, *cr
 			rbLister:      management.RBAC.RoleBindings("").Controller().Lister(),
 			rtLister:      management.Management.RoleTemplates("").Controller().Lister(),
 			nsLister:      management.Core.Namespaces("").Controller().Lister(),
+			userLister:    management.Management.Users("").Controller().Lister(),
 			rbIndexer:     rbInformer.GetIndexer(),
 			crbIndexer:    crbInformer.GetIndexer(),
 			userMGR:       management.UserManager,
@@ -65,6 +66,7 @@ func newRTBLifecycles(management *config.ManagementContext) (*prtbLifecycle, *cr
 			rbLister:      management.RBAC.RoleBindings("").Controller().Lister(),
 			rtLister:      management.Management.RoleTemplates("").Controller().Lister(),
 			nsLister:      management.Core.Namespaces("").Controller().Lister(),
+			userLister:    management.Management.Users("").Controller().Lister(),
 			rbIndexer:     rbInformer.GetIndexer(),
 			crbIndexer:    crbInformer.GetIndexer(),
 			userMGR:       management.UserManager,
@@ -83,6 +85,7 @@ type manager struct {
 	crbLister     typesrbacv1.ClusterRoleBindingLister
 	rtLister      v3.RoleTemplateLister
 	nsLister      v13.NamespaceLister
+	userLister    v3.UserLister
 	rbIndexer     cache.Indexer
 	crbIndexer    cache.Indexer
 	mgmt          *config.ManagementContext

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -55,7 +55,7 @@ func (p *prtbLifecycle) Remove(obj *v3.ProjectRoleTemplateBinding) (*v3.ProjectR
 }
 
 func (p *prtbLifecycle) reconcileSubject(binding *v3.ProjectRoleTemplateBinding) (*v3.ProjectRoleTemplateBinding, error) {
-	if binding.UserName != "" || binding.GroupName != "" || binding.GroupPrincipalName != "" {
+	if binding.GroupName != "" || binding.GroupPrincipalName != "" || (binding.UserPrincipalName != "" && binding.UserName != "") {
 		return binding, nil
 	}
 
@@ -67,6 +67,20 @@ func (p *prtbLifecycle) reconcileSubject(binding *v3.ProjectRoleTemplateBinding)
 		}
 
 		binding.UserName = user.Name
+		return binding, nil
+	}
+
+	if binding.UserPrincipalName == "" && binding.UserName != "" {
+		u, err := p.mgr.userLister.Get("", binding.UserName)
+		if err != nil {
+			return binding, err
+		}
+		for _, p := range u.PrincipalIDs {
+			if strings.HasSuffix(p, binding.UserName) {
+				binding.UserPrincipalName = p
+				break
+			}
+		}
 		return binding, nil
 	}
 

--- a/tests/core/test_default_roles.py
+++ b/tests/core/test_default_roles.py
@@ -61,6 +61,9 @@ def test_cluster_create_default_role(admin_mc, cleanup_roles, remove_resource):
 
     for binding in cluster.clusterRoleTemplateBindings():
         assert binding.roleTemplateId in test_roles
+        assert binding.userId is not None
+        user = client.by_id_user(binding.userId)
+        assert binding.userPrincipalId in user.principalIds
 
 
 @pytest.mark.nonparallel
@@ -115,6 +118,9 @@ def test_project_create_default_role(admin_mc, cleanup_roles, remove_resource):
 
     for binding in project.projectRoleTemplateBindings():
         assert binding.roleTemplateId in test_roles
+        assert binding.userId is not None
+        user = client.by_id_user(binding.userId)
+        assert binding.userPrincipalId in user.principalIds
 
 
 @pytest.mark.nonparallel


### PR DESCRIPTION
Problem: The UI cannot display project and cluster creator
on the members page. This is because we change the permissions
on the user role such that non-admin users can no longer list
users at /v3/users.

Solution: The UI only uses /v3/users to look up members as a
fallback. It first tries to hit /v3/principals, which normal users
DO have access to. The problem was that we were not setting the
userPrincipalId on the special "creator" CRTB/PRTBs that are
created when a project or clsuter is created.

So, we just need to set that userPrincipalId field on the CRTBs
and PRTBs to allow the UI to resolve the principal properly.

https://github.com/rancher/rancher/issues/15160