### PR TITLE
Evaluate proper error

### DIFF
--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -116,12 +116,12 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 		var conditionErr error
 		if cluster.Spec.EKSConfig.Imported {
 			cluster, conditionErr = e.setFalse(cluster, apimgmtv3.ClusterConditionPending, fmt.Sprintf(failedToDeployEKSOperatorErr, err))
-			if err != nil {
+			if conditionErr != nil {
 				return cluster, conditionErr
 			}
 		} else {
 			cluster, conditionErr = e.setFalse(cluster, apimgmtv3.ClusterConditionProvisioned, fmt.Sprintf(failedToDeployEKSOperatorErr, err))
-			if err != nil {
+			if conditionErr != nil {
 				return cluster, conditionErr
 			}
 		}


### PR DESCRIPTION
**Problem:**
Prior, the error from deploying the eks-operator was evaluated but the condition update error was returned. The condition
update error is usually nil. This caused the controller to not reenqueue the cluster. Since the cluster was not reenqueued the
app was not redeployed unless a separate event caused the cluster or another cluster to reenqueue. Now, the condition error is evaluated and the original error is returned if the condition error is nil.

**Solution:**
Now, the condition error is evaluated and the original error is returned if the condition error is nil.

**Issue:**
https://github.com/rancher/rancher/issues/29127
