### PR TITLE
Adding controller to add a sec token annotation

### DIFF
--- a/pkg/controllers/management/clusterstatus/temporarycredentials.go
+++ b/pkg/controllers/management/clusterstatus/temporarycredentials.go
@@ -1,0 +1,50 @@
+package clusterstatus
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+)
+
+const temporaryCredentialsAnnotationKey = "clusterstatus.management.cattle.io/temporary-security-credentials"
+
+func Register(management *config.ManagementContext) {
+	c := &clusterAnnotations{
+		clusters: management.Management.Clusters(""),
+	}
+
+	management.Management.Clusters("").AddHandler("temporary-credentials", c.sync)
+}
+
+type clusterAnnotations struct {
+	clusters v3.ClusterInterface
+}
+
+func (cd *clusterAnnotations) sync(key string, cluster *v3.Cluster) error {
+	if key == "" || cluster == nil || cluster.DeletionTimestamp != nil {
+		return nil
+	}
+
+	if eksConfig := cluster.Spec.AmazonElasticContainerServiceConfig; eksConfig != nil {
+		newValue := strconv.FormatBool(eksConfig.SessionToken != "")
+
+		if newValue != cluster.Annotations[temporaryCredentialsAnnotationKey] {
+			original := cluster
+			cluster = original.DeepCopy()
+
+			if cluster.Annotations == nil {
+				cluster.Annotations = make(map[string]string)
+			}
+
+			cluster.Annotations[temporaryCredentialsAnnotationKey] = newValue
+			_, err := cd.clusters.Update(cluster)
+			if err != nil {
+				return fmt.Errorf("error updating temporary credentials annotation: %v", err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/controllers/management/controller.go
+++ b/pkg/controllers/management/controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/management/clustergc"
 	"github.com/rancher/rancher/pkg/controllers/management/clusterprovisioner"
 	"github.com/rancher/rancher/pkg/controllers/management/clusterstats"
+	"github.com/rancher/rancher/pkg/controllers/management/clusterstatus"
 	"github.com/rancher/rancher/pkg/controllers/management/compose"
 	"github.com/rancher/rancher/pkg/controllers/management/node"
 	"github.com/rancher/rancher/pkg/controllers/management/nodedriver"
@@ -34,6 +35,7 @@ func Register(ctx context.Context, management *config.ManagementContext, manager
 	clustergc.Register(management)
 	clusterprovisioner.Register(management)
 	clusterstats.Register(management, manager)
+	clusterstatus.Register(management)
 	compose.Register(management, manager)
 	nodedriver.Register(management)
 	nodepool.Register(management)

--- a/tests/core/test_kontainer_engine_validation.py
+++ b/tests/core/test_kontainer_engine_validation.py
@@ -7,17 +7,22 @@ def get_error_message_for_eks_config(admin_mc, remove_resource, config):
         name=random_str(), amazonElasticContainerServiceConfig=config)
     remove_resource(cluster)
 
+    def get_provisioned_type(cluster):
+        for condition in cluster.conditions:
+            if condition.type == "Provisioned":
+                return condition.message
+
     def has_provision_status():
         new_cluster = admin_mc.client.reload(cluster)
 
-        return hasattr(new_cluster, "conditions")
+        return \
+            hasattr(new_cluster, "conditions") and \
+            get_provisioned_type(new_cluster) is not None
 
     wait_until(has_provision_status, 10)
     cluster = admin_mc.client.reload(cluster)
 
-    for condition in cluster.conditions:
-        if condition.type == "Provisioned":
-            return condition.message
+    return get_provisioned_type(cluster)
 
 
 def test_min_nodes_cannot_be_greater_than_max(admin_mc, remove_resource):


### PR DESCRIPTION
This change adds a controller that looks for the `sessionToken` to be present
on the EKS config, and if it is there, add an annotation to the cluster.  The
reason this is necessary is becuase credentials that have a `sessionToken`
will expire and the UI must take additional steps to refresh the credentials
before attempting an operation on the cluster, but because `sessionToken` is a
password field, it will be hidden from the UI also.
    
Issue:
https://github.com/rancher/rancher/issues/16005


------------

Also contains a change that modifies how some of the kontainer-engine validation tests were
running to make sure they wait for the `provisioned` condition to appear on
the cluster before asserting that a value is present.  Before this change a
race condition was present and sometimes the tests would fail unnecessarily.

