### PR TITLE
Add labels to link PRTB/CRTB to RB/CRB  by namespace+name

### DIFF
--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/types/slice"
+	"github.com/rancher/rancher/pkg/clustermanager"
 	v13 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	typesrbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
@@ -19,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -36,15 +38,18 @@ func newRTBLifecycles(management *config.ManagementContext) (*prtbLifecycle, *cr
 			mgmt:          management,
 			projectLister: management.Management.Projects("").Controller().Lister(),
 			crbLister:     management.RBAC.ClusterRoleBindings("").Controller().Lister(),
+			crbClient:     management.RBAC.ClusterRoleBindings(""),
 			crLister:      management.RBAC.ClusterRoles("").Controller().Lister(),
 			rLister:       management.RBAC.Roles("").Controller().Lister(),
 			rbLister:      management.RBAC.RoleBindings("").Controller().Lister(),
+			rbClient:      management.RBAC.RoleBindings(""),
 			rtLister:      management.Management.RoleTemplates("").Controller().Lister(),
 			userLister:    management.Management.Users("").Controller().Lister(),
 			rbIndexer:     rbInformer.GetIndexer(),
 			crbIndexer:    crbInformer.GetIndexer(),
 			userMGR:       management.UserManager,
 			controller:    ptrbMGMTController,
+			prtbs:         management.Management.ProjectRoleTemplateBindings(""),
 		},
 		projectLister: management.Management.Projects("").Controller().Lister(),
 		clusterLister: management.Management.Clusters("").Controller().Lister(),
@@ -54,15 +59,18 @@ func newRTBLifecycles(management *config.ManagementContext) (*prtbLifecycle, *cr
 			mgmt:          management,
 			projectLister: management.Management.Projects("").Controller().Lister(),
 			crbLister:     management.RBAC.ClusterRoleBindings("").Controller().Lister(),
+			crbClient:     management.RBAC.ClusterRoleBindings(""),
 			crLister:      management.RBAC.ClusterRoles("").Controller().Lister(),
 			rLister:       management.RBAC.Roles("").Controller().Lister(),
 			rbLister:      management.RBAC.RoleBindings("").Controller().Lister(),
+			rbClient:      management.RBAC.RoleBindings(""),
 			rtLister:      management.Management.RoleTemplates("").Controller().Lister(),
 			userLister:    management.Management.Users("").Controller().Lister(),
 			rbIndexer:     rbInformer.GetIndexer(),
 			crbIndexer:    crbInformer.GetIndexer(),
 			userMGR:       management.UserManager,
 			controller:    ctrbMGMTController,
+			crtbs:         management.Management.ClusterRoleTemplateBindings(""),
 		},
 		clusterLister: management.Management.Clusters("").Controller().Lister(),
 	}
@@ -70,31 +78,36 @@ func newRTBLifecycles(management *config.ManagementContext) (*prtbLifecycle, *cr
 }
 
 type manager struct {
-	projectLister v3.ProjectLister
-	crLister      typesrbacv1.ClusterRoleLister
-	rLister       typesrbacv1.RoleLister
-	rbLister      typesrbacv1.RoleBindingLister
-	crbLister     typesrbacv1.ClusterRoleBindingLister
-	rtLister      v3.RoleTemplateLister
-	nsLister      v13.NamespaceLister
-	userLister    v3.UserLister
-	rbIndexer     cache.Indexer
-	crbIndexer    cache.Indexer
-	mgmt          *config.ManagementContext
-	userMGR       user.Manager
-	controller    string
+	projectLister  v3.ProjectLister
+	crLister       typesrbacv1.ClusterRoleLister
+	rLister        typesrbacv1.RoleLister
+	rbLister       typesrbacv1.RoleBindingLister
+	rbClient       typesrbacv1.RoleBindingInterface
+	crbLister      typesrbacv1.ClusterRoleBindingLister
+	crbClient      typesrbacv1.ClusterRoleBindingInterface
+	rtLister       v3.RoleTemplateLister
+	nsLister       v13.NamespaceLister
+	userLister     v3.UserLister
+	rbIndexer      cache.Indexer
+	crbIndexer     cache.Indexer
+	mgmt           *config.ManagementContext
+	userMGR        user.Manager
+	controller     string
+	clusterManager *clustermanager.Manager
+	crtbs          v3.ClusterRoleTemplateBindingInterface
+	prtbs          v3.ProjectRoleTemplateBindingInterface
 }
 
 // When a CRTB is created that gives a subject some permissions in a project or cluster, we need to create a "membership" binding
 // that gives the subject access to the the cluster custom resource itself
 // This is painfully similar to ensureProjectMemberBinding, but making one function that handles both is overly complex
