### PR TITLE
Draft - Introduce standard user

### DIFF
--- a/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test
+++ b/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test
@@ -51,14 +51,15 @@ node {
               "${imageName} /bin/bash -c \'pytest -v -s --junit-xml=${setupResultsOut} " +
               "${deployPytestOptions} ${testsDir}\'"
 
-            // copy file containing CATTLE_TEST_URL & ADMIN_TOKEN and load into environment variables
+            // copy file containing CATTLE_TEST_URL, ADMIN_TOKEN, USER_TOKEN and load into environment variables
             sh "docker cp ${setupContainer}:${rootPath}${testsDir}${rancherConfig} ."
             load rancherConfig
 
             // run tests
             sh "docker run --name ${testContainer} -t --env-file ${envFile} " +
               "${imageName} /bin/bash -c \'export CATTLE_TEST_URL=${env.CATTLE_TEST_URL} " +
-              "&& export ADMIN_TOKEN=${env.ADMIN_TOKEN} && pytest -v -s --junit-xml=${testResultsOut} " +
+              "&& export ADMIN_TOKEN=${env.ADMIN_TOKEN} && export USER_TOKEN=${env.USER_TOKEN} "+
+              "&& pytest -v -s --junit-xml=${testResultsOut} " +
               "${PYTEST_OPTIONS} ${testsDir}\'"
           } catch(err) {
             echo "Error: " + err

--- a/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_ontag
+++ b/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_ontag
@@ -89,14 +89,15 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                   "pytest -v -s --junit-xml=${setupResultsOut} " +
                   "${deployPytestOptions} ${testsDir}\'"
 
-                // copy file containing CATTLE_TEST_URL & ADMIN_TOKEN and load into environment variables
+                // copy file containing CATTLE_TEST_URL, ADMIN_TOKEN, USER_TOKEN and load into environment variables
                 sh "docker cp ${setupContainer}:${rootPath}${testsDir}${rancherConfig} ."
                 load rancherConfig
 
                 // run tests
                 sh "docker run --name ${testContainer} -t --env-file ${envFile} " +
                   "${imageName} /bin/bash -c \'export CATTLE_TEST_URL=${env.CATTLE_TEST_URL} " +
-                  "&& export ADMIN_TOKEN=${env.ADMIN_TOKEN} && pytest -v -s --junit-xml=${testResultsOut} " +
+                  "&& export ADMIN_TOKEN=${env.ADMIN_TOKEN} && export USER_TOKEN=${env.USER_TOKEN} " +
+                  "&& pytest -v -s --junit-xml=${testResultsOut} " +
                   "${PYTEST_OPTIONS} ${testsDir}\'"
               } catch(err) {
                 echo "Error: " + err

--- a/tests/validation/tests/v3_api/Jenkinsfile_provisioning_tests
+++ b/tests/validation/tests/v3_api/Jenkinsfile_provisioning_tests
@@ -17,7 +17,7 @@ node {
     withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
                           string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
                           string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
-                          string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD')]) {
+                          string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD')]) {
       stage('Checkout') {
         deleteDir()
         checkout([
@@ -61,7 +61,7 @@ node {
         }
 
         stage('Run provisioning tests') {
-          params = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"), string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}"), string(name: 'BRANCH', value: branch) ]
+          params = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"), string(name: 'USER_TOKEN', value: "${USER_TOKEN}"), string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}"), string(name: 'BRANCH', value: branch) ]
 
           jobs["custom"] = { build job: 'rancher-v3_custom_provisioning', parameters: params}
           jobs["do"] = { build job: 'rancher-v3_do_provisioning', parameters: params }
@@ -80,7 +80,8 @@ node {
               sleep(time: RANCHER_DELETE_DELAY.toInteger(), unit: "HOURS")
               sh "docker run --name ${deleteContainer} -t --env-file ${envFile} " +
               "${imageName} /bin/bash -c \'export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " +
-              "export ADMIN_TOKEN=${ADMIN_TOKEN} && pytest -v -s --junit-xml=${deleteResultsOut} " +
+              "export ADMIN_TOKEN=${ADMIN_TOKEN} && export USER_TOKEN=${USER_TOKEN} &&" +
+              "pytest -v -s --junit-xml=${deleteResultsOut} " +
               "${deletePytestOptions} ${testsDir}\'"
             }
             else {

--- a/tests/validation/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
+++ b/tests/validation/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
@@ -91,7 +91,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
           }
 
           stage('Run provisioning tests') {
-            params = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"), string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}"), string(name: 'BRANCH', value: branch) ]
+            params = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"), string(name: 'USER_TOKEN', value: "${USER_TOKEN}"), string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}"), string(name: 'BRANCH', value: branch) ]
 
             jobs["custom"] = { build job: 'rancher-v3_test_custom_cluster', parameters: params}
             jobs["do"] = { build job: 'rancher-v3_test_do_cluster', parameters: params }
@@ -110,7 +110,8 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                 sleep(time: RANCHER_DELETE_DELAY.toInteger(), unit: "HOURS")
                 sh "docker run --name ${deleteContainer} -t --env-file ${envFile} " +
                 "${imageName} /bin/bash -c \'export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " +
-                "export ADMIN_TOKEN=${ADMIN_TOKEN} && pytest -v -s --junit-xml=${deleteResultsOut} " +
+                "export ADMIN_TOKEN=${ADMIN_TOKEN} && export USER_TOKEN=${USER_TOKEN} && "+
+                "pytest -v -s --junit-xml=${deleteResultsOut} " +
                 "${deletePytestOptions} ${testsDir}\'"
               }
               else {

--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -18,8 +18,13 @@ DEFAULT_MONITORING_TIMEOUT = 180
 
 CATTLE_TEST_URL = os.environ.get('CATTLE_TEST_URL', "http://localhost:80")
 CATTLE_API_URL = CATTLE_TEST_URL + "/v3"
+CATTLE_AUTH_URL = \
+    CATTLE_TEST_URL + "/v3-public/localproviders/local?action=login"
 
 ADMIN_TOKEN = os.environ.get('ADMIN_TOKEN', "None")
+USER_TOKEN = os.environ.get('USER_TOKEN', "None")
+USER_PASSWORD = os.environ.get('USER_PASSWORD', "None")
+
 kube_fname = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                           "k8s_kube_config")
 MACHINE_TIMEOUT = float(os.environ.get('RANCHER_MACHINE_TIMEOUT', "1200"))
@@ -52,6 +57,10 @@ def random_test_name(name="test"):
 
 def get_admin_client():
     return rancher.Client(url=CATTLE_API_URL, token=ADMIN_TOKEN, verify=False)
+
+
+def get_user_client():
+    return rancher.Client(url=CATTLE_API_URL, token=USER_TOKEN, verify=False)
 
 
 def get_client_for_token(token):
@@ -402,7 +411,7 @@ def wait_for_pod_to_running(client, pod, timeout=DEFAULT_TIMEOUT):
 
 
 def get_schedulable_nodes(cluster):
