### PR TITLE
Cherry-pick fix for #25048

### DIFF
--- a/pkg/controllers/user/logging/generator/templatesource.go
+++ b/pkg/controllers/user/logging/generator/templatesource.go
@@ -20,6 +20,8 @@ var SourceTemplate = `
   time_format  %Y-%m-%dT%H:%M:%S.%N
   tag  {{ .ContainerLogSourceTag }}.*
   format  json
+  skip_refresh_on_startup true
+  read_from_head true
 </source>
 {{end}}
 
@@ -31,6 +33,8 @@ var SourceTemplate = `
   time_format  %Y-%m-%dT%H:%M:%S
   tag  {{ .ContainerLogSourceTag }}.*
   format  json
+  skip_refresh_on_startup true
+  read_from_head true
 </source>
 {{end}}
 `


### PR DESCRIPTION
…(#25049)

adds skip_refresh_on_startup and read_from_head to fluentd collector

Problem: The delay between the start of the pods and the start of logging.
    Fluentd collector is using the `@type tail`, which will only send new log
    events. Starting with the end of file position from the when it became aware of
    the log file.  This prevents centralized logging from collecting the output of
    the pods starting up.
Solution: Setting `read_from_head true` causes the fluentd collector to read
    the file from the beginning and forward.  `skip_refresh_on_startup true` makes
    this processess start a little faster.
Issue: https://github.com/rancher/rancher/issues/25048