### PR TITLE
[2.2] Remove stuck Global Role bindings and RoleTemplates

### DIFF
--- a/pkg/controllers/user/rbac/handler_base.go
+++ b/pkg/controllers/user/rbac/handler_base.go
@@ -118,10 +118,12 @@ func Register(ctx context.Context, workload *config.UserContext) {
 	rti := workload.Management.Management.RoleTemplates("")
 	rtSync := v3.NewRoleTemplateLifecycleAdapter("cluster-roletemplate-sync_"+workload.ClusterName, true, rti, newRTLifecycle(r))
 	workload.Management.Management.RoleTemplates("").AddHandler(ctx, "cluster-roletemplate-sync", rtSync)
+	workload.Management.Management.RoleTemplates("").AddHandler(ctx, "legacy-rt-cleaner", newLegacyRTCleaner(r).sync)
 
 	grbi := workload.Management.Management.GlobalRoleBindings("")
 	grbSync := v3.NewGlobalRoleBindingLifecycleAdapter("grb-sync_"+workload.ClusterName, true, grbi, newGlobalRoleBindingHandler(workload))
 	workload.Management.Management.GlobalRoleBindings("").AddHandler(ctx, "grb-sync", grbSync)
+	workload.Management.Management.GlobalRoleBindings("").AddHandler(ctx, "legacy-grb-cleaner", newLegacyGRBCleaner(r).sync)
 }
 
 type manager struct {

--- a/pkg/controllers/user/rbac/legacy_grb_cleaner.go
+++ b/pkg/controllers/user/rbac/legacy_grb_cleaner.go
@@ -1,0 +1,63 @@
+package rbac
+
+import (
+	"strings"
+	"time"
+
+	"github.com/rancher/norman/lifecycle"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type grbCleaner struct {
+	m *manager
+}
+
+func newLegacyGRBCleaner(m *manager) *grbCleaner {
+	return &grbCleaner{m: m}
+}
+
+func (p *grbCleaner) sync(key string, obj *v3.GlobalRoleBinding) (runtime.Object, error) {
+	if key == "" || obj == nil {
+		return nil, nil
+	}
+	if obj.DeletionTimestamp == nil || len(obj.Finalizers) == 0 {
+		return nil, nil
+	}
+	if time.Since(obj.DeletionTimestamp.Time) < 1*time.Hour {
+		return nil, nil
+	}
+	obj, err := p.removeStuckFinalizer(obj)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	return obj, nil
+
+}
+
+func (p *grbCleaner) removeStuckFinalizer(obj *v3.GlobalRoleBinding) (*v3.GlobalRoleBinding, error) {
+	obj = obj.DeepCopy()
+	modified := false
+	md, err := meta.Accessor(obj)
+	if err != nil {
+		return obj, err
+	}
+
+	finalizers := md.GetFinalizers()
+	for i := len(finalizers) - 1; i >= 0; i-- {
+		f := finalizers[i]
+		if strings.HasPrefix(f, lifecycle.ScopedFinalizerKey) {
+			finalizers = append(finalizers[:i], finalizers[i+1:]...)
+			modified = true
+		}
+	}
+
+	if modified {
+		md.SetFinalizers(finalizers)
+		obj, e := p.m.workload.Management.Management.GlobalRoleBindings("").Update(obj)
+		return obj, e
+	}
+	return obj, nil
+}

--- a/pkg/controllers/user/rbac/legacy_rt_cleaner.go
+++ b/pkg/controllers/user/rbac/legacy_rt_cleaner.go
@@ -1,0 +1,63 @@
+package rbac
+
+import (
+	"strings"
+	"time"
+
+	"github.com/rancher/norman/lifecycle"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type rtCleaner struct {
+	m *manager
+}
+
+func newLegacyRTCleaner(m *manager) *rtCleaner {
+	return &rtCleaner{m: m}
+}
+
+func (p *rtCleaner) sync(key string, obj *v3.RoleTemplate) (runtime.Object, error) {
+	if key == "" || obj == nil {
+		return nil, nil
+	}
+	if obj.DeletionTimestamp == nil || len(obj.Finalizers) == 0 {
+		return nil, nil
+	}
+	if time.Since(obj.DeletionTimestamp.Time) < 1*time.Hour {
+		return nil, nil
+	}
+	obj, err := p.removeStuckFinalizer(obj)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	return obj, nil
+
+}
+
+func (p *rtCleaner) removeStuckFinalizer(obj *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+	obj = obj.DeepCopy()
+	modified := false
+	md, err := meta.Accessor(obj)
+	if err != nil {
+		return obj, err
+	}
+
+	finalizers := md.GetFinalizers()
+	for i := len(finalizers) - 1; i >= 0; i-- {
+		f := finalizers[i]
+		if strings.HasPrefix(f, lifecycle.ScopedFinalizerKey) {
+			finalizers = append(finalizers[:i], finalizers[i+1:]...)
+			modified = true
+		}
+	}
+
+	if modified {
+		md.SetFinalizers(finalizers)
+		obj, e := p.m.workload.Management.Management.RoleTemplates("").Update(obj)
+		return obj, e
+	}
+	return obj, nil
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -39,8 +39,8 @@ github.com/mcuadros/go-version                6d5863ca60fa6fe914b5fd43ed8533d756
 github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
-github.com/rancher/norman                     c96ac0ef2eee72c159e014750436343afc4e0bbd
-github.com/rancher/types                      2fe116852f64112b06cc2f7ab8ccf16c49825f30
+github.com/rancher/norman                     659cceabaf2ace35ea6f6721f4993d1d04f0bd80
+github.com/rancher/types                      cf412afc1a0bb88c7235f2aeb5dfbdbdc5ff4cef 
 github.com/rancher/kontainer-engine           cedd75d7b076a3e848e933816bf7f9b3d3f1deaf
 github.com/rancher/rke                        5069e892d4f03e283190a0433ddc3c9d93a2f047
 

--- a/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_daemon_set_controller.go
+++ b/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_daemon_set_controller.go
@@ -151,7 +151,6 @@ func (c *daemonSetController) AddHandler(ctx context.Context, name string, handl
 }
 
 func (c *daemonSetController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler DaemonSetHandlerFunc) {
-	resource.PutClusterScoped(DaemonSetGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_daemon_set_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_daemon_set_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1beta2
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *daemonSetLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object,
 }
 
 func NewDaemonSetLifecycleAdapter(name string, clusterScoped bool, client DaemonSetInterface, l DaemonSetLifecycle) DaemonSetHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(DaemonSetGroupVersionResource)
+	}
 	adapter := &daemonSetLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1beta2.DaemonSet) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_deployment_controller.go
+++ b/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_deployment_controller.go
@@ -151,7 +151,6 @@ func (c *deploymentController) AddHandler(ctx context.Context, name string, hand
 }
 
 func (c *deploymentController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler DeploymentHandlerFunc) {
-	resource.PutClusterScoped(DeploymentGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_deployment_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_deployment_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1beta2
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *deploymentLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object
 }
 
 func NewDeploymentLifecycleAdapter(name string, clusterScoped bool, client DeploymentInterface, l DeploymentLifecycle) DeploymentHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(DeploymentGroupVersionResource)
+	}
 	adapter := &deploymentLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1beta2.Deployment) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_replica_set_controller.go
+++ b/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_replica_set_controller.go
@@ -151,7 +151,6 @@ func (c *replicaSetController) AddHandler(ctx context.Context, name string, hand
 }
 
 func (c *replicaSetController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ReplicaSetHandlerFunc) {
-	resource.PutClusterScoped(ReplicaSetGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_replica_set_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_replica_set_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1beta2
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *replicaSetLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object
 }
 
 func NewReplicaSetLifecycleAdapter(name string, clusterScoped bool, client ReplicaSetInterface, l ReplicaSetLifecycle) ReplicaSetHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ReplicaSetGroupVersionResource)
+	}
 	adapter := &replicaSetLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1beta2.ReplicaSet) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_stateful_set_controller.go
+++ b/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_stateful_set_controller.go
@@ -151,7 +151,6 @@ func (c *statefulSetController) AddHandler(ctx context.Context, name string, han
 }
 
 func (c *statefulSetController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler StatefulSetHandlerFunc) {
-	resource.PutClusterScoped(StatefulSetGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_stateful_set_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/apps/v1beta2/zz_generated_stateful_set_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1beta2
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *statefulSetLifecycleAdapter) Updated(obj runtime.Object) (runtime.Objec
 }
 
 func NewStatefulSetLifecycleAdapter(name string, clusterScoped bool, client StatefulSetInterface, l StatefulSetLifecycle) StatefulSetHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(StatefulSetGroupVersionResource)
+	}
 	adapter := &statefulSetLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1beta2.StatefulSet) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/batch/v1/zz_generated_job_controller.go
+++ b/vendor/github.com/rancher/types/apis/batch/v1/zz_generated_job_controller.go
@@ -151,7 +151,6 @@ func (c *jobController) AddHandler(ctx context.Context, name string, handler Job
 }
 
 func (c *jobController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler JobHandlerFunc) {
-	resource.PutClusterScoped(JobGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/batch/v1/zz_generated_job_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/batch/v1/zz_generated_job_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *jobLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, error
 }
 
 func NewJobLifecycleAdapter(name string, clusterScoped bool, client JobInterface, l JobLifecycle) JobHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(JobGroupVersionResource)
+	}
 	adapter := &jobLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.Job) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/batch/v1beta1/zz_generated_cron_job_controller.go
+++ b/vendor/github.com/rancher/types/apis/batch/v1beta1/zz_generated_cron_job_controller.go
@@ -151,7 +151,6 @@ func (c *cronJobController) AddHandler(ctx context.Context, name string, handler
 }
 
 func (c *cronJobController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler CronJobHandlerFunc) {
-	resource.PutClusterScoped(CronJobGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/batch/v1beta1/zz_generated_cron_job_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/batch/v1beta1/zz_generated_cron_job_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1beta1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/api/batch/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *cronJobLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, e
 }
 
 func NewCronJobLifecycleAdapter(name string, clusterScoped bool, client CronJobInterface, l CronJobLifecycle) CronJobHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(CronJobGroupVersionResource)
+	}
 	adapter := &cronJobLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1beta1.CronJob) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/cluster.cattle.io/v3/zz_generated_cluster_auth_token_controller.go
+++ b/vendor/github.com/rancher/types/apis/cluster.cattle.io/v3/zz_generated_cluster_auth_token_controller.go
@@ -150,7 +150,6 @@ func (c *clusterAuthTokenController) AddHandler(ctx context.Context, name string
 }
 
 func (c *clusterAuthTokenController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ClusterAuthTokenHandlerFunc) {
-	resource.PutClusterScoped(ClusterAuthTokenGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/cluster.cattle.io/v3/zz_generated_cluster_auth_token_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/cluster.cattle.io/v3/zz_generated_cluster_auth_token_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *clusterAuthTokenLifecycleAdapter) Updated(obj runtime.Object) (runtime.
 }
 
 func NewClusterAuthTokenLifecycleAdapter(name string, clusterScoped bool, client ClusterAuthTokenInterface, l ClusterAuthTokenLifecycle) ClusterAuthTokenHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ClusterAuthTokenGroupVersionResource)
