### PR TITLE
[Monitoring] Allow users to configure DNS monitoring

### DIFF
--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -281,13 +281,11 @@ func (ch *clusterHandler) deployApp(appName, appTargetNamespace string, appProje
 	mustAppAnswers := map[string]string{
 		"enabled": "false",
 
-		"exporter-coredns.enabled":  "false",
 		"exporter-coredns.apiGroup": monitoring.APIVersion.Group,
 
 		"exporter-kube-controller-manager.enabled":  "false",
 		"exporter-kube-controller-manager.apiGroup": monitoring.APIVersion.Group,
 
-		"exporter-kube-dns.enabled":  "false",
 		"exporter-kube-dns.apiGroup": monitoring.APIVersion.Group,
 
 		"exporter-kube-etcd.enabled":  "false",


### PR DESCRIPTION
**Problem:**
Doesn't allow user to configure DNS monitoring

**Solution:**
Remove `false` configuration item from mandatory option:
- if interested in kube-dns metrics (v1.12)
    + configuring `exporter-kube-dns.enabled` item as `true` when
    enabling cluster-level monitoring
    + guaranteeing the DNS service of `kube-system` namespace has:
        - `k8s-app=kube-dns` label
        - `dnsmasq-metrics` port with `TCP:10054`
        - `skydns-metrics` port with `TCP:10055`
- if interested in coredns metrics (v1.14)
    + configuring `exporter-coredns.enabled` item as `true` when enabling
    cluster-level monitoring
    + guaranteeing the DNS service of `kube-system` namespace has:
        - `k8s-app=kube-dns` label
        - `metrics` port with `TCP:9153`

**Issue:**
https://github.com/rancher/rancher/issues/21066