### PR TITLE
Disable empty gzip

### DIFF
--- a/server/responsewriter/gzip.go
+++ b/server/responsewriter/gzip.go
@@ -23,16 +23,28 @@ type gzipResponseWriter struct {
 }
 
 func (g gzipResponseWriter) Write(b []byte) (int, error) {
+	// Header logic is kept here in case the user does not use WriteHeader
+	g.Header().Set("Content-Encoding", "gzip")
+	g.Header().Del("Content-Length")
+
 	return g.Writer.Write(b)
 }
 
-// should always be used when using gzip to overwrite outdated header info
+// Close uses gzip to write gzip footer if message is gzip encoded
+func (g gzipResponseWriter) Close(writer *gzip.Writer) {
+	if g.Header().Get("Content-Encoding") == "gzip" {
+		writer.Close()
+	}
+}
+
+// WriteHeader sets gzip encoding and removes length. Should always be used when using gzip writer.
 func (g gzipResponseWriter) WriteHeader(statusCode int) {
 	g.Header().Set("Content-Encoding", "gzip")
 	g.Header().Del("Content-Length")
 	g.ResponseWriter.WriteHeader(statusCode)
 }
 
+// Gzip creates a gzip writer if gzip encoding is accepted.
 func Gzip(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
@@ -40,16 +52,16 @@ func Gzip(handler http.Handler) http.Handler {
 			return
 		}
 		gz := gzip.NewWriter(w)
-		defer gz.Close()
 
 		gzw := &wrapWriter{gzipResponseWriter{Writer: gz, ResponseWriter: w}, http.StatusOK}
-		// setting content-encoding is kept here in case the user does not use WriteHeader
-		gzw.Header().Set("Content-Encoding", "gzip")
+		defer gzw.Close(gz)
+
+		// Content encoding will be set once Write or WriteHeader is called, to avoid gzipping empty messages
 		handler.ServeHTTP(gzw, r)
 	})
 }
 
