### PR TITLE
Don't error out on updating bundled helm repos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20200911065618-cfede8c002dd
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20200825145542-a04e2061be24
-	github.com/rancher/wrangler v0.6.2-0.20200909050541-7465f10bdac7
+	github.com/rancher/wrangler v0.6.2-0.20200915162151-29365defe4ed
 	github.com/robfig/cron v1.1.0
 	github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7 // indirect
 	github.com/satori/go.uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1047,8 +1047,8 @@ github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:Nmtml
 github.com/rancher/wrangler v0.6.2-0.20200714200521-c61fae623942/go.mod h1:8LdIqAQPHysxNlHqmKbUiDIx9ULt9IHUauh9aOnr67k=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
 github.com/rancher/wrangler v0.6.2-0.20200822010948-6d667521af49/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
-github.com/rancher/wrangler v0.6.2-0.20200909050541-7465f10bdac7 h1:gtMTBRZjOHwhEtQytyh9ku9DaF4m0Aumh6Xw9hG4DRI=
-github.com/rancher/wrangler v0.6.2-0.20200909050541-7465f10bdac7/go.mod h1:I7qe4DZNMOLKVa9ax7DJdBZ0XtKOppLF/dalhPX3vaE=
+github.com/rancher/wrangler v0.6.2-0.20200915162151-29365defe4ed h1:/XpF3RLaW/yA2MKLBGCOs0ZuzaeDGxiDT30r12VIVS0=
+github.com/rancher/wrangler v0.6.2-0.20200915162151-29365defe4ed/go.mod h1:I7qe4DZNMOLKVa9ax7DJdBZ0XtKOppLF/dalhPX3vaE=
 github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e h1:UJpGtw6IKs0dHPTF+6Wd12lskeCZZAejl8/ie/fc1+0=
 github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e/go.mod h1:2lcWR98q8HU3U4mVETnXc8quNG0uXxrt8vKd6cAa/30=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/pkg/catalogv2/git/download.go
+++ b/pkg/catalogv2/git/download.go
@@ -64,14 +64,19 @@ func Ensure(secret *corev1.Secret, namespace, name, gitURL, commit string) error
 	return git.Ensure(commit)
 }
 
-func gitForRepo(secret *corev1.Secret, namespace, name, gitURL string) (*git.Git, error) {
-	u, err := url.Parse(gitURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse URL %s: %w", gitURL, err)
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return nil, fmt.Errorf("invalid git URL scheme %s, only http(s) supported", u.Scheme)
+func isBundled(git *git.Git) bool {
+	return strings.HasPrefix(git.Directory, staticDir)
+}
 
+func gitForRepo(secret *corev1.Secret, namespace, name, gitURL string) (*git.Git, error) {
+	if !strings.HasPrefix(gitURL, "git@") {
+		u, err := url.Parse(gitURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse URL %s: %w", gitURL, err)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return nil, fmt.Errorf("invalid git URL scheme %s, only http(s) and git supported", u.Scheme)
+		}
 	}
 	dir := gitDir(namespace, name, gitURL)
 	headers := map[string]string{}

--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -151,6 +151,8 @@ func (r *repoHandler) download(repoSpec *catalog.RepoSpec, status catalog.RepoSt
 		if err != nil {
 			return status, err
 		}
+		status.URL = repoSpec.GitRepo
+		status.Branch = repoSpec.GitBranch
 		index, err = git.BuildOrGetIndex(metadata.Namespace, metadata.Name, repoSpec.GitRepo)
 	} else if repoSpec.GitRepo != "" {
 		commit, err = git.Update(secret, metadata.Namespace, metadata.Name, repoSpec.GitRepo, repoSpec.GitBranch)


### PR DESCRIPTION
If we fail to update a repo or the system catalog is set to bundled we do
   not record any error.