### PR TITLE
Package catalog into build

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -27,6 +27,12 @@ ENV TELEMETRY_VERSION v0.5.6
 ENV DOCKER_MACHINE_LINODE_VERSION v0.1.8
 ENV LINODE_UI_DRIVER_VERSION v0.3.0
 
+RUN mkdir -p /var/lib/rancher/management-state/local-catalogs/system-library && \
+    mkdir -p /var/lib/rancher/management-state/local-catalogs/library && \
+    git clone -b $CATTLE_SYSTEM_CHART_DEFAULT_BRANCH --single-branch https://github.com/rancher/system-charts /var/lib/rancher/management-state/local-catalogs/system-library && \
+    git clone -b master --single-branch https://github.com/rancher/charts /var/lib/rancher/management-state/local-catalogs/library
+
+
 RUN curl -sLf https://github.com/rancher/machine-package/releases/download/${CATTLE_MACHINE_VERSION}/docker-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin && \
     curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin && \
     curl -LO https://github.com/linode/docker-machine-driver-linode/releases/download/${DOCKER_MACHINE_LINODE_VERSION}/docker-machine-driver-linode_linux-amd64.zip && \

--- a/pkg/catalog/helm/helm.go
+++ b/pkg/catalog/helm/helm.go
@@ -37,10 +37,11 @@ var (
 	httpClient  = &http.Client{
 		Timeout: httpTimeout,
 	}
-	uuid         = settings.InstallUUID.Get()
-	Locker       = locker.New()
-	CatalogCache = filepath.Join("management-state", "catalog-cache")
-	IconCache    = filepath.Join(CatalogCache, ".icon-cache")
+	uuid            = settings.InstallUUID.Get()
+	Locker          = locker.New()
+	CatalogCache    = filepath.Join("management-state", "catalog-cache")
+	IconCache       = filepath.Join(CatalogCache, ".icon-cache")
+	InternalCatalog = filepath.Join("management-state", "local-catalogs")
 )
 
 type Helm struct {

--- a/pkg/catalog/manager/catalog_sync.go
+++ b/pkg/catalog/manager/catalog_sync.go
@@ -26,6 +26,17 @@ func (m *Manager) Sync(key string, obj *v3.Catalog) (runtime.Object, error) {
 		return nil, err
 	}
 
+	// When setting SystemCatalog is set to bundled, always force our catalogs to keep running that way
+	if m.bundledMode {
+		if (catalog.Name == "library" || catalog.Name == "system-library") && catalog.Spec.CatalogKind != helmlib.KindHelmInternal {
+			catalog.Spec.CatalogKind = helmlib.KindHelmInternal
+			catalog, err = m.catalogClient.Update(catalog)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	commit, helm, err := helmlib.NewForceUpdate(catalog)
 	if err != nil {
 		return m.updateCatalogError(catalog, err)

--- a/pkg/catalog/manager/manager.go
+++ b/pkg/catalog/manager/manager.go
@@ -2,11 +2,13 @@ package manager
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	helmlib "github.com/rancher/rancher/pkg/catalog/helm"
 	"github.com/rancher/rancher/pkg/controllers/user/helm/common"
 	"github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/settings"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	projectv3 "github.com/rancher/types/apis/project.cattle.io/v3"
 	"github.com/rancher/types/config"
@@ -29,9 +31,14 @@ type Manager struct {
 	ClusterCatalogLister  v3.ClusterCatalogLister
 	appRevisionClient     projectv3.AppRevisionInterface
 	lastUpdateTime        time.Time
+	bundledMode           bool
 }
 
 func New(management *config.ManagementContext) *Manager {
+	var bundledMode bool
+	if strings.ToLower(settings.SystemCatalog.Get()) == "bundled" {
+		bundledMode = true
+	}
 	return &Manager{
 		catalogClient:         management.Management.Catalogs(""),
 		CatalogLister:         management.Management.Catalogs("").Controller().Lister(),
@@ -45,6 +52,7 @@ func New(management *config.ManagementContext) *Manager {
 		clusterCatalogClient:  management.Management.ClusterCatalogs(""),
 		ClusterCatalogLister:  management.Management.ClusterCatalogs("").Controller().Lister(),
 		appRevisionClient:     management.Project.AppRevisions(""),
+		bundledMode:           bundledMode,
 	}
 }
 

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -67,6 +67,7 @@ var (
 	RotateCertsIfExpiringInDays       = NewSetting("rotate-certs-if-expiring-in-days", "7")  // 7 days
 	ClusterTemplateEnforcement        = NewSetting("cluster-template-enforcement", "false")
 	InitialDockerRootDir              = NewSetting("initial-docker-root-dir", "/var/lib/docker")
+	SystemCatalog                     = NewSetting("system-catalog", "external") // Options are 'external' or 'bundled'
 )
 
 func init() {


### PR DESCRIPTION
This adds a new setting `system-catalog` which changes the source of the catalogs. The two options are `bundled` and `external` with a default of `external`. If set to `bundled` the two rancher catalogs will only use the bundled version of the catalog from the build and will not attempt to fetch from the internet. If set to `bundled` the normal catalog will be disable by default but can be turned back on. This is to stop people from trying to install apps when the image may not be available to install. 

In order to update a catalog a new one could be copied in (not ideal) or the version of rancher updated in which case a new version could potentially be in the build. 

Issue: https://github.com/rancher/rancher/issues/20387