### PR TITLE
Backport: Update kafka vendor to support detect kafka broker controller

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -65,5 +65,5 @@ github.com/stretchr/testify                   v1.2.2
 github.com/coreos/prometheus-operator         v0.25.0
 github.com/prometheus/client_golang           v0.9.1
 
-github.com/segmentio/kafka-go                 v0.2.2
+github.com/segmentio/kafka-go                 218fd49cff39a9e6f2981437cf99090a7d1c4a5b
 github.com/vmihailenco/msgpack                v4.0.1

--- a/vendor/github.com/segmentio/kafka-go/README.md
+++ b/vendor/github.com/segmentio/kafka-go/README.md
@@ -30,6 +30,11 @@ APIs for interacting with Kafka, mirroring concepts and implementing interfaces 
 the Go standard library to make it easy to use and integrate with existing
 software.
 
+## Kafka versions
+
+`kafka-go` is currently compatible with Kafka versions from 0.10.1.0 to 2.1.0. While latest versions will be working,
+some features available from the Kafka API may not be implemented yet.
+
 ## Connection [![GoDoc](https://godoc.org/github.com/segmentio/kafka-go?status.svg)](https://godoc.org/github.com/segmentio/kafka-go#Conn)
 
 The `Conn` type is the core of the `kafka-go` package. It wraps around a raw
@@ -112,7 +117,7 @@ r.Close()
 ### Consumer Groups
 
 ```kafka-go``` also supports Kafka consumer groups including broker managed offsets.
-To enable consumer groups, simplify specify the GroupID in the ReaderConfig.
+To enable consumer groups, simply specify the GroupID in the ReaderConfig.
 
 ReadMessage automatically commits offsets when using consumer groups.
 
