### PR TITLE
Improve logic for checking logging app deploy success

### DIFF
--- a/pkg/api/customization/logging/action.go
+++ b/pkg/api/customization/logging/action.go
@@ -153,9 +153,9 @@ func (h *Handler) dryRunLoggingTarget(apiContext *types.APIContext, level, clust
 		return err
 	}
 
-	pods := context.Core.Pods(loggingconfig.LoggingNamespace)
+	podLister := context.Core.Pods(loggingconfig.LoggingNamespace).Controller().Lister()
 	namespaces := context.Core.Namespaces(metav1.NamespaceAll)
-	testerDeployer := deployer.NewTesterDeployer(context.Management, h.appsGetter, h.projectLister, pods, h.projectLoggingLister, namespaces, h.templateLister)
+	testerDeployer := deployer.NewTesterDeployer(context.Management, h.appsGetter, h.projectLister, podLister, h.projectLoggingLister, namespaces, h.templateLister)
 	configGenerator := configsyncer.NewConfigGenerator(metav1.NamespaceAll, h.projectLoggingLister, namespaces.Controller().Lister())
 
 	var dryRunConfigBuf []byte

--- a/pkg/controllers/user/logging/deployer/appdeployer_test.go
+++ b/pkg/controllers/user/logging/deployer/appdeployer_test.go
@@ -1,0 +1,57 @@
+package deployer
+
+import (
+	"testing"
+
+	loggingconfig "github.com/rancher/rancher/pkg/controllers/user/logging/config"
+	"github.com/rancher/types/apis/core/v1/fakes"
+
+	"github.com/stretchr/testify/assert"
+	k8scorev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestIsDeploySuccess(t *testing.T) {
+
+	fakeLabels := map[string]string{"app": "fake"}
+	fluentdLabels := map[string]string{"app": "fluentd"}
+
+	err := testIsDeploySuccess(fluentdLabels, k8scorev1.PodRunning, fakeLabels, k8scorev1.PodRunning)
+	assert.Nil(t, err)
+
+	err = testIsDeploySuccess(fluentdLabels, k8scorev1.PodRunning, fakeLabels, k8scorev1.PodPending)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+
+}
+
+func testIsDeploySuccess(expectLabels map[string]string, expectedPhase k8scorev1.PodPhase, actualLabels map[string]string, actualPhase k8scorev1.PodPhase) error {
+	appDeployer := AppDeployer{
+		PodLister: &fakes.PodListerMock{
+			ListFunc: getPods(actualLabels, actualPhase),
+		},
+	}
+
+	return appDeployer.isDeploySuccess(loggingconfig.LoggingNamespace, expectLabels)
+}
+
+func getPods(podLabels map[string]string, phase k8scorev1.PodPhase) func(namespace string, selector labels.Selector) ([]*k8scorev1.Pod, error) {
+	return func(namespace string, selector labels.Selector) ([]*k8scorev1.Pod, error) {
+		return []*k8scorev1.Pod{
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:    podLabels,
+					Namespace: loggingconfig.LoggingNamespace,
+				},
+				Status: k8scorev1.PodStatus{
+					Phase: phase,
+				},
+			},
+		}, nil
+	}
+}

--- a/pkg/controllers/user/logging/deployer/deployer.go
+++ b/pkg/controllers/user/logging/deployer/deployer.go
@@ -50,7 +50,7 @@ func NewDeployer(cluster *config.UserContext, secretSyncer *configsyncer.SecretM
 	appDeployer := &AppDeployer{
 		AppsGetter: appsgetter,
 		Namespaces: cluster.Core.Namespaces(metav1.NamespaceAll),
-		Pods:       cluster.Core.Pods(metav1.NamespaceAll),
+		PodLister:  cluster.Core.Pods(metav1.NamespaceAll).Controller().Lister(),
 	}
 
 	return &Deployer{

--- a/pkg/controllers/user/logging/deployer/testerdeployer.go
+++ b/pkg/controllers/user/logging/deployer/testerdeployer.go
@@ -26,11 +26,11 @@ type TesterDeployer struct {
 	systemAccountManager *systemaccount.Manager
 }
 
-func NewTesterDeployer(mgmtCtx *config.ManagementContext, appsGetter projectv3.AppsGetter, projectLister mgmtv3.ProjectLister, pods v1.PodInterface, projectLoggingLister mgmtv3.ProjectLoggingLister, namespaces v1.NamespaceInterface, templateLister mgmtv3.CatalogTemplateLister) *TesterDeployer {
+func NewTesterDeployer(mgmtCtx *config.ManagementContext, appsGetter projectv3.AppsGetter, projectLister mgmtv3.ProjectLister, podLister v1.PodLister, projectLoggingLister mgmtv3.ProjectLoggingLister, namespaces v1.NamespaceInterface, templateLister mgmtv3.CatalogTemplateLister) *TesterDeployer {
 	appDeployer := &AppDeployer{
 		AppsGetter: appsGetter,
 		Namespaces: namespaces,
-		Pods:       pods,
+		PodLister:  podLister,
 	}
 
 	return &TesterDeployer{


### PR DESCRIPTION
Problem:
Enable logging in a PSP restricted cluster. Check that logging app is deployed but no fluentd pods are deployed due to PSP limitation, disable logging, and notice that the logging app is not removed.

Solution:
This is cause by wrong use of rancher.ticker, when the timeout, the ticker get stop, but the ticker channel isn't close cause loop

Issue:
https://github.com/rancher/rancher/issues/22797