### PR TITLE
Disable previous enabling Project Monitoring

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -566,6 +566,13 @@ func Pipeline(schemas *types.Schemas, management *config.ScaledContext, clusterM
 
 func Project(schemas *types.Schemas, management *config.ScaledContext) {
 	schema := schemas.Schema(&managementschema.Version, client.ProjectType)
+
+	// delete monitoring resource action
+	delete(schema.ResourceActions, "disableMonitoring")
+	delete(schema.ResourceActions, "editMonitoring")
+	delete(schema.ResourceActions, "enableMonitoring")
+	delete(schema.ResourceActions, "viewMonitoring")
+
 	schema.Formatter = projectaction.Formatter
 	handler := &projectaction.Handler{
 		Projects:       management.Management.Projects(""),


### PR DESCRIPTION
**Problem:**
Project Monitoring will cause permission leak.

**Solution:**
- Prevent any actions for Project Monitoring
- Disable any previous enabling Project Monitoring