### PR TITLE
Remove duplicated configure for cluster logging

### DIFF
--- a/pkg/controllers/managementuser/logging/generator/templatesource.go
+++ b/pkg/controllers/managementuser/logging/generator/templatesource.go
@@ -17,9 +17,7 @@ var SourceTemplate = `
   @type  tail
   path  /var/log/containers/*.log
   pos_file  /fluentd/log/{{ .ContainerLogPosFilename}}
-  time_format  %Y-%m-%dT%H:%M:%S.%N
   tag  {{ .ContainerLogSourceTag }}.*
-  format  json
   skip_refresh_on_startup true
   read_from_head true
 


### PR DESCRIPTION
Problem:
PR for collect containerd logs bring in dulicated configure cause dry-run return warning

Solution:
remove duplicated configure

Issue:
https://github.com/rancher/rancher/issues/26543