### PR TITLE
[fix #14905] Allow relative chart url

### DIFF
--- a/pkg/catalog/helm/helm.go
+++ b/pkg/catalog/helm/helm.go
@@ -79,6 +79,14 @@ func (h *Helm) request(pathURL, method string) (*http.Response, error) {
 		return nil, err
 	}
 
+	if !baseEndpoint.IsAbs() {
+		helmURL, err := url.Parse(h.url)
+		if err != nil {
+			return nil, err
+		}
+		baseEndpoint = helmURL.ResolveReference(baseEndpoint)
+	}
+
 	if len(h.username) > 0 && len(h.password) > 0 {
 		baseEndpoint.User = url.UserPassword(h.username, h.password)
 	}


### PR DESCRIPTION
Hello!

Some chart repos, for example `cert-manager`, uses relative chart urls:
```yaml
apiVersion: v1
entries:
  cert-manager:
    # ...
    urls:
    - charts/cert-manager-v0.7.0.tgz
```
This cause rancher error:
```
[ERROR] Failed to load chart: Error fetching helm URLs: [Error in HTTP GET of [charts/cert-manager-v0.7.0.tgz], error: Get charts/cert-manager-v0.7.0.tgz: unsupported protocol scheme ""]
```
This small PR resolves relative chart url to an absolute from repo url. It would be very cool to see this PR in 2.2.2, because it allows to install such important app as `cert-manager` via rancher interface!

Related:
https://github.com/rancher/rancher/issues/14905
https://github.com/helm/helm/pull/2512