### PR TITLE
Revert "Revert "Update helm version""

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
-ENV CATTLE_HELM_VERSION v2.10.0-rancher10
+ENV CATTLE_HELM_VERSION v2.14.3-rancher1
 ENV CATTLE_K3S_VERSION v0.8.0
 ENV CATTLE_ETCD_VERSION v3.3.14
 
@@ -28,11 +28,11 @@ ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm64=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64 \
     DOCKER_URL=DOCKER_URL_${ARCH}
 
-ENV HELM_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/helm \
-    HELM_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/helm-arm64 \
+ENV HELM_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm \
+    HELM_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm-arm64 \
     HELM_URL=HELM_URL_${ARCH} \
-    TILLER_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/tiller \
-    TILLER_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/tiller-arm64 \
+    TILLER_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller \
+    TILLER_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller-arm64 \
     TILLER_URL=TILLER_URL_${ARCH} \
     K3S_URL_amd64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s \
     K3S_URL_arm64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s-arm64 \
@@ -41,13 +41,15 @@ ENV HELM_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HE
     ETCD_URL_arm64=https://github.com/etcd-io/etcd/releases/download/${CATTLE_ETCD_VERSION}/etcd-${CATTLE_ETCD_VERSION}-linux-arm64.tar.gz \
     ETCD_URL=ETCD_URL_${ARCH}
 
-RUN curl -sLf ${!HELM_URL} > /usr/bin/helm && \
-    curl -sLf ${!TILLER_URL} > /usr/bin/tiller && \
+RUN curl -sLf ${!HELM_URL} > /usr/bin/rancher-helm && \
+    curl -sLf ${!TILLER_URL} > /usr/bin/rancher-tiller && \
     curl -sLf ${!K3S_URL} > /usr/bin/k3s && \
     curl -sfL ${!ETCD_URL} | tar xvzf - --strip-components=1 -C /usr/bin/ etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcd && \
-    chmod +x /usr/bin/helm /usr/bin/tiller /usr/bin/k3s && \
-    helm init -c && \
-    helm plugin install https://github.com/rancher/helm-unittest && \
+    chmod +x /usr/bin/rancher-helm /usr/bin/rancher-tiller /usr/bin/k3s && \
+    ln -s /usr/bin/rancher-helm /usr/bin/helm && \
+    ln -s /usr/bin/rancher-tiller /usr/bin/tiller && \
+    rancher-helm init -c && \
+    rancher-helm plugin install https://github.com/rancher/helm-unittest && \
     mkdir -p /go/src/github.com/rancher/rancher/.kube && \
     ln -s /etc/rancher/k3s/k3s.yaml /go/src/github.com/rancher/rancher/.kube/k3s.yaml
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -16,7 +16,7 @@ ARG IMAGE_REPO=rancher
 ARG SYSTEM_CHART_DEFAULT_BRANCH=release-v2.3
 
 ENV CATTLE_SYSTEM_CHART_DEFAULT_BRANCH=$SYSTEM_CHART_DEFAULT_BRANCH
-ENV CATTLE_HELM_VERSION v2.10.0-rancher12
+ENV CATTLE_HELM_VERSION v2.14.3-rancher1
 ENV CATTLE_K3S_VERSION v0.8.0
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher12-1
 ENV CATTLE_ETCD_VERSION v3.3.14
@@ -43,11 +43,11 @@ ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERS
     TINI_URL_arm64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 \
     TINI_URL=TINI_URL_${ARCH}
 
-ENV HELM_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/helm \
-    HELM_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/helm-arm64 \
+ENV HELM_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm \
+    HELM_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm-arm64 \
     HELM_URL=HELM_URL_${ARCH} \
-    TILLER_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/tiller \
-    TILLER_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/tiller-arm64 \
+    TILLER_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller \
+    TILLER_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller-arm64 \
     TILLER_URL=TILLER_URL_${ARCH} \
     K3S_URL_amd64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s \
     K3S_URL_arm64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s-arm64 \
