### PR TITLE
 Store userinfo in userattribute

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20200518163824-9e4ed62a470a
 	github.com/rancher/system-upgrade-controller v0.4.1-0.20200326220202-4655d4a551bd
-	github.com/rancher/types v0.0.0-20200518225435-048e08ca752c
+	github.com/rancher/types v0.0.0-20200522181207-0db99d3f04a9
 	github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f
 	github.com/rancher/wrangler-api v0.6.1-0.20200515193802-dcf70881b087
 	github.com/robfig/cron v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -919,8 +919,8 @@ github.com/rancher/steve v0.0.0-20200518163824-9e4ed62a470a/go.mod h1:48ecYu5vn9
 github.com/rancher/system-upgrade-controller v0.4.1-0.20200326220202-4655d4a551bd h1:h4VDCviV2Iixfk9SjUcfzq0l+pRsvadt2QSNuoQKfxE=
 github.com/rancher/system-upgrade-controller v0.4.1-0.20200326220202-4655d4a551bd/go.mod h1:8x2eK9Q5/1c2AC9xJtNFyAyjP9ytP4uPHhGA6wajIS0=
 github.com/rancher/types v0.0.0-20200326224235-0d1e1dcc8d55/go.mod h1:k5LoTlUpefw0eAzFSJsZI0gf+C4WE41yrc1jm/MS1nM=
-github.com/rancher/types v0.0.0-20200518225435-048e08ca752c h1:4rrj1gi7ztZXhqnrKuz3EaKtR3VzRQyJDQOu+5sunN0=
-github.com/rancher/types v0.0.0-20200518225435-048e08ca752c/go.mod h1:1f9IG3X8ZreqsCNnt60wcEpGC4p8k9qYp/UZflb1DYw=
+github.com/rancher/types v0.0.0-20200522181207-0db99d3f04a9 h1:ABRv+NNc2+ZvBJYJtZFT+4dDBl4P1GDpPMrJ5pn8kCE=
+github.com/rancher/types v0.0.0-20200522181207-0db99d3f04a9/go.mod h1:1f9IG3X8ZreqsCNnt60wcEpGC4p8k9qYp/UZflb1DYw=
 github.com/rancher/wrangler v0.1.4/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rancher/wrangler v0.4.1/go.mod h1:1cR91WLhZgkZ+U4fV9nVuXqKurWbgXcIReU4wnQvTN8=
 github.com/rancher/wrangler v0.5.0/go.mod h1:txHSBkPtVgNH/0pUCvdP0Ak0HptAOc9ffBmFxQnL4z4=

--- a/pkg/auth/providers/github/github_account.go
+++ b/pkg/auth/providers/github/github_account.go
@@ -16,6 +16,9 @@ type Account struct {
 	AvatarURL string `json:"avatar_url,omitempty"`
 	HTMLURL   string `json:"html_url,omitempty"`
 	Type      string `json:"type,omitempty"`
+	Email     string `json:"email,omitempty"`
+	Company   string `json:"company,omitempty"`
+	Location  string `json:"location,omitempty"`
 }
 
 //Team defines properties a team on github has
@@ -24,6 +27,12 @@ type Team struct {
 	Organization map[string]interface{} `json:"organization,omitempty"`
 	Name         string                 `json:"name,omitempty"`
 	Slug         string                 `json:"slug,omitempty"`
+}
+
+// EmailResponse is used for getting response from the emails endpoint. https://developer.github.com/v3/users/emails/#response .We only need the Email and Primary fields
+type EmailResponse struct {
+	Email   string `json:"email,omitempty"`
+	Primary bool   `json:"primary,omitempty"`
 }
 
 func (t *Team) toGithubAccount(url string, account *Account) {

--- a/pkg/auth/providers/github/github_client.go
+++ b/pkg/auth/providers/github/github_client.go
@@ -76,7 +76,27 @@ func (g *GClient) getUser(githubAccessToken string, config *v3.GithubConfig) (Ac
 		logrus.Errorf("Github getGithubUser: error unmarshalling response, err: %v", err)
 		return Account{}, err
 	}
-
+	// If the UserInfo endpoint does not return the email of a user, we need to query the emails endpoint
+	if githubAcct.Email == "" {
+		emailURL := g.getURL("USER_EMAIL", config)
+		emailResp, _, err := g.getFromGithub(githubAccessToken, emailURL)
+		if err != nil {
+			logrus.Errorf("Github getGithubUser: GET email url %v received error from github, err: %v", emailURL, err)
+			return Account{}, err
+		}
+		var userEmails []EmailResponse
+		if err := json.Unmarshal(emailResp, &userEmails); err != nil {
+			logrus.Errorf("Github getGithubUser: error unmarshalling email response, err: %v", err)
+			return Account{}, err
+		}
+		// This api endpoint doesn't accept query parameter to filter on primary, so we get all emails and loop through it
+		for _, userEmail := range userEmails {
+			if userEmail.Primary {
+				githubAcct.Email = userEmail.Email
+				break
+			}
+		}
+	}
 	return githubAcct, nil
 }
 
