### PR TITLE
Qualify agent images in DS and deployment for cattle-*-agent pods

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -17,7 +17,7 @@ var (
 	provider       Provider
 	InjectDefaults string
 
-	AgentImage                        = NewSetting("agent-image", "rancher/rancher-agent:master-head")
+	AgentImage                        = NewSetting("agent-image", "docker.io/rancher/rancher-agent:master-head")
 	AuthImage                         = NewSetting("auth-image", v3.ToolsSystemImages.AuthSystemImages.KubeAPIAuth)
 	AuthorizationCacheTTLSeconds      = NewSetting("authorization-cache-ttl-seconds", "10")
 	AuthorizationDenyCacheTTLSeconds  = NewSetting("authorization-deny-cache-ttl-seconds", "10")


### PR DESCRIPTION
cri-o doesn't support unqualified images by default, this fixes the problem for cattle-*-agent pods.

Fixes https://github.com/rancher/rancher/issues/27754