### PR TITLE
Forward port: Remove invalid parsing of distinguishedName in AD refresh principals

### DIFF
--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -115,11 +115,8 @@ func (p *adProvider) RefetchGroupPrincipals(principalID string, secret string) (
 	}
 
 	dn := externalID
-	if strings.Contains(externalID, `\`) {
-		dn = strings.SplitN(externalID, `\`, 2)[1]
-	}
 
-	logrus.Debugf("LDAP Search query: {%s}", dn)
+	logrus.Debugf("LDAP Refetch principals base DN : {%s}", dn)
 
 	search := ldapv2.NewSearchRequest(
 		dn,


### PR DESCRIPTION
ExternalID is the distinguishedName of a user, which is being used as the baseDN
in ldap search query in RefetchGroupPrincipals. This doesn't need to be split on `\`.
That split is only for when we're using some field that has "logindomain\username"
format. Splitting incorrectly on `\` removed a part of the distinguishedName leading
to ldap errors

https://github.com/rancher/rancher/issues/23684

forward port of https://github.com/rancher/rancher/pull/23035