### PR TITLE
WIP: Revert "Add current user principal to allowedIDs during auth setup"

### DIFF
--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -259,9 +259,6 @@ func (s *Provider) HandleSamlAssertion(w http.ResponseWriter, r *http.Request, a
 
 	userPrincipal, groupPrincipals = s.getSamlPrincipals(config, samlData)
 	allowedPrincipals := config.AllowedPrincipalIDs
-	if s.clientState.GetState(r, "Rancher_Action") == "testAndEnable" && config.AccessMode == "restricted" {
-		allowedPrincipals = append(allowedPrincipals, userPrincipal.Name)
-	}
 
 	allowed, err := s.userMGR.CheckAccess(config.AccessMode, allowedPrincipals, userPrincipal, groupPrincipals)
 	if err != nil {

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -14,13 +14,13 @@ import (
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
-	"github.com/rancher/types/apis/management.cattle.io/v3public"
 	"github.com/rancher/types/client/management/v3"
 	publicclient "github.com/rancher/types/client/management/v3public"
 	"github.com/rancher/types/config"
 	"github.com/rancher/types/user"
 	"github.com/sirupsen/logrus"
 
+	"github.com/rancher/types/apis/management.cattle.io/v3public"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )


### PR DESCRIPTION
Reverts rancher/rancher#15750
The issue https://github.com/rancher/rancher/issues/15724 needed a UI fix, 
referenced in this issue https://github.com/rancher/rancher/issues/15769
So this PR reverts the backend fix as it won't be needed