### PR TITLE
Fixed issue where the node drivers where not downloaded on url update

### DIFF
--- a/pkg/controllers/management/drivers/dynamic_driver.go
+++ b/pkg/controllers/management/drivers/dynamic_driver.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -39,7 +38,7 @@ func (d *DynamicDriver) Install() error {
 		return nil
 	}
 
-	binaryPath := path.Join(binDir(), d.DriverName)
+	binaryPath := d.binName()
 	tmpPath := binaryPath + "-tmp"
 	f, err := os.OpenFile(tmpPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {
@@ -66,7 +65,8 @@ func (d *DynamicDriver) Install() error {
 	return nil
 }
 
-func (d *BaseDriver) Excutable() error {
+// Executable is will return nil if the driver can be executed
+func (d *BaseDriver) Executable() error {
 	if d.DriverName == "" {
 		return fmt.Errorf("Empty driver name")
 	}
@@ -75,7 +75,7 @@ func (d *BaseDriver) Excutable() error {
 		return nil
 	}
 
-	binaryPath := path.Join(binDir(), d.DriverName)
+	binaryPath := d.binName()
 	_, err := os.Stat(binaryPath)
 	if err != nil {
 		return fmt.Errorf("Driver %s not found", binaryPath)

--- a/pkg/controllers/management/drivers/nodedriver/machine_driver.go
+++ b/pkg/controllers/management/drivers/nodedriver/machine_driver.go
@@ -146,7 +146,7 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 		if err := driver.Install(); err != nil {
 			return nil, err
 		}
-		if err = driver.Excutable(); err != nil {
+		if err = driver.Executable(); err != nil {
 			return nil, err
 		}
 		obj.Spec.DisplayName = strings.TrimPrefix(driver.Name(), drivers.DockerMachineDriverPrefix)


### PR DESCRIPTION
This PR intends to fix the issue rancher/rancher#18058 .

The node driver will be downloaded if the cache version doesn't exits.
Previously, it was only checking the binary executable which doesn't contain any version information.