### PR TITLE
Wait remove kd test

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -612,7 +612,8 @@ func KontainerDriver(schemas *types.Schemas, management *config.ScaledContext) {
 	schema.Formatter = kontainerdriver.NewFormatter(management)
 	schema.Store = kontainerdriver.NewStore(management, schema.Store)
 	kontainerDriverValidator := kontainerdriver.Validator{
-		KontainerDriverLister: management.Management.KontainerDrivers("").Controller().Lister(),
+		KontainerDriverLister:    management.Management.KontainerDrivers("").Controller().Lister(),
+		KontainerDriverInterface: management.Management.KontainerDrivers(""),
 	}
 	schema.Validator = kontainerDriverValidator.Validator
 }

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -316,9 +316,12 @@ def wait_remove_resource(admin_mc, request, remove_resource, timeout=DEFAULT_TIM
 
     def _cleanup(resource):
         def clean():
+            print("begin cleanup")
             remove_resource(resource)
             wait_until(lambda: client.reload(resource) is None)
+            print("cleanup done")
         request.addfinalizer(clean)
+
     return _cleanup
 
 

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -309,14 +309,14 @@ def remove_resource(admin_mc, request):
 
 
 @pytest.fixture()
-def wait_remove_resource(admin_mc, request, timeout=DEFAULT_TIMEOUT):
+def wait_remove_resource(admin_mc, request, remove_resource, timeout=DEFAULT_TIMEOUT):
     """Remove a resource after a test finishes even if the test fails and
     wait until deletion is confirmed."""
     client = admin_mc.client
 
     def _cleanup(resource):
         def clean():
-            client.delete(resource)
+            remove_resource(resource)
             wait_until(lambda: client.reload(resource) is None)
         request.addfinalizer(clean)
     return _cleanup

--- a/tests/core/test_kontainer_drivers.py
+++ b/tests/core/test_kontainer_drivers.py
@@ -153,41 +153,7 @@ def test_enabling_driver_exposes_schema(admin_mc, wait_remove_resource):
     verify_driver_in_types(admin_mc.client, kd)
 
 
-@pytest.mark.nonparallel
-def test_upgrade_changes_schema(admin_mc, wait_remove_resource):
-    client = admin_mc.client
-    URL = DRIVER_AMD64_URL
-    if platform.machine() == "aarch64":
-        URL = DRIVER_ARM64_URL
-    kd = client.create_kontainerDriver(
-        createDynamicSchema=True,
-        active=True,
-        url=URL
-    )
-    wait_remove_resource(kd)
 
-    kd = wait_for_condition('Active', 'True', admin_mc.client, kd,
-                            timeout=90)
-
-    verify_driver_in_types(client, kd)
-    kdSchema = client.schema.types[kd.name + 'EngineConfig']
-    assert 'specialTestingField' not in kdSchema.resourceFields
-
-    NEW_URL = NEW_DRIVER_URL
-    if platform.machine() == "aarch64":
-        NEW_URL = NEW_DRIVER_ARM64_URL
-    kd.url = NEW_URL
-    kd = client.update_by_id_kontainerDriver(kd.id, kd)
-
-    def schema_updated():
-        client.reload_schema()
-        kdSchema = client.schema.types[kd.name + 'EngineConfig']
-        return 'specialTestingField' in kdSchema.resourceFields
-
-    wait_until(schema_updated)
-
-    kdSchema = client.schema.types[kd.name + 'EngineConfig']
-    assert 'specialTestingField' in kdSchema.resourceFields
 
 
 @pytest.mark.nonparallel
@@ -270,3 +236,39 @@ def verify_driver_not_in_types(client, kd):
     wait_until(check)
     client.reload_schema()
     assert kd.name + 'EngineConfig' not in client.schema.types
+
+@pytest.mark.nonparallel
+def test_upgrade_changes_schema(admin_mc, wait_remove_resource):
+    client = admin_mc.client
+    URL = DRIVER_AMD64_URL
+    if platform.machine() == "aarch64":
+        URL = DRIVER_ARM64_URL
+    kd = client.create_kontainerDriver(
+        createDynamicSchema=True,
+        active=True,
+        url=URL
+    )
+    wait_remove_resource(kd)
+
+    kd = wait_for_condition('Active', 'True', admin_mc.client, kd,
+                            timeout=90)
+
+    verify_driver_in_types(client, kd)
+    kdSchema = client.schema.types[kd.name + 'EngineConfig']
+    assert 'specialTestingField' not in kdSchema.resourceFields
+
+    NEW_URL = NEW_DRIVER_URL
+    if platform.machine() == "aarch64":
+        NEW_URL = NEW_DRIVER_ARM64_URL
+    kd.url = NEW_URL
+    kd = client.update_by_id_kontainerDriver(kd.id, kd)
+
+    def schema_updated():
+        client.reload_schema()
+        kdSchema = client.schema.types[kd.name + 'EngineConfig']
+        return 'specialTestingField' in kdSchema.resourceFields
+
+    wait_until(schema_updated)
+
+    kdSchema = client.schema.types[kd.name + 'EngineConfig']
+    assert 'specialTestingField' in kdSchema.resourceFields

--- a/tests/core/test_kontainer_drivers.py
+++ b/tests/core/test_kontainer_drivers.py
@@ -52,7 +52,7 @@ def test_kontainer_driver_lifecycle(admin_mc, remove_resource,
         active=True,
         url=URL
     )
-    remove_resource(kd)
+    wait_remove_resource(kd)
 
     # Test that it is in downloading state while downloading
     kd = wait_for_condition('Downloaded', 'Unknown', admin_mc.client, kd)

--- a/tests/core/test_kontainer_drivers.py
+++ b/tests/core/test_kontainer_drivers.py
@@ -47,6 +47,7 @@ def test_kontainer_driver_lifecycle(admin_mc, remove_resource,
     URL = DRIVER_AMD64_URL
     if platform.machine() == "aarch64":
         URL = DRIVER_ARM64_URL
+    print("ln 50")
     kd = admin_mc.client.create_kontainerDriver(
         createDynamicSchema=True,
         active=True,
@@ -107,6 +108,8 @@ def test_kontainer_driver_lifecycle(admin_mc, remove_resource,
     admin_mc.client.delete(kd)
     # test driver is removed from schema after deletion
     verify_driver_not_in_types(admin_mc.client, kd)
+    print("test lifecycle done")
+
 
 
 @pytest.mark.nonparallel
@@ -117,6 +120,7 @@ def test_enabling_driver_exposes_schema(admin_mc, wait_remove_resource):
     URL = DRIVER_AMD64_URL
     if platform.machine() == "aarch64":
         URL = DRIVER_ARM64_URL
+        print("ln123")
     kd = admin_mc.client.create_kontainerDriver(
         createDynamicSchema=True,
         active=False,
@@ -151,6 +155,7 @@ def test_enabling_driver_exposes_schema(admin_mc, wait_remove_resource):
     kd.active = True
     admin_mc.client.update_by_id_kontainerDriver(kd.id, kd)
     verify_driver_in_types(admin_mc.client, kd)
+    print("test enable done")
 
 
 
@@ -163,13 +168,14 @@ def test_create_duplicate_driver_conflict(admin_mc, wait_remove_resource):
     URL = DRIVER_AMD64_URL
     if platform.machine() == "aarch64":
         URL = DRIVER_ARM64_URL
+        print("line 171")
     kd = admin_mc.client.create_kontainerDriver(
         createDynamicSchema=True,
         active=True,
         url=URL
     )
     wait_remove_resource(kd)
-    kd = wait_for_condition('Active', 'True', admin_mc.client, kd, timeout=90)
+    wait_for_condition('Active', 'True', admin_mc.client, kd, timeout=90)
 
     try:
         kd2 = admin_mc.client.create_kontainerDriver(
@@ -182,6 +188,7 @@ def test_create_duplicate_driver_conflict(admin_mc, wait_remove_resource):
     except ApiError as e:
         assert e.error.status == 409
         assert "Driver URL already in use:" in e.error.message
+        print("test create done")
 
 
 @pytest.mark.nonparallel
@@ -191,13 +198,14 @@ def test_update_duplicate_driver_conflict(admin_mc, wait_remove_resource):
     URL = DRIVER_AMD64_URL
     if platform.machine() == "aarch64":
         URL = DRIVER_ARM64_URL
+        print("ln 201")
     kd1 = admin_mc.client.create_kontainerDriver(
         createDynamicSchema=True,
         active=True,
         url=URL
     )
     wait_remove_resource(kd1)
-    kd1 = wait_for_condition('Active', 'True', admin_mc.client, kd1,
+    wait_for_condition('Active', 'True', admin_mc.client, kd1,
                              timeout=90)
 
     kd2 = admin_mc.client.create_kontainerDriver(
@@ -214,6 +222,7 @@ def test_update_duplicate_driver_conflict(admin_mc, wait_remove_resource):
     except ApiError as e:
         assert e.error.status == 409
         assert "Driver URL already in use:" in e.error.message
+        print("test dup done")
 
 
 def verify_driver_in_types(client, kd):
@@ -240,6 +249,7 @@ def verify_driver_not_in_types(client, kd):
 @pytest.mark.nonparallel
 def test_upgrade_changes_schema(admin_mc, wait_remove_resource):
     client = admin_mc.client
+    print("ln 252")
     URL = DRIVER_AMD64_URL
     if platform.machine() == "aarch64":
         URL = DRIVER_ARM64_URL
@@ -272,3 +282,4 @@ def test_upgrade_changes_schema(admin_mc, wait_remove_resource):
 
     kdSchema = client.schema.types[kd.name + 'EngineConfig']
     assert 'specialTestingField' in kdSchema.resourceFields
+    print("test upgrade done")


### PR DESCRIPTION
Add wait_remove to kd test
Problem: If a kontainer driver test is not cleaned up properly then other tests in the suite will fail making root cause more difficult
Solution:
test_kontainer_driver_lifecycle will now cleanup even if the test fails.