### PR TITLE
update logging test function

### DIFF
--- a/pkg/api/customization/logging/action.go
+++ b/pkg/api/customization/logging/action.go
@@ -134,7 +134,7 @@ func (h *Handler) testLoggingTarget(clusterName string, target mgmtv3.LoggingTar
 		return nil
 	}
 
-	return wp.TestReachable(clusterDialer)
+	return wp.TestReachable(clusterDialer, true)
 }
 
 func (h *Handler) dryRunLoggingTarget(apiContext *types.APIContext, level, clusterName, projectID string, target mgmtv3.LoggingTargets) error {

--- a/pkg/controllers/user/logging/generator/cluster_template.go
+++ b/pkg/controllers/user/logging/generator/cluster_template.go
@@ -221,8 +221,10 @@ var ClusterTemplate = `{{ if .clusterTarget.CurrentTarget }}
     verify_mode 0
     {{end }}
 
-    {{- if .clusterTarget.SyslogConfig.Certificate }}
+    {{- if .clusterTarget.SyslogConfig.EnableTLS }}
     tls true        
+    {{end}}
+    {{- if .clusterTarget.SyslogConfig.Certificate }}
     ca_file /fluentd/etc/config/ssl/cluster_{{.clusterName}}_ca.pem
     {{end}}
 

--- a/pkg/controllers/user/logging/generator/project_template.go
+++ b/pkg/controllers/user/logging/generator/project_template.go
@@ -215,8 +215,11 @@ var ProjectTemplate = `
       verify_mode 0
       {{end }}
 
-      {{- if $store.SyslogConfig.Certificate }}
+      {{- if $store.SyslogConfig.EnableTLS }}
       tls true        
+      {{end}}
+
+      {{- if $store.SyslogConfig.Certificate }}
       ca_file /fluentd/etc/config/ssl/project_{{$store.WrapProjectName}}_ca.pem
       {{end }}
 

--- a/pkg/controllers/user/logging/utils/custom.go
+++ b/pkg/controllers/user/logging/utils/custom.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config/dialer"
+)
+
+type customTargetTestWrap struct {
+	*v3.CustomTargetConfig
+}
+
+func (w *customTargetTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
+	return nil
+}

--- a/pkg/controllers/user/logging/utils/elasticsearch.go
+++ b/pkg/controllers/user/logging/utils/elasticsearch.go
@@ -1,0 +1,86 @@
+package utils
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config/dialer"
+)
+
+type elasticsearchTestWrap struct {
+	*v3.ElasticsearchConfig
+}
+
+func (w *elasticsearchTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
+	url, err := url.Parse(w.Endpoint)
+	if err != nil {
+		return errors.Wrapf(err, "parse url %s failed", w.Endpoint)
+	}
+
+	isTLS := url.Scheme == "https"
+	var tlsConfig *tls.Config
+	if isTLS {
+		tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, w.ClientKeyPass, w.SSLVersion, url.Hostname(), w.SSLVerify)
+		if err != nil {
+			return errors.Wrap(err, "build tls config failed")
+		}
+	}
+
+	if !includeSendTestLog {
+		conn, err := newTCPConn(dial, url.Host, tlsConfig, true)
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}
+
+	index := getIndex(w.DateFormat, w.IndexPrefix)
+
+	url.Path = path.Join(url.Path, index, "/container_log")
+
+	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(httpTestData))
+	if err != nil {
+		return errors.Wrap(err, "create request failed")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if w.AuthUserName != "" && w.AuthPassword != "" {
+		req.SetBasicAuth(w.AuthUserName, w.AuthPassword)
+	}
+
+	return testReachableHTTP(dial, req, tlsConfig)
+}
+
+func getIndex(dateFormat, prefix string) string {
+	var index string
+	today := time.Now()
+	switch dateFormat {
+	case "YYYY":
+		index = fmt.Sprintf("%s-%04d", prefix, today.Year())
+	case "YYYY-MM":
+		index = fmt.Sprintf("%s-%04d-%02d", prefix, today.Year(), today.Month())
+	case "YYYY-MM-DD":
+		index = fmt.Sprintf("%s-%04d-%02d-%02d", prefix, today.Year(), today.Month(), today.Day())
+	}
+	return index
+}
+
+func getDateFormat(dateformat string) string {
+	ToRealMap := map[string]string{
+		"YYYY-MM-DD": "%Y-%m-%d",
+		"YYYY-MM":    "%Y-%m",
+		"YYYY":       "%Y",
+	}
+	if _, ok := ToRealMap[dateformat]; ok {
+		return ToRealMap[dateformat]
+	}
+	return "%Y-%m-%d"
+}

--- a/pkg/controllers/user/logging/utils/fluentd.go
+++ b/pkg/controllers/user/logging/utils/fluentd.go
@@ -1,0 +1,173 @@
+package utils
+
+import (
+	"crypto/sha512"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config/dialer"
+	"github.com/vmihailenco/msgpack"
+)
+
+var (
+	letterHex                = "0123456789abcdef"
+	fluentdForwarderTestData = []byte(fmt.Sprintf(`["rancher",[[ %d, {"message": "`+testMessage+`"}]]]`, time.Now().Unix()))
+)
+
+type fluentForwarderTestWrap struct {
+	*v3.FluentForwarderConfig
+}
+
+type heloOption struct {
+	Nonce     string `json:"nonce"`
+	Auth      string `json:"auth"`
+	Keepalive bool   `json:"keepalive"`
+}
+
+func (w *fluentForwarderTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
+	var err error
+
+	for _, s := range w.FluentServers {
+		var tlsConfig *tls.Config
+		if w.EnableTLS {
+			serverName := s.Hostname
+			if serverName == "" {
+				host, _, err := net.SplitHostPort(s.Endpoint)
+				if err != nil {
+					return errors.Wrapf(err, "parse endpoint %s failed", s.Endpoint)
+				}
+				serverName = host
+			}
+			tlsConfig, err = buildTLSConfig(w.Certificate, "", "", "", "", serverName, false)
+			if err != nil {
+				return err
+			}
+		}
+
+		conn, err := newTCPConn(dial, s.Endpoint, tlsConfig, true)
+		if err != nil {
+			return err
+		}
+
+		if !includeSendTestLog {
+			conn.Close()
+			continue
+		}
+
+		if err := w.sendData2Server(conn, s.SharedKey, s.Username, s.Password, s.Endpoint); err != nil {
+			conn.Close()
+			return err
+		}
+
+		conn.Close()
+	}
+	return nil
+}
+
+func (w *fluentForwarderTestWrap) sendData2Server(conn net.Conn, shareKey, username, password, endpoint string) error {
+	if shareKey == "" && username == "" && password == "" {
+		if _, err := conn.Write(fluentdForwarderTestData); err != nil {
+			return errors.Wrapf(err, "write data to server %s failed", endpoint)
+		}
+	}
+
+	buf := make([]byte, 1024)
+	if _, err := conn.Read(buf); err != nil && err != io.EOF {
+		return errors.Wrapf(err, "read data from fluent forwarder server %s failed", endpoint)
+	}
+
+	var heloBody []interface{}
+	if err := msgpack.Unmarshal(buf, &heloBody); err != nil {
+		return errors.Wrapf(err, "use msgpack to unmashal helo from %s failed", endpoint)
+	}
+
+	if len(heloBody) < 2 {
+		return errors.New("helo body from fluentd don't have enough info")
+	}
+
+	var heloOption heloOption
+	if err := convert.ToObj(heloBody[1], &heloOption); err != nil {
+		return errors.Wrapf(err, "convert helo body from %s failed", endpoint)
+	}
+
+	nonce, err := base64.StdEncoding.DecodeString(heloOption.Nonce)
+	if err != nil {
+		return errors.Wrapf(err, "decode nonce from %s failed", endpoint)
+	}
+
+	auth, err := base64.StdEncoding.DecodeString(heloOption.Auth)
+	if err != nil {
+		return errors.Wrapf(err, "decode auth from %s failed", endpoint)
+	}
+
+	ping, err := w.generateFluentForwarderPing(shareKey, string(nonce), username, password, string(auth))
+	if err != nil {
+		return errors.Wrap(err, "generate fluent forwarder ping failed")
+	}
+
+	if _, err = conn.Write([]byte(ping)); err != nil {
+		return errors.Wrap(err, "write ping info to fluent forwarder failed")
+	}
+
+	if _, err = conn.Write(fluentdForwarderTestData); err != nil {
+		return errors.Wrap(err, "write test data to fluent forwarder failed")
+	}
+
+	pongBuf := make([]byte, 1024)
+	if _, err = conn.Read(pongBuf); err != nil && err != io.EOF {
+		return errors.Wrapf(err, "read pong data from fluent forwarder server %s failed", endpoint)
+	}
+
+	return w.decodeFluentForwarderPong(pongBuf)
+}
+
+func (w *fluentForwarderTestWrap) generateFluentForwarderPing(shareKey, nonce, username, password, auth string) (string, error) {
+	// format from fluentd code: ['PING', self_hostname, shared_key_salt, sha512_hex(shared_key_salt + self_hostname + nonce + shared_key), username || '', sha512_hex(auth_salt + username + password) || '']
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", errors.Wrap(err, "get host failed")
+	}
+
+	salt := randHex(16)
+	fullSharedKey := fmt.Sprintf("%s%s%s%s", salt, hostname, nonce, shareKey)
+	hash := sha512.New()
+	hash.Write([]byte(fullSharedKey))
+	sharedKeyHex := hex.EncodeToString(hash.Sum(nil))
+
+	passwordHex := ""
+	if auth != "" {
+		fullPassword := fmt.Sprintf("%s%s%s", auth, username, password)
+		passwordHash := sha512.New()
+		passwordHash.Write([]byte(fullPassword))
+		passwordHex = hex.EncodeToString(passwordHash.Sum(nil))
+	}
+	return fmt.Sprintf(`["PING", "%s", "%s", "%s", "%s", "%s"]`, hostname, salt, sharedKeyHex, username, passwordHex), nil
+}
+
+func (w *fluentForwarderTestWrap) decodeFluentForwarderPong(pong []byte) error {
+	// format from fluentd code ['PONG', bool(authentication result), 'reason if authentication failed', self_hostname, sha512_hex(salt + self_hostname + nonce + sharedkey)]
+	// sample:  ["PONG",false,"shared_key mismatch","",""]
+	pongMsg := string(pong)
+	pongMsg = strings.TrimPrefix(pongMsg, "[")
+	pongMsg = strings.TrimSuffix(pongMsg, "]")
+	pongMsgArray := strings.Split(pongMsg, ",")
+	if len(pongMsgArray) != 5 {
+		return errors.New("invalid format pong msg from fluentd, " + pongMsg)
+	}
+
+	if pongMsgArray[1] == "false" {
+		return errors.New("auth failed from fluentd, pong response: " + pongMsgArray[2])
+	}
+
+	return nil
+}

