### PR TITLE
bump helm version to v2.10

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
-ENV CATTLE_HELM_VERSION v2.9.1-rancher3
+ENV CATTLE_HELM_VERSION v2.10.0-rancher1
 
 RUN apt-get update && \
     apt-get install -y gcc ca-certificates git wget curl vim less file xz-utils unzip && \

--- a/pkg/controllers/user/helm/common.go
+++ b/pkg/controllers/user/helm/common.go
@@ -48,8 +48,7 @@ func helmInstall(templateDir, kubeconfigPath string, app *v3.App) error {
 	cont, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	addr := common.GenerateRandomPort()
-	probeAddr := common.GenerateRandomPort()
-	go common.StartTiller(cont, addr, probeAddr, app.Spec.TargetNamespace, kubeconfigPath)
+	go common.StartTiller(cont, addr, app.Spec.TargetNamespace, kubeconfigPath)
 	return common.InstallCharts(templateDir, addr, app)
 }
 
@@ -57,8 +56,7 @@ func helmDelete(kubeconfigPath string, app *v3.App) error {
 	cont, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	addr := common.GenerateRandomPort()
-	probeAddr := common.GenerateRandomPort()
-	go common.StartTiller(cont, addr, probeAddr, app.Spec.TargetNamespace, kubeconfigPath)
+	go common.StartTiller(cont, addr, app.Spec.TargetNamespace, kubeconfigPath)
 	return common.DeleteCharts(addr, app)
 }
 

--- a/pkg/controllers/user/helm/common/common.go
+++ b/pkg/controllers/user/helm/common/common.go
@@ -36,8 +36,8 @@ func ParseExternalID(externalID string) (string, error) {
 }
 
 // StartTiller start tiller server and return the listening address of the grpc address
-func StartTiller(context context.Context, port, probePort, namespace, kubeConfigPath string) error {
-	cmd := exec.Command(tillerName, "--listen", ":"+port, "--probe", ":"+probePort)
+func StartTiller(context context.Context, port, namespace, kubeConfigPath string) error {
+	cmd := exec.Command(tillerName, "--listen", ":"+port)
 	cmd.Env = []string{fmt.Sprintf("%s=%s", "KUBECONFIG", kubeConfigPath), fmt.Sprintf("%s=%s", "TILLER_NAMESPACE", namespace)}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Update helm version to v2.10, will need `crd-install` hook for catalog apps that use CRD or operators (e,g, etcd-operator, prometheus-operator). Also, the latest version will address more [common bugs](https://github.com/helm/helm/releases/tag/v2.10.0) in the helm . #15344 