### PR TITLE
[v2.4] check for nil upgradeStrategy

### DIFF
--- a/pkg/controllers/management/rkeworkerupgrader/upgrade.go
+++ b/pkg/controllers/management/rkeworkerupgrader/upgrade.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/management/clusterprovisioner"
 	nodeserver "github.com/rancher/rancher/pkg/rkenodeconfigserver"
 	"github.com/rancher/rancher/pkg/systemaccount"
+	rkedefaults "github.com/rancher/rke/cluster"
 	"github.com/rancher/rke/util"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
@@ -234,6 +235,15 @@ func (uh *upgradeHandler) upgradeCluster(cluster *v3.Cluster, nodeName string, p
 		v3.ClusterConditionUpgraded.Unknown(clusterCopy)
 		v3.ClusterConditionUpgraded.Message(clusterCopy, "updating worker nodes")
 		clusterCopy.Status.NodeVersion++
+
+		if cluster.Status.AppliedSpec.RancherKubernetesEngineConfig.UpgradeStrategy == nil {
+			clusterCopy.Status.AppliedSpec.RancherKubernetesEngineConfig.UpgradeStrategy = &v3.NodeUpgradeStrategy{
+				MaxUnavailableWorker:       rkedefaults.DefaultMaxUnavailableWorker,
+				MaxUnavailableControlplane: rkedefaults.DefaultMaxUnavailableControlplane,
+				Drain:                      false,
+			}
+		}
+
 		var err error
 		cluster, err = uh.clusters.Update(clusterCopy)
 		if err != nil {


### PR DESCRIPTION
backport https://github.com/rancher/rancher/pull/26685 
We initialize node upgrade strategy in cluster store, but on rancher upgrade if a cluster automatically gets upgraded, it'll panic because of nil upgradeStrategy

#26586