### PR TITLE
 Don't default rke clusters lb cap to false

### DIFF
--- a/pkg/controllers/management/cluster/clustercontroller.go
+++ b/pkg/controllers/management/cluster/clustercontroller.go
@@ -114,8 +114,6 @@ func (c *controller) RKECapabilities(capabilities v3.Capabilities, rkeConfig v3.
 		capabilities.LoadBalancerCapabilities = c.L4Capability(true, ElasticLoadBalancer, []string{"TCP"}, true)
 	case azure.AzureCloudProviderName:
 		capabilities.LoadBalancerCapabilities = c.L4Capability(true, AzureL4LB, []string{"TCP", "UDP"}, true)
-	default:
-		capabilities.LoadBalancerCapabilities = c.L4Capability(false, "", []string{}, false)
 	}
 	// only if not custom, non custom clusters have nodepools set
 	nodes, err := c.nodeLister.List(clusterName, labels.Everything())

--- a/pkg/controllers/management/cluster/clustercontroller_test.go
+++ b/pkg/controllers/management/cluster/clustercontroller_test.go
@@ -3,17 +3,19 @@ package cluster
 import (
 	"testing"
 
+	"github.com/rancher/rke/cloudprovider/aws"
+	"github.com/rancher/rke/cloudprovider/azure"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/apis/management.cattle.io/v3/fakes"
-
 	"github.com/stretchr/testify/assert"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
 const testServiceNodePortRange = "10000-32769"
 
-func TestSetNodePortRange(t *testing.T) {
+func initializeController() *controller {
 	c := controller{
 		nodeLister: &fakes.NodeListerMock{
 			ListFunc: func(namespace string, selector labels.Selector) ([]*v3.Node, error) {
@@ -21,7 +23,11 @@ func TestSetNodePortRange(t *testing.T) {
 			},
 		},
 	}
+	return &c
+}
 
+func TestSetNodePortRange(t *testing.T) {
+	c := initializeController()
 	testCluster := v3.Cluster{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "testCluster",
@@ -40,4 +46,30 @@ func TestSetNodePortRange(t *testing.T) {
 	caps, err := c.RKECapabilities(caps, *testCluster.Spec.RancherKubernetesEngineConfig, testCluster.Name)
 	assert.Nil(t, err)
 	assert.Equal(t, testServiceNodePortRange, caps.NodePortRange)
+}
+
+func TestLoadBalancerCapability(t *testing.T) {
+	c := initializeController()
+	lbCap := true
+	testCluster := v3.Cluster{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "testCluster",
+		},
+		Spec: v3.ClusterSpec{
+			RancherKubernetesEngineConfig: &v3.RancherKubernetesEngineConfig{},
+		},
+	}
+	// map of cloud provider name to expected lb capability
+	cloudProviderLBCapabilityMap := map[v3.CloudProvider]*bool{
+		v3.CloudProvider{}: nil,
+		v3.CloudProvider{Name: aws.AWSCloudProviderName}:     &lbCap,
+		v3.CloudProvider{Name: azure.AzureCloudProviderName}: &lbCap,
+	}
+	for cloudProvider, expectedLB := range cloudProviderLBCapabilityMap {
+		testCluster.Spec.RancherKubernetesEngineConfig.CloudProvider = cloudProvider
+		caps := v3.Capabilities{}
+		caps, err := c.RKECapabilities(caps, *testCluster.Spec.RancherKubernetesEngineConfig, testCluster.Name)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedLB, caps.LoadBalancerCapabilities.Enabled)
+	}
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/18275#issuecomment-490601105

Couldn't add integration test, since the test would have to create a cluster and the final check is to see if adding an lb in this cluster's project is enabled in the ui