### PR TITLE
Remove version compare when upgrade alerting

### DIFF
--- a/pkg/controllers/user/alert/deployer/upgradeimpl.go
+++ b/pkg/controllers/user/alert/deployer/upgradeimpl.go
@@ -89,9 +89,6 @@ func (l *alertService) Upgrade(currentVersion string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if currentVersion == NewVersion {
-		return currentVersion, nil
-	}
 
 	appName, _ := monitorutil.ClusterAlertManagerInfo()
 	//migrate legacy


### PR DESCRIPTION
Problem:
Rancher 2.2.4 and 2.2.5 use monitoring chart 0.0.3, version check will
prevent app upgrade when version not change but we still want to update
the app

Solution:
Remove version check when upgrade alertmanager

Issue:
https://github.com/rancher/rancher/issues/21113