### PR TITLE
Make Rancher go to 11

### DIFF
--- a/pkg/dialer/factory.go
+++ b/pkg/dialer/factory.go
@@ -25,7 +25,10 @@ import (
 
 func NewFactory(apiContext *config.ScaledContext) (dialer.Factory, error) {
 	authorizer := tunnelserver.NewAuthorizer(apiContext)
-	tunneler := tunnelserver.NewTunnelServer(apiContext, authorizer)
+	tunneler, err := tunnelserver.NewTunnelServer(apiContext, authorizer)
+	if err != nil {
+		return nil, err
+	}
 
 	secretStore, err := nodeconfig.NewStore(apiContext.Core.Namespaces(""), apiContext.Core)
 	if err != nil {

--- a/pkg/remotedialer/client/main.go
+++ b/pkg/remotedialer/client/main.go
@@ -28,5 +28,5 @@ func main() {
 		"X-Tunnel-ID": []string{id},
 	}
 
-	remotedialer.ClientConnect(addr, headers, nil, nil, nil)
+	remotedialer.ClientConnect(addr, headers, nil, func(string, string) bool { return true }, nil)
 }

--- a/pkg/remotedialer/client_dialer.go
+++ b/pkg/remotedialer/client_dialer.go
@@ -5,9 +5,11 @@ import (
 	"net"
 	"sync"
 	"time"
+
+	"github.com/rancher/types/config/dialer"
 )
 
-func clientDial(conn *connection, message *message) {
+func clientDial(dialer dialer.Dialer, conn *connection, message *message) {
 	defer conn.Close()
 
 	var (
@@ -15,10 +17,10 @@ func clientDial(conn *connection, message *message) {
 		err     error
 	)
 
-	if message.deadline == 0 {
-		netConn, err = net.Dial(message.proto, message.address)
-	} else {
+	if dialer == nil {
 		netConn, err = net.DialTimeout(message.proto, message.address, time.Duration(message.deadline)*time.Millisecond)
+	} else {
+		netConn, err = dialer(message.proto, message.address)
 	}
 
 	if err != nil {

--- a/pkg/remotedialer/dialer.go
+++ b/pkg/remotedialer/dialer.go
@@ -8,17 +8,17 @@ import (
 )
 
 func (s *Server) HasSession(clientKey string) bool {
-	_, err := s.sessions.getByClient(clientKey)
+	_, err := s.sessions.getDialer(clientKey, 0)
 	return err == nil
 }
 
 func (s *Server) Dial(clientKey string, deadline time.Duration, proto, address string) (net.Conn, error) {
-	session, err := s.sessions.getByClient(clientKey)
+	d, err := s.sessions.getDialer(clientKey, deadline)
 	if err != nil {
 		return nil, err
 	}
 
-	return session.serverConnect(deadline, proto, address)
+	return d(proto, address)
 }
 
 func (s *Server) Dialer(clientKey string, deadline time.Duration) dialer.Dialer {

--- a/pkg/remotedialer/dummy/main.go
+++ b/pkg/remotedialer/dummy/main.go
@@ -15,7 +15,7 @@ var (
 )
 
 func main() {
-	flag.StringVar(&listen, "listen", ":8124", "Listen address")
+	flag.StringVar(&listen, "listen", ":8125", "Listen address")
 	flag.Parse()
 
 	fmt.Println("listening ", listen)

--- a/pkg/remotedialer/peer.go
+++ b/pkg/remotedialer/peer.go
@@ -1,0 +1,119 @@
+package remotedialer
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	Token = "X-API-Tunnel-Token"
+	ID    = "X-API-Tunnel-ID"
+)
+
+func (s *Server) AddPeer(url, id, token string) {
+	if s.PeerID == "" || s.PeerToken == "" {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	peer := peer{
+		url:    url,
+		id:     id,
+		token:  token,
+		cancel: cancel,
+	}
+
+	logrus.Infof("Adding peer %s, %s", url, id)
+
+	s.peerLock.Lock()
+	defer s.peerLock.Unlock()
+
+	if p, ok := s.peers[id]; ok {
+		if p.equals(peer) {
+			return
+		}
+		p.cancel()
+	}
+
+	s.peers[id] = peer
+	go peer.start(ctx, s)
+}
+
+func (s *Server) RemovePeer(id string) {
+	s.peerLock.Lock()
+	defer s.peerLock.Unlock()
+
+	if p, ok := s.peers[id]; ok {
+		logrus.Infof("Removing peer %s", id)
+		p.cancel()
+	}
+	delete(s.peers, id)
+}
+
+type peer struct {
+	url, id, token string
+	cancel         func()
+}
+
+func (p peer) equals(other peer) bool {
+	return p.url == other.url &&
+		p.id == other.id &&
+		p.token == other.token
+}
+
+func (p *peer) start(ctx context.Context, s *Server) {
+	headers := http.Header{
+		ID:    {s.PeerID},
+		Token: {s.PeerToken},
+	}
+
+	dialer := &websocket.Dialer{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			break
+		default:
+		}
+
+		ws, _, err := dialer.Dial(p.url, headers)
+		if err != nil {
+			logrus.Errorf("Failed to connect to peer %s %#v: %v", p.url, headers, err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		session := newClientSession(func(string, string) bool { return true }, ws)
+		session.dialer = func(network, address string) (net.Conn, error) {
+			parts := strings.SplitN(network, "::", 2)
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("invalid clientKey/proto: %s", network)
+			}
+			return s.Dial(parts[0], 15*time.Second, parts[1], address)
+		}
+
+		s.sessions.addListener(session)
+		_, err = session.serve()
+		s.sessions.removeListener(session)
+		session.Close()
+
+		if err != nil {
+			logrus.Errorf("Failed to serve peer connection %s: %v", p.id, err)
+		}
+
+		ws.Close()
+		time.Sleep(5 * time.Second)
+	}
+}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -26,6 +26,8 @@ var (
 	KubernetesVersion               = NewSetting("k8s-version", v3.DefaultK8s)
 	KubernetesVersionToSystemImages = NewSetting("k8s-version-to-images", getSystemImages())
 	MachineVersion                  = NewSetting("machine-version", "dev")
+	Namespace                       = NewSetting("namespace", "cattle-system")
+	PeerServices                    = NewSetting("peer-service", "rancher")
 	RDNSServerBaseURL               = NewSetting("rdns-base-url", "https://api.lb.rancher.cloud/v1")
 	ServerImage                     = NewSetting("server-image", "rancher/rancher")
 	ServerURL                       = NewSetting("server-url", "")

--- a/pkg/tunnelserver/peermanager.go
+++ b/pkg/tunnelserver/peermanager.go
@@ -1,0 +1,104 @@
+package tunnelserver
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/norman/types/set"
+	"github.com/rancher/rancher/pkg/remotedialer"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/net"
+)
+
+type peerManager struct {
+	sync.Mutex
+	token     string
+	urlFormat string
+	server    *remotedialer.Server
+	peers     map[string]bool
+}
+
+func startPeerManager(context *config.ScaledContext, server *remotedialer.Server) error {
+	tokenBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if os.IsNotExist(err) {
+		logrus.Infof("Running in single server mode, will not peer connections")
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	ip, err := net.ChooseHostInterface()
+	if err != nil {
+		return errors.Wrap(err, "choosing interface IP")
+	}
+
+	logrus.Infof("Running in clustered mode with ID %s, monitoring endpoint %s/%s", ip, settings.Namespace.Get(), settings.PeerServices.Get())
+
+	server.PeerID = ip.String()
+	server.PeerToken = string(tokenBytes)
+
+	pm := &peerManager{
+		token:     server.PeerToken,
+		urlFormat: "wss://%s/v3/connect",
+		server:    server,
+		peers:     map[string]bool{},
+	}
+
+	context.Core.Endpoints(settings.Namespace.Get()).AddHandler("peer-manager-controller", pm.syncService)
+	return nil
+}
+
+func (p *peerManager) syncService(key string, endpoint *v1.Endpoints) error {
+	if endpoint == nil {
+		return nil
+	}
+
+	parts := strings.SplitN(key, "/", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+
+	ns, name := parts[0], parts[1]
+	if ns != settings.Namespace.Get() {
+		return nil
+	}
+
+	for _, svc := range strings.Split(settings.PeerServices.Get(), ",") {
+		if name == strings.TrimSpace(svc) {
+			p.addRemovePeers(endpoint)
+			break
+		}
+	}
+
+	return nil
+}
+
+func (p *peerManager) addRemovePeers(endpoints *v1.Endpoints) {
+	p.Lock()
+	defer p.Unlock()
+
+	newSet := map[string]bool{}
+	for _, subset := range endpoints.Subsets {
+		for _, addr := range subset.Addresses {
+			if addr.IP != p.server.PeerID {
+				newSet[addr.IP] = true
+			}
+		}
+	}
+
+	toCreate, toDelete, _ := set.Diff(newSet, p.peers)
+	for _, ip := range toCreate {
+		p.server.AddPeer(fmt.Sprintf(p.urlFormat, ip), ip, p.token)
+	}
+	for _, ip := range toDelete {
+		p.server.RemovePeer(ip)
+	}
+	p.peers = newSet
+}

--- a/pkg/tunnelserver/tunnel.go
+++ b/pkg/tunnelserver/tunnel.go
@@ -41,14 +41,9 @@ type input struct {
 	Cluster *cluster     `json:"cluster"`
 }
 
-func NewTunnelServer(context *config.ScaledContext, authorizer *Authorizer) *remotedialer.Server {
-	ready := func() bool {
-		return context.Leader
-	}
-	return remotedialer.New(authorizer.authorizeTunnel, func(rw http.ResponseWriter, req *http.Request, code int, err error) {
-		rw.WriteHeader(code)
-		rw.Write([]byte(err.Error()))
-	}, ready)
+func NewTunnelServer(context *config.ScaledContext, authorizer *Authorizer) (*remotedialer.Server, error) {
+	rd := remotedialer.New(authorizer.authorizeTunnel, remotedialer.DefaultErrorWriter)
+	return rd, startPeerManager(context, rd)
 }
 
 func NewAuthorizer(context *config.ScaledContext) *Authorizer {


### PR DESCRIPTION
Adds the ability to run more that 1 Rancher server in a HA setup.
The enabling change is that the remotedialer tunnels will now call
across to peers to connect to the proper node owning the tunnel.