### PR TITLE
[2.2] Return the icon url to the template to display in the UI

### DIFF
--- a/pkg/api/customization/catalog/template.go
+++ b/pkg/api/customization/catalog/template.go
@@ -84,7 +84,7 @@ func (t TemplateWrapper) TemplateIconHandler(apiContext *types.APIContext, next 
 		if err := access.ByID(apiContext, apiContext.Version, apiContext.Type, apiContext.ID, template); err != nil {
 			return err
 		}
-		if template.Icon == "" {
+		if template.Icon == "" || strings.HasPrefix(template.Icon, "http:") || strings.HasPrefix(template.Icon, "https:") {
 			http.Error(apiContext.Response, "", http.StatusNoContent)
 			return nil
 		}
@@ -130,6 +130,9 @@ func (t TemplateWrapper) TemplateIconHandler(apiContext *types.APIContext, next 
 
 		iconReader := bytes.NewReader(iconBytes)
 		apiContext.Response.Header().Set("Cache-Control", "private, max-age=604800")
+		// add security headers (similar to raw.githubusercontent)
+		apiContext.Response.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
+		apiContext.Response.Header().Set("X-Content-Type-Options", "nosniff")
 		http.ServeContent(apiContext.Response, apiContext.Request, template.IconFilename, t, iconReader)
 		return nil
 	default:

--- a/pkg/catalog/helm/helm.go
+++ b/pkg/catalog/helm/helm.go
@@ -530,6 +530,9 @@ func (h *Helm) fetchIcon(iconURL, versionDir string) ([]byte, string, string, er
 	if strings.HasPrefix(iconURL, "file:") {
 		return h.iconFromFile(iconURL, versionDir)
 	}
+	if strings.HasPrefix(iconURL, "http:") || strings.HasPrefix(iconURL, "https:") {
+		return nil, "", iconURL, nil
+	}
 	return nil, "", "", errors.Errorf("unknown file type [%s]", iconURL)
 }
 


### PR DESCRIPTION
Problem: The icon url was not returned to the template so the template
    would not display icons for charts with remote icons.

Solution: Do not fetch the icon but still return the url of the icon
    to the template