### PR TITLE
Add nil check for version on status

### DIFF
--- a/pkg/catalog/manager/manager.go
+++ b/pkg/catalog/manager/manager.go
@@ -226,6 +226,10 @@ func (m *Manager) ValidateKubeVersion(template *v3.CatalogTemplateVersion, clust
 		return err
 	}
 
+	if cluster.Status.Version == nil {
+		return fmt.Errorf("cluster [%s] status version is not available yet. Cannot validate kube version for template [%s]", clusterName, template.Name)
+	}
+
 	k8sVersion, err := semver.Parse(strings.TrimPrefix(cluster.Status.Version.String(), "v"))
 	if err != nil {
 		return err


### PR DESCRIPTION
**Problem:**
Prior, version could be accessed before it was set. This would occur on clusters that were newly provisioned or in the process of being provisioned and did not have version set yet.

**Solution:**
Added nil check for version on status. Now, if the version is not set an error will be returned so that controllers can retry until version is available.

**Issue:**
https://github.com/rancher/rancher/issues/30143