### PR TITLE
exclude lxcfs and tmpfs devices from node storage check

### DIFF
--- a/pkg/controllers/user/alert/initdata.go
+++ b/pkg/controllers/user/alert/initdata.go
@@ -239,7 +239,7 @@ var entries = []entry{
 					},
 					MetricRule: &v3.MetricRule{
 						Description: "Device on node is running full within the next 24 hours",
-						Expression:  `predict_linear(node_filesystem_free_bytes{mountpoint!~"^/etc/(?:resolv.conf|hosts|hostname)$"}[6h], 3600 * 24) < 0`,
+						Expression:  `predict_linear(node_filesystem_free_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}[6h], 3600 * 24) < 0`,
 						Comparison:  manager.ComparisonHasValue,
 						Duration:    "10m",
 					},


### PR DESCRIPTION
it fixes the issue that was described on https://forums.rancher.com/t/rancher-monitoring-is-falsely-alerting-on-var-lib-lxcfs-running-out-of-disk-space/14513