--- a/pkg/controllers/user/logging/utils/kafka.go
+++ b/pkg/controllers/user/logging/utils/kafka.go
@@ -1,0 +1,136 @@
+package utils
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config/dialer"
+	kafka "github.com/segmentio/kafka-go"
+)
+
+var (
+	kafkaTestData = kafka.Message{Value: []byte(testMessage)}
+)
+
+type kafkaTestWrap struct {
+	*v3.KafkaConfig
+}
+
+func (w *kafkaTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
+	if w.SaslUsername != "" && w.SaslPassword != "" {
+		//TODO: Now we don't have a out of the box Kafka go client fit our request which both support sasl and could pass conn to it.
+		//kafka-go has a PR to support sasl, but not merge yet due to the mantainer want support Negotiation and Kerberos as well, we will add test func to sasl after the sasl in kafka-go is stable
+		return nil
+	}
+
+	if w.ZookeeperEndpoint != "" {
+		url, err := url.Parse(w.ZookeeperEndpoint)
+		if err != nil {
+			return errors.Wrapf(err, "parse url %s failed", url)
+		}
+
+		var tlsConfig *tls.Config
+		if url.Scheme == "https" {
+			tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, "", "", url.Hostname(), true)
+			if err != nil {
+				return err
+			}
+		}
+
+		conn, err := newTCPConn(dial, url.Host, tlsConfig, true)
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}
+
+	for _, v := range w.BrokerEndpoints {
+		url, err := url.Parse(v)
+		if err != nil {
+			return errors.Wrapf(err, "parse url %s failed", url)
+		}
+
+		var tlsConfig *tls.Config
+		if url.Scheme == "https" {
+			tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, "", "", url.Hostname(), true)
+			if err != nil {
+				return err
+			}
+		}
+
+		if includeSendTestLog {
+			if err := w.sendData2Kafka(url.Host, dial, tlsConfig); err != nil {
+				return err
+			}
+		}
+
+	}
+	return nil
+}
+
+func (w *kafkaTestWrap) sendData2Kafka(smartHost string, dial dialer.Dialer, tlsConfig *tls.Config) error {
+	leaderConn, err := w.kafkaConn(dial, tlsConfig, smartHost)
+	if err != nil {
+		return err
+	}
+	defer leaderConn.Close()
+
+	if _, err := leaderConn.WriteMessages(kafkaTestData); err != nil {
+		return errors.Wrap(err, "write test message to kafka failed")
+	}
+
+	return nil
+}
+
+func (w *kafkaTestWrap) kafkaConn(dial dialer.Dialer, config *tls.Config, smartHost string) (*kafka.Conn, error) {
+	defaultPartition := 0
+
+	conn, err := newTCPConn(dial, smartHost, config, false)
+	if err != nil {
+		return nil, err
+	}
+
+	kafkaConn := kafka.NewConn(conn, w.Topic, defaultPartition)
+	topicConf := kafka.TopicConfig{
+		Topic:             w.Topic,
+		NumPartitions:     1,
+		ReplicationFactor: 1,
+	}
+
+	if err := kafkaConn.CreateTopics(topicConf); err != nil {
+		kafkaConn.Close()
+		return nil, err
+	}
+
+	partitions, err := kafkaConn.ReadPartitions(w.Topic)
+	if err != nil {
+		kafkaConn.Close()
+		return nil, err
+	}
+
+	var leader kafka.Broker
+	for _, v := range partitions {
+		if v.ID == defaultPartition {
+			leader = v.Leader
+		}
+	}
+
+	leaderSmartHost := fmt.Sprintf("%s:%d", leader.Host, leader.Port)
+
+	if leaderSmartHost == smartHost {
+		return kafkaConn, nil
+	}
+
+	kafkaConn.Close()
+
+	LeaderConn, err := newTCPConn(dial, leaderSmartHost, config, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return kafka.NewConn(LeaderConn, w.Topic, defaultPartition), nil
+}

--- a/pkg/controllers/user/logging/utils/splunk.go
+++ b/pkg/controllers/user/logging/utils/splunk.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config/dialer"
+)
+
+var (
+	httpTestData = []byte(`{"event": "` + testMessage + `", "sourcetype": "rancher"}`)
+)
+
+type splunkTestWrap struct {
+	*v3.SplunkConfig
+}
+
+func (w *splunkTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
+	url, err := url.Parse(w.Endpoint)
+	if err != nil {
+		return errors.Wrapf(err, "parse url %s failed", url)
+	}
+
+	isTLS := url.Scheme == "https"
+	var tlsConfig *tls.Config
+	if isTLS {
+		tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, w.ClientKeyPass, "", url.Hostname(), w.SSLVerify)
+		if err != nil {
+			return errors.Wrap(err, "build tls config failed")
+		}
+	}
+
+	if !includeSendTestLog {
+		conn, err := newTCPConn(dial, url.Host, tlsConfig, true)
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}
+
+	url.Path = path.Join(url.Path, "/services/collector")
+	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(httpTestData))
+	if err != nil {
+		return errors.Wrap(err, "create request failed")
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Splunk %s", w.Token))
+
+	return testReachableHTTP(dial, req, tlsConfig)
+}

