### PR TITLE
[2.4] Update Kontainer Engine to 4442123b5eaa

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/prometheus/common v0.9.1
 	github.com/prometheus/tsdb v0.8.0 // indirect
 	github.com/rancher/dynamiclistener v0.2.1-0.20200418023342-52ede5ec9234
-	github.com/rancher/kontainer-engine v0.0.4-dev.0.20201105021851-978771216b05
+	github.com/rancher/kontainer-engine v0.0.4-dev.0.20201106160106-4442123b5eaa
 	github.com/rancher/machine v0.15.0-rancher25
 	github.com/rancher/norman v0.0.0-20200806175025-f974dbfb2734
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a

--- a/go.sum
+++ b/go.sum
@@ -845,8 +845,8 @@ github.com/rancher/client-go v1.18.8-rancher.4/go.mod h1:HqFqMllQ5NnQJNwjro9k5zM
 github.com/rancher/dynamiclistener v0.2.1-0.20200213165308-111c5b43e932/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
 github.com/rancher/dynamiclistener v0.2.1-0.20200418023342-52ede5ec9234 h1:wZ1Zh7fI7B9hfZw9Ouhz7171CZKu6XffM3ysUhhO6i0=
 github.com/rancher/dynamiclistener v0.2.1-0.20200418023342-52ede5ec9234/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
-github.com/rancher/kontainer-engine v0.0.4-dev.0.20201105021851-978771216b05 h1:ZI4/iWMyJj8N9iTqLU37qHobeu5Dwk9iurroKIkAFoc=
-github.com/rancher/kontainer-engine v0.0.4-dev.0.20201105021851-978771216b05/go.mod h1:CofnuNGQefXjvq95fwXNVFJzOdrVW3ZUtQZC9ezQzHQ=
+github.com/rancher/kontainer-engine v0.0.4-dev.0.20201106160106-4442123b5eaa h1:ezPSQT6x5TIBUSmMg75VibTJJGZs2qEYNRHonaOx4ns=
+github.com/rancher/kontainer-engine v0.0.4-dev.0.20201106160106-4442123b5eaa/go.mod h1:CofnuNGQefXjvq95fwXNVFJzOdrVW3ZUtQZC9ezQzHQ=
 github.com/rancher/machine v0.15.0-rancher25 h1:i78iohBm9QLmxHOMM1ZssYwSNIObPdDUQjZ9h1mo8Jc=
 github.com/rancher/machine v0.15.0-rancher25/go.mod h1:Q7gKLOkNb8z8A/fYUhHFJ/ChJfpF8JVFxHPKZgEgpPA=
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009 h1:Xsxh7fX3+2wAUJtPy8g2lZh0cYuyifqhBL0vxCIYojs=

--- a/vendor/github.com/rancher/kontainer-engine/drivers/aks/aks_driver.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/aks/aks_driver.go
@@ -772,14 +772,9 @@ func (d *Driver) createOrUpdate(ctx context.Context, options *types.DriverOption
 		}
 	}
 
-	// Only set the LoadBalancerSKU if we are creating a cluster. If the LoadBalancerSKU is omitted, then set it to
-	// "Standard" as the default. If a LoadBalancerSKU is provided, then set it accordingly.
-	if create {
-		if driverState.LoadBalancerSku == "" {
-			networkProfile.LoadBalancerSku = containerservice.Standard
-		} else {
-			networkProfile.LoadBalancerSku = containerservice.LoadBalancerSku(driverState.LoadBalancerSku)
-		}
+	loadBalancerSku := containerservice.LoadBalancerSku(driverState.LoadBalancerSku)
+	if create && containerservice.Standard == loadBalancerSku {
+		networkProfile.LoadBalancerSku = loadBalancerSku
 	}
 
 	var agentPoolProfiles *[]containerservice.ManagedClusterAgentPoolProfile

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -369,7 +369,7 @@ github.com/rancher/dynamiclistener/server
 github.com/rancher/dynamiclistener/storage/file
 github.com/rancher/dynamiclistener/storage/kubernetes
 github.com/rancher/dynamiclistener/storage/memory
-# github.com/rancher/kontainer-engine v0.0.4-dev.0.20201105021851-978771216b05
+# github.com/rancher/kontainer-engine v0.0.4-dev.0.20201106160106-4442123b5eaa
 github.com/rancher/kontainer-engine/cluster
 github.com/rancher/kontainer-engine/drivers/aks
 github.com/rancher/kontainer-engine/drivers/eks


### PR DESCRIPTION
Update Kontainer Engine to 4442123b5eaa. This commit contains the
changes needed to only change the LoadBalancerSKU for AKS to standard if
provided.

KE PR: rancher/kontainer-engine#246
Original Issue: #23715