### PR TITLE
[Master] Set reload_connections to false by default for es

### DIFF
--- a/pkg/controllers/user/logging/generator/templatematch.go
+++ b/pkg/controllers/user/logging/generator/templatematch.go
@@ -40,6 +40,9 @@ var MatchTemplate = `
 {{ if eq .CurrentTarget "elasticsearch" }}
 	@type elasticsearch
 	include_tag_key  true
+	reload_connections false
+	reconnect_on_error true
+	reload_on_failure true
 	{{- if and .ElasticsearchConfig.AuthUserName .ElasticsearchConfig.AuthPassword}}
 	user {{.ElasticsearchConfig.AuthUserName}}
 	password {{.ElasticsearchConfig.AuthPassword}}


### PR DESCRIPTION
2.4 PR https://github.com/rancher/rancher/pull/26733

Issue:

fluent-plugin-elasticsearch reloads connection after 10000 requests. Sometimes this reloading functionality bothers users to send events with ES plugin. Fluentd will stop to send logs to ES.

Solution:

Set it to false by following https://github.com/uken/fluent-plugin-elasticsearch#stopped-to-send-events-on-k8s-why . It works in users env with this setting. So users would like to have this configured by default. This is also the default value in upstream fluentd `kubernetes-daemonset`

https://github.com/rancher/rancher/issues/21744