### PR TITLE
Update Norman

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -39,7 +39,7 @@ github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d756
 github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
-github.com/rancher/norman                     e10534b012b0c9b3b7fb12002cd06aecf8917ae3
+github.com/rancher/norman                     98366575743bf58017f4faeb71513cf81fd22b0c
 github.com/rancher/types                      e3a7b1174de6d7d1d202bbc4e919d9cc99d6b9a6
 github.com/rancher/kontainer-engine           071b4a6da0600bbba904eda5a6645b8866812b96
 github.com/rancher/rke                        v0.2.0

--- a/vendor/github.com/rancher/norman/clientbase/common.go
+++ b/vendor/github.com/rancher/norman/clientbase/common.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -216,7 +217,9 @@ func NewAPIClient(opts *ClientOpts) (APIBaseClient, error) {
 	if err != nil {
 		return result, err
 	}
-	defer resp.Body.Close()
+	defer func(closer io.Closer) {
+		closer.Close()
+	}(resp.Body)
 
 	if resp.StatusCode != 200 {
 		return result, NewAPIError(resp, opts.URL)
@@ -242,7 +245,9 @@ func NewAPIClient(opts *ClientOpts) (APIBaseClient, error) {
 		if err != nil {
 			return result, err
 		}
-		defer resp.Body.Close()
+		defer func(closer io.Closer) {
+			closer.Close()
+		}(resp.Body)
 
 		if resp.StatusCode != 200 {
 			return result, NewAPIError(resp, schemasURLs)

--- a/vendor/github.com/rancher/norman/clientbase/ops.go
+++ b/vendor/github.com/rancher/norman/clientbase/ops.go
@@ -120,6 +120,12 @@ func (a *APIOperations) DoNext(nextURL string, respObject interface{}) error {
 }
 
 func (a *APIOperations) DoModify(method string, url string, createObj interface{}, respObject interface{}) error {
+	if createObj == nil {
+		createObj = map[string]string{}
+	}
+	if respObject == nil {
+		respObject = &map[string]interface{}{}
+	}
 	bodyContent, err := json.Marshal(createObj)
 	if err != nil {
 		return err

--- a/vendor/github.com/rancher/norman/parse/collection.go
+++ b/vendor/github.com/rancher/norman/parse/collection.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	defaultLimit = int64(1000)
-	maxLimit     = int64(3000)
+	maxLimit     = int64(10000)
 )
 
 func QueryOptions(apiContext *types.APIContext, schema *types.Schema) types.QueryOptions {
@@ -67,7 +67,7 @@ func parsePagination(apiContext *types.APIContext) *types.Pagination {
 			return result
 		}
 
-		if limitInt > maxLimit {
+		if limitInt > maxLimit || limitInt == -1 {
 			result.Limit = &maxLimit
 		} else if limitInt >= 0 {
 			result.Limit = &limitInt


### PR DESCRIPTION
Problem:
Response times are too slow for resources such as pods. The UI is making paged requests. Since response are paginated after processing, each paged response takes about the same amount of time for the backend to process as a full response. Pagination is not being used to fragment results and -1 is being passed as a parameter by the UI.

Solution:
Norman now provides a recognized option for opting out of pagination. A value of -1 will prevent the response from being paginated.

Issue:
https://github.com/rancher/rancher/issues/18870
#18522
#18295