### PR TITLE
Fix istio integration tests

### DIFF
--- a/tests/integration/suite/test_istio.py
+++ b/tests/integration/suite/test_istio.py
@@ -10,6 +10,7 @@ istio_crd_url = "https://raw.githubusercontent.com/istio/istio/1.1.5" \
                 "/install/kubernetes/helm/istio-init/files/crd-10.yaml"
 
 
+@pytest.mark.nonparallel
 def test_virtual_service(admin_pc):
     client = admin_pc.client
     ns = admin_pc.cluster.client.create_namespace(
@@ -39,6 +40,7 @@ def test_virtual_service(admin_pc):
     client.delete(ns)
 
 
+@pytest.mark.nonparallel
 def test_destination_rule(admin_pc):
     client = admin_pc.client
     ns = admin_pc.cluster.client.create_namespace(


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/21492

Problem:
Tests fail when istio tests are distributed to different workers. Module-scope fixtures/teardown can run multiple times in this case, causing race condition that the 1st test may clean up istio CRDs while the
2nd test is running.

Solution:
Run istio API tests in nonparallel.