### PR TITLE
Preserve nested membership on refetch principals

### DIFF
--- a/pkg/auth/providers/googleoauth/goauth_provider.go
+++ b/pkg/auth/providers/googleoauth/goauth_provider.go
@@ -270,7 +270,14 @@ func (g *googleOauthProvider) RefetchGroupPrincipals(principalID string, secret 
 		return principals, err
 	}
 	logrus.Debugf("[Google OAuth] GetPrincipal: Parsed principalID")
-	return g.getGroupsUserBelongsTo(adminSvc, externalID, config.Hostname, config)
+	groupPrincipals, err := g.getGroupsUserBelongsTo(adminSvc, externalID, config.Hostname, config)
+	if err != nil {
+		return principals, err
+	}
+	if !config.NestedGroupMembershipEnabled {
+		return groupPrincipals, nil
+	}
+	return g.fetchParentGroups(config, groupPrincipals, adminSvc, config.Hostname)
 }
 
 func (g *googleOauthProvider) CanAccessWithGroupProviders(userPrincipalID string, groupPrincipals []v3.Principal) (bool, error) {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/24334
The refetch groups api for google auth wasn't checking if the nested
group membership option was enabled. This commit adds that check
to ensure nested group membership is preserved on refetch api