### PR TITLE
-head version as dev when setting k8s versions

### DIFF
--- a/pkg/controllers/management/kontainerdrivermetadata/data_getter.go
+++ b/pkg/controllers/management/kontainerdrivermetadata/data_getter.go
@@ -207,7 +207,7 @@ func newVersionInfo() *VersionInfo {
 
 func GetRancherVersion() string {
 	rancherVersion := settings.ServerVersion.Get()
-	if strings.HasPrefix(rancherVersion, "dev") || strings.HasPrefix(rancherVersion, "master") {
+	if strings.HasPrefix(rancherVersion, "dev") || strings.HasPrefix(rancherVersion, "master") || strings.HasSuffix(rancherVersion, "-head") {
 		return RancherVersionDev
 	}
 	if strings.HasPrefix(rancherVersion, "v") {


### PR DESCRIPTION
Forwardport of https://github.com/rancher/rancher/pull/29343