### PR TITLE
Add nodeCount to formatter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20200331001732-ccc92e7b19f2
 	github.com/rancher/system-upgrade-controller v0.4.1-0.20200326220202-4655d4a551bd
-	github.com/rancher/types v0.0.0-20200404135832-7a787b354966
+	github.com/rancher/types v0.0.0-20200407154953-bd140b76a4df
 	github.com/rancher/wrangler v0.5.4-0.20200326191509-4054411d9736
 	github.com/rancher/wrangler-api v0.5.1-0.20200326194427-c13310506d04
 	github.com/robfig/cron v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -524,6 +524,7 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
+github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc h1:f8eY6cV/x1x+HLjOp4r72s/31/V2aTUtg5oKRRPf8/Q=
 github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -882,8 +883,6 @@ github.com/rancher/client-go v1.18.0-rancher.1/go.mod h1:uQSYDYs4WhVZ9i6AIoEZuwU
 github.com/rancher/dynamiclistener v0.2.1-0.20200213165308-111c5b43e932/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
 github.com/rancher/dynamiclistener v0.2.1-0.20200403051005-4436fc6b4890 h1:cuE3NbOo0x7J52KwPXv9A0jh7tMJI4d2eAISW04xrwg=
 github.com/rancher/dynamiclistener v0.2.1-0.20200403051005-4436fc6b4890/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
-github.com/rancher/kontainer-engine v0.0.4-dev.0.20200403004702-f9faabcc049b h1:ANlxi+hf1tOTflxWFVXJ7XQ5ddTfjwjUMkM/9i42V/M=
-github.com/rancher/kontainer-engine v0.0.4-dev.0.20200403004702-f9faabcc049b/go.mod h1:mQnNiMtNrIcliLZDPQqmdfd4ucSr84h0DQDWo9C9KqE=
 github.com/rancher/kontainer-engine v0.0.4-dev.0.20200406202044-bf3f55d3710a h1:RZ9NkRBZo4Z2oOd93pcNe+b28qE5nAOTr0EhMWLEPMM=
 github.com/rancher/kontainer-engine v0.0.4-dev.0.20200406202044-bf3f55d3710a/go.mod h1:mQnNiMtNrIcliLZDPQqmdfd4ucSr84h0DQDWo9C9KqE=
 github.com/rancher/machine v0.15.0-rancher25 h1:i78iohBm9QLmxHOMM1ZssYwSNIObPdDUQjZ9h1mo8Jc=
@@ -912,8 +911,8 @@ github.com/rancher/steve v0.0.0-20200331001732-ccc92e7b19f2/go.mod h1:BABDaLXbTN
 github.com/rancher/system-upgrade-controller v0.4.1-0.20200326220202-4655d4a551bd h1:h4VDCviV2Iixfk9SjUcfzq0l+pRsvadt2QSNuoQKfxE=
 github.com/rancher/system-upgrade-controller v0.4.1-0.20200326220202-4655d4a551bd/go.mod h1:8x2eK9Q5/1c2AC9xJtNFyAyjP9ytP4uPHhGA6wajIS0=
 github.com/rancher/types v0.0.0-20200326224235-0d1e1dcc8d55/go.mod h1:k5LoTlUpefw0eAzFSJsZI0gf+C4WE41yrc1jm/MS1nM=
-github.com/rancher/types v0.0.0-20200404135832-7a787b354966 h1:wnrSNbnN8wysvw4VZnYoD7yUH03+0ZUwUdNeM+USal0=
-github.com/rancher/types v0.0.0-20200404135832-7a787b354966/go.mod h1:dFo1jHAqDecEB+ODKVTx1I7YXpW1qbH2ybOaU3SSDD4=
+github.com/rancher/types v0.0.0-20200407154953-bd140b76a4df h1:NXMMnJZH+5ZMAKCTMod4PLcjMvI2gWyiyUfO/T07hjc=
+github.com/rancher/types v0.0.0-20200407154953-bd140b76a4df/go.mod h1:dFo1jHAqDecEB+ODKVTx1I7YXpW1qbH2ybOaU3SSDD4=
 github.com/rancher/wrangler v0.1.4/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rancher/wrangler v0.4.1/go.mod h1:1cR91WLhZgkZ+U4fV9nVuXqKurWbgXcIReU4wnQvTN8=
 github.com/rancher/wrangler v0.5.0/go.mod h1:txHSBkPtVgNH/0pUCvdP0Ak0HptAOc9ffBmFxQnL4z4=

