### PR TITLE
Allow initializing features without controllers

### DIFF
--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -35,6 +35,10 @@ func InitializeFeatures(ctx *config.ScaledContext, featureArgs string) {
 		logrus.Errorf("failed to apply feature args: %v", err)
 	}
 
+	if ctx == nil {
+		return
+	}
+
 	// creates any features in map that do not exist, updates features with new default value
 	for key, f := range features {
 		f.featuresLister = ctx.Management.Features("").Controller().Lister()
@@ -112,6 +116,10 @@ func applyArgumentDefaults(featureArgs string) error {
 // Enabled returns whether the Feature is enabled in the global feature gate.
 // This should be primarily used for schema enable function and add feature handler functions
 func (f *feature) Enabled() bool {
+	if f.featuresLister == nil {
+		return f.def
+	}
+
 	featureState, err := f.featuresLister.Get("", f.name)
 	if err != nil {
 		return false

--- a/pkg/features/feature_test.go
+++ b/pkg/features/feature_test.go
@@ -30,3 +30,10 @@ func TestApplyArgumentDefaults(t *testing.T) {
 		assert.NotNil(err)
 	}
 }
+
+func TestInitializeNil(t *testing.T) {
+	assert := assert.New(t)
+	assert.False(Steve.Enabled())
+	InitializeFeatures(nil, "steve=true")
+	assert.True(Steve.Enabled())
+}


### PR DESCRIPTION
This change allows the ScaledContext to be nil allowing features to be
initialized from the command line only.