### PR TITLE
[2.3] Downstream Agent Tracking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.3-0.20190906213150-8b3983d91ed6
 	github.com/rancher/rke v1.0.1-rc3.0.20191223214100-cc03007e3777
-	github.com/rancher/types v0.0.0-20191220141556-ad31d6815bbd
+	github.com/rancher/types v0.0.0-20191226170233-4d49bbf42146
 	github.com/rancher/wrangler v0.1.6-0.20190822171720-e78d8316ee95
 	github.com/robfig/cron v1.1.0
 	github.com/russellhaering/goxmldsig v0.0.0-20180122054445-a348271703b2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -668,6 +668,8 @@ github.com/rancher/types v0.0.0-20190930165650-6bbedae77a35/go.mod h1:I0hSpsw/Zv
 github.com/rancher/types v0.0.0-20191115181915-fa1ec441252a/go.mod h1:K5zlxVpe7bY2QgOs1YUcU8dVXtzKncxpGEcvxGMgr0k=
 github.com/rancher/types v0.0.0-20191220141556-ad31d6815bbd h1:7wlqMFfCZKvcsC7CMF1u0+3Lo7S5VE/SfN3k8CcLi8I=
 github.com/rancher/types v0.0.0-20191220141556-ad31d6815bbd/go.mod h1:yYtjxRexsviS9aPO0qp1gqnMSLRRoe0JW6Mqu1EbJZM=
