### PR TITLE
change pipeline env logic

### DIFF
--- a/pkg/pipeline/engine/jenkins/convert.go
+++ b/pkg/pipeline/engine/jenkins/convert.go
@@ -215,7 +215,7 @@ StageLoop:
 		stage := c.execution.Spec.PipelineConfig.Stages[i]
 		for j := len(stage.Steps) - 1; j >= 0; j-- {
 			step := stage.Steps[j]
-			if step.PublishImageConfig != nil {
+			if step.PublishImageConfig != nil && utils.MatchAll(stage.When, c.execution) && utils.MatchAll(step.When, c.execution) {
 				config := step.PublishImageConfig
 				if config.PushRemote {
 					registry = step.PublishImageConfig.Registry


### PR DESCRIPTION
The ole version will get env from the lastest stage's lastest publish step.
But I think it should be get from the the lastest had been used stage's lastest had been used publish step.