### PR TITLE
Fix the problem alerting can not be enabled

### DIFF
--- a/pkg/controllers/user/alert/deployer/deployer.go
+++ b/pkg/controllers/user/alert/deployer/deployer.go
@@ -289,7 +289,8 @@ func (d *appDeployer) deploy(appName, appTargetNamespace, systemProjectID string
 	if err != nil && !apierrors.IsNotFound(err) {
 		return false, fmt.Errorf("failed to query %q App in %s Project, %v", appName, systemProjectName, err)
 	}
-	if app.Name == appName {
+
+	if app != nil && app.Name == appName {
 		if app.DeletionTimestamp != nil {
 			return false, fmt.Errorf("stale %q App in %s Project is still on terminating", appName, systemProjectName)
 		}


### PR DESCRIPTION
Problem:

Alerting can not be enabled

Solution:

If it is the first time to deploy cluster-alerting, the variable “app” is null in here.
https://github.com/rancher/rancher/blob/master/pkg/controllers/user/alert/deployer/deployer.go#L288
https://github.com/rancher/rancher/blob/master/pkg/controllers/user/alert/deployer/deployer.go#L292

So we need to check if it's null.

Related Issue:  

https://github.com/rancher/rancher/issues/25507