### PR TITLE
[WIP]Support upgrading Monitoring from catalog app page

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -2,8 +2,9 @@ package managementstored
 
 import (
 	"context"
-	"github.com/rancher/rancher/pkg/namespace"
 	"net/http"
+
+	"github.com/rancher/rancher/pkg/namespace"
 
 	"github.com/rancher/norman/store/crd"
 	"github.com/rancher/norman/store/proxy"
@@ -215,6 +216,7 @@ func Clusters(schemas *types.Schemas, managementContext *config.ScaledContext, c
 		ClusterManager:     clusterManager,
 		NodeTemplateGetter: managementContext.Management,
 		BackupClient:       managementContext.Management.EtcdBackups(""),
+		AppClient:          managementContext.Project.Apps(""),
 	}
 
 	schema := schemas.Schema(&managementschema.Version, client.ClusterType)
@@ -572,6 +574,7 @@ func Project(schemas *types.Schemas, management *config.ScaledContext) {
 		ProjectLister:  management.Management.Projects("").Controller().Lister(),
 		UserMgr:        management.UserManager,
 		ClusterManager: management.ClientGetter.(*clustermanager.Manager),
+		AppClient:      management.Project.Apps(""),
 	}
 	schema.ActionHandler = handler.Actions
 }

--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -346,7 +346,7 @@ func (ch *clusterHandler) deployApp(appName, appTargetNamespace string, appProje
 	appCatalogID := settings.SystemMonitoringCatalogID.Get()
 	app := &v3.App{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: monitoring.CopyCreatorID(nil, cluster.Annotations),
+			Annotations: monitoring.CopyCreatorIDAndOverwroteAppAnswers(nil, cluster.Annotations),
 			Labels:      monitoring.OwnedLabels(appName, appTargetNamespace, appProjectName, monitoring.ClusterLevel),
 			Name:        appName,
 			Namespace:   appDeployProjectID,

--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -48,7 +48,7 @@ func (ch *clusterHandler) sync(key string, cluster *mgmtv3.Cluster) (runtime.Obj
 		return cluster, nil
 	}
 
-	if !mgmtv3.ClusterConditionAgentDeployed.IsTrue(cluster) {
+	if !mgmtv3.ClusterConditionPrometheusOperatorDeployed.IsTrue(cluster) {
 		return cluster, nil
 	}
 
@@ -364,6 +364,9 @@ func (ch *clusterHandler) deployApp(appName, appTargetNamespace string, appProje
 	if err != nil {
 		return nil, err
 	}
+
+	// clean overwrote answers from annotation
+	monitoring.DropOverwroteAppAnswers(cluster.Annotations)
 
 	return appAnswers, nil
 }

--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -257,7 +257,7 @@ func (ch *clusterHandler) deployApp(appName, appTargetNamespace string, appProje
 	}
 
 	mustAppAnswers := map[string]string{
-		"enabled": "false",
+		"operator.enabled": "false",
 
 		"exporter-coredns.enabled":  "false",
 		"exporter-coredns.apiGroup": monitoring.APIVersion.Group,

--- a/pkg/controllers/user/monitoring/operatorHandler.go
+++ b/pkg/controllers/user/monitoring/operatorHandler.go
@@ -187,7 +187,7 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) (backErr erro
 		appAnswers[mustKey] = mustVal
 	}
 
-	annotations := monitoring.CopyCreatorID(nil, cluster.Annotations)
+	annotations := monitoring.CopyCreatorIDAndOverwroteAppAnswers(nil, cluster.Annotations)
 	annotations["cluster.cattle.io/addon"] = appName
 	targetApp := &projectv3.App{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/user/monitoring/operatorHandler.go
+++ b/pkg/controllers/user/monitoring/operatorHandler.go
@@ -152,11 +152,41 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) (backErr erro
 		return errors.Wrap(err, "failed to ensure monitoring project name")
 	}
 
-	appAnswers := map[string]string{
-		"enabled":      "true",
-		"apiGroup":     monitoring.APIVersion.Group,
-		"nameOverride": "prometheus-operator",
+	mustAppAnswers := map[string]string{
+		"operator.enabled":      "true",
+		"operator.apiGroup":     monitoring.APIVersion.Group,
+		"operator.nameOverride": "prometheus-operator",
+
+		"exporter-coredns.enabled": "false",
+
+		"exporter-kube-controller-manager.enabled": "false",
+
+		"exporter-kube-dns.enabled": "false",
+
+		"exporter-kube-scheduler.enabled": "false",
+
+		"exporter-kube-state.enabled": "false",
+
+		"exporter-kubelets.enabled": "false",
+
+		"exporter-kubernetes.enabled": "false",
+
+		"exporter-node.enabled": "false",
+
+		"exporter-fluentd.enabled": "false",
+
+		"grafana.enabled": "false",
+
+		"prometheus.enabled": "false",
 	}
+
+	appAnswers := monitoring.OverwriteAppAnswers(map[string]string{}, cluster.Annotations)
+
+	// cannot overwrite mustAppAnswers
+	for mustKey, mustVal := range mustAppAnswers {
+		appAnswers[mustKey] = mustVal
+	}
+
 	annotations := monitoring.CopyCreatorID(nil, cluster.Annotations)
 	annotations["cluster.cattle.io/addon"] = appName
 	targetApp := &projectv3.App{

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -36,6 +36,10 @@ func (ph *projectHandler) sync(key string, project *mgmtv3.Project) (runtime.Obj
 		return project, errors.Wrapf(err, "failed to find Cluster %s", clusterID)
 	}
 
+	if !mgmtv3.ClusterConditionPrometheusOperatorDeployed.IsTrue(cluster) {
+		return cluster, nil
+	}
+
 	clusterName := cluster.Spec.DisplayName
 	projectTag := getProjectTag(project, clusterName)
 	src := project
@@ -232,6 +236,9 @@ func (ph *projectHandler) deployApp(appName, appTargetNamespace string, appProje
 	if err != nil {
 		return err
 	}
+
+	// clean overwrote answers from annotation
+	monitoring.DropOverwroteAppAnswers(project.Annotations)
 
 	return nil
 }

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -147,7 +147,7 @@ func (ph *projectHandler) deployApp(appName, appTargetNamespace string, appProje
 	}
 
 	mustAppAnswers := map[string]string{
-		"enabled": "false",
+		"operator.enabled": "false",
 
 		"exporter-coredns.enabled": "false",
 

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -214,7 +214,7 @@ func (ph *projectHandler) deployApp(appName, appTargetNamespace string, appProje
 	appCatalogID := settings.SystemMonitoringCatalogID.Get()
 	app := &v3.App{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: monitoring.CopyCreatorID(nil, project.Annotations),
+			Annotations: monitoring.CopyCreatorIDAndOverwroteAppAnswers(nil, project.Annotations),
 			Labels:      monitoring.OwnedLabels(appName, appTargetNamespace, appProjectName, monitoring.ProjectLevel),
 			Name:        appName,
 			Namespace:   appDeployProjectID,

--- a/pkg/monitoring/deploy.go
+++ b/pkg/monitoring/deploy.go
@@ -119,7 +119,8 @@ func DeployApp(cattleAppClient projectv3.AppInterface, projectID string, createO
 		}
 	} else {
 		app = app.DeepCopy()
-		app.Spec.Answers = createOrUpdateApp.Spec.Answers
+		// overwrite monitoring page passed
+		app.Spec.Answers = OverwriteAppAnswers(app.Spec.Answers, createOrUpdateApp.Annotations)
 		if _, err = cattleAppClient.Update(app); err != nil {
 			return errors.Wrapf(err, "failed to update %q App", appName)
 		}

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -263,3 +263,7 @@ func GetOverwroteAppAnswers(annotations map[string]string) map[string]string {
 
 	return map[string]string{}
 }
+
+func DropOverwroteAppAnswers(annotations map[string]string) {
+	delete(annotations, cattleOverwriteAppAnswersAnnotationKey)
+}

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -72,13 +72,19 @@ func OwnedAppListOptions(clusterID, appName, appTargetNamespace string) metav1.L
 	}
 }
 
-func CopyCreatorID(toAnnotations, fromAnnotations map[string]string) map[string]string {
-	if val, exist := fromAnnotations[cattleCreatorIDAnnotationKey]; exist {
-		if toAnnotations == nil {
-			toAnnotations = make(map[string]string, 2)
-		}
+func CopyCreatorIDAndOverwroteAppAnswers(toAnnotations, fromAnnotations map[string]string) map[string]string {
+	if toAnnotations == nil {
+		toAnnotations = make(map[string]string, 2)
+	}
 
+	// copy creatorID
+	if val, exist := fromAnnotations[cattleCreatorIDAnnotationKey]; exist {
 		toAnnotations[cattleCreatorIDAnnotationKey] = val
+	}
+
+	// copy overwroteAppAnswers
+	if val, exist := fromAnnotations[cattleOverwriteAppAnswersAnnotationKey]; exist {
+		toAnnotations[cattleOverwriteAppAnswersAnnotationKey] = val
 	}
 
 	return toAnnotations


### PR DESCRIPTION
**Problem:**
Upgrading Monitoring app from the Catalog App page, after a while (something trigged `cluster` or `project` CRD updating), the configuration from Monitoring page will overwrite the new modification.

**Solution:**
- Detecting the target app exist or not at first
- Cleaning overwrite configuration (storing in `cluster.Annotations`) after finishing
- Backing the actual `answers` when viewing in Monitoring page

**Issue:**
https://github.com/rancher/rancher/issues/18578

**Related PR:**
https://github.com/rancher/system-charts/pull/27