### PR TITLE
Add Oracle Container Engine (OKE) as a builtin cluster driver.

### DIFF
--- a/app/kontainerdriver_data.go
+++ b/app/kontainerdriver_data.go
@@ -88,6 +88,16 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 	); err != nil {
 		return err
 	}
+	if err := creator.addCustomDriver(
+		"oraclecontainerengine",
+		"https://github.com/rancher-plugins/kontainer-engine-driver-oke/releases/download/v1.4.0/kontainer-engine-driver-oke-linux",
+		"a42bd8b14e780edc426119f143acbc54a93a07f8b62f193b9e261ddd85db6e9c",
+		"",
+		false,
+		"*.oraclecloud.com",
+	); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/tests/integration/suite/test_rbac.py
+++ b/tests/integration/suite/test_rbac.py
@@ -471,14 +471,14 @@ def ns_count(client, count):
 
 def test_appropriate_users_can_see_kontainer_drivers(user_factory):
     kds = user_factory().client.list_kontainer_driver()
-    assert len(kds) == 8
+    assert len(kds) == 9
 
     kds = user_factory('clusters-create').client.list_kontainer_driver()
-    assert len(kds) == 8
+    assert len(kds) == 9
 
     kds = user_factory('kontainerdrivers-manage').client. \
         list_kontainer_driver()
-    assert len(kds) == 8
+    assert len(kds) == 9
 
     kds = user_factory('settings-manage').client.list_kontainer_driver()
     assert len(kds) == 0


### PR DESCRIPTION
This pull request adds the most recent [Oracle Container Engine (OKE) cluster driver](https://github.com/rancher-plugins/kontainer-engine-driver-oke) to be `builtin` (but `inactive` by default for the time being). 

Notes:
- Link to a related [PR in the UI repo](https://github.com/rancher/ui/pull/3931) also up for review.
