### PR TITLE
Drop printing rancher logs on test failure

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -15,11 +15,6 @@ cleanup()
         rke remove --dind --force --config $dindYML
         rm -f $dindYML
     done
-    if [ $EXIT -ne 0 ]; then
-        echo '***RANCHER LOGS***'
-        cat $CWD/rancherlogs.txt
-        echo '***END RANCHER LOGS***'
-    fi
     return $EXIT
 }
 
@@ -31,7 +26,7 @@ if [ ${ARCH} == arm64 ]; then
 fi
 
 echo Starting rancher server
-$(dirname $0)/run &> $CWD/rancherlogs.txt &
+$(dirname $0)/run &> /dev/null &
 PID=$!
 trap cleanup exit
 


### PR DESCRIPTION
This adds significant time to failed builds and is not used due to the
sheer volume of them when something does fail.