### PR TITLE
Forwardport: Whitelist envvars for jail

### DIFF
--- a/pkg/controllers/management/node/utils.go
+++ b/pkg/controllers/management/node/utils.go
@@ -124,11 +124,11 @@ func buildCommand(nodeDir string, node *v3.Node, cmdArgs []string) (*exec.Cmd, e
 	command.SysProcAttr = &syscall.SysProcAttr{}
 	command.SysProcAttr.Credential = cred
 	command.SysProcAttr.Chroot = path.Join(jailer.BaseJailPath, node.Namespace)
-	command.Env = []string{
-
+	envvars := []string{
 		nodeDirEnvKey + nodeDir,
 		"PATH=/usr/bin:/var/lib/rancher/management-state/bin",
 	}
+	command.Env = jailer.WhitelistEnvvars(envvars)
 	return command, nil
 }
 

--- a/pkg/controllers/user/helm/common/common.go
+++ b/pkg/controllers/user/helm/common/common.go
@@ -216,5 +216,6 @@ func JailCommand(cmd *exec.Cmd, jailPath string) (*exec.Cmd, error) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
 	cmd.SysProcAttr.Credential = cred
 	cmd.SysProcAttr.Chroot = jailPath
+	cmd.Env = jailer.WhitelistEnvvars(cmd.Env)
 	return cmd, nil
 }

--- a/pkg/jailer/jailer.go
+++ b/pkg/jailer/jailer.go
@@ -8,11 +8,13 @@ import (
 	"os/user"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/sirupsen/logrus"
 )
 
@@ -80,4 +82,22 @@ func GetUserCred() (*syscall.Credential, error) {
 	gid := uint32(i)
 
 	return &syscall.Credential{Uid: uid, Gid: gid}, nil
+}
+
+func WhitelistEnvvars(envvars []string) []string {
+	wl := settings.WhitelistEnvironmentVars.Get()
+	envWhiteList := strings.Split(wl, ",")
+
+	if len(envWhiteList) == 0 {
+		return envvars
+	}
+
+	for _, wlVar := range envWhiteList {
+		wlVar = strings.TrimSpace(wlVar)
+		if val := os.Getenv(wlVar); val != "" {
+			envvars = append(envvars, wlVar+"="+val)
+		}
+	}
+
+	return envvars
 }

--- a/pkg/jailer/jailer_test.go
+++ b/pkg/jailer/jailer_test.go
@@ -1,0 +1,46 @@
+package jailer
+
+import (
+	"os"
+	"testing"
+
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_WhitelistEnvvars(t *testing.T) {
+	settings.WhitelistEnvironmentVars.Set("ENVVAR_FOO")
+	defer os.Unsetenv("ENVVAR_FOO")
+
+	type testCase struct {
+		input    []string
+		expected []string
+		envValue string
+	}
+
+	testCases := []testCase{
+		// Base case, nothing goes in, no env set, nothing comes out
+		{
+			envValue: "",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			envValue: "BAR",
+			input:    []string{},
+			expected: []string{"ENVVAR_FOO=BAR"},
+		},
+		{
+			envValue: "ALPHA",
+			input:    []string{"BAZ=FOOBAZ"},
+			expected: []string{"BAZ=FOOBAZ", "ENVVAR_FOO=ALPHA"},
+		},
+	}
+
+	for _, tc := range testCases {
+		os.Setenv("ENVVAR_FOO", tc.envValue)
+		envs := WhitelistEnvvars(tc.input)
+		assert.Equal(t, envs, tc.expected)
+	}
+
+}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -54,6 +54,7 @@ var (
 	UIKubernetesSupportedVersions     = NewSetting("ui-k8s-supported-versions-range", ">= 1.11.0 <=1.14.x")
 	UIKubernetesDefaultVersion        = NewSetting("ui-k8s-default-version-range", "<=1.14.x")
 	WhitelistDomain                   = NewSetting("whitelist-domain", "forums.rancher.com")
+	WhitelistEnvironmentVars          = NewSetting("whitelist-envvars", "HTTP_PROXY,HTTPS_PROXY,NO_PROXY")
 	SystemMonitoringCatalogID         = NewSetting("system-monitoring-catalog-id", "catalog://?catalog=system-library&template=rancher-monitoring&version=0.0.3")
 	SystemLoggingCatalogID            = NewSetting("system-logging-catalog-id", "catalog://?catalog=system-library&template=rancher-logging&version=0.1.1")
 	SystemExternalDNSCatalogID        = NewSetting("system-externaldns-catalog-id", "catalog://?catalog=system-library&template=rancher-external-dns&version=0.0.1")

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1.0
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     2da1bd2ffcacdef4bdf7e2c193d32f3b04ebd6d0
-github.com/rancher/kontainer-engine           95afcc99c7958e84122f011e610ff380d3555cf3
+github.com/rancher/kontainer-engine           b98bad2201bb24636c1b745237838958c02ccea1
 github.com/rancher/rke                        f36020741696d687576b8d42bb1efa07f08c6184
 github.com/rancher/kontainer-driver-metadata  949885dc589573e2fd8ee3a72ec70b6c5226384d
 github.com/rancher/types                      29db9d560e2cb45d477b2a426bdfdcdc2c38b443

--- a/vendor/github.com/rancher/kontainer-engine/service/service.go
+++ b/vendor/github.com/rancher/kontainer-engine/service/service.go
@@ -439,9 +439,7 @@ func (r *RunningDriver) Start() (string, error) {
 			cmd.SysProcAttr = &syscall.SysProcAttr{}
 			cmd.SysProcAttr.Credential = cred
 			cmd.SysProcAttr.Chroot = "/opt/jail/driver-jail"
-			cmd.Env = []string{"PATH=/usr/bin"}
-			logrus.Infof("CMD info: %+v", cmd)
-			logrus.Infof("SysProc: %+v", cmd.SysProcAttr)
+			cmd.Env = whitelistEnvvars([]string{"PATH=/usr/bin"})
 		}
 
 		// redirect output to console
@@ -616,4 +614,25 @@ func getUserCred() (*syscall.Credential, error) {
 	gid := uint32(i)
 
 	return &syscall.Credential{Uid: uid, Gid: gid}, nil
+}
+
+func whitelistEnvvars(envvars []string) []string {
+	wl := os.Getenv("CATTLE_KONTAINER_ENGINE_WHITELIST_ENVVARS")
+	envWhiteList := strings.Split(wl, ",")
+
+	if len(envWhiteList) == 0 {
+		envWhiteList = []string{
+			"HTTP_PROXY",
+			"HTTPS_PROXY",
+			"NO_PROXY",
+		}
+	}
+
+	for _, wlVar := range envWhiteList {
+		if val := os.Getenv(wlVar); val != "" {
+			envvars = append(envvars, wlVar+"="+val)
+		}
+	}
+
+	return envvars
 }


### PR DESCRIPTION
Problem:
The jail clears the env and sets only ones required to run. This drops
envvars that might be needed for a proxy

Solution:
Add a whitelist of envvars to pull into the jail with a default list to
support proxies or user updated setting

https://github.com/rancher/rancher/issues/20709