### PR TITLE
Automation - add wait for remove app in test_logging

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -1611,6 +1611,24 @@ def wait_for_app_to_active(client, app_id,
     return application
 
 
+def wait_for_app_to_remove(client, app_id,
+                           timeout=DEFAULT_MULTI_CLUSTER_APP_TIMEOUT):
+    start = time.time()
+    app_data = client.list_app(id=app_id).data
+    if len(app_data) == 0:
+        return
+    application = app_data[0]
+    while application.state == "removing" or application.state == "active":
+        if time.time() - start > timeout / 10:
+            raise AssertionError(
+                "Timed out waiting for app to not be installed")
+        time.sleep(.2)
+        app_data = client.list_app(id=app_id).data
+        if len(app_data) == 0:
+            break
+        application = app_data[0]
+
+
 def validate_response_app_endpoint(p_client, appId,
                                    timeout=DEFAULT_MULTI_CLUSTER_APP_TIMEOUT):
     ingress_list = p_client.list_ingress(namespaceId=appId).data

--- a/tests/validation/tests/v3_api/test_logging.py
+++ b/tests/validation/tests/v3_api/test_logging.py
@@ -8,6 +8,7 @@ from .common import create_project_and_ns
 from .common import get_project_client_for_token
 from .common import create_kubeconfig
 from .common import wait_for_app_to_active
+from .common import wait_for_app_to_remove
 from .common import CATTLE_TEST_URL
 from .common import USER_TOKEN
 
@@ -31,7 +32,7 @@ CATTLE_ClUSTER_LOGGING_FLUENTD_TEST = \
     CATTLE_TEST_URL + "/v3/clusterloggings?action=test"
 CATTLE_PROJECT_LOGGING_FLUENTD_TEST = \
     CATTLE_TEST_URL + "/v3/projectloggings?action=test"
-FLUENTD_AGGREGATOR_CATALOG_ID = "catalog://?catalog=library&template=fluentd-aggregator&version=0.3.0"
+FLUENTD_AGGREGATOR_CATALOG_ID = "catalog://?catalog=library&template=fluentd-aggregator&version=0.3.1"
 
 
 def test_send_log_to_fluentd(setup_fluentd_aggregator):
@@ -253,6 +254,8 @@ def create_cluster_logging(config):
 def delete_cluster_logging(cluster_logging):
     admin_client = namespace["admin_client"]
     admin_client.delete(cluster_logging)
+    sys_p_client = namespace["sys_p_client"]
+    wait_for_app_to_remove(sys_p_client, fluentd_app_name)
 
 
 def create_project_logging(config):
@@ -268,6 +271,8 @@ def create_project_logging(config):
 def delete_project_logging(project_logging):
     admin_client = namespace["admin_client"]
     admin_client.delete(project_logging)
+    sys_p_client = namespace["sys_p_client"]
+    wait_for_app_to_remove(sys_p_client, fluentd_app_name)
 
 
 @pytest.fixture(scope='module', autouse="True")


### PR DESCRIPTION
This fixes the `test_project_fluentd_target` test which was failing because `test_fluentd_target` removed the the fluentd app was part of the test teardown. Making the app to change state to `removing`.

When in `removing` state the `wait_for_app_to_active` check failed due to `app_data[0]` is empty when it checks for `deploying` state.

Here with this change we ensure wait until the app is removed during the test teardown before executing the next test.

Update the fluentd catalog template version to fix `test_send_log_to_fluentd` too.