### PR TITLE
Do not turn off monitoring/alerting from templateRevision during cluster updates.

### DIFF
--- a/tests/integration/suite/test_clustertemplate.py
+++ b/tests/integration/suite/test_clustertemplate.py
@@ -787,12 +787,14 @@ def test_update_cluster_monitoring(admin_mc, remove_resource):
     assert cluster.conditions[0].type == 'Pending'
     assert cluster.conditions[0].status == 'True'
 
-    # update cluster to use rev2 that turns of monitoring
-    # expect error
-    with pytest.raises(ApiError) as e:
-        client.update(cluster,
-                      name=cluster_name, clusterTemplateRevisionId=rev2.id)
-    assert e.value.error.status == 422
+    # update cluster to use rev2 that turns off monitoring
+    # expect no change to monitoring
+
+    client.update(cluster,
+                  name=cluster_name, clusterTemplateRevisionId=rev2.id)
+
+    reloaded_cluster = client.by_id_cluster(cluster.id)
+    assert reloaded_cluster.enableClusterMonitoring is True
 
     client.delete(cluster)
     wait_for_cluster_to_be_deleted(client, cluster.id)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/23795

This is a change to the original fix:
Earlier the fix was to throw error while upgrading to a revision that can turn off monitoring and alerting on the cluster.

Instead of erroring out, the fix now is to ignore the template revision's flag when they are false during update cluster usecase.

This will allow the cluster updates (edit cluster to change overrides or update revision) to go through but keep monitoring/alerting intact.