### PR TITLE
[Windows] Fix could not use GCEPersistentDisk on Windows

### DIFF
--- a/package/windows/cleanup.ps1
+++ b/package/windows/cleanup.ps1
@@ -112,6 +112,11 @@ try {
         }
     }
 
+    # restore repair #
+    if (Test-Path "$RancherDir\GetGcePdName.dll") {
+        Remove-Module GetGcePdName -Force -ErrorAction Ignore
+    }
+
     # rancher #
     Remove-Item -Path "$CNIDir\*" -Recurse -Force -ErrorAction Ignore
     Remove-Item -Path "$KubeDir\*" -Recurse -Force -ErrorAction Ignore


### PR DESCRIPTION
**Problem:**
K8S GCE cloud provider has replace `Get-GcePdName` with native windows
support of `Get-Disk`, but the GCE VMs haven't injected the new
method.

**Solution:**
Following
https://github.com/kubernetes/kubernetes/blob/f49fe2a7504c40684573f3e4928e8b0bfdfb2b30/cluster/gce/windows/k8s-node-setup.psm1#L782-L795,
we can patch the `Get-GcePdName`.

**Issue:**
https://github.com/rancher/rancher/issues/20180