### PR TITLE
Fix missing auto-generated ingress svc issue

### DIFF
--- a/pkg/controllers/user/controllers.go
+++ b/pkg/controllers/user/controllers.go
@@ -69,6 +69,7 @@ func Register(ctx context.Context, cluster *config.UserContext, clusterRec *mana
 	monitoring.Register(ctx, cluster)
 	istio.Register(ctx, cluster)
 	certsexpiration.Register(ctx, cluster)
+	ingress.Register(ctx, cluster.UserOnlyContext())
 	ingresshostgen.Register(ctx, cluster.UserOnlyContext())
 	windows.Register(ctx, clusterRec, cluster)
 
@@ -110,7 +111,6 @@ func RegisterUserOnly(ctx context.Context, cluster *config.UserOnlyContext) erro
 
 	dnsrecord.Register(ctx, cluster)
 	externalservice.Register(ctx, cluster)
-	ingress.Register(ctx, cluster)
 	nslabels.Register(ctx, cluster)
 	targetworkloadservice.Register(ctx, cluster)
 	workload.Register(ctx, cluster)


### PR DESCRIPTION
**Problem:**
Ingress returns 503 due to auto-generated ingress svc is missing if we change the ingress domain to something other than xip.io

**Solution:**
The ingress controller is using the `IngressIPDomain` setting.
So the controller should run in Rancher side.

https://github.com/rancher/rancher/issues/24018