### PR TITLE
QA Validation - if node.externalIpAddress is not set, fallback to node.ipAddress

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -440,7 +440,7 @@ def validate_ingress(p_client, cluster, workloads, host, path,
     nodes = get_schedulable_nodes(cluster)
     target_name_list = get_target_names(p_client, workloads)
     for node in nodes:
-        host_ip = node.externalIpAddress
+        host_ip = resolve_node_ip(node)
         cmd = curl_args + " http://" + host_ip + path
         validate_http_response(cmd, target_name_list)
 
@@ -795,7 +795,8 @@ def delete_cluster(client, cluster):
             ip_filter['Values'] = ip_list
             filters.append(ip_filter)
             for node in nodes:
-                ip_list.append(node.externalIpAddress)
+                host_ip = resolve_node_ip(node)
+                ip_list.append(host_ip)
             assert len(ip_filter) > 0
             print(ip_filter)
             aws_nodes = AmazonWebServices().get_nodes(filters)
@@ -991,7 +992,7 @@ def validate_hostPort(p_client, workload, source_port, cluster):
                 target_name_list.append(pod.name)
                 break
         if len(target_name_list) > 0:
-            host_ip = node.externalIpAddress
+            host_ip = resolve_node_ip(node)
             curl_cmd = " http://" + host_ip + ":" + \
                        str(source_port) + "/name.html"
             validate_http_response(curl_cmd, target_name_list)
@@ -1015,7 +1016,7 @@ def validate_nodePort(p_client, workload, cluster):
         target_name_list.append(pod.name)
     print("target name list:" + str(target_name_list))
     for node in nodes:
-        host_ip = node.externalIpAddress
+        host_ip = resolve_node_ip(node)
         curl_cmd = " http://" + host_ip + ":" + \
                    str(source_port) + "/name.html"
         validate_http_response(curl_cmd, target_name_list)
@@ -1164,3 +1165,12 @@ def validate_response_app_endpoint(p_client, appId):
             except requests.ConnectionError:
                 print("failed to connect")
                 assert False, "failed to connect to the app"
+
+
+def resolve_node_ip(node):
+    if hasattr(node, 'externalIpAddress'):
+        node_ip = node.externalIpAddress
+    else:
+        node_ip = node.ipAddress
+    return node_ip
+    


### PR DESCRIPTION
In ingress and port tests, fallback to ipAddress if externalIpAddress is not set on node

@drpebcak @sangeethah 