### PR TITLE
Sort nodes conditions before being compared

### DIFF
--- a/pkg/controllers/user/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/user/nodesyncer/nodessyncer.go
@@ -3,6 +3,7 @@ package nodesyncer
 import (
 	"fmt"
 	"reflect"
+	"sort"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -390,6 +391,9 @@ func resetConditions(machine *v3.Node) *v3.Node {
 		toUpdateCond.LastTransitionTime = metav1.Time{}
 		toUpdateConds = append(toUpdateConds, *toUpdateCond)
 	}
+	sort.Slice(toUpdateConds, func(i, j int) bool {
+		return toUpdateConds[i].Type < toUpdateConds[j].Type
+	})
 	updated.Status.InternalNodeStatus.Conditions = toUpdateConds
 	return updated
 }


### PR DESCRIPTION
**Problem:**
The rancher nodes are always getting updated becuase the conditions
of them is always different from the nodes' in user cluster. It is
because the condition lists of them are compared without sortting.

**Solution:**
Sort the condition list for both kinds of node before comparing
them.

Related issue: https://github.com/rancher/rancher/issues/18759