### PR TITLE
Pipeline components upgrade

### DIFF
--- a/pkg/controllers/user/pipeline/controller/pipelineexecution/deploy.go
+++ b/pkg/controllers/user/pipeline/controller/pipelineexecution/deploy.go
@@ -471,7 +471,7 @@ func GetJenkinsDeployment(ns string) *appsv1beta2.Deployment {
 										}},
 								}, {
 									Name:  "JAVA_OPTS",
-									Value: "-Xmx300m -Dhudson.slaves.NodeProvisioner.initialDelay=0 -Dhudson.slaves.NodeProvisioner.MARGIN=50 -Dhudson.slaves.NodeProvisioner.MARGIN0=0.85 -Dhudson.model.LoadStatistics.clock=2000 -Dhudson.slaves.NodeProvisioner.recurrencePeriod=2000",
+									Value: "-Xmx300m -Dhudson.slaves.NodeProvisioner.initialDelay=0 -Dhudson.slaves.NodeProvisioner.MARGIN=50 -Dhudson.slaves.NodeProvisioner.MARGIN0=0.85 -Dhudson.model.LoadStatistics.clock=2000 -Dhudson.slaves.NodeProvisioner.recurrencePeriod=2000 -Dhudson.model.UpdateCenter.never=true",
 								}, {
 									Name:  "NAMESPACE",
 									Value: ns,

--- a/pkg/pipeline/engine/jenkins/engine.go
+++ b/pkg/pipeline/engine/jenkins/engine.go
@@ -365,7 +365,7 @@ func (j *Engine) SyncExecution(execution *v3.PipelineExecution) (bool, error) {
 				if err := j.successStep(execution, stage, step, jenkinsStage); err != nil {
 					return false, err
 				}
-			} else if status == "FAILED" && execution.Status.Stages[stage].Steps[step].State != utils.StateFailed {
+			} else if (status == "FAILED" || status == "ABORTED") && execution.Status.Stages[stage].Steps[step].State != utils.StateFailed {
 				updated = true
 				if err := j.failStep(execution, stage, step, jenkinsStage); err != nil {
 					return false, err


### PR DESCRIPTION
Related issues:
https://github.com/rancher/rancher/issues/19322
https://github.com/rancher/rancher/issues/18526

1. Adapt to newer Jenkins 2.164
    - Sync timeout steps in ABORTED status
    - Add hudson.model.UpdateCenter.never=true option
2. Implement pipeline components upgrade

Depend on:
types PR: https://github.com/rancher/types/pull/897
newer Jenkins image release: https://github.com/rancher/pipeline-jenkins-server/pull/3