### PR TITLE
Modifying the print statement to make it easier to run validations tests on multiple clusters

### DIFF
--- a/tests/validation/tests/v3_api/test_kdm_changes.py
+++ b/tests/validation/tests/v3_api/test_kdm_changes.py
@@ -135,6 +135,7 @@ def test_clusters_for_kdm():
 
     # printing results
     print("--------------Passed Cluster information--------------'\n")
+    print("Clusters: " + ''.join('{0},'.format(key) for key, value in passed_cluster.items()))
     for key, value in passed_cluster.items():
         print(key + "-->" + str(value) + "\n")
     print("--------------Failed Cluster information--------------'\n")


### PR DESCRIPTION
Modifying the print statement to make it easier to run validations tests on multiple clusters
```
Clusters: calico-63494,canal-89112,flannel-11742,weave-61277,
```