### PR TITLE
[2.2]Small fix for helm extra args

### DIFF
--- a/pkg/controllers/user/helm/common/extra_args_injection.go
+++ b/pkg/controllers/user/helm/common/extra_args_injection.go
@@ -31,12 +31,20 @@ func injectDefaultRegistry(obj *v3.App) map[string]string {
 
 	catalogWithNamespace := values.Query().Get("catalog")
 	split := strings.SplitN(catalogWithNamespace, "/", 2)
-	catalog := split[len(split)-1]
-
-	reg := settings.SystemDefaultRegistry.Get()
-	if catalog != systemCatalogName || reg == "" {
+	if len(split) != 2 {
 		return nil
 	}
+	catalog := split[len(split)-1]
+
+	if catalog != systemCatalogName {
+		return nil
+	}
+
+	reg := settings.SystemDefaultRegistry.Get()
+	if reg == "" {
+		return nil
+	}
+
 	return map[string]string{"systemDefaultRegistry": reg}
 }
 


### PR DESCRIPTION
Check len for split `catalogWithNamespace`
Check catalogName before getting the
`SystemDefaultRegistry` value from etcd.

Base on comments in PR https://github.com/rancher/rancher/pull/20184.