### PR TITLE
[2.5] Add a cache to the azureAD group retrieval

### DIFF
--- a/pkg/controllers/management/auth/setting.go
+++ b/pkg/controllers/management/auth/setting.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
+	"github.com/rancher/rancher/pkg/auth/providers/azure"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +34,8 @@ func (n *SettingController) sync(key string, obj *v3.Setting) (runtime.Object, e
 		providerrefresh.UpdateRefreshCronTime(obj.Value)
 	case "auth-user-info-max-age-seconds":
 		providerrefresh.UpdateRefreshMaxAge(obj.Value)
+	case "azure-group-cache-size":
+		azure.UpdateGroupCacheSize(obj.Value)
 	}
 
 	return nil, nil

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -24,6 +24,7 @@ var (
 	AuthTokenMaxTTLMinutes            = NewSetting("auth-token-max-ttl-minutes", "0") // never expire
 	AuthorizationCacheTTLSeconds      = NewSetting("authorization-cache-ttl-seconds", "10")
 	AuthorizationDenyCacheTTLSeconds  = NewSetting("authorization-deny-cache-ttl-seconds", "10")
+	AzureGroupCacheSize               = NewSetting("azure-group-cache-size", "10000")
 	CACerts                           = NewSetting("cacerts", "")
 	CLIURLDarwin                      = NewSetting("cli-url-darwin", "https://releases.rancher.com/cli/v1.0.0-alpha8/rancher-darwin-amd64-v1.0.0-alpha8.tar.gz")
 	CLIURLLinux                       = NewSetting("cli-url-linux", "https://releases.rancher.com/cli/v1.0.0-alpha8/rancher-linux-amd64-v1.0.0-alpha8.tar.gz")


### PR DESCRIPTION
Problem:
In large azureAD setups user sync and even on login causes a large
amount of API calls to azureAD to fetch users groups.

Solution:
Cache the group principals as this is static data so it's causing
unnecessary load on rancher and the azureAD API
User syncs are an order of magnitude faster after the cache is populated

backport of: #29521