### PR TITLE
Skip setting workloadId for pods with non-workload owner refs

### DIFF
--- a/pkg/api/store/pod/owner.go
+++ b/pkg/api/store/pod/owner.go
@@ -115,7 +115,7 @@ func SaveOwner(apiContext *types.APIContext, kind, name string, data map[string]
 
 func resolveWorkloadID(apiContext *types.APIContext, data map[string]interface{}) string {
 	kind, name := getOwner(data)
-	if kind == "" {
+	if kind == "" || !workload.WorkloadKinds[kind] {
 		return ""
 	}
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/22106

Looking at adding a test.