### PR TITLE
don't attempt to deploy app in a terminating namespace

### DIFF
--- a/pkg/controllers/user/helm/controller.go
+++ b/pkg/controllers/user/helm/controller.go
@@ -149,9 +149,14 @@ func (l *Lifecycle) Updated(obj *v3.App) (runtime.Object, error) {
 						AppIDsLabel:         obj.Name},
 				},
 			}
-			_, err := l.NsClient.Create(&n)
-			if err != nil && !errors.IsAlreadyExists(err) {
-				return obj, err
+			ns, err := l.NsClient.Create(&n)
+			if err != nil {
+				if !errors.IsAlreadyExists(err) {
+					return obj, err
+				}
+				if ns.DeletionTimestamp != nil {
+					return obj, fmt.Errorf("waiting for namespace %s to be terminated", obj.Namespace)
+				}
 			} else if err == nil {
 				created = true
 			}


### PR DESCRIPTION
Issue: If mcApp is deleted and immediately created in same project,
there's a chance app namespace is still getting terminated.
We'd still be able to fetch it, but if it gets deleted before helm
checks, it'll create a new ns which won't have required labels.
It doesn't always reproduce, but better to add a check.