### PR TITLE
Add support to select monitoring version on deployment

### DIFF
--- a/pkg/api/customization/cluster/actions_monitoring.go
+++ b/pkg/api/customization/cluster/actions_monitoring.go
@@ -27,14 +27,20 @@ func (a ActionHandler) viewMonitoring(actionName string, action *types.Action, a
 	}
 
 	// need to support `map[string]string` as entry value type in norman Builder.convertMap
-	answers, err := convert.EncodeToMap(monitoring.GetOverwroteAppAnswers(cluster.Annotations))
+	answers, version := monitoring.GetOverwroteAppAnswersAndVersion(cluster.Annotations)
+	encodeAnswers, err := convert.EncodeToMap(answers)
 	if err != nil {
 		return httperror.WrapAPIError(err, httperror.ServerError, "failed to parse response")
 	}
-	apiContext.WriteResponse(http.StatusOK, map[string]interface{}{
-		"answers": answers,
+	resp := map[string]interface{}{
+		"answers": encodeAnswers,
 		"type":    "monitoringOutput",
-	})
+	}
+	if version != "" {
+		resp["version"] = version
+	}
+
+	apiContext.WriteResponse(http.StatusOK, resp)
 	return nil
 }
 

--- a/pkg/api/customization/project/project_actions.go
+++ b/pkg/api/customization/project/project_actions.go
@@ -137,14 +137,20 @@ func (h *Handler) viewMonitoring(actionName string, action *types.Action, apiCon
 	}
 
 	// need to support `map[string]string` as entry value type in norman Builder.convertMap
-	answers, err := convert.EncodeToMap(monitoring.GetOverwroteAppAnswers(project.Annotations))
+	answers, version := monitoring.GetOverwroteAppAnswersAndVersion(project.Annotations)
+	encodeAnswers, err := convert.EncodeToMap(answers)
 	if err != nil {
 		return httperror.WrapAPIError(err, httperror.ServerError, "failed to parse response")
 	}
-	apiContext.WriteResponse(http.StatusOK, map[string]interface{}{
-		"answers": answers,
+	resp := map[string]interface{}{
+		"answers": encodeAnswers,
 		"type":    "monitoringOutput",
-	})
+	}
+	if version != "" {
+		resp["version"] = version
+	}
+
+	apiContext.WriteResponse(http.StatusOK, resp)
 	return nil
 }
 

--- a/pkg/catalog/manager/traverse.go
+++ b/pkg/catalog/manager/traverse.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	helmlib "github.com/rancher/rancher/pkg/catalog/helm"
+	cutils "github.com/rancher/rancher/pkg/catalog/utils"
 	"github.com/rancher/rancher/pkg/namespace"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	client "github.com/rancher/types/client/management/v3"
@@ -141,7 +142,7 @@ func (m *Manager) traverseAndUpdate(helm *helmlib.Helm, commit string, cmt *Cata
 			}
 
 			if catalogType == client.CatalogType {
-				v.ExternalID = fmt.Sprintf("catalog://?catalog=%s&template=%s&version=%s", catalog.Name, template.Spec.FolderName, v.Version)
+				v.ExternalID = fmt.Sprintf(cutils.CatalogExternalIDFormat, catalog.Name, template.Spec.FolderName, v.Version)
 			} else {
 				v.ExternalID = fmt.Sprintf("catalog://?catalog=%s/%s&type=%s&template=%s&version=%s", templateNamespace, catalog.Name, catalogType, template.Spec.FolderName, v.Version)
 			}

--- a/pkg/catalog/utils/utils.go
+++ b/pkg/catalog/utils/utils.go
@@ -5,6 +5,11 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+const (
+	CatalogExternalIDFormat = "catalog://?catalog=%s&template=%s&version=%s"
+	SystemLibraryName       = "system-library"
+)
+
 // Config holds libcompose top level configuration
 type Config struct {
 	Version  string                 `yaml:"version,omitempty"`

--- a/pkg/controllers/user/alert/deployer/upgradeimpl.go
+++ b/pkg/controllers/user/alert/deployer/upgradeimpl.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/rancher/norman/controller"
+	cutils "github.com/rancher/rancher/pkg/catalog/utils"
 	alertutil "github.com/rancher/rancher/pkg/controllers/user/alert/common"
 	"github.com/rancher/rancher/pkg/controllers/user/helm/common"
 	monitorutil "github.com/rancher/rancher/pkg/monitoring"
@@ -99,7 +100,7 @@ func (l *AlertService) Upgrade(currentVersion string) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "get template %s failed", templateID)
 	}