+	}
 	adapter := &clusterAuthTokenLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ClusterAuthToken) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/cluster.cattle.io/v3/zz_generated_cluster_user_attribute_controller.go
+++ b/vendor/github.com/rancher/types/apis/cluster.cattle.io/v3/zz_generated_cluster_user_attribute_controller.go
@@ -150,7 +150,6 @@ func (c *clusterUserAttributeController) AddHandler(ctx context.Context, name st
 }
 
 func (c *clusterUserAttributeController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ClusterUserAttributeHandlerFunc) {
-	resource.PutClusterScoped(ClusterUserAttributeGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/cluster.cattle.io/v3/zz_generated_cluster_user_attribute_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/cluster.cattle.io/v3/zz_generated_cluster_user_attribute_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *clusterUserAttributeLifecycleAdapter) Updated(obj runtime.Object) (runt
 }
 
 func NewClusterUserAttributeLifecycleAdapter(name string, clusterScoped bool, client ClusterUserAttributeInterface, l ClusterUserAttributeLifecycle) ClusterUserAttributeHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ClusterUserAttributeGroupVersionResource)
+	}
 	adapter := &clusterUserAttributeLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ClusterUserAttribute) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_component_status_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_component_status_controller.go
@@ -150,7 +150,6 @@ func (c *componentStatusController) AddHandler(ctx context.Context, name string,
 }
 
 func (c *componentStatusController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ComponentStatusHandlerFunc) {
-	resource.PutClusterScoped(ComponentStatusGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_component_status_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_component_status_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *componentStatusLifecycleAdapter) Updated(obj runtime.Object) (runtime.O
 }
 
 func NewComponentStatusLifecycleAdapter(name string, clusterScoped bool, client ComponentStatusInterface, l ComponentStatusLifecycle) ComponentStatusHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ComponentStatusGroupVersionResource)
+	}
 	adapter := &componentStatusLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.ComponentStatus) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_config_map_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_config_map_controller.go
@@ -151,7 +151,6 @@ func (c *configMapController) AddHandler(ctx context.Context, name string, handl
 }
 
 func (c *configMapController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ConfigMapHandlerFunc) {
-	resource.PutClusterScoped(ConfigMapGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_config_map_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_config_map_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *configMapLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object,
 }
 
 func NewConfigMapLifecycleAdapter(name string, clusterScoped bool, client ConfigMapInterface, l ConfigMapLifecycle) ConfigMapHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ConfigMapGroupVersionResource)
+	}
 	adapter := &configMapLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.ConfigMap) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_endpoints_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_endpoints_controller.go
@@ -151,7 +151,6 @@ func (c *endpointsController) AddHandler(ctx context.Context, name string, handl
 }
 
 func (c *endpointsController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler EndpointsHandlerFunc) {
-	resource.PutClusterScoped(EndpointsGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_endpoints_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_endpoints_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *endpointsLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object,
 }
 
 func NewEndpointsLifecycleAdapter(name string, clusterScoped bool, client EndpointsInterface, l EndpointsLifecycle) EndpointsHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(EndpointsGroupVersionResource)
+	}
 	adapter := &endpointsLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.Endpoints) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_event_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_event_controller.go
@@ -150,7 +150,6 @@ func (c *eventController) AddHandler(ctx context.Context, name string, handler E
 }
 
 func (c *eventController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler EventHandlerFunc) {
-	resource.PutClusterScoped(EventGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_event_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_event_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *eventLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, err
 }
 
 func NewEventLifecycleAdapter(name string, clusterScoped bool, client EventInterface, l EventLifecycle) EventHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(EventGroupVersionResource)
+	}
 	adapter := &eventLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.Event) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_limit_range_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_limit_range_controller.go
@@ -151,7 +151,6 @@ func (c *limitRangeController) AddHandler(ctx context.Context, name string, hand
 }
 
 func (c *limitRangeController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler LimitRangeHandlerFunc) {
-	resource.PutClusterScoped(LimitRangeGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_limit_range_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_limit_range_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *limitRangeLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object
 }
 
 func NewLimitRangeLifecycleAdapter(name string, clusterScoped bool, client LimitRangeInterface, l LimitRangeLifecycle) LimitRangeHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(LimitRangeGroupVersionResource)
+	}
 	adapter := &limitRangeLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.LimitRange) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_namespace_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_namespace_controller.go
@@ -150,7 +150,6 @@ func (c *namespaceController) AddHandler(ctx context.Context, name string, handl
 }
 
 func (c *namespaceController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler NamespaceHandlerFunc) {
-	resource.PutClusterScoped(NamespaceGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_namespace_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_namespace_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *namespaceLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object,
 }
 
 func NewNamespaceLifecycleAdapter(name string, clusterScoped bool, client NamespaceInterface, l NamespaceLifecycle) NamespaceHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(NamespaceGroupVersionResource)
+	}
 	adapter := &namespaceLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.Namespace) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_node_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_node_controller.go
@@ -150,7 +150,6 @@ func (c *nodeController) AddHandler(ctx context.Context, name string, handler No
 }
 
 func (c *nodeController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler NodeHandlerFunc) {
-	resource.PutClusterScoped(NodeGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_node_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_node_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *nodeLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, erro
 }
 
 func NewNodeLifecycleAdapter(name string, clusterScoped bool, client NodeInterface, l NodeLifecycle) NodeHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(NodeGroupVersionResource)
+	}
 	adapter := &nodeLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.Node) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_persistent_volume_claim_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_persistent_volume_claim_controller.go
@@ -151,7 +151,6 @@ func (c *persistentVolumeClaimController) AddHandler(ctx context.Context, name s
 }
 
 func (c *persistentVolumeClaimController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler PersistentVolumeClaimHandlerFunc) {
-	resource.PutClusterScoped(PersistentVolumeClaimGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_persistent_volume_claim_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_persistent_volume_claim_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *persistentVolumeClaimLifecycleAdapter) Updated(obj runtime.Object) (run
 }
 
 func NewPersistentVolumeClaimLifecycleAdapter(name string, clusterScoped bool, client PersistentVolumeClaimInterface, l PersistentVolumeClaimLifecycle) PersistentVolumeClaimHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(PersistentVolumeClaimGroupVersionResource)
+	}
 	adapter := &persistentVolumeClaimLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.PersistentVolumeClaim) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_pod_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_pod_controller.go
@@ -151,7 +151,6 @@ func (c *podController) AddHandler(ctx context.Context, name string, handler Pod
 }
 
 func (c *podController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler PodHandlerFunc) {
-	resource.PutClusterScoped(PodGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_pod_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_pod_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *podLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, error
 }
 
 func NewPodLifecycleAdapter(name string, clusterScoped bool, client PodInterface, l PodLifecycle) PodHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(PodGroupVersionResource)
+	}
 	adapter := &podLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.Pod) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_replication_controller_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_replication_controller_controller.go
@@ -151,7 +151,6 @@ func (c *replicationControllerController) AddHandler(ctx context.Context, name s
 }
 
 func (c *replicationControllerController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ReplicationControllerHandlerFunc) {
-	resource.PutClusterScoped(ReplicationControllerGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_replication_controller_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_replication_controller_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *replicationControllerLifecycleAdapter) Updated(obj runtime.Object) (run
 }
 
 func NewReplicationControllerLifecycleAdapter(name string, clusterScoped bool, client ReplicationControllerInterface, l ReplicationControllerLifecycle) ReplicationControllerHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ReplicationControllerGroupVersionResource)
+	}
 	adapter := &replicationControllerLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.ReplicationController) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_resource_quota_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_resource_quota_controller.go
@@ -151,7 +151,6 @@ func (c *resourceQuotaController) AddHandler(ctx context.Context, name string, h
 }
 
 func (c *resourceQuotaController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ResourceQuotaHandlerFunc) {
-	resource.PutClusterScoped(ResourceQuotaGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_resource_quota_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_resource_quota_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *resourceQuotaLifecycleAdapter) Updated(obj runtime.Object) (runtime.Obj
 }
 
 func NewResourceQuotaLifecycleAdapter(name string, clusterScoped bool, client ResourceQuotaInterface, l ResourceQuotaLifecycle) ResourceQuotaHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ResourceQuotaGroupVersionResource)
+	}
 	adapter := &resourceQuotaLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.ResourceQuota) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_secret_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_secret_controller.go
@@ -151,7 +151,6 @@ func (c *secretController) AddHandler(ctx context.Context, name string, handler 
 }
 
 func (c *secretController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler SecretHandlerFunc) {
-	resource.PutClusterScoped(SecretGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_secret_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_secret_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *secretLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, er
 }
 
 func NewSecretLifecycleAdapter(name string, clusterScoped bool, client SecretInterface, l SecretLifecycle) SecretHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(SecretGroupVersionResource)
+	}
 	adapter := &secretLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.Secret) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_service_account_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_service_account_controller.go
@@ -151,7 +151,6 @@ func (c *serviceAccountController) AddHandler(ctx context.Context, name string, 
 }
 
 func (c *serviceAccountController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ServiceAccountHandlerFunc) {
-	resource.PutClusterScoped(ServiceAccountGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_service_account_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_service_account_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *serviceAccountLifecycleAdapter) Updated(obj runtime.Object) (runtime.Ob
 }
 
 func NewServiceAccountLifecycleAdapter(name string, clusterScoped bool, client ServiceAccountInterface, l ServiceAccountLifecycle) ServiceAccountHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ServiceAccountGroupVersionResource)
+	}
 	adapter := &serviceAccountLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.ServiceAccount) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_service_controller.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_service_controller.go
@@ -151,7 +151,6 @@ func (c *serviceController) AddHandler(ctx context.Context, name string, handler
 }
 
 func (c *serviceController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ServiceHandlerFunc) {
-	resource.PutClusterScoped(ServiceGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/core/v1/zz_generated_service_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/core/v1/zz_generated_service_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *serviceLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, e
 }
 
 func NewServiceLifecycleAdapter(name string, clusterScoped bool, client ServiceInterface, l ServiceLifecycle) ServiceHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ServiceGroupVersionResource)
+	}
 	adapter := &serviceLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.Service) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/extensions/v1beta1/zz_generated_ingress_controller.go
+++ b/vendor/github.com/rancher/types/apis/extensions/v1beta1/zz_generated_ingress_controller.go
@@ -151,7 +151,6 @@ func (c *ingressController) AddHandler(ctx context.Context, name string, handler
 }
 
 func (c *ingressController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler IngressHandlerFunc) {
-	resource.PutClusterScoped(IngressGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/extensions/v1beta1/zz_generated_ingress_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/extensions/v1beta1/zz_generated_ingress_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1beta1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *ingressLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, e
 }
 
 func NewIngressLifecycleAdapter(name string, clusterScoped bool, client IngressInterface, l IngressLifecycle) IngressHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(IngressGroupVersionResource)
+	}
 	adapter := &ingressLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1beta1.Ingress) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/extensions/v1beta1/zz_generated_pod_security_policy_controller.go
