### PR TITLE
fix automation bugs

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -1643,7 +1643,9 @@ def wait_for_app_to_active(client, app_id,
     while application.state != "active":
         if time.time() - start > timeout:
             raise AssertionError(
-                "Timed out waiting for state to get to active")
+                "Timed out waiting for {0} to get to active,"
+                " the actual state: {1}".format(application.name,
+                                                application.state))
         time.sleep(.5)
         app = client.list_app(id=app_id).data
         assert len(app) >= 1

--- a/tests/validation/tests/v3_api/test_global_role.py
+++ b/tests/validation/tests/v3_api/test_global_role.py
@@ -415,5 +415,5 @@ def validate_edit_global_role(token, global_role, permission=False):
     gr = client.reload(global_role)
     assert gr.newUserDefault is False
     # check that there is no rule left
-    assert gr.rules is None
+    assert (gr.rules is None or gr.rules == [])
     return gr


### PR DESCRIPTION
fix a couple of failed cases in the automation
- fix the issue that API returns empty list `[]` instead of `None`
- increase the waiting time for metrics available in cluster’s page
- fix the issue that test_rbac_cluster_owner_control_cluster_monitoring due to timing issue 