### PR TITLE
Adjust NewPrometheusQuery for Monitoring

### DIFF
--- a/pkg/api/customization/monitor/cluster_graph_action.go
+++ b/pkg/api/customization/monitor/cluster_graph_action.go
@@ -73,7 +73,7 @@ func (h *ClusterGraphHandler) QuerySeriesAction(actionName string, action *types
 	defer cancel()
 
 	svcName, svcNamespace, svcPort := monitorutil.ClusterPrometheusEndpoint()
-	prometheusQuery, err := NewPrometheusQuery(reqContext, clusterName, token, svcNamespace, svcName, svcPort, h.dialerFactory)
+	prometheusQuery, err := NewPrometheusQuery(reqContext, clusterName, token, svcNamespace, svcName, svcPort, h.dialerFactory, userContext)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/customization/monitor/metric_action.go
+++ b/pkg/api/customization/monitor/metric_action.go
@@ -95,7 +95,7 @@ func (h *MetricHandler) Action(actionName string, action *types.Action, apiConte
 		reqContext, cancel := context.WithTimeout(context.Background(), prometheusReqTimeout)
 		defer cancel()
 
-		prometheusQuery, err := NewPrometheusQuery(reqContext, clusterName, token, svcNamespace, svcName, svcPort, h.dialerFactory)
+		prometheusQuery, err := NewPrometheusQuery(reqContext, clusterName, token, svcNamespace, svcName, svcPort, h.dialerFactory, userContext)
 		if err != nil {
 			return err
 		}
@@ -152,7 +152,7 @@ func (h *MetricHandler) Action(actionName string, action *types.Action, apiConte
 		defer cancel()
 
 		svcName, svcNamespace, svcPort := monitorutil.ClusterPrometheusEndpoint()
-		prometheusQuery, err := NewPrometheusQuery(reqContext, clusterName, token, svcNamespace, svcName, svcPort, h.dialerFactory)
+		prometheusQuery, err := NewPrometheusQuery(reqContext, clusterName, token, svcNamespace, svcName, svcPort, h.dialerFactory, userContext)
 		if err != nil {
 			return err
 		}
@@ -200,7 +200,7 @@ func (h *MetricHandler) Action(actionName string, action *types.Action, apiConte
 		defer cancel()
 
 		svcName, svcNamespace, svcPort := monitorutil.ProjectPrometheusEndpoint(projectName)
-		prometheusQuery, err := NewPrometheusQuery(reqContext, clusterName, token, svcNamespace, svcName, svcPort, h.dialerFactory)
+		prometheusQuery, err := NewPrometheusQuery(reqContext, clusterName, token, svcNamespace, svcName, svcPort, h.dialerFactory, userContext)
 		if err != nil {
 			return err
 		}

--- a/pkg/api/customization/monitor/project_graph_action.go
+++ b/pkg/api/customization/monitor/project_graph_action.go
@@ -69,7 +69,7 @@ func (h *ProjectGraphHandler) QuerySeriesAction(actionName string, action *types
 	defer cancel()
 
 	svcName, svcNamespace, svcPort := monitorutil.ClusterPrometheusEndpoint()
-	prometheusQuery, err := NewPrometheusQuery(reqContext, clusterName, token, svcNamespace, svcName, svcPort, h.dialerFactory)
+	prometheusQuery, err := NewPrometheusQuery(reqContext, clusterName, token, svcNamespace, svcName, svcPort, h.dialerFactory, userContext)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/user/controllers.go
+++ b/pkg/controllers/user/controllers.go
@@ -91,6 +91,7 @@ func RegisterFollower(ctx context.Context, cluster *config.UserContext, kubeConf
 	cluster.Core.Services("").Controller()
 	cluster.RBAC.ClusterRoleBindings("").Controller()
 	cluster.RBAC.RoleBindings("").Controller()
+	cluster.Core.Endpoints("").Controller()
 	return nil
 }
 


### PR DESCRIPTION
**Problem:**
Using Service to query metric expressions will increase the pressure on
the DNS service within the cluster

**Solution:**
Replace by ClusterIP

**Issue:**
https://github.com/rancher/rancher/issues/19292