### PR TITLE
create secrets for password fields in authconfigs 

### DIFF
--- a/app/authconfig_data.go
+++ b/app/authconfig_data.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/client/management/v3"
 	"github.com/rancher/types/config"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -47,6 +48,10 @@ func addAuthConfigs(management *config.ManagementContext) error {
 		return err
 	}
 
+	if err := createMgmtNamespace(management); err != nil {
+		return err
+	}
+
 	return addAuthConfig(localprovider.Name, client.LocalConfigType, true, management)
 }
 
@@ -62,5 +67,17 @@ func addAuthConfig(name, aType string, enabled bool, management *config.Manageme
 		return err
 	}
 
+	return nil
+}
+
+func createMgmtNamespace(management *config.ManagementContext) error {
+	_, err := management.Core.Namespaces("").Create(&corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "mgmt-secrets",
+		},
+	})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
 	return nil
 }

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -29,6 +29,7 @@ import (
 	nodeStore "github.com/rancher/rancher/pkg/api/store/node"
 	nodeTemplateStore "github.com/rancher/rancher/pkg/api/store/nodetemplate"
 	"github.com/rancher/rancher/pkg/api/store/noopwatching"
+	passwordStore "github.com/rancher/rancher/pkg/api/store/password"
 	"github.com/rancher/rancher/pkg/api/store/preference"
 	"github.com/rancher/rancher/pkg/api/store/scoped"
 	"github.com/rancher/rancher/pkg/api/store/userscope"
@@ -140,8 +141,15 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	nodeStore.SetupStore(schemas.Schema(&managementschema.Version, client.NodeType))
 	projectStore.SetProjectStore(schemas.Schema(&managementschema.Version, client.ProjectType), apiContext)
 	setupScopedTypes(schemas)
+	setupPasswordTypes(ctx, schemas, apiContext)
 
 	return nil
+}
+
+func setupPasswordTypes(ctx context.Context, schemas *types.Schemas, management *config.ScaledContext) {
+	secretStore := management.Core.Secrets("")
+	nsStore := management.Core.Namespaces("")
+	passwordStore.SetPasswordStore(schemas, secretStore, nsStore)
 }
 
 func setupScopedTypes(schemas *types.Schemas) {

--- a/pkg/api/store/password/store.go
+++ b/pkg/api/store/password/store.go
@@ -1,0 +1,279 @@
+package store
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/rancher/types/config"
+
+	"github.com/rancher/norman/types/values"
+
+	"github.com/rancher/norman/types/convert"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/types/apis/core/v1"
+	managementschema "github.com/rancher/types/apis/management.cattle.io/v3/schema"
+	projectschema "github.com/rancher/types/apis/project.cattle.io/v3/schema"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var separator = ".."
+
+type PasswordStore struct {
+	Schemas     map[string]*types.Schema
+	Fields      map[string]map[string]interface{}
+	Stores      map[string]types.Store
+	secretStore v1.SecretInterface
+	nsStore     v1.NamespaceInterface
+}
+
+func SetPasswordStore(schemas *types.Schemas, secretStore v1.SecretInterface, nsStore v1.NamespaceInterface) {
+	modifyProjectTypes := map[string]bool{
+		"githubPipelineConfig": true,
+		"gitlabPipelineConfig": true,
+	}
+
+	pwdStore := &PasswordStore{
+		Schemas:     map[string]*types.Schema{},
+		Fields:      map[string]map[string]interface{}{},
+		Stores:      map[string]types.Store{},
+		secretStore: secretStore,
+		nsStore:     nsStore,
+	}
+
+	pwdTypes := []string{}
+
+	for _, storeType := range pwdTypes {
+		var schema *types.Schema
+		if _, ok := modifyProjectTypes[storeType]; ok {
+			schema = schemas.Schema(&projectschema.Version, storeType)
+		} else {
+			schema = schemas.Schema(&managementschema.Version, storeType)
+		}
+		data := getFields(schema, schemas)
+		id := schema.ID
+		pwdStore.Stores[id] = schema.Store
+		pwdStore.Fields[id] = data
+		schema.Store = pwdStore
+
+	}
+}
+
+func (p *PasswordStore) Create(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}) (map[string]interface{}, error) {
+	if err := p.replacePasswords(data, schema.ID); err != nil {
+	}
+	return p.Stores[schema.ID].Create(apiContext, schema, data)
+}
+
+func (p *PasswordStore) ByID(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
+	data, err := p.Stores[schema.ID].ByID(apiContext, schema, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := p.assignBack(data, schema.ID); err != nil {
+		return nil, err
+	}
+	return data, err
+}
+
+func (p *PasswordStore) Context() types.StorageContext {
+	return config.ManagementStorageContext
+}
+
+func (p *PasswordStore) Delete(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
+	return p.Stores[schema.ID].Delete(apiContext, schema, id)
+}
+
+func (p *PasswordStore) List(apiContext *types.APIContext, schema *types.Schema, opt *types.QueryOptions) ([]map[string]interface{}, error) {
+	return p.Stores[schema.ID].List(apiContext, schema, opt)
+}
+
+func (p *PasswordStore) Update(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, id string) (map[string]interface{}, error) {
+	if err := p.replacePasswords(data, schema.ID); err != nil {
+		return nil, err
+	}
+	data, err := p.Stores[schema.ID].Update(apiContext, schema, data, id)
+	if err != nil {
+		return nil, err
+	}
+	return data, err
+}
+
+func (p *PasswordStore) Watch(apiContext *types.APIContext, schema *types.Schema, opt *types.QueryOptions) (chan map[string]interface{}, error) {
+	return p.Stores[schema.ID].Watch(apiContext, schema, opt)
+}
+
+type fieldInfo struct {
+	paths []string
+	value string
+}
+
+func (p *PasswordStore) replacePasswords(data map[string]interface{}, id string) error {
+	var fieldData []fieldInfo
+	var path []string
+	buildFieldData(convert.ToMapInterface(p.Fields[id]), data, &fieldData, path)
+
+	return p.handlePasswordFields(fieldData, data, id)
+}
+
+func (p *PasswordStore) assignBack(data map[string]interface{}, id string) error {
+	var fieldData []fieldInfo
+	var path []string
+
+	buildFieldData(convert.ToMapInterface(p.Fields[id]), data, &fieldData, path)
+
+	for _, info := range fieldData {
+		split := strings.SplitN(info.value, ":", 2)
+		if len(split) != 2 {
+			continue
+		}
+		value, err := p.getSecret([]string{"mgmt-secrets", "githubconfig-clientsecret"})
+		if err != nil {
+			return fmt.Errorf("error getting secret for field %s", info.value)
+		}
+		values.PutValue(data, value, info.paths...)
+	}
+	return nil
+}
+
+func (p *PasswordStore) handlePasswordFields(fieldData []fieldInfo, data map[string]interface{}, id string) error {
+	for _, info := range fieldData {
+		var name, namespace string
+		if _, ok := data["name"]; ok {
+			name = convert.ToString(data["name"])
+		} else {
+			name = fmt.Sprintf("%s-%s", id, info.paths[len(info.paths)-1])
+		}
+		if val, ok := data["id"]; ok {
+			splitID := strings.Split(convert.ToString(val), ":")
+			if len(splitID) == 2 {
+				namespace = splitID[1]
+			} else if len(splitID) == 1 {
+				namespace = splitID[0]
+			}
+		}
+		if namespace == "" {
+			namespace = "mgmt-secrets"
+		}
+		if err := p.createOrUpdateSecrets(info.value, name, namespace); err != nil {
+			return err
+		}
+		values.PutValue(data, fmt.Sprintf("%s:%s", namespace, strings.ToLower(name)), info.paths...)
+	}
+	return nil
+}
+
+func buildFieldData(data1 map[string]interface{}, data2 map[string]interface{}, fieldData *[]fieldInfo, path []string) {
+	for key1, val1 := range data1 {
+		if val2, ok := data2[key1]; ok {
+			if convert.ToString(val1) == separator {
+				val := convert.ToString(val2)
+				if val != "" {
+					split := strings.Split(val, ":")
+					if len(split) == 2 && (split[0] == "mgmt-secrets") {
+						// rancher referenced
+						logrus.Debugf("rancher referenced, continue %s", val)
+						continue
+					}
+				}
+				path = append(path, key1)
+				*fieldData = append(*fieldData, fieldInfo{path, val})
+			} else {
+				valArr := convert.ToMapSlice(val2)
+				if valArr == nil {
+					buildFieldData(convert.ToMapInterface(val1), convert.ToMapInterface(val2), fieldData, append(path, key1))
+				} else {
+					for _, each := range valArr {
+						buildFieldData(convert.ToMapInterface(val1), each, fieldData, append(path, key1))
+					}
+				}
+			}
+		}
+	}
+}
+
+func (p *PasswordStore) createOrUpdateSecrets(data, name, namespace string) error {
+	_, err := p.nsStore.Get(namespace, metav1.GetOptions{})
+	if err != nil && errors.IsNotFound(err) {
+		if _, err := p.nsStore.Create(&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}); err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	if err != nil {
+		return err
+	}
+	name = strings.ToLower(name)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		StringData: map[string]string{name: data},
+		Type:       corev1.SecretTypeOpaque,
+	}
+	existing, err := p.secretStore.GetNamespaced(namespace, name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		_, err = p.secretStore.Create(secret)
+		return err
+	} else if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(existing.StringData, secret.StringData) {
+		existing.StringData = secret.StringData
+		_, err = p.secretStore.Update(existing)
+	}
+	return err
+}
+
+func (p *PasswordStore) getSecret(input []string) (string, error) {
+	returned := ""
+	secret, err := p.secretStore.GetNamespaced(input[0], input[1], metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	for key, val := range secret.Data {
+		if key == input[1] {
+			returned = string(val)
+		}
+	}
+	return returned, nil
+}
+
+func (p *PasswordStore) deleteSecret(name string, namespace string) error {
+	err := p.secretStore.DeleteNamespaced(namespace, name, &metav1.DeleteOptions{})
+	if err != nil && errors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func getFields(schema *types.Schema, schemas *types.Schemas) map[string]interface{} {
+	data := map[string]interface{}{}
+	for name, field := range schema.ResourceFields {
+		fieldType := field.Type
+		if strings.HasPrefix(fieldType, "array") {
+			fieldType = strings.Split(fieldType, "[")[1]
+			fieldType = fieldType[:len(fieldType)-1]
+		}
+		checkSchema := schemas.Schema(&managementschema.Version, fieldType)
+		if checkSchema != nil {
+			value := getFields(checkSchema, schemas)
+			if len(value) > 0 {
+				data[name] = value
+			}
+		} else {
+			if field.Type == "password" {
+				data[name] = separator
+			}
+		}
+	}
+	return data
+}

--- a/pkg/auth/providers/activedirectory/activedirectory_provider.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_provider.go
@@ -11,14 +11,14 @@ import (
 
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
-	"github.com/rancher/types/apis/management.cattle.io/v3"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/rancher/rancher/pkg/auth/tokens"
+	corev1 "github.com/rancher/types/apis/core/v1"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/apis/management.cattle.io/v3public"
 	"github.com/rancher/types/client/management/v3public"
 	"github.com/rancher/types/config"
 	"github.com/rancher/types/user"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -35,6 +35,7 @@ var scopes = []string{UserScope, GroupScope}
 type adProvider struct {
 	ctx         context.Context
 	authConfigs v3.AuthConfigInterface
+	secrets     corev1.SecretInterface
 	userMGR     user.Manager
 	certs       string
 	caPool      *x509.CertPool
@@ -45,6 +46,7 @@ func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.
 	return &adProvider{
 		ctx:         ctx,
 		authConfigs: mgmtCtx.Management.AuthConfigs(""),
+		secrets:     mgmtCtx.Core.Secrets(""),
 		userMGR:     userMGR,
 		tokenMGR:    tokenMGR,
 	}

--- a/pkg/auth/providers/azure/azure_actions.go
+++ b/pkg/auth/providers/azure/azure_actions.go
@@ -69,6 +69,13 @@ func (ap *azureProvider) testAndApply(actionName string, action *types.Action, r
 		Code: azureADConfigApplyInput.Code,
 	}
 
+	if azureADConfig.ApplicationSecret != "" {
+		value, err := common.ReadFromSecret(ap.secrets, azureADConfig.ApplicationSecret, "")
+		if err != nil {
+			return err
+		}
+		azureADConfig.ApplicationSecret = value
+	}
 	//Call provider
 	userPrincipal, groupPrincipals, providerToken, err := ap.loginUser(azureLogin, &azureADConfig, true)
 	if err != nil {

--- a/pkg/auth/providers/common/password.go
+++ b/pkg/auth/providers/common/password.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	corev1 "github.com/rancher/types/apis/core/v1"
+	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const SecretsNamespace = "mgmt-secrets"
+
+func CreateOrUpdateSecrets(secrets corev1.SecretInterface, secretInfo string, field string, authType string) error {
+	if secretInfo == "" {
+		return nil
+	}
+	name := fmt.Sprintf("%s-%s", authType, field)
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: SecretsNamespace,
+		},
+		StringData: map[string]string{field: secretInfo},
+		Type:       v1.SecretTypeOpaque,
+	}
+
+	curr, err := secrets.Controller().Lister().Get(SecretsNamespace, name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("error getting secret for %s : %v", name, err)
+	}
+	if err == nil && !reflect.DeepEqual(curr.Data, secret.Data) {
+		_, err = secrets.Update(secret)
+		if err != nil {
+			return fmt.Errorf("error updating secret %s: %v", name, err)
+		}
+	} else if apierrors.IsNotFound(err) {
+		_, err = secrets.Create(secret)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("error creating secret %s %v", name, err)
+		}
+	}
+	return nil
+}
+
+func ReadFromSecret(secrets corev1.SecretInterface, secretInfo string, field string) (string, error) {
+	split := strings.SplitN(secretInfo, ":", 2)
+	if len(split) == 2 {
+		secret, err := secrets.GetNamespaced(split[0], split[1], metav1.GetOptions{})
+		if err != nil {
+			return "", fmt.Errorf("error getting secret %s %v", secretInfo, err)
+		}
+		for key, val := range secret.Data {
+			if key == field {
+				return string(val), nil
+			}
+		}
+	}
+	return secretInfo, nil
+}

--- a/pkg/auth/providers/github/githubconfig_actions.go
+++ b/pkg/auth/providers/github/githubconfig_actions.go
@@ -8,9 +8,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
-	"github.com/rancher/types/apis/management.cattle.io/v3"
-
 	"github.com/rancher/rancher/pkg/auth/providers/common"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/apis/management.cattle.io/v3public"
 	"github.com/rancher/types/client/management/v3"
 )
@@ -90,10 +89,17 @@ func (g *ghProvider) testAndApply(actionName string, action *types.Action, reque
 		return httperror.NewAPIError(httperror.InvalidBodyContent,
 			fmt.Sprintf("Failed to parse body: %v", err))
 	}
-
 	githubConfig = githubConfigApplyInput.GithubConfig
 	githubLogin := &v3public.GithubLogin{
 		Code: githubConfigApplyInput.Code,
+	}
+
+	if githubConfig.ClientSecret != "" {
+		value, err := common.ReadFromSecret(g.secrets, githubConfig.ClientSecret, "clientsecret")
+		if err != nil {
+			return err
+		}
+		githubConfig.ClientSecret = value
 	}
 
 	//Call provider to testLogin

--- a/pkg/auth/providers/ldap/ldap_provider.go
+++ b/pkg/auth/providers/ldap/ldap_provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/tokens"
+	corev1 "github.com/rancher/types/apis/core/v1"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -37,6 +38,7 @@ var freeIpaScopes = []string{FreeIpaUserScope, FreeIpaGroupScope}
 type ldapProvider struct {
 	ctx                   context.Context
 	authConfigs           v3.AuthConfigInterface
+	secrets               corev1.SecretInterface
 	userMGR               user.Manager
 	tokenMGR              *tokens.Manager
 	certs                 string
@@ -51,6 +53,7 @@ func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.
 	return &ldapProvider{
 		ctx:                   ctx,
 		authConfigs:           mgmtCtx.Management.AuthConfigs(""),
+		secrets:               mgmtCtx.Core.Secrets(""),
 		userMGR:               userMGR,
 		tokenMGR:              tokenMGR,
 		providerName:          providerName,

--- a/pkg/auth/providers/saml/saml_actions.go
+++ b/pkg/auth/providers/saml/saml_actions.go
@@ -46,6 +46,15 @@ func (s *Provider) testAndEnable(actionName string, action *types.Action, reques
 		return err
 	}
 
+	if samlConfig.SpKey != "" {
+		value, err := common.ReadFromSecret(s.secrets, samlConfig.SpKey, "spkey")
+
+		if err != nil {
+			return err
+		}
+		samlConfig.SpKey = value
+	}
+
 	err = InitializeSamlServiceProvider(samlConfig, s.name)
 	if err != nil {
 		return err

--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rancher/rancher/pkg/auth/providers/common"
+
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/gorilla/mux"
@@ -258,6 +260,16 @@ func (s *Provider) HandleSamlAssertion(w http.ResponseWriter, r *http.Request, a
 		log.Errorf("SAML: Error getting saml config %v", err)
 		http.Redirect(w, r, redirectURL+"/login?errorCode=500", http.StatusFound)
 		return
+	}
+
+	if config.SpKey != "" {
+		value, err := common.ReadFromSecret(s.secrets, config.SpKey, "spkey")
+		if err != nil {
+			log.Errorf("SAML: Error reading from secret %v", err)
+			http.Redirect(w, r, redirectURL+"/login?errorCode=500", http.StatusFound)
+			return
+		}
+		config.SpKey = value
 	}
 
 	userPrincipal, groupPrincipals, err = s.getSamlPrincipals(config, samlData)


### PR DESCRIPTION
(Currently, this works only for authConfigs, more work to be done for 
- cluster and node types, should be done along with nodetemplate changes 
- project pipeline types, need to figure out if store can be used for them) 

`password/store.go` contains generic logic to create secret for any field that is of type password. To add a schema that has password fields, it needs to be added to `pwdTypes`. 

Create/Update would create secret and store reference to it as value, ByID puts the actual data back. 
