### PR TITLE
cis 1.5 support automation

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -79,6 +79,10 @@ TEST_ALL_SNAPSHOT = ast.literal_eval(
 if_test_all_snapshot = \
     pytest.mark.skipif(TEST_ALL_SNAPSHOT is False,
                        reason='Snapshots check tests are skipped')
+DATA_SUBDIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                           'resource')
+# As of release 2.4 default rke scan profile is "rke-cis-1.4"
+CIS_SCAN_PROFILE = os.environ.get('RANCHER_CIS_SCAN_PROFILE', "rke-cis-1.4")
 
 # here are all supported roles for RBAC testing
 CLUSTER_MEMBER = "cluster-member"
@@ -177,11 +181,13 @@ nested_group = {
     "group_dic": None,
     "groups": None
 }
-if_test_group_rbac = pytest.mark.skipif(not AUTH_PROVIDER
-                                        or not AUTH_USER_PASSWORD,
-                                        reason='Group RBAC tests are skipped.'
-                                               'Required AUTH env variables '
-                                               'have not been set.')
+auth_requirements = not AUTH_PROVIDER or not AUTH_USER_PASSWORD
+if_test_group_rbac = pytest.mark.skipif(
+    auth_requirements,
+    reason='Group RBAC tests are skipped.'
+           'Required AUTH env variables '
+           'have not been set.'
+)
 
 
 def is_windows(os_type=TEST_OS):
@@ -246,8 +252,8 @@ def wait_for_condition(client, resource, check_function, fail_handler=None,
     while not check_function(resource):
         if time.time() - start > timeout:
             exceptionMsg = 'Timeout waiting for ' + resource.baseType + \
-                ' to satisfy condition: ' + \
-                inspect.getsource(check_function)
+                           ' to satisfy condition: ' + \
+                           inspect.getsource(check_function)
             if fail_handler:
                 exceptionMsg = exceptionMsg + fail_handler(resource)
             raise Exception(exceptionMsg)
@@ -977,6 +983,7 @@ def validate_dns_entry_windows(pod, host, expected):
                 ping_validation_pass = True
                 break
         return ping_validation_pass and (" (0% loss)" in str(ping_output))
+
     wait_for(callback=ping_check,
              timeout_message="Failed to ping {0}".format(host))
 
@@ -990,6 +997,7 @@ def validate_dns_entry_windows(pod, host, expected):
                 dig_validation_pass = False
                 break
         return dig_validation_pass
+
     wait_for(callback=dig_check,
              timeout_message="Failed to resolve {0}".format(host))
 
@@ -1743,8 +1751,9 @@ def validate_catalog_app(proj_client, app, external_id, answer=None):
     parameters = external_id.split('&')
     assert len(parameters) > 1, \
         "Incorrect list of parameters from catalog external ID"
-    chart = parameters[len(parameters) - 2].split("=")[1] + "-" + \
-        parameters[len(parameters) - 1].split("=")[1]
+    chart_prefix = parameters[len(parameters) - 2].split("=")[1]
+    chart_suffix = parameters[len(parameters) - 1].split("=")[1]
+    chart = chart_prefix + "-" + chart_suffix
     app_name = parameters[len(parameters) - 2].split("=")[1]
     workloads = proj_client.list_workload(namespaceId=ns).data
     for wl in workloads:
@@ -1915,13 +1924,13 @@ def rbac_cleanup():
     """ remove the project, namespace and users created for the RBAC tests"""
     try:
         client = get_admin_client()
-    except:
+    except Exception:
         print("Not able to get admin client. Not performing RBAC cleanup")
         return
     for _, value in rbac_data["users"].items():
         try:
             client.delete(value["user"])
-        except:
+        except Exception:
             pass
     client.delete(rbac_data["project"])
     client.delete(rbac_data["wl_unshared"])
@@ -2024,9 +2033,10 @@ def validate_create_catalog(token, catalog_name, branch, url, permission=True):
             client.create_catalog(name=catalog_name,
                                   branch=branch,
                                   url=url)
-        assert e.value.error.status == 403 and \
-            e.value.error.code == 'Forbidden', \
-            "user with no permission should receive 403: Forbidden"
+        error_msg = "user with no permission should receive 403: Forbidden"
+        error_code = e.value.error.code
+        error_status = e.value.error.status
+        assert error_status == 403 and error_code == 'Forbidden', error_msg
         return None
     else:
         try:
@@ -2142,7 +2152,7 @@ def validate_backup_create(namespace, backup_info, backup_mode=None):
                 continue
             get_filesystem_snapshots = 'ls /opt/rke/etcd-snapshots'
             response = node.execute_command(get_filesystem_snapshots)[0]
-            assert backup_info["etcdbackupdata"][0]['filename'] in response,\
+            assert backup_info["etcdbackupdata"][0]['filename'] in response, \
                 "The filename doesn't match any of the files locally"
     return namespace, backup_info
 
@@ -2191,7 +2201,7 @@ def validate_backup_delete(namespace, backup_info, backup_mode=None):
         cluster.etcdBackups(name=backup_info["backupname"])['data'][0]
     )
     wait_for_backup_to_delete(cluster, backup_info["backupname"])
