### PR TITLE
Add pipeline configuration for self-signed git service

### DIFF
--- a/pkg/controllers/user/pipeline/controller/project/project.go
+++ b/pkg/controllers/user/pipeline/controller/project/project.go
@@ -25,6 +25,7 @@ import (
 var settings = map[string]string{
 	utils.SettingExecutorQuota:   utils.SettingExecutorQuotaDefault,
 	utils.SettingSigningDuration: utils.SettingSigningDurationDefault,
+	utils.SettingGitCaCerts:      "",
 }
 
 func Register(ctx context.Context, cluster *config.UserContext) {

--- a/pkg/pipeline/engine/engine.go
+++ b/pkg/pipeline/engine/engine.go
@@ -24,6 +24,7 @@ func New(cluster *config.UserContext, useCache bool) PipelineEngine {
 	sourceCodeCredentials := cluster.Management.Project.SourceCodeCredentials("")
 	sourceCodeCredentialLister := sourceCodeCredentials.Controller().Lister()
 	pipelineLister := cluster.Management.Project.Pipelines("").Controller().Lister()
+	pipelineSettingLister := cluster.Management.Project.PipelineSettings("").Controller().Lister()
 	dialer := cluster.Management.Dialer
 
 	engine := &jenkins.Engine{
@@ -36,6 +37,7 @@ func New(cluster *config.UserContext, useCache bool) PipelineEngine {
 		SourceCodeCredentials:      sourceCodeCredentials,
 		SourceCodeCredentialLister: sourceCodeCredentialLister,
 		PipelineLister:             pipelineLister,
+		PipelineSettingLister:      pipelineSettingLister,
 
 		Dialer:      dialer,
 		ClusterName: cluster.ClusterName,

--- a/pkg/pipeline/engine/jenkins/engine.go
+++ b/pkg/pipeline/engine/jenkins/engine.go
@@ -48,6 +48,7 @@ type Engine struct {
 	SourceCodeCredentials      v3.SourceCodeCredentialInterface
 	SourceCodeCredentialLister v3.SourceCodeCredentialLister
 	PipelineLister             v3.PipelineLister
+	PipelineSettingLister      v3.PipelineSettingLister
 
 	ClusterName string
 	Dialer      dialer.Factory
@@ -236,7 +237,11 @@ func (j *Engine) prepareRegistryCredential(execution *v3.PipelineExecution, regi
 
 func (j *Engine) createPipelineJob(client *Client, execution *v3.PipelineExecution) error {
 	logrus.Debug("create jenkins job for pipeline")
-	jobconf, err := ConvertPipelineExecutionToJenkinsPipeline(execution)
+	converter, err := initJenkinsPipelineConverter(execution, j.PipelineSettingLister)
+	if err != nil {
+		return err
+	}
+	jobconf, err := converter.convertPipelineExecutionToJenkinsPipeline()
 	if err != nil {
 		return err
 	}
@@ -247,7 +252,11 @@ func (j *Engine) createPipelineJob(client *Client, execution *v3.PipelineExecuti
 
 func (j *Engine) updatePipelineJob(client *Client, execution *v3.PipelineExecution) error {
 	logrus.Debug("update jenkins job for pipeline")
-	jobconf, err := ConvertPipelineExecutionToJenkinsPipeline(execution)
+	converter, err := initJenkinsPipelineConverter(execution, j.PipelineSettingLister)
+	if err != nil {
+		return err
+	}
+	jobconf, err := converter.convertPipelineExecutionToJenkinsPipeline()
 	if err != nil {
 		return err
 	}

--- a/pkg/pipeline/engine/jenkins/model.go
+++ b/pkg/pipeline/engine/jenkins/model.go
@@ -2,12 +2,6 @@ package jenkins
 
 import "encoding/xml"
 
-type PipelineStep struct {
-	command          string
-	image            string
-	containerOptions string
-}
-
 type PipelineJob struct {
 	XMLName    xml.Name   `xml:"flow-definition"`
 	Plugin     string     `xml:"plugin,attr"`

--- a/pkg/pipeline/utils/constants.go
+++ b/pkg/pipeline/utils/constants.go
@@ -4,6 +4,7 @@ const (
 	PipelineNamespace              = "cattle-pipeline"
 	PipelineNamespaceSuffix        = "-pipeline"
 	JenkinsName                    = "jenkins"
+	JenkinsAgentContainerName      = "jnlp"
 	PipelineName                   = "pipeline"
 	PipelineSecretName             = "pipeline-secret"
 	PipelineAPIKeySecretName       = "pipeline-api-key"
@@ -13,6 +14,8 @@ const (
 	PipelineSecretAPITokenKey      = "API_TOKEN"
 	PipelineSecretDefaultUser      = "admin"
 	PipelineSecretDefaultToken     = "admin123"
+	GitCaCertVolumeName            = "git-ca-crt"
+	GitCaCertPath                  = "/home/jenkins/certs"
 	RegistryName                   = "docker-registry"
 	RegistryProxyName              = "registry-proxy"
 	RegistryCrt                    = "client.cert"
@@ -95,6 +98,7 @@ const (
 	SettingExecutorQuotaDefault   = "2"
 	SettingSigningDuration        = "registry-signing-duration"
 	SettingSigningDurationDefault = "2160h"
+	SettingGitCaCerts             = "git-cacerts"
 
 	DefaultTimeout = 60
 )


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/16136

~~Depending on a new tag of the slave image.~~
Edit:
Change to use init container to deal with cacerts, in this way we can avoid maintaining a customized agent image.
Change the construction of build pod template in a more "go-client-style" way, so that we can do fine-grained
tweaks more easily.

---
To integrate with self-signed certificate git service,
1. Add ca root certificate to rancher per the [instruction](https://rancher.com/docs/rancher/v2.x/en/admin-settings/custom-ca-root-certificate/)
2. configure ca root certificate in project pipeline setting, then the build pod will add it for git clone.