+++ b/vendor/github.com/rancher/types/apis/extensions/v1beta1/zz_generated_pod_security_policy_controller.go
@@ -150,7 +150,6 @@ func (c *podSecurityPolicyController) AddHandler(ctx context.Context, name strin
 }
 
 func (c *podSecurityPolicyController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler PodSecurityPolicyHandlerFunc) {
-	resource.PutClusterScoped(PodSecurityPolicyGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/extensions/v1beta1/zz_generated_pod_security_policy_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/extensions/v1beta1/zz_generated_pod_security_policy_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1beta1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *podSecurityPolicyLifecycleAdapter) Updated(obj runtime.Object) (runtime
 }
 
 func NewPodSecurityPolicyLifecycleAdapter(name string, clusterScoped bool, client PodSecurityPolicyInterface, l PodSecurityPolicyLifecycle) PodSecurityPolicyHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(PodSecurityPolicyGroupVersionResource)
+	}
 	adapter := &podSecurityPolicyLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1beta1.PodSecurityPolicy) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_auth_config_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_auth_config_controller.go
@@ -149,7 +149,6 @@ func (c *authConfigController) AddHandler(ctx context.Context, name string, hand
 }
 
 func (c *authConfigController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler AuthConfigHandlerFunc) {
-	resource.PutClusterScoped(AuthConfigGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_auth_config_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_auth_config_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *authConfigLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object
 }
 
 func NewAuthConfigLifecycleAdapter(name string, clusterScoped bool, client AuthConfigInterface, l AuthConfigLifecycle) AuthConfigHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(AuthConfigGroupVersionResource)
+	}
 	adapter := &authConfigLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *AuthConfig) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_catalog_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_catalog_controller.go
@@ -149,7 +149,6 @@ func (c *catalogController) AddHandler(ctx context.Context, name string, handler
 }
 
 func (c *catalogController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler CatalogHandlerFunc) {
-	resource.PutClusterScoped(CatalogGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_catalog_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_catalog_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *catalogLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, e
 }
 
 func NewCatalogLifecycleAdapter(name string, clusterScoped bool, client CatalogInterface, l CatalogLifecycle) CatalogHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(CatalogGroupVersionResource)
+	}
 	adapter := &catalogLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Catalog) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_catalog_template_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_catalog_template_controller.go
@@ -150,7 +150,6 @@ func (c *catalogTemplateController) AddHandler(ctx context.Context, name string,
 }
 
 func (c *catalogTemplateController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler CatalogTemplateHandlerFunc) {
-	resource.PutClusterScoped(CatalogTemplateGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_catalog_template_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_catalog_template_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *catalogTemplateLifecycleAdapter) Updated(obj runtime.Object) (runtime.O
 }
 
 func NewCatalogTemplateLifecycleAdapter(name string, clusterScoped bool, client CatalogTemplateInterface, l CatalogTemplateLifecycle) CatalogTemplateHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(CatalogTemplateGroupVersionResource)
+	}
 	adapter := &catalogTemplateLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *CatalogTemplate) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_catalog_template_version_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_catalog_template_version_controller.go
@@ -150,7 +150,6 @@ func (c *catalogTemplateVersionController) AddHandler(ctx context.Context, name 
 }
 
 func (c *catalogTemplateVersionController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler CatalogTemplateVersionHandlerFunc) {
-	resource.PutClusterScoped(CatalogTemplateVersionGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_catalog_template_version_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_catalog_template_version_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *catalogTemplateVersionLifecycleAdapter) Updated(obj runtime.Object) (ru
 }
 
 func NewCatalogTemplateVersionLifecycleAdapter(name string, clusterScoped bool, client CatalogTemplateVersionInterface, l CatalogTemplateVersionLifecycle) CatalogTemplateVersionHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(CatalogTemplateVersionGroupVersionResource)
+	}
 	adapter := &catalogTemplateVersionLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *CatalogTemplateVersion) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cloud_credential_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cloud_credential_controller.go
@@ -150,7 +150,6 @@ func (c *cloudCredentialController) AddHandler(ctx context.Context, name string,
 }
 
 func (c *cloudCredentialController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler CloudCredentialHandlerFunc) {
-	resource.PutClusterScoped(CloudCredentialGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cloud_credential_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cloud_credential_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *cloudCredentialLifecycleAdapter) Updated(obj runtime.Object) (runtime.O
 }
 
 func NewCloudCredentialLifecycleAdapter(name string, clusterScoped bool, client CloudCredentialInterface, l CloudCredentialLifecycle) CloudCredentialHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(CloudCredentialGroupVersionResource)
+	}
 	adapter := &cloudCredentialLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *CloudCredential) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_alert_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_alert_controller.go
@@ -150,7 +150,6 @@ func (c *clusterAlertController) AddHandler(ctx context.Context, name string, ha
 }
 
 func (c *clusterAlertController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ClusterAlertHandlerFunc) {
-	resource.PutClusterScoped(ClusterAlertGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_alert_group_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_alert_group_controller.go
@@ -150,7 +150,6 @@ func (c *clusterAlertGroupController) AddHandler(ctx context.Context, name strin
 }
 
 func (c *clusterAlertGroupController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ClusterAlertGroupHandlerFunc) {
-	resource.PutClusterScoped(ClusterAlertGroupGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_alert_group_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_alert_group_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *clusterAlertGroupLifecycleAdapter) Updated(obj runtime.Object) (runtime
 }
 
 func NewClusterAlertGroupLifecycleAdapter(name string, clusterScoped bool, client ClusterAlertGroupInterface, l ClusterAlertGroupLifecycle) ClusterAlertGroupHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ClusterAlertGroupGroupVersionResource)
+	}
 	adapter := &clusterAlertGroupLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ClusterAlertGroup) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_alert_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_alert_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *clusterAlertLifecycleAdapter) Updated(obj runtime.Object) (runtime.Obje
 }
 
 func NewClusterAlertLifecycleAdapter(name string, clusterScoped bool, client ClusterAlertInterface, l ClusterAlertLifecycle) ClusterAlertHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ClusterAlertGroupVersionResource)
+	}
 	adapter := &clusterAlertLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ClusterAlert) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_alert_rule_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_alert_rule_controller.go
@@ -150,7 +150,6 @@ func (c *clusterAlertRuleController) AddHandler(ctx context.Context, name string
 }
 
 func (c *clusterAlertRuleController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ClusterAlertRuleHandlerFunc) {
-	resource.PutClusterScoped(ClusterAlertRuleGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_alert_rule_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_alert_rule_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *clusterAlertRuleLifecycleAdapter) Updated(obj runtime.Object) (runtime.
 }
 
 func NewClusterAlertRuleLifecycleAdapter(name string, clusterScoped bool, client ClusterAlertRuleInterface, l ClusterAlertRuleLifecycle) ClusterAlertRuleHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ClusterAlertRuleGroupVersionResource)
+	}
 	adapter := &clusterAlertRuleLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ClusterAlertRule) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_catalog_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_catalog_controller.go
@@ -150,7 +150,6 @@ func (c *clusterCatalogController) AddHandler(ctx context.Context, name string, 
 }
 
 func (c *clusterCatalogController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ClusterCatalogHandlerFunc) {
-	resource.PutClusterScoped(ClusterCatalogGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_catalog_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_catalog_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *clusterCatalogLifecycleAdapter) Updated(obj runtime.Object) (runtime.Ob
 }
 
 func NewClusterCatalogLifecycleAdapter(name string, clusterScoped bool, client ClusterCatalogInterface, l ClusterCatalogLifecycle) ClusterCatalogHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ClusterCatalogGroupVersionResource)
+	}
 	adapter := &clusterCatalogLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ClusterCatalog) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_controller.go
@@ -149,7 +149,6 @@ func (c *clusterController) AddHandler(ctx context.Context, name string, handler
 }
 
 func (c *clusterController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ClusterHandlerFunc) {
-	resource.PutClusterScoped(ClusterGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *clusterLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, e
 }
 
 func NewClusterLifecycleAdapter(name string, clusterScoped bool, client ClusterInterface, l ClusterLifecycle) ClusterHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ClusterGroupVersionResource)
+	}
 	adapter := &clusterLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Cluster) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_logging_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_logging_controller.go
@@ -150,7 +150,6 @@ func (c *clusterLoggingController) AddHandler(ctx context.Context, name string, 
 }
 
 func (c *clusterLoggingController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ClusterLoggingHandlerFunc) {
-	resource.PutClusterScoped(ClusterLoggingGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_logging_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_logging_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *clusterLoggingLifecycleAdapter) Updated(obj runtime.Object) (runtime.Ob
 }
 
 func NewClusterLoggingLifecycleAdapter(name string, clusterScoped bool, client ClusterLoggingInterface, l ClusterLoggingLifecycle) ClusterLoggingHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ClusterLoggingGroupVersionResource)
+	}
 	adapter := &clusterLoggingLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ClusterLogging) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_monitor_graph_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_monitor_graph_controller.go
@@ -150,7 +150,6 @@ func (c *clusterMonitorGraphController) AddHandler(ctx context.Context, name str
 }
 
 func (c *clusterMonitorGraphController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ClusterMonitorGraphHandlerFunc) {
-	resource.PutClusterScoped(ClusterMonitorGraphGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_monitor_graph_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_monitor_graph_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *clusterMonitorGraphLifecycleAdapter) Updated(obj runtime.Object) (runti
 }
 
 func NewClusterMonitorGraphLifecycleAdapter(name string, clusterScoped bool, client ClusterMonitorGraphInterface, l ClusterMonitorGraphLifecycle) ClusterMonitorGraphHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ClusterMonitorGraphGroupVersionResource)
+	}
 	adapter := &clusterMonitorGraphLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ClusterMonitorGraph) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_registration_token_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_registration_token_controller.go
@@ -150,7 +150,6 @@ func (c *clusterRegistrationTokenController) AddHandler(ctx context.Context, nam
 }
 
 func (c *clusterRegistrationTokenController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ClusterRegistrationTokenHandlerFunc) {
-	resource.PutClusterScoped(ClusterRegistrationTokenGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_registration_token_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_registration_token_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *clusterRegistrationTokenLifecycleAdapter) Updated(obj runtime.Object) (
 }
 
 func NewClusterRegistrationTokenLifecycleAdapter(name string, clusterScoped bool, client ClusterRegistrationTokenInterface, l ClusterRegistrationTokenLifecycle) ClusterRegistrationTokenHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ClusterRegistrationTokenGroupVersionResource)
