### PR TITLE
Handle upgrades with previously added charts

### DIFF
--- a/pkg/api/customization/catalog/template_test.go
+++ b/pkg/api/customization/catalog/template_test.go
@@ -1,0 +1,45 @@
+package catalog
+
+import "testing"
+
+func Test_containsIconURL(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want string
+	}{
+		{
+			"base",
+			`name: afc616
+			version: 1.21.0
+			appVersion: 6.9.0
+			description: DataDog Agent
+			keywords:
+			- monitoring
+			- alerting
+			- metric
+			home: https://www.datadoghq.com
+			icon: https://raw.githubusercontent.com/matthewbelisle-wf/afc616/master/xss.svg
+			sources:
+			- https://app.datadoghq.com/account/settings#agent/kubernetes
+			- https://github.com/DataDog/datadog-agent
+			maintainers:
+			- name: hkaj
+			email: haissam@datadoghq.com
+			- name: irabinovitch
+			email: ilan@datadoghq.com
+			- name: xvello
+			email: xavier.vello@datadoghq.com
+			- name: charlyf
+			email: charly@datadoghq.com`,
+			"https://raw.githubusercontent.com/matthewbelisle-wf/afc616/master/xss.svg",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findIconURL(tt.s); got != tt.want {
+				t.Errorf("containsIconURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -184,8 +184,9 @@ func Templates(schemas *types.Schemas, managementContext *config.ScaledContext) 
 	schema := schemas.Schema(&managementschema.Version, client.TemplateType)
 
 	wrapper := catalog.TemplateWrapper{
-		TemplateContentClient: managementContext.Management.TemplateContents(""),
-		TemplateVersion:       managementContext.Management.TemplateVersions(""),
+		TemplateContentClients: managementContext.Management.TemplateContents(""),
+		TemplateVersions:       managementContext.Management.TemplateVersions("").Controller().Lister(),
+		TemplateClients:        managementContext.Management.Templates(""),
 	}
 	schema.Formatter = wrapper.TemplateFormatter
 	schema.LinkHandler = wrapper.TemplateIconHandler

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -182,10 +182,12 @@ func Clusters(schemas *types.Schemas, managementContext *config.ScaledContext, c
 
 func Templates(schemas *types.Schemas, managementContext *config.ScaledContext) {
 	schema := schemas.Schema(&managementschema.Version, client.TemplateType)
-	schema.Formatter = catalog.TemplateFormatter
+
 	wrapper := catalog.TemplateWrapper{
 		TemplateContentClient: managementContext.Management.TemplateContents(""),
+		TemplateVersion:       managementContext.Management.TemplateVersions(""),
 	}
+	schema.Formatter = wrapper.TemplateFormatter
 	schema.LinkHandler = wrapper.TemplateIconHandler
 }
 


### PR DESCRIPTION
If the chart has been added previously then the url of the icon will
not be included in the iconFilename. Instead of defaulting to serving
the icons, check if they have a url for the icon in the chart. If they
do, proceed to send the url to the UI and do not serve the icon data.

    