### PR TITLE
Ignore Accessor error in role index

### DIFF
--- a/pkg/controllers/management/auth/indexes.go
+++ b/pkg/controllers/management/auth/indexes.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/rbac/v1"
 	meta2 "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,14 +35,15 @@ func rbRoleSubjectKeys(roleName string, subjects []v1.Subject) []string {
 }
 
 func indexByMembershipBindingOwner(obj interface{}) ([]string, error) {
-	obj, ok := obj.(runtime.Object)
+	ro, ok := obj.(runtime.Object)
 	if !ok {
 		return []string{}, nil
 	}
 
-	meta, err := meta2.Accessor(obj)
+	meta, err := meta2.Accessor(ro)
 	if err != nil {
-		return nil, err
+		logrus.Warnf("[indexByMembershipBindingOwner] unexpected object type: %T, err: %v", obj, err.Error())
+		return []string{}, nil
 	}
 
 	ns := meta.GetNamespace()


### PR DESCRIPTION
Problem:
If an object does not implement the correct interface the binding
indexer will error and no rbac changes will be processed

Solution:
Dont return the error because the indexer only gives back valid objects
anyways so this will allow rbac changes to continue despite an invalid
object in the cache

https://github.com/rancher/rancher/issues/29947