### PR TITLE
generate correct registry auth for private registry

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -375,12 +375,7 @@ func (m *Lifecycle) deployAgent(nodeDir string, obj *v3.Node) error {
 		return err
 	}
 
-	cluster, err := m.clusterLister.Get("", obj.Namespace)
-	if err != nil {
-		return err
-	}
-
-	drun := clusterregistrationtokens.NodeCommand(token, cluster)
+	drun := clusterregistrationtokens.NodeCommand(token, nil)
 	args := buildAgentCommand(obj, drun)
 	cmd, err := buildCommand(nodeDir, obj, args)
 	if err != nil {


### PR DESCRIPTION
Issues: 
- incorrect value of registry auth is passed so worker nodes can't create process 
- nodes created via docker-machine cannot use private registry credentials, so new node creation fails 

PR fixes: 
- registry auth creation 
- deployAgent should only use System default registry to append to agent-image 

https://github.com/rancher/rancher/issues/20029