### PR TITLE
Update rancher golang version to 1.11

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -13,7 +13,7 @@ RUN apt-get update && \
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.9.2.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN wget -O - https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get github.com/golang/lint/golint
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \

--- a/pkg/api/customization/podsecuritypolicytemplate/podsecuritypolicytemplate.go
+++ b/pkg/api/customization/podsecuritypolicytemplate/podsecuritypolicytemplate.go
@@ -89,7 +89,7 @@ func (f *Format) Formatter(apiContext *types.APIContext, resource *types.RawReso
 	// check if PSPT is assigned to a cluster or project
 	projectsWithPSPT, err := f.ProjectIndexer.ByIndex(projectByPSPTKey, resource.ID)
 	if err != nil {
-		logrus.Warn("failed to determine if PSPT was assigned to a project: %v", err)
+		logrus.Warnf("failed to determine if PSPT was assigned to a project: %v", err)
 		return
 	}
 

--- a/pkg/controllers/user/alert/watcher/node.go
+++ b/pkg/controllers/user/alert/watcher/node.go
@@ -47,7 +47,7 @@ func (w *NodeWatcher) watch(ctx context.Context, interval time.Duration) {
 	for range ticker.Context(ctx, interval) {
 		err := w.watchRule()
 		if err != nil {
-			logrus.Infof("Failed to watch node", err)
+			logrus.Infof("Failed to watch node, error: %v", err)
 		}
 	}
 }

--- a/pkg/controllers/user/alert/watcher/pod.go
+++ b/pkg/controllers/user/alert/watcher/pod.go
@@ -60,7 +60,7 @@ func (w *PodWatcher) watch(ctx context.Context, interval time.Duration) {
 	for range ticker.Context(ctx, interval) {
 		err := w.watchRule()
 		if err != nil {
-			logrus.Infof("Failed to watch pod", err)
+			logrus.Infof("Failed to watch pod, error: %v", err)
 		}
 	}
 }

--- a/pkg/controllers/user/alert/watcher/syscomponent.go
+++ b/pkg/controllers/user/alert/watcher/syscomponent.go
@@ -41,7 +41,7 @@ func (w *SysComponentWatcher) watch(ctx context.Context, interval time.Duration)
 	for range ticker.Context(ctx, interval) {
 		err := w.watchRule()
 		if err != nil {
-			logrus.Infof("Failed to watch system component", err)
+			logrus.Infof("Failed to watch system component, error: %v", err)
 		}
 	}
 }

--- a/pkg/controllers/user/alert/watcher/workload.go
+++ b/pkg/controllers/user/alert/watcher/workload.go
@@ -60,7 +60,7 @@ func (w *WorkloadWatcher) watch(ctx context.Context, interval time.Duration) {
 	for range ticker.Context(ctx, interval) {
 		err := w.watchRule()
 		if err != nil {
-			logrus.Infof("Failed to watch deployment", err)
+			logrus.Infof("Failed to watch deployment, error: %v", err)
 		}
 	}
 }

--- a/pkg/controllers/user/dnsrecord/dnsrecord.go
+++ b/pkg/controllers/user/dnsrecord/dnsrecord.go
@@ -92,7 +92,7 @@ func (c *Controller) reconcileEndpoints(key string, obj *corev1.Service) error {
 	err := json.Unmarshal([]byte(value), &records)
 	if err != nil {
 		// just log the error, can't really do anything here.
-		logrus.Debugf("Failed to unmarshal targetDnsRecordIds", err)
+		logrus.Debugf("Failed to unmarshal targetDnsRecordIds, error: %v", err)
 		return nil
 	}
 	if records == nil {

--- a/pkg/controllers/user/externalservice/external_ip_service.go
+++ b/pkg/controllers/user/externalservice/external_ip_service.go
@@ -51,7 +51,7 @@ func (c *Controller) sync(key string, obj *corev1.Service) error {
 	var ipsStr []string
 	err := json.Unmarshal([]byte(obj.Annotations[ExternalIPsAnnotation]), &ipsStr)
 	if err != nil {
-		logrus.Debugf("Failed to unmarshal ipAddresses", err)
+		logrus.Debugf("Failed to unmarshal ipAddresses, error: %v", err)
 		return nil
 	}
 	if ipsStr == nil {

--- a/pkg/controllers/user/logging/utils/daemonset.go
+++ b/pkg/controllers/user/logging/utils/daemonset.go
@@ -229,7 +229,7 @@ func NewFluentdDaemonset(name, namespace, dockerRootDir string) *v1beta2.DaemonS
 					},
 					ServiceAccountName:            loggingconfig.FluentdName,
 					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
-					Volumes: allVols,
+					Volumes:                       allVols,
 				},
 			},
 		},

--- a/pkg/controllers/user/targetworkloadservice/target_workload_service.go
+++ b/pkg/controllers/user/targetworkloadservice/target_workload_service.go
@@ -124,7 +124,7 @@ func getServiceWorkloadIDs(obj *corev1.Service) []string {
 	err := json.Unmarshal([]byte(value), &workloadIDs)
 	if err != nil {
 		// just log the error, can't really do anything here.
-		logrus.Debugf("Failed to unmarshal targetWorkloadIds", err)
+		logrus.Debugf("Failed to unmarshal targetWorkloadIds, error: %v", err)
 	}
 	return workloadIDs
 }

--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -65,9 +65,8 @@ fi
 set -e -x
 REGISTRY=$1
 
