### PR TITLE
vendor rke v1.2.0-rc8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/rancher/norman v0.0.0-20200820225344-b715968cde24
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20200820180140-e5448aaba7ee
-	github.com/rancher/rke v1.2.0-rc7.0.20200820212544-6dd6fc76e39f
+	github.com/rancher/rke v1.2.0-rc8
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20200810194305-6ebfa39af82c
 	github.com/rancher/system-upgrade-controller v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -949,8 +949,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a h1:6xqYlVz4uAX
 github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8wJ/coee2n9ed937uPBWQArBaVlxs+5wkkS9KiyDc=
 github.com/rancher/remotedialer v0.2.6-0.20200820180140-e5448aaba7ee h1:hAHJO9u3nF4NMoHC3FwdlQ+O/WnBvehkr9Ubwt3jk+g=
 github.com/rancher/remotedialer v0.2.6-0.20200820180140-e5448aaba7ee/go.mod h1:dbzn9NF1JWbGEHL6Q/1KG4KFROILiY/j6wmfF1Np3fk=
-github.com/rancher/rke v1.2.0-rc7.0.20200820212544-6dd6fc76e39f h1:S3X9AoOA+m4m8K/StQen1FUSSetrKR2UViAqitjOmrY=
-github.com/rancher/rke v1.2.0-rc7.0.20200820212544-6dd6fc76e39f/go.mod h1:aPSc14Hp8UGLscL/wB9ZZQHPX/kjDiPXLcoMTCY2NS4=
+github.com/rancher/rke v1.2.0-rc8 h1:WrEE/NVUyBHk1ueIIwUiKu4Qt6Tefemq8qpjLVT5SqE=
+github.com/rancher/rke v1.2.0-rc8/go.mod h1:aPSc14Hp8UGLscL/wB9ZZQHPX/kjDiPXLcoMTCY2NS4=
 github.com/rancher/saml v0.0.0-20180713225824-ce1532152fde h1:+gd9up4jLeFeuNC5bHn7qfRXZO9WKtBe8b4vhucg9lg=
 github.com/rancher/saml v0.0.0-20180713225824-ce1532152fde/go.mod h1:Bp1IBnlwVB1EqRfSKecoPyf+1Wjh8zykMjlq4vJJhxY=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=


### PR DESCRIPTION
vendor rke v1.2.0-rc8

includes:
- https://github.com/rancher/rke/pull/2212