-    assert len(cluster.etcdBackups(name=backup_info["backupname"])) == 0,\
+    assert len(cluster.etcdBackups(name=backup_info["backupname"])) == 0, \
         "backup shouldn't be listed in the Cluster backups"
     if backup_mode == "s3":
         # Check the backup reference is deleted in Rancher and S3
@@ -2285,6 +2295,7 @@ def get_user_by_group(group, nested=False):
     if nested is False, return the direct users in the group;
     otherwise, return all users including those from nested groups
     """
+
     def get_user_in_nested_group(group, source):
         if group == "":
             return []
@@ -2402,6 +2413,7 @@ class WebsocketLogParse:
     the class is used for receiving and parsing the message
     received from the websocket
     """
+
     def __init__(self):
         self.lock = Lock()
         self._last_message = ''
@@ -2582,3 +2594,58 @@ def delete_resource_in_AWS_by_prefix(resource_prefix):
 
     print("deletion is done")
     return None
+
+
+def configure_cis_requirements(aws_nodes, profile, node_roles, client,
+                               cluster):
+    i = 0
+    if profile == 'rke-cis-1.4':
+        for aws_node in aws_nodes:
+            aws_node.execute_command("sudo sysctl -w vm.overcommit_memory=1")
+            aws_node.execute_command("sudo sysctl -w kernel.panic=10")
+            aws_node.execute_command("sudo sysctl -w kernel.panic_on_oops=1")
+            if node_roles[i] == ["etcd"]:
+                aws_node.execute_command("sudo useradd etcd")
+            docker_run_cmd = \
+                get_custom_host_registration_cmd(client,
+                                                 cluster,
+                                                 node_roles[i],
+                                                 aws_node)
+            aws_node.execute_command(docker_run_cmd)
+            i += 1
+    elif profile == 'rke-cis-1.5':
+        for aws_node in aws_nodes:
+            aws_node.execute_command("sudo sysctl -w vm.overcommit_memory=1")
+            aws_node.execute_command("sudo sysctl -w kernel.panic=10")
+            aws_node.execute_command("sudo sysctl -w vm.panic_on_oom=0")
+            aws_node.execute_command("sudo sysctl -w kernel.panic_on_oops=1")
+            aws_node.execute_command("sudo sysctl -w "
+                                     "kernel.keys.root_maxbytes=25000000")
+            if node_roles[i] == ["etcd"]:
+                aws_node.execute_command("sudo groupadd -g 52034 etcd")
+                aws_node.execute_command("sudo useradd -u 52034 -g 52034 etcd")
+            docker_run_cmd = \
+                get_custom_host_registration_cmd(client,
+                                                 cluster,
+                                                 node_roles[i],
+                                                 aws_node)
+            aws_node.execute_command(docker_run_cmd)
+            i += 1
+    time.sleep(5)
+    cluster = validate_cluster_state(client, cluster)
+
+    # the workloads under System project to get active
+    time.sleep(20)
+    if profile == 'rke-cis-1.5':
+        create_kubeconfig(cluster)
+        network_policy_file = DATA_SUBDIR + "/default-allow-all.yaml"
+        account_update_file = DATA_SUBDIR + "/account_update.yaml"
+        items = execute_kubectl_cmd("get namespaces -A")["items"]
+        all_ns = [item["metadata"]["name"] for item in items]
+        for ns in all_ns:
+            execute_kubectl_cmd("apply -f {0} -n {1}".
+                                format(network_policy_file, ns))
+            execute_kubectl_cmd('patch serviceaccount default'
+                                ' -n {0} -p "$(cat {1})"'.
+                                format(ns, account_update_file))
+    return cluster

