### PR TITLE
Fix drone CI build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rancher
 
-[![Build Status](https://drone8.rancher.io/api/badges/rancher/rancher/status.svg?branch=master)](https://drone8.rancher.io/rancher/rancher)
+[![Build Status](https://drone-publish.rancher.io/api/badges/rancher/rancher/status.svg?branch=master)](https://drone-publish.rancher.io/rancher/rancher)
 [![Docker Pulls](https://img.shields.io/docker/pulls/rancher/rancher.svg)](https://store.docker.com/community/images/rancher/rancher)
 [![Go Report Card](https://goreportcard.com/badge/github.com/rancher/rancher)](https://goreportcard.com/report/github.com/rancher/rancher)
 


### PR DESCRIPTION
The CI build badge does not load correctly
Before
<img width="1009" alt="rancher:rancher: Complete container management platform 2019-09-20 16-46-46" src="https://user-images.githubusercontent.com/1014383/65364392-5fdf7b80-dbc6-11e9-858b-1f7e15c9837f.png">
 
Change the base url from "drone8.rancher.io" to "drone-publish.rancher.io"
After
<img width="997" alt="yatish27:rancher at patch-2 2019-09-24 20-35-20" src="https://user-images.githubusercontent.com/1014383/65567394-f5eb0d00-df0a-11e9-9edc-ed5fb244400d.png">
