### PR TITLE
Print warning instead of returning error when fails to clean up pipeline webhook

### DIFF
--- a/pkg/controllers/user/pipeline/controller/pipeline/pipeline.go
+++ b/pkg/controllers/user/pipeline/controller/pipeline/pipeline.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rancher/types/apis/project.cattle.io/v3"
 	"github.com/rancher/types/config"
 	"github.com/satori/go.uuid"
-	"k8s.io/apimachinery/pkg/api/errors"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -48,8 +48,9 @@ func (l *Lifecycle) Updated(obj *v3.Pipeline) (runtime.Object, error) {
 
 func (l *Lifecycle) Remove(obj *v3.Pipeline) (runtime.Object, error) {
 	if obj.Status.WebHookID != "" {
-		if err := l.deleteHook(obj); err != nil && !errors.IsNotFound(err) {
-			return obj, err
+		if err := l.deleteHook(obj); err != nil {
+			logrus.WithError(err).Warnf("fail to delete webhook for pipeline %q", obj.Name)
+			return obj, nil
 		}
 	}
 	return obj, nil


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/17322

Problem:
Pipeline resource stuck in removing state in cases when gitlab credentials are revoked, gitlab instance no longer exists, etc.

Solution:
Print warning instead of returning erros when fails to clean up pipeline hooks