### PR TITLE
Install logging & alert with cluster system account

### DIFF
--- a/pkg/controllers/user/alert/deployer/deployer.go
+++ b/pkg/controllers/user/alert/deployer/deployer.go
@@ -270,7 +270,7 @@ func (d *appDeployer) getSecret(secretName, secretNamespace string) *corev1.Secr
 }
 
 func (d *appDeployer) deploy(appName, appTargetNamespace, systemProjectID string) (bool, error) {
-	_, systemProjectName := ref.Parse(systemProjectID)
+	clusterName, systemProjectName := ref.Parse(systemProjectID)
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -308,7 +308,7 @@ func (d *appDeployer) deploy(appName, appTargetNamespace, systemProjectID string
 		return false, fmt.Errorf("failed to find catalog by ID %q, %v", catalogID, err)
 	}
 
-	creator, err := d.systemAccountManager.GetProjectSystemUser(systemProjectName)
+	creator, err := d.systemAccountManager.GetSystemUser(clusterName)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controllers/user/logging/deployer/deployer.go
+++ b/pkg/controllers/user/logging/deployer/deployer.go
@@ -80,7 +80,7 @@ func (d *Deployer) sync() error {
 		return d.appDeployer.cleanup(appName, namepspace, systemProjectID)
 	}
 
-	creator, err := d.systemAccountManager.GetProjectSystemUser(systemProject.Name)
+	creator, err := d.systemAccountManager.GetSystemUser(systemProject.Spec.ClusterName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Problem:**
1. Logging and alerting app can't be deployed due to privileges of
account is not enough.

**Solution:**
1. Use cluster system account instead of project system account to
install them.

**Related Issues:**
master

https://github.com/rancher/rancher/issues/19971
https://github.com/rancher/rancher/issues/19959

2.2 (We need to backport to 2.2 branch)
https://github.com/rancher/rancher/issues/19974
https://github.com/rancher/rancher/issues/19970