### PR TITLE
add proper detailed message when agent failed to register

### DIFF
--- a/pkg/rkenodeconfigclient/client.go
+++ b/pkg/rkenodeconfigclient/client.go
@@ -56,7 +56,7 @@ func ConfigClient(ctx context.Context, url string, header http.Header, writeCert
 			return rkeworker.ExecutePlan(ctx, nc, writeCertOnly)
 		}
 
-		logrus.Infof("waiting for node to register")
+		logrus.Infof("waiting for node to register. Either cluster is not ready for registering or etcd and controlplane node have to be registered first")
 		time.Sleep(2 * time.Second)
 	}
 }

--- a/pkg/rkenodeconfigserver/nodeserver.go
+++ b/pkg/rkenodeconfigserver/nodeserver.go
@@ -97,7 +97,7 @@ func (n *RKENodeConfigServer) ServeHTTP(rw http.ResponseWriter, req *http.Reques
 
 	if err != nil {
 		rw.WriteHeader(http.StatusInternalServerError)
-		rw.Write([]byte(err.Error()))
+		rw.Write([]byte("Failed to construct node config. Error: " + err.Error()))
 		return
 	}
 


### PR DESCRIPTION
Problems: it is not clear when agent failed to register due to etcd and
controlplane nodes missing or some random errors when failed to
construct node config which user has no idea what it is.
Solution: add proper log message.
https://github.com/rancher/rancher/issues/12548