### PR TITLE
Exclude unrelated namespaces when validate namespace's quota

### DIFF
--- a/pkg/api/store/namespace/store.go
+++ b/pkg/api/store/namespace/store.go
@@ -134,7 +134,7 @@ func (p *Store) validateResourceQuota(apiContext *types.APIContext, schema *type
 	var namespaces []clusterclient.Namespace
 	options := &types.QueryOptions{
 		Conditions: []*types.QueryCondition{
-			types.NewConditionFromString("projectId", types.ModifierEQ, convert.ToString(data["projectId"])),
+			types.NewConditionFromString("projectId", types.ModifierEQ, projectID),
 		},
 	}
 	if err := access.List(apiContext, &schema.Version, clusterclient.NamespaceType, options, &namespaces); err != nil {


### PR DESCRIPTION
## Problem (#24479)
The `data["projectId"]` value is empty when updates namespace with `ResourceQuota`, this cause `validateResourceQuota ` function aggregate some unexpected namespaces for validate.
## Solution
Change `data["projectId"]` to `projectID` variable.

## Validation Test PR

https://github.com/rancher/rancher/pull/24550