### PR TITLE
Assign default to value if nil

### DIFF
--- a/pkg/api/customization/feature/feature.go
+++ b/pkg/api/customization/feature/feature.go
@@ -35,3 +35,12 @@ func Validator(request *types.APIContext, schema *types.Schema, data map[string]
 
 	return nil
 }
+
+func Formatter(request *types.APIContext, resource *types.RawResource) {
+	if request.Method == http.MethodGet {
+		if resource.Values["value"] == nil {
+			// if value is nil, then this ensure default value will be used
+			resource.Values["value"] = resource.Values["default"]
+		}
+	}
+}

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -511,6 +511,7 @@ func Setting(schemas *types.Schemas) {
 func Feature(schemas *types.Schemas) {
 	schema := schemas.Schema(&managementschema.Version, client.FeatureType)
 	schema.Validator = feature.Validator
+	schema.Formatter = feature.Formatter
 	schema.Store = featStore.New(schema.Store)
 }
 


### PR DESCRIPTION
Problem:
Value may be empty despite have a default value. This could lead to confusion.

Solution:
Assign default value to value field in feature GET responses.

Issue:
https://github.com/rancher/rancher/issues/22895