### PR TITLE
increment cluster node version for cluster rollback

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -587,6 +587,7 @@ func resetRkeConfigFlags(cluster *v3.Cluster, updateTriggered bool) {
 		cluster.Spec.RancherKubernetesEngineConfig.RotateCertificates = nil
 		if cluster.Spec.RancherKubernetesEngineConfig.Restore.Restore {
 			cluster.Annotations[RkeRestoreAnnotation] = "true"
+			cluster.Status.NodeVersion++
 		}
 		cluster.Spec.RancherKubernetesEngineConfig.Restore = v3.RestoreConfig{}
 		if cluster.Status.AppliedSpec.RancherKubernetesEngineConfig != nil {


### PR DESCRIPTION
Problem:
This broke with a recent fix of moving when to increment
node version for upgrade logic. If node version is not
incremented, node plans won't get restored on rollback

https://github.com/rancher/rancher/issues/26289