### PR TITLE
Improve error handling when available quota is not enough for the pipeline namespace

### DIFF
--- a/pkg/controllers/user/pipeline/controller/pipelineexecution/deploy.go
+++ b/pkg/controllers/user/pipeline/controller/pipelineexecution/deploy.go
@@ -140,6 +140,15 @@ func (l *Lifecycle) waitResourceQuotaInitCondition(namespace string) error {
 		if err != nil {
 			return err
 		}
+
+		invalid, err := namespaceutil.IsNamespaceConditionSet(ns, resourcequota.ResourceQuotaValidatedCondition, false)
+		if err != nil {
+			return err
+		}
+		if invalid {
+			return fmt.Errorf("available resource quota in this project does not fit for the dedicated pipeline namespace, please make sure there is vacancy for the default namespace quota")
+		}
+
 		set, err := namespaceutil.IsNamespaceConditionSet(ns, resourcequota.ResourceQuotaInitCondition, true)
 		if err != nil {
 			return err

--- a/pkg/controllers/user/resourcequota/resource_quota_calculate_used.go
+++ b/pkg/controllers/user/resourcequota/resource_quota_calculate_used.go
@@ -63,7 +63,7 @@ func (c *calculateLimitController) calculateProjectResourceQuota(projectID strin
 		if ns.DeletionTimestamp != nil {
 			continue
 		}
-		set, err := namespaceutil.IsNamespaceConditionSet(ns, resourceQuotaValidatedCondition, true)
+		set, err := namespaceutil.IsNamespaceConditionSet(ns, ResourceQuotaValidatedCondition, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/controllers/user/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/user/resourcequota/resource_quota_sync.go
@@ -26,7 +26,7 @@ const (
 	resourceQuotaLabel              = "resourcequota.management.cattle.io/default-resource-quota"
 	resourceQuotaAnnotation         = "field.cattle.io/resourceQuota"
 	limitRangeAnnotation            = "field.cattle.io/containerDefaultResourceLimit"
-	resourceQuotaValidatedCondition = "ResourceQuotaValidated"
+	ResourceQuotaValidatedCondition = "ResourceQuotaValidated"
 	ResourceQuotaInitCondition      = "ResourceQuotaInit"
 )
 
@@ -371,12 +371,12 @@ func (c *SyncController) validateAndSetNamespaceQuota(ns *corev1.Namespace, quot
 }
 
 func (c *SyncController) setValidated(ns *corev1.Namespace, value bool, msg string) (*corev1.Namespace, error) {
-	set, err := namespaceutil.IsNamespaceConditionSet(ns, resourceQuotaValidatedCondition, value)
+	set, err := namespaceutil.IsNamespaceConditionSet(ns, ResourceQuotaValidatedCondition, value)
 	if set || err != nil {
 		return ns, err
 	}
 	toUpdate := ns.DeepCopy()
-	err = namespaceutil.SetNamespaceCondition(toUpdate, time.Second*1, resourceQuotaValidatedCondition, value, msg)
+	err = namespaceutil.SetNamespaceCondition(toUpdate, time.Second*1, ResourceQuotaValidatedCondition, value, msg)
 	if err != nil {
 		return ns, err
 	}


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/16538

Problem:
When available resource quota in a project does not satisfy the default namespace quota, pipeline builds fails with error "create secret failed due to exceeding resource quota"

Solution:
Check validated condition of the namespace and show a better error message