--- a/tests/validation/tests/v3_api/resource/account_update.yaml
+++ b/tests/validation/tests/v3_api/resource/account_update.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+automountServiceAccountToken: false

--- a/tests/validation/tests/v3_api/resource/default-allow-all.yaml
+++ b/tests/validation/tests/v3_api/resource/default-allow-all.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-allow-all
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/tests/validation/tests/v3_api/test_cis_scan.py
+++ b/tests/validation/tests/v3_api/test_cis_scan.py
@@ -1,14 +1,12 @@
 import pytest
 import requests
 import time
-import os
 from rancher import ApiError
 from lib.aws import AmazonWebServices
-from .common import CLUSTER_MEMBER
+from .common import CLUSTER_MEMBER, configure_cis_requirements
 from .common import CLUSTER_OWNER
+from .common import CIS_SCAN_PROFILE
 from .common import cluster_cleanup
-from .common import create_kubeconfig
-from .common import execute_kubectl_cmd
 from .common import get_user_client
 from .common import get_user_client_and_cluster
 from .common import get_custom_host_registration_cmd
@@ -25,10 +23,7 @@ from .common import USER_TOKEN
 from .common import validate_cluster_state
 from .common import wait_for_cluster_node_count
 from .test_rke_cluster_provisioning import HOST_NAME, \
-    rke_config_cis, POD_SECURITY_POLICY_TEMPLATE  # NOQA
-CIS_SCAN_PROFILE = os.environ.get('RANCHER_CIS_SCAN_PROFILE', "rke-cis-1.4")
-DATA_SUBDIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resource')
-# As of release 2.4 default rke scan profile is "rke-cis-1.4"
+    POD_SECURITY_POLICY_TEMPLATE, get_cis_rke_config  # NOQA
 
 scan_results = {
     "rke-cis-1.4": {
@@ -37,9 +32,9 @@ scan_results = {
         "not_applicable": 19, "total": 97, "fail": 0
     },
     "rke-cis-1.5": {
-        "permissive": {"pass": 0, "fail": 0, "skip": 0},
-        "hardened": {"pass": 0, "fail": 0, "skip": 0},
-        "not_applicable": 0, "total": 0, "fail": 0
+        "permissive": {"pass": 58, "fail": 0, "skip": 14},
+        "hardened": {"pass": 72, "fail": 0, "skip": 0},
+        "not_applicable": 20, "total": 92, "fail": 0
     }
 }
 DEFAULT_TIMEOUT = 120
@@ -110,7 +105,7 @@ def test_cis_scan_skip_test_ui():
         report_link,
         token=USER_TOKEN,
         test_total=scan_results[CIS_SCAN_PROFILE]["total"],
-        tests_passed=scan_results[CIS_SCAN_PROFILE]["hardened"]["pass"]-1,
+        tests_passed=scan_results[CIS_SCAN_PROFILE]["hardened"]["pass"] - 1,
         tests_skipped=scan_results[CIS_SCAN_PROFILE]["hardened"]["skip"] + 1
     )
     print(report["results"][0]["checks"][0]["state"])
@@ -170,7 +165,7 @@ def test_cis_scan_edit_cluster():
     cluster = cluster_detail["cluster"]
     # Add 2 etcd nodes to the cluster
     for i in range(0, 2):
-        aws_node = aws_nodes[3+i]
+        aws_node = aws_nodes[3 + i]
         aws_node.execute_command("sudo sysctl -w vm.overcommit_memory=1")
         aws_node.execute_command("sudo sysctl -w kernel.panic=10")
         aws_node.execute_command("sudo sysctl -w kernel.panic_on_oops=1")
@@ -199,7 +194,7 @@ def test_cis_scan_edit_cluster():
 
     # edit nodes and run command
     for i in range(0, 2):
-        aws_node = aws_nodes[3+i]
+        aws_node = aws_nodes[3 + i]
         aws_node.execute_command("sudo useradd etcd")
 
     # run CIS Scan
@@ -229,7 +224,7 @@ def test_rbac_run_scan_cluster_owner():
         test_total=scan_results[CIS_SCAN_PROFILE]["total"],
         tests_passed=scan_results[CIS_SCAN_PROFILE]["permissive"]["pass"],
         tests_skipped=scan_results[CIS_SCAN_PROFILE]["permissive"]["skip"]
-        )
+    )
 
 
 @if_test_rbac
@@ -269,34 +264,23 @@ def create_project_client(request):
     node_roles = [
         ["controlplane"], ["etcd"], ["worker"]
     ]
