### PR TITLE
Add crd rbac tests and custom answers test

### DIFF
--- a/tests/validation/tests/v3_api/.gitignore
+++ b/tests/validation/tests/v3_api/.gitignore
@@ -1,1 +1,2 @@
 k8s_kube_config
+*_kubeconfig

--- a/tests/validation/tests/v3_api/resource/istio/crds/adapter.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/adapter.yaml
@@ -1,0 +1,11 @@
+apiVersion: "config.istio.io/v1alpha2"
+kind: adapter
+metadata:
+  name: test
+spec:
+  description: test
+  session_based: false
+  templates:
+  - apigee-authorization
+  - apigee-analytics
+  config: fake

--- a/tests/validation/tests/v3_api/resource/istio/crds/attributemanifest.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/attributemanifest.yaml
@@ -1,0 +1,56 @@
+apiVersion: "config.istio.io/v1alpha2"
+kind: attributemanifest
+metadata:
+  name: test
+spec:
+   attributes:
+      source.ip:
+        valueType: IP_ADDRESS
+      source.labels:
+        valueType: STRING_MAP
+      source.name:
+        valueType: STRING
+      source.namespace:
+        valueType: STRING
+      source.owner:
+        valueType: STRING
+      source.serviceAccount:
+        valueType: STRING
+      source.services:
+        valueType: STRING
+      source.workload.uid:
+        valueType: STRING
+      source.workload.name:
+        valueType: STRING
+      source.workload.namespace:
+        valueType: STRING
+      destination.ip:
+        valueType: IP_ADDRESS
+      destination.labels:
+        valueType: STRING_MAP
+      destination.metadata:
+        valueType: STRING_MAP
+      destination.name:
+        valueType: STRING
+      destination.namespace:
+        valueType: STRING
+      destination.owner:
+        valueType: STRING
+      destination.service.uid:
+        valueType: STRING
+      destination.service.name:
+        valueType: STRING
+      destination.service.namespace:
+        valueType: STRING
+      destination.service.host:
+        valueType: STRING
+      destination.serviceAccount:
+        valueType: STRING
+      destination.workload.uid:
+        valueType: STRING
+      destination.workload.name:
+        valueType: STRING
+      destination.workload.namespace:
+        valueType: STRING
+      destination.container.name:
+        valueType: STRING

--- a/tests/validation/tests/v3_api/resource/istio/crds/authenticationpolicy.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/authenticationpolicy.yaml
@@ -1,0 +1,7 @@
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "default"
+spec:
+  peers:
+  - mtls: {}

--- a/tests/validation/tests/v3_api/resource/istio/crds/authorizationpolicy.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/authorizationpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+ name: test
+spec:
+ selector:
+   matchLabels:
+     app: httpbin
+     version: v1
+ rules:
+ - from:
+   - source:
+       principals: ["cluster.local/ns/default/sa/sleep"]
+   - source:
+       namespaces: ["test"]
+   to:
+   - operation:
+       methods: ["GET"]
+       paths: ["/info*"]
+   - operation:
+       methods: ["POST"]
+       paths: ["/data"]
+   when:
+   - key: request.auth.claims[iss]
+     values: ["https://accounts.google.com"]

--- a/tests/validation/tests/v3_api/resource/istio/crds/destinationrule.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/destinationrule.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: test
+spec:
+  host: fake.test.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      simple: LEAST_CONN

--- a/tests/validation/tests/v3_api/resource/istio/crds/envoyfilter.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/envoyfilter.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: test-ef
+spec:
+  workloadSelector:
+    labels:
+      app: reviews
+  configPatches:
+    # The first patch adds the lua filter to the listener/http connection manager
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        portNumber: 8080
+        filterChain:
+          filter:
+            name: "envoy.http_connection_manager"
+            subFilter:
+              name: "envoy.router"
+    patch:
+      operation: INSERT_BEFORE
+      value: # lua filter specification
+       name: envoy.lua
+       config:
+         inlineCode: |
+           function envoy_on_request(request_handle)
+             -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
+             local headers, body = request_handle:httpCall(
+              "lua_cluster",
+              {
+               [":method"] = "POST",
+               [":path"] = "/acl",
+               [":authority"] = "internal.org.net"
+              },
+             "authorize call",
+             5000)
+           end

--- a/tests/validation/tests/v3_api/resource/istio/crds/gateway.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: test-gateway
+spec:
+  selector:
+    app: my-gateway-controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "ns1/*"
+    - "ns2/foo.bar.com"

--- a/tests/validation/tests/v3_api/resource/istio/crds/handler.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/handler.yaml
@@ -1,0 +1,16 @@
+apiVersion: "config.istio.io/v1alpha2"
+kind: handler
+metadata:
+  name: test
+spec:
+  compiledAdapter: prometheus
+  params:
+    metrics:
+    - name: request_count
+      instance_name: requestcount.metric.istio-system
+      kind: COUNTER
+      label_names:
+      - source_service
+      - source_version
+      - destination_service
+      - destination_version

