### PR TITLE
Drop dashboard from being a feature flag

### DIFF
--- a/pkg/agent/steve/steve.go
+++ b/pkg/agent/steve/steve.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/rancher"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
@@ -21,10 +20,6 @@ var (
 )
 
 func Run(ctx context.Context) error {
-	if !features.Steve.Enabled() {
-		return nil
-	}
-
 	runLock.Lock()
 	defer runLock.Unlock()
 

--- a/pkg/api/steve/proxy/proxy.go
+++ b/pkg/api/steve/proxy/proxy.go
@@ -127,13 +127,7 @@ func (h *Handler) MatchNonLegacy(prefix string, force bool) gmux.MatcherFunc {
 		}
 		match.Vars["clusterID"] = clusterID
 
-		cluster, err := h.clusters.Get(clusterID)
-		if err != nil {
-			return true
-		}
-
-		// No steve means we are upgrading a node that doesn't have the right proxy
-		return cluster.Status.AgentFeatures[features.Steve.Name()]
+		return true
 	}
 }
 

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rancher/norman/types"
 	util "github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/clustermanager"
-	"github.com/rancher/rancher/pkg/features"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/image"
 	"github.com/rancher/rancher/pkg/kubectl"
@@ -240,9 +239,8 @@ func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
 	}
 	logrus.Tracef("clusterDeploy: deployAgent: desiredAuth is [%s] for cluster [%s]", desiredAuth, cluster.Name)
 
-	desiredFeatures := map[string]bool{
-		features.Steve.Name(): features.Steve.Enabled(),
-	}
+	desiredFeatures := map[string]bool{}
+
 	logrus.Tracef("clusterDeploy: deployAgent: desiredFeatures is [%v] for cluster [%s]", desiredFeatures, cluster.Name)
 
 	if !redeployAgent(cluster, desiredAgent, desiredAuth, desiredFeatures) {

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -29,12 +29,6 @@ var (
 		true,
 		true,
 		true)
-	Steve = newFeature(
-		"dashboard",
-		"Deploy experimental new UI for managing resources inside of clusters.",
-		true,
-		false,
-		true)
 	SteveProxy = newFeature(
 		"proxy",
 		"Use new experimental proxy for Kubernetes API requests.",
@@ -56,11 +50,12 @@ var (
 )
 
 type Feature struct {
-	name string
-	// val is the effective value- it is equal to default until explicitly changed
+	name        string
 	description string
-	val         bool
-	def         bool
+	// val is the effective value- it is equal to default until explicitly changed
+	val bool
+	// default value of feature
+	def bool
 	// if a feature is not dynamic, then rancher must be restarted when the value is changed
 	dynamic bool
 	// Whether we should install this feature or assume something else will install and manage the Feature CR
@@ -233,7 +228,7 @@ func newFeature(name, description string, def, dynamic, install bool) *Feature {
 	}
 
 	// feature will be stored in feature map, features contained in feature
-	// map will be then be initialized
+	// map will then be initialized
 	features[name] = feature
 
 	return feature

--- a/pkg/rbac/access_control.go
+++ b/pkg/rbac/access_control.go
@@ -4,13 +4,12 @@ import (
 	"context"
 
 	"github.com/rancher/norman/types"
-	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/steve/pkg/accesscontrol"
 	v1 "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
 )
 
 func NewAccessControl(ctx context.Context, clusterName string, rbacClient v1.Interface) types.AccessControl {
-	asl := accesscontrol.NewAccessStore(ctx, features.Steve.Enabled(), rbacClient)
+	asl := accesscontrol.NewAccessStore(ctx, true, rbacClient)
 	return NewAccessControlWithASL(clusterName, rbacClient, asl)
 }
 

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rancher/rancher/pkg/catalogv2/content"
 	"github.com/rancher/rancher/pkg/catalogv2/helmop"
 	"github.com/rancher/rancher/pkg/catalogv2/system"
-	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io"
 	catalogcontrollers "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io"
@@ -177,7 +176,7 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 		return nil, err
 	}
 
-	asl := accesscontrol.NewAccessStore(ctx, features.Steve.Enabled(), steveControllers.RBAC)
+	asl := accesscontrol.NewAccessStore(ctx, true, steveControllers.RBAC)
 
 	cg, err := client.NewFactory(restConfig, false)
 	if err != nil {


### PR DESCRIPTION
This will enable dashboard permanently. The feature CR will still exist but it just won't do anything to dashboard. This is being done so that rollback will not be broken if the CR is dropped on upgrade. 

https://github.com/rancher/rancher/issues/28928
https://github.com/rancher/rancher/issues/28930