### PR TITLE
Disable operator when enable alert

### DIFF
--- a/pkg/controllers/user/alert/deployer/deployer.go
+++ b/pkg/controllers/user/alert/deployer/deployer.go
@@ -340,6 +340,7 @@ func (d *appDeployer) deploy(appName, appTargetNamespace, systemProjectID string
 				"alertmanager.apiGroup":               monitorutil.APIVersion.Group,
 				"alertmanager.enabledRBAC":            "false",
 				"alertmanager.configFromSecret":       secret.Name,
+				"operator.enabled":                    "false",
 			},
 			Description:     "Alertmanager for Rancher Monitoring",
 			ExternalID:      catalogID,

--- a/pkg/controllers/user/alert/deployer/upgradeimpl.go
+++ b/pkg/controllers/user/alert/deployer/upgradeimpl.go
@@ -89,9 +89,6 @@ func (l *alertService) Upgrade(currentVersion string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if currentVersion == NewVersion {
-		return currentVersion, nil
-	}
 
 	appName, _ := monitorutil.ClusterAlertManagerInfo()
 	//migrate legacy
@@ -132,6 +129,7 @@ func (l *alertService) Upgrade(currentVersion string) (string, error) {
 	}
 	newApp := app.DeepCopy()
 	newApp.Spec.ExternalID = newCatalogID
+	newApp.Spec.Answers["operator.enabled"] = "false"
 
 	if !reflect.DeepEqual(newApp, app) {
 		if _, err = l.apps.Update(newApp); err != nil {


### PR DESCRIPTION
Problem:
System chart have bug that enable alertmanager will also deploy operator if not set false to enable operator

Solution:
Set enable operator to false, system charts bug will be fixed later

Issue:
https://github.com/rancher/rancher/issues/20975