### PR TITLE
Skip k3sClusterConfig for RKE and hosted k8s clusters

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -298,6 +298,10 @@ func (p *Provisioner) update(cluster *v3.Cluster, create bool) (*v3.Cluster, err
 	v3.ClusterConditionProvisioned.Reason(cluster, "")
 	v3.ClusterConditionPending.True(cluster)
 
+	if cluster.Spec.RancherKubernetesEngineConfig != nil || cluster.Spec.GenericEngineConfig != nil {
+		return cluster, nil
+	}
+
 	err = k3sClusterConfig(cluster)
 	if err != nil {
 		return cluster, err


### PR DESCRIPTION
When RKE up provisions cluster and Provisioned condition is set to True, cluster.Status.Driver might not have been set yet when k3sClusterConfig is called. Which causes it to return error `"waiting for full cluster configuration"`. Due to which `reconcileCluster` calls `driverCreate` again which causes RKE to consider it as a newly generated cluster and RKE regenerates certs for it.