### PR TITLE
add excludeRegexp to latest channel in update.rancher.io

### DIFF
--- a/channels.yaml
+++ b/channels.yaml
@@ -1,6 +1,7 @@
 channels:
 - name: latest
   latestRegexp: .*
+  excludeRegexp: ^[^+]+-
 - name: testing
   latestRegexp: .*
 github:


### PR DESCRIPTION
Right after rancher 2.5 is launched, Latest channel needs to only show main releases (v2.5.0). this pr adds add excludeRegexp to latest channel in update.rancher.io to exclude testing releases from latest channel