### PR TITLE
Add namespace filters for projects

### DIFF
--- a/pkg/api/store/projectsetter/project_setter_test.go
+++ b/pkg/api/store/projectsetter/project_setter_test.go
@@ -1,0 +1,73 @@
+package projectsetter
+
+import (
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/pkg/project"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"testing"
+)
+
+// Tests that getMatchingNamespaces returns the proper amount namespaces given duplicates, empty slices, and multiple
+// matching namespaces.
+func TestOptionsCorrectNamespaces(t *testing.T) {
+	dummyAPIContext := &types.APIContext{
+		Method:     http.MethodGet,
+		SubContext: map[string]string{"/v3/schemas/project": "p-test123"},
+	}
+
+	namespaceList := []*v1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "ns1",
+				Annotations: map[string]string{project.ProjectIDAnn: "p-test123"},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "ns2",
+				Annotations: map[string]string{project.ProjectIDAnn: "p-test1234"},
+			},
+		},
+	}
+
+	namespaces := getMatchingNamespaces(*dummyAPIContext, namespaceList)
+
+	if len(namespaces) == 0 {
+		t.Error("Matching namespace was not returned")
+	}
+
+	namespaceList = []*v1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "ns1",
+				Annotations: map[string]string{project.ProjectIDAnn: "p-test123"},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "ns2",
+				Annotations: map[string]string{project.ProjectIDAnn: "p-test1234"},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "ns3",
+				Annotations: map[string]string{project.ProjectIDAnn: "p-test123"},
+			},
+		},
+	}
+
+	namespaces = getMatchingNamespaces(*dummyAPIContext, namespaceList)
+	if len(namespaces) != 2 {
+		t.Error("Should be able to find multiple namespaces")
+	}
+
+	namespaceList = []*v1.Namespace{}
+	namespaces = getMatchingNamespaces(*dummyAPIContext, namespaceList)
+
+	if len(namespaces) > 0 {
+		t.Error("Namespaces should not be returned from empty namespace list")
+	}
+}

--- a/pkg/api/store/projectsetter/store.go
+++ b/pkg/api/store/projectsetter/store.go
@@ -5,8 +5,11 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/rancher/pkg/clustermanager"
+	"github.com/rancher/rancher/pkg/project"
 	"github.com/rancher/types/apis/core/v1"
 	"github.com/rancher/types/client/cluster/v3"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func New(store types.Store, manager *clustermanager.Manager) types.Store {
@@ -14,15 +17,33 @@ func New(store types.Store, manager *clustermanager.Manager) types.Store {
 		ClusterManager: manager,
 	}
 	return &transform.Store{
-		Store:             store,
+		Store: projectSetter{
+			store,
+			manager,
+		},
 		Transformer:       t.object,
 		ListTransformer:   t.list,
 		StreamTransformer: t.stream,
 	}
 }
 
+type projectSetter struct {
+	types.Store
+
+	ClusterManager *clustermanager.Manager
+}
+
 type transformer struct {
 	ClusterManager *clustermanager.Manager
+}
+
+func (p projectSetter) List(apiContext *types.APIContext, schema *types.Schema, opt *types.QueryOptions) ([]map[string]interface{}, error) {
+	options := *opt
+	if err := p.setOptionsNamespaces(apiContext, &options); err != nil {
+		return nil, err
+	}
+
+	return p.Store.List(apiContext, schema, &options)
 }
 
 func (t *transformer) object(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, opt *types.QueryOptions) (map[string]interface{}, error) {
@@ -41,6 +62,56 @@ func (t *transformer) list(apiContext *types.APIContext, schema *types.Schema, d
 	}
 
 	return data, nil
+}
+
+// Retrieves project from api sub-context, then finds associated namespaces. If found, assigns to options.
+func (p projectSetter) setOptionsNamespaces(apiContext *types.APIContext, opt *types.QueryOptions) error {
+	clusterName := p.ClusterManager.ClusterName(apiContext)
+	if clusterName == "" {
+		return nil
+	}
+
+	clusterContext, err := p.ClusterManager.UserContext(clusterName)
+	if err != nil {
+		return err
+	}
+
+	namespaces, err := clusterContext.Core.Namespaces("").Controller().Lister().List("", labels.NewSelector())
+	if err != nil {
+		return err
+	}
+
+	matchingNamespaces := getMatchingNamespaces(*apiContext, namespaces)
+
+	if opt == nil {
+		opt = &types.QueryOptions{}
+	}
+
+	// It is important this field is set to not nil even if there are no namespaces, so that no namespaces are queried instead of all namespaces
+	if opt.Namespaces == nil {
+		opt.Namespaces = make([]string, 0)
+	}
+
+	// Not using namespaces in opt.Conditions to avoid conflicts
+	opt.Namespaces = append(opt.Namespaces, matchingNamespaces...)
+
+	return nil
+}
+
+func getMatchingNamespaces(apiContext types.APIContext, namespaces []*k8sv1.Namespace) []string {
+	var matchingNamespaces []string
+
+	projectID := apiContext.SubContext["/v3/schemas/project"]
+	if projectID == "" {
+		return matchingNamespaces
+	}
+
+	for _, ns := range namespaces {
+		if ns.Annotations[project.ProjectIDAnn] == projectID {
+			matchingNamespaces = append(matchingNamespaces, ns.Name)
+		}
+	}
+	return matchingNamespaces
 }
 
 func (t *transformer) stream(apiContext *types.APIContext, schema *types.Schema, data chan map[string]interface{}, opt *types.QueryOptions) (chan map[string]interface{}, error) {

--- a/vendor.conf
+++ b/vendor.conf
@@ -39,7 +39,7 @@ github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d756
 github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
-github.com/rancher/norman                     98366575743bf58017f4faeb71513cf81fd22b0c
+github.com/rancher/norman                     c55b1eed181c98c6f3985d306608ffcbbbc5898b
 github.com/rancher/types                      e3a7b1174de6d7d1d202bbc4e919d9cc99d6b9a6
 github.com/rancher/kontainer-engine           071b4a6da0600bbba904eda5a6645b8866812b96
 github.com/rancher/rke                        v0.2.0

--- a/vendor/github.com/rancher/norman/types/server_types.go
+++ b/vendor/github.com/rancher/norman/types/server_types.go
@@ -184,6 +184,8 @@ type QueryOptions struct {
 	Pagination *Pagination
 	Conditions []*QueryCondition
 	Options    map[string]string
+	// Set namespaces to an empty array will result in an empty response
+	Namespaces []string
 }
 
 type ReferenceValidator interface {


### PR DESCRIPTION
Problem:
Requests associated with a particular project are not being filtered. Consequently, requests for projects that posses a fraction of total resources are taking longer than necessary to return.

Solution:
Identify namespaces for given project and use them to filter project related requests.

Issues:
https://github.com/rancher/rancher/issues/18870
https://github.com/rancher/rancher/issues/18522
https://github.com/rancher/rancher/issues/18295
https://github.com/rancher/rancher/issues/16605