### PR TITLE
Only allow cluster export on RKE

### DIFF
--- a/pkg/api/customization/cluster/actions_yaml.go
+++ b/pkg/api/customization/cluster/actions_yaml.go
@@ -86,6 +86,11 @@ func (a ActionHandler) ExportYamlHandler(actionName string, action *types.Action
 	if err != nil {
 		return err
 	}
+
+	if cluster.Status.Driver != v3.ClusterDriverRKE {
+		return fmt.Errorf("cluster %v does not support being exported", cluster.Name)
+	}
+
 	topkey := compose.Config{}
 	topkey.Version = "v3"
 	c := mgmtclient.Cluster{}
@@ -128,6 +133,7 @@ func (a ActionHandler) ExportYamlHandler(actionName string, action *types.Action
 		delete(m["nodePools"].(map[string]interface{})[name].(map[string]interface{}), "actions")
 		delete(m["nodePools"].(map[string]interface{})[name].(map[string]interface{}), "links")
 	}
+
 	data, err := json.Marshal(m)
 	if err != nil {
 		return err

--- a/pkg/api/customization/cluster/formatter.go
+++ b/pkg/api/customization/cluster/formatter.go
@@ -24,8 +24,8 @@ func (f *Formatter) Formatter(request *types.APIContext, resource *types.RawReso
 	resource.Links["shell"] = shellLink
 	resource.AddAction(request, v3.ClusterActionGenerateKubeconfig)
 	resource.AddAction(request, v3.ClusterActionImportYaml)
-	resource.AddAction(request, v3.ClusterActionExportYaml)
 	if _, ok := resource.Values["rancherKubernetesEngineConfig"]; ok {
+		resource.AddAction(request, v3.ClusterActionExportYaml)
 		resource.AddAction(request, v3.ClusterActionRotateCertificates)
 		if _, ok := values.GetValue(resource.Values, "rancherKubernetesEngineConfig", "services", "etcd", "backupConfig"); ok {
 			resource.AddAction(request, v3.ClusterActionBackupEtcd)

--- a/tests/integration/suite/test_cluster_defaults.py
+++ b/tests/integration/suite/test_cluster_defaults.py
@@ -37,8 +37,8 @@ def test_generic_initial_defaults(admin_mc):
 
 def test_generic_initial_conditions(admin_mc, remove_resource):
     cluster = admin_mc.client.create_cluster(
-            name=random_str(), amazonElasticContainerServiceConfig={
-                "accessKey": "asdfsd"})
+        name=random_str(), amazonElasticContainerServiceConfig={
+            "accessKey": "asdfsd"})
     remove_resource(cluster)
 
     assert len(cluster.conditions) == 3
@@ -50,12 +50,14 @@ def test_generic_initial_conditions(admin_mc, remove_resource):
 
     assert cluster.conditions[2].type == 'Waiting'
     assert cluster.conditions[2].status == 'Unknown'
+
+    assert 'exportYaml' not in cluster.actions
 
 
 def test_rke_initial_conditions(admin_mc, remove_resource):
     cluster = admin_mc.client.create_cluster(
-            name=random_str(), rancherKubernetesEngineConfig={
-                "accessKey": "asdfsd"})
+        name=random_str(), rancherKubernetesEngineConfig={
+            "accessKey": "asdfsd"})
     remove_resource(cluster)
 
     assert len(cluster.conditions) == 3
@@ -67,6 +69,8 @@ def test_rke_initial_conditions(admin_mc, remove_resource):
 
     assert cluster.conditions[2].type == 'Waiting'
     assert cluster.conditions[2].status == 'Unknown'
+
+    assert 'exportYaml' in cluster.actions
 
 
 def test_import_initial_conditions(admin_mc, remove_resource):


### PR DESCRIPTION
Problem:
Some clusters don't support being exported so an unusable config is
being returned

Solution:
Add an error message and remove export link from non-RKE clusters

Issue: https://github.com/rancher/rancher/issues/21309