### PR TITLE
Patch supported intermediary certificates for Windows 1903

### DIFF
--- a/package/windows/execute.ps1
+++ b/package/windows/execute.ps1
@@ -292,7 +292,8 @@ if ($CATTLE_CA_CHECKSUM)
             $caBytes = @()
         } elseif ($_ -match '-+END CERTIFICATE-+') {
             $caTemp = New-TemporaryFile
-            Set-Content -Value $caBytes -Path $caTemp.FullName -Encoding Byte
+            $caString = [Convert]::ToBase64String($caBytes)
+            Set-Content -Value $caString -Path $caTemp.FullName
             certoc.exe -addstore root $caTemp.FullName | Out-Null
             if (-not $?) {
                 $caTemp.Delete()


### PR DESCRIPTION
**Problem:**
the Powershell of `1903` has changed from `v5.1` to `v6.0`, and then `Set-Content` hasn't supported `Bytes` as an encoding type:

- v5.1:
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-content?view=powershell-5.1#parameters
- v6.0:
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-content?view=powershell-6#parameters

**Solution:**
Import the certificate after converting the bytes to string

**Issue:**
Reopen: https://github.com/rancher/rancher/issues/20436
