### PR TITLE
Expose more params on GlobalDNSProvider and set them as answers to the app 

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     03b89d4fb7143786491cee420102775a803fbed1
-github.com/rancher/types                      db1c229e453fc86e2bdc72ca10e22fc896b7e494
+github.com/rancher/types                      ecb463d3eb096b3e02a473f9ce9a77c64d29641b
 github.com/rancher/kontainer-engine           7606e7e7a2dcad29f22758ad689a00ea622c2d1f
 github.com/rancher/rke                        c89198b9ff2fc00b0a1c0e0c07fde5f41a83d50c
 

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/globaldns_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/globaldns_types.go
@@ -52,13 +52,18 @@ type GlobalDNSProviderSpec struct {
 }
 
 type Route53ProviderConfig struct {
-	AccessKey string `json:"accessKey" norman:"notnullable,required,minLength=1"`
-	SecretKey string `json:"secretKey" norman:"notnullable,required,minLength=1,type=password"`
+	AccessKey       string `json:"accessKey" norman:"notnullable,required,minLength=1"`
+	SecretKey       string `json:"secretKey" norman:"notnullable,required,minLength=1,type=password"`
+	CredentialsPath string `json:"credentialsPath" norman:"default=/.aws"`
+	RoleArn         string `json:"roleArn,omitempty"`
+	Region          string `json:"region" norman:"default=us-east-1"`
+	ZoneType        string `json:"zoneType" norman:"default=public"`
 }
 
 type CloudflareProviderConfig struct {
-	APIKey   string `json:"apiKey" norman:"notnullable,required,minLength=1,type=password"`
-	APIEmail string `json:"apiEmail" norman:"notnullable,required,minLength=1"`
+	APIKey       string `json:"apiKey" norman:"notnullable,required,minLength=1,type=password"`
+	APIEmail     string `json:"apiEmail" norman:"notnullable,required,minLength=1"`
+	ProxySetting string `json:"proxySetting" norman:"default=true"`
 }
 
 type UpdateGlobalDNSTargetsInput struct {

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cloudflare_provider_config.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cloudflare_provider_config.go
@@ -1,12 +1,14 @@
 package client
 
 const (
-	CloudflareProviderConfigType          = "cloudflareProviderConfig"
-	CloudflareProviderConfigFieldAPIEmail = "apiEmail"
-	CloudflareProviderConfigFieldAPIKey   = "apiKey"
+	CloudflareProviderConfigType              = "cloudflareProviderConfig"
+	CloudflareProviderConfigFieldAPIEmail     = "apiEmail"
+	CloudflareProviderConfigFieldAPIKey       = "apiKey"
+	CloudflareProviderConfigFieldProxySetting = "proxySetting"
 )
 
 type CloudflareProviderConfig struct {
-	APIEmail string `json:"apiEmail,omitempty" yaml:"apiEmail,omitempty"`
-	APIKey   string `json:"apiKey,omitempty" yaml:"apiKey,omitempty"`
+	APIEmail     string `json:"apiEmail,omitempty" yaml:"apiEmail,omitempty"`
+	APIKey       string `json:"apiKey,omitempty" yaml:"apiKey,omitempty"`
+	ProxySetting string `json:"proxySetting,omitempty" yaml:"proxySetting,omitempty"`
 }

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_route53provider_config.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_route53provider_config.go
@@ -1,12 +1,20 @@
 package client
 
 const (
-	Route53ProviderConfigType           = "route53ProviderConfig"
-	Route53ProviderConfigFieldAccessKey = "accessKey"
-	Route53ProviderConfigFieldSecretKey = "secretKey"
+	Route53ProviderConfigType                 = "route53ProviderConfig"
+	Route53ProviderConfigFieldAccessKey       = "accessKey"
+	Route53ProviderConfigFieldCredentialsPath = "credentialsPath"
+	Route53ProviderConfigFieldRegion          = "region"
+	Route53ProviderConfigFieldRoleArn         = "roleArn"
+	Route53ProviderConfigFieldSecretKey       = "secretKey"
+	Route53ProviderConfigFieldZoneType        = "zoneType"
 )
 
 type Route53ProviderConfig struct {
-	AccessKey string `json:"accessKey,omitempty" yaml:"accessKey,omitempty"`
-	SecretKey string `json:"secretKey,omitempty" yaml:"secretKey,omitempty"`
+	AccessKey       string `json:"accessKey,omitempty" yaml:"accessKey,omitempty"`
+	CredentialsPath string `json:"credentialsPath,omitempty" yaml:"credentialsPath,omitempty"`
+	Region          string `json:"region,omitempty" yaml:"region,omitempty"`
+	RoleArn         string `json:"roleArn,omitempty" yaml:"roleArn,omitempty"`
+	SecretKey       string `json:"secretKey,omitempty" yaml:"secretKey,omitempty"`
+	ZoneType        string `json:"zoneType,omitempty" yaml:"zoneType,omitempty"`
 }

--- a/vendor/github.com/rancher/types/image/mirror.go
+++ b/vendor/github.com/rancher/types/image/mirror.go
@@ -20,6 +20,7 @@ func Mirror(image string) string {
 	image = strings.Replace(image, "alpine/git", "rancher/alpine-git", 1)
 	image = strings.Replace(image, "prom/", "rancher/prom-", 1)
 	image = strings.Replace(image, "quay.io/pires", "rancher", 1)
+	image = strings.Replace(image, "coredns/", "rancher/coredns-", 1)
 
 	Mirrors[image] = orig
 	return image

--- a/vendor/github.com/rancher/types/vendor.conf
+++ b/vendor/github.com/rancher/types/vendor.conf
@@ -2,5 +2,5 @@
 github.com/rancher/types
 
 github.com/pkg/errors v0.8.0
-github.com/rancher/norman 03b89d4fb7143786491cee420102775a803fbed1
+github.com/rancher/norman 01a9966237719f0ccad07194cb4ee161d7431495
 github.com/coreos/prometheus-operator         v0.25.0 


### PR DESCRIPTION
Refers types: https://github.com/rancher/types/pull/778

Sets additional parameters configured on the GlobalDNSProvider Object. Also, now on update, we will update only the GlobalDNSProvider settings to the App answers and not update entire answers map - so if user has added any extra answers underneath, we dont wipe everything out.

rancher/rancher#19251