### PR TITLE
Fix hight CPU load when enabling Monitoring in local cluster

### DIFF
--- a/pkg/controllers/user/monitoring/config_refresh_handler.go
+++ b/pkg/controllers/user/monitoring/config_refresh_handler.go
@@ -101,16 +101,16 @@ func (h *ConfigRefreshHandler) getProjectNamespaces(projectID string) ([]string,
 		return nil, err
 	}
 	var rtn []string
-	defer sort.Strings(rtn)
 	for _, ns := range nsList {
 		rtn = append(rtn, ns.Name)
 	}
+
+	sort.Strings(rtn)
 	return rtn, nil
 }
 
 func getAnnotationNamespaces(obj *monitoringv1.Prometheus) ([]string, error) {
 	var rtn []string
-	defer sort.Strings(rtn)
 	data, ok := obj.Annotations[projectNSAnnotation]
 	if !ok {
 		return rtn, nil
@@ -121,6 +121,7 @@ func getAnnotationNamespaces(obj *monitoringv1.Prometheus) ([]string, error) {
 		return rtn, err
 	}
 
+	sort.Strings(rtn)
 	return rtn, nil
 }
 


### PR DESCRIPTION
**Problem:**
`defer sort.Strings(rtn)` cannot sort the real rtn before return, then
this cause the Prometheus CRD update loop may never stop.

**Solution:**
Use a execution function to wrap

**Issue:**
https://github.com/rancher/rancher/issues/19248