### PR TITLE
Use cattle-system instead of dashboard-shells for shell

### DIFF
--- a/pkg/api/steve/clusters/clusters.go
+++ b/pkg/api/steve/clusters/clusters.go
@@ -17,7 +17,7 @@ import (
 func Register(ctx context.Context, server *steve.Server) error {
 	shell := &shell{
 		cg:           server.ClientFactory,
-		namespace:    "dashboard-shells",
+		namespace:    "cattle-system",
 		impersonator: podimpersonation.New("shell", server.ClientFactory, time.Hour, settings.FullShellImage),
 	}
 


### PR DESCRIPTION
This commit switched to use cattle-system instead of dashboard-shells
for shell containers, in order to avoid patching dashboard-shells for
CIS compliance.