### PR TITLE
Update mcapp addproject input parsing

### DIFF
--- a/pkg/api/customization/multiclusterapp/multi_cluster_app.go
+++ b/pkg/api/customization/multiclusterapp/multi_cluster_app.go
@@ -155,7 +155,7 @@ func (w Wrapper) modifyProjects(request *types.APIContext, actionName string) (*
 	if accessType != gaccess.OwnerAccess {
 		return nil, existingProjects, inputProjects, inputAnswers, fmt.Errorf("only owners can modify projects of multiclusterapp")
 	}
-	var updateMultiClusterAppTargetsInput v3.UpdateMultiClusterAppTargetsInput
+	var updateMultiClusterAppTargetsInput client.UpdateMultiClusterAppTargetsInput
 	actionInput, err := parse.ReadBody(request.Request)
 	if err != nil {
 		return nil, existingProjects, inputProjects, inputAnswers, err
@@ -172,7 +172,13 @@ func (w Wrapper) modifyProjects(request *types.APIContext, actionName string) (*
 			return nil, existingProjects, inputProjects, inputAnswers, err
 		}
 	}
-	inputAnswers = updateMultiClusterAppTargetsInput.Answers
+	for _, a := range updateMultiClusterAppTargetsInput.Answers {
+		inputAnswers = append(inputAnswers, v3.Answer{
+			ProjectName: a.ProjectID,
+			ClusterName: a.ClusterID,
+			Values:      a.Values,
+		})
+	}
 	// check if the input includes answers, and if they are only for the input projects
 	if len(inputAnswers) > 0 {
 		inputProjectsMap := make(map[string]bool)

--- a/vendor.conf
+++ b/vendor.conf
@@ -42,7 +42,7 @@ github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f6841
 github.com/rancher/norman                     362802224f64fd09a56be0d275f6ec1d7ecf2164
 github.com/rancher/kontainer-engine           fe57856dc1d75c706614e3439b400eddc8879d88
 github.com/rancher/rke                        947b7eeaad2a382f729256efb70f1e937440ea03
-github.com/rancher/types                      d0b7740d2089fdf9befdec93ccc9211e67e49a03
+github.com/rancher/types                      0f5ebf405a9c84f4fef43665ac58a118be4d5657
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/multi_cluster_app.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/multi_cluster_app.go
@@ -85,5 +85,5 @@ type MultiClusterAppRollbackInput struct {
 
 type UpdateMultiClusterAppTargetsInput struct {
 	Projects []string `json:"projects" norman:"type=array[reference[project]],required"`
-	Answers  []Answer `json:"answers" norman:"type=array[reference[answer]]"`
+	Answers  []Answer `json:"answers"`
 }

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_update_multi_cluster_app_targets_input.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_update_multi_cluster_app_targets_input.go
@@ -7,6 +7,6 @@ const (
 )
 
 type UpdateMultiClusterAppTargetsInput struct {
-	Answers  []string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	Answers  []Answer `json:"answers,omitempty" yaml:"answers,omitempty"`
 	Projects []string `json:"projects,omitempty" yaml:"projects,omitempty"`
 }


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/18209

Related types PR: https://github.com/rancher/types/pull/726

Problem:
The addProject action input parsed by backend is different from the Answer schema used by UI/client.

Solution:
Parse input to `client.UpdateMultiClusterAppTargetsInput` instead of `apiv3.UpdateMultiClusterAppTargetsInput`