### PR TITLE
Ensure the summary metrics is disabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/ehazlett/simplelog"
+	_ "github.com/rancher/norman/controller"
 	"github.com/rancher/norman/pkg/dump"
 	"github.com/rancher/norman/pkg/kwrapper/k8s"
 	"github.com/rancher/norman/signal"


### PR DESCRIPTION
Import the norman controller in `main.go` to ensure the `init()`
function will be run first.

Related issue: https://github.com/rancher/rancher/issues/17434