### PR TITLE
Add GRB cleanup for deleted GR

### DIFF
--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -694,7 +694,8 @@ func GlobalRole(schemas *types.Schemas, management *config.ScaledContext) {
 
 func GlobalRoleBindings(schemas *types.Schemas, management *config.ScaledContext) {
 	schema := schemas.Schema(&managementschema.Version, client.GlobalRoleBindingType)
-	schema.Store = grbstore.Wrap(schema.Store, management.Management.GlobalRoleBindings("").Controller().Lister())
+	grLister := management.Management.GlobalRoles("").Controller().Lister()
+	schema.Store = grbstore.Wrap(schema.Store, grLister)
 }
 
 func RoleTemplate(schemas *types.Schemas, management *config.ScaledContext) {

--- a/pkg/api/store/globalrolebindings/globalrolebinding_store.go
+++ b/pkg/api/store/globalrolebindings/globalrolebinding_store.go
@@ -1,28 +1,60 @@
 package grbstore
 
 import (
+	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/values"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const GrbVersion = "field.cattle.io/grbUpgrade"
 
-func Wrap(store types.Store, grbLister v3.GlobalRoleBindingLister) types.Store {
+func Wrap(store types.Store, grLister v3.GlobalRoleLister) types.Store {
 	return &grbStore{
-		Store:     store,
-		grbLister: grbLister,
+		Store:    store,
+		grLister: grLister,
 	}
 }
 
 type grbStore struct {
 	types.Store
-	grbLister v3.GlobalRoleBindingLister
+
+	grLister v3.GlobalRoleLister
 }
 
 func (s *grbStore) Create(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}) (map[string]interface{}, error) {
+	values.PutValue(data, "true", "annotations", GrbVersion)
 
-	values.PutValue(data, "true", "metadata", "annotations", GrbVersion)
+	err := s.addOwnerReference(data)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, httperror.NewAPIError(httperror.NotFound, err.Error())
+		}
+		return nil, err
+	}
 
 	return s.Store.Create(apiContext, schema, data)
+}
+
+// addOwnerReference ensures that a globalRolebinding will be deleted when the role it references
+// is deleted
+func (s *grbStore) addOwnerReference(data map[string]interface{}) error {
+	globalRoleName, _ := data["globalRoleId"].(string)
+
+	globalRole, err := s.grLister.Get("", globalRoleName)
+	if err != nil {
+		return err
+	}
+
+	ownerReference := v1.OwnerReference{
+		APIVersion: globalRole.APIVersion,
+		Kind:       globalRole.Kind,
+		Name:       globalRole.Name,
+		UID:        globalRole.UID,
+	}
+	values.PutValue(data, []v1.OwnerReference{ownerReference}, "ownerReferences")
+
+	return nil
 }

--- a/pkg/controllers/management/auth/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalrolebinding_handler.go
@@ -36,6 +36,7 @@ func newGlobalRoleBindingLifecycle(management *config.ManagementContext) *global
 	return &globalRoleBindingLifecycle{
 		crbLister:    management.RBAC.ClusterRoleBindings("").Controller().Lister(),
 		crbClient:    management.RBAC.ClusterRoleBindings(""),
+		grbClient:    management.Management.GlobalRoleBindings(""),
 		grLister:     management.Management.GlobalRoles("").Controller().Lister(),
 		roles:        management.RBAC.Roles(""),
 		roleBindings: management.RBAC.RoleBindings(""),
@@ -46,6 +47,7 @@ type globalRoleBindingLifecycle struct {
 	crbLister    rbacv1.ClusterRoleBindingLister
 	grLister     v3.GlobalRoleLister
 	crbClient    rbacv1.ClusterRoleBindingInterface
+	grbClient    v3.GlobalRoleBindingInterface
 	roles        rbacv1.RoleInterface
 	roleBindings rbacv1.RoleBindingInterface
 }

--- a/tests/integration/suite/test_global_role_bindings.py
+++ b/tests/integration/suite/test_global_role_bindings.py
@@ -1,3 +1,6 @@
+import pytest
+
+from rancher import ApiError
 from .common import random_str
 
 
@@ -15,3 +18,19 @@ def test_cannot_update_global_role(admin_mc, remove_resource):
         id=grb.id,
         globalRoleId="settings-manage")
     assert grb.globalRoleId == "nodedrivers-manage"
+
+
+def test_globalrole_must_exist(admin_mc, remove_resource):
+    """Asserts that globalRoleId must reference an existing role"""
+    admin_client = admin_mc.client
+
+    with pytest.raises(ApiError) as e:
+        grb = admin_client.create_global_role_binding(
+            name="gr-" + random_str(),
+            globalRoleId="somefakerole",
+            userId=admin_mc.user.id
+        )
+        remove_resource(grb)
+    assert e.value.error.status == 404
+    assert "globalRole.management.cattle.io \"somefakerole\" not found" in \
+        e.value.error.message


### PR DESCRIPTION
**Problem:**
If a globalrole is deleted, globalrolebindings referencing it are left over.

**Solution:**
Add globalrole being referenced in GlobalRoleName field as an owner reference for globalrolebindings.

**Issue:**
https://github.com/rancher/rancher/issues/16216