### PR TITLE
Remove logging of cluster token

### DIFF
--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -204,7 +204,7 @@ func run() error {
 		if !isConnect() {
 			wsURL += "/register"
 		}
-		logrus.Infof("Connecting to %s with token %s", wsURL, token)
+		logrus.Infof("Connecting to %s", wsURL)
 		remotedialer.ClientConnect(wsURL, http.Header(headers), nil, func(proto, address string) bool {
 			switch proto {
 			case "tcp":


### PR DESCRIPTION
The secret token was being logged, since logs can be piped to public storage, we shouldn't log it.