### PR TITLE
[2.3] Handle rollback actions

### DIFF
--- a/pkg/api/store/workload/workload_store.go
+++ b/pkg/api/store/workload/workload_store.go
@@ -34,19 +34,21 @@ func NewWorkloadAggregateStore(schemas *types.Schemas, manager *clustermanager.M
 		schemas.Schema(&schema.Version, "job"),
 		schemas.Schema(&schema.Version, "cronJob"))
 
+	workloadConfig := workload.Config{
+		ClusterManager: manager,
+		Schemas:        store.Schemas,
+	}
+
 	for _, s := range store.Schemas {
 		if s.ID == "deployment" {
-			s.Formatter = workload.DeploymentFormatter
+			s.Formatter = workloadConfig.DeploymentFormatter
 		} else {
-			s.Formatter = workload.Formatter
+			s.Formatter = workloadConfig.Formatter
 		}
 	}
 
 	workloadSchema.Store = store
-	actionWrapper := workload.ActionWrapper{
-		ClusterManager: manager,
-	}
-	workloadSchema.ActionHandler = actionWrapper.ActionHandler
+	workloadSchema.ActionHandler = workloadConfig.ActionHandler
 	workloadSchema.LinkHandler = workload.Handler{}.LinkHandler
 }
 


### PR DESCRIPTION
Original PR: rancher/rancher#29710 

```bash
(rancher) [nickgerace at rancherbook in ~/git/rancher/tests/integration/suite] (0) (2.3-rollback-actions)
% pytest -k test_perform_mca_action_read_only
============================================================= test session starts =============================================================
platform darwin -- Python 3.8.6, pytest-4.4.1, py-1.9.0, pluggy-0.13.1
rootdir: /Users/nickgerace/git/rancher/tests/integration
plugins: metadata-1.10.0, repeat-0.8.0, html-1.20.0, xdist-1.28.0, ordering-0.6, forked-1.3.0
collected 243 items / 242 deselected / 1 selected                                                                                             

test_multi_cluster_app.py .                                                                                                             [100%]

================================================== 1 passed, 242 deselected in 7.65 seconds ===================================================
```