### PR TITLE
Return the icon url to the template to display in the UI

### DIFF
--- a/pkg/catalog/helm/helm.go
+++ b/pkg/catalog/helm/helm.go
@@ -530,6 +530,9 @@ func (h *Helm) fetchIcon(iconURL, versionDir string) ([]byte, string, string, er
 	if strings.HasPrefix(iconURL, "file:") {
 		return h.iconFromFile(iconURL, versionDir)
 	}
+	if strings.HasPrefix(iconURL, "http:") || strings.HasPrefix(iconURL, "https:") {
+		return nil, "", iconURL, nil
+	}
 	return nil, "", "", errors.Errorf("unknown file type [%s]", iconURL)
 }
 


### PR DESCRIPTION
Problem: The icon url was not returned to the template so the template
would not display icons for charts with remote icons.

Solution: Do not fetch the icon but still return the url of the icon
to the template.