### PR TITLE
[WIP]Don't use timestamp in monitoring app

### DIFF
--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -391,7 +391,7 @@ func (ch *clusterHandler) deployApp(appName, appTargetNamespace string, appProje
 		},
 	}
 
-	_, err = monitoring.DeployApp(ch.app.cattleAppClient, appDeployProjectID, app, false)
+	_, err = monitoring.DeployApp(ch.app.cattleAppClient, appDeployProjectID, app)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/user/monitoring/operatorHandler.go
+++ b/pkg/controllers/user/monitoring/operatorHandler.go
@@ -1,7 +1,6 @@
 package monitoring
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 
@@ -11,7 +10,6 @@ import (
 	mgmtv3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	projectv3 "github.com/rancher/types/apis/project.cattle.io/v3"
 	"github.com/sirupsen/logrus"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -211,17 +209,7 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) (backErr erro
 		},
 	}
 
-	// redeploy operator App forcibly if cannot find the workload
-	var forceRedeploy bool
-	appWorkload, err := app.agentDeploymentClient.GetNamespaced(appTargetNamespace, fmt.Sprintf("prometheus-operator-%s", appName), metav1.GetOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return errors.Wrapf(err, "failed to get deployment %s/prometheus-operator-%s", appTargetNamespace, appName)
-	}
-	if appWorkload == nil || appWorkload.Name == "" || appWorkload.DeletionTimestamp != nil {
-		forceRedeploy = true
-	}
-
-	_, err = monitoring.DeployApp(app.cattleAppClient, appDeployProjectID, targetApp, forceRedeploy)
+	_, err = monitoring.DeployApp(app.cattleAppClient, appDeployProjectID, targetApp)
 	if err != nil {
 		return errors.Wrap(err, "failed to ensure prometheus operator app")
 	}

--- a/pkg/controllers/user/monitoring/project_handler.go
+++ b/pkg/controllers/user/monitoring/project_handler.go
@@ -236,7 +236,7 @@ func (ph *projectHandler) deployApp(appName, appTargetNamespace string, appProje
 		},
 	}
 
-	deployed, err := monitoring.DeployApp(ph.app.cattleAppClient, appDeployProjectID, app, false)
+	deployed, err := monitoring.DeployApp(ph.app.cattleAppClient, appDeployProjectID, app)
 	if err != nil {
 		return err
 	}

--- a/pkg/monitoring/deploy.go
+++ b/pkg/monitoring/deploy.go
@@ -2,7 +2,7 @@ package monitoring
 
 import (
 	"fmt"
-	"time"
+	"reflect"
 
 	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/controllers/user/nslabels"
@@ -84,7 +84,7 @@ func GetSystemProjectID(cattleProjectsClient mgmtv3.ProjectInterface) (string, e
 	return systemProject.Name, nil
 }
 
-func DeployApp(cattleAppClient projectv3.AppInterface, projectID string, createOrUpdateApp *projectv3.App, forceRedeploy bool) (*projectv3.App, error) {
+func DeployApp(cattleAppClient projectv3.AppInterface, projectID string, createOrUpdateApp *projectv3.App) (*projectv3.App, error) {
 	if createOrUpdateApp == nil {
 		return nil, errors.New("cannot deploy a nil App")
 	}
@@ -105,16 +105,11 @@ func DeployApp(cattleAppClient projectv3.AppInterface, projectID string, createO
 			return rtn, errors.Wrapf(err, "failed to create %q App", appName)
 		}
 	} else {
+		if reflect.DeepEqual(createOrUpdateApp.Spec.Answers, app.Spec.Answers) && reflect.DeepEqual(createOrUpdateApp.Spec.ValuesYaml, app.Spec.ValuesYaml) {
+			return app, nil
+		}
 		app = app.DeepCopy()
 		app.Spec.Answers = createOrUpdateApp.Spec.Answers
-
-		// clean up status
-		if forceRedeploy {
-			if app.Spec.Answers == nil {
-				app.Spec.Answers = make(map[string]string, 1)
-			}
-			app.Spec.Answers["redeployTs"] = fmt.Sprintf("%d", time.Now().Unix())
-		}
 
 		if rtn, err = cattleAppClient.Update(app); err != nil {
 			return nil, errors.Wrapf(err, "failed to update %q App", appName)


### PR DESCRIPTION
**Problem:**
The monitoring app helper updates app with newest timestamp in answers
cause the app revision grows every sync of cluster.

**Solution:**
Remove the timestamp in monitoring app answers.