### PR TITLE
Capability override

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ replace (
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009
 
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.3
+	github.com/rancher/types => github.com/rmweir/types v0.0.0-20191007233918-ad727ce5bdba
 
 	k8s.io/api => k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783

--- a/go.sum
+++ b/go.sum
@@ -624,10 +624,6 @@ github.com/rancher/saml v0.0.0-20180713225824-ce1532152fde h1:+gd9up4jLeFeuNC5bH
 github.com/rancher/saml v0.0.0-20180713225824-ce1532152fde h1:+gd9up4jLeFeuNC5bHn7qfRXZO9WKtBe8b4vhucg9lg=
 github.com/rancher/saml v0.0.0-20180713225824-ce1532152fde/go.mod h1:Bp1IBnlwVB1EqRfSKecoPyf+1Wjh8zykMjlq4vJJhxY=
 github.com/rancher/saml v0.0.0-20180713225824-ce1532152fde/go.mod h1:Bp1IBnlwVB1EqRfSKecoPyf+1Wjh8zykMjlq4vJJhxY=
-github.com/rancher/types v0.0.0-20190930165650-6bbedae77a35 h1:8ocmE+9FUB0EuOZ7HiDWb5zBXdlQootMX9sMXFCOerk=
-github.com/rancher/types v0.0.0-20190930165650-6bbedae77a35/go.mod h1:I0hSpsw/ZvWuOOvhiExji5IIkeQtmn4IvFcn7nbjhrk=
-github.com/rancher/types v0.0.0-20191003184925-ab3403a2c8ca h1:nr7M7Gdk1mFnTiF5c6mXuKK5T+VFuxMO1AxoAK2bI7Y=
-github.com/rancher/types v0.0.0-20191003184925-ab3403a2c8ca/go.mod h1:3k1KigFfdRBJhiE8EXTpoM0aPXAFuYuGxKtU93oNxAY=
 github.com/rancher/wrangler v0.1.5 h1:HiXOeP6Kci2DK+e04D1g6INT77xAYpAr54zmTTe0Spk=
 github.com/rancher/wrangler v0.1.5/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rancher/wrangler v0.1.6-0.20190822171720-e78d8316ee95 h1:/yghR1MGJk6l6CVxJSx9JGBFP1D6NchJ74wJz7JwxC4=
@@ -635,6 +631,8 @@ github.com/rancher/wrangler v0.1.6-0.20190822171720-e78d8316ee95/go.mod h1:EYP7c
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rlmcpherson/s3gof3r v0.5.0/go.mod h1:s7vv7SMDPInkitQMuZzH615G7yWHdrU2r/Go7Bo71Rs=
+github.com/rmweir/types v0.0.0-20191007233918-ad727ce5bdba h1:pZef/x/8EobHPdkkPqLkGQH31MUeX9l1HoKpyEH/kTg=
+github.com/rmweir/types v0.0.0-20191007233918-ad727ce5bdba/go.mod h1:3k1KigFfdRBJhiE8EXTpoM0aPXAFuYuGxKtU93oNxAY=
 github.com/robfig/cron v1.1.0 h1:jk4/Hud3TTdcrJgUOBgsqrZBarcxl6ADIjSC2iniwLY=
 github.com/robfig/cron v1.1.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/controllers/management/cluster/clustercontroller_test.go
+++ b/pkg/controllers/management/cluster/clustercontroller_test.go
@@ -1,8 +1,11 @@
 package cluster
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/rancher/norman/types"
 	"github.com/rancher/rke/cloudprovider/aws"
 	"github.com/rancher/rke/cloudprovider/azure"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
@@ -11,6 +14,7 @@ import (
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/pointer"
 )
 
 const testServiceNodePortRange = "10000-32769"
@@ -105,4 +109,88 @@ func TestIngressCapability(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, testCluster.Spec.RancherKubernetesEngineConfig.Ingress.Provider, caps.IngressCapabilities[0].IngressProvider)
 	}
