### PR TITLE
Do not turn off monitoring/alerting from templateRevision during cluster updates

### DIFF
--- a/pkg/api/store/cluster/cluster_store.go
+++ b/pkg/api/store/cluster/cluster_store.go
@@ -480,6 +480,19 @@ func (r *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 			return nil, httperror.NewAPIError(httperror.InvalidOption, fmt.Sprintf("cannot update cluster, cluster cannot be changed to a new clusterTemplate"))
 		}
 
+		if !clusterTemplateRevision.Spec.ClusterConfig.EnableClusterMonitoring {
+			//this template will turn off ClusterMonitoring, ensure that the cluster is not using Monitoring
+			if convert.ToBool(existingCluster[managementv3.ClusterSpecFieldEnableClusterMonitoring]) {
+				return nil, httperror.NewAPIError(httperror.InvalidOption, fmt.Sprintf("cannot update cluster to this RKE template revision, since it will turn off the cluster monitoring"))
+			}
+		}
+
+		if !clusterTemplateRevision.Spec.ClusterConfig.EnableClusterAlerting {
+			if convert.ToBool(existingCluster[managementv3.ClusterSpecFieldEnableClusterAlerting]) {
+				return nil, httperror.NewAPIError(httperror.InvalidOption, fmt.Sprintf("cannot update cluster to this RKE template revision, since it will turn off the cluster alerting"))
+			}
+		}
+
 		clusterConfigSchema := apiContext.Schemas.Schema(&managementschema.Version, managementv3.ClusterSpecBaseType)
 		clusterUpdate, err := loadDataFromTemplate(clusterTemplateRevision, clusterTemplate, data, clusterConfigSchema, existingCluster)
 		if err != nil {

--- a/pkg/api/store/cluster/cluster_store.go
+++ b/pkg/api/store/cluster/cluster_store.go
@@ -480,19 +480,6 @@ func (r *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 			return nil, httperror.NewAPIError(httperror.InvalidOption, fmt.Sprintf("cannot update cluster, cluster cannot be changed to a new clusterTemplate"))
 		}
 
-		if !clusterTemplateRevision.Spec.ClusterConfig.EnableClusterMonitoring {
-			//this template will turn off ClusterMonitoring, ensure that the cluster is not using Monitoring
-			if convert.ToBool(existingCluster[managementv3.ClusterSpecFieldEnableClusterMonitoring]) {
-				return nil, httperror.NewAPIError(httperror.InvalidOption, fmt.Sprintf("cannot update cluster to this RKE template revision, since it will turn off the cluster monitoring"))
-			}
-		}
-
-		if !clusterTemplateRevision.Spec.ClusterConfig.EnableClusterAlerting {
-			if convert.ToBool(existingCluster[managementv3.ClusterSpecFieldEnableClusterAlerting]) {
-				return nil, httperror.NewAPIError(httperror.InvalidOption, fmt.Sprintf("cannot update cluster to this RKE template revision, since it will turn off the cluster alerting"))
-			}
-		}
-
 		clusterConfigSchema := apiContext.Schemas.Schema(&managementschema.Version, managementv3.ClusterSpecBaseType)
 		clusterUpdate, err := loadDataFromTemplate(clusterTemplateRevision, clusterTemplate, data, clusterConfigSchema, existingCluster)
 		if err != nil {
@@ -500,6 +487,15 @@ func (r *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 		}
 
 		data = clusterUpdate
+
+		//keep monitoring and alerting flags on the cluster as is, no turning off these flags from templaterevision.
+		if !clusterTemplateRevision.Spec.ClusterConfig.EnableClusterMonitoring {
+			data[managementv3.ClusterSpecFieldEnableClusterMonitoring] = existingCluster[managementv3.ClusterSpecFieldEnableClusterMonitoring]
+		}
+		if !clusterTemplateRevision.Spec.ClusterConfig.EnableClusterAlerting {
+			data[managementv3.ClusterSpecFieldEnableClusterAlerting] = existingCluster[managementv3.ClusterSpecFieldEnableClusterAlerting]
+		}
+
 	} else if existingCluster[managementv3.ClusterSpecFieldClusterTemplateRevisionID] != nil {
 		return nil, httperror.NewFieldAPIError(httperror.MissingRequired, "ClusterTemplateRevision", "this cluster is created from a clusterTemplateRevision, please pass the clusterTemplateRevision")
 	}

--- a/tests/integration/suite/test_clustertemplate.py
+++ b/tests/integration/suite/test_clustertemplate.py
@@ -787,9 +787,12 @@ def test_cluster_desc_update(admin_mc, list_remove_resource):
     wait_for_cluster_to_be_deleted(client, cluster.id)
 
 
-def test_update_cluster_monitoring(admin_mc, remove_resource):
-    cluster_template = create_cluster_template(admin_mc,
-                                               remove_resource, [], admin_mc)
+def test_update_cluster_monitoring(admin_mc, list_remove_resource):
+    cluster_template = create_cluster_template(admin_mc, [], admin_mc)
+
+    remove_list = [cluster_template]
+    list_remove_resource(remove_list)
+
     tId = cluster_template.id
     client = admin_mc.client
     cconfig = {
@@ -835,16 +838,18 @@ def test_update_cluster_monitoring(admin_mc, remove_resource):
     cluster = wait_for_cluster_create(client, name=cluster_name,
                                       clusterTemplateRevisionId=rev1.id,
                                       description="template from cluster")
-    remove_resource(cluster)
+    remove_list.insert(0, cluster)
     assert cluster.conditions[0].type == 'Pending'
     assert cluster.conditions[0].status == 'True'
 
-    # update cluster to use rev2 that turns of monitoring
-    # expect error
-    with pytest.raises(ApiError) as e:
-        client.update(cluster,
-                      name=cluster_name, clusterTemplateRevisionId=rev2.id)
-    assert e.value.error.status == 422
+    # update cluster to use rev2 that turns off monitoring
+    # expect no change to monitoring
+
+    client.update(cluster,
+                  name=cluster_name, clusterTemplateRevisionId=rev2.id)
+
+    reloaded_cluster = client.by_id_cluster(cluster.id)
+    assert reloaded_cluster.enableClusterMonitoring is True
 
     client.delete(cluster)
     wait_for_cluster_to_be_deleted(client, cluster.id)


### PR DESCRIPTION
This is a forwardport PR missed from release/v2.3: #24194

The fix is to ignore the template revision's "EnableClusterAlerting or EnableClusterMonitoring" flag when they are false during update cluster usecase for a cluster using a clusterTemplate.

This will allow the cluster updates (edit cluster to change overrides or update revision) to go through but keep monitoring/alerting intact.

#27753