### PR TITLE
Renamed provider json key name

### DIFF
--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -141,7 +141,7 @@ type ClusterStatus struct {
 	// Component statuses will represent cluster's components (etcd/controller/scheduler) health
 	// https://kubernetes.io/docs/api-reference/v1.8/#componentstatus-v1-core
 	Driver                               string                      `json:"driver"`
-	Provider                             string                      `json:"provider"`
+	Provider                             string                      `json:"clusterProvider"`
 	AgentImage                           string                      `json:"agentImage"`
 	AgentFeatures                        map[string]bool             `json:"agentFeatures,omitempty"`
 	AuthImage                            string                      `json:"authImage"`

--- a/pkg/client/generated/management/v3/zz_generated_cluster.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster.go
@@ -54,7 +54,7 @@ const (
 	ClusterFieldNodeCount                            = "nodeCount"
 	ClusterFieldNodeVersion                          = "nodeVersion"
 	ClusterFieldOwnerReferences                      = "ownerReferences"
-	ClusterFieldProvider                             = "provider"
+	ClusterFieldProvider                             = "clusterProvider"
 	ClusterFieldRancherKubernetesEngineConfig        = "rancherKubernetesEngineConfig"
 	ClusterFieldRemoved                              = "removed"
 	ClusterFieldRequested                            = "requested"
@@ -119,7 +119,7 @@ type Cluster struct {
 	NodeCount                            int64                          `json:"nodeCount,omitempty" yaml:"nodeCount,omitempty"`
 	NodeVersion                          int64                          `json:"nodeVersion,omitempty" yaml:"nodeVersion,omitempty"`
 	OwnerReferences                      []OwnerReference               `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	Provider                             string                         `json:"provider,omitempty" yaml:"provider,omitempty"`
+	Provider                             string                         `json:"clusterProvider,omitempty" yaml:"clusterProvider,omitempty"`
 	RancherKubernetesEngineConfig        *RancherKubernetesEngineConfig `json:"rancherKubernetesEngineConfig,omitempty" yaml:"rancherKubernetesEngineConfig,omitempty"`
 	Removed                              string                         `json:"removed,omitempty" yaml:"removed,omitempty"`
 	Requested                            map[string]string              `json:"requested,omitempty" yaml:"requested,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_cluster_status.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_status.go
@@ -25,7 +25,7 @@ const (
 	ClusterStatusFieldMonitoringStatus                     = "monitoringStatus"
 	ClusterStatusFieldNodeCount                            = "nodeCount"
 	ClusterStatusFieldNodeVersion                          = "nodeVersion"
-	ClusterStatusFieldProvider                             = "provider"
+	ClusterStatusFieldProvider                             = "clusterProvider"
 	ClusterStatusFieldRequested                            = "requested"
 	ClusterStatusFieldScheduledClusterScanStatus           = "scheduledClusterScanStatus"
 	ClusterStatusFieldVersion                              = "version"
@@ -55,7 +55,7 @@ type ClusterStatus struct {
 	MonitoringStatus                     *MonitoringStatus           `json:"monitoringStatus,omitempty" yaml:"monitoringStatus,omitempty"`
 	NodeCount                            int64                       `json:"nodeCount,omitempty" yaml:"nodeCount,omitempty"`
 	NodeVersion                          int64                       `json:"nodeVersion,omitempty" yaml:"nodeVersion,omitempty"`
-	Provider                             string                      `json:"provider,omitempty" yaml:"provider,omitempty"`
+	Provider                             string                      `json:"clusterProvider,omitempty" yaml:"clusterProvider,omitempty"`
 	Requested                            map[string]string           `json:"requested,omitempty" yaml:"requested,omitempty"`
 	ScheduledClusterScanStatus           *ScheduledClusterScanStatus `json:"scheduledClusterScanStatus,omitempty" yaml:"scheduledClusterScanStatus,omitempty"`
 	Version                              *Info                       `json:"version,omitempty" yaml:"version,omitempty"`


### PR DESCRIPTION
Renamed cluster's provider field's json key from "provider" to
"clusterProvider". This is because the UI computes values for
provider which are overridden when it is provided. This causes
the EKS edit UI to not properly show. The values from this
field cannot always be used in place of the computed provider.
For example, EKSv1 and EKSv2 would have the same provider
value in the backend but need to be handled differently in the
UI.

**Issue:**
https://github.com/rancher/rancher/issues/28355