--- a/tests/validation/tests/v3_api/resource/istio/crds/httpapispec.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/httpapispec.yaml
@@ -1,0 +1,38 @@
+apiVersion: config.istio.io/v1alpha2
+kind: HTTPAPISpec
+metadata:
+  name: petstore-test
+spec:
+  attributes:
+    attributes:
+      api.service:
+        stringValue: petstore.swagger.io
+      api.version:
+        stringValue: 1.0.0
+  patterns:
+  - attributes:
+      attributes:
+        api.operation:
+          stringValue: findPets
+    httpMethod: GET
+    uriTemplate: /api/pets
+  - attributes:
+      attributes:
+        api.operation:
+          stringValue: addPet
+    httpMethod: POST
+    uriTemplate: /api/pets
+  - attributes:
+      attributes:
+        api.operation:
+          stringValue: findPetById
+    httpMethod: GET
+    uriTemplate: /api/pets/{id}
+  - attributes:
+      attributes:
+        api.operation:
+          stringValue: deletePet
+    httpMethod: DELETE
+    uriTemplate: /api/pets/{id}
+  apiKeys:
+  - query: api-key

--- a/tests/validation/tests/v3_api/resource/istio/crds/httpapispecbinding.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/httpapispecbinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.istio.io/v1alpha2
+kind: HTTPAPISpecBinding
+metadata:
+  name: my-binding
+  namespace: default
+spec:
+  services:
+  - name: foo
+    namespace: bar
+  apiSpecs:
+  - name: petstore
+    namespace: default

--- a/tests/validation/tests/v3_api/resource/istio/crds/quotaspec.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/quotaspec.yaml
@@ -1,0 +1,9 @@
+apiVersion: config.istio.io/v1alpha2
+kind: QuotaSpec
+metadata:
+  name: request-count
+spec:
+  rules:
+  - quotas:
+    - charge: 1
+      quota: requestcount

--- a/tests/validation/tests/v3_api/resource/istio/crds/quotaspecbinding.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/quotaspecbinding.yaml
@@ -1,0 +1,9 @@
+apiVersion: config.istio.io/v1alpha2
+kind: QuotaSpecBinding
+metadata:
+  name: request-count
+spec:
+  quotaSpecs:
+  - name: request-count
+  services:
+  - name: productpage

--- a/tests/validation/tests/v3_api/resource/istio/crds/rbacconfig.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/rbacconfig.yaml
@@ -1,0 +1,8 @@
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: RbacConfig
+metadata:
+  name: default
+spec:
+  mode: ON_WITH_INCLUSION
+  inclusion:
+    namespaces: []

--- a/tests/validation/tests/v3_api/resource/istio/crds/rule.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/rule.yaml
@@ -1,0 +1,9 @@
+apiVersion: config.istio.io/v1alpha2
+kind: rule
+metadata:
+  name: test
+spec:
+  actions:
+  - handler: fakehandler
+    instances:
+    - fakeinstance

--- a/tests/validation/tests/v3_api/resource/istio/crds/serviceentry.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/serviceentry.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: test
+spec:
+  hosts:
+  - www.googleapis.com
+  location: MESH_EXTERNAL
+  ports:
+  - number: 443
+    name: https
+    protocol: TLS
+  resolution: DNS

--- a/tests/validation/tests/v3_api/resource/istio/crds/servicerole.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/servicerole.yaml
@@ -1,0 +1,11 @@
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: test
+spec:
+  rules:
+  - services: ["products.svc.cluster.local"]
+    methods: ["GET", "HEAD"]
+    constraints:
+    - key: "destination.labels[version]"
+      values: ["v1", "v2"]

--- a/tests/validation/tests/v3_api/resource/istio/crds/servicerolebinding.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/servicerolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: test-binding
+spec:
+  subjects:
+  - user: alice@yahoo.com
+  - properties:
+      source.namespace: "abc"
+  roleRef:
+    kind: ServiceRole
+    name: "products-viewer"

--- a/tests/validation/tests/v3_api/resource/istio/crds/sidecar.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/sidecar.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  name: default
+spec:
+  egress:
+  - hosts:
+    - "./*"
+    - "istio-system/*"

--- a/tests/validation/tests/v3_api/resource/istio/crds/template.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/template.yaml
@@ -1,0 +1,8 @@
+apiVersion: "config.istio.io/v1alpha2"
+kind: template
+metadata:
+  name: checknothing
+spec:
+  descriptor: "fake"
+  foo: "bar"
+---

--- a/tests/validation/tests/v3_api/resource/istio/crds/virtualservice.yaml
+++ b/tests/validation/tests/v3_api/resource/istio/crds/virtualservice.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: test-reviews-routing
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  http:
+  - name: "reviews-v2-routes"
+    match:
+    - uri:
+        prefix: "/consumercatalog"
+    rewrite:
+      uri: "/newcatalog"
+    route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v2
+  - name: "reviews-v1-route"
+    route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v1


### PR DESCRIPTION
Closes: #25097 

CRD RBAC tests added. Left the known failing ones commented out, and ignored the `certmanager` CRDs (that are also known to be failing in current state). These should be added when all of those are fixed.

Also created a test for validating all of the possible custom answers in Istio. It validates a few things:
1. Expected workloads, by name, are deployed successfully and all their pods are running.
2. There are no additional workloads deployed.
3. All of the workload containers have an image that starts with `rancher/` which is important for airgap setups.