### PR TITLE
[WIP] Support to deploy prometheus-adapter in cluster-level Monitoring

### DIFF
--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -283,6 +283,8 @@ func (ch *clusterHandler) deployApp(appName, appTargetNamespace string, appProje
 
 		"exporter-fluentd.enabled": "true",
 
+		"prometheus-adapter.enabled": "false",
+
 		"grafana.persistence.enabled": "false",
 
 		"prometheus.persistence.enabled": "false",
@@ -317,6 +319,8 @@ func (ch *clusterHandler) deployApp(appName, appTargetNamespace string, appProje
 		"grafana.enabled":            "true",
 		"grafana.apiGroup":           monitoring.APIVersion.Group,
 		"grafana.serviceAccountName": appName,
+
+		"prometheus-adapter.serviceAccountName": appName,
 
 		"prometheus.enabled":                        "true",
 		"prometheus.apiGroup":                       monitoring.APIVersion.Group,

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -173,6 +173,8 @@ func (ph *projectHandler) deployApp(appName, appTargetNamespace string, appProje
 
 		"exporter-fluentd.enabled": "false",
 
+		"prometheus-adapter.enabled": "false",
+
 		"grafana.enabled":  "true",
 		"grafana.level":    "project",
 		"grafana.apiGroup": monitoring.APIVersion.Group,


### PR DESCRIPTION
- Make prometheus-adapter disabled at default
- Share `cluster-monitoring` ServiceAccount with cluster-level Prometheus