### PR TITLE
Move location of bundled catalogs

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -27,10 +27,10 @@ ENV KUBECTL_VERSION v1.16.1
 ENV DOCKER_MACHINE_LINODE_VERSION v0.1.8
 ENV LINODE_UI_DRIVER_VERSION v0.3.0
 
-RUN mkdir -p /var/lib/rancher/management-state/local-catalogs/system-library && \
-    mkdir -p /var/lib/rancher/management-state/local-catalogs/library && \
-    git clone -b $CATTLE_SYSTEM_CHART_DEFAULT_BRANCH --single-branch https://github.com/rancher/system-charts /var/lib/rancher/management-state/local-catalogs/system-library && \
-    git clone -b master --single-branch https://github.com/rancher/charts /var/lib/rancher/management-state/local-catalogs/library
+RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
+    mkdir -p /var/lib/rancher-data/local-catalogs/library && \
+    git clone -b $CATTLE_SYSTEM_CHART_DEFAULT_BRANCH --single-branch https://github.com/rancher/system-charts /var/lib/rancher-data/local-catalogs/system-library && \
+    git clone -b master --single-branch https://github.com/rancher/charts /var/lib/rancher-data/local-catalogs/library
 
 
 RUN curl -sLf https://github.com/rancher/machine-package/releases/download/${CATTLE_MACHINE_VERSION}/docker-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin && \

--- a/pkg/catalog/helm/helm.go
+++ b/pkg/catalog/helm/helm.go
@@ -41,7 +41,7 @@ var (
 	Locker          = locker.New()
 	CatalogCache    = filepath.Join("management-state", "catalog-cache")
 	IconCache       = filepath.Join(CatalogCache, ".icon-cache")
-	InternalCatalog = filepath.Join("management-state", "local-catalogs")
+	InternalCatalog = filepath.Join("..", "rancher-data", "local-catalogs")
 )
 
 type Helm struct {


### PR DESCRIPTION
Problem:
When bind mounting /var/lib/rancher the catalog cache won't exist on the
local filesystem

Solution:
Move the catalog cache to a location we don't tell people to bind mount
like /var/lib/rancher-data

#23427