### PR TITLE
Check if CIS v2 CRD is present and error out while running CIS v1 clusterscan

### DIFF
--- a/pkg/controllers/managementuser/cis/register.go
+++ b/pkg/controllers/managementuser/cis/register.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/systemaccount"
@@ -96,6 +95,7 @@ func Register(ctx context.Context, userContext *config.UserContext) {
 		dsClient:                     dsClient,
 		dsLister:                     dsLister,
 		templateLister:               templateLister,
+		apiExtensionsClient:          userContext.APIExtClient,
 	}
 	clusterScanClient.AddClusterScopedLifecycle(ctx, "cisScanHandler", clusterName, clusterScanHandler)
 


### PR DESCRIPTION
If CIS v2 is enabled via dashboard on a cluster, we want to disallow users from running a CIS v1 scan. 

Reason is that we do have a limitation of running only one CIS scan at any given time for a cluster - there cannot be parallel scans running. This limitation is due to the sonobuoy tool. 

Even if we want to just stall the scans when another one is running, it is complicated to predict the run times of scheduled scans if present on the cluster. Hence we just want to disable the v1 scans if user has enabled CIS v2 feature.