### PR TITLE
Set maxSurge and maxUnavailable to 1 to allow rolling upgrades when antiAffinity is set to required

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -12,6 +12,11 @@ spec:
   selector:
     matchLabels:
       app: {{ template "rancher.fullname" . }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Fix for issue https://github.com/rancher/rancher/issues/24518