### PR TITLE
Parameterize driver error

### DIFF
--- a/pkg/controllers/management/drivers/base_driver.go
+++ b/pkg/controllers/management/drivers/base_driver.go
@@ -230,7 +230,7 @@ func (d *BaseDriver) copyBinary(cacheFile, input string) (string, error) {
 	}))
 
 	if file == "" {
-		return "", fmt.Errorf("failed to find machine driver in archive. There must be a file of form docker-machine-driver*")
+		return "", fmt.Errorf("failed to find driver in archive. There must be a file of form %s*", d.BinaryPrefix)
 	}
 
 	if driverName == "" {


### PR DESCRIPTION
This method is used for both node and kontainer-engine drivers but
this error was not parameterized accordingly.

https://github.com/rancher/rancher/issues/18365