### PR TITLE
Remove monitoring and logging catalog id setting

### DIFF
--- a/pkg/catalog/utils/version_test.go
+++ b/pkg/catalog/utils/version_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/rancher/rancher/pkg/settings"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 )
 
 func TestVersionBetween(t *testing.T) {
@@ -128,4 +131,74 @@ func TestVersionSatifiesRange(t *testing.T) {
 	testInvalidVersion(t, "versionInvalid-1.0", "<v1.0.0-validVersion")
 	testInvalidVersion(t, "versionInvalid-1.0", "<=v1.0.0-validVersion")
 
+}
+
+func TestLatestAvailableTemplateVersion(t *testing.T) {
+	template := &v3.CatalogTemplate{
+		Template: v3.Template{
+			Spec: v3.TemplateSpec{
+				Versions: []v3.TemplateVersionSpec{
+					{
+						ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.16",
+						Version:           "0.12.16",
+						RancherMinVersion: "v2.2.0",
+						RancherMaxVersion: "v2.3.0",
+					},
+					{
+						ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.15",
+						Version:           "0.12.15",
+						RancherMinVersion: "v2.1.0",
+						RancherMaxVersion: "v2.2.0",
+					},
+					{
+						ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.14",
+						Version:           "0.12.14",
+						RancherMinVersion: "v2.0.0",
+						RancherMaxVersion: "v2.1.0",
+					},
+				},
+			},
+		},
+	}
+
+	templateWithoutRancherVersion := &v3.CatalogTemplate{
+		Template: v3.Template{
+			Spec: v3.TemplateSpec{
+				Versions: []v3.TemplateVersionSpec{
+					{
+						ExternalID: "catalog://?catalog=library&template=artifactory-ha&version=0.12.16",
+						Version:    "0.12.16",
+					},
+					{
+						ExternalID: "catalog://?catalog=library&template=artifactory-ha&version=0.12.15",
+						Version:    "0.12.15",
+					},
+					{
+						ExternalID: "catalog://?catalog=library&template=artifactory-ha&version=0.12.14",
+						Version:    "0.12.14",
+					},
+				},
+			},
+		},
+	}
+
+	testLatestAvailableTemplateVersion(t, "v2.1.0", "0.12.15", template)
+	testLatestAvailableTemplateVersion(t, "dev", "0.12.16", template)
+	testLatestAvailableTemplateVersion(t, "master", "0.12.16", template)
+	testLatestAvailableTemplateVersion(t, "master-head", "0.12.16", template)
+	testLatestAvailableTemplateVersion(t, "", "0.12.16", template)
+
+	testLatestAvailableTemplateVersion(t, "v2.1.0", "0.12.16", templateWithoutRancherVersion)
+	testLatestAvailableTemplateVersion(t, "dev", "0.12.16", templateWithoutRancherVersion)
+	testLatestAvailableTemplateVersion(t, "master", "0.12.16", templateWithoutRancherVersion)
+	testLatestAvailableTemplateVersion(t, "master-head", "0.12.16", templateWithoutRancherVersion)
+	testLatestAvailableTemplateVersion(t, "", "0.12.16", templateWithoutRancherVersion)
+}
+
+func testLatestAvailableTemplateVersion(t *testing.T, serverVersion, expectedCatalogVersion string, template *v3.CatalogTemplate) {
+	err := settings.ServerVersion.Set(serverVersion)
+	assert.Nil(t, err)
+	templateVertion, err := LatestAvailableTemplateVersion(template)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedCatalogVersion, templateVertion.Version)
 }

