### PR TITLE
changing the default system charts branch to dev

### DIFF
--- a/app/catalog_data.go
+++ b/app/catalog_data.go
@@ -21,7 +21,7 @@ const (
 	libraryName   = "library"
 
 	systemLibraryURL    = "https://git.rancher.io/system-charts"
-	systemLibraryBranch = "master"
+	systemLibraryBranch = "dev"
 	systemLibraryName   = "system-library"
 	defSystemChartVer   = "management.cattle.io/default-system-chart-version"
 )


### PR DESCRIPTION
Addresses: https://github.com/rancher/rancher/issues/21315
Problem: In a development environment, the system-charts repo is pointing incorrectly to `master` branch.
Fix: Change to `dev`