### PR TITLE
Revert the change for alert controller name

### DIFF
--- a/pkg/controllers/user/alert/controller.go
+++ b/pkg/controllers/user/alert/controller.go
@@ -77,7 +77,7 @@ func Register(ctx context.Context, cluster *config.UserContext) {
 		clusterName:        cluster.ClusterName,
 	}
 	projects := cluster.Management.Management.Projects("")
-	projects.AddClusterScopedLifecycle(ctx, "project-precan-alertpoicy-controller", cluster.ClusterName, projectLifecycle)
+	projects.AddClusterScopedLifecycle(ctx, "project-precan-alert-controller", cluster.ClusterName, projectLifecycle)
 
 	statesyncer.StartStateSyncer(ctx, cluster, alertmanager)
 	initClusterPreCanAlerts(clusterAlertGroups, clusterAlertRules, cluster.ClusterName)


### PR DESCRIPTION
Issue: Cannot remove project from upgraded cluster.

Reason: the cause is that the name of the controller was changed. Lifecycle controllers cannot have name changes bc then old finalizers will not get cleaned up.

Solution: Change the name back

https://github.com/rancher/rancher/issues/19130