### PR TITLE
[2.4] Add Helm 3 app & multi-cluster deployment support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ __pycache__
 .kube/
 .DS_Store
 tests/validation/.idea
+all.yaml
+kustomization.yaml

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -11,6 +11,10 @@ ENV CATTLE_CHANNELSERVER_VERSION v0.3.0
 # version used by helm plugin install script
 ENV CATTLE_HELM_UNITTEST_VERSION v0.1.6-rancher1
 ENV GO111MODULE off
+# helm 3 version
+ENV HELM_VERSION v3.1.0
+ENV KUSTOMIZE_VERSION v3.5.4
+
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
 ENV RANCHER_METADATA_BRANCH=dev-v2.4
 
@@ -34,9 +38,10 @@ ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm64=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64 \
     DOCKER_URL=DOCKER_URL_${ARCH}
 
-ENV HELM_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm \
-    HELM_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm-arm64 \
-    HELM_URL=HELM_URL_${ARCH} \
+ENV HELM_URL_V2_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm \
+    HELM_URL_V2_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm-arm64 \
+    HELM_URL_V2=HELM_URL_V2_${ARCH} \
+    HELM_URL_V3=https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz \
     TILLER_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller \
     TILLER_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller-arm64 \
     TILLER_URL=TILLER_URL_${ARCH} \
@@ -48,18 +53,38 @@ ENV HELM_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HE
     CHANNELSERVER_URL=CHANNELSERVER_URL_${ARCH} \
     ETCD_URL_amd64=https://github.com/etcd-io/etcd/releases/download/${CATTLE_ETCD_VERSION}/etcd-${CATTLE_ETCD_VERSION}-linux-amd64.tar.gz \
     ETCD_URL_arm64=https://github.com/etcd-io/etcd/releases/download/${CATTLE_ETCD_VERSION}/etcd-${CATTLE_ETCD_VERSION}-linux-arm64.tar.gz \
-    ETCD_URL=ETCD_URL_${ARCH}
+    ETCD_URL=ETCD_URL_${ARCH} \
+    KUSTOMIZE_URL_amd64=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz \
+    KUSTOMIZE_URL_arm64=https://github.com/brendarearden/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_arm64.tar.gz \
+    KUSTOMIZE_URL=KUSTOMIZE_URL_${ARCH}
 
-RUN curl -sLf ${!HELM_URL} > /usr/bin/rancher-helm && \
+RUN if [ "${ARCH}" == "arm64" ]; then \
+    curl -sLf ${!KUSTOMIZE_URL} | tar xvzf - --strip-components=1 -C /usr/bin; else \
+    curl -sOL ${!KUSTOMIZE_URL} && \
+    sleep 1 && \
+    tar xzf kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz -C /usr/bin && \
+    rm kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz; \
+    fi
+
+# set up helm 2
+RUN curl -sLf ${!HELM_URL_V2} > /usr/bin/rancher-helm && \
     curl -sLf ${!TILLER_URL} > /usr/bin/rancher-tiller && \
-    curl -sLf ${!CHANNELSERVER_URL} > /usr/bin/channelserver && \
-    curl -sLf ${!K3S_URL} > /usr/bin/k3s && \
-    curl -sfL ${!ETCD_URL} | tar xvzf - --strip-components=1 -C /usr/bin/ etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcd && \
-    chmod +x /usr/bin/rancher-helm /usr/bin/rancher-tiller /usr/bin/k3s /usr/bin/channelserver && \
+    chmod +x /usr/bin/rancher-helm /usr/bin/rancher-tiller && \
     ln -s /usr/bin/rancher-helm /usr/bin/helm && \
     ln -s /usr/bin/rancher-tiller /usr/bin/tiller && \
