### PR TITLE
Support exist condition for metric alert

### DIFF
--- a/pkg/controllers/user/alert/deployer/notification_template.go
+++ b/pkg/controllers/user/alert/deployer/notification_template.go
@@ -105,7 +105,11 @@ Project Name: {{ .Labels.project_name}}{{ end }}
 {{- if .Labels.pod_name }}
 Pod Name: {{ .Labels.pod_name}}{{ else if .Labels.pod -}}Pod Name: {{ .Labels.pod}}{{ end }}
 Expression: {{ .Labels.expression}}
+{{- if .Labels.threshold_value }}
 Description: Threshold Crossed: datapoint value {{ .Annotations.current_value}} was {{ .Labels.comparison}} to the threshold ({{ .Labels.threshold_value}}) for ({{ .Labels.duration}})
+{{- else}}
+Description: The configured event happened for ({{ .Labels.duration}}): expression matched, datapoint value is {{ .Annotations.current_value}}
+{{ end -}}
 {{ end -}}
 {{- if .Labels.logs }}
 Logs: {{ .Labels.logs}}
@@ -177,7 +181,11 @@ Pod Name: {{.Labels.pod_name}}{{ else if .Labels.pod -}}Pod Name: {{.Labels.pod}
 Namespace: {{.Labels.namespace}}<br>
 {{ end -}}
 Expression: {{.Labels.expression}}<br>
+{{- if .Labels.threshold_value }}
 Description: Threshold Crossed: datapoint value {{ .Annotations.current_value}} was {{ .Labels.comparison}} to the threshold ({{ .Labels.threshold_value}}) for ({{ .Labels.duration}})<br>
+{{- else}}
+Description: The configured event happened for ({{ .Labels.duration}}): expression matched, datapoint value is {{ .Annotations.current_value}}<br>
+{{ end -}}
 {{ end -}}
 {{- if .Labels.logs }}
 Logs: {{ .Labels.logs}}

--- a/pkg/controllers/user/alert/manager/prometheus_operator.go
+++ b/pkg/controllers/user/alert/manager/prometheus_operator.go
@@ -20,6 +20,7 @@ import (
 )
 
 var (
+	ComparisonHasValue       = "has-value"
 	ComparisonEqual          = "equal"
 	ComparisonNotEqual       = "not-equal"
 	ComparisonGreaterThan    = "greater-than"
@@ -30,6 +31,7 @@ var (
 
 var (
 	comparisonMap = map[string]string{
+		ComparisonHasValue:       "",
 		ComparisonEqual:          "==",
 		ComparisonNotEqual:       "!=",
 		ComparisonGreaterThan:    ">",
@@ -175,7 +177,7 @@ func Metric2Rule(groupID, ruleID, serverity, displayName, clusterName, projectNa
 }
 
 func getExpr(expr, comparison string, thresholdValue float64) string {
-	if comparison != "" {
+	if comparison != ComparisonHasValue {
 		return fmt.Sprintf("%s%s%v", expr, comparisonMap[comparison], thresholdValue)
 	}
 	return expr


### PR DESCRIPTION
Problem:
Now we only support compare condition and the threshold for metric alert

Solution:
Add exist condition for metric alert

Issue:
https://github.com/rancher/rancher/issues/21302

Types:
https://github.com/rancher/types/pull/914