### PR TITLE
Add timeout to exec command in node controller

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -287,10 +287,11 @@ func (m *Lifecycle) provision(driverConfig, nodeDir string, obj *v3.Node) (*v3.N
 	}
 
 	createCommandsArgs := buildCreateCommand(obj, configRawMap)
-	cmd, err := buildCommand(nodeDir, obj, createCommandsArgs)
+	cmd, cancel, err := buildCommand(nodeDir, obj, createCommandsArgs)
 	if err != nil {
 		return obj, err
 	}
+	defer cancel()
 
 	logrus.Infof("Provisioning node %s", obj.Spec.RequestedHostname)
 
@@ -388,10 +389,11 @@ func (m *Lifecycle) deployAgent(nodeDir string, obj *v3.Node) error {
 
 	drun := clusterregistrationtokens.NodeCommand(token)
 	args := buildAgentCommand(obj, drun)
-	cmd, err := buildCommand(nodeDir, obj, args)
+	cmd, cancel, err := buildCommand(nodeDir, obj, args)
 	if err != nil {
 		return err
 	}
+	defer cancel()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return errors.Wrap(err, string(output))


### PR DESCRIPTION
We sometimes faced the issue that executing command line is stuck indefinitely.
e.g) When docker-machine failed `yum update` for some reasons, node is stuck with `Provisioning centos...`
This patch adds timeout to execute command line.