### PR TITLE
Fix fatal error in concurrent map

### DIFF
--- a/pkg/dynamiclistener/server.go
+++ b/pkg/dynamiclistener/server.go
@@ -95,9 +95,11 @@ func (s *Server) updateIPs(savedIPs map[string]bool) map[string]bool {
 	}
 
 	certs := map[string]string{}
+	s.Lock()
 	for key, cert := range s.certs {
 		certs[key] = certToString(cert)
 	}
+	s.Unlock()
 
 	if !reflect.DeepEqual(certs, cfg.GeneratedCerts) {
 		cfg = cfg.DeepCopy()


### PR DESCRIPTION
Mutex Lock & Unlock updateIps to prevent `concurrent map iteration and
map write` when iterating through certs.

For rancher/rancher/issues/16759