### PR TITLE
sort grep namespace list for project logging

### DIFF
--- a/pkg/controllers/user/logging/generator/generator.go
+++ b/pkg/controllers/user/logging/generator/generator.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -83,6 +84,7 @@ func GenerateProjectConfig(projectLoggings []*mgmtv3.ProjectLogging, namespaces 
 			continue
 		}
 
+		sort.Strings(grepNamespace)
 		formatgrepNamespace := fmt.Sprintf("(%s)", strings.Join(grepNamespace, "|"))
 		isSystemProject := v.Spec.ProjectName == systemProjectID
 		wpl, err := newWrapProjectLogging(v.Spec, formatgrepNamespace, certDir, isSystemProject)


### PR DESCRIPTION
Problem:
unsorted namespace cause useless configure update and reload

Solution:
sort namespace

Issue:
https://github.com/rancher/rancher/issues/22721