--- a/tests/integration/suite/test_cluster.py
+++ b/tests/integration/suite/test_cluster.py
@@ -1,0 +1,69 @@
+from .common import random_str
+from .conftest import wait_for
+from kubernetes.client import CustomObjectsApi
+
+
+def test_cluster_node_count(admin_mc, remove_resource,
+                            raw_remove_custom_resource):
+    """Test that the cluster node count gets updated as nodes are added"""
+    client = admin_mc.client
+    cluster = client.create_cluster(
+        name=random_str(),
+        rancherKubernetesEngineConfig={
+            "accessKey": "junk"
+        }
+    )
+    remove_resource(cluster)
+
+    def _check_node_count(cluster, nodes):
+        c = client.reload(cluster)
+        return c.nodeCount == nodes
+
+    def _node_count_fail(cluster, nodes):
+        c = client.reload(cluster)
+        s = "cluster {} failed to have proper node count, expected: {} has: {}"
+        return s.format(c.id, nodes, c.nodeCount)
+
+    node_count = 0
+    wait_for(lambda: _check_node_count(cluster, node_count),
+             fail_handler=lambda: _node_count_fail(cluster, node_count))
+
+    # Nodes have to be created manually through k8s client to attach to a
+    # pending cluster
+    k8s_dynamic_client = CustomObjectsApi(admin_mc.k8s_client)
+    body = {
+        "metadata": {
+            "name": random_str(),
+            "namespace": cluster.id,
+        },
+        "kind": "Node",
+        "apiVersion": "management.cattle.io/v3",
+    }
+
+    dynamic_nt = k8s_dynamic_client.create_namespaced_custom_object(
+        "management.cattle.io", "v3", cluster.id, 'nodes', body)
+    raw_remove_custom_resource(dynamic_nt)
+
+    node_count = 1
+    wait_for(lambda: _check_node_count(cluster, node_count),
+             fail_handler=lambda: _node_count_fail(cluster, node_count))
+
+    # Create node number 2
+    body['metadata']['name'] = random_str()
+
+    dynamic_nt1 = k8s_dynamic_client.create_namespaced_custom_object(
+        "management.cattle.io", "v3", cluster.id, 'nodes', body)
+    raw_remove_custom_resource(dynamic_nt1)
+
+    node_count = 2
+    wait_for(lambda: _check_node_count(cluster, node_count),
+             fail_handler=lambda: _node_count_fail(cluster, node_count))
+
+    # Delete a node
+    k8s_dynamic_client.delete_namespaced_custom_object(
+        "management.cattle.io", "v3", cluster.id, 'nodes',
+        dynamic_nt1['metadata']['name'], {})
+
+    node_count = 1
+    wait_for(lambda: _check_node_count(cluster, node_count),
+             fail_handler=lambda: _node_count_fail(cluster, node_count))

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -153,6 +153,7 @@ type ClusterStatus struct {
 	Capabilities                         Capabilities                `json:"capabilities,omitempty"`
 	MonitoringStatus                     *MonitoringStatus           `json:"monitoringStatus,omitempty" norman:"nocreate,noupdate"`
 	NodeVersion                          int                         `json:"nodeVersion,omitempty"`
+	NodeCount                            int                         `json:"nodeCount,omitempty" norman:"nocreate,noupdate"`
 	IstioEnabled                         bool                        `json:"istioEnabled,omitempty" norman:"nocreate,noupdate,default=false"`
 	CertificatesExpiration               map[string]CertExpiration   `json:"certificatesExpiration,omitempty"`
 	ScheduledClusterScanStatus           *ScheduledClusterScanStatus `json:"scheduledClusterScanStatus,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster.go
@@ -49,6 +49,7 @@ const (
 	ClusterFieldLocalClusterAuthEndpoint             = "localClusterAuthEndpoint"
 	ClusterFieldMonitoringStatus                     = "monitoringStatus"
 	ClusterFieldName                                 = "name"
+	ClusterFieldNodeCount                            = "nodeCount"
 	ClusterFieldNodeVersion                          = "nodeVersion"
 	ClusterFieldOwnerReferences                      = "ownerReferences"
 	ClusterFieldRancherKubernetesEngineConfig        = "rancherKubernetesEngineConfig"
@@ -109,6 +110,7 @@ type Cluster struct {
 	LocalClusterAuthEndpoint             *LocalClusterAuthEndpoint      `json:"localClusterAuthEndpoint,omitempty" yaml:"localClusterAuthEndpoint,omitempty"`
 	MonitoringStatus                     *MonitoringStatus              `json:"monitoringStatus,omitempty" yaml:"monitoringStatus,omitempty"`
 	Name                                 string                         `json:"name,omitempty" yaml:"name,omitempty"`
+	NodeCount                            int64                          `json:"nodeCount,omitempty" yaml:"nodeCount,omitempty"`
 	NodeVersion                          int64                          `json:"nodeVersion,omitempty" yaml:"nodeVersion,omitempty"`
 	OwnerReferences                      []OwnerReference               `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
 	RancherKubernetesEngineConfig        *RancherKubernetesEngineConfig `json:"rancherKubernetesEngineConfig,omitempty" yaml:"rancherKubernetesEngineConfig,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_status.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_status.go
@@ -22,6 +22,7 @@ const (
 	ClusterStatusFieldIstioEnabled                         = "istioEnabled"
 	ClusterStatusFieldLimits                               = "limits"
 	ClusterStatusFieldMonitoringStatus                     = "monitoringStatus"
+	ClusterStatusFieldNodeCount                            = "nodeCount"
 	ClusterStatusFieldNodeVersion                          = "nodeVersion"
 	ClusterStatusFieldRequested                            = "requested"
 	ClusterStatusFieldScheduledClusterScanStatus           = "scheduledClusterScanStatus"
@@ -49,6 +50,7 @@ type ClusterStatus struct {
 	IstioEnabled                         bool                        `json:"istioEnabled,omitempty" yaml:"istioEnabled,omitempty"`
 	Limits                               map[string]string           `json:"limits,omitempty" yaml:"limits,omitempty"`
 	MonitoringStatus                     *MonitoringStatus           `json:"monitoringStatus,omitempty" yaml:"monitoringStatus,omitempty"`
+	NodeCount                            int64                       `json:"nodeCount,omitempty" yaml:"nodeCount,omitempty"`
 	NodeVersion                          int64                       `json:"nodeVersion,omitempty" yaml:"nodeVersion,omitempty"`
 	Requested                            map[string]string           `json:"requested,omitempty" yaml:"requested,omitempty"`
 	ScheduledClusterScanStatus           *ScheduledClusterScanStatus `json:"scheduledClusterScanStatus,omitempty" yaml:"scheduledClusterScanStatus,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -489,7 +489,7 @@ github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1
 github.com/rancher/system-upgrade-controller/pkg/condition
 github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/scheme
 github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/typed/upgrade.cattle.io/v1
-# github.com/rancher/types v0.0.0-20200404135832-7a787b354966
+# github.com/rancher/types v0.0.0-20200407154953-bd140b76a4df
 github.com/rancher/types/apis/apiregistration.k8s.io/v1
 github.com/rancher/types/apis/apps/v1
 github.com/rancher/types/apis/autoscaling/v2beta2


### PR DESCRIPTION
Problem:
The CLI displays a node count for clusters which required the CLI to make multiple API calls

Solution:
Add a new nodeCount field based off a lister and included in the formatter to help the CLI 

Depends on https://github.com/rancher/types/pull/1133

Issue https://github.com/rancher/rancher/issues/25227