### PR TITLE
sync metadata setting after ns gets created

### DIFF
--- a/app/global_namespace.go
+++ b/app/global_namespace.go
@@ -27,5 +27,8 @@ func addCattleGlobalNamespace(management *config.ManagementContext) error {
 		return fmt.Errorf("Error creating %v namespace: %v", namespace.GlobalNamespace, err)
 	}
 
+	logrus.Debugf("calling sync for driver metadata")
+	management.Management.Settings("").Controller().Enqueue("", "rke-metadata-url")
+
 	return nil
 }

--- a/pkg/controllers/management/kontainerdrivermetadata/metadata_handler.go
+++ b/pkg/controllers/management/kontainerdrivermetadata/metadata_handler.go
@@ -82,6 +82,7 @@ func (m *MetadataController) sync(key string, test *v3.Setting) (runtime.Object,
 		return nil, fmt.Errorf("driverMetadata error getting interval in int %s %v", settings.RkeMetadataRefreshIntervalMins.Get(), err)
 	}
 	if tickerData != nil {
+		m.refresh(url, false)
 		if tickerData.url != url || tickerData.interval != interval {
 			tickerData.cancelFunc()
 
@@ -111,10 +112,6 @@ func (m *MetadataController) initTicker(ctx context.Context) {
 
 func (m *MetadataController) startTicker(ctx context.Context, tickerData *TickerData, init bool) {
 	checkInterval, url := tickerData.interval, tickerData.url
-	// run once, then start ticker if setting values change if not init
-	if !init {
-		m.refresh(url, false)
-	}
 	for range ticker.Context(ctx, checkInterval) {
 		logrus.Infof("driverMetadata: checking rke-metadata-url every %v", checkInterval)
 		m.refresh(url, false)


### PR DESCRIPTION
If global namespace isn't found, we miss the init logic and then have to wait for refresh interval to take place