### PR TITLE
CA linefeed fix

### DIFF
--- a/pkg/api/controllers/dynamiclistener/listener_controller.go
+++ b/pkg/api/controllers/dynamiclistener/listener_controller.go
@@ -3,6 +3,7 @@ package dynamiclistener
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/rancher/pkg/cert"
@@ -21,7 +22,7 @@ type Controller struct {
 	listenConfig       v3.ListenConfigInterface
 	listenConfigLister v3.ListenConfigLister
 	secrets            v1.SecretInterface
-	server             *dynamiclistener.Server
+	server             dynamiclistener.ServerInterface
 }
 
 type storageUpdater interface {
@@ -95,9 +96,10 @@ func (c *Controller) enable(listener *v3.ListenConfig) error {
 }
 
 func (c *Controller) updateCurrent(listener *v3.ListenConfig) error {
-	settings.CACerts.Set(listener.CACerts)
-	if listener.Key != "" && listener.CACerts != "" && listener.Cert != "" {
-		certInfo, err := cert.Info(listener.Cert+"\n"+listener.CACerts, listener.Key)
+	caCerts := strings.TrimSpace(listener.CACerts)
+	settings.CACerts.Set(caCerts)
+	if listener.Key != "" && caCerts != "" && listener.Cert != "" {
+		certInfo, err := cert.Info(listener.Cert+"\n"+caCerts, listener.Key)
 		if err != nil {
 			return err
 		}

--- a/pkg/api/controllers/dynamiclistener/listener_controller_test.go
+++ b/pkg/api/controllers/dynamiclistener/listener_controller_test.go
@@ -1,0 +1,103 @@
+package dynamiclistener
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/pkg/dynamiclistener"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/types/apis/core/v1"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	caCerts = `-----BEGIN CERTIFICATE-----
+MIIDoDCCAoigAwIBAgIUARVYAJKrXL1Eb06sULOq2oLnPKIwDQYJKoZIhvcNAQEL
+BQAwaDELMAkGA1UEBhMCVVMxDzANBgNVBAgTBk9yZWdvbjERMA8GA1UEBxMIUG9y
+dGxhbmQxEzARBgNVBAoTCkt1YmVybmV0ZXMxCzAJBgNVBAsTAkNBMRMwEQYDVQQD
+EwpLdWJlcm5ldGVzMB4XDTE4MDkwNzE3MDcwMFoXDTIzMDkwNjE3MDcwMFowaDEL
+MAkGA1UEBhMCVVMxDzANBgNVBAgTBk9yZWdvbjERMA8GA1UEBxMIUG9ydGxhbmQx
+EzARBgNVBAoTCkt1YmVybmV0ZXMxCzAJBgNVBAsTAkNBMRMwEQYDVQQDEwpLdWJl
+cm5ldGVzMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1eBwN09XYAlH
+zubyFH4wt+1+9cRnvfIicZwQd9Fv6KDmQ2EpyhJx8a5okf7RErPTctm41gUtBSr+
+OoBnoA2K8YzcDOlDAdjo8Pb2612VAF9idYaQe3yG6+wfBTU6eCKd3NVpzw3gJMao
+h4pFHCUvUWhBC4LWh8plEI0T7B0ncDXQThKdLb+bxZu6IoBvOIYWQ6+vatkwUkOi
+PC4JyQoK4M31qgfNiB0XVMdNKi99PWwj3ErnfxPj7nmHbZ9+57uHfeHJfyLH3it7
+XfH4fbtfvN+IL/e/DBS0M/y2g5uaBDas3gBz1MisQ60csl3vdv1zast//GSlED8D
+N21Lk5DXwQIDAQABo0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB
+/zAdBgNVHQ4EFgQUyXeIPPSg65/o2CFshNbkydwUh6YwDQYJKoZIhvcNAQELBQAD
+ggEBAIcFQs7DQl4haOICbzlXmScaFD6HGysewarrAPrDDsW3U5fot1911ePyiX66
+vw/yEX9wjoGrUQSUkQ9tQN9XKzXo8uROg2y2a+UP2wrkCBP4OdZ6WlQTjMwIlm7J
+x33HdJl4jrbb1WBgAUQomJsQEMdDS2ck62/I4iIITmO6Udt41MFUS0dlVIXJcsss
+wOknWY3c2qe9HB8Kma7R+85EcvI3p9VVHrHKTA7uSYLXWuidM8DK1Ew/2VgfMc3H
+LhN5DBiStvQVA2++hahXDNlftpQXc/hZUq/Zu5U3MCG/yaFS4L1EzD5bRAkxK7Zl
+XaIj5O6tpM0zOzPqmUJEsKiNxTI=
+-----END CERTIFICATE-----`
+	newLine = "\n"
+)
+
+type StubListerConfig struct {
+	v3.ListenConfigInterface
+}
+
+type StubListenConfigLister struct {
+	v3.ListenConfigLister
+}
+
+func (s *StubListenConfigLister) List(namespace string, selector labels.Selector) (ret []*v3.ListenConfig, err error) {
+	return nil, nil
+}
+
+type StubSecretsInterface struct {
+	v1.SecretInterface
+}
+
+type StubServerInterface struct {
+	dynamiclistener.ServerInterface
+}
+
+func (s *StubServerInterface) Enable(config *v3.ListenConfig) (bool, error) {
+	return true, nil
+}
+
+func testCACertIsTransformedTo(t *testing.T, original string, final string) {
+	controller := &Controller{
+		listenConfig:       &StubListerConfig{},
+		listenConfigLister: &StubListenConfigLister{},
+		secrets:            &StubSecretsInterface{},
+		server:             &StubServerInterface{},
+	}
+
+	err := controller.sync("", &v3.ListenConfig{Enabled: true, CACerts: original})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if settings.CACerts.Get() != final {
+		t.Errorf("expected %v but got %v", final, settings.CACerts.Get())
+	}
+}
+
+func TestCertWithNoNewLines(t *testing.T) {
+	testCACertIsTransformedTo(t, caCerts, caCerts)
+}
+
+func TestCertWithOneNewLine(t *testing.T) {
+	testCACertIsTransformedTo(t, caCerts+newLine, caCerts)
+}
+
+func TestCertWithManyNewLines(t *testing.T) {
+	testCACertIsTransformedTo(t, caCerts+newLine+newLine+newLine, caCerts)
+}
+
+func TestCertWithPrecedingNewLine(t *testing.T) {
+	testCACertIsTransformedTo(t, newLine+caCerts, caCerts)
+}
+
+func TestCertWithManyPrecedingNewLines(t *testing.T) {
+	testCACertIsTransformedTo(t, newLine+newLine+newLine+caCerts, caCerts)
+}
+
+func TestCertWithPrecedingAndFollowingNewLines(t *testing.T) {
+	testCACertIsTransformedTo(t, newLine+newLine+newLine+caCerts+newLine+newLine+newLine, caCerts)
+}

--- a/pkg/dynamiclistener/server.go
+++ b/pkg/dynamiclistener/server.go
@@ -39,6 +39,12 @@ type ListenConfigStorage interface {
 	Get(namespace, name string) (*v3.ListenConfig, error)
 }
 
+type ServerInterface interface {
+	Disable(config *v3.ListenConfig)
+	Enable(config *v3.ListenConfig) (bool, error)
+	Shutdown() error
+}
+
 type Server struct {
 	sync.Mutex
 
@@ -63,7 +69,7 @@ type Server struct {
 }
 
 func NewServer(ctx context.Context, listenConfigStorage ListenConfigStorage,
-	handler http.Handler, httpPort, httpsPort int) *Server {
+	handler http.Handler, httpPort, httpsPort int) ServerInterface {
 	s := &Server{
 		listenConfigStorage: listenConfigStorage,
 		handler:             handler,

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f6841
 github.com/rancher/types                      2f7c66d509a3d96e0fbbdfab5da5501fe763fa8d
 
 
-github.com/rancher/norman                     012759b2f8e7f8e03b545fe7092b6f6e6a0ce182
+github.com/rancher/norman                     915dc06a9d1a52cb21eb0c03a822804c455e603e
 github.com/rancher/kontainer-engine           fdf37c064534aa6697ca329beaef74f710e81408
 github.com/rancher/rke                        cb5067207173605072be62c0f2d2f77e92a16a6d
 

--- a/vendor/github.com/rancher/norman/parse/builder/builder.go
+++ b/vendor/github.com/rancher/norman/parse/builder/builder.go
@@ -330,6 +330,9 @@ func ConvertSimple(fieldType string, value interface{}, op Operation) (interface
 	case "password":
 		return convert.ToString(value), nil
 	case "string":
+		if op.IsList() {
+			return convert.ToStringNoTrim(value), nil
+		}
 		return convert.ToString(value), nil
 	case "dnsLabel":
 		str := convert.ToString(value)

--- a/vendor/github.com/rancher/norman/types/convert/convert.go
+++ b/vendor/github.com/rancher/norman/types/convert/convert.go
@@ -44,7 +44,7 @@ func Singular(value interface{}) interface{} {
 	return value
 }
 
-func ToString(value interface{}) string {
+func ToStringNoTrim(value interface{}) string {
 	if t, ok := value.(time.Time); ok {
 		return t.Format(time.RFC3339)
 	}
@@ -52,7 +52,11 @@ func ToString(value interface{}) string {
 	if single == nil {
 		return ""
 	}
-	return strings.TrimSpace(fmt.Sprint(single))
+	return fmt.Sprint(single)
+}
+
+func ToString(value interface{}) string {
+	return strings.TrimSpace(ToStringNoTrim(value))
 }
 
 func ToTimestamp(value interface{}) (int64, error) {


### PR DESCRIPTION
Adding logic to strip preceding and following newliens from ca certs so that
checksums are calculated properly.  This is to fix an issue where
rancher-agents could not connect to rancher.

Issue:
#13831

Depends on:
https://github.com/rancher/norman/pull/194