### PR TITLE
Add flag to enable TRACE logging

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -47,6 +47,7 @@ type Config struct {
 	HTTPSListenPort   int
 	K8sMode           string
 	Debug             bool
+	Trace             bool
 	NoCACerts         bool
 	AuditLogPath      string
 	AuditLogMaxage    int

--- a/main.go
+++ b/main.go
@@ -68,6 +68,11 @@ func main() {
 			Usage:       "Enable debug logs",
 			Destination: &config.Debug,
 		},
+		cli.BoolFlag{
+			Name:        "trace",
+			Usage:       "Enable trace logs",
+			Destination: &config.Trace,
+		},
 		cli.StringFlag{
 			Name:        "add-local",
 			Usage:       "Add local cluster (true, false, auto)",
@@ -177,10 +182,6 @@ func main() {
 }
 
 func initLogs(c *cli.Context, cfg app.Config) {
-	if cfg.Debug {
-		logrus.SetLevel(logrus.DebugLevel)
-	}
-
 	switch c.String("log-format") {
 	case "simple":
 		logrus.SetFormatter(&simplelog.StandardFormatter{})
@@ -190,6 +191,15 @@ func initLogs(c *cli.Context, cfg app.Config) {
 		logrus.SetFormatter(&logrus.JSONFormatter{})
 	}
 	logrus.SetOutput(os.Stdout)
+	if cfg.Debug {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.Debugf("Loglevel set to [%v]", logrus.DebugLevel)
+	}
+	if cfg.Trace {
+		logrus.SetLevel(logrus.TraceLevel)
+		logrus.Tracef("Loglevel set to [%v]", logrus.TraceLevel)
+	}
+
 	logserver.StartServerWithDefaults()
 }
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/24994

Basically the same approach as described in https://github.com/rancher/rke/pull/1939#issue-383010276

It could have gone outside of the struct (`c.Bool`) but as Debug is there as well, I added it in.