### PR TITLE
[WIP]Don't use timestamp in monitoring app

### DIFF
--- a/pkg/controllers/user/cis/clusterScanHandler.go
+++ b/pkg/controllers/user/cis/clusterScanHandler.go
@@ -157,7 +157,7 @@ func (csh *cisScanHandler) deployApp(clusterName, appName string) error {
 		},
 	}
 
-	_, err = utils.DeployApp(csh.mgmtCtxAppClient, appDeployProjectID, app, false)
+	_, err = utils.DeployApp(csh.mgmtCtxAppClient, appDeployProjectID, app)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -390,7 +390,7 @@ func (ch *clusterHandler) deployApp(appName, appTargetNamespace string, appProje
 		},
 	}
 
-	_, err = utils.DeployApp(ch.app.cattleAppClient, appDeployProjectID, app, false)
+	_, err = utils.DeployApp(ch.app.cattleAppClient, appDeployProjectID, app)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/user/monitoring/operatorHandler.go
+++ b/pkg/controllers/user/monitoring/operatorHandler.go
@@ -1,7 +1,6 @@
 package monitoring
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 
@@ -13,7 +12,6 @@ import (
 	mgmtv3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	projectv3 "github.com/rancher/types/apis/project.cattle.io/v3"
 	"github.com/sirupsen/logrus"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -213,17 +211,7 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) (backErr erro
 		},
 	}
 
-	// redeploy operator App forcibly if cannot find the workload
-	var forceRedeploy bool
-	appWorkload, err := app.agentDeploymentClient.GetNamespaced(appTargetNamespace, fmt.Sprintf("prometheus-operator-%s", appName), metav1.GetOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return errors.Wrapf(err, "failed to get deployment %s/prometheus-operator-%s", appTargetNamespace, appName)
-	}
-	if appWorkload == nil || appWorkload.Name == "" || appWorkload.DeletionTimestamp != nil {
-		forceRedeploy = true
-	}
-
-	_, err = utils.DeployApp(app.cattleAppClient, appDeployProjectID, targetApp, forceRedeploy)
+	_, err = utils.DeployApp(app.cattleAppClient, appDeployProjectID, targetApp)
 	if err != nil {
 		return errors.Wrap(err, "failed to ensure prometheus operator app")
 	}

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -226,7 +226,7 @@ func (ph *projectHandler) deployApp(appName, appTargetNamespace string, appProje
 		},
 	}
 
-	deployed, err := utils.DeployApp(ph.app.cattleAppClient, appDeployProjectID, app, false)
+	deployed, err := utils.DeployApp(ph.app.cattleAppClient, appDeployProjectID, app)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Problem:**
The monitoring app helper updates app with newest timestamp in answers
cause the app revision grows every sync of cluster.

**Solution:**
Remove the timestamp in monitoring app answers.