### PR TITLE
verify min k8s version before running scan

### DIFF
--- a/pkg/api/customization/cluster/actionhandler.go
+++ b/pkg/api/customization/cluster/actionhandler.go
@@ -25,7 +25,10 @@ type ActionHandler struct {
 	ClusterTemplateClient         v3.ClusterTemplateInterface
 	ClusterTemplateRevisionClient v3.ClusterTemplateRevisionInterface
 	SubjectAccessReviewClient     v1.SubjectAccessReviewInterface
+	CisBenchmarkVersionClient     v3.CisBenchmarkVersionInterface
 	CisBenchmarkVersionLister     v3.CisBenchmarkVersionLister
+	CisConfigClient               v3.CisConfigInterface
+	CisConfigLister               v3.CisConfigLister
 }
 
 func (a ActionHandler) ClusterActionHandler(actionName string, action *types.Action, apiContext *types.APIContext) error {

--- a/pkg/api/customization/cluster/actions_cis.go
+++ b/pkg/api/customization/cluster/actions_cis.go
@@ -79,6 +79,14 @@ func (a ActionHandler) runCisScan(actionName string, action *types.Action, apiCo
 			return httperror.WrapAPIError(err, httperror.ServerError,
 				fmt.Sprintf("error fetching cis benchmark version %v", cisScanConfig.OverrideBenchmarkVersion))
 		}
+		_, _, err = cis.GetBenchmarkVersionToUse(cisScanConfig.OverrideBenchmarkVersion,
+			cluster.Spec.RancherKubernetesEngineConfig.Version,
+			a.CisConfigLister, a.CisConfigClient,
+			a.CisBenchmarkVersionLister, a.CisBenchmarkVersionClient,
+		)
+		if err != nil {
+			return httperror.NewAPIError(httperror.MethodNotAllowed, err.Error())
+		}
 	}
 
 	isManual := true

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -265,6 +265,9 @@ func Clusters(schemas *types.Schemas, managementContext *config.ScaledContext, c
 		ClusterTemplateClient:         managementContext.Management.ClusterTemplates(""),
 		ClusterTemplateRevisionClient: managementContext.Management.ClusterTemplateRevisions(""),
 		SubjectAccessReviewClient:     managementContext.K8sClient.AuthorizationV1().SubjectAccessReviews(),
+		CisConfigClient:               managementContext.Management.CisConfigs(""),
+		CisConfigLister:               managementContext.Management.CisConfigs("").Controller().Lister(),
+		CisBenchmarkVersionClient:     managementContext.Management.CisBenchmarkVersions(""),
 		CisBenchmarkVersionLister:     managementContext.Management.CisBenchmarkVersions("").Controller().Lister(),
 	}
 

--- a/pkg/controllers/user/cis/clusterScanHandler.go
+++ b/pkg/controllers/user/cis/clusterScanHandler.go
@@ -9,10 +9,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/app/utils"
-	"github.com/rancher/rancher/pkg/controllers/management/kontainerdrivermetadata"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/systemaccount"
-	"github.com/rancher/rke/util"
 	"github.com/rancher/security-scan/pkg/kb-summarizer/report"
 	appsv1 "github.com/rancher/types/apis/apps/v1"
 	rcorev1 "github.com/rancher/types/apis/core/v1"
