### PR TITLE
Can assign groups to global roles

### DIFF
--- a/pkg/api/customization/globalrolebinding/validator.go
+++ b/pkg/api/customization/globalrolebinding/validator.go
@@ -1,0 +1,23 @@
+package globalrolebinding
+
+import (
+	"net/http"
+
+	"github.com/rancher/norman/httperror"
+	"github.com/rancher/norman/types"
+)
+
+func Validator(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
+	if request.Method == http.MethodPut {
+		return nil
+	}
+
+	hasSingleSubject := (data["groupPrincipalId"] != nil && data["userId"] == nil) ||
+		(data["groupPrincipalId"] == nil && data["userId"] != nil)
+
+	if !hasSingleSubject {
+		return httperror.NewAPIError(httperror.InvalidBodyContent, "must contain field [groupPrincipalId] "+
+			"OR field [userId]")
+	}
+	return nil
+}

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/customization/feature"
 	"github.com/rancher/rancher/pkg/api/customization/globaldns"
 	"github.com/rancher/rancher/pkg/api/customization/globalrole"
+	"github.com/rancher/rancher/pkg/api/customization/globalrolebinding"
 	"github.com/rancher/rancher/pkg/api/customization/kontainerdriver"
 	"github.com/rancher/rancher/pkg/api/customization/logging"
 	"github.com/rancher/rancher/pkg/api/customization/monitor"
