### PR TITLE
Fix the issue OTC driver cannot be activated

### DIFF
--- a/app/machinedriver_data.go
+++ b/app/machinedriver_data.go
@@ -61,8 +61,8 @@ func addMachineDrivers(management *config.ManagementContext) error {
 	if err := addMachineDriver("openstack", "local://", "", "", nil, false, true, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver("otc", "https://dockermachinedriver.obs.eu-de.otc.t-systems.com/docker-machine-driver-otc",
-		"", "b4c05f6598dcfac7a8f10899aaac3d42", []string{"*.otc.t-systems.com"}, false, false, management); err != nil {
+	if err := addMachineDriver("otc", "https://github.com/rancher-plugins/docker-machine-driver-otc/releases/download/v2019.5.7/docker-machine-driver-otc",
+		"", "3f793ebb0ebd9477b9166ec542f77e25", []string{"*.otc.t-systems.com"}, false, false, management); err != nil {
 		return err
 	}
 	if err := addMachineDriver("packet", "https://github.com/packethost/docker-machine-driver-packet/releases/download/v0.1.4/docker-machine-driver-packet_linux-amd64.zip",


### PR DESCRIPTION
Problem:

Previous otc download url is pointing to the latest version. We cannot make sure the checksum for it always correct.

Solution:

Point it to a particular version of otc driver.

https://github.com/rancher/rancher/issues/19223