### PR TITLE
Fix the problem Monitoring - app and namespace are left when deleting the project

### DIFF
--- a/pkg/app/utils/utils.go
+++ b/pkg/app/utils/utils.go
@@ -18,7 +18,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func EnsureAppProjectName(userNSClient v1.NamespaceInterface, ownedProjectID, clusterName, appTargetNamespace string) (string, error) {
+const (
+	creatorIDAnno = "field.cattle.io/creatorId"
+)
+
+func EnsureAppProjectName(userNSClient v1.NamespaceInterface, ownedProjectID, clusterName, appTargetNamespace, creatorID string) (string, error) {
 	// detect Namespace
 	deployNamespace, err := userNSClient.Get(appTargetNamespace, metav1.GetOptions{})
 	if err != nil && !kerrors.IsNotFound(err) {
@@ -33,7 +37,8 @@ func EnsureAppProjectName(userNSClient v1.NamespaceInterface, ownedProjectID, cl
 	} else {
 		deployNamespace = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: appTargetNamespace,
+				Name:        appTargetNamespace,
+				Annotations: map[string]string{creatorIDAnno: creatorID},
 			},
 		}
 

--- a/pkg/controllers/user/cis/clusterScanHandler.go
+++ b/pkg/controllers/user/cis/clusterScanHandler.go
@@ -239,12 +239,11 @@ func (csh *cisScanHandler) deployApp(appInfo *appInfo) error {
 		return err
 	}
 
-	appProjectName, err := utils.EnsureAppProjectName(csh.userCtxNSClient, appDeployProjectID, appInfo.clusterName, v3.DefaultNamespaceForCis)
+	creator, err := csh.systemAccountManager.GetSystemUser(appInfo.clusterName)
 	if err != nil {
 		return err
 	}
-
-	creator, err := csh.systemAccountManager.GetSystemUser(appInfo.clusterName)
+	appProjectName, err := utils.EnsureAppProjectName(csh.userCtxNSClient, appDeployProjectID, appInfo.clusterName, v3.DefaultNamespaceForCis, creator.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -157,12 +157,17 @@ func (ch *clusterHandler) doSync(cluster *mgmtv3.Cluster) error {
 }
 
 func (ch *clusterHandler) ensureAppProjectName(clusterID, appTargetNamespace string) (string, error) {
+	creator, err := ch.app.systemAccountManager.GetSystemUser(ch.clusterName)
+	if err != nil {
+		return "", err
+	}
+
 	appDeployProjectID, err := utils.GetSystemProjectID(clusterID, ch.app.projectLister)
 	if err != nil {
 		return "", err
 	}
 
-	appProjectName, err := utils.EnsureAppProjectName(ch.app.agentNamespaceClient, appDeployProjectID, clusterID, appTargetNamespace)
+	appProjectName, err := utils.EnsureAppProjectName(ch.app.agentNamespaceClient, appDeployProjectID, clusterID, appTargetNamespace, creator.Name)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controllers/user/monitoring/operatorHandler.go
+++ b/pkg/controllers/user/monitoring/operatorHandler.go
@@ -156,7 +156,12 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) (backErr erro
 		return errors.Wrap(err, "failed to get System Project ID")
 	}
 
-	appProjectName, err := utils.EnsureAppProjectName(app.agentNamespaceClient, appDeployProjectID, cluster.Name, appTargetNamespace)
+	creator, err := app.systemAccountManager.GetSystemUser(cluster.Name)
+	if err != nil {
+		return err
+	}
+
+	appProjectName, err := utils.EnsureAppProjectName(app.agentNamespaceClient, appDeployProjectID, cluster.Name, appTargetNamespace, creator.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to ensure monitoring project name")
 	}
@@ -184,11 +189,6 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) (backErr erro
 	// cannot overwrite mustAppAnswers
 	for mustKey, mustVal := range mustAppAnswers {
 		appAnswers[mustKey] = mustVal
-	}
-
-	creator, err := app.systemAccountManager.GetSystemUser(cluster.Name)
-	if err != nil {
-		return err
 	}
 
 	annotations := map[string]string{

--- a/pkg/controllers/user/monitoring/projectHandler.go
+++ b/pkg/controllers/user/monitoring/projectHandler.go
@@ -132,7 +132,12 @@ func (ph *projectHandler) doSync(project *mgmtv3.Project, clusterName string) er
 }
 
 func (ph *projectHandler) ensureAppProjectName(appTargetNamespace string, project *mgmtv3.Project) (string, error) {
-	appProjectName, err := utils.EnsureAppProjectName(ph.app.agentNamespaceClient, project.Name, project.Spec.ClusterName, appTargetNamespace)
+	creator, err := ph.app.systemAccountManager.GetProjectSystemUser(project.Name)
+	if err != nil {
+		return "", err
+	}
+
+	appProjectName, err := utils.EnsureAppProjectName(ph.app.agentNamespaceClient, project.Name, project.Spec.ClusterName, appTargetNamespace, creator.Name)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Problem:

Monitoring - app and namespace are left when deleting the project

Solution:

If the namespace's creatorID is null, it wouldn't remove the namespace when deleting the project.
https://github.com/rancher/rancher/blame/fa26eccdb1ec6d9065877340f6b90ef374969adf/pkg/controllers/user/rbac/project_handler.go#L66
so add parameter creatorID for function EnsureAppProjectName can fix it.

Related Issue: 

https://github.com/rancher/rancher/issues/23848