### PR TITLE
Set ID to name if empty

### DIFF
--- a/pkg/api/customization/setting/setting.go
+++ b/pkg/api/customization/setting/setting.go
@@ -36,13 +36,22 @@ func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 
 func Validator(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
 	var setting v3client.Setting
-	if err := access.ByID(request, request.Version, v3client.SettingType, request.ID, &setting); err != nil {
-		return err
+
+	// request.ID is taken from the request request url, it is possible that the request url does not contain the id
+	id := request.ID
+	if name, ok := data["name"].(string); ok && id == "" {
+		id = name
+	}
+
+	if err := access.ByID(request, request.Version, v3client.SettingType, id, &setting); err != nil {
+		if !httperror.IsNotFound(err) {
+			return err
+		}
 	}
 	if setting.Source == "env" {
-		return httperror.NewAPIError(httperror.MethodNotAllowed, fmt.Sprintf("%s is readOnly because its value is from environment variable", request.ID))
-	} else if slice.ContainsString(readOnlySettings, setting.ID) {
-		return httperror.NewAPIError(httperror.MethodNotAllowed, fmt.Sprintf("%s is readOnly", request.ID))
+		return httperror.NewAPIError(httperror.MethodNotAllowed, fmt.Sprintf("%s is readOnly because its value is from environment variable", id))
+	} else if slice.ContainsString(readOnlySettings, id) {
+		return httperror.NewAPIError(httperror.MethodNotAllowed, fmt.Sprintf("%s is readOnly", id))
 	}
 
 	newValue, ok := data["value"]
@@ -55,7 +64,7 @@ func Validator(request *types.APIContext, schema *types.Schema, data map[string]
 	}
 
 	var err error
-	switch request.ID {
+	switch id {
 	case "auth-user-info-max-age-seconds":
 		_, err = providerrefresh.ParseMaxAge(newValueString)
 	case "auth-user-info-resync-cron":

--- a/tests/integration/test_settings.py
+++ b/tests/integration/test_settings.py
@@ -1,0 +1,78 @@
+import pytest
+from rancher import ApiError
+
+
+# cacerts is readOnly, and should not be able to be set through the API
+def test_create_read_only(admin_mc, remove_resource):
+    client = admin_mc.client
+
+    with pytest.raises(ApiError) as e:
+        setting = client.create_setting(name="cacerts", value="a")
+        remove_resource(setting)
+
+    assert e.value.error.status == 405
+    assert "readOnly" in e.value.error.message
+
+
+# cacerts is readOnly setting, and should not be able to be updated through API
+def test_update_read_only(admin_mc, remove_resource):
+    client = admin_mc.client
+
+    with pytest.raises(ApiError) as e:
+        setting = client.update_by_id_setting(id="cacerts", value="b")
+        remove_resource(setting)
+
+    assert e.value.error.status == 405
+    assert "readOnly" in e.value.error.message
+
+
+# cacerts is readOnly, and should be able to be read
+def test_get_read_only(admin_mc, remove_resource):
+    client = admin_mc.client
+    setting = client.by_id_setting(id="cacerts")
+    remove_resource(setting)
+
+
+# user should be able to create a setting that does not exist yet
+def test_create(admin_mc, remove_resource):
+    client = admin_mc.client
+    setting = client.create_setting(name="samplesetting1", value="a")
+    remove_resource(setting)
+
+    assert setting.value == "a"
+
+
+# user should not be able to create a setting if it already exists
+def test_create_existing(admin_mc, remove_resource):
+    client = admin_mc.client
+    setting = client.create_setting(name="samplefsetting2", value="a")
+    remove_resource(setting)
+
+    with pytest.raises(ApiError) as e:
+        setting2 = client.create_setting(name="samplefsetting2", value="a")
+        remove_resource(setting2)
+
+    assert e.value.error.status == 409
+    assert e.value.error.code == "AlreadyExists"
+
+
+# user should be able to update a setting if it exists
+def test_update(admin_mc, remove_resource):
+    client = admin_mc.client
+    setting = client.create_setting(name="samplesetting3", value="a")
+    remove_resource(setting)
+
+    setting = client.update_by_id_setting(id="samplesetting3", value="b")
+    assert setting.value == "b"
+
+
+# user should not be able to update a setting if it does not exists
+def test_update_nonexisting(admin_mc, remove_resource):
+    client = admin_mc.client
+
+    with pytest.raises(ApiError) as e:
+        setting = client.update_by_id_setting(id="samplesetting4", value="a")
+        remove_resource(setting)
+
+    assert e.value.error.status == 404
+    assert e.value.error.code == "NotFound"

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     5b40a733665d4cf68aab19b6c2d9b46211f5a0d5
-github.com/rancher/types                      5f3a823cfec7cad701daadd1d428f4309d0e1c57 
+github.com/rancher/types                      5f3a823cfec7cad701daadd1d428f4309d0e1c57
 github.com/rancher/kontainer-engine           7606e7e7a2dcad29f22758ad689a00ea622c2d1f
 github.com/rancher/rke                        c89198b9ff2fc00b0a1c0e0c07fde5f41a83d50c
 

--- a/vendor/github.com/rancher/norman/httperror/error.go
+++ b/vendor/github.com/rancher/norman/httperror/error.go
@@ -105,6 +105,14 @@ func IsAPIError(err error) bool {
 	return ok
 }
 
+func IsNotFound(err error) bool {
+	if apiError, ok := err.(*APIError); ok {
+		return apiError.Code.Status == 404
+	}
+
+	return false
+}
+
 func IsConflict(err error) bool {
 	if apiError, ok := err.(*APIError); ok {
 		return apiError.Code.Status == 409

--- a/vendor/github.com/rancher/types/vendor.conf
+++ b/vendor/github.com/rancher/types/vendor.conf
@@ -2,5 +2,5 @@
 github.com/rancher/types
 
 github.com/pkg/errors v0.8.0
-github.com/rancher/norman 5b40a733665d4cf68aab19b6c2d9b46211f5a0d5 transitive=true 
+github.com/rancher/norman 7387aa53a5ba8545ac61fb612b7ed33286e995f6 transitive=true 
 github.com/coreos/prometheus-operator         v0.25.0 


### PR DESCRIPTION
Problem:
Request ID is always used to query a setting. Request ID is set by parsing the request URL. It is possible for a setting request URL to not include the setting ID, and instead include it in the body.
When this was the case, the request would return with an error.

Solution:
If request ID is empty, the name will be used instead. Now, the setting can be properly set despite not having its ID in the request URL (this is the expected behavior).

Issues:
https://github.com/rancher/rancher/issues/19705