### PR TITLE
Wait for pods to reach desired count after workloads get to active state.

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -218,8 +218,11 @@ def validate_workload(p_client, workload, type, ns_name, pod_count=1,
     # scheduled wait time
     if type == "cronJob":
         time.sleep(wait_for_cron_pods)
+    pods = wait_for_pods_in_workload(p_client, workload, pod_count)
+    assert len(pods) == pod_count
     pods = p_client.list_pod(workloadId=workload.id).data
     assert len(pods) == pod_count
+
     for pod in pods:
         wait_for_pod_to_running(p_client, pod)
     wl_result = execute_kubectl_cmd(
@@ -1173,4 +1176,3 @@ def resolve_node_ip(node):
     else:
         node_ip = node.ipAddress
     return node_ip
-    


### PR DESCRIPTION
@bmdepesa Can you review this PR?

Problem:
This fix is made to address random test case failures when the following validation method fails , since we assume the correct number of pods to be available as soon as the workload gets to active state.  Although this is true most of the time , we have seen random test failures around this check.

Fix:
We are now waiting for the desired number of pods to be made available for a maximum of 2 minutes, before we proceed to asserting the pod check.


```
def validate_workload(p_client, workload, type, ns_name, pod_count=1,
                          wait_for_cron_pods=60):
        workload = wait_for_wl_to_active(p_client, workload)
        assert workload.state == "active"
        # For cronjob, wait for the first pod to get created after
        # scheduled wait time
        if type == "cronJob":
            time.sleep(wait_for_cron_pods)
        pods = p_client.list_pod(workloadId=workload.id).data
>       assert len(pods) == pod_count
E       AssertionError
```