### PR TITLE
Validate error when creating role

### DIFF
--- a/pkg/controllers/user/rbac/prtb_handler.go
+++ b/pkg/controllers/user/rbac/prtb_handler.go
@@ -261,7 +261,7 @@ func (m *manager) reconcileRoleForProjectAccessToGlobalResource(resource string,
 		},
 		Rules: rules,
 	})
-	if err != nil {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return roleName, errors.Wrapf(err, "couldn't create role %v", roleName)
 	}
 


### PR DESCRIPTION
The error check needs to validate the error type, if the role exists no error should be returned. 
This is a 2nd piece of:
https://github.com/rancher/rancher/issues/23804