### PR TITLE
Updated kontainer-engine to latest

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     0557aa4ff31a3a0f007dcb1b684894f23cda390c
-github.com/rancher/kontainer-engine           70debf4b384743e27bb47ae69d5842f10bc07aff
+github.com/rancher/kontainer-engine           76256b60bcfa9346ab64d22c14106b500a6cd052
 github.com/rancher/rke                        v0.2.0-rc4
 github.com/rancher/types                      01c47593ba389eb4cc2e0a2e0d80052d2d12a97f
 

--- a/vendor/github.com/rancher/kontainer-engine/drivers/eks/templates.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/eks/templates.go
@@ -503,7 +503,7 @@ Resources:
   NodeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      AssociatePublicIpAddress: !Ref PublicIps
+      AssociatePublicIpAddress: !Ref PublicIp
       IamInstanceProfile: !Ref NodeInstanceProfile
       ImageId: !Ref NodeImageId
       InstanceType: !Ref NodeInstanceType


### PR DESCRIPTION
Problem: EKS cluster creation fails due to incorrect parameter in template.

Solution: Updated kontainer-engine to latest version, which uses a correct template.

Issue: https://github.com/rancher/rancher/issues/17635