### PR TITLE
SAML Logins Group Principals Not Created on First Login

### DIFF
--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -573,23 +573,19 @@ func (m *Manager) UserAttributeCreateOrUpdate(userID, provider string, groupPrin
 		return err
 	}
 
-	// Exists, just update if necessary
-	attribs = attribs.DeepCopy()
-
-	if m.UserAttributeChanged(attribs, provider, groupPrincipals) {
+	if needCreate {
 		attribs.GroupPrincipals[provider] = v3.Principals{Items: groupPrincipals}
-		if !needCreate {
-			_, err := m.userAttributes.Update(attribs)
-			if err != nil {
-				return err
-			}
+		_, err := m.userAttributes.Create(attribs)
+		if err != nil {
+			return err
 		}
-
 		return nil
 	}
 
-	if needCreate {
-		_, err := m.userAttributes.Create(attribs)
+	// Exists, just update if necessary
+	if m.UserAttributeChanged(attribs, provider, groupPrincipals) {
+		attribs.GroupPrincipals[provider] = v3.Principals{Items: groupPrincipals}
+		_, err := m.userAttributes.Update(attribs)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Problem**
When a first time user logs in via SAML their group principals are not set, subsequent logins it does work. You can easily recreate this by logging in with a new user and going to /v3/principals, logout and login again and now groups will show up. You can delete the user via an Admin user and recreate this every time.

**Solution**
Logic is a little off in tokens.UserAttributeCreateOrUpdate. The create logic is under the update logic and the SAML user will get caught in the update logic and ultimately return without saving the UserAttribute.