### PR TITLE
Make security groups optional when VPC is provided

### DIFF
--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -399,18 +399,13 @@ func (v *Validator) validateEKSConfig(request *types.APIContext, cluster map[str
 	}
 
 	if !createFromImport {
-		// validate either all networking fields are provided or no networking fields are provided
+		// If security groups are provided, then subnets must also be provided
 		securityGroups, _ := eksConfig["securityGroups"].([]interface{})
 		subnets, _ := eksConfig["subnets"].([]interface{})
 
-		allNetworkingFieldsProvided := len(subnets) != 0 && len(securityGroups) != 0
-		noNetworkingFieldsProvided := len(subnets) == 0 && len(securityGroups) == 0
-
-		if !(allNetworkingFieldsProvided || noNetworkingFieldsProvided) {
-			if !createFromImport {
-				return httperror.NewAPIError(httperror.InvalidBodyContent,
-					"must provide both networking fields (subnets, securityGroups) or neither")
-			}
+		if len(securityGroups) != 0 && len(subnets) == 0 {
+			return httperror.NewAPIError(httperror.InvalidBodyContent,
+				"subnets must be provided if security groups are provided")
 		}
 	}
 


### PR DESCRIPTION
Previously, if a user provided a VPC ID, they were also required to
provide at least one security group. However, this requirement is
extraneous. So a user is able to provide a VPC ID and not provide any
security groups.

Conversely, if a user does provide security groups, then those security
groups are already attached to a VPC. Therefore, the VPC should be
provided as well.

Issue:
https://github.com/rancher/rancher/issues/29826

EKS Operator PR:
https://github.com/rancher/eks-operator/pull/21