### PR TITLE
Bump memory limit for pipeline Minio.

### DIFF
--- a/pkg/controllers/managementuser/pipeline/controller/pipelineexecution/deploy.go
+++ b/pkg/controllers/managementuser/pipeline/controller/pipelineexecution/deploy.go
@@ -896,7 +896,7 @@ func GetMinioDeployment(ns string) *appsv1.Deployment {
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
-									corev1.ResourceMemory: *resource.NewQuantity(200e6, resource.BinarySI),
+									corev1.ResourceMemory: *resource.NewQuantity(500e6, resource.BinarySI),
 								},
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),

--- a/pkg/controllers/managementuser/pipeline/upgrade/upgradeimpl.go
+++ b/pkg/controllers/managementuser/pipeline/upgrade/upgradeimpl.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/rancher/rancher/pkg/controllers/managementuser/pipeline/controller/pipelineexecution"
 	appsv1 "github.com/rancher/rancher/pkg/generated/norman/apps/v1"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
@@ -17,6 +16,7 @@ import (
 	"github.com/rancher/rancher/pkg/types/config"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -94,7 +94,7 @@ func (l *PipelineService) upgradeComponents(ns string) error {
 		return fmt.Errorf("upgrade system service %s:%s failed, %v", jenkinsDeployment.Namespace, jenkinsDeployment.Name, err)
 	}
 
-	//Only update image for Registry and Minio to preserve user customized configurations such as volumes
+	//Only update image or resources for Registry and Minio to preserve user customized configurations such as volumes
 	registryDeployment, err := l.deploymentLister.Get(ns, utils.RegistryName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -116,6 +116,12 @@ func (l *PipelineService) upgradeComponents(ns string) error {
 	}
 	toUpdateMinio := minioDeployment.DeepCopy()
 	toUpdateMinio.Spec.Template.Spec.Containers[0].Image = images.Resolve(v32.ToolsSystemImages.PipelineSystemImages.Minio)
+	if toUpdateMinio.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().Cmp(*resource.NewQuantity(500e6, resource.BinarySI)) < 0 {
+		toUpdateMinio.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+			corev1.ResourceCPU:    *toUpdateMinio.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu(),
+			corev1.ResourceMemory: *resource.NewQuantity(500e6, resource.BinarySI),
+		}
+	}
 	if _, err := l.deployments.Update(toUpdateMinio); err != nil {
 		return err
 	}


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/28031

Problem:
Newer version Minio consumes more memory. It may exceed the current limit.

Solution:
Bump memory limit from 200M to 500M and handle upgrade.