### PR TITLE
feat(chart): switcher to enable/disable ingress

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -35,4 +36,5 @@ spec:
   - hosts:
     - {{ .Values.hostname }}
     secretName: tls-rancher-ingress
+{{- end }}
 {{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  type: {{ .Values.service.type }}
   ports:
   - port: 80
     targetPort: 80

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -46,6 +46,7 @@ imagePullSecrets: []
 ### ingress ###
 # Readme for details and instruction on adding tls secrets.
 ingress:
+  enabled: true
   extraAnnotations:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
@@ -58,6 +59,11 @@ ingress:
   tls:
     # options: rancher, letsEncrypt, secret
     source: rancher
+
+### service ###
+# Define service type. to have the option to use LoadBalancer, NodePort or ClusterIP (default)
+service:
+  type: ClusterIP
 
 ### LetsEncrypt config ###
 # ProTip: The production environment only allows you to register a name 5 times a week.


### PR DESCRIPTION
This pull Request is mainly for Rancher Helm Chart.
Changes: 
- Have a switcher to turn off/on the ingress.
- Define service types. Loadbalancer, NodePort or ClusterIP

Use Cases:
- if you are using IstioGateways and you don't need an Ingress.
- if you need other service type like NodePort or LB using GKE Ingress associated with IAP service.
Just to have a bit of control 