### PR TITLE
Add channels.yaml file

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,0 +1,10 @@
+channels:
+- name: latest
+  latestRegexp: .*
+  excludeRegexp: ^[^+]+-
+- name: testing
+  latestRegexp: .*
+github:
+  owner: rancher
+  repo: rancher
+redirectBase: https://github.com/rancher/rancher/releases/tag/


### PR DESCRIPTION
In preparation for having an install script for rancherd, we need this
channels.yaml server so that we can stand up a channel-server that
points at it.

The need is that channel-server allows our install script to control what is considered "stable" better than just pointing at the "latest" tag on github. The problem with the "latest" tag on github is that, for example, 2.3.17 would be marked as latest if it came out most recently if even a 2.5.1 existed. So, we standup a public service at update.rancher.io that is running channel-server which allows us to say 2.5.1 is the latest stable, but if you want the latest 2.3 release, just point at the v2.3 channel