### PR TITLE
Fixed the duplicate wrapping Windows service options

### DIFF
--- a/pkg/controllers/management/kontainerdrivermetadata/data_getter.go
+++ b/pkg/controllers/management/kontainerdrivermetadata/data_getter.go
@@ -94,8 +94,7 @@ func GetRKEK8sServiceOptions(k8sVersion string, svcOptionLister v3.RKEK8sService
 	if !ok {
 		return k8sSvcOption, fmt.Errorf("getSvcOptions: no service-option key present for %s", k8sVersion)
 	}
-	name := getVersionNameWithOsType(val, osType)
-	return getRKEServiceOption(name, svcOptionLister, svcOptions)
+	return getRKEServiceOption(val, svcOptionLister, svcOptions)
 }
 
 func GetK8sVersionInfo(


### PR DESCRIPTION
**Problem:**
Since we wrapped the name of service options with `w` twice, it was impossible to get the correct service options for Windows worker

**Solution:**
Drop the latest wrapping