### PR TITLE
Check token in SearhPrincipals to avoid panic

### DIFF
--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -142,6 +142,12 @@ func GetPrincipal(principalID string, myToken v3.Token) (v3.Principal, error) {
 }
 
 func SearchPrincipals(name, principalType string, myToken v3.Token) ([]v3.Principal, error) {
+	if myToken.AuthProvider == "" {
+		return []v3.Principal{}, fmt.Errorf("[SearchPrincipals] no authProvider specified in token")
+	}
+	if providers[myToken.AuthProvider] == nil {
+		return []v3.Principal{}, fmt.Errorf("[SearchPrincipals] authProvider %v not initialized", myToken.AuthProvider)
+	}
 	principals, err := providers[myToken.AuthProvider].SearchPrincipals(name, principalType, myToken)
 	if err != nil {
 		return principals, err


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/20159
The panic will occur only if the authProvider field on token is empty or the provider isn't configured.
Not sure why either of this would happen. But this commit will avoid panic and error will indicate what was causing it.