### PR TITLE
Support local chart app upgrade & rollback

### DIFF
--- a/pkg/controllers/user/helm/controller.go
+++ b/pkg/controllers/user/helm/controller.go
@@ -269,6 +269,8 @@ func (l *Lifecycle) createAppRevision(obj *v3.App, template, notes string, faile
 	release.Status.ProjectName = projectName
 	release.Status.ExternalID = obj.Spec.ExternalID
 	release.Status.ValuesYaml = obj.Spec.ValuesYaml
+	release.Status.Files = obj.Spec.Files
+
 	digest := sha256.New()
 	digest.Write([]byte(template))
 	tag := hex.EncodeToString(digest.Sum(nil))

--- a/vendor.conf
+++ b/vendor.conf
@@ -41,7 +41,7 @@ github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f6841
 github.com/rancher/norman                     2d37b1235bcfeccf7ecd9e0b1a461f1d9b7fac47
 github.com/rancher/kontainer-engine           391960fdb29300ebccda7b48e9ad44415782e0a5
 github.com/rancher/rke                        aa16d70ca616af0112ae2a6bb25e33a777eb2ae7
-github.com/rancher/types                      7b93e996dc18d5ae6d167eb25ad1e24fc54ac716
+github.com/rancher/types                      8206f5d59b4e70bf70981aaaa2af7888c92b2327
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/catalog_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/catalog_types.go
@@ -3,7 +3,6 @@ package v3
 import (
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
-
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
@@ -75,12 +75,14 @@ type AppRevisionStatus struct {
 	Answers     map[string]string `json:"answers"`
 	Digest      string            `json:"digest"`
 	ValuesYaml  string            `json:"valuesYaml,omitempty"`
+	Files       map[string]string `json:"files,omitempty"`
 }
 
 type AppUpgradeConfig struct {
 	ExternalID   string            `json:"externalId,omitempty"`
 	Answers      map[string]string `json:"answers,omitempty"`
 	ForceUpgrade bool              `json:"forceUpgrade,omitempty"`
+	Files        map[string]string `json:"files,omitempty"`
 }
 
 type RollbackRevision struct {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_deepcopy.go
@@ -170,6 +170,13 @@ func (in *AppRevisionStatus) DeepCopyInto(out *AppRevisionStatus) {
 			(*out)[key] = val
 		}
 	}
+	if in.Files != nil {
+		in, out := &in.Files, &out.Files
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -246,6 +253,13 @@ func (in *AppUpgradeConfig) DeepCopyInto(out *AppUpgradeConfig) {
 	*out = *in
 	if in.Answers != nil {
 		in, out := &in.Answers, &out.Answers
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Files != nil {
+		in, out := &in.Files, &out.Files
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_revision_status.go
+++ b/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_revision_status.go
@@ -5,6 +5,7 @@ const (
 	AppRevisionStatusFieldAnswers    = "answers"
 	AppRevisionStatusFieldDigest     = "digest"
 	AppRevisionStatusFieldExternalID = "externalId"
+	AppRevisionStatusFieldFiles      = "files"
 	AppRevisionStatusFieldProjectID  = "projectId"
 	AppRevisionStatusFieldValuesYaml = "valuesYaml"
 )
@@ -13,6 +14,7 @@ type AppRevisionStatus struct {
 	Answers    map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
 	Digest     string            `json:"digest,omitempty" yaml:"digest,omitempty"`
 	ExternalID string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
+	Files      map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
 	ProjectID  string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
 	ValuesYaml string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }

--- a/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_upgrade_config.go
+++ b/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_upgrade_config.go
@@ -4,11 +4,13 @@ const (
 	AppUpgradeConfigType              = "appUpgradeConfig"
 	AppUpgradeConfigFieldAnswers      = "answers"
 	AppUpgradeConfigFieldExternalID   = "externalId"
+	AppUpgradeConfigFieldFiles        = "files"
 	AppUpgradeConfigFieldForceUpgrade = "forceUpgrade"
 )
 
 type AppUpgradeConfig struct {
 	Answers      map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
 	ExternalID   string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
+	Files        map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
 	ForceUpgrade bool              `json:"forceUpgrade,omitempty" yaml:"forceUpgrade,omitempty"`
 }


### PR DESCRIPTION
This is a rebased version of https://github.com/rancher/rancher/pull/17278

#### Below is the original description
**Problem:**
- Cannot upgrade local chart app
- Cannot rollback local chart app

**Solution:**
- Input local app templates when upgrading
- Record local app templates in `AppRevision`, restore them into `App` when rollbacking

**Issue:**
#15711

**Related PR:**
- https://github.com/rancher/types/pull/664
