### PR TITLE
Set `ui-index` setting to local if rancher version is formal

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"strings"
-
 	normanapi "github.com/rancher/norman/api"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/settings"
@@ -18,14 +16,14 @@ func NewServer(schemas *types.Schemas) (*normanapi.Server, error) {
 }
 
 func cssURL() string {
-	if !strings.HasPrefix(settings.ServerVersion.Get(), "v") {
+	if settings.UIIndex.Get() != "local" {
 		return ""
 	}
 	return "/api-ui/ui.min.css"
 }
 
 func jsURL() string {
-	if !strings.HasPrefix(settings.ServerVersion.Get(), "v") {
+	if settings.UIIndex.Get() != "local" {
 		return ""
 	}
 	return "/api-ui/ui.min.js"

--- a/pkg/settings/generator/main.go
+++ b/pkg/settings/generator/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/rancher/rancher/pkg/settings"
+)
+
+type dummyProvider struct {
+	settings map[string]string
+}
+
+func (d *dummyProvider) Get(name string) string {
+	return ""
+}
+
+func (d *dummyProvider) Set(name, value string) error {
+	return nil
+}
+
+func (d *dummyProvider) SetIfUnset(name, value string) error {
+	return nil
+}
+
+func (d *dummyProvider) SetAll(settings map[string]settings.Setting) error {
+	for name := range settings {
+		key := "CATTLE_" + strings.ToUpper(strings.Replace(name, "-", "_", -1)) + "_DEFAULT"
+		d.settings[key] = name
+	}
+	return nil
+}
+
+/*
+The goal of this function is to fetch the default value of settings
+from environment variable and return as json to stdout.
+The return json should be set to the building parameters
+`pkg/settings.InjectDefaults` of Rancher and `InjectDefaults` will
+be loaded and override the default value of the settings when Rancher
+is initializing.
+*/
+func main() {
+	provider := &dummyProvider{
+		settings: map[string]string{},
+	}
+	settings.SetProvider(provider)
+	output := map[string]string{}
+	for key, name := range provider.settings {
+		value := os.Getenv(key)
+		if value == "" {
+			continue
+		}
+		output[name] = value
+	}
+	data, _ := json.Marshal(output)
+	os.Stdout.Write(data)
+}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -3,14 +3,15 @@ package settings
 import (
 	"encoding/json"
 	"os"
+	"strings"
 
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 )
 
 var (
-	settings   = map[string]Setting{}
-	provider   Provider
-	RKEVersion string
+	settings       = map[string]Setting{}
+	provider       Provider
+	InjectDefaults string
 
 	AgentImage                      = NewSetting("agent-image", "rancher/rancher-agent:master")
 	AuthImage                       = NewSetting("auth-image", "erikwilson/kube-api-auth:latest") // FIXME: Update to Rancher image when released
@@ -33,7 +34,7 @@ var (
 	Namespace                       = NewSetting("namespace", os.Getenv("CATTLE_NAMESPACE"))
 	PeerServices                    = NewSetting("peer-service", os.Getenv("CATTLE_PEER_SERVICE"))
 	RDNSServerBaseURL               = NewSetting("rdns-base-url", "https://api.lb.rancher.cloud/v1")
-	RkeVersion                      = NewSetting("rke-version", RKEVersion)
+	RkeVersion                      = NewSetting("rke-version", "")
 	ServerImage                     = NewSetting("server-image", "rancher/rancher")
 	ServerURL                       = NewSetting("server-url", "")
 	ServerVersion                   = NewSetting("server-version", "dev")
@@ -52,6 +53,24 @@ var (
 	AuthUserInfoMaxAgeSeconds       = NewSetting("auth-user-info-max-age-seconds", "3600") // 1 hour
 	APIUIVersion                    = NewSetting("api-ui-version", "1.1.6")                // Please update the CATTLE_API_UI_VERSION in package/Dockerfile when updating the version here.
 )
+
+func init() {
+	if InjectDefaults == "" {
+		return
+	}
+	defaults := map[string]string{}
+	if err := json.Unmarshal([]byte(InjectDefaults), &defaults); err != nil {
+		return
+	}
+	for name, defaultValue := range defaults {
+		value, ok := settings[name]
+		if !ok {
+			continue
+		}
+		value.Default = defaultValue
+		settings[name] = value
+	}
+}
 
 type Provider interface {
 	Get(name string) string
@@ -122,4 +141,8 @@ func getSystemImages() string {
 		return ""
 	}
 	return string(data)
+}
+
+func GetENVKey(key string) string {
+	return "CATTLE_" + strings.ToUpper(strings.Replace(key, "-", "_", -1))
 }

--- a/scripts/build-server
+++ b/scripts/build-server
@@ -8,6 +8,6 @@ cd $(dirname $0)/..
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
 
-RKE_VERSION=$(grep -m1 '^github.com/rancher/rke' vendor.conf | awk '{print $2}')
+DEFAULT_VERSIONS=`go run ./pkg/settings/generator/main.go`
 
-CGO_ENABLED=0 go build -i -tags k8s -ldflags "-X main.VERSION=$VERSION -X github.com/rancher/rancher/pkg/settings.RKEVersion=$RKE_VERSION $LINKFLAGS" -o bin/rancher
+CGO_ENABLED=0 go build -i -tags k8s -ldflags "-X main.VERSION=$VERSION -X github.com/rancher/rancher/pkg/settings.InjectDefaults=$DEFAULT_VERSIONS $LINKFLAGS" -o bin/rancher

--- a/scripts/version
+++ b/scripts/version
@@ -49,3 +49,14 @@ echo "ARCH: $ARCH"
 echo "CHART_REPO: $CHART_REPO"
 echo "CHART_VERSION: $CHART_VERSION"
 echo "VERSION: $VERSION"
+
+if echo "$VERSION" | grep -q -e '^v.*' ; then 
+    UI_INDEX="local"
+fi
+
+pushd $(dirname $0)/.. > /dev/null
+# Settings default value
+export CATTLE_UI_INDEX_DEFAULT=${UI_INDEX:-"https://releases.rancher.com/ui/latest2/index.html"}
+export CATTLE_RKE_VERSION_DEFAULT="$(grep -m1 '^github.com/rancher/rke' vendor.conf | awk '{print $2}')"
+
+popd > /dev/null

--- a/server/ui/ui.go
+++ b/server/ui/ui.go
@@ -1,13 +1,11 @@
 package ui
 
 import (
+	"crypto/tls"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"crypto/tls"
 
 	"github.com/rancher/norman/parse"
 	"github.com/rancher/rancher/pkg/settings"
@@ -29,19 +27,11 @@ func Content() http.Handler {
 }
 
 func UI(next http.Handler) http.Handler {
-	local := false
 	_, err := os.Stat(indexHTML())
-	if err == nil {
-		local = true
-	}
-
-	if local && !strings.HasPrefix(settings.ServerVersion.Get(), "v") {
-		local = false
-	}
-
+	local := err == nil
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if parse.IsBrowser(req, true) {
-			if local {
+			if local && settings.UIIndex.Get() == "local" {
 				http.ServeFile(resp, req, indexHTML())
 			} else {
 				ui(resp, req)


### PR DESCRIPTION
**Problem:**
For now, we don't respect the `ui-index` setting in formal
rancher version. There is no way for users to customize their UI in
those version.

**Solution:**
- Use `local` value in `ui-index` setting when it is a formal version.
- When `ui-index` setting is `local`, fetch UI from file
- When in development version, always fetch UI from remote address
in `ui-index`.

Related issue:
https://github.com/rancher/rancher/issues/14392