### PR TITLE
Fix typo

### DIFF
--- a/pkg/api/customization/kontainerdriver/store.go
+++ b/pkg/api/customization/kontainerdriver/store.go
@@ -47,7 +47,7 @@ func (s *store) Delete(apiContext *types.APIContext, schema *types.Schema, id st
 
 	clustersWithKontainerDriver, err := s.ClusterIndexer.ByIndex(clusterByKontainerDriverKey, driver.Status.DisplayName)
 	if err != nil {
-		return nil, errorsutil.WithMessage(err, fmt.Sprintf("error determing if kontainer driver [%s] was in use", driver.Status.DisplayName))
+		return nil, errorsutil.WithMessage(err, fmt.Sprintf("error determining if kontainer driver [%s] was in use", driver.Status.DisplayName))
 	}
 
 	if len(clustersWithKontainerDriver) != 0 {

--- a/pkg/controllers/management/etcdbackup/etcdbackup.go
+++ b/pkg/controllers/management/etcdbackup/etcdbackup.go
@@ -157,7 +157,7 @@ func (c *Controller) doClusterBackupSync(cluster *v3.Cluster) error {
 	if cluster == nil || cluster.DeletionTimestamp != nil {
 		return nil
 	}
-	// check if the cluster is eligable for backup.
+	// check if the cluster is eligible for backup.
 	if !shouldBackup(cluster) {
 		return nil
 	}


### PR DESCRIPTION
Misspell Finds commonly misspelled English words

warning: "determing" is a misspelling of "determining" (misspell)
warning: "eligable" is a misspelling of "eligible" (misspell)