### PR TITLE
Allow communication with EKS clusters with private API endpoint

### DIFF
--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -11,10 +11,9 @@ import (
 	"strings"
 	"sync"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/rancher/norman/httperror"
-	factory "github.com/rancher/rancher/pkg/dialer"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	dialer2 "github.com/rancher/rancher/pkg/dialer"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config/dialer"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -173,7 +172,7 @@ func (r *RemoteService) getTransport() (http.RoundTripper, error) {
 			return nil, err
 		}
 		transport.DialContext = d
-		if factory.IsCloudDriver(newCluster) {
+		if dialer2.IsPublicCloudDriver(newCluster) {
 			transport.Proxy = http.ProxyFromEnvironment
 		}
 	}

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -10,12 +10,12 @@ import (
 	"sync"
 	"time"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	util "github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/clustermanager"
+	"github.com/rancher/rancher/pkg/dialer"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/image"
 	"github.com/rancher/rancher/pkg/kubectl"
@@ -219,6 +219,11 @@ func getDesiredImage(cluster *v3.Cluster) string {
 }
 
 func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
+	if dialer.HasPublicAPIEndpoint(cluster) {
+		logrus.Debugf("clusterDeploy: deployAgent: cluster [%s] is private so agent cannot be deployed automatically", cluster.Name)
+		return nil
+	}
+
 	if cluster.Spec.Internal {
 		return nil
 	}


### PR DESCRIPTION
Rancher is able to import and create clusters with private API endpoint, but is not able to communicate with them afterwards. Now, as long as the agent is deployed, rancher is able to tunnel to communicate with the API.

Issue:
https://github.com/rancher/rancher/issues/29907