+	}
 	adapter := &clusterRegistrationTokenLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ClusterRegistrationToken) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_role_template_binding_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_role_template_binding_controller.go
@@ -150,7 +150,6 @@ func (c *clusterRoleTemplateBindingController) AddHandler(ctx context.Context, n
 }
 
 func (c *clusterRoleTemplateBindingController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ClusterRoleTemplateBindingHandlerFunc) {
-	resource.PutClusterScoped(ClusterRoleTemplateBindingGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_role_template_binding_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_role_template_binding_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *clusterRoleTemplateBindingLifecycleAdapter) Updated(obj runtime.Object)
 }
 
 func NewClusterRoleTemplateBindingLifecycleAdapter(name string, clusterScoped bool, client ClusterRoleTemplateBindingInterface, l ClusterRoleTemplateBindingLifecycle) ClusterRoleTemplateBindingHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ClusterRoleTemplateBindingGroupVersionResource)
+	}
 	adapter := &clusterRoleTemplateBindingLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ClusterRoleTemplateBinding) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_compose_config_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_compose_config_controller.go
@@ -149,7 +149,6 @@ func (c *composeConfigController) AddHandler(ctx context.Context, name string, h
 }
 
 func (c *composeConfigController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ComposeConfigHandlerFunc) {
-	resource.PutClusterScoped(ComposeConfigGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_compose_config_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_compose_config_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *composeConfigLifecycleAdapter) Updated(obj runtime.Object) (runtime.Obj
 }
 
 func NewComposeConfigLifecycleAdapter(name string, clusterScoped bool, client ComposeConfigInterface, l ComposeConfigLifecycle) ComposeConfigHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ComposeConfigGroupVersionResource)
+	}
 	adapter := &composeConfigLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ComposeConfig) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_dynamic_schema_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_dynamic_schema_controller.go
@@ -149,7 +149,6 @@ func (c *dynamicSchemaController) AddHandler(ctx context.Context, name string, h
 }
 
 func (c *dynamicSchemaController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler DynamicSchemaHandlerFunc) {
-	resource.PutClusterScoped(DynamicSchemaGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_dynamic_schema_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_dynamic_schema_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *dynamicSchemaLifecycleAdapter) Updated(obj runtime.Object) (runtime.Obj
 }
 
 func NewDynamicSchemaLifecycleAdapter(name string, clusterScoped bool, client DynamicSchemaInterface, l DynamicSchemaLifecycle) DynamicSchemaHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(DynamicSchemaGroupVersionResource)
+	}
 	adapter := &dynamicSchemaLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *DynamicSchema) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_etcd_backup_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_etcd_backup_controller.go
@@ -150,7 +150,6 @@ func (c *etcdBackupController) AddHandler(ctx context.Context, name string, hand
 }
 
 func (c *etcdBackupController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler EtcdBackupHandlerFunc) {
-	resource.PutClusterScoped(EtcdBackupGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_etcd_backup_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_etcd_backup_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *etcdBackupLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object
 }
 
 func NewEtcdBackupLifecycleAdapter(name string, clusterScoped bool, client EtcdBackupInterface, l EtcdBackupLifecycle) EtcdBackupHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(EtcdBackupGroupVersionResource)
+	}
 	adapter := &etcdBackupLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *EtcdBackup) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_dns_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_dns_controller.go
@@ -150,7 +150,6 @@ func (c *globalDnsController) AddHandler(ctx context.Context, name string, handl
 }
 
 func (c *globalDnsController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler GlobalDNSHandlerFunc) {
-	resource.PutClusterScoped(GlobalDNSGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_dns_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_dns_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *globalDnsLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object,
 }
 
 func NewGlobalDNSLifecycleAdapter(name string, clusterScoped bool, client GlobalDNSInterface, l GlobalDNSLifecycle) GlobalDNSHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(GlobalDNSGroupVersionResource)
+	}
 	adapter := &globalDnsLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *GlobalDNS) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_dns_provider_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_dns_provider_controller.go
@@ -150,7 +150,6 @@ func (c *globalDnsProviderController) AddHandler(ctx context.Context, name strin
 }
 
 func (c *globalDnsProviderController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler GlobalDNSProviderHandlerFunc) {
-	resource.PutClusterScoped(GlobalDNSProviderGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_dns_provider_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_dns_provider_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *globalDnsProviderLifecycleAdapter) Updated(obj runtime.Object) (runtime
 }
 
 func NewGlobalDNSProviderLifecycleAdapter(name string, clusterScoped bool, client GlobalDNSProviderInterface, l GlobalDNSProviderLifecycle) GlobalDNSProviderHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(GlobalDNSProviderGroupVersionResource)
+	}
 	adapter := &globalDnsProviderLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *GlobalDNSProvider) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_role_binding_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_role_binding_controller.go
@@ -149,7 +149,6 @@ func (c *globalRoleBindingController) AddHandler(ctx context.Context, name strin
 }
 
 func (c *globalRoleBindingController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler GlobalRoleBindingHandlerFunc) {
-	resource.PutClusterScoped(GlobalRoleBindingGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_role_binding_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_role_binding_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *globalRoleBindingLifecycleAdapter) Updated(obj runtime.Object) (runtime
 }
 
 func NewGlobalRoleBindingLifecycleAdapter(name string, clusterScoped bool, client GlobalRoleBindingInterface, l GlobalRoleBindingLifecycle) GlobalRoleBindingHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(GlobalRoleBindingGroupVersionResource)
+	}
 	adapter := &globalRoleBindingLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *GlobalRoleBinding) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_role_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_role_controller.go
@@ -149,7 +149,6 @@ func (c *globalRoleController) AddHandler(ctx context.Context, name string, hand
 }
 
 func (c *globalRoleController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler GlobalRoleHandlerFunc) {
-	resource.PutClusterScoped(GlobalRoleGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_role_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_global_role_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *globalRoleLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object
 }
 
 func NewGlobalRoleLifecycleAdapter(name string, clusterScoped bool, client GlobalRoleInterface, l GlobalRoleLifecycle) GlobalRoleHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(GlobalRoleGroupVersionResource)
+	}
 	adapter := &globalRoleLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *GlobalRole) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_group_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_group_controller.go
@@ -149,7 +149,6 @@ func (c *groupController) AddHandler(ctx context.Context, name string, handler G
 }
 
 func (c *groupController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler GroupHandlerFunc) {
-	resource.PutClusterScoped(GroupGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_group_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_group_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *groupLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, err
 }
 
 func NewGroupLifecycleAdapter(name string, clusterScoped bool, client GroupInterface, l GroupLifecycle) GroupHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(GroupGroupVersionResource)
+	}
 	adapter := &groupLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Group) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_group_member_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_group_member_controller.go
@@ -149,7 +149,6 @@ func (c *groupMemberController) AddHandler(ctx context.Context, name string, han
 }
 
 func (c *groupMemberController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler GroupMemberHandlerFunc) {
-	resource.PutClusterScoped(GroupMemberGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_group_member_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_group_member_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *groupMemberLifecycleAdapter) Updated(obj runtime.Object) (runtime.Objec
 }
 
 func NewGroupMemberLifecycleAdapter(name string, clusterScoped bool, client GroupMemberInterface, l GroupMemberLifecycle) GroupMemberHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(GroupMemberGroupVersionResource)
+	}
 	adapter := &groupMemberLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *GroupMember) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_kontainer_driver_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_kontainer_driver_controller.go
@@ -149,7 +149,6 @@ func (c *kontainerDriverController) AddHandler(ctx context.Context, name string,
 }
 
 func (c *kontainerDriverController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler KontainerDriverHandlerFunc) {
-	resource.PutClusterScoped(KontainerDriverGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_kontainer_driver_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_kontainer_driver_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *kontainerDriverLifecycleAdapter) Updated(obj runtime.Object) (runtime.O
 }
 
 func NewKontainerDriverLifecycleAdapter(name string, clusterScoped bool, client KontainerDriverInterface, l KontainerDriverLifecycle) KontainerDriverHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(KontainerDriverGroupVersionResource)
+	}
 	adapter := &kontainerDriverLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *KontainerDriver) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_ldap_config_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_ldap_config_controller.go
@@ -149,7 +149,6 @@ func (c *ldapConfigController) AddHandler(ctx context.Context, name string, hand
 }
 
 func (c *ldapConfigController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler LdapConfigHandlerFunc) {
-	resource.PutClusterScoped(LdapConfigGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_ldap_config_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_ldap_config_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *ldapConfigLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object
 }
 
 func NewLdapConfigLifecycleAdapter(name string, clusterScoped bool, client LdapConfigInterface, l LdapConfigLifecycle) LdapConfigHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(LdapConfigGroupVersionResource)
+	}
 	adapter := &ldapConfigLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *LdapConfig) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_listen_config_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_listen_config_controller.go
@@ -149,7 +149,6 @@ func (c *listenConfigController) AddHandler(ctx context.Context, name string, ha
 }
 
 func (c *listenConfigController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ListenConfigHandlerFunc) {
-	resource.PutClusterScoped(ListenConfigGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_listen_config_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_listen_config_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *listenConfigLifecycleAdapter) Updated(obj runtime.Object) (runtime.Obje
 }
 
 func NewListenConfigLifecycleAdapter(name string, clusterScoped bool, client ListenConfigInterface, l ListenConfigLifecycle) ListenConfigHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ListenConfigGroupVersionResource)
+	}
 	adapter := &listenConfigLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ListenConfig) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_monitor_metric_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_monitor_metric_controller.go
@@ -150,7 +150,6 @@ func (c *monitorMetricController) AddHandler(ctx context.Context, name string, h
 }
 
 func (c *monitorMetricController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler MonitorMetricHandlerFunc) {
-	resource.PutClusterScoped(MonitorMetricGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_monitor_metric_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_monitor_metric_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *monitorMetricLifecycleAdapter) Updated(obj runtime.Object) (runtime.Obj
 }
 
 func NewMonitorMetricLifecycleAdapter(name string, clusterScoped bool, client MonitorMetricInterface, l MonitorMetricLifecycle) MonitorMetricHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(MonitorMetricGroupVersionResource)
+	}
 	adapter := &monitorMetricLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *MonitorMetric) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_multi_cluster_app_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_multi_cluster_app_controller.go
@@ -150,7 +150,6 @@ func (c *multiClusterAppController) AddHandler(ctx context.Context, name string,
 }
 
 func (c *multiClusterAppController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler MultiClusterAppHandlerFunc) {
-	resource.PutClusterScoped(MultiClusterAppGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_multi_cluster_app_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_multi_cluster_app_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *multiClusterAppLifecycleAdapter) Updated(obj runtime.Object) (runtime.O
 }
 
 func NewMultiClusterAppLifecycleAdapter(name string, clusterScoped bool, client MultiClusterAppInterface, l MultiClusterAppLifecycle) MultiClusterAppHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(MultiClusterAppGroupVersionResource)
+	}
 	adapter := &multiClusterAppLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *MultiClusterApp) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_multi_cluster_app_revision_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_multi_cluster_app_revision_controller.go
