### PR TITLE
set condition to unknown if driver doesn't exist

### DIFF
--- a/pkg/controllers/management/nodedriver/machine_driver.go
+++ b/pkg/controllers/management/nodedriver/machine_driver.go
@@ -64,6 +64,11 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 		return obj, nil
 	}
 
+	if !driver.Exists() {
+		v3.NodeDriverConditionDownloaded.Unknown(obj)
+		v3.NodeDriverConditionInstalled.Unknown(obj)
+	}
+
 	newObj, err := v3.NodeDriverConditionDownloaded.Once(obj, func() (runtime.Object, error) {
 		// update status
 		obj, err = m.nodeDriverClient.Update(obj)


### PR DESCRIPTION
This commit sets both installed and downloaded condition to unknown so that nodeDriver can be re-downloaded if driver doesn't exist. Fix https://github.com/rancher/rancher/issues/15661