### PR TITLE
Use dynamic ssh key name to find key v2.2

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -321,7 +321,7 @@ func aliasToPath(driver string, config map[string]interface{}, ns string) error 
 				hasher.Write([]byte(fileContents))
 				sha := base32.StdEncoding.WithPadding(-1).EncodeToString(hasher.Sum(nil))[:10]
 				fullPath := path.Join(baseDir, sha)
-				err := ioutil.WriteFile(fullPath, []byte(fileContents), 0644)
+				err := ioutil.WriteFile(fullPath, []byte(fileContents), 0600)
 				if err != nil {
 					return err
 				}
@@ -447,7 +447,12 @@ func (m *Lifecycle) saveConfig(config *nodeconfig.NodeConfig, nodeDir string, ob
 		return obj, err
 	}
 
-	sshKey, err := getSSHKey(nodeDir, obj)
+	keyPath, err := config.SSHKeyPath()
+	if err != nil {
+		return obj, err
+	}
+
+	sshKey, err := getSSHKey(nodeDir, keyPath, obj)
 	if err != nil {
 		return obj, err
 	}

--- a/pkg/nodeconfig/config.go
+++ b/pkg/nodeconfig/config.go
@@ -103,6 +103,15 @@ func (m *NodeConfig) TLSConfig() (*TLSConfig, error) {
 	return extractTLS(m.cm[configKey])
 }
 
+func (m *NodeConfig) SSHKeyPath() (string, error) {
+	config, err := m.getConfig()
+	if err != nil {
+		return "", err
+	}
+
+	return convert.ToString(values.GetValueN(config, "Driver", "SSHKeyPath")), nil
+}
+
 func (m *NodeConfig) IP() (string, error) {
 	config, err := m.getConfig()
 	if err != nil {


### PR DESCRIPTION
Problem: 
key name is hardcoded to 'id_rsa'

Solution:
Use the name of the file that gets generated when a user passes in an sshkey instead of using a generated one