### PR TITLE
Adds a new label to CRB/RB created for a CRTB/PRTB

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	pkgrbac "github.com/rancher/rancher/pkg/rbac"
@@ -15,16 +16,23 @@ import (
 )
 
 const (
-	clusterResource             = "clusters"
-	membershipBindingOwner      = "memberhsip-binding-owner"
-	membershipBindingOwnerIndex = "auth.management.cattle.io/membership-binding-owner"
-	crtbInProjectBindingOwner   = "crtb-in-project-binding-owner"
-	prtbInClusterBindingOwner   = "prtb-in-cluster-binding-owner"
-	rbByOwnerIndex              = "auth.management.cattle.io/rb-by-owner"
-	rbByRoleAndSubjectIndex     = "auth.management.cattle.io/crb-by-role-and-subject"
-	ctrbMGMTController          = "mgmt-auth-crtb-controller"
-	rtbLabelUpdated             = "auth.management.cattle.io/rtb-label-updated"
-	rtbCrbRbLabelsUpdated       = "auth.management.cattle.io/crb-rb-labels-updated"
+	/* Prior to 2.5, the label "memberhsip-binding-owner" was set on the CRB/RBs for a roleTemplateBinding with the key being the roleTemplateBinding's UID.
+	2.5 onwards, instead of the roleTemplateBinding's UID, a combination of its namespace and name will be used in this label.
+	CRB/RBs on clusters upgraded from 2.4.x to 2.5 will continue to carry the original label with UID. To ensure permissions are managed properly on upgrade,
+	we need to change the label value as well.
+	So the older label value, membershipBindingOwnerLegacy (<=2.4.x) will continue to be "memberhsip-binding-owner" (notice the spelling mistake),
+	and the new label, membershipBindingOwner will be "membership-binding-owner" (a different label value with the right spelling)*/
+	membershipBindingOwnerLegacy = "memberhsip-binding-owner"
+	membershipBindingOwner       = "membership-binding-owner"
+	clusterResource              = "clusters"
+	membershipBindingOwnerIndex  = "auth.management.cattle.io/membership-binding-owner"
+	crtbInProjectBindingOwner    = "crtb-in-project-binding-owner"
+	prtbInClusterBindingOwner    = "prtb-in-cluster-binding-owner"
+	rbByOwnerIndex               = "auth.management.cattle.io/rb-by-owner"
+	rbByRoleAndSubjectIndex      = "auth.management.cattle.io/crb-by-role-and-subject"
+	ctrbMGMTController           = "mgmt-auth-crtb-controller"
+	rtbLabelUpdated              = "auth.management.cattle.io/rtb-label-updated"
+	rtbCrbRbLabelsUpdated        = "auth.management.cattle.io/crb-rb-labels-updated"
 )
 
 var clusterManagmentPlaneResources = map[string]string{
@@ -74,7 +82,7 @@ func (c *crtbLifecycle) Updated(obj *v3.ClusterRoleTemplateBinding) (runtime.Obj
 }
 
 func (c *crtbLifecycle) Remove(obj *v3.ClusterRoleTemplateBinding) (runtime.Object, error) {
-	if err := c.mgr.reconcileClusterMembershipBindingForDelete("", getRTBLabelKey(obj.ObjectMeta)); err != nil {
+	if err := c.mgr.reconcileClusterMembershipBindingForDelete("", pkgrbac.GetRTBLabel(obj.ObjectMeta)); err != nil {
 		return nil, err
 	}
 	err := c.removeMGMTClusterScopedPrivilegesInProjectNamespace(obj)
@@ -148,7 +156,7 @@ func (c *crtbLifecycle) reconcileBindings(binding *v3.ClusterRoleTemplateBinding
 	if err != nil {
 		return err
 	}
-	if err := c.mgr.ensureClusterMembershipBinding(clusterRoleName, getRTBLabelKey(binding.ObjectMeta), cluster, isOwnerRole, subject); err != nil {
+	if err := c.mgr.ensureClusterMembershipBinding(clusterRoleName, pkgrbac.GetRTBLabel(binding.ObjectMeta), cluster, isOwnerRole, subject); err != nil {
 		return err
 	}
 
@@ -174,7 +182,7 @@ func (c *crtbLifecycle) removeMGMTClusterScopedPrivilegesInProjectNamespace(bind
 	if err != nil {
 		return err
 	}
-	bindingKey := getRTBLabelKey(binding.ObjectMeta)
+	bindingKey := pkgrbac.GetRTBLabel(binding.ObjectMeta)
 	for _, p := range projects {
 		set := labels.Set(map[string]string{bindingKey: crtbInProjectBindingOwner})
 		rbs, err := c.mgr.rbLister.List(p.Name, set.AsSelector())
@@ -201,18 +209,18 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 		return nil
 	}
 
-	var returnErr []error
+	var returnErr error
 	requirements, err := getLabelRequirements(binding.Namespace, binding.Name)
 	if err != nil {
 		return err
 	}
 
-	set := labels.Set(map[string]string{string(binding.UID): membershipBindingOwner})
+	set := labels.Set(map[string]string{string(binding.UID): membershipBindingOwnerLegacy})
 	crbs, err := c.mgr.crbLister.List(v1.NamespaceAll, set.AsSelector().Add(requirements...))
 	if err != nil {
 		return err
 	}
-	bindingKey := getRTBLabelKey(binding.ObjectMeta)
+	bindingKey := pkgrbac.GetRTBLabel(binding.ObjectMeta)
 	for _, crb := range crbs {
 		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			crbToUpdate, updateErr := c.mgr.crbClient.Get(crb.Name, v1.GetOptions{})
@@ -225,7 +233,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 			return err
 		})
 		if retryErr != nil {
-			returnErr = append(returnErr, retryErr)
+			returnErr = multierror.Append(returnErr, retryErr)
 		}
 	}
 
@@ -247,11 +255,11 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 			return err
 		})
 		if retryErr != nil {
-			returnErr = append(returnErr, retryErr)
+			returnErr = multierror.Append(returnErr, retryErr)
 		}
 	}
-	if len(returnErr) > 0 {
-		return fmt.Errorf("%v", returnErr)
+	if returnErr != nil {
+		return returnErr
 	}
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -600,7 +600,3 @@ func rtbByClusterAndRoleTemplateName(obj interface{}) ([]string, error) {
 	}
 	return []string{idx}, nil
 }
-
-func getRTBLabel(bindingMeta metav1.ObjectMeta) string {
-	return bindingMeta.Namespace + "_" + bindingMeta.Name
-}

--- a/pkg/controllers/managementuser/rbac/roletemplate_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplate_handler.go
@@ -3,6 +3,7 @@ package rbac
 import (
 	"github.com/pkg/errors"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/rbac"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -92,8 +93,8 @@ func (c *rtSync) syncRT(template *v3.RoleTemplate, usedInProjects bool, prtbs []
 			return err
 		}
 
-		rtbUID := string(prtb.UID)
-		set := labels.Set(map[string]string{rtbUID: owner})
+		rtbNsAndName := rbac.GetRTBLabel(prtb.ObjectMeta)
+		set := labels.Set(map[string]string{rtbNsAndName: owner})
 		existingCrbs, err := c.m.crbLister.List("", set.AsSelector())
 		if err != nil {
 			return err

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -10,6 +10,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/ref"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -141,4 +142,8 @@ func TypeFromContext(apiContext *types.APIContext, resource *types.RawResource) 
 		return apiContext.Type
 	}
 	return resource.Type
+}
+
+func GetRTBLabel(objMeta metav1.ObjectMeta) string {
+	return objMeta.Namespace + "_" + objMeta.Name
 }

