### PR TITLE
[2.4] Allow users to overwrite operator-init values

### DIFF
--- a/pkg/controllers/user/monitoring/operatorHandler.go
+++ b/pkg/controllers/user/monitoring/operatorHandler.go
@@ -183,7 +183,7 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) (backErr erro
 	// take operator answers from overwrite answers
 	answers, version := monitoring.GetOverwroteAppAnswersAndVersion(cluster.Annotations)
 	for ansKey, ansVal := range answers {
-		if strings.HasPrefix(ansKey, "operator.") {
+		if strings.HasPrefix(ansKey, "operator.") || strings.HasPrefix(ansKey, "operator-init.") {
 			appAnswers[ansKey] = ansVal
 		}
 	}


### PR DESCRIPTION
This is a "backport" of a commit from `master` here: https://github.com/rancher/rancher/commit/0dee1debc6933c4feb062a30bd509b7d4d294b51

I was unable to cherry pick this commit since it is in a different file in `release/v2.4`.

Original PR: https://github.com/rancher/rancher/pull/29478
Related Issue: https://github.com/rancher/rancher/issues/27253