### PR TITLE
Create rolebindings for etcdbackups in cluster's ns

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -33,6 +33,7 @@ var clusterManagmentPlaneResources = map[string]string{
 	"clustermonitorgraphs":                     "management.cattle.io",
 	"clusterregistrationtokens":                "management.cattle.io",
 	"clusterroletemplatebindings":              "management.cattle.io",
+	"etcdbackups":                              "management.cattle.io",
 	"nodes":                                    "management.cattle.io",
 	"nodepools":                                "management.cattle.io",
 	"notifiers":                                "management.cattle.io",

--- a/tests/integration/suite/test_etcdbackups.py
+++ b/tests/integration/suite/test_etcdbackups.py
@@ -1,0 +1,32 @@
+from .conftest import wait_until
+import kubernetes
+
+
+role_template = "backups-manage"
+
+
+def test_access_to_etcd_backups(admin_mc, user_factory, remove_resource):
+    client = admin_mc.client
+    restricted_user = user_factory(globalRoleId='user-base')
+
+    # add user to local cluster with "Manage cluster backups" role
+    crtb_rstrd = client.create_cluster_role_template_binding(
+        clusterId="local",
+        roleTemplateId=role_template,
+        userId=restricted_user.user.id, )
+    remove_resource(crtb_rstrd)
+    wait_until(crtb_cb(client, crtb_rstrd))
+
+    # check that role "backups-manage" was created in the cluster
+    rbac = kubernetes.client.RbacAuthorizationV1Api(admin_mc.k8s_client)
+    role = rbac.read_namespaced_role(role_template, "local")
+    assert role is not None
+    assert "etcdbackups" in role.rules[0].resources
+
+
+def crtb_cb(client, crtb):
+    """Wait for the crtb to have the userId populated"""
+    def cb():
+        c = client.reload(crtb)
+        return c.userPrincipalId is not None
+    return cb


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/20911

Although etcdbackups are scoped to a cluster, they are rancher mgmt resources,
and need to be added to the `clusterManagmentPlaneResources` list. The crtb_handler.go
ensures all cluster members get access to resources in this list by creating
role bindings.
The "user" global role has get/list/watch permissions on etcdbackups, so cluster
members with 'user" role don't need this and will be able to see etcdbackups
even without this resource being in the `clusterManagmentPlaneResources` list.
But any user having "user-base" global role or created with any custom permissions
will require this change so they can see the etcdbackups in their cluster.