### PR TITLE
allow setting the cluster's k8s version

### DIFF
--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_custom_cluster_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_custom_cluster_matrix
@@ -118,7 +118,8 @@ node {
                       string(name: 'RANCHER_SERVER_VERSION', value: "${rancher_version}"), 
                       string(name: 'BRANCH', value: branch),
                       string(name: 'RANCHER_OS_DOCKER_VERSION', value: "${version}"),
-                      string(name: 'DOCKER_INSTALLED', value: "${DOCKER_INSTALLED}")
+                      string(name: 'DOCKER_INSTALLED', value: "${DOCKER_INSTALLED}"),
+                      string(name: 'RANCHER_K8S_VERSION', value: "${env.RANCHER_K8S_VERSION}")
                       ]
                 println "parameters: ${params}"
                 jobs["${version}"] = { build job: 'rancher-v3_ontag_custom_certification', parameters: params }


### PR DESCRIPTION
Add the ability to pass RANCHER_K8S_VERSION to downstream pipelines for clusters being provisioned. 

Changes to the pipeline configuration have been done. 

Tests are passed.