### PR TITLE
Ignore alreadyExist error in usermanager

### DIFF
--- a/pkg/auth/providers/common/usermanager.go
+++ b/pkg/auth/providers/common/usermanager.go
@@ -350,7 +350,9 @@ func (m *userManager) CreateNewUserClusterRoleBinding(userName string, userUID a
 
 		cr, err = m.rbacClient.ClusterRoles("").Create(role)
 		if err != nil {
-			return err
+			if !apierrors.IsAlreadyExists(err) {
+				return err
+			}
 		}
 	}
 
@@ -378,7 +380,9 @@ func (m *userManager) CreateNewUserClusterRoleBinding(userName string, userUID a
 		}
 		_, err = m.rbacClient.ClusterRoleBindings("").Create(crb)
 		if err != nil {
-			return err
+			if !apierrors.IsAlreadyExists(err) {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Problem:
CreateNewUserClusterRoleBinding attempts to create the role and binding
for a user, under a race this can error and return an alreadyExists

Solution:
Ignore alreadyExists errors here and continue