### PR TITLE
[2.4] Lowercase resource set in proxyStore

### DIFF
--- a/pkg/api/server/userstored/proxy_store.go
+++ b/pkg/api/server/userstored/proxy_store.go
@@ -25,7 +25,7 @@ func addProxyStore(ctx context.Context, schemas *types.Schemas, context *config.
 
 	prefix := []string{"api"}
 	kind := s.CodeName
-	plural := s.PluralName
+	plural := strings.ToLower(s.PluralName)
 
 	var version, group string
 	parts := strings.SplitN(apiVersion, "/", 2)


### PR DESCRIPTION
The resource name is takes from the Norman schema PluralName field.
In norman this is a plural form of the ID field which is typically
camelCase.  A Kubernetes resource field is always lowerscase. In
Rancher <=2.3 the RBAC system would do case insensitive checks
against all strings. In Rancher 2.4 the RBAC system was switch from
Norman to Steve.  Steve's implementation is much faster and more
proper and as a result does not do case insensitive checks. It is
expected that all input to the RBAC system is proper. This is the one
place in Rancher where we weird not generating a proper resource name.