### PR TITLE
Log cert parse error instead of returning err

### DIFF
--- a/pkg/api/store/secret/store.go
+++ b/pkg/api/store/secret/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/store/cert"
 	client "github.com/rancher/types/client/project/v3"
 	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
 )
 
 type Store struct {
@@ -62,7 +63,8 @@ func NewNamespacedSecretStore(ctx context.Context, clientGetter proxy.ClientGett
 					return data, nil
 				}
 				if err := cert.AddCertInfo(data); err != nil {
-					return nil, err
+					logrus.Errorf("Error %v parsing cert %v. Will not display correctly in UI", err, data["name"])
+					return data, nil
 				}
 				return data, nil
 			},


### PR DESCRIPTION
The secrets store calls AddCertInfo to parse cert so it populates all the necessary
UI fields. But if the cert is malformed AddCertInfo throws an error. This also
prevents the project in which this cert exists from loading in UI.
This commit logs the error message instead of returning error. This way the cert
will still not display in UI properly since it is malformed, but this won't stop
the project from loading.

#23285
