### PR TITLE
Update dynamic schema for EKS subnets

### DIFF
--- a/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
+++ b/pkg/controllers/management/drivers/kontainerdriver/kontainerdriver.go
@@ -206,6 +206,13 @@ func (l *Lifecycle) getResourceFields(obj *v3.KontainerDriver) (map[string]v3.Fi
 		},
 	}
 
+	if obj.Name == "amazonelasticcontainerservice" {
+		if val, ok := resourceFields["subnets"]; ok {
+			val.Update = false
+			resourceFields["subnets"] = val
+		}
+	}
+
 	return resourceFields, nil
 }
 


### PR DESCRIPTION
The way kontainer-engine works today with cloudformation doesn't allow
for editing of subnets. This change modifies the schema to report
'Updatable' as 'False' for the EKS subnets.

Updates:https://github.com/rancher/rancher/issues/24652

There is still UI work for reflect these fields as Uneditable though