### PR TITLE
Correct the OwnerReferences of Role and Rolebindings to use correct resource Kind and apiVersion

### DIFF
--- a/pkg/controllers/management/cloudcredential/controller.go
+++ b/pkg/controllers/management/cloudcredential/controller.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/rancher/rancher/pkg/controllers/management/rbac"
+	typesv1 "github.com/rancher/types/apis/core/v1"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
 	"github.com/rancher/types/namespace"
@@ -41,7 +42,7 @@ func (n *Controller) ccSync(key string, cloudCredential *v1.Secret) (runtime.Obj
 		return cloudCredential, fmt.Errorf("cloud credential %v has no creatorId annotation", cloudCredential.Name)
 	}
 	if err := rbac.CreateRoleAndRoleBinding(
-		rbac.CloudCredentialResource, cloudCredential.Name, namespace.GlobalNamespace, "v1", creatorID, []string{"*"}, cloudCredential.UID, []v3.Member{},
+		rbac.CloudCredentialResource, typesv1.SecretResource.Kind, cloudCredential.Name, namespace.GlobalNamespace, "v1", creatorID, []string{"*"}, cloudCredential.UID, []v3.Member{},
 		n.managementContext); err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/management/clustertemplate/clustertemplate_rbac.go
+++ b/pkg/controllers/management/clustertemplate/clustertemplate_rbac.go
@@ -64,8 +64,8 @@ func (ct *clusterTemplateController) sync(key string, clusterTemplate *v3.Cluste
 		return clusterTemplate, fmt.Errorf("clusterTemplate %v has no creatorId annotation", metaAccessor.GetName())
 	}
 
