### PR TITLE
Update gometalinter to v3.0.0

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -14,7 +14,7 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
 RUN wget -O - https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && curl -L https://raw.githubusercontent.com/alecthomas/gometalinter/v2.0.12/scripts/install.sh | sh
+    go get github.com/rancher/trash && curl -L https://raw.githubusercontent.com/alecthomas/gometalinter/v3.0.0/scripts/install.sh | sh
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \


### PR DESCRIPTION
Version 2.0.12 breaks build with the following error:
```
alecthomas/gometalinter info checking GitHub for latest tag
    alecthomas/gometalinter info found version: 3.0.0 for v3.0.0/linux/amd64
    alecthomas/gometalinter info installed ./bin/gometalinter
    alecthomas/gometalinter info installed ./bin/gocyclo
    alecthomas/gometalinter info installed ./bin/nakedret
    alecthomas/gometalinter info installed ./bin/misspell
    alecthomas/gometalinter info installed ./bin/gosec
    alecthomas/gometalinter info installed ./bin/golint
    alecthomas/gometalinter info installed ./bin/ineffassign
    alecthomas/gometalinter info installed ./bin/goconst
    alecthomas/gometalinter info installed ./bin/errcheck
    alecthomas/gometalinter info installed ./bin/maligned
    alecthomas/gometalinter info installed ./bin/unconvert
    alecthomas/gometalinter info installed ./bin/dupl
    alecthomas/gometalinter info installed ./bin/structcheck
    alecthomas/gometalinter info installed ./bin/varcheck
    alecthomas/gometalinter info installed ./bin/safesql
    alecthomas/gometalinter info installed ./bin/deadcode
    alecthomas/gometalinter info installed ./bin/lll
    alecthomas/gometalinter info installed ./bin/goimports
    alecthomas/gometalinter info installed ./bin/gotype
    install: cannot stat '/tmp/tmp.t5jO1EUy4r/gometalinter-3.0.0-linux-amd64/gosimple': No such file or directory
    The command '/bin/sh -c wget -O - https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local &&     go get github.com/rancher/trash && curl -L https://raw.githubusercontent.com/alecthomas/gometalinter/v2.0.12/scripts/install.sh | sh' returned a non-zero code: 1
    FATA[0028] exit status 1                                
    Makefile:11: recipe for target 'build-server' failed
    make: *** [build-server] Error 1
```