### PR TITLE
ARGO-2037: Add namespace templates so that rancher's helm deploys out of spinnaker.

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -2,6 +2,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ template "rancher.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rancher.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "rancher.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rancher.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/chart/templates/issuer-letsEncrypt.yaml
+++ b/chart/templates/issuer-letsEncrypt.yaml
@@ -4,6 +4,7 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Issuer
 metadata:
   name: {{ template "rancher.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rancher.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/chart/templates/issuer-rancher.yaml
+++ b/chart/templates/issuer-rancher.yaml
@@ -4,6 +4,7 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Issuer
 metadata:
   name: {{ template "rancher.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rancher.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "rancher.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rancher.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/chart/templates/serviceAccount.yaml
+++ b/chart/templates/serviceAccount.yaml
@@ -2,6 +2,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ template "rancher.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rancher.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}


### PR DESCRIPTION
ATM spinnaker can't deploy rancher via rancher's helm chart in anything but the spinnaker's default namespace because rancher's helm chart does not consistently conform to the requirements of namespace lines.
In fact the namespace lines are applied inconsistently leading to the deployment of rancher (via helm, in spinnaker) being non-viable.
This PR fixes this.
Here is the spinnaker docs regarding this: https://www.spinnaker.io/guides/user/kubernetes-v2/deploy-helm/#configure-the-bake-manifest-stage