### PR TITLE
Set `ui-index` setting to local if rancher version is formal

### DIFF
--- a/pkg/api/customization/setting/setting.go
+++ b/pkg/api/customization/setting/setting.go
@@ -3,12 +3,15 @@ package setting
 import (
 	"fmt"
 
+	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
+	v3client "github.com/rancher/types/client/management/v3"
 )
 
-func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
+func PipelineFormatter(apiContext *types.APIContext, resource *types.RawResource) {
 	v, ok := resource.Values["value"]
 	if !ok || v == "" {
 		resource.Values["value"] = resource.Values["default"]
@@ -18,7 +21,21 @@ func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 	}
 }
 
+func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
+	if convert.ToString(resource.Values["source"]) == "env" {
+		delete(resource.Links, "update")
+	}
+}
+
 func Validator(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
+	var setting v3client.Setting
+	if err := access.ByID(request, request.Version, v3client.SettingType, request.ID, &setting); err != nil {
+		return err
+	}
+	if setting.Source == "env" {
+		return httperror.NewAPIError(httperror.MethodNotAllowed, fmt.Sprintf("%s is readOnly because its value is from environment variable", request.ID))
+	}
+
 	newValue, ok := data["value"]
 	if !ok {
 		return fmt.Errorf("value not found")

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"strings"
-
 	normanapi "github.com/rancher/norman/api"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/settings"
@@ -18,14 +16,14 @@ func NewServer(schemas *types.Schemas) (*normanapi.Server, error) {
 }
 
 func cssURL() string {
-	if !strings.HasPrefix(settings.ServerVersion.Get(), "v") {
+	if settings.UIIndex.Get() != "local" {
 		return ""
 	}
 	return "/api-ui/ui.min.css"
 }
 
 func jsURL() string {
-	if !strings.HasPrefix(settings.ServerVersion.Get(), "v") {
+	if settings.UIIndex.Get() != "local" {
 		return ""
 	}
 	return "/api-ui/ui.min.js"

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -37,6 +37,7 @@ import (
 	passwordStore "github.com/rancher/rancher/pkg/api/store/password"
 	"github.com/rancher/rancher/pkg/api/store/preference"
 	"github.com/rancher/rancher/pkg/api/store/scoped"
+	settingstore "github.com/rancher/rancher/pkg/api/store/setting"
 	"github.com/rancher/rancher/pkg/api/store/userscope"
 	"github.com/rancher/rancher/pkg/auth/principals"
 	"github.com/rancher/rancher/pkg/auth/providers"
@@ -412,6 +413,7 @@ func Setting(schemas *types.Schemas) {
 	schema := schemas.Schema(&managementschema.Version, client.SettingType)
 	schema.Formatter = setting.Formatter
 	schema.Validator = setting.Validator
+	schema.Store = settingstore.New(schema.Store)
 }
 
 func LoggingTypes(schemas *types.Schemas, management *config.ScaledContext, clusterManager *clustermanager.Manager, k8sProxy http.Handler) {
@@ -506,7 +508,7 @@ func Pipeline(schemas *types.Schemas, management *config.ScaledContext, clusterM
 	schema.ActionHandler = pipelineExecutionHandler.ActionHandler
 
 	schema = schemas.Schema(&projectschema.Version, projectclient.PipelineSettingType)
-	schema.Formatter = setting.Formatter
+	schema.Formatter = setting.PipelineFormatter
 
 	sourceCodeCredentialHandler := &pipeline.SourceCodeCredentialHandler{
 		SourceCodeCredentials:      management.Project.SourceCodeCredentials(""),

--- a/pkg/api/store/setting/store.go
+++ b/pkg/api/store/setting/store.go
@@ -1,0 +1,34 @@
+package setting
+
+import (
+	"os"
+
+	"github.com/rancher/norman/store/transform"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/pkg/settings"
+)
+
+func New(store types.Store) types.Store {
+	return &transform.Store{
+		Store: store,
+		Transformer: func(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, opt *types.QueryOptions) (map[string]interface{}, error) {
+			v, ok := data["value"]
+			value := os.Getenv(settings.GetENVKey(apiContext.ID))
+			switch {
+			case value != "":
+				data["value"] = value
+				data["customized"] = false
+				data["source"] = "env"
+
+			case !ok || v == "":
+				data["value"] = data["default"]
+				data["customized"] = false
+				data["source"] = "default"
+			default:
+				data["customized"] = true
+				data["source"] = "db"
+			}
+			return data, nil
+		},
+	}
+}

--- a/pkg/settings/generator/main.go
+++ b/pkg/settings/generator/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/rancher/rancher/pkg/settings"
+)
+
+type dummyProvider struct {
+	settings map[string]string
+}
+
+func (d *dummyProvider) Get(name string) string {
+	return ""
+}
+
+func (d *dummyProvider) Set(name, value string) error {
+	return nil
+}
+
+func (d *dummyProvider) SetIfUnset(name, value string) error {
+	return nil
+}
+
+func (d *dummyProvider) SetAll(settings map[string]settings.Setting) error {
+	for name := range settings {
+		key := "CATTLE_" + strings.ToUpper(strings.Replace(name, "-", "_", -1)) + "_DEFAULT"
+		d.settings[key] = name
+	}
+	return nil
+}
+
+/*
+The goal of this function is to fetch the default value of settings
+from environment variable and return as json to stdout.
+The return json should be set to the building parameters
+`pkg/settings.InjectDefaults` of Rancher and `InjectDefaults` will
+be loaded and override the default value of the settings when Rancher
+is initializing.
+*/
+func main() {
+	provider := &dummyProvider{
+		settings: map[string]string{},
+	}
+	settings.SetProvider(provider)
+	output := map[string]string{}
+	for key, name := range provider.settings {
+		value := os.Getenv(key)
+		if value == "" {
+			continue
+		}
+		output[name] = value
+	}
+	data, _ := json.Marshal(output)
+	os.Stdout.Write(data)
+}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -3,14 +3,15 @@ package settings
 import (
 	"encoding/json"
 	"os"
+	"strings"
 
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 )
 
 var (
-	settings   = map[string]Setting{}
-	provider   Provider
-	RKEVersion string
+	settings       = map[string]Setting{}
+	provider       Provider
+	InjectDefaults string
 
 	AgentImage                      = NewSetting("agent-image", "rancher/rancher-agent:master")
 	AuthImage                       = NewSetting("auth-image", "erikwilson/kube-api-auth:latest") // FIXME: Update to Rancher image when released
@@ -33,7 +34,7 @@ var (
 	Namespace                       = NewSetting("namespace", os.Getenv("CATTLE_NAMESPACE"))
 	PeerServices                    = NewSetting("peer-service", os.Getenv("CATTLE_PEER_SERVICE"))
 	RDNSServerBaseURL               = NewSetting("rdns-base-url", "https://api.lb.rancher.cloud/v1")
-	RkeVersion                      = NewSetting("rke-version", RKEVersion)
+	RkeVersion                      = NewSetting("rke-version", "")
 	ServerImage                     = NewSetting("server-image", "rancher/rancher")
 	ServerURL                       = NewSetting("server-url", "")
 	ServerVersion                   = NewSetting("server-version", "dev")
@@ -52,6 +53,24 @@ var (
 	AuthUserInfoMaxAgeSeconds       = NewSetting("auth-user-info-max-age-seconds", "3600") // 1 hour
 	APIUIVersion                    = NewSetting("api-ui-version", "1.1.6")                // Please update the CATTLE_API_UI_VERSION in package/Dockerfile when updating the version here.
 )
+
+func init() {
+	if InjectDefaults == "" {
+		return
+	}
+	defaults := map[string]string{}
+	if err := json.Unmarshal([]byte(InjectDefaults), &defaults); err != nil {
+		return
+	}
+	for name, defaultValue := range defaults {
+		value, ok := settings[name]
+		if !ok {
+			continue
+		}
+		value.Default = defaultValue
+		settings[name] = value
+	}
+}
 
 type Provider interface {
 	Get(name string) string
@@ -122,4 +141,8 @@ func getSystemImages() string {
 		return ""
 	}
 	return string(data)
+}
+
+func GetENVKey(key string) string {
+	return "CATTLE_" + strings.ToUpper(strings.Replace(key, "-", "_", -1))
 }

--- a/scripts/build-server
+++ b/scripts/build-server
@@ -8,6 +8,6 @@ cd $(dirname $0)/..
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
 
-RKE_VERSION=$(grep -m1 '^github.com/rancher/rke' vendor.conf | awk '{print $2}')
+DEFAULT_VERSIONS=`go run ./pkg/settings/generator/main.go`
 
-CGO_ENABLED=0 go build -i -tags k8s -ldflags "-X main.VERSION=$VERSION -X github.com/rancher/rancher/pkg/settings.RKEVersion=$RKE_VERSION $LINKFLAGS" -o bin/rancher
+CGO_ENABLED=0 go build -i -tags k8s -ldflags "-X main.VERSION=$VERSION -X github.com/rancher/rancher/pkg/settings.InjectDefaults=$DEFAULT_VERSIONS $LINKFLAGS" -o bin/rancher

--- a/scripts/version
+++ b/scripts/version
@@ -49,3 +49,14 @@ echo "ARCH: $ARCH"
 echo "CHART_REPO: $CHART_REPO"
 echo "CHART_VERSION: $CHART_VERSION"
 echo "VERSION: $VERSION"
+
+if echo "$TAG" | grep -q -e '^v.*' ; then 
+    UI_INDEX="local"
+fi
+
+pushd $(dirname $0)/.. > /dev/null
+# Settings default value
+CATTLE_UI_INDEX_DEFAULT=${UI_INDEX:-"https://releases.rancher.com/ui/latest2/index.html"}
+CATTLE_RKE_VERSION_DEFAULT="$(grep -m1 '^github.com/rancher/rke' vendor.conf | awk '{print $2}')"
+
+popd > /dev/null

--- a/server/ui/ui.go
+++ b/server/ui/ui.go
@@ -1,13 +1,11 @@
 package ui
 
 import (
+	"crypto/tls"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"crypto/tls"
 
 	"github.com/rancher/norman/parse"
 	"github.com/rancher/rancher/pkg/settings"
@@ -29,19 +27,11 @@ func Content() http.Handler {
 }
 
 func UI(next http.Handler) http.Handler {
-	local := false
 	_, err := os.Stat(indexHTML())
-	if err == nil {
-		local = true
-	}
-
-	if local && !strings.HasPrefix(settings.ServerVersion.Get(), "v") {
-		local = false
-	}
-
+	local := err == nil
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if parse.IsBrowser(req, true) {
-			if local {
+			if local && settings.UIIndex.Get() == "local" {
 				http.ServeFile(resp, req, indexHTML())
 			} else {
 				ui(resp, req)


### PR DESCRIPTION
**Problem:**
For now, we don't respect the `ui-index` setting in formal
rancher version. There is no way for users to customize their UI in
those version.
Restart rancher will reset the settings value to environment variable
even the setting has value already.

**Solution:**
- Set the default values of each settings when building Rancher. We can have different default for different Rancher server version.
- ~Use `local` value in `ui-index` setting when it is a formal version. And Use CDN address when it is a dev version.~
- Set default value `local`  in `ui-index` setting when it is a formal version. And Use CDN address when it is a dev version.
- When `ui-index` setting is `local`, fetch UI and API-UI from file.
- ~Update the setting's value only when the value is empty. And the order should always be~
  - ~From DB~
  - ~From environment variable~
  - ~From Default~
- According to what @vincent99 suggests, the setting is readOnly when its value is come from environment variable.

**Types PR:**
https://github.com/rancher/types/pull/680

**Issue:**
https://github.com/rancher/rancher/issues/14392
https://github.com/rancher/rancher/issues/17312