### PR TITLE
Support v3.cluster.status.ComponentStatusesLastSync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ replace (
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.3
+	github.com/rancher/types => github.com/ukinau/types v0.0.0-20200330152112-6cf9354ea86b
 
 	k8s.io/api => k8s.io/api v0.18.0
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -524,6 +524,7 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
+github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc h1:f8eY6cV/x1x+HLjOp4r72s/31/V2aTUtg5oKRRPf8/Q=
 github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -1044,6 +1045,8 @@ github.com/uber/jaeger-client-go v2.20.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMW
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/ukinau/types v0.0.0-20200330152112-6cf9354ea86b h1:FVynrqLstEMNsZP1/m5Q6Gva7cnQw+jS4WsTwBomz78=
+github.com/ukinau/types v0.0.0-20200330152112-6cf9354ea86b/go.mod h1:dFo1jHAqDecEB+ODKVTx1I7YXpW1qbH2ybOaU3SSDD4=
 github.com/ultraware/funlen v0.0.1/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/funlen v0.0.2/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/urfave/cli v1.11.1-0.20151120215642-0302d3914d2a/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/controllers/user/healthsyncer/healthsyncer.go
+++ b/pkg/controllers/user/healthsyncer/healthsyncer.go
@@ -81,6 +81,8 @@ func (h *HealthSyncer) getComponentStatus(cluster *v3.Cluster) error {
 	sort.Slice(cluster.Status.ComponentStatuses, func(i, j int) bool {
 		return cluster.Status.ComponentStatuses[i].Name < cluster.Status.ComponentStatuses[j].Name
 	})
+	updateTime := metav1.Now()
+	cluster.Status.ComponentStatusesLastSync = &updateTime
 	return nil
 }
 

--- a/vendor/github.com/gregjones/httpcache/.travis.yml
+++ b/vendor/github.com/gregjones/httpcache/.travis.yml
@@ -1,18 +1,19 @@
 sudo: false
 language: go
+go:
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - master
 matrix:
   allow_failures:
     - go: master
   fast_finish: true
-  include:
-    - go: 1.10.x
-    - go: 1.11.x
-      env: GOFMT=1
-    - go: master
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
   - go get -t -v ./...
-  - if test -n "${GOFMT}"; then gofmt -w -s . && git diff --exit-code; fi
+  - diff -u <(echo -n) <(gofmt -d .)
   - go tool vet .
   - go test -v -race ./...

--- a/vendor/github.com/gregjones/httpcache/httpcache.go
+++ b/vendor/github.com/gregjones/httpcache/httpcache.go
@@ -416,14 +416,14 @@ func canStaleOnError(respHeaders, reqHeaders http.Header) bool {
 func getEndToEndHeaders(respHeaders http.Header) []string {
 	// These headers are always hop-by-hop
 	hopByHopHeaders := map[string]struct{}{
-		"Connection":          {},
-		"Keep-Alive":          {},
-		"Proxy-Authenticate":  {},
-		"Proxy-Authorization": {},
-		"Te":                  {},
-		"Trailers":            {},
-		"Transfer-Encoding":   {},
-		"Upgrade":             {},
+		"Connection":          struct{}{},
+		"Keep-Alive":          struct{}{},
+		"Proxy-Authenticate":  struct{}{},
+		"Proxy-Authorization": struct{}{},
+		"Te":                struct{}{},
+		"Trailers":          struct{}{},
+		"Transfer-Encoding": struct{}{},
+		"Upgrade":           struct{}{},
 	}
 
 	for _, extra := range strings.Split(respHeaders.Get("connection"), ",") {
@@ -433,7 +433,7 @@ func getEndToEndHeaders(respHeaders http.Header) []string {
 		}
 	}
 	endToEndHeaders := []string{}
-	for respHeader := range respHeaders {
+	for respHeader, _ := range respHeaders {
 		if _, ok := hopByHopHeaders[respHeader]; !ok {
 			endToEndHeaders = append(endToEndHeaders, respHeader)
 		}

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -138,6 +138,7 @@ type ClusterStatus struct {
 	AgentFeatures                        map[string]bool             `json:"agentFeatures,omitempty"`
 	AuthImage                            string                      `json:"authImage"`
 	ComponentStatuses                    []ClusterComponentStatus    `json:"componentStatuses,omitempty"`
+	ComponentStatusesLastSync            *metav1.Time                `json:"componentStatusesLastSync,omitempty"`
 	APIEndpoint                          string                      `json:"apiEndpoint,omitempty"`
 	ServiceAccountToken                  string                      `json:"serviceAccountToken,omitempty"`
 	CACert                               string                      `json:"caCert,omitempty"`

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -2325,6 +2325,10 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ComponentStatusesLastSync != nil {
+		in, out := &in.ComponentStatusesLastSync, &out.ComponentStatusesLastSync
+		*out = (*in).DeepCopy()
+	}
 	if in.Capacity != nil {
 		in, out := &in.Capacity, &out.Capacity
 		*out = make(corev1.ResourceList, len(*in))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -220,7 +220,7 @@ github.com/googleapis/gnostic/extensions
 github.com/gorilla/mux
 # github.com/gorilla/websocket v1.4.1
 github.com/gorilla/websocket
-# github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc
+# github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
 github.com/gregjones/httpcache
 github.com/gregjones/httpcache/diskcache
 # github.com/hashicorp/errwrap v1.0.0
@@ -489,7 +489,7 @@ github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1
 github.com/rancher/system-upgrade-controller/pkg/condition
 github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/scheme
 github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/typed/upgrade.cattle.io/v1
-# github.com/rancher/types v0.0.0-20200327203838-a36e8d24795f
+# github.com/rancher/types v0.0.0-20200327203838-a36e8d24795f => github.com/ukinau/types v0.0.0-20200330152112-6cf9354ea86b
 github.com/rancher/types/apis/apiregistration.k8s.io/v1
 github.com/rancher/types/apis/apps/v1
 github.com/rancher/types/apis/autoscaling/v2beta2


### PR DESCRIPTION
Related: #https://github.com/rancher/rancher/issues/26363

## Overview 
To monitor/detect when is the last time healthsycner synced,
This commit make healthsync updated ComponentStatusesLastSync fields
with the time to get status from k8s.

## Dependency 
* https://github.com/rancher/types/pull/1130
    * currently go.mod is indicating to my branch: https://github.com/ukinau/types/tree/Add-ComponentStatusesLastSync , but it will be replaced back to rke/types once PR got merged 

## Notes 
* I didn't mean to update `gregjones/httpcache` but `go mod vendor` seems updating it. So If we need to create PR separately, I can get rid of that change. 