-    client = get_admin_client()
+    client = get_user_client()
     nodes = client.list_node(clusterId=cluster.id).data
     schedulable_nodes = []
     for node in nodes:
@@ -416,7 +425,7 @@ def get_role_nodes(cluster, role):
     control_nodes = []
     worker_nodes = []
     node_list = []
-    client = get_admin_client()
+    client = get_user_client()
     nodes = client.list_node(clusterId=cluster.id).data
     for node in nodes:
         if node.etcd:
@@ -568,6 +577,8 @@ def validate_http_response(cmd, target_name_list, client_pod=None):
 def validate_cluster(client, cluster, intermediate_state="provisioning",
                      check_intermediate_state=True, skipIngresscheck=True,
                      nodes_not_in_active_state=[], k8s_version=""):
+    # Allow sometime for the "cluster_owner" CRTB to take effect
+    time.sleep(5)
     cluster = validate_cluster_state(
         client, cluster,
         check_intermediate_state=check_intermediate_state,
@@ -580,8 +591,8 @@ def validate_cluster(client, cluster, intermediate_state="provisioning",
         check_cluster_version(cluster, k8s_version)
     if hasattr(cluster, 'rancherKubernetesEngineConfig'):
         check_cluster_state(len(get_role_nodes(cluster, "etcd")))
-    project, ns = create_project_and_ns(ADMIN_TOKEN, cluster)
-    p_client = get_project_client_for_token(project, ADMIN_TOKEN)
+    project, ns = create_project_and_ns(USER_TOKEN, cluster)
+    p_client = get_project_client_for_token(project, USER_TOKEN)
     con = [{"name": "test1",
             "image": TEST_IMAGE}]
     name = random_test_name("default")
@@ -755,6 +766,8 @@ def get_custom_host_registration_cmd(client, cluster, roles, node):
 
 
 def create_custom_host_registration_token(client, cluster):
+    # Allow sometime for the "cluster_owner" CRTB to take effect
+    time.sleep(5)
     cluster_token = client.create_cluster_registration_token(
         clusterId=cluster.id)
     cluster_token = client.wait_success(cluster_token)
@@ -908,8 +921,8 @@ def wait_for_pods_in_workload(p_client, workload, pod_count,
     return pods
 
 
-def get_admin_client_and_cluster():
-    client = get_admin_client()
+def get_user_client_and_cluster():
+    client = get_user_client()
     if CLUSTER_NAME == "":
         clusters = client.list_cluster().data
     else:
@@ -976,6 +989,7 @@ def cluster_cleanup(client, cluster, aws_nodes=None):
     else:
         env_details = "env.CATTLE_TEST_URL='" + CATTLE_TEST_URL + "'\n"
         env_details += "env.ADMIN_TOKEN='" + ADMIN_TOKEN + "'\n"
+        env_details += "env.USER_TOKEN='" + USER_TOKEN + "'\n"
         env_details += "env.CLUSTER_NAME='" + cluster.name + "'\n"
         create_config_file(env_details)
 
@@ -1141,7 +1155,7 @@ def wait_for_mcapp_to_active(client, multiClusterApp,
 def wait_for_app_to_active(client, app_id,
                            timeout=DEFAULT_MULTI_CLUSTER_APP_TIMEOUT):
     time.sleep(5)
-    #When the app is deployed it goes into Active state for a short
+    # When the app is deployed it goes into Active state for a short
     # period of time and then into installing/deploying.
     app_data = client.list_app(id=app_id).data
     start = time.time()
@@ -1278,10 +1292,10 @@ def validate_app_deletion(client, app_id,
 
 def validate_catalog_app(proj_client, app, external_id, answer=None):
     if answer is None:
-        answers = get_defaut_question_answers(get_admin_client(), external_id)
+        answers = get_defaut_question_answers(get_user_client(), external_id)
     else:
         answers = answer
-    #validate app is active
+    # validate app is active
     app = wait_for_app_to_active(proj_client, app.id)
     assert app.externalId == external_id, \
         "the version of the app is not correct"
@@ -1298,7 +1312,28 @@ def validate_catalog_app(proj_client, app, external_id, answer=None):
         assert wl.workloadLabels.chart == chart, \
             "the chart version is wrong"
 
-    #validate_app_answers
+    # Validate_app_answers
     assert len(answers.items() - app["answers"].items()) == 0, \
         "Answers are not same as the original catalog answers"
     return app
+
+
+def create_user(client, cattle_auth_url=CATTLE_AUTH_URL):
+    user_name = random_name()
+    user = client.create_user(username=user_name,
+                              password=USER_PASSWORD)
+    client.create_global_role_binding(globalRoleId="user",
+                                      subjectKind="User",
+                                      userId=user.id)
+    user_token = get_user_token(user, cattle_auth_url)
+    return user, user_token
+
+
+def get_user_token(user, cattle_auth_url=CATTLE_AUTH_URL):
+    r = requests.post(cattle_auth_url, json={
+        'username': user.username,
+        'password': USER_PASSWORD,
+        'responseType': 'json',
+    }, verify=False)
+    print(r.json())
+    return r.json()["token"]

--- a/tests/validation/tests/v3_api/scripts/configure.sh
+++ b/tests/validation/tests/v3_api/scripts/configure.sh
@@ -4,7 +4,7 @@ set -eu
 
 DEBUG="${DEBUG:-false}"
 
-env | egrep '^(CATTLE_|ADMIN|DO|RANCHER_|AWS_|DEBUG|DEFAULT_|OS_|DOCKER_|CLOUD_|KUBE|BUILD_NUMBER|AZURE).*\=.+' | sort > .env
+env | egrep '^(CATTLE_|ADMIN|USER|DO|RANCHER_|AWS_|DEBUG|DEFAULT_|OS_|DOCKER_|CLOUD_|KUBE|BUILD_NUMBER|AZURE).*\=.+' | sort > .env
 
 if [ "false" != "${DEBUG}" ]; then
     cat .env

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -70,12 +70,13 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
 
       def CATTLE_TEST_URL_2 = ""
       def ADMIN_TOKEN_2 = ""
+      def USER_TOKEN_2 = ""
 
       wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
         withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
                           string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
                           string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
-                          string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD')]) {
+                          string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD')]) {
 
           println "Branch: ${branch}"
           stage('Checkout') {
@@ -109,12 +110,13 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                     "pytest -v -s --junit-xml=${setupResultsOut} " +
                     "${deployPytestOptions} ${testsDir}\'"
 
-                  // copy file containing CATTLE_TEST_URL & ADMIN_TOKEN and load into environment variables
+                  // copy file containing CATTLE_TEST_URL, ADMIN_TOKEN, USER_TOKEN and load into environment variables
                   sh "docker cp ${setupContainer}:${rootPath}${testsDir}${rancherConfig} ."
                   load rancherConfig
 
                   CATTLE_TEST_URL_2 = "${CATTLE_TEST_URL}"
                   ADMIN_TOKEN_2 = "${ADMIN_TOKEN}"
+                  USER_TOKEN_2 = "${USER_TOKEN}"
                 } catch(err) {
                   echo "Error: " + err
                   echo 'Test run had failures. Collecting results...'
@@ -146,11 +148,13 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                     println "Branch: ${branch}"
                     params = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"),
                               string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}"),
+                              string(name: 'USER_TOKEN', value: "${USER_TOKEN}"),
                               string(name: 'RANCHER_SERVER_VERSION', value: "${rancher_version}"), 
                               string(name: 'BRANCH', value: branch) ]
 
                     params2 = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL_2}"),
                                 string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN_2}"),
+                                string(name: 'USER_TOKEN', value: "${USER_TOKEN_2}"),
                                 string(name: 'RANCHER_SERVER_VERSION', value: "${rancher_version}"),
                                 string(name: 'BRANCH', value: branch) ]
 
@@ -177,7 +181,8 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                   try {
                     sh "docker run --name ${deleteContainer} -t --env-file ${envFile} " +
                     "${imageName} /bin/bash -c \'export CATTLE_TEST_URL=${env.CATTLE_TEST_URL} && " +
-                    "export ADMIN_TOKEN=${env.ADMIN_TOKEN} && pytest -v -s --junit-xml=${deleteResultsOut} " +
+                    "export ADMIN_TOKEN=${env.ADMIN_TOKEN} && export USER_TOKEN=${env.USER_TOKEN} &&"+
+                    "pytest -v -s --junit-xml=${deleteResultsOut} " +
                     "${deletePytestOptions} ${testsDir}\'"
                   } catch(err) {
                     echo "Error: " + err
@@ -186,7 +191,8 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                   try {
                     sh "docker run --name ${deleteContainer2} -t --env-file ${envFile} " +
                     "${imageName} /bin/bash -c \'export CATTLE_TEST_URL=${CATTLE_TEST_URL_2} && " +
-                    "export ADMIN_TOKEN=${ADMIN_TOKEN_2} && pytest -v -s --junit-xml=${deleteResultsOut2} " +
+                    "export ADMIN_TOKEN=${ADMIN_TOKEN_2} && export USER_TOKEN=${USER_TOKEN_2} &&" +
+                    "pytest -v -s --junit-xml=${deleteResultsOut2} " +
                     "${deletePytestOptions} ${testsDir}\'"
                   } catch(err) {
                     echo "Error: " + err

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_provision_and_test
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_provision_and_test
@@ -44,7 +44,7 @@ node {
                       string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'RANCHER_AKS_SECRET_KEY'),
                       string(credentialsId: 'RANCHER_REGISTRY_USER_NAME', variable: 'RANCHER_REGISTRY_USER_NAME'),
                       string(credentialsId: 'RANCHER_REGISTRY_PASSWORD', variable: 'RANCHER_REGISTRY_PASSWORD'),
-                      string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                      string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD'),
                       string(credentialsId: 'RANCHER_GKE_CREDENTIAL', variable: 'RANCHER_GKE_CREDENTIAL')]) {
       stage('Checkout') {
         deleteDir()

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade
@@ -31,7 +31,7 @@ node {
                       string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'RANCHER_AKS_SECRET_KEY'),
                       string(credentialsId: 'RANCHER_REGISTRY_USER_NAME', variable: 'RANCHER_REGISTRY_USER_NAME'),
                       string(credentialsId: 'RANCHER_REGISTRY_PASSWORD', variable: 'RANCHER_REGISTRY_PASSWORD'),
-                      string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                      string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD'),
                       string(credentialsId: 'RANCHER_GKE_CREDENTIAL', variable: 'RANCHER_GKE_CREDENTIAL')]) {
       stage('Prechecks & checkout preupgrade branch') {
         if (RANCHER_SERVER_VERSION == "") {
@@ -102,7 +102,8 @@ node {
           sh "docker run --name ${containerPrefix}_provision  --env-file .env " +
             "${imageName} /bin/bash -c \'" +
             "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " +
-            "export ADMIN_TOKEN=${ADMIN_TOKEN} && " + 
+            "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+            "export USER_TOKEN=${USER_TOKEN} && " +
             "pytest -v -s --junit-xml=provision.xml -k test_rke_${RANCHER_CLUSTER_TYPE}_host_${RANCHER_CLUSTER_PROFILE} ${testsDir}\'"
         } catch(err) {
           buildFail = true
@@ -118,6 +119,7 @@ node {
             "${imageName} /bin/bash -c \'" +
             "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
             "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+            "export USER_TOKEN=${USER_TOKEN} && " +
             "export RANCHER_VALIDATE_RESOURCES_PREFIX=autopre && " +
             "export RANCHER_CREATE_RESOURCES_PREFIX=autopre && " +
             "export RANCHER_UPGRADE_CHECK=preupgrade && " +
@@ -159,6 +161,7 @@ node {
             "${imageName} /bin/bash -c \'" +
             "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
             "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+            "export USER_TOKEN=${USER_TOKEN} && " +
             "export RANCHER_UPGRADE_CHECK=upgrade_rancher && " +
             "pytest -v -s --junit-xml=upgrade.xml -k test_rancher_upgrade ${testsDir}\'"
         } catch(err) {
@@ -176,6 +179,7 @@ node {
             "${imageName} /bin/bash -c \'" + 
             "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
             "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+            "export USER_TOKEN=${USER_TOKEN} && " +
             "export RANCHER_VALIDATE_RESOURCES_PREFIX=autopre && " +
             "export RANCHER_CREATE_RESOURCES_PREFIX=autopost && " +
             "export RANCHER_UPGRADE_CHECK=postupgrade && " +
@@ -199,6 +203,7 @@ node {
               "${imageName} /bin/bash -c \'" +
               "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
               "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+              "export USER_TOKEN=${USER_TOKEN} && " +
               "pytest -v -s --junit-xml=k8supgrade.xml -k test_edit_cluster_k8s_version ${testsDir}\'"
           }
         } catch(err) {
@@ -216,6 +221,7 @@ node {
               "${imageName} /bin/bash -c \'" + 
               "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
               "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+              "export USER_TOKEN=${USER_TOKEN} && " +
               "export RANCHER_VALIDATE_RESOURCES_PREFIX=autopost && " +
               "export RANCHER_CREATE_RESOURCES_PREFIX=autopost2 && " +
               "export RANCHER_UPGRADE_CHECK=postupgrade && " +
@@ -239,7 +245,7 @@ node {
             sh "docker run --name ${containerPrefix}_delete -t --env-file .env " + 
             "${imageName} /bin/bash -c \'" +
             "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
-            "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+            "export USER_TOKEN=${USER_TOKEN} && " +
             "pytest -v -s --junit-xml=delete.xml " +
             "-k test_delete_rancher_server ${testsDir}\'"
           } else {

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade_multiple
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_single_upgrade_multiple
@@ -39,7 +39,7 @@ node {
                       string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'RANCHER_AKS_SECRET_KEY'),
                       string(credentialsId: 'RANCHER_REGISTRY_USER_NAME', variable: 'RANCHER_REGISTRY_USER_NAME'),
                       string(credentialsId: 'RANCHER_REGISTRY_PASSWORD', variable: 'RANCHER_REGISTRY_PASSWORD'),
-                      string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                      string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD'),
                       string(credentialsId: 'RANCHER_GKE_CREDENTIAL', variable: 'RANCHER_GKE_CREDENTIAL')]) {
         deleteDir()
 
@@ -352,6 +352,7 @@ def runProvision(def cluster, def exportString) {
       "export RANCHER_CLUSTER_NAME=${cluster_name} && " +
       "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " +
       "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+      "export USER_TOKEN=${USER_TOKEN} && " +
       "${exportString}" + 
       "pytest -v -s -k test_rke_${cluster}_host_${CLUSTER_PROFILE} ${testsDir} " +
       "--junit-xml=reports/${reportName}.xml " +
@@ -380,6 +381,7 @@ def runPreupgradeTests(def cluster, def validate, def create) {
         "export RANCHER_CLUSTER_NAME=${cluster_name} && " +
         "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
         "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+        "export USER_TOKEN=${USER_TOKEN} && " +
         "export RANCHER_VALIDATE_RESOURCES_PREFIX=${validate} && " +
         "export RANCHER_CREATE_RESOURCES_PREFIX=${create} && " +
         "export RANCHER_UPGRADE_CHECK=preupgrade && " +
@@ -420,6 +422,7 @@ def upgradeRancher() {
       "export RANCHER_CLUSTER_NAME=${cluster_name} && " +
       "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
       "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+      "export USER_TOKEN=${USER_TOKEN} && " +
       "export RANCHER_UPGRADE_CHECK=upgrade_rancher && " +
       "pytest -v -s -k test_rancher_upgrade ${testsDir} " +
       "--junit-xml=reports/${reportName}.xml " +
@@ -451,6 +454,7 @@ def runPostupgradeTests(def cluster, def validate, def create, def xmlPrefix="")
         "export RANCHER_CLUSTER_NAME=${cluster_name} && " +
         "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
         "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+        "export USER_TOKEN=${USER_TOKEN} && " +
         "export RANCHER_VALIDATE_RESOURCES_PREFIX=${validate} && " +
         "export RANCHER_CREATE_RESOURCES_PREFIX=${create} && " +
         "export RANCHER_UPGRADE_CHECK=postupgrade && " +
@@ -486,6 +490,7 @@ def run_k8s_upgrade(def cluster, def k8s_version) {
         "export RANCHER_K8S_VERSION_UPGRADE=${k8s_version} && " +
         "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
         "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+        "export USER_TOKEN=${USER_TOKEN} && " +
         "pytest -v -s -k test_edit_cluster_k8s_version ${testsDir} " +
         "--junit-xml=reports/${reportName}.xml " +
         "${htmlString}\'"
@@ -510,6 +515,7 @@ def deleteRancherServer() {
         "${imageName} /bin/bash -c \'" +
         "export CATTLE_TEST_URL=${CATTLE_TEST_URL} && " + 
         "export ADMIN_TOKEN=${ADMIN_TOKEN} && " +
+        "export USER_TOKEN=${USER_TOKEN} && " +
         "pytest -v -s -k test_delete_rancher_server ${testsDir} " +
         "--junit-xml=reports/${reportName}.xml " +
         "${htmlString}\'"

--- a/tests/validation/tests/v3_api/test_aks_cluster.py
+++ b/tests/validation/tests/v3_api/test_aks_cluster.py
@@ -19,7 +19,7 @@ akscredential = pytest.mark.skipif(not (SUBSCRIPTION_ID and TENANT_ID and
 @akscredential
 def test_create_aks_cluster():
 
-    client = get_admin_client()
+    client = get_user_client()
     aksConfig = get_aks_config()
 
     print("Cluster creation")
@@ -41,7 +41,7 @@ def get_aks_version():
         }
         headers = {"Content-Type": "application/json",
                    "Accept": "application/json",
-                   "Authorization": "Bearer " + ADMIN_TOKEN}
+                   "Authorization": "Bearer " + USER_TOKEN}
 
         aks_version_url = CATTLE_TEST_URL + "/meta/aksVersions"
         print(aks_version_url)

--- a/tests/validation/tests/v3_api/test_bkp_restore.py
+++ b/tests/validation/tests/v3_api/test_bkp_restore.py
@@ -7,7 +7,7 @@ namespace = {"p_client": None, "ns": None, "cluster": None, "project": None}
 def test_bkp_restore():
     p_client = namespace["p_client"]
     ns = namespace["ns"]
-    client = get_admin_client()
+    client = get_user_client()
     cluster = namespace["cluster"]
     name = random_test_name("default")
 
@@ -67,11 +67,11 @@ def test_bkp_restore():
 
 @pytest.fixture(scope='module', autouse="True")
 def create_project_client(request):
-    client, cluster = get_admin_client_and_cluster()
+    client, cluster = get_user_client_and_cluster()
     create_kubeconfig(cluster)
-    p, ns = create_project_and_ns(ADMIN_TOKEN, cluster, "testsecret")
-    p_client = get_project_client_for_token(p, ADMIN_TOKEN)
-    c_client = get_cluster_client_for_token(cluster, ADMIN_TOKEN)
+    p, ns = create_project_and_ns(USER_TOKEN, cluster, "testsecret")
+    p_client = get_project_client_for_token(p, USER_TOKEN)
+    c_client = get_cluster_client_for_token(cluster, USER_TOKEN)
     namespace["p_client"] = p_client
     namespace["ns"] = ns
     namespace["cluster"] = cluster
@@ -79,7 +79,7 @@ def create_project_client(request):
     namespace["c_client"] = c_client
 
     def fin():
-        client = get_admin_client()
+        client = get_user_client()
         client.delete(namespace["project"])
     request.addfinalizer(fin)
 

--- a/tests/validation/tests/v3_api/test_eks_cluster.py
+++ b/tests/validation/tests/v3_api/test_eks_cluster.py
@@ -15,7 +15,7 @@ ekscredential = pytest.mark.skipif(not (EKS_ACCESS_KEY and EKS_SECRET_KEY),
 @ekscredential
 def test_create_eks_cluster():
 
-    client = get_admin_client()
+    client = get_user_client()
     eksConfig = get_eks_config()
 
     print("Cluster creation")

--- a/tests/validation/tests/v3_api/test_gke_cluster.py
+++ b/tests/validation/tests/v3_api/test_gke_cluster.py
@@ -12,7 +12,7 @@ gkecredential = pytest.mark.skipif(not CREDENTIALS, reason='GKE Credentials '
 @gkecredential
 def test_create_gke_cluster():
 
-    client = get_admin_client()
+    client = get_user_client()
     gkeConfig = get_gke_config()
 
     print("Cluster creation")
@@ -47,7 +47,7 @@ def get_gke_version_credentials():
         }
         headers = {"Content-Type": "application/json",
                    "Accept": "application/json",
-                   "Authorization": "Bearer " + ADMIN_TOKEN}
+                   "Authorization": "Bearer " + USER_TOKEN}
 
         gke_version_url = CATTLE_TEST_URL + "/meta/gkeVersions"
         print(gke_version_url)

--- a/tests/validation/tests/v3_api/test_import_cluster.py
+++ b/tests/validation/tests/v3_api/test_import_cluster.py
@@ -10,7 +10,7 @@ AWS_SSH_KEY_NAME = os.environ.get("AWS_SSH_KEY_NAME")
 
 def test_import_rke_cluster():
 
-    client = get_admin_client()
+    client = get_user_client()
 
     # Create nodes in AWS
     aws_nodes = create_nodes()

--- a/tests/validation/tests/v3_api/test_ingress.py
+++ b/tests/validation/tests/v3_api/test_ingress.py
@@ -323,16 +323,16 @@ def test_ingress_xip_io():
 
 @pytest.fixture(scope='module', autouse="True")
 def create_project_client(request):
-    client, cluster = get_admin_client_and_cluster()
+    client, cluster = get_user_client_and_cluster()
     create_kubeconfig(cluster)
-    p, ns = create_project_and_ns(ADMIN_TOKEN, cluster, "testingress")
-    p_client = get_project_client_for_token(p, ADMIN_TOKEN)
+    p, ns = create_project_and_ns(USER_TOKEN, cluster, "testingress")
+    p_client = get_project_client_for_token(p, USER_TOKEN)
     namespace["p_client"] = p_client
     namespace["ns"] = ns
     namespace["cluster"] = cluster
     namespace["project"] = p
 
     def fin():
-        client = get_admin_client()
+        client = get_user_client()
         client.delete(namespace["project"])
     request.addfinalizer(fin)

--- a/tests/validation/tests/v3_api/test_k8s_version_networkmodes.py
+++ b/tests/validation/tests/v3_api/test_k8s_version_networkmodes.py
@@ -43,7 +43,7 @@ def validate_k8s_version(k8s_version, plugin="canal"):
     node_roles = [["controlplane"], ["controlplane"],
                   ["etcd"], ["etcd"], ["etcd"],
                   ["worker"], ["worker"], ["worker"]]
-    client = get_admin_client()
+    client = get_user_client()
     cluster = client.create_cluster(name=random_name(),
                                     driver="rancherKubernetesEngine",
                                     rancherKubernetesEngineConfig=rke_config)

--- a/tests/validation/tests/v3_api/test_multi_cluster_app.py
+++ b/tests/validation/tests/v3_api/test_multi_cluster_app.py
@@ -260,11 +260,11 @@ def test_multi_cluster_project_answer_override():
 
 def test_multi_cluster_cluster_answer_override():
     assert_if_valid_cluster_count()
-    client, clusters = get_admin_client_and_cluster_mcapp()
+    client, clusters = get_user_client_and_cluster_mcapp()
     cluster1 = clusters[0]
     p3, ns3 = create_project_and_ns(
-        ADMIN_TOKEN, cluster1, random_test_name("mcapp-3"))
-    p_client2 = get_project_client_for_token(p3, ADMIN_TOKEN)
+        USER_TOKEN, cluster1, random_test_name("mcapp-3"))
+    p_client2 = get_project_client_for_token(p3, USER_TOKEN)
     project_detail["c2_id"] = cluster1.id
     project_detail["namespace2"] = ns3
     project_detail["p2_id"] = p3.id
@@ -391,18 +391,18 @@ def test_multi_cluster_rolling_upgrade():
 
 @pytest.fixture(scope='module', autouse="True")
 def create_project_client(request):
-    client, clusters = get_admin_client_and_cluster_mcapp()
+    client, clusters = get_user_client_and_cluster_mcapp()
     if len(clusters) > 1:
         global_client["cluster_count"] = True
     assert_if_valid_cluster_count()
     cluster1 = clusters[0]
     cluster2 = clusters[1]
     p1, ns1 = create_project_and_ns(
-        ADMIN_TOKEN, cluster1, random_test_name("mcapp-1"))
-    p_client1 = get_project_client_for_token(p1, ADMIN_TOKEN)
+        USER_TOKEN, cluster1, random_test_name("mcapp-1"))
+    p_client1 = get_project_client_for_token(p1, USER_TOKEN)
     p2, ns2 = create_project_and_ns(
-        ADMIN_TOKEN, cluster2, random_test_name("mcapp-2"))
-    p_client2 = get_project_client_for_token(p2, ADMIN_TOKEN)
+        USER_TOKEN, cluster2, random_test_name("mcapp-2"))
+    p_client2 = get_project_client_for_token(p2, USER_TOKEN)
     project_detail["c0_id"] = cluster1.id
     project_detail["p0_id"] = p1.id
     project_detail["namespace0"] = ns1
@@ -420,7 +420,7 @@ def create_project_client(request):
     global_client["client"] = client
 
     def fin():
-        client_admin = get_admin_client()
+        client_admin = get_user_client()
         client_admin.delete(p1, ns1, p_client1)
         client_admin.delete(p2, ns2, p_client2)
 
@@ -451,9 +451,9 @@ def validate_multi_cluster_app_cluster(multiclusterapp):
         validate_app_version(project_client, multiclusterapp, app_id)
 
 
-def get_admin_client_and_cluster_mcapp():
+def get_user_client_and_cluster_mcapp():
     clusters = []
-    client = get_admin_client()
+    client = get_user_client()
     if CLUSTER_NAME != "" and CLUSTER_NAME_2 != "":
         assert len(client.list_cluster(name=CLUSTER_NAME).data) != 0, \
             "Cluster is not available: %r" % CLUSTER_NAME

--- a/tests/validation/tests/v3_api/test_network_policy.py
+++ b/tests/validation/tests/v3_api/test_network_policy.py
@@ -34,7 +34,7 @@ def test_connectivity_between_pods():
     # Check that pods belonging to different namespace within the
     # same project can communicate
 
-    c_client = get_cluster_client_for_token(cluster, ADMIN_TOKEN)
+    c_client = get_cluster_client_for_token(cluster, USER_TOKEN)
     ns1 = create_ns(c_client, cluster, namespace["project"])
     workload1 = p_client.create_workload(name=name,
                                          containers=con,
@@ -51,8 +51,8 @@ def test_connectivity_between_pods():
     # Check communication between pods belonging to different namespace across
     # different projects
 
-    p2, ns2 = create_project_and_ns(ADMIN_TOKEN, cluster)
-    p2_client = get_project_client_for_token(p2, ADMIN_TOKEN)
+    p2, ns2 = create_project_and_ns(USER_TOKEN, cluster)
+    p2_client = get_project_client_for_token(p2, USER_TOKEN)
 
     workload2 = p2_client.create_workload(name=name,
                                           containers=con,
@@ -71,16 +71,16 @@ def test_connectivity_between_pods():
 
 @pytest.fixture(scope='module', autouse="True")
 def create_project_client(request):
-    client, cluster = get_admin_client_and_cluster()
+    client, cluster = get_user_client_and_cluster()
     create_kubeconfig(cluster)
-    p, ns = create_project_and_ns(ADMIN_TOKEN, cluster, "testnp")
-    p_client = get_project_client_for_token(p, ADMIN_TOKEN)
+    p, ns = create_project_and_ns(USER_TOKEN, cluster, "testnp")
+    p_client = get_project_client_for_token(p, USER_TOKEN)
     namespace["p_client"] = p_client
     namespace["ns"] = ns
     namespace["cluster"] = cluster
     namespace["project"] = p
 
     def fin():
-        client = get_admin_client()
+        client = get_user_client()
         client.delete(namespace["project"])
     request.addfinalizer(fin)

--- a/tests/validation/tests/v3_api/test_nfs.py
+++ b/tests/validation/tests/v3_api/test_nfs.py
@@ -152,16 +152,16 @@ def test_nfs_wl_daemonSet():
 
 @pytest.fixture(scope="module", autouse="True")
 def create_project_client(request):
-    client, cluster = get_admin_client_and_cluster()
+    client, cluster = get_user_client_and_cluster()
     create_kubeconfig(cluster)
-    p, ns = create_project_and_ns(ADMIN_TOKEN, cluster, "project-test-nfs")
-    p_client = get_project_client_for_token(p, ADMIN_TOKEN)
+    p, ns = create_project_and_ns(USER_TOKEN, cluster, "project-test-nfs")
+    p_client = get_project_client_for_token(p, USER_TOKEN)
     nfs_node = provision_nfs_server()
     nfs_ip = nfs_node.get_public_ip()
     print("the IP of the NFS: ", nfs_ip)
 
     # add  persistent volume to the cluster
-    cluster_client = get_cluster_client_for_token(cluster, ADMIN_TOKEN)
+    cluster_client = get_cluster_client_for_token(cluster, USER_TOKEN)
     pv_name = random_test_name("pv")
     pv_config = {"type": "persistentVolume",
                  "accessModes": ["ReadWriteOnce"],
@@ -195,7 +195,7 @@ def create_project_client(request):
 
     def fin():
         cluster_client = get_cluster_client_for_token(namespace["cluster"],
-                                                      ADMIN_TOKEN)
+                                                      USER_TOKEN)
         cluster_client.delete(namespace["project"])
         cluster_client.delete(namespace["pv"])
         if DELETE_NFS is True:

--- a/tests/validation/tests/v3_api/test_project_quota.py
+++ b/tests/validation/tests/v3_api/test_project_quota.py
@@ -30,7 +30,7 @@ def test_create_project_quota():
     # successfully. Verify namespacedefault resource quota is set
 
     cluster = namespace["cluster"]
-    client = get_admin_client()
+    client = get_user_client()
     c_client = namespace["c_client"]
 
     quota = default_project_quota()
@@ -67,7 +67,7 @@ def test_resource_quota_create_namespace_with_ns_quota():
     # namespace creation is allowed within the quota
 
     cluster = namespace["cluster"]
-    client = get_admin_client()
+    client = get_user_client()
     c_client = namespace["c_client"]
 
     quota = default_project_quota()
@@ -146,11 +146,11 @@ def validate_resoucequota_thru_kubectl(namespace):
 
 @pytest.fixture(scope='module', autouse="True")
 def create_project_client(request):
-    client, cluster = get_admin_client_and_cluster()
+    client, cluster = get_user_client_and_cluster()
     create_kubeconfig(cluster)
-    p, ns = create_project_and_ns(ADMIN_TOKEN, cluster, "testworkload")
-    p_client = get_project_client_for_token(p, ADMIN_TOKEN)
-    c_client = get_cluster_client_for_token(cluster, ADMIN_TOKEN)
+    p, ns = create_project_and_ns(USER_TOKEN, cluster, "testworkload")
+    p_client = get_project_client_for_token(p, USER_TOKEN)
+    c_client = get_cluster_client_for_token(cluster, USER_TOKEN)
     namespace["p_client"] = p_client
     namespace["ns"] = ns
     namespace["cluster"] = cluster
@@ -158,6 +158,6 @@ def create_project_client(request):
     namespace["c_client"] = c_client
 
     def fin():
-        client = get_admin_client()
+        client = get_user_client()
         client.delete(namespace["project"])
     request.addfinalizer(fin)

--- a/tests/validation/tests/v3_api/test_registry.py
+++ b/tests/validation/tests/v3_api/test_registry.py
@@ -216,11 +216,11 @@ def create_validate_workload_with_invalid_registry(p_client, ns):
 
 @pytest.fixture(scope='module', autouse="True")
 def create_project_client(request):
-    client, cluster = get_admin_client_and_cluster()
+    client, cluster = get_user_client_and_cluster()
     create_kubeconfig(cluster)
-    p, ns = create_project_and_ns(ADMIN_TOKEN, cluster, "testregistry")
-    p_client = get_project_client_for_token(p, ADMIN_TOKEN)
-    c_client = get_cluster_client_for_token(cluster, ADMIN_TOKEN)
+    p, ns = create_project_and_ns(USER_TOKEN, cluster, "testregistry")
+    p_client = get_project_client_for_token(p, USER_TOKEN)
+    c_client = get_cluster_client_for_token(cluster, USER_TOKEN)
     namespace["p_client"] = p_client
     namespace["ns"] = ns
     namespace["cluster"] = cluster
@@ -228,6 +228,6 @@ def create_project_client(request):
     namespace["c_client"] = c_client
 
     def fin():
-        client = get_admin_client()
+        client = get_user_client()
         client.delete(namespace["project"])
     request.addfinalizer(fin)

--- a/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
+++ b/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
@@ -2,6 +2,7 @@ import os
 from threading import Thread
 import pytest
 from .common import *  # NOQA
+from rancher import ApiError
 
 K8S_VERSION = os.environ.get('RANCHER_K8S_VERSION', "")
 K8S_VERSION_UPGRADE = os.environ.get('RANCHER_K8S_VERSION_UPGRADE', "")
@@ -156,7 +157,7 @@ def test_rke_custom_host_1():
             1, random_test_name(HOST_NAME))
     node_roles = ["worker", "controlplane", "etcd"]
 
-    client = get_admin_client()
+    client = get_user_client()
     cluster = client.create_cluster(name=evaluate_clustername(),
                                     driver="rancherKubernetesEngine",
                                     rancherKubernetesEngineConfig=rke_config)
@@ -177,7 +178,7 @@ def test_rke_custom_host_2():
     node_roles = [["controlplane"], ["etcd"],
                   ["worker"], ["worker"], ["worker"]]
 
-    client = get_admin_client()
+    client = get_user_client()
     cluster = client.create_cluster(name=evaluate_clustername(),
                                     driver="rancherKubernetesEngine",
                                     rancherKubernetesEngineConfig=rke_config)
@@ -202,7 +203,7 @@ def test_rke_custom_host_3():
         ["etcd"], ["etcd"], ["etcd"],
         ["worker"], ["worker"], ["worker"]
     ]
-    client = get_admin_client()
+    client = get_user_client()
     cluster = client.create_cluster(name=evaluate_clustername(),
                                     driver="rancherKubernetesEngine",
                                     rancherKubernetesEngineConfig=rke_config)
@@ -230,7 +231,7 @@ def test_rke_custom_host_4():
         {"roles": ["worker"],
          "nodes": [aws_nodes[5], aws_nodes[6], aws_nodes[7]]}
     ]
-    client = get_admin_client()
+    client = get_user_client()
     cluster = client.create_cluster(name=evaluate_clustername(),
                                     driver="rancherKubernetesEngine",
                                     rancherKubernetesEngineConfig=rke_config)
@@ -260,7 +261,7 @@ def test_rke_custom_host_stress():
     worker_role = ["worker"]
     for int in range(0, worker_count):
         node_roles.append(worker_role)
-    client = get_admin_client()
+    client = get_user_client()
     cluster = client.create_cluster(name=evaluate_clustername(),
                                     driver="rancherKubernetesEngine",
                                     rancherKubernetesEngineConfig=rke_config)
@@ -284,7 +285,7 @@ def test_rke_custom_host_etcd_plane_changes():
     node_roles = [["controlplane"], ["etcd"],
                   ["worker"], ["worker"], ["worker"]]
 
-    client = get_admin_client()
+    client = get_user_client()
     cluster = client.create_cluster(name=evaluate_clustername(),
                                     driver="rancherKubernetesEngine",
                                     rancherKubernetesEngineConfig=rke_config)
@@ -330,7 +331,7 @@ def test_rke_custom_host_etcd_plane_changes_1():
     node_roles = [["controlplane"], ["etcd"],
                   ["worker"], ["worker"], ["worker"]]
 
-    client = get_admin_client()
+    client = get_user_client()
     cluster = client.create_cluster(name=evaluate_clustername(),
                                     driver="rancherKubernetesEngine",
                                     rancherKubernetesEngineConfig=rke_config)
@@ -371,7 +372,7 @@ def test_rke_custom_host_control_plane_changes():
     node_roles = [["controlplane"], ["etcd"],
                   ["worker"], ["worker"], ["worker"]]
 
-    client = get_admin_client()
+    client = get_user_client()
     cluster = client.create_cluster(name=evaluate_clustername(),
                                     driver="rancherKubernetesEngine",
                                     rancherKubernetesEngineConfig=rke_config)
@@ -410,7 +411,7 @@ def test_rke_custom_host_worker_plane_changes():
     node_roles = [["controlplane"], ["etcd"],
                   ["worker"]]
 
-    client = get_admin_client()
+    client = get_user_client()
     cluster = client.create_cluster(name=evaluate_clustername(),
                                     driver="rancherKubernetesEngine",
                                     rancherKubernetesEngineConfig=rke_config)
@@ -448,7 +449,7 @@ def test_rke_custom_host_control_node_power_down():
     node_roles = [["controlplane"], ["etcd"],
                   ["worker"]]
 
-    client = get_admin_client()
+    client = get_user_client()
     cluster = client.create_cluster(name=evaluate_clustername(),
                                     driver="rancherKubernetesEngine",
                                     rancherKubernetesEngineConfig=rke_config)
@@ -496,7 +497,7 @@ def test_rke_custom_host_control_node_power_down():
 
 @if_test_edit_cluster
 def test_edit_cluster_k8s_version():
-    client = get_admin_client()
+    client = get_user_client()
     clusters = client.list_cluster(name=evaluate_clustername()).data
     assert len(clusters) == 1
     cluster = clusters[0]
@@ -511,7 +512,7 @@ def test_edit_cluster_k8s_version():
 
 
 def test_delete_cluster():
-    client = get_admin_client()
+    client = get_user_client()
     if len(evaluate_clustername()) > 0:
         clusters = client.list_cluster(name=evaluate_clustername()).data
     else:
@@ -522,12 +523,11 @@ def test_delete_cluster():
 
 def validate_rke_dm_host_1(node_template,
                            rancherKubernetesEngineConfig=rke_config):
-    client = get_admin_client()
+    client = get_user_client()
     nodes = []
     node_name = random_node_name()
     node = {"hostnamePrefix": node_name,
             "nodeTemplateId": node_template.id,
-            "requestedHostname": node_name,
             "controlPlane": True,
             "etcd": True,
             "worker": True,
@@ -541,7 +541,7 @@ def validate_rke_dm_host_1(node_template,
 
 def validate_rke_dm_host_2(node_template,
                            rancherKubernetesEngineConfig=rke_config):
-    client = get_admin_client()
+    client = get_user_client()
     nodes = []
     node_name = random_node_name()
     node = {"hostnamePrefix": node_name,
@@ -571,7 +571,7 @@ def validate_rke_dm_host_2(node_template,
 
 def validate_rke_dm_host_3(node_template,
                            rancherKubernetesEngineConfig=rke_config):
-    client = get_admin_client()
+    client = get_user_client()
     nodes = []
     node_name = random_node_name()
     node = {"hostnamePrefix": node_name,
@@ -601,7 +601,7 @@ def validate_rke_dm_host_3(node_template,
 
 def validate_rke_dm_host_4(node_template,
                            rancherKubernetesEngineConfig=rke_config):
-    client = get_admin_client()
+    client = get_user_client()
 
     # Create cluster and add a node pool to this cluster
     nodes = []
@@ -645,24 +645,22 @@ def create_and_vaildate_cluster(client, nodes,
     node_pools = []
     for node in nodes:
         node["clusterId"] = cluster.id
-        node_pool = client.create_node_pool(**node)
+        success = False
+        start = time.time()
+        while not success:
+            if time.time() - start > 10:
+                raise AssertionError(
+                    "Timed out waiting for cluster owner global Roles")
+            try:
+                time.sleep(1)
+                node_pool = client.create_node_pool(**node)
+                success = True
+            except ApiError:
+                success = False
         node_pool = client.wait_success(node_pool)
         node_pools.append(node_pool)
 
     cluster = validate_cluster(client, cluster)
-    nodes = client.list_node(clusterId=cluster.id).data
-    assert len(nodes) == len(nodes)
-    for node in nodes:
-        assert node.state == "active"
-    expected_host_names = []
-
-    for node in nodes:
-        expected_host_names.append(node["requestedHostname"])
-    for node in nodes:
-        assert node["requestedHostname"] in expected_host_names
-        i = expected_host_names.index(node["requestedHostname"])
-        del expected_host_names[i]
-    assert len(expected_host_names) == 0
     return cluster, node_pools
 
 
@@ -680,7 +678,7 @@ def evaluate_clustername():
 
 @pytest.fixture(scope='session')
 def node_template_az():
-    client = get_admin_client()
+    client = get_user_client()
     ec2_cloud_credential_config = {
         "clientId": AZURE_CLIENT_ID,
         "clientSecret": AZURE_CLIENT_SECRET,
@@ -731,7 +729,6 @@ def node_template_az():
         azureConfig=azConfig,
         name=random_name(),
         driver="azure",
-        namespaceId="fixme",
         cloudCredentialId=azure_cloud_credential.id,
         useInternalIpAddress=True)
     node_template = client.wait_success(node_template)
@@ -740,7 +737,7 @@ def node_template_az():
 
 @pytest.fixture(scope='session')
 def node_template_do():
-    client = get_admin_client()
+    client = get_user_client()
     do_cloud_credential_config = {"accessToken": DO_ACCESSKEY}
     do_cloud_credential = client.create_cloud_credential(
         digitaloceancredentialConfig=do_cloud_credential_config
@@ -751,7 +748,6 @@ def node_template_do():
                             "image": "ubuntu-16-04-x64"},
         name=random_name(),
         driver="digitalocean",
-        namespaceId="fixme",
         cloudCredentialId=do_cloud_credential.id,
         useInternalIpAddress=True)
     node_template = client.wait_success(node_template)
@@ -760,7 +756,7 @@ def node_template_do():
 
 @pytest.fixture(scope='session')
 def node_template_ec2():
-    client = get_admin_client()
+    client = get_user_client()
     ec2_cloud_credential_config = {"accessKey": AWS_ACCESS_KEY_ID,
                                    "secretKey": AWS_SECRET_ACCESS_KEY}
     ec2_cloud_credential = client.create_cloud_credential(
@@ -782,7 +778,6 @@ def node_template_ec2():
     node_template = client.create_node_template(
         amazonec2Config=amazonec2Config,
         name=random_name(),
-        namespaceId="fixme",
         useInternalIpAddress=True,
         driver="amazonec2",
         engineInstallURL=engine_install_url,
@@ -795,7 +790,7 @@ def node_template_ec2():
 
 @pytest.fixture(scope='session')
 def node_template_ec2_with_provider():
-    client = get_admin_client()
+    client = get_user_client()
     ec2_cloud_credential_config = {"accessKey": AWS_ACCESS_KEY_ID,
                                    "secretKey": AWS_SECRET_ACCESS_KEY}
     ec2_cloud_credential = client.create_cloud_credential(
@@ -818,7 +813,6 @@ def node_template_ec2_with_provider():
     node_template = client.create_node_template(
         amazonec2Config=amazonec2Config,
         name=random_name(),
-        namespaceId="fixme",
         useInternalIpAddress=True,
         driver="amazonec2",
         engineInstallURL=engine_install_url,

--- a/tests/validation/tests/v3_api/test_sa.py
+++ b/tests/validation/tests/v3_api/test_sa.py
@@ -22,5 +22,5 @@ def test_sa_for_user_clusters():
 
 @pytest.fixture(scope='module', autouse="True")
 def create_cluster_client(request):
-    client, cluster = get_admin_client_and_cluster()
+    client, cluster = get_user_client_and_cluster()
     create_kubeconfig(cluster)

--- a/tests/validation/tests/v3_api/test_secrets.py
+++ b/tests/validation/tests/v3_api/test_secrets.py
@@ -173,11 +173,11 @@ def test_edit_secret_single_ns():
 
 @pytest.fixture(scope='module', autouse="True")
 def create_project_client(request):
-    client, cluster = get_admin_client_and_cluster()
+    client, cluster = get_user_client_and_cluster()
     create_kubeconfig(cluster)
-    p, ns = create_project_and_ns(ADMIN_TOKEN, cluster, "testsecret")
-    p_client = get_project_client_for_token(p, ADMIN_TOKEN)
-    c_client = get_cluster_client_for_token(cluster, ADMIN_TOKEN)
+    p, ns = create_project_and_ns(USER_TOKEN, cluster, "testsecret")
+    p_client = get_project_client_for_token(p, USER_TOKEN)
+    c_client = get_cluster_client_for_token(cluster, USER_TOKEN)
     namespace["p_client"] = p_client
     namespace["ns"] = ns
     namespace["cluster"] = cluster
@@ -185,7 +185,7 @@ def create_project_client(request):
     namespace["c_client"] = c_client
 
     def fin():
-        client = get_admin_client()
+        client = get_user_client()
         client.delete(namespace["project"])
     request.addfinalizer(fin)
 

--- a/tests/validation/tests/v3_api/test_service_discovery.py
+++ b/tests/validation/tests/v3_api/test_service_discovery.py
@@ -373,12 +373,12 @@ def create_dns_record(record, p_client=None):
 
 @pytest.fixture(scope='module', autouse="True")
 def setup(request):
-    client, cluster = get_admin_client_and_cluster()
+    client, cluster = get_user_client_and_cluster()
     create_kubeconfig(cluster)
 
-    p, ns = create_project_and_ns(ADMIN_TOKEN, cluster, "testsd")
-    p_client = get_project_client_for_token(p, ADMIN_TOKEN)
-    c_client = get_cluster_client_for_token(cluster, ADMIN_TOKEN)
+    p, ns = create_project_and_ns(USER_TOKEN, cluster, "testsd")
+    p_client = get_project_client_for_token(p, USER_TOKEN)
+    c_client = get_cluster_client_for_token(cluster, USER_TOKEN)
 
     new_ns = create_ns(c_client, cluster, p)
 
@@ -415,7 +415,7 @@ def setup(request):
     assert len(namespace["testclient_pods"]) == 2
 
     def fin():
-        client = get_admin_client()
+        client = get_user_client()
         client.delete(namespace["project"])
 
     if RANCHER_CLEANUP_PROJECT == "True":

--- a/tests/validation/tests/v3_api/test_workload.py
+++ b/tests/validation/tests/v3_api/test_workload.py
@@ -547,17 +547,17 @@ def test_wl_with_lb_scale_and_upgrade():
 
 @pytest.fixture(scope='module', autouse="True")
 def create_project_client(request):
-    client, cluster = get_admin_client_and_cluster()
+    client, cluster = get_user_client_and_cluster()
     create_kubeconfig(cluster)
     p, ns = create_project_and_ns(
-        ADMIN_TOKEN, cluster, random_test_name("testworkload"))
-    p_client = get_project_client_for_token(p, ADMIN_TOKEN)
+        USER_TOKEN, cluster, random_test_name("testworkload"))
+    p_client = get_project_client_for_token(p, USER_TOKEN)
     namespace["p_client"] = p_client
     namespace["ns"] = ns
     namespace["cluster"] = cluster
     namespace["project"] = p
 
     def fin():
-        client = get_admin_client()
+        client = get_user_client()
         client.delete(namespace["project"])
     request.addfinalizer(fin)


### PR DESCRIPTION
Changes to enable having both standard user and global admin users -  https://github.com/rancher/rancher/issues/23318

This will enable rbac cases to be implemented which would involve creating users and run all other tests as standard user who is a cluster owner.

