### PR TITLE
Update OTC hash

### DIFF
--- a/app/machinedriver_data.go
+++ b/app/machinedriver_data.go
@@ -62,7 +62,7 @@ func addMachineDrivers(management *config.ManagementContext) error {
 		return err
 	}
 	if err := addMachineDriver("otc", "https://dockermachinedriver.obs.eu-de.otc.t-systems.com/docker-machine-driver-otc",
-		"", "b4c05f6598dcfac7a8f10899aaac3d42", []string{"*.otc.t-systems.com"}, false, false, management); err != nil {
+		"", "3f793ebb0ebd9477b9166ec542f77e25", []string{"*.otc.t-systems.com"}, false, false, management); err != nil {
 		return err
 	}
 	if err := addMachineDriver("packet", "https://github.com/packethost/docker-machine-driver-packet/releases/download/v0.1.4/docker-machine-driver-packet_linux-amd64.zip",


### PR DESCRIPTION
New binary has been released

Maybe we need to update the binary to another place. So we can control the version.

https://dockermachinedriver.obs.eu-de.otc.t-systems.com/docker-machine-driver-otc

https://github.com/rancher/rancher/issues/19223