### PR TITLE
Check dev mode for system charts

### DIFF
--- a/app/catalog_data.go
+++ b/app/catalog_data.go
@@ -120,7 +120,10 @@ func syncCatalogs(management *config.ManagementContext) error {
 				return err
 			}
 			desiredDefaultURL := systemLibraryURL
-			desiredDefaultBranch := systemLibraryBranch
+			desiredDefaultBranch := ""
+			if devMode := os.Getenv("CATTLE_DEV_MODE"); devMode != "" {
+				desiredDefaultBranch = "dev"
+			}
 
 			if fromEnvURL := os.Getenv("CATTLE_SYSTEM_CHART_DEFAULT_URL"); fromEnvURL != "" {
 				desiredDefaultURL = fromEnvURL
@@ -128,6 +131,11 @@ func syncCatalogs(management *config.ManagementContext) error {
 
 			if fromEnvBranch := os.Getenv("CATTLE_SYSTEM_CHART_DEFAULT_BRANCH"); fromEnvBranch != "" {
 				desiredDefaultBranch = fromEnvBranch
+			}
+
+			if desiredDefaultBranch == "" {
+				panic(fmt.Errorf("If you are developing, set CATTLE_DEV_MODE environment variable to \"true\"." +
+					"Otherwise, set CATTLE_SYSTEM_CHART_DEFAULT_to desired default branch."))
 			}
 
 			return updateCatalogURL(management.Management.Catalogs(""), desiredDefaultURL, desiredDefaultBranch)


### PR DESCRIPTION
Problem:
users in dev mode were on the master system charts branch. If env
variable was forgotten, it would not have been immediately
apparent.

Solution:
Now, if in dev mode system charts default branch is set to dev.
If not in dev mode and no branch has been set to CATTLE_
_SYSTEM_CHART_DEFAULT_BRANCH, rancher will panic.
