### PR TITLE
Clean cattle-prometheus ns

### DIFF
--- a/pkg/agent/clean/clean.go
+++ b/pkg/agent/clean/clean.go
@@ -93,7 +93,7 @@ func Cluster() error {
 	}
 
 	var errors []error
-	var toRemove []string
+	var toRemove = make([]string, len(nsToRemove))
 	copy(toRemove, nsToRemove)
 
 	for _, f := range getNSFuncs {


### PR DESCRIPTION
Fix variable initial problem in pkg/agent/clean.go

**Problem:**
Can't copy string slice from `nsToRemove` to `toRemove` in client.go so
the namespace cleaning logic won't clean namespaces in `nsToRemove`.

**Solution:**
We should initial the `toRemove` variable with `make([]string, len(nsToRemove))`

Related issue:
https://github.com/rancher/rancher/issues/19476