### PR TITLE
don't error out on missing template

### DIFF
--- a/pkg/controllers/management/kontainerdrivermetadata/data.go
+++ b/pkg/controllers/management/kontainerdrivermetadata/data.go
@@ -319,7 +319,7 @@ func getLabelMap(k8sVersion string, data map[string]map[string]string,
 			}
 		}
 		if !found {
-			return nil, fmt.Errorf("no template found for k8sVersion %s plugin %s", k8sVersion, addon)
+			logrus.Debugf("getPluginData: no template found for k8sVersion %s plugin %s", k8sVersion, addon)
 		}
 	}
 	// store service options


### PR DESCRIPTION
old constraint: each plugin template must be present for all k8s versions
this is not very convenient if a new plugin is introduced only for new
versions, changed from error to warning

https://github.com/rancher/kontainer-driver-metadata/pull/76