### PR TITLE
stabilize test_auth when used in Jenkins

### DIFF
--- a/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test
+++ b/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test
@@ -139,11 +139,14 @@ node {
 
           sh "docker stop ${setupContainer}"
           sh "docker stop ${testContainer}"
-          sh "docker stop ${deleteContainer}"
 
           sh "docker rm -v ${setupContainer}"
           sh "docker rm -v ${testContainer}"
-          sh "docker rm -v ${deleteContainer}"
+
+          if (env.RANCHER_DELETE_SERVER.toLowerCase() == "true" && RANCHER_DEPLOYED) {
+            sh "docker stop ${deleteContainer}"
+            sh "docker rm -v ${deleteContainer}"
+          }
 
           sh "docker rmi ${imageName}"
         } // finally

--- a/tests/validation/tests/v3_api/test_auth.py
+++ b/tests/validation/tests/v3_api/test_auth.py
@@ -17,7 +17,7 @@ from .test_rke_cluster_provisioning import create_and_validate_custom_host
 Prerequisite:
 1. testautoadmin as your admin user, if the fixture detects the auth
    is disabled it will be enabled automatically.
-2. Two clusters in your setup, if none or one are detected by the fixture 
+2. Two clusters in your setup, if none or one are detected by the fixture
    will create clusters to match two
 '''
 
@@ -741,21 +741,24 @@ def create_project_client(request):
 
     cluster_total = len(client.list_cluster().data)
     node_roles = [["controlplane", "etcd", "worker"]]
+    kargs = {'node_roles': node_roles,
+             'random_cluster_name': True,
+             'validate': False}
     aws_nodes1 = cluster1 = None
     aws_nodes2 = cluster2 = None
     if cluster_total == 0:
-        cluster1, aws_nodes1 = create_and_validate_custom_host(node_roles, True)
-        cluster2, aws_nodes2 = create_and_validate_custom_host(node_roles, True)
+        cluster1, aws_nodes1 = create_and_validate_custom_host(**kargs)
+        cluster2, aws_nodes2 = create_and_validate_custom_host(**kargs)
     if cluster_total == 1:
-        cluster1, aws_nodes1 = create_and_validate_custom_host(node_roles, True)
+        cluster2, aws_nodes2 = create_and_validate_custom_host(**kargs)
 
     clusters = client.list_cluster().data
     assert len(clusters) >= 2
-    cluster1 = clusters[0]
+    cluster1 = cluster1 if cluster1 else clusters[0]
     for project in client.list_project():
         delete_existing_users_in_project(client, project)
     p1, ns1 = create_project_and_ns(ADMIN_TOKEN, cluster1)
-    cluster2 = clusters[1]
+    cluster2 = cluster2 if cluster2 else clusters[1]
     p2, ns2 = create_project_and_ns(ADMIN_TOKEN, cluster2)
     setup["cluster1"] = cluster1
     setup["project1"] = p1
@@ -773,8 +776,8 @@ def create_project_client(request):
                 cluster_cleanup(client, cluster1, aws_nodes1)
                 cluster_cleanup(client, cluster2, aws_nodes2)
         if cluster_total == 1:
-            if aws_nodes1:
-                cluster_cleanup(client, cluster1, aws_nodes1)
+            if aws_nodes2:
+                cluster_cleanup(client, cluster2, aws_nodes2)
     request.addfinalizer(fin)
 
 

--- a/tests/validation/tests/v3_api/test_custom_host_reg.py
+++ b/tests/validation/tests/v3_api/test_custom_host_reg.py
@@ -107,7 +107,7 @@ def test_deploy_rancher_server():
 
 
 def test_delete_rancher_server():
-    client = get_user_client()
+    client = get_admin_client()
     clusters = client.list_cluster().data
     for cluster in clusters:
         delete_cluster(client, cluster)

--- a/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
+++ b/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
@@ -1013,7 +1013,8 @@ def register_host_after_delay(client, cluster, node_role, delay):
         time.sleep(delay)
 
 
-def create_and_validate_custom_host(node_roles, random_cluster_name=False):
+def create_and_validate_custom_host(node_roles, random_cluster_name=False,
+                                    validate=True):
     client = get_user_client()
     aws_nodes = \
         AmazonWebServices().create_multiple_nodes(
@@ -1021,8 +1022,10 @@ def create_and_validate_custom_host(node_roles, random_cluster_name=False):
 
     cluster, nodes = create_custom_host_from_nodes(aws_nodes, node_roles,
                                                    random_cluster_name)
-    cluster = validate_cluster(client, cluster, check_intermediate_state=False,
-                               k8s_version=K8S_VERSION)
+    if validate:
+        cluster = validate_cluster(client, cluster,
+                                   check_intermediate_state=False,
+                                   k8s_version=K8S_VERSION)
     return cluster, nodes
 
 


### PR DESCRIPTION
Make sure to only remove the delete container if Rancher was deployed and `DELETE_RANCHER_SERVER` is `true`

Fix the `cluster` and `aws_nodes` references when cleaning up the test_auth resources.

Use the admin context when `DELETE_RANCHER_SERVER` is true to delete the clusters before deleting the Rancher server.

Added `validate` parameter for `create_and_validate_custom_host` for making the cluster validation optional. This will save resources as we won't need to validate workloads/ingresses availability for tests that don't need them for validation, in this case `test_auth` and thus no need to deploy VM instances larger than `t2.medium` in AWS.