### PR TITLE
remove the script setting facl again on the certs dir

### DIFF
--- a/package/run.sh
+++ b/package/run.sh
@@ -108,20 +108,6 @@ check_x509_cert()
     fi
 }
 
-set_certs_dir_permissions()
-{
-    local certs_dir=$1
-    # check for acl mask
-    masked=0
-    getfacl -p $certs_dir | grep -q mask::r-x || masked=1
-    if [ $masked -eq 0 ]; then
-        chmod 755 $certs_dir
-        setfacl -R -m m::rX $certs_dir
-    else
-        chmod 755 $certs_dir
-    fi
-}
-
 AGENT_IMAGE=${AGENT_IMAGE:-ubuntu:14.04}
 
 export CATTLE_ADDRESS
@@ -263,7 +249,7 @@ if [ -n "$CATTLE_CA_CHECKSUM" ]; then
     else
         mkdir -p /etc/kubernetes/ssl/certs
         mv $temp /etc/kubernetes/ssl/certs/serverca
-        set_certs_dir_permissions /etc/kubernetes/ssl
+        chmod 755 /etc/kubernetes/ssl
         chmod 700 /etc/kubernetes/ssl/certs
         chmod 600 /etc/kubernetes/ssl/certs/serverca
         mkdir -p /etc/docker/certs.d/$CATTLE_SERVER_HOSTNAME_WITH_PORT


### PR DESCRIPTION
https://github.com/rancherlabs/rancher-security/issues/368

This method was originally added to ensure facl permissions are set again by rancher since the dir was set at 700 permission and that would change the facl - https://github.com/rancher/rancher/pull/22220

But now rke-tools sets the dir at 755 which gives read access to all users, so we need not re-run the setfacl command. When this command is re-run it changes the file permissions to 640, but we need the files to be at 600 for CIS compliance.