### PR TITLE
Evaluate upstream only if spec nodegroups are nil

### DIFF
--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -204,7 +204,7 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 		addNgMessage := "Cannot deploy agent without nodegroups. Add a nodegroup."
 		noNodeGroupsOnSpec := len(cluster.Spec.EKSConfig.NodeGroups) == 0
 		noNodeGroupsOnUpstreamSpec := len(cluster.Status.EKSStatus.UpstreamSpec.NodeGroups) == 0
-		if (cluster.Spec.EKSConfig.NodeGroups != nil && noNodeGroupsOnSpec) || noNodeGroupsOnUpstreamSpec {
+		if (cluster.Spec.EKSConfig.NodeGroups != nil && noNodeGroupsOnSpec) || (cluster.Spec.EKSConfig.NodeGroups == nil && noNodeGroupsOnUpstreamSpec) {
 			cluster, err = e.setFalse(cluster, apimgmtv3.ClusterConditionWaiting, addNgMessage)
 			if err != nil {
 				return cluster, err


### PR DESCRIPTION
**Problem:**
Prior, upstream spec was being checked for nodegroup length even if nodegroups were set on spec. This caused an error when nodegroups were finished provisioning in EKS so the EKS Cluster Config object was in "active" phase but the refresh handler had not updated the upstream spec since before the nodegroups were being created.

**Solution:**
Evaluate upstream only if spec nodegroups are nil.

**Issues:**
https://github.com/rancher/rancher/issues/28962