### PR TITLE
[2.2.3]Sorting etcd tls config before setup the config

### DIFF
--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -348,6 +348,9 @@ func (ch *clusterHandler) deployApp(appName, appTargetNamespace string, appProje
 			}
 
 			if etcdTLSConfig != nil {
+				sort.Slice(etcdTLSConfig, func(i, j int) bool {
+					return etcdTLSConfig[i].internalAddress < etcdTLSConfig[j].internalAddress
+				})
 				appAnswers["exporter-kube-etcd.certFile"] = etcdTLSConfig[0].certPath
 				appAnswers["exporter-kube-etcd.keyFile"] = etcdTLSConfig[0].keyPath
 			}


### PR DESCRIPTION
Problem:

Monitoring get redeployed due to etcd params updated. However, it is not expected as the etcd address doesn't change at all.

Solution:

Sort it before assign.

Issue:

https://github.com/rancher/rancher/issues/19945