### PR TITLE
move clusterdeploy controller to user controllers

### DIFF
--- a/pkg/controllers/management/controller.go
+++ b/pkg/controllers/management/controller.go
@@ -6,7 +6,6 @@ import (
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/controllers/management/auth"
 	"github.com/rancher/rancher/pkg/controllers/management/catalog"
-	"github.com/rancher/rancher/pkg/controllers/management/clusterdeploy"
 	"github.com/rancher/rancher/pkg/controllers/management/clusterevents"
 	"github.com/rancher/rancher/pkg/controllers/management/clustergc"
 	"github.com/rancher/rancher/pkg/controllers/management/clusterprovisioner"
@@ -28,7 +27,6 @@ func Register(ctx context.Context, management *config.ManagementContext, manager
 
 	// a-z
 	catalog.Register(ctx, management)
-	clusterdeploy.Register(management, manager)
 	clusterevents.Register(ctx, management)
 	clustergc.Register(management)
 	clusterprovisioner.Register(management)

--- a/pkg/controllers/user/controllers.go
+++ b/pkg/controllers/user/controllers.go
@@ -3,6 +3,7 @@ package user
 import (
 	"context"
 
+	"github.com/rancher/rancher/pkg/controllers/management/clusterdeploy"
 	"github.com/rancher/rancher/pkg/controllers/management/compose/common"
 	"github.com/rancher/rancher/pkg/controllers/user/alert"
 	"github.com/rancher/rancher/pkg/controllers/user/approuter"
@@ -27,6 +28,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/user/targetworkloadservice"
 	"github.com/rancher/rancher/pkg/controllers/user/workload"
 	"github.com/rancher/types/config"
+
 	// init upgrade implement
 	_ "github.com/rancher/rancher/pkg/controllers/user/alert/upgrade"
 	_ "github.com/rancher/rancher/pkg/controllers/user/logging/upgrade"
@@ -54,6 +56,7 @@ func Register(ctx context.Context, cluster *config.UserContext, kubeConfigGetter
 	endpoints.Register(ctx, cluster)
 	approuter.Register(ctx, cluster)
 	resourcequota.Register(ctx, cluster)
+	clusterdeploy.Register(cluster, kubeConfigGetter)
 
 	userOnlyContext := cluster.UserOnlyContext()
 	dnsrecord.Register(ctx, userOnlyContext)


### PR DESCRIPTION
This commit move clusterdeploy controller to user controller so that
auth controller can be running before it. Also add logic to wait for
initialRolePoplated conditions when deploying agent yaml to make sure we
have the permission. Addresses https://github.com/rancher/rancher/issues/13129