### PR TITLE
Fix kubelet needs to be restart if node is deleted in UI

### DIFF
--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -39,6 +39,10 @@ const (
 )
 
 func main() {
+	if _, err := reconcileKubelet(context.Background()); err != nil {
+		logrus.Warnf("failed to reconcile kubelet, error: %v", err)
+	}
+
 	logrus.SetOutput(colorable.NewColorableStdout())
 	logserver.StartServerWithDefaults()
 	if os.Getenv("CATTLE_DEBUG") == "true" || os.Getenv("RANCHER_DEBUG") == "true" {
@@ -299,6 +303,26 @@ func run() error {
 					if err != nil {
 						logrus.Errorf("failed to check plan: %v", err)
 					}
+
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+
+		// launching reconcileKubelet in a goroutine to make sure kubelet will be restarted
+		// every three minutes until managed agent comes up and take over
+		go func() {
+			for {
+				select {
+				case <-time.After(3 * time.Minute):
+					done, err := reconcileKubelet(ctx)
+					if err != nil {
+						logrus.Errorf("failed to reconcile kubelet: %v", err)
+					}
+					if done {
+						break
+					}
 				case <-ctx.Done():
 					return
 				}
@@ -347,4 +371,40 @@ func certinfo(cert *x509.Certificate) {
 	logrus.Infof("NotAfter: %+v", cert.NotAfter)
 	logrus.Infof("SignatureAlgorithm: %+v", cert.SignatureAlgorithm)
 	logrus.Infof("PublicKeyAlgorithm: %+v", cert.PublicKeyAlgorithm)
+}
+
+// reconcileKubelet restarts kubelet in unmanaged agents
+func reconcileKubelet(ctx context.Context) (bool, error) {
+	if os.Getenv("CATTLE_K8S_MANAGED") == "true" {
+		return true, nil
+	}
+
+	nodeName := os.Getenv("CATTLE_NODE_NAME")
+	logrus.Infof("node %v is not registered, restarting kubelet now", nodeName)
+	c, err := client.NewEnvClient()
+	if err != nil {
+		return false, err
+	}
+	defer c.Close()
+
+	args := filters.NewArgs()
+	args.Add("label", "io.rancher.rke.container.name=kubelet")
+
+	containers, err := c.ContainerList(ctx, types.ContainerListOptions{
+		All:     true,
+		Filters: args,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	for _, container := range containers {
+		if len(container.Names) > 0 && strings.Contains(container.Names[0], "kubelet") {
+			if err := c.ContainerRestart(ctx, container.ID, nil); err != nil {
+				return false, err
+			}
+			break
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
Problem:
Today if node is deleted from rancher, we immdiately delete v1.node from
kubernetes. Since we don't clean up agent(or did a poor job in cleaning
agent). All the system containers keep running including kubelet. This
will cause kubelet keep throwing node not found error. This is because
kubelet only register new node at start up, and without restart kubelet
it will not re-register node again. https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet_node_status.go#L52

Solution:
In our agent code, add kubelet restart logic. Notice that this logic is
only added into unmanaged agent(which is only added through docker run
command). This is because once managed agents are added, kubelet should
be ready since managed agents are pods from daemonset which mean the
node is schedulable now. Once managed agents are added unmanaged agents
will be cleaned up, then this logic will not be needed anymore.