### PR TITLE
add functional and RBAC tests for group global role binding

### DIFF
--- a/tests/validation/tests/v3_api/conftest.py
+++ b/tests/validation/tests/v3_api/conftest.py
@@ -1,20 +1,20 @@
 import urllib3
-from .common import *
+from .common import * # NOQA
 
 # This stops ssl warnings for insecure certs
 urllib3.disable_warnings()
 
 
 def pytest_configure(config):
-    if TEST_RBAC is False:
-        return
-    rbac_prepare()
+    if TEST_RBAC:
+        rbac_prepare()
+    if AUTH_PROVIDER_NAME != "":
+        prepare_auth_data()
 
 
 def pytest_unconfigure(config):
-    if TEST_RBAC is False:
-        return
-    rbac_cleanup()
+    if TEST_RBAC:
+        rbac_cleanup()
 
 
 @pytest.fixture

--- a/tests/validation/tests/v3_api/resource/activedirectory.json
+++ b/tests/validation/tests/v3_api/resource/activedirectory.json
@@ -59,7 +59,7 @@
   "specialchar_in_password": [
     "test1"
   ],
-  "specialchar_in_userdn":[
+  "specialchar_in_userdn": [
     "craigcomma",
     "firstcomma"
   ],
@@ -70,5 +70,34 @@
     "testcommagroup",
     "testuser1",
     "test(san)&abc"
-  ]
+  ],
+  "nested_group_info": {
+    "users": [
+      "nestedtestuser1",
+      "nestedtestuser2",
+      "nestedtestuser3"
+    ],
+   "nestgroup1": {
+      "users": [
+        "nestedtestuser1"
+      ],
+      "groups": [
+        "nestgroup2"
+      ]
+    },
+    "nestgroup2": {
+      "users": [
+        "nestedtestuser2"
+      ],
+      "groups": [
+        "nestgroup3"
+      ]
+    },
+    "nestgroup3": {
+      "users": [
+        "nestedtestuser3"
+      ],
+      "groups": []
+    }
+  }
 }

--- a/tests/validation/tests/v3_api/resource/freeipa.json
+++ b/tests/validation/tests/v3_api/resource/freeipa.json
@@ -66,5 +66,34 @@
   ],
   "specialgroup1-_.$": [
     "testauto25"
-  ]
+  ],
+  "nested_group_info": {
+    "users": [
+      "nestedtestuser1",
+      "nestedtestuser2",
+      "nestedtestuser3"
+    ],
+    "nestgroup1": {
+      "users": [
+        "nestedtestuser1"
+      ],
+      "groups": [
+        "nestgroup2"
+      ]
+    },
+    "nestgroup2": {
+      "users": [
+        "nestedtestuser2"
+      ],
+      "groups": [
+        "nestgroup3"
+      ]
+    },
+    "nestgroup3": {
+      "users": [
+        "nestedtestuser3"
+      ],
+      "groups": []
+    }
+  }
 }

--- a/tests/validation/tests/v3_api/resource/openldap.json
+++ b/tests/validation/tests/v3_api/resource/openldap.json
@@ -67,5 +67,34 @@
   ],
   "test(group&)abc(group)": [
     "testuser9"
-  ]
+  ],
+  "nested_group_info": {
+    "users": [
+      "nestedtestuser1",
+      "nestedtestuser2",
+      "nestedtestuser3"
+    ],
+    "nestgroup1": {
+      "users": [
+        "nestedtestuser1"
+      ],
+      "groups": [
+        "nestgroup2"
+      ]
+    },
+    "nestgroup2": {
+      "users": [
+        "nestedtestuser2"
+      ],
+      "groups": [
+        "nestgroup3"
+      ]
+    },
+    "nestgroup3": {
+      "users": [
+        "nestedtestuser3"
+      ],
+      "groups": []
+    }
+  }
 }

