### PR TITLE
Remove dev-v2.3 branch setting in Dockerfile

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -16,7 +16,7 @@ ARG IMAGE_REPO=rancher
 ARG SYSTEM_CHART_DEFAULT_BRANCH=release-v2.3
 
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
-ARG RANCHER_METADATA_BRANCH=dev-v2.3
+ARG RANCHER_METADATA_BRANCH=
 
 ENV CATTLE_SYSTEM_CHART_DEFAULT_BRANCH=$SYSTEM_CHART_DEFAULT_BRANCH
 ENV CATTLE_HELM_VERSION v2.14.3-rancher1


### PR DESCRIPTION
The branch is automatically calculated in 
https://github.com/rancher/rancher/blob/release/v2.3/pkg/settings/setting.go#L158