### PR TITLE
Create a jail first when node gets created

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -154,9 +154,18 @@ func (m *Lifecycle) Create(obj *v3.Node) (runtime.Object, error) {
 	}
 
 	newObj, err := v3.NodeConditionInitialized.Once(obj, func() (runtime.Object, error) {
+		logrus.Debugf("Called v3.NodeConditionInitialized.Once for [%s] in namespace [%s]", obj.Name, obj.Namespace)
+		// Ensure jail is created first, else the function `NewNodeConfig` will create the full jail path (including parent jail directory) and CreateJail will remove the directory as it does not contain a done file
+		if !m.devMode {
+			err := jailer.CreateJail(obj.Namespace)
+			if err != nil {
+				return nil, errors.WithMessage(err, "node create jail error")
+			}
+		}
+
 		nodeConfig, err := nodeconfig.NewNodeConfig(m.secretStore, obj)
 		if err != nil {
-			return obj, errors.Wrap(err, "failed to create node driver config")
+			return obj, errors.WithMessagef(err, "failed to create node driver config for node [%v]", obj.Name)
 		}
 
 		defer nodeConfig.Cleanup()
@@ -179,13 +188,6 @@ func (m *Lifecycle) Create(obj *v3.Node) (runtime.Object, error) {
 			obj.Status.NodeTemplateSpec.EngineInstallURL = defaultEngineInstallURL
 		}
 
-		if !m.devMode {
-			err := jailer.CreateJail(obj.Namespace)
-			if err != nil {
-				return nil, errors.WithMessage(err, "node create jail error")
-			}
-		}
-
 		return obj, nil
 	})
 
@@ -194,6 +196,7 @@ func (m *Lifecycle) Create(obj *v3.Node) (runtime.Object, error) {
 
 func (m *Lifecycle) getNodeTemplate(nodeTemplateName string) (*v3.NodeTemplate, error) {
 	ns, n := ref.Parse(nodeTemplateName)
+	logrus.Debugf("getNodeTemplate parsed [%s] to ns: [%s] and n: [%s]", nodeTemplateName, ns, n)
 	return m.nodeTemplateClient.GetNamespaced(ns, n, metav1.GetOptions{})
 }
 
@@ -559,10 +562,11 @@ func (m *Lifecycle) refreshNodeConfig(nc *nodeconfig.NodeConfig, obj *v3.Node) e
 	data := rawTemplate.(*unstructured.Unstructured).Object
 	rawConfig, ok := values.GetValue(data, template.Spec.Driver+"Config")
 	if !ok {
-		return fmt.Errorf("node config not specified for node %v", obj.Name)
+		return fmt.Errorf("refreshNodeConfig: node config not specified for node %v", obj.Name)
 	}
 
 	if err := m.updateRawConfigFromCredential(data, rawConfig, template); err != nil {
+		logrus.Debugf("refreshNodeConfig: error calling updateRawConfigFromCredential for [%v]: %v", obj.Name, err)
 		return err
 	}
 
@@ -570,7 +574,7 @@ func (m *Lifecycle) refreshNodeConfig(nc *nodeconfig.NodeConfig, obj *v3.Node) e
 
 	if template.Spec.Driver == amazonec2 {
 		setEc2ClusterIDTag(rawConfig, obj.Namespace)
-		logrus.Debug("[refreshNodeConfig] Updating amazonec2 machine config")
+		logrus.Debug("refreshNodeConfig: Updating amazonec2 machine config")
 		//TODO: Update to not be amazon specific, this needs to be moved to the driver
 		update, err = nc.UpdateAmazonAuth(rawConfig)
 		if err != nil {

--- a/pkg/nodeconfig/config.go
+++ b/pkg/nodeconfig/config.go
@@ -89,11 +89,13 @@ func (m *NodeConfig) FullDir() string {
 }
 
 func (m *NodeConfig) Cleanup() error {
+	logrus.Debugf("Cleaning up [%s]", m.fullMachinePath)
 	return os.RemoveAll(m.fullMachinePath)
 }
 
 func (m *NodeConfig) Remove() error {
 	m.Cleanup()
+	logrus.Debugf("Removing [%v]", m.id)
 	return m.store.Remove(m.id)
 }
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/24695

Problem: When creating multiple nodes from a node template at the same time, some node provisioning would error on first try showing `lstat: no such file or directory`

Root cause: A function (`newNodeConfig`) would create the whole jail directory structure (including parent directories), causing the actual createjail function to think the jail was incomplete (because there is no `done` file which indicates a jail is ready which is only created by the `CreateJail` function)

Solution: Move the `CreateJail` function to be the first to be called so it can be created as expected