@@ -696,6 +697,7 @@ func GlobalRoleBindings(schemas *types.Schemas, management *config.ScaledContext
 	schema := schemas.Schema(&managementschema.Version, client.GlobalRoleBindingType)
 	grLister := management.Management.GlobalRoles("").Controller().Lister()
 	schema.Store = grbstore.Wrap(schema.Store, grLister)
+	schema.Validator = globalrolebinding.Validator
 }
 
 func RoleTemplate(schemas *types.Schemas, management *config.ScaledContext) {

--- a/pkg/controllers/management/auth/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalrolebinding_handler.go
@@ -128,11 +128,8 @@ func (grb *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBind
 	if !ok {
 		crbName = crbNamePrefix + globalRoleBinding.Name
 	}
-	subject := v1.Subject{
-		Kind:     "User",
-		Name:     globalRoleBinding.UserName,
-		APIGroup: rbacv1.GroupName,
-	}
+
+	subject := rbac.GetGRBSubject(globalRoleBinding)
 	crb, _ := grb.crbLister.Get("", crbName)
 	if crb != nil {
 		subjects := []v1.Subject{subject}

--- a/pkg/controllers/user/rbac/globalrole_handler.go
+++ b/pkg/controllers/user/rbac/globalrole_handler.go
@@ -59,12 +59,7 @@ func (c *grbHandler) sync(key string, obj *v3.GlobalRoleBinding) (runtime.Object
 		ObjectMeta: metav1.ObjectMeta{
 			Name: bindingName,
 		},
-		Subjects: []v12.Subject{
-			{
-				Kind: "User",
-				Name: obj.UserName,
-			},
-		},
+		Subjects: []v12.Subject{rbac.GetGRBSubject(obj)},
 		RoleRef: v12.RoleRef{
 			Name: "cluster-admin",
 			Kind: "ClusterRole",
@@ -84,5 +79,5 @@ func grbByUserAndRole(obj interface{}) ([]string, error) {
 		return []string{}, nil
 	}
 
-	return []string{grb.UserName + "-" + grb.GlobalRoleName}, nil
+	return []string{rbac.GetGRBTargetKey(grb) + "-" + grb.GlobalRoleName}, nil
 }

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -1,6 +1,8 @@
 package rbac
 
 import (
+	"crypto/sha256"
+	"encoding/base32"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -69,5 +71,38 @@ func BuildSubjectFromRTB(object interface{}) (rbacv1.Subject, error) {
 }
 
 func GrbCRBName(grb *v3.GlobalRoleBinding) string {
-	return "globaladmin-" + grb.UserName
+	return "globaladmin-" + GetGRBTargetKey(grb)
+}
+
+// GetGRBSubject creates and returns a subject that is
+// determined by inspecting the the GRB's target fields
+func GetGRBSubject(grb *v3.GlobalRoleBinding) rbacv1.Subject {
+	kind := "User"
+	name := grb.UserName
+	if grb.ClusterName == "" && grb.GroupPrincipalName != "" {
+		kind = "Group"
+		name = grb.GroupPrincipalName
+	}
+
+	return rbacv1.Subject{
+		Kind:     kind,
+		Name:     name,
+		APIGroup: rbacv1.GroupName,
+	}
+}
+
+// getGRBTargetKey returns a key that uniquely identifies the given GRB's target.
+// If a user is being targeted, then the user's name is returned.
+// Otherwise, the group principal name is converted to a valid user string and
+// is returned.
+func GetGRBTargetKey(grb *v3.GlobalRoleBinding) string {
+	name := grb.UserName
+
+	if name == "" {
+		hasher := sha256.New()
+		hasher.Write([]byte(grb.GroupPrincipalName))
+		sha := base32.StdEncoding.WithPadding(-1).EncodeToString(hasher.Sum(nil))[:10]
+		name = "u-" + strings.ToLower(sha)
+	}
+	return name
 }

--- a/tests/integration/suite/common.py
+++ b/tests/integration/suite/common.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 import random
 import time
 
@@ -157,3 +159,9 @@ def wait_for_atleast_workload(pclient, nsid, timeout=60, count=0):
         interval *= 2
         workloads = pclient.list_workload(namespaceId=nsid)
     return workloads
+
+
+def string_to_encoding(input):
+    m = hashlib.sha256()
+    m.update(bytes(input, 'utf-8'))
+    return base64.b32encode(m.digest())[:10].decode('utf-8')

--- a/tests/integration/suite/test_global_role_bindings.py
+++ b/tests/integration/suite/test_global_role_bindings.py
@@ -1,7 +1,11 @@
 import pytest
 
 from rancher import ApiError
-from .common import random_str
+
+from kubernetes.client.rest import ApiException
+from kubernetes.client import RbacAuthorizationV1Api
+from .conftest import wait_for
+from .common import random_str, string_to_encoding
 
 
 def test_cannot_update_global_role(admin_mc, remove_resource):
@@ -33,4 +37,105 @@ def test_globalrole_must_exist(admin_mc, remove_resource):
         remove_resource(grb)
     assert e.value.error.status == 404
     assert "globalRole.management.cattle.io \"somefakerole\" not found" in \
+           e.value.error.message
+
+
+def test_cannot_update_subject(admin_mc, user_mc, remove_resource):
+    """Asserts that userId and groupPrincipalId fields cannot be
+    changed"""
+    admin_client = admin_mc.client
+
+    grb = admin_client.create_global_role_binding(
+        name="gr-" + random_str(),
+        userId=admin_mc.user.id,
+        globalRoleId="nodedrivers-manage")
+    remove_resource(grb)
+
+    grb = admin_client.update_by_id_global_role_binding(
+        id=grb.id,
+        userId=user_mc.user.id)
+    assert grb.userId == admin_mc.user.id
+
+    grb = admin_client.update_by_id_global_role_binding(
+        id=grb.id,
+        groupPrincipalId="groupa")
+    assert grb.userId == admin_mc.user.id
+    assert grb.groupPrincipalId is None
+
+
+def test_grb_crb_lifecycle(admin_mc, remove_resource):
+    """Asserts that global role binding creation and deletion
+    properly creates and deletes underlying cluster role binding"""
+    admin_client = admin_mc.client
+
+    # admin role is used because it requires an
+    # additional cluster role bindig to be managed
+    grb = admin_client.create_global_role_binding(
+        groupPrincipalId="asd", globalRoleId="admin"
+    )
+    remove_resource
+
+    cattle_grb = "cattle-globalrolebinding-" + grb.id
+    admin_grb = "globaladmin-u-" + string_to_encoding("asd").lower()
+
+    api_instance = RbacAuthorizationV1Api(
+        admin_mc.k8s_client)
+
+    def get_crb_by_id(id):
+        def get_crb_from_k8s():
+            try:
+                return api_instance.read_cluster_role_binding(id)
+            except ApiException as e:
+                assert e.status == 404
+        return get_crb_from_k8s
+
+    k8s_grb = wait_for(get_crb_by_id(cattle_grb))
+    assert k8s_grb.subjects[0].kind == "Group"
+    assert k8s_grb.subjects[0].name == "asd"
+
+    k8s_grb = wait_for(get_crb_by_id(admin_grb))
+    assert k8s_grb.subjects[0].kind == "Group"
+    assert k8s_grb.subjects[0].name == "asd"
+
+    grb = admin_client.reload(grb)
+    admin_client.delete(grb)
+
+    def crb_deleted_by_id(id):
+        def is_crb_deleted():
+            try:
+                api_instance.read_cluster_role_binding(id)
+            except ApiException as e:
+                return e.status == 404
+            return False
+        return is_crb_deleted
+
+    wait_for(crb_deleted_by_id(cattle_grb))
+    wait_for(crb_deleted_by_id(admin_grb))
+
+
+def test_grb_targets_user_or_group(admin_mc, remove_resource):
+    """Asserts that a globalrolebinding must exclusively target
+    a userId or groupPrincipalId"""
+    admin_client = admin_mc.client
+
+    with pytest.raises(ApiError) as e:
+        grb = admin_client.create_global_role_binding(
+            userId="asd",
+            groupPrincipalId="asd",
+            globalRoleId="admin"
+        )
+        remove_resource(grb)
+
+    assert e.value.error.status == 422
+    assert "must contain field [groupPrincipalId] OR field [userId]" in\
         e.value.error.message
+
+    with pytest.raises(ApiError) as e:
+        grb = admin_client.create_global_role_binding(
+            globalRoleId="admin"
+        )
+        remove_resource(grb)
+
+    assert e.value.error.status == 422
+    assert "must contain field [groupPrincipalId] OR field [userId]" in \
+           e.value.error.message

--- a/tests/integration/suite/test_node.py
+++ b/tests/integration/suite/test_node.py
@@ -1,10 +1,8 @@
-import base64
-import hashlib
 import os
 import tempfile
 import pytest
 from rancher import ApiError
-from .common import auth_check, random_str
+from .common import auth_check, random_str, string_to_encoding
 from .conftest import wait_for
 import time
 
@@ -240,12 +238,6 @@ def wait_for_cloud_credential(client, cloud_credential_id, timeout=60):
             if val["id"] == cloud_credential_id:
                 cred = val
     return cred
-
-
-def string_to_encoding(input):
-    m = hashlib.sha256()
-    m.update(bytes(input, 'utf-8'))
-    return base64.b32encode(m.digest())[:10].decode('utf-8')
 
 
 def wait_for_node_template(client, node_template_id, timeout=60):


### PR DESCRIPTION
**Problem:**
Admins would like to assign AD groups to global roles so when a member is added that belongs to that group, they will inherit the global role permissions.

**Solution:**
Support assigning group principal IDs to global role bindings.

**Issue:**
https://github.com/rancher/rancher/issues/22707