### PR TITLE
[2.4] Enqueue controller if still in upgrading state

### DIFF
--- a/pkg/controllers/management/k3supgrade/register.go
+++ b/pkg/controllers/management/k3supgrade/register.go
@@ -2,6 +2,7 @@ package k3supgrade
 
 import (
 	"context"
+	"time"
 
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/systemaccount"
@@ -23,6 +24,7 @@ type handler struct {
 	nodeLister             v3.NodeLister
 	systemAccountManager   *systemaccount.Manager
 	manager                *clustermanager.Manager
+	clusterEnqueueAfter    func(name string, duration time.Duration)
 }
 
 const (
@@ -37,6 +39,7 @@ func Register(ctx context.Context, wContext *wrangler.Context, mgmtCtx *config.M
 		systemUpgradeNamespace: systemUpgradeNS,
 		clusterCache:           wContext.Mgmt.Cluster().Cache(),
 		clusterClient:          wContext.Mgmt.Cluster(),
+		clusterEnqueueAfter:    wContext.Mgmt.Cluster().EnqueueAfter,
 		apps:                   mgmtCtx.Project.Apps(metav1.NamespaceAll),
 		appLister:              mgmtCtx.Project.Apps("").Controller().Lister(),
 		templateLister:         mgmtCtx.Management.CatalogTemplates("").Controller().Lister(),


### PR DESCRIPTION
While upgrading k3s clusters the controller may cause updates that do not change the cluster object. This means that the controller will not be run again to exit the updating state. In these cases, the controller should re-enqueue itself.

This PR is needed to update the 2.4 release branch 

Addresses https://github.com/rancher/rancher/issues/26286, specifically https://github.com/rancher/rancher/issues/26286#issuecomment-608137620 

