### PR TITLE
[2.3] Fix Gitlab pipeline integration issue

### DIFF
--- a/pkg/pipeline/remote/gitlab/gitlab.go
+++ b/pkg/pipeline/remote/gitlab/gitlab.go
@@ -91,7 +91,7 @@ func (c *client) Login(code string) (*v3.SourceCodeCredential, error) {
 	token, err := gitlabOauthConfig.Exchange(oauth2.NoContext, code)
 	if err != nil {
 		return nil, err
-	} else if token.TokenType != "bearer" || token.AccessToken == "" {
+	} else if strings.ToLower(token.TokenType) != "bearer" || token.AccessToken == "" {
 		return nil, fmt.Errorf("Fail to get accesstoken with oauth config")
 	}
 	return c.GetAccount(token.AccessToken)


### PR DESCRIPTION
In recent Gitlab version, the Oauth API returns Bearer token type instead of bearer as shown in the docs, making the condition check here fails.

https://github.com/rancher/rancher/issues/25975