### PR TITLE
Fix kontainer-engine driver reactivation

### DIFF
--- a/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
+++ b/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
@@ -348,6 +348,15 @@ func (l *Lifecycle) Updated(obj *v3.KontainerDriver) (runtime.Object, error) {
 	switch { // dealing with deactivate action
 	case !obj.Spec.Active && l.DynamicSchemaExists(obj):
 		v3.KontainerDriverConditionInactive.Unknown(obj)
+		// delete the active condition
+		var i int
+		for _, con := range obj.Status.Conditions {
+			if con.Type != string(v3.KontainerDriverConditionActive) {
+				obj.Status.Conditions[i] = con
+				i++
+			}
+		}
+		obj.Status.Conditions = obj.Status.Conditions[:i]
 		// we don't need to show the Inactivating state so we don't need to store the Inactivate condition
 		fallthrough
 	case !obj.Spec.Active:


### PR DESCRIPTION
Problem:
If you deactivate and then reactivate a kontainer-engine driver,
the schema for it will not be readded. This is because there is logic
that only creates/updates the schema if the "active" condition is not
true. But, when a driver is deactivated, we do not change the value
of the active condition. So, when it is reactivated, the schema is never
recreated.

Solution:
Delete the active condition when the driver is deactivated. Settting
the condition to falst, "", or unknown is not sufficient because it causes
the state of the resrouce in the UI to go to activating.

https://github.com/rancher/rancher/issues/18800