### PR TITLE
Handle not found error incase multiclusterapp is deleted

### DIFF
--- a/pkg/controllers/user/globaldns/user_cluster_ingress.go
+++ b/pkg/controllers/user/globaldns/user_cluster_ingress.go
@@ -150,6 +150,11 @@ func (ic *UserIngressController) doesGlobalDNSTargetCurrentCluster(globalDNS *v3
 			return false, err
 		}
 		mcapp, err := ic.multiclusterappLister.Get(namespace.GlobalNamespace, mcappName)
+		if err != nil && k8serrors.IsNotFound(err) {
+			logrus.Debugf("UserIngressController: reconcileallgdns, multiclusterapp not found by name %v, might be marked for deletion", mcappName)
+			//pass the check and let the controller continue in this case, it will enqueue update to globaldns and the other controller will figure out the endpoint updates
+			return true, nil
+		}
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
This is the case when MulticlusterApp id selected for a globalDNS and then it is deleted. In this case the ingress gets deleted and the controller tries to reconcile all globalDNS of the cluster. While checking the multiclusterapp, if it gets a not found error, we should continue since the app might be marked for deletion.

https://github.com/rancher/rancher/issues/17833