### PR TITLE
[2.4.6] Fix logging dry-run function return error

### DIFF
--- a/pkg/controllers/user/controllers.go
+++ b/pkg/controllers/user/controllers.go
@@ -98,6 +98,7 @@ func Register(ctx context.Context, cluster *config.UserContext, clusterRec *mana
 }
 
 func RegisterFollower(ctx context.Context, cluster *config.UserContext, kubeConfigGetter common.KubeConfigGetter, clusterManager healthsyncer.ClusterControllerLifecycle) error {
+	cluster.Core.Pods("").Controller()
 	cluster.Core.Namespaces("").Controller()
 	cluster.Core.Services("").Controller()
 	cluster.RBAC.ClusterRoleBindings("").Controller()

--- a/pkg/controllers/user/logging/deployer/testerdeployer.go
+++ b/pkg/controllers/user/logging/deployer/testerdeployer.go
@@ -26,9 +26,10 @@ type TesterDeployer struct {
 	systemAccountManager *systemaccount.Manager
 }
 
-func NewTesterDeployer(mgmtCtx *config.ManagementContext, appsGetter projectv3.AppsGetter, projectLister mgmtv3.ProjectLister, podLister v1.PodLister, projectLoggingLister mgmtv3.ProjectLoggingLister, namespaces v1.NamespaceInterface, templateLister mgmtv3.CatalogTemplateLister) *TesterDeployer {
+func NewTesterDeployer(mgmtCtx *config.ManagementContext, appsGetter projectv3.AppsGetter, appLister projectv3.AppLister, projectLister mgmtv3.ProjectLister, podLister v1.PodLister, projectLoggingLister mgmtv3.ProjectLoggingLister, namespaces v1.NamespaceInterface, templateLister mgmtv3.CatalogTemplateLister) *TesterDeployer {
 	appDeployer := &AppDeployer{
 		AppsGetter: appsGetter,
+		AppsLister: appLister,
 		Namespaces: namespaces,
 		PodLister:  podLister,
 	}


### PR DESCRIPTION
Problem:
1. This PR brings in some crash https://github.com/rancher/rancher/commit/4dcd2b751f1b2fecf21351b082935f8e12ca9446. It added appLister but forgot to init it here https://github.com/rancher/rancher/blob/master/pkg/controllers/user/logging/deployer/testerdeployer.go#L30. Then when we do a dry run, server crashes and returns 500, but UI still shows a success.
2. Dry run fails because it can't find the fluentd-test pod. The reason is that userContext from clustermanager does not start controller now, so we can't get pods from controller.
3. After fluentd 1.x <match fluent.**> will get deprecated warning.

Solution:
1. Init appLister
2. Use pod interface client instead of pod controller
3. Add latest fluentd suggested format <label @FLUENT_LOG>

Issue:
https://github.com/rancher/rancher/issues/26543

Master PR:

https://github.com/rancher/rancher/pull/27660