+}
+
+type capabilitiesTestCase struct {
+	annotations  map[string]string
+	capabilities v3.Capabilities
+	result       v3.Capabilities
+	errMsg       string
+}
+
+func TestOverrideCapabilities(t *testing.T) {
+	assert := assert.New(t)
+
+	fakeCapabilitiesSchema := types.Schema{
+		ResourceFields: map[string]types.Field{
+			"pspEnabled": {
+				Type: "boolean",
+			},
+			"nodePortRange": {
+				Type: "string",
+			},
+			"ingressCapabilities": {
+				Type: "something",
+			},
+		},
+	}
+	tests := []capabilitiesTestCase{
+		{
+			annotations: map[string]string{
+				fmt.Sprintf("%s%s", capabilitiesAnnotation, "pspEnabled"): "true",
+			},
+			capabilities: v3.Capabilities{},
+			result: v3.Capabilities{
+				PspEnabled: pointer.BoolPtr(true),
+			},
+		},
+		{
+			annotations: map[string]string{
+				fmt.Sprintf("%s%s", capabilitiesAnnotation, "nodePortRange"): "9999",
+			},
+			capabilities: v3.Capabilities{},
+			result: v3.Capabilities{
+				NodePortRange: "9999",
+			},
+		},
+		{
+			annotations: map[string]string{
+				fmt.Sprintf("%s%s", capabilitiesAnnotation, "ingressCapabilities"): "[{\"customDefaultBackend\":true,\"ingressProvider\":\"asdf\"}]",
+			},
+			capabilities: v3.Capabilities{},
+			result: v3.Capabilities{
+				IngressCapabilities: []v3.IngressCapabilities{
+					{
+						CustomDefaultBackend: pointer.BoolPtr(true),
+						IngressProvider:      "asdf",
+					},
+				},
+			},
+		},
+		{
+			annotations: map[string]string{
+				fmt.Sprintf("%s%s", capabilitiesAnnotation, "notarealcapability"): "something",
+			},
+			capabilities: v3.Capabilities{},
+			errMsg:       "resource field [notarealcapability] from capabillities annotation not found",
+		},
+		{
+			annotations: map[string]string{
+				fmt.Sprintf("%s%s", capabilitiesAnnotation, "pspEnabled"): "5",
+			},
+			capabilities: v3.Capabilities{},
+			errMsg:       "strconv.ParseBool: parsing \"5\": invalid syntax",
+		},
+	}
+
+	for _, test := range tests {
+		result, err := overrideCapabilities(test.annotations, test.capabilities, &fakeCapabilitiesSchema)
+		if err != nil {
+			assert.Equal(test.errMsg, err.Error())
+		} else {
+			assert.True(reflect.DeepEqual(test.result, result))
+		}
+	}
+
+	assert.Nil(nil)
 }

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -242,6 +242,7 @@ type Capabilities struct {
 	NodePoolScalingSupported bool                     `json:"nodePoolScalingSupported,omitempty"`
 	NodePortRange            string                   `json:"nodePortRange,omitempty"`
 	TaintSupport             *bool                    `json:"taintSupport,omitempty"`
+	PspEnabled               *bool                    `json:"pspEnabled,omitempty"`
 }
 
 type LoadBalancerCapabilities struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -569,6 +569,11 @@ func (in *Capabilities) DeepCopyInto(out *Capabilities) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PspEnabled != nil {
+		in, out := &in.PspEnabled, &out.PspEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_capabilities.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_capabilities.go
@@ -6,6 +6,7 @@ const (
 	CapabilitiesFieldLoadBalancerCapabilities = "loadBalancerCapabilities"
 	CapabilitiesFieldNodePoolScalingSupported = "nodePoolScalingSupported"
 	CapabilitiesFieldNodePortRange            = "nodePortRange"
+	CapabilitiesFieldPspEnabled               = "pspEnabled"
 	CapabilitiesFieldTaintSupport             = "taintSupport"
 )
 
@@ -14,5 +15,6 @@ type Capabilities struct {
 	LoadBalancerCapabilities *LoadBalancerCapabilities `json:"loadBalancerCapabilities,omitempty" yaml:"loadBalancerCapabilities,omitempty"`
 	NodePoolScalingSupported bool                      `json:"nodePoolScalingSupported,omitempty" yaml:"nodePoolScalingSupported,omitempty"`
 	NodePortRange            string                    `json:"nodePortRange,omitempty" yaml:"nodePortRange,omitempty"`
+	PspEnabled               *bool                     `json:"pspEnabled,omitempty" yaml:"pspEnabled,omitempty"`
 	TaintSupport             *bool                     `json:"taintSupport,omitempty" yaml:"taintSupport,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -284,8 +284,8 @@ github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 # github.com/rancher/kontainer-driver-metadata v0.0.0-20191003190312-bd4630881fb2
-github.com/rancher/kontainer-driver-metadata/rke/templates
 github.com/rancher/kontainer-driver-metadata/rke
+github.com/rancher/kontainer-driver-metadata/rke/templates
 # github.com/rancher/kontainer-engine v0.0.4-dev.0.20190930174220-db9e24343393
 github.com/rancher/kontainer-engine/logstream
 github.com/rancher/kontainer-engine/service
@@ -370,10 +370,11 @@ github.com/rancher/rke/dind
 github.com/rancher/rke/cloudprovider/custom
 github.com/rancher/rke/cloudprovider/openstack
 github.com/rancher/rke/cloudprovider/vsphere
-# github.com/rancher/types v0.0.0-20191003184925-ab3403a2c8ca
+# github.com/rancher/types v0.0.0-20191003184925-ab3403a2c8ca => github.com/rmweir/types v0.0.0-20191007233918-ad727ce5bdba
 github.com/rancher/types/apis/management.cattle.io/v3
 github.com/rancher/types/client/management/v3
 github.com/rancher/types/config
+github.com/rancher/types/image
 github.com/rancher/types/apis/core/v1
 github.com/rancher/types/apis/management.cattle.io/v3/schema
 github.com/rancher/types/peermanager
@@ -384,7 +385,6 @@ github.com/rancher/types/client/cluster/v3
 github.com/rancher/types/client/project/v3
 github.com/rancher/types/user
 github.com/rancher/types/compose
-github.com/rancher/types/image
 github.com/rancher/types/config/dialer
 github.com/rancher/types/apis/apps/v1
 github.com/rancher/types/apis/apiregistration.k8s.io/v1


### PR DESCRIPTION
Problem:
Users want to use psp feature on imported cluster's that have it enabled. Before providing UI for this, we need a way of know whether an imported cluster has it enabled.

Solution:
Provide a way of overriding capabilities via annotations.

Depends on:
https://github.com/rancher/types/pull/998

Issue:
https://github.com/rancher/rancher/issues/21039