### PR TITLE
ignore global timeout error from kubectl drain

### DIFF
--- a/pkg/controllers/user/nodesyncer/cordonfieldssyncer.go
+++ b/pkg/controllers/user/nodesyncer/cordonfieldssyncer.go
@@ -24,7 +24,7 @@ const (
 )
 
 var nodeMapLock = sync.Mutex{}
-var toIgnoreErrs = []string{"--ignore-daemonsets", "--delete-local-data", "--force", "did not complete within"}
+var toIgnoreErrs = []string{"--ignore-daemonsets", "--delete-local-data", "--force", "did not complete within", "global timeout reached"}
 
 func (m *nodesSyncer) syncCordonFields(key string, obj *v3.Node) (runtime.Object, error) {
 	if obj == nil || obj.DeletionTimestamp != nil || obj.Spec.DesiredNodeUnschedulable == "" {


### PR DESCRIPTION
there was a bug in kubectl related to how timeout was respected
during drain, they fixed it and also changed the err msg.
we need to include that in our ignoreErr list, so we don't retry
draining node in that scenario.

#26010