### PR TITLE
Add hostname validation for google oauth

### DIFF
--- a/pkg/auth/providers/googleoauth/goauth_helper.go
+++ b/pkg/auth/providers/googleoauth/goauth_helper.go
@@ -14,13 +14,18 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
-func (g *googleOauthProvider) getUserInfoAndGroups(adminSvc *admin.Service, gOAuthToken *oauth2.Token, config *v3.GoogleOauthConfig) (v3.Principal, []v3.Principal, error) {
+func (g *googleOauthProvider) getUserInfoAndGroups(adminSvc *admin.Service, gOAuthToken *oauth2.Token, config *v3.GoogleOauthConfig, testAndEnableAction bool) (v3.Principal, []v3.Principal, error) {
 	var userPrincipal v3.Principal
 	var groupPrincipals []v3.Principal
 	// use the access token to make requests, get user info
 	user, err := g.goauthClient.getUser(gOAuthToken.AccessToken, config)
 	if err != nil {
 		return userPrincipal, groupPrincipals, err
+	}
+	if testAndEnableAction {
+		if user.HostedDomain != config.Hostname {
+			return userPrincipal, groupPrincipals, fmt.Errorf("invalid hostname provided")
+		}
 	}
 	userPrincipal = g.toPrincipal(userType, *user, nil)
 	userPrincipal.Me = true

--- a/pkg/auth/providers/googleoauth/goauth_provider.go
+++ b/pkg/auth/providers/googleoauth/goauth_provider.go
@@ -107,7 +107,7 @@ func (g *googleOauthProvider) loginUser(c context.Context, googleOAuthCredential
 	if err != nil {
 		return userPrincipal, groupPrincipals, "", err
 	}
-	userPrincipal, groupPrincipals, err = g.getUserInfoAndGroups(adminSvc, gOAuthToken, config)
+	userPrincipal, groupPrincipals, err = g.getUserInfoAndGroups(adminSvc, gOAuthToken, config, testAndEnableAction)
 	if err != nil {
 		return userPrincipal, groupPrincipals, "", err
 	}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/21412

This commit validates the hostname provided while configuring google oauth. When the test user logs into their google account, we get the hostname as one of the attributes of that user. So this commit checks that the hostname from user's attributes matches the hostname provided in the authconfig.