### PR TITLE
apply http.DefaultTransport DialContext Timeout and KeepAlive to prox…

### DIFF
--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -253,7 +253,10 @@ func ToRESTConfig(cluster *v3.Cluster, context *config.ScaledContext) (*rest.Con
 		Timeout: 30 * time.Second,
 		WrapTransport: func(rt http.RoundTripper) http.RoundTripper {
 			if ht, ok := rt.(*http.Transport); ok {
-				ht.DialContext = nil
+				ht.DialContext = (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext
 				ht.DialTLS = tlsDialer
 				ht.Dial = clusterDialer
 			}


### PR DESCRIPTION
…y and watch

Rancher frequently loses its proxy and watch connections to AKS clusters leading to timeouts while browsing the UI as well as delayed Catalog App deployments. The likely root cause of these failures is the Basic Azure Load Balancer limitation where it doesn't send tcpReset (RST) after an idle timeout. This leads to zombie client connections.

The fix is to use the defaults from http.DefaultTransport for DialContext Timeout and KeepAlive similar to the fix made for [kubectl proxy](https://github.com/kubernetes/kubernetes/pull/63793) to address the same issue.

This fix goes along with https://github.com/rancher/norman/pull/247 to address AKS/rancher integration issues.