### PR TITLE
Fix helm-git cache updates on HA (v2.2 backport)

### DIFF
--- a/app/catalog_data.go
+++ b/app/catalog_data.go
@@ -148,7 +148,7 @@ func doAddCatalogs(management *config.ManagementContext, name, url, branch strin
 			},
 			Spec: v3.CatalogSpec{
 				URL:         url,
-				CatalogKind: "helm",
+				CatalogKind: "helm:git",
 				Branch:      branch,
 			},
 		}

--- a/pkg/catalog/git/git.go
+++ b/pkg/catalog/git/git.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"bytes"
-	"fmt"
 	"net/url"
 	"os/exec"
 	"strings"
@@ -14,11 +13,11 @@ func Clone(path, url, branch string) error {
 	return runcmd("git", "clone", "-b", branch, "--single-branch", url, path)
 }
 
-func Update(path, branch string) error {
+func Update(path, commit string) error {
 	if err := runcmd("git", "-C", path, "fetch"); err != nil {
 		return err
 	}
-	return runcmd("git", "-C", path, "checkout", fmt.Sprintf("origin/%s", branch))
+	return runcmd("git", "-C", path, "checkout", commit)
 }
 
 func HeadCommit(path string) (string, error) {

--- a/pkg/catalog/helm/helm.go
+++ b/pkg/catalog/helm/helm.go
@@ -47,6 +47,7 @@ type Helm struct {
 	IconPath    string
 	catalogName string
 	Hash        string
+	Kind        string
 	url         string
 	branch      string
 	username    string


### PR DESCRIPTION
Verifies the git catalog cache is at the specified last commit for
helm.New.

Makes git catalog detection more robust and adds possibility for
explicitly defining the catalog kind (`helm:git` or `helm:http`).