### PR TITLE
remove the rebooting for instances that have Docker installed

### DIFF
--- a/tests/validation/lib/aws.py
+++ b/tests/validation/lib/aws.py
@@ -160,13 +160,6 @@ class AmazonWebServices(CloudProviderBase):
 
         if wait_for_ready:
             nodes = self.wait_for_nodes_state(nodes)
-            # hack for instances
-            if self.DOCKER_INSTALLED.lower() == 'true':
-                time.sleep(5)
-                self.reboot_nodes(nodes)
-                time.sleep(10)
-                nodes = self.wait_for_nodes_state(nodes)
-
             # wait for window nodes to come up so we can decrypt the password
             if ssh_user == "Administrator":
                 time.sleep(60 * 6)


### PR DESCRIPTION
The rebooting is not necessary and can be problematic, especially for instances using rancherOS