### PR TITLE
Add wait in projectcatalog access check test

### DIFF
--- a/tests/integration/suite/test_project_catalog.py
+++ b/tests/integration/suite/test_project_catalog.py
@@ -250,6 +250,7 @@ def test_project_catalog_access_before_app_creation(admin_mc, admin_pc,
         roleTemplateId="project-owner",
         userId=user.user.id)
     remove_resource(prtb_owner)
+    wait_until(prtb_cb(client, prtb_owner))
     u_p_client = user_project_client(user, admin_pc.project)
     try:
         # creating app in user's project, using template version from


### PR DESCRIPTION
All other tests that create prtb/crtb for a user have this wait check before using the user's client. So adding the same wait check here too will fix the flakiness