--- a/pkg/controllers/user/logging/utils/syslog.go
+++ b/pkg/controllers/user/logging/utils/syslog.go
@@ -1,0 +1,115 @@
+package utils
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log/syslog"
+	"net"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config/dialer"
+)
+
+type syslogTestWrap struct {
+	*v3.SyslogConfig
+}
+
+func (w *syslogTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
+	//TODO: for udp we can't use cluster dialer now, how to handle in cluster deploy syslog
+	syslogTestData := newRFC5424Message(w.Severity, w.Program, w.Token, testMessage)
+	if w.Protocol == "udp" {
+		conn, err := net.Dial("udp", w.Endpoint)
+		if err != nil {
+			return errors.Wrapf(err, "dail to udp endpoint %s failed", w.Endpoint)
+		}
+		defer conn.Close()
+
+		if includeSendTestLog {
+			return writeToUDPConn(syslogTestData, w.Endpoint)
+		}
+		return nil
+	}
+
+	var tlsConfig *tls.Config
+	if w.EnableTLS {
+		hostName, _, err := net.SplitHostPort(w.Endpoint)
+		if err != nil {
+			return errors.Wrapf(err, "parse endpoint %s failed", w.Endpoint)
+		}
+
+		tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, "", "", hostName, w.SSLVerify)
+		if err != nil {
+			return err
+		}
+	}
+
+	conn, err := newTCPConn(dial, w.Endpoint, tlsConfig, true)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if !includeSendTestLog {
+		return nil
+	}
+
+	if _, err = conn.Write(syslogTestData); err != nil {
+		return errors.Wrapf(err, "write data to server %s failed", w.Endpoint)
+	}
+
+	if !w.EnableTLS {
+		// for not tls try read to check whether the server close connect already
+		resBuf := make([]byte, 1024)
+		if _, err := conn.Read(resBuf); err != nil {
+			return errors.Wrapf(err, "read data from syslog server %s failed", w.Endpoint)
+		}
+	}
+
+	return nil
+}
+
+func newRFC5424Message(severityStr, app, token, msg string) []byte {
+	if app == "" {
+		app = "rancher"
+	}
+
+	severity := getSeverity(severityStr)
+	syslogVersion := 1
+	timestamp := time.Now().Format(time.RFC3339)
+	msgID := randHex(6)
+	hostname, _ := os.Hostname()
+
+	return []byte(fmt.Sprintf("<%d>%v %v %v %v %v %v [%v] %v\n",
+		severity,
+		syslogVersion,
+		timestamp,
+		hostname,
+		app,
+		os.Getpid(),
+		msgID,
+		token,
+		msg,
+	))
+}
+
+func getSeverity(severityStr string) syslog.Priority {
+	severityMap := map[string]syslog.Priority{
+		"emerg":   syslog.LOG_EMERG,
+		"alert":   syslog.LOG_ALERT,
+		"crit":    syslog.LOG_CRIT,
+		"err":     syslog.LOG_ERR,
+		"warning": syslog.LOG_WARNING,
+		"notice":  syslog.LOG_NOTICE,
+		"info":    syslog.LOG_INFO,
+		"debug":   syslog.LOG_DEBUG,
+	}
+
+	if severity, ok := severityMap[severityStr]; ok {
+		return severity
+	}
+
+	return syslog.LOG_INFO
+}

--- a/pkg/controllers/user/logging/utils/templatewrap.go
+++ b/pkg/controllers/user/logging/utils/templatewrap.go
@@ -296,15 +296,3 @@ func parseEndpoint(endpoint string) (host string, scheme string, err error) {
 
 	return u.Host, u.Scheme, nil
 }
-
-func getDateFormat(dateformat string) string {
-	ToRealMap := map[string]string{
-		"YYYY-MM-DD": "%Y-%m-%d",
-		"YYYY-MM":    "%Y-%m",
-		"YYYY":       "%Y",
-	}
-	if _, ok := ToRealMap[dateformat]; ok {
-		return ToRealMap[dateformat]
-	}
-	return "%Y-%m-%d"
-}

--- a/pkg/controllers/user/logging/utils/testwrap.go
+++ b/pkg/controllers/user/logging/utils/testwrap.go
@@ -9,12 +9,16 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"log/syslog"
 	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/rancher/norman/types/convert"
