### PR TITLE
Move cattle-global-data to System project

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -39,7 +39,7 @@ var (
 	ServerURL                       = NewSetting("server-url", "")
 	ServerVersion                   = NewSetting("server-version", "dev")
 	SystemDefaultRegistry           = NewSetting("system-default-registry", "")
-	SystemNamespaces                = NewSetting("system-namespaces", "kube-system,kube-public,cattle-system,cattle-alerting,cattle-logging,cattle-pipeline,cattle-prometheus,ingress-nginx")
+	SystemNamespaces                = NewSetting("system-namespaces", "kube-system,kube-public,cattle-system,cattle-alerting,cattle-logging,cattle-pipeline,cattle-prometheus,ingress-nginx,cattle-global-data")
 	TelemetryOpt                    = NewSetting("telemetry-opt", "prompt")
 	UIFeedBackForm                  = NewSetting("ui-feedback-form", "")
 	UIIndex                         = NewSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")

--- a/tests/core/test_system_project.py
+++ b/tests/core/test_system_project.py
@@ -5,7 +5,8 @@ systemProjectLabel = "authz.management.cattle.io/system-project"
 defaultProjectLabel = "authz.management.cattle.io/default-project"
 initial_system_namespaces = set(["kube-system",
                                  "cattle-system",
-                                 "kube-public"])
+                                 "kube-public",
+                                 "cattle-global-data"])
 
 
 def test_system_project_created(admin_cc):


### PR DESCRIPTION
Fix for https://github.com/rancher/rancher/issues/17508

Upon creation of System project, the global namespace will be moved to the System project