### PR TITLE
[server-chart] add additional env variables.

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -90,6 +90,9 @@ spec:
         - name: NO_PROXY
           value: {{ .Values.noProxy }}
 {{- end }}
+{{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 8}}
+{{- end }}
         livenessProbe:
           tcpSocket:
             port: 80
@@ -121,7 +124,7 @@ spec:
           name: audit-log
 {{- end }}
 {{- if gt .Values.auditLog.level 0.0 }}
-      # Make audit logs avalible for Rancher log collecter tools.
+      # Make audit logs available for Rancher log collector tools.
       - image: busybox
         name: {{ template "rancher.name" . }}-audit-log
         command: ["tail"]

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -14,3 +14,33 @@ tests:
   - contains:
       path: spec.template.spec.containers[0].args
       content: "--add-local=auto"
+- it: should add CATTLE_SYSTEM_DEFAULT_REGISTRY to env and maintain default vars
+  set:
+    extraEnv:
+    - name: CATTLE_SYSTEM_DEFAULT_REGISTRY
+      value: registry.example.com
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: CATTLE_SYSTEM_DEFAULT_REGISTRY
+        value: registry.example.com
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: CATTLE_PEER_SERVICE
+        value: RELEASE-NAME-rancher
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: CATTLE_NAMESPACE
+        value: NAMESPACE
+- it: should Just have default env vars
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env
+      value:
+      - name: CATTLE_NAMESPACE
+        value: NAMESPACE
+      - name: CATTLE_PEER_SERVICE
+        value: RELEASE-NAME-rancher

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,6 +25,11 @@ addLocal: "auto"
 # Add debug flag to Rancher server
 debug: false
 
+# Extra environment variables passed to the rancher pods.
+# extraEnv:
+# - name: CATTLE_SYSTEM_DEFAULT_REGISTRY
+#   value: "registry.example.com"
+
 # Fully qualified name to reach your Rancher server
 # hostname: rancher.my.org
 

--- a/scripts/chart/build
+++ b/scripts/chart/build
@@ -4,12 +4,12 @@ set -e
 
 echo "-- chart/build --"
 
-cd $(dirname $0)/../..
-. ./scripts/version
+cd $(dirname $0)/..
+. ./version
 
 rm -rf /tmp/chart
 mkdir -p /tmp/chart/
-cp -Rf ./chart /tmp/chart/rancher
+cp -Rf ../chart /tmp/chart/rancher
 
 sed -i -e "s/%VERSION%/${CHART_VERSION}/g" /tmp/chart/rancher/Chart.yaml
 sed -i -e "s/%APP_VERSION%/${VERSION}/g" /tmp/chart/rancher/Chart.yaml

--- a/scripts/chart/copy
+++ b/scripts/chart/copy
@@ -4,8 +4,8 @@ set -e
 
 echo "-- chart/copy --"
 
-cd $(dirname $0)/../..
-. ./scripts/version
+cd $(dirname $0)/..
+. ./version
 
 # A Promotion is from Latest to Stable.
 if [[ -z "${DRONE_TAG}" ]]; then
@@ -19,10 +19,10 @@ if [[ "${CHART_REPO}" != "latest" ]]; then
 fi
 
 # Remove any existing charts.
-rm -rf ./bin/chart
+rm -rf ../bin/chart
 
-mkdir -p ./bin/chart/stable
+mkdir -p ../bin/chart/stable
 
-curl -f -H 'Cache-Control: max-age=0,no-cache' -H 'Host: releases.rancher.com' "https://c.storage.googleapis.com/server-charts/latest/rancher-${CHART_VERSION}.tgz?$(date +%s%N)" -o ./bin/chart/stable/rancher-${CHART_VERSION}.tgz
+curl -f -H 'Cache-Control: max-age=0,no-cache' -H 'Host: releases.rancher.com' "https://c.storage.googleapis.com/server-charts/latest/rancher-${CHART_VERSION}.tgz?$(date +%s%N)" -o ../bin/chart/stable/rancher-${CHART_VERSION}.tgz
 
-./scripts/chart/index stable
+./chart/index stable

--- a/scripts/chart/index
+++ b/scripts/chart/index
@@ -9,4 +9,4 @@ repo_index=${1}
 echo "Getting current index from ${repo_index}"
 curl -f -H 'Cache-Control: max-age=0,no-cache' -H 'Host: releases.rancher.com' "https://c.storage.googleapis.com/server-charts/${repo_index}/index.yaml?$(date +%s%N)" -o /tmp/index.yaml
 
-helm repo index --merge /tmp/index.yaml ./bin/chart/${repo_index}
+helm repo index --merge /tmp/index.yaml ../bin/chart/${repo_index}

--- a/scripts/chart/package
+++ b/scripts/chart/package
@@ -4,16 +4,16 @@ set -e
 
 echo "-- chart/package --"
 
-cd $(dirname $0)/../..
-. ./scripts/version
+cd $(dirname $0)/..
+. ./version
 
-mkdir -p ./bin/chart/${CHART_REPO}
+mkdir -p ../bin/chart/${CHART_REPO}
 
-helm package -d ./bin/chart/${CHART_REPO} /tmp/chart/rancher
+helm package -d ../bin/chart/${CHART_REPO} /tmp/chart/rancher
 
 if [[ "${CHART_REPO}" == "dev" ]]; then
     echo "dev repo - skipping index"
 else
     echo "updating index ... "
-    ./scripts/chart/index ${CHART_REPO}
+    ./chart/index ${CHART_REPO}
 fi

--- a/scripts/chart/test
+++ b/scripts/chart/test
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-cd $(dirname $0)/../..
-
 echo "-- chart/test --"
 
 # Check for helm

--- a/scripts/chart/validate
+++ b/scripts/chart/validate
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-cd $(dirname $0)/../..
-
 echo "-- chart/validate --"
 
 # Check for helm

--- a/scripts/version
+++ b/scripts/version
@@ -7,7 +7,7 @@ fi
 
 COMMIT=$(git rev-parse --short HEAD)
 COMMIT_DATE=$(git --no-pager log -1 --format='%ct')
-COMMIT_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's/\W+/-/g')
+COMMIT_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's/[^a-zA-Z0-9]+/-/g')
 GIT_TAG=${DRONE_TAG:-$(git tag -l --contains HEAD | head -n 1)}
 LAST_TAG=${GIT_TAG:-'v0.0.0'}
 


### PR DESCRIPTION
- Add option to define arbitrary additional environmental variable to rancher pods for #17156 
- Minor fixes for chart build
  - sed replace non-word characters in branch name with `-`
  - change relative path in chart build scripts so `grep vendor.conf` in `script/version` doesn't error.