### PR TITLE
Change agent docker socket check to warning

### DIFF
--- a/package/run.sh
+++ b/package/run.sh
@@ -147,9 +147,9 @@ fi
 
 if [ "$CATTLE_CLUSTER" != "true" ]; then
     if [ ! -w /var/run/docker.sock ] || [ ! -S /var/run/docker.sock ]; then
-        error Please bind mount in the docker socket to /var/run/docker.sock
-        error example:  docker run -v /var/run/docker.sock:/var/run/docker.sock ...
-        exit 1
+        warn "Docker socket is not available!"
+        warn "Please bind mount in the docker socket to /var/run/docker.sock if docker errors occur"
+        warn "example:  docker run -v /var/run/docker.sock:/var/run/docker.sock ..."
     fi
 fi
 

--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -178,7 +178,7 @@ func run() error {
 		}
 
 		if err := cleanup(context.Background()); err != nil {
-			return err
+			logrus.Warnf("Unable to perform docker cleanup: %v", err)
 		}
 
 		go func() {


### PR DESCRIPTION
k3s does not require a docker socket, so produce a warning instead of
error if the socket is not present when running the agent.

For rancher/k3s/issues/69