### PR TITLE
Refactor project level Monitoring

### DIFF
--- a/pkg/api/customization/monitor/cluster_graph_action.go
+++ b/pkg/api/customization/monitor/cluster_graph_action.go
@@ -70,8 +70,8 @@ func (h *ClusterGraphHandler) QuerySeriesAction(actionName string, action *types
 	reqContext, cancel := context.WithTimeout(context.Background(), prometheusReqTimeout)
 	defer cancel()
 
-	svcName, svcNamespace, _ := monitorutil.ClusterPrometheusEndpoint()
-	prometheusQuery, err := NewPrometheusQuery(reqContext, userContext, clusterName, token, svcNamespace, svcName, h.clustermanager, h.dialerFactory)
+	svcName, svcNamespace, svcPort := monitorutil.ClusterPrometheusEndpoint()
+	prometheusQuery, err := NewPrometheusQuery(reqContext, clusterName, token, svcNamespace, svcName, svcPort, h.dialerFactory)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/customization/monitor/handler_utils.go
+++ b/pkg/api/customization/monitor/handler_utils.go
@@ -3,7 +3,6 @@ package monitor
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -25,17 +24,6 @@ var (
 	defaultTo          = "now"
 	defaultFrom        = "now-" + defaultQueryDuring
 )
-
-func getPrometheusEndpoint(userContext *config.UserContext, namespace, name string) (string, error) {
-	svc, err := userContext.Core.Services("").Controller().Lister().Get(namespace, name)
-	if err != nil {
-		return "", fmt.Errorf("Failed to get service for prometheus-server %v", err)
-	}
-
-	port := svc.Spec.Ports[0].Port
-	url := "http://" + svc.Name + "." + svc.Namespace + ".svc.cluster.local:" + strconv.Itoa(int(port))
-	return url, nil
-}
 
 func newClusterGraphInputParser(input v3.QueryGraphInput) *clusterGraphInputParser {
 	return &clusterGraphInputParser{

--- a/pkg/api/customization/monitor/metric_action.go
+++ b/pkg/api/customization/monitor/metric_action.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rancher/rancher/pkg/ref"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config/dialer"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func NewMetricHandler(dialerFactory dialer.Factory, clustermanager *clustermanager.Manager) *MetricHandler {
@@ -211,25 +210,9 @@ func (h *MetricHandler) Action(actionName string, action *types.Action, apiConte
 			return fmt.Errorf("get project metric list failed, %v", err)
 		}
 
-		// get name list for pod/container metric from cluster prometheus
-		clusterSvcName, clusterSvcNamespace, _ := monitorutil.ClusterPrometheusEndpoint()
-		clusterPrometheusQuery, err := NewPrometheusQuery(reqContext, userContext, clusterName, token, clusterSvcNamespace, clusterSvcName, h.clustermanager, h.dialerFactory)
-		if err != nil {
-			return err
-		}
-
-		clusterNames, err := clusterPrometheusQuery.GetLabelValues("__name__")
-		if err != nil {
-			return fmt.Errorf("get cluster metric list failed, %v", err)
-		}
-
-		names := sets.String{}
-		names.Insert(projectNames...)
-		names.Insert(clusterNames...)
-
 		data := map[string]interface{}{
 			"type":  "metricNamesOutput",
-			"names": names.List(),
+			"names": projectNames,
 		}
 		apiContext.WriteResponse(http.StatusOK, data)
 	}

--- a/pkg/api/customization/monitor/project_graph_action.go
+++ b/pkg/api/customization/monitor/project_graph_action.go
@@ -66,8 +66,8 @@ func (h *ProjectGraphHandler) QuerySeriesAction(actionName string, action *types
 	reqContext, cancel := context.WithTimeout(context.Background(), prometheusReqTimeout)
 	defer cancel()
 
-	svcName, svcNamespace, _ := monitorutil.ClusterPrometheusEndpoint()
-	prometheusQuery, err := NewPrometheusQuery(reqContext, userContext, clusterName, token, svcNamespace, svcName, h.clustermanager, h.dialerFactory)
+	svcName, svcNamespace, svcPort := monitorutil.ClusterPrometheusEndpoint()
+	prometheusQuery, err := NewPrometheusQuery(reqContext, clusterName, token, svcNamespace, svcName, svcPort, h.dialerFactory)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/customization/monitor/prometheus_manager.go
+++ b/pkg/api/customization/monitor/prometheus_manager.go
@@ -12,8 +12,6 @@ import (
 	promapi "github.com/prometheus/client_golang/api"
 	promapiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/rancher/rancher/pkg/clustermanager"
-	"github.com/rancher/types/config"
 	"github.com/rancher/types/config/dialer"
 	"golang.org/x/sync/errgroup"
 )
@@ -28,16 +26,13 @@ type Queries struct {
 	eg  *errgroup.Group
 }
 
-func NewPrometheusQuery(ctx context.Context, userContext *config.UserContext, clusterName, authToken, svcNamespace, svcName string, clustermanager *clustermanager.Manager, dialerFactory dialer.Factory) (*Queries, error) {
+func NewPrometheusQuery(ctx context.Context, clusterName, authToken, svcNamespace, svcName, svcPort string, dialerFactory dialer.Factory) (*Queries, error) {
 	dial, err := dialerFactory.ClusterDialer(clusterName)
 	if err != nil {
 		return nil, fmt.Errorf("get dail from usercontext failed, %v", err)
 	}
 
-	endpoint, err := getPrometheusEndpoint(userContext, svcNamespace, svcName)
-	if err != nil {
-		return nil, err
-	}
+	endpoint := fmt.Sprintf("http://%s.%s:%s", svcName, svcNamespace, svcPort)
 
 	api, err := newPrometheusAPI(dial, endpoint, authToken)
 	if err != nil {

--- a/pkg/controllers/user/monitoring/register.go
+++ b/pkg/controllers/user/monitoring/register.go
@@ -43,7 +43,8 @@ func Register(ctx context.Context, agentContext *config.UserContext) {
 		cattleClusterClient: cattleClustersClient,
 		app:                 ah,
 	}
-	cattleClustersClient.AddHandler(ctx, "prometheus-operator-handler", oh.sync)
+	cattleClustersClient.AddHandler(ctx, "prometheus-operator-handler", oh.syncCluster)
+	cattleProjectsClient.Controller().AddClusterScopedHandler(ctx, "prometheus-operator-handler", clusterName, oh.syncProject)
 
 	// cluster handler
 	ch := &clusterHandler{

--- a/pkg/monitoring/deploy.go
+++ b/pkg/monitoring/deploy.go
@@ -138,7 +138,6 @@ func WithdrawApp(cattleAppClient projectv3.AppInterface, appLabels metav1.ListOp
 		return errors.Wrapf(err, "failed to find App with %s", appLabels.String())
 	}
 
-	monitoringApps = monitoringApps.DeepCopy()
 	for _, app := range monitoringApps.Items {
 		if app.DeletionTimestamp == nil {
 			if err := cattleAppClient.DeleteNamespaced(app.Namespace, app.Name, &metav1.DeleteOptions{}); err != nil {

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -124,16 +124,16 @@ func ProjectMonitoringInfo(projectName string) (appName, appTargetNamespace stri
 	return projectLevelAppName, fmt.Sprintf("%s-%s", cattleNamespaceName, projectName)
 }
 
-func ProjectPrometheusServiceInfo(projectName string) (headlessServiceName, namespace string) {
-	return prometheusHeadlessServiceName, fmt.Sprintf("%s-%s", cattleNamespaceName, projectName)
-}
-
 func ClusterAlertManagerEndpoint() (headlessServiceName, namespace, port string) {
 	return alertManagerHeadlessServiceName, cattleNamespaceName, "9093"
 }
 
 func ClusterPrometheusEndpoint() (headlessServiceName, namespace, port string) {
 	return prometheusHeadlessServiceName, cattleNamespaceName, "9090"
+}
+
+func ProjectPrometheusEndpoint(projectName string) (headlessServiceName, namespace, port string) {
+	return prometheusHeadlessServiceName, fmt.Sprintf("%s-%s", cattleNamespaceName, projectName), "9090"
 }
 
 /*OverwriteAppAnswers Usage


### PR DESCRIPTION
**Problem:**
Based on https://github.com/rancher/rancher/issues/16932, we have addressed something that wasn't a bug. We shouldn't delete `project-level` monitoring if the user was monitoring a custom app.

**Solution:**
- Don't disable `project-level` when disabling `cluster-level`
- Don't detect `cluster-level` enabling or not when enabling `project-level`
- Ensure Prometheus Operator existent when any `project-level` is enabling Monitoring
- Use `federate` as default sync mode when `project-level` deploying

**Issue:**
- https://github.com/rancher/rancher/issues/18115
- https://github.com/rancher/rancher/issues/18218