### PR TITLE
Quote true value for restricted default admin

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
 {{- end }}
 {{- if .Values.restrictedAdmin }}
         - name: CATTLE_RESTRICTED_DEFAULT_ADMIN
-          value: true
+          value: "true"
 {{- end}}
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}


### PR DESCRIPTION
Helm parses the value as a literal true which is incorrect and causes the error seen. Quote the value so it's parsed as a string.

https://github.com/rancher/rancher/issues/29186