### PR TITLE
Remove content-length from gzip responses

### DIFF
--- a/pkg/api/customization/node/node.go
+++ b/pkg/api/customization/node/node.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -222,12 +223,14 @@ func (h Handler) LinkHandler(apiContext *types.APIContext, next types.RequestHan
 	if err := w.Close(); err != nil {
 		return err
 	}
+
 	apiContext.Response.Header().Set("Content-Length", strconv.Itoa(len(buf.Bytes())))
 	apiContext.Response.Header().Set("Content-Type", "application/octet-stream")
 	apiContext.Response.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.zip", node[client.NodeSpecFieldRequestedHostname]))
 	apiContext.Response.Header().Set("Cache-Control", "private")
 	apiContext.Response.Header().Set("Pragma", "private")
 	apiContext.Response.Header().Set("Expires", "Wed 24 Feb 1982 18:42:00 GMT")
+	apiContext.Response.WriteHeader(http.StatusOK)
 	_, err = apiContext.Response.Write(buf.Bytes())
 	if err != nil {
 		return err

--- a/server/responsewriter/gzip.go
+++ b/server/responsewriter/gzip.go
@@ -26,6 +26,13 @@ func (g gzipResponseWriter) Write(b []byte) (int, error) {
 	return g.Writer.Write(b)
 }
 
+// should always be used when using gzip to overwrite outdated header info
+func (g gzipResponseWriter) WriteHeader(statusCode int) {
+	g.Header().Set("Content-Encoding", "gzip")
+	g.Header().Del("Content-Length")
+	g.ResponseWriter.WriteHeader(statusCode)
+}
+
 func Gzip(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
@@ -36,6 +43,7 @@ func Gzip(handler http.Handler) http.Handler {
 		defer gz.Close()
 
 		gzw := &wrapWriter{gzipResponseWriter{Writer: gz, ResponseWriter: w}, http.StatusOK}
+		// setting content-encoding is kept here in case the user does not use WriteHeader
 		gzw.Header().Set("Content-Encoding", "gzip")
 		handler.ServeHTTP(gzw, r)
 	})

--- a/server/responsewriter/gzip_test.go
+++ b/server/responsewriter/gzip_test.go
@@ -1,0 +1,87 @@
+package responsewriter
+
+import (
+	"compress/gzip"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// all other writers will attempt additional unnecessary logic
+// this implements http.responseWriter and io.Writer
+type DummyWriter struct {
+	header map[string][]string
+}
+
+type DummyHandler struct {
+}
+
+func NewDummyWriter() *DummyWriter {
+	return &DummyWriter{map[string][]string{}}
+}
+
+func (d *DummyWriter) Header() http.Header {
+	return d.header
+}
+
+func (d *DummyWriter) Write(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (d *DummyWriter) WriteHeader(int) {
+}
+
+func (d *DummyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+}
+
+// WriteHeader should delete current content-length in header
+func TestWriteHeader(t *testing.T) {
+	w := NewDummyWriter()
+	gz := &gzipResponseWriter{gzip.NewWriter(w), w}
+
+	gz.Header().Set("Content-Length", "80")
+	gz.WriteHeader(400)
+	// Content-Length should have been deleted in WriterHeader, resulting in empty string
+	assert.Equal(t, "", gz.Header().Get("Content-Length"))
+	assert.Equal(t, "gzip", gz.Header().Get("Content-Encoding"))
+}
+
+// Gzip handler function should set content-type to "gzip" if accept-encoding header contains gzip
+func TestHandlerSetContent(t *testing.T) {
+	rw := NewDummyWriter()
+	handler := &DummyHandler{}
+	req := &http.Request{}
+
+	req.Header = map[string][]string{}
+	handlerFunc := Gzip(handler)
+
+	// test when accept-encoding only contains gzip
+	req.Header.Set("Accept-Encoding", "gzip")
+	handlerFunc.ServeHTTP(rw, req)
+	assert.Equal(t, "gzip", rw.Header().Get("Content-Encoding"))
+
+	// test when accept-encoding contains multiple options, including gzip
+	req.Header.Set("Accept-Encoding", "json, xml, gzip")
+	handlerFunc.ServeHTTP(rw, req)
+	assert.Equal(t, "gzip", rw.Header().Get("Content-Encoding"))
+}
+
+// Gzip handler function should not change content-type if accept encoding does not contain gzip
+func TestHandlerForNonGzip(t *testing.T) {
+	rw := NewDummyWriter()
+	handler := &DummyHandler{}
+	req := &http.Request{}
+
+	req.Header = map[string][]string{}
+	handlerFunc := Gzip(handler)
+
+	// test when there is no Accept-Encoding header
+	handlerFunc.ServeHTTP(rw, req)
+	assert.NotEqual(t, "gzip", rw.Header().Get("Content-Encoding"))
+
+	// test when there are multiple Accept-Encoding header values, none of which are gzip
+	req.Header.Set("Accept-Encoding", "json, xml")
+	handlerFunc.ServeHTTP(rw, req)
+	assert.NotEqual(t, "gzip", rw.Header().Get("Content-Encoding"))
+}


### PR DESCRIPTION
Problem:

Gzipped responses could have content-length set prematurely. Nodekeys would overwrite content-length header. This caused an error and would prevent nodekeys response from being properly interpreted when using http2.

Solution:

Removed content-length header from all gzipped responses. Also, added gzip encoding check for node keys logic.

Issue:
https://github.com/rancher/rancher/issues/19702

