### PR TITLE
more improvement for app deploy

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,6 +3,7 @@ FROM ubuntu:18.04
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
+ENV CATTLE_HELM_VERSION v2.9.1-rancher2
 
 RUN apt-get update && \
     apt-get install -y gcc ca-certificates git wget curl vim less file xz-utils unzip && \
@@ -18,6 +19,10 @@ RUN wget -O - https://storage.googleapis.com/golang/go1.9.2.linux-${!GOLANG_ARCH
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
     DOCKER_URL=DOCKER_URL_${ARCH}
+
+RUN curl -sLf https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/helm > /usr/bin/helm && \
+    curl -sLf https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/tiller > /usr/bin/tiller && \
+    chmod +x /usr/bin/helm /usr/bin/tiller
 
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
-ENV CATTLE_HELM_VERSION v2.9.1-rancher2
+ENV CATTLE_HELM_VERSION v2.9.1-rancher3
 
 RUN apt-get update && \
     apt-get install -y gcc ca-certificates git wget curl vim less file xz-utils unzip && \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /root/.kube && \
     ln -s /usr/bin/rancher /usr/bin/reset-password
 WORKDIR /var/lib/rancher
 
-ENV CATTLE_HELM_VERSION v2.9.1-rancher1
+ENV CATTLE_HELM_VERSION v2.9.1-rancher3
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher1-1
 ENV LOGLEVEL_VERSION v0.1
 ENV TINI_VERSION v0.18.0
@@ -19,8 +19,9 @@ RUN curl -sLf https://github.com/rancher/machine-package/releases/download/${CAT
     curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-amd64-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin && \
     curl -sLf https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini > /usr/bin/tini && \
     curl -sLf https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/helm > /usr/bin/helm && \
+    curl -sLf https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/tiller > /usr/bin/tiller && \
     curl -sLf https://github.com/rancher/telemetry/releases/download/${TELEMETRY_VERSION}/telemetry > /usr/bin/telemetry && \
-    chmod +x /usr/bin/helm /usr/bin/tini /usr/bin/telemetry
+    chmod +x /usr/bin/helm /usr/bin/tini /usr/bin/telemetry /usr/bin/tiller
 
 ENV CATTLE_UI_PATH /usr/share/rancher/ui
 ENV CATTLE_UI_VERSION 2.0.67

--- a/pkg/controllers/user/helm/common.go
+++ b/pkg/controllers/user/helm/common.go
@@ -3,14 +3,13 @@ package helm
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"encoding/base64"
 
 	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/controllers/user/helm/common"
