### PR TITLE
Increase timeout for kontainer driver tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -323,8 +323,30 @@ def wait_remove_resource(admin_mc, request, timeout=DEFAULT_TIMEOUT):
 
     def _cleanup(resource):
         def clean():
-            client.delete(resource)
+            try:
+                client.delete(resource)
+            except ApiError as e:
+                if e.error.status != 404:
+                    raise e
             wait_until(lambda: client.reload(resource) is None)
+        request.addfinalizer(clean)
+    return _cleanup
+
+
+@pytest.fixture()
+def list_remove_resource(admin_mc, request):
+    """Takes list of resources to remove & supports reordering of the list """
+    client = admin_mc.client
+
+    def _cleanup(resource):
+        def clean():
+            for item in resource:
+                try:
+                    client.delete(item)
+                except ApiError as e:
+                    if e.error.status != 404:
+                        raise e
+                wait_until(lambda: client.reload(item) is None)
         request.addfinalizer(clean)
     return _cleanup
 

--- a/tests/integration/test_kontainer_drivers.py
+++ b/tests/integration/test_kontainer_drivers.py
@@ -9,17 +9,17 @@ NEW_DRIVER_URL = "https://github.com/rancher/kontainer-engine-driver-" \
                  "example/releases/download/v0.2.2/kontainer-engine-" \
                  "driver-example-" + sys.platform + "-amd64"
 NEW_DRIVER_ARM64_URL = "https://github.com/rancher/kontainer-engine-driver-" \
-                 "example/releases/download/v0.2.2/kontainer-engine-" \
-                 "driver-example-" + sys.platform + "-arm64"
+                       "example/releases/download/v0.2.2/kontainer-engine-" \
+                       "driver-example-" + sys.platform + "-arm64"
 DRIVER_AMD64_URL = "https://github.com/rancher/" \
-             "kontainer-engine-driver-example/" \
-             "releases/download/v0.2.1/kontainer-engine-driver-example-" \
-             + sys.platform
+                   "kontainer-engine-driver-example/" \
+                   "releases/download/v0.2.1/kontainer-engine-driver-example-"\
+                   + sys.platform
 DRIVER_ARM64_URL = "https://github.com/jianghang8421/" \
-             "kontainer-engine-driver-example/" \
-             "releases/download/v0.2.1-multiarch/" \
-             "kontainer-engine-driver-example-" \
-             + sys.platform + "-arm64"
+                   "kontainer-engine-driver-example/" \
+                   "releases/download/v0.2.1-multiarch/" \
+                   "kontainer-engine-driver-example-" \
+                   + sys.platform + "-arm64"
 
 
 def test_builtin_drivers_are_present(admin_mc):
@@ -48,8 +48,7 @@ def test_builtin_drivers_are_present(admin_mc):
 
 
 @pytest.mark.nonparallel
-def test_kontainer_driver_lifecycle(admin_mc, remove_resource,
-                                    wait_remove_resource):
+def test_kontainer_driver_lifecycle(admin_mc, list_remove_resource):
     URL = DRIVER_AMD64_URL
     if platform.machine() == "aarch64":
         URL = DRIVER_ARM64_URL
@@ -58,7 +57,8 @@ def test_kontainer_driver_lifecycle(admin_mc, remove_resource,
         active=True,
         url=URL
     )
-    remove_resource(kd)
+    remove_list = [kd]
+    list_remove_resource(remove_list)
 
     # Test that it is in downloading state while downloading
     kd = wait_for_condition('Downloaded', 'Unknown', admin_mc.client, kd)
@@ -90,9 +90,9 @@ def test_kontainer_driver_lifecycle(admin_mc, remove_resource,
             "credentials": "bad credentials",
             "nodeCount": 3
         })
-    remove_resource(cluster)
+    # order matters here, need to remove cluster before kontainer driver
+    remove_list.insert(0, cluster)
 
-    # verify delete link has been removed from the driver
     def check_remove_link(kod):
         kod = admin_mc.client.reload(kod)
         if hasattr(kod.links, "remove"):
@@ -100,16 +100,26 @@ def test_kontainer_driver_lifecycle(admin_mc, remove_resource,
         return True
 
     wait_for(lambda: check_remove_link(kd))
-    # try to delete it anyway
     with pytest.raises(ApiError) as e:
         admin_mc.client.delete(kd)
 
     assert e.value.error.status == 405
+
     # cleanup local cluster, note this depends on a force delete of the cluster
     # within rancher since this cluster is not a "true" cluster
+
+    def cluster_steady_state(clus):
+        clus = admin_mc.client.reload(clus)
+        if "lifecycle.cattle.io/" \
+           "create.mgmt-cluster-rbac-remove" in clus.annotations:
+            return True
+        return False
+
+    # this typically takes at least 45 seconds
+    wait_for(lambda: cluster_steady_state(cluster), timeout=90)
     admin_mc.client.delete(cluster)
     # wait for removal link to return
-    wait_for(lambda: not (check_remove_link(kd)))
+    wait_for(lambda: not (check_remove_link(kd)), timeout=90)
     admin_mc.client.delete(kd)
     # test driver is removed from schema after deletion
     verify_driver_not_in_types(admin_mc.client, kd)


### PR DESCRIPTION
Kontainer driver tests should wait for cluster to reach a steady state
before performing actions that depend on cluster state.