### PR TITLE
Add resource configurations for pipeline pods

### DIFF
--- a/pkg/controllers/user/pipeline/controller/pipelineexecution/deploy.go
+++ b/pkg/controllers/user/pipeline/controller/pipelineexecution/deploy.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -459,6 +460,16 @@ func GetJenkinsDeployment(ns string) *appsv1beta2.Deployment {
 									},
 								},
 							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(1024E6, resource.BinarySI),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(300E6, resource.BinarySI),
+								},
+							},
 						},
 					},
 				},
@@ -561,6 +572,16 @@ func GetRegistryDeployment(ns string) *appsv1beta2.Deployment {
 								{
 									Name:  "REGISTRY_AUTH_HTPASSWD_PATH",
 									Value: utils.RegistryAuthPath + utils.PipelineSecretRegistryTokenKey,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(200E6, resource.BinarySI),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(100E6, resource.BinarySI),
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -828,6 +849,16 @@ func GetMinioDeployment(ns string) *appsv1beta2.Deployment {
 								{
 									Name:          utils.MinioName,
 									ContainerPort: utils.MinioPort,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(200E6, resource.BinarySI),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(100E6, resource.BinarySI),
 								},
 							},
 						},

--- a/pkg/controllers/user/pipeline/controller/project/project.go
+++ b/pkg/controllers/user/pipeline/controller/project/project.go
@@ -23,9 +23,13 @@ import (
 // provider configs & pipeline settings for projects.
 
 var settings = map[string]string{
-	utils.SettingExecutorQuota:   utils.SettingExecutorQuotaDefault,
-	utils.SettingSigningDuration: utils.SettingSigningDurationDefault,
-	utils.SettingGitCaCerts:      "",
+	utils.SettingExecutorQuota:         utils.SettingExecutorQuotaDefault,
+	utils.SettingSigningDuration:       utils.SettingSigningDurationDefault,
+	utils.SettingGitCaCerts:            "",
+	utils.SettingExecutorMemoryRequest: utils.SettingExecutorMemoryRequestDefault,
+	utils.SettingExecutorMemoryLimit:   utils.SettingExecutorMemoryLimitDefault,
+	utils.SettingExecutorCPURequest:    utils.SettingExecutorCPURequestDefault,
+	utils.SettingExecutorCPULimit:      utils.SettingExecutorCPULimitDefault,
 }
 
 func Register(ctx context.Context, cluster *config.UserContext) {

--- a/pkg/pipeline/utils/constants.go
+++ b/pkg/pipeline/utils/constants.go
@@ -94,11 +94,28 @@ const (
 	EnvImageRepo         = "CICD_IMAGE_REPO"
 	EnvLocalRegistry     = "CICD_LOCAL_REGISTRY"
 
-	SettingExecutorQuota          = "executor-quota"
-	SettingExecutorQuotaDefault   = "2"
-	SettingSigningDuration        = "registry-signing-duration"
-	SettingSigningDurationDefault = "2160h"
-	SettingGitCaCerts             = "git-cacerts"
+	SettingExecutorQuota                = "executor-quota"
+	SettingExecutorQuotaDefault         = "2"
+	SettingSigningDuration              = "registry-signing-duration"
+	SettingSigningDurationDefault       = "2160h"
+	SettingGitCaCerts                   = "git-cacerts"
+	SettingExecutorMemoryRequest        = "executor-memory-request"
+	SettingExecutorMemoryRequestDefault = "10Mi"
+	SettingExecutorMemoryLimit          = "executor-memory-limit"
+	SettingExecutorMemoryLimitDefault   = "1Gi"
+	SettingExecutorCPURequest           = "executor-cpu-request"
+	SettingExecutorCPURequestDefault    = "10m"
+	SettingExecutorCPULimit             = "executor-cpu-limit"
+	SettingExecutorCPULimitDefault      = "1"
+
+	PipelineToolsMemoryRequestDefault = "10Mi"
+	PipelineToolsMemoryLimitDefault   = "100Mi"
+	PipelineToolsCPURequestDefault    = "10m"
+	PipelineToolsCPULimitDefault      = "300m"
+	StepMemoryRequestDefault          = "10Mi"
+	StepMemoryLimitDefault            = "1Gi"
+	StepCPURequestDefault             = "10m"
+	StepCPULimitDefault               = "1"
 
 	DefaultTimeout = 60
 )

--- a/vendor.conf
+++ b/vendor.conf
@@ -42,7 +42,7 @@ github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f6841
 github.com/rancher/norman                     0557aa4ff31a3a0f007dcb1b684894f23cda390c
 github.com/rancher/kontainer-engine           76256b60bcfa9346ab64d22c14106b500a6cd052
 github.com/rancher/rke                        3094ac132d12085f48a1e96ff0f0461d6830f5fe
-github.com/rancher/types                      0ad2733a324500ce758d01befaa836109b77c0ab
+github.com/rancher/types                      c021df3ec2d7ce29cbca599cf5dca032101d0257
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/pipeline_types.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/pipeline_types.go
@@ -233,10 +233,14 @@ type Step struct {
 	PublishCatalogConfig *PublishCatalogConfig `json:"publishCatalogConfig,omitempty" yaml:"publishCatalogConfig,omitempty"`
 	ApplyAppConfig       *ApplyAppConfig       `json:"applyAppConfig,omitempty" yaml:"applyAppConfig,omitempty"`
 
-	Env        map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
-	EnvFrom    []EnvFrom         `json:"envFrom,omitempty" yaml:"envFrom,omitempty"`
-	Privileged bool              `json:"privileged,omitempty" yaml:"privileged,omitempty"`
-	When       *Constraints      `json:"when,omitempty" yaml:"when,omitempty"`
+	Env           map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
+	EnvFrom       []EnvFrom         `json:"envFrom,omitempty" yaml:"envFrom,omitempty"`
+	Privileged    bool              `json:"privileged,omitempty" yaml:"privileged,omitempty"`
+	CPURequest    string            `json:"cpuRequest,omitempty" yaml:"cpuRequest,omitempty"`
+	CPULimit      string            `json:"cpuLimit,omitempty" yaml:"cpuLimit,omitempty"`
+	MemoryRequest string            `json:"memoryRequest,omitempty" yaml:"memoryRequest,omitempty"`
+	MemoryLimit   string            `json:"memoryLimit,omitempty" yaml:"memoryLimit,omitempty"`
+	When          *Constraints      `json:"when,omitempty" yaml:"when,omitempty"`
 }
 
 type Constraints struct {

--- a/vendor/github.com/rancher/types/client/project/v3/zz_generated_step.go
+++ b/vendor/github.com/rancher/types/client/project/v3/zz_generated_step.go
@@ -4,8 +4,12 @@ const (
 	StepType                      = "step"
 	StepFieldApplyAppConfig       = "applyAppConfig"
 	StepFieldApplyYamlConfig      = "applyYamlConfig"
+	StepFieldCPULimit             = "cpuLimit"
+	StepFieldCPURequest           = "cpuRequest"
 	StepFieldEnv                  = "env"
 	StepFieldEnvFrom              = "envFrom"
+	StepFieldMemoryLimit          = "memoryLimit"
+	StepFieldMemoryRequest        = "memoryRequest"
 	StepFieldPrivileged           = "privileged"
 	StepFieldPublishCatalogConfig = "publishCatalogConfig"
 	StepFieldPublishImageConfig   = "publishImageConfig"
@@ -17,8 +21,12 @@ const (
 type Step struct {
 	ApplyAppConfig       *ApplyAppConfig       `json:"applyAppConfig,omitempty" yaml:"applyAppConfig,omitempty"`
 	ApplyYamlConfig      *ApplyYamlConfig      `json:"applyYamlConfig,omitempty" yaml:"applyYamlConfig,omitempty"`
+	CPULimit             string                `json:"cpuLimit,omitempty" yaml:"cpuLimit,omitempty"`
+	CPURequest           string                `json:"cpuRequest,omitempty" yaml:"cpuRequest,omitempty"`
 	Env                  map[string]string     `json:"env,omitempty" yaml:"env,omitempty"`
 	EnvFrom              []EnvFrom             `json:"envFrom,omitempty" yaml:"envFrom,omitempty"`
+	MemoryLimit          string                `json:"memoryLimit,omitempty" yaml:"memoryLimit,omitempty"`
+	MemoryRequest        string                `json:"memoryRequest,omitempty" yaml:"memoryRequest,omitempty"`
 	Privileged           bool                  `json:"privileged,omitempty" yaml:"privileged,omitempty"`
 	PublishCatalogConfig *PublishCatalogConfig `json:"publishCatalogConfig,omitempty" yaml:"publishCatalogConfig,omitempty"`
 	PublishImageConfig   *PublishImageConfig   `json:"publishImageConfig,omitempty" yaml:"publishImageConfig,omitempty"`


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/16538

Problem:
    Pipeline components fail to run when project resource quota is set.

Solution:
    Add resource configurations for pipeline components, 
    Add relevant settings for agent container.
    Add configurations for pipeline step so that users have fine-grained control for each container in the build pod.

Notes:
1. Users change the default resource configurations of pipeline components by editing the workloads. It can be done by updating answers once pipeline components are moved to a system app.
2. ~~The resource configurations of build pods apply to every container in the pod.~~

Related types pr: https://github.com/rancher/types/pull/687