### PR TITLE
Get resource type properly in formatter

### DIFF
--- a/pkg/api/customization/alert/alert_action.go
+++ b/pkg/api/customization/alert/alert_action.go
@@ -160,7 +160,7 @@ func (h *Handler) ProjectAlertRuleActionHandler(actionName string, action *types
 
 func canUpdateAlert(apiContext *types.APIContext, resource *types.RawResource) bool {
 	var groupName, resourceName string
-	switch apiContext.Type {
+	switch rbac.TypeFromContext(apiContext, resource) {
 	case client.ClusterAlertRuleType:
 		groupName, resourceName = v3.ClusterAlertRuleGroupVersionKind.Group, v3.ClusterAlertRuleResource.Name
 	case client.ProjectAlertRuleType:

--- a/pkg/api/customization/catalog/catalog.go
+++ b/pkg/api/customization/catalog/catalog.go
@@ -232,7 +232,7 @@ func (a ActionHandler) RefreshClusterCatalogActionHandler(actionName string, act
 
 func canUpdateCatalog(apiContext *types.APIContext, resource *types.RawResource) bool {
 	var groupName, resourceName string
-	switch apiContext.Type {
+	switch rbac.TypeFromContext(apiContext, resource) {
 	case client.CatalogType:
 		groupName, resourceName = v3.CatalogGroupVersionKind.Group, v3.CatalogResource.Name
 	case client.ClusterCatalogType:

--- a/pkg/api/customization/logging/action.go
+++ b/pkg/api/customization/logging/action.go
@@ -321,7 +321,7 @@ func addCertPrefixPath(certDir, file string) string {
 
 func canPerformLoggingAction(apiContext *types.APIContext, resource *types.RawResource, ns string) bool {
 	var groupName, resourceName string
-	switch apiContext.Type {
+	switch rbac.TypeFromContext(apiContext, resource) {
 	case mgmtv3client.ClusterLoggingType:
 		groupName, resourceName = mgmtv3.ClusterLoggingGroupVersionKind.Group, mgmtv3.ClusterLoggingResource.Name
 	case mgmtv3client.ProjectLoggingType:

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -135,3 +135,10 @@ func ObjFromContext(apiContext *types.APIContext, resource *types.RawResource) m
 	}
 	return obj
 }
+
+func TypeFromContext(apiContext *types.APIContext, resource *types.RawResource) string {
+	if resource == nil {
+		return apiContext.Type
+	}
+	return resource.Type
+}

--- a/pkg/rbac/common_test.go
+++ b/pkg/rbac/common_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/rancher/norman/types"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -81,6 +82,40 @@ func Test_BuildSubjectFromRTB(t *testing.T) {
 			t.Errorf("roletemplatebinding %v should return error", tcase.from)
 		} else if !tcase.iserr && !reflect.DeepEqual(tcase.to, output) {
 			t.Errorf("the subject %v from roletemplatebinding %v is mismatched, expect %v", output, tcase.from, tcase.to)
+		}
+	}
+}
+
+func Test_TypeFromContext(t *testing.T) {
+	type testCase struct {
+		apiContext   *types.APIContext
+		resource     *types.RawResource
+		expectedType string
+	}
+
+	testCases := []testCase{
+		{
+			apiContext: &types.APIContext{
+				Type: "catalog",
+			},
+			resource:     nil,
+			expectedType: "catalog",
+		},
+		{
+			apiContext: &types.APIContext{
+				Type: "subscribe",
+			},
+			resource: &types.RawResource{
+				Type: "catalog",
+			},
+			expectedType: "catalog",
+		},
+	}
+
+	for _, tcase := range testCases {
+		outputType := TypeFromContext(tcase.apiContext, tcase.resource)
+		if tcase.expectedType != outputType {
+			t.Errorf("resource type %s is mismatched, expect %s", outputType, tcase.expectedType)
 		}
 	}
 }


### PR DESCRIPTION
Address issues:
https://github.com/rancher/rancher/issues/27094
https://github.com/rancher/rancher/issues/27163
apicontext.Type equals to "subscribe" for websocket events. Handle this
case properly.