@@ -150,7 +150,6 @@ func (c *multiClusterAppRevisionController) AddHandler(ctx context.Context, name
 }
 
 func (c *multiClusterAppRevisionController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler MultiClusterAppRevisionHandlerFunc) {
-	resource.PutClusterScoped(MultiClusterAppRevisionGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_multi_cluster_app_revision_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_multi_cluster_app_revision_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *multiClusterAppRevisionLifecycleAdapter) Updated(obj runtime.Object) (r
 }
 
 func NewMultiClusterAppRevisionLifecycleAdapter(name string, clusterScoped bool, client MultiClusterAppRevisionInterface, l MultiClusterAppRevisionLifecycle) MultiClusterAppRevisionHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(MultiClusterAppRevisionGroupVersionResource)
+	}
 	adapter := &multiClusterAppRevisionLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *MultiClusterAppRevision) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_controller.go
@@ -150,7 +150,6 @@ func (c *nodeController) AddHandler(ctx context.Context, name string, handler No
 }
 
 func (c *nodeController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler NodeHandlerFunc) {
-	resource.PutClusterScoped(NodeGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_driver_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_driver_controller.go
@@ -149,7 +149,6 @@ func (c *nodeDriverController) AddHandler(ctx context.Context, name string, hand
 }
 
 func (c *nodeDriverController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler NodeDriverHandlerFunc) {
-	resource.PutClusterScoped(NodeDriverGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_driver_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_driver_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *nodeDriverLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object
 }
 
 func NewNodeDriverLifecycleAdapter(name string, clusterScoped bool, client NodeDriverInterface, l NodeDriverLifecycle) NodeDriverHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(NodeDriverGroupVersionResource)
+	}
 	adapter := &nodeDriverLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *NodeDriver) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *nodeLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, erro
 }
 
 func NewNodeLifecycleAdapter(name string, clusterScoped bool, client NodeInterface, l NodeLifecycle) NodeHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(NodeGroupVersionResource)
+	}
 	adapter := &nodeLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Node) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_pool_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_pool_controller.go
@@ -150,7 +150,6 @@ func (c *nodePoolController) AddHandler(ctx context.Context, name string, handle
 }
 
 func (c *nodePoolController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler NodePoolHandlerFunc) {
-	resource.PutClusterScoped(NodePoolGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_pool_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_pool_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *nodePoolLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, 
 }
 
 func NewNodePoolLifecycleAdapter(name string, clusterScoped bool, client NodePoolInterface, l NodePoolLifecycle) NodePoolHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(NodePoolGroupVersionResource)
+	}
 	adapter := &nodePoolLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *NodePool) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_template_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_template_controller.go
@@ -150,7 +150,6 @@ func (c *nodeTemplateController) AddHandler(ctx context.Context, name string, ha
 }
 
 func (c *nodeTemplateController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler NodeTemplateHandlerFunc) {
-	resource.PutClusterScoped(NodeTemplateGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_template_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_node_template_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *nodeTemplateLifecycleAdapter) Updated(obj runtime.Object) (runtime.Obje
 }
 
 func NewNodeTemplateLifecycleAdapter(name string, clusterScoped bool, client NodeTemplateInterface, l NodeTemplateLifecycle) NodeTemplateHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(NodeTemplateGroupVersionResource)
+	}
 	adapter := &nodeTemplateLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *NodeTemplate) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_notifier_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_notifier_controller.go
@@ -150,7 +150,6 @@ func (c *notifierController) AddHandler(ctx context.Context, name string, handle
 }
 
 func (c *notifierController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler NotifierHandlerFunc) {
-	resource.PutClusterScoped(NotifierGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_notifier_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_notifier_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *notifierLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, 
 }
 
 func NewNotifierLifecycleAdapter(name string, clusterScoped bool, client NotifierInterface, l NotifierLifecycle) NotifierHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(NotifierGroupVersionResource)
+	}
 	adapter := &notifierLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Notifier) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_pod_security_policy_template_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_pod_security_policy_template_controller.go
@@ -149,7 +149,6 @@ func (c *podSecurityPolicyTemplateController) AddHandler(ctx context.Context, na
 }
 
 func (c *podSecurityPolicyTemplateController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler PodSecurityPolicyTemplateHandlerFunc) {
-	resource.PutClusterScoped(PodSecurityPolicyTemplateGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_pod_security_policy_template_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_pod_security_policy_template_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *podSecurityPolicyTemplateLifecycleAdapter) Updated(obj runtime.Object) 
 }
 
 func NewPodSecurityPolicyTemplateLifecycleAdapter(name string, clusterScoped bool, client PodSecurityPolicyTemplateInterface, l PodSecurityPolicyTemplateLifecycle) PodSecurityPolicyTemplateHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(PodSecurityPolicyTemplateGroupVersionResource)
+	}
 	adapter := &podSecurityPolicyTemplateLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *PodSecurityPolicyTemplate) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_pod_security_policy_template_project_binding_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_pod_security_policy_template_project_binding_controller.go
@@ -150,7 +150,6 @@ func (c *podSecurityPolicyTemplateProjectBindingController) AddHandler(ctx conte
 }
 
 func (c *podSecurityPolicyTemplateProjectBindingController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler PodSecurityPolicyTemplateProjectBindingHandlerFunc) {
-	resource.PutClusterScoped(PodSecurityPolicyTemplateProjectBindingGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_pod_security_policy_template_project_binding_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_pod_security_policy_template_project_binding_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *podSecurityPolicyTemplateProjectBindingLifecycleAdapter) Updated(obj ru
 }
 
 func NewPodSecurityPolicyTemplateProjectBindingLifecycleAdapter(name string, clusterScoped bool, client PodSecurityPolicyTemplateProjectBindingInterface, l PodSecurityPolicyTemplateProjectBindingLifecycle) PodSecurityPolicyTemplateProjectBindingHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(PodSecurityPolicyTemplateProjectBindingGroupVersionResource)
+	}
 	adapter := &podSecurityPolicyTemplateProjectBindingLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *PodSecurityPolicyTemplateProjectBinding) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_preference_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_preference_controller.go
@@ -150,7 +150,6 @@ func (c *preferenceController) AddHandler(ctx context.Context, name string, hand
 }
 
 func (c *preferenceController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler PreferenceHandlerFunc) {
-	resource.PutClusterScoped(PreferenceGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_preference_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_preference_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *preferenceLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object
 }
 
 func NewPreferenceLifecycleAdapter(name string, clusterScoped bool, client PreferenceInterface, l PreferenceLifecycle) PreferenceHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(PreferenceGroupVersionResource)
+	}
 	adapter := &preferenceLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Preference) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_principal_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_principal_controller.go
@@ -149,7 +149,6 @@ func (c *principalController) AddHandler(ctx context.Context, name string, handl
 }
 
 func (c *principalController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler PrincipalHandlerFunc) {
-	resource.PutClusterScoped(PrincipalGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_principal_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_principal_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *principalLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object,
 }
 
 func NewPrincipalLifecycleAdapter(name string, clusterScoped bool, client PrincipalInterface, l PrincipalLifecycle) PrincipalHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(PrincipalGroupVersionResource)
+	}
 	adapter := &principalLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Principal) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_alert_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_alert_controller.go
@@ -150,7 +150,6 @@ func (c *projectAlertController) AddHandler(ctx context.Context, name string, ha
 }
 
 func (c *projectAlertController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ProjectAlertHandlerFunc) {
-	resource.PutClusterScoped(ProjectAlertGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_alert_group_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_alert_group_controller.go
@@ -150,7 +150,6 @@ func (c *projectAlertGroupController) AddHandler(ctx context.Context, name strin
 }
 
 func (c *projectAlertGroupController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ProjectAlertGroupHandlerFunc) {
-	resource.PutClusterScoped(ProjectAlertGroupGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_alert_group_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_alert_group_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *projectAlertGroupLifecycleAdapter) Updated(obj runtime.Object) (runtime
 }
 
 func NewProjectAlertGroupLifecycleAdapter(name string, clusterScoped bool, client ProjectAlertGroupInterface, l ProjectAlertGroupLifecycle) ProjectAlertGroupHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ProjectAlertGroupGroupVersionResource)
+	}
 	adapter := &projectAlertGroupLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ProjectAlertGroup) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_alert_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_alert_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *projectAlertLifecycleAdapter) Updated(obj runtime.Object) (runtime.Obje
 }
 
 func NewProjectAlertLifecycleAdapter(name string, clusterScoped bool, client ProjectAlertInterface, l ProjectAlertLifecycle) ProjectAlertHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ProjectAlertGroupVersionResource)
+	}
 	adapter := &projectAlertLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ProjectAlert) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_alert_rule_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_alert_rule_controller.go
@@ -150,7 +150,6 @@ func (c *projectAlertRuleController) AddHandler(ctx context.Context, name string
 }
 
 func (c *projectAlertRuleController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ProjectAlertRuleHandlerFunc) {
-	resource.PutClusterScoped(ProjectAlertRuleGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_alert_rule_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_alert_rule_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *projectAlertRuleLifecycleAdapter) Updated(obj runtime.Object) (runtime.
 }
 
 func NewProjectAlertRuleLifecycleAdapter(name string, clusterScoped bool, client ProjectAlertRuleInterface, l ProjectAlertRuleLifecycle) ProjectAlertRuleHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ProjectAlertRuleGroupVersionResource)
+	}
 	adapter := &projectAlertRuleLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ProjectAlertRule) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_catalog_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_catalog_controller.go
@@ -150,7 +150,6 @@ func (c *projectCatalogController) AddHandler(ctx context.Context, name string, 
 }
 
 func (c *projectCatalogController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ProjectCatalogHandlerFunc) {
-	resource.PutClusterScoped(ProjectCatalogGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_catalog_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_catalog_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *projectCatalogLifecycleAdapter) Updated(obj runtime.Object) (runtime.Ob
 }
 
 func NewProjectCatalogLifecycleAdapter(name string, clusterScoped bool, client ProjectCatalogInterface, l ProjectCatalogLifecycle) ProjectCatalogHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ProjectCatalogGroupVersionResource)
+	}
 	adapter := &projectCatalogLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ProjectCatalog) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_controller.go
@@ -150,7 +150,6 @@ func (c *projectController) AddHandler(ctx context.Context, name string, handler
 }
 
 func (c *projectController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ProjectHandlerFunc) {
-	resource.PutClusterScoped(ProjectGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *projectLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, e
 }
 
 func NewProjectLifecycleAdapter(name string, clusterScoped bool, client ProjectInterface, l ProjectLifecycle) ProjectHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ProjectGroupVersionResource)
+	}
 	adapter := &projectLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Project) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_logging_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_logging_controller.go
