### PR TITLE
Helm version checks

### DIFF
--- a/pkg/api/customization/catalog/validator.go
+++ b/pkg/api/customization/catalog/validator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/pkg/controllers/user/helm/common"
 )
 
 var (
@@ -24,11 +25,16 @@ func Validator(request *types.APIContext, schema *types.Schema, data map[string]
 			u.Scheme = strings.ToLower(u.Scheme) // git commands are case-sensitive
 			data["url"] = u.String()
 		}
-		return nil
 	} else if request.Method == http.MethodPost {
 		return httperror.NewAPIError(httperror.MissingRequired, "Catalog URL not specified")
 	}
 
+	if helmVersion, ok := data["helmVersion"]; ok {
+		toLowerHelmVersion := strings.ToLower(helmVersion.(string))
+		if strings.Contains(toLowerHelmVersion, "v3") && !common.IsHelm3(toLowerHelmVersion) {
+			return httperror.NewAPIError(httperror.InvalidBodyContent, "Invalid helm 3 version")
+		}
+	}
 	return nil
 }
 

--- a/pkg/api/customization/catalog/validator.go
+++ b/pkg/api/customization/catalog/validator.go
@@ -28,9 +28,10 @@ func Validator(request *types.APIContext, schema *types.Schema, data map[string]
 	} else if request.Method == http.MethodPost {
 		return httperror.NewAPIError(httperror.MissingRequired, "Catalog URL not specified")
 	}
-
+	//
 	if helmVersion, ok := data["helmVersion"]; ok {
 		toLowerHelmVersion := strings.ToLower(helmVersion.(string))
+		// determine if user is setting helmVersion to helm 3 and validate to help user set value correctly
 		if strings.Contains(toLowerHelmVersion, "v3") && !common.IsHelm3(toLowerHelmVersion) {
 			return httperror.NewAPIError(httperror.InvalidBodyContent, "Invalid helm 3 version")
 		}

--- a/pkg/api/customization/catalog/validator_test.go
+++ b/pkg/api/customization/catalog/validator_test.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"testing"
 
+	"github.com/rancher/norman/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,4 +43,79 @@ func TestValidateURL(t *testing.T) {
 			assert.Equal(t, gotErr != nil, tt.wantErr)
 		})
 	}
+}
+
+func TestValidateHelm3Version(t *testing.T) {
+	request := testAsAPIContext()
+	schema := testAsSchema()
+	testsWithValues := []struct {
+		name        string
+		helmVersion string
+		wantErr     bool
+	}{
+		{
+			name:        "Empty helm 3 value",
+			helmVersion: "",
+			wantErr:     false,
+		},
+		{
+			name:        "Non helm 3 value",
+			helmVersion: "v2",
+			wantErr:     false,
+		},
+		{
+			name:        "Allow full helm 3 value",
+			helmVersion: "helm_v3",
+			wantErr:     false,
+		},
+		{
+			name:        "Allow shortened helm 3 value",
+			helmVersion: "v3",
+			wantErr:     false,
+		},
+		{
+			name:        "Invalid helm 3 value",
+			helmVersion: "sdfasdfasdv3",
+			wantErr:     true,
+		},
+	}
+
+	testWithNoVersion := []struct {
+		name    string
+		wantErr bool
+	}{
+		{
+			name:    "No helm 3 value in data map",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range testsWithValues {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make(map[string]interface{})
+			data["helmVersion"] = tt.helmVersion
+			gotErr := Validator(request, schema, data)
+			assert.Equal(t, gotErr != nil, tt.wantErr)
+		})
+	}
+
+	for _, tt := range testWithNoVersion {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make(map[string]interface{})
+			gotErr := Validator(request, schema, data)
+			assert.Equal(t, gotErr != nil, tt.wantErr)
+		})
+	}
+}
+
+// setup api context for validation test
+func testAsAPIContext() *types.APIContext {
+	testAPIContext := &types.APIContext{}
+	return testAPIContext
+}
+
+// setup schema for validation test
+func testAsSchema() *types.Schema {
+	testSchema := &types.Schema{}
+	return testSchema
 }

--- a/pkg/controllers/user/helm/common.go
+++ b/pkg/controllers/user/helm/common.go
@@ -58,7 +58,7 @@ func helmInstall(tempDirs *common.HelmPath, app *v3.App) error {
 	cont, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	addr := common.GenerateRandomPort()
-	if common.IsHelm2(app.Status.HelmVersion) {
+	if !common.IsHelm3(app.Status.HelmVersion) {
 		go func() {
 			err := common.StartTiller(cont, tempDirs, addr, app.Spec.TargetNamespace)
 			if err != nil {
@@ -73,7 +73,7 @@ func helmDelete(tempDirs *common.HelmPath, app *v3.App) error {
 	cont, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	addr := common.GenerateRandomPort()
-	if common.IsHelm2(app.Status.HelmVersion) {
+	if !common.IsHelm3(app.Status.HelmVersion) {
 		go func() {
 			err := common.StartTiller(cont, tempDirs, addr, app.Spec.TargetNamespace)
 			if err != nil {

--- a/pkg/controllers/user/helm/common/common.go
+++ b/pkg/controllers/user/helm/common/common.go
@@ -329,7 +329,7 @@ func createKustomizeFiles(tempDirs *HelmPath, labelValue string) error {
 }
 
 func IsHelm3(helmName string) bool {
-	if helmName == HelmV3 {
+	if helmName == HelmV3 || strings.ToLower(helmName) == "v3" {
 		return true
 	}
 	return false

--- a/pkg/controllers/user/helm/common/common.go
+++ b/pkg/controllers/user/helm/common/common.go
@@ -334,10 +334,3 @@ func IsHelm3(helmName string) bool {
 	}
 	return false
 }
-
-func IsHelm2(helmName string) bool {
-	if helmName == HelmV2 || helmName == "" {
-		return true
-	}
-	return false
-}


### PR DESCRIPTION
**Problem**
Helm version checks were too strict causing tiller not to start for helm2 consistently
Helm version checks were too strict so helm3 could only be one value

**Solution**
Allow for helm3 to be "helm_v3" or "v3"
Add validation for helm 3 since it needs to be specific values
Change the isHelm2 check to !isHelm3 to ensure helmVersion for helm 2 can be more flexible

**Issue**
#26450 