### PR TITLE
Token hashing uses sha256

### DIFF
--- a/pkg/auth/tokens/manager_test.go
+++ b/pkg/auth/tokens/manager_test.go
@@ -127,7 +127,7 @@ func (d *DummyIndexer) ListIndexFuncValues(indexName string) []string {
 func (d *DummyIndexer) ByIndex(indexName, indexKey string) ([]interface{}, error) {
 	return []interface{}{
 		&v3.Token{
-			Token: "$1:fc5d88fa6e60a091:15:8:1:dUzBSmpqILPEsA/DzulT0lf4T8xu6juX2NU0sMqLXYADzUiYIB3yFMN4EvLSD7PJ1N0g9Rd99sB3Nfe8YW5eDg", // "testkey"
+			Token: "$1:dGVzdHNhbHQ:THYNxKRchboM+OTTYgV2vjXO8T7GoIfkT+vkI7eWH60", // testsalt, testkey
 			ObjectMeta: v1.ObjectMeta{
 				Name: "testname",
 			},

--- a/pkg/auth/tokens/sha256.go
+++ b/pkg/auth/tokens/sha256.go
@@ -1,0 +1,67 @@
+package tokens
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const hashFormat = "$%d:%s:%s" // $version:salt:hash -> $1:abc:def
+const Version = 1
+
+// CreateSHA256Hash can be used for basic key hashing, includes a random salt
+func CreateSHA256Hash(secretKey string) (string, error) {
+	salt := make([]byte, 8)
+	_, err := rand.Read(salt)
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.Sum256([]byte(fmt.Sprintf("%s%s", salt, secretKey)))
+	encSalt := base64.RawStdEncoding.EncodeToString(salt)
+	encKey := base64.RawStdEncoding.EncodeToString(hash[:])
+	return fmt.Sprintf(hashFormat, Version, encSalt, encKey), nil
+}
+
+// VerifySHA256Hash takes a key and compares it with stored hash, including its salt
+func VerifySHA256Hash(hash, secretKey string) error {
+	if !strings.HasPrefix(hash, "$") {
+		return errors.New("hash format invalid")
+	}
+	splitHash := strings.SplitN(strings.TrimPrefix(hash, "$"), ":", 3)
+	if len(splitHash) != 3 {
+		return errors.New("hash format invalid")
+	}
+
+	version, err := strconv.Atoi(splitHash[0])
+	if err != nil {
+		return err
+	}
+	if version != Version {
+		return fmt.Errorf("hash version %d does not match package version %d", version, Version)
+	}
+
+	salt, enc := splitHash[1], splitHash[2]
+	// base64 decode stored salt and key
+	decodedKey, err := base64.RawStdEncoding.DecodeString(enc)
+	if err != nil {
+		return err
+	}
+	if len(decodedKey) < 1 {
+		return errors.New("secretKey hash does not match") // Don't allow accidental empty string to succeed
+	}
+	decodedSalt, err := base64.RawStdEncoding.DecodeString(salt)
+	if err != nil {
+		return err
+	}
+	// compare the two
+	hashedSecretKey := sha256.Sum256([]byte(string(decodedSalt) + secretKey))
+	if subtle.ConstantTimeCompare(decodedKey, hashedSecretKey[:]) == 0 {
+		return errors.New("secretKey hash does not match")
+	}
+	return nil
+}

--- a/pkg/auth/tokens/sha256_test.go
+++ b/pkg/auth/tokens/sha256_test.go
@@ -1,0 +1,28 @@
+package tokens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicHash(t *testing.T) {
+	secretKey := "hello world"
+	hash, err := CreateSHA256Hash(secretKey)
+	assert.Nil(t, err)
+	assert.NotNil(t, hash)
+	// Now check it
+	assert.Nil(t, VerifySHA256Hash(hash, secretKey))
+	assert.NotNil(t, VerifySHA256Hash(hash, "incorrect"))
+}
+
+func TestLongKey(t *testing.T) {
+	secretKey := strings.Repeat("A", 720)
+	hash, err := CreateSHA256Hash(secretKey)
+	assert.Nil(t, err)
+	assert.NotNil(t, hash)
+	// Now check it
+	assert.Nil(t, VerifySHA256Hash(hash, secretKey))
+	assert.NotNil(t, VerifySHA256Hash(hash, secretKey+":wrong!"))
+}

--- a/pkg/auth/tokens/token_util.go
+++ b/pkg/auth/tokens/token_util.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
-	"github.com/rancher/rancher/pkg/controllers/user/clusterauthtoken/common"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 )
@@ -106,8 +105,8 @@ func VerifyToken(storedToken *v3.Token, tokenName, tokenKey string) (int, error)
 	if storedToken.ObjectMeta.Name != tokenName {
 		return 422, errors.New("Invalid auth token value")
 	}
-	if err := common.VerifyHash(storedToken.Token, tokenKey); err != nil {
-		logrus.Errorf("VerifyHash failed with error: %v", err)
+	if err := VerifySHA256Hash(storedToken.Token, tokenKey); err != nil {
+		logrus.Errorf("VerifySHA256Hash failed with error: %v", err)
 		return 422, errors.New("Invalid auth token value")
 	}
 	if IsExpired(*storedToken) {
@@ -119,8 +118,7 @@ func VerifyToken(storedToken *v3.Token, tokenName, tokenKey string) (int, error)
 // ConvertTokenKeyToHash takes a token with an un-hashed key and converts it to a hashed key
 func ConvertTokenKeyToHash(token *v3.Token) error {
 	if token != nil && len(token.Token) > 0 {
-		var err error
-		hashedToken, err := common.CreateHash(token.Token)
+		hashedToken, err := CreateSHA256Hash(token.Token)
 		if err != nil {
 			logrus.Errorf("Failed to generate hash from token: %v", err)
 			return errors.New("failed to generate hash from token")


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/25786

Notes: 
* Can't use Sscanf for parsing format because go stumbles on multiple strings not delimited by spaces, so had to go the split route.
* hashedSecretKey is actually a `[]uint8` but thats basically a byte so comparison is ok. The `[:]` converts array to slice. 