@@ -34,17 +38,19 @@ const (
 )
 
 const (
-	letterHex = "0123456789abcdef"
-	pongWait  = time.Duration(60 * time.Second)
+	letterHex       = "0123456789abcdef"
+	deadlineTimeout = time.Duration(2 * time.Second)
 )
 
 var (
-	httpTestData             = []byte(`{"event": "Rancher logging target setting validated", "sourcetype": "rancher"}`)
-	fluentdForwarderTestData = []byte(fmt.Sprintf(`["rancher",[[ %d, {"message": "Rancher logging target setting validated"}]]]`, time.Now().Unix()))
+	testMessage              = "Rancher logging target setting validated"
+	fluentdForwarderTestData = []byte(fmt.Sprintf(`["rancher",[[ %d, {"message": "`+testMessage+`"}]]]`, time.Now().Unix()))
+	kafkaTestData            = kafka.Message{Value: []byte(testMessage)}
+	httpTestData             = []byte(`{"event": "` + testMessage + `", "sourcetype": "rancher"}`)
 )
 
 type LoggingTargetTestWrap interface {
-	TestReachable(dial dialer.Dialer) error
+	TestReachable(dial dialer.Dialer, includeSendTestLog bool) error
 }
 
 func NewLoggingTargetTestWrap(loggingTargets v3.LoggingTargets) LoggingTargetTestWrap {
@@ -89,15 +95,33 @@ type customTargetTestWrap struct {
 	*v3.CustomTargetConfig
 }
 
-func (w *elasticsearchTestWrap) TestReachable(dial dialer.Dialer) error {
+func (w *elasticsearchTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
 	url, err := url.Parse(w.Endpoint)
 	if err != nil {
 		return errors.Wrapf(err, "parse url %s failed", w.Endpoint)
 	}
 
+	isTLS := url.Scheme == "https"
+	var tlsConfig *tls.Config
+	if isTLS {
+		tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, w.ClientKeyPass, w.SSLVersion, url.Hostname(), w.SSLVerify)
+		if err != nil {
+			return errors.Wrap(err, "build tls config failed")
+		}
+	}
+
+	if !includeSendTestLog {
+		conn, err := newTCPConn(dial, url.Host, tlsConfig, true)
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}
+
 	index := getIndex(w.DateFormat, w.IndexPrefix)
 
-	url.Path = path.Join(url.Path, index, "/_doc")
+	url.Path = path.Join(url.Path, index, "/container_log")
 
 	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(httpTestData))
 	if err != nil {
@@ -105,41 +129,74 @@ func (w *elasticsearchTestWrap) TestReachable(dial dialer.Dialer) error {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	return testReachableHTTP(dial, req, w.Certificate, w.ClientCert, w.ClientKey, w.ClientKeyPass, "", w.SSLVerify)
+	if w.AuthUserName != "" && w.AuthPassword != "" {
+		req.SetBasicAuth(w.AuthUserName, w.AuthPassword)
+	}
+
+	return testReachableHTTP(dial, req, tlsConfig)
 }
 
-func (w *splunkTestWrap) TestReachable(dial dialer.Dialer) error {
+func (w *splunkTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
 	url, err := url.Parse(w.Endpoint)
 	if err != nil {
 		return errors.Wrapf(err, "parse url %s failed", url)
 	}
 
-	url.Path = path.Join(url.Path, "/services/collector")
+	isTLS := url.Scheme == "https"
+	var tlsConfig *tls.Config
+	if isTLS {
+		tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, w.ClientKeyPass, "", url.Hostname(), w.SSLVerify)
+		if err != nil {
+			return errors.Wrap(err, "build tls config failed")
+		}
+	}
 
+	if !includeSendTestLog {
+		conn, err := newTCPConn(dial, url.Host, tlsConfig, true)
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}
+
+	url.Path = path.Join(url.Path, "/services/collector")
 	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(httpTestData))
 	if err != nil {
 		return errors.Wrap(err, "create request failed")
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Splunk %s", w.Token))
 
-	return testReachableHTTP(dial, req, w.Certificate, w.ClientCert, w.ClientKey, w.ClientKeyPass, "", w.SSLVerify)
+	return testReachableHTTP(dial, req, tlsConfig)
 }
 
-func (w *kafkaTestWrap) TestReachable(dial dialer.Dialer) error {
+func (w *kafkaTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
 	if w.SaslUsername != "" && w.SaslPassword != "" {
 		//TODO: Now we don't have a out of the box Kafka go client fit our request which both support sasl and could pass conn to it.
 		//kafka-go has a PR to support sasl, but not merge yet due to the mantainer want support Negotiation and Kerberos as well, we will add test func to sasl after the sasl in kafka-go is stable
 		return nil
 	}
 
-	partition := 0
 	if w.ZookeeperEndpoint != "" {
 		url, err := url.Parse(w.ZookeeperEndpoint)
 		if err != nil {
 			return errors.Wrapf(err, "parse url %s failed", url)
 		}
 
-		return sendData2Kafka(w.Topic, partition, dial, "tcp", url.Host, "", "", "", "", "", false)
+		var tlsConfig *tls.Config
+		if url.Scheme == "https" {
+			tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, "", "", url.Hostname(), true)
+			if err != nil {
+				return err
+			}
+		}
+
+		conn, err := newTCPConn(dial, url.Host, tlsConfig, true)
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
 	}
 
 	for _, v := range w.BrokerEndpoints {
@@ -147,45 +204,135 @@ func (w *kafkaTestWrap) TestReachable(dial dialer.Dialer) error {
 		if err != nil {
 			return errors.Wrapf(err, "parse url %s failed", url)
 		}
-		if err := sendData2Kafka(w.Topic, partition, dial, "tcp", url.Host, w.Certificate, w.ClientCert, w.ClientKey, "", "", false); err != nil {
-			return err
+
+		var tlsConfig *tls.Config
+		if url.Scheme == "https" {
+			tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, "", "", url.Hostname(), true)
+			if err != nil {
+				return err
+			}
 		}
+
+		if includeSendTestLog {
+			if err := w.sendData2Kafka(url.Host, dial, tlsConfig); err != nil {
+				return err
+			}
+		}
+
 	}
 	return nil
 }
 
-func (w *syslogTestWrap) TestReachable(dial dialer.Dialer) error {
-	return testReachable(httpTestData, dial, w.Protocol, w.Endpoint, "", w.ClientCert, w.ClientKey, "", "", w.SSLVerify)
-}
+func (w *syslogTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
+	//TODO: for udp we can't use cluster dialer now, how to handle in cluster deploy syslog
+	syslogTestData := newRFC5424Message(w.Severity, w.Program, w.Token, testMessage)
+	if w.Protocol == "udp" {
+		conn, err := newUDPConn(w.Endpoint)
+		if err != nil {
+			return errors.Wrapf(err, "dail to udp endpoint %s failed", w.Endpoint)
+		}
+		defer conn.Close()
 
-func (w *fluentForwarderTestWrap) TestReachable(dial dialer.Dialer) error {
-	for _, s := range w.FluentServers {
-		if err := w.sendData2Server(dial, s.SharedKey, s.Username, s.Password, s.Endpoint, s.Hostname, w.Certificate); err != nil {
+		if includeSendTestLog {
+			if _, err = conn.Write(syslogTestData); err != nil {
+				return errors.Wrapf(err, "write to udp endpoint %s failed", w.Endpoint)
+			}
+		}
+		return nil
+	}
+
+	var tlsConfig *tls.Config
+	if w.EnableTLS {
+		hostName, _, err := net.SplitHostPort(w.Endpoint)
+		if err != nil {
+			return errors.Wrapf(err, "parse endpoint %s failed", w.Endpoint)
+		}
+
+		tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, "", "", hostName, w.SSLVerify)
+		if err != nil {
 			return err
 		}
 	}
-	return nil
-}
 
-func (w *fluentForwarderTestWrap) sendData2Server(dial dialer.Dialer, shareKey, username, password, endpoint, hostname, certificate string) error {
-	if shareKey == "" && username == "" && password == "" {
-		return testReachable(fluentdForwarderTestData, dial, "tcp", endpoint, certificate, "", "", "", "", false)
-	}
-	conn, err := newConn(dial, "tcp", endpoint, certificate, "", "", "", "", hostname, false)
+	conn, err := newTCPConn(dial, w.Endpoint, tlsConfig, true)
 	if err != nil {
 		return err
 	}
-
-	conn.SetReadDeadline(time.Now().Add(pongWait))
 	defer conn.Close()
 
+	if !includeSendTestLog {
+		return nil
+	}
+
+	if _, err = conn.Write(syslogTestData); err != nil {
+		return errors.Wrapf(err, "write data to server %s failed", w.Endpoint)
+	}
+
+	if !w.EnableTLS {
+		// for not tls try read to check whether the server close connect already
+		resBuf := make([]byte, 1024)
+		if _, err := conn.Read(resBuf); err != nil {
+			return errors.Wrapf(err, "read data from syslog server %s failed", w.Endpoint)
+		}
+	}
+
+	return nil
+}
+
+func (w *fluentForwarderTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
+	var err error
+
+	for _, s := range w.FluentServers {
+		var tlsConfig *tls.Config
+		if w.EnableTLS {
+			serverName := s.Hostname
+			if serverName == "" {
+				host, _, err := net.SplitHostPort(s.Endpoint)
+				if err != nil {
+					return errors.Wrapf(err, "parse endpoint %s failed", s.Endpoint)
+				}
+				serverName = host
+			}
+			tlsConfig, err = buildTLSConfig(w.Certificate, "", "", "", "", serverName, false)
+			if err != nil {
+				return err
+			}
+		}
+
+		conn, err := newTCPConn(dial, s.Endpoint, tlsConfig, true)
+		if err != nil {
+			return err
+		}
+
+		if !includeSendTestLog {
+			conn.Close()
+			continue
+		}
+
+		if err := w.sendData2Server(conn, s.SharedKey, s.Username, s.Password, s.Endpoint); err != nil {
+			conn.Close()
+			return err
+		}
+
+		conn.Close()
+	}
+	return nil
+}
+
+func (w *fluentForwarderTestWrap) sendData2Server(conn net.Conn, shareKey, username, password, endpoint string) error {
+	if shareKey == "" && username == "" && password == "" {
+		if _, err := conn.Write(fluentdForwarderTestData); err != nil {
+			return errors.Wrapf(err, "write data to server %s failed", endpoint)
+		}
+	}
+
 	buf := make([]byte, 1024)
-	if _, err = conn.Read(buf); err != nil {
+	if _, err := conn.Read(buf); err != nil && err != io.EOF {
 		return errors.Wrapf(err, "read data from fluent forwarder server %s failed", endpoint)
 	}
 
 	var heloBody []interface{}
-	if err = msgpack.Unmarshal(buf, &heloBody); err != nil {
+	if err := msgpack.Unmarshal(buf, &heloBody); err != nil {
 		return errors.Wrapf(err, "use msgpack to unmashal helo from %s failed", endpoint)
 	}
 
@@ -194,7 +341,7 @@ func (w *fluentForwarderTestWrap) sendData2Server(dial dialer.Dialer, shareKey, 
 	}
 
 	var heloOption heloOption
-	if err = convert.ToObj(heloBody[1], &heloOption); err != nil {
+	if err := convert.ToObj(heloBody[1], &heloOption); err != nil {
 		return errors.Wrapf(err, "convert helo body from %s failed", endpoint)
 	}
 
@@ -221,10 +368,15 @@ func (w *fluentForwarderTestWrap) sendData2Server(dial dialer.Dialer, shareKey, 
 		return errors.Wrap(err, "write test data to fluent forwarder failed")
 	}
 
-	return nil
+	pongBuf := make([]byte, 1024)
+	if _, err = conn.Read(pongBuf); err != nil && err != io.EOF {
+		return errors.Wrapf(err, "read pong data from fluent forwarder server %s failed", endpoint)
+	}
+
+	return w.decodeFluentForwarderPong(pongBuf)
 }
 
-func (w *customTargetTestWrap) TestReachable(dial dialer.Dialer) error {
+func (w *customTargetTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
 	return nil
 }
 
@@ -235,6 +387,7 @@ type heloOption struct {
 }
 
 func (w *fluentForwarderTestWrap) generateFluentForwarderPing(shareKey, nonce, username, password, auth string) (string, error) {
+	// format from fluentd code: ['PING', self_hostname, shared_key_salt, sha512_hex(shared_key_salt + self_hostname + nonce + shared_key), username || '', sha512_hex(auth_salt + username + password) || '']
 	hostname, err := os.Hostname()
 	if err != nil {
 		return "", errors.Wrap(err, "get host failed")
@@ -264,12 +417,25 @@ func randHex(n int) string {
 	return string(b)
 }
 
-func testReachableHTTP(dial dialer.Dialer, req *http.Request, rootCA, clientCert, clientKey, clientKeyPass, sslVersion string, sslVerify bool) error {
-	tlsConfig, err := buildTLSConfig(rootCA, clientCert, clientKey, clientKeyPass, sslVersion, "", sslVerify)
-	if err != nil {
-		return errors.Wrap(err, "build tls config failed")
+func (w *fluentForwarderTestWrap) decodeFluentForwarderPong(pong []byte) error {
+	// format from fluentd code ['PONG', bool(authentication result), 'reason if authentication failed', self_hostname, sha512_hex(salt + self_hostname + nonce + sharedkey)]
+	// sample:  ["PONG",false,"shared_key mismatch","",""]
+	pongMsg := string(pong)
+	pongMsg = strings.TrimPrefix(pongMsg, "[")
+	pongMsg = strings.TrimSuffix(pongMsg, "]")
+	pongMsgArray := strings.Split(pongMsg, ",")
+	if len(pongMsgArray) != 5 {
+		return errors.New("invalid format pong msg from fluentd, " + pongMsg)
 	}
 
+	if pongMsgArray[1] == "false" {
+		return errors.New("auth failed from fluentd, pong response: " + pongMsgArray[2])
+	}
+
+	return nil
+}
+
+func testReachableHTTP(dial dialer.Dialer, req *http.Request, tlsConfig *tls.Config) error {
 	transport := &http.Transport{
 		Dial:            dial,
 		TLSClientConfig: tlsConfig,
@@ -280,89 +446,132 @@ func testReachableHTTP(dial dialer.Dialer, req *http.Request, rootCA, clientCert
 		Timeout:   10 * time.Second,
 	}
 
-	if _, err = client.Do(req); err != nil {
+	res, err := client.Do(req)
+	if err != nil {
 		return errors.Wrapf(err, "request to logging target %s failed", req.URL)
 	}
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return errors.Wrapf(err, "read response body from %s failed, response code is %v", req.URL.String(), res.StatusCode)
+		}
+		return fmt.Errorf("response code from %s is %v, not include in the 2xx success HTTP status codes, response body: %s", req.URL.String(), res.StatusCode, string(body))
+	}
+
 	return nil
 }
 
-func testReachable(data []byte, dialer dialer.Dialer, protocal, smartHost, rootCA, clientCert, clientKey, clientKeyPass, sslVersion string, sslVerify bool) error {
-	conn, err := newConn(dialer, protocal, smartHost, rootCA, clientCert, clientKey, clientKeyPass, sslVersion, "", sslVerify)
-	if err != nil {
-		return err
-	}
-	_, err = conn.Write(data)
-	if err != nil {
-		return errors.Wrapf(err, "write data to server %s failed", smartHost)
-	}
-	defer conn.Close()
-	return nil
-}
-
-func newConn(dialer dialer.Dialer, protocal, smartHost, rootCA, clientCert, clientKey, clientKeyPass, sslVersion, serverName string, sslVerify bool) (net.Conn, error) {
-	tlsConfig, err := buildTLSConfig(rootCA, clientCert, clientKey, clientKeyPass, sslVersion, serverName, sslVerify)
-	if err != nil {
-		return nil, errors.Wrap(err, "build tls config failed")
-	}
-
-	conn, err := dialer(protocal, smartHost)
+func newTCPConn(dialer dialer.Dialer, smartHost string, tlsConfig *tls.Config, handshake bool) (net.Conn, error) {
+	conn, err := dialer("tcp", smartHost)
 	if err != nil {
 		return nil, errors.Wrap(err, "create raw conn failed")
 	}
+	conn.SetDeadline(time.Now().Add(deadlineTimeout))
 
 	if tlsConfig == nil {
 		return conn, nil
 	}
 
 	tlsConn := tls.Client(conn, tlsConfig)
-	if err := tlsConn.Handshake(); err != nil {
-		conn.Close()
-		return nil, errors.Wrap(err, "tls handshake failed")
+	if handshake {
+		if err := tlsConn.Handshake(); err != nil {
+			conn.Close()
+			return nil, errors.Wrapf(err, "tls handshake %s failed", smartHost)
+		}
 	}
-
 	return tlsConn, nil
 }
 
-func sendData2Kafka(topic string, partition int, dialer dialer.Dialer, protocal, smartHost, rootCA, clientCert, clientKey, clientKeyPass, sslVersion string, sslVerify bool) error {
-	conn, err := newConn(dialer, protocal, smartHost, rootCA, clientCert, clientKey, clientKeyPass, sslVersion, "", sslVerify)
+func newUDPConn(smartHost string) (net.Conn, error) {
+	conn, err := net.Dial("udp", smartHost)
+	if err != nil {
+		return nil, errors.Wrapf(err, "dail to udp endpoint %s failed", smartHost)
+	}
+	conn.SetDeadline(time.Now().Add(deadlineTimeout))
+	return conn, nil
+}
+
+func (w *kafkaTestWrap) sendData2Kafka(smartHost string, dial dialer.Dialer, tlsConfig *tls.Config) error {
+	leaderConn, err := w.kafkaConn(dial, tlsConfig, smartHost)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer leaderConn.Close()
 
-	topicConf := kafka.TopicConfig{
-		Topic:             topic,
-		NumPartitions:     1,
-		ReplicationFactor: 1,
-	}
-	kafkaConn := kafka.NewConn(conn, topic, partition)
-	if err = kafkaConn.CreateTopics(topicConf); err != nil {
-		return errors.Wrapf(err, "create topic %s failed", topic)
-	}
-	defer kafkaConn.Close()
-
-	if err = kafkaConn.SetWriteDeadline(time.Now().Add(10 * time.Second)); err != nil {
-		return errors.Wrap(err, "set kafka conn deadline failed")
-	}
-	if _, err = kafkaConn.WriteMessages(
-		kafka.Message{
-			Value: []byte("Rancher logging target setting validated!")},
-	); err != nil {
+	if _, err := leaderConn.WriteMessages(kafkaTestData); err != nil {
 		return errors.Wrap(err, "write test message to kafka failed")
 	}
 
 	return nil
 }
 
-func decodePEM(clientKey, clientKeyPass string) (string, error) {
-	p, _ := pem.Decode([]byte(clientKey))
+func (w *kafkaTestWrap) kafkaConn(dial dialer.Dialer, config *tls.Config, smartHost string) (*kafka.Conn, error) {
+	defaultPartition := 0
 
-	decodeClientKey, err := x509.DecryptPEMBlock(p, []byte(clientKeyPass))
+	conn, err := newTCPConn(dial, smartHost, config, false)
 	if err != nil {
-		return "", errors.Wrap(err, "decrrypt client key failed")
+		return nil, err
 	}
 
-	return string(decodeClientKey[:]), err
+	kafkaConn := kafka.NewConn(conn, w.Topic, defaultPartition)
+	topicConf := kafka.TopicConfig{
+		Topic:             w.Topic,
+		NumPartitions:     1,
+		ReplicationFactor: 1,
+	}
+
+	if err := kafkaConn.CreateTopics(topicConf); err != nil {
+		kafkaConn.Close()
+		return nil, err
+	}
+
+	partitions, err := kafkaConn.ReadPartitions(w.Topic)
+	if err != nil {
+		kafkaConn.Close()
+		return nil, err
+	}
+
+	var leader kafka.Broker
+	for _, v := range partitions {
+		if v.ID == defaultPartition {
+			leader = v.Leader
+		}
+	}
+
+	leaderSmartHost := fmt.Sprintf("%s:%d", leader.Host, leader.Port)
+
+	if leaderSmartHost == smartHost {
+		return kafkaConn, nil
+	}
+
+	kafkaConn.Close()
+
+	LeaderConn, err := newTCPConn(dial, leaderSmartHost, config, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return kafka.NewConn(LeaderConn, w.Topic, defaultPartition), nil
+}
+
+func decodePEM(clientKey, passphrase string) ([]byte, error) {
+	clientKeyBytes := []byte(clientKey)
+	pemBlock, _ := pem.Decode(clientKeyBytes)
+	if pemBlock == nil {
+		return nil, fmt.Errorf("no valid private key found")
+	}
+
+	var err error
+	if x509.IsEncryptedPEMBlock(pemBlock) {
+		clientKeyBytes, err = x509.DecryptPEMBlock(pemBlock, []byte(passphrase))
+		if err != nil {
+			return nil, errors.Wrap(err, "private key is encrypted, but could not decrypt it")
+		}
+		clientKeyBytes = pem.EncodeToMemory(&pem.Block{Type: pemBlock.Type, Bytes: clientKeyBytes})
+	}
+
+	return clientKeyBytes, nil
 }
 
 func buildTLSConfig(rootCA, clientCert, clientKey, clientKeyPass, sslVersion, serverName string, sslVerify bool) (config *tls.Config, err error) {
@@ -372,23 +581,19 @@ func buildTLSConfig(rootCA, clientCert, clientKey, clientKeyPass, sslVersion, se
 
 	config = &tls.Config{
 		InsecureSkipVerify: !sslVerify,
+		ServerName:         serverName,
 	}
 
-	if serverName != "" {
-		config.InsecureSkipVerify = false
-		config.ServerName = serverName
-	}
-
-	var decodeClientKey = clientKey
+	var decodeClientKeyBytes = []byte(clientKey)
 	if clientKeyPass != "" {
-		decodeClientKey, err = decodePEM(clientKey, clientKeyPass)
+		decodeClientKeyBytes, err = decodePEM(clientKey, clientKeyPass)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if clientCert != "" {
-		cert, err := tls.X509KeyPair([]byte(clientCert), []byte(decodeClientKey))
+		cert, err := tls.X509KeyPair([]byte(clientCert), decodeClientKeyBytes)
 		if err != nil {
 			return nil, errors.Wrap(err, "load client cert and key failed")
 		}
@@ -434,4 +639,47 @@ func getIndex(dateFormat, prefix string) string {
 		index = fmt.Sprintf("%s-%04d-%02d-%02d", prefix, today.Year(), today.Month(), today.Day())
 	}
 	return index
+}
+
+func newRFC5424Message(severityStr, app, token, msg string) []byte {
+	if app == "" {
+		app = "rancher"
+	}
+
+	severity := getSeverity(severityStr)
+	syslogVersion := 1
+	timestamp := time.Now().Format(time.RFC3339)
+	msgID := randHex(6)
+	hostname, _ := os.Hostname()
+
+	return []byte(fmt.Sprintf("<%d>%v %v %v %v %v %v [%v] %v\n",
+		severity,
+		syslogVersion,
+		timestamp,
+		hostname,
+		app,
+		os.Getpid(),
+		msgID,
+		token,
+		msg,
+	))
+}
+
+func getSeverity(severityStr string) syslog.Priority {
+	severityMap := map[string]syslog.Priority{
+		"emerg":   syslog.LOG_EMERG,
+		"alert":   syslog.LOG_ALERT,
+		"crit":    syslog.LOG_CRIT,
+		"err":     syslog.LOG_ERR,
+		"warning": syslog.LOG_WARNING,
+		"notice":  syslog.LOG_NOTICE,
+		"info":    syslog.LOG_INFO,
+		"debug":   syslog.LOG_DEBUG,
+	}
+
+	if severity, ok := severityMap[severityStr]; ok {
+		return severity
+	}
+
+	return syslog.LOG_INFO
 }

--- a/pkg/controllers/user/logging/utils/testwrap.go
+++ b/pkg/controllers/user/logging/utils/testwrap.go
@@ -1,33 +1,20 @@
 package utils
 
 import (
-	"bytes"
-	"crypto/sha512"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/base64"
-	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	"io"
 	"io/ioutil"
-	"log/syslog"
 	"math/rand"
 	"net"
 	"net/http"
-	"net/url"
-	"os"
-	"path"
-	"strings"
 	"time"
 
-	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config/dialer"
 
 	"github.com/pkg/errors"
-	kafka "github.com/segmentio/kafka-go"
-	"github.com/vmihailenco/msgpack"
 )
 
 const (
@@ -38,15 +25,11 @@ const (
 )
 
 const (
-	letterHex       = "0123456789abcdef"
 	deadlineTimeout = time.Duration(2 * time.Second)
 )
 
 var (
-	testMessage              = "Rancher logging target setting validated"
-	fluentdForwarderTestData = []byte(fmt.Sprintf(`["rancher",[[ %d, {"message": "`+testMessage+`"}]]]`, time.Now().Unix()))
-	kafkaTestData            = kafka.Message{Value: []byte(testMessage)}
-	httpTestData             = []byte(`{"event": "` + testMessage + `", "sourcetype": "rancher"}`)
+	testMessage = "Rancher logging target setting validated"
 )
 
 type LoggingTargetTestWrap interface {
@@ -66,370 +49,6 @@ func NewLoggingTargetTestWrap(loggingTargets v3.LoggingTargets) LoggingTargetTes
 		return &fluentForwarderTestWrap{loggingTargets.FluentForwarderConfig}
 	} else if loggingTargets.CustomTargetConfig != nil {
 		return &customTargetTestWrap{loggingTargets.CustomTargetConfig}
-	}
-
-	return nil
-}
-
-type elasticsearchTestWrap struct {
-	*v3.ElasticsearchConfig
-}
-
-type splunkTestWrap struct {
-	*v3.SplunkConfig
-}
-
-type kafkaTestWrap struct {
-	*v3.KafkaConfig
-}
-
-type syslogTestWrap struct {
-	*v3.SyslogConfig
-}
-
-type fluentForwarderTestWrap struct {
-	*v3.FluentForwarderConfig
-}
-
-type customTargetTestWrap struct {
-	*v3.CustomTargetConfig
-}
-
-func (w *elasticsearchTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
-	url, err := url.Parse(w.Endpoint)
-	if err != nil {
-		return errors.Wrapf(err, "parse url %s failed", w.Endpoint)
-	}
-
-	isTLS := url.Scheme == "https"
-	var tlsConfig *tls.Config
-	if isTLS {
-		tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, w.ClientKeyPass, w.SSLVersion, url.Hostname(), w.SSLVerify)
-		if err != nil {
-			return errors.Wrap(err, "build tls config failed")
-		}
-	}
-
-	if !includeSendTestLog {
-		conn, err := newTCPConn(dial, url.Host, tlsConfig, true)
-		if err != nil {
-			return err
-		}
-		conn.Close()
-		return nil
-	}
-
-	index := getIndex(w.DateFormat, w.IndexPrefix)
-
-	url.Path = path.Join(url.Path, index, "/container_log")
-
-	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(httpTestData))
-	if err != nil {
-		return errors.Wrap(err, "create request failed")
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	if w.AuthUserName != "" && w.AuthPassword != "" {
-		req.SetBasicAuth(w.AuthUserName, w.AuthPassword)
-	}
-
-	return testReachableHTTP(dial, req, tlsConfig)
-}
-
-func (w *splunkTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
-	url, err := url.Parse(w.Endpoint)
-	if err != nil {
-		return errors.Wrapf(err, "parse url %s failed", url)
-	}
-
-	isTLS := url.Scheme == "https"
-	var tlsConfig *tls.Config
-	if isTLS {
-		tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, w.ClientKeyPass, "", url.Hostname(), w.SSLVerify)
-		if err != nil {
-			return errors.Wrap(err, "build tls config failed")
-		}
-	}
-
-	if !includeSendTestLog {
-		conn, err := newTCPConn(dial, url.Host, tlsConfig, true)
-		if err != nil {
-			return err
-		}
-		conn.Close()
-		return nil
-	}
-
-	url.Path = path.Join(url.Path, "/services/collector")
-	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(httpTestData))
-	if err != nil {
-		return errors.Wrap(err, "create request failed")
-	}
-	req.Header.Set("Authorization", fmt.Sprintf("Splunk %s", w.Token))
-
-	return testReachableHTTP(dial, req, tlsConfig)
-}
-
-func (w *kafkaTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
-	if w.SaslUsername != "" && w.SaslPassword != "" {
-		//TODO: Now we don't have a out of the box Kafka go client fit our request which both support sasl and could pass conn to it.
-		//kafka-go has a PR to support sasl, but not merge yet due to the mantainer want support Negotiation and Kerberos as well, we will add test func to sasl after the sasl in kafka-go is stable
-		return nil
-	}
-
-	if w.ZookeeperEndpoint != "" {
-		url, err := url.Parse(w.ZookeeperEndpoint)
-		if err != nil {
-			return errors.Wrapf(err, "parse url %s failed", url)
-		}
-
-		var tlsConfig *tls.Config
-		if url.Scheme == "https" {
-			tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, "", "", url.Hostname(), true)
-			if err != nil {
-				return err
-			}
-		}
-
-		conn, err := newTCPConn(dial, url.Host, tlsConfig, true)
-		if err != nil {
-			return err
-		}
-		conn.Close()
-		return nil
-	}
-
-	for _, v := range w.BrokerEndpoints {
-		url, err := url.Parse(v)
-		if err != nil {
-			return errors.Wrapf(err, "parse url %s failed", url)
-		}
-
-		var tlsConfig *tls.Config
-		if url.Scheme == "https" {
-			tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, "", "", url.Hostname(), true)
-			if err != nil {
-				return err
-			}
-		}
-
-		if includeSendTestLog {
-			if err := w.sendData2Kafka(url.Host, dial, tlsConfig); err != nil {
-				return err
-			}
-		}
-
-	}
-	return nil
-}
-
-func (w *syslogTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
-	//TODO: for udp we can't use cluster dialer now, how to handle in cluster deploy syslog
-	syslogTestData := newRFC5424Message(w.Severity, w.Program, w.Token, testMessage)
-	if w.Protocol == "udp" {
-		conn, err := newUDPConn(w.Endpoint)
-		if err != nil {
-			return errors.Wrapf(err, "dail to udp endpoint %s failed", w.Endpoint)
-		}
-		defer conn.Close()
-
-		if includeSendTestLog {
-			if _, err = conn.Write(syslogTestData); err != nil {
-				return errors.Wrapf(err, "write to udp endpoint %s failed", w.Endpoint)
-			}
-		}
-		return nil
-	}
-
-	var tlsConfig *tls.Config
-	if w.EnableTLS {
-		hostName, _, err := net.SplitHostPort(w.Endpoint)
-		if err != nil {
-			return errors.Wrapf(err, "parse endpoint %s failed", w.Endpoint)
-		}
-
-		tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, "", "", hostName, w.SSLVerify)
-		if err != nil {
-			return err
-		}
-	}
-
-	conn, err := newTCPConn(dial, w.Endpoint, tlsConfig, true)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	if !includeSendTestLog {
-		return nil
-	}
-
-	if _, err = conn.Write(syslogTestData); err != nil {
-		return errors.Wrapf(err, "write data to server %s failed", w.Endpoint)
-	}
-
-	if !w.EnableTLS {
-		// for not tls try read to check whether the server close connect already
-		resBuf := make([]byte, 1024)
-		if _, err := conn.Read(resBuf); err != nil {
-			return errors.Wrapf(err, "read data from syslog server %s failed", w.Endpoint)
-		}
-	}
-
-	return nil
-}
-
-func (w *fluentForwarderTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
-	var err error
-
-	for _, s := range w.FluentServers {
-		var tlsConfig *tls.Config
-		if w.EnableTLS {
-			serverName := s.Hostname
-			if serverName == "" {
-				host, _, err := net.SplitHostPort(s.Endpoint)
-				if err != nil {
-					return errors.Wrapf(err, "parse endpoint %s failed", s.Endpoint)
-				}
-				serverName = host
-			}
-			tlsConfig, err = buildTLSConfig(w.Certificate, "", "", "", "", serverName, false)
-			if err != nil {
-				return err
-			}
-		}
-
-		conn, err := newTCPConn(dial, s.Endpoint, tlsConfig, true)
-		if err != nil {
-			return err
-		}
-
-		if !includeSendTestLog {
-			conn.Close()
-			continue
-		}
-
-		if err := w.sendData2Server(conn, s.SharedKey, s.Username, s.Password, s.Endpoint); err != nil {
-			conn.Close()
-			return err
-		}
-
-		conn.Close()
-	}
-	return nil
-}
-
-func (w *fluentForwarderTestWrap) sendData2Server(conn net.Conn, shareKey, username, password, endpoint string) error {
-	if shareKey == "" && username == "" && password == "" {
-		if _, err := conn.Write(fluentdForwarderTestData); err != nil {
-			return errors.Wrapf(err, "write data to server %s failed", endpoint)
-		}
-	}
-
-	buf := make([]byte, 1024)
-	if _, err := conn.Read(buf); err != nil && err != io.EOF {
-		return errors.Wrapf(err, "read data from fluent forwarder server %s failed", endpoint)
-	}
-
-	var heloBody []interface{}
-	if err := msgpack.Unmarshal(buf, &heloBody); err != nil {
-		return errors.Wrapf(err, "use msgpack to unmashal helo from %s failed", endpoint)
-	}
-
-	if len(heloBody) < 2 {
-		return errors.New("helo body from fluentd don't have enough info")
-	}
-
-	var heloOption heloOption
-	if err := convert.ToObj(heloBody[1], &heloOption); err != nil {
-		return errors.Wrapf(err, "convert helo body from %s failed", endpoint)
-	}
-
-	nonce, err := base64.StdEncoding.DecodeString(heloOption.Nonce)
-	if err != nil {
-		return errors.Wrapf(err, "decode nonce from %s failed", endpoint)
-	}
-
-	auth, err := base64.StdEncoding.DecodeString(heloOption.Auth)
-	if err != nil {
-		return errors.Wrapf(err, "decode auth from %s failed", endpoint)
-	}
-
-	ping, err := w.generateFluentForwarderPing(shareKey, string(nonce), username, password, string(auth))
-	if err != nil {
-		return errors.Wrap(err, "generate fluent forwarder ping failed")
-	}
-
-	if _, err = conn.Write([]byte(ping)); err != nil {
-		return errors.Wrap(err, "write ping info to fluent forwarder failed")
-	}
-
-	if _, err = conn.Write(fluentdForwarderTestData); err != nil {
-		return errors.Wrap(err, "write test data to fluent forwarder failed")
-	}
-
-	pongBuf := make([]byte, 1024)
-	if _, err = conn.Read(pongBuf); err != nil && err != io.EOF {
-		return errors.Wrapf(err, "read pong data from fluent forwarder server %s failed", endpoint)
-	}
-
-	return w.decodeFluentForwarderPong(pongBuf)
-}
-
-func (w *customTargetTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bool) error {
-	return nil
-}
-
-type heloOption struct {
-	Nonce     string `json:"nonce"`
-	Auth      string `json:"auth"`
-	Keepalive bool   `json:"keepalive"`
-}
-
-func (w *fluentForwarderTestWrap) generateFluentForwarderPing(shareKey, nonce, username, password, auth string) (string, error) {
-	// format from fluentd code: ['PING', self_hostname, shared_key_salt, sha512_hex(shared_key_salt + self_hostname + nonce + shared_key), username || '', sha512_hex(auth_salt + username + password) || '']
-	hostname, err := os.Hostname()
-	if err != nil {
-		return "", errors.Wrap(err, "get host failed")
-	}
-
-	salt := randHex(16)
-	fullSharedKey := fmt.Sprintf("%s%s%s%s", salt, hostname, nonce, shareKey)
-	hash := sha512.New()
-	hash.Write([]byte(fullSharedKey))
-	sharedKeyHex := hex.EncodeToString(hash.Sum(nil))
-
-	passwordHex := ""
-	if auth != "" {
-		fullPassword := fmt.Sprintf("%s%s%s", auth, username, password)
-		passwordHash := sha512.New()
-		passwordHash.Write([]byte(fullPassword))
-		passwordHex = hex.EncodeToString(passwordHash.Sum(nil))
-	}
-	return fmt.Sprintf(`["PING", "%s", "%s", "%s", "%s", "%s"]`, hostname, salt, sharedKeyHex, username, passwordHex), nil
-}
-
-func randHex(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = letterHex[rand.Intn(len(letterHex))]
-	}
-	return string(b)
-}
-
-func (w *fluentForwarderTestWrap) decodeFluentForwarderPong(pong []byte) error {
-	// format from fluentd code ['PONG', bool(authentication result), 'reason if authentication failed', self_hostname, sha512_hex(salt + self_hostname + nonce + sharedkey)]
-	// sample:  ["PONG",false,"shared_key mismatch","",""]
-	pongMsg := string(pong)
-	pongMsg = strings.TrimPrefix(pongMsg, "[")
-	pongMsg = strings.TrimSuffix(pongMsg, "]")
-	pongMsgArray := strings.Split(pongMsg, ",")
-	if len(pongMsgArray) != 5 {
-		return errors.New("invalid format pong msg from fluentd, " + pongMsg)
-	}
-
-	if pongMsgArray[1] == "false" {
-		return errors.New("auth failed from fluentd, pong response: " + pongMsgArray[2])
 	}
 
 	return nil
@@ -462,6 +81,20 @@ func testReachableHTTP(dial dialer.Dialer, req *http.Request, tlsConfig *tls.Con
 	return nil
 }
 
+func writeToUDPConn(data []byte, smartHost string) error {
+	conn, err := net.Dial("udp", smartHost)
+	if err != nil {
+		return errors.Wrapf(err, "dail to udp endpoint %s failed", smartHost)
+	}
+	defer conn.Close()
+
+	_, err = conn.Write(data)
+	if err != nil {
+		return errors.Wrapf(err, "write udp endpoint %s failed", smartHost)
+	}
+	return nil
+}
+
 func newTCPConn(dialer dialer.Dialer, smartHost string, tlsConfig *tls.Config, handshake bool) (net.Conn, error) {
 	conn, err := dialer("tcp", smartHost)
 	if err != nil {
@@ -490,69 +123,6 @@ func newUDPConn(smartHost string) (net.Conn, error) {
 	}
 	conn.SetDeadline(time.Now().Add(deadlineTimeout))
 	return conn, nil
-}
-
-func (w *kafkaTestWrap) sendData2Kafka(smartHost string, dial dialer.Dialer, tlsConfig *tls.Config) error {
-	leaderConn, err := w.kafkaConn(dial, tlsConfig, smartHost)
-	if err != nil {
-		return err
-	}
-	defer leaderConn.Close()
-
-	if _, err := leaderConn.WriteMessages(kafkaTestData); err != nil {
-		return errors.Wrap(err, "write test message to kafka failed")
-	}
-
-	return nil
-}
-
-func (w *kafkaTestWrap) kafkaConn(dial dialer.Dialer, config *tls.Config, smartHost string) (*kafka.Conn, error) {
-	defaultPartition := 0
-
-	conn, err := newTCPConn(dial, smartHost, config, false)
-	if err != nil {
-		return nil, err
-	}
-
-	kafkaConn := kafka.NewConn(conn, w.Topic, defaultPartition)
-	topicConf := kafka.TopicConfig{
-		Topic:             w.Topic,
-		NumPartitions:     1,
-		ReplicationFactor: 1,
-	}
-
-	if err := kafkaConn.CreateTopics(topicConf); err != nil {
-		kafkaConn.Close()
-		return nil, err
-	}
-
-	partitions, err := kafkaConn.ReadPartitions(w.Topic)
-	if err != nil {
-		kafkaConn.Close()
-		return nil, err
-	}
-
-	var leader kafka.Broker
-	for _, v := range partitions {
-		if v.ID == defaultPartition {
-			leader = v.Leader
-		}
-	}
-
-	leaderSmartHost := fmt.Sprintf("%s:%d", leader.Host, leader.Port)
-
-	if leaderSmartHost == smartHost {
-		return kafkaConn, nil
-	}
-
-	kafkaConn.Close()
-
-	LeaderConn, err := newTCPConn(dial, leaderSmartHost, config, false)
-	if err != nil {
-		return nil, err
-	}
-
-	return kafka.NewConn(LeaderConn, w.Topic, defaultPartition), nil
 }
 
 func decodePEM(clientKey, passphrase string) ([]byte, error) {
@@ -627,59 +197,10 @@ func buildTLSConfig(rootCA, clientCert, clientKey, clientKeyPass, sslVersion, se
 	return config, nil
 }
 
-func getIndex(dateFormat, prefix string) string {
-	var index string
-	today := time.Now()
-	switch dateFormat {
-	case "YYYY":
-		index = fmt.Sprintf("%s-%04d", prefix, today.Year())
-	case "YYYY-MM":
-		index = fmt.Sprintf("%s-%04d-%02d", prefix, today.Year(), today.Month())
-	case "YYYY-MM-DD":
-		index = fmt.Sprintf("%s-%04d-%02d-%02d", prefix, today.Year(), today.Month(), today.Day())
+func randHex(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterHex[rand.Intn(len(letterHex))]
 	}
-	return index
-}
-
-func newRFC5424Message(severityStr, app, token, msg string) []byte {
-	if app == "" {
-		app = "rancher"
-	}
-
-	severity := getSeverity(severityStr)
-	syslogVersion := 1
-	timestamp := time.Now().Format(time.RFC3339)
-	msgID := randHex(6)
-	hostname, _ := os.Hostname()
-
-	return []byte(fmt.Sprintf("<%d>%v %v %v %v %v %v [%v] %v\n",
-		severity,
-		syslogVersion,
-		timestamp,
-		hostname,
-		app,
-		os.Getpid(),
-		msgID,
-		token,
-		msg,
-	))
-}
-
-func getSeverity(severityStr string) syslog.Priority {
-	severityMap := map[string]syslog.Priority{
-		"emerg":   syslog.LOG_EMERG,
-		"alert":   syslog.LOG_ALERT,
-		"crit":    syslog.LOG_CRIT,
-		"err":     syslog.LOG_ERR,
-		"warning": syslog.LOG_WARNING,
-		"notice":  syslog.LOG_NOTICE,
-		"info":    syslog.LOG_INFO,
-		"debug":   syslog.LOG_DEBUG,
-	}
-
-	if severity, ok := severityMap[severityStr]; ok {
-		return severity
-	}
-
-	return syslog.LOG_INFO
+	return string(b)
 }

--- a/pkg/controllers/user/logging/watcher/watcher.go
+++ b/pkg/controllers/user/logging/watcher/watcher.go
@@ -65,7 +65,7 @@ func (e *endpointWatcher) checkClusterTarget() error {
 	if wl == nil {
 		err = nil
 	} else {
-		err = wl.TestReachable(clusterDialer)
+		err = wl.TestReachable(clusterDialer, false)
 	}
 
 	updatedObj := setClusterLoggingErrMsg(obj, err)
@@ -96,7 +96,7 @@ func (e *endpointWatcher) checkProjectTarget() error {
 		if wp == nil {
 			err = nil
 		} else {
-			err = wp.TestReachable(clusterDialer)
+			err = wp.TestReachable(clusterDialer, false)
 		}
 
 		updatedObj := setProjectLoggingErrMsg(v, err)

--- a/pkg/controllers/user/logging/watcher/watcher.go
+++ b/pkg/controllers/user/logging/watcher/watcher.go
@@ -31,7 +31,7 @@ func StartEndpointWatcher(ctx context.Context, cluster *config.UserContext) {
 		clusterLoggings: cluster.Management.Management.ClusterLoggings(cluster.ClusterName),
 		projectLoggings: cluster.Management.Management.ProjectLoggings(metav1.NamespaceAll),
 	}
-	go s.watch(ctx, 10*time.Second)
+	go s.watch(ctx, 120*time.Second)
 }
 
 func (e *endpointWatcher) watch(ctx context.Context, interval time.Duration) {

--- a/vendor.conf
+++ b/vendor.conf
@@ -42,7 +42,7 @@ github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f6841
 github.com/rancher/norman                     196df5ed9da30dac3aa715879f44616238b8085f
 github.com/rancher/kontainer-engine           0544470a0e37edf70909790e63c653fed318fbd6
 github.com/rancher/rke                        v0.2.0-rc5
-github.com/rancher/types                      7746d46d672f3811e95b1629db079a046dd4f8a5
+github.com/rancher/types                      a56d41fc8d26e965092abb48ab9b58e19f4e16e3
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/logging_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/logging_types.go
@@ -141,6 +141,7 @@ type SyslogConfig struct {
 	Program     string `json:"program,omitempty"`
 	Protocol    string `json:"protocol,omitempty" norman:"default=udp,type=enum,options=udp|tcp"`
 	Token       string `json:"token,omitempty" norman:"type=password"`
+	EnableTLS   bool   `json:"enableTls,omitempty" norman:"default=false"`
 	Certificate string `json:"certificate,omitempty"`
 	ClientCert  string `json:"clientCert,omitempty"`
 	ClientKey   string `json:"clientKey,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_syslog_config.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_syslog_config.go
@@ -5,6 +5,7 @@ const (
 	SyslogConfigFieldCertificate = "certificate"
 	SyslogConfigFieldClientCert  = "clientCert"
 	SyslogConfigFieldClientKey   = "clientKey"
+	SyslogConfigFieldEnableTLS   = "enableTls"
 	SyslogConfigFieldEndpoint    = "endpoint"
 	SyslogConfigFieldProgram     = "program"
 	SyslogConfigFieldProtocol    = "protocol"
@@ -17,6 +18,7 @@ type SyslogConfig struct {
 	Certificate string `json:"certificate,omitempty" yaml:"certificate,omitempty"`
 	ClientCert  string `json:"clientCert,omitempty" yaml:"clientCert,omitempty"`
 	ClientKey   string `json:"clientKey,omitempty" yaml:"clientKey,omitempty"`
+	EnableTLS   bool   `json:"enableTls,omitempty" yaml:"enableTls,omitempty"`
 	Endpoint    string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 	Program     string `json:"program,omitempty" yaml:"program,omitempty"`
 	Protocol    string `json:"protocol,omitempty" yaml:"protocol,omitempty"`


### PR DESCRIPTION
This is the same as https://github.com/rancher/rancher/pull/17785, but with
proper vendoring. I'm opening so that we can get the issues moved over to test.



Problem:
1. elasticsearch test func if not send the same type as config in fluentd will cause elasticsearch throw multiple type for one index error
2. watcher for check enable reachable should not send test log
3. improve test func and testWrap.go file too long

Solution:
1. improve logging test action related function
2. support when user use test action will send test log, while the watcher will only check reachable
3. separate different target test func to different files

Types:
https://github.com/rancher/types/pull/705

Issue:
https://github.com/rancher/rancher/issues/15380
https://github.com/rancher/rancher/issues/17658