### PR TITLE
Use no cache in pipeline log api handler

### DIFF
--- a/pkg/api/customization/pipeline/pipeline_execution_log.go
+++ b/pkg/api/customization/pipeline/pipeline_execution_log.go
@@ -55,7 +55,7 @@ func (h *ExecutionHandler) handleLog(apiContext *types.APIContext) error {
 		return err
 	}
 
-	pipelineEngine := engine.New(userContext)
+	pipelineEngine := engine.New(userContext, false)
 
 	c, err := upgrader.Upgrade(apiContext.Response, apiContext.Request, nil)
 	if err != nil {

--- a/pkg/controllers/user/pipeline/controller/pipelineexecution/pipelineexecution.go
+++ b/pkg/controllers/user/pipeline/controller/pipelineexecution/pipelineexecution.go
@@ -122,7 +122,7 @@ func Register(ctx context.Context, cluster *config.UserContext) {
 	sourceCodeCredentialLister := cluster.Management.Project.SourceCodeCredentials("").Controller().Lister()
 	notifierLister := cluster.Management.Management.Notifiers("").Controller().Lister()
 
-	pipelineEngine := engine.New(cluster)
+	pipelineEngine := engine.New(cluster, true)
 	pipelineExecutionLifecycle := &Lifecycle{
 		namespaces:          namespaces,
 		namespaceLister:     namespaceLister,

--- a/pkg/pipeline/engine/engine.go
+++ b/pkg/pipeline/engine/engine.go
@@ -15,7 +15,7 @@ type PipelineEngine interface {
 	SyncExecution(execution *v3.PipelineExecution) (bool, error)
 }
 
-func New(cluster *config.UserContext) PipelineEngine {
+func New(cluster *config.UserContext, useCache bool) PipelineEngine {
 	serviceLister := cluster.Core.Services("").Controller().Lister()
 	podLister := cluster.Core.Pods("").Controller().Lister()
 	secrets := cluster.Core.Secrets("")
@@ -27,6 +27,7 @@ func New(cluster *config.UserContext) PipelineEngine {
 	dialer := cluster.Management.Dialer
 
 	engine := &jenkins.Engine{
+		UseCache:                   useCache,
 		ServiceLister:              serviceLister,
 		PodLister:                  podLister,
 		Secrets:                    secrets,

--- a/pkg/pipeline/engine/jenkins/engine.go
+++ b/pkg/pipeline/engine/jenkins/engine.go
@@ -30,6 +30,8 @@ import (
 )
 
 type Engine struct {
+	// UseCache affects resources that is not cached in follower instances of HA mode
+	UseCache         bool
 	JenkinsClient    *Client
 	HTTPClient       *http.Client
 	ServiceLister    v1.ServiceLister
@@ -88,7 +90,12 @@ func (j *Engine) getJenkinsClient(execution *v3.PipelineExecution) (*Client, err
 	}
 	user := utils.PipelineSecretDefaultUser
 	ns := utils.GetPipelineCommonName(execution)
-	secret, err := j.SecretLister.Get(ns, utils.PipelineSecretName)
+	var secret *corev1.Secret
+	if j.UseCache {
+		secret, err = j.SecretLister.Get(ns, utils.PipelineSecretName)
+	} else {
+		secret, err = j.Secrets.GetNamespaced(ns, utils.PipelineSecretName, metav1.GetOptions{})
+	}
 	if err != nil || secret.Data == nil {
 		return nil, fmt.Errorf("error get jenkins token - %v", err)
 	}


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/17079

Problem:
Fail to fetch pipeline log when api is handled by follower instance in HA install

Solution:
Use no cache when querying cluster resources in api handlers