### PR TITLE
Change cluster_version to accommodate rc versioning

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -959,7 +959,7 @@ def check_cluster_version(cluster, version):
     assert cluster_k8s_version == version, \
         "cluster_k8s_version: " + cluster_k8s_version + \
         " Expected: " + version
-    expected_k8s_version = version[:version.find("-")]
+    expected_k8s_version = version[:version.find("-rancher")]
     k8s_version = execute_kubectl_cmd("version")
     kubectl_k8s_version = k8s_version["serverVersion"]["gitVersion"]
     assert kubectl_k8s_version == expected_k8s_version, \


### PR DESCRIPTION
Changed line `expected_k8s_version = version[:version.find("-")]` to search for `"-rancher"`. This will allow us to continue automation on k8s versions such as `v1.19.0-rc.4-rancher1-1`. Otherwise, automation will fail searching for v1.19.0 when actual version is `v1.19.0-rc.4`.