### PR TITLE
empty cloud credential fields in nodetemplate config if credID is set

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -2,6 +2,7 @@ package managementstored
 
 import (
 	"context"
+	"github.com/rancher/rancher/pkg/namespace"
 	"net/http"
 
 	"github.com/rancher/norman/store/crd"
@@ -331,8 +332,9 @@ func NodeTemplates(schemas *types.Schemas, management *config.ScaledContext) {
 	}
 	schema.Formatter = f.Formatter
 	s := &nodeTemplateStore.Store{
-		Store:          userscope.NewStore(management.Core.Namespaces(""), schema.Store),
-		NodePoolLister: npl,
+		Store:                 userscope.NewStore(management.Core.Namespaces(""), schema.Store),
+		NodePoolLister:        npl,
+		CloudCredentialLister: management.Core.Secrets(namespace.GlobalNamespace).Controller().Lister(),
 	}
 	schema.Store = s
 	schema.Validator = nodetemplate.Validator
@@ -369,7 +371,8 @@ func SecretTypes(ctx context.Context, schemas *types.Schemas, management *config
 		"secrets")
 
 	credSchema := schemas.Schema(&managementschema.Version, client.CloudCredentialType)
-	credSchema.Store = cred.Wrap(mgmtSecretSchema.Store, management.Core.Namespaces(""))
+	credSchema.Store = cred.Wrap(mgmtSecretSchema.Store,
+		management.Core.Namespaces(""))
 	credSchema.Validator = cred.Validator
 }
 

--- a/pkg/api/store/nodetemplate/store.go
+++ b/pkg/api/store/nodetemplate/store.go
@@ -1,15 +1,24 @@
 package nodetemplate
 
 import (
+	"fmt"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/norman/types/values"
+	"github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/ref"
+	corev1 "github.com/rancher/types/apis/core/v1"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
+	"strings"
 )
 
 type Store struct {
 	types.Store
-	NodePoolLister v3.NodePoolLister
+	NodePoolLister        v3.NodePoolLister
+	CloudCredentialLister corev1.SecretLister
 }
 
 func (s *Store) Delete(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
@@ -23,4 +32,62 @@ func (s *Store) Delete(apiContext *types.APIContext, schema *types.Schema, id st
 		}
 	}
 	return s.Store.Delete(apiContext, schema, id)
+}
+
+func (s *Store) Create(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}) (map[string]interface{}, error) {
+	if err := s.replaceCloudCredFields(data); err != nil {
+		return data, err
+	}
+	return s.Store.Create(apiContext, schema, data)
+}
+
+func (s *Store) Update(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, id string) (map[string]interface{}, error) {
+	if err := s.replaceCloudCredFields(data); err != nil {
+		return data, err
+	}
+	return s.Store.Update(apiContext, schema, data, id)
+}
+
+func (s *Store) replaceCloudCredFields(data map[string]interface{}) error {
+	credID := convert.ToString(values.GetValueN(data, "cloudCredentialId"))
+	if credID == "" {
+		return nil
+	}
+	ns, name := ref.Parse(credID)
+	if ns == "" || name == "" {
+		return fmt.Errorf("invalid credID %s", credID)
+	}
+	cred, err := s.CloudCredentialLister.Get(namespace.GlobalNamespace, name)
+	if err != nil {
+		return fmt.Errorf("error getting cloud cred %s: %v", credID, err)
+	}
+	if len(cred.Data) == 0 {
+		return fmt.Errorf("empty credID data %s", credID)
+	}
+	configName, credConfigName := "", ""
+	for key := range cred.Data {
+		splitKey := strings.SplitN(key, "-", 2)
+		if len(splitKey) == 2 && strings.HasSuffix(splitKey[0], "credentialConfig") {
+			configName = strings.Replace(splitKey[0], "credential", "", 1)
+			credConfigName = splitKey[0]
+			break
+		}
+	}
+	if configName == "" {
+		return fmt.Errorf("empty configName for credID %s", configName)
+	}
+	toReplace := convert.ToMapInterface(values.GetValueN(data, configName))
+	if len(toReplace) == 0 {
+		return nil
+	}
+	var fields []string
+	for key := range cred.Data {
+		splitKey := strings.SplitN(key, "-", 2)
+		if len(splitKey) == 2 && splitKey[0] == credConfigName {
+			toReplace[splitKey[1]] = ""
+			fields = append(fields, splitKey[1])
+		}
+	}
+	logrus.Debugf("replaceCloudCredFields: %v for credID %s", fields, credID)
+	return nil
 }


### PR DESCRIPTION
we shouldn't store cred field data in nodetemplate config if credID is provided,
for instance - on nodetemplate edit of upgraded setups

https://github.com/rancher/rancher/issues/18205