### PR TITLE
Cleanup legacy globalrolebindings finalizers to deleted clusters

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -41,6 +41,7 @@ import (
 	clustertemplatestore "github.com/rancher/rancher/pkg/api/store/clustertemplate"
 	featStore "github.com/rancher/rancher/pkg/api/store/feature"
 	globaldnsAPIStore "github.com/rancher/rancher/pkg/api/store/globaldns"
+	grbstore "github.com/rancher/rancher/pkg/api/store/globalrolebindings"
 	nodeStore "github.com/rancher/rancher/pkg/api/store/node"
 	nodeTemplateStore "github.com/rancher/rancher/pkg/api/store/nodetemplate"
 	"github.com/rancher/rancher/pkg/api/store/noopwatching"
@@ -170,6 +171,7 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	ProjectRoleTemplateBinding(schemas, apiContext)
 	TemplateContent(schemas)
 	PodSecurityPolicyTemplate(schemas, apiContext)
+	GlobalRoleBindings(schemas, apiContext)
 	RoleTemplate(schemas, apiContext)
 	MultiClusterApps(schemas, apiContext)
 	GlobalDNSs(schemas, apiContext, localClusterEnabled)
@@ -636,6 +638,11 @@ func ClusterRoleTemplateBinding(schemas *types.Schemas, management *config.Scale
 func ProjectRoleTemplateBinding(schemas *types.Schemas, management *config.ScaledContext) {
 	schema := schemas.Schema(&managementschema.Version, client.ProjectRoleTemplateBindingType)
 	schema.Validator = roletemplatebinding.NewPRTBValidator(management)
+}
+
+func GlobalRoleBindings(schemas *types.Schemas, management *config.ScaledContext) {
+	schema := schemas.Schema(&managementschema.Version, client.GlobalRoleBindingType)
+	schema.Store = grbstore.Wrap(schema.Store, management.Management.GlobalRoleBindings("").Controller().Lister())
 }
 
 func RoleTemplate(schemas *types.Schemas, management *config.ScaledContext) {

--- a/pkg/api/store/globalrolebindings/globalrolebinding_store.go
+++ b/pkg/api/store/globalrolebindings/globalrolebinding_store.go
@@ -1,0 +1,28 @@
+package grbstore
+
+import (
+	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/values"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+)
+
+const GrbVersion = "field.cattle.io/grbUpgrade"
+
+func Wrap(store types.Store, grbLister v3.GlobalRoleBindingLister) types.Store {
+	return &grbStore{
+		Store:     store,
+		grbLister: grbLister,
+	}
+}
+
+type grbStore struct {
+	types.Store
+	grbLister v3.GlobalRoleBindingLister
+}
+
+func (s *grbStore) Create(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}) (map[string]interface{}, error) {
+
+	values.PutValue(data, "true", "metadata", "annotations", GrbVersion)
+
+	return s.Store.Create(apiContext, schema, data)
+}

--- a/pkg/api/store/roletemplate/store.go
+++ b/pkg/api/store/roletemplate/store.go
@@ -5,9 +5,12 @@ import (
 
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/values"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"k8s.io/apimachinery/pkg/labels"
 )
+
+const RTVersion = "field.cattle.io/rtUpgrade"
 
 func Wrap(store types.Store, rtLister v3.RoleTemplateLister) types.Store {
 	return &rtStore{
@@ -37,4 +40,11 @@ func (s *rtStore) Delete(apiContext *types.APIContext, schema *types.Schema, id 
 		}
 	}
 	return s.Store.Delete(apiContext, schema, id)
+}
+
+func (s *rtStore) Create(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}) (map[string]interface{}, error) {
+
+	values.PutValue(data, "true", "metadata", "annotations", RTVersion)
+
+	return s.Store.Create(apiContext, schema, data)
 }

--- a/tests/integration/suite/test_users.py
+++ b/tests/integration/suite/test_users.py
@@ -1,5 +1,7 @@
 import pytest
+from kubernetes.client import CustomObjectsApi
 from rancher import ApiError
+from .conftest import random_str, wait_for
 
 
 def test_user_cant_delete_self(admin_mc):
@@ -16,3 +18,59 @@ def test_user_cant_deactivate_self(admin_mc):
         client.update(admin_mc.user, enabled=False)
 
     assert e.value.error.status == 422
+
+
+def test_globalrolebinding_finalizer_cleanup(admin_mc, remove_resource):
+    """This ensures that globalrolebinding cleanup of clusters < v2.2.8
+        is performed correctly"""
+    client = admin_mc.client
+    grb = client.create_globalRoleBinding(
+        globalRoleId="admin", userId="u-" + random_str()
+    )
+    remove_resource(grb)
+    assert grb.annotations["field.cattle.io/grbUpgrade"] == "true"
+
+    # create a grb without the rancher api with a bad finalizer
+    api = CustomObjectsApi(admin_mc.k8s_client)
+    json = {
+        "apiVersion": "management.cattle.io/v3",
+        "globalRoleName": "admin",
+        "kind": "GlobalRoleBinding",
+        "metadata": {
+            "finalizers": ["clusterscoped.controller.cattle.io/grb-sync_fake"],
+            "generation": 1,
+            "name": "grb-" + random_str(),
+        },
+        "userName": "u-" + random_str(),
+    }
+    grb_k8s = api.create_cluster_custom_object(
+        group="management.cattle.io",
+        version="v3",
+        plural="globalrolebindings",
+        body=json,
+    )
+    remove_resource(grb_k8s["metadata"]["name"])
+    grb_name = grb_k8s["metadata"]["name"]
+    grb_k8s = client.by_id_globalRoleBinding(id=grb_name)
+
+    def check_annotation():
+        grb1 = client.by_id_globalRoleBinding(grb_k8s.id)
+        try:
+            if grb1.annotations["field.cattle.io/grbUpgrade"] == "true":
+                return True
+            else:
+                return False
+        except (AttributeError, KeyError):
+            return False
+
+    wait_for(check_annotation, fail_handler=lambda: "annotation was not added")
+    grb1 = api.get_cluster_custom_object(
+        group="management.cattle.io",
+        version="v3",
+        plural="globalrolebindings",
+        name=grb_k8s.id,
+    )
+    assert (
+        "clusterscoped.controller.cattle.io/grb-sync_fake"
+        not in grb1["metadata"]["finalizers"]
+    )

--- a/tests/integration/suite/test_users.py
+++ b/tests/integration/suite/test_users.py
@@ -49,9 +49,9 @@ def test_globalrolebinding_finalizer_cleanup(admin_mc, remove_resource):
         plural="globalrolebindings",
         body=json,
     )
-    remove_resource(grb_k8s["metadata"]["name"])
     grb_name = grb_k8s["metadata"]["name"]
     grb_k8s = client.by_id_globalRoleBinding(id=grb_name)
+    remove_resource(grb_k8s)
 
     def check_annotation():
         grb1 = client.by_id_globalRoleBinding(grb_k8s.id)
@@ -74,3 +74,54 @@ def test_globalrolebinding_finalizer_cleanup(admin_mc, remove_resource):
         "clusterscoped.controller.cattle.io/grb-sync_fake"
         not in grb1["metadata"]["finalizers"]
     )
