### PR TITLE
Add taints to rke config node for new node

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -512,6 +512,7 @@ func (m *Lifecycle) saveConfig(config *nodeconfig.NodeConfig, nodeDir string, ob
 			obj.Spec.UpdateTaintsFromAPI = &falseValue
 		}
 	}
+	obj.Status.NodeConfig.Taints = taints.GetRKETaintsFromTaints(obj.Spec.DesiredNodeTaints)
 
 	return obj, nil
 }

--- a/pkg/taints/utils.go
+++ b/pkg/taints/utils.go
@@ -95,3 +95,16 @@ func GetRKETaintsFromStrings(sources []string) []v3.RKETaint {
 	}
 	return rtn
 }
+
+func GetRKETaintsFromTaints(sources []v1.Taint) []v3.RKETaint {
+	rtn := make([]v3.RKETaint, len(sources))
+	for i, source := range sources {
+		rtn[i] = v3.RKETaint{
+			Key:       source.Key,
+			Effect:    source.Effect,
+			Value:     source.Value,
+			TimeAdded: source.TimeAdded,
+		}
+	}
+	return rtn
+}


### PR DESCRIPTION
Not only set v3.Node.Spec.DesiredNodeTaints but also set
obj.Status.NodeConfig.Taints. So RKE will generate taints to node
after node is provisioned.


https://github.com/rancher/rancher/issues/21577