### PR TITLE
lock git operations on repo hash

### DIFF
--- a/tests/core/test_catalog.py
+++ b/tests/core/test_catalog.py
@@ -4,12 +4,20 @@ from .common import wait_for_template_to_be_created, \
 
 def test_catalog(admin_mc):
     client = admin_mc.client
-    name = random_str()
+    name1 = random_str()
+    name2 = random_str()
     url = "https://github.com/StrongMonkey/charts-1.git"
-    catalog = client.create_catalog(name=name,
-                                    branch="test",
-                                    url=url,
-                                    )
-    wait_for_template_to_be_created(client, name)
-    client.delete(catalog)
-    wait_for_template_to_be_deleted(client, name)
+    catalog1 = client.create_catalog(name=name1,
+                                     branch="test",
+                                     url=url,
+                                     )
+    catalog2 = client.create_catalog(name=name2,
+                                     branch="test",
+                                     url=url,
+                                     )
+    wait_for_template_to_be_created(client, name1)
+    wait_for_template_to_be_created(client, name2)
+    client.delete(catalog1)
+    client.delete(catalog2)
+    wait_for_template_to_be_deleted(client, name1)
+    wait_for_template_to_be_deleted(client, name2)


### PR DESCRIPTION
Adding a lock on the hash value of (git repo + branch) to prevent
concurrent operations on the same git repo.