### PR TITLE
Use newer apiVersion for ingress

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "rancher.fullname" . }}


### PR DESCRIPTION
**BACKPORT**

**Problem**
Starting in 1.16 Ingress was no longer in the extensions/v1beta1 api, so it is not recognized

**Solution**
Update the apiVersion to a version that is supported in the following kubernetes versions
```
1.19.2 (default)
1.18.9
1.17.12
1.16.15
```
**Issue**
#29144

**Master PR**
https://github.com/rancher/rancher/pull/29336

**Additional Information**
The use of networking.k8s.io/v1beta1 started in 1.16 and will be removed in v1.22 .

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
```
The v1.22 release will stop serving the following deprecated API versions in favor of newer and more stable API versions:

Ingress in the extensions/v1beta1 API version will no longer be served
Migrate to use the networking.k8s.io/v1beta1 API version, available since v1.14. Existing persisted data can be retrieved/updated via the new version.
```