### PR TITLE
local filesystem test for clusters snapshots

### DIFF
--- a/tests/validation/lib/aws.py
+++ b/tests/validation/lib/aws.py
@@ -156,7 +156,7 @@ class AmazonWebServices(CloudProviderBase):
                 "BlockDeviceMappings":
                     [{"DeviceName": "/dev/sda1", "Ebs": {"VolumeSize": 50}}]
                 }
-        if (len(AWS_IAM_PROFILE) > 0):
+        if len(AWS_IAM_PROFILE) > 0:
             args["IamInstanceProfile"] = {'Name': AWS_IAM_PROFILE}
 
         instance = self._client.run_instances(**args)

--- a/tests/validation/lib/node.py
+++ b/tests/validation/lib/node.py
@@ -35,18 +35,26 @@ class Node(object):
         self.ssh_key_path = ssh_key_path
         self.os_version = os_version
         self.docker_version = docker_version
-        self.roles = None
+        self._roles = []
         self.labels = labels or {}
         self.state = state
         self._ssh_client = paramiko.SSHClient()
         self._ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         self.ssh_port = '22'
 
+    @property
+    def roles(self):
+        return self._roles
+
+    @roles.setter
+    def roles(self, r):
+        self._roles = r
+
     def wait_for_ssh_ready(self):
         command = 'whomai'
         start_time = int(time.time())
         logs_while_waiting = ''
-        while(int(time.time()) - start_time < 100):
+        while int(time.time()) - start_time < 100:
             try:
                 self._ssh_client.connect(
                     self.public_ip_address, username=self.ssh_user,

--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -53,10 +53,15 @@ AWS_S3_BUCKET_FOLDER_NAME = os.environ.get("AWS_S3_BUCKET_FOLDER_NAME", "")
 LINODE_ACCESSKEY = os.environ.get('RANCHER_LINODE_ACCESSKEY', "None")
 
 TEST_RBAC = ast.literal_eval(os.environ.get('RANCHER_TEST_RBAC', "False"))
-if_test_rbac = pytest.mark.skipif(TEST_RBAC is False, reason='rbac tests are skipped')
+if_test_rbac = pytest.mark.skipif(TEST_RBAC is False,
+                                  reason='rbac tests are skipped')
 
-TEST_S3 = ast.literal_eval(os.environ.get('RANCHER_TEST_S3', "False"))
-if_test_s3 = pytest.mark.skipif(TEST_S3 is False, reason='S3 tests are skipped')
+TEST_ALL_SNAPSHOT = ast.literal_eval(
+    os.environ.get('RANCHER_TEST_ALL_SNAPSHOT', "False")
+)
+if_test_all_snapshot = \
+    pytest.mark.skipif(TEST_ALL_SNAPSHOT is False,
+                       reason='Snapshots check tests are skipped')
 
 CLUSTER_MEMBER = "cluster-member"
 CLUSTER_OWNER  = "cluster-owner"
@@ -878,7 +883,7 @@ def delete_cluster(client, cluster):
     # Delete Cluster
     client.delete(cluster)
     # Delete nodes(in cluster) from AWS for Imported and Custom Cluster
-    if (len(nodes) > 0):
+    if len(nodes) > 0:
         cluster_type = get_cluster_type(client, cluster)
         print(cluster_type)
         if get_cluster_type(client, cluster) in ["Imported", "Custom"]:

--- a/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
+++ b/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
@@ -983,6 +983,8 @@ def create_and_validate_custom_host(node_roles):
         docker_run_cmd = \
             get_custom_host_registration_cmd(client, cluster, node_roles[i],
                                              aws_node)
+        for nr in node_roles[i]:
+            aws_node.roles.append(nr)
         aws_node.execute_command(docker_run_cmd)
         i += 1
     cluster = validate_cluster(client, cluster, k8s_version=K8S_VERSION)


### PR DESCRIPTION
Adding support to check the local filesystem snapshot files in `/opt/rke/etcd-snapshots`
Creating a AWS custom cluster to be able to ssh into the `etcd` nodes.
Iterate over the `etcd` nodes to check each node's local filesystem.