### PR TITLE
Adjust Monitoring status detection logic

### DIFF
--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -5,17 +5,16 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	kcluster "github.com/rancher/kontainer-engine/cluster"
-	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/rancher/pkg/controllers/user/nslabels"
 	"github.com/rancher/rancher/pkg/monitoring"
 	"github.com/rancher/rancher/pkg/node"
 	"github.com/rancher/rancher/pkg/ref"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rke/pki"
+	corev1 "github.com/rancher/types/apis/core/v1"
 	mgmtv3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/apis/project.cattle.io/v3"
 	k8scorev1 "k8s.io/api/core/v1"
@@ -40,6 +39,7 @@ type etcdTLSConfig struct {
 type clusterHandler struct {
 	clusterName          string
 	cattleClustersClient mgmtv3.ClusterInterface
+	agentEndpointsLister corev1.EndpointsLister
 	app                  *appHandler
 }
 
@@ -64,10 +64,6 @@ func (ch *clusterHandler) sync(key string, cluster *mgmtv3.Cluster) (runtime.Obj
 		}
 
 		cpy = updated
-	}
-
-	if err != nil {
-		err = errors.Wrapf(err, "unable to sync Cluster %s", clusterTag)
 	}
 
 	return cpy, err
@@ -99,17 +95,38 @@ func (ch *clusterHandler) doSync(cluster *mgmtv3.Cluster) error {
 			}
 		}
 
-		appAnswers, err := ch.deployApp(appName, appTargetNamespace, appProjectName, cluster, etcdTLSConfigs, systemComponentMap)
+		_, err = ch.deployApp(appName, appTargetNamespace, appProjectName, cluster, etcdTLSConfigs, systemComponentMap)
 		if err != nil {
 			mgmtv3.ClusterConditionMonitoringEnabled.Unknown(cluster)
 			mgmtv3.ClusterConditionMonitoringEnabled.Message(cluster, err.Error())
 			return errors.Wrap(err, "failed to deploy monitoring")
 		}
 
