### PR TITLE
Conditionally deploy rancher server for support matrix tests

### DIFF
--- a/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_support_matrix
+++ b/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_support_matrix
@@ -84,15 +84,21 @@ node {
 
           stage('Deploy Rancher Server') {
             try {
-              // deploy rancher server
-              sh "docker run --name ${setupContainer} -t --env-file ${envFile} " +
-                "${imageName} /bin/bash -c \'pytest -v -s --junit-xml=${setupResultsOut} " +
-                "${deployPytestOptions} ${testsDir}\'"
-              RANCHER_DEPLOYED = true
+              if (env.CATTLE_TEST_URL == "" && env.ADMIN_TOKEN == "" && env.USER_TOKEN == "") {
+                // deploy rancher server
+                sh "docker run --name ${setupContainer} -t --env-file ${envFile} " +
+                  "${imageName} /bin/bash -c \'pytest -v -s --junit-xml=${setupResultsOut} " +
+                  "${deployPytestOptions} ${testsDir}\'"
+                RANCHER_DEPLOYED = true
 
-              // copy file containing CATTLE_TEST_URL, ADMIN_TOKEN, USER_TOKEN and load into environment variables
-              sh "docker cp ${setupContainer}:${rootPath}${testsDir}${rancherConfig} ."
-              load rancherConfig
+                // copy file containing CATTLE_TEST_URL, ADMIN_TOKEN, USER_TOKEN and load into environment variables
+                sh "docker cp ${setupContainer}:${rootPath}${testsDir}${rancherConfig} ."
+                load rancherConfig
+              }
+              else {
+                echo "User Provided Rancher Server"
+                RANCHER_DEPLOYED = false
+              }
 
             } catch(err) {
               echo "Error: " + err

--- a/tests/validation/tests/v3_api/test_deploy_clusters.py
+++ b/tests/validation/tests/v3_api/test_deploy_clusters.py
@@ -60,7 +60,6 @@ def test_deploy_rke():
         env_details += cluster.name
         print("Successfully deployed {} with kubernetes version {}".format(
             cluster.name, k8s_version))
-    create_config_file(env_details)
 
 
 @if_not_auto_deploy_eks
@@ -162,4 +161,7 @@ def set_data(request):
     def fin():
         global env_details
         env_details += "'"
+        print("\n{}".format(env_details))
+        create_config_file(env_details)
+
     request.addfinalizer(fin)


### PR DESCRIPTION
- Added a check to be able to provide a rancher server instead of building one
- Fixed an error that was causing the cluster names to be incorrectly written to the environment variable