### PR TITLE
WIP Hide resource actions for globalDNS on non-HA setup

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -172,8 +172,19 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	setupScopedTypes(schemas)
 	setupPasswordTypes(ctx, schemas, apiContext)
 	multiclusterapp.SetMemberStore(ctx, schemas.Schema(&managementschema.Version, client.MultiClusterAppType), apiContext)
-
+	resetHASchemas(schemas, apiContext)
 	return nil
+}
+
+func resetHASchemas(schemas *types.Schemas, apiContext *config.ScaledContext) {
+	if apiContext.PeerManager == nil {
+		globalDNS := schemas.Schema(&managementschema.Version, client.GlobalDNSType)
+		globalDNS.CollectionMethods = []string{}
+		globalDNS.ResourceMethods = []string{}
+		globalDNSProvider := schemas.Schema(&managementschema.Version, client.GlobalDNSProviderType)
+		globalDNSProvider.CollectionMethods = []string{}
+		globalDNSProvider.ResourceMethods = []string{}
+	}
 }
 
 func setupPasswordTypes(ctx context.Context, schemas *types.Schemas, management *config.ScaledContext) {

--- a/tests/core/test_globaldns.py
+++ b/tests/core/test_globaldns.py
@@ -3,6 +3,7 @@ from rancher import ApiError
 import pytest
 
 
+@pytest.mark.skip(reason='drone needs to change to run rancher in HA mode')
 def test_dns_fqdn_unique(admin_mc):
     client = admin_mc.client
     provider_name = random_str()
@@ -28,6 +29,7 @@ def test_dns_fqdn_unique(admin_mc):
     client.delete(globaldns_provider)
 
 
+@pytest.mark.skip(reason='drone needs to change to run rancher in HA mode')
 def test_dns_provider_deletion(admin_mc):
     client = admin_mc.client
     provider_name = random_str()


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/17558

@cjellick the downside of this fix is - had to disable global dns api validation tests. Will add them back once we start deploying Rancher in HA mode on Drone. We should really start doing it as that's the recommended install mode.