@@ -356,6 +376,8 @@ func (g *GClient) getURL(endpoint string, config *v3.GithubConfig) string {
 		toReturn = apiEndpoint + "/orgs/"
 	case "USER_INFO":
 		toReturn = apiEndpoint + "/user"
+	case "USER_EMAIL":
+		toReturn = apiEndpoint + "/user/emails"
 	case "ORG_INFO":
 		toReturn = apiEndpoint + "/user/orgs?per_page=1"
 	case "USER_PICTURE":

--- a/pkg/auth/providers/github/github_provider.go
+++ b/pkg/auth/providers/github/github_provider.go
@@ -377,6 +377,11 @@ func (g *ghProvider) toPrincipal(principalType string, acct Account, token *v3.T
 		if token != nil {
 			princ.Me = g.isThisUserMe(token.UserPrincipal, princ)
 		}
+		princ.ExtraInfo = map[string]string{
+			"Email":    acct.Email,
+			"Company":  acct.Company,
+			"Location": acct.Location,
+		}
 	} else {
 		princ.PrincipalType = "group"
 		if token != nil {

--- a/pkg/auth/providers/github/githubconfig_actions.go
+++ b/pkg/auth/providers/github/githubconfig_actions.go
@@ -85,7 +85,7 @@ func githubRedirectURL(hostname, clientID string, tls bool) string {
 	} else {
 		redirect = githubDefaultHostName
 	}
-	redirect = redirect + "/login/oauth/authorize?client_id=" + clientID
+	redirect = redirect + "/login/oauth/authorize?client_id=" + clientID + "&scope=read:org%20user:email"
 	return redirect
 }
 

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authn_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authn_types.go
@@ -80,6 +80,7 @@ type UserAttribute struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	UserName        string
+	UserPrincipal   Principal
 	GroupPrincipals map[string]Principals // the value is a []Principal, but code generator cannot handle slice as a value
 	LastRefresh     string
 	NeedsRefresh    bool

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -10063,6 +10063,7 @@ func (in *UserAttribute) DeepCopyInto(out *UserAttribute) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.UserPrincipal.DeepCopyInto(&out.UserPrincipal)
 	if in.GroupPrincipals != nil {
 		in, out := &in.GroupPrincipals, &out.GroupPrincipals
 		*out = make(map[string]Principals, len(*in))

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_user_attribute.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_user_attribute.go
@@ -14,6 +14,7 @@ const (
 	UserAttributeFieldRemoved         = "removed"
 	UserAttributeFieldUUID            = "uuid"
 	UserAttributeFieldUserName        = "userName"
+	UserAttributeFieldUserPrincipal   = "userPrincipal"
 )
 
 type UserAttribute struct {
@@ -29,4 +30,5 @@ type UserAttribute struct {
 	Removed         string               `json:"removed,omitempty" yaml:"removed,omitempty"`
 	UUID            string               `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 	UserName        string               `json:"userName,omitempty" yaml:"userName,omitempty"`
+	UserPrincipal   *Principal           `json:"userPrincipal,omitempty" yaml:"userPrincipal,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -496,7 +496,7 @@ github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1
 github.com/rancher/system-upgrade-controller/pkg/condition
 github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/scheme
 github.com/rancher/system-upgrade-controller/pkg/generated/clientset/versioned/typed/upgrade.cattle.io/v1
-# github.com/rancher/types v0.0.0-20200518225435-048e08ca752c
+# github.com/rancher/types v0.0.0-20200522181207-0db99d3f04a9
 github.com/rancher/types/apis/apiregistration.k8s.io/v1
 github.com/rancher/types/apis/apps/v1
 github.com/rancher/types/apis/autoscaling/v2beta2


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/27028
Depends on https://github.com/rancher/types/pull/1145

This commit adds a field UserInfo on to UserAttribute CRD. The fields in
UserInfo vary per provider and can be set as a map. For github we want to save the
company, location, email and github ID.
The userInfo api endpoint of github already returns all these fields.
This commit adds 3 new fields to github Account type so we can get the
values for company,location and email from [github api response](https://developer.github.com/v3/users/#response). And saves
all these fields on the userAttribute crd object of that user

Although userinfo endpoint returns email too, it only does so for emails
set on the profile. For other users we need to request email from user/emails
endpoint. So this commit also adds the scope "user:email" for this request.
Now on UI won't add the existing "read:org" scope either, the api will add that too