### PR TITLE
Add driver type to nodePool resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/rancher/norman v0.0.0-20190829223613-7317090b9b71
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/rke v0.3.0-rc8.0.20190830174211-32bf922fc5ac
-	github.com/rancher/types v0.0.0-20190829235015-3aced2bfa27e
+	github.com/rancher/types v0.0.0-20190830223007-e70505280772
 	github.com/rancher/wrangler v0.1.6-0.20190822171720-e78d8316ee95
 	github.com/robfig/cron v1.1.0
 	github.com/russellhaering/goxmldsig v0.0.0-20180122054445-a348271703b2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -304,6 +304,8 @@ github.com/rancher/types v0.0.0-20190822170951-b99efa820bc3/go.mod h1:9L7VLTwNVt
 github.com/rancher/types v0.0.0-20190827214052-704648244586/go.mod h1:9L7VLTwNVt7vJYwP/7xrQ4tWghDQ+zl9//RTqRjGxes=
 github.com/rancher/types v0.0.0-20190829235015-3aced2bfa27e h1:kAcwk3EvvYxvKHVpod4JWkh77z0HxUEuvGPV7pG6NSo=
 github.com/rancher/types v0.0.0-20190829235015-3aced2bfa27e/go.mod h1:9L7VLTwNVt7vJYwP/7xrQ4tWghDQ+zl9//RTqRjGxes=
+github.com/rancher/types v0.0.0-20190830223007-e70505280772 h1:NLx69aTYYlbrSrOupUXzIiRaiSZ5ayRvXDVogjPs7Nk=
+github.com/rancher/types v0.0.0-20190830223007-e70505280772/go.mod h1:9L7VLTwNVt7vJYwP/7xrQ4tWghDQ+zl9//RTqRjGxes=
 github.com/rancher/wrangler v0.1.5 h1:HiXOeP6Kci2DK+e04D1g6INT77xAYpAr54zmTTe0Spk=
 github.com/rancher/wrangler v0.1.5/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rancher/wrangler v0.1.6-0.20190822171720-e78d8316ee95 h1:/yghR1MGJk6l6CVxJSx9JGBFP1D6NchJ74wJz7JwxC4=

--- a/pkg/api/customization/nodepool/formatter.go
+++ b/pkg/api/customization/nodepool/formatter.go
@@ -1,0 +1,35 @@
+package nodepool
+
+import (
+	"strings"
+
+	"github.com/rancher/norman/types"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	client "github.com/rancher/types/client/management/v3"
+	"github.com/sirupsen/logrus"
+)
+
+type Formatter struct {
+	NodeTemplateLister v3.NodeTemplateLister
+}
+
+func (ntf *Formatter) Formatter(request *types.APIContext, resource *types.RawResource) {
+	nodeTemplateID, _ := resource.Values[client.NodePoolFieldNodeTemplateID].(string)
+	if nodeTemplateID == "" {
+		return
+	}
+
+	// id is namespace:name
+	parts := strings.Split(nodeTemplateID, ":")
+	if len(parts) != 2 {
+		return
+	}
+
+	template, err := ntf.NodeTemplateLister.Get(parts[0], parts[1])
+	if err != nil {
+		logrus.Warnf("Failed to get nodeTemplate driver for nodePool %v. Error: %v", resource.ID, err)
+		return
+	}
+
+	resource.Values["driver"] = template.Spec.Driver
+}

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/customization/monitor"
 	"github.com/rancher/rancher/pkg/api/customization/multiclusterapp"
 	"github.com/rancher/rancher/pkg/api/customization/node"
+	"github.com/rancher/rancher/pkg/api/customization/nodepool"
 	"github.com/rancher/rancher/pkg/api/customization/nodetemplate"
 	"github.com/rancher/rancher/pkg/api/customization/pipeline"
 	"github.com/rancher/rancher/pkg/api/customization/podsecuritypolicytemplate"
@@ -453,6 +454,13 @@ func NodeTypes(schemas *types.Schemas, management *config.ScaledContext) error {
 	schema.LinkHandler = machineHandler.LinkHandler
 	actionWrapper := node.ActionWrapper{}
 	schema.ActionHandler = actionWrapper.ActionHandler
+
+	schema = schemas.Schema(&managementschema.Version, client.NodePoolType)
+	ntl := management.Management.NodeTemplates("").Controller().Lister()
+	f := &nodepool.Formatter{
+		NodeTemplateLister: ntl,
+	}
+	schema.Formatter = f.Formatter
 	return nil
 }
 

