### PR TITLE
Fix shadowing of keyPairName

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -41,7 +41,7 @@ github.com/robfig/cron                        v1.1
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     c55b1eed181c98c6f3985d306608ffcbbbc5898b
 github.com/rancher/types                      1f8a7696aafde37fd40be4b30ca59c272a5970e9
-github.com/rancher/kontainer-engine           383cd276bc67501382d9667a8c367090c83d752f
+github.com/rancher/kontainer-engine           7606e7e7a2dcad29f22758ad689a00ea622c2d1f
 github.com/rancher/rke                        c89198b9ff2fc00b0a1c0e0c07fde5f41a83d50c
 
 gopkg.in/ldap.v2                              v2.5.0

--- a/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
@@ -494,7 +494,7 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 		stack, err := d.createStack(svc, getVPCStackName(state.DisplayName), displayName, vpcTemplate, []string{},
 			[]*cloudformation.Parameter{})
 		if err != nil {
-			return info, fmt.Errorf("error creating stack: %v", err)
+			return info, fmt.Errorf("error creating stack with VPC template: %v", err)
 		}
 
 		securityGroupsString := getParameterValueFromOutput("SecurityGroups", stack.Stacks[0].Outputs)
@@ -534,7 +534,7 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 		stack, err := d.createStack(svc, getServiceRoleName(state.DisplayName), displayName, serviceRoleTemplate,
 			[]string{cloudformation.CapabilityCapabilityIam}, nil)
 		if err != nil {
-			return info, fmt.Errorf("error creating stack: %v", err)
+			return info, fmt.Errorf("error creating stack with service role template: %v", err)
 		}
 
 		roleARN = getParameterValueFromOutput("RoleArn", stack.Stacks[0].Outputs)
@@ -587,7 +587,7 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 	keyPairName := state.KeyPairName
 
 	if keyPairName == "" {
-		keyPairName := getEC2KeyPairName(state.DisplayName)
+		keyPairName = getEC2KeyPairName(state.DisplayName)
 		_, err = ec2svc.CreateKeyPair(&ec2.CreateKeyPairInput{
 			KeyName: aws.String(keyPairName),
 		})
@@ -652,7 +652,7 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions, _ *ty
 			{ParameterKey: aws.String("PublicIp"), ParameterValue: aws.String(strconv.FormatBool(publicIP))},
 		})
 	if err != nil {
-		return info, fmt.Errorf("error creating stack: %v", err)
+		return info, fmt.Errorf("error creating stack with worker nodes template: %v", err)
 	}
 
 	nodeInstanceRole := getParameterValueFromOutput("NodeInstanceRole", stack.Stacks[0].Outputs)


### PR DESCRIPTION
Problem:  Key pair name was shadowed causing the assignment to be
ineffective

Solution: Avoid re-declartion of keyPairName within if-statement.
Also formatting changes by gofmt -s and additonal context for
cloudformation failures.
Dependency: https://github.com/rancher/kontainer-engine/pull/150
Fixs https://github.com/rancher/rancher/issues/19483