### PR TITLE
Scripts to create rancher, clusters, and run validation tests against them

### DIFF
--- a/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_support_matrix
+++ b/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_support_matrix
@@ -1,0 +1,188 @@
+#!groovy
+
+node {
+  def rootPath = "/src/rancher-validation/"
+  def setupContainer = "${JOB_NAME}${env.BUILD_NUMBER}_setup"
+  def clusterSetupContainer = "${JOB_NAME}${env.BUILD_NUMBER}_cluster_setup"
+  def testContainer = "${JOB_NAME}${env.BUILD_NUMBER}_test"
+  def deleteContainer = "${JOB_NAME}${env.BUILD_NUMBER}_delete"
+
+  def deployPytestOptions = "-k test_deploy_rancher_server"
+  def deletePytestOptions = "-k test_delete_rancher_server"
+  def deployClusterPytestOptions = "-k test_deploy_clusters"
+
+  def setupResultsOut = "setup-results.xml"
+  def clusterSetupResultsOut = "cluster-setup-results.xml"
+  def testResultsOut = "results.xml"
+  def deleteResultsOut = "delete-results.xml"
+  def imageName = "rancher-validation-${JOB_NAME}${env.BUILD_NUMBER}"
+  def testsDir = "tests/v3_api/"
+
+  def envFile = ".env"
+  def rancherConfig = "rancher_env.config"
+
+  def branch = "master"
+  if ("${env.branch}" != "null" && "${env.branch}" != "") {
+    branch = "${env.branch}"
+  }
+
+  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+    withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                      string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+                      string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'RANCHER_EKS_ACCESS_KEY'),
+                      string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'RANCHER_EKS_SECRET_KEY'),
+                      string(credentialsId: 'DO_ACCESSKEY', variable: 'DO_ACCESSKEY'),
+                      string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                      string(credentialsId: 'RANCHER_SSH_KEY', variable: 'RANCHER_SSH_KEY'),
+                      string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                      string(credentialsId: 'AZURE_TENANT_ID', variable: 'AZURE_TENANT_ID'),
+                      string(credentialsId: 'AZURE_CLIENT_ID', variable: 'AZURE_CLIENT_ID'),
+                      string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'AZURE_CLIENT_SECRET'),
+                      string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'RANCHER_AKS_SUBSCRIPTION_ID'),
+                      string(credentialsId: 'AZURE_TENANT_ID', variable: 'RANCHER_AKS_TENANT_ID'),
+                      string(credentialsId: 'AZURE_CLIENT_ID', variable: 'RANCHER_AKS_CLIENT_ID'),
+                      string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'RANCHER_AKS_SECRET_KEY'),
+                      string(credentialsId: 'RANCHER_REGISTRY_USER_NAME', variable: 'RANCHER_REGISTRY_USER_NAME'),
+                      string(credentialsId: 'RANCHER_REGISTRY_PASSWORD', variable: 'RANCHER_REGISTRY_PASSWORD'),
+                      string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                      string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD'),
+                      string(credentialsId: 'RANCHER_GKE_CREDENTIAL', variable: 'RANCHER_GKE_CREDENTIAL'),
+                      string(credentialsId: 'RANCHER_AUTH_USER_PASSWORD', variable: 'RANCHER_AUTH_USER_PASSWORD'),
+                      string(credentialsId: 'RANCHER_HOSTNAME_OR_IP_ADDRESS', variable: 'RANCHER_HOSTNAME_OR_IP_ADDRESS'),
+                      string(credentialsId: 'RANCHER_CA_CERTIFICATE', variable: 'RANCHER_CA_CERTIFICATE'),
+                      string(credentialsId: 'RANCHER_SERVICE_ACCOUNT_NAME', variable: 'RANCHER_SERVICE_ACCOUNT_NAME'),
+                      string(credentialsId: 'RANCHER_SERVICE_ACCOUNT_PASSWORD', variable: 'RANCHER_SERVICE_ACCOUNT_PASSWORD'),
+                      string(credentialsId: 'RANCHER_USER_SEARCH_BASE', variable: 'RANCHER_USER_SEARCH_BASE'),
+                      string(credentialsId: 'RANCHER_DEFAULT_LOGIN_DOMAIN', variable: 'RANCHER_DEFAULT_LOGIN_DOMAIN')]) {
+      stage('Checkout') {
+        deleteDir()
+        checkout([
+                  $class: 'GitSCM',
+                  branches: [[name: "*/${branch}"]],
+                  extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                  userRemoteConfigs: scm.userRemoteConfigs
+                ])
+      }
+
+      dir ("tests/validation") {
+        try {
+          stage('Configure and Build') {
+            if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
+              dir(".ssh") {
+                def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
+                writeFile file: AWS_SSH_KEY_NAME, text: decoded
+              }
+            }
+
+            sh "./tests/v3_api/scripts/configure.sh"
+            sh "./tests/v3_api/scripts/build.sh"
+          }
+
+          stage('Deploy Rancher Server') {
+            try {
+              // deploy rancher server
+              sh "docker run --name ${setupContainer} -t --env-file ${envFile} " +
+                "${imageName} /bin/bash -c \'pytest -v -s --junit-xml=${setupResultsOut} " +
+                "${deployPytestOptions} ${testsDir}\'"
+              RANCHER_DEPLOYED = true
+
+              // copy file containing CATTLE_TEST_URL, ADMIN_TOKEN, USER_TOKEN and load into environment variables
+              sh "docker cp ${setupContainer}:${rootPath}${testsDir}${rancherConfig} ."
+              load rancherConfig
+
+            } catch(err) {
+              echo "Error: " + err
+              RANCHER_DEPLOYED = false
+            }
+          }
+
+          stage('Deploy Clusters') {
+            try {
+              // deploy clusters of different versions
+              sh "docker run --name ${clusterSetupContainer} -t --env-file ${envFile} " +
+                  "${imageName} /bin/bash -c \'export CATTLE_TEST_URL=${env.CATTLE_TEST_URL} " +
+                  "&& export ADMIN_TOKEN=${env.ADMIN_TOKEN} && export USER_TOKEN=${env.USER_TOKEN} "+
+                  "&& pytest -v -s --junit-xml=${clusterSetupResultsOut} " +
+                "${deployClusterPytestOptions} ${testsDir}\'"
+
+              // copy file containing CLUSTER_NAMES and load into environment variables
+              sh "docker cp ${clusterSetupContainer}:${rootPath}${testsDir}${rancherConfig} ."
+              load rancherConfig
+
+            } catch(err) {
+              echo "Error: " + err
+            }
+          }
+
+          stage('Run Validation Tests in Parallel') {
+            try {
+                echo "Running validation tests. Environment:"
+                sh "docker run --rm --name testEnvironmentCheck -t --env-file ${envFile} " +
+                   "${imageName} /bin/bash -c \'export CATTLE_TEST_URL=${env.CATTLE_TEST_URL} " +
+                   "&& export ADMIN_TOKEN=${env.ADMIN_TOKEN} && export USER_TOKEN=${env.USER_TOKEN} "+
+                   "&& export RANCHER_CLUSTER_NAMES=${env.CLUSTER_NAMES} " + "&& printenv\'"
+                jobs = [:]
+                cluster_arr = env.CLUSTER_NAMES.split(",")
+                cluster_count = cluster_arr.size()
+                for (int i = 0; i < cluster_count; i++) {
+                  def params = [
+                    string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"),
+                    string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}"),
+                    string(name: 'USER_TOKEN', value: "${USER_TOKEN}"),
+                    string(name: 'RANCHER_CLUSTER_NAME', value: "${cluster_arr[i]}"),
+                    string(name: 'PYTEST_OPTIONS', value: "${PYTEST_OPTIONS}"),
+                  ]
+                  echo "Params are: ${params}"
+                  jobs["test-${i}"] = { build job: 'rancher-v3_needs_cluster', parameters: params }
+                }
+                parallel jobs
+            } catch(err) {
+                echo "Error: " + err
+            }
+          }
+
+        } catch(err) {
+          echo "Error: " + err
+        } finally {
+          stage('Delete Rancher Server') {
+            try {
+              if (env.RANCHER_DELETE_SERVER.toLowerCase() == "true" && RANCHER_DEPLOYED) {
+                sh "docker run --name ${deleteContainer} -t --env-file ${envFile} " +
+                "${imageName} /bin/bash -c \'export CATTLE_TEST_URL=${env.CATTLE_TEST_URL} && " +
+                "export ADMIN_TOKEN=${env.ADMIN_TOKEN} && export USER_TOKEN=${env.USER_TOKEN} && "+
+                "pytest -v -s --junit-xml=${deleteResultsOut} " +
+                "${deletePytestOptions} ${testsDir}\'"
+                sh "docker cp ${deleteContainer}:${rootPath}${deleteResultsOut} ."
+                step([$class: 'JUnitResultArchiver', testResults: "**/${deleteResultsOut}"])
+              }
+              else {
+                echo "Rancher server not deployed, skipping delete."
+              }
+            } catch(err) {
+              echo "Error: " + err
+              currentBuild.result = 'FAILURE'
+            }
+          }
+
+          stage('Test Report') {
+            // copy and archive test results
+            sh "docker cp ${setupContainer}:${rootPath}${setupResultsOut} ."
+            sh "docker cp ${clusterSetupContainer}:${rootPath}${clusterSetupResultsOut} ."
+            step([$class: 'JUnitResultArchiver', testResults: "**/${setupResultsOut}"])
+            step([$class: 'JUnitResultArchiver', testResults: "**/${clusterSetupResultsOut}"])
+          }
+
+          sh "docker stop ${setupContainer}"
+          sh "docker stop ${clusterSetupContainer}"
+          sh "docker stop ${deleteContainer}"
+
+          sh "docker rm -v ${setupContainer}"
+          sh "docker rm -v ${clusterSetupContainer}"
+          sh "docker rm -v ${deleteContainer}"
+
+          sh "docker rmi ${imageName}"
+        } // finally
+      } // dir
+    } // creds
+  } // wrap
+} // node

