### PR TITLE
change log level for getRKEServiceOption

### DIFF
--- a/pkg/controllers/management/kontainerdrivermetadata/data_getter.go
+++ b/pkg/controllers/management/kontainerdrivermetadata/data_getter.go
@@ -63,9 +63,9 @@ func getRKEServiceOption(name string, svcOptionLister v3.RKEK8sServiceOptionList
 		}
 	}
 	if svcOption.Labels[sendRKELabel] == "false" {
-		logrus.Infof("svcOption False %s", name)
 		return k8sSvcOption, nil
 	}
+	logrus.Debugf("getRKEServiceOption: sending svcOption %s", name)
 	return &svcOption.ServiceOptions, nil
 }
 


### PR DESCRIPTION
service options are now passed to generatePlan which happens very often,
logging it in debug and only when svcOption is passed