### PR TITLE
add check for invalid podSecurityPolicyTemplateId

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -647,11 +647,12 @@ func Project(schemas *types.Schemas, management *config.ScaledContext) {
 	schema := schemas.Schema(&managementschema.Version, client.ProjectType)
 	schema.Formatter = projectaction.Formatter
 	handler := &projectaction.Handler{
-		Projects:       management.Management.Projects(""),
-		ProjectLister:  management.Management.Projects("").Controller().Lister(),
-		UserMgr:        management.UserManager,
-		ClusterManager: management.ClientGetter.(*clustermanager.Manager),
-		ClusterLister:  management.Management.Clusters("").Controller().Lister(),
+		Projects:          management.Management.Projects(""),
+		ProjectLister:     management.Management.Projects("").Controller().Lister(),
+		UserMgr:           management.UserManager,
+		ClusterManager:    management.ClientGetter.(*clustermanager.Manager),
+		ClusterLister:     management.Management.Clusters("").Controller().Lister(),
+		PSPTemplateLister: management.Management.PodSecurityPolicyTemplates("").Controller().Lister(),
 	}
 	schema.ActionHandler = handler.Actions
 }


### PR DESCRIPTION
**Problem:**
Project's action `setpodsecuritypolicytemplate` does not handle the invalid podSecurityPolicyTemplateId

**Solution:**
Return error if the podSecurityPolicyTemplate does not exist 

**Issue:**
https://github.com/rancher/rancher/issues/23931