@@ -238,7 +243,7 @@ w := kafka.NewWriter(kafka.WriterConfig{
 
 ### Compression
 
-Compression can be enable on the writer :
+Compression can be enabled on the `Writer` by configuring the `CompressionCodec`:
 
 ```go
 w := kafka.NewWriter(kafka.WriterConfig{
@@ -248,7 +253,15 @@ w := kafka.NewWriter(kafka.WriterConfig{
 })
 ```
 
-The reader will by default figure out if the consumed messages are compressed by intepreting the message attributes.
+The `Reader` will by determine if the consumed messages are compressed by 
+examining the message attributes.  However, the package(s) for all expected 
+codecs must be imported so that they get loaded correctly.  For example, if you 
+are going to be receiving messages compressed with Snappy, add the following
+import:
+
+```go
+import _ "github.com/segmentio/kafka-go/snappy"
+```
 
 ## TLS Support
 

--- a/vendor/github.com/segmentio/kafka-go/compression.go
+++ b/vendor/github.com/segmentio/kafka-go/compression.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-var errUnknownCodec = errors.New("invalid codec")
+var errUnknownCodec = errors.New("the compression code is invalid or its codec has not been imported")
 
 var codecs = make(map[int8]CompressionCodec)
 var codecsMutex sync.RWMutex
@@ -47,6 +47,5 @@ type CompressionCodec interface {
 	Decode(src []byte) ([]byte, error)
 }
 
-const compressionCodecMask int8 = 0x03
-const DefaultCompressionLevel int = -1
+const compressionCodecMask int8 = 0x07
 const CompressionNoneCode = 0

--- a/vendor/github.com/segmentio/kafka-go/docker-compose.yml
+++ b/vendor/github.com/segmentio/kafka-go/docker-compose.yml
@@ -1,12 +1,13 @@
 version: "3"
 services:
   kafka:
-    image: wurstmeister/kafka:0.11.0.1
+    image: wurstmeister/kafka:2.11-0.11.0.3
     restart: on-failure:3
     links:
       - zookeeper
     ports:
       - "9092:9092"
+      - "9093:9093"
     environment:
       KAFKA_VERSION: '0.11.0.1'
       KAFKA_BROKER_ID: 1
@@ -17,7 +18,13 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_MESSAGE_MAX_BYTES: 200000000
-
+      KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
+      CUSTOM_INIT_SCRIPT: |-
+        echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
+        /opt/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
   zookeeper:
     image: wurstmeister/zookeeper
     ports:

--- a/vendor/github.com/segmentio/kafka-go/error.go
+++ b/vendor/github.com/segmentio/kafka-go/error.go
@@ -64,6 +64,27 @@ const (
 	TransactionalIDAuthorizationFailed Error = 53
 	SecurityDisabled                   Error = 54
 	BrokerAuthorizationFailed          Error = 55
+	KafkaStorageError                  Error = 56
+	LogDirNotFound                     Error = 57
+	SASLAuthenticationFailed           Error = 58
+	UnknownProducerId                  Error = 59
+	ReassignmentInProgress             Error = 60
+	DelegationTokenAuthDisabled        Error = 61
+	DelegationTokenNotFound            Error = 62
+	DelegationTokenOwnerMismatch       Error = 63
+	DelegationTokenRequestNotAllowed   Error = 64
+	DelegationTokenAuthorizationFailed Error = 65
+	DelegationTokenExpired             Error = 66
+	InvalidPrincipalType               Error = 67
+	NonEmptyGroup                      Error = 68
+	GroupIdNotFound                    Error = 69
+	FetchSessionIDNotFound             Error = 70
+	InvalidFetchSessionEpoch           Error = 71
+	ListenerNotFound                   Error = 72
+	TopicDeletionDisabled              Error = 73
+	FencedLeaderEpoch                  Error = 74
+	UnknownLeaderEpoch                 Error = 75
+	UnsupportedCompressionType         Error = 76
 )
 
 // Error satisfies the error interface.
@@ -201,6 +222,48 @@ func (e Error) Title() string {
 		return "Security Disabled"
 	case BrokerAuthorizationFailed:
 		return "Broker Authorization Failed"
+	case KafkaStorageError:
+		return "Kafka Storage Error"
+	case LogDirNotFound:
+		return "Log Dir Not Found"
+	case SASLAuthenticationFailed:
+		return "SASL Authentication Failed"
+	case UnknownProducerId:
+		return "Unknown Producer ID"
+	case ReassignmentInProgress:
+		return "Reassignment In Progress"
+	case DelegationTokenAuthDisabled:
+		return "Delegation Token Auth Disabled"
+	case DelegationTokenNotFound:
+		return "Delegation Token Not Found"
+	case DelegationTokenOwnerMismatch:
+		return "Delegation Token Owner Mismatch"
+	case DelegationTokenRequestNotAllowed:
+		return "Delegation Token Request Not Allowed"
+	case DelegationTokenAuthorizationFailed:
+		return "Delegation Token Authorization Failed"
+	case DelegationTokenExpired:
+		return "Delegation Token Expired"
+	case InvalidPrincipalType:
+		return "Invalid Principal Type"
+	case NonEmptyGroup:
+		return "Non Empty Group"
+	case GroupIdNotFound:
+		return "Group ID Not Found"
+	case FetchSessionIDNotFound:
+		return "Fetch Session ID Not Found"
+	case InvalidFetchSessionEpoch:
+		return "Invalid Fetch Session Epoch"
+	case ListenerNotFound:
+		return "Listener Not Found"
+	case TopicDeletionDisabled:
+		return "Topic Deletion Disabled"
+	case FencedLeaderEpoch:
+		return "Fenced Leader Epoch"
+	case UnknownLeaderEpoch:
+		return "Unknown Leader Epoch"
+	case UnsupportedCompressionType:
+		return "Unsupported Compression Type"
 	}
 	return ""
 }
@@ -318,6 +381,48 @@ func (e Error) Description() string {
 		return "the security features are disabled"
 	case BrokerAuthorizationFailed:
 		return "the broker authorization failed"
+	case KafkaStorageError:
+		return "disk error when trying to access log file on the disk"
+	case LogDirNotFound:
+		return "the user-specified log directory is not found in the broker config"
+	case SASLAuthenticationFailed:
+		return "SASL Authentication failed"
+	case UnknownProducerId:
+		return "the broker could not locate the producer metadata associated with the producer ID"
+	case ReassignmentInProgress:
+		return "a partition reassignment is in progress"
+	case DelegationTokenAuthDisabled:
+		return "delegation token feature is not enabled"
+	case DelegationTokenNotFound:
+		return "delegation token is not found on server"
+	case DelegationTokenOwnerMismatch:
+		return "specified principal is not valid owner/renewer"
+	case DelegationTokenRequestNotAllowed:
+		return "delegation token requests are not allowed on plaintext/1-way ssl channels and on delegation token authenticated channels"
+	case DelegationTokenAuthorizationFailed:
+		return "delegation token authorization failed"
+	case DelegationTokenExpired:
+		return "delegation token is expired"
+	case InvalidPrincipalType:
+		return "supplied principaltype is not supported"
+	case NonEmptyGroup:
+		return "the group is not empty"
+	case GroupIdNotFound:
+		return "the group ID does not exist"
+	case FetchSessionIDNotFound:
+		return "the fetch session ID was not found"
+	case InvalidFetchSessionEpoch:
+		return "the fetch session epoch is invalid"
+	case ListenerNotFound:
+		return "there is no listener on the leader broker that matches the listener on which metadata request was processed"
+	case TopicDeletionDisabled:
+		return "topic deletion is disabled"
+	case FencedLeaderEpoch:
+		return "the leader epoch in the request is older than the epoch on the broker"
+	case UnknownLeaderEpoch:
+		return "the leader epoch in the request is newer than the epoch on the broker"
+	case UnsupportedCompressionType:
+		return "the requesting client does not support the compression type of given partition"
 	}
 	return ""
 }

