### PR TITLE
Backport Add check for cluster scoped finalizers

### DIFF
--- a/pkg/controllers/management/clustergc/cluster_scoped_gc.go
+++ b/pkg/controllers/management/clustergc/cluster_scoped_gc.go
@@ -5,58 +5,27 @@ import (
 	"strings"
 
 	"github.com/rancher/norman/lifecycle"
-	"github.com/rancher/norman/objectclient"
-	"github.com/rancher/types/apis/core/v1"
+	"github.com/rancher/norman/resource"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/labels"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/cache"
-)
-
-const (
-	prtbByClusterIndex = "managment.cattle.io/prtb-by-cluster"
+	"k8s.io/client-go/dynamic"
 )
 
 func Register(ctx context.Context, management *config.ManagementContext) {
-	informer := management.Management.ProjectRoleTemplateBindings("").Controller().Informer()
-	indexers := map[string]cache.IndexFunc{
-		prtbByClusterIndex: prtbByCluster,
-	}
-	informer.AddIndexers(indexers)
-
 	gc := &gcLifecycle{
-		rtLister:                management.Management.RoleTemplates("").Controller().Lister(),
-		grbLister:               management.Management.GlobalRoleBindings("").Controller().Lister(),
-		projectLister:           management.Management.Projects("").Controller().Lister(),
-		crtbLister:              management.Management.ClusterRoleTemplateBindings("").Controller().Lister(),
-		nodeLister:              management.Management.Nodes("").Controller().Lister(),
-		psptLister:              management.Management.PodSecurityPolicyTemplates("").Controller().Lister(),
-		secretsLister:           management.Core.Secrets("").Controller().Lister(),
-		clusterAlertGroupLister: management.Management.ClusterAlertGroups("").Controller().Lister(),
-		projectAlertGroupLister: management.Management.ProjectAlertGroups("").Controller().Lister(),
-		projectAlertRuleLister:  management.Management.ProjectAlertRules("").Controller().Lister(),
-		prtbIndexer:             informer.GetIndexer(),
-		mgmt:                    management,
+		mgmt: management,
 	}
 
 	management.Management.Clusters("").AddLifecycle(ctx, "cluster-scoped-gc", gc)
 }
 
 type gcLifecycle struct {
-	projectLister           v3.ProjectLister
-	crtbLister              v3.ClusterRoleTemplateBindingLister
-	prtbIndexer             cache.Indexer
-	nodeLister              v3.NodeLister
-	rtLister                v3.RoleTemplateLister
-	grbLister               v3.GlobalRoleBindingLister
-	psptLister              v3.PodSecurityPolicyTemplateLister
-	secretsLister           v1.SecretLister
-	clusterAlertGroupLister v3.ClusterAlertGroupLister
-	projectAlertGroupLister v3.ProjectAlertGroupLister
-	projectAlertRuleLister  v3.ProjectAlertRuleLister
-	mgmt                    *config.ManagementContext
+	mgmt *config.ManagementContext
 }
 
 func (c *gcLifecycle) Create(obj *v3.Cluster) (runtime.Object, error) {
@@ -67,12 +36,12 @@ func (c *gcLifecycle) Updated(obj *v3.Cluster) (runtime.Object, error) {
 	return nil, nil
 }
 
-func cleanFinalizers(clusterName string, object runtime.Object, client *objectclient.ObjectClient) error {
-	object = object.DeepCopyObject()
+func cleanFinalizers(clusterName string, object *unstructured.Unstructured, dynamicClient dynamic.ResourceInterface) (*unstructured.Unstructured, error) {
+	object = object.DeepCopy()
 	modified := false
 	md, err := meta.Accessor(object)
 	if err != nil {
-		return err
+		return object, err
 	}
 	finalizers := md.GetFinalizers()
 	for i := len(finalizers) - 1; i >= 0; i-- {
@@ -85,146 +54,31 @@ func cleanFinalizers(clusterName string, object runtime.Object, client *objectcl
 
 	if modified {
 		md.SetFinalizers(finalizers)
-		_, err := client.Update(md.GetName(), object)
-		return err
+		obj, e := dynamicClient.Update(object, metav1.UpdateOptions{})
+		return obj, e
 	}
-	return nil
+	return object, nil
 }
 
 func (c *gcLifecycle) Remove(cluster *v3.Cluster) (runtime.Object, error) {
-	rts, err := c.rtLister.List("", labels.Everything())
-	if err != nil {
-		return cluster, err
-	}
-	oClient := c.mgmt.Management.RoleTemplates("").ObjectClient()
-	for _, rt := range rts {
-		if err := cleanFinalizers(cluster.Name, rt, oClient); err != nil {
+
+	for key := range resource.Get() {
+		objList, err := c.mgmt.DynamicClient.Resource(key).List(metav1.ListOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				// skip this iteration, no objects were initialized of this type for the cluster
+				continue
+			}
 			return cluster, err
 		}
-	}
 
-	grbs, err := c.grbLister.List("", labels.Everything())
-	if err != nil {
-		return cluster, err
-	}
-	oClient = c.mgmt.Management.GlobalRoleBindings("").ObjectClient()
-	for _, grb := range grbs {
-		if err := cleanFinalizers(cluster.Name, grb, oClient); err != nil {
-			return cluster, err
-		}
-	}
-
-	projects, err := c.projectLister.List(cluster.Name, labels.Everything())
-	if err != nil {
-		return cluster, err
-	}
-	oClient = c.mgmt.Management.Projects(cluster.Name).ObjectClient()
-	for _, p := range projects {
-		if err := cleanFinalizers(cluster.Name, p, oClient); err != nil {
-			return cluster, err
-		}
-	}
-
-	crtbs, err := c.crtbLister.List(cluster.Name, labels.Everything())
-	if err != nil {
-		return cluster, err
-	}
-	oClient = c.mgmt.Management.ClusterRoleTemplateBindings("").ObjectClient()
-	for _, p := range crtbs {
-		if err := cleanFinalizers(cluster.Name, p, oClient); err != nil {
-			return cluster, err
-		}
-	}
-
-	projectAlertRules, err := c.projectAlertRuleLister.List("", labels.Everything())
-	if err != nil {
-		return cluster, err
-	}
-	oClient = c.mgmt.Management.ProjectAlertRules("").ObjectClient()
-	for _, p := range projectAlertRules {
-		if err := cleanFinalizers(cluster.Name, p, oClient); err != nil {
-			return cluster, err
-		}
-	}
-
-	projectAlertGroups, err := c.projectAlertGroupLister.List("", labels.Everything())
-	if err != nil {
-		return cluster, err
-	}
-	oClient = c.mgmt.Management.ProjectAlertGroups("").ObjectClient()
-	for _, p := range projectAlertGroups {
-		if err := cleanFinalizers(cluster.Name, p, oClient); err != nil {
-			return cluster, err
-		}
-	}
-
-	clusterAlertGroups, err := c.clusterAlertGroupLister.List("", labels.Everything())
-	if err != nil {
-		return cluster, err
-	}
-	oClient = c.mgmt.Management.ClusterAlertGroups("").ObjectClient()
-	for _, p := range clusterAlertGroups {
-		if err := cleanFinalizers(cluster.Name, p, oClient); err != nil {
-			return cluster, err
-		}
-	}
-
-	secrets, err := c.secretsLister.List("", labels.Everything())
-	if err != nil {
-		return cluster, err
-	}
-	oClient = c.mgmt.Core.Secrets("").ObjectClient()
-	for _, p := range secrets {
-		if err := cleanFinalizers(cluster.Name, p, oClient); err != nil {
-			return cluster, err
-		}
-	}
-
-	nodes, err := c.nodeLister.List(cluster.Name, labels.Everything())
-	if err != nil {
-		return cluster, err
-	}
-	oClient = c.mgmt.Management.Nodes("").ObjectClient()
-	for _, p := range nodes {
-		if err := cleanFinalizers(cluster.Name, p, oClient); err != nil {
-			return cluster, err
-		}
-	}
-
-	pspts, err := c.psptLister.List("", labels.Everything())
-	if err != nil {
-		return cluster, err
-	}
-	oClient = c.mgmt.Management.PodSecurityPolicyTemplates("").ObjectClient()
-	for _, pspt := range pspts {
-		if err := cleanFinalizers(cluster.Name, pspt, oClient); err != nil {
-			return cluster, err
-		}
-	}
-
-	prtbs, err := c.prtbIndexer.ByIndex(prtbByClusterIndex, cluster.Name)
-	if err != nil {
-		return cluster, err
-	}
-	for _, pr := range prtbs {
-		prtb, _ := pr.(*v3.ProjectRoleTemplateBinding)
-		oClient = c.mgmt.Management.ProjectRoleTemplateBindings(prtb.Namespace).ObjectClient()
-		if err := cleanFinalizers(cluster.Name, prtb, oClient); err != nil {
-			return cluster, err
+		for _, obj := range objList.Items {
+			_, err = cleanFinalizers(cluster.Name, &obj, c.mgmt.DynamicClient.Resource(key).Namespace(obj.GetNamespace()))
+			if err != nil {
+				return cluster, err
+			}
 		}
 	}
 
 	return nil, nil
-}
-
-func prtbByCluster(obj interface{}) ([]string, error) {
-	prtb, ok := obj.(*v3.ProjectRoleTemplateBinding)
-	if !ok {
-		return []string{}, nil
-	}
-
-	if parts := strings.SplitN(prtb.ProjectName, ":", 2); len(parts) == 2 && len(parts[1]) > 0 {
-		return []string{parts[0]}, nil
-	}
-	return []string{}, nil
 }

--- a/pkg/controllers/management/clustergc/cluster_scoped_gc_test.go
+++ b/pkg/controllers/management/clustergc/cluster_scoped_gc_test.go
@@ -1,0 +1,138 @@
+package clustergc
+
+import (
+	"testing"
+
+	"github.com/rancher/norman/lifecycle"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func TestCleanFinalizersGeneric(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		object      *unstructured.Unstructured
+		wantFinal   []string
+	}{
+		{
+			name:        "basic case",
+			clusterName: "test",
+			object: finalizerFactory(
+				lifecycle.ScopedFinalizerKey + "blah" + "_" + "test",
+			),
+			wantFinal: []string{},
+		},
+		{
+			"DontRemoveUnrelated",
+			"a",
+			finalizerFactory(
+				lifecycle.ScopedFinalizerKey+"App"+"_"+"b",
+				lifecycle.ScopedFinalizerKey+"App"+"_"+"a",
+			),
+			[]string{lifecycle.ScopedFinalizerKey + "App" + "_" + "b"},
+		},
+		{
+			"NoFinalizers",
+			"a",
+			&unstructured.Unstructured{},
+			nil,
+		},
+		{
+			"DontAffectNonScoped",
+			"a",
+			finalizerFactory("controller.cattle.io/" + "App" + "_" + "a"),
+			[]string{"controller.cattle.io/" + "App" + "_" + "a"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			object, err := cleanFinalizers(tt.clusterName, tt.object, mockDynamicResourceInterface{})
+			if err != nil {
+				t.Errorf("cleanFinalizersGeneric() error = %v", err)
+			}
+			md, err := meta.Accessor(object)
+			if err != nil {
+				t.Errorf("cleanFinalizersGeneric() error = %v", err)
+			}
+			finalizers := md.GetFinalizers()
+			assert.Equal(t, tt.wantFinal, finalizers)
+		})
+	}
+}
+
+// use meta accessors to set finalizer values
+func finalizerFactory(finals ...string) *unstructured.Unstructured {
+
+	randomStr := "nameofType"
+	metadata := &metav1.ObjectMeta{
+		Name:       randomStr,
+		Finalizers: finals,
+	}
+	unstruct := &unstructured.Unstructured{}
+	err := setObjectMeta(unstruct, metadata)
+	if err != nil {
+		panic(err)
+	}
+	return unstruct
+
+}
+
+func setObjectMeta(u *unstructured.Unstructured, objectMeta *metav1.ObjectMeta) error {
+	if objectMeta == nil {
+		unstructured.RemoveNestedField(u.UnstructuredContent(), "metadata")
+		return nil
+	}
+	metadata, err := runtime.DefaultUnstructuredConverter.ToUnstructured(objectMeta)
+	if err != nil {
+		return err
+	}
+	if u.Object == nil {
+		u.Object = make(map[string]interface{})
+	}
+	u.Object["metadata"] = metadata
+	return nil
+}
+
+type mockDynamicResourceInterface struct{}
+
+func (mockDynamicResourceInterface) Update(obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return obj, nil
+}
+
+func (mockDynamicResourceInterface) Create(obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	panic("implement me")
+}
+
+func (mockDynamicResourceInterface) UpdateStatus(obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	panic("implement me")
+}
+
+func (mockDynamicResourceInterface) Delete(name string, options *metav1.DeleteOptions, subresources ...string) error {
+	panic("implement me")
+}
+
+func (mockDynamicResourceInterface) DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	panic("implement me")
+}
+
+func (mockDynamicResourceInterface) Get(name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	panic("implement me")
+}
+
+func (mockDynamicResourceInterface) List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	panic("implement me")
+}
+
+func (mockDynamicResourceInterface) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	panic("implement me")
+}
+
+func (mockDynamicResourceInterface) Patch(name string, pt types.PatchType, data []byte, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	panic("implement me")
+}


### PR DESCRIPTION
Problem: Cluster scoped finalizers were preventing deletion of
    resources. The previous solution of manually writing cleanup code
    within cluster_scoped_gc.go was difficult to maintain.

Solution: All generated handlers have an init function that adds to a
    map within the norman framework. During cluster deletion this map is
    iterated over and finalizers are removed as needed.

Addresses  https://github.com/rancher/rancher/issues/19900 https://github.com/rancher/rancher/issues/19899