### PR TITLE
Fix rke cluster provision issue

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -360,7 +360,15 @@ func skipProvisioning(cluster *v3.Cluster) bool {
 func (p *Provisioner) getConfig(reconcileRKE bool, spec v3.ClusterSpec, driverName, clusterName string) (*v3.ClusterSpec, interface{}, error) {
 	var v interface{}
 	if spec.GenericEngineConfig == nil {
-		v = map[string]interface{}{}
+		if spec.RancherKubernetesEngineConfig != nil {
+			var err error
+			v, err = convert.EncodeToMap(spec.RancherKubernetesEngineConfig)
+			if err != nil {
+				return nil, nil, err
+			}
+		} else {
+			v = map[string]interface{}{}
+		}
 	} else {
 		v = *spec.GenericEngineConfig
 	}


### PR DESCRIPTION
**Problem:**
RKE cluster provisioned by Rancher keep firing provision log like
```
Provisioning cluster [xxx]
Updating cluster [xxx]
Provisioned cluster [xxx]
```
Because cluster resource object is being updated by cluster provisioner

**Solution:**
As commit

**Issue**
https://github.com/rancher/rancher/issues/16955