### PR TITLE
Create and upgrade multiple k3s clusters with validation tests

### DIFF
--- a/tests/validation/tests/v3_api/resource/terraform/master/instances_server.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/master/instances_server.tf
@@ -1,5 +1,5 @@
 resource "aws_db_instance" "db" {
-  identifier = "${var.resource_name}-multinode-db"
+  identifier = "${var.resource_name}-db"
   allocated_storage    = 20
   storage_type         = "gp2"
   engine               = var.external_db
@@ -29,7 +29,7 @@ resource "aws_instance" "master" {
   vpc_security_group_ids = ["${var.sg_id}"]
   key_name = "jenkins-rke-validation"
   tags = {
-    Name = "${var.resource_name}-multinode-server"
+    Name = "${var.resource_name}-server"
   }
   provisioner "remote-exec" {
     inline = [
@@ -64,7 +64,7 @@ resource "aws_instance" "master2-ha" {
   vpc_security_group_ids = ["${var.sg_id}"]
   key_name = "jenkins-rke-validation"
   tags = {
-    Name = "${var.resource_name}-multinode-servers"
+    Name = "${var.resource_name}-servers"
   }
   provisioner "remote-exec" {
     inline = [
@@ -82,7 +82,7 @@ resource "aws_lb_target_group" "aws_tg_80" {
   port             = 80
   protocol         = "TCP"
   vpc_id           = "${var.vpc_id}"
-  name             = "${var.resource_name}-multinode-tg-80"
+  name             = "${var.resource_name}-tg-80"
   health_check {
         protocol = "HTTP"
         port = "traffic-port"
@@ -115,7 +115,7 @@ resource "aws_lb_target_group" "aws_tg_443" {
   port             = 443
   protocol         = "TCP"
   vpc_id           = "${var.vpc_id}"
-  name             = "${var.resource_name}-multinode-tg-443"
+  name             = "${var.resource_name}-tg-443"
   health_check {
         protocol = "HTTP"
         port = 80
@@ -148,7 +148,7 @@ resource "aws_lb_target_group" "aws_tg_6443" {
   port             = 6443
   protocol         = "TCP"
   vpc_id           = "${var.vpc_id}"
-  name             = "${var.resource_name}-multinode-tg-6443"
+  name             = "${var.resource_name}-tg-6443"
 }
 
 resource "aws_lb_target_group_attachment" "aws_tg_attachment_6443" {
@@ -171,7 +171,7 @@ resource "aws_lb" "aws_nlb" {
   internal           = false
   load_balancer_type = "network"
   subnets            = ["${var.subnets}"] 
-  name               = "${var.resource_name}-multinode-nlb"
+  name               = "${var.resource_name}-nlb"
 }
 
 resource "aws_lb_listener" "aws_nlb_listener_80" {

--- a/tests/validation/tests/v3_api/resource/terraform/worker/instances_worker.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/worker/instances_worker.tf
@@ -13,7 +13,7 @@ resource "aws_instance" "mysql-worker" {
   vpc_security_group_ids = ["${var.sg_id}"]
   key_name = "jenkins-rke-validation"
   tags          = {
-    Name = "${var.resource_name}-multinode-worker"
+    Name = "${var.resource_name}-worker"
   }
   provisioner "remote-exec" {
     inline      = [

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_k3s_upgrade
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_k3s_upgrade
@@ -1,0 +1,188 @@
+#!groovy
+
+def needs_cluster(py_options, upgrade_check, create_resource_prefix) {
+    try {
+      jobs = [:]
+      cluster_arr = env.RANCHER_CLUSTER_NAMES.split(",")
+      version_arr = env.RANCHER_CLUSTER_UPGRADE_VERSIONS.split(",")
+      cluster_count = cluster_arr.size()
+      RANCHER_UPGRADE_CHECK = "upgrade_cluster"
+      RANCHER_VALIDATE_RESOURCES_PREFIX = "mystep1"
+      for (int i = 0; i < cluster_count; i++) {
+        def params = [
+          string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"),
+          string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}"),
+          string(name: 'USER_TOKEN', value: "${USER_TOKEN}"),
+          string(name: 'RANCHER_CLUSTER_NAME', value: "${cluster_arr[i]}"),
+          string(name: 'PYTEST_OPTIONS', value: "-k ${py_options}"),
+          string(name: 'RANCHER_UPGRADE_CHECK', value: "${upgrade_check}"),
+          string(name: 'RANCHER_CLUSTER_UPGRADE_VERSION', value: "${version_arr[i]}"),
+          string(name: 'RANCHER_VALIDATE_RESOURCES_PREFIX', value: "${RANCHER_VALIDATE_RESOURCES_PREFIX}"),
+          string(name: 'RANCHER_CREATE_RESOURCES_PREFIX', value: "${create_resource_prefix}"),
+        ]
+        echo "Params are: ${params}"
+        jobs["test-${i}"] = { build job: 'rancher-v3_needs_cluster', parameters: params }
+      }
+      parallel jobs
+  } catch(err) {
+      echo "Error: " + err
+      currentBuild.result = 'UNSTABLE'
+  }
+}
+
+node {
+  def rootPath = "/src/rancher-validation/"
+  def job_name = "${JOB_NAME}"
+  if (job_name.contains('/')) { 
+    job_names = job_name.split('/')
+    job_name = job_names[job_names.size() - 1] 
+  }
+
+  def setupContainer = "${job_name}${env.BUILD_NUMBER}_setup"
+  def clusterSetupContainer = "${job_name}${env.BUILD_NUMBER}_cluster_setup"
+
+  def deployPytestOptions = "-k test_deploy_rancher_server"
+  def deployClusterPytestOptions = "-k test_deploy_k3s"
+
+  def setupResultsOut = "setup-results.xml"
+  def imageName = "rancher-validation-${job_name}${env.BUILD_NUMBER}"
+  def testsDir = "tests/v3_api/"
+
+  def envFile = ".env"
+  def rancherConfig = "rancher_env.config"
+
+  def branch = "master"
+  if ("${env.branch}" != "null" && "${env.branch}" != "") {
+    branch = "${env.branch}"
+  }
+
+  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+    withFolderProperties {
+      withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                        string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+                        string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                        string(credentialsId: 'RANCHER_SSH_KEY', variable: 'RANCHER_SSH_KEY'),
+                        string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                        string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD')]) {
+        stage('Checkout') {
+          deleteDir()
+          checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: "*/${branch}"]],
+                    extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                    userRemoteConfigs: scm.userRemoteConfigs
+                  ])
+        }
+
+        dir ("tests/validation") {
+          try {
+            stage('Configure and Build') {
+              if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
+                dir(".ssh") {
+                  def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
+                  writeFile file: AWS_SSH_KEY_NAME, text: decoded
+                }
+              }
+
+              sh "./tests/v3_api/scripts/configure.sh"
+              sh "./tests/v3_api/scripts/build.sh"
+            }
+
+            stage('Deploy Rancher Server') {
+              try {
+                if (!env.CATTLE_TEST_URL.trim() && !env.ADMIN_TOKEN.trim() && !env.USER_TOKEN.trim()) {
+                  // deploy rancher server
+                  sh "docker run --name ${setupContainer} -t --env-file ${envFile} " +
+                    "${imageName} /bin/bash -c \'export RANCHER_AUTO_DEPLOY_CUSTOM_CLUSTER=False " +
+                    "&& pytest -v -s --junit-xml=${setupResultsOut} " +
+                    "${deployPytestOptions} ${testsDir}\'"
+                  RANCHER_DEPLOYED = true
+
+                  // copy file containing CATTLE_TEST_URL, ADMIN_TOKEN, USER_TOKEN and load into environment variables
+                  sh "docker cp ${setupContainer}:${rootPath}${testsDir}${rancherConfig} ."
+                  load rancherConfig
+                }
+                else {
+                  echo "User Provided Rancher Server"
+                  RANCHER_DEPLOYED = false
+                }
+
+              } catch(err) {
+                echo "Error: " + err
+                RANCHER_DEPLOYED = false
+              }
+            }
+
+            stage('Deploy k3s Clusters') {
+              try {
+                  echo "Deploying k3s clusters. Versions: ${RANCHER_K3S_VERSIONS}. Names: ${RANCHER_CLUSTER_NAMES}"
+                  jobs = [:]
+                  k3s_versions = RANCHER_K3S_VERSIONS.split(",")
+                  cluster_arr = RANCHER_CLUSTER_NAMES.split(",")
+                  cluster_count = cluster_arr.size()
+                  for (int i = 0; i < cluster_count; i++) {
+                    def params = [
+                      string(name: 'RANCHER_HOSTNAME_PREFIX', value: "${cluster_arr[i]}"),
+                      string(name: 'RANCHER_CLUSTER_NAME', value: "${cluster_arr[i]}"),
+                      string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"),
+                      string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}"),
+                      string(name: 'USER_TOKEN', value: "${USER_TOKEN}"),
+                      string(name: 'RANCHER_K3S_NO_OF_SERVER_NODES', value: "${RANCHER_K3S_NO_OF_SERVER_NODES}"),
+                      string(name: 'RANCHER_K3S_NO_OF_WORKER_NODES', value: "${RANCHER_K3S_NO_OF_WORKER_NODES}"),
+                      string(name: 'RANCHER_K3S_VERSION', value: "${k3s_versions[i]}"),
+                      string(name: 'AWS_AMI', value: "${K3S_AWS_AMI}"),
+                      string(name: 'RANCHER_K3S_SERVER_FLAGS', value: "${RANCHER_K3S_SERVER_FLAGS}"),
+                      string(name: 'RANCHER_K3S_WORKER_FLAGS', value: "${RANCHER_K3S_WORKER_FLAGS}"),
+                      string(name: 'RANCHER_DB_USERNAME', value: "${RANCHER_DB_USERNAME}"),
+                      string(name: 'RANCHER_DB_PASSWORD', value: "${RANCHER_DB_PASSWORD}"),
+                      string(name: 'AWS_USER', value: "${AWS_USER}"),
+                      string(name: 'RANCHER_EXTERNAL_DB', value: "${RANCHER_EXTERNAL_DB}"),
+                      string(name: 'RANCHER_EXTERNAL_DB_VERSION', value: "${RANCHER_EXTERNAL_DB_VERSION}"),
+                      string(name: 'RANCHER_INSTANCE_CLASS', value: "${RANCHER_INSTANCE_CLASS}"),
+                      string(name: 'RANCHER_DB_GROUP_NAME', value: "${RANCHER_DB_GROUP_NAME}"),
+                    ]
+                    echo "Params are: ${params}"
+                    jobs["test-${i}"] = { build job: 'rancher_v3_import_k3s_ha_cluster', parameters: params }
+                  }
+                  parallel jobs
+                  CLUSTERS_CREATED = true
+              } catch(err) {
+                  echo "Error: " + err
+                  currentBuild.result = 'UNSTABLE'
+              }
+            }
+
+            stage('Run Preupgrade Tests in Parallel') {
+              needs_cluster("test_upgrade", "preupgrade", "mystep1")
+            }
+
+            stage('Upgrade Clusters') {
+              echo "Upgrading clusters from versions: ${RANCHER_K3S_VERSIONS} to ${RANCHER_CLUSTER_UPGRADE_VERSIONS}"
+              needs_cluster("test_cluster_upgrade", "upgrade_cluster", "mystep1")
+            }
+
+            stage('Run Postupgrade Tests in Parallel') {
+              needs_cluster("test_upgrade", "postupgrade", "mystep2")
+            }
+
+          } catch(err) {
+            echo "Error: " + err
+          } finally {
+
+            stage('Test Report') {
+              // copy and archive test results
+              if (RANCHER_DEPLOYED) {
+                sh "docker cp ${setupContainer}:${rootPath}${setupResultsOut} ."
+                sh "docker stop ${setupContainer}"
+                sh "docker rm -v ${setupContainer}"
+                step([$class: 'JUnitResultArchiver', testResults: "**/${setupResultsOut}"])
+              }
+            }
+
+            sh "docker rmi ${imageName}"
+          } // finally
+        } // dir
+      } // creds
+    } // folder properties
+  } // wrap
+} // node

--- a/tests/validation/tests/v3_api/test_custom_host_reg.py
+++ b/tests/validation/tests/v3_api/test_custom_host_reg.py
@@ -115,6 +115,10 @@ def test_deploy_rancher_server():
     env_details += "env.ADMIN_TOKEN='" + token + "'\n"
     env_details += "env.USER_TOKEN='" + user_token + "'\n"
 
+    if UPDATE_KDM:
+        update_and_validate_kdm(KDM_URL, admin_token=token,
+                                rancher_api_url=RANCHER_SERVER_URL + "/v3")
+
     if AUTO_DEPLOY_CUSTOM_CLUSTER:
         aws_nodes = \
             AmazonWebServices().create_multiple_nodes(
@@ -141,6 +145,7 @@ def test_deploy_rancher_server():
             i += 1
         validate_cluster_state(client, cluster)
         env_details += "env.CLUSTER_NAME='" + cluster.name + "'\n"
+
     create_config_file(env_details)
 
 

--- a/tests/validation/tests/v3_api/test_deploy_clusters.py
+++ b/tests/validation/tests/v3_api/test_deploy_clusters.py
@@ -6,11 +6,6 @@ from .test_gke_cluster import get_gke_config, \
 from .test_rke_cluster_provisioning import create_and_validate_custom_host
 from .test_import_cluster import create_and_validate_import_cluster
 
-KDM_BRANCH = os.environ.get('RANCHER_KDM_BRANCH', "")
-KDM_URL = os.environ.get(
-    "RANCHER_KDM_URL",
-    "https://github.com/rancher/kontainer-driver-metadata.git")
-
 env_details = "env.RANCHER_CLUSTER_NAMES='"
 cluster_details = {"rke": {}, "rke_import": {},
                    "eks": {}, "aks": {}, "gke": {}}
@@ -176,29 +171,8 @@ def test_deploy_aks():
 
 @pytest.fixture(scope='module', autouse="True")
 def set_data(request):
-    print("In set_data function")
-    if KDM_BRANCH != "":
-        print("Updating KDM to use {}/tree/{}".format(KDM_URL, KDM_BRANCH))
-        header = {'Authorization': 'Bearer ' + ADMIN_TOKEN}
-        kdm_url = CATTLE_API_URL + "/settings/rke-metadata-config"
-        kdm_json = {
-            "name": "rke-metadata-config",
-            "value": json.dumps({
-                "branch": KDM_BRANCH,
-                "refresh-interval-minutes": "1440",
-                "url": KDM_URL
-            })
-        }
-        r = requests.put(kdm_url, verify=False, headers=header, json=kdm_json)
-        r_content = json.loads(r.content)
-        assert r.ok
-        assert r_content['name'] == kdm_json['name']
-        assert r_content['value'] == kdm_json['value']
-
-        # Refresh Kubernetes Metadata
-        kdm_refresh_url = CATTLE_API_URL + "/kontainerdrivers?action=refresh"
-        response = requests.post(kdm_refresh_url, verify=False, headers=header)
-        assert response.ok
+    if UPDATE_KDM is True:
+        update_and_validate_kdm(KDM_URL)
 
     def fin():
         global env_details

--- a/tests/validation/tests/v3_api/test_upgrade.py
+++ b/tests/validation/tests/v3_api/test_upgrade.py
@@ -23,6 +23,7 @@ sshUser = os.environ.get('RANCHER_SSH_USER', "ubuntu")
 rancherVersion = os.environ.get('RANCHER_SERVER_VERSION', "master")
 upgradeVersion = os.environ.get('RANCHER_SERVER_VERSION_UPGRADE', "master")
 upgradeImage = os.environ.get('RANCHER_UPGRADE_IMAGE', "rancher/rancher")
+CLUSTER_VERSION = os.environ.get('RANCHER_CLUSTER_UPGRADE_VERSION', "")
 
 value = base64.b64encode(b"valueall")
 keyvaluepair = {"testall": value.decode('utf-8')}
@@ -89,6 +90,9 @@ if_validate_ingress = pytest.mark.skipif(
 if_upgrade_rancher = pytest.mark.skipif(
     upgrade_check_stage != "upgrade_rancher",
     reason='This test is only for testing upgrading Rancher')
+if_upgrade_cluster = pytest.mark.skipif(
+    upgrade_check_stage != "upgrade_cluster",
+    reason='This test is only for testing upgrading clusters')
 
 
 @if_post_upgrade
@@ -230,6 +234,15 @@ def test_rancher_upgrade():
     client = get_user_client()
     version = client.list_setting(name="server-version").data[0].value
     assert version == upgradeVersion
+
+
+# the flag if_upgrade_cluster is false all the time
+# because we do not have this option for the variable RANCHER_UPGRADE_CHECK
+# instead, we will have a new pipeline that calls this function directly
+@if_upgrade_cluster
+def test_cluster_upgrade():
+    upgrade_cluster()
+    wait_for_ready_nodes()
 
 
 def create_and_validate_wl():
@@ -625,6 +638,38 @@ def upgrade_rancher_server(serverIp,
           sshUser, sshKeyPath))
 
     wait_until_active(CATTLE_TEST_URL)
+
+
+def upgrade_cluster():
+    print("Upgrading cluster {} to version {}".format(
+        CLUSTER_NAME, CLUSTER_VERSION))
+    client, cluster = get_user_client_and_cluster()
+    if cluster.k3sConfig:
+        k3s_config = cluster.k3sConfig
+        k3s_updated_config = k3s_config.copy()
+        k3s_updated_config["kubernetesVersion"] = CLUSTER_VERSION
+        client.update(cluster, name=cluster.name, k3sConfig=k3s_updated_config)
+        cluster = get_cluster_by_name(client, CLUSTER_NAME)
+        assert cluster.k3sConfig["kubernetesVersion"] == CLUSTER_VERSION
+
+
+def wait_for_ready_nodes():
+    client, cluster = get_user_client_and_cluster()
+    start = time.time()
+    nodes = client.list_node(clusterId=cluster.id).data
+    unready_nodes = []
+    for node in nodes:
+        unready_nodes.append(node.id)
+    while unready_nodes and time.time() - start < MACHINE_TIMEOUT:
+        nodes = client.list_node(clusterId=cluster.id).data
+        for node in nodes:
+            if node.info.kubernetes.kubeletVersion == CLUSTER_VERSION:
+                time.sleep(5)
+                wait_for_node_status(client, node, "active")
+                if node.id in unready_nodes:
+                    unready_nodes.remove(node.id)
+    assert not unready_nodes, "Nodes did not successfully upgrade " \
+                              "within the timeout"
 
 
 def create_and_validate_catalog_app():


### PR DESCRIPTION
- Adds Jenkins job to import multiple k3s clusters, run preupgrade, upgrade, and run postupgrade jobs
- Adds upgrade_cluster code for k3s clusters
- Removes some extraneous prints and "multinode" text from k3s creation code