@@ -150,7 +150,6 @@ func (c *projectLoggingController) AddHandler(ctx context.Context, name string, 
 }
 
 func (c *projectLoggingController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ProjectLoggingHandlerFunc) {
-	resource.PutClusterScoped(ProjectLoggingGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_logging_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_logging_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *projectLoggingLifecycleAdapter) Updated(obj runtime.Object) (runtime.Ob
 }
 
 func NewProjectLoggingLifecycleAdapter(name string, clusterScoped bool, client ProjectLoggingInterface, l ProjectLoggingLifecycle) ProjectLoggingHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ProjectLoggingGroupVersionResource)
+	}
 	adapter := &projectLoggingLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ProjectLogging) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_monitor_graph_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_monitor_graph_controller.go
@@ -150,7 +150,6 @@ func (c *projectMonitorGraphController) AddHandler(ctx context.Context, name str
 }
 
 func (c *projectMonitorGraphController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ProjectMonitorGraphHandlerFunc) {
-	resource.PutClusterScoped(ProjectMonitorGraphGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_monitor_graph_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_monitor_graph_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *projectMonitorGraphLifecycleAdapter) Updated(obj runtime.Object) (runti
 }
 
 func NewProjectMonitorGraphLifecycleAdapter(name string, clusterScoped bool, client ProjectMonitorGraphInterface, l ProjectMonitorGraphLifecycle) ProjectMonitorGraphHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ProjectMonitorGraphGroupVersionResource)
+	}
 	adapter := &projectMonitorGraphLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ProjectMonitorGraph) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_network_policy_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_network_policy_controller.go
@@ -150,7 +150,6 @@ func (c *projectNetworkPolicyController) AddHandler(ctx context.Context, name st
 }
 
 func (c *projectNetworkPolicyController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ProjectNetworkPolicyHandlerFunc) {
-	resource.PutClusterScoped(ProjectNetworkPolicyGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_network_policy_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_network_policy_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *projectNetworkPolicyLifecycleAdapter) Updated(obj runtime.Object) (runt
 }
 
 func NewProjectNetworkPolicyLifecycleAdapter(name string, clusterScoped bool, client ProjectNetworkPolicyInterface, l ProjectNetworkPolicyLifecycle) ProjectNetworkPolicyHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ProjectNetworkPolicyGroupVersionResource)
+	}
 	adapter := &projectNetworkPolicyLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ProjectNetworkPolicy) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_role_template_binding_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_role_template_binding_controller.go
@@ -150,7 +150,6 @@ func (c *projectRoleTemplateBindingController) AddHandler(ctx context.Context, n
 }
 
 func (c *projectRoleTemplateBindingController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ProjectRoleTemplateBindingHandlerFunc) {
-	resource.PutClusterScoped(ProjectRoleTemplateBindingGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_role_template_binding_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_project_role_template_binding_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *projectRoleTemplateBindingLifecycleAdapter) Updated(obj runtime.Object)
 }
 
 func NewProjectRoleTemplateBindingLifecycleAdapter(name string, clusterScoped bool, client ProjectRoleTemplateBindingInterface, l ProjectRoleTemplateBindingLifecycle) ProjectRoleTemplateBindingHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ProjectRoleTemplateBindingGroupVersionResource)
+	}
 	adapter := &projectRoleTemplateBindingLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ProjectRoleTemplateBinding) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_role_template_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_role_template_controller.go
@@ -149,7 +149,6 @@ func (c *roleTemplateController) AddHandler(ctx context.Context, name string, ha
 }
 
 func (c *roleTemplateController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler RoleTemplateHandlerFunc) {
-	resource.PutClusterScoped(RoleTemplateGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_role_template_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_role_template_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *roleTemplateLifecycleAdapter) Updated(obj runtime.Object) (runtime.Obje
 }
 
 func NewRoleTemplateLifecycleAdapter(name string, clusterScoped bool, client RoleTemplateInterface, l RoleTemplateLifecycle) RoleTemplateHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(RoleTemplateGroupVersionResource)
+	}
 	adapter := &roleTemplateLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *RoleTemplate) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_setting_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_setting_controller.go
@@ -149,7 +149,6 @@ func (c *settingController) AddHandler(ctx context.Context, name string, handler
 }
 
 func (c *settingController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler SettingHandlerFunc) {
-	resource.PutClusterScoped(SettingGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_setting_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_setting_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *settingLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, e
 }
 
 func NewSettingLifecycleAdapter(name string, clusterScoped bool, client SettingInterface, l SettingLifecycle) SettingHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(SettingGroupVersionResource)
+	}
 	adapter := &settingLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Setting) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_template_content_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_template_content_controller.go
@@ -149,7 +149,6 @@ func (c *templateContentController) AddHandler(ctx context.Context, name string,
 }
 
 func (c *templateContentController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler TemplateContentHandlerFunc) {
-	resource.PutClusterScoped(TemplateContentGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_template_content_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_template_content_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *templateContentLifecycleAdapter) Updated(obj runtime.Object) (runtime.O
 }
 
 func NewTemplateContentLifecycleAdapter(name string, clusterScoped bool, client TemplateContentInterface, l TemplateContentLifecycle) TemplateContentHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(TemplateContentGroupVersionResource)
+	}
 	adapter := &templateContentLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *TemplateContent) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_template_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_template_controller.go
@@ -149,7 +149,6 @@ func (c *templateController) AddHandler(ctx context.Context, name string, handle
 }
 
 func (c *templateController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler TemplateHandlerFunc) {
-	resource.PutClusterScoped(TemplateGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_template_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_template_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *templateLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, 
 }
 
 func NewTemplateLifecycleAdapter(name string, clusterScoped bool, client TemplateInterface, l TemplateLifecycle) TemplateHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(TemplateGroupVersionResource)
+	}
 	adapter := &templateLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Template) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_template_version_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_template_version_controller.go
@@ -149,7 +149,6 @@ func (c *templateVersionController) AddHandler(ctx context.Context, name string,
 }
 
 func (c *templateVersionController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler TemplateVersionHandlerFunc) {
-	resource.PutClusterScoped(TemplateVersionGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_template_version_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_template_version_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *templateVersionLifecycleAdapter) Updated(obj runtime.Object) (runtime.O
 }
 
 func NewTemplateVersionLifecycleAdapter(name string, clusterScoped bool, client TemplateVersionInterface, l TemplateVersionLifecycle) TemplateVersionHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(TemplateVersionGroupVersionResource)
+	}
 	adapter := &templateVersionLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *TemplateVersion) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_token_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_token_controller.go
@@ -149,7 +149,6 @@ func (c *tokenController) AddHandler(ctx context.Context, name string, handler T
 }
 
 func (c *tokenController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler TokenHandlerFunc) {
-	resource.PutClusterScoped(TokenGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_token_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_token_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *tokenLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, err
 }
 
 func NewTokenLifecycleAdapter(name string, clusterScoped bool, client TokenInterface, l TokenLifecycle) TokenHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(TokenGroupVersionResource)
+	}
 	adapter := &tokenLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Token) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_user_attribute_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_user_attribute_controller.go
@@ -149,7 +149,6 @@ func (c *userAttributeController) AddHandler(ctx context.Context, name string, h
 }
 
 func (c *userAttributeController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler UserAttributeHandlerFunc) {
-	resource.PutClusterScoped(UserAttributeGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_user_attribute_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_user_attribute_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *userAttributeLifecycleAdapter) Updated(obj runtime.Object) (runtime.Obj
 }
 
 func NewUserAttributeLifecycleAdapter(name string, clusterScoped bool, client UserAttributeInterface, l UserAttributeLifecycle) UserAttributeHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(UserAttributeGroupVersionResource)
+	}
 	adapter := &userAttributeLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *UserAttribute) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_user_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_user_controller.go
@@ -149,7 +149,6 @@ func (c *userController) AddHandler(ctx context.Context, name string, handler Us
 }
 
 func (c *userController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler UserHandlerFunc) {
-	resource.PutClusterScoped(UserGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_user_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_user_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *userLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, erro
 }
 
 func NewUserLifecycleAdapter(name string, clusterScoped bool, client UserInterface, l UserLifecycle) UserHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(UserGroupVersionResource)
+	}
 	adapter := &userLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *User) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3public/zz_generated_auth_provider_controller.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3public/zz_generated_auth_provider_controller.go
@@ -149,7 +149,6 @@ func (c *authProviderController) AddHandler(ctx context.Context, name string, ha
 }
 
 func (c *authProviderController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler AuthProviderHandlerFunc) {
-	resource.PutClusterScoped(AuthProviderGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3public/zz_generated_auth_provider_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3public/zz_generated_auth_provider_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3public
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *authProviderLifecycleAdapter) Updated(obj runtime.Object) (runtime.Obje
 }
 
 func NewAuthProviderLifecycleAdapter(name string, clusterScoped bool, client AuthProviderInterface, l AuthProviderLifecycle) AuthProviderHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(AuthProviderGroupVersionResource)
+	}
 	adapter := &authProviderLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *AuthProvider) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_alertmanager_controller.go
