### PR TITLE
[v2.3] Add api group name to apiversion

### DIFF
--- a/pkg/controllers/management/globaldns/globaldns_handler.go
+++ b/pkg/controllers/management/globaldns/globaldns_handler.go
@@ -148,7 +148,7 @@ func (n *GDController) generateNewIngressSpec(globaldns *v3.GlobalDNS) *v1beta1.
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Name:       globaldns.Name,
-					APIVersion: "v3",
+					APIVersion: globaldns.APIVersion,
 					UID:        globaldns.UID,
 					Kind:       globaldns.Kind,
 					Controller: &controller,

--- a/pkg/controllers/management/globaldns/globaldnsprovider_catalog_launcher.go
+++ b/pkg/controllers/management/globaldns/globaldnsprovider_catalog_launcher.go
@@ -217,7 +217,7 @@ func (n *ProviderCatalogLauncher) createUpdateExternalDNSApp(obj *v3.GlobalDNSPr
 		controller := true
 		ownerRef := []metav1.OwnerReference{{
 			Name:       obj.Name,
-			APIVersion: "v3",
+			APIVersion: obj.APIVersion,
 			UID:        obj.UID,
 			Kind:       obj.Kind,
 			Controller: &controller,


### PR DESCRIPTION
**Problem**
APIVersions for `github.com/rancher/types/apis/management.cattle.io/v3` were being listed at `APIVersion: "v3"`. It is common practice to list `<GROUP_NAME>/<VERSION>` as the value for APIVersion. 

**Solution**
Update APIVersion to include group name in the version. Example `APIVersion: "v3"` >> `APIVersion: "management.cattle.io/v3`

**Issue**
#24294 