### PR TITLE
Add ability to use private image registry when deploying logging tools

### DIFF
--- a/pkg/controllers/user/helm/common.go
+++ b/pkg/controllers/user/helm/common.go
@@ -107,6 +107,7 @@ func generateTemplates(obj *v3.App, templateVersionClient mgmtv3.CatalogTemplate
 		return "", "", "", err
 	}
 
+	common.InjectDefaultRegistry(obj)
 	setValues := []string{}
 	if obj.Spec.Answers != nil {
 		answers := obj.Spec.Answers
@@ -116,6 +117,7 @@ func generateTemplates(obj *v3.App, templateVersionClient mgmtv3.CatalogTemplate
 		}
 		setValues = append([]string{"--set"}, strings.Join(result, ","))
 	}
+
 	commands := append([]string{"template", dir, "--name", obj.Name, "--namespace", obj.Spec.TargetNamespace}, setValues...)
 
 	cmd := exec.Command(helmName, commands...)


### PR DESCRIPTION
problem:
After we refactored the logging, we can not deploy logging tools in an
air gap environment.

Solution:
Add the ability to use the private image registry when deploying logging
tools

Issue:
https://github.com/rancher/rancher/issues/17568

Related PR:
https://github.com/rancher/system-charts/pull/10

Test steps:
1. Set the `system-default-registry` to a private registry via the Settings menu.
2. Launch the logging.
3. Check if the rancher-logging app pulls the image from the set private registry.