--- a/tests/validation/tests/v3_api/test_group_grb.py
+++ b/tests/validation/tests/v3_api/test_group_grb.py
@@ -1,110 +1,307 @@
-from .common import *   # NOQA
+from .common import *  # NOQA
 from rancher import ApiError
-
 import pytest
-import rancher
 import requests
 
 '''
 Prerequisite:
-Enable AD with TLS, and using testuser1 as admin user.
-
-Description:
-This test asserts that a user who is not assigned to an admin globarole,
-but is in a group that is assigned to an admin global role, has admin has
-admin privileges.
-
-Steps:
-1. login to user A who is in group B
-2. attempt to create a resources that requires admin privileges
-    a. assert Forbidden error
-3. create a globalrolebinding that assigns group B to the admin
-globalrole.
-    a. assert user A can now create a resource that requires admin
-    privileges
-4. delete globalrolebinding created in step 3.
-5. attempt to create a resource that requires admin privileges
-    a. assert Forbidden error
+    - Enable Auth
+    - Optional: searching nested group enabled
+    - All users used for testing global group role binding should not be used
+      to create the cluster when preparing the Rancher setup
 '''
 
-AUTH_PROVIDER = os.environ.get('RANCHER_AUTH_PROVIDER', "")
-
-# username of auth user that only has user privileges
-RANCHER_AUTH_USERNAME = os.environ.get('RANCHER_AUTH_USERNAME', "")
-# password for auth user
-RANCHER_AUTH_PASSWORD = os.environ.get('RANCHER_AUTH_PASSWORD', "")
-# name of auth group that auth user is a member of
-RANCHER_AUTH_GROUP = os.environ.get('RANCHER_AUTH_GROUP', "")
-
-CATTLE_AUTH_URL = \
-    CATTLE_TEST_URL + \
-    "/v3-public/"+AUTH_PROVIDER+"Providers/" + \
-    AUTH_PROVIDER.lower()+"?action=login"
-
-CATTLE_AUTH_PROVIDER_URL = \
-    CATTLE_TEST_URL + "/v3/"+AUTH_PROVIDER+"Configs/"+AUTH_PROVIDER.lower()
-
+# values used to create a catalog
+BRANCH = "dev"
+URL = "https://git.rancher.io/system-charts"
+# the link to search principals in the auth provider
 CATTLE_AUTH_PRINCIPAL_URL = CATTLE_TEST_URL + "/v3/principals?action=search"
 
 
-def test_group_grbs():
-    groups = search_ad_groups(RANCHER_AUTH_GROUP, ADMIN_TOKEN)
-    admin_client = get_admin_client()
+def test_ggrb_1(remove_resource):
+    """ test that when a global role is assigned to a group,
+    all users in the group will get the permission;
+    when the ggrb is removed, all users in the group will lose
+    the permission.
 
-    r = requests.post(CATTLE_AUTH_URL, json={
-        'username': RANCHER_AUTH_USERNAME,
-        'password': RANCHER_AUTH_PASSWORD,
-        'responseType': 'json',
-    }, verify=False)
+    the default global role "catalogs-manage" is used
+    """
 
