### PR TITLE
Provisioning fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/prometheus/common v0.9.1
 	github.com/rancher/apiserver v0.0.0-20200721152301-4388bb184a8e
 	github.com/rancher/dynamiclistener v0.2.1-0.20200714201033-9c1939da3af9
-	github.com/rancher/eks-operator v0.1.0-rc19
+	github.com/rancher/eks-operator v0.1.0-rc22
 	github.com/rancher/lasso v0.0.0-20200515155337-a34e1e26ad91
 	github.com/rancher/machine v0.15.0-rancher25
 	github.com/rancher/norman v0.0.0-20200714195611-b3163ad4ebc4

--- a/go.sum
+++ b/go.sum
@@ -798,8 +798,8 @@ github.com/rancher/apiserver v0.0.0-20200721152301-4388bb184a8e/go.mod h1:8W0Ewa
 github.com/rancher/client-go v1.18.0-rancher.1/go.mod h1:uQSYDYs4WhVZ9i6AIoEZuwUggLVEF64HOD37boKAtF8=
 github.com/rancher/dynamiclistener v0.2.1-0.20200714201033-9c1939da3af9 h1:Mo5mPXi7k/TgzMcUIuDpbNxiX2bYh68+yEpaur5Nx80=
 github.com/rancher/dynamiclistener v0.2.1-0.20200714201033-9c1939da3af9/go.mod h1:qr0QfhwzcVCR+Ao9WyfnE+jmOpfEAdRhXtNOZGJ3nCQ=
-github.com/rancher/eks-operator v0.1.0-rc19 h1:XcWumddPLdkSEkNGdv65U7Uk+bBDZF2wAeYAwnZVZwo=
-github.com/rancher/eks-operator v0.1.0-rc19/go.mod h1:TrTF54+K2X6QLhVFspIfawYcPnVNLSIBrgCvpE1BiqM=
+github.com/rancher/eks-operator v0.1.0-rc22 h1:wPX+aP/kJ3q9wA7qiZ8jEDbRZ6PV6cWnodemKbWXmcw=
+github.com/rancher/eks-operator v0.1.0-rc22/go.mod h1:TrTF54+K2X6QLhVFspIfawYcPnVNLSIBrgCvpE1BiqM=
 github.com/rancher/lasso v0.0.0-20200427171700-e0509f89f319/go.mod h1:6Dw19z1lDIpL887eelVjyqH/mna1hfR61ddCFOG78lw=
 github.com/rancher/lasso v0.0.0-20200513231433-d0ce66327a25/go.mod h1:6Dw19z1lDIpL887eelVjyqH/mna1hfR61ddCFOG78lw=
 github.com/rancher/lasso v0.0.0-20200515155337-a34e1e26ad91 h1:p4VVl0tr6YAeUILFMCn+0DKzbUOS0ah9biSsL7Sy6S4=
@@ -829,6 +829,7 @@ github.com/rancher/wrangler v0.6.2-0.20200714200521-c61fae623942/go.mod h1:8LdIq
 github.com/rancher/wrangler v0.6.2-0.20200721203632-787d93e49342 h1:uV30QVtfowET6yuTdW2shqoliWmcqxKLeaKgC7hj7Is=
 github.com/rancher/wrangler v0.6.2-0.20200721203632-787d93e49342/go.mod h1:GSBsgNCMgSgpTXoyto5e35lTm5akYQVPzse5q3/rZ4w=
 github.com/rancher/wrangler-api v0.5.1-0.20200326194427-c13310506d04/go.mod h1:R3nemXoECcrDqXDSHdY7yJay4j42TeEkU79Hep0rdJ8=
+github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e h1:UJpGtw6IKs0dHPTF+6Wd12lskeCZZAejl8/ie/fc1+0=
 github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e/go.mod h1:2lcWR98q8HU3U4mVETnXc8quNG0uXxrt8vKd6cAa/30=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -154,6 +154,7 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 	if !reflect.DeepEqual(eksClusterConfigMap, eksClusterConfigDynamic.Object["spec"]) {
 		// if cluster is imported make sure it's original spec has been copied copied before mutating
 		if !cluster.Spec.EKSConfig.Imported || cluster.GetAnnotations()[importedAnno] == "true" {
+			logrus.Infof("change detected for cluster [%s], updating EKSClusterConfig", cluster.Name)
 			return e.updateEKSClusterConfig(cluster, eksClusterConfigDynamic, eksClusterConfigMap)
 		}
 	}
@@ -288,7 +289,7 @@ func (e *eksOperatorController) updateEKSClusterConfig(cluster *mgmtv3.Cluster, 
 		case event := <-w.ResultChan():
 			eksClusterConfigDynamic = event.Object.(*unstructured.Unstructured)
 			status, _ := eksClusterConfigDynamic.Object["status"].(map[string]interface{})
-			if status["phase"] != "updating" {
+			if status["phase"] == "active" {
 				continue
 			}
 

--- a/vendor/github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1/types.go
+++ b/vendor/github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1/types.go
@@ -68,7 +68,6 @@ type NodeGroup struct {
 	InstanceType         *string            `json:"instanceType" norman:"required"`
 	Labels               map[string]*string `json:"labels"`
 	Ec2SshKey            *string            `json:"ec2SshKey"`
-	SourceSecurityGroups []*string          `json:"sourceSecurityGroups"`
 	DesiredSize          *int64             `json:"desiredSize"`
 	MaxSize              *int64             `json:"maxSize"`
 	MinSize              *int64             `json:"minSize"`

--- a/vendor/github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1/zz_generated_deepcopy.go
@@ -194,17 +194,6 @@ func (in *NodeGroup) DeepCopyInto(out *NodeGroup) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.SourceSecurityGroups != nil {
-		in, out := &in.SourceSecurityGroups, &out.SourceSecurityGroups
-		*out = make([]*string, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(string)
-				**out = **in
-			}
-		}
-	}
 	if in.DesiredSize != nil {
 		in, out := &in.DesiredSize, &out.DesiredSize
 		*out = new(int64)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -375,7 +375,7 @@ github.com/rancher/dynamiclistener/server
 github.com/rancher/dynamiclistener/storage/file
 github.com/rancher/dynamiclistener/storage/kubernetes
 github.com/rancher/dynamiclistener/storage/memory
-# github.com/rancher/eks-operator v0.1.0-rc19
+# github.com/rancher/eks-operator v0.1.0-rc22
 github.com/rancher/eks-operator/pkg/apis/eks.cattle.io
 github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1
 # github.com/rancher/lasso v0.0.0-20200515155337-a34e1e26ad91


### PR DESCRIPTION
**Problem:**
Cluster's with EKSConfigs are not finishing provisioning.
This is caused by two things:
1. eks-operator package is out of data, so when comparing the two EKSClusterConfig objects (the one on the cluster's spec and the one in cattle-global-data) they are evaluated as non equal. This disrupts the waiting for creation process.
2. Even in the above case the object should be re-enqueued. This is not happening because it is assumed that if the object is not observed to be in the "updating" phase, there is no need to wait on the object.

**Solution:**
1. Update eks-operator package to latest.2
2. Re-enqueue if the object is observed to be in any state other than "active".

**Issue:**
https://github.com/rancher/rancher/issues/28096