### PR TITLE
 Add ETCD_UNSUPPORTED_ARCH env var for arm64 rancher image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -74,6 +74,7 @@ RUN chmod +x /usr/bin/entrypoint.sh
 ENV CATTLE_AGENT_IMAGE rancher/rancher-agent:${VERSION}
 ENV CATTLE_WINDOWS_AGENT_IMAGE rancher/rancher-agent:${VERSION}-nanoserver-1803
 ENV CATTLE_SERVER_IMAGE rancher/rancher
+ENV ETCD_UNSUPPORTED_ARCH=${ARCH}
 
 ENV SSL_CERT_DIR /etc/rancher/ssl
 VOLUME /var/lib/rancher

--- a/vendor.conf
+++ b/vendor.conf
@@ -42,7 +42,7 @@ github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f6841
 github.com/rancher/norman                     a265edee9d1be1daf44670f2f8b187cc61b36c04
 github.com/rancher/types                      6e04fa3e4a6af9c9542c475b436ce12b28e31c13
 github.com/rancher/kontainer-engine           e8045252b7e1afd54e680dfff45fa20e0870d2d1
-github.com/rancher/rke                        65cda9f50dd7c4637a9952891b35b706d9762ba4
+github.com/rancher/rke                        b6d90f411085bb9ca7bfe6294d68cf00dc058594
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1

--- a/vendor/github.com/rancher/rke/cluster/plan.go
+++ b/vendor/github.com/rancher/rke/cluster/plan.go
@@ -775,6 +775,10 @@ func (c *Cluster) BuildEtcdProcess(host *hosts.Host, etcdHosts []*hosts.Host, pr
 	Env = append(Env, fmt.Sprintf("ETCDCTL_CACERT=%s", pki.GetCertPath(pki.CACertName)))
 	Env = append(Env, fmt.Sprintf("ETCDCTL_CERT=%s", pki.GetCertPath(nodeName)))
 	Env = append(Env, fmt.Sprintf("ETCDCTL_KEY=%s", pki.GetKeyPath(nodeName)))
+
+	if architecture == "aarch64" {
+		architecture = "arm64"
+	}
 	Env = append(Env, fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=%s", architecture))
 
 	Env = append(Env, c.Services.Etcd.ExtraEnv...)


### PR DESCRIPTION
The ETCD needs `ETCD_UNSUPPORTED_ARCH=arm64` env var to be set to run on ARM64 platform.

https://github.com/rancher/rancher/issues/16461