### PR TITLE
Fix kdm/data.json cache issue

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -86,8 +86,7 @@ RUN curl -sLf ${!CHANNELSERVER_URL} > /usr/bin/channelserver && \
     curl -sfL ${!ETCD_URL} | tar xvzf - --strip-components=1 -C /usr/bin/ etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcd && \
     chmod +x /usr/bin/k3s /usr/bin/channelserver && \
     mkdir -p /go/src/github.com/rancher/rancher/.kube && \
-    ln -s /etc/rancher/k3s/k3s.yaml /go/src/github.com/rancher/rancher/.kube/k3s.yaml && \
-    curl -sLf https://releases.rancher.com/kontainer-driver-metadata/${RANCHER_METADATA_BRANCH}/data.json > /root/data.json
+    ln -s /etc/rancher/k3s/k3s.yaml /go/src/github.com/rancher/rancher/.kube/k3s.yaml
 
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -98,8 +98,7 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     curl -sLf https://github.com/rancher/telemetry/releases/download/${TELEMETRY_VERSION}/telemetry-${ARCH} > /usr/bin/telemetry && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/tini /usr/bin/telemetry /usr/bin/k3s /usr/bin/kubectl /usr/bin/channelserver && \
-    mkdir -p /var/lib/rancher-data/driver-metadata && \
-    curl -sLf https://releases.rancher.com/kontainer-driver-metadata/${RANCHER_METADATA_BRANCH}/data.json > /var/lib/rancher-data/driver-metadata/data.json
+    mkdir -p /var/lib/rancher-data/driver-metadata
 
 ENV CATTLE_UI_PATH /usr/share/rancher/ui
 ENV CATTLE_UI_VERSION 2.4.8
@@ -140,6 +139,8 @@ COPY kustomize.sh /usr/bin/
 COPY jailer.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/kustomize.sh
+
+COPY data.json /var/lib/rancher-data/driver-metadata/
 
 ENV CATTLE_AGENT_IMAGE ${IMAGE_REPO}/rancher-agent:${VERSION}
 ENV CATTLE_SERVER_IMAGE ${IMAGE_REPO}/rancher

--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -64,7 +65,7 @@ func run(systemChartPath string, imagesFromArgs []string) error {
 	}
 
 	// already downloaded in dapper
-	b, err := ioutil.ReadFile("/root/data.json")
+	b, err := ioutil.ReadFile(filepath.Join(os.Getenv("HOME"), "bin", "data.json"))
 	if err != nil {
 		return err
 	}

--- a/pkg/image/resolve_test.go
+++ b/pkg/image/resolve_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -259,7 +261,7 @@ func TestGetImages(t *testing.T) {
 }
 
 func getTestK8sVersionInfo() (*kd.VersionInfo, *kd.VersionInfo, error) {
-	b, err := ioutil.ReadFile("/root/data.json")
+	b, err := ioutil.ReadFile(filepath.Join(os.Getenv("HOME"), "bin", "data.json"))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/scripts/build-server
+++ b/scripts/build-server
@@ -23,3 +23,5 @@ CGO_ENABLED=0 go build -i -tags k8s \
    -X github.com/rancher/rancher/pkg/version.GitCommit=$COMMIT
    -X github.com/rancher/rancher/pkg/settings.InjectDefaults=$DEFAULT_VALUES $LINKFLAGS" \
   -o bin/rancher
+
+curl -sLf https://releases.rancher.com/kontainer-driver-metadata/${RANCHER_METADATA_BRANCH}/data.json > bin/data.json

--- a/scripts/package
+++ b/scripts/package
@@ -21,7 +21,7 @@ if [ -n "$DRONE_TAG" ]; then
     TAG=$DRONE_TAG
 fi
 
-cp ../bin/rancher ../bin/agent .
+cp ../bin/rancher ../bin/agent ../bin/data.json .
 
 IMAGE=${REPO}/rancher:${TAG}
 AGENT_IMAGE=${REPO}/rancher-agent:${TAG}


### PR DESCRIPTION
This commit moves data.json from dockerfile.dapper into scripts/package,
also use dockerfile ARG to disable dockerfile caching.