### PR TITLE
 Fix owner-level roles cannot enable/disable monitoring

### DIFF
--- a/pkg/api/customization/cluster/actionhandler.go
+++ b/pkg/api/customization/cluster/actionhandler.go
@@ -50,7 +50,11 @@ type ActionHandler struct {
 
 func (a ActionHandler) ClusterActionHandler(actionName string, action *types.Action, apiContext *types.APIContext) error {
 	canUpdateCluster := func() bool {
-		return apiContext.AccessControl.CanDo(v3.ClusterGroupVersionKind.Group, v3.ClusterResource.Name, "update", apiContext, nil, apiContext.Schema) == nil
+		cluster := map[string]interface{}{
+			"id": apiContext.ID,
+		}
+
+		return apiContext.AccessControl.CanDo(v3.ClusterGroupVersionKind.Group, v3.ClusterResource.Name, "update", apiContext, cluster, apiContext.Schema) == nil
 	}
 
 	switch actionName {

--- a/pkg/api/customization/project/project_actions.go
+++ b/pkg/api/customization/project/project_actions.go
@@ -47,7 +47,11 @@ type Handler struct {
 
 func (h *Handler) Actions(actionName string, action *types.Action, apiContext *types.APIContext) error {
 	canUpdateProject := func() bool {
-		return apiContext.AccessControl.CanDo(v3.ProjectGroupVersionKind.Group, v3.ProjectResource.Name, "update", apiContext, nil, apiContext.Schema) == nil
+		project := map[string]interface{}{
+			"id": apiContext.ID,
+		}
+
+		return apiContext.AccessControl.CanDo(v3.ProjectGroupVersionKind.Group, v3.ProjectResource.Name, "update", apiContext, project, apiContext.Schema) == nil
 	}
 
 	switch actionName {


### PR DESCRIPTION
**Problem:**
https://github.com/rancher/rancher/issues/16889#issuecomment-451589719

**Solution:**
Use meaningful object when `AccessControl.CanDo` checking

**Issue:**
- #17736
- #17737
- #16889 (Related)

**Patch:**
https://github.com/rancher/rancher/pull/17056