### PR TITLE
Set local rke2 cluster to rancherd, and prevent upgrades through rancher

### DIFF
--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -76,6 +76,7 @@ const (
 	ClusterDriverK3os     = "k3os"
 	ClusterDriverRke2     = "rke2"
 	ClusterDriverEKS      = "EKS"
+	ClusterDriverRancherD = "rancherd"
 )
 
 // +genclient

--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -74,8 +74,8 @@ func Register(ctx context.Context, management *config.ManagementContext) {
 		Backups:               management.Management.EtcdBackups("").Controller().Lister(),
 		RKESystemImagesLister: management.Management.RkeK8sSystemImages("").Controller().Lister(),
 		RKESystemImages:       management.Management.RkeK8sSystemImages(""),
+		DaemonsetLister:       management.Apps.DaemonSets("").Controller().Lister(),
 	}
-
 	// Add handlers
 	p.Clusters.AddLifecycle(ctx, "cluster-provisioner-controller", p)
 	management.Management.Nodes("").AddHandler(ctx, "cluster-provisioner-controller", p.machineChanged)
@@ -1042,6 +1042,7 @@ func (p *Provisioner) k3sBasedClusterConfig(cluster *v3.Cluster, nodes []*v3.Nod
 			cluster.Spec.K3sConfig.SetStrategy(1, 1)
 		}
 	} else if strings.Contains(cluster.Status.Version.String(), "rke2") {
+
 		daemonsets, _ := p.DaemonsetLister.List("cattle-system", labels.Everything())
 		for _, daemonset := range daemonsets {
 			if daemonset.GetName() == "rancher" {

--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -686,7 +686,8 @@ func skipLocalK3sImported(cluster *apimgmtv3.Cluster) bool {
 		cluster.Status.Driver == apimgmtv3.ClusterDriverImported ||
 		cluster.Status.Driver == apimgmtv3.ClusterDriverK3s ||
 		cluster.Status.Driver == apimgmtv3.ClusterDriverK3os ||
-		cluster.Status.Driver == apimgmtv3.ClusterDriverRke2
+		cluster.Status.Driver == apimgmtv3.ClusterDriverRke2 ||
+		cluster.Status.Driver == apimgmtv3.ClusterDriverRancherD
 }
 
 func (p *Provisioner) getConfig(reconcileRKE bool, spec apimgmtv3.ClusterSpec, driverName, clusterName string) (*apimgmtv3.ClusterSpec, interface{}, error) {
@@ -1015,7 +1016,8 @@ func k3sBasedClusterConfig(cluster *v3.Cluster, nodes []*v3.Node) error {
 	}
 	if cluster.Status.Driver == apimgmtv3.ClusterDriverK3s ||
 		cluster.Status.Driver == apimgmtv3.ClusterDriverK3os ||
-		cluster.Status.Driver == apimgmtv3.ClusterDriverRke2 {
+		cluster.Status.Driver == apimgmtv3.ClusterDriverRke2 ||
+		cluster.Status.Driver == apimgmtv3.ClusterDriverRancherD {
 		return nil //no-op
 	}
 
@@ -1037,6 +1039,10 @@ func k3sBasedClusterConfig(cluster *v3.Cluster, nodes []*v3.Node) error {
 			cluster.Spec.K3sConfig.SetStrategy(1, 1)
 		}
 	} else if strings.Contains(cluster.Status.Version.String(), "rke2") {
+		if cluster.Name == "local" {
+			cluster.Status.Driver = apimgmtv3.ClusterDriverRancherD
+			return nil
+		}
 		cluster.Status.Driver = apimgmtv3.ClusterDriverRke2
 		if cluster.Spec.Rke2Config == nil {
 			cluster.Spec.Rke2Config = &apimgmtv3.Rke2Config{

--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -74,7 +74,8 @@ func (c *ClusterLifecycleCleanup) Remove(obj *v3.Cluster) (runtime.Object, error
 	} else if obj.Status.Driver == v32.ClusterDriverImported ||
 		obj.Status.Driver == v32.ClusterDriverK3s ||
 		obj.Status.Driver == v32.ClusterDriverK3os ||
-		obj.Status.Driver == v32.ClusterDriverRke2 {
+		obj.Status.Driver == v32.ClusterDriverRke2 ||
+		obj.Status.Driver == v32.ClusterDriverRancherD {
 		err = c.cleanupImportedCluster(obj)
 	}
 	if err != nil {

--- a/pkg/dialer/factory.go
+++ b/pkg/dialer/factory.go
@@ -61,7 +61,8 @@ func IsCloudDriver(cluster *v3.Cluster) bool {
 		cluster.Status.Driver != v32.ClusterDriverRKE &&
 		cluster.Status.Driver != v32.ClusterDriverK3s &&
 		cluster.Status.Driver != v32.ClusterDriverK3os &&
-		cluster.Status.Driver != v32.ClusterDriverRke2
+		cluster.Status.Driver != v32.ClusterDriverRke2 &&
+		cluster.Status.Driver != v32.ClusterDriverRancherD
 }
 
 func (f *Factory) translateClusterAddress(cluster *v3.Cluster, clusterHostPort, address string) string {

--- a/pkg/types/config/context.go
+++ b/pkg/types/config/context.go
@@ -184,6 +184,7 @@ type ManagementContext struct {
 	Project    projectv3.Interface
 	RBAC       rbacv1.Interface
 	Core       corev1.Interface
+	Apps       appsv1.Interface
 }
 
 type UserContext struct {
@@ -301,6 +302,10 @@ func newManagementContext(c *ScaledContext) (*ManagementContext, error) {
 	}
 
 	context.Core, err = corev1.NewFromControllerFactory(controllerFactory)
+	if err != nil {
+		return nil, err
+	}
+	context.Apps, err = appsv1.NewFromControllerFactory(controllerFactory)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Proposed change** 
- Add a separate driver for rancherd, which can be set when the local cluster is rke2
- Set the config for rancherd cluster to nil
issue : https://github.com/rancher/rke2/issues/201