### PR TITLE
Revert change to nodeDriver schemas

### DIFF
--- a/pkg/controllers/management/drivers/nodedriver/utils.go
+++ b/pkg/controllers/management/drivers/nodedriver/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/rpc"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/docker/machine/libmachine/drivers/plugin/localbinary"
@@ -53,9 +54,11 @@ func FlagToField(flag cli.Flag) (string, v3.Field, error) {
 		field.Description = v.Usage
 		field.Default.StringValue = v.Value
 	case *cli.IntFlag:
+		// This will make the int flag appear as a string field in the rancher API, but we are doing this to maintain
+		// backward compatibility, at least until we fix a bug that prevents nodeDriver schemas from updating upon
+		// a Rancher upgrade
 		field.Description = v.Usage
-		field.Type = "int"
-		field.Default.IntValue = v.Value
+		field.Default.StringValue = strconv.Itoa(v.Value)
 	case *cli.BoolFlag:
 		field.Type = "boolean"
 		field.Description = v.Usage


### PR DESCRIPTION
In our v2.1 and earlier releases, we had a bug that caused machine driver
fields of type int to be presented in the Rancher API as string fields.

We fixed this on master, but later realized that it would be a breaking
API change. We could have dealt with just the breaking API change, but this
also exposed a bug that node driver schemas were not automatically updated
when Rancher was upgraded. The combination of fixing the int-to-string bug
but not fixing the update bug is too confusing. So, we are rolling back the
change to match how it was in v2.1.

We will have to fix these two bugs together at a later date.