### PR TITLE
Adding shibboleth + OpenLDAP Search Auth Provider

### DIFF
--- a/app/authconfig_data.go
+++ b/app/authconfig_data.go
@@ -54,6 +54,10 @@ func addAuthConfigs(management *config.ManagementContext) error {
 		return err
 	}
 
+	if err := addAuthConfig(saml.ShibbolethName, client.ShibbolethConfigType, false, management); err != nil {
+		return err
+	}
+
 	if err := addAuthConfig(googleoauth.Name, client.GoogleOauthConfigType, false, management); err != nil {
 		return err
 	}

--- a/pkg/api/controllers/samlconfig/samlconfig.go
+++ b/pkg/api/controllers/samlconfig/samlconfig.go
@@ -40,7 +40,7 @@ func (a *authProvider) sync(key string, config *v3.AuthConfig) (runtime.Object, 
 	}
 
 	if config.Name != saml.PingName && config.Name != saml.ADFSName && config.Name != saml.KeyCloakName &&
-		config.Name != saml.OKTAName {
+		config.Name != saml.OKTAName && config.Name != saml.ShibbolethName {
 		return nil, nil
 	}
 

--- a/pkg/api/store/auth/store.go
+++ b/pkg/api/store/auth/store.go
@@ -13,18 +13,27 @@ import (
 	client "github.com/rancher/types/client/management/v3"
 )
 
-var TypeToFields = map[string][]string{
-	client.GithubConfigType:          {client.GithubConfigFieldClientSecret},
-	client.ActiveDirectoryConfigType: {client.ActiveDirectoryConfigFieldServiceAccountPassword},
-	client.AzureADConfigType:         {client.AzureADConfigFieldApplicationSecret},
-	client.OpenLdapConfigType:        {client.LdapConfigFieldServiceAccountPassword},
-	client.FreeIpaConfigType:         {client.LdapConfigFieldServiceAccountPassword},
-	client.PingConfigType:            {client.PingConfigFieldSpKey},
-	client.ADFSConfigType:            {client.ADFSConfigFieldSpKey},
-	client.KeyCloakConfigType:        {client.KeyCloakConfigFieldSpKey},
-	client.OKTAConfigType:            {client.OKTAConfigFieldSpKey},
-	client.GoogleOauthConfigType:     {client.GoogleOauthConfigFieldOauthCredential, client.GoogleOauthConfigFieldServiceAccountCredential},
-}
+var (
+	TypeToFields = map[string][]string{
+		client.GithubConfigType:          {client.GithubConfigFieldClientSecret},
+		client.ActiveDirectoryConfigType: {client.ActiveDirectoryConfigFieldServiceAccountPassword},
+		client.AzureADConfigType:         {client.AzureADConfigFieldApplicationSecret},
+		client.OpenLdapConfigType:        {client.LdapConfigFieldServiceAccountPassword},
+		client.FreeIpaConfigType:         {client.LdapConfigFieldServiceAccountPassword},
+		client.PingConfigType:            {client.PingConfigFieldSpKey},
+		client.ADFSConfigType:            {client.ADFSConfigFieldSpKey},
+		client.KeyCloakConfigType:        {client.KeyCloakConfigFieldSpKey},
+		client.OKTAConfigType:            {client.OKTAConfigFieldSpKey},
+		client.ShibbolethConfigType:      {client.ShibbolethConfigFieldSpKey},
+		client.GoogleOauthConfigType:     {client.GoogleOauthConfigFieldOauthCredential, client.GoogleOauthConfigFieldServiceAccountCredential},
+	}
+
+	SubTypeToFields = map[string]map[string][]string{
+		client.ShibbolethConfigType: {
+			client.ShibbolethConfigFieldOpenLdapConfig: {client.LdapConfigFieldServiceAccountPassword},
+		},
+	}
+)
 
 func Wrap(store types.Store, secrets corev1.SecretInterface) types.Store {
 	return &Store{
@@ -45,15 +54,46 @@ func (s *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 	}
 
 	kind := convert.ToString(authType)
-	fields := TypeToFields[kind]
+	fields, ok := TypeToFields[kind]
+	subFields, subOk := SubTypeToFields[kind]
+	if !ok && !subOk {
+		return s.Store.Update(apiContext, schema, data, id)
+	}
+
+	var err error
 	for _, field := range fields {
 		if val, ok := data[field]; ok {
-			val := convert.ToString(val)
-			if err := common.CreateOrUpdateSecrets(s.Secrets, val, strings.ToLower(field), strings.ToLower(kind)); err != nil {
-				return nil, fmt.Errorf("error creating secret for %s:%s", kind, field)
+			data[field], err = s.CreateOrUpdateSecrets(convert.ToString(val), field, kind)
+			if err != nil {
+				return nil, err
 			}
-			data[field] = fmt.Sprintf("%s:%s-%s", namespace.GlobalNamespace, strings.ToLower(kind), strings.ToLower(field))
 		}
 	}
+
+	// subfields for embedded configs, see saml group search using openldap
+	for subField, subFieldList := range subFields {
+		if subData, ok := data[subField]; ok {
+			subData, casteOk := subData.(map[string]interface{})
+			if !casteOk {
+				continue
+			}
+			for _, field := range subFieldList {
+				if val, ok := subData[field]; ok {
+					subData[field], err = s.CreateOrUpdateSecrets(convert.ToString(val), field, kind)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+		}
+	}
+
 	return s.Store.Update(apiContext, schema, data, id)
+}
+
+func (s *Store) CreateOrUpdateSecrets(value, field, kind string) (string, error) {
+	if err := common.CreateOrUpdateSecrets(s.Secrets, value, strings.ToLower(field), strings.ToLower(kind)); err != nil {
+		return "", fmt.Errorf("error creating secret for %s:%s", kind, field)
+	}
+	return fmt.Sprintf("%s:%s-%s", namespace.GlobalNamespace, strings.ToLower(kind), strings.ToLower(field)), nil
 }

--- a/pkg/auth/providers/ldap/ldap_actions.go
+++ b/pkg/auth/providers/ldap/ldap_actions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
+	"github.com/rancher/rancher/pkg/auth/providers/common/ldap"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	managementschema "github.com/rancher/types/apis/management.cattle.io/v3/schema"
 	"github.com/rancher/types/apis/management.cattle.io/v3public"
@@ -70,7 +71,7 @@ func (p *ldapProvider) testAndApply(actionName string, action *types.Action, req
 		config.ServiceAccountPassword = value
 	}
 
-	caPool, err := newCAPool(config.Certificate)
+	caPool, err := ldap.NewCAPool(config.Certificate)
 	if err != nil {
 		return err
 	}

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -116,6 +116,13 @@ func Configure(ctx context.Context, mgmt *config.ScaledContext) {
 	providersByType[client.OKTAConfigType] = p
 	providersByType[publicclient.OKTAProviderType] = p
 
+	p = saml.Configure(ctx, mgmt, userMGR, tokenMGR, saml.ShibbolethName)
+	ProviderNames[saml.ShibbolethName] = true
+	UnrefreshableProviders[saml.ShibbolethName] = false
+	providers[saml.ShibbolethName] = p
+	providersByType[client.ShibbolethConfigType] = p
+	providersByType[publicclient.ShibbolethProviderType] = p
+
 	p = googleoauth.Configure(ctx, mgmt, userMGR, tokenMGR)
 	ProviderNames[googleoauth.Name] = true
 	ProvidersWithSecrets[googleoauth.Name] = true

--- a/pkg/auth/providers/publicapi/handler.go
+++ b/pkg/auth/providers/publicapi/handler.go
@@ -32,6 +32,7 @@ var authProviderTypes = []string{
 	v3public.ADFSProviderType,
 	v3public.KeyCloakProviderType,
 	v3public.OKTAProviderType,
+	v3public.ShibbolethProviderType,
 	v3public.GoogleOAuthProviderType,
 }
 

--- a/pkg/auth/providers/publicapi/login.go
+++ b/pkg/auth/providers/publicapi/login.go
@@ -145,6 +145,9 @@ func (h *loginHandler) createLoginToken(request *types.APIContext) (v3.Token, st
 	case client.OKTAProviderType:
 		input = &v3public.SamlLoginInput{}
 		providerName = saml.OKTAName
+	case client.ShibbolethProviderType:
+		input = &v3public.SamlLoginInput{}
+		providerName = saml.ShibbolethName
 	case client.GoogleOAuthProviderType:
 		input = &v3public.GoogleOauthLogin{}
 		providerName = googleoauth.Name
@@ -161,8 +164,9 @@ func (h *loginHandler) createLoginToken(request *types.APIContext) (v3.Token, st
 	// Authenticate User
 	// SAML's login flow is different from the other providers. Unlike the other providers, it gets the logged in user's data via a POST from
 	// the identity provider on a separate endpoint specifically for that.
+
 	if providerName == saml.PingName || providerName == saml.ADFSName || providerName == saml.KeyCloakName ||
-		providerName == saml.OKTAName {
+		providerName == saml.OKTAName || providerName == saml.ShibbolethName {
 		err = saml.PerformSamlLogin(providerName, request, input)
 		return v3.Token{}, "saml", err
 	}

--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -170,6 +170,9 @@ func InitializeSamlServiceProvider(configToSet *v3.SamlConfig, name string) erro
 	case OKTAName:
 		root.Get("OktaACS").HandlerFunc(provider.ServeHTTP)
 		root.Get("OktaMetadata").HandlerFunc(provider.ServeHTTP)
+	case ShibbolethName:
+		root.Get("ShibbolethACS").HandlerFunc(provider.ServeHTTP)
+		root.Get("ShibbolethMetadata").HandlerFunc(provider.ServeHTTP)
 	}
 
 	appliedVersion = configToSet.ResourceVersion
@@ -180,6 +183,7 @@ func InitializeSamlServiceProvider(configToSet *v3.SamlConfig, name string) erro
 func AuthHandler() http.Handler {
 	root = mux.NewRouter()
 	root.Use(responsewriter.ContentTypeOptions)
+
 	root.Methods("POST").Path("/v1-saml/ping/saml/acs").Name("PingACS")
 	root.Methods("GET").Path("/v1-saml/ping/saml/metadata").Name("PingMetadata")
 
@@ -191,6 +195,9 @@ func AuthHandler() http.Handler {
 
 	root.Methods("POST").Path("/v1-saml/okta/saml/acs").Name("OktaACS")
 	root.Methods("GET").Path("/v1-saml/okta/saml/metadata").Name("OktaMetadata")
+
+	root.Methods("POST").Path("/v1-saml/shibboleth/saml/acs").Name("ShibbolethACS")
+	root.Methods("GET").Path("/v1-saml/shibboleth/saml/metadata").Name("ShibbolethMetadata")
 
 	return root
 }

--- a/pkg/auth/providers/setup.go
+++ b/pkg/auth/providers/setup.go
@@ -23,6 +23,7 @@ var authConfigTypes = []string{
 	client.ADFSConfigType,
 	client.KeyCloakConfigType,
 	client.OKTAConfigType,
+	client.ShibbolethConfigType,
 	client.GoogleOauthConfigType,
 }
 

--- a/tests/integration/suite/test_auth_configs.py
+++ b/tests/integration/suite/test_auth_configs.py
@@ -15,7 +15,7 @@ def test_auth_configs(admin_mc):
 
     configs = client.list_auth_config()
 
-    assert configs.pagination.total == 11
+    assert configs.pagination.total == 12
 
     gh = None
     local = None
@@ -28,6 +28,7 @@ def test_auth_configs(admin_mc):
     keycloak = None
     okta = None
     googleoauth = None
+    shibboleth = None
 
     for c in configs:
         if c.type == "githubConfig":
@@ -52,6 +53,8 @@ def test_auth_configs(admin_mc):
             okta = c
         elif c.type == "googleOauthConfig":
             googleoauth = c
+        elif c.type == "shibbolethConfig":
+            shibboleth = c
 
     for x in [gh, local, ad, azure, openldap,
               freeIpa, ping, adfs, keycloak, okta, googleoauth]:
@@ -83,6 +86,8 @@ def test_auth_configs(admin_mc):
 
     assert googleoauth.actions.configureTest
     assert googleoauth.actions.testAndApply
+
+    assert shibboleth.actions.testAndEnable
 
 
 def test_auth_config_secrets(admin_mc):


### PR DESCRIPTION
Adds a new SAML auth provider for Shibboleth but couples it with OpenLDAP searching for Principals. It operates as a standalone SAML provider with no needed extra configs but if you backend Shibboleth with OpenLDAP you can configure it like a regular OpenLDAP auth provider but only works for get/search so you can find and assign principals to Clusters/Projects/etc.

This PR explicitly avoids Refetching principals, please see this Issue to track potentially adding that functionality: https://github.com/rancher/rancher/issues/25397

**Overview**

- Added Shibboleth as a new Auth Provider
- Added OpenLdapFields to Shibboleth Auth Type to store params
- Cut into functionality in SAML provider to call out to ldap provider (GetPrincipal/SearchPrincipal)
- Added store/retrieve of secrets from sub field of auth config (see auth/store.go and getLdapConfig)


#24235
requires: rancher/types#1085