### PR TITLE
Fix Helm install error

### DIFF
--- a/package/jailer.sh
+++ b/package/jailer.sh
@@ -23,6 +23,7 @@ cp -r /lib /opt/jail/$NAME
 cp -r /lib64 /opt/jail/$NAME
 cp /etc/ssl/certs/ca-certificates.crt /opt/jail/$NAME/etc/ssl/certs
 cp /etc/resolv.conf /opt/jail/$NAME/etc/
+cp /etc/hosts /opt/jail/$NAME/etc/
 
 if [ -d /var/lib/rancher/management-state/bin ]; then
   ( cd /var/lib/rancher/management-state/bin


### PR DESCRIPTION
**Problem:**
Create jailer for helm install but missing the `/etc/hosts`

**Solution:**
Copy the `/etc/hosts` to `/opt/jail/$NAME/etc/` to fix the network
namespace.

Related issues:
https://github.com/rancher/rancher/issues/20389
https://github.com/rancher/rancher/issues/20289