### PR TITLE
Change MultiClusterAppRevision ownerReferences

### DIFF
--- a/pkg/controllers/management/multiclusterapp/controller_multiclusterapp.go
+++ b/pkg/controllers/management/multiclusterapp/controller_multiclusterapp.go
@@ -296,7 +296,7 @@ func (m *MCAppManager) updateApp(app *pv3.App, answerMap map[string]map[string]s
 func (m *MCAppManager) createRevision(mcapp *v3.MultiClusterApp, creatorID string) (*v3.MultiClusterAppRevision, error) {
 	ownerReference := metav1.OwnerReference{
 		APIVersion: "management.cattle.io/v3",
-		Kind:       rbac.MultiClusterAppResource,
+		Kind:       v3.MultiClusterAppGroupVersionKind.Kind,
 		Name:       mcapp.Name,
 		UID:        mcapp.UID,
 	}

--- a/pkg/controllers/management/multiclusterapp/handler_multiclusterapp.go
+++ b/pkg/controllers/management/multiclusterapp/handler_multiclusterapp.go
@@ -19,7 +19,10 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 )
+
+const ownerRefUpdated = "auth.management.cattle.io/owner-ref-updated"
 
 type MCAppController struct {
 	multiClusterApps              v3.MultiClusterAppInterface
@@ -35,8 +38,9 @@ type MCAppController struct {
 }
 
 type MCAppRevisionController struct {
-	managementContext     *config.ManagementContext
-	multiClusterAppLister v3.MultiClusterAppLister
+	managementContext        *config.ManagementContext
+	multiClusterAppLister    v3.MultiClusterAppLister
+	multiClusterAppRevisions v3.MultiClusterAppRevisionInterface
 }
 
 type ProjectController struct {
@@ -66,8 +70,9 @@ func Register(ctx context.Context, management *config.ManagementContext, cluster
 		users:                         management.Management.Users(""),
 	}
 	r := MCAppRevisionController{
-		managementContext:     management,
-		multiClusterAppLister: management.Management.MultiClusterApps("").Controller().Lister(),
+		managementContext:        management,
+		multiClusterAppLister:    management.Management.MultiClusterApps("").Controller().Lister(),
+		multiClusterAppRevisions: management.Management.MultiClusterAppRevisions(""),
 	}
 	projects := management.Management.Projects("")
 	p := ProjectController{
@@ -186,6 +191,11 @@ func (r *MCAppRevisionController) sync(key string, mcappRevision *v3.MultiCluste
 	if mcappRevision == nil || mcappRevision.DeletionTimestamp != nil {
 		return mcappRevision, nil
 	}
+
+	if err := r.updateOwnerRef(mcappRevision); err != nil {
+		return mcappRevision, err
+	}
+
 	metaAccessor, err := meta.Accessor(mcappRevision)
 	if err != nil {
 		return mcappRevision, err
@@ -212,6 +222,48 @@ func (r *MCAppRevisionController) sync(key string, mcappRevision *v3.MultiCluste
 	}
 
 	return mcappRevision, nil
+}
+
+func (r *MCAppRevisionController) updateOwnerRef(mcappRevision *v3.MultiClusterAppRevision) error {
+	/* MCAppRevision has had wrong OwnerReference format till 2.5, the ownerReference kind should be "MultiClusterApp" and not "multiclusterapps"
+	    ownerReferences:
+	    - apiVersion: management.cattle.io/v3
+	      kind: multiclusterapps
+	      name: datadogmcapp
+	      uid: 32cdd51f-b152-44fa-93bb-1054a3203541
+	The revisions created before 2.5 need to be updated to use the right format
+	*/
+	if mcappRevision.Labels != nil && mcappRevision.Labels[ownerRefUpdated] == "true" {
+		return nil
+	}
+	var needsUpdate bool
+	for ind, ownerRef := range mcappRevision.OwnerReferences {
+		if ownerRef.Kind == "multiclusterapps" {
+			ownerRef.Kind = v3.MultiClusterAppGroupVersionKind.Kind
+			mcappRevision.OwnerReferences[ind] = ownerRef
+			needsUpdate = true
+		}
+	}
+
+	if !needsUpdate {
+		return nil
+	}
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		mcappRevisionToUpdate, updateErr := r.multiClusterAppRevisions.GetNamespaced(mcappRevision.Namespace, mcappRevision.Name, v1.GetOptions{})
+		if updateErr != nil {
+			return updateErr
+		}
+		mcappRevisionToUpdate.OwnerReferences = mcappRevision.OwnerReferences
+		if mcappRevisionToUpdate.Labels == nil {
+			mcappRevisionToUpdate.Labels = make(map[string]string)
+		}
+		mcappRevisionToUpdate.Labels[ownerRefUpdated] = "true"
+		_, err := r.multiClusterAppRevisions.Update(mcappRevisionToUpdate)
+		return err
+	})
+
+	return retryErr
 }
 
 func (p *ProjectController) sync(key string, project *v3.Project) (runtime.Object, error) {


### PR DESCRIPTION
MultiClusterAppRevision objects have incorrect ownerReferences for MultiClusterApps.
The field ownerReference.Kind should be "MultiClusterApp" and not "multiclusterapps". With
this commit, the newly created MultiClusterAppRevisions will have the right ownerReferences,
and the existing revisions on an upgraded setup will get updated

https://github.com/rancher/rancher/issues/29122