### PR TITLE
Refactor rbac for sharing global ns resources

### DIFF
--- a/pkg/api/customization/globalnamespaceaccess/access_common.go
+++ b/pkg/api/customization/globalnamespaceaccess/access_common.go
@@ -409,6 +409,9 @@ func (ma *MemberAccess) GetAccessTypeOfCaller(callerID, creatorID, name string, 
 		if username != "" { // found the caller
 			return m.AccessType, nil
 		}
+		if m.GroupPrincipalName == "*" {
+			return m.AccessType, nil
+		}
 	}
 	return "", fmt.Errorf("user %v is not in members list", callerID)
 }

--- a/pkg/controllers/management/cloudcredential/controller.go
+++ b/pkg/controllers/management/cloudcredential/controller.go
@@ -44,10 +44,11 @@ func (n *Controller) ccSync(key string, cloudCredential *v1.Secret) (runtime.Obj
 		return cloudCredential, fmt.Errorf("cloud credential %v has no creatorId annotation", cloudCredential.Name)
 	}
 	if err := globalnamespacerbac.CreateRoleAndRoleBinding(
-		globalnamespacerbac.CloudCredentialResource, cloudCredential.Name, cloudCredential.UID, []v3.Member{}, creatorID,
-		n.managementContext, "*"); err != nil {
+		globalnamespacerbac.CloudCredentialResource, cloudCredential.Name, "v1", creatorID, []string{"*"}, cloudCredential.UID, []v3.Member{},
+		n.managementContext); err != nil {
 		return nil, err
 	}
+
 	return cloudCredential, nil
 }
 

