### PR TITLE
Fixes notification for helm chart promotion via right indentation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -881,11 +881,10 @@ steps:
   when:
     event:
       exclude:
-      - pull_request
-      instance:
-        include:
-        - drone-publish.rancher.io
-      status:
+        - pull_request
+    instance:
+      - drone-publish.rancher.io
+    status:
       - failure
 
 volumes:


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/30015

Tested with drone exec and exit codes, and it appears to correctly only fire on failure now.

Hard to tell from diff but this is the new code, I just de-indented instance and status
```
  when:
    event:
      exclude:
        - pull_request
    instance:
      - drone-publish.rancher.io
    status:
      - failure
```