### PR TITLE
[Automation] - removing service account patch step from CIS 1.5 requirements

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -2639,13 +2639,9 @@ def configure_cis_requirements(aws_nodes, profile, node_roles, client,
     if profile == 'rke-cis-1.5':
         create_kubeconfig(cluster)
         network_policy_file = DATA_SUBDIR + "/default-allow-all.yaml"
-        account_update_file = DATA_SUBDIR + "/account_update.yaml"
         items = execute_kubectl_cmd("get namespaces -A")["items"]
         all_ns = [item["metadata"]["name"] for item in items]
         for ns in all_ns:
             execute_kubectl_cmd("apply -f {0} -n {1}".
                                 format(network_policy_file, ns))
-            execute_kubectl_cmd('patch serviceaccount default'
-                                ' -n {0} -p "$(cat {1})"'.
-                                format(ns, account_update_file))
     return cluster

--- a/tests/validation/tests/v3_api/resource/account_update.yaml
+++ b/tests/validation/tests/v3_api/resource/account_update.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: default
-automountServiceAccountToken: false


### PR DESCRIPTION
The latest CIS 1.5 changes include a fix for security scan id `5.1.5`. RKE based clusters won't need this step anymore as the service account patch will be applied to all namespaces except `default` and `kube-system` namespaces.