### PR TITLE
Add force upgrade for system apps

### DIFF
--- a/pkg/controllers/user/alert/deployer/upgradeimpl.go
+++ b/pkg/controllers/user/alert/deployer/upgradeimpl.go
@@ -167,6 +167,9 @@ func (l *AlertService) Upgrade(currentVersion string) (string, error) {
 			return "", fmt.Errorf("catalog %v not ready", systemCatalogName)
 		}
 
+		// add force upgrade to handle chart compatibility in different version
+		projectv3.AppConditionForceUpgrade.Unknown(newApp)
+
 		if _, err = l.apps.Update(newApp); err != nil {
 			return "", fmt.Errorf("update app %s:%s failed, %v", app.Namespace, app.Name, err)
 		}

--- a/pkg/controllers/user/logging/deployer/upgradeimpl.go
+++ b/pkg/controllers/user/logging/deployer/upgradeimpl.go
@@ -13,6 +13,7 @@ import (
 	appsv1beta2 "github.com/rancher/types/apis/apps/v1beta2"
 	v1 "github.com/rancher/types/apis/core/v1"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	projectv3 "github.com/rancher/types/apis/project.cattle.io/v3"
 	"github.com/rancher/types/config"
 
 	"github.com/pkg/errors"
@@ -139,6 +140,9 @@ func (l *LoggingService) Upgrade(currentVersion string) (string, error) {
 	newApp.Spec.ExternalID = newCatalogID
 
 	if !reflect.DeepEqual(newApp, app) {
+		// add force upgrade to handle chart compatibility in different version
+		projectv3.AppConditionForceUpgrade.Unknown(newApp)
+
 		if _, err = l.appDeployer.AppsGetter.Apps(metav1.NamespaceAll).Update(newApp); err != nil {
 			return "", errors.Wrapf(err, "update app %s:%s failed", app.Namespace, app.Name)
 		}


### PR DESCRIPTION
Problem:
After version v1 release for deployment, statefulset, daemonset, there is some compatibility issue, like updates to deployment/statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden. So upgrade chart may get failed.

Solution:
Add force upgrade for system app

Issue:
https://github.com/rancher/rancher/issues/21770

Related Charts PR:
https://github.com/rancher/system-charts/pull/78