### PR TITLE
Add SSH keys to EKS nodes

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -41,7 +41,7 @@ github.com/robfig/cron                        v1.1
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     c55b1eed181c98c6f3985d306608ffcbbbc5898b
 github.com/rancher/types                      e3a7b1174de6d7d1d202bbc4e919d9cc99d6b9a6
-github.com/rancher/kontainer-engine           071b4a6da0600bbba904eda5a6645b8866812b96
+github.com/rancher/kontainer-engine           f346ce86d3402370e36e04fd64026debb72220c7
 github.com/rancher/rke                        v0.2.0
 
 gopkg.in/ldap.v2                              v2.5.0

--- a/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
@@ -81,12 +81,12 @@ type Driver struct {
 }
 
 type state struct {
-	ClusterName  string
-	DisplayName  string
-	ClientID     string
-	ClientSecret string
-	SessionToken string
-
+	ClusterName       string
+	DisplayName       string
+	ClientID          string
+	ClientSecret      string
+	SessionToken      string
+	KeyPairName       string
 	KubernetesVersion string
 
 	MinimumASGSize int64
@@ -219,6 +219,13 @@ func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags
 				"--resource NodeGroup --region ${AWS::Region}\n",
 		},
 	}
+	driverFlag.Options["keyPairName"] = &types.Flag{
+		Type:  types.StringType,
+		Usage: "Allow user to specify key name to use",
+		Default: &types.Default{
+			DefaultString: "",
+		},
+	}
 
 	driverFlag.Options["kubernetes-version"] = &types.Flag{
 		Type:    types.StringType,
@@ -276,6 +283,7 @@ func getStateFromOptions(driverOptions *types.DriverOptions) (state, error) {
 	state.SecurityGroups = options.GetValueFromDriverOptions(driverOptions, types.StringSliceType, "security-groups", "securityGroups").(*types.StringSlice).Value
 	state.AMI = options.GetValueFromDriverOptions(driverOptions, types.StringType, "ami").(string)
 	state.AssociateWorkerNodePublicIP, _ = options.GetValueFromDriverOptions(driverOptions, types.BoolPointerType, "associate-worker-node-public-ip", "associateWorkerNodePublicIp").(*bool)
+	state.KeyPairName = options.GetValueFromDriverOptions(driverOptions, types.StringType, "keyPairName").(string)
 
 	// UserData
 	state.UserData = options.GetValueFromDriverOptions(driverOptions, types.StringType, "user-data", "userData").(string)
@@ -561,12 +569,22 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 	if err != nil {
 		return info, fmt.Errorf("error parsing CA data: %v", err)
 	}
-
+	// SSH Key pair creation
 	ec2svc := ec2.New(sess)
-	keyPairName := getEC2KeyPairName(state.DisplayName)
-	_, err = ec2svc.CreateKeyPair(&ec2.CreateKeyPairInput{
-		KeyName: aws.String(keyPairName),
-	})
+	// make keyPairName visible outside of conditional scope
+	keyPairName := state.KeyPairName
+
+	if keyPairName == "" {
+		keyPairName := getEC2KeyPairName(state.DisplayName)
+		_, err = ec2svc.CreateKeyPair(&ec2.CreateKeyPairInput{
+			KeyName: aws.String(keyPairName),
+		})
+	} else {
+		_, err = ec2svc.CreateKeyPair(&ec2.CreateKeyPairInput{
+			KeyName: aws.String(keyPairName),
+		})
+	}
+
 	if err != nil && !isDuplicateKeyError(err) {
 		return info, fmt.Errorf("error creating key pair %v", err)
 	}
@@ -615,7 +633,7 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 				int(volumeSize)))},
 			{ParameterKey: aws.String("NodeInstanceType"), ParameterValue: aws.String(state.InstanceType)},
 			{ParameterKey: aws.String("NodeImageId"), ParameterValue: aws.String(amiID)},
-			{ParameterKey: aws.String("KeyName"), ParameterValue: aws.String(keyPairName)}, // TODO let the user specify this
+			{ParameterKey: aws.String("KeyName"), ParameterValue: aws.String(keyPairName)},
 			{ParameterKey: aws.String("VpcId"), ParameterValue: aws.String(vpcid)},
 			{ParameterKey: aws.String("Subnets"),
 				ParameterValue: aws.String(strings.Join(toStringLiteralSlice(subnetIds), ","))},


### PR DESCRIPTION
Problem: We would like to specify the SSH key to be used.

Solution:
Add a field 'keyPairName' to the schema to support using a previously
created SSH key in EC2.
https://github.com/rancher/rancher/issues/14598
*Dependency on*
https://github.com/rancher/kontainer-engine/pull/125