### PR TITLE
[2.3] Update Aliyun-Driver

### DIFF
--- a/app/machinedriver_data.go
+++ b/app/machinedriver_data.go
@@ -60,8 +60,8 @@ func addMachineDrivers(management *config.ManagementContext) error {
 		[]string{"machine-driver.oss-cn-shanghai.aliyuncs.com"}, false, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver("aliyunecs", "http://machine-driver.oss-cn-shanghai.aliyuncs.com/aliyun/1.0.2/linux/amd64/docker-machine-driver-aliyunecs.tgz",
-		"", "c31b9da2c977e70c2eeee5279123a95d", []string{"ecs.aliyuncs.com"}, false, false, management); err != nil {
+	if err := addMachineDriver("aliyunecs", "https://drivers.rancher.cn/node-driver-aliyun/1.0.4/docker-machine-driver-aliyunecs.tgz",
+		"", "5990d40d71c421a85563df9caf069466f300cd75723effe4581751b0de9a6a0e", []string{"ecs.aliyuncs.com"}, false, false, management); err != nil {
 		return err
 	}
 	if err := addMachineDriver(Amazonec2driver, "local://", "", "",


### PR DESCRIPTION
When calling the AllocateEipAddress API, we need to specify the InternetChargeType parameter to PayByTraffic when the selected region is not in Mainland China (the default value is PayByBandwidth).

Update driver Aliyun ECS to support `InternetChargeType` field

Related PR:

https://github.com/rancher/ui/pull/3893

Related Issue:

https://github.com/rancher/rancher/issues/26526