### PR TITLE
Validation - Support HA install for most cert types

### DIFF
--- a/tests/validation/tests/v3_api/Jenkinsfile
+++ b/tests/validation/tests/v3_api/Jenkinsfile
@@ -37,6 +37,11 @@ node {
                       string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
                       string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD'),
                       string(credentialsId: 'RANCHER_GKE_CREDENTIAL', variable: 'RANCHER_GKE_CREDENTIAL'),
+                      string(credentialsId: 'RANCHER_VALID_TLS_CERT', variable: 'RANCHER_VALID_TLS_CERT'),
+                      string(credentialsId: 'RANCHER_VALID_TLS_KEY', variable: 'RANCHER_VALID_TLS_KEY'),
+                      string(credentialsId: 'RANCHER_BYO_TLS_CERT', variable: 'RANCHER_BYO_TLS_CERT'),
+                      string(credentialsId: 'RANCHER_BYO_TLS_KEY', variable: 'RANCHER_BYO_TLS_KEY'),
+                      string(credentialsId: 'RANCHER_PRIVATE_CA_CERT', variable: 'RANCHER_PRIVATE_CA_CERT'),
                       string(credentialsId: 'RANCHER_AUTH_USER_PASSWORD', variable: 'RANCHER_AUTH_USER_PASSWORD')]) {
                         
       stage('Checkout') {


### PR DESCRIPTION
Support most cert types for HA installation: 
* Rancher self-signed
* Bring your own valid cert
* Bring your own self-signed cert
* LetsEncrypt

Certificate values are stored in Jenkins credentials