@@ -22,10 +21,8 @@ import (
 
 const (
 	helmName    = "helm"
-	kubectl     = "kubectl"
 	appLabel    = "io.cattle.field/appId"
 	failedLabel = "io.cattle.field/failed-revision"
-	kcEnv       = "KUBECONFIG"
 )
 
 func WriteTempDir(rootDir string, files map[string]string) (string, error) {
@@ -47,13 +44,13 @@ func WriteTempDir(rootDir string, files map[string]string) (string, error) {
 	return "", nil
 }
 
-func helmInstall(templateDir, kubeconfigPath string, app *v3.App, install bool) error {
+func helmInstall(templateDir, kubeconfigPath string, app *v3.App) error {
 	cont, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	addr := common.GenerateRandomPort()
 	probeAddr := common.GenerateRandomPort()
 	go common.StartTiller(cont, addr, probeAddr, app.Spec.TargetNamespace, kubeconfigPath)
-	return common.InstallCharts(templateDir, addr, app, install)
+	return common.InstallCharts(templateDir, addr, app)
 }
 
 func helmDelete(kubeconfigPath string, app *v3.App) error {

--- a/pkg/controllers/user/helm/common/common.go
+++ b/pkg/controllers/user/helm/common/common.go
@@ -1,17 +1,17 @@
 package common
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math/rand"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
-
-	"bytes"
 
 	"github.com/pkg/errors"
 	"github.com/rancher/types/apis/project.cattle.io/v3"
@@ -54,11 +54,18 @@ func StartTiller(context context.Context, port, probePort, namespace, kubeConfig
 func GenerateRandomPort() string {
 	s1 := rand.NewSource(time.Now().UnixNano())
 	r1 := rand.New(s1)
-	port := base + r1.Intn(end-base+1)
-	return strconv.Itoa(port)
+	for {
+		port := base + r1.Intn(end-base+1)
+		ln, err := net.Listen("tcp", ":"+strconv.Itoa(port))
+		if err != nil {
+			continue
+		}
+		ln.Close()
+		return strconv.Itoa(port)
+	}
 }
 
-func InstallCharts(rootDir, port string, obj *v3.App, install bool) error {
+func InstallCharts(rootDir, port string, obj *v3.App) error {
 	setValues := []string{}
 	if obj.Spec.Answers != nil {
 		answers := obj.Spec.Answers
@@ -69,11 +76,7 @@ func InstallCharts(rootDir, port string, obj *v3.App, install bool) error {
 		setValues = append([]string{"--set-string"}, strings.Join(result, ","))
 	}
 	commands := make([]string, 0)
-	if install {
-		commands = append([]string{"install", "--namespace", obj.Spec.TargetNamespace, "--name", obj.Name}, setValues...)
-	} else {
-		commands = append([]string{"upgrade", "--namespace", obj.Spec.TargetNamespace, obj.Name}, setValues...)
-	}
+	commands = append([]string{"upgrade", "--install", "--namespace", obj.Spec.TargetNamespace, obj.Name}, setValues...)
 	commands = append(commands, rootDir)
 
 	cmd := exec.Command(helmName, commands...)
@@ -82,16 +85,15 @@ func InstallCharts(rootDir, port string, obj *v3.App, install bool) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = stderrBuf
 	if err := cmd.Start(); err != nil {
-		return errors.Wrapf(err, "failed to install app %s. error: %s", obj.Name, stderrBuf.String())
+		return errors.Errorf("failed to install app %s. %s", obj.Name, stderrBuf.String())
 	}
 	if err := cmd.Wait(); err != nil {
-		// if install fail then we delete the release. It can sanctify the error msg.
-		if install {
-			if err := DeleteCharts(port, obj); err != nil {
-				return err
-			}
+		// if the first install failed, the second install would have error message like `has no deployed releases`, then the
+		// original error is masked. We need to filter out the message and always return the last one if error matches this pattern
+		if strings.Contains(stderrBuf.String(), "has no deployed releases") {
+			return errors.New(v3.AppConditionInstalled.GetMessage(obj))
 		}
-		return errors.Wrapf(err, "failed to install app %s. error: %s", obj.Name, stderrBuf.String())
+		return errors.Errorf("failed to install app %s. %s", obj.Name, stderrBuf.String())
 	}
 	return nil
 }
@@ -100,8 +102,8 @@ func DeleteCharts(port string, obj *v3.App) error {
 	cmd := exec.Command(helmName, "delete", "--purge", obj.Name)
 	cmd.Env = []string{fmt.Sprintf("%s=%s", "HELM_HOST", "127.0.0.1:"+port)}
 	combinedOutput, err := cmd.CombinedOutput()
-	if combinedOutput != nil && strings.Contains(string(combinedOutput), fmt.Sprintf("Error: release: \"%s\" not found", obj.Name)) {
+	if err != nil && combinedOutput != nil && strings.Contains(string(combinedOutput), fmt.Sprintf("Error: release: \"%s\" not found", obj.Name)) {
 		return nil
 	}
-	return err
+	return errors.New(string(combinedOutput))
 }

--- a/tests/core/common.py
+++ b/tests/core/common.py
@@ -104,3 +104,33 @@ def auth_check(schema, id, access, props=None):
             assert prop_actual == prop
 
     return 1
+
+
+def wait_for_template_to_be_created(client, name, timeout=45):
+    found = False
+    start = time.time()
+    interval = 0.5
+    while not found:
+        if time.time() - start > timeout:
+            raise AssertionError(
+                "Timed out waiting for templates")
+        templates = client.list_template(catalogId=name)
+        if len(templates) > 0:
+            found = True
+        time.sleep(interval)
+        interval *= 2
+
+
+def wait_for_template_to_be_deleted(client, name, timeout=45):
+    found = False
+    start = time.time()
+    interval = 0.5
+    while not found:
+        if time.time() - start > timeout:
+            raise AssertionError(
+                "Timed out waiting for templates")
+        templates = client.list_template(catalogId=name)
+        if len(templates) == 0:
+            found = True
+        time.sleep(interval)
+        interval *= 2

--- a/tests/core/test_app.py
+++ b/tests/core/test_app.py
@@ -1,0 +1,126 @@
+from .common import random_str
+from .test_catalog import wait_for_template_to_be_created
+import time
+
+
+def test_app_mysql(admin_pc):
+    client = admin_pc.client
+    name = random_str()
+
+    ns = admin_pc.cluster.client.create_namespace(name=random_str(),
+                                                  projectId=admin_pc.
+                                                  project.id)
+    answers = {
+        "defaultImage": "true",
+        "image": "mysql",
+        "imageTag": "5.7.14",
+        "mysqlDatabase": "admin",
+        "mysqlPassword": "",
+        "mysqlUser": "admin",
+        "persistence.enabled": "false",
+        "persistence.size": "8Gi",
+        "persistence.storageClass": "",
+        "service.nodePort": "",
+        "service.port": "3306",
+        "service.type": "ClusterIP"
+    }
+    client.create_app(
+        name=name,
+        externalId="catalog://?catalog=library&template=mysql&version=0.3.7",
+        targetNamespace=ns.name,
+        projectId=admin_pc.project.id,
+        answers=answers
+    )
+    wait_for_workload(client, ns.name, count=1)
+
+
+def test_app_wordpress(admin_pc):
+    client = admin_pc.client
+    name = random_str()
+
+    ns = admin_pc.cluster.client.create_namespace(name=random_str(),
+                                                  projectId=admin_pc.
+                                                  project.id)
+
+    answers = {
+        "defaultImage": "true",
+        "externalDatabase.database": "",
+        "externalDatabase.host": "",
+        "externalDatabase.password": "",
+        "externalDatabase.port": "3306",
+        "externalDatabase.user": "",
+        "image.repository": "bitnami/wordpress",
+        "image.tag": "4.9.4",
+        "ingress.enabled": "true",
+        "ingress.hosts[0].name": "xip.io",
+        "mariadb.enabled": "true",
+        "mariadb.image.repository": "bitnami/mariadb",
+        "mariadb.image.tag": "10.1.32",
+        "mariadb.mariadbDatabase": "wordpress",
+        "mariadb.mariadbPassword": "",
+        "mariadb.mariadbUser": "wordpress",
+        "mariadb.persistence.enabled": "false",
+        "mariadb.persistence.size": "8Gi",
+        "mariadb.persistence.storageClass": "",
+        "nodePorts.http": "",
+        "nodePorts.https": "",
+        "persistence.enabled": "false",
+        "persistence.size": "10Gi",
+        "persistence.storageClass": "",
+        "serviceType": "NodePort",
+        "wordpressEmail": "user@example.com",
+        "wordpressPassword": "",
+        "wordpressUsername": "user"
+    }
+    external_id = "catalog://?catalog=library&template=wordpress&version=1.0.5"
+    client.create_app(
+        name=name,
+        externalId=external_id,
+        targetNamespace=ns.name,
+        projectId=admin_pc.project.id,
+        answers=answers
+    )
+    wait_for_workload(client, ns.name, count=2)
+
+
+def test_prehook_chart(admin_pc, admin_mc):
+    client = admin_pc.client
+    name = random_str()
+
+    ns = admin_pc.cluster.client.create_namespace(name=random_str(),
+                                                  projectId=admin_pc.
+                                                  project.id)
+    url = "https://github.com/StrongMonkey/charts-1.git"
+    catalog = admin_mc.client.create_catalog(name=random_str(),
+                                             branch="test",
+                                             url=url,
+                                             )
+    wait_for_template_to_be_created(admin_mc.client, catalog.name)
+    external_id = "catalog://?catalog=" + \
+                  catalog.name + "&template=busybox&version=0.0.2"
+    client.create_app(
+        name=name,
+        externalId=external_id,
+        targetNamespace=ns.name,
+        projectId=admin_pc.project.id,
+    )
+    # it will be only one workload(job), because the deployment has to
+    # wait for job to be finished, and it will never finish because we
+    # can't create real container
+    wait_for_workload(client, ns.name, count=1)
+    jobs = client.list_job(namespaceId=ns.id)
+    assert len(jobs) == 1
+
+
+def wait_for_workload(client, ns, timeout=60, count=0):
+    start = time.time()
+    interval = 0.5
+    workloads = client.list_workload(namespaceId=ns)
+    while len(workloads.data) != count:
+        workloads = client.list_workload(namespaceId=ns)
+        time.sleep(interval)
+        if time.time() - start > timeout:
+            print(workloads)
+            raise Exception('Timeout waiting for workload service')
+        interval *= 2
+    return workloads

--- a/tests/core/test_catalog.py
+++ b/tests/core/test_catalog.py
@@ -1,6 +1,5 @@
-from .common import random_str
-
-import time
+from .common import wait_for_template_to_be_created, \
+    wait_for_template_to_be_deleted, random_str
 
 
 def test_catalog(admin_mc):
@@ -14,33 +13,3 @@ def test_catalog(admin_mc):
     wait_for_template_to_be_created(client, name)
     client.delete(catalog)
     wait_for_template_to_be_deleted(client, name)
-
-
-def wait_for_template_to_be_created(client, name, timeout=45):
-    found = False
-    start = time.time()
-    interval = 0.5
-    while not found:
-        if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for templates")
-        templates = client.list_template(catalogId=name)
-        if len(templates) > 0:
-            found = True
-        time.sleep(interval)
-        interval *= 2
-
-
-def wait_for_template_to_be_deleted(client, name, timeout=45):
-    found = False
-    start = time.time()
-    interval = 0.5
-    while not found:
-        if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for templates")
-        templates = client.list_template(catalogId=name)
-        if len(templates) == 0:
-            found = True
-        time.sleep(interval)
-        interval *= 2

--- a/vendor.conf
+++ b/vendor.conf
@@ -37,12 +37,12 @@ github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c6
 github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d7567c5b0b
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
-github.com/rancher/types                      2dcb95d094ec01fefa8a8736b4b74b09f389d559
+github.com/rancher/types                      6b3463d9baad7aa30fa0c0b06cc8198ad52413e6
 
 
 github.com/rancher/norman                     1d3cf7aee832f7e60e417df8998998f981cb2441
 github.com/rancher/kontainer-engine           2b4ed633b1aa73a109db704264513bfe9210f52b
-github.com/rancher/rke                        bcb6e13618f03e8b57957d89cde3232b937eeb99
+github.com/rancher/rke                        cb5067207173605072be62c0f2d2f77e92a16a6d
 
 gopkg.in/ldap.v2     v2.5.0
 gopkg.in/asn1-ber.v1 v1.1

--- a/vendor/github.com/rancher/rke/cmd/config.go
+++ b/vendor/github.com/rancher/rke/cmd/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -40,6 +41,18 @@ func ConfigCommand() cli.Command {
 			cli.BoolFlag{
 				Name:  "print,p",
 				Usage: "Print configuration",
+			},
+			cli.BoolFlag{
+				Name:  "system-images",
+				Usage: "Generate the default system images",
+			},
+			cli.BoolFlag{
+				Name:  "all",
+				Usage: "Generate the default system images for all versions",
+			},
+			cli.StringFlag{
+				Name:  "version",
+				Usage: "Generate the default system images for specific k8s versions",
 			},
 		},
 	}
@@ -81,6 +94,9 @@ func writeConfig(cluster *v3.RancherKubernetesEngineConfig, configFile string, p
 }
 
 func clusterConfig(ctx *cli.Context) error {
+	if ctx.Bool("system-images") {
+		return generateSystemImagesList(ctx.String("version"), ctx.Bool("all"))
+	}
 	configFile := ctx.String("name")
 	print := ctx.Bool("print")
 	cluster := v3.RancherKubernetesEngineConfig{}
@@ -382,4 +398,64 @@ func getAddonManifests(reader *bufio.Reader) ([]string, error) {
 	}
 
 	return addonSlice, nil
+}
+
+func generateSystemImagesList(version string, all bool) error {
+	allVersions := []string{}
+	for version := range v3.AllK8sVersions {
+		allVersions = append(allVersions, version)
+	}
+	if all {
+		for version, rkeSystemImages := range v3.AllK8sVersions {
+			logrus.Infof("Generating images list for version [%s]:", version)
+			uniqueImages := getUniqueSystemImageList(rkeSystemImages)
+			for _, image := range uniqueImages {
+				if image == "" {
+					continue
+				}
+				fmt.Printf("%s\n", image)
+			}
+		}
+		return nil
+	}
+	if len(version) == 0 {
+		version = v3.DefaultK8s
+	}
+	rkeSystemImages := v3.AllK8sVersions[version]
+	if rkeSystemImages == (v3.RKESystemImages{}) {
+		return fmt.Errorf("k8s version is not supported, supported versions are: %v", allVersions)
+	}
+	logrus.Infof("Generating images list for version [%s]:", version)
+	uniqueImages := getUniqueSystemImageList(rkeSystemImages)
+	for _, image := range uniqueImages {
+		if image == "" {
+			continue
+		}
+		fmt.Printf("%s\n", image)
+	}
+	return nil
+}
+
+func getUniqueSystemImageList(rkeSystemImages v3.RKESystemImages) []string {
+	imagesReflect := reflect.ValueOf(rkeSystemImages)
+	images := make([]string, imagesReflect.NumField())
+	for i := 0; i < imagesReflect.NumField(); i++ {
+		images[i] = imagesReflect.Field(i).Interface().(string)
+	}
+	return getUniqueSlice(images)
+}
+
+func getUniqueSlice(slice []string) []string {
+	encountered := map[string]bool{}
+	unqiue := []string{}
+
+	for i := range slice {
+		if encountered[slice[i]] {
+			continue
+		} else {
+			encountered[slice[i]] = true
+			unqiue = append(unqiue, slice[i])
+		}
+	}
+	return unqiue
 }

--- a/vendor/github.com/rancher/rke/hosts/dialer.go
+++ b/vendor/github.com/rancher/rke/hosts/dialer.go
@@ -40,7 +40,7 @@ func newDialer(h *Host, kind string) (*dialer, error) {
 			netConn:         "tcp",
 			useSSHAgentAuth: h.SSHAgentAuth,
 		}
-		if bastionDialer.sshKeyString == "" {
+		if bastionDialer.sshKeyString == "" && !bastionDialer.useSSHAgentAuth {
 			var err error
 			bastionDialer.sshKeyString, err = privateKeyPath(h.BastionHost.SSHKeyPath)
 			if err != nil {
@@ -59,7 +59,7 @@ func newDialer(h *Host, kind string) (*dialer, error) {
 		bastionDialer:   bastionDialer,
 	}
 
-	if dialer.sshKeyString == "" {
+	if dialer.sshKeyString == "" && !dialer.useSSHAgentAuth {
 		var err error
 		dialer.sshKeyString, err = privateKeyPath(h.SSHKeyPath)
 		if err != nil {

--- a/vendor/github.com/rancher/rke/vendor.conf
+++ b/vendor/github.com/rancher/rke/vendor.conf
@@ -17,11 +17,11 @@ github.com/pkg/errors                    f15c970de5b76fac0b59abb32d62c17cc7bed26
 gopkg.in/check.v1                        11d3bc7aa68e238947792f30573146a3231fc0f1
 k8s.io/client-go                         v7.0.0 transitive=true
 github.com/gorilla/websocket             v1.2.0
-golang.org/x/sync 			                 fd80eb99c8f653c847d294a001bdf2a3a6f768f5
+golang.org/x/sync                        fd80eb99c8f653c847d294a001bdf2a3a6f768f5
 github.com/coreos/etcd                   52f73c5a6cb0d1d196ffd6eced406c9d8502078a transitive=true
 github.com/coreos/go-semver              e214231b295a8ea9479f11b70b35d5acf3556d9b
 github.com/ugorji/go/codec               ccfe18359b55b97855cee1d3f74e5efbda4869dc
 github.com/Microsoft/go-winio            ab35fc04b6365e8fcb18e6e9e41ea4a02b10b175
 github.com/go-ini/ini                    06f5f3d67269ccec1fe5fe4134ba6e982984f7f5
 github.com/rancher/norman                c032c4611f2eec1652ef37d254f0e8ccf90c80aa
-github.com/rancher/types                 27bc977d20f999a5140d9f0f0b837d7f0e2bc99d
+github.com/rancher/types                 eb5a4fd55a4ada9d64713530f02cbaf3f1b8c2ea

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	DefaultK8s = "v1.11.2-rancher1-1"
+	DefaultK8s = "v1.11.2-rancher1-2"
 )
 
 var (
@@ -19,7 +19,7 @@ var (
 	k8sVersionsCurrent = []string{
 		"v1.9.7-rancher2-2",
 		"v1.10.5-rancher1-2",
-		"v1.11.2-rancher1-1",
+		"v1.11.2-rancher1-2",
 	}
 
 	// K8sVersionToRKESystemImages is dynamically populated on init() with the latest versions
@@ -29,7 +29,8 @@ var (
 	K8sVersionServiceOptions = map[string]KubernetesServicesOptions{
 		"v1.11": {
 			KubeAPI: map[string]string{
-				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+				"enable-admission-plugins": "ServiceAccount,NamespaceLifecycle,LimitRanger,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds",
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
@@ -39,6 +40,7 @@ var (
 			KubeAPI: map[string]string{
 				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
 				"endpoint-reconciler-type": "lease",
+				"enable-admission-plugins": "ServiceAccount,NamespaceLifecycle,LimitRanger,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds",
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
@@ -47,6 +49,7 @@ var (
 		"v1.9": {
 			KubeAPI: map[string]string{
 				"endpoint-reconciler-type": "lease",
+				"admission-control":        "ServiceAccount,NamespaceLifecycle,LimitRanger,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds",
 			},
 		},
 	}
@@ -453,6 +456,32 @@ var (
 			CanalNode:                 m("quay.io/calico/node:v3.1.1"),
 			CanalCNI:                  m("quay.io/calico/cni:v3.1.1"),
 			CanalFlannel:              m("quay.io/coreos/flannel:v0.9.1"),
+			WeaveNode:                 m("weaveworks/weave-kube:2.1.2"),
+			WeaveCNI:                  m("weaveworks/weave-npc:2.1.2"),
+			PodInfraContainer:         m("gcr.io/google_containers/pause-amd64:3.1"),
+			Ingress:                   m("rancher/nginx-ingress-controller:0.16.2-rancher1"),
+			IngressBackend:            m("k8s.gcr.io/defaultbackend:1.4"),
+			MetricsServer:             m("gcr.io/google_containers/metrics-server-amd64:v0.2.1"),
+		},
+		"v1.11.2-rancher1-2": {
+			Etcd:                      m("quay.io/coreos/etcd:v3.2.18"),
+			Kubernetes:                m("rancher/hyperkube:v1.11.2-rancher1"),
+			Alpine:                    m("rancher/rke-tools:v0.1.14"),
+			NginxProxy:                m("rancher/rke-tools:v0.1.14"),
+			CertDownloader:            m("rancher/rke-tools:v0.1.14"),
+			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.14"),
+			KubeDNS:                   m("gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.10"),
+			DNSmasq:                   m("gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.10"),
+			KubeDNSSidecar:            m("gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.10"),
+			KubeDNSAutoscaler:         m("gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0"),
+			Flannel:                   m("quay.io/coreos/flannel:v0.10.0"),
+			FlannelCNI:                m("quay.io/coreos/flannel-cni:v0.3.0"),
+			CalicoNode:                m("quay.io/calico/node:v3.1.3"),
+			CalicoCNI:                 m("quay.io/calico/cni:v3.1.3"),
+			CalicoCtl:                 m("quay.io/calico/ctl:v2.0.0"),
+			CanalNode:                 m("quay.io/calico/node:v3.1.3"),
+			CanalCNI:                  m("quay.io/calico/cni:v3.1.3"),
+			CanalFlannel:              m("quay.io/coreos/flannel:v0.10.0"),
 			WeaveNode:                 m("weaveworks/weave-kube:2.1.2"),
 			WeaveCNI:                  m("weaveworks/weave-npc:2.1.2"),
 			PodInfraContainer:         m("gcr.io/google_containers/pause-amd64:3.1"),

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_windows_default.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_windows_default.go
@@ -164,6 +164,14 @@ var (
 			CanalCNIBinaries:   m("rancher/canal-cni:v0.0.1-nanoserver-1803"),
 			KubeletPause:       m("rancher/kubelet-pause:v0.0.1-nanoserver-1803"),
 		},
+		"v1.11.2-rancher1-2": {
+			NginxProxy:         m("rancher/nginx-proxy:v0.0.1-nanoserver-1803"),
+			KubernetesBinaries: m("rancher/hyperkube:v1.11.2-nanoserver-1803"),
+			FlannelCNIBinaries: m("rancher/flannel-cni:v0.0.1-nanoserver-1803"),
+			CalicoCNIBinaries:  m("rancher/calico-cni:v0.0.1-nanoserver-1803"),
+			CanalCNIBinaries:   m("rancher/canal-cni:v0.0.1-nanoserver-1803"),
+			KubeletPause:       m("rancher/kubelet-pause:v0.0.1-nanoserver-1803"),
+		},
 	}
 )
 

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
@@ -29,6 +29,7 @@ type AppSpec struct {
 
 var (
 	AppConditionInstalled condition.Cond = "Installed"
+	AppConditionMigrated  condition.Cond = "Migrated"
 )
 
 type AppStatus struct {


### PR DESCRIPTION
This pr fixes several issues:
1. deployApp is no longer called in create lifecycle. All the logic is
handled through update. Also we don't delete bad release if it failed to
install for the first time. Related issue:
https://github.com/rancher/rancher/issues/15264,
https://github.com/rancher/rancher/issues/15252
2. Handle the error message gracefully so that when users failed to
install, proper error message is presented. (permission and etc...)
3. Add to check to ensure the port allocated to helm and tiller is not
used.