### PR TITLE
Psp validator

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -648,6 +648,7 @@ func Project(schemas *types.Schemas, management *config.ScaledContext) {
 		ProjectLister:  management.Management.Projects("").Controller().Lister(),
 		UserMgr:        management.UserManager,
 		ClusterManager: management.ClientGetter.(*clustermanager.Manager),
+		ClusterLister:  management.Management.Clusters("").Controller().Lister(),
 	}
 	schema.ActionHandler = handler.Actions
 }

--- a/pkg/controllers/management/cluster/clustercontroller.go
+++ b/pkg/controllers/management/cluster/clustercontroller.go
@@ -33,7 +33,7 @@ const (
 	AzureL4LB               = "Azure L4 LB"
 	NginxIngressProvider    = "Nginx"
 	DefaultNodePortRange    = "30000-32767"
-	capabilitiesAnnotation  = "capabilities.cattle.io/"
+	capabilitiesAnnotation  = "capabilities/"
 )
 
 type controller struct {


### PR DESCRIPTION
**Problem:**
User can set psp template even if psp is not enabled.

**Solution:**
Return error in apply psp action is psp is disabled for the cluster

**Issue:**
https://github.com/rancher/rancher/issues/21548