### PR TITLE
Fix helm repo constant refreshing

### DIFF
--- a/pkg/catalogv2/http/download.go
+++ b/pkg/catalogv2/http/download.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 
 	"github.com/rancher/wrangler/pkg/schemas/validation"
 
@@ -35,7 +36,7 @@ func Icon(secret *corev1.Secret, repoURL string, caBundle []byte, insecureSkipTL
 		return nil, "", err
 	}
 	if !u.IsAbs() {
-		base, err := url.Parse(repoURL)
+		base, err := url.Parse(strings.TrimSuffix(repoURL, "/") + "/")
 		if err != nil {
 			return nil, "", err
 		}
@@ -75,7 +76,7 @@ func Chart(secret *corev1.Secret, repoURL string, caBundle []byte, insecureSkipT
 		return nil, err
 	}
 	if !u.IsAbs() {
-		base, err := url.Parse(repoURL)
+		base, err := url.Parse(strings.TrimSuffix(repoURL, "/") + "/")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	"strings"
 	"time"
 
 	catalog "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
@@ -168,7 +167,7 @@ func (r *repoHandler) download(repoSpec *catalog.RepoSpec, status catalog.RepoSt
 		}
 		index, err = git.BuildOrGetIndex(metadata.Namespace, metadata.Name, repoSpec.GitRepo)
 	} else if repoSpec.URL != "" {
-		status.URL = strings.TrimSuffix(repoSpec.URL, "/") + "/"
+		status.URL = repoSpec.URL
 		status.Branch = ""
 		index, err = helmhttp.DownloadIndex(secret, repoSpec.URL, repoSpec.CABundle, repoSpec.InsecureSkipTLSverify)
 	} else {


### PR DESCRIPTION
The helm repo was being refreshed because `repoSpec.URL` and `status.URL` were different. They were different because we were ensuring that `status.URL` ended with a '/'. Now we only add the slash if it is needed to download a chart.

The issue is that `base.ResolveReference(u)` will remove the last part of the path unless it ends in a '/'.
You can see the difference in this playground: https://play.golang.org/p/DbXvDC_S6ZX