### PR TITLE
fix PVC creation error  when storageClass exists 

### DIFF
--- a/tests/validation/tests/v3_api/test_nfs.py
+++ b/tests/validation/tests/v3_api/test_nfs.py
@@ -182,6 +182,7 @@ def create_project_client(request):
                   "name": pvc_name,
                   "volumeId": pv_object.id,
                   "namespaceId": ns.id,
+                  "storageClassId": "",
                   "resources": {"requests": {"storage": "10Gi"}}
                   }
     pvc_object = p_client.create_persistent_volume_claim(pvc_config)


### PR DESCRIPTION
Problem:
When we create a pvc using an existing pv, the default storage class is used instead of the pv

Solution:
pass the `storageClassID` as an empty string in the request

Result:
the pvc is created using the pv
<img width="1483" alt="Screen Shot 2020-01-29 at 7 16 13 PM" src="https://user-images.githubusercontent.com/6218999/73414798-2d106700-42cd-11ea-8ff8-3ea4a2f4b641.png">
