### PR TITLE
Fix worker taints not applied

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -537,7 +537,7 @@ func (m *Lifecycle) saveConfig(config *nodeconfig.NodeConfig, nodeDir string, ob
 		// the expect taints are based on the node pool. so we don't need to set taints with same key and effect by template because
 		// the taints from node pool should override the taints from template.
 		if _, ok := nodeSet[key]; !ok {
-			expectTaints = append(obj.Spec.DesiredNodeTaints, template.Spec.NodeTaints[ti])
+			expectTaints = append(expectTaints, template.Spec.NodeTaints[ti])
 		}
 	}
 	obj.Status.NodeConfig.Taints = taints.GetRKETaintsFromTaints(expectTaints)

--- a/pkg/rkenodeconfigserver/nodeserver_test.go
+++ b/pkg/rkenodeconfigserver/nodeserver_test.go
@@ -1,0 +1,90 @@
+package rkenodeconfigserver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rancher/rancher/pkg/taints"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestAppendKubeletArgs(t *testing.T) {
+	type testCase struct {
+		name             string
+		currentCommand   []string
+		taints           []v3.RKETaint
+		expectedTaintSet map[string]struct{}
+	}
+	testCases := []testCase{
+		testCase{
+			name:           "taints args not exists",
+			currentCommand: []string{"kubelet", "--register-node"},
+			taints: []v3.RKETaint{
+				v3.RKETaint{
+					Key:    "test1",
+					Value:  "value1",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				v3.RKETaint{
+					Key:    "test2",
+					Value:  "value2",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedTaintSet: map[string]struct{}{
+				"test1=value1:NoSchedule": struct{}{},
+				"test2=value2:NoSchedule": struct{}{},
+			},
+		},
+		testCase{
+			name:           "taints args exists",
+			currentCommand: []string{"kubelet", "--register-node", "--register-with-taints=node-role.kubernetes.io/controlplane=true:NoSchedule"},
+			taints: []v3.RKETaint{
+				v3.RKETaint{
+					Key:    "test1",
+					Value:  "value1",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedTaintSet: map[string]struct{}{
+				"node-role.kubernetes.io/controlplane=true:NoSchedule": struct{}{},
+				"test1=value1:NoSchedule":                              struct{}{},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		processes := getKubeletProcess(tc.currentCommand)
+		afterAppend := appendTaintsToKubeletArgs(processes, tc.taints)
+		appendedCommand := getCommandFromProcesses(afterAppend)
+		assert.Equal(t, tc.expectedTaintSet, appendedCommand, "", "")
+	}
+}
+
+func getKubeletProcess(commands []string) map[string]v3.Process {
+	return map[string]v3.Process{
+		"kubelet": v3.Process{
+			Name:    "kubelet",
+			Command: commands,
+		},
+	}
+}
+
+func getCommandFromProcesses(processes map[string]v3.Process) map[string]struct{} {
+	kubelet, ok := processes["kubelet"]
+	if !ok {
+		return nil
+	}
+	rtn := map[string]struct{}{}
+	var tmp map[string]int
+	for _, command := range kubelet.Command {
+		if strings.HasPrefix(command, "--register-with-taints=") {
+			tmp = taints.GetTaintSet(taints.GetTaintsFromStrings(strings.Split(strings.TrimPrefix(command, "--register-with-taints="), ",")))
+		}
+	}
+	for key := range tmp {
+		rtn[key] = struct{}{}
+	}
+	return rtn
+}

--- a/pkg/taints/utils.go
+++ b/pkg/taints/utils.go
@@ -13,6 +13,10 @@ func GetTaintsString(taint v1.Taint) string {
 	return fmt.Sprintf("%s=%s:%s", taint.Key, taint.Value, taint.Effect)
 }
 
+func GetRKETaintsString(taint v3.RKETaint) string {
+	return fmt.Sprintf("%s=%s:%s", taint.Key, taint.Value, taint.Effect)
+}
+
 func GetKeyEffectString(taint v1.Taint) string {
 	return fmt.Sprintf("%s:%s", taint.Key, taint.Effect)
 }
@@ -85,6 +89,14 @@ func GetRKETaintsFromStrings(sources []string) []v3.RKETaint {
 	return rtn
 }
 
+func GetStringsFromRKETaint(taints []v3.RKETaint) []string {
+	var rtn []string
+	for _, taint := range taints {
+		rtn = append(rtn, GetRKETaintsString(taint))
+	}
+	return rtn
+}
+
 func GetRKETaintsFromTaints(sources []v1.Taint) []v3.RKETaint {
 	rtn := make([]v3.RKETaint, len(sources))
 	for i, source := range sources {
@@ -94,6 +106,41 @@ func GetRKETaintsFromTaints(sources []v1.Taint) []v3.RKETaint {
 			Value:     source.Value,
 			TimeAdded: source.TimeAdded,
 		}
+	}
+	return rtn
+}
+
+func GetStringsFromTaint(taints []v1.Taint) []string {
+	var rtn []string
+	for _, taint := range taints {
+		rtn = append(rtn, GetTaintsString(taint))
+	}
+	return rtn
+}
+
+func GetTaintsFromStrings(sources []string) []v1.Taint {
+	var rtn []v1.Taint
+	for _, source := range sources {
+		taint := GetTaintFromString(source)
+		if taint == nil {
+			continue
+		}
+		rtn = append(rtn, *taint)
+	}
+	return rtn
+}
+
+//MergeTaints will override t1 taint by t2 with same key and effect
+func MergeTaints(t1 []v1.Taint, t2 []v1.Taint) []v1.Taint {
+	set1 := GetKeyEffectTaintSet(t1)
+	set2 := GetKeyEffectTaintSet(t2)
+	rtn := t2
+	for key, i := range set1 {
+		if j, ok := set2[key]; ok {
+			logrus.Infof("overriding taint %s with %s", GetTaintsString(t1[i]), GetTaintsString(t2[j]))
+			continue
+		}
+		rtn = append(rtn, t1[i])
 	}
 	return rtn
 }

--- a/pkg/taints/utils_test.go
+++ b/pkg/taints/utils_test.go
@@ -1,0 +1,86 @@
+package taints
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestMergeTaints(t *testing.T) {
+	type testCase struct {
+		name         string
+		t1           []v1.Taint
+		t2           []v1.Taint
+		mergedTaints []v1.Taint
+	}
+	testCases := []testCase{
+		testCase{
+			name: "merge with unique key and effect",
+			t1: []v1.Taint{
+				v1.Taint{
+					Key:    "t1",
+					Value:  "t1",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			t2: []v1.Taint{
+				v1.Taint{
+					Key:    "t2",
+					Value:  "t2",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			mergedTaints: []v1.Taint{
+				v1.Taint{
+					Key:    "t1",
+					Value:  "t1",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				v1.Taint{
+					Key:    "t2",
+					Value:  "t2",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		testCase{
+			name: "override values",
+			t1: []v1.Taint{
+				v1.Taint{
+					Key:    "t1",
+					Value:  "t1",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			t2: []v1.Taint{
+				v1.Taint{
+					Key:    "t1",
+					Value:  "v3",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			mergedTaints: []v1.Taint{
+				v1.Taint{
+					Key:    "t1",
+					Value:  "v3",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		merged := MergeTaints(tc.t1, tc.t2)
+		mergedSet := getUniqueSet(GetTaintSet(merged))
+		expectedSet := getUniqueSet(GetTaintSet(tc.mergedTaints))
+		assert.Equal(t, expectedSet, mergedSet, "test case %s failed, expected merged taints %+v are different from merged taints %+v", tc.name, expectedSet, mergedSet)
+	}
+}
+
+func getUniqueSet(set map[string]int) map[string]struct{} {
+	rtn := make(map[string]struct{}, len(set))
+	for key := range set {
+		rtn[key] = struct{}{}
+	}
+	return rtn
+}


### PR DESCRIPTION
**Problem:**
Setting node pool taints and node template taints doesn't work.

**Solution:**
Add kubelet args `--register-with-taints` parameters to kubelet worker
process. So those taints will be added after kubelet is up and running.

Related issue:
https://github.com/rancher/rancher/issues/22513