### PR TITLE
update tcp max package size

### DIFF
--- a/pkg/controllers/user/logging/generator/cluster_template.go
+++ b/pkg/controllers/user/logging/generator/cluster_template.go
@@ -168,6 +168,7 @@ var ClusterTemplate = `{{ if .clusterTarget.CurrentTarget }}
     {{ if .clusterTarget.SyslogConfig.Program }}
     program {{.clusterTarget.SyslogConfig.Program}}
     {{end -}}
+    packet_size 65535
     
     {{ if eq .clusterTarget.SyslogConfig.SSLVerify true}}
     verify_mode 1

--- a/pkg/controllers/user/logging/generator/project_template.go
+++ b/pkg/controllers/user/logging/generator/project_template.go
@@ -152,6 +152,7 @@ var ProjectTemplate = `{{range $i, $store := .projectTargets -}}
     {{ if $store.SyslogConfig.Program }}
     program {{$store.SyslogConfig.Program}}
     {{end -}}
+    packet_size 65535
 
     {{ if eq $store.SyslogConfig.SSLVerify true}}
     verify_mode 1


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/15631
@aemneina Get log truncate in syslog-ng, update tcp max packet_size to fix it.

Details:  find that the plugin we use have a config call package_size, after some test, I find that config quite like the max size for each log. For example, the host mtu is 1500, and if I config the package_size to 1500, and the log size is 1600, this log will be separate to 2 packets, one length is 1440, another is 61(total is 1501). And the log exceeds 1500 will lost, it has been truncated before send out. So we could config default value for the packet_size to the max tcp packet and just let  lower layers protocol to split the log into several packets and deliver them.