### PR TITLE
Turn it up to 10 TILLER_HISTORY_MAX

### DIFF
--- a/pkg/controllers/user/helm/common/common.go
+++ b/pkg/controllers/user/helm/common/common.go
@@ -82,7 +82,7 @@ func SplitExternalID(externalID string) (string, string, string, string, string,
 func StartTiller(context context.Context, tempDirs *HelmPath, port, namespace string) error {
 	probePort := GenerateRandomPort()
 	cmd := exec.Command(tillerName, "--listen", ":"+port, "--probe", ":"+probePort)
-	cmd.Env = []string{fmt.Sprintf("%s=%s", "KUBECONFIG", tempDirs.KubeConfigInJail), fmt.Sprintf("%s=%s", "TILLER_NAMESPACE", namespace), fmt.Sprintf("%s=%s", "TILLER_HISTORY_MAX", "1")}
+	cmd.Env = []string{fmt.Sprintf("%s=%s", "KUBECONFIG", tempDirs.KubeConfigInJail), fmt.Sprintf("%s=%s", "TILLER_NAMESPACE", namespace), fmt.Sprintf("%s=%s", "TILLER_HISTORY_MAX", "10")}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
Problem:
Tiller can get stuck when an upgrade fails and we don't have any
versions to get back to

Solution:
Up the history count so tiller can find one that deployed successfully
to rollback to

https://github.com/rancher/rancher/issues/21070