--- a/pkg/controllers/management/clustertemplate/clustertemplate_rbac.go
+++ b/pkg/controllers/management/clustertemplate/clustertemplate_rbac.go
@@ -1,0 +1,115 @@
+package clustertemplate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/rancher/pkg/controllers/management/globalnamespacerbac"
+	"github.com/rancher/rancher/pkg/namespace"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	creatorIDAnn = "field.cattle.io/creatorId"
+	ctLabel      = "io.cattle.field/clusterTemplateId"
+)
+
+type clusterTemplateController struct {
+	clusterTemplates              v3.ClusterTemplateInterface
+	clusterTemplateLister         v3.ClusterTemplateLister
+	clusterTemplateRevisionLister v3.ClusterTemplateRevisionLister
+	managementContext             *config.ManagementContext
+}
+
+type clusterTemplateRevisionController struct {
+	clusterTemplateRevisions      v3.ClusterTemplateRevisionInterface
+	clusterTemplateRevisionLister v3.ClusterTemplateRevisionLister
+	clusterTemplateLister         v3.ClusterTemplateLister
+	managementContext             *config.ManagementContext
+}
+
+func registerRbacControllers(ctx context.Context, mgmt *config.ManagementContext) {
+	ct := clusterTemplateController{
+		managementContext:             mgmt,
+		clusterTemplates:              mgmt.Management.ClusterTemplates(""),
+		clusterTemplateLister:         mgmt.Management.ClusterTemplates("").Controller().Lister(),
+		clusterTemplateRevisionLister: mgmt.Management.ClusterTemplateRevisions("").Controller().Lister(),
+	}
+	ct.clusterTemplates.AddHandler(ctx, "cluster-template-rbac-controller", ct.sync)
+
+	ctr := clusterTemplateRevisionController{
+		clusterTemplateRevisions:      mgmt.Management.ClusterTemplateRevisions(""),
+		clusterTemplateRevisionLister: mgmt.Management.ClusterTemplateRevisions("").Controller().Lister(),
+		clusterTemplateLister:         mgmt.Management.ClusterTemplates("").Controller().Lister(),
+	}
+	ctr.clusterTemplateRevisions.AddHandler(ctx, "cluster-template-rev-rbac-controller", ctr.sync)
+}
+
+func (ct *clusterTemplateController) sync(key string, clusterTemplate *v3.ClusterTemplate) (runtime.Object, error) {
+	if clusterTemplate == nil || clusterTemplate.DeletionTimestamp != nil {
+		return nil, nil
+	}
+	metaAccessor, err := meta.Accessor(clusterTemplate)
+	if err != nil {
+		return clusterTemplate, err
+	}
+	creatorID, ok := metaAccessor.GetAnnotations()[globalnamespacerbac.CreatorIDAnn]
+	if !ok {
+		return clusterTemplate, fmt.Errorf("clusterTemplate %v has no creatorId annotation", metaAccessor.GetName())
+	}
+
+	if err := globalnamespacerbac.CreateRoleAndRoleBinding(globalnamespacerbac.ClusterTemplateResource, clusterTemplate.Name,
+		globalnamespacerbac.RancherManagementAPIVersion, creatorID, []string{globalnamespacerbac.RancherManagementAPIVersion},
+		clusterTemplate.UID,
+		clusterTemplate.Spec.Members, ct.managementContext); err != nil {
+		return nil, err
+	}
+
+	//see if any revision exists and call CreateRoleAndRoleBinding for it so that if this is an update request adding/removing members,
+	//it reflects on the permissions for revisions too
+	revisions, err := ct.clusterTemplateRevisionLister.List(namespace.GlobalNamespace, labels.SelectorFromSet(map[string]string{ctLabel: clusterTemplate.Name}))
+	if err != nil && !apierrors.IsNotFound(err) {
+		return clusterTemplate, err
+	}
+	for _, rev := range revisions {
+		ct.managementContext.Management.ClusterTemplateRevisions(namespace.GlobalNamespace).Controller().Enqueue(namespace.GlobalNamespace, rev.Name)
+	}
+	return clusterTemplate, nil
+}
+
+func (ctr *clusterTemplateRevisionController) sync(key string, clusterTemplateRev *v3.ClusterTemplateRevision) (runtime.Object, error) {
+	if clusterTemplateRev == nil || clusterTemplateRev.DeletionTimestamp != nil {
+		return nil, nil
+	}
+	metaAccessor, err := meta.Accessor(clusterTemplateRev)
+	if err != nil {
+		return clusterTemplateRev, err
+	}
+	creatorID, ok := metaAccessor.GetAnnotations()[globalnamespacerbac.CreatorIDAnn]
+	if !ok {
+		return clusterTemplateRev, fmt.Errorf("clusterTemplateRevision %v has no creatorId annotation", metaAccessor.GetName())
+	}
+
+	// get members field from clusterTemplate
+	clusterTemplateName, ok := clusterTemplateRev.Labels[ctLabel]
+	if !ok {
+		return clusterTemplateRev, fmt.Errorf("clustertemplate revision created without setting clustertemplate label")
+	}
+	clusterTemp, err := ctr.clusterTemplateLister.Get(namespace.GlobalNamespace, clusterTemplateName)
+	if err != nil {
+		return clusterTemplateRev, err
+	}
+	if err := globalnamespacerbac.CreateRoleAndRoleBinding(globalnamespacerbac.ClusterTemplateResource, clusterTemplateRev.Name,
+		globalnamespacerbac.RancherManagementAPIVersion, creatorID, []string{globalnamespacerbac.RancherManagementAPIVersion},
+		clusterTemplateRev.UID,
+		clusterTemp.Spec.Members, ctr.managementContext); err != nil {
+		return nil, err
+	}
+	return clusterTemplateRev, nil
+}

--- a/pkg/controllers/management/clustertemplate/revision_controller.go
+++ b/pkg/controllers/management/clustertemplate/revision_controller.go
@@ -38,6 +38,7 @@ func Register(ctx context.Context, management *config.ManagementContext) {
 	if n != nil {
 		management.Management.ClusterTemplateRevisions("").AddHandler(ctx, RevisionController, n.sync)
 	}
+	registerRbacControllers(ctx, management)
 }
 
 //sync is called periodically and on real updates

