### PR TITLE
pass canChangeValuePolicy to avoid panic error

### DIFF
--- a/pkg/controllers/user/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/user/nodesyncer/nodessyncer.go
@@ -189,7 +189,7 @@ func (m *nodesSyncer) updateLabels(node *corev1.Node, obj *v3.Node, nodePlan v3.
 }
 
 func (m *nodesSyncer) updateAnnotations(node *corev1.Node, obj *v3.Node, nodePlan v3.RKEConfigNodePlan) (*corev1.Node, *v3.Node, error) {
-	finalMap, changed := computeDelta(node.Annotations, nodePlan.Annotations, obj.Spec.MetadataUpdate.Annotations, nil)
+	finalMap, changed := computeDelta(node.Annotations, nodePlan.Annotations, obj.Spec.MetadataUpdate.Annotations, allowAllPolicy)
 	if !changed {
 		return node, obj, nil
 	}
@@ -227,6 +227,10 @@ func (m *nodesSyncer) syncLabels(key string, obj *v3.Node) (runtime.Object, erro
 
 func onlyKubeLabels(key string) bool {
 	return strings.Contains(key, "kubernetes.io")
+}
+
+func allowAllPolicy(_ string) bool {
+	return true
 }
 
 // computeDelta will return the final updated map to apply and a boolean indicating whether there are changes to be applied.


### PR DESCRIPTION
**Issue:** panic because canChangeValuePolicy is nil
https://github.com/rancher/rancher/issues/25164 

**Solution:** 

I'm using allowAll for annotations because didn't find any checks before refactor PR: https://github.com/rancher/rancher/pull/22866 

nodePlan initially sends the following annotations, https://github.com/rancher/rancher/blob/master/vendor/github.com/rancher/rke/cluster/plan.go#L131
```
"rke.cattle.io/internal-ip": host.InternalAddress
"rke.cattle.io/external-ip": host.Address
```

I don't know when these values on v1.Node could differ from initially set values from nodePlan..
