### PR TITLE
Allow rancher chart to config private registry

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -91,6 +91,10 @@ spec:
         - name: NO_PROXY
           value: {{ .Values.noProxy }}
 {{- end }}
+{{- if .Values.systemDefaultRegistry }}
+        - name: CATTLE_SYSTEM_DEFAULT_REGISTRY
+          value: {{ .Values.systemDefaultRegistry }}
+{{- end }}
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}
 {{- end }}

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -16,15 +16,21 @@ tests:
       content: "--add-local=auto"
 - it: should add CATTLE_SYSTEM_DEFAULT_REGISTRY to env and maintain default vars
   set:
+    systemDefaultRegistry: "registry.example.com"
     extraEnv:
-    - name: CATTLE_SYSTEM_DEFAULT_REGISTRY
-      value: registry.example.com
+    - name: CATTLE_TLS_MIN_VERSION
+      value: "1.0"
   asserts:
   - contains:
       path: spec.template.spec.containers[0].env
       content:
         name: CATTLE_SYSTEM_DEFAULT_REGISTRY
-        value: registry.example.com
+        value: "registry.example.com"
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: CATTLE_TLS_MIN_VERSION
+        value: "1.0"
   - contains:
       path: spec.template.spec.containers[0].env
       content:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -32,8 +32,8 @@ debug: false
 
 # Extra environment variables passed to the rancher pods.
 # extraEnv:
-# - name: CATTLE_SYSTEM_DEFAULT_REGISTRY
-#   value: "registry.example.com"
+# - name: CATTLE_TLS_MIN_VERSION
+#   value: "1.0"
 
 # Fully qualified name to reach your Rancher server
 # hostname: rancher.my.org
@@ -99,3 +99,5 @@ resources: {}
 # - ingress (default)
 # - external
 tls: ingress
+
+systemDefaultRegistry: ""


### PR DESCRIPTION
**Issue:**
users should be able to configure the private registry directly when they install Rancher, instead of having to use an environment variable.


**Solution:**
Allow Rancher chart to config private registry directly using `global. systemDefaultRegistry `.

**Related Issue:**
#22014