### PR TITLE
Fix pod scheduling problem in windows cluster

### DIFF
--- a/pkg/api/store/workload/toleration_test.go
+++ b/pkg/api/store/workload/toleration_test.go
@@ -1,0 +1,40 @@
+package workload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchedulingRuleFoundLinux(t *testing.T) {
+	type testcase struct {
+		name       string
+		rule       string
+		foundLinux bool
+	}
+	testcases := []testcase{
+		testcase{
+			name:       "rule operator equal",
+			rule:       "beta.kubernetes.io/os = linux",
+			foundLinux: true,
+		},
+		testcase{
+			name:       "rule operator not equal",
+			rule:       "beta.kubernetes.io/os != windows",
+			foundLinux: true,
+		},
+		testcase{
+			name:       "rule operator in",
+			rule:       "beta.kubernetes.io/os in (linux , darwin)",
+			foundLinux: true,
+		},
+		testcase{
+			name:       "rule key not match",
+			rule:       "test = test2",
+			foundLinux: false,
+		},
+	}
+	for _, c := range testcases {
+		assert.Equalf(t, c.foundLinux, schedulingRuleFoundLinux([]string{c.rule}), "case %s failed, function schedulingRuleFoundLinux is not as expected", c.name)
+	}
+}

--- a/pkg/controllers/user/windows/node_test.go
+++ b/pkg/controllers/user/windows/node_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/rancher/rancher/pkg/taints"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/apis/management.cattle.io/v3/fakes"
 	"github.com/stretchr/testify/assert"
@@ -36,7 +37,7 @@ func Test_nodeController(t *testing.T) {
 					Namespace: "local",
 				},
 				Status: v3.NodeStatus{
-					NodeLabels: HostOSLabels[0],
+					NodeLabels: taints.HostOSLabels["beta.kubernetes.io/os"],
 				},
 			},
 			shouldCall: true,
@@ -64,12 +65,12 @@ func Test_nodeController(t *testing.T) {
 				Spec: v3.NodeSpec{
 					InternalNodeSpec: v1.NodeSpec{
 						Taints: []v1.Taint{
-							nodeTaint,
+							taints.NodeTaint,
 						},
 					},
 				},
 				Status: v3.NodeStatus{
-					NodeLabels: HostOSLabels[0],
+					NodeLabels: taints.HostOSLabels["beta.kubernetes.io/os"],
 				},
 			},
 			shouldCall: false,
@@ -86,7 +87,7 @@ func Test_nodeController(t *testing.T) {
 					UpdateTaintsFromAPI: &falseValue,
 				},
 				Status: v3.NodeStatus{
-					NodeLabels: HostOSLabels[0],
+					NodeLabels: taints.HostOSLabels["beta.kubernetes.io/os"],
 				},
 			},
 			shouldCall: false,

--- a/pkg/controllers/user/windows/pod_redeploy_controller.go
+++ b/pkg/controllers/user/windows/pod_redeploy_controller.go
@@ -1,0 +1,45 @@
+package windows
+
+import (
+	util "github.com/rancher/rancher/pkg/controllers/user/workload"
+	apicorev1 "github.com/rancher/types/apis/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// podRedeployController is to delete the pod doesn't have the tolerate configuration but its owner has it.
+// We will only force delete those pod without tolerate configuration.
+type podRedeployController struct {
+	workloadHandler util.CommonController
+	podClient       apicorev1.PodInterface
+}
+
+func (c *podRedeployController) sync(key string, obj *v1.Pod) (runtime.Object, error) {
+	if obj == nil || obj.DeletionTimestamp != nil {
+		return obj, nil
+	}
+	if !canDeployedIntoLinuxNode(obj.Spec) {
+		return obj, nil
+	}
+
+	owner, err := c.workloadHandler.GetWorkloadByOwnerReferences(obj.Namespace, obj.OwnerReferences)
+	if err != nil {
+		return obj, err
+	}
+	if owner == nil {
+		return obj, nil
+	}
+
+	// don't do anything if the owner workload doesn't have the toleration
+	if !tolerationExists(owner.TemplateSpec.Spec.Tolerations) {
+		return obj, nil
+	}
+
+	// if the pod doesn't have the tolerations, we need to delete it and let the owner recreate it.
+	if !tolerationExists(obj.Spec.Tolerations) {
+		return nil, c.podClient.DeleteNamespaced(obj.Namespace, obj.Name, &metav1.DeleteOptions{})
+	}
+
+	return obj, nil
+}

--- a/pkg/controllers/user/windows/register.go
+++ b/pkg/controllers/user/windows/register.go
@@ -18,5 +18,12 @@ func Register(ctx context.Context, cluster *v3.Cluster, userContext *config.User
 	}
 	userContext.Management.Management.Nodes(clusterName).AddClusterScopedHandler(ctx, "linux-node-taints-handler", clusterName, node.sync)
 	workload := &WorkloadTolerationHandler{}
-	workload.workloadController = util.NewWorkloadController(ctx, userContext.UserOnlyContext(), workload.sync)
+	workloadController := util.NewWorkloadController(ctx, userContext.UserOnlyContext(), workload.sync)
+	workload.workloadController = workloadController
+
+	pod := &podRedeployController{
+		workloadHandler: workloadController,
+		podClient:       userContext.Core.Pods(""),
+	}
+	userContext.Core.Pods("").AddHandler(ctx, "linux-pod-redeployer", pod.sync)
 }

