### PR TITLE
release/v2.0 - [server-chart] add ingress config snippet

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -18,3 +18,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
   {{- end -}}
 {{- end -}}
+
+# Render Values in configurationSnippet
+{{- define "configurationSnippet" -}}
+  {{- tpl (.Values.ingress.configurationSnippet) . -}}
+{{- end -}}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -8,6 +8,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
+{{- if .Values.ingress.configurationSnippet }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      {{ template "configurationSnippet" . }}
+{{- end }}
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,6 +12,10 @@ imagePullSecrets: []
 ### ingress ###
 # See tls section for details.
 ingress:
+  # configurationSnippet - Add additional Nginx configuration. This example statically sets a header on the ingress.
+  # configurationSnippet: |
+  #   more_set_input_headers X-Forwarded-Host {{ .Values.hostname }};
+
   tls:
     # rancher, letsEncrypt, secrets
     source: rancher


### PR DESCRIPTION
backport for #19958

Add chart option to pass in additional nginx configuration snippets and clean up some extra white space in values.yaml.

Example: Statically set a header:

```
helm install ./bin/chart/dev/rancher-0.0.0-dirty.c1c2e191e.tgz --name rancher \
--namespace cattle-system \
--set rancherImageTag=v2.2.2 \
--set hostname=jgreat-test-3.eng.rancher.space \
--set ingress.configurationSnippet='more_set_input_headers X-Forwarded-Host {{ .Values.hostname }};'
```