### PR TITLE
Configurable Helm chart TLS secret name

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -30,5 +30,5 @@ spec:
   tls:
   - hosts:
     - {{ .Values.hostname }}
-    secretName: tls-rancher-ingress
+    secretName: {{ .Values.tls.secretName }}
 {{- end }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -30,5 +30,5 @@ spec:
   tls:
   - hosts:
     - {{ .Values.hostname }}
-    secretName: {{ .Values.tls.secretName }}
+    secretName: {{ .Values.ingress.tls.secretName }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -52,6 +52,7 @@ ingress:
   tls:
     # rancher, letsEncrypt, secrets
     source: rancher
+    secretName: tls-rancher-ingress
 
 ### LetsEncrypt config ###
 # ProTip: The production environment only allows you to register a name 5 times a week.


### PR DESCRIPTION
Our TLS secret is used by different tools and it would help us to have the possibility to configure the secret used by the ingress.