### PR TITLE
Don't allow access to the local cluster if local cluster is not enabled

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -330,7 +330,7 @@ func newSteve(ctx context.Context, rancher *Rancher) (http.Handler, error) {
 		Next:            rancher.Handler,
 		StartHooks: []steveserver.StartHook{
 			func(ctx context.Context, server *steveserver.Server) error {
-				return steve.Setup(server, rancher.WranglerContext)
+				return steve.Setup(server, rancher.WranglerContext, localClusterEnabled(rancher.Config), rancher.Handler)
 			},
 			clusterapiServer.Setup,
 		},


### PR DESCRIPTION
If local cluster is not enabled the following rules apply

disallow access to (they should result in 404)
/api/*
/apis/*
/v1/*
/k8s/clusters/local/*

allow only GET requests on
/v1/management.cattle.io* requests