### PR TITLE
Set KDM branch explicitly to release-v2.4

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -16,7 +16,7 @@ ENV HELM_VERSION v3.2.0
 ENV KUSTOMIZE_VERSION v3.5.4
 
 # kontainer-driver-metadata branch to be set for specific branch, logic at rancher/rancher/pkg/settings/setting.go
-ENV RANCHER_METADATA_BRANCH=dev-v2.4
+ENV RANCHER_METADATA_BRANCH=release-v2.4
 
 RUN apt-get update && \
     apt-get install -y gcc ca-certificates git wget curl vim less file xz-utils unzip && \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -16,7 +16,7 @@ ARG IMAGE_REPO=rancher
 ARG SYSTEM_CHART_DEFAULT_BRANCH=release-v2.4
 ARG DASHBOARD_BRANCH=release-2.4
 # kontainer-driver-metadata branch to be set for specific branch, logic at rancher/rancher/pkg/settings/setting.go
-ARG RANCHER_METADATA_BRANCH=dev-v2.4
+ARG RANCHER_METADATA_BRANCH=release-v2.4
 
 ENV CATTLE_SYSTEM_CHART_DEFAULT_BRANCH=$SYSTEM_CHART_DEFAULT_BRANCH
 ENV CATTLE_HELM_VERSION v2.16.5-rancher1


### PR DESCRIPTION
Should these be explicitly set to release-v2.4 or blank based on the settings logic? I'm thinking it should be blank, but figured I'd start with explicitly setting it since that's what we did with Release v2.4.3

https://github.com/rancher/rancher/blob/release/v2.4.4/pkg/settings/setting.go#L176