### PR TITLE
Enable eu-west-1 for new EKS clusters

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -41,7 +41,7 @@ github.com/rancher/types                      acbf0812a36a4fcc3ea2b7442381532188
 
 
 github.com/rancher/norman                     915dc06a9d1a52cb21eb0c03a822804c455e603e
-github.com/rancher/kontainer-engine           3a7e844b5568f398deb2d44464945ac8f9f6d0bd
+github.com/rancher/kontainer-engine           935c35211b3b03b49624c426ec49a0685a667148
 github.com/rancher/rke                        00e317250d0d4a1aedb91717064c37628bcd7da8
 
 gopkg.in/ldap.v2     v2.5.0

--- a/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
@@ -40,6 +40,7 @@ import (
 var amiForRegion = map[string]string{
 	"us-west-2": "ami-73a6e20b",
 	"us-east-1": "ami-dea4d5a1",
+	"eu-west-1": "ami-066110c1a7466949e",
 }
 
 type Driver struct {


### PR DESCRIPTION
See https://github.com/rancher/rancher/issues/15484

This brings in changes to kontainer-engine to enable EKS eu-west-1 for new clusters. Depends on https://github.com/rancher/kontainer-engine/pull/82

This is a backend only change, the UI declares these separately and will need to be updated accordingly