### PR TITLE
Remove unnecessary channel assignment

### DIFF
--- a/cmd/rancherd/install.sh
+++ b/cmd/rancherd/install.sh
@@ -51,7 +51,7 @@ setup_env() {
 
     # --- make sure install channel has a value
     if [ -z "${INSTALL_RANCHERD_CHANNEL}" ]; then
-        INSTALL_RANCHERD_CHANNEL="testing"
+        INSTALL_RANCHERD_CHANNEL="latest"
     fi
 
     # --- make sure install type has a value
@@ -117,7 +117,6 @@ get_release_version() {
     else
         info "finding release for channel ${INSTALL_RANCHERD_CHANNEL}"
         INSTALL_RANCHERD_CHANNEL_URL=${INSTALL_RANCHERD_CHANNEL_URL:-'https://update.rancher.io/v1-release/channels'}
-        INSTALL_RANCHERD_CHANNEL=${INSTALL_RANCHERD_CHANNEL:-'latest'}
         version_url="${INSTALL_RANCHERD_CHANNEL_URL}/${INSTALL_RANCHERD_CHANNEL}"
         case ${DOWNLOADER} in
         *curl)


### PR DESCRIPTION
This pr sets the default INSTALL_RANCHERD_CHANNEL to latest if not specified and removes the unnecessary assessment in get_version function 
Default was set to testing
```
$ curl -sfL https://get.rancher.io | sudo sh -
[INFO]  finding release for channel testing
[INFO]  using v2.5.0-rc3 as release
[INFO]  downloading checksums at https://github.com/rancher/rancher/releases/download/v2.5.0-rc3/sha256sum.txt
[INFO]  downloading tarball at https://github.com/rancher/rancher/releases/download/v2.5.0-rc3/rancherd-amd64.tar.gz
[INFO]  verifying installer
[INFO]  unpacking tarball file 
```