### PR TITLE
Correcting snapshot to backup for etcd rolling snapshots

### DIFF
--- a/rke-templates/3-node-certificate-recognizedca.yml
+++ b/rke-templates/3-node-certificate-recognizedca.yml
@@ -14,7 +14,7 @@ nodes:
 
 services:
   etcd:
-    backup: true
+    snapshot: true
     creation: 6h
     retention: 24h
 

--- a/rke-templates/3-node-certificate.yml
+++ b/rke-templates/3-node-certificate.yml
@@ -14,7 +14,7 @@ nodes:
 
 services:
   etcd:
-    backup: true
+    snapshot: true
     creation: 6h
     retention: 24h
 

--- a/rke-templates/3-node-externalssl-certificate.yml
+++ b/rke-templates/3-node-externalssl-certificate.yml
@@ -14,7 +14,7 @@ nodes:
 
 services:
   etcd:
-    backup: true
+    snapshot: true
     creation: 6h
     retention: 24h
 

--- a/rke-templates/3-node-externalssl-recognizedca.yml
+++ b/rke-templates/3-node-externalssl-recognizedca.yml
@@ -14,7 +14,7 @@ nodes:
 
 services:
   etcd:
-    backup: true
+    snapshot: true
     creation: 6h
     retention: 24h
 


### PR DESCRIPTION
When etcd rolling snapshots are attempted to be enabled with `backup: true`, RKE does not respect this parameter. We must change the rke-allinone config files to reflect `snapshot: true`