### PR TITLE
Keep chart repo URL intact

### DIFF
--- a/pkg/catalog/helm/helm.go
+++ b/pkg/catalog/helm/helm.go
@@ -108,8 +108,6 @@ func (h *Helm) request(pathURL string) (*http.Response, error) {
 }
 
 func (h *Helm) downloadIndex(indexURL string) (*RepoIndex, error) {
-	indexURL = strings.TrimSuffix(indexURL, "/")
-	indexURL = indexURL + "/index.yaml"
 	resp, err := h.request(indexURL)
 	if err != nil {
 		if e, ok := err.(net.Error); ok && e.Timeout() {


### PR DESCRIPTION
Don't change the repo URL given by user.