### PR TITLE
Make errors not increase chart count

### DIFF
--- a/pkg/catalog/manager/catalog_sync.go
+++ b/pkg/catalog/manager/catalog_sync.go
@@ -1,12 +1,17 @@
 package manager
 
 import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
 	helmlib "github.com/rancher/rancher/pkg/catalog/helm"
 	"github.com/rancher/rancher/pkg/namespace"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func (m *Manager) updateCatalogError(catalog *v3.Catalog, err error) (runtime.Object, error) {
@@ -53,6 +58,25 @@ func (m *Manager) Sync(key string, obj *v3.Catalog) (runtime.Object, error) {
 		catalog: catalog,
 	}
 
-	logrus.Infof("Updating global catalog %s", catalog.Name)
-	return nil, m.traverseAndUpdate(helm, commit, cmt)
+	backoff := wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2,
+		Jitter:   0,
+		Steps:    5,
+	}
+
+	err = wait.ExponentialBackoff(backoff, func() (bool, error) {
+		logrus.Infof("Updating global catalog %s", catalog.Name)
+		err := m.traverseAndUpdate(helm, commit, cmt)
+		if err != nil {
+			logrus.Error(err)
+			if errors.IsNotFound(err) || errors.IsGone(err) || errors.IsResourceExpired(err) || errors.IsConflict(err) || errors.IsInvalid(err) || err.Error() == "Catalog is no longer available" {
+				return true, nil
+			}
+			return false, nil
+		}
+		return true, nil
+	})
+	return nil, nil
+
 }

--- a/pkg/catalog/manager/crd.go
+++ b/pkg/catalog/manager/crd.go
@@ -107,6 +107,7 @@ func (m *Manager) updateTemplate(template *v3.CatalogTemplate, toUpdate v3.Catal
 			if err := m.templateVersionClient.DeleteNamespaced(template.Namespace, tv.Name, &metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
 				return false, err
 			}
+			updated = true
 		}
 	}
 

--- a/pkg/catalog/manager/traverse.go
+++ b/pkg/catalog/manager/traverse.go
@@ -18,6 +18,7 @@ import (
 )
 
 func (m *Manager) traverseAndUpdate(helm *helmlib.Helm, commit string, cmt *CatalogInfo) error {
+
 	var templateNamespace string
 	catalog := cmt.catalog
 	projectCatalog := cmt.projectCatalog


### PR DESCRIPTION
Problem:
The count for catalog templates was increasing after create or update was called even if they threw an error. TemplateSpec value "UpgradeVersionLinks" was being set prior to DeepEquals being called during update causing the template to indicate that it needed updating when no values had changed. 

Solution:
Add bool to indicate if function completed without errors. Move "UpgradeVersionLinks" to be set only when it is needed.  

Issue: 
#23368