### PR TITLE
[2.4] Changes for detecting admin & cluster ownership

### DIFF
--- a/pkg/controllers/user/rbac/globalrole_handler.go
+++ b/pkg/controllers/user/rbac/globalrole_handler.go
@@ -1,10 +1,12 @@
 package rbac
 
 import (
+	"github.com/rancher/norman/types/slice"
 	"github.com/rancher/rancher/pkg/rbac"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	rbacv1 "github.com/rancher/types/apis/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
 	v12 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +29,9 @@ func newGlobalRoleBindingHandler(workload *config.UserContext) v3.GlobalRoleBind
 		grbIndexer:          informer.GetIndexer(),
 		clusterRoleBindings: workload.RBAC.ClusterRoleBindings(""),
 		crbLister:           workload.RBAC.ClusterRoleBindings("").Controller().Lister(),
+		grLister:            workload.Management.Management.GlobalRoles("").Controller().Lister(),
 	}
+
 	return h.sync
 }
 
@@ -36,13 +40,23 @@ func newGlobalRoleBindingHandler(workload *config.UserContext) v3.GlobalRoleBind
 type grbHandler struct {
 	clusterRoleBindings rbacv1.ClusterRoleBindingInterface
 	crbLister           rbacv1.ClusterRoleBindingLister
+	grLister            v3.GlobalRoleLister
 	grbIndexer          cache.Indexer
 }
 
 func (c *grbHandler) sync(key string, obj *v3.GlobalRoleBinding) (runtime.Object, error) {
-	if obj == nil || obj.DeletionTimestamp != nil || obj.GlobalRoleName != "admin" {
+	if obj == nil || obj.DeletionTimestamp != nil {
 		return obj, nil
 	}
+
+	isAdmin, err := c.isAdminRole(obj.GlobalRoleName)
+	if err != nil {
+		return nil, err
+	} else if !isAdmin {
+		return obj, nil
+	}
+
+	logrus.Debugf("%v is an admin role", obj.GlobalRoleName)
 
 	bindingName := rbac.GrbCRBName(obj)
 	b, err := c.crbLister.Get("", bindingName)
@@ -70,7 +84,40 @@ func (c *grbHandler) sync(key string, obj *v3.GlobalRoleBinding) (runtime.Object
 			return obj, err
 		}
 	}
+
 	return obj, nil
+}
+
+// isAdminRole detects whether a GlobalRole has admin permissions or not.
+func (c *grbHandler) isAdminRole(rtName string) (bool, error) {
+	gr, err := c.grLister.Get("", rtName)
+	if err != nil {
+		return false, err
+	}
+
+	// global role is builtin admin role
+	if gr.Builtin && gr.Name == "admin" {
+		return true, nil
+	}
+
+	var hasResourceRule, hasNonResourceRule bool
+	for _, rule := range gr.Rules {
+		if slice.ContainsString(rule.Resources, "*") && slice.ContainsString(rule.APIGroups, "*") && slice.ContainsString(rule.Verbs, "*") {
+			hasResourceRule = true
+			continue
+		}
+		if slice.ContainsString(rule.NonResourceURLs, "*") && slice.ContainsString(rule.Verbs, "*") {
+			hasNonResourceRule = true
+			continue
+		}
+	}
+
+	// global role has an admin resource rule, and admin nonResourceURLs rule
+	if hasResourceRule && hasNonResourceRule {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func grbByUserAndRole(obj interface{}) ([]string, error) {

--- a/pkg/controllers/user/rbac/handler_base.go
+++ b/pkg/controllers/user/rbac/handler_base.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/types/convert"
+	"github.com/rancher/norman/types/slice"
 	"github.com/rancher/rancher/pkg/controllers/user/resourcequota"
 	nsutils "github.com/rancher/rancher/pkg/namespace"
 	pkgrbac "github.com/rancher/rancher/pkg/rbac"
@@ -207,9 +208,14 @@ func (m *manager) createClusterRole(rt *v3.RoleTemplate) error {
 }
 
 func (m *manager) ensureNamespacedRoles(rt *v3.RoleTemplate) error {
-	if rt.Name == "cluster-owner" {
+	isClusterOwner, err := m.isClusterOwner(rt.Name)
+	if err != nil {
+		return err
+	} else if isClusterOwner {
 		return nil
 	}
+
+	// role template is not a cluster owner
 	switch rt.Context {
 	case "cluster":
 		if err := m.updateRole(rt, m.clusterName); err != nil {
@@ -226,7 +232,47 @@ func (m *manager) ensureNamespacedRoles(rt *v3.RoleTemplate) error {
 			}
 		}
 	}
+
 	return nil
+}
+
+// isClusterOwner checks if a role template is cluster-owner, has cluster ownership rules, or inherits from a role template that grants cluster ownership.
+func (m *manager) isClusterOwner(rtName string) (bool, error) {
+	rt, err := m.rtLister.Get("", rtName)
+	if err != nil {
+		return false, err
+	}
+
+	// role template is the builtin cluster-owner
+	if rt.Builtin && rt.Context == "cluster" && rt.Name == "cluster-owner" {
+		return true, nil
+	}
+
+	// role template has rules for cluster ownership
+	for _, rule := range rt.Rules {
+		if slice.ContainsString(rule.Resources, "clusters") {
+			if slice.ContainsString(rule.Verbs, "own") {
+				return true, nil
+			}
+		}
+	}
+
+	isOwner := false
+	if len(rt.RoleTemplateNames) > 0 {
+		for _, inherited := range rt.RoleTemplateNames {
+			// recurse on inherited role template to check for cluster ownership
+			isOwner, err = m.isClusterOwner(inherited)
+			if err != nil {
+				return false, err
+			}
+
+			if isOwner {
+				return true, nil
+			}
+		}
+	}
+
+	return isOwner, nil
 }
 
 func (m *manager) updateRole(rt *v3.RoleTemplate, namespace string) error {


### PR DESCRIPTION
A role template with cluster ownership permissions can be either:
1. Builtin `Cluster Owner`
2. Have rules for "own" on "clusters" resources
3. Inherit from a role template that has 1. or 2.

When a user is added to a cluster with any of 1, 2, or 3, there should not be any namespaced roles created, this PR fixes an issue where that was happening and leading to errors. 

When a user is created and associated to a role, if they are associated to a global role with admin permissions that isn't admin, they are not getting the proper permissions / capabilities. Changes to globalrole_handler.go fix this issue. 

Previous related PR: 
- rancher/rancher#27978