### PR TITLE
[2.5] Move fleetWorkspaceName so it is not included in templates

### DIFF
--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -110,7 +110,6 @@ type ClusterSpecBase struct {
 	WindowsPreferedCluster               bool                                    `json:"windowsPreferedCluster" norman:"noupdate"`
 	LocalClusterAuthEndpoint             LocalClusterAuthEndpoint                `json:"localClusterAuthEndpoint,omitempty"`
 	ScheduledClusterScan                 *ScheduledClusterScan                   `json:"scheduledClusterScan,omitempty"`
-	FleetWorkspaceName                   string                                  `json:"fleetWorkspaceName,omitempty"`
 }
 
 type ClusterSpec struct {
@@ -130,6 +129,7 @@ type ClusterSpec struct {
 	ClusterTemplateRevisionName         string                      `json:"clusterTemplateRevisionName,omitempty" norman:"type=reference[clusterTemplateRevision]"`
 	ClusterTemplateAnswers              Answer                      `json:"answers,omitempty"`
 	ClusterTemplateQuestions            []Question                  `json:"questions,omitempty" norman:"nocreate,noupdate"`
+	FleetWorkspaceName                  string                      `json:"fleetWorkspaceName,omitempty"`
 }
 
 type ImportedConfig struct {

--- a/pkg/client/generated/management/v3/zz_generated_cluster_spec_base.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_spec_base.go
@@ -11,7 +11,6 @@ const (
 	ClusterSpecBaseFieldEnableClusterAlerting               = "enableClusterAlerting"
 	ClusterSpecBaseFieldEnableClusterMonitoring             = "enableClusterMonitoring"
 	ClusterSpecBaseFieldEnableNetworkPolicy                 = "enableNetworkPolicy"
-	ClusterSpecBaseFieldFleetWorkspaceName                  = "fleetWorkspaceName"
 	ClusterSpecBaseFieldLocalClusterAuthEndpoint            = "localClusterAuthEndpoint"
 	ClusterSpecBaseFieldRancherKubernetesEngineConfig       = "rancherKubernetesEngineConfig"
 	ClusterSpecBaseFieldScheduledClusterScan                = "scheduledClusterScan"
@@ -28,7 +27,6 @@ type ClusterSpecBase struct {
 	EnableClusterAlerting               bool                           `json:"enableClusterAlerting,omitempty" yaml:"enableClusterAlerting,omitempty"`
 	EnableClusterMonitoring             bool                           `json:"enableClusterMonitoring,omitempty" yaml:"enableClusterMonitoring,omitempty"`
 	EnableNetworkPolicy                 *bool                          `json:"enableNetworkPolicy,omitempty" yaml:"enableNetworkPolicy,omitempty"`
-	FleetWorkspaceName                  string                         `json:"fleetWorkspaceName,omitempty" yaml:"fleetWorkspaceName,omitempty"`
 	LocalClusterAuthEndpoint            *LocalClusterAuthEndpoint      `json:"localClusterAuthEndpoint,omitempty" yaml:"localClusterAuthEndpoint,omitempty"`
 	RancherKubernetesEngineConfig       *RancherKubernetesEngineConfig `json:"rancherKubernetesEngineConfig,omitempty" yaml:"rancherKubernetesEngineConfig,omitempty"`
 	ScheduledClusterScan                *ScheduledClusterScan          `json:"scheduledClusterScan,omitempty" yaml:"scheduledClusterScan,omitempty"`

--- a/pkg/data/dashboard/cluster_data.go
+++ b/pkg/data/dashboard/cluster_data.go
@@ -15,11 +15,11 @@ func addLocalCluster(embedded bool, adminName string, wrangler *wrangler.Context
 			Name: "local",
 		},
 		Spec: v32.ClusterSpec{
-			Internal:    true,
-			DisplayName: "local",
+			Internal:           true,
+			DisplayName:        "local",
+			FleetWorkspaceName: "fleet-local",
 			ClusterSpecBase: v32.ClusterSpecBase{
-				DockerRootDir:      settings.InitialDockerRootDir.Get(),
-				FleetWorkspaceName: "fleet-local",
+				DockerRootDir: settings.InitialDockerRootDir.Get(),
 			},
 		},
 		Status: v32.ClusterStatus{


### PR DESCRIPTION
The template is holding the fleetWorkspaceName which causes the validating webhook to validate permissions a normal user does not have. rancher-operator will set the NS if not set which is the current intended flow.
#29349