### PR TITLE
Stop admin sync and update restricted admin perms

### DIFF
--- a/pkg/controllers/managementuser/rbac/cluster_handler.go
+++ b/pkg/controllers/managementuser/rbac/cluster_handler.go
@@ -21,7 +21,8 @@ func newClusterHandler(workload *config.UserContext) v3.ClusterHandlerFunc { //*
 	informer := workload.Management.Management.GlobalRoleBindings("").Controller().Informer()
 
 	ch := &clusterHandler{
-		grbIndexer: informer.GetIndexer(),
+		clusterName: workload.ClusterName,
+		grbIndexer:  informer.GetIndexer(),
 		// Management level resources
 		grbController: workload.Management.Management.GlobalRoleBindings("").Controller(),
 		clusters:      workload.Management.Management.Clusters(""),
@@ -33,7 +34,8 @@ func newClusterHandler(workload *config.UserContext) v3.ClusterHandlerFunc { //*
 }
 
 type clusterHandler struct {
-	grbIndexer cache.Indexer
+	clusterName string
+	grbIndexer  cache.Indexer
 	// Management level resources
 	grbController v3.GlobalRoleBindingController
 	clusters      v3.ClusterInterface
@@ -43,7 +45,13 @@ type clusterHandler struct {
 }
 
 func (h *clusterHandler) sync(key string, obj *v3.Cluster) (runtime.Object, error) {
-	if key == "" || obj == nil {
+	// We recieve clusters with no data, when that happens no checks will work so just ignore them
+	if key == "" || obj == nil || obj.Name == "" {
+		return nil, nil
+	}
+
+	// Don't operate on a cluster this handler isn't created for
+	if h.clusterName != obj.Name {
 		return nil, nil
 	}
 
@@ -59,10 +67,6 @@ func (h *clusterHandler) sync(key string, obj *v3.Cluster) (runtime.Object, erro
 
 func (h *clusterHandler) doSync(cluster *v3.Cluster) error {
 	_, err := v32.ClusterConditionGlobalAdminsSynced.DoUntilTrue(cluster, func() (runtime.Object, error) {
-		// We recieve clusters with no data, when that happens no checks will work so just ignore them
-		if cluster.Name == "" {
-			return nil, nil
-		}
 		// Sync both admin types
 		for _, roleName := range []string{rbac.GlobalAdmin, rbac.GlobalRestrictedAdmin} {
 			// Do not sync restricted-admin to the local cluster as 'cluster-admin'

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -80,7 +80,8 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("project.cattle.io").resources("*").verbs("*").
 		addRule().apiGroups("fleet.cattle.io").resources("*").verbs("*").
 		addRule().apiGroups("rancher.cattle.io").resources("*").verbs("*").
-		addRule().apiGroups("catalog.cattle.io").resources("*").verbs("*")
+		addRule().apiGroups("catalog.cattle.io").resources("*").verbs("*").
+		addRule().apiGroups("").resources("secrets").verbs("create")
 
 	rb.addRole("User", "user").
 		addRule().apiGroups("management.cattle.io").resources("principals", "roletemplates").verbs("get", "list", "watch").


### PR DESCRIPTION
Problem:
The cluster admin sync is in a cluster controller which processes all
clusters so if a sync for a different cluster comes in the sync will
still happen locally
restricted-admin can't create cloud credentials

Solution:
Make the controller only work on the cluster it was registered for
Add secret create perms in the local cluster, this is the same as `user` and required to create cloud credentials


https://github.com/rancher/rancher/issues/29279