### PR TITLE
build link to rancher-images correctly

### DIFF
--- a/pkg/api/customization/kontainerdriver/formatter.go
+++ b/pkg/api/customization/kontainerdriver/formatter.go
@@ -2,6 +2,7 @@ package kontainerdriver
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/rancher/norman/types"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
@@ -30,7 +31,11 @@ func NewFormatter(manangement *config.ScaledContext) types.Formatter {
 
 func CollectionFormatter(apiContext *types.APIContext, collection *types.GenericCollection) {
 	collection.AddAction(apiContext, "refresh")
-	collection.Links["rancher-images"] = fmt.Sprintf("%srancher-images", apiContext.URLBuilder.Current())
+	currContext := apiContext.URLBuilder.Current()
+	if !strings.HasSuffix(currContext, "/") {
+		currContext = fmt.Sprintf("%s/", currContext)
+	}
+	collection.Links["rancher-images"] = fmt.Sprintf("%srancher-images", currContext)
 }
 
 const clusterByGenericEngineConfigKey = "genericEngineConfig"


### PR DESCRIPTION
Problem: current apiContext depends on how user accesses url, could be "/kontainerdrivers" or "/kontainerdrivers/". 

Solution: Handle both scenarios, by appending "/"

https://github.com/rancher/rancher/issues/22462 