### PR TITLE
Use gometalinter instead of golint

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,11 @@
+{
+    "Enable": [
+        "golint",
+        "vet"
+    ],
+    "Exclude": [
+        "or be unexported",
+        "hyperkube"
+    ],
+    "Deadline": "60s"
+}

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -14,7 +14,7 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
 RUN wget -O - https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get golang.org/x/lint/golint
+    go get github.com/rancher/trash && curl -L https://raw.githubusercontent.com/alecthomas/gometalinter/v2.0.12/scripts/install.sh | sh
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \

--- a/pkg/auth/providerrefresh/refresh_daemon.go
+++ b/pkg/auth/providerrefresh/refresh_daemon.go
@@ -342,7 +342,7 @@ func ParseMaxAge(setting string) (time.Duration, error) {
 	durString := fmt.Sprintf("%vs", setting)
 	dur, err := time.ParseDuration(durString)
 	if err != nil {
-		return 0, errors.New(fmt.Sprintf("Error parsing auth refresh max age: %v", err))
+		return 0, fmt.Errorf("Error parsing auth refresh max age: %v", err)
 	}
 	return dur, nil
 }
@@ -353,7 +353,7 @@ func ParseCron(setting string) (cron.Schedule, error) {
 	}
 	schedule, err := cron.ParseStandard(setting)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Error parsing auth refresh cron: %v", err))
+		return nil, fmt.Errorf("Error parsing auth refresh cron: %v", err)
 	}
 	return schedule, nil
 }

