### PR TITLE
[server-chart] configurable busybox image

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -125,7 +125,7 @@ spec:
 {{- end }}
 {{- if gt .Values.auditLog.level 0.0 }}
       # Make audit logs available for Rancher log collector tools.
-      - image: busybox
+      - image: {{ .Values.busyboxImage }}
         name: {{ template "rancher.name" . }}-audit-log
         command: ["tail"]
         args: ["-F", "/var/log/auditlog/rancher-api-audit.log"]

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -44,3 +44,20 @@ tests:
         value: NAMESPACE
       - name: CATTLE_PEER_SERVICE
         value: RELEASE-NAME-rancher
+- it: should set busybox image as busybox
+  set:
+    auditLog:
+      level: 1
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[1].image
+      value: busybox
+- it: should override busybox image
+  set:
+    auditLog:
+      level: 1
+    busyboxImage: my.private.repo:5000/rancher/busybox:1.0.1
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[1].image
+      value: my.private.repo:5000/rancher/busybox:1.0.1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -22,6 +22,10 @@ auditLog:
 # Adding the "local" cluster available in the GUI can be convenient, but any user with access to this cluster has "root" on any of the clusters that Rancher manages.
 # options; "auto", "false". (auto pretty much means true)
 addLocal: "auto"
+
+# Image for collecting rancher audit logs.
+busyboxImage: busybox
+
 # Add debug flag to Rancher server
 debug: false
 


### PR DESCRIPTION
Air Gap installs that want to configure the rancher audit log may need to configure the image repo for busybox container used to capture the logs for shipping.