### PR TITLE
Remove deprecated kubelet options when Windows deploying

### DIFF
--- a/pkg/rkenodeconfigserver/nodeserver_test.go
+++ b/pkg/rkenodeconfigserver/nodeserver_test.go
@@ -1,0 +1,13 @@
+package rkenodeconfigserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_compareTag(t *testing.T) {
+	assert.False(t, compareTag("v1.11.0-xx", "v1.12.0-xx"))
+	assert.True(t, compareTag("v1.12.0-xx", "v1.12.0-xx"))
+	assert.True(t, compareTag("v1.13.0-xx", "v1.12.0"))
+}


### PR DESCRIPTION
**Problem:**
Since 1.12, cadvisor API surface has been removed
https://github.com/kubernetes/kubernetes/issues/56523

**Solution:**
Judge Kubernetes version to remove `--cadvisor-port`

**Issue:**
https://github.com/rancher/rancher/issues/17341