### PR TITLE
Modify GenericEncryptedStore set secret logic

### DIFF
--- a/pkg/encryptedstore/secrets_store.go
+++ b/pkg/encryptedstore/secrets_store.go
@@ -2,11 +2,14 @@ package encryptedstore
 
 import (
 	"reflect"
+	"time"
 
 	v1 "github.com/rancher/types/apis/core/v1"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -63,38 +66,84 @@ func (g *GenericEncryptedStore) getKey(name string) string {
 }
 
 func (g *GenericEncryptedStore) Set(name string, data map[string]string) error {
-	return g.set(name, data, 0)
+	return g.set(name, data)
 }
 
-func (g *GenericEncryptedStore) set(name string, data map[string]string, try int) error {
+func (g *GenericEncryptedStore) set(name string, data map[string]string) error {
+	logrus.Debugf("[GenericEncryptedStore]: set secret called for %v", g.getKey(name))
 	sec, err := g.secretLister.Get(g.namespace, g.getKey(name))
 	if errors.IsNotFound(err) {
+		logrus.Debugf("[GenericEncryptedStore]: Creating secret for %v", g.getKey(name))
 		sec = &corev1.Secret{}
 		sec.Name = g.getKey(name)
 		sec.StringData = data
-		if _, err := g.secrets.Create(sec); err != nil && !errors.IsAlreadyExists(err) {
-			return err
+		if _, err := g.secrets.Create(sec); err != nil {
+			if !errors.IsAlreadyExists(err) {
+				return err
+			}
+			logrus.Debugf("[GenericEncryptedStore]: secret %v already exists, updating secret", sec.Name)
+			// if secret already exists, update it with the current cluster status
+			return g.updateSecretWithBackoff(name, data)
 		}
 		return nil
 	} else if err != nil {
 		return err
 	}
 
-	orig := sec.DeepCopy()
-	if sec.Data == nil {
-		sec.Data = map[string][]byte{}
-	}
-	for k, v := range data {
-		sec.Data[k] = []byte(v)
-	}
-
-	if !reflect.DeepEqual(orig, sec) {
-		_, err = g.secrets.Update(sec)
-		if err != nil && try < 5 {
-			return g.set(name, data, try+1)
+	secToUpdate := prepareSecretForUpdate(sec, data)
+	if !reflect.DeepEqual(secToUpdate.Data, sec.Data) {
+		logrus.Debugf("[GenericEncryptedStore]: updating secret %v", g.getKey(name))
+		_, err = g.secrets.Update(secToUpdate)
+		if err != nil {
+			if !errors.IsConflict(err) {
+				return err
+			}
+			return g.updateSecretWithBackoff(name, data)
 		}
 	}
 	return err
+}
+
+func (g *GenericEncryptedStore) updateSecretWithBackoff(name string, data map[string]string) error {
+	backoff := wait.Backoff{
+		Duration: 100 * time.Millisecond,
+		Factor:   1,
+		Jitter:   0,
+		Steps:    5,
+	}
+	return wait.ExponentialBackoff(backoff, func() (bool, error) {
+		// fetch secret from the db when retrying due to IsConflict/IsAlreadyExists error
+		secret, err := g.secrets.GetNamespaced(g.namespace, g.getKey(name), metav1.GetOptions{})
+		if err != nil {
+			logrus.Errorf("[GenericEncryptedStore]: error getting secret %v from db: %v", g.getKey(name), err)
+			return false, err
+		}
+		secToUpdate := prepareSecretForUpdate(secret, data)
+		if !reflect.DeepEqual(secToUpdate.Data, secret.Data) {
+			_, err = g.secrets.Update(secToUpdate)
+			if err != nil {
+				if errors.IsConflict(err) {
+					logrus.Errorf("[GenericEncryptedStore]: conflict error updating secret %v: %v, retrying update", g.getKey(name), err)
+					return false, nil
+				}
+				logrus.Errorf("[GenericEncryptedStore]: error when updating secret %v: %v", g.getKey(name), err)
+				return false, err
+			}
+			logrus.Debugf("[GenericEncryptedStore]: successfully updated secret %v ", g.getKey(name))
+		}
+		return true, nil
+	})
+}
+
+func prepareSecretForUpdate(secret *corev1.Secret, data map[string]string) *corev1.Secret {
+	secToUpdate := secret.DeepCopy()
+	if secToUpdate.Data == nil {
+		secToUpdate.Data = map[string][]byte{}
+	}
+	for k, v := range data {
+		secToUpdate.Data[k] = []byte(v)
+	}
+	return secToUpdate
 }
 
 func (g *GenericEncryptedStore) Remove(name string) error {


### PR DESCRIPTION
Throughout cluster provisioning kontainer-engine saves the cluster with different statuses by calling GenericEncryptedStore.Set
Sometimes creating/updating these secrets wasn't saving the cluster with the desired status, leading to some intermittent errors during cluster provisioning.
This commit adds the following changes to ensure cluster gets saved with the correct status
1. If cluster secret create returns IsAlreadyExists, get the secret object and update
it with current expected value
2. When updating a secret, update the object obtained from DeepCopy and not the one returned
from lister.

https://github.com/rancher/rancher/issues/25554
https://github.com/rancher/rancher/issues/25524