### PR TITLE
Handling HA install rancher local cluster may has empty value for field dockerRootDir

### DIFF
--- a/app/cluster_data.go
+++ b/app/cluster_data.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"github.com/rancher/rancher/pkg/settings"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +18,9 @@ func addLocalCluster(embedded bool, adminName string, management *config.Managem
 		Spec: v3.ClusterSpec{
 			Internal:    true,
 			DisplayName: "local",
+			ClusterSpecBase: v3.ClusterSpecBase{
+				DockerRootDir: settings.InitialDockerRootDir.Get(),
+			},
 		},
 		Status: v3.ClusterStatus{
 			Driver: v3.ClusterDriverImported,

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -65,6 +65,7 @@ var (
 	APIUIVersion                      = NewSetting("api-ui-version", "1.1.6")                // Please update the CATTLE_API_UI_VERSION in package/Dockerfile when updating the version here.
 	RotateCertsIfExpiringInDays       = NewSetting("rotate-certs-if-expiring-in-days", "7")  // 7 days
 	ClusterTemplateEnforcement        = NewSetting("cluster-template-enforcement", "false")
+	InitialDockerRootDir              = NewSetting("initial-docker-root-dir", "/var/lib/docker")
 )
 
 func init() {


### PR DESCRIPTION
Problem:
In HA installed rancher, local cluster is created by backend, not UI, field dockerRootDir may have an empty value

Solution:
Check dockerRootDir one more time when enable logging

Issue:
https://github.com/rancher/rancher/issues/21112