### PR TITLE
Make Keycloak entity ID configurable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 replace (
 	git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.2.0+incompatible
-	github.com/crewjam/saml => github.com/rancher/saml v0.0.0-20180713225824-ce1532152fde
+	github.com/crewjam/saml => github.com/rancher/saml v0.0.3-rancher1
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc10

--- a/go.sum
+++ b/go.sum
@@ -1030,8 +1030,8 @@ github.com/rancher/remotedialer v0.2.6-0.20200820180140-e5448aaba7ee h1:hAHJO9u3
 github.com/rancher/remotedialer v0.2.6-0.20200820180140-e5448aaba7ee/go.mod h1:dbzn9NF1JWbGEHL6Q/1KG4KFROILiY/j6wmfF1Np3fk=
 github.com/rancher/rke v1.2.0 h1:IxnUfQKyiQ1F16xERd9JSboS8g43JHtjpmtcfgssHQE=
 github.com/rancher/rke v1.2.0/go.mod h1:aPSc14Hp8UGLscL/wB9ZZQHPX/kjDiPXLcoMTCY2NS4=
-github.com/rancher/saml v0.0.0-20180713225824-ce1532152fde h1:+gd9up4jLeFeuNC5bHn7qfRXZO9WKtBe8b4vhucg9lg=
-github.com/rancher/saml v0.0.0-20180713225824-ce1532152fde/go.mod h1:Bp1IBnlwVB1EqRfSKecoPyf+1Wjh8zykMjlq4vJJhxY=
+github.com/rancher/saml v0.0.3-rancher1 h1:rX1UIHVGn8v8AXG8GyMHezXU9+l8zs6o+Psk7OmylEs=
+github.com/rancher/saml v0.0.3-rancher1/go.mod h1:Bp1IBnlwVB1EqRfSKecoPyf+1Wjh8zykMjlq4vJJhxY=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
 github.com/rancher/steve v0.0.0-20201001183606-e0e2eddcb1b2 h1:D0kqOYXm1mTLwmckKajkTU9630Io+FZyqNH372FnjYg=

--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -370,6 +370,7 @@ type SamlConfig struct {
 	UserNameField      string `json:"userNameField"      norman:"required"`
 	UIDField           string `json:"uidField"           norman:"required"`
 	RancherAPIHost     string `json:"rancherApiHost"     norman:"required"`
+	EntityID           string `json:"entityID"`
 }
 
 type SamlConfigTestInput struct {

--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -133,6 +133,7 @@ func InitializeSamlServiceProvider(configToSet *v32.SamlConfig, name string) err
 		Certificate: cert,
 		MetadataURL: metadataURL,
 		AcsURL:      acsURL,
+		EntityID:    configToSet.EntityID,
 	}
 
 	// XML unmarshal throws an error for IdP Metadata cacheDuration field, as it's of type xml Duration. Using a separate struct for unmarshaling for now


### PR DESCRIPTION
Problem: When configuring SAML auth for Rancher, Rancher (service provider) sets the rancher metadata URL as the authentication request issuer (service provider entity ID). This is how the saml library we use sets it, and is a common way of setting the issuer. SAML identity providers (keycloak, adfs etc) have fields that accept the service provider entity ID, which must match the auth request issuer. For Keycloak this field is called `ClientID`. Recently there has been a change in the saml library, which allows users to configure this entity ID, and set it to some custom value instead of the metadata URL. We use a fork of this library, and the version we are on does not include this change. So Keycloak can only be configured with rancher metadata URL as the clientID and users cannot configure it with some custom reserved clientID

Solution: To include this fix in 2.5.2, update rancher's fork of saml to include this change. This change was added with this commit https://github.com/rancher/saml/commit/0fa95beb269fc67ac0fce223e96ccb14fb4207b2.
Add a configurable entity ID field to the saml config. 

Post 2.5.2 we will stop using rancher's fork and use the upstream saml library, this is tracked in a [separate task](https://github.com/rancher/tasks/issues/112)
https://github.com/rancher/rancher/issues/29212