### PR TITLE
Already Exists Role

### DIFF
--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -737,7 +737,7 @@ func (m *manager) reconcileManagementPlaneRole(namespace string, resourceToVerbs
 		},
 		Rules: rules,
 	})
-	if err != nil {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "couldn't create role %v", rt.Name)
 	}
 


### PR DESCRIPTION
**Problem**
Controller appeared to make hard create calls even when object already existed. Cache was not updating quick enough, so check for already exists was not catching when create was called close together.  

**Solution**
Add check for IsAlreadyExists for err so that it is not returned

**Issue**
#23804