### PR TITLE
Record provisioning errors from eks-operator

### DIFF
--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -162,6 +162,7 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 	// get EKS Cluster Config's phase
 	status, _ := eksClusterConfigDynamic.Object["status"].(map[string]interface{})
 	phase, _ := status["phase"]
+	failureMessage, _ := status["failureMessage"].(string)
 
 	switch phase {
 	case "creating":
@@ -171,9 +172,13 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 			return cluster, err
 		}
 
-		logrus.Infof("waiting for EKS cluster [%s] to finish creating", cluster.Name)
 		e.clusterEnqueueAfter(cluster.Name, 20*time.Second)
-		return cluster, nil
+		if failureMessage == "" {
+			logrus.Infof("waiting for cluster EKS [%s] to finish creating", cluster.Name)
+			return e.setUnknown(cluster, apimgmtv3.ClusterConditionProvisioned, "")
+		}
+		logrus.Infof("waiting for cluster EKS [%s] create failure to be resolved", cluster.Name)
+		return e.setFalse(cluster, apimgmtv3.ClusterConditionProvisioned, failureMessage)
 	case "active":
 		if cluster.Spec.EKSConfig.Imported {
 			// copy upstream spec if newly imported
@@ -224,7 +229,7 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 		}
 
 		// check for unauthorized error
-		if failureMessage, _ := status["failureMessage"].(string); failureMessage != "" {
+		if failureMessage != "" {
 			if strings.Contains(failureMessage, "403") {
 				return e.setFalse(cluster, apimgmtv3.ClusterConditionUpdated, "cannot access EKS, check cloud credential")
 			}
@@ -237,7 +242,6 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 			return cluster, err
 		}
 
-		failureMessage, _ := status["failureMessage"].(string)
 		e.clusterEnqueueAfter(cluster.Name, 20*time.Second)
 		if failureMessage == "" {
 			logrus.Infof("waiting for cluster EKS [%s] to update", cluster.Name)
@@ -256,7 +260,20 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 			logrus.Infof("waiting for cluster create [%s] to start", cluster.Name)
 		}
 		e.clusterEnqueueAfter(cluster.Name, 20*time.Second)
-		return cluster, nil
+		if failureMessage == "" {
+			if cluster.Spec.EKSConfig.Imported {
+				cluster, err = e.setUnknown(cluster, apimgmtv3.ClusterConditionPending, "")
+				if err != nil {
+					return cluster, err
+				}
+				logrus.Infof("waiting for cluster import [%s] to start", cluster.Name)
+			} else {
+				logrus.Infof("waiting for cluster create [%s] to start", cluster.Name)
+			}
+			return e.setUnknown(cluster, apimgmtv3.ClusterConditionProvisioned, "")
+		}
+		logrus.Infof("waiting for cluster EKS [%s] pre-create failure to be resolved", cluster.Name)
+		return e.setFalse(cluster, apimgmtv3.ClusterConditionProvisioned, failureMessage)
 	}
 }
 


### PR DESCRIPTION
**Problem:**
Errors are not displayed to user during provisioning.

**Solution:**
Copy failure message from EKS cluster config object to Rancher cluster. If it is not empty set provisioning to false.

**Issue:**
https://github.com/rancher/rancher/issues/28129