### PR TITLE
Detect and require --privileged on container start

### DIFF
--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 set -e
 
+if [ ! -e /run/secrets/kubernetes.io/serviceaccount ] && [ ! -e /dev/kmsg ]; then
+    echo "ERROR: Rancher must be ran with the --privileged flag when running outside of Kubernetes"
+    exit 1
+fi
 exec tini -- rancher --http-listen-port=80 --https-listen-port=443 --audit-log-path=${AUDIT_LOG_PATH} --audit-level=${AUDIT_LEVEL} --audit-log-maxage=${AUDIT_LOG_MAXAGE} --audit-log-maxbackup=${AUDIT_LOG_MAXBACKUP} --audit-log-maxsize=${AUDIT_LOG_MAXSIZE} "${@}"


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/28910

The idea is that it will first look for a k8s service account, if it finds it it assumes it is running in k8s, not docker standalone. 
