### PR TITLE
Use ClusterName for KubeConfig User's name

### DIFF
--- a/pkg/kubeconfig/templates.go
+++ b/pkg/kubeconfig/templates.go
@@ -16,7 +16,7 @@ clusters:
 {{- end}}
 
 users:
-- name: "{{.User}}"
+- name: "{{.ClusterName}}"
   user:
     token: "{{.Token}}"
 
@@ -24,7 +24,7 @@ contexts:
 {{- range .Nodes}}
 - name: "{{.ClusterName}}"
   context:
-    user: "{{.User}}"
+    user: "{{.ClusterName}}"
     cluster: "{{.ClusterName}}"
 {{- end}}
 
@@ -40,7 +40,7 @@ clusters:
     api-version: v1
 
 users:
-- name: "{{.User}}"
+- name: "{{.ClusterName}}"
   user:
     username: "{{.Username}}"
     password: "{{.Password}}"
@@ -48,7 +48,7 @@ users:
 contexts:
 - name: "{{.ClusterName}}"
   context:
-    user: "{{.User}}"
+    user: "{{.ClusterName}}"
     cluster: "{{.ClusterName}}"
 
 current-context: "{{.ClusterName}}"


### PR DESCRIPTION
Currently the user name is always the same for every config you generate
(`u-xxxxx`), so the kubeconfigs for 2 clusters cannot be merged together.

Instead, Generate kubeconfigs with the User, Context, and Cluster name all
set to the cluster `name`, so that the configs of any two clusters (with
different names...) can be merged together successfully by kubectl.