### PR TITLE
RBAC handler should handle sa kind PRTB

### DIFF
--- a/pkg/controllers/user/rbac/handler_base.go
+++ b/pkg/controllers/user/rbac/handler_base.go
@@ -394,8 +394,10 @@ func getPRTBProjectAndSubjectKey(prtb *v3.ProjectRoleTemplateBinding) string {
 		name = prtb.UserPrincipalName
 	} else if prtb.GroupName != "" {
 		name = prtb.GroupName
-	} else {
+	} else if prtb.GroupPrincipalName != "" {
 		name = prtb.GroupPrincipalName
+	} else if prtb.ServiceAccount != "" {
+		name = prtb.ServiceAccount
 	}
 	return prtb.ProjectName + "." + name
 }

--- a/pkg/controllers/user/rbac/namespace_handler.go
+++ b/pkg/controllers/user/rbac/namespace_handler.go
@@ -166,7 +166,7 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 			return false, errors.Wrapf(err, "object %v is not valid project role template binding", prtb)
 		}
 
-		if prtb.UserName == "" && prtb.GroupPrincipalName == "" && prtb.GroupName == "" {
+		if prtb.UserName == "" && prtb.GroupPrincipalName == "" && prtb.GroupName == "" && prtb.ServiceAccount == "" {
 			continue
 		}
 


### PR DESCRIPTION
**Problem:**
The project monitoring can't fetch metrics from the namespace moved
from the other project

**Solution:**
The RBAC handler should handle service account type PRTB
too.

**Issues:**

https://github.com/rancher/rancher/issues/20459
https://github.com/rancher/rancher/issues/20390