### PR TITLE
Add service proxy access for manager service role

### DIFF
--- a/app/role_data.go
+++ b/app/role_data.go
@@ -232,7 +232,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("*").resources("ingresses").verbs("get", "list", "watch")
 
 	rb.addRoleTemplate("Manage Services", "services-manage", "project", true, false, false, false).
-		addRule().apiGroups("*").resources("services", "endpoints").verbs("*")
+		addRule().apiGroups("*").resources("services", "services/proxy", "endpoints").verbs("*")
 
 	rb.addRoleTemplate("View Services", "services-view", "project", true, false, false, false).
 		addRule().apiGroups("*").resources("services", "endpoints").verbs("get", "list", "watch")


### PR DESCRIPTION
Problem:

The base role of read-only is the default kubernetes role view. services/proxy is not in Kubernetes view role.

Solution:

Add service proxy access for manager service role

https://github.com/rancher/rancher/issues/16967