### PR TITLE
add rancher typed values like `string:` to catalog apps

### DIFF
--- a/pkg/controllers/user/helm/common.go
+++ b/pkg/controllers/user/helm/common.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -108,14 +107,9 @@ func generateTemplates(obj *v3.App, templateVersionClient mgmtv3.CatalogTemplate
 	}
 
 	common.InjectDefaultRegistry(obj)
-	setValues := []string{}
-	if obj.Spec.Answers != nil {
-		answers := obj.Spec.Answers
-		result := []string{}
-		for k, v := range answers {
-			result = append(result, fmt.Sprintf("%s=%s", k, v))
-		}
-		setValues = append([]string{"--set"}, strings.Join(result, ","))
+	setValues, err := common.GenerateAnswerSetValues(obj, tempDir)
+	if err != nil {
+		return "", "", "", err
 	}
 
 	commands := append([]string{"template", dir, "--name", obj.Name, "--namespace", obj.Spec.TargetNamespace}, setValues...)

--- a/pkg/controllers/user/helm/controller.go
+++ b/pkg/controllers/user/helm/controller.go
@@ -104,7 +104,7 @@ func (l *Lifecycle) Updated(obj *v3.App) (runtime.Object, error) {
 			return nil, err
 		}
 		if obj.Spec.ExternalID != "" {
-			if currentRevision.Status.ExternalID == obj.Spec.ExternalID && reflect.DeepEqual(currentRevision.Status.Answers, obj.Spec.Answers) {
+			if currentRevision.Status.ExternalID == obj.Spec.ExternalID && reflect.DeepEqual(currentRevision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(currentRevision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
 				if !v3.AppConditionForceUpgrade.IsTrue(obj) {
 					v3.AppConditionForceUpgrade.True(obj)
 				}
@@ -112,7 +112,7 @@ func (l *Lifecycle) Updated(obj *v3.App) (runtime.Object, error) {
 			}
 		}
 		if obj.Status.AppliedFiles != nil {
-			if reflect.DeepEqual(obj.Status.AppliedFiles, obj.Spec.Files) && reflect.DeepEqual(currentRevision.Status.Answers, obj.Spec.Answers) {
+			if reflect.DeepEqual(obj.Status.AppliedFiles, obj.Spec.Files) && reflect.DeepEqual(currentRevision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(currentRevision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
 				if !v3.AppConditionForceUpgrade.IsTrue(obj) {
 					v3.AppConditionForceUpgrade.True(obj)
 				}
@@ -268,6 +268,7 @@ func (l *Lifecycle) createAppRevision(obj *v3.App, template, notes string, faile
 	release.Status.Answers = obj.Spec.Answers
 	release.Status.ProjectName = projectName
 	release.Status.ExternalID = obj.Spec.ExternalID
+	release.Status.ValuesYaml = obj.Spec.ValuesYaml
 	digest := sha256.New()
 	digest.Write([]byte(template))
 	tag := hex.EncodeToString(digest.Sum(nil))

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,4 +1,4 @@
-#Gpackage
+# package
 github.com/rancher/rancher
 
 k8s.io/kubernetes                             v1.12.2-lite2                            https://github.com/ibuildthecloud/k3s.git  transitive=true,staging=true
@@ -42,7 +42,7 @@ github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f6841
 github.com/rancher/norman                     0557aa4ff31a3a0f007dcb1b684894f23cda390c
 github.com/rancher/kontainer-engine           76256b60bcfa9346ab64d22c14106b500a6cd052
 github.com/rancher/rke                        eedec3c1e9a76708c4821d1172f0ed842b3c9e47
-github.com/rancher/types                      68de51b62acfcced8ea1a6acc9f73cae7d7bc425
+github.com/rancher/types                      e93e22d7a1bca35ef60adb33cc5472687c0d6aee https://github.com/guangbochen/types.git
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
@@ -26,6 +26,7 @@ type AppSpec struct {
 	AppRevisionName     string            `json:"appRevisionName,omitempty" norman:"type=reference[/v3/project/schemas/apprevision]"`
 	Prune               bool              `json:"prune,omitempty"`
 	MultiClusterAppName string            `json:"multiClusterAppName,omitempty" norman:"type=reference[/v3/schemas/multiclusterapp]"`
+	ValuesYaml          string            `json:"valuesYaml,omitempty"`
 }
 
 var (
@@ -73,6 +74,7 @@ type AppRevisionStatus struct {
 	ExternalID  string            `json:"externalId"`
 	Answers     map[string]string `json:"answers"`
 	Digest      string            `json:"digest"`
+	ValuesYaml  string            `json:"valuesYaml,omitempty"`
 }
 
 type AppUpgradeConfig struct {

--- a/vendor/github.com/rancher/types/client/project/v3/zz_generated_app.go
+++ b/vendor/github.com/rancher/types/client/project/v3/zz_generated_app.go
@@ -31,6 +31,7 @@ const (
 	AppFieldTransitioning        = "transitioning"
 	AppFieldTransitioningMessage = "transitioningMessage"
 	AppFieldUUID                 = "uuid"
+	AppFieldValuesYaml           = "valuesYaml"
 )
 
 type App struct {
@@ -60,6 +61,7 @@ type App struct {
 	Transitioning        string            `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
 	TransitioningMessage string            `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
 	UUID                 string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	ValuesYaml           string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }
 
 type AppCollection struct {

--- a/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_revision_status.go
+++ b/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_revision_status.go
@@ -6,6 +6,7 @@ const (
 	AppRevisionStatusFieldDigest     = "digest"
 	AppRevisionStatusFieldExternalID = "externalId"
 	AppRevisionStatusFieldProjectID  = "projectId"
+	AppRevisionStatusFieldValuesYaml = "valuesYaml"
 )
 
 type AppRevisionStatus struct {
@@ -13,4 +14,5 @@ type AppRevisionStatus struct {
 	Digest     string            `json:"digest,omitempty" yaml:"digest,omitempty"`
 	ExternalID string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
 	ProjectID  string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
+	ValuesYaml string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }

--- a/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_spec.go
+++ b/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_spec.go
@@ -11,6 +11,7 @@ const (
 	AppSpecFieldProjectID         = "projectId"
 	AppSpecFieldPrune             = "prune"
 	AppSpecFieldTargetNamespace   = "targetNamespace"
+	AppSpecFieldValuesYaml        = "valuesYaml"
 )
 
 type AppSpec struct {
@@ -23,4 +24,5 @@ type AppSpec struct {
 	ProjectID         string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
 	Prune             bool              `json:"prune,omitempty" yaml:"prune,omitempty"`
 	TargetNamespace   string            `json:"targetNamespace,omitempty" yaml:"targetNamespace,omitempty"`
+	ValuesYaml        string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }


### PR DESCRIPTION
**Problem:**
catalog answer field automatically converts a numbered string into a number instead of keeping it as string #13158

**Solution:**
add a custom parser to identify if answers have the prefix (e.g, `string:11111` will be converted to string `11111`), and convert those values accordingly. If not, fall back to the old one.

**Related Issues:**
#13158 

**Related PRs:**
should be merged after the #17576.

***Example of Testing cases:***
1. deploy the `WordPress` app and set the WordPress password to `string:11111`
2. after the app is launched visiting the WordPress page with /wp-admin
3. check if the user can log in with default username: user, and password: `11111`
