### PR TITLE
Compare ldap types insensitive to case

### DIFF
--- a/pkg/auth/providers/common/ldap/ldap_util.go
+++ b/pkg/auth/providers/common/ldap/ldap_util.go
@@ -85,7 +85,7 @@ func IsType(search []*ldapv2.EntryAttribute, varType string) bool {
 	for _, attrib := range search {
 		if attrib.Name == "objectClass" {
 			for _, val := range attrib.Values {
-				if val == varType {
+				if strings.EqualFold(val, varType) {
 					return true
 				}
 			}


### PR DESCRIPTION
Some entries can have a type like inetorgperson or
inetOrgPerson. Those should be treated the same, but our comparison
was case sensitive.