### PR TITLE
Removed pending from non-imported driver and added reason to forget error.

### DIFF
--- a/pkg/api/store/cluster/cluster_store.go
+++ b/pkg/api/store/cluster/cluster_store.go
@@ -167,6 +167,7 @@ func (r *Store) Create(apiContext *types.APIContext, schema *types.Schema, data 
 		values.PutValue(data, m, managementv3.ClusterFieldAnnotations)
 	}
 
+
 	if err = setInitialConditions(data); err != nil {
 		return nil, err
 	}
@@ -184,25 +185,28 @@ func setInitialConditions(data map[string]interface{}) error {
 		return fmt.Errorf("unable to parse field \"%v\" type \"%v\" as \"[]map[string]interface{}\"",
 			managementv3.ClusterStatusFieldConditions, reflect.TypeOf(data[managementv3.ClusterStatusFieldConditions]))
 	}
-
-	data[managementv3.ClusterStatusFieldConditions] =
-		append(
-			conditions,
-			[]map[string]interface{}{
-				{
-					"status": "True",
-					"type":   string(v3.ClusterConditionPending),
-				},
-				{
-					"status": "Unknown",
-					"type":   string(v3.ClusterConditionProvisioned),
-				},
-				{
-					"status": "Unknown",
-					"type":   string(v3.ClusterConditionWaiting),
-				},
-			}...,
-		)
+	for key := range data {
+		if strings.Index(key, "Config") == len(key)-6 {
+			data[managementv3.ClusterStatusFieldConditions] =
+				append(
+					conditions,
+					[]map[string]interface{}{
+						{
+							"status": "True",
+							"type":   string(v3.ClusterConditionPending),
+						},
+						{
+							"status": "Unknown",
+							"type":   string(v3.ClusterConditionProvisioned),
+						},
+						{
+							"status": "Unknown",
+							"type":   string(v3.ClusterConditionWaiting),
+						},
+					}...,
+				)
+		}
+	}
 
 	return nil
 }

--- a/pkg/api/store/cluster/cluster_store.go
+++ b/pkg/api/store/cluster/cluster_store.go
@@ -167,7 +167,6 @@ func (r *Store) Create(apiContext *types.APIContext, schema *types.Schema, data 
 		values.PutValue(data, m, managementv3.ClusterFieldAnnotations)
 	}
 
