### PR TITLE
[v2.3] utilize proxy in proxy handler

### DIFF
--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -167,6 +167,7 @@ func (r *RemoteService) getTransport() (http.RoundTripper, error) {
 			return nil, err
 		}
 		transport.Dial = d
+		transport.Proxy = http.ProxyFromEnvironment
 	}
 
 	r.caCert = newCluster.Status.CACert


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/25488 

**Setup:** 
Spin up Rancher HA in semi-airgapped environment (with HTTP/HTTPS forward proxies and no ability for Rancher to directly access the internet without utilizing these forward proxies)
Attempt to provision a ClusterDriver cluster (GKE, EKS, AKS for example)

**Note** 
Only tested for ClusterDriver clusters, but I'm guessing it'd also break for RKE clusters -- Couldn't test that out because of https://github.com/rancher/rancher/issues/28411 

**Issues:** 
(1) agents are unable to deploy into the cluster and the cluster never finishes provisioning 
This is because the request doesn't go through proxy and directly to cluster's endpoint. 

(2) kubectl exec shell and view logs from UI doesn't work 
For upgrade requests, the `UpgradeAwareHandler` doesn't use transport.Proxy but instead relies on the dialer. We pass only native dialer for cloud drivers which don't utilize proxy. 

**Solution:**
I could think of 2 ways to fix this: This PR implements (a) 
(a) Setting transport.Proxy for all requests + Custom proxy for upgrade requests 
- Applies to all clusters, Setting `transport.Proxy = http.ProxyFromEnvironment` on transport from cluster dialer fixes the issue. While this applies to all clusters, I think it makes sense that all requests go through the configured proxy unless no_proxy is set.
- Custom proxy for upgrade requests is similar to `UpgradeAwareHandler` avoiding the upgrade path 

(b) Change the cloud driver's dialer function to handle the connect to proxy 
- Applies to only hosted providers, sample implementation - https://github.com/rancher/rancher/pull/28413 (uses code for http proxy from an existing gist I found online, not sure of the licensing)  