### PR TITLE
pass mcAppId to addProject action 

### DIFF
--- a/pkg/api/customization/globaldns/validator_globaldns.go
+++ b/pkg/api/customization/globaldns/validator_globaldns.go
@@ -95,7 +95,7 @@ func (w Wrapper) Validator(request *types.APIContext, schema *types.Schema, data
 
 	originalMultiClusterApp := gDNS.Spec.MultiClusterAppName
 	newMultiClusterApp := convert.ToString(data[client.GlobalDNSFieldMultiClusterAppID])
-	if originalMultiClusterApp != newMultiClusterApp {
+	if newMultiClusterApp != "" && originalMultiClusterApp != newMultiClusterApp {
 		// check access to new multiclusterapp
 		return ma.CheckCallerAccessToTargets(request, []string{newMultiClusterApp}, client.MultiClusterAppType, &client.MultiClusterApp{})
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -42,7 +42,7 @@ github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f6841
 github.com/rancher/norman                     61998c76e33d2c411a13aead9e13a0451462f4a7
 github.com/rancher/kontainer-engine           dc8ca48e82981b0cd39d353d9760df2b9669b112
 github.com/rancher/rke                        2fa825f3fea692ef83dd1e024c3848bed660c843
-github.com/rancher/types                      eecb8f99861742147470dffcd08c0207052f11e7
+github.com/rancher/types                      673f1c33c2565b64951733b39c00b843ee69f918
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/globaldns_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/globaldns_types.go
@@ -63,7 +63,8 @@ type CloudflareProviderConfig struct {
 }
 
 type UpdateGlobalDNSTargetsInput struct {
-	ProjectNames []string `json:"projectNames" norman:"type=array[reference[project]]"`
+	MultiClusterAppName string   `json:"multiClusterAppName" norman:"type=reference[multiClusterApp]"`
+	ProjectNames        []string `json:"projectNames" norman:"type=array[reference[project]]"`
 }
 
 type AlidnsProviderConfig struct {

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_update_global_dnstargets_input.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_update_global_dnstargets_input.go
@@ -1,10 +1,12 @@
 package client
 
 const (
-	UpdateGlobalDNSTargetsInputType            = "updateGlobalDNSTargetsInput"
-	UpdateGlobalDNSTargetsInputFieldProjectIDs = "projectIds"
+	UpdateGlobalDNSTargetsInputType                   = "updateGlobalDNSTargetsInput"
+	UpdateGlobalDNSTargetsInputFieldMultiClusterAppID = "multiClusterAppId"
+	UpdateGlobalDNSTargetsInputFieldProjectIDs        = "projectIds"
 )
 
 type UpdateGlobalDNSTargetsInput struct {
-	ProjectIDs []string `json:"projectIds,omitempty" yaml:"projectIds,omitempty"`
+	MultiClusterAppID string   `json:"multiClusterAppId,omitempty" yaml:"multiClusterAppId,omitempty"`
+	ProjectIDs        []string `json:"projectIds,omitempty" yaml:"projectIds,omitempty"`
 }


### PR DESCRIPTION
1) Issue: Currently only projectIds are passed in input, so we've no
idea if user has edited mcAppID and validation always fails.

2) If new mcAppID is empty, we should not do `access.ById` else that fails in proxy_store. 

https://github.com/rancher/rancher/issues/18366
https://github.com/rancher/types/pull/735