### PR TITLE
[2.4] Fix unstructured decoded with managedfields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,4 +123,5 @@ require (
 	k8s.io/kubectl v0.18.0
 	k8s.io/kubernetes v1.18.0
 	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/pipeline/providers/bitbucketcloud/provider.go
+++ b/pkg/pipeline/providers/bitbucketcloud/provider.go
@@ -60,18 +60,11 @@ func (b *BcProvider) GetProviderConfig(projectID string) (interface{}, error) {
 		return nil, fmt.Errorf("failed to decode the config, error: %v", err)
 	}
 
-	metadataMap, ok := storedBitbucketPipelineConfigMap["metadata"].(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("failed to retrieve BitbucketConfig metadata, cannot read k8s Unstructured data")
+	objectMeta, err := common.ObjectMetaFromUnstructureContent(storedBitbucketPipelineConfigMap)
+	if err != nil {
+		return nil, err
 	}
-
-	typemeta := &metav1.ObjectMeta{}
-	//time.Time cannot decode directly
-	delete(metadataMap, "creationTimestamp")
-	if err := mapstructure.Decode(metadataMap, typemeta); err != nil {
-		return nil, fmt.Errorf("failed to decode the config, error: %v", err)
-	}
-	storedBitbucketPipelineConfig.ObjectMeta = *typemeta
+	storedBitbucketPipelineConfig.ObjectMeta = *objectMeta
 	storedBitbucketPipelineConfig.APIVersion = "project.cattle.io/v3"
 	storedBitbucketPipelineConfig.Kind = v3.SourceCodeProviderConfigGroupVersionKind.Kind
 	return storedBitbucketPipelineConfig, nil

--- a/pkg/pipeline/providers/bitbucketserver/provider.go
+++ b/pkg/pipeline/providers/bitbucketserver/provider.go
@@ -58,18 +58,11 @@ func (b *BsProvider) GetProviderConfig(projectID string) (interface{}, error) {
 		return nil, fmt.Errorf("failed to decode the config, error: %v", err)
 	}
 
-	metadataMap, ok := storedBitbucketPipelineConfigMap["metadata"].(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("failed to retrieve BitbucketConfig metadata, cannot read k8s Unstructured data")
+	objectMeta, err := common.ObjectMetaFromUnstructureContent(storedBitbucketPipelineConfigMap)
+	if err != nil {
+		return nil, err
 	}
-
-	typemeta := &metav1.ObjectMeta{}
-	//time.Time cannot decode directly
-	delete(metadataMap, "creationTimestamp")
-	if err := mapstructure.Decode(metadataMap, typemeta); err != nil {
-		return nil, fmt.Errorf("failed to decode the config, error: %v", err)
-	}
-	storedBitbucketPipelineConfig.ObjectMeta = *typemeta
+	storedBitbucketPipelineConfig.ObjectMeta = *objectMeta
 	storedBitbucketPipelineConfig.APIVersion = "project.cattle.io/v3"
 	storedBitbucketPipelineConfig.Kind = v3.SourceCodeProviderConfigGroupVersionKind.Kind
 	return storedBitbucketPipelineConfig, nil

--- a/pkg/pipeline/providers/common/provider.go
+++ b/pkg/pipeline/providers/common/provider.go
@@ -2,8 +2,11 @@ package common
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
+	"time"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
@@ -220,6 +223,33 @@ func (b BaseProvider) RefreshReposByCredentialAndConfig(credential *v3.SourceCod
 	}
 
 	return repos, nil
+}
+
+func ObjectMetaFromUnstructureContent(unstructuredContent map[string]interface{}) (*metav1.ObjectMeta, error) {
+	metadataMap, ok := unstructuredContent["metadata"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to retrieve metadata, cannot read k8s unstructured data")
+	}
+
+	objectMeta := &metav1.ObjectMeta{}
+	stringToTimeHook := func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		if f.Kind() == reflect.String && t == reflect.TypeOf(metav1.Time{}) {
+			time, err := time.Parse(time.RFC3339, data.(string))
+			return metav1.Time{Time: time}, err
+		}
+		return data, nil
+	}
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: stringToTimeHook,
+		Result:     objectMeta,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := decoder.Decode(metadataMap); err != nil {
+		return nil, fmt.Errorf("failed to decode metadata, error: %v", err)
+	}
+	return objectMeta, nil
 }
 
 func normalizeName(name string) string {

--- a/pkg/pipeline/providers/common/provider_test.go
+++ b/pkg/pipeline/providers/common/provider_test.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	fooProviderInstance = `
+apiVersion: project.cattle.io/v3
+kind: SourceCodeProviderConfig
+metadata:
+  creationTimestamp: "2000-01-01T00:00:00Z"
+  generation: 1
+  labels:
+    foo: bar
+  managedFields:
+  - apiVersion: project.cattle.io/v3
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:cattle.io/creator: {}
+      f:projectName: {}
+      f:type: {}
+    manager: Go-http-client
+    operation: Update
+    time: "2000-01-01T00:00:00Z"
+  name: foo
+  namespace: p-test
+  resourceVersion: "1234"
+  selfLink: /apis/project.cattle.io/v3/namespaces/p-test/sourcecodeproviderconfigs/foo
+  uid: 693145a1-22e4-471d-8410-d7555458702f
+projectName: local:p-abcde
+type: fooConfig`
+)
+
+func TestObjectMetaFromUnstructureContent(t *testing.T) {
+	foo := &unstructured.Unstructured{}
+	err := yaml.Unmarshal([]byte(fooProviderInstance), &foo.Object)
+	assert.Nil(t, err)
+	objectMeta, err := ObjectMetaFromUnstructureContent(foo.UnstructuredContent())
+	assert.Nil(t, err)
+	assert.Equal(t, "foo", objectMeta.Name)
+	assert.Equal(t, "p-test", objectMeta.Namespace)
+	assert.Equal(t, map[string]string{"foo": "bar"}, objectMeta.Labels)
+}

--- a/pkg/pipeline/providers/github/actions.go
+++ b/pkg/pipeline/providers/github/actions.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/rancher/pkg/pipeline/providers/common"
 	"github.com/rancher/rancher/pkg/pipeline/remote/model"
 	"github.com/rancher/rancher/pkg/ref"
 	mv3 "github.com/rancher/types/apis/management.cattle.io/v3"
@@ -199,18 +200,11 @@ func (g *GhProvider) getGithubConfigCR() (*mv3.GithubConfig, error) {
 		return nil, fmt.Errorf("failed to decode the config, error: %v", err)
 	}
 
-	metadataMap, ok := storedGithubConfigMap["metadata"].(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("failed to retrieve GithubConfig metadata, cannot read k8s Unstructured data")
+	objectMeta, err := common.ObjectMetaFromUnstructureContent(storedGithubConfigMap)
+	if err != nil {
+		return nil, err
 	}
-
-	typemeta := &metav1.ObjectMeta{}
-	//time.Time cannot decode directly
-	delete(metadataMap, "creationTimestamp")
-	if err := mapstructure.Decode(metadataMap, typemeta); err != nil {
-		return nil, fmt.Errorf("failed to decode the config, error: %v", err)
-	}
-	storedGithubConfig.ObjectMeta = *typemeta
+	storedGithubConfig.ObjectMeta = *objectMeta
 
 	return storedGithubConfig, nil
 }

--- a/pkg/pipeline/providers/github/provider.go
+++ b/pkg/pipeline/providers/github/provider.go
@@ -62,11 +62,6 @@ func (g *GhProvider) GetProviderConfig(projectID string) (interface{}, error) {
 		return nil, fmt.Errorf("failed to decode the config, error: %v", err)
 	}
 
-	metadataMap, ok := storedGithubPipelineConfigMap["metadata"].(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("failed to retrieve GithubConfig metadata, cannot read k8s Unstructured data")
-	}
-
 	if storedGithubPipelineConfig.Inherit {
 		globalConfig, err := g.getGithubConfigCR()
 		if err != nil {
@@ -75,13 +70,11 @@ func (g *GhProvider) GetProviderConfig(projectID string) (interface{}, error) {
 		storedGithubPipelineConfig.ClientSecret = globalConfig.ClientSecret
 	}
 
-	typemeta := &metav1.ObjectMeta{}
-	//time.Time cannot decode directly
-	delete(metadataMap, "creationTimestamp")
-	if err := mapstructure.Decode(metadataMap, typemeta); err != nil {
-		return nil, fmt.Errorf("failed to decode the config, error: %v", err)
+	objectMeta, err := common.ObjectMetaFromUnstructureContent(storedGithubPipelineConfigMap)
+	if err != nil {
+		return nil, err
 	}
-	storedGithubPipelineConfig.ObjectMeta = *typemeta
+	storedGithubPipelineConfig.ObjectMeta = *objectMeta
 	storedGithubPipelineConfig.APIVersion = "project.cattle.io/v3"
 	storedGithubPipelineConfig.Kind = v3.SourceCodeProviderConfigGroupVersionKind.Kind
 	return storedGithubPipelineConfig, nil

--- a/pkg/pipeline/providers/gitlab/provider.go
+++ b/pkg/pipeline/providers/gitlab/provider.go
@@ -60,18 +60,12 @@ func (g *GlProvider) GetProviderConfig(projectID string) (interface{}, error) {
 	if err := mapstructure.Decode(storedGitlabPipelineConfigMap, storedGitlabPipelineConfig); err != nil {
 		return nil, fmt.Errorf("failed to decode the config, error: %v", err)
 	}
-	metadataMap, ok := storedGitlabPipelineConfigMap["metadata"].(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("failed to retrieve GitlabConfig metadata, cannot read k8s Unstructured data")
-	}
 
-	typemeta := &metav1.ObjectMeta{}
-	//time.Time cannot decode directly
-	delete(metadataMap, "creationTimestamp")
-	if err := mapstructure.Decode(metadataMap, typemeta); err != nil {
-		return nil, fmt.Errorf("failed to decode the config, error: %v", err)
+	objectMeta, err := common.ObjectMetaFromUnstructureContent(storedGitlabPipelineConfigMap)
+	if err != nil {
+		return nil, err
 	}
-	storedGitlabPipelineConfig.ObjectMeta = *typemeta
+	storedGitlabPipelineConfig.ObjectMeta = *objectMeta
 	storedGitlabPipelineConfig.APIVersion = "project.cattle.io/v3"
 	storedGitlabPipelineConfig.Kind = v3.SourceCodeProviderConfigGroupVersionKind.Kind
 	return storedGitlabPipelineConfig, nil


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/27011

Problem:
Decoding unstructured pipeline provider configs fails in k8s 1.18+ with managedFields introduced.

Solution:
Decode time fields properly.