### PR TITLE
Move python linting to validate

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -42,5 +42,5 @@ done
 echo Running tests
 
 cd $(dirname $0)/../tests/integration
-tox -- -m "not nonparallel" -n $(nproc)
-tox -- -m nonparallel
+tox -e rancher -- -m "not nonparallel" -n $(nproc)
+tox -e rancher -- -m nonparallel

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,7 +1,12 @@
 #!/bin/bash
 set -e
 
-cd $(dirname $0)/..
+echo Running: flake8 python linting
+
+cd $(dirname $0)/../tests/integration
+tox -e flake8
+
+cd ../..
 
 if ! command -v golangci-lint; then	echo Running: go fmt	
     echo Skipping validation: no golangci-lint available	test -z "$(go fmt ./... | tee /dev/stderr)"

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -1,12 +1,14 @@
 [tox]
-envlist=flake8, py38
-
-[testenv]
-deps=-rrequirements.txt
-changedir=suite
-commands=pytest --durations=20 -rfE -v {posargs}
+envlist = flake8,rancher
 
 [testenv:flake8]
+basepython = python3.8
 deps=-rrequirements.txt
 changedir={toxinidir}
 commands=flake8 suite
+
+[testenv:rancher]
+basepython = python3.8
+deps=-rrequirements.txt
+changedir=suite
+commands=pytest --durations=20 -rfE -v {posargs}


### PR DESCRIPTION
Problem: python linting errors only showed up after basically everything was already run, meaning it could run for 10+ minutes unnecessarily

Root cause: Tests were merged into this repo as is, meaning linting and testing are run in two envs but in one go. Another issue was that the tests still continued to run, even when flake8 failed on linting

Solution: Move linting of python to `validate`, similar to Go linting, so that code formatting issues are caught directly