### PR TITLE
Add ui-banners setting

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -56,6 +56,7 @@ var (
 	TelemetryOpt                      = NewSetting("telemetry-opt", "prompt")
 	TLSMinVersion                     = NewSetting("tls-min-version", "1.2")
 	TLSCiphers                        = NewSetting("tls-ciphers", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305")
+	UIBanners                         = NewSetting("ui-banners", "{}")
 	UIFeedBackForm                    = NewSetting("ui-feedback-form", "")
 	UIIndex                           = NewSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
 	UIPath                            = NewSetting("ui-path", "")

--- a/server/server.go
+++ b/server/server.go
@@ -102,6 +102,7 @@ func Start(ctx context.Context, localClusterEnabled bool, scaledContext *config.
 	root.Handle("/v3/settings/cacerts", rawAuthedAPIs).Methods(http.MethodGet)
 	root.Handle("/v3/settings/first-login", rawAuthedAPIs).Methods(http.MethodGet)
 	root.Handle("/v3/settings/ui-pl", rawAuthedAPIs).Methods(http.MethodGet)
+	root.Handle("/v3/settings/ui-banners", rawAuthedAPIs).Methods(http.MethodGet)
 	root.Handle("/v3/tokenreview", tokenReview).Methods(http.MethodPost)
 	root.PathPrefix("/metrics").Handler(metricsHandler)
 	root.PathPrefix("/v3").Handler(chainGzip.Handler(auditHandler))


### PR DESCRIPTION
This PR adds the ui-banners setting to Rancher, which will be used to facilitate customizable header / footer banners on the Rancher UI.

Note: GET requests to the setting are unauthenticated so that they can be queried from the login page.

Related Issue: https://github.com/rancher/rancher/issues/26562