### PR TITLE
update the rbac tests for monitoring v2

### DIFF
--- a/tests/validation/tests/v3_api/resource/rbac/monitoring/monitoring_rbac.json
+++ b/tests/validation/tests/v3_api/resource/rbac/monitoring/monitoring_rbac.json
@@ -1,16 +1,6 @@
 {
   "monitoring-admin": {
     "should_pass": [
-      "create -f {resource_root}/rbac/monitoring/cr_configmap_base.yaml",
-      "get configmap",
-      "get configmap test-example-1",
-      "apply  -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
-      "delete -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
-      "create -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
-      "get secret",
-      "get secret test-example-1",
-      "apply  -f {resource_root}/rbac/monitoring/cr_secret_upgrade.yaml",
-      "delete -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
       "create -f {resource_root}/rbac/monitoring/cr_pod_monitor_base.yaml",
       "get podmonitors.monitoring.coreos.com",
       "get podmonitors.monitoring.coreos.com test-example-1",
@@ -32,6 +22,16 @@
       "get prometheuses.monitoring.coreos.com test-example-1"
     ],
     "should_fail": [
+      "create -f {resource_root}/rbac/monitoring/cr_configmap_base.yaml",
+      "get configmap",
+      "get configmap test-example-1",
+      "apply  -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
+      "create -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
+      "get secret",
+      "get secret test-example-1",
+      "apply  -f {resource_root}/rbac/monitoring/cr_secret_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
       "create -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
       "apply  -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
       "delete -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
@@ -42,16 +42,6 @@
   },
   "monitoring-edit": {
     "should_pass": [
-      "create -f {resource_root}/rbac/monitoring/cr_configmap_base.yaml",
-      "get configmap",
-      "get configmap test-example-1",
-      "apply  -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
-      "delete -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
-      "create -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
-      "get secret",
-      "get secret test-example-1",
-      "apply  -f {resource_root}/rbac/monitoring/cr_secret_upgrade.yaml",
-      "delete -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
       "create -f {resource_root}/rbac/monitoring/cr_pod_monitor_base.yaml",
       "get podmonitors.monitoring.coreos.com",
       "get podmonitors.monitoring.coreos.com test-example-1",
@@ -73,6 +63,16 @@
       "get prometheuses.monitoring.coreos.com test-example-1"
     ],
     "should_fail": [
+      "create -f {resource_root}/rbac/monitoring/cr_configmap_base.yaml",
+      "get configmap",
+      "get configmap test-example-1",
+      "apply  -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
+      "create -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
+      "get secret",
+      "get secret test-example-1",
+      "apply  -f {resource_root}/rbac/monitoring/cr_secret_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
       "create -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
       "apply  -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
       "delete -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
@@ -83,10 +83,6 @@
   },
   "monitoring-view": {
     "should_pass": [
-      "get configmap",
-      "get configmap my-config",
-      "get secret",
-      "get secret mysecret",
       "get podmonitors.monitoring.coreos.com",
       "get podmonitors.monitoring.coreos.com test-example-1",
       "get prometheusrules.monitoring.coreos.com",
@@ -99,9 +95,13 @@
       "get prometheuses.monitoring.coreos.com test-example-1"
     ],
     "should_fail": [
+      "get configmap",
+      "get configmap my-config",
       "create -f {resource_root}/rbac/monitoring/cr_configmap_base.yaml",
       "apply  -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
       "delete -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
+      "get secret",
+      "get secret mysecret",
       "create -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
       "apply  -f {resource_root}/rbac/monitoring/cr_secret_upgrade.yaml",
       "delete -f {resource_root}/rbac/monitoring/cr_secret_upgrade.yaml",
@@ -122,7 +122,7 @@
       "delete -f {resource_root}/rbac/monitoring/cr_prometheus.yaml"
     ]
   },
-  "grafana-config-edit": {
+  "admin": {
     "should_pass": [
       "create -f {resource_root}/rbac/monitoring/cr_configmap_base.yaml",
       "get configmap",
@@ -132,49 +132,6 @@
       "create -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
       "get secret",
       "get secret test-example-1",
-      "apply  -f {resource_root}/rbac/monitoring/cr_secret_upgrade.yaml",
-      "delete -f {resource_root}/rbac/monitoring/cr_secret_base.yaml"
-    ],
-    "should_fail": [
-      "create -f {resource_root}/rbac/monitoring/cr_pod_monitor_base.yaml",
-      "get podmonitors.monitoring.coreos.com",
-      "get podmonitors.monitoring.coreos.com test-example-1",
-      "apply  -f {resource_root}/rbac/monitoring/cr_pod_monitor_upgrade.yaml",
-      "delete -f {resource_root}/rbac/monitoring/cr_pod_monitor_upgrade.yaml",
-      "create -f {resource_root}/rbac/monitoring/cr_prometheus_rule_base.yaml",
-      "get prometheusrules.monitoring.coreos.com",
-      "get prometheusrules.monitoring.coreos.com test-example-1",
-      "apply  -f {resource_root}/rbac/monitoring/cr_prometheus_rule_upgrade.yaml",
-      "delete -f {resource_root}/rbac/monitoring/cr_prometheus_rule_upgrade.yaml",
-      "create -f {resource_root}/rbac/monitoring/cr_service_monitor_base.yaml",
-      "get servicemonitors.monitoring.coreos.com",
-      "get servicemonitors.monitoring.coreos.com test-example-1",
-      "apply  -f {resource_root}/rbac/monitoring/cr_service_monitor_upgrade.yaml",
-      "delete -f {resource_root}/rbac/monitoring/cr_service_monitor_upgrade.yaml",
-      "create -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
-      "get alertmanagers.monitoring.coreos.com",
-      "get alertmanagers.monitoring.coreos.com test-example-1",
-      "apply  -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
-      "delete -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
-      "create -f {resource_root}/rbac/monitoring/cr_prometheus.yaml",
-      "get prometheuses.monitoring.coreos.com",
-      "get prometheuses.monitoring.coreos.com test-example-1",
-      "apply  -f {resource_root}/rbac/monitoring/cr_prometheus.yaml",
-      "delete -f {resource_root}/rbac/monitoring/cr_prometheus.yaml"
-    ]
-  },
-    "grafana-config-view": {
-    "should_pass": [
-      "get configmap",
-      "get configmap my-config",
-      "get secret",
-      "get secret mysecret"
-    ],
-    "should_fail": [
-      "create -f {resource_root}/rbac/monitoring/cr_configmap_base.yaml",
-      "apply  -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
-      "delete -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
-      "create -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
       "apply  -f {resource_root}/rbac/monitoring/cr_secret_upgrade.yaml",
       "delete -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
       "create -f {resource_root}/rbac/monitoring/cr_pod_monitor_base.yaml",
@@ -192,14 +149,98 @@
       "get servicemonitors.monitoring.coreos.com test-example-1",
       "apply  -f {resource_root}/rbac/monitoring/cr_service_monitor_upgrade.yaml",
       "delete -f {resource_root}/rbac/monitoring/cr_service_monitor_upgrade.yaml",
-      "create -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
       "get alertmanagers.monitoring.coreos.com",
       "get alertmanagers.monitoring.coreos.com test-example-1",
+      "get prometheuses.monitoring.coreos.com",
+      "get prometheuses.monitoring.coreos.com test-example-1"
+    ],
+    "should_fail": [
+      "create -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
       "apply  -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
       "delete -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
       "create -f {resource_root}/rbac/monitoring/cr_prometheus.yaml",
+      "apply  -f {resource_root}/rbac/monitoring/cr_prometheus.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_prometheus.yaml"
+    ]
+  },
+  "edit": {
+    "should_pass": [
+      "create -f {resource_root}/rbac/monitoring/cr_configmap_base.yaml",
+      "get configmap",
+      "get configmap test-example-1",
+      "apply  -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
+      "create -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
+      "get secret",
+      "get secret test-example-1",
+      "apply  -f {resource_root}/rbac/monitoring/cr_secret_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
+      "create -f {resource_root}/rbac/monitoring/cr_pod_monitor_base.yaml",
+      "get podmonitors.monitoring.coreos.com",
+      "get podmonitors.monitoring.coreos.com test-example-1",
+      "apply  -f {resource_root}/rbac/monitoring/cr_pod_monitor_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_pod_monitor_upgrade.yaml",
+      "create -f {resource_root}/rbac/monitoring/cr_prometheus_rule_base.yaml",
+      "get prometheusrules.monitoring.coreos.com",
+      "get prometheusrules.monitoring.coreos.com test-example-1",
+      "apply  -f {resource_root}/rbac/monitoring/cr_prometheus_rule_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_prometheus_rule_upgrade.yaml",
+      "create -f {resource_root}/rbac/monitoring/cr_service_monitor_base.yaml",
+      "get servicemonitors.monitoring.coreos.com",
+      "get servicemonitors.monitoring.coreos.com test-example-1",
+      "apply  -f {resource_root}/rbac/monitoring/cr_service_monitor_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_service_monitor_upgrade.yaml",
+      "get alertmanagers.monitoring.coreos.com",
+      "get alertmanagers.monitoring.coreos.com test-example-1",
       "get prometheuses.monitoring.coreos.com",
-      "get prometheuses.monitoring.coreos.com test-example-1",
+      "get prometheuses.monitoring.coreos.com test-example-1"
+    ],
+    "should_fail": [
+      "create -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
+      "apply  -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
+      "create -f {resource_root}/rbac/monitoring/cr_prometheus.yaml",
+      "apply  -f {resource_root}/rbac/monitoring/cr_prometheus.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_prometheus.yaml"
+    ]
+  },
+  "view": {
+    "should_pass": [
+      "get configmap",
+      "get configmap my-config",
+      "get podmonitors.monitoring.coreos.com",
+      "get podmonitors.monitoring.coreos.com test-example-1",
+      "get prometheusrules.monitoring.coreos.com",
+      "get prometheusrules.monitoring.coreos.com test-example-1",
+      "get servicemonitors.monitoring.coreos.com",
+      "get servicemonitors.monitoring.coreos.com test-example-1",
+      "get alertmanagers.monitoring.coreos.com",
+      "get alertmanagers.monitoring.coreos.com test-example-1",
+      "get prometheuses.monitoring.coreos.com",
+      "get prometheuses.monitoring.coreos.com test-example-1"
+    ],
+    "should_fail": [
+      "create -f {resource_root}/rbac/monitoring/cr_configmap_base.yaml",
+      "apply  -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_configmap_upgrade.yaml",
+      "get secret",
+      "get secret mysecret",
+      "create -f {resource_root}/rbac/monitoring/cr_secret_base.yaml",
+      "apply  -f {resource_root}/rbac/monitoring/cr_secret_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_secret_upgrade.yaml",
+      "create -f {resource_root}/rbac/monitoring/cr_pod_monitor_base.yaml",
+      "apply  -f {resource_root}/rbac/monitoring/cr_pod_monitor_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_pod_monitor_upgrade.yaml",
+      "create -f {resource_root}/rbac/monitoring/cr_prometheus_rule_base.yaml",
+      "apply  -f {resource_root}/rbac/monitoring/cr_prometheus_rule_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_prometheus_rule_upgrade.yaml",
+      "create -f {resource_root}/rbac/monitoring/cr_service_monitor_base.yaml",
+      "apply  -f {resource_root}/rbac/monitoring/cr_service_monitor_upgrade.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_service_monitor_upgrade.yaml",
+      "create -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
+      "apply  -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
+      "delete -f {resource_root}/rbac/monitoring/cr_alert_manager.yaml",
+      "create -f {resource_root}/rbac/monitoring/cr_prometheus.yaml",
       "apply  -f {resource_root}/rbac/monitoring/cr_prometheus.yaml",
       "delete -f {resource_root}/rbac/monitoring/cr_prometheus.yaml"
     ]


### PR DESCRIPTION
- add tests for `admin`, `edit` and `view` clusterroles 
- move tests for `secret` and `configmap` form should_pass to should_fail for monitoring-admin, monitoring-edit, and monitoring-view
- remove tests for grafana-config-admin, grafana-config-edit, and grafana-config-view because those clusterrols do no exist anymore.  