### PR TITLE
Revert "mark linode active by default"

### DIFF
--- a/app/machinedriver_data.go
+++ b/app/machinedriver_data.go
@@ -60,7 +60,7 @@ func addMachineDrivers(management *config.ManagementContext) error {
 	}
 	if err := addMachineDriver(nodetemplate.Linodedriver, "https://github.com/linode/docker-machine-driver-linode/releases/download/v0.1.7/docker-machine-driver-linode_linux-amd64.zip",
 		"https://linode.github.io/rancher-ui-driver-linode/releases/v0.3.0-alpha.1/component.js", "faaf1d7d53b55a369baeeb0855b069921a36131868fe3641eb595ac1ff4cf16f",
-		[]string{"linode.github.io", "api.linode.com"}, true, false, management); err != nil {
+		[]string{"linode.github.io", "api.linode.com"}, false, false, management); err != nil {
 		return err
 	}
 	if err := addMachineDriver("openstack", "local://", "", "", nil, false, true, management); err != nil {


### PR DESCRIPTION
This reverts commit 4dc6f7c9fcb92c65fa9acf758ed9bc49e18096b0.