### PR TITLE
Set `ui-index` setting to local if rancher version is formal

### DIFF
--- a/pkg/api/controllers/settings/settings.go
+++ b/pkg/api/controllers/settings/settings.go
@@ -1,8 +1,8 @@
 package settings
 
 import (
+	"fmt"
 	"os"
-	"strings"
 
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
@@ -31,6 +31,10 @@ type settingsProvider struct {
 }
 
 func (s *settingsProvider) Get(name string) string {
+	value := os.Getenv(settings.GetEnvKey(name))
+	if value != "" {
+		return value
+	}
 	obj, err := s.settingsLister.Get("", name)
 	if err != nil {
 		return s.fallback[name]
@@ -42,6 +46,10 @@ func (s *settingsProvider) Get(name string) string {
 }
 
 func (s *settingsProvider) Set(name, value string) error {
+	envValue := os.Getenv(settings.GetEnvKey(name))
+	if envValue != "" {
+		return fmt.Errorf("setting %s can not be set because it is from environment variable", name)
+	}
 	obj, err := s.settings.Get(name, v1.GetOptions{})
 	if err != nil {
 		return err
@@ -67,11 +75,11 @@ func (s *settingsProvider) SetIfUnset(name, value string) error {
 	return err
 }
 
-func (s *settingsProvider) SetAll(settings map[string]settings.Setting) error {
+func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error {
 	fallback := map[string]string{}
 
-	for name, setting := range settings {
-		key := "CATTLE_" + strings.ToUpper(strings.Replace(name, "-", "_", -1))
+	for name, setting := range settingsMap {
+		key := settings.GetEnvKey(name)
 		value := os.Getenv(key)
 
 		obj, err := s.settings.Get(setting.Name, v1.GetOptions{})

--- a/pkg/api/customization/setting/setting.go
+++ b/pkg/api/customization/setting/setting.go
@@ -3,12 +3,15 @@ package setting
 import (
 	"fmt"
 
+	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
+	v3client "github.com/rancher/types/client/management/v3"
 )
 
-func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
+func PipelineFormatter(apiContext *types.APIContext, resource *types.RawResource) {
 	v, ok := resource.Values["value"]
 	if !ok || v == "" {
 		resource.Values["value"] = resource.Values["default"]
@@ -18,7 +21,21 @@ func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 	}
 }
 
+func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
+	if convert.ToString(resource.Values["source"]) == "env" {
+		delete(resource.Links, "update")
+	}
+}
+
 func Validator(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
+	var setting v3client.Setting
+	if err := access.ByID(request, request.Version, v3client.SettingType, request.ID, &setting); err != nil {
+		return err
+	}
+	if setting.Source == "env" {
+		return httperror.NewAPIError(httperror.MethodNotAllowed, fmt.Sprintf("%s is readOnly because its value is from environment variable", request.ID))
+	}
+
 	newValue, ok := data["value"]
 	if !ok {
 		return fmt.Errorf("value not found")

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"strings"
-
 	normanapi "github.com/rancher/norman/api"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/settings"
@@ -18,14 +16,14 @@ func NewServer(schemas *types.Schemas) (*normanapi.Server, error) {
 }
 
 func cssURL() string {
-	if !strings.HasPrefix(settings.ServerVersion.Get(), "v") {
+	if settings.UIIndex.Get() != "local" {
 		return ""
 	}
 	return "/api-ui/ui.min.css"
 }
 
 func jsURL() string {
-	if !strings.HasPrefix(settings.ServerVersion.Get(), "v") {
+	if settings.UIIndex.Get() != "local" {
 		return ""
 	}
 	return "/api-ui/ui.min.js"

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -40,6 +40,7 @@ import (
 	passwordStore "github.com/rancher/rancher/pkg/api/store/password"
 	"github.com/rancher/rancher/pkg/api/store/preference"
 	"github.com/rancher/rancher/pkg/api/store/scoped"
+	settingstore "github.com/rancher/rancher/pkg/api/store/setting"
 	"github.com/rancher/rancher/pkg/api/store/userscope"
 	"github.com/rancher/rancher/pkg/auth/principals"
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
@@ -438,6 +439,7 @@ func Setting(schemas *types.Schemas) {
 	schema := schemas.Schema(&managementschema.Version, client.SettingType)
 	schema.Formatter = setting.Formatter
 	schema.Validator = setting.Validator
+	schema.Store = settingstore.New(schema.Store)
 }
 
 func LoggingTypes(schemas *types.Schemas, management *config.ScaledContext, clusterManager *clustermanager.Manager, k8sProxy http.Handler) {
@@ -532,7 +534,7 @@ func Pipeline(schemas *types.Schemas, management *config.ScaledContext, clusterM
 	schema.ActionHandler = pipelineExecutionHandler.ActionHandler
 
 	schema = schemas.Schema(&projectschema.Version, projectclient.PipelineSettingType)
-	schema.Formatter = setting.Formatter
+	schema.Formatter = setting.PipelineFormatter
 
 	sourceCodeCredentialHandler := &pipeline.SourceCodeCredentialHandler{
 		SourceCodeCredentials:      management.Project.SourceCodeCredentials(""),

--- a/pkg/api/store/setting/store.go
+++ b/pkg/api/store/setting/store.go
@@ -1,0 +1,36 @@
+package setting
+
+import (
+	"os"
+
+	"github.com/rancher/norman/store/transform"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/rancher/pkg/settings"
+)
+
+func New(store types.Store) types.Store {
+	return &transform.Store{
+		Store: store,
+		Transformer: func(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, opt *types.QueryOptions) (map[string]interface{}, error) {
+			v, ok := data["value"]
+			id := convert.ToString(data["id"])
+			value, ok2 := os.LookupEnv(settings.GetEnvKey(id))
+			switch {
+			case ok2:
+				data["value"] = value
+				data["customized"] = false
+				data["source"] = "env"
+
+			case !ok || v == "":
+				data["value"] = data["default"]
+				data["customized"] = false
+				data["source"] = "default"
+			default:
+				data["customized"] = true
+				data["source"] = "db"
+			}
+			return data, nil
+		},
+	}
+}

--- a/scripts/build-server
+++ b/scripts/build-server
@@ -8,6 +8,12 @@ cd $(dirname $0)/..
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
 
-RKE_VERSION=$(grep -m1 '^github.com/rancher/rke' vendor.conf | awk '{print $2}')
+if echo "$VERSION" | grep -q -e '^v.*' ; then 
+    UI_INDEX="local"
+fi
+RKE_VERSION="$(grep -m1 '^github.com/rancher/rke' vendor.conf | awk '{print $2}')"
 
-CGO_ENABLED=0 go build -i -tags k8s -ldflags "-X main.VERSION=$VERSION -X github.com/rancher/rancher/pkg/settings.RKEVersion=$RKE_VERSION $LINKFLAGS" -o bin/rancher
+# Inject Setting values
+DEFAULT_VALUES="{\"ui-index\":\"${UI_INDEX}\",\"rke-version\":\"${RKE_VERSION}\"}"
+
+CGO_ENABLED=0 go build -i -tags k8s -ldflags "-X main.VERSION=$VERSION -X github.com/rancher/rancher/pkg/settings.InjectDefaults=$DEFAULT_VALUES $LINKFLAGS" -o bin/rancher

--- a/server/ui/ui.go
+++ b/server/ui/ui.go
@@ -1,13 +1,11 @@
 package ui
 
 import (
+	"crypto/tls"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"crypto/tls"
 
 	"github.com/rancher/norman/parse"
 	"github.com/rancher/rancher/pkg/settings"
@@ -29,19 +27,11 @@ func Content() http.Handler {
 }
 
 func UI(next http.Handler) http.Handler {
-	local := false
 	_, err := os.Stat(indexHTML())
-	if err == nil {
-		local = true
-	}
-
-	if local && !strings.HasPrefix(settings.ServerVersion.Get(), "v") {
-		local = false
-	}
-
+	local := err == nil
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if parse.IsBrowser(req, true) {
-			if local {
+			if local && settings.UIIndex.Get() == "local" {
 				http.ServeFile(resp, req, indexHTML())
 			} else {
 				ui(resp, req)


### PR DESCRIPTION
**Problem:**
For now, we don't respect the `ui-index` setting in formal
rancher version. There is no way for users to customize their UI in
those version.

**Solution:**
- Use `local` value in `ui-index` setting when it is a formal version.
- When `ui-index` setting is `local`, fetch UI from file
- When in development version, always fetch UI from remote address
in `ui-index`.

Related issue:
https://github.com/rancher/rancher/issues/14392
https://github.com/rancher/rancher/issues/17488
https://github.com/rancher/rancher/issues/17312