### PR TITLE
GlobalDNS FQDN should be of type hostname

### DIFF
--- a/tests/integration/suite/test_globaldns.py
+++ b/tests/integration/suite/test_globaldns.py
@@ -261,3 +261,23 @@ def test_cloudflare_provider_proxy_setting(admin_mc, remove_resource):
     assert gdns_provider.cloudflareProviderConfig.proxySetting is True
 
     remove_resource(globaldns_provider)
+
+
+def test_dns_fqdn_hostname(admin_mc, remove_resource):
+    client = admin_mc.client
+    provider_name = random_str()
+    access = random_str()
+    secret = random_str()
+    globaldns_provider = \
+        client.create_global_dns_provider(
+                                         name=provider_name,
+                                         rootDomain="example.com",
+                                         route53ProviderConfig={
+                                             'accessKey': access,
+                                             'secretKey': secret})
+    remove_resource(globaldns_provider)
+
+    fqdn = random_str() + ".example!!!*.com"
+    with pytest.raises(ApiError) as e:
+        client.create_global_dns(fqdn=fqdn, providerId=provider_name)
+        assert e.value.error.status == 422

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     ea122abac582d745a00dba0aaf946c29ee8d9d90
-github.com/rancher/types                      f8fcf6b36224c6d3359fba70d8a3f258ab7e7d10
+github.com/rancher/types                      ebd23f9ff460bbfa78e497e5d5fd9ea520b5dc7b 
 github.com/rancher/kontainer-engine           7606e7e7a2dcad29f22758ad689a00ea622c2d1f
 github.com/rancher/rke                        5f4cff3f4c6fe3d56d6f9e237177e740620d2c45
 

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/globaldns_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/globaldns_types.go
@@ -18,7 +18,7 @@ type GlobalDNS struct {
 }
 
 type GlobalDNSSpec struct {
-	FQDN                string   `json:"fqdn,omitempty" norman:"required"`
+	FQDN                string   `json:"fqdn,omitempty" norman:"type=hostname,required"`
 	TTL                 int64    `json:"ttl,omitempty" norman:"default=300"`
 	ProjectNames        []string `json:"projectNames" norman:"type=array[reference[project]],noupdate"`
 	MultiClusterAppName string   `json:"multiClusterAppName,omitempty" norman:"type=reference[multiClusterApp]"`


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/19738

Now the GlobalDNS FQDN is of type "hostname" which is a series of dnsLabels, that can only have alphanumeric characters and hyphen(-), separated by dot(.)

rancher/types PR:https://github.com/rancher/types/pull/822