### PR TITLE
[flakey test][forwardport] Ensure error state

### DIFF
--- a/tests/integration/suite/test_catalog.py
+++ b/tests/integration/suite/test_catalog.py
@@ -1,6 +1,7 @@
 import pytest
 import time
 from rancher import ApiError
+from .conftest import wait_for
 
 from .common import wait_for_template_to_be_created, \
     wait_for_template_to_be_deleted, random_str, wait_for_atleast_workload
@@ -291,7 +292,6 @@ def test_invalid_catalog_charts(admin_mc, remove_resource):
     client = admin_mc.client
     name = random_str()
     url = "https://github.com/rancher/integration-test-charts"
-
     catalog = client.create_catalog(name=name,
                                     branch="broke-charts",
                                     url=url,
@@ -299,14 +299,20 @@ def test_invalid_catalog_charts(admin_mc, remove_resource):
     remove_resource(catalog)
     wait_for_template_to_be_created(client, catalog.id)
 
-    catalog = client.reload(catalog)
+    def get_errored_catalog(catalog):
+        catalog = client.reload(catalog)
+        if catalog.transitioning == "error":
+            return catalog
+        return None
+    catalog = wait_for(lambda: get_errored_catalog(catalog),
+                       fail_handler=lambda:
+                       "catalog was not found in error state")
     templates = client.list_template(catalogId=catalog.id).data
 
     assert "areallylongnamelikereallyreallylongwestillneedmorez234dasdfasd"\
         not in templates
     assert "bad-chart_name" not in templates
     assert catalog.state == "refreshed"
-    assert catalog.transitioning == "error"
     assert catalog.transitioningMessage == "Error syncing catalog " + name
     # this will break if github repo changes
     assert len(templates) == 6


### PR DESCRIPTION
**Problem**
Test was occasionally getting information from chart when it was retrying and not in error state

**Solution**
Ensure the catalog is in refreshed error and not refreshed syncing when assertions on ran

**Issue**
#24446