### PR TITLE
provision  a NFS server when running tests for PV and PVC

### DIFF
--- a/tests/validation/lib/node.py
+++ b/tests/validation/lib/node.py
@@ -136,3 +136,6 @@ class Node(object):
                 "Error:'docker exec' command received this stderr output: "
                 "{0}".format(result[1]))
         return result[0]
+
+    def get_public_ip(self):
+        return self.public_ip_address

--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -1174,3 +1174,14 @@ def resolve_node_ip(node):
     else:
         node_ip = node.ipAddress
     return node_ip
+
+
+def provision_nfs_server():
+    node = AmazonWebServices().create_node(random_test_name("nfs-server"))
+    node.wait_for_ssh_ready()
+    c_path = os.getcwd()
+    cmd_path = c_path + "/tests/v3_api/scripts/nfs-setup.sh"
+    command = open(cmd_path, 'r').read()
+    node.execute_command(command)
+    return node
+

--- a/tests/validation/tests/v3_api/scripts/nfs-setup.sh
+++ b/tests/validation/tests/v3_api/scripts/nfs-setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -x
+
+sudo apt-get update
+if sudo apt-get install -y nfs-kernel-server ; then
+  echo "install nfs-kernel-server successfully, continue "
+else
+  echo "fixing the error"
+  sudo rm /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock*
+  sudo dpkg --configure -a
+  sudo apt-get install -y nfs-kernel-server
+fi
+
+sudo mkdir -p /nfs
+sudo chown nobody:nogroup /nfs
+echo  "/nfs    *(rw,sync,no_subtree_check)" | sudo tee  /etc/exports
+sudo exportfs -a
+sudo service nfs-kernel-server start
+sudo ufw allow 2049


### PR DESCRIPTION
An NFS server will be deployed in AWS for testing Persistent Volumes and Persistent Volume Claims.
A new configurable variable `RANCHER_DELETE_NFS` is introduced. The NFS server will be deleted automatically if `RANCHER_DELETE_NFS` is set to `True`, or be kept if `RANCHER_DELETE_NFS` is set to `False` 