### PR TITLE
RBAC for v2 apps

### DIFF
--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -29,6 +29,9 @@ var globalResourcesNeededInProjects = map[string]map[string]bool{
 	"apiservices": {
 		"apiregistration.k8s.io": true,
 	},
+	"clusterrepos": {
+		"catalog.cattle.io": true,
+	},
 }
 
 func newPRTBLifecycle(m *manager) *prtbLifecycle {

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -139,7 +139,8 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("clustercatalogs").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("clustermonitorgraphs").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("catalogtemplates").verbs("get", "list", "watch").
-		addRule().apiGroups("management.cattle.io").resources("catalogtemplateversions").verbs("get", "list", "watch")
+		addRule().apiGroups("management.cattle.io").resources("catalogtemplateversions").verbs("get", "list", "watch").
+		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch")
 
 	rb.addRoleTemplate("Create Projects", "projects-create", "cluster", false, false, false).
 		addRule().apiGroups("management.cattle.io").resources("projects").verbs("create")
@@ -219,6 +220,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("rbac.istio.io").resources("rbacconfigs", "serviceroles", "servicerolebindings").verbs("*").
 		addRule().apiGroups("security.istio.io").resources("authorizationpolicies").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("projects").verbs("own").
+		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos", "operations", "releases", "apps").verbs("get", "list", "watch").
 		setRoleTemplateNames("admin")
 
 	rb.addRoleTemplate("Project Member", "project-member", "project", false, false, false).
@@ -250,6 +252,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("authentication.istio.io").resources("policies").verbs("*").
 		addRule().apiGroups("rbac.istio.io").resources("rbacconfigs", "serviceroles", "servicerolebindings").verbs("*").
 		addRule().apiGroups("security.istio.io").resources("authorizationpolicies").verbs("*").
+		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos", "operations", "releases", "apps").verbs("get", "list", "watch").
 		setRoleTemplateNames("edit")
 
 	rb.addRoleTemplate("Read-only", "read-only", "project", false, false, false).
@@ -277,6 +280,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("authentication.istio.io").resources("policies").verbs("get", "list", "watch").
 		addRule().apiGroups("rbac.istio.io").resources("rbacconfigs", "serviceroles", "servicerolebindings").verbs("get", "list", "watch").
 		addRule().apiGroups("security.istio.io").resources("authorizationpolicies").verbs("get", "list", "watch").
+		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos", "operations", "releases", "apps").verbs("get", "list", "watch").
 		setRoleTemplateNames("view")
 
 	rb.addRoleTemplate("Create Namespaces", "create-ns", "project", false, false, false).

--- a/tests/integration/suite/test_kontainer_engine_annotations.py
+++ b/tests/integration/suite/test_kontainer_engine_annotations.py
@@ -1,5 +1,5 @@
 from .common import random_str
-from .conftest import wait_until
+from .conftest import wait_until, wait_for
 
 annotation = "clusterstatus.management.cattle.io/" \
              "temporary-security-credentials"
@@ -102,8 +102,8 @@ def test_editing_eks_cluster_gives_temp_creds_annotation(
         amazonElasticContainerServiceConfig=eks
     )
 
-    wait_until(has_cluster_annotation(admin_mc.client, cluster,
-                                      expected="true"))
+    wait_for(has_cluster_annotation(admin_mc.client, cluster,
+                                    expected="true"), timeout=120)
 
     cluster = admin_mc.client.reload(cluster)
 


### PR DESCRIPTION
**Problem**: Users with role cluster-member, project-owner and project-member cannot list Charts
**Solution**: Add rules for the `catalog.cattle.io` CRDs to these roles
With this change, 
* Cluster-member:
 1. Can list all Charts
 2. Can list installed Apps only of their projects (if they belong to a project or have created one)

* Project-owner and Project-member 
 1. Can list all Charts
 2. Can list only those Apps that are installed in namespaces belonging to their projects. (By default I can't select what namespace to install an app in in the dashboard, so I tested this by first installing an app then moving the namespace to a project)

* This commit also adds rules for the project scoped Read-only role:
1. Can list all Charts
2. Can list only those Apps that are installed in namespaces belonging to their projects
we do the same for v1 apps

https://github.com/rancher/rancher/issues/28861