### PR TITLE
Catalog log fix

### DIFF
--- a/pkg/catalog/manager/catalog_common.go
+++ b/pkg/catalog/manager/catalog_common.go
@@ -104,7 +104,7 @@ func (m *Manager) updateCatalogInfo(cmt *CatalogInfo, catalogType string, templa
 		}
 		v3.CatalogConditionRefreshed.Unknown(obj)
 		if templateName != "" {
-			v3.CatalogConditionRefreshed.Message(obj, fmt.Sprintf("syncing template %v", templateName))
+			v3.CatalogConditionRefreshed.Message(obj, fmt.Sprintf("syncing catalog %v", cmt.catalog.Name))
 		} else {
 			v3.CatalogConditionRefreshed.Message(obj, fmt.Sprintf(""))
 		}

--- a/pkg/catalog/manager/catalog_common.go
+++ b/pkg/catalog/manager/catalog_common.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"fmt"
+	"strings"
 
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	client "github.com/rancher/types/client/management/v3"
@@ -48,6 +49,10 @@ func (m *Manager) deleteTemplates(key string, namespace string) error {
 	for _, t := range templates {
 		tvs, err := m.getTemplateVersion(t.Name, namespace)
 		if err != nil {
+			//if template version doesn't exist continue to delete template
+			if strings.Contains(err.Error(), "invalid label value") {
+				continue
+			}
 			return err
 		}
 		for k := range tvs {

--- a/pkg/catalog/manager/crd.go
+++ b/pkg/catalog/manager/crd.go
@@ -52,7 +52,10 @@ func (m *Manager) getTemplateMap(catalogName string, namespace string) (map[stri
 }
 
 func (m *Manager) updateTemplate(template *v3.CatalogTemplate, toUpdate v3.CatalogTemplate) error {
-	r, _ := labels.NewRequirement(TemplateNameLabel, selection.Equals, []string{template.Name})
+	r, err := labels.NewRequirement(TemplateNameLabel, selection.Equals, []string{template.Name})
+	if err != nil {
+		return err
+	}
 	templateVersions, err := m.templateVersionLister.List(template.Namespace, labels.NewSelector().Add(*r))
 	if err != nil {
 		return errors.Wrapf(err, "failed to list templateVersions")
@@ -145,7 +148,10 @@ func mergeLabels(set1, set2 map[string]string) map[string]string {
 
 func (m *Manager) getTemplateVersion(templateName string, namespace string) (map[string]struct{}, error) {
 	//because templates is a cluster resource now so we set namespace to "" when listing it.
-	r, _ := labels.NewRequirement(TemplateNameLabel, selection.Equals, []string{templateName})
+	r, err := labels.NewRequirement(TemplateNameLabel, selection.Equals, []string{templateName})
+	if err != nil {
+		return nil, err
+	}
 	templateVersions, err := m.templateVersionLister.List(namespace, labels.NewSelector().Add(*r))
 	if err != nil {
 		return nil, err

--- a/pkg/catalog/manager/traverse_test.go
+++ b/pkg/catalog/manager/traverse_test.go
@@ -1,0 +1,194 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/rancher/norman/types"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_Set_Catalog_Error_State(t *testing.T) {
+	type testcase struct {
+		caseName       string
+		catalogInfo    CatalogInfo
+		catalog        v3.Catalog
+		projectCatalog v3.ProjectCatalog
+		clusterCatalog v3.ClusterCatalog
+	}
+	testcases := []testcase{
+		{
+			caseName: "default",
+			catalogInfo: CatalogInfo{
+				catalog:        nil,
+				projectCatalog: nil,
+				clusterCatalog: nil,
+			},
+			catalog: v3.Catalog{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "testCatalog"},
+				Status: v3.CatalogStatus{
+					LastRefreshTimestamp: "",
+					Commit:               "",
+					HelmVersionCommits:   nil,
+					Conditions: []v3.CatalogCondition{
+						{
+							Type:    "Refreshed",
+							Status:  "True",
+							Message: "Test Catalog Stuff",
+						},
+					},
+				},
+			},
+			projectCatalog: v3.ProjectCatalog{
+				Namespaced:  types.Namespaced{},
+				Catalog:     v3.Catalog{},
+				ProjectName: "",
+			},
+
+			clusterCatalog: v3.ClusterCatalog{
+				Namespaced:  types.Namespaced{},
+				Catalog:     v3.Catalog{},
+				ClusterName: "",
+			},
+		},
+		{
+			caseName: "catalogcondition nil status & nil message",
+			catalogInfo: CatalogInfo{
+				catalog:        nil,
+				projectCatalog: nil,
+				clusterCatalog: nil,
+			},
+			catalog: v3.Catalog{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "testCatalog"},
+				Status: v3.CatalogStatus{
+					LastRefreshTimestamp: "",
+					Commit:               "",
+					HelmVersionCommits:   nil,
+				},
+			},
+			projectCatalog: v3.ProjectCatalog{
+				Namespaced:  types.Namespaced{},
+				Catalog:     v3.Catalog{},
+				ProjectName: "",
+			},
+
+			clusterCatalog: v3.ClusterCatalog{
+				Namespaced:  types.Namespaced{},
+				Catalog:     v3.Catalog{},
+				ClusterName: "",
+			},
+		},
+		{
+			caseName: "default",
+			catalogInfo: CatalogInfo{
+				catalog:        nil,
+				projectCatalog: nil,
+				clusterCatalog: nil,
+			},
+			catalog: v3.Catalog{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "testCatalog"},
+				Status: v3.CatalogStatus{
+					LastRefreshTimestamp: "",
+					Commit:               "",
+					HelmVersionCommits:   nil,
+					Conditions: []v3.CatalogCondition{
+						{
+							Type: "Refreshed",
+						},
+					},
+				},
+			},
+			projectCatalog: v3.ProjectCatalog{
+				Namespaced:  types.Namespaced{},
+				Catalog:     v3.Catalog{},
+				ProjectName: "",
+			},
+
+			clusterCatalog: v3.ClusterCatalog{
+				Namespaced:  types.Namespaced{},
+				Catalog:     v3.Catalog{},
+				ClusterName: "",
+			},
+		},
+		{
+			caseName: "false status",
+			catalogInfo: CatalogInfo{
+				catalog:        nil,
+				projectCatalog: nil,
+				clusterCatalog: nil,
+			},
+			catalog: v3.Catalog{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "testCatalog"},
+				Status: v3.CatalogStatus{
+					LastRefreshTimestamp: "",
+					Commit:               "",
+					HelmVersionCommits:   nil,
+					Conditions: []v3.CatalogCondition{
+						{
+							Type:    "Refreshed",
+							Status:  "False",
+							Message: "Test Catalog Stuff",
+						},
+					},
+				},
+			},
+			projectCatalog: v3.ProjectCatalog{
+				Namespaced:  types.Namespaced{},
+				Catalog:     v3.Catalog{},
+				ProjectName: "",
+			},
+
+			clusterCatalog: v3.ClusterCatalog{
+				Namespaced:  types.Namespaced{},
+				Catalog:     v3.Catalog{},
+				ClusterName: "",
+			},
+		},
+		{
+			caseName: "invalid status",
+			catalogInfo: CatalogInfo{
+				catalog:        nil,
+				projectCatalog: nil,
+				clusterCatalog: nil,
+			},
+			catalog: v3.Catalog{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "testCatalog"},
+				Status: v3.CatalogStatus{
+					LastRefreshTimestamp: "",
+					Commit:               "",
+					HelmVersionCommits:   nil,
+					Conditions: []v3.CatalogCondition{
+						{
+							Type:    "Refreshed",
+							Status:  "thisisnotanormalstatus",
+							Message: "Test Catalog Stuff",
+						},
+					},
+				},
+			},
+			projectCatalog: v3.ProjectCatalog{
+				Namespaced:  types.Namespaced{},
+				Catalog:     v3.Catalog{},
+				ProjectName: "",
+			},
+
+			clusterCatalog: v3.ClusterCatalog{
+				Namespaced:  types.Namespaced{},
+				Catalog:     v3.Catalog{},
+				ClusterName: "",
+			},
+		},
+	}
+
+	for _, c := range testcases {
+		setCatalogErrorState(&c.catalogInfo, &c.catalog, &c.projectCatalog, &c.clusterCatalog)
+		assert.True(t, v3.CatalogConditionRefreshed.IsFalse(&c.catalog))
+		assert.Equal(t, "Error syncing catalog testCatalog", v3.CatalogConditionRefreshed.GetMessage(&c.catalog))
+	}
+}


### PR DESCRIPTION
Problems:
The count for catalog templates was increasing after create or update was called even if they threw an error. TemplateSpec value "UpgradeVersionLinks" was being set prior to DeepEquals being called during update causing the template to indicate that it needed updating when no values had changed. Long label name was erring after template was being created. 

Solution:
Increment count only where there is not an error. Move "UpgradeVersionLinks" to be set only when it is needed. Add log to indicate files had a failure. Make errors indicate when the error occurred instead of being generic. Check for label length before allowing template to create. Delete template during delete if template version doesn't exist to ensure catalog delete occurs successfully. Reduce the number of times update is called on the catalog to reduce logging. UI no longer displays the individual templates that are syncing, but that the catalog is syncing. 

Issue:
#23368
#19724 