### PR TITLE
Replace `+` with`-` for name compliance

### DIFF
--- a/pkg/catalog/manager/catalog_common.go
+++ b/pkg/catalog/manager/catalog_common.go
@@ -214,7 +214,7 @@ func getValidTemplateName(catalogName, chartName string) string {
 // https://github.com/helm/helm/blob/3582b03a91bb994aa4d33a7bc50de5205f734c7a/pkg/chartutil/create.go
 func getValidTemplateNameWithVersion(templateName, version string) string {
 	label := fmt.Sprintf("%s-%s", templateName, version)
-	label = strings.ReplaceAll(label, "+", "_")
+	label = strings.ReplaceAll(label, "+", "-")
 	label = strings.TrimSuffix(label, "-")
 	return label
 }


### PR DESCRIPTION
Initially replaced `+` with `_` but should be `-` to be valid kubernetes name

**Related PR:** 
https://github.com/rancher/rancher/pull/25920