### PR TITLE
[WIP]update vendor

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -41,7 +41,7 @@ github.com/robfig/cron                        v1.1
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     a265edee9d1be1daf44670f2f8b187cc61b36c04
 github.com/rancher/types                      68532a907ed4fd6b14b839e779529c9963ae1765
-github.com/rancher/kontainer-engine           071b4a6da0600bbba904eda5a6645b8866812b96
+github.com/rancher/kontainer-engine           gke-update-nodeversion                   https://github.com/fyery-chen/kontainer-engine.git
 github.com/rancher/rke                        066f9300a81c680bb593e676d70aa47e2f0c4601
 
 gopkg.in/ldap.v2                              v2.5.0

--- a/vendor/github.com/rancher/kontainer-engine/drivers/gke/gke_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/gke/gke_driver.go
@@ -658,7 +658,7 @@ func (d *Driver) Update(ctx context.Context, info *types.ClusterInfo, opts *type
 	if newState.NodeVersion != "" {
 		log.Infof(ctx, "Updating node version to %v", newState.NodeVersion)
 		operation, err := svc.Projects.Zones.Clusters.NodePools.Update(state.ProjectID, state.Zone, state.Name, state.NodePoolID, &raw.UpdateNodePoolRequest{
-			NodeVersion: state.NodeVersion,
+			NodeVersion: newState.NodeVersion,
 		}).Context(ctx).Do()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Problem:
Users cannot upgrade k8s version from Rancher server.

Solution:
Updated the GKE update interface of kontainer-engine

Issue:
rancher/rancher#18976

Related PR:
https://github.com/rancher/kontainer-engine/pull/141