### PR TITLE
Improve wait_for_condition

### DIFF
--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -334,8 +334,10 @@ def wait_for_condition(condition_type, status, client, obj, timeout=45):
         obj = client.reload(obj)
         delta = time.time() - start
         if delta > timeout:
-            msg = 'Timeout waiting for [{}:{}] for condition after {}' \
-                ' seconds'.format(obj.type, obj.id, delta)
+            msg = 'Expected condition {} to have status {}\n'\
+                'Timeout waiting for [{}:{}] for condition after {} ' \
+                'seconds\n {}'.format(condition_type, status, obj.type, obj.id,
+                                      delta, str(obj))
             raise Exception(msg)
     return obj
 


### PR DESCRIPTION
Problem: When tests failed on wait_for_condition function, they did not
produce enough information to accurately debug.

Solution:
They now dump the entire object to the log
https://github.com/rancher/rancher/issues/18239