### PR TITLE
skip validation if clusterUpdated is not true

### DIFF
--- a/pkg/api/store/cluster/cluster_store.go
+++ b/pkg/api/store/cluster/cluster_store.go
@@ -964,9 +964,9 @@ func (r *Store) validateUnavailableNodes(data, existingData map[string]interface
 		return fmt.Errorf("error getting cluster, try again %v", err)
 	}
 	// no need to validate if cluster's already provisioning or upgrading
-	if v3.ClusterConditionProvisioned.IsUnknown(cluster) ||
-		v3.ClusterConditionUpgraded.IsUnknown(cluster) ||
-		v3.ClusterConditionUpdated.IsUnknown(cluster) {
+	if !v3.ClusterConditionProvisioned.IsTrue(cluster) ||
+		!v3.ClusterConditionUpdated.IsTrue(cluster) ||
+		v3.ClusterConditionUpgraded.IsUnknown(cluster) {
 		return nil
 	}
 	spec, err := getRkeConfig(data)


### PR DESCRIPTION
(This is only temporary, because condition again becomes Unknown during retry) 

Problem:
Using cond.IsUnknown doesn't include when condition has
finished with some error and it becomes cond.False. 

Solution:
Use !cond.IsTrue

https://github.com/rancher/rancher/issues/26120