### PR TITLE
Fix snapshot upgrade

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -133,6 +133,7 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	authn.SetUserStore(schemas.Schema(&managementschema.Version, client.UserType), apiContext)
 	authn.SetRTBStore(ctx, schemas.Schema(&managementschema.Version, client.ClusterRoleTemplateBindingType), apiContext)
 	authn.SetRTBStore(ctx, schemas.Schema(&managementschema.Version, client.ProjectRoleTemplateBindingType), apiContext)
+	cluster.SetClusterStore(ctx, schemas.Schema(&managementschema.Version, client.ClusterType), apiContext)
 	nodeStore.SetupStore(schemas.Schema(&managementschema.Version, client.NodeType))
 	projectStore.SetProjectStore(schemas.Schema(&managementschema.Version, client.ProjectType), apiContext)
 	setupScopedTypes(schemas)

--- a/pkg/controllers/management/clusterprovisioner/driver.go
+++ b/pkg/controllers/management/clusterprovisioner/driver.go
@@ -34,6 +34,12 @@ func (p *Provisioner) driverUpdate(cluster *v3.Cluster, spec v3.ClusterSpec) (ap
 		return cluster.Status.APIEndpoint, cluster.Status.ServiceAccountToken, cluster.Status.CACert, nil
 	}
 
+	if spec.RancherKubernetesEngineConfig != nil && spec.RancherKubernetesEngineConfig.Services.Etcd.Snapshot == nil &&
+		applied.RancherKubernetesEngineConfig != nil && applied.RancherKubernetesEngineConfig.Services.Etcd.Snapshot == nil {
+		_false := false
+		cluster.Spec.RancherKubernetesEngineConfig.Services.Etcd.Snapshot = &_false
+	}
+
 	if newCluster, err := p.Clusters.Update(cluster); err == nil {
 		cluster = newCluster
 	}


### PR DESCRIPTION
For existing clusters, the snapshot value for the etcd service is nil. The RKE driver will interpret this as true, but we want it to behave as false in the API. We catch it before norman applies defaults (which would cause it to show as true), and say that if it is nil, it is false.

We also now convert a nil value for the snapshot setting as false. This only happens when we're already planning on passing the clusterspec to the driver update. This way, nil snapshot values which are considered false in the UI don't get handled as true in the RKE driver