-	newExternalID := fmt.Sprintf("catalog://?catalog=%s&template=%s&version=%s", systemCatalogName, templateName, template.Spec.DefaultVersion)
+	newExternalID := fmt.Sprintf(cutils.CatalogExternalIDFormat, systemCatalogName, templateName, template.Spec.DefaultVersion)
 
 	newVersion, _, err := common.ParseExternalID(newExternalID)
 	if err != nil {
@@ -108,7 +109,7 @@ func (l *AlertService) Upgrade(currentVersion string) (string, error) {
 
 	appName, _ := monitorutil.ClusterAlertManagerInfo()
 	//migrate legacy
-	if !strings.Contains(currentVersion, "system-library-rancher-monitoring") {
+	if !strings.Contains(currentVersion, monitorutil.RancherMonitoringTemplateName) {
 		if err := l.migrateLegacyClusterAlert(); err != nil {
 			return "", err
 		}

--- a/pkg/controllers/user/helm/common/extra_args_injection.go
+++ b/pkg/controllers/user/helm/common/extra_args_injection.go
@@ -3,6 +3,7 @@ package common
 import (
 	"net/url"
 
+	cutils "github.com/rancher/rancher/pkg/catalog/utils"
 	"github.com/rancher/rancher/pkg/ref"
 	"github.com/rancher/rancher/pkg/settings"
 	v3 "github.com/rancher/types/apis/project.cattle.io/v3"
@@ -10,10 +11,6 @@ import (
 )
 
 type InjectAppArgsFunc func(obj *v3.App) (content map[string]string)
-
-const (
-	systemCatalogName = "system-library"
-)
 
 var (
 	extraArgsFuncs = []InjectAppArgsFunc{
@@ -29,7 +26,7 @@ func injectDefaultRegistry(obj *v3.App) map[string]string {
 		return nil
 	}
 
-	if values.Query().Get("catalog") != systemCatalogName {
+	if values.Query().Get("catalog") != cutils.SystemLibraryName {
 		return nil
 	}
 

--- a/pkg/controllers/user/istio/appHandler.go
+++ b/pkg/controllers/user/istio/appHandler.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	cutils "github.com/rancher/rancher/pkg/catalog/utils"
 	v3 "github.com/rancher/types/apis/project.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,7 +16,6 @@ import (
 )
 
 const (
-	systemCatalogName = "system-library"
 	istioTemplateName = "rancher-istio"
 	istioAppName      = "cluster-istio"
 )
@@ -51,7 +51,7 @@ func isIstioApp(obj *v3.App) bool {
 
 	template := values.Query().Get("template")
 
-	if catalog == systemCatalogName && template == istioTemplateName {
+	if catalog == cutils.SystemLibraryName && template == istioTemplateName {
 		return true
 	}
 	return false

--- a/pkg/controllers/user/logging/config/config.go
+++ b/pkg/controllers/user/logging/config/config.go
@@ -2,14 +2,15 @@ package constant
 
 import (
 	"fmt"
+
+	cutils "github.com/rancher/rancher/pkg/catalog/utils"
 )
 
 const (
-	AppName           = "rancher-logging"
-	TesterAppName     = "rancher-logging-tester"
-	AppInitVersion    = "0.1.1"
-	systemCatalogName = "system-library"
-	templateName      = "rancher-logging"
+	AppName        = "rancher-logging"
+	TesterAppName  = "rancher-logging-tester"
+	AppInitVersion = "0.1.1"
+	templateName   = "rancher-logging"
 )
 
 const (
@@ -79,15 +80,15 @@ func SecretDataKeyCertKey(level, name string) string {
 }
 
 func RancherLoggingTemplateID() string {
-	return fmt.Sprintf("%s-%s", systemCatalogName, templateName)
+	return fmt.Sprintf("%s-%s", cutils.SystemLibraryName, templateName)
 }
 
 func RancherLoggingFullVersion() string {
-	return fmt.Sprintf("%s-%s-%s", systemCatalogName, templateName, AppInitVersion)
+	return fmt.Sprintf("%s-%s-%s", cutils.SystemLibraryName, templateName, AppInitVersion)
 }
 
 func RancherLoggingCatalogID(version string) string {
-	return fmt.Sprintf("catalog://?catalog=%s&template=%s&version=%s", systemCatalogName, templateName, version)
+	return fmt.Sprintf(cutils.CatalogExternalIDFormat, cutils.SystemLibraryName, templateName, version)
 }
 
 func RancherLoggingConfigSecretName() string {

--- a/pkg/controllers/user/monitoring/appHandler.go
+++ b/pkg/controllers/user/monitoring/appHandler.go
@@ -26,6 +26,7 @@ type appHandler struct {
 	agentNamespaceClient        corev1.NamespaceInterface
 	systemAccountManager        *systemaccount.Manager
 	projectLister               mgmtv3.ProjectLister
+	catalogTemplateLister       mgmtv3.CatalogTemplateLister
 }
 
 func (ah *appHandler) withdrawApp(clusterID, appName, appTargetNamespace string) error {

--- a/pkg/controllers/user/monitoring/register.go
+++ b/pkg/controllers/user/monitoring/register.go
@@ -39,6 +39,7 @@ func Register(ctx context.Context, agentContext *config.UserContext) {
 		agentNamespaceClient:        agentContext.Core.Namespaces(metav1.NamespaceAll),
 		systemAccountManager:        systemaccount.NewManager(agentContext.Management),
 		projectLister:               mgmtContext.Projects(metav1.NamespaceAll).Controller().Lister(),
+		catalogTemplateLister:       mgmtContext.CatalogTemplates(metav1.NamespaceAll).Controller().Lister(),
 	}
 
 	// operator handler

--- a/pkg/controllers/user/systemimage/systemimage.go
+++ b/pkg/controllers/user/systemimage/systemimage.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	cutils "github.com/rancher/rancher/pkg/catalog/utils"
 	alerting "github.com/rancher/rancher/pkg/controllers/user/alert/deployer"
 	logging "github.com/rancher/rancher/pkg/controllers/user/logging/deployer"
 	pipeline "github.com/rancher/rancher/pkg/controllers/user/pipeline/upgrade"
@@ -18,7 +19,6 @@ import (
 )
 
 var systemProjectLabels = labels.Set(map[string]string{"authz.management.cattle.io/system-project": "true"})
-var systemLibraryName = "system-library"
 
 type Syncer struct {
 	clusterName      string
@@ -44,7 +44,7 @@ func (s *Syncer) SyncCatalog(key string, obj *v3.Catalog) (runtime.Object, error
 		return nil, nil
 	}
 
-	if obj.Name != systemLibraryName {
+	if obj.Name != cutils.SystemLibraryName {
 		return obj, nil
 	}
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -43,7 +43,7 @@ github.com/rancher/norman                     043a1c919df3ada12d5592e7f0259404cb
 github.com/rancher/kontainer-engine           b98bad2201bb24636c1b745237838958c02ccea1
 github.com/rancher/rke                        2bc960a01c731b42ee13ca7a1f86558bc941cb3c
 github.com/rancher/kontainer-driver-metadata  a6ceb896b4e0b3a0eff3a2f5aac379b7c7d2896a
-github.com/rancher/types                      839eead94ce4d64c40e9cc2ba7994eeb8079bb03
+github.com/rancher/types                      facd19d687db66c61ad49eddffc461991b7c5492
 
 gopkg.in/ldap.v2                              v2.5.0
 gopkg.in/asn1-ber.v1                          v1.1

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -256,10 +256,12 @@ type IngressCapabilities struct {
 }
 
 type MonitoringInput struct {
+	Version string            `json:"version,omitempty"`
 	Answers map[string]string `json:"answers,omitempty"`
 }
 
 type MonitoringOutput struct {
+	Version string            `json:"version,omitempty"`
 	Answers map[string]string `json:"answers,omitempty"`
 }
 

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_monitoring_input.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_monitoring_input.go
@@ -3,8 +3,10 @@ package client
 const (
 	MonitoringInputType         = "monitoringInput"
 	MonitoringInputFieldAnswers = "answers"
+	MonitoringInputFieldVersion = "version"
 )
 
 type MonitoringInput struct {
 	Answers map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	Version string            `json:"version,omitempty" yaml:"version,omitempty"`
 }

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_monitoring_output.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_monitoring_output.go
@@ -3,8 +3,10 @@ package client
 const (
 	MonitoringOutputType         = "monitoringOutput"
 	MonitoringOutputFieldAnswers = "answers"
+	MonitoringOutputFieldVersion = "version"
 )
 
 type MonitoringOutput struct {
 	Answers map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	Version string            `json:"version,omitempty" yaml:"version,omitempty"`
 }


### PR DESCRIPTION
**Problem:**
monitoring version is currently hardcoded in rancher server code.
Monitoring API should allow UI to pass the monitoring version to the backend.

**Solution:**
Add support to accept monitoring version in Rancher api
https://github.com/rancher/types/pull/909

**Issue:**
rancher#21460
