### PR TITLE
node agent windows should tolerate all taints

### DIFF
--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -273,12 +273,7 @@ spec:
                     - linux
       serviceAccountName: cattle
       tolerations:
-      - effect: NoExecute
-        key: "node-role.kubernetes.io/etcd"
-        value: "true"
-      - effect: NoSchedule
-        key: "node-role.kubernetes.io/controlplane"
-        value: "true"
+      - operator: Exists
       containers:
       - name: agent
         image: {{.AgentImage}}


### PR DESCRIPTION
Related issue:
https://github.com/rancher/rancher/issues/22857