### PR TITLE
Fix race condition when monitoring deploying

### DIFF
--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -349,7 +349,6 @@ func (ah *appHandler) grantClusterMonitoringPermissions(appName, appTargetNamesp
 	appServiceAccountName := appName
 	appClusterRoleName := appServiceAccountName
 	appClusterRoleBindingName := appServiceAccountName + "-binding"
-	ownedLabels := monitoring.OwnedLabels(appName, appTargetNamespace, monitoring.ClusterLevel)
 
 	err := stream(
 		// detect ServiceAccount (the name as same as App)
@@ -367,7 +366,7 @@ func (ah *appHandler) grantClusterMonitoringPermissions(appName, appTargetNamesp
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      appServiceAccountName,
 						Namespace: appTargetNamespace,
-						Labels:    ownedLabels,
+						Labels:    monitoring.OwnedLabels(appName, appTargetNamespace, monitoring.ClusterLevel),
 					},
 				}
 
@@ -466,7 +465,7 @@ func (ah *appHandler) grantClusterMonitoringPermissions(appName, appTargetNamesp
 				appClusterRole = &k8srbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   appClusterRoleName,
-						Labels: ownedLabels,
+						Labels: monitoring.OwnedLabels(appName, appTargetNamespace, monitoring.ClusterLevel),
 					},
 					Rules: rules,
 				}
@@ -493,7 +492,7 @@ func (ah *appHandler) grantClusterMonitoringPermissions(appName, appTargetNamesp
 				appClusterRoleBinding = &k8srbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   appClusterRoleBindingName,
-						Labels: ownedLabels,
+						Labels: monitoring.OwnedLabels(appName, appTargetNamespace, monitoring.ClusterLevel),
 					},
 					Subjects: []k8srbacv1.Subject{
 						{

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -181,7 +181,6 @@ func (ah *appHandler) grantProjectMonitoringPermissions(appName, appTargetNamesp
 	appServiceAccountName := appName
 	appClusterRoleName := fmt.Sprintf("%s-%s", appName, project.Name)
 	appClusterRoleBindingName := appClusterRoleName + "-binding"
-	ownedLabels := monitoring.OwnedLabels(appName, appTargetNamespace, monitoring.ProjectLevel)
 
 	err := stream(
 		// detect ServiceAccount (the name as same as App)
@@ -199,7 +198,7 @@ func (ah *appHandler) grantProjectMonitoringPermissions(appName, appTargetNamesp
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      appServiceAccountName,
 						Namespace: appTargetNamespace,
-						Labels:    ownedLabels,
+						Labels:    monitoring.OwnedLabels(appName, appTargetNamespace, monitoring.ProjectLevel),
 					},
 				}
 
@@ -225,7 +224,7 @@ func (ah *appHandler) grantProjectMonitoringPermissions(appName, appTargetNamesp
 				appClusterRoleBinding = &k8srbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   appClusterRoleBindingName,
-						Labels: ownedLabels,
+						Labels: monitoring.OwnedLabels(appName, appTargetNamespace, monitoring.ProjectLevel),
 					},
 					Subjects: []k8srbacv1.Subject{
 						{

--- a/pkg/monitoring/system.go
+++ b/pkg/monitoring/system.go
@@ -101,7 +101,6 @@ func grantSystemMonitorRBAC(agentServiceAccountGetter corev1.ServiceAccountsGett
 	appServiceAccountName := appName
 	appClusterRoleName := appServiceAccountName
 	appClusterRoleBindingName := appServiceAccountName + "-binding"
-	ownedLabels := OwnedLabels(appName, appTargetNamespace, SystemLevel)
 
 	err := utilerrors.AggregateGoroutines(
 		// detect ServiceAccount (the name as same as App)
@@ -119,7 +118,7 @@ func grantSystemMonitorRBAC(agentServiceAccountGetter corev1.ServiceAccountsGett
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      appServiceAccountName,
 						Namespace: appTargetNamespace,
-						Labels:    ownedLabels,
+						Labels:    OwnedLabels(appName, appTargetNamespace, SystemLevel),
 					},
 				}
 
@@ -186,7 +185,7 @@ func grantSystemMonitorRBAC(agentServiceAccountGetter corev1.ServiceAccountsGett
 				appClusterRole = &k8srbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   appClusterRoleName,
-						Labels: ownedLabels,
+						Labels: OwnedLabels(appName, appTargetNamespace, SystemLevel),
 					},
 					Rules: rules,
 				}
@@ -213,7 +212,7 @@ func grantSystemMonitorRBAC(agentServiceAccountGetter corev1.ServiceAccountsGett
 				appClusterRoleBinding = &k8srbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   appClusterRoleBindingName,
-						Labels: ownedLabels,
+						Labels: OwnedLabels(appName, appTargetNamespace, SystemLevel),
 					},
 					Subjects: []k8srbacv1.Subject{
 						{


### PR DESCRIPTION
Problem:
norman will insert a created signal to CRDs labels, then causing race
if sharing the same labels map instance  between several goroutines.

Solution:
Repeat to create labels map

Issue:
https://github.com/rancher/rancher/issues/16914