### PR TITLE
Always return errors if status is not ready

### DIFF
--- a/pkg/controllers/user/monitoring/clusterHandler.go
+++ b/pkg/controllers/user/monitoring/clusterHandler.go
@@ -118,8 +118,8 @@ func (ch *clusterHandler) doSync(cluster *mgmtv3.Cluster) error {
 		}
 		if !isReady {
 			mgmtv3.ClusterConditionMonitoringEnabled.Unknown(cluster)
-			mgmtv3.ClusterConditionMonitoringEnabled.Message(cluster, "prometheus is not ready")
-			return nil
+			mgmtv3.ClusterConditionMonitoringEnabled.Message(cluster, "prometheus pods are not ready to serve traffic")
+			return errors.New("clusterMonitoring: prometheus pods are not ready to serve traffic")
 		}
 
 		cluster.Status.MonitoringStatus.GrafanaEndpoint = fmt.Sprintf("/k8s/clusters/%s/api/v1/namespaces/%s/services/http:access-grafana:80/proxy/", cluster.Name, appTargetNamespace)


### PR DESCRIPTION
This commit fixed an issue where an error will always be returned so
that controller will try to re-sync the status on the next run