### PR TITLE
Correctly transitions through upgrading states for single node k3s upgrade

### DIFF
--- a/pkg/controllers/management/k3supgrade/deployPlans.go
+++ b/pkg/controllers/management/k3supgrade/deployPlans.go
@@ -154,7 +154,7 @@ func cmp(a, b planv1.Plan) bool {
 func (h *handler) modifyClusterCondition(cluster *v3.Cluster, masterPlan, workerPlan planv1.Plan) (*v3.Cluster, error) {
 
 	// implement a simple state machine
-	// NotUpgraded => MasterPlanUpgrading => WorkerPlanUpgrading => NotUpgraded
+	// NotUpgraded => MasterPlanUpgrading || WorkerPlanUpgrading =>  NotUpgraded
 
 	if masterPlan.Name != "" && len(masterPlan.Status.Applying) > 0 {
 		v3.ClusterConditionUpgraded.Unknown(cluster)
@@ -172,6 +172,7 @@ func (h *handler) modifyClusterCondition(cluster *v3.Cluster, masterPlan, worker
 	}
 
 	// if we made it this far nothing is applying
+	// see k3supgrade_handler also
 	v3.ClusterConditionUpgraded.True(cluster)
 	return h.clusterClient.Update(cluster)
 

--- a/pkg/controllers/management/k3supgrade/k3supgrade_handler.go
+++ b/pkg/controllers/management/k3supgrade/k3supgrade_handler.go
@@ -43,7 +43,7 @@ func (h *handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster,
 		}
 		if !needsUpgrade {
 			// if upgrade was in progress, make sure to set the state back
-			if strings.Contains(v3.ClusterConditionUpgraded.GetMessage(cluster), "worker") {
+			if v3.ClusterConditionUpgraded.IsUnknown(cluster) {
 				v3.ClusterConditionUpgraded.True(cluster)
 				v3.ClusterConditionUpgraded.Message(cluster, "")
 				return h.clusterClient.Update(cluster)


### PR DESCRIPTION
Previously, the state transition logic assumed that the worker plans would always be applied. That is not the case in a single-node controlplane k3s cluster.
To leave the updating state now, there is no requirement that the last plan to have been applying was a worker plan.

Addresses https://github.com/rancher/rancher/issues/25869