### PR TITLE
Update test to be nonparallel

### DIFF
--- a/tests/integration/suite/test_catalog.py
+++ b/tests/integration/suite/test_catalog.py
@@ -270,6 +270,7 @@ def test_embedded_system_catalog_missing_edit_link(admin_mc):
     assert "update" not in system_catalog.links
 
 
+@pytest.mark.nonparallel
 def test_catalog_refresh(admin_mc):
     """Test that on refresh the response includes the names of the catalogs
     that are being refreshed"""


### PR DESCRIPTION
Problem:
Catalog refresh lists all catalogs then attempts a refresh, if another
tests deletes that test mid refresh the call errors

Solution:
Mark the test as nonparallel

Issue: https://github.com/rancher/rancher/issues/26451