### PR TITLE
V2.5 rc1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -107,8 +107,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry /usr/bin/k3s /usr/bin/kubectl /usr/bin/channelserver && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-ENV CATTLE_UI_VERSION 2.5.0-alpha5
-ENV CATTLE_DASHBOARD_UI_VERSION v2.5.0-alpha5
+ENV CATTLE_UI_VERSION 2.5.0-rc1
+ENV CATTLE_DASHBOARD_UI_VERSION v2.5.0-rc1
 ENV CATTLE_CLI_VERSION v2.4.6
 
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.


### PR DESCRIPTION
Not swapping the chart branches anymore for RC's. RKE/CLI already up to date. 