### PR TITLE
Add custom driver validator

### DIFF
--- a/pkg/api/customization/kontainerdriver/validator.go
+++ b/pkg/api/customization/kontainerdriver/validator.go
@@ -20,11 +20,7 @@ func (v *Validator) Validator(request *types.APIContext, schema *types.Schema, d
 		return httperror.WrapAPIError(err, httperror.InvalidBodyContent, "Kontainer driver spec conversion error")
 	}
 
-	if err := v.validateKontainerDriverURL(request, spec); err != nil {
-		return err
-	}
-
-	return nil
+	return v.validateKontainerDriverURL(request, spec)
 }
 
 func (v *Validator) validateKontainerDriverURL(request *types.APIContext, spec v3.KontainerDriverSpec) error {
@@ -34,7 +30,7 @@ func (v *Validator) validateKontainerDriverURL(request *types.APIContext, spec v
 	}
 
 	for _, driver := range kontainerDrivers {
-		if driver.Spec.URL == spec.URL && driver.Name == request.ID {
+		if driver.Spec.URL == spec.URL && driver.Name != request.ID {
 			return httperror.NewAPIError(httperror.Conflict, fmt.Sprintf("Driver URL already in use: %s", spec.URL))
 		}
 	}

--- a/pkg/api/customization/kontainerdriver/validator.go
+++ b/pkg/api/customization/kontainerdriver/validator.go
@@ -1,0 +1,43 @@
+package kontainerdriver
+
+import (
+	"fmt"
+	"github.com/rancher/norman/httperror"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type Validator struct {
+	KontainerDriverLister v3.KontainerDriverLister
+}
+
+func (v *Validator) Validator(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
+	var spec v3.KontainerDriverSpec
+
+	if err := convert.ToObj(data, &spec); err != nil {
+		return httperror.WrapAPIError(err, httperror.InvalidBodyContent, "Kontainer driver spec conversion error")
+	}
+
+	if err := v.validateKontainerDriverURL(request, spec); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (v *Validator) validateKontainerDriverURL(request *types.APIContext, spec v3.KontainerDriverSpec) error {
+	kontainerDrivers, err := v.KontainerDriverLister.List("", labels.NewSelector())
+	if err != nil {
+		return httperror.WrapAPIError(err, httperror.ServerError, "Failed to list kontainer drivers")
+	}
+
+	for _, driver := range kontainerDrivers {
+		if driver.Spec.URL == spec.URL && driver.Name == request.ID {
+			return httperror.NewAPIError(httperror.Conflict, fmt.Sprintf("Driver URL already in use: %s", spec.URL))
+		}
+	}
+
+	return nil
+}

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -609,6 +609,11 @@ func KontainerDriver(schemas *types.Schemas, management *config.ScaledContext) {
 	}
 	schema.ActionHandler = handler.ActionHandler
 	schema.Formatter = kontainerdriver.Formatter
+
+	kontainerDriverValidator := kontainerdriver.Validator{
+		KontainerDriverLister: management.Management.KontainerDrivers("").Controller().Lister(),
+	}
+	schema.Validator = kontainerDriverValidator.Validator
 }
 
 func MultiClusterApps(schemas *types.Schemas, management *config.ScaledContext) {

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -305,7 +305,20 @@ def remove_resource(admin_mc, request):
                 if e.error.status != 404:
                     raise e
         request.addfinalizer(clean)
+    return _cleanup
 
+
+@pytest.fixture()
+def wait_remove_resource(admin_mc, request, timeout=DEFAULT_TIMEOUT):
+    """Remove a resource after a test finishes even if the test fails and
+    wait until deletion is confirmed."""
+    client = admin_mc.client
+
+    def _cleanup(resource):
+        def clean():
+            client.delete(resource)
+            wait_until(lambda: client.reload(resource) is None)
+        request.addfinalizer(clean)
     return _cleanup
 
 

--- a/tests/core/test_kontainer_drivers.py
+++ b/tests/core/test_kontainer_drivers.py
@@ -2,6 +2,7 @@ import sys
 
 import pytest
 
+from rancher import ApiError
 from .conftest import wait_for_condition, wait_until
 
 DRIVER_URL = "https://github.com/rancher/kontainer-engine-driver-example/" \
@@ -63,7 +64,7 @@ def test_kontainer_driver_lifecycle(admin_mc, remove_resource):
 
 
 @pytest.mark.nonparallel
-def test_enabling_driver_exposes_schema(admin_mc, remove_resource):
+def test_enabling_driver_exposes_schema(admin_mc, wait_remove_resource):
     """ Test if enabling driver exposes its dynamic schema, drivers are
      downloaded / installed once they are active """
     kd = admin_mc.client.create_kontainerDriver(
@@ -71,7 +72,7 @@ def test_enabling_driver_exposes_schema(admin_mc, remove_resource):
         active=False,
         url=DRIVER_URL
     )
-    remove_resource(kd)
+    wait_remove_resource(kd)
 
     kd = wait_for_condition('Inactive', 'True', admin_mc.client, kd,
                             timeout=90)
@@ -95,6 +96,60 @@ def test_enabling_driver_exposes_schema(admin_mc, remove_resource):
     admin_mc.client.update_by_id_kontainerDriver(kd.id, kd)
 
     verify_driver_not_in_types(admin_mc.client, kd)
+
+
+@pytest.mark.nonparallel
+def test_create_duplicate_driver_conflict(admin_mc, wait_remove_resource):
+    """ Test if adding a driver with a pre-existing driver's URL
+    returns a conflict error"""
+    kd = admin_mc.client.create_kontainerDriver(
+        createDynamicSchema=True,
+        active=True,
+        url=DRIVER_URL
+    )
+    wait_remove_resource(kd)
+    kd = wait_for_condition('Active', 'True', admin_mc.client, kd, timeout=90)
+
+    try:
+        kd2 = admin_mc.client.create_kontainerDriver(
+            createDynamicSchema=True,
+            active=True,
+            url=DRIVER_URL
+        )
+        wait_remove_resource(kd2)
+        pytest.fail("Failed to catch duplicate driver URL on create")
+    except ApiError as e:
+        assert e.error.status == 409
+        assert "Driver URL already in use:" in e.error.message
+
+
+@pytest.mark.nonparallel
+def test_update_duplicate_driver_conflict(admin_mc, wait_remove_resource):
+    """ Test if updating a driver's URL to a pre-existing driver's URL
+    returns a conflict error"""
+    kd1 = admin_mc.client.create_kontainerDriver(
+        createDynamicSchema=True,
+        active=True,
+        url=DRIVER_URL
+    )
+    wait_remove_resource(kd1)
+    kd1 = wait_for_condition('Active', 'True', admin_mc.client, kd1,
+                             timeout=90)
+
+    kd2 = admin_mc.client.create_kontainerDriver(
+        createDynamicSchema=True,
+        active=True,
+        url=DRIVER_URL + "2"
+    )
+    wait_remove_resource(kd2)
+    kd2.url = DRIVER_URL
+
+    try:
+        admin_mc.client.update_by_id_kontainerDriver(kd2.id, kd2)
+        pytest.fail("Failed to catch duplicate driver URL on update")
+    except ApiError as e:
+        assert e.error.status == 409
+        assert "Driver URL already in use:" in e.error.message
 
 
 def verify_driver_in_types(client, kd):


### PR DESCRIPTION
Problem: Users are able to create duplicate drivers (same download URLs).

Solution: Add validator that checks whether the proposed driver URL already exists.

Issue: https://github.com/rancher/rancher/issues/18126