### PR TITLE
Do not look at the automount_service_account_token flag of default SA in non-system namespaces

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -58,7 +58,7 @@ var (
 	ServerURL                         = NewSetting("server-url", "")
 	ServerVersion                     = NewSetting("server-version", "dev")
 	SystemDefaultRegistry             = NewSetting("system-default-registry", "")
-	SystemNamespaces                  = NewSetting("system-namespaces", "kube-system,kube-public,cattle-system,cattle-alerting,cattle-logging,cattle-pipeline,cattle-prometheus,ingress-nginx,cattle-global-data,cattle-istio,kube-node-lease,cert-manager,cattle-global-nt,security-scan")
+	SystemNamespaces                  = NewSetting("system-namespaces", "kube-system,kube-public,cattle-system,cattle-alerting,cattle-logging,cattle-pipeline,cattle-prometheus,ingress-nginx,cattle-global-data,cattle-istio,kube-node-lease,cert-manager,cattle-global-nt,security-scan,fleet-system")
 	TelemetryOpt                      = NewSetting("telemetry-opt", "")
 	TLSMinVersion                     = NewSetting("tls-min-version", "1.2")
 	TLSCiphers                        = NewSetting("tls-ciphers", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305")

--- a/tests/integration/suite/test_system_project.py
+++ b/tests/integration/suite/test_system_project.py
@@ -10,7 +10,8 @@ initial_system_namespaces = set(["kube-node-lease",
                                  "cattle-system",
                                  "kube-public",
                                  "cattle-global-data",
-                                 "cattle-global-nt"])
+                                 "cattle-global-nt",
+                                 "fleet-system"])
 loggingNamespace = "cattle-logging"
 
 

--- a/tests/integration/suite/test_system_project.py
+++ b/tests/integration/suite/test_system_project.py
@@ -93,12 +93,7 @@ def test_system_namespaces_default_svc_account(admin_mc):
                 else:
                     return False
             else:
-                if sa.automount_service_account_token is None:
-                    return True
-                elif sa.automount_service_account_token is True:
-                    return True
-                else:
-                    return False
+                return True
 
         def _sa_update_fail():
             name = sa.metadata.name


### PR DESCRIPTION
The test test_system_project.py is failing for `fleet-system` namespace. It is not present in system_namespaces setting, hence should the test should not error out for it irrespective of the value of the automount_service_account_token flag of the default SA.


Also adding fleet-system to system-namespaces setting.

