### PR TITLE
Update alert notify template to support when alertmanager send multiple alert and add workload info for pod and event alert

### DIFF
--- a/pkg/api/customization/namespace/link.go
+++ b/pkg/api/customization/namespace/link.go
@@ -6,24 +6,12 @@ import (
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/clustermanager"
+	"github.com/rancher/rancher/pkg/resourcelink"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	printers2 "k8s.io/cli-runtime/pkg/genericclioptions/printers"
 	"k8s.io/kubernetes/pkg/printers"
 )
-
-var ExportResourcePrefixMappings = map[string]string{
-	"pods":                   "api/v1",
-	"configmaps":             "api/v1",
-	"services":               "api/v1",
-	"replicationcontrollers": "api/v1",
-	"deployments":            "apis/extensions/v1beta1",
-	"daemonsets":             "apis/extensions/v1beta1",
-	"replicasets":            "apis/extensions/v1beta1",
-	"statefulsets":           "apis/apps/v1beta1",
-	"jobs":                   "apis/batch/v1",
-	"cronjobs":               "apis/batch/v1beta1",
-}
 
 var ExportPrinters = map[string]printers.ResourcePrinter{
 	"json": &printers2.JSONPrinter{},
@@ -120,7 +108,7 @@ func (s *yamlLinkHandler) LinkHandler(apiContext *types.APIContext, next types.R
 //getResourcePrefixMap converts resource path like `/api/v1/pods` to kind-prefix mappings
 func getResourcePrefixMap(resources []string) map[string]string {
 	if len(resources) == 0 {
-		return ExportResourcePrefixMappings
+		return resourcelink.ExportResourcePrefixMappings
 	}
 	m := map[string]string{}
 	for _, r := range resources {

--- a/pkg/controllers/user/alert/deployer/notification_template.go
+++ b/pkg/controllers/user/alert/deployer/notification_template.go
@@ -76,15 +76,24 @@ Total Memory: {{ .Labels.total_mem}}
 {{- else if eq .Labels.alert_type "podRestarts" }}
 Project Name: {{ .Labels.project_name}}
 Namespace: {{ .Labels.namespace}}
+{{- if .Labels.workload_name }}
+Workload Name: {{.Labels.workload_name}}
+{{ end -}}
 Container Name: {{ .Labels.container_name}}
 {{- else if eq .Labels.alert_type "podNotRunning" }}
 Project Name: {{ .Labels.project_name}}
 Namespace: {{ .Labels.namespace}}
+{{- if .Labels.workload_name }}
+Workload Name: {{.Labels.workload_name}}
+{{ end -}}
 Container Name: {{ .Labels.container_name}}
 {{- else if eq .Labels.alert_type "podNotScheduled" }}
 Project Name: {{ .Labels.project_name}}
 Namespace: {{ .Labels.namespace}}
 Pod Name: {{ .Labels.pod_name}}
+{{- if .Labels.workload_name }}
+Workload Name: {{.Labels.workload_name}}
+{{ end -}}
 {{- else if eq .Labels.alert_type "workload" }}
 Project Name: {{ .Labels.project_name}}
 Available Replicas: {{ .Labels.available_replicas}}
@@ -139,14 +148,23 @@ Total Memory: {{ .Labels.total_mem}}<br>
 {{- else if eq .Labels.alert_type "podRestarts" }}
 Project Name: {{.Labels.project_name}}<br>
 Namespace: {{ .Labels.namespace}}<br>
+{{- if .Labels.workload_name }}
+Workload Name: {{.Labels.workload_name}}<br>
+{{ end -}}
 Container Name: {{.Labels.container_name}}<br>
 {{- else if eq .Labels.alert_type "podNotRunning" }}
 Project Name: {{.Labels.project_name}}<br>
 Namespace: {{ .Labels.namespace}}<br>
+{{- if .Labels.workload_name }}
+Workload Name: {{.Labels.workload_name}}<br>
+{{ end -}}
 Container Name: {{ .Labels.container_name}}<br>
 {{- else if eq .Labels.alert_type "podNotScheduled" }}
 Project Name: {{.Labels.project_name}}<br>
 Namespace: {{ .Labels.namespace}}<br>
+{{- if .Labels.workload_name }}
+Workload Name: {{.Labels.workload_name}}<br>
+{{ end -}}
 Pod Name: {{ .Labels.pod_name}}<br>
 {{- else if eq .Labels.alert_type "workload"}}
 Project Name: {{.Labels.project_name}}<br>

--- a/pkg/controllers/user/alert/watcher/event.go
+++ b/pkg/controllers/user/alert/watcher/event.go
@@ -7,11 +7,15 @@ import (
 
 	"github.com/rancher/rancher/pkg/controllers/user/alert/common"
 	"github.com/rancher/rancher/pkg/controllers/user/alert/manager"
+	"github.com/rancher/rancher/pkg/controllers/user/workload"
 	"github.com/rancher/types/apis/core/v1"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
+
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -22,16 +26,24 @@ type EventWatcher struct {
 	alertManager           *manager.AlertManager
 	clusterName            string
 	clusterLister          v3.ClusterLister
+	workloadFetcher        workloadFetcher
+	podLister              v1.PodLister
 }
 
 func StartEventWatcher(ctx context.Context, cluster *config.UserContext, manager *manager.AlertManager) {
 	events := cluster.Core.Events("")
+	workloadFetcher := workloadFetcher{
+		workloadController: workload.NewWorkloadController(ctx, cluster.UserOnlyContext(), nil),
+	}
+
 	eventWatcher := &EventWatcher{
 		eventLister:            events.Controller().Lister(),
 		clusterAlertRuleLister: cluster.Management.Management.ClusterAlertRules(cluster.ClusterName).Controller().Lister(),
 		alertManager:           manager,
 		clusterName:            cluster.ClusterName,
 		clusterLister:          cluster.Management.Management.Clusters("").Controller().Lister(),
+		workloadFetcher:        workloadFetcher,
+		podLister:              cluster.Core.Pods(metav1.NamespaceAll).Controller().Lister(),
 	}
 
 	events.AddHandler(ctx, "cluster-event-alert-watcher", eventWatcher.Sync)
@@ -82,6 +94,18 @@ func (l *EventWatcher) Sync(key string, obj *corev1.Event) (runtime.Object, erro
 			data["event_firstseen"] = fmt.Sprintf("%s", obj.FirstTimestamp)
 			data["event_lastseen"] = fmt.Sprintf("%s", obj.LastTimestamp)
 
+			if alert.Spec.EventRule.ResourceKind == "Pod" || alert.Spec.EventRule.ResourceKind == "Deployment" || alert.Spec.EventRule.ResourceKind == "StatefulSet" || alert.Spec.EventRule.ResourceKind == "DaemonSet" {
+				workloadName, err := l.getWorkloadInfo(obj.InvolvedObject.Namespace, obj.InvolvedObject.Name, alert.Spec.EventRule.ResourceKind)
+				if err != nil {
+					errors.Wrap(err, "failed to fetch cho")
+				}
+
+				if workloadName != "" {
+					data["workload_name"] = workloadName
+				}
+
+			}
+
 			if err := l.alertManager.SendAlert(data); err != nil {
 				logrus.Errorf("Failed to send alert: %v", err)
 			}
@@ -90,4 +114,62 @@ func (l *EventWatcher) Sync(key string, obj *corev1.Event) (runtime.Object, erro
 	}
 
 	return nil, nil
+}
+
+func (l *EventWatcher) getWorkloadInfo(namespace, name, kind string) (string, error) {
+	if kind == "Pod" {
+		pod, err := l.podLister.Get(namespace, name)
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to get pod %s:%s", namespace, name)
+		}
+		if len(pod.OwnerReferences) == 0 {
+			return pod.Name, nil
+		}
+		ownerRef := pod.OwnerReferences[0]
+		name = ownerRef.Name
+		kind = ownerRef.Kind
+	}
+
+	workloadName, err := l.workloadFetcher.getWorkloadName(namespace, name, kind)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to get workload info for alert")
+	}
+	return workloadName, nil
+}
+
+type workloadFetcher struct {
+	workloadController workload.CommonController
+}
+
+func (w *workloadFetcher) getWorkloadName(namespace, name, kind string) (string, error) {
+	if kind == "Deployment" || kind == "StatefulSet" || kind == "DaemonSet" || kind == "CronJob" {
+		return name, nil
+	}
+
+	workloadID := fmt.Sprintf("%s:%s:%s", kind, namespace, name)
+	workload, err := w.workloadController.GetByWorkloadID(workloadID)
+	if err != nil {
+		return "", errors.Wrapf(err, "get workload %s failed", workloadID)
+	}
+
+	allRef := workload.OwnerReferences
+	if len(allRef) == 0 {
+		return name, nil
+	}
+
+	ref := allRef[0]
+	refName := ref.Name
+	refKind := ref.Kind
+
+	if kind == "Job" && refKind != "CronJob" {
+		return name, nil
+	}
+
+	refWorkloadID := fmt.Sprintf("%s:%s:%s", refKind, namespace, refName)
+	refWorkload, err := w.workloadController.GetByWorkloadID(refWorkloadID)
+	if err != nil {
+		return "", errors.Wrapf(err, "get workload %s failed", workloadID)
+	}
+
+	return w.getWorkloadName(refWorkload.Namespace, refWorkload.Name, refWorkload.Kind)
 }

--- a/pkg/controllers/user/alert/watcher/node.go
+++ b/pkg/controllers/user/alert/watcher/node.go
@@ -188,6 +188,7 @@ func (w *NodeWatcher) checkNodeCPUUsage(alert *v3.ClusterAlertRule, machine *v3.
 			data := map[string]string{}
 			data["rule_id"] = ruleID
 			data["group_id"] = alert.Spec.GroupName
+			data["alert_name"] = alert.Spec.DisplayName
 			data["alert_type"] = "nodeCPU"
 			data["severity"] = alert.Spec.Severity
 			data["cluster_name"] = clusterDisplayName
@@ -220,6 +221,7 @@ func (w *NodeWatcher) checkNodeReady(alert *v3.ClusterAlertRule, machine *v3.Nod
 				data := map[string]string{}
 				data["rule_id"] = ruleID
 				data["group_id"] = alert.Spec.GroupName
+				data["alert_name"] = alert.Spec.DisplayName
 				data["alert_type"] = "nodeHealthy"
 				data["severity"] = alert.Spec.Severity
 				data["cluster_name"] = clusterDisplayName

--- a/pkg/controllers/user/alert/watcher/workload.go
+++ b/pkg/controllers/user/alert/watcher/workload.go
@@ -163,6 +163,7 @@ func (w *WorkloadWatcher) checkWorkloadCondition(wl *workload.Workload, alert *v
 		data["project_name"] = projectName
 		data["workload_name"] = wl.Name
 		data["workload_namespace"] = wl.Namespace
+		data["workload_kind"] = wl.Kind
 		data["available_percentage"] = strconv.Itoa(percentage)
 		data["available_replicas"] = strconv.Itoa(int(wl.Status.AvailableReplicas))
 		data["desired_replicas"] = strconv.Itoa(int(wl.Status.Replicas))

--- a/pkg/resourcelink/resourcelink.go
+++ b/pkg/resourcelink/resourcelink.go
@@ -1,0 +1,14 @@
+package resourcelink
+
+var ExportResourcePrefixMappings = map[string]string{
+	"pods":                   "api/v1",
+	"configmaps":             "api/v1",
+	"services":               "api/v1",
+	"replicationcontrollers": "api/v1",
+	"deployments":            "apis/extensions/v1beta1",
+	"daemonsets":             "apis/extensions/v1beta1",
+	"replicasets":            "apis/extensions/v1beta1",
+	"statefulsets":           "apis/apps/v1beta1",
+	"jobs":                   "apis/batch/v1",
+	"cronjobs":               "apis/batch/v1beta1",
+}


### PR DESCRIPTION
Update alert notify template to support when alertmanager send multi alert in one request

Problem:
1. Alertmanager may send alert array, current notify template just use the first alert in array to contribute the notify info, not support multi alert well
2. it would help user to know the alerting pod belong to which workload if we could add workload info
3. alert name is miss for node alert

Solution:
1. Update notify template to support multi alert
2. add workload info 
3. add alert name in node alert

Issue:
https://github.com/rancher/rancher/issues/17472
https://github.com/rancher/rancher/issues/16990
https://github.com/rancher/rancher/issues/17535

