### PR TITLE
Helm Chart: Default to Pulbic certs when `--set tls=external`

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
 {{- end }}
 {{- if .Values.privateCA }}
         # Private CA - don't clear ca certs
-{{- else if eq .Values.ingress.tls.source "rancher" }}
+{{- else if and (eq .Values.tls "ingress") (eq .Values.ingress.tls.source "rancher") }}
         # Rancher self-signed - don't clear ca certs
 {{- else }}
         # Public trusted CA - clear ca certs

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -73,3 +73,32 @@ tests:
   - equal:
       path: spec.template.spec.containers[1].image
       value: my.private.repo:5000/rancher/busybox:1.0.1
+- it: should not have command arg "--no-cacerts" when using private CA
+  set:
+    privateCA: "true"
+  asserts:
+  - notContains:
+      path: spec.template.spec.containers[0].args
+      content: "--no-cacerts"
+- it: should not have command arg "--no-cacerts" when using default (rancher) ingress TLS
+  set:
+    tls: "ingress"
+  asserts:
+  - notContains:
+      path: spec.template.spec.containers[0].args
+      content: "--no-cacerts"
+- it: should have command arg "--no-cacerts" when using letsEncrypt ingress TLS
+  set:
+    tls: "ingress"
+    ingress.tls.source: "letsEncrypt"
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: "--no-cacerts"
+- it: should have command arg "--no-cacerts" when using external TLS
+  set:
+    tls: "external"
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: "--no-cacerts"


### PR DESCRIPTION
- Fixes #20573 
- Check for `.Values.tls == ingress` in addition to `Values.ingress.tls.source == "rancher"` when determining if self-signed should be used