### PR TITLE
On master create agent image with build number in it

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -35,7 +35,7 @@ steps:
   settings:
     build_args:
     - ARCH=amd64
-    - VERSION=${DRONE_BRANCH/release\//}-head
+    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_BUILD_NUMBER}-head
     - SYSTEM_CHART_DEFAULT_BRANCH=dev
     context: package/
     custom_dns: 1.1.1.1
@@ -59,7 +59,7 @@ steps:
   settings:
     build_args:
     - ARCH=amd64
-    - VERSION=${DRONE_BRANCH/release\//}-head
+    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_BUILD_NUMBER}-head
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -237,7 +237,7 @@ steps:
   settings:
     build_args:
     - ARCH=arm64
-    - VERSION=${DRONE_BRANCH/release\//}-head
+    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_BUILD_NUMBER}-head
     - SYSTEM_CHART_DEFAULT_BRANCH=dev
     context: package/
     custom_dns: 1.1.1.1
@@ -261,7 +261,7 @@ steps:
   settings:
     build_args:
     - ARCH=arm64
-    - VERSION=${DRONE_BRANCH/release\//}-head
+    - VERSION=${DRONE_BRANCH/release\//}-${DRONE_BUILD_NUMBER}-head
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile.agent
@@ -381,7 +381,7 @@ steps:
       build_args:
         - SERVERCORE_VERSION=1809
         - ARCH=amd64
-        - VERSION=${DRONE_BRANCH/release\//}-head
+        - VERSION=${DRONE_BRANCH/release\//}-${DRONE_BUILD_NUMBER}-head
       context: package/windows
       custom_dns: 1.1.1.1
       dockerfile: package/windows/Dockerfile.agent
@@ -489,7 +489,7 @@ steps:
       build_args:
         - SERVERCORE_VERSION=1903
         - ARCH=amd64
-        - VERSION=${DRONE_BRANCH/release\//}-head
+        - VERSION=${DRONE_BRANCH/release\//}-${DRONE_BUILD_NUMBER}-head
       context: package/windows
       custom_dns: 1.1.1.1
       dockerfile: package/windows/Dockerfile.agent

--- a/manifest-agent.tmpl
+++ b/manifest-agent.tmpl
@@ -1,4 +1,4 @@
-image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
+image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.number}}-head{{/if}}
 manifests:
   -
     image: rancher/rancher-agent:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-amd64


### PR DESCRIPTION
We need the agent tag to be unique for master builds so that when
you upgrade you always get the proper agent image pushed to the
downstream clusters.