### PR TITLE
[v2.4] update AuthTokenMaxTTLMinutes default to 0

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -18,7 +18,7 @@ var (
 
 	AgentImage                        = NewSetting("agent-image", "rancher/rancher-agent:master-head")
 	AuthImage                         = NewSetting("auth-image", v3.ToolsSystemImages.AuthSystemImages.KubeAPIAuth)
-	AuthTokenMaxTTLMinutes            = NewSetting("auth-token-max-ttl-minutes", "1440") // 24 hours
+	AuthTokenMaxTTLMinutes            = NewSetting("auth-token-max-ttl-minutes", "0") // never expire
 	AuthorizationCacheTTLSeconds      = NewSetting("authorization-cache-ttl-seconds", "10")
 	AuthorizationDenyCacheTTLSeconds  = NewSetting("authorization-deny-cache-ttl-seconds", "10")
 	CACerts                           = NewSetting("cacerts", "")


### PR DESCRIPTION
The old behavior will be preserved by default. It's configurable for opt-in by changing the value. 

https://github.com/rancher/rancher/issues/28668 