### PR TITLE
Istio virtual service UI feature flag

### DIFF
--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -18,6 +18,7 @@ var (
 	// Features, ex.: ClusterRandomName = newFeature("cluster-randomizer", false)
 
 	UnsupportedStorageDrivers = newFeature("unsupported-storage-drivers", false)
+	IstioVirtualServiceUI     = newFeature("istio-virtual-service-ui", false)
 )
 
 type feature struct {


### PR DESCRIPTION
Issue:

Virtual Service UI support is hidden.
Instead of removing it, we can use feature flag to turn it off. 
Users can turn it on if they want.

https://github.com/rancher/rancher/issues/23137