### PR TITLE
Should use len to check empty request/response body

### DIFF
--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -114,12 +114,11 @@ func (a *auditLog) write(userInfo *UserInfo, reqHeaders, resHeaders http.Header,
 	}
 
 	buffer.Write(bytes.TrimSuffix(alByte, []byte("}")))
-
-	if a.writer.Level >= levelRequest && a.reqBody != nil {
+	if a.writer.Level >= levelRequest && len(a.reqBody) > 0 {
 		buffer.WriteString(`,"requestBody":`)
 		buffer.Write(bytes.TrimSuffix(a.reqBody, []byte("\n")))
 	}
-	if a.writer.Level >= levelRequestResponse && resHeaders.Get("Content-Type") == contentTypeJSON && resBody != nil {
+	if a.writer.Level >= levelRequestResponse && resHeaders.Get("Content-Type") == contentTypeJSON && len(resBody) > 0 {
 		buffer.WriteString(`,"responseBody":`)
 		buffer.Write(bytes.TrimSuffix(resBody, []byte("\n")))
 	}


### PR DESCRIPTION
Problem:
will record bad format log when the request/response body is empty

Solution:
use len to check the request/response body

Issue:
https://github.com/rancher/rancher/issues/17394