### PR TITLE
Validation - Add Helm version param for tools

### DIFF
--- a/tests/validation/Dockerfile.v3api
+++ b/tests/validation/Dockerfile.v3api
@@ -6,6 +6,7 @@ WORKDIR $WORKSPACE
 ENV PYTHONPATH /src/rancher-validation
 ARG RKE_VERSION=v1.0.2
 ARG CLI_VERSION=v2.3.2
+ARG RANCHER_HELM_VERSION=v3.3.4
 ARG SONOBUOY_VERSION=0.18.2
 
 
@@ -21,8 +22,8 @@ RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERS
     tar -x -f rancher-linux-amd64-$CLI_VERSION.tar.gz && \
     mv rancher-$CLI_VERSION/rancher /bin/rancherctl && \
     chmod +x /bin/rancherctl && \
-    wget https://get.helm.sh/helm-v3.0.2-linux-amd64.tar.gz && \
-    tar -x -f helm-v3.0.2-linux-amd64.tar.gz && \
+    wget https://get.helm.sh/helm-$RANCHER_HELM_VERSION-linux-amd64.tar.gz && \
+    tar -x -f helm-$RANCHER_HELM_VERSION-linux-amd64.tar.gz && \
     mv linux-amd64/helm /bin/helm_v3 && \
     chmod +x /bin/helm_v3 && \
     wget https://releases.hashicorp.com/terraform/0.12.10/terraform_0.12.10_linux_amd64.zip && \

--- a/tests/validation/tests/v3_api/scripts/build.sh
+++ b/tests/validation/tests/v3_api/scripts/build.sh
@@ -5,6 +5,7 @@ set -eu
 
 DEBUG="${DEBUG:-false}"
 RKE_VERSION="${RKE_VERSION:-v1.0.2}"
+RANCHER_HELM_VERSION="${RANCHER_HELM_VERSION:-v3.3.4}"
 KUBECTL_VERSION="${KUBECTL_VERSION:-v1.16.6}"
 CLI_VERSION="${CLI_VERSION:-v2.4.5}"
 SONOBUOY_VERSION="${SONOBUOY_VERSION:-0.18.2}"
@@ -20,7 +21,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../" && pwd )"
 
 count=0
 while [[ 3 -gt $count ]]; do    
-    docker build -q -f Dockerfile.v3api --build-arg CLI_VERSION=$CLI_VERSION --build-arg RKE_VERSION=$RKE_VERSION --build-arg KUBECTL_VERSION=$KUBECTL_VERSION --build-arg SONOBUOY_VERSION=$SONOBUOY_VERSION -t rancher-validation-${TRIM_JOB_NAME}${BUILD_NUMBER} .
+    docker build -q -f Dockerfile.v3api --build-arg CLI_VERSION=$CLI_VERSION --build-arg RKE_VERSION=$RKE_VERSION --build-arg RANCHER_HELM_VERSION=$RANCHER_HELM_VERSION --build-arg KUBECTL_VERSION=$KUBECTL_VERSION --build-arg SONOBUOY_VERSION=$SONOBUOY_VERSION -t rancher-validation-${TRIM_JOB_NAME}${BUILD_NUMBER} .
 
     if [[ $? -eq 0 ]]; then break; fi
     count=$(($count + 1))


### PR DESCRIPTION
Add Helm version param - default to v3.3.4
Tested locally for default version: 
```
validation % ./tests/v3_api/scripts/build.sh
validation % docker run rancher-validation /bin/bash -c 'helm_v3 version'
version.BuildInfo{Version:"v3.3.4", GitCommit:"a61ce5633af99708171414353ed49547cf05013d", GitTreeState:"clean", GoVersion:"go1.14.9"}
```