### PR TITLE
kontainer-engine vendor update

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -39,7 +39,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     362802224f64fd09a56be0d275f6ec1d7ecf2164
-github.com/rancher/kontainer-engine           ec205a52e39af6e02e84db1075049eea6a6d9104
+github.com/rancher/kontainer-engine           issue_18165 https://github.com/thxCode/rancher-kontainer-engine
 github.com/rancher/rke                        b120f2a066b08acc29c271e0cfa581a86352a3e0
 github.com/rancher/types                      801e95278462dc62f3bb2ddfeabbe08ef651d18e
 

--- a/vendor/github.com/rancher/kontainer-engine/drivers/aks/aks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/aks/aks_driver.go
@@ -808,7 +808,7 @@ func (d *Driver) createOrUpdate(ctx context.Context, options *types.DriverOption
 				DNSPrefix:      to.StringPtr(agentDNSPrefix),
 				Count:          countPointer,
 				MaxPods:        maxPodsPointer,
-				Name:           to.StringPtr(safeSlice(driverState.AgentName, 12)),
+				Name:           to.StringPtr(driverState.AgentName),
 				OsDiskSizeGB:   osDiskSizeGBPointer,
 				OsType:         containerservice.Linux,
 				StorageProfile: agentStorageProfile,


### PR DESCRIPTION
**Problem:**
Change previous cluster agent pool name will cause AKS API error

**Solution:**
Don't change the previous cluster agent pool name

**Issue:**
https://github.com/rancher/rancher/issues/18165

**Related PR:**
https://github.com/rancher/kontainer-engine/pull/130