### PR TITLE
check for nil Backupconfig.Enabled and disable backup if nil

### DIFF
--- a/pkg/controllers/management/etcdbackup/etcdbackup.go
+++ b/pkg/controllers/management/etcdbackup/etcdbackup.go
@@ -83,8 +83,7 @@ func (c *Controller) Create(b *v3.EtcdBackup) (runtime.Object, error) {
 		cluster.Spec.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig == nil {
 		return b, fmt.Errorf("[etcd-backup] cluster doesn't have a backup config")
 	}
-	if cluster.Spec.RancherKubernetesEngineConfig != nil &&
-		cluster.Spec.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig != nil &&
+	if cluster.Spec.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.Enabled == nil ||
 		!*cluster.Spec.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.Enabled {
 		return b, fmt.Errorf("[etcd-backup] backup is disabled for cluster [%s]", cluster.Name)
 	}
@@ -386,9 +385,8 @@ func shouldBackup(cluster *v3.Cluster) bool {
 		logrus.Debugf("[etcd-backup] No backup config for cluster [%s]", cluster.Name)
 		return false
 	}
-	if etcdService.BackupConfig != nil &&
-		etcdService.BackupConfig.Enabled != nil &&
-		!*etcdService.BackupConfig.Enabled {
+	if etcdService.BackupConfig.Enabled == nil ||
+		!*cluster.Spec.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.Enabled {
 		logrus.Debugf("[etcd-backup] Backup is disabled cluster [%s]", cluster.Name)
 		return false
 	}


### PR DESCRIPTION
Fix for new panic I saw in 2.2.0 rc17 
Also fixed: shouldBackup will return false if Enabled is null.

```2019/03/25 13:39:36 [ERROR] EtcdBackupController c-lzksq/c-lzksq-rl-gf6wc recovered from panic "runtime error: invalid memory address or nil pointer dereference". (err=<nil>) Call stack:
/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:72
/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:154
/usr/local/go/src/runtime/asm_amd64.s:522
/usr/local/go/src/runtime/panic.go:513
/usr/local/go/src/runtime/panic.go:82
/usr/local/go/src/runtime/signal_unix.go:390
/go/src/github.com/rancher/rancher/pkg/controllers/management/etcdbackup/etcdbackup.go:88
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_etcd_backup_lifecycle_adapter.go:29
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/lifecycle/object.go:219
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/lifecycle/object.go:191
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/lifecycle/object.go:181
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/lifecycle/object.go:219
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/lifecycle/object.go:64
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/lifecycle/object.go:45
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_etcd_backup_lifecycle_adapter.go:56
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_etcd_backup_controller.go:134
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/controller/generic_controller.go:348
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/controller/generic_controller.go:258
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/controller/generic_controller.go:246
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/controller/generic_controller.go:238
/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133
/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134
/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
/usr/local/go/src/runtime/asm_amd64.s:1333
2019/03/25 13:39:36 [ERROR] EtcdBackupController c-lzksq/c-lzksq-rl-gf6wc recovered from panic "runtime error: invalid memory address or nil pointer dereference". (err=<nil>) Call stack:
/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:72
/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:154
/usr/local/go/src/runtime/asm_amd64.s:522
/usr/local/go/src/runtime/panic.go:513
/usr/local/go/src/runtime/panic.go:82
/usr/local/go/src/runtime/signal_unix.go:390
/go/src/github.com/rancher/rancher/pkg/controllers/management/etcdbackup/etcdbackup.go:88
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_etcd_backup_lifecycle_adapter.go:29
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/lifecycle/object.go:219
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/lifecycle/object.go:191
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/lifecycle/object.go:181
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/lifecycle/object.go:219
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/lifecycle/object.go:64
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/lifecycle/object.go:45
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_etcd_backup_lifecycle_adapter.go:56
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_etcd_backup_controller.go:134
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/controller/generic_controller.go:348
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/controller/generic_controller.go:258
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/controller/generic_controller.go:246
/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/controller/generic_controller.go:238
/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133
/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134
/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
/usr/local/go/src/runtime/asm_amd64.s:1333
```