### PR TITLE
Refactor kontainer driver controller

### DIFF
--- a/tests/core/test_kontainer_drivers.py
+++ b/tests/core/test_kontainer_drivers.py
@@ -16,6 +16,10 @@ def test_builtin_drivers_are_present(admin_mc):
     for name in ['azureKubernetesService',
                  'googleKubernetesEngine',
                  'amazonElasticContainerService']:
+        kd = admin_mc.client.list_kontainerDriver(
+            name=name,
+        ).data[0]
+        wait_for_condition('Active', "True", admin_mc.client, kd, timeout=90)
         # check in schema
         assert name + "Config" in types
 


### PR DESCRIPTION
**Problem:**
1. Transition state `Downloading` is missing when activating a cloud
driver.
2. Check kontainer engine driver binary function will always return
false even the binary exists in the path.

**Solution:**
1. Move all the download logic to `Updated` and use the
`Downloaded` condition to drive the actual download process.
2. If driver's ExecutablePath exists, Use it to check binary exists
first.

Related Issue: https://github.com/rancher/rancher/issues/18211