### PR TITLE
[2.4] Force redeploy cluster-monitoring if workload doesn't exist

### DIFF
--- a/pkg/controllers/user/helm/controller.go
+++ b/pkg/controllers/user/helm/controller.go
@@ -148,9 +148,11 @@ func (l *Lifecycle) Updated(obj *v3.App) (runtime.Object, error) {
 			if !v3.AppConditionForceUpgrade.IsTrue(obj) {
 				v3.AppConditionForceUpgrade.True(obj)
 			}
+			logrus.Debugf("[helm-controller] App %v doesn't require update", obj.Name)
 			return obj, nil
 		}
 	}
+	logrus.Debugf("[helm-controller] Updating app %v", obj.Name)
 	created := false
 	if obj.Spec.MultiClusterAppName != "" {
 		if _, err := l.NsLister.Get("", obj.Spec.TargetNamespace); err != nil && !errors.IsNotFound(err) {

--- a/pkg/controllers/user/monitoring/appHandler.go
+++ b/pkg/controllers/user/monitoring/appHandler.go
@@ -18,6 +18,7 @@ type appHandler struct {
 	cattleMonitorMetricClient mgmtv3.MonitorMetricInterface
 	agentDeploymentClient     appsv1.DeploymentInterface
 	agentStatefulSetClient    appsv1.StatefulSetInterface
+	agentStatefulSetLister    appsv1.StatefulSetLister
 	agentServiceAccountClient corev1.ServiceAccountInterface
 	agentSecretClient         corev1.SecretInterface
 	agentNodeClient           corev1.NodeInterface

--- a/pkg/controllers/user/monitoring/register.go
+++ b/pkg/controllers/user/monitoring/register.go
@@ -31,6 +31,7 @@ func Register(ctx context.Context, agentContext *config.UserContext) {
 		cattleMonitorMetricClient: mgmtContext.MonitorMetrics(metav1.NamespaceAll),
 		agentDeploymentClient:     agentContext.Apps.Deployments(metav1.NamespaceAll),
 		agentStatefulSetClient:    agentContext.Apps.StatefulSets(metav1.NamespaceAll),
+		agentStatefulSetLister:    agentContext.Apps.StatefulSets(metav1.NamespaceAll).Controller().Lister(),
 		agentServiceAccountClient: agentContext.Core.ServiceAccounts(metav1.NamespaceAll),
 		agentSecretClient:         agentContext.Core.Secrets(metav1.NamespaceAll),
 		agentNodeClient:           agentContext.Core.Nodes(metav1.NamespaceAll),


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/26440
Problem: Enabling rancher cluster-monitoring launches 2 apps, `cluster-monitoring` and `monitoring-operator`. If there's an error when installing these apps, monitoring controller has logic to force redeploy only the `monitoring-operator` app. So if the error is resolved, only `monitoring-operator` gets deployed but not `cluster-monitoring`

Solution: This commit adds the same logic to force deploy `cluster-monitoring` app, by checking whether the workload it should have created exists or not