### PR TITLE
Check if cert is a file before copy

### DIFF
--- a/package/jailer.sh
+++ b/package/jailer.sh
@@ -38,11 +38,11 @@ if [ -d /var/lib/rancher/management-state/bin ] && [ "$(ls -A /var/lib/rancher/m
   )
 fi
 
-if [ -e /etc/ssl/certs/ca-additional.pem ]; then
+if [[ -f /etc/ssl/certs/ca-additional.pem ]]; then
   cp /etc/ssl/certs/ca-additional.pem /opt/jail/$NAME/etc/ssl/certs
 fi
 
-if [ -e /etc/rancher/ssl/cacerts.pem ]; then
+if [[ -f /etc/rancher/ssl/cacerts.pem ]]; then
   cp /etc/rancher/ssl/cacerts.pem /opt/jail/$NAME/etc/ssl/certs
 fi
 


### PR DESCRIPTION
Problem:
Jailer script was verifing the cert existed so if cert is a dir cp will
fail

Solution:
Validate cert is a file before attempting to copy

Issue: https://github.com/rancher/rancher/issues/22068