### PR TITLE
Validation - Added test to create an EKS cluster using boto API

### DIFF
--- a/tests/validation/Dockerfile.v3api
+++ b/tests/validation/Dockerfile.v3api
@@ -35,5 +35,8 @@ RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERS
     tar -xzf "sonobuoy_$SONOBUOY_VERSION"_linux_amd64.tar.gz -C /tmp && \
     mv /tmp/sonobuoy /usr/local/bin && \
     chmod +x /usr/local/bin/sonobuoy && \
+    wget https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip && \
+    unzip awscli-exe-linux-x86_64.zip && \
+    ./aws/install && \
     cd $WORKSPACE && \
     pip install -r requirements_v3api.txt

--- a/tests/validation/lib/aws.py
+++ b/tests/validation/lib/aws.py
@@ -36,9 +36,19 @@ AWS_INSTANCE_TYPE = os.environ.get("AWS_INSTANCE_TYPE", 't3a.medium')
 AWS_WINDOWS_VOLUME_SIZE = os.environ.get("AWS_WINDOWS_VOLUME_SIZE", "100")
 AWS_WINDOWS_INSTANCE_TYPE = 't3.xlarge'
 
+EKS_VERSION = os.environ.get("RANCHER_EKS_K8S_VERSION")
+EKS_ROLE_ARN = os.environ.get("RANCHER_EKS_ROLE_ARN")
+EKS_WORKER_ROLE_ARN = os.environ.get("RANCHER_EKS_WORKER_ROLE_ARN")
+
+AWS_SUBNETS = []
+if ',' in AWS_SUBNET:
+    AWS_SUBNETS = AWS_SUBNET.split(',')
+else:
+    AWS_SUBNETS = [AWS_SUBNET]
+
 
 class AmazonWebServices(CloudProviderBase):
-
+    
     def __init__(self):
         self._client = boto3.client(
             'ec2',
@@ -59,6 +69,12 @@ class AmazonWebServices(CloudProviderBase):
 
         self._db_client = boto3.client(
             'rds',
+            aws_access_key_id=AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+            region_name=AWS_REGION)
+
+        self._eks_client = boto3.client(
+            'eks',
             aws_access_key_id=AWS_ACCESS_KEY_ID,
             aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
             region_name=AWS_REGION)
@@ -549,3 +565,66 @@ class AmazonWebServices(CloudProviderBase):
                                                DeleteAutomatedBackups=True)
         except ClientError:
             return None
+
+    def create_eks_cluster(self, name):
+        kubeconfig_path = self.create_eks_controlplane(name)
+        self.create_eks_nodegroup(name, '{}-ng'.format(name))
+        return kubeconfig_path
+
+    def create_eks_controlplane(self, name):
+        vpcConfiguration = {
+            "subnetIds": AWS_SUBNETS,
+            "securityGroupIds": [AWS_SECURITY_GROUP],
+            "endpointPublicAccess": True,
+            "endpointPrivateAccess": False
+        }
+
+        self._eks_client.\
+            create_cluster(name=name,
+                           version=EKS_VERSION,
+                           roleArn=EKS_ROLE_ARN,
+                           resourcesVpcConfig=vpcConfiguration)
+
+        return self.wait_for_eks_cluster_state(name, "ACTIVE")
+
+    def create_eks_nodegroup(self, cluster_name, name):
+        scaling_config = {
+            "minSize": 3,
+            "maxSize": 3,
+            "desiredSize": 3
+        }
+
+        remote_access = {
+            "ec2SshKey": AWS_SSH_KEY_NAME.replace('.pem', '')
+        }
+
+        return self._eks_client.\
+            create_nodegroup(clusterName=cluster_name,
+                             nodegroupName=name,
+                             scalingConfig=scaling_config,
+                             diskSize=20,
+                             subnets=AWS_SUBNETS,
+                             instanceTypes=[AWS_INSTANCE_TYPE],
+                             nodeRole=EKS_WORKER_ROLE_ARN,
+                             remoteAccess=remote_access)
+
+    def describe_eks_cluster(self, name):
+        try:
+            return self._eks_client.describe_cluster(name=name)
+        except ClientError:
+            return None
+
+    def wait_for_eks_cluster_state(self, name, target_state, timeout=1200):
+        start = time.time()
+        cluster = self.describe_eks_cluster(name)['cluster']
+        status = cluster['status']
+        while status != target_state:
+            if time.time() - start > timeout:
+                raise AssertionError(
+                    "Timed out waiting for state to get to " + target_state)
+
+            time.sleep(5)
+            cluster = self.describe_eks_cluster(name)['cluster']
+            status = cluster['status']
+            print(status)
+        return cluster

