### PR TITLE
Use cluster.Name + machine.Name for dialer session key

### DIFF
--- a/pkg/dialer/factory.go
+++ b/pkg/dialer/factory.go
@@ -202,8 +202,9 @@ func (f *Factory) DockerDialer(clusterName, machineName string) (dialer.Dialer, 
 		return nil, err
 	}
 
-	if f.TunnelServer.HasSession(machine.Name) {
-		d := f.TunnelServer.Dialer(machine.Name, 15*time.Second)
+	sessionKey := machineSessionKey(machine)
+	if f.TunnelServer.HasSession(sessionKey) {
+		d := f.TunnelServer.Dialer(sessionKey, 15*time.Second)
 		return func(string, string) (net.Conn, error) {
 			return d("unix", "/var/run/docker.sock")
 		}, nil
@@ -232,10 +233,15 @@ func (f *Factory) nodeDialer(clusterName, machineName string) (dialer.Dialer, er
 		return nil, err
 	}
 
-	if f.TunnelServer.HasSession(machine.Name) {
-		d := f.TunnelServer.Dialer(machine.Name, 15*time.Second)
+	sessionKey := machineSessionKey(machine)
+	if f.TunnelServer.HasSession(sessionKey) {
+		d := f.TunnelServer.Dialer(sessionKey, 15*time.Second)
 		return dialer.Dialer(d), nil
 	}
 
 	return nil, fmt.Errorf("can not build dialer to %s:%s", clusterName, machineName)
+}
+
+func machineSessionKey(machine *v3.Node) string {
+	return fmt.Sprintf("%s/%s", machine.Namespace, machine.Name)
 }

--- a/pkg/tunnelserver/tunnel.go
+++ b/pkg/tunnelserver/tunnel.go
@@ -83,7 +83,7 @@ type Client struct {
 func (t *Authorizer) authorizeTunnel(req *http.Request) (string, bool, error) {
 	client, ok, err := t.Authorize(req)
 	if client != nil && client.Node != nil {
-		return client.Node.Name, ok, err
+		return client.Cluster.Name + "/" + client.Node.Name, ok, err
 	} else if client != nil && client.Cluster != nil {
 		return client.Cluster.Name, ok, err
 	}


### PR DESCRIPTION
Two machines with the same hostname in two different clusters will clash for the dialer session.  The end result is if you have two clusters with nodes with the same hostname and you are using RKE, one of the clusters will not provision. 