### PR TITLE
Add cloudscale.ch driver.

### DIFF
--- a/app/machinedriver_data.go
+++ b/app/machinedriver_data.go
@@ -79,6 +79,11 @@ func addMachineDrivers(management *config.ManagementContext) error {
 		[]string{"objects-east.cloud.ca"}, false, false, management); err != nil {
 		return err
 	}
+	if err := addMachineDriver("cloudscale", "https://github.com/cloudscale-ch/docker-machine-driver-cloudscale/releases/download/v1.2.0/docker-machine-driver-cloudscale_v1.2.0_linux_amd64.tar.gz",
+		"https://objects.rma.cloudscale.ch/cloudscale-rancher-v2-ui-driver/component.js", "e33fbd6c2f87b1c470bcb653cc8aa50baf914a9d641a2f18f86a07c398cfb544",
+		[]string{"objects.rma.cloudscale.ch"}, false, false, management); err != nil {
+		return err
+	}
 	if err := addMachineDriver(DigitalOceandriver, "local://", "", "", []string{"api.digitalocean.com"}, true, true, management); err != nil {
 		return err
 	}


### PR DESCRIPTION
This adds the [cloudscale.ch](https://www.cloudscale.ch/en/) machine and ui-driver to the list of drivers available for installation with rancher.

This PR is essentially the same as https://github.com/rancher/rancher/pull/21347 (unfortunately, the source repo of the old PR got deleted, sorry for the noise). I have also updated the `docker-machine-driver-cloudscale` URL and rebased the commit.

Our drivers are maintained at:
 * https://github.com/cloudscale-ch/ui-driver-cloudscale
 * https://github.com/cloudscale-ch/docker-machine-driver-cloudscale

![Screenshot](https://raw.githubusercontent.com/cloudscale-ch/ui-driver-cloudscale/master/docs/configuration-screen.png)