### PR TITLE
add linode driver data for cloud credentials

### DIFF
--- a/app/machinedriver_data.go
+++ b/app/machinedriver_data.go
@@ -55,7 +55,7 @@ func addMachineDrivers(management *config.ManagementContext) error {
 		return err
 	}
 	if err := addMachineDriver(nodetemplate.Linodedriver, "https://github.com/linode/docker-machine-driver-linode/releases/download/v0.1.7/docker-machine-driver-linode_linux-amd64.zip",
-		"https://linode.github.io/rancher-ui-driver-linode/releases/v0.2.0/component.js", "faaf1d7d53b55a369baeeb0855b069921a36131868fe3641eb595ac1ff4cf16f",
+		"https://linode.github.io/rancher-ui-driver-linode/releases/v0.3.0-alpha.1/component.js", "faaf1d7d53b55a369baeeb0855b069921a36131868fe3641eb595ac1ff4cf16f",
 		[]string{"linode.github.io", "api.linode.com"}, false, false, management); err != nil {
 		return err
 	}

--- a/app/machinedriver_data.go
+++ b/app/machinedriver_data.go
@@ -15,6 +15,7 @@ import (
 var driverData = map[string]map[string][]string{
 	nodetemplate.Amazonec2driver: {"cred": []string{"accessKey"}},
 	nodetemplate.Azuredriver:     {"cred": []string{"clientId", "subscriptionId"}},
+	nodetemplate.Linodedriver:    {"password": []string{"token"}},
 	nodetemplate.Vmwaredriver:    {"cred": []string{"username", "vcenter", "vcenterPort"}},
 }
 var driverDefaults = map[string]map[string]string{
@@ -53,9 +54,9 @@ func addMachineDrivers(management *config.ManagementContext) error {
 	if err := addMachineDriver("exoscale", "local://", "", "", []string{"api.exoscale.ch"}, false, true, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver("linode", "https://github.com/linode/docker-machine-driver-linode/releases/download/v0.1.7/docker-machine-driver-linode_linux-amd64.zip",
+	if err := addMachineDriver(nodetemplate.Linodedriver, "https://github.com/linode/docker-machine-driver-linode/releases/download/v0.1.7/docker-machine-driver-linode_linux-amd64.zip",
 		"https://linode.github.io/rancher-ui-driver-linode/releases/v0.2.0/component.js", "faaf1d7d53b55a369baeeb0855b069921a36131868fe3641eb595ac1ff4cf16f",
-		[]string{"linode.github.io"}, false, false, management); err != nil {
+		[]string{"linode.github.io", "api.linode.com"}, false, false, management); err != nil {
 		return err
 	}
 	if err := addMachineDriver("openstack", "local://", "", "", nil, false, true, management); err != nil {

--- a/pkg/api/customization/nodetemplate/validation.go
+++ b/pkg/api/customization/nodetemplate/validation.go
@@ -9,6 +9,7 @@ import (
 const (
 	Amazonec2driver    = "amazonec2"
 	Azuredriver        = "azure"
+	Linodedriver       = "linode"
 	Vmwaredriver       = "vmwarevsphere"
 	DigitalOceandriver = "digitalocean"
 )


### PR DESCRIPTION
Creates a cloud credential for use by the Linode node driver.

Related to https://github.com/rancher/ui/pull/2834, and https://github.com/linode/rancher-ui-driver-linode/pull/7

After https://github.com/linode/rancher-ui-driver-linode/pull/7 is merged, the updated/released component.js should be [referenced](https://github.com/rancher/rancher/pull/20281/files#diff-3dda985564938bb62acd5b2d96e45aa0R58) in this PR.