### PR TITLE
fix for k8s version check for cis scan

### DIFF
--- a/pkg/api/customization/cluster/actions_cis.go
+++ b/pkg/api/customization/cluster/actions_cis.go
@@ -79,14 +79,14 @@ func (a ActionHandler) runCisScan(actionName string, action *types.Action, apiCo
 			return httperror.WrapAPIError(err, httperror.ServerError,
 				fmt.Sprintf("error fetching cis benchmark version %v", cisScanConfig.OverrideBenchmarkVersion))
 		}
-		_, _, err = cis.GetBenchmarkVersionToUse(cisScanConfig.OverrideBenchmarkVersion,
-			cluster.Spec.RancherKubernetesEngineConfig.Version,
-			a.CisConfigLister, a.CisConfigClient,
-			a.CisBenchmarkVersionLister, a.CisBenchmarkVersionClient,
-		)
-		if err != nil {
-			return httperror.NewAPIError(httperror.MethodNotAllowed, err.Error())
-		}
+	}
+	_, _, err = cis.GetBenchmarkVersionToUse(cisScanConfig.OverrideBenchmarkVersion,
+		cluster.Spec.RancherKubernetesEngineConfig.Version,
+		a.CisConfigLister, a.CisConfigClient,
+		a.CisBenchmarkVersionLister, a.CisBenchmarkVersionClient,
+	)
+	if err != nil {
+		return httperror.NewAPIError(httperror.MethodNotAllowed, err.Error())
 	}
 
 	isManual := true


### PR DESCRIPTION
addresses: https://github.com/rancher/rancher/issues/25996

The check should have been outside the if block, fixing the issue.