### PR TITLE
Backport: Don't default rke clusters lb cap to false

### DIFF
--- a/pkg/controllers/management/cluster/clustercontroller.go
+++ b/pkg/controllers/management/cluster/clustercontroller.go
@@ -114,8 +114,6 @@ func (c *controller) RKECapabilities(capabilities v3.Capabilities, rkeConfig v3.
 		capabilities.LoadBalancerCapabilities = c.L4Capability(true, ElasticLoadBalancer, []string{"TCP"}, true)
 	case azure.AzureCloudProviderName:
 		capabilities.LoadBalancerCapabilities = c.L4Capability(true, AzureL4LB, []string{"TCP", "UDP"}, true)
-	default:
-		capabilities.LoadBalancerCapabilities = c.L4Capability(false, "", []string{}, false)
 	}
 	// only if not custom, non custom clusters have nodepools set
 	nodes, err := c.nodeLister.List(clusterName, labels.Everything())


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/18275#issuecomment-490601105