### PR TITLE
Fix panic on UserController

### DIFF
--- a/pkg/controllers/management/auth/user.go
+++ b/pkg/controllers/management/auth/user.go
@@ -376,7 +376,10 @@ func (l *userLifecycle) deleteClusterUserAttributes(username string, tokens []*v
 	set := make(map[string]*v3.Cluster)
 	for _, token := range tokens {
 		cluster, err := l.clusterLister.Get("", token.ClusterName)
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
 			return err
 		}
 		set[token.ClusterName] = cluster


### PR DESCRIPTION
User controller could panic on cluster deletion due to accessing a nil
reference of cluster.Name within the set. Non-existent clusters now will
not be added to the map.

This will need to be backported as well