### PR TITLE
[2.5 backports] Bump rke2 rancherd and add config parse flag

### DIFF
--- a/cmd/rancherd/bundle/lib/systemd/system/rancherd-agent.service
+++ b/cmd/rancherd/bundle/lib/systemd/system/rancherd-agent.service
@@ -3,7 +3,9 @@ Description=Rancher Kubernetes Engine v2 (agent)
 Documentation=https://rancher.com/docs/rancher/v2.x/en/
 Wants=network-online.target
 After=network-online.target
-Conflicts=rancherd-server.service,rke2-server.service,rke2-agent.service
+Conflicts=rancherd-server.service
+Conflicts=rke2-agent.service
+Conflicts=rke2-server.service
 
 [Install]
 WantedBy=multi-user.target

--- a/cmd/rancherd/bundle/lib/systemd/system/rancherd-server.service
+++ b/cmd/rancherd/bundle/lib/systemd/system/rancherd-server.service
@@ -1,9 +1,11 @@
 [Unit]
-Description=Rancher Kubernetes Engine v2 (agent)
+Description=Rancher Kubernetes Engine v2 (server)
 Documentation=https://rancher.com/docs/rancher/v2.x/en/
 Wants=network-online.target
 After=network-online.target
-Conflicts=rancherd-agent.service,rke2-agent.service,rke2-server.service
+Conflicts=rancherd-agent.service
+Conflicts=rke2-agent.service
+Conflicts=rke2-server.service
 
 [Install]
 WantedBy=multi-user.target

--- a/cmd/rancherd/go.mod
+++ b/cmd/rancherd/go.mod
@@ -65,7 +65,7 @@ replace (
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/k3s v1.19.2-0.20200930184558-c3c983198f4c
-	github.com/rancher/rke2 v1.18.10-0.20201005021635-67ded31a6924 // v1.18.9+rke2r1 ... If you update this, also update rancher/package/Dockerfile.runtime
+	github.com/rancher/rke2 v1.18.11-0.20201016034716-8e418583df2c // v1.18.10+rke2r1 ... If you update this, also update rancher/package/Dockerfile.runtime
 	github.com/rancher/wrangler v0.6.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/urfave/cli v1.22.2

--- a/cmd/rancherd/go.mod
+++ b/cmd/rancherd/go.mod
@@ -64,6 +64,7 @@ replace (
 
 require (
 	github.com/pkg/errors v0.9.1
+	github.com/rancher/k3s v1.19.2-0.20200930184558-c3c983198f4c
 	github.com/rancher/rke2 v1.18.10-0.20201005021635-67ded31a6924 // v1.18.9+rke2r1 ... If you update this, also update rancher/package/Dockerfile.runtime
 	github.com/rancher/wrangler v0.6.1
 	github.com/sirupsen/logrus v1.6.0

--- a/cmd/rancherd/go.sum
+++ b/cmd/rancherd/go.sum
@@ -729,8 +729,8 @@ github.com/rancher/kubernetes/staging/src/k8s.io/sample-apiserver v1.19.0-k3s1/g
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=
-github.com/rancher/rke2 v1.18.10-0.20201005021635-67ded31a6924 h1:2JgcTA7UAr4maFygQm7IU2qXSqGWONYPuRyfKiLsDYw=
-github.com/rancher/rke2 v1.18.10-0.20201005021635-67ded31a6924/go.mod h1:lB/VGKzTG5Btr69JOIL2dlywEDSUk3mb7mCOqCZSOHE=
+github.com/rancher/rke2 v1.18.11-0.20201016034716-8e418583df2c h1:cOLJAEU19Lbscyur7bwMBRWwvY8LOObpS8UxV66Ih0k=
+github.com/rancher/rke2 v1.18.11-0.20201016034716-8e418583df2c/go.mod h1:lB/VGKzTG5Btr69JOIL2dlywEDSUk3mb7mCOqCZSOHE=
 github.com/rancher/wrangler v0.1.4/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rancher/wrangler v0.4.0/go.mod h1:1cR91WLhZgkZ+U4fV9nVuXqKurWbgXcIReU4wnQvTN8=
 github.com/rancher/wrangler v0.6.0/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=

--- a/cmd/rancherd/main.go
+++ b/cmd/rancherd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 
+	"github.com/rancher/k3s/pkg/configfilearg"
 	"github.com/rancher/rancher/cmd/rancherd/auth"
 	"github.com/rancher/rke2/pkg/cli/cmds"
 	"github.com/sirupsen/logrus"
@@ -22,7 +23,7 @@ func main() {
 		},
 	}
 
-	if err := app.Run(os.Args); err != nil {
+	if err := app.Run(configfilearg.MustParse(os.Args)); err != nil {
 		logrus.Fatal(err)
 	}
 }

--- a/package/Dockerfile.runtime
+++ b/package/Dockerfile.runtime
@@ -1,4 +1,4 @@
-ARG RKE2_VERSION=v1.18.9-rke2r1
+ARG RKE2_VERSION=v1.18.10-rke2r1
 # if you’re changing this, also change rancher/cmd/rancherd/go.mod
 FROM rancher/rke2-runtime:${RKE2_VERSION}
 COPY rancher.yaml /charts/


### PR DESCRIPTION
Backports: 
* This pr updates rke2 version in rancherd to v1.18.10+rke2r1 https://github.com/rancher/rancher/pull/29560
* This Issue PR : https://github.com/rancher/rancher/issues/29583