### PR TITLE
Remove example feature

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -54,7 +54,6 @@ import (
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/controllers/management/compose/common"
 	md "github.com/rancher/rancher/pkg/controllers/management/kontainerdrivermetadata"
-	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/nodeconfig"
 	sourcecodeproviders "github.com/rancher/rancher/pkg/pipeline/providers"
@@ -664,7 +663,6 @@ func KontainerDriver(schemas *types.Schemas, management *config.ScaledContext) {
 	schema.CollectionFormatter = kontainerdriver.CollectionFormatter
 	schema.Formatter = kontainerdriver.NewFormatter(management)
 	schema.Store = kontainerdriver.NewStore(management, schema.Store)
-	schema.Enabled = features.ClusterRandomizer.Enabled
 	kontainerDriverValidator := kontainerdriver.Validator{
 		KontainerDriverLister: management.Management.KontainerDrivers("").Controller().Lister(),
 	}

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -16,8 +16,6 @@ var (
 	features = make(map[string]*feature)
 
 	// Features, ex.: ClusterRandomName = newFeature("cluster-randomizer", false)
-
-	ClusterRandomizer = newFeature("cluster-randomizer", true)
 )
 
 type feature struct {


### PR DESCRIPTION
Example feature, and its assignment to kontainerdriver was intended for demonstrations and testing. It is being taken out as it does not serve a purpose.