### PR TITLE
Move two handlers from user to mgmt context

### DIFF
--- a/pkg/controllers/management/auth/register.go
+++ b/pkg/controllers/management/auth/register.go
@@ -16,6 +16,8 @@ func RegisterEarly(ctx context.Context, management *config.ManagementContext, cl
 	n := newTokenController(management)
 	ua := newUserAttributeController(management)
 	s := newAuthSettingController(management)
+	grbLegacy := newLegacyGRBCleaner(management)
+	rtLegacy := newLegacyRTCleaner(management)
 
 	management.Management.ProjectRoleTemplateBindings("").AddLifecycle(ctx, ptrbMGMTController, prtb)
 	management.Management.ClusterRoleTemplateBindings("").AddLifecycle(ctx, ctrbMGMTController, crtb)
@@ -27,6 +29,8 @@ func RegisterEarly(ctx context.Context, management *config.ManagementContext, cl
 	management.Management.Tokens("").AddHandler(ctx, tokenController, n.sync)
 	management.Management.UserAttributes("").AddHandler(ctx, userAttributeController, ua.sync)
 	management.Management.Settings("").AddHandler(ctx, authSettingController, s.sync)
+	management.Management.GlobalRoleBindings("").AddHandler(ctx, "legacy-grb-cleaner", grbLegacy.sync)
+	management.Management.RoleTemplates("").AddHandler(ctx, "legacy-rt-cleaner", rtLegacy.sync)
 }
 
 func RegisterLate(ctx context.Context, management *config.ManagementContext) {

--- a/pkg/controllers/user/rbac/handler_base.go
+++ b/pkg/controllers/user/rbac/handler_base.go
@@ -118,12 +118,10 @@ func Register(ctx context.Context, workload *config.UserContext) {
 	rti := workload.Management.Management.RoleTemplates("")
 	rtSync := v3.NewRoleTemplateLifecycleAdapter("cluster-roletemplate-sync_"+workload.ClusterName, true, rti, newRTLifecycle(r))
 	workload.Management.Management.RoleTemplates("").AddHandler(ctx, "cluster-roletemplate-sync", rtSync)
-	workload.Management.Management.RoleTemplates("").AddHandler(ctx, "legacy-rt-cleaner", newLegacyRTCleaner(r).sync)
 
 	grbi := workload.Management.Management.GlobalRoleBindings("")
 	grbSync := v3.NewGlobalRoleBindingLifecycleAdapter("grb-sync_"+workload.ClusterName, true, grbi, newGlobalRoleBindingHandler(workload))
 	workload.Management.Management.GlobalRoleBindings("").AddHandler(ctx, "grb-sync", grbSync)
-	workload.Management.Management.GlobalRoleBindings("").AddHandler(ctx, "legacy-grb-cleaner", newLegacyGRBCleaner(r).sync)
 }
 
 type manager struct {


### PR DESCRIPTION
Two handlers were incorrectly added to the user context instead
of the management context. These handlers are for mgmt plane resources:
globalRoleBinding and RoleTemplate, so they should be in the mgmt
plane.

https://github.com/rancher/rancher/issues/22512