### PR TITLE
Hide clustertemplate answers on clusterspec 

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -230,9 +230,7 @@ func setupScopedTypes(schemas *types.Schemas) {
 
 func Clusters(schemas *types.Schemas, managementContext *config.ScaledContext, clusterManager *clustermanager.Manager, k8sProxy http.Handler) {
 	schema := schemas.Schema(&managementschema.Version, client.ClusterType)
-	clusterFormatter := ccluster.Formatter{
-		KontainerDriverLister: managementContext.Management.KontainerDrivers("").Controller().Lister(),
-	}
+	clusterFormatter := ccluster.NewFormatter(schemas, managementContext)
 	schema.Formatter = clusterFormatter.Formatter
 	schema.CollectionFormatter = clusterFormatter.CollectionFormatter
 	clusterStore := cluster.GetClusterStore(schema, managementContext, clusterManager, k8sProxy)

--- a/pkg/api/store/cluster/cluster_store.go
+++ b/pkg/api/store/cluster/cluster_store.go
@@ -93,9 +93,11 @@ func (t *transformer) transposeGenericConfigToDynamicField(data map[string]inter
 }
 
 func GetClusterStore(schema *types.Schema, mgmt *config.ScaledContext, clusterManager *clustermanager.Manager, k8sProxy http.Handler) *Store {
+
 	transformer := transformer{
 		KontainerDriverLister: mgmt.Management.KontainerDrivers("").Controller().Lister(),
 	}
+
 	t := &transform.Store{
 		Store:       schema.Store,
 		Transformer: transformer.TransformerFunc,


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/21519

Answers to Questions set on ClusterTemplate are stored on the Cluster Spec when user creates the cluster with answers. If the properties set as answers are password/secret fields, we should not display such answers on API.