### PR TITLE
Update CRB and RB if roleTemplate's inherited roles are edited

### DIFF
--- a/pkg/controllers/user/rbac/reconcile_roletemplate.go
+++ b/pkg/controllers/user/rbac/reconcile_roletemplate.go
@@ -1,0 +1,135 @@
+package rbac
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rancher/norman/types/slice"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (m *manager) reconcileProjectAccessToGlobalResources(binding *v3.ProjectRoleTemplateBinding, rts map[string]*v3.RoleTemplate) (map[string]bool, error) {
+	var role string
+	var createNSPerms bool
+	var roles []string
+	if parts := strings.SplitN(binding.ProjectName, ":", 2); len(parts) == 2 && len(parts[1]) > 0 {
+		projectName := parts[1]
+		var roleVerb, roleSuffix string
+		for _, r := range rts {
+			for _, rule := range r.Rules {
+				if slice.ContainsString(rule.Resources, "namespaces") && len(rule.ResourceNames) == 0 {
+					if slice.ContainsString(rule.Verbs, "*") || slice.ContainsString(rule.Verbs, "create") {
+						roleVerb = "*"
+						createNSPerms = true
+						break
+					}
+				}
+
+			}
+		}
+		if roleVerb == "" {
+			roleVerb = "get"
+		}
+		roleSuffix = projectNSVerbToSuffix[roleVerb]
+		role = fmt.Sprintf(projectNSGetClusterRoleNameFmt, projectName, roleSuffix)
+		roles = append(roles, role)
+
+		for _, rt := range rts {
+			for resource := range globalResourcesNeededInProjects {
+				verbs, err := m.checkForGlobalResourceRules(rt, resource)
+				if err != nil {
+					return nil, err
+				}
+				if len(verbs) > 0 {
+					roleName, err := m.reconcileRoleForProjectAccessToGlobalResource(resource, rt, verbs)
+					if err != nil {
+						return nil, err
+					}
+					roles = append(roles, roleName)
+				}
+			}
+		}
+	}
+
+	if len(roles) == 0 {
+		return nil, nil
+	}
+
+	bindingCli := m.workload.RBAC.ClusterRoleBindings("")
+
+	if createNSPerms {
+		roles = append(roles, "create-ns")
+		if nsRole, _ := m.crLister.Get("", "create-ns"); nsRole == nil {
+			createNSRT, err := m.rtLister.Get("", "create-ns")
+			if err != nil {
+				return nil, err
+			}
+			if err := m.ensureRoles(map[string]*v3.RoleTemplate{"create-ns": createNSRT}); err != nil && !apierrors.IsAlreadyExists(err) {
+				return nil, err
+			}
+		}
+	}
+
+	rtbUID := string(binding.UID)
+	subject, err := pkgrbac.BuildSubjectFromRTB(binding)
+	if err != nil {
+		return nil, err
+	}
+	crbsToKeep := make(map[string]bool)
+	for _, role := range roles {
+		crbKey := rbRoleSubjectKey(role, subject)
+		crbs, _ := m.crbIndexer.ByIndex(crbByRoleAndSubjectIndex, crbKey)
+		if len(crbs) == 0 {
+			logrus.Infof("Creating clusterRoleBinding for project access to global resource for subject %v role %v.", subject.Name, role)
+			createdCRB, err := bindingCli.Create(&rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "clusterrolebinding-",
+					Labels: map[string]string{
+						rtbUID: owner,
+					},
+				},
+				Subjects: []rbacv1.Subject{subject},
+				RoleRef: rbacv1.RoleRef{
+					Kind: "ClusterRole",
+					Name: role,
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+			crbsToKeep[createdCRB.Name] = true
+		} else {
+		CRBs:
+			for _, obj := range crbs {
+				crb, ok := obj.(*rbacv1.ClusterRoleBinding)
+				if !ok {
+					continue
+				}
+				crbsToKeep[crb.Name] = true
+				for owner := range crb.Labels {
+					if rtbUID == owner {
+						continue CRBs
+					}
+				}
+
+				crb = crb.DeepCopy()
+				if crb.Labels == nil {
+					crb.Labels = map[string]string{}
+				}
+				crb.Labels[rtbUID] = owner
+				logrus.Infof("Updating clusterRoleBinding %v for project access to global resource for subject %v role %v.", crb.Name, subject.Name, role)
+				_, err := bindingCli.Update(crb)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+	}
+	return crbsToKeep, nil
+}

--- a/tests/integration/suite/test_role_template.py
+++ b/tests/integration/suite/test_role_template.py
@@ -228,53 +228,62 @@ def test_role_template_update_inherited_role(admin_mc, remove_resource,
     role_template_id = cloned_pm['id']
     wait_for_role_template_creation(admin_mc, name)
 
+    # create a namespace in this project
+    ns_name = random_str()
+    ns = admin_pc.cluster.client.create_namespace(name=ns_name,
+                                                  projectId=admin_pc.
+                                                  project.id)
+    remove_resource(ns)
+
     # add user to a project with this role
     user_cloned_pm = user_factory()
     prtb = client.create_project_role_template_binding(
         name="prtb-" + random_str(),
         userId=user_cloned_pm.user.id,
         projectId=admin_pc.project.id,
-        roleTemplateId=cloned_pm.id
+        roleTemplateId=role_template_id
     )
     remove_resource(prtb)
     wait_until_available(user_cloned_pm.client, admin_pc.project)
 
-    # check crbs created for this user
+    # As the user, assert that the two expected role bindings exist in the
+    # namespace for the user. There should be one for the rancher role
+    # 'cloned_pm' and one for the k8s built-in role 'edit'
     rbac = kubernetes.client.RbacAuthorizationV1Api(admin_mc.k8s_client)
-    prtb_selector = prtb.uuid + "=" + "owner-user"
-    crbs = rbac.list_cluster_role_binding(label_selector=prtb_selector)
-    # crbs that get created for roleTemplate cloned from project-member
-    project_id = admin_pc.project.id.split(":")[1]
-    pm_crbs = [role_template_id+"-promoted",
-               project_id+"-namespaces-edit", "create-ns"]
-    for crb in crbs.items:
-        assert crb.role_ref.name in pm_crbs
+    rbs = rbac.list_namespaced_role_binding(ns_name)
+    rb_dict = {}
+    for rb in rbs.items:
+        if rb.subjects[0].name == user_cloned_pm.user.id:
+            rb_dict[rb.role_ref.name] = rb
+    assert role_template_id in rb_dict
+    assert 'edit' in rb_dict
 
     # now edit the roleTemplate to remove "edit" from inherited roles,
     # and add "view" to inherited roles
     client.update(cloned_pm, roleTemplateIds=["view"])
     wait_until(lambda: client.reload(cloned_pm)['roleTemplateIds'] is ["view"])
-    # check crbs are updated
 
-    pm_crbs = [role_template_id + "-promoted",
-               project_id + "-namespaces-readonly"]
-
-    def check_crb(rbac):
-        crbs = rbac.list_cluster_role_binding(label_selector=prtb_selector)
-        for crb in crbs.items:
-            if crb.role_ref.name == project_id + "-namespaces-readonly":
+    def check_rb(rbac):
+        rbs = rbac.list_namespaced_role_binding(ns_name)
+        for rb in rbs.items:
+            if rb.subjects[0].name == user_cloned_pm.user.id \
+                    and rb.role_ref.name == "view":
                 return True
 
-    wait_for(lambda: check_crb(rbac), timeout=60,
-             fail_handler=lambda: 'failed to check updated role')
+    wait_for(lambda: check_rb(rbac), timeout=60,
+             fail_handler=lambda: 'failed to check updated rolebinding')
 
-    crbs = rbac.list_cluster_role_binding(label_selector=prtb_selector)
-    found_crbs = []
-    for crb in crbs.items:
-        found_crbs.append(crb.role_ref.name)
-
-    for crb in pm_crbs:
-        assert crb in found_crbs
+    # Now there should be one rolebinding for the rancher role
+    # 'cloned_pm' and one for the k8s built-in role 'view'
+    rbac = kubernetes.client.RbacAuthorizationV1Api(admin_mc.k8s_client)
+    rbs = rbac.list_namespaced_role_binding(ns_name)
+    rb_dict = {}
+    for rb in rbs.items:
+        if rb.subjects[0].name == user_cloned_pm.user.id:
+            rb_dict[rb.role_ref.name] = rb
+    assert role_template_id in rb_dict
+    assert 'view' in rb_dict
+    assert 'edit' not in rb_dict
 
 
 def wait_for_role_template_creation(admin_mc, rt_name, timeout=60):


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/23658

When a user is added to project/cluster, based on the roleTemplate, rolebindings
and clusterrolebindings are created for that user.

When user is added to a  project, following clusterRoleBindings are created
* roleTemplate.Name-promoted: if storageClass, persistentVolumes and apiservices are
among the roles's resources
* project.Name-namespaces-edit and create-ns: if there is "create" or "*" permission on the
"namespaces" resource of any of the rules in the roleTemplate
* project.Name-namespaces-readonly: if there is no "create" permission on "namespaces" resources in any of the rules in roletemplate

Along with this, roleBindings are created in the namespaces belonging to that project:
* One with the clusterRole of the roleTemplate.Name
* One with the Kubernetes default role associated with the roleTemplate

The project-member role inherits the "edit" Kubernetes default role. So when a new roleTemplate
is created by cloning this role, that will also inherit the "edit" role.

The bug is that if a user is added to a project with this cloned role, on editing the cloned role and removing the "edit" inherited role, and replacing it with "view", the corresponding roleBindings for the user don't get updated.

This commit fixes it by calling the same logic that exists on the creation/edit of a prtb,
on the edit of a roleTemplate as well.