### PR TITLE
Handle panic is alert watch code

### DIFF
--- a/pkg/controllers/user/alert/watcher/node.go
+++ b/pkg/controllers/user/alert/watcher/node.go
@@ -106,6 +106,11 @@ func (w *NodeWatcher) watchRule() error {
 			}
 			for _, node := range nodes {
 				machine := nodeHelper.GetNodeByNodeName(machines, node.Name)
+				// handle the case when v3.node can't be found for v1.node
+				if machine == nil {
+					logrus.Warnf("Failed to find node %s", node.Name)
+					continue
+				}
 				w.checkNodeCondition(alert, machine)
 			}
 		}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/23250

This pr just fixes the situation when v3.node (machine) can't be found for v1.node. 

The reason for node missing can vary. Node might have been registered in k8s, but not propagated to rancher yet via nodesyncer. Added logging to reflect this situation.