### PR TITLE
Improve alert deploy/upgrade logic

### DIFF
--- a/pkg/controllers/user/monitoring/operatorHandler.go
+++ b/pkg/controllers/user/monitoring/operatorHandler.go
@@ -64,7 +64,7 @@ func (h *operatorHandler) syncProject(key string, project *mgmtv3.Project) (runt
 
 	var newCluster *mgmtv3.Cluster
 	//should deploy
-	if project.Spec.EnableProjectMonitoring {
+	if cluster.Spec.EnableClusterAlerting || project.Spec.EnableProjectMonitoring {
 		newObj, err := mgmtv3.ClusterConditionPrometheusOperatorDeployed.DoUntilTrue(cluster, func() (runtime.Object, error) {
 			cpy := cluster.DeepCopy()
 			return cpy, deploySystemMonitor(cpy, h.app)
@@ -90,8 +90,8 @@ func (h *operatorHandler) syncProject(key string, project *mgmtv3.Project) (runt
 }
 
 func withdrawSystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) error {
-	isAlertingDisabling := mgmtv3.MonitoringConditionAlertmaanagerDeployed.IsFalse(cluster) ||
-		mgmtv3.MonitoringConditionAlertmaanagerDeployed.GetStatus(cluster) == ""
+	isAlertingDisabling := mgmtv3.ClusterConditionAlertingEnabled.IsFalse(cluster) ||
+		mgmtv3.ClusterConditionAlertingEnabled.GetStatus(cluster) == ""
 	isClusterMonitoringDisabling := mgmtv3.ClusterConditionMonitoringEnabled.IsFalse(cluster) ||
 		mgmtv3.ClusterConditionMonitoringEnabled.GetStatus(cluster) == ""
 	//status false and empty should withdraw. when status unknown, it means the deployment has error while deploying apps


### PR DESCRIPTION
Problem:
1.Project level operator withdraw check also need to check whether the
alert is enable
2.For HA mode, single isDeploy value is not good

Solution:
1.Check whether the alert is enable when withdraw the operator in
project level
2.Use the app status to check whether the alertmanager deployed

Issue:
https://github.com/rancher/rancher/issues/18478