### PR TITLE
[Master] Send detail information after alert is resolved

### DIFF
--- a/pkg/controllers/user/alert/deployer/notification_template.go
+++ b/pkg/controllers/user/alert/deployer/notification_template.go
@@ -52,8 +52,14 @@ The metric {{ .CommonLabels.alert_name}} crossed the threshold
 {{ end -}}
 
 {{- define "__text_list" -}}
+{{- if eq .Status "resolved" -}}
+{{ range .Alerts.Resolved }}
+{{ template "__text_single" . }}
+{{ end -}}
+{{- else}}
 {{ range .Alerts.Firing }}
 {{ template "__text_single" . }}
+{{ end -}}
 {{ end -}}
 {{ end -}}
 
@@ -124,8 +130,14 @@ Logs: {{ .Labels.logs}}
 {{ end -}}
 
 {{- define "__email_text_list" -}}
+{{- if eq .Status "resolved" -}}
+{{ range .Alerts.Resolved }}
+{{ template "__email_text_single" . }}
+{{ end -}}
+{{- else}}
 {{ range .Alerts.Firing }}
 {{ template "__email_text_single" . }}
+{{ end -}}
 {{ end -}}
 {{ end -}}
 


### PR DESCRIPTION
Problem:

the resolved notification will not contain any body providing details of the cluster and deployment the error related to, but just the subject, e.g. [Resolved]Warning event of Pod occurred. As a result with multiple alerts firing it is not possible to determine from the Resolved notification which alert is resolved.
Solution:

Add body text to resolved notifications

Related Issue:

https://github.com/rancher/rancher/issues/24156


Before:

![image](https://user-images.githubusercontent.com/21168270/78616390-ad8fad00-78a6-11ea-9075-5580aaa1949d.png)


After:

![image](https://user-images.githubusercontent.com/21168270/78616429-c4360400-78a6-11ea-81f9-afd13f589f15.png)

2.4 Backport PR:

https://github.com/rancher/rancher/pull/26520