### PR TITLE
setting applied spec and spec generic config

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -13,6 +13,8 @@ RUN curl -sLf https://github.com/rancher/machine-package/releases/download/v0.15
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
+RUN touch /bin/foo
+
 RUN wget -O - https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && curl -L https://raw.githubusercontent.com/alecthomas/gometalinter/v3.0.0/scripts/install.sh | sh
 


### PR DESCRIPTION
Set generic config

Now sets generic config and remove old config from spec
and applied spec. Prior, on upgrade getConfig would return
an empty interface for the old config. Consequently, new
config and old config would always fail comparison. This
caused the provisioner to proceed unnecessarily and
contribute to the update status. Now, configs will pass if
they are equal.