--- a/vendor/github.com/segmentio/kafka-go/produce.go
+++ b/vendor/github.com/segmentio/kafka-go/produce.go
@@ -111,3 +111,42 @@ func (p *produceResponsePartitionV2) readFrom(r *bufio.Reader, sz int) (remain i
 	}
 	return
 }
+
+type produceResponsePartitionV7 struct {
+	Partition   int32
+	ErrorCode   int16
+	Offset      int64
+	Timestamp   int64
+	StartOffset int64
+}
+
+func (p produceResponsePartitionV7) size() int32 {
+	return 4 + 2 + 8 + 8 + 8
+}
+
+func (p produceResponsePartitionV7) writeTo(w *bufio.Writer) {
+	writeInt32(w, p.Partition)
+	writeInt16(w, p.ErrorCode)
+	writeInt64(w, p.Offset)
+	writeInt64(w, p.Timestamp)
+	writeInt64(w, p.StartOffset)
+}
+
+func (p *produceResponsePartitionV7) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	if remain, err = readInt32(r, sz, &p.Partition); err != nil {
+		return
+	}
+	if remain, err = readInt16(r, remain, &p.ErrorCode); err != nil {
+		return
+	}
+	if remain, err = readInt64(r, remain, &p.Offset); err != nil {
+		return
+	}
+	if remain, err = readInt64(r, remain, &p.Timestamp); err != nil {
+		return
+	}
+	if remain, err = readInt64(r, remain, &p.StartOffset); err != nil {
+		return
+	}
+	return
+}

