### PR TITLE
Fix cannot run Windows agent with multiple controlplanes

### DIFF
--- a/package/windows/hyperkube.ps1
+++ b/package/windows/hyperkube.ps1
@@ -511,7 +511,7 @@ stream {
     $servers = ""
     $tempConfig = New-TemporaryFile
 
-    $CPHosts -split "," | % {
+    $CPHosts -split ";" | % {
         $servers += ("server $_" + ":6443;`t")
     }
     $newConfig = $tmpl.Replace("{0}", $servers).ToString()


### PR DESCRIPTION
**Problem:**
Use the wrong separator to split the controlplanes address list

**Solution:**
Change "," to ";"

**Issue:**
https://github.com/rancher/rancher/issues/20178