### PR TITLE
[forwardport] Cannot generate kubeconfig with cluster-scoped API tokens 

### DIFF
--- a/pkg/clusterrouter/lookup.go
+++ b/pkg/clusterrouter/lookup.go
@@ -15,7 +15,7 @@ func GetClusterID(req *http.Request) string {
 	parts := strings.Split(req.URL.Path, "/")
 	if len(parts) > 3 &&
 		parts[0] == "" &&
-		parts[1] == "k8s" &&
+		(parts[1] == "k8s" || parts[1] == "v3") &&
 		(parts[2] == "clusters" || parts[2] == "cluster") {
 		return parts[3]
 	}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/26482