### PR TITLE
Add nil check to generate kube config action

### DIFF
--- a/pkg/api/customization/cluster/actions_kubeconfig.go
+++ b/pkg/api/customization/cluster/actions_kubeconfig.go
@@ -20,8 +20,8 @@ func (a ActionHandler) GenerateKubeconfigActionHandler(actionName string, action
 		token string
 		err   error
 	)
-
-	if cluster.LocalClusterAuthEndpoint.Enabled {
+	endpointEnabled := cluster.LocalClusterAuthEndpoint != nil && cluster.LocalClusterAuthEndpoint.Enabled
+	if endpointEnabled {
 		token, err = a.getClusterToken(cluster.ID, apiContext)
 	} else {
 		token, err = a.getToken(apiContext)
@@ -30,7 +30,7 @@ func (a ActionHandler) GenerateKubeconfigActionHandler(actionName string, action
 		return err
 	}
 
-	if cluster.LocalClusterAuthEndpoint.Enabled {
+	if endpointEnabled {
 		cfg, err = kubeconfig.ForClusterTokenBased(&cluster, apiContext.ID, apiContext.Request.Host, token)
 	} else {
 		cfg, err = kubeconfig.ForTokenBased(cluster.Name, apiContext.ID, apiContext.Request.Host, token)


### PR DESCRIPTION
**Problem:**
The cluster generateKubeconfig action panics if cluster contains a nil localClusterAuthEndpoint.

**Solution:**
Nil check localClusterAuthEndpoint

**Issue:**
https://github.com/rancher/rancher/issues/23783

**Notes:**
This happens because to use access.byId the client cluster struct needs to be used, opposed to the regular management struct. Typically there is a default localClusterAuthEndpoint but all struct fields on the client cluster struct are pointers, and so the default is nil. This is a generated struct.

This only occurs when the request lacks a localClusterAuthEndpoint or it is explicitly set to null in the request. The UI is currently omitting the localClusterAuthEndpoint (see following issue):
https://github.com/rancher/rancher/issues/23913