### PR TITLE
Adding code to fix aks timeouts

### DIFF
--- a/pkg/dialer/factory.go
+++ b/pkg/dialer/factory.go
@@ -171,9 +171,11 @@ func hostPort(cluster *v3.Cluster) string {
 }
 
 func native() (dialer.Dialer, error) {
-	return func(network, address string) (net.Conn, error) {
-		return net.DialTimeout(network, address, 30*time.Second)
-	}, nil
+	netDialer := net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	return netDialer.Dial, nil
 }
 
 func (f *Factory) DockerDialer(clusterName, machineName string) (dialer.Dialer, error) {

--- a/vendor.conf
+++ b/vendor.conf
@@ -39,7 +39,7 @@ github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d756
 github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
-github.com/rancher/norman                     9ba19df9be29359a86aada80311f725fec5dba85
+github.com/rancher/norman                     61998c76e33d2c411a13aead9e13a0451462f4a7
 github.com/rancher/kontainer-engine           dc8ca48e82981b0cd39d353d9760df2b9669b112
 github.com/rancher/rke                        40cd80a20864aad8003575c89c2ec74e996ee118
 github.com/rancher/types                      5a372fcc37cbd0de83f91b0428d5f69acdc410bd

--- a/vendor/github.com/rancher/norman/pkg/remotedialer/client_dialer.go
+++ b/vendor/github.com/rancher/norman/pkg/remotedialer/client_dialer.go
@@ -16,7 +16,11 @@ func clientDial(dialer Dialer, conn *connection, message *message) {
 	)
 
 	if dialer == nil {
-		netConn, err = net.DialTimeout(message.proto, message.address, time.Duration(message.deadline)*time.Millisecond)
+		netDialer := &net.Dialer{
+			Timeout:   time.Duration(message.deadline) * time.Millisecond,
+			KeepAlive: 30 * time.Second,
+		}
+		netConn, err = netDialer.Dial(message.proto, message.address)
 	} else {
 		netConn, err = dialer(message.proto, message.address)
 	}

--- a/vendor/github.com/rancher/norman/restwatch/rest.go
+++ b/vendor/github.com/rancher/norman/restwatch/rest.go
@@ -21,7 +21,7 @@ func UnversionedRESTClientFor(config *rest.Config) (rest.Interface, error) {
 	}
 
 	newConfig := *config
-	newConfig.Timeout = time.Hour
+	newConfig.Timeout = 30 * time.Minute
 	watchClient, err := rest.UnversionedRESTClientFor(&newConfig)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/rancher/norman/store/proxy/proxy_store.go
+++ b/vendor/github.com/rancher/norman/store/proxy/proxy_store.go
@@ -256,7 +256,7 @@ func (s *Store) realWatch(apiContext *types.APIContext, schema *types.Schema, op
 		k8sClient = watchClient.WatchClient()
 	}
 
-	timeout := int64(60 * 60)
+	timeout := int64(60 * 30)
 	req := s.common(namespace, k8sClient.Get())
 	req.VersionedParams(&metav1.ListOptions{
 		Watch:           true,


### PR DESCRIPTION
This change addresses an issue where AKS clusters would timeout due to Azure
lbs failing to send tcpResets (RST) after an idle timeout.  This causes errors
to appear on the Rancher UI and logs.  This issue resolves that by adding a
keep alive to the dialer and changing some timeouts to prevent the errors from
appearing.

This is only for AKS cluster provisioned through the AKS Kontainer Driver
integration, imported clusters still exhibit this behavior.

Issue:
#14354 

Depends on:
https://github.com/rancher/norman/pull/254