### PR TITLE
Return error in LDAP

### DIFF
--- a/pkg/auth/providers/common/ldap/ldap_util.go
+++ b/pkg/auth/providers/common/ldap/ldap_util.go
@@ -197,8 +197,7 @@ func AttributesToPrincipal(attribs []*ldapv2.EntryAttribute, dnStr, scope, provi
 		}
 		kind = "group"
 	} else {
-		logrus.Errorf("Failed to get attributes for %s", dnStr)
-		return nil, nil
+		return nil, fmt.Errorf("Failed to get attributes for %s", dnStr)
 	}
 
 	principal := &v3.Principal{


### PR DESCRIPTION
Problem:
An error is being logged but not returned. This causes the caller to
panic when attempting to dereference the pointer

Solution:
Return the error instead of logging it allowing caller to catch the
error

Issue: https://github.com/rancher/rancher/issues/15757