### PR TITLE
Add rancher.cattle-system to tls san

### DIFF
--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -13,5 +13,9 @@ spec:
     targetPort: 80
     protocol: TCP
     name: http
+  - port: 443
+    targetPort: 443
+    protocol: TCP
+    name: https
   selector:
     app: {{ template "rancher.fullname" . }}

--- a/cmd/rancherd/chart/templates/service.yaml
+++ b/cmd/rancherd/chart/templates/service.yaml
@@ -9,5 +9,9 @@ spec:
       targetPort: 80
       protocol: TCP
       name: http
+    - port: 443
+      targetPort: 443
+      protocol: TCP
+      name: https
   selector:
     app: rancher

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -147,7 +147,7 @@ func readConfig(secrets corev1controllers.SecretController, acmeDomains []string
 		return "", noCACerts, nil, errors.Wrapf(err, "parsing %s", settings.RotateCertsIfExpiringInDays.Get())
 	}
 
-	sans := []string{"localhost", "127.0.0.1"}
+	sans := []string{"localhost", "127.0.0.1", "rancher.cattle-system"}
 	ip, err := net.ChooseHostInterface()
 	if err == nil {
 		sans = append(sans, ip.String())


### PR DESCRIPTION
This is used for fleet-controller to be able to talk to rancher API(and
downstream cluster) using k8s service name(Service IP). This is a more
efficient way and can bypass proxy if rancher is installed behind a
proxy