### PR TITLE
publish on head of master and release branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-name: default-amd64
+name: default-linux-amd64
 
 platform:
   os: linux
@@ -8,7 +8,6 @@ platform:
 
 steps:
 - name: build
-  pull: default
   image: rancher/dapper:v0.4.1
   commands:
   - dapper ci
@@ -23,7 +22,6 @@ steps:
     - tag
 
 - name: stage-binaries
-  pull: default
   image: rancher/dapper:v0.4.1
   commands:
   - "cp -r ./bin/* ./package/"
@@ -32,53 +30,54 @@ steps:
     - push
     - tag
 
-- name: docker-publish-master
-  pull: default
+- name: docker-publish-head
   image: plugins/docker
   settings:
     build_args:
     - ARCH=amd64
-    - VERSION=master
+    - "VERSION=${DRONE_BRANCH}"
     - SYSTEM_CHART_DEFAULT_BRANCH=dev
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
+    tag: ${DRONE_BRANCH/\//-}-linux-amd64
     password:
       from_secret: docker_password
     repo: rancher/rancher
-    tag: master-amd64
     username:
       from_secret: docker_username
   when:
-    branch:
-    - master
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/release/v*"
     event:
     - push
 
 - name: docker-publish-master-agent
-  pull: default
   image: plugins/docker
   settings:
     build_args:
     - ARCH=amd64
-    - VERSION=master
+    - "VERSION=${DRONE_BRANCH}"
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
+    tag: ${DRONE_BRANCH/\//-}-linux-amd64
     password:
       from_secret: docker_password
     repo: rancher/rancher-agent
-    tag: master-amd64
     username:
       from_secret: docker_username
   when:
-    branch:
-    - master
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/release/v*"
     event:
     - push
 
 - name: docker-publish
-  pull: default
   image: plugins/docker
   settings:
     build_args:
@@ -90,7 +89,7 @@ steps:
     password:
       from_secret: docker_password
     repo: rancher/rancher
-    tag: "${DRONE_TAG}-amd64"
+    tag: "${DRONE_TAG}-linux-amd64"
     username:
       from_secret: docker_username
   when:
@@ -98,7 +97,6 @@ steps:
     - tag
 
 - name: docker-publish-agent
-  pull: default
   image: plugins/docker
   settings:
     build_args:
@@ -110,7 +108,7 @@ steps:
     password:
       from_secret: docker_password
     repo: rancher/rancher-agent
-    tag: "${DRONE_TAG}-amd64"
+    tag: "${DRONE_TAG}-linux-amd64"
     username:
       from_secret: docker_username
   when:
@@ -118,7 +116,6 @@ steps:
     - tag
 
 - name: github_binary_prerelease
-  pull: default
   image: plugins/github-release
   settings:
     api_key:
@@ -132,12 +129,10 @@ steps:
     event:
     - tag
     ref:
-      include:
-      - "refs/tags/*rc*"
-      - "refs/tags/*alpha*"
+    - "refs/tags/*rc*"
+    - "refs/tags/*alpha*"
 
 - name: github_binary_release
-  pull: default
   image: plugins/github-release
   settings:
     api_key:
@@ -156,20 +151,21 @@ steps:
       - "refs/tags/*rc*"
       - "refs/tags/*alpha*"
 
-- name: chart-publish
-  pull: default
-  image: plugins/gcs
+- name: slack_notify
+  image: plugins/slack
   settings:
-    acl:
-    - allUsers:READER
-    cache_control: "public,no-cache,proxy-revalidate"
-    source: bin/chart
-    target: releases.rancher.com/server-charts
-    token:
-      from_secret: google_auth_key
+    template: "Build {{build.link}} failed to publish an image/artifact.\n"
+    username: Drone_Publish
+    webhook:
+      from_secret: slack_webhook
   when:
     event:
-    - tag
+      exclude:
+      - pull_request
+    instance:
+    - drone-publish.rancher.io
+    status:
+    - failure
 
 volumes:
 - name: docker
@@ -180,9 +176,10 @@ trigger:
   event:
     exclude:
     - promote
+
 ---
 kind: pipeline
-name: default-arm64
+name: default-linux-arm64
 
 platform:
   os: linux
@@ -190,7 +187,6 @@ platform:
 
 steps:
 - name: build
-  pull: default
   image: rancher/dapper:v0.4.1
   commands:
   - dapper ci
@@ -205,7 +201,6 @@ steps:
     - tag
 
 - name: stage-binaries
-  pull: default
   image: rancher/dapper:v0.4.1
   commands:
   - "cp -r ./bin/* ./package/"
@@ -214,53 +209,54 @@ steps:
     - push
     - tag
 
-- name: docker-publish-master
-  pull: default
+- name: docker-publish-head
   image: plugins/docker
   settings:
     build_args:
     - ARCH=arm64
-    - VERSION=master
+    - "VERSION=${DRONE_BRANCH}"
     - SYSTEM_CHART_DEFAULT_BRANCH=dev
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
+    tag: ${DRONE_BRANCH/\//-}-linux-arm64
     password:
       from_secret: docker_password
     repo: rancher/rancher
-    tag: master-arm64
     username:
       from_secret: docker_username
   when:
-    branch:
-    - master
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/release/v*"
     event:
     - push
 
 - name: docker-publish-master-agent
-  pull: default
   image: plugins/docker
   settings:
     build_args:
     - ARCH=arm64
-    - VERSION=master
+    - "VERSION=${DRONE_BRANCH}"
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
+    tag: ${DRONE_BRANCH/\//-}-linux-arm64
     password:
       from_secret: docker_password
     repo: rancher/rancher-agent
-    tag: master-arm64
     username:
       from_secret: docker_username
   when:
-    branch:
-    - master
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/release/v*"
     event:
     - push
 
 - name: docker-publish
-  pull: default
   image: plugins/docker
   settings:
     build_args:
@@ -272,7 +268,7 @@ steps:
     password:
       from_secret: docker_password
     repo: rancher/rancher
-    tag: "${DRONE_TAG}-arm64"
+    tag: "${DRONE_TAG}-linux-arm64"
     username:
       from_secret: docker_username
   when:
@@ -280,7 +276,6 @@ steps:
     - tag
 
 - name: docker-publish-agent
-  pull: default
   image: plugins/docker
   settings:
     build_args:
@@ -292,12 +287,29 @@ steps:
     password:
       from_secret: docker_password
     repo: rancher/rancher-agent
-    tag: "${DRONE_TAG}-arm64"
+    tag: "${DRONE_TAG}-linux-arm64"
     username:
       from_secret: docker_username
   when:
     event:
     - tag
+
+- name: slack_notify
+  image: plugins/slack
+  settings:
+    template: "Build {{build.link}} failed to publish an image/artifact.\n"
+    username: Drone_Publish
+    webhook:
+      from_secret: slack_webhook
+  when:
+    event:
+      exclude:
+      - pull_request
+    instance:
+    - drone-publish.rancher.io
+    status:
+    - failure
+
 volumes:
 - name: docker
   host:
@@ -307,75 +319,123 @@ trigger:
   event:
     exclude:
     - promote
+
 ---
 kind: pipeline
 name: manifest
 
+platform:
+  os: linux
+  arch: amd64
+
 steps:
-  - name: push-master-manifest
-    image: plugins/manifest:1.0.2
-    settings:
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      target: "rancher/rancher:master"
-      template: "rancher/rancher:master-ARCH"
-      platforms:
-        - linux/amd64
-        - linux/arm64
-    when:
-      branch:
-        - master
-      event:
-        - push
-  - name: push-master-agent-manifest
-    image: plugins/manifest:1.0.2
-    settings:
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      target: "rancher/rancher-agent:master"
-      template: "rancher/rancher-agent:master-ARCH"
-      platforms:
-        - linux/amd64
-        - linux/arm64
-    when:
-      branch:
-        - master
-      event:
-        - push
-  - name: push-manifest
-    image: plugins/manifest:1.0.2
-    settings:
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      target: "rancher/rancher:${DRONE_TAG}"
-      template: "rancher/rancher:${DRONE_TAG}-ARCH"
-      platforms:
-        - linux/amd64
-        - linux/arm64
-    when:
-      event:
-        - tag
-  - name: push-agent-manifest
-    image: plugins/manifest:1.0.2
-    settings:
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      target: "rancher/rancher-agent:${DRONE_TAG}"
-      template: "rancher/rancher-agent:${DRONE_TAG}-ARCH"
-      platforms:
-        - linux/amd64
-        - linux/arm64
-    when:
-      event:
-        - tag
+- name: push-head-manifest
+  image: plugins/manifest:1.1.0
+  settings:
+    ignore_missing: true
+    password:
+      from_secret: docker_password
+    spec: manifest.tmpl
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/release/v*"
+    event:
+    - push
+
+- name: push-head-agent-manifest
+  image: plugins/manifest:1.1.0
+  settings:
+    ignore_missing: true
+    password:
+      from_secret: docker_password
+    spec: manifest-agent.tmpl
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/release/v*"
+    event:
+    - push
+
+- name: push-manifest
+  image: plugins/manifest:1.1.0
+  settings:
+    ignore_missing: true
+    password:
+      from_secret: docker_password
+    spec: manifest.tmpl
+    username:
+      from_secret: docker_username
+  when:
+    event:
+    - tag
+
+- name: push-agent-manifest
+  image: plugins/manifest:1.1.0
+  settings:
+    ignore_missing: true
+    password:
+      from_secret: docker_password
+    spec: manifest-agent.tmpl
+    username:
+      from_secret: docker_username
+  when:
+    event:
+    - tag
+
+- name: build-chart
+  image: rancher/dapper:v0.4.1
+  commands:
+  - dapper chart/ci
+  privileged: true
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - push
+    - tag
+
+- name: chart-publish
+  image: plugins/gcs
+  settings:
+    acl:
+    - allUsers:READER
+    cache_control: "public,no-cache,proxy-revalidate"
+    source: bin/chart
+    target: releases.rancher.com/server-charts
+    token:
+      from_secret: google_auth_key
+  when:
+    event:
+    - tag
+
+- name: slack_notify
+  image: plugins/slack
+  settings:
+    template: "Build {{build.link}} failed to push manifests.\n"
+    username: Drone_Publish
+    webhook:
+      from_secret: slack_webhook
+  when:
+    event:
+      exclude:
+      - pull_request
+    instance:
+    - drone-publish.rancher.io
+    status:
+    - failure
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
 
 trigger:
   event:
@@ -383,19 +443,19 @@ trigger:
     - promote
 
 depends_on:
-- default-amd64
-- default-arm64
+- default-linux-amd64
+- default-linux-arm64
+
 ---
 kind: pipeline
 name: publish
 
 platform:
   os: linux
-  arch: amd64 
+  arch: amd64
 
 steps:
 - name: chart-promote
-  pull: default
   image: rancher/dapper:v0.4.1
   commands:
   - dapper chart/copy
@@ -409,7 +469,6 @@ steps:
     - promote-stable
 
 - name: chart-publish
-  pull: default
   image: plugins/gcs
   settings:
     acl:
@@ -420,6 +479,18 @@ steps:
     token:
       from_secret: google_auth_key
 
+- name: slack_notify
+  image: plugins/slack
+  settings:
+    template: "Build {{build.link}} failed to promote chart.\n"
+    username: Drone_Publish
+    webhook:
+      from_secret: slack_webhook
+  when:
+    event:
+      exclude:
+      - pull_request
+
 volumes:
 - name: docker
   host:
@@ -428,4 +499,3 @@ volumes:
 trigger:
   event:
   - promote
-...

--- a/manifest-agent.tmpl
+++ b/manifest-agent.tmpl
@@ -1,0 +1,14 @@
+image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}
+manifests:
+- image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-linux-amd64
+  platform:
+    architecture: amd64
+    os: linux
+- image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-linux-arm64
+  platform:
+    architecture: arm64
+    os: linux
+- image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-linux-arm
+  platform:
+    architecture: arm
+    os: linux

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -1,0 +1,14 @@
+image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}
+manifests:
+- image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-linux-amd64
+  platform:
+    architecture: amd64
+    os: linux
+- image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-linux-arm64
+  platform:
+    architecture: arm64
+    os: linux
+- image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-linux-arm
+  platform:
+    architecture: arm
+    os: linux


### PR DESCRIPTION
This PR extends the functionality used to automatically build docker images when code is pushed to master so that `release/v*` branches also get created.

It also syncs the drone.yaml with the master branch to get changes that have been made there related to tagging conventions and manifests.

`master` builds are tagged `master`. `release/v*` branches have the `/` replaced with a `-` - for example `release-v2.2`

I have verified the following cases:
* We do NOT create docker images or manifests on push to branches that are not `master` or `release/v*`.
* When we tag a branch, it does NOT trigger the `head` steps.
* When we push to `master` or `release/v*` it DOES create and publish a `rancher/rancher` and `rancher/rancher-agent` image and manifest.

What I can't verify:
* Any steps that actually involve doing a release - since I can't replicate everything required to make that happen. These should still work as expected, but some changes have been made to the drone.yml that affects these, to bring this branch in line with master.