### PR TITLE
Patch the missing Monitoring metrics

### DIFF
--- a/pkg/api/customization/project/project_actions.go
+++ b/pkg/api/customization/project/project_actions.go
@@ -29,19 +29,6 @@ import (
 func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 	resource.AddAction(apiContext, "setpodsecuritypolicytemplate")
 	resource.AddAction(apiContext, "exportYaml")
-
-	if err := apiContext.AccessControl.CanDo(v3.ProjectGroupVersionKind.Group, v3.ProjectResource.Name, "update", apiContext, resource.Values, apiContext.Schema); err == nil {
-		if convert.ToBool(resource.Values["enableProjectMonitoring"]) {
-			resource.AddAction(apiContext, "disableMonitoring")
-			resource.AddAction(apiContext, "editMonitoring")
-		} else {
-			resource.AddAction(apiContext, "enableMonitoring")
-		}
-	}
-
-	if convert.ToBool(resource.Values["enableProjectMonitoring"]) {
-		resource.AddAction(apiContext, "viewMonitoring")
-	}
 }
 
 type Handler struct {


### PR DESCRIPTION
**Problem:**
- Cannot see the workload/container/pod metrics as `ProjectMetricGraph` has been deleted.
- Although delete monitoring action from schema resources, UI still can
seen `enableMonitoring` action link

**Solution:**
- Cannot delete `ProjectMetricGraph` directly.
- Remove actions addition from `Formatter`

**Issue:**
- https://github.com/rancher/rancher/issues/19516
- https://github.com/rancher/rancher/issues/19528