### PR TITLE
[2.4] Modify check to grant owner permissions

### DIFF
--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -758,6 +758,15 @@ func (m *manager) checkReferencedRoles(roleTemplateName string) (bool, error) {
 		return false, err
 	}
 
+	// upon upgrades, crtb/prtbs are reconciled before roletemplates.
+	// So these roles won't have the "own" verb at the time of this check added 2.4.6 onwards
+	if roleTemplate.Builtin && roleTemplate.Context == "project" && roleTemplateName == "project-owner" {
+		return true, nil
+	}
+	if roleTemplate.Builtin && roleTemplate.Context == "cluster" && roleTemplateName == "cluster-owner" {
+		return true, nil
+	}
+
 	for _, rule := range roleTemplate.Rules {
 		if slice.ContainsString(rule.Resources, projectResource) || slice.ContainsString(rule.Resources, clusterResource) {
 			if slice.ContainsString(rule.Verbs, "own") {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/28014

Problem: On upgraded setups, clusterrolebinding for system account of a cluster
gets deleted.
The builtin cluster-owner and project-owner roles have a new verb to indicate
ownership. On upgraded setups, the cluster and project roleTemplateBindings
get reconciled before the roletemplates are reconciled. Because of which the
clusterRoleTemplateBinding controller compares a role's rules with the non-updated
cluster-owner roleTemplate. Same happens for project-owner role. This leads to the
deletion of clusterrolebindings that bind the user to owner role.

Solution: This commit adds back the check for role names of "cluster-owner" and
"project-owner" roles. So the role template binding controllers will consider
users with these roles as owners and won't delete the clusterrolebindings.

There are integration tests for checking whether cloned project-owner/cluster-owner roles get owner permissions or not. But this particular scenario is only during upgrade, so I couldn't add integration test