### PR TITLE
update vendor of kontainer-engine

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -39,7 +39,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     362802224f64fd09a56be0d275f6ec1d7ecf2164
-github.com/rancher/kontainer-engine           ec205a52e39af6e02e84db1075049eea6a6d9104
+github.com/rancher/kontainer-engine           gke-legacy-authorization                 https://github.com/fyery-chen/kontainer-engine.git
 github.com/rancher/rke                        b120f2a066b08acc29c271e0cfa581a86352a3e0
 github.com/rancher/types                      801e95278462dc62f3bb2ddfeabbe08ef651d18e
 

--- a/vendor/github.com/rancher/kontainer-engine/drivers/gke/gke_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/gke/gke_driver.go
@@ -180,10 +180,6 @@ func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags
 		Type:  types.BoolType,
 		Usage: "To enable kubernetes alpha feature",
 	}
-	driverFlag.Options["legacy-authorization"] = &types.Flag{
-		Type:  types.BoolType,
-		Usage: "Enable legacy authorization",
-	}
 	driverFlag.Options["enable-stackdriver-logging"] = &types.Flag{
 		Type:  types.BoolPointerType,
 		Usage: "Disable stackdriver logging",
@@ -345,7 +341,7 @@ func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags
 		Usage: "The sub-network to use for the cluster",
 	}
 	driverFlag.Options["enable-legacy-abac"] = &types.Flag{
-		Type:  types.StringType,
+		Type:  types.BoolType,
 		Usage: "Whether to enable legacy abac on the cluster",
 	}
 	driverFlag.Options["locations"] = &types.Flag{
@@ -450,7 +446,7 @@ func getStateFromOpts(driverOptions *types.DriverOptions) (state, error) {
 	d.NodePool.Config.ImageType = options.GetValueFromDriverOptions(driverOptions, types.StringType, "imageType").(string)
 	d.Network = options.GetValueFromDriverOptions(driverOptions, types.StringType, "network").(string)
 	d.SubNetwork = options.GetValueFromDriverOptions(driverOptions, types.StringType, "subNetwork").(string)
-	d.LegacyAbac = options.GetValueFromDriverOptions(driverOptions, types.BoolType, "legacy-authorization", "enableLegacyAbac").(bool)
+	d.LegacyAbac = options.GetValueFromDriverOptions(driverOptions, types.BoolType, "enable-legacy-abac", "enableLegacyAbac").(bool)
 	d.Locations = []string{}
 	locations := options.GetValueFromDriverOptions(driverOptions, types.StringSliceType, "locations").(*types.StringSlice)
 	for _, location := range locations.Value {


### PR DESCRIPTION
Problem:
There are two different options related to a same field in GKE.

Solution:
Remove the redundant options.

Issue:
[rancher/rancher#17015](https://github.com/rancher/rancher/issues/17015)

Related PR:
https://github.com/rancher/kontainer-engine/pull/129