### PR TITLE
Explicitly use int64 for owner decision

### DIFF
--- a/pkg/api/controllers/usercontrollers/usercontroller.go
+++ b/pkg/api/controllers/usercontrollers/usercontroller.go
@@ -141,7 +141,7 @@ func (u *userControllersController) amOwner(peers tpeermanager.Peers, cluster *v
 		ck--
 	}
 
-	scaled := int(ck) * len(peers.IDs) / math.MaxUint32
+	scaled := int64(ck) * int64(len(peers.IDs)) / math.MaxUint32
 	logrus.Debugf("%s(%v): (%v * %v) / %v = %v[%v] = %v, self = %v\n", cluster.Name, cluster.UID, ck,
 		uint32(len(peers.IDs)), math.MaxUint32, peers.IDs, scaled, peers.IDs[scaled], peers.SelfID)
 	return peers.IDs[scaled] == peers.SelfID


### PR DESCRIPTION
Current logic to decide owner of cluster is depending on int64.
This is the logic quoted from pkg/api/controllers/usercontrollers/usercontroller.go

> ck := crc32.ChecksumIEEE([]byte(cluster.UID))
> scaled := int(ck) * len(peers.IDs) / math.MaxUint32

We expect that int(ck) * len(peers.IDs) must be overflow of int32.
That's why we here cast int32 with int. but int behavior would
be different depending on environment.

So if we know always we want to use int64,
It's better to use explicitly int64 instead of int