### PR TITLE
Updating dynamic schemas when kontainer drivers change

### DIFF
--- a/pkg/api/controllers/dynamicschema/dynamicschema.go
+++ b/pkg/api/controllers/dynamicschema/dynamicschema.go
@@ -84,7 +84,13 @@ func (c *Controller) add(dynamicSchema *v3.DynamicSchema) error {
 		schema.ID = dynamicSchema.Name
 	}
 	schema.Version = managementSchema.Version
-	c.Schemas.AddSchema(schema)
+	schema.DynamicSchemaVersion = dynamicSchema.ResourceVersion
+
+	if schema.Embed {
+		c.Schemas.AddSchema(schema)
+	} else {
+		c.Schemas.ForceAddSchema(schema)
+	}
 
 	return nil
 }

--- a/tests/core/test_dynamic_schemas.py
+++ b/tests/core/test_dynamic_schemas.py
@@ -1,0 +1,44 @@
+import copy
+import pytest
+
+from .conftest import wait_until
+
+
+@pytest.mark.nonparallel
+def test_dynamic_schemas_update(request, admin_mc):
+    assert not schema_has_field(admin_mc)
+
+    eks_schema = admin_mc.client.by_id_dynamicSchema(
+        'amazonelasticcontainerserviceconfig')
+
+    new_field = copy.deepcopy(eks_schema.resourceFields['displayName'])
+    new_field.description = 'My special field.'
+    setattr(eks_schema.resourceFields, 'mySpecialField', new_field)
+
+    admin_mc.client.update_by_id_dynamicSchema(eks_schema.id, eks_schema)
+    request.addfinalizer(lambda: cleanup_extra_field(admin_mc))
+    assert schema_has_field(admin_mc)
+
+
+def cleanup_extra_field(admin_mc):
+    eks_schema = admin_mc.client.by_id_dynamicSchema(
+        'amazonelasticcontainerserviceconfig')
+    delattr(eks_schema.resourceFields, 'mySpecialField')
+    admin_mc.client.delete(eks_schema)
+    admin_mc.client.create_dynamicSchema(eks_schema)
+
+    wait_until(lambda: not schema_has_field(admin_mc))
+
+
+def schema_has_field(admin_mc):
+    admin_mc.client.reload_schema()
+    schemas = admin_mc.client.schema.types
+
+    eks_schema = None
+    for name, schema in schemas.items():
+        if name == "amazonElasticContainerServiceConfig":
+            eks_schema = schema
+
+    return hasattr(eks_schema.resourceFields,
+                   'mySpecialField') and eks_schema.resourceFields[
+               'mySpecialField'] is not None

--- a/tests/core/test_kontainer_drivers.py
+++ b/tests/core/test_kontainer_drivers.py
@@ -5,7 +5,7 @@ import pytest
 from .conftest import wait_for_condition, wait_until
 
 DRIVER_URL = "https://github.com/rancher/kontainer-engine-driver-example/" \
-             "releases/download/v0.2.0/kontainer-engine-driver-example-" \
+             "releases/download/v0.2.1/kontainer-engine-driver-example-" \
              + sys.platform
 
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,10 +38,10 @@ github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d756
 github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
-github.com/rancher/norman                     2d37b1235bcfeccf7ecd9e0b1a461f1d9b7fac47
+github.com/rancher/norman                     362802224f64fd09a56be0d275f6ec1d7ecf2164
 github.com/rancher/kontainer-engine           391960fdb29300ebccda7b48e9ad44415782e0a5
 github.com/rancher/rke                        e6b677a885e2d38f4a1604d5ce2d4ae59883f072
-github.com/rancher/types                      7b93e996dc18d5ae6d167eb25ad1e24fc54ac716
+github.com/rancher/types                      6370ec9f4e38c80f3a8161990d1efa8622004ea5
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1

