### PR TITLE
Add notifier-config-syncer

### DIFF
--- a/pkg/controllers/user/alert/controller.go
+++ b/pkg/controllers/user/alert/controller.go
@@ -43,6 +43,8 @@ func Register(ctx context.Context, cluster *config.UserContext) {
 	clusterAlertGroups := cluster.Management.Management.ClusterAlertGroups(cluster.ClusterName)
 	projectAlertGroups := cluster.Management.Management.ProjectAlertGroups("")
 
+	notifiers := cluster.Management.Management.Notifiers(cluster.ClusterName)
+
 	deploy := deployer.NewDeployer(cluster, alertmanager)
 	clusterAlertGroups.AddClusterScopedHandler(ctx, "cluster-alert-group-deployer", cluster.ClusterName, deploy.ClusterGroupSync)
 	projectAlertGroups.AddClusterScopedHandler(ctx, "project-alert-group-deployer", cluster.ClusterName, deploy.ProjectGroupSync)
@@ -56,6 +58,7 @@ func Register(ctx context.Context, cluster *config.UserContext) {
 
 	clusterAlertRules.AddClusterScopedHandler(ctx, "cluster-alert-rule-controller", cluster.ClusterName, configSyncer.ClusterRuleSync)
 	projectAlertRules.AddClusterScopedHandler(ctx, "project-alert-rule-controller", cluster.ClusterName, configSyncer.ProjectRuleSync)
+	notifiers.AddClusterScopedHandler(ctx, "notifier-config-syncer", cluster.ClusterName, configSyncer.NotifierSync)
 
 	cleaner := &alertGroupCleaner{
 		clusterName:        cluster.ClusterName,


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/21127

Problem:
When notifiers are updated, configurations of alert-manager are not
synced.

Solution:
Sync configs on notifier updates


We used to do the sync in [v2.1](https://github.com/rancher/rancher/blob/release/v2.1/pkg/controllers/user/alert/controller.go#L39). This is probably a regression if it is not intentionally dropped.