--- a/pkg/controllers/user/helm/common/extra_args_test.go
+++ b/pkg/controllers/user/helm/common/extra_args_test.go
@@ -28,7 +28,7 @@ func Test_injectDefaultRegistry(t *testing.T) {
 		{
 			app: &v3.App{
 				Spec: v3.AppSpec{
-					ExternalID: settings.SystemMonitoringCatalogID.Get(),
+					ExternalID: settings.SystemExternalDNSCatalogID.Get(),
 				},
 			},
 			want: true,

--- a/pkg/controllers/user/logging/config/config.go
+++ b/pkg/controllers/user/logging/config/config.go
@@ -9,7 +9,7 @@ import (
 const (
 	AppName        = "rancher-logging"
 	TesterAppName  = "rancher-logging-tester"
-	AppInitVersion = "0.1.1"
+	AppInitVersion = "initializing"
 	templateName   = "rancher-logging"
 )
 
@@ -83,7 +83,7 @@ func RancherLoggingTemplateID() string {
 	return fmt.Sprintf("%s-%s", cutils.SystemLibraryName, templateName)
 }
 
-func RancherLoggingFullVersion() string {
+func RancherLoggingInitVersion() string {
 	return fmt.Sprintf("%s-%s-%s", cutils.SystemLibraryName, templateName, AppInitVersion)
 }
 

--- a/pkg/controllers/user/logging/deployer/deployer.go
+++ b/pkg/controllers/user/logging/deployer/deployer.go
@@ -2,6 +2,7 @@ package deployer
 
 import (
 	"github.com/rancher/norman/controller"
+	versionutil "github.com/rancher/rancher/pkg/catalog/utils"
 	loggingconfig "github.com/rancher/rancher/pkg/controllers/user/logging/config"
 	"github.com/rancher/rancher/pkg/controllers/user/logging/configsyncer"
 	"github.com/rancher/rancher/pkg/controllers/user/logging/utils"
@@ -143,9 +144,12 @@ func (d *Deployer) deployRancherLogging(systemProjectID, appCreator string) erro
 		return errors.Wrapf(err, "failed to find template by ID %s", templateVersionID)
 	}
 
-	catalogID := loggingconfig.RancherLoggingCatalogID(template.Spec.DefaultVersion)
+	templateVersion, err := versionutil.LatestAvailableTemplateVersion(template)
+	if err != nil {
+		return err
+	}
 
-	app := rancherLoggingApp(appCreator, systemProjectID, catalogID, driverDir, dockerRootDir)
+	app := rancherLoggingApp(appCreator, systemProjectID, templateVersion.ExternalID, driverDir, dockerRootDir)
 
 	windowsNodes, err := d.nodeLister.List(metav1.NamespaceAll, windowNodeLabel)
 	if err != nil {

--- a/pkg/controllers/user/logging/deployer/upgradeimpl.go
+++ b/pkg/controllers/user/logging/deployer/upgradeimpl.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"time"
 
+	versionutil "github.com/rancher/rancher/pkg/catalog/utils"
 	"github.com/rancher/rancher/pkg/controllers/user/helm/common"
 	loggingconfig "github.com/rancher/rancher/pkg/controllers/user/logging/config"
 	"github.com/rancher/rancher/pkg/project"
-	"github.com/rancher/rancher/pkg/settings"
 	appsv1 "github.com/rancher/types/apis/apps/v1"
 	v1 "github.com/rancher/types/apis/core/v1"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
@@ -60,12 +60,7 @@ func (l *LoggingService) Init(cluster *config.UserContext) {
 }
 
 func (l *LoggingService) Version() (string, error) {
-	catalogID := settings.SystemLoggingCatalogID.Get()
-	templateVersionID, _, err := common.ParseExternalID(catalogID)
-	if err != nil {
-		return "", fmt.Errorf("get system logging catalog version failed, %v", err)
-	}
-	return templateVersionID, nil
+	return loggingconfig.RancherLoggingInitVersion(), nil
 }
 
 func (l *LoggingService) Upgrade(currentVersion string) (string, error) {
@@ -76,7 +71,12 @@ func (l *LoggingService) Upgrade(currentVersion string) (string, error) {
 		return "", errors.Wrapf(err, "get template %s failed", templateID)
 	}
 
-	newFullVersion := fmt.Sprintf("%s-%s", templateID, template.Spec.DefaultVersion)
+	templateVersion, err := versionutil.LatestAvailableTemplateVersion(template)
+	if err != nil {
+		return "", err
+	}
+
+	newFullVersion := fmt.Sprintf("%s-%s", templateID, templateVersion.Version)
 	if currentVersion == newFullVersion {
 		return currentVersion, nil
 	}
@@ -98,8 +98,6 @@ func (l *LoggingService) Upgrade(currentVersion string) (string, error) {
 	}
 
 	//upgrade old app
-	newVersion := template.Spec.DefaultVersion
-	newCatalogID := loggingconfig.RancherLoggingCatalogID(newVersion)
 	defaultSystemProjects, err := l.projectLister.List(metav1.NamespaceAll, labels.Set(project.SystemProjectLabel).AsSelector())
 	if err != nil {
 		return "", errors.Wrap(err, "list system project failed")
@@ -122,7 +120,7 @@ func (l *LoggingService) Upgrade(currentVersion string) (string, error) {
 		return "", errors.Wrapf(err, "get app %s:%s failed", systemProject.Name, appName)
 	}
 
-	_, systemCatalogName, _, _, _, err := common.SplitExternalID(newCatalogID)
+	_, systemCatalogName, _, _, _, err := common.SplitExternalID(templateVersion.ExternalID)
 	if err != nil {
 		return "", err
 	}
@@ -137,7 +135,7 @@ func (l *LoggingService) Upgrade(currentVersion string) (string, error) {
 	}
 
 	newApp := app.DeepCopy()
-	newApp.Spec.ExternalID = newCatalogID
+	newApp.Spec.ExternalID = templateVersion.ExternalID
 
 	if !reflect.DeepEqual(newApp, app) {
 		// add force upgrade to handle chart compatibility in different version

--- a/pkg/controllers/user/logging/deployer/upgradeimpl_test.go
+++ b/pkg/controllers/user/logging/deployer/upgradeimpl_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	expectedVersion := "system-library-rancher-logging-0.1.1"
+	expectedVersion := "system-library-rancher-logging-initializing"
 	loggingService := &LoggingService{}
 	version, err := loggingService.Version()
 	if err != nil {

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rancher/norman/types"
 	cutils "github.com/rancher/rancher/pkg/catalog/utils"
+	versionutil "github.com/rancher/rancher/pkg/catalog/utils"
 	ns "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/ref"
 	mgmtv3 "github.com/rancher/types/apis/management.cattle.io/v3"
@@ -236,7 +237,12 @@ func GetMonitoringCatalogID(version string, catalogTemplateLister mgmtv3.Catalog
 		if err != nil {
 			return "", err
 		}
-		version = template.Spec.DefaultVersion
+
+		templateVersion, err := versionutil.LatestAvailableTemplateVersion(template)
+		if err != nil {
+			return "", err
+		}
+		version = templateVersion.Version
 	}
 	return fmt.Sprintf(cutils.CatalogExternalIDFormat, cutils.SystemLibraryName, monitoringTemplateName, version), nil
 }

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -55,10 +55,7 @@ var (
 	UIKubernetesDefaultVersion        = NewSetting("ui-k8s-default-version-range", "<=1.14.x")
 	WhitelistDomain                   = NewSetting("whitelist-domain", "forums.rancher.com")
 	WhitelistEnvironmentVars          = NewSetting("whitelist-envvars", "HTTP_PROXY,HTTPS_PROXY,NO_PROXY")
-	SystemMonitoringCatalogID         = NewSetting("system-monitoring-catalog-id", "catalog://?catalog=system-library&template=rancher-monitoring&version=0.0.3")
-	SystemLoggingCatalogID            = NewSetting("system-logging-catalog-id", "catalog://?catalog=system-library&template=rancher-logging&version=0.1.1")
 	SystemExternalDNSCatalogID        = NewSetting("system-externaldns-catalog-id", "catalog://?catalog=system-library&template=rancher-external-dns&version=0.0.2")
-	SystemGlobalIstioCatalogID        = NewSetting("system-global-istio-catalog-id", "catalog://?catalog=system-library&template=rancher-istio&version=0.0.1")
 	SystemCISBenchmarkCatalogID       = NewSetting("system-cis-benchmark-catalog-id", "catalog://?catalog=system-library&template=rancher-cis-benchmark&version=0.1.0")
 	AuthUserInfoResyncCron            = NewSetting("auth-user-info-resync-cron", "0 0 * * *")
 	AuthUserSessionTTLMinutes         = NewSetting("auth-user-session-ttl-minutes", "960")   // 16 hours


### PR DESCRIPTION
Problem:

When we deploy alerting, we are using the monitoring catalog setting to decide which version we should deploy. We should use the latest version (limited by rancher min and max version) instead of hard code version in Rancher server.

Solution:

Remove monitoring catalog from setting and remove legacy code

Issue:
https://github.com/rancher/rancher/issues/22615