### PR TITLE
strip "release/" and add "-head" suffix

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -35,12 +35,12 @@ steps:
   settings:
     build_args:
     - ARCH=amd64
-    - VERSION=${DRONE_BRANCH/\//-}
+    - VERSION=${DRONE_BRANCH/release\//}-head
     - SYSTEM_CHART_DEFAULT_BRANCH=dev
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
-    tag: ${DRONE_BRANCH/\//-}-linux-amd64
+    tag: ${DRONE_BRANCH/release\//}-head-linux-amd64
     password:
       from_secret: docker_password
     repo: rancher/rancher
@@ -59,11 +59,11 @@ steps:
   settings:
     build_args:
     - ARCH=amd64
-    - VERSION=${DRONE_BRANCH/\//-}
+    - VERSION=${DRONE_BRANCH/release\//}-head
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
-    tag: ${DRONE_BRANCH/\//-}-linux-amd64
+    tag: ${DRONE_BRANCH/release\//}-head-linux-amd64
     password:
       from_secret: docker_password
     repo: rancher/rancher-agent
@@ -82,7 +82,7 @@ steps:
   settings:
     build_args:
     - ARCH=amd64
-    - VERSION=${DRONE_BRANCH/\//-}
+    - VERSION=${DRONE_BRANCH/release\//}-head
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
@@ -214,12 +214,12 @@ steps:
   settings:
     build_args:
     - ARCH=arm64
-    - VERSION=${DRONE_BRANCH/\//-}
+    - VERSION=${DRONE_BRANCH/release\//}-head
     - SYSTEM_CHART_DEFAULT_BRANCH=dev
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
-    tag: ${DRONE_BRANCH/\//-}-linux-arm64
+    tag: ${DRONE_BRANCH/release\//}-head-linux-arm64
     password:
       from_secret: docker_password
     repo: rancher/rancher
@@ -238,11 +238,11 @@ steps:
   settings:
     build_args:
     - ARCH=arm64
-    - VERSION=${DRONE_BRANCH/\//-}
+    - VERSION=${DRONE_BRANCH/release\//}-head
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
-    tag: ${DRONE_BRANCH/\//-}-linux-arm64
+    tag: ${DRONE_BRANCH/release\//}-head-linux-arm64
     password:
       from_secret: docker_password
     repo: rancher/rancher-agent
@@ -358,14 +358,14 @@ steps:
       build_args:
         - SERVERCORE_VERSION=1809
         - ARCH=amd64
-        - VERSION=${DRONE_BRANCH/\//-}
+        - VERSION=${DRONE_BRANCH/release\//}-head
       context: package/windows
       custom_dns: 1.1.1.1
       dockerfile: package/windows/Dockerfile.agent
       password:
         from_secret: docker_password
       repo: rancher/rancher-agent
-      tag: ${DRONE_BRANCH/\//-}-windows-1809
+      tag: ${DRONE_BRANCH/release\//}-head-windows-1809
       username:
         from_secret: docker_username
     volumes:

--- a/manifest-agent.tmpl
+++ b/manifest-agent.tmpl
@@ -1,22 +1,22 @@
-image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}
+image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
 manifests:
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-linux-amd64
+    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-linux-arm64
+    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm64
     platform:
       architecture: arm64
       os: linux
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-linux-arm
+    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm
     platform:
       architecture: arm
       os: linux
   -
-    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-windows-1809
+    image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-1809
     platform:
       architecture: amd64
       os: windows

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -1,22 +1,22 @@
-image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}
+image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
 manifests:
   -
-    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-linux-amd64
+    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-linux-arm64
+    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm64
     platform:
       architecture: arm64
       os: linux
   -
-    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-linux-arm
+    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm
     platform:
       architecture: arm
       os: linux
   -
-    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "/" "-" build.branch }}{{/if}}-windows-1809
+    image: rancher/rancher:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-1809
     platform:
       architecture: amd64
       os: windows


### PR DESCRIPTION
After this, tags in the docker hub will be formatted as `master-head` and `v2.2-head`