### PR TITLE
Switch back to golangci

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -1,0 +1,34 @@
+{
+    "linters": {
+        "disable-all": true,
+        "enable": [
+            "govet",
+            "golint",
+            "goimports"
+        ]
+    },
+    "linters-settings": {
+        "govet": {
+            "check-shadowing": false
+        },
+        "gofmt": {
+            "simplify": false
+        }
+    },
+    "run": {
+        "skip-dirs": [
+            "vendor",
+            "tests"
+        ],
+        "tests": false,
+        "timeout": "10m"
+    },
+    "issues": {
+        "exclude-rules": [
+            {
+                "linters": "govet",
+                "text": "^(nilness|structtag)"
+            }
+        ]
+    }
+}

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -15,13 +15,11 @@ RUN curl -sLf https://github.com/rancher/machine-package/releases/download/v0.15
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.12.9.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && \
-    go get -u golang.org/x/lint/golint && \
-    go get -d golang.org/x/tools/cmd/goimports && \
-    # This needs to be kept up to date with rancher/types
-    git -C /go/src/golang.org/x/tools/cmd/goimports checkout -b release-branch.go1.12 origin/release-branch.go1.12 && \
-    go install golang.org/x/tools/cmd/goimports
+RUN wget -O - https://storage.googleapis.com/golang/go1.12.9.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local
+
+RUN if [ "${ARCH}" == "amd64" ]; then \	
+    curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.20.0; \	
+    fi
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
@@ -53,12 +51,6 @@ RUN curl -sLf ${!HELM_URL} > /usr/bin/helm && \
 
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 
-# FIXME: Update to Rancher RKE when released
-ENV RKE_URL_amd64=https://github.com/rancher/rke/releases/download/v0.2.0-rc8/rke_linux-amd64 \
-    RKE_URL_arm64=https://github.com/rancher/rke/releases/download/v0.2.0-rc8/rke_linux-arm64 \
-    RKE_URL=RKE_URL_${ARCH}
-
-RUN wget -O - ${!RKE_URL} > /usr/bin/rke && chmod +x /usr/bin/rke
 ENV KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/${ARCH}/kubectl
 RUN wget -O - ${KUBECTL_URL} > /usr/bin/kubectl && chmod +x /usr/bin/kubectl
 

--- a/scripts/ci
+++ b/scripts/ci
@@ -3,9 +3,7 @@ set -e
 
 cd $(dirname $0)
 
-if [ ${ARCH} == amd64 ]; then
-    ./validate
-fi
+./validate
 ./build
 ./test
 ./package

--- a/scripts/test
+++ b/scripts/test
@@ -15,9 +15,11 @@ cleanup()
         rke remove --dind --force --config $dindYML
         rm -f $dindYML
     done
-    echo '***RANCHER LOGS***'
-    cat $CWD/rancherlogs.txt
-    echo '***END RANCHER LOGS***'
+    if [ $EXIT -ne 0 ]; then
+        echo '***RANCHER LOGS***'
+        cat $CWD/rancherlogs.txt
+        echo '***END RANCHER LOGS***'
+    fi
     return $EXIT
 }
 

--- a/scripts/validate
+++ b/scripts/validate
@@ -3,14 +3,10 @@ set -e
 
 cd $(dirname $0)/..
 
-echo Running: go fmt	
-test -z "$(go fmt ./... | tee /dev/stderr)"
+if ! command -v golangci-lint; then	echo Running: go fmt	
+    echo Skipping validation: no golangci-lint available	test -z "$(go fmt ./... | tee /dev/stderr)"
+    exit	
+fi	
 
-echo Running: go vet	
-test -z "$(go vet ./... 2>&1 | tee /dev/stderr)"
-
-echo Running: golint	
-test -z "$(go list ./... | grep -v /vendor/ | xargs -L1 golint | grep -v 'or be unexported' | tee /dev/stderr)"
-
-echo Running: goimports
-test -z "$(goimports -d $(find . -type f -name '*.go' -not -path "./vendor/*") | tee /dev/stderr)"
+echo Running: golangci-lint
+golangci-lint run


### PR DESCRIPTION
This switches rancher back to golangci and runs the same linters we were running before. It also adds a change to stop printing the rancher logs after the tests run if the tests do not fail. This saves ~6 min in build time. 