### PR TITLE
Allow editing load balancer capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 /tests/MANIFEST
 /tests/.cache
 /tests/.tox
+/tests/integration/.tox/
+/tests/integration/MANIFEST
 /tests/.venv
 /tests/.idea
 /default.etcd

--- a/pkg/controllers/management/cluster/clustercontroller_test.go
+++ b/pkg/controllers/management/cluster/clustercontroller_test.go
@@ -5,15 +5,15 @@ import (
 
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/apis/management.cattle.io/v3/fakes"
-
 	"github.com/stretchr/testify/assert"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
 const testServiceNodePortRange = "10000-32769"
 
-func TestSetNodePortRange(t *testing.T) {
+func initializeController() *controller {
 	c := controller{
 		nodeLister: &fakes.NodeListerMock{
 			ListFunc: func(namespace string, selector labels.Selector) ([]*v3.Node, error) {
@@ -21,7 +21,11 @@ func TestSetNodePortRange(t *testing.T) {
 			},
 		},
 	}
+	return &c
+}
 
+func TestSetNodePortRange(t *testing.T) {
+	c := initializeController()
 	testCluster := v3.Cluster{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "testCluster",
@@ -33,11 +37,40 @@ func TestSetNodePortRange(t *testing.T) {
 						ServiceNodePortRange: testServiceNodePortRange,
 					},
 				},
+				CloudProvider: v3.CloudProvider{},
 			},
 		},
 	}
+
 	caps := v3.Capabilities{}
-	caps, err := c.RKECapabilities(caps, *testCluster.Spec.RancherKubernetesEngineConfig, testCluster.Name)
+	caps, err := c.RKECapabilities(caps, caps, *testCluster.Spec.RancherKubernetesEngineConfig, testCluster.Name)
 	assert.Nil(t, err)
 	assert.Equal(t, testServiceNodePortRange, caps.NodePortRange)
+}
+
+func TestLoadBalancerCapability(t *testing.T) {
+	c := initializeController()
+	testCluster := v3.Cluster{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "testCluster",
+		},
+		Spec: v3.ClusterSpec{
+			RancherKubernetesEngineConfig: &v3.RancherKubernetesEngineConfig{
+				CloudProvider: v3.CloudProvider{},
+			},
+		},
+	}
+
+	caps := v3.Capabilities{}
+	// the default values are set in this case
+	caps, err := c.RKECapabilities(caps, caps, *testCluster.Spec.RancherKubernetesEngineConfig, testCluster.Name)
+	assert.Nil(t, err)
+	assert.False(t, *caps.LoadBalancerCapabilities.Enabled)
+
+	enabled := true
+	userInputCaps := v3.Capabilities{LoadBalancerCapabilities: v3.LoadBalancerCapabilities{Enabled: &enabled}}
+	caps, err = c.RKECapabilities(userInputCaps, caps, *testCluster.Spec.RancherKubernetesEngineConfig, testCluster.Name)
+	assert.Nil(t, err)
+	assert.NotNil(t, caps.LoadBalancerCapabilities.Enabled)
+	assert.True(t, *caps.LoadBalancerCapabilities.Enabled)
 }

