### PR TITLE
Fixing eks upgrade to latest so it doesn't error

### DIFF
--- a/pkg/api/store/cluster/cluster_store.go
+++ b/pkg/api/store/cluster/cluster_store.go
@@ -166,11 +166,12 @@ func (r *Store) Create(apiContext *types.APIContext, schema *types.Schema, data 
 		return nil, httperror.NewFieldAPIError(httperror.InvalidOption, "enableNetworkPolicy", err.Error())
 	}
 
-	if eksConfig := data["amazonElasticContainerServiceConfig"]; eksConfig != nil {
-		sessionToken, _ := values.GetValue(data, "amazonElasticContainerServiceConfig", "sessionToken")
+	if driverName, _ := values.GetValue(data, "genericEngineConfig", "driverName"); driverName == "amazonelasticcontainerservice" {
+		sessionToken, _ := values.GetValue(data, "genericEngineConfig", "sessionToken")
 		annotation, _ := values.GetValue(data, managementv3.ClusterFieldAnnotations)
 		m := toMap(annotation)
-		m[clusterstatus.TemporaryCredentialsAnnotationKey] = strconv.FormatBool(sessionToken != nil)
+		m[clusterstatus.TemporaryCredentialsAnnotationKey] = strconv.FormatBool(
+			sessionToken != "" && sessionToken != nil)
 		values.PutValue(data, m, managementv3.ClusterFieldAnnotations)
 	}
 

--- a/pkg/controllers/management/clusterstatus/temporarycredentials.go
+++ b/pkg/controllers/management/clusterstatus/temporarycredentials.go
@@ -36,7 +36,7 @@ func (cd *clusterAnnotations) sync(key string, cluster *v3.Cluster) (runtime.Obj
 			return nil, nil
 		}
 
-		newValue := strconv.FormatBool(eksConfig["sessionToken"] != "")
+		newValue := strconv.FormatBool(eksConfig["sessionToken"] != "" && eksConfig["sessionToken"] != nil)
 		original := cluster
 		cluster = original.DeepCopy()
 

--- a/tests/core/test_kontainer_engine_annotations.py
+++ b/tests/core/test_kontainer_engine_annotations.py
@@ -1,48 +1,110 @@
 from .common import random_str
 from .conftest import wait_until
 
+annotation = "clusterstatus.management.cattle.io/" \
+             "temporary-security-credentials"
+access_key = "accessKey"
+secret_key = "secretKey"
+session_token = "sessionToken"
+region = "region"
 
-def get_cluster_annotation(admin_mc, remove_resource, config):
+"""
+There are effectively 2 ways that an EKS cluster will get a temporary \
+security credentials annotation.  The first way is if it is created with \
+a session token, then an annotation will be added in the \
+cluster_store.go.  The other way is if a cluster is edited to add a \
+session token.  In this case a controller will watch for the change and \
+apply the annotation.  We test for both of those scenarios here.
+"""
+
+
+def has_cluster_annotation(client, cluster, expected=None):
+    def poll():
+        cluster2 = client.reload(cluster)
+
+        has_attribute = hasattr(cluster2.annotations, annotation)
+
+        if expected is not None:
+            return has_attribute and cluster2.annotations[annotation] == \
+                   expected
+        else:
+            return has_attribute
+
+    return poll
+
+
+def assert_cluster_annotation(expected, admin_mc, remove_resource, config):
     cluster = admin_mc.client.create_cluster(
         name=random_str(), amazonElasticContainerServiceConfig=config)
     remove_resource(cluster)
 
-    def has_cluster_annotation():
-        cluster2 = admin_mc.client.reload(cluster)
+    assert cluster.annotations[annotation] == expected
 
-        return \
-            hasattr(cluster2.annotations,
-                    "clusterstatus.management.cattle.io/"
-                    "temporary-security-credentials")
-
-    wait_until(has_cluster_annotation)
+    wait_until(has_cluster_annotation(admin_mc.client, cluster))
 
     cluster = admin_mc.client.reload(cluster)
 
-    return cluster.annotations[
-        "clusterstatus.management.cattle.io/temporary-security-credentials"]
+    assert cluster.annotations[annotation] == expected
+
+    return cluster
 
 
 def test_eks_cluster_gets_temp_security_credentials_annotation(
         admin_mc, remove_resource):
     eks = {
-        "accessKey": "not a real access key",
-        "secretKey": "not a real secret key",
-        "sessionToken": "not a real session token",
-        "region": "us-west-2",
+        access_key: "not a real access key",
+        secret_key: "not a real secret key",
+        session_token: "not a real session token",
+        region: "us-west-2",
     }
 
-    annotation = get_cluster_annotation(admin_mc, remove_resource, eks)
-    assert annotation == "true"
+    assert_cluster_annotation("true", admin_mc, remove_resource, eks)
 
 
-def test_eks_cluster_does_not_get_temp_security_credentials_annotation(
+def test_eks_does_not_get_temp_security_creds_annotation_no_field(
         admin_mc, remove_resource):
     eks = {
-        "accessKey": "not a real access key",
-        "secretKey": "not a real secret key",
-        "region": "us-west-2",
+        access_key: "not a real access key",
+        secret_key: "not a real secret key",
+        region: "us-west-2",
     }
 
-    annotation = get_cluster_annotation(admin_mc, remove_resource, eks)
-    assert annotation == "false"
+    assert_cluster_annotation("false", admin_mc, remove_resource, eks)
+
+
+def test_eks_does_not_get_temp_security_creds_annotation_empty_field(
+        admin_mc, remove_resource):
+    eks = {
+        access_key: "not a real access key",
+        secret_key: "not a real secret key",
+        session_token: "",
+        region: "us-west-2",
+    }
+
+    assert_cluster_annotation("false", admin_mc, remove_resource, eks)
+
+
+def test_editing_eks_cluster_gives_temp_creds_annotation(
+        admin_mc, remove_resource):
+    eks = {
+        access_key: "not a real access key",
+        secret_key: "not a real secret key",
+        region: "us-west-2",
+    }
+
+    cluster = assert_cluster_annotation("false", admin_mc, remove_resource,
+                                        eks)
+    eks = cluster.amazonElasticContainerServiceConfig
+    setattr(eks, session_token, "not a real session token")
+    cluster = admin_mc.client.update_by_id_cluster(
+        id=cluster.id,
+        name=cluster.name,
+        amazonElasticContainerServiceConfig=eks
+    )
+
+    wait_until(has_cluster_annotation(admin_mc.client, cluster,
+                                      expected="true"))
+
+    cluster = admin_mc.client.reload(cluster)
+
+    assert cluster.annotations[annotation] == "true"

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     9ba19df9be29359a86aada80311f725fec5dba85
-github.com/rancher/kontainer-engine           fe57856dc1d75c706614e3439b400eddc8879d88
+github.com/rancher/kontainer-engine           dc8ca48e82981b0cd39d353d9760df2b9669b112
 github.com/rancher/rke                        40cd80a20864aad8003575c89c2ec74e996ee118
 github.com/rancher/types                      5a372fcc37cbd0de83f91b0428d5f69acdc410bd
 


### PR DESCRIPTION
This change brings in the EKS upgrade correction from kontainer-engine (Issue: #18162) and also corrects the below issue:

---------

This change ensures that the temporary security credentials annotation is set
properly on an EKS cluster that has a session token.  Previously if the
session token field was missing or nil it would fail to be set in certain
places.  this change ensures that the temp security creds annotation will only
be set to false if the field is neither missing nor empty.

Issue:
#18285


Depends on:
https://github.com/rancher/kontainer-engine/pull/132