### PR TITLE
[2.3] Add settingProvider to propagate settings to cluster API

### DIFF
--- a/pkg/controllers/user/controllers.go
+++ b/pkg/controllers/user/controllers.go
@@ -33,6 +33,8 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/user/resourcequota"
 	"github.com/rancher/rancher/pkg/controllers/user/secret"
 	"github.com/rancher/rancher/pkg/controllers/user/servicemonitor"
+	"github.com/rancher/rancher/pkg/controllers/user/setting"
+	"github.com/rancher/rancher/pkg/controllers/user/settingprovider"
 	"github.com/rancher/rancher/pkg/controllers/user/systemimage"
 	"github.com/rancher/rancher/pkg/controllers/user/targetworkloadservice"
 	"github.com/rancher/rancher/pkg/controllers/user/windows"
@@ -69,8 +71,8 @@ func Register(ctx context.Context, cluster *config.UserContext, clusterRec *mana
 	monitoring.Register(ctx, cluster)
 	istio.Register(ctx, cluster)
 	certsexpiration.Register(ctx, cluster)
-	ingresshostgen.Register(ctx, cluster.UserOnlyContext())
 	windows.Register(ctx, clusterRec, cluster)
+	setting.Register(ctx, cluster)
 
 	// register controller for API
 	cluster.APIAggregation.APIServices("").Controller()
@@ -104,10 +106,18 @@ func RegisterFollower(ctx context.Context, cluster *config.UserContext, kubeConf
 }
 
 func RegisterUserOnly(ctx context.Context, cluster *config.UserOnlyContext) error {
-	if err := createUserClusterCRDs(ctx, cluster); err != nil {
+	err := createUserClusterCRDs(ctx, cluster)
+	if err != nil {
 		return err
 	}
 
+	// Don't register secret powered setting in the local cluster
+	if cluster.ClusterName != setting.LocalClusterName {
+		if err = settingprovider.Register(ctx, cluster); err != nil {
+			return err
+		}
+	}
+	ingresshostgen.Register(ctx, cluster)
 	dnsrecord.Register(ctx, cluster)
 	externalservice.Register(ctx, cluster)
 	ingress.Register(ctx, cluster)
@@ -116,7 +126,6 @@ func RegisterUserOnly(ctx context.Context, cluster *config.UserOnlyContext) erro
 	workload.Register(ctx, cluster)
 	servicemonitor.Register(ctx, cluster)
 	monitoring.RegisterAgent(ctx, cluster)
-
 	return nil
 }
 

--- a/pkg/controllers/user/setting/register.go
+++ b/pkg/controllers/user/setting/register.go
@@ -1,0 +1,173 @@
+package setting
+
+import (
+	"context"
+	"fmt"
+
+	v1 "github.com/rancher/types/apis/core/v1"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// SettingProviderController listens for setting CUD in management API
+// and propagates the changes to the secret of cattle-system namespace in cluster API
+type Controller struct {
+	secrets                 v1.SecretInterface
+	secretsLister           v1.SecretLister
+	managementSettingLister v3.SettingLister
+	clusterName             string
+}
+
+const (
+	CattleNamespace          = "cattle-system"
+	DefaultSettingSecretName = "cattle-setting-provider"
+	settingSecretAnnotation  = "secret.setting.cattle.io/secret"
+	LocalClusterName         = "local"
+)
+
+var syncSettings = []string{"ingress-ip-domain", "rdns-base-url"}
+
+func Register(ctx context.Context, cluster *config.UserContext) {
+	c := &Controller{
+		secrets:                 cluster.Core.Secrets(""),
+		secretsLister:           cluster.Core.Secrets("").Controller().Lister(),
+		managementSettingLister: cluster.Management.Management.Settings("").Controller().Lister(),
+		clusterName:             cluster.ClusterName,
+	}
+
+	if cluster.ClusterName == LocalClusterName {
+		return
+	}
+
+	sync := v3.NewSettingLifecycleAdapter(fmt.Sprintf("settingProviderController_%s", cluster.ClusterName), true,
+		cluster.Management.Management.Settings(""), c)
+
+	cluster.Management.Management.Settings("").AddHandler(ctx, "settingProviderController",
+		func(key string, obj *v3.Setting) (runtime.Object, error) {
+			if obj == nil {
+				return sync(key, nil)
+			}
+
+			// only propagate settings within the sync settings array
+			_, found := find(syncSettings, obj.Name)
+			if !found {
+				return nil, nil
+			}
+
+			if obj.Labels != nil {
+				if obj.Labels["cattle.io/creator"] == "norman" {
+					return sync(key, obj)
+				}
+			}
+
+			return nil, nil
+		})
+}
+
+func (c *Controller) Create(obj *v3.Setting) (runtime.Object, error) {
+	return nil, c.createOrUpdate(obj, CattleNamespace)
+}
+
+func (c *Controller) Updated(obj *v3.Setting) (runtime.Object, error) {
+	return nil, c.createOrUpdate(obj, CattleNamespace)
+}
+
+func (c *Controller) Remove(obj *v3.Setting) (runtime.Object, error) {
+	settingSecret, err := c.secretExistsForSetting(DefaultSettingSecretName, CattleNamespace)
+	if err != nil {
+		return nil, err
+	}
+	if settingSecret == nil {
+		logrus.Infof("Default setting secret [%s] not exist in namespace [%s], skip to delete",
+			DefaultSettingSecretName, CattleNamespace)
+		return nil, nil
+	}
+	toUpdate := settingSecret.DeepCopy()
+	logrus.Infof("Deleting setting data [%s] in secret [%s]", obj.Name, DefaultSettingSecretName)
+	delete(toUpdate.Data, obj.Name)
+	_, err = c.secrets.Update(toUpdate)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (c *Controller) createOrUpdate(obj *v3.Setting, ns string) error {
+	secret, err := c.secretExistsForSetting(DefaultSettingSecretName, ns)
+	if err != nil {
+		return err
+	}
+
+	logrus.Debugf("Copying setting [%s:%s] into secret [%s] at namespace [%s]",
+		obj.Name, obj.Value, DefaultSettingSecretName, ns)
+
+	// create a new secret and store setting value if not exist
+	if secret == nil {
+		secret = SetDefaultSettingSecret(DefaultSettingSecretName, ns)
+		toCreate := updateSettingSecretStringData(secret, obj)
+		_, err := c.secrets.Create(toCreate)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// update existing secret with new setting value
+	toUpdate := secret.DeepCopy()
+	toUpdate = updateSettingSecretStringData(toUpdate, obj)
+	_, err = c.secrets.Update(toUpdate)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) secretExistsForSetting(name, ns string) (*corev1.Secret, error) {
+	obj, err := c.secretsLister.Get(ns, name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	if obj.DeletionTimestamp != nil {
+		return nil, nil
+	}
+
+	return obj, nil
+}
+
+func SetDefaultSettingSecret(name, namespace string) *corev1.Secret {
+	defaultSettingSecret := &corev1.Secret{}
+	defaultSettingSecret.Name = name
+	defaultSettingSecret.Namespace = namespace
+	defaultSettingSecret.Type = corev1.SecretTypeOpaque
+	defaultSettingSecret.Annotations = make(map[string]string)
+	defaultSettingSecret.StringData = make(map[string]string)
+	defaultSettingSecret.Annotations[settingSecretAnnotation] = "true"
+	return defaultSettingSecret
+}
+
+func updateSettingSecretStringData(secret *corev1.Secret, setting *v3.Setting) *corev1.Secret {
+	var updateValue = setting.Value
+	if updateValue == "" {
+		updateValue = setting.Default
+	}
+	stringData := map[string]string{setting.Name: updateValue}
+	secret.StringData = stringData
+	return secret
+}
+
+func find(slice []string, val string) (int, bool) {
+	for i, item := range slice {
+		if item == val {
+			return i, true
+		}
+	}
+	return -1, false
+}

--- a/pkg/controllers/user/setting/register_test.go
+++ b/pkg/controllers/user/setting/register_test.go
@@ -1,0 +1,69 @@
+package setting
+
+import (
+	"fmt"
+	"testing"
+
+	v1fakes "github.com/rancher/types/apis/core/v1/fakes"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/apis/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	ingressIpDomain      = "ingress-ip-domain"
+	ingressIpDomainValue = "foo.bar"
+	rdnsBaseURL          = "rdns-base-url"
+	rdnsBaseURLValue     = "https://foo.bar.rancher.cloud/v1"
+)
+
+func TestSecretChangeOnSettingList(t *testing.T) {
+	settings := []*v3.Setting{
+		{ObjectMeta: metav1.ObjectMeta{
+			Name: ingressIpDomain,
+		}, Value: ingressIpDomainValue},
+		{ObjectMeta: metav1.ObjectMeta{
+			Name: rdnsBaseURL,
+		}, Value: rdnsBaseURLValue},
+	}
+
+	c := Controller{
+		managementSettingLister: &fakes.SettingListerMock{
+			ListFunc: func(namespace string, selector labels.Selector) ([]*v3.Setting, error) {
+				return settings, nil
+			},
+		},
+		secretsLister: &v1fakes.SecretListerMock{
+			GetFunc: func(namespace string, name string) (*v1.Secret, error) {
+				if namespace == CattleNamespace {
+					return &v1.Secret{}, nil
+				}
+				return nil, fmt.Errorf("invalid namespace %s", namespace)
+			},
+		},
+		secrets: &v1fakes.SecretInterfaceMock{
+			UpdateFunc: func(secret *v1.Secret) (*v1.Secret, error) {
+				if value, exist := secret.StringData[ingressIpDomain]; exist {
+					if value == ingressIpDomainValue {
+						return secret, nil
+					}
+					return nil, fmt.Errorf("invalid secret data %v", secret.StringData)
+				} else if value, exist = secret.StringData[rdnsBaseURL]; exist {
+					if value == rdnsBaseURLValue {
+						return secret, nil
+					}
+					return nil, fmt.Errorf("invalid secret data %v", secret.StringData)
+				}
+				return nil, fmt.Errorf("invalid secret %v", secret)
+			},
+		},
+	}
+
+	for _, s := range settings {
+		err := c.createOrUpdate(s, CattleNamespace)
+		assert.NoError(t, err)
+	}
+}

--- a/pkg/controllers/user/settingprovider/register.go
+++ b/pkg/controllers/user/settingprovider/register.go
@@ -1,0 +1,123 @@
+package settingprovider
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	csetting "github.com/rancher/rancher/pkg/controllers/user/setting"
+	"github.com/rancher/rancher/pkg/settings"
+	v1 "github.com/rancher/types/apis/core/v1"
+	"github.com/rancher/types/config"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Register(ctx context.Context, workload *config.UserOnlyContext) error {
+	sp := &settingsProvider{
+		secrets:       workload.Core.Secrets(""),
+		secretsLister: workload.Core.Secrets("").Controller().Lister(),
+	}
+
+	if err := settings.SetProvider(sp); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type settingsProvider struct {
+	secrets       v1.SecretInterface
+	secretsLister v1.SecretLister
+	fallback      map[string]string
+}
+
+func (s *settingsProvider) Get(name string) string {
+	value := os.Getenv(settings.GetEnvKey(name))
+	if value != "" {
+		return value
+	}
+	obj, err := s.secretsLister.Get(csetting.CattleNamespace, csetting.DefaultSettingSecretName)
+	if err != nil {
+		return s.fallback[name]
+	}
+
+	if obj.Data[name] == nil {
+		return s.fallback[name]
+	}
+
+	return string(obj.Data[name])
+}
+
+func (s *settingsProvider) Set(name, value string) error {
+	envValue := os.Getenv(settings.GetEnvKey(name))
+	if envValue != "" {
+		return fmt.Errorf("setting %s can not be set because it is from environment variable", name)
+	}
+	obj, err := s.secrets.GetNamespaced(csetting.CattleNamespace, csetting.DefaultSettingSecretName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	stringData := map[string]string{name: value}
+	obj.StringData = stringData
+	_, err = s.secrets.Update(obj)
+	return err
+}
+
+func (s *settingsProvider) SetIfUnset(name, value string) error {
+	obj, err := s.secrets.GetNamespaced(csetting.CattleNamespace, csetting.DefaultSettingSecretName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if obj.Data[name] != nil {
+		return nil
+	}
+
+	obj.StringData[name] = value
+	_, err = s.secrets.Update(obj)
+	return err
+}
+
+func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error {
+	fallback := map[string]string{}
+	obj, err := s.secrets.GetNamespaced(csetting.CattleNamespace, csetting.DefaultSettingSecretName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			obj = csetting.SetDefaultSettingSecret(csetting.DefaultSettingSecretName, csetting.CattleNamespace)
+			_, err := s.secrets.Create(obj)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	stringData := make(map[string]string)
+	for name, setting := range settingsMap {
+		key := settings.GetEnvKey(name)
+		value := os.Getenv(key)
+
+		if obj.Data[name] == nil {
+			stringData[name] = setting.Default
+			if value != "" {
+				stringData[name] = value
+			}
+		} else {
+			if value != "" && string(obj.Data[name]) != value {
+				stringData[name] = value
+			}
+		}
+		fallback[name] = stringData[name]
+	}
+	obj.StringData = stringData
+	_, err = s.secrets.Update(obj)
+	if err != nil {
+		return err
+	}
+
+	s.fallback = fallback
+	return nil
+}

--- a/pkg/controllers/user/settingprovider/register_test.go
+++ b/pkg/controllers/user/settingprovider/register_test.go
@@ -1,0 +1,58 @@
+package settingprovider
+
+import (
+	"fmt"
+	"testing"
+
+	csetting "github.com/rancher/rancher/pkg/controllers/user/setting"
+	"github.com/rancher/rancher/pkg/settings"
+	v1fakes "github.com/rancher/types/apis/core/v1/fakes"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	v1b "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	ingressIpDomain      = "ingress-ip-domain"
+	ingressIpDomainValue = "foo.bar"
+	rdnsBaseURL          = "rdns-base-url"
+	rdnsBaseURLValue     = "https://foo.bar.rancher.cloud/v1"
+)
+
+func TestClusterSettingProvider(t *testing.T) {
+	testSettings := make(map[string]settings.Setting, 2)
+	testSettings[ingressIpDomain] = settings.Setting{
+		Default: ingressIpDomainValue,
+	}
+	testSettings[rdnsBaseURL] = settings.Setting{
+		Default: rdnsBaseURLValue,
+	}
+
+	sp := settingsProvider{
+		secretsLister: &v1fakes.SecretListerMock{
+			GetFunc: func(namespace string, name string) (*v1.Secret, error) {
+				if namespace == csetting.CattleNamespace {
+					return &v1.Secret{}, nil
+				}
+				return nil, fmt.Errorf("invalid namespace %s", namespace)
+			},
+		},
+		secrets: &v1fakes.SecretInterfaceMock{
+			GetNamespacedFunc: func(namespace string, name string, opts v1b.GetOptions) (*v1.Secret, error) {
+				return &v1.Secret{}, nil
+			},
+			UpdateFunc: func(secret *v1.Secret) (*v1.Secret, error) {
+				return secret, nil
+			},
+		},
+	}
+
+	err := sp.SetAll(testSettings)
+	assert.NoError(t, err)
+
+	domain := sp.Get(ingressIpDomain)
+	assert.Equal(t, ingressIpDomainValue, domain)
+
+	rdns := sp.Get(rdnsBaseURL)
+	assert.Equal(t, rdnsBaseURLValue, rdns)
+}


### PR DESCRIPTION
backport : https://github.com/rancher/rancher/pull/24138

Related Issue: https://github.com/rancher/rancher/issues/24018