### PR TITLE
Fix directory permissions override

### DIFF
--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -6,7 +6,7 @@ ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
 
 RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates jq iproute2 vim-tiny less bash-completion unzip sysstat && \
+    apt-get install -y --no-install-recommends curl ca-certificates jq iproute2 vim-tiny less bash-completion unzip sysstat acl && \
     curl -sLf ${!DOCKER_URL} > /usr/bin/docker && \
     chmod +x /usr/bin/docker && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.13.7/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \

--- a/package/run.sh
+++ b/package/run.sh
@@ -108,6 +108,20 @@ check_x509_cert()
     fi
 }
 
+set_certs_dir_permissions()
+{
+    local certs_dir=$1
+    # check for acl mask
+    masked=0
+    getfacl -p $certs_dir | grep -q mask::r-x || masked=1
+    if [ $masked -eq 0 ]; then
+        chmod 700 $certs_dir
+        setfacl -R -m m::rX $certs_dir
+    else
+        chmod 700 $certs_dir
+    fi
+}
+
 AGENT_IMAGE=${AGENT_IMAGE:-ubuntu:14.04}
 
 export CATTLE_ADDRESS
@@ -249,8 +263,9 @@ if [ -n "$CATTLE_CA_CHECKSUM" ]; then
     else
         mkdir -p /etc/kubernetes/ssl/certs
         mv $temp /etc/kubernetes/ssl/certs/serverca
-        chmod 700 /etc/kubernetes/ssl /etc/kubernetes/ssl/certs
-	chmod 600 /etc/kubernetes/ssl/certs/serverca
+        set_certs_dir_permissions /etc/kubernetes/ssl
+        chmod 700 /etc/kubernetes/ssl/certs
+        chmod 600 /etc/kubernetes/ssl/certs/serverca
         mkdir -p /etc/docker/certs.d/$CATTLE_SERVER_HOSTNAME_WITH_PORT
         cp /etc/kubernetes/ssl/certs/serverca /etc/docker/certs.d/$CATTLE_SERVER_HOSTNAME_WITH_PORT/ca.crt
 


### PR DESCRIPTION
To allow using custom uid/gid for etcd, we use ACLs to grant the etcd user read permissions to the certificates directory. The `chmod` this PR replaces deletes these ACLs when the node agent is switched from a container to a pod. The new function re-applies the needed acls if they where already set.