### PR TITLE
Fix dns auto generate issue

### DIFF
--- a/pkg/controllers/user/controllers.go
+++ b/pkg/controllers/user/controllers.go
@@ -73,6 +73,7 @@ func Register(ctx context.Context, cluster *config.UserContext, clusterRec *mana
 	monitoring.Register(ctx, cluster)
 	istio.Register(ctx, cluster)
 	certsexpiration.Register(ctx, cluster)
+	ingresshostgen.Register(ctx, cluster.UserOnlyContext())
 
 	if clusterRec.Spec.LocalClusterAuthEndpoint.Enabled {
 		err := clusterauthtoken.CRDSetup(ctx, cluster.UserOnlyContext())
@@ -109,7 +110,6 @@ func RegisterUserOnly(ctx context.Context, cluster *config.UserOnlyContext) erro
 	dnsrecord.Register(ctx, cluster)
 	externalservice.Register(ctx, cluster)
 	ingress.Register(ctx, cluster)
-	ingresshostgen.Register(ctx, cluster)
 	nslabels.Register(ctx, cluster)
 	targetworkloadservice.Register(ctx, cluster)
 	workload.Register(ctx, cluster)


### PR DESCRIPTION
**Problem:**
No effect when `xip.io` suffix is changed to other suffix.

**Solution:**
The ingresshostgen controller is using the `IngressIPDomain` setting.
So the controller should run in Rancher side.

**Issue:**

https://github.com/rancher/rancher/issues/19915