### PR TITLE
Update tests to use python3.7

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -27,7 +27,7 @@ RUN curl -sLf https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VE
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 
 RUN apt-get update && \
-    apt-get install -y tox
+    apt-get install -y tox python3.7
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG
 ENV DAPPER_SOURCE /go/src/github.com/rancher/rancher/

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,4 +9,4 @@ pytest-xdist==1.22.4
 pyyaml==3.13
 netaddr==0.7.19
 requests==2.19.1
-kubernetes==6.0.0
+kubernetes==7.0.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,11 +1,11 @@
 git+https://github.com/rancher/client-python.git@e3762d5e63e7f9c6ef327e967b876c06dbf43949
-websocket-client==0.48.0
-PyJWT==1.4.0
+websocket-client==0.53.0
+PyJWT==1.6.4
 
 flake8==3.5.0
-pytest==3.4
-pytest-repeat==0.5.0
-pytest-xdist==1.22.4
+pytest==3.8
+pytest-repeat==0.7.0
+pytest-xdist==1.23.0
 pyyaml==3.13
 netaddr==0.7.19
 requests==2.19.1

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=flake8, py36
+envlist=flake8, py37
 
 [testenv]
 deps=-rrequirements.txt


### PR DESCRIPTION
Update the tests to use python3.7. 
This also updates all current pinned dependencies to the most recent version.