### PR TITLE
Add "user-data" to EKS nodes

### DIFF
--- a/tests/core/test_kontainer_engine_config.py
+++ b/tests/core/test_kontainer_engine_config.py
@@ -27,3 +27,49 @@ def test_gke_config_appears_correctly(admin_mc, remove_resource):
 
     # test that a cluster returned from a PUT has the correct config
     assert cluster.googleKubernetesEngineConfig.nodeCount == 4
+
+
+def test_eks_config_appears_correctly(admin_mc, remove_resource):
+    """ Simple test to ensure that cluster returned from POST is correct"""
+    cluster = admin_mc.client.create_cluster(
+        name=random_str(), amazonElasticContainerServiceConfig={
+             "accessKey": "MyAccessKey",
+             "ami": "",
+             "associateWorkerNodePublicIp": True,
+             "displayName": "EKS-api-cluster",
+             "driverName": "amazonelasticcontainerservice",
+             "instanceType": "t3.small",
+             "kubernetesVersion": "1.11",
+             "maximumNodes": 3,
+             "minimumNodes": 1,
+             "region": "us-east-2",
+             "secretKey": "secret-key",
+             "serviceRole": "",
+             "sessionToken": "",
+             "userData": "!#/bin/bash\ntouch /tmp/testfile.txt",
+             "virtualNetwork": "",
+            })
+    remove_resource(cluster)
+
+    # test cluster returned from POST has correct config
+    assert cluster.amazonElasticContainerServiceConfig.maximumNodes == 3
+
+    assert (cluster.amazonElasticContainerServiceConfig.userData ==
+            "!#/bin/bash\ntouch /tmp/testfile.txt")
+
+    clusters = admin_mc.client.list_cluster(name=cluster.name)
+
+    # test that a cluster returned from a list has the correct config
+    assert len(clusters) == 1
+    assert (clusters.data[0].amazonElasticContainerServiceConfig.maximumNodes
+            == 3)
+
+    cluster = admin_mc.client.by_id_cluster(cluster.id)
+    # test that a cluster returned from a GET has the correct config
+    assert cluster.amazonElasticContainerServiceConfig.maximumNodes == 3
+
+    cluster.amazonElasticContainerServiceConfig.maximumNodes = 5
+    cluster = admin_mc.client.update_by_id_cluster(cluster.id, cluster)
+
+    # test that cluster returned from PUT has correct config
+    assert cluster.amazonElasticContainerServiceConfig.maximumNodes == 5

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     196df5ed9da30dac3aa715879f44616238b8085f
-github.com/rancher/kontainer-engine           a19128afb48bd0f669bc1c4e9b96a597791edc3f
+github.com/rancher/kontainer-engine           0544470a0e37edf70909790e63c653fed318fbd6
 github.com/rancher/rke                        v0.2.0-rc5
 github.com/rancher/types                      d8b411ad219d10356ec50e40561029fc7d41bb96
 