-
 	if err = setInitialConditions(data); err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -181,7 +181,9 @@ func (p *Provisioner) pending(cluster *v3.Cluster) (*v3.Cluster, error) {
 	}
 
 	if driver == "" {
-		return cluster, &controller.ForgetError{Err: fmt.Errorf("waiting for full cluster configuration")}
+		return cluster, &controller.ForgetError{
+			Err:    fmt.Errorf("waiting for full cluster configuration"),
+			Reason: "Pending"}
 	}
 
 	if driver != cluster.Status.Driver {
@@ -647,7 +649,6 @@ func (p *Provisioner) reconcileRKENodes(clusterName string) ([]v3.RKEConfigNode,
 		return nil, &controller.ForgetError{
 			Err:    fmt.Errorf("waiting for etcd and controlplane nodes to be registered"),
 			Reason: "Provisioning",
-
 		}
 	}
 

--- a/tests/core/test_cluster_defaults.py
+++ b/tests/core/test_cluster_defaults.py
@@ -5,7 +5,7 @@ from .common import random_str
 
 
 @pytest.mark.skip(reason="cluster-defaults disabled")
-def test_initial_defaults(admin_mc):
+def test_generic_initial_defaults(admin_mc):
     cclient = admin_mc.client
     schema_defaults = {}
     setting_defaults = {}
@@ -35,8 +35,10 @@ def test_initial_defaults(admin_mc):
     assert schema_defaults == setting_defaults
 
 
-def test_initial_conditions(admin_mc, remove_resource):
-    cluster = admin_mc.client.create_cluster(name=random_str())
+def test_generic_initial_conditions(admin_mc, remove_resource):
+    cluster = admin_mc.client.create_cluster(
+            name=random_str(), amazonElasticContainerServiceConfig={
+                "accessKey": "asdfsd"})
     remove_resource(cluster)
 
     assert len(cluster.conditions) == 3
@@ -48,3 +50,27 @@ def test_initial_conditions(admin_mc, remove_resource):
 
     assert cluster.conditions[2].type == 'Waiting'
     assert cluster.conditions[2].status == 'Unknown'
+
+
+def test_rke_initial_conditions(admin_mc, remove_resource):
+    cluster = admin_mc.client.create_cluster(
+            name=random_str(), rancherKubernetesEngineConfig={
+                "accessKey": "asdfsd"})
+    remove_resource(cluster)
+
+    assert len(cluster.conditions) == 3
+    assert cluster.conditions[0].type == 'Pending'
+    assert cluster.conditions[0].status == 'True'
+
+    assert cluster.conditions[1].type == 'Provisioned'
+    assert cluster.conditions[1].status == 'Unknown'
+
+    assert cluster.conditions[2].type == 'Waiting'
+    assert cluster.conditions[2].status == 'Unknown'
+
+
+def test_import_initial_conditions(admin_mc, remove_resource):
+    cluster = admin_mc.client.create_cluster(name=random_str())
+    remove_resource(cluster)
+
+    assert cluster.conditions is None

--- a/tests/core/test_cluster_defaults.py
+++ b/tests/core/test_cluster_defaults.py
@@ -1,5 +1,7 @@
-import pytest
 import json
+import pytest
+
+from .common import random_str
 
 
 @pytest.mark.skip(reason="cluster-defaults disabled")
@@ -15,12 +17,12 @@ def test_initial_defaults(admin_mc):
         if name == "enableNetworkPolicy":
             schema_defaults["enableNetworkPolicy"] = default
 
-    for name in cclient.schema.types['rancherKubernetesEngineConfig']\
+    for name in cclient.schema.types['rancherKubernetesEngineConfig'] \
             .resourceFields.keys():
         if name == "ignoreDockerVersion":
-            schema_defaults["ignoreDockerVersion"] = cclient.schema.\
-                types["rancherKubernetesEngineConfig"].\
-                resourceFields["ignoreDockerVersion"].\
+            schema_defaults["ignoreDockerVersion"] = cclient.schema. \
+                types["rancherKubernetesEngineConfig"]. \
+                resourceFields["ignoreDockerVersion"]. \
                 data_dict()["default"]
 
     setting = cclient.list_setting(name="cluster-defaults")
@@ -31,3 +33,18 @@ def test_initial_defaults(admin_mc):
         data["rancherKubernetesEngineConfig"]["ignoreDockerVersion"]
 
     assert schema_defaults == setting_defaults
+
+
+def test_initial_conditions(admin_mc, remove_resource):
+    cluster = admin_mc.client.create_cluster(name=random_str())
+    remove_resource(cluster)
+
+    assert len(cluster.conditions) == 3
+    assert cluster.conditions[0].type == 'Pending'
+    assert cluster.conditions[0].status == 'True'
+
+    assert cluster.conditions[1].type == 'Provisioned'
+    assert cluster.conditions[1].status == 'Unknown'
+
+    assert cluster.conditions[2].type == 'Waiting'
+    assert cluster.conditions[2].status == 'Unknown'


### PR DESCRIPTION
Problem: The label for pending state should not be red. The "transitioning" field in API should not be error. New clusters should not start as "Active". RKE clusters were not showing "Pending" status before, but now they are.

Solution: Give ForgetError associated with pending state a reason, "Pending". Much like the provisioning state's reason, "Provisioning". The state is now blue, like provisioning and remove states. Transition field has a value of "yes". Removed pending state from non-imported drivers. This will prevent drivers from starting in "Active" state. Execute pending logic once, and return RKEdriver regardless of error. Pending will no longer hang. Driver will return despite inevitable forget error.

Issues: #17281, #15907, #17201, #17673, #17282 