### PR TITLE
Validate CRTB and PRTB targets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/rancher/rke v1.1.0-rc6
 	github.com/rancher/security-scan v0.1.5
 	github.com/rancher/steve v0.0.0-20200214232004-4218314653de
-	github.com/rancher/types v0.0.0-20200219204417-26b7145e8f0a
+	github.com/rancher/types v0.0.0-20200220172136-2eaa9b5bc71b
 	github.com/rancher/wrangler v0.4.2-0.20200215064225-8abf292acf7b
 	github.com/rancher/wrangler-api v0.4.1
 	github.com/robfig/cron v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -837,8 +837,8 @@ github.com/rancher/types v0.0.0-20200123224322-9adcafc483ee h1:kYxNoRYCC9wP72ou8
 github.com/rancher/types v0.0.0-20200123224322-9adcafc483ee/go.mod h1:rN9IgDRV1O4HTJCLtpLqyUEfdPsoeBoH2wNUm8PPThk=
 github.com/rancher/types v0.0.0-20200218191331-dc762fc27c91 h1:IitaXkx6eqd4nCQMzJkGriaNWk/kDKfO5CasK3AXhp4=
 github.com/rancher/types v0.0.0-20200218191331-dc762fc27c91/go.mod h1:7v/f4VGMfBQi5yQQxlFHylW6QP4w6vCxd6KKPG5sZpM=
-github.com/rancher/types v0.0.0-20200219204417-26b7145e8f0a h1:TMC1ZXqVK4uCyN/RGHGN+NFGefWhkZo07VhYb+Sctbo=
-github.com/rancher/types v0.0.0-20200219204417-26b7145e8f0a/go.mod h1:7v/f4VGMfBQi5yQQxlFHylW6QP4w6vCxd6KKPG5sZpM=
+github.com/rancher/types v0.0.0-20200220172136-2eaa9b5bc71b h1:cYJ5dqJGDV365Mgqqh/IG3dBIK99Qo52s3BfS0/giRg=
+github.com/rancher/types v0.0.0-20200220172136-2eaa9b5bc71b/go.mod h1:7v/f4VGMfBQi5yQQxlFHylW6QP4w6vCxd6KKPG5sZpM=
 github.com/rancher/wrangler v0.1.4/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rancher/wrangler v0.4.0/go.mod h1:1cR91WLhZgkZ+U4fV9nVuXqKurWbgXcIReU4wnQvTN8=
 github.com/rancher/wrangler v0.4.1 h1:kQLE6syPbX4ciwU4OF+EHIPT9zj6r6pyN83u9Gsv5eg=

--- a/tests/integration/suite/test_cluster_role_template_bindings.py
+++ b/tests/integration/suite/test_cluster_role_template_bindings.py
@@ -1,0 +1,67 @@
+import pytest
+
+from .common import random_str
+from .conftest import wait_for
+from rancher import ApiError
+
+
+def test_cannot_target_users_and_group(admin_mc, remove_resource):
+    """Asserts that a clusterroletemplatebinding cannot target both
+    user and group subjects"""
+    admin_client = admin_mc.client
+
+    with pytest.raises(ApiError) as e:
+        crtb = admin_client.create_cluster_role_template_binding(
+            name="crtb-"+random_str(),
+            clusterId="local",
+            userId=admin_mc.user.id,
+            groupPrincipalId="someauthprovidergroupid",
+            roleTemplateId="clustercatalogs-view")
+        remove_resource(crtb)
+    assert e.value.error.status == 422
+    assert "must target a user [userId]/[userPrincipalId] OR a group " \
+        "[groupId]/[groupPrincipalId]" in e.value.error.message
+
+
+def test_must_have_target(admin_mc, remove_resource):
+    """Asserts that a clusterroletemplatebinding must have a subject"""
+    admin_client = admin_mc.client
+
+    with pytest.raises(ApiError) as e:
+        crtb = admin_client.create_cluster_role_template_binding(
+            name="crtb-" + random_str(),
+            clusterId="local",
+            roleTemplateId="clustercatalogs-view")
+        remove_resource(crtb)
+    assert e.value.error.status == 422
+    assert "must target a user [userId]/[userPrincipalId] OR a group " \
+           "[groupId]/[groupPrincipalId]" in e.value.error.message
+
+
+def test_cannot_update_subjects_or_cluster(admin_mc, remove_resource):
+    """Asserts non-metadata fields cannot be updated"""
+    admin_client = admin_mc.client
+    old_crtb = admin_client.create_cluster_role_template_binding(
+        name="crtb-" + random_str(),
+        clusterId="local",
+        userId=admin_mc.user.id,
+        roleTemplateId="clustercatalogs-view")
+    remove_resource(old_crtb)
+
+    wait_for(lambda: admin_client.reload(old_crtb).userPrincipalId is not None)
+    old_crtb = admin_client.reload(old_crtb)
+
+    crtb = admin_client.update_by_id_cluster_role_template_binding(
+        id=old_crtb.id,
+        clusterId="fakecluster",
+        userId="",
+        userPrincipalId="asdf",
+        groupPrincipalId="asdf",
+        group="asdf"
+    )
+
+    assert crtb.get("clusterId") == old_crtb.get("clusterId")
+    assert crtb.get("userId") == old_crtb.get("userId")
+    assert crtb.get("userPrincipalId") == old_crtb.get("userPrincipalId")
+    assert crtb.get("groupPrincipalId") == old_crtb.get("groupPrincipalId")
+    assert crtb.get("group") == old_crtb.get("group")

