### PR TITLE
Add force remove, rename Driver, update kontainer-engine

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/driver.go
+++ b/pkg/controllers/management/clusterprovisioner/driver.go
@@ -29,7 +29,7 @@ func (p *Provisioner) driverCreate(cluster *v3.Cluster, spec v3.ClusterSpec) (ap
 		return "", "", "", err
 	}
 
-	return p.Driver.Create(ctx, cluster.Name, kontainerDriver, spec)
+	return p.engineService.Create(ctx, cluster.Name, kontainerDriver, spec)
 }
 
 func (p *Provisioner) getKontainerDriver(spec v3.ClusterSpec) (*v3.KontainerDriver, error) {
@@ -75,7 +75,7 @@ func (p *Provisioner) driverUpdate(cluster *v3.Cluster, spec v3.ClusterSpec) (ap
 		return "", "", "", err
 	}
 
-	return p.Driver.Update(ctx, cluster.Name, kontainerDriver, spec)
+	return p.engineService.Update(ctx, cluster.Name, kontainerDriver, spec)
 }
 
 func (p *Provisioner) driverRemove(cluster *v3.Cluster, forceRemove bool) error {
@@ -94,7 +94,7 @@ func (p *Provisioner) driverRemove(cluster *v3.Cluster, forceRemove bool) error 
 			return nil, err
 		}
 
-		return cluster, p.Driver.Remove(ctx, cluster.Name, kontainerDriver, spec, forceRemove)
+		return cluster, p.engineService.Remove(ctx, cluster.Name, kontainerDriver, spec, forceRemove)
 	})
 
 	return err
@@ -118,7 +118,7 @@ func (p *Provisioner) driverRestore(cluster *v3.Cluster, spec v3.ClusterSpec) (s
 	}
 
 	snapshot := strings.Split(spec.RancherKubernetesEngineConfig.Restore.SnapshotName, ":")[1]
-	return p.Driver.ETCDRestore(ctx, cluster.Name, kontainerDriver, spec, snapshot)
+	return p.engineService.ETCDRestore(ctx, cluster.Name, kontainerDriver, spec, snapshot)
 
 }
 
@@ -133,7 +133,7 @@ func (p *Provisioner) generateServiceAccount(cluster *v3.Cluster, spec v3.Cluste
 		return "", err
 	}
 
-	return p.Driver.GenerateServiceAccount(ctx, cluster.Name, kontainerDriver, spec)
+	return p.engineService.GenerateServiceAccount(ctx, cluster.Name, kontainerDriver, spec)
 }
 
 func (p *Provisioner) removeLegacyServiceAccount(cluster *v3.Cluster, spec v3.ClusterSpec) error {
@@ -147,7 +147,7 @@ func (p *Provisioner) removeLegacyServiceAccount(cluster *v3.Cluster, spec v3.Cl
 		return err
 	}
 
-	return p.Driver.RemoveLegacyServiceAccount(ctx, cluster.Name, kontainerDriver, spec)
+	return p.engineService.RemoveLegacyServiceAccount(ctx, cluster.Name, kontainerDriver, spec)
 }
 
 func cleanRKE(spec v3.ClusterSpec) v3.ClusterSpec {

--- a/pkg/controllers/management/clusterprovisioner/driver.go
+++ b/pkg/controllers/management/clusterprovisioner/driver.go
@@ -78,7 +78,7 @@ func (p *Provisioner) driverUpdate(cluster *v3.Cluster, spec v3.ClusterSpec) (ap
 	return p.Driver.Update(ctx, cluster.Name, kontainerDriver, spec)
 }
 
-func (p *Provisioner) driverRemove(cluster *v3.Cluster) error {
+func (p *Provisioner) driverRemove(cluster *v3.Cluster, forceRemove bool) error {
 	ctx, logger := clusterprovisioninglogger.NewLogger(p.Clusters, cluster, v3.ClusterConditionProvisioned)
 	defer logger.Close()
 
@@ -94,7 +94,7 @@ func (p *Provisioner) driverRemove(cluster *v3.Cluster) error {
 			return nil, err
 		}
 
-		return cluster, p.Driver.Remove(ctx, cluster.Name, kontainerDriver, spec)
+		return cluster, p.Driver.Remove(ctx, cluster.Name, kontainerDriver, spec, forceRemove)
 	})
 
 	return err

--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -37,7 +37,7 @@ type Provisioner struct {
 	ClusterController     v3.ClusterController
 	Clusters              v3.ClusterInterface
 	NodeLister            v3.NodeLister
-	Driver                service.EngineService
+	engineService         *service.EngineService
 	backoff               *flowcontrol.Backoff
 	KontainerDriverLister v3.KontainerDriverLister
 	DynamicSchemasLister  v3.DynamicSchemaLister
@@ -46,7 +46,7 @@ type Provisioner struct {
 
 func Register(ctx context.Context, management *config.ManagementContext) {
 	p := &Provisioner{
-		Driver:                service.NewEngineService(NewPersistentStore(management.Core.Namespaces(""), management.Core)),
+		engineService:         service.NewEngineService(NewPersistentStore(management.Core.Namespaces(""), management.Core)),
 		Clusters:              management.Management.Clusters(""),
 		ClusterController:     management.Management.Clusters("").Controller(),
 		NodeLister:            management.Management.Nodes("").Controller().Lister(),

--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -83,7 +83,8 @@ func (p *Provisioner) Remove(cluster *v3.Cluster) (runtime.Object, error) {
 	}
 
 	for i := 0; i < 4; i++ {
-		err := p.driverRemove(cluster)
+		// cluster will be forcefully removed on last attempt
+		err := p.driverRemove(cluster, i == 3)
 		if err == nil {
 			break
 		}

--- a/pkg/controllers/management/etcdbackup/etcdbackup.go
+++ b/pkg/controllers/management/etcdbackup/etcdbackup.go
@@ -34,7 +34,7 @@ type Controller struct {
 	clusterLister         v3.ClusterLister
 	backupClient          v3.EtcdBackupInterface
 	backupLister          v3.EtcdBackupLister
-	backupDriver          service.EngineService
+	backupDriver          *service.EngineService
 	secretsClient         v1.SecretInterface
 	KontainerDriverLister v3.KontainerDriverLister
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     a265edee9d1be1daf44670f2f8b187cc61b36c04
-github.com/rancher/kontainer-engine           dc8ca48e82981b0cd39d353d9760df2b9669b112
+github.com/rancher/kontainer-engine           8bcffab1eba9a7d4055c1201e638d357afe3adf9
 github.com/rancher/rke                        d618819f323b55bc5a8efe6317ff5ff2cf57db29
 github.com/rancher/types                      083953864c59f320cc9173b0a8969bc4cce82e9c
 


### PR DESCRIPTION
Problem: Removing unavailable cluster causes cluster to hang in removal state in UI.

Solution: Update to latest kontainer engine which logs errors caused by driver remove instead of returning it, then proceeds to remove cluster from persist store.

Issue: https://github.com/rancher/rancher/issues/18328