### PR TITLE
Fix project monitoring v2.2

### DIFF
--- a/app/role_data.go
+++ b/app/role_data.go
@@ -174,6 +174,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("management.cattle.io").resources("catalogtemplates").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("catalogtemplateversions").verbs("*").
 		addRule().apiGroups("monitoring.cattle.io").resources("prometheus").verbs("view").
+		addRule().apiGroups("monitoring.coreos.com").resources("prometheuses", "prometheusRules", "serviceMonitors").verbs("*").
 		setRoleTemplateNames("admin")
 
 	rb.addRoleTemplate("Project Member", "project-member", "project", true, false, false, false).
@@ -197,6 +198,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("management.cattle.io").resources("catalogtemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("catalogtemplateversions").verbs("get", "list", "watch").
 		addRule().apiGroups("monitoring.cattle.io").resources("prometheus").verbs("view").
+		addRule().apiGroups("monitoring.coreos.com").resources("prometheuses", "prometheusRules", "serviceMonitors").verbs("*").
 		setRoleTemplateNames("edit")
 
 	rb.addRoleTemplate("Read-only", "read-only", "project", true, false, false, false).
@@ -216,6 +218,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("management.cattle.io").resources("clustercatalogs").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectcatalogs").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectmonitorgraphs").verbs("get", "list", "watch").
+		addRule().apiGroups("monitoring.coreos.com").resources("prometheuses", "prometheusRules", "serviceMonitors").verbs("get", "list", "watch").
 		setRoleTemplateNames("view")
 
 	rb.addRoleTemplate("Create Namespaces", "create-ns", "project", true, false, false, false).
@@ -290,6 +293,10 @@ func addRoles(management *config.ManagementContext) (string, error) {
 
 	rb.addRoleTemplate("View Project Catalogs", "projectcatalogs-view", "project", true, false, false, false).
 		addRule().apiGroups("management.cattle.io").resources("projectcatalogs").verbs("get", "list", "watch")
+
+	rb.addRoleTemplate("Project Monitoring View Role", "project-monitoring-readonly", "project", true, false, true, false).
+		addRule().apiGroups("monitoring.cattle.io").resources("prometheus").verbs("view").
+		setRoleTemplateNames("view")
 
 	// Not specific to project or cluster
 	// TODO When clusterevents has value, consider adding this back in

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"github.com/pkg/errors"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -134,7 +134,7 @@ func (c *crtbLifecycle) reconcilBindings(binding *v3.ClusterRoleTemplateBinding)
 		clusterRoleName = strings.ToLower(fmt.Sprintf("%v-clustermember", clusterName))
 	}
 
