### PR TITLE
[FEATURE] Post a elasticsearch test message with a bulk request.

### DIFF
--- a/pkg/controllers/user/logging/utils/elasticsearch.go
+++ b/pkg/controllers/user/logging/utils/elasticsearch.go
@@ -44,10 +44,12 @@ func (w *elasticsearchTestWrap) TestReachable(ctx context.Context, dial dialer.D
 	}
 
 	index := getIndex(w.DateFormat, w.IndexPrefix)
+	url.Path = path.Join(url.Path, "/_bulk")
 
-	url.Path = path.Join(url.Path, index, "/container_log")
-
-	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(httpTestData))
+	bulkTestData := []byte(`{"index":{"_index":"` + index + `","_type":"container_log"}}` + "\n")
+	bulkTestData = append(bulkTestData, httpTestData...)
+	bulkTestData = append(bulkTestData, "\n"...)
+	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(bulkTestData))
 	if err != nil {
 		return errors.Wrap(err, "create request failed")
 	}


### PR DESCRIPTION
**problem**
With elasticsearch the test button is posting to `<cluster>/<index>/container_log`
For ES6 this is fine, but ES7 and higher types are not allowed anymore.

**suggestion**
* Fluentd ES test button with POST _bulk
* Fluentd ES test button removes the _type containerlog

**support**
ES6: type and id can be mixed
ES7: still allows a single type
ES8: types are going bye bye

**bulk request**
fluentd is posting with _bulk requests on root  
Because we use a loadbalancer that only allows _bulk requests,  
i would like to test my route with a bulk request
```
	// elasticsearch <= 6
	url.Path = path.Join(url.Path, index, "/container_log")
	bulkTestData = httpTestData
	
	// elasticsearch 7
	url.Path = path.Join(url.Path, "/_bulk")
	bulkTestData = []byte(`{"index":{"_index":"` + index + `","_type":"container_log"}}\n` + httpTestData)

	// elasticsearch 8
	url.Path = path.Join(url.Path, "/_bulk")
	bulkTestData = []byte(`{"index":{"_index":"` + index + `"}\n` + httpTestData)
	
	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(bulkTestData))
```
**better**
I Don't know what the plans are with elasticsearch 8, but i would suggest to use the one without `_type`. Because the only thing that is tested is if the index exists. Better test would be to send a request parsed by fluentd. This way it will also build a correct mapping file.