### PR TITLE
Dont mutate eksv1 subnets

### DIFF
--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/management/k3sbasedupgrade"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/cis"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/kontainer-engine/service"
 	"github.com/rancher/rancher/pkg/namespace"
 	mgmtSchema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
@@ -64,10 +62,6 @@ func (v *Validator) Validator(request *types.APIContext, schema *types.Schema, d
 	}
 
 	if err := v.validateScheduledClusterScan(&clientClusterSpec); err != nil {
-		return err
-	}
-
-	if err := v.validateGenericEngineConfig(request, &clusterSpec); err != nil {
 		return err
 	}
 
@@ -307,31 +301,6 @@ func (v *Validator) accessTemplate(request *types.APIContext, spec *mgmtclient.C
 	return nil
 }
 
-// validateGenericEngineConfig allows for additional validation of clusters that depend on Kontainer Engine or Rancher Machine driver
-func (v *Validator) validateGenericEngineConfig(request *types.APIContext, spec *v32.ClusterSpec) error {
-
-	if request.Method == http.MethodPost {
-		return nil
-	}
-
-	if spec.AmazonElasticContainerServiceConfig != nil {
-		// compare with current cluster
-		clusterName := request.ID
-		prevCluster, err := v.ClusterLister.Get("", clusterName)
-		if err != nil {
-			return err
-		}
-
-		err = validateEKS(*prevCluster.Spec.GenericEngineConfig, *spec.AmazonElasticContainerServiceConfig)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-
-}
-
 func (v *Validator) validateEKSConfig(request *types.APIContext, cluster map[string]interface{}) error {
 	eksConfig, ok := cluster["eksConfig"].(map[string]interface{})
 	if !ok {
@@ -458,25 +427,6 @@ func validateEKSNodegroups(request *types.APIContext, eksConfig map[string]inter
 		ngMap, _ := ng.(map[string]interface{})
 		if name, ok := ngMap["nodegroupName"].(string); ok && name == "" {
 			return noNodegroupsError
-		}
-	}
-	return nil
-}
-
-func validateEKS(prevCluster, newCluster map[string]interface{}) error {
-	// check config is for EKS clusters
-	if driver, ok := prevCluster["driverName"]; ok {
-		if driver != service.AmazonElasticContainerServiceDriverName {
-			return nil
-		}
-	}
-
-	// don't allow for updating subnets
-	if prev, ok := prevCluster["subnets"]; ok {
-		if new, ok := newCluster["subnets"]; ok {
-			if !reflect.DeepEqual(prev, new) {
-				return httperror.NewAPIError(httperror.InvalidBodyContent, "cannot modify EKS subnets after creation")
-			}
 		}
 	}
 	return nil

--- a/tests/integration/suite/test_cluster_defaults.py
+++ b/tests/integration/suite/test_cluster_defaults.py
@@ -56,56 +56,21 @@ def test_generic_initial_conditions(admin_mc, remove_resource):
 
 
 def test_eks_cluster_immutable_subnets(admin_mc, remove_resource):
+    original_subnets = ["subnet-045bfaeca7d3f1cb3", "subnet-02388a166136f98c4"]
     cluster = admin_mc.client.create_cluster(
         name=random_str(), amazonElasticContainerServiceConfig={
             "accessKey": "asdfsd",
             "secretKey": "verySecretKey",
-            "subnets": [
-                "subnet-045bfaeca7d3f1cb3",
-                "subnet-02388a166136f98c4"
-            ]})
+            "subnets": original_subnets})
     remove_resource(cluster)
 
-    def cannot_modify_error():
-        with pytest.raises(ApiError) as e:
-            # try to edit cluster subnets
-            admin_mc.client.update_by_id_cluster(
-                id=cluster.id,
-                amazonElasticContainerServiceConfig={
-                     "accessKey": "asdfsd",
-                     "secretKey": "verySecretKey",
-                     "subnets": [
-                         "subnet-045bfaeca7d3f1cb3"
-                     ]})
-        if e.value.error.status == 404:
-            return False
-        print(e)
-        assert e.value.error.status == 422
-        assert e.value.error.message ==\
-            'cannot modify EKS subnets after creation'
-        return True
+    cluster.amazonElasticContainerServiceConfig.subnets = ["asd"]
+    cluster = admin_mc.client.update_by_id_cluster(cluster.id, cluster)
 
-    # lister used by cluster validator may not be up to date, may need to retry
-    wait_for(cannot_modify_error)
-
-    # tests updates still work
-    new = admin_mc.client.update_by_id_cluster(
-       id=cluster.id,
-       name=cluster.name,
-       description="update",
-       amazonElasticContainerServiceConfig={
-           # required field when updating KE clusters
-           "driverName": "amazonelasticcontainerservice",
-           "accessKey": "asdfsd",
-           "secretKey": "verySecretKey",
-           "subnets": [
-               "subnet-045bfaeca7d3f1cb3",
-               "subnet-02388a166136f98c4"
-           ]})
-
-    assert new.id == cluster.id
-    assert not hasattr(cluster, "description")
-    assert hasattr(new, "description")
+    new_subnets = cluster.amazonElasticContainerServiceConfig.subnets
+    assert len(original_subnets) == len(new_subnets)
+    for key, value in enumerate(new_subnets):
+        assert original_subnets[key] == value
 
 
 def test_rke_initial_conditions(admin_mc, remove_resource):


### PR DESCRIPTION
**Problem:**
Prior, if subnets were different an error would be returned. Before v2.5 sending a request with an empty array would result in a nil field. Now it results in an empty array. This is causing the error to return given the same cluster body.

**Solution:**
To prevent field updates sometimes the "noupdate" tag is used. These were not used before because the subnets are in a dynamic config. Now, logic has been added to the cluster store to implement the same behavior as the "noupdate" tag which simply does not mutate its fields value.

**Issue:**
https://github.com/rancher/rancher/issues/28999