### PR TITLE
add more fields to azure and vsphere cloud credential config

### DIFF
--- a/app/machinedriver_data.go
+++ b/app/machinedriver_data.go
@@ -11,8 +11,9 @@ import (
 )
 
 var driverData = map[string]map[string][]string{
-	"amazonec2": {"cred": []string{"accessKey"}},
-	"azure":     {"cred": []string{"clientId"}},
+	"amazonec2":     {"cred": []string{"accessKey"}},
+	"azure":         {"cred": []string{"clientId", "subscriptionId"}},
+	"vmwarevsphere": {"cred": []string{"username", "vcenter", "vcenterPort"}},
 }
 
 type machineDriverCompare struct {


### PR DESCRIPTION
Cloud credentials should include all fields necessary for authentication, adding required fields. 