### PR TITLE
[2.2]Install cluster monitoring with system account

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -190,7 +190,7 @@ func (cd *clusterDeploy) setNetworkPolicyAnn(cluster *v3.Cluster) error {
 }
 
 func (cd *clusterDeploy) getKubeConfig(cluster *v3.Cluster) (*clientcmdapi.Config, error) {
-	user, err := cd.systemAccountManager.GetSystemUser(cluster)
+	user, err := cd.systemAccountManager.GetSystemUser(cluster.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/user/logging/deployer/appdeployer.go
+++ b/pkg/controllers/user/logging/deployer/appdeployer.go
@@ -119,7 +119,7 @@ func (d *AppDeployer) isDeploySuccess(targetNamespace string, selector map[strin
 	return fmt.Errorf("timeout check deploy app status, namespace: %s, labels: %v", targetNamespace, selector)
 }
 
-func rancherLoggingApp(systemProjectCreator, systemProjectID, catalogID, driverDir string) *projectv3.App {
+func rancherLoggingApp(appCreator, systemProjectID, catalogID, driverDir string) *projectv3.App {
 	appName := loggingconfig.AppName
 	namepspace := loggingconfig.LoggingNamespace
 	_, systemProjectName := ref.Parse(systemProjectID)
@@ -127,7 +127,7 @@ func rancherLoggingApp(systemProjectCreator, systemProjectID, catalogID, driverD
 	return &projectv3.App{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				creatorIDAnn: systemProjectCreator,
+				creatorIDAnn: appCreator,
 			},
 			Name:      appName,
 			Namespace: systemProjectName,
@@ -146,7 +146,7 @@ func rancherLoggingApp(systemProjectCreator, systemProjectID, catalogID, driverD
 	}
 }
 
-func loggingTesterApp(systemProjectCreator, systemProjectID, catalogID, clusterConfig, projectConfig string) *projectv3.App {
+func loggingTesterApp(appCreator, systemProjectID, catalogID, clusterConfig, projectConfig string) *projectv3.App {
 	appName := loggingconfig.TesterAppName
 	namepspace := loggingconfig.LoggingNamespace
 	_, systemProjectName := ref.Parse(systemProjectID)
@@ -154,7 +154,7 @@ func loggingTesterApp(systemProjectCreator, systemProjectID, catalogID, clusterC
 	return &projectv3.App{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				creatorIDAnn: systemProjectCreator,
+				creatorIDAnn: appCreator,
 			},
 			Name:      appName,
 			Namespace: systemProjectName,

--- a/pkg/controllers/user/monitoring/appHandler.go
+++ b/pkg/controllers/user/monitoring/appHandler.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"github.com/rancher/rancher/pkg/monitoring"
+	"github.com/rancher/rancher/pkg/systemaccount"
 	appsv1beta2 "github.com/rancher/types/apis/apps/v1beta2"
 	corev1 "github.com/rancher/types/apis/core/v1"
 	mgmtv3 "github.com/rancher/types/apis/management.cattle.io/v3"
@@ -23,6 +24,7 @@ type appHandler struct {
 	agentSecretClient           corev1.SecretInterface
 	agentNodeClient             corev1.NodeInterface
 	agentNamespaceClient        corev1.NamespaceInterface
+	systemAccountManager        *systemaccount.Manager
 }
 
 func (ah *appHandler) withdrawApp(clusterID, appName, appTargetNamespace string) error {

--- a/pkg/controllers/user/monitoring/operatorHandler.go
+++ b/pkg/controllers/user/monitoring/operatorHandler.go
@@ -168,8 +168,17 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) (backErr erro
 		"apiGroup":     monitoring.APIVersion.Group,
 		"nameOverride": "prometheus-operator",
 	}
-	annotations := monitoring.CopyCreatorID(nil, cluster.Annotations)
-	annotations["cluster.cattle.io/addon"] = appName
+
+	creator, err := app.systemAccountManager.GetSystemUser(cluster.Name)
+	if err != nil {
+		return err
+	}
+
+	annotations := map[string]string{
+		"cluster.cattle.io/addon": appName,
+		creatorIDAnno:             creator.Name,
+	}
+
 	targetApp := &projectv3.App{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: annotations,

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -248,10 +248,15 @@ func (ph *projectHandler) deployApp(appName, appTargetNamespace string, appProje
 		appAnswers["prometheus.sync.path"] = "/api/v1/read"
 	}
 
+	creator, err := ph.app.systemAccountManager.GetProjectSystemUser(project.Name)
+	if err != nil {
+		return err
+	}
+
 	appCatalogID := settings.SystemMonitoringCatalogID.Get()
 	app := &v3.App{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: monitoring.CopyCreatorID(nil, project.Annotations),
+			Annotations: map[string]string{creatorIDAnno: creator.Name},
 			Labels:      monitoring.OwnedLabels(appName, appTargetNamespace, appProjectName, monitoring.ProjectLevel),
 			Name:        appName,
 			Namespace:   appDeployProjectID,
@@ -265,7 +270,7 @@ func (ph *projectHandler) deployApp(appName, appTargetNamespace string, appProje
 		},
 	}
 
-	err := monitoring.DeployApp(ph.app.cattleAppClient, appDeployProjectID, app)
+	err = monitoring.DeployApp(ph.app.cattleAppClient, appDeployProjectID, app)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/user/monitoring/register.go
+++ b/pkg/controllers/user/monitoring/register.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/rancher/rancher/pkg/monitoring"
+	"github.com/rancher/rancher/pkg/systemaccount"
 	"github.com/rancher/types/config"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +37,7 @@ func Register(ctx context.Context, agentContext *config.UserContext) {
 		agentSecretClient:           agentContext.Core.Secrets(metav1.NamespaceAll),
 		agentNodeClient:             agentContext.Core.Nodes(metav1.NamespaceAll),
 		agentNamespaceClient:        agentContext.Core.Namespaces(metav1.NamespaceAll),
+		systemAccountManager:        systemaccount.NewManager(agentContext.Management),
 	}
 
 	// operator handler

--- a/pkg/controllers/user/nodesyncer/cordonfieldssyncer.go
+++ b/pkg/controllers/user/nodesyncer/cordonfieldssyncer.go
@@ -190,7 +190,7 @@ func (d *NodeDrain) getKubeConfig() (*clientcmdapi.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	user, err := d.systemAccountManager.GetSystemUser(cluster)
+	user, err := d.systemAccountManager.GetSystemUser(cluster.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/systemaccount/systemaccount.go
+++ b/pkg/systemaccount/systemaccount.go
@@ -49,7 +49,7 @@ type Manager struct {
 }
 
 func (s *Manager) CreateSystemAccount(cluster *v3.Cluster) error {
-	user, err := s.GetSystemUser(cluster)
+	user, err := s.GetSystemUser(cluster.Name)
 	if err != nil {
 		return err
 	}
@@ -73,8 +73,8 @@ func (s *Manager) CreateSystemAccount(cluster *v3.Cluster) error {
 	return err
 }
 
-func (s *Manager) GetSystemUser(cluster *v3.Cluster) (*v3.User, error) {
-	return s.userManager.EnsureUser(fmt.Sprintf("system://%s", cluster.Name), "System account for Cluster "+cluster.Name)
+func (s *Manager) GetSystemUser(clusterName string) (*v3.User, error) {
+	return s.userManager.EnsureUser(fmt.Sprintf("system://%s", clusterName), "System account for Cluster "+clusterName)
 }
 
 func (s *Manager) GetOrCreateSystemClusterToken(clusterName string) (string, error) {

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -147,6 +147,20 @@ def admin_pc(admin_cc, remove_resource):
 
 
 @pytest.fixture
+def admin_system_pc(admin_mc):
+    """Returns a ProjectContext for the system project in the local cluster
+    for the default global admin user."""
+    admin = admin_mc.client
+    plist = admin.list_project(name='System', clusterId='local')
+    assert len(plist) == 1
+    p = plist.data[0]
+    url = p.links.self + '/schemas'
+    return ProjectContext(admin_cc, p, rancher.Client(url=url,
+                                                      verify=False,
+                                                      token=admin.token))
+
+
+@pytest.fixture
 def user_mc(user_factory):
     """Returns a ManagementContext for a newly created standard user"""
     return user_factory()

--- a/tests/core/test_system_app_creator.py
+++ b/tests/core/test_system_app_creator.py
@@ -1,0 +1,36 @@
+from .common import random_str
+import time
+
+
+def test_system_app_creator(admin_mc, admin_system_pc, remove_resource):
+    client = admin_mc.client
+    provider_name = random_str()
+    access = random_str()
+    secret = random_str()
+    globaldns_provider = \
+        client.create_global_dns_provider(
+                                         name=provider_name,
+                                         rootDomain="example.com",
+                                         route53ProviderConfig={
+                                             'accessKey': access,
+                                             'secretKey': secret})
+    remove_resource(globaldns_provider)
+    app = wait_for_system_app(
+        admin_system_pc.client,
+        "systemapp-"+globaldns_provider.name)
+    # the creator id of system app won't be listed in api
+    assert app.creatorId != globaldns_provider.creatorId
+
+
+def wait_for_system_app(client, name, timeout=60):
+    start = time.time()
+    interval = 0.5
+    apps = client.list_app(name=name)
+    while len(apps.data) != 1:
+        if time.time() - start > timeout:
+            print(apps)
+            raise Exception('Timeout waiting for workload service')
+        time.sleep(interval)
+        interval *= 2
+        apps = client.list_app(name=name)
+    return apps.data[0]


### PR DESCRIPTION
Backport for https://github.com/rancher/rancher/pull/19644

**Problem:**
We are using cluster creator id as cluster monitoring creator. There
will be issue if the cluster creator is disabled or deleted.

**Solution:**
We should use system account to install cluster monitoring.

Related issue: https://github.com/rancher/rancher/issues/18787