### PR TITLE
Add newlines to ssh keys for nodetemplates

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -331,13 +331,19 @@ func aliasToPath(driver string, config map[string]interface{}, ns string) error 
 				if fileContents == "" {
 					continue
 				}
-				hasher.Reset()
-				hasher.Write([]byte(fileContents))
-				sha := base32.StdEncoding.WithPadding(-1).EncodeToString(hasher.Sum(nil))[:10]
+
 				fileName := driverField
 				if ok := nodedriver.SSHKeyFields[schemaField]; ok {
 					fileName = "id_rsa"
+					// The ending newline gets stripped, add em back
+					if !strings.HasSuffix(fileContents, "\n") {
+						fileContents = fileContents + "\n"
+					}
 				}
+
+				hasher.Reset()
+				hasher.Write([]byte(fileContents))
+				sha := base32.StdEncoding.WithPadding(-1).EncodeToString(hasher.Sum(nil))[:10]
 
 				fileDir := path.Join(baseDir, sha)
 


### PR DESCRIPTION
Problem:
When parsing nodetemplates initially new lines are dropped from the end
of ssh keys

Solution:
Add them back before writing them out for docker-machine usage

https://github.com/rancher/rancher/issues/23743