### PR TITLE
fix upgrade system image failed when manage multiple clusters

### DIFF
--- a/pkg/controllers/user/controllers.go
+++ b/pkg/controllers/user/controllers.go
@@ -41,11 +41,6 @@ import (
 	projectclient "github.com/rancher/types/client/project/v3"
 	"github.com/rancher/types/config"
 	"github.com/rancher/types/factory"
-
-	// init upgrade implement
-	_ "github.com/rancher/rancher/pkg/controllers/user/alert/deployer"
-	_ "github.com/rancher/rancher/pkg/controllers/user/logging/deployer"
-	_ "github.com/rancher/rancher/pkg/controllers/user/pipeline/upgrade"
 )
 
 func Register(ctx context.Context, cluster *config.UserContext, clusterRec *managementv3.Cluster, kubeConfigGetter common.KubeConfigGetter, clusterManager healthsyncer.ClusterControllerLifecycle) error {

--- a/pkg/controllers/user/logging/deployer/upgradeimpl.go
+++ b/pkg/controllers/user/logging/deployer/upgradeimpl.go
@@ -1,14 +1,13 @@
 package deployer
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/rancher/rancher/pkg/controllers/user/helm/common"
 	loggingconfig "github.com/rancher/rancher/pkg/controllers/user/logging/config"
-	"github.com/rancher/rancher/pkg/controllers/user/systemimage"
 	"github.com/rancher/rancher/pkg/project"
 	"github.com/rancher/rancher/pkg/settings"
 	appsv1beta2 "github.com/rancher/types/apis/apps/v1beta2"
@@ -24,12 +23,14 @@ import (
 )
 
 var (
-	serviceName = "logging"
+	ServiceName             = "logging"
+	waitCatalogSyncInterval = 60 * time.Second
 )
 
-type loggingService struct {
+type LoggingService struct {
 	clusterName    string
 	clusterLister  v3.ClusterLister
+	catalogLister  v3.CatalogLister
 	projectLister  v3.ProjectLister
 	templateLister v3.CatalogTemplateLister
 	daemonsets     appsv1beta2.DaemonSetInterface
@@ -37,11 +38,11 @@ type loggingService struct {
 	appDeployer    *AppDeployer
 }
 
-func init() {
-	systemimage.RegisterSystemService(serviceName, &loggingService{})
+func NewService() *LoggingService {
+	return &LoggingService{}
 }
 
-func (l *loggingService) Init(ctx context.Context, cluster *config.UserContext) {
+func (l *LoggingService) Init(cluster *config.UserContext) {
 	ad := &AppDeployer{
 		AppsGetter: cluster.Management.Project,
 		Namespaces: cluster.Core.Namespaces(metav1.NamespaceAll),
@@ -49,14 +50,15 @@ func (l *loggingService) Init(ctx context.Context, cluster *config.UserContext) 
 
 	l.clusterName = cluster.ClusterName
 	l.clusterLister = cluster.Management.Management.Clusters("").Controller().Lister()
-	l.projectLister = cluster.Management.Management.Projects(metav1.NamespaceAll).Controller().Lister()
+	l.catalogLister = cluster.Management.Management.Catalogs(metav1.NamespaceAll).Controller().Lister()
+	l.projectLister = cluster.Management.Management.Projects(cluster.ClusterName).Controller().Lister()
 	l.templateLister = cluster.Management.Management.CatalogTemplates(metav1.NamespaceAll).Controller().Lister()
 	l.daemonsets = cluster.Apps.DaemonSets(loggingconfig.LoggingNamespace)
 	l.secrets = cluster.Core.Secrets(loggingconfig.LoggingNamespace)
 	l.appDeployer = ad
 }
 
-func (l *loggingService) Version() (string, error) {
+func (l *LoggingService) Version() (string, error) {
 	catalogID := settings.SystemLoggingCatalogID.Get()
 	templateVersionID, _, err := common.ParseExternalID(catalogID)
 	if err != nil {
@@ -65,7 +67,7 @@ func (l *loggingService) Version() (string, error) {
 	return templateVersionID, nil
 }
 
-func (l *loggingService) Upgrade(currentVersion string) (string, error) {
+func (l *LoggingService) Upgrade(currentVersion string) (string, error) {
 	appName := loggingconfig.AppName
 	templateID := loggingconfig.RancherLoggingTemplateID()
 	template, err := l.templateLister.Get(namespace.GlobalNamespace, templateID)
@@ -84,7 +86,7 @@ func (l *loggingService) Upgrade(currentVersion string) (string, error) {
 		return "", fmt.Errorf("get cluster %s failed, %v", l.clusterName, err)
 	}
 	if !v3.ClusterConditionReady.IsTrue(cluster) {
-		return "", fmt.Errorf("upgrade system service %s failed, cluster %v not ready", serviceName, l.clusterName)
+		return "", fmt.Errorf("cluster %v not ready", l.clusterName)
 	}
 
 	//clean old version
@@ -118,6 +120,21 @@ func (l *loggingService) Upgrade(currentVersion string) (string, error) {
 		}
 		return "", errors.Wrapf(err, "get app %s:%s failed", systemProject.Name, appName)
 	}
+
+	_, systemCatalogName, _, _, _, err := common.SplitExternalID(newCatalogID)
+	if err != nil {
+		return "", err
+	}
+
+	systemCatalog, err := l.catalogLister.Get(metav1.NamespaceAll, systemCatalogName)
+	if err != nil {
+		return "", fmt.Errorf("get catalog %s failed, %v", systemCatalogName, err)
+	}
+
+	if !v3.CatalogConditionUpgraded.IsTrue(systemCatalog) || !v3.CatalogConditionRefreshed.IsTrue(systemCatalog) || !v3.CatalogConditionDiskCached.IsTrue(systemCatalog) {
+		return "", fmt.Errorf("catalog %v not ready", systemCatalogName)
+	}
+
 	newApp := app.DeepCopy()
 	newApp.Spec.ExternalID = newCatalogID
 
@@ -129,7 +146,7 @@ func (l *loggingService) Upgrade(currentVersion string) (string, error) {
 	return newFullVersion, nil
 }
 
-func (l *loggingService) removeLegacy() error {
+func (l *LoggingService) removeLegacy() error {
 	op := metav1.DeletePropagationBackground
 	errMsg := "failed to remove legacy logging %s %s:%s when upgrade"
 

--- a/pkg/controllers/user/logging/deployer/upgradeimpl_test.go
+++ b/pkg/controllers/user/logging/deployer/upgradeimpl_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestVersion(t *testing.T) {
 	expectedVersion := "system-library-rancher-logging-0.1.1"
-	loggingService := &loggingService{}
+	loggingService := &LoggingService{}
 	version, err := loggingService.Version()
 	if err != nil {
 		t.Error(err)

--- a/pkg/controllers/user/systemimage/register.go
+++ b/pkg/controllers/user/systemimage/register.go
@@ -7,11 +7,13 @@ import (
 )
 
 func Register(ctx context.Context, cluster *config.UserContext) {
+	projClient := cluster.Management.Management.Projects("")
+	catalogClient := cluster.Management.Management.Catalogs("")
+	systemServices := getSystemService()
 	for _, v := range systemServices {
-		v.Init(ctx, cluster)
+		v.Init(cluster)
 	}
 
-	projClient := cluster.Management.Management.Projects("")
 	syncer := Syncer{
 		clusterName:      cluster.ClusterName,
 		projects:         projClient,
@@ -20,7 +22,8 @@ func Register(ctx context.Context, cluster *config.UserContext) {
 		daemonsetLister:  cluster.Apps.DaemonSets("").Controller().Lister(),
 		deployments:      cluster.Apps.Deployments(""),
 		deploymentLister: cluster.Apps.Deployments("").Controller().Lister(),
+		systemSercices:   systemServices,
 	}
-	projClient.AddClusterScopedHandler(ctx, "system-image-upgrade-controller", cluster.ClusterName, syncer.Sync)
-
+	projClient.AddClusterScopedHandler(ctx, "system-image-upgrade-controller", cluster.ClusterName, syncer.SyncProject)
+	catalogClient.AddHandler(ctx, "system-image-upgrade-catalog-controller", syncer.SyncCatalog)
 }

--- a/pkg/controllers/user/systemimage/systemimage.go
+++ b/pkg/controllers/user/systemimage/systemimage.go
@@ -4,14 +4,21 @@ import (
 	"encoding/json"
 	"fmt"
 
+	alerting "github.com/rancher/rancher/pkg/controllers/user/alert/deployer"
+	logging "github.com/rancher/rancher/pkg/controllers/user/logging/deployer"
+	pipeline "github.com/rancher/rancher/pkg/controllers/user/pipeline/upgrade"
 	"github.com/rancher/rancher/pkg/project"
 	"github.com/rancher/types/apis/apps/v1beta2"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var systemProjectLabels = labels.Set(map[string]string{"authz.management.cattle.io/system-project": "true"})
+var systemLibraryName = "system-library"
 
 type Syncer struct {
 	clusterName      string
@@ -21,16 +28,33 @@ type Syncer struct {
 	deploymentLister v1beta2.DeploymentLister
 	projectLister    v3.ProjectLister
 	projects         v3.ProjectInterface
+	userContext      *config.UserContext
+	systemSercices   map[string]SystemService
 }
 
-func (s *Syncer) Sync(key string, obj *v3.Project) (runtime.Object, error) {
+func (s *Syncer) SyncProject(key string, obj *v3.Project) (runtime.Object, error) {
+	if obj == nil || obj.DeletionTimestamp != nil {
+		return nil, nil
+	}
+	return obj, s.Sync()
+}
+
+func (s *Syncer) SyncCatalog(key string, obj *v3.Catalog) (runtime.Object, error) {
 	if obj == nil || obj.DeletionTimestamp != nil {
 		return nil, nil
 	}
 
+	if obj.Name != systemLibraryName {
+		return obj, nil
+	}
+
+	return obj, s.Sync()
+}
+
+func (s *Syncer) Sync() error {
 	projects, err := s.projectLister.List(s.clusterName, systemProjectLabels.AsSelector())
 	if err != nil {
-		return nil, fmt.Errorf("get projects failed when try to upgrade system tools, %v", err)
+		return fmt.Errorf("get projects failed when try to upgrade system tools, %v", err)
 	}
 
 	var systemProject *v3.Project
@@ -41,23 +65,23 @@ func (s *Syncer) Sync(key string, obj *v3.Project) (runtime.Object, error) {
 	}
 
 	if systemProject == nil {
-		return nil, nil
+		return nil
 	}
 
 	versionMap := make(map[string]string)
 	curSysImageVersion := systemProject.Annotations[project.SystemImageVersionAnn]
 	if curSysImageVersion != "" {
 		if err = json.Unmarshal([]byte(curSysImageVersion), &versionMap); err != nil {
-			return nil, fmt.Errorf("unmashal current system service version failed, %v", err)
+			return fmt.Errorf("unmashal current system service version failed, %v", err)
 		}
 	}
 
 	changed := false
-	for k, v := range systemServices {
+	for k, v := range s.systemSercices {
 		oldVersion := versionMap[k]
 		newVersion, err := v.Upgrade(oldVersion)
 		if err != nil {
-			return nil, err
+			return errors.Wrapf(err, "upgrade cluster %s system service %s failed", s.clusterName, k)
 		}
 		if oldVersion != newVersion {
 			changed = true
@@ -66,20 +90,22 @@ func (s *Syncer) Sync(key string, obj *v3.Project) (runtime.Object, error) {
 	}
 
 	if !changed {
-		return nil, nil
+		return nil
 	}
 
 	newVersion, err := json.Marshal(versionMap)
 	if err != nil {
-		return nil, fmt.Errorf("marshal new system service version %v failed, %v", versionMap, err)
+		return fmt.Errorf("marshal new system service version %v failed, %v", versionMap, err)
 	}
 
 	systemProject.Annotations[project.SystemImageVersionAnn] = string(newVersion)
-	return s.projects.Update(systemProject)
+	_, err = s.projects.Update(systemProject)
+	return err
 }
 
 func GetSystemImageVersion() (string, error) {
 	versionMap := make(map[string]string)
+	systemServices := getSystemService()
 	for k, v := range systemServices {
 		version, err := v.Version()
 		if err != nil {
@@ -94,4 +120,12 @@ func GetSystemImageVersion() (string, error) {
 	}
 
 	return string(b), nil
+}
+
+func getSystemService() map[string]SystemService {
+	return map[string]SystemService{
+		alerting.ServiceName: alerting.NewService(),
+		logging.ServiceName:  logging.NewService(),
+		pipeline.ServiceName: pipeline.NewService(),
+	}
 }

--- a/pkg/controllers/user/systemimage/upgrader.go
+++ b/pkg/controllers/user/systemimage/upgrader.go
@@ -1,35 +1,11 @@
 package systemimage
 
 import (
-	"context"
-	"crypto/sha1"
-	"encoding/json"
-	"fmt"
-
 	"github.com/rancher/types/config"
-	"github.com/sirupsen/logrus"
 )
 
-var systemServices = make(map[string]SystemService)
-
 type SystemService interface {
-	Init(ctx context.Context, cluster *config.UserContext)
+	Init(cluster *config.UserContext)
 	Upgrade(currentVersion string) (newVersion string, err error)
 	Version() (string, error)
-}
-
-func RegisterSystemService(name string, systemService SystemService) {
-	if _, exists := systemServices[name]; exists {
-		logrus.Errorf("system service '%s' tried to register twice", name)
-	}
-	systemServices[name] = systemService
-}
-
-func DefaultGetVersion(obj interface{}) (string, error) {
-	b, err := json.Marshal(obj)
-	if err != nil {
-		return "", fmt.Errorf("marshal obj failed when get system image version: %v", err)
-	}
-
-	return fmt.Sprintf("%x", sha1.Sum(b))[:7], nil
 }


### PR DESCRIPTION
Problem:
only one cluster system server upgrade success when there are multiple
cluster

Solution:
this cause by only one alert/logging/pipeline upgradeService was init,
when there are multiple cluster, the former clusterName will be
overwrite by the laster one. Now change handle multiple cluster when
init upgradeService

Issue:
https://github.com/rancher/rancher/issues/21455
https://github.com/rancher/rancher/issues/21323
https://github.com/rancher/rancher/issues/20975
