### PR TITLE
Retry on conflict for enable monitoring actions

### DIFF
--- a/pkg/api/norman/customization/cluster/utils.go
+++ b/pkg/api/norman/customization/cluster/utils.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/types/values"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 	authV1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -20,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	clientauthv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 type noopCloser struct {
@@ -150,4 +152,19 @@ func CanCreateRKETemplate(callerID string, subjectAccessReviewClient clientauthv
 	}
 	logrus.Debugf("CanCreateRKETemplate: %v", result)
 	return result.Status.Allowed, nil
+}
+
+// updateClusterWithRetryOnConflict attempts to update the cluster with the changes encoded in the updateFunc. It only retries if a conflict error is returned.
+func updateClusterWithRetryOnConflict(clusterClient v3.ClusterInterface, cluster *v3.Cluster, updateFunc func(*v3.Cluster) *v3.Cluster) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		currentCluster, err := clusterClient.Get(cluster.Name, v12.GetOptions{})
+		if err != nil {
+			return err
+		}
+		cluster = updateFunc(currentCluster)
+		if _, err = clusterClient.Update(cluster); err != nil {
+			return err
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
This commit introduces changes to try harder to prevent the following error from appearing:
```
2020/11/25 15:53:58 [ERROR] API error response 500 for POST /v3/clusters/c-l4bdt?action=enableMonitoring. Cause: Operation cannot be fulfilled on clusters.management.cattle.io "c-l4bdt": the object has been modified; please apply your changes to the latest version and try again
```

The root cause of this error is that we do not normally retry on a conflict, so before it was appearing even after spinning up just 4 clusters in succession and trying to immediately enable monitoring.

~Now the error still appears, but it appears extremely infrequently (around 1 in every 12 if you just hammer the API at the same time).~ **(fixed)**

Related Issue: https://github.com/rancher/rancher/issues/30188

This will be backported to 2.4 / 2.5 line after merge.