### PR TITLE
Adapt syslog severity and api severity value

### DIFF
--- a/pkg/controllers/user/logging/generator/cluster_template.go
+++ b/pkg/controllers/user/logging/generator/cluster_template.go
@@ -208,7 +208,7 @@ var ClusterTemplate = `{{ if .clusterTarget.CurrentTarget }}
     @type remote_syslog
     host {{.clusterTarget.SyslogTemplateWrap.Host}}
     port {{.clusterTarget.SyslogTemplateWrap.Port}}
-    severity {{.clusterTarget.SyslogConfig.Severity}}
+    severity {{.clusterTarget.SyslogTemplateWrap.WrapSeverity}}
     protocol {{.clusterTarget.SyslogConfig.Protocol}}
     {{- if .clusterTarget.SyslogConfig.Program }}
     program {{.clusterTarget.SyslogConfig.Program}}

--- a/pkg/controllers/user/logging/generator/project_template.go
+++ b/pkg/controllers/user/logging/generator/project_template.go
@@ -202,7 +202,7 @@ var ProjectTemplate = `
       @type remote_syslog
       host {{$store.SyslogTemplateWrap.Host}}
       port {{$store.SyslogTemplateWrap.Port}}
-      severity {{$store.SyslogConfig.Severity}}
+      severity {{$store.SyslogTemplateWrap.WrapSeverity}}
       protocol {{$store.SyslogConfig.Protocol}}
       {{- if $store.SyslogConfig.Program }}
       program {{$store.SyslogConfig.Program}}

--- a/pkg/controllers/user/logging/utils/syslog.go
+++ b/pkg/controllers/user/logging/utils/syslog.go
@@ -113,3 +113,17 @@ func getSeverity(severityStr string) syslog.Priority {
 
 	return syslog.LOG_INFO
 }
+
+func getWrapSeverity(severity string) string {
+	// for adapt api and fluentd config
+	severityMap := map[string]string{
+		"warning": "warn",
+	}
+
+	wrapSeverity := severityMap[severity]
+	if wrapSeverity == "" {
+		return severity
+	}
+
+	return wrapSeverity
+}

--- a/pkg/controllers/user/logging/utils/templatewrap.go
+++ b/pkg/controllers/user/logging/utils/templatewrap.go
@@ -104,8 +104,9 @@ type KafkaTemplateWrap struct {
 
 type SyslogTemplateWrap struct {
 	v3.SyslogConfig
-	Host string
-	Port string
+	Host         string
+	Port         string
+	WrapSeverity string
 }
 
 type FluentForwarderTemplateWrap struct {
@@ -223,10 +224,12 @@ func newSyslogTemplateWrap(syslogConfig *v3.SyslogConfig) (*SyslogTemplateWrap, 
 	if err != nil {
 		return nil, err
 	}
+
 	return &SyslogTemplateWrap{
 		SyslogConfig: *syslogConfig,
 		Host:         host,
 		Port:         port,
+		WrapSeverity: getWrapSeverity(syslogConfig.Severity),
 	}, nil
 }
 


### PR DESCRIPTION
Problem:
The fluentd syslog gem depends on an old gem, and it used deprecated warn instead of warning

Solution:
Add api and syslog adapter

Issue:
https://github.com/rancher/rancher/issues/18472