### PR TITLE
check the graph etcd-peer-traffic only when there are more than one etcd node

### DIFF
--- a/tests/validation/tests/v3_api/test_monitoring.py
+++ b/tests/validation/tests/v3_api/test_monitoring.py
@@ -522,6 +522,12 @@ def check_data(source, target_list):
 def validate_cluster_graph(action_query, resource_type, timeout=10):
     target_graph_list = copy.deepcopy(name_mapping.get(resource_type))
     rancher_client, cluster = get_user_client_and_cluster()
+    # handle the special case that if the graph etcd-peer-traffic is
+    # is not available if there is only one etcd node in the cluster
+    if resource_type == "etcd":
+        nodes = get_etcd_nodes(cluster, rancher_client)
+        if len(nodes) == 1:
+            target_graph_list.remove("etcd-peer-traffic")
     start = time.time()
     while True:
         res = rancher_client.action(**action_query)


### PR DESCRIPTION

the graph `etcd-peer-traffic ` is available only when there are more than 1 etcd node, so 
- remove it from the list if only 1 etcd node exists
- otherwise, keep it 