### PR TITLE
Remove the member attribute of the group query

### DIFF
--- a/pkg/auth/providers/common/ldap/ldap_util.go
+++ b/pkg/auth/providers/common/ldap/ldap_util.go
@@ -152,7 +152,6 @@ func GetUserSearchAttributesForLDAP(ObjectClass string, config *v3.LdapConfig) [
 
 func GetGroupSearchAttributesForLDAP(ObjectClass string, config *v3.LdapConfig) []string {
 	groupSeachAttributes := []string{config.GroupMemberUserAttribute,
-		config.GroupMemberMappingAttribute,
 		ObjectClass,
 		config.GroupObjectClass,
 		config.UserLoginAttribute,


### PR DESCRIPTION
A group could have thousands of members and this makes the group query really slow on huge ldap setups. When we pull data for groups, we do not need the members unless it is for nested group functionality. For nested groups the query remains same and is not changed.

https://github.com/rancher/rancher/issues/26061