### PR TITLE
Auth refresh in HA unreliable

### DIFF
--- a/pkg/api/customization/authn/user_actions.go
+++ b/pkg/api/customization/authn/user_actions.go
@@ -33,6 +33,7 @@ func (h *Handler) CollectionFormatter(apiContext *types.APIContext, collection *
 type Handler struct {
 	UserClient               v3.UserInterface
 	GlobalRoleBindingsClient v3.GlobalRoleBindingInterface
+	UserAuthRefresher        providerrefresh.UserAuthRefresher
 }
 
 func (h *Handler) Actions(actionName string, action *types.Action, apiContext *types.APIContext) error {
@@ -156,9 +157,9 @@ func (h *Handler) refreshAttributes(actionName string, action *types.Action, req
 	}
 
 	if request.ID != "" {
-		providerrefresh.TriggerUserRefresh(request.ID, true)
+		h.UserAuthRefresher.TriggerUserRefresh(request.ID, true)
 	} else {
-		providerrefresh.TriggerAllUserRefresh()
+		h.UserAuthRefresher.TriggerAllUserRefresh()
 	}
 
 	request.WriteResponse(http.StatusOK, nil)

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -41,6 +41,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/store/scoped"
 	"github.com/rancher/rancher/pkg/api/store/userscope"
 	"github.com/rancher/rancher/pkg/auth/principals"
+	"github.com/rancher/rancher/pkg/auth/providerrefresh"
 	"github.com/rancher/rancher/pkg/auth/providers"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/controllers/management/compose/common"
@@ -131,7 +132,7 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	ClusterRoleTemplateBinding(schemas, apiContext)
 	Templates(ctx, schemas, apiContext)
 	TemplateVersion(ctx, schemas, apiContext)
-	User(schemas, apiContext)
+	User(ctx, schemas, apiContext)
 	Catalog(schemas, apiContext)
 	ProjectCatalog(schemas, apiContext)
 	ClusterCatalog(schemas, apiContext)
@@ -365,11 +366,12 @@ func SecretTypes(ctx context.Context, schemas *types.Schemas, management *config
 	credSchema.Validator = cred.Validator
 }
 
-func User(schemas *types.Schemas, management *config.ScaledContext) {
+func User(ctx context.Context, schemas *types.Schemas, management *config.ScaledContext) {
 	schema := schemas.Schema(&managementschema.Version, client.UserType)
 	handler := &authn.Handler{
 		UserClient:               management.Management.Users(""),
 		GlobalRoleBindingsClient: management.Management.GlobalRoleBindings(""),
+		UserAuthRefresher:        providerrefresh.NewUserAuthRefresher(ctx, management),
 	}
 
 	schema.Formatter = handler.UserFormatter


### PR DESCRIPTION
Problem: In an HA setup, the user auth refresh logic that is triggered
from an API action did not work properly. The controllers and logic
were setup such that it would only work on the "leader" node. On
non-leader nodes, the logic would panic.

This fixes the problem by move the logic to the proper API scope,
ensuring that it is available and proeprly configured on every node.

https://github.com/rancher/rancher/issues/17939