### PR TITLE
[2.4]Ldap: Remove the member attribute of the group query 

### DIFF
--- a/pkg/auth/providers/common/ldap/ldap_util.go
+++ b/pkg/auth/providers/common/ldap/ldap_util.go
@@ -152,7 +152,6 @@ func GetUserSearchAttributesForLDAP(ObjectClass string, config *v3.LdapConfig) [
 
 func GetGroupSearchAttributesForLDAP(ObjectClass string, config *v3.LdapConfig) []string {
 	groupSeachAttributes := []string{config.GroupMemberUserAttribute,
-		config.GroupMemberMappingAttribute,
 		ObjectClass,
 		config.GroupObjectClass,
 		config.UserLoginAttribute,


### PR DESCRIPTION
Backport PR for https://github.com/rancher/rancher/issues/26061

What is the fix?

- The fix currently in test for this issue removes the "member" attribute from the search queries done for a group. This avoids pulling all the members of a group.

- It was found that when we pull details of a group, we do not need its list of members in most cases. Only case where we need to find a groups members is when nested group memberships are enabled on the auth config, since we then need to look at all sub-groups of this group.

What to test?

- We need to test and validate that all the functionalities related to OpenLDAP, FreeIPA and AD(less impacted) are unaffected.
- Especially testcases around cluster/project memberships granted to groups should let the group members correct access
- Also need to make sure that testcases around nested groups are working fine.
- Also should validate with large dataset - with users having say 1000 groups and few groups having 1000 members.