### PR TITLE
implements external database configure for helm charts

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -65,6 +65,16 @@ spec:
         # Public trusted CA - clear ca certs
         - "--no-cacerts"
 {{- end }}
+{{- if .Values.database.use }}
+        - "--db-host {{ .Values.database.host }}"
+        - "--db-port {{ .Values.database.port }}"
+        - "--db-user {{ .Values.database.user }}"
+        - "--db-pass {{ .Values.database.password }}"
+        - "--db-name {{ .Values.database.name }}"
+{{- end }}
+{{- if .Values.database.strictEnforcing }}
+        - "--db-strict-enforcing {{ .Values.database.strictEnforcing }}"
+{{- end }}
         - "--http-listen-port=80"
         - "--https-listen-port=443"
         - "--add-local={{ .Values.addLocal }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -37,6 +37,17 @@ debug: false
 # Fully qualified name to reach your Rancher server
 # hostname: rancher.my.org
 
+# Using External Dabatase
+## Ref: https://rancher.com/docs/rancher/v1.6/en/installing-rancher/installing-server/#single-container-external-database
+database:
+  use: false
+  host: "db.example.com"
+  port: "3306"
+  user: "rancher"
+  password: "rancher"
+  name: "cattle"
+  strictEnforcing: false
+
 ## Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []


### PR DESCRIPTION
Hi contributors!

This PR becomes to enable configure external Database value.

Now, Helm charts have not a data's persistent solution.
So, it should use a stateful layer outside.