### PR TITLE
Disable delete parent

### DIFF
--- a/pkg/api/customization/roletemplate/roletemplate_test.go
+++ b/pkg/api/customization/roletemplate/roletemplate_test.go
@@ -1,0 +1,83 @@
+package roletemplate
+
+import (
+	"testing"
+
+	"github.com/rancher/norman/types"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/apis/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// testAsRoleTemplate creates resource with ID set to key and runs roletemplate formatter
+func testAsRoletemplate(key string) *types.RawResource {
+	mockRTLister := &fakes.RoleTemplateListerMock{
+		ListFunc: mockList,
+	}
+
+	testWrapper := Wrapper{
+		mockRTLister,
+	}
+
+	testResource := &types.RawResource{
+		ID: key,
+		Links: map[string]string{
+			"update": "/test/link",
+			"remove": "/test/link2",
+		},
+	}
+
+	testWrapper.Formatter(nil, testResource)
+
+	return testResource
+}
+
+func mockList(namespace string, selector labels.Selector) ([]*v3.RoleTemplate, error) {
+	return []*v3.RoleTemplate{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "rt1",
+			},
+			RoleTemplateNames: []string{"asdf", "asdf", "test123"},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "rt2",
+			},
+			RoleTemplateNames: []string{"aasdfsdf", "adsasdff"},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "rt3",
+			},
+			RoleTemplateNames: []string{},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "rt3",
+			},
+			RoleTemplateNames: []string{"test321"},
+		}}, nil
+}
+
+// TestDelete confirms that the remove resource link is filtered when roletemplate is inherited
+func TestDelete(t *testing.T) {
+	assert := assert.New(t)
+
+	// test when roletemplate is not a parent of another roletemplate, should have all links
+	resource := testAsRoletemplate("somekey")
+	assert.Equal(resource.Links["remove"], "/test/link2")
+	assert.Equal(resource.Links["update"], "/test/link")
+
+	// test when roletemplate is a parent of another roletemplate, should not have remove link
+	resource = testAsRoletemplate("test123")
+	assert.Equal(resource.Links["remove"], "")
+	assert.Equal(resource.Links["update"], "/test/link")
+
+	// test when roletemplate is only parent of another roletemplate, should not have remove link
+	resource = testAsRoletemplate("test321")
+	assert.Equal(resource.Links["remove"], "")
+	assert.Equal(resource.Links["update"], "/test/link")
+}

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -45,6 +45,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/store/noopwatching"
 	passwordStore "github.com/rancher/rancher/pkg/api/store/password"
 	"github.com/rancher/rancher/pkg/api/store/preference"
+	rtStore "github.com/rancher/rancher/pkg/api/store/roletemplate"
 	"github.com/rancher/rancher/pkg/api/store/scoped"
 	settingstore "github.com/rancher/rancher/pkg/api/store/setting"
 	"github.com/rancher/rancher/pkg/api/store/userscope"
@@ -643,7 +644,9 @@ func RoleTemplate(schemas *types.Schemas, management *config.ScaledContext) {
 		RoleTemplateLister: management.Management.RoleTemplates("").Controller().Lister(),
 	}
 	schema := schemas.Schema(&managementschema.Version, client.RoleTemplateType)
+	schema.Formatter = rt.Formatter
 	schema.Validator = rt.Validator
+	schema.Store = rtStore.Wrap(schema.Store, management.Management.RoleTemplates("").Controller().Lister())
 }
 
 func KontainerDriver(schemas *types.Schemas, management *config.ScaledContext) {

--- a/pkg/api/store/roletemplate/store.go
+++ b/pkg/api/store/roletemplate/store.go
@@ -1,0 +1,40 @@
+package roletemplate
+
+import (
+	"fmt"
+
+	"github.com/rancher/norman/httperror"
+	"github.com/rancher/norman/types"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func Wrap(store types.Store, rtLister v3.RoleTemplateLister) types.Store {
+	return &rtStore{
+		Store:    store,
+		rtLister: rtLister,
+	}
+}
+
+type rtStore struct {
+	types.Store
+
+	rtLister v3.RoleTemplateLister
+}
+
+func (s *rtStore) Delete(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
+	roleTemplates, err := s.rtLister.List("", labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	// check if roletemplate is referenced as parent by any other roletemplate
+	for _, rt := range roleTemplates {
+		for _, parent := range rt.RoleTemplateNames {
+			if parent == id {
+				return nil, httperror.NewAPIError(httperror.Conflict, fmt.Sprintf("roletemplate [%s] cannot be deleted because roletemplate [%s] inherits from it", id, rt.Name))
+			}
+		}
+	}
+	return s.Store.Delete(apiContext, schema, id)
+}

--- a/pkg/api/store/roletemplate/store_test.go
+++ b/pkg/api/store/roletemplate/store_test.go
@@ -1,0 +1,93 @@
+package roletemplate
+
+import (
+	"testing"
+
+	"github.com/rancher/norman/types"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/apis/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type dummyStore struct{}
+
+// testWithInherited attempt delete given key and inserts the key in  the inherited
+// list for a roletemplate if insertInLister is true.
+func testWithInherited(key string, insertInLister bool) (map[string]interface{}, error) {
+	insert := "randomstringnotusedkey"
+	if insertInLister {
+		insert = key
+	}
+	mockRTLister := &fakes.RoleTemplateListerMock{
+		ListFunc: mockList(insert),
+	}
+
+	testStore := Wrap(dummyStore{}, mockRTLister)
+
+	return testStore.Delete(nil, nil, key)
+}
+
+func mockList(insert string) func(namespace string, selector labels.Selector) ([]*v3.RoleTemplate, error) {
+	return func(namespace string, selector labels.Selector) ([]*v3.RoleTemplate, error) {
+		return []*v3.RoleTemplate{
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "rt1",
+				},
+				RoleTemplateNames: []string{"asdf", "asdf"},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "rt2",
+				},
+				RoleTemplateNames: []string{"aasdfsdf", insert, "adsasdff"},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "rt3",
+				},
+				RoleTemplateNames: []string{},
+			}}, nil
+	}
+}
+
+// TestDelete confirms that the store prevents a roletemplate from being deleted if another roletemplate inherits from it
+func TestDelete(t *testing.T) {
+	assert := assert.New(t)
+
+	// test when roletemplate is not a parent of another roletemplate, should not cause error
+	_, err := testWithInherited("somekey", false)
+	assert.Nil(err)
+
+	// test when roletemplate is a parent of another roletemplate, should cause error
+	_, err = testWithInherited("somekey", true)
+	assert.Contains(err.Error(), "Conflict 409: roletemplate [somekey] cannot be deleted because roletemplate [rt2] inherits from it")
+}
+
+func (ds dummyStore) Context() types.StorageContext {
+	return types.StorageContext("test")
+}
+func (ds dummyStore) ByID(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
+	return nil, nil
+}
+func (ds dummyStore) List(apiContext *types.APIContext, schema *types.Schema, opt *types.QueryOptions) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (ds dummyStore) Create(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}) (map[string]interface{}, error) {
+	return data, nil
+}
+
+func (ds dummyStore) Update(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, id string) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (ds dummyStore) Delete(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (ds dummyStore) Watch(apiContext *types.APIContext, schema *types.Schema, opt *types.QueryOptions) (chan map[string]interface{}, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Problem:
Roletemplate can be delete even if another roletemplate inherits from it.

Solution:
Check whether another roletemplate inherits from roletemplate being deleted and return error if so.

Issue:
https://github.com/rancher/rancher/issues/19133