### PR TITLE
Do not require "local://" principal on users

### DIFF
--- a/pkg/auth/providers/common/usermanager.go
+++ b/pkg/auth/providers/common/usermanager.go
@@ -619,7 +619,18 @@ func userByPrincipal(obj interface{}) ([]string, error) {
 		return []string{}, nil
 	}
 
-	return u.PrincipalIDs, nil
+	match := false
+	for _, id := range u.PrincipalIDs {
+		if strings.HasPrefix(id, "local://") {
+			match = true
+			break
+		}
+	}
+
+	if match {
+		return u.PrincipalIDs, nil
+	}
+	return append(u.PrincipalIDs, "local://"+u.Name), nil
 }
 
 func crtbsByPrincipalAndUser(obj interface{}) ([]string, error) {

--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -141,6 +141,9 @@ func getLocalPrincipalID(user *v3.User) string {
 			principalID = p
 		}
 	}
+	if principalID == "" {
+		return Name + "://" + user.Name
+	}
 	return principalID
 }
 


### PR DESCRIPTION
Do enable a more "gitops" friendly flow we'd rather not prefer this
redudany field was required.  If one uses kubectl apply to create a
user with an external principal and then the controller adds
"local://" is modifies the principal list which is hard to reconcile
later on a subsequent apply.