### PR TITLE
Fix flaky globalrole test

### DIFF
--- a/pkg/api/customization/globalrole/validator.go
+++ b/pkg/api/customization/globalrole/validator.go
@@ -3,8 +3,10 @@ package globalrole
 import (
 	"net/http"
 
+	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 type Wrapper struct {
@@ -18,6 +20,9 @@ func (w Wrapper) Validator(request *types.APIContext, schema *types.Schema, data
 
 	gr, err := w.GlobalRoleLister.Get("", request.ID)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return httperror.NewAPIError(httperror.NotFound, err.Error())
+		}
 		return err
 	}
 

--- a/tests/integration/suite/test_global_roles.py
+++ b/tests/integration/suite/test_global_roles.py
@@ -2,6 +2,7 @@ import pytest
 from rancher import ApiError
 
 from .common import random_str
+from .conftest import wait_for
 
 
 @pytest.mark.nonparallel
@@ -43,7 +44,14 @@ def test_only_admin_can_crud_global_roles(admin_mc, user_mc, remove_resource):
 
     gr.annotations = {"test": "asdf"}
 
-    gr = admin_client.update_by_id_global_role(id=gr.id, value=gr)
+    def try_gr_update():
+        try:
+            return admin_client.update_by_id_global_role(id=gr.id, value=gr)
+        except ApiError as e:
+            e.error.status == 404
+            return False
+
+    wait_for(try_gr_update)
 
     gr_list = admin_client.list_global_role()
     assert len(gr_list.data) > 0

--- a/tests/integration/suite/test_global_roles.py
+++ b/tests/integration/suite/test_global_roles.py
@@ -46,9 +46,11 @@ def test_only_admin_can_crud_global_roles(admin_mc, user_mc, remove_resource):
 
     def try_gr_update():
         try:
-            return admin_client.update_by_id_global_role(id=gr.id, value=gr)
+            return admin_client.update_by_id_global_role(
+                    id=gr.id,
+                    value=gr)
         except ApiError as e:
-            e.error.status == 404
+            assert e.error.status == 404
             return False
 
     wait_for(try_gr_update)
@@ -70,9 +72,15 @@ def test_only_admin_can_crud_global_roles(admin_mc, user_mc, remove_resource):
         user_client.by_id_global_role(id=gr3.id)
     gr3.annotations = {"test2": "jkl"}
 
-    with pytest.raises(ApiError) as e:
-        user_client.update_by_id_global_role(id=gr3.id, value=gr3)
-    assert e.value.error.status == 403
+    def try_gr_unauth():
+        with pytest.raises(ApiError) as e:
+            user_client.update_by_id_global_role(id=gr3.id, value=gr3)
+        if e.value.error.status == 404:
+            return False
+        assert e.value.error.status == 403
+        return True
+
+    wait_for(try_gr_unauth)
 
     gr_list = user_client.list_global_role()
     assert len(gr_list.data) == 0


### PR DESCRIPTION
Problem:
Globalrole test results have been flakey. This is not due to the test. The validator is using a lister which does not always update quickly enough after object creation, leading to not found errors.

Solution:
Use client/interface instead of a lister.

Issue:
https://github.com/rancher/rancher/issues/24115