### PR TITLE
Add max history helm3

### DIFF
--- a/pkg/controllers/user/helm/common/common.go
+++ b/pkg/controllers/user/helm/common/common.go
@@ -31,6 +31,7 @@ const (
 	HelmV2          = "rancher-helm"
 	HelmV3          = "helm_v3"
 	forceUpgradeStr = "--force"
+	maxHistory      = "10"
 )
 
 type HelmPath struct {
@@ -99,7 +100,7 @@ func SplitExternalID(externalID string) (string, string, string, string, string,
 func StartTiller(context context.Context, tempDirs *HelmPath, port, namespace string) error {
 	probePort := GenerateRandomPort()
 	cmd := exec.Command(tillerName, "--listen", ":"+port, "--probe-listen", ":"+probePort)
-	cmd.Env = []string{fmt.Sprintf("%s=%s", "KUBECONFIG", tempDirs.KubeConfigInJail), fmt.Sprintf("%s=%s", "TILLER_NAMESPACE", namespace), fmt.Sprintf("%s=%s", "TILLER_HISTORY_MAX", "10")}
+	cmd.Env = []string{fmt.Sprintf("%s=%s", "KUBECONFIG", tempDirs.KubeConfigInJail), fmt.Sprintf("%s=%s", "TILLER_NAMESPACE", namespace), fmt.Sprintf("%s=%s", "TILLER_HISTORY_MAX", maxHistory)}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -148,7 +149,7 @@ func InstallCharts(tempDirs *HelmPath, port string, obj *v3.App) error {
 			return err
 		}
 		logrus.Infof("Installing chart using helm version: %s", HelmV3)
-		commands = append([]string{"upgrade", "--install", obj.Name, "--namespace", obj.Spec.TargetNamespace, "--kubeconfig", tempDirs.KubeConfigInJail, "--post-renderer", tempDirs.KustomizeInJail}, timeoutArgs...)
+		commands = append([]string{"upgrade", "--install", obj.Name, "--namespace", obj.Spec.TargetNamespace, "--kubeconfig", tempDirs.KubeConfigInJail, "--post-renderer", tempDirs.KustomizeInJail, "--history-max", maxHistory}, timeoutArgs...)
 	} else {
 		logrus.Infof("Installing chart using helm version: %s", HelmV2)
 		commands = append([]string{"upgrade", "--install", "--namespace", obj.Spec.TargetNamespace, obj.Name}, timeoutArgs...)


### PR DESCRIPTION
**Problem**
Duplicate revisions were being created. Helm 3 no longer uses tiller, so max history was not being set. Helm 2 utilizes `TILLER_MAX_HISTORY`

**Solution**
Set history max for helm 3 using the `--history-max` flag to ensure the correct number of revisions were being created

**Issue**
#25846 