### PR TITLE
RKE Config Added to Backups and Restore Options for version/config

### DIFF
--- a/pkg/api/customization/cluster/actions_etcd.go
+++ b/pkg/api/customization/cluster/actions_etcd.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -15,6 +16,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/management/etcdbackup"
 	"github.com/rancher/rancher/pkg/ref"
 	mgmtv3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	client "github.com/rancher/types/client/management/v3"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -38,7 +40,12 @@ func (a ActionHandler) BackupEtcdHandler(actionName string, action *types.Action
 		return errors.Wrapf(err, "failed to get Cluster by ID %s", apiContext.ID)
 	}
 
-	newBackup := etcdbackup.NewBackupObject(cluster, true)
+	newBackup, err := etcdbackup.NewBackupObject(cluster, true)
+	if err != nil {
+		response["message"] = "failed to initialize etcdbackup object"
+		apiContext.WriteResponse(http.StatusInternalServerError, response)
+		return errors.Wrapf(err, "failed to initialize etcdbackup object")
+	}
 
 	backup, err := a.BackupClient.Create(newBackup)
 	if err != nil {
@@ -88,13 +95,14 @@ func (a ActionHandler) RestoreFromEtcdBackupHandler(actionName string, action *t
 		return errors.Wrapf(err, "failed to get Cluster by ID %s", apiContext.ID)
 	}
 
+	var backup *v3.EtcdBackup
 	clusterBackupConfig := cluster.Spec.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig
 	if clusterBackupConfig != nil && clusterBackupConfig.S3BackupConfig == nil {
 		ns, name := ref.Parse(input.EtcdBackupID)
 		if ns == "" || name == "" {
 			return httperror.NewAPIError(httperror.InvalidFormat, fmt.Sprintf("invalid input id %s", input.EtcdBackupID))
 		}
-		backup, err := a.BackupClient.GetNamespaced(ns, name, v1.GetOptions{})
+		backup, err = a.BackupClient.GetNamespaced(ns, name, v1.GetOptions{})
 		if err != nil {
 			response["message"] = "error getting backup config"
 			apiContext.WriteResponse(http.StatusInternalServerError, response)
@@ -106,8 +114,32 @@ func (a ActionHandler) RestoreFromEtcdBackupHandler(actionName string, action *t
 		}
 	}
 
+	if input.RestoreRkeConfig != "" && backup.Status.ClusterObject == "" {
+		// attempting to restore rke config and the backup does not contain data, probably pre 2.4 backup
+		return httperror.NewAPIError(httperror.MethodNotAllowed,
+			fmt.Sprintf("unable to restore RKE config, backup contains no cluster object: %s", input.EtcdBackupID))
+	}
+
+	// backup was taken in 2.4+ and has content
+	switch strings.ToLower(input.RestoreRkeConfig) {
+	case "kubernetesversion":
+		// restore from copy stored inline to not have to decompress object
+		cluster.Spec.RancherKubernetesEngineConfig.Version = backup.Status.KubernetesVersion
+	case "all":
+		clusterBackup, err := etcdbackup.DecompressCluster(backup.Status.ClusterObject)
+		if err != nil {
+			response["message"] = "error decompressing cluster object"
+			apiContext.WriteResponse(http.StatusInternalServerError, response)
+			return errors.Wrap(err,
+				fmt.Sprintf("error decompressing cluster object for backupid %s: %s", input.EtcdBackupID, err))
+		}
+		cluster.Spec.RancherKubernetesEngineConfig = clusterBackup.Spec.RancherKubernetesEngineConfig
+	}
+
+	// flag cluster for restore
 	cluster.Spec.RancherKubernetesEngineConfig.Restore.SnapshotName = input.EtcdBackupID
 	cluster.Spec.RancherKubernetesEngineConfig.Restore.Restore = true
+
 	if _, err = a.ClusterClient.Update(cluster); err != nil {
 		response["message"] = "failed to update cluster object"
 		apiContext.WriteResponse(http.StatusInternalServerError, response)

--- a/pkg/controllers/management/etcdbackup/etcdbackup.go
+++ b/pkg/controllers/management/etcdbackup/etcdbackup.go
@@ -1,10 +1,15 @@
 package etcdbackup
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -187,7 +192,10 @@ func (c *Controller) doClusterBackupSync(cluster *v3.Cluster) error {
 }
 
 func (c *Controller) createNewBackup(cluster *v3.Cluster) (*v3.EtcdBackup, error) {
-	newBackup := NewBackupObject(cluster, false)
+	newBackup, err := NewBackupObject(cluster, false)
+	if err != nil {
+		return nil, err
+	}
 	v3.BackupConditionCreated.CreateUnknownIfNotExists(newBackup)
 	return c.backupClient.Create(newBackup)
 
@@ -261,7 +269,7 @@ func (c *Controller) rotateExpiredBackups(cluster *v3.Cluster, clusterBackups []
 	return nil
 }
 
-func NewBackupObject(cluster *v3.Cluster, manual bool) *v3.EtcdBackup {
+func NewBackupObject(cluster *v3.Cluster, manual bool) (*v3.EtcdBackup, error) {
 	controller := true
 	typeFlag := "r"     // recurring is the default
 	providerFlag := "l" // local is the default
@@ -273,6 +281,12 @@ func NewBackupObject(cluster *v3.Cluster, manual bool) *v3.EtcdBackup {
 		providerFlag = "s" // s3 backup
 	}
 	prefix := fmt.Sprintf("%s-%s%s-", cluster.Name, typeFlag, providerFlag)
+
+	compressedCluster, err := CompressCluster(cluster)
+	if err != nil {
+		return nil, err
+	}
+
 	return &v3.EtcdBackup{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    cluster.Name,
@@ -291,7 +305,62 @@ func NewBackupObject(cluster *v3.Cluster, manual bool) *v3.EtcdBackup {
 			ClusterID: cluster.Name,
 			Manual:    manual,
 		},
+		Status: v3.EtcdBackupStatus{
+			KubernetesVersion: cluster.Spec.RancherKubernetesEngineConfig.Version,
+			ClusterObject:     compressedCluster,
+		},
+	}, nil
+}
+
+func CompressCluster(cluster *v3.Cluster) (string, error) {
+	jsonCluster, err := json.Marshal(cluster)
+	if err != nil {
+		return "", err
 	}
+
+	var gzCluster bytes.Buffer
+	gz := gzip.NewWriter(&gzCluster)
+	defer gz.Close()
+
+	_, err = gz.Write([]byte(jsonCluster))
+	if err != nil {
+		return "", err
+	}
+
+	if err := gz.Close(); err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(gzCluster.Bytes()), nil
+}
+
+func DecompressCluster(cluster string) (*v3.Cluster, error) {
+	clusterGzip, err := base64.StdEncoding.DecodeString(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("error base64.DecodeString: %v", err)
+	}
+
+	buffer := bytes.NewBuffer(clusterGzip)
+
+	var gz io.Reader
+	gz, err = gzip.NewReader(buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	var clusterJSON bytes.Buffer
+	_, err = io.Copy(&clusterJSON, gz)
+	if err != nil {
+		return nil, err
+	}
+
+	c := v3.Cluster{}
+	err = json.Unmarshal(clusterJSON.Bytes(), &c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &c, nil
 }
 
 func generateBackupFilename(snapshotName string, backupConfig *v3.BackupConfig) string {


### PR DESCRIPTION
Rebase of this PR which is already approved: https://github.com/rancher/rancher/pull/25545

The snapshot process only stores some basic metadata, this will add the entire cluster object in order to help track the state of the cluster when the backup is made. A restoreRkeConfig was added to the etcd restore action which supports "all" and "kubernetesVersion" meaning during the restore you can choose to restore the entirety of the cluster config or leave the cluster config as is and only restore the kubernetes version.
#22232 
types: https://github.com/rancher/types/pull/1101