### PR TITLE
Update 2.3 to Correct UI Index for Head Builds

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -51,7 +51,7 @@ var (
 	TLSMinVersion                     = NewSetting("tls-min-version", "1.2")
 	TLSCiphers                        = NewSetting("tls-ciphers", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305")
 	UIFeedBackForm                    = NewSetting("ui-feedback-form", "")
-	UIIndex                           = NewSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
+	UIIndex                           = NewSetting("ui-index", "https://releases.rancher.com/ui/latest-2.3/index.html")
 	UIPath                            = NewSetting("ui-path", "")
 	UIPL                              = NewSetting("ui-pl", "rancher")
 	UIKubernetesSupportedVersions     = NewSetting("ui-k8s-supported-versions-range", ">= 1.11.0 <=1.14.x")

--- a/scripts/build-server
+++ b/scripts/build-server
@@ -11,7 +11,7 @@ mkdir -p bin
 if echo "$VERSION" | grep -q -e '^v.*' ; then 
     UI_INDEX="local"
 fi
-UI_INDEX=${UI_INDEX:-"https://releases.rancher.com/ui/latest2/index.html"}
+UI_INDEX=${UI_INDEX:-"https://releases.rancher.com/ui/latest-2.3/index.html"}
 RKE_VERSION="$(grep -m1 'github.com/rancher/rke' go.mod | awk '{print $2}')"
 
 # Inject Setting values


### PR DESCRIPTION
Release branch should point to its corresponding latest ui branch so we don't have to change the ui-index tag when launching new 2.3 dev clusters. 