### PR TITLE
Change default system-charts branch to dev

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /var/lib/rancher
 
 ARG ARCH=amd64
 ARG IMAGE_REPO=rancher
-ARG SYSTEM_CHART_DEFAULT_BRANCH=v2.3-dev
+ARG SYSTEM_CHART_DEFAULT_BRANCH=dev
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go  
 ARG RANCHER_METADATA_BRANCH=
 

--- a/scripts/package
+++ b/scripts/package
@@ -4,7 +4,7 @@ set -e
 source $(dirname $0)/version
 
 ARCH=${ARCH:-"amd64"}
-SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"v2.3-dev"}
+SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"dev"}
 SUFFIX=""
 [ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
 


### PR DESCRIPTION
I discovered this while testing https://github.com/rancher/rancher/pull/25021, the offending image (grafana) kept appearing and it seemed to default to `v2.3-dev` branch for system-charts in `master` which is pretty confusing. As we branch this to a release, rancher `master` -> system-charts `dev` seems logical. Also, this is what is currently documented.