### PR TITLE
Fix concurrent map read and map write

### DIFF
--- a/pkg/controllers/user/rbac/namespace_handler.go
+++ b/pkg/controllers/user/rbac/namespace_handler.go
@@ -63,7 +63,7 @@ func (n *nsLifecycle) Create(obj *v1.Namespace) (runtime.Object, error) {
 		return obj, err
 	}
 
-	go updateStatusAnnotation(hasPRTBs, *obj, n.m)
+	go updateStatusAnnotation(hasPRTBs, obj.DeepCopy(), n.m)
 
 	return obj, err
 }
@@ -400,7 +400,7 @@ func crByNS(obj interface{}) ([]string, error) {
 	return result, nil
 }
 
-func updateStatusAnnotation(hasPRTBs bool, namespace v1.Namespace, mgr *manager) {
+func updateStatusAnnotation(hasPRTBs bool, namespace *v1.Namespace, mgr *manager) {
 	if _, ok := namespace.Annotations[projectIDAnnotation]; ok {
 		for i := 0; i < 10; i++ {
 			time.Sleep(time.Millisecond * 500)


### PR DESCRIPTION
Problem:
Ocassionally we see panics in our builds bc of a concurrent read/write
on the namespace's annotation property

Solution:
Deep copy the namespace so that there is no chance of the concurrent
read/write

https://github.com/rancher/rancher/issues/16891


this is the panic we see:
```
runtime.throw(0x3437b44, 0x21)
	/usr/local/Cellar/go/1.11.1/libexec/src/runtime/panic.go:608 +0x72 fp=0xc006ace440 sp=0xc006ace410 pc=0x102e112
runtime.mapaccess2_faststr(0x2ee5560, 0xc0061128d0, 0x34245a8, 0x19, 0x0, 0x0)
	/usr/local/Cellar/go/1.11.1/libexec/src/runtime/map_faststr.go:110 +0x458 fp=0xc006ace4b0 sp=0xc006ace440 pc=0x1014608
github.com/rancher/rancher/pkg/controllers/user/rbac.updateStatusAnnotation(0x0, 0xc0039bd330, 0x9, 0xc0039bd318, 0x2, 0xc0039bd340, 0x7, 0x0, 0x0, 0x0, ...)
	/Users/nathanieljenan/go/src/github.com/rancher/rancher/pkg/controllers/user/rbac/namespace_handler.go:404 +0x64 fp=0xc006ace6a0 sp=0xc006ace4b0 pc=0x21fa6f4
runtime.goexit()
	/usr/local/Cellar/go/1.11.1/libexec/src/runtime/asm_amd64.s:1333 +0x1 fp=0xc006ace6a8 sp=0xc006ace6a0 pc=0x105e1d1
created by github.com/rancher/rancher/pkg/controllers/user/rbac.(*nsLifecycle).Create
	/Users/nathanieljenan/go/src/github.com/rancher/rancher/pkg/controllers/user/rbac/namespace_handler.go:66 +0x19b
```