### PR TITLE
[Backport]2.4: Fix return err when secret webhook-receiver is not found

### DIFF
--- a/pkg/controllers/user/alert/configsyncer/configsyncer.go
+++ b/pkg/controllers/user/alert/configsyncer/configsyncer.go
@@ -121,7 +121,7 @@ func (d *ConfigSyncer) sync() error {
 	}
 
 	systemProjectName := project.Name
-	isDeployed, err := d.isAppDeploy(systemProjectName)
+	isDeployed, webhookReceiverEnabled, err := d.isAppDeploy(systemProjectName)
 	if err != nil {
 		return err
 	}
@@ -253,8 +253,10 @@ func (d *ConfigSyncer) sync() error {
 		logrus.Debug("The config stay the same, will not update the secret")
 	}
 
-	if err := d.syncReceiver(notifiers, cAlertGroupsMap, pAlertGroupsMap); err != nil {
-		return errors.Wrapf(err, "Update Webhook Receiver Config")
+	if webhookReceiverEnabled {
+		if err := d.syncWebhookConfig(notifiers, cAlertGroupsMap, pAlertGroupsMap); err != nil {
+			return errors.Wrapf(err, "Update Webhook Receiver Config")
+		}
 	}
 
 	return nil
@@ -642,22 +644,26 @@ func (d *ConfigSyncer) addRecipients(notifiers []*v3.Notifier, receiver *alertco
 
 }
 
-func (d *ConfigSyncer) isAppDeploy(appNamespace string) (bool, error) {
+func (d *ConfigSyncer) isAppDeploy(appNamespace string) (bool, bool, error) {
 	appName, _ := monitorutil.ClusterAlertManagerInfo()
 	app, err := d.appLister.Get(appNamespace, appName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return false, nil
+			return false, false, nil
 		}
 
-		return false, errors.Wrapf(err, "get app %s failed", appName)
+		return false, false, errors.Wrapf(err, "get app %s failed", appName)
 	}
 
 	if app.DeletionTimestamp != nil {
-		return false, nil
+		return false, false, nil
 	}
 
-	return true, nil
+	if webhookReceiverEnabled, ok := app.Spec.Answers[deployer.WebhookReceiverEnable]; ok && webhookReceiverEnabled == "true" {
+		return true, true, nil
+	}
+
+	return true, false, nil
 }
 
 func includeProjectMetrics(projectAlerts []*v3.ProjectAlertRule) bool {
@@ -703,7 +709,7 @@ func toAlertManagerURL(urlStr string) (*alertconfig.URL, error) {
 	return &alertconfig.URL{URL: url}, nil
 }
 
-func (d *ConfigSyncer) syncReceiver(notifiers []*v3.Notifier, cAlertGroupsMap map[string]*v3.ClusterAlertGroup, pAlertGroupsMap map[string]*v3.ProjectAlertGroup) error {
+func (d *ConfigSyncer) syncWebhookConfig(notifiers []*v3.Notifier, cAlertGroupsMap map[string]*v3.ClusterAlertGroup, pAlertGroupsMap map[string]*v3.ProjectAlertGroup) error {
 	var recipients []v3.Recipient
 	for _, group := range cAlertGroupsMap {
 		recipients = append(recipients, group.Spec.Recipients...)

--- a/pkg/controllers/user/alert/deployer/deployer.go
+++ b/pkg/controllers/user/alert/deployer/deployer.go
@@ -33,7 +33,7 @@ import (
 var (
 	creatorIDAnn          = "field.cattle.io/creatorId"
 	systemProjectLabel    = map[string]string{"authz.management.cattle.io/system-project": "true"}
-	webhookReceiverEnable = "webhook-receiver.enabled"
+	WebhookReceiverEnable = "webhook-receiver.enabled"
 
 	webhookReceiverTypes = []string{
 		"dingtalk",
@@ -318,9 +318,9 @@ func (d *appDeployer) deploy(appName, appTargetNamespace, systemProjectID string
 			return false, fmt.Errorf("stale %q App in %s Project is still on terminating", appName, systemProjectName)
 		}
 
-		if app.Spec.Answers[webhookReceiverEnable] != enableWebhookReceiver {
+		if app.Spec.Answers[WebhookReceiverEnable] != enableWebhookReceiver {
 			copy := app.DeepCopy()
-			copy.Spec.Answers[webhookReceiverEnable] = enableWebhookReceiver
+			copy.Spec.Answers[WebhookReceiverEnable] = enableWebhookReceiver
 			_, err := d.appsGetter.Apps(systemProjectName).Update(copy)
 			if err != nil {
 				return false, fmt.Errorf("failed to update %q App, %v", appName, err)
@@ -360,7 +360,7 @@ func (d *appDeployer) deploy(appName, appTargetNamespace, systemProjectID string
 				"alertmanager.enabledRBAC":            "false",
 				"alertmanager.configFromSecret":       secret.Name,
 				"operator.enabled":                    "false",
-				webhookReceiverEnable:                 enableWebhookReceiver,
+				WebhookReceiverEnable:                 enableWebhookReceiver,
 			},
 			Description:     "Alertmanager for Rancher Monitoring",
 			ExternalID:      templateVersion.ExternalID,


### PR DESCRIPTION
**Problem:**

The user has not configured an alert that requires webhook-receiver, but will still receive the error log `secret webhook-receiver is not found`.

**Solution:**

Execute `syncWebhookConfig` only when `webhook-receiver.enabled` is `true`

**Relate issue:**

https://github.com/rancher/rancher/issues/28954