### PR TITLE
Prevent nil pointer if download fails

### DIFF
--- a/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
+++ b/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
@@ -70,6 +70,9 @@ func (l *Lifecycle) Create(obj *v3.KontainerDriver) (runtime.Object, error) {
 
 	if !obj.Spec.BuiltIn {
 		obj, err = l.download(obj)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		v3.KontainerDriverConditionDownloaded.True(obj)
 		v3.KontainerDriverConditionInstalled.True(obj)


### PR DESCRIPTION
This change prevents a nil pointer from occuring if the download of a
kontainer driver fails.  The func will return the error to the lfc handler
and the normal error backoff logic will take place.

Issue:
https://github.com/rancher/rancher/issues/17425