### PR TITLE
Ntfs32 patch 1 image load

### DIFF
--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -394,6 +394,11 @@ set -e -x
 docker load --input ${images}
 
 for i in $(cat ${list}); do
+    if [[ ! ${i} =~ '/' ]]
+    then
+        docker tag ${i} rancher/${i}
+        i="rancher/${i}"
+    fi
     docker tag ${i} ${reg}/${i}
     docker push ${reg}/${i}
 done
@@ -463,6 +468,10 @@ $content=Get-Content -path ${image-list}
 docker load --input ${images}
 
 foreach ($item in $content) {
+    if(!$item.contains("/")) {
+        docker tag ${item} rancher/${item}
+        $item="rancher/${item}"
+    }
     docker tag $item $Registry/$item
     docker push $Registry/$item
 }

--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -469,8 +469,8 @@ docker load --input ${images}
 
 foreach ($item in $content) {
     if(!$item.contains("/")) {
-        docker tag ${item} rancher/${item}
-        $item="rancher/${item}"
+        docker tag ${item} "rancher/"+${item}
+        $item="rancher/"+${item}
     }
     docker tag $item $Registry/$item
     docker push $Registry/$item


### PR DESCRIPTION
Problem:
in file: https://github.com/rancher/rancher/blob/v2.2.2/pkg/image/resolve.go
official images will be load like rancher/images:xxx
and rancher-load-images.sh tag official images to privatexxx.com:5000/registry:2
can't push to private registry,
Private registry not any default registry.

Solution:
tag official images to rancher/${image} and push.

Issue:
rancher/rancher#18780
rancher/rancher#19716