### PR TITLE
WIP: Make local cluster default off

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -141,7 +141,7 @@ func addData(management *config.ManagementContext, cfg Config) error {
 		return err
 	}
 
-	if cfg.AddLocal == "true" || (cfg.AddLocal == "auto" && !cfg.Embedded) {
+	if cfg.AddLocal == "true" {
 		if err := addLocalCluster(cfg.Embedded, adminName, management); err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -64,8 +64,8 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:        "add-local",
-			Usage:       "Add local cluster (true, false, auto)",
-			Value:       "auto",
+			Usage:       "Add local cluster (true, false)",
+			Value:       "false",
 			Destination: &config.AddLocal,
 		},
 		cli.IntFlag{


### PR DESCRIPTION
This change makes it so the local cluster defaults to "off" in all cases.
Previously the local cluster would turn on by default is not flag was
provided. Now the `add-local` flag must be explicitly set.

Issue:
https://github.com/rancherlabs/rancher-security/issues/26