### PR TITLE
Cluster driver remove bug fix

### DIFF
--- a/pkg/api/customization/kontainerdriver/formatter.go
+++ b/pkg/api/customization/kontainerdriver/formatter.go
@@ -2,10 +2,40 @@ package kontainerdriver
 
 import (
 	"github.com/rancher/norman/types"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/client/management/v3"
+	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/tools/cache"
 )
 
-func Formatter(request *types.APIContext, resource *types.RawResource) {
+type Format struct {
+	ClusterIndexer cache.Indexer
+}
+
+func NewFormatter(manangement *config.ScaledContext) types.Formatter {
+	clusterInformer := manangement.Management.Clusters("").Controller().Informer()
+	// use an indexer instead of expensive k8s api calls
+	clusterInformer.AddIndexers(map[string]cache.IndexFunc{
+		clusterByKontainerDriverKey: clusterByKontainerDriver,
+	})
+
+	format := Format{
+		ClusterIndexer: clusterInformer.GetIndexer(),
+	}
+	return format.Formatter
+}
+
+const clusterByKontainerDriverKey = "clusterbyKontainerDriver"
+
+func clusterByKontainerDriver(obj interface{}) ([]string, error) {
+	cluster, ok := obj.(*v3.Cluster)
+	if !ok {
+		return []string{}, nil
+	}
+	return []string{cluster.Status.Driver}, nil
+}
+func (f *Format) Formatter(request *types.APIContext, resource *types.RawResource) {
 	state, ok := resource.Values["state"].(string)
 	if ok {
 		if state == "active" {
@@ -16,8 +46,19 @@ func Formatter(request *types.APIContext, resource *types.RawResource) {
 			resource.AddAction(request, "activate")
 		}
 	}
-
+	// if cluster driver is a built-in, delete removal link from UI
 	if builtIn, _ := resource.Values[client.KontainerDriverFieldBuiltIn].(bool); builtIn {
 		delete(resource.Links, "remove")
+	}
+	resName := resource.Values[client.KontainerDriverFieldName]
+	// resName will be nil when first added
+	if resName != nil {
+		clustersWithKontainerDriver, err := f.ClusterIndexer.ByIndex(clusterByKontainerDriverKey, resName.(string))
+		if err != nil {
+			logrus.Warnf("failed to determine if kontainer driver %v was in use by a cluster : %v", resName.(string), err)
+		} else if len(clustersWithKontainerDriver) != 0 {
+			// if cluster driver in use, delete removal link from UI
+			delete(resource.Links, "remove")
+		}
 	}
 }

--- a/pkg/api/customization/kontainerdriver/store.go
+++ b/pkg/api/customization/kontainerdriver/store.go
@@ -1,0 +1,57 @@
+package kontainerdriver
+
+import (
+	"fmt"
+
+	errorsutil "github.com/pkg/errors"
+	"github.com/rancher/norman/httperror"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+)
+
+type store struct {
+	types.Store
+	KontainerDriverLister v3.KontainerDriverLister
+	ClusterIndexer        cache.Indexer
+}
+
+func NewStore(management *config.ScaledContext, s types.Store) types.Store {
+	clusterInformer := management.Management.Clusters("").Controller().Informer()
+	// use an indexer instead of expensive k8s api calls
+	clusterInformer.AddIndexers(map[string]cache.IndexFunc{
+		clusterByKontainerDriverKey: clusterByKontainerDriver,
+	})
+	kd := management.Management.KontainerDrivers("").Controller().Lister()
+	storeObj := store{
+		Store:                 s,
+		KontainerDriverLister: kd,
+		ClusterIndexer:        clusterInformer.GetIndexer(),
+	}
+	return &storeObj
+}
+
+// Delete removes the KontainerDriver if it is not in use by a cluster
+func (s *store) Delete(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
+	//need to get the full driver since just the id is not enough see if a cluster uses it
+	driver, err := s.KontainerDriverLister.Get("", id)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, errorsutil.WithMessage(err, fmt.Sprintf("error getting kontainer driver %s", id))
+		}
+		//if driver is not found, don't return error
+		return nil, nil
+	}
+
+	clustersWithKontainerDriver, err := s.ClusterIndexer.ByIndex(clusterByKontainerDriverKey, driver.Status.DisplayName)
+	if err != nil {
+		return nil, errorsutil.WithMessage(err, fmt.Sprintf("error determing if kontainer driver [%s] was in use", driver.Status.DisplayName))
+	}
+
+	if len(clustersWithKontainerDriver) != 0 {
+		return nil, httperror.NewAPIError(httperror.MethodNotAllowed, "cluster Driver is in use by one or more clusters, delete clusters before deleting this driver")
+	}
+	return s.Store.Delete(apiContext, schema, id)
+}

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -609,8 +609,8 @@ func KontainerDriver(schemas *types.Schemas, management *config.ScaledContext) {
 		KontainerDriverLister: management.Management.KontainerDrivers("").Controller().Lister(),
 	}
 	schema.ActionHandler = handler.ActionHandler
-	schema.Formatter = kontainerdriver.Formatter
-
+	schema.Formatter = kontainerdriver.NewFormatter(management)
+	schema.Store = kontainerdriver.NewStore(management, schema.Store)
 	kontainerDriverValidator := kontainerdriver.Validator{
 		KontainerDriverLister: management.Management.KontainerDrivers("").Controller().Lister(),
 	}

--- a/pkg/controllers/management/clusterprovisioner/driver.go
+++ b/pkg/controllers/management/clusterprovisioner/driver.go
@@ -9,6 +9,8 @@ import (
 	"github.com/rancher/rancher/pkg/clusterprovisioninglogger"
 	"github.com/rancher/rke/services"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -91,6 +93,10 @@ func (p *Provisioner) driverRemove(cluster *v3.Cluster, forceRemove bool) error 
 
 		kontainerDriver, err := p.getKontainerDriver(spec)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrus.Warnf("Could not find kontainer driver for cluster removal [%v]", err)
+				return nil, nil
+			}
 			return nil, err
 		}
 

--- a/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
+++ b/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
@@ -425,6 +425,7 @@ func getDynamicFieldName(obj *v3.KontainerDriver) string {
 	return obj.Status.DisplayName + "EngineConfig"
 }
 
+// Remove the Kontainer Cluster driver, see also the Schema.Store for kontainer driver
 func (l *Lifecycle) Remove(obj *v3.KontainerDriver) (runtime.Object, error) {
 	logrus.Infof("remove kontainerdriver %v", obj.Name)
 


### PR DESCRIPTION
Fix for cluster driver nil error

Problem: A cluster driver could be deleted when there were active
clusters that depended on that driver.

Solution: The API will not crash if a cluster driver is unable to be
removed. Kontainer drivers are no longer able to be removed via the UI
or API if there is a cluster that uses that driver.
https://github.com/rancher/rancher/issues/18460