### PR TITLE
Fixed the bug that node-driver can't set the integer value

### DIFF
--- a/pkg/controllers/management/node/utils.go
+++ b/pkg/controllers/management/node/utils.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -57,9 +56,13 @@ func buildCreateCommand(node *v3.Node, configMap map[string]interface{}) []strin
 
 	for k, v := range configMap {
 		dmField := "--" + sDriver + "-" + strings.ToLower(regExHyphen.ReplaceAllString(k, "${1}-${2}"))
+		if v == nil {
+			continue
+		}
+
 		switch v.(type) {
-		case int64:
-			cmd = append(cmd, dmField, strconv.FormatInt(v.(int64), 10))
+		case float64:
+			cmd = append(cmd, dmField, fmt.Sprintf("%v", v))
 		case string:
 			if v.(string) != "" {
 				cmd = append(cmd, dmField, v.(string))


### PR DESCRIPTION
Problem:
When we set the field of integer type, it can't be converted normally in
backend

Solution:
When we decode json data by map[string]interface{}, it is decoded to
float64 instead of int or int64

Issue:
https://github.com/rancher/rancher/issues/18822

More Info:

In v2.1.7, we store the nodeConfig and generate dynamicSchema fields from machine driver's flags in 
https://github.com/rancher/rancher/blob/release/v2.1/pkg/controllers/management/nodedriver/machine_driver.go#L111. And when we are dealing with `IntFlag` wen don't set int type for that field https://github.com/rancher/rancher/blob/release/v2.1/pkg/controllers/management/nodedriver/utils.go#L56-L59.

As a result, we store all the int flag value as string field in nodeConfig. So when it is building machine driver create command https://github.com/rancher/rancher/blob/release/v2.1/pkg/controllers/management/node/utils.go#L61-L66, we will never hit the `case int64:` and it works fine.

In 2.2, we fix that `FlagToFleid` in https://github.com/rancher/rancher/blob/master/pkg/controllers/management/drivers/nodedriver/utils.go#L56-L60. So we store int flag value as int. But when it comes to `buidCreateCommand`
https://github.com/rancher/rancher/blob/master/pkg/controllers/management/node/utils.go#L60-L78
, and the number type will be `json.Unmarshal` into `float64`. Then we can never add those parameters to the command as there is not a `case float64:`