### PR TITLE
Update OKE cluster driver.

### DIFF
--- a/pkg/data/management/kontainerdriver_data.go
+++ b/pkg/data/management/kontainerdriver_data.go
@@ -92,8 +92,8 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 	}
 	if err := creator.addCustomDriver(
 		"oraclecontainerengine",
-		"https://github.com/rancher-plugins/kontainer-engine-driver-oke/releases/download/v1.4.1/kontainer-engine-driver-oke-linux",
-		"3b5ae026ffb6ca48f90157e51d428d966b97f780431060e7697e411ce08fe769",
+		"https://github.com/rancher-plugins/kontainer-engine-driver-oke/releases/download/v1.4.2/kontainer-engine-driver-oke-linux",
+		"6cfdecfdafe229b695746af6773b79643dbedba2f690e5e14ef47d5813250805",
 		"",
 		false,
 		"*.oraclecloud.com",


### PR DESCRIPTION
This MR updates [OKE Cluster Driver](https://github.com/rancher-plugins/kontainer-engine-driver-oke) to version `v1.4.2`, that has a small but important [bug-fix](https://github.com/rancher-plugins/kontainer-engine-driver-oke/commit/bd5a70b80f57e57835afbbec74204915b700c5ac) to create the correct number of nodes in a single AD region.

Related Issue:

https://github.com/rancher-plugins/kontainer-engine-driver-oke/issues/14