--- a/tests/integration/suite/test_node.py
+++ b/tests/integration/suite/test_node.py
@@ -12,7 +12,7 @@ import time
 def test_node_fields(admin_mc):
     cclient = admin_mc.client
     fields = {
-        'annotations': 'r',
+        'annotations': 'cru',
         'labels': 'cru',
         'nodeTaints': 'r',
         'namespaceId': 'cr',

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema/schema.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema/schema.go
@@ -341,13 +341,24 @@ func nodeTypes(schemas *types.Schemas) *types.Schemas {
 		AddMapperForType(&Version, v3.NodeDriver{}, m.DisplayName{}).
 		AddMapperForType(&Version, v3.NodeTemplate{}, m.DisplayName{}).
 		MustImport(&Version, v3.PublicEndpoint{}).
-		MustImport(&Version, v3.NodePool{}).
+		MustImportAndCustomize(&Version, v3.NodePool{}, func(schema *types.Schema) {
+			schema.ResourceFields["driver"] = types.Field{
+				Type:     "string",
+				CodeName: "Driver",
+				Create:   false,
+				Update:   false,
+			}
+		}).
 		MustImport(&Version, v3.NodeDrainInput{}).
 		MustImportAndCustomize(&Version, v3.Node{}, func(schema *types.Schema) {
 			labelField := schema.ResourceFields["labels"]
 			labelField.Create = true
 			labelField.Update = true
 			schema.ResourceFields["labels"] = labelField
+			annotationField := schema.ResourceFields["annotations"]
+			annotationField.Create = true
+			annotationField.Update = true
+			schema.ResourceFields["annotations"] = annotationField
 			unschedulable := schema.ResourceFields["unschedulable"]
 			unschedulable.Create = false
 			unschedulable.Update = false

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_node_pool.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_node_pool.go
@@ -13,6 +13,7 @@ const (
 	NodePoolFieldCreatorID               = "creatorId"
 	NodePoolFieldDeleteNotReadyAfterSecs = "deleteNotReadyAfterSecs"
 	NodePoolFieldDisplayName             = "displayName"
+	NodePoolFieldDriver                  = "driver"
 	NodePoolFieldEtcd                    = "etcd"
 	NodePoolFieldHostnamePrefix          = "hostnamePrefix"
 	NodePoolFieldLabels                  = "labels"
@@ -42,6 +43,7 @@ type NodePool struct {
 	CreatorID               string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	DeleteNotReadyAfterSecs int64             `json:"deleteNotReadyAfterSecs,omitempty" yaml:"deleteNotReadyAfterSecs,omitempty"`
 	DisplayName             string            `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Driver                  string            `json:"driver,omitempty" yaml:"driver,omitempty"`
 	Etcd                    bool              `json:"etcd,omitempty" yaml:"etcd,omitempty"`
 	HostnamePrefix          string            `json:"hostnamePrefix,omitempty" yaml:"hostnamePrefix,omitempty"`
 	Labels                  map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -355,7 +355,7 @@ github.com/rancher/rke/dind
 github.com/rancher/rke/cloudprovider/custom
 github.com/rancher/rke/cloudprovider/openstack
 github.com/rancher/rke/cloudprovider/vsphere
-# github.com/rancher/types v0.0.0-20190829235015-3aced2bfa27e
+# github.com/rancher/types v0.0.0-20190830223007-e70505280772
 github.com/rancher/types/apis/management.cattle.io/v3
 github.com/rancher/types/client/management/v3
 github.com/rancher/types/config


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/22080

Types PR: https://github.com/rancher/types/pull/971

Adds a virtual field (not stored in db) to the nodepool resource via formatter that identifies the driver type (string). 

Hit `/v3/schemas/nodePool` to see schema
Hit `/v3/nodePool` to see resources

Schema
<img width="199" alt="driver-on-schema-2" src="https://user-images.githubusercontent.com/571419/64048774-91b17500-cb27-11e9-927b-2737fc9f2435.png">


Resource
<img width="344" alt="driver-on-object" src="https://user-images.githubusercontent.com/571419/64048623-15b72d00-cb27-11e9-9a51-41268e1a29e0.png">