-	subject, err := buildSubjectFromRTB(binding)
+	subject, err := pkgrbac.BuildSubjectFromRTB(binding)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -1,9 +1,8 @@
 package auth
 
 import (
-	"reflect"
-
 	"fmt"
+	"reflect"
 
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/objectclient"
@@ -762,49 +761,4 @@ func buildRule(resource string, verbs map[string]bool) v1.PolicyRule {
 		Verbs:     vs,
 		APIGroups: []string{"*"},
 	}
-}
-
-func buildSubjectFromRTB(binding interface{}) (v1.Subject, error) {
-	var userName, groupPrincipalName, groupName, name, kind string
-	if rtb, ok := binding.(*v3.ProjectRoleTemplateBinding); ok {
-		userName = rtb.UserName
-		groupPrincipalName = rtb.GroupPrincipalName
-		groupName = rtb.GroupName
-	} else if rtb, ok := binding.(*v3.ClusterRoleTemplateBinding); ok {
-		userName = rtb.UserName
-		groupPrincipalName = rtb.GroupPrincipalName
-		groupName = rtb.GroupName
-	} else {
-		return v1.Subject{}, errors.Errorf("unrecognized roleTemplateBinding type: %v", binding)
-	}
-
-	if userName != "" {
-		name = userName
-		kind = "User"
-	}
-
-	if groupPrincipalName != "" {
-		if name != "" {
-			return v1.Subject{}, errors.Errorf("roletemplatebinding has more than one subject fields set: %v", binding)
-		}
-		name = groupPrincipalName
-		kind = "Group"
-	}
-
-	if groupName != "" {
-		if name != "" {
-			return v1.Subject{}, errors.Errorf("roletemplatebinding has more than one subject fields set: %v", binding)
-		}
-		name = groupName
-		kind = "Group"
-	}
-
-	if name == "" {
-		return v1.Subject{}, errors.Errorf("roletemplatebinding doesn't have any subject fields set: %v", binding)
-	}
-
-	return v1.Subject{
-		Kind: kind,
-		Name: name,
-	}, nil
 }

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/pkg/errors"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 )
@@ -48,6 +49,9 @@ type prtbLifecycle struct {
 }
 
 func (p *prtbLifecycle) Create(obj *v3.ProjectRoleTemplateBinding) (runtime.Object, error) {
+	if obj.ServiceAccount != "" {
+		return obj, nil
+	}
 	obj, err := p.reconcileSubject(obj)
 	if err != nil {
 		return nil, err
@@ -57,6 +61,9 @@ func (p *prtbLifecycle) Create(obj *v3.ProjectRoleTemplateBinding) (runtime.Obje
 }
 
 func (p *prtbLifecycle) Updated(obj *v3.ProjectRoleTemplateBinding) (runtime.Object, error) {
+	if obj.ServiceAccount != "" {
+		return obj, nil
+	}
 	obj, err := p.reconcileSubject(obj)
 	if err != nil {
 		return nil, err
@@ -159,7 +166,7 @@ func (p *prtbLifecycle) reconcileBindings(binding *v3.ProjectRoleTemplateBinding
 		projectRoleName = strings.ToLower(fmt.Sprintf("%v-projectmember", projectName))
 	}
 
-	subject, err := buildSubjectFromRTB(binding)
+	subject, err := pkgrbac.BuildSubjectFromRTB(binding)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/user/helm/common.go
+++ b/pkg/controllers/user/helm/common.go
@@ -122,8 +122,8 @@ func (l *Lifecycle) generateTemplates(obj *v3.App) (string, string, string, stri
 
 	appDir := filepath.Join(tempDir, appSubDir)
 
-	common.InjectDefaultRegistry(obj)
-	setValues, err := common.GenerateAnswerSetValues(obj, tempDir)
+	extraArgs := common.GetExtraArgs(obj)
+	setValues, err := common.GenerateAnswerSetValues(obj, tempDir, extraArgs)
 	if err != nil {
 		return "", "", "", tempDir, err
 	}

--- a/pkg/controllers/user/helm/common/common.go
+++ b/pkg/controllers/user/helm/common/common.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/namespace"
-	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/types/apis/project.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 )
@@ -28,9 +27,6 @@ const (
 	tillerName      = "tiller"
 	helmName        = "helm"
 	forceUpgradeStr = "--force"
-
-	systemCatalogName     = "system-library"
-	systemDefaultRegistry = "global.systemDefaultRegistry"
 )
 
 func ParseExternalID(externalID string) (string, string, error) {
@@ -65,26 +61,6 @@ func SplitExternalID(externalID string) (string, string, string, string, string,
 	return templateVersionNamespace, catalog, catalogType, template, version, nil
 }
 
-func InjectDefaultRegistry(obj *v3.App) {
-	if obj.Spec.Answers == nil || obj.Spec.Answers[systemDefaultRegistry] != "" {
-		return
-	}
-
-	values, err := url.Parse(obj.Spec.ExternalID)
-	if err != nil {
-		logrus.Errorf("check catalog type failed: %s", err.Error())
-	}
-
-	catalogWithNamespace := values.Query().Get("catalog")
-	split := strings.SplitN(catalogWithNamespace, "/", 2)
-	catalog := split[len(split)-1]
-
-	reg := settings.SystemDefaultRegistry.Get()
-	if catalog == systemCatalogName && reg != "" {
-		obj.Spec.Answers[systemDefaultRegistry] = reg
-	}
-}
-
 // StartTiller start tiller server and return the listening address of the grpc address
 func StartTiller(context context.Context, port, probePort, namespace, kubeConfigPath string) error {
 	cmd := exec.Command(tillerName, "--listen", ":"+port, "--probe", ":"+probePort)
@@ -117,8 +93,8 @@ func GenerateRandomPort() string {
 }
 
 func InstallCharts(rootDir, port string, obj *v3.App) error {
-	InjectDefaultRegistry(obj)
-	setValues, err := GenerateAnswerSetValues(obj, rootDir)
+	extraArgs := GetExtraArgs(obj)
+	setValues, err := GenerateAnswerSetValues(obj, rootDir, extraArgs)
 	if err != nil {
 		return err
 	}
@@ -155,7 +131,7 @@ func InstallCharts(rootDir, port string, obj *v3.App) error {
 	return nil
 }
 
-func GenerateAnswerSetValues(app *v3.App, tempDir string) ([]string, error) {
+func GenerateAnswerSetValues(app *v3.App, tempDir string, extraArgs map[string]string) ([]string, error) {
 	setValues := []string{}
 	// a user-supplied values file will overridden default values.yaml
 	if app.Spec.ValuesYaml != "" {
@@ -166,10 +142,16 @@ func GenerateAnswerSetValues(app *v3.App, tempDir string) ([]string, error) {
 		setValues = append(setValues, "--values", valuesYaml)
 	}
 	// `--set` values will overridden the user-supplied values.yaml file
-	if app.Spec.Answers != nil {
+	if app.Spec.Answers != nil || extraArgs != nil {
 		answers := app.Spec.Answers
 		var values = []string{}
 		for k, v := range answers {
+			if _, ok := extraArgs[k]; ok {
+				continue
+			}
+			values = append(values, fmt.Sprintf("%s=%s", k, v))
+		}
+		for k, v := range extraArgs {
 			values = append(values, fmt.Sprintf("%s=%s", k, v))
 		}
 		setValues = append(setValues, "--set", strings.Join(values, ","))

--- a/pkg/controllers/user/helm/common/extra_args_injection.go
+++ b/pkg/controllers/user/helm/common/extra_args_injection.go
@@ -1,0 +1,60 @@
+package common
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/rancher/rancher/pkg/ref"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/types/apis/project.cattle.io/v3"
+	"github.com/sirupsen/logrus"
+)
+
+type InjectAppArgsFunc func(obj *v3.App) (content map[string]string)
+
+const (
+	systemCatalogName = "system-library"
+)
+
+var (
+	extraArgsFuncs = []InjectAppArgsFunc{
+		injectDefaultRegistry,
+		injectClusterInfo,
+	}
+)
+
+func injectDefaultRegistry(obj *v3.App) map[string]string {
+	values, err := url.Parse(obj.Spec.ExternalID)
+	if err != nil {
+		logrus.Errorf("check catalog type failed: %s", err.Error())
+	}
+
+	catalogWithNamespace := values.Query().Get("catalog")
+	split := strings.SplitN(catalogWithNamespace, "/", 2)
+	catalog := split[len(split)-1]
+
+	reg := settings.SystemDefaultRegistry.Get()
+	if catalog != systemCatalogName || reg == "" {
+		return nil
+	}
+	return map[string]string{"systemDefaultRegistry": reg}
+}
+
+func injectClusterInfo(obj *v3.App) map[string]string {
+	clusterName, projectName := ref.Parse(obj.Spec.ProjectName)
+	return map[string]string{
+		"clusterName": clusterName,
+		"projectName": projectName,
+	}
+}
+
+func GetExtraArgs(app *v3.App) map[string]string {
+	rtn := map[string]string{}
+	for _, afunc := range extraArgsFuncs {
+		content := afunc(app)
+		for k, v := range content {
+			rtn["global."+k] = v
+		}
+	}
+	return rtn
+}

--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -385,7 +385,7 @@ func (ch *clusterHandler) deployApp(appName, appTargetNamespace string, appProje
 		},
 	}
 
-	err = monitoring.DeployApp(ch.app.cattleAppClient, appDeployProjectID, app)
+	_, err = monitoring.DeployApp(ch.app.cattleAppClient, appDeployProjectID, app)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/user/monitoring/operatorHandler.go
+++ b/pkg/controllers/user/monitoring/operatorHandler.go
@@ -195,7 +195,7 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) (backErr erro
 		},
 	}
 
-	err = monitoring.DeployApp(app.cattleAppClient, appDeployProjectID, targetApp)
+	_, err = monitoring.DeployApp(app.cattleAppClient, appDeployProjectID, targetApp)
 	if err != nil {
 		return errors.Wrap(err, "failed to ensure prometheus operator app")
 	}

--- a/pkg/controllers/user/monitoring/register.go
+++ b/pkg/controllers/user/monitoring/register.go
@@ -70,11 +70,18 @@ func Register(ctx context.Context, agentContext *config.UserContext) {
 	}
 	agentClusterMonitoringEndpointClient.AddHandler(ctx, "cluster-monitoring-enabled-handler", cmeh.sync)
 
+	prtbInformer := mgmtContext.ProjectRoleTemplateBindings("").Controller().Informer()
+	prtbInformer.AddIndexers(map[string]cache.IndexFunc{
+		prtbBySA: prtbBySAFunc,
+	})
+
 	// project handler
 	ph := &projectHandler{
 		clusterName:         clusterName,
 		cattleClusterClient: cattleClustersClient,
 		cattleProjectClient: cattleProjectsClient,
+		prtbIndexer:         prtbInformer.GetIndexer(),
+		prtbClient:          mgmtContext.ProjectRoleTemplateBindings(""),
 		app:                 ah,
 	}
 	cattleProjectsClient.Controller().AddClusterScopedHandler(ctx, "project-monitoring-handler", clusterName, ph.sync)

--- a/pkg/controllers/user/rbac/prtb_handler.go
+++ b/pkg/controllers/user/rbac/prtb_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/types/slice"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
@@ -51,7 +52,7 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 		logrus.Warnf("ProjectRoleTemplateBinding %v has no role template set. Skipping.", binding.Name)
 		return nil
 	}
-	if binding.UserName == "" && binding.GroupPrincipalName == "" && binding.GroupName == "" {
+	if binding.UserName == "" && binding.GroupPrincipalName == "" && binding.GroupName == "" && binding.ServiceAccount == "" {
 		return nil
 	}
 
@@ -175,7 +176,7 @@ func (p *prtbLifecycle) reconcileProjectAccessToGlobalResources(binding *v3.Proj
 	}
 
 	rtbUID := string(binding.UID)
-	subject, err := buildSubjectFromRTB(binding)
+	subject, err := pkgrbac.BuildSubjectFromRTB(binding)
 	if err != nil {
 		return err
 	}

--- a/pkg/monitoring/deploy.go
+++ b/pkg/monitoring/deploy.go
@@ -98,34 +98,35 @@ func GetSystemProjectID(cattleProjectsClient mgmtv3.ProjectInterface) (string, e
 	return systemProject.Name, nil
 }
 
-func DeployApp(cattleAppClient projectv3.AppInterface, projectID string, createOrUpdateApp *projectv3.App) error {
+func DeployApp(cattleAppClient projectv3.AppInterface, projectID string, createOrUpdateApp *projectv3.App) (*projectv3.App, error) {
 	if createOrUpdateApp == nil {
-		return errors.New("cannot deploy a nil App")
+		return nil, errors.New("cannot deploy a nil App")
 	}
+	var rtn *projectv3.App
 
 	appName := createOrUpdateApp.Name
 	app, err := cattleAppClient.GetNamespaced(projectID, appName, metav1.GetOptions{})
 	if err != nil && !k8serrors.IsNotFound(err) {
-		return errors.Wrapf(err, "failed to query %q App in %s Project", appName, projectID)
+		return nil, errors.Wrapf(err, "failed to query %q App in %s Project", appName, projectID)
 	}
 
 	if app.DeletionTimestamp != nil {
-		return fmt.Errorf("stale %q App in %s Project is still on terminating", appName, projectID)
+		return nil, fmt.Errorf("stale %q App in %s Project is still on terminating", appName, projectID)
 	}
 
 	if app.Name == "" {
-		if _, err = cattleAppClient.Create(createOrUpdateApp); err != nil {
-			return errors.Wrapf(err, "failed to create %q App", appName)
+		if rtn, err = cattleAppClient.Create(createOrUpdateApp); err != nil {
+			return rtn, errors.Wrapf(err, "failed to create %q App", appName)
 		}
 	} else {
 		app = app.DeepCopy()
 		app.Spec.Answers = createOrUpdateApp.Spec.Answers
-		if _, err = cattleAppClient.Update(app); err != nil {
-			return errors.Wrapf(err, "failed to update %q App", appName)
+		if rtn, err = cattleAppClient.Update(app); err != nil {
+			return nil, errors.Wrapf(err, "failed to update %q App", appName)
 		}
 	}
 
-	return nil
+	return rtn, nil
 }
 
 func WithdrawApp(cattleAppClient projectv3.AppInterface, appLabels metav1.ListOptions) error {

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -1,0 +1,69 @@
+package rbac
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// BuildSubjectFromRTB This function will generate
+// PRTB and CRTB to the subject with user, group
+// or service account
+func BuildSubjectFromRTB(object interface{}) (rbacv1.Subject, error) {
+	var userName, groupPrincipalName, groupName, name, kind, sa, namespace string
+	if rtb, ok := object.(*v3.ProjectRoleTemplateBinding); ok {
+		userName = rtb.UserName
+		groupPrincipalName = rtb.GroupPrincipalName
+		groupName = rtb.GroupName
+		sa = rtb.ServiceAccount
+	} else if rtb, ok := object.(*v3.ClusterRoleTemplateBinding); ok {
+		userName = rtb.UserName
+		groupPrincipalName = rtb.GroupPrincipalName
+		groupName = rtb.GroupName
+	} else {
+		return rbacv1.Subject{}, errors.Errorf("unrecognized roleTemplateBinding type: %v", object)
+	}
+
+	if userName != "" {
+		name = userName
+		kind = "User"
+	}
+
+	if groupPrincipalName != "" {
+		if name != "" {
+			return rbacv1.Subject{}, errors.Errorf("roletemplatebinding has more than one subject fields set: %v", object)
+		}
+		name = groupPrincipalName
+		kind = "Group"
+	}
+
+	if groupName != "" {
+		if name != "" {
+			return rbacv1.Subject{}, errors.Errorf("roletemplatebinding has more than one subject fields set: %v", object)
+		}
+		name = groupName
+		kind = "Group"
+	}
+
+	if sa != "" {
+		parts := strings.SplitN(sa, ":", 2)
+		if len(parts) < 2 {
+			return rbacv1.Subject{}, errors.Errorf("service account %s of projectroletemplatebinding is invalid: %v", sa, object)
+		}
+		namespace = parts[0]
+		name = parts[1]
+		kind = "ServiceAccount"
+	}
+
+	if name == "" {
+		return rbacv1.Subject{}, errors.Errorf("roletemplatebinding doesn't have any subject fields set: %v", object)
+	}
+
+	return rbacv1.Subject{
+		Namespace: namespace,
+		Kind:      kind,
+		Name:      name,
+	}, nil
+}

--- a/pkg/rbac/common_test.go
+++ b/pkg/rbac/common_test.go
@@ -1,0 +1,86 @@
+package rbac
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func Test_BuildSubjectFromRTB(t *testing.T) {
+	type testCase struct {
+		from  interface{}
+		to    rbacv1.Subject
+		iserr bool
+	}
+
+	userSubject := rbacv1.Subject{
+		Kind: "User",
+		Name: "tmp-user",
+	}
+
+	groupSubject := rbacv1.Subject{
+		Kind: "Group",
+		Name: "tmp-group",
+	}
+
+	saSubject := rbacv1.Subject{
+		Kind:      "ServiceAccount",
+		Name:      "tmp-sa",
+		Namespace: "tmp-namespace",
+	}
+
+	testCases := []testCase{
+		testCase{
+			from:  nil,
+			iserr: true,
+		},
+		testCase{
+			from: &v3.ProjectRoleTemplateBinding{
+				UserName: userSubject.Name,
+			},
+			to: userSubject,
+		},
+		testCase{
+			from: &v3.ProjectRoleTemplateBinding{
+				GroupName: groupSubject.Name,
+			},
+			to: groupSubject,
+		},
+		testCase{
+			from: &v3.ProjectRoleTemplateBinding{
+				ServiceAccount: fmt.Sprintf("%s:%s", saSubject.Namespace, saSubject.Name),
+			},
+			to: saSubject,
+		},
+		testCase{
+			from: &v3.ClusterRoleTemplateBinding{
+				UserName: userSubject.Name,
+			},
+			to: userSubject,
+		},
+		testCase{
+			from: &v3.ClusterRoleTemplateBinding{
+				GroupName: groupSubject.Name,
+			},
+			to: groupSubject,
+		},
+		testCase{
+			from: &v3.ProjectRoleTemplateBinding{
+				ServiceAccount: "wrong-format",
+			},
+			iserr: true,
+		},
+	}
+
+	for _, tcase := range testCases {
+		output, err := BuildSubjectFromRTB(tcase.from)
+		if tcase.iserr && err == nil {
+			t.Errorf("roletemplatebinding %v should return error", tcase.from)
+		} else if !tcase.iserr && !reflect.DeepEqual(tcase.to, output) {
+			t.Errorf("the subject %v from roletemplatebinding %v is mismatched, expect %v", output, tcase.from, tcase.to)
+		}
+	}
+}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -50,7 +50,7 @@ var (
 	UIKubernetesSupportedVersions   = NewSetting("ui-k8s-supported-versions-range", ">= 1.11.0 <=1.13.x")
 	UIKubernetesDefaultVersion      = NewSetting("ui-k8s-default-version-range", "<=1.13.x")
 	WhitelistDomain                 = NewSetting("whitelist-domain", "forums.rancher.com")
-	SystemMonitoringCatalogID       = NewSetting("system-monitoring-catalog-id", "catalog://?catalog=system-library&template=rancher-monitoring&version=0.0.2")
+	SystemMonitoringCatalogID       = NewSetting("system-monitoring-catalog-id", "catalog://?catalog=system-library&template=rancher-monitoring&version=0.0.3")
 	SystemExternalDNSCatalogID      = NewSetting("system-externaldns-catalog-id", "catalog://?catalog=system-library&template=rancher-external-dns&version=0.0.1")
 	AuthUserInfoResyncCron          = NewSetting("auth-user-info-resync-cron", "0 0 * * *")
 	AuthUserInfoMaxAgeSeconds       = NewSetting("auth-user-info-max-age-seconds", "3600") // 1 hour

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     d50bd367299c3fc8e4ed9d4d558d032d540e7a2c
-github.com/rancher/types                      448bf336f7d3050bcf04b645cc7d6a83e627b9f2
+github.com/rancher/types                      502718e81aacda1a2473bb8cb504fd6e3a2b8af5
 github.com/rancher/kontainer-engine           9e153e13cd4b376e38c727900ef69cca395cd636
 github.com/rancher/rke                        v0.2.3-rc2
 

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
@@ -123,6 +123,7 @@ type ProjectRoleTemplateBinding struct {
 	GroupPrincipalName string `json:"groupPrincipalName,omitempty" norman:"type=reference[principal]"`
 	ProjectName        string `json:"projectName,omitempty" norman:"required,type=reference[project]"`
 	RoleTemplateName   string `json:"roleTemplateName,omitempty" norman:"required,type=reference[roleTemplate]"`
+	ServiceAccount     string `json:"serviceAccount,omitempty" norman:"nocreate,noupdate"`
 }
 
 type ClusterRoleTemplateBinding struct {

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_project_role_template_binding.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_project_role_template_binding.go
@@ -18,6 +18,7 @@ const (
 	ProjectRoleTemplateBindingFieldProjectID        = "projectId"
 	ProjectRoleTemplateBindingFieldRemoved          = "removed"
 	ProjectRoleTemplateBindingFieldRoleTemplateID   = "roleTemplateId"
+	ProjectRoleTemplateBindingFieldServiceAccount   = "serviceAccount"
 	ProjectRoleTemplateBindingFieldUUID             = "uuid"
 	ProjectRoleTemplateBindingFieldUserID           = "userId"
 	ProjectRoleTemplateBindingFieldUserPrincipalID  = "userPrincipalId"
@@ -37,6 +38,7 @@ type ProjectRoleTemplateBinding struct {
 	ProjectID        string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
 	Removed          string            `json:"removed,omitempty" yaml:"removed,omitempty"`
 	RoleTemplateID   string            `json:"roleTemplateId,omitempty" yaml:"roleTemplateId,omitempty"`
+	ServiceAccount   string            `json:"serviceAccount,omitempty" yaml:"serviceAccount,omitempty"`
 	UUID             string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 	UserID           string            `json:"userId,omitempty" yaml:"userId,omitempty"`
 	UserPrincipalID  string            `json:"userPrincipalId,omitempty" yaml:"userPrincipalId,omitempty"`


### PR DESCRIPTION
Backport PR for https://github.com/rancher/rancher/pull/19766

For project monitoring fix, we have following changes:
- Update project monitoring app answers due to the charts version updated.
- Create the project role template binding for service account when enabling project monitoring.
- Support generating sa subject from PRTB.

Support helm install with app info:
Inject cluster name, project name and default registry parameters as extra answers values when helm installing.
We are no longer storing them in app answers like the old default registry parameter.
