### PR TITLE
[2.4] Check nil pointer for node.status.NodeConfig

### DIFF
--- a/pkg/controllers/user/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/user/nodesyncer/nodessyncer.go
@@ -182,10 +182,13 @@ func (m *nodesSyncer) updateLabels(node *corev1.Node, obj *v3.Node, nodePlan v3.
 	}
 
 	node, obj = node.DeepCopy(), obj.DeepCopy()
-	planValues, changed := computePlanDelta(obj.Status.NodeConfig.Labels, obj.Spec.MetadataUpdate.Labels)
-	if changed {
-		obj.Status.NodeConfig.Labels = planValues
+	if obj.Status.NodeConfig != nil {
+		planValues, changed := computePlanDelta(obj.Status.NodeConfig.Labels, obj.Spec.MetadataUpdate.Labels)
+		if changed {
+			obj.Status.NodeConfig.Labels = planValues
+		}
 	}
+
 	node.Labels = finalMap
 
 	obj.Spec.MetadataUpdate.Labels = v3.MapDelta{}


### PR DESCRIPTION
Backport: https://github.com/rancher/rancher/pull/26509
Issue: https://github.com/rancher/rancher/issues/26496

UpdateLabel method is called for any type of node, even if nodePlan is
passed into the method. This commit fixed the bug where
node.status.NodeConfig could be nil if it is a imported node.