+++ b/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_alertmanager_controller.go
@@ -151,7 +151,6 @@ func (c *alertmanagerController) AddHandler(ctx context.Context, name string, ha
 }
 
 func (c *alertmanagerController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler AlertmanagerHandlerFunc) {
-	resource.PutClusterScoped(AlertmanagerGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_alertmanager_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_alertmanager_lifecycle_adapter.go
@@ -3,6 +3,7 @@ package v1
 import (
 	v1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -51,6 +52,9 @@ func (w *alertmanagerLifecycleAdapter) Updated(obj runtime.Object) (runtime.Obje
 }
 
 func NewAlertmanagerLifecycleAdapter(name string, clusterScoped bool, client AlertmanagerInterface, l AlertmanagerLifecycle) AlertmanagerHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(AlertmanagerGroupVersionResource)
+	}
 	adapter := &alertmanagerLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.Alertmanager) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_prometheus_controller.go
+++ b/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_prometheus_controller.go
@@ -151,7 +151,6 @@ func (c *prometheusController) AddHandler(ctx context.Context, name string, hand
 }
 
 func (c *prometheusController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler PrometheusHandlerFunc) {
-	resource.PutClusterScoped(PrometheusGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_prometheus_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_prometheus_lifecycle_adapter.go
@@ -3,6 +3,7 @@ package v1
 import (
 	v1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -51,6 +52,9 @@ func (w *prometheusLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object
 }
 
 func NewPrometheusLifecycleAdapter(name string, clusterScoped bool, client PrometheusInterface, l PrometheusLifecycle) PrometheusHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(PrometheusGroupVersionResource)
+	}
 	adapter := &prometheusLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.Prometheus) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_prometheus_rule_controller.go
+++ b/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_prometheus_rule_controller.go
@@ -151,7 +151,6 @@ func (c *prometheusRuleController) AddHandler(ctx context.Context, name string, 
 }
 
 func (c *prometheusRuleController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler PrometheusRuleHandlerFunc) {
-	resource.PutClusterScoped(PrometheusRuleGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_prometheus_rule_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_prometheus_rule_lifecycle_adapter.go
@@ -3,6 +3,7 @@ package v1
 import (
 	v1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -51,6 +52,9 @@ func (w *prometheusRuleLifecycleAdapter) Updated(obj runtime.Object) (runtime.Ob
 }
 
 func NewPrometheusRuleLifecycleAdapter(name string, clusterScoped bool, client PrometheusRuleInterface, l PrometheusRuleLifecycle) PrometheusRuleHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(PrometheusRuleGroupVersionResource)
+	}
 	adapter := &prometheusRuleLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.PrometheusRule) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_service_monitor_controller.go
+++ b/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_service_monitor_controller.go
@@ -151,7 +151,6 @@ func (c *serviceMonitorController) AddHandler(ctx context.Context, name string, 
 }
 
 func (c *serviceMonitorController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ServiceMonitorHandlerFunc) {
-	resource.PutClusterScoped(ServiceMonitorGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_service_monitor_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/monitoring.coreos.com/v1/zz_generated_service_monitor_lifecycle_adapter.go
@@ -3,6 +3,7 @@ package v1
 import (
 	v1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -51,6 +52,9 @@ func (w *serviceMonitorLifecycleAdapter) Updated(obj runtime.Object) (runtime.Ob
 }
 
 func NewServiceMonitorLifecycleAdapter(name string, clusterScoped bool, client ServiceMonitorInterface, l ServiceMonitorLifecycle) ServiceMonitorHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ServiceMonitorGroupVersionResource)
+	}
 	adapter := &serviceMonitorLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.ServiceMonitor) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/networking.k8s.io/v1/zz_generated_network_policy_controller.go
+++ b/vendor/github.com/rancher/types/apis/networking.k8s.io/v1/zz_generated_network_policy_controller.go
@@ -151,7 +151,6 @@ func (c *networkPolicyController) AddHandler(ctx context.Context, name string, h
 }
 
 func (c *networkPolicyController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler NetworkPolicyHandlerFunc) {
-	resource.PutClusterScoped(NetworkPolicyGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/networking.k8s.io/v1/zz_generated_network_policy_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/networking.k8s.io/v1/zz_generated_network_policy_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *networkPolicyLifecycleAdapter) Updated(obj runtime.Object) (runtime.Obj
 }
 
 func NewNetworkPolicyLifecycleAdapter(name string, clusterScoped bool, client NetworkPolicyInterface, l NetworkPolicyLifecycle) NetworkPolicyHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(NetworkPolicyGroupVersionResource)
+	}
 	adapter := &networkPolicyLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.NetworkPolicy) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_app_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_app_controller.go
@@ -150,7 +150,6 @@ func (c *appController) AddHandler(ctx context.Context, name string, handler App
 }
 
 func (c *appController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler AppHandlerFunc) {
-	resource.PutClusterScoped(AppGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_app_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_app_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *appLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, error
 }
 
 func NewAppLifecycleAdapter(name string, clusterScoped bool, client AppInterface, l AppLifecycle) AppHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(AppGroupVersionResource)
+	}
 	adapter := &appLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *App) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_app_revision_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_app_revision_controller.go
@@ -150,7 +150,6 @@ func (c *appRevisionController) AddHandler(ctx context.Context, name string, han
 }
 
 func (c *appRevisionController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler AppRevisionHandlerFunc) {
-	resource.PutClusterScoped(AppRevisionGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_app_revision_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_app_revision_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *appRevisionLifecycleAdapter) Updated(obj runtime.Object) (runtime.Objec
 }
 
 func NewAppRevisionLifecycleAdapter(name string, clusterScoped bool, client AppRevisionInterface, l AppRevisionLifecycle) AppRevisionHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(AppRevisionGroupVersionResource)
+	}
 	adapter := &appRevisionLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *AppRevision) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_basic_auth_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_basic_auth_controller.go
@@ -150,7 +150,6 @@ func (c *basicAuthController) AddHandler(ctx context.Context, name string, handl
 }
 
 func (c *basicAuthController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler BasicAuthHandlerFunc) {
-	resource.PutClusterScoped(BasicAuthGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_basic_auth_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_basic_auth_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *basicAuthLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object,
 }
 
 func NewBasicAuthLifecycleAdapter(name string, clusterScoped bool, client BasicAuthInterface, l BasicAuthLifecycle) BasicAuthHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(BasicAuthGroupVersionResource)
+	}
 	adapter := &basicAuthLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *BasicAuth) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_certificate_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_certificate_controller.go
@@ -150,7 +150,6 @@ func (c *certificateController) AddHandler(ctx context.Context, name string, han
 }
 
 func (c *certificateController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler CertificateHandlerFunc) {
-	resource.PutClusterScoped(CertificateGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_certificate_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_certificate_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *certificateLifecycleAdapter) Updated(obj runtime.Object) (runtime.Objec
 }
 
 func NewCertificateLifecycleAdapter(name string, clusterScoped bool, client CertificateInterface, l CertificateLifecycle) CertificateHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(CertificateGroupVersionResource)
+	}
 	adapter := &certificateLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Certificate) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_docker_credential_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_docker_credential_controller.go
@@ -150,7 +150,6 @@ func (c *dockerCredentialController) AddHandler(ctx context.Context, name string
 }
 
 func (c *dockerCredentialController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler DockerCredentialHandlerFunc) {
-	resource.PutClusterScoped(DockerCredentialGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_docker_credential_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_docker_credential_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *dockerCredentialLifecycleAdapter) Updated(obj runtime.Object) (runtime.
 }
 
 func NewDockerCredentialLifecycleAdapter(name string, clusterScoped bool, client DockerCredentialInterface, l DockerCredentialLifecycle) DockerCredentialHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(DockerCredentialGroupVersionResource)
+	}
 	adapter := &dockerCredentialLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *DockerCredential) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_basic_auth_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_basic_auth_controller.go
@@ -150,7 +150,6 @@ func (c *namespacedBasicAuthController) AddHandler(ctx context.Context, name str
 }
 
 func (c *namespacedBasicAuthController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler NamespacedBasicAuthHandlerFunc) {
-	resource.PutClusterScoped(NamespacedBasicAuthGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_basic_auth_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_basic_auth_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *namespacedBasicAuthLifecycleAdapter) Updated(obj runtime.Object) (runti
 }
 
 func NewNamespacedBasicAuthLifecycleAdapter(name string, clusterScoped bool, client NamespacedBasicAuthInterface, l NamespacedBasicAuthLifecycle) NamespacedBasicAuthHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(NamespacedBasicAuthGroupVersionResource)
+	}
 	adapter := &namespacedBasicAuthLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *NamespacedBasicAuth) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_certificate_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_certificate_controller.go
@@ -150,7 +150,6 @@ func (c *namespacedCertificateController) AddHandler(ctx context.Context, name s
 }
 
 func (c *namespacedCertificateController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler NamespacedCertificateHandlerFunc) {
-	resource.PutClusterScoped(NamespacedCertificateGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_certificate_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_certificate_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *namespacedCertificateLifecycleAdapter) Updated(obj runtime.Object) (run
 }
 
 func NewNamespacedCertificateLifecycleAdapter(name string, clusterScoped bool, client NamespacedCertificateInterface, l NamespacedCertificateLifecycle) NamespacedCertificateHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(NamespacedCertificateGroupVersionResource)
+	}
 	adapter := &namespacedCertificateLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *NamespacedCertificate) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_docker_credential_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_docker_credential_controller.go
@@ -150,7 +150,6 @@ func (c *namespacedDockerCredentialController) AddHandler(ctx context.Context, n
 }
 
 func (c *namespacedDockerCredentialController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler NamespacedDockerCredentialHandlerFunc) {
-	resource.PutClusterScoped(NamespacedDockerCredentialGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_docker_credential_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_docker_credential_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *namespacedDockerCredentialLifecycleAdapter) Updated(obj runtime.Object)
 }
 
 func NewNamespacedDockerCredentialLifecycleAdapter(name string, clusterScoped bool, client NamespacedDockerCredentialInterface, l NamespacedDockerCredentialLifecycle) NamespacedDockerCredentialHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(NamespacedDockerCredentialGroupVersionResource)
+	}
 	adapter := &namespacedDockerCredentialLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *NamespacedDockerCredential) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_service_account_token_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_service_account_token_controller.go
@@ -150,7 +150,6 @@ func (c *namespacedServiceAccountTokenController) AddHandler(ctx context.Context
 }
 
 func (c *namespacedServiceAccountTokenController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler NamespacedServiceAccountTokenHandlerFunc) {
-	resource.PutClusterScoped(NamespacedServiceAccountTokenGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_service_account_token_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_service_account_token_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *namespacedServiceAccountTokenLifecycleAdapter) Updated(obj runtime.Obje
 }
 
 func NewNamespacedServiceAccountTokenLifecycleAdapter(name string, clusterScoped bool, client NamespacedServiceAccountTokenInterface, l NamespacedServiceAccountTokenLifecycle) NamespacedServiceAccountTokenHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(NamespacedServiceAccountTokenGroupVersionResource)
+	}
 	adapter := &namespacedServiceAccountTokenLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *NamespacedServiceAccountToken) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_ssh_auth_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_ssh_auth_controller.go
@@ -150,7 +150,6 @@ func (c *namespacedSshAuthController) AddHandler(ctx context.Context, name strin
 }
 
 func (c *namespacedSshAuthController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler NamespacedSSHAuthHandlerFunc) {
-	resource.PutClusterScoped(NamespacedSSHAuthGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_ssh_auth_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_namespaced_ssh_auth_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *namespacedSshAuthLifecycleAdapter) Updated(obj runtime.Object) (runtime
 }
 
 func NewNamespacedSSHAuthLifecycleAdapter(name string, clusterScoped bool, client NamespacedSSHAuthInterface, l NamespacedSSHAuthLifecycle) NamespacedSSHAuthHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(NamespacedSSHAuthGroupVersionResource)
+	}
 	adapter := &namespacedSshAuthLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *NamespacedSSHAuth) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_pipeline_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_pipeline_controller.go
@@ -150,7 +150,6 @@ func (c *pipelineController) AddHandler(ctx context.Context, name string, handle
 }
 
 func (c *pipelineController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler PipelineHandlerFunc) {
-	resource.PutClusterScoped(PipelineGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_pipeline_execution_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_pipeline_execution_controller.go
@@ -150,7 +150,6 @@ func (c *pipelineExecutionController) AddHandler(ctx context.Context, name strin
 }
 
 func (c *pipelineExecutionController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler PipelineExecutionHandlerFunc) {
-	resource.PutClusterScoped(PipelineExecutionGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_pipeline_execution_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_pipeline_execution_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *pipelineExecutionLifecycleAdapter) Updated(obj runtime.Object) (runtime
 }
 
 func NewPipelineExecutionLifecycleAdapter(name string, clusterScoped bool, client PipelineExecutionInterface, l PipelineExecutionLifecycle) PipelineExecutionHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(PipelineExecutionGroupVersionResource)
+	}
 	adapter := &pipelineExecutionLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *PipelineExecution) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_pipeline_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_pipeline_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *pipelineLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, 
 }
 
 func NewPipelineLifecycleAdapter(name string, clusterScoped bool, client PipelineInterface, l PipelineLifecycle) PipelineHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(PipelineGroupVersionResource)
