### PR TITLE
[Windows] Fix removed Windows node to re-add after restarting

### DIFF
--- a/pkg/agent/main_windows.go
+++ b/pkg/agent/main_windows.go
@@ -94,16 +94,12 @@ func getTokenAndURL() (string, string, error) {
 }
 
 func isConnected() bool {
-	_, err := os.Stat("connected")
+	_, err := os.Stat(`C:\etc\rancher\connected`)
 	return err == nil
 }
 
-func resetConnected() {
-	os.RemoveAll("connected")
-}
-
 func connected() {
-	f, _ := os.Create("connected")
+	f, _ := os.Create(`C:\etc\rancher\connected`)
 	defer f.Close()
 }
 
@@ -192,8 +188,6 @@ func (a *agentService) start(selfChangeRequest chan<- svc.ChangeRequest) error {
 }
 
 func doConnect(ctx context.Context, host, token string, headers map[string][]string, onConnect func(ctx context.Context) error, selfChangeRequest chan<- svc.ChangeRequest) {
-	defer resetConnected()
-
 	connectingStatus := make(chan remotedialer.ConnectingStatus)
 	defer close(connectingStatus)
 


### PR DESCRIPTION
**Problem:**
Add back after restarting the removed Windows node

**Solution:**
Return ErrNodeOrClusterNotFound error if could not found the node or cluster

**Issue:**
https://github.com/rancher/rancher/issues/20496

**result:**
- Windows agent will stop itself after removing from UI:
    ![image](https://user-images.githubusercontent.com/3394724/59266663-bd386800-8c7a-11e9-8287-b7f24f9b1ac7.png)
- Restart the removed agent:
    ![image](https://user-images.githubusercontent.com/3394724/59266858-549dbb00-8c7b-11e9-8dc9-cd3efce288d4.png)
