### PR TITLE
No need to check for storageClass existence while creating a pvc from pv

### DIFF
--- a/pkg/api/customization/persistentvolumeclaim/validator.go
+++ b/pkg/api/customization/persistentvolumeclaim/validator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/api/store/storageclass"
 	"github.com/rancher/rancher/pkg/clustermanager"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -28,7 +29,10 @@ func (v *Validator) Validator(request *types.APIContext, schema *types.Schema, d
 
 	storageClass, err := c.Storage.StorageClasses("").Get(storageClassID, v1.GetOptions{})
 	if err != nil {
-		return err
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		return nil
 	}
 
 	// if the referenced storage class does not have a storageaccounttype, storage account creation will fail in k8s

--- a/tests/integration/suite/test_persistent_volume_claim.py
+++ b/tests/integration/suite/test_persistent_volume_claim.py
@@ -104,3 +104,26 @@ def test_can_create_azure_any_accountstoragetype(admin_pc, admin_cc,
             }
         })
     remove_resource(pvc2)
+
+
+def test_can_create_pvc_no_storage_no_vol(admin_pc, remove_resource):
+    """Tests that a PVC referencing no storage class and no volume
+       can be created
+    """
+    ns = admin_pc.cluster.client.create_namespace(
+        name="ns" + random_str(),
+        projectId=admin_pc.project.id)
+    remove_resource(ns)
+
+    pvc = admin_pc.client.create_persistent_volume_claim(
+        name="pc" + random_str(),
+        namespaceId=ns.id,
+        accessModes=["ReadWriteOnce"],
+        resources={
+            "requests": {
+                "storage": "30Gi"
+            }
+        })
+    remove_resource(pvc)
+    assert pvc is not None
+    assert pvc.state == "pending"


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/26605
Dropping the api validation to check if storageClass exists while creating a pvc from an existing pv, since it is not needed and the resources can be created without an actual storageclass existing. 