+
+
+def test_roletemplate_finalizer_cleanup(admin_mc, remove_resource):
+    """ This ensures that roletemplates cleanup for clusters < v2.2.8
+        is performed correctly"""
+    client = admin_mc.client
+    rt = client.create_roleTemplate(name="rt-" + random_str())
+    remove_resource(rt)
+    assert rt.annotations["field.cattle.io/rtUpgrade"] == "true"
+
+    # create rt  without rancher api with a bad finalizer
+    api = CustomObjectsApi(admin_mc.k8s_client)
+    json = {
+        "apiVersion": "management.cattle.io/v3",
+        "kind": "RoleTemplate",
+        "metadata": {
+            "finalizers": [
+                "clusterscoped.controller.cattle.io/" +
+                "cluster-roletemplate-sync_fake"
+            ],
+            "name": "test-" + random_str(),
+        }
+    }
+    rt_k8s = api.create_cluster_custom_object(
+        group="management.cattle.io",
+        version="v3",
+        plural="roletemplates",
+        body=json,
+    )
+    rt_name = rt_k8s["metadata"]["name"]
+    rt_k8s = client.by_id_roleTemplate(id=rt_name)
+    remove_resource(rt_k8s)
+
+    def check_annotation():
+        rt1 = client.by_id_roleTemplate(rt_k8s.id)
+        try:
+            if rt1.annotations["field.cattle.io/rtUpgrade"] == "true":
+                return True
+            else:
+                return False
+        except (AttributeError, KeyError):
+            return False
+    wait_for(check_annotation, fail_handler=lambda: "annotation was not added")
+    rt1 = api.get_cluster_custom_object(
+        group="management.cattle.io",
+        version="v3",
+        plural="roletemplates",
+        name=rt_k8s.id,
+    )
+    assert "clusterscoped.controller.cattle.io/grb-sync_fake" \
+        not in rt1["metadata"]["finalizers"]


### PR DESCRIPTION
Previously, this only removed finalizers from deleted grbs with a 1 hour delay.
This meant that when a user had their admin access removed it would take one hour for
the change to propogate if they had a finalizer to a non-existent cluster in their list of finalizers.

Now, we premptively remove "bad" finalziers from grbs that point to non-existent clusters so that on
change they will not need to be cleaned. This only occurs for grbs with a creation timestamp greater than
one hour to prevent interference with normal handler operations.

Similar to: https://github.com/rancher/rancher/pull/22338
Addresses: https://github.com/rancher/rancher/issues/22486