### PR TITLE
Fix worker kubelet restart with private regsitries

### DIFF
--- a/pkg/rkeworker/docker.go
+++ b/pkg/rkeworker/docker.go
@@ -186,6 +186,7 @@ func changed(ctx context.Context, c *client.Client, expectedProcess v3.Process, 
 	actualProcess.Name = expectedProcess.Name
 	actualProcess.HealthCheck.URL = expectedProcess.HealthCheck.URL
 	actualProcess.RestartPolicy = expectedProcess.RestartPolicy
+	actualProcess.ImageRegistryAuthConfig = expectedProcess.ImageRegistryAuthConfig
 
 	changed := false
 	t := reflect.TypeOf(actualProcess)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/16282

This PR will prevent the agent from restarting the components containers if the private registries configuration changed. This is ok since the container doesn't use this configuration anyway, it's passed to docker earlier to be able to pull the image.