### PR TITLE
[2.5] Allow users to overwrite operator-init values

### DIFF
--- a/pkg/controllers/managementagent/monitoring/operatorHandler.go
+++ b/pkg/controllers/managementagent/monitoring/operatorHandler.go
@@ -187,7 +187,7 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler) (backErr erro
 	// take operator answers from overwrite answers
 	answers, version := monitoring.GetOverwroteAppAnswersAndVersion(cluster.Annotations)
 	for ansKey, ansVal := range answers {
-		if strings.HasPrefix(ansKey, "operator.") {
+		if strings.HasPrefix(ansKey, "operator.") || strings.HasPrefix(ansKey, "operator-init.") {
 			appAnswers[ansKey] = ansVal
 		}
 	}


### PR DESCRIPTION
(cherry picked from commit 0dee1debc6933c4feb062a30bd509b7d4d294b51)

Original PR: https://github.com/rancher/rancher/pull/29478
Related Issue: https://github.com/rancher/rancher/issues/27253