### PR TITLE
[2.3.2] enhance logging configure

### DIFF
--- a/pkg/api/customization/logging/validator.go
+++ b/pkg/api/customization/logging/validator.go
@@ -75,8 +75,10 @@ func validate(level, containerLogSourceTag string, loggingTargets v3.LoggingTarg
 		}
 	}
 
-	if err = generator.ValidateCustomTags(wrap); err != nil {
-		return err
+	if len(outputTags) != 0 {
+		if err = generator.ValidateCustomTags(wrap); err != nil {
+			return err
+		}
 	}
 
 	return generator.ValidateCustomTarget(wrap)

--- a/pkg/controllers/user/logging/config/config.go
+++ b/pkg/controllers/user/logging/config/config.go
@@ -102,3 +102,7 @@ func RancherLoggingSSLSecretName() string {
 func GetNamespacePattern(namespace string) string {
 	return fmt.Sprintf("^%s$", namespace)
 }
+
+func GetNamespacePathPattern(namespace string) string {
+	return fmt.Sprintf("/var/log/containers/*_%s_*.log", namespace)
+}

--- a/pkg/controllers/user/logging/generator/targetwrap.go
+++ b/pkg/controllers/user/logging/generator/targetwrap.go
@@ -39,7 +39,7 @@ type ClusterLoggingTemplateWrap struct {
 }
 
 type ProjectLoggingTemplateWrap struct {
-	GrepNamespace string
+	ContainerSourcePath string
 
 	v3.LoggingCommonField
 	LoggingTargetTemplateWrap
@@ -88,7 +88,7 @@ func newWrapClusterLogging(logging v3.ClusterLoggingSpec, excludeNamespace, cert
 	}, nil
 }
 
-func newWrapProjectLogging(logging v3.ProjectLoggingSpec, grepNamespace, certDir string, isSystemProject bool) (*ProjectLoggingTemplateWrap, error) {
+func newWrapProjectLogging(logging v3.ProjectLoggingSpec, containerSourcePath, certDir string, isSystemProject bool) (*ProjectLoggingTemplateWrap, error) {
 	wrap, err := NewLoggingTargetTemplateWrap(logging.LoggingTargets)
 	if err != nil {
 		return nil, errors.Wrapf(err, "wrapper logging target failed")
@@ -106,7 +106,7 @@ func newWrapProjectLogging(logging v3.ProjectLoggingSpec, grepNamespace, certDir
 	containerLogPosFilename := getContainerLogPosFilename(level, logging.ProjectName)
 
 	return &ProjectLoggingTemplateWrap{
-		GrepNamespace:             grepNamespace,
+		ContainerSourcePath:       containerSourcePath,
 		LoggingCommonField:        logging.LoggingCommonField,
 		LoggingTargetTemplateWrap: *wrap,
 		IncludeRke:                isSystemProject,

--- a/pkg/controllers/user/logging/generator/template.go
+++ b/pkg/controllers/user/logging/generator/template.go
@@ -8,6 +8,7 @@ var Template = `
 {{end }}
 {{- template "source-container" . -}}
 {{- template "filter-container" . -}}
+{{- template "filter-add-logtype" . -}}
 {{- template "filter-custom-tags" . -}}
 {{- template "filter-prometheus" . -}}
 {{- template "filter-exclude-system-component" . -}}
@@ -21,10 +22,10 @@ var Template = `
 {{- template "source-rke" $store -}}
 {{- template "filter-rke" $store -}}
 {{end }}
-{{- template "source-container" $store -}}
+{{- template "source-project-container" $store -}}
 {{- template "filter-container" $store -}}
+{{- template "filter-add-projectid" $store -}}
 {{- template "filter-custom-tags" $store -}}
-{{- template "filter-project-namespace" $store -}}
 {{- template "filter-prometheus" $store -}}
 {{- template "filter-sumo" $store -}}
 {{- template "match" $store -}}

--- a/pkg/controllers/user/logging/generator/templatefilter.go
+++ b/pkg/controllers/user/logging/generator/templatefilter.go
@@ -35,11 +35,26 @@ var FilterTemplate = `
 {{end}}
 
 {{define "filter-custom-tags"}}
+{{- if .OutputTags}}
+<filter {{ .ContainerLogSourceTag }}.**>
+  @type record_transformer
+  <record>
+    tag ${tag}
+    {{- range $k, $val := .OutputTags }}
+    {{$k}}  {{$val | escapeString}}
+    {{end}}
+  </record>
+</filter>
+{{end}}
+{{end}}
+
+{{define "filter-project-custom-tags"}}
 <filter {{ .ContainerLogSourceTag }}.**>
   @type record_transformer
   <record>
     tag ${tag}
     log_type k8s_normal_container 
+    projectID {{ .ContainerLogSourceTag}}
     {{- range $k, $val := .OutputTags }}
     {{$k}}  {{$val | escapeString}}
     {{end}}
@@ -87,28 +102,24 @@ var FilterTemplate = `
 {{end}}
 {{end}}
 
-{{define "filter-project-namespace"}}
+{{define "filter-add-projectid"}}
 <filter {{ .ContainerLogSourceTag}}.**>
   @type record_transformer
-  enable_ruby  true
   <record>
     tag ${tag}
-    namespace ${record["kubernetes"]["namespace_name"]}
+    log_type k8s_normal_container 
     projectID {{ .ContainerLogSourceTag}}
   </record>
 </filter>
+{{end}}
 
-<filter {{ .ContainerLogSourceTag}}.**>
-  @type grep
-  <regexp>
-    key namespace
-    pattern {{.GrepNamespace}}
-  </regexp>
-</filter>
-
+{{define "filter-add-logtype"}}
 <filter {{ .ContainerLogSourceTag}}.**>
   @type record_transformer
-  remove_keys namespace
+  <record>
+    tag ${tag}
+    log_type k8s_normal_container 
+  </record>
 </filter>
 {{end}}
 `

--- a/pkg/controllers/user/logging/generator/templatematch.go
+++ b/pkg/controllers/user/logging/generator/templatematch.go
@@ -107,7 +107,11 @@ var MatchTemplate = `
 	output_data_type  "json"
 	output_include_tag  true
 	output_include_time  true
-	max_send_retries 3
+	max_send_retries 5
+	kafka_agg_max_bytes 768000
+	kafka_agg_max_messages 500
+	get_kafka_client_log true 
+
 	{{- if .KafkaConfig.Certificate }}        
 	ssl_ca_cert {{.CertFilePrefix}}_ca.pem
 	{{end}}
@@ -225,11 +229,14 @@ var MatchTemplate = `
 	  path /fluentd/log/buffer/{{.BufferFile}}
 	  flush_mode interval
 	  flush_interval {{.OutputFlushInterval}}s
-	  flush_thread_count 8
+	  flush_thread_count 16
+	  {{- if eq .CurrentTarget "kafka"}}
+	  chunk_limit_size 32m
+	  {{end}}
 	  {{- if eq .CurrentTarget "splunk"}}
 	  chunk_limit_size 8m
 	  {{end}}
-	  queued_chunks_limit_size 200
+	  queued_chunks_limit_size 300
 	</buffer> 
 	slow_flush_log_threshold 40.0	
 {{end}}

--- a/pkg/controllers/user/logging/generator/templatesource.go
+++ b/pkg/controllers/user/logging/generator/templatesource.go
@@ -9,7 +9,6 @@ var SourceTemplate = `
   time_format  %Y-%m-%dT%H:%M:%S.%N
   tag  {{ .RkeLogTag }}.*
   format  json
-  read_from_head  true
 </source>
 {{end}}
 
@@ -21,7 +20,17 @@ var SourceTemplate = `
   time_format  %Y-%m-%dT%H:%M:%S.%N
   tag  {{ .ContainerLogSourceTag }}.*
   format  json
-  read_from_head  true
+</source>
+{{end}}
+
+{{define "source-project-container"}}
+<source>
+  @type  tail
+  path  {{ .ContainerSourcePath}}
+  pos_file  /fluentd/log/{{ .ContainerLogPosFilename}}
+  time_format  %Y-%m-%dT%H:%M:%S
+  tag  {{ .ContainerLogSourceTag }}.*
+  format  json
 </source>
 {{end}}
 `

--- a/pkg/controllers/user/logging/generator/validator.go
+++ b/pkg/controllers/user/logging/generator/validator.go
@@ -82,7 +82,7 @@ func validateFragmentsMatchExpected(fragments fluentd.Fragment, expected map[str
 
 func validateFragmentExist(expectedName string, fragments fluentd.Fragment) error {
 	if len(fragments) == 0 {
-		return errors.New("not configure element found")
+		return errors.New("no " + expectedName + " configure element found")
 	}
 
 	if len(fragments) > 1 {

--- a/pkg/controllers/user/logging/generator/validator_test.go
+++ b/pkg/controllers/user/logging/generator/validator_test.go
@@ -168,7 +168,7 @@ func compareCustomConfigure(clusterWrap ClusterLoggingTemplateWrap, projectWrap 
 
 	projectWrap.Content = content
 	projectWrap.CurrentTarget = loggingconfig.CustomTarget
-	if err := ValidateCustomTags(projectWrap); err != nil {
+	if err := ValidateCustomTarget(projectWrap); err != nil {
 		actualErrMsg = err.Error()
 	}
 


### PR DESCRIPTION
Problem:
1. Project match source use all file under /var/log/containers which include log files not belong to this project
2. When configuring read_from_head, if target file is large, it takes a long time and starting other plugins isn't executed until reading file is finished.
3. Default file chunk size is 256M, kafka plugin will iterate over each 256M file and deliver each 1024K, it takes a long time if file is too large

Solution:
1. Only tail file belong to this project
2. Remove read_from_head
3. reduce each chunk file size for kafka, set default kafka aggregation threshold higher

Issue:
https://github.com/rancher/rancher/issues/23303