-    token = r.json()["token"]
-
-    testuser3_client = rancher.Client(
-        url=CATTLE_TEST_URL + "/v3",
-        token=token,
-        verify=False)
-
-    with pytest.raises(ApiError) as e:
-        rt = testuser3_client.create_role_template(name="rt-"+random_str())
-
-    assert e.value.error.status == 403
-    assert e.value.error.code == 'Forbidden'
-
-    gr = admin_client.create_global_role_binding(
-        globalRoleId="admin",
-        groupPrincipalId=groups[0]["id"])
-
-    def try_create_role_template():
-        try:
-            return testuser3_client.create_role_template(name="rt-" + random_str())
-        except ApiError as e:
-            assert e.error.status == 403
-            assert e.value.error.code == 'Forbidden'
-            return False
-
-    rt = wait_for(try_create_role_template)
-    admin_client.delete(gr)
-
-    # once user is no longer admin, they will be unable to see local cluster
-    # this is less wasteful than attemptingg to create roletemplates until
-    # unauthorized error is encountered
-    wait_for(lambda: len(testuser3_client.list_cluster()) == 0)
-
-    try:
-        testuser3_client.create_role_template(name="rt-" + random_str())
-    except ApiError as e:
-        assert e.error.status == 403
-        assert e.error.code == 'Forbidden'
+    target_group_name = get_group(NESTED_GROUP_ENABLED)
+    users = get_user_by_group(target_group_name, NESTED_GROUP_ENABLED)
+    # check that users can not create catalogs
+    for user in users:
+        validate_permission_create_catalog(user, False)
+    g_id = get_group_principal_id(target_group_name, ADMIN_TOKEN)
+    ggrb = get_admin_client().create_global_role_binding(
+        globalRoleId="catalogs-manage", groupPrincipalId=g_id)
+    # check that users can create catalogs now
+    for user in users:
+        catalog = validate_permission_create_catalog(user, True)
+        remove_resource(catalog)
+    # delete the ggrb
+    get_admin_client().delete(ggrb)
+    # check that users can not create catalogs
+    for user in users:
+        validate_permission_create_catalog(user, False)
 
 
-def search_ad_groups(searchkey, token, expected_status=200):
+def test_ggrb_2(remove_resource):
+    """ test that after editing the global role, users'
+    permissions reflect the changes
+
+    Steps:
+    - users in group1 cannot list clusters or create catalogs
+    - create a custom global role gr1 that permits creating catalogs
+    - create the global group role binding ggrb1 to bind gr1 to group1
+    - users in group1 can create catalogs now
+    - edit gr1 to remove the permission of creating catalogs, add the
+    permission of listing clusters
+    - users in group1 cannot create catalogs, but can list clusters
+    """
+
+    target_group_name = get_group(NESTED_GROUP_ENABLED)
+    users = get_user_by_group(target_group_name, NESTED_GROUP_ENABLED)
+    # check that users can not create catalogs or list clusters
+    for user in users:
+        validate_permission_create_catalog(user, False)
+        validate_permission_list_cluster(user, 0)
+    # create a custom global role that permits create catalogs
+    admin_c = get_admin_client()
+    template = generate_template_global_role(name=random_name(),
+                                             template=TEMPLATE_MANAGE_CATALOG)
+    gr = admin_c.create_global_role(template)
+    remove_resource(gr)
+    g_id = get_group_principal_id(target_group_name, ADMIN_TOKEN)
+    ggrb = get_admin_client().create_global_role_binding(
+        globalRoleId=gr["id"], groupPrincipalId=g_id)
+    # check that users can create catalogs now, but not list clusters
+    for user in users:
+        validate_permission_list_cluster(user, 0)
+        catalog = validate_permission_create_catalog(user, True)
+        remove_resource(catalog)
+    # edit the global role
+    rules = [
+        {
+            "type": "/v3/schemas/policyRule",
+            "apiGroups": [
+                "management.cattle.io"
+            ],
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "resources": [
+                "clusters"
+            ]
+        }
+    ]
+    admin_c.update(gr, rules=rules)
+    target_num = len(admin_c.list_cluster().data)
+    # check that users can list clusters, but not create catalogs
+    for user in users:
+        validate_permission_create_catalog(user, False)
+        validate_permission_list_cluster(user, target_num)
+    # delete the ggrb
+    admin_c.delete(ggrb)
+    for user in users:
+        validate_permission_list_cluster(user, 0)
+
+
+def test_ggrb_3(remove_resource):
+    """ test that when a global role is assigned to a group,
+    all users in the group get the permission from the role,
+    users not in the group do not get the permission
+
+    Steps:
+    - users in the group cannot list clusters
+    - users not in the group cannot list clusters
+    - create a custom global role gr1 that permits listing clusters
+    - create the global group role binding ggrb1 to bind gr1 to the group
+    - users in the group can list clusters now
+    - users not in group still cannot list clusters
+    - delete the ggrb1
+    - users in the group can not list clusters
+    """
+
+    target_g, user1 = get_a_group_and_a_user_not_in_it(NESTED_GROUP_ENABLED)
+    users = get_user_by_group(target_g, NESTED_GROUP_ENABLED)
+    # check that users in the group can not list clusters
+    for user in users:
+        validate_permission_list_cluster(user, 0)
+    # check that user not in the group can not list clusters
+    validate_permission_list_cluster(user1, 0)
+
+    g_id = get_group_principal_id(target_g, ADMIN_TOKEN)
+    # create a custom global role that permits listing clusters
+    admin_c = get_admin_client()
+    template = generate_template_global_role(name=random_name(),
+                                             template=TEMPLATE_LIST_CLUSTER)
+    gr = admin_c.create_global_role(template)
+    remove_resource(gr)
+    ggrb = admin_c.create_global_role_binding(globalRoleId=gr["id"],
+                                              groupPrincipalId=g_id)
+    remove_resource(ggrb)
+    target_num = len(admin_c.list_cluster().data)
+    # check that users in the group can list clusters
+    for user in users:
+        validate_permission_list_cluster(user, target_num)
+    # check that user not in the group can not list clusters
+    validate_permission_list_cluster(user1, 0)
+    # delete the ggrb
+    admin_c.delete(ggrb)
+    # check that users in the group can not list clusters
+    for user in users:
+        validate_permission_list_cluster(user, 0)
+
+
+# cluster owner, cluster member, project owner, project member
+# and project read-only can not list ggrb
+rbac_list_ggrb = [
+    (CLUSTER_OWNER, 0),
+    (CLUSTER_MEMBER, 0),
+    (PROJECT_OWNER, 0),
+    (PROJECT_MEMBER, 0),
+    (PROJECT_READ_ONLY, 0),
+]
+
+# cluster owner, cluster member, project owner, project member
+# and project read-only can not create or delete ggrb
+rbac_create_delete_ggrb = [
+    (CLUSTER_OWNER, False),
+    (CLUSTER_MEMBER, False),
+    (PROJECT_OWNER, False),
+    (PROJECT_MEMBER, False),
+    (PROJECT_READ_ONLY, False),
+]
+
+
+@if_test_rbac
+@pytest.mark.parametrize(["role", "expected_count"], rbac_list_ggrb)
+def test_rbac_ggrb_list(role, expected_count):
+    token = rbac_get_user_token_by_role(role)
+    validate_permission_list_ggrb(token, expected_count)
+
+
+@if_test_rbac
+@pytest.mark.parametrize(["role", "permission"], rbac_create_delete_ggrb)
+def test_rbac_ggrb_create(role, permission):
+    token = rbac_get_user_token_by_role(role)
+    validate_permission_create_ggrb(token, permission)
+
+
+@if_test_rbac
+@pytest.mark.parametrize(["role", "permission"], rbac_create_delete_ggrb)
+def test_rbac_ggrb_delete(role, permission):
+    token = rbac_get_user_token_by_role(role)
+    validate_permission_delete_ggrb(token, permission)
+
+
+def get_group_principal_id(group_name, token, expected_status=200):
+    """ get the group's principal id from the auth provider"""
     headers = {'Authorization': 'Bearer ' + token}
     r = requests.post(CATTLE_AUTH_PRINCIPAL_URL,
-                      json={'name': searchkey, 'principalType': 'group',
+                      json={'name': group_name,
+                            'principalType': 'group',
                             'responseType': 'json'},
                       verify=False, headers=headers)
     assert r.status_code == expected_status
+    return r.json()['data'][0]["id"]
 
-    if r.status_code == 200:
-        data = r.json()['data']
-        return data
+
+def validate_permission_list_cluster(username, num=0):
+    """ check if the user from auth provider has the permission to
+    list clusters
+
+    :param username: username from the auth provider
+    :param num: expected number of clusters
+    """
+    token = login_as_auth_user(username, AUTH_USER_PASSWORD)
+    user_client = get_client_for_token(token)
+    clusters = user_client.list_cluster().data
+    assert len(clusters) == num
+
+
+def validate_permission_create_catalog(username, permission=False):
+    """ check if the user from auth provider has the permission to
+    create new catalog
+    """
+    name = random_name()
+    token = login_as_auth_user(username, AUTH_USER_PASSWORD)
+    return validate_create_catalog(token, catalog_name=name, branch=BRANCH,
+                                   url=URL, permission=permission)
+
+
+def validate_permission_list_ggrb(token, num=0):
+    """ check if the user from auth provider has the permission to
+    list global role bindings
+    """
+    user_client = get_client_for_token(token)
+    clusters = user_client.list_global_role_binding().data
+    assert len(clusters) == num
+
+
+def validate_permission_create_ggrb(token, permission=False):
+    """ check if the user from auth provider has the permission to
+    create group global role bindings
+    """
+    target_group_name = get_group()
+    g_id = get_group_principal_id(target_group_name, ADMIN_TOKEN)
+    role = generate_a_global_role()
+    client = get_client_for_token(token)
+    if not permission:
+        with pytest.raises(ApiError) as e:
+            client.create_global_role_binding(globalRoleId=role["id"],
+                                              groupPrincipalId=g_id)
+        assert e.value.error.status == 403 and \
+            e.value.error.code == 'Forbidden', \
+            "user with no permission should receive 403: Forbidden"
+        return None
+    else:
+        try:
+            rtn = \
+                client.create_global_role_binding(globalRoleId=role["id"],
+                                                  groupPrincipalId=g_id)
+            return rtn
+        except ApiError as e:
+            assert False, "user with permission should receive no exception:" \
+                          + str(e.error.status) + " " + e.error.code
+
+
+def validate_permission_delete_ggrb(token, permission=False):
+    """ check if the user from auth provider has the permission to
+    deleting group global role bindings
+    """
+    ggrb = validate_permission_create_ggrb(ADMIN_TOKEN, True)
+    client = get_client_for_token(token)
+    if not permission:
+        with pytest.raises(ApiError) as e:
+            client.delete(ggrb)
+        assert e.value.error.status == 403 and \
+            e.value.error.code == 'Forbidden', \
+            "user with no permission should receive 403: Forbidden"
+        get_admin_client().delete(ggrb)
+    else:
+        try:
+            client.delete(ggrb)
+        except ApiError as e:
+            get_admin_client().delete(ggrb)
+            assert False, "user with permission should receive no exception:" \
+                          + str(e.error.status) + " " + e.error.code
+
+
+def generate_a_global_role():
+    """ return a global role with the permission of listing cluster"""
+    admin_c = get_admin_client()
+    template = generate_template_global_role(name=random_name(),
+                                             template=TEMPLATE_LIST_CLUSTER)
+    return admin_c.create_global_role(template)
+
+
+@pytest.fixture(scope='module', autouse="True")
+def create_project_client(request):
+    client, cluster = get_user_client_and_cluster()
+    create_kubeconfig(cluster)
+    if NESTED_GROUP_ENABLED:
+        assert is_nested(), "no nested group is found"


### PR DESCRIPTION
This PR adds functional and RBAC tests for group global role binding.
- 3 functional tests
- 15 rbac tests

Prerequisite:
- Enable Auth in the Rancher setup 
- Optional: searching nested group enabled

It supports three Auth providers: 
- activeDirectory
- freeIPA
- openIdap

tests can be run with or without searching in nested groups.

It introduces the following global variables
- RANCHER_AUTH_USER_PASSWORD
- RANCHER_AUTH_PROVIDER
- RANCHER_NESTED_GROUP_ENABLED
