### PR TITLE
Disable deletion for readonly settings and remove setting deletion from test

### DIFF
--- a/pkg/api/customization/setting/setting.go
+++ b/pkg/api/customization/setting/setting.go
@@ -12,7 +12,7 @@ import (
 	v3client "github.com/rancher/types/client/management/v3"
 )
 
-var readOnlySettings = []string{
+var ReadOnlySettings = []string{
 	"cacerts",
 }
 
@@ -29,7 +29,7 @@ func PipelineFormatter(apiContext *types.APIContext, resource *types.RawResource
 func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 	if convert.ToString(resource.Values["source"]) == "env" {
 		delete(resource.Links, "update")
-	} else if slice.ContainsString(readOnlySettings, resource.ID) {
+	} else if slice.ContainsString(ReadOnlySettings, resource.ID) {
 		delete(resource.Links, "update")
 	}
 }
@@ -50,7 +50,7 @@ func Validator(request *types.APIContext, schema *types.Schema, data map[string]
 	}
 	if setting.Source == "env" {
 		return httperror.NewAPIError(httperror.MethodNotAllowed, fmt.Sprintf("%s is readOnly because its value is from environment variable", id))
-	} else if slice.ContainsString(readOnlySettings, id) {
+	} else if slice.ContainsString(ReadOnlySettings, id) {
 		return httperror.NewAPIError(httperror.MethodNotAllowed, fmt.Sprintf("%s is readOnly", id))
 	}
 

--- a/pkg/api/store/setting/store.go
+++ b/pkg/api/store/setting/store.go
@@ -1,36 +1,54 @@
 package setting
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/store/transform"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/norman/types/slice"
+	"github.com/rancher/rancher/pkg/api/customization/setting"
 	"github.com/rancher/rancher/pkg/settings"
 )
 
-func New(store types.Store) types.Store {
-	return &transform.Store{
-		Store: store,
-		Transformer: func(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, opt *types.QueryOptions) (map[string]interface{}, error) {
-			v, ok := data["value"]
-			id := convert.ToString(data["id"])
-			value, ok2 := os.LookupEnv(settings.GetEnvKey(id))
-			switch {
-			case ok2:
-				data["value"] = value
-				data["customized"] = false
-				data["source"] = "env"
+type Store struct {
+	types.Store
+}
 
-			case !ok || v == "":
-				data["value"] = data["default"]
-				data["customized"] = false
-				data["source"] = "default"
-			default:
-				data["customized"] = true
-				data["source"] = "db"
-			}
-			return data, nil
+func New(store types.Store) types.Store {
+	return &Store{
+		&transform.Store{
+			Store: store,
+			Transformer: func(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, opt *types.QueryOptions) (map[string]interface{}, error) {
+				v, ok := data["value"]
+				id := convert.ToString(data["id"])
+				value, ok2 := os.LookupEnv(settings.GetEnvKey(id))
+				switch {
+				case ok2:
+					data["value"] = value
+					data["customized"] = false
+					data["source"] = "env"
+
+				case !ok || v == "":
+					data["value"] = data["default"]
+					data["customized"] = false
+					data["source"] = "default"
+				default:
+					data["customized"] = true
+					data["source"] = "db"
+				}
+				return data, nil
+			},
 		},
 	}
+}
+
+func (s *Store) Delete(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
+	if slice.ContainsString(setting.ReadOnlySettings, id) {
+		return nil, httperror.NewAPIError(httperror.MethodNotAllowed, fmt.Sprintf("Cannot delete readOnly setting %s.", id))
+	}
+
+	return s.Store.Delete(apiContext, schema, id)
 }

--- a/tests/integration/suite/test_rbac.py
+++ b/tests/integration/suite/test_rbac.py
@@ -3,7 +3,7 @@ from rancher import ApiError
 
 from .common import random_str
 from .conftest import wait_until_available, \
-    cluster_and_client, wait_for, ClusterContext  # kubernetes_api_client
+    cluster_and_client, kubernetes_api_client, wait_for, ClusterContext
 
 
 def test_multi_user(admin_mc, user_mc):
@@ -19,7 +19,6 @@ def test_multi_user(admin_mc, user_mc):
     assert len(ac) == 0
 
 
-'''
 def test_project_owner(admin_cc, admin_mc, user_mc, remove_resource):
     """Tests that a non-admin member can create a project, create and
     add a namespace to it, and can do workload related things in the namespace.
@@ -140,7 +139,6 @@ def test_project_owner(admin_cc, admin_mc, user_mc, remove_resource):
     })
     response = auth.create_self_subject_access_review(access_review)
     assert response.status.allowed is True
-'''
 
 
 def test_removing_user_from_cluster(admin_pc, admin_mc, user_mc, admin_cc,
@@ -226,7 +224,6 @@ def test_user_role_permissions(admin_mc, user_factory, remove_resource):
                                            "to view roleTemplates")
 
 
-'''
 def test_impersonation_passthrough(admin_mc, admin_cc, user_mc, user_factory,
                                    remove_resource, request):
     """Test users abalility to impersonate other users"""
@@ -322,7 +319,6 @@ def test_impersonation_passthrough(admin_mc, admin_cc, user_mc, user_factory,
     # User1 should now be abele to imerpsonate as user2
     response = user1_auth.create_self_subject_access_review(access_review2)
     assert response.status.allowed is True
-'''
 
 
 def test_permissions_can_be_removed(admin_cc, admin_mc, user_mc, request,

--- a/tests/integration/suite/test_settings.py
+++ b/tests/integration/suite/test_settings.py
@@ -7,8 +7,7 @@ def test_create_read_only(admin_mc, remove_resource):
     client = admin_mc.client
 
     with pytest.raises(ApiError) as e:
-        setting = client.create_setting(name="cacerts", value="a")
-        remove_resource(setting)
+        client.create_setting(name="cacerts", value="a")
 
     assert e.value.error.status == 405
     assert "readOnly" in e.value.error.message
@@ -19,8 +18,7 @@ def test_update_read_only(admin_mc, remove_resource):
     client = admin_mc.client
 
     with pytest.raises(ApiError) as e:
-        setting = client.update_by_id_setting(id="cacerts", value="b")
-        remove_resource(setting)
+        client.update_by_id_setting(id="cacerts", value="b")
 
     assert e.value.error.status == 405
     assert "readOnly" in e.value.error.message
@@ -29,8 +27,19 @@ def test_update_read_only(admin_mc, remove_resource):
 # cacerts is readOnly, and should be able to be read
 def test_get_read_only(admin_mc, remove_resource):
     client = admin_mc.client
+    client.by_id_setting(id="cacerts")
+
+
+# cacerts is readOnly, and user should not be able to delete
+def test_delete_read_only(admin_mc, remove_resource):
+    client = admin_mc.client
     setting = client.by_id_setting(id="cacerts")
-    remove_resource(setting)
+
+    with pytest.raises(ApiError) as e:
+        client.delete(setting)
+
+    assert e.value.error.status == 405
+    assert "readOnly" in e.value.error.message
 
 
 # user should be able to create a setting that does not exist yet


### PR DESCRIPTION
Problem:
Setting tests are deleting cacert setting causing some rbac tests to fail if they are executed after.

Solution:
Disable ability to delete readonly settings with settings API. Settings tests no longer attempt remove cacert setting, aside from test for deletion. Reenabled rbac tests.