### PR TITLE
Adds cert expiration warnings for local cluster

### DIFF
--- a/pkg/controllers/management/certsexpiration/certsexpiration.go
+++ b/pkg/controllers/management/certsexpiration/certsexpiration.go
@@ -1,0 +1,82 @@
+package certsexpiration
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	"github.com/rancher/rancher/pkg/rkecerts"
+	rkeCluster "github.com/rancher/rke/cluster"
+	v1 "github.com/rancher/types/apis/core/v1"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// This controller handles cert expiration for local cluster only
+func Register(ctx context.Context, management *config.ManagementContext) {
+	c := &certsExpiration{
+		clusters:        management.Management.Clusters(""),
+		configMapLister: management.Core.ConfigMaps("kube-system").Controller().Lister(),
+	}
+	management.Management.Clusters("").AddHandler(ctx, "certificate-expiration", c.sync)
+}
+
+type certsExpiration struct {
+	clusters        v3.ClusterInterface
+	configMapLister v1.ConfigMapLister
+}
+
+func (c *certsExpiration) sync(key string, cluster *v3.Cluster) (runtime.Object, error) {
+	if cluster == nil || cluster.Name != "local" {
+		return cluster, nil // We are only checking local cluster
+	}
+	cm, err := c.configMapLister.Get("kube-system", rkeCluster.FullStateConfigMapName)
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return cluster, nil // not an rke cluster, nothing we can do
+		}
+		return cluster, err
+	}
+	certBundle, err := rkecerts.CertBundleFromConfig(cm)
+	if err != nil {
+		return cluster, err
+	}
+	rkecerts.CleanCertificateBundle(certBundle)
+
+	certsExpInfo := map[string]v3.CertExpiration{}
+	for certName, certObj := range certBundle {
+		info, err := rkecerts.GetCertExpiration(certObj.CertificatePEM)
+		if err != nil {
+			logrus.Debugf("failed to get expiration date for certificate [%s] for local cluster: %v", certName, err)
+			continue
+		}
+		certsExpInfo[certName] = info
+		err = logCertExpirationWarning(certName, info)
+		if err != nil {
+			logrus.Warnf("certificate [%s] from local cluster has or will expire and date is corrupted: %v", certName, err)
+			continue
+		}
+	}
+	// Update certExpiration on cluster obj in order for it to display in API, and the UI if expiring
+	if !reflect.DeepEqual(cluster.Status.CertificatesExpiration, certsExpInfo) {
+		cluster.Status.CertificatesExpiration = certsExpInfo
+		return c.clusters.Update(cluster)
+	}
+	return cluster, nil
+}
+
+func logCertExpirationWarning(name string, certExp v3.CertExpiration) error {
+	date, err := time.Parse(time.RFC3339, certExp.ExpirationDate)
+	if err != nil {
+		return err
+	}
+	if time.Now().UTC().After(date) { // warn if expired
+		logrus.Warnf("Certificate from local cluster has expired: %s", name)
+	} else if time.Now().UTC().AddDate(0, 1, 0).After(date) { // warn if within a month
+		logrus.Warnf("Certificate from local cluster will expire soon: %s", name)
+	}
+	return nil
+}

--- a/pkg/controllers/management/controller.go
+++ b/pkg/controllers/management/controller.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/controllers/management/auth"
 	"github.com/rancher/rancher/pkg/controllers/management/catalog"
+	"github.com/rancher/rancher/pkg/controllers/management/certsexpiration"
 	"github.com/rancher/rancher/pkg/controllers/management/cloudcredential"
 	"github.com/rancher/rancher/pkg/controllers/management/cluster"
 	"github.com/rancher/rancher/pkg/controllers/management/clusterdeploy"
@@ -37,6 +38,7 @@ func Register(ctx context.Context, management *config.ManagementContext, manager
 
 	// a-z
 	catalog.Register(ctx, management)
+	certsexpiration.Register(ctx, management)
 	cluster.Register(ctx, management)
 	clusterdeploy.Register(ctx, management, manager)
 	clustergc.Register(ctx, management)

--- a/pkg/rkecerts/expiration.go
+++ b/pkg/rkecerts/expiration.go
@@ -1,0 +1,59 @@
+package rkecerts
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	rkeCluster "github.com/rancher/rke/cluster"
+	"github.com/rancher/rke/pki"
+	"github.com/rancher/rke/pki/cert"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	v1 "k8s.io/api/core/v1"
+)
+
+func CleanCertificateBundle(certs map[string]pki.CertificatePKI) {
+	for name := range certs {
+		if strings.Contains(name, "token") || strings.Contains(name, "header") || strings.Contains(name, "admin") {
+			delete(certs, name)
+		}
+	}
+}
+
+func GetCertExpiration(c string) (v3.CertExpiration, error) {
+	date, err := GetCertExpirationDate(c)
+	if err != nil {
+		return v3.CertExpiration{}, err
+	}
+	return v3.CertExpiration{
+		ExpirationDate: date.Format(time.RFC3339),
+	}, nil
+}
+
+func GetCertExpirationDate(c string) (*time.Time, error) {
+	certs, err := cert.ParseCertsPEM([]byte(c))
+	if err != nil {
+		return nil, err
+	}
+	if len(certs) == 0 {
+		return nil, errors.New("no valid certs found")
+	}
+	return &certs[0].NotAfter, nil
+}
+
+func CertBundleFromConfig(cm *v1.ConfigMap) (map[string]pki.CertificatePKI, error) {
+	if cm == nil {
+		return nil, errors.New("full-cluster-state configmap not found")
+	}
+	rawCerts, ok := cm.Data[rkeCluster.FullStateConfigMapName]
+	if !ok {
+		return nil, errors.New("full-cluster-state configmap does not contain data")
+	}
+	rkeFullState := &rkeCluster.FullState{}
+	err := json.Unmarshal([]byte(rawCerts), rkeFullState)
+	if err != nil {
+		return nil, err
+	}
+	return rkeFullState.CurrentState.CertificatesBundle, nil
+}

