### PR TITLE
Change log level to info for globaldns providers

### DIFF
--- a/pkg/controllers/management/globaldns/globaldnsprovider_catalog_launcher.go
+++ b/pkg/controllers/management/globaldns/globaldnsprovider_catalog_launcher.go
@@ -89,7 +89,6 @@ func (n *ProviderCatalogLauncher) handleRoute53Provider(obj *v3.GlobalDNSProvide
 		"aws.secretKey": obj.Spec.Route53ProviderConfig.SecretKey,
 		"txtOwnerId":    rancherInstallUUID + "_" + obj.Name,
 		"rbac.create":   "true",
-		"logLevel":      "debug",
 		"policy":        "sync",
 	}
 
@@ -108,7 +107,6 @@ func (n *ProviderCatalogLauncher) handleCloudflareProvider(obj *v3.GlobalDNSProv
 		"cloudflare.email":  obj.Spec.CloudflareProviderConfig.APIEmail,
 		"txtOwnerId":        rancherInstallUUID + "_" + obj.Name,
 		"rbac.create":       "true",
-		"logLevel":          "debug",
 		"policy":            "sync",
 	}
 
@@ -129,7 +127,6 @@ func (n *ProviderCatalogLauncher) handleAlidnsProvider(obj *v3.GlobalDNSProvider
 		"alibabacloud.secretKey": obj.Spec.AlidnsProviderConfig.SecretKey,
 		"txtOwnerId":             rancherInstallUUID + "_" + obj.Name,
 		"rbac.create":            "true",
-		"logLevel":               "debug",
 		"policy":                 "sync",
 	}
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/18641

Logging at info by default now, changing chart answers to not set the loglevel. Chart will set it to info by default.