### PR TITLE
Cluster/project owners should be able to see app revisions

### DIFF
--- a/app/role_data.go
+++ b/app/role_data.go
@@ -125,6 +125,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("management.cattle.io").resources("projects").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectroletemplatebindings").verbs("get", "list", "watch").
 		addRule().apiGroups("project.cattle.io").resources("apps").verbs("get", "list", "watch").
+		addRule().apiGroups("project.cattle.io").resources("apprevisions").verbs("get", "list", "watch").
 		addRule().apiGroups("").resources("namespaces").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("persistentvolumes").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("storageclasses").verbs("get", "list", "watch").
@@ -169,6 +170,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 	rb.addRoleTemplate("Project Owner", "project-owner", "project", true, false, false, false).
 		addRule().apiGroups("management.cattle.io").resources("projectroletemplatebindings").verbs("*").
 		addRule().apiGroups("project.cattle.io").resources("apps").verbs("*").
+		addRule().apiGroups("project.cattle.io").resources("apprevisions").verbs("*").
 		addRule().apiGroups("project.cattle.io").resources("pipelines").verbs("*").
 		addRule().apiGroups("project.cattle.io").resources("pipelineexecutions").verbs("*").
 		addRule().apiGroups("project.cattle.io").resources("pipelinesettings").verbs("*").
@@ -200,6 +202,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 	rb.addRoleTemplate("Project Member", "project-member", "project", true, false, false, false).
 		addRule().apiGroups("management.cattle.io").resources("projectroletemplatebindings").verbs("get", "list", "watch").
 		addRule().apiGroups("project.cattle.io").resources("apps").verbs("*").
+		addRule().apiGroups("project.cattle.io").resources("apprevisions").verbs("*").
 		addRule().apiGroups("project.cattle.io").resources("pipelines").verbs("*").
 		addRule().apiGroups("project.cattle.io").resources("pipelineexecutions").verbs("*").
 		addRule().apiGroups("").resources("namespaces").verbs("create").
@@ -229,6 +232,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 	rb.addRoleTemplate("Read-only", "read-only", "project", true, false, false, false).
 		addRule().apiGroups("management.cattle.io").resources("projectroletemplatebindings").verbs("get", "list", "watch").
 		addRule().apiGroups("project.cattle.io").resources("apps").verbs("get", "list", "watch").
+		addRule().apiGroups("project.cattle.io").resources("apprevisions").verbs("get", "list", "watch").
 		addRule().apiGroups("project.cattle.io").resources("pipelines").verbs("get", "list", "watch").
 		addRule().apiGroups("project.cattle.io").resources("pipelineexecutions").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("persistentvolumes").verbs("get", "list", "watch").
@@ -261,6 +265,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		"replicasets", "replicasets/scale", "replicationcontrollers/scale", "horizontalpodautoscalers").verbs("*").
 		addRule().apiGroups("*").resources("limitranges", "pods/log", "pods/status", "replicationcontrollers/status", "resourcequotas", "resourcequotas/status", "bindings").verbs("get", "list", "watch").
 		addRule().apiGroups("project.cattle.io").resources("apps").verbs("*").
+		addRule().apiGroups("project.cattle.io").resources("apprevisions").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("projectmonitorgraphs").verbs("get", "list", "watch")
 
 	rb.addRoleTemplate("View Workloads", "workloads-view", "project", true, false, false, false).
@@ -270,6 +275,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		"replicasets", "replicasets/scale", "replicationcontrollers/scale", "horizontalpodautoscalers").verbs("get", "list", "watch").
 		addRule().apiGroups("*").resources("limitranges", "pods/log", "pods/status", "replicationcontrollers/status", "resourcequotas", "resourcequotas/status", "bindings").verbs("get", "list", "watch").
 		addRule().apiGroups("project.cattle.io").resources("apps").verbs("get", "list", "watch").
+		addRule().apiGroups("project.cattle.io").resources("apprevisions").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("projectmonitorgraphs").verbs("get", "list", "watch")
 
 	rb.addRoleTemplate("Manage Ingress", "ingress-manage", "project", true, false, false, false).

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -21,6 +21,7 @@ const (
 
 var projectManagmentPlaneResources = map[string]string{
 	"apps":                        "project.cattle.io",
+	"apprevisions":                "project.cattle.io",
 	"catalogtemplates":            "management.cattle.io",
 	"catalogtemplateversions":     "management.cattle.io",
 	"pipelines":                   "project.cattle.io",

--- a/tests/integration/suite/test_rbac.py
+++ b/tests/integration/suite/test_rbac.py
@@ -495,9 +495,20 @@ def test_member_can_perform_app_action(admin_mc, admin_pc, remove_resource,
         action_name="upgrade",
         answers={"asdf": "asdf"})
 
-    '''
-        TODO: write rollback test, currently blocked by issue #20204
-    '''
+    def _app_revisions_exist():
+        a = admin_pc.client.reload(app)
+        return len(a.revision().data) > 0
+
+    wait_for(_app_revisions_exist, fail_handler=lambda: 'no revisions exist')
+    proj_user_client = user_project_client(user_mc, project)
+    app = proj_user_client.reload(app)
+    revID = app.revision().data[0]['id']
+    revID = revID.split(":")[1] if ":" in revID else revID
+    user.client.action(
+        obj=app,
+        action_name="rollback",
+        revisionId=revID
+    )
 
 
 def test_readonly_cannot_edit_secret(admin_mc, user_mc, admin_pc,


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/20204

* Adding to `projectManagmentPlaneResources` is required to allow users who are solely cluster owners to access revisions.
* Adding to role_data.go is required to allow project specific users to access revisions, it's matched with `apps` permissions for uniformity, since apps and their revisions should be 1:1. 

### QA

1. Create a user that is a cluster owner on a non-local cluster. Launch an app, after it loads you should be able to see revisions. 
2. Same as step 1 but as a project owner. 