### PR TITLE
Move user controllers to agent

### DIFF
--- a/pkg/agent/cluster/controllers.go
+++ b/pkg/agent/cluster/controllers.go
@@ -1,0 +1,35 @@
+package cluster
+
+import (
+	"context"
+
+	clusterController "github.com/rancher/rancher/pkg/controllers/user"
+	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+)
+
+func RunControllers() error {
+	logrus.Info("Starting user controllers")
+	c, err := rest.InClusterConfig()
+	if err != nil {
+		return err
+	}
+
+	userOnly, err := config.NewUserOnlyContext(*c)
+	if err != nil {
+		return err
+	}
+
+	err = clusterController.RegisterUserOnly(context.Background(), userOnly)
+	if err != nil {
+		return err
+	}
+
+	err = userOnly.Start(context.Background())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -171,6 +171,10 @@ func run() error {
 		}
 
 		if isCluster() {
+			err = cluster.RunControllers()
+			if err != nil {
+				logrus.Fatal(err)
+			}
 			return nil
 		}
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -37,7 +37,7 @@ github.com/smartystreets/go-aws-auth          8ef1316913ee4f44bc48c2456e44a5c1c6
 github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d7567c5b0b
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
-github.com/rancher/types                      52df5bbb83f3271986a9f781778d1657cc288d3d
+github.com/rancher/types                      006bf1d436540f6725b95988c2bdd21c7f891c3c
 
 
 github.com/rancher/norman                     ad4865987ce75d8d012441478e193eaaa1e1078f


### PR DESCRIPTION
Start of moving the user controllers to the agent. The controllers currently being moved do not require access back to the management plane. 

Issue: https://github.com/rancher/rancher/issues/15100
Requires https://github.com/rancher/types/pull/594