### PR TITLE
Fixed spelling of occurred (from occured)

### DIFF
--- a/vendor/github.com/docker/spdystream/connection.go
+++ b/vendor/github.com/docker/spdystream/connection.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	ErrInvalidStreamId   = errors.New("Invalid stream id")
-	ErrTimeout           = errors.New("Timeout occured")
+	ErrTimeout           = errors.New("Timeout occurred")
 	ErrReset             = errors.New("Stream reset")
 	ErrWriteClosedStream = errors.New("Write on closed stream")
 )

--- a/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
+++ b/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
@@ -47,7 +47,7 @@ func (c *LRU) Purge() {
 	c.evictList.Init()
 }
 
-// Add adds a value to the cache.  Returns true if an eviction occured.
+// Add adds a value to the cache.  Returns true if an eviction occurred.
 func (c *LRU) Add(key, value interface{}) bool {
 	// Check for existing item
 	if ent, ok := c.items[key]; ok {

--- a/vendor/github.com/prometheus/common/expfmt/decode.go
+++ b/vendor/github.com/prometheus/common/expfmt/decode.go
@@ -166,7 +166,7 @@ func (sd *SampleDecoder) Decode(s *model.Vector) error {
 // ExtractSamples builds a slice of samples from the provided metric
 // families. If an error occurs during sample extraction, it continues to
 // extract from the remaining metric families. The returned error is the last
-// error that has occured.
+// error that has occurred.
 func ExtractSamples(o *DecodeOptions, fams ...*dto.MetricFamily) (model.Vector, error) {
 	var (
 		all     model.Vector


### PR DESCRIPTION
This is a trivial fix - simply fixing spelling of the word occurred
in all the locations where it was found to be spelt incorrectly.

(there were 164 other instances of the word, but they were spelt correctly)