### PR TITLE
[Master] Fix logging dry-run function return error

### DIFF
--- a/pkg/api/norman/customization/logging/action.go
+++ b/pkg/api/norman/customization/logging/action.go
@@ -41,12 +41,21 @@ var (
 	fluentdCommand      = "fluentd -q --dry-run -i "
 	cleanCertDirCommand = "rm -rf "
 	tmpCertDirPrefix    = "/fluentd/etc/config/tmpCert"
+	/* Default configuration <match fluent.*> in old version rancher/fluentd is deprecated,
+	append the latest configuration to avoid the warning from old version rancher/fluentd. */
+	fluentdLabelConfig = `
+<label @FLUENT_LOG>
+    <match fluent.*>
+      	@type null
+    </match>
+</label>`
 )
 
 type Handler struct {
 	clusterManager       *clustermanager.Manager
 	dialerFactory        dialer.Factory
 	appsGetter           projectv3.AppsGetter
+	appLister            projectv3.AppLister
 	projectLister        mgmtv3.ProjectLister
 	templateLister       mgmtv3.CatalogTemplateLister
 	projectLoggingLister mgmtv3.ProjectLoggingLister
@@ -57,6 +66,7 @@ func NewHandler(management *config.ScaledContext, clusterManager *clustermanager
 		clusterManager:       clusterManager,
 		dialerFactory:        management.Dialer,
 		appsGetter:           management.Project,
+		appLister:            management.Project.Apps("").Controller().Lister(),
 		projectLister:        management.Management.Projects("").Controller().Lister(),
 		templateLister:       management.Management.CatalogTemplates("").Controller().Lister(),
 		projectLoggingLister: management.Management.ProjectLoggings("").Controller().Lister(),
@@ -169,9 +179,9 @@ func (h *Handler) dryRunLoggingTarget(apiContext *types.APIContext, level, clust
 		return err
 	}
 
-	podLister := context.Core.Pods(loggingconfig.LoggingNamespace).Controller().Lister()
+	podLister := context.Core.Pods(metav1.NamespaceAll).Controller().Lister()
 	namespaces := context.Core.Namespaces(metav1.NamespaceAll)
-	testerDeployer := deployer.NewTesterDeployer(context.Management, h.appsGetter, h.projectLister, podLister, h.projectLoggingLister, namespaces, h.templateLister)
+	testerDeployer := deployer.NewTesterDeployer(context.Management, h.appsGetter, h.appLister, h.projectLister, podLister, h.projectLoggingLister, namespaces, h.templateLister)
 	configGenerator := configsyncer.NewConfigGenerator(metav1.NamespaceAll, h.projectLoggingLister, namespaces.Controller().Lister())
 
 	var dryRunConfigBuf []byte
@@ -208,6 +218,8 @@ func (h *Handler) dryRunLoggingTarget(apiContext *types.APIContext, level, clust
 		certificate, clientCert, clientKey = configsyncer.GetSSLConfig(new.Spec.LoggingTargets)
 		certScretKeyName = strings.Replace(projectID, ":", "_", -1)
 	}
+
+	dryRunConfigBuf = append(dryRunConfigBuf, []byte(fluentdLabelConfig)...)
 
 	certificatePath = addCertPrefixPath(tmpCertDir, loggingconfig.SecretDataKeyCa(level, certScretKeyName))
 	clientCertPath = addCertPrefixPath(tmpCertDir, loggingconfig.SecretDataKeyCert(level, certScretKeyName))

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -86,6 +86,7 @@ func Register(ctx context.Context, cluster *config.UserContext, clusterRec *mana
 }
 
 func RegisterFollower(ctx context.Context, cluster *config.UserContext, kubeConfigGetter common.KubeConfigGetter, clusterManager healthsyncer.ClusterControllerLifecycle) error {
+	cluster.Core.Pods("").Controller()
 	cluster.Core.Namespaces("").Controller()
 	cluster.Core.Services("").Controller()
 	cluster.RBAC.ClusterRoleBindings("").Controller()

--- a/pkg/controllers/managementuser/logging/deployer/testerdeployer.go
+++ b/pkg/controllers/managementuser/logging/deployer/testerdeployer.go
@@ -27,9 +27,10 @@ type TesterDeployer struct {
 	systemAccountManager *systemaccount.Manager
 }
 
-func NewTesterDeployer(mgmtCtx *config.ManagementContext, appsGetter projectv3.AppsGetter, projectLister mgmtv3.ProjectLister, podLister v1.PodLister, projectLoggingLister mgmtv3.ProjectLoggingLister, namespaces v1.NamespaceInterface, templateLister mgmtv3.CatalogTemplateLister) *TesterDeployer {
+func NewTesterDeployer(mgmtCtx *config.ManagementContext, appsGetter projectv3.AppsGetter, appLister projectv3.AppLister, projectLister mgmtv3.ProjectLister, podLister v1.PodLister, projectLoggingLister mgmtv3.ProjectLoggingLister, namespaces v1.NamespaceInterface, templateLister mgmtv3.CatalogTemplateLister) *TesterDeployer {
 	appDeployer := &AppDeployer{
 		AppsGetter: appsGetter,
+		AppsLister: appLister,
 		Namespaces: namespaces,
 		PodLister:  podLister,
 	}


### PR DESCRIPTION
Problem:
1. This PR bring in some crash https://github.com/rancher/rancher/commit/4dcd2b751f1b2fecf21351b082935f8e12ca9446. it adds appLister but forget to init it here https://github.com/rancher/rancher/blob/master/pkg/controllers/user/logging/deployer/testerdeployer.go#L30. Then when we use dry run, and server got crash, return 500, but UI still show success.

2. After fluentd 1.x <match fluent.**> will get deprecated warning.

Solution:
1. Init appLister
2. Add latest fluentd suggested format <label @FLUENT_LOG>

Issue:
https://github.com/rancher/rancher/issues/26543