### PR TITLE
Don't add scheduler if not used

### DIFF
--- a/pkg/embedded/embedded.go
+++ b/pkg/embedded/embedded.go
@@ -171,7 +171,6 @@ func runK8s(ctx context.Context, kubeConfig string, args []string) {
 
 	hk.AddServer(hyperkube.NewKubeAPIServer())
 	hk.AddServer(hyperkube.NewKubeControllerManager())
-	hk.AddServer(hyperkube.NewScheduler())
 
 	logrus.Info("Running ", strings.Join(args, " "))
 	if err := hk.Run(args, ctx.Done()); err != nil {


### PR DESCRIPTION
@StrongMonkey Do we need to keep this if we removed it from processes in this commit: https://github.com/rancher/rancher/commit/8559f713320da4a797599fc0c59491a210e5c8b9#diff-7e3da37086bb215488bbda60242629ab ?