### PR TITLE
enqueue node if node plan isn't initialized after rke up

### DIFF
--- a/pkg/controllers/management/rkeworkerupgrader/upgrade.go
+++ b/pkg/controllers/management/rkeworkerupgrader/upgrade.go
@@ -397,6 +397,10 @@ func (uh *upgradeHandler) toUpgradeCluster(cluster *v3.Cluster) (bool, bool, err
 		}
 
 		if node.Status.NodePlan == nil || v32.NodeConditionRegistered.IsUnknown(node) {
+			// enqueue if node plan isn't initialized yet
+			if node.Status.NodePlan == nil {
+				uh.nodes.Controller().Enqueue(node.Namespace, node.Name)
+			}
 			// node's not yet registered, change in its node plan should do nothing for cluster upgrade
 			continue
 		}


### PR DESCRIPTION
Forward Port https://github.com/rancher/rancher/pull/29657

Problem:
Node plan doesn't get initialized on the v3.Node if sync is missed,
so node gets stuck in registering without an Edit/Delete.

Solution:
Check if node plan is set during cluster's toUpgrade logic, which
is called after every rke sync.

https://github.com/rancher/rancher/issues/29620 