### PR TITLE
fix a pytest failure caused by missing variable 

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -2803,7 +2803,7 @@ def create_service_account_configfile():
     return name
 
 
-def test_reader(file_path=None):
+def rbac_test_file_reader(file_path=None):
     """
     This method generates test cases from an input file and return the result
     that can be used to parametrize pytest cases
@@ -2811,6 +2811,8 @@ def test_reader(file_path=None):
     :return: a list of tuples of
             (cluster_role, command, authorization, service account name)
     """
+    if test_rbac_v2 == "False":
+        return []
 
     if file_path is None:
         pytest.fail("no file is provided")

--- a/tests/validation/tests/v3_api/test_rbac_2.py
+++ b/tests/validation/tests/v3_api/test_rbac_2.py
@@ -3,7 +3,7 @@ import os
 from .common import create_kubeconfig
 from .common import DATA_SUBDIR
 from .common import get_user_client_and_cluster
-from .common import test_reader
+from .common import rbac_test_file_reader
 from .common import validate_cluster_role_rbac
 from .common import if_test_rbac_v2
 
@@ -16,7 +16,7 @@ def create_project_client():
 
 @if_test_rbac_v2
 @pytest.mark.parametrize("cluster_role, command, authorization, name",
-                         test_reader(os.path.join(
+                         rbac_test_file_reader(os.path.join(
                              DATA_SUBDIR,
                              'rbac/monitoring/monitoring_rbac.json')))
 def test_monitoring_rbac_v2(cluster_role, command, authorization, name):


### PR DESCRIPTION
add a check for the value of the global variable in the test_reader method, so it returns without going forward. 