### PR TITLE
package/windows: The -caChecksum parameter should not be mandatory

### DIFF
--- a/package/windows/start.ps1
+++ b/package/windows/start.ps1
@@ -3,7 +3,7 @@
 param (
     [parameter(Mandatory = $true)] [string]$server,
     [parameter(Mandatory = $true)] [string]$token,
-    [parameter(Mandatory = $true)] [string]$caChecksum,
+    [parameter(Mandatory = $false)] [string]$caChecksum,
     [parameter(Mandatory = $false)] [string]$nodeName,
     [parameter(Mandatory = $false)] [string]$address,
     [parameter(Mandatory = $false)] [string]$internalAddress,


### PR DESCRIPTION
Rancher does not generate a `-caChecksum` parameter if you are using Option C of the [single node install documentation](https://rancher.com/docs/rancher/v2.x/en/installation/single-node/). If this option is used the `rancher/rancher-agent` image for windows must be customized to work around this limitation.

#15966 