### PR TITLE
remove cluster from password types

### DIFF
--- a/pkg/api/store/password/store.go
+++ b/pkg/api/store/password/store.go
@@ -47,7 +47,7 @@ func SetPasswordStore(schemas *types.Schemas, secretStore v1.SecretInterface, ns
 		nsStore:     nsStore,
 	}
 
-	pwdTypes := []string{"cluster"}
+	pwdTypes := []string{}
 
 	for _, storeType := range pwdTypes {
 		var schema *types.Schema


### PR DESCRIPTION
can't store password fields of cluster in secret, because dereferencing
and updating spec doesn't work if kontainer-engine doesn't use the same spec