### PR TITLE
FIX env substitution in pipeline config

### DIFF
--- a/pkg/pipeline/engine/jenkins/mappper.go
+++ b/pkg/pipeline/engine/jenkins/mappper.go
@@ -102,12 +102,12 @@ func (c *jenkinsPipelineConverter) convertPipelineExecutionToJenkinsPipeline() (
 	if err := utils.ValidPipelineConfig(c.execution.Spec.PipelineConfig); err != nil {
 		return nil, err
 	}
+	parsePreservedEnvVar(c.execution)
 	script, err := c.convertPipelineExecutionToPipelineScript()
 	if err != nil {
 		return nil, err
 	}
 
-	parsePreservedEnvVar(c.execution)
 	pipelineJob := &PipelineJob{
 		Plugin: WorkflowJobPlugin,
 		Definition: Definition{


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/17757

Problem:
Preserved environment variables do not get substituted in pipeline configs

Solution:
Do envvar substituion before converting to Jenkins pipeline script