### PR TITLE
Fix node taints not showing

### DIFF
--- a/pkg/taints/utils.go
+++ b/pkg/taints/utils.go
@@ -12,6 +12,10 @@ func GetTaintsString(taint v1.Taint) string {
 	return fmt.Sprintf("%s=%s:%s", taint.Key, taint.Value, taint.Effect)
 }
 
+func GetKeyEffectString(taint v1.Taint) string {
+	return fmt.Sprintf("%s:%s", taint.Key, taint.Effect)
+}
+
 func GetTaintFromString(taintStr string) *v1.Taint {
 	taintStruct := strings.Split(taintStr, "=")
 	if len(taintStruct) != 2 {
@@ -37,6 +41,14 @@ func GetTaintSet(taints []v1.Taint) map[string]int {
 	rtn := map[string]int{}
 	for i, taint := range taints {
 		rtn[GetTaintsString(taint)] = i
+	}
+	return rtn
+}
+
+func GetKeyEffectTaintSet(taints []v1.Taint) map[string]int {
+	rtn := map[string]int{}
+	for i, taint := range taints {
+		rtn[GetKeyEffectString(taint)] = i
 	}
 	return rtn
 }


### PR DESCRIPTION
**Problem:**
The node taints won't be set if there have duplicated taints in
node template and node pool.

**Solution:**
For the new node from node pool, the taints with same key and template
will respect the one from the node pool. The other taints from the node
template will be added to newly create node.

https://github.com/rancher/rancher/issues/13972