### PR TITLE
Update naming of files for node drivers

### DIFF
--- a/pkg/controllers/management/drivers/nodedriver/machine_driver.go
+++ b/pkg/controllers/management/drivers/nodedriver/machine_driver.go
@@ -38,7 +38,7 @@ var (
 		"otc":          map[string]string{"privateKeyFile": "privateKeyFile"},
 		"packet":       map[string]string{"userdata": "userdata"},
 	}
-	sshKeyFields = map[string]bool{
+	SSHKeyFields = map[string]bool{
 		"sshKeyContents": true,
 		"sshKey":         true,
 		"privateKeyFile": true,
@@ -110,7 +110,7 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 		}
 		userCredFields, pwdFields, defaults := getCredFields(obj.Annotations)
 		for name, field := range existingSchema.Spec.ResourceFields {
-			if _, ok := sshKeyFields[name]; ok {
+			if _, ok := SSHKeyFields[name]; ok {
 				if field.Type != "password" {
 					forceUpdate = true
 					break
@@ -203,7 +203,7 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 			}
 		}
 
-		if field.Type == "password" && !sshKeyFields[name] || userCredFields[name] {
+		if field.Type == "password" && !SSHKeyFields[name] || userCredFields[name] {
 			credField := field
 			credField.Required = true
 			if val, ok := defaults[name]; ok {
@@ -212,7 +212,7 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 			credFields[name] = credField
 		}
 
-		if _, ok := sshKeyFields[name]; ok {
+		if _, ok := SSHKeyFields[name]; ok {
 			field.Type = "password"
 		}
 

--- a/tests/integration/suite/test_node.py
+++ b/tests/integration/suite/test_node.py
@@ -152,9 +152,9 @@ def test_writing_config_to_disk(admin_mc, wait_remove_resource):
         clusterId="local")
     wait_remove_resource(node_pool)
 
-    file_name = string_to_encoding(userdata)
+    dir_name = string_to_encoding(userdata)
 
-    full_path = os.path.join(tempdir, file_name)
+    full_path = os.path.join(tempdir, dir_name, 'userdata')
 
     def file_exists():
         try:


### PR DESCRIPTION
Problem:
When using a nodetemplate and passing in file info, that file that gets
created has a hashed name which ends up coming out in the downloaded
keys for a node

Solution:
Use the hash to create the dir and name the file as related to the field
on the driver

https://github.com/rancher/rancher/issues/20576