### PR TITLE
Add kubeVersion checks for catalogv1

### DIFF
--- a/pkg/api/norman/customization/app/app.go
+++ b/pkg/api/norman/customization/app/app.go
@@ -5,15 +5,14 @@ import (
 	"net/http"
 	"reflect"
 
-	v32 "github.com/rancher/rancher/pkg/apis/project.cattle.io/v3"
-
 	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/parse"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/types/values"
-	catUtil "github.com/rancher/rancher/pkg/catalog/utils"
+	v32 "github.com/rancher/rancher/pkg/apis/project.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	clusterv3 "github.com/rancher/rancher/pkg/client/generated/cluster/v3"
 	projectv3 "github.com/rancher/rancher/pkg/client/generated/project/v3"
 	"github.com/rancher/rancher/pkg/controllers/management/compose/common"
@@ -30,6 +29,7 @@ import (
 
 type Wrapper struct {
 	Clusters              v3.ClusterInterface
+	CatalogManager        manager.CatalogManager
 	TemplateVersionClient v3.CatalogTemplateVersionInterface
 	TemplateVersionLister v3.CatalogTemplateVersionLister
 	KubeConfigGetter      common.KubeConfigGetter
@@ -116,24 +116,24 @@ func (w Wrapper) ActionHandler(actionName string, action *types.Action, apiConte
 	if err != nil {
 		return err
 	}
+	clusterName, namespace := ref.Parse(app.ProjectID)
+	obj, err := w.AppGetter.Apps(namespace).Get(app.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
 	switch actionName {
 	case "upgrade":
 		externalID := convert.ToString(actionInput["externalId"])
 
-		err := w.validateRancherVersion(externalID)
-		if err != nil {
-			return err
+		if err := w.validateChartCompatibility(externalID, clusterName); err != nil {
+			return httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())
 		}
 
 		answers := actionInput["answers"]
 		forceUpgrade := actionInput["forceUpgrade"]
 		files := actionInput["files"]
 		valuesYaml := actionInput["valuesYaml"]
-		_, namespace := ref.Parse(app.ProjectID)
-		obj, err := w.AppGetter.Apps(namespace).Get(app.Name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
+
 		if answers != nil {
 			m, ok := answers.(map[string]interface{})
 			if ok {
@@ -189,9 +189,8 @@ func (w Wrapper) ActionHandler(actionName string, action *types.Action, apiConte
 			return err
 		}
 
-		err := w.validateRancherVersion(appRevision.Status.ExternalID)
-		if err != nil {
-			return err
+		if err := w.validateChartCompatibility(appRevision.Status.ExternalID, clusterName); err != nil {
+			return httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())
 		}
 
 		_, namespace := ref.Parse(app.ProjectID)
@@ -244,7 +243,7 @@ func (w Wrapper) LinkHandler(apiContext *types.APIContext, next types.RequestHan
 	return nil
 }
 
-func (w Wrapper) validateRancherVersion(externalID string) error {
+func (w Wrapper) validateChartCompatibility(externalID, clusterName string) error {
 	if externalID == "" {
 		return nil
 	}
@@ -256,5 +255,5 @@ func (w Wrapper) validateRancherVersion(externalID string) error {
 	if err != nil {
 		return err
 	}
-	return catUtil.ValidateRancherVersion(template)
+	return w.CatalogManager.ValidateChartCompatibility(template, clusterName)
 }

--- a/pkg/api/norman/customization/catalog/store.go
+++ b/pkg/api/norman/customization/catalog/store.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/norman/store/proxy"
 	"github.com/rancher/norman/store/transform"
 	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	catUtil "github.com/rancher/rancher/pkg/catalog/utils"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	hcommon "github.com/rancher/rancher/pkg/controllers/managementuser/helm/common"
@@ -20,11 +21,13 @@ import (
 type templateStore struct {
 	types.Store
 	CatalogTemplateVersionLister v3.CatalogTemplateVersionLister
+	CatalogManager               manager.CatalogManager
 }
 
 func GetTemplateStore(ctx context.Context, managementContext *config.ScaledContext) types.Store {
 	ts := templateStore{
 		CatalogTemplateVersionLister: managementContext.Management.CatalogTemplateVersions("").Controller().Lister(),
+		CatalogManager:               managementContext.CatalogManager,
 	}
 
 	s := &transform.Store{
@@ -89,7 +92,7 @@ func (t *templateStore) templateVersionForRancherVersion(apiContext *types.APICo
 		return true
 	}
 
-	err = catUtil.ValidateRancherVersion(template)
+	err = t.CatalogManager.ValidateRancherVersion(template)
 	if err != nil {
 		return false
 	}

--- a/pkg/api/norman/customization/cluster/actionhandler.go
+++ b/pkg/api/norman/customization/cluster/actionhandler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	gaccess "github.com/rancher/rancher/pkg/api/norman/customization/globalnamespaceaccess"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	mgmtclient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -19,9 +20,11 @@ import (
 type ActionHandler struct {
 	NodepoolGetter                v3.NodePoolsGetter
 	ClusterClient                 v3.ClusterInterface
+	CatalogManager                manager.CatalogManager
 	NodeTemplateGetter            v3.NodeTemplatesGetter
 	UserMgr                       user.Manager
 	ClusterManager                *clustermanager.Manager
+	CatalogTemplateVersionLister  v3.CatalogTemplateVersionLister
 	BackupClient                  v3.EtcdBackupInterface
 	ClusterScanClient             v3.ClusterScanInterface
 	ClusterTemplateClient         v3.ClusterTemplateInterface

--- a/pkg/api/norman/customization/multiclusterapp/validator_multiclusterapp.go
+++ b/pkg/api/norman/customization/multiclusterapp/validator_multiclusterapp.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/norman/types/set"
 	"github.com/rancher/norman/types/values"
 	gaccess "github.com/rancher/rancher/pkg/api/norman/customization/globalnamespaceaccess"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	pv3 "github.com/rancher/rancher/pkg/generated/norman/project.cattle.io/v3"
@@ -44,6 +45,7 @@ type Wrapper struct {
 	ClusterLister                 v3.ClusterLister
 	Apps                          pv3.AppInterface
 	TemplateVersionLister         v3.CatalogTemplateVersionLister
+	CatalogManager                manager.CatalogManager
 }
 
 const (

--- a/pkg/api/norman/customization/project/project_store.go
+++ b/pkg/api/norman/customization/project/project_store.go
@@ -289,6 +289,7 @@ func (s *projectStore) getNamespacesCount(apiContext *types.APIContext, project 
 	if err != nil {
 		return 0, err
 	}
+
 	namespaces, err := clusterContext.Core.Namespaces("").List(metav1.ListOptions{})
 	if err != nil {
 		return 0, err

--- a/pkg/api/norman/server/managementstored/setup.go
+++ b/pkg/api/norman/server/managementstored/setup.go
@@ -257,8 +257,10 @@ func Clusters(schemas *types.Schemas, managementContext *config.ScaledContext, c
 	handler := ccluster.ActionHandler{
 		NodepoolGetter:                managementContext.Management,
 		ClusterClient:                 managementContext.Management.Clusters(""),
+		CatalogManager:                managementContext.CatalogManager,
 		UserMgr:                       managementContext.UserManager,
 		ClusterManager:                clusterManager,
+		CatalogTemplateVersionLister:  managementContext.Management.CatalogTemplateVersions("").Controller().Lister(),
 		NodeTemplateGetter:            managementContext.Management,
 		BackupClient:                  managementContext.Management.EtcdBackups(""),
 		ClusterScanClient:             managementContext.Management.ClusterScans(""),
@@ -518,10 +520,13 @@ func App(schemas *types.Schemas, management *config.ScaledContext, kubeConfigGet
 		Store:                 schema.Store,
 		Apps:                  management.Project.Apps("").Controller().Lister(),
 		TemplateVersionLister: management.Management.CatalogTemplateVersions("").Controller().Lister(),
+		CatalogManager:        management.CatalogManager,
+		ClusterLister:         management.Management.Clusters("").Controller().Lister(),
 	}
 	schema.Store = store
 	wrapper := app.Wrapper{
 		Clusters:              management.Management.Clusters(""),
+		CatalogManager:        management.CatalogManager,
 		TemplateVersionClient: management.Management.CatalogTemplateVersions(""),
 		TemplateVersionLister: management.Management.CatalogTemplateVersions("").Controller().Lister(),
 		KubeConfigGetter:      kubeConfigGetter,
@@ -782,6 +787,7 @@ func MultiClusterApps(schemas *types.Schemas, management *config.ScaledContext) 
 		ClusterLister:                 management.Management.Clusters("").Controller().Lister(),
 		Apps:                          management.Project.Apps(""),
 		TemplateVersionLister:         management.Management.CatalogTemplateVersions("").Controller().Lister(),
+		CatalogManager:                management.CatalogManager,
 	}
 	schema.Formatter = wrapper.Formatter
 	schema.ActionHandler = wrapper.ActionHandler

--- a/pkg/api/norman/store/app/store.go
+++ b/pkg/api/norman/store/app/store.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
 	pv3app "github.com/rancher/rancher/pkg/api/norman/customization/app"
-	catUtil "github.com/rancher/rancher/pkg/catalog/utils"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	hcommon "github.com/rancher/rancher/pkg/controllers/managementuser/helm/common"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -23,6 +23,8 @@ type Store struct {
 	types.Store
 	Apps                  pv3.AppLister
 	TemplateVersionLister v3.CatalogTemplateVersionLister
+	CatalogManager        manager.CatalogManager
+	ClusterLister         v3.ClusterLister
 }
 
 func (s *Store) Create(apiContext *types.APIContext, schema *types.Schema, data map[string]interface{}) (map[string]interface{}, error) {
@@ -34,8 +36,11 @@ func (s *Store) Create(apiContext *types.APIContext, schema *types.Schema, data 
 		return nil, err
 	}
 
-	if err := s.validateRancherVersion(data); err != nil {
-		return nil, err
+	projectID, _ := data["projectId"].(string)
+	clusterName, _ := ref.Parse(projectID)
+
+	if err := s.validateChartCompatibility(clusterName, data); err != nil {
+		return nil, httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())
 	}
 
 	return s.Store.Create(apiContext, schema, data)
@@ -57,12 +62,15 @@ func (s *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 		return nil, err
 	}
 
-	if err := s.validateRancherVersion(data); err != nil {
+	if err := s.validateForMultiClusterApp(id, "update"); err != nil {
 		return nil, err
 	}
 
-	if err := s.validateForMultiClusterApp(id, "update"); err != nil {
-		return nil, err
+	projectID, _ := data["projectId"].(string)
+	clusterName, _ := ref.Parse(projectID)
+
+	if err := s.validateChartCompatibility(clusterName, data); err != nil {
+		return nil, httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())
 	}
 
 	return s.Store.Update(apiContext, schema, data, id)
@@ -86,7 +94,7 @@ func (s *Store) validateForMultiClusterApp(id string, msg string) error {
 	return nil
 }
 
-func (s *Store) validateRancherVersion(data map[string]interface{}) error {
+func (s *Store) validateChartCompatibility(clusterName string, data map[string]interface{}) error {
 	externalID := convert.ToString(data["externalId"])
 	if externalID == "" {
 		return nil
@@ -102,7 +110,7 @@ func (s *Store) validateRancherVersion(data map[string]interface{}) error {
 		return err
 	}
 
-	return catUtil.ValidateRancherVersion(template)
+	return s.CatalogManager.ValidateChartCompatibility(template, clusterName)
 }
 
 func (s *Store) checkAccessToTemplateVersion(apiContext *types.APIContext, data map[string]interface{}) error {

--- a/pkg/catalog/manager/manager.go
+++ b/pkg/catalog/manager/manager.go
@@ -2,16 +2,22 @@ package manager
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/blang/semver"
+	mVersion "github.com/mcuadros/go-version"
+	"github.com/pkg/errors"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	helmlib "github.com/rancher/rancher/pkg/catalog/helm"
+	"github.com/rancher/rancher/pkg/catalog/utils"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/helm/common"
+	managementv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	projectv3 "github.com/rancher/rancher/pkg/generated/norman/project.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
-	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +26,7 @@ import (
 type Manager struct {
 	catalogClient         v3.CatalogInterface
 	CatalogLister         v3.CatalogLister
+	clusterLister         v3.ClusterLister
 	templateClient        v3.CatalogTemplateInterface
 	templateContentClient v3.TemplateContentInterface
 	templateVersionClient v3.CatalogTemplateVersionInterface
@@ -34,24 +41,33 @@ type Manager struct {
 	bundledMode           bool
 }
 
-func New(management *config.ManagementContext) *Manager {
+type CatalogManager interface {
+	ValidateChartCompatibility(template *v3.CatalogTemplateVersion, clusterName string) error
+	ValidateKubeVersion(template *v3.CatalogTemplateVersion, clusterName string) error
+	ValidateRancherVersion(template *v3.CatalogTemplateVersion) error
+	LatestAvailableTemplateVersion(template *v3.CatalogTemplate, clusterName string) (*v32.TemplateVersionSpec, error)
+	GetSystemAppCatalogID(templateVersionID, clusterName string) (string, error)
+}
+
+func New(management managementv3.Interface, project projectv3.Interface) *Manager {
 	var bundledMode bool
 	if strings.ToLower(settings.SystemCatalog.Get()) == "bundled" {
 		bundledMode = true
 	}
 	return &Manager{
-		catalogClient:         management.Management.Catalogs(""),
-		CatalogLister:         management.Management.Catalogs("").Controller().Lister(),
-		templateClient:        management.Management.CatalogTemplates(""),
-		templateContentClient: management.Management.TemplateContents(""),
-		templateVersionClient: management.Management.CatalogTemplateVersions(""),
-		templateLister:        management.Management.CatalogTemplates("").Controller().Lister(),
-		templateVersionLister: management.Management.CatalogTemplateVersions("").Controller().Lister(),
-		projectCatalogClient:  management.Management.ProjectCatalogs(""),
-		ProjectCatalogLister:  management.Management.ProjectCatalogs("").Controller().Lister(),
-		clusterCatalogClient:  management.Management.ClusterCatalogs(""),
-		ClusterCatalogLister:  management.Management.ClusterCatalogs("").Controller().Lister(),
-		appRevisionClient:     management.Project.AppRevisions(""),
+		catalogClient:         management.Catalogs(""),
+		CatalogLister:         management.Catalogs("").Controller().Lister(),
+		clusterLister:         management.Clusters("").Controller().Lister(),
+		templateClient:        management.CatalogTemplates(""),
+		templateContentClient: management.TemplateContents(""),
+		templateVersionClient: management.CatalogTemplateVersions(""),
+		templateLister:        management.CatalogTemplates("").Controller().Lister(),
+		templateVersionLister: management.CatalogTemplateVersions("").Controller().Lister(),
+		projectCatalogClient:  management.ProjectCatalogs(""),
+		ProjectCatalogLister:  management.ProjectCatalogs("").Controller().Lister(),
+		clusterCatalogClient:  management.ClusterCatalogs(""),
+		ClusterCatalogLister:  management.ClusterCatalogs("").Controller().Lister(),
+		appRevisionClient:     project.AppRevisions(""),
 		bundledMode:           bundledMode,
 	}
 }
@@ -183,4 +199,109 @@ func (m *Manager) deleteBadCatalogTemplates() []error {
 	}
 
 	return errs
+}
+
+func (m *Manager) ValidateChartCompatibility(template *v3.CatalogTemplateVersion, clusterName string) error {
+	if err := m.ValidateRancherVersion(template); err != nil {
+		return err
+	}
+	if err := m.ValidateKubeVersion(template, clusterName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) ValidateKubeVersion(template *v3.CatalogTemplateVersion, clusterName string) error {
+	if template.Spec.KubeVersion == "" {
+		return nil
+	}
+	constraint, err := semver.ParseRange(template.Spec.KubeVersion)
+	if err != nil {
+		logrus.Errorf("failed to parse constraint for kubeversion %s: %v", template.Spec.KubeVersion, err)
+		return nil
+	}
+
+	cluster, err := m.clusterLister.Get("", clusterName)
+	if err != nil {
+		return err
+	}
+
+	k8sVersion, err := semver.Parse(strings.TrimPrefix(cluster.Status.Version.String(), "v"))
+	if err != nil {
+		return err
+	}
+	if !constraint(k8sVersion) {
+		return fmt.Errorf("incompatible kubernetes version [%s] for template [%s]", k8sVersion.String(), template.Name)
+	}
+	return nil
+}
+
+func (m *Manager) ValidateRancherVersion(template *v3.CatalogTemplateVersion) error {
+	rancherMin := template.Spec.RancherMinVersion
+	rancherMax := template.Spec.RancherMaxVersion
+
+	serverVersion := settings.ServerVersion.Get()
+
+	// don't compare if we are running as dev or in the build env
+	if !utils.ReleaseServerVersion(serverVersion) {
+		return nil
+	}
+
+	if rancherMin != "" && !mVersion.Compare(serverVersion, rancherMin, ">=") {
+		return fmt.Errorf("rancher min version not met")
+	}
+
+	if rancherMax != "" && !mVersion.Compare(serverVersion, rancherMax, "<=") {
+		return fmt.Errorf("rancher max version exceeded")
+	}
+
+	return nil
+}
+
+func (m *Manager) LatestAvailableTemplateVersion(template *v3.CatalogTemplate, clusterName string) (*v32.TemplateVersionSpec, error) {
+	versions := template.DeepCopy().Spec.Versions
+	if len(versions) == 0 {
+		return nil, errors.New("empty catalog template version list")
+	}
+
+	sort.Slice(versions, func(i, j int) bool {
+		val1, err := semver.ParseTolerant(versions[i].Version)
+		if err != nil {
+			return false
+		}
+
+		val2, err := semver.ParseTolerant(versions[j].Version)
+		if err != nil {
+			return false
+		}
+
+		return val2.LT(val1)
+	})
+
+	for _, templateVersion := range versions {
+		catalogTemplateVersion := &v3.CatalogTemplateVersion{
+			TemplateVersion: v3.TemplateVersion{
+				Spec: templateVersion,
+			},
+		}
+
+		if err := m.ValidateChartCompatibility(catalogTemplateVersion, clusterName); err == nil {
+			return &templateVersion, nil
+		}
+	}
+
+	return nil, errors.Errorf("template %s incompatible with rancher version or cluster's [%s] kubernetes version", template.Name, clusterName)
+}
+
+func (m *Manager) GetSystemAppCatalogID(templateVersionID, clusterName string) (string, error) {
+	template, err := m.templateLister.Get(namespace.GlobalNamespace, templateVersionID)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to find template by ID %s", templateVersionID)
+	}
+
+	templateVersion, err := m.LatestAvailableTemplateVersion(template, clusterName)
+	if err != nil {
+		return "", err
+	}
+	return templateVersion.ExternalID, nil
 }

--- a/pkg/catalog/manager/manager_test.go
+++ b/pkg/catalog/manager/manager_test.go
@@ -1,0 +1,81 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLatestAvailableTemplateVersion(t *testing.T) {
+	template := &v3.CatalogTemplate{
+		Template: v3.Template{
+			Spec: v3.TemplateSpec{
+				Versions: []v3.TemplateVersionSpec{
+					{
+						ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.16",
+						Version:           "0.12.16",
+						RancherMinVersion: "v2.2.0",
+						RancherMaxVersion: "v2.3.0",
+					},
+					{
+						ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.15",
+						Version:           "0.12.15",
+						RancherMinVersion: "v2.1.0",
+						RancherMaxVersion: "v2.2.0",
+					},
+					{
+						ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.14",
+						Version:           "0.12.14",
+						RancherMinVersion: "v2.0.0",
+						RancherMaxVersion: "v2.1.0",
+					},
+				},
+			},
+		},
+	}
+
+	templateWithoutRancherVersion := &v3.CatalogTemplate{
+		Template: v3.Template{
+			Spec: v3.TemplateSpec{
+				Versions: []v3.TemplateVersionSpec{
+					{
+						ExternalID: "catalog://?catalog=library&template=artifactory-ha&version=0.12.16",
+						Version:    "0.12.16",
+					},
+					{
+						ExternalID: "catalog://?catalog=library&template=artifactory-ha&version=0.12.15",
+						Version:    "0.12.15",
+					},
+					{
+						ExternalID: "catalog://?catalog=library&template=artifactory-ha&version=0.12.14",
+						Version:    "0.12.14",
+					},
+				},
+			},
+		},
+	}
+
+	testLatestAvailableTemplateVersion(t, "v2.1.0", "0.12.15", template)
+	testLatestAvailableTemplateVersion(t, "dev", "0.12.16", template)
+	testLatestAvailableTemplateVersion(t, "master", "0.12.16", template)
+	testLatestAvailableTemplateVersion(t, "master-head", "0.12.16", template)
+	testLatestAvailableTemplateVersion(t, "", "0.12.16", template)
+
+	testLatestAvailableTemplateVersion(t, "v2.1.0", "0.12.16", templateWithoutRancherVersion)
+	testLatestAvailableTemplateVersion(t, "dev", "0.12.16", templateWithoutRancherVersion)
+	testLatestAvailableTemplateVersion(t, "master", "0.12.16", templateWithoutRancherVersion)
+	testLatestAvailableTemplateVersion(t, "master-head", "0.12.16", templateWithoutRancherVersion)
+	testLatestAvailableTemplateVersion(t, "", "0.12.16", templateWithoutRancherVersion)
+}
+
+func testLatestAvailableTemplateVersion(t *testing.T, serverVersion, expectedCatalogVersion string, template *v3.CatalogTemplate) {
+	err := settings.ServerVersion.Set(serverVersion)
+	assert.Nil(t, err)
+
+	catalogManager := Manager{}
+	templateVersion, err := catalogManager.LatestAvailableTemplateVersion(template, "")
+	assert.Nil(t, err)
+	assert.Equal(t, expectedCatalogVersion, templateVersion.Version)
+}

--- a/pkg/catalog/utils/utils.go
+++ b/pkg/catalog/utils/utils.go
@@ -4,8 +4,6 @@ import (
 	"regexp"
 
 	"github.com/pkg/errors"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
@@ -90,17 +88,4 @@ func ValidateURL(pathURL string) error {
 		return errors.New("Invalid characters in url")
 	}
 	return nil
-}
-
-func GetSystemAppCatalogID(templateVersionID string, templateLister v3.CatalogTemplateLister) (string, error) {
-	template, err := templateLister.Get(namespace.GlobalNamespace, templateVersionID)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to find template by ID %s", templateVersionID)
-	}
-
-	templateVersion, err := LatestAvailableTemplateVersion(template)
-	if err != nil {
-		return "", err
-	}
-	return templateVersion.ExternalID, nil
 }

--- a/pkg/catalog/utils/version.go
+++ b/pkg/catalog/utils/version.go
@@ -1,18 +1,10 @@
 package utils
 
 import (
-	"sort"
 	"strings"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/blang/semver"
-	mVersion "github.com/mcuadros/go-version"
-	"github.com/pkg/errors"
-	"github.com/rancher/norman/httperror"
 	"github.com/rancher/rancher/pkg/catalog/utils/version"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/settings"
 )
 
 func VersionBetween(a, b, c string) bool {
@@ -63,28 +55,6 @@ func VersionGreaterThan(a, b string) bool {
 	return version.GreaterThan(a, b)
 }
 
-func ValidateRancherVersion(template *v3.CatalogTemplateVersion) error {
-	rancherMin := template.Spec.RancherMinVersion
-	rancherMax := template.Spec.RancherMaxVersion
-
-	serverVersion := settings.ServerVersion.Get()
-
-	// don't compare if we are running as dev or in the build env
-	if !ReleaseServerVersion(serverVersion) {
-		return nil
-	}
-
-	if rancherMin != "" && !mVersion.Compare(serverVersion, rancherMin, ">=") {
-		return httperror.NewAPIError(httperror.InvalidBodyContent, "rancher min version not met")
-	}
-
-	if rancherMax != "" && !mVersion.Compare(serverVersion, rancherMax, "<=") {
-		return httperror.NewAPIError(httperror.InvalidBodyContent, "rancher max version exceeded")
-	}
-
-	return nil
-}
-
 func ReleaseServerVersion(serverVersion string) bool {
 	if serverVersion == "dev" ||
 		serverVersion == "master" ||
@@ -93,38 +63,4 @@ func ReleaseServerVersion(serverVersion string) bool {
 		return false
 	}
 	return true
-}
-
-func LatestAvailableTemplateVersion(template *v3.CatalogTemplate) (*v32.TemplateVersionSpec, error) {
-	versions := template.DeepCopy().Spec.Versions
-	if len(versions) == 0 {
-		return nil, errors.New("empty catalog template version list")
-	}
-
-	sort.Slice(versions, func(i, j int) bool {
-		val1, err := semver.ParseTolerant(versions[i].Version)
-		if err != nil {
-			return false
-		}
-
-		val2, err := semver.ParseTolerant(versions[j].Version)
-		if err != nil {
-			return false
-		}
-
-		return val2.LT(val1)
-	})
-
-	for _, templateVersion := range versions {
-		catalogTemplateVersion := &v3.CatalogTemplateVersion{
-			TemplateVersion: v3.TemplateVersion{
-				Spec: templateVersion,
-			},
-		}
-		if err := ValidateRancherVersion(catalogTemplateVersion); err == nil {
-			return &templateVersion, nil
-		}
-	}
-
-	return nil, errors.Errorf("template %s allowed rancher version not match current server", template.Name)
 }

--- a/pkg/catalog/utils/version_test.go
+++ b/pkg/catalog/utils/version_test.go
@@ -3,12 +3,7 @@ package utils
 import (
 	"testing"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/stretchr/testify/assert"
-
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/settings"
 )
 
 func TestVersionBetween(t *testing.T) {
@@ -133,74 +128,4 @@ func TestVersionSatifiesRange(t *testing.T) {
 	testInvalidVersion(t, "versionInvalid-1.0", "<v1.0.0-validVersion")
 	testInvalidVersion(t, "versionInvalid-1.0", "<=v1.0.0-validVersion")
 
-}
-
-func TestLatestAvailableTemplateVersion(t *testing.T) {
-	template := &v3.CatalogTemplate{
-		Template: v3.Template{
-			Spec: v32.TemplateSpec{
-				Versions: []v32.TemplateVersionSpec{
-					{
-						ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.16",
-						Version:           "0.12.16",
-						RancherMinVersion: "v2.2.0",
-						RancherMaxVersion: "v2.3.0",
-					},
-					{
-						ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.15",
-						Version:           "0.12.15",
-						RancherMinVersion: "v2.1.0",
-						RancherMaxVersion: "v2.2.0",
-					},
-					{
-						ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.14",
-						Version:           "0.12.14",
-						RancherMinVersion: "v2.0.0",
-						RancherMaxVersion: "v2.1.0",
-					},
-				},
-			},
-		},
-	}
-
-	templateWithoutRancherVersion := &v3.CatalogTemplate{
-		Template: v3.Template{
-			Spec: v32.TemplateSpec{
-				Versions: []v32.TemplateVersionSpec{
-					{
-						ExternalID: "catalog://?catalog=library&template=artifactory-ha&version=0.12.16",
-						Version:    "0.12.16",
-					},
-					{
-						ExternalID: "catalog://?catalog=library&template=artifactory-ha&version=0.12.15",
-						Version:    "0.12.15",
-					},
-					{
-						ExternalID: "catalog://?catalog=library&template=artifactory-ha&version=0.12.14",
-						Version:    "0.12.14",
-					},
-				},
-			},
-		},
-	}
-
-	testLatestAvailableTemplateVersion(t, "v2.1.0", "0.12.15", template)
-	testLatestAvailableTemplateVersion(t, "dev", "0.12.16", template)
-	testLatestAvailableTemplateVersion(t, "master", "0.12.16", template)
-	testLatestAvailableTemplateVersion(t, "master-head", "0.12.16", template)
-	testLatestAvailableTemplateVersion(t, "", "0.12.16", template)
-
-	testLatestAvailableTemplateVersion(t, "v2.1.0", "0.12.16", templateWithoutRancherVersion)
-	testLatestAvailableTemplateVersion(t, "dev", "0.12.16", templateWithoutRancherVersion)
-	testLatestAvailableTemplateVersion(t, "master", "0.12.16", templateWithoutRancherVersion)
-	testLatestAvailableTemplateVersion(t, "master-head", "0.12.16", templateWithoutRancherVersion)
-	testLatestAvailableTemplateVersion(t, "", "0.12.16", templateWithoutRancherVersion)
-}
-
-func testLatestAvailableTemplateVersion(t *testing.T, serverVersion, expectedCatalogVersion string, template *v3.CatalogTemplate) {
-	err := settings.ServerVersion.Set(serverVersion)
-	assert.Nil(t, err)
-	templateVertion, err := LatestAvailableTemplateVersion(template)
-	assert.Nil(t, err)
-	assert.Equal(t, expectedCatalogVersion, templateVertion.Version)
 }

--- a/pkg/controllers/management/catalog/controller.go
+++ b/pkg/controllers/management/catalog/controller.go
@@ -80,7 +80,7 @@ func doUntilSucceeds(ctx context.Context, retryPeriod time.Duration, f func() bo
 
 func Run(ctx context.Context, refreshInterval int, management *config.ManagementContext) error {
 	logrus.Infof("Starting catalog controller")
-	m := manager.New(management)
+	m := manager.New(management.Management, management.Project)
 
 	controller := management.Management.Catalogs("").Controller()
 	controller.AddHandler(ctx, "catalog", m.Sync)

--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -18,7 +18,7 @@ import (
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	apiprojv3 "github.com/rancher/rancher/pkg/apis/project.cattle.io/v3"
 	utils2 "github.com/rancher/rancher/pkg/app"
-	"github.com/rancher/rancher/pkg/catalog/utils"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	"github.com/rancher/rancher/pkg/controllers/management/eksupstreamrefresh"
 	"github.com/rancher/rancher/pkg/controllers/management/rbac"
 	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
@@ -74,6 +74,7 @@ type eksOperatorController struct {
 	appClient            projectv3.AppInterface
 	nsClient             corev1.NamespaceInterface
 	clusterClient        v3.ClusterClient
+	catalogManager       manager.CatalogManager
 	systemAccountManager *systemaccount.Manager
 	dynamicClient        dynamic.NamespaceableResourceInterface
 }
@@ -489,7 +490,7 @@ func (e *eksOperatorController) deployEKSOperator() error {
 		return err
 	}
 
-	latestTemplateVersion, err := utils.LatestAvailableTemplateVersion(template)
+	latestTemplateVersion, err := e.catalogManager.LatestAvailableTemplateVersion(template, "local")
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/management/globaldns/globaldnsprovider_catalog_launcher.go
+++ b/pkg/controllers/management/globaldns/globaldnsprovider_catalog_launcher.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/rancher/norman/types/convert"
 	passwordutil "github.com/rancher/rancher/pkg/api/norman/store/password"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	cutils "github.com/rancher/rancher/pkg/catalog/utils"
-	versionutil "github.com/rancher/rancher/pkg/catalog/utils"
 	"github.com/rancher/rancher/pkg/controllers/management/rbac"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -43,6 +43,7 @@ type ProviderCatalogLauncher struct {
 	userManager       user.Manager
 	secrets           v1.SecretInterface
 	templateLister    v3.CatalogTemplateLister
+	catalogManager    manager.CatalogManager
 }
 
 func newGlobalDNSProviderCatalogLauncher(ctx context.Context, mgmt *config.ManagementContext) *ProviderCatalogLauncher {
@@ -54,6 +55,7 @@ func newGlobalDNSProviderCatalogLauncher(ctx context.Context, mgmt *config.Manag
 		userManager:       mgmt.UserManager,
 		secrets:           mgmt.Core.Secrets(""),
 		templateLister:    mgmt.Management.CatalogTemplates(metav1.NamespaceAll).Controller().Lister(),
+		catalogManager:    mgmt.CatalogManager,
 	}
 	return n
 }
@@ -213,7 +215,7 @@ func (n *ProviderCatalogLauncher) createUpdateExternalDNSApp(obj *v3.GlobalDnsPr
 		}
 	} else {
 		//create new app
-		appCatalogID, err := n.getExternalDNSCatalogID()
+		appCatalogID, err := n.getExternalDNSCatalogID(localClusterName)
 		if err != nil {
 			return nil, err
 		}
@@ -285,9 +287,9 @@ func (n *ProviderCatalogLauncher) getSystemProjectID() (string, error) {
 	return systemProject.Name, nil
 }
 
-func (n *ProviderCatalogLauncher) getExternalDNSCatalogID() (string, error) {
+func (n *ProviderCatalogLauncher) getExternalDNSCatalogID(clusterName string) (string, error) {
 	templateVersionID := n.getRancherExternalDNSTemplateID()
-	return versionutil.GetSystemAppCatalogID(templateVersionID, n.templateLister)
+	return n.catalogManager.GetSystemAppCatalogID(templateVersionID, clusterName)
 }
 
 func (n *ProviderCatalogLauncher) getRancherExternalDNSTemplateID() string {

--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -10,7 +10,6 @@ import (
 	v33 "github.com/rancher/rancher/pkg/apis/project.cattle.io/v3"
 
 	"github.com/coreos/go-semver/semver"
-	"github.com/rancher/rancher/pkg/catalog/utils"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/project"
@@ -113,7 +112,7 @@ func (h *handler) deployK3sBasedUpgradeController(clusterName string, isK3s, isR
 		return err
 	}
 
-	latestTemplateVersion, err := utils.LatestAvailableTemplateVersion(template)
+	latestTemplateVersion, err := h.catalogManager.LatestAvailableTemplateVersion(template, clusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/management/k3sbasedupgrade/register.go
+++ b/pkg/controllers/management/k3sbasedupgrade/register.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	manager2 "github.com/rancher/rancher/pkg/catalog/manager"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	wranglerv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -18,6 +19,7 @@ type handler struct {
 	systemUpgradeNamespace string
 	clusterCache           wranglerv3.ClusterCache
 	clusterClient          wranglerv3.ClusterClient
+	catalogManager         manager2.CatalogManager
 	apps                   projectv3.AppInterface
 	appLister              projectv3.AppLister
 	templateLister         v3.CatalogTemplateLister

--- a/pkg/controllers/managementagent/monitoring/clusterHandler.go
+++ b/pkg/controllers/managementagent/monitoring/clusterHandler.go
@@ -11,6 +11,7 @@ import (
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v33 "github.com/rancher/rancher/pkg/apis/project.cattle.io/v3"
 	app2 "github.com/rancher/rancher/pkg/app"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	"github.com/rancher/rancher/pkg/controllers/managementagent/nslabels"
 	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -45,6 +46,7 @@ type etcdTLSConfig struct {
 type clusterHandler struct {
 	clusterName          string
 	cattleClustersClient mgmtv3.ClusterInterface
+	cattleCatalogManager manager.CatalogManager
 	agentEndpointsLister corev1.EndpointsLister
 	app                  *appHandler
 }
@@ -346,7 +348,7 @@ func (ch *clusterHandler) deployApp(appName, appTargetNamespace string, appProje
 		"prometheus.ruleSelector.matchExpressions[0].values[1]":                             monitoring.CattleMonitoringPrometheusRuleLabelValue,
 	}
 
-	appAnswers, appCatalogID, err := monitoring.OverwriteAppAnswersAndCatalogID(optionalAppAnswers, cluster.Annotations, ch.app.catalogTemplateLister)
+	appAnswers, appCatalogID, err := monitoring.OverwriteAppAnswersAndCatalogID(optionalAppAnswers, cluster.Annotations, ch.app.catalogTemplateLister, ch.cattleCatalogManager, ch.clusterName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/managementagent/monitoring/projectHandler.go
+++ b/pkg/controllers/managementagent/monitoring/projectHandler.go
@@ -12,6 +12,7 @@ import (
 	v33 "github.com/rancher/rancher/pkg/apis/project.cattle.io/v3"
 
 	"github.com/pkg/errors"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/project.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/monitoring"
@@ -30,6 +31,7 @@ const (
 type projectHandler struct {
 	clusterName         string
 	clusterLister       mgmtv3.ClusterLister
+	catalogManager      manager.CatalogManager
 	cattleProjectClient mgmtv3.ProjectInterface
 	prtbClient          mgmtv3.ProjectRoleTemplateBindingInterface
 	prtbIndexer         cache.Indexer
@@ -197,7 +199,7 @@ func (ph *projectHandler) deployApp(appName, appTargetNamespace string, appProje
 		"prometheus.cluster.alertManagerNamespace": clusterAlertManagerSvcNamespaces,
 	}
 
-	appAnswers, appCatalogID, err := monitoring.OverwriteAppAnswersAndCatalogID(optionalAppAnswers, project.Annotations, ph.app.catalogTemplateLister)
+	appAnswers, appCatalogID, err := monitoring.OverwriteAppAnswersAndCatalogID(optionalAppAnswers, project.Annotations, ph.app.catalogTemplateLister, ph.catalogManager, ph.clusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/managementagent/monitoring/register.go
+++ b/pkg/controllers/managementagent/monitoring/register.go
@@ -67,6 +67,7 @@ func Register(ctx context.Context, agentContext *config.UserContext) {
 	ch := &clusterHandler{
 		clusterName:          clusterName,
 		cattleClustersClient: cattleClustersClient,
+		cattleCatalogManager: cattleContext.CatalogManager,
 		agentEndpointsLister: agentClusterMonitoringEndpointLister,
 		app:                  ah,
 	}

--- a/pkg/controllers/managementuser/cis/clusterScanHandler.go
+++ b/pkg/controllers/managementuser/cis/clusterScanHandler.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	cutils "github.com/rancher/rancher/pkg/catalog/utils"
-	versionutil "github.com/rancher/rancher/pkg/catalog/utils"
 	appsv1 "github.com/rancher/rancher/pkg/generated/norman/apps/v1"
 	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	rcorev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
@@ -53,6 +53,7 @@ type cisScanHandler struct {
 	clusterNamespace             string
 	clusterClient                v3.ClusterInterface
 	clusterLister                v3.ClusterLister
+	catalogManager               manager.CatalogManager
 	projectLister                v3.ProjectLister
 	nodeLister                   corev1.NodeLister
 	appClient                    projv3.AppInterface
@@ -333,7 +334,7 @@ func (csh *cisScanHandler) Updated(cs *v3.ClusterScan) (runtime.Object, error) {
 }
 
 func (csh *cisScanHandler) deployApp(appInfo *appInfo) error {
-	appCatalogID, err := csh.getCISBenchmarkCatalogID()
+	appCatalogID, err := csh.getCISBenchmarkCatalogID(appInfo.clusterName)
 	if err != nil {
 		return errors.Wrapf(err, "cisScanHandler: deployApp: failed to find cis system catalog %q", appCatalogID)
 	}
@@ -477,9 +478,9 @@ func (csh *cisScanHandler) ensureCleanup(cs *v3.ClusterScan) error {
 	return err
 }
 
-func (csh *cisScanHandler) getCISBenchmarkCatalogID() (string, error) {
+func (csh *cisScanHandler) getCISBenchmarkCatalogID(clusterName string) (string, error) {
 	templateVersionID := csh.getRancherCISBenchmarkTemplateID()
-	return versionutil.GetSystemAppCatalogID(templateVersionID, csh.templateLister)
+	return csh.catalogManager.GetSystemAppCatalogID(templateVersionID, clusterName)
 }
 
 func (csh *cisScanHandler) getRancherCISBenchmarkTemplateID() string {

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -6,11 +6,10 @@ import (
 	"regexp"
 	"strings"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/rancher/norman/types"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	cutils "github.com/rancher/rancher/pkg/catalog/utils"
-	versionutil "github.com/rancher/rancher/pkg/catalog/utils"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	ns "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/ref"
@@ -209,7 +208,7 @@ grafana.persistence.size             	| 50Gi
 
 */
 func OverwriteAppAnswersAndCatalogID(rawAnswers map[string]string, annotations map[string]string,
-	catalogTemplateLister mgmtv3.CatalogTemplateLister) (map[string]string, string, error) {
+	catalogTemplateLister mgmtv3.CatalogTemplateLister, catalogManager manager.CatalogManager, clusterName string) (map[string]string, string, error) {
 	overwriteAnswers, version := GetOverwroteAppAnswersAndVersion(annotations)
 	for specialKey, value := range overwriteAnswers {
 		if strings.HasPrefix(specialKey, "_tpl-") {
@@ -233,19 +232,19 @@ func OverwriteAppAnswersAndCatalogID(rawAnswers map[string]string, annotations m
 	for key, value := range overwriteAnswers {
 		rawAnswers[key] = value
 	}
-	catalogID, err := GetMonitoringCatalogID(version, catalogTemplateLister)
+	catalogID, err := GetMonitoringCatalogID(version, catalogTemplateLister, catalogManager, clusterName)
 
 	return rawAnswers, catalogID, err
 }
 
-func GetMonitoringCatalogID(version string, catalogTemplateLister mgmtv3.CatalogTemplateLister) (string, error) {
+func GetMonitoringCatalogID(version string, catalogTemplateLister mgmtv3.CatalogTemplateLister, catalogManager manager.CatalogManager, clusterName string) (string, error) {
 	if version == "" {
 		template, err := catalogTemplateLister.Get(ns.GlobalNamespace, RancherMonitoringTemplateName)
 		if err != nil {
 			return "", err
 		}
 
-		templateVersion, err := versionutil.LatestAvailableTemplateVersion(template)
+		templateVersion, err := catalogManager.LatestAvailableTemplateVersion(template, clusterName)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/multiclustermanager/app.go
+++ b/pkg/multiclustermanager/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/tokens"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	managementController "github.com/rancher/rancher/pkg/controllers/management"
 	"github.com/rancher/rancher/pkg/controllers/management/eksupstreamrefresh"
@@ -60,6 +61,8 @@ func buildScaledContext(ctx context.Context, wranglerContext *wrangler.Context, 
 		return nil, nil, err
 	}
 
+	scaledContext.CatalogManager = manager.New(scaledContext.Management, scaledContext.Project)
+
 	if err := managementcrds.Create(ctx, wranglerContext.RESTConfig); err != nil {
 		return nil, nil, err
 	}
@@ -84,6 +87,7 @@ func buildScaledContext(ctx context.Context, wranglerContext *wrangler.Context, 
 	scaledContext.RunContext = ctx
 
 	manager := clustermanager.NewManager(cfg.HTTPSListenPort, scaledContext, wranglerContext.RBAC, wranglerContext.ASL)
+
 	scaledContext.AccessControl = manager
 	scaledContext.ClientGetter = manager
 

--- a/pkg/types/config/context.go
+++ b/pkg/types/config/context.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/norman/restwatch"
 	"github.com/rancher/norman/store/proxy"
 	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	apiregistrationv1 "github.com/rancher/rancher/pkg/generated/norman/apiregistration.k8s.io/v1"
 	appsv1 "github.com/rancher/rancher/pkg/generated/norman/apps/v1"
 	autoscaling "github.com/rancher/rancher/pkg/generated/norman/autoscaling/v2beta2"
@@ -61,6 +62,7 @@ type ScaledContext struct {
 	Dialer            dialer.Factory
 	UserManager       user.Manager
 	PeerManager       peermanager.PeerManager
+	CatalogManager    manager.CatalogManager
 
 	Management managementv3.Interface
 	Project    projectv3.Interface
@@ -82,6 +84,7 @@ func (c *ScaledContext) NewManagementContext() (*ManagementContext, error) {
 	}
 	mgmt.Dialer = c.Dialer
 	mgmt.UserManager = c.UserManager
+	mgmt.CatalogManager = c.CatalogManager
 	c.managementContext = mgmt
 	return mgmt, nil
 }
@@ -179,6 +182,7 @@ type ManagementContext struct {
 	Scheme            *runtime.Scheme
 	Dialer            dialer.Factory
 	UserManager       user.Manager
+	CatalogManager    manager.CatalogManager
 
 	Management managementv3.Interface
 	Project    projectv3.Interface


### PR DESCRIPTION
**Problem:**
Some charts will only be compatible with certain kubernetes versions

**Solution:**
Validate kubernetes version meets kubeVersion constraint in chart if one is set.

**Issue:**
https://github.com/rancher/rancher/issues/29346