### PR TITLE
Add content handler to gzip chain

### DIFF
--- a/server/responsewriter/content.go
+++ b/server/responsewriter/content.go
@@ -1,7 +1,11 @@
 package responsewriter
 
 import (
+	"bufio"
+	"fmt"
+	"net"
 	"net/http"
+	"reflect"
 	"strings"
 )
 
@@ -28,4 +32,11 @@ func ContentType(handler http.Handler) http.Handler {
 		writer := ContentTypeWriter{ResponseWriter: w}
 		handler.ServeHTTP(writer, r)
 	})
+}
+
+func (c ContentTypeWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := c.ResponseWriter.(http.Hijacker); ok {
+		return hijacker.Hijack()
+	}
+	return nil, nil, fmt.Errorf("Upstream ResponseWriter of type %v does not implement http.Hijacker", reflect.TypeOf(c.ResponseWriter))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -67,7 +67,7 @@ func Start(ctx context.Context, httpPort, httpsPort int, localClusterEnabled boo
 
 	samlRoot := saml.AuthHandler()
 	chain := responsewriter.NewMiddlewareChain(responsewriter.Gzip, responsewriter.NoCache, responsewriter.DenyFrameOptions, responsewriter.ContentType, ui.UI)
-	chainGzip := responsewriter.NewMiddlewareChain(responsewriter.Gzip)
+	chainGzip := responsewriter.NewMiddlewareChain(responsewriter.Gzip, responsewriter.ContentType)
 
 	root.Handle("/", chain.Handler(managementAPI))
 	root.PathPrefix("/v3-public").Handler(publicAPI)


### PR DESCRIPTION
Problem:
Monitoring would break on certain browsers because header was not being.

Solution:
Set use content handler in gzip chain. This handler will properly set content type header when necessary.

Refactor of:
https://github.com/rancher/rancher/pull/19497

Issue:
https://github.com/rancher/rancher/issues/19507