### PR TITLE
Fix cannot use customized cluster domain

### DIFF
--- a/pkg/controllers/user/alert/manager/alertmanager.go
+++ b/pkg/controllers/user/alert/manager/alertmanager.go
@@ -115,7 +115,7 @@ func (m *AlertManager) GetAlertManagerEndpoint() (string, error) {
 		return "", fmt.Errorf("Failed to get service for alertmanager, %v", err)
 	}
 
-	url := "http://" + svc.Name + "." + svc.Namespace + ".svc.cluster.local:" + port
+	url := "http://" + svc.Name + "." + svc.Namespace + ".svc:" + port
 	return url, nil
 }
 

--- a/pkg/controllers/user/pipeline/controller/pipelineexecution/deploy.go
+++ b/pkg/controllers/user/pipeline/controller/pipelineexecution/deploy.go
@@ -292,7 +292,7 @@ func (l *Lifecycle) reconcileRegistryCrtSecret(clusterID, projectID string) erro
 			DNSNames: []string{
 				utils.RegistryName,
 				fmt.Sprintf("%s.%s", utils.RegistryName, ns),
-				fmt.Sprintf("%s.%s.svc.cluster.local", utils.RegistryName, ns),
+				fmt.Sprintf("%s.%s.svc", utils.RegistryName, ns),
 			},
 		},
 	}

--- a/pkg/controllers/user/pipeline/controller/pipelineexecution/registrycertsyncer.go
+++ b/pkg/controllers/user/pipeline/controller/pipelineexecution/registrycertsyncer.go
@@ -172,7 +172,7 @@ func (s *RegistryCertSyncer) generateCert(clusterID, projectID string) (*x509.Ce
 			DNSNames: []string{
 				utils.RegistryName,
 				fmt.Sprintf("%s.%s", utils.RegistryName, ns),
-				fmt.Sprintf("%s.%s.svc.cluster.local", utils.RegistryName, ns),
+				fmt.Sprintf("%s.%s.svc", utils.RegistryName, ns),
 			},
 		},
 	}


### PR DESCRIPTION
**Problem:**

Rancher Server triggered alerts doesn't work when using customized cluster domain.

**Solution:**

Remove the hard code `cluster.local`

**Related Issue:**

https://github.com/rancher/rancher/issues/26597