### PR TITLE
[2.4] Fix the issue that preferences show other user's name 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20200401220414-61a905156cd1
 	github.com/rancher/system-upgrade-controller v0.3.1
-	github.com/rancher/types v0.0.0-20200326224903-b4612bd96d9b
+	github.com/rancher/types v0.0.0-20200404135946-29ff83f9682c
 	github.com/rancher/wrangler v0.5.3
 	github.com/rancher/wrangler-api v0.5.0
 	github.com/robfig/cron v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -922,6 +922,8 @@ github.com/rancher/types v0.0.0-20200303162837-300a04e6f743/go.mod h1:k5LoTlUpef
 github.com/rancher/types v0.0.0-20200304001827-068a357fa053/go.mod h1:k5LoTlUpefw0eAzFSJsZI0gf+C4WE41yrc1jm/MS1nM=
 github.com/rancher/types v0.0.0-20200326224903-b4612bd96d9b h1:nLJOQuk36vCXFQuD03L5Fh9xpF9n9U7/76WNGDjOjeY=
 github.com/rancher/types v0.0.0-20200326224903-b4612bd96d9b/go.mod h1:k5LoTlUpefw0eAzFSJsZI0gf+C4WE41yrc1jm/MS1nM=
+github.com/rancher/types v0.0.0-20200404135946-29ff83f9682c h1:G6sn1o/xDayog3/jm8XoMoQTs4il8P0r6HMYTp2fy6E=
+github.com/rancher/types v0.0.0-20200404135946-29ff83f9682c/go.mod h1:k5LoTlUpefw0eAzFSJsZI0gf+C4WE41yrc1jm/MS1nM=
 github.com/rancher/wrangler v0.1.4/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rancher/wrangler v0.2.1-0.20191025041946-1fd360590735/go.mod h1:zmXTOSzU0vhumCyl0+Acq2FEP5WJOJRqnCQDegknyWA=
 github.com/rancher/wrangler v0.4.1/go.mod h1:1cR91WLhZgkZ+U4fV9nVuXqKurWbgXcIReU4wnQvTN8=

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authn_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authn_types.go
@@ -47,7 +47,7 @@ type User struct {
 	Password           string     `json:"password,omitempty" norman:"writeOnly,noupdate"`
 	MustChangePassword bool       `json:"mustChangePassword,omitempty"`
 	PrincipalIDs       []string   `json:"principalIds,omitempty" norman:"type=array[reference[principal]]"`
-	Me                 bool       `json:"me,omitempty"`
+	Me                 bool       `json:"me,omitempty" norman:"nocreate,noupdate"`
 	Enabled            *bool      `json:"enabled,omitempty" norman:"default=true"`
 	Spec               UserSpec   `json:"spec,omitempty"`
 	Status             UserStatus `json:"status"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -479,7 +479,7 @@ github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io
 github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1
 github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/scheme
 github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/typed/upgrade.cattle.io/v1
-# github.com/rancher/types v0.0.0-20200326224903-b4612bd96d9b
+# github.com/rancher/types v0.0.0-20200404135946-29ff83f9682c
 github.com/rancher/types/apis/apiregistration.k8s.io/v1
 github.com/rancher/types/apis/apps/v1
 github.com/rancher/types/apis/autoscaling/v2beta2


### PR DESCRIPTION
**Problem:**

Preferences show other user's name and username instead of the logged in user

**Solution:**

Users can set `Me` field of another user to true in Rancher UI.
And it will be always true even after logout and login.
Set `Me` field to nocreate and noupdate

**Related Issue:**

rancher/rancher#14420

**Related PR:**

https://github.com/rancher/types/pull/1131