### PR TITLE
Fix logging to es can't use char @ in password

### DIFF
--- a/pkg/controllers/user/logging/generator/cluster_template.go
+++ b/pkg/controllers/user/logging/generator/cluster_template.go
@@ -109,10 +109,10 @@ var ClusterTemplate = `{{ if .clusterTarget.CurrentTarget }}
     @type elasticsearch
     include_tag_key  true
     {{- if and .clusterTarget.ElasticsearchConfig.AuthUserName .clusterTarget.ElasticsearchConfig.AuthPassword}}
-    hosts {{.clusterTarget.ElasticsearchTemplateWrap.Scheme}}://{{.clusterTarget.ElasticsearchConfig.AuthUserName}}:{{.clusterTarget.ElasticsearchConfig.AuthPassword}}@{{.clusterTarget.ElasticsearchTemplateWrap.Host}}
-    {{- else }}
+    user {{.clusterTarget.ElasticsearchConfig.AuthUserName}}
+    password {{.clusterTarget.ElasticsearchConfig.AuthPassword}}
+    {{- end }}
     hosts {{.clusterTarget.ElasticsearchConfig.Endpoint}}    
-    {{end }}
     logstash_format true
     logstash_prefix "{{.clusterTarget.ElasticsearchConfig.IndexPrefix}}"
     logstash_dateformat  {{.clusterTarget.ElasticsearchTemplateWrap.DateFormat}}

--- a/pkg/controllers/user/logging/generator/project_template.go
+++ b/pkg/controllers/user/logging/generator/project_template.go
@@ -103,10 +103,10 @@ var ProjectTemplate = `
       @type elasticsearch
       include_tag_key  true
       {{- if and $store.ElasticsearchConfig.AuthUserName $store.ElasticsearchConfig.AuthPassword}}
-      hosts {{$store.ElasticsearchTemplateWrap.Scheme}}://{{$store.ElasticsearchConfig.AuthUserName}}:{{$store.ElasticsearchConfig.AuthPassword}}@{{$store.ElasticsearchTemplateWrap.Host}}
-      {{else }}
+      user {{$store.ElasticsearchConfig.AuthUserName}}
+      password {{$store.ElasticsearchConfig.AuthPassword}}
+      {{- end }}
       hosts {{$store.ElasticsearchConfig.Endpoint}}    
-      {{end }}
 
       logstash_prefix "{{$store.ElasticsearchConfig.IndexPrefix}}"
       logstash_format true


### PR DESCRIPTION
**Problem:**
Rancher logging to elastic doesnt support passwords with special
characters like `@` and `#`.

**Solution:**
Use `user` and `password` field in fluentd es configuration
instead of adding them to es url.

Related issue: https://github.com/rancher/rancher/issues/18389