### PR TITLE
[2.4] Add to lower for name and version

### DIFF
--- a/pkg/catalog/manager/traverse.go
+++ b/pkg/catalog/manager/traverse.go
@@ -87,7 +87,7 @@ func (m *Manager) traverseAndUpdate(helm *helmlib.Helm, commit string, cmt *Cata
 
 		template := v3.CatalogTemplate{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: chart,
+				Name: strings.ToLower(chart),
 			},
 		}
 		template.Namespace = templateNamespace
@@ -110,7 +110,7 @@ func (m *Manager) traverseAndUpdate(helm *helmlib.Helm, commit string, cmt *Cata
 		var versions []v3.TemplateVersionSpec
 		for _, version := range metadata {
 			v := v3.TemplateVersionSpec{
-				Version: version.Version,
+				Version: strings.ToLower(version.Version),
 			}
 
 			files, err := helm.FetchLocalFiles(version)


### PR DESCRIPTION
**Backport**
------
**Problem**
catalog was storing template version with toLower but using original name and version that was not lower case to try to retrieve the templates

**Solution**
Add toLower on template name and template version so its stored and called the same way

**Issue**
#19615
