### PR TITLE
[2.5] Fix image list for airgap

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -91,6 +91,9 @@ RUN curl -sLf https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERS
 
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 
+ENV YQ_URL=https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_${ARCH}
+RUN wget -O - ${YQ_URL} > /usr/bin/yq && chmod +x /usr/bin/yq
+
 ENV KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/${ARCH}/kubectl
 RUN wget -O - ${KUBECTL_URL} > /usr/bin/kubectl && chmod +x /usr/bin/kubectl
 

--- a/scripts/package
+++ b/scripts/package
@@ -1,23 +1,14 @@
 #!/bin/bash
 set -e
 
-extract_latest_version_tgz() {
-    # Takes in a path to a chart's directory, finds the latest version's tgz and extracts it
-    # All crd tgz are ignored
-    # Max depth is set to prevent extracting a tgz contained within another tgz, which is the case for charts containing a helm repo
-    LATEST_VERSION_TGZ_PATH=$(find $1 -maxdepth 1 -name "*.tgz" ! -name "*crd*.tgz" -print | sort -Vr | head -1)
-    if [[ $LATEST_VERSION_TGZ_PATH ]]; then
-        tar -xvf $LATEST_VERSION_TGZ_PATH -C $(dirname $LATEST_VERSION_TGZ_PATH)
-    fi
-}
-export -f extract_latest_version_tgz
-
 ./k3s-images.sh
 
 source $(dirname $0)/version
 
 ARCH=${ARCH:-"amd64"}
+SYSTEM_CHART_REPO_DIR=build/system-charts
 SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"dev-v2.4"}
+CHART_REPO_DIR=build/charts
 CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"dev-v2.5"}
 
 cd $(dirname $0)/../package
@@ -49,20 +40,32 @@ cd ../bin
 
 if [ ! -d build/system-charts ]; then
     mkdir -p build
-    git clone --branch $SYSTEM_CHART_DEFAULT_BRANCH https://github.com/rancher/system-charts build/system-charts
+    git clone --depth=1 --no-tags --branch $SYSTEM_CHART_DEFAULT_BRANCH https://github.com/rancher/system-charts $SYSTEM_CHART_REPO_DIR
 fi
 
 if [ ! -d build/charts ]; then
-    git clone --branch $CHART_DEFAULT_BRANCH https://github.com/rancher/charts build/charts
+    INDEX_PATH=$CHART_REPO_DIR/index.yaml
+    git clone --branch $CHART_DEFAULT_BRANCH https://github.com/rancher/charts $CHART_REPO_DIR
 
-    # Iterate through chart directories and execute callback to extract latest version tgz
-    find build/charts/assets -type d -maxdepth 1 -exec bash -c 'extract_latest_version_tgz {}' \;
+    # Get list of paths to tarballs of the latest version of each chart from Helm repo's index.yaml
+    LATEST_TGZ_PATHS=$(yq r $INDEX_PATH "entries.*.[0].urls[0]")
+
+    # Extract the tarballs in the list, skip extracting CRD charts
+    for TGZ_PATH in $LATEST_TGZ_PATHS; do
+        TGZ_REL_PATH=$CHART_REPO_DIR/$TGZ_PATH
+        if [[ $TGZ_PATH == *crd*.tgz ]]; then
+            echo "Skipped CRD: $TGZ_REL_PATH"
+        else
+            echo "Extract: $TGZ_REL_PATH"
+            tar -xvf $TGZ_REL_PATH -C $(dirname $TGZ_REL_PATH)
+        fi
+    done
 
     # Remove index to force building a virtual index like system charts
-    rm -f build/charts/index.yaml build/charts/assets/index.yaml
+    rm -f $INDEX_PATH $CHART_REPO_DIR/assets/index.yaml
 fi
 
-TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go build/system-charts build/charts $IMAGE $AGENT_IMAGE
+TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go $SYSTEM_CHART_REPO_DIR $CHART_REPO_DIR/assets $IMAGE $AGENT_IMAGE
 
 if [ ${ARCH} == amd64 ]; then
     # rancherd tarball


### PR DESCRIPTION
**Problem:**
The tarballs of the latest version of each chart needs to be extracted before the `rancher-images.txt` for airgap setups can be created. The previous logic that does this pre-processing leverages on `sort -Vr` (reverse version-sort) to find the latest version of each chart, but it's proven to be unreliable at times as shown in the related issues below.

**Solution:**
Modify pre-processing logic to read the repo's `index.yaml` using `yq` to find the latest version of each chart. Since we don't allow modifying old charts, it's safe to assume that `index.yaml` will always contain a list of chart sorted in the correct order.

Ran `make ci` locally and the generated `rancher-images.txt` contained the correct tags for `rancher/fleet` and `rancher/rancher-operator`

**Related Issues:**
https://github.com/rancher/rancher/issues/29591
https://github.com/rancher/rancher/issues/29599


