### PR TITLE
Add cloudscale.ch driver.

### DIFF
--- a/app/machinedriver_data.go
+++ b/app/machinedriver_data.go
@@ -51,6 +51,11 @@ func addMachineDrivers(management *config.ManagementContext) error {
 		[]string{"objects-east.cloud.ca"}, false, false, management); err != nil {
 		return err
 	}
+	if err := addMachineDriver("cloudscale", "https://github.com/cloudscale-ch/docker-machine-driver-cloudscale/releases/download/v1.0.0/docker-machine-driver-cloudscale_v1.0.0_linux_amd64.tar.gz",
+		"https://objects.cloudscale.ch/cloudscale-rancher-v2-ui-driver/component.js", "73eb95d58706b53076baf9baef8df720b97c06f7140f607fba6a65d0735a179c",
+		[]string{"objects.cloudscale.ch"}, false, false, management); err != nil {
+		return err
+	}
 	if err := addMachineDriver(nodetemplate.DigitalOceandriver, "local://", "", "", []string{"api.digitalocean.com"}, true, true, management); err != nil {
 		return err
 	}


### PR DESCRIPTION
This adds the [cloudscale.ch](https://www.cloudscale.ch/en/) machine and ui-driver to the list of drivers available for installation with rancher.

Our drivers are maintained at:
 * https://github.com/cloudscale-ch/ui-driver-cloudscale
 * https://github.com/cloudscale-ch/docker-machine-driver-cloudscale

![Screenshot](https://raw.githubusercontent.com/cloudscale-ch/ui-driver-cloudscale/master/docs/configuration-screen.png)