### PR TITLE
Backport:  Check inherited role for project/cluster member

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -125,8 +125,11 @@ func (c *crtbLifecycle) reconcilBindings(binding *v3.ClusterRoleTemplateBinding)
 	if cluster == nil {
 		return errors.Errorf("cannot create binding because cluster %v was not found", clusterName)
 	}
-
-	isOwnerRole := binding.RoleTemplateName == "cluster-owner"
+	// if roletemplate is not builtin, check if it's inherited/cloned
+	isOwnerRole, err := c.mgr.checkReferencedRoles(binding.RoleTemplateName)
+	if err != nil {
+		return err
+	}
 	var clusterRoleName string
 	if isOwnerRole {
 		clusterRoleName = strings.ToLower(fmt.Sprintf("%v-clusterowner", clusterName))

--- a/tests/integration/suite/test_role_template.py
+++ b/tests/integration/suite/test_role_template.py
@@ -118,6 +118,32 @@ def test_context_crtb(admin_mc, admin_cc, remove_resource,
     assert "Cannot edit" in e.value.error.message
 
 
+def test_cloned_role_permissions(admin_mc, remove_resource, user_factory,
+                                 admin_pc):
+    client = admin_mc.client
+    rt_name = random_str()
+    rt = client.create_role_template(name=rt_name, context="project",
+                                     roleTemplateIds=["project-owner"])
+    remove_resource(rt)
+    wait_for_role_template_creation(admin_mc, rt_name)
+
+    # user with cloned project owner role should be able to enable monitoring
+    cloned_user = user_factory()
+    remove_resource(cloned_user)
+
+    prtb = admin_mc.client.create_project_role_template_binding(
+        name="prtb-" + random_str(),
+        userId=cloned_user.user.id,
+        projectId=admin_pc.project.id,
+        roleTemplateId=rt.id
+    )
+    remove_resource(prtb)
+    wait_until_available(cloned_user.client, admin_pc.project)
+
+    project = cloned_user.client.by_id_project(admin_pc.project.id)
+    assert project.actions.enableMonitoring
+
+
 def wait_for_role_template_creation(admin_mc, rt_name, timeout=60):
     start = time.time()
     interval = 0.5


### PR DESCRIPTION
The auth controller creates rolebindings for a project member in the
project's cluster's namespace along with those in project's namespaces.
The rolebinding in cluster's ns, is either projectmember or projectowner,
depending on the prtb's roleTemplateName. This doesn't take into consideration
the inherited/cloned roles. This commit gets the parent builtin role
and creates projectmember or projectowner rb accordingly.
Same for cluster rb