### PR TITLE
Fixing RKE edit issue

### DIFF
--- a/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
+++ b/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
@@ -378,7 +378,7 @@ func (l *Lifecycle) Updated(obj *v3.KontainerDriver) (runtime.Object, error) {
 }
 
 func hasStaticSchema(obj *v3.KontainerDriver) bool {
-	return obj.Name == "rancherKubernetesEngine" || obj.Name == "import"
+	return obj.Name == service.RancherKubernetesEngineDriverName || obj.Name == service.ImportDriverName
 }
 
 func getDynamicTypeName(obj *v3.KontainerDriver) string {

--- a/tests/core/test_kontainer_engine_config.py
+++ b/tests/core/test_kontainer_engine_config.py
@@ -33,22 +33,22 @@ def test_eks_config_appears_correctly(admin_mc, remove_resource):
     """ Simple test to ensure that cluster returned from POST is correct"""
     cluster = admin_mc.client.create_cluster(
         name=random_str(), amazonElasticContainerServiceConfig={
-             "accessKey": "MyAccessKey",
-             "ami": "",
-             "associateWorkerNodePublicIp": True,
-             "displayName": "EKS-api-cluster",
-             "driverName": "amazonelasticcontainerservice",
-             "instanceType": "t3.small",
-             "kubernetesVersion": "1.11",
-             "maximumNodes": 3,
-             "minimumNodes": 1,
-             "region": "us-east-2",
-             "secretKey": "secret-key",
-             "serviceRole": "",
-             "sessionToken": "",
-             "userData": "!#/bin/bash\ntouch /tmp/testfile.txt",
-             "virtualNetwork": "",
-            })
+            "accessKey": "MyAccessKey",
+            "ami": "",
+            "associateWorkerNodePublicIp": True,
+            "displayName": "EKS-api-cluster",
+            "driverName": "amazonelasticcontainerservice",
+            "instanceType": "t3.small",
+            "kubernetesVersion": "1.11",
+            "maximumNodes": 3,
+            "minimumNodes": 1,
+            "region": "us-east-2",
+            "secretKey": "secret-key",
+            "serviceRole": "",
+            "sessionToken": "",
+            "userData": "!#/bin/bash\ntouch /tmp/testfile.txt",
+            "virtualNetwork": "",
+        })
     remove_resource(cluster)
 
     # test cluster returned from POST has correct config
@@ -73,3 +73,16 @@ def test_eks_config_appears_correctly(admin_mc, remove_resource):
 
     # test that cluster returned from PUT has correct config
     assert cluster.amazonElasticContainerServiceConfig.maximumNodes == 5
+
+
+def test_rke_config_appears_correctly(admin_mc, remove_resource):
+    """ Testing a single field from the RKE config to ensure that the
+    schema is properly populated"""
+    cluster = admin_mc.client.create_cluster(
+        name=random_str(), rancherKubernetesEngineConfig={
+            "kubernetesVersion": "some-fake-version",
+        })
+    remove_resource(cluster)
+
+    k8s_version = cluster.rancherKubernetesEngineConfig.kubernetesVersion
+    assert k8s_version == "some-fake-version"


### PR DESCRIPTION
This fixes a issue with the RKE schema where it was being overwritten by a bad
set of fields coming from the RKE driver.  This was preventing existing RKE
clusters from being edited on the UI because the config was bad.  The fix
works by correcting the `rancherkubernetesengine` kontainer driver resource
name in the `hasStaticSchema` check in the kontainer driver controller so that
it will not attempt to use the rke_driver.go schema and default to the built
in RKE struct.

Issue:
https://github.com/rancher/rancher/issues/18120