-    rancher-helm init -c && \
-    rancher-helm plugin install https://github.com/rancher/helm-unittest && \
+    helm init -c && \
+    helm plugin install https://github.com/rancher/helm-unittest
+
+# set up helm 3
+RUN mkdir /usr/tmp && \
+    curl ${HELM_URL_V3} | tar xvzf - --strip-components=1 -C /usr/tmp/ && \
+    mv /usr/tmp/helm /usr/bin/helm_v3 && \
+    chmod +x /usr/bin/kustomize
+
+RUN curl -sLf ${!CHANNELSERVER_URL} > /usr/bin/channelserver && \
+    curl -sLf ${!K3S_URL} > /usr/bin/k3s && \
+    curl -sfL ${!ETCD_URL} | tar xvzf - --strip-components=1 -C /usr/bin/ etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcd && \
+    chmod +x /usr/bin/k3s /usr/bin/channelserver && \
     mkdir -p /go/src/github.com/rancher/rancher/.kube && \
     ln -s /etc/rancher/k3s/k3s.yaml /go/src/github.com/rancher/rancher/.kube/k3s.yaml && \
     curl -sLf https://releases.rancher.com/kontainer-driver-metadata/${RANCHER_METADATA_BRANCH}/data.json > /root/data.json

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ replace (
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.3
+	github.com/rancher/types => github.com/brendarearden/types v0.0.0-20200303192431-db66b084c040
 
 	k8s.io/api => k8s.io/api v0.17.2
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.17.2
@@ -87,7 +88,7 @@ require (
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20200302231302-020fd6252623
 	github.com/rancher/system-upgrade-controller v0.3.1
-	github.com/rancher/types v0.0.0-20200304001827-068a357fa053
+	github.com/rancher/types v0.0.0-20200303162837-300a04e6f743
 	github.com/rancher/wrangler v0.5.1-0.20200302190048-e60d4be8fc9b
 	github.com/rancher/wrangler-api v0.5.0
 	github.com/robfig/cron v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ replace (
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.3
-	github.com/rancher/types => github.com/brendarearden/types v0.0.0-20200303192431-db66b084c040
 
 	k8s.io/api => k8s.io/api v0.17.2
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.17.2
@@ -88,7 +87,7 @@ require (
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20200302231302-020fd6252623
 	github.com/rancher/system-upgrade-controller v0.3.1
-	github.com/rancher/types v0.0.0-20200303162837-300a04e6f743
+	github.com/rancher/types v0.0.0-20200305160044-e8e610dd9e01
 	github.com/rancher/wrangler v0.5.1-0.20200302190048-e60d4be8fc9b
 	github.com/rancher/wrangler-api v0.5.0
 	github.com/robfig/cron v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,6 @@ github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx2
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/brancz/gojsontoyaml v0.0.0-20190425155809-e8bd32d46b3d/go.mod h1:IyUJYN1gvWjtLF5ZuygmxbnsAyP3aJS6cHzIuZY50B0=
-github.com/brendarearden/types v0.0.0-20200303192431-db66b084c040 h1:9rKez+dqEfY0aW+1vSVk6YWJ7Kk1+XumXpzWaSFBZMQ=
-github.com/brendarearden/types v0.0.0-20200303192431-db66b084c040/go.mod h1:k5LoTlUpefw0eAzFSJsZI0gf+C4WE41yrc1jm/MS1nM=
 github.com/bugsnag/bugsnag-go v0.0.0-20151120182711-02e952891c52/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20160118154447-aceac81c6e2f/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
@@ -896,6 +894,8 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200107122003-4708915ac6ef/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/prometheus/tsdb v0.8.0 h1:w1tAGxsBMLkuGrFMhqgcCeBkM5d1YI24udArs+aASuQ=
+github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quobyte/api v0.1.2/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rackspace/gophercloud v0.0.0-20150408191457-ce0f487f6747/go.mod h1:4bJ1FwuaBZ6dt1VcDX5/O662mwR8GWqS4l68H6hkoYQ=
@@ -934,6 +934,8 @@ github.com/rancher/system-upgrade-controller v0.3.1/go.mod h1:/2W/8WEqCSrz66hOYr
 github.com/rancher/types v0.0.0-20200303162837-300a04e6f743/go.mod h1:k5LoTlUpefw0eAzFSJsZI0gf+C4WE41yrc1jm/MS1nM=
 github.com/rancher/types v0.0.0-20200304001827-068a357fa053 h1:8IucmgkU1URdPq1FVGzg9Bg+N/TyC4SXpzW7kMcpVSU=
 github.com/rancher/types v0.0.0-20200304001827-068a357fa053/go.mod h1:k5LoTlUpefw0eAzFSJsZI0gf+C4WE41yrc1jm/MS1nM=
+github.com/rancher/types v0.0.0-20200305160044-e8e610dd9e01 h1:NmO8066VGBZpVlOV91pFSbjnIOTWU6hEIXkTt6ZfNRs=
+github.com/rancher/types v0.0.0-20200305160044-e8e610dd9e01/go.mod h1:k5LoTlUpefw0eAzFSJsZI0gf+C4WE41yrc1jm/MS1nM=
 github.com/rancher/wrangler v0.1.4/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rancher/wrangler v0.2.1-0.20191025041946-1fd360590735/go.mod h1:zmXTOSzU0vhumCyl0+Acq2FEP5WJOJRqnCQDegknyWA=
 github.com/rancher/wrangler v0.4.0/go.mod h1:1cR91WLhZgkZ+U4fV9nVuXqKurWbgXcIReU4wnQvTN8=

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx2
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/brancz/gojsontoyaml v0.0.0-20190425155809-e8bd32d46b3d/go.mod h1:IyUJYN1gvWjtLF5ZuygmxbnsAyP3aJS6cHzIuZY50B0=
+github.com/brendarearden/types v0.0.0-20200303192431-db66b084c040 h1:9rKez+dqEfY0aW+1vSVk6YWJ7Kk1+XumXpzWaSFBZMQ=
+github.com/brendarearden/types v0.0.0-20200303192431-db66b084c040/go.mod h1:k5LoTlUpefw0eAzFSJsZI0gf+C4WE41yrc1jm/MS1nM=
 github.com/bugsnag/bugsnag-go v0.0.0-20151120182711-02e952891c52/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20160118154447-aceac81c6e2f/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
@@ -894,8 +896,6 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200107122003-4708915ac6ef/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/prometheus/tsdb v0.8.0 h1:w1tAGxsBMLkuGrFMhqgcCeBkM5d1YI24udArs+aASuQ=
-github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quobyte/api v0.1.2/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rackspace/gophercloud v0.0.0-20150408191457-ce0f487f6747/go.mod h1:4bJ1FwuaBZ6dt1VcDX5/O662mwR8GWqS4l68H6hkoYQ=

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -30,6 +30,8 @@ ENV KUBECTL_VERSION v1.16.1
 ENV DOCKER_MACHINE_LINODE_VERSION v0.1.8
 ENV LINODE_UI_DRIVER_VERSION v0.3.0
 ENV RANCHER_METADATA_BRANCH ${RANCHER_METADATA_BRANCH}
+ENV HELM_VERSION v3.1.0
+ENV KUSTOMIZE_VERSION v3.5.4
 
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/library && \
@@ -47,9 +49,10 @@ ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERS
     TINI_URL_arm64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 \
     TINI_URL=TINI_URL_${ARCH}
 
-ENV HELM_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm \
-    HELM_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm-arm64 \
-    HELM_URL=HELM_URL_${ARCH} \
+ENV HELM_URL_V2_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm \
+    HELM_URL_V2_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm-arm64 \
+    HELM_URL_V2=HELM_URL_V2_${ARCH} \
+    HELM_URL_V3=https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz \
     TILLER_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller \
     TILLER_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller-arm64 \
     TILLER_URL=TILLER_URL_${ARCH} \
@@ -61,17 +64,38 @@ ENV HELM_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HE
     CHANNELSERVER_URL=CHANNELSERVER_URL_${ARCH} \
     ETCD_URL_amd64=https://github.com/etcd-io/etcd/releases/download/${CATTLE_ETCD_VERSION}/etcd-${CATTLE_ETCD_VERSION}-linux-amd64.tar.gz \
     ETCD_URL_arm64=https://github.com/etcd-io/etcd/releases/download/${CATTLE_ETCD_VERSION}/etcd-${CATTLE_ETCD_VERSION}-linux-arm64.tar.gz \
-    ETCD_URL=ETCD_URL_${ARCH}
+    ETCD_URL=ETCD_URL_${ARCH} \
+    KUSTOMIZE_URL_amd64=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz \
+    KUSTOMIZE_URL_arm64=https://github.com/brendarearden/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_arm64.tar.gz \
+    KUSTOMIZE_URL=KUSTOMIZE_URL_${ARCH}
+
+RUN if [ "${ARCH}" == "arm64" ]; then \
+    curl -sLf ${!KUSTOMIZE_URL} | tar xvzf - --strip-components=1 -C /usr/bin; else \
+    curl -sOL ${!KUSTOMIZE_URL} && \
+    sleep 1 && \
+    tar xzf kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz -C /usr/bin && \
+    rm kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz; \
+    fi
+
+# set up helm 2
+RUN curl -sLf ${!HELM_URL_V2} > /usr/bin/rancher-helm && \
+    curl -sLf ${!TILLER_URL} > /usr/bin/rancher-tiller && \
+    ln -s /usr/bin/rancher-helm /usr/bin/helm && \
+    ln -s /usr/bin/rancher-tiller /usr/bin/tiller && \
+    chmod +x /usr/bin/rancher-helm /usr/bin/rancher-tiller
+
+# set up helm 3
+RUN curl ${HELM_URL_V3} | tar xvzf - --strip-components=1 -C /usr/bin && \
+    mv /usr/bin/helm /usr/bin/helm_v3 && \
+    chmod +x /usr/bin/kustomize
 
 RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
-    curl -sLf ${!HELM_URL} > /usr/bin/rancher-helm && \
-    curl -sLf ${!TILLER_URL} > /usr/bin/rancher-tiller && \
     curl -sLf ${!CHANNELSERVER_URL} > /usr/bin/channelserver && \
     curl -sLf ${!K3S_URL} > /usr/bin/k3s && \
     curl -sfL ${!ETCD_URL} | tar xvzf - --strip-components=1 -C /usr/bin/ etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcd etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcdctl && \
     curl -sLf https://github.com/rancher/telemetry/releases/download/${TELEMETRY_VERSION}/telemetry-${ARCH} > /usr/bin/telemetry && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
-    chmod +x /usr/bin/rancher-helm /usr/bin/tini /usr/bin/telemetry /usr/bin/rancher-tiller /usr/bin/k3s /usr/bin/kubectl /usr/bin/channelserver && \
+    chmod +x /usr/bin/tini /usr/bin/telemetry /usr/bin/k3s /usr/bin/kubectl /usr/bin/channelserver && \
     mkdir -p /var/lib/rancher-data/driver-metadata && \
     curl -sLf https://releases.rancher.com/kontainer-driver-metadata/${RANCHER_METADATA_BRANCH}/data.json > /var/lib/rancher-data/driver-metadata/data.json
 
@@ -110,8 +134,10 @@ ENV CATTLE_CLI_URL_WINDOWS https://releases.rancher.com/cli2/${CATTLE_CLI_VERSIO
 ARG VERSION=dev
 ENV CATTLE_SERVER_VERSION ${VERSION}
 COPY entrypoint.sh rancher /usr/bin/
+COPY kustomize.sh /usr/bin/
 COPY jailer.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
+RUN chmod +x /usr/bin/kustomize.sh
 
 ENV CATTLE_AGENT_IMAGE ${IMAGE_REPO}/rancher-agent:${VERSION}
 ENV CATTLE_SERVER_IMAGE ${IMAGE_REPO}/rancher

--- a/package/jailer.sh
+++ b/package/jailer.sh
@@ -17,6 +17,7 @@ mkdir -p /opt/jail/$NAME/management-state/node/nodes
 mkdir -p /opt/jail/$NAME/var/lib/rancher/management-state/bin
 mkdir -p /opt/jail/$NAME/management-state/bin
 mkdir -p /opt/jail/$NAME/tmp
+mkdir -p /opt/jail/$NAME/bin
 
 # Copy over required files to the jail
 if [[ -d /lib64 ]]; then
@@ -55,14 +56,32 @@ cp -r -l /opt/drivers/management-state/bin /opt/jail/$NAME/var/lib/rancher/manag
 # Hard link rancher-machine into the jail
 cp -l /usr/bin/rancher-machine /opt/jail/$NAME/usr/bin
 
-# Hard link helm into the jail
+# Hard link helm_2 into the jail
 cp -l /usr/bin/rancher-helm /opt/jail/$NAME/usr/bin
+
+# Hard link helm_3 into the jail
+cp -l /usr/bin/helm_v3 /opt/jail/$NAME/usr/bin
 
 # Hard link tiller into the jail
 cp -l /usr/bin/rancher-tiller /opt/jail/$NAME/usr/bin
 
+# Hard link kustomize into the jail
+cp -l /usr/bin/kustomize /opt/jail/$NAME/usr/bin
+
+# Hard link custom kustomize script into jail
+cp -l /usr/bin/kustomize.sh /opt/jail/$NAME
+
 # Hard link ssh into the jail
 cp -l /usr/bin/ssh /opt/jail/$NAME/usr/bin
+
+# Hard link cat into the jail
+cp -l /bin/cat /opt/jail/$NAME/bin/
+
+# Hard link bash into the jail
+cp -l /bin/bash /opt/jail/$NAME/bin/
+
+# Hard link rm into the jail
+cp -l /bin/rm /opt/jail/$NAME/bin/
 
 cd /dev
 # tar copy /dev excluding mqueue and shm

--- a/package/kustomize.sh
+++ b/package/kustomize.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cat <&0 > "$CATTLE_KUSTOMIZE_YAML"/all.yaml
+
+kustomize build "$CATTLE_KUSTOMIZE_YAML" && rm "$CATTLE_KUSTOMIZE_YAML"/all.yaml

--- a/pkg/catalog/manager/crd.go
+++ b/pkg/catalog/manager/crd.go
@@ -171,6 +171,7 @@ func (m *Manager) createTemplateVersions(catalogName string, versionsSpec []v3.T
 	for _, spec := range versionsSpec {
 		templateVersion := &v3.CatalogTemplateVersion{}
 		templateVersion.Spec = spec
+		templateVersion.Status = v3.TemplateVersionStatus{HelmVersion: template.Status.HelmVersion}
 		templateVersion.Name = fmt.Sprintf("%s-%v", template.Name, spec.Version)
 		templateVersion.Namespace = template.Namespace
 		templateVersion.Labels = map[string]string{

--- a/pkg/catalog/manager/traverse.go
+++ b/pkg/catalog/manager/traverse.go
@@ -102,6 +102,7 @@ func (m *Manager) traverseAndUpdate(helm *helmlib.Helm, commit string, cmt *Cata
 		template.Spec.IconFilename = iconFilename
 		template.Spec.FolderName = chart
 		template.Spec.DisplayName = chart
+		template.Status.HelmVersion = catalog.Spec.HelmVersion
 		label := map[string]string{}
 		var versions []v3.TemplateVersionSpec
 		for _, version := range metadata {

--- a/tests/integration/suite/test_rbac.py
+++ b/tests/integration/suite/test_rbac.py
@@ -554,7 +554,7 @@ def test_member_can_perform_app_action(admin_mc, admin_pc, remove_resource,
     app = client.create_app(
         name="test-" + random_str(),
         externalId="catalog://?catalog=library&template"
-                   "=mysql&version=0.3.7&"
+                   "=mysql&version=1.3.1&"
                    "namespace=cattle-global-data",
         targetNamespace=ns.name,
         projectId=project.id
@@ -584,8 +584,8 @@ def test_member_can_perform_app_action(admin_mc, admin_pc, remove_resource,
     def _app_revisions_exist():
         a = admin_pc.client.reload(app)
         return len(a.revision().data) > 0
-
-    wait_for(_app_revisions_exist, fail_handler=lambda: 'no revisions exist')
+    wait_for(_app_revisions_exist, timeout=60,
+             fail_handler=lambda: 'no revisions exist')
     proj_user_client = user_project_client(user_mc, project)
     app = proj_user_client.reload(app)
     revID = app.revision().data[0]['id']

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/catalog_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/catalog_types.go
@@ -27,6 +27,7 @@ type CatalogSpec struct {
 	CatalogKind string `json:"catalogKind,omitempty"`
 	Username    string `json:"username,omitempty"`
 	Password    string `json:"password,omitempty" norman:"type=password"`
+	HelmVersion string `json:"helmVersion,omitempty" norman:"noupdate"`
 }
 
 type CatalogStatus struct {
@@ -114,6 +115,7 @@ type TemplateSpec struct {
 }
 
 type TemplateStatus struct {
+	HelmVersion string `json:"helmVersion,omitempty" norman:"noupdate,nocreate"`
 }
 
 type TemplateVersion struct {
@@ -165,6 +167,7 @@ type TemplateVersionSpec struct {
 }
 
 type TemplateVersionStatus struct {
+	HelmVersion string `json:"helmVersion,omitempty" norman:"noupdate,nocreate"`
 }
 
 type File struct {

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
@@ -58,7 +58,7 @@ type AppStatus struct {
 	Notes                string            `json:"notes,omitempty"`
 	Conditions           []AppCondition    `json:"conditions,omitempty"`
 	LastAppliedTemplates string            `json:"lastAppliedTemplate,omitempty"`
-	HelmVersion          string            `json:"helmVersion,omitempty" norman:"nocreate,noupdate"`
+	HelmVersion          string            `json:"helmVersion,omitempty" norman:"noupdate,nocreate"`
 }
 
 type AppCondition struct {

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_catalog.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_catalog.go
@@ -13,6 +13,7 @@ const (
 	CatalogFieldCreated              = "created"
 	CatalogFieldCreatorID            = "creatorId"
 	CatalogFieldDescription          = "description"
+	CatalogFieldHelmVersion          = "helmVersion"
 	CatalogFieldKind                 = "kind"
 	CatalogFieldLabels               = "labels"
 	CatalogFieldLastRefreshTimestamp = "lastRefreshTimestamp"
@@ -37,6 +38,7 @@ type Catalog struct {
 	Created              string             `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID            string             `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	Description          string             `json:"description,omitempty" yaml:"description,omitempty"`
+	HelmVersion          string             `json:"helmVersion,omitempty" yaml:"helmVersion,omitempty"`
 	Kind                 string             `json:"kind,omitempty" yaml:"kind,omitempty"`
 	Labels               map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
 	LastRefreshTimestamp string             `json:"lastRefreshTimestamp,omitempty" yaml:"lastRefreshTimestamp,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_catalog_spec.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_catalog_spec.go
@@ -5,6 +5,7 @@ const (
 	CatalogSpecFieldBranch      = "branch"
 	CatalogSpecFieldCatalogKind = "catalogKind"
 	CatalogSpecFieldDescription = "description"
+	CatalogSpecFieldHelmVersion = "helmVersion"
 	CatalogSpecFieldPassword    = "password"
 	CatalogSpecFieldURL         = "url"
 	CatalogSpecFieldUsername    = "username"
@@ -14,6 +15,7 @@ type CatalogSpec struct {
 	Branch      string `json:"branch,omitempty" yaml:"branch,omitempty"`
 	CatalogKind string `json:"catalogKind,omitempty" yaml:"catalogKind,omitempty"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	HelmVersion string `json:"helmVersion,omitempty" yaml:"helmVersion,omitempty"`
 	Password    string `json:"password,omitempty" yaml:"password,omitempty"`
 	URL         string `json:"url,omitempty" yaml:"url,omitempty"`
 	Username    string `json:"username,omitempty" yaml:"username,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_catalog.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_catalog.go
@@ -14,6 +14,7 @@ const (
 	ClusterCatalogFieldCreated              = "created"
 	ClusterCatalogFieldCreatorID            = "creatorId"
 	ClusterCatalogFieldDescription          = "description"
+	ClusterCatalogFieldHelmVersion          = "helmVersion"
 	ClusterCatalogFieldKind                 = "kind"
 	ClusterCatalogFieldLabels               = "labels"
 	ClusterCatalogFieldLastRefreshTimestamp = "lastRefreshTimestamp"
@@ -40,6 +41,7 @@ type ClusterCatalog struct {
 	Created              string             `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID            string             `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	Description          string             `json:"description,omitempty" yaml:"description,omitempty"`
+	HelmVersion          string             `json:"helmVersion,omitempty" yaml:"helmVersion,omitempty"`
 	Kind                 string             `json:"kind,omitempty" yaml:"kind,omitempty"`
 	Labels               map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
 	LastRefreshTimestamp string             `json:"lastRefreshTimestamp,omitempty" yaml:"lastRefreshTimestamp,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_project_catalog.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_project_catalog.go
@@ -13,6 +13,7 @@ const (
 	ProjectCatalogFieldCreated              = "created"
 	ProjectCatalogFieldCreatorID            = "creatorId"
 	ProjectCatalogFieldDescription          = "description"
+	ProjectCatalogFieldHelmVersion          = "helmVersion"
 	ProjectCatalogFieldKind                 = "kind"
 	ProjectCatalogFieldLabels               = "labels"
 	ProjectCatalogFieldLastRefreshTimestamp = "lastRefreshTimestamp"
@@ -39,6 +40,7 @@ type ProjectCatalog struct {
 	Created              string             `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID            string             `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	Description          string             `json:"description,omitempty" yaml:"description,omitempty"`
+	HelmVersion          string             `json:"helmVersion,omitempty" yaml:"helmVersion,omitempty"`
 	Kind                 string             `json:"kind,omitempty" yaml:"kind,omitempty"`
 	Labels               map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
 	LastRefreshTimestamp string             `json:"lastRefreshTimestamp,omitempty" yaml:"lastRefreshTimestamp,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_template_status.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_template_status.go
@@ -1,8 +1,10 @@
 package client
 
 const (
-	TemplateStatusType = "templateStatus"
+	TemplateStatusType             = "templateStatus"
+	TemplateStatusFieldHelmVersion = "helmVersion"
 )
 
 type TemplateStatus struct {
+	HelmVersion string `json:"helmVersion,omitempty" yaml:"helmVersion,omitempty"`
 }

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_template_version_status.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_template_version_status.go
@@ -1,8 +1,10 @@
 package client
 
 const (
-	TemplateVersionStatusType = "templateVersionStatus"
+	TemplateVersionStatusType             = "templateVersionStatus"
+	TemplateVersionStatusFieldHelmVersion = "helmVersion"
 )
 
 type TemplateVersionStatus struct {
+	HelmVersion string `json:"helmVersion,omitempty" yaml:"helmVersion,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -477,7 +477,7 @@ github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io
 github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1
 github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/scheme
 github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/typed/upgrade.cattle.io/v1
-# github.com/rancher/types v0.0.0-20200304001827-068a357fa053
+# github.com/rancher/types v0.0.0-20200305160044-e8e610dd9e01
 github.com/rancher/types/apis/apiregistration.k8s.io/v1
 github.com/rancher/types/apis/apps/v1
 github.com/rancher/types/apis/autoscaling/v2beta2


### PR DESCRIPTION
**Problem**
Helm released Helm 3 and new applications need to be deployed using helm in order to support the newest features offered by helm 3 charts

**Solution** 
Add helm 3 to rancher while keeping currently deployed apps maintained with helm 2

**Issues** 
#25260 
#25261 
#21070 
#25262 

**Dependent on**
https://github.com/rancher/helm-unittest/pull/6
https://github.com/rancher/types/pull/1095
https://github.com/rancher/kustomizebuild/pull/1
https://github.com/rancher/types/pull/1106