### PR TITLE
[release/v2.4] Allow nodes to be deleted if cant access cluster

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -761,10 +761,15 @@ func (m *Lifecycle) deleteV1Node(node *v3.Node) (runtime.Object, error) {
 		return node, err
 	}
 
+	ctx, cancel := context.WithTimeout(context.TODO(), 45*time.Second)
+	defer cancel()
 	err = userClient.K8sClient.CoreV1().Nodes().Delete(
-		context.TODO(), node.Status.NodeName, metav1.DeleteOptions{})
-	if !kerror.IsNotFound(err) {
-		return node, err
+		ctx, node.Status.NodeName, metav1.DeleteOptions{})
+	select {
+	case <-ctx.Done():
+		if !kerror.IsNotFound(err) && ctx.Err() != context.DeadlineExceeded {
+			return node, err
+		}
 	}
 
 	return node, nil


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/29801

The node controller logic was changed, which included a change to return error on node v1 delete if it wasnt a nodenotfound error. In testing it was discovered that when a cluster is inaccessible (e.g. shutdown all etcd nodes), the error "context deadline exceeded" was returned but the node never got deleted. This adds that condition to pass so it can be deleted, and the cluster can be restored using the way it worked before this change.