+	}
 	adapter := &pipelineLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Pipeline) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_pipeline_setting_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_pipeline_setting_controller.go
@@ -150,7 +150,6 @@ func (c *pipelineSettingController) AddHandler(ctx context.Context, name string,
 }
 
 func (c *pipelineSettingController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler PipelineSettingHandlerFunc) {
-	resource.PutClusterScoped(PipelineSettingGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_pipeline_setting_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_pipeline_setting_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *pipelineSettingLifecycleAdapter) Updated(obj runtime.Object) (runtime.O
 }
 
 func NewPipelineSettingLifecycleAdapter(name string, clusterScoped bool, client PipelineSettingInterface, l PipelineSettingLifecycle) PipelineSettingHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(PipelineSettingGroupVersionResource)
+	}
 	adapter := &pipelineSettingLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *PipelineSetting) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_service_account_token_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_service_account_token_controller.go
@@ -150,7 +150,6 @@ func (c *serviceAccountTokenController) AddHandler(ctx context.Context, name str
 }
 
 func (c *serviceAccountTokenController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ServiceAccountTokenHandlerFunc) {
-	resource.PutClusterScoped(ServiceAccountTokenGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_service_account_token_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_service_account_token_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *serviceAccountTokenLifecycleAdapter) Updated(obj runtime.Object) (runti
 }
 
 func NewServiceAccountTokenLifecycleAdapter(name string, clusterScoped bool, client ServiceAccountTokenInterface, l ServiceAccountTokenLifecycle) ServiceAccountTokenHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ServiceAccountTokenGroupVersionResource)
+	}
 	adapter := &serviceAccountTokenLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *ServiceAccountToken) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_credential_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_credential_controller.go
@@ -150,7 +150,6 @@ func (c *sourceCodeCredentialController) AddHandler(ctx context.Context, name st
 }
 
 func (c *sourceCodeCredentialController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler SourceCodeCredentialHandlerFunc) {
-	resource.PutClusterScoped(SourceCodeCredentialGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_credential_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_credential_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *sourceCodeCredentialLifecycleAdapter) Updated(obj runtime.Object) (runt
 }
 
 func NewSourceCodeCredentialLifecycleAdapter(name string, clusterScoped bool, client SourceCodeCredentialInterface, l SourceCodeCredentialLifecycle) SourceCodeCredentialHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(SourceCodeCredentialGroupVersionResource)
+	}
 	adapter := &sourceCodeCredentialLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *SourceCodeCredential) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_provider_config_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_provider_config_controller.go
@@ -150,7 +150,6 @@ func (c *sourceCodeProviderConfigController) AddHandler(ctx context.Context, nam
 }
 
 func (c *sourceCodeProviderConfigController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler SourceCodeProviderConfigHandlerFunc) {
-	resource.PutClusterScoped(SourceCodeProviderConfigGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_provider_config_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_provider_config_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *sourceCodeProviderConfigLifecycleAdapter) Updated(obj runtime.Object) (
 }
 
 func NewSourceCodeProviderConfigLifecycleAdapter(name string, clusterScoped bool, client SourceCodeProviderConfigInterface, l SourceCodeProviderConfigLifecycle) SourceCodeProviderConfigHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(SourceCodeProviderConfigGroupVersionResource)
+	}
 	adapter := &sourceCodeProviderConfigLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *SourceCodeProviderConfig) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_provider_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_provider_controller.go
@@ -149,7 +149,6 @@ func (c *sourceCodeProviderController) AddHandler(ctx context.Context, name stri
 }
 
 func (c *sourceCodeProviderController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler SourceCodeProviderHandlerFunc) {
-	resource.PutClusterScoped(SourceCodeProviderGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_provider_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_provider_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *sourceCodeProviderLifecycleAdapter) Updated(obj runtime.Object) (runtim
 }
 
 func NewSourceCodeProviderLifecycleAdapter(name string, clusterScoped bool, client SourceCodeProviderInterface, l SourceCodeProviderLifecycle) SourceCodeProviderHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(SourceCodeProviderGroupVersionResource)
+	}
 	adapter := &sourceCodeProviderLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *SourceCodeProvider) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_repository_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_repository_controller.go
@@ -150,7 +150,6 @@ func (c *sourceCodeRepositoryController) AddHandler(ctx context.Context, name st
 }
 
 func (c *sourceCodeRepositoryController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler SourceCodeRepositoryHandlerFunc) {
-	resource.PutClusterScoped(SourceCodeRepositoryGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_repository_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_source_code_repository_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *sourceCodeRepositoryLifecycleAdapter) Updated(obj runtime.Object) (runt
 }
 
 func NewSourceCodeRepositoryLifecycleAdapter(name string, clusterScoped bool, client SourceCodeRepositoryInterface, l SourceCodeRepositoryLifecycle) SourceCodeRepositoryHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(SourceCodeRepositoryGroupVersionResource)
+	}
 	adapter := &sourceCodeRepositoryLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *SourceCodeRepository) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_ssh_auth_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_ssh_auth_controller.go
@@ -150,7 +150,6 @@ func (c *sshAuthController) AddHandler(ctx context.Context, name string, handler
 }
 
 func (c *sshAuthController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler SSHAuthHandlerFunc) {
-	resource.PutClusterScoped(SSHAuthGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_ssh_auth_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_ssh_auth_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *sshAuthLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, e
 }
 
 func NewSSHAuthLifecycleAdapter(name string, clusterScoped bool, client SSHAuthInterface, l SSHAuthLifecycle) SSHAuthHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(SSHAuthGroupVersionResource)
+	}
 	adapter := &sshAuthLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *SSHAuth) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_workload_controller.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_workload_controller.go
@@ -150,7 +150,6 @@ func (c *workloadController) AddHandler(ctx context.Context, name string, handle
 }
 
 func (c *workloadController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler WorkloadHandlerFunc) {
-	resource.PutClusterScoped(WorkloadGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_workload_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/zz_generated_workload_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,9 @@ func (w *workloadLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, 
 }
 
 func NewWorkloadLifecycleAdapter(name string, clusterScoped bool, client WorkloadInterface, l WorkloadLifecycle) WorkloadHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(WorkloadGroupVersionResource)
+	}
 	adapter := &workloadLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *Workload) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_binding_controller.go
+++ b/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_binding_controller.go
@@ -150,7 +150,6 @@ func (c *clusterRoleBindingController) AddHandler(ctx context.Context, name stri
 }
 
 func (c *clusterRoleBindingController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ClusterRoleBindingHandlerFunc) {
-	resource.PutClusterScoped(ClusterRoleBindingGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_binding_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_binding_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *clusterRoleBindingLifecycleAdapter) Updated(obj runtime.Object) (runtim
 }
 
 func NewClusterRoleBindingLifecycleAdapter(name string, clusterScoped bool, client ClusterRoleBindingInterface, l ClusterRoleBindingLifecycle) ClusterRoleBindingHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ClusterRoleBindingGroupVersionResource)
+	}
 	adapter := &clusterRoleBindingLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.ClusterRoleBinding) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_controller.go
+++ b/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_controller.go
@@ -150,7 +150,6 @@ func (c *clusterRoleController) AddHandler(ctx context.Context, name string, han
 }
 
 func (c *clusterRoleController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler ClusterRoleHandlerFunc) {
-	resource.PutClusterScoped(ClusterRoleGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *clusterRoleLifecycleAdapter) Updated(obj runtime.Object) (runtime.Objec
 }
 
 func NewClusterRoleLifecycleAdapter(name string, clusterScoped bool, client ClusterRoleInterface, l ClusterRoleLifecycle) ClusterRoleHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(ClusterRoleGroupVersionResource)
+	}
 	adapter := &clusterRoleLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.ClusterRole) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_role_binding_controller.go
+++ b/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_role_binding_controller.go
@@ -151,7 +151,6 @@ func (c *roleBindingController) AddHandler(ctx context.Context, name string, han
 }
 
 func (c *roleBindingController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler RoleBindingHandlerFunc) {
-	resource.PutClusterScoped(RoleBindingGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_role_binding_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_role_binding_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *roleBindingLifecycleAdapter) Updated(obj runtime.Object) (runtime.Objec
 }
 
 func NewRoleBindingLifecycleAdapter(name string, clusterScoped bool, client RoleBindingInterface, l RoleBindingLifecycle) RoleBindingHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(RoleBindingGroupVersionResource)
+	}
 	adapter := &roleBindingLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.RoleBinding) (runtime.Object, error) {

--- a/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_role_controller.go
+++ b/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_role_controller.go
@@ -151,7 +151,6 @@ func (c *roleController) AddHandler(ctx context.Context, name string, handler Ro
 }
 
 func (c *roleController) AddClusterScopedHandler(ctx context.Context, name, cluster string, handler RoleHandlerFunc) {
-	resource.PutClusterScoped(RoleGroupVersionResource)
 	c.GenericController.AddHandler(ctx, name, func(key string, obj interface{}) (interface{}, error) {
 		if obj == nil {
 			return handler(key, nil)

--- a/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_role_lifecycle_adapter.go
+++ b/vendor/github.com/rancher/types/apis/rbac.authorization.k8s.io/v1/zz_generated_role_lifecycle_adapter.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
+	"github.com/rancher/norman/resource"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -51,6 +52,9 @@ func (w *roleLifecycleAdapter) Updated(obj runtime.Object) (runtime.Object, erro
 }
 
 func NewRoleLifecycleAdapter(name string, clusterScoped bool, client RoleInterface, l RoleLifecycle) RoleHandlerFunc {
+	if clusterScoped {
+		resource.PutClusterScoped(RoleGroupVersionResource)
+	}
 	adapter := &roleLifecycleAdapter{lifecycle: l}
 	syncFn := lifecycle.NewObjectLifecycleAdapter(name, clusterScoped, adapter, client.ObjectClient())
 	return func(key string, obj *v1.Role) (runtime.Object, error) {


### PR DESCRIPTION
Problem: In the cluster scoped finalizer removal refactor some finalizers
    were not cleaned up. This was due to way they were being added without
    calling AddClusterScoped Finalizer

Solution: Write legacy sync handlers to remove orphaned resources and
    update norman code generation to add cluster scoped handlers to the
    resource map in the LifecycleAdapter function instead of inside controllers.
    This essentially moves the resource map add further up the call.

_Dependencies_:
https://github.com/rancher/norman/pull/296
https://github.com/rancher/types/pull/946
