### PR TITLE
Removing import kontainer driver as it is unnecessary

### DIFF
--- a/app/kontainerdriver_data.go
+++ b/app/kontainerdriver_data.go
@@ -25,7 +25,7 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 		drivers:       management.Management.KontainerDrivers(""),
 	}
 
-	if err := creator.add("import"); err != nil {
+	if err := cleanupImportDriver(creator); err != nil {
 		return err
 	}
 
@@ -75,6 +75,19 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 		false,
 		"*.myhuaweicloud.com",
 	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func cleanupImportDriver(creator driverCreator) error {
+	var err error
+	if _, err = creator.driversLister.Get("", "import"); err == nil {
+		err = creator.drivers.Delete("import", &v1.DeleteOptions{})
+	}
+
+	if !errors.IsNotFound(err) {
 		return err
 	}
 

--- a/tests/core/test_rbac.py
+++ b/tests/core/test_rbac.py
@@ -377,14 +377,14 @@ def test_permissions_can_be_removed(admin_cc, admin_mc, user_mc,
 
 def test_appropriate_users_can_see_kontainer_drivers(user_factory):
     kds = user_factory().client.list_kontainer_driver()
-    assert len(kds) == 8
+    assert len(kds) == 7
 
     kds = user_factory('clusters-create').client.list_kontainer_driver()
-    assert len(kds) == 8
+    assert len(kds) == 7
 
     kds = user_factory('kontainerdrivers-manage').client. \
         list_kontainer_driver()
-    assert len(kds) == 8
+    assert len(kds) == 7
 
     kds = user_factory('settings-manage').client.list_kontainer_driver()
     assert len(kds) == 0


### PR DESCRIPTION
This change removes import driver from the kontainer engine drivers this is
because it is unnecessary (import_driver.go is never called by Rancer) and is
causing difficulties on the UI where it has to be filtered from the list of
drivers.  Also contains cleanup logic for previous versions of Rancher to
remove the existing import driver.

Issue:
#18273