### PR TITLE
dont run package during ci process

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -6,5 +6,5 @@ cd $(dirname $0)
 ./validate
 ./build
 ./test
-./package
+#./package
 ./chart/ci


### PR DESCRIPTION
Taking package step out of script/ci to minimize chance of rate limiting during publishing steps.