### PR TITLE
Configure HandshakeTimeout in websocket.Dialer

### DIFF
--- a/pkg/agent/windows/remotedialer/client_windows.go
+++ b/pkg/agent/windows/remotedialer/client_windows.go
@@ -45,7 +45,7 @@ func ClientConnectWhileWindows(ctx context.Context, wsURL string, headers http.H
 
 func connectToProxyWhileWindows(rootContext context.Context, proxyURL string, headers http.Header, auth remotedialer.ConnectAuthorizer, dialer *websocket.Dialer, blockingOnConnect func(context.Context) error) error {
 	if dialer == nil {
-		dialer = &websocket.Dialer{}
+		dialer = &websocket.Dialer{HandshakeTimeout: 10 * time.Second}
 	}
 
 	eg, ctx := errgroup.WithContext(rootContext)


### PR DESCRIPTION
To prevent agent from being hung in the middle of Websocket Session
Handshake, We'd better to set HandshakeTimeout

Related to https://github.com/rancher/rancher/issues/21117