### PR TITLE
Do not set k8s version or networkpolicy on update

### DIFF
--- a/pkg/api/store/cluster/cluster_store.go
+++ b/pkg/api/store/cluster/cluster_store.go
@@ -186,7 +186,7 @@ func (r *Store) Create(apiContext *types.APIContext, schema *types.Schema, data 
 		}
 	}
 
-	err := setKubernetesVersion(data)
+	err := setKubernetesVersion(data, true)
 	if err != nil {
 		return nil, err
 	}
@@ -463,7 +463,7 @@ func (r *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 		return nil, httperror.NewFieldAPIError(httperror.MissingRequired, "ClusterTemplateRevision", "this cluster is created from a clusterTemplateRevision, please pass the clusterTemplateRevision")
 	}
 
-	err = setKubernetesVersion(data)
+	err = setKubernetesVersion(data, false)
 	if err != nil {
 		return nil, err
 	}
@@ -549,14 +549,17 @@ func canUseClusterName(apiContext *types.APIContext, requestedName string) error
 	return nil
 }
 
-func setKubernetesVersion(data map[string]interface{}) error {
+func setKubernetesVersion(data map[string]interface{}, create bool) error {
 	rkeConfig, ok := values.GetValue(data, "rancherKubernetesEngineConfig")
 	if ok && rkeConfig != nil {
 		k8sVersion := values.GetValueN(data, "rancherKubernetesEngineConfig", "kubernetesVersion")
 		if k8sVersion == nil || k8sVersion == "" {
-			//set k8s version to system default on the spec
-			defaultVersion := settings.KubernetesVersion.Get()
-			values.PutValue(data, defaultVersion, "rancherKubernetesEngineConfig", "kubernetesVersion")
+			// Only set when its a new cluster
+			if create {
+				//set k8s version to system default on the spec
+				defaultVersion := settings.KubernetesVersion.Get()
+				values.PutValue(data, defaultVersion, "rancherKubernetesEngineConfig", "kubernetesVersion")
+			}
 		} else {
 			//if k8s version is already of rancher version form, noop
 			//if k8s version is of form 1.14.x, figure out the latest
@@ -624,7 +627,7 @@ func validateNetworkFlag(data map[string]interface{}, create bool) error {
 	rkeConfig := values.GetValueN(data, "rancherKubernetesEngineConfig")
 	plugin := convert.ToString(values.GetValueN(convert.ToMapInterface(rkeConfig), "network", "plugin"))
 
-	if enableNetworkPolicy == nil {
+	if enableNetworkPolicy == nil && create {
 		// setting default values for new clusters if value not passed
 		values.PutValue(data, false, "enableNetworkPolicy")
 	} else if value := convert.ToBool(enableNetworkPolicy); value {

--- a/tests/integration/suite/test_kontainer_engine_config.py
+++ b/tests/integration/suite/test_kontainer_engine_config.py
@@ -86,3 +86,74 @@ def test_rke_config_appears_correctly(admin_mc, remove_resource):
 
     k8s_version = cluster.rancherKubernetesEngineConfig.kubernetesVersion
     assert k8s_version == "v1.12.9-rancher1-1"
+
+
+def test_rke_config_no_change_k8sversion_addon(admin_mc, remove_resource):
+    """ Testing if kubernetesVersion stays the same after updating
+    something else in the cluster, e.g. addonJobTimeout"""
+    k8s_version = "v1.12.9-rancher1-1"
+    cluster = admin_mc.client.create_cluster(
+        name=random_str(), rancherKubernetesEngineConfig={
+            "kubernetesVersion": k8s_version,
+        })
+    remove_resource(cluster)
+    cluster = admin_mc.client.update_by_id_cluster(
+       id=cluster.id,
+       name=cluster.name,
+       rancherKubernetesEngineConfig={
+            "addonJobTimeout": 45,
+        })
+    k8s_version_post = cluster.rancherKubernetesEngineConfig.kubernetesVersion
+    assert k8s_version_post == k8s_version
+
+
+def test_rke_config_no_change_k8sversion_np(admin_mc, remove_resource):
+    """ Testing if kubernetesVersion stays the same after updating
+    something else in the cluster, e.g. addonJobTimeout"""
+    cluster_config_np_false = {
+        "enableNetworkPolicy": "false",
+        "rancherKubernetesEngineConfig": {
+            "addonJobTimeout": 45,
+            "kubernetesVersion": "v1.12.9-rancher1-1",
+            "network": {
+                "plugin": "canal",
+            }
+        }
+    }
+
+    cluster = admin_mc.client.create_cluster(
+            name=random_str(),
+            cluster=cluster_config_np_false,
+    )
+    remove_resource(cluster)
+
+    cluster_config_np_true = {
+        "name": cluster.name,
+        "enableNetworkPolicy": "true",
+        "rancherKubernetesEngineConfig": {
+            "network": {
+                "plugin": "canal",
+            }
+        }
+    }
+
+    cluster = admin_mc.client.update_by_id_cluster(
+        cluster.id,
+        cluster_config_np_true,
+    )
+
+    cluster_config_addonjob = {
+        "name": cluster.name,
+        "rancherKubernetesEngineConfig": {
+            "addonJobTimeout": 55,
+            "network": {
+                "plugin": "canal",
+            }
+        }
+    }
+
+    cluster = admin_mc.client.update_by_id_cluster(
+        cluster.id,
+        cluster_config_addonjob,
+    )
+    assert cluster.enableNetworkPolicy is True


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/24982
https://github.com/rancher/rancher/issues/23759

My first attempt was to just remove the two functions (`setKubernetesVersion` and `validateNetworkFlag`) from `Update` but we want to keep the logic of testing for deprecated k8s versions and the logic of testing for network policy so I changed it to pass existingCluster on update so the functions can determine when its a new cluster and when its an update.