### PR TITLE
revert use set-string in install charts

### DIFF
--- a/pkg/controllers/user/helm/common/common.go
+++ b/pkg/controllers/user/helm/common/common.go
@@ -73,7 +73,7 @@ func InstallCharts(rootDir, port string, obj *v3.App) error {
 		for k, v := range answers {
 			result = append(result, fmt.Sprintf("%s=%s", k, v))
 		}
-		setValues = append([]string{"--set-string"}, strings.Join(result, ","))
+		setValues = append([]string{"--set"}, strings.Join(result, ","))
 	}
 	commands := make([]string, 0)
 	commands = append([]string{"upgrade", "--install", "--namespace", obj.Spec.TargetNamespace, obj.Name}, setValues...)


### PR DESCRIPTION
This resolves the similar issue in the [PR](https://github.com/rancher/rancher/pull/15043), but fixed for set type during install the charts. @StrongMonkey @cjellick .

comments: If we use --set-string, all the value will be considered a string. This won't be a problem for just rendering templates because they just render string, but the thing would break if you expect to compare a boolean or number. #15344 