### PR TITLE
[2.4] Add a cache to the azureAD group retrieval

### DIFF
--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -4,17 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/Azure/go-autorest/autorest/adal"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/tokens"
+	"github.com/rancher/rancher/pkg/settings"
 	corev1 "github.com/rancher/types/apis/core/v1"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/apis/management.cattle.io/v3public"
@@ -34,6 +37,8 @@ const (
 	Name = "azuread"
 )
 
+var groupCache *lru.Cache
+
 type azureProvider struct {
 	ctx         context.Context
 	authConfigs v3.AuthConfigInterface
@@ -42,12 +47,13 @@ type azureProvider struct {
 	tokenMGR    *tokens.Manager
 }
 
-func Configure(
-	ctx context.Context,
-	mgmtCtx *config.ScaledContext,
-	userMGR user.Manager,
-	tokenMGR *tokens.Manager,
-) common.AuthProvider {
+func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.Manager, tokenMGR *tokens.Manager) common.AuthProvider {
+	var err error
+	groupCache, err = lru.New(settings.AzureGroupCacheSize.GetInt())
+	if err != nil {
+		logrus.Warnf("initial azure-group-cache-size was invalid value, setting to 10000 error:%v", err)
+		groupCache, _ = lru.New(10000)
+	}
 
 	return &azureProvider{
 		ctx:         ctx,
@@ -427,17 +433,23 @@ func (ap *azureProvider) userToPrincipal(user graphrbac.User) v3.Principal {
 	return p
 }
 
-func (ap *azureProvider) userGroupsToPrincipals(
-	azureClient *azureClient,
-	groups graphrbac.UserGetMemberGroupsResult,
-) ([]v3.Principal, error) {
+func (ap *azureProvider) userGroupsToPrincipals(azureClient *azureClient, groups graphrbac.UserGetMemberGroupsResult) ([]v3.Principal, error) {
 	start := time.Now()
 	logrus.Debug("[AZURE_PROVIDER] Started gathering users groups")
+
 	var g errgroup.Group
 	groupPrincipals := make([]v3.Principal, len(*groups.Value))
 	for i, group := range *groups.Value {
 		j := i
 		gp := group
+
+		// Check the cache first, if it exists that saves an API call to azure
+		if principal, ok := groupCache.Get(gp); ok {
+			p := principal.(v3.Principal)
+			groupPrincipals[j] = p
+			continue
+		}
+
 		g.Go(func() error {
 			groupObj, err := azureClient.groupClient.Get(context.Background(), gp)
 			if err != nil {
@@ -447,6 +459,9 @@ func (ap *azureProvider) userGroupsToPrincipals(
 
 			p := ap.groupToPrincipal(groupObj)
 			p.MemberOf = true
+
+			// Add to the cache
+			groupCache.Add(gp, p)
 			groupPrincipals[j] = p
 			return nil
 		})
@@ -454,7 +469,7 @@ func (ap *azureProvider) userGroupsToPrincipals(
 	if err := g.Wait(); err != nil {
 		return nil, err
 	}
-	logrus.Debugf("[AZURE_PROVIDER] Completed gathering users groups, took %v", time.Now().Sub(start))
+	logrus.Infof("[AZURE_PROVIDER] Completed gathering users groups, took %v, keys in cache:%v", time.Since(start), groupCache.Len())
 	return groupPrincipals, nil
 }
 
@@ -558,4 +573,17 @@ func (ap *azureProvider) CanAccessWithGroupProviders(userPrincipalID string, gro
 		return false, err
 	}
 	return allowed, nil
+}
+
+func UpdateGroupCacheSize(size string) {
+	i, err := strconv.Atoi(size)
+	if err != nil {
+		logrus.Errorf("error parsing azure-group-cache-size, skipping update %v", err)
+		return
+	}
+	if i < 0 {
+		logrus.Error("azure-group-cache-size must be >= 0, skipping update")
+		return
+	}
+	groupCache.Resize(i)
 }

--- a/pkg/controllers/management/auth/setting.go
+++ b/pkg/controllers/management/auth/setting.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
+	"github.com/rancher/rancher/pkg/auth/providers/azure"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +34,8 @@ func (n *SettingController) sync(key string, obj *v3.Setting) (runtime.Object, e
 		providerrefresh.UpdateRefreshCronTime(obj.Value)
 	case "auth-user-info-max-age-seconds":
 		providerrefresh.UpdateRefreshMaxAge(obj.Value)
+	case "azure-group-cache-size":
+		azure.UpdateGroupCacheSize(obj.Value)
 	}
 
 	return nil, nil

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -21,6 +21,7 @@ var (
 	AuthTokenMaxTTLMinutes            = NewSetting("auth-token-max-ttl-minutes", "0") // never expire
 	AuthorizationCacheTTLSeconds      = NewSetting("authorization-cache-ttl-seconds", "10")
 	AuthorizationDenyCacheTTLSeconds  = NewSetting("authorization-deny-cache-ttl-seconds", "10")
+	AzureGroupCacheSize               = NewSetting("azure-group-cache-size", "10000")
 	CACerts                           = NewSetting("cacerts", "")
 	CLIURLDarwin                      = NewSetting("cli-url-darwin", "https://releases.rancher.com/cli/v1.0.0-alpha8/rancher-darwin-amd64-v1.0.0-alpha8.tar.gz")
 	CLIURLLinux                       = NewSetting("cli-url-linux", "https://releases.rancher.com/cli/v1.0.0-alpha8/rancher-linux-amd64-v1.0.0-alpha8.tar.gz")


### PR DESCRIPTION
Problem:
In large azureAD setups user sync and even on login causes a large
amount of API calls to azureAD to fetch users groups.

Solution:
Cache the group principals as this is static data so it's causing
unnecessary load on rancher and the azureAD API
User syncs are an order of magnitude faster after the cache is populated

backport of: https://github.com/rancher/rancher/pull/29521