### PR TITLE
Change app status if true

### DIFF
--- a/pkg/controllers/user/helm/controller.go
+++ b/pkg/controllers/user/helm/controller.go
@@ -228,7 +228,7 @@ func (l *Lifecycle) Updated(obj *v3.App) (runtime.Object, error) {
 func (l *Lifecycle) DeployApp(obj *v3.App) (*v3.App, error) {
 	obj = obj.DeepCopy()
 	var err error
-	if !v3.AppConditionInstalled.IsUnknown(obj) {
+	if v3.AppConditionInstalled.IsTrue(obj) {
 		v3.AppConditionInstalled.Unknown(obj)
 		// update status in the UI
 		obj, err = l.AppGetter.Apps("").Update(obj)


### PR DESCRIPTION
**Problem**
When `helm template` or `helm install` fails, the app continues to retry installing and the error backoff never happens so disk space fills up. This appears to be occurring due to the app status getting set to false and then set back to unknown which updates the app continuously.

**Solution**
Only change the app install status back to unknown if the app install status is true. This will allow for the controller back off to occur

**Issue**
#25383 