-func (m *manager) ensureClusterMembershipBinding(roleName, rtbUID string, cluster *v3.Cluster, makeOwner bool, subject v1.Subject) error {
+func (m *manager) ensureClusterMembershipBinding(roleName, rtbNsAndName string, cluster *v3.Cluster, makeOwner bool, subject v1.Subject) error {
 	if err := m.createClusterMembershipRole(roleName, cluster, makeOwner); err != nil {
 		return err
 	}
 
 	key := rbRoleSubjectKey(roleName, subject)
-	crbs, err := m.crbIndexer.ByIndex(membershipBindingOwnerIndex, "/"+rtbUID)
+	crbs, err := m.crbIndexer.ByIndex(membershipBindingOwnerIndex, "/"+rtbNsAndName)
 	if err != nil {
 		return err
 	}
@@ -111,7 +124,7 @@ func (m *manager) ensureClusterMembershipBinding(roleName, rtbUID string, cluste
 		}
 	}
 
-	if err := m.reconcileClusterMembershipBindingForDelete(roleName, rtbUID); err != nil {
+	if err := m.reconcileClusterMembershipBindingForDelete(roleName, rtbNsAndName); err != nil {
 		return err
 	}
 
@@ -130,7 +143,7 @@ func (m *manager) ensureClusterMembershipBinding(roleName, rtbUID string, cluste
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "clusterrolebinding-",
 				Labels: map[string]string{
-					rtbUID: membershipBindingOwner,
+					rtbNsAndName: membershipBindingOwner,
 				},
 			},
 			Subjects: []v1.Subject{subject},
@@ -144,7 +157,7 @@ func (m *manager) ensureClusterMembershipBinding(roleName, rtbUID string, cluste
 
 	crb, _ = objs[0].(*v1.ClusterRoleBinding)
 	for owner := range crb.Labels {
-		if rtbUID == owner {
+		if rtbNsAndName == owner {
 			return nil
 		}
 	}
@@ -153,7 +166,7 @@ func (m *manager) ensureClusterMembershipBinding(roleName, rtbUID string, cluste
 	if crb.Labels == nil {
 		crb.Labels = map[string]string{}
 	}
-	crb.Labels[rtbUID] = membershipBindingOwner
+	crb.Labels[rtbNsAndName] = membershipBindingOwner
 	logrus.Infof("[%v] Updating clusterRoleBinding %v for cluster membership in cluster %v for subject %v", m.controller, crb.Name, cluster.Name, subject.Name)
 	_, err = m.mgmt.RBAC.ClusterRoleBindings("").Update(crb)
 	return err
@@ -161,13 +174,13 @@ func (m *manager) ensureClusterMembershipBinding(roleName, rtbUID string, cluste
 
 // When a PRTB is created that gives a subject some permissions in a project or cluster, we need to create a "membership" binding
 // that gives the subject access to the the project/cluster custom resource itself
-func (m *manager) ensureProjectMembershipBinding(roleName, rtbUID, namespace string, project *v3.Project, makeOwner bool, subject v1.Subject) error {
+func (m *manager) ensureProjectMembershipBinding(roleName, rtbNsAndName, namespace string, project *v3.Project, makeOwner bool, subject v1.Subject) error {
 	if err := m.createProjectMembershipRole(roleName, namespace, project, makeOwner); err != nil {
 		return err
 	}
 
 	key := rbRoleSubjectKey(roleName, subject)
-	rbs, err := m.rbIndexer.ByIndex(membershipBindingOwnerIndex, namespace+"/"+rtbUID)
+	rbs, err := m.rbIndexer.ByIndex(membershipBindingOwnerIndex, namespace+"/"+rtbNsAndName)
 	if err != nil {
 		return err
 	}
@@ -184,7 +197,7 @@ func (m *manager) ensureProjectMembershipBinding(roleName, rtbUID, namespace str
 		}
 	}
 
-	if err := m.reconcileProjectMembershipBindingForDelete(namespace, roleName, rtbUID); err != nil {
+	if err := m.reconcileProjectMembershipBindingForDelete(namespace, roleName, rtbNsAndName); err != nil {
 		return err
 	}
 
@@ -203,7 +216,7 @@ func (m *manager) ensureProjectMembershipBinding(roleName, rtbUID, namespace str
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "rolebinding-",
 				Labels: map[string]string{
-					rtbUID: membershipBindingOwner,
+					rtbNsAndName: membershipBindingOwner,
 				},
 			},
 			Subjects: []v1.Subject{subject},
@@ -217,7 +230,7 @@ func (m *manager) ensureProjectMembershipBinding(roleName, rtbUID, namespace str
 
 	rb, _ = objs[0].(*v1.RoleBinding)
 	for owner := range rb.Labels {
-		if rtbUID == owner {
+		if rtbNsAndName == owner {
 			return nil
 		}
 	}
@@ -226,7 +239,7 @@ func (m *manager) ensureProjectMembershipBinding(roleName, rtbUID, namespace str
 	if rb.Labels == nil {
 		rb.Labels = map[string]string{}
 	}
-	rb.Labels[rtbUID] = membershipBindingOwner
+	rb.Labels[rtbNsAndName] = membershipBindingOwner
 	logrus.Infof("[%v] Updating roleBinding %v for project membership in project %v for subject %v", m.controller, rb.Name, project.Name, subject.Name)
 	_, err = m.mgmt.RBAC.RoleBindings(namespace).Update(rb)
 	return err
@@ -303,24 +316,24 @@ func (m *manager) createMembershipRole(resourceType, roleName string, makeOwner 
 
 // The CRTB has been deleted or modified, either delete or update the membership binding so that the subject
 // is removed from the cluster if they should be
-func (m *manager) reconcileClusterMembershipBindingForDelete(roleToKeep, rtbUID string) error {
+func (m *manager) reconcileClusterMembershipBindingForDelete(roleToKeep, rtbNsAndName string) error {
 	convert := func(i interface{}) string {
 		rb, _ := i.(*v1.ClusterRoleBinding)
 		return rb.RoleRef.Name
 	}
 
-	return m.reconcileMembershipBindingForDelete("", roleToKeep, rtbUID, m.crbIndexer, convert, m.mgmt.RBAC.ClusterRoleBindings("").ObjectClient())
+	return m.reconcileMembershipBindingForDelete("", roleToKeep, rtbNsAndName, m.crbIndexer, convert, m.mgmt.RBAC.ClusterRoleBindings("").ObjectClient())
 }
 
 // The PRTB has been deleted, either delete or update the project membership binding so that the subject
 // is removed from the project if they should be
-func (m *manager) reconcileProjectMembershipBindingForDelete(namespace, roleToKeep, rtbUID string) error {
+func (m *manager) reconcileProjectMembershipBindingForDelete(namespace, roleToKeep, rtbNsAndName string) error {
 	convert := func(i interface{}) string {
 		rb, _ := i.(*v1.RoleBinding)
 		return rb.RoleRef.Name
 	}
 
-	return m.reconcileMembershipBindingForDelete(namespace, roleToKeep, rtbUID, m.rbIndexer, convert, m.mgmt.RBAC.RoleBindings(namespace).ObjectClient())
+	return m.reconcileMembershipBindingForDelete(namespace, roleToKeep, rtbNsAndName, m.rbIndexer, convert, m.mgmt.RBAC.RoleBindings(namespace).ObjectClient())
 }
 
 type convertFn func(i interface{}) string
@@ -464,6 +477,7 @@ func (m *manager) grantManagementClusterScopedPrivilegesInProjectNamespace(roleT
 
 	desiredRBs := map[string]*v1.RoleBinding{}
 	roleBindings := m.mgmt.RBAC.RoleBindings(projectNamespace)
+	bindingKey := getRTBLabelKey(binding.ObjectMeta)
 	for _, role := range roles {
 		resourceToVerbs := map[string]map[string]bool{}
 		for resource, apiGroup := range resources {
@@ -486,7 +500,7 @@ func (m *manager) grantManagementClusterScopedPrivilegesInProjectNamespace(roleT
 						ObjectMeta: metav1.ObjectMeta{
 							Name: bindingName,
 							Labels: map[string]string{
-								string(binding.UID): crtbInProjectBindingOwner,
+								bindingKey: crtbInProjectBindingOwner,
 							},
 						},
 						Subjects: []v1.Subject{subject},
@@ -506,7 +520,7 @@ func (m *manager) grantManagementClusterScopedPrivilegesInProjectNamespace(roleT
 	}
 
 	currentRBs := map[string]*v1.RoleBinding{}
-	set := labels.Set(map[string]string{string(binding.UID): crtbInProjectBindingOwner})
+	set := labels.Set(map[string]string{bindingKey: crtbInProjectBindingOwner})
 	current, err := m.rbLister.List(projectNamespace, set.AsSelector())
 	if err != nil {
 		return err
@@ -529,6 +543,7 @@ func (m *manager) grantManagementProjectScopedPrivilegesInClusterNamespace(roleT
 
 	desiredRBs := map[string]*v1.RoleBinding{}
 	roleBindings := m.mgmt.RBAC.RoleBindings(clusterNamespace)
+	bindingKey := getRTBLabelKey(binding.ObjectMeta)
 	for _, role := range roles {
 		resourceToVerbs := map[string]map[string]bool{}
 		for resource, apiGroup := range resources {
@@ -546,7 +561,7 @@ func (m *manager) grantManagementProjectScopedPrivilegesInClusterNamespace(roleT
 						ObjectMeta: metav1.ObjectMeta{
 							Name: bindingName,
 							Labels: map[string]string{
-								string(binding.UID): prtbInClusterBindingOwner,
+								bindingKey: prtbInClusterBindingOwner,
 							},
 						},
 						Subjects: []v1.Subject{subject},
@@ -566,7 +581,7 @@ func (m *manager) grantManagementProjectScopedPrivilegesInClusterNamespace(roleT
 	}
 
 	currentRBs := map[string]*v1.RoleBinding{}
-	set := labels.Set(map[string]string{string(binding.UID): prtbInClusterBindingOwner})
+	set := labels.Set(map[string]string{bindingKey: prtbInClusterBindingOwner})
 	current, err := m.rbLister.List(clusterNamespace, set.AsSelector())
 	if err != nil {
 		return err
@@ -791,4 +806,20 @@ func (m *manager) checkReferencedRoles(roleTemplateName string) (bool, error) {
 		}
 	}
 	return isOwnerRole, nil
+}
+
+func getLabelRequirements(bindingNamespace, bindingName string) ([]labels.Requirement, error) {
+	reqUpdatedLabel, err := labels.NewRequirement(rtbLabelUpdated, selection.DoesNotExist, []string{})
+	if err != nil {
+		return []labels.Requirement{}, err
+	}
+	reqNsAndNameLabel, err := labels.NewRequirement(bindingNamespace+"_"+bindingName, selection.DoesNotExist, []string{})
+	if err != nil {
+		return []labels.Requirement{}, err
+	}
+	return []labels.Requirement{*reqUpdatedLabel, *reqNsAndNameLabel}, nil
+}
+
+func getRTBLabelKey(bindingMeta metav1.ObjectMeta) string {
+	return bindingMeta.Namespace + "_" + bindingMeta.Name
 }

--- a/pkg/controllers/managementuser/rbac/globalrole_handler.go
+++ b/pkg/controllers/managementuser/rbac/globalrole_handler.go
@@ -37,6 +37,7 @@ func RegisterIndexers(ctx context.Context, scaledContext *config.ScaledContext) 
 		prtbByProjecSubjectIndex:         prtbByProjectAndSubject,
 		rtbByClusterAndRoleTemplateIndex: rtbByClusterAndRoleTemplateName,
 		prtbByUIDIndex:                   prtbByUID,
+		prtbByNsAndNameIndex:             prtbByNsName,
 	}
 	if err := prtbInformer.AddIndexers(prtbIndexers); err != nil {
 		return err

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -138,13 +138,23 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 	// Get project that contain this namespace
 	projectID := ns.Annotations[projectIDAnnotation]
 	if len(projectID) == 0 {
+		// if namespace does not belong to a project, delete all rolebindings from that namespace that were created for a PRTB
+		// such rolebindings will have the label "authz.cluster.cattle.io/rtb-owner" prior to 2.5 and
+		// "authz.cluster.cattle.io/rtb-owner-updated" 2.5 onwards
 		rbs, err := n.m.rbLister.List(ns.Name, labels.Everything())
 		if err != nil {
 			return false, errors.Wrapf(err, "couldn't list role bindings in %s", ns.Name)
 		}
 		client := n.m.workload.RBAC.RoleBindings(ns.Name).ObjectClient()
 		for _, rb := range rbs {
-			if uid := convert.ToString(rb.Labels[rtbOwnerLabel]); uid != "" {
+			// rtbOwnerLabelLegacy
+			if uid := convert.ToString(rb.Labels[rtbOwnerLabelLegacy]); uid != "" {
+				logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
+				if err := client.Delete(rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+					return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
+				}
+			}
+			if nsAndName := convert.ToString(rb.Labels[rtbOwnerLabel]); nsAndName != "" {
 				logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
 				if err := client.Delete(rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 					return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
@@ -208,7 +218,7 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 	client := n.m.workload.RBAC.RoleBindings(ns.Name).ObjectClient()
 
 	for _, rb := range rbs {
-		if uid := convert.ToString(rb.Labels[rtbOwnerLabel]); uid != "" {
+		if uid := convert.ToString(rb.Labels[rtbOwnerLabelLegacy]); uid != "" {
 			prtbs, err := n.m.prtbIndexer.ByIndex(prtbByUIDIndex, uid)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
@@ -228,8 +238,28 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 				}
 			}
 		}
-	}
 
+		if nsAndName := convert.ToString(rb.Labels[rtbOwnerLabel]); nsAndName != "" {
+			prtbs, err := n.m.prtbIndexer.ByIndex(prtbByNsAndNameIndex, nsAndName)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				} else {
+					return false, errors.Wrapf(err, "couldn't find prtb for %s", rb.Name)
+				}
+			}
+			for _, prtb := range prtbs {
+				if prtb, ok := prtb.(*v3.ProjectRoleTemplateBinding); ok {
+					if prtb.Namespace != namespace {
+						logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
+						if err := client.Delete(rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+							return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
+						}
+					}
+				}
+			}
+		}
+	}
 	return hasPRTBs, nil
 }
 

--- a/pkg/controllers/managementuser/rbac/reconcile_roletemplate.go
+++ b/pkg/controllers/managementuser/rbac/reconcile_roletemplate.go
@@ -75,7 +75,7 @@ func (m *manager) reconcileProjectAccessToGlobalResources(binding *v3.ProjectRol
 		}
 	}
 
-	rtbUID := string(binding.UID)
+	rtbUID := binding.Namespace + "_" + binding.Name
 	subject, err := pkgrbac.BuildSubjectFromRTB(binding)
 	if err != nil {
 		return nil, err

--- a/tests/integration/suite/test_rbac.py
+++ b/tests/integration/suite/test_rbac.py
@@ -250,9 +250,12 @@ def test_removing_user_from_cluster(admin_pc, admin_mc, user_mc, admin_cc,
     api_instance = kubernetes.client.RbacAuthorizationV1Api(
         admin_mc.k8s_client)
 
+    split = str.split(prtb.id, ":")
+    prtb_key = split[0]+"_"+split[1]
+
     # Find the expected k8s clusterRoleBinding
     crbs = api_instance.list_cluster_role_binding(
-        label_selector=prtb.uuid + "=" + mbo)
+        label_selector=prtb_key + "=" + mbo)
 
     assert len(crbs.items) == 1
 
@@ -262,7 +265,7 @@ def test_removing_user_from_cluster(admin_pc, admin_mc, user_mc, admin_cc,
 
     def crb_callback():
         crbs = api_instance.list_cluster_role_binding(
-            label_selector=prtb.uuid + "=" + mbo)
+            label_selector=prtb_key + "=" + mbo)
         return len(crbs.items) == 0
 
     def fail_handler():


### PR DESCRIPTION
The projectroletemplatebinding and clusterroletemplatebinding UIDs are used as label keys for
clusterrolebindings and rolebindings in the management cluster as follows
* CRTB.UID is the label key for a CRB, CRTB.UID=memberhsip-binding-owner
* CRTB.UID is label key for the RB, CRTB.UID=crtb-in-project-binding-owner (in the namespace of each project in the cluster that the user has access to)
* PRTB.UID  is the label key for a CRB, PRTB.UID=memberhsip-binding-owner (with role c-xxxx-clustermember)
* PRTB.UID is the label key for RB, PRTB.UID=memberhsip-binding-owner (with role denoting the permissions in project)
* PRTB.UID is also the label key for RB, PRTB.UID=prtb-in-cluster-binding-owner (with role=exact roletemplate ID)

PRTB/CRTB are also used as label values for clusterrolebindings and rolebindings in user clusters
* CRTB.UID is label value for CRB, authz.cluster.cattle.io/rtb-owner=CRTB.UID
* PRTB.UID is label key for CRB, PRTB.UID=owner-user
* PRTB.UID is the label value for RBs, authz.cluster.cattle.io/rtb-owner=PRTB.UID

With the backup-restore-operator, there are two cases in which using UIDs as labels on rolebindings/clusterrolebindings will not give users correct permissions:
1. Migrating rancher to a new cluster: In this case, all PRTB/CRTBs will get newly created on the new server, and so their UIDs will be newly generated. But the rolebindings/clusterrolebindings will be still using the older UIDs as labels, and there's no way to update them.
2. Restoring on the same cluster with the intention to add back project/cluster members that were removed: An example of this use case:
   1. Add a user user1 as cluster-owner
   2. Take a backup
   3. Remove user1 from the cluster
   4. Restore from backup
In this case, the backup saves the RB/CRB linked to the CRTB with the label containing CRTB.UID, and once the user is removed, its CRTB will be deleted. So on restore, CRTB will be newly created so its UID changes, and there's no way to update the label on the corresponding CRB/RB.

As a solution, this commit adds a label for the RB/CRBs associated with any CRTB/PRTB with key "CRTB.Namespace_CRTB.Name" OR "PRTB.Namespace_PRTB.Name", in addition to the CRTB.UID and PRTB.UID respectively.
So 2.5 fresh install onwards the only label will be "CRTB.Namespace_CRTB.Name" OR "PRTB.Namespace_PRTB.Name"
But on upgraded setups this new label will be in addition to the label containing CRTB.UID or PRTB.UID to cover the rollback scenario
https://github.com/rancher/rancher/issues/28370
https://github.com/rancher/backup-restore-operator/issues/25