### PR TITLE
Fix cluster provisioning killed by system users being logged out. 

### DIFF
--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -428,5 +428,16 @@ func (l *Provider) CanAccessWithGroupProviders(userPrincipalID string, groupPrin
 	if err != nil {
 		return false, err
 	}
-	return user.Username != "", nil
+
+	if user.Username != "" {
+		return true, nil
+	}
+
+	for _, principalID := range user.PrincipalIDs {
+		if strings.HasPrefix(principalID, "system://") {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
Fixes an issue where system users are logged out due to not having a `user.Username`