### PR TITLE
Add namespace to NodeConfig baseDir

### DIFF
--- a/pkg/nodeconfig/config.go
+++ b/pkg/nodeconfig/config.go
@@ -33,7 +33,7 @@ func NewStore(namespaceInterface v1.NamespaceInterface, secretsGetter v1.Secrets
 }
 
 func NewNodeConfig(store *encryptedstore.GenericEncryptedStore, node *v3.Node) (*NodeConfig, error) {
-	nodeDir, err := buildBaseHostDir(node.Spec.RequestedHostname)
+	nodeDir, err := buildBaseHostDir(node.Namespace + "-" + node.Spec.RequestedHostname)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit will fix issues with directories being overwritten when
provisioning multiple clusters simultaneously using the same name
prefix.

For /issues/15456, /issues/17543