### PR TITLE
[forwardport]Make jailer timeout a setting - master

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -28,6 +28,7 @@ var (
 	HelmVersion                       = NewSetting("helm-version", "dev")
 	IngressIPDomain                   = NewSetting("ingress-ip-domain", "xip.io")
 	InstallUUID                       = NewSetting("install-uuid", "")
+	JailerTimeout                     = NewSetting("jailer-timeout", "60")
 	KubernetesVersion                 = NewSetting("k8s-version", "")
 	KubernetesVersionToServiceOptions = NewSetting("k8s-version-to-service-options", "")
 	KubernetesVersionToSystemImages   = NewSetting("k8s-version-to-images", "")


### PR DESCRIPTION
Problem:
On some systems the default time of 10 seconds can cause the initial
jail creation to fail and Rancher won't be able to start
The error message is also not clear as to what failed

Solution:
Make the timeout a setting and also increase the default to 60 seconds
Update error message to clarify the failure is coming from the timeout

https://github.com/rancher/rancher/issues/23241