### PR TITLE
Add LoadBalancerSKU support to AKS creation

### DIFF
--- a/pkg/kontainer-engine/drivers/aks/aks_driver_test.go
+++ b/pkg/kontainer-engine/drivers/aks/aks_driver_test.go
@@ -1,8 +1,10 @@
 package aks
 
 import (
+	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-10-01/containerservice"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,4 +25,12 @@ func Test_generateUniqueLogWorkspace(t *testing.T) {
 		assert.Equal(t, tt.want, got)
 		assert.Len(t, got, 63)
 	}
+}
+
+func TestLoadBalancerSKUDefault(t *testing.T) {
+	driver := NewDriver()
+	flags, err := driver.GetDriverCreateOptions(context.TODO())
+	a := assert.New(t)
+	a.NoError(err)
+	a.Equal(flags.Options["load-balancer-sku"].GetValue(), string(containerservice.Standard))
 }


### PR DESCRIPTION
Add LoadBalancerSKU support to AKS creation. We default to "Standard" by
default. Add unit test for the new functionality. Update existing code
to work with new Azure SDK module. Deprecate AgentStorageProfile.

Issue: #23715

```bash
[nickgerace at rancherbook in ~/git/rancher/pkg/kontainer-engine/drivers/aks] (0) (issue-23715)
% go test -v -run TestLoadBalancerSKU
=== RUN   TestLoadBalancerSKU
--- PASS: TestLoadBalancerSKU (0.00s)
PASS
ok  	github.com/rancher/rancher/pkg/kontainer-engine/drivers/aks	0.300s
```

Continuing work from @GGGitBoy: https://github.com/rancher/kontainer-engine/pull/201