### PR TITLE
Avoid calling a nil handler for SAML endpoints

### DIFF
--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -155,6 +155,8 @@ func InitializeSamlServiceProvider(configToSet *v3.SamlConfig, name string) erro
 	}
 	provider.clientState = &cookieStore
 
+	root.Use(responsewriter.ContentTypeOptions)
+
 	SamlProviders[name] = provider
 
 	switch name {
@@ -182,7 +184,6 @@ func InitializeSamlServiceProvider(configToSet *v3.SamlConfig, name string) erro
 
 func AuthHandler() http.Handler {
 	root = mux.NewRouter()
-	root.Use(responsewriter.ContentTypeOptions)
 
 	root.Methods("POST").Path("/v1-saml/ping/saml/acs").Name("PingACS")
 	root.Methods("GET").Path("/v1-saml/ping/saml/metadata").Name("PingMetadata")


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/27288

This issue was introduced by https://github.com/rancher/rancher/pull/23814.

This is what I found out regarding this issue. For the `v1-saml` endpoint, we create a new mux router, and add named routes for the providers. This does not involve setting a handler for any of these named routes. When `root.Use` is configuring a handler for this router, and the route is called, there is no handler on the router which causes the handler to be nil, and the code will panic.

Moving this to the part of the code where we specify the `HandlerFunc` for the named routes resolves this issue.

Based on my testing, the `root.Use(responsewriter.ContentTypeOptions)` on the main mux router is already used on all the requests, but after talking to Dan, this needs to be set on every handler.