### PR TITLE
Ensure cluster context is set during app's namespace deletion

### DIFF
--- a/pkg/controllers/management/multiclusterapp/controller_multiclusterapp.go
+++ b/pkg/controllers/management/multiclusterapp/controller_multiclusterapp.go
@@ -593,6 +593,13 @@ func (m *MCAppManager) delete(appsToDelete []*pv3.App, clusterContexts map[strin
 			if clusterName == "" {
 				return fmt.Errorf("error getting correct cluster name %s", app.Namespace)
 			}
+			if _, ok := clusterContexts[clusterName]; !ok {
+				userContext, err := m.clusterManager.UserContext(clusterName)
+				if err != nil {
+					return err
+				}
+				clusterContexts[clusterName] = userContext
+			}
 			if err := clusterContexts[clusterName].Core.Namespaces("").Delete(appWorkloadNamespace, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 				return err
 			}


### PR DESCRIPTION
Addresses: https://github.com/rancher/rancher/issues/18229

When a target project is removed, the call to delete the namespace for the app's workloads relies on clusterContext map which is created using target projects. So this map won't have the clusterContext of the target project being removed, if no other projects from that particular cluster are listed as targets. This commit adds a check to see if the clusterContexts map has the current cluster in it, if not then adds the usercontext for it