### PR TITLE
update vendor to fix invalid default value for float type and no omit threshold value

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d756
 github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
-github.com/rancher/types                      3ba50684a67ca057bc3e0bfd1f19a8f98409a00c
+github.com/rancher/types                      f9aa4289251a52e3bec75072e188ca98fb40a252
 github.com/rancher/norman                     0557aa4ff31a3a0f007dcb1b684894f23cda390c
 github.com/rancher/kontainer-engine           f5495908e7f8225d301316fd78a8fd3dfec803d2
 github.com/rancher/rke                        30d8c8a30ff421abc293eafaa233bce34b72d218

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/alerting_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/alerting_types.go
@@ -200,12 +200,10 @@ type CommonRuleField struct {
 
 type MetricRule struct {
 	Expression     string  `json:"expression,omitempty" norman:"required"`
-	LegendFormat   string  `json:"legendFormat,omitempty"`
-	Step           int64   `json:"step,omitempty"`
 	Description    string  `json:"description,omitempty"`
-	Duration       string  `json:"duration,omitempty"`
+	Duration       string  `json:"duration,omitempty" norman:"required"`
 	Comparison     string  `json:"comparison,omitempty" norman:"type=enum,options=equal|not-equal|greater-than|less-than|greater-or-equal|less-or-equal,default=equal"`
-	ThresholdValue float64 `json:"thresholdValue,omitempty" norman:"type=float"`
+	ThresholdValue float64 `json:"thresholdValue,omitempty" norman:"required,type=float"`
 }
 
 type TimingField struct {

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_metric_rule.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_metric_rule.go
@@ -6,8 +6,6 @@ const (
 	MetricRuleFieldDescription    = "description"
 	MetricRuleFieldDuration       = "duration"
 	MetricRuleFieldExpression     = "expression"
-	MetricRuleFieldLegendFormat   = "legendFormat"
-	MetricRuleFieldStep           = "step"
 	MetricRuleFieldThresholdValue = "thresholdValue"
 )
 
@@ -16,7 +14,5 @@ type MetricRule struct {
 	Description    string  `json:"description,omitempty" yaml:"description,omitempty"`
 	Duration       string  `json:"duration,omitempty" yaml:"duration,omitempty"`
 	Expression     string  `json:"expression,omitempty" yaml:"expression,omitempty"`
-	LegendFormat   string  `json:"legendFormat,omitempty" yaml:"legendFormat,omitempty"`
-	Step           int64   `json:"step,omitempty" yaml:"step,omitempty"`
 	ThresholdValue float64 `json:"thresholdValue,omitempty" yaml:"thresholdValue,omitempty"`
 }


### PR DESCRIPTION
update vendor to fix invalid default value for float type and no omit threshold value

Problem:
1. default value for float return zero string
2. we need threshold value to build alert expression, 0 is useful value

Solution:
1. fix float type default value in norman
2. not omit threshold value in types

Issue:
https://github.com/rancher/rancher/issues/16958

Types:
https://github.com/rancher/types/pull/647

Norman:
https://github.com/rancher/norman/pull/237