### PR TITLE
Add ingress class option to helm chart

### DIFF
--- a/chart/templates/issuer-letsEncrypt.yaml
+++ b/chart/templates/issuer-letsEncrypt.yaml
@@ -28,7 +28,7 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: nginx
+          class: {{ .Values.letsEncrypt.ingress.class }}
     {{- else if or (.Capabilities.APIVersions.Has "certmanager.k8s.io/v1alpha1") (and (eq (int $certmanagerVer._0) 0) (lt (int $certmanagerVer._1) 11)) }}
     http01: {}
     {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -65,7 +65,9 @@ ingress:
 letsEncrypt:
   # email: none@example.com
   environment: production
-
+  ingress:
+    # options: traefik, nginx
+    class: ""
 # If you are using certs signed by a private CA set to 'true' and set the 'tls-ca'
 # in the 'rancher-system' namespace. See the README.md for details
 privateCA: false


### PR DESCRIPTION
Removing ingress Class nginx so that any ingress controller can use the ingress defined for lets encrypt

https://github.com/rancher/rancher/issues/26323