### PR TITLE
Make helm max history a setting

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -35,6 +35,7 @@ var (
 	GlobalRegistryEnabled             = NewSetting("global-registry-enabled", "false")
 	GithubProxyAPIURL                 = NewSetting("github-proxy-api-url", "https://api.github.com")
 	HelmVersion                       = NewSetting("helm-version", "dev")
+	HelmMaxHistory                    = NewSetting("helm-max-history", "10")
 	IngressIPDomain                   = NewSetting("ingress-ip-domain", "xip.io")
 	InstallUUID                       = NewSetting("install-uuid", "")
 	JailerTimeout                     = NewSetting("jailer-timeout", "60")


### PR DESCRIPTION
Problem:
HelmMaxHistory is hardcoded to 10, in a setup with many helm apps this
causes a lot of secrets to be created

Solution:
Make helmMaxHistory a setting so it can be set based on customer needs

https://github.com/rancher/rancher/issues/28728