### PR TITLE
Update vendor.conf

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -29,7 +29,6 @@ golang.org/x/sys                              c11f84a56e43e20a78cee75a7c034031ec
 golang.org/x/sync                             fd80eb99c8f653c847d294a001bdf2a3a6f768f5
 google.golang.org/api                         v0.1.0
 google.golang.org/grpc                        v1.9.1
-google.golang.org/api/tpu/v1                  8e296ef260056b6323d10727db40512dac6d92d5
 gopkg.in/check.v1                             20d25e2804050c1cd24a7eea1e7a6447dd0e74ec
 github.com/mitchellh/mapstructure             v1.1.2
 github.com/gorilla/websocket                  6eb6ad425a89


### PR DESCRIPTION
Remove useless dependence google.golang.org/api/tpu/v1

@cjellick @loganhz to keep the vendor.conf and vendor dir in sync.