### PR TITLE
Enqueue CRTBs on RoleTemplate changes

### DIFF
--- a/pkg/controllers/management/auth/role_template_lifecycle.go
+++ b/pkg/controllers/management/auth/role_template_lifecycle.go
@@ -15,25 +15,36 @@ import (
 const (
 	roleTemplateLifecycleName = "mgmt-auth-roletemplate-lifecycle"
 	prtbByRoleTemplateIndex   = "management.cattle.io/prtb-by-role-template"
+	crtbByRoleTemplateIndex   = "management.cattle.io/crtb-by-role-template"
 )
 
 type roleTemplateLifecycle struct {
 	prtbIndexer    cache.Indexer
 	prtbClient     v3.ProjectRoleTemplateBindingInterface
+	crtbIndexer    cache.Indexer
+	crtbClient     v3.ClusterRoleTemplateBindingInterface
 	clusters       v3.ClusterInterface
 	clusterManager *clustermanager.Manager
 }
 
 func newRoleTemplateLifecycle(management *config.ManagementContext, clusterManager *clustermanager.Manager) v3.RoleTemplateLifecycle {
-	informer := management.Management.ProjectRoleTemplateBindings("").Controller().Informer()
-	indexers := map[string]cache.IndexFunc{
+	prtbInformer := management.Management.ProjectRoleTemplateBindings("").Controller().Informer()
+	prtbIndexers := map[string]cache.IndexFunc{
 		prtbByRoleTemplateIndex: prtbByRoleTemplate,
 	}
-	informer.AddIndexers(indexers)
+	prtbInformer.AddIndexers(prtbIndexers)
+
+	crtbInformer := management.Management.ClusterRoleTemplateBindings("").Controller().Informer()
+	crtbIndexers := map[string]cache.IndexFunc{
+		crtbByRoleTemplateIndex: crtbByRoleTemplate,
+	}
+	crtbInformer.AddIndexers(crtbIndexers)
 
 	rtl := &roleTemplateLifecycle{
-		prtbIndexer:    informer.GetIndexer(),
+		prtbIndexer:    prtbInformer.GetIndexer(),
 		prtbClient:     management.Management.ProjectRoleTemplateBindings(""),
+		crtbIndexer:    crtbInformer.GetIndexer(),
+		crtbClient:     management.Management.ClusterRoleTemplateBindings(""),
 		clusters:       management.Management.Clusters(""),
 		clusterManager: clusterManager,
 	}
@@ -41,16 +52,23 @@ func newRoleTemplateLifecycle(management *config.ManagementContext, clusterManag
 }
 
 func (rtl *roleTemplateLifecycle) Create(obj *v3.RoleTemplate) (runtime.Object, error) {
-	if err := rtl.enqueuePrtbs(obj); err != nil {
-		return nil, err
-	}
-	return nil, nil
+	return rtl.enqueueRtbs(obj)
 }
 
 func (rtl *roleTemplateLifecycle) Updated(obj *v3.RoleTemplate) (runtime.Object, error) {
+	return rtl.enqueueRtbs(obj)
+}
+
+// enqueueRtbs enqueues crtbs and prtbs associated to the role template.
+func (rtl *roleTemplateLifecycle) enqueueRtbs(obj *v3.RoleTemplate) (runtime.Object, error) {
 	if err := rtl.enqueuePrtbs(obj); err != nil {
 		return nil, err
 	}
+
+	if err := rtl.enqueueCrtbs(obj); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
@@ -96,11 +114,11 @@ func (rtl *roleTemplateLifecycle) Remove(obj *v3.RoleTemplate) (runtime.Object, 
 	if len(allErrors) > 0 {
 		return obj, fmt.Errorf("errors deleting dowstream clusterRole: %v", allErrors)
 	}
-	return obj, nil
 
+	return obj, nil
 }
 
-// enqueue any prtb's linked to this roleTemplate in order to re-sync it via reconcileBindings
+// enqueue any prtbs linked to this roleTemplate in order to re-sync them via reconcileBindings
 func (rtl *roleTemplateLifecycle) enqueuePrtbs(updatedRT *v3.RoleTemplate) error {
 	prtbs, err := rtl.prtbIndexer.ByIndex(prtbByRoleTemplateIndex, updatedRT.Name)
 	if err != nil {
@@ -114,10 +132,32 @@ func (rtl *roleTemplateLifecycle) enqueuePrtbs(updatedRT *v3.RoleTemplate) error
 	return nil
 }
 
+// enqueue any crtbs linked to this roleTemplate in order to re-sync them via reconcileBindings
+func (rtl *roleTemplateLifecycle) enqueueCrtbs(updatedRT *v3.RoleTemplate) error {
+	crtbs, err := rtl.crtbIndexer.ByIndex(crtbByRoleTemplateIndex, updatedRT.Name)
+	if err != nil {
+		return err
+	}
+	for _, x := range crtbs {
+		if crtb, ok := x.(*v3.ClusterRoleTemplateBinding); ok {
+			rtl.crtbClient.Controller().Enqueue(crtb.Namespace, crtb.Name)
+		}
+	}
+	return nil
+}
+
 func prtbByRoleTemplate(obj interface{}) ([]string, error) {
 	prtb, ok := obj.(*v3.ProjectRoleTemplateBinding)
 	if !ok {
 		return []string{}, nil
 	}
 	return []string{prtb.RoleTemplateName}, nil
+}
+
+func crtbByRoleTemplate(obj interface{}) ([]string, error) {
+	crtb, ok := obj.(*v3.ClusterRoleTemplateBinding)
+	if !ok {
+		return []string{}, nil
+	}
+	return []string{crtb.RoleTemplateName}, nil
 }

--- a/pkg/controllers/management/auth/role_template_lifecycle_test.go
+++ b/pkg/controllers/management/auth/role_template_lifecycle_test.go
@@ -15,7 +15,6 @@ const testNamespace = "test-cluster"
 const testRoleTemplateName = "fake-role-template"
 
 func TestEnqueuePrtbsOnRoleTemplateUpdate(t *testing.T) {
-
 	existingPrtbs := []*v3.ProjectRoleTemplateBinding{
 		{
 			ObjectMeta: v1.ObjectMeta{
@@ -74,4 +73,65 @@ func TestEnqueuePrtbsOnRoleTemplateUpdate(t *testing.T) {
 	err := rtl.enqueuePrtbs(&updatedRT)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(mockedProjectRoleTemplateBindingController.EnqueueCalls()))
+}
+
+func TestEnqueueCrtbsOnRoleTemplateUpdate(t *testing.T) {
+	existingCrtbs := []*v3.ClusterRoleTemplateBinding{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "crtb-1",
+				Namespace: testNamespace,
+			},
+			RoleTemplateName: testRoleTemplateName,
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "crtb-2",
+				Namespace: testNamespace,
+			},
+			RoleTemplateName: "this-is-not-the-rt-you-are-looking-for",
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "crtb-3",
+				Namespace: testNamespace,
+			},
+			RoleTemplateName: testRoleTemplateName,
+		},
+	}
+
+	// Mock crtb controller to catch enqueue calls
+	mockCrtbController := fakes.ClusterRoleTemplateBindingControllerMock{
+		EnqueueFunc: func(namespace string, name string) {},
+	}
+
+	// Setup a mock indexer that uses our custom index and method, then add test objects
+	indexers := map[string]cache.IndexFunc{
+		crtbByRoleTemplateIndex: crtbByRoleTemplate,
+	}
+	mockIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	mockIndexer.AddIndexers(indexers)
+	for _, obj := range existingCrtbs {
+		mockIndexer.Add(obj)
+	}
+
+	rtl := roleTemplateLifecycle{
+		crtbIndexer: mockIndexer,
+		crtbClient: &fakes.ClusterRoleTemplateBindingInterfaceMock{
+			ControllerFunc: func() v3.ClusterRoleTemplateBindingController {
+				return &mockCrtbController
+			},
+		},
+	}
+
+	updatedRT := v3.RoleTemplate{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      testRoleTemplateName,
+			Namespace: testNamespace,
+		},
+	}
+	// Now pass in a roleTemplate with name that matches a subset of test objects
+	err := rtl.enqueueCrtbs(&updatedRT)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(mockCrtbController.EnqueueCalls()))
 }


### PR DESCRIPTION
Currently when a RoleTemplate changes in the management cluster, only the ProjectRoleTemplateBindings associated with that RoleTemplate are enqueued for processing. This needs to be extended to ClusterRoleTemplateBindings associated with the RoleTemplate that is changing. This fixes an issue where RoleBindings in the management cluster are not created when a RoleTempalte with cluster context is updated. Enqueueing the CRTBs triggers the CRTB Handler logic which in turn creates the required RoleBindings in the management cluster. 

Previous related PR: https://github.com/rancher/rancher/pull/22394