### PR TITLE
HTTP proxy support for Rancher Continuous Delivery (fleet)

### DIFF
--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -74,6 +74,9 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 	if envVal, ok := os.LookupEnv("HTTP_PROXY"); ok {
 		gitjobChartValues["proxy"] = envVal
 	}
+	if envVal, ok := os.LookupEnv("HTTPS_PROXY"); ok {
+		gitjobChartValues["proxy"] = envVal
+	}
 	if envVal, ok := os.LookupEnv("NO_PROXY"); ok {
 		gitjobChartValues["noProxy"] = envVal
 	}

--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -69,7 +69,7 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 		"global":       systemGlobalRegistry,
 	}
 
-	gitjobChartValues := map[string]interface{}{}
+	gitjobChartValues :=  make(map[string]interface{})
 
 	if envVal, ok := os.LookupEnv("HTTP_PROXY"); ok {
 		gitjobChartValues["proxy"] = envVal

--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -74,9 +74,6 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 	if envVal, ok := os.LookupEnv("HTTP_PROXY"); ok {
 		gitjobChartValues["proxy"] = envVal
 	}
-	if envVal, ok := os.LookupEnv("HTTPS_PROXY"); ok {
-		gitjobChartValues["proxy"] = envVal
-	}
 	if envVal, ok := os.LookupEnv("NO_PROXY"); ok {
 		gitjobChartValues["noProxy"] = envVal
 	}

--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -69,7 +69,7 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 		"global":       systemGlobalRegistry,
 	}
 
-	gitjobChartValues :=  make(map[string]interface{})
+	gitjobChartValues := make(map[string]interface{})
 
 	if envVal, ok := os.LookupEnv("HTTP_PROXY"); ok {
 		gitjobChartValues["proxy"] = envVal


### PR DESCRIPTION
This PR, together with https://github.com/rancher/fleet/pull/143 and https://github.com/rancher/gitjob/pull/20, helps to propagate Rancher HTTP proxy settings to fleet system chart installation, which enables fleet to work with external git repositories in environments behind corporate proxy.
Fixes #30042