### PR TITLE
Update OCI node driver.

### DIFF
--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -100,8 +100,8 @@ func addMachineDrivers(management *config.ManagementContext) error {
 		"/assets/rancher-ui-driver-linode/component.js", "b31b6a504c59ee758d2dda83029fe4a85b3f5601e22dfa58700a5e6c8f450dc7", []string{"api.linode.com"}, linodeBuiltin, linodeBuiltin, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(OCIDriver, "https://github.com/rancher-plugins/rancher-machine-driver-oci/releases/download/v1.0.0/docker-machine-driver-oci-linux",
-		"", "ae62d1f7f9bc894e57af4f264ab6776824212fb5e1b59f657e3ad953b621eb5f", []string{"*.oraclecloud.com"}, false, false, management); err != nil {
+	if err := addMachineDriver(OCIDriver, "https://github.com/rancher-plugins/rancher-machine-driver-oci/releases/download/v1.0.1/docker-machine-driver-oci-linux",
+		"", "6867f59e9f33bdbce34b5bf9476c48d2edc2ef4bca8a2ef82ccaa1de57af811c", []string{"*.oraclecloud.com"}, false, false, management); err != nil {
 		return err
 	}
 	if err := addMachineDriver(OpenstackDriver, "local://", "", "", nil, false, true, management); err != nil {


### PR DESCRIPTION
This MR updates [OCI Node Driver](https://github.com/rancher-plugins/rancher-machine-driver-oci) to version `v1.0.1`, that has a small but critical [update](https://github.com/rancher-plugins/rancher-machine-driver-oci/commit/83f0fea460841c7150bd9a8d6d0c46c791f5e17c) to the driver's internal pre-check.

Related Issue:

#28449