### PR TITLE
Fix for cluster driver reset

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -670,13 +670,13 @@ func (p *Provisioner) getConfig(reconcileRKE bool, spec v3.ClusterSpec, driverNa
 	return &spec, v, nil
 }
 
-func (p *Provisioner) getDriver(cluster *v3.Cluster) (string, error) {
+func GetDriver(cluster *v3.Cluster, driverLister v3.KontainerDriverLister) (string, error) {
 	var driver *v3.KontainerDriver
 	var err error
 
 	if cluster.Spec.GenericEngineConfig != nil {
 		kontainerDriverName := (*cluster.Spec.GenericEngineConfig)["driverName"].(string)
-		driver, err = p.KontainerDriverLister.Get("", kontainerDriverName)
+		driver, err = driverLister.Get("", kontainerDriverName)
 		if err != nil {
 			return "", err
 		}
@@ -700,7 +700,7 @@ func (p *Provisioner) validateDriver(cluster *v3.Cluster) (string, error) {
 		return v3.ClusterDriverImported, nil
 	}
 
-	newDriver, err := p.getDriver(cluster)
+	newDriver, err := GetDriver(cluster, p.KontainerDriverLister)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
There can be a situation when the `cluster.status.driver` field remains empty on rke clusters even after the cluster is provisioned. The issue was addressed by @rmweir in the following commit:

https://github.com/rancher/rancher/commit/03dd1256a789ccb11299c3edea23549466a0cb04

This particular PR is to address the issue when cluster-agent on its connect sets the `cluster.status.driver` field to "imported" if the field is empty. That results in provisioning code never being invoked on subsequent cluster updates for rke clusters. 

The fix introduces a check for figuring out if the cluster really qualifies for imported, before marking it this way. So if you are upgrading from the older version of rancher where the `cluster.status.driver`  is already set to "" on rke cluster(s), it will never get reset by the agent code.