### PR TITLE
On cluster/project delete, remove system account created for it

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -49,7 +49,11 @@ func (cd *clusterDeploy) sync(key string, cluster *v3.Cluster) (runtime.Object, 
 		err, updateErr error
 	)
 
-	if key == "" || cluster == nil {
+	if cluster == nil || cluster.DeletionTimestamp != nil {
+		// remove the system account user created for this cluster
+		if err := cd.systemAccountManager.RemoveSystemAccount(key); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}
 

--- a/pkg/controllers/user/pipeline/controller/project/project.go
+++ b/pkg/controllers/user/pipeline/controller/project/project.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"github.com/rancher/rancher/pkg/pipeline/remote/model"
 	"github.com/rancher/rancher/pkg/pipeline/utils"
 	"github.com/rancher/rancher/pkg/ref"
@@ -15,8 +13,10 @@ import (
 	pv3 "github.com/rancher/types/apis/project.cattle.io/v3"
 	pclient "github.com/rancher/types/client/project/v3"
 	"github.com/rancher/types/config"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // This controller is responsible for initializing source code
@@ -60,6 +60,10 @@ func (l *Syncer) Sync(key string, obj *v3.Project) (runtime.Object, error) {
 		splits := strings.Split(key, "/")
 		if len(splits) == 2 {
 			projectID = splits[1]
+		}
+		// remove the system account created for this project
+		if err := l.systemAccountManager.RemoveSystemAccount(projectID); err != nil {
+			return nil, err
 		}
 		return nil, l.cleanInternalRegistryEntry(projectID)
 	}


### PR DESCRIPTION
When creating a cluster or project, we create a system user account, which creates a globalRoleBinding.
This user is not being removed when cluster/project is deleted, hence the user and corresponding globalRoleBinding are left behind.
This commit removes the user on cluster/project delete. And the user controller already removes the grb https://github.com/rancher/rancher/blob/release/v2.2/pkg/controllers/management/auth/user.go#L171
Addresses: https://github.com/rancher/rancher/issues/19018