### PR TITLE
Fix panic in refresher logic

### DIFF
--- a/pkg/auth/providerrefresh/daemon.go
+++ b/pkg/auth/providerrefresh/daemon.go
@@ -1,0 +1,109 @@
+package providerrefresh
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/rancher/pkg/auth/tokens"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+	"github.com/robfig/cron"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	ref *refresher
+	c   = cron.New()
+)
+
+func StartRefreshDaemon(ctx context.Context, scaledContext *config.ScaledContext, mgmtContext *config.ManagementContext, refreshCronTime string, maxAge string) {
+	ref = &refresher{
+		tokenLister:         mgmtContext.Management.Tokens("").Controller().Lister(),
+		tokens:              mgmtContext.Management.Tokens(""),
+		userLister:          mgmtContext.Management.Users("").Controller().Lister(),
+		tokenMGR:            tokens.NewManager(ctx, scaledContext),
+		userAttributes:      mgmtContext.Management.UserAttributes(""),
+		userAttributeLister: mgmtContext.Management.UserAttributes("").Controller().Lister(),
+		settingLister:       mgmtContext.Management.Settings("").Controller().Lister(),
+	}
+
+	UpdateRefreshMaxAge(maxAge)
+	UpdateRefreshCronTime(refreshCronTime)
+
+}
+
+func UpdateRefreshCronTime(refreshCronTime string) {
+	if ref == nil {
+		return
+	}
+
+	parsed, err := ParseCron(refreshCronTime)
+	if err != nil {
+		logrus.Errorf("%v", err)
+		return
+	}
+
+	c.Stop()
+	c = cron.New()
+
+	if parsed != nil {
+		job := cron.FuncJob(RefreshAllForCron)
+		c.Schedule(parsed, job)
+		c.Start()
+	}
+}
+
+func UpdateRefreshMaxAge(maxAge string) {
+	if ref == nil {
+		return
+	}
+
+	ref.ensureMaxAgeUpToDate(maxAge)
+}
+
+func RefreshAllForCron() {
+	if ref == nil {
+		return
+	}
+
+	logrus.Debug("Triggering auth refresh cron")
+	ref.refreshAll(false)
+}
+
+func RefreshAttributes(attribs *v3.UserAttribute) (*v3.UserAttribute, error) {
+	if ref == nil {
+		return nil, errors.Errorf("refresh daemon not yet initialized")
+	}
+
+	logrus.Debugf("Starting refresh process for %v", attribs.Name)
+	modified, err := ref.refreshAttributes(attribs)
+	if err != nil {
+		return nil, err
+	}
+	logrus.Debugf("Finished refresh process for %v", attribs.Name)
+	modified.LastRefresh = time.Now().UTC().Format(time.RFC3339)
+	modified.NeedsRefresh = false
+	return modified, nil
+}
+
+func ParseMaxAge(setting string) (time.Duration, error) {
+	durString := fmt.Sprintf("%vs", setting)
+	dur, err := time.ParseDuration(durString)
+	if err != nil {
+		return 0, fmt.Errorf("Error parsing auth refresh max age: %v", err)
+	}
+	return dur, nil
+}
+
+func ParseCron(setting string) (cron.Schedule, error) {
+	if setting == "" {
+		return nil, nil
+	}
+	schedule, err := cron.ParseStandard(setting)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing auth refresh cron: %v", err)
+	}
+	return schedule, nil
+}


### PR DESCRIPTION
In a previous commit, we fix a problem where the refresher would not
work properly in HA setups because it was only running properly on the
leader node. We fixed that by confiugring it to run on all nodes
and by supplying a reference to a refresher to the custom api action
logic.

However, we still have a global scoped refresher that runs on the leader.
This is because it needs launched from a cron. In the previous fix,
we missed one reference to the global variable. It should have been changed
to the local function receiver varaible, but wasn't.

This commit fixes that issue by changing that reference and avoids future issues
like that by separating all the globally scoped references and logic into their
own file (daemon.go) and all the logic that is scoped solely the refresher itself
into another file (refresher.go).

addresses https://github.com/rancher/rancher/issues/17958