### PR TITLE
Add reason to forget error

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -556,7 +556,10 @@ func (p *Provisioner) validateDriver(cluster *v3.Cluster) (string, error) {
 	}
 
 	if newDriver == "" {
-		return "", &controller.ForgetError{Err: fmt.Errorf("waiting for nodes")}
+		return "", &controller.ForgetError{
+			Err:    fmt.Errorf("waiting for nodes"),
+			Reason: "Pending",
+		}
 	}
 
 	if oldDriver != newDriver {


### PR DESCRIPTION
Problem: 
Forget error was treated as a normal error when waiting for nodes and caused the status to be highlighted red. 

Solution:
Added reason to forget error when waiting for nodes. The status will remain its intended color.
(Additional changes made in ui PR: https://github.com/rancher/ui/pull/2709)
(Most common color issue previously resolved in: https://github.com/rancher/rancher/pull/17980)

Issue:
https://github.com/rancher/rancher/issues/18062