### PR TITLE
Updating OPA gatekeeper to latest beta version v3.1.0-beta.8

### DIFF
--- a/scripts/istio-images-mirror
+++ b/scripts/istio-images-mirror
@@ -30,6 +30,6 @@ quay.io/calico/cni rancher/calico-cni v3.13.0
 quay.io/calico/kube-controllers rancher/calico-kube-controllers v3.13.0
 quay.io/calico/pod2daemon-flexvol rancher/calico-pod2daemon-flexvol v3.13.0
 us.gcr.io/k8s-artifacts-prod/external-dns/external-dns rancher/kubernetes-external-dns v0.6.0
-quay.io/open-policy-agent/gatekeeper rancher/opa-gatekeeper v3.1.0-beta.7
+quay.io/open-policy-agent/gatekeeper rancher/opa-gatekeeper v3.1.0-beta.8
 k8s.gcr.io/k8s-dns-node-cache rancher/k8s-dns-node-cache 1.15.7
 sonobuoy/sonobuoy rancher/sonobuoy-sonobuoy v0.16.3


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/26453

Updating the image to use latest beta version release by gatekeeper