### PR TITLE
 Restrain project level monitoring

### DIFF
--- a/pkg/api/customization/project/project_actions.go
+++ b/pkg/api/customization/project/project_actions.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/api/handler"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
@@ -28,10 +29,19 @@ func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 	resource.AddAction(apiContext, "setpodsecuritypolicytemplate")
 	resource.AddAction(apiContext, "exportYaml")
 
-	if convert.ToBool(resource.Values["enableProjectMonitoring"]) {
-		resource.AddAction(apiContext, "disableMonitoring")
-	} else {
-		resource.AddAction(apiContext, "enableMonitoring")
+	if clusterID := convert.ToString(resource.Values["clusterId"]); len(clusterID) != 0 {
+		cluster := &client.Cluster{}
+		access.ByID(apiContext, apiContext.Version, client.ClusterType, clusterID, &cluster)
+
+		if !cluster.EnableClusterMonitoring {
+			return
+		}
+
+		if convert.ToBool(resource.Values["enableProjectMonitoring"]) {
+			resource.AddAction(apiContext, "disableMonitoring")
+		} else {
+			resource.AddAction(apiContext, "enableMonitoring")
+		}
 	}
 
 }

--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -146,6 +146,12 @@ func (ch *clusterHandler) syncClusterMonitoring(cluster *mgmtv3.Cluster) error {
 		mgmtv3.ClusterConditionMonitoringEnabled.True(cluster)
 		mgmtv3.ClusterConditionMonitoringEnabled.Message(cluster, "")
 	} else if cluster.Status.MonitoringStatus != nil {
+		if err := ch.disableAllOwnedProjectsMonitoring(cluster.Name); err != nil {
+			mgmtv3.ClusterConditionMonitoringEnabled.Unknown(cluster)
+			mgmtv3.ClusterConditionMonitoringEnabled.Message(cluster, err.Error())
+			return errors.Wrap(err, "failed to disable all owned projects monitoring")
+		}
+
 		if err := ch.app.withdrawApp(appName, appTargetNamespace); err != nil {
 			mgmtv3.ClusterConditionMonitoringEnabled.Unknown(cluster)
 			mgmtv3.ClusterConditionMonitoringEnabled.Message(cluster, err.Error())
@@ -236,6 +242,32 @@ func (ch *clusterHandler) detectMonitoringComponentsWhileUninstall(appName, appT
 			return isGrafanaWithdrew(ch.app.agentWorkloadsClient, appTargetNamespace, appName, monitoringStatus)
 		},
 	)
+}
+
+func (ch *clusterHandler) disableAllOwnedProjectsMonitoring(clusterID string) error {
+	projectClient := ch.app.cattleProjectsGetter.Projects(clusterID)
+
+	ownedProjectList, err := projectClient.List(metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to list all projects")
+	}
+
+	ownedProjectItems := ownedProjectList.Items
+	disableFns := make([]func() error, 0, len(ownedProjectItems))
+	for _, ownedProject := range ownedProjectItems {
+		copyOwnedProject := ownedProject.DeepCopy()
+		if copyOwnedProject.DeletionTimestamp != nil || !copyOwnedProject.Spec.EnableProjectMonitoring {
+			continue
+		}
+		copyOwnedProject.Spec.EnableProjectMonitoring = false
+
+		disableFns = append(disableFns, func() error {
+			_, err := projectClient.Update(copyOwnedProject)
+			return err
+		})
+	}
+
+	return stream(disableFns...)
 }
 
 func (ah *appHandler) deployEtcdCert(clusterName, appTargetNamespace string) ([]*etcdTLSConfig, error) {

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/rancher/norman/controller"
 	"github.com/rancher/rancher/pkg/monitoring"
 	"github.com/rancher/rancher/pkg/settings"
 	mgmtv3 "github.com/rancher/types/apis/management.cattle.io/v3"
@@ -34,9 +35,15 @@ func (ph *projectHandler) sync(key string, project *mgmtv3.Project) (runtime.Obj
 		return project, nil
 	}
 
-	_, err := ph.cattleClustersClient.Get(project.Spec.ClusterName, metav1.GetOptions{})
+	clusterID := project.Spec.ClusterName
+	cluster, err := ph.cattleClustersClient.Get(clusterID, metav1.GetOptions{})
 	if err != nil {
-		return project, errors.Wrapf(err, "failed to find Cluster %s", project.Spec.ClusterName)
+		return project, errors.Wrapf(err, "failed to find Cluster %s", clusterID)
+	}
+	if !cluster.Spec.EnableClusterMonitoring {
+		return project, &controller.ForgetError{
+			Err: errors.New("unable to operate Project Monitoring without enabling Cluster Monitoring"),
+		}
 	}
 
 	projectTag := getProjectTag(project)

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -40,7 +40,7 @@ func (ph *projectHandler) sync(key string, project *mgmtv3.Project) (runtime.Obj
 	if err != nil {
 		return project, errors.Wrapf(err, "failed to find Cluster %s", clusterID)
 	}
-	if !cluster.Spec.EnableClusterMonitoring {
+	if !cluster.Spec.EnableClusterMonitoring && project.Spec.EnableProjectMonitoring {
 		return project, &controller.ForgetError{
 			Err: errors.New("unable to operate Project Monitoring without enabling Cluster Monitoring"),
 		}


### PR DESCRIPTION
Problem:
- It can enable project level monitoring even if cluster level monitoring
is disabling
- Disable cluster level monitoring but don't withdraw project-levels

Solution:
- Check project related cluster is enabling monitoring or not
- Modify all projects `Spec.EnabledProjectMonitoring` to false before
owner-cluster withdraw its monitoring apps

Issue:
#16932 