### PR TITLE
Add Linode.com machine driver

### DIFF
--- a/app/machinedriver_data.go
+++ b/app/machinedriver_data.go
@@ -47,6 +47,11 @@ func addMachineDrivers(management *config.ManagementContext) error {
 	if err := addMachineDriver("exoscale", "local://", "", "", []string{"api.exoscale.ch"}, false, true, management); err != nil {
 		return err
 	}
+	if err := addMachineDriver("linode", "https://github.com/linode/docker-machine-driver-linode/releases/download/v0.1.6/docker-machine-driver-linode_linux-amd64.zip",
+		"https://linode.github.io/rancher-ui-driver-linode/releases/v0.2.0/component.js", "4d53a20a6ee3090a713c48c2d3f5ed45",
+		[]string{"linode.github.io"}, false, false, management); err != nil {
+		return err
+	}
 	if err := addMachineDriver("openstack", "local://", "", "", nil, false, true, management); err != nil {
 		return err
 	}


### PR DESCRIPTION
This adds the Linode machine driver to the list of drivers available for installation with Rancher.

* Machine Driver: `https://github.com/linode/docker-machine-driver-linode/releases/download/v0.1.6/docker-machine-driver-linode_linux-amd64.zip`
* UI Driver: `https://linode.github.io/rancher-ui-driver-linode/releases/v0.2.0/component.js`
* MD5Sum:  `4d53a20a6ee3090a713c48c2d3f5ed45` (Is a sha sum acceptable here? Seems both are used in the provider list)
* Whitelist Domains: `linode.github.io`
		

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/317653/52570737-1504b680-2de2-11e9-9d18-df0afcc72511.png">

https://linode.github.io/rancher-ui-driver-linode/
https://github.com/linode/docker-machine-driver-linode/
