### PR TITLE
Updated apiVersion for ClusterRoleBinding to avoid deprecation warning

### DIFF
--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -44,7 +44,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cattle-admin-binding


### PR DESCRIPTION
Fix for https://github.com/rancher/rancher/issues/30043