### PR TITLE
Fix cluster driver delete while provisioning

### DIFF
--- a/pkg/api/customization/kontainerdriver/formatter.go
+++ b/pkg/api/customization/kontainerdriver/formatter.go
@@ -17,7 +17,7 @@ func NewFormatter(manangement *config.ScaledContext) types.Formatter {
 	clusterInformer := manangement.Management.Clusters("").Controller().Informer()
 	// use an indexer instead of expensive k8s api calls
 	clusterInformer.AddIndexers(map[string]cache.IndexFunc{
-		clusterByGenericEngineConfigKey: clusterByGenericEngineConfig,
+		clusterByGenericEngineConfigKey: clusterByKontainerDriver,
 	})
 
 	format := Format{
@@ -28,9 +28,9 @@ func NewFormatter(manangement *config.ScaledContext) types.Formatter {
 
 const clusterByGenericEngineConfigKey = "genericEngineConfig"
 
-// IndexFunction that uses cluster's genericEngineConfig map[string]interface{}
-// to lookup the driverName
-func clusterByGenericEngineConfig(obj interface{}) ([]string, error) {
+// clusterByKontainerDriver is an indexer function that uses the cluster genericEngineConfig
+// driverName field
+func clusterByKontainerDriver(obj interface{}) ([]string, error) {
 	cluster, ok := obj.(*v3.Cluster)
 	if !ok {
 		return []string{}, nil

--- a/tests/integration/test_kontainer_drivers.py
+++ b/tests/integration/test_kontainer_drivers.py
@@ -23,6 +23,7 @@ DRIVER_ARM64_URL = "https://github.com/jianghang8421/" \
 
 
 def test_builtin_drivers_are_present(admin_mc):
+    """Test if builtin kd are present and cannot be deleted via API or UI"""
     admin_mc.client.reload_schema()
     types = admin_mc.client.schema.types
 
@@ -39,6 +40,11 @@ def test_builtin_drivers_are_present(admin_mc):
         # verify has no delete link because its built in
         kd = admin_mc.client.by_id_kontainer_driver(name.lower())
         assert not hasattr(kd.links, 'remove')
+        # assert cannot delete it via API
+        with pytest.raises(ApiError) as e:
+            admin_mc.client.delete(kd)
+
+        assert e.value.error.status == 405
 
 
 @pytest.mark.nonparallel


### PR DESCRIPTION
Problem: A cluster driver could be deleted when there were active
clusters that depended on that driver.

Solution: The API will not crash if a cluster driver is unable to be
removed. Kontainer drivers are no longer able to be removed via the UI
or API if there is a cluster that uses that driver.
Fix https://github.com/rancher/rancher/issues/18761