### PR TITLE
Change pending label color and transitioning value

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -180,7 +180,10 @@ func (p *Provisioner) pending(cluster *v3.Cluster) (*v3.Cluster, error) {
 		}
 
 		if driver == "" {
-			return cluster, &controller.ForgetError{Err: fmt.Errorf("waiting for full cluster configuration")}
+			return cluster, &controller.ForgetError{
+				Err:    fmt.Errorf("waiting for full cluster configuration"),
+				Reason: "Pending",
+			}
 		}
 
 		if driver != cluster.Status.Driver {


### PR DESCRIPTION
Problem: The label for pending state should not be red. The "transitioning" field in API should not be error. Concerns about pending state existing for users have not witnessed it before.

Solution: Give forgetError associated with pending state a reason, "Pending". Much like the provisioning state's reason, "Provisioning". The state is now blue, like provisioning and remove states. Transition field has a value of "yes". Previous commits related to other issues ( 
 https://github.com/rancher/rancher/issues/16955 ) have purposely extended the scenario in which user sees "Pending". Previously, rancher would switch between provision and update.

Issues: rancher/rancher#17281, rancher/rancher#15907, rancher/rancher#17201