### PR TITLE
Image missing in image.txt if tag is float type

### DIFF
--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -292,12 +292,11 @@ func generateImages(inputMap map[interface{}]interface{}, output map[string]stru
 		return
 	}
 	repo, repoOk := r.(string)
-	tag, tagOk := t.(string)
-	if !repoOk || !tagOk {
+	if !repoOk {
 		return
 	}
 
-	output[fmt.Sprintf("%s:%s", repo, tag)] = struct{}{}
+	output[fmt.Sprintf("%s:%v", repo, t)] = struct{}{}
 
 	return
 }


### PR DESCRIPTION
**Problem:**
If the tag variable is treated as float or int, we won't include
that image in our image list.

**Solution:**
Don't parse tag to string.

Related issue:
https://github.com/rancher/rancher/issues/22553
