### PR TITLE
Allow users to select global/cluster catalog in dropdown during launch

### DIFF
--- a/app/role_data.go
+++ b/app/role_data.go
@@ -47,7 +47,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 	rb.addRole("User", "user").addRule().apiGroups("management.cattle.io").resources("principals", "roletemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("preferences").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("settings").verbs("get", "list", "watch").
-		addRule().apiGroups("management.cattle.io").resources("templates", "templateversions").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("templates", "templateversions", "catalogs").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("clusters").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("kontainerdrivers").verbs("get", "list", "watch").

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -36,6 +36,7 @@ var projectManagmentPlaneResources = []string{
 }
 var prtbClusterManagmentPlaneResources = []string{
 	"notifiers",
+	"clustercatalogs",
 	"catalogtemplates",
 	"catalogtemplateversions",
 }

--- a/tests/core/test_catalog.py
+++ b/tests/core/test_catalog.py
@@ -86,3 +86,11 @@ def test_global_catalog_template_access(admin_mc, user_factory,
 
     client.delete(catalog)
     wait_for_template_to_be_deleted(client, name)
+
+
+def test_user_can_list_global_catalog(user_factory, remove_resource):
+    user1 = user_factory()
+    remove_resource(user1)
+    user_client = user1.client
+    c = user_client.list_catalog(name="library")
+    assert len(c) == 1

--- a/tests/core/test_project_catalog.py
+++ b/tests/core/test_project_catalog.py
@@ -112,8 +112,6 @@ def test_create_project_catalog_after_user_addition(admin_mc,
     name = random_str()
     project_name = str.lstrip(admin_pc.project.id, "local:")
     catalog_name = project_name + ":" + name
-    # template_name = "local-" + project_name + "-" + name + "-etcd-operator"
-    # template_version_name = template_name + "-0.7.6"
     url = "https://github.com/mrajashree/charts.git"
 
     project = admin_pc.project


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/17638

Adding rule for "catalogs" for user role allows all users to list global catalogs. This will in turn let cluster and project roles list global catalogs as requested in the issue. Adding cluster-catalogs to `prtbClusterManagmentPlaneResources` will allow project roles to list cluster catalog as requested in the issue