### PR TITLE
GlobalDNSProvider cannot be deleted until GlobalDNS entries referring it exist

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -153,6 +153,7 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	RoleTemplate(schemas, apiContext)
 	MultiClusterApps(schemas, apiContext)
 	GlobalDNSs(schemas, apiContext)
+	GlobalDNSProviders(schemas, apiContext)
 	Monitor(schemas, apiContext, clusterManager)
 	KontainerDriver(schemas, apiContext)
 
@@ -644,4 +645,13 @@ func GlobalDNSs(schemas *types.Schemas, management *config.ScaledContext) {
 	schema.ActionHandler = gdns.ActionHandler
 	schema.Validator = gdns.Validator
 	schema.Store = globaldnsAPIStore.Wrap(schema.Store)
+}
+
+func GlobalDNSProviders(schemas *types.Schemas, management *config.ScaledContext) {
+	schema := schemas.Schema(&managementschema.Version, client.GlobalDNSProviderType)
+	schema.Store = &globalresource.GlobalNamespaceStore{
+		Store:              schema.Store,
+		NamespaceInterface: management.Core.Namespaces(""),
+	}
+	schema.Store = globaldnsAPIStore.ProviderWrap(schema.Store)
 }

--- a/pkg/api/store/globaldns/globaldnsprovider_store.go
+++ b/pkg/api/store/globaldns/globaldnsprovider_store.go
@@ -1,0 +1,48 @@
+package globaldns
+
+import (
+	"github.com/rancher/norman/api/access"
+	"github.com/rancher/norman/httperror"
+	"github.com/rancher/norman/types"
+	managementv3 "github.com/rancher/types/client/management/v3"
+)
+
+func ProviderWrap(store types.Store) types.Store {
+	storeWrapped := &ProviderStore{
+		Store: store,
+	}
+	return storeWrapped
+}
+
+type ProviderStore struct {
+	types.Store
+}
+
+func (p *ProviderStore) Delete(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
+
+	if err := canDeleteProvider(apiContext, id); err != nil {
+		return nil, err
+	}
+
+	return p.Store.Delete(apiContext, schema, id)
+}
+
+func canDeleteProvider(apiContext *types.APIContext, id string) error {
+
+	//check if there are any globalDNS entries referencing this provider
+	var globalDNSs []managementv3.GlobalDNS
+
+	conditions := []*types.QueryCondition{
+		types.NewConditionFromString(managementv3.GlobalDNSFieldProviderID, types.ModifierEQ, []string{id}...),
+	}
+
+	if err := access.List(apiContext, apiContext.Version, managementv3.GlobalDNSType, &types.QueryOptions{Conditions: conditions}, &globalDNSs); err != nil {
+		return err
+	}
+
+	if len(globalDNSs) > 0 {
+		return httperror.NewAPIError(httperror.PermissionDenied, "Cannot delete the provider until GlobalDNS entries referring it are removed")
+	}
+
+	return nil
+}

--- a/tests/core/test_globaldns.py
+++ b/tests/core/test_globaldns.py
@@ -26,3 +26,28 @@ def test_dns_fqdn_unique(admin_mc):
 
     client.delete(globaldns_entry)
     client.delete(globaldns_provider)
+
+
+def test_dns_provider_deletion(admin_mc):
+    client = admin_mc.client
+    provider_name = random_str()
+    access = random_str()
+    secret = random_str()
+    globaldns_provider = \
+        client.create_global_dns_provider(
+                                         name=provider_name,
+                                         route53ProviderConfig={
+                                             'accessKey': access,
+                                             'secretKey': secret,
+                                             'rootDomain': "example.com"})
+
+    fqdn = random_str() + ".example.com"
+    globaldns_entry = \
+        client.create_global_dns(fqdn=fqdn, providerId=provider_name)
+
+    with pytest.raises(ApiError) as e:
+        client.delete(globaldns_provider)
+        assert e.value.error.status == 403
+
+    client.delete(globaldns_entry)
+    client.delete(globaldns_provider)


### PR DESCRIPTION
This is the fix to avoid deleting the GlobalDNSProvider if some entries are referencing it.

Added an integration test for the same.

https://github.com/rancher/rancher/issues/17518