### PR TITLE
[2.4] wait for dockerInfo to be set before creating node plan

### DIFF
--- a/pkg/controllers/management/rkeworkerupgrader/plan.go
+++ b/pkg/controllers/management/rkeworkerupgrader/plan.go
@@ -30,6 +30,8 @@ func (uh *upgradeHandler) nonWorkerPlan(node *v3.Node, cluster *v3.Cluster) (*v3
 	hostAddress := node.Status.NodeConfig.Address
 	hostDockerInfo := infos[hostAddress]
 
+	logrus.Debugf("getDockerInfo for node [%s] dockerInfo [%s]", node.Name, hostDockerInfo.DockerRootDir)
+
 	svcOptions, err := uh.getServiceOptions(rkeConfig.Version, hostDockerInfo.OSType)
 	if err != nil {
 		return nil, err
@@ -85,6 +87,8 @@ func (uh *upgradeHandler) workerPlan(node *v3.Node, cluster *v3.Cluster) (*v3.RK
 	if err != nil {
 		return nil, err
 	}
+
+	logrus.Debugf("getDockerInfo for node [%s] dockerInfo [%s]", node.Name, hostDockerInfo.DockerRootDir)
 
 	np := &v3.RKEConfigNodePlan{}
 

--- a/pkg/controllers/management/rkeworkerupgrader/upgrade.go
+++ b/pkg/controllers/management/rkeworkerupgrader/upgrade.go
@@ -161,7 +161,10 @@ func (uh *upgradeHandler) Sync(key string, node *v3.Node) (runtime.Object, error
 }
 
 func (uh *upgradeHandler) updateNodePlan(node *v3.Node, cluster *v3.Cluster, create bool) (*v3.Node, error) {
-	if node.Status.NodeConfig == nil {
+	if node.Status.NodeConfig == nil || node.Status.DockerInfo == nil {
+		logrus.Debugf("cluster [%s] worker-upgrade: node [%s] waiting for node status sync: "+
+			"nodeConfigNil [%v] dockerInfoNil [%v]", cluster.Name, node.Name, node.Status.NodeConfig == nil, node.Status.DockerInfo == nil)
+		// can't create correct node plan if node config or docker info hasn't been set
 		return node, nil
 	}
 	nodePlan, err := uh.getNodePlan(node, cluster)

--- a/pkg/controllers/management/rkeworkerupgrader/upgrade.go
+++ b/pkg/controllers/management/rkeworkerupgrader/upgrade.go
@@ -383,7 +383,8 @@ func (uh *upgradeHandler) toUpgradeCluster(cluster *v3.Cluster) (bool, bool, err
 			continue
 		}
 
-		if node.Status.NodePlan == nil {
+		if node.Status.NodePlan == nil || v3.NodeConditionRegistered.IsUnknown(node) {
+			// node's not yet registered, change in its node plan should do nothing for cluster upgrade
 			continue
 		}
 


### PR DESCRIPTION
Problem:
creating node plan with empty dockerRootDir results into wrong kubelet's process

https://github.com/rancher/rancher/issues/26790

Problem:
change in node plan of registering nodes triggers cluster upgrade for other worker nodes

https://github.com/rancher/rancher/issues/26807