### PR TITLE
Update vendor for Private EKS Cluster

### DIFF
--- a/pkg/api/customization/cluster/formatter.go
+++ b/pkg/api/customization/cluster/formatter.go
@@ -34,6 +34,16 @@ func Formatter(request *types.APIContext, resource *types.RawResource) {
 		setTrueIfNil(configMap, client.GoogleKubernetesEngineConfigFieldEnableHTTPLoadBalancing)
 		setTrueIfNil(configMap, client.GoogleKubernetesEngineConfigFieldEnableNetworkPolicyConfig)
 	}
+
+	if eksConfig, ok := resource.Values[client.ClusterSpecFieldAmazonElasticContainerServiceConfig]; ok {
+		configMap, ok := eksConfig.(map[string]interface{})
+		if !ok {
+			logrus.Errorf("could not convert aks config to map")
+			return
+		}
+
+		setTrueIfNil(configMap, client.AmazonElasticContainerServiceConfigFieldAssociateWorkerNodePublicIP)
+	}
 }
 
 func setTrueIfNil(configMap map[string]interface{}, fieldName string) {

--- a/tests/core/test_kontainer_engine_validation.py
+++ b/tests/core/test_kontainer_engine_validation.py
@@ -1,0 +1,68 @@
+from .common import random_str
+from .conftest import wait_until
+
+
+def get_error_message_for_eks_config(admin_mc, remove_resource, config):
+    cluster = admin_mc.client.create_cluster(
+        name=random_str(), amazonElasticContainerServiceConfig=config)
+    remove_resource(cluster)
+
+    def has_provision_status():
+        new_cluster = admin_mc.client.reload(cluster)
+
+        return hasattr(new_cluster, "conditions")
+
+    wait_until(has_provision_status, 10)
+    cluster = admin_mc.client.reload(cluster)
+
+    for condition in cluster.conditions:
+        if condition.type == "Provisioned":
+            return condition.message
+
+
+def test_min_nodes_cannot_be_greater_than_max(admin_mc, remove_resource):
+    eks = {
+        "accessKey": "not a real access key",
+        "secretKey": "not a real secret key",
+        "region": "us-west-2",
+        "minimumNodes": 3,
+        "maximumNodes": 2
+    }
+    provision_message = \
+        get_error_message_for_eks_config(admin_mc, remove_resource, eks)
+
+    assert provision_message == "error parsing state: maximum nodes cannot " \
+                                "be less than minimum nodes"
+
+
+def test_min_nodes_cannot_be_zero(admin_mc, remove_resource):
+    eks = {
+        "accessKey": "not a real access key",
+        "secretKey": "not a real secret key",
+        "region": "us-west-2",
+        "minimumNodes": 0,
+        "maximumNodes": 0
+    }
+    provision_message = get_error_message_for_eks_config(admin_mc,
+                                                         remove_resource, eks)
+
+    assert provision_message == "error parsing state: minimum nodes must be " \
+                                "greater than 0"
+
+
+def test_private_cluster_requires_vpc_subnets(admin_mc, remove_resource):
+    eks = {
+        "accessKey": "not a real access key",
+        "secretKey": "not a real secret key",
+        "region": "us-west-2",
+        "minimumNodes": 1,
+        "maximumNodes": 3,
+        "associateWorkerNodePublicIp": False
+    }
+    provision_message = get_error_message_for_eks_config(admin_mc,
+                                                         remove_resource, eks)
+
+    assert \
+        provision_message == \
+        "error parsing state: if AssociateWorkerNodePublicIP is set to " \
+        "false a VPC and subnets must also be provided"

--- a/vendor.conf
+++ b/vendor.conf
@@ -37,11 +37,11 @@ github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c6
 github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d7567c5b0b
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
-github.com/rancher/types                      d7ca3628b2c4bc5546671aa7b2cdc126825f2d1b
+github.com/rancher/types                      52df5bbb83f3271986a9f781778d1657cc288d3d
 
 
-github.com/rancher/norman                     ee8e325eb5d88ce29f15b0aef077f53ff1d2384b
-github.com/rancher/kontainer-engine           9facd8e2fdd11f5cf8745d1524bd337958bbacf3
+github.com/rancher/norman                     ad4865987ce75d8d012441478e193eaaa1e1078f
+github.com/rancher/kontainer-engine           fe94db358dcea7f0ba0458524895bdf635a44718
 github.com/rancher/rke  v0.1.10
 
 gopkg.in/ldap.v2     v2.5.0

--- a/vendor/github.com/rancher/kontainer-engine/Dockerfile.dapper
+++ b/vendor/github.com/rancher/kontainer-engine/Dockerfile.dapper
@@ -2,7 +2,7 @@ FROM golang:1.9.1
 RUN apt-get update && \
     apt-get install -y xz-utils zip rsync
 RUN go get github.com/rancher/trash
-RUN go get github.com/golang/lint/golint
+RUN go get golang.org/x/lint/golint
 RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 > /usr/bin/docker && \
     chmod +x /usr/bin/docker
 ENV PATH /go/bin:$PATH

--- a/vendor/github.com/rancher/kontainer-engine/drivers/eks/templates.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/eks/templates.go
@@ -1,0 +1,509 @@
+package eks
+
+const (
+	vpcTemplate = `---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Amazon EKS Sample VPC'
+
+Parameters:
+
+  VpcBlock:
+    Type: String
+    Default: 192.168.0.0/16
+    Description: The CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range.
+
+  Subnet01Block:
+    Type: String
+    Default: 192.168.64.0/18
+    Description: CidrBlock for subnet 01 within the VPC
+
+  Subnet02Block:
+    Type: String
+    Default: 192.168.128.0/18
+    Description: CidrBlock for subnet 02 within the VPC
+
+  Subnet03Block:
+    Type: String
+    Default: 192.168.192.0/18
+    Description: CidrBlock for subnet 03 within the VPC
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      -
+        Label:
+          default: "Worker Network Configuration"
+        Parameters:
+          - VpcBlock
+          - Subnet01Block
+          - Subnet02Block
+          - Subnet03Block
+
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock:  !Ref VpcBlock
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+      - Key: Name
+        Value: !Sub '${AWS::StackName}-VPC'
+
+  InternetGateway:
+    Type: "AWS::EC2::InternetGateway"
+
+  VPCGatewayAttachment:
+    Type: "AWS::EC2::VPCGatewayAttachment"
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref VPC
+
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: Public Subnets
+      - Key: Network
+        Value: Public
+
+  Route:
+    DependsOn: VPCGatewayAttachment
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  Subnet01:
+    Type: AWS::EC2::Subnet
+    Metadata:
+      Comment: Subnet 01
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - '0'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Ref: Subnet01Block
+      VpcId:
+        Ref: VPC
+      Tags:
+      - Key: Name
+        Value: !Sub "${AWS::StackName}-Subnet01"
+
+  Subnet02:
+    Type: AWS::EC2::Subnet
+    Metadata:
+      Comment: Subnet 02
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - '1'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Ref: Subnet02Block
+      VpcId:
+        Ref: VPC
+      Tags:
+      - Key: Name
+        Value: !Sub "${AWS::StackName}-Subnet02"
+
+  Subnet03:
+    Type: AWS::EC2::Subnet
+    Metadata:
+      Comment: Subnet 03
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - '2'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Ref: Subnet03Block
+      VpcId:
+        Ref: VPC
+      Tags:
+      - Key: Name
+        Value: !Sub "${AWS::StackName}-Subnet03"
+
+  Subnet01RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref Subnet01
+      RouteTableId: !Ref RouteTable
+
+  Subnet02RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref Subnet02
+      RouteTableId: !Ref RouteTable
+
+  Subnet03RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref Subnet03
+      RouteTableId: !Ref RouteTable
+
+  ControlPlaneSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Cluster communication with worker nodes
+      VpcId: !Ref VPC
+
+Outputs:
+
+  SubnetIds:
+    Description: All subnets in the VPC
+    Value: !Join [ ",", [ !Ref Subnet01, !Ref Subnet02, !Ref Subnet03 ] ]
+
+  SecurityGroups:
+    Description: Security group for the cluster control plane communication with worker nodes
+    Value: !Join [ ",", [ !Ref ControlPlaneSecurityGroup ] ]
+
+  VpcId:
+    Description: The VPC Id
+    Value: !Ref VPC
+`
+	workerNodesTemplate = `---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Amazon EKS - Node Group - Released 2018-08-30'
+
+Parameters:
+
+  KeyName:
+    Description: The EC2 Key Pair to allow SSH access to the instances
+    Type: AWS::EC2::KeyPair::KeyName
+
+  NodeImageId:
+    Type: AWS::EC2::Image::Id
+    Description: AMI id for the node instances.
+
+  NodeInstanceType:
+    Description: EC2 instance type for the node instances
+    Type: String
+    Default: t2.medium
+    AllowedValues:
+    - t2.small
+    - t2.medium
+    - t2.large
+    - t2.xlarge
+    - t2.2xlarge
+    - m3.medium
+    - m3.large
+    - m3.xlarge
+    - m3.2xlarge
+    - m4.large
+    - m4.xlarge
+    - m4.2xlarge
+    - m4.4xlarge
+    - m4.10xlarge
+    - m5.large
+    - m5.xlarge
+    - m5.2xlarge
+    - m5.4xlarge
+    - m5.12xlarge
+    - m5.24xlarge
+    - c4.large
+    - c4.xlarge
+    - c4.2xlarge
+    - c4.4xlarge
+    - c4.8xlarge
+    - c5.large
+    - c5.xlarge
+    - c5.2xlarge
+    - c5.4xlarge
+    - c5.9xlarge
+    - c5.18xlarge
+    - i3.large
+    - i3.xlarge
+    - i3.2xlarge
+    - i3.4xlarge
+    - i3.8xlarge
+    - i3.16xlarge
+    - r3.xlarge
+    - r3.2xlarge
+    - r3.4xlarge
+    - r3.8xlarge
+    - r4.large
+    - r4.xlarge
+    - r4.2xlarge
+    - r4.4xlarge
+    - r4.8xlarge
+    - r4.16xlarge
+    - x1.16xlarge
+    - x1.32xlarge
+    - p2.xlarge
+    - p2.8xlarge
+    - p2.16xlarge
+    - p3.2xlarge
+    - p3.8xlarge
+    - p3.16xlarge
+    ConstraintDescription: Must be a valid EC2 instance type
+
+  NodeAutoScalingGroupMinSize:
+    Type: Number
+    Description: Minimum size of Node Group ASG.
+    Default: 1
+
+  NodeAutoScalingGroupMaxSize:
+    Type: Number
+    Description: Maximum size of Node Group ASG.
+    Default: 3
+
+  NodeVolumeSize:
+    Type: Number
+    Description: Node volume size
+    Default: 20
+
+  ClusterName:
+    Description: The cluster name provided when the cluster was created. If it is incorrect, nodes will not be able to join the cluster.
+    Type: String
+
+  BootstrapArguments:
+    Description: Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami
+    Default: ""
+    Type: String
+
+  NodeGroupName:
+    Description: Unique identifier for the Node Group.
+    Type: String
+
+  ClusterControlPlaneSecurityGroup:
+    Description: The security group of the cluster control plane.
+    Type: AWS::EC2::SecurityGroup::Id
+
+  VpcId:
+    Description: The VPC of the worker instances
+    Type: AWS::EC2::VPC::Id
+
+  Subnets:
+    Description: The subnets where workers can be created.
+    Type: List<AWS::EC2::Subnet::Id>
+
+  PublicIp:
+    Description: Associate the public IP addresses of the worker nodes
+    Type: String
+    Default: "true"
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      -
+        Label:
+          default: "EKS Cluster"
+        Parameters:
+          - ClusterName
+          - ClusterControlPlaneSecurityGroup
+      -
+        Label:
+          default: "Worker Node Configuration"
+        Parameters:
+          - NodeGroupName
+          - NodeAutoScalingGroupMinSize
+          - NodeAutoScalingGroupMaxSize
+          - NodeInstanceType
+          - NodeImageId
+          - NodeVolumeSize
+          - KeyName
+          - BootstrapArguments
+      -
+        Label:
+          default: "Worker Network Configuration"
+        Parameters:
+          - VpcId
+          - Subnets
+
+Resources:
+
+  NodeInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: "/"
+      Roles:
+      - !Ref NodeInstanceRole
+
+  NodeInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: "/"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+
+  NodeSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for all nodes in the cluster
+      VpcId:
+        !Ref VpcId
+      Tags:
+      - Key: !Sub "kubernetes.io/cluster/${ClusterName}"
+        Value: 'owned'
+
+  NodeSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow node to communicate with each other
+      GroupId: !Ref NodeSecurityGroup
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
+      IpProtocol: '-1'
+      FromPort: 0
+      ToPort: 65535
+
+  NodeSecurityGroupFromControlPlaneIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow worker Kubelets and pods to receive communication from the cluster control plane
+      GroupId: !Ref NodeSecurityGroup
+      SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
+      IpProtocol: tcp
+      FromPort: 1025
+      ToPort: 65535
+
+  ControlPlaneEgressToNodeSecurityGroup:
+    Type: AWS::EC2::SecurityGroupEgress
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow the cluster control plane to communicate with worker Kubelet and pods
+      GroupId: !Ref ClusterControlPlaneSecurityGroup
+      DestinationSecurityGroupId: !Ref NodeSecurityGroup
+      IpProtocol: tcp
+      FromPort: 1025
+      ToPort: 65535
+
+  NodeSecurityGroupFromControlPlaneOn443Ingress:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow pods running extension API servers on port 443 to receive communication from cluster control plane
+      GroupId: !Ref NodeSecurityGroup
+      SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+
+  ControlPlaneEgressToNodeSecurityGroupOn443:
+    Type: AWS::EC2::SecurityGroupEgress
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow the cluster control plane to communicate with pods running extension API servers on port 443
+      GroupId: !Ref ClusterControlPlaneSecurityGroup
+      DestinationSecurityGroupId: !Ref NodeSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+
+  ClusterControlPlaneSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow pods to communicate with the cluster API Server
+      GroupId: !Ref ClusterControlPlaneSecurityGroup
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
+      IpProtocol: tcp
+      ToPort: 443
+      FromPort: 443
+
+  NodeGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      DesiredCapacity: !Ref NodeAutoScalingGroupMaxSize
+      LaunchConfigurationName: !Ref NodeLaunchConfig
+      MinSize: !Ref NodeAutoScalingGroupMinSize
+      MaxSize: !Ref NodeAutoScalingGroupMaxSize
+      VPCZoneIdentifier:
+        !Ref Subnets
+      Tags:
+      - Key: Name
+        Value: !Sub "${ClusterName}-${NodeGroupName}-Node"
+        PropagateAtLaunch: 'true'
+      - Key: !Sub 'kubernetes.io/cluster/${ClusterName}'
+        Value: 'owned'
+        PropagateAtLaunch: 'true'
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MinInstancesInService: '1'
+        MaxBatchSize: '1'
+
+  NodeLaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      AssociatePublicIpAddress: !Ref PublicIp
+      IamInstanceProfile: !Ref NodeInstanceProfile
+      ImageId: !Ref NodeImageId
+      InstanceType: !Ref NodeInstanceType
+      KeyName: !Ref KeyName
+      SecurityGroups:
+      - !Ref NodeSecurityGroup
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: !Ref NodeVolumeSize
+            VolumeType: gp2
+            DeleteOnTermination: true
+      UserData:
+        Fn::Base64:
+          !Sub |
+            #!/bin/bash
+            set -o xtrace
+            /etc/eks/bootstrap.sh ${ClusterName} ${BootstrapArguments}
+            /opt/aws/bin/cfn-signal --exit-code $? \
+                     --stack  ${AWS::StackName} \
+                     --resource NodeGroup  \
+                     --region ${AWS::Region}
+
+Outputs:
+  NodeInstanceRole:
+    Description: The node instance role
+    Value: !GetAtt NodeInstanceRole.Arn
+`
+	serviceRoleTemplate = `---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Amazon EKS Service Role'
+
+
+Resources:
+
+  AWSServiceRoleForAmazonEKS:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - eks.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEKSServicePolicy
+        - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+
+Outputs:
+
+  RoleArn:
+    Description: The role that EKS will use to create AWS resources for Kubernetes clusters
+    Value: !GetAtt AWSServiceRoleForAmazonEKS.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-RoleArn"
+
+`
+)

--- a/vendor/github.com/rancher/kontainer-engine/vendor.conf
+++ b/vendor/github.com/rancher/kontainer-engine/vendor.conf
@@ -1,6 +1,6 @@
 k8s.io/client-go                     v7.0.0                                   transitive=true
 github.com/coreos/etcd               52f73c5a6cb0d1d196ffd6eced406c9d8502078a transitive=true
-github.com/golang/protobuf           1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
+github.com/golang/protobuf           ddf22928ea3c56eb4292a0adbbf5001b1e8e7d0d
 github.com/sirupsen/logrus           v1.0.3
 github.com/urfave/cli                v1.20.0
 golang.org/x/net                     4b14673ba32bee7f5ac0f990a48f033919fd418b
@@ -29,7 +29,13 @@ github.com/go-ini/ini                5e9692864e22d02ac79e2fa499cffb00520b4fea
 github.com/jmespath/go-jmespath      c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5
 github.com/heptio/authenticator      d282f87a19728018b67d80754bcb3e9b0457403f
 github.com/smartystreets/go-aws-auth 8ef1316913ee4f44bc48c2456e44a5c1c68ea53b
+github.com/prometheus/client_golang  v0.8.0
+github.com/prometheus/client_model   5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f
+github.com/prometheus/procfs         418d78d0b9a7b7de3a6bbc8a23def624cc977bb2
+github.com/prometheus/common         c7de2306084e37d54b8be01f3541a8464345e9a5
+github.com/beorn7/perks              3a771d992973f24aa725d07868b467d1ddfceafb
+github.com/matttproud/golang_protobuf_extensions v1.0.1
 
 github.com/rancher/rke               2e82c18d4b6fe3afbb3970cbf518b5c0a811bcaa
-github.com/rancher/norman            57e8282a33f04091e30df7700bd328f3205c1189   
-github.com/rancher/types             30c4b554a2a981481361c3e85c54c4592b2a69b9
+github.com/rancher/norman            ad4865987ce75d8d012441478e193eaaa1e1078f
+github.com/rancher/types             52df5bbb83f3271986a9f781778d1657cc288d3d

--- a/vendor/github.com/rancher/norman/Dockerfile.dapper
+++ b/vendor/github.com/rancher/norman/Dockerfile.dapper
@@ -1,29 +1,14 @@
-FROM ubuntu:16.04
-# FROM arm=armhf/ubuntu:16.04
+FROM golang:1.11-alpine
 
-ARG DAPPER_HOST_ARCH
-ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
-
-RUN apt-get update && \
-    apt-get install -y gcc ca-certificates git wget curl vim less file && \
-    rm -f /bin/sh && ln -s /bin/bash /bin/sh
-
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
-    GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-
-RUN wget -O - https://storage.googleapis.com/golang/go1.8.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get github.com/golang/lint/golint
-
-ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
-    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
-    DOCKER_URL=DOCKER_URL_${ARCH}
-
-RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
+RUN apk -U add bash git gcc musl-dev docker
+RUN go get -d golang.org/x/lint/golint && \
+    git -C /go/src/golang.org/x/lint/golint checkout -b current 06c8688daad7faa9da5a0c2f163a3d14aac986ca && \
+    go install golang.org/x/lint/golint && \
+    rm -rf /go/src /go/pkg
 
 ENV DAPPER_SOURCE /go/src/github.com/rancher/norman/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true
-ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
 ENV HOME ${DAPPER_SOURCE}
 WORKDIR ${DAPPER_SOURCE}
 

--- a/vendor/github.com/rancher/norman/Makefile
+++ b/vendor/github.com/rancher/norman/Makefile
@@ -10,14 +10,6 @@ TARGETS := $(shell ls scripts)
 $(TARGETS): .dapper
 	./.dapper $@
 
-trash: .dapper
-	./.dapper -m bind trash
-
-trash-keep: .dapper
-	./.dapper -m bind trash -k
-
-deps: trash
-
 .DEFAULT_GOAL := ci
 
 .PHONY: $(TARGETS)

--- a/vendor/github.com/rancher/norman/condition/condition.go
+++ b/vendor/github.com/rancher/norman/condition/condition.go
@@ -89,9 +89,16 @@ func (c Cond) ReasonAndMessageFromError(obj runtime.Object, err error) {
 	}
 	cond := findOrCreateCond(obj, string(c))
 	setValue(cond, "Message", err.Error())
-	if ce, ok := err.(*conditionError); ok {
+	switch ce := err.(type) {
+	case *conditionError:
 		setValue(cond, "Reason", ce.reason)
-	} else {
+	case *controller.ForgetError:
+		if ce.Reason != "" {
+			setValue(cond, "Reason", ce.Reason)
+		} else {
+			setValue(cond, "Reason", "Error")
+		}
+	default:
 		setValue(cond, "Reason", "Error")
 	}
 }

--- a/vendor/github.com/rancher/norman/controller/error.go
+++ b/vendor/github.com/rancher/norman/controller/error.go
@@ -1,7 +1,8 @@
 package controller
 
 type ForgetError struct {
-	Err error
+	Err    error
+	Reason string
 }
 
 func (f *ForgetError) Error() string {

--- a/vendor/github.com/rancher/norman/controller/generic_controller.go
+++ b/vendor/github.com/rancher/norman/controller/generic_controller.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	errors2 "github.com/pkg/errors"
+	"github.com/rancher/norman/metrics"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/types"
 	"github.com/sirupsen/logrus"
@@ -23,7 +24,8 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-const MetricsEnv = "NORMAN_QUEUE_METRICS"
+const MetricsQueueEnv = "NORMAN_QUEUE_METRICS"
+const MetricsReflectorEnv = "NORMAN_REFLECTOR_METRICS"
 
 var (
 	resyncPeriod = 2 * time.Hour
@@ -31,8 +33,11 @@ var (
 
 // Override the metrics providers
 func init() {
-	if os.Getenv(MetricsEnv) != "true" {
-		DisableAllControllerMetrics()
+	if os.Getenv(MetricsQueueEnv) != "true" {
+		DisableControllerWorkqueuMetrics()
+	}
+	if os.Getenv(MetricsReflectorEnv) != "true" {
+		DisableControllerReflectorMetrics()
 	}
 }
 
@@ -257,7 +262,11 @@ func (g *genericController) syncHandler(s string) (err error) {
 	var errs []error
 	for _, handler := range g.handlers {
 		logrus.Debugf("%s calling handler %s %s", g.name, handler.name, s)
+		metrics.IncTotalHandlerExecution(g.name, handler.name)
 		if err := handler.handler(s); err != nil {
+			if !ignoreError(err, false) {
+				metrics.IncTotalHandlerFailure(g.name, handler.name, s)
+			}
 			errs = append(errs, &handlerError{
 				name: handler.name,
 				err:  err,

--- a/vendor/github.com/rancher/norman/go.mod
+++ b/vendor/github.com/rancher/norman/go.mod
@@ -1,0 +1,55 @@
+module github.com/rancher/norman
+
+require (
+	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
+	github.com/davecgh/go-spew v1.1.1-0.20170626231645-782f4967f2dc // indirect
+	github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680
+	github.com/gogo/protobuf v0.0.0-20170330071051-c0656edd0d9e // indirect
+	github.com/golang/glog v0.0.0-20141105023935-44145f04b68c // indirect
+	github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 // indirect
+	github.com/golang/protobuf v1.2.0 // indirect
+	github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367 // indirect
+	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d // indirect
+	github.com/gorilla/websocket v0.0.0-20150714140627-6eb6ad425a89
+	github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880 // indirect
+	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c // indirect
+	github.com/imdario/mergo v0.0.0-20141206190957-6633656539c1 // indirect
+	github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3 // indirect
+	github.com/kr/pretty v0.0.0-20140812000539-f31442d60e51 // indirect
+	github.com/kr/text v0.0.0-20130911015532-6807e777504f // indirect
+	github.com/maruel/panicparse v1.1.1
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v0.0.0-20180320133207-05fbef0ca5da // indirect
+	github.com/onsi/ginkgo v1.2.1-0.20170318221715-67b9df7f55fe // indirect
+	github.com/onsi/gomega v0.0.0-20160911051023-d59fa0ac68bb // indirect
+	github.com/pkg/errors v0.8.0
+	github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0 // indirect
+	github.com/prometheus/client_golang v0.8.0
+	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 // indirect
+	github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e // indirect
+	github.com/prometheus/procfs v0.0.0-20180920065004-418d78d0b9a7 // indirect
+	github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2
+	github.com/spf13/pflag v1.0.1 // indirect
+	github.com/stretchr/testify v1.1.5-0.20170601210322-f6abca593680
+	golang.org/x/crypto v0.0.0-20170825220121-81e90905daef // indirect
+	golang.org/x/net v0.0.0-20170809000501-1c05540f6879 // indirect
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
+	golang.org/x/sys v0.0.0-20171031081856-95c657629925 // indirect
+	golang.org/x/text v0.0.0-20170810154203-b19bf474d317 // indirect
+	golang.org/x/time v0.0.0-20161028155119-f51c12702a4d
+	golang.org/x/tools v0.0.0-20170428054726-2382e3994d48 // indirect
+	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
+	gopkg.in/inf.v0 v0.9.0 // indirect
+	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 // indirect
+	gopkg.in/yaml.v2 v2.0.0-20170721113624-670d4cfef054 // indirect
+	k8s.io/api v0.0.0-20180621150657-6c0bbc3e58fa
+	k8s.io/apiextensions-apiserver v0.0.0-20180621165922-80db67131e8d
+	k8s.io/apimachinery v0.0.0-20180619225948-e386b2658ed2
+	k8s.io/client-go v2.0.0-alpha.0.0.20180621152933-b0722d92a7c1+incompatible
+	k8s.io/gengo v0.0.0-20180223161844-01a732e01d00
+	k8s.io/kube-openapi v0.0.0-20180509051136-39cb288412c4 // indirect
+	k8s.io/kubernetes v1.10.5
+)

--- a/vendor/github.com/rancher/norman/go.sum
+++ b/vendor/github.com/rancher/norman/go.sum
@@ -22,7 +22,9 @@ github.com/gorilla/websocket v0.0.0-20150714140627-6eb6ad425a89 h1:f3M+RTnIGEhCF
 github.com/gorilla/websocket v0.0.0-20150714140627-6eb6ad425a89/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880 h1:OaRuzt9oCKNui8cCskZijoKUwe+aCuuCwvx1ox8FNyw=
 github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c h1:kQWxfPIHVLbgLzphqk3QUflDy9QdksZR4ygR807bpy0=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
+github.com/imdario/mergo v0.0.0-20141206190957-6633656539c1 h1:FeeCi0I2Fu8kA8IXrdVPtGzym+mW9bzfj9f26EaES9k=
 github.com/imdario/mergo v0.0.0-20141206190957-6633656539c1/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3 h1:/UewZcckqhvnnS0C6r3Sher2hSEbVmM6Ogpcjen08+Y=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -30,6 +32,7 @@ github.com/kr/pretty v0.0.0-20140812000539-f31442d60e51 h1:kGEU5h0EzkNa+B8Q3e0Gl
 github.com/kr/pretty v0.0.0-20140812000539-f31442d60e51/go.mod h1:Bvhd+E3laJ0AVkG0c9rmtZcnhV0HQ3+c3YxxqTvc/gA=
 github.com/kr/text v0.0.0-20130911015532-6807e777504f h1:JaNmHIV9Eby6srQVWuiQ6n8ko2o/lG6udSRCbFZe1fs=
 github.com/kr/text v0.0.0-20130911015532-6807e777504f/go.mod h1:sjUstKUATFIcff4qlB53Kml0wQPtJVc/3fWrmuUmcfA=
+github.com/maruel/panicparse v1.1.1 h1:k62YPcEoLncEEpjMt92GtG5ugb8WL/510Ys3/h5IkRc=
 github.com/maruel/panicparse v1.1.1/go.mod h1:nty42YY5QByNC5MM7q/nj938VbgPU7avs45z6NClpxI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -53,10 +56,6 @@ github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e h1:n/3MEhJQjQxrO
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20180920065004-418d78d0b9a7 h1:NgR6WN8nQ4SmFC1sSUHY8SriLuWCZ6cCIQtH4vDZN3c=
 github.com/prometheus/procfs v0.0.0-20180920065004-418d78d0b9a7/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
-github.com/rancher/norman v0.0.0-20180925184916-d675dc79491f h1:HFqoOtSaJM2IV0W0MeqvmA0GUyWlO1AKQZm14K4GN8M=
-github.com/rancher/norman v0.0.0-20180925184916-d675dc79491f/go.mod h1:RG+lnsTkAH0hpXtWUsBSmrgPrPccC2z6d7M1m/grjO0=
-github.com/rancher/norman v0.0.0-20181010023203-ad4865987ce7 h1:sLQZP5VDqDjctHvTsxMsfrtACC+eooWOySuWgLd6q/8=
-github.com/rancher/norman v0.0.0-20181010023203-ad4865987ce7/go.mod h1:hIlaLlQ+ZVmTY/Hv+JBmxKLhJzOpHbG2IhaWOkHaSBs=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2 h1:a07zp0wovcAE2jH+wlD22JLqUH6Rdl8Aon+NiyPxE+0=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/spf13/pflag v1.0.1 h1:aCvUg6QPl3ibpQUxyLkrEkCHtPqYJL4x9AuhqVqFis4=
@@ -85,6 +84,7 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 h1:OAj3g0cR6Dx/R07QgQe8wkA9RNj
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/inf.v0 v0.9.0 h1:3zYtXIO92bvsdS3ggAdA8Gb4Azj0YU+TVY1uGYNFA8o=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+pGZeX22Ufu6fibxDVjU=
 gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
 gopkg.in/yaml.v2 v2.0.0-20170721113624-670d4cfef054 h1:ROF+R/wHHruzF40n5DfPv2jwm7rCJwvs8fz+RTZWjLE=
 gopkg.in/yaml.v2 v2.0.0-20170721113624-670d4cfef054/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
@@ -100,4 +100,5 @@ k8s.io/gengo v0.0.0-20180223161844-01a732e01d00 h1:vt4Sh/+HFnLoTScgFLNoMjNqOg0sQ
 k8s.io/gengo v0.0.0-20180223161844-01a732e01d00/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/kube-openapi v0.0.0-20180509051136-39cb288412c4 h1:gW+EUB2I96nbxVenV/8ctfbACsHP+yxlT2dhMCsiy+s=
 k8s.io/kube-openapi v0.0.0-20180509051136-39cb288412c4/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
+k8s.io/kubernetes v1.10.5 h1:buoMLO5r3BpYzUebBdwxa67P2evcpmaydiiKMLq9K1U=
 k8s.io/kubernetes v1.10.5/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=

--- a/vendor/github.com/rancher/norman/metrics/generic_controller.go
+++ b/vendor/github.com/rancher/norman/metrics/generic_controller.go
@@ -1,0 +1,58 @@
+package metrics
+
+import (
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const MetricsGenericControllerEnv = "NORMAN_GENERIC_CONTROLLER_METRICS"
+
+var (
+	genericControllerMetrics = false
+	TotalHandlerExecution    = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: "norman_generic_controller",
+			Name:      "total_handler_execution",
+			Help:      "Total Count of executing handler",
+		},
+		[]string{"name", "handlerName"},
+	)
+
+	TotalHandlerFailure = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: "norman_generic_controller",
+			Name:      "total_handler_failure",
+			Help:      "Total Count of handler failure",
+		},
+		[]string{"name", "handlerName", "key"},
+	)
+)
+
+func init() {
+	if os.Getenv(MetricsGenericControllerEnv) == "true" {
+		genericControllerMetrics = true
+	}
+}
+
+func IncTotalHandlerExecution(controllerName, handlerName string) {
+	if genericControllerMetrics {
+		TotalHandlerExecution.With(
+			prometheus.Labels{
+				"name":        controllerName,
+				"handlerName": handlerName},
+		).Inc()
+	}
+}
+
+func IncTotalHandlerFailure(controllerName, handlerName, key string) {
+	if genericControllerMetrics {
+		TotalHandlerFailure.With(
+			prometheus.Labels{
+				"name":        controllerName,
+				"handlerName": handlerName,
+				"key":         key,
+			},
+		).Inc()
+	}
+}

--- a/vendor/github.com/rancher/norman/objectclient/dynamic/content.go
+++ b/vendor/github.com/rancher/norman/objectclient/dynamic/content.go
@@ -1,0 +1,58 @@
+package dynamic
+
+import (
+	ejson "encoding/json"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	NegotiatedSerializer = negotiatedSerializer{}
+)
+
+type negotiatedSerializer struct{}
+
+func (s negotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{
+		{
+			MediaType:     "application/json",
+			EncodesAsText: true,
+			Serializer: dynamicCodec{
+				Encoder: unstructured.UnstructuredJSONScheme,
+			},
+		},
+	}
+}
+
+func (s negotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return encoder
+}
+
+func (s negotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return decoder
+}
+
+type dynamicCodec struct {
+	runtime.Encoder
+}
+
+func (dynamicCodec) Decode(data []byte, gvk *schema.GroupVersionKind, obj runtime.Object) (runtime.Object, *schema.GroupVersionKind, error) {
+	obj, gvk, err := unstructured.UnstructuredJSONScheme.Decode(data, gvk, obj)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if _, ok := obj.(*metav1.Status); !ok && strings.ToLower(gvk.Kind) == "status" {
+		obj = &metav1.Status{}
+		err := ejson.Unmarshal(data, obj)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return obj, gvk, nil
+}

--- a/vendor/github.com/rancher/norman/objectclient/object_client.go
+++ b/vendor/github.com/rancher/norman/objectclient/object_client.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	restclientwatch "k8s.io/client-go/rest/watch"
 )
@@ -138,7 +137,7 @@ func (p *ObjectClient) GetNamespaced(namespace, name string, opts metav1.GetOpti
 	}
 	err := req.
 		Resource(p.resource.Name).
-		VersionedParams(&opts, dynamic.VersionedParameterEncoderWithV1Fallback).
+		VersionedParams(&opts, metav1.ParameterCodec).
 		Name(name).
 		Do().
 		Into(result)
@@ -153,7 +152,7 @@ func (p *ObjectClient) Get(name string, opts metav1.GetOptions) (runtime.Object,
 		Prefix(p.getAPIPrefix(), p.gvk.Group, p.gvk.Version).
 		NamespaceIfScoped(p.ns, p.resource.Namespaced).
 		Resource(p.resource.Name).
-		VersionedParams(&opts, dynamic.VersionedParameterEncoderWithV1Fallback).
+		VersionedParams(&opts, metav1.ParameterCodec).
 		Name(name).
 		Do().
 		Into(result)
@@ -215,7 +214,7 @@ func (p *ObjectClient) List(opts metav1.ListOptions) (runtime.Object, error) {
 		Prefix(p.getAPIPrefix(), p.gvk.Group, p.gvk.Version).
 		NamespaceIfScoped(p.ns, p.resource.Namespaced).
 		Resource(p.resource.Name).
-		VersionedParams(&opts, dynamic.VersionedParameterEncoderWithV1Fallback).
+		VersionedParams(&opts, metav1.ParameterCodec).
 		Do().
 		Into(result)
 }
@@ -231,7 +230,7 @@ func (p *ObjectClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Prefix("watch").
 		NamespaceIfScoped(p.ns, p.resource.Namespaced).
 		Resource(p.resource.Name).
-		VersionedParams(&opts, dynamic.VersionedParameterEncoderWithV1Fallback).
+		VersionedParams(&opts, metav1.ParameterCodec).
 		Stream()
 	if err != nil {
 		return nil, err
@@ -279,7 +278,7 @@ func (p *ObjectClient) DeleteCollection(deleteOptions *metav1.DeleteOptions, lis
 		Prefix(p.getAPIPrefix(), p.gvk.Group, p.gvk.Version).
 		NamespaceIfScoped(p.ns, p.resource.Namespaced).
 		Resource(p.resource.Name).
-		VersionedParams(&listOptions, dynamic.VersionedParameterEncoderWithV1Fallback).
+		VersionedParams(&listOptions, metav1.ParameterCodec).
 		Body(deleteOptions).
 		Do().
 		Error()

--- a/vendor/github.com/rancher/norman/store/proxy/proxy_store.go
+++ b/vendor/github.com/rancher/norman/store/proxy/proxy_store.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/rancher/norman/httperror"
+	"github.com/rancher/norman/objectclient/dynamic"
 	"github.com/rancher/norman/pkg/broadcast"
 	"github.com/rancher/norman/restwatch"
 	"github.com/rancher/norman/types"
@@ -25,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	restclientwatch "k8s.io/client-go/rest/watch"
 )
@@ -52,8 +52,7 @@ type simpleClientGetter struct {
 func NewClientGetterFromConfig(config rest.Config) (ClientGetter, error) {
 	dynamicConfig := config
 	if dynamicConfig.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		dynamicConfig.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		dynamicConfig.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	unversionedClient, err := rest.UnversionedRESTClientFor(&dynamicConfig)
@@ -232,7 +231,7 @@ func (s *Store) realWatch(apiContext *types.APIContext, schema *types.Schema, op
 		Watch:           true,
 		TimeoutSeconds:  &timeout,
 		ResourceVersion: "0",
-	}, dynamic.VersionedParameterEncoderWithV1Fallback)
+	}, metav1.ParameterCodec)
 
 	body, err := req.Stream()
 	if err != nil {

--- a/vendor/github.com/rancher/norman/types/convert/merge/merge.go
+++ b/vendor/github.com/rancher/norman/types/convert/merge/merge.go
@@ -9,7 +9,7 @@ import (
 )
 
 func APIUpdateMerge(schema *types.Schema, schemas *types.Schemas, dest, src map[string]interface{}, replace bool) map[string]interface{} {
-	result := mergeMaps("", nil, schema, schemas, replace, dest, src)
+	result := UpdateMerge(schema, schemas, dest, src, replace)
 	if s, ok := dest["status"]; ok {
 		result["status"] = s
 	}
@@ -17,6 +17,10 @@ func APIUpdateMerge(schema *types.Schema, schemas *types.Schemas, dest, src map[
 		result["metadata"] = mergeMetadata(convert.ToMapInterface(m), convert.ToMapInterface(src["metadata"]))
 	}
 	return result
+}
+
+func UpdateMerge(schema *types.Schema, schemas *types.Schemas, dest, src map[string]interface{}, replace bool) map[string]interface{} {
+	return mergeMaps("", nil, schema, schemas, replace, dest, src)
 }
 
 func isProtected(k string) bool {

--- a/vendor/github.com/rancher/norman/types/mapper/pendingstatus.go
+++ b/vendor/github.com/rancher/norman/types/mapper/pendingstatus.go
@@ -1,0 +1,35 @@
+package mapper
+
+import (
+	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/norman/types/values"
+)
+
+type PendingStatus struct {
+}
+
+func (s PendingStatus) FromInternal(data map[string]interface{}) {
+	if data == nil {
+		return
+	}
+
+	if data["state"] != "active" {
+		return
+	}
+
+	conditions := convert.ToMapSlice(values.GetValueN(data, "status", "conditions"))
+	if len(conditions) > 0 {
+		return
+	}
+
+	data["state"] = "pending"
+}
+
+func (s PendingStatus) ToInternal(data map[string]interface{}) error {
+	return nil
+}
+
+func (s PendingStatus) ModifySchema(schema *types.Schema, schemas *types.Schemas) error {
+	return nil
+}

--- a/vendor/github.com/rancher/norman/types/schemas.go
+++ b/vendor/github.com/rancher/norman/types/schemas.go
@@ -170,7 +170,12 @@ func (s *Schemas) embed(schema *Schema) {
 	newSchema.ResourceFields = map[string]Field{}
 
 	for k, v := range target.ResourceFields {
-		newSchema.ResourceFields[k] = v
+		// We remove the dynamic fields off the existing schema in case
+		// they've been removed from the dynamic schema so they won't
+		// be accidentally left over
+		if !v.DynamicField {
+			newSchema.ResourceFields[k] = v
+		}
 	}
 	for k, v := range schema.ResourceFields {
 		newSchema.ResourceFields[k] = v

--- a/vendor/github.com/rancher/norman/types/types.go
+++ b/vendor/github.com/rancher/norman/types/types.go
@@ -68,6 +68,17 @@ type Resource struct {
 	Actions map[string]string `json:"actions"`
 }
 
+type NamedResource struct {
+	Resource
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type NamedResourceCollection struct {
+	Collection
+	Data []NamedResource `json:"data,omitempty"`
+}
+
 type APIVersion struct {
 	Group            string `json:"group,omitempty"`
 	Version          string `json:"version,omitempty"`
@@ -136,6 +147,7 @@ type Field struct {
 	InvalidChars string      `json:"invalidChars,omitempty"`
 	Description  string      `json:"description,omitempty"`
 	CodeName     string      `json:"-"`
+	DynamicField bool        `json:"dynamicField,omitempty"`
 }
 
 type Action struct {

--- a/vendor/github.com/rancher/norman/vendor.conf
+++ b/vendor/github.com/rancher/norman/vendor.conf
@@ -1,5 +1,0 @@
-# package
-github.com/rancher/norman
-
-k8s.io/kubernetes v1.10.5 transitive=true,staging=true
-bitbucket.org/ww/goautoneg a547fc61f48d567d5b4ec6f8aee5573d8efce11d https://github.com/rancher/goautoneg.git

--- a/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_k8s_client.go
+++ b/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_k8s_client.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
+	"github.com/rancher/norman/objectclient/dynamic"
 	"github.com/rancher/norman/restwatch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
 
@@ -34,8 +34,7 @@ type Client struct {
 
 func NewForConfig(config rest.Config) (Interface, error) {
 	if config.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		config.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		config.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	restClient, err := restwatch.UnversionedRESTClientFor(&config)

--- a/vendor/github.com/rancher/types/apis/batch/v1/zz_generated_k8s_client.go
+++ b/vendor/github.com/rancher/types/apis/batch/v1/zz_generated_k8s_client.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
+	"github.com/rancher/norman/objectclient/dynamic"
 	"github.com/rancher/norman/restwatch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
 
@@ -28,8 +28,7 @@ type Client struct {
 
 func NewForConfig(config rest.Config) (Interface, error) {
 	if config.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		config.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		config.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	restClient, err := restwatch.UnversionedRESTClientFor(&config)

--- a/vendor/github.com/rancher/types/apis/batch/v1beta1/zz_generated_k8s_client.go
+++ b/vendor/github.com/rancher/types/apis/batch/v1beta1/zz_generated_k8s_client.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
+	"github.com/rancher/norman/objectclient/dynamic"
 	"github.com/rancher/norman/restwatch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
 
@@ -28,8 +28,7 @@ type Client struct {
 
 func NewForConfig(config rest.Config) (Interface, error) {
 	if config.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		config.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		config.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	restClient, err := restwatch.UnversionedRESTClientFor(&config)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_k8s_client.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_k8s_client.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
+	"github.com/rancher/norman/objectclient/dynamic"
 	"github.com/rancher/norman/restwatch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
 
@@ -52,8 +52,7 @@ type Client struct {
 
 func NewForConfig(config rest.Config) (Interface, error) {
 	if config.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		config.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		config.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	restClient, err := restwatch.UnversionedRESTClientFor(&config)

--- a/vendor/github.com/rancher/types/apis/extensions/v1beta1/zz_generated_k8s_client.go
+++ b/vendor/github.com/rancher/types/apis/extensions/v1beta1/zz_generated_k8s_client.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
+	"github.com/rancher/norman/objectclient/dynamic"
 	"github.com/rancher/norman/restwatch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
 
@@ -30,8 +30,7 @@ type Client struct {
 
 func NewForConfig(config rest.Config) (Interface, error) {
 	if config.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		config.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		config.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	restClient, err := restwatch.UnversionedRESTClientFor(&config)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -220,15 +220,16 @@ type AmazonElasticContainerServiceConfig struct {
 	AccessKey string `json:"accessKey" norman:"required"`
 	SecretKey string `json:"secretKey" norman:"required,type=password"`
 
-	Region         string   `json:"region"`
-	InstanceType   string   `json:"instanceType"`
-	MinimumNodes   int      `json:"minimumNodes"`
-	MaximumNodes   int      `json:"maximumNodes"`
-	VirtualNetwork string   `json:"virtualNetwork,omitempty"`
-	Subnets        []string `json:"subnets,omitempty"`
-	SecurityGroups []string `json:"securityGroups,omitempty"`
-	ServiceRole    string   `json:"serviceRole,omitempty"`
-	AMI            string   `json:"ami,omitempty"`
+	Region                      string   `json:"region"`
+	InstanceType                string   `json:"instanceType"`
+	MinimumNodes                int      `json:"minimumNodes"`
+	MaximumNodes                int      `json:"maximumNodes"`
+	VirtualNetwork              string   `json:"virtualNetwork,omitempty"`
+	Subnets                     []string `json:"subnets,omitempty"`
+	SecurityGroups              []string `json:"securityGroups,omitempty"`
+	ServiceRole                 string   `json:"serviceRole,omitempty"`
+	AMI                         string   `json:"ami,omitempty"`
+	AssociateWorkerNodePublicIP *bool    `json:"associateWorkerNodePublicIp,omitempty" norman:"default=true"`
 }
 
 type ClusterEvent struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -188,6 +188,15 @@ func (in *AmazonElasticContainerServiceConfig) DeepCopyInto(out *AmazonElasticCo
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.AssociateWorkerNodePublicIP != nil {
+		in, out := &in.AssociateWorkerNodePublicIP, &out.AssociateWorkerNodePublicIP
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_k8s_client.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_k8s_client.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
+	"github.com/rancher/norman/objectclient/dynamic"
 	"github.com/rancher/norman/restwatch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
 
@@ -102,8 +102,7 @@ type Client struct {
 
 func NewForConfig(config rest.Config) (Interface, error) {
 	if config.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		config.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		config.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	restClient, err := restwatch.UnversionedRESTClientFor(&config)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3public/zz_generated_k8s_client.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3public/zz_generated_k8s_client.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
+	"github.com/rancher/norman/objectclient/dynamic"
 	"github.com/rancher/norman/restwatch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
 
@@ -28,8 +28,7 @@ type Client struct {
 
 func NewForConfig(config rest.Config) (Interface, error) {
 	if config.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		config.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		config.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	restClient, err := restwatch.UnversionedRESTClientFor(&config)

--- a/vendor/github.com/rancher/types/apis/networking.k8s.io/v1/zz_generated_k8s_client.go
+++ b/vendor/github.com/rancher/types/apis/networking.k8s.io/v1/zz_generated_k8s_client.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
+	"github.com/rancher/norman/objectclient/dynamic"
 	"github.com/rancher/norman/restwatch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
 
@@ -28,8 +28,7 @@ type Client struct {
 
 func NewForConfig(config rest.Config) (Interface, error) {
 	if config.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		config.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		config.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	restClient, err := restwatch.UnversionedRESTClientFor(&config)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_k8s_client.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_k8s_client.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
+	"github.com/rancher/norman/objectclient/dynamic"
 	"github.com/rancher/norman/restwatch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
 
@@ -66,8 +66,7 @@ type Client struct {
 
 func NewForConfig(config rest.Config) (Interface, error) {
 	if config.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		config.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		config.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	restClient, err := restwatch.UnversionedRESTClientFor(&config)

--- a/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_k8s_client.go
+++ b/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_k8s_client.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
+	"github.com/rancher/norman/objectclient/dynamic"
 	"github.com/rancher/norman/restwatch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
 
@@ -34,8 +34,7 @@ type Client struct {
 
 func NewForConfig(config rest.Config) (Interface, error) {
 	if config.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		config.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		config.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	restClient, err := restwatch.UnversionedRESTClientFor(&config)

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_amazon_elastic_container_service_config.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_amazon_elastic_container_service_config.go
@@ -1,30 +1,32 @@
 package client
 
 const (
-	AmazonElasticContainerServiceConfigType                = "amazonElasticContainerServiceConfig"
-	AmazonElasticContainerServiceConfigFieldAMI            = "ami"
-	AmazonElasticContainerServiceConfigFieldAccessKey      = "accessKey"
-	AmazonElasticContainerServiceConfigFieldInstanceType   = "instanceType"
-	AmazonElasticContainerServiceConfigFieldMaximumNodes   = "maximumNodes"
-	AmazonElasticContainerServiceConfigFieldMinimumNodes   = "minimumNodes"
-	AmazonElasticContainerServiceConfigFieldRegion         = "region"
-	AmazonElasticContainerServiceConfigFieldSecretKey      = "secretKey"
-	AmazonElasticContainerServiceConfigFieldSecurityGroups = "securityGroups"
-	AmazonElasticContainerServiceConfigFieldServiceRole    = "serviceRole"
-	AmazonElasticContainerServiceConfigFieldSubnets        = "subnets"
-	AmazonElasticContainerServiceConfigFieldVirtualNetwork = "virtualNetwork"
+	AmazonElasticContainerServiceConfigType                             = "amazonElasticContainerServiceConfig"
+	AmazonElasticContainerServiceConfigFieldAMI                         = "ami"
+	AmazonElasticContainerServiceConfigFieldAccessKey                   = "accessKey"
+	AmazonElasticContainerServiceConfigFieldAssociateWorkerNodePublicIP = "associateWorkerNodePublicIp"
+	AmazonElasticContainerServiceConfigFieldInstanceType                = "instanceType"
+	AmazonElasticContainerServiceConfigFieldMaximumNodes                = "maximumNodes"
+	AmazonElasticContainerServiceConfigFieldMinimumNodes                = "minimumNodes"
+	AmazonElasticContainerServiceConfigFieldRegion                      = "region"
+	AmazonElasticContainerServiceConfigFieldSecretKey                   = "secretKey"
+	AmazonElasticContainerServiceConfigFieldSecurityGroups              = "securityGroups"
+	AmazonElasticContainerServiceConfigFieldServiceRole                 = "serviceRole"
+	AmazonElasticContainerServiceConfigFieldSubnets                     = "subnets"
+	AmazonElasticContainerServiceConfigFieldVirtualNetwork              = "virtualNetwork"
 )
 
 type AmazonElasticContainerServiceConfig struct {
-	AMI            string   `json:"ami,omitempty" yaml:"ami,omitempty"`
-	AccessKey      string   `json:"accessKey,omitempty" yaml:"accessKey,omitempty"`
-	InstanceType   string   `json:"instanceType,omitempty" yaml:"instanceType,omitempty"`
-	MaximumNodes   int64    `json:"maximumNodes,omitempty" yaml:"maximumNodes,omitempty"`
-	MinimumNodes   int64    `json:"minimumNodes,omitempty" yaml:"minimumNodes,omitempty"`
-	Region         string   `json:"region,omitempty" yaml:"region,omitempty"`
-	SecretKey      string   `json:"secretKey,omitempty" yaml:"secretKey,omitempty"`
-	SecurityGroups []string `json:"securityGroups,omitempty" yaml:"securityGroups,omitempty"`
-	ServiceRole    string   `json:"serviceRole,omitempty" yaml:"serviceRole,omitempty"`
-	Subnets        []string `json:"subnets,omitempty" yaml:"subnets,omitempty"`
-	VirtualNetwork string   `json:"virtualNetwork,omitempty" yaml:"virtualNetwork,omitempty"`
+	AMI                         string   `json:"ami,omitempty" yaml:"ami,omitempty"`
+	AccessKey                   string   `json:"accessKey,omitempty" yaml:"accessKey,omitempty"`
+	AssociateWorkerNodePublicIP *bool    `json:"associateWorkerNodePublicIp,omitempty" yaml:"associateWorkerNodePublicIp,omitempty"`
+	InstanceType                string   `json:"instanceType,omitempty" yaml:"instanceType,omitempty"`
+	MaximumNodes                int64    `json:"maximumNodes,omitempty" yaml:"maximumNodes,omitempty"`
+	MinimumNodes                int64    `json:"minimumNodes,omitempty" yaml:"minimumNodes,omitempty"`
+	Region                      string   `json:"region,omitempty" yaml:"region,omitempty"`
+	SecretKey                   string   `json:"secretKey,omitempty" yaml:"secretKey,omitempty"`
+	SecurityGroups              []string `json:"securityGroups,omitempty" yaml:"securityGroups,omitempty"`
+	ServiceRole                 string   `json:"serviceRole,omitempty" yaml:"serviceRole,omitempty"`
+	Subnets                     []string `json:"subnets,omitempty" yaml:"subnets,omitempty"`
+	VirtualNetwork              string   `json:"virtualNetwork,omitempty" yaml:"virtualNetwork,omitempty"`
 }

--- a/vendor/github.com/rancher/types/config/context.go
+++ b/vendor/github.com/rancher/types/config/context.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/event"
+	"github.com/rancher/norman/objectclient/dynamic"
 	"github.com/rancher/norman/restwatch"
 	"github.com/rancher/norman/signal"
 	"github.com/rancher/norman/store/proxy"
@@ -28,7 +29,6 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -116,8 +116,7 @@ func NewScaledContext(config rest.Config) (*ScaledContext, error) {
 
 	dynamicConfig := config
 	if dynamicConfig.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		dynamicConfig.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		dynamicConfig.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	context.UnversionedClient, err = restwatch.UnversionedRESTClientFor(&dynamicConfig)
@@ -289,8 +288,7 @@ func NewManagementContext(config rest.Config) (*ManagementContext, error) {
 
 	dynamicConfig := config
 	if dynamicConfig.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		dynamicConfig.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		dynamicConfig.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	context.UnversionedClient, err = restwatch.UnversionedRESTClientFor(&dynamicConfig)
@@ -402,8 +400,7 @@ func NewUserContext(scaledContext *ScaledContext, config rest.Config, clusterNam
 
 	dynamicConfig := config
 	if dynamicConfig.NegotiatedSerializer == nil {
-		configConfig := dynamic.ContentConfig()
-		dynamicConfig.NegotiatedSerializer = configConfig.NegotiatedSerializer
+		dynamicConfig.NegotiatedSerializer = dynamic.NegotiatedSerializer
 	}
 
 	context.UnversionedClient, err = restwatch.UnversionedRESTClientFor(&dynamicConfig)

--- a/vendor/github.com/rancher/types/go.mod
+++ b/vendor/github.com/rancher/types/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/types
 
 require (
 	github.com/pkg/errors v0.8.0
-	github.com/rancher/norman v0.0.0-20180925184916-d675dc79491f
+	github.com/rancher/norman v0.0.0-20181010023203-ad4865987ce7
 	github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2
 	k8s.io/api v0.0.0-20180621150657-6c0bbc3e58fa
 	k8s.io/apiextensions-apiserver v0.0.0-20180621165922-80db67131e8d


### PR DESCRIPTION
This change adds a formatter to default the AssociateWorkerPublicIPAddress
to true if it is set to nil.  This is because that field must be true to
allow the default vpc and subnets to work.

Also adds tests to check that the validation around eks driver works.

Issue:
#15419 

Depends on:
https://github.com/rancher/kontainer-engine/pull/89
https://github.com/rancher/types/pull/591