### PR TITLE
Add fleetworkspace admin, member and readonly roles

### DIFF
--- a/pkg/data/dashboard/add.go
+++ b/pkg/data/dashboard/add.go
@@ -40,5 +40,9 @@ func Add(ctx context.Context, wrangler *wrangler.Context, addLocal, removeLocal,
 		return err
 	}
 
+	if err := AddFleetRoles(wrangler); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/data/dashboard/fleet.go
+++ b/pkg/data/dashboard/fleet.go
@@ -1,0 +1,152 @@
+package dashboard
+
+import (
+	"reflect"
+
+	"github.com/rancher/rancher/pkg/features"
+	"github.com/rancher/rancher/pkg/wrangler"
+	rbacv1 "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func AddFleetRoles(wrangler *wrangler.Context) error {
+	f, err := wrangler.Mgmt.Feature().Get("fleet", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if !features.IsEnabled(f) {
+		return nil
+	}
+
+	return ensureFleetRoles(wrangler.RBAC)
+}
+
+func ensureFleetRoles(rbac rbacv1.Interface) error {
+	fleetWorkspaceAdminRole := v1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fleetworkspace-admin",
+		},
+		Rules: []v1.PolicyRule{
+			{
+				APIGroups: []string{
+					"fleet.cattle.io",
+				},
+				Resources: []string{
+					"clusterregistrationtokens",
+					"gitreporestrictions",
+					"clusterregistrations",
+					"clusters",
+					"gitrepos",
+					"bundles",
+					"clustergroups",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+			{
+				APIGroups: []string{
+					"rbac.authorization.k8s.io",
+				},
+				Resources: []string{
+					"rolebindings",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+		},
+	}
+
+	fleetWorkspaceMemberRole := v1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fleetworkspace-member",
+		},
+		Rules: []v1.PolicyRule{
+			{
+				APIGroups: []string{
+					"fleet.cattle.io",
+				},
+				Resources: []string{
+					"gitrepos",
+					"bundles",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+			{
+				APIGroups: []string{
+					"fleet.cattle.io",
+				},
+				Resources: []string{
+					"clusterregistrationtokens",
+					"gitreporestrictions",
+					"clusterregistrations",
+					"clusters",
+					"clustergroups",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
+		},
+	}
+
+	fleetWorkspaceReadonlyRole := v1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fleetworkspace-readonly",
+		},
+		Rules: []v1.PolicyRule{
+			{
+				APIGroups: []string{
+					"fleet.cattle.io",
+				},
+				Resources: []string{
+					"clusterregistrationtokens",
+					"gitreporestrictions",
+					"clusterregistrations",
+					"clusters",
+					"gitrepos",
+					"bundles",
+					"clustergroups",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
+		},
+	}
+
+	clusterRoles := []v1.ClusterRole{
+		fleetWorkspaceAdminRole,
+		fleetWorkspaceMemberRole,
+		fleetWorkspaceReadonlyRole,
+	}
+
+	for _, role := range clusterRoles {
+		existing, err := rbac.ClusterRole().Get(role.Name, metav1.GetOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		} else if errors.IsNotFound(err) {
+			if _, err := rbac.ClusterRole().Create(&role); err != nil {
+				return err
+			}
+		} else {
+			if !reflect.DeepEqual(existing.Rules, role.Rules) {
+				if _, err := rbac.ClusterRole().Update(&role); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/data/management/add.go
+++ b/pkg/data/management/add.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 )
 
-func Add(wrangler *wrangler.Context, management *config.ManagementContext, addLocal, removeLocal, embedded bool) error {
+func Add(wrangler *wrangler.Context, management *config.ManagementContext) error {
 	_, err := addRoles(wrangler, management)
 	if err != nil {
 		return err

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -94,6 +94,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("kontainerdrivers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("nodetemplates").verbs("create").
+		addRule().apiGroups("management.cattle.io").resources("fleetworkspaces").verbs("create").
 		addRule().apiGroups("").resources("secrets").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("multiclusterapps", "globaldnses", "globaldnsproviders", "clustertemplaterevisions").verbs("create").
 		addRule().apiGroups("project.cattle.io").resources("sourcecodecredentials").verbs("*").

--- a/pkg/multiclustermanager/app.go
+++ b/pkg/multiclustermanager/app.go
@@ -189,7 +189,7 @@ func (m *mcm) Start(ctx context.Context) error {
 				return errors.Wrap(err, "failed to create management context")
 			}
 
-			if err := managementdata.Add(m.wranglerContext, management, m.localClusterEnabled, m.removeLocalCluster, m.embedded); err != nil {
+			if err := managementdata.Add(m.wranglerContext, management); err != nil {
 				return errors.Wrap(err, "failed to add management data")
 			}
 


### PR DESCRIPTION
This PR add three built-in clusterRoles in local cluster that user can create roleBinding for:
1. Fleetworkspace admin:
Full permission on regular fleet resource(gitrepo,bundle...) 
Full permissionon clusterregistrations and clusterregistrationtokens
Full permission roleBindings
2. Fleetworkspace member
Full permissionon regular fleet resource(gitrepo,bundle...) 
3. Fleetworkspace readonly
Readonly permission on regular fleet resource(gitrepo,bundle...)

Also the standard user will now have the ability to create fleet workspace. Once a user created a fleetworkspace it is granted Fleetworkspace admin role in the fleet namespace + full permission on the current fleetworkspace. This also grants admin the ability to add cluster into fleetworkspace too since it has `*` verb. This is done through https://github.com/rancher/webhook/pull/13.

Admin will have the ability to add user into its own fleetworkspace by creating rolebindings. It can grant user member/readonly roles by creating rolebinding with built-in roles, and also can give user the ability to see fleetworkspace itself(by creating a view clusterrole that has `get` verb to the current workspace and clusterrolebindings to that user)