### PR TITLE
Add helm unitttest version env var

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,6 +8,8 @@ ENV CATTLE_MACHINE_VERSION v0.15.0-rancher32
 ENV CATTLE_K3S_VERSION v1.17.2+k3s1
 ENV CATTLE_ETCD_VERSION v3.4.3
 ENV CATTLE_CHANNELSERVER_VERSION v0.1.0
+# version used by helm plugin install script
+ENV CATTLE_HELM_UNITTEST_VERSION v0.1.6-rancher1
 ENV GO111MODULE off
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
 ENV RANCHER_METADATA_BRANCH=dev-v2.4


### PR DESCRIPTION
**Problem** 
Hitting rate limit for github api calls when helm-unittest plugin was being install

**Solution** 
Rewrite plugin install script to pull the binary down directly based on a new `HELM_UNITTEST_VERSION` env var and existing `ARCH` env var from dapper file

**Issue** 
#25660 

**Dependent on**
https://github.com/rancher/helm-unittest/pull/7