### PR TITLE
Support local chart app upgrade & rollback

### DIFF
--- a/pkg/controllers/user/helm/controller.go
+++ b/pkg/controllers/user/helm/controller.go
@@ -269,6 +269,8 @@ func (l *Lifecycle) createAppRevision(obj *v3.App, template, notes string, faile
 	release.Status.ProjectName = projectName
 	release.Status.ExternalID = obj.Spec.ExternalID
 	release.Status.ValuesYaml = obj.Spec.ValuesYaml
+	release.Status.Files = obj.Spec.Files
+
 	digest := sha256.New()
 	digest.Write([]byte(template))
 	tag := hex.EncodeToString(digest.Sum(nil))

--- a/vendor.conf
+++ b/vendor.conf
@@ -41,7 +41,7 @@ github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f6841
 github.com/rancher/norman                     362802224f64fd09a56be0d275f6ec1d7ecf2164
 github.com/rancher/kontainer-engine           391960fdb29300ebccda7b48e9ad44415782e0a5
 github.com/rancher/rke                        e6b677a885e2d38f4a1604d5ce2d4ae59883f072
-github.com/rancher/types                      6370ec9f4e38c80f3a8161990d1efa8622004ea5
+github.com/rancher/types                      9577885c7a5818696ff24e7a9fc5a5059692ed49
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1


### PR DESCRIPTION
**Problem:**
- Cannot upgrade local chart app
- Cannot rollback local chart app

**Solution:**
- Input local app templates when upgrading
- Record local app templates in `AppRevision`, restore them into `App` when rollbacking

**Issue:**
#15711

**Related PR:**
- https://github.com/rancher/types/pull/664
