### PR TITLE
[forwardport] Drop the detecting for system locale language

### DIFF
--- a/package/windows/bootstrap.ps1
+++ b/package/windows/bootstrap.ps1
@@ -123,13 +123,6 @@ catch
     Log-Warn "Could not detect the DISK resource: `$(`$_.Exception.Message)"
 }
 
-Log-Info "Detecting host system locale ..."
-`$sysLocale = Get-WinSystemLocale | Select-Object -ExpandProperty "IetfLanguageTag"
-if (-not `$sysLocale.StartsWith('en-'))
-{
-    Log-Fatal "Only support with English System Locale"
-}
-
 Log-Info "Detecting host Docker name pipe existing ..."
 `$dockerNPipe = Get-ChildItem //./pipe/ -ErrorAction Ignore | ? Name -eq "docker_engine"
 if (-not `$dockerNPipe)


### PR DESCRIPTION
Forwardport PR https://github.com/rancher/rancher/pull/23735

**Problem:**
The local language verification is used for avoiding the failure running
of Flannel.

**Solution:**
Repackage the Flannel with a new vendor to satisfy none English system.

**Related PR:**
https://github.com/rancher/rke-tools/pull/85

**Issue:**
https://github.com/rancher/rancher/issues/23078
