### PR TITLE
validate enableNetpolicy only on update

### DIFF
--- a/pkg/api/customization/node/node.go
+++ b/pkg/api/customization/node/node.go
@@ -48,7 +48,9 @@ func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 	if nodeTemplateID == nil && customConfig == nil {
 		delete(resource.Links, "remove")
 	}
-	if resource.Values[client.NodeFieldWorker] != true {
+	if resource.Values[client.NodeFieldWorker] != true ||
+		resource.Values["state"] == "registering" ||
+		resource.Values["state"] == "unavailable" {
 		return
 	}
 	if resource.Values["state"] == "draining" {


### PR DESCRIPTION
Problem: since this field is on cluster level, making it true in
default setting results into error for non-RKE clusters. 


https://github.com/rancher/rancher/issues/15432
https://github.com/rancher/rancher/issues/15430