### PR TITLE
Use rancher fork of client-go for proxy issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ replace (
 	github.com/crewjam/saml => github.com/rancher/saml v0.0.0-20180713225824-ce1532152fde
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009
+	k8s.io/client-go => github.com/rancher/client-go v1.14.5-rancher.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,8 @@ github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.3 h1:CTwfnzjQ+8dS6MhHHu4YswVAD99sL2wjPqP+VkURmKE=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
+github.com/rancher/client-go v1.14.5-rancher.1 h1:3lriccMjs8HpK4H3OyHo1a0GIvr0lO/sEJSupl3QTz8=
+github.com/rancher/client-go v1.14.5-rancher.1/go.mod h1:N4rIJ5TXwpEuCvEf9SJLCX2CqgSTIIyCK8zIV34IZhE=
 github.com/rancher/kontainer-driver-metadata v0.0.0-20190819174335-6eb94126a98c h1:Of+EnlLZ33fmeZgQhr/Pb80iMaR9L8mQ2xvhzQk4o4w=
 github.com/rancher/kontainer-driver-metadata v0.0.0-20190819174335-6eb94126a98c/go.mod h1:VDixap7YjDnNwlfxL4gl890ThOVinEZE3qyAaG0xcQE=
 github.com/rancher/kontainer-driver-metadata v0.0.0-20190823210613-624182a785ce h1:4onzkfpjfusENeAFn7NhUSCdmBkFez3dRAaqDQGV8ng=

--- a/vendor/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/vendor/k8s.io/client-go/tools/cache/shared_informer.go
@@ -260,7 +260,8 @@ func (s *sharedIndexInformer) AddIndexers(indexers Indexers) error {
 	defer s.startedLock.Unlock()
 
 	if s.started {
-		return fmt.Errorf("informer has already started")
+		s.blockDeltas.Lock()
+		defer s.blockDeltas.Unlock()
 	}
 
 	return s.indexer.AddIndexers(indexers)

--- a/vendor/k8s.io/client-go/tools/cache/thread_safe_store.go
+++ b/vendor/k8s.io/client-go/tools/cache/thread_safe_store.go
@@ -125,6 +125,11 @@ func (c *threadSafeMap) Replace(items map[string]interface{}, resourceVersion st
 	c.items = items
 
 	// rebuild any index
+	c.rebuildIndices()
+}
+
+// rebuildIndices rebuilds all indices for the current set c.items. Assumes that c.lock is held by caller
+func (c *threadSafeMap) rebuildIndices() {
 	c.indices = Indices{}
 	for key, item := range c.items {
 		c.updateIndices(nil, item, key)
@@ -229,10 +234,6 @@ func (c *threadSafeMap) AddIndexers(newIndexers Indexers) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if len(c.items) > 0 {
-		return fmt.Errorf("cannot add indexers to running index")
-	}
-
 	oldKeys := sets.StringKeySet(c.indexers)
 	newKeys := sets.StringKeySet(newIndexers)
 
@@ -243,6 +244,11 @@ func (c *threadSafeMap) AddIndexers(newIndexers Indexers) error {
 	for k, v := range newIndexers {
 		c.indexers[k] = v
 	}
+
+	if len(c.items) > 0 {
+		c.rebuildIndices()
+	}
+
 	return nil
 }
 

--- a/vendor/k8s.io/client-go/transport/token_source.go
+++ b/vendor/k8s.io/client-go/transport/token_source.go
@@ -64,6 +64,10 @@ type tokenSourceTransport struct {
 	ort  http.RoundTripper
 }
 
+func (tst *tokenSourceTransport) WrappedRoundTripper() http.RoundTripper {
+	return tst.base
+}
+
 func (tst *tokenSourceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// This is to allow --token to override other bearer token providers.
 	if req.Header.Get("Authorization") != "" {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -686,7 +686,7 @@ k8s.io/apiserver/pkg/apis/audit/v1beta1
 k8s.io/apiserver/pkg/authorization/authorizer
 # k8s.io/cli-runtime v0.0.0-20190805185326-9eaa1a86d213
 k8s.io/cli-runtime/pkg/printers
-# k8s.io/client-go v11.0.1-0.20190805182715-88a2adca7e76+incompatible
+# k8s.io/client-go v11.0.1-0.20190805182715-88a2adca7e76+incompatible => github.com/rancher/client-go v1.14.5-rancher.1
 k8s.io/client-go/rest
 k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/kubernetes


### PR DESCRIPTION
There was two patches to client-go that were in k3s that Rancher
relied on.  Including those back.