### PR TITLE
[WIP] Update kontainer-engine and change formatter

### DIFF
--- a/pkg/api/customization/cluster/formatter.go
+++ b/pkg/api/customization/cluster/formatter.go
@@ -59,11 +59,18 @@ func (f *Formatter) Formatter(request *types.APIContext, resource *types.RawReso
 		}
 
 		setTrueIfNil(configMap, "associateWorkerNodePublicIp")
+		setIntIfNil(configMap, "nodeVolumeSize", 20)
 	}
 }
 
 func setTrueIfNil(configMap map[string]interface{}, fieldName string) {
 	if configMap[fieldName] == nil {
 		configMap[fieldName] = true
+	}
+}
+
+func setIntIfNil(configMap map[string]interface{}, fieldName string, replaceVal int) {
+	if configMap[fieldName] == nil {
+		configMap[fieldName] = replaceVal
 	}
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     196df5ed9da30dac3aa715879f44616238b8085f
-github.com/rancher/kontainer-engine           4c182aae43d1b6f954aef261b9866f324df36af3 https://github.com/rmweir/kontainer-engine.git
+github.com/rancher/kontainer-engine           f460a5b15063e93ba75700dc819c4b8bbc39a388 https://github.com/rmweir/kontainer-engine.git
 github.com/rancher/rke                        eedec3c1e9a76708c4821d1172f0ed842b3c9e47
 github.com/rancher/types                      81075bc782ea51c08e3931f7d3b81c61923b0ed3
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     196df5ed9da30dac3aa715879f44616238b8085f
-github.com/rancher/kontainer-engine           447b7766d6aa1f15986c182eb2d7b7e97ef3678e
+github.com/rancher/kontainer-engine           4c182aae43d1b6f954aef261b9866f324df36af3 https://github.com/rmweir/kontainer-engine.git
 github.com/rancher/rke                        eedec3c1e9a76708c4821d1172f0ed842b3c9e47
 github.com/rancher/types                      81075bc782ea51c08e3931f7d3b81c61923b0ed3
 

--- a/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
@@ -408,6 +408,7 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 	if err != nil {
 		return nil, fmt.Errorf("error parsing state: %v", err)
 	}
+
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(state.Region),
 		Credentials: credentials.NewStaticCredentials(

--- a/vendor/github.com/rancher/kontainer-engine/drivers/options/options.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/options/options.go
@@ -11,6 +11,13 @@ func GetValueFromDriverOptions(driverOptions *types.DriverOptions, optionType st
 			}
 		}
 		return int64(0)
+	case types.IntPointerType:
+		for _, key := range keys {
+			if value, ok := driverOptions.IntOptions[key]; ok {
+				return &value
+			}
+		}
+		return nil
 	case types.StringType:
 		for _, key := range keys {
 			if value, ok := driverOptions.StringOptions[key]; ok {

--- a/vendor/github.com/rancher/kontainer-engine/types/types.go
+++ b/vendor/github.com/rancher/kontainer-engine/types/types.go
@@ -13,6 +13,8 @@ const (
 	BoolPointerType = "boolPtr"
 	// IntType is the type for int flag
 	IntType = "int"
+	// IntPointereType flag should be used if the int value can be nil
+	IntPointerType = "intPtr"
 	// StringSliceType is the type for stringSlice flag
 	StringSliceType = "stringSlice"
 )

--- a/vendor/github.com/rancher/kontainer-engine/types/types.go
+++ b/vendor/github.com/rancher/kontainer-engine/types/types.go
@@ -13,7 +13,7 @@ const (
 	BoolPointerType = "boolPtr"
 	// IntType is the type for int flag
 	IntType = "int"
-	// IntPointereType flag should be used if the int value can be nil
+	// IntPointerType flag should be used if the int value can be nil
 	IntPointerType = "intPtr"
 	// StringSliceType is the type for stringSlice flag
 	StringSliceType = "stringSlice"


### PR DESCRIPTION
*WIP*

Problem: User wants to be able to configure node volume size.

Solution: The latest version of kontainer-engine enables the configuration of
node volume size. Formatter will automatically change values of nil to 20.
Clusters that were created before this commit will not have a value for 
nodeVolumeSize in configMap, despite being set to 20 by AWS.

Issue: https://github.com/rancher/rancher/issues/16437