### PR TITLE
Fix logging upgrade bug

### DIFF
--- a/pkg/controllers/user/logging/configsyncer/configgenerator.go
+++ b/pkg/controllers/user/logging/configsyncer/configgenerator.go
@@ -37,7 +37,7 @@ func (s *ConfigGenerator) GenerateClusterLoggingConfig(clusterLogging *mgmtv3.Cl
 	}
 
 	var excludeNamespaces string
-	if !*clusterLogging.Spec.IncludeSystemComponent {
+	if clusterLogging.Spec.IncludeSystemComponent != nil && !*clusterLogging.Spec.IncludeSystemComponent {
 		var err error
 		if excludeNamespaces, err = s.addExcludeNamespaces(systemProjectID); err != nil {
 			return nil, err

--- a/pkg/controllers/user/logging/utils/templatewrap.go
+++ b/pkg/controllers/user/logging/utils/templatewrap.go
@@ -47,11 +47,16 @@ func NewWrapClusterLogging(logging v3.ClusterLoggingSpec, excludeNamespace strin
 		return nil, nil
 	}
 
+	includeSystemComponent := true
+	if logging.IncludeSystemComponent != nil {
+		includeSystemComponent = *logging.IncludeSystemComponent
+	}
+
 	return &ClusterLoggingTemplateWrap{
 		LoggingCommonField:        logging.LoggingCommonField,
 		LoggingTargetTemplateWrap: *wrap,
 		ExcludeNamespace:          excludeNamespace,
-		IncludeSystemComponent:    *logging.IncludeSystemComponent,
+		IncludeSystemComponent:    includeSystemComponent,
 	}, nil
 }
 


### PR DESCRIPTION
Problem:
1. old fluentd/log-aggregator, secret not be removed when upgrading rancher server with a enable logging
2. includeSystemComponent will be nil for server upgrade from old version

Solution:
1. clean old resource
2. handle nil situation

Issue:
https://github.com/rancher/rancher/issues/18054
https://github.com/rancher/rancher/issues/18055