### PR TITLE
Disable removing system-catalog

### DIFF
--- a/pkg/api/customization/catalog/validator.go
+++ b/pkg/api/customization/catalog/validator.go
@@ -28,6 +28,7 @@ func Validator(request *types.APIContext, schema *types.Schema, data map[string]
 	} else if request.Method == http.MethodPost {
 		return httperror.NewAPIError(httperror.MissingRequired, "Catalog URL not specified")
 	}
+
 	return nil
 }
 

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -38,6 +38,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/customization/secret"
 	"github.com/rancher/rancher/pkg/api/customization/setting"
 	appStore "github.com/rancher/rancher/pkg/api/store/app"
+	catalogStore "github.com/rancher/rancher/pkg/api/store/catalog"
 	"github.com/rancher/rancher/pkg/api/store/cert"
 	"github.com/rancher/rancher/pkg/api/store/cluster"
 	clustertemplatestore "github.com/rancher/rancher/pkg/api/store/clustertemplate"
@@ -332,6 +333,7 @@ func Catalog(schemas *types.Schemas, managementContext *config.ScaledContext) {
 	schema.CollectionFormatter = catalog.CollectionFormatter
 	schema.LinkHandler = handler.ExportYamlHandler
 	schema.Validator = catalog.Validator
+	schema.Store = catalogStore.Wrap(schema.Store)
 }
 
 func ProjectCatalog(schemas *types.Schemas, managementContext *config.ScaledContext) {
@@ -343,6 +345,7 @@ func ProjectCatalog(schemas *types.Schemas, managementContext *config.ScaledCont
 	schema.ActionHandler = handler.RefreshProjectCatalogActionHandler
 	schema.CollectionFormatter = catalog.CollectionFormatter
 	schema.Validator = catalog.Validator
+	schema.Store = catalogStore.Wrap(schema.Store)
 }
 
 func ClusterCatalog(schemas *types.Schemas, managementContext *config.ScaledContext) {
@@ -354,6 +357,7 @@ func ClusterCatalog(schemas *types.Schemas, managementContext *config.ScaledCont
 	schema.ActionHandler = handler.RefreshClusterCatalogActionHandler
 	schema.CollectionFormatter = catalog.CollectionFormatter
 	schema.Validator = catalog.Validator
+	schema.Store = catalogStore.Wrap(schema.Store)
 }
 
 func ClusterRegistrationTokens(schemas *types.Schemas) {

--- a/pkg/api/store/catalog/store.go
+++ b/pkg/api/store/catalog/store.go
@@ -1,0 +1,57 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rancher/norman/httperror"
+	"github.com/rancher/norman/types"
+	c "github.com/rancher/rancher/pkg/api/customization/catalog"
+	"github.com/rancher/rancher/pkg/settings"
+)
+
+type Store struct {
+	types.Store
+}
+
+func Wrap(store types.Store) types.Store {
+	return &Store{
+		store,
+	}
+}
+
+func (s *Store) Delete(apiContext *types.APIContext, schema *types.Schema, id string) (map[string]interface{}, error) {
+	isSystemCatalog, err := s.isSystemCatalog(apiContext, schema, id)
+	if err != nil {
+		return nil, err
+	}
+	if isSystemCatalog {
+		return nil, httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprint("not allowed to delete system-library catalog"))
+	}
+	return s.Store.Delete(apiContext, schema, id)
+}
+
+func (s *Store) Update(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}, id string) (map[string]interface{}, error) {
+	isSystemCatalog, err := s.isSystemCatalog(apiContext, schema, id)
+	if err != nil {
+		return nil, err
+	}
+	if isSystemCatalog {
+		if strings.ToLower(settings.SystemCatalog.Get()) == "bundled" {
+			return nil, httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprint("not allowed to edit system-library catalog"))
+		}
+	}
+	return s.Store.Update(apiContext, schema, data, id)
+}
+
+// isSystemCatalog checks whether the catalog is the the system catalog maintained by rancher
+func (s *Store) isSystemCatalog(apiContext *types.APIContext, schema *types.Schema, id string) (bool, error) {
+	catalog, err := s.ByID(apiContext, schema, id)
+	if err != nil {
+		return false, err
+	}
+	if catalog["url"] == c.SystemLibraryURL && catalog["name"] == c.SystemCatalogName {
+		return true, nil
+	}
+	return false, nil
+}

--- a/tests/integration/suite/test_catalog.py
+++ b/tests/integration/suite/test_catalog.py
@@ -216,3 +216,62 @@ def test_relative_paths(admin_mc, admin_pc, remove_resource):
     remove_resource(mysqlha)
     wait_for_atleast_workload(pclient=admin_pc.client, nsid=ns.id, timeout=60,
                               count=1)
+
+
+def test_cannot_delete_system_catalog(admin_mc):
+    """This test asserts that the system catalog cannot be delete"""
+    client = admin_mc.client
+
+    system_catalog = client.by_id_catalog("system-library")
+
+    with pytest.raises(ApiError) as e:
+        client.delete(system_catalog)
+
+    assert e.value.error.status == 422
+    assert e.value.error.message == 'not allowed to delete system-library' \
+                                    ' catalog'
+
+
+def test_system_catalog_missing_remove_link(admin_mc):
+    """This test asserts that the remove link is missing from system-catalog's
+    links"""
+    client = admin_mc.client
+
+    system_catalog = client.by_id_catalog("system-library")
+
+    assert "remove" not in system_catalog.links
+
+
+def test_cannot_update_system_if_embedded(admin_mc):
+    """This test asserts that the system catalog cannot be updated if
+    system-catalog setting is set to 'bundled'"""
+    client = admin_mc.client
+
+    system_catalog_setting = client.by_id_setting("system-catalog")
+    # this could potentially interfere with other tests if they were to rely
+    # on system-catalog setting
+    client.update_by_id_setting(id=system_catalog_setting.id, value="bundled")
+
+    system_catalog = client.by_id_catalog("system-library")
+
+    with pytest.raises(ApiError) as e:
+        client.update_by_id_catalog(id=system_catalog.id, branch="asd")
+
+    assert e.value.error.status == 422
+    assert e.value.error.message == 'not allowed to edit system-library' \
+                                    ' catalog'
+
+
+def test_embedded_system_catalog_missing_edit_link(admin_mc):
+    """This test asserts that the system catalog is missing the 'update' link
+    if system-catalog setting is set to 'bundled'"""
+    client = admin_mc.client
+
+    system_catalog_setting = client.by_id_setting("system-catalog")
+    # this could potentially interfere with other tests if they were to rely
+    # on system-catalog setting
+    client.update_by_id_setting(id=system_catalog_setting.id, value="bundled")
+
+    system_catalog = client.by_id_catalog("system-library")
+
+    assert "update" not in system_catalog.links


### PR DESCRIPTION
Problem:
Prior, system-catalog was hidden to prevent these actions. This prevented user from viewing errors with system-catalog. Prior to that, user was able to delete system-catalog which could be dangerous.

Solution:
Allow user to view system catalog, but prevent them from deleting it.

Issue:
https://github.com/rancher/rancher/issues/22771

Related Issue:
https://github.com/rancher/rancher/issues/22490
