### PR TITLE
use default when k8s version not found

### DIFF
--- a/pkg/controllers/management/kontainerdrivermetadata/data_getter.go
+++ b/pkg/controllers/management/kontainerdrivermetadata/data_getter.go
@@ -5,23 +5,20 @@ import (
 	"strings"
 
 	mVersion "github.com/mcuadros/go-version"
-	"github.com/rancher/rancher/pkg/settings"
-	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
-
-	"github.com/sirupsen/logrus"
-
 	"github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rke/util"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func GetCisConfigParams(
-	k8sVersion string,
+	name string,
 	cisConfigLister v3.CisConfigLister,
 	cisConfig v3.CisConfigInterface,
 ) (v3.CisConfigParams, error) {
-	name := util.GetTagMajorVersion(k8sVersion)
 	c, err := cisConfigLister.Get(namespace.GlobalNamespace, name)
 	if err != nil {
 		if !errors.IsNotFound(err) {

--- a/pkg/controllers/user/cis/clusterScanHandler.go
+++ b/pkg/controllers/user/cis/clusterScanHandler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/management/kontainerdrivermetadata"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/systemaccount"
+	"github.com/rancher/rke/util"
 	rcorev1 "github.com/rancher/types/apis/core/v1"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	projv3 "github.com/rancher/types/apis/project.cattle.io/v3"
@@ -84,14 +85,15 @@ func (csh *cisScanHandler) Create(cs *v3.ClusterScan) (runtime.Object, error) {
 	if !v3.ClusterScanConditionCreated.IsTrue(cs) {
 		logrus.Infof("cisScanHandler: Create: deploying helm chart")
 		currentK8sVersion := cluster.Spec.RancherKubernetesEngineConfig.Version
+		shortK8sVersion := util.GetTagMajorVersion(currentK8sVersion)
 		cisConfigParams, err := kontainerdrivermetadata.GetCisConfigParams(
-			currentK8sVersion,
+			shortK8sVersion,
 			csh.cisConfigLister,
 			csh.cisConfig,
 		)
 		if err != nil {
-			logrus.Debugf("cisScanHandler: Create: benchmark version not found for k8s version: %v, using default",
-				currentK8sVersion)
+			logrus.Debugf("cisScanHandler: Create: benchmark version not found for k8s version: %v(%v), using default",
+				currentK8sVersion, shortK8sVersion)
 			cisConfigParams, err = kontainerdrivermetadata.GetCisConfigParams(
 				"default",
 				csh.cisConfigLister,


### PR DESCRIPTION
Addresses: https://github.com/rancher/rancher/issues/25179

Resolve the short k8s version before, not during fetching the CIS config