### PR TITLE
Do not update endpoints on pods

### DIFF
--- a/pkg/controllers/user/endpoints/endpoints.go
+++ b/pkg/controllers/user/endpoints/endpoints.go
@@ -55,13 +55,8 @@ func Register(ctx context.Context, workload *config.UserContext) {
 	workload.Core.Services("").AddHandler(ctx, "servicesEndpointsController", s.sync)
 
 	p := &PodsController{
-		nodeLister:         workload.Core.Nodes("").Controller().Lister(),
-		pods:               workload.Core.Pods(""),
-		serviceLister:      workload.Core.Services("").Controller().Lister(),
 		podLister:          workload.Core.Pods("").Controller().Lister(),
 		workloadController: workloadUtil.NewWorkloadController(ctx, workload.UserOnlyContext(), nil),
-		machinesLister:     workload.Management.Management.Nodes(workload.ClusterName).Controller().Lister(),
-		clusterName:        workload.ClusterName,
 	}
 	workload.Core.Pods("").AddHandler(ctx, "hostPortEndpointsController", p.sync)
 

--- a/pkg/controllers/user/endpoints/pod_endpoints.go
+++ b/pkg/controllers/user/endpoints/pod_endpoints.go
@@ -7,24 +7,17 @@ import (
 
 	workloadutil "github.com/rancher/rancher/pkg/controllers/user/workload"
 	"github.com/rancher/types/apis/core/v1"
-	"github.com/rancher/types/apis/management.cattle.io/v3"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// This controller is responsible for monitoring pods
-// and setting public endpoints on them based on HostPort pods
-// and NodePort/LoadBalancer services backing up the pod
+// This controller is responsible for monitoring pods having host port set
+// and sending an update event to the corresponding workload
+// so the endpoints can be reconciled for those
 
 type PodsController struct {
-	nodeLister         v1.NodeLister
-	pods               v1.PodInterface
 	podLister          v1.PodLister
-	serviceLister      v1.ServiceLister
 	workloadController workloadutil.CommonController
-	machinesLister     v3.NodeLister
-	clusterName        string
 }
 
 func (c *PodsController) sync(key string, obj *corev1.Pod) (*corev1.Pod, error) {
@@ -33,7 +26,6 @@ func (c *PodsController) sync(key string, obj *corev1.Pod) (*corev1.Pod, error) 
 	}
 
 	var pods []*corev1.Pod
-	var services []*corev1.Service
 	var err error
 	if strings.HasSuffix(key, allEndpoints) {
 		namespace := ""
@@ -44,39 +36,22 @@ func (c *PodsController) sync(key string, obj *corev1.Pod) (*corev1.Pod, error) 
 		if err != nil {
 			return nil, err
 		}
-		services, err = c.serviceLister.List(namespace, labels.NewSelector())
-		if err != nil {
-			return nil, err
-		}
 	} else {
-		services, err = c.serviceLister.List(obj.Namespace, labels.NewSelector())
-		if err != nil {
-			return nil, err
-		}
 		pods = append(pods, obj)
 	}
 
-	nodesToUpdate := map[string]bool{}
 	workloadsToUpdate := map[string]*workloadutil.Workload{}
-	nodeNameToMachine, err := getNodeNameToMachine(c.clusterName, c.machinesLister, c.nodeLister)
 	if err != nil {
 		return nil, err
 	}
 	for _, pod := range pods {
-		updated, err := c.updatePodEndpoints(pod, services, nodeNameToMachine)
-		if err != nil {
-			return nil, err
-		}
-		if updated {
-			if pod.Spec.NodeName != "" && podHasHostPort(pod) {
-				nodesToUpdate[pod.Spec.NodeName] = true
-				workloads, err := c.workloadController.GetWorkloadsMatchingLabels(pod.Namespace, pod.Labels)
-				if err != nil {
-					return nil, err
-				}
-				for _, w := range workloads {
-					workloadsToUpdate[key] = w
-				}
+		if pod.Spec.NodeName != "" && podHasHostPort(pod) {
+			workloads, err := c.workloadController.GetWorkloadsMatchingLabels(pod.Namespace, pod.Labels)
+			if err != nil {
+				return nil, err
+			}
+			for _, w := range workloads {
+				workloadsToUpdate[key] = w
 			}
 		}
 	}
@@ -98,64 +73,4 @@ func podHasHostPort(obj *corev1.Pod) bool {
 		}
 	}
 	return false
-}
-
-func (c *PodsController) updatePodEndpoints(obj *corev1.Pod, services []*corev1.Service, nodeNameToMachine map[string]*v3.Node) (updated bool, err error) {
-	if obj.Spec.NodeName == "" {
-		return false, nil
-	}
-
-	if obj.DeletionTimestamp != nil {
-		return true, nil
-	}
-
-	// 1. update pod with endpoints
-	// a) from HostPort
-	newPublicEps, err := convertHostPortToEndpoint(obj, c.clusterName, nodeNameToMachine[obj.Spec.NodeName])
-	if err != nil {
-		return false, err
-	}
-	allNodesIP, err := getAllNodesPublicEndpointIP(c.machinesLister, c.clusterName)
-	if err != nil {
-		return false, err
-	}
-	// b) from services
-	for _, svc := range services {
-		if svc.Namespace != obj.Namespace {
-			continue
-		}
-		set := labels.Set{}
-		for key, val := range svc.Spec.Selector {
-			set[key] = val
-		}
-		selector := labels.SelectorFromSet(set)
-		if selector.Matches(labels.Set(obj.Labels)) {
-			eps, err := convertServiceToPublicEndpoints(svc, "", nil, allNodesIP)
-			if err != nil {
-				return false, err
-			}
-			newPublicEps = append(newPublicEps, eps...)
-		}
-	}
-
-	existingPublicEps := getPublicEndpointsFromAnnotations(obj.Annotations)
-	if areEqualEndpoints(existingPublicEps, newPublicEps) {
-		return false, nil
-	}
-	toUpdate := obj.DeepCopy()
-	epsToUpdate, err := publicEndpointsToString(newPublicEps)
-	if err != nil {
-		return false, err
-	}
-
-	logrus.Infof("Updating pod [%s/%s] with public endpoints [%v]", obj.Namespace, obj.Name, epsToUpdate)
-	if toUpdate.Annotations == nil {
-		toUpdate.Annotations = make(map[string]string)
-	}
-	toUpdate.Annotations[endpointsAnnotation] = epsToUpdate
-	_, err = c.pods.Update(toUpdate)
-	if err != nil {
-		return false, err
-	}
-	return true, nil
 }


### PR DESCRIPTION
as pod annotaitons updates are disallowed on k8s 1.12, and the pods' endpoints weren't used anywhere in the UI anyway. The workloads' endpoints should be used as a reference instead

https://github.com/rancher/rancher/issues/15963