### PR TITLE
set default for ignoreDaemonSets in cluster store

### DIFF
--- a/pkg/api/norman/customization/node/node.go
+++ b/pkg/api/norman/customization/node/node.go
@@ -131,6 +131,10 @@ func drainNode(actionName string, apiContext *types.APIContext, stop bool) error
 		if err != nil {
 			return err
 		}
+		if drainInput != nil && drainInput.IgnoreDaemonSets == nil {
+			trueVal := true
+			drainInput.IgnoreDaemonSets = &trueVal
+		}
 		values.PutValue(node, drainInput, "nodeDrainInput")
 	}
 	values.PutValue(node, actionName, "desiredNodeUnschedulable")

--- a/pkg/schemas/management.cattle.io/v3/schema.go
+++ b/pkg/schemas/management.cattle.io/v3/schema.go
@@ -381,11 +381,7 @@ func nodeTypes(schemas *types.Schemas) *types.Schemas {
 				Update:   false,
 			}
 		}).
-		MustImportAndCustomize(&Version, v3.NodeDrainInput{}, func(schema *types.Schema) {
-			dsField := schema.ResourceFields["ignoreDaemonSets"]
-			trueVal := true
-			dsField.Default = &trueVal
-		}).
+		MustImport(&Version, v3.NodeDrainInput{}).
 		MustImportAndCustomize(&Version, v3.Node{}, func(schema *types.Schema) {
 			labelField := schema.ResourceFields["labels"]
 			labelField.Create = true


### PR DESCRIPTION
Setting default in schema for *bool field ignoreDaemonSets doesn't work, because the `v3/schemas/nodeDrainInput` still shows ignoreDaemonSets as bool and available options = [null, true, false]. Changing the store so that it defaults to &true when null is passed. 

https://github.com/rancher/rancher/issues/28905