### PR TITLE
Fix the issue that users cannot remove proxyUrl of notifier

### DIFF
--- a/pkg/controllers/user/alert/configsyncer/configsyncer.go
+++ b/pkg/controllers/user/alert/configsyncer/configsyncer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/user/alert/deployer"
 	"github.com/rancher/rancher/pkg/controllers/user/alert/manager"
 	monitorutil "github.com/rancher/rancher/pkg/monitoring"
+	notifierutil "github.com/rancher/rancher/pkg/notifiers"
 	"github.com/rancher/rancher/pkg/project"
 	"github.com/rancher/rancher/pkg/ref"
 	v1 "github.com/rancher/types/apis/core/v1"
@@ -467,7 +468,7 @@ func (d *ConfigSyncer) addRecipients(notifiers []*v3.Notifier, receiver *alertco
 					Description:    `{{ template "rancher.title" . }}`,
 				}
 
-				if notifier.Spec.PagerdutyConfig.HTTPClientConfig != nil {
+				if notifierutil.IsHTTPClientConfigSet(notifier.Spec.PagerdutyConfig.HTTPClientConfig) {
 					url, err := toAlertManagerURL(notifier.Spec.PagerdutyConfig.HTTPClientConfig.ProxyURL)
 					if err != nil {
 						logrus.Errorf("Failed to parse pagerduty proxy url %s, %v", notifier.Spec.PagerdutyConfig.HTTPClientConfig.ProxyURL, err)
@@ -506,7 +507,7 @@ func (d *ConfigSyncer) addRecipients(notifiers []*v3.Notifier, receiver *alertco
 					wechat.ToParty = recipient
 				}
 
-				if notifier.Spec.WechatConfig.HTTPClientConfig != nil {
+				if notifierutil.IsHTTPClientConfigSet(notifier.Spec.WechatConfig.HTTPClientConfig) {
 					url, err := toAlertManagerURL(notifier.Spec.WechatConfig.HTTPClientConfig.ProxyURL)
 					if err != nil {
 						logrus.Errorf("Failed to parse wechat proxy url %s, %v", notifier.Spec.WechatConfig.HTTPClientConfig.ProxyURL, err)
@@ -529,7 +530,7 @@ func (d *ConfigSyncer) addRecipients(notifiers []*v3.Notifier, receiver *alertco
 					webhook.URL = r.Recipient
 				}
 
-				if notifier.Spec.WebhookConfig.HTTPClientConfig != nil {
+				if notifierutil.IsHTTPClientConfigSet(notifier.Spec.WebhookConfig.HTTPClientConfig) {
 					url, err := toAlertManagerURL(notifier.Spec.WebhookConfig.HTTPClientConfig.ProxyURL)
 					if err != nil {
 						logrus.Errorf("Failed to parse webhook proxy url %s, %v", notifier.Spec.WebhookConfig.HTTPClientConfig.ProxyURL, err)
@@ -556,7 +557,7 @@ func (d *ConfigSyncer) addRecipients(notifiers []*v3.Notifier, receiver *alertco
 					slack.Channel = r.Recipient
 				}
 
-				if notifier.Spec.SlackConfig.HTTPClientConfig != nil {
+				if notifierutil.IsHTTPClientConfigSet(notifier.Spec.SlackConfig.HTTPClientConfig) {
 					url, err := toAlertManagerURL(notifier.Spec.SlackConfig.HTTPClientConfig.ProxyURL)
 					if err != nil {
 						logrus.Errorf("Failed to parse slack proxy url %s, %v", notifier.Spec.SlackConfig.HTTPClientConfig.ProxyURL, err)

--- a/pkg/notifiers/sender.go
+++ b/pkg/notifiers/sender.go
@@ -516,7 +516,7 @@ func NewClientFromConfig(cfg *v3.HTTPClientConfig, dialer dialer.Dialer) (*http.
 		Timeout: time.Second * 10,
 	}
 
-	if cfg != nil {
+	if IsHTTPClientConfigSet(cfg) {
 		proxyURL, err := url.Parse(cfg.ProxyURL)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed to parse notifier proxy url %s", cfg.ProxyURL)
@@ -537,4 +537,11 @@ func post(client *http.Client, url string, bodyType string, body io.Reader) (*ht
 	}
 	req.Header.Set("Content-Type", bodyType)
 	return client.Do(req)
+}
+
+func IsHTTPClientConfigSet(cfg *v3.HTTPClientConfig) bool {
+	if cfg != nil && cfg.ProxyURL != "" {
+		return true
+	}
+	return false
 }

--- a/pkg/notifiers/sender_test.go
+++ b/pkg/notifiers/sender_test.go
@@ -1,0 +1,40 @@
+package notifiers
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsHTTPClientConfigSet(t *testing.T) {
+	type testCase struct {
+		httpConfig *v3.HTTPClientConfig
+		want       bool
+	}
+
+	testCases := []testCase{
+		testCase{
+			httpConfig: &v3.HTTPClientConfig{
+				ProxyURL: "test",
+			},
+			want: true,
+		},
+		testCase{
+			httpConfig: &v3.HTTPClientConfig{
+				ProxyURL: "",
+			},
+			want: false,
+		},
+		testCase{
+			httpConfig: nil,
+			want:       false,
+		},
+	}
+
+	assert := assert.New(t)
+	for _, tcase := range testCases {
+		assert.Equal(IsHTTPClientConfigSet(tcase.httpConfig), tcase.want)
+	}
+
+}


### PR DESCRIPTION
**Problem:**

After users set a proxy url for a notifier, they can not really remove it in alert manager config. 
Rancher will always set an empty proxyUrl in alert manger config for the notifier. So alert manager cannot send out alerts due to the empty proxy url setting.

**Solution:**

So we need to check if  it's empty.

**Related Issue:**

https://github.com/rancher/rancher/issues/26089

**Related PR:**

https://github.com/rancher/ui/pull/3854


