### PR TITLE
support removing rancher ha setup from AWS

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -2537,7 +2537,7 @@ def delete_resource_in_AWS_by_prefix(resource_prefix):
     :param resource_prefix: the prefix of resource name
     :return: None
     """
-    # delete nodes
+    # delete nodes of both local and custom clusters
     node_filter = [{
         'Name': 'tag:Name',
         'Values': [resource_prefix + "-*"]

--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -16,6 +16,12 @@ from .common import set_url_password_token
 from .common import validate_cluster
 from .common import validate_cluster_state
 from .common import wait_until_active
+from .common import delete_cluster
+from .common import CATTLE_TEST_URL
+from .common import get_user_token
+from .common import ADMIN_PASSWORD
+from .common import get_client_for_token
+from .common import delete_resource_in_AWS_by_prefix
 from lib.aws import AmazonWebServices
 from .test_rke_cluster_provisioning import rke_config
 
@@ -27,6 +33,7 @@ test_run_id = random_test_name("auto")
 # if hostname is not provided, generate one ( to support onTag )
 RANCHER_HOSTNAME_PREFIX = os.environ.get("RANCHER_HOSTNAME_PREFIX",
                                          test_run_id)
+# RANCHER_HA_HOSTNAME is provided when installing Rancher into a k3s setup
 RANCHER_HA_HOSTNAME = os.environ.get(
     "RANCHER_HA_HOSTNAME", RANCHER_HOSTNAME_PREFIX + ".qa.rancher.space")
 resource_prefix = RANCHER_HA_HOSTNAME.split(".qa.rancher.space")[0]
@@ -48,6 +55,25 @@ RANCHER_HA_KUBECONFIG = os.environ.get("RANCHER_HA_KUBECONFIG")
 AWS_SSH_KEY_NAME = os.environ.get("AWS_SSH_KEY_NAME")
 kubeconfig_path = DATA_SUBDIR + "/kube_config_cluster-ha-filled.yml"
 export_cmd = "export KUBECONFIG=" + kubeconfig_path
+
+
+def test_remove_rancher_ha():
+    assert CATTLE_TEST_URL.endswith(".qa.rancher.space"), \
+        "the CATTLE_TEST_URL need to end with .qa.rancher.space"
+    admin_token = get_user_token("admin", ADMIN_PASSWORD)
+    client = get_client_for_token(admin_token)
+
+    # delete clusters except the local cluster
+    clusters = client.list_cluster(id_ne="local").data
+    print("deleting the following clusters: {}"
+          .format([cluster.name for cluster in clusters]))
+    for cluster in clusters:
+        print("deleting the following cluster : {}".format(cluster.name))
+        delete_cluster(client, cluster)
+
+    resource_prefix = \
+        CATTLE_TEST_URL.split(".qa.rancher.space")[0].split("//")[1]
+    delete_resource_in_AWS_by_prefix(resource_prefix)
 
 
 def test_install_rancher_ha(precheck_certificate_options):
@@ -79,7 +105,7 @@ def test_install_rancher_ha(precheck_certificate_options):
 
 def create_custom_cluster(admin_client):
     auth_url = RANCHER_SERVER_URL + \
-               "/v3-public/localproviders/local?action=login"
+        "/v3-public/localproviders/local?action=login"
     user, user_token = create_user(admin_client, auth_url)
 
     aws_nodes = \

--- a/tests/validation/tests/v3_api/test_import_k3s_cluster.py
+++ b/tests/validation/tests/v3_api/test_import_k3s_cluster.py
@@ -54,6 +54,10 @@ def test_import_k3s_multiple_control_cluster():
     cluster = create_rancher_cluster(client, k3s_clusterfilepath)
 
 
+def test_delete_k3s():
+    delete_resource_in_AWS_by_prefix(RANCHER_RESOURCE_NAME)
+
+
 def create_single_control_cluster():
     # Get URL and User_Token
     client = get_user_client()


### PR DESCRIPTION
This PR enables us to delete the rancher ha setup from AWS
it does the following:
- delete clusters within Rancher server 
- delete instances, target groups, load balancers, database, and route53 records in AWS

the only parameter needed is `CATTLE_TEST_URL`

Update:
add support for removing a k3s setup from AWS by resource name prefix  `RANCHER_RESOURCE_NAME`
