### PR TITLE
Update kontainer-engine

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1.0
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     f7bdda798a65df9bbf4c91ce7d3e4439655d45c3
-github.com/rancher/kontainer-engine           e5962e748ba4c0c020b45ed8ba050e912cc358ae
+github.com/rancher/kontainer-engine           2cc7e2fc9d20e0ce8a68352ccd3728a9cecf0636
 github.com/rancher/rke                        66f7c26d396a841cd1f13fd19f20b84a9ba635bc
 github.com/rancher/kontainer-driver-metadata  821544f898e7bcbc0a475d2f0afccc6c272f691c
 github.com/rancher/types                      db699f0c0639de0e57c09cb89517f1914f2750ac

--- a/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/eks/eks_driver.go
@@ -274,7 +274,7 @@ func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags
 	driverFlag.Options["kubernetes-version"] = &types.Flag{
 		Type:    types.StringType,
 		Usage:   "The kubernetes master version",
-		Default: &types.Default{DefaultString: "1.10"},
+		Default: &types.Default{DefaultString: "1.13"},
 	}
 
 	return &driverFlag, nil
@@ -288,7 +288,7 @@ func (d *Driver) GetDriverUpdateOptions(ctx context.Context) (*types.DriverFlags
 	driverFlag.Options["kubernetes-version"] = &types.Flag{
 		Type:    types.StringType,
 		Usage:   "The kubernetes version to update",
-		Default: &types.Default{DefaultString: "1.10"},
+		Default: &types.Default{DefaultString: "1.13"},
 	}
 	driverFlag.Options["access-key"] = &types.Flag{
 		Type:  types.StringType,


### PR DESCRIPTION
Updated kontainer-engine which now uses proper default k8s version for EKS clusters.