### PR TITLE
[2.2.2-patch]Support helm install with app info

### DIFF
--- a/pkg/controllers/user/helm/common.go
+++ b/pkg/controllers/user/helm/common.go
@@ -122,8 +122,8 @@ func (l *Lifecycle) generateTemplates(obj *v3.App) (string, string, string, stri
 
 	appDir := filepath.Join(tempDir, appSubDir)
 
-	common.InjectDefaultRegistry(obj)
-	setValues, err := common.GenerateAnswerSetValues(obj, tempDir)
+	extraArgs := common.GetExtraArgs(obj)
+	setValues, err := common.GenerateAnswerSetValues(obj, tempDir, extraArgs)
 	if err != nil {
 		return "", "", "", tempDir, err
 	}

--- a/pkg/controllers/user/helm/common/extra_args_injection.go
+++ b/pkg/controllers/user/helm/common/extra_args_injection.go
@@ -1,0 +1,60 @@
+package common
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/rancher/rancher/pkg/ref"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/types/apis/project.cattle.io/v3"
+	"github.com/sirupsen/logrus"
+)
+
+type InjectAppArgsFunc func(obj *v3.App) (content map[string]string)
+
+const (
+	systemCatalogName = "system-library"
+)
+
+var (
+	extraArgsFuncs = []InjectAppArgsFunc{
+		injectDefaultRegistry,
+		injectClusterInfo,
+	}
+)
+
+func injectDefaultRegistry(obj *v3.App) map[string]string {
+	values, err := url.Parse(obj.Spec.ExternalID)
+	if err != nil {
+		logrus.Errorf("check catalog type failed: %s", err.Error())
+	}
+
+	catalogWithNamespace := values.Query().Get("catalog")
+	split := strings.SplitN(catalogWithNamespace, "/", 2)
+	catalog := split[len(split)-1]
+
+	reg := settings.SystemDefaultRegistry.Get()
+	if catalog != systemCatalogName || reg == "" {
+		return nil
+	}
+	return map[string]string{"systemDefaultRegistry": reg}
+}
+
+func injectClusterInfo(obj *v3.App) map[string]string {
+	clusterName, projectName := ref.Parse(obj.Spec.ProjectName)
+	return map[string]string{
+		"clusterName": clusterName,
+		"projectName": projectName,
+	}
+}
+
+func GetExtraArgs(app *v3.App) map[string]string {
+	rtn := map[string]string{}
+	for _, afunc := range extraArgsFuncs {
+		content := afunc(app)
+		for k, v := range content {
+			rtn["global."+k] = v
+		}
+	}
+	return rtn
+}


### PR DESCRIPTION
Inject cluster name, project name and default registy parameters as
extra answers values when helm installing.
We are no longer storing them in app answers like the old default
registry parameter.