### PR TITLE
[WIP] Initial test architecture and validation tests for rancher cli

### DIFF
--- a/tests/validation/tests/v3_api/cli_common.py
+++ b/tests/validation/tests/v3_api/cli_common.py
@@ -1,0 +1,77 @@
+import ast
+import os
+import logging
+import sys
+
+from .common import run_command, run_command_with_stderr
+
+logging.basicConfig(stream=sys.stdout,
+                    level=os.environ.get("LOGLEVEL", "INFO"),
+                    format='%(asctime)s - %(name)s - '
+                           '[%(levelname)5s]: %(message)s')
+DEFAULT_CONTEXT = os.environ.get('DEFAULT_CONTEXT', None)
+
+
+class RancherCli:
+    DEBUG_LOGS = ast.literal_eval(
+        os.environ.get('DEBUG', "False").capitalize())
+    log = logging.getLogger(__name__)
+
+    @classmethod
+    def run_command(cls, command, expect_error=False):
+        command = "rancherctl {}".format(command)
+        if cls.DEBUG_LOGS:
+            cls.log.debug("run cmd:\t%s", command)
+        if expect_error:
+            result = run_command_with_stderr(command, log_out=False)
+        else:
+            result = run_command(command, log_out=False)
+        if cls.DEBUG_LOGS:
+            cls.log.debug("returns:\t%s", result)
+        return result
+
+    def set_log_level(self, level):
+        self.log.setLevel(level)
+
+    def login(self, url, token, **kwargs):
+        context = kwargs.get("context", DEFAULT_CONTEXT)
+        if context is None:
+            raise ValueError("No context supplied for rancher login!")
+        cmd = "login {} --token {} --context {} --skip-verify".format(
+            url, token, context)
+        self.run_command(cmd, expect_error=True)
+
+    def switch_context(self, project_id):
+        self.run_command("context switch {}".format(project_id),
+                         expect_error=True)
+
+    def get_context(self):
+        result = self.run_command("context current")
+        cluster_name = result[8:result.index(" ")].strip()
+        project_name = result[result.index("Project:") + 8:].strip()
+        return cluster_name, project_name
+
+    def get_cluster_by_name(self, name):
+        for c in self.get_clusters():
+            if c["name"] == name:
+                return c
+
+    def get_current_cluster(self):
+        for c in self.get_clusters():
+            if c["current"]:
+                return c
+
+    def get_clusters(self):
+        result = self.run_command("clusters ls --format '{{.Cluster.ID}}"
+                                  "|{{.Cluster.Name}}|{{.Current}}|{{.Cluster.UUID}}'")
+        clusters = []
+        for c in result.splitlines():
+            c = c.split("|")
+            cluster = {
+                "id": c[0],
+                "name": c[1],
+                "current": c[2] == "*",
+                "uuid": c[3]
+            }
+            clusters.append(cluster)
+        return clusters

--- a/tests/validation/tests/v3_api/cli_objects.py
+++ b/tests/validation/tests/v3_api/cli_objects.py
@@ -1,0 +1,101 @@
+import time
+
+from .common import get_user_client, random_test_name
+from .cli_common import RancherCli, DEFAULT_CONTEXT
+
+DEFAULT_TIMEOUT = 60
+
+class CliProject(RancherCli):
+    def __init__(self):
+        self.initial_projects = self.get_current_projects()
+
+    def create_project(self, name=None,
+                       cluster_id=None, use_context=True):
+        if name is None:
+            name = random_test_name("ptest")
+        if cluster_id is None:
+            cluster = self.get_context()[0]
+            cluster_id = self.get_cluster_by_name(cluster)["id"]
+        self.run_command("projects create --cluster {} {}".format(cluster_id,
+                                                                  name))
+        project = None
+        for p in self.get_current_projects():
+            if p["name"] == name:
+                project = p
+                self.log.info("Project '%s' created successfully "
+                              "in cluster '%s'", name, cluster_id)
+                break
+        if project is None:
+            self.log.error("Failed to create project '%s' "
+                           "in cluster '%s'", name, cluster_id)
+            return project
+
+        if use_context:
+            self.log.info("Switching context to newly created project: "
+                          "%s", name)
+            for p in self.get_current_projects():
+                if p["name"] == name:
+                    self.switch_context(p["id"])
+                    break
+        return project
+
+    def delete_project(self, name):
+        self.run_command("projects rm {}".format(name))
+
+    @classmethod
+    def get_current_projects(cls):
+        """This uses the Rancher Python Client to retrieve the current projects
+        as there is not a CLI way to do this without passing stdin at the time
+        of creation (2/13/2020, Rancher v2.3.5).
+        Returns array of dictionaries containing id, name, clusterid, & uuid"""
+        client = get_user_client()
+        projects = client.list_project()
+        current_projects = []
+        for project in projects:
+            p = {
+                "id": project["id"],
+                "name": project["name"],
+                "clusterId": project["clusterId"],
+                "state": project["state"],
+                "uuid": project["uuid"]
+            }
+            current_projects.append(p)
+        cls.log.debug("Projects: %s", current_projects)
+        return current_projects
+
+    def create_namespace(self, name=None):
+        if name is None:
+            name = random_test_name("nstest")
+        self.run_command("namespace create {}".format(name))
+        return name
+
+    def delete_namespace(self, name):
+        self.run_command("namespace delete {}".format(name))
+
+        deleted = False
+        self.log.debug("Waiting for the namespace to be deleted")
+        start_time = time.time()
+        while not deleted and time.time() - start_time < DEFAULT_TIMEOUT:
+            namespaces = self.run_command("namespace ls -q")
+            if name not in namespaces.splitlines():
+                deleted = True
+
+        if not deleted:
+            ns = self.run_command("namespace ls --format '{{.Namespace.Name}}"
+                                  "|{{.Namespace.State}}' "
+                                  "| grep {}".format(name))
+            self.log.warn("Namespace did not delete within timeout. "
+                          "Status: %s", ns.split("|")[1])
+            if not ns:
+                return True
+            return False
+        return True
+
+    def get_namespaces(self):
+        namespaces = self.run_command("namespace ls --format "
+                                      "'{{.Namespace.Name}}"
+                                      "|{{.Namespace.State}}'")
+        return namespaces.splitlines()
+
+    def move_namespace(self, name, project_id):
+        self.run_command("namespace move {} {}".format(name, project_id))

