### PR TITLE
Increase size of parent cache

### DIFF
--- a/pkg/api/store/pod/owner.go
+++ b/pkg/api/store/pod/owner.go
@@ -2,10 +2,9 @@ package pod
 
 import (
 	"fmt"
-	"time"
-
 	"strings"
 
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/values"
@@ -13,11 +12,10 @@ import (
 	"github.com/rancher/rancher/pkg/ref"
 	"github.com/rancher/types/apis/project.cattle.io/v3/schema"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/cache"
 )
 
 var (
-	ownerCache = cache.NewLRUExpireCache(1000)
+	ownerCache, _ = lru.New(100000)
 )
 
 type key struct {
@@ -65,7 +63,7 @@ func getOwnerWithKind(apiContext *types.APIContext, namespace, ownerKind, name s
 	ownerCache.Add(key, value{
 		Kind: kind,
 		Name: name,
-	}, time.Hour)
+	})
 
 	return kind, name, nil
 }
@@ -112,7 +110,7 @@ func SaveOwner(apiContext *types.APIContext, kind, name string, data map[string]
 	ownerCache.Add(key, value{
 		Kind: parentKind,
 		Name: parentName,
-	}, time.Hour)
+	})
 }
 
 func resolveWorkloadID(apiContext *types.APIContext, data map[string]interface{}) string {


### PR DESCRIPTION
Problem:
Requests are taking a long time, particularly pod requests. If there are a large amount of resources (over 1k) records are shifted out of the cache before they are ever accessed. This causes a large amount of misses, forcing the parent information to be retrieved. This retrieval can take >50ms per item.

Solution:
Increased size of parent cache to 100k from 1k. Size of cache has increased 10x and misses have been largely reduced.

_Note: object being cached has small memory footprint, and should not lead to large increase of memory_

Issues:
https://github.com/rancher/rancher/issues/18870
https://github.com/rancher/rancher/issues/18522
https://github.com/rancher/rancher/issues/18295