--- a/tests/validation/tests/v3_api/test_deploy_clusters.py
+++ b/tests/validation/tests/v3_api/test_deploy_clusters.py
@@ -1,0 +1,70 @@
+from .common import *  # NOQA
+from .test_rke_cluster_provisioning import create_and_validate_custom_host
+
+if_not_auto_deploy_rke = pytest.mark.skipif(
+    ast.literal_eval(
+        os.environ.get(
+            'RANCHER_TEST_DEPLOY_RKE', "False")) is False,
+    reason='auto deploy RKE tests are skipped')
+if_not_auto_deploy_eks = pytest.mark.skipif(
+    ast.literal_eval(
+        os.environ.get(
+            'RANCHER_TEST_DEPLOY_EKS', "False")) is False,
+    reason='auto deploy EKS tests are skipped')
+if_not_auto_deploy_gke = pytest.mark.skipif(
+    ast.literal_eval(
+        os.environ.get(
+            'RANCHER_TEST_DEPLOY_GKE', "False")) is False,
+    reason='auto deploy GKE tests are skipped')
+if_not_auto_deploy_aks = pytest.mark.skipif(
+    ast.literal_eval(
+        os.environ.get(
+            'RANCHER_TEST_DEPLOY_AKS', "False")) is False,
+    reason='auto deploy AKS tests are skipped')
+
+
+@if_not_auto_deploy_rke
+def test_deploy_rke():
+    print("Deploying RKE Clusters")
+
+    # TODO: Change kdm if env variable supplied (in module fixture)
+
+    rancher_version = get_setting_value_by_name('server-version')
+    if str(rancher_version).startswith('v2.2'):
+        k8s_v = get_setting_value_by_name('k8s-version-to-images')
+        default_k8s_versions = json.loads(k8s_v).keys()
+    else:
+        k8s_v = get_setting_value_by_name('k8s-versions-current')
+        default_k8s_versions = k8s_v.split(",")
+
+    # Create clusters
+    env_details = "env.CLUSTER_NAMES='"
+    for k8s_version in default_k8s_versions:
+        if env_details != "env.CLUSTER_NAMES='":
+            env_details += ","
+        print("Deploying RKE Cluster using kubernetes version {}".format(
+            k8s_version))
+        node_roles = [["controlplane"], ["etcd"],
+                      ["worker"], ["worker"], ["worker"]]
+        cluster, aws_nodes = create_and_validate_custom_host(
+            node_roles, random_cluster_name=True, version=k8s_version)
+        env_details += cluster.name
+        print("Successfully deployed {} with kubernetes version {}".format(
+            cluster.name, k8s_version))
+    env_details += "'"
+    create_config_file(env_details)
+
+
+@if_not_auto_deploy_eks
+def test_deploy_eks():
+    print("Deploying EKS Clusters")
+
+
+@if_not_auto_deploy_gke
+def test_deploy_gke():
+    print("Deploying GKE Clusters")
+
+
+@if_not_auto_deploy_aks
+def test_deploy_aks():
+    print("Deploying AKS Clusters")

