### PR TITLE
Allow users to overwrite operator-init values

### DIFF
--- a/pkg/controllers/managementagent/monitoring/operatorHandler.go
+++ b/pkg/controllers/managementagent/monitoring/operatorHandler.go
@@ -187,7 +187,7 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) (backErr erro
 	// take operator answers from overwrite answers
 	answers, version := monitoring.GetOverwroteAppAnswersAndVersion(cluster.Annotations)
 	for ansKey, ansVal := range answers {
-		if strings.HasPrefix(ansKey, "operator.") {
+		if strings.HasPrefix(ansKey, "operator.") || strings.HasPrefix(ansKey, "operator-init.") {
 			appAnswers[ansKey] = ansVal
 		}
 	}


### PR DESCRIPTION
Context: `operatorHandler` is the Rancher controller that does two things:
1) It installs all the CRDs onto the cluster via deploying `operator-init`
2) It installs the actual Prometheus Operator pod via deploying `operator`

It's triggered to deploy when either Monitoring or Alerting is enabled since it represents that components (CRDs + Operator) that both features need in order to be deployed successfully onto a cluster.

Before https://github.com/rancher/system-charts/pull/357, we never had a reason to need to pass in values to `operator-init`, but after that change goes in we should respect overrides passed in by the user via answers for that subchart.

Related Issue: https://github.com/rancher/rancher/issues/27253