### PR TITLE
[metrics] buildObservedLabelMaps: fix data race on the range iterator

### DIFF
--- a/pkg/metrics/garbagecollector.go
+++ b/pkg/metrics/garbagecollector.go
@@ -103,6 +103,7 @@ func buildObservedLabelMaps(collectors []interface{}, targetLabel string, observ
 	// }
 	count := 0
 	for _, collector := range collectors {
+		collector := collector
 		metricChan := make(chan prometheus.Metric)
 		metricFrame := &dto.Metric{}
 		go func() { collector.(prometheus.Collector).Collect(metricChan); close(metricChan) }()


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

Go uses the same address for the iterator variable. Create a local copy of the iterator variable otherwise it will end up using the last value of collector for all the goroutines.