### PR TITLE
Add `rancher/` prefix for images from dockerhub library

### DIFF
--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -10,6 +10,10 @@ import (
 func Resolve(image string) string {
 	reg := settings.SystemDefaultRegistry.Get()
 	if reg != "" && !strings.HasPrefix(image, reg) {
+		//Images from Dockerhub Library repo, we add rancher prefix when using private registry
+		if !strings.Contains(image, "/") {
+			image = "rancher/" + image
+		}
 		return path.Join(reg, image)
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/16666