### PR TITLE
[2.4] Do not turn off monitoring/alerting from templateRevision during cluster updates

### DIFF
--- a/pkg/api/store/cluster/cluster_store.go
+++ b/pkg/api/store/cluster/cluster_store.go
@@ -480,6 +480,19 @@ func (r *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 			return nil, httperror.NewAPIError(httperror.InvalidOption, fmt.Sprintf("cannot update cluster, cluster cannot be changed to a new clusterTemplate"))
 		}
 
+		if !clusterTemplateRevision.Spec.ClusterConfig.EnableClusterMonitoring {
+			//this template will turn off ClusterMonitoring, ensure that the cluster is not using Monitoring
+			if convert.ToBool(existingCluster[managementv3.ClusterSpecFieldEnableClusterMonitoring]) {
+				return nil, httperror.NewAPIError(httperror.InvalidOption, fmt.Sprintf("cannot update cluster to this RKE template revision, since it will turn off the cluster monitoring"))
+			}
+		}
+
+		if !clusterTemplateRevision.Spec.ClusterConfig.EnableClusterAlerting {
+			if convert.ToBool(existingCluster[managementv3.ClusterSpecFieldEnableClusterAlerting]) {
+				return nil, httperror.NewAPIError(httperror.InvalidOption, fmt.Sprintf("cannot update cluster to this RKE template revision, since it will turn off the cluster alerting"))
+			}
+		}
+
 		clusterConfigSchema := apiContext.Schemas.Schema(&managementschema.Version, managementv3.ClusterSpecBaseType)
 		clusterUpdate, err := loadDataFromTemplate(clusterTemplateRevision, clusterTemplate, data, clusterConfigSchema, existingCluster)
 		if err != nil {

--- a/pkg/api/store/cluster/cluster_store.go
+++ b/pkg/api/store/cluster/cluster_store.go
@@ -480,19 +480,6 @@ func (r *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 			return nil, httperror.NewAPIError(httperror.InvalidOption, fmt.Sprintf("cannot update cluster, cluster cannot be changed to a new clusterTemplate"))
 		}
 
-		if !clusterTemplateRevision.Spec.ClusterConfig.EnableClusterMonitoring {
-			//this template will turn off ClusterMonitoring, ensure that the cluster is not using Monitoring
-			if convert.ToBool(existingCluster[managementv3.ClusterSpecFieldEnableClusterMonitoring]) {
-				return nil, httperror.NewAPIError(httperror.InvalidOption, fmt.Sprintf("cannot update cluster to this RKE template revision, since it will turn off the cluster monitoring"))
-			}
-		}
-
-		if !clusterTemplateRevision.Spec.ClusterConfig.EnableClusterAlerting {
-			if convert.ToBool(existingCluster[managementv3.ClusterSpecFieldEnableClusterAlerting]) {
-				return nil, httperror.NewAPIError(httperror.InvalidOption, fmt.Sprintf("cannot update cluster to this RKE template revision, since it will turn off the cluster alerting"))
-			}
-		}
-
 		clusterConfigSchema := apiContext.Schemas.Schema(&managementschema.Version, managementv3.ClusterSpecBaseType)
 		clusterUpdate, err := loadDataFromTemplate(clusterTemplateRevision, clusterTemplate, data, clusterConfigSchema, existingCluster)
 		if err != nil {
@@ -500,6 +487,15 @@ func (r *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 		}
 
 		data = clusterUpdate
+
+		//keep monitoring and alerting flags on the cluster as is, no turning off these flags from templaterevision.
+		if !clusterTemplateRevision.Spec.ClusterConfig.EnableClusterMonitoring {
+			data[managementv3.ClusterSpecFieldEnableClusterMonitoring] = existingCluster[managementv3.ClusterSpecFieldEnableClusterMonitoring]
+		}
+		if !clusterTemplateRevision.Spec.ClusterConfig.EnableClusterAlerting {
+			data[managementv3.ClusterSpecFieldEnableClusterAlerting] = existingCluster[managementv3.ClusterSpecFieldEnableClusterAlerting]
+		}
+
 	} else if existingCluster[managementv3.ClusterSpecFieldClusterTemplateRevisionID] != nil {
 		return nil, httperror.NewFieldAPIError(httperror.MissingRequired, "ClusterTemplateRevision", "this cluster is created from a clusterTemplateRevision, please pass the clusterTemplateRevision")
 	}

--- a/tests/integration/suite/test_clustertemplate.py
+++ b/tests/integration/suite/test_clustertemplate.py
@@ -786,6 +786,69 @@ def test_cluster_desc_update(admin_mc, list_remove_resource):
     wait_for_cluster_to_be_deleted(client, cluster.id)
 
 
+def test_update_cluster_monitoring(admin_mc, remove_resource):
+    cluster_template = create_cluster_template(admin_mc,
+                                               remove_resource, [], admin_mc)
+    tId = cluster_template.id
+    client = admin_mc.client
+    cconfig = {
+        "rancherKubernetesEngineConfig": {
+            "services": {
+                "type": "rkeConfigServices",
+                "kubeApi": {
+                    "alwaysPullImages": "false",
+                    "podSecurityPolicy": "false",
+                    "serviceNodePortRange": "30000-32767",
+                    "type": "kubeAPIService"
+                }
+            }
+        },
+        "enableClusterMonitoring": "true",
+        "defaultPodSecurityPolicyTemplateId": "restricted",
+    }
+    rev1 = client.create_cluster_template_revision(clusterConfig=cconfig,
+                                                   name="v1",
+                                                   clusterTemplateId=tId,
+                                                   enabled="true")
+    cconfig2 = {
+        "rancherKubernetesEngineConfig": {
+            "services": {
+                "type": "rkeConfigServices",
+                "kubeApi": {
+                    "alwaysPullImages": "false",
+                    "podSecurityPolicy": "false",
+                    "serviceNodePortRange": "30000-32767",
+                    "type": "kubeAPIService"
+                }
+            }
+        },
+        "enableClusterMonitoring": "false",
+        "defaultPodSecurityPolicyTemplateId": "restricted",
+    }
+    rev2 = client.create_cluster_template_revision(clusterConfig=cconfig2,
+                                                   name="v2",
+                                                   clusterTemplateId=tId,
+                                                   enabled="true")
+
+    cluster_name = random_str()
+    cluster = wait_for_cluster_create(client, name=cluster_name,
+                                      clusterTemplateRevisionId=rev1.id,
+                                      description="template from cluster")
+    remove_resource(cluster)
+    assert cluster.conditions[0].type == 'Pending'
+    assert cluster.conditions[0].status == 'True'
+
+    # update cluster to use rev2 that turns of monitoring
+    # expect error
+    with pytest.raises(ApiError) as e:
+        client.update(cluster,
+                      name=cluster_name, clusterTemplateRevisionId=rev2.id)
+    assert e.value.error.status == 422
+
+    client.delete(cluster)
+    wait_for_cluster_to_be_deleted(client, cluster.id)
+
+
 def rtb_cb(client, rtb):
     """Wait for the prtb to have the userId populated"""
     def cb():


### PR DESCRIPTION
This is a forwardport PR from release/v2.3: https://github.com/rancher/rancher/pull/24194

The fix is to ignore the template revision's "EnableClusterAlerting or EnableClusterMonitoring" flag when they are false during update cluster usecase for a cluster using a clusterTemplate.

This will allow the cluster updates (edit cluster to change overrides or update revision) to go through but keep monitoring/alerting intact.

https://github.com/rancher/rancher/issues/27753