### PR TITLE
Add cluster permission to project member/owner/readonly

### DIFF
--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -36,6 +36,9 @@ var globalResourcesNeededInProjects = map[string]map[string]bool{
 	"clusterrepos": {
 		"catalog.cattle.io": true,
 	},
+	"clusters": {
+		"management.cattle.io": true,
+	},
 }
 
 func newPRTBLifecycle(m *manager) *prtbLifecycle {

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -231,6 +231,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("security.istio.io").resources("authorizationpolicies").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("projects").verbs("own").
 		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos", "operations", "releases", "apps").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("clusters").verbs("get").
 		setRoleTemplateNames("admin")
 
 	rb.addRoleTemplate("Project Member", "project-member", "project", false, false, false).
@@ -263,6 +264,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("rbac.istio.io").resources("rbacconfigs", "serviceroles", "servicerolebindings").verbs("*").
 		addRule().apiGroups("security.istio.io").resources("authorizationpolicies").verbs("*").
 		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos", "operations", "releases", "apps").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("clusters").verbs("get").
 		setRoleTemplateNames("edit")
 
 	rb.addRoleTemplate("Read-only", "read-only", "project", false, false, false).
@@ -291,6 +293,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("rbac.istio.io").resources("rbacconfigs", "serviceroles", "servicerolebindings").verbs("get", "list", "watch").
 		addRule().apiGroups("security.istio.io").resources("authorizationpolicies").verbs("get", "list", "watch").
 		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos", "operations", "releases", "apps").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("clusters").verbs("get").
 		setRoleTemplateNames("view")
 
 	rb.addRoleTemplate("Create Namespaces", "create-ns", "project", false, false, false).


### PR DESCRIPTION
This commit adds cluster.management.cattle.io to project
member/owner/readonly roles, as these roles also need to access cluster
shell and part of the functionality relies on access to the local
cluster resource in downstream cluster