--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -359,7 +359,7 @@ func (ah *appHandler) grantClusterMonitoringPermissions(appName, appTargetNamesp
 			}
 			if appServiceAccount.Name == appServiceAccountName {
 				if appServiceAccount.DeletionTimestamp != nil {
-					return errors.New(fmt.Sprintf("stale %q ServiceAccount in %q Namespace is still on terminating", appServiceAccountName, appTargetNamespace))
+					return fmt.Errorf("stale %q ServiceAccount in %q Namespace is still on terminating", appServiceAccountName, appTargetNamespace)
 				}
 			} else {
 				appServiceAccount = &k8scorev1.ServiceAccount{
@@ -452,7 +452,7 @@ func (ah *appHandler) grantClusterMonitoringPermissions(appName, appTargetNamesp
 
 			if appClusterRole.Name == appClusterRoleName {
 				if appClusterRole.DeletionTimestamp != nil {
-					return errors.New(fmt.Sprintf("stale %q ClusterRole is still on terminating", appClusterRoleName))
+					return fmt.Errorf("stale %q ClusterRole is still on terminating", appClusterRoleName)
 				}
 
 				// ensure
@@ -486,7 +486,7 @@ func (ah *appHandler) grantClusterMonitoringPermissions(appName, appTargetNamesp
 			}
 			if appClusterRoleBinding.Name == appClusterRoleBindingName {
 				if appClusterRoleBinding.DeletionTimestamp != nil {
-					return errors.New(fmt.Sprintf("stale %q ClusterRoleBinding is still on terminating", appClusterRoleBindingName))
+					return fmt.Errorf("stale %q ClusterRoleBinding is still on terminating", appClusterRoleBindingName)
 				}
 			} else {
 				appClusterRoleBinding = &k8srbacv1.ClusterRoleBinding{

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -191,7 +191,7 @@ func (ah *appHandler) grantProjectMonitoringPermissions(appName, appTargetNamesp
 			}
 			if appServiceAccount.Name == appServiceAccountName {
 				if appServiceAccount.DeletionTimestamp != nil {
-					return errors.New(fmt.Sprintf("stale %q ServiceAccount in %q Namespace is still on terminating", appServiceAccountName, appTargetNamespace))
+					return fmt.Errorf("stale %q ServiceAccount in %q Namespace is still on terminating", appServiceAccountName, appTargetNamespace)
 				}
 			} else {
 				appServiceAccount = &k8scorev1.ServiceAccount{
@@ -218,7 +218,7 @@ func (ah *appHandler) grantProjectMonitoringPermissions(appName, appTargetNamesp
 			}
 			if appClusterRoleBinding.Name == appClusterRoleBindingName {
 				if appClusterRoleBinding.DeletionTimestamp != nil {
-					return errors.New(fmt.Sprintf("stale %q ClusterRoleBinding is still on terminating", appClusterRoleBindingName))
+					return fmt.Errorf("stale %q ClusterRoleBinding is still on terminating", appClusterRoleBindingName)
 				}
 			} else {
 				appClusterRoleBinding = &k8srbacv1.ClusterRoleBinding{

--- a/pkg/monitoring/deploy.go
+++ b/pkg/monitoring/deploy.go
@@ -27,7 +27,7 @@ func EnsureAppProjectName(agentNamespacesClient corev1.NamespaceInterface, owned
 
 	if deployNamespace.Name == appTargetNamespace {
 		if deployNamespace.DeletionTimestamp != nil {
-			return "", errors.New(fmt.Sprintf("stale %q Namespace is still on terminating", appTargetNamespace))
+			return "", fmt.Errorf("stale %q Namespace is still on terminating", appTargetNamespace)
 		}
 	} else {
 		deployNamespace = &k8scorev1.Namespace{
@@ -97,7 +97,7 @@ func GetSystemProjectID(cattleProjectsClient mgmtv3.ProjectInterface) (string, e
 		}
 	}
 	if systemProject == nil {
-		return "", errors.New(fmt.Sprintf("failed to find any cattle system project"))
+		return "", fmt.Errorf("failed to find any cattle system project")
 	}
 
 	return systemProject.Name, nil
@@ -111,7 +111,7 @@ func DeployApp(cattleAppsGetter projectv3.AppsGetter, projectID string, createAp
 	}
 	if app.Name == appName {
 		if app.DeletionTimestamp != nil {
-			return errors.New(fmt.Sprintf("stale %q App in %s Project is still on terminating", appName, projectID))
+			return fmt.Errorf("stale %q App in %s Project is still on terminating", appName, projectID)
 		}
 
 		return nil

--- a/pkg/monitoring/system.go
+++ b/pkg/monitoring/system.go
@@ -111,7 +111,7 @@ func grantSystemMonitorRBAC(agentServiceAccountGetter corev1.ServiceAccountsGett
 			}
 			if appServiceAccount.Name == appServiceAccountName {
 				if appServiceAccount.DeletionTimestamp != nil {
-					return errors.New(fmt.Sprintf("stale %q ServiceAccount is still on terminating", appServiceAccountName))
+					return fmt.Errorf("stale %q ServiceAccount is still on terminating", appServiceAccountName)
 				}
 			} else {
 				appServiceAccount = &k8scorev1.ServiceAccount{
@@ -172,7 +172,7 @@ func grantSystemMonitorRBAC(agentServiceAccountGetter corev1.ServiceAccountsGett
 
 			if appClusterRole.Name == appClusterRoleName {
 				if appClusterRole.DeletionTimestamp != nil {
-					return errors.New(fmt.Sprintf("stale %q ClusterRole is still on terminating", appClusterRoleName))
+					return fmt.Errorf("stale %q ClusterRole is still on terminating", appClusterRoleName)
 				}
 
 				// ensure
@@ -206,7 +206,7 @@ func grantSystemMonitorRBAC(agentServiceAccountGetter corev1.ServiceAccountsGett
 			}
 			if appClusterRoleBinding.Name == appClusterRoleBindingName {
 				if appClusterRoleBinding.DeletionTimestamp != nil {
-					return errors.New(fmt.Sprintf("stale %q ClusterRoleBinding is still on terminating", appClusterRoleBindingName))
+					return fmt.Errorf("stale %q ClusterRoleBinding is still on terminating", appClusterRoleBindingName)
 				}
 			} else {
 				appClusterRoleBinding = &k8srbacv1.ClusterRoleBinding{

--- a/scripts/validate
+++ b/scripts/validate
@@ -7,11 +7,9 @@ echo Running validation
 
 PACKAGES=". $(find . -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
 
-echo Running: go vet
-go vet ${PACKAGES}
-echo Running: golint
+echo Running: gometalinter
 for i in ${PACKAGES}; do
-    if [ -n "$(golint $i | grep -Ev 'hyperkube|should have comment.*or be unexported' | tee /dev/stderr)" ]; then
+    if [ -n "$(gometalinter $i | tee /dev/stderr)" ]; then
         failed=true
     fi
 done


### PR DESCRIPTION
Doesn't do anything extra yet, still just runs `golint` and `go vet`, but this sets up the preliminaries for adding other linters like `deadcode` etc. I just figured we'd wait on those until some of the big features have landed. Some of them also have some larger change sets so probably warrant being split up anyways. 