### PR TITLE
Move grb-sync out of cluster level

### DIFF
--- a/pkg/controllers/management/auth/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalrolebinding_handler.go
@@ -1,11 +1,15 @@
 package auth
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/pkg/errors"
+	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types/slice"
+	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/rbac"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	rbacv1 "github.com/rancher/types/apis/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/types/config"
@@ -18,38 +22,40 @@ import (
 
 var (
 	globalRoleBindingLabel = map[string]string{"authz.management.cattle.io/globalrolebinding": "true"}
-	crbNameAnnotation      = "authz.management.cattle.io/crb-name"
-	crbNamePrefix          = "cattle-globalrolebinding-"
-	grbController          = "mgmt-auth-grb-controller"
 )
 
 const (
-	globalCatalogRole                  = "global-catalog"
-	globalCatalogRoleBinding           = "global-catalog-binding"
-	templateResourceRule               = "templates"
-	templateVersionResourceRule        = "templateversions"
 	catalogTemplateResourceRule        = "catalogtemplates"
 	catalogTemplateVersionResourceRule = "catalogtemplateversions"
+	crbNameAnnotation                  = "authz.management.cattle.io/crb-name"
+	crbNamePrefix                      = "cattle-globalrolebinding-"
+	globalCatalogRole                  = "global-catalog"
+	globalCatalogRoleBinding           = "global-catalog-binding"
+	grbController                      = "mgmt-auth-grb-controller"
+	templateResourceRule               = "templates"
+	templateVersionResourceRule        = "templateversions"
 )
 
-func newGlobalRoleBindingLifecycle(management *config.ManagementContext) *globalRoleBindingLifecycle {
+func newGlobalRoleBindingLifecycle(management *config.ManagementContext, clusterManager *clustermanager.Manager) *globalRoleBindingLifecycle {
 	return &globalRoleBindingLifecycle{
-		crbLister:    management.RBAC.ClusterRoleBindings("").Controller().Lister(),
-		crbClient:    management.RBAC.ClusterRoleBindings(""),
-		grbClient:    management.Management.GlobalRoleBindings(""),
-		grLister:     management.Management.GlobalRoles("").Controller().Lister(),
-		roles:        management.RBAC.Roles(""),
-		roleBindings: management.RBAC.RoleBindings(""),
+		clusters:       management.Management.Clusters(""),
+		clusterManager: clusterManager,
+		crbClient:      management.RBAC.ClusterRoleBindings(""),
+		crbLister:      management.RBAC.ClusterRoleBindings("").Controller().Lister(),
+		grLister:       management.Management.GlobalRoles("").Controller().Lister(),
+		roles:          management.RBAC.Roles(""),
+		roleBindings:   management.RBAC.RoleBindings(""),
 	}
 }
 
 type globalRoleBindingLifecycle struct {
-	crbLister    rbacv1.ClusterRoleBindingLister
-	grLister     v3.GlobalRoleLister
-	crbClient    rbacv1.ClusterRoleBindingInterface
-	grbClient    v3.GlobalRoleBindingInterface
-	roles        rbacv1.RoleInterface
-	roleBindings rbacv1.RoleBindingInterface
+	clusters       v3.ClusterInterface
+	clusterManager *clustermanager.Manager
+	crbClient      rbacv1.ClusterRoleBindingInterface
+	crbLister      rbacv1.ClusterRoleBindingLister
+	grLister       v3.GlobalRoleLister
+	roles          rbacv1.RoleInterface
+	roleBindings   rbacv1.RoleBindingInterface
 }
 
 func (grb *globalRoleBindingLifecycle) Create(obj *v3.GlobalRoleBinding) (runtime.Object, error) {
@@ -59,12 +65,62 @@ func (grb *globalRoleBindingLifecycle) Create(obj *v3.GlobalRoleBinding) (runtim
 
 func (grb *globalRoleBindingLifecycle) Updated(obj *v3.GlobalRoleBinding) (runtime.Object, error) {
 	err := grb.reconcileGlobalRoleBinding(obj)
-	return nil, err
+	return obj, err
 }
 
 func (grb *globalRoleBindingLifecycle) Remove(obj *v3.GlobalRoleBinding) (runtime.Object, error) {
+	if obj.GlobalRoleName == "admin" {
+		return obj, grb.deleteAdminBinding(obj)
+	}
 	// Don't need to delete the created ClusterRole because owner reference will take care of that
-	return nil, nil
+	return obj, nil
+}
+
+func (grb *globalRoleBindingLifecycle) deleteAdminBinding(obj *v3.GlobalRoleBinding) error {
+	// Explicit API call to ensure we have the most recent cluster info when deleting admin bindings
+	clusters, err := grb.clusters.List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Collect all the errors to delete as many user context bindings as possible
+	var allErrors []error
+
+	for _, cluster := range clusters.Items {
+		userContext, err := grb.clusterManager.UserContext(cluster.Name)
+		if err != nil {
+			// ClusterUnavailable error indicates the record can't talk to the downstream cluster
+			if !IsClusterUnavailable(err) {
+				allErrors = append(allErrors, err)
+			}
+			continue
+		}
+
+		bindingName := rbac.GrbCRBName(obj)
+		b, err := userContext.RBAC.ClusterRoleBindings("").Controller().Lister().Get("", bindingName)
+		if err != nil {
+			// User context clusterRoleBinding doesn't exist
+			if !apierrors.IsNotFound(err) {
+				allErrors = append(allErrors, err)
+			}
+			continue
+		}
+
+		err = userContext.RBAC.ClusterRoleBindings("").Delete(b.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			// User context clusterRoleBinding doesn't exist
+			if !apierrors.IsNotFound(err) {
+				allErrors = append(allErrors, err)
+			}
+			continue
+		}
+
+	}
+
+	if len(allErrors) > 0 {
+		return fmt.Errorf("errors deleting admin global role binding: %v", allErrors)
+	}
+	return nil
 }
 
 func (grb *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBinding *v3.GlobalRoleBinding) error {
@@ -246,4 +302,11 @@ func (grb *globalRoleBindingLifecycle) addRulesForTemplateAndTemplateVersions(gl
 		}
 	}
 	return nil
+}
+
+func IsClusterUnavailable(err error) bool {
+	if apiError, ok := err.(*httperror.APIError); ok {
+		return apiError.Code == httperror.ClusterUnavailable
+	}
+	return false
 }

--- a/pkg/controllers/management/auth/legacy_grb_cleaner.go
+++ b/pkg/controllers/management/auth/legacy_grb_cleaner.go
@@ -3,29 +3,23 @@ package auth
 import (
 	"strings"
 
-	"github.com/rancher/norman/lifecycle"
 	grbstore "github.com/rancher/rancher/pkg/api/store/globalrolebindings"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type grbCleaner struct {
-	clusterLister v3.ClusterLister
-	mgmt          *config.ManagementContext
+	mgmt *config.ManagementContext
 }
 
 func newLegacyGRBCleaner(m *config.ManagementContext) *grbCleaner {
 	return &grbCleaner{
-		mgmt:          m,
-		clusterLister: m.Management.Clusters("").Controller().Lister(),
+		mgmt: m,
 	}
 }
 
-// this function addresses issues with grb not being cleaned up that was an issue from v2.2.3 - v2.2.8
-// it works on previously created objects outside of the timeline of normal sync handlers to correct issues with finalizers not be removed on deletion and finalizers not being dropped on cluster deletion
+// sync cleans up all GRBs to drop cluster-scoped lifecycle handler finalizers
 func (p *grbCleaner) sync(key string, obj *v3.GlobalRoleBinding) (runtime.Object, error) {
 	if key == "" || obj == nil {
 		return nil, nil
@@ -33,10 +27,9 @@ func (p *grbCleaner) sync(key string, obj *v3.GlobalRoleBinding) (runtime.Object
 	if obj.Annotations[grbstore.GrbVersion] == "true" {
 		return obj, nil
 	}
-	obj, err := p.removeFinalizerFromNonExistentCluster(obj)
-	if err != nil && !errors.IsNotFound(err) {
-		return obj, err
-	}
+
+	obj = p.cleanFinalizers(obj)
+
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
@@ -46,26 +39,14 @@ func (p *grbCleaner) sync(key string, obj *v3.GlobalRoleBinding) (runtime.Object
 	return p.mgmt.Management.GlobalRoleBindings("").Update(obj)
 }
 
-func (p *grbCleaner) removeFinalizerFromNonExistentCluster(obj *v3.GlobalRoleBinding) (*v3.GlobalRoleBinding, error) {
-	obj = obj.DeepCopy()
-
-	md, err := meta.Accessor(obj)
-	if err != nil {
-		return obj, err
-	}
-
-	finalizers := md.GetFinalizers()
-	for i := len(finalizers) - 1; i >= 0; i-- {
-		f := finalizers[i]
-		if strings.HasPrefix(f, lifecycle.ScopedFinalizerKey) {
-			s := strings.Split(f, "_")
-			// if cluster was not reported, its a deleted cluster and will cause the finalizer to hang in the future
-			if _, err = p.clusterLister.Get("", s[1]); errors.IsNotFound(err) {
-				finalizers = append(finalizers[:i], finalizers[i+1:]...)
-			}
+func (p *grbCleaner) cleanFinalizers(obj *v3.GlobalRoleBinding) *v3.GlobalRoleBinding {
+	var newFinalizers []string
+	for _, finalizer := range obj.GetFinalizers() {
+		if strings.HasPrefix(finalizer, "clusterscoped.controller.cattle.io/grb-sync_") {
+			continue
 		}
+		newFinalizers = append(newFinalizers, finalizer)
 	}
-
-	md.SetFinalizers(finalizers)
-	return obj, nil
+	obj.SetFinalizers(newFinalizers)
+	return obj
 }

--- a/pkg/controllers/management/auth/register.go
+++ b/pkg/controllers/management/auth/register.go
@@ -10,7 +10,7 @@ import (
 func RegisterEarly(ctx context.Context, management *config.ManagementContext, clusterManager *clustermanager.Manager) {
 	prtb, crtb := newRTBLifecycles(management)
 	gr := newGlobalRoleLifecycle(management)
-	grb := newGlobalRoleBindingLifecycle(management)
+	grb := newGlobalRoleBindingLifecycle(management, clusterManager)
 	p, c := newPandCLifecycles(management)
 	u := newUserLifecycle(management, clusterManager)
 	n := newTokenController(management)

--- a/pkg/controllers/user/rbac/globalrole_handler.go
+++ b/pkg/controllers/user/rbac/globalrole_handler.go
@@ -1,6 +1,7 @@
 package rbac
 
 import (
+	"github.com/rancher/rancher/pkg/rbac"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	rbacv1 "github.com/rancher/types/apis/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/types/config"
@@ -15,18 +16,19 @@ const (
 	grbByUserAndRoleIndex = "authz.cluster.cattle.io/grb-by-user-and-role"
 )
 
-func newGlobalRoleBindingHandler(workload *config.UserContext) *grbHandler {
+func newGlobalRoleBindingHandler(workload *config.UserContext) v3.GlobalRoleBindingHandlerFunc {
 	informer := workload.Management.Management.GlobalRoleBindings("").Controller().Informer()
 	indexers := map[string]cache.IndexFunc{
 		grbByUserAndRoleIndex: grbByUserAndRole,
 	}
 	informer.AddIndexers(indexers)
 
-	return &grbHandler{
+	h := &grbHandler{
 		grbIndexer:          informer.GetIndexer(),
 		clusterRoleBindings: workload.RBAC.ClusterRoleBindings(""),
 		crbLister:           workload.RBAC.ClusterRoleBindings("").Controller().Lister(),
 	}
+	return h.sync
 }
 
 // grbHandler ensures the global admins have full access to every cluster. If a globalRoleBinding is created that uses
@@ -37,12 +39,12 @@ type grbHandler struct {
 	grbIndexer          cache.Indexer
 }
 
-func (c *grbHandler) Create(obj *v3.GlobalRoleBinding) (runtime.Object, error) {
-	if obj.GlobalRoleName != "admin" {
+func (c *grbHandler) sync(key string, obj *v3.GlobalRoleBinding) (runtime.Object, error) {
+	if obj == nil || obj.DeletionTimestamp != nil || obj.GlobalRoleName != "admin" {
 		return obj, nil
 	}
 
-	bindingName := grbCRBName(obj)
+	bindingName := rbac.GrbCRBName(obj)
 	b, err := c.crbLister.Get("", bindingName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return obj, err
@@ -68,36 +70,12 @@ func (c *grbHandler) Create(obj *v3.GlobalRoleBinding) (runtime.Object, error) {
 			Kind: "ClusterRole",
 		},
 	})
-	return obj, err
-}
-
-func (c *grbHandler) Updated(obj *v3.GlobalRoleBinding) (runtime.Object, error) {
-	return nil, nil
-}
-
-func (c *grbHandler) Remove(obj *v3.GlobalRoleBinding) (runtime.Object, error) {
-	if obj.GlobalRoleName != "admin" {
-		return obj, nil
-	}
-
-	grbs, err := c.grbIndexer.ByIndex(grbByUserAndRoleIndex, obj.UserName+"-"+obj.GlobalRoleName)
 	if err != nil {
-		return obj, err
+		if !apierrors.IsAlreadyExists(err) {
+			return obj, err
+		}
 	}
-
-	if len(grbs) > 1 {
-		return obj, nil
-	}
-
-	if err := c.clusterRoleBindings.Delete(grbCRBName(obj), nil); err != nil && !apierrors.IsNotFound(err) {
-		return obj, err
-	}
-
 	return obj, nil
-}
-
-func grbCRBName(grb *v3.GlobalRoleBinding) string {
-	return "globaladmin-" + grb.UserName
 }
 
 func grbByUserAndRole(obj interface{}) ([]string, error) {

--- a/pkg/controllers/user/rbac/handler_base.go
+++ b/pkg/controllers/user/rbac/handler_base.go
@@ -98,6 +98,7 @@ func Register(ctx context.Context, workload *config.UserContext) {
 	workload.RBAC.ClusterRoleBindings("").AddHandler(ctx, "legacy-crb-cleaner-sync", newLegacyCRBCleaner(r).sync)
 	workload.Management.Management.ClusterRoleTemplateBindings("").AddClusterScopedLifecycle(ctx, "cluster-crtb-sync", workload.ClusterName, newCRTBLifecycle(r))
 	workload.Management.Management.Clusters("").AddHandler(ctx, "global-admin-cluster-sync", newClusterHandler(workload))
+	workload.Management.Management.GlobalRoleBindings("").AddHandler(ctx, "grb-cluster-sync", newGlobalRoleBindingHandler(workload))
 
 	sync := &resourcequota.SyncController{
 		Namespaces:          workload.Core.Namespaces(""),
@@ -117,10 +118,6 @@ func Register(ctx context.Context, workload *config.UserContext) {
 	rti := workload.Management.Management.RoleTemplates("")
 	rtSync := v3.NewRoleTemplateLifecycleAdapter("cluster-roletemplate-sync_"+workload.ClusterName, true, rti, newRTLifecycle(r))
 	workload.Management.Management.RoleTemplates("").AddHandler(ctx, "cluster-roletemplate-sync", rtSync)
-
-	grbi := workload.Management.Management.GlobalRoleBindings("")
-	grbSync := v3.NewGlobalRoleBindingLifecycleAdapter("grb-sync_"+workload.ClusterName, true, grbi, newGlobalRoleBindingHandler(workload))
-	workload.Management.Management.GlobalRoleBindings("").AddHandler(ctx, "grb-sync", grbSync)
 }
 
 type manager struct {

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -67,3 +67,7 @@ func BuildSubjectFromRTB(object interface{}) (rbacv1.Subject, error) {
 		Name:      name,
 	}, nil
 }
+
+func GrbCRBName(grb *v3.GlobalRoleBinding) string {
+	return "globaladmin-" + grb.UserName
+}


### PR DESCRIPTION
Problem:
grb-sync is a cluster scoped lifecycle handler so if many clusters are
coming in all the handlers collide to try and update grbs with
finalizers

Solution:
Move grb-sync to management level and push bindings to the cluster

https://github.com/rancher/rancher/issues/23806