### PR TITLE
Refresh trigger action and settings validators

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -316,11 +316,13 @@ func SecretTypes(ctx context.Context, schemas *types.Schemas, management *config
 
 func User(schemas *types.Schemas, management *config.ScaledContext) {
 	schema := schemas.Schema(&managementschema.Version, client.UserType)
-	schema.Formatter = authn.UserFormatter
-	schema.CollectionFormatter = authn.CollectionFormatter
 	handler := &authn.Handler{
-		UserClient: management.Management.Users(""),
+		UserClient:               management.Management.Users(""),
+		GlobalRoleBindingsClient: management.Management.GlobalRoleBindings(""),
 	}
+
+	schema.Formatter = handler.UserFormatter
+	schema.CollectionFormatter = handler.CollectionFormatter
 	schema.ActionHandler = handler.Actions
 }
 
@@ -373,6 +375,7 @@ func App(schemas *types.Schemas, management *config.ScaledContext, kubeConfigGet
 func Setting(schemas *types.Schemas) {
 	schema := schemas.Schema(&managementschema.Version, client.SettingType)
 	schema.Formatter = setting.Formatter
+	schema.Validator = setting.Validator
 }
 
 func LoggingTypes(schemas *types.Schemas) {

--- a/pkg/auth/providerrefresh/refresh_daemon.go
+++ b/pkg/auth/providerrefresh/refresh_daemon.go
@@ -62,7 +62,7 @@ func UpdateRefreshCronTime(refreshCronTime string) {
 		return
 	}
 
-	parsed, err := parseCron(refreshCronTime)
+	parsed, err := ParseCron(refreshCronTime)
 	if err != nil {
 		logrus.Errorf("%v", err)
 		return
@@ -83,7 +83,7 @@ func UpdateRefreshMaxAge(maxAge string) {
 		return
 	}
 
-	parsed, err := parseMaxAge(maxAge)
+	parsed, err := ParseMaxAge(maxAge)
 	if err != nil {
 		logrus.Errorf("%v", err)
 		return
@@ -338,7 +338,7 @@ func (r *refresher) refreshAttributes(attribs *v3.UserAttribute) (*v3.UserAttrib
 	return attribs, nil
 }
 
-func parseMaxAge(setting string) (time.Duration, error) {
+func ParseMaxAge(setting string) (time.Duration, error) {
 	durString := fmt.Sprintf("%vs", setting)
 	dur, err := time.ParseDuration(durString)
 	if err != nil {
@@ -347,7 +347,7 @@ func parseMaxAge(setting string) (time.Duration, error) {
 	return dur, nil
 }
 
-func parseCron(setting string) (cron.Schedule, error) {
+func ParseCron(setting string) (cron.Schedule, error) {
 	if setting == "" {
 		return nil, nil
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -39,7 +39,7 @@ github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d756
 github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
-github.com/rancher/types                      fb9250553f32b398898d58b5e19631722c9e4a62
+github.com/rancher/types                      f58341a6c4ae09802505f0fc46f9cc2de5f3fd4f
 github.com/rancher/norman                     0557aa4ff31a3a0f007dcb1b684894f23cda390c
 github.com/rancher/kontainer-engine           1a64367368737271557abdac38b7582f689f78f6
 github.com/rancher/rke                        e79da956e948c16231d823715f1f0f7a297d8ef2

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema/schema.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema/schema.go
@@ -337,11 +337,13 @@ func authnTypes(schemas *types.Schemas) *types.Schemas {
 					Input:  "setPasswordInput",
 					Output: "user",
 				},
+				"refreshauthprovideraccess": {},
 			}
 			schema.CollectionActions = map[string]types.Action{
 				"changepassword": {
 					Input: "changePasswordInput",
 				},
+				"refreshauthprovideraccess": {},
 			}
 		}).
 		MustImportAndCustomize(&Version, v3.AuthConfig{}, func(schema *types.Schema) {

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_user.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_user.go
@@ -68,9 +68,13 @@ type UserOperations interface {
 	ByID(id string) (*User, error)
 	Delete(container *User) error
 
+	ActionRefreshauthprovideraccess(resource *User) error
+
 	ActionSetpassword(resource *User, input *SetPasswordInput) (*User, error)
 
 	CollectionActionChangepassword(resource *UserCollection, input *ChangePasswordInput) error
+
+	CollectionActionRefreshauthprovideraccess(resource *UserCollection) error
 }
 
 func newUserClient(apiClient *Client) *UserClient {
@@ -124,6 +128,11 @@ func (c *UserClient) Delete(container *User) error {
 	return c.apiClient.Ops.DoResourceDelete(UserType, &container.Resource)
 }
 
+func (c *UserClient) ActionRefreshauthprovideraccess(resource *User) error {
+	err := c.apiClient.Ops.DoAction(UserType, "refreshauthprovideraccess", &resource.Resource, nil, nil)
+	return err
+}
+
 func (c *UserClient) ActionSetpassword(resource *User, input *SetPasswordInput) (*User, error) {
 	resp := &User{}
 	err := c.apiClient.Ops.DoAction(UserType, "setpassword", &resource.Resource, input, resp)
@@ -132,5 +141,10 @@ func (c *UserClient) ActionSetpassword(resource *User, input *SetPasswordInput) 
 
 func (c *UserClient) CollectionActionChangepassword(resource *UserCollection, input *ChangePasswordInput) error {
 	err := c.apiClient.Ops.DoCollectionAction(UserType, "changepassword", &resource.Collection, input, nil)
+	return err
+}
+
+func (c *UserClient) CollectionActionRefreshauthprovideraccess(resource *UserCollection) error {
+	err := c.apiClient.Ops.DoCollectionAction(UserType, "refreshauthprovideraccess", &resource.Collection, nil, nil)
 	return err
 }


### PR DESCRIPTION
See: https://github.com/rancher/rancher/issues/17067#issuecomment-451312069

Depends on: https://github.com/rancher/types/pull/674

Provides actions for manually triggering auth refresh, as well as for validating the auth refresh related settings