### PR TITLE
[Master] fix fluentd mounted docker root isn't updated

### DIFF
--- a/pkg/controllers/user/logging/deployer/appdeployer.go
+++ b/pkg/controllers/user/logging/deployer/appdeployer.go
@@ -164,6 +164,7 @@ func rancherLoggingApp(appCreator, systemProjectID, catalogID, driverDir, docker
 
 				//new version
 				"fluentd.fluentd-linux.enabled":                     "true",
+				"fluentd.fluentd-linux.cluster.dockerRoot":          dockerRoot,
 				"log-aggregator.log-aggregator-linux.enabled":       "true",
 				"log-aggregator.log-aggregator-linux.flexVolumeDir": driverDir,
 			},

--- a/pkg/controllers/user/logging/deployer/deployer.go
+++ b/pkg/controllers/user/logging/deployer/deployer.go
@@ -26,6 +26,7 @@ import (
 var (
 	fluentdSystemWriteKeys = []string{
 		"fluentd.cluster.dockerRoot",
+		"fluentd.fluentd-linux.cluster.dockerRoot",
 		"fluentd.fluentd-windows.enabled",
 	}
 	windowNodeLabel = labels.Set(map[string]string{"beta.kubernetes.io/os": "windows"}).AsSelector()


### PR DESCRIPTION
Problem:

When user updated docker root in cluster page, fluentd mounted docker root isn't updated. This bug is introduced in 2.3.
We need to update rancher logging's app config in this case.

Solution:
Update rancher logging app's config

Issue:
https://github.com/rancher/rancher/issues/21112