### PR TITLE
Changed S3 Backups Path

### DIFF
--- a/pkg/controllers/management/etcdbackup/etcdbackup.go
+++ b/pkg/controllers/management/etcdbackup/etcdbackup.go
@@ -296,7 +296,7 @@ func getBackupFilename(snapshotName string, cluster *v3.Cluster) string {
 		return ""
 	}
 	target := cluster.Spec.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.S3BackupConfig
-	return fmt.Sprintf("https://s3-%s.amazonaws.com/%s/%s", target.Region, target.BucketName, snapshotName)
+	return fmt.Sprintf("https://s3.%s.amazonaws.com/%s/%s", target.Region, target.BucketName, snapshotName)
 }
 
 func (c *Controller) deleteS3Snapshot(b *v3.EtcdBackup) error {


### PR DESCRIPTION
If someone is in us-east-1 region the domain would be https://s3-us-east-1.amazonaws.com and AWS doesn't have DNS for this. If we still wanted to use the dash it would be https://s3-external-1.amazonaws.com which is confusing. So I changed it from dash to period. So domains would now look like this https://s3.us-east-1.amazonaws.com which also conforms to AWS standards for region and is less confusing.

https://docs.aws.amazon.com/general/latest/gr/rande.html
![Screen Shot 2019-03-21 at 12 00 47 PM](https://user-images.githubusercontent.com/3812216/54770347-0673a100-4bd1-11e9-882c-57306cf950d5.png)