### PR TITLE
Check if dir is empty before copy v2.1

### DIFF
--- a/package/jailer.sh
+++ b/package/jailer.sh
@@ -25,7 +25,7 @@ cp /etc/ssl/certs/ca-certificates.crt /opt/jail/$NAME/etc/ssl/certs
 cp /etc/resolv.conf /opt/jail/$NAME/etc/
 cp /etc/hosts /opt/jail/$NAME/etc/
 
-if [ -d /var/lib/rancher/management-state/bin ]; then
+if [ -d /var/lib/rancher/management-state/bin ] && [ "$(ls -A /var/lib/rancher/management-state/bin)" ]; then
   ( cd /var/lib/rancher/management-state/bin
     for f in *; do
       if [ ! -f "/opt/drivers/management-state/bin/$f" ]; then


### PR DESCRIPTION
Problem:
If the bin dir is empty stat fails on "*"

Solution:
Verify the dir has contents before attempting the copy