### PR TITLE
Don't log whole value of token since it's sensitive data

### DIFF
--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -204,7 +204,10 @@ func run() error {
 		if !isConnect() {
 			wsURL += "/register"
 		}
-		logrus.Infof("Connecting to %s with token %s", wsURL, token)
+		// Don't show whole token value, show first/last 4 characters instead
+		logrus.Infof("Connecting to %s with token %s", wsURL,
+			token[0:4]+strings.Repeat("*", len(token)-4*2)+token[len(token)-4:],
+		)
 		remotedialer.ClientConnect(wsURL, http.Header(headers), nil, func(proto, address string) bool {
 			switch proto {
 			case "tcp":


### PR DESCRIPTION
Currently Node Agent, Cluster Agent print whole token in log, but they are sensitive data, so we should not print whole value. we'd better to mask some part and show only first / last 4 characters.
rancher/rancher#18112
