### PR TITLE
Fix rancherd not setting admin on local clusters

### DIFF
--- a/cmd/rancherd/auth/auth.go
+++ b/cmd/rancherd/auth/auth.go
@@ -169,7 +169,7 @@ func ResetAdmin(_ *cli.Context) error {
 						},
 						"apiVersion":     "management.cattle.io/v3",
 						"kind":           "GlobalRoleBinding",
-						"username":       adminName,
+						"userName":       adminName,
 						"globalRoleName": "admin",
 					},
 				}, v1.CreateOptions{})


### PR DESCRIPTION
This commit fixed an issue where local admin is not set as the cluster
owner of local cluster. This is because when we disable the default
admin, all the controller won't be able to rerun twice since all the
conditions have been set to true. Thus in reset-admin, when we first
bootstrap the password, we need to set creatorId on the annotation and
also revert the condition to be false so that controller can be re-run
to add corresponding roles/rolebindings