### PR TITLE
Stop reconciling if managed agent is found

### DIFF
--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/mattn/go-colorable"
+	"github.com/rancher/norman/types/slice"
 	"github.com/rancher/rancher/pkg/agent/clean"
 	"github.com/rancher/rancher/pkg/agent/cluster"
 	"github.com/rancher/rancher/pkg/agent/node"
@@ -320,6 +321,7 @@ func run() error {
 		// launching reconcileKubelet in a goroutine to make sure kubelet will be restarted
 		// every three minutes until managed agent comes up and take over
 		go func() {
+		loop:
 			for {
 				select {
 				case <-time.After(3 * time.Minute):
@@ -328,7 +330,7 @@ func run() error {
 						logrus.Errorf("failed to reconcile kubelet: %v", err)
 					}
 					if done {
-						break
+						break loop
 					}
 				case <-ctx.Done():
 					return
@@ -393,13 +395,20 @@ func reconcileKubelet(ctx context.Context) (bool, error) {
 		return true, nil
 	}
 
-	nodeName := os.Getenv("CATTLE_NODE_NAME")
-	logrus.Infof("node %v is not registered, restarting kubelet now", nodeName)
 	c, err := client.NewEnvClient()
 	if err != nil {
 		return false, err
 	}
 	defer c.Close()
+
+	exist, err := checkManagedAgents(ctx, c)
+	if err != nil {
+		return false, err
+	}
+	if exist {
+		logrus.Infof("managed agent exists, stop reconciling kubelet")
+		return true, nil
+	}
 
 	args := filters.NewArgs()
 	args.Add("label", "io.rancher.rke.container.name=kubelet")
@@ -414,11 +423,42 @@ func reconcileKubelet(ctx context.Context) (bool, error) {
 
 	for _, container := range containers {
 		if len(container.Names) > 0 && strings.Contains(container.Names[0], "kubelet") {
+			nodeName := os.Getenv("CATTLE_NODE_NAME")
+			logrus.Infof("node %v is not registered, restarting kubelet now", nodeName)
 			if err := c.ContainerRestart(ctx, container.ID, nil); err != nil {
 				return false, err
 			}
 			break
 		}
 	}
+	return false, nil
+}
+
+func checkManagedAgents(ctx context.Context, c *client.Client) (bool, error) {
+	args := filters.NewArgs()
+	args.Add("label", "io.cattle.agent=true")
+
+	containers, err := c.ContainerList(ctx, types.ContainerListOptions{
+		All:     true,
+		Filters: args,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	for _, container := range containers {
+		con, err := c.ContainerInspect(ctx, container.ID)
+		if err != nil {
+			return false, err
+		}
+		// this check if container is a managed node-agent
+		if _, ok := container.Labels["io.kubernetes.pod.namespace"]; ok &&
+			con.Config != nil &&
+			slice.ContainsString(con.Config.Env, "CATTLE_K8S_MANAGED=true") &&
+			slice.ContainsString(con.Config.Env, "CATTLE_CLUSTER=false") {
+			return true, nil
+		}
+	}
+
 	return false, nil
 }


### PR DESCRIPTION
This double checks if manage agent is found and unmanaged agent can't be
cleaned up by managed agent due to race condition. Once managed agent
is found then the loop is immediately terminated.