### PR TITLE
Update README.md to mention http to https port redirect conversion formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To get automated notifications of our latest release, you can watch the announce
 
     sudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 rancher/rancher
 
-Open your browser to https://localhost
+Open your browser to https://localhost or http://localhost (http will be redirected to https, but attention please, if you were not using hostport 80 for http, example like `-p 8080:80`, the https redirect URL would be https://localhost:8443, not https://localhost, because the external https port would follow the formula `https_port = ((http_port / 1000) * 1000) + 443)` to be converted)
 
 ## Installation
 Rancher can be deployed in either a single node or multi-node setup.  Please refer to the following for guides on how to get Rancher up and running.


### PR DESCRIPTION
Rancher would change external http port to https port by using conversion formula https://github.com/rancher/rancher/blob/979a592142c95ede885fcc54ceb99746bea58885/pkg/dynamiclistener/server.go#L529, example like `8080 to 8443, 30080 to 30443`, but this is not mentioned in any document, so sometimes if we werre using external http port without 80 (like 8080) and external https port 443, or some port not following the formula above, the http redirect would be confused. So, for user-friendly, adding a hint or trouble shooting in an obvious document would be better.