### PR TITLE
Add user controllers back to agent

### DIFF
--- a/pkg/agent/cluster/controllers.go
+++ b/pkg/agent/cluster/controllers.go
@@ -4,6 +4,10 @@ import (
 	"context"
 
 	"github.com/rancher/rancher/pkg/agent/steve"
+	"github.com/rancher/rancher/pkg/controllers/managementagent"
+	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
 )
 
 var running bool
@@ -11,6 +15,25 @@ var running bool
 func RunControllers(ctx context.Context) error {
 	if running {
 		return nil
+	}
+
+	logrus.Info("Starting user controllers")
+	c, err := rest.InClusterConfig()
+	if err != nil {
+		return err
+	}
+
+	userOnly, err := config.NewUserOnlyContext(*c)
+	if err != nil {
+		return err
+	}
+
+	if err := managementagent.Register(ctx, userOnly); err != nil {
+		return err
+	}
+
+	if err := userOnly.Start(ctx); err != nil {
+		return err
 	}
 
 	if err := steve.Run(ctx); err != nil {


### PR DESCRIPTION
This set of user controllers was not running in the agent which handles the resources which are not working. 

https://github.com/rancher/rancher/issues/28338