### PR TITLE
WIP: Adding cluster initial conditions

### DIFF
--- a/tests/core/test_cluster_defaults.py
+++ b/tests/core/test_cluster_defaults.py
@@ -1,5 +1,7 @@
-import pytest
 import json
+import pytest
+
+from .common import random_str
 
 
 @pytest.mark.skip(reason="cluster-defaults disabled")
@@ -15,12 +17,12 @@ def test_initial_defaults(admin_mc):
         if name == "enableNetworkPolicy":
             schema_defaults["enableNetworkPolicy"] = default
 
-    for name in cclient.schema.types['rancherKubernetesEngineConfig']\
+    for name in cclient.schema.types['rancherKubernetesEngineConfig'] \
             .resourceFields.keys():
         if name == "ignoreDockerVersion":
-            schema_defaults["ignoreDockerVersion"] = cclient.schema.\
-                types["rancherKubernetesEngineConfig"].\
-                resourceFields["ignoreDockerVersion"].\
+            schema_defaults["ignoreDockerVersion"] = cclient.schema. \
+                types["rancherKubernetesEngineConfig"]. \
+                resourceFields["ignoreDockerVersion"]. \
                 data_dict()["default"]
 
     setting = cclient.list_setting(name="cluster-defaults")
@@ -31,3 +33,18 @@ def test_initial_defaults(admin_mc):
         data["rancherKubernetesEngineConfig"]["ignoreDockerVersion"]
 
     assert schema_defaults == setting_defaults
+
+
+def test_initial_conditions(admin_mc, remove_resource):
+    cluster = admin_mc.client.create_cluster(name=random_str())
+    remove_resource(cluster)
+
+    assert len(cluster.conditions) == 3
+    assert cluster.conditions[0].type == 'Pending'
+    assert cluster.conditions[0].status == 'True'
+
+    assert cluster.conditions[1].type == 'Provisioned'
+    assert cluster.conditions[1].status == 'Unknown'
+
+    assert cluster.conditions[2].type == 'Waiting'
+    assert cluster.conditions[2].status == 'Unknown'


### PR DESCRIPTION
This change adds a set of initial conditions to newly created clusters. These
conditions are so that a cluster shows the proper status on the UI before any
controllers have had a chance to run (this can be quite a few moments) on the
cluster.

Issue:
https://github.com/rancher/rancher/issues/16884
https://github.com/rancher/rancher/issues/17282