### PR TITLE
[release/v2.2] Change scheduling for node/cluster agent pods

### DIFF
--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -91,7 +91,29 @@ spec:
                   operator: NotIn
                   values:
                     - windows
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/controlplane
+                operator: In
+                values:
+                - "true"
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/etcd
+                operator: In
+                values:
+                - "true"
       serviceAccountName: cattle
+      tolerations:
+      - effect: NoExecute
+        key: "node-role.kubernetes.io/etcd"
+        value: "true"
+      - effect: NoSchedule
+        key: "node-role.kubernetes.io/controlplane"
+        value: "true"
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -142,12 +164,7 @@ spec:
       hostNetwork: true
       serviceAccountName: cattle
       tolerations:
-      - effect: NoExecute
-        key: "node-role.kubernetes.io/etcd"
-        value: "true"
-      - effect: NoSchedule
-        key: "node-role.kubernetes.io/controlplane"
-        value: "true"
+      - operator: Exists
       containers:
       - name: agent
         image: {{.AgentImage}}
@@ -225,6 +242,21 @@ spec:
                   operator: NotIn
                   values:
                     - windows
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/controlplane
+                operator: In
+                values:
+                - "true"
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/etcd
+                operator: In
+                values:
+                - "true"
       hostNetwork: true
       serviceAccountName: cattle
       tolerations:


### PR DESCRIPTION
Problem: Manually tainted nodes will not get new cattle-node-agent pods due to insufficient tolerations.
Solution: Allow all taints for cattle-node-agent. This change also prefers controlplane and etcd nodes for cattle-cluster-agent.