### PR TITLE
[WIP]Fix the issue that catalog app cannot be removed if the creator user is deleted

### DIFF
--- a/pkg/controllers/user/helm/controller.go
+++ b/pkg/controllers/user/helm/controller.go
@@ -175,8 +175,8 @@ func (l *Lifecycle) Remove(obj *v3.App) (runtime.Object, error) {
 		return obj, err
 	}
 	defer os.RemoveAll(tempDir)
-	kubeConfigPath, err := l.writeKubeConfig(obj, tempDir)
-	if err != nil {
+	kubeConfigPath := os.ExpandEnv("$HOME/.kube/config")
+	if _, err := os.Stat(kubeConfigPath); err != nil {
 		return obj, err
 	}
 	// try three times and succeed


### PR DESCRIPTION
Problem:
Cannot delete/upgrade Rancher catalog apps when their creator user is deleted

Solution:
We can always use the admin user's kubeconfig in $HOME/.kube/config

https://github.com/rancher/rancher/issues/16274