### PR TITLE
Set node role to worker if nodepool has no role assigned

### DIFF
--- a/pkg/controllers/management/nodepool/nodepool.go
+++ b/pkg/controllers/management/nodepool/nodepool.go
@@ -349,6 +349,10 @@ func (c *Controller) updateNodeRoles(existing *v3.Node, nodePool *v3.NodePool, s
 		newRoles = append(newRoles, "worker")
 	}
 
+	if len(newRoles) == 0 {
+		newRoles = []string{"worker"}
+	}
+
 	toUpdate.Status.NodeConfig.Role = newRoles
 	if simulate {
 		return toUpdate, nil


### PR DESCRIPTION
This makes the logic consist where no role means worker role.  For custom this is how we do it, but for node pools it seems to be different.

https://github.com/rancher/rancher/issues/28758