### PR TITLE
Fix state for upgrading k3s clusters

### DIFF
--- a/pkg/controllers/management/k3supgrade/deployPlans.go
+++ b/pkg/controllers/management/k3supgrade/deployPlans.go
@@ -1,0 +1,176 @@
+package k3supgrade
+
+import (
+	"fmt"
+	"reflect"
+
+	planv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
+	planClientset "github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/typed/upgrade.cattle.io/v1"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// deployPlans creates a master and worker plan in the downstream cluster to instrument
+// the system-upgrade-controller in the downstream cluster
+func (h *handler) deployPlans(cluster *v3.Cluster) error {
+
+	// access downstream cluster
+	clusterCtx, err := h.manager.UserContext(cluster.Name)
+	if err != nil {
+		return err
+
+	}
+
+	// create a client for GETing Plans in the downstream cluster
+	planConfig, err := planClientset.NewForConfig(&clusterCtx.RESTConfig)
+	if err != nil {
+		return err
+	}
+	planClient := planConfig.Plans(metav1.NamespaceAll)
+
+	planList, err := planClient.List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	masterPlan := &planv1.Plan{}
+	workerPlan := &planv1.Plan{}
+	// deactivate all existing plans that are not managed by Rancher
+	for _, plan := range planList.Items {
+		if _, ok := plan.Labels[rancherManagedPlan]; !ok {
+			// inverse selection is used here, we select a non-existent label
+			lsr := metav1.LabelSelectorRequirement{
+				Key:      upgradeDisableLabelKey,
+				Operator: metav1.LabelSelectorOpExists,
+			}
+			plan.Spec.NodeSelector.MatchExpressions = append(plan.Spec.NodeSelector.MatchExpressions, lsr)
+
+			_, err = planClient.Update(&plan)
+			if err != nil {
+				return err
+			}
+
+		} else {
+
+			switch name := plan.Name; name {
+			case k3sMasterPlanName:
+				if plan.Namespace == systemUpgradeNS {
+					masterPlan = &plan
+				}
+			case k3sWorkerPlanName:
+				if plan.Namespace == systemUpgradeNS {
+					workerPlan = &plan
+				}
+			}
+		}
+	}
+	// if rancher plans exist, do we need to update?
+	if masterPlan.Name != "" || workerPlan.Name != "" {
+		if masterPlan.Name != "" {
+			newMaster := configureMasterPlan(*masterPlan, cluster.Spec.K3sConfig.Version,
+				cluster.Spec.K3sConfig.ServerConcurrency,
+				cluster.Spec.K3sConfig.DrainServerNodes)
+
+			if !cmp(*masterPlan, newMaster) {
+				planClient = planConfig.Plans(systemUpgradeNS)
+				masterPlan, err = planClient.Update(&newMaster)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if workerPlan.Name != "" {
+			newWorker := configureWorkerPlan(*workerPlan, cluster.Spec.K3sConfig.Version,
+				cluster.Spec.K3sConfig.WorkerConcurrency,
+				cluster.Spec.K3sConfig.DrainWorkerNodes)
+
+			if !cmp(*workerPlan, newWorker) {
+				planClient = planConfig.Plans(systemUpgradeNS)
+				workerPlan, err = planClient.Update(&newWorker)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+	} else { // create the plans
+		planClient = planConfig.Plans(systemUpgradeNS)
+		genMasterPlan := generateMasterPlan(cluster.Spec.K3sConfig.Version,
+			cluster.Spec.K3sConfig.ServerConcurrency,
+			cluster.Spec.K3sConfig.DrainServerNodes)
+
+		masterPlan, err = planClient.Create(&genMasterPlan)
+		if err != nil {
+			return err
+		}
+		genWorkerPlan := generateWorkerPlan(cluster.Spec.K3sConfig.Version,
+			cluster.Spec.K3sConfig.WorkerConcurrency,
+			cluster.Spec.K3sConfig.DrainWorkerNodes)
+
+		workerPlan, err = planClient.Create(&genWorkerPlan)
+		if err != nil {
+			return err
+		}
+		logrus.Infof("Plans successfully deployed into cluster %s", cluster.Name)
+	}
+
+	cluster, err = h.modifyClusterCondition(cluster, *masterPlan, *workerPlan)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//cmp compares two plans but does not compare their Status, returns true if they are the same
+func cmp(a, b planv1.Plan) bool {
+	if a.Namespace != b.Namespace {
+		return false
+	}
+
+	if a.Spec.Version != b.Spec.Version {
+		return false
+	}
+
+	if a.Spec.Concurrency != b.Spec.Concurrency {
+		return false
+	}
+
+	if !reflect.DeepEqual(a.Spec, b.Spec) {
+		return false
+	}
+	if !reflect.DeepEqual(a.Labels, b.Labels) {
+		return false
+	}
+	if !reflect.DeepEqual(a.TypeMeta, b.TypeMeta) {
+		return false
+	}
+	return true
+}
+
+//cluster state management during the upgrade, plans may be ""
+func (h *handler) modifyClusterCondition(cluster *v3.Cluster, masterPlan, workerPlan planv1.Plan) (*v3.Cluster, error) {
+
+	// implement a simple state machine
+	// NotUpgraded => MasterPlanUpgrading => WorkerPlanUpgrading => NotUpgraded
+
+	if masterPlan.Name != "" && len(masterPlan.Status.Applying) > 0 {
+		v3.ClusterConditionUpgraded.Unknown(cluster)
+		masterPlanMessage := fmt.Sprintf("controlplane node [%s] being upgraded", masterPlan.Status.Applying[0])
+		v3.ClusterConditionUpgraded.Message(cluster, masterPlanMessage)
+		return h.clusterClient.Update(cluster)
+
+	}
+
+	if workerPlan.Name != "" && len(workerPlan.Status.Applying) > 0 {
+		v3.ClusterConditionUpgraded.Unknown(cluster)
+		workerPlanMessage := fmt.Sprintf("worker node [%s] is being upgraded", workerPlan.Status.Applying[0])
+		v3.ClusterConditionUpgraded.Message(cluster, workerPlanMessage)
+		return h.clusterClient.Update(cluster)
+	}
+
+	// if we made it this far nothing is applying
+	v3.ClusterConditionUpgraded.True(cluster)
+	return h.clusterClient.Update(cluster)
+
+}

--- a/pkg/controllers/management/k3supgrade/register.go
+++ b/pkg/controllers/management/k3supgrade/register.go
@@ -2,18 +2,14 @@ package k3supgrade
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/systemaccount"
 	"github.com/rancher/rancher/pkg/wrangler"
 	wranglerv3 "github.com/rancher/rancher/pkg/wrangler/generated/controllers/management.cattle.io/v3"
-	planv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
-	planClientset "github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/typed/upgrade.cattle.io/v1"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	projectv3 "github.com/rancher/types/apis/project.cattle.io/v3"
 	"github.com/rancher/types/config"
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -24,6 +20,7 @@ type handler struct {
 	apps                   projectv3.AppInterface
 	appLister              projectv3.AppLister
 	templateLister         v3.CatalogTemplateLister
+	nodeLister             v3.NodeLister
 	systemAccountManager   *systemaccount.Manager
 	manager                *clustermanager.Manager
 }
@@ -31,7 +28,7 @@ type handler struct {
 const (
 	systemUpgradeNS        = "cattle-system"
 	rancherManagedPlan     = "rancher-managed"
-	upgradeDisableLabelKey = "plan.upgrade.cattle.io/disable"
+	upgradeDisableLabelKey = "upgrade.cattle.io/disable"
 	k3sUpgraderCatalogName = "system-library-rancher-k3s-upgrader"
 )
 
@@ -43,150 +40,10 @@ func Register(ctx context.Context, wContext *wrangler.Context, mgmtCtx *config.M
 		apps:                   mgmtCtx.Project.Apps(metav1.NamespaceAll),
 		appLister:              mgmtCtx.Project.Apps("").Controller().Lister(),
 		templateLister:         mgmtCtx.Management.CatalogTemplates("").Controller().Lister(),
+		nodeLister:             mgmtCtx.Management.Nodes("").Controller().Lister(),
 		systemAccountManager:   systemaccount.NewManager(mgmtCtx),
 		manager:                manager,
 	}
 
 	wContext.Mgmt.Cluster().OnChange(ctx, "k3s-upgrade-controller", h.onClusterChange)
-}
-
-// deployPlans creates a master and worker plan in the downstream cluster to instrument
-// the system-upgrade-controller in the downstream cluster
-func (h *handler) deployPlans(cluster *v3.Cluster) error {
-
-	// access downstream cluster
-	clusterCtx, err := h.manager.UserContext(cluster.Name)
-	if err != nil {
-		return err
-
-	}
-
-	// create a client for GETing Plans in the downstream cluster
-	planConfig, err := planClientset.NewForConfig(&clusterCtx.RESTConfig)
-	if err != nil {
-		return err
-	}
-	planClient := planConfig.Plans(metav1.NamespaceAll)
-
-	planList, err := planClient.List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	masterPlan := planv1.Plan{}
-	workerPlan := planv1.Plan{}
-	// deactivate all existing plans that are not managed by Rancher
-	for _, plan := range planList.Items {
-		if _, ok := plan.Labels[rancherManagedPlan]; !ok {
-			// inverse selection is used here, we select a non-existent label
-			plan.Spec.NodeSelector = &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{{
-					Key:      upgradeDisableLabelKey,
-					Operator: metav1.LabelSelectorOpExists,
-				}}}
-
-			_, err = planClient.Update(&plan)
-			if err != nil {
-				return err
-			}
-		} else {
-			// if any of the rancher plans are currently applying, set updating status on cluster
-			if len(plan.Status.Applying) > 0 {
-				v3.ClusterConditionUpdated.Unknown(cluster)
-				cluster, err = h.clusterClient.Update(cluster)
-				if err != nil {
-					return err
-				}
-			} else {
-				//set it back if not
-				if v3.ClusterConditionUpdated.IsUnknown(cluster) {
-					v3.ClusterConditionUpdated.True(cluster)
-					cluster, err = h.clusterClient.Update(cluster)
-					if err != nil {
-						return err
-					}
-				}
-			}
-
-			switch name := plan.Name; name {
-			case k3sMasterPlanName:
-				masterPlan = plan
-			case k3sWorkerPlanName:
-				workerPlan = plan
-			}
-		}
-	}
-
-	// if rancher plans exist, do we need to update?
-	if masterPlan.Name != "" || workerPlan.Name != "" {
-		if masterPlan.Name != "" {
-			newMaster := configureMasterPlan(masterPlan, cluster.Spec.K3sConfig.Version, cluster.Spec.K3sConfig.ServerConcurrency,
-				cluster.Spec.K3sConfig.DrainServerNodes)
-
-			if !cmp(masterPlan, newMaster) {
-				planClient = planConfig.Plans(systemUpgradeNS)
-				_, err = planClient.Update(&newMaster)
-				if err != nil {
-					return err
-				}
-			}
-		}
-
-		if workerPlan.Name != "" {
-			newWorker := configureWorkerPlan(workerPlan, cluster.Spec.K3sConfig.Version, cluster.Spec.K3sConfig.WorkerConcurrency,
-				cluster.Spec.K3sConfig.DrainWorkerNodes)
-
-			if !cmp(workerPlan, newWorker) {
-				planClient = planConfig.Plans(systemUpgradeNS)
-				_, err = planClient.Update(&newWorker)
-				if err != nil {
-					return err
-				}
-			}
-		}
-
-	} else { // create the plans
-		planClient = planConfig.Plans(systemUpgradeNS)
-		masterPlan = generateMasterPlan(cluster.Spec.K3sConfig.Version,
-			cluster.Spec.K3sConfig.ServerConcurrency, cluster.Spec.K3sConfig.DrainServerNodes)
-		_, err = planClient.Create(&masterPlan)
-		if err != nil {
-			return err
-		}
-		workerPlan = generateWorkerPlan(cluster.Spec.K3sConfig.Version,
-			cluster.Spec.K3sConfig.WorkerConcurrency, cluster.Spec.K3sConfig.DrainWorkerNodes)
-		_, err = planClient.Create(&workerPlan)
-		if err != nil {
-			return err
-		}
-		logrus.Infof("Plans successfully deployed into cluster %s", cluster.Name)
-	}
-
-	return nil
-}
-
-//cmp compares two plans but does not compare their Status, returns true if they are the same
-func cmp(a, b planv1.Plan) bool {
-	if a.Namespace != b.Namespace {
-		return false
-	}
-
-	if a.Spec.Version != b.Spec.Version {
-		return false
-	}
-
-	if a.Spec.Concurrency != b.Spec.Concurrency {
-		return false
-	}
-
-	//TODO Refactor to not use reflection
-	if !reflect.DeepEqual(a.Spec, b.Spec) {
-		return false
-	}
-	if !reflect.DeepEqual(a.ObjectMeta, b.ObjectMeta) {
-		return false
-	}
-	if !reflect.DeepEqual(a.TypeMeta, b.TypeMeta) {
-		return false
-	}
-	return true
 }

--- a/pkg/controllers/management/k3supgrade/template.go
+++ b/pkg/controllers/management/k3supgrade/template.go
@@ -24,11 +24,7 @@ var genericPlan = planv1.Plan{
 	Spec: planv1.PlanSpec{
 		Concurrency:        0,
 		ServiceAccountName: systemUpgradeServiceAccount,
-		Channel:            "",
-		Version:            "",
-		Secrets:            nil,
-		Prepare:            nil,
-		Cordon:             false,
+		Cordon:             true,
 		Upgrade: &planv1.ContainerSpec{
 			Image: upgradeImage,
 		},


### PR DESCRIPTION
K3s clusters will now correctly report their state as during an upgrade and it will be reflected in the UI.

https://github.com/rancher/rancher/issues/25371