### PR TITLE
Make sure to nilcheck Enabled in enable-default-admin

### DIFF
--- a/app/ensure_admin_user.go
+++ b/app/ensure_admin_user.go
@@ -123,7 +123,7 @@ func createNewAdmin(client v3.Interface, length int) error {
 }
 
 func ensureAdminIsEnabled(admin v3.User) bool {
-	if *admin.Enabled {
+	if admin.Enabled == nil || *admin.Enabled {
 		fmt.Fprintf(os.Stdout, "Existing default admin user (%v) is already enabled\n", admin.Name)
 		return false
 	}


### PR DESCRIPTION
This performs reparations in regards to #15613

When we create a new user, the Enabled pointer is nil, it has an assumed default of true. Since we were dereferencing the pointer, it would panic if they had not previously been explicitly enabled/disabled.