### PR TITLE
[2.4] get nodename from v1.Node

### DIFF
--- a/pkg/controllers/user/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/user/nodesyncer/nodessyncer.go
@@ -57,6 +57,7 @@ type nodeDrain struct {
 	systemAccountManager *systemaccount.Manager
 	clusterLister        v3.ClusterLister
 	machines             v3.NodeInterface
+	nodeLister           v1.NodeLister
 	ctx                  context.Context
 	nodesToContext       map[string]context.CancelFunc
 }
@@ -89,6 +90,7 @@ func Register(ctx context.Context, cluster *config.UserContext, kubeConfigGetter
 		systemAccountManager: systemaccount.NewManager(cluster.Management),
 		clusterLister:        cluster.Management.Management.Clusters("").Controller().Lister(),
 		machines:             cluster.Management.Management.Nodes(cluster.ClusterName),
+		nodeLister:           cluster.Core.Nodes("").Controller().Lister(),
 		ctx:                  ctx,
 		nodesToContext:       map[string]context.CancelFunc{},
 	}


### PR DESCRIPTION
nodename on v3.node changes depending on how it's registered, and it currently fails when cloud provider is enabled. Using v1.node name to run `kubectl drain` resolves the issue. 

https://github.com/rancher/rancher/issues/23333 