### PR TITLE
Refactor cluster actions

### DIFF
--- a/pkg/api/customization/cluster/actionhandler.go
+++ b/pkg/api/customization/cluster/actionhandler.go
@@ -58,40 +58,40 @@ func (a ActionHandler) ClusterActionHandler(actionName string, action *types.Act
 	}
 
 	switch actionName {
-	case "generateKubeconfig":
+	case v3.ClusterActionGenerateKubeconfig:
 		return a.GenerateKubeconfigActionHandler(actionName, action, apiContext)
-	case "importYaml":
+	case v3.ClusterActionImportYaml:
 		return a.ImportYamlHandler(actionName, action, apiContext)
-	case "exportYaml":
+	case v3.ClusterActionExportYaml:
 		return a.ExportYamlHandler(actionName, action, apiContext)
-	case "viewMonitoring":
+	case v3.ClusterActionViewMonitoring:
 		return a.viewMonitoring(actionName, action, apiContext)
-	case "editMonitoring":
+	case v3.ClusterActionEditMonitoring:
 		if !canUpdateCluster() {
 			return httperror.NewAPIError(httperror.Unauthorized, "can not access")
 		}
 		return a.editMonitoring(actionName, action, apiContext)
-	case "enableMonitoring":
+	case v3.ClusterActionEnableMonitoring:
 		if !canUpdateCluster() {
 			return httperror.NewAPIError(httperror.Unauthorized, "can not access")
 		}
 		return a.enableMonitoring(actionName, action, apiContext)
-	case "disableMonitoring":
+	case v3.ClusterActionDisableMonitoring:
 		if !canUpdateCluster() {
 			return httperror.NewAPIError(httperror.Unauthorized, "can not access")
 		}
 		return a.disableMonitoring(actionName, action, apiContext)
-	case "backupEtcd":
+	case v3.ClusterActionBackupEtcd:
 		if !canUpdateCluster() {
 			return httperror.NewAPIError(httperror.Unauthorized, "can not backup etcd")
 		}
 		return a.BackupEtcdHandler(actionName, action, apiContext)
-	case "restoreFromEtcdBackup":
+	case v3.ClusterActionRestoreFromEtcdBackup:
 		if !canUpdateCluster() {
 			return httperror.NewAPIError(httperror.Unauthorized, "can not restore etcd backup")
 		}
 		return a.RestoreFromEtcdBackupHandler(actionName, action, apiContext)
-	case "rotateCertificates":
+	case v3.ClusterActionRotateCertificates:
 		if !canUpdateCluster() {
 			return httperror.NewAPIError(httperror.Unauthorized, "can not rotate certificates")
 		}

--- a/pkg/api/customization/cluster/formatter.go
+++ b/pkg/api/customization/cluster/formatter.go
@@ -22,28 +22,28 @@ func (f *Formatter) Formatter(request *types.APIContext, resource *types.RawReso
 	shellLink = strings.Replace(shellLink, "http", "ws", 1)
 	shellLink = strings.Replace(shellLink, "/shell", "?shell=true", 1)
 	resource.Links["shell"] = shellLink
-	resource.AddAction(request, "generateKubeconfig")
-	resource.AddAction(request, "importYaml")
-	resource.AddAction(request, "exportYaml")
+	resource.AddAction(request, v3.ClusterActionGenerateKubeconfig)
+	resource.AddAction(request, v3.ClusterActionImportYaml)
+	resource.AddAction(request, v3.ClusterActionExportYaml)
 	if _, ok := resource.Values["rancherKubernetesEngineConfig"]; ok {
-		resource.AddAction(request, "rotateCertificates")
+		resource.AddAction(request, v3.ClusterActionRotateCertificates)
 		if _, ok := values.GetValue(resource.Values, "rancherKubernetesEngineConfig", "services", "etcd", "backupConfig"); ok {
-			resource.AddAction(request, "backupEtcd")
-			resource.AddAction(request, "restoreFromEtcdBackup")
+			resource.AddAction(request, v3.ClusterActionBackupEtcd)
+			resource.AddAction(request, v3.ClusterActionRestoreFromEtcdBackup)
 		}
 	}
 
 	if err := request.AccessControl.CanDo(v3.ClusterGroupVersionKind.Group, v3.ClusterResource.Name, "update", request, resource.Values, request.Schema); err == nil {
 		if convert.ToBool(resource.Values["enableClusterMonitoring"]) {
-			resource.AddAction(request, "disableMonitoring")
-			resource.AddAction(request, "editMonitoring")
+			resource.AddAction(request, v3.ClusterActionDisableMonitoring)
+			resource.AddAction(request, v3.ClusterActionEditMonitoring)
 		} else {
-			resource.AddAction(request, "enableMonitoring")
+			resource.AddAction(request, v3.ClusterActionEnableMonitoring)
 		}
 	}
 
 	if convert.ToBool(resource.Values["enableClusterMonitoring"]) {
-		resource.AddAction(request, "viewMonitoring")
+		resource.AddAction(request, v3.ClusterActionViewMonitoring)
 	}
 
 	if gkeConfig, ok := resource.Values["googleKubernetesEngineConfig"]; ok {

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     ea122abac582d745a00dba0aaf946c29ee8d9d90
-github.com/rancher/types                      3d66c9393f0e3472c8eaec8e5dbc41155155a021
+github.com/rancher/types                      83a44f57
 github.com/rancher/kontainer-engine           7606e7e7a2dcad29f22758ad689a00ea622c2d1f
 github.com/rancher/rke                        c08d7738b23055859e9a45bcbb9a58534210a8fa
 

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -20,6 +20,17 @@ func init() {
 type ClusterConditionType string
 
 const (
+	ClusterActionGenerateKubeconfig    = "generateKubeconfig"
+	ClusterActionImportYaml            = "importYaml"
+	ClusterActionExportYaml            = "exportYaml"
+	ClusterActionViewMonitoring        = "viewMonitoring"
+	ClusterActionEditMonitoring        = "editMonitoring"
+	ClusterActionEnableMonitoring      = "enableMonitoring"
+	ClusterActionDisableMonitoring     = "disableMonitoring"
+	ClusterActionBackupEtcd            = "backupEtcd"
+	ClusterActionRestoreFromEtcdBackup = "restoreFromEtcdBackup"
+	ClusterActionRotateCertificates    = "rotateCertificates"
+
 	// ClusterConditionReady Cluster ready to serve API (healthy when true, unhealthy when false)
 	ClusterConditionReady          condition.Cond = "Ready"
 	ClusterConditionPending        condition.Cond = "Pending"

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema/schema.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema/schema.go
@@ -198,31 +198,31 @@ func clusterTypes(schemas *types.Schemas) *types.Schemas {
 				field.Required = false
 				return field
 			})
-			schema.ResourceActions["generateKubeconfig"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionGenerateKubeconfig] = types.Action{
 				Output: "generateKubeConfigOutput",
 			}
-			schema.ResourceActions["importYaml"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionImportYaml] = types.Action{
 				Input:  "importClusterYamlInput",
 				Output: "importYamlOutput",
 			}
-			schema.ResourceActions["exportYaml"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionExportYaml] = types.Action{
 				Output: "exportOutput",
 			}
-			schema.ResourceActions["enableMonitoring"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionEnableMonitoring] = types.Action{
 				Input: "monitoringInput",
 			}
-			schema.ResourceActions["disableMonitoring"] = types.Action{}
-			schema.ResourceActions["viewMonitoring"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionDisableMonitoring] = types.Action{}
+			schema.ResourceActions[v3.ClusterActionViewMonitoring] = types.Action{
 				Output: "monitoringOutput",
 			}
-			schema.ResourceActions["editMonitoring"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionEditMonitoring] = types.Action{
 				Input: "monitoringInput",
 			}
-			schema.ResourceActions["backupEtcd"] = types.Action{}
-			schema.ResourceActions["restoreFromEtcdBackup"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionBackupEtcd] = types.Action{}
+			schema.ResourceActions[v3.ClusterActionRestoreFromEtcdBackup] = types.Action{
 				Input: "restoreFromEtcdBackupInput",
 			}
-			schema.ResourceActions["rotateCertificates"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionRotateCertificates] = types.Action{
 				Input:  "rotateCertificateInput",
 				Output: "rotateCertificateOutput",
 			}


### PR DESCRIPTION
The actions are currently duplicated using direct strings. Refactoring them.
Relevant types PR: https://github.com/rancher/types/pull/830