### PR TITLE
update logging namespace matching pattern

### DIFF
--- a/pkg/controllers/user/logging/config/config.go
+++ b/pkg/controllers/user/logging/config/config.go
@@ -93,3 +93,7 @@ func RancherLoggingConfigSecretName() string {
 func RancherLoggingSSLSecretName() string {
 	return fmt.Sprintf("%s-%s", AppName, LoggingSSLSecretName)
 }
+
+func GetNamespacePattern(namespace string) string {
+	return fmt.Sprintf("^%s$", namespace)
+}

--- a/pkg/controllers/user/logging/configsyncer/configgenerator.go
+++ b/pkg/controllers/user/logging/configsyncer/configgenerator.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/rancher/norman/controller"
+	loggingconfig "github.com/rancher/rancher/pkg/controllers/user/logging/config"
 	"github.com/rancher/rancher/pkg/controllers/user/logging/generator"
 	"github.com/rancher/rancher/pkg/project"
 	"github.com/rancher/types/apis/core/v1"
@@ -96,7 +97,8 @@ func (s *ConfigGenerator) addExcludeNamespaces(systemProjectID string) (string, 
 	var systemNamespaces []string
 	for _, v := range namespaces {
 		if v.Annotations[project.ProjectIDAnn] == systemProjectID {
-			systemNamespaces = append(systemNamespaces, v.Name)
+			namespacePattern := loggingconfig.GetNamespacePattern(v.Name)
+			systemNamespaces = append(systemNamespaces, namespacePattern)
 		}
 	}
 

--- a/pkg/controllers/user/logging/generator/generator.go
+++ b/pkg/controllers/user/logging/generator/generator.go
@@ -58,7 +58,8 @@ func GenerateProjectConfig(projectLoggings []*mgmtv3.ProjectLogging, namespaces 
 		var grepNamespace []string
 		for _, v2 := range namespaces {
 			if nsProjectName, ok := v2.Annotations[project.ProjectIDAnn]; ok && nsProjectName == v.Spec.ProjectName {
-				grepNamespace = append(grepNamespace, v2.Name)
+				namespacePattern := loggingconfig.GetNamespacePattern(v2.Name)
+				grepNamespace = append(grepNamespace, namespacePattern)
 			}
 		}
 


### PR DESCRIPTION
Problem:
For namespaces have same prefix belong to different projects, for example project1 have namespace default, project2 have namespace
default2, fluentd not match the exact namespace which makes project1 logging could get the log from namespace default2

Solution:
update regex to match the exact namespace