--- a/tests/integration/suite/test_project_role_template_bindings.py
+++ b/tests/integration/suite/test_project_role_template_bindings.py
@@ -1,0 +1,73 @@
+import pytest
+
+from .common import random_str
+from .conftest import wait_for
+from rancher import ApiError
+
+
+def test_cannot_target_users_and_group(admin_mc, remove_resource):
+    """Asserts that a projectroletemplatebinding cannot target both
+    user and group subjects"""
+    admin_client = admin_mc.client
+
+    project = admin_client.create_project(
+        name="p-" + random_str(),
+        clusterId="local")
+    remove_resource(project)
+
+    with pytest.raises(ApiError) as e:
+        prtb = admin_client.create_project_role_template_binding(
+            name="prtb-"+random_str(),
+            projectId=project.id,
+            userId=admin_mc.user.id,
+            groupPrincipalId="someauthprovidergroupid",
+            roleTemplateId="projectcatalogs-view")
+        remove_resource(prtb)
+    assert e.value.error.status == 422
+    assert "must target a user [userId]/[userPrincipalId] OR a group " \
+        "[groupId]/[groupPrincipalId]" in e.value.error.message
+
+
+def test_must_have_target(admin_mc, admin_pc, remove_resource):
+    """Asserts that a projectroletemplatebinding must have a subject"""
+    admin_client = admin_mc.client
+
+    with pytest.raises(ApiError) as e:
+        prtb = admin_client.create_project_role_template_binding(
+            name="prtb-" + random_str(),
+            projectId=admin_pc.project.id,
+            roleTemplateId="projectcatalogs-view")
+        remove_resource(prtb)
+    assert e.value.error.status == 422
+    assert "must target a user [userId]/[userPrincipalId] OR a group " \
+           "[groupId]/[groupPrincipalId]" in e.value.error.message
+
+
+def test_cannot_update_subject_or_proj(admin_mc, admin_pc, remove_resource):
+    """Asserts non-metadata fields cannot be updated"""
+    admin_client = admin_mc.client
+
+    old_prtb = admin_client.create_project_role_template_binding(
+        name="prtb-" + random_str(),
+        projectId=admin_pc.project.id,
+        userId=admin_mc.user.id,
+        roleTemplateId="projectcatalogs-view")
+    remove_resource(old_prtb)
+
+    wait_for(lambda: admin_client.reload(old_prtb).userPrincipalId is not None)
+    old_prtb = admin_client.reload(old_prtb)
+
+    prtb = admin_client.update_by_id_project_role_template_binding(
+        id=old_prtb.id,
+        clusterId="fakeproject",
+        userId="",
+        userPrincipalId="asdf",
+        groupPrincipalId="asdf",
+        group="asdf"
+    )
+
+    assert prtb.get("projectId") == old_prtb.get("projectId")
+    assert prtb.get("userId") == old_prtb.get("userId")
+    assert prtb.get("userPrincipalId") == old_prtb.get("userPrincipalId")
+    assert prtb.get("groupPrincipalId") == old_prtb.get("groupPrincipalId")
+    assert prtb.get("group") == old_prtb.get("group")

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
@@ -119,11 +119,11 @@ type ProjectRoleTemplateBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	UserName           string `json:"userName,omitempty" norman:"type=reference[user]"`
-	UserPrincipalName  string `json:"userPrincipalName,omitempty" norman:"type=reference[principal]"`
-	GroupName          string `json:"groupName,omitempty" norman:"type=reference[group]"`
-	GroupPrincipalName string `json:"groupPrincipalName,omitempty" norman:"type=reference[principal]"`
-	ProjectName        string `json:"projectName,omitempty" norman:"required,type=reference[project]"`
+	UserName           string `json:"userName,omitempty" norman:"noupdate,type=reference[user]"`
+	UserPrincipalName  string `json:"userPrincipalName,omitempty" norman:"noupdate,type=reference[principal]"`
+	GroupName          string `json:"groupName,omitempty" norman:"noupdate,type=reference[group]"`
+	GroupPrincipalName string `json:"groupPrincipalName,omitempty" norman:"noupdate,type=reference[principal]"`
+	ProjectName        string `json:"projectName,omitempty" norman:"required,noupdate,type=reference[project]"`
 	RoleTemplateName   string `json:"roleTemplateName,omitempty" norman:"required,type=reference[roleTemplate]"`
 	ServiceAccount     string `json:"serviceAccount,omitempty" norman:"nocreate,noupdate"`
 }
