### PR TITLE
[ v2.5.2 ]Use capabilities to check if has apiVersion

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,4 +1,8 @@
+{{- if (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "rancher.fullname" . }}


### PR DESCRIPTION
**Backport**

**Problem**
Deprecation warning is still visible

**Solution**
Determine if Ingress is available at the networking/v1 apiVersion and default to v1beta1 if it is not

**Issue**
https://github.com/rancher/rancher/issues/29144

**Additional Info**
Checking apiVersion has resource is available starting at helm 2.15
