### PR TITLE
Validate upgrades for EKS clusters

### DIFF
--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	eksv1 "github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
@@ -353,21 +353,24 @@ func (v *Validator) validateEKSConfig(request *types.APIContext, cluster map[str
 
 	createFromImport := request.Method == http.MethodPost && eksConfig["imported"] == true
 
-	var prevSpec *eksv1.EKSClusterConfigSpec
+	var prevCluster *v3.Cluster
 
 	if request.Method == http.MethodPut {
-		prevCluster, err := v.ClusterLister.Get("", request.ID)
+		var err error
+		prevCluster, err = v.ClusterLister.Get("", request.ID)
 		if err != nil {
 			return err
 		}
-		prevSpec = prevCluster.Spec.EKSConfig
 	}
 
 	if !createFromImport {
-		if err := validateEKSNodegroups(request, eksConfig, prevSpec); err != nil {
+		if err := validateEKSKubernetesVersion(eksConfig, prevCluster); err != nil {
 			return err
 		}
-		if err := validateEKSAccess(request, eksConfig, prevSpec); err != nil {
+		if err := validateEKSNodegroups(eksConfig); err != nil {
+			return err
+		}
+		if err := validateEKSAccess(request, eksConfig, prevCluster); err != nil {
 			return err
 		}
 	}
@@ -420,15 +423,15 @@ func (v *Validator) validateEKSConfig(request *types.APIContext, cluster map[str
 	return nil
 }
 
-func validateEKSAccess(request *types.APIContext, eksConfig map[string]interface{}, prevSpec *eksv1.EKSClusterConfigSpec) error {
+func validateEKSAccess(request *types.APIContext, eksConfig map[string]interface{}, prevCluster *v3.Cluster) error {
 	publicAccess, _ := eksConfig["publicAccess"]
 	privateAccess, _ := eksConfig["privateAccess"]
 	if request.Method != http.MethodPost {
 		if publicAccess == nil {
-			publicAccess = prevSpec.PublicAccess
+			publicAccess = prevCluster.Spec.EKSConfig.PublicAccess
 		}
 		if privateAccess == nil {
-			privateAccess = prevSpec.PrivateAccess
+			privateAccess = prevCluster.Spec.EKSConfig.PrivateAccess
 		}
 	}
 
@@ -440,25 +443,74 @@ func validateEKSAccess(request *types.APIContext, eksConfig map[string]interface
 	return nil
 }
 
-func validateEKSNodegroups(request *types.APIContext, eksConfig map[string]interface{}, prevSpec *eksv1.EKSClusterConfigSpec) error {
-	noNodegroupsError := httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf("must have at least one nodegroup"))
-	nodegroups, ok := eksConfig["nodeGroups"].([]interface{})
-	if !ok || nodegroups == nil {
-		if request.Method == http.MethodPost {
-			return noNodegroupsError
-		}
-		if prevSpec.NodeGroups != nil && len(prevSpec.NodeGroups) == 0 {
-			return noNodegroupsError
-		}
-	} else if len(nodegroups) == 0 {
-		return noNodegroupsError
+// validateEKSKubernetesVersion checks whether a kubernetes version is provided and if it is supported
+func validateEKSKubernetesVersion(eksConfig map[string]interface{}, prevCluster *v3.Cluster) error {
+	clusterVersion, _ := eksConfig["kubernetesVersion"]
+	if clusterVersion == nil {
+		return nil
 	}
+
+	if clusterVersion == "" {
+		return httperror.NewAPIError(httperror.InvalidBodyContent, "cluster kubernetes version cannot be empty string")
+	}
+
+	if prevCluster == nil {
+		return nil
+	}
+
+	nodegroups := prevCluster.Spec.EKSConfig.NodeGroups
+	if nodegroups == nil {
+		if prevCluster.Status.EKSStatus.UpstreamSpec == nil {
+			return httperror.NewAPIError(httperror.ClusterUnavailable, "upstream spec not available yet, unable to validate kubernetes version upgrade")
+		}
+		nodegroups = prevCluster.Status.EKSStatus.UpstreamSpec.NodeGroups
+	}
+
+	currentVersion := prevCluster.Spec.EKSConfig.KubernetesVersion
+	if currentVersion == nil {
+		currentVersion = prevCluster.Status.EKSStatus.UpstreamSpec.KubernetesVersion
+	}
+	for _, ng := range nodegroups {
+		if aws.StringValue(currentVersion) != aws.StringValue(ng.Version) {
+			return httperror.NewAPIError(httperror.InvalidBodyContent, "nodegroups' versions must match cluster's kubernetes version before cluster upgrade")
+		}
+	}
+
+	return nil
+}
+
+// validateEKSNodegroups checks whether a given nodegroup version is empty or not supported.
+// More involved validation is performed in the EKS-operator.
+func validateEKSNodegroups(eksConfig map[string]interface{}) error {
+	nodegroups, _ := eksConfig["nodeGroups"].([]interface{})
+	if nodegroups == nil {
+		return nil
+	}
+	if len(nodegroups) == 0 {
+		return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf("must have at least one nodegroup"))
+	}
+
+	var errors []string
 
 	for _, ng := range nodegroups {
 		ngMap, _ := ng.(map[string]interface{})
-		if name, ok := ngMap["nodegroupName"].(string); ok && name == "" {
-			return noNodegroupsError
+		name, _ := ngMap["nodegroupName"].(string)
+		if name == "" {
+			return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf("nodegroupName cannot be an empty"))
 		}
+
+		version, _ := ngMap["version"]
+		if version == nil {
+			continue
+		}
+		if version == "" {
+			errors = append(errors, fmt.Sprintf("nodegroup [%s] version cannot be empty string", name))
+			continue
+		}
+	}
+
+	if len(errors) != 0 {
+		return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf(strings.Join(errors, ";")))
 	}
 	return nil
 }

--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -277,13 +277,6 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 			}
 		}
 
-		// check for unauthorized error
-		if failureMessage != "" {
-			if strings.Contains(failureMessage, "403") {
-				return e.setFalse(cluster, apimgmtv3.ClusterConditionUpdated, "cannot access EKS, check cloud credential")
-			}
-		}
-
 		cluster, err = e.recordAppliedSpec(cluster)
 		if err != nil {
 			return cluster, err
@@ -302,6 +295,9 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 			return e.setUnknown(cluster, apimgmtv3.ClusterConditionUpdated, "")
 		}
 		logrus.Infof("waiting for cluster EKS [%s] update failure to be resolved", cluster.Name)
+		if strings.Contains(failureMessage, "403") {
+			failureMessage = "cannot access EKS, check cloud credential"
+		}
 		return e.setFalse(cluster, apimgmtv3.ClusterConditionUpdated, failureMessage)
 	default:
 		if cluster.Spec.EKSConfig.Imported {


### PR DESCRIPTION
**Problem:**
EKS cluster version can be upgraded twice in a row without upgrading nodegroups. This is not valid in EKS. There is validation for this in the eks-operator but not stopping the user at the API level puts the cluster in a state that cannot be fixed through the UI.

**Solution:**
Add validation to the API that does not let the cluster upgrade unless all nodegroup versions are equal to the current kubernetes version.

**Issue:**
https://github.com/rancher/rancher/issues/28968