-// Must implement Hijacker to properly chain with handlers expecting a hijacker handler to be passed
+// Hijack must be implemented to properly chain with handlers expecting a hijacker handler to be passed
 func (g *gzipResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if hijacker, ok := g.ResponseWriter.(http.Hijacker); ok {
 		return hijacker.Hijack()

--- a/server/responsewriter/gzip_test.go
+++ b/server/responsewriter/gzip_test.go
@@ -8,17 +8,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// all other writers will attempt additional unnecessary logic
-// this implements http.responseWriter and io.Writer
+// All other writers will attempt additional unnecessary logic
+// Implements http.responseWriter and io.Writer
 type DummyWriter struct {
 	header map[string][]string
+	buffer []byte
 }
 
 type DummyHandler struct {
 }
 
+type DummyHandlerWithWrite struct {
+	DummyHandler
+	next http.Handler
+}
+
 func NewDummyWriter() *DummyWriter {
-	return &DummyWriter{map[string][]string{}}
+	return &DummyWriter{map[string][]string{}, []byte{}}
+}
+
+func NewRequest(accept string) *http.Request {
+	return &http.Request{
+		Header: map[string][]string{"Accept-Encoding": {accept}},
+	}
 }
 
 func (d *DummyWriter) Header() http.Header {
@@ -26,6 +38,7 @@ func (d *DummyWriter) Header() http.Header {
 }
 
 func (d *DummyWriter) Write(p []byte) (n int, err error) {
+	d.buffer = append(d.buffer, p...)
 	return 0, nil
 }
 
@@ -35,53 +48,127 @@ func (d *DummyWriter) WriteHeader(int) {
 func (d *DummyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
-// WriteHeader should delete current content-length in header
+func (d *DummyHandlerWithWrite) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte{0, 0})
+	if d.next != nil {
+		d.next.ServeHTTP(w, r)
+	}
+}
+
+// TestWriteHeader asserts content-length header is deleted and content-encoding header is set to gzip
 func TestWriteHeader(t *testing.T) {
+	assert := assert.New(t)
+
 	w := NewDummyWriter()
 	gz := &gzipResponseWriter{gzip.NewWriter(w), w}
 
 	gz.Header().Set("Content-Length", "80")
 	gz.WriteHeader(400)
 	// Content-Length should have been deleted in WriterHeader, resulting in empty string
-	assert.Equal(t, "", gz.Header().Get("Content-Length"))
-	assert.Equal(t, "gzip", gz.Header().Get("Content-Encoding"))
+	assert.Equal("", gz.Header().Get("Content-Length"))
+	assert.Equal(1, len(w.header["Content-Encoding"]))
+	assert.Equal("gzip", gz.Header().Get("Content-Encoding"))
 }
 
-// Gzip handler function should set content-type to "gzip" if accept-encoding header contains gzip
-func TestHandlerSetContent(t *testing.T) {
+// TestSetContentWithoutWrite asserts content-encoding is NOT "gzip" if accept-encoding header does not contain gzip
+func TestSetContentWithoutWrite(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test content encoding header when write is not used
+	handlerFunc := Gzip(&DummyHandler{})
+
+	// Test when accept-encoding only contains gzip
 	rw := NewDummyWriter()
-	handler := &DummyHandler{}
-	req := &http.Request{}
-
-	req.Header = map[string][]string{}
-	handlerFunc := Gzip(handler)
-
-	// test when accept-encoding only contains gzip
-	req.Header.Set("Accept-Encoding", "gzip")
+	req := NewRequest("gzip")
 	handlerFunc.ServeHTTP(rw, req)
-	assert.Equal(t, "gzip", rw.Header().Get("Content-Encoding"))
+	// Content encoding should be empty since write has not been used
+	assert.Equal(0, len(rw.header["Content-Encoding"]))
+	assert.Equal("", rw.Header().Get("Content-Encoding"))
 
-	// test when accept-encoding contains multiple options, including gzip
-	req.Header.Set("Accept-Encoding", "json, xml, gzip")
+	// Test when accept-encoding contains multiple options, including gzip
+	rw = NewDummyWriter()
+	req = NewRequest("json, xml, gzip")
 	handlerFunc.ServeHTTP(rw, req)
-	assert.Equal(t, "gzip", rw.Header().Get("Content-Encoding"))
+	assert.Equal(0, len(rw.header["Content-Encoding"]))
+	assert.Equal("", rw.Header().Get("Content-Encoding"))
+
+	// Test when accept-encoding is empty
+	req = NewRequest("")
+	rw = NewDummyWriter()
+	handlerFunc.ServeHTTP(rw, req)
+	assert.Equal(0, len(rw.header["Content-Encoding"]))
+	assert.Equal("", rw.Header().Get("Content-Encoding"))
+
+	// Test when accept-encoding is is not empty but does not include gzip
+	req = NewRequest("json, xml")
+	rw = NewDummyWriter()
+	handlerFunc.ServeHTTP(rw, req)
+	assert.Equal(0, len(rw.header["Content-Encoding"]))
+	assert.Equal("", rw.Header().Get("Content-Encoding"))
 }
 
-// Gzip handler function should not change content-type if accept encoding does not contain gzip
-func TestHandlerForNonGzip(t *testing.T) {
+// TestSetContentWithWrite asserts content-encoding is "gzip" if accept-encoding header contains gzip
+func TestSetContentWithWrite(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test content encoding header when write is used
+	handlerFunc := Gzip(&DummyHandlerWithWrite{})
+
+	// Test when accept-encoding only contains gzip
+	req := NewRequest("gzip")
 	rw := NewDummyWriter()
-	handler := &DummyHandler{}
-	req := &http.Request{}
-
-	req.Header = map[string][]string{}
-	handlerFunc := Gzip(handler)
-
-	// test when there is no Accept-Encoding header
 	handlerFunc.ServeHTTP(rw, req)
-	assert.NotEqual(t, "gzip", rw.Header().Get("Content-Encoding"))
+	// Content encoding should be gzip since write has been used
+	assert.Equal(1, len(rw.header["Content-Encoding"]))
+	assert.Equal("gzip", rw.Header().Get("Content-Encoding"))
 
-	// test when there are multiple Accept-Encoding header values, none of which are gzip
-	req.Header.Set("Accept-Encoding", "json, xml")
+	// Test when accept-encoding contains multiple options, including gzip
+	req = NewRequest("json, xml, gzip")
+	rw = NewDummyWriter()
 	handlerFunc.ServeHTTP(rw, req)
-	assert.NotEqual(t, "gzip", rw.Header().Get("Content-Encoding"))
+	// Content encoding should be gzip since write has been used
+	assert.Equal(1, len(rw.header["Content-Encoding"]))
+	assert.Equal("gzip", rw.Header().Get("Content-Encoding"))
+
+	// Test when accept-encoding is empty
+	req = NewRequest("")
+	rw = NewDummyWriter()
+	handlerFunc.ServeHTTP(rw, req)
+	// Content encoding should be empty since gzip is not an accepted encoding
+	assert.Equal(0, len(rw.header["Content-Encoding"]))
+	assert.Equal("", rw.Header().Get("Content-Encoding"))
+
+	// Test when accept-encoding is is not empty but does not include gzip
+	req = NewRequest("json, xml")
+	rw = NewDummyWriter()
+	handlerFunc.ServeHTTP(rw, req)
+	// Content encoding should be empty since gzip is not an accepted encoding
+	assert.Equal(0, len(rw.header["Content-Encoding"]))
+	assert.Equal("", rw.Header().Get("Content-Encoding"))
+}
+
+// TestMultipleWrites ensures that Write can be used multiple times
+func TestMultipleWrites(t *testing.T) {
+	assert := assert.New(t)
+
+	// Handler function that contains one writing handler
+	handlerFuncOneWrite := Gzip(&DummyHandlerWithWrite{})
+
+	// Handler function that contains a chain of two writing handlers
+	handlerFuncTwoWrites := Gzip(&DummyHandlerWithWrite{next: &DummyHandlerWithWrite{}})
+
+	req := NewRequest("gzip")
+	rw := NewDummyWriter()
+	handlerFuncOneWrite.ServeHTTP(rw, req)
+	oneWriteResult := rw.buffer
+
+	req = NewRequest("gzip")
+	rw = NewDummyWriter()
+	handlerFuncTwoWrites.ServeHTTP(rw, req)
+	multiWriteResult := rw.buffer
+
+	// Content encoding should be gzip since write has been used (twice)
+	assert.Equal(1, len(rw.header["Content-Encoding"]))
+	assert.Equal("gzip", rw.Header().Get("Content-Encoding"))
+	assert.NotEqual(multiWriteResult, oneWriteResult)
 }


### PR DESCRIPTION
Problem:

Responses with no body were being needlessly gzipped. This generated confusion as empty responses had a length greater than zero.

Solution:

Gzip encoding is now only used once a response writer writes to body.

Issue:
https://github.com/rancher/rancher/issues/19553
