### PR TITLE
The env variable for system chart branch per release version will be set from package/Dockerfile only

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,7 +36,6 @@ steps:
     build_args:
     - ARCH=amd64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_BUILD_NUMBER}-head
-    - SYSTEM_CHART_DEFAULT_BRANCH=dev
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile
@@ -238,7 +237,6 @@ steps:
     build_args:
     - ARCH=arm64
     - VERSION=${DRONE_BRANCH/release\//}-${DRONE_BUILD_NUMBER}-head
-    - SYSTEM_CHART_DEFAULT_BRANCH=dev
     context: package/
     custom_dns: 1.1.1.1
     dockerfile: package/Dockerfile


### PR DESCRIPTION
Removing the env variable set by .drone.yml which was overriding the value for SYSTEM_CHART_DEFAULT_BRANCH  set in the package/Dockerfile for the head images.

It is easier to maintain this variable only at one place (package/Dockerfile) and change it in release branches at the same place as needed.

