### PR TITLE
Drop share mount process

### DIFF
--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -21,7 +21,6 @@ RUN apt-get update && \
 ENV LOGLEVEL_VERSION v0.1.3
 
 RUN curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin
-RUN curl -sL https://github.com/rancher/share-mnt/releases/download/v1.0.7/share-mnt-${ARCH}.tar.gz | tar xvzf - -C /usr/bin
 ENV KUBEPROMPT_VERSION v1.0.10
 
 RUN curl -sL https://github.com/c-bata/kube-prompt/releases/download/${KUBEPROMPT_VERSION}/kube-prompt_${KUBEPROMPT_VERSION}_linux_${ARCH}.zip > /usr/bin/kube-prompt.zip && unzip /usr/bin/kube-prompt.zip -d /usr/bin

--- a/package/share-root.sh
+++ b/package/share-root.sh
@@ -3,11 +3,6 @@ set -x
 
 trap 'exit 0' SIGTERM
 ID=$(grep :devices: /proc/self/cgroup | head -n1 | awk -F/ '{print $NF}' | sed -e 's/docker-\(.*\)\.scope/\1/')
-IMAGE=$(docker inspect -f '{{.Config.Image}}' $ID)
 bash -c "$1"
 
-docker run --privileged --net host --pid host -v /:/host --rm --entrypoint /usr/bin/share-mnt $IMAGE "${@:2}" -- norun
-while ! docker start kubelet; do
-    sleep 2
-done
 docker kill --signal=SIGTERM $ID

--- a/pkg/controllers/management/rkeworkerupgrader/plan.go
+++ b/pkg/controllers/management/rkeworkerupgrader/plan.go
@@ -10,7 +10,6 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/librke"
 	nodeserver "github.com/rancher/rancher/pkg/rkenodeconfigserver"
-	rkehosts "github.com/rancher/rke/hosts"
 	rkeservices "github.com/rancher/rke/services"
 	rketypes "github.com/rancher/rke/types"
 	"github.com/sirupsen/logrus"
@@ -53,8 +52,7 @@ func (uh *upgradeHandler) nonWorkerPlan(node *v3.Node, cluster *v3.Cluster) (*rk
 	for _, tempNode := range plan.Nodes {
 		if tempNode.Address == hostAddress {
 
-			b2d := strings.Contains(infos[tempNode.Address].OperatingSystem, rkehosts.B2DOS)
-			np.Processes = nodeserver.AugmentProcesses(token, tempNode.Processes, false, b2d,
+			np.Processes = nodeserver.AugmentProcesses(token, tempNode.Processes, false,
 				node.Status.NodeConfig.HostnameOverride, cluster)
 
 			np.Processes = nodeserver.AppendTaintsToKubeletArgs(np.Processes, node.Status.NodeConfig.Taints)
@@ -102,8 +100,7 @@ func (uh *upgradeHandler) workerPlan(node *v3.Node, cluster *v3.Cluster) (*rkety
 			if hostDockerInfo.OSType == "windows" { // compatible with Windows
 				np.Processes = nodeserver.EnhanceWindowsProcesses(tempNode.Processes)
 			} else {
-				b2d := strings.Contains(infos[tempNode.Address].OperatingSystem, rkehosts.B2DOS)
-				np.Processes = nodeserver.AugmentProcesses(token, tempNode.Processes, true, b2d,
+				np.Processes = nodeserver.AugmentProcesses(token, tempNode.Processes, true,
 					node.Status.NodeConfig.HostnameOverride, cluster)
 			}
 			np.Processes = nodeserver.AppendTaintsToKubeletArgs(np.Processes, node.Status.NodeConfig.Taints)

--- a/pkg/rkenodeconfigserver/nodeserver_test.go
+++ b/pkg/rkenodeconfigserver/nodeserver_test.go
@@ -92,7 +92,7 @@ func getAugmentedKubeletProcesses() map[string]rketypes.Process {
 		},
 	}
 
-	return AugmentProcesses("token", processes, true, false, "dummynode", &cluster)
+	return AugmentProcesses("token", processes, true, "dummynode", &cluster)
 }
 
 func getCommandFromProcesses(processes map[string]rketypes.Process) map[string]struct{} {

--- a/pkg/rkenodeconfigserver/nodeserver_test.go
+++ b/pkg/rkenodeconfigserver/nodeserver_test.go
@@ -66,9 +66,9 @@ func TestAppendKubeletArgs(t *testing.T) {
 func TestShareMntArgs(t *testing.T) {
 	augmentedProcesses := getAugmentedKubeletProcesses()
 	args := augmentedProcesses["share-mnt"].Args
-	// args should be "--", "share-root.sh", "node command in one string", "one argument per shared bind in kubelet process"
-	// By default, arg count is 3, plus 2 shared binds we use in the test
-	assert.Equal(t, 5, len(args), "args count for share-mnt should be the same")
+	// args should be "--", "share-root.sh", "node command in one string"
+	// By default, arg count is 3
+	assert.Equal(t, 3, len(args), "args count for share-mnt should be the same")
 }
 
 func getKubeletProcess(commands []string) map[string]rketypes.Process {


### PR DESCRIPTION
Problem:
The share-mount process is ran on every install/upgrade. This was used for boot2Docker which is no longer supported. 

Solution:
Drop the share-mount binary from the agent image and stop running it. This does not stop the rke process `share-mnt` from running in order to write certs. 
These are two different things with similar names that perform different functions. 

https://github.com/rancher/rancher/issues/25702