### PR TITLE
make users have access to listing pods metrics

### DIFF
--- a/app/role_data.go
+++ b/app/role_data.go
@@ -155,6 +155,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("*").resources("persistentvolumes").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("storageclasses").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("persistentvolumeclaims").verbs("*").
+		addRule().apiGroups("metrics.k8s.io").resources("pods").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("notifiers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectalertrules").verbs("*").
@@ -176,6 +177,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("*").resources("persistentvolumes").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("storageclasses").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("persistentvolumeclaims").verbs("*").
+		addRule().apiGroups("metrics.k8s.io").resources("pods").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("notifiers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectalertrules").verbs("*").
@@ -196,6 +198,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("*").resources("persistentvolumes").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("storageclasses").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("persistentvolumeclaims").verbs("get", "list", "watch").
+		addRule().apiGroups("metrics.k8s.io").resources("pods").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("notifiers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectalertrules").verbs("get", "list", "watch").

--- a/tests/core/test_rbac.py
+++ b/tests/core/test_rbac.py
@@ -125,6 +125,22 @@ def test_project_owner(admin_cc, admin_mc, user_mc, remove_resource):
     response = auth.create_self_subject_access_review(access_review)
     assert response.status.allowed is True
 
+    # List_namespaced_pod just list the pods of default core groups.
+    # If you want to list the metrics of pods,
+    # users should have the permissions of metrics.k8s.io group.
+    # As a proof, we use this particular k8s api, check that the user can list
+    # pods.metrics.k8s.io using the subject access review api
+    access_review = kubernetes.client.V1LocalSubjectAccessReview(spec={
+        "resourceAttributes": {
+            'namespace': ns.name,
+            'verb': 'list',
+            'resource': 'pods',
+            'group': 'metrics.k8s.io',
+        },
+    })
+    response = auth.create_self_subject_access_review(access_review)
+    assert response.status.allowed is True
+
 
 def test_removing_user_from_cluster(admin_pc, admin_mc, user_mc, admin_cc,
                                     remove_resource):


### PR DESCRIPTION
Problems:
Metrics server is deployed to the cluster but users do not have access
to listing pods metrics.

Solutions:
Add permissions to access metrics group in roletemplate of
project-owner, project-member, read-only.

Issues:
https://github.com/rancher/rancher/issues/15866