### PR TITLE
[WIP] Add "Get User Info" global role

### DIFF
--- a/app/role_data.go
+++ b/app/role_data.go
@@ -48,6 +48,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 	rb.addRole("Manage PodSecurityPolicy Templates", "podsecuritypolicytemplates-manage").addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("*")
 	rb.addRole("Manage Cluster Scans", "clusterscans-manage").addRule().apiGroups("management.cattle.io").resources("clusterscans").verbs("*")
 	rb.addRole("Create Cluster Templates", "clustertemplates-create").addRule().apiGroups("management.cattle.io").resources("clustertemplates", "clustertemplaterevisions").verbs("create")
+	rb.addRole("Get User Info", "principals-get").addRule().apiGroups("management.cattle.io").resources("principals", "roletemplates").verbs("get", "list", "watch")
 
 	rb.addRole("Admin", "admin").addRule().apiGroups("*").resources("*").verbs("*").
 		addRule().apiGroups().nonResourceURLs("*").verbs("*")


### PR DESCRIPTION
There's no way to give related permissions to base-role users atm.
As a result, a project owner with custom roles is not able to add project members.