### PR TITLE
[2.5] Add trailing slash to helm repo url

### DIFF
--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
 	catalog "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
@@ -167,7 +168,7 @@ func (r *repoHandler) download(repoSpec *catalog.RepoSpec, status catalog.RepoSt
 		}
 		index, err = git.BuildOrGetIndex(metadata.Namespace, metadata.Name, repoSpec.GitRepo)
 	} else if repoSpec.URL != "" {
-		status.URL = repoSpec.URL
+		status.URL = strings.TrimSuffix(repoSpec.URL, "/") + "/"
 		status.Branch = ""
 		index, err = helmhttp.DownloadIndex(secret, repoSpec.URL, repoSpec.CABundle, repoSpec.InsecureSkipTLSverify)
 	} else {


### PR DESCRIPTION
If the helm repo url does not end with a '/' and the chart url is relative, then the end of the helm repo path was being removed.

For example, if the helm repo was `https://helm.example.com/repo/charts` and the chart url was `chart-v1.0.0.tgz`, then the url was being resolved to `https://helm.example.com/repo/chart-v1.0.0.tgz`. This was incorrect.

Ensuring that the repo url ends with a '/' fixes this problem.

Issue:
https://github.com/rancher/rancher/issues/29557

To elaborate on how this fixes the issue: when the path was being altered in the undesired way as above, the response was HTML with a 404 status. When the `gzip` reader tried to decompress the expected response, it produced and `invalid header error`because it was reading HTML instead of gzip.