--- a/tests/validation/requirements_v3api.txt
+++ b/tests/validation/requirements_v3api.txt
@@ -1,6 +1,6 @@
 git+https://github.com/rancher/client-python.git@master#egg=client-python
-boto3==1.10.6
-botocore==1.13.6
+boto3==1.14.30
+botocore==1.17.30
 cryptography==2.8
 flake8==3.5.0
 invoke==1.2.0

--- a/tests/validation/tests/v3_api/test_boto_create_eks.py
+++ b/tests/validation/tests/v3_api/test_boto_create_eks.py
@@ -1,0 +1,47 @@
+import base64
+
+from .common import run_command_with_stderr
+from .test_eks_cluster import ekscredential
+from .test_eks_cluster import \
+    DATA_SUBDIR, EKS_ACCESS_KEY, EKS_SECRET_KEY, EKS_REGION
+from .test_rke_cluster_provisioning import evaluate_clustername
+from lib.aws import AmazonWebServices
+
+
+@ekscredential
+def test_boto_create_eks():
+    cluster_name = evaluate_clustername()
+    AmazonWebServices().create_eks_cluster(cluster_name)
+    kc_path = get_eks_kubeconfig(cluster_name)
+    out = run_command_with_stderr(
+            'kubectl --kubeconfig {} get svc'.format(kc_path))
+    print(out)
+    out = run_command_with_stderr(
+            'kubectl --kubeconfig {} get nodes'.format(kc_path))
+    print(out)
+
+
+def get_eks_kubeconfig(cluster_name):
+    kubeconfig_path = DATA_SUBDIR + "/kube_config_hosted_eks.yml"
+
+    exports = 'export AWS_ACCESS_KEY_ID={} && ' + \
+        'export AWS_SECRET_ACCESS_KEY={}'.format(
+            EKS_ACCESS_KEY, EKS_SECRET_KEY)
+
+    # log_out=False so we don't write the keys to the console
+    run_command_with_stderr(exports, log_out=False)
+
+    command = 'aws eks --region {} update-kubeconfig '.format(EKS_REGION) + \
+        '--name {} --kubeconfig {}'.format(cluster_name, kubeconfig_path)
+    run_command_with_stderr(command)
+
+    print("\n\nKubeconfig:")
+    kubeconfig_file = open(kubeconfig_path, "r")
+    kubeconfig_contents = kubeconfig_file.read()
+    kubeconfig_file.close()
+    kubeconfig_contents_encoded = base64.b64encode(
+        kubeconfig_contents.encode("utf-8")).decode("utf-8")
+    print("\n\n" + kubeconfig_contents + "\n\n")
+    print("\nBase64 encoded: \n\n" + kubeconfig_contents_encoded + "\n\n")
+
+    return kubeconfig_path


### PR DESCRIPTION
Requires: 
```
RANCHER_EKS_ACCESS_KEY
RANCHER_EKS_SECRET_KEY
RANCHER_EKS_REGION
RANCHER_EKS_K8S_VERSION
AWS_SUBNET
RANCHER_EKS_ROLE_ARN
RANCHER_EKS_WORKER_ROLE_ARN
RANCHER_CLUSTER_NAME
```

To use the generated kubeconfig locally requires `aws` cli installed and configured w/ access key & secret key used to create the cluster