--- a/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
+++ b/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
@@ -1014,23 +1014,26 @@ def register_host_after_delay(client, cluster, node_role, delay):
 
 
 def create_and_validate_custom_host(node_roles, random_cluster_name=False,
-                                    validate=True):
+                                    validate=True, version=K8S_VERSION):
+
     client = get_user_client()
     aws_nodes = \
         AmazonWebServices().create_multiple_nodes(
             len(node_roles), random_test_name(HOST_NAME))
 
     cluster, nodes = create_custom_host_from_nodes(aws_nodes, node_roles,
-                                                   random_cluster_name)
+                                                   random_cluster_name,
+                                                   version=version)
     if validate:
         cluster = validate_cluster(client, cluster,
                                    check_intermediate_state=False,
-                                   k8s_version=K8S_VERSION)
+                                   k8s_version=version)
     return cluster, nodes
 
 
 def create_custom_host_from_nodes(nodes, node_roles,
-                                  random_cluster_name=False, windows=False):
+                                  random_cluster_name=False, windows=False,
+                                  version=K8S_VERSION):
     client = get_user_client()
     cluster_name = random_name() if random_cluster_name \
         else evaluate_clustername()
@@ -1039,6 +1042,8 @@ def create_custom_host_from_nodes(nodes, node_roles,
         config = rke_config_windows
     else:
         config = rke_config
+    if version != "":
+        config["kubernetesVersion"] = version
 
     cluster = client.create_cluster(name=cluster_name,
                                     driver="rancherKubernetesEngine",


### PR DESCRIPTION
This initial PR introduces a new Jenkinsfile that has three functional stages:
1. Deploy Rancher server
2. Deploy clusters into that rancher server
3. Run validation tests in parallel on those clusters

This is initially working with RKE clusters and will be expanded for EKS, GKE, and AKS very soon. Custom Clusters can also be added eventually.