### PR TITLE
Change capability anno

### DIFF
--- a/pkg/controllers/management/cluster/clustercontroller.go
+++ b/pkg/controllers/management/cluster/clustercontroller.go
@@ -33,7 +33,7 @@ const (
 	AzureL4LB               = "Azure L4 LB"
 	NginxIngressProvider    = "Nginx"
 	DefaultNodePortRange    = "30000-32767"
-	capabilitiesAnnotation  = "capabilities.cattle.io/"
+	capabilitiesAnnotation  = "capabilities/"
 )
 
 type controller struct {


### PR DESCRIPTION
**Problem:**
User cannot set capability override annotation through rancher because norman removes annotations containing cattle.io.

**Solution:**
Rename annotation to cattle.capabilities.io.

**Issue:**
https://github.com/rancher/rancher/issues/21039