### PR TITLE
Fix duplicate prompt expressions when operating alert rule

### DIFF
--- a/pkg/api/customization/monitor/metric_action.go
+++ b/pkg/api/customization/monitor/metric_action.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/rancher/pkg/ref"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config/dialer"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func NewMetricHandler(dialerFactory dialer.Factory, clustermanager *clustermanager.Manager) *MetricHandler {
@@ -222,10 +223,13 @@ func (h *MetricHandler) Action(actionName string, action *types.Action, apiConte
 			return fmt.Errorf("get cluster metric list failed, %v", err)
 		}
 
-		names := append(projectNames, clusterNames...)
+		names := sets.String{}
+		names.Insert(projectNames...)
+		names.Insert(clusterNames...)
+
 		data := map[string]interface{}{
 			"type":  "metricNamesOutput",
-			"names": names,
+			"names": names.List(),
 		}
 		apiContext.WriteResponse(http.StatusOK, data)
 	}


### PR DESCRIPTION
**Problem:**
When adding/editing alert rules in project-level alerting, there are two
same prompt expressions in Expression selection.

**Solution:**
Using String set to merge the same expression.

**Issue:**
https://github.com/rancher/rancher/issues/17999