### PR TITLE
bump kontainer-engine

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/types                      34d49d1c94ed7efc3d58adc4af855cedd9b87f55
 github.com/rancher/norman                     0557aa4ff31a3a0f007dcb1b684894f23cda390c
-github.com/rancher/kontainer-engine           c98af46881ad5034393fc42a15d374c7b5ee7305
+github.com/rancher/kontainer-engine           f5495908e7f8225d301316fd78a8fd3dfec803d2
 github.com/rancher/rke                        30d8c8a30ff421abc293eafaa233bce34b72d218
 
 gopkg.in/ldap.v2                              v2.5.0

--- a/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
@@ -307,6 +307,11 @@ func (d *Driver) createStack(svc *cloudformation.CloudFormation, name string, di
 					reason = *event.ResourceStatusReason
 					break
 				}
+
+				if *event.ResourceStatus == "ROLLBACK_IN_PROGRESS" {
+					reason = *event.ResourceStatusReason
+					// do not break so that CREATE_FAILED takes priority
+				}
 			}
 		}
 		return nil, fmt.Errorf("stack failed to create: %v", reason)


### PR DESCRIPTION
See: rancher/rancher#16786, https://github.com/rancher/kontainer-engine/pull/103

When handling errors in stack creation, sometimes there is no CREATE_FAILED event, and the reason is attached to the ROLLBACK_IN_PROGRESS event.

This change still allows CREATE_FAILED events to take priority.

