### PR TITLE
allow cluster-owner users to access cis info

### DIFF
--- a/pkg/controllers/user/cis/rbac.go
+++ b/pkg/controllers/user/cis/rbac.go
@@ -1,0 +1,134 @@
+package cis
+
+import (
+	"fmt"
+
+	"github.com/rancher/rancher/pkg/namespace"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	rbacv1 "github.com/rancher/types/apis/rbac.authorization.k8s.io/v1"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	cisReadOnlyRoleName = "cis-readonly"
+)
+
+type cisScanRBACHandler struct {
+	roles             rbacv1.RoleInterface
+	roleLister        rbacv1.RoleLister
+	roleBindings      rbacv1.RoleBindingInterface
+	roleBindingLister rbacv1.RoleBindingLister
+}
+
+func (rh *cisScanRBACHandler) Sync(key string, crtb *v3.ClusterRoleTemplateBinding) (runtime.Object, error) {
+	if crtb == nil {
+		return nil, nil
+	}
+	if crtb.DeletionTimestamp != nil {
+		return rh.handleDelete(key, crtb)
+	}
+	if crtb.RoleTemplateName != "cluster-owner" || crtb.ClusterName == "local" {
+		return nil, nil
+	}
+	logrus.Debugf("cisScanRBACHandler: Sync: crtb: %+v", crtb)
+
+	if err := rh.createRoles(); err != nil {
+		return nil, err
+	}
+	if err := rh.createRoleBindings(crtb); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (rh *cisScanRBACHandler) handleDelete(_ string, crtb *v3.ClusterRoleTemplateBinding) (runtime.Object, error) {
+	logrus.Debugf("cisScanRBACHandler: handleDelete: crtb: %+v", crtb)
+	rbName, err := getRoleBindingName(crtb)
+	if err != nil {
+		return nil, err
+	}
+	err = rh.roleBindings.Delete(rbName, &metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	logrus.Debugf("cisScanRBACHandler: handleDelete: deleting rb of user: %v for cluster: %v", crtb.UserName, crtb.ClusterName)
+	return nil, nil
+}
+
+func (rh *cisScanRBACHandler) createRoles() error {
+	_, err := rh.roleLister.Get(namespace.GlobalNamespace, cisReadOnlyRoleName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			rule := v1.PolicyRule{
+				Verbs:     []string{"get", "list", "watch"},
+				APIGroups: []string{"management.cattle.io"},
+				Resources: []string{"cisconfigs", "cisbenchmarkversions"},
+			}
+			role := &v1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cisReadOnlyRoleName,
+					Namespace: namespace.GlobalNamespace,
+				},
+				Rules: []v1.PolicyRule{rule},
+			}
+			_, err = rh.roles.Create(role)
+			if err != nil && !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	return nil
+}
+
+func (rh *cisScanRBACHandler) createRoleBindings(crtb *v3.ClusterRoleTemplateBinding) error {
+	rbName, err := getRoleBindingName(crtb)
+	if err != nil {
+		return err
+	}
+	_, err = rh.roleBindingLister.Get(namespace.GlobalNamespace, rbName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			subject := v1.Subject{
+				Kind: "User",
+				Name: crtb.UserName,
+			}
+			rb := &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      rbName,
+					Namespace: namespace.GlobalNamespace,
+				},
+				Subjects: []v1.Subject{subject},
+				RoleRef: v1.RoleRef{
+					Kind: "Role",
+					Name: cisReadOnlyRoleName,
+				},
+			}
+			_, err := rh.roleBindings.Create(rb)
+			if err != nil && !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+			logrus.Debugf("cisScanRBACHandler: createRoleBindings: creating rb of user: %v for cluster: %v", crtb.UserName, crtb.ClusterName)
+		} else {
+			return err
+		}
+	}
+	return nil
+}
+
+func getRoleBindingName(crtb *v3.ClusterRoleTemplateBinding) (string, error) {
+	rbName := ""
+	if crtb.UserName == "" {
+		return rbName, fmt.Errorf("username not found in crtb: %v", crtb.Name)
+	}
+	if crtb.ClusterName == "" {
+		return rbName, fmt.Errorf("cluster name not found in crtb: %v", crtb.Name)
+	}
+	rbName = crtb.UserName + "-" + crtb.ClusterName + "-" + cisReadOnlyRoleName
+	return rbName, nil
+}

--- a/pkg/tunnelserver/tunnel.go
+++ b/pkg/tunnelserver/tunnel.go
@@ -154,7 +154,7 @@ func (t *Authorizer) Authorize(req *http.Request) (*Client, bool, error) {
 
 func (t *Authorizer) getMachine(cluster *v3.Cluster, inNode *client.Node) (*v3.Node, error) {
 	machineName := machineName(inNode)
-	logrus.Debugf("getMachine: looking up machine [%s] in cluster [%s]", machineName, cluster.Name)
+	//logrus.Debugf("getMachine: looking up machine [%s] in cluster [%s]", machineName, cluster.Name)
 	machine, err := t.machineLister.Get(cluster.Name, machineName)
 	if apierrors.IsNotFound(err) {
 		if objs, err := t.nodeIndexer.ByIndex(nodeKeyIndex, fmt.Sprintf("%s/%s", cluster.Name, inNode.RequestedHostname)); err == nil {
@@ -349,7 +349,7 @@ func (t *Authorizer) readInput(cluster *v3.Cluster, req *http.Request) (*input, 
 func machineName(machine *client.Node) string {
 	digest := md5.Sum([]byte(machine.RequestedHostname))
 	machineNameMD5 := fmt.Sprintf("m-%s", hex.EncodeToString(digest[:])[:12])
-	logrus.Debugf("machineName: returning [%s] for node with RequestedHostname [%s]", machineNameMD5, machine.RequestedHostname)
+	//logrus.Debugf("machineName: returning [%s] for node with RequestedHostname [%s]", machineNameMD5, machine.RequestedHostname)
 	return machineNameMD5
 }
 


### PR DESCRIPTION
addresses: https://github.com/rancher/rancher/issues/25990

Since UI fetches cis scan related information from the API and
the user didn't have privileges, empty data was returned, hence
the drop down was empty.

Fixed the problem by adding a controller that handles the RBAC
correctly for cluster-owner users.