### PR TITLE
Fix system taints missing

### DIFF
--- a/pkg/controllers/management/nodepool/nodepool.go
+++ b/pkg/controllers/management/nodepool/nodepool.go
@@ -124,11 +124,6 @@ func (c *Controller) createNode(name string, nodePool *v3.NodePool, simulate boo
 		},
 	}
 
-	if len(nodePool.Spec.NodeTaints) > 0 {
-		newNode.Spec.DesiredNodeTaints = append(newNode.Spec.DesiredNodeTaints, nodePool.Spec.NodeTaints...)
-		newNode.Spec.UpdateTaintsFromAPI = &falseValue
-	}
-
 	if simulate {
 		return newNode, nil
 	}

--- a/pkg/controllers/user/nodesyncer/nodetaints_test.go
+++ b/pkg/controllers/user/nodesyncer/nodetaints_test.go
@@ -1,0 +1,205 @@
+package nodesyncer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rancher/norman/httperror"
+	nodehelper "github.com/rancher/rancher/pkg/node"
+	"github.com/rancher/rancher/pkg/taints"
+	fake1 "github.com/rancher/types/apis/core/v1/fakes"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	fake3 "github.com/rancher/types/apis/management.cattle.io/v3/fakes"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type syncTaintsTestCase struct {
+	name                string
+	machine             v3.Node
+	node                v1.Node
+	nodeShouldUpdate    bool
+	nodeUpdated         bool
+	machineShouldUpdate bool
+	machineUpdated      bool
+}
+
+func TestSyncNodeTaints(t *testing.T) {
+	falseValue := false
+	testCases := []*syncTaintsTestCase{
+		&syncTaintsTestCase{
+			name:                "test taints equal",
+			machineShouldUpdate: true,
+			nodeShouldUpdate:    false,
+			machine: v3.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test1", Labels: map[string]string{nodehelper.LabelNodeName: "test1"}},
+				Status: v3.NodeStatus{
+					Conditions: []v3.NodeCondition{
+						v3.NodeCondition{
+							Type:   v3.NodeConditionRegistered,
+							Status: v1.ConditionTrue,
+						},
+					},
+					NodeName: "test1",
+				},
+				Spec: v3.NodeSpec{
+					DesiredNodeTaints: []v1.Taint{
+						v1.Taint{Key: "test-key", Value: "test-value", Effect: v1.TaintEffectNoSchedule},
+					},
+					UpdateTaintsFromAPI: &falseValue,
+				},
+			},
+			node: v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test1"},
+				Spec: v1.NodeSpec{
+					Taints: []v1.Taint{
+						v1.Taint{Key: "test-key", Value: "test-value", Effect: v1.TaintEffectNoSchedule},
+					},
+				},
+			},
+		},
+		&syncTaintsTestCase{
+			name:                "test add taints",
+			machineShouldUpdate: true,
+			nodeShouldUpdate:    true,
+			machine: v3.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test2", Labels: map[string]string{nodehelper.LabelNodeName: "test2"}},
+				Status: v3.NodeStatus{
+					Conditions: []v3.NodeCondition{
+						v3.NodeCondition{
+							Type:   v3.NodeConditionRegistered,
+							Status: v1.ConditionTrue,
+						},
+					},
+					NodeName: "test2",
+				},
+				Spec: v3.NodeSpec{
+					DesiredNodeTaints: []v1.Taint{
+						v1.Taint{Key: "test-key", Value: "test-value", Effect: v1.TaintEffectNoSchedule},
+					},
+					UpdateTaintsFromAPI: &falseValue,
+				},
+			},
+			node: v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test2"},
+				Spec:       v1.NodeSpec{},
+			},
+		},
+		&syncTaintsTestCase{
+			name:                "test remove taints",
+			machineShouldUpdate: true,
+			nodeShouldUpdate:    true,
+			machine: v3.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test3", Labels: map[string]string{nodehelper.LabelNodeName: "test3"}},
+				Status: v3.NodeStatus{
+					Conditions: []v3.NodeCondition{
+						v3.NodeCondition{
+							Type:   v3.NodeConditionRegistered,
+							Status: v1.ConditionTrue,
+						},
+					},
+					NodeName: "test3",
+				},
+				Spec: v3.NodeSpec{
+					UpdateTaintsFromAPI: &falseValue,
+				},
+			},
+			node: v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test3"},
+				Spec: v1.NodeSpec{
+					Taints: []v1.Taint{
+						v1.Taint{Key: "test-key", Value: "test-value", Effect: v1.TaintEffectNoSchedule},
+					},
+				},
+			},
+		},
+	}
+	syncer := nodesSyncer{
+		machines: &fake3.NodeInterfaceMock{
+			UpdateFunc: getMachineUpdateFunc(t, testCases),
+		},
+		nodeLister: &fake1.NodeListerMock{
+			GetFunc: getNodeListerGetFunc(t, testCases),
+		},
+		nodeClient: &fake1.NodeInterfaceMock{
+			UpdateFunc: getNodeInterfaceUpdateFunc(t, testCases),
+		},
+	}
+	for _, c := range testCases {
+		if _, err := syncer.syncTaints(c.machine.Name, &c.machine); err != nil {
+			t.Fatalf("test case %s failed, syncTaints return errors %s", c.name, err.Error())
+		}
+		if c.nodeShouldUpdate != c.nodeUpdated {
+			t.Fatalf("test case %s failed, expect node update status is %v but got %v", c.name, c.nodeShouldUpdate, c.nodeUpdated)
+		}
+		if c.machineShouldUpdate != c.machineUpdated {
+			t.Fatalf("test case %s failed, expect machine update status is %v but got %v", c.name, c.machineShouldUpdate, c.machineUpdated)
+		}
+	}
+}
+
+func getMachineUpdateFunc(t *testing.T, cases []*syncTaintsTestCase) func(*v3.Node) (*v3.Node, error) {
+	machineSet := caseByMachine(t, cases)
+	return func(in1 *v3.Node) (*v3.Node, error) {
+		c := machineSet[in1.Name]
+		c.machineUpdated = true
+		c.machine = *in1
+		if c.machine.Spec.DesiredNodeTaints != nil || c.machine.Spec.UpdateTaintsFromAPI != nil {
+			t.Fatalf("test case %s failed, update machine in node taints syncer should set DesiredNodeTaints and UpdateTaintsFromAPI to nil", c.name)
+		}
+		return &c.machine, nil
+	}
+}
+
+func getNodeListerGetFunc(t *testing.T, cases []*syncTaintsTestCase) func(string, string) (*v1.Node, error) {
+	nodeSet := caseByNode(t, cases)
+	return func(namespace string, name string) (*v1.Node, error) {
+		c, ok := nodeSet[name]
+		if !ok {
+			return nil, httperror.NewAPIError(httperror.NotFound, fmt.Sprintf("node %s not found", name))
+		}
+		return &c.node, nil
+	}
+}
+
+func getNodeInterfaceUpdateFunc(t *testing.T, cases []*syncTaintsTestCase) func(*v1.Node) (*v1.Node, error) {
+	nodeSet := caseByNode(t, cases)
+	return func(in1 *v1.Node) (*v1.Node, error) {
+		c, ok := nodeSet[in1.Name]
+		if !ok {
+			return nil, httperror.NewAPIError(httperror.NotFound, fmt.Sprintf("node %s not found", in1.Name))
+		}
+		if !c.nodeShouldUpdate {
+			return nil, fmt.Errorf("test case %s should not get into node update function", c.name)
+		}
+		toAdd, toDel := taints.GetToDiffTaints(in1.Spec.Taints, c.machine.Spec.DesiredNodeTaints)
+		if len(toAdd) != 0 || len(toDel) != 0 {
+			return nil, fmt.Errorf("test case %s failed, node taints are different from machine taints", c.name)
+		}
+		c.nodeUpdated = true
+		c.node = *in1
+		return in1, nil
+	}
+}
+
+func caseByMachine(t *testing.T, cases []*syncTaintsTestCase) map[string]*syncTaintsTestCase {
+	rtn := map[string]*syncTaintsTestCase{}
+	for _, c := range cases {
+		if _, ok := rtn[c.machine.Name]; ok {
+			t.Fatalf("test case %s has duplicated machine name %s", c.name, c.machine.Name)
+		}
+		rtn[c.machine.Name] = c
+	}
+	return rtn
+}
+
+func caseByNode(t *testing.T, cases []*syncTaintsTestCase) map[string]*syncTaintsTestCase {
+	rtn := map[string]*syncTaintsTestCase{}
+	for _, c := range cases {
+		if _, ok := rtn[c.node.Name]; ok {
+			t.Fatalf("test case %s has duplicated node name %s", c.name, c.node.Name)
+		}
+		rtn[c.node.Name] = c
+	}
+	return rtn
+}

