### PR TITLE
Refresh credentials on node removal

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -43,10 +43,6 @@ const (
 	amazonec2               = "amazonec2"
 )
 
-var (
-	falseValue = false
-)
-
 // aliases maps Schema field => driver field
 // The opposite of this lives in pkg/controllers/management/drivers/nodedriver/machine_driver.go
 var aliases = map[string]map[string]string{
@@ -154,6 +150,18 @@ func (m *Lifecycle) Create(obj *v3.Node) (runtime.Object, error) {
 	}
 
 	newObj, err := v3.NodeConditionInitialized.Once(obj, func() (runtime.Object, error) {
+		nodeConfig, err := nodeconfig.NewNodeConfig(m.secretStore, obj)
+		if err != nil {
+			return obj, errors.Wrap(err, "failed to create node driver config")
+		}
+
+		defer nodeConfig.Cleanup()
+
+		err = m.refreshNodeConfig(nodeConfig, obj)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "unable to create config for node %v", obj.Name)
+		}
+
 		template, err := m.getNodeTemplate(obj.Spec.NodeTemplateName)
 		if err != nil {
 			return obj, err
@@ -167,40 +175,14 @@ func (m *Lifecycle) Create(obj *v3.Node) (runtime.Object, error) {
 			obj.Status.NodeTemplateSpec.EngineInstallURL = defaultEngineInstallURL
 		}
 
-		rawTemplate, err := m.nodeTemplateGenericClient.GetNamespaced(template.Namespace, template.Name, metav1.GetOptions{})
-		if err != nil {
-			return obj, err
-		}
-		data := rawTemplate.(*unstructured.Unstructured).Object
-		rawConfig, ok := values.GetValue(data, template.Spec.Driver+"Config")
-		if !ok {
-			return obj, fmt.Errorf("node config not specified")
-		}
-		if template.Spec.Driver == amazonec2 {
-			setEc2ClusterIDTag(rawConfig, obj.Namespace)
-		}
-		if err := m.updateRawConfigFromCredential(data, rawConfig, template); err != nil {
-			return obj, err
-		}
-		bytes, err := json.Marshal(rawConfig)
-		if err != nil {
-			return obj, errors.Wrap(err, "failed to marshal node driver config")
-		}
 		if !m.devMode {
 			err := jailer.CreateJail(obj.Namespace)
 			if err != nil {
 				return nil, errors.WithMessage(err, "node create jail error")
 			}
 		}
-		config, err := nodeconfig.NewNodeConfig(m.secretStore, obj)
-		if err != nil {
-			return obj, errors.Wrap(err, "failed to save node driver config")
-		}
-		defer config.Cleanup()
 
-		config.SetDriverConfig(string(bytes))
-
-		return obj, config.Save()
+		return obj, nil
 	})
 
 	return newObj.(*v3.Node), err
@@ -241,10 +223,17 @@ func (m *Lifecycle) Remove(obj *v3.Node) (runtime.Object, error) {
 		if err != nil {
 			return obj, err
 		}
+
 		if err := config.Restore(); err != nil {
 			return obj, err
 		}
+
 		defer config.Remove()
+
+		err = m.refreshNodeConfig(config, obj)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "unable to refresh config for node %v", obj.Name)
+		}
 
 		mExists, err := nodeExists(config.Dir(), obj)
 		if err != nil {
@@ -413,6 +402,11 @@ func (m *Lifecycle) ready(obj *v3.Node) (*v3.Node, error) {
 		return obj, err
 	}
 
+	err = m.refreshNodeConfig(config, obj)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "unable to refresh config for node %v", obj.Name)
+	}
+
 	driverConfig, err := config.DriverConfig()
 	if err != nil {
 		return nil, err
@@ -551,6 +545,63 @@ func (m *Lifecycle) saveConfig(config *nodeconfig.NodeConfig, nodeDir string, ob
 	obj.Status.NodeConfig.Taints = taints.GetRKETaintsFromTaints(expectTaints)
 
 	return obj, nil
+}
+
+func (m *Lifecycle) refreshNodeConfig(nc *nodeconfig.NodeConfig, obj *v3.Node) error {
+	template, err := m.getNodeTemplate(obj.Spec.NodeTemplateName)
+	if err != nil {
+		return err
+	}
+
+	rawTemplate, err := m.nodeTemplateGenericClient.GetNamespaced(template.Namespace, template.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	data := rawTemplate.(*unstructured.Unstructured).Object
+	rawConfig, ok := values.GetValue(data, template.Spec.Driver+"Config")
+	if !ok {
+		return fmt.Errorf("node config not specified for node %v", obj.Name)
+	}
+
+	if err := m.updateRawConfigFromCredential(data, rawConfig, template); err != nil {
+		return err
+	}
+
+	var update bool
+
+	if template.Spec.Driver == amazonec2 {
+		setEc2ClusterIDTag(rawConfig, obj.Namespace)
+		logrus.Debug("[refreshNodeConfig] Updating amazonec2 machine config")
+		//TODO: Update to not be amazon specific, this needs to be moved to the driver
+		update, err = nc.UpdateAmazonAuth(rawConfig)
+		if err != nil {
+			return err
+		}
+	}
+
+	bytes, err := json.Marshal(rawConfig)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal node driver config")
+	}
+
+	newConfig := string(bytes)
+
+	currentConfig, err := nc.DriverConfig()
+	if err != nil {
+		return err
+	}
+
+	if currentConfig != newConfig || update {
+		err = nc.SetDriverConfig(string(bytes))
+		if err != nil {
+			return err
+		}
+
+		return nc.Save()
+	}
+
+	return nil
 }
 
 func (m *Lifecycle) isNodeInAppliedSpec(node *v3.Node) (bool, error) {


### PR DESCRIPTION
Problem:
The same credential used to create a node is used to delete it so if a
cloud cred is updated or keys rotated nodes will leak

Solution:
Before doing an update or delete of a node rebuild the credentials using
the latest cloud cred referenced in the template

https://github.com/rancher/rancher/issues/24234