### PR TITLE
catch output from running commands

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -563,7 +563,9 @@ def run_command_with_stderr(command, log_out=True):
         returncode = e.returncode
 
     if log_out:
-        print("returns: \t{0}".format(returncode))
+        print("return code: \t{0}".format(returncode))
+        if returncode != 0:
+            print("output: \t{0}".format(output))
 
     return output
 

--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -63,8 +63,8 @@ def test_upgrade_ha(precheck_upgrade_options):
 def ha_setup(install_cm=True):
     print(RANCHER_HA_HOSTNAME)
     nodes = create_resources()
-    rke_config = create_rke_cluster_config(nodes)
-    create_rke_cluster(rke_config)
+    rke_config_path = create_rke_cluster_config(nodes)
+    create_rke_cluster(rke_config_path)
     if install_cm:
         install_cert_manager()
     add_repo_create_namespace()
@@ -277,6 +277,7 @@ def create_rke_cluster_config(aws_nodes):
                                   aws_nodes[2].private_ip_address)
 
     rkeconfig = rkeconfig.replace("$AWS_SSH_KEY_NAME", AWS_SSH_KEY_NAME)
+    print("cluster-ha-filled.yml: \n" + rkeconfig + "\n")
 
     clusterfilepath = DATA_SUBDIR + "/" + "cluster-ha-filled.yml"
 


### PR DESCRIPTION
pint out the output of running commands in the console for better tracking and easier debugging. 