### PR TITLE
RBAC changes for etcdbackups

### DIFF
--- a/app/role_data.go
+++ b/app/role_data.go
@@ -66,7 +66,6 @@ func addRoles(management *config.ManagementContext) (string, error) {
 		addRule().apiGroups("management.cattle.io").resources("multiclusterapps", "globaldnses", "globaldnsproviders").verbs("create").
 		addRule().apiGroups("project.cattle.io").resources("sourcecodecredentials").verbs("*").
 		addRule().apiGroups("project.cattle.io").resources("sourcecoderepositories").verbs("*").
-		addRule().apiGroups("management.cattle.io").resources("etcdbackups").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("rkek8ssystemimages").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("rkek8sserviceoptions").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("rkeaddons").verbs("get", "list", "watch")

--- a/tests/integration/suite/test_etcdbackups.py
+++ b/tests/integration/suite/test_etcdbackups.py
@@ -5,7 +5,7 @@ import kubernetes
 role_template = "backups-manage"
 
 
-def test_access_to_etcd_backups(admin_mc, user_factory, remove_resource):
+def test_backups_manage_role(admin_mc, user_factory, remove_resource):
     client = admin_mc.client
     restricted_user = user_factory(globalRoleId='user-base')
 
@@ -22,6 +22,13 @@ def test_access_to_etcd_backups(admin_mc, user_factory, remove_resource):
     role = rbac.read_namespaced_role(role_template, "local")
     assert role is not None
     assert "etcdbackups" in role.rules[0].resources
+
+
+def test_standard_users_cannot_access_backups(admin_mc, user_factory):
+    client = admin_mc.client
+    user_role = client.by_id_global_role("user")
+    for r in user_role['rules']:
+        assert "etcdbackups" not in r['resources']
 
 
 def crtb_cb(client, crtb):


### PR DESCRIPTION
This commit removes get/list/watch permissions on etcdbackups that "user"
globalRole had. Because this was also granting project members access to backups.

Also this commit checks if user has "create" permission for etcdbackup for the
backupEtcd actionHandler. Till now it checked if user has the permission to "update"
the cluster. Users added with "backups-manage" role won't have rights to update clusters,
hence won't be able to create etcdbackups either in spite of being granted this role.
This issue is resolved by checking for permissions on etcdbackups instead

https://github.com/rancher/rancher/issues/20911#issuecomment-518332555