### PR TITLE
[2.3] Update RKE to v1.0.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/rancher/norman v0.0.0-20200227003532-35fa47cccad7
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.5
-	github.com/rancher/rke v1.0.12-rc1
+	github.com/rancher/rke v1.0.12
 	github.com/rancher/types v0.0.0-20200723232851-b1294beb7945
 	github.com/rancher/wrangler v0.4.1
 	github.com/robfig/cron v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -659,8 +659,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8w
 github.com/rancher/remotedialer v0.2.5 h1:rNMMcJp5fU7FZ3wGFKSmDrXrSt8MYo5na4CzXddIr2A=
 github.com/rancher/remotedialer v0.2.5/go.mod h1:dbzn9NF1JWbGEHL6Q/1KG4KFROILiY/j6wmfF1Np3fk=
 github.com/rancher/rke v0.3.0-rc11.0.20190930172345-88449ec73b31/go.mod h1:5uw/a0TlRpyf2ASPgEo4HBSEFsc80zuR4raGwazwJa8=
-github.com/rancher/rke v1.0.12-rc1 h1:+B+CkGlzck53i7EOPaA39YG1aacLB/wgqACM2PKPsa8=
-github.com/rancher/rke v1.0.12-rc1/go.mod h1:HmRah8fPujuuN02JqttzbpyMo0n1ozDyfMfa6n8WaKE=
+github.com/rancher/rke v1.0.12 h1:ljmZdRlHtjDLKwdBYFOFDxjkU3YeRSeQVl0d6yQCs/w=
+github.com/rancher/rke v1.0.12/go.mod h1:HmRah8fPujuuN02JqttzbpyMo0n1ozDyfMfa6n8WaKE=
 github.com/rancher/saml v0.0.0-20180713225824-ce1532152fde h1:+gd9up4jLeFeuNC5bHn7qfRXZO9WKtBe8b4vhucg9lg=
 github.com/rancher/saml v0.0.0-20180713225824-ce1532152fde h1:+gd9up4jLeFeuNC5bHn7qfRXZO9WKtBe8b4vhucg9lg=
 github.com/rancher/saml v0.0.0-20180713225824-ce1532152fde/go.mod h1:Bp1IBnlwVB1EqRfSKecoPyf+1Wjh8zykMjlq4vJJhxY=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -364,7 +364,7 @@ github.com/rancher/rdns-server/model
 # github.com/rancher/remotedialer v0.2.5
 github.com/rancher/remotedialer
 github.com/rancher/remotedialer/metrics
-# github.com/rancher/rke v1.0.12-rc1
+# github.com/rancher/rke v1.0.12
 github.com/rancher/rke/addons
 github.com/rancher/rke/authz
 github.com/rancher/rke/cloudprovider


### PR DESCRIPTION
RKE v1.0.12 has been released and the dependency needs to be updated in Rancher