### PR TITLE
Add support for private catalog

### DIFF
--- a/pkg/catalog/git/git.go
+++ b/pkg/catalog/git/git.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"strings"
 
@@ -49,4 +50,15 @@ func runcmd(name string, arg ...string) error {
 		return errors.Wrap(err, bufErr.String())
 	}
 	return nil
+}
+
+// FormatURL generates request url if is a private catalog
+func FormatURL(pathURL, username, password string) string {
+	if len(username) > 0 && len(password) > 0 {
+		if u, err := url.Parse(pathURL); err == nil {
+			u.User = url.UserPassword(username, password)
+			return u.String()
+		}
+	}
+	return pathURL
 }

--- a/pkg/catalog/manager/catalog_sync.go
+++ b/pkg/catalog/manager/catalog_sync.go
@@ -20,6 +20,7 @@ func (m *Manager) Sync(key string, obj *v3.Catalog) (runtime.Object, error) {
 	}
 
 	repoPath, commit, err := m.prepareRepoPath(*catalog)
+
 	if err != nil {
 		v3.CatalogConditionRefreshed.False(catalog)
 		v3.CatalogConditionRefreshed.ReasonAndMessageFromError(catalog, err)
@@ -29,9 +30,10 @@ func (m *Manager) Sync(key string, obj *v3.Catalog) (runtime.Object, error) {
 
 	if commit == catalog.Status.Commit {
 		logrus.Debugf("Catalog %s is already up to date", catalog.Name)
-		if v3.CatalogConditionRefreshed.IsUnknown(catalog) {
+		if !v3.CatalogConditionRefreshed.IsTrue(catalog) {
 			v3.CatalogConditionRefreshed.True(catalog)
 			v3.CatalogConditionRefreshed.Reason(catalog, "")
+			v3.CatalogConditionRefreshed.Message(catalog, "")
 			m.catalogClient.Update(catalog)
 		}
 		return nil, nil

--- a/pkg/catalog/manager/cluster_catalog_sync.go
+++ b/pkg/catalog/manager/cluster_catalog_sync.go
@@ -34,9 +34,10 @@ func (m *Manager) ClusterCatalogSync(key string, obj *v3.ClusterCatalog) (runtim
 
 	if commit == clusterCatalog.Status.Commit {
 		logrus.Debugf("Catalog %s is already up to date", clusterCatalog.Name)
-		if v3.CatalogConditionRefreshed.IsUnknown(clusterCatalog) {
+		if !v3.CatalogConditionRefreshed.IsTrue(clusterCatalog) {
 			v3.CatalogConditionRefreshed.True(clusterCatalog)
 			v3.CatalogConditionRefreshed.Reason(clusterCatalog, "")
+			v3.CatalogConditionRefreshed.Message(clusterCatalog, "")
 			m.clusterCatalogClient.Update(clusterCatalog)
 		}
 		return nil, nil

--- a/pkg/catalog/manager/project_catalog_sync.go
+++ b/pkg/catalog/manager/project_catalog_sync.go
@@ -34,9 +34,10 @@ func (m *Manager) ProjectCatalogSync(key string, obj *v3.ProjectCatalog) (runtim
 
 	if commit == projectCatalog.Status.Commit {
 		logrus.Debugf("Project catalog %s is already up to date", projectCatalog.Name)
-		if v3.CatalogConditionRefreshed.IsUnknown(projectCatalog) {
+		if !v3.CatalogConditionRefreshed.IsTrue(projectCatalog) {
 			v3.CatalogConditionRefreshed.True(projectCatalog)
 			v3.CatalogConditionRefreshed.Reason(projectCatalog, "")
+			v3.CatalogConditionRefreshed.Message(projectCatalog, "")
 			m.projectCatalogClient.Update(projectCatalog)
 		}
 		return nil, nil

--- a/pkg/catalog/manager/traverse.go
+++ b/pkg/catalog/manager/traverse.go
@@ -102,7 +102,7 @@ func (m *Manager) traverseAndUpdate(repoPath, commit string, cmt *CatalogInfo) e
 			v := v3.TemplateVersionSpec{
 				Version: version.Version,
 			}
-			files, err := helm.FetchFiles(version, version.URLs)
+			files, err := helm.FetchFiles(version, version.URLs, catalog.Spec.Username, catalog.Spec.Password)
 			if err != nil {
 				errs = append(errs, err)
 				continue

--- a/vendor.conf
+++ b/vendor.conf
@@ -36,7 +36,7 @@ github.com/heptio/authenticator               d282f87a19728018b67d80754bcb3e9b04
 github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d7567c5b0b
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
-github.com/rancher/types                      3efcb2647b3790a22d964915254f6dc82fa2b287
+github.com/rancher/types                      e61aba037643c498264253c91524fa1baa8a1e5e
 github.com/rancher/norman                     d17873e97a7ca59b3f37bff3d5d52ea37b4f7556
 github.com/rancher/kontainer-engine           b2de4c5d41fe49f887f25654e4f3b132ad93cdc1
 github.com/rancher/rke                        ca3968fddb3d2a09ce7d1644bc5be4816451fea2

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/catalog_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/catalog_types.go
@@ -24,6 +24,8 @@ type CatalogSpec struct {
 	URL         string `json:"url,omitempty" norman:"required"`
 	Branch      string `json:"branch,omitempty"`
 	CatalogKind string `json:"catalogKind,omitempty"`
+	Username    string `json:"username,omitempty"`
+	Password    string `json:"password,omitempty" norman:"type=password"`
 }
 
 type CatalogStatus struct {

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_catalog.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_catalog.go
@@ -18,12 +18,14 @@ const (
 	CatalogFieldLastRefreshTimestamp = "lastRefreshTimestamp"
 	CatalogFieldName                 = "name"
 	CatalogFieldOwnerReferences      = "ownerReferences"
+	CatalogFieldPassword             = "password"
 	CatalogFieldRemoved              = "removed"
 	CatalogFieldState                = "state"
 	CatalogFieldTransitioning        = "transitioning"
 	CatalogFieldTransitioningMessage = "transitioningMessage"
 	CatalogFieldURL                  = "url"
 	CatalogFieldUUID                 = "uuid"
+	CatalogFieldUsername             = "username"
 )
 
 type Catalog struct {
@@ -40,12 +42,14 @@ type Catalog struct {
 	LastRefreshTimestamp string             `json:"lastRefreshTimestamp,omitempty" yaml:"lastRefreshTimestamp,omitempty"`
 	Name                 string             `json:"name,omitempty" yaml:"name,omitempty"`
 	OwnerReferences      []OwnerReference   `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Password             string             `json:"password,omitempty" yaml:"password,omitempty"`
 	Removed              string             `json:"removed,omitempty" yaml:"removed,omitempty"`
 	State                string             `json:"state,omitempty" yaml:"state,omitempty"`
 	Transitioning        string             `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
 	TransitioningMessage string             `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
 	URL                  string             `json:"url,omitempty" yaml:"url,omitempty"`
 	UUID                 string             `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Username             string             `json:"username,omitempty" yaml:"username,omitempty"`
 }
 
 type CatalogCollection struct {

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_catalog_spec.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_catalog_spec.go
@@ -5,12 +5,16 @@ const (
 	CatalogSpecFieldBranch      = "branch"
 	CatalogSpecFieldCatalogKind = "catalogKind"
 	CatalogSpecFieldDescription = "description"
+	CatalogSpecFieldPassword    = "password"
 	CatalogSpecFieldURL         = "url"
+	CatalogSpecFieldUsername    = "username"
 )
 
 type CatalogSpec struct {
 	Branch      string `json:"branch,omitempty" yaml:"branch,omitempty"`
 	CatalogKind string `json:"catalogKind,omitempty" yaml:"catalogKind,omitempty"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Password    string `json:"password,omitempty" yaml:"password,omitempty"`
 	URL         string `json:"url,omitempty" yaml:"url,omitempty"`
+	Username    string `json:"username,omitempty" yaml:"username,omitempty"`
 }

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_catalog.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_catalog.go
@@ -20,12 +20,14 @@ const (
 	ClusterCatalogFieldName                 = "name"
 	ClusterCatalogFieldNamespaceId          = "namespaceId"
 	ClusterCatalogFieldOwnerReferences      = "ownerReferences"
+	ClusterCatalogFieldPassword             = "password"
 	ClusterCatalogFieldRemoved              = "removed"
 	ClusterCatalogFieldState                = "state"
 	ClusterCatalogFieldTransitioning        = "transitioning"
 	ClusterCatalogFieldTransitioningMessage = "transitioningMessage"
 	ClusterCatalogFieldURL                  = "url"
 	ClusterCatalogFieldUUID                 = "uuid"
+	ClusterCatalogFieldUsername             = "username"
 )
 
 type ClusterCatalog struct {
@@ -44,12 +46,14 @@ type ClusterCatalog struct {
 	Name                 string             `json:"name,omitempty" yaml:"name,omitempty"`
 	NamespaceId          string             `json:"namespaceId,omitempty" yaml:"namespaceId,omitempty"`
 	OwnerReferences      []OwnerReference   `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Password             string             `json:"password,omitempty" yaml:"password,omitempty"`
 	Removed              string             `json:"removed,omitempty" yaml:"removed,omitempty"`
 	State                string             `json:"state,omitempty" yaml:"state,omitempty"`
 	Transitioning        string             `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
 	TransitioningMessage string             `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
 	URL                  string             `json:"url,omitempty" yaml:"url,omitempty"`
 	UUID                 string             `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Username             string             `json:"username,omitempty" yaml:"username,omitempty"`
 }
 
 type ClusterCatalogCollection struct {

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_project_catalog.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_project_catalog.go
@@ -19,6 +19,7 @@ const (
 	ProjectCatalogFieldName                 = "name"
 	ProjectCatalogFieldNamespaceId          = "namespaceId"
 	ProjectCatalogFieldOwnerReferences      = "ownerReferences"
+	ProjectCatalogFieldPassword             = "password"
 	ProjectCatalogFieldProjectID            = "projectId"
 	ProjectCatalogFieldRemoved              = "removed"
 	ProjectCatalogFieldState                = "state"
@@ -26,6 +27,7 @@ const (
 	ProjectCatalogFieldTransitioningMessage = "transitioningMessage"
 	ProjectCatalogFieldURL                  = "url"
 	ProjectCatalogFieldUUID                 = "uuid"
+	ProjectCatalogFieldUsername             = "username"
 )
 
 type ProjectCatalog struct {
@@ -43,6 +45,7 @@ type ProjectCatalog struct {
 	Name                 string             `json:"name,omitempty" yaml:"name,omitempty"`
 	NamespaceId          string             `json:"namespaceId,omitempty" yaml:"namespaceId,omitempty"`
 	OwnerReferences      []OwnerReference   `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Password             string             `json:"password,omitempty" yaml:"password,omitempty"`
 	ProjectID            string             `json:"projectId,omitempty" yaml:"projectId,omitempty"`
 	Removed              string             `json:"removed,omitempty" yaml:"removed,omitempty"`
 	State                string             `json:"state,omitempty" yaml:"state,omitempty"`
@@ -50,6 +53,7 @@ type ProjectCatalog struct {
 	TransitioningMessage string             `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
 	URL                  string             `json:"url,omitempty" yaml:"url,omitempty"`
 	UUID                 string             `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Username             string             `json:"username,omitempty" yaml:"username,omitempty"`
 }
 
 type ProjectCatalogCollection struct {


### PR DESCRIPTION
Address #13371 
1. support http/s helm catalog server with basic auth.
2. support git clone for private repo with username and password(access token).

Types PR: rancher/types#599
UI Issue: https://github.com/rancher/rancher/issues/16244