### PR TITLE
Scope redeployAgent repo check for cluster repo

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -172,16 +172,16 @@ func redeployAgent(cluster *v3.Cluster, desiredAgent, desiredAuth string, desire
 	repoChange := false
 	if cluster.Spec.RancherKubernetesEngineConfig != nil {
 		if cluster.Status.AppliedSpec.RancherKubernetesEngineConfig != nil {
-			desiredRepo := util.GetPrivateRepo(cluster)
-			var appliedRepo *v3.PrivateRegistry
 			if len(cluster.Status.AppliedSpec.RancherKubernetesEngineConfig.PrivateRegistries) > 0 {
-				appliedRepo = &cluster.Status.AppliedSpec.RancherKubernetesEngineConfig.PrivateRegistries[0]
-			}
-			if desiredRepo != nil && appliedRepo != nil && !reflect.DeepEqual(desiredRepo, appliedRepo) {
-				repoChange = true
-			}
-			if (desiredRepo == nil && appliedRepo != nil) || (desiredRepo != nil && appliedRepo == nil) {
-				repoChange = true
+				desiredRepo := util.GetPrivateRepo(cluster)
+				appliedRepo := &cluster.Status.AppliedSpec.RancherKubernetesEngineConfig.PrivateRegistries[0]
+
+				if desiredRepo != nil && appliedRepo != nil && !reflect.DeepEqual(desiredRepo, appliedRepo) {
+					repoChange = true
+				}
+				if (desiredRepo == nil && appliedRepo != nil) || (desiredRepo != nil && appliedRepo == nil) {
+					repoChange = true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/27218

appliedRepo is only set when private_registries is configured in the cluster config, else it is nil. The check for nil is always hit when the Rancher setup is configured to only use system default registry (when the registry does not require auth), so redeployAgent will always be hit in case where Rancher is configured with only a system default registry. This change scopes the repoChange check to clusters that have a private registry configured in the cluster (and appliedRepo is not nil). When system default registry changes, this will be caught by the logic in imageChange, as this uses the full repo path to the image (including the system default registry)