### PR TITLE
[2.4] Agent image should come from cluster private registry

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -375,7 +375,12 @@ func (m *Lifecycle) deployAgent(nodeDir string, obj *v3.Node) error {
 		return err
 	}
 
-	drun := clusterregistrationtokens.NodeCommand(token, nil)
+	cluster, err := m.clusterLister.Get("", obj.Namespace)
+	if err != nil {
+		return err
+	}
+
+	drun := clusterregistrationtokens.NodeCommand(token, cluster)
 	args := buildAgentCommand(obj, drun)
 	cmd, err := buildCommand(nodeDir, obj, args)
 	if err != nil {


### PR DESCRIPTION
Issue:
- https://github.com/rancher/rancher/issues/26366

Solution:
Retrieve and then use cluster object when resolving the node agent image

[TESTING]