### PR TITLE
Fixed panic in monitoring handler

### DIFF
--- a/pkg/controllers/user/monitoring/cluster_monitoring_enabled_handler.go
+++ b/pkg/controllers/user/monitoring/cluster_monitoring_enabled_handler.go
@@ -44,6 +44,10 @@ func (h *clusterMonitoringEnabledHandler) sync(key string, endpoints *k8scorev1.
 
 // sync will trigger clusterHandler sync loop when node updated, if Cluster Monitoring is enabling.
 func (h *clusterMonitoringEnabledHandler) syncWindowsNode(key string, node *k8scorev1.Node) (runtime.Object, error) {
+	if node == nil || node.Labels == nil {
+		return node, nil
+	}
+
 	_, monitoringNamespace := monitoring.ClusterMonitoringInfo()
 	cluster, err := h.cattleClusterLister.Get(metav1.NamespaceAll, h.clusterName)
 	if err != nil || cluster.DeletionTimestamp != nil {


### PR DESCRIPTION
Fixed the panic observed on one of the setups:

```
E1108 00:31:41.148173       6 reflector.go:123] github.com/rancher/norman/controller/generic_controller.go:175: Failed to list *v1.ReplicationController: Get https://10.200.2.152:6443/api/v1/replicationcontrollers?limit=500&resourceVersion=0&timeout=30s: EOF 
2019/11/08 00:31:46 [ERROR] NodeController trident recovered from panic "runtime error: invalid memory address or nil pointer dereference". (err=<nil>) Call stack: 
goroutine 152120 [running]: 
github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/runtime.RecoverFromPanic(0xc00ca2ddb0) 
	/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:158 +0xb5 
panic(0x2d21360, 0x5d48e80) 
	/usr/local/go/src/runtime/panic.go:522 +0x1b5 
github.com/rancher/rancher/pkg/controllers/user/monitoring.(*clusterMonitoringEnabledHandler).syncWindowsNode(0xc0026fb9c0, 0xc001bc5036, 0x7, 0x0, 0xc00b8ca380, 0x7fa309f98d98, 0x0, 0x0) 
	/go/src/github.com/rancher/rancher/pkg/controllers/user/monitoring/cluster_monitoring_enabled_handler.go:58 +0xe7 
```