### PR TITLE
Changing Rancher to use a new logging system chart version

### DIFF
--- a/pkg/controllers/user/logging/config/config.go
+++ b/pkg/controllers/user/logging/config/config.go
@@ -7,7 +7,7 @@ import (
 const (
 	AppName           = "rancher-logging"
 	TesterAppName     = "rancher-logging-tester"
-	AppInitVersion    = "0.0.1"
+	AppInitVersion    = "0.1.1"
 	systemCatalogName = "system-library"
 	templateName      = "rancher-logging"
 )
@@ -80,6 +80,10 @@ func SecretDataKeyCertKey(level, name string) string {
 
 func RancherLoggingTemplateID() string {
 	return fmt.Sprintf("%s-%s", systemCatalogName, templateName)
+}
+
+func RancherLoggingFullVersion() string {
+	return fmt.Sprintf("%s-%s-%s", systemCatalogName, templateName, AppInitVersion)
 }
 
 func RancherLoggingCatalogID(version string) string {

--- a/pkg/controllers/user/logging/deployer/upgradeimpl.go
+++ b/pkg/controllers/user/logging/deployer/upgradeimpl.go
@@ -6,9 +6,11 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/rancher/rancher/pkg/controllers/user/helm/common"
 	loggingconfig "github.com/rancher/rancher/pkg/controllers/user/logging/config"
 	"github.com/rancher/rancher/pkg/controllers/user/systemimage"
 	"github.com/rancher/rancher/pkg/project"
+	"github.com/rancher/rancher/pkg/settings"
 	appsv1beta2 "github.com/rancher/types/apis/apps/v1beta2"
 	"github.com/rancher/types/apis/core/v1"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
@@ -53,7 +55,12 @@ func (l *loggingService) Init(ctx context.Context, cluster *config.UserContext) 
 }
 
 func (l *loggingService) Version() (string, error) {
-	return loggingconfig.RancherLoggingFullVersion(), nil
+	catalogID := settings.SystemLoggingCatalogID.Get()
+	templateVersionID, _, err := common.ParseExternalID(catalogID)
+	if err != nil {
+		return "", fmt.Errorf("get system logging catalog version failed, %v", err)
+	}
+	return templateVersionID, nil
 }
 
 func (l *loggingService) Upgrade(currentVersion string) (string, error) {

--- a/pkg/controllers/user/logging/deployer/upgradeimpl.go
+++ b/pkg/controllers/user/logging/deployer/upgradeimpl.go
@@ -53,7 +53,7 @@ func (l *loggingService) Init(ctx context.Context, cluster *config.UserContext) 
 }
 
 func (l *loggingService) Version() (string, error) {
-	return loggingconfig.AppInitVersion, nil
+	return loggingconfig.RancherLoggingFullVersion(), nil
 }
 
 func (l *loggingService) Upgrade(currentVersion string) (string, error) {

--- a/pkg/controllers/user/logging/deployer/upgradeimpl_test.go
+++ b/pkg/controllers/user/logging/deployer/upgradeimpl_test.go
@@ -1,0 +1,19 @@
+package deployer
+
+import (
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	expectedVersion := "system-library-rancher-logging-0.1.1"
+	loggingService := &loggingService{}
+	version, err := loggingService.Version()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if version != expectedVersion {
+		t.Errorf("output version %s isn't equal to expected version %s", version, expectedVersion)
+	}
+}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -50,6 +50,7 @@ var (
 	UIKubernetesDefaultVersion      = NewSetting("ui-k8s-default-version-range", "<=1.13.x")
 	WhitelistDomain                 = NewSetting("whitelist-domain", "forums.rancher.com")
 	SystemMonitoringCatalogID       = NewSetting("system-monitoring-catalog-id", "catalog://?catalog=system-library&template=rancher-monitoring&version=0.0.3")
+	SystemLoggingCatalogID          = NewSetting("system-logging-catalog-id", "catalog://?catalog=system-library&template=rancher-logging&version=0.1.1")
 	SystemExternalDNSCatalogID      = NewSetting("system-externaldns-catalog-id", "catalog://?catalog=system-library&template=rancher-external-dns&version=0.0.1")
 	AuthUserInfoResyncCron          = NewSetting("auth-user-info-resync-cron", "0 0 * * *")
 	AuthUserInfoMaxAgeSeconds       = NewSetting("auth-user-info-max-age-seconds", "3600") // 1 hour


### PR DESCRIPTION
Problem:
logging system chart have new version
Solution:
update init logging system version to latest one

Issue:
https://github.com/rancher/rancher/issues/19836

Charts PR:
https://github.com/rancher/system-charts/pull/38