### PR TITLE
Fix CRD store panic

### DIFF
--- a/pkg/controllers/user/controllers.go
+++ b/pkg/controllers/user/controllers.go
@@ -72,7 +72,7 @@ func Register(ctx context.Context, cluster *config.UserContext, clusterRec *mana
 	istio.Register(ctx, cluster)
 	certsexpiration.Register(ctx, cluster)
 
-	if clusterRec.Spec.LocalClusterAuthEndpoint.Enabled {
+	if clusterRec.Spec.LocalClusterAuthEndpoint.Enabled && managementv3.ClusterConditionReady.IsTrue(clusterRec) {
 		err := clusterauthtoken.CRDSetup(ctx, cluster.UserOnlyContext())
 		if err != nil {
 			return err


### PR DESCRIPTION
In case of k8s v1.14 user cluster becoming unavailable, and rancher server is restarted, rancher will panic:
```
panic: creating CRD store Get https://x.x.x.x:6443/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions?timeout=30s: context deadline exceeded (Client.Timeout exceeded while awaiting headers)

goroutine 11794 [running]:
github.com/rancher/rancher/vendor/github.com/rancher/norman/store/crd.(*Factory).BatchCreateCRDs.func1(0xc007bcbf00, 0xc007bcbf20, 0x2, 0x2, 0xc00b99c8c0, 0x74d01c0, 0x4892180, 0xc00c083c40, 0x3e787fc, 0x4)
        /go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/store/crd/init.go:65 +0x2c2
created by github.com/rancher/rancher/vendor/github.com/rancher/norman/store/crd.(*Factory).BatchCreateCRDs
        /go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/store/crd/init.go:50 +0xce
```