### PR TITLE
Mirror kube-state-metrics image

### DIFF
--- a/scripts/istio-images-mirror
+++ b/scripts/istio-images-mirror
@@ -14,6 +14,7 @@ pstauffer/curl rancher/pstauffer-curl v1.0.3
 coredns/coredns rancher/coredns-coredns 1.1.2
 quay.io/coreos/prometheus-operator rancher/coreos-prometheus-operator v0.32.0
 quay.io/coreos/prometheus-config-reloader rancher/coreos-prometheus-config-reloader v0.32.0
+quay.io/coreos/kube-state-metrics rancher/coreos-kube-state-metrics v1.8.0
 plugins/docker rancher/plugins-docker 18.09
 minio/minio rancher/minio-minio RELEASE.2019-09-25T18-25-51Z
 grafana/grafana rancher/grafana-grafana 6.3.6


### PR DESCRIPTION
Problem:

There are some error logs in coreos-kube-state-metrics pod for monitoring

Solution:

Bump coreos-kube-state-metrics version to support k8s 1.16

Issue:

rancher/rancher#23556