### PR TITLE
Updates for global registry support

### DIFF
--- a/package/run.sh
+++ b/package/run.sh
@@ -213,6 +213,7 @@ fi
 
 # Extract hostname from URL
 CATTLE_SERVER_HOSTNAME=$(echo $CATTLE_SERVER | sed -e 's/[^/]*\/\/\([^@]*@\)\?\([^:/]*\).*/\2/')
+CATTLE_SERVER_HOSTNAME_WITH_PORT=$(echo $CATTLE_SERVER | sed -e 's/[^/]*\/\/\([^@]*@\)\?\(.*\).*/\2/')
 # Resolve IPv4 address(es) from hostname
 RESOLVED_ADDR=$(getent ahostsv4 $CATTLE_SERVER_HOSTNAME | sed -n 's/ *STREAM.*//p')
 
@@ -246,6 +247,9 @@ if [ -n "$CATTLE_CA_CHECKSUM" ]; then
     else
         mkdir -p /etc/kubernetes/ssl/certs
         mv $temp /etc/kubernetes/ssl/certs/serverca
+        mkdir -p /etc/docker/certs.d/$CATTLE_SERVER_HOSTNAME_WITH_PORT
+        cp /etc/kubernetes/ssl/certs/serverca /etc/docker/certs.d/$CATTLE_SERVER_HOSTNAME_WITH_PORT/ca.crt
+
     fi
 fi
 

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -24,6 +24,7 @@ var (
 	EngineNewestVersion             = NewSetting("engine-newest-version", "v17.12.0")
 	EngineSupportedRange            = NewSetting("engine-supported-range", "~v1.11.2 || ~v1.12.0 || ~v1.13.0 || ~v17.03.0 || ~v17.06.0 || ~v17.09.0 || ~v18.06.0 || ~v18.09.0")
 	FirstLogin                      = NewSetting("first-login", "true")
+	GlobalRegistryEnabled           = NewSetting("global-registry-enabled", "false")
 	HelmVersion                     = NewSetting("helm-version", "dev")
 	IngressIPDomain                 = NewSetting("ingress-ip-domain", "xip.io")
 	InstallUUID                     = NewSetting("install-uuid", "")

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -177,6 +177,8 @@ spec:
           mountPath: /var/run
         - name: run
           mountPath: /run
+        - name: docker-certs
+          mountPath: /etc/docker/certs.d
         securityContext:
           privileged: true
       volumes:
@@ -195,6 +197,10 @@ spec:
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-{{.TokenKey}}
+      - hostPath:
+          path: /etc/docker/certs.d
+          type: DirectoryOrCreate
+        name: docker-certs
   updateStrategy:
     type: RollingUpdate
 


### PR DESCRIPTION
1. Add `global-registry-enabled` setting, It is used to detect whether global registry is enabled for non-admin users.
2. Copy ca cert to `/etc/docker/certs.d/<server-host>[:port]/ca.crt` on the host([see reference](https://docs.docker.com/engine/security/certificates/)). So that nodes on clusters can connect to the global registry in custom CA root cases. CA cert locates in `/etc/kubernetes/ssl/certs/serverca` both inside node agents & on the hosts before, this keeps the same.
  In this solution, `/etc/docker/certs.d` instead of `/etc/docker/certs.d/<server-host>[:port]` on the host mounts node agent containers, due to two limitations:
  - Colon is not supported in kuberentes volume path, which may be needed in docker cert path. [see](https://github.com/kubernetes/kubernetes/issues/21681#issuecomment-187260705)
  - hostpath-subpath is broken, And looks like we need a deprecated kubelet flag for [that](https://github.com/rancher/rancher/issues/14836).

Depending on the system-chart PR: https://github.com/rancher/system-charts/pull/41

https://github.com/rancher/rancher/issues/20597