### PR TITLE
Support run kube-proxy on Windows with AWS cloud provider

### DIFF
--- a/pkg/rkenodeconfigserver/nodeserver.go
+++ b/pkg/rkenodeconfigserver/nodeserver.go
@@ -476,7 +476,6 @@ func createWindowsProcesses(rkeConfig *v3.RancherKubernetesEngineConfig, configN
 		"register-with-taints":         "beta.kubernetes.io/os=windows:PreferNoSchedule",
 		"client-ca-file":               "c:" + rkepki.GetCertPath(rkepki.CACertName),
 		"kubeconfig":                   "c:" + rkepki.GetConfigPath(rkepki.KubeNodeCertName),
-		"hostname-override":            configNode.HostnameOverride,
 		"cluster-domain":               clusterDomain,
 		"cluster-dns":                  dnsServiceIP,
 		"node-ip":                      configNode.InternalAddress,
@@ -489,10 +488,9 @@ func createWindowsProcesses(rkeConfig *v3.RancherKubernetesEngineConfig, configN
 		"authentication-token-webhook": "true",
 	}, serviceOptions.Kubelet)
 	extendingKubeproxyOptions := extendMap(map[string]string{
-		"v":                 "2",
-		"proxy-mode":        "kernelspace",
-		"kubeconfig":        "c:" + rkepki.GetConfigPath(rkepki.KubeProxyCertName),
-		"hostname-override": configNode.HostnameOverride,
+		"v":          "2",
+		"proxy-mode": "kernelspace",
+		"kubeconfig": "c:" + rkepki.GetConfigPath(rkepki.KubeProxyCertName),
 	}, serviceOptions.Kubeproxy)
 
 	flannelBackendConfig := map[string]interface{}{}


### PR DESCRIPTION
**Problem:**
Cannot run kube-proxy on Windows with AWS cloud provider if doesn't
indicate the AWS instance internal name.

**Solution:**
Set `hostname-override` on agent side

**Issue:**
https://github.com/rancher/rancher/issues/20185