### PR TITLE
Fix nodepool scaling

### DIFF
--- a/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
+++ b/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
@@ -762,7 +762,8 @@ def validate_rke_dm_host_4(node_template,
     node_pool = node_pools[0]
 
     # Increase the scale of the node pool to 3
-    node_pool = client.update(node_pool, quantity=3)
+    node_pool = client.update(node_pool, nodeTemplateId=node_template.id,
+                              quantity=3)
     cluster = validate_cluster(client, cluster, intermediate_state="updating")
     nodes = client.list_node(clusterId=cluster.id).data
     assert len(nodes) == 3


### PR DESCRIPTION
When scaling up existing node pool , it is required to pass `nodeTemplateId` without which we get the following error:
```
rancher.ApiError: (ApiError(...), "NotFound : unable to find node template []\n\t{'baseType': 'error', 'code': 'NotFound', 'message': 'unable to find node template []', 'status': 404, 'type': 'error'}")
```
Fix is made to pass  `nodeTemplateId` when scaling up existing node pool.