--- a/vendor/github.com/segmentio/kafka-go/protocol.go
+++ b/vendor/github.com/segmentio/kafka-go/protocol.go
@@ -22,17 +22,23 @@ const (
 	syncGroupRequest        apiKey = 14
 	describeGroupsRequest   apiKey = 15
 	listGroupsRequest       apiKey = 16
+	saslHandshakeRequest    apiKey = 17
+	apiVersionsRequest      apiKey = 18
 	createTopicsRequest     apiKey = 19
 	deleteTopicsRequest     apiKey = 20
+	saslAuthenticateRequest apiKey = 36
 )
 
 type apiVersion int16
 
 const (
-	v0 apiVersion = 0
-	v1 apiVersion = 1
-	v2 apiVersion = 2
-	v3 apiVersion = 3
+	v0  apiVersion = 0
+	v1  apiVersion = 1
+	v2  apiVersion = 2
+	v3  apiVersion = 3
+	v5  apiVersion = 5
+	v7  apiVersion = 7
+	v10 apiVersion = 10
 )
 
 type requestHeader struct {

--- a/vendor/github.com/segmentio/kafka-go/sasl/sasl.go
+++ b/vendor/github.com/segmentio/kafka-go/sasl/sasl.go
@@ -1,0 +1,31 @@
+package sasl
+
+import "context"
+
+// Mechanism implements the SASL state machine.  It is initialized by calling
+// Start at which point the initial bytes should be sent to the server. The
+// caller then loops by passing the server's response into Next and then sending
+// Next's returned bytes to the server.  Eventually either Next will indicate
+// that the authentication has been successfully completed or an error will
+// cause the state machine to exit prematurely.
+//
+// A Mechanism must be re-usable, but it does not need to be safe for concurrent
+// access by multiple go routines.
+type Mechanism interface {
+	// Start begins SASL authentication. It returns the authentication mechanism
+	// name and "initial response" data (if required by the selected mechanism).
+	// A non-nil error causes the client to abort the authentication attempt.
+	//
+	// A nil ir value is different from a zero-length value. The nil value
+	// indicates that the selected mechanism does not use an initial response,
+	// while a zero-length value indicates an empty initial response, which must
+	// be sent to the server.
+	//
+	// In order to ensure that the Mechanism is reusable, calling Start must
+	// reset any internal state.
+	Start(ctx context.Context) (mech string, ir []byte, err error)
+
+	// Next continues challenge-response authentication. A non-nil error causes
+	// the client to abort the authentication attempt.
+	Next(ctx context.Context, challenge []byte) (done bool, response []byte, err error)
+}

--- a/vendor/github.com/segmentio/kafka-go/saslauthenticate.go
+++ b/vendor/github.com/segmentio/kafka-go/saslauthenticate.go
@@ -1,0 +1,54 @@
+package kafka
+
+import (
+	"bufio"
+)
+
+type saslAuthenticateRequestV0 struct {
+	// Data holds the SASL payload
+	Data []byte
+}
+
+func (t saslAuthenticateRequestV0) size() int32 {
+	return sizeofBytes(t.Data)
+}
+
+func (t *saslAuthenticateRequestV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	return readBytes(r, sz, &t.Data)
+}
+
+func (t saslAuthenticateRequestV0) writeTo(w *bufio.Writer) {
+	writeBytes(w, t.Data)
+}
+
+type saslAuthenticateResponseV0 struct {
+	// ErrorCode holds response error code
+	ErrorCode int16
+
+	ErrorMessage string
+
+	Data []byte
+}
+
+func (t saslAuthenticateResponseV0) size() int32 {
+	return sizeofInt16(t.ErrorCode) + sizeofString(t.ErrorMessage) + sizeofBytes(t.Data)
+}
+
+func (t saslAuthenticateResponseV0) writeTo(w *bufio.Writer) {
+	writeInt16(w, t.ErrorCode)
+	writeString(w, t.ErrorMessage)
+	writeBytes(w, t.Data)
+}
+
+func (t *saslAuthenticateResponseV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	if remain, err = readInt16(r, sz, &t.ErrorCode); err != nil {
+		return
+	}
+	if remain, err = readString(r, remain, &t.ErrorMessage); err != nil {
+		return
+	}
+	if remain, err = readBytes(r, remain, &t.Data); err != nil {
+		return
+	}
+	return
+}

--- a/vendor/github.com/segmentio/kafka-go/saslhandshake.go
+++ b/vendor/github.com/segmentio/kafka-go/saslhandshake.go
@@ -1,0 +1,53 @@
+package kafka
+
+import (
+	"bufio"
+)
+
+// saslHandshakeRequestV0 implements the format for V0 and V1 SASL
+// requests (they are identical)
+type saslHandshakeRequestV0 struct {
+	// Mechanism holds the SASL Mechanism chosen by the client.
+	Mechanism string
+}
+
+func (t saslHandshakeRequestV0) size() int32 {
+	return sizeofString(t.Mechanism)
+}
+
+func (t *saslHandshakeRequestV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	return readString(r, sz, &t.Mechanism)
+}
+
+func (t saslHandshakeRequestV0) writeTo(w *bufio.Writer) {
+	writeString(w, t.Mechanism)
+}
+
+// saslHandshakeResponseV0 implements the format for V0 and V1 SASL
+// responses (they are identical)
+type saslHandshakeResponseV0 struct {
+	// ErrorCode holds response error code
+	ErrorCode int16
+
+	// Array of mechanisms enabled in the server
+	EnabledMechanisms []string
+}
+
+func (t saslHandshakeResponseV0) size() int32 {
+	return sizeofInt16(t.ErrorCode) + sizeofStringArray(t.EnabledMechanisms)
+}
+
+func (t saslHandshakeResponseV0) writeTo(w *bufio.Writer) {
+	writeInt16(w, t.ErrorCode)
+	writeStringArray(w, t.EnabledMechanisms)
+}
+
+func (t *saslHandshakeResponseV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	if remain, err = readInt16(r, sz, &t.ErrorCode); err != nil {
+		return
+	}
+	if remain, err = readStringArray(r, remain, &t.EnabledMechanisms); err != nil {
+		return
+	}
+	return
+}

--- a/vendor/github.com/segmentio/kafka-go/sizeof.go
+++ b/vendor/github.com/segmentio/kafka-go/sizeof.go
@@ -48,6 +48,13 @@ func sizeofString(s string) int32 {
 	return 2 + int32(len(s))
 }
 
+func sizeofNullableString(s *string) int32 {
+	if s == nil {
+		return 2
+	}
+	return sizeofString(*s)
+}
+
 func sizeofBool(_ bool) int32 {
 	return 1
 }

--- a/vendor/github.com/segmentio/kafka-go/write.go
+++ b/vendor/github.com/segmentio/kafka-go/write.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	"time"
 )
 
