### PR TITLE
[v2.4] add retry for creating kubeconfig tokens

### DIFF
--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -103,7 +103,7 @@ func (m *Manager) createDerivedToken(jsonInput clientv3.Token, tokenAuthValue st
 		return v3.Token{}, 401, err
 	}
 
-	tokenTTL, err := ValidateMaxTTL(time.Duration(int(jsonInput.TTLMillis)) * time.Minute)
+	tokenTTL, err := ValidateMaxTTL(time.Duration(int(jsonInput.TTLMillis)) * time.Millisecond)
 	if err != nil {
 		return v3.Token{}, 500, fmt.Errorf("error validating max-ttl %v", err)
 	}


### PR DESCRIPTION
If token's expired and still being deleted, create tokens would fail