-		if err := ch.detectAppComponentsWhileInstall(appName, appTargetNamespace, cluster, appAnswers); err != nil {
+		isReady, err := ch.isPrometheusReady(cluster)
+		if err != nil {
 			mgmtv3.ClusterConditionMonitoringEnabled.Unknown(cluster)
 			mgmtv3.ClusterConditionMonitoringEnabled.Message(cluster, err.Error())
-			return errors.Wrap(err, "failed to detect the installation status of monitoring components")
+			return err
+		}
+		if !isReady {
+			mgmtv3.ClusterConditionMonitoringEnabled.Unknown(cluster)
+			mgmtv3.ClusterConditionMonitoringEnabled.Message(cluster, "prometheus is not ready")
+			return nil
+		}
+
+		if cluster.Status.MonitoringStatus == nil {
+			cluster.Status.MonitoringStatus = &mgmtv3.MonitoringStatus{
+				GrafanaEndpoint: fmt.Sprintf("/k8s/clusters/%s/api/v1/namespaces/%s/services/http:access-grafana:80/proxy/", cluster.Name, appTargetNamespace),
+			}
+		}
+
+		_, err = ConditionMetricExpressionDeployed.DoUntilTrue(cluster.Status.MonitoringStatus, func() (status *mgmtv3.MonitoringStatus, e error) {
+			return status, ch.deployMetrics(cluster)
+		})
+		if err != nil {
+			mgmtv3.ClusterConditionMonitoringEnabled.Unknown(cluster)
+			mgmtv3.ClusterConditionMonitoringEnabled.Message(cluster, err.Error())
+			return errors.Wrap(err, "failed to deploy monitoring metrics")
 		}
 
 		mgmtv3.ClusterConditionMonitoringEnabled.True(cluster)
@@ -121,14 +138,16 @@ func (ch *clusterHandler) doSync(cluster *mgmtv3.Cluster) error {
 			return errors.Wrap(err, "failed to withdraw monitoring")
 		}
 
-		if err := ch.detectAppComponentsWhileUninstall(appName, appTargetNamespace, cluster); err != nil {
+		if err := ch.withdrawMetrics(cluster); err != nil {
 			mgmtv3.ClusterConditionMonitoringEnabled.Unknown(cluster)
 			mgmtv3.ClusterConditionMonitoringEnabled.Message(cluster, err.Error())
-			return errors.Wrap(err, "failed to detect the uninstallation status of monitoring components")
+			return errors.Wrap(err, "failed to withdraw monitoring metrics")
 		}
 
 		mgmtv3.ClusterConditionMonitoringEnabled.False(cluster)
 		mgmtv3.ClusterConditionMonitoringEnabled.Message(cluster, "")
+
+		cluster.Status.MonitoringStatus = nil
 	}
 
 	return nil
@@ -368,118 +387,6 @@ func (ch *clusterHandler) deployApp(appName, appTargetNamespace string, appProje
 	return appAnswers, nil
 }
 
-func (ch *clusterHandler) detectAppComponentsWhileInstall(appName, appTargetNamespace string, cluster *mgmtv3.Cluster, appAnswers map[string]string) error {
-	if cluster.Status.MonitoringStatus == nil {
-		cluster.Status.MonitoringStatus = &mgmtv3.MonitoringStatus{
-			Conditions: []mgmtv3.MonitoringCondition{
-				{Type: mgmtv3.ClusterConditionType(ConditionGrafanaDeployed), Status: k8scorev1.ConditionFalse},
-				{Type: mgmtv3.ClusterConditionType(ConditionNodeExporterDeployed), Status: k8scorev1.ConditionFalse},
-				{Type: mgmtv3.ClusterConditionType(ConditionKubeStateExporterDeployed), Status: k8scorev1.ConditionFalse},
-				{Type: mgmtv3.ClusterConditionType(ConditionPrometheusDeployed), Status: k8scorev1.ConditionFalse},
-				{Type: mgmtv3.ClusterConditionType(ConditionMetricExpressionDeployed), Status: k8scorev1.ConditionFalse},
-			},
-		}
-	}
-	monitoringStatus := cluster.Status.MonitoringStatus
-
-	enabledExporterNode := convert.ToBool(appAnswers["exporter-node.enabled"])
-	if enabledExporterNode {
-		ConditionNodeExporterDeployed.Add(monitoringStatus)
-	} else {
-		ConditionNodeExporterDeployed.Del(monitoringStatus)
-	}
-
-	enabledExporterKubeState := convert.ToBool(appAnswers["exporter-kube-state.enabled"])
-	if enabledExporterKubeState {
-		ConditionKubeStateExporterDeployed.Add(monitoringStatus)
-	} else {
-		ConditionKubeStateExporterDeployed.Del(monitoringStatus)
-	}
-
-	checkers := make([]func() error, 0, len(monitoringStatus.Conditions))
-	if !ConditionGrafanaDeployed.IsTrue(monitoringStatus) {
-		checkers = append(checkers, func() error {
-			return isGrafanaDeployed(ch.app.agentDeploymentClient, appTargetNamespace, appName, monitoringStatus, cluster.Name)
-		})
-	}
-	if enabledExporterNode && !ConditionNodeExporterDeployed.IsTrue(monitoringStatus) {
-		checkers = append(checkers, func() error {
-			return isNodeExporterDeployed(ch.app.agentDaemonSetClient, appTargetNamespace, appName, monitoringStatus)
-		})
-	}
-	if enabledExporterKubeState && !ConditionKubeStateExporterDeployed.IsTrue(monitoringStatus) {
-		checkers = append(checkers, func() error {
-			return isKubeStateExporterDeployed(ch.app.agentDeploymentClient, appTargetNamespace, appName, monitoringStatus)
-		})
-	}
-	if !ConditionPrometheusDeployed.IsTrue(monitoringStatus) {
-		checkers = append(checkers, func() error {
-			return isPrometheusDeployed(ch.app.agentStatefulSetClient, appTargetNamespace, appName, monitoringStatus)
-		})
-	}
-	if !ConditionMetricExpressionDeployed.IsTrue(monitoringStatus) {
-		checkers = append(checkers, func() error {
-			return isMetricExpressionDeployed(cluster.Name, ch.app.cattleClusterGraphClient, ch.app.cattleMonitorMetricClient, monitoringStatus)
-		})
-	}
-
-	if len(checkers) == 0 {
-		return nil
-	}
-
-	err := stream(checkers...)
-	if err != nil {
-		time.Sleep(5 * time.Second)
-	}
-
-	return err
-}
-
-func (ch *clusterHandler) detectAppComponentsWhileUninstall(appName, appTargetNamespace string, cluster *mgmtv3.Cluster) error {
-	if cluster.Status.MonitoringStatus == nil {
-		return nil
-	}
-	monitoringStatus := cluster.Status.MonitoringStatus
-
-	checkers := make([]func() error, 0, len(monitoringStatus.Conditions))
-	if !ConditionGrafanaDeployed.IsFalse(monitoringStatus) {
-		checkers = append(checkers, func() error {
-			return isGrafanaWithdrew(ch.app.agentDeploymentClient, appTargetNamespace, appName, monitoringStatus)
-		})
-	}
-	if !ConditionNodeExporterDeployed.IsFalse(monitoringStatus) {
-		checkers = append(checkers, func() error {
-			return isNodeExporterWithdrew(ch.app.agentDaemonSetClient, appTargetNamespace, appName, monitoringStatus)
-		})
-	}
-	if !ConditionKubeStateExporterDeployed.IsFalse(monitoringStatus) {
-		checkers = append(checkers, func() error {
-			return isKubeStateExporterWithdrew(ch.app.agentDeploymentClient, appTargetNamespace, appName, monitoringStatus)
-		})
-	}
-	if !ConditionPrometheusDeployed.IsFalse(monitoringStatus) {
-		checkers = append(checkers, func() error {
-			return isPrometheusWithdrew(ch.app.agentStatefulSetClient, appTargetNamespace, appName, monitoringStatus)
-		})
-	}
-	if !ConditionMetricExpressionDeployed.IsFalse(monitoringStatus) {
-		checkers = append(checkers, func() error {
-			return isMetricExpressionWithdrew(cluster.Name, ch.app.cattleClusterGraphClient, ch.app.cattleMonitorMetricClient, monitoringStatus)
-		})
-	}
-
-	if len(checkers) == 0 {
-		return nil
-	}
-
-	err := stream(checkers...)
-	if err != nil {
-		time.Sleep(5 * time.Second)
-	}
-
-	return err
-}
-
 func getClusterTag(cluster *mgmtv3.Cluster) string {
 	return fmt.Sprintf("%s(%s)", cluster.Name, cluster.Spec.DisplayName)
 }
@@ -498,4 +405,65 @@ func getCertName(name string) string {
 
 func getKeyName(name string) string {
 	return fmt.Sprintf("%s-key.pem", name)
+}
+
+func (ch *clusterHandler) deployMetrics(cluster *mgmtv3.Cluster) error {
+	clusterName := cluster.Name
+
+	for _, metric := range preDefinedClusterMetrics {
+		newObj := metric.DeepCopy()
+		newObj.Namespace = clusterName
+
+		_, err := ch.app.cattleMonitorMetricClient.Create(newObj)
+		if err != nil && !k8serrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	for _, graph := range preDefinedClusterGraph {
+		newObj := graph.DeepCopy()
+		newObj.Namespace = clusterName
+
+		_, err := ch.app.cattleClusterGraphClient.Create(newObj)
+		if err != nil && !k8serrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (ch *clusterHandler) withdrawMetrics(cluster *mgmtv3.Cluster) error {
+	clusterName := cluster.Name
+
+	for _, metric := range preDefinedClusterMetrics {
+		err := ch.app.cattleMonitorMetricClient.DeleteNamespaced(clusterName, metric.Name, &metav1.DeleteOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	for _, graph := range preDefinedClusterGraph {
+		err := ch.app.cattleClusterGraphClient.DeleteNamespaced(clusterName, graph.Name, &metav1.DeleteOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (ch *clusterHandler) isPrometheusReady(cluster *mgmtv3.Cluster) (bool, error) {
+	svcName, namespace, _ := monitoring.ClusterPrometheusEndpoint()
+
+	endpoints, err := ch.agentEndpointsLister.Get(namespace, svcName)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get %s/%s endpoints", namespace, svcName)
+	}
+
+	if len(endpoints.Subsets) == 0 || len(endpoints.Subsets[0].Addresses) == 0 {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/pkg/controllers/user/monitoring/cluster_monitoring_enabled_handler.go
+++ b/pkg/controllers/user/monitoring/cluster_monitoring_enabled_handler.go
@@ -1,0 +1,38 @@
+package monitoring
+
+import (
+	"github.com/rancher/rancher/pkg/monitoring"
+	mgmtv3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	k8scorev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// clusterMonitoringEnabledHandler syncs the Cluster Monitoring Prometheus status.
+type clusterMonitoringEnabledHandler struct {
+	clusterName             string
+	cattleClusterController mgmtv3.ClusterController
+	cattleClusterLister     mgmtv3.ClusterLister
+}
+
+// sync will trigger clusterHandler sync loop, if Cluster Monitoring is enabling.
+func (h *clusterMonitoringEnabledHandler) sync(key string, endpoints *k8scorev1.Endpoints) (runtime.Object, error) {
+	endpointName, _, _ := monitoring.ClusterPrometheusEndpoint()
+	if endpoints == nil || endpoints.DeletionTimestamp != nil || endpoints.Name != endpointName {
+		return endpoints, nil
+	}
+
+	cluster, err := h.cattleClusterLister.Get(metav1.NamespaceAll, h.clusterName)
+	if err != nil || cluster.DeletionTimestamp != nil {
+		return endpoints, err
+	}
+
+	// only consider enabling monitoring
+	if !cluster.Spec.EnableClusterMonitoring {
+		return endpoints, nil
+	}
+
+	// trigger clusterHandler sync loop
+	h.cattleClusterController.Enqueue(metav1.NamespaceAll, h.clusterName)
+	return endpoints, nil
+}

--- a/pkg/controllers/user/monitoring/handleComponents.go
+++ b/pkg/controllers/user/monitoring/handleComponents.go
@@ -6,17 +6,14 @@ import (
 	"github.com/pkg/errors"
 	appsv1beta2 "github.com/rancher/types/apis/apps/v1beta2"
 	mgmtv3 "github.com/rancher/types/apis/management.cattle.io/v3"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
-	ConditionGrafanaDeployed           = condition(mgmtv3.MonitoringConditionGrafanaDeployed)
-	ConditionNodeExporterDeployed      = condition(mgmtv3.MonitoringConditionNodeExporterDeployed)
-	ConditionKubeStateExporterDeployed = condition(mgmtv3.MonitoringConditionKubeStateExporterDeployed)
-	ConditionPrometheusDeployed        = condition(mgmtv3.MonitoringConditionPrometheusDeployed)
-	ConditionMetricExpressionDeployed  = condition(mgmtv3.MonitoringConditionMetricExpressionDeployed)
+	ConditionGrafanaDeployed          = condition(mgmtv3.MonitoringConditionGrafanaDeployed)
+	ConditionPrometheusDeployed       = condition(mgmtv3.MonitoringConditionPrometheusDeployed)
+	ConditionMetricExpressionDeployed = condition(mgmtv3.MonitoringConditionMetricExpressionDeployed)
 )
 
 // All component names base on rancher-monitoring chart
@@ -33,7 +30,7 @@ func isGrafanaDeployed(agentDeploymentClient appsv1beta2.DeploymentInterface, ap
 		}
 
 		status := obj.Status
-		if status.Replicas != (status.AvailableReplicas - status.UnavailableReplicas) {
+		if status.Replicas != status.ReadyReplicas {
 			return nil, errors.New("Grafana Deployment is deploying")
 		}
 
@@ -63,83 +60,6 @@ func isGrafanaWithdrew(agentDeploymentClient appsv1beta2.DeploymentInterface, ap
 	return err
 }
 
-func isNodeExporterDeployed(agentDaemonSetClient appsv1beta2.DaemonSetInterface, appNamespace, appNameSuffix string, monitoringStatus *mgmtv3.MonitoringStatus) error {
-	_, err := ConditionNodeExporterDeployed.DoUntilTrue(monitoringStatus, func() (*mgmtv3.MonitoringStatus, error) {
-		obj, err := agentDaemonSetClient.GetNamespaced(appNamespace, "exporter-node-"+appNameSuffix, metav1.GetOptions{})
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				return nil, errors.New("Node Exporter DaemonSet isn't deployed")
-			}
-
-			return nil, errors.Wrap(err, "failed to get Node Exporter DaemonSet information")
-		}
-
-		if obj.Status.DesiredNumberScheduled != obj.Status.CurrentNumberScheduled {
-			return nil, errors.New("Node Exporter DaemonSet is deploying")
-		}
-
-		return monitoringStatus, nil
-	})
-
-	return err
-}
-
-func isNodeExporterWithdrew(agentDaemonSetClient appsv1beta2.DaemonSetInterface, appNamespace, appNameSuffix string, monitoringStatus *mgmtv3.MonitoringStatus) error {
-	_, err := ConditionNodeExporterDeployed.DoUntilFalse(monitoringStatus, func() (*mgmtv3.MonitoringStatus, error) {
-		_, err := agentDaemonSetClient.GetNamespaced(appNamespace, "exporter-node-"+appNameSuffix, metav1.GetOptions{})
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				return monitoringStatus, nil
-			}
-
-			return nil, errors.Wrap(err, "failed to get Node Exporter DaemonSet information")
-		}
-
-		return nil, errors.New("Node Exporter DaemonSet is withdrawing")
-	})
-
-	return err
-}
-
-func isKubeStateExporterDeployed(agentDeploymentClient appsv1beta2.DeploymentInterface, appNamespace, appNameSuffix string, monitoringStatus *mgmtv3.MonitoringStatus) error {
-	_, err := ConditionKubeStateExporterDeployed.DoUntilTrue(monitoringStatus, func() (*mgmtv3.MonitoringStatus, error) {
-		obj, err := agentDeploymentClient.GetNamespaced(appNamespace, "exporter-kube-state-"+appNameSuffix, metav1.GetOptions{})
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				return nil, errors.New("Kube State Exporter Deployment isn't deployed")
-			}
-
-			return nil, errors.Wrap(err, "failed to get Kube State Exporter Deployment information")
-		}
-
-		status := obj.Status
-		if status.Replicas != (status.AvailableReplicas - status.UnavailableReplicas) {
-			return nil, errors.New("Kube State Exporter Deployment is deploying")
-		}
-
-		return monitoringStatus, nil
-	})
-
-	return err
-}
-
-func isKubeStateExporterWithdrew(agentDeploymentClient appsv1beta2.DeploymentInterface, appNamespace, appNameSuffix string, monitoringStatus *mgmtv3.MonitoringStatus) error {
-	_, err := ConditionKubeStateExporterDeployed.DoUntilFalse(monitoringStatus, func() (*mgmtv3.MonitoringStatus, error) {
-		_, err := agentDeploymentClient.GetNamespaced(appNamespace, "exporter-kube-state-"+appNameSuffix, metav1.GetOptions{})
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				return monitoringStatus, nil
-			}
-
-			return nil, errors.Wrap(err, "failed to get Kube State Exporter Deployment information")
-		}
-
-		return nil, errors.New("Kube State Exporter Deployment is withdrawing")
-	})
-
-	return err
-}
-
 func isPrometheusDeployed(agentStatefulSetClient appsv1beta2.StatefulSetInterface, appNamespace, appNameSuffix string, monitoringStatus *mgmtv3.MonitoringStatus) error {
 	_, err := ConditionPrometheusDeployed.DoUntilTrue(monitoringStatus, func() (*mgmtv3.MonitoringStatus, error) {
 		obj, err := agentStatefulSetClient.GetNamespaced(appNamespace, "prometheus-"+appNameSuffix, metav1.GetOptions{})
@@ -151,7 +71,7 @@ func isPrometheusDeployed(agentStatefulSetClient appsv1beta2.StatefulSetInterfac
 			return nil, errors.Wrap(err, "failed to get Prometheus StatefulSet information")
 		}
 
-		if obj.Status.Replicas != obj.Status.CurrentReplicas {
+		if obj.Status.Replicas != obj.Status.ReadyReplicas {
 			return nil, errors.New("Prometheus StatefulSet is deploying")
 		}
 
@@ -176,50 +96,4 @@ func isPrometheusWithdrew(agentStatefulSetClient appsv1beta2.StatefulSetInterfac
 	})
 
 	return err
-}
-
-func isMetricExpressionDeployed(clusterName string, clusterGraphClient mgmtv3.ClusterMonitorGraphInterface, monitorMetricsClient mgmtv3.MonitorMetricInterface, monitoringStatus *mgmtv3.MonitoringStatus) error {
-	_, err := ConditionMetricExpressionDeployed.DoUntilTrue(monitoringStatus, func() (*mgmtv3.MonitoringStatus, error) {
-		for _, metric := range preDefinedClusterMetrics {
-			newObj := metric.DeepCopy()
-			newObj.Namespace = clusterName
-			if _, err := monitorMetricsClient.Create(newObj); err != nil && !apierrors.IsAlreadyExists(err) {
-				return monitoringStatus, err
-			}
-		}
-		for _, graph := range preDefinedClusterGraph {
-			newObj := graph.DeepCopy()
-			newObj.Namespace = clusterName
-			if _, err := clusterGraphClient.Create(newObj); err != nil && !apierrors.IsAlreadyExists(err) {
-				return monitoringStatus, err
-			}
-		}
-		return monitoringStatus, nil
-	})
-
-	if err != nil {
-		return errors.Wrapf(err, "failed to deploy metric expression into Cluster %s", clusterName)
-	}
-	return nil
-}
-
-func isMetricExpressionWithdrew(clusterName string, clusterGraphClient mgmtv3.ClusterMonitorGraphInterface, monitorMetricsClient mgmtv3.MonitorMetricInterface, monitoringStatus *mgmtv3.MonitoringStatus) error {
-	_, err := ConditionMetricExpressionDeployed.DoUntilFalse(monitoringStatus, func() (*mgmtv3.MonitoringStatus, error) {
-		for _, metric := range preDefinedClusterMetrics {
-			if err := monitorMetricsClient.DeleteNamespaced(clusterName, metric.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-				return monitoringStatus, err
-			}
-		}
-		for _, graph := range preDefinedClusterGraph {
-			if err := clusterGraphClient.DeleteNamespaced(clusterName, graph.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-				return monitoringStatus, err
-			}
-		}
-		return monitoringStatus, nil
-	})
-
-	if err != nil {
-		return errors.Wrapf(err, "failed to deploy metric expression into Cluster %s", clusterName)
-	}
-	return nil
 }


### PR DESCRIPTION
**Problem:**
After enabling Monitoring, Rancher dashboard cannot perceive cluster level Prometheus is working or not. 

**Solution:**
- Don't reconcile Conditions of `MonitoringStatus`, which cause so many useless logs, https://github.com/rancher/rancher/issues/17733. Focusing on `MonitoringEnabled` condition is enought, it needs to change UI logic, @loganhz : 

![image](https://user-images.githubusercontent.com/3394724/55209160-22ec8a80-521c-11e9-981b-cf61d559ba4e.png)

- Setup a handler to watch the cluster level Prometheus StatefulSet is ready or not

**Issue:**
- https://github.com/rancher/rancher/issues/17733
- https://github.com/rancher/rancher/issues/19278