### PR TITLE
Self Healing nodepools

### DIFF
--- a/pkg/controllers/management/nodepool/nodepool.go
+++ b/pkg/controllers/management/nodepool/nodepool.go
@@ -3,25 +3,30 @@ package nodepool
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
+	"sync"
 	"time"
-
-	"reflect"
 
 	"github.com/rancher/rancher/pkg/ref"
 	"github.com/rancher/rke/services"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var (
-	nameRegexp = regexp.MustCompile("^(.*?)([0-9]+)$")
+	nameRegexp       = regexp.MustCompile("^(.*?)([0-9]+)$")
+	unReachableTaint = v1.Taint{
+		Key:    "node.kubernetes.io/unreachable",
+		Effect: "NoExecute",
+	}
 )
 
 type Controller struct {
@@ -30,6 +35,8 @@ type Controller struct {
 	NodePools          v3.NodePoolInterface
 	NodeLister         v3.NodeLister
 	Nodes              v3.NodeInterface
+	mutex              sync.RWMutex
+	syncmap            map[string]bool
 }
 
 func Register(ctx context.Context, management *config.ManagementContext) {
@@ -39,6 +46,7 @@ func Register(ctx context.Context, management *config.ManagementContext) {
 		NodePools:          management.Management.NodePools(""),
 		NodeLister:         management.Management.Nodes("").Controller().Lister(),
 		Nodes:              management.Management.Nodes(""),
+		syncmap:            make(map[string]bool),
 	}
 
 	// Add handlers
@@ -52,7 +60,7 @@ func (c *Controller) Create(nodePool *v3.NodePool) (runtime.Object, error) {
 
 func (c *Controller) Updated(nodePool *v3.NodePool) (runtime.Object, error) {
 	obj, err := v3.NodePoolConditionUpdated.Do(nodePool, func() (runtime.Object, error) {
-		return nodePool, c.createNodes(nodePool)
+		return nodePool, c.reconcile(nodePool)
 	})
 	return obj.(*v3.NodePool), err
 }
@@ -140,7 +148,7 @@ func (c *Controller) deleteNode(node *v3.Node, duration time.Duration) error {
 	})
 }
 
-func (c *Controller) createNodes(nodePool *v3.NodePool) error {
+func (c *Controller) reconcile(nodePool *v3.NodePool) error {
 	changed, err := c.createOrCheckNodes(nodePool, true)
 	if err != nil {
 		return err
@@ -185,10 +193,11 @@ func (c *Controller) nodes(nodePool *v3.NodePool, simulate bool) ([]*v3.Node, er
 
 func (c *Controller) createOrCheckNodes(nodePool *v3.NodePool, simulate bool) (bool, error) {
 	var (
-		err     error
-		byName  = map[string]*v3.Node{}
-		changed = false
-		nodes   []*v3.Node
+		err                 error
+		byName              = map[string]*v3.Node{}
+		changed             = false
+		nodes               []*v3.Node
+		deleteNotReadyAfter = nodePool.Spec.DeleteNotReadyAfterSecs * time.Second
 	)
 
 	allNodes, err := c.nodes(nodePool, simulate)
@@ -207,10 +216,31 @@ func (c *Controller) createOrCheckNodes(nodePool *v3.NodePool, simulate bool) (b
 		if v3.NodeConditionProvisioned.IsFalse(node) || v3.NodeConditionInitialized.IsFalse(node) || v3.NodeConditionConfigSaved.IsFalse(node) {
 			changed = true
 			if !simulate {
-				c.deleteNode(node, 2*time.Minute)
+				_ = c.deleteNode(node, 2*time.Minute)
 			}
 		}
-
+		// remove unreachable node with the unreachable taint & status of Ready being Unknown
+		q := getTaint(node.Spec.InternalNodeSpec.Taints, &unReachableTaint)
+		if q != nil && deleteNotReadyAfter > 0 {
+			changed = true
+			if isNodeReadyUnknown(node) && !simulate {
+				start := q.TimeAdded.Time
+				if time.Since(start) > deleteNotReadyAfter {
+					err = c.deleteNode(node, 0)
+					if err != nil {
+						return false, err
+					}
+				} else {
+					c.mutex.Lock()
+					nodeid := node.Namespace + ":" + node.Name
+					if _, ok := c.syncmap[nodeid]; !ok {
+						c.syncmap[nodeid] = true
+						go c.requeue(deleteNotReadyAfter, nodePool, node)
+					}
+					c.mutex.Unlock()
+				}
+			}
+		}
 		nodes = append(nodes, node)
 	}
 
@@ -318,4 +348,46 @@ func (c *Controller) updateNodeRoles(existing *v3.Node, nodePool *v3.NodePool, s
 	}
 
 	return c.Nodes.Update(toUpdate)
+}
+
+// requeue checks every 5 seconds if the node is still unreachable with one goroutine per node
+func (c *Controller) requeue(timeout time.Duration, np *v3.NodePool, node *v3.Node) {
+
+	t := getTaint(node.Spec.InternalNodeSpec.Taints, &unReachableTaint)
+	for t != nil {
+		time.Sleep(5 * time.Second)
+		exist, err := c.NodeLister.Get(node.Namespace, node.Name)
+		if err != nil {
+			break
+		}
+		t = getTaint(exist.Spec.InternalNodeSpec.Taints, &unReachableTaint)
+		if t != nil && time.Since(t.TimeAdded.Time) > timeout {
+			logrus.Debugf("Enqueue nodepool controller: %s %s", np.Namespace, np.Name)
+			c.NodePoolController.Enqueue(np.Namespace, np.Name)
+			break
+		}
+	}
+	c.mutex.Lock()
+	delete(c.syncmap, node.Namespace+":"+node.Name)
+	c.mutex.Unlock()
+}
+
+// getTaint returns the taint that matches the given request
+func getTaint(taints []v1.Taint, taintToFind *v1.Taint) *v1.Taint {
+	for _, taint := range taints {
+		if taint.MatchTaint(taintToFind) {
+			return &taint
+		}
+	}
+	return nil
+}
+
+// IsNodeReady returns true if a node Ready condition is Unknown; false otherwise.
+func isNodeReadyUnknown(node *v3.Node) bool {
+	for _, c := range node.Status.InternalNodeStatus.Conditions {
+		if c.Type == v1.NodeReady {
+			return c.Status == v1.ConditionUnknown
+		}
+	}
+	return false
 }

--- a/pkg/controllers/management/nodepool/nodepool_test.go
+++ b/pkg/controllers/management/nodepool/nodepool_test.go
@@ -1,0 +1,45 @@
+package nodepool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parsePrefix(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		fullPrefix    string
+		wantPrefix    string
+		wantMinLength int
+		wantStart     int
+	}{{
+		name:          "prefix with an 2 digit integer",
+		fullPrefix:    "my-worker25",
+		wantPrefix:    "my-worker",
+		wantMinLength: 2,
+		wantStart:     25,
+	}, {
+		name:          "prefix with an 1 digit integer",
+		fullPrefix:    "pool4",
+		wantPrefix:    "pool",
+		wantMinLength: 1,
+		wantStart:     4,
+	}, {
+		name:          "default case",
+		fullPrefix:    "genericNodepool",
+		wantPrefix:    "genericNodepool",
+		wantMinLength: 1,
+		wantStart:     1,
+	},
+	}
+	for _, tt := range tests {
+
+		gotPrefix, gotMinLength, gotStart := parsePrefix(tt.fullPrefix)
+
+		assert.Equal(t, tt.wantPrefix, gotPrefix)
+		assert.Equal(t, tt.wantMinLength, gotMinLength)
+		assert.Equal(t, tt.wantStart, gotStart)
+	}
+}

--- a/pkg/controllers/user/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/user/nodesyncer/nodessyncer.go
@@ -236,7 +236,7 @@ func (m *nodesSyncer) reconcileAll() error {
 			return err
 		}
 		if node == nil {
-			logrus.Debugf("Failed to get node for machine [%s]", machine.Name)
+			logrus.Debugf("Failed to get node for machine [%s], preparing to delete", machine.Name)
 			toDelete[machine.Name] = machine
 			continue
 		}


### PR DESCRIPTION
Verified following:

- [x]    Cluster created with cloud provider passed in (AWS). Check that the node is gone from Kubernetes only when it is removed from the cloud provider.
 - [x]   Cluster created without cloud provider option. Check at which point the node gets removed form Kubernetes.
 - [x]  `Kubectl delete node` is removed from Rancher UI as well. Rancher UI should reflect `kubectl get nodes` as closely as possible.
- [ ] Nodes are scaled down oldest first (sorted in the UI?)
- [x] Ensure no regression for this issue https://github.com/rancher/rancher/pull/13609

This fix allows nodes deleted via the `kubectl delete node` to actually be deleted in Rancher. If a cloud provider is used this means that `kubectl delete node` will actually destroy the underlying infrastructure. 

This PR also includes the feature of self-healing nodepools, where nodepools can have the self-healing option set to True & configure a timeout specified in seconds to delete and attempt to recreate the node. 

- [x] _Dependency_ Types PR: https://github.com/rancher/types/pull/868