### PR TITLE
Changing kontainer engine driver naming convention

### DIFF
--- a/pkg/controllers/management/drivers/kontainer_driver.go
+++ b/pkg/controllers/management/drivers/kontainer_driver.go
@@ -14,7 +14,7 @@ type KontainerDriver struct {
 	BaseDriver
 }
 
-var KontainerDriverPrefix = "kontainer-engine-"
+var KontainerDriverPrefix = "kontainer-engine-driver-"
 
 func NewKontainerDriver(builtin bool, name, url, hash string) *KontainerDriver {
 	d := &KontainerDriver{

--- a/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
+++ b/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
@@ -28,7 +28,7 @@ const (
 	DriverDir       = "./management-state/kontainer-drivers/"
 )
 
-var kontainerDriverName = regexp.MustCompile("kontainer-engine-(.+)$")
+var kontainerDriverName = regexp.MustCompile("kontainer-engine-driver-(.+)$")
 
 func Register(ctx context.Context, management *config.ManagementContext) {
 	lifecycle := &Lifecycle{

--- a/tests/core/test_kontainer_drivers.py
+++ b/tests/core/test_kontainer_drivers.py
@@ -1,11 +1,12 @@
-import pytest
 import sys
+
+import pytest
 
 from .conftest import wait_for_condition, wait_until
 
-DRIVER_URL = "https://github.com/rancher/kontainer-engine-" + \
-             "example-driver/releases/download/v0.1.0/kontainer-engine-" + \
-             "example-driver-" + sys.platform
+DRIVER_URL = "https://github.com/rancher/kontainer-engine-driver-example/" \
+             "releases/download/v0.2.0/kontainer-engine-driver-example-" \
+             + sys.platform
 
 
 def test_builtin_drivers_are_present(admin_mc):
@@ -36,6 +37,10 @@ def test_kontainer_driver_lifecycle(admin_mc, remove_resource):
                        timeout=90)
     kd = admin_mc.client.reload(kd)
     verify_driver_in_types(admin_mc.client, kd)
+
+    # verify the leading kontainer driver identifier and trailing system
+    # type are removed from the name
+    assert kd.name == "example"
 
     # test driver is removed from schema after deletion
     admin_mc.client.delete(kd)


### PR DESCRIPTION
This change renames the example driver to support the new kontainer engine
driver naming convention. The new convention is
`kontainer-engine-driver-<<driver name>>-<<extra info>>`.

Depends on:
https://github.com/rancher/kontainer-engine-driver-example/pull/3/

Issue:
https://github.com/rancher/rancher/issues/16842