### PR TITLE
change to use scale context instead of user context when access mgmt …

### DIFF
--- a/pkg/api/customization/monitor/cluster_graph_action.go
+++ b/pkg/api/customization/monitor/cluster_graph_action.go
@@ -181,7 +181,7 @@ func nodeName2InternalIP(nodeLister v3.NodeLister, clusterName, nodeName string)
 	_, name := ref.Parse(nodeName)
 	node, err := nodeLister.Get(clusterName, name)
 	if err != nil {
-		return "", fmt.Errorf("get node from mgnt faild, %v", err)
+		return "", fmt.Errorf("get node from mgmt failed, %v", err)
 	}
 
 	internalNodeIP := getInternalNodeIP(node)

--- a/pkg/api/customization/monitor/handler_utils.go
+++ b/pkg/api/customization/monitor/handler_utils.go
@@ -320,19 +320,19 @@ func parseTimeParams(from, to, interval string) (start, end time.Time, step time
 	timeRange := NewTimeRange(from, to)
 	start, err = timeRange.ParseFrom()
 	if err != nil {
-		err = fmt.Errorf("parse param from value %s faild, %v", from, err)
+		err = fmt.Errorf("parse param from value %s failed, %v", from, err)
 		return
 	}
 
 	end, err = timeRange.ParseTo()
 	if err != nil {
-		err = fmt.Errorf("parse param to value %s faild, %v", to, err)
+		err = fmt.Errorf("parse param to value %s failed, %v", to, err)
 		return
 	}
 
 	i, err := getIntervalFrom(interval, defaultMinInterval)
 	if err != nil {
-		err = fmt.Errorf("parse param interval value %s faild, %v", i, err)
+		err = fmt.Errorf("parse param interval value %s failed, %v", i, err)
 		return
 	}
 	intervalCalculator := newIntervalCalculator(&IntervalOptions{MinInterval: i})

--- a/pkg/api/customization/monitor/handler_utils.go
+++ b/pkg/api/customization/monitor/handler_utils.go
@@ -212,7 +212,7 @@ func getAuthToken(userContext *config.UserContext, appName, namespace string) (s
 	return string(secret.Data["token"]), nil
 }
 
-func parseMetricParams(userContext *config.UserContext, resourceType, clusterName string, metricParams map[string]string) (map[string]string, error) {
+func parseMetricParams(userContext *config.UserContext, nodeLister v3.NodeLister, resourceType, clusterName string, metricParams map[string]string) (map[string]string, error) {
 	newMetricParams := make(map[string]string)
 	for k, v := range metricParams {
 		newMetricParams[k] = v
@@ -226,7 +226,7 @@ func parseMetricParams(userContext *config.UserContext, resourceType, clusterNam
 		if instance == "" {
 			return nil, fmt.Errorf("instance in metric params is empty")
 		}
-		ip, err = nodeName2InternalIP(userContext, clusterName, instance)
+		ip, err = nodeName2InternalIP(nodeLister, clusterName, instance)
 		if err != nil {
 			return newMetricParams, err
 		}

--- a/pkg/api/customization/monitor/project_graph_action.go
+++ b/pkg/api/customization/monitor/project_graph_action.go
@@ -58,7 +58,7 @@ func (h *ProjectGraphHandler) QuerySeriesAction(actionName string, action *types
 	}
 
 	prometheusName, prometheusNamespace := monitorutil.ClusterMonitoringInfo()
-	token, err := getAuthToken(userContext, prometheusName, prometheusNamespace) //todo
+	token, err := getAuthToken(userContext, prometheusName, prometheusNamespace)
 	if err != nil {
 		return err
 	}
@@ -77,12 +77,13 @@ func (h *ProjectGraphHandler) QuerySeriesAction(actionName string, action *types
 		return err
 	}
 
+	mgmtClient := h.clustermanager.ScaledContext.Management
 	var queries []*PrometheusQuery
 	for _, graph := range graphs {
 		g := graph
 		_, projectName := ref.Parse(graph.ProjectID)
 		refName := getRefferenceGraphName(projectName, graph.Name)
-		monitorMetrics, err := graph2Metrics(userContext, clusterName, g.ResourceType, refName, graph.MetricsSelector, graph.DetailsMetricsSelector, inputParser.Input.MetricParams, inputParser.Input.IsDetails)
+		monitorMetrics, err := graph2Metrics(userContext, mgmtClient, clusterName, g.ResourceType, refName, graph.MetricsSelector, graph.DetailsMetricsSelector, inputParser.Input.MetricParams, inputParser.Input.IsDetails)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
change to use scale context instead of user context when access mgmt

Problem:
could not access mgmt side resource when import ha cluster

Solution:
change to use scale context to access mgmt side resource

Issue:
https://github.com/rancher/rancher/issues/17026
https://github.com/rancher/rancher/issues/17053