### PR TITLE
Change AD group search query to use begins-with match

### DIFF
--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -371,7 +371,7 @@ func (p *adProvider) searchUser(name string, config *v3.ActiveDirectoryConfig, l
 
 func (p *adProvider) searchGroup(name string, config *v3.ActiveDirectoryConfig, lConn *ldapv2.Conn) ([]v3.Principal, error) {
 	// GroupSearchFilter should be follow AD search filter syntax, enclosed by parentheses
-	query := "(&(" + ObjectClass + "=" + config.GroupObjectClass + ")(" + config.GroupSearchAttribute + "=*" + name + "*)" + config.GroupSearchFilter + ")"
+	query := "(&(" + ObjectClass + "=" + config.GroupObjectClass + ")(" + config.GroupSearchAttribute + "=" + name + "*)" + config.GroupSearchFilter + ")"
 	logrus.Debugf("LDAPProvider searchGroup query: %s", query)
 	return p.searchLdap(query, GroupScope, config, lConn)
 }


### PR DESCRIPTION
"Contains" match used in Active Directory for looking up groups seems to be taking long time. This PR changes the group lookup query to use "Begins-with" match