### PR TITLE
Giving users the ability to view kontainer drivers

### DIFF
--- a/app/role_data.go
+++ b/app/role_data.go
@@ -24,12 +24,14 @@ func addRoles(management *config.ManagementContext) (string, error) {
 	rb.addRole("Create Clusters", "clusters-create").addRule().apiGroups("management.cattle.io").resources("clusters").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("templates", "templateversions").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("kontainerdrivers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("nodetemplates").verbs("*").
 		addRule().apiGroups("*").resources("secrets").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("etcdbackups").verbs("get", "list", "watch")
 
 	rb.addRole("Manage Node Drivers", "nodedrivers-manage").addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("*")
+	rb.addRole("Manage Cluster Drivers", "kontainerdrivers-manage").addRule().apiGroups("management.cattle.io").resources("kontainerdrivers").verbs("*")
 	rb.addRole("Manage Catalogs", "catalogs-manage").addRule().apiGroups("management.cattle.io").resources("catalogs", "templates", "templateversions").verbs("*")
 	rb.addRole("Use Catalog Templates", "catalogs-use").addRule().apiGroups("management.cattle.io").resources("templates", "templateversions").verbs("get", "list", "watch")
 	rb.addRole("Manage Users", "users-manage").addRule().apiGroups("management.cattle.io").resources("users", "globalrolebindings").verbs("*").
@@ -48,6 +50,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("management.cattle.io").resources("templates", "templateversions").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("clusters").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("kontainerdrivers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("nodetemplates").verbs("*").
 		addRule().apiGroups("*").resources("secrets").verbs("create").

--- a/tests/core/test_rbac.py
+++ b/tests/core/test_rbac.py
@@ -267,9 +267,9 @@ def test_impersonation_passthrough(admin_mc, admin_cc, user_mc, user_factory,
         metadata={'name': 'limited-impersonator'},
         rules=[{
             'resources': ['users'],
-            'apiGroups':[''],
-            'verbs':['impersonate'],
-            'resourceNames':[user2.user.id]
+            'apiGroups': [''],
+            'verbs': ['impersonate'],
+            'resourceNames': [user2.user.id]
         }]
     )
     impersonate_role = admin_rbac.create_cluster_role(body)
@@ -357,3 +357,18 @@ def test_permissions_can_be_removed(admin_cc, admin_mc, user_mc,
 
     user_cc = new_user_cc(user_mc)
     assert len(user_cc.client.list_namespace()) == 1
+
+
+def test_appropriate_users_can_see_kontainer_drivers(user_factory):
+    kds = user_factory().client.list_kontainer_driver()
+    assert len(kds) == 8
+
+    kds = user_factory('clusters-create').client.list_kontainer_driver()
+    assert len(kds) == 8
+
+    kds = user_factory('kontainerdrivers-manage').client. \
+        list_kontainer_driver()
+    assert len(kds) == 8
+
+    kds = user_factory('settings-manage').client.list_kontainer_driver()
+    assert len(kds) == 0


### PR DESCRIPTION
This change gives standard users the ability to view kontainer driver
resources.  This is important because in order to create a cluster the user
must be able to list kontainer drivers to know what options are available.
This capability is also added to the `Create Clusters` role as they also need
to be able to view kontainer drivers.

This also adds a `Manage Cluster Drivers` role to mirror the `Manage Node
Drivers` role.

Issue:
https://github.com/rancher/rancher/issues/17634