### PR TITLE
Detect Content-Type before gzip compression

### DIFF
--- a/server/responsewriter/gzip.go
+++ b/server/responsewriter/gzip.go
@@ -23,6 +23,10 @@ type gzipResponseWriter struct {
 }
 
 func (g gzipResponseWriter) Write(b []byte) (int, error) {
+	if g.Header().Get("Content-Type") == "" {
+		// If Content-Type is not set, detect it to keep consistent with the non-gzip way, otherwise it falls back to application/x-gzip
+		g.Header().Set("Content-Type", http.DetectContentType(b))
+	}
 	return g.Writer.Write(b)
 }
 


### PR DESCRIPTION
Problem:
Some APIs can break on Firefox browser with gzip encoding.

Solution:
Detect Content-Type header before gzip compression

Notes:
1. The broken APIs returns `Content-Type: application/x-gzip`
2. Per the [net/http description](https://golang.org/pkg/net/http/):
>// If WriteHeader has not yet been called, Write calls
	// WriteHeader(http.StatusOK) before writing the data. If the Header
	// does not contain a Content-Type line, Write adds a Content-Type set
	// to the result of passing the initial 512 bytes of written data to
	// DetectContentType.

When DetectContentType is called after gzip-writes, it falls back to the `Content-Type: application/x-gzip`