### PR TITLE
Ignore the first 60s error for HPA object

### DIFF
--- a/pkg/api/server/userstored/setup.go
+++ b/pkg/api/server/userstored/setup.go
@@ -3,6 +3,7 @@ package userstored
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/rancher/norman/store/subtype"
 	"github.com/rancher/norman/types"
@@ -13,6 +14,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/store/apiservice"
 	"github.com/rancher/rancher/pkg/api/store/cert"
 	"github.com/rancher/rancher/pkg/api/store/crd"
+	"github.com/rancher/rancher/pkg/api/store/hpa"
 	"github.com/rancher/rancher/pkg/api/store/ingress"
 	"github.com/rancher/rancher/pkg/api/store/namespace"
 	"github.com/rancher/rancher/pkg/api/store/nocondition"
@@ -168,4 +170,5 @@ func HPA(schemas *types.Schemas, manager *clustermanager.Manager) {
 	schema := schemas.Schema(&schema.Version, client.HorizontalPodAutoscalerType)
 	schema.Store = apiservice.NewAPIServicFilterStoreFunc(manager, "autoscaling/v2beta2")(schema.Store)
 	schema.Store = nocondition.NewWrapper("initializing", "")(schema.Store)
+	schema.Store = hpa.NewIgnoreTransitioningErrorStore(schema.Store, 60*time.Second, "initializing")
 }

--- a/pkg/api/store/hpa/store.go
+++ b/pkg/api/store/hpa/store.go
@@ -1,0 +1,60 @@
+package hpa
+
+import (
+	"time"
+
+	"github.com/rancher/norman/store/transform"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/values"
+)
+
+const (
+	condition = "ScalingActive"
+	status    = "False"
+	reason    = "FailedGetResourceMetric"
+)
+
+func NewIgnoreTransitioningErrorStore(store types.Store, d time.Duration, expectedState string) types.Store {
+	return &transform.Store{
+		Store: store,
+		Transformer: func(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, opt *types.QueryOptions) (map[string]interface{}, error) {
+			transitioning, _ := values.GetValue(data, "transitioning")
+			if transitioning != "error" {
+				return data, nil
+			}
+			conditions, ok := values.GetSlice(data, "conditions")
+			if !ok {
+				return data, nil
+			}
+			var found bool
+			for _, c := range conditions {
+				t, _ := values.GetValue(c, "type")
+				s, _ := values.GetValue(c, "status")
+				r, _ := values.GetValue(c, "reason")
+				if t == condition && s == status && r == reason {
+					found = true
+					break
+				}
+			}
+			created, ok := values.GetValue(data, "created")
+			if !ok {
+				return data, nil
+			}
+			t, err := time.Parse(time.RFC3339, created.(string))
+			if err != nil {
+				return data, nil
+			}
+			if time.Now().Sub(t).Nanoseconds()-d.Nanoseconds() > 0 {
+				return data, nil
+			}
+			if found {
+				values.PutValue(data, "yes", "transitioning")
+				values.PutValue(data, "", "transitioningMessage")
+				if expectedState != "" {
+					values.PutValue(data, expectedState, "state")
+				}
+			}
+			return data, nil
+		},
+	}
+}


### PR DESCRIPTION
**Problem:**
HPA with cpu rules for newly created workload will get
`transitioning=error` because the HPA controller can't get the cpu
metrics for newly created workload.

**Solutions:**
Ignore the transitioning error for the first 60s after HPA has been
created.

Related issue:
https://github.com/rancher/rancher/issues/20955