### PR TITLE
hideByOwner only if opt.Options[hidden] is not set

### DIFF
--- a/pkg/api/store/workload/transform_store.go
+++ b/pkg/api/store/workload/transform_store.go
@@ -23,12 +23,12 @@ func NewTransformStore(store types.Store) types.Store {
 			hide := true
 			if opt != nil && opt.Options["hidden"] == "true" {
 				hide = false
-			}
-			if opt != nil && opt.Options["ByID"] == "true" {
+			} else if opt != nil && opt.Options["ByID"] == "true" {
 				hide = false
+			} else {
+				hide = hideByOwner(data)
 			}
 			typeName := definition.GetType(data)
-			hide = hideByOwner(data)
 			name, _ := data["name"].(string)
 			if hide && data["ownerReferences"] != nil {
 				pod.SaveOwner(apiContext, typeName, name, data)


### PR DESCRIPTION
If `opt.Options["hidden"]` set true, replicaSets should be shown in API and hide should remain false, otherwise no replicaSets would be listed under `/revisions`. 

https://github.com/rancher/rancher/pull/16267
Issue: https://github.com/rancher/rancher/issues/16408 
Backport Issue: https://github.com/rancher/rancher/issues/16409 