### PR TITLE
[2.4] Use Catalog TemplateLister to find out the latest version of system chart

### DIFF
--- a/pkg/catalog/utils/utils.go
+++ b/pkg/catalog/utils/utils.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 
 	"github.com/pkg/errors"
+	"github.com/rancher/rancher/pkg/namespace"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
@@ -88,4 +90,17 @@ func ValidateURL(pathURL string) error {
 		return errors.New("Invalid characters in url")
 	}
 	return nil
+}
+
+func GetSystemAppCatalogID(templateVersionID string, templateLister v3.CatalogTemplateLister) (string, error) {
+	template, err := templateLister.Get(namespace.GlobalNamespace, templateVersionID)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to find template by ID %s", templateVersionID)
+	}
+
+	templateVersion, err := LatestAvailableTemplateVersion(template)
+	if err != nil {
+		return "", err
+	}
+	return templateVersion.ExternalID, nil
 }

--- a/pkg/controllers/user/cis/register.go
+++ b/pkg/controllers/user/cis/register.go
@@ -58,6 +58,8 @@ func Register(ctx context.Context, userContext *config.UserContext) {
 	cisBenchmarkVersion := userContext.Management.Management.CisBenchmarkVersions(namespace.GlobalNamespace)
 	cisBenchmarkVersionLister := cisBenchmarkVersion.Controller().Lister()
 
+	templateLister := userContext.Management.Management.CatalogTemplates(metav1.NamespaceAll).Controller().Lister()
+
 	// Responsible for syncing the benchmark version info from mgmt ctx
 	// to config maps in user cluster
 	cisBenchmarkVersionHandler := &cisBenchmarkVersionHandler{
@@ -91,6 +93,7 @@ func Register(ctx context.Context, userContext *config.UserContext) {
 		podLister:                    podLister,
 		dsClient:                     dsClient,
 		dsLister:                     dsLister,
+		templateLister:               templateLister,
 	}
 	clusterScanClient.AddClusterScopedLifecycle(ctx, "cisScanHandler", clusterName, clusterScanHandler)
 

--- a/pkg/controllers/user/helm/common/extra_args_test.go
+++ b/pkg/controllers/user/helm/common/extra_args_test.go
@@ -28,7 +28,7 @@ func Test_injectDefaultRegistry(t *testing.T) {
 		{
 			app: &v3.App{
 				Spec: v3.AppSpec{
-					ExternalID: settings.SystemExternalDNSCatalogID.Get(),
+					ExternalID: "catalog://?catalog=system-library&template=rancher-external-dns&version=0.1.0",
 				},
 			},
 			want: true,

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -64,8 +64,6 @@ var (
 	UIKubernetesDefaultVersion        = NewSetting("ui-k8s-default-version-range", "<=1.14.x")
 	WhitelistDomain                   = NewSetting("whitelist-domain", "forums.rancher.com")
 	WhitelistEnvironmentVars          = NewSetting("whitelist-envvars", "HTTP_PROXY,HTTPS_PROXY,NO_PROXY")
-	SystemExternalDNSCatalogID        = NewSetting("system-externaldns-catalog-id", "catalog://?catalog=system-library&template=rancher-external-dns&version=0.1.0")
-	SystemCISBenchmarkCatalogID       = NewSetting("system-cis-benchmark-catalog-id", "catalog://?catalog=system-library&template=rancher-cis-benchmark&version=0.1.0")
 	AuthUserInfoResyncCron            = NewSetting("auth-user-info-resync-cron", "0 0 * * *")
 	AuthUserSessionTTLMinutes         = NewSetting("auth-user-session-ttl-minutes", "960")   // 16 hours
 	AuthUserInfoMaxAgeSeconds         = NewSetting("auth-user-info-max-age-seconds", "3600") // 1 hour


### PR DESCRIPTION
Backport PR for https://github.com/rancher/rancher/issues/26388

System apps like rancher-external-dns and cis-scan were using hardcoded setting to use the latest template from the system library. This requires us to always update rancher when a new version is added to the system library app.

This fix removes the use of hardcoded settings and instead reads the latest version by listing the Catalog Template from the TemplateLister.

