### PR TITLE
Treat nil and empty subnets as equal

### DIFF
--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -522,12 +522,14 @@ func validateEKS(prevCluster, newCluster map[string]interface{}) error {
 	}
 
 	// don't allow for updating subnets
-	if prev, ok := prevCluster["subnets"]; ok {
-		if new, ok := newCluster["subnets"]; ok {
-			if !reflect.DeepEqual(prev, new) {
-				return httperror.NewAPIError(httperror.InvalidBodyContent, "cannot modify EKS subnets after creation")
-			}
-		}
+	prev, _ := prevCluster["subnets"].([]interface{})
+	new, _ := newCluster["subnets"].([]interface{})
+	if len(prev) == 0 && len(new) == 0 {
+		// should treat empty and nil as equal
+		return nil
+	}
+	if !reflect.DeepEqual(prev, new) {
+		return httperror.NewAPIError(httperror.InvalidBodyContent, "cannot modify EKS subnets after creation")
 	}
 	return nil
 }


### PR DESCRIPTION
**Problem:**
Lasso has been fixed so that passing an empty slice for a field does not automatically result in nil. Due to this, saving the same cluster spec as before would result as an empty slice instead of nil. These are technically not equal and result in an error.

**Soution:**
Now, since they are effectively equal they will be treated as such.

**Issue:**
https://github.com/rancher/rancher/issues/28999