### PR TITLE
Revert "Reenable HTTP2"

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 
 	os.Unsetenv("SSH_AUTH_SOCK")
 	os.Unsetenv("SSH_AGENT_PID")
+	os.Setenv("DISABLE_HTTP2", "true")
 
 	if dm := os.Getenv("CATTLE_DEV_MODE"); dm != "" {
 		if dir, err := os.Getwd(); err == nil {


### PR DESCRIPTION
**Problem:**
Users, especially those with clusters consisting of >100 namespace and pods, are running into a "backed up reader" error when switching between projects

**Solution:**
Disable http2 because we believe it is causing issues with the way we use websockets. @ibuildthecloud will continue to look into http2 to see what we can do to avoid these problems when we do integrate it.

**Issue:**
https://github.com/rancher/rancher/issues/26624