### PR TITLE
address empty namespace not set for refresh action of cluster/project catalogs

### DIFF
--- a/pkg/api/customization/catalog/catalog.go
+++ b/pkg/api/customization/catalog/catalog.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"github.com/rancher/rancher/pkg/ref"
 	"time"
 
 	"bytes"
@@ -109,7 +110,8 @@ func (a ActionHandler) RefreshProjectCatalogActionHandler(actionName string, act
 
 	prjCatalogs := []v3.ProjectCatalog{}
 	if apiContext.ID != "" {
-		catalog, err := a.ProjectCatalogClient.Get(apiContext.ID, metav1.GetOptions{})
+		ns, name := ref.Parse(apiContext.ID)
+		catalog, err := a.ProjectCatalogClient.GetNamespaced(ns, name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -140,7 +142,8 @@ func (a ActionHandler) RefreshClusterCatalogActionHandler(actionName string, act
 
 	clCatalogs := []v3.ClusterCatalog{}
 	if apiContext.ID != "" {
-		catalog, err := a.ClusterCatalogClient.Get(apiContext.ID, metav1.GetOptions{})
+		ns, name := ref.Parse(apiContext.ID)
+		catalog, err := a.ClusterCatalogClient.GetNamespaced(ns, name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Issues: #16585.

The root cause of this issue is get cluster/project level catalog without namespace specifcation will return `an empty namespace may not be set when a resource name is provided` server error in the `refresh action`.

@mrajashree can u please review this change, thanks.