### PR TITLE
Update RKEMetadataConfig setting to use dev branch for kontainer-driver-metadata

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -146,7 +146,7 @@ func NewSetting(name, def string) Setting {
 func getMetadataConfig() string {
 	data := map[string]interface{}{
 		"url":                      "https://github.com/rancher/kontainer-driver-metadata.git",
-		"branch":                   "master",
+		"branch":                   "dev",
 		"refresh-interval-minutes": "1440",
 	}
 	ans, err := json.Marshal(data)


### PR DESCRIPTION
Changing setting to dev branch since we branched off for 2.3 and will use master branch only for releases.