### PR TITLE
increment cluster.Status.NodeVersion only on plan change

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -522,7 +522,8 @@ func (p *Provisioner) reconcileCluster(cluster *v3.Cluster, create bool) (*v3.Cl
 		cluster.Status.CACert = caCert
 		resetRkeConfigFlags(cluster, updateTriggered)
 
-		if cluster.Status.AppliedSpec.RancherKubernetesEngineConfig != nil {
+		// initialize on first rke up
+		if cluster.Status.AppliedSpec.RancherKubernetesEngineConfig != nil && cluster.Status.NodeVersion == 0 {
 			cluster.Status.NodeVersion++
 		}
 


### PR DESCRIPTION
Problem:
Current design is to increment node version of cluster status on
every rke up. Deleting a node during upgrade also results into
a rke up, and it causes all nodes to upgrade again because of mismatch
between node and cluster's applied versions.

Solution:
change cluster.status.nodeversion only when plan changes on rke up

https://github.com/rancher/rancher/issues/26164