### PR TITLE
Don't use DISABLE_HTTP2 env var

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,6 @@ func main() {
 
 	os.Unsetenv("SSH_AUTH_SOCK")
 	os.Unsetenv("SSH_AGENT_PID")
-	os.Setenv("DISABLE_HTTP2", "true")
 
 	if dm := os.Getenv("CATTLE_DEV_MODE"); dm != "" {
 		if dir, err := os.Getwd(); err == nil {

--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -295,7 +295,8 @@ func ToRESTConfig(cluster *v3.Cluster, context *config.ScaledContext) (*rest.Con
 		Host:        u.String(),
 		BearerToken: cluster.Status.ServiceAccountToken,
 		TLSClientConfig: rest.TLSClientConfig{
-			CAData: append(caBytes, suffix...),
+			CAData:     append(caBytes, suffix...),
+			NextProtos: []string{"http/1.1"},
 		},
 		Timeout:     45 * time.Second,
 		RateLimiter: ratelimit.None,


### PR DESCRIPTION
By properly configure the NextProtos to disable http2. Using the
DISABLE_HTTP2 env var causes a repeated log message.