### PR TITLE
[forwardport] Update auth check to use cache

### DIFF
--- a/pkg/api/norman/customization/cluster/formatter.go
+++ b/pkg/api/norman/customization/cluster/formatter.go
@@ -8,7 +8,6 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/types/values"
-	gaccess "github.com/rancher/rancher/pkg/api/norman/customization/globalnamespaceaccess"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	managementschema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
@@ -94,8 +93,7 @@ func (f *Formatter) Formatter(request *types.APIContext, resource *types.RawReso
 		}
 		if _, ok := resource.Values["rancherKubernetesEngineConfig"]; ok {
 			if val, ok := values.GetValue(resource.Values, "clusterTemplateRevisionId"); ok && val == nil {
-				callerID := request.Request.Header.Get(gaccess.ImpersonateUserHeader)
-				if canCreateTemplates, _ := CanCreateRKETemplate(callerID, f.SubjectAccessReviewClient); canCreateTemplates {
+				if err := request.AccessControl.CanDo(v3.ClusterTemplateGroupVersionKind.Group, v3.ClusterTemplateResource.Name, "create", request, resource.Values, request.Schema); err == nil {
 					resource.AddAction(request, v32.ClusterActionSaveAsTemplate)
 				}
 			}


### PR DESCRIPTION
Problem:
When listing large amounts of clusters (200) the call takes approx 40
seconds to complete vs 1 second when using kubectl directly

Solution:
The formatter uses a hard API call to check auth on the clusterTemplate
perms for the user. This adds 200ms per cluster when running locally.
Swap this call to use the cached access through the request
AccessControl

https://github.com/rancher/rancher/issues/27192