### PR TITLE
Validation - Provision Windows custom cluster

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -1068,13 +1068,20 @@ def get_custom_host_registration_cmd(client, cluster, roles, node):
         cluster_token = cluster_tokens[0]
     else:
         cluster_token = create_custom_host_registration_token(client, cluster)
-    cmd = cluster_token.nodeCommand
-    for role in roles:
-        assert role in allowed_roles
-        cmd += " --" + role
+    
     additional_options = " --address " + node.public_ip_address + \
-                         " --internal-address " + node.private_ip_address
-    cmd += additional_options
+                            " --internal-address " + node.private_ip_address
+
+    if 'windows' in node.os_version:
+        cmd = cluster_token.windowsNodeCommand
+        cmd = cmd.replace('| iex', '--worker' + additional_options + ' | iex ')
+    else:
+        cmd = cluster_token.nodeCommand
+        for role in roles:
+            assert role in allowed_roles
+            cmd += " --" + role
+        
+        cmd += additional_options
     return cmd
 
 

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -164,6 +164,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                     jobs["ec2"] = { build job: 'rancher-v3_ontag_ec2_certification', parameters: params }
                     jobs["az"] = { build job: 'rancher-v3_ontag_az_certification', parameters: params }
                     jobs["custom"] = { build job: 'rancher-v3_ontag_custom_certification', parameters: params}
+                    jobs["windows"] = { build job: 'rancher-v3_ontag_windows_certification', parameters: params}
 
                     // Rancher server 2 is used to test GKE, EKS, AKS and Imported clusters
                     jobs["gke"] = { build job: 'rancher-v3_ontag_gke_certification', parameters: params2 }

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_provision_and_test
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_provision_and_test
@@ -12,11 +12,14 @@ node {
   def TESTS_TO_RUN =  [ "test_wl", "test_dns_record", "test_rbac","test_connectivity", "test_ingress",
                         "test_secrets", "test_registry", "test_service_discovery", "test_websocket"]
 
+  def WINDOWS_PYTEST_OPTIONS = "-k \"test_ingress or test_rbac or test_sa or test_secrets or test_service_discovery or test_workload\""
+
   if (env.RANCHER_SKIP_INGRESS == "True") { 
     TESTS_TO_RUN = TESTS_TO_RUN - ["test_ingress"]
   }
 
-  def PYTEST_OPTIONS = "-k \"" + TESTS_TO_RUN.join(" or ") +"\""
+  def LINUX_PYTEST_OPTIONS = "-k \"" + TESTS_TO_RUN.join(" or ") +"\""
+  def PYTEST_OPTIONS = LINUX_PYTEST_OPTIONS
 
   def branch = "master"
   if ("${env.branch}" != "null" && "${env.branch}" != "") {
@@ -77,6 +80,10 @@ node {
               // copy file containing CATTLE_TEST_URL & ADMIN_TOKEN and load into environment variables
               sh "docker cp ${provisionContainer}:${rootPath}${testsDir}${rancherConfig} ."
               load rancherConfig
+
+              if (env.RANCHER_TEST_OS == 'windows') {
+                PYTEST_OPTIONS = WINDOWS_PYTEST_OPTIONS
+              }
 
               sh "docker run --name ${testContainer}  --env-file .env " +
                 "${imageName} /bin/bash -c \'export RANCHER_CLUSTER_NAME=${env.CLUSTER_NAME} && pytest -v -s --junit-xml=${testResultsOut} ${PYTEST_OPTIONS} ${testsDir}\'"

--- a/tests/validation/tests/v3_api/test_windows_cluster.py
+++ b/tests/validation/tests/v3_api/test_windows_cluster.py
@@ -1,0 +1,49 @@
+
+from .common import TEST_IMAGE
+from .common import TEST_IMAGE_NGINX
+from .common import TEST_IMAGE_OS_BASE
+from .common import cluster_cleanup
+from .common import get_user_client
+from .common import random_test_name
+from .test_rke_cluster_provisioning import create_custom_host_from_nodes
+from .test_rke_cluster_provisioning import HOST_NAME
+
+from lib.aws import AmazonWebServices
+from threading import Thread
+
+def test_windows_provisioning():
+    node_roles_linux = [["controlplane"], ["etcd"], ["worker"]]
+    node_roles_windows = [["worker"], ["worker"], ["worker"]]
+
+    win_nodes = \
+        AmazonWebServices().create_multiple_nodes(
+            len(node_roles_windows), random_test_name(HOST_NAME), os_version="windows-1903", 
+            docker_version="19.03")
+
+    aws_nodes = \
+        AmazonWebServices().create_multiple_nodes(
+            len(node_roles_linux), random_test_name(HOST_NAME))
+
+    nodes = aws_nodes + win_nodes
+    node_roles = node_roles_linux + node_roles_windows
+
+    cluster, aws_nodes = create_custom_host_from_nodes(nodes, 
+                                                       node_roles, 
+                                                       random_cluster_name=True, 
+                                                       windows=True)
+                                                       
+    node_threads = []
+    for node in win_nodes:
+        thread = Thread(target=pull_images, args=[node])
+        node_threads.append(thread)
+        thread.start()
+
+    for thread in node_threads:
+        thread.join()
+        
+    cluster_cleanup(get_user_client(), cluster, nodes)
+
+def pull_images(node):
+    print("Pulling images on node: " + node.host_name)
+    pull_result = node.execute_command("docker pull " + TEST_IMAGE + " && " + "docker pull " + TEST_IMAGE_NGINX + " && " + "docker pull " + TEST_IMAGE)
+    print(pull_result)


### PR DESCRIPTION
Added ability to create Windows nodes and execute commands with `node.exec_command`

* Nodes must be created w/ `create_multiple_nodes`
* See example `test_windows_cluster.py`
* Windows nodes default to 100gb volume and t3.xlarge instance size