### PR TITLE
Fix version for publishing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -82,7 +82,7 @@ steps:
   settings:
     build_args:
     - ARCH=amd64
-    - VERSION=${DRONE_BRANCH/release\//}-head
+    - "VERSION=${DRONE_TAG}"
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile


### PR DESCRIPTION
Agent image had the wrong version because of this mistake.
It is working correctly on v2.2 branch and this brings the two in line.