### PR TITLE
Add EKS user-data modification warning to default

### DIFF
--- a/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
@@ -216,7 +216,8 @@ func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags
 				"/etc/eks/bootstrap.sh ${ClusterName} ${BootstrapArguments}" +
 				"/opt/aws/bin/cfn-signal --exit-code $? " +
 				"--stack  ${AWS::StackName} " +
-				"--resource NodeGroup --region ${AWS::Region}\n",
+				"--resource NodeGroup --region ${AWS::Region}\n" +
+				"#### APPEND BELOW IF USING AWS AMI ###########",
 		},
 	}
 


### PR DESCRIPTION
Problem: The current warning for modifying user data is not clear enough

Solution: Add inline comment for to clearly delineate where changes may be made.

https://github.com/rancher/rancher/issues/16300
Also see this doc update:
https://github.com/rancher/docs/pull/1128