### PR TITLE
Fix ineffective assignment in rkecerts

### DIFF
--- a/pkg/rkecerts/certs.go
+++ b/pkg/rkecerts/certs.go
@@ -88,6 +88,7 @@ func (b *Bundle) SafeMarshal() (string, error) {
 	certs := b.certs
 	if pkiCert, ok := certs[pki.CACertName]; ok {
 		pkiCert.Key = nil
+		certs[pki.CACertName] = pkiCert
 	}
 	err := rkecerts.Save(certs, output)
 	return output.String(), err


### PR DESCRIPTION
The SafeMarshal() function inside of rkecerts did not effectively set
the key field to nil.