@@ -45,9 +46,36 @@ func writeInt64(w *bufio.Writer, i int64) {
 	w.WriteByte(b[7])
 }
 
+func writeVarInt(w *bufio.Writer, i int64) {
+	i = i<<1 ^ i>>63
+	for i&0x7f != i {
+		w.WriteByte(byte(i&0x7f | 0x80))
+		i >>= 7
+	}
+	w.WriteByte(byte(i))
+}
+
+func varIntLen(i int64) (l int) {
+	i = i<<1 ^ i>>63
+	for i&0x7f != i {
+		l++
+		i >>= 7
+	}
+	l++
+	return l
+}
+
 func writeString(w *bufio.Writer, s string) {
 	writeInt16(w, int16(len(s)))
 	w.WriteString(s)
+}
+
+func writeNullableString(w *bufio.Writer, s *string) {
+	if s == nil {
+		writeInt16(w, -1)
+	} else {
+		writeString(w, *s)
+	}
 }
 
 func writeBytes(w *bufio.Writer, b []byte) {
@@ -149,6 +177,100 @@ func writeFetchRequestV2(w *bufio.Writer, correlationID int32, clientID, topic s
 	return w.Flush()
 }
 
+func writeFetchRequestV5(w *bufio.Writer, correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration, isolationLevel int8) error {
+	h := requestHeader{
+		ApiKey:        int16(fetchRequest),
+		ApiVersion:    int16(v5),
+		CorrelationID: correlationID,
+		ClientID:      clientID,
+	}
+	h.Size = (h.size() - 4) +
+		4 + // replica ID
+		4 + // max wait time
+		4 + // min bytes
+		4 + // max bytes
+		1 + // isolation level
+		4 + // topic array length
+		sizeofString(topic) +
+		4 + // partition array length
+		4 + // partition
+		8 + // offset
+		8 + // log start offset
+		4 // max bytes
+
+	h.writeTo(w)
+	writeInt32(w, -1) // replica ID
+	writeInt32(w, milliseconds(maxWait))
+	writeInt32(w, int32(minBytes))
+	writeInt32(w, int32(maxBytes))
+	writeInt8(w, isolationLevel) // isolation level 0 - read uncommitted
+
+	// topic array
+	writeArrayLen(w, 1)
+	writeString(w, topic)
+
+	// partition array
+	writeArrayLen(w, 1)
+	writeInt32(w, partition)
+	writeInt64(w, offset)
+	writeInt64(w, int64(0)) // log start offset only used when is sent by follower
+	writeInt32(w, int32(maxBytes))
+
+	return w.Flush()
+}
+
+func writeFetchRequestV10(w *bufio.Writer, correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration, isolationLevel int8) error {
+	h := requestHeader{
+		ApiKey:        int16(fetchRequest),
+		ApiVersion:    int16(v10),
+		CorrelationID: correlationID,
+		ClientID:      clientID,
+	}
+	h.Size = (h.size() - 4) +
+		4 + // replica ID
+		4 + // max wait time
+		4 + // min bytes
+		4 + // max bytes
+		1 + // isolation level
+		4 + // session ID
+		4 + // session epoch
+		4 + // topic array length
+		sizeofString(topic) +
+		4 + // partition array length
+		4 + // partition
+		4 + // current leader epoch
+		8 + // fetch offset
+		8 + // log start offset
+		4 + // partition max bytes
+		4 // forgotten topics data
+
+	h.writeTo(w)
+	writeInt32(w, -1) // replica ID
+	writeInt32(w, milliseconds(maxWait))
+	writeInt32(w, int32(minBytes))
+	writeInt32(w, int32(maxBytes))
+	writeInt8(w, isolationLevel) // isolation level 0 - read uncommitted
+	writeInt32(w, 0)             //FIXME
+	writeInt32(w, -1)            //FIXME
+
+	// topic array
+	writeArrayLen(w, 1)
+	writeString(w, topic)
+
+	// partition array
+	writeArrayLen(w, 1)
+	writeInt32(w, partition)
+	writeInt32(w, -1) //FIXME
+	writeInt64(w, offset)
+	writeInt64(w, int64(0)) // log start offset only used when is sent by follower
+	writeInt32(w, int32(maxBytes))
+
+	// forgotten topics array
+	writeArrayLen(w, 0) // forgotten topics not supported yet
+
+	return w.Flush()
+}
+
 func writeListOffsetRequestV1(w *bufio.Writer, correlationID int32, clientID, topic string, partition int32, time int64) error {
 	h := requestHeader{
 		ApiKey:        int16(listOffsetRequest),
@@ -179,30 +301,16 @@ func writeListOffsetRequestV1(w *bufio.Writer, correlationID int32, clientID, to
 	return w.Flush()
 }
 
-func writeProduceRequestV2(w *bufio.Writer, codec CompressionCodec, correlationID int32, clientID, topic string, partition int32, timeout time.Duration, requiredAcks int16, msgs ...Message) error {
-	var size int32
-	attributes := int8(CompressionNoneCode)
+func writeProduceRequestV2(w *bufio.Writer, codec CompressionCodec, correlationID int32, clientID, topic string, partition int32, timeout time.Duration, requiredAcks int16, msgs ...Message) (err error) {
 
-	// if compressing, replace the slice of messages with a single compressed
-	// message set.
+	attributes := int8(CompressionNoneCode)
 	if codec != nil {
-		var err error
 		if msgs, err = compress(codec, msgs...); err != nil {
 			return err
 		}
 		attributes = codec.Code()
 	}
-
-	for _, msg := range msgs {
-		size += 8 + // offset
-			4 + // message size
-			4 + // crc
-			1 + // magic byte
-			1 + // attributes
-			8 + // timestamp
-			sizeofBytes(msg.Key) +
-			sizeofBytes(msg.Value)
-	}
+	size := messageSetSize(msgs...)
 
 	h := requestHeader{
 		ApiKey:        int16(produceRequest),
@@ -231,13 +339,265 @@ func writeProduceRequestV2(w *bufio.Writer, codec CompressionCodec, correlationI
 	// partition array
 	writeArrayLen(w, 1)
 	writeInt32(w, partition)
-	writeInt32(w, size)
 
+	writeInt32(w, size)
 	for _, msg := range msgs {
 		writeMessage(w, msg.Offset, attributes, msg.Time, msg.Key, msg.Value)
 	}
+	return w.Flush()
+}
+
+func writeProduceRequestV3(w *bufio.Writer, codec CompressionCodec, correlationID int32, clientID, topic string, partition int32, timeout time.Duration, requiredAcks int16, transactionalID *string, msgs ...Message) (err error) {
+
+	var size int32
+	var compressed []byte
+	var attributes int16
+	if codec != nil {
+		attributes = int16(codec.Code())
+		recordBuf := &bytes.Buffer{}
+		recordBuf.Grow(int(recordBatchSize(msgs...)))
+		compressedWriter := bufio.NewWriter(recordBuf)
+		for i, msg := range msgs {
+			writeRecord(compressedWriter, 0, msgs[0].Time, int64(i), msg)
+		}
+		compressedWriter.Flush()
+
+		compressed, err = codec.Encode(recordBuf.Bytes())
+		if err != nil {
+			return
+		}
+		attributes = int16(codec.Code())
+		size = recordBatchHeaderSize() + int32(len(compressed))
+	} else {
+		size = recordBatchSize(msgs...)
+	}
+
+	h := requestHeader{
+		ApiKey:        int16(produceRequest),
+		ApiVersion:    int16(v3),
+		CorrelationID: correlationID,
+		ClientID:      clientID,
+	}
+	h.Size = (h.size() - 4) +
+		sizeofNullableString(transactionalID) +
+		2 + // required acks
+		4 + // timeout
+		4 + // topic array length
+		sizeofString(topic) + // topic
+		4 + // partition array length
+		4 + // partition
+		4 + // message set size
+		size
+
+	h.writeTo(w)
+	writeNullableString(w, transactionalID)
+	writeInt16(w, requiredAcks) // required acks
+	writeInt32(w, milliseconds(timeout))
+
+	// topic array
+	writeArrayLen(w, 1)
+	writeString(w, topic)
+
+	// partition array
+	writeArrayLen(w, 1)
+	writeInt32(w, partition)
+
+	writeInt32(w, size)
+	if codec != nil {
+		err = writeRecordBatch(w, attributes, size, func(w *bufio.Writer) {
+			w.Write(compressed)
+		}, msgs...)
+	} else {
+		err = writeRecordBatch(w, attributes, size, func(w *bufio.Writer) {
+			for i, msg := range msgs {
+				writeRecord(w, 0, msgs[0].Time, int64(i), msg)
+			}
+		}, msgs...)
+	}
+	if err != nil {
+		return
+	}
 
 	return w.Flush()
+}
+
+func writeProduceRequestV7(w *bufio.Writer, codec CompressionCodec, correlationID int32, clientID, topic string, partition int32, timeout time.Duration, requiredAcks int16, transactionalID *string, msgs ...Message) (err error) {
+
+	var size int32
+	var compressed []byte
+	var attributes int16
+	if codec != nil {
+		attributes = int16(codec.Code())
+		recordBuf := &bytes.Buffer{}
+		recordBuf.Grow(int(recordBatchSize(msgs...)))
+		compressedWriter := bufio.NewWriter(recordBuf)
+		for i, msg := range msgs {
+			writeRecord(compressedWriter, 0, msgs[0].Time, int64(i), msg)
+		}
+		compressedWriter.Flush()
+
+		compressed, err = codec.Encode(recordBuf.Bytes())
+		if err != nil {
+			return
+		}
+		attributes = int16(codec.Code())
+		size = recordBatchHeaderSize() + int32(len(compressed))
+	} else {
+		size = recordBatchSize(msgs...)
+	}
+
+	h := requestHeader{
+		ApiKey:        int16(produceRequest),
+		ApiVersion:    int16(v7),
+		CorrelationID: correlationID,
+		ClientID:      clientID,
+	}
+	h.Size = (h.size() - 4) +
+		sizeofNullableString(transactionalID) +
+		2 + // required acks
+		4 + // timeout
+		4 + // topic array length
+		sizeofString(topic) + // topic
+		4 + // partition array length
+		4 + // partition
+		4 + // message set size
+		size
+
+	h.writeTo(w)
+	writeNullableString(w, transactionalID)
+	writeInt16(w, requiredAcks) // required acks
+	writeInt32(w, milliseconds(timeout))
+
+	// topic array
+	writeArrayLen(w, 1)
+	writeString(w, topic)
+
+	// partition array
+	writeArrayLen(w, 1)
+	writeInt32(w, partition)
+
+	writeInt32(w, size)
+	if codec != nil {
+		err = writeRecordBatch(w, attributes, size, func(w *bufio.Writer) {
+			w.Write(compressed)
+		}, msgs...)
+	} else {
+		err = writeRecordBatch(w, attributes, size, func(w *bufio.Writer) {
+			for i, msg := range msgs {
+				writeRecord(w, 0, msgs[0].Time, int64(i), msg)
+			}
+		}, msgs...)
+	}
+	if err != nil {
+		return
+	}
+
+	return w.Flush()
+}
+
+func messageSetSize(msgs ...Message) (size int32) {
+	for _, msg := range msgs {
+		size += 8 + // offset
+			4 + // message size
+			4 + // crc
+			1 + // magic byte
+			1 + // attributes
+			8 + // timestamp
+			sizeofBytes(msg.Key) +
+			sizeofBytes(msg.Value)
+	}
+	return
+}
+
+func recordBatchHeaderSize() int32 {
+	return 8 + // base offset
+		4 + // batch length
+		4 + // partition leader epoch
+		1 + // magic
+		4 + // crc
+		2 + // attributes
+		4 + // last offset delta
+		8 + // first timestamp
+		8 + // max timestamp
+		8 + // producer id
+		2 + // producer epoch
+		4 + // base sequence
+		4 // msg count
+}
+
+func recordBatchSize(msgs ...Message) (size int32) {
+	size = recordBatchHeaderSize()
+
+	baseTime := msgs[0].Time
+
+	for i, msg := range msgs {
+
+		sz := recordSize(&msg, msg.Time.Sub(baseTime), int64(i))
+
+		size += int32(sz + varIntLen(int64(sz)))
+	}
+	return
+}
+
+func writeRecordBatch(w *bufio.Writer, attributes int16, size int32, write func(*bufio.Writer), msgs ...Message) error {
+
+	baseTime := msgs[0].Time
+
+	writeInt64(w, int64(0))
+
+	writeInt32(w, int32(size-12)) // 12 = batch length + base offset sizes
+
+	writeInt32(w, -1) // partition leader epoch
+	writeInt8(w, 2)   // magic byte
+
+	crcBuf := &bytes.Buffer{}
+	crcBuf.Grow(int(size - 12)) // 12 = batch length + base offset sizes
+	crcWriter := bufio.NewWriter(crcBuf)
+
+	writeInt16(crcWriter, attributes)         // attributes, timestamp type 0 - create time, not part of a transaction, no control messages
+	writeInt32(crcWriter, int32(len(msgs)-1)) // max offset
+	writeInt64(crcWriter, timestamp(baseTime))
+	lastTime := timestamp(msgs[len(msgs)-1].Time)
+	writeInt64(crcWriter, int64(lastTime))
+	writeInt64(crcWriter, -1)               // default producer id for now
+	writeInt16(crcWriter, -1)               // default producer epoch for now
+	writeInt32(crcWriter, -1)               // default base sequence
+	writeInt32(crcWriter, int32(len(msgs))) // record count
+
+	write(crcWriter)
+	if err := crcWriter.Flush(); err != nil {
+		return err
+	}
+
+	crcTable := crc32.MakeTable(crc32.Castagnoli)
+	crcChecksum := crc32.Checksum(crcBuf.Bytes(), crcTable)
+
+	writeInt32(w, int32(crcChecksum))
+	if _, err := w.Write(crcBuf.Bytes()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var maxDate = time.Date(5000, time.January, 0, 0, 0, 0, 0, time.UTC)
+
+func recordSize(msg *Message, timestampDelta time.Duration, offsetDelta int64) (size int) {
+	size += 1 + // attributes
+		varIntLen(int64(timestampDelta)) +
+		varIntLen(offsetDelta) +
+		varIntLen(int64(len(msg.Key))) +
+		len(msg.Key) +
+		varIntLen(int64(len(msg.Value))) +
+		len(msg.Value) +
+		varIntLen(int64(len(msg.Headers)))
+	for _, h := range msg.Headers {
+		size += varIntLen(int64(len([]byte(h.Key)))) +
+			len([]byte(h.Key)) +
+			varIntLen(int64(len(h.Value))) +
+			len(h.Value)
+	}
+	return
 }
 
 func compress(codec CompressionCodec, msgs ...Message) ([]Message, error) {
@@ -285,4 +645,30 @@ func msgSize(key, value []byte) int32 {
 		8 + // timestamp
 		sizeofBytes(key) +
 		sizeofBytes(value)
+}
+
+// Messages with magic >2 are called records. This method writes messages using message format 2.
+func writeRecord(w *bufio.Writer, attributes int8, baseTime time.Time, offset int64, msg Message) {
+
+	timestampDelta := msg.Time.Sub(baseTime)
+	offsetDelta := int64(offset)
+
+	writeVarInt(w, int64(recordSize(&msg, timestampDelta, offsetDelta)))
+
+	writeInt8(w, attributes)
+	writeVarInt(w, int64(timestampDelta))
+	writeVarInt(w, offsetDelta)
+
+	writeVarInt(w, int64(len(msg.Key)))
+	w.Write(msg.Key)
+	writeVarInt(w, int64(len(msg.Value)))
+	w.Write(msg.Value)
+	writeVarInt(w, int64(len(msg.Headers)))
+
+	for _, h := range msg.Headers {
+		writeVarInt(w, int64(len(h.Key)))
+		w.Write([]byte(h.Key))
+		writeVarInt(w, int64(len(h.Value)))
+		w.Write(h.Value)
+	}
 }


### PR DESCRIPTION
Problem:
Test function for sending log could support auto-detect kafka broker
controller by updating the vendor, then user don't need to input
the endpoint for kafka controler
Solution:
update kafka vendor and detect broker controller

Issue:
https://github.com/rancher/rancher/issues/20095