### PR TITLE
 Stop in-use nodeTemplate from being deleted

### DIFF
--- a/pkg/api/customization/nodetemplate/formatter.go
+++ b/pkg/api/customization/nodetemplate/formatter.go
@@ -1,0 +1,27 @@
+package nodetemplate
+
+import (
+	"github.com/rancher/norman/types"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type Formatter struct {
+	NodePoolLister v3.NodePoolLister
+}
+
+func (ntf *Formatter) Formatter(request *types.APIContext, resource *types.RawResource) {
+	pools, err := ntf.NodePoolLister.List("", labels.Everything())
+	if err != nil {
+		logrus.Warnf("Failed to determine if Node Template is being used. Error: %v", err)
+		return
+	}
+
+	for _, pool := range pools {
+		if pool.Spec.NodeTemplateName == resource.ID {
+			delete(resource.Links, "remove")
+			return
+		}
+	}
+}

--- a/pkg/api/store/nodetemplate/store.go
+++ b/pkg/api/store/nodetemplate/store.go
@@ -1,0 +1,26 @@
+package nodetemplate
+
+import (
+	"github.com/rancher/norman/httperror"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type Store struct {
+	types.Store
+	NodePoolLister v3.NodePoolLister
+}
+
+func (s *Store) Delete(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
+	pools, err := s.NodePoolLister.List("", labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	for _, pool := range pools {
+		if pool.Spec.NodeTemplateName == id {
+			return nil, httperror.NewAPIError(httperror.MethodNotAllowed, "Template is in use by a node pool.")
+		}
+	}
+	return s.Store.Delete(apiContext, schema, id)
+}

--- a/tests/core/test_node.py
+++ b/tests/core/test_node.py
@@ -1,4 +1,7 @@
+import pytest
+from rancher import ApiError
 from .common import auth_check
+from .conftest import wait_for
 
 
 def test_node_fields(admin_mc):
@@ -45,3 +48,48 @@ def test_node_fields(admin_mc):
     fields['customConfig'] = 'cru'
 
     auth_check(cclient.schema, 'node', 'crud', fields)
+
+
+def test_node_template_delete(admin_mc, remove_resource):
+    """Test deleting a nodeTemplate that is in use by a nodePool.
+    The nodeTemplate should not be deleted while in use, after the nodePool is
+    removed it should delete.
+    """
+    client = admin_mc.client
+    node_template = client.create_node_template(azureConfig={})
+    node_pool = client.create_node_pool(
+        nodeTemplateId=node_template.id,
+        hostnamePrefix="test1",
+        clusterId="local")
+
+    # node_pool needs to come first or the API will stop the delete if the
+    # template still exists
+    remove_resource(node_pool)
+    remove_resource(node_template)
+
+    assert node_pool.nodeTemplateId == node_template.id
+
+    # Attempting to delete the template should raise an ApiError
+    with pytest.raises(ApiError) as e:
+        client.delete(node_template)
+    assert e.value.error.status == 405
+
+    # remove link should not be available
+    node_template = client.reload(node_template)
+    assert 'remove' not in node_template.links.data_dict()
+
+    client.delete(node_pool)
+
+    def _node_pool_reload():
+        np = client.reload(node_pool)
+        return np is None
+
+    wait_for(_node_pool_reload)
+
+    node_template = client.reload(node_template)
+    assert 'remove' in node_template.links.data_dict()
+    # NodePool is gone, template should delete
+    client.delete(node_template)
+
+    node_template = client.reload(node_template)
+    assert node_template is None


### PR DESCRIPTION
Problem:
A user can delete a nodeTemplate at anytime, this causes issues when
trying to scale nodes

Solution:
Check if the template is being used and if it is do not allow it to be
deleted and remove the 'remove' link from the api

Issue: rancher/rancher#13354