--- a/pkg/controllers/user/windows/workload_common_test.go
+++ b/pkg/controllers/user/windows/workload_common_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	util "github.com/rancher/rancher/pkg/controllers/user/workload"
+	"github.com/rancher/rancher/pkg/taints"
 	typesv1beta2 "github.com/rancher/types/apis/apps/v1beta2"
 	v1beta2fakes "github.com/rancher/types/apis/apps/v1beta2/fakes"
 	typesbatchv1 "github.com/rancher/types/apis/batch/v1"
@@ -394,8 +395,8 @@ func validateUpdate(c workloadTestCase, in1 runtime.Object) error {
 		return fmt.Errorf("workload %s should be get in update function", c.reference.workload.Key)
 	}
 	podSpec := getPodSpec(in1)
-	if !helper.TolerationsTolerateTaint(podSpec.Tolerations, &nodeTaint) {
-		return fmt.Errorf("workload %s should have toleration for taint %+v", c.reference.workload.Key, nodeTaint)
+	if !helper.TolerationsTolerateTaint(podSpec.Tolerations, &taints.NodeTaint) {
+		return fmt.Errorf("workload %s should have toleration for taint %+v", c.reference.workload.Key, taints.NodeTaint)
 	}
 	return nil
 }

--- a/pkg/controllers/user/windows/workload_test.go
+++ b/pkg/controllers/user/windows/workload_test.go
@@ -102,7 +102,7 @@ func Test_canDeploy(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		assert.Equalf(t, canDeployedIntoLinuxNode(c.target), c.canDeploy, "failed to tell which workload wants to be deployed into linux, test case: %s", c.name)
+		assert.Equalf(t, canDeployedIntoLinuxNode(c.target.TemplateSpec.Spec), c.canDeploy, "failed to tell which workload wants to be deployed into linux, test case: %s", c.name)
 	}
 }
 

--- a/pkg/controllers/user/workload/workload_common.go
+++ b/pkg/controllers/user/workload/workload_common.go
@@ -849,8 +849,8 @@ func (c CommonController) GetWorkloadByOwnerReferences(ns string, owners []metav
 		return workload, nil
 	}
 	nextWorkload, err := c.GetWorkloadByOwnerReferences(ns, workload.OwnerReferences)
-	if err != nil {
-		return workload, nil
+	if nextWorkload == nil {
+		return workload, err
 	}
 	return nextWorkload, nil
 }


### PR DESCRIPTION
**Problem:**
In windows preferred cluster, the pod create by linux node workload
won't be rescheduled immediately after we add toleration to the workload.

**Solution:**
1. Delete the pods which the pod doesn't have linux node toleration but
its owner workload has it.
2. In windows preferred cluster, we should set workload toleration in
api level. In this case, our controller won't need to add toleration again.


https://github.com/rancher/rancher/issues/20805