### PR TITLE
Change scope to subtree for openldap login search

### DIFF
--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -68,7 +68,7 @@ func (p *ldapProvider) loginUser(credential *v3public.BasicLogin, config *v3.Lda
 	}
 
 	searchOpRequest := ldapv2.NewSearchRequest(userDN,
-		ldapv2.ScopeBaseObject, ldapv2.NeverDerefAliases, 0, 0, false,
+		ldapv2.ScopeWholeSubtree, ldapv2.NeverDerefAliases, 0, 0, false,
 		fmt.Sprintf("(%v=%v)", ObjectClass, config.UserObjectClass),
 		operationalAttrList, nil)
 	opResult, err := lConn.Search(searchOpRequest)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/20002
Problem: For openldap during auth setup and login, after user bind, a query is executed to get the user's attributes. This query uses `base` search scope. For some users this query didn't return any user entries. As per the ldap logs provided by the user in issue description, their ldap server returns entry only if search scope is set to `subtree`. 

Solution: This commit changes ldap login query search scope from `base` to `subtree`. The query searches for entry with provided user object class so the entry returned should be that of a valid user. Works with our openldap and freeipa test setups.