### PR TITLE
Display Temporary Security Credentials annotation immediately on cluster create

### DIFF
--- a/pkg/controllers/management/clusterstatus/temporarycredentials.go
+++ b/pkg/controllers/management/clusterstatus/temporarycredentials.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rancher/types/config"
 )
 
-const temporaryCredentialsAnnotationKey = "clusterstatus.management.cattle.io/temporary-security-credentials"
+const TemporaryCredentialsAnnotationKey = "clusterstatus.management.cattle.io/temporary-security-credentials"
 
 func Register(management *config.ManagementContext) {
 	c := &clusterAnnotations{
@@ -30,7 +30,7 @@ func (cd *clusterAnnotations) sync(key string, cluster *v3.Cluster) error {
 	if eksConfig := cluster.Spec.AmazonElasticContainerServiceConfig; eksConfig != nil {
 		newValue := strconv.FormatBool(eksConfig.SessionToken != "")
 
-		if newValue != cluster.Annotations[temporaryCredentialsAnnotationKey] {
+		if newValue != cluster.Annotations[TemporaryCredentialsAnnotationKey] {
 			original := cluster
 			cluster = original.DeepCopy()
 
@@ -38,7 +38,7 @@ func (cd *clusterAnnotations) sync(key string, cluster *v3.Cluster) error {
 				cluster.Annotations = make(map[string]string)
 			}
 
-			cluster.Annotations[temporaryCredentialsAnnotationKey] = newValue
+			cluster.Annotations[TemporaryCredentialsAnnotationKey] = newValue
 			_, err := cd.clusters.Update(cluster)
 			if err != nil {
 				return fmt.Errorf("error updating temporary credentials annotation: %v", err)

--- a/tests/core/test_kontainer_engine_annotations.py
+++ b/tests/core/test_kontainer_engine_annotations.py
@@ -1,0 +1,37 @@
+from .common import random_str
+
+
+def get_cluster_annotation(admin_mc, remove_resource, config):
+    cluster = admin_mc.client.create_cluster(
+        name=random_str(), amazonElasticContainerServiceConfig=config)
+    remove_resource(cluster)
+
+    cluster = admin_mc.client.reload(cluster)
+
+    return cluster.annotations[
+        "clusterstatus.management.cattle.io/temporary-security-credentials"]
+
+
+def test_eks_cluster_gets_temp_security_credentials_annotation(
+        admin_mc, remove_resource):
+    eks = {
+        "accessKey": "not a real access key",
+        "secretKey": "not a real secret key",
+        "sessionToken": "not a real session token",
+        "region": "us-west-2",
+    }
+
+    annotation = get_cluster_annotation(admin_mc, remove_resource, eks)
+    assert annotation == "true"
+
+
+def test_eks_cluster_does_not_get_temp_security_credentials_annotation(
+        admin_mc, remove_resource):
+    eks = {
+        "accessKey": "not a real access key",
+        "secretKey": "not a real secret key",
+        "region": "us-west-2",
+    }
+
+    annotation = get_cluster_annotation(admin_mc, remove_resource, eks)
+    assert annotation == "false"

--- a/tests/core/test_kontainer_engine_validation.py
+++ b/tests/core/test_kontainer_engine_validation.py
@@ -10,7 +10,8 @@ def get_error_message_for_eks_config(admin_mc, remove_resource, config):
     def get_provisioned_type(cluster):
         for condition in cluster.conditions:
             if condition.type == "Provisioned":
-                return condition.message
+                if hasattr(condition, 'message'):
+                    return condition.message
 
     def has_provision_status():
         new_cluster = admin_mc.client.reload(cluster)


### PR DESCRIPTION
This change makes is to that the temporary security credentials annotation
displays immediately on the cluster instead of only after the cluster has
finished provisioning.

Issue:
#16005

--------

Also corrects an intermittent test failure do to the condition dict having
no `message` field on it.