### PR TITLE
Fix the test that can fail due to pending cluster delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,10 @@
 /package/rancher
 /package/agent
 /tests/MANIFEST
+/tests/integration/MANIFEST
 /tests/.cache
 /tests/.tox
+/tests/integration/.tox/
 /tests/.venv
 /tests/.idea
 /default.etcd


### PR DESCRIPTION
Fixing the flaky test that can fail if a cluster delete remains pending, then removal of the cluster_template will error out during teardown of the test.

https://github.com/rancher/rancher/issues/20869 