### PR TITLE
Fix helm creating lots of configmaps

### DIFF
--- a/pkg/api/customization/app/app.go
+++ b/pkg/api/customization/app/app.go
@@ -151,7 +151,8 @@ func (w Wrapper) ActionHandler(actionName string, action *types.Action, apiConte
 		if valuesYaml != nil {
 			obj.Spec.ValuesYaml = convert.ToString(valuesYaml)
 		}
-
+		// indicate this a user driven action
+		pv3.AppConditionUserTriggeredAction.True(obj)
 		if _, err := w.AppGetter.Apps(namespace).Update(obj); err != nil {
 			return err
 		}
@@ -183,7 +184,8 @@ func (w Wrapper) ActionHandler(actionName string, action *types.Action, apiConte
 			obj.Annotations[creatorIDAnno] = w.UserManager.GetUser(apiContext)
 		}
 		obj.Spec.Files = appRevision.Status.Files
-
+		// indicate this a user driven action
+		pv3.AppConditionUserTriggeredAction.True(obj)
 		if _, err := w.AppGetter.Apps(namespace).Update(obj); err != nil {
 			return err
 		}

--- a/pkg/controllers/user/helm/common/common.go
+++ b/pkg/controllers/user/helm/common/common.go
@@ -88,7 +88,7 @@ func InjectDefaultRegistry(obj *v3.App) {
 // StartTiller start tiller server and return the listening address of the grpc address
 func StartTiller(context context.Context, port, probePort, namespace, kubeConfigPath string) error {
 	cmd := exec.Command(tillerName, "--listen", ":"+port, "--probe", ":"+probePort)
-	cmd.Env = []string{fmt.Sprintf("%s=%s", "KUBECONFIG", kubeConfigPath), fmt.Sprintf("%s=%s", "TILLER_NAMESPACE", namespace)}
+	cmd.Env = []string{fmt.Sprintf("%s=%s", "KUBECONFIG", kubeConfigPath), fmt.Sprintf("%s=%s", "TILLER_NAMESPACE", namespace), fmt.Sprintf("%s=%s", "TILLER_HISTORY_MAX", "1")}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
@@ -97,6 +97,7 @@ func StartTiller(context context.Context, port, probePort, namespace, kubeConfig
 	defer cmd.Wait()
 	select {
 	case <-context.Done():
+		logrus.Debug("Stopping Tiller")
 		return cmd.Process.Kill()
 	}
 }
@@ -127,8 +128,11 @@ func InstallCharts(rootDir, port string, obj *v3.App) error {
 
 	if v3.AppConditionForceUpgrade.IsUnknown(obj) {
 		commands = append(commands, forceUpgradeStr)
+		// don't leave force recreate on the object
+		v3.AppConditionForceUpgrade.True(obj)
 	}
-
+	// switch userTriggeredAction back
+	v3.AppConditionUserTriggeredAction.Unknown(obj)
 	cmd := exec.Command(helmName, commands...)
 	cmd.Env = []string{fmt.Sprintf("%s=%s", "HELM_HOST", "127.0.0.1:"+port)}
 	stderrBuf := &bytes.Buffer{}

--- a/pkg/controllers/user/helm/controller.go
+++ b/pkg/controllers/user/helm/controller.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	errorsutil "github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/controllers/management/compose/common"
 	"github.com/rancher/rancher/pkg/ref"
 	"github.com/rancher/rancher/pkg/systemaccount"
@@ -87,9 +88,18 @@ type Lifecycle struct {
 
 func (l *Lifecycle) Create(obj *v3.App) (runtime.Object, error) {
 	v3.AppConditionMigrated.True(obj)
+	v3.AppConditionUserTriggeredAction.Unknown(obj)
 	return obj, nil
 }
 
+/*
+Updated depends on several conditions:
+	AppConditionMigrated: protects upgrade path for apps <2.1
+	AppConditionInstalled: flips status in UI and drives logic
+	AppConditionDeployed: flips status in UI
+	AppConditionForceUpgrade: add destructive `--force` param to helm upgrade when set to Unknown
+	AppConditionUserTriggeredAction: Indicates when `upgrade` or `rollback` is called by the user
+*/
 func (l *Lifecycle) Updated(obj *v3.App) (runtime.Object, error) {
 	if obj.Spec.ExternalID == "" && len(obj.Spec.Files) == 0 {
 		return obj, nil
@@ -108,6 +118,7 @@ func (l *Lifecycle) Updated(obj *v3.App) (runtime.Object, error) {
 	if err != nil {
 		return obj, err
 	}
+
 	obj = newObj.(*v3.App)
 	appRevisionClient := l.AppRevisionGetter.AppRevisions(projectName)
 	if obj.Spec.AppRevisionName != "" {
@@ -115,21 +126,20 @@ func (l *Lifecycle) Updated(obj *v3.App) (runtime.Object, error) {
 		if err != nil {
 			return nil, err
 		}
-		if obj.Spec.ExternalID != "" {
-			if currentRevision.Status.ExternalID == obj.Spec.ExternalID && reflect.DeepEqual(currentRevision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(currentRevision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
-				if !v3.AppConditionForceUpgrade.IsTrue(obj) {
-					v3.AppConditionForceUpgrade.True(obj)
-				}
-				return obj, nil
+		/*
+			This if statement gates most of the logic for Update. We should only deploy the app when we actually want to.
+			But we call update when we may only want to change a UI status. In those cases, we should return here and not
+			go further. We want to deploy the app when:
+				* The current App revision is different than the app, ex. the app is different than it was before
+				* The force upgrade flag is set, where AppConditionForceUpgrade being unknown is equal to true.
+				* The user caused the action by way of clicking either upgrade or rollback
+		*/
+		if isSame(obj, currentRevision) && !v3.AppConditionForceUpgrade.IsUnknown(obj) &&
+			!v3.AppConditionUserTriggeredAction.IsTrue(obj) {
+			if !v3.AppConditionForceUpgrade.IsTrue(obj) {
+				v3.AppConditionForceUpgrade.True(obj)
 			}
-		}
-		if obj.Status.AppliedFiles != nil {
-			if reflect.DeepEqual(obj.Status.AppliedFiles, obj.Spec.Files) && reflect.DeepEqual(currentRevision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(currentRevision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
-				if !v3.AppConditionForceUpgrade.IsTrue(obj) {
-					v3.AppConditionForceUpgrade.True(obj)
-				}
-				return obj, nil
-			}
+			return obj, nil
 		}
 	}
 	created := false
@@ -209,6 +219,7 @@ func (l *Lifecycle) DeployApp(obj *v3.App) (*v3.App, error) {
 	var err error
 	if !v3.AppConditionInstalled.IsUnknown(obj) {
 		v3.AppConditionInstalled.Unknown(obj)
+		// update status in the UI
 		obj, err = l.AppGetter.Apps("").Update(obj)
 		if err != nil {
 			return obj, err
@@ -305,6 +316,12 @@ func (l *Lifecycle) Run(obj *v3.App, template, templateDir, notes string) error 
 		return err
 	}
 	if err := helmInstall(templateDir, kubeConfigPath, obj); err != nil {
+		// create an app revision so that user can decide to continue
+		err2 := l.createAppRevision(obj, template, notes, true)
+		if err2 != nil {
+			return errorsutil.Wrapf(err, "error encountered while creating appRevision %v",
+				err2)
+		}
 		return err
 	}
 	return l.createAppRevision(obj, template, notes, false)
@@ -372,4 +389,22 @@ func (l *Lifecycle) writeKubeConfig(obj *v3.App, tempDir string, remove bool) (s
 		return "", err
 	}
 	return kubeConfigPath, nil
+}
+
+func isSame(obj *v3.App, revision *v3.AppRevision) bool {
+	if obj.Spec.ExternalID != "" {
+		if revision.Status.ExternalID == obj.Spec.ExternalID && reflect.DeepEqual(revision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(revision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
+			return true
+		}
+		return false
+	}
+
+	if obj.Status.AppliedFiles != nil {
+		if reflect.DeepEqual(obj.Status.AppliedFiles, obj.Spec.Files) && reflect.DeepEqual(revision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(revision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
+			return true
+		}
+		return false
+	}
+
+	return false
 }


### PR DESCRIPTION
Problem: Helm/Tiller creates configmaps to track revision changes.
Rancher should use AppRevisions to do this but was not tracking AppRevisions
on failed helm upgrades. This caused rancher to run helm/tiller multiple
times on failing helm charts which created a large number of configmaps
quickly which would slow down the UI.

Solution: Rancher now correctly makes AppRevisions for failed helm
upgrades. Tiller has a max revision history of 1 (the minimum for
tiller to remain functional). Tiller will delete previous configmaps
the each time it is run. This also introduces the userTriggeredAction condition for cases where the helm controller should run regardless to carry out a user's intention. 
See https://github.com/rancher/rancher/issues/18571
See https://github.com/rancher/rancher/issues/17101
_Dependency_ : https://github.com/rancher/types/pull/786
_Test_: https://github.com/rancher/validation/pull/157