### PR TITLE
replace the / in VERSION arg

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -35,7 +35,7 @@ steps:
   settings:
     build_args:
     - ARCH=amd64
-    - "VERSION=${DRONE_BRANCH}"
+    - VERSION=${DRONE_BRANCH/\//-}
     - SYSTEM_CHART_DEFAULT_BRANCH=dev
     context: package/
     custom_dns: 1.1.1.1
@@ -54,12 +54,12 @@ steps:
     event:
     - push
 
-- name: docker-publish-master-agent
+- name: docker-publish-head-agent
   image: plugins/docker
   settings:
     build_args:
     - ARCH=amd64
-    - "VERSION=${DRONE_BRANCH}"
+    - VERSION=${DRONE_BRANCH/\//-}
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -214,7 +214,7 @@ steps:
   settings:
     build_args:
     - ARCH=arm64
-    - "VERSION=${DRONE_BRANCH}"
+    - VERSION=${DRONE_BRANCH/\//-}
     - SYSTEM_CHART_DEFAULT_BRANCH=dev
     context: package/
     custom_dns: 1.1.1.1
@@ -238,7 +238,7 @@ steps:
   settings:
     build_args:
     - ARCH=arm64
-    - "VERSION=${DRONE_BRANCH}"
+    - VERSION=${DRONE_BRANCH/\//-}
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent


### PR DESCRIPTION
This should fix the issue with the rancher-agent docker image using an invalid tag name when using a `release-v*` docker image.