### PR TITLE
Nodegroup upgrade

### DIFF
--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -169,7 +169,9 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 	status, _ := eksClusterConfigDynamic.Object["status"].(map[string]interface{})
 	phase, _ := status["phase"]
 	failureMessage, _ := status["failureMessage"].(string)
-
+	if strings.Contains(failureMessage, "403") {
+		failureMessage = fmt.Sprintf("cannot access EKS, check cloud credential: %s", failureMessage)
+	}
 	switch phase {
 	case "creating":
 		// set provisioning to unknown
@@ -274,13 +276,6 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 					return cluster, statusErr
 				}
 				return cluster, err
-			}
-		}
-
-		// check for unauthorized error
-		if failureMessage != "" {
-			if strings.Contains(failureMessage, "403") {
-				return e.setFalse(cluster, apimgmtv3.ClusterConditionUpdated, "cannot access EKS, check cloud credential")
 			}
 		}
 


### PR DESCRIPTION
**Problem:**
Users need the option to upgrade nodegroups the amazon way or to create new nodegroups and delete ones that are outdated.

**Solution:**
Nodegroup versions now must be provide. On create they must match the control plane's kubernetes version. Control plane and nodegroup versions will be validated against supported versions. More in depth validation will be performed in the eks-operator.

**Issue:**
https://github.com/rancher/rancher/issues/27777
https://github.com/rancher/rancher/issues/28968