### PR TITLE
Validation - Decrypt AWS Windows password

### DIFF
--- a/tests/validation/requirements_v3api.txt
+++ b/tests/validation/requirements_v3api.txt
@@ -17,4 +17,5 @@ pytest-ordering==0.6
 python-digitalocean==1.13.2
 PyYAML==5.2
 requests==2.22.0
+rsa==4.0
 websocket-client==0.53.0


### PR DESCRIPTION
* Added a method to decrypt the Windows Administrator password for AWS nodes.
* Added Windows AMI for us-east-2 region

Node must have been launched with the same `AWS_SSH_KEY_NAME, AWS_SSH_PEM_KEY` as specified in environment/parameters. 

Make sure to wait at least 5 minutes after launching the instance before decrypting password -- if not ready, the password will be blank

```
def test_windows_decrypt_password():
    # instance-id can be retrieved from query or node object in framework
    password = AmazonWebServices().decrypt_windows_password('i-0000000000')
    print("Password: " + password)
```