### PR TITLE
Don't check the creator ID when reconciling serviceMonitor

### DIFF
--- a/pkg/controllers/user/servicemonitor/utils.go
+++ b/pkg/controllers/user/servicemonitor/utils.go
@@ -72,7 +72,7 @@ func getServiceMonitorFromWorkload(w *util.Workload) (*monitoringv1.ServiceMonit
 			Annotations: map[string]string{
 				util.WorkloadAnnotation: workloadTargetAnnotation,
 			},
-			GenerateName: "sm-",
+			Name: w.Name,
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{},
 	}
@@ -110,9 +110,6 @@ func getWorkloadFromOwners(namespace string, owners []metav1.OwnerReference, lis
 func areServiceMonitorEqual(a, b *monitoringv1.ServiceMonitor) bool {
 	sort.Sort(EndpointSorter(a.Spec.Endpoints))
 	sort.Sort(EndpointSorter(b.Spec.Endpoints))
-	// if !reflect.DeepEqual(a.Spec.Endpoints, b.Spec.Endpoints) {
-	// 	return false
-	// }
 	if len(a.Spec.Endpoints) != len(b.Spec.Endpoints) {
 		return false
 	}

--- a/pkg/controllers/user/servicemonitor/workloadmetricsservice.go
+++ b/pkg/controllers/user/servicemonitor/workloadmetricsservice.go
@@ -23,10 +23,6 @@ func (c *MetricsServiceController) createService(key string, w *util.Workload) e
 		}
 	}
 
-	if _, ok := w.Annotations[creatorIDAnnotation]; !ok {
-		return nil
-	}
-
 	if errs := validation.IsDNS1123Subdomain(w.Name); len(errs) != 0 {
 		logrus.Debugf("Not creating service for workload [%s]: dns name is invalid", w.Name)
 		return nil
@@ -66,7 +62,7 @@ func (c *MetricsServiceController) ReconcileServiceMonitor(w *util.Workload) err
 			return err
 		}
 	case expectedServiceMonitor != nil: //Create scenario
-		if _, err := c.smClient.Create(expectedServiceMonitor); err != nil {
+		if _, err := c.smClient.Create(expectedServiceMonitor); err != nil && !apierrors.IsAlreadyExists(err) {
 			return err
 		}
 	case sm != nil: //Delete scenario


### PR DESCRIPTION
**Problem:**
The ServiceMonitor only applys to workloads with creatorID

**Soluetion:**
Don't need to check creatorID when reconciling ServiceMonitor
for Workload.

Related issue:
https://github.com/rancher/rancher/issues/17145