### PR TITLE
Fix resource_quota_sync deepEqual bug

### DIFF
--- a/pkg/controllers/user/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/user/resourcequota/resource_quota_sync.go
@@ -16,6 +16,7 @@ import (
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	clientcache "k8s.io/client-go/tools/cache"
@@ -100,11 +101,11 @@ func limitsChanged(existing []corev1.LimitRangeItem, toUpdate []corev1.LimitRang
 	if len(existing) == 0 || len(toUpdate) == 0 {
 		return true
 	}
-	if !reflect.DeepEqual(existing[0].DefaultRequest, toUpdate[0].DefaultRequest) {
+	if !apiequality.Semantic.DeepEqual(existing[0].DefaultRequest, toUpdate[0].DefaultRequest) {
 		return true
 	}
 
-	if !reflect.DeepEqual(existing[0].Default, toUpdate[0].Default) {
+	if !apiequality.Semantic.DeepEqual(existing[0].Default, toUpdate[0].Default) {
 		return true
 	}
 	return false
@@ -142,7 +143,7 @@ func (c *SyncController) CreateResourceQuota(ns *corev1.Namespace) (runtime.Obje
 	} else {
 		if quotaSpec == nil {
 			operation = "delete"
-		} else if quotaToUpdate != "" || !reflect.DeepEqual(existing.Spec.Hard, quotaSpec.Hard) {
+		} else if quotaToUpdate != "" || !apiequality.Semantic.DeepEqual(existing.Spec.Hard, quotaSpec.Hard) {
 			operation = "update"
 		}
 	}

--- a/pkg/controllers/user/resourcequota/resource_quota_sync_test.go
+++ b/pkg/controllers/user/resourcequota/resource_quota_sync_test.go
@@ -1,0 +1,108 @@
+package resourcequota
+
+import (
+	"reflect"
+	"testing"
+
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestLimitsChanged(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		existing []corev1.LimitRangeItem
+		toUpdate []corev1.LimitRangeItem
+		expected bool
+	}{
+		{
+			name: "limitsChange using semantic.DeepEqual",
+			existing: []corev1.LimitRangeItem{
+				{
+					Type: corev1.LimitTypePod,
+					Default: corev1.ResourceList{
+						corev1.ResourceCPU: *resource.NewQuantity(1, resource.DecimalSI),
+					},
+					DefaultRequest: corev1.ResourceList{
+						corev1.ResourceCPU: *resource.NewMilliQuantity(1000, resource.DecimalSI),
+					},
+				},
+			},
+			toUpdate: []corev1.LimitRangeItem{
+				{
+					Type: corev1.LimitTypePod,
+					Default: corev1.ResourceList{
+						corev1.ResourceCPU: *resource.NewQuantity(1, resource.DecimalSI),
+					},
+					DefaultRequest: corev1.ResourceList{
+						corev1.ResourceCPU: *resource.NewQuantity(1, resource.DecimalSI),
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		result := limitsChanged(tt.existing, tt.toUpdate)
+		assert.Equal(t, tt.expected, result)
+	}
+}
+
+func TestSemanticDeepEqual(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		method   func(x, y interface{}) bool
+		src      *v3.ResourceQuotaLimit
+		dst      *v3.ResourceQuotaLimit
+		expected bool
+	}{
+		{
+			name:   "compare ResourceQuota using reflect.DeepEqual",
+			method: reflect.DeepEqual,
+			src: &v3.ResourceQuotaLimit{
+				Pods:        "30",
+				RequestsCPU: "1000m",
+			},
+			dst: &v3.ResourceQuotaLimit{
+				Pods:        "30",
+				RequestsCPU: "1",
+			},
+			expected: false,
+		},
+		{
+			name:   "compare ResourceQuota using semantic.DeepEqual",
+			method: apiequality.Semantic.DeepEqual,
+			src: &v3.ResourceQuotaLimit{
+				Pods:        "30",
+				RequestsCPU: "1000m",
+			},
+			dst: &v3.ResourceQuotaLimit{
+				Pods:        "30",
+				RequestsCPU: "1",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		srcResourceList, err := convertProjectResourceLimitToResourceList(tt.src)
+		if err != nil {
+			t.Error(err)
+		}
+
+		dstResourceList, err := convertProjectResourceLimitToResourceList(tt.dst)
+		if err != nil {
+			t.Error(err)
+		}
+
+		result := tt.method(srcResourceList, dstResourceList)
+		assert.Equal(t, tt.expected, result)
+	}
+
+}


### PR DESCRIPTION
## Problem(#24502)
Using `reflect.DeepEqual` to compare `resource.Quantity` can lead to the compare results are not expected. This problem is particularly acute when setting CPU related quotas. [Code Line 1](https://github.com/rancher/rancher/blob/master/pkg/controllers/user/resourcequota/resource_quota_sync.go#L103-L109) [Code Line 2](
https://github.com/rancher/rancher/blob/master/pkg/controllers/user/resourcequota/resource_quota_sync.go#L145)

## Solution
Using `k8s.io/apimachinery/pkg/api/equality` [Sementic](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/equality/semantic.go#L31) Ignore formatting, only care that numeric value stayed the same. [References kubernetes quotaController code](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/resourcequota/resource_quota_controller.go#L214)





