### PR TITLE
[2.5] Add LoadBalancerSKU support to AKS creation

### DIFF
--- a/pkg/kontainer-engine/drivers/aks/aks_driver_test.go
+++ b/pkg/kontainer-engine/drivers/aks/aks_driver_test.go
@@ -1,8 +1,10 @@
 package aks
 
 import (
+	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-10-01/containerservice"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,4 +25,12 @@ func Test_generateUniqueLogWorkspace(t *testing.T) {
 		assert.Equal(t, tt.want, got)
 		assert.Len(t, got, 63)
 	}
+}
+
+func TestLoadBalancerSKUDefault(t *testing.T) {
+	driver := NewDriver()
+	flags, err := driver.GetDriverCreateOptions(context.TODO())
+	a := assert.New(t)
+	a.NoError(err)
+	a.Equal(flags.Options["load-balancer-sku"].GetValue(), string(containerservice.Standard))
 }


### PR DESCRIPTION
Add LoadBalancerSKU support to AKS creation. We default to "Standard" by
default. Add unit test for the new functionality. Update existing code
to work with new Azure SDK module. Deprecate AgentStorageProfile.

Co-authored-by: GGGitBoy <1812041288@qq.com>

Original PR: #29901 
Original Issue: #23715 