### PR TITLE
[2.5] Check CisStatusScan existence before Sync

### DIFF
--- a/pkg/controllers/managementuser/alert/watcher/cluster_scan.go
+++ b/pkg/controllers/managementuser/alert/watcher/cluster_scan.go
@@ -53,6 +53,12 @@ func (csw *ClusterScanWatcher) Sync(_ string, cs *v3.ClusterScan) (runtime.Objec
 	if cs.DeletionTimestamp != nil {
 		return cs, nil
 	}
+	// Cis sends alerts when the cluster scan has completed, and when it has completed with failures.
+	// In both scenarios, the "CisScanStatus" needs to be set in order to send an alert, so we skip
+	// sending alerts until then.
+	if cs.Status.CisScanStatus == nil {
+		return cs, nil
+	}
 	// Start with Unknown, True if there is/are a matching alert rule(s), else False
 	if !(v32.ClusterScanConditionAlerted.IsUnknown(cs) &&
 		v32.ClusterScanConditionCompleted.IsTrue(cs)) {

--- a/pkg/controllers/managementuser/cis/clusterScanHandler.go
+++ b/pkg/controllers/managementuser/cis/clusterScanHandler.go
@@ -313,6 +313,7 @@ func (csh *cisScanHandler) Updated(cs *v3.ClusterScan) (runtime.Object, error) {
 				NotApplicable: r.NotApplicable,
 			}
 
+			cs = cs.DeepCopy()
 			cs.Status.CisScanStatus = cisScanStatus
 		}
 		v32.ClusterScanConditionCompleted.True(cs)
@@ -324,8 +325,8 @@ func (csh *cisScanHandler) Updated(cs *v3.ClusterScan) (runtime.Object, error) {
 		}
 		updatedCluster := cluster.DeepCopy()
 		updatedCluster.Status.CurrentCisRunName = ""
-		if _, err := csh.clusterClient.Update(updatedCluster); err != nil {
-			return nil, fmt.Errorf("cisScanHandler: Updated: failed to update cluster about CIS scan completion with error %v", err)
+		if cs, err := csh.clusterClient.Update(updatedCluster); err != nil {
+			return cs, fmt.Errorf("cisScanHandler: Updated: failed to update cluster about CIS scan completion with error %v", err)
 		}
 	}
 	return cs, nil


### PR DESCRIPTION
Check if the CisStatusScan field exists is before accessing it in
Sync. If Fail is "nil", a panic will occur in the child function:
isAlertRuleMatching. Ensure that we are using a deep copied "cs"
object when creating the CisStatusScan object.

Original PR: #29566
Original Issue: #29518

This is a backport of the original, merged PR.