--- a/vendor/github.com/rancher/norman/types/schemas.go
+++ b/vendor/github.com/rancher/norman/types/schemas.go
@@ -108,10 +108,16 @@ func (s *Schemas) removeReferences(schema *Schema) {
 func (s *Schemas) AddSchema(schema Schema) *Schemas {
 	s.Lock()
 	defer s.Unlock()
-	return s.doAddSchema(schema)
+	return s.doAddSchema(schema, false)
 }
 
-func (s *Schemas) doAddSchema(schema Schema) *Schemas {
+func (s *Schemas) ForceAddSchema(schema Schema) *Schemas {
+	s.Lock()
+	defer s.Unlock()
+	return s.doAddSchema(schema, true)
+}
+
+func (s *Schemas) doAddSchema(schema Schema, replace bool) *Schemas {
 	s.setupDefaults(&schema)
 
 	if s.AddHook != nil {
@@ -125,9 +131,20 @@ func (s *Schemas) doAddSchema(schema Schema) *Schemas {
 		s.versions = append(s.versions, schema.Version)
 	}
 
-	if _, ok := schemas[schema.ID]; !ok {
+	if _, ok := schemas[schema.ID]; !ok ||
+		(replace && schema.DynamicSchemaVersion != schemas[schema.ID].DynamicSchemaVersion) {
 		schemas[schema.ID] = &schema
-		s.schemas = append(s.schemas, &schema)
+
+		if replace {
+			for i, candidate := range s.schemas {
+				if candidate.ID == schema.ID {
+					s.schemas[i] = &schema
+					break
+				}
+			}
+		} else {
+			s.schemas = append(s.schemas, &schema)
+		}
 
 		if !schema.Embed {
 			s.addReferences(&schema)
@@ -159,7 +176,7 @@ func (s *Schemas) removeEmbed(schema *Schema) {
 	}
 
 	s.doRemoveSchema(*target)
-	s.doAddSchema(newSchema)
+	s.doAddSchema(newSchema, false)
 }
 
 func (s *Schemas) embed(schema *Schema) {
@@ -184,7 +201,7 @@ func (s *Schemas) embed(schema *Schema) {
 	}
 
 	s.doRemoveSchema(*target)
-	s.doAddSchema(newSchema)
+	s.doAddSchema(newSchema, false)
 }
 
 func (s *Schemas) addReferences(schema *Schema) {

--- a/vendor/github.com/rancher/norman/types/types.go
+++ b/vendor/github.com/rancher/norman/types/types.go
@@ -94,25 +94,26 @@ var NamespaceScope TypeScope = "namespace"
 type TypeScope string
 
 type Schema struct {
-	ID                string            `json:"id,omitempty"`
-	Embed             bool              `json:"embed,omitempty"`
-	EmbedType         string            `json:"embedType,omitempty"`
-	CodeName          string            `json:"-"`
-	CodeNamePlural    string            `json:"-"`
-	PkgName           string            `json:"-"`
-	Type              string            `json:"type,omitempty"`
-	BaseType          string            `json:"baseType,omitempty"`
-	Links             map[string]string `json:"links"`
-	Version           APIVersion        `json:"version"`
-	PluralName        string            `json:"pluralName,omitempty"`
-	ResourceMethods   []string          `json:"resourceMethods,omitempty"`
-	ResourceFields    map[string]Field  `json:"resourceFields"`
-	ResourceActions   map[string]Action `json:"resourceActions,omitempty"`
-	CollectionMethods []string          `json:"collectionMethods,omitempty"`
-	CollectionFields  map[string]Field  `json:"collectionFields,omitempty"`
-	CollectionActions map[string]Action `json:"collectionActions,omitempty"`
-	CollectionFilters map[string]Filter `json:"collectionFilters,omitempty"`
-	Scope             TypeScope         `json:"-"`
+	ID                   string            `json:"id,omitempty"`
+	Embed                bool              `json:"embed,omitempty"`
+	EmbedType            string            `json:"embedType,omitempty"`
+	CodeName             string            `json:"-"`
+	CodeNamePlural       string            `json:"-"`
+	PkgName              string            `json:"-"`
+	Type                 string            `json:"type,omitempty"`
+	BaseType             string            `json:"baseType,omitempty"`
+	Links                map[string]string `json:"links"`
+	Version              APIVersion        `json:"version"`
+	PluralName           string            `json:"pluralName,omitempty"`
+	ResourceMethods      []string          `json:"resourceMethods,omitempty"`
+	ResourceFields       map[string]Field  `json:"resourceFields"`
+	ResourceActions      map[string]Action `json:"resourceActions,omitempty"`
+	CollectionMethods    []string          `json:"collectionMethods,omitempty"`
+	CollectionFields     map[string]Field  `json:"collectionFields,omitempty"`
+	CollectionActions    map[string]Action `json:"collectionActions,omitempty"`
+	CollectionFilters    map[string]Filter `json:"collectionFilters,omitempty"`
+	DynamicSchemaVersion string            `json:"dynamicSchemaVersion,omitempty"`
+	Scope                TypeScope         `json:"-"`
 
 	InternalSchema      *Schema             `json:"-"`
 	Mapper              Mapper              `json:"-"`

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/catalog_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/catalog_types.go
@@ -3,7 +3,6 @@ package v3
 import (
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
-
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema_types.go
@@ -18,18 +18,19 @@ type DynamicSchema struct {
 }
 
 type DynamicSchemaSpec struct {
-	SchemaName        string            `json:"schemaName,omitempty"`
-	Embed             bool              `json:"embed,omitempty"`
-	EmbedType         string            `json:"embedType,omitempty"`
-	PluralName        string            `json:"pluralName,omitempty"`
-	ResourceMethods   []string          `json:"resourceMethods,omitempty"`
-	ResourceFields    map[string]Field  `json:"resourceFields,omitempty"`
-	ResourceActions   map[string]Action `json:"resourceActions,omitempty"`
-	CollectionMethods []string          `json:"collectionMethods,omitempty"`
-	CollectionFields  map[string]Field  `json:"collectionFields,omitempty"`
-	CollectionActions map[string]Action `json:"collectionActions,omitempty"`
-	CollectionFilters map[string]Filter `json:"collectionFilters,omitempty"`
-	IncludeableLinks  []string          `json:"includeableLinks,omitempty"`
+	SchemaName           string            `json:"schemaName,omitempty"`
+	Embed                bool              `json:"embed,omitempty"`
+	EmbedType            string            `json:"embedType,omitempty"`
+	PluralName           string            `json:"pluralName,omitempty"`
+	ResourceMethods      []string          `json:"resourceMethods,omitempty"`
+	ResourceFields       map[string]Field  `json:"resourceFields,omitempty"`
+	ResourceActions      map[string]Action `json:"resourceActions,omitempty"`
+	CollectionMethods    []string          `json:"collectionMethods,omitempty"`
+	CollectionFields     map[string]Field  `json:"collectionFields,omitempty"`
+	CollectionActions    map[string]Action `json:"collectionActions,omitempty"`
+	CollectionFilters    map[string]Filter `json:"collectionFilters,omitempty"`
+	IncludeableLinks     []string          `json:"includeableLinks,omitempty"`
+	DynamicSchemaVersion string            `json:"dynamicSchemaVersion,omitempty"`
 }
 
 type DynamicSchemaStatus struct {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
@@ -75,12 +75,14 @@ type AppRevisionStatus struct {
 	Answers     map[string]string `json:"answers"`
 	Digest      string            `json:"digest"`
 	ValuesYaml  string            `json:"valuesYaml,omitempty"`
+	Files       map[string]string `json:"files,omitempty"`
 }
 
 type AppUpgradeConfig struct {
 	ExternalID   string            `json:"externalId,omitempty"`
 	Answers      map[string]string `json:"answers,omitempty"`
 	ForceUpgrade bool              `json:"forceUpgrade,omitempty"`
+	Files        map[string]string `json:"files,omitempty"`
 }
 
 type RollbackRevision struct {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_deepcopy.go
@@ -170,6 +170,13 @@ func (in *AppRevisionStatus) DeepCopyInto(out *AppRevisionStatus) {
 			(*out)[key] = val
 		}
 	}
+	if in.Files != nil {
+		in, out := &in.Files, &out.Files
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -246,6 +253,13 @@ func (in *AppUpgradeConfig) DeepCopyInto(out *AppUpgradeConfig) {
 	*out = *in
 	if in.Answers != nil {
 		in, out := &in.Answers, &out.Answers
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Files != nil {
+		in, out := &in.Files, &out.Files
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_dynamic_schema.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_dynamic_schema.go
@@ -13,6 +13,7 @@ const (
 	DynamicSchemaFieldCollectionMethods    = "collectionMethods"
 	DynamicSchemaFieldCreated              = "created"
 	DynamicSchemaFieldCreatorID            = "creatorId"
+	DynamicSchemaFieldDynamicSchemaVersion = "dynamicSchemaVersion"
 	DynamicSchemaFieldEmbed                = "embed"
 	DynamicSchemaFieldEmbedType            = "embedType"
 	DynamicSchemaFieldIncludeableLinks     = "includeableLinks"
@@ -41,6 +42,7 @@ type DynamicSchema struct {
 	CollectionMethods    []string             `json:"collectionMethods,omitempty" yaml:"collectionMethods,omitempty"`
 	Created              string               `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID            string               `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	DynamicSchemaVersion string               `json:"dynamicSchemaVersion,omitempty" yaml:"dynamicSchemaVersion,omitempty"`
 	Embed                bool                 `json:"embed,omitempty" yaml:"embed,omitempty"`
 	EmbedType            string               `json:"embedType,omitempty" yaml:"embedType,omitempty"`
 	IncludeableLinks     []string             `json:"includeableLinks,omitempty" yaml:"includeableLinks,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_dynamic_schema_spec.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_dynamic_schema_spec.go
@@ -1,32 +1,34 @@
 package client
 
 const (
-	DynamicSchemaSpecType                   = "dynamicSchemaSpec"
-	DynamicSchemaSpecFieldCollectionActions = "collectionActions"
-	DynamicSchemaSpecFieldCollectionFields  = "collectionFields"
-	DynamicSchemaSpecFieldCollectionFilters = "collectionFilters"
-	DynamicSchemaSpecFieldCollectionMethods = "collectionMethods"
-	DynamicSchemaSpecFieldEmbed             = "embed"
-	DynamicSchemaSpecFieldEmbedType         = "embedType"
-	DynamicSchemaSpecFieldIncludeableLinks  = "includeableLinks"
-	DynamicSchemaSpecFieldPluralName        = "pluralName"
-	DynamicSchemaSpecFieldResourceActions   = "resourceActions"
-	DynamicSchemaSpecFieldResourceFields    = "resourceFields"
-	DynamicSchemaSpecFieldResourceMethods   = "resourceMethods"
-	DynamicSchemaSpecFieldSchemaName        = "schemaName"
+	DynamicSchemaSpecType                      = "dynamicSchemaSpec"
+	DynamicSchemaSpecFieldCollectionActions    = "collectionActions"
+	DynamicSchemaSpecFieldCollectionFields     = "collectionFields"
+	DynamicSchemaSpecFieldCollectionFilters    = "collectionFilters"
+	DynamicSchemaSpecFieldCollectionMethods    = "collectionMethods"
+	DynamicSchemaSpecFieldDynamicSchemaVersion = "dynamicSchemaVersion"
+	DynamicSchemaSpecFieldEmbed                = "embed"
+	DynamicSchemaSpecFieldEmbedType            = "embedType"
+	DynamicSchemaSpecFieldIncludeableLinks     = "includeableLinks"
+	DynamicSchemaSpecFieldPluralName           = "pluralName"
+	DynamicSchemaSpecFieldResourceActions      = "resourceActions"
+	DynamicSchemaSpecFieldResourceFields       = "resourceFields"
+	DynamicSchemaSpecFieldResourceMethods      = "resourceMethods"
+	DynamicSchemaSpecFieldSchemaName           = "schemaName"
 )
 
 type DynamicSchemaSpec struct {
-	CollectionActions map[string]Action `json:"collectionActions,omitempty" yaml:"collectionActions,omitempty"`
-	CollectionFields  map[string]Field  `json:"collectionFields,omitempty" yaml:"collectionFields,omitempty"`
-	CollectionFilters map[string]Filter `json:"collectionFilters,omitempty" yaml:"collectionFilters,omitempty"`
-	CollectionMethods []string          `json:"collectionMethods,omitempty" yaml:"collectionMethods,omitempty"`
-	Embed             bool              `json:"embed,omitempty" yaml:"embed,omitempty"`
-	EmbedType         string            `json:"embedType,omitempty" yaml:"embedType,omitempty"`
-	IncludeableLinks  []string          `json:"includeableLinks,omitempty" yaml:"includeableLinks,omitempty"`
-	PluralName        string            `json:"pluralName,omitempty" yaml:"pluralName,omitempty"`
-	ResourceActions   map[string]Action `json:"resourceActions,omitempty" yaml:"resourceActions,omitempty"`
-	ResourceFields    map[string]Field  `json:"resourceFields,omitempty" yaml:"resourceFields,omitempty"`
-	ResourceMethods   []string          `json:"resourceMethods,omitempty" yaml:"resourceMethods,omitempty"`
-	SchemaName        string            `json:"schemaName,omitempty" yaml:"schemaName,omitempty"`
+	CollectionActions    map[string]Action `json:"collectionActions,omitempty" yaml:"collectionActions,omitempty"`
+	CollectionFields     map[string]Field  `json:"collectionFields,omitempty" yaml:"collectionFields,omitempty"`
+	CollectionFilters    map[string]Filter `json:"collectionFilters,omitempty" yaml:"collectionFilters,omitempty"`
+	CollectionMethods    []string          `json:"collectionMethods,omitempty" yaml:"collectionMethods,omitempty"`
+	DynamicSchemaVersion string            `json:"dynamicSchemaVersion,omitempty" yaml:"dynamicSchemaVersion,omitempty"`
+	Embed                bool              `json:"embed,omitempty" yaml:"embed,omitempty"`
+	EmbedType            string            `json:"embedType,omitempty" yaml:"embedType,omitempty"`
+	IncludeableLinks     []string          `json:"includeableLinks,omitempty" yaml:"includeableLinks,omitempty"`
+	PluralName           string            `json:"pluralName,omitempty" yaml:"pluralName,omitempty"`
+	ResourceActions      map[string]Action `json:"resourceActions,omitempty" yaml:"resourceActions,omitempty"`
+	ResourceFields       map[string]Field  `json:"resourceFields,omitempty" yaml:"resourceFields,omitempty"`
+	ResourceMethods      []string          `json:"resourceMethods,omitempty" yaml:"resourceMethods,omitempty"`
+	SchemaName           string            `json:"schemaName,omitempty" yaml:"schemaName,omitempty"`
 }

--- a/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_revision_status.go
+++ b/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_revision_status.go
@@ -5,6 +5,7 @@ const (
 	AppRevisionStatusFieldAnswers    = "answers"
 	AppRevisionStatusFieldDigest     = "digest"
 	AppRevisionStatusFieldExternalID = "externalId"
+	AppRevisionStatusFieldFiles      = "files"
 	AppRevisionStatusFieldProjectID  = "projectId"
 	AppRevisionStatusFieldValuesYaml = "valuesYaml"
 )
@@ -13,6 +14,7 @@ type AppRevisionStatus struct {
 	Answers    map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
 	Digest     string            `json:"digest,omitempty" yaml:"digest,omitempty"`
 	ExternalID string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
+	Files      map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
 	ProjectID  string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
 	ValuesYaml string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }

--- a/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_upgrade_config.go
+++ b/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_upgrade_config.go
@@ -4,11 +4,13 @@ const (
 	AppUpgradeConfigType              = "appUpgradeConfig"
 	AppUpgradeConfigFieldAnswers      = "answers"
 	AppUpgradeConfigFieldExternalID   = "externalId"
+	AppUpgradeConfigFieldFiles        = "files"
 	AppUpgradeConfigFieldForceUpgrade = "forceUpgrade"
 )
 
 type AppUpgradeConfig struct {
 	Answers      map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
 	ExternalID   string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
+	Files        map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
 	ForceUpgrade bool              `json:"forceUpgrade,omitempty" yaml:"forceUpgrade,omitempty"`
 }


### PR DESCRIPTION
This change makes it so that kontainer driver schemas will update when their
corresponding driver options update.  It works by adding a new method to the
norman Schemas struct `ForceAddSchema`.  This allows schemas that already
exist to be updated without getting stuck in endless loops.

Depends on:
https://github.com/rancher/types/pull/708
https://github.com/rancher/norman/pull/249

Issue:
https://github.com/rancher/rancher/issues/17712