### PR TITLE
Update rancher-images.txt generation for airgap

### DIFF
--- a/pkg/api/norman/customization/kontainerdriver/actionhandler.go
+++ b/pkg/api/norman/customization/kontainerdriver/actionhandler.go
@@ -153,12 +153,12 @@ func (lh ListHandler) LinkHandler(apiContext *types.APIContext, next types.Reque
 	var targetImages []string
 	switch apiContext.ID {
 	case linuxImages:
-		targetImages, err = image.GetImages(systemCatalogChartPath, []string{}, []string{}, rkeSysImages, image.Linux)
+		targetImages, err = image.GetImages(systemCatalogChartPath, "", []string{}, []string{}, rkeSysImages, image.Linux)
 		if err != nil {
 			return httperror.WrapAPIError(err, httperror.ServerError, "error getting image list for linux platform")
 		}
 	case windowsImages:
-		targetImages, err = image.GetImages(systemCatalogChartPath, []string{}, []string{}, rkeSysImages, image.Windows)
+		targetImages, err = image.GetImages(systemCatalogChartPath, "", []string{}, []string{}, rkeSysImages, image.Windows)
 		if err != nil {
 			return httperror.WrapAPIError(err, httperror.ServerError, "error getting image list for windows platform")
 		}

--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -42,16 +42,16 @@ var (
 )
 
 func main() {
-	if len(os.Args) < 2 {
-		log.Fatal("system charts path is required, please set it as the first parameter")
+	if len(os.Args) < 3 {
+		log.Fatal("\"main.go\" requires 2 arguments. Usage: go run main.go [SYSTEM_CHART_PATH] [CHART_PATH] [OPTIONAL]...")
 	}
 
-	if err := run(os.Args[1], os.Args[2:]); err != nil {
+	if err := run(os.Args[1], os.Args[2], os.Args[3:]); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func run(systemChartPath string, imagesFromArgs []string) error {
+func run(systemChartPath, chartPath string, imagesFromArgs []string) error {
 	tag, ok := os.LookupEnv("TAG")
 	if !ok {
 		return fmt.Errorf("no tag %s", tag)
@@ -87,12 +87,12 @@ func run(systemChartPath string, imagesFromArgs []string) error {
 
 	k3sUpgradeImages := getK3sUpgradeImages(rancherVersion, data.K3S)
 
-	targetImages, err := img.GetImages(systemChartPath, k3sUpgradeImages, imagesFromArgs, linuxInfo.RKESystemImages, img.Linux)
+	targetImages, err := img.GetImages(systemChartPath, chartPath, k3sUpgradeImages, imagesFromArgs, linuxInfo.RKESystemImages, img.Linux)
 	if err != nil {
 		return err
 	}
 
-	targetWindowsImages, err := img.GetImages(systemChartPath, []string{}, []string{getWindowsAgentImage()}, windowsInfo.RKESystemImages, img.Windows)
+	targetWindowsImages, err := img.GetImages(systemChartPath, chartPath, []string{}, []string{getWindowsAgentImage()}, windowsInfo.RKESystemImages, img.Windows)
 	if err != nil {
 		return err
 	}

--- a/scripts/package
+++ b/scripts/package
@@ -38,4 +38,10 @@ if [ ! -d build/system-charts ]; then
     mkdir -p build
     git clone --branch $SYSTEM_CHART_DEFAULT_BRANCH https://github.com/rancher/system-charts build/system-charts
 fi
-TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go build/system-charts $IMAGE $AGENT_IMAGE
+
+if [ ! -d build/charts ]; then
+    mkdir -p build
+    git clone --branch $CHART_DEFAULT_BRANCH https://github.com/rancher/charts build/charts
+fi
+
+TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go build/system-charts build/charts $IMAGE $AGENT_IMAGE


### PR DESCRIPTION
**This PR includes the following:**

The logic behind generating a file listing all images we use (`rancher-images.txt`) for airgap has been updated to support extracting the names of images used by charts in `rancher/charts` in a similar way it is done for `rancher/system-charts`. The main difference is system-charts is not a helm repo so the charts are contained in local directories and a virtual index is created to walk through them, whereas dev charts is a helm repo with an index we can use, but the charts are packaged into tgz files that will need to be extracted before the walk.
A flag `isLocalHelmRepo` has been added to distinguish between the two cases, and in the case we have a local helm repo (flag value is true), the tgz of the latest version of a chart will be extracted before the walk.

**IMPORTANT:**
Since `rancher/charts` will not be a catalog in ECM, the option to generate a `rancher-images.txt` when you hit the version button in the bottom left corner of the ember UI will not include images from `rancher/charts`.

This PR will not pass the CI tests because there are charts using the following images which aren't mirrored yet and they
prevent the generator from creating a `rancher-images.txt` successfully since they are treated as errors.

Images in `rancher/charts` in need of mirrors:
- ibuildthecloud/fleet:v0.3.0-alpha2                         
- banzaicloud/logging-operator:3.4.0                         
- jettech/kube-webhook-certgen:v1.2.1                        
- docker.io/jimmidyson/configmap-reload:v0.3.0               
- curlimages/curl:7.70.0                                     
- busybox:1.31.1                                             
- kiwigrid/k8s-sidecar:0.1.151                               
- quay.io/prometheus/node-exporter:v1.0.0                    
- quay.io/coreos/prometheus-config-reloader:v0.38.1          
- jettech/kube-webhook-certgen:v1.0.0                        
- k8s.gcr.io/hyperkube:v1.16.12                              
- directxman12/k8s-prometheus-adapter-amd64:v0.6.0           
- ibuildthecloud/fleet-agent:v0.3.0-alpha2                   
- quay.io/kubernetes-ingress-controller/nginx-                                                           
- grafana/grafana:7.0.5                                      
- quay.io/coreos/kube-state-metrics:v1.9.7                   
- quay.io/coreos/prometheus-operator:v0.38.1                 
- quay.io/prometheus/prometheus:v2.18.1                      
- squareup/ghostunnel:v1.5.2                                 
- k8s.gcr.io/defaultbackend-amd64:1.5                        
- quay.io/prometheus/alertmanager:v0.20.0  

**Related PR:** https://github.com/rancher/rancher/issues/27487