-	if err := rbac.CreateRoleAndRoleBinding(rbac.ClusterTemplateResource, clusterTemplate.Name, namespace.GlobalNamespace,
-		rbac.RancherManagementAPIVersion, creatorID, []string{rbac.RancherManagementAPIVersion},
+	if err := rbac.CreateRoleAndRoleBinding(rbac.ClusterTemplateResource, v3.ClusterTemplateGroupVersionKind.Kind, clusterTemplate.Name, namespace.GlobalNamespace,
+		rbac.RancherManagementAPIVersion, creatorID, []string{rbac.RancherManagementAPIGroup},
 		clusterTemplate.UID,
 		clusterTemplate.Spec.Members, ct.managementContext); err != nil {
 		return nil, err
@@ -105,8 +105,8 @@ func (ctr *clusterTemplateRevisionController) sync(key string, clusterTemplateRe
 	if err != nil {
 		return nil, err
 	}
-	if err := rbac.CreateRoleAndRoleBinding(rbac.ClusterTemplateRevisionResource, clusterTemplateRev.Name, namespace.GlobalNamespace,
-		rbac.RancherManagementAPIVersion, creatorID, []string{rbac.RancherManagementAPIVersion},
+	if err := rbac.CreateRoleAndRoleBinding(rbac.ClusterTemplateRevisionResource, v3.ClusterTemplateRevisionGroupVersionKind.Kind, clusterTemplateRev.Name, namespace.GlobalNamespace,
+		rbac.RancherManagementAPIVersion, creatorID, []string{rbac.RancherManagementAPIGroup},
 		clusterTemplateRev.UID,
 		clusterTemp.Spec.Members, ctr.managementContext); err != nil {
 		return nil, err

--- a/pkg/controllers/management/globaldns/globaldns_handler.go
+++ b/pkg/controllers/management/globaldns/globaldns_handler.go
@@ -58,8 +58,8 @@ func (n *GDController) sync(key string, obj *v3.GlobalDns) (runtime.Object, erro
 		return nil, fmt.Errorf("GlobalDNS %v has no creatorId annotation", metaAccessor.GetName())
 	}
 
-	if err := rbac.CreateRoleAndRoleBinding(rbac.GlobalDNSResource, obj.Name, namespace.GlobalNamespace,
-		rbac.RancherManagementAPIVersion, creatorID, []string{rbac.RancherManagementAPIVersion},
+	if err := rbac.CreateRoleAndRoleBinding(rbac.GlobalDNSResource, v3.GlobalDnsGroupVersionKind.Kind, obj.Name, namespace.GlobalNamespace,
+		rbac.RancherManagementAPIVersion, creatorID, []string{rbac.RancherManagementAPIGroup},
 		obj.UID, obj.Spec.Members, n.managementContext); err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/management/globaldns/globaldnsprovider_catalog_launcher.go
+++ b/pkg/controllers/management/globaldns/globaldnsprovider_catalog_launcher.go
@@ -70,8 +70,8 @@ func (n *ProviderCatalogLauncher) sync(key string, obj *v3.GlobalDNSProvider) (r
 		return nil, fmt.Errorf("GlobalDNS %v has no creatorId annotation", metaAccessor.GetName())
 	}
 
-	if err := rbac.CreateRoleAndRoleBinding(rbac.GlobalDNSProviderResource, obj.Name, namespace.GlobalNamespace,
-		rbac.RancherManagementAPIVersion, creatorID, []string{rbac.RancherManagementAPIVersion},
+	if err := rbac.CreateRoleAndRoleBinding(rbac.GlobalDNSProviderResource, v3.GlobalDNSProviderGroupVersionKind.Kind, obj.Name, namespace.GlobalNamespace,
+		rbac.RancherManagementAPIVersion, creatorID, []string{rbac.RancherManagementAPIGroup},
 		obj.UID, obj.Spec.Members, n.managementContext); err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/management/multiclusterapp/handler_multiclusterapp.go
+++ b/pkg/controllers/management/multiclusterapp/handler_multiclusterapp.go
@@ -157,8 +157,8 @@ func (mc *MCAppController) sync(key string, mcapp *v3.MultiClusterApp) (runtime.
 		}
 	}
 
-	if err := rbac.CreateRoleAndRoleBinding(rbac.MultiClusterAppResource, mcapp.Name, namespace.GlobalNamespace,
-		rbac.RancherManagementAPIVersion, creatorID, []string{rbac.RancherManagementAPIVersion},
+	if err := rbac.CreateRoleAndRoleBinding(rbac.MultiClusterAppResource, v3.MultiClusterAppGroupVersionKind.Kind, mcapp.Name, namespace.GlobalNamespace,
+		rbac.RancherManagementAPIVersion, creatorID, []string{rbac.RancherManagementAPIGroup},
 		mcapp.UID,
 		mcapp.Spec.Members, mc.managementContext); err != nil {
 		return nil, err
@@ -172,8 +172,8 @@ func (mc *MCAppController) sync(key string, mcapp *v3.MultiClusterApp) (runtime.
 	}
 	for _, rev := range revisions {
 		if err := rbac.CreateRoleAndRoleBinding(
-			rbac.MultiClusterAppRevisionResource, rev.Name, namespace.GlobalNamespace, rbac.RancherManagementAPIVersion,
-			creatorID, []string{rbac.RancherManagementAPIVersion}, rev.UID, mcapp.Spec.Members,
+			rbac.MultiClusterAppRevisionResource, v3.MultiClusterAppRevisionGroupVersionKind.Kind, rev.Name, namespace.GlobalNamespace, rbac.RancherManagementAPIVersion,
+			creatorID, []string{rbac.RancherManagementAPIGroup}, rev.UID, mcapp.Spec.Members,
 			mc.managementContext); err != nil {
 			return nil, err
 		}
@@ -205,8 +205,8 @@ func (r *MCAppRevisionController) sync(key string, mcappRevision *v3.MultiCluste
 	}
 
 	if err := rbac.CreateRoleAndRoleBinding(
-		rbac.MultiClusterAppRevisionResource, mcappRevision.Name, namespace.GlobalNamespace, rbac.RancherManagementAPIVersion,
-		creatorID, []string{rbac.RancherManagementAPIVersion}, mcappRevision.UID, mcapp.Spec.Members,
+		rbac.MultiClusterAppRevisionResource, v3.MultiClusterAppRevisionGroupVersionKind.Kind, mcappRevision.Name, namespace.GlobalNamespace, rbac.RancherManagementAPIVersion,
+		creatorID, []string{rbac.RancherManagementAPIGroup}, mcappRevision.UID, mcapp.Spec.Members,
 		r.managementContext); err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/management/nodetemplate/nodetemplate.go
+++ b/pkg/controllers/management/nodetemplate/nodetemplate.go
@@ -100,8 +100,8 @@ func (nt *nodeTemplateController) sync(key string, nodeTemplate *v3.NodeTemplate
 	}
 
 	// Create Role and RBs if they do not exist
-	if err := rbac.CreateRoleAndRoleBinding(rbac.NodeTemplateResource, nodeTemplate.Name, namespace.NodeTemplateGlobalNamespace,
-		rbac.RancherManagementAPIVersion, creatorID, []string{rbac.RancherManagementAPIVersion},
+	if err := rbac.CreateRoleAndRoleBinding(rbac.NodeTemplateResource, v3.NodeTemplateGroupVersionKind.Kind, nodeTemplate.Name, namespace.NodeTemplateGlobalNamespace,
+		rbac.RancherManagementAPIVersion, creatorID, []string{rbac.RancherManagementAPIGroup},
 		nodeTemplate.UID,
 		[]v3.Member{}, nt.mgmtCtx); err != nil {
 		return nil, err


### PR DESCRIPTION
[ForwardPort] for PR https://github.com/rancher/rancher/pull/27445

 This PR fixes the OwnerReferences of Role and Rolebindings created for ClusterTemplate, ClusterTemplateRevision, GlobalDNS, MulticlusterApp and NodeTemplate resources.

The OwnerReferences were using wrong kind and apiVersion for these resources.
https://github.com/rancher/rancher/issues/26861