### PR TITLE
Parse version of k3s prepare image

### DIFF
--- a/pkg/controllers/management/k3supgrade/template.go
+++ b/pkg/controllers/management/k3supgrade/template.go
@@ -1,6 +1,8 @@
 package k3supgrade
 
 import (
+	"strings"
+
 	"github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io"
 	planv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,8 +73,7 @@ func generateWorkerPlan(version string, concurrency int, drain bool) planv1.Plan
 
 	// worker plans wait for master plans to complete
 	workerPlan.Spec.Prepare = &planv1.ContainerSpec{
-		// TODO: the image version doesn't matter here, needs something recent
-		Image: upgradeImage + ":" + "v1.17.3-k3s1",
+		Image: upgradeImage + ":" + parseVersion(version),
 		Args:  []string{"prepare", k3sMasterPlanName},
 	}
 	// select all nodes that are not master
@@ -122,8 +123,7 @@ func configureWorkerPlan(workerPlan planv1.Plan, version string, concurrency int
 
 	// worker plans wait for master plans to complete
 	workerPlan.Spec.Prepare = &planv1.ContainerSpec{
-		// TODO need a recent valid image tag here...
-		Image: upgradeImage + ":" + "v1.17.3-k3s1",
+		Image: upgradeImage + ":" + parseVersion(version),
 		Args:  []string{"prepare", k3sMasterPlanName},
 	}
 
@@ -135,4 +135,9 @@ func configureWorkerPlan(workerPlan planv1.Plan, version string, concurrency int
 	}
 
 	return workerPlan
+}
+
+// a valid k3s version needs to be converted to valid docker tag (v1.17.3+k3s1 => v1.17.3-k3s1)
+func parseVersion(v string) string {
+	return strings.Replace(v, "+", "-", -1)
 }

--- a/pkg/controllers/management/k3supgrade/template_test.go
+++ b/pkg/controllers/management/k3supgrade/template_test.go
@@ -1,0 +1,25 @@
+package k3supgrade
+
+import "testing"
+
+func Test_parseVersion(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{
+			"base",
+			"v1.17.3+k3s1",
+			"v1.17.3-k3s1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseVersion(tt.version); got != tt.want {
+				t.Errorf("parseVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The prepare image is no longer hardcoded and it will be parsed to
convert a k3s release tag to an k3s-upgrade image. ie v1.17.3+k3s1 => v1.17.3-k3s1

Addresses https://github.com/rancher/rancher/issues/25907