--- a/tests/integration/suite/test_cluster_capabilities.py
+++ b/tests/integration/suite/test_cluster_capabilities.py
@@ -1,0 +1,76 @@
+from .common import random_str
+
+
+def test_user_input_capabilities_create(admin_mc, remove_resource):
+    client = admin_mc.client
+    name = random_str()
+    # create cluster, set the capabilities in spec
+    # only lb caps are allowed to be created/edited through API
+    # rest should be set by the controller.
+    cluster = client.\
+        create_cluster(name=name,
+                       rancherKubernetesEngineConfig={
+                        "kubernetesVersion": "some-fake-version",
+                        "cloudProvider": {
+                            "name": "",
+                        },
+                        },
+                       userInputCapabilities={
+                        "loadBalancerCapabilities": {
+                            "enabled": "true",
+                        },
+                        "ingressCapabilities": {
+                            "ingressProvider": "test_provider",
+                        },
+                        "nodePoolScalingSupported": "true",
+                        "nodePortRange": "10000-32000",
+                        })
+    remove_resource(cluster)
+    cluster = client.reload(cluster)
+    spec_capabilities = cluster['userInputCapabilities']
+    # only lb capability can be set during creation,
+    # so only that should be true
+    assert spec_capabilities['loadBalancerCapabilities']['enabled'] is True
+    # the other caps should not match the ones provided during create,
+    # since these fields have the nocreate tag
+    assert 'ingressCapabilities' not in spec_capabilities
+    assert spec_capabilities['nodePoolScalingSupported'] is False
+    assert 'nodePortRange' not in spec_capabilities
+
+
+def test_user_input_capabilities_update(admin_mc, remove_resource):
+    client = admin_mc.client
+    name = random_str()
+    # create cluster, set the capabilities in spec
+    # only lb caps are allowed to be created/edited through API
+    # rest should be set by the controller.
+    cluster = client. \
+        create_cluster(name=name,
+                       rancherKubernetesEngineConfig={
+                           "kubernetesVersion": "some-fake-version",
+                           "cloudProvider": {
+                               "name": "",
+                           },
+                       })
+    remove_resource(cluster)
+    cluster = client.reload(cluster)
+    cluster = client.update(cluster, name=name,
+                            userInputCapabilities={
+                             "loadBalancerCapabilities": {
+                                "enabled": "true",
+                             },
+                             "ingressCapabilities": {
+                                "ingressProvider": "test_provider",
+                             },
+                             "nodePoolScalingSupported": "true",
+                             "nodePortRange": "10000-32000",
+                            })
+    spec_capabilities = cluster['userInputCapabilities']
+    # only lb capability can be set during update,
+    # so only that should be true
+    assert spec_capabilities['loadBalancerCapabilities']['enabled'] is True
+    # the other caps should not match the ones provided during update,
+    # since these fields have the noupdate tag
+    assert 'ingressCapabilities' not in spec_capabilities
+    assert spec_capabilities['nodePoolScalingSupported'] is False
+    assert 'nodePortRange' not in spec_capabilities

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     ea122abac582d745a00dba0aaf946c29ee8d9d90
-github.com/rancher/types                      927dd05a5e51bd6ad0af37d42fa4123f7dba0317
+github.com/rancher/types                      clustercapsspec https://github.com/mrajashree/types
 github.com/rancher/kontainer-engine           7606e7e7a2dcad29f22758ad689a00ea622c2d1f
 github.com/rancher/rke                        c4839f0ecc66b4ba2dc2faa4ab550a26fe37bdd4
 

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -92,6 +92,7 @@ type ClusterSpec struct {
 	EnableClusterAlerting                bool                           `json:"enableClusterAlerting" norman:"default=false"`
 	EnableClusterMonitoring              bool                           `json:"enableClusterMonitoring" norman:"default=false"`
 	LocalClusterAuthEndpoint             LocalClusterAuthEndpoint       `json:"localClusterAuthEndpoint,omitempty"`
+	UserInputCapabilities                Capabilities                   `json:"userInputCapabilities,omitempty"`
 }
 
 type ImportedConfig struct {
@@ -215,9 +216,9 @@ type ImportYamlOutput struct {
 
 type Capabilities struct {
 	LoadBalancerCapabilities LoadBalancerCapabilities `json:"loadBalancerCapabilities,omitempty"`
-	IngressCapabilities      []IngressCapabilities    `json:"ingressCapabilities,omitempty"`
-	NodePoolScalingSupported bool                     `json:"nodePoolScalingSupported,omitempty"`
-	NodePortRange            string                   `json:"nodePortRange,omitempty"`
+	IngressCapabilities      []IngressCapabilities    `json:"ingressCapabilities,omitempty" norman:"nocreate,noupdate"`
+	NodePoolScalingSupported bool                     `json:"nodePoolScalingSupported,omitempty" norman:"nocreate,noupdate"`
+	NodePortRange            string                   `json:"nodePortRange,omitempty" norman:"nocreate,noupdate"`
 }
 
 type LoadBalancerCapabilities struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -1808,6 +1808,7 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		**out = **in
 	}
 	out.LocalClusterAuthEndpoint = in.LocalClusterAuthEndpoint
+	in.UserInputCapabilities.DeepCopyInto(&out.UserInputCapabilities)
 	return
 }
 

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster.go
@@ -47,6 +47,7 @@ const (
 	ClusterFieldTransitioning                        = "transitioning"
 	ClusterFieldTransitioningMessage                 = "transitioningMessage"
 	ClusterFieldUUID                                 = "uuid"
+	ClusterFieldUserInputCapabilities                = "userInputCapabilities"
 	ClusterFieldVersion                              = "version"
 )
 
@@ -93,6 +94,7 @@ type Cluster struct {
 	Transitioning                        string                         `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
 	TransitioningMessage                 string                         `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
 	UUID                                 string                         `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	UserInputCapabilities                *Capabilities                  `json:"userInputCapabilities,omitempty" yaml:"userInputCapabilities,omitempty"`
 	Version                              *Info                          `json:"version,omitempty" yaml:"version,omitempty"`
 }
 

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_spec.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_spec.go
@@ -20,6 +20,7 @@ const (
 	ClusterSpecFieldInternal                            = "internal"
 	ClusterSpecFieldLocalClusterAuthEndpoint            = "localClusterAuthEndpoint"
 	ClusterSpecFieldRancherKubernetesEngineConfig       = "rancherKubernetesEngineConfig"
+	ClusterSpecFieldUserInputCapabilities               = "userInputCapabilities"
 )
 
 type ClusterSpec struct {
@@ -41,4 +42,5 @@ type ClusterSpec struct {
 	Internal                            bool                           `json:"internal,omitempty" yaml:"internal,omitempty"`
 	LocalClusterAuthEndpoint            *LocalClusterAuthEndpoint      `json:"localClusterAuthEndpoint,omitempty" yaml:"localClusterAuthEndpoint,omitempty"`
 	RancherKubernetesEngineConfig       *RancherKubernetesEngineConfig `json:"rancherKubernetesEngineConfig,omitempty" yaml:"rancherKubernetesEngineConfig,omitempty"`
+	UserInputCapabilities               *Capabilities                  `json:"userInputCapabilities,omitempty" yaml:"userInputCapabilities,omitempty"`
 }


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/18275
Types PR: https://github.com/rancher/types/pull/816

For RKE provisioned clusters that aren't using cloud providers like aws/azure, there is no l4 load balancing solution added during cluster provisioning. Hence the load balancer capability is set to False by the cluster controller, and so in UI while creating a workload, the option of adding a lb is disabled. There are solutions such as MetalLB for bare metal clusters which can be added later on, and when they're added, rancher should enable lb creation. But there's no sure way of detecting whether a bare metal lb is added or not, since there are different ways of adding MetalLB, and users could also use their custom controllers in place of MetalLB. So we now allow users to edit the load balancer capabilities on the cluster, so they can set it to true when they add their lbs. The controller uses this value instead of the default one.