### PR TITLE
Remove impersonation header in shells

### DIFF
--- a/pkg/api/steve/clusters/shell.go
+++ b/pkg/api/steve/clusters/shell.go
@@ -69,6 +69,8 @@ func (s *shell) proxyRequest(rw http.ResponseWriter, req *http.Request, pod *v1.
 		Director: func(req *http.Request) {
 			req.URL = attachURL
 			req.Host = attachURL.Host
+			delete(req.Header, "Impersonate-Group")
+			delete(req.Header, "Impersonate-User")
 			delete(req.Header, "Authorization")
 			delete(req.Header, "Cookie")
 		},

--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -137,6 +137,8 @@ func (s *Operations) proxyLogRequest(rw http.ResponseWriter, req *http.Request, 
 		Director: func(req *http.Request) {
 			req.URL = logURL
 			req.Host = logURL.Host
+			delete(req.Header, "Impersonate-Group")
+			delete(req.Header, "Impersonate-User")
 			delete(req.Header, "Authorization")
 			delete(req.Header, "Cookie")
 		},


### PR DESCRIPTION
This commits removes the impersonation header when passed into the shell
proxy, as it needs admin access to exec into the shell not the user