### PR TITLE
Changes to get test_auth working with AD auth provider

### DIFF
--- a/tests/validation/requirements_v3api.txt
+++ b/tests/validation/requirements_v3api.txt
@@ -1,4 +1,4 @@
-git+https://github.com/rancher/client-python.git@e3762d5e63e7f9c6ef327e967b876c06dbf43949
+git+https://github.com/rancher/client-python.git@master#egg=client-python
 boto3==1.10.6
 botocore==1.13.6
 cryptography==2.8


### PR DESCRIPTION
The original structure and logic is untouched.
Most of the work was to remove some repetitive code like `enable_ad_nestedgroups` and `enable_openldap_nestedgroups`.

Pre-requirements are now automatically provisioned if they are not prepared. Including enabling auth and provisioning two clusters.
Updated the requirements file to be compatible with both `pip` and `pipenv` because `pipenv` is more strict and required `#egg=<app name>`

Everything else is just renaming to follow pep8 rules and making sure `flake8` report is ok.