--- a/pkg/controllers/management/globaldns/globaldns_handler.go
+++ b/pkg/controllers/management/globaldns/globaldns_handler.go
@@ -67,7 +67,8 @@ func (n *GDController) sync(key string, obj *v3.GlobalDNS) (runtime.Object, erro
 	}
 
 	if err := globalnamespacerbac.CreateRoleAndRoleBinding(globalnamespacerbac.GlobalDNSResource, obj.Name,
-		obj.UID, obj.Spec.Members, creatorID, n.managementContext); err != nil {
+		globalnamespacerbac.RancherManagementAPIVersion, creatorID, []string{globalnamespacerbac.RancherManagementAPIVersion},
+		obj.UID, obj.Spec.Members, n.managementContext); err != nil {
 		return nil, err
 	}
 	//check if status.endpoints is set, if yes create a dummy ingress if not already present

--- a/pkg/controllers/management/globaldns/globaldnsprovider_catalog_launcher.go
+++ b/pkg/controllers/management/globaldns/globaldnsprovider_catalog_launcher.go
@@ -63,7 +63,8 @@ func (n *ProviderCatalogLauncher) sync(key string, obj *v3.GlobalDNSProvider) (r
 	}
 
 	if err := globalnamespacerbac.CreateRoleAndRoleBinding(globalnamespacerbac.GlobalDNSProviderResource, obj.Name,
-		obj.UID, obj.Spec.Members, creatorID, n.managementContext); err != nil {
+		globalnamespacerbac.RancherManagementAPIVersion, creatorID, []string{globalnamespacerbac.RancherManagementAPIVersion},
+		obj.UID, obj.Spec.Members, n.managementContext); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controllers/management/globalnamespacerbac/rbac_common.go
+++ b/pkg/controllers/management/globalnamespacerbac/rbac_common.go
@@ -13,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 const (
@@ -23,31 +24,37 @@ const (
 	MultiClusterAppRevisionResource = "multiclusterapprevisions"
 	GlobalDNSResource               = "globaldnses"
 	GlobalDNSProviderResource       = "globaldnsproviders"
+	ClusterTemplateResource         = "clustertemplates"
+	ClusterTemplateRevisionResource = "clustertemplaterevisions"
 	CloudCredentialResource         = "secrets"
 	CreatorIDAnn                    = "field.cattle.io/creatorId"
+	RancherManagementAPIVersion     = "management.cattle.io"
 )
 
-func CreateRoleAndRoleBinding(resource string, name string, UID types.UID, members []v3.Member, creatorID string,
-	managementContext *config.ManagementContext, apiGroup ...string) error {
-	/* Create 3 Roles containing the resource (multiclusterapp or globalDNS), and the current multiclusterapp/globalDNS in resourceNames list
+var subjectWithAllUsers = k8srbacv1.Subject{
+	Kind:     "Group",
+	Name:     user.AllAuthenticated,
+	APIGroup: rbacv1.GroupName,
+}
+
+func CreateRoleAndRoleBinding(resource, name, apiVersion, creatorID string, apiGroup []string, UID types.UID, members []v3.Member,
+	mgmt *config.ManagementContext) error {
+	/* Create 3 Roles containing the CRD, and the current CR in resourceNames list
 	1. Role with owner verbs (Owner access, includes creator); name multiclusterapp.Name + "-ma" / (globalDNS.Name + "-ga")
 	2. Role with "get", "list" "watch" verbs (ReadOnly access); name multiclusterapp.Name + "-mr" / (globalDNS.Name + "-gr")
 	3. Role with "update" verb (Member access); name multiclusterapp.Name + "-mu" / (globalDNS.Name + "-gu")
 	*/
-	api := []string{"management.cattle.io"}
-	if len(apiGroup) > 0 {
-		api = apiGroup
-	}
-	if _, err := createRole(resource, ownerAccess, name, UID, managementContext, api); err != nil {
+
+	if _, err := createRole(resource, name, ownerAccess, apiVersion, apiGroup, UID, mgmt); err != nil {
 		return err
 	}
 
-	// Create a roleBinding referring the role with everything access, and containing creator of the multiclusterapp, along with
+	// Create a roleBinding referring the role with everything access, and containing creator of the resouce, along with
 	// any members that have everything access
 	var ownerAccessSubjects, readOnlyAccessSubjects, memberAccessSubjects []k8srbacv1.Subject
 	ownerAccessSubjects = append(ownerAccessSubjects, k8srbacv1.Subject{Kind: "User", Name: creatorID, APIGroup: rbacv1.GroupName})
 	for _, m := range members {
-		s, err := buildSubjectForMember(m, managementContext)
+		s, err := buildSubjectForMember(m, mgmt)
 		if err != nil {
 			return err
 		}
@@ -60,47 +67,45 @@ func CreateRoleAndRoleBinding(resource string, name string, UID types.UID, membe
 			readOnlyAccessSubjects = append(readOnlyAccessSubjects, s)
 		default:
 			if resource == GlobalDNSProviderResource || resource == GlobalDNSResource {
+				// since these two resources only have one access type "owner" for their members
 				ownerAccessSubjects = append(ownerAccessSubjects, s)
 			} else {
+				// for mcapp and cluster templates which can have other access types
 				readOnlyAccessSubjects = append(readOnlyAccessSubjects, s)
 			}
 		}
 	}
 
-	if _, err := createRoleBinding(ownerAccess, name, UID, ownerAccessSubjects, managementContext, resource, api); err != nil {
+	if err := createRoleBindingForMembers(resource, name, ownerAccess, apiVersion, UID, ownerAccessSubjects, mgmt); err != nil {
 		return err
 	}
 
 	// Check if there are members with readonly or member(update) access; if found then create rolebindings for those
 	if len(readOnlyAccessSubjects) > 0 {
-		if _, err := createRole(resource, readOnlyAccess, name, UID, managementContext, api); err != nil {
+		if _, err := createRole(resource, name, readOnlyAccess, apiVersion, apiGroup, UID, mgmt); err != nil {
 			return err
 		}
-		if _, err := createRoleBinding(readOnlyAccess, name, UID, readOnlyAccessSubjects, managementContext, resource, api); err != nil {
+		if err := createRoleBindingForMembers(resource, name, readOnlyAccess, apiVersion, UID, readOnlyAccessSubjects, mgmt); err != nil {
 			return err
 		}
 	}
 	if len(memberAccessSubjects) > 0 {
-		if _, err := createRole(resource, memberAccess, name, UID, managementContext, api); err != nil {
+		if _, err := createRole(resource, name, memberAccess, apiVersion, apiGroup, UID, mgmt); err != nil {
 			return err
 		}
-		if _, err := createRoleBinding(memberAccess, name, UID, memberAccessSubjects, managementContext, resource, api); err != nil {
+		if err := createRoleBindingForMembers(resource, name, memberAccess, apiVersion, UID, memberAccessSubjects, mgmt); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func createRole(resource string, roleAccess string, resourceName string, resourceUID types.UID,
-	managementContext *config.ManagementContext, apiGroups []string) (*k8srbacv1.Role, error) {
-	roleName, verbs := getRoleNameAndVerbs(roleAccess, resourceName, resource)
-	apiVersion := "management.cattle.io/v3"
-	if apiGroups[0] != "management.cattle.io" {
-		apiVersion = "v1" // for cloud credential
-	}
+func createRole(resourceType, resourceName, roleAccess, apiVersion string, apiGroups []string, resourceUID types.UID,
+	mgmt *config.ManagementContext) (*k8srbacv1.Role, error) {
+	roleName, verbs := getRoleNameAndVerbs(roleAccess, resourceName, resourceType)
 	ownerReference := metav1.OwnerReference{
 		APIVersion: apiVersion,
-		Kind:       resource,
+		Kind:       resourceType,
 		Name:       resourceName,
 		UID:        resourceUID,
 	}
@@ -113,16 +118,16 @@ func createRole(resource string, roleAccess string, resourceName string, resourc
 		Rules: []k8srbacv1.PolicyRule{
 			{
 				APIGroups:     apiGroups,
-				Resources:     []string{resource},
+				Resources:     []string{resourceType},
 				ResourceNames: []string{resourceName},
 				Verbs:         verbs,
 			},
 		},
 	}
-	role, err := managementContext.RBAC.Roles("").GetNamespaced(namespace.GlobalNamespace, roleName, metav1.GetOptions{})
+	role, err := mgmt.RBAC.Roles("").GetNamespaced(namespace.GlobalNamespace, roleName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			role, err = managementContext.RBAC.Roles("").Create(newRole)
+			role, err = mgmt.RBAC.Roles("").Create(newRole)
 			if err != nil {
 				return nil, err
 			}
@@ -132,7 +137,7 @@ func createRole(resource string, roleAccess string, resourceName string, resourc
 	} else if role != nil {
 		if !reflect.DeepEqual(newRole, role) {
 			toUpdate := newRole.DeepCopy()
-			updated, err := managementContext.RBAC.Roles("").Update(toUpdate)
+			updated, err := mgmt.RBAC.Roles("").Update(toUpdate)
 			if err != nil {
 				return updated, err
 			}
@@ -141,24 +146,23 @@ func createRole(resource string, roleAccess string, resourceName string, resourc
 	return role, nil
 }
 
-func createRoleBinding(roleAccess string, name string, UID types.UID,
-	subjects []k8srbacv1.Subject, managementContext *config.ManagementContext, resource string, apiGroups []string) (*k8srbacv1.RoleBinding, error) {
-	roleName, _ := getRoleNameAndVerbs(roleAccess, name, resource)
+func createRoleBindingForMembers(resourceType, resourceName, roleAccess, apiVersion string, UID types.UID,
+	subjects []k8srbacv1.Subject, mgmt *config.ManagementContext) error {
+	roleName, _ := getRoleNameAndVerbs(roleAccess, resourceName, resourceType)
 	// we can define the rolebinding first, since if it's not already present we can call create. And if it's present then we'll
 	// still need to compare the current members' list
 	sort.Slice(subjects, func(i, j int) bool { return subjects[i].Name < subjects[j].Name })
+	return createRoleBinding(resourceType, resourceName, roleName, apiVersion, mgmt, UID, subjects)
+}
 
-	apiVersion := "management.cattle.io/v3"
-	if apiGroups[0] != "management.cattle.io" {
-		apiVersion = "v1" // for cloud credential
-	}
+func createRoleBinding(resourceType, resourceName, roleName, apiVersion string, mgmt *config.ManagementContext,
+	resourceUID types.UID, subjects []k8srbacv1.Subject) error {
 	ownerReference := metav1.OwnerReference{
 		APIVersion: apiVersion,
-		Kind:       resource,
-		Name:       name,
-		UID:        UID,
+		Kind:       resourceType,
+		Name:       resourceName,
+		UID:        resourceUID,
 	}
-
 	newRoleBinding := &k8srbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            roleName,
@@ -171,39 +175,45 @@ func createRoleBinding(roleAccess string, name string, UID types.UID,
 		},
 		Subjects: subjects,
 	}
-
-	roleBinding, err := managementContext.RBAC.RoleBindings("").GetNamespaced(namespace.GlobalNamespace, roleName, metav1.GetOptions{})
+	roleBinding, err := mgmt.RBAC.RoleBindings("").GetNamespaced(namespace.GlobalNamespace, roleName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			_, err = managementContext.RBAC.RoleBindings("").Create(newRoleBinding)
+			_, err = mgmt.RBAC.RoleBindings("").Create(newRoleBinding)
 			if err != nil && !apierrors.IsAlreadyExists(err) {
-				return nil, err
+				return err
 			}
 		} else {
-			return nil, err
+			return err
 		}
 	} else if roleBinding != nil {
 		if !reflect.DeepEqual(roleBinding, newRoleBinding) {
 			toUpdate := newRoleBinding.DeepCopy()
-			updated, err := managementContext.RBAC.RoleBindings("").Update(toUpdate)
+			_, err := mgmt.RBAC.RoleBindings("").Update(toUpdate)
 			if err != nil {
-				return updated, err
+				return err
 			}
 		}
 	}
-	return newRoleBinding, nil
+	return nil
 }
 
-func getRoleNameAndVerbs(roleAccess string, resourceName string, resource string) (string, []string) {
+func getRoleNameAndVerbs(roleAccess string, resourceName string, resourceType string) (string, []string) {
 	var roleName string
 	var verbs []string
-	switch resource {
+
+	switch resourceType {
 	case MultiClusterAppResource:
 		resourceName += "-m-"
+	case MultiClusterAppRevisionResource:
+		resourceName += "-mr-"
 	case GlobalDNSResource:
 		resourceName += "-g-"
 	case GlobalDNSProviderResource:
 		resourceName += "-gp-"
+	case ClusterTemplateResource:
+		resourceName += "-ct-"
+	case ClusterTemplateRevisionResource:
+		resourceName += "-ctr-"
 	}
 	switch roleAccess {
 	case ownerAccess:
@@ -216,6 +226,7 @@ func getRoleNameAndVerbs(roleAccess string, resourceName string, resource string
 		roleName = resourceName + "r"
 		verbs = []string{"get", "list", "watch"}
 	}
+
 	return roleName, verbs
 }
 
@@ -241,6 +252,11 @@ func buildSubjectForMember(member v3.Member, managementContext *config.Managemen
 
 	if name == "" {
 		return k8srbacv1.Subject{}, fmt.Errorf("member %v doesn't have any name fields set", member)
+	}
+
+	if name == "*" {
+		//member.GroupPrincipalName = subjectWithAllUsers.Name
+		return subjectWithAllUsers, nil
 	}
 
 	return k8srbacv1.Subject{

--- a/tests/integration/suite/common.py
+++ b/tests/integration/suite/common.py
@@ -134,3 +134,12 @@ def wait_for_template_to_be_deleted(client, name, timeout=45):
             found = True
         time.sleep(interval)
         interval *= 2
+
+
+def check_subject_in_rb(rbac, ns, subject_id):
+    rbs = rbac.list_namespaced_role_binding(ns)
+    for rb in rbs.items:
+        for i in range(0, len(rb.subjects)):
+            if rb.subjects[i].name == subject_id:
+                return True
+    return False

--- a/tests/integration/suite/test_multi_cluster_app.py
+++ b/tests/integration/suite/test_multi_cluster_app.py
@@ -1,5 +1,4 @@
-from .common import random_str, check_if_members_updated, \
- check_subject_in_rb
+from .common import random_str, check_subject_in_rb
 from rancher import ApiError
 from .conftest import wait_until, wait_for
 import time
@@ -93,9 +92,6 @@ def test_multiclusterapp_create_with_members(admin_mc, admin_pc,
     new_members = [{"userPrincipalId": "local://"+user_member.user.id,
                    "accessType": "read-only"}, {"groupPrincipalId": "*"}]
     client.update(mcapp, members=new_members, roles=roles)
-    wait_for(lambda: check_if_members_updated(admin_mc, id, 'groupPrincipalId',
-                                              '*'),
-             timeout=60, fail_handler=fail_handler(members_resource))
 
     # now user_not_member should be able to access this mcapp without
     # being explicitly added
@@ -490,4 +486,4 @@ def check_updated_roles(admin_mc, mcapp_name, roles):
 
 
 def fail_handler(resource):
-    return "failed waiting for multiclusterapp" + resource + " to get updated"
+    return "failed waiting for multiclusterapp " + resource + " to get updated"


### PR DESCRIPTION
This PR introduces two changes:
1. Multiclusterapp, global dns providers & entries are created in the cattle-global-data namespace. They can be shared by users other than their creators through the Members field. The rbac controllers create roles containing the resourceNames, and rolebindings with these roles for the members.
Now these resources can also be shared by everyone, by typing in the character `*` in the search box of members. This will translate to the `system:authenticated` k8s rbac group on the rolebinding for a role containing this resource. This will allow all authenticated users to have access to this resource.

2. Adds the same sharing logic with Members and all authenticated users for clustertemplates