### PR TITLE
validate number of notReady nodes on cluster update

### DIFF
--- a/pkg/controllers/management/rkeworkerupgrader/upgrade.go
+++ b/pkg/controllers/management/rkeworkerupgrader/upgrade.go
@@ -236,7 +236,7 @@ func (uh *upgradeHandler) upgradeCluster(cluster *v3.Cluster, nodeName string) e
 
 	toPrepareMap, toProcessMap, upgradedMap, notReadyMap, filtered, upgrading, done := uh.filterNodes(nodes, cluster.Status.NodeVersion)
 
-	maxAllowed, err := calculateMaxUnavailable(cluster.Spec.RancherKubernetesEngineConfig.UpgradeStrategy.MaxUnavailableWorker, filtered)
+	maxAllowed, err := CalculateMaxUnavailable(cluster.Spec.RancherKubernetesEngineConfig.UpgradeStrategy.MaxUnavailableWorker, filtered)
 	if err != nil {
 		return err
 	}
@@ -369,7 +369,7 @@ func (uh *upgradeHandler) toUpgradeCluster(cluster *v3.Cluster) (bool, error) {
 	return false, nil
 }
 
-func calculateMaxUnavailable(maxUnavailable string, nodes int) (int, error) {
+func CalculateMaxUnavailable(maxUnavailable string, nodes int) (int, error) {
 	parsedMax := intstr.Parse(maxUnavailable)
 	maxAllowed, err := intstr.GetValueFromIntOrPercent(&parsedMax, nodes, false)
 	if err != nil {


### PR DESCRIPTION
With introduction of maxUnavailable, we want to make sure we check if there are ready nodes to upgrade or else just error out. 

https://github.com/rancher/rancher/issues/26005