### PR TITLE
 Remove orphaned system account users

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -144,6 +144,7 @@ func Run(ctx context.Context, kubeConfig rest.Config, cfg *Config) error {
 		cronTime := settings.AuthUserInfoResyncCron.Get()
 		maxAge := settings.AuthUserInfoMaxAgeSeconds.Get()
 		providerrefresh.StartRefreshDaemon(ctx, scaledContext, management, cronTime, maxAge)
+		cleanupOrphanedSystemUsers(management)
 		logrus.Infof("Rancher startup complete")
 
 		<-ctx.Done()

--- a/app/app.go
+++ b/app/app.go
@@ -144,7 +144,7 @@ func Run(ctx context.Context, kubeConfig rest.Config, cfg *Config) error {
 		cronTime := settings.AuthUserInfoResyncCron.Get()
 		maxAge := settings.AuthUserInfoMaxAgeSeconds.Get()
 		providerrefresh.StartRefreshDaemon(ctx, scaledContext, management, cronTime, maxAge)
-		cleanupOrphanedSystemUsers(management)
+		cleanupOrphanedSystemUsers(ctx, management)
 		logrus.Infof("Rancher startup complete")
 
 		<-ctx.Done()

--- a/app/user_cleanup.go
+++ b/app/user_cleanup.go
@@ -1,0 +1,137 @@
+package app
+
+import (
+	"strings"
+	"time"
+
+	"github.com/rancher/rancher/pkg/systemaccount"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type userCleanup struct {
+	users         v3.UserInterface
+	userLister    v3.UserLister
+	clusterLister v3.ClusterLister
+	projectLister v3.ProjectLister
+}
+
+func cleanupOrphanedSystemUsers(management *config.ManagementContext) {
+	u := userCleanup{
+		users:         management.Management.Users(""),
+		userLister:    management.Management.Users("").Controller().Lister(),
+		clusterLister: management.Management.Clusters("").Controller().Lister(),
+		projectLister: management.Management.Projects("").Controller().Lister(),
+	}
+
+	go wait.PollImmediate(time.Hour*24, 0, func() (bool, error) {
+		logrus.Debugf("Starting orphaned system users cleanup with exponentialBackoff")
+		steps := 5
+		backOffDuration := time.Minute * 10
+		factor := 2
+		var err error
+		for steps > 0 {
+			err = u.cleanup()
+			if err != nil {
+				time.Sleep(backOffDuration)
+				backOffDuration = time.Duration(factor) * backOffDuration
+			} else {
+				break
+			}
+			steps--
+		}
+		if err != nil {
+			// returning false, nil because PollImmediate terminates on error
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func (u *userCleanup) cleanup() error {
+	users, err := u.userLister.List("", labels.Everything())
+	if err != nil {
+		logrus.Errorf("Error listing users during system account users cleanup: %v", err)
+		return err
+	}
+	clusters, err := u.clusterLister.List("", labels.Everything())
+	if err != nil {
+		logrus.Errorf("Error listing clusters during system account users cleanup: %v", err)
+		return err
+	}
+	var returnErr error
+	for _, user := range users {
+		systemUser := false
+		for _, principal := range user.PrincipalIDs {
+			if strings.HasPrefix(principal, "system://") {
+				systemUser = true
+				break
+			}
+		}
+		if !systemUser {
+			continue
+		}
+		if err := u.checkClusterOrProjectExistsForSystemUser(user, clusters); err != nil {
+			// errors are logged in checkClusterOrProjectExistsForSystemUser, but continue for loop for other users
+			// returning only one error at the end is sufficient for ExponentialBackoff/PollImmediate to try this again
+			returnErr = err
+		}
+	}
+	return returnErr
+}
+
+func (u *userCleanup) checkClusterOrProjectExistsForSystemUser(user *v3.User, clusters []*v3.Cluster) error {
+	displayName := user.DisplayName
+	if strings.HasPrefix(user.DisplayName, systemaccount.ClusterSystemAccountPrefix) {
+		clusterID := strings.TrimPrefix(displayName, systemaccount.ClusterSystemAccountPrefix)
+		// check if this cluster exists, if not, delete this user
+		clusterExists := false
+		for _, cluster := range clusters {
+			if cluster.Name == clusterID {
+				clusterExists = true
+				break
+			}
+		}
+		if clusterExists {
+			return nil
+		}
+		// cluster not found, delete the system user
+		return u.deleteSystemUser(user.Name)
+	} else if strings.HasPrefix(user.DisplayName, systemaccount.ProjectSystemAccountPrefix) {
+		projectID := strings.TrimPrefix(displayName, systemaccount.ProjectSystemAccountPrefix)
+		// check if this project exists, if not, delete this user
+		// how to find the cluster ID of this project: go through all clusters
+		projectExists := false
+		for _, cluster := range clusters {
+			project, err := u.projectLister.Get(cluster.Name, projectID)
+			if err != nil && !errors.IsNotFound(err) {
+				logrus.Errorf("Error finding project %v during system account users cleanup: %v", projectID, err)
+				return err
+			} else if err == nil && project != nil {
+				projectExists = true
+				break
+			}
+		}
+		if projectExists {
+			return nil
+		}
+		// project not found, so delete the system user for this project
+		return u.deleteSystemUser(user.Name)
+	}
+	return nil
+}
+
+func (u *userCleanup) deleteSystemUser(userName string) error {
+	err := u.users.Delete(userName, &v1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) && !errors.IsGone(err) {
+		return err
+	}
+	logrus.Debugf("Deleted system user %v since its associated cluster/project no longer exists", userName)
+	return nil
+}

--- a/pkg/controllers/user/pipeline/controller/project/project.go
+++ b/pkg/controllers/user/pipeline/controller/project/project.go
@@ -61,10 +61,6 @@ func (l *Syncer) Sync(key string, obj *v3.Project) (runtime.Object, error) {
 		if len(splits) == 2 {
 			projectID = splits[1]
 		}
-		// remove the system account created for this project
-		if err := l.systemAccountManager.RemoveSystemAccount(projectID); err != nil {
-			return nil, err
-		}
 		return nil, l.cleanInternalRegistryEntry(projectID)
 	}
 

--- a/pkg/systemaccount/systemaccount.go
+++ b/pkg/systemaccount/systemaccount.go
@@ -13,8 +13,10 @@ import (
 )
 
 const (
-	clusterOwnerRole  = "cluster-owner"
-	projectMemberRole = "project-member"
+	clusterOwnerRole           = "cluster-owner"
+	projectMemberRole          = "project-member"
+	ClusterSystemAccountPrefix = "System account for Cluster "
+	ProjectSystemAccountPrefix = "System account for Project "
 )
 
 func NewManager(management *config.ManagementContext) *Manager {
@@ -74,7 +76,7 @@ func (s *Manager) CreateSystemAccount(cluster *v3.Cluster) error {
 }
 
 func (s *Manager) GetSystemUser(clusterName string) (*v3.User, error) {
-	return s.userManager.EnsureUser(fmt.Sprintf("system://%s", clusterName), "System account for Cluster "+clusterName)
+	return s.userManager.EnsureUser(fmt.Sprintf("system://%s", clusterName), ClusterSystemAccountPrefix+clusterName)
 }
 
 func (s *Manager) GetOrCreateSystemClusterToken(clusterName string) (string, error) {
@@ -139,7 +141,7 @@ func (s *Manager) GetOrCreateProjectSystemAccount(projectID string) error {
 }
 
 func (s *Manager) GetProjectSystemUser(projectName string) (*v3.User, error) {
-	return s.userManager.EnsureUser(fmt.Sprintf("system://%s", projectName), "System account for Project "+projectName)
+	return s.userManager.EnsureUser(fmt.Sprintf("system://%s", projectName), ProjectSystemAccountPrefix+projectName)
 }
 
 func (s *Manager) GetOrCreateProjectSystemToken(projectName string) (string, error) {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/19018

A system user account is created for every cluster and project.
2.2.3 and prior versions did not delete these accounts when their clusters
or projects were deleted. 2.2.4 has the fix to delete these system users.
But the system users left behind from cluster/project deletion prior to 2.2.4
need to be cleaned up. This only needs to be done once on startup.