### PR TITLE
Fix airgap for fleet

### DIFF
--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -46,7 +46,8 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 	}
 
 	if setting.Name != settings.ServerURL.Name &&
-		setting.Name != settings.CACerts.Name {
+		setting.Name != settings.CACerts.Name &&
+		setting.Name != settings.SystemDefaultRegistry.Name {
 		return setting, nil
 	}
 
@@ -55,9 +56,15 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 		return setting, err
 	}
 
+	systemGlobalRegistry := map[string]interface{}{
+		"cattle": map[string]interface{}{
+			"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+		},
+	}
 	return setting, h.manager.Ensure(fleetChart.ReleaseNamespace, fleetChart.ChartName,
 		map[string]interface{}{
 			"apiServerURL": settings.ServerURL.Get(),
 			"apiServerCA":  settings.CACerts.Get(),
+			"global":       systemGlobalRegistry,
 		})
 }

--- a/pkg/controllers/management/systemcharts/controller.go
+++ b/pkg/controllers/management/systemcharts/controller.go
@@ -7,6 +7,7 @@ import (
 	catalog "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/catalogv2/system"
 	namespaces "github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
 )
 
@@ -52,8 +53,15 @@ func (h *handler) onRepo(key string, repo *catalog.ClusterRepo) (*catalog.Cluste
 		return repo, nil
 	}
 
+	systemGlobalRegistry := map[string]interface{}{
+		"cattle": map[string]interface{}{
+			"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+		},
+	}
 	for _, chartDef := range toInstall {
-		if err := h.manager.Ensure(chartDef.ReleaseNamespace, chartDef.ChartName, nil); err != nil {
+		if err := h.manager.Ensure(chartDef.ReleaseNamespace, chartDef.ChartName, map[string]interface{}{
+			"global": systemGlobalRegistry,
+		}); err != nil {
 			return repo, err
 		}
 	}


### PR DESCRIPTION
This commit add global registry setting and pass it to the fleet charts
that are installed by controller, since these settings can't be passed
from UI.