### PR TITLE
Ensure auth provider can find multiclusterapp member's principal

### DIFF
--- a/pkg/api/customization/multiclusterapp/store.go
+++ b/pkg/api/customization/multiclusterapp/store.go
@@ -99,12 +99,17 @@ func (s *Store) setDisplayName(apiContext *types.APIContext, schema *types.Schem
 	if !found {
 		return data, nil
 	}
+	token, err := s.auth.TokenFromRequest(apiContext.Request)
+	if err != nil {
+		return nil, err
+	}
+	if token.AuthProvider == providers.LocalProvider {
+		// getPrincipal if called, will be called on local auth provider, and will not find a user with external auth principal ID
+		// hence returning, since the only thing this method does is setting display name by getting it from the external auth provider.
+		return data, nil
+	}
 	for _, m := range membersMapSlice {
 		if principalID, ok := m[client.MemberFieldUserPrincipalID].(string); ok && principalID != "" && !strings.HasPrefix(principalID, "local://") {
-			token, err := s.auth.TokenFromRequest(apiContext.Request)
-			if err != nil {
-				return nil, err
-			}
 			princ, err := providers.GetPrincipal(principalID, *token)
 			if err != nil {
 				return nil, err

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -24,7 +24,7 @@ var (
 	ProvidersWithSecrets   = make(map[string]bool)
 	UnrefreshableProviders = make(map[string]bool)
 	providers              = make(map[string]common.AuthProvider)
-	localProvider          = "local"
+	LocalProvider          = "local"
 	providersByType        = make(map[string]common.AuthProvider)
 	confMu                 sync.Mutex
 )
@@ -123,8 +123,8 @@ func AuthenticateUser(input interface{}, providerName string) (v3.Principal, []v
 func GetPrincipal(principalID string, myToken v3.Token) (v3.Principal, error) {
 	principal, err := providers[myToken.AuthProvider].GetPrincipal(principalID, myToken)
 
-	if err != nil && myToken.AuthProvider != localProvider {
-		p2, e2 := providers[localProvider].GetPrincipal(principalID, myToken)
+	if err != nil && myToken.AuthProvider != LocalProvider {
+		p2, e2 := providers[LocalProvider].GetPrincipal(principalID, myToken)
 		if e2 == nil {
 			return p2, nil
 		}
@@ -138,8 +138,8 @@ func SearchPrincipals(name, principalType string, myToken v3.Token) ([]v3.Princi
 	if err != nil {
 		return principals, err
 	}
-	if myToken.AuthProvider != localProvider {
-		lp := providers[localProvider]
+	if myToken.AuthProvider != LocalProvider {
+		lp := providers[LocalProvider]
 		if lpDedupe, _ := lp.(*local.Provider); lpDedupe != nil {
 			localPrincipals, err := lpDedupe.SearchPrincipalsDedupe(name, principalType, myToken, principals)
 			if err != nil {


### PR DESCRIPTION
A user could have turned on external auth and added some user from that external auth
provider as a member of a multiclusterapp. After this when user logs back in as local
user, searching and adding new members from the external auth provider to the existing
multiclusterapp will fail. But even upgrading the multiclusterapp is failing, because
during upgrade, there is a call to getPrincipal of the members and set their displayNames
This call can be skipped if the current auth provider found in token is for local auth,
whereas the principalIDs of the members are from an external auth provider

Addresses: https://github.com/rancher/rancher/issues/18252