### PR TITLE
remove unused code

### DIFF
--- a/pkg/controllers/management/rkeworkerupgrader/upgrade.go
+++ b/pkg/controllers/management/rkeworkerupgrader/upgrade.go
@@ -135,12 +135,7 @@ func (uh *upgradeHandler) Sync(key string, node *v3.Node) (runtime.Object, error
 	}
 
 	// proceed only if node and cluster's versions mismatch
-	if cluster.Status.NodeVersion == node.Status.AppliedNodeVersion {
-		if v3.NodeConditionUpgraded.IsUnknown(node) {
-			if err := uh.updateNodeActive(node); err != nil {
-				return nil, err
-			}
-		}
+	if cluster.Status.NodeVersion == node.Status.NodePlan.Version {
 		return node, nil
 	}
 
@@ -155,13 +150,6 @@ func (uh *upgradeHandler) Sync(key string, node *v3.Node) (runtime.Object, error
 			return uh.updateNodePlan(node, cluster, false)
 		}
 	} else {
-		if planChangedForUpgrade(nodePlan, node.Status.NodePlan.Plan) {
-			logrus.Infof("cluster [%s] worker-upgrade: plan changed for node [%s], call upgrade to reconcile cluster", cluster.Name, node.Name)
-			if err := uh.upgradeCluster(cluster, node.Name, false); err != nil {
-				return nil, err
-			}
-			return node, nil
-		}
 		if planChangedForUpdate(nodePlan, node.Status.NodePlan.Plan) {
 			logrus.Infof("cluster [%s] worker-upgrade: plan changed for update [%s]", cluster.Name, node.Name)
 			return uh.updateNodePlan(node, cluster, false)


### PR DESCRIPTION
saw this in logs: after RKE restore, if a node sync comes in before restore logic kicks in, it's going to reconcile thinking it's upgrade! 

```
2020/03/26 21:04:09 [INFO] image changed for [kubelet] old: rancher/hyperkube:v1.16.8-rancher1 new: rancher/hyperkube:v1.15.11-rancher1
2020/03/26 21:04:09 [INFO] cluster [c-nvgn7] worker-upgrade: plan changed for node [m-zglrc], call upgrade to reconcile cluster
2020/03/26 21:04:09 [INFO] cluster [c-nvgn7] worker-upgrade: updated cluster for upgrading: [3] 
2020/03/26 21:04:09 [INFO] cluster [c-nvgn7] worker-upgrade: updated node [m-svw2h] to cordon
2020/03/26 21:04:09 [INFO] cluster [c-nvgn7] worker-upgrade: updated node [m-tqkpp] to cordon
2020/03/26 21:04:10 [INFO] cluster [c-nvgn7] worker-upgrade: call upgrade to reconcile for node [m-svw2h]
2020/03/26 21:04:10 [INFO] cluster [c-nvgn7] worker-upgrade: updated node [m-svw2h] to upgrade
2020/03/26 21:04:10 [INFO] cluster [c-nvgn7] worker-upgrade: call upgrade to reconcile for node [m-tqkpp]
2020/03/26 21:04:10 [INFO] cluster [c-nvgn7] worker-upgrade: updated node [m-tqkpp] to upgrade
```