### PR TITLE
Fixing kontainer driver activate/deactivate links

### DIFF
--- a/pkg/api/customization/kontainerdriver/formatter.go
+++ b/pkg/api/customization/kontainerdriver/formatter.go
@@ -6,8 +6,16 @@ import (
 )
 
 func Formatter(request *types.APIContext, resource *types.RawResource) {
-	resource.AddAction(request, "activate")
-	resource.AddAction(request, "deactivate")
+	state, ok := resource.Values["state"].(string)
+	if ok {
+		if state == "active" {
+			resource.AddAction(request, "deactivate")
+		}
+
+		if state == "inactive" {
+			resource.AddAction(request, "activate")
+		}
+	}
 
 	if builtIn, _ := resource.Values[client.KontainerDriverFieldBuiltIn].(bool); builtIn {
 		delete(resource.Links, "remove")

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -144,6 +144,7 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	MultiClusterApps(schemas, apiContext)
 	GlobalDNSs(schemas, apiContext)
 	Monitor(schemas, apiContext, clusterManager)
+	KontainerDriver(schemas, apiContext)
 
 	if err := NodeTypes(schemas, apiContext); err != nil {
 		return err

--- a/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
+++ b/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
@@ -320,6 +320,9 @@ func (l *Lifecycle) Updated(obj *v3.KontainerDriver) (runtime.Object, error) {
 	var err error
 	if obj.Spec.URL != obj.Status.ActualURL || v3.KontainerDriverConditionDownloaded.IsFalse(obj) || !l.driverExists(obj) {
 		obj, err = l.download(obj)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if obj.Spec.Active {

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -230,6 +230,7 @@ def wait_for_condition(condition_type, status, client, obj, timeout=45):
             msg = 'Timeout waiting for [{}:{}] for condition after {}' \
                 ' seconds'.format(obj.type, obj.id, delta)
             raise Exception(msg)
+    return obj
 
 
 def wait_until(cb, timeout=DEFAULT_TIMEOUT):


### PR DESCRIPTION
This change corrects the activate/deactivate links on kontainer drivers. The
activate/deactivate links were not being shown because the kontainer driver
setup function was not being called in setup.go.  This change adds that
function call in and also adds a test to prevent a regression.

Issue:
https://github.com/rancher/rancher/issues/16858