### PR TITLE
Fix catalog templates don't sync in HA mode

### DIFF
--- a/pkg/api/controllers/catalog/catalog.go
+++ b/pkg/api/controllers/catalog/catalog.go
@@ -2,6 +2,10 @@ package catalog
 
 import (
 	"context"
+	"fmt"
+	"github.com/rancher/rancher/pkg/catalog/git"
+	"github.com/rancher/types/client/management/v3"
+	"k8s.io/client-go/tools/cache"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +13,7 @@ import (
 
 	"github.com/bep/debounce"
 	helmlib "github.com/rancher/rancher/pkg/catalog/helm"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	"github.com/rancher/rancher/pkg/ticker"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
@@ -36,6 +41,77 @@ func Register(ctx context.Context, context *config.ScaledContext) {
 	context.Management.Catalogs("").Controller().AddHandler(ctx, "catalogCache", cleaner.destroyCatalogSync)
 	context.Management.ClusterCatalogs("").Controller().AddHandler(ctx, "clusterCatalogCache", cleaner.destroyClusterCatalogSync)
 	context.Management.ProjectCatalogs("").Controller().AddHandler(ctx, "projectCatalogCache", cleaner.destroyProjectCatalogSync)
+
+	// Don't need to watch catalog sync events on leader node of duplicate actions
+	if context.PeerManager != nil && !context.PeerManager.IsLeader() {
+		logrus.Debug("registering scaled context catalog handler")
+		context.Management.Catalogs("").Controller().AddHandler(ctx, "scaledCatalogSync", cleaner.scaledCatalogSync)
+		context.Management.ClusterCatalogs("").Controller().AddHandler(ctx, "scaledClusterCatalogSync", cleaner.scaledClusterCatalogSync)
+		context.Management.ProjectCatalogs("").Controller().AddHandler(ctx, "scaledProjectCatalogSync", cleaner.scaledProjectCatalogSync)
+	}
+}
+
+func (c *CacheCleaner) scaledCatalogSync(key string, obj *v3.Catalog) (runtime.Object, error) {
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if obj == nil {
+		return nil, nil
+	}
+
+	// always get a refresh catalog from etcd
+	catalog, err := c.catalogClient.GetNamespaced(ns, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	cmt := &manager.CatalogInfo{
+		Catalog: obj,
+	}
+	return c.checkCatalogUpdate(catalog, cmt)
+}
+
+func (c *CacheCleaner) scaledProjectCatalogSync(key string, obj *v3.ProjectCatalog) (runtime.Object, error) {
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if obj == nil {
+		return nil, nil
+	}
+
+	// always get a refresh project catalog from etcd
+	projectCatalog, err := c.projectCatalogClient.GetNamespaced(ns, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	cmt := &manager.CatalogInfo{
+		ProjectCatalog: projectCatalog,
+	}
+	return c.checkCatalogUpdate(&projectCatalog.Catalog, cmt)
+}
+
+func (c *CacheCleaner) scaledClusterCatalogSync(key string, obj *v3.ClusterCatalog) (runtime.Object, error) {
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if obj == nil {
+		return nil, nil
+	}
+
+	// always get a refresh cluster catalog from etcd
+	clusterCatalog, err := c.clusterCatalogClient.GetNamespaced(ns, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	cmt := &manager.CatalogInfo{
+		ClusterCatalog: clusterCatalog,
+	}
+	return c.checkCatalogUpdate(&clusterCatalog.Catalog, cmt)
 }
 
 func (c *CacheCleaner) runPeriodicCatalogCacheCleaner(ctx context.Context, interval time.Duration) {
@@ -141,4 +217,51 @@ func cleanupPath(dir string, files []string, valid map[string]bool) int {
 		logrus.Debugf("Catalog-cache removed entry from disk: %s", dirFile)
 	}
 	return count
+}
+
+func (c CacheCleaner) checkCatalogUpdate(catalog *v3.Catalog, cmt *manager.CatalogInfo) (runtime.Object, error) {
+	hashPath := helmlib.CatalogSHA256Hash(catalog)
+	path := filepath.Join(helmlib.CatalogCache, hashPath)
+	if _, err := os.Stat(path); err == nil {
+		if git.IsGitPath(path) {
+			// if git path exist, check if the local cache commit is same with the updated commit
+			headCommit, err := git.HeadCommit(path)
+			if err != nil {
+				return nil, err
+			}
+			if !manager.IsUpToDate(headCommit, catalog) {
+				return c.newForceUpdateCatalog(catalog, cmt)
+			}
+		} else {
+			// if it's not a git path repo, update as helm index catalog
+			return c.newForceUpdateCatalog(catalog, cmt)
+		}
+	} else if os.IsNotExist(err) {
+		return c.newForceUpdateCatalog(catalog, cmt)
+	} else {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (c CacheCleaner) newForceUpdateCatalog(obj *v3.Catalog, cmt *manager.CatalogInfo) (runtime.Object, error) {
+	catalogType := manager.GetCatalogType(cmt)
+	commit, helm, err := helmlib.NewForceUpdate(obj)
+	logrus.Debugf("Helm update local path: %s to commit %s", helm.LocalPath, commit)
+	if err != nil {
+		switch catalogType {
+		case client.CatalogType:
+			manager.SetRefreshedError(obj, err)
+			return c.catalogClient.Update(cmt.Catalog)
+		case client.ClusterCatalogType:
+			manager.SetRefreshedError(obj, err)
+			return c.clusterCatalogClient.Update(cmt.ClusterCatalog)
+		case client.ProjectCatalogType:
+			manager.SetRefreshedError(obj, err)
+			return c.projectCatalogClient.Update(cmt.ProjectCatalog)
+		default:
+			return nil, fmt.Errorf("incorrect catalog type")
+		}
+	}
+	return nil, nil
 }

--- a/pkg/catalog/git/git.go
+++ b/pkg/catalog/git/git.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -61,4 +63,12 @@ func FormatURL(pathURL, username, password string) string {
 		}
 	}
 	return pathURL
+}
+
+func IsGitPath(path string) bool {
+	gitPath := filepath.Join(path, ".git")
+	if _, err := os.Stat(gitPath); err == nil {
+		return true
+	}
+	return false
 }

--- a/pkg/catalog/helm/setup.go
+++ b/pkg/catalog/helm/setup.go
@@ -106,7 +106,7 @@ func (h *Helm) update() (string, error) {
 		commit string
 		err    error
 	)
-	if git.IsValid(pathURL) {
+	if git.IsGitPath(h.LocalPath) || git.IsValid(pathURL) {
 		commit, err = h.updateGit(pathURL)
 	} else {
 		commit, err = h.updateIndex()

--- a/pkg/catalog/manager/catalog_common.go
+++ b/pkg/catalog/manager/catalog_common.go
@@ -18,7 +18,7 @@ func hasAllUpdates(catalog *v3.Catalog) bool {
 	return upgraded && diskCached
 }
 
-func isUpToDate(commit string, catalog *v3.Catalog) bool {
+func IsUpToDate(commit string, catalog *v3.Catalog) bool {
 	commitsEqual := commit == catalog.Status.Commit
 	updated := hasAllUpdates(catalog)
 	return commitsEqual && updated
@@ -35,7 +35,7 @@ func setRefreshed(catalog *v3.Catalog) bool {
 	return false
 }
 
-func setRefreshedError(catalog *v3.Catalog, err error) {
+func SetRefreshedError(catalog *v3.Catalog, err error) {
 	v3.CatalogConditionRefreshed.False(catalog)
 	v3.CatalogConditionRefreshed.ReasonAndMessageFromError(catalog, err)
 }
@@ -75,10 +75,10 @@ func (m *Manager) deleteTemplates(key string, namespace string) error {
 	return nil
 }
 
-func getCatalogType(cmt *CatalogInfo) string {
-	if cmt.projectCatalog == nil && cmt.clusterCatalog == nil {
+func GetCatalogType(cmt *CatalogInfo) string {
+	if cmt.ProjectCatalog == nil && cmt.ClusterCatalog == nil {
 		return client.CatalogType
-	} else if cmt.projectCatalog != nil {
+	} else if cmt.ProjectCatalog != nil {
 		return client.ProjectCatalogType
 	} else {
 		return client.ClusterCatalogType
@@ -90,11 +90,11 @@ func (m *Manager) updateCatalogInfo(cmt *CatalogInfo, catalogType string, templa
 	if condition {
 		switch catalogType {
 		case client.CatalogType:
-			obj = runtime.Object(cmt.catalog)
+			obj = runtime.Object(cmt.Catalog)
 		case client.ProjectCatalogType:
-			obj = runtime.Object(cmt.projectCatalog)
+			obj = runtime.Object(cmt.ProjectCatalog)
 		case client.ClusterCatalogType:
-			obj = runtime.Object(cmt.clusterCatalog)
+			obj = runtime.Object(cmt.ClusterCatalog)
 		default:
 			return cmt, fmt.Errorf("incorrect catalog type")
 		}
@@ -109,15 +109,15 @@ func (m *Manager) updateCatalogInfo(cmt *CatalogInfo, catalogType string, templa
 	if updateOnly {
 		switch catalogType {
 		case client.CatalogType:
-			if _, err := m.catalogClient.Update(cmt.catalog); err != nil {
+			if _, err := m.catalogClient.Update(cmt.Catalog); err != nil {
 				return nil, err
 			}
 		case client.ProjectCatalogType:
-			if _, err := m.projectCatalogClient.Update(cmt.projectCatalog); err != nil {
+			if _, err := m.projectCatalogClient.Update(cmt.ProjectCatalog); err != nil {
 				return nil, err
 			}
 		case client.ClusterCatalogType:
-			if _, err := m.clusterCatalogClient.Update(cmt.clusterCatalog); err != nil {
+			if _, err := m.clusterCatalogClient.Update(cmt.ClusterCatalog); err != nil {
 				return nil, err
 			}
 		default:
@@ -128,31 +128,31 @@ func (m *Manager) updateCatalogInfo(cmt *CatalogInfo, catalogType string, templa
 
 	switch catalogType {
 	case client.CatalogType:
-		catalog := cmt.catalog
-		if newCatalog, err := m.catalogClient.Update(cmt.catalog); err == nil {
+		catalog := cmt.Catalog
+		if newCatalog, err := m.catalogClient.Update(cmt.Catalog); err == nil {
 			catalog = newCatalog
 		} else {
 			catalog, _ = m.catalogClient.Get(catalog.Name, metav1.GetOptions{})
 		}
-		cmt.catalog = catalog
+		cmt.Catalog = catalog
 	case client.ProjectCatalogType:
-		projectCatalog := cmt.projectCatalog
+		projectCatalog := cmt.ProjectCatalog
 		if newCatalog, err := m.projectCatalogClient.Update(projectCatalog); err == nil {
 			projectCatalog = newCatalog
 		} else {
 			projectCatalog, _ = m.projectCatalogClient.Get(projectCatalog.Name, metav1.GetOptions{})
 		}
-		cmt.catalog = &projectCatalog.Catalog
-		cmt.projectCatalog = projectCatalog
+		cmt.Catalog = &projectCatalog.Catalog
+		cmt.ProjectCatalog = projectCatalog
 	case client.ClusterCatalogType:
-		clusterCatalog := cmt.clusterCatalog
+		clusterCatalog := cmt.ClusterCatalog
 		if newCatalog, err := m.clusterCatalogClient.Update(clusterCatalog); err == nil {
 			clusterCatalog = newCatalog
 		} else {
 			clusterCatalog, _ = m.clusterCatalogClient.Get(clusterCatalog.Name, metav1.GetOptions{})
 		}
-		cmt.catalog = &clusterCatalog.Catalog
-		cmt.clusterCatalog = clusterCatalog
+		cmt.Catalog = &clusterCatalog.Catalog
+		cmt.ClusterCatalog = clusterCatalog
 	default:
 		return cmt, fmt.Errorf("incorrect catalog type")
 	}

--- a/pkg/catalog/manager/catalog_sync.go
+++ b/pkg/catalog/manager/catalog_sync.go
@@ -1,17 +1,16 @@
 package manager
 
 import (
-	"github.com/rancher/types/apis/management.cattle.io/v3"
-	"github.com/sirupsen/logrus"
-
 	helmlib "github.com/rancher/rancher/pkg/catalog/helm"
 	"github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func (m *Manager) updateCatalogError(catalog *v3.Catalog, err error) (runtime.Object, error) {
-	setRefreshedError(catalog, err)
+	SetRefreshedError(catalog, err)
 	m.catalogClient.Update(catalog)
 	return nil, err
 }
@@ -32,7 +31,7 @@ func (m *Manager) Sync(key string, obj *v3.Catalog) (runtime.Object, error) {
 		return m.updateCatalogError(catalog, err)
 	}
 
-	if isUpToDate(commit, catalog) {
+	if IsUpToDate(commit, catalog) {
 		if setRefreshed(catalog) {
 			m.catalogClient.Update(catalog)
 		}
@@ -40,7 +39,7 @@ func (m *Manager) Sync(key string, obj *v3.Catalog) (runtime.Object, error) {
 	}
 
 	cmt := &CatalogInfo{
-		catalog: catalog,
+		Catalog: catalog,
 	}
 
 	logrus.Infof("Updating global catalog %s", catalog.Name)

--- a/pkg/catalog/manager/cluster_catalog_sync.go
+++ b/pkg/catalog/manager/cluster_catalog_sync.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (m *Manager) updateClusterCatalogError(clusterCatalog *v3.ClusterCatalog, err error) (runtime.Object, error) {
-	setRefreshedError(&clusterCatalog.Catalog, err)
+	SetRefreshedError(&clusterCatalog.Catalog, err)
 	m.clusterCatalogClient.Update(clusterCatalog)
 	return nil, err
 }
@@ -36,7 +36,7 @@ func (m *Manager) ClusterCatalogSync(key string, obj *v3.ClusterCatalog) (runtim
 		return m.updateClusterCatalogError(clusterCatalog, err)
 	}
 
-	if isUpToDate(commit, &clusterCatalog.Catalog) {
+	if IsUpToDate(commit, &clusterCatalog.Catalog) {
 		if setRefreshed(&clusterCatalog.Catalog) {
 			m.clusterCatalogClient.Update(clusterCatalog)
 		}
@@ -44,8 +44,8 @@ func (m *Manager) ClusterCatalogSync(key string, obj *v3.ClusterCatalog) (runtim
 	}
 
 	cmt := &CatalogInfo{
-		catalog:        &clusterCatalog.Catalog,
-		clusterCatalog: clusterCatalog,
+		Catalog:        &clusterCatalog.Catalog,
+		ClusterCatalog: clusterCatalog,
 	}
 
 	logrus.Infof("Updating cluster catalog %s", clusterCatalog.Name)

--- a/pkg/catalog/manager/config.go
+++ b/pkg/catalog/manager/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 type CatalogInfo struct {
-	catalog        *v3.Catalog
-	projectCatalog *v3.ProjectCatalog
-	clusterCatalog *v3.ClusterCatalog
+	Catalog        *v3.Catalog
+	ProjectCatalog *v3.ProjectCatalog
+	ClusterCatalog *v3.ClusterCatalog
 }

--- a/pkg/catalog/manager/project_catalog_sync.go
+++ b/pkg/catalog/manager/project_catalog_sync.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (m *Manager) updateProjectCatalogError(projectCatalog *v3.ProjectCatalog, err error) (runtime.Object, error) {
-	setRefreshedError(&projectCatalog.Catalog, err)
+	SetRefreshedError(&projectCatalog.Catalog, err)
 	m.projectCatalogClient.Update(projectCatalog)
 	return nil, err
 }
@@ -36,7 +36,7 @@ func (m *Manager) ProjectCatalogSync(key string, obj *v3.ProjectCatalog) (runtim
 		return m.updateProjectCatalogError(projectCatalog, err)
 	}
 
-	if isUpToDate(commit, &projectCatalog.Catalog) {
+	if IsUpToDate(commit, &projectCatalog.Catalog) {
 		if setRefreshed(&projectCatalog.Catalog) {
 			m.projectCatalogClient.Update(projectCatalog)
 		}
@@ -44,8 +44,8 @@ func (m *Manager) ProjectCatalogSync(key string, obj *v3.ProjectCatalog) (runtim
 	}
 
 	cmt := &CatalogInfo{
-		catalog:        &projectCatalog.Catalog,
-		projectCatalog: projectCatalog,
+		Catalog:        &projectCatalog.Catalog,
+		ProjectCatalog: projectCatalog,
 	}
 
 	logrus.Infof("Updating project catalog %s", projectCatalog.Name)

--- a/pkg/catalog/manager/traverse.go
+++ b/pkg/catalog/manager/traverse.go
@@ -19,10 +19,10 @@ import (
 
 func (m *Manager) traverseAndUpdate(helm *helmlib.Helm, commit string, cmt *CatalogInfo) error {
 	var templateNamespace string
-	catalog := cmt.catalog
-	projectCatalog := cmt.projectCatalog
-	clusterCatalog := cmt.clusterCatalog
-	catalogType := getCatalogType(cmt)
+	catalog := cmt.Catalog
+	projectCatalog := cmt.ProjectCatalog
+	clusterCatalog := cmt.ClusterCatalog
+	catalogType := GetCatalogType(cmt)
 
 	index, err := helm.LoadIndex()
 	if err != nil {
@@ -192,13 +192,13 @@ func (m *Manager) traverseAndUpdate(helm *helmlib.Helm, commit string, cmt *Cata
 			return err
 		}
 
-		catalog = cmt.catalog
-		projectCatalog = cmt.projectCatalog
-		clusterCatalog = cmt.clusterCatalog
+		catalog = cmt.Catalog
+		projectCatalog = cmt.ProjectCatalog
+		clusterCatalog = cmt.ClusterCatalog
 		if catalog == nil || catalog.Name == "" {
 			return errors.New("Catalog is no longer available")
 		}
-		if isUpToDate(commit, catalog) {
+		if IsUpToDate(commit, catalog) {
 			logrus.Debugf("Stopping catalog [%s] update, catalog already up to date", catalog.Name)
 			return nil
 		}
@@ -242,9 +242,9 @@ func (m *Manager) traverseAndUpdate(helm *helmlib.Helm, commit string, cmt *Cata
 	} else if clusterCatalog != nil {
 		clusterCatalog.Catalog = *catalog
 	}
-	cmt.catalog = catalog
-	cmt.projectCatalog = projectCatalog
-	cmt.clusterCatalog = clusterCatalog
+	cmt.Catalog = catalog
+	cmt.ProjectCatalog = projectCatalog
+	cmt.ClusterCatalog = clusterCatalog
 	if len(terrors) > 0 {
 		if _, err := m.updateCatalogInfo(cmt, catalogType, "", false, true); err != nil {
 			return err
@@ -266,9 +266,9 @@ func (m *Manager) traverseAndUpdate(helm *helmlib.Helm, commit string, cmt *Cata
 	} else if clusterCatalog != nil {
 		clusterCatalog.Catalog = *catalog
 	}
-	cmt.catalog = catalog
-	cmt.projectCatalog = projectCatalog
-	cmt.clusterCatalog = clusterCatalog
+	cmt.Catalog = catalog
+	cmt.ProjectCatalog = projectCatalog
+	cmt.ClusterCatalog = clusterCatalog
 	if _, err := m.updateCatalogInfo(cmt, catalogType, "", true, true); err != nil {
 		return err
 	}


### PR DESCRIPTION
Problems:
Catalog templates didn't get updated in rancher follower node on HA mode.
rancher/rancher#19638

Solution:
Registering scaledContext handlers on catalog api controller to respond to catalog templates sync events:
1. only the master node will update the catalog template and templateVersion CRDs.
2. scaledContext catalog controller will retry and timeout on each rancher node respectively if catalog templates fail to update.

Related PR:
Validation Test: https://github.com/rancher/validation/pull/160