### PR TITLE
[2.3.4] Log json parsing format and sort namespaces

### DIFF
--- a/pkg/controllers/user/logging/configsyncer/configgenerator.go
+++ b/pkg/controllers/user/logging/configsyncer/configgenerator.go
@@ -99,6 +99,6 @@ func (s *ConfigGenerator) addExcludeNamespaces(systemProjectID string) (string, 
 			systemNamespaces = append(systemNamespaces, namespacePattern)
 		}
 	}
-
+	sort.Strings(systemNamespaces)
 	return strings.Join(systemNamespaces, "|"), nil
 }

--- a/pkg/controllers/user/logging/generator/templatefilter.go
+++ b/pkg/controllers/user/logging/generator/templatefilter.go
@@ -127,11 +127,17 @@ var FilterTemplate = `
 {{- if .EnableJSONParsing}}
 <filter {{ .ContainerLogSourceTag}}.**>
   @type parser
+  <parse>
+    @type multi_format
+    <pattern>
+      format json
+    </pattern>
+    <pattern>
+      format none
+    </pattern>
+  </parse>
   key_name log
   reserve_data true
-  <parse>
-    @type json
-  </parse>
 </filter>
 {{end}}
 {{end}}


### PR DESCRIPTION
**1. Fixed fluentd log parsing full of backslash**

Solution:
Use multi_format plugin to avoid fluentd logging warning when parsing the log to JSON if it's not in JSON format.

Related issue:
https://github.com/rancher/rancher/issues/24545

**2. Enable sorting grep system namespace for logging**

Related PR:
https://github.com/rancher/system-charts/pull/141

Need to merge https://github.com/rancher/system-charts/pull/141 first