### PR TITLE
Fix several auth refresh bugs.

### DIFF
--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -109,9 +109,14 @@ func (p *adProvider) RefetchGroupPrincipals(principalID string, secret string) (
 		return nil, err
 	}
 
-	samName := principalID
-	if strings.Contains(principalID, `\`) {
-		samName = strings.SplitN(principalID, `\`, 2)[1]
+	externalID, _, err := p.getDNAndScopeFromPrincipalID(principalID)
+	if err != nil {
+		return nil, err
+	}
+
+	samName := externalID
+	if strings.Contains(externalID, `\`) {
+		samName = strings.SplitN(externalID, `\`, 2)[1]
 	}
 	query := fmt.Sprintf("(%v=%v)", config.UserLoginAttribute, ldapv2.EscapeFilter(samName))
 	logrus.Debugf("LDAP Search query: {%s}", query)

--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -428,5 +428,5 @@ func (l *Provider) CanAccessWithGroupProviders(userPrincipalID string, groupPrin
 	if err != nil {
 		return false, err
 	}
-	return user.Name != "", nil
+	return user.Username != "", nil
 }

--- a/pkg/controllers/management/auth/register.go
+++ b/pkg/controllers/management/auth/register.go
@@ -14,6 +14,7 @@ func RegisterEarly(ctx context.Context, management *config.ManagementContext) {
 	u := newUserLifecycle(management)
 	n := newTokenController(management)
 	ua := newUserAttributeController(management)
+	s := newAuthSettingController(management)
 
 	management.Management.ProjectRoleTemplateBindings("").AddLifecycle(ctx, ptrbMGMTController, prtb)
 	management.Management.ClusterRoleTemplateBindings("").AddLifecycle(ctx, ctrbMGMTController, crtb)
@@ -24,6 +25,7 @@ func RegisterEarly(ctx context.Context, management *config.ManagementContext) {
 	management.Management.Users("").AddLifecycle(ctx, userController, u)
 	management.Management.Tokens("").AddHandler(ctx, tokenController, n.sync)
 	management.Management.UserAttributes("").AddHandler(ctx, userAttributeController, ua.sync)
+	management.Management.Settings("").AddHandler(ctx, authSettingController, s.sync)
 }
 
 func RegisterLate(ctx context.Context, management *config.ManagementContext) {

--- a/pkg/controllers/management/auth/setting.go
+++ b/pkg/controllers/management/auth/setting.go
@@ -7,11 +7,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	authSettingController = "mgmt-auth-settings-controller"
+)
+
 type SettingController struct {
 	settings v3.SettingInterface
 }
 
-func newSettingController(mgmt *config.ManagementContext) *SettingController {
+func newAuthSettingController(mgmt *config.ManagementContext) *SettingController {
 	n := &SettingController{
 		settings: mgmt.Management.Settings(""),
 	}


### PR DESCRIPTION
See: https://github.com/rancherlabs/rancher-security/issues/40, https://github.com/rancherlabs/rancher-security/issues/44

Fixes a bug on AD refresh, prevents local auth from sometimes blocking refresh on long-lived tokens, and fixes a bug where auth-refresh related settings wouldn't actually take effect on change. 