### PR TITLE
[2.2] Inject custom ca cert to publish catalog containers

### DIFF
--- a/pkg/pipeline/engine/jenkins/convert.go
+++ b/pkg/pipeline/engine/jenkins/convert.go
@@ -236,6 +236,9 @@ StageLoop:
 }
 
 func (c *jenkinsPipelineConverter) configPublishCatalogContainer(container *v1.Container, step *v3.Step) error {
+	if c.opts.gitCaCerts != "" {
+		c.injectGitCaCertToContainer(container)
+	}
 	config := step.PublishCatalogConfig
 	container.Image = images.Resolve(mv3.ToolsSystemImages.PipelineSystemImages.KubeApply)
 	envs := map[string]string{

--- a/pkg/pipeline/engine/jenkins/mappper.go
+++ b/pkg/pipeline/engine/jenkins/mappper.go
@@ -268,14 +268,7 @@ func (c *jenkinsPipelineConverter) injectGitCaCert(pod *v1.Pod) {
 	}
 	for i, container := range pod.Spec.Containers {
 		if container.Name == utils.JenkinsAgentContainerName {
-			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{
-				Name:  "GIT_SSL_CAINFO",
-				Value: utils.GitCaCertPath + "/ca.crt",
-			})
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, v1.VolumeMount{
-				Name:      utils.GitCaCertVolumeName,
-				MountPath: utils.GitCaCertPath,
-			})
+			c.injectGitCaCertToContainer(&pod.Spec.Containers[i])
 			break
 		}
 	}
@@ -284,6 +277,17 @@ func (c *jenkinsPipelineConverter) injectGitCaCert(pod *v1.Pod) {
 		VolumeSource: v1.VolumeSource{
 			EmptyDir: &v1.EmptyDirVolumeSource{},
 		},
+	})
+}
+
+func (c *jenkinsPipelineConverter) injectGitCaCertToContainer(container *v1.Container) {
+	container.Env = append(container.Env, v1.EnvVar{
+		Name:  "GIT_SSL_CAINFO",
+		Value: utils.GitCaCertPath + "/ca.crt",
+	})
+	container.VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{
+		Name:      utils.GitCaCertVolumeName,
+		MountPath: utils.GitCaCertPath,
 	})
 }
 


### PR DESCRIPTION
For release/v2.2
Address issue: https://github.com/rancher/rancher/issues/19313

Problem:
When users configure a custom git ca cert, it is not available for the publish catalog steps.

Solution:
Inject the custom ca cert to publish catalog containers.