### PR TITLE
add secret option that works for tls

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -41,3 +41,17 @@ spec:
     - {{ .Values.hostname }}
     secretName: tls-rancher-ingress
 {{- end }}
+{{- if eq .Values.tls "ingress" }}
+  tls:
+  - hosts:
+    - {{ .Values.hostname }}
+    secretName: tls-rancher-ingress
+{{- end }}
+{{- if eq .Values.ingress.tls.source "secret" }}
+  tls:
+  - hosts:
+    - {{ .Values.hostname }}
+    secretName: {{ .Values.ingress.tls.secretName }}
+{{- end }}
+
+

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -58,6 +58,8 @@ ingress:
   tls:
     # options: rancher, letsEncrypt, secret
     source: rancher
+    # set secret name if TLS provided excternally via a secret
+    # secretName:
 
 ### LetsEncrypt config ###
 # ProTip: The production environment only allows you to register a name 5 times a week.


### PR DESCRIPTION
Currently secrets cannot be provided for TLS that are managed outside of the chart. The name is instead hardcoded. It would be nice to be able to have it reference an already deployed TLS secret.