### PR TITLE
Trigger crtb controller on project creation

### DIFF
--- a/pkg/controllers/management/auth/project_cluster_handler_test.go
+++ b/pkg/controllers/management/auth/project_cluster_handler_test.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/apis/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const clusterID = "test-cluster"
+
+func TestEnqueueCrtbsOnProjectCreation(t *testing.T) {
+	existingCrtbs := []*v3.ClusterRoleTemplateBinding{
+		{ObjectMeta: v1.ObjectMeta{
+			Name:      "crtb-1",
+			Namespace: clusterID,
+		}},
+		{ObjectMeta: v1.ObjectMeta{
+			Name:      "crtb-2",
+			Namespace: clusterID,
+		}},
+	}
+
+	mockedClusterRoleTemplateBindingController := fakes.ClusterRoleTemplateBindingControllerMock{
+		EnqueueFunc: func(namespace string, name string) {},
+	}
+	c := projectLifecycle{
+		mgr: &mgr{
+			crtbLister: &fakes.ClusterRoleTemplateBindingListerMock{
+				ListFunc: func(namespace string, selector labels.Selector) ([]*v3.ClusterRoleTemplateBinding, error) {
+					return existingCrtbs, nil
+				},
+			},
+			crtbClient: &fakes.ClusterRoleTemplateBindingInterfaceMock{
+				ControllerFunc: func() v3.ClusterRoleTemplateBindingController {
+					return &mockedClusterRoleTemplateBindingController
+				},
+			},
+		},
+	}
+
+	newProject := v3.Project{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-project",
+			Namespace: clusterID,
+		},
+	}
+	c.enqueueCrtbs(&newProject)
+	assert.Equal(t, len(existingCrtbs), len(mockedClusterRoleTemplateBindingController.EnqueueCalls()))
+}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/19589
https://github.com/rancher/rancher/issues/15819

Problem: Users added as cluster-owners cannot create apps/add members in projects added to the
cluster after they have been made cluster-owners

Cause: The crtb controller lists all existing projects and creates rolebindings
in each project for the current crtb's user. So cluster-owners get access to resources
under `projectManagmentPlaneResources` for projects that exist already in the cluster when
they are being added. The same sync needs to happen on adding a new project to the cluster
as well which wasn't happening.

Fix: On project sync, enqueue clusterroletemplatebindings of that project's cluster.