### PR TITLE
Forbid readonly clustertemplate members from creating revisions

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -723,11 +723,7 @@ func ClusterTemplates(schemas *types.Schemas, management *config.ScaledContext) 
 		Store:              schema.Store,
 		NamespaceInterface: management.Core.Namespaces(""),
 	}
-	users := management.Management.Users("")
-	grbLister := management.Management.GlobalRoleBindings("").Controller().Lister()
-	grLister := management.Management.GlobalRoles("").Controller().Lister()
-
-	schema.Store = clustertemplatestore.WrapStore(schema.Store, users, grbLister, grLister)
+	schema.Store = clustertemplatestore.WrapStore(schema.Store, management)
 
 	schema.Formatter = wrapper.Formatter
 	schema.LinkHandler = wrapper.LinkHandler
@@ -737,7 +733,7 @@ func ClusterTemplates(schemas *types.Schemas, management *config.ScaledContext) 
 		Store:              revisionSchema.Store,
 		NamespaceInterface: management.Core.Namespaces(""),
 	}
-	revisionSchema.Store = clustertemplatestore.WrapStore(revisionSchema.Store, users, grbLister, grLister)
+	revisionSchema.Store = clustertemplatestore.WrapStore(revisionSchema.Store, management)
 	revisionSchema.CollectionFormatter = wrapper.CollectionFormatter
 	revisionSchema.ActionHandler = wrapper.ClusterTemplateRevisionsActionHandler
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/21164

Read-only members of a clusterTemplate should not be able to create revisions for it.
This is because there's a chance such a revision could get set as the default revision on clusterTemplate, thus updating it, which a read-only member should not be allowed to.