@@ -111,40 +109,24 @@ func (csh *cisScanHandler) Create(cs *v3.ClusterScan) (runtime.Object, error) {
 	if !v3.ClusterScanConditionCreated.IsTrue(cs) {
 		logrus.Infof("cisScanHandler: Create: deploying helm chart")
 		currentK8sVersion := cluster.Spec.RancherKubernetesEngineConfig.Version
-		shortK8sVersion := util.GetTagMajorVersion(currentK8sVersion)
-		cisConfigParams, err := kontainerdrivermetadata.GetCisConfigParams(
-			shortK8sVersion,
-			csh.cisConfigLister,
-			csh.cisConfigClient,
-		)
-		if err != nil {
-			logrus.Debugf("cisScanHandler: Create: benchmark version not found for k8s version: %v(%v), using default",
-				currentK8sVersion, shortK8sVersion)
-			cisConfigParams, err = kontainerdrivermetadata.GetCisConfigParams(
-				"default",
-				csh.cisConfigLister,
-				csh.cisConfigClient,
-			)
-			if err != nil {
-				return cs, fmt.Errorf("error fetching default cis config: %v", err)
-			}
+		overrideBenchmarkVersion := ""
+		if cs.Spec.ScanConfig.CisScanConfig != nil {
+			overrideBenchmarkVersion = cs.Spec.ScanConfig.CisScanConfig.OverrideBenchmarkVersion
 		}
-		benchmarkInfo, err := kontainerdrivermetadata.GetCisBenchmarkVersionInfo(
-			cisConfigParams.BenchmarkVersion,
-			csh.cisBenchmarkVersionLister,
-			csh.cisBenchmarkVersionClient,
+		bv, bvManaged, err := GetBenchmarkVersionToUse(overrideBenchmarkVersion, currentK8sVersion,
+			csh.cisConfigLister, csh.cisConfigClient,
+			csh.cisBenchmarkVersionLister, csh.cisBenchmarkVersionClient,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("cisScanHandler: Create: error fetching benchmark version info %v: %v",
-				cisConfigParams.BenchmarkVersion, err)
+			return cs, err
 		}
 		logrus.Debugf("cisScanHandler: Create: k8sVersion: %v, benchmarkVersion: %v",
-			currentK8sVersion, cisConfigParams.BenchmarkVersion)
+			currentK8sVersion, bv)
 		skipOverride := false
 		appInfo := &appInfo{
 			appName:                  cs.Name,
 			clusterName:              cs.Spec.ClusterID,
-			overrideBenchmarkVersion: cisConfigParams.BenchmarkVersion,
+			overrideBenchmarkVersion: bv,
 		}
 		if cs.Spec.ScanConfig.CisScanConfig != nil {
 			if cs.Spec.ScanConfig.CisScanConfig.DebugMaster {
@@ -156,10 +138,12 @@ func (csh *cisScanHandler) Create(cs *v3.ClusterScan) (runtime.Object, error) {
 			if cs.Spec.ScanConfig.CisScanConfig.OverrideSkip != nil {
 				skipOverride = true
 			}
-			if cs.Spec.ScanConfig.CisScanConfig.OverrideBenchmarkVersion != "" {
-				logrus.Debugf("cisScanHandler: Create: user requested overrideBenchmarkVersion: %v",
-					cs.Spec.ScanConfig.CisScanConfig.OverrideBenchmarkVersion)
-				appInfo.overrideBenchmarkVersion = cs.Spec.ScanConfig.CisScanConfig.OverrideBenchmarkVersion
+		}
+		if bvManaged {
+			appInfo.notApplicableSkipConfigMapName = getNotApplicableConfigMapName(bv)
+			if cs.Spec.ScanConfig.CisScanConfig.Profile == "" ||
+				cs.Spec.ScanConfig.CisScanConfig.Profile == v3.CisScanProfileTypePermissive {
+				appInfo.defaultSkipConfigMapName = getDefaultSkipConfigMapName(bv)
 			}
 		}
 
@@ -186,18 +170,6 @@ func (csh *cisScanHandler) Create(cs *v3.ClusterScan) (runtime.Object, error) {
 		}
 		if cm != nil {
 			appInfo.userSkipConfigMapName = cm.Name
-		}
-
-		if benchmarkInfo.Managed {
-			bv := cisConfigParams.BenchmarkVersion
-			if cs.Spec.ScanConfig.CisScanConfig.OverrideBenchmarkVersion != "" {
-				bv = cs.Spec.ScanConfig.CisScanConfig.OverrideBenchmarkVersion
-			}
-			appInfo.notApplicableSkipConfigMapName = getNotApplicableConfigMapName(bv)
-			if cs.Spec.ScanConfig.CisScanConfig.Profile == "" ||
-				cs.Spec.ScanConfig.CisScanConfig.Profile == v3.CisScanProfileTypePermissive {
-				appInfo.defaultSkipConfigMapName = getDefaultSkipConfigMapName(bv)
-			}
 		}
 
 		// Deploy the system helm chart

--- a/pkg/controllers/user/cis/utils.go
+++ b/pkg/controllers/user/cis/utils.go
@@ -5,9 +5,12 @@ import (
 	"time"
 
 	"github.com/rancher/rancher/pkg/app/utils"
+	"github.com/rancher/rancher/pkg/controllers/management/kontainerdrivermetadata"
 	"github.com/rancher/rancher/pkg/controllers/user/nslabels"
+	"github.com/rancher/rke/util"
 	rcorev1 "github.com/rancher/types/apis/core/v1"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -106,4 +109,77 @@ func ValidateClusterBeforeLaunchingScan(cluster *v3.Cluster) error {
 		return fmt.Errorf("CIS scan already running on cluster")
 	}
 	return nil
+}
+
+// If overrideBenchmarkVersion is not specified, we use the cluster k8s version to
+// figure out which benchmark version to use. If there is no matching k8s version in
+// cis configs, we use "default" entry. Each of these benchmark versions have a min
+// k8s version to use.
+func GetBenchmarkVersionToUse(overrideBenchmarkVersion string, currentK8sVersion string,
+	cisConfigLister v3.CisConfigLister, cisConfigClient v3.CisConfigInterface,
+	cisBenchmarkVersionLister v3.CisBenchmarkVersionLister, cisBenchmarkVersionClient v3.CisBenchmarkVersionInterface,
+) (string, bool, error) {
+	bv := overrideBenchmarkVersion
+	shortK8sVersion := util.GetTagMajorVersion(currentK8sVersion)
+	if bv == "" {
+		cisConfigParams, err := kontainerdrivermetadata.GetCisConfigParams(
+			shortK8sVersion,
+			cisConfigLister,
+			cisConfigClient,
+		)
+		if err != nil {
+			logrus.Debugf("cisScanHandler: benchmark version not found for k8s version: %v, using default",
+				shortK8sVersion)
+			cisConfigParams, err = kontainerdrivermetadata.GetCisConfigParams(
+				"default",
+				cisConfigLister,
+				cisConfigClient,
+			)
+			if err != nil {
+				return "", false, fmt.Errorf("cisScanHandler: error fetching default cis config: %v", err)
+			}
+		}
+		bv = cisConfigParams.BenchmarkVersion
+	}
+	benchmarkInfo, err := kontainerdrivermetadata.GetCisBenchmarkVersionInfo(
+		bv,
+		cisBenchmarkVersionLister,
+		cisBenchmarkVersionClient,
+	)
+	if err != nil {
+		return "", false, fmt.Errorf("cisScanHandler: error fetching benchmark version info %v: %v",
+			bv, err)
+	}
+	sufficient, err := isClusterVersionSufficient(shortK8sVersion, benchmarkInfo.MinKubernetesVersion)
+	if err != nil {
+		return "", false, err
+	}
+	if !sufficient {
+		return "", false, fmt.Errorf("minimum k8s version %v needed for running cis scan", benchmarkInfo.MinKubernetesVersion)
+	}
+	return bv, benchmarkInfo.Managed, nil
+}
+
+func isClusterVersionSufficient(shortClusterK8SVersion, benchmarkMinK8SVersion string) (bool, error) {
+	benchmarkK8sVersionSemVer, err := util.StrToSemVer(ConvertToSemVerStr(benchmarkMinK8SVersion))
+	if err != nil {
+		return false, fmt.Errorf("cisScanHandler: error getting sem version for benchmark k8s version %v: %v",
+			benchmarkMinK8SVersion, err)
+	}
+	clusterK8sSemVerStr := ConvertToSemVerStr(shortClusterK8SVersion)
+	clusterK8sSemVer, err := util.StrToSemVer(clusterK8sSemVerStr)
+	if err != nil {
+		return false, fmt.Errorf("cisScanHandler: error getting sem version for cluster k8s version %v: %v",
+			clusterK8sSemVer, err)
+	}
+	logrus.Debugf("cisScanHandler: checking if cluster version %v is less than min version: %v",
+		clusterK8sSemVerStr, benchmarkMinK8SVersion)
+	if clusterK8sSemVer.LessThan(*benchmarkK8sVersionSemVer) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func ConvertToSemVerStr(tag string) string {
+	return tag + ".0"
 }


### PR DESCRIPTION
addresses: https://github.com/rancher/rancher/issues/25996

Minimum k8s version required for a benchmark version is available in the CRD. Added checks to compare that with the cluster version when the scan is initiated.