### PR TITLE
Set LoadBalancerSKU to empty string for AKS [2.5]

### DIFF
--- a/pkg/kontainer-engine/drivers/aks/aks_driver_test.go
+++ b/pkg/kontainer-engine/drivers/aks/aks_driver_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-10-01/containerservice"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,10 +26,12 @@ func Test_generateUniqueLogWorkspace(t *testing.T) {
 	}
 }
 
+// Test that the default LoadBalancerSKU is an empty string. We need this to maintain compatibility
+// with older AKS clusters without the LoadBalancerSKU field set upon creation.
 func TestLoadBalancerSKUDefault(t *testing.T) {
 	driver := NewDriver()
 	flags, err := driver.GetDriverCreateOptions(context.TODO())
 	a := assert.New(t)
 	a.NoError(err)
-	a.Equal(flags.Options["load-balancer-sku"].GetValue(), string(containerservice.Standard))
+	a.Equal(flags.Options["load-balancer-sku"].GetValue(), "")
 }


### PR DESCRIPTION
Set LoadBalancerSKU to empty string for AKS. This allows for the field
to be omitted for older AKS clusters.

Issue: https://github.com/rancher/rancher/issues/23715