### PR TITLE
[v2.4] pass correct ttl duration for validating max ttl

### DIFF
--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -103,7 +103,7 @@ func (m *Manager) createDerivedToken(jsonInput clientv3.Token, tokenAuthValue st
 		return v3.Token{}, 401, err
 	}
 
-	tokenTTL, err := ValidateMaxTTL(time.Duration(int(jsonInput.TTLMillis)) * time.Millisecond)
+	tokenTTL, err := ValidateMaxTTL(time.Duration(int64(jsonInput.TTLMillis)) * time.Minute)
 	if err != nil {
 		return v3.Token{}, 500, fmt.Errorf("error validating max-ttl %v", err)
 	}


### PR DESCRIPTION
thought I forgot passing correct duration while fixing auth token bug but seems like UI is now passing the value in minutes so need to update 