### PR TITLE
Change SAML redirect and error code based on action

### DIFF
--- a/pkg/auth/providers/saml/saml_actions.go
+++ b/pkg/auth/providers/saml/saml_actions.go
@@ -56,7 +56,7 @@ func (s *Provider) testAndEnable(actionName string, action *types.Action, reques
 	finalRedirectURL := samlLogin.FinalRedirectURL
 	provider.clientState.SetState(request.Response, request.Request, "Rancher_UserID", provider.userMGR.GetUser(request))
 	provider.clientState.SetState(request.Response, request.Request, "Rancher_FinalRedirectURL", finalRedirectURL)
-	provider.clientState.SetState(request.Response, request.Request, "Rancher_Action", "testAndEnable")
+	provider.clientState.SetState(request.Response, request.Request, "Rancher_Action", testAndEnableAction)
 	idpRedirectURL, err := provider.HandleSamlLogin(request.Response, request.Request)
 	if err != nil {
 		return err

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -26,10 +26,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const PingName = "ping"
-const ADFSName = "adfs"
-const KeyCloakName = "keycloak"
-const OKTAName = "okta"
+const (
+	PingName            = "ping"
+	ADFSName            = "adfs"
+	KeyCloakName        = "keycloak"
+	OKTAName            = "okta"
+	loginAction         = "login"
+	testAndEnableAction = "testAndEnable"
+)
 
 type Provider struct {
 	ctx             context.Context
@@ -99,7 +103,7 @@ func PerformSamlLogin(name string, apiContext *types.APIContext, input interface
 
 	if provider, ok := SamlProviders[name]; ok {
 		provider.clientState.SetState(apiContext.Response, apiContext.Request, "Rancher_FinalRedirectURL", finalRedirectURL)
-		provider.clientState.SetState(apiContext.Response, apiContext.Request, "Rancher_Action", "login")
+		provider.clientState.SetState(apiContext.Response, apiContext.Request, "Rancher_Action", loginAction)
 		idpRedirectURL, err := provider.HandleSamlLogin(apiContext.Response, apiContext.Request)
 		if err != nil {
 			return err


### PR DESCRIPTION
Change error code for incorrect attributes to 422
Redirects for login action should have /login in the route and those for testAndEnable action should have `&` before adding errorCode, because UI sets the first param to `?config=samlProviderName`

https://github.com/rancher/rancher/issues/15530

Tested with UI changes and seems to work