### PR TITLE
introduce env var rancher_metadata_branch 

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -14,6 +14,8 @@ WORKDIR /var/lib/rancher
 ARG ARCH=amd64
 ARG IMAGE_REPO=rancher
 ARG SYSTEM_CHART_DEFAULT_BRANCH=v2.3-dev
+# kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go  
+ARG RANCHER_METADATA_BRANCH=
 
 ENV CATTLE_SYSTEM_CHART_DEFAULT_BRANCH=$SYSTEM_CHART_DEFAULT_BRANCH
 ENV CATTLE_HELM_VERSION v2.14.3-rancher1
@@ -26,6 +28,7 @@ ENV TELEMETRY_VERSION v0.5.10
 ENV KUBECTL_VERSION v1.16.1
 ENV DOCKER_MACHINE_LINODE_VERSION v0.1.8
 ENV LINODE_UI_DRIVER_VERSION v0.3.0
+ENV RANCHER_METADATA_BRANCH ${RANCHER_METADATA_BRANCH}
 
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/library && \

--- a/pkg/catalog/git/git.go
+++ b/pkg/catalog/git/git.go
@@ -41,7 +41,10 @@ func RemoteBranchHeadCommit(url, branch string) (string, error) {
 		return "", errors.Wrap(err, string(output))
 	}
 	parts := strings.Split(string(output), "\t")
-	return parts[0], nil
+	if len(parts) > 0 && len(parts[0]) > 0 {
+		return parts[0], nil
+	}
+	return "", fmt.Errorf("no commit found for url %s branch %s", branch, url)
 }
 
 func IsValid(url string) bool {

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -154,9 +154,12 @@ func GetEnvKey(key string) string {
 func getMetadataConfig() string {
 	key := GetEnvKey("server-version")
 	rancherVersion := os.Getenv(key)
-	branch := "dev"
-	if releaseServerVersion(rancherVersion) {
-		branch = "master"
+	branch := os.Getenv("RANCHER_METADATA_BRANCH")
+	if branch == "" {
+		branch = "dev"
+		if releaseServerVersion(rancherVersion) {
+			branch = "master"
+		}
 	}
 	data := map[string]interface{}{
 		"url":                      "https://github.com/rancher/kontainer-driver-metadata.git",


### PR DESCRIPTION
- allow metadata branch to be set via env var `RANCHER_METADATA_BRANCH` 
- need to return error if commit is not found while loading data 

https://github.com/rancher/rancher/issues/24743