### PR TITLE
Add support for rancher/charts in rancher-images.txt generator

### DIFF
--- a/pkg/api/norman/customization/kontainerdriver/actionhandler.go
+++ b/pkg/api/norman/customization/kontainerdriver/actionhandler.go
@@ -153,12 +153,12 @@ func (lh ListHandler) LinkHandler(apiContext *types.APIContext, next types.Reque
 	var targetImages []string
 	switch apiContext.ID {
 	case linuxImages:
-		targetImages, err = image.GetImages(systemCatalogChartPath, []string{}, []string{}, rkeSysImages, image.Linux)
+		targetImages, err = image.GetImages(systemCatalogChartPath, "", []string{}, []string{}, rkeSysImages, image.Linux)
 		if err != nil {
 			return httperror.WrapAPIError(err, httperror.ServerError, "error getting image list for linux platform")
 		}
 	case windowsImages:
-		targetImages, err = image.GetImages(systemCatalogChartPath, []string{}, []string{}, rkeSysImages, image.Windows)
+		targetImages, err = image.GetImages(systemCatalogChartPath, "", []string{}, []string{}, rkeSysImages, image.Windows)
 		if err != nil {
 			return httperror.WrapAPIError(err, httperror.ServerError, "error getting image list for windows platform")
 		}

--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -42,16 +42,16 @@ var (
 )
 
 func main() {
-	if len(os.Args) < 2 {
-		log.Fatal("system charts path is required, please set it as the first parameter")
+	if len(os.Args) < 3 {
+		log.Fatal("\"main.go\" requires 2 arguments. Usage: go run main.go [SYSTEM_CHART_PATH] [CHART_PATH] [OPTIONAL]...")
 	}
 
-	if err := run(os.Args[1], os.Args[2:]); err != nil {
+	if err := run(os.Args[1], os.Args[2], os.Args[3:]); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func run(systemChartPath string, imagesFromArgs []string) error {
+func run(systemChartPath, chartPath string, imagesFromArgs []string) error {
 	tag, ok := os.LookupEnv("TAG")
 	if !ok {
 		return fmt.Errorf("no tag %s", tag)
@@ -87,12 +87,12 @@ func run(systemChartPath string, imagesFromArgs []string) error {
 
 	k3sUpgradeImages := getK3sUpgradeImages(rancherVersion, data.K3S)
 
-	targetImages, err := img.GetImages(systemChartPath, k3sUpgradeImages, imagesFromArgs, linuxInfo.RKESystemImages, img.Linux)
+	targetImages, err := img.GetImages(systemChartPath, chartPath, k3sUpgradeImages, imagesFromArgs, linuxInfo.RKESystemImages, img.Linux)
 	if err != nil {
 		return err
 	}
 
-	targetWindowsImages, err := img.GetImages(systemChartPath, []string{}, []string{getWindowsAgentImage()}, windowsInfo.RKESystemImages, img.Windows)
+	targetWindowsImages, err := img.GetImages(systemChartPath, chartPath, []string{}, []string{getWindowsAgentImage()}, windowsInfo.RKESystemImages, img.Windows)
 	if err != nil {
 		return err
 	}

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -133,12 +133,21 @@ func walkthroughMap(inputMap map[interface{}]interface{}, walkFunc func(map[inte
 	}
 }
 
-func GetImages(systemChartPath string, k3sUpgradeImages, imagesFromArgs []string, rkeSystemImages map[string]rketypes.RKESystemImages, osType OSType) ([]string, error) {
+func GetImages(systemChartPath, chartPath string, k3sUpgradeImages, imagesFromArgs []string, rkeSystemImages map[string]rketypes.RKESystemImages, osType OSType) ([]string, error) {
 	var images []string
 
-	// fetch images from charts
+	// fetch images from system charts
 	if systemChartPath != "" {
-		imagesInCharts, err := fetchImagesFromCharts(systemChartPath, osType)
+		imagesInSystemCharts, err := fetchImagesFromCharts(systemChartPath, osType)
+		if err != nil {
+			return []string{}, errors.Wrap(err, "failed to fetch images from system charts")
+		}
+		images = append(images, imagesInSystemCharts...)
+	}
+
+	// fetch images from charts
+	if chartPath != "" {
+		imagesInCharts, err := fetchImagesFromCharts(chartPath, osType)
 		if err != nil {
 			return []string{}, errors.Wrap(err, "failed to fetch images from charts")
 		}

--- a/scripts/package
+++ b/scripts/package
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -e
 
+extract_latest_version_tgz() {
+    # Takes in a path to a chart's directory, finds the latest version's tgz and extracts it
+    # All crd tgz are ignored
+    # Max depth is set to prevent extracting a tgz contained within another tgz, which is the case for charts containing a helm repo
+    LATEST_VERSION_TGZ_PATH=$(find $1 -maxdepth 1 -name "*.tgz" ! -name "*crd*.tgz" -print | sort -Vr | head -1)
+    if [[ $LATEST_VERSION_TGZ_PATH ]]; then
+        tar -xvf $LATEST_VERSION_TGZ_PATH -C $(dirname $LATEST_VERSION_TGZ_PATH)
+    fi
+}
+export -f extract_latest_version_tgz
+
 source $(dirname $0)/version
 
 ARCH=${ARCH:-"amd64"}
@@ -38,4 +49,15 @@ if [ ! -d build/system-charts ]; then
     mkdir -p build
     git clone --branch $SYSTEM_CHART_DEFAULT_BRANCH https://github.com/rancher/system-charts build/system-charts
 fi
-TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go build/system-charts $IMAGE $AGENT_IMAGE
+
+if [ ! -d build/charts ]; then
+    git clone --branch $CHART_DEFAULT_BRANCH https://github.com/rancher/charts build/charts
+
+    # Iterate through chart directories and execute callback to extract latest version tgz
+    find build/charts/assets -type d -maxdepth 1 -exec bash -c 'extract_latest_version_tgz {}' \;
+
+    # Remove index to force building a virtual index like system charts
+    rm -f build/charts/index.yaml build/charts/assets/index.yaml
+fi
+
+TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go build/system-charts build/charts $IMAGE $AGENT_IMAGE


### PR DESCRIPTION
**This PR includes the following:**

Add support in image list generator for picking images in rancher/charts so they are included in the generated `rancher-images.txt`. The `rancher/charts` repo is cloned and pre-processed so that images are picked the same way is done for system charts. The pre-processing includes deleting the index files so that a virtual one is built, and finding and extracting the latest version's tgz of each chart. 

Functions in the image and main package were modified to take in an extra path to a local `rancher/charts` repo.
The main reason behind doing that versus just calling main.go twice (one for each chart repo) is that we would be adding in unnecessary complexity because we overwrite the generated images text file, and images are normalized before is created. 

**IMPORTANT:**
Since rancher/charts will not be a catalog in ECM, the option to generate a rancher-images.txt when you hit the version button in the bottom left corner of the ember UI will not include images from rancher/charts.

This PR will not pass the CI tests because there are charts using the following images which aren't mirrored yet and they
prevent the generator from creating a rancher-images.txt successfully since they are treated as errors.

Images in rancher/charts in need of mirrors:
```
location: nginx-ingress/values.yaml                                       
- quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.30.0        
- jettech/kube-webhook-certgen:v1.0.0                                          
- k8s.gcr.io/defaultbackend-amd64:1.5

location: rancher-kiali-server/values.yaml                         
- kiali/kiali:v1.22.0

location: rancher-logging/values.yaml                                   
- banzaicloud/logging-operator:3.4.0

location: rancher-monitoring/charts/grafana/values.yaml              
- kiwigrid/k8s-sidecar:0.1.151                                                 
- grafana/grafana:7.0.5                                                        
- curlimages/curl:7.70.0                                                       
- busybox:1.31.1

location: rancher-monitoring/charts/kube-state-metrics/values.yaml
- quay.io/coreos/kube-state-metrics:v1.9.7

location: rancher-monitoring/charts/prometheus-adapter/values.yaml
- directxman12/k8s-prometheus-adapter-amd64:v0.6.0

location: rancher-monitoring/charts/prometheus-node-exporter/values.yaml
- quay.io/prometheus/node-exporter:v1.0.0

location: rancher-monitoring/values.yaml
- jettech/kube-webhook-certgen:v1.2.1
- directxman12/k8s-prometheus-adapter-amd64:v0.6.0
```
**Issue** #27487
**Previous PR:** https://github.com/rancher/rancher/pull/28554