### PR TITLE
add support for deprecating k8s versions

### DIFF
--- a/app/setting.go
+++ b/app/setting.go
@@ -1,41 +1,10 @@
 package app
 
 import (
-	"sort"
-
-	"github.com/rancher/rke/util"
-
 	"github.com/pborman/uuid"
-	metadata "github.com/rancher/kontainer-driver-metadata/rke"
-	kd "github.com/rancher/rancher/pkg/controllers/management/kontainerdrivermetadata"
 	"github.com/rancher/rancher/pkg/settings"
 )
 
 func addSetting() error {
-	if err := settings.InstallUUID.SetIfUnset(uuid.NewRandom().String()); err != nil {
-		return err
-	}
-	return addK8sVersionData()
-}
-
-func addK8sVersionData() error {
-	rancherVersion := kd.GetRancherVersion()
-	k8sCurrVersions := map[string]interface{}{}
-
-	k8sVersionToRKESystemImages, k8sVersionToSvcOptions := kd.GetK8sVersionInfo(rancherVersion,
-		metadata.DriverData.K8sVersionRKESystemImages,
-		metadata.DriverData.K8sVersionServiceOptions,
-		metadata.DriverData.K8sVersionInfo)
-
-	for k := range k8sVersionToRKESystemImages {
-		k8sCurrVersions[k] = nil
-	}
-
-	var keys []string
-	for k := range k8sVersionToRKESystemImages {
-		keys = append(keys, util.GetTagMajorVersion(k))
-	}
-	sort.Strings(keys)
-
-	return kd.SaveSettings(k8sCurrVersions, k8sVersionToSvcOptions, metadata.DriverData.RancherDefaultK8sVersions, rancherVersion, keys)
+	return settings.InstallUUID.SetIfUnset(uuid.NewRandom().String())
 }

--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -724,6 +724,9 @@ func (p *Provisioner) validateDriver(cluster *v3.Cluster) (string, error) {
 func (p *Provisioner) getSystemImages(spec v3.ClusterSpec) (*v3.RKESystemImages, error) {
 	// fetch system images from settings
 	version := spec.RancherKubernetesEngineConfig.Version
+	if isDeprecated(version) {
+		return nil, fmt.Errorf("failed to find system images for version %s, it is deprecated", version)
+	}
 	systemImages, err := kd.GetRKESystemImages(version, p.RKESystemImagesLister, p.RKESystemImages)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find system images for version %s: %v", version, err)
@@ -947,4 +950,9 @@ func GetBackupFilename(backup *v3.EtcdBackup) string {
 		snapshot = strings.TrimSuffix(backup.Spec.Filename, path.Ext(backup.Spec.Filename))
 	}
 	return snapshot
+}
+
+func isDeprecated(version string) bool {
+	deprecatedVersions := convert.ToMapInterface(settings.KubernetesVersionsDeprecated.Get())
+	return convert.ToBool(deprecatedVersions[version])
 }

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -32,6 +32,7 @@ var (
 	KubernetesVersionToServiceOptions = NewSetting("k8s-version-to-service-options", "")
 	KubernetesVersionToSystemImages   = NewSetting("k8s-version-to-images", "")
 	KubernetesVersionsCurrent         = NewSetting("k8s-versions-current", "")
+	KubernetesVersionsDeprecated      = NewSetting("k8s-versions-deprecated", "")
 	MachineVersion                    = NewSetting("machine-version", "dev")
 	Namespace                         = NewSetting("namespace", os.Getenv("CATTLE_NAMESPACE"))
 	PeerServices                      = NewSetting("peer-service", os.Getenv("CATTLE_PEER_SERVICE"))


### PR DESCRIPTION
removing content in `app/setting.go` because this logic is already covered when metadata gets loaded and settings get updated. 

https://github.com/rancher/rancher/issues/21695