### PR TITLE
DeriveKubernetesVersion from the generic major.minor.patch

### DIFF
--- a/pkg/api/customization/clustertemplate/utils.go
+++ b/pkg/api/customization/clustertemplate/utils.go
@@ -9,23 +9,31 @@ import (
 	"github.com/rancher/norman/httperror"
 )
 
-func CheckKubernetesVersionFormat(k8sVersion string) error {
+const (
+	RKEConfigK8sVersion = "rancherKubernetesEngineConfig.kubernetesVersion"
+)
+
+func CheckKubernetesVersionFormat(k8sVersion string) (bool, error) {
 	if !strings.Contains(k8sVersion, "-rancher") {
 		errMsg := fmt.Sprintf("Requested kubernetesVersion %v is not of valid semver [major.minor.patch] format", k8sVersion)
 		vparts := strings.Split(k8sVersion, ".")
 		if len(vparts) != 3 {
-			return httperror.NewAPIError(httperror.InvalidFormat, errMsg)
+			return false, httperror.NewAPIError(httperror.InvalidFormat, errMsg)
 		}
 		for _, part := range vparts[:2] {
 			//part should be a numeric value
 			if _, err := strconv.Atoi(part); err != nil {
-				return httperror.NewAPIError(httperror.InvalidFormat, errMsg)
+				return false, httperror.NewAPIError(httperror.InvalidFormat, errMsg)
 			}
 		}
 		_, err := semver.ParseRange("=" + k8sVersion)
 		if err != nil {
-			return httperror.NewAPIError(httperror.InvalidFormat, errMsg)
+			return false, httperror.NewAPIError(httperror.InvalidFormat, errMsg)
+		}
+
+		if vparts[2] == "x" {
+			return true, nil
 		}
 	}
-	return nil
+	return false, nil
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/21084

New changes to this ticket:
---- If a template specifies Kubernetes version of the format 1.14.x, a Question for the "rancherKubernetesEngineConfig.kubernetesVersion" should also be set - API will error out if a question is not added. 
---- When a cluster is created from a clusterTemplate that specifies the k8sversion of a format 1.14.x
backend will translate this to rancher supported kubernetes version on the create. If user does not provide an answer to the k8sversion Template Question, Backend will use the default value for translation.
---- On editing such a cluster, If the answer to the k8sversion Template Question is not different, no translation will be done again. This prevents the auto-upgrade to newer version as was seen on earlier tests.
---- If user wants to upgrade the cluster to newer k8sversion, he/she should set the new answer(with specific k8sversion or higher patch as 1.15.x) on cluster edit or change the templateRevision having a newer k8s support.

