### PR TITLE
Stop creating admins if RestrictedDefaultAdmin is set

### DIFF
--- a/pkg/controllers/managementuser/rbac/cluster_handler.go
+++ b/pkg/controllers/managementuser/rbac/cluster_handler.go
@@ -59,6 +59,10 @@ func (h *clusterHandler) sync(key string, obj *v3.Cluster) (runtime.Object, erro
 
 func (h *clusterHandler) doSync(cluster *v3.Cluster) error {
 	_, err := v32.ClusterConditionGlobalAdminsSynced.DoUntilTrue(cluster, func() (runtime.Object, error) {
+		// We recieve clusters with no data, when that happens no checks will work so just ignore them
+		if cluster.Name == "" {
+			return nil, nil
+		}
 		// Sync both admin types
 		for _, roleName := range []string{rbac.GlobalAdmin, rbac.GlobalRestrictedAdmin} {
 			// Do not sync restricted-admin to the local cluster as 'cluster-admin'

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -475,7 +475,7 @@ func BootstrapAdmin(management *wrangler.Context, createClusterRoleBinding bool)
 			}
 		}
 
-		if createClusterRoleBinding {
+		if createClusterRoleBinding && settings.RestrictedDefaultAdmin.Get() != "true" {
 			users, err := management.Mgmt.User().List(v1.ListOptions{
 				LabelSelector: set.String(),
 			})


### PR DESCRIPTION
There were multiple other places we are creating admins for local cluster, this actually ends up with the same bindings multiple times but this PR does not address that. 
https://github.com/rancher/rancher/issues/29279
