### PR TITLE
[master] Update nodepool Validator

### DIFF
--- a/pkg/api/customization/nodepool/validator.go
+++ b/pkg/api/customization/nodepool/validator.go
@@ -2,22 +2,58 @@ package nodepool
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	mgmtclient "github.com/rancher/rancher/pkg/client/generated/management/v3"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	mgmtSchema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
 )
 
-func Validator(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
-	nodetemplateID, _ := data["nodeTemplateId"].(string)
+type Validator struct {
+	NodePoolLister v3.NodePoolLister
+}
+
+func (v *Validator) Validator(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
+	// validate access to nodetemplate
+	nodetemplateID, ok := data["nodeTemplateId"].(string)
+	if !ok {
+		// nodetemplate not passed, nothing to check
+		return nil
+	}
+	if request.ID == "" {
+		// creating new pool, confirm access to template
+		return checkNodetemplateAccess(request, nodetemplateID)
+	}
+
+	// validate request ID is in the right format
+	split := strings.SplitN(request.ID, ":", 2)
+	if len(split) != 2 {
+		return httperror.NewAPIError(httperror.NotFound, fmt.Sprintf("unable to find nodepool [%s]", request.ID))
+	}
+	cluster, nodepool := split[0], split[1]
+	np, err := v.NodePoolLister.Get(cluster, nodepool)
+	if err != nil {
+		return httperror.NewAPIError(httperror.NotFound, fmt.Sprintf("unable to find nodepool [%s]", request.ID))
+	}
+
+	if np.Spec.NodeTemplateName != nodetemplateID {
+		// pulling from lister failed, or update attempt to the nodetemplate
+		return checkNodetemplateAccess(request, nodetemplateID)
+	}
+
+	return nil
+}
+
+func checkNodetemplateAccess(request *types.APIContext, nodetemplateID string) error {
 	if err := access.ByID(request, &mgmtSchema.Version, mgmtclient.NodeTemplateType, nodetemplateID, nil); err != nil {
 		if httperror.IsNotFound(err) || httperror.IsForbidden(err) {
 			return httperror.NewAPIError(httperror.NotFound, fmt.Sprintf("unable to find node template [%s]", nodetemplateID))
 		}
 		return httperror.NewAPIError(httperror.ServerError, err.Error())
-
 	}
+
 	return nil
 }

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -502,7 +502,11 @@ func NodeTypes(schemas *types.Schemas, management *config.ScaledContext) error {
 		NodeTemplateLister: ntl,
 	}
 	schema.Formatter = f.Formatter
-	schema.Validator = nodepool.Validator
+
+	nodepoolValidator := nodepool.Validator{
+		NodePoolLister: management.Management.NodePools("").Controller().Lister(),
+	}
+	schema.Validator = nodepoolValidator.Validator
 	return nil
 }
 

--- a/tests/integration/suite/test_node.py
+++ b/tests/integration/suite/test_node.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import pytest
 from rancher import ApiError
+from kubernetes.client import CoreV1Api
 from .common import auth_check, random_str, string_to_encoding
 from .conftest import wait_for
 import time
@@ -210,9 +211,9 @@ def test_amazon_node_driver_schema(admin_mc):
             'amazonec2config missing support for field {}'.format(field)
 
 
-def create_node_template(client):
+def create_node_template(client, clientId="test"):
     cloud_credential = client.create_cloud_credential(
-        azurecredentialConfig={"clientId": "test",
+        azurecredentialConfig={"clientId": clientId,
                                "subscriptionId": "test",
                                "clientSecret": "test"})
     wait_for_cloud_credential(client, cloud_credential.id)
@@ -237,6 +238,7 @@ def wait_for_cloud_credential(client, cloud_credential_id, timeout=60):
             raise Exception('Timeout waiting for cloud credential')
         time.sleep(interval)
         interval *= 2
+        creds = client.list_cloud_credential()
         for val in creds:
             if val["id"] == cloud_credential_id:
                 cred = val
@@ -278,6 +280,79 @@ def test_user_access_to_other_template(user_factory, remove_resource):
     assert e.value.error.status == 404
     assert e.value.error.message == \
         "unable to find node template [%s]" % user2_node_template.id
+
+
+def test_user_cluster_owner_access_to_pool(admin_mc,
+                                           user_factory,
+                                           remove_resource,
+                                           wait_remove_resource):
+    """Test that a cluster created by the admin is accessible by another user
+    added as a cluster-owner, validate nodepool changing and switching
+    nodetemplate"""
+
+    # make an admin and user client
+    admin_client = admin_mc.client
+    k8sclient = CoreV1Api(admin_mc.k8s_client)
+    user = user_factory()
+
+    # make a cluster
+    cluster = admin_client.create_cluster(
+        name=random_str(),
+        rancherKubernetesEngineConfig={
+            "accessKey": "junk"
+        }
+    )
+    remove_resource(cluster)
+
+    # wait for the namespace created by the cluster
+    def _check_namespace(cluster):
+        for n in k8sclient.list_namespace().items:
+            if n.metadata.name == cluster.id:
+                return True
+        return False
+
+    wait_for(lambda: _check_namespace(cluster))
+
+    # add user as cluster-owner to the cluster
+    crtb = admin_client.create_cluster_role_template_binding(
+        userId=user.user.id,
+        roleTemplateId="cluster-owner",
+        clusterId=cluster.id,
+    )
+    remove_resource(crtb)
+
+    # admin creates a node template and assigns to a pool
+    admin_node_template, admin_cloud_credential = create_node_template(
+        admin_client, "admincloudcred-" + random_str())
+    admin_pool = admin_client.create_node_pool(
+        nodeTemplateId=admin_node_template.id,
+        hostnamePrefix="test",
+        clusterId=cluster.id)
+    wait_remove_resource(admin_pool)
+    remove_resource(admin_cloud_credential)
+    remove_resource(admin_node_template)
+
+    # create a template for the user to try and assign
+    user_node_template, user_cloud_credential = create_node_template(
+        user.client, "usercloudcred-" + random_str())
+    remove_resource(user_cloud_credential)
+    remove_resource(user_node_template)
+
+    # will pass, cluster owner user can change pool quantity
+    user.client.update(admin_pool, quantity=2)
+    # will pass, can set to a template owned by the user
+    user.client.update(admin_pool, nodeTemplateId=user_node_template.id)
+
+    # will fail, can not update nodepool template,
+    # if no access to the original template
+    with pytest.raises(ApiError) as e:
+        user.client.update(admin_pool, nodeTemplateId=admin_node_template.id)
+    assert e.value.error.status == 404
+    assert e.value.error.message == "unable to find node template [%s]" % \
+                                    admin_node_template.id
+
+    # delete this by hand and the rest will cleanup
+    admin_client.delete(admin_pool)
 
 
 def test_admin_access_to_node_template(admin_mc, list_remove_resource):


### PR DESCRIPTION
Problem: User added to cluster via cluster role binding can not update
nodepool quantity.
Cause: Nodepool validator was only checking if the user has access to
the entire nodetemplate. Since the added user had no access to the
nodetemplate created by another use the error was being thrown.
Fix: Updated the validator to do the following.
First, check the user has access to the nodepool, this will pass for
both original and added user.
Second, pull the nopepool from the lister. If the user is attempting to
make a change to pool's template, validate the user has access to the
new pool before letting them change it.
Validate everything else, -/+ to the nodepool quantity will validate as
it is a PUT with the existing nodetemplate but a different quantity
value passed.

https://github.com/rancher/rancher/issues/27031