### PR TITLE
add annotation to all nodes

### DIFF
--- a/pkg/controllers/user/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/user/nodesyncer/nodessyncer.go
@@ -121,6 +121,13 @@ func (n *NodeSyncer) needUpdate(key string, node *corev1.Node) (bool, error) {
 	if existing == nil {
 		return true, nil
 	}
+	if existing.Annotations[annotationName] == "" {
+		existing.Annotations[annotationName] = "true"
+		if _, err := n.nodesSyncer.machines.Update(existing); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
 	nodeToPodMap, err := n.nodesSyncer.getNonTerminatedPods()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
the annotation is needed when cleaning up nodes. This adds annotations
to all other nodes so that if a node is deleted from k8s api rancher
will automatically clean them up on rancher side.
https://github.com/rancher/rancher/issues/14184