### PR TITLE
[WIP] Updated kontainer engine to latest

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     196df5ed9da30dac3aa715879f44616238b8085f
-github.com/rancher/kontainer-engine           f3300b1bd603b545a30c61a475a686219e08e609
+github.com/rancher/kontainer-engine           0f15d786cb51b707b5bcb1e23110647ffc381468 https://github.com/rmweir/kontainer-engine.git
 github.com/rancher/rke                        v0.2.0-rc5
 github.com/rancher/types                      a3c9a8f4614922719729a05256e18f235e918622
 

--- a/vendor/github.com/rancher/kontainer-engine/cluster/cluster.go
+++ b/vendor/github.com/rancher/kontainer-engine/cluster/cluster.go
@@ -298,14 +298,16 @@ func toInfo(c *Cluster) *types.ClusterInfo {
 
 // Remove removes a cluster
 func (c *Cluster) Remove(ctx context.Context) error {
-	defer c.PersistStore.Remove(c.Name)
 	if err := c.restore(); errors.IsNotFound(err) {
 		return nil
 	} else if err != nil {
 		return err
 	}
 
-	return c.Driver.Remove(ctx, toInfo(c))
+	if err := c.Driver.Remove(ctx, toInfo(c)); err != nil {
+		return err
+	}
+	return c.PersistStore.Remove(c.Name)
 }
 
 func (c *Cluster) GetCapabilities(ctx context.Context) (*types.Capabilities, error) {


### PR DESCRIPTION
WIP

Problem: Clusters failing to remove when error encountered upon creation.

Solution: The latest version of kontainer engine prevents unmarshalling error by
returning state info during creation along with errors. Kontainer engine now only
removes cluster from persist store if remove was successful. GKE driver retries
long enough for cluster to finish provisioning.

Issue: #17424 