### PR TITLE
Set 755 on the ssl dir so that etcd user can read the cert files

### DIFF
--- a/package/run.sh
+++ b/package/run.sh
@@ -115,10 +115,10 @@ set_certs_dir_permissions()
     masked=0
     getfacl -p $certs_dir | grep -q mask::r-x || masked=1
     if [ $masked -eq 0 ]; then
-        chmod 700 $certs_dir
+        chmod 755 $certs_dir
         setfacl -R -m m::rX $certs_dir
     else
-        chmod 700 $certs_dir
+        chmod 755 $certs_dir
     fi
 }
 


### PR DESCRIPTION
reverting https://github.com/rancher/rancher/pull/22220/

This change is reverting the permissions set by rke-tools in this PR https://github.com/rancher/rke-tools/pull/88

We no longer set the acls on the files, hence this change is no longer needed.