### PR TITLE
Make helm jail name unique master

### DIFF
--- a/pkg/controllers/user/helm/common.go
+++ b/pkg/controllers/user/helm/common.go
@@ -198,15 +198,17 @@ func createTempDir(obj *v3.App) (*common.HelmPath, error) {
 		}, nil
 	}
 
-	err := jailer.CreateJail(obj.Name)
+	jailDir := obj.Spec.ProjectName + ":" + obj.Name
+
+	err := jailer.CreateJail(jailDir)
 	if err != nil {
 		return nil, err
 	}
 
 	paths := &common.HelmPath{
-		FullPath:         filepath.Join(jailer.BaseJailPath, obj.Name),
+		FullPath:         filepath.Join(jailer.BaseJailPath, jailDir),
 		InJailPath:       "/",
-		KubeConfigFull:   filepath.Join(jailer.BaseJailPath, obj.Name, ".kubeconfig"),
+		KubeConfigFull:   filepath.Join(jailer.BaseJailPath, jailDir, ".kubeconfig"),
 		KubeConfigInJail: "/.kubeconfig",
 	}
 


### PR DESCRIPTION
Problem:
The helm jail is based off the app name so if multiple apps with the
same name come through the jail can get deleted out from under other
running processes

Solution:
Make the jail name unique

https://github.com/rancher/rancher/issues/21449
#21455
#21323
#20975