### PR TITLE
[2.5] Bump rke2 in rancherd 2.5

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,6 +1,7 @@
 channels:
 - name: latest
   latestRegexp: .*
+  excludeRegexp: ^[^+]+-
 - name: testing
   latestRegexp: .*
 github:

--- a/cmd/rancherd/go.mod
+++ b/cmd/rancherd/go.mod
@@ -64,7 +64,7 @@ replace (
 
 require (
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/rke2 v1.18.9-rc1.0.20201001233850-e08dea90e3f9 // v1.18.9-rc1+rke2 ... If you update this, also update rancher/package/Dockerfile.runtime
+	github.com/rancher/rke2 v1.18.10-0.20201005021635-67ded31a6924 // v1.18.9+rke2r1 ... If you update this, also update rancher/package/Dockerfile.runtime
 	github.com/rancher/wrangler v0.6.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/urfave/cli v1.22.2

--- a/cmd/rancherd/go.sum
+++ b/cmd/rancherd/go.sum
@@ -729,8 +729,8 @@ github.com/rancher/kubernetes/staging/src/k8s.io/sample-apiserver v1.19.0-k3s1/g
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=
-github.com/rancher/rke2 v1.18.9-rc1.0.20201001233850-e08dea90e3f9 h1:XA3/j0Ho9XmvKZoqS8MmRNyPo6bSMJKcv6PY50fGxZc=
-github.com/rancher/rke2 v1.18.9-rc1.0.20201001233850-e08dea90e3f9/go.mod h1:lB/VGKzTG5Btr69JOIL2dlywEDSUk3mb7mCOqCZSOHE=
+github.com/rancher/rke2 v1.18.10-0.20201005021635-67ded31a6924 h1:2JgcTA7UAr4maFygQm7IU2qXSqGWONYPuRyfKiLsDYw=
+github.com/rancher/rke2 v1.18.10-0.20201005021635-67ded31a6924/go.mod h1:lB/VGKzTG5Btr69JOIL2dlywEDSUk3mb7mCOqCZSOHE=
 github.com/rancher/wrangler v0.1.4/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rancher/wrangler v0.4.0/go.mod h1:1cR91WLhZgkZ+U4fV9nVuXqKurWbgXcIReU4wnQvTN8=
 github.com/rancher/wrangler v0.6.0/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=

--- a/package/Dockerfile.runtime
+++ b/package/Dockerfile.runtime
@@ -1,4 +1,4 @@
-ARG RKE2_VERSION=v1.18.9-rc1-rke2
+ARG RKE2_VERSION=v1.18.9-rke2r1
 # if you’re changing this, also change rancher/cmd/rancherd/go.mod
 FROM rancher/rke2-runtime:${RKE2_VERSION}
 COPY rancher.yaml /charts/


### PR DESCRIPTION
This Pr updates rke2 version to `v1.18.9+rke2r1` in rancherd and adds exclude expression to latest channel

