### PR TITLE
Remove panic when deploying eks-operator fails

### DIFF
--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -103,6 +103,19 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 	}
 
 	if err := e.deployEKSOperator(); err != nil {
+		failedToDeployEKSOperatorErr := "failed to deploy eks-operator: %v"
+		var conditionErr error
+		if cluster.Spec.EKSConfig.Imported {
+			cluster, conditionErr = e.setFalse(cluster, apimgmtv3.ClusterConditionPending, fmt.Sprintf(failedToDeployEKSOperatorErr, err))
+			if err != nil {
+				return cluster, conditionErr
+			}
+		} else {
+			cluster, conditionErr = e.setFalse(cluster, apimgmtv3.ClusterConditionProvisioned, fmt.Sprintf(failedToDeployEKSOperatorErr, err))
+			if err != nil {
+				return cluster, conditionErr
+			}
+		}
 		return cluster, err
 	}
 
@@ -461,8 +474,9 @@ func (e *eksOperatorController) deployEKSOperator() error {
 
 	systemProject, err := project.GetSystemProject(localCluster, e.projectCache)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
 	systemProjectID := ref.Ref(systemProject)
 	_, systemProjectName := ref.Parse(systemProjectID)
 


### PR DESCRIPTION
**Problem:**
Prior, rancher would fail if deploying eks-operator returned an error. This disrupted setups that did not have a local cluster.

**Solution:**
Now, cluster condition will be set to false and error will be displayed.

**Issue:**
https://github.com/rancher/rancher/issues/28764