### PR TITLE
Resolve the confusion that occurs when disabling monitoring

### DIFF
--- a/pkg/controllers/user/monitoring/appHandler.go
+++ b/pkg/controllers/user/monitoring/appHandler.go
@@ -25,6 +25,6 @@ type appHandler struct {
 	agentNamespaceClient        corev1.NamespaceInterface
 }
 
-func (ah *appHandler) withdrawApp(appName, appTargetNamespace string) error {
-	return monitoring.WithdrawApp(ah.cattleAppClient, monitoring.OwnedAppListOptions(appName, appTargetNamespace))
+func (ah *appHandler) withdrawApp(clusterID, appName, appTargetNamespace string) error {
+	return monitoring.WithdrawApp(ah.cattleAppClient, monitoring.OwnedAppListOptions(clusterID, appName, appTargetNamespace))
 }

--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -121,7 +121,7 @@ func (ch *clusterHandler) doSync(cluster *mgmtv3.Cluster) error {
 			return errors.Wrap(err, "failed to disable all owned projects monitoring")
 		}
 
-		if err := ch.app.withdrawApp(appName, appTargetNamespace); err != nil {
+		if err := ch.app.withdrawApp(cluster.Name, appName, appTargetNamespace); err != nil {
 			mgmtv3.ClusterConditionMonitoringEnabled.Unknown(cluster)
 			mgmtv3.ClusterConditionMonitoringEnabled.Message(cluster, err.Error())
 			return errors.Wrap(err, "failed to withdraw monitoring")

--- a/pkg/controllers/user/monitoring/operatorHandler.go
+++ b/pkg/controllers/user/monitoring/operatorHandler.go
@@ -43,7 +43,7 @@ func (h *operatorHandler) sync(key string, obj *mgmtv3.Cluster) (runtime.Object,
 				mgmtv3.ClusterConditionMonitoringEnabled.GetStatus(obj) == "") &&
 			!mgmtv3.ClusterConditionPrometheusOperatorDeployed.IsFalse(obj) {
 			newCluster = obj.DeepCopy()
-			if err = withdrawSystemMonitor(h.app); err != nil {
+			if err = withdrawSystemMonitor(h.app, newCluster.Name); err != nil {
 				mgmtv3.ClusterConditionPrometheusOperatorDeployed.Unknown(newCluster)
 				mgmtv3.ClusterConditionPrometheusOperatorDeployed.ReasonAndMessageFromError(newCluster, err)
 			} else {
@@ -111,10 +111,10 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) (backErr erro
 	return nil
 }
 
-func withdrawSystemMonitor(app *appHandler) error {
+func withdrawSystemMonitor(app *appHandler, clusterID string) error {
 	appName, appTargetNamespace := monitoring.SystemMonitoringInfo()
 
-	if err := monitoring.WithdrawApp(app.cattleAppClient, monitoring.OwnedAppListOptions(appName, appTargetNamespace)); err != nil {
+	if err := monitoring.WithdrawApp(app.cattleAppClient, monitoring.OwnedAppListOptions(clusterID, appName, appTargetNamespace)); err != nil {
 		return errors.Wrap(err, "failed to withdraw prometheus operator app")
 	}
 

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -111,7 +111,7 @@ func (ph *projectHandler) doSync(project *mgmtv3.Project, clusterName string) er
 		mgmtv3.ProjectConditionMonitoringEnabled.True(project)
 		mgmtv3.ProjectConditionMonitoringEnabled.Message(project, "")
 	} else if project.Status.MonitoringStatus != nil {
-		if err := ph.app.withdrawApp(appName, appTargetNamespace); err != nil {
+		if err := ph.app.withdrawApp(project.Spec.ClusterName, appName, appTargetNamespace); err != nil {
 			mgmtv3.ProjectConditionMonitoringEnabled.Unknown(project)
 			mgmtv3.ProjectConditionMonitoringEnabled.Message(project, err.Error())
 			return errors.Wrap(err, "failed to withdraw monitoring")

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -66,9 +66,9 @@ var (
 	}
 )
 
-func OwnedAppListOptions(appName, appTargetNamespace string) metav1.ListOptions {
+func OwnedAppListOptions(clusterID, appName, appTargetNamespace string) metav1.ListOptions {
 	return metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s, %s=%s", appNameLabelKey, appName, appTargetNamespaceLabelKey, appTargetNamespace),
+		LabelSelector: fmt.Sprintf("%s=%s, %s=%s, %s=%s", appClusterIDLabelKey, clusterID, appNameLabelKey, appName, appTargetNamespaceLabelKey, appTargetNamespace),
 	}
 }
 


### PR DESCRIPTION
**Problem:**
Assuming there are two clusters, monitoring is enabled. When disabling
the monitoring of cluster A, monitoring app of cluster B also be
dropped. But cluster B is still in monitoring `enabling` status.

**Solution:**
When withdrawing the monitoring app, we need to increase a `clusterID`
parameter to ensure dropping the app of expected cluster.

**Issue:**
https://github.com/rancher/rancher/issues/18146