--- a/pkg/rkecerts/expiration_test.go
+++ b/pkg/rkecerts/expiration_test.go
@@ -1,0 +1,116 @@
+package rkecerts
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	rkeCluster "github.com/rancher/rke/cluster"
+	"github.com/rancher/rke/pki"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	v1 "k8s.io/api/core/v1"
+)
+
+var exampleCert = "-----BEGIN CERTIFICATE-----\nMIICpDCCAYwCCQCPcjBFQaNrJjANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls\nb2NhbGhvc3QwHhcNMjAwMjI1MTYxMDAxWhcNMjEwMjI0MTYxMDAxWjAUMRIwEAYD\nVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDj\nPcg9ksAr44psuf0SHwFQC6GceTNHggKZDAqADlhFCZ9P5kb+JUJJ86u08LLDSBDF\nl0EsQSPbmCJmr7mnUf7byBBC8/5pTiZXIHM7VUhjL5Ooq8D9xbylTah8fMmcQbdc\nv8RffbHIpQ7oEHrpfEdv8FeIdpQEdiCVzZBV6LX/Cw5YkJvAx4P/E7Kf2c99YGeP\nmRxI94vThrd3mtFCzyyXgrW1wUtbBipFC/y0vpVhCceDAWThQeSF6ZwjxXOjUqvC\netME1jwnnn7al2GmbcfhY8sx73EQwbQI+Kn5sul+oixRHFL4XFZIWCYe2YXJ2dpC\n7SxF+844YT4fEyItEG83AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAErzQ7eS1rB8\nOx/we9yC3X3z+5V0cH91tyXvGrVYJuWN+kdv/bQP0Gu+Fvk+82jHcoQS8hRn77t+\noyfph/lk8WicsllVud06Z7K16akxzBtSUahkw38UuVxuQ8U5ZuH5JkyZVcRyq210\nR3sn5U9gxFZ3zISfWhZI8EXU/K7IB03Bv3HG0uZwRpI8w5O6jC9vD2hoFHPpqlTQ\nfVpQjALKswZWdN5Dm7YP9JpUjWrl6lFmkE2cpj+F0cZHIgWupsBgVT7WwRUGgZPN\nstf+yTf2og2fVciZuopzfMhk545Zwye7CUseOP6YOeWKnm/UbR314fKX7Rum1saM\nbVQypIiA8ds=\n-----END CERTIFICATE-----\n"
+
+func TestGetCertExpirationDate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cert    string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name:    "return correct date",
+			cert:    exampleCert,
+			want:    time.Date(2021, 02, 24, 16, 10, 01, 0, time.UTC),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetCertExpirationDate(tt.cert)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetCertExpirationDate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.want.Equal(*got) {
+				t.Errorf("GetCertExpirationDate() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetCertExpiration(t *testing.T) {
+	tests := []struct {
+		name    string
+		cert    string
+		want    v3.CertExpiration
+		wantErr bool
+	}{
+		{
+			name: "valid cert",
+			cert: exampleCert,
+			want: v3.CertExpiration{
+				ExpirationDate: "2021-02-24T16:10:01Z",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetCertExpiration(tt.cert)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetCertExpiration() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCertExpiration() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCertBundleFromConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		configMap v1.ConfigMap
+		want      map[string]pki.CertificatePKI
+		wantErr   bool
+	}{
+		{
+			name: "valid configmap",
+			configMap: v1.ConfigMap{
+				Data: map[string]string{
+					rkeCluster.FullStateConfigMapName: fmt.Sprintf("{\"currentState\":{\"certificatesBundle\":{\"kube-admin\":{\"certificatePEM\":\"%s\"}}}}", strings.Replace(exampleCert, "\n", `\n`, -1)),
+				},
+			},
+			want: map[string]pki.CertificatePKI{
+				"kube-admin": pki.CertificatePKI{
+					CertificatePEM: exampleCert,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "invalid configmap",
+			configMap: v1.ConfigMap{},
+			want:      nil,
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CertBundleFromConfig(&tt.configMap)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CertBundleFromConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CertBundleFromConfig() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/23543

Implements management controller to check for RKE's `full-cluster-state` configMap for expiring certs. Re-used lots of the user-controller code which checked downstream clusters, so I moved that into pkg to share. 

### Blockers 
**Requires UI update**: The UI shows the warning but it also shows option to rotate certificates, which the local cluster can't do because it doesn't have an RKE Config. UI should be able to check and see if rotate action exists on the cluster, and if not then [hide the link](https://github.com/rancher/ui/blob/master/lib/monitoring/addon/components/cluster-dashboard/template.hbs#L1-L3). 

![Screen Shot 2020-02-24 at 4 28 48 PM](https://user-images.githubusercontent.com/571419/75200422-e0307c80-5722-11ea-9949-387531d664c7.png)
