### PR TITLE
[2.4] Enable agent image to be pulled from private registry

### DIFF
--- a/pkg/controllers/management/node/utils.go
+++ b/pkg/controllers/management/node/utils.go
@@ -46,6 +46,12 @@ func buildAgentCommand(node *v3.Node, dockerRun string) []string {
 	return cmd
 }
 
+func buildLoginCommand(node *v3.Node, login string) []string {
+	cmd := []string{"--native-ssh", "ssh", node.Spec.RequestedHostname}
+	cmd = append(cmd, strings.Fields(login)...)
+	return cmd
+}
+
 func buildCreateCommand(node *v3.Node, configMap map[string]interface{}) []string {
 	sDriver := strings.ToLower(node.Status.NodeTemplateSpec.Driver)
 	cmd := []string{"create", "-d", sDriver}


### PR DESCRIPTION
Issue:
- rancher/rancher#26366 

Solution:
- Resolve the agent image using the cluster object so that it is qualified with the private registry url
- If there's a cluster private registry defined, execute a docker login command on the downstream node via `rancher-machine` before the agent is deployed
- Escape special characters in password since login is via command line

Testing:
- Setup a private registry w/ rancher images
- Launch a cluster w/ a private registry
- tested w/ passwords:
```
testpassword
a$b"'@123`*\
```