### PR TITLE
[2.4] Ingress with no path will cause a panic

### DIFF
--- a/pkg/controllers/user/endpoints/endpoints.go
+++ b/pkg/controllers/user/endpoints/endpoints.go
@@ -305,6 +305,9 @@ func convertIngressToServicePublicEndpointsMap(obj *extensionsv1beta1.Ingress, a
 		if rule.Host == ipDomain {
 			continue
 		}
+		if rule.HTTP == nil {
+			continue
+		}
 		for _, path := range rule.HTTP.Paths {
 			for port, proto := range ports {
 				if port == 80 {

--- a/pkg/controllers/user/ingress/ingress.go
+++ b/pkg/controllers/user/ingress/ingress.go
@@ -97,6 +97,9 @@ func generateExpectedServices(state map[string]string, obj *v1beta1.Ingress) (ma
 	rtn := map[string]ingressService{}
 	for _, r := range obj.Spec.Rules {
 		host := r.Host
+		if r.HTTP == nil {
+			continue
+		}
 		for _, b := range r.HTTP.Paths {
 			key := GetStateKey(obj.Name, obj.Namespace, host, b.Path, convert.ToString(b.Backend.ServicePort.IntVal))
 			if workloadIDs, ok := state[key]; ok {


### PR DESCRIPTION
If no path is set the HTTP field is nil causing a panic. The below yaml
cause Rancher to panic.

apiVersion: extensions/v1beta1
kind: Ingress
spec:
  rules:
  - host: hostname