### PR TITLE
[2.2 backport] Allow all taints for agents and kube-api-auth

### DIFF
--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -108,12 +108,7 @@ spec:
                 - "true"
       serviceAccountName: cattle
       tolerations:
-      - effect: NoExecute
-        key: "node-role.kubernetes.io/etcd"
-        value: "true"
-      - effect: NoSchedule
-        key: "node-role.kubernetes.io/controlplane"
-        value: "true"
+      - operator: Exists
       containers:
         - name: cluster-register
           imagePullPolicy: IfNotPresent
@@ -242,30 +237,14 @@ spec:
                   operator: NotIn
                   values:
                     - windows
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/controlplane
-                operator: In
-                values:
-                - "true"
-          - weight: 1
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/etcd
-                operator: In
-                values:
-                - "true"
+                - key: node-role.kubernetes.io/controlplane
+                  operator: In
+                  values:
+                    - "true"
       hostNetwork: true
       serviceAccountName: cattle
       tolerations:
-      - effect: NoExecute
-        key: "node-role.kubernetes.io/etcd"
-        value: "true"
-      - effect: NoSchedule
-        key: "node-role.kubernetes.io/controlplane"
-        value: "true"
+      - operator: Exists
       containers:
       - name: kube-api-auth
         image: {{.AuthImage}}


### PR DESCRIPTION
Problem: Manually tainted etcd/controlplane nodes won't get cluster-agent or kube-api-auth scheduled

Solution: Allow all taints for agents and kube-api-auth, restrict kube-api-auth to controlplane nodes