### PR TITLE
flakey test: EKS subnet test failing because cluster is slow to create on arm

### DIFF
--- a/tests/integration/suite/test_cluster_defaults.py
+++ b/tests/integration/suite/test_cluster_defaults.py
@@ -2,7 +2,7 @@ import json
 import pytest
 from rancher import ApiError
 from .common import random_str
-from .conftest import wait_for
+from .conftest import wait_for, wait_for_condition
 
 
 @pytest.mark.skip(reason="cluster-defaults disabled")
@@ -65,6 +65,8 @@ def test_eks_cluster_immutable_subnets(admin_mc, remove_resource):
                 "subnet-02388a166136f98c4"
             ]})
     remove_resource(cluster)
+    wait_for_condition(
+        'DefaultProjectCreated', 'True', admin_mc.client, cluster)
 
     # try to edit cluster subnets
     with pytest.raises(ApiError) as e:


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/27258