### PR TITLE
Role name changed to RKE templates and flaky test fixes

### DIFF
--- a/app/role_data.go
+++ b/app/role_data.go
@@ -47,7 +47,7 @@ func addRoles(management *config.ManagementContext) (string, error) {
 	rb.addRole("Manage Features", "features-manage").addRule().apiGroups("management.cattle.io").resources("features").verbs("get", "list", "watch", "update")
 	rb.addRole("Manage PodSecurityPolicy Templates", "podsecuritypolicytemplates-manage").addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("*")
 	rb.addRole("Manage Cluster Scans", "clusterscans-manage").addRule().apiGroups("management.cattle.io").resources("clusterscans").verbs("*")
-	rb.addRole("Create Cluster Templates", "clustertemplates-create").addRule().apiGroups("management.cattle.io").resources("clustertemplates").verbs("create")
+	rb.addRole("Create RKE Templates", "clustertemplates-create").addRule().apiGroups("management.cattle.io").resources("clustertemplates").verbs("create")
 
 	rb.addRole("Admin", "admin").addRule().apiGroups("*").resources("*").verbs("*").
 		addRule().apiGroups().nonResourceURLs("*").verbs("*")


### PR DESCRIPTION
- Changing the global role name to say "Create RKE Templates" https://github.com/rancher/rancher/issues/22805
- Fix for flaky test issue https://github.com/rancher/rancher/issues/22735