--- a/vendor/github.com/rancher/kontainer-engine/cluster/cluster.go
+++ b/vendor/github.com/rancher/kontainer-engine/cluster/cluster.go
@@ -298,14 +298,16 @@ func toInfo(c *Cluster) *types.ClusterInfo {
 
 // Remove removes a cluster
 func (c *Cluster) Remove(ctx context.Context) error {
-	defer c.PersistStore.Remove(c.Name)
 	if err := c.restore(); errors.IsNotFound(err) {
 		return nil
 	} else if err != nil {
 		return err
 	}
 
-	return c.Driver.Remove(ctx, toInfo(c))
+	if err := c.Driver.Remove(ctx, toInfo(c)); err != nil {
+		return err
+	}
+	return c.PersistStore.Remove(c.Name)
 }
 
 func (c *Cluster) GetCapabilities(ctx context.Context) (*types.Capabilities, error) {

--- a/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
@@ -213,7 +213,7 @@ func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags
 		Usage: "Pass user-data to the nodes to perform automated configuration tasks",
 		Default: &types.Default{
 			DefaultString: "#!/bin/bash\nset -o xtrace\n" +
-				"/etc/eks/bootstrap.sh EKS-api-cluster\n" +
+				"/etc/eks/bootstrap.sh ${ClusterName} ${BootstrapArguments}" +
 				"/opt/aws/bin/cfn-signal --exit-code $? " +
 				"--stack  ${AWS::StackName} " +
 				"--resource NodeGroup --region ${AWS::Region}\n",
@@ -263,6 +263,8 @@ func getStateFromOptions(driverOptions *types.DriverOptions) (state, error) {
 	state.SecurityGroups = options.GetValueFromDriverOptions(driverOptions, types.StringSliceType, "security-groups", "securityGroups").(*types.StringSlice).Value
 	state.AMI = options.GetValueFromDriverOptions(driverOptions, types.StringType, "ami").(string)
 	state.AssociateWorkerNodePublicIP, _ = options.GetValueFromDriverOptions(driverOptions, types.BoolPointerType, "associate-worker-node-public-ip", "associateWorkerNodePublicIp").(*bool)
+
+	// UserData
 	state.UserData = options.GetValueFromDriverOptions(driverOptions, types.StringType, "user-data", "userData").(string)
 
 	return state, state.validate()
@@ -427,6 +429,9 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 		return nil, fmt.Errorf("error parsing state: %v", err)
 	}
 
+	info := &types.ClusterInfo{}
+	storeState(info, state)
+
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(state.Region),
 		Credentials: credentials.NewStaticCredentials(
@@ -436,7 +441,7 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 		),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error getting new aws session: %v", err)
+		return info, fmt.Errorf("error getting new aws session: %v", err)
 	}
 
 	svc := cloudformation.New(sess)
@@ -452,14 +457,14 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 		stack, err := d.createStack(svc, getVPCStackName(state.DisplayName), displayName, vpcTemplate, []string{},
 			[]*cloudformation.Parameter{})
 		if err != nil {
-			return nil, fmt.Errorf("error creating stack: %v", err)
+			return info, fmt.Errorf("error creating stack: %v", err)
 		}
 
 		securityGroupsString := getParameterValueFromOutput("SecurityGroups", stack.Stacks[0].Outputs)
 		subnetIdsString := getParameterValueFromOutput("SubnetIds", stack.Stacks[0].Outputs)
 
 		if securityGroupsString == "" || subnetIdsString == "" {
-			return nil, fmt.Errorf("no security groups or subnet ids were returned")
+			return info, fmt.Errorf("no security groups or subnet ids were returned")
 		}
 
 		securityGroups = toStringPointerSlice(strings.Split(securityGroupsString, ","))
@@ -469,7 +474,7 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 			StackName: aws.String(state.DisplayName + "-eks-vpc"),
 		})
 		if err != nil {
-			return nil, fmt.Errorf("error getting stack resoures")
+			return info, fmt.Errorf("error getting stack resoures")
 		}
 
 		for _, resource := range resources.StackResources {
@@ -492,12 +497,12 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 		stack, err := d.createStack(svc, getServiceRoleName(state.DisplayName), displayName, serviceRoleTemplate,
 			[]string{cloudformation.CapabilityCapabilityIam}, nil)
 		if err != nil {
-			return nil, fmt.Errorf("error creating stack: %v", err)
+			return info, fmt.Errorf("error creating stack: %v", err)
 		}
 
 		roleARN = getParameterValueFromOutput("RoleArn", stack.Stacks[0].Outputs)
 		if roleARN == "" {
-			return nil, fmt.Errorf("no RoleARN was returned")
+			return info, fmt.Errorf("no RoleARN was returned")
 		}
 	} else {
 		logrus.Infof("Retrieving existing service role")
@@ -506,7 +511,7 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 			RoleName: aws.String(state.ServiceRole),
 		})
 		if err != nil {
-			return nil, fmt.Errorf("error getting role: %v", err)
+			return info, fmt.Errorf("error getting role: %v", err)
 		}
 
 		roleARN = *role.Role.Arn
@@ -525,19 +530,19 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 		Version: aws.String(state.KubernetesVersion),
 	})
 	if err != nil && !isClusterConflict(err) {
-		return nil, fmt.Errorf("error creating cluster: %v", err)
+		return info, fmt.Errorf("error creating cluster: %v", err)
 	}
 
 	cluster, err := d.waitForClusterReady(eksService, state)
 	if err != nil {
-		return nil, err
+		return info, err
 	}
 
 	logrus.Infof("Cluster provisioned successfully")
 
 	capem, err := base64.StdEncoding.DecodeString(*cluster.Cluster.CertificateAuthority.Data)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing CA data: %v", err)
+		return info, fmt.Errorf("error parsing CA data: %v", err)
 	}
 
 	ec2svc := ec2.New(sess)
@@ -546,7 +551,7 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 		KeyName: aws.String(keyPairName),
 	})
 	if err != nil && !isDuplicateKeyError(err) {
-		return nil, fmt.Errorf("error creating key pair %v", err)
+		return info, fmt.Errorf("error creating key pair %v", err)
 	}
 
 	logrus.Infof("Creating worker nodes")
@@ -600,21 +605,19 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 			{ParameterKey: aws.String("PublicIp"), ParameterValue: aws.String(strconv.FormatBool(publicIP))},
 		})
 	if err != nil {
-		return nil, fmt.Errorf("error creating stack: %v", err)
+		return info, fmt.Errorf("error creating stack: %v", err)
 	}
 
 	nodeInstanceRole := getParameterValueFromOutput("NodeInstanceRole", stack.Stacks[0].Outputs)
 	if nodeInstanceRole == "" {
-		return nil, fmt.Errorf("no node instance role returned in output: %v", err)
+		return info, fmt.Errorf("no node instance role returned in output: %v", err)
 	}
 
 	err = d.createConfigMap(state, *cluster.Cluster.Endpoint, capem, nodeInstanceRole)
 	if err != nil {
-		return nil, err
+		return info, err
 	}
 
-	info := &types.ClusterInfo{}
-	storeState(info, state)
 	return info, nil
 }
 


### PR DESCRIPTION
Problem: We would like to add user-data to EKS nodes.

Solution: Modify default cloudformation template for userData parameter.
If userData is specified then it will use that for EKS node bringup.
Update amazonElasticContainerServiceConfig schema with new userData
resourcefield. Also added integration tests to ensure EKS clusters
behave as expected.
https://github.com/rancher/rancher/issues/16300

*Dependency*
https://github.com/rancher/kontainer-engine/pull/122