### PR TITLE
Enqueue controller if still in upgrading state

### DIFF
--- a/pkg/controllers/management/k3supgrade/deployPlans.go
+++ b/pkg/controllers/management/k3supgrade/deployPlans.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	planv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	planClientset "github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/typed/upgrade.cattle.io/v1"
@@ -178,8 +179,7 @@ func (h *handler) modifyClusterCondition(cluster *v3.Cluster, masterPlan, worker
 		c := cluster.Spec.K3sConfig.ServerConcurrency
 		masterPlanMessage := fmt.Sprintf("controlplane node [%s] being upgraded",
 			upgradingMessage(c, masterPlan.Status.Applying))
-		v3.ClusterConditionUpgraded.Message(cluster, masterPlanMessage)
-		return h.clusterClient.Update(cluster)
+		return h.enqueueOrUpdate(cluster, masterPlanMessage)
 
 	}
 
@@ -188,8 +188,7 @@ func (h *handler) modifyClusterCondition(cluster *v3.Cluster, masterPlan, worker
 		c := cluster.Spec.K3sConfig.WorkerConcurrency
 		workerPlanMessage := fmt.Sprintf("worker node [%s] being upgraded",
 			upgradingMessage(c, workerPlan.Status.Applying))
-		v3.ClusterConditionUpgraded.Message(cluster, workerPlanMessage)
-		return h.clusterClient.Update(cluster)
+		return h.enqueueOrUpdate(cluster, workerPlanMessage)
 	}
 
 	// if we made it this far nothing is applying
@@ -209,4 +208,16 @@ func upgradingMessage(concurrency int, nodes []string) string {
 	}
 
 	return strings.Join(nodes[:concurrency], ", ")
+}
+
+func (h *handler) enqueueOrUpdate(cluster *v3.Cluster, upgradeMessage string) (*v3.Cluster, error) {
+	if v3.ClusterConditionUpgraded.GetMessage(cluster) == upgradeMessage {
+		// update would be no op
+		h.clusterEnqueueAfter(cluster.Name, time.Second*5) // prevent controller from remaining in this state
+		return cluster, nil
+	}
+
+	v3.ClusterConditionUpgraded.Message(cluster, upgradeMessage)
+	return h.clusterClient.Update(cluster)
+
 }

--- a/pkg/controllers/management/k3supgrade/register.go
+++ b/pkg/controllers/management/k3supgrade/register.go
@@ -2,6 +2,7 @@ package k3supgrade
 
 import (
 	"context"
+	"time"
 
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/systemaccount"
@@ -23,6 +24,7 @@ type handler struct {
 	nodeLister             v3.NodeLister
 	systemAccountManager   *systemaccount.Manager
 	manager                *clustermanager.Manager
+	clusterEnqueueAfter    func(name string, duration time.Duration)
 }
 
 const (
@@ -37,6 +39,7 @@ func Register(ctx context.Context, wContext *wrangler.Context, mgmtCtx *config.M
 		systemUpgradeNamespace: systemUpgradeNS,
 		clusterCache:           wContext.Mgmt.Cluster().Cache(),
 		clusterClient:          wContext.Mgmt.Cluster(),
+		clusterEnqueueAfter:    wContext.Mgmt.Cluster().EnqueueAfter,
 		apps:                   mgmtCtx.Project.Apps(metav1.NamespaceAll),
 		appLister:              mgmtCtx.Project.Apps("").Controller().Lister(),
 		templateLister:         mgmtCtx.Management.CatalogTemplates("").Controller().Lister(),


### PR DESCRIPTION
While upgrading k3s clusters the controller may cause updates that do not change the cluster object. This means that the controller will not be run again to exit the updating state. In these cases the controller should re-enqueue itself.

Addresses https://github.com/rancher/rancher/issues/26286