### PR TITLE
Make ldap search for objectClass case-insensitive

### DIFF
--- a/pkg/auth/providers/common/ldap/ldap_util.go
+++ b/pkg/auth/providers/common/ldap/ldap_util.go
@@ -98,7 +98,7 @@ func HasPermission(attributes []*ldapv2.EntryAttribute, userObjectClass string, 
 
 func IsType(search []*ldapv2.EntryAttribute, varType string) bool {
 	for _, attrib := range search {
-		if attrib.Name == "objectClass" {
+		if strings.EqualFold(attrib.Name, "objectClass") {
 			for _, val := range attrib.Values {
 				if strings.EqualFold(val, varType) {
 					logrus.Debugf("ldap IsType found object of type %s", varType)

--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -121,14 +121,8 @@ func (p *ldapProvider) getPrincipalsFromSearchResult(result *ldapv2.SearchResult
 
 	logrus.Debugf("SearchResult memberOf attribute {%s}", userMemberAttribute)
 
-	isType := false
-	objectClass := entry.GetAttributeValues(ObjectClass)
-	for _, obj := range objectClass {
-		if strings.EqualFold(string(obj), config.UserObjectClass) {
-			isType = true
-		}
-	}
-	if !isType {
+	if !ldap.IsType(userAttributes, config.UserObjectClass) {
+		logrus.Debugf("The objectClass %s was not found in the user attributes", config.UserObjectClass)
 		return v3.Principal{}, nil, nil
 	}
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/28077

I work with an LDAP server which the ObjectClass attribute is in lowercase, i.e., "objectclass".

When Rancher makes the search for objectclass attributes it expects the literal name "objectClass", i.e, it's case-sensitive, which makes the LDAP authentication never work because it won't find any attributes in this case.

To fix this, I changed the search to make it case-insensitive, using EqualFold function.

I also changed the isType check method from ldap_client.go so it can use the new case-insensitive function from ldap package.

I have builded and tested this fix in my environment, and LDAP provider worked just fine.