### PR TITLE
Add support for Amazon us-gov regions

### DIFF
--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -69,7 +69,7 @@ func addMachineDrivers(management *config.ManagementContext) error {
 		return err
 	}
 	if err := addMachineDriver(Amazonec2driver, "local://", "", "",
-		[]string{"iam.amazonaws.com", "iam.%.amazonaws.com.cn", "ec2.%.amazonaws.com", "ec2.%.amazonaws.com.cn", "eks.%.amazonaws.com", "kms.%.amazonaws.com"},
+		[]string{"iam.amazonaws.com", "iam.us-gov.amazonaws.com", "iam.%.amazonaws.com.cn", "ec2.%.amazonaws.com", "ec2.%.amazonaws.com.cn", "eks.%.amazonaws.com", "kms.%.amazonaws.com"},
 		true, true, management); err != nil {
 		return err
 	}

--- a/pkg/httpproxy/sign.go
+++ b/pkg/httpproxy/sign.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	defaultAWSRegion = "us-east-1"
+	defaultAWSRegion      = "us-east-1"
+	defaultUSGovAWSRegion = "us-gov-west-1"
 )
 
 var requiredHeadersForAws = map[string]bool{"host": true,
@@ -115,8 +116,12 @@ func (a awsv4) getServiceAndRegion(host string) (string, string) {
 		}
 	}
 
-	// if no region is found, global endpoint is assumed. In this case us-east-1 should be used for signing:
+	// if no region is found, global endpoint is assumed.
 	// https://docs.aws.amazon.com/general/latest/gr/sigv4_elements.html
+	if strings.Contains(host, "us-gov") {
+		return service, defaultUSGovAWSRegion
+	}
+
 	return service, defaultAWSRegion
 }
 


### PR DESCRIPTION
The Amazon IAM requests use the "global" region. However, the global
region for us-gov is different from standard AWS. The global region and
host are added for us-gov.

Issue:
https://github.com/rancher/rancher/issues/27080