--- a/pkg/controllers/user/nodesyncer/nodetaints_test.go
+++ b/pkg/controllers/user/nodesyncer/nodetaints_test.go
@@ -169,9 +169,6 @@ func getNodeInterfaceUpdateFunc(t *testing.T, cases []*syncTaintsTestCase) func(
 		if !ok {
 			return nil, httperror.NewAPIError(httperror.NotFound, fmt.Sprintf("node %s not found", in1.Name))
 		}
-		if !c.nodeShouldUpdate {
-			return nil, fmt.Errorf("test case %s should not get into node update function", c.name)
-		}
 		toAdd, toDel := taints.GetToDiffTaints(in1.Spec.Taints, c.machine.Spec.DesiredNodeTaints)
 		if len(toAdd) != 0 || len(toDel) != 0 {
 			return nil, fmt.Errorf("test case %s failed, node taints are different from machine taints", c.name)

--- a/pkg/controllers/user/windows/register.go
+++ b/pkg/controllers/user/windows/register.go
@@ -11,9 +11,8 @@ func Register(ctx context.Context, cluster *v3.Cluster, userContext *config.User
 	if !cluster.Spec.WindowsPreferedCluster {
 		return
 	}
-	clusterName := userContext.ClusterName
 	node := &NodeTaintsController{
-		nodeClient: userContext.Management.Management.Nodes(clusterName),
+		nodeClient: userContext.Core.Nodes(""),
 	}
-	userContext.Management.Management.Nodes(clusterName).AddClusterScopedHandler(ctx, "linux-node-taints-handler", clusterName, node.sync)
+	userContext.Core.Nodes("").AddHandler(ctx, "linux-node-taints-handler", node.sync)
 }

--- a/pkg/taints/utils.go
+++ b/pkg/taints/utils.go
@@ -54,17 +54,6 @@ func GetKeyEffectTaintSet(taints []v1.Taint) map[string]int {
 	return rtn
 }
 
-func GetTaintsFromStrings(sources []string) []v1.Taint {
-	var rtn []v1.Taint
-	for _, taintStr := range sources {
-		taint := GetTaintFromString(taintStr)
-		if taint != nil {
-			rtn = append(rtn, *taint)
-		}
-	}
-	return rtn
-}
-
 func GetToDiffTaints(current, desired []v1.Taint) (toAdd map[int]v1.Taint, toDel map[int]v1.Taint) {
 	toAdd, toDel = map[int]v1.Taint{}, map[int]v1.Taint{}
 	currentSet := GetTaintSet(current)


### PR DESCRIPTION
**Problem:**
Node taints syncer will remove `node-role.kubernetes.io/etcd` and
`node-role.kubernetes.io/controlplane` taints. It is because we set
taints both in RKE and Rancher side and the Rancher side will override
those taints added by RKE

**Solution:**
- Apply taints from node pool and node template to RKE config node so RKE
will add them when generating node.
- Linux node taints controller for Windows cluster add our taints to v1.Node
directly so we don't need to reuse the taints syncer logic of v3.Node.


Related issue:
https://github.com/rancher/rancher/issues/20805

