### PR TITLE
Do not run on HTTPS because it might redirect improperly

### DIFF
--- a/pkg/agent/steve/steve.go
+++ b/pkg/agent/steve/steve.go
@@ -43,7 +43,7 @@ func Run(ctx context.Context) error {
 			r, err := rancher.New(ctx, c, &rancher.Options{
 				BindHost:        "127.0.0.1",
 				HTTPListenPort:  6080,
-				HTTPSListenPort: 6443,
+				HTTPSListenPort: 0,
 				AddLocal:        "true",
 				Agent:           true,
 			})


### PR DESCRIPTION
If the x-forwarded-proto header is not set properly it will redirect
to HTTPS but the path will be wrong.  So just don't run on https as it's
not ever used.