### PR TITLE
Support uppercase characters in version strings

### DIFF
--- a/pkg/catalog/manager/catalog_common.go
+++ b/pkg/catalog/manager/catalog_common.go
@@ -216,5 +216,6 @@ func getValidTemplateNameWithVersion(templateName, version string) string {
 	label := fmt.Sprintf("%s-%s", templateName, version)
 	label = strings.ReplaceAll(label, "+", "-")
 	label = strings.TrimSuffix(label, "-")
+	label = strings.ToLower(label)
 	return label
 }


### PR DESCRIPTION
Added support for uppercase characters in version strings by adding a ToLower in getValidTemplateNameWithVersion