### PR TITLE
Move creation of accesscontrol

### DIFF
--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -121,20 +121,21 @@ func (m *Manager) start(ctx context.Context, cluster *v3.Cluster, controllers, c
 		m.Stop(obj.(*record).clusterRec)
 	}
 
-	controller, err := m.toRecord(ctx, cluster)
+	clusterRecord, err := m.toRecord(ctx, cluster)
 	if err != nil {
 		m.markUnavailable(cluster.Name)
 		return nil, err
 	}
-	if controller == nil {
+	if clusterRecord == nil {
 		return nil, httperror.NewAPIError(httperror.ClusterUnavailable, "cluster not found")
 	}
 
-	obj, _ = m.controllers.LoadOrStore(cluster.UID, controller)
+	obj, _ = m.controllers.LoadOrStore(cluster.UID, clusterRecord)
 	if err := m.startController(obj.(*record), controllers, clusterOwner); err != nil {
 		m.markUnavailable(cluster.Name)
 		return nil, err
 	}
+
 	return obj.(*record), nil
 }
 
@@ -221,6 +222,10 @@ func (m *Manager) doStart(rec *record, clusterOwner bool) (exit error) {
 	done := make(chan error, 1)
 	go func() {
 		defer close(done)
+
+		logrus.Debugf("[clustermanager] creating AccessControl for cluster %v", rec.cluster.ClusterName)
+		rec.accessControl = rbac.NewAccessControl(rec.ctx, rec.cluster.ClusterName, rec.cluster.RBACw)
+
 		err := rec.cluster.Start(rec.ctx)
 		if err == nil {
 			transaction.Commit()
@@ -386,9 +391,8 @@ func (m *Manager) toRecord(ctx context.Context, cluster *v3.Cluster) (*record, e
 	}
 
 	s := &record{
-		cluster:       clusterContext,
-		clusterRec:    cluster,
-		accessControl: rbac.NewAccessControl(ctx, cluster.Name, clusterContext.RBACw),
+		cluster:    clusterContext,
+		clusterRec: cluster,
 	}
 	s.ctx, s.cancel = context.WithCancel(ctx)
 


### PR DESCRIPTION
Problem:
When a cluster agent is diconnected rancher tries to start the
controllers in a slow loop, but this causes a memory leak. The leak
stems from adding a handler in client-go which has no method to
deregister the handler so a fixed size array leaks every time.

Solution:
Don't create access control until Rancher has verified a connection to
the cluster which is a good indication controllers will start. There is
technically a small leak here every time we start these controllers.

Issue: https://github.com/rancher/rancher/issues/29429