### PR TITLE
Deleting OPA Gatekeeper constrainttemplates when gatekeeper app is removed

### DIFF
--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -64,6 +64,24 @@ func Delete(yaml []byte, kubeConfig *clientcmdapi.Config) ([]byte, error) {
 	return runWithHTTP2(cmd)
 }
 
+func DeleteAll(kubeConfig *clientcmdapi.Config, resourceType string, args []string) ([]byte, error) {
+	kubeConfigFile, err := writeKubeConfig(kubeConfig)
+	defer cleanup(kubeConfigFile)
+
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command("kubectl",
+		"--kubeconfig",
+		kubeConfigFile.Name(),
+		"delete",
+		resourceType,
+		"--all")
+
+	cmd.Args = append(cmd.Args, args...)
+	return runWithHTTP2(cmd)
+}
+
 func Drain(ctx context.Context, kubeConfig *clientcmdapi.Config, nodeName string, args []string) ([]byte, string, error) {
 	kubeConfigFile, err := writeKubeConfig(kubeConfig)
 	defer cleanup(kubeConfigFile)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/25575

Adding in logic to clean up OPA Gatekeeper constrainttemplates during removal of the app as part of the Helm lifecycle remove.

Not adding an extra controller since that would need us to add a finalizer on the app, and finalizer is known to possibly cause blocking issues with deletion.
Instead adding this part of the existing lifecycle handler.