-    profile = CIS_SCAN_PROFILE
-    if profile == "rke-cis-1.4":
-        rke_config_temp = rke_config_cis
+    rke_config_temp = get_cis_rke_config()
     client = get_user_client()
-    cluster = client.create_cluster(name=random_test_name(),
-                                    driver="rancherKubernetesEngine",
-                                    rancherKubernetesEngineConfig=
-                                    rke_config_temp,
-                                    defaultPodSecurityPolicyTemplateId=
-                                    POD_SECURITY_POLICY_TEMPLATE)
+    cluster = client.create_cluster(
+        name=random_test_name(),
+        driver="rancherKubernetesEngine",
+        rancherKubernetesEngineConfig=rke_config_temp,
+        defaultPodSecurityPolicyTemplateId=POD_SECURITY_POLICY_TEMPLATE
+    )
     assert cluster.state == "provisioning"
-    i = 0
-    for i in range(0, 3):
-        aws_node = aws_nodes[i]
-        aws_node.execute_command("sudo sysctl -w vm.overcommit_memory=1")
-        aws_node.execute_command("sudo sysctl -w kernel.panic=10")
-        aws_node.execute_command("sudo sysctl -w kernel.panic_on_oops=1")
-        if node_roles[i] == ["etcd"]:
-            aws_node.execute_command("sudo useradd etcd")
-        docker_run_cmd = \
-            get_custom_host_registration_cmd(client, cluster, node_roles[i],
-                                             aws_node)
-        aws_node.execute_command(docker_run_cmd)
-    time.sleep(5)
-    cluster = validate_cluster_state(client, cluster)
-
-    # the worklods under System project to get active
-    time.sleep(20)
+    # In the original design creates 5 nodes but only 3 are used
+    # the other 2 nodes are for test_cis_scan_edit_cluster
+    cluster = configure_cis_requirements(aws_nodes[:3],
+                                         CIS_SCAN_PROFILE,
+                                         node_roles,
+                                         client,
+                                         cluster
+                                         )
     cluster_detail["cluster"] = cluster
 
     def fin():
@@ -305,10 +289,11 @@ def create_project_client(request):
     request.addfinalizer(fin)
 
 
-def verify_cis_scan_report(report_link, token, test_total,
-                           tests_passed, tests_skipped,
-                           tests_failed=scan_results[CIS_SCAN_PROFILE]["fail"],
-                           tests_na=scan_results[CIS_SCAN_PROFILE]["not_applicable"]):
+def verify_cis_scan_report(
+        report_link, token, test_total,
+        tests_passed, tests_skipped,
+        tests_failed=scan_results[CIS_SCAN_PROFILE]["fail"],
+        tests_na=scan_results[CIS_SCAN_PROFILE]["not_applicable"]):
     head = {'Authorization': 'Bearer ' + token}
     response = requests.get(report_link, verify=False, headers=head)
     report = response.json()

--- a/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
+++ b/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
@@ -91,7 +91,7 @@ rke_config_windows = {
             "type": "kubeAPIService"}},
     "sshAgentAuth": False}
 
