### PR TITLE
fix the bug that test fails because 'NoneType' object has no attribute 'rstrip'

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -891,10 +891,11 @@ def validate_http_response(cmd, target_name_list, client_pod=None,
                 wget_cmd = "wget -qO- " + cmd
             result = kubectl_pod_exec(client_pod, wget_cmd)
             result = result.decode()
-        result = result.rstrip()
-        assert result in target_name_list
-        if result in target_hit_list:
-            target_hit_list.remove(result)
+        if result is not None:
+            result = result.rstrip()
+            assert result in target_name_list
+            if result in target_hit_list:
+                target_hit_list.remove(result)
     print("After removing all, the rest is: ", target_hit_list)
     assert len(target_hit_list) == 0
 

--- a/tests/validation/tests/v3_api/test_custom_host_reg.py
+++ b/tests/validation/tests/v3_api/test_custom_host_reg.py
@@ -54,8 +54,8 @@ def test_deploy_rancher_server():
             'sudo docker run -d --name="rancher-server" ' \
             '--restart=unless-stopped -p 80:80 -p 443:443  ' \
             'rancher/rancher'
-    print(RANCHER_SERVER_CMD)
     RANCHER_SERVER_CMD += ":" + RANCHER_SERVER_VERSION
+    print(RANCHER_SERVER_CMD)
     aws_nodes = AmazonWebServices().create_multiple_nodes(
         1, random_test_name("testsa" + HOST_NAME))
     aws_nodes[0].execute_command(RANCHER_SERVER_CMD)


### PR DESCRIPTION
1. fix the bug that test fails because 'NoneType' object has no attribute 'rstrip'
The error in logs:
```
>           result = result.rstrip()
E           AttributeError: 'NoneType' object has no attribute 'rstrip'

tests/v3_api/common.py:894: AttributeError
```

2. print the full RANCHER_SERVER_CMD 