### PR TITLE
Improve alert linux node disk running full expression

### DIFF
--- a/pkg/controllers/user/alert/initdata.go
+++ b/pkg/controllers/user/alert/initdata.go
@@ -274,11 +274,10 @@ func initClusterPreCanAlerts(clusterAlertGroups v3.ClusterAlertGroupInterface, c
 				TimingField: defaultTimingField,
 			},
 			MetricRule: &v3.MetricRule{
-				Description:    "Device on node is running full within the next 24 hours",
-				Expression:     `predict_linear(node_filesystem_files_free{mountpoint!~"^/etc/(?:resolv.conf|hosts|hostname)$"}[6h], 3600 * 24)`,
-				Comparison:     manager.ComparisonLessOrEqual,
-				Duration:       "10m",
-				ThresholdValue: 1,
+				Description: "Device on node is running full within the next 24 hours",
+				Expression:  `predict_linear(node_filesystem_files_free{mountpoint!~"^/etc/(?:resolv.conf|hosts|hostname)$"}[6h], 3600 * 24) < 0`,
+				Comparison:  manager.ComparisonHasValue,
+				Duration:    "10m",
 			},
 		},
 		Status: v3.AlertStatus{


### PR DESCRIPTION
Problem:
After monitoring charts upgraded, this expression value change from no data point to 0

Solution:
Update the thredshold for this expression

Issue:
https://github.com/rancher/rancher/issues/22680