--- a/tests/integration/suite/test_clustertemplate.py
+++ b/tests/integration/suite/test_clustertemplate.py
@@ -367,7 +367,7 @@ def test_updated_members_revision_access(admin_mc, remove_resource,
     rb_name = name + "-ctr-r"
     wait_for(lambda: check_subject_in_rb(rbac, 'cattle-global-data',
                                          user_member.user.id, rb_name),
-             timeout=60,
+             timeout=120,
              fail_handler=fail_handler(rb_resource))
     revision = user_member.client.by_id_cluster_template_revision(rev.id)
     assert revision is not None


### PR DESCRIPTION
**Problem**: Upgrading to 2.5 adds a new label containing the CRTB/PRTB namespace and name
to the CRB/RBs created for the it. Both labels have the same value "memberhsip-binding-owner".
When a CRTB/PRTB is deleted, the indexer gets all RTBs with this label value. If there are more
than one labels with this value, the CRB/RB is not deleted. On upgrade there will be two labels with
the same value, one is the existing label with UID as key and the other is the new label with ns+name

**Solution**: Change the label value. With this, on an upgraded setup, the controllers will only check if
the RB/CRB has a label with the new value. There will be only one such label, so on CRTB/PRTB deletion
the RB/CRB will get deleted. This is also required when migrating an upgraded setup using backup-restore-operator

https://github.com/rancher/rancher/issues/28370
Also addresses remaining comments from https://github.com/rancher/rancher/pull/28423
https://github.com/rancher/rancher/issues/29099