### PR TITLE
Avoid npe for cluster object in sync

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -66,7 +66,7 @@ type clusterDeploy struct {
 }
 
 func (cd *clusterDeploy) sync(key string, cluster *v3.Cluster) (runtime.Object, error) {
-	logrus.Tracef("clusterDeploy: sync called for cluster [%s], key [%s]", cluster.Name, key)
+	logrus.Tracef("clusterDeploy: sync called for key [%s]", key)
 	var (
 		err, updateErr error
 	)


### PR DESCRIPTION
Seen during build:

```
2020/05/21 14:26:27 [INFO] [mgmt-cluster-rbac-delete] Creating namespace local
2020/05/21 14:26:27 [INFO] [mgmt-cluster-rbac-delete] Creating Default project for cluster local
I0521 14:26:27.946919   28307 controller.go:606] quota admission added evaluator for: projects.management.cattle.io
E0521 14:26:27.948682   28269 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 4055 [running]:
github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x3677640, 0x6bb0200)
	/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
panic(0x3677640, 0x6bb0200)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/rancher/rancher/pkg/controllers/management/clusterdeploy.(*clusterDeploy).sync(0xc0008d24c0, 0x3e3ba81, 0x5, 0x0, 0xc001032380, 0x7fdaf8836460, 0x0, 0x0)
	/go/src/github.com/rancher/rancher/pkg/controllers/management/clusterdeploy/clusterdeploy.go:69 +0x37
github.com/rancher/rancher/vendor/github.com/rancher/types/apis/management.cattle.io/v3.(*clusterController).AddHandler.func1(0x3e3ba81, 0x5, 0x0, 0x0, 0xc001d1fad0, 0x3, 0x3, 0x0)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_controller.go:149 +0xe0
github.com/rancher/rancher/vendor/github.com/rancher/norman/controller.(*genericController).AddHandler.func1(0x3e3ba81, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/controller/generic_controller.go:57 +0x1e1
github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.SharedControllerHandlerFunc.OnChange(0xc001b32900, 0x3e3ba81, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/sharedcontroller.go:29 +0x4e
github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.(*sharedHandler).OnChange(0xc0017471a0, 0x3e3ba81, 0x5, 0x0, 0x0, 0x42e800, 0x0)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/sharedhandler.go:65 +0x150
github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.(*controller).syncHandler(0xc0000f3760, 0x3e3ba81, 0x5, 0xc002950690, 0xc0030e4d30)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/controller.go:208 +0x122
github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.(*controller).processSingleItem(0xc0000f3760, 0x33bb480, 0xc0054ccd20, 0x0, 0x0)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/controller.go:193 +0xf0
github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.(*controller).processNextWorkItem(0xc0000f3760, 0x40ae82)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/controller.go:170 +0x51
github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.(*controller).runWorker(0xc0000f3760)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/controller.go:159 +0x2b
github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc002ce2c00)
	/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5e
github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc002ce2c00, 0x4610920, 0xc0021934d0, 0xc00256ea01, 0xc0004b4120)
	/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xa3
github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc002ce2c00, 0x3b9aca00, 0x0, 0x1, 0xc0004b4120)
	/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0xe2
github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait.Until(0xc002ce2c00, 0x3b9aca00, 0xc0004b4120)
	/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90 +0x4d
created by github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.(*controller).run
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/controller.go:130 +0x35e
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x25d07c7]
goroutine 4055 [running]:
github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:55 +0x105
panic(0x3677640, 0x6bb0200)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/rancher/rancher/pkg/controllers/management/clusterdeploy.(*clusterDeploy).sync(0xc0008d24c0, 0x3e3ba81, 0x5, 0x0, 0xc001032380, 0x7fdaf8836460, 0x0, 0x0)
	/go/src/github.com/rancher/rancher/pkg/controllers/management/clusterdeploy/clusterdeploy.go:69 +0x37
github.com/rancher/rancher/vendor/github.com/rancher/types/apis/management.cattle.io/v3.(*clusterController).AddHandler.func1(0x3e3ba81, 0x5, 0x0, 0x0, 0xc001d1fad0, 0x3, 0x3, 0x0)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_cluster_controller.go:149 +0xe0
github.com/rancher/rancher/vendor/github.com/rancher/norman/controller.(*genericController).AddHandler.func1(0x3e3ba81, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/norman/controller/generic_controller.go:57 +0x1e1
github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.SharedControllerHandlerFunc.OnChange(0xc001b32900, 0x3e3ba81, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/sharedcontroller.go:29 +0x4e
github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.(*sharedHandler).OnChange(0xc0017471a0, 0x3e3ba81, 0x5, 0x0, 0x0, 0x42e800, 0x0)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/sharedhandler.go:65 +0x150
github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.(*controller).syncHandler(0xc0000f3760, 0x3e3ba81, 0x5, 0xc002950690, 0xc0030e4d30)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/controller.go:208 +0x122
github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.(*controller).processSingleItem(0xc0000f3760, 0x33bb480, 0xc0054ccd20, 0x0, 0x0)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/controller.go:193 +0xf0
github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.(*controller).processNextWorkItem(0xc0000f3760, 0x40ae82)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/controller.go:170 +0x51
github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.(*controller).runWorker(0xc0000f3760)
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/controller.go:159 +0x2b
github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc002ce2c00)
	/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5e
github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc002ce2c00, 0x4610920, 0xc0021934d0, 0xc00256ea01, 0xc0004b4120)
	/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xa3
github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc002ce2c00, 0x3b9aca00, 0x0, 0x1, 0xc0004b4120)
	/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0xe2
github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait.Until(0xc002ce2c00, 0x3b9aca00, 0xc0004b4120)
	/go/src/github.com/rancher/rancher/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90 +0x4d
created by github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller.(*controller).run
	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/lasso/pkg/controller/controller.go:130 +0x35e
I0521 14:26:38.103114   28307 leaderelection.go:288] failed to renew lease kube-system/cloud-controller-manager: failed to tryAcquireOrRenew context deadline exceeded
F0521 14:26:38.103165   28307 controllermanager.go:213] leaderelection lost
```