### PR TITLE
Fix port conflict error

### DIFF
--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -233,11 +233,12 @@ def wait_for_condition(condition_type, status, client, obj, timeout=45):
     return obj
 
 
-def wait_until(cb, timeout=DEFAULT_TIMEOUT):
+def wait_until(cb, timeout=DEFAULT_TIMEOUT, backoff=True):
     start_time = time.time()
     interval = 1
     while time.time() < start_time + timeout and cb() is False:
-        interval *= 2
+        if backoff:
+            interval *= 2
         time.sleep(interval)
 
 

--- a/tests/core/test_kontainer_engine_validation.py
+++ b/tests/core/test_kontainer_engine_validation.py
@@ -2,9 +2,9 @@ from .common import random_str
 from .conftest import wait_until
 
 
-def get_error_message_for_eks_config(admin_mc, remove_resource, config):
+def assert_has_error_message(admin_mc, remove_resource, eks, message):
     cluster = admin_mc.client.create_cluster(
-        name=random_str(), amazonElasticContainerServiceConfig=config)
+        name=random_str(), amazonElasticContainerServiceConfig=eks)
     remove_resource(cluster)
 
     def get_provisioned_type(cluster):
@@ -12,6 +12,7 @@ def get_error_message_for_eks_config(admin_mc, remove_resource, config):
             if condition.type == "Provisioned":
                 if hasattr(condition, 'message'):
                     return condition.message
+        return None
 
     def has_provision_status():
         new_cluster = admin_mc.client.reload(cluster)
@@ -20,10 +21,22 @@ def get_error_message_for_eks_config(admin_mc, remove_resource, config):
             hasattr(new_cluster, "conditions") and \
             get_provisioned_type(new_cluster) is not None
 
-    wait_until(has_provision_status, 60)
+    def has_error_message():
+        for condition in cluster.conditions:
+            if condition.type == "Provisioned":
+                if getattr(condition, 'message') == message:
+                    return True
+
+        return False
+
+    wait_until(has_provision_status)
     cluster = admin_mc.client.reload(cluster)
 
-    return get_provisioned_type(cluster)
+    wait_until(has_error_message, timeout=120, backoff=False)
+    cluster = admin_mc.client.reload(cluster)
+
+    assert has_error_message(), "no error message %r was present" % \
+                                message
 
 
 def test_min_nodes_cannot_be_greater_than_max(admin_mc, remove_resource):
@@ -34,11 +47,10 @@ def test_min_nodes_cannot_be_greater_than_max(admin_mc, remove_resource):
         "minimumNodes": 3,
         "maximumNodes": 2
     }
-    provision_message = \
-        get_error_message_for_eks_config(admin_mc, remove_resource, eks)
 
-    assert provision_message == "error parsing state: maximum nodes cannot " \
-                                "be less than minimum nodes"
+    assert_has_error_message(admin_mc, remove_resource, eks,
+                             "error parsing state: maximum nodes cannot "
+                             "be less than minimum nodes")
 
 
 def test_min_nodes_cannot_be_zero(admin_mc, remove_resource):
@@ -49,11 +61,9 @@ def test_min_nodes_cannot_be_zero(admin_mc, remove_resource):
         "minimumNodes": 0,
         "maximumNodes": 0
     }
-    provision_message = get_error_message_for_eks_config(admin_mc,
-                                                         remove_resource, eks)
-
-    assert provision_message == "error parsing state: minimum nodes must be " \
-                                "greater than 0"
+    assert_has_error_message(admin_mc, remove_resource, eks,
+                             "error parsing state: minimum nodes must be "
+                             "greater than 0")
 
 
 def test_private_cluster_requires_vpc_subnets(admin_mc, remove_resource):
@@ -65,10 +75,7 @@ def test_private_cluster_requires_vpc_subnets(admin_mc, remove_resource):
         "maximumNodes": 3,
         "associateWorkerNodePublicIp": False
     }
-    provision_message = get_error_message_for_eks_config(admin_mc,
-                                                         remove_resource, eks)
-
-    assert \
-        provision_message == \
-        "error parsing state: if AssociateWorkerNodePublicIP is set to " \
-        "false a VPC and subnets must also be provided"
+    assert_has_error_message(admin_mc, remove_resource, eks,
+                             "error parsing state: if "
+                             "AssociateWorkerNodePublicIP is set to "
+                             "false a VPC and subnets must also be provided")


### PR DESCRIPTION
The kontainer engine validation tests are failing intermittently with a port
conflict error.  It is believed that this is due to an intermittent failure in
the GRPC connection. Because the tests are checking the first error message
returned, and not waiting for the connection to be reestablished and the
proper validation error returned, they are failing incorrectly.  This change
makes the tests poll for the correct error message and only fail when the
timeout has been reached.

Issue:
#16895