### PR TITLE
check nil and timestamp when deleting catalog

### DIFF
--- a/pkg/catalog/manager/sync.go
+++ b/pkg/catalog/manager/sync.go
@@ -9,10 +9,7 @@ import (
 
 func (m *Manager) Sync(key string, obj *v3.Catalog) error {
 	if obj == nil {
-		return nil
-	}
-	if obj.DeletionTimestamp != nil {
-		templates, err := m.getTemplateMap(obj.Name)
+		templates, err := m.getTemplateMap(key)
 		if err != nil {
 			return err
 		}

--- a/tests/core/test_catalog.py
+++ b/tests/core/test_catalog.py
@@ -1,0 +1,43 @@
+from .common import *
+
+
+def test_catalog(admin_mc):
+    client = admin_mc.client
+    name = random_str()
+    catalog = client.create_catalog(name=name,
+                                    branch="test",
+                                    url="https://github.com/StrongMonkey/charts-1.git"
+                                    )
+    wait_for_template_to_be_created(client, name)
+    client.delete(catalog)
+    wait_for_template_to_be_deleted(client, name)
+
+
+def wait_for_template_to_be_created(client, name, timeout=45):
+    found = False
+    start = time.time()
+    interval = 0.5
+    while not found:
+        if time.time() - start > timeout:
+            raise AssertionError(
+                "Timed out waiting for templates")
+        templates = client.list_template(catalogId=name)
+        if len(templates) > 0:
+            found = True
+        time.sleep(interval)
+        interval *= 2
+
+
+def wait_for_template_to_be_deleted(client, name, timeout=45):
+    found = False
+    start = time.time()
+    interval = 0.5
+    while not found:
+        if time.time() - start > timeout:
+            raise AssertionError(
+                "Timed out waiting for templates")
+        templates = client.list_template(catalogId=name)
+        if len(templates) == 0:
+            found = True
+        time.sleep(interval)
+        interval *= 2


### PR DESCRIPTION
We switched to use background deletion since 2.0.7 and that doesn't set
DeletionTimeStamp if no finalizer is set. So we have to check both
options to make sure delete logic is executed.