### PR TITLE
Small fix for helm extra args

### DIFF
--- a/pkg/controllers/user/helm/common/extra_args_injection.go
+++ b/pkg/controllers/user/helm/common/extra_args_injection.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"net/url"
-	"strings"
 
 	"github.com/rancher/rancher/pkg/ref"
 	"github.com/rancher/rancher/pkg/settings"
@@ -26,17 +25,19 @@ var (
 func injectDefaultRegistry(obj *v3.App) map[string]string {
 	values, err := url.Parse(obj.Spec.ExternalID)
 	if err != nil {
-		logrus.Errorf("check catalog type failed: %s", err.Error())
-	}
-
-	catalogWithNamespace := values.Query().Get("catalog")
-	split := strings.SplitN(catalogWithNamespace, "/", 2)
-	catalog := split[len(split)-1]
-
-	reg := settings.SystemDefaultRegistry.Get()
-	if catalog != systemCatalogName || reg == "" {
+		logrus.Errorf("parsing externalID failed: %s", err.Error())
 		return nil
 	}
+
+	if values.Query().Get("catalog") != systemCatalogName {
+		return nil
+	}
+
+	reg := settings.SystemDefaultRegistry.Get()
+	if reg == "" {
+		return nil
+	}
+
 	return map[string]string{"systemDefaultRegistry": reg}
 }
 

--- a/pkg/controllers/user/helm/common/extra_args_test.go
+++ b/pkg/controllers/user/helm/common/extra_args_test.go
@@ -1,0 +1,48 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/types/apis/project.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_injectDefaultRegistry(t *testing.T) {
+	testRegistry := "test.registry.com"
+	err := settings.SystemDefaultRegistry.Set(testRegistry)
+	assert.Nil(t, err, "failed to set system default registry settings")
+
+	testCases := []struct {
+		app  *v3.App
+		want bool
+	}{
+		{
+			app: &v3.App{
+				Spec: v3.AppSpec{
+					ExternalID: "catalog://?catalog=library&template=wordpress&version=2.1.11",
+				},
+			},
+			want: false,
+		},
+		{
+			app: &v3.App{
+				Spec: v3.AppSpec{
+					ExternalID: settings.SystemMonitoringCatalogID.Get(),
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testApp := testCase.app
+		injectMap := injectDefaultRegistry(testApp)
+		if !testCase.want {
+			assert.Nilf(t, injectMap, "catalog id %s should not get default registry parameters", testApp.Spec.ExternalID)
+		} else {
+			v, _ := injectMap["systemDefaultRegistry"]
+			assert.Equalf(t, testRegistry, v, "catalog id %s should not get default registry parameters", testApp.Spec.ExternalID)
+		}
+	}
+}


### PR DESCRIPTION
Check len for split `catalogWithNamespace`
Check catalogName before getting the
`SystemDefaultRegistry` value from etcd.

Base on comments in PR https://github.com/rancher/rancher/pull/20184.