### PR TITLE
fix for multiline configurationSnippet

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -21,5 +21,5 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 # Render Values in configurationSnippet
 {{- define "configurationSnippet" -}}
-  {{- tpl (.Values.ingress.configurationSnippet) . -}}
+  {{- tpl (.Values.ingress.configurationSnippet) . | nindent 6 -}}
 {{- end -}}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
 {{- if .Values.ingress.configurationSnippet }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{ template "configurationSnippet" . }}
+      {{- template "configurationSnippet" . }}
 {{- end }}
 {{- if eq .Values.tls "external" }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false" # turn off ssl redirect for external.

--- a/chart/tests/ingress_test.yaml
+++ b/chart/tests/ingress_test.yaml
@@ -23,7 +23,7 @@ tests:
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
 - it: should over write proxy-connect-timeout
-  set: 
+  set:
     ingress.extraAnnotations:
       nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
   asserts:
@@ -39,7 +39,7 @@ tests:
     hostname: test
     ingress.tls.source: secret
   asserts:
-  - isNull: 
+  - isNull:
       path: certmanager\.k8s\.io/issuer
   - contains:
       path: spec.tls
@@ -52,7 +52,7 @@ tests:
     hostname: host.example.com
     ingress:
       configurationSnippet: |
-        more_set_input_headers X-Forwarded-Host {{ .Values.hostname }};
+        more_set_input_headers "X-Forwarded-Host: {{ .Values.hostname }}";
   asserts:
   - equal:
       path: metadata.annotations
@@ -62,4 +62,22 @@ tests:
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
         nginx.ingress.kubernetes.io/configuration-snippet: |
-          more_set_input_headers X-Forwarded-Host host.example.com;
+          more_set_input_headers "X-Forwarded-Host: host.example.com";
+- it: should be able to set multiple lines using configurationSnippet
+  set:
+    hostname: host.example.com
+    ingress:
+      configurationSnippet: |
+        more_set_input_headers "X-Forwarded-Host: {{ .Values.hostname }}";
+        more_set_input_headers "foo: bar";
+  asserts:
+  - equal:
+      path: metadata.annotations
+      value:
+        certmanager.k8s.io/issuer: RELEASE-NAME-rancher
+        nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+          more_set_input_headers "X-Forwarded-Host: host.example.com";
+          more_set_input_headers "foo: bar";

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -53,7 +53,7 @@ ingress:
 
   # configurationSnippet - Add additional Nginx configuration. This example statically sets a header on the ingress.
   # configurationSnippet: |
-  #   more_set_input_headers X-Forwarded-Host {{ .Values.hostname }};
+  #   more_set_input_headers "X-Forwarded-Host: {{ .Values.hostname }}";
 
   tls:
     # options: rancher, letsEncrypt, secret


### PR DESCRIPTION
Current behavior if you set a `configurationSnippet` that is more than one line does not respect indentation for any line after the first one:
```
  annotations:
    nginx.ingress.kubernetes.io/configuration-snippet: |
      more_set_input_headers "foo: bar";
more_set_input_headers "bar: baz";
```

This PR fixes the helm templating so that the lines are indented properly.

```
  annotations:
    nginx.ingress.kubernetes.io/configuration-snippet: |
      more_set_input_headers "foo: bar";
      more_set_input_headers "bar: baz";
```