-rke_config_cis = {
+rke_config_cis_1_4 = {
     "addonJobTimeout": 30,
     "authentication":
     {"strategy": "x509",
@@ -186,9 +186,76 @@ rke_config_cis = {
         }},
     "sshAgentAuth": False}
 
+rke_config_cis_1_5 = {
+    "addonJobTimeout": 30,
+    "ignoreDockerVersion": True,
+    "services": {
+        "etcd": {
+            "gid": 52034,
+            "uid": 52034,
+            "type": "etcdService"},
+        "kubeApi": {
+            "podSecurityPolicy": True,
+            "secretsEncryptionConfig":
+                {"enabled": True},
+            "auditLog":
+                {"enabled": True},
+            "eventRateLimit":
+                {"enabled": True},
+            "type": "kubeAPIService"},
+        "kubeController": {
+            "extraArgs": {
+                "feature-gates": "RotateKubeletServerCertificate=true",
+            },
+        },
+        "scheduler": {
+            "image": "",
+            "extraArgs": {},
+            "extraBinds": [],
+            "extraEnv": []
+        },
+        "kubelet": {
+            "generateServingCertificate": True,
+            "extraArgs": {
+                "feature-gates": "RotateKubeletServerCertificate=true",
+                "protect-kernel-defaults": True,
+                "tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_"
+                                     "128_GCM_SHA256,"
+                                     "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
+                                     "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,"
+                                     "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
+                                     "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,"
+                                     "TLS_ECDHE_ECDSA_WITH_AES_"
+                                     "256_GCM_SHA384,"
+                                     "TLS_RSA_WITH_AES_256_GCM_SHA384,"
+                                     "TLS_RSA_WITH_AES_128_GCM_SHA256"
+            },
+            "extraBinds": [],
+            "extraEnv": [],
+            "clusterDomain": "",
+            "infraContainerImage": "",
+            "clusterDnsServer": "",
+            "failSwapOn": False
+        },
+    },
+    "network":
+        {"plugin": "",
+         "options": {},
+         "mtu": 0,
+         "nodeSelector": {}},
+    "authentication": {
+        "strategy": "",
+        "sans": [],
+        "webhook": None,
+    },
+    "sshAgentAuth": False,
+    "windowsPreferredCluster": False
+}
+
 if K8S_VERSION != "":
     rke_config["kubernetesVersion"] = K8S_VERSION
-    rke_config_cis["kubernetesVersion"] = K8S_VERSION
+    rke_config_cis_1_4["kubernetesVersion"] = K8S_VERSION
+    rke_config_cis_1_5["kubernetesVersion"] = K8S_VERSION
 
 
 rke_config_aws_provider = rke_config.copy()
@@ -221,14 +288,15 @@ if_test_edit_cluster = pytest.mark.skipif(
 
 def test_cis_complaint():
     # rke_config_cis
-    aws_nodes = \
-        AmazonWebServices().create_multiple_nodes(
-            8, random_test_name(HOST_NAME))
     node_roles = [
         ["controlplane"], ["controlplane"],
         ["etcd"], ["etcd"], ["etcd"],
         ["worker"], ["worker"], ["worker"]
     ]
+    aws_nodes = \
+        AmazonWebServices().create_multiple_nodes(
+            len(node_roles), random_test_name(HOST_NAME))
+    rke_config_cis = get_cis_rke_config()
     client = get_admin_client()
     cluster = client.create_cluster(
         name=evaluate_clustername(),
@@ -236,19 +304,12 @@ def test_cis_complaint():
         rancherKubernetesEngineConfig=rke_config_cis,
         defaultPodSecurityPolicyTemplateId=POD_SECURITY_POLICY_TEMPLATE)
     assert cluster.state == "provisioning"
-    i = 0
-    for aws_node in aws_nodes:
-        aws_node.execute_command("sudo sysctl -w vm.overcommit_memory=1")
-        aws_node.execute_command("sudo sysctl -w kernel.panic=10")
-        aws_node.execute_command("sudo sysctl -w kernel.panic_on_oops=1")
-        if node_roles[i] == ["etcd"]:
-            aws_node.execute_command("sudo useradd etcd")
-        docker_run_cmd = \
-            get_custom_host_registration_cmd(client, cluster, node_roles[i],
-                                             aws_node)
-        aws_node.execute_command(docker_run_cmd)
-        i += 1
-    cluster = validate_cluster_state(client, cluster)
+    configure_cis_requirements(aws_nodes,
+                               CIS_SCAN_PROFILE,
+                               node_roles,
+                               client,
+                               cluster
+                               )
     cluster_cleanup(client, cluster, aws_nodes)
 
 
@@ -1069,3 +1130,21 @@ def create_custom_host_from_nodes(nodes, node_roles,
                                      check_intermediate_state=False)
 
     return cluster, nodes
+
+
+def get_cis_rke_config(profile=CIS_SCAN_PROFILE):
+    rke_tmp_config = None
+    rke_config_dict = None
+    try:
+        rke_config_dict = {
+            'rke-cis-1.4': rke_config_cis_1_4,
+            'rke-cis-1.5': rke_config_cis_1_5
+        }
+        rke_tmp_config = rke_config_dict[profile]
+    except KeyError:
+        print('Invalid RKE CIS profile. Supported profiles: ')
+        for k in rke_config_dict.keys():
+            print("{0}".format(k))
+    else:
+        print('Valid RKE CIS Profile loaded: {0}'.format(profile))
+    return rke_tmp_config


### PR DESCRIPTION
Also included some formatting to fix the reported `flake8` errors.

I focused on getting the following tests working only so far for this initial support.

```
test_cis_scan_run_scan
test_cis_complaint
```

There are number of tests that are assuming CIS 1.4 that will need to get updated in future update iterations.