### PR TITLE
Only use the node dialer if the host is a control plane node or ready

### DIFF
--- a/pkg/dialer/factory.go
+++ b/pkg/dialer/factory.go
@@ -178,7 +178,8 @@ func (f *Factory) clusterDialer(clusterName, address string) (dialer.Dialer, err
 	}
 
 	for _, node := range nodes {
-		if node.DeletionTimestamp == nil && v32.NodeConditionProvisioned.IsTrue(node) {
+		if node.DeletionTimestamp == nil && v32.NodeConditionProvisioned.IsTrue(node) &&
+			(node.Spec.ControlPlane || v32.NodeConditionReady.IsTrue(node)) {
 			logrus.Tracef("dialerFactory: using node [%s]/[%s] for nodeDialer",
 				node.Labels["management.cattle.io/nodename"], node.Name)
 			if nodeDialer, err := f.nodeDialer(clusterName, node.Name); err == nil {


### PR DESCRIPTION
During cluster provisioning you could end up with a node being first in the
   list that is worker only and wait to be provisioned because the control
   plane is still provisioning. In this situation we chose the worker node for
   the node dialer which fails because the nginx proxy does not exist yet. 
   Because the node dialer fails we can't deploy the cluster agent and get
   stuck in a failing loop.