### PR TITLE
Prevent getting cluster.name when clusterClient returns an error

### DIFF
--- a/cmd/rancherd/auth/auth.go
+++ b/cmd/rancherd/auth/auth.go
@@ -31,7 +31,14 @@ var (
 	defaultAdminLabel      = map[string]string{defaultAdminLabelKey: defaultAdminLabelValue}
 )
 
-func ResetAdmin(_ *cli.Context) error {
+func ResetAdmin(ctx *cli.Context) error {
+	if err := resetAdmin(ctx); err != nil {
+		return errors.Wrap(err, "Cluster and rancher are not ready. Please try later! ")
+	}
+	return nil
+}
+
+func resetAdmin(_ *cli.Context) error {
 	ctx := context.Background()
 	token, err := randomtoken.Generate()
 	if err != nil {

--- a/cmd/rancherd/auth/auth.go
+++ b/cmd/rancherd/auth/auth.go
@@ -276,7 +276,7 @@ func ResetAdmin(_ *cli.Context) error {
 func setClusterAnnotation(ctx context.Context, clustersClient dynamic.NamespaceableResourceInterface, adminName string) error {
 	cluster, err := clustersClient.Get(ctx, "local", v1.GetOptions{})
 	if err != nil {
-		return errors.Errorf("Cluster %s is not ready yet", cluster.GetName())
+		return errors.Errorf("Local cluster is not ready yet")
 	}
 	if adminName == "" {
 		return errors.Errorf("User is not set yet")

--- a/cmd/rancherd/auth/auth.go
+++ b/cmd/rancherd/auth/auth.go
@@ -33,7 +33,7 @@ var (
 
 func ResetAdmin(ctx *cli.Context) error {
 	if err := resetAdmin(ctx); err != nil {
-		return errors.Wrap(err, "Cluster and rancher are not ready. Please try later! ")
+		return errors.Wrap(err, "cluster and rancher are not ready. Please try later.")
 	}
 	return nil
 }


### PR DESCRIPTION
To avoid the panic presented in https://github.com/rancher/rancher/issues/29565
remove cluster.GetName() call when clusterClient returns an error