### PR TITLE
Multi import fix

### DIFF
--- a/pkg/api/norman/server/managementstored/setup.go
+++ b/pkg/api/norman/server/managementstored/setup.go
@@ -272,6 +272,7 @@ func Clusters(schemas *types.Schemas, managementContext *config.ScaledContext, c
 	schema.ActionHandler = handler.ClusterActionHandler
 
 	clusterValidator := ccluster.Validator{
+		ClusterClient:                 managementContext.Management.Clusters(""),
 		ClusterLister:                 managementContext.Management.Clusters("").Controller().Lister(),
 		ClusterTemplateLister:         managementContext.Management.ClusterTemplates("").Controller().Lister(),
 		ClusterTemplateRevisionLister: managementContext.Management.ClusterTemplateRevisions("").Controller().Lister(),


### PR DESCRIPTION
**Problem:**
User can create multiple Rancher clusters referencing the same EKS cluster.

**Solution:**
Add validation to check that a Rancher cluster does not already exist with the given displayName.

**Issue:**
https://github.com/rancher/rancher/issues/28130