### PR TITLE
Don't retry telemetry forever

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -102,10 +102,6 @@ func Run(ctx context.Context, kubeConfig rest.Config, cfg *Config) error {
 			scaledContext.PeerManager.Leader()
 		}
 
-		if err := telemetry.Start(ctx, cfg.HTTPSListenPort, scaledContext); err != nil {
-			panic(err)
-		}
-
 		management, err := scaledContext.NewManagementContext()
 		if err != nil {
 			panic(err)
@@ -117,6 +113,10 @@ func Run(ctx context.Context, kubeConfig rest.Config, cfg *Config) error {
 		}
 
 		if err := addData(management, *cfg); err != nil {
+			panic(err)
+		}
+
+		if err := telemetry.Start(ctx, cfg.HTTPSListenPort, scaledContext); err != nil {
 			panic(err)
 		}
 


### PR DESCRIPTION
If we can't obtain a token for launching the telemetry service,
do not retry forever, give up after 3 tries.