### PR TITLE
Add an identifier for external-dns records to avoid deleting records added by other providers

### DIFF
--- a/pkg/controllers/management/globaldns/cloudflare_template.go
+++ b/pkg/controllers/management/globaldns/cloudflare_template.go
@@ -24,6 +24,7 @@ spec:
         - --provider=cloudflare
         - --cloudflare-proxied # (optional) enable the proxy feature of Cloudflare (DDOS protection, CDN...)
         - --log-level=debug
+        - --txt-owner-id={{.identifier}}
         - --publish-internal-services
         env:
         - name: CF_API_KEY

--- a/pkg/controllers/management/globaldns/globaldns_provider.go
+++ b/pkg/controllers/management/globaldns/globaldns_provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/types/config"
 	"github.com/sirupsen/logrus"
 
+	"github.com/rancher/rancher/pkg/settings"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	k8srbacV1 "k8s.io/api/rbac/v1beta1"
@@ -106,12 +107,15 @@ func (n *ProviderLauncher) sync(key string, obj *v3.GlobalDNSProvider) (runtime.
 }
 
 func (n *ProviderLauncher) handleRoute53Provider(obj *v3.GlobalDNSProvider) (runtime.Object, error) {
+	rancherInstallUUID := settings.InstallUUID.Get()
+
 	//create external-dns route53 provider
 	data := map[string]interface{}{
 		"awsAccessKey":   obj.Spec.Route53ProviderConfig.AccessKey,
 		"awsSecretKey":   obj.Spec.Route53ProviderConfig.SecretKey,
 		"route53Domain":  obj.Spec.Route53ProviderConfig.RootDomain,
 		"deploymentName": obj.Name,
+		"identifier":     rancherInstallUUID + "_" + obj.Name,
 	}
 	if err := n.createExternalDNSDeployment(obj, data, Route53DeploymentTemplate, Route53DNSProvider); err != nil {
 		return nil, err
@@ -121,12 +125,14 @@ func (n *ProviderLauncher) handleRoute53Provider(obj *v3.GlobalDNSProvider) (run
 }
 
 func (n *ProviderLauncher) handleCloudflareProvider(obj *v3.GlobalDNSProvider) (runtime.Object, error) {
+	rancherInstallUUID := settings.InstallUUID.Get()
 	//create external-dns cloudflare provider
 	data := map[string]interface{}{
 		"apiKey":           obj.Spec.CloudflareProviderConfig.APIKey,
 		"apiEmail":         obj.Spec.CloudflareProviderConfig.APIEmail,
 		"cloudflareDomain": obj.Spec.CloudflareProviderConfig.RootDomain,
 		"deploymentName":   obj.Name,
+		"identifier":       rancherInstallUUID + "_" + obj.Name,
 	}
 	if err := n.createExternalDNSDeployment(obj, data, CloudflareDeploymentTemplate, CloudflareDNSProvider); err != nil {
 		return nil, err

--- a/pkg/controllers/management/globaldns/route53_template.go
+++ b/pkg/controllers/management/globaldns/route53_template.go
@@ -29,6 +29,6 @@ spec:
         - --provider=aws
         - --aws-zone-type=public # only look at public hosted zones (valid values are public, private or no value for both)
         - --registry=txt
-        - --txt-owner-id=my-identifier
+        - --txt-owner-id={{.identifier}}
         - --log-level=debug
         - --publish-internal-services`


### PR DESCRIPTION
Add an identifier for external-dns records to avoid deleting records added by other providers

Fix for https://github.com/rancher/rancher/issues/17812