### PR TITLE
Cluster agent controllers should only run once

### DIFF
--- a/pkg/agent/cluster/controllers.go
+++ b/pkg/agent/cluster/controllers.go
@@ -9,7 +9,13 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+var running bool
+
 func RunControllers() error {
+	if running {
+		return nil
+	}
+
 	logrus.Info("Starting user controllers")
 	c, err := rest.InClusterConfig()
 	if err != nil {
@@ -31,5 +37,6 @@ func RunControllers() error {
 		return err
 	}
 
+	running = true
 	return nil
 }


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/17148