### PR TITLE
Add new restricted-admin role

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -104,6 +104,10 @@ spec:
         - name: CATTLE_SYSTEM_CATALOG
           value: bundled
 {{- end }}
+{{- if .Values.restrictedAdmin }}
+        - name: CATTLE_RESTRICTED_DEFAULT_ADMIN
+          value: true
+{{- end}}
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -28,6 +28,9 @@ busyboxImage: busybox
 # Add debug flag to Rancher server
 debug: false
 
+# When starting Rancher for the first time, bootstrap the admin as restricted-admin
+restrictedAdmin: false
+
 # Extra environment variables passed to the rancher pods.
 # extraEnv:
 # - name: CATTLE_TLS_MIN_VERSION

--- a/pkg/controllers/management/auth/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalrolebinding_handler.go
@@ -73,7 +73,7 @@ func (grb *globalRoleBindingLifecycle) Updated(obj *v3.GlobalRoleBinding) (runti
 }
 
 func (grb *globalRoleBindingLifecycle) Remove(obj *v3.GlobalRoleBinding) (runtime.Object, error) {
-	if obj.GlobalRoleName == "admin" {
+	if obj.GlobalRoleName == rbac.GlobalAdmin || obj.GlobalRoleName == rbac.GlobalRestrictedAdmin {
 		return obj, grb.deleteAdminBinding(obj)
 	}
 	// Don't need to delete the created ClusterRole because owner reference will take care of that

--- a/pkg/controllers/managementuser/rbac/globalrole_handler.go
+++ b/pkg/controllers/managementuser/rbac/globalrole_handler.go
@@ -57,6 +57,7 @@ func newGlobalRoleBindingHandler(workload *config.UserContext) v3.GlobalRoleBind
 	informer := workload.Management.Management.GlobalRoleBindings("").Controller().Informer()
 
 	h := &grbHandler{
+		clusterName:         workload.ClusterName,
 		grbIndexer:          informer.GetIndexer(),
 		clusterRoleBindings: workload.RBAC.ClusterRoleBindings(""),
 		crbLister:           workload.RBAC.ClusterRoleBindings("").Controller().Lister(),
@@ -69,6 +70,7 @@ func newGlobalRoleBindingHandler(workload *config.UserContext) v3.GlobalRoleBind
 // grbHandler ensures the global admins have full access to every cluster. If a globalRoleBinding is created that uses
 // the admin role, then the user in that binding gets a clusterRoleBinding in every user cluster to the cluster-admin role
 type grbHandler struct {
+	clusterName         string
 	clusterRoleBindings rbacv1.ClusterRoleBindingInterface
 	crbLister           rbacv1.ClusterRoleBindingLister
 	grbIndexer          cache.Indexer
@@ -84,6 +86,11 @@ func (c *grbHandler) sync(key string, obj *v3.GlobalRoleBinding) (runtime.Object
 	if err != nil {
 		return nil, err
 	} else if !isAdmin {
+		return obj, nil
+	}
+
+	// Do not sync restricted-admin to the local cluster as 'cluster-admin'
+	if c.clusterName == "local" && obj.GlobalRoleName == rbac.GlobalRestrictedAdmin {
 		return obj, nil
 	}
 
@@ -127,7 +134,7 @@ func (c *grbHandler) isAdminRole(rtName string) (bool, error) {
 	}
 
 	// global role is builtin admin role
-	if gr.Builtin && gr.Name == "admin" {
+	if gr.Builtin && (gr.Name == rbac.GlobalAdmin || gr.Name == rbac.GlobalRestrictedAdmin) {
 		return true, nil
 	}
 

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -73,6 +73,15 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("*").resources("*").verbs("*").
 		addRule().apiGroups().nonResourceURLs("*").verbs("*")
 
+	// restricted-admin will get cluster admin access to all downstream clusters but limited access to the local cluster
+	// The validating webhook will ensure GRBs PRTBs and CRTBs are not created by a restricted admin in the local cluster
+	rb.addRole("Restricted Admin", "restricted-admin").
+		addRule().apiGroups("management.cattle.io").resources("*").verbs("*").
+		addRule().apiGroups("project.cattle.io").resources("*").verbs("*").
+		addRule().apiGroups("fleet.cattle.io").resources("*").verbs("*").
+		addRule().apiGroups("rancher.cattle.io").resources("*").verbs("*").
+		addRule().apiGroups("catalog.cattle.io").resources("*").verbs("*")
+
 	rb.addRole("User", "user").
 		addRule().apiGroups("management.cattle.io").resources("principals", "roletemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("preferences").verbs("*").

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -451,6 +451,10 @@ func BootstrapAdmin(management *wrangler.Context, createClusterRoleBinding bool)
 			bindings = &v3.GlobalRoleBindingList{}
 		}
 		if len(bindings.Items) == 0 {
+			adminRole := "admin"
+			if settings.RestrictedDefaultAdmin.Get() == "true" {
+				adminRole = "restricted-admin"
+			}
 			_, err = management.Mgmt.GlobalRoleBinding().Create(
 				&v3.GlobalRoleBinding{
 					ObjectMeta: v1.ObjectMeta{
@@ -458,7 +462,7 @@ func BootstrapAdmin(management *wrangler.Context, createClusterRoleBinding bool)
 						Labels:       defaultAdminLabel,
 					},
 					UserName:       adminName,
-					GlobalRoleName: "admin",
+					GlobalRoleName: adminRole,
 				})
 			if err != nil {
 				logrus.Warnf("Failed to create default admin global role binding: %v", err)

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	NamespaceID = "namespaceId"
-	ProjectID   = "projectId"
-	ClusterID   = "clusterId"
+	NamespaceID           = "namespaceId"
+	ProjectID             = "projectId"
+	ClusterID             = "clusterId"
+	GlobalAdmin           = "admin"
+	GlobalRestrictedAdmin = "restricted-admin"
 )
 
 // BuildSubjectFromRTB This function will generate
@@ -79,7 +81,13 @@ func BuildSubjectFromRTB(object interface{}) (rbacv1.Subject, error) {
 }
 
 func GrbCRBName(grb *v3.GlobalRoleBinding) string {
-	return "globaladmin-" + GetGRBTargetKey(grb)
+	var prefix string
+	if grb.GlobalRoleName == GlobalAdmin {
+		prefix = "globaladmin-"
+	} else {
+		prefix = "globalrestrictedadmin-"
+	}
+	return prefix + GetGRBTargetKey(grb)
 }
 
 // GetGRBSubject creates and returns a subject that is

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -91,6 +91,7 @@ var (
 	ShellImage                        = NewSetting("shell-image", "rancher/shell:v0.1.3")
 	IgnoreNodeName                    = NewSetting("ignore-node-name", "") // nodes to ignore when syncing v1.node to v3.node
 	NoDefaultAdmin                    = NewSetting("no-default-admin", "")
+	RestrictedDefaultAdmin            = NewSetting("restricted-default-admin", "false") // When bootstrapping the admin for the first time, give them the global role restricted-admin
 	EKSUpstreamRefreshCron            = NewSetting("eks-refresh-cron", "*/5 * * * *")
 )
 


### PR DESCRIPTION
Problem:
With local cluster now being required the admin role will have full
access to the local cluster which is not good from a security
perspective

Solution:
Add a new restricted-admin role with limited access to the local cluster
but cluster-admin access to all downstream clusters. The
restricted-admin will not be able to create anything rbac related in the
local cluster but should have access otherwise.
Add new setting and update helm chart with the option to set the default admin created on first startup to the restricted-admin role. 

https://github.com/rancher/rancher/issues/28977