### PR TITLE
add support of custom values.yaml in catalog apps

### DIFF
--- a/pkg/controllers/user/helm/common.go
+++ b/pkg/controllers/user/helm/common.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -108,14 +107,9 @@ func generateTemplates(obj *v3.App, templateVersionClient mgmtv3.CatalogTemplate
 	}
 
 	common.InjectDefaultRegistry(obj)
-	setValues := []string{}
-	if obj.Spec.Answers != nil {
-		answers := obj.Spec.Answers
-		result := []string{}
-		for k, v := range answers {
-			result = append(result, fmt.Sprintf("%s=%s", k, v))
-		}
-		setValues = append([]string{"--set"}, strings.Join(result, ","))
+	setValues, err := common.GenerateAnswerSetValues(obj, tempDir)
+	if err != nil {
+		return "", "", "", err
 	}
 
 	commands := append([]string{"template", dir, "--name", obj.Name, "--namespace", obj.Spec.TargetNamespace}, setValues...)

--- a/pkg/controllers/user/helm/common/common.go
+++ b/pkg/controllers/user/helm/common/common.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -105,17 +107,11 @@ func GenerateRandomPort() string {
 }
 
 func InstallCharts(rootDir, port string, obj *v3.App) error {
-	setValues := []string{}
 	InjectDefaultRegistry(obj)
-	if obj.Spec.Answers != nil {
-		answers := obj.Spec.Answers
-		result := []string{}
-		for k, v := range answers {
-			result = append(result, fmt.Sprintf("%s=%s", k, v))
-		}
-		setValues = append([]string{"--set"}, strings.Join(result, ","))
+	setValues, err := GenerateAnswerSetValues(obj, rootDir)
+	if err != nil {
+		return err
 	}
-
 	commands := make([]string, 0)
 	commands = append([]string{"upgrade", "--install", "--namespace", obj.Spec.TargetNamespace, obj.Name}, setValues...)
 	commands = append(commands, rootDir)
@@ -141,6 +137,28 @@ func InstallCharts(rootDir, port string, obj *v3.App) error {
 		return errors.Errorf("failed to install app %s. %s", obj.Name, stderrBuf.String())
 	}
 	return nil
+}
+
+func GenerateAnswerSetValues(app *v3.App, tempDir string) ([]string, error) {
+	setValues := []string{}
+	// a user-supplied values file will overridden default values.yaml
+	if app.Spec.ValuesYaml != "" {
+		valuesYaml := filepath.Join(tempDir, "custom-values.yaml")
+		if err := ioutil.WriteFile(valuesYaml, []byte(app.Spec.ValuesYaml), 0755); err != nil {
+			return setValues, err
+		}
+		setValues = append(setValues, "--values", valuesYaml)
+	}
+	// `--set` values will overridden the user-supplied values.yaml file
+	if app.Spec.Answers != nil {
+		answers := app.Spec.Answers
+		var values = []string{}
+		for k, v := range answers {
+			values = append(values, fmt.Sprintf("%s=%s", k, v))
+		}
+		setValues = append(setValues, "--set", strings.Join(values, ","))
+	}
+	return setValues, nil
 }
 
 func DeleteCharts(port string, obj *v3.App) error {

--- a/pkg/controllers/user/helm/controller.go
+++ b/pkg/controllers/user/helm/controller.go
@@ -104,7 +104,7 @@ func (l *Lifecycle) Updated(obj *v3.App) (runtime.Object, error) {
 			return nil, err
 		}
 		if obj.Spec.ExternalID != "" {
-			if currentRevision.Status.ExternalID == obj.Spec.ExternalID && reflect.DeepEqual(currentRevision.Status.Answers, obj.Spec.Answers) {
+			if currentRevision.Status.ExternalID == obj.Spec.ExternalID && reflect.DeepEqual(currentRevision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(currentRevision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
 				if !v3.AppConditionForceUpgrade.IsTrue(obj) {
 					v3.AppConditionForceUpgrade.True(obj)
 				}
@@ -112,7 +112,7 @@ func (l *Lifecycle) Updated(obj *v3.App) (runtime.Object, error) {
 			}
 		}
 		if obj.Status.AppliedFiles != nil {
-			if reflect.DeepEqual(obj.Status.AppliedFiles, obj.Spec.Files) && reflect.DeepEqual(currentRevision.Status.Answers, obj.Spec.Answers) {
+			if reflect.DeepEqual(obj.Status.AppliedFiles, obj.Spec.Files) && reflect.DeepEqual(currentRevision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(currentRevision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
 				if !v3.AppConditionForceUpgrade.IsTrue(obj) {
 					v3.AppConditionForceUpgrade.True(obj)
 				}
@@ -268,6 +268,7 @@ func (l *Lifecycle) createAppRevision(obj *v3.App, template, notes string, faile
 	release.Status.Answers = obj.Spec.Answers
 	release.Status.ProjectName = projectName
 	release.Status.ExternalID = obj.Spec.ExternalID
+	release.Status.ValuesYaml = obj.Spec.ValuesYaml
 	digest := sha256.New()
 	digest.Write([]byte(template))
 	tag := hex.EncodeToString(digest.Sum(nil))

--- a/tests/core/test_app.py
+++ b/tests/core/test_app.py
@@ -170,6 +170,34 @@ def wait_for_app_annotation(admin_pc, ns, app_name, timeout=60):
     return ns
 
 
+def test_app_custom_values_file(admin_pc, admin_mc):
+    client = admin_pc.client
+    ns = admin_pc.cluster.client.create_namespace(name=random_str(),
+                                                  projectId=admin_pc.
+                                                  project.id)
+    wait_for_template_to_be_created(admin_mc.client, "library")
+    values_yaml = "replicaCount: 2\r\nimage:\r\n  " \
+                  "repository: registry\r\n  tag: 2.7"
+    answers = {
+        "image.tag": "2.6"
+    }
+    app = client.create_app(
+        name=random_str(),
+        externalId="catalog://?catalog=library&template=docker-registry"
+                   "&version=1.6.1&namespace=cattle-global-data",
+        targetNamespace=ns.name,
+        projectId=admin_pc.project.id,
+        valuesYaml=values_yaml,
+        answers=answers
+    )
+    workloads = wait_for_workload(client, ns.name, count=1)
+    print(workloads)
+    assert workloads.data[0].deploymentStatus.unavailableReplicas == 2
+    assert workloads.data[0].containers[0].image == "registry:2.6"
+    client.delete(app)
+    wait_for_app_to_be_deleted(client, app)
+
+
 def wait_for_workload(client, ns, timeout=60, count=0):
     start = time.time()
     interval = 0.5

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,4 +1,4 @@
-#Gpackage
+# package
 github.com/rancher/rancher
 
 k8s.io/kubernetes                             v1.12.2-lite2                            https://github.com/ibuildthecloud/k3s.git  transitive=true,staging=true
@@ -42,7 +42,7 @@ github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f6841
 github.com/rancher/norman                     b694ecb0eb159776edc3ea84036ee46390c8d7fe
 github.com/rancher/kontainer-engine           391960fdb29300ebccda7b48e9ad44415782e0a5
 github.com/rancher/rke                        aa16d70ca616af0112ae2a6bb25e33a777eb2ae7
-github.com/rancher/types                      48a9fbb6f12a99cbe15e93b00211824993809098
+github.com/rancher/types                      7b93e996dc18d5ae6d167eb25ad1e24fc54ac716
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
@@ -26,6 +26,7 @@ type AppSpec struct {
 	AppRevisionName     string            `json:"appRevisionName,omitempty" norman:"type=reference[/v3/project/schemas/apprevision]"`
 	Prune               bool              `json:"prune,omitempty"`
 	MultiClusterAppName string            `json:"multiClusterAppName,omitempty" norman:"type=reference[/v3/schemas/multiclusterapp]"`
+	ValuesYaml          string            `json:"valuesYaml,omitempty"`
 }
 
 var (
@@ -73,6 +74,7 @@ type AppRevisionStatus struct {
 	ExternalID  string            `json:"externalId"`
 	Answers     map[string]string `json:"answers"`
 	Digest      string            `json:"digest"`
+	ValuesYaml  string            `json:"valuesYaml,omitempty"`
 }
 
 type AppUpgradeConfig struct {

--- a/vendor/github.com/rancher/types/client/project/v3/zz_generated_app.go
+++ b/vendor/github.com/rancher/types/client/project/v3/zz_generated_app.go
@@ -31,6 +31,7 @@ const (
 	AppFieldTransitioning        = "transitioning"
 	AppFieldTransitioningMessage = "transitioningMessage"
 	AppFieldUUID                 = "uuid"
+	AppFieldValuesYaml           = "valuesYaml"
 )
 
 type App struct {
@@ -60,6 +61,7 @@ type App struct {
 	Transitioning        string            `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
 	TransitioningMessage string            `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
 	UUID                 string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	ValuesYaml           string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }
 
 type AppCollection struct {

--- a/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_revision_status.go
+++ b/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_revision_status.go
@@ -6,6 +6,7 @@ const (
 	AppRevisionStatusFieldDigest     = "digest"
 	AppRevisionStatusFieldExternalID = "externalId"
 	AppRevisionStatusFieldProjectID  = "projectId"
+	AppRevisionStatusFieldValuesYaml = "valuesYaml"
 )
 
 type AppRevisionStatus struct {
@@ -13,4 +14,5 @@ type AppRevisionStatus struct {
 	Digest     string            `json:"digest,omitempty" yaml:"digest,omitempty"`
 	ExternalID string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
 	ProjectID  string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
+	ValuesYaml string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }

--- a/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_spec.go
+++ b/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_spec.go
@@ -11,6 +11,7 @@ const (
 	AppSpecFieldProjectID         = "projectId"
 	AppSpecFieldPrune             = "prune"
 	AppSpecFieldTargetNamespace   = "targetNamespace"
+	AppSpecFieldValuesYaml        = "valuesYaml"
 )
 
 type AppSpec struct {
@@ -23,4 +24,5 @@ type AppSpec struct {
 	ProjectID         string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
 	Prune             bool              `json:"prune,omitempty" yaml:"prune,omitempty"`
 	TargetNamespace   string            `json:"targetNamespace,omitempty" yaml:"targetNamespace,omitempty"`
+	ValuesYaml        string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }


### PR DESCRIPTION
**Problem:**
user should be able to post a custom `values.yaml` to override the default one.

**Solution:**
add a new field called `valuesYaml` which allows the user to post a custom `values.yml` file to override default one, and `--set` values in the answers will override the user-supplied `values.yaml`.

**Related Issues:**
#17122 #16680 #14608

**Related PRs:**
types: https://github.com/rancher/types/pull/684
UI: https://github.com/rancher/rancher/issues/17605