### PR TITLE
[Logging] add client key and certificate for logging fluentd

### DIFF
--- a/pkg/controllers/user/logging/configsyncer/configsyncer.go
+++ b/pkg/controllers/user/logging/configsyncer/configsyncer.go
@@ -238,6 +238,8 @@ func GetSSLConfig(target mgmtv3.LoggingTargets) (string, string, string) {
 		clientKey = target.SyslogConfig.ClientKey
 	} else if target.FluentForwarderConfig != nil {
 		certificate = target.FluentForwarderConfig.Certificate
+		clientCert = target.FluentForwarderConfig.ClientCert
+		clientKey = target.FluentForwarderConfig.ClientKey
 	} else if target.CustomTargetConfig != nil {
 		certificate = target.CustomTargetConfig.Certificate
 		clientCert = target.CustomTargetConfig.ClientCert

--- a/pkg/controllers/user/logging/generator/templatematch.go
+++ b/pkg/controllers/user/logging/generator/templatematch.go
@@ -167,7 +167,14 @@ var MatchTemplate = `
 	{{end}}
 	{{- if .FluentForwarderConfig.Certificate }}
 	tls_cert_path {{.CertFilePrefix}}_ca.pem
-	{{end}}  
+	{{end}}
+	{{- if and .FluentForwarderConfig.ClientCert .FluentForwarderConfig.ClientKey}}
+	tls_client_cert_path {{.CertFilePrefix}}_client-cert.pem
+	tls_client_private_key_path {{.CertFilePrefix}}_client-key.pem
+	{{end}}
+	{{- if .FluentForwarderConfig.ClientKeyPass}}
+	tls_client_private_key_passphrase {{.FluentForwarderConfig.ClientKeyPass}}
+	{{end}}
 	{{- if .FluentForwarderConfig.Compress }}
 	compress gzip
 	{{end}}

--- a/pkg/controllers/user/logging/utils/fluentd.go
+++ b/pkg/controllers/user/logging/utils/fluentd.go
@@ -46,7 +46,7 @@ func (w *fluentForwarderTestWrap) TestReachable(dial dialer.Dialer, includeSendT
 			if serverName == "" {
 				serverName = host
 			}
-			tlsConfig, err = buildTLSConfig(w.Certificate, "", "", "", "", serverName, true)
+			tlsConfig, err = buildTLSConfig(w.Certificate, w.ClientCert, w.ClientKey, w.ClientKeyPass, "", serverName, w.SSLVerify)
 			if err != nil {
 				return err
 			}

--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -1136,19 +1136,17 @@ def wait_for_mcapp_to_active(client, multiClusterApp,
 
 def wait_for_app_to_active(client, app_id,
                            timeout=DEFAULT_MULTI_CLUSTER_APP_TIMEOUT):
-    app_data = client.list_app(name=app_id).data
     start = time.time()
-    assert len(app_data) == 1, "Cannot find app"
-    application = app_data[0]
-    while application.state != "active":
+    while True:
+        app_data = client.list_app(name=app_id).data
+        if len(app_data) == 1:
+            application = app_data[0]
+            if application.state == "active":
+                return application
         if time.time() - start > timeout:
             raise AssertionError(
                 "Timed out waiting for state to get to active")
         time.sleep(.5)
-        app = client.list_app(name=app_id).data
-        assert len(app) == 1
-        application = app[0]
-    return application
 
 
 def validate_response_app_endpoint(p_client, appId):

--- a/tests/validation/tests/v3_api/test_logging.py
+++ b/tests/validation/tests/v3_api/test_logging.py
@@ -1,5 +1,6 @@
 import pytest
 import requests
+import base64
 import time
 from .common import random_test_name
 from .common import get_admin_client_and_cluster
@@ -12,7 +13,7 @@ from .common import CATTLE_TEST_URL
 from .common import ADMIN_TOKEN
 
 namespace = {"p_client": None, "ns": None, "cluster": None, "project": None,
-             "name_prefix": None}
+             "name_prefix": None, "admin_client": None, "sys_p_client": None}
 fluentd_aggregator_answers = {"defaultImage": "true",
                               "image.repository": "guangbo/fluentd",
                               "image.tag": "dev",
@@ -87,6 +88,189 @@ def setup_fluentd_aggregator(request):
     wait_for_app_to_active(p_client, app.name)
 
 
+fluentd_app_name = "rancher-logging"
+fluentd_secret_name = "rancher-logging-fluentd"
+endpoint_host = "rancher.com"
+endpoint_port = "24224"
+username = "user1"
+password = "my_password"
+shared_key = "my_shared_key"
+weight = 100
+
+
+def test_fluentd_target(request):
+    cluster = namespace["cluster"]
+    cluster_logging = create_cluster_logging(fluentd_target_without_ssl())
+    request.addfinalizer(lambda: delete_cluster_logging(cluster_logging))
+    wait_for_logging_app()
+
+    # wait for config to sync
+    time.sleep(120)
+
+    config = get_fluentd_config("cluster.conf")
+    assert fluentd_ssl_configure("cluster_" + namespace["cluster"].id) not in config
+    assert fluentd_server_configure() in config
+
+    ssl_config = fluentd_target_with_ssl()
+    admin_client = namespace["admin_client"]
+    admin_client.update_by_id_cluster_logging(id=cluster_logging.id,
+                                              name=cluster_logging.name,
+                                              clusterId=cluster.id,
+                                              fluentForwarderConfig=ssl_config)
+    # wait for config to sync
+    time.sleep(60)
+    config = get_fluentd_config("cluster.conf")
+    assert fluentd_ssl_configure("cluster_" + namespace["cluster"].id) in config
+    assert fluentd_server_configure() in config
+
+
+def test_project_fluentd_target(request):
+    project = namespace["project"]
+    wrap_project_name = project.id.replace(':', '_')
+    project_logging = create_project_logging(fluentd_target_without_ssl())
+    request.addfinalizer(lambda: delete_project_logging(project_logging))
+    wait_for_logging_app()
+
+    # wait for config to sync
+    time.sleep(60)
+    config = get_fluentd_config("project.conf")
+    assert fluentd_ssl_configure("project_" + wrap_project_name) not in config
+    assert fluentd_server_configure() in config
+
+    ssl_config = fluentd_target_with_ssl()
+    admin_client = namespace["admin_client"]
+    admin_client.update_by_id_project_logging(id=project_logging.id,
+                                              name=project_logging.name,
+                                              projectId=project.id,
+                                              fluentForwarderConfig=ssl_config)
+    # wait for config to sync
+    time.sleep(60)
+    config = get_fluentd_config("project.conf")
+    assert fluentd_ssl_configure("project_" + wrap_project_name) in config
+    assert fluentd_server_configure() in config
+
+
+def wait_for_logging_app():
+    sys_p_client = namespace["sys_p_client"]
+    wait_for_app_to_active(sys_p_client, fluentd_app_name)
+
+
+def fluentd_target_with_ssl():
+    return {"certificate": "-----BEGIN CERTIFICATE-----\
+                    ----END CERTIFICATE-----",
+            "clientCert": "-----BEGIN CERTIFICATE-----\
+                    ----END CERTIFICATE-----",
+            "clientKey": "-----BEGIN PRIVATE KEY-----\
+                    ----END PRIVATE KEY-----",
+            "compress": True,
+            "enableTls": True,
+            "fluentServers": [
+                {
+                    "endpoint": endpoint_host + ":" + endpoint_port,
+                    "username": username,
+                    "password": password,
+                    "sharedKey": shared_key,
+                    "weight": weight
+                }
+            ],
+            }
+
+
+def fluentd_target_without_ssl():
+    return {"compress": True,
+            "enableTls": True,
+            "fluentServers": [
+                {
+                    "endpoint": endpoint_host + ":" + endpoint_port,
+                    "username": username,
+                    "password": password,
+                    "sharedKey": shared_key,
+                    "weight": weight
+                }
+            ],
+            }
+
+
+def fluentd_ssl_configure(name):
+    return f"""tls_cert_path /fluentd/etc/config/ssl/{name}_ca.pem
+tls_client_cert_path /fluentd/etc/config/ssl/{name}_client-cert.pem
+tls_client_private_key_path /fluentd/etc/config/ssl/{name}_client-key.pem"""
+
+
+def fluentd_server_configure():
+    return f"""<server>
+host {endpoint_host}
+port {endpoint_port}
+shared_key {shared_key}
+username  {username}
+password  {password}
+weight  {weight}
+</server>"""
+
+
+def get_system_project_client():
+    cluster = namespace["cluster"]
+    admin_client = namespace["admin_client"]
+    projects = admin_client.list_project(name="System",
+                                         clusterId=cluster.id).data
+    assert len(projects) == 1
+    project = projects[0]
+    sys_p_client = get_project_client_for_token(project, ADMIN_TOKEN)
+    return sys_p_client
+
+
+def get_namespaced_secret(name):
+    sys_p_client = namespace["sys_p_client"]
+    secres = sys_p_client.list_namespaced_secret(name=name)
+    assert len(secres.data) == 1
+    return secres.data[0]
+
+
+def get_fluentd_config(key):
+    secret = get_namespaced_secret(fluentd_secret_name)
+    base64_cluster_conf = secret.data[key]
+    tmp = base64.b64decode(base64_cluster_conf).decode("utf-8")
+    return strip_whitespace(tmp)
+
+
+def strip_whitespace(ws):
+    new_str = []
+    for s in ws.strip().splitlines(True):
+        if s.strip():
+            new_str.append(s.strip())
+    return "\n".join(new_str)
+
+
+def create_cluster_logging(config):
+    cluster = namespace["cluster"]
+    admin_client = namespace["admin_client"]
+    name = random_test_name("fluentd")
+    return admin_client.create_cluster_logging(name=name,
+                                               clusterId=cluster.id,
+                                               fluentForwarderConfig=config
+                                               )
+
+
+def delete_cluster_logging(cluster_logging):
+    admin_client = namespace["admin_client"]
+    admin_client.delete(cluster_logging)
+
+
+def create_project_logging(config):
+    project = namespace["project"]
+    admin_client = namespace["admin_client"]
+    name = random_test_name("fluentd")
+    return admin_client.create_project_logging(name=name,
+                                               projectId=project.id,
+                                               fluentForwarderConfig=config
+                                               )
+
+
+def delete_project_logging(project_logging):
+    admin_client = namespace["admin_client"]
+    admin_client.delete(project_logging)
+
+
 @pytest.fixture(scope='module', autouse="True")
 def create_project_client(request):
     client, cluster = get_admin_client_and_cluster()
@@ -98,6 +282,8 @@ def create_project_client(request):
     namespace["ns"] = ns
     namespace["cluster"] = cluster
     namespace["project"] = p
+    namespace["admin_client"] = client
+    namespace["sys_p_client"] = get_system_project_client()
 
     def fin():
         client = get_admin_client()


### PR DESCRIPTION
Problem:
advance mode have support client key and certificate for fluentd logging
target but normal mode not yet

Solution:
add client key and certificate for fluentd

types:
https://github.com/rancher/types/pull/739

Issue:
https://github.com/rancher/rancher/issues/18438

Integration test pr:
https://github.com/rancher/validation/pull/161