### PR TITLE
[backport] Add validation to psptBinding creation

### DIFF
--- a/pkg/api/customization/podsecuritypolicybinding/validator.go
+++ b/pkg/api/customization/podsecuritypolicybinding/validator.go
@@ -1,0 +1,36 @@
+package podsecuritypolicybinding
+
+import (
+	"github.com/rancher/norman/httperror"
+	"github.com/rancher/norman/types"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+type validator struct {
+	psptTemplateLister v3.PodSecurityPolicyTemplateLister
+}
+
+func NewValidator(context *config.ScaledContext) types.Validator {
+	v := &validator{
+		psptTemplateLister: context.Management.PodSecurityPolicyTemplates("").Controller().Lister(),
+	}
+	return v.validate
+}
+
+// validate checks that the podSecurityPolicyTemplateId is in the request and is an existing template
+func (v *validator) validate(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
+	p, ok := data["podSecurityPolicyTemplateId"].(string)
+	if !ok {
+		return httperror.NewAPIError(httperror.InvalidBodyContent, "missing required podSecurityPolicyTemplateId")
+	}
+
+	_, err := v.psptTemplateLister.Get("", p)
+	if k8serrors.IsNotFound(err) {
+		return httperror.NewAPIError(httperror.InvalidBodyContent, "podSecurityPolicyTemplate not found")
+	}
+
+	// If the error is anything else just return it
+	return err
+}

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/customization/nodepool"
 	"github.com/rancher/rancher/pkg/api/customization/nodetemplate"
 	"github.com/rancher/rancher/pkg/api/customization/pipeline"
+	psptBinding "github.com/rancher/rancher/pkg/api/customization/podsecuritypolicybinding"
 	"github.com/rancher/rancher/pkg/api/customization/podsecuritypolicytemplate"
 	projectStore "github.com/rancher/rancher/pkg/api/customization/project"
 	projectaction "github.com/rancher/rancher/pkg/api/customization/project"
@@ -176,6 +177,7 @@ func Setup(ctx context.Context, apiContext *config.ScaledContext, clusterManager
 	ProjectRoleTemplateBinding(schemas, apiContext)
 	TemplateContent(schemas)
 	PodSecurityPolicyTemplate(schemas, apiContext)
+	PodSecurityPolicyTemplateProjectBinding(schemas, apiContext)
 	GlobalRoleBindings(schemas, apiContext)
 	RoleTemplate(schemas, apiContext)
 	MultiClusterApps(schemas, apiContext)
@@ -659,6 +661,11 @@ func PodSecurityPolicyTemplate(schemas *types.Schemas, management *config.Scaled
 		Store: schema.Store,
 	}
 	schema.Validator = podsecuritypolicytemplate.Validator
+}
+
+func PodSecurityPolicyTemplateProjectBinding(schemas *types.Schemas, management *config.ScaledContext) {
+	schema := schemas.Schema(&managementschema.Version, client.PodSecurityPolicyTemplateProjectBindingType)
+	schema.Validator = psptBinding.NewValidator(management)
 }
 
 func ClusterRoleTemplateBinding(schemas *types.Schemas, management *config.ScaledContext) {


### PR DESCRIPTION
Problem:
When creating a psptBinding a template id is required but not validated
so an invalid value does not return to the user and causes the
controller to keep trying to create resources

Solution:
Validate the template ID belongs to a real template before creating the
binding

https://github.com/rancher/rancher/issues/22556