### PR TITLE
Nodedriver Schemas, Defaulting array[string] to Nullable

### DIFF
--- a/pkg/controllers/management/drivers/nodedriver/utils.go
+++ b/pkg/controllers/management/drivers/nodedriver/utils.go
@@ -42,6 +42,7 @@ func FlagToField(flag cli.Flag) (string, v3.Field, error) {
 	case *cli.StringSliceFlag:
 		field.Type = "array[string]"
 		field.Description = v.Usage
+		field.Nullable = true
 		field.Default.StringSliceValue = v.Value
 	case *BoolPointerFlag:
 		field.Type = "boolean"


### PR DESCRIPTION
array[string] in the dynamicschemas were a little annoying to edit in the api ui because they default to null when an empty array `[]` is sent over. On edit you would have to change each one to [] or "" to make it save properly.