### PR TITLE
Corrected the checks in UserclusterIngressController 

### DIFF
--- a/pkg/controllers/user/globaldns/globaldns_common.go
+++ b/pkg/controllers/user/globaldns/globaldns_common.go
@@ -47,6 +47,18 @@ func ifEndpointsDiffer(endpointsOne []string, endpointsTwo []string) bool {
 	return false
 }
 
+func dedupEndpoints(endpoints []string) []string {
+	mapEndpoints := make(map[string]bool)
+	res := []string{}
+	for _, ep := range endpoints {
+		if !mapEndpoints[ep] {
+			mapEndpoints[ep] = true
+			res = append(res, ep)
+		}
+	}
+	return res
+}
+
 func reconcileGlobalDNSEndpoints(globalDNS *v3.GlobalDNS) {
 	//aggregate all clusterEndpoints and form the final DNS endpoints[]
 	var reconciledEps []string

--- a/pkg/controllers/user/globaldns/user_cluster_ingress.go
+++ b/pkg/controllers/user/globaldns/user_cluster_ingress.go
@@ -12,6 +12,7 @@ import (
 	projectv3 "github.com/rancher/types/apis/project.cattle.io/v3"
 	"github.com/rancher/types/config"
 	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -68,36 +69,41 @@ func (ic *UserIngressController) sync(key string, obj *v1beta1.Ingress) (runtime
 	}
 
 	if noGlobalDNS {
-		logrus.Debug("UserIngressController: Skipping run, no Global DNS registered")
 		return nil, nil
 	}
 
 	annotations := obj.Annotations
-
 	//look for globalDNS annotation, if found load the GlobalDNS if there are Ingress endpoints
 	if annotations[annotationGlobalDNS] != "" && len(obj.Status.LoadBalancer.Ingress) > 0 {
 		fqdnRequested := annotations[annotationGlobalDNS]
 		//check if the corresponding GlobalDNS CR is present
 		globalDNS, err := ic.findGlobalDNS(fqdnRequested)
 
-		if globalDNS == nil {
+		if globalDNS == nil || (err != nil && k8serrors.IsNotFound(err)) {
 			return nil, nil
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("UserIngressController: Cannot find GlobalDNS resource for FQDN requested %v", fqdnRequested)
+			return nil, fmt.Errorf("UserIngressController: Error %v while finding  GlobalDNS resource for FQDN requested %v", err, fqdnRequested)
 		}
 
-		//check if 'multiclusterappID' on GlobalDNS CR matches the annotation on ingress OR
-		if err = ic.checkForMultiClusterApp(obj, globalDNS); err != nil {
-			return nil, err
+		//check if 'multiclusterappID' or targetProjects on GlobalDNS CR matches the ingress's app/project
+		if obj.DeletionTimestamp == nil {
+			var checkPassed bool
+			if globalDNS.Spec.MultiClusterAppName != "" {
+				checkPassed, err = ic.checkForMultiClusterApp(obj, globalDNS)
+			} else if len(globalDNS.Spec.ProjectNames) > 0 {
+				//check if 'projectNames' on GlobalDNS CR matches to the user's project for multiclusterapp
+				checkPassed, err = ic.checkForProjects(obj, globalDNS)
+			}
+			if err != nil {
+				return nil, err
+			}
+			if !checkPassed {
+				logrus.Debugf("UserIngressController: Not enqueing update on globaldns %v, for ingress key %v", globalDNS, key)
+				return nil, nil
+			}
 		}
-
-		//check if 'projectNames' on GlobalDNS CR matches to the user's project for multiclusterapp
-		if err = ic.checkForProjects(obj, globalDNS); err != nil {
-			return nil, err
-		}
-
 		//update endpoints on GlobalDNS status field by enqueueing update on GlobalDNS
 		ic.globalDNSs.Controller().Enqueue(namespace.GlobalNamespace, globalDNS.Name)
 
@@ -199,52 +205,63 @@ func (ic *UserIngressController) isProjectApproved(projectsApproved []string, pr
 	return false
 }
 
-func (ic *UserIngressController) checkForMultiClusterApp(obj *v1beta1.Ingress, globalDNS *v3.GlobalDNS) error {
-	if globalDNS.Spec.MultiClusterAppName != "" {
-		ingressLabels := obj.Labels
-		appID := ingressLabels[appSelectorLabel]
+func (ic *UserIngressController) checkForMultiClusterApp(obj *v1beta1.Ingress, globalDNS *v3.GlobalDNS) (bool, error) {
+	ingressLabels := obj.Labels
+	appID := ingressLabels[appSelectorLabel]
 
-		if appID != "" {
-			//find the app CR
-			// go through all projects from multiclusterapp's targets
-			mcappName, err := getMultiClusterAppName(globalDNS.Spec.MultiClusterAppName)
-			if err != nil {
-				return err
+	if appID != "" {
+		//find the app CR
+		// go through all projects from multiclusterapp's targets
+		mcappName, err := getMultiClusterAppName(globalDNS.Spec.MultiClusterAppName)
+		if err != nil {
+			return false, err
+		}
+		mcapp, err := ic.multiclusterappLister.Get(namespace.GlobalNamespace, mcappName)
+		if err != nil && k8serrors.IsNotFound(err) {
+			logrus.Debugf("UserIngressController: multiclusterapp not found by name %v", mcappName)
+			//pass the check and let the controller continue in this case, it will enqueue update to globaldns and the other controller will figure out the endpoint updates
+			return true, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("UserIngressController: Error %v listing multiclusterapp by name %v", err, mcappName)
+		}
+		for _, t := range mcapp.Spec.Targets {
+			split := strings.SplitN(t.ProjectName, ":", 2)
+			if len(split) != 2 {
+				return false, fmt.Errorf("error in splitting project ID %v", t.ProjectName)
 			}
-			mcapp, err := ic.multiclusterappLister.Get(namespace.GlobalNamespace, mcappName)
-			if err != nil {
-				return err
+			if split[0] != ic.clusterName {
+				continue
 			}
-			for _, t := range mcapp.Spec.Targets {
-				split := strings.SplitN(t.ProjectName, ":", 2)
-				if len(split) != 2 {
-					return fmt.Errorf("error in splitting project ID %v", t.ProjectName)
-				}
-				projectNS := split[1]
-				userApp, err := ic.appLister.Get(projectNS, appID)
-				if err != nil {
-					return fmt.Errorf("UserIngressController: Cannot find the App with the Id %v", userApp)
-				}
-				if !strings.EqualFold(userApp.Spec.MultiClusterAppName, globalDNS.Spec.MultiClusterAppName) {
-					return fmt.Errorf("UserIngressController: Cannot configure DNS since the App is not part of MulticlusterApp %v", globalDNS.Spec.MultiClusterAppName)
-				}
+			projectNS := split[1]
+			userApp, err := ic.appLister.Get(projectNS, appID)
+			if err != nil && k8serrors.IsNotFound(err) {
+				logrus.Debugf("UserIngressController: The app %v for this ingress is not under the target namespace %v of multiclusterapp", projectNS, appID)
+				return false, nil
+			} else if err != nil {
+				return false, fmt.Errorf("UserIngressController: Error finding the App with the Id %v under namespace %v", appID, projectNS)
+			}
+
+			if strings.EqualFold(userApp.Spec.MultiClusterAppName, mcappName) {
+				return true, nil
 			}
 		}
 	}
-	return nil
+	return false, nil
 }
 
-func (ic *UserIngressController) checkForProjects(obj *v1beta1.Ingress, globalDNS *v3.GlobalDNS) error {
-	if len(globalDNS.Spec.ProjectNames) > 0 {
-		ns, err := ic.namespaceLister.Get("", obj.Namespace)
-		if err != nil {
-			return fmt.Errorf("UserIngressController: Cannot find the App's namespace with the Id %v, error: %v", obj.Namespace, err)
-		}
-		nameSpaceProject := ns.ObjectMeta.Labels[projectSelectorLabel]
-
-		if !ic.isProjectApproved(globalDNS.Spec.ProjectNames, nameSpaceProject) {
-			return fmt.Errorf("UserIngressController: Cannot configure DNS since the App's project '%v' does not match GlobalDNS projectNames %v", nameSpaceProject, globalDNS.Spec.ProjectNames)
-		}
+func (ic *UserIngressController) checkForProjects(obj *v1beta1.Ingress, globalDNS *v3.GlobalDNS) (bool, error) {
+	ns, err := ic.namespaceLister.Get("", obj.Namespace)
+	if err != nil {
+		return false, fmt.Errorf("UserIngressController: Cannot find the App's namespace with the Id %v, error: %v", obj.Namespace, err)
 	}
-	return nil
+	nameSpaceProject := ns.ObjectMeta.Labels[projectSelectorLabel]
+
+	logrus.Debugf("UserIngressController: check if Ingress's project %v belongs to GlobalDNS target projects %v", nameSpaceProject, globalDNS.Spec.ProjectNames)
+
+	if ic.isProjectApproved(globalDNS.Spec.ProjectNames, nameSpaceProject) {
+		return true, nil
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
- The user_cluster_ingress controller syncs updates on Ingresses that use GlobalDNS, and calls updates on the GlobalDNS object. 
- Before calling this update on GlobalDNS, we ensure that the Ingress belongs to a target project of the GlobalDNS. 
- This check was failing when the Ingress was a part of multiclusterapp due to (1. appID being wrong on Ingress and 2. Multiclusterappname comparison on globalDNS and the App was failing)
- Due to this, updates to GlobalDNS were not getting called on Ingress update.


https://github.com/rancher/rancher/issues/17507
https://github.com/rancher/rancher/issues/17748