+github.com/rancher/types v0.0.0-20191226170233-4d49bbf42146 h1:4o0FbrWDEvMln+darsGgErpByxQEyx535C+gn8ScPIs=
+github.com/rancher/types v0.0.0-20191226170233-4d49bbf42146/go.mod h1:yYtjxRexsviS9aPO0qp1gqnMSLRRoe0JW6Mqu1EbJZM=
 github.com/rancher/wrangler v0.1.5 h1:HiXOeP6Kci2DK+e04D1g6INT77xAYpAr54zmTTe0Spk=
 github.com/rancher/wrangler v0.1.5/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rancher/wrangler v0.1.6-0.20190822171720-e78d8316ee95 h1:/yghR1MGJk6l6CVxJSx9JGBFP1D6NchJ74wJz7JwxC4=

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/rancher/norman/types"
@@ -20,12 +21,26 @@ import (
 	"github.com/rancher/types/config"
 	"github.com/rancher/types/user"
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-const AgentForceDeployAnn = "io.cattle.agent.force.deploy"
+const (
+	AgentForceDeployAnn = "io.cattle.agent.force.deploy"
+	nodeImage           = "nodeImage"
+	clusterImage        = "clusterImage"
+)
+
+var (
+	agentImagesMutex sync.RWMutex
+	agentImages      = map[string]map[string]string{
+		nodeImage:    map[string]string{},
+		clusterImage: map[string]string{},
+	}
+)
 
 func Register(ctx context.Context, management *config.ManagementContext, clusterManager *clustermanager.Manager) {
 	c := &clusterDeploy{
@@ -101,6 +116,13 @@ func (cd *clusterDeploy) doSync(cluster *v3.Cluster) error {
 	if err != nil {
 		return err
 	}
+
+	if cluster.Status.AgentImage != "" && !agentImagesCached(cluster.Name) {
+		if err := cd.cacheAgentImages(cluster.Name); err != nil {
+			return err
+		}
+	}
+
 	err = cd.deployAgent(cluster)
 	if err != nil {
 		return err
@@ -130,15 +152,33 @@ func redeployAgent(cluster *v3.Cluster, desiredAgent, desiredAuth string) bool {
 	}
 
 	if forceDeploy || imageChange || repoChange {
-		logrus.Infof("Redeploy Rancher Agents is needed: forceDeploy=%v, agent/auth image changed=%v,"+
-			" private repo changed=%v", forceDeploy, imageChange, repoChange)
+		logrus.Infof("Redeploy Rancher Agents is needed for %s: forceDeploy=%v, agent/auth image changed=%v,"+
+			" private repo changed=%v", cluster.Name, forceDeploy, imageChange, repoChange)
 		return true
 	}
+
+	na, ca := getAgentImages(cluster.Name)
+	if cluster.Status.AgentImage != na || cluster.Status.AgentImage != ca {
+		// downstream agent does not match, kick a redeploy with settings agent
+		logrus.Infof("Redeploy Rancher Agents due to Downstream Agent Image Mismatch for %s: was %s and will be %s",
+			cluster.Name, na, image.ResolveWithCluster(settings.AgentImage.Get(), cluster))
+		clearAgentImages(cluster.Name)
+		return true
+	}
+
 	return false
 }
 
+func getDesiredImage(cluster *v3.Cluster) string {
+	if cluster.Spec.AgentImageOverride != "" {
+		return cluster.Spec.AgentImageOverride
+	}
+
+	return cluster.Spec.DesiredAgentImage
+}
+
 func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
-	desiredAgent := cluster.Spec.DesiredAgentImage
+	desiredAgent := getDesiredImage(cluster)
 	if desiredAgent == "" || desiredAgent == "fixed" {
 		desiredAgent = image.ResolveWithCluster(settings.AgentImage.Get(), cluster)
 	}
@@ -160,7 +200,7 @@ func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
 		return err
 	}
 
-	_, err = v3.ClusterConditionAgentDeployed.Do(cluster, func() (runtime.Object, error) {
+	if _, err = v3.ClusterConditionAgentDeployed.Do(cluster, func() (runtime.Object, error) {
 		yaml, err := cd.getYAML(cluster, desiredAgent, desiredAuth)
 		if err != nil {
 			return cluster, err
@@ -187,26 +227,27 @@ func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
 		}
 		v3.ClusterConditionAgentDeployed.Message(cluster, string(output))
 		return cluster, nil
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 
-	if err == nil {
-		cluster.Status.AgentImage = desiredAgent
-		if cluster.Spec.DesiredAgentImage == "fixed" {
-			cluster.Spec.DesiredAgentImage = desiredAgent
-		}
-		cluster.Status.AuthImage = desiredAuth
-		if cluster.Spec.DesiredAuthImage == "fixed" {
-			cluster.Spec.DesiredAuthImage = desiredAuth
-		}
-		if cluster.Annotations[AgentForceDeployAnn] == "true" {
-			cluster.Annotations[AgentForceDeployAnn] = "false"
-		}
+	if err = cd.cacheAgentImages(cluster.Name); err != nil {
+		return err
 	}
 
-	return err
+	cluster.Status.AgentImage = desiredAgent
+	if cluster.Spec.DesiredAgentImage == "fixed" {
+		cluster.Spec.DesiredAgentImage = desiredAgent
+	}
+	cluster.Status.AuthImage = desiredAuth
+	if cluster.Spec.DesiredAuthImage == "fixed" {
+		cluster.Spec.DesiredAuthImage = desiredAuth
+	}
+	if cluster.Annotations[AgentForceDeployAnn] == "true" {
+		cluster.Annotations[AgentForceDeployAnn] = "false"
+	}
+
+	return nil
 }
 
 func (cd *clusterDeploy) setNetworkPolicyAnn(cluster *v3.Cluster) error {
@@ -256,4 +297,86 @@ func (cd *clusterDeploy) getYAML(cluster *v3.Cluster, agentImage, authImage stri
 		cluster)
 
 	return buf.Bytes(), err
+}
+
+func (cd *clusterDeploy) getClusterAgentImage(name string) (string, error) {
+	uc, err := cd.clusterManager.UserContext(name)
+	if err != nil {
+		return "", err
+	}
+
+	d, err := uc.Apps.Deployments("cattle-system").Get("cattle-cluster-agent", v1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return "", err
+		}
+		return "", nil
+	}
+
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Name == "cluster-register" {
+			return c.Image, nil
+		}
+	}
+
+	return "", nil
+}
+
+func (cd *clusterDeploy) getNodeAgentImage(name string) (string, error) {
+	uc, err := cd.clusterManager.UserContext(name)
+	if err != nil {
+		return "", err
+	}
+
+	ds, err := uc.Apps.DaemonSets("cattle-system").Get("cattle-node-agent", v1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return "", err
+		}
+		return "", nil
+	}
+
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		if c.Name == "agent" {
+			return c.Image, nil
+		}
+	}
+
+	return "", nil
+}
+
+func (cd *clusterDeploy) cacheAgentImages(name string) error {
+	na, err := cd.getNodeAgentImage(name)
+	if err != nil {
+		return err
+	}
+
+	ca, err := cd.getClusterAgentImage(name)
+	if err != nil {
+		return err
+	}
+
+	agentImagesMutex.Lock()
+	defer agentImagesMutex.Unlock()
+	agentImages[nodeImage][name] = na
+	agentImages[clusterImage][name] = ca
+	return nil
+}
+
+func agentImagesCached(name string) bool {
+	na, ca := getAgentImages(name)
+	return na != "" && ca != ""
+}
+
+func getAgentImages(name string) (string, string) {
+	agentImagesMutex.RLock()
+	defer agentImagesMutex.RUnlock()
+	return agentImages[nodeImage][name], agentImages[clusterImage][name]
+}
+
+func clearAgentImages(name string) {
+	agentImagesMutex.Lock()
+	defer agentImagesMutex.Unlock()
+	delete(agentImages[nodeImage], name)
+	delete(agentImages[clusterImage], name)
 }

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -89,6 +89,7 @@ type Cluster struct {
 type ClusterSpecBase struct {
 	DesiredAgentImage                    string                         `json:"desiredAgentImage"`
 	DesiredAuthImage                     string                         `json:"desiredAuthImage"`
+	AgentImageOverride                   string                         `json:"agentImageOverride"`
 	RancherKubernetesEngineConfig        *RancherKubernetesEngineConfig `json:"rancherKubernetesEngineConfig,omitempty"`
 	DefaultPodSecurityPolicyTemplateName string                         `json:"defaultPodSecurityPolicyTemplateName,omitempty" norman:"type=reference[podSecurityPolicyTemplate]"`
 	DefaultClusterRoleForProjectMembers  string                         `json:"defaultClusterRoleForProjectMembers,omitempty" norman:"type=reference[roleTemplate]"`
@@ -128,7 +129,6 @@ type ClusterStatus struct {
 	// https://kubernetes.io/docs/api-reference/v1.8/#componentstatus-v1-core
 	Driver                               string                    `json:"driver"`
 	AgentImage                           string                    `json:"agentImage"`
-	AgentImageOverride                   string                    `json:"agentImageOverride"`
 	AuthImage                            string                    `json:"authImage"`
 	ComponentStatuses                    []ClusterComponentStatus  `json:"componentStatuses,omitempty"`
 	APIEndpoint                          string                    `json:"apiEndpoint,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_spec.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_spec.go
@@ -2,6 +2,7 @@ package client
 
 const (
 	ClusterSpecType                                     = "clusterSpec"
+	ClusterSpecFieldAgentImageOverride                  = "agentImageOverride"
 	ClusterSpecFieldAmazonElasticContainerServiceConfig = "amazonElasticContainerServiceConfig"
 	ClusterSpecFieldAzureKubernetesServiceConfig        = "azureKubernetesServiceConfig"
 	ClusterSpecFieldClusterTemplateAnswers              = "answers"
@@ -28,6 +29,7 @@ const (
 )
 
 type ClusterSpec struct {
+	AgentImageOverride                  string                         `json:"agentImageOverride,omitempty" yaml:"agentImageOverride,omitempty"`
 	AmazonElasticContainerServiceConfig map[string]interface{}         `json:"amazonElasticContainerServiceConfig,omitempty" yaml:"amazonElasticContainerServiceConfig,omitempty"`
 	AzureKubernetesServiceConfig        map[string]interface{}         `json:"azureKubernetesServiceConfig,omitempty" yaml:"azureKubernetesServiceConfig,omitempty"`
 	ClusterTemplateAnswers              *Answer                        `json:"answers,omitempty" yaml:"answers,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_spec_base.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_spec_base.go
@@ -2,6 +2,7 @@ package client
 
 const (
 	ClusterSpecBaseType                                     = "clusterSpecBase"
+	ClusterSpecBaseFieldAgentImageOverride                  = "agentImageOverride"
 	ClusterSpecBaseFieldDefaultClusterRoleForProjectMembers = "defaultClusterRoleForProjectMembers"
 	ClusterSpecBaseFieldDefaultPodSecurityPolicyTemplateID  = "defaultPodSecurityPolicyTemplateId"
 	ClusterSpecBaseFieldDesiredAgentImage                   = "desiredAgentImage"
@@ -16,6 +17,7 @@ const (
 )
 
 type ClusterSpecBase struct {
+	AgentImageOverride                  string                         `json:"agentImageOverride,omitempty" yaml:"agentImageOverride,omitempty"`
 	DefaultClusterRoleForProjectMembers string                         `json:"defaultClusterRoleForProjectMembers,omitempty" yaml:"defaultClusterRoleForProjectMembers,omitempty"`
 	DefaultPodSecurityPolicyTemplateID  string                         `json:"defaultPodSecurityPolicyTemplateId,omitempty" yaml:"defaultPodSecurityPolicyTemplateId,omitempty"`
 	DesiredAgentImage                   string                         `json:"desiredAgentImage,omitempty" yaml:"desiredAgentImage,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_status.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_status.go
@@ -4,7 +4,6 @@ const (
 	ClusterStatusType                                      = "clusterStatus"
 	ClusterStatusFieldAPIEndpoint                          = "apiEndpoint"
 	ClusterStatusFieldAgentImage                           = "agentImage"
-	ClusterStatusFieldAgentImageOverride                   = "agentImageOverride"
 	ClusterStatusFieldAllocatable                          = "allocatable"
 	ClusterStatusFieldAppliedEnableNetworkPolicy           = "appliedEnableNetworkPolicy"
 	ClusterStatusFieldAppliedPodSecurityPolicyTemplateName = "appliedPodSecurityPolicyTemplateId"
@@ -28,7 +27,6 @@ const (
 type ClusterStatus struct {
 	APIEndpoint                          string                    `json:"apiEndpoint,omitempty" yaml:"apiEndpoint,omitempty"`
 	AgentImage                           string                    `json:"agentImage,omitempty" yaml:"agentImage,omitempty"`
-	AgentImageOverride                   string                    `json:"agentImageOverride,omitempty" yaml:"agentImageOverride,omitempty"`
 	Allocatable                          map[string]string         `json:"allocatable,omitempty" yaml:"allocatable,omitempty"`
 	AppliedEnableNetworkPolicy           bool                      `json:"appliedEnableNetworkPolicy,omitempty" yaml:"appliedEnableNetworkPolicy,omitempty"`
 	AppliedPodSecurityPolicyTemplateName string                    `json:"appliedPodSecurityPolicyTemplateId,omitempty" yaml:"appliedPodSecurityPolicyTemplateId,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -385,7 +385,7 @@ github.com/rancher/rke/pki/cert
 github.com/rancher/rke/services
 github.com/rancher/rke/templates
 github.com/rancher/rke/util
-# github.com/rancher/types v0.0.0-20191220141556-ad31d6815bbd
+# github.com/rancher/types v0.0.0-20191226170233-4d49bbf42146
 github.com/rancher/types/apis/apiregistration.k8s.io/v1
 github.com/rancher/types/apis/apps/v1
 github.com/rancher/types/apis/autoscaling/v2beta2


### PR DESCRIPTION
Adding a map in the clusterdeploy template to track the downstream agent incase of upgrade/rollback as per this bug report https://github.com/rancher/rancher/issues/21386

Read my writeup in that issue which tells you how to recreate this problem locally.