### PR TITLE
Fix mounting cacerts.pem

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -116,7 +116,7 @@ spec:
 {{- end }}
 {{- if .Values.privateCA }}
         # Pass CA cert into rancher for private CA
-        - mountPath: /etc/rancher/ssl
+        - mountPath: /etc/rancher/ssl/cacerts.pem
           name: tls-ca-volume
           subPath: cacerts.pem
           readOnly: true


### PR DESCRIPTION
Hello!
rancher fails to start when `cacerts.pem` mounted at `/etc/rancher/ssl`
```
2019/02/26 14:31:02 [INFO] Listening on /tmp/log.sock
2019/02/26 14:31:02 [INFO] Rancher version v2.2.0-rc1 is starting
2019/02/26 14:31:02 [INFO] Rancher arguments {ACMEDomains:[] AddLocal:auto Embedded:false KubeConfig: HTTPListenPort:80 HTTPSListenPort:443 K8sMode:auto Debug:false NoCACerts:false ListenConfig:<nil> AuditLogPath:/var/log/auditlog/rancher-api-audit.log AuditLogMaxage:10 AuditLogMaxsize:100 AuditLogMaxbackup:10 AuditLevel:0}
I0226 14:31:02.487331       5 http.go:110] HTTP2 has been explicitly disabled
2019/02/26 14:31:02 [FATAL] open /etc/rancher/ssl/cert.pem: not a directory
```