--- a/tests/validation/tests/v3_api/test_cli.py
+++ b/tests/validation/tests/v3_api/test_cli.py
@@ -1,0 +1,95 @@
+import os
+import pytest
+
+from .cli_common import RancherCli, DEFAULT_CONTEXT
+from .common import CATTLE_TEST_URL, USER_TOKEN, get_user_client
+from .cli_objects import CliProject
+
+CLUSTER_NAMES = [os.environ.get("RANCHER_CLUSTER_NAME_1", ""),
+                 os.environ.get("RANCHER_CLUSTER_NAME_2", "")]
+
+
+def test_list_clusters(rancher_cli: RancherCli):
+    rancher_cli.log.info("Testing Listing Clusters")
+    clusters = rancher_cli.get_clusters()
+    assert len(clusters) == 2
+    for cluster in clusters:
+        assert cluster["name"] in CLUSTER_NAMES
+
+
+def test_context_switching(rancher_cli: RancherCli):
+    rancher_cli.log.info("Testing Context Switching")
+    clusters = rancher_cli.get_clusters()
+    client = get_user_client()
+    projects = client.list_project()
+    for project in projects:
+        rancher_cli.switch_context(project['id'])
+        cluster_name, project_name = rancher_cli.get_context()
+        assert any(cluster["id"] == project['clusterId']
+                   and cluster["name"] == cluster_name for cluster in clusters)
+        assert project_name == project['name']
+
+
+def test_project_manipulation(remove_cli_resource, cli_projects: CliProject):
+    cli_projects.log.info("Testing Creating and Deleting Projects")
+    project = cli_projects.create_project(use_context=False)
+    remove_cli_resource("project", project["id"])
+    assert project is not None
+    assert len(cli_projects.initial_projects) == \
+        len(cli_projects.get_current_projects()) - 1
+
+    cli_projects.delete_project(project["name"])
+    assert len(cli_projects.initial_projects) == \
+        len(cli_projects.get_current_projects())
+
+
+def test_namespace_manipulation(remove_cli_resource, cli_projects: CliProject):
+    cli_projects.log.info("Testing Creating, Deleting, and Moving Namespaces")
+    p1 = cli_projects.create_project()
+    remove_cli_resource("project", p1["id"])
+    namespace = cli_projects.create_namespace()
+    remove_cli_resource("namespace", namespace)
+    assert len(cli_projects.get_namespaces()) == 1
+    assert "{}|active".format(namespace) in cli_projects.get_namespaces()
+
+    p2 = cli_projects.create_project(use_context=False)
+    remove_cli_resource("project", p2["id"])
+    cli_projects.move_namespace(namespace, p2["id"])
+    assert len(cli_projects.get_namespaces()) == 0
+    cli_projects.switch_context(p2["id"])
+    assert len(cli_projects.get_namespaces()) == 1
+    assert "{}|active".format(namespace) in cli_projects.get_namespaces()
+
+    deleted = cli_projects.delete_namespace(namespace)
+    assert deleted
+
+
+@pytest.fixture()
+def cli_projects(rancher_cli):
+    return CliProject()
+
+
+@pytest.fixture(scope='module', autouse="True")
+def rancher_cli(request):
+    cli = RancherCli()
+    cli.login(CATTLE_TEST_URL, USER_TOKEN)
+    return cli
+
+
+@pytest.fixture
+def remove_cli_resource(request, rancher_cli):
+    """Remove a resource after a test finishes even if the test fails.
+
+    How to use:
+      pass this function as an argument of your testing function,
+      then call this function with the resource type and its id
+      as arguments after creating any new resource
+    """
+    def _cleanup(resource, r_id):
+        def clean():
+            rancher_cli.switch_context(DEFAULT_CONTEXT)
+            rancher_cli.log.info("Cleaning up {}: {}".format(resource, r_id))
+            rancher_cli.run_command("{} delete {}".format(resource, r_id),
+                                    expect_error=True)
+        request.addfinalizer(clean)
+    return _cleanup


### PR DESCRIPTION
- Is part of v3_api as it will use the API/rancher Client in some tests for comparisons and to retrieve object IDs that are otherwise not available in the CLI
- Uses a logging framework instead of prints
- Broken up into classes for cli object types to keep concerned areas focused in specific parts