### PR TITLE
Fix logging to es can't use char @ in password

### DIFF
--- a/pkg/controllers/user/logging/generator/cluster_template.go
+++ b/pkg/controllers/user/logging/generator/cluster_template.go
@@ -76,11 +76,11 @@ var ClusterTemplate = `{{ if .clusterTarget.CurrentTarget }}
     {{ if eq .clusterTarget.CurrentTarget "elasticsearch"}}
     @type elasticsearch
     include_tag_key  true
-    {{ if and .clusterTarget.ElasticsearchConfig.AuthUserName .clusterTarget.ElasticsearchConfig.AuthPassword}}
-    hosts {{.clusterTarget.WrapElasticsearch.Scheme}}://{{.clusterTarget.ElasticsearchConfig.AuthUserName}}:{{.clusterTarget.ElasticsearchConfig.AuthPassword}}@{{.clusterTarget.WrapElasticsearch.Host}}
-    {{else -}}
+    {{- if and .clusterTarget.ElasticsearchConfig.AuthUserName .clusterTarget.ElasticsearchConfig.AuthPassword}}
+    user {{.clusterTarget.ElasticsearchConfig.AuthUserName}}
+    password {{.clusterTarget.ElasticsearchConfig.AuthPassword}}
+    {{- end }}
     hosts {{.clusterTarget.ElasticsearchConfig.Endpoint}}    
-    {{end -}}
     logstash_format true
     logstash_prefix "{{.clusterTarget.ElasticsearchConfig.IndexPrefix}}"
     logstash_dateformat  {{.clusterTarget.WrapElasticsearch.DateFormat}}

--- a/pkg/controllers/user/logging/generator/project_template.go
+++ b/pkg/controllers/user/logging/generator/project_template.go
@@ -59,11 +59,11 @@ var ProjectTemplate = `{{range $i, $store := .projectTargets -}}
     {{ if eq $store.CurrentTarget "elasticsearch"}}
     @type elasticsearch
     include_tag_key  true
-    {{ if and $store.ElasticsearchConfig.AuthUserName $store.ElasticsearchConfig.AuthPassword}}
-    hosts {{$store.WrapElasticsearch.Scheme}}://{{$store.ElasticsearchConfig.AuthUserName}}:{{$store.ElasticsearchConfig.AuthPassword}}@{{$store.WrapElasticsearch.Host}}
-    {{else -}}
+    {{- if and $store.ElasticsearchConfig.AuthUserName $store.ElasticsearchConfig.AuthPassword}}
+    user {{$store.ElasticsearchConfig.AuthUserName}}
+    password {{$store.ElasticsearchConfig.AuthPassword}}
+    {{- end }}
     hosts {{$store.ElasticsearchConfig.Endpoint}}    
-    {{end -}}
 
     logstash_prefix "{{$store.ElasticsearchConfig.IndexPrefix}}"
     logstash_format true


### PR DESCRIPTION
**Problem:**
Rancher logging to elastic doesnt support passwords with special
characters like `@` and `#`.

**Solution:**
Use `user` and `password` field in fluentd es configuration
instead of adding them to es url.

https://github.com/rancher/rancher/issues/18835