### PR TITLE
Change permissions on cluster and node agent

### DIFF
--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -130,6 +130,7 @@ spec:
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-{{.TokenKey}}
+          defaultMode: 320
 
 ---
 
@@ -209,6 +210,7 @@ spec:
       - name: cattle-credentials
         secret:
           secretName: cattle-credentials-{{.TokenKey}}
+          defaultMode: 320
       - hostPath:
           path: /etc/docker/certs.d
           type: DirectoryOrCreate


### PR DESCRIPTION
The previous permissions defaulted to 644. The permissions are now
500 (octal) which is 320 in decimal.
P.S. When modifying defaultMode use decimal always to avoid conversion
errors. chmod 500 -> defaultMode: 320