### PR TITLE
update rke2 version in dockerfile.runtime

### DIFF
--- a/cmd/rancherd/go.mod
+++ b/cmd/rancherd/go.mod
@@ -64,7 +64,7 @@ replace (
 
 require (
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/rke2 v1.18.9-rc1.0.20201001233850-e08dea90e3f9 // v1.18.8-beta19+rke2
+	github.com/rancher/rke2 v1.18.9-rc1.0.20201001233850-e08dea90e3f9 // v1.18.9-rc1+rke2 ... If you update this, also update rancher/package/Dockerfile.runtime
 	github.com/rancher/wrangler v0.6.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/urfave/cli v1.22.2

--- a/package/Dockerfile.runtime
+++ b/package/Dockerfile.runtime
@@ -1,3 +1,4 @@
-ARG RKE2_VERSION=v1.18.9-rc1-rke2 # if you’re changing this, also change rancher/cmd/rancherd/go.mod
+ARG RKE2_VERSION=v1.18.9-rc1-rke2
+# if you’re changing this, also change rancher/cmd/rancherd/go.mod
 FROM rancher/rke2-runtime:${RKE2_VERSION}
 COPY rancher.yaml /charts/

--- a/package/Dockerfile.runtime
+++ b/package/Dockerfile.runtime
@@ -1,3 +1,3 @@
-ARG RKE2_VERSION=v1.18.8-beta19-rke2
+ARG RKE2_VERSION=v1.18.9-rc1-rke2
 FROM rancher/rke2-runtime:${RKE2_VERSION}
 COPY rancher.yaml /charts/

--- a/package/Dockerfile.runtime
+++ b/package/Dockerfile.runtime
@@ -1,3 +1,3 @@
-ARG RKE2_VERSION=v1.18.9-rc1-rke2
+ARG RKE2_VERSION=v1.18.9-rc1-rke2 # if you’re changing this, also change rancher/cmd/rancherd/go.mod
 FROM rancher/rke2-runtime:${RKE2_VERSION}
 COPY rancher.yaml /charts/


### PR DESCRIPTION
Problem: updating rke2 version in go mod didn't pull the correct hardened images 
Solution: the new rke2 version should be updated in package/Dockerfile.runtime
issue: https://github.com/rancher/rancher/issues/29354