### PR TITLE
Fix notifying multiple recipients in pipeline

### DIFF
--- a/pkg/controllers/user/pipeline/controller/pipelineexecution/pipelineexecution.go
+++ b/pkg/controllers/user/pipeline/controller/pipelineexecution/pipelineexecution.go
@@ -480,7 +480,8 @@ func (l *Lifecycle) doNotify(obj *v3.PipelineExecution) (runtime.Object, error) 
 		message = obj.Spec.PipelineConfig.Notification.Message
 	}
 	var g errgroup.Group
-	for _, toSendRecipient := range toSendRecipients {
+	for i := range toSendRecipients {
+		toSendRecipient := toSendRecipients[i]
 		notifierMessage := &notifiers.Message{
 			Content: message,
 		}


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/22591

Problem:
When multiple recipients are configured in pipeline notification, one of
them get notified multiple times.

Solution:
Avoid using loop iterator variable in go routines.