### PR TITLE
Add check and unit test for release semver 

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -108,7 +108,7 @@ func PrefixPrivateRegistry(image string) string {
 }
 
 func IsRelease() bool {
-	return releasePattern.MatchString(ServerVersion.Get())
+	return !strings.Contains(ServerVersion.Get(), "head") && releasePattern.MatchString(ServerVersion.Get())
 }
 
 func init() {

--- a/pkg/settings/setting_test.go
+++ b/pkg/settings/setting_test.go
@@ -1,0 +1,31 @@
+package settings
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRelease(t *testing.T) {
+	inputs := map[string]bool{
+		"dev":         false,
+		"master-head": false,
+		"master":      false,
+		"v2.5.2":      true,
+		"v2":          true,
+		"v2.0":        true,
+		"v2.x":        true,
+		"v2.5-head":   false,
+		"2.5":         false,
+		"2.5-head":    false,
+	}
+	a := assert.New(t)
+	for key, value := range inputs {
+		if err := ServerVersion.Set(key); err != nil {
+			t.Errorf("Encountered error while setting temp version: %v\n", err)
+		}
+		result := IsRelease()
+		a.Equal(value, result, fmt.Sprintf("Expected value [%t] for key [%s]. Got value [%t]", value, key, result))
+	}
+}


### PR DESCRIPTION
Add check and unit test for release semver. The check parses for a "head" substring.
The IsRelease function needs to be able to discern a v2.X-head branch from a release.
Add unit test for the IsRelease function.

Related issue: #29362 