### PR TITLE
Backport: Redeploy Operator when accidentally deleted

### DIFF
--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -385,7 +385,7 @@ func (ch *clusterHandler) deployApp(appName, appTargetNamespace string, appProje
 		},
 	}
 
-	err = monitoring.DeployApp(ch.app.cattleAppClient, appDeployProjectID, app)
+	err = monitoring.DeployApp(ch.app.cattleAppClient, appDeployProjectID, app, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -270,7 +270,7 @@ func (ph *projectHandler) deployApp(appName, appTargetNamespace string, appProje
 		},
 	}
 
-	err = monitoring.DeployApp(ph.app.cattleAppClient, appDeployProjectID, app)
+	err = monitoring.DeployApp(ph.app.cattleAppClient, appDeployProjectID, app, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Problem:**
False deletion of Operator workload causes the redeployment of
Cluster Monitoring to fail.

**Solution:**
Check Operator workload isn't alive, then redeploy the App.

**Issue:**
https://github.com/rancher/rancher/issues/19998