### PR TITLE
Change alertmanager default slack api url to valid url

### DIFF
--- a/pkg/controllers/user/alert/manager/alertmanager.go
+++ b/pkg/controllers/user/alert/manager/alertmanager.go
@@ -124,7 +124,7 @@ func GetAlertManagerDefaultConfig() *alertconfig.Config {
 
 	resolveTimeout, _ := model.ParseDuration("5m")
 	config.Global = &alertconfig.GlobalConfig{
-		SlackAPIURL:    "slack_api_url",
+		SlackAPIURL:    "https://api.slack.com",
 		ResolveTimeout: resolveTimeout,
 		SMTPRequireTLS: false,
 	}


### PR DESCRIPTION
Problem:
alertmanager has error log for parsing the invalid url, and it require a
global slack api url

Solution:
change the global slack api url to a valid url

Issue:
https://github.com/rancher/rancher/issues/18398