### PR TITLE
[2.5] Add generated changes for EntityID from SAML config

### DIFF
--- a/pkg/client/generated/management/v3/zz_generated_adfs_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_adfs_config.go
@@ -9,6 +9,7 @@ const (
 	ADFSConfigFieldCreatorID           = "creatorId"
 	ADFSConfigFieldDisplayNameField    = "displayNameField"
 	ADFSConfigFieldEnabled             = "enabled"
+	ADFSConfigFieldEntityID            = "entityID"
 	ADFSConfigFieldGroupsField         = "groupsField"
 	ADFSConfigFieldIDPMetadataContent  = "idpMetadataContent"
 	ADFSConfigFieldLabels              = "labels"
@@ -32,6 +33,7 @@ type ADFSConfig struct {
 	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	DisplayNameField    string            `json:"displayNameField,omitempty" yaml:"displayNameField,omitempty"`
 	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	EntityID            string            `json:"entityID,omitempty" yaml:"entityID,omitempty"`
 	GroupsField         string            `json:"groupsField,omitempty" yaml:"groupsField,omitempty"`
 	IDPMetadataContent  string            `json:"idpMetadataContent,omitempty" yaml:"idpMetadataContent,omitempty"`
 	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_key_cloak_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_key_cloak_config.go
@@ -9,6 +9,7 @@ const (
 	KeyCloakConfigFieldCreatorID           = "creatorId"
 	KeyCloakConfigFieldDisplayNameField    = "displayNameField"
 	KeyCloakConfigFieldEnabled             = "enabled"
+	KeyCloakConfigFieldEntityID            = "entityID"
 	KeyCloakConfigFieldGroupsField         = "groupsField"
 	KeyCloakConfigFieldIDPMetadataContent  = "idpMetadataContent"
 	KeyCloakConfigFieldLabels              = "labels"
@@ -32,6 +33,7 @@ type KeyCloakConfig struct {
 	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	DisplayNameField    string            `json:"displayNameField,omitempty" yaml:"displayNameField,omitempty"`
 	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	EntityID            string            `json:"entityID,omitempty" yaml:"entityID,omitempty"`
 	GroupsField         string            `json:"groupsField,omitempty" yaml:"groupsField,omitempty"`
 	IDPMetadataContent  string            `json:"idpMetadataContent,omitempty" yaml:"idpMetadataContent,omitempty"`
 	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_okta_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_okta_config.go
@@ -9,6 +9,7 @@ const (
 	OKTAConfigFieldCreatorID           = "creatorId"
 	OKTAConfigFieldDisplayNameField    = "displayNameField"
 	OKTAConfigFieldEnabled             = "enabled"
+	OKTAConfigFieldEntityID            = "entityID"
 	OKTAConfigFieldGroupsField         = "groupsField"
 	OKTAConfigFieldIDPMetadataContent  = "idpMetadataContent"
 	OKTAConfigFieldLabels              = "labels"
@@ -32,6 +33,7 @@ type OKTAConfig struct {
 	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	DisplayNameField    string            `json:"displayNameField,omitempty" yaml:"displayNameField,omitempty"`
 	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	EntityID            string            `json:"entityID,omitempty" yaml:"entityID,omitempty"`
 	GroupsField         string            `json:"groupsField,omitempty" yaml:"groupsField,omitempty"`
 	IDPMetadataContent  string            `json:"idpMetadataContent,omitempty" yaml:"idpMetadataContent,omitempty"`
 	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_ping_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_ping_config.go
@@ -9,6 +9,7 @@ const (
 	PingConfigFieldCreatorID           = "creatorId"
 	PingConfigFieldDisplayNameField    = "displayNameField"
 	PingConfigFieldEnabled             = "enabled"
+	PingConfigFieldEntityID            = "entityID"
 	PingConfigFieldGroupsField         = "groupsField"
 	PingConfigFieldIDPMetadataContent  = "idpMetadataContent"
 	PingConfigFieldLabels              = "labels"
@@ -32,6 +33,7 @@ type PingConfig struct {
 	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	DisplayNameField    string            `json:"displayNameField,omitempty" yaml:"displayNameField,omitempty"`
 	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	EntityID            string            `json:"entityID,omitempty" yaml:"entityID,omitempty"`
 	GroupsField         string            `json:"groupsField,omitempty" yaml:"groupsField,omitempty"`
 	IDPMetadataContent  string            `json:"idpMetadataContent,omitempty" yaml:"idpMetadataContent,omitempty"`
 	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_shibboleth_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_shibboleth_config.go
@@ -9,6 +9,7 @@ const (
 	ShibbolethConfigFieldCreatorID           = "creatorId"
 	ShibbolethConfigFieldDisplayNameField    = "displayNameField"
 	ShibbolethConfigFieldEnabled             = "enabled"
+	ShibbolethConfigFieldEntityID            = "entityID"
 	ShibbolethConfigFieldGroupsField         = "groupsField"
 	ShibbolethConfigFieldIDPMetadataContent  = "idpMetadataContent"
 	ShibbolethConfigFieldLabels              = "labels"
@@ -33,6 +34,7 @@ type ShibbolethConfig struct {
 	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	DisplayNameField    string            `json:"displayNameField,omitempty" yaml:"displayNameField,omitempty"`
 	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	EntityID            string            `json:"entityID,omitempty" yaml:"entityID,omitempty"`
 	GroupsField         string            `json:"groupsField,omitempty" yaml:"groupsField,omitempty"`
 	IDPMetadataContent  string            `json:"idpMetadataContent,omitempty" yaml:"idpMetadataContent,omitempty"`
 	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`


### PR DESCRIPTION
The following PR added the new EntityID field for SAML config: https://github.com/rancher/rancher/pull/29571
It didn't contain the generated changes, this PR adds in generated changes