### PR TITLE
Update EngineISOURL

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -21,7 +21,7 @@ var (
 	CLIURLLinux                     = NewSetting("cli-url-linux", "https://releases.rancher.com/cli/v1.0.0-alpha8/rancher-linux-amd64-v1.0.0-alpha8.tar.gz")
 	CLIURLWindows                   = NewSetting("cli-url-windows", "https://releases.rancher.com/cli/v1.0.0-alpha8/rancher-windows-386-v1.0.0-alpha8.zip")
 	EngineInstallURL                = NewSetting("engine-install-url", "https://releases.rancher.com/install-docker/18.09.sh")
-	EngineISOURL                    = NewSetting("engine-iso-url", "https://releases.rancher.com/os/latest/rancheros-vmware.iso")
+	EngineISOURL                    = NewSetting("engine-iso-url", "https://releases.rancher.com/os/latest/vmware/rancheros-autoformat.iso")
 	EngineNewestVersion             = NewSetting("engine-newest-version", "v17.12.0")
 	EngineSupportedRange            = NewSetting("engine-supported-range", "~v1.11.2 || ~v1.12.0 || ~v1.13.0 || ~v17.03.0 || ~v17.06.0 || ~v17.09.0 || ~v18.06.0 || ~v18.09.0")
 	FirstLogin                      = NewSetting("first-login", "true")


### PR DESCRIPTION
They are the same and are used for docker-machine:
"""
old link: https://releases.rancher.com/os/latest/rancheros-vmware.iso
new link: https://releases.rancher.com/os/latest/vmware/rancheros-autoformat.iso
"""
But I recommend using the new link, which makes it easier to
distinguish. Since we also support regular ISO for vmware:
https://releases.rancher.com/os/latest/vmware/rancheros.iso