### PR TITLE
KeySize needs to be handled as bits not bytes

### DIFF
--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -102,7 +102,7 @@ func Info(pemCerts, pemKey string) (*CertificateInfo, error) {
 		certInfo.ExpiresAt = cert.NotAfter
 		certInfo.IssuedAt = cert.NotBefore
 		certInfo.Issuer = cert.Issuer.CommonName
-		certInfo.KeySize = size
+		certInfo.KeySize = size * 8
 		certInfo.SerialNumber = cert.SerialNumber.String()
 		certInfo.Version = cert.Version
 


### PR DESCRIPTION
Having the impression, that the UI displays a certificate-key-length currently as a bytes-value, and not as bits. In the example shown below I've verified that the actual object in the Kubernetes-API is actually a 4096-bit RSA-based certificate.

![image](https://user-images.githubusercontent.com/460945/84589418-a8168c00-ae2e-11ea-802f-c2115e57a8dd.png)

When I get it right, the value is derived here in [rsaMatchAndKeySize:L61](https://github.com/rancher/rancher/blob/831e1bf5adfce06e97d1152d9f98927c81196a76/pkg/cert/cert.go#L61) as bytes - but then later not being converted to bits before returned to the UI.

PS: it's a certificate issued by _cert-manager_