### PR TITLE
Make rancher compatible with cri-o

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
       - image: {{ .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.rancherImagePullPolicy }}
         name: {{ template "rancher.name" . }}
+        capabilities:
+          add:
+            - MKNOD
         ports:
         - containerPort: 80
           protocol: TCP


### PR DESCRIPTION
Adding MKNOD capability has no effect in docker and containerd where it is enabled by default, but makes rancher compatible with cri-o.

Solves:
https://github.com/rancher/rancher/issues/27297
https://github.com/rancher/rancher/issues/27160