### PR TITLE
Update kontainer-engine and change formatter

### DIFF
--- a/pkg/api/customization/cluster/formatter.go
+++ b/pkg/api/customization/cluster/formatter.go
@@ -59,11 +59,18 @@ func (f *Formatter) Formatter(request *types.APIContext, resource *types.RawReso
 		}
 
 		setTrueIfNil(configMap, "associateWorkerNodePublicIp")
+		setIntIfNil(configMap, "nodeVolumeSize", 20)
 	}
 }
 
 func setTrueIfNil(configMap map[string]interface{}, fieldName string) {
 	if configMap[fieldName] == nil {
 		configMap[fieldName] = true
+	}
+}
+
+func setIntIfNil(configMap map[string]interface{}, fieldName string, replaceVal int) {
+	if configMap[fieldName] == nil {
+		configMap[fieldName] = replaceVal
 	}
 }

--- a/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
+++ b/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
@@ -274,7 +274,7 @@ func toResourceField(name string, flag *types.Flag) (string, v3.Field, error) {
 		if flag.Default != nil {
 			field.Default.StringValue = flag.Default.DefaultString
 		}
-	} else if flag.Type == types.IntType {
+	} else if flag.Type == types.IntType || flag.Type == types.IntPointerType {
 		field.Type = "int"
 
 		if flag.Default != nil {

--- a/tests/core/test_kontainer_engine_validation.py
+++ b/tests/core/test_kontainer_engine_validation.py
@@ -68,6 +68,21 @@ def test_min_nodes_cannot_be_zero(admin_mc, remove_resource):
                              "greater than 0")
 
 
+def test_node_volume_size_cannot_be_zero(admin_mc, remove_resource):
+    eks = {
+        "accessKey": "not a real access key",
+        "secretKey": "not a real secret key",
+        "region": "us-west-2",
+        "kubernetesVersion": "1.11",
+        "minimumNodes": 1,
+        "maximumNodes": 3,
+        "nodeVolumeSize": 0
+    }
+    assert_has_error_message(admin_mc, remove_resource, eks,
+                             "error parsing state: node volume size must "
+                             "be greater than 0")
+
+
 def test_private_cluster_requires_vpc_subnets(admin_mc, remove_resource):
     eks = {
         "accessKey": "not a real access key",

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     196df5ed9da30dac3aa715879f44616238b8085f
-github.com/rancher/kontainer-engine           f3300b1bd603b545a30c61a475a686219e08e609
+github.com/rancher/kontainer-engine           a19128afb48bd0f669bc1c4e9b96a597791edc3f
 github.com/rancher/rke                        v0.2.0-rc5
 github.com/rancher/types                      a3c9a8f4614922719729a05256e18f235e918622
 

--- a/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
@@ -91,6 +91,7 @@ type state struct {
 
 	MinimumASGSize int64
 	MaximumASGSize int64
+	NodeVolumeSize *int64
 
 	InstanceType string
 	Region       string
@@ -166,6 +167,13 @@ func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags
 			DefaultInt: 3,
 		},
 	}
+	driverFlag.Options["node-volume-size"] = &types.Flag{
+		Type:  types.IntPointerType,
+		Usage: "The volume size for each node",
+		Default: &types.Default{
+			DefaultInt: 20,
+		},
+	}
 
 	driverFlag.Options["virtual-network"] = &types.Flag{
 		Type:  types.StringType,
@@ -231,6 +239,7 @@ func getStateFromOptions(driverOptions *types.DriverOptions) (state, error) {
 	state.InstanceType = options.GetValueFromDriverOptions(driverOptions, types.StringType, "instance-type", "instanceType").(string)
 	state.MinimumASGSize = options.GetValueFromDriverOptions(driverOptions, types.IntType, "minimum-nodes", "minimumNodes").(int64)
 	state.MaximumASGSize = options.GetValueFromDriverOptions(driverOptions, types.IntType, "maximum-nodes", "maximumNodes").(int64)
+	state.NodeVolumeSize, _ = options.GetValueFromDriverOptions(driverOptions, types.IntPointerType, "node-volume-size", "nodeVolumeSize").(*int64)
 	state.VirtualNetwork = options.GetValueFromDriverOptions(driverOptions, types.StringType, "virtual-network", "virtualNetwork").(string)
 	state.Subnets = options.GetValueFromDriverOptions(driverOptions, types.StringSliceType, "subnets").(*types.StringSlice).Value
 	state.ServiceRole = options.GetValueFromDriverOptions(driverOptions, types.StringType, "service-role", "serviceRole").(string)
@@ -275,6 +284,10 @@ func (state *state) validate() error {
 
 	if state.MaximumASGSize < state.MinimumASGSize {
 		return fmt.Errorf("maximum nodes cannot be less than minimum nodes")
+	}
+
+	if state.NodeVolumeSize != nil && *state.NodeVolumeSize < 1 {
+		return fmt.Errorf("node volume size must be greater than 0")
 	}
 
 	networkEmpty := state.VirtualNetwork == ""
@@ -536,6 +549,13 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 		publicIP = *state.AssociateWorkerNodePublicIP
 	}
 
+	var volumeSize int64
+	if state.NodeVolumeSize == nil {
+		volumeSize = 20
+	} else {
+		volumeSize = *state.NodeVolumeSize
+	}
+
 	stack, err := d.createStack(svc, getWorkNodeName(state.DisplayName), displayName, workerNodesTemplate,
 		[]string{cloudformation.CapabilityCapabilityIam},
 		[]*cloudformation.Parameter{
@@ -548,6 +568,8 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 				int(state.MinimumASGSize)))},
 			{ParameterKey: aws.String("NodeAutoScalingGroupMaxSize"), ParameterValue: aws.String(strconv.Itoa(
 				int(state.MaximumASGSize)))},
+			{ParameterKey: aws.String("NodeVolumeSize"), ParameterValue: aws.String(strconv.Itoa(
+				int(volumeSize)))},
 			{ParameterKey: aws.String("NodeInstanceType"), ParameterValue: aws.String(state.InstanceType)},
 			{ParameterKey: aws.String("NodeImageId"), ParameterValue: aws.String(amiID)},
 			{ParameterKey: aws.String("KeyName"), ParameterValue: aws.String(keyPairName)}, // TODO let the user specify this

--- a/vendor/github.com/rancher/kontainer-engine/drivers/options/options.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/options/options.go
@@ -11,6 +11,13 @@ func GetValueFromDriverOptions(driverOptions *types.DriverOptions, optionType st
 			}
 		}
 		return int64(0)
+	case types.IntPointerType:
+		for _, key := range keys {
+			if value, ok := driverOptions.IntOptions[key]; ok {
+				return &value
+			}
+		}
+		return nil
 	case types.StringType:
 		for _, key := range keys {
 			if value, ok := driverOptions.StringOptions[key]; ok {

--- a/vendor/github.com/rancher/kontainer-engine/types/types.go
+++ b/vendor/github.com/rancher/kontainer-engine/types/types.go
@@ -13,6 +13,8 @@ const (
 	BoolPointerType = "boolPtr"
 	// IntType is the type for int flag
 	IntType = "int"
+	// IntPointerType flag should be used if the int value can be nil
+	IntPointerType = "intPtr"
 	// StringSliceType is the type for stringSlice flag
 	StringSliceType = "stringSlice"
 )


### PR DESCRIPTION
WIP

Problem: User wants to be able to configure node volume size.

Solution: The latest version of kontainer-engine enables the configuration of
node volume size. Formatter will automatically change values of nil to 20.
Clusters that were created before this commit will not have a value for
nodeVolumeSize in configMap, despite being set to 20 by AWS.

Depends on: https://github.com/rancher/kontainer-engine/pull/118

Issue: #16437