### PR TITLE
Fix embeded registry pull

### DIFF
--- a/pkg/apis/management.cattle.io/v3/tools_system_images.go
+++ b/pkg/apis/management.cattle.io/v3/tools_system_images.go
@@ -15,12 +15,12 @@ var (
 		PipelineSystemImages: projectv3.PipelineSystemImages{
 			Jenkins:       m("rancher/pipeline-jenkins-server:v0.1.4"),
 			JenkinsJnlp:   m("jenkins/jnlp-slave:3.35-4"),
-			AlpineGit:     m("rancher/pipeline-tools:v0.1.14"),
+			AlpineGit:     m("rancher/pipeline-tools:v0.1.15"),
 			PluginsDocker: m("plugins/docker:18.09"),
 			Minio:         m("minio/minio:RELEASE.2020-07-13T18-09-56Z"),
 			Registry:      m("registry:2"),
-			RegistryProxy: m("rancher/pipeline-tools:v0.1.14"),
-			KubeApply:     m("rancher/pipeline-tools:v0.1.14"),
+			RegistryProxy: m("rancher/pipeline-tools:v0.1.15"),
+			KubeApply:     m("rancher/pipeline-tools:v0.1.15"),
 		},
 		AuthSystemImages: AuthSystemImages{
 			KubeAPIAuth: m("rancher/kube-api-auth:v0.1.4"),

--- a/pkg/controllers/managementuser/pipeline/controller/pipelineexecution/deploy.go
+++ b/pkg/controllers/managementuser/pipeline/controller/pipelineexecution/deploy.go
@@ -134,7 +134,7 @@ func (l *Lifecycle) deploy(projectName string) error {
 	if err := l.reconcileRegistryCredential(projectName, token); err != nil {
 		return err
 	}
-	nginxDaemonset := getProxyDaemonset()
+	nginxDaemonset := GetProxyDaemonset()
 	if _, err := l.daemonsets.Create(nginxDaemonset); err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "Error creating the nginx proxy")
 	}
@@ -761,7 +761,7 @@ func (l *Lifecycle) getAvailablePort() (string, error) {
 
 }
 
-func getProxyDaemonset() *appsv1.DaemonSet {
+func GetProxyDaemonset() *appsv1.DaemonSet {
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: utils.PipelineNamespace,

--- a/pkg/controllers/managementuser/pipeline/controller/pipelineexecution/deploy.go
+++ b/pkg/controllers/managementuser/pipeline/controller/pipelineexecution/deploy.go
@@ -346,6 +346,9 @@ func getRegistryCredential(projectID string, token string, hostname string) (*co
 			Annotations: map[string]string{
 				projectIDFieldLabel: projectID,
 			},
+			Labels: map[string]string{
+				"cattle.io/creator": "norman",
+			},
 		},
 		Data: map[string][]byte{
 			corev1.DockerConfigJsonKey: configJSON,


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/28167

1. Adds the `cattle.io/creatorId: norman` label on registry credential creation. It is gone due to framework changes but is required in [secret controller](https://github.com/rancher/rancher/blob/0325ea11a57b59118863483cf2d4c2167b684fad/pkg/controllers/managementuser/secret/secret.go#L73)
2. Bump rancher/pipeline-tools image version for registry-proxy configuration updates.

Depend on https://github.com/rancher/pipeline-tools/pull/23 and a newer image release(expected to be `rancher/pipeline-tools:v0.1.15`)