### PR TITLE
do not run package as part of CI

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -6,5 +6,5 @@ cd $(dirname $0)
 ./validate
 ./build
 ./test
-./package
+#./package
 ./chart/ci


### PR DESCRIPTION
Minimizing the number of calls to gh during the build process.
Will rely on docker publish plugin once merged and/or published for now.