### PR TITLE
[2.4] Fix cache inconsistencies for RoleBindings/ClusterRoleBindings

### DIFF
--- a/pkg/controllers/management/auth/indexes.go
+++ b/pkg/controllers/management/auth/indexes.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"strings"
+
 	v1 "k8s.io/api/rbac/v1"
 	meta2 "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,20 +39,25 @@ func rbRoleSubjectKeys(roleName string, subjects []v1.Subject) []string {
 }
 
 func indexByMembershipBindingOwner(obj interface{}) ([]string, error) {
-	if obj, ok := obj.(runtime.Object); ok {
-		meta, err := meta2.Accessor(obj)
-		if err != nil {
-			return nil, err
-		}
+	obj, ok := obj.(runtime.Object)
+	if !ok {
+		return []string{}, nil
+	}
 
-		for k, v := range meta.GetLabels() {
-			if v == membershipBindingOwner {
-				return []string{meta.GetNamespace() + "/" + k}, nil
-			}
+	meta, err := meta2.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	ns := meta.GetNamespace()
+	var keys []string
+	for k, v := range meta.GetLabels() {
+		if v == membershipBindingOwner {
+			keys = append(keys, strings.Join([]string{ns, k}, "/"))
 		}
 	}
 
-	return nil, nil
+	return keys, nil
 }
 
 func rbByRoleAndSubject(obj interface{}) ([]string, error) {


### PR DESCRIPTION
Issue addressed by this PR:
- rancher/rancher#28094

We were unintentionally removing important labels from cached objects. Any modifications should go through the api server so their deltas can be consumed and processed by the controller's underlying SharedIndexInformer and cache/indices can be updated accordingly. I added a deep copy to mitigate this issue. The cache no longer contains stale keys that resolve to nil objects with this change. I also addressed an issue with the `membershipBindingOwnerIndex` where we were returning once we found a single owner. Technically there can be multiple owners, so this function now returns a list of all owner keys.