### PR TITLE
Remove the logic to detect monitoring charts

### DIFF
--- a/pkg/controllers/user/monitoring/operatorHandler.go
+++ b/pkg/controllers/user/monitoring/operatorHandler.go
@@ -150,10 +150,6 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) (backErr erro
 	appName, appTargetNamespace := monitoring.SystemMonitoringInfo()
 
 	appCatalogID := settings.SystemMonitoringCatalogID.Get()
-	err := monitoring.DetectAppCatalogExistence(appCatalogID, app.cattleTemplateVersionClient)
-	if err != nil {
-		return errors.Wrapf(err, "failed to ensure catalog %q", appCatalogID)
-	}
 
 	appDeployProjectID, err := monitoring.GetSystemProjectID(app.cattleProjectClient)
 	if err != nil {

--- a/pkg/monitoring/deploy.go
+++ b/pkg/monitoring/deploy.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/rancher/rancher/pkg/controllers/user/helm/common"
 	"github.com/rancher/rancher/pkg/controllers/user/nslabels"
 	"github.com/rancher/rancher/pkg/project"
 	corev1 "github.com/rancher/types/apis/core/v1"
@@ -62,20 +61,6 @@ func EnsureAppProjectName(agentNamespacesClient corev1.NamespaceInterface, owned
 	}
 
 	return appProjectName, nil
-}
-
-func DetectAppCatalogExistence(appCatalogID string, cattleTemplateVersionsClient mgmtv3.CatalogTemplateVersionInterface) error {
-	templateVersionID, templateVersionNamespace, err := common.ParseExternalID(appCatalogID)
-	if err != nil {
-		return errors.Wrapf(err, "failed to parse catalog ID %q", appCatalogID)
-	}
-
-	_, err = cattleTemplateVersionsClient.GetNamespaced(templateVersionNamespace, templateVersionID, metav1.GetOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "failed to find catalog by ID %q", appCatalogID)
-	}
-
-	return nil
 }
 
 func GetSystemProjectID(cattleProjectsClient mgmtv3.ProjectInterface) (string, error) {


### PR DESCRIPTION
**Problem:**
It is not user friendly to show the monitoring template not found
error in UI.

**Solution:**
The error for template not found is not necessary as we won't update
the existing monitoring app to the newest version. Just remove it.

Related issue:
https://github.com/rancher/rancher/issues/20309