### PR TITLE
automation - run tests on multiple OS and Docker version

### DIFF
--- a/tests/validation/lib/aws.py
+++ b/tests/validation/lib/aws.py
@@ -32,6 +32,10 @@ PRIVATE_IMAGES = {
         'image': 'ami-00769ca587d8e100c', 'ssh_user': 'rancher'},
     "rhel-7.6-docker-native-113": {
         'image': 'ami-04b9aacf7e1512c0b', 'ssh_user': 'ec2-user'},
+    "rhel-7.7-docker-native-113": {
+        'image': 'ami-069569219156fdf07', 'ssh_user': 'ec2-user'},
+    "rhel-7.7-docker-19.03": {
+        'image': 'ami-068182ee3b273d6ec', 'ssh_user': 'ec2-user'},
     "suse-sles12-sp2-docker-18061ce": {
         'image': 'ami-0cc154aeb82bd8fa0', 'ssh_user': 'ec2-user'},
     "ubuntu-16.04-docker-18.09": {

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_custom_cluster_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_custom_cluster_matrix
@@ -1,0 +1,134 @@
+#!groovy
+
+// RANCHER_VERSION resolution is first via Jenkins Build Parameter RANCHER_VERSION fed in from console,
+// then from $DOCKER_TRIGGER_TAG which is sourced from the Docker Hub Jenkins plugin webhook.
+def rancher_version() {
+  try { if ('' != RANCHER_VERSION) { return RANCHER_VERSION } }
+  catch (MissingPropertyException e) {}
+
+  try { return DOCKER_TRIGGER_TAG }
+  catch (MissingPropertyException e) {}
+
+  echo  'Neither RANCHER_VERSION nor DOCKER_TRIGGER_TAG have been specified!'
+  error()
+}
+
+node {
+  def TESTS_TO_RUN =  [ "test_wl", "test_dns_record", "test_rbac","test_connectivity", "test_ingress",
+                        "test_secrets", "test_registry", "test_service_discovery"]
+
+  if (env.RANCHER_SKIP_INGRESS == "True") { 
+    TESTS_TO_RUN = TESTS_TO_RUN - ["test_ingress"]
+  }
+  // convert the list into pytest parameter format 
+  def PYTEST_OPTIONS = "-k \"" + TESTS_TO_RUN.join(" or ") +"\""
+
+  // set the branch for the testing code
+  def branch = "master"
+  if ("${env.branch}" != "null" && "${env.branch}" != "") {
+    branch = "${env.branch}"
+  }
+  println "Branch env: ${env.branch}"
+  println "Branch: ${branch}"
+
+  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+    withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                      string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+                      string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'RANCHER_EKS_ACCESS_KEY'),
+                      string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'RANCHER_EKS_SECRET_KEY'),
+                      string(credentialsId: 'DO_ACCESSKEY', variable: 'DO_ACCESSKEY'),
+                      string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                      string(credentialsId: 'RANCHER_SSH_KEY', variable: 'RANCHER_SSH_KEY'),
+                      string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                      string(credentialsId: 'AZURE_TENANT_ID', variable: 'AZURE_TENANT_ID'), 
+                      string(credentialsId: 'AZURE_CLIENT_ID', variable: 'AZURE_CLIENT_ID'),
+                      string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'AZURE_CLIENT_SECRET'),
+                      string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'RANCHER_AKS_SUBSCRIPTION_ID'),
+                      string(credentialsId: 'AZURE_TENANT_ID', variable: 'RANCHER_AKS_TENANT_ID'), 
+                      string(credentialsId: 'AZURE_CLIENT_ID', variable: 'RANCHER_AKS_CLIENT_ID'),
+                      string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'RANCHER_AKS_SECRET_KEY'),
+                      string(credentialsId: 'RANCHER_REGISTRY_USER_NAME', variable: 'RANCHER_REGISTRY_USER_NAME'),
+                      string(credentialsId: 'RANCHER_REGISTRY_PASSWORD', variable: 'RANCHER_REGISTRY_PASSWORD'),
+                      string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD'),
+                      string(credentialsId: 'RANCHER_GKE_CREDENTIAL', variable: 'RANCHER_GKE_CREDENTIAL')]) {
+      stage('Checkout') {
+        deleteDir()
+        checkout([
+                  $class: 'GitSCM',
+                  branches: [[name: "*/${branch}"]],
+                  extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                  userRemoteConfigs: scm.userRemoteConfigs
+                ])
+      }
+      // change the current directory
+      dir ("tests/validation") {
+        stage('Configure and Build') {
+          if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
+            dir(".ssh") {
+              def decoded = new String(env.AWS_SSH_PEM_KEY.decodeBase64())
+              writeFile file: env.AWS_SSH_KEY_NAME, text: decoded
+            }
+          }
+          sh "./tests/v3_api/scripts/configure.sh"
+          sh "./tests/v3_api/scripts/build.sh"
+        }
+
+        stage('install Rancher') {
+          // skip provisioning a new Rancher Server 
+          // if CATTLE_TEST_URL, ADMIN_TOKEN, USER_TOKEN are provided
+          if(env.CATTLE_TEST_URL != "" || env.ADMIN_TOKEN != "" || env.USER_TOKEN != "") {
+            println "Rancher Server is provided: ${env.CATTLE_TEST_URL}"
+          }
+          else {
+            def rancherContainerName = "${JOB_NAME}${env.BUILD_NUMBER}_rancher_server"
+            def envFile = ".env"
+            def imageName = "rancher-validation-${JOB_NAME}${env.BUILD_NUMBER}"
+            def rancher_version = rancher_version()
+            def deployPytestOptions = "-k test_deploy_rancher_server"
+            def setupResultsOut = "setup-results.xml"
+            def testResultsOut = "results.xml"
+            def testsDir = "tests/v3_api/"
+            def rancherConfig = "rancher_env.config"
+            def rootPath = "/src/rancher-validation/"
+            // deploy rancher server
+            sh "docker run --name ${rancherContainerName} -t --env-file ${envFile} " +
+              "${imageName} /bin/bash -c \'export RANCHER_SERVER_VERSION=${rancher_version} && " +
+              "pytest -v -s --junit-xml=${setupResultsOut} " +
+              "${deployPytestOptions} ${testsDir}\'"
+
+            // copy file containing CATTLE_TEST_URL, ADMIN_TOKEN, USER_TOKEN 
+            // and load into environment variables
+            sh "docker cp ${rancherContainerName}:${rootPath}${testsDir}${rancherConfig} ."
+            load rancherConfig
+            println "Rancher Server ip: ${env.CATTLE_TEST_URL}"
+          }
+        }
+        
+        stage('run subjobs in parallel') {
+          try {
+              jobs = [:]
+              // get the list of versions
+              def versions = RANCHER_CLUSTER_OS_DOCKER_VERSION.split(',')
+              for(int i = 0; i < versions.size(); i++) {
+                def version = versions[i].trim()
+                def params = [
+                      string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"),
+                      string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}"),
+                      string(name: 'USER_TOKEN', value: "${USER_TOKEN}"),
+                      string(name: 'RANCHER_SERVER_VERSION', value: "${rancher_version}"), 
+                      string(name: 'BRANCH', value: branch),
+                      string(name: 'RANCHER_OS_DOCKER_VERSION', value: "${version}"),
+                      string(name: 'DOCKER_INSTALLED', value: "${DOCKER_INSTALLED}")
+                      ]
+                println "parameters: ${params}"
+                jobs["${version}"] = { build job: 'rancher-v3_ontag_custom_certification', parameters: params }
+              }
+              parallel jobs
+          } catch(err) {
+              echo "Error: " + err
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/24722

Add a pipeline file that can 
- run Rancher server
- provision clusters with different OS and docker version
- run tests on those clusters

Add the following two private images:

- RHEL7.7_Native_Docker_1.13.1
- RHEL7.7_Upstream_Docker_19.03