### PR TITLE
Add 2 new settings allowing to configure tolerations for agent

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -38,6 +38,8 @@ var (
 	SystemDefaultRegistry           = NewSetting("system-default-registry", "")
 	SystemNamespaces                = NewSetting("system-namespaces", "kube-system,kube-public,cattle-system,cattle-alerting,cattle-logging,cattle-pipeline,ingress-nginx")
 	TelemetryOpt                    = NewSetting("telemetry-opt", "prompt")
+	TolerationsOfClusterAgent       = NewSetting("tolerations-of-clusteragent", "")
+	TolerationsOfNodeAgent          = NewSetting("tolerations-of-nodeagent", "")
 	UIFeedBackForm                  = NewSetting("ui-feedback-form", "")
 	UIIndex                         = NewSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
 	UIPath                          = NewSetting("ui-path", "")

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"text/template"
 
 	"io"
@@ -12,6 +13,8 @@ import (
 	"strings"
 
 	"github.com/rancher/rancher/pkg/settings"
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
 )
 
 var (
@@ -19,12 +22,14 @@ var (
 )
 
 type context struct {
-	CAChecksum string
-	AgentImage string
-	TokenKey   string
-	Token      string
-	URL        string
-	URLPlain   string
+	CAChecksum                string
+	AgentImage                string
+	TokenKey                  string
+	Token                     string
+	URL                       string
+	URLPlain                  string
+	TolerationsOfClusterAgent []v1.Toleration
+	TolerationsOfNodeAgent    []v1.Toleration
 }
 
 func SystemTemplate(resp io.Writer, agentImage, token, url string) error {
@@ -32,12 +37,14 @@ func SystemTemplate(resp io.Writer, agentImage, token, url string) error {
 	tokenKey := hex.EncodeToString(d[:])[:7]
 
 	context := &context{
-		CAChecksum: CAChecksum(),
-		AgentImage: agentImage,
-		TokenKey:   tokenKey,
-		Token:      base64.StdEncoding.EncodeToString([]byte(token)),
-		URL:        base64.StdEncoding.EncodeToString([]byte(url)),
-		URLPlain:   url,
+		CAChecksum:                CAChecksum(),
+		AgentImage:                agentImage,
+		TokenKey:                  tokenKey,
+		Token:                     base64.StdEncoding.EncodeToString([]byte(token)),
+		URL:                       base64.StdEncoding.EncodeToString([]byte(url)),
+		URLPlain:                  url,
+		TolerationsOfClusterAgent: TolerationsOfClusterAgent(),
+		TolerationsOfNodeAgent:    TolerationsOfNodeAgent(),
 	}
 
 	return t.Execute(resp, context)
@@ -53,4 +60,32 @@ func CAChecksum() string {
 		return hex.EncodeToString(digest[:])
 	}
 	return ""
+}
+
+func TolerationsOfClusterAgent() []v1.Toleration {
+	var tolerationsOfClusterAgents []v1.Toleration
+	tolerationsOfClusterAgentJSON := settings.TolerationsOfClusterAgent.Get()
+	if tolerationsOfClusterAgentJSON != "" {
+		err := json.Unmarshal([]byte(tolerationsOfClusterAgentJSON), &tolerationsOfClusterAgents)
+		if err != nil {
+			logrus.Errorf("Failed to prase tolerations-of-clusteragent in settings, err: %v", err)
+			return nil
+		}
+		return tolerationsOfClusterAgents
+	}
+	return nil
+}
+
+func TolerationsOfNodeAgent() []v1.Toleration {
+	var tolerationsOfNodeAgents []v1.Toleration
+	tolerationsOfNodeAgentJSON := settings.TolerationsOfNodeAgent.Get()
+	if tolerationsOfNodeAgentJSON != "" {
+		err := json.Unmarshal([]byte(tolerationsOfNodeAgentJSON), &tolerationsOfNodeAgents)
+		if err != nil {
+			logrus.Errorf("Failed to prase tolerations-of-nodeagent in settings, err: %v", err)
+			return nil
+		}
+		return tolerationsOfNodeAgents
+	}
+	return nil
 }

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -91,6 +91,21 @@ spec:
                   operator: NotIn
                   values:
                     - windows
+      {{- if .TolerationsOfClusterAgent}}
+      tolerations:
+      {{- range $i, $v := .TolerationsOfClusterAgent }}
+      - {{ if $v.Effect }}effect: {{ $v.Effect }}
+        {{ end -}}
+        {{ if $v.Key }}key: "{{ $v.Key }}"
+        {{ end -}}
+        {{ if $v.Value }}value: "{{ $v.Value }}"
+        {{ end -}}
+        {{ if $v.Operator }}operator: "{{ $v.Operator }}"
+        {{ end -}}
+        {{ if $v.TolerationSeconds }}tolerationSeconds: "{{ $v.TolerationSeconds }}"
+        {{ end -}}
+      {{- end }}
+      {{- end }}
       serviceAccountName: cattle
       containers:
         - name: cluster-register
@@ -148,6 +163,18 @@ spec:
       - effect: NoSchedule
         key: "node-role.kubernetes.io/controlplane"
         value: "true"
+      {{- range $i, $v := .TolerationsOfNodeAgent }}
+      - {{ if $v.Effect }}effect: {{ $v.Effect }}
+        {{ end -}}
+        {{ if $v.Key }}key: "{{ $v.Key }}"
+        {{ end -}}
+        {{ if $v.Value }}value: "{{ $v.Value }}"
+        {{ end -}}
+        {{ if $v.Operator }}operator: "{{ $v.Operator }}"
+        {{ end -}}
+        {{ if $v.TolerationSeconds }}tolerationSeconds: "{{ $v.TolerationSeconds }}"
+        {{ end -}}
+      {{- end }}
       containers:
       - name: agent
         image: {{.AgentImage}}


### PR DESCRIPTION
This commit add 2 configurations to implement following feature request
https://github.com/rancher/rancher/issues/15990

Added configurations are following 2 items.
 - tolerations-of-clusteragent
    -> tolerations for cluster-agent deployment
 - tolerations-of-nodeagent
    -> tolerations for node-agent daemonset

Both of configuration expect to receive json value like following
CATTLE_TOLERATIONS_OF_NODEAGENT=
[{"key": "cinder-persistent-storage", "value": "false", "effect": "NoSchedule"}]
CATTLE_TOLERATIONS_OF_CLUSTERAGENT=
[{"key": "cinder-persistent-storage", "value": "false", "effect": "NoSchedule"}]

If you passed broken json format, specified value will be ignored and no
additional tolerations are added after log error.