### PR TITLE
Fix Windows host-gw mode public ip issue

### DIFF
--- a/package/windows/hyperkube.ps1
+++ b/package/windows/hyperkube.ps1
@@ -636,9 +636,6 @@ function start-flanneld {
         "`"--alsologtostderr=true`""
         "`"--log-file=$LogDir\flanneld.log`""
     )
-    if ($NodePublicIP) {
-        $flanneldArgs += @("`"--public-ip=$NodePublicIP`"")
-    }
     if ($NodeIP) {
         $flanneldArgs += @("`"--iface=$NodeIP`"")
     }

--- a/package/windows/run.ps1
+++ b/package/windows/run.ps1
@@ -181,14 +181,17 @@ $CATTLE_NODE_NAME = $CATTLE_NODE_NAME.ToLower()
 # check node address #
 $CATTLE_ADDRESS = get-address -Addr $CATTLE_ADDRESS
 $CATTLE_INTERNAL_ADDRESS = get-address -Addr $CATTLE_INTERNAL_ADDRESS
-if (-not $CATTLE_ADDRESS) {
+if (-not $CATTLE_INTERNAL_ADDRESS) {
     try {
         $route = Find-NetRoute -RemoteIPAddress 8.8.8.8 | Select-Object -First 1
-        $CATTLE_ADDRESS = $route.IPAddress
+        $CATTLE_INTERNAL_ADDRESS = $route.IPAddress
     } catch {}
 }
+if (-not $CATTLE_INTERNAL_ADDRESS) {
+    throw "-internalAddress is a required option"
+}
 if (-not $CATTLE_ADDRESS) {
-    throw "-address is a required option"
+    $CATTLE_ADDRESS = $CATTLE_INTERNAL_ADDRESS
 }
 
 # download cattle server CA #


### PR DESCRIPTION
**Problem:**
Use `host-gw`, if passing public IP, flannel will be failed to run.

**Solution:**
- Remove `--public-ip` when flanneld starting
- `-internalAddress` should be the required option on Windows, because, on Windows, kubelet cannot confirm which nic has the correct internal address, we need to pass it into `--node-ip` as kubelet running args.

**Issue:**
https://github.com/rancher/rancher/issues/19964