### PR TITLE
enable validate fluentd ssl ca

### DIFF
--- a/pkg/controllers/user/logging/utils/fluentd.go
+++ b/pkg/controllers/user/logging/utils/fluentd.go
@@ -48,7 +48,7 @@ func (w *fluentForwarderTestWrap) TestReachable(dial dialer.Dialer, includeSendT
 				}
 				serverName = host
 			}
-			tlsConfig, err = buildTLSConfig(w.Certificate, "", "", "", "", serverName, false)
+			tlsConfig, err = buildTLSConfig(w.Certificate, "", "", "", "", serverName, true)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
problem:
not validate ca and hostname for fluentd test function is not the same
logic as fluentd

Solution:
enable validate ca and hostname

Issue:
https://github.com/rancher/rancher/issues/18332