### PR TITLE
Disable kubernetes upgrades on embedded cluster

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -1020,6 +1020,7 @@ func (p *Provisioner) k3sBasedClusterConfig(cluster *v3.Cluster, nodes []*v3.Nod
 		cluster.Status.Driver == apimgmtv3.ClusterDriverRancherD {
 		return nil //no-op
 	}
+	isEmbedded := cluster.Status.Driver == apimgmtv3.ClusterDriverLocal
 
 	if strings.Contains(cluster.Status.Version.String(), "k3s") {
 		for _, node := range nodes {
@@ -1031,8 +1032,8 @@ func (p *Provisioner) k3sBasedClusterConfig(cluster *v3.Cluster, nodes []*v3.Nod
 		if cluster.Status.Driver != apimgmtv3.ClusterDriverK3os {
 			cluster.Status.Driver = apimgmtv3.ClusterDriverK3s
 		}
-		// only set these values on init
-		if cluster.Spec.K3sConfig == nil {
+		// only set these values on init, and not for embedded clusters as those shouldn't be upgraded
+		if cluster.Spec.K3sConfig == nil && !isEmbedded {
 			cluster.Spec.K3sConfig = &apimgmtv3.K3sConfig{
 				Version: cluster.Status.Version.String(),
 			}

--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -32,6 +32,11 @@ func (h *handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster,
 	if !isK3s && !isRke2 {
 		return cluster, nil
 	}
+	// Don't allow nil configs to continue for given cluster type
+	if (isK3s && cluster.Spec.K3sConfig == nil) || (isRke2 && cluster.Spec.Rke2Config == nil) {
+		return cluster, nil
+	}
+
 	var (
 		updateVersion string
 		strategy      v32.ClusterUpgradeStrategy
@@ -46,10 +51,6 @@ func (h *handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster,
 
 	}
 	if updateVersion == "" {
-		return cluster, nil
-	}
-
-	if (isK3s && cluster.Spec.K3sConfig == nil) || (isRke2 && cluster.Spec.Rke2Config == nil) {
 		return cluster, nil
 	}
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/29412

This PR stops the k3s portion of provisioner from setting the K3sConfig on an embedded cluster.  UI shown below. Upgrading the cluster is then not possible in the API as k3sConfig is gone. 

Embedded logic is here: https://github.com/rancher/rancher/blob/master/pkg/data/dashboard/cluster_data.go#L40-L42

~Potential caveats: Is it bad for the cluster not to be labeled as k3s ? As far as I can tell that just stops some validating logic around upgrade version, and stops k3s-upgrade-controller, which is what we want. The version on an embedded cluster should never be upgraded.~ It's labeled as K3s now. Only downside now is that we don't have a flag to see if its embedded for other features. 

<img width="1322" alt="Screen Shot 2020-10-15 at 3 22 38 PM" src="https://user-images.githubusercontent.com/571419/96192160-4c523180-0efa-11eb-8f1a-f284534a9825.png">

