### PR TITLE
fix could logging config not sync correctly

### DIFF
--- a/pkg/controllers/user/logging/configsyncer/configsyncer.go
+++ b/pkg/controllers/user/logging/configsyncer/configsyncer.go
@@ -33,7 +33,7 @@ func NewConfigSyncer(cluster *config.UserContext, SecretManager *SecretManager) 
 	configGenerator := NewConfigGenerator(clusterName, clusterLoggingLister, projectLoggingLister, namespaceLister)
 
 	return &ConfigSyncer{
-		apps:                 cluster.Project.Apps(metav1.NamespaceAll),
+		apps:                 cluster.Management.Project.Apps(metav1.NamespaceAll),
 		clusterName:          clusterName,
 		clusterLoggingLister: clusterLoggingLister,
 		projectLoggingLister: projectLoggingLister,

--- a/pkg/controllers/user/logging/utils/testwrap.go
+++ b/pkg/controllers/user/logging/utils/testwrap.go
@@ -103,6 +103,7 @@ func (w *elasticsearchTestWrap) TestReachable(dial dialer.Dialer) error {
 	if err != nil {
 		return errors.Wrap(err, "create request failed")
 	}
+	req.Header.Set("Content-Type", "application/json")
 
 	return testReachableHTTP(dial, req, w.Certificate, w.ClientCert, w.ClientKey, w.ClientKeyPass, "", w.SSLVerify)
 }
@@ -119,6 +120,7 @@ func (w *splunkTestWrap) TestReachable(dial dialer.Dialer) error {
 	if err != nil {
 		return errors.Wrap(err, "create request failed")
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Splunk %s", w.Token))
 
 	return testReachableHTTP(dial, req, w.Certificate, w.ClientCert, w.ClientKey, w.ClientKeyPass, "", w.SSLVerify)
 }
@@ -425,11 +427,11 @@ func getIndex(dateFormat, prefix string) string {
 	today := time.Now()
 	switch dateFormat {
 	case "YYYY":
-		index = fmt.Sprintf("%s-%d", prefix, today.Year())
+		index = fmt.Sprintf("%s-%04d", prefix, today.Year())
 	case "YYYY-MM":
-		index = fmt.Sprintf("%s-%d-%d", prefix, today.Year(), today.Month())
+		index = fmt.Sprintf("%s-%04d-%02d", prefix, today.Year(), today.Month())
 	case "YYYY-MM-DD":
-		index = fmt.Sprintf("%s-%d-%d-%d", prefix, today.Year(), today.Month(), today.Day())
+		index = fmt.Sprintf("%s-%04d-%02d-%02d", prefix, today.Year(), today.Month(), today.Day())
 	}
 	return index
 }


### PR DESCRIPTION
Problem:
1. fix logging config could not sync correctly because could not detect logging app deploy
2. add header when sending test log to elasticsearch/splunk

Solution:
1. use management context to get app
2. add content-type in the request to elasticsearch header and token in the request to splunk

Issue:
https://github.com/rancher/rancher/issues/17600
https://github.com/rancher/rancher/issues/17599