### PR TITLE
Update jailer script

### DIFF
--- a/package/jailer.sh
+++ b/package/jailer.sh
@@ -26,6 +26,7 @@ cp /etc/ssl/certs/ca-certificates.crt /opt/jail/$NAME/etc/ssl/certs
 cp /etc/resolv.conf /opt/jail/$NAME/etc/
 cp /etc/passwd /opt/jail/$NAME/etc/
 cp /etc/hosts /opt/jail/$NAME/etc/
+cp /etc/nsswitch.conf /opt/jail/$NAME/etc/
 
 if [ -d /var/lib/rancher/management-state/bin ] && [ "$(ls -A /var/lib/rancher/management-state/bin)" ]; then
   ( cd /var/lib/rancher/management-state/bin

--- a/package/jailer.sh
+++ b/package/jailer.sh
@@ -21,8 +21,10 @@ mkdir -p /opt/jail/$NAME/tmp
 # Copy over required files to the jail
 cp -r /lib /opt/jail/$NAME
 cp -r /lib64 /opt/jail/$NAME
+cp -r /usr/lib /opt/jail/$NAME/usr
 cp /etc/ssl/certs/ca-certificates.crt /opt/jail/$NAME/etc/ssl/certs
 cp /etc/resolv.conf /opt/jail/$NAME/etc/
+cp /etc/passwd /opt/jail/$NAME/etc/
 cp /etc/hosts /opt/jail/$NAME/etc/
 
 if [ -d /var/lib/rancher/management-state/bin ] && [ "$(ls -A /var/lib/rancher/management-state/bin)" ]; then
@@ -47,8 +49,11 @@ cp -l /usr/bin/helm /opt/jail/$NAME/usr/bin
 # Hard link tiller into the jail 
 cp -l /usr/bin/tiller /opt/jail/$NAME/usr/bin
 
+# Hard link ssh into the jail
+cp -l /usr/bin/ssh /opt/jail/$NAME/usr/bin
+
 cd /dev
 # tar copy /dev excluding mqueue and shm
-tar cf - --exclude=mqueue --exclude=shm . | (cd /opt/jail/${NAME}/dev; tar xfp -)
+tar cf - --exclude=mqueue --exclude=shm --exclude=pts . | (cd /opt/jail/${NAME}/dev; tar xfp -)
 
 touch /opt/jail/$NAME/done


### PR DESCRIPTION
Problem:
ssh is not in the jail causing docker-machine to use the native go ssh package, this causes issues depending on the OS the system is running

Solution:
Pull in ssh and required supporting libs

https://github.com/rancher/rancher/issues/20753
https://github.com/rancher/rancher/issues/20289