### PR TITLE
Increase etcd system servce alert groupt wait seconds

### DIFF
--- a/pkg/controllers/user/alert/initdata.go
+++ b/pkg/controllers/user/alert/initdata.go
@@ -138,6 +138,7 @@ func initClusterPreCanAlerts(clusterAlertGroups v3.ClusterAlertGroupInterface, c
 		logrus.Warnf("Failed to create precan rules for %s: %v", name, err)
 	}
 
+	inherited := false
 	name = "etcd-system-service"
 	rule = &v3.ClusterAlertRule{
 		ObjectMeta: metav1.ObjectMeta{
@@ -149,7 +150,12 @@ func initClusterPreCanAlerts(clusterAlertGroups v3.ClusterAlertGroupInterface, c
 			CommonRuleField: v3.CommonRuleField{
 				Severity:    SeverityCritical,
 				DisplayName: "Etcd is unavailable",
-				TimingField: defaultTimingField,
+				Inherited:   &inherited,
+				TimingField: v3.TimingField{
+					GroupWaitSeconds:      600,
+					GroupIntervalSeconds:  180,
+					RepeatIntervalSeconds: 3600,
+				},
 			},
 			SystemServiceRule: &v3.SystemServiceRule{
 				Condition: "etcd",


### PR DESCRIPTION
Problem:
Sometimes get etcd unhealth alert, but may cause by network or disk problem, actually etcd is health

Solution:
Improve group wait seconds to 10 mins as issue mentioned

Issue:
https://github.com/rancher/rancher/issues/19474