@@ -57,13 +57,13 @@ ENV HELM_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HE
     ETCD_URL=ETCD_URL_${ARCH}
 
 RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
-    curl -sLf ${!HELM_URL} > /usr/bin/helm && \
-    curl -sLf ${!TILLER_URL} > /usr/bin/tiller && \
+    curl -sLf ${!HELM_URL} > /usr/bin/rancher-helm && \
+    curl -sLf ${!TILLER_URL} > /usr/bin/rancher-tiller && \
     curl -sLf ${!K3S_URL} > /usr/bin/k3s && \
     curl -sfL ${!ETCD_URL} | tar xvzf - --strip-components=1 -C /usr/bin/ etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcd etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcdctl && \
     curl -sLf https://github.com/rancher/telemetry/releases/download/${TELEMETRY_VERSION}/telemetry-${ARCH} > /usr/bin/telemetry && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
-    chmod +x /usr/bin/helm /usr/bin/tini /usr/bin/telemetry /usr/bin/tiller /usr/bin/k3s /usr/bin/kubectl
+    chmod +x /usr/bin/rancher-helm /usr/bin/tini /usr/bin/telemetry /usr/bin/rancher-tiller /usr/bin/k3s /usr/bin/kubectl
 
 ENV CATTLE_UI_PATH /usr/share/rancher/ui
 ENV CATTLE_UI_VERSION 2.3.16

--- a/package/jailer.sh
+++ b/package/jailer.sh
@@ -56,10 +56,10 @@ cp -r -l /opt/drivers/management-state/bin /opt/jail/$NAME/var/lib/rancher/manag
 cp -l /usr/bin/docker-machine /opt/jail/$NAME/usr/bin
 
 # Hard link helm into the jail 
-cp -l /usr/bin/helm /opt/jail/$NAME/usr/bin
+cp -l /usr/bin/rancher-helm /opt/jail/$NAME/usr/bin
 
 # Hard link tiller into the jail 
-cp -l /usr/bin/tiller /opt/jail/$NAME/usr/bin
+cp -l /usr/bin/rancher-tiller /opt/jail/$NAME/usr/bin
 
 # Hard link ssh into the jail
 cp -l /usr/bin/ssh /opt/jail/$NAME/usr/bin

--- a/pkg/controllers/user/helm/common.go
+++ b/pkg/controllers/user/helm/common.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	helmName    = "helm"
+	helmName    = "rancher-helm"
 	appLabel    = "io.cattle.field/appId"
 	failedLabel = "io.cattle.field/failed-revision"
 )

--- a/pkg/controllers/user/helm/common/common.go
+++ b/pkg/controllers/user/helm/common/common.go
@@ -26,8 +26,8 @@ import (
 const (
 	base            = 32768
 	end             = 61000
-	tillerName      = "tiller"
-	helmName        = "helm"
+	tillerName      = "rancher-tiller"
+	helmName        = "rancher-helm"
 	forceUpgradeStr = "--force"
 )
 
@@ -81,7 +81,7 @@ func SplitExternalID(externalID string) (string, string, string, string, string,
 // StartTiller start tiller server and return the listening address of the grpc address
 func StartTiller(context context.Context, tempDirs *HelmPath, port, namespace string) error {
 	probePort := GenerateRandomPort()
-	cmd := exec.Command(tillerName, "--listen", ":"+port, "--probe", ":"+probePort)
+	cmd := exec.Command(tillerName, "--listen", ":"+port, "--probe-listen", ":"+probePort)
 	cmd.Env = []string{fmt.Sprintf("%s=%s", "KUBECONFIG", tempDirs.KubeConfigInJail), fmt.Sprintf("%s=%s", "TILLER_NAMESPACE", namespace), fmt.Sprintf("%s=%s", "TILLER_HISTORY_MAX", "10")}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Reverts rancher/rancher#23399 - This was backed out of the release branch for v2.3.1, so it needs to be added back in after v2.3.1 is released. 

Update helm version
    
    Problem:
    Helm needs to be updated and renamed to stop name colisions
    
    Solution:
    Rebase helm, update all calls to use rancher-helm