### PR TITLE
add ingress pathtype

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -47,6 +47,9 @@ spec:
           serviceName: {{ template "rancher.fullname" . }}
           servicePort: 80
           {{- end }}
+        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+        pathType: ImplementationSpecific
+        {{- end }}
 {{- if eq .Values.tls "ingress" }}
   tls:
   - hosts:


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/29874
https://github.com/rancher/rancher/issues/29144

Recreated the error, and successfully fixed it with this patch, using the default `ImplementationSpecific`: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#better-path-matching-with-path-types
