### PR TITLE
set latest channel as default for rancherd install.sh

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,7 +1,6 @@
 channels:
 - name: latest
   latestRegexp: .*
-  excludeRegexp: ^[^+]+-
 - name: testing
   latestRegexp: .*
 github:

--- a/cmd/rancherd/install.sh
+++ b/cmd/rancherd/install.sh
@@ -117,7 +117,7 @@ get_release_version() {
     else
         info "finding release for channel ${INSTALL_RANCHERD_CHANNEL}"
         INSTALL_RANCHERD_CHANNEL_URL=${INSTALL_RANCHERD_CHANNEL_URL:-'https://update.rancher.io/v1-release/channels'}
-        INSTALL_RANCHERD_CHANNEL=${INSTALL_RANCHERD_CHANNEL:-'stable'}
+        INSTALL_RANCHERD_CHANNEL=${INSTALL_RANCHERD_CHANNEL:-'latest'}
         version_url="${INSTALL_RANCHERD_CHANNEL_URL}/${INSTALL_RANCHERD_CHANNEL}"
         case ${DOWNLOADER} in
         *curl)


### PR DESCRIPTION
This pr sets the latest channel -if not specified via INSTALL_RANCHERD_CHANNEL- as the default install channel. 
issue : https://github.com/rancher/rancher/issues/29209