### PR TITLE
Upgrade system charts

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -161,7 +161,7 @@ func addData(management *config.ManagementContext, cfg Config) error {
 		return err
 	}
 
-	if err := addCatalogs(management); err != nil {
+	if err := syncCatalogs(management); err != nil {
 		return err
 	}
 

--- a/app/catalog_data.go
+++ b/app/catalog_data.go
@@ -1,11 +1,18 @@
 package app
 
 import (
-	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"time"
+
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -16,9 +23,92 @@ const (
 	systemLibraryURL    = "https://git.rancher.io/system-charts"
 	systemLibraryBranch = "master"
 	systemLibraryName   = "system-library"
+	defSystemChartVer   = "management.cattle.io/default-system-chart-version"
 )
 
-func addCatalogs(management *config.ManagementContext) error {
+// updateCatalogURL updates annotations if they are outdated and system catalog url/branch if it matches outdated defaults
+func updateCatalogURL(catalogClient v3.CatalogInterface, desiredDefaultURL string, desiredDefaultBranch string) error {
+	oldCatalog, err := catalogClient.Get(systemLibraryName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	desiredCatalog := oldCatalog.DeepCopy()
+
+	if oldAnno := oldCatalog.Annotations[defSystemChartVer]; oldAnno == "" {
+		// If url/branch are old defaults, update - otherwise they are user set and should not be changed
+		if oldCatalog.Spec.URL == systemLibraryURL && oldCatalog.Spec.Branch == systemLibraryBranch {
+			setDesiredChartLib(desiredCatalog, desiredDefaultURL, desiredDefaultBranch)
+		}
+	} else {
+		oldAnnotations := make(map[string]interface{})
+		json.Unmarshal([]byte(oldAnno), &oldAnnotations)
+
+		// If url/branch catalog spec and annotation do not match, user likely has not changed it, so to new defaults
+		if oldCatalog.Spec.URL == oldAnnotations["url"] && oldCatalog.Spec.Branch == oldAnnotations["branch"] {
+			setDesiredChartLib(desiredCatalog, desiredDefaultURL, desiredDefaultBranch)
+		}
+	}
+
+	// Annotation should be up to date with current desired default
+	setCatalogAnnotation(desiredCatalog, desiredDefaultURL, desiredDefaultBranch)
+
+	// If old catalog does not match desired catalog state, update
+	if !reflect.DeepEqual(oldCatalog, desiredCatalog) {
+		return exponentialCatalogUpdate(catalogClient, desiredCatalog)
+	}
+
+	return nil
+}
+
+// setCatalogAnnotation sets default system chart version to match the desired URL and desired branch env variables
+func setCatalogAnnotation(catalog *v3.Catalog, desiredURL string, desiredBranch string) {
+	if catalog.Annotations == nil {
+		catalog.Annotations = make(map[string]string)
+	}
+	systemChartMap := make(map[string]string)
+	systemChartMap["url"] = desiredURL
+	systemChartMap["branch"] = desiredBranch
+
+	defChartAnno, _ := json.Marshal(systemChartMap)
+	catalog.Annotations[defSystemChartVer] = string(defChartAnno)
+}
+
+// setDesiredChartLib sets the catalog url and branch to match the desired URL and desired branch env variables
+func setDesiredChartLib(catalog *v3.Catalog, desiredURL string, desiredBranch string) {
+	catalog.Spec.URL = desiredURL
+	catalog.Spec.Branch = desiredBranch
+}
+
+func exponentialCatalogUpdate(catalogClient v3.CatalogInterface, desiredCatalog *v3.Catalog) error {
+	backoff := wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2,
+		Steps:    3,
+	}
+	catalog := desiredCatalog
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		if _, err := catalogClient.Update(catalog); err != nil {
+			if !errors.IsConflict(err) {
+				return false, err
+			}
+
+			if catalog, err = catalogClient.Get(systemLibraryName, metav1.GetOptions{}); err != nil {
+				return false, err
+			}
+			catalog.Annotations[defSystemChartVer] = desiredCatalog.Annotations[defSystemChartVer]
+			setDesiredChartLib(catalog, desiredCatalog.Spec.URL, desiredCatalog.Spec.Branch)
+
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed upgrading system-chart catalog: %v", err)
+	}
+	return nil
+}
+
+func syncCatalogs(management *config.ManagementContext) error {
 	return utilerrors.AggregateGoroutines(
 		// add charts
 		func() error {
@@ -26,13 +116,28 @@ func addCatalogs(management *config.ManagementContext) error {
 		},
 		// add rancher-charts
 		func() error {
-			return doAddCatalogs(management, systemLibraryName, systemLibraryURL, systemLibraryBranch)
+			if err := doAddCatalogs(management, systemLibraryName, systemLibraryURL, systemLibraryBranch); err != nil {
+				return err
+			}
+			desiredDefaultURL := systemLibraryURL
+			desiredDefaultBranch := systemLibraryBranch
+
+			if fromEnvURL := os.Getenv("CATTLE_SYSTEM_CHART_DEFAULT_URL"); fromEnvURL != "" {
+				desiredDefaultURL = fromEnvURL
+			}
+
+			if fromEnvBranch := os.Getenv("CATTLE_SYSTEM_CHART_DEFAULT_BRANCH"); fromEnvBranch != "" {
+				desiredDefaultBranch = fromEnvBranch
+			}
+
+			return updateCatalogURL(management.Management.Catalogs(""), desiredDefaultURL, desiredDefaultBranch)
 		},
 	)
 }
 
 func doAddCatalogs(management *config.ManagementContext, name, url, branch string) error {
 	catalogClient := management.Management.Catalogs("")
+
 	_, err := catalogClient.Get(name, metav1.GetOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return err
@@ -51,5 +156,6 @@ func doAddCatalogs(management *config.ManagementContext, name, url, branch strin
 			return err
 		}
 	}
+
 	return nil
 }

--- a/app/catalog_data_test.go
+++ b/app/catalog_data_test.go
@@ -1,0 +1,215 @@
+package app
+
+import (
+	"encoding/json"
+	"testing"
+
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/apis/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewCatalogClientMock(oldURL string, oldBranch string, annoURL string, annoBranch string) v3.CatalogInterface {
+	catalog := &v3.Catalog{
+		Spec: v3.CatalogSpec{
+			URL:    oldURL,
+			Branch: oldBranch,
+		},
+	}
+
+	if annoURL != "" || annoBranch != "" {
+		setCatalogAnnotation(catalog, annoURL, annoBranch)
+	}
+
+	return &fakes.CatalogInterfaceMock{
+		GetFunc: func(name string, opts v1.GetOptions) (*v3.Catalog, error) {
+			if name == systemLibraryName {
+				return catalog, nil
+			}
+			return nil, nil
+		},
+		UpdateFunc: func(c *v3.Catalog) (*v3.Catalog, error) {
+			catalog = c
+			return catalog, nil
+		},
+	}
+}
+
+// TestUpdateCatalogHasAnnoMatchEnv tests for scenarios where system-library catalog does not contain a chart version annotation
+func TestUpdateCatalogNoAnno(t *testing.T) {
+	assert := assert.New(t)
+
+	// If Annotations field is nil and current url/branch match v2.2.2 values,
+	// the url/branch should be set and annotation updated
+	c := NewCatalogClientMock(systemLibraryURL, systemLibraryBranch, "", "")
+
+	updateCatalogURL(c, systemLibraryURL, "v3")
+
+	catalog, err := c.Get(systemLibraryName, v1.GetOptions{})
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, catalog.Spec.URL)
+	assert.Equal("v3", catalog.Spec.Branch)
+
+	annoMap := make(map[string]string)
+	err = json.Unmarshal([]byte(catalog.Annotations[defSystemChartVer]), &annoMap)
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, annoMap["url"])
+	assert.Equal("v3", annoMap["branch"])
+
+	// If Annotations field is nil and current url/branch do not match v2.2.2 values,
+	// the url/branch should not be set and annotations should be updated
+	c = NewCatalogClientMock("https://test-system-chart-url.io/", "v4", "", "")
+
+	updateCatalogURL(c, systemLibraryURL, "v3")
+	catalog, err = c.Get(systemLibraryName, v1.GetOptions{})
+	assert.Nil(err)
+	assert.Equal("https://test-system-chart-url.io/", catalog.Spec.URL)
+	assert.Equal("v4", catalog.Spec.Branch)
+
+	annoMap = make(map[string]string)
+	err = json.Unmarshal([]byte(catalog.Annotations[defSystemChartVer]), &annoMap)
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, annoMap["url"])
+	assert.Equal("v3", annoMap["branch"])
+}
+
+// TestUpdateCatalogHasAnnoMatchEnv tests for scenarios where system-library catalog contains a chart version annotation,
+// and the system-library catalog spec does match the "SYSTEM_CHART_DEFAULT" environment variable
+func TestUpdateCatalogHasAnnoMatchEnv(t *testing.T) {
+	assert := assert.New(t)
+
+	// If the url and branch DO match the old defaults and DO match environment and DO match annotation
+	// the url/branch and annotation should remain the same
+	c := NewCatalogClientMock(systemLibraryURL, systemLibraryBranch, systemLibraryURL, systemLibraryBranch)
+
+	updateCatalogURL(c, systemLibraryURL, systemLibraryBranch)
+	catalog, err := c.Get(systemLibraryName, v1.GetOptions{})
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, catalog.Spec.URL)
+	assert.Equal(systemLibraryBranch, catalog.Spec.Branch)
+
+	annoMap := make(map[string]string)
+	err = json.Unmarshal([]byte(catalog.Annotations[defSystemChartVer]), &annoMap)
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, annoMap["url"])
+	assert.Equal(systemLibraryBranch, annoMap["branch"])
+
+	// If the url and branch DO match the old defaults and DO match environment and DO NOT match annotation
+	// the url/branch should NOT be updated and annotations should be updated
+	c = NewCatalogClientMock(systemLibraryURL, systemLibraryBranch, systemLibraryURL, "v3")
+
+	updateCatalogURL(c, systemLibraryURL, systemLibraryBranch)
+	catalog, err = c.Get(systemLibraryName, v1.GetOptions{})
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, catalog.Spec.URL)
+	assert.Equal(systemLibraryBranch, catalog.Spec.Branch)
+
+	annoMap = make(map[string]string)
+	err = json.Unmarshal([]byte(catalog.Annotations[defSystemChartVer]), &annoMap)
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, annoMap["url"])
+	assert.Equal(systemLibraryBranch, annoMap["branch"])
+
+	// If the url and branch DO NOT match the old defaults and DO match environment and DO match annotation
+	// the url/branch should NOT be updated and annotations NOT should be updated
+	c = NewCatalogClientMock(systemLibraryURL, "v4", systemLibraryURL, "v4")
+
+	updateCatalogURL(c, systemLibraryURL, "v4")
+	catalog, err = c.Get(systemLibraryName, v1.GetOptions{})
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, catalog.Spec.URL)
+	assert.Equal("v4", catalog.Spec.Branch)
+
+	annoMap = make(map[string]string)
+	err = json.Unmarshal([]byte(catalog.Annotations[defSystemChartVer]), &annoMap)
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, annoMap["url"])
+	assert.Equal("v4", annoMap["branch"])
+
+	// If the url and branch DO NOT match the old defaults and DO match environment and DO NOT match annotation
+	// the url/branch should NOT be updated and annotations should be updated
+	c = NewCatalogClientMock(systemLibraryURL, "v5", systemLibraryURL, "v4")
+
+	updateCatalogURL(c, systemLibraryURL, "v5")
+	catalog, err = c.Get(systemLibraryName, v1.GetOptions{})
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, catalog.Spec.URL)
+	assert.Equal("v5", catalog.Spec.Branch)
+
+	annoMap = make(map[string]string)
+	err = json.Unmarshal([]byte(catalog.Annotations[defSystemChartVer]), &annoMap)
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, annoMap["url"])
+	assert.Equal("v5", annoMap["branch"])
+}
+
+// TestUpdateCatalogHasAnnoMatchEnv tests for scenarios where system-library catalog contains a chart version annotation,
+// and the system-library catalog spec does not match the "SYSTEM_CHART_DEFAULT" environment variable
+func TestUpdateCatalogHasAnnoNoMatchEnv(t *testing.T) {
+	assert := assert.New(t)
+
+	// If the url and branch DO match the old defaults, DO NOT match Environment, DO match annotation
+	// the url/branch should be set and annotations should be updated
+	c := NewCatalogClientMock(systemLibraryURL, systemLibraryBranch, systemLibraryURL, systemLibraryBranch)
+
+	updateCatalogURL(c, systemLibraryURL, "v2.2")
+	catalog, err := c.Get(systemLibraryName, v1.GetOptions{})
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, catalog.Spec.URL)
+	assert.Equal("v2.2", catalog.Spec.Branch)
+
+	annoMap := make(map[string]string)
+	err = json.Unmarshal([]byte(catalog.Annotations[defSystemChartVer]), &annoMap)
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, annoMap["url"])
+	assert.Equal("v2.2", annoMap["branch"])
+
+	// If the url and branch DO match the old defaults, DO NOT match Environment, DO NOT match annotation
+	// the url/branch should not be set and annotations should be updated (if not equal to environment)
+	c = NewCatalogClientMock(systemLibraryURL, systemLibraryBranch, systemLibraryURL, "v2")
+
+	updateCatalogURL(c, systemLibraryURL, "v2.2")
+	catalog, err = c.Get(systemLibraryName, v1.GetOptions{})
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, catalog.Spec.URL)
+	assert.Equal(systemLibraryBranch, catalog.Spec.Branch)
+
+	annoMap = make(map[string]string)
+	err = json.Unmarshal([]byte(catalog.Annotations[defSystemChartVer]), &annoMap)
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, annoMap["url"])
+	assert.Equal("v2.2", annoMap["branch"])
+
+	// If the url and branch DO NOT match the old defaults, DO NOT match Environment, DO match annotation
+	// the url/branch should be set and annotations should be updated
+	c = NewCatalogClientMock(systemLibraryURL, "v0.5", systemLibraryURL, "v0.5")
+
+	updateCatalogURL(c, systemLibraryURL, "v2.2")
+	catalog, err = c.Get(systemLibraryName, v1.GetOptions{})
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, catalog.Spec.URL)
+	assert.Equal("v2.2", catalog.Spec.Branch)
+
+	annoMap = make(map[string]string)
+	err = json.Unmarshal([]byte(catalog.Annotations[defSystemChartVer]), &annoMap)
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, annoMap["url"])
+	assert.Equal("v2.2", annoMap["branch"])
+
+	// If the url and branch DO NOT match the old defaults, DO NOT match Environment, DO NOT match annotation
+	// the url/branch should not be set and annotations should be updated (if not equal to environment)
+	c = NewCatalogClientMock(systemLibraryURL, "v0.5", systemLibraryURL, "v1")
+
+	updateCatalogURL(c, systemLibraryURL, "v2.2")
+	catalog, err = c.Get(systemLibraryName, v1.GetOptions{})
+	assert.Nil(err)
+	assert.Equal(systemLibraryURL, catalog.Spec.URL)
+	assert.Equal("v0.5", catalog.Spec.Branch)
+
+	annoMap = make(map[string]string)
+	err = json.Unmarshal([]byte(catalog.Annotations[defSystemChartVer]), &annoMap)
+	assert.Nil(err)
+	assert.Equal(annoMap["url"], systemLibraryURL)
+	assert.Equal(annoMap["branch"], "v2.2")
+}


### PR DESCRIPTION
Problem:

Old versions of rancher may be incompatible with system charts master branch.

Solution:
Added logic for maintaining default url/branch for system-library
catalog, and its annotation.

Issue:
https://github.com/rancher/rancher/issues/20115