### PR TITLE
Precan alert for etcd has leader should be not equal to 1

### DIFF
--- a/pkg/controllers/user/alert/initdata.go
+++ b/pkg/controllers/user/alert/initdata.go
@@ -51,7 +51,7 @@ func initClusterPreCanAlerts(clusterAlertGroups v3.ClusterAlertGroupInterface, c
 			MetricRule: &v3.MetricRule{
 				Description:    "Etcd member has no leader",
 				Expression:     `etcd_server_has_leader{job="exporter-kube-etcd-cluster-monitoring"}`,
-				Comparison:     manager.ComparisonLessThan,
+				Comparison:     manager.ComparisonNotEqual,
 				Duration:       "3m",
 				ThresholdValue: 1,
 			},


### PR DESCRIPTION
Problem:
Now the etcd has leader alert is leader less than 1

Solution:
Change to not equal to 1

Issue:
https://github.com/rancher/rancher/issues/16945