-docker load --input rancher-images.tar.gz
-
-`)
+docker load --input rancher-images.tar.gz`)
+	fmt.Fprint(load, "\n\n")
 
 	for _, saveImage := range saveImages(targetImages) {
 		fmt.Fprintf(load, "docker tag %s ${REGISTRY}/%s\n", saveImage, saveImage)

--- a/pkg/pipeline/remote/gitlab/gitlab.go
+++ b/pkg/pipeline/remote/gitlab/gitlab.go
@@ -125,12 +125,12 @@ func (c *client) CreateHook(pipeline *v3.Pipeline, accessToken string) (string, 
 	project := url.QueryEscape(user + "/" + repo)
 	hookURL := fmt.Sprintf("%s/hooks?pipelineId=%s", settings.ServerURL.Get(), ref.Ref(pipeline))
 	opt := &gitlab.AddProjectHookOptions{
-		PushEvents:          gitlab.Bool(true),
-		MergeRequestsEvents: gitlab.Bool(true),
-		TagPushEvents:       gitlab.Bool(true),
-		URL:                 gitlab.String(hookURL),
+		PushEvents:            gitlab.Bool(true),
+		MergeRequestsEvents:   gitlab.Bool(true),
+		TagPushEvents:         gitlab.Bool(true),
+		URL:                   gitlab.String(hookURL),
 		EnableSSLVerification: gitlab.Bool(false),
-		Token: gitlab.String(pipeline.Status.Token),
+		Token:                 gitlab.String(pipeline.Status.Token),
 	}
 
 	url := fmt.Sprintf("%s/projects/%s/hooks", c.API, project)

--- a/pkg/rkenodeconfigserver/nodeserver.go
+++ b/pkg/rkenodeconfigserver/nodeserver.go
@@ -448,7 +448,7 @@ func createWindowsProcesses(rkeConfig *v3.RancherKubernetesEngineConfig, configN
 	serviceOptions := v3.K8sVersionWindowsServiceOptions[clusterMajorVersion]
 
 	extendingKubeletOptions := extendMap(map[string]string{
-		"v": "2",
+		"v":                            "2",
 		"pod-infra-container-image":    kubeletPauseImage,
 		"allow-privileged":             "true",
 		"anonymous-auth":               "false",

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -106,13 +106,13 @@ func createToken(management *config.ScaledContext) (string, error) {
 		},
 	))
 	if err != nil {
-		return "", errors.Wrapf(err, "Can't list admin-user for telemetry. Err: %v. Retry after 5 seconds")
+		return "", errors.Wrapf(err, "Can't list admin-user for telemetry. Err: %v. Retry after 5 seconds", err)
 	}
 	for _, user := range users {
 		if user.DisplayName == adminRole {
 			token, err := management.UserManager.EnsureToken("telemetry", "telemetry token", user.Name)
 			if err != nil {
-				return "", errors.Wrapf(err, "Can't create token for telemetry. Err: %v. Retry after 5 seconds")
+				return "", errors.Wrapf(err, "Can't create token for telemetry. Err: %v. Retry after 5 seconds", err)
 			}
 			return token, nil
 		}

--- a/scripts/build-agent
+++ b/scripts/build-agent
@@ -6,5 +6,5 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-[ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
+[ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
 CGO_ENABLED=0 go build -i -tags k8s -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/agent ./pkg/agent

--- a/scripts/build-server
+++ b/scripts/build-server
@@ -6,7 +6,7 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-[ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
+[ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
 
 RKE_VERSION=$(grep '^github.com/rancher/rke' vendor.conf | awk '{print $2}')
 


### PR DESCRIPTION
1. I tried upgrading rancher to golang 1.11, its again failing with same error as it did for go 1.10.3/4
```
Running: go fmt
# github.com/rancher/rancher
loadinternal: cannot find runtime/cgo
# github.com/rancher/rancher/pkg/agent
loadinternal: cannot find runtime/cgo
Running tests
./test: line 37: 30468 Trace/breakpoint trap   (core dumped) KUBECONFIG= ../../$CMD --add-local=true  (wd: /go/src/github.com/rancher/rancher/build/testdata)
```
2. Then I tried removing CGO_ENABLED=0 from build-server/build-agent. `make ci` was successfult, but then rancher server crashed while creating a single node DO cluster with some cgo related errors.
```
goroutine 20542 [syscall]:
runtime.cgocall(0x3d0ad10, 0xc435f24f58, 0x51c3a04)
    /usr/local/go/src/runtime/cgocall.go:128 +0x64 fp=0xc435f24f10 sp=0xc435f24ed8 pc=0x4022f4
os/user._Cfunc_mygetgrgid_r(0x0, 0xc425e7f540, 0xc419d70, 0x400, 0xc427b07470, 0x0)
```
These are same failures that happened while upgrading to golang 1.10.3/4
3. Then I added CGO_ENABLED=0 back and removed linkmode=external from linkflags, and the images got created plus the server didn’t crash either on DO cluster creation, but the cluster doesn’t get created properly and fails with this error (at least didn't crash this time)
```
2018/09/05 21:18:06 [ERROR] cluster [c-cn9rf] provisioning: [controlPlane] Failed to bring up Control Plane: Failed to verify healthcheck: Failed to check https://localhost:6443/healthz for service [kube-apiserver] on host [138.197.101.9]: Get https://localhost:6443/healthz: can not build dialer to c-cn9rf:m-9gsfl, log: I0905 21:17:00.456185       1 logs.go:49] http: TLS handshake error from 138.197.101.9:46406: EOF
```
4. After that I added back `linkmode external`, and also added osusergo and netgo tags to the go build command, but that again leads to the first error and eventually seg fault.