### PR TITLE
always pass node-ip parameter to kubelet

### DIFF
--- a/vendor/github.com/rancher/rke/cluster/plan.go
+++ b/vendor/github.com/rancher/rke/cluster/plan.go
@@ -437,6 +437,7 @@ func (c *Cluster) BuildKubeletProcess(host *hosts.Host, prefixPath string, svcOp
 		"hostname-override":         host.HostnameOverride,
 		"kubeconfig":                pki.GetConfigPath(pki.KubeNodeCertName),
 		"pod-infra-container-image": c.Services.Kubelet.InfraContainerImage,
+		"node-ip":                   host.InternalAddress,
 		"root-dir":                  path.Join(prefixPath, "/var/lib/kubelet"),
 	}
 	if host.DockerInfo.OSType == "windows" { // compatible with Windows
@@ -452,9 +453,6 @@ func (c *Cluster) BuildKubeletProcess(host *hosts.Host, prefixPath string, svcOp
 
 	if host.IsControl && !host.IsWorker {
 		CommandArgs["register-with-taints"] = unschedulableControlTaint
-	}
-	if host.Address != host.InternalAddress {
-		CommandArgs["node-ip"] = host.InternalAddress
 	}
 	if len(c.CloudProvider.Name) > 0 {
 		CommandArgs["cloud-config"] = cloudConfigFileName


### PR DESCRIPTION
this fixes issue #25042. Where I started my rancher with the "internal-address"
and "address" both set to the ip address on eth1(192.168.33.0/24 in my case), to
make it not auto choose the ip adress eth0(10.0.2.15) which in my case was used
for NAT on vagrant. Because "address" and "internal-address" were both set to
the same value the "node-ip" parameter was never passed to the kublet, and the
kublet autoresolved its ip to the one on eth0.