### PR TITLE
Use positive option instead of negative in cluster logging

### DIFF
--- a/pkg/controllers/user/logging/configsyncer/configgenerator.go
+++ b/pkg/controllers/user/logging/configsyncer/configgenerator.go
@@ -37,7 +37,7 @@ func (s *ConfigGenerator) GenerateClusterLoggingConfig(clusterLogging *mgmtv3.Cl
 	}
 
 	var excludeNamespaces string
-	if clusterLogging.Spec.ExcludeSystemComponent {
+	if !*clusterLogging.Spec.IncludeSystemComponent {
 		var err error
 		if excludeNamespaces, err = s.addExcludeNamespaces(systemProjectID); err != nil {
 			return nil, err

--- a/pkg/controllers/user/logging/generator/cluster_template.go
+++ b/pkg/controllers/user/logging/generator/cluster_template.go
@@ -2,7 +2,7 @@ package generator
 
 var ClusterTemplate = `{{ if .clusterTarget.CurrentTarget }}
 
-{{- if eq .clusterTarget.ExcludeSystemComponent false }}
+{{- if eq .clusterTarget.IncludeSystemComponent true }}
 <source>
   @type  tail
   path  /var/lib/rancher/rke/log/*.log
@@ -79,7 +79,7 @@ var ClusterTemplate = `{{ if .clusterTarget.CurrentTarget }}
   </metric>
 </filter>
 
-{{- if eq .clusterTarget.ExcludeSystemComponent true }}
+{{- if eq .clusterTarget.IncludeSystemComponent false }}
 <filter cluster.**>
   @type grep
   <exclude>
@@ -91,7 +91,7 @@ var ClusterTemplate = `{{ if .clusterTarget.CurrentTarget }}
 
 {{- if eq .clusterTarget.CurrentTarget "syslog"}}
 {{- if .clusterTarget.SyslogConfig.Token}}
-<filter  cluster.** cluster-custom.** {{ if eq .clusterTarget.ExcludeSystemComponent false }}rke.**{{end }} >
+<filter  cluster.** cluster-custom.** {{ if eq .clusterTarget.IncludeSystemComponent true }}rke.**{{end }} >
   @type record_transformer
   <record>
     tag ${tag} {{.clusterTarget.SyslogConfig.Token}}
@@ -100,7 +100,7 @@ var ClusterTemplate = `{{ if .clusterTarget.CurrentTarget }}
 {{end }}
 {{end }}
 
-<match  cluster.** cluster-custom.** {{ if eq .clusterTarget.ExcludeSystemComponent false }}rke.**{{end }} > 
+<match  cluster.** cluster-custom.** {{ if eq .clusterTarget.IncludeSystemComponent true }}rke.**{{end }} > 
   @type copy
   <store>
     {{- if or (eq .clusterTarget.CurrentTarget "elasticsearch") (eq .clusterTarget.CurrentTarget "splunk") (eq .clusterTarget.CurrentTarget "syslog") (eq .clusterTarget.CurrentTarget "kafka") (eq .clusterTarget.CurrentTarget "fluentforwarder")}}

--- a/pkg/controllers/user/logging/utils/templatewrap.go
+++ b/pkg/controllers/user/logging/utils/templatewrap.go
@@ -25,7 +25,7 @@ type ClusterLoggingTemplateWrap struct {
 	v3.LoggingCommonField
 	LoggingTargetTemplateWrap
 	ExcludeNamespace       string
-	ExcludeSystemComponent bool
+	IncludeSystemComponent bool
 }
 
 type ProjectLoggingTemplateWrap struct {
@@ -51,7 +51,7 @@ func NewWrapClusterLogging(logging v3.ClusterLoggingSpec, excludeNamespace strin
 		LoggingCommonField:        logging.LoggingCommonField,
 		LoggingTargetTemplateWrap: *wrap,
 		ExcludeNamespace:          excludeNamespace,
-		ExcludeSystemComponent:    logging.ExcludeSystemComponent,
+		IncludeSystemComponent:    *logging.IncludeSystemComponent,
 	}, nil
 }
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -42,7 +42,7 @@ github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f6841
 github.com/rancher/norman                     b694ecb0eb159776edc3ea84036ee46390c8d7fe
 github.com/rancher/kontainer-engine           0544470a0e37edf70909790e63c653fed318fbd6
 github.com/rancher/rke                        aa16d70ca616af0112ae2a6bb25e33a777eb2ae7
-github.com/rancher/types                      1d346f8e7dcaf5f60f41cc3b52c8a55bb08866f5
+github.com/rancher/types                      60be9b917628130ec3d049a5646859168c37340c
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/logging_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/logging_types.go
@@ -56,7 +56,7 @@ type ClusterLoggingSpec struct {
 	LoggingTargets
 	LoggingCommonField
 	ClusterName            string `json:"clusterName" norman:"type=reference[cluster]"`
-	ExcludeSystemComponent bool   `json:"excludeSystemComponent,omitempty"`
+	IncludeSystemComponent *bool  `json:"includeSystemComponent,omitempty" norman:"default=true"`
 }
 
 type ProjectLoggingSpec struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -1438,6 +1438,11 @@ func (in *ClusterLoggingSpec) DeepCopyInto(out *ClusterLoggingSpec) {
 	*out = *in
 	in.LoggingTargets.DeepCopyInto(&out.LoggingTargets)
 	in.LoggingCommonField.DeepCopyInto(&out.LoggingCommonField)
+	if in.IncludeSystemComponent != nil {
+		in, out := &in.IncludeSystemComponent, &out.IncludeSystemComponent
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_logging.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_logging.go
@@ -14,9 +14,9 @@ const (
 	ClusterLoggingFieldCreatorID              = "creatorId"
 	ClusterLoggingFieldCustomTargetConfig     = "customTargetConfig"
 	ClusterLoggingFieldElasticsearchConfig    = "elasticsearchConfig"
-	ClusterLoggingFieldExcludeSystemComponent = "excludeSystemComponent"
 	ClusterLoggingFieldFailedSpec             = "failedSpec"
 	ClusterLoggingFieldFluentForwarderConfig  = "fluentForwarderConfig"
+	ClusterLoggingFieldIncludeSystemComponent = "includeSystemComponent"
 	ClusterLoggingFieldKafkaConfig            = "kafkaConfig"
 	ClusterLoggingFieldLabels                 = "labels"
 	ClusterLoggingFieldName                   = "name"
@@ -43,9 +43,9 @@ type ClusterLogging struct {
 	CreatorID              string                 `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	CustomTargetConfig     *CustomTargetConfig    `json:"customTargetConfig,omitempty" yaml:"customTargetConfig,omitempty"`
 	ElasticsearchConfig    *ElasticsearchConfig   `json:"elasticsearchConfig,omitempty" yaml:"elasticsearchConfig,omitempty"`
-	ExcludeSystemComponent bool                   `json:"excludeSystemComponent,omitempty" yaml:"excludeSystemComponent,omitempty"`
 	FailedSpec             *ClusterLoggingSpec    `json:"failedSpec,omitempty" yaml:"failedSpec,omitempty"`
 	FluentForwarderConfig  *FluentForwarderConfig `json:"fluentForwarderConfig,omitempty" yaml:"fluentForwarderConfig,omitempty"`
+	IncludeSystemComponent *bool                  `json:"includeSystemComponent,omitempty" yaml:"includeSystemComponent,omitempty"`
 	KafkaConfig            *KafkaConfig           `json:"kafkaConfig,omitempty" yaml:"kafkaConfig,omitempty"`
 	Labels                 map[string]string      `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Name                   string                 `json:"name,omitempty" yaml:"name,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_logging_spec.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_logging_spec.go
@@ -6,8 +6,8 @@ const (
 	ClusterLoggingSpecFieldCustomTargetConfig     = "customTargetConfig"
 	ClusterLoggingSpecFieldDisplayName            = "displayName"
 	ClusterLoggingSpecFieldElasticsearchConfig    = "elasticsearchConfig"
-	ClusterLoggingSpecFieldExcludeSystemComponent = "excludeSystemComponent"
 	ClusterLoggingSpecFieldFluentForwarderConfig  = "fluentForwarderConfig"
+	ClusterLoggingSpecFieldIncludeSystemComponent = "includeSystemComponent"
 	ClusterLoggingSpecFieldKafkaConfig            = "kafkaConfig"
 	ClusterLoggingSpecFieldOutputFlushInterval    = "outputFlushInterval"
 	ClusterLoggingSpecFieldOutputTags             = "outputTags"
@@ -20,8 +20,8 @@ type ClusterLoggingSpec struct {
 	CustomTargetConfig     *CustomTargetConfig    `json:"customTargetConfig,omitempty" yaml:"customTargetConfig,omitempty"`
 	DisplayName            string                 `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	ElasticsearchConfig    *ElasticsearchConfig   `json:"elasticsearchConfig,omitempty" yaml:"elasticsearchConfig,omitempty"`
-	ExcludeSystemComponent bool                   `json:"excludeSystemComponent,omitempty" yaml:"excludeSystemComponent,omitempty"`
 	FluentForwarderConfig  *FluentForwarderConfig `json:"fluentForwarderConfig,omitempty" yaml:"fluentForwarderConfig,omitempty"`
+	IncludeSystemComponent *bool                  `json:"includeSystemComponent,omitempty" yaml:"includeSystemComponent,omitempty"`
 	KafkaConfig            *KafkaConfig           `json:"kafkaConfig,omitempty" yaml:"kafkaConfig,omitempty"`
 	OutputFlushInterval    int64                  `json:"outputFlushInterval,omitempty" yaml:"outputFlushInterval,omitempty"`
 	OutputTags             map[string]string      `json:"outputTags,omitempty" yaml:"outputTags,omitempty"`


### PR DESCRIPTION
This is the same as https://github.com/rancher/rancher/pull/17998
but rebased and with fixed up vendor.conf

Below is the text from the original PR

Problem:
excludeSystemComponent is a negative field

Solution:
change to includeSystemComponent and use true as default

Issue:
https://github.com/rancher/rancher/issues/15555

Types:
https://github.com/rancher/types/pull/715