### PR TITLE
Set upgrading status sooner

### DIFF
--- a/pkg/controllers/management/k3supgrade/deployPlans.go
+++ b/pkg/controllers/management/k3supgrade/deployPlans.go
@@ -156,6 +156,12 @@ func (h *handler) modifyClusterCondition(cluster *v3.Cluster, masterPlan, worker
 	// implement a simple state machine
 	// NotUpgraded => MasterPlanUpgrading || WorkerPlanUpgrading =>  NotUpgraded
 
+	if masterPlan.Name == "" && workerPlan.Name == "" {
+		v3.ClusterConditionUpgraded.Unknown(cluster)
+		v3.ClusterConditionUpgraded.Message(cluster, "cluster is being upgraded")
+		return h.clusterClient.Update(cluster)
+	}
+
 	if masterPlan.Name != "" && len(masterPlan.Status.Applying) > 0 {
 		v3.ClusterConditionUpgraded.Unknown(cluster)
 		masterPlanMessage := fmt.Sprintf("controlplane node [%s] being upgraded", masterPlan.Status.Applying[0])

--- a/pkg/controllers/management/k3supgrade/k3supgrade_handler.go
+++ b/pkg/controllers/management/k3supgrade/k3supgrade_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/project"
 	"github.com/rancher/rancher/pkg/ref"
+	planv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	v32 "github.com/rancher/types/apis/project.cattle.io/v3"
 	"github.com/sirupsen/logrus"
@@ -52,6 +53,12 @@ func (h *handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster,
 		}
 
 	}
+	// set cluster upgrading status
+	cluster, err = h.modifyClusterCondition(cluster, planv1.Plan{}, planv1.Plan{})
+	if err != nil {
+		return cluster, err
+	}
+
 	// create or update k3supgradecontroller if necessary
 	if err = h.deployK3sUpgradeController(cluster.Name); err != nil {
 		return cluster, err


### PR DESCRIPTION
Problem: Previously the updating state would be set after plans were
deployed into the downstream cluster which meant that the whole helm
install would need to occur before the cluster entered upgrading.

Solution: When an upgrade is determined to be necessary, the cluster
state is updating. This is before the system-upgrade controller is
deployed.

Addresses https://github.com/rancher/rancher/issues/26024