### PR TITLE
Add --alt-cmd flag

### DIFF
--- a/app/ensure_admin_user.go
+++ b/app/ensure_admin_user.go
@@ -16,6 +16,7 @@ import (
 func RegisterEnsureDefaultAdminCommand() {
 	reexec.Register("/usr/bin/ensure-default-admin", ensureDefaultAdmin)
 	reexec.Register("ensure-default-admin", ensureDefaultAdmin)
+	RegisterAlternateCommand("ensure-default-admin", ensureDefaultAdmin)
 }
 
 func ensureDefaultAdmin() {

--- a/app/resetpassword.go
+++ b/app/resetpassword.go
@@ -19,6 +19,7 @@ import (
 func RegisterPasswordResetCommand() {
 	reexec.Register("/usr/bin/reset-password", resetPassword)
 	reexec.Register("reset-password", resetPassword)
+	RegisterAlternateCommand("reset-password", resetPassword)
 }
 
 const (

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ var (
 func main() {
 	app.RegisterPasswordResetCommand()
 	app.RegisterEnsureDefaultAdminCommand()
-	if reexec.Init() {
+	if reexec.Init() || app.InitAlternateCommand() {
 		return
 	}
 


### PR DESCRIPTION
allows passing --alt-cmd="reset-password" (or other commands) to proc reexec registered functions

This can wait until 2.1 is branched.