### PR TITLE
Don't set active state to newly created HPA

### DIFF
--- a/pkg/api/store/nocondition/store.go
+++ b/pkg/api/store/nocondition/store.go
@@ -1,0 +1,25 @@
+package nocondition
+
+import (
+	"github.com/rancher/norman/store/transform"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/values"
+)
+
+//NewWrapper returns a wrapper store which sets your object to transitioning state if your object has no conditions.
+func NewWrapper(state, message string) func(types.Store) types.Store {
+	return func(store types.Store) types.Store {
+		return &transform.Store{
+			Store: store,
+			Transformer: func(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, opt *types.QueryOptions) (map[string]interface{}, error) {
+				conditions, ok := values.GetSlice(data, "conditions")
+				if !ok || len(conditions) == 0 {
+					values.PutValue(data, state, "state")
+					values.PutValue(data, "yes", "transitioning")
+					values.PutValue(data, message, "transitioningMessage")
+				}
+				return data, nil
+			},
+		}
+	}
+}

--- a/tests/integration/suite/test_hpa.py
+++ b/tests/integration/suite/test_hpa.py
@@ -65,6 +65,7 @@ def test_hpa(admin_pc):
     )
     assert len(hpas) == 1
     hpa = hpas.data[0]
+    assert hpa.state == "initializing"
     client.delete(hpa)
     client.delete(workload)
     client.delete(ns)


### PR DESCRIPTION
**Problem:**
The hpa object needs conditions to indicate the state,
if there are not any, we should set it to initializing.

Related issue:
https://github.com/rancher/rancher/issues/20955

Related PR:
https://github.com/rancher/types/pull/907