### PR TITLE
[WIP] Rancher License monitoring tool

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -43,6 +43,7 @@ var (
 	RkeVersion                        = NewSetting("rke-version", "")
 	RkeMetadataConfig                 = NewSetting("rke-metadata-config", getMetadataConfig())
 	ServerImage                       = NewSetting("server-image", "rancher/rancher")
+	ServerLicense                     = NewSetting("server-license", "")
 	ServerURL                         = NewSetting("server-url", "")
 	ServerVersion                     = NewSetting("server-version", "dev")
 	SystemDefaultRegistry             = NewSetting("system-default-registry", "")


### PR DESCRIPTION
This PR contains: 
- Rancher server setting to store Rancher support license, `server-license`.
- Telemetry start condition when `server-license` is set.

This is a WIP related with [Rancher License monitoring tool
](https://github.com/rancherlabs/rancher-security/issues/332)