### PR TITLE
Add valuesYaml to the catalog upgrade action

### DIFF
--- a/pkg/api/customization/app/app.go
+++ b/pkg/api/customization/app/app.go
@@ -115,6 +115,7 @@ func (w Wrapper) ActionHandler(actionName string, action *types.Action, apiConte
 		answers := actionInput["answers"]
 		forceUpgrade := actionInput["forceUpgrade"]
 		files := actionInput["files"]
+		valuesYaml := actionInput["valuesYaml"]
 		_, namespace := ref.Parse(app.ProjectID)
 		obj, err := w.AppGetter.Apps(namespace).Get(app.Name, metav1.GetOptions{})
 		if err != nil {
@@ -148,10 +149,14 @@ func (w Wrapper) ActionHandler(actionName string, action *types.Action, apiConte
 				obj.Spec.ExternalID = "" // ignore externalID
 			}
 		}
+		if valuesYaml != nil {
+			obj.Spec.ValuesYaml = convert.ToString(valuesYaml)
+		}
 
 		if _, err := w.AppGetter.Apps(namespace).Update(obj); err != nil {
 			return err
 		}
+		apiContext.WriteResponse(http.StatusNoContent, map[string]interface{}{})
 		return nil
 	case "rollback":
 		forceUpgrade := actionInput["forceUpgrade"]
@@ -183,6 +188,7 @@ func (w Wrapper) ActionHandler(actionName string, action *types.Action, apiConte
 		if _, err := w.AppGetter.Apps(namespace).Update(obj); err != nil {
 			return err
 		}
+		apiContext.WriteResponse(http.StatusNoContent, map[string]interface{}{})
 		return nil
 	}
 	return nil

--- a/vendor.conf
+++ b/vendor.conf
@@ -41,7 +41,7 @@ github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f6841
 github.com/rancher/norman                     362802224f64fd09a56be0d275f6ec1d7ecf2164
 github.com/rancher/kontainer-engine           ec205a52e39af6e02e84db1075049eea6a6d9104
 github.com/rancher/rke                        e6b677a885e2d38f4a1604d5ce2d4ae59883f072
-github.com/rancher/types                      801e95278462dc62f3bb2ddfeabbe08ef651d18e
+github.com/rancher/types                      fb39132562f7f115088feee9376e6042a53d3db8 https://github.com/guangbochen/types
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
@@ -83,6 +83,7 @@ type AppUpgradeConfig struct {
 	Answers      map[string]string `json:"answers,omitempty"`
 	ForceUpgrade bool              `json:"forceUpgrade,omitempty"`
 	Files        map[string]string `json:"files,omitempty"`
+	ValuesYaml   string            `json:"valuesYaml,omitempty"`
 }
 
 type RollbackRevision struct {

--- a/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_upgrade_config.go
+++ b/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_upgrade_config.go
@@ -6,6 +6,7 @@ const (
 	AppUpgradeConfigFieldExternalID   = "externalId"
 	AppUpgradeConfigFieldFiles        = "files"
 	AppUpgradeConfigFieldForceUpgrade = "forceUpgrade"
+	AppUpgradeConfigFieldValuesYaml   = "valuesYaml"
 )
 
 type AppUpgradeConfig struct {
@@ -13,4 +14,5 @@ type AppUpgradeConfig struct {
 	ExternalID   string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
 	Files        map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
 	ForceUpgrade bool              `json:"forceUpgrade,omitempty" yaml:"forceUpgrade,omitempty"`
+	ValuesYaml   string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }


### PR DESCRIPTION
**Problem:**
Cannot update valuesYaml field for catalog app in the upgrade

**Solution:**
Add valuesYaml filed to the catalog upgrade action.

**Issues:**
#18111

**Related PRs:**
rancher/types#723