### PR TITLE
Drop another cloudflare header

### DIFF
--- a/pkg/httpproxy/proxy.go
+++ b/pkg/httpproxy/proxy.go
@@ -24,6 +24,7 @@ var (
 		"transfer-encoding": true,
 		"content-length":    true,
 		"x-api-auth-header": true,
+		"cf-connecting-ip":  true,
 		"cf-ray":            true,
 		"impersonate-user":  true,
 		"impersonate-group": true,


### PR DESCRIPTION
Drop another header that CloudFlare uses to detect loops so that User -> Rancher behind CloudFlare -> DigitalOcean behind CloudFlare works.  https://github.com/rancher/rancher/issues/11280