### PR TITLE
Create a codefresh.yml file 

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -1,0 +1,126 @@
+version: '1.0'
+stages:
+  - Pre-build
+  - Build
+  - Build-images
+  - Push-images
+  - Github-pre-release
+  - Github-release
+  
+steps:
+
+  build_dapper:
+    type: build
+    image_name: dapper
+    build_arguments:
+      - DAPPER_HOST_ARCH=amd64
+    dockerfile: ./Dockerfile.dapper
+    stage: Pre-build
+    
+  build:
+    image: ${{build_dapper}}
+    working_directory: IMAGE_WORK_DIR
+    commands:
+      - rm -r /go/src/github.com/rancher/rancher
+      - ln -s /codefresh/volume/rancher -T /go/src/github.com/rancher/rancher # make a symlink to Codefresh volume from the GOPATH
+      - cd /go/src/github.com/rancher/rancher
+      - ./scripts/entry ci
+    stage: Build
+      
+  stage_binaries:
+    image: rancher/dapper:1.11.2
+    commands:
+      - cp -r ./bin/* ./package/
+    when:
+      condition:
+        any:
+          pushEvent: 'match("${{CF_BRANCH}}", "^master$|release\/.*|^alpha$", false) == true'
+          tagEvent: 'match("${{CF_BASE_BRANCH}}", "^master$|release\/.*|rc", false) == true'
+    stage: Build-images
+    
+  build_images:
+    type: parallel
+    steps:     
+      docker_build_master:
+        type: build
+        image_name: rancher
+        dockerfile: Dockerfile
+        working_directory: './package'
+        build_arguments:
+          - VERSION=master
+        tag: master
+        when:
+         condition:
+           any:
+            pushEvent: 'match("${{CF_BRANCH}}", "master", false) == true'
+            tagEvent: 'match("${{CF_BASE_BRANCH}}", "^master$|release\/.*|^alpha$|rc", false) == true'
+        stage: Build-images
+        
+      docker_build_agent:
+        type: build
+        image_name: rancher-agent
+        dockerfile: Dockerfile.agent
+        working_directory: './package'
+        build_arguments:
+         - VERSION=master
+        tag: master
+        when:
+         condition:
+           any:
+              pushEvent: 'match("${{CF_BRANCH}}", "master", false) == true'
+              tagEvent: 'match("${{CF_BASE_BRANCH}}", "^master$|release\/.*|^alpha$|rc", false) == true'
+        stage: Build-images
+  
+  push_images:
+    type: parallel
+    steps:
+      docker_push_master:
+        type: push
+        candidate: ${{docker_build_master}}
+        image_name: rancher/rancher  
+        tag: ${{CF_BRANCH_TAG_NORMALIZED}}
+        registry: dockerhub
+        when:
+          condition:
+           any:
+              pushEvent: 'match("${{CF_BRANCH}}", "master", false) == true'
+              tagEvent: 'match("${{CF_BASE_BRANCH}}", "^master$|release\/.*|^alpha$|rc", false) == true'
+        stage: Push-images
+        
+      docker_push_agent:
+        type: push
+        candidate: ${{docker_build_agent}}
+        image_name: rancher/rancher-agent  
+        tag: ${{CF_BRANCH_TAG_NORMALIZED}}
+        registry: dockerhub
+        when:
+          condition:
+           any:
+              pushEvent: 'match("${{CF_BRANCH}}", "master", false) == true'
+              tagEvent: 'match("${{CF_BASE_BRANCH}}", "^master$|release\/.*|^alpha$|rc", false) == true'
+        stage: Push-images
+
+  github_binary_prerelease:
+    image: codefresh/cfstep-github-release
+    environment:
+      - GITHUB_TOKEN=${{GITHUB_TOKEN}}
+      - FILES=bin/rancher-*
+      - PRERELEASE=true
+    when:
+      condition:
+        all:
+          tagName: 'match("${{CF_BRANCH}}", "rc|alpha", false) == true'
+          tagBaseBranch: 'match("${{CF_BASE_BRANCH}}", "^master$|release\/.*|^alpha$|rc", false) == true'
+    stage: Github-pre-release
+    
+  github_binary_release:
+    image: codefresh/cfstep-github-release
+    environment:
+      - GITHUB_TOKEN=${{GITHUB_TOKEN}}
+      - FILES=bin/rancher-*
+    when:
+      condition:
+        all:
+          tagName: '!match("${{CF_BRANCH}}", "rc|alpha", false) == true'
+          tagBaseBranch: 'match("${{CF_BASE_BRANCH}}", "^master$|release\/.*|rc", false) == true'
+    stage: Github-release


### PR DESCRIPTION
The YAML file describing a Codefresh pipeline

# A comment to the pipeline

The logic of the pipeline is similar to the one in the drone pipeline

### Pipeline Trigger:
* According to the logic of the drone pipeline, the pipeline must be triggered by github "push"  or "tag" events. 

### Stages: 

#### Stage: Pre-build
* Builds the image that the Dapper tool would build to be used later as build environment. No specific trigger conditions

#### Stage: Build
* Builds code and performs local testing against virtual Kubernetes cluster. Uses the image prepared with the "dapper" in the previous step as build environment. It is comprised a lot of bash, python scripting and even of golang code. Kind of a black box to me, but seems to work correctly with the changes in terms of the Codefresh pipeline.
* No specific trigger conditions
* Requires access to the docker daemon

#### Stage: Build-images
* Builds rancher master and rancher agent docker images.
* Triggered in case if the branch is master,  release/* or alpha on the "push" or "tag" github events
* Images are built *in parallel*

#### Stage: Push-images
* Pushes images to dockerhub. The registry integration point name must be specified 
* Triggered in case if the branch is master,  release/* or alpha on the "push" or "tag" github events. If github event is "push", an image is tagged with "master". If the event is "tag", the image is tagged with the git tag
*Images are pushed *in parallel*

#### Stage: Github-pre-release
* Creates a github pre-release
* Triggered in case if the branch is master,  release/* or alpha only on the github "tag" event, If the tag name contains "rc" (release candidate) or "alpha"

#### Stage: Github-release
* Creates a github release
* Triggered in case if the branch is master,  release/* only on the github "tag" event, If the tag name NOT contains "rc" (release candidate) or "alpha"

### Gaps uncovered
Currently Codefresh lacks the ability to setup step conditions based on github events. To achieve that here is used the $CF_BASE_BRANCH variable, which contains the name of the base branch in case if pipeline was triggered by a tag event, otherwise contains nothing.