### PR TITLE
Configure TTL for GlobalDNS entries

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -41,7 +41,7 @@ github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f6841
 github.com/rancher/norman                     362802224f64fd09a56be0d275f6ec1d7ecf2164
 github.com/rancher/kontainer-engine           391960fdb29300ebccda7b48e9ad44415782e0a5
 github.com/rancher/rke                        e6b677a885e2d38f4a1604d5ce2d4ae59883f072
-github.com/rancher/types                      6370ec9f4e38c80f3a8161990d1efa8622004ea5
+github.com/rancher/types                      9577885c7a5818696ff24e7a9fc5a5059692ed49
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/globaldns_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/globaldns_types.go
@@ -19,6 +19,7 @@ type GlobalDNS struct {
 
 type GlobalDNSSpec struct {
 	FQDN                string   `json:"fqdn,omitempty" norman:"required"`
+	TTL                 int64    `json:"ttl,omitempty"`
 	ProjectNames        []string `json:"projectNames" norman:"type=array[reference[project]],noupdate"`
 	MultiClusterAppName string   `json:"multiClusterAppName,omitempty" norman:"type=reference[multiClusterApp]"`
 	ProviderName        string   `json:"providerName,omitempty" norman:"type=reference[globalDnsProvider],required"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_global_dns.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_global_dns.go
@@ -20,6 +20,7 @@ const (
 	GlobalDNSFieldRemoved              = "removed"
 	GlobalDNSFieldState                = "state"
 	GlobalDNSFieldStatus               = "status"
+	GlobalDNSFieldTTL                  = "ttl"
 	GlobalDNSFieldTransitioning        = "transitioning"
 	GlobalDNSFieldTransitioningMessage = "transitioningMessage"
 	GlobalDNSFieldUUID                 = "uuid"
@@ -41,6 +42,7 @@ type GlobalDNS struct {
 	Removed              string            `json:"removed,omitempty" yaml:"removed,omitempty"`
 	State                string            `json:"state,omitempty" yaml:"state,omitempty"`
 	Status               *GlobalDNSStatus  `json:"status,omitempty" yaml:"status,omitempty"`
+	TTL                  int64             `json:"ttl,omitempty" yaml:"ttl,omitempty"`
 	Transitioning        string            `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
 	TransitioningMessage string            `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
 	UUID                 string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_global_dns_spec.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_global_dns_spec.go
@@ -7,6 +7,7 @@ const (
 	GlobalDNSSpecFieldMultiClusterAppID = "multiClusterAppId"
 	GlobalDNSSpecFieldProjectIDs        = "projectIds"
 	GlobalDNSSpecFieldProviderID        = "providerId"
+	GlobalDNSSpecFieldTTL               = "ttl"
 )
 
 type GlobalDNSSpec struct {
@@ -15,4 +16,5 @@ type GlobalDNSSpec struct {
 	MultiClusterAppID string   `json:"multiClusterAppId,omitempty" yaml:"multiClusterAppId,omitempty"`
 	ProjectIDs        []string `json:"projectIds,omitempty" yaml:"projectIds,omitempty"`
 	ProviderID        string   `json:"providerId,omitempty" yaml:"providerId,omitempty"`
+	TTL               int64    `json:"ttl,omitempty" yaml:"ttl,omitempty"`
 }


### PR DESCRIPTION
This is the fix for https://github.com/rancher/rancher/issues/17871

The kubernetes-incubator/external-dns supports configuring TTL for a DNS record using an annotation:
https://github.com/kubernetes-incubator/external-dns/blob/master/docs/ttl.md

As a fix, added TTL parameter to GlobalDNS entry (types PR: https://github.com/rancher/types/pull/717) and it will get applied as an annotation to the mgmt plane ingress that the external-dns provider syncs up with.