### PR TITLE
Update EKS template to use newest AMI in all available regions

### DIFF
--- a/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
@@ -36,9 +36,16 @@ import (
 )
 
 var amiForRegion = map[string]string{
-	"us-west-2": "ami-0a54c984b9f908c81",
-	"us-east-1": "ami-0440e4f6b9713faf6",
-	"eu-west-1": "ami-0c7a4976cb6fafd3a",
+	"us-west-2": "ami-0a2abab4107669c1b",
+	"us-east-1": "ami-0c24db5df6badc35a",
+	"us-east-2": "ami-0c2e8d28b1f854c68",
+	"eu-west-1": "ami-01e08d22b9439c15a",
+	"eu-central-1": "ami-010caa98bae9a09e2",
+	"eu-north-1": "ami-06ee67302ab7cf838",
+	"ap-northeast-1": "ami-0f0e8066383e7a2cb",
+	"ap-northeast-2": "ami-0b7baa90de70f683f",
+	"ap-southeast-1": "ami-019966ed970c18502",
+	"ap-southeast-2": "ami-06ade0abbd8eca425",
 }
 
 type Driver struct {


### PR DESCRIPTION
Address issue: #17081 

Problem:
Currently rancher does not allow provisioning of new EKS clusters in all regions where the service is available. Additionally, the existing AMI's do not support the latest version of Amazon EKS-optimized AMI

Solution:
Create additional mapping items and update all AMI's according to https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html as of 1/11/19