@@ -133,11 +133,11 @@ type ClusterRoleTemplateBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	UserName           string `json:"userName,omitempty" norman:"type=reference[user]"`
-	UserPrincipalName  string `json:"userPrincipalName,omitempty" norman:"type=reference[principal]"`
-	GroupName          string `json:"groupName,omitempty" norman:"type=reference[group]"`
-	GroupPrincipalName string `json:"groupPrincipalName,omitempty" norman:"type=reference[principal]"`
-	ClusterName        string `json:"clusterName,omitempty" norman:"required,type=reference[cluster]"`
+	UserName           string `json:"userName,omitempty" norman:"noupdate,type=reference[user]"`
+	UserPrincipalName  string `json:"userPrincipalName,omitempty" norman:"noupdate,type=reference[principal]"`
+	GroupName          string `json:"groupName,omitempty" norman:"noupdate,type=reference[group]"`
+	GroupPrincipalName string `json:"groupPrincipalName,omitempty" norman:"noupdate,type=reference[principal]"`
+	ClusterName        string `json:"clusterName,omitempty" norman:"required,noupdate,type=reference[cluster]"`
 	RoleTemplateName   string `json:"roleTemplateName,omitempty" norman:"required,type=reference[roleTemplate]"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -453,7 +453,7 @@ github.com/rancher/steve/pkg/server/resources/common
 github.com/rancher/steve/pkg/server/resources/counts
 github.com/rancher/steve/pkg/server/router
 github.com/rancher/steve/pkg/server/store/proxy
-# github.com/rancher/types v0.0.0-20200219204417-26b7145e8f0a
+# github.com/rancher/types v0.0.0-20200220172136-2eaa9b5bc71b
 github.com/rancher/types/apis/apiregistration.k8s.io/v1
 github.com/rancher/types/apis/apps/v1
 github.com/rancher/types/apis/autoscaling/v2beta2


### PR DESCRIPTION
**Dependency:**
types (merge first): https://github.com/rancher/types/pull/1042

**Problem:**
CRTBs and PRTBs can currently target both, a user and a group, or neither. Those are invalid and will cause handlers to continuously fail.

**Solution:**
Add a validator to ensure CRTBs and PRTBs are target a user or (exclusive) a group.

**Issue:**
https://github.com/rancher/rancher/issues/24036