### PR TITLE
PSPT test improvement

### DIFF
--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -127,7 +127,7 @@ def cluster_and_client(cluster_id, mgmt_client):
 
 
 @pytest.fixture
-def admin_pc(request, admin_cc):
+def admin_pc(request, admin_cc, remove_resource):
     """Returns a ProjectContext for a newly created project in the local
     cluster for the default global admin user. The project will be deleted
     when this fixture is cleaned up."""
@@ -138,7 +138,7 @@ def admin_pc(request, admin_cc):
     wait_for_condition("BackingNamespaceCreated", "True",
                        admin_cc.management.client, p)
     assert p.state == 'active'
-    request.addfinalizer(lambda: admin_cc.management.client.delete(p))
+    remove_resource(p)
     url = p.links.self + '/schemas'
     return ProjectContext(admin_cc, p, rancher.Client(url=url,
                                                       verify=False,

--- a/tests/core/test_pod_security_policies.py
+++ b/tests/core/test_pod_security_policies.py
@@ -1,6 +1,6 @@
 import kubernetes
-
 from .conftest import kubernetes_api_client, wait_for
+from .common import random_str
 
 
 def cleanup_pspt(client, request, cluster):
@@ -16,20 +16,35 @@ def cleanup_pspt(client, request, cluster):
     )
 
 
-def setup_cluster_with_pspt(client, request, template="pspt1"):
-    """
-    WARNING: This function is not safe for parallel exec, only used by
-    test_service_accounts!!
-    Sets the 'local' cluster to have the pspt given by template, if it exists,
-    returns the pspt and cleans up. If it does, creates a copy and applies it.
-    If it does not, it creates a generic one. Also adds a finalizer for cleanup
-    """
-    pspt = client.by_id_pod_security_policy_template(template)
+def create_pspt(client):
+    """ Creates a minimally valid pspt with cleanup left to caller"""
+    runas = {"rule": "RunAsAny"}
+    selinx = {"rule": "RunAsAny"}
+    supgrp = {"ranges": [{"max": 65535, "min": 1}],
+              "rule": "MustRunAs"
+              }
+    fsgrp = {"ranges": [{"max": 65535, "min": 1, }],
+             "rule": "MustRunAs",
+             }
+    pspt = \
+        client.create_pod_security_policy_template(name="test" + random_str(),
+                                                   description="Test PSPT",
+                                                   privileged=False,
+                                                   seLinux=selinx,
+                                                   supplementalGroups=supgrp,
+                                                   runAsUser=runas,
+                                                   fsGroup=fsgrp,
+                                                   volumes='*'
+                                                   )
+    return pspt
 
-    if pspt is None:
-        # See: v3/podsecuritypolicytemplates
-        pspt = client.create_pod_security_policy_template(template)
 
+def setup_cluster_with_pspt(client, request):
+    """
+       Sets the 'local' cluster to mock a PSP by applying a minimally valid
+       restricted type PSPT
+    """
+    pspt = create_pspt(client)
     pspt_id = pspt.id
 
     # this won't enforce pod security policies on the local cluster but it
@@ -74,7 +89,7 @@ def test_service_accounts_have_role_binding(admin_mc, request):
     wait_for(lambda: service_account_has_role_binding(rbac, pspt), timeout=30)
 
 
-def test_pod_security_policy_template_del(admin_mc, request, remove_resource):
+def test_pod_security_policy_template_del(admin_mc, admin_pc, remove_resource):
     """ Test for pod security policy template binding correctly
     ref https://github.com/rancher/rancher/issues/15728
     ref https://localhost:8443/v3/podsecuritypolicytemplates
@@ -82,49 +97,45 @@ def test_pod_security_policy_template_del(admin_mc, request, remove_resource):
     api_client = admin_mc.client
     # these create a mock pspts... not valid for real psp's
 
-    pspt_proj = api_client.create_pod_security_policy_template("pspt2")
+    pspt_proj = create_pspt(api_client)
     # add a finalizer to delete the pspt
     remove_resource(pspt_proj)
 
-    #  create a project in order to establish bindings
-    def create_project():
-        p = api_client.create_project(name="test-unrestrict-proj",
-                                      clusterId="local")
-        p = api_client.wait_success(p)
-        # In case something goes badly, add a finalizer to
-        # delete the project as the admin
-        remove_resource(p)
-
-        p.setpodsecuritypolicytemplate(
-            podSecurityPolicyTemplateId=pspt_proj.id)
-
-        return p
-
-    proj = create_project()
-    # wait to use proj object until done transitioning
+    #  creates a project and handles cleanup
+    proj = admin_pc.project
+    proj.setpodsecuritypolicytemplate(podSecurityPolicyTemplateId=pspt_proj.id)
     proj = api_client.wait_success(proj)
+
     # Check that project was created successfully with pspt
     assert proj.state == 'active'
     assert proj.podSecurityPolicyTemplateId == pspt_proj.id
 
+    def check_psptpb():
+        proj_obj = proj.podSecurityPolicyTemplateProjectBindings()
+        for data in proj_obj.data:
+            if (data.targetProjectId == proj.id and
+               data.podSecurityPolicyTemplateId == pspt_proj.id):
+                return True
+
+        return False
+
+    wait_for(check_psptpb, lambda: "PSPTB project binding not found")
     # allow for binding deletion
     api_client.delete(proj)
 
-    def check_project(client, proj):
-        return client.by_id_project(proj.id) is None
+    def check_project():
+        return api_client.by_id_project(proj.id) is None
 
-    wait_for(lambda: check_project(api_client, proj))
+    wait_for(check_project)
     # delete the PSPT that was associated with the deleted project
     api_client.delete(pspt_proj)
 
-    def pspt_del_check(client, p):
-        if client.by_id_pod_security_policy_template(p.id) is None:
+    def pspt_del_check():
+        if api_client.by_id_pod_security_policy_template(pspt_proj.id) is None:
             return True
         else:  # keep checking to see delete occurred
             return False
 
     # will timeout if pspt is not deleted
-    # this validates bug
-    wait_for(lambda: pspt_del_check(api_client, pspt_proj))
-
+    wait_for(pspt_del_check)
     assert api_client.by_id_pod_security_policy_template(pspt_proj.id) is None


### PR DESCRIPTION
Problem:
Errors are being thrown in Rancher logs due to incorrect PSPT creation.
PSPTPB are not being verified to exist.

Solution:
Update test to create valid PSPs
Update test_pod_security_policy_del to test that that PSPTPB's
are being created and assigned to the correct project.