### PR TITLE
Update global external-dns default to system-chart 0.0.2

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -57,7 +57,7 @@ var (
 	WhitelistEnvironmentVars          = NewSetting("whitelist-envvars", "HTTP_PROXY,HTTPS_PROXY,NO_PROXY")
 	SystemMonitoringCatalogID         = NewSetting("system-monitoring-catalog-id", "catalog://?catalog=system-library&template=rancher-monitoring&version=0.0.3")
 	SystemLoggingCatalogID            = NewSetting("system-logging-catalog-id", "catalog://?catalog=system-library&template=rancher-logging&version=0.1.1")
-	SystemExternalDNSCatalogID        = NewSetting("system-externaldns-catalog-id", "catalog://?catalog=system-library&template=rancher-external-dns&version=0.0.1")
+	SystemExternalDNSCatalogID        = NewSetting("system-externaldns-catalog-id", "catalog://?catalog=system-library&template=rancher-external-dns&version=0.0.2")
 	SystemGlobalIstioCatalogID        = NewSetting("system-global-istio-catalog-id", "catalog://?catalog=system-library&template=rancher-istio&version=0.0.1")
 	SystemCISBenchmarkCatalogID       = NewSetting("system-cis-benchmark-catalog-id", "catalog://?catalog=system-library&template=rancher-cis-benchmark&version=0.1.0")
 	AuthUserInfoResyncCron            = NewSetting("auth-user-info-resync-cron", "0 0 * * *")


### PR DESCRIPTION
**Issue:**
Create a GDNS provider, the 0.0.1 version of the rancher-external-dns being used.

**Solution:**
Update the global external-dns default to system-chart v0.0.2


Related Issue:
https://github.com/rancher/rancher/issues/21768