### PR TITLE
[2.2]Cache the API UI in local file

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -29,6 +29,9 @@ ENV CATTLE_UI_PATH /usr/share/rancher/ui
 ENV CATTLE_UI_VERSION 2.0.77
 ENV CATTLE_CLI_VERSION v2.0.7-rc2
 
+# Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
+ENV CATTLE_API_UI_VERSION 1.1.6
+
 RUN mkdir -p /var/log/auditlog
 ENV AUDIT_LOG_PATH /var/log/auditlog/rancher-api-audit.log
 ENV AUDIT_LOG_MAXAGE 10
@@ -40,6 +43,9 @@ VOLUME /var/log/auditlog
 RUN mkdir -p /usr/share/rancher/ui && \
     cd /usr/share/rancher/ui && \
     curl -sL https://releases.rancher.com/ui/${CATTLE_UI_VERSION}.tar.gz | tar xvzf - --strip-components=1 && \
+    mkdir -p /usr/share/rancher/ui/api-ui && \
+    cd /usr/share/rancher/ui/api-ui && \
+    curl -sL https://releases.rancher.com/api-ui/${CATTLE_API_UI_VERSION}.tar.gz | tar xvzf - --strip-components=1 && \
     cd /var/lib/rancher
 
 ENV CATTLE_CLI_URL_DARWIN  https://releases.rancher.com/cli2/${CATTLE_CLI_VERSION}/rancher-darwin-amd64-${CATTLE_CLI_VERSION}.tar.gz

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"strings"
+
+	normanapi "github.com/rancher/norman/api"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/pkg/settings"
+)
+
+func NewServer(schemas *types.Schemas) (*normanapi.Server, error) {
+	server := normanapi.NewAPIServer()
+	if err := server.AddSchemas(schemas); err != nil {
+		return nil, err
+	}
+	server.CustomAPIUIResponseWriter(cssURL, jsURL, settings.APIUIVersion.Get)
+	return server, nil
+}
+
+func cssURL() string {
+	if !strings.HasPrefix(settings.ServerVersion.Get(), "v") {
+		return ""
+	}
+	return "/api-ui/ui.min.css"
+}
+
+func jsURL() string {
+	if !strings.HasPrefix(settings.ServerVersion.Get(), "v") {
+		return ""
+	}
+	return "/api-ui/ui.min.js"
+}

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"net/http"
 
-	normanapi "github.com/rancher/norman/api"
 	"github.com/rancher/norman/api/builtin"
 	"github.com/rancher/norman/pkg/subscribe"
+	rancherapi "github.com/rancher/rancher/pkg/api"
 	"github.com/rancher/rancher/pkg/api/controllers/dynamicschema"
 	"github.com/rancher/rancher/pkg/api/controllers/samlconfig"
 	"github.com/rancher/rancher/pkg/api/controllers/settings"
@@ -37,19 +37,18 @@ func New(ctx context.Context, scaledContext *config.ScaledContext, clusterManage
 		return nil, err
 	}
 
-	server := normanapi.NewAPIServer()
-	server.AccessControl = scaledContext.AccessControl
-
-	if err := server.AddSchemas(scaledContext.Schemas); err != nil {
+	server, err := rancherapi.NewServer(scaledContext.Schemas)
+	if err != nil {
 		return nil, err
 	}
+	server.AccessControl = scaledContext.AccessControl
 
 	dynamicschema.Register(ctx, scaledContext, server.Schemas)
 	whitelistproxyNodeDriver.Register(ctx, scaledContext)
 	whitelistproxyKontainerDriver.Register(ctx, scaledContext)
 	samlconfig.Register(ctx, scaledContext)
 	usercontrollers.Register(ctx, scaledContext, clusterManager)
-	err := settings.Register(scaledContext)
+	err = settings.Register(scaledContext)
 
 	return server, err
 }

--- a/pkg/auth/providers/publicapi/handler.go
+++ b/pkg/auth/providers/publicapi/handler.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"net/http"
 
-	normanapi "github.com/rancher/norman/api"
 	"github.com/rancher/norman/store/subtype"
 	"github.com/rancher/norman/types"
+	rancherapi "github.com/rancher/rancher/pkg/api"
 	publicSchema "github.com/rancher/types/apis/management.cattle.io/v3public/schema"
 	v3public "github.com/rancher/types/client/management/v3public"
 	"github.com/rancher/types/config"
@@ -18,11 +18,7 @@ func NewHandler(ctx context.Context, mgmtCtx *config.ScaledContext) (http.Handle
 		return nil, err
 	}
 
-	server := normanapi.NewAPIServer()
-	if err := server.AddSchemas(schemas); err != nil {
-		return nil, err
-	}
-	return server, nil
+	return rancherapi.NewServer(schemas)
 }
 
 var authProviderTypes = []string{

--- a/pkg/auth/tokens/api.go
+++ b/pkg/auth/tokens/api.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"net/http"
 
-	normanapi "github.com/rancher/norman/api"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
+	rancherapi "github.com/rancher/rancher/pkg/api"
 	managementSchema "github.com/rancher/types/apis/management.cattle.io/v3/schema"
 	"github.com/rancher/types/client/management/v3"
 	"github.com/rancher/types/config"
@@ -40,12 +40,7 @@ func NewAPIHandler(ctx context.Context, apiContext *config.ScaledContext) (http.
 	schema.CreateHandler = api.tokenCreateHandler
 	schema.DeleteHandler = api.tokenDeleteHandler
 
-	server := normanapi.NewAPIServer()
-	if err := server.AddSchemas(schemas); err != nil {
-		return nil, err
-	}
-
-	return server, nil
+	return rancherapi.NewServer(schemas)
 }
 
 type tokenAPI struct {

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -49,6 +49,7 @@ var (
 	SystemMonitoringCatalogID       = NewSetting("system-monitoring-catalog-id", "catalog://?catalog=system-library&template=rancher-monitoring&version=0.0.1")
 	AuthUserInfoResyncCron          = NewSetting("auth-user-info-resync-cron", "0 0 * * *")
 	AuthUserInfoMaxAgeSeconds       = NewSetting("auth-user-info-max-age-seconds", "3600") // 1 hour
+	APIUIVersion                    = NewSetting("api-ui-version", "1.1.6")                // Please update the CATTLE_API_UI_VERSION in package/Dockerfile when updating the version here.
 )
 
 type Provider interface {

--- a/server/server.go
+++ b/server/server.go
@@ -94,6 +94,9 @@ func Start(ctx context.Context, httpPort, httpsPort int, scaledContext *config.S
 	root.Handle("/robots.txt", uiContent)
 	root.Handle("/VERSION.txt", uiContent)
 
+	//API UI
+	root.PathPrefix("/api-ui").Handler(uiContent)
+
 	registerHealth(root)
 
 	dynamiclistener.Start(ctx, scaledContext, httpPort, httpsPort, root)


### PR DESCRIPTION
For now, we are using the specific api ui version in
https://releases.rancher.com/api-ui/. It is not good for
air gap rancher setup. It needs to be cached in local files.