### PR TITLE
Add timeout for read data from connection

### DIFF
--- a/pkg/controllers/user/logging/utils/fluentd.go
+++ b/pkg/controllers/user/logging/utils/fluentd.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"strings"
@@ -80,9 +79,8 @@ func (w *fluentForwarderTestWrap) sendData2Server(conn net.Conn, shareKey, usern
 			return errors.Wrapf(err, "couldn't write data to fluentd forwarder %s", endpoint)
 		}
 	}
-
-	buf := make([]byte, 1024)
-	if _, err := conn.Read(buf); err != nil && err != io.EOF {
+	buf, err := readDataWithTimeout(conn)
+	if err != nil {
 		return errors.Wrapf(err, "couldn't read data from fluentd forwarder %s", endpoint)
 	}
 
@@ -123,9 +121,9 @@ func (w *fluentForwarderTestWrap) sendData2Server(conn net.Conn, shareKey, usern
 		return errors.Wrap(err, "couldn't write test data to fluentd forwarder")
 	}
 
-	pongBuf := make([]byte, 1024)
-	if _, err = conn.Read(pongBuf); err != nil && err != io.EOF {
-		return errors.Wrap(err, "couldn't read pong data from fluentd forwarder")
+	pongBuf, err := readDataWithTimeout(conn)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't read pong data from fluentd forwarder")
 	}
 
 	return w.decodeFluentForwarderPong(pongBuf)

--- a/pkg/controllers/user/logging/utils/syslog.go
+++ b/pkg/controllers/user/logging/utils/syslog.go
@@ -60,12 +60,10 @@ func (w *syslogTestWrap) TestReachable(dial dialer.Dialer, includeSendTestLog bo
 		return errors.Wrapf(err, "couldn't write data to syslog %s", w.Endpoint)
 	}
 
-	if !w.EnableTLS {
-		// for not tls try read to check whether the server close connect already
-		resBuf := make([]byte, 1024)
-		if _, err := conn.Read(resBuf); err != nil {
-			return errors.Wrapf(err, "couldn't read data from syslog %s", w.Endpoint)
-		}
+	// try read to check whether the server close connect already
+	// because can't set read deadline for remote dialer, so if the error is timeout will treat as remote server not close the connection
+	if _, err := readDataWithTimeout(conn); err != nil && err != errReadDataTimeout {
+		return errors.Wrapf(err, "couldn't read data from syslog %s", w.Endpoint)
 	}
 
 	return nil


### PR DESCRIPTION
### Problem

This issue happens when the fluentd server is configured with tls, but we try to connect to it without tls in Rancher.
In this case if you click `Test` button, the UI hangs.

![image](https://user-images.githubusercontent.com/19684717/53786627-37a86c00-3f57-11e9-9a15-1ac171d59b27.png)

### Reason

Steps to check the connectivity is following:

1. Create the connection (tcp handshake, ssl handshake)
2. Read data from fluentd to get nonce from server
3. Use nonce to generate fluentd ping and send ping to fluentd server
4. Get pong from fluentd server

You can see that the tcp handshake is finished, but fluentd throw error about tls in the screenshots.
Now the step for getting nonce from fluentd get blocked.

connection status:
![image](https://user-images.githubusercontent.com/5936271/53862515-9850ab00-4022-11e9-9d4f-b528996a08f9.png)

fluentd log:
![image](https://user-images.githubusercontent.com/5936271/53863591-8e7c7700-4025-11e9-9ee2-e1ad8619783f.png)

### Solution

Add a read function which supports timeout. Then we can use it when user click `Test` button in UI. The change is safe and it only impacts the `Test` feature.

###  Related Issue

https://github.com/rancher/rancher/issues/18575