### PR TITLE
removed --quiet for > /dev/null, logic to rerun command

### DIFF
--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -397,16 +397,18 @@ if [[ $help ]]; then
     exit 0
 fi
 
-set -e
-
 pulled=""
 while IFS= read -r i; do
     [ -z "${i}" ] && continue
-    if [ $(docker pull --quiet "${i}") ]; then
+    if docker pull "${i}" > /dev/null 2>&1; then
         echo "Image pull success: ${i}"
         pulled="${pulled} ${i}"
     else
-        echo "Image pull failed: ${i}"
+        if docker inspect "${i}" > /dev/null 2>&1; then
+            pulled="${pulled} ${i}"		
+        else
+            echo "Image pull failed: ${i}"
+        fi
     fi
 done < "${list}"
 


### PR DESCRIPTION
quiet wasn't supported in < docker 19 so added redirect output instead and the $pulled param wasn't being filled the second run of the command so added logic to inspect and added the image to the tar.gz even if it was already pulled.