### PR TITLE
Clone system-chart repo with master branch

### DIFF
--- a/scripts/package
+++ b/scripts/package
@@ -37,5 +37,5 @@ echo Built ${IMAGE} #${AGENT_IMAGE}
 echo
 
 cd ../bin
-mkdir -p /tmp/system-charts && git clone https://github.com/rancher/system-charts /tmp/system-charts
+mkdir -p /tmp/system-charts && git clone --branch master https://github.com/rancher/system-charts /tmp/system-charts
 TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go /tmp/system-charts $IMAGE $AGENT_IMAGE


### PR DESCRIPTION
**Problem:**
We use `git clone` in package to get system charts repo and we will
get the default branch `dev` instead of `master`. We need master
branch for building release.

**Solution:**
Using git clone with `--branch master`

Related issue: https://github.com/rancher/rancher/issues/18747