### PR TITLE
[2.4] Do not check user access for user's locally stored charts

### DIFF
--- a/pkg/api/store/app/store.go
+++ b/pkg/api/store/app/store.go
@@ -110,6 +110,10 @@ func (s *Store) checkAccessToTemplateVersion(apiContext *types.APIContext, data 
 	if err != nil {
 		return err
 	}
+	if templateVersionID == "" && ns == "" {
+		// all users can use a local template to create apps
+		return nil
+	}
 	if ns == namespace.GlobalNamespace {
 		// all users have read access to global catalogs, and can use their template versions to create apps
 		return nil
@@ -133,8 +137,8 @@ func (s *Store) verifyAppExternalIDMatchesProject(data map[string]interface{}, i
 	if err != nil {
 		return err
 	}
-	if catalogNs == namespace.GlobalNamespace {
-		// apps from global catalog can be launched in any clusters
+	if catalogNs == namespace.GlobalNamespace || catalogNs == "" {
+		// apps from global catalog or local template can be launched in any cluster
 		return nil
 	}
 

--- a/tests/integration/suite/test_app.py
+++ b/tests/integration/suite/test_app.py
@@ -760,6 +760,28 @@ def test_app_externalid_target_project_verification(admin_mc,
     p1_client.update(app, update_data)
 
 
+def test_local_app_can_deploy(admin_pc, admin_mc, remove_resource):
+    """Test that an app without an externalId can be deployed
+    successfully to simulate a local app deployed through cli"""
+    app_client = admin_pc.client
+    app_name = random_str()
+    ns = admin_pc.cluster.client.create_namespace(name=random_str(),
+                                                  projectId=admin_pc.
+                                                  project.id)
+    remove_resource(ns)
+
+    # create app without the externalId value set
+    app = app_client.create_app(
+        name=app_name,
+        targetNamespace=ns.name,
+        projectId=admin_pc.project.id,
+    )
+    remove_resource(app)
+    wait_for(lambda: app_client.by_id_app(app.id) is not None,
+             fail_handler=lambda:
+             "app could not be found")
+
+
 def wait_for_workload(client, ns, timeout=60, count=0):
     start = time.time()
     interval = 0.5


### PR DESCRIPTION
**Backport**
https://github.com/rancher/rancher/pull/27591

**Problem**
When using the cli to install an app from a local chart (ex:rancher app install . my-name) an error is returned from the ProjectClient.App.Create(app) method stating "failed to find resource by id". Since the externalID is empty, any checks that require data from the externalID is failing on ByID checks. externalID is added to a template when the catalog it belongs to is being traversed to make those templates available here. There is no catalog information available when installing an app from a local chart through the cli since it is a standalone chart.

**Solution**
return nil when externalID is empty prior to ByID checks

**Issue**
#23832