### PR TITLE
[v2.4] don't override token during retry

### DIFF
--- a/pkg/auth/providers/common/usermanager.go
+++ b/pkg/auth/providers/common/usermanager.go
@@ -299,13 +299,14 @@ func (m *userManager) newTokenForKubeconfig(clusterName, tokenName, description,
 	}
 	// retry if can't use existing token
 	err = wait.ExponentialBackoff(backoff, func() (bool, error) {
-		token, err = m.tokens.Create(token)
+		createdToken, err = m.tokens.Create(token)
 		if err != nil {
 			if apierrors.IsAlreadyExists(err) {
 				return false, nil
 			}
 			return false, err
 		}
+		token = createdToken
 		return true, nil
 	})
 	if err != nil {


### PR DESCRIPTION
if the create fails, on retry we create using incorrect object