### PR TITLE
Fix set default namespace's limitRange bug

### DIFF
--- a/pkg/api/norman/store/namespace/store.go
+++ b/pkg/api/norman/store/namespace/store.go
@@ -18,7 +18,7 @@ import (
 )
 
 const quotaField = "resourceQuota"
-const containerRecsourceLimitField = "containerDefaultResourceLimit"
+const containerResourceLimitField = "containerDefaultResourceLimit"
 
 func New(store types.Store) types.Store {
 	t := &transform.Store{
@@ -156,9 +156,9 @@ func (p *Store) validateResourceQuota(apiContext *types.APIContext, schema *type
 	}
 
 	// set default resource limit
-	limit := data[containerRecsourceLimitField]
-	if limit == nil {
-		data[containerRecsourceLimitField] = project.ContainerDefaultResourceLimit
+	crlMap := convert.ToMapInterface(data[containerResourceLimitField])
+	if len(crlMap) <= 0 {
+		data[containerResourceLimitField] = project.ContainerDefaultResourceLimit
 	}
 
 	isFit, msg, err := resourcequota.IsQuotaFit(nsQuotaLimit, nsLimits, projectQuotaLimit)


### PR DESCRIPTION
#18877

`data[containerResourceLimitField]` will not be nil, because the UI passes an empty `map[]` object, not nil.

# How to reproduce
  1. create a project with `Resource Quotas`
  2. create a namespace under the project which you created
  3. edit project: set `Container Default Resource Limit`
  4. edit & save namespace

Then take a look at namespace, you will find namespace's `Container Default Resource Limit` is empty.


Signed-off-by: Jason-ZW <zhenyang@rancher.com>