### PR TITLE
[2.5] Update cli tag

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -109,7 +109,7 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
 
 ENV CATTLE_UI_VERSION 2.5.2-rc2
 ENV CATTLE_DASHBOARD_UI_VERSION v2.5.2-rc2
-ENV CATTLE_CLI_VERSION 2.4.7-rc1
+ENV CATTLE_CLI_VERSION v2.4.7-rc1
 
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV CATTLE_API_UI_VERSION 1.1.9


### PR DESCRIPTION
This PR is to correct the cli tag which was changed in https://github.com/rancher/rancher/pull/29578/files#diff-c55d1ee74f32cd4b9eeeceaec981a180f52e761acb158a5b0b0e088c7725c9caL112