### PR TITLE
Revert "Remove time sleeping on monitoring status detection"

### DIFF
--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	kcluster "github.com/rancher/kontainer-engine/cluster"
@@ -174,6 +175,8 @@ func (ch *clusterHandler) syncClusterMonitoring(cluster *mgmtv3.Cluster) error {
 }
 
 func (ch *clusterHandler) detectMonitoringComponentsWhileInstall(appName, appTargetNamespace string, cluster *mgmtv3.Cluster) error {
+	time.Sleep(5 * time.Second)
+
 	if cluster.Status.MonitoringStatus == nil {
 		cluster.Status.MonitoringStatus = &mgmtv3.MonitoringStatus{
 			Conditions: []mgmtv3.MonitoringCondition{
@@ -211,6 +214,8 @@ func (ch *clusterHandler) detectMonitoringComponentsWhileUninstall(appName, appT
 	if cluster.Status.MonitoringStatus == nil {
 		return nil
 	}
+
+	time.Sleep(5 * time.Second)
 
 	monitoringStatus := cluster.Status.MonitoringStatus
 

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/monitoring"
@@ -143,6 +144,8 @@ func (ph *projectHandler) syncProjectMonitoring(project *mgmtv3.Project, project
 }
 
 func (ph *projectHandler) detectMonitoringComponentsWhileInstall(appName, appTargetNamespace string, project *mgmtv3.Project) error {
+	time.Sleep(5 * time.Second)
+
 	if project.Status.MonitoringStatus == nil {
 		project.Status.MonitoringStatus = &mgmtv3.MonitoringStatus{
 			Conditions: []mgmtv3.MonitoringCondition{
@@ -158,6 +161,8 @@ func (ph *projectHandler) detectMonitoringComponentsWhileUninstall(appName, appT
 	if project.Status.MonitoringStatus == nil {
 		return nil
 	}
+
+	time.Sleep(5 * time.Second)
 
 	return isGrafanaWithdrew(ph.app.agentWorkloadsClient, appTargetNamespace, appName, project.Status.MonitoringStatus)
 }


### PR DESCRIPTION
**Problem:**
This fix doesn't work as expected and make it worse.
We need to revert it first.

**Solution:**
Revert https://github.com/rancher/rancher/pull/16997

**Issue:**
https://github.com/rancher/rancher/issues/17013