### PR TITLE
Add ability to force an App Answer to string

### DIFF
--- a/pkg/api/norman/customization/app/app.go
+++ b/pkg/api/norman/customization/app/app.go
@@ -130,21 +130,29 @@ func (w Wrapper) ActionHandler(actionName string, action *types.Action, apiConte
 		}
 
 		answers := actionInput["answers"]
+		answersForceString := actionInput["answersForceString"]
 		forceUpgrade := actionInput["forceUpgrade"]
 		files := actionInput["files"]
 		valuesYaml := actionInput["valuesYaml"]
 
+		obj.Spec.Answers = make(map[string]string)
 		if answers != nil {
-			m, ok := answers.(map[string]interface{})
-			if ok {
-				obj.Spec.Answers = make(map[string]string)
+			if m, ok := answers.(map[string]interface{}); ok {
 				for k, v := range m {
 					obj.Spec.Answers[k] = convert.ToString(v)
 				}
 			}
-		} else {
-			obj.Spec.Answers = make(map[string]string)
 		}
+
+		obj.Spec.AnswersForceString = make(map[string]bool)
+		if answersForceString != nil {
+			if m, ok := answersForceString.(map[string]interface{}); ok {
+				for k, v := range m {
+					obj.Spec.AnswersForceString[k] = convert.ToBool(v)
+				}
+			}
+		}
+
 		obj.Spec.ExternalID = externalID
 		if convert.ToBool(forceUpgrade) {
 			v32.AppConditionForceUpgrade.Unknown(obj)

--- a/pkg/api/norman/customization/cluster/actions_monitoring.go
+++ b/pkg/api/norman/customization/cluster/actions_monitoring.go
@@ -30,14 +30,19 @@ func (a ActionHandler) viewMonitoring(actionName string, action *types.Action, a
 	}
 
 	// need to support `map[string]string` as entry value type in norman Builder.convertMap
-	answers, version := monitoring.GetOverwroteAppAnswersAndVersion(cluster.Annotations)
+	answers, answersForceString, version := monitoring.GetOverwroteAppAnswersAndVersion(cluster.Annotations)
 	encodeAnswers, err := convert.EncodeToMap(answers)
 	if err != nil {
 		return httperror.WrapAPIError(err, httperror.ServerError, "failed to parse response")
 	}
+	encodeAnswersForceString, err := convert.EncodeToMap(answersForceString)
+	if err != nil {
+		return httperror.WrapAPIError(err, httperror.ServerError, "failed to parse response")
+	}
 	resp := map[string]interface{}{
-		"answers": encodeAnswers,
-		"type":    "monitoringOutput",
+		"answers":            encodeAnswers,
+		"answersForceString": encodeAnswersForceString,
+		"type":               "monitoringOutput",
 	}
 	if version != "" {
 		resp["version"] = version

--- a/pkg/api/norman/customization/multiclusterapp/multi_cluster_app.go
+++ b/pkg/api/norman/customization/multiclusterapp/multi_cluster_app.go
@@ -258,9 +258,10 @@ func (w Wrapper) modifyProjects(request *types.APIContext, actionName string) ([
 	}
 	for _, a := range updateMultiClusterAppTargetsInput.Answers {
 		inputAnswers = append(inputAnswers, v32.Answer{
-			ProjectName: a.ProjectID,
-			ClusterName: a.ClusterID,
-			Values:      a.Values,
+			ProjectName:       a.ProjectID,
+			ClusterName:       a.ClusterID,
+			Values:            a.Values,
+			ValuesForceString: a.ValuesForceString,
 		})
 	}
 	// check if the input includes answers, and if they are only for the input projects

--- a/pkg/api/norman/customization/project/project_actions.go
+++ b/pkg/api/norman/customization/project/project_actions.go
@@ -141,14 +141,19 @@ func (h *Handler) viewMonitoring(actionName string, action *types.Action, apiCon
 	}
 
 	// need to support `map[string]string` as entry value type in norman Builder.convertMap
-	answers, version := monitoring.GetOverwroteAppAnswersAndVersion(project.Annotations)
+	answers, answersForceString, version := monitoring.GetOverwroteAppAnswersAndVersion(project.Annotations)
 	encodeAnswers, err := convert.EncodeToMap(answers)
 	if err != nil {
 		return httperror.WrapAPIError(err, httperror.ServerError, "failed to parse response")
 	}
+	encodeAnswersForceString, err := convert.EncodeToMap(answersForceString)
+	if err != nil {
+		return httperror.WrapAPIError(err, httperror.ServerError, "failed to parse response")
+	}
 	resp := map[string]interface{}{
-		"answers": encodeAnswers,
-		"type":    "monitoringOutput",
+		"answers":            encodeAnswers,
+		"answersForceString": encodeAnswersForceString,
+		"type":               "monitoringOutput",
 	}
 	if version != "" {
 		resp["version"] = version

--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -303,13 +303,15 @@ type IngressCapabilities struct {
 }
 
 type MonitoringInput struct {
-	Version string            `json:"version,omitempty"`
-	Answers map[string]string `json:"answers,omitempty"`
+	Version            string            `json:"version,omitempty"`
+	Answers            map[string]string `json:"answers,omitempty"`
+	AnswersForceString map[string]bool   `json:"answersForceString,omitempty"`
 }
 
 type MonitoringOutput struct {
-	Version string            `json:"version,omitempty"`
-	Answers map[string]string `json:"answers,omitempty"`
+	Version            string            `json:"version,omitempty"`
+	Answers            map[string]string `json:"answers,omitempty"`
+	AnswersForceString map[string]bool   `json:"answersForceString,omitempty"`
 }
 
 type RestoreFromEtcdBackupInput struct {

--- a/pkg/apis/management.cattle.io/v3/multi_cluster_app.go
+++ b/pkg/apis/management.cattle.io/v3/multi_cluster_app.go
@@ -63,9 +63,10 @@ func (t *Target) ObjClusterName() string {
 }
 
 type Answer struct {
-	ProjectName string            `json:"projectName,omitempty" norman:"type=reference[project]"`
-	ClusterName string            `json:"clusterName,omitempty" norman:"type=reference[cluster]"`
-	Values      map[string]string `json:"values,omitempty" norman:"required"`
+	ProjectName       string            `json:"projectName,omitempty" norman:"type=reference[project]"`
+	ClusterName       string            `json:"clusterName,omitempty" norman:"type=reference[cluster]"`
+	Values            map[string]string `json:"values,omitempty" norman:"required"`
+	ValuesForceString map[string]bool   `json:"valuesForceString,omitempty"`
 }
 
 func (a *Answer) ObjClusterName() string {

--- a/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -295,6 +295,13 @@ func (in *Answer) DeepCopyInto(out *Answer) {
 			(*out)[key] = val
 		}
 	}
+	if in.ValuesForceString != nil {
+		in, out := &in.ValuesForceString, &out.ValuesForceString
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -5337,6 +5344,13 @@ func (in *MonitoringInput) DeepCopyInto(out *MonitoringInput) {
 			(*out)[key] = val
 		}
 	}
+	if in.AnswersForceString != nil {
+		in, out := &in.AnswersForceString, &out.AnswersForceString
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -5356,6 +5370,13 @@ func (in *MonitoringOutput) DeepCopyInto(out *MonitoringOutput) {
 	if in.Answers != nil {
 		in, out := &in.Answers, &out.Answers
 		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.AnswersForceString != nil {
+		in, out := &in.AnswersForceString, &out.AnswersForceString
+		*out = make(map[string]bool, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/pkg/apis/project.cattle.io/v3/app_types.go
+++ b/pkg/apis/project.cattle.io/v3/app_types.go
@@ -32,6 +32,7 @@ type AppSpec struct {
 	ExternalID          string            `json:"externalId,omitempty"`
 	Files               map[string]string `json:"files,omitempty"`
 	Answers             map[string]string `json:"answers,omitempty"`
+	AnswersForceString  map[string]bool   `json:"answersForceString,omitempty"`
 	Wait                bool              `json:"wait,omitempty"`
 	Timeout             int               `json:"timeout,omitempty" norman:"min=1,default=300"`
 	AppRevisionName     string            `json:"appRevisionName,omitempty" norman:"type=reference[/v3/project/schemas/apprevision]"`
@@ -103,12 +104,13 @@ func (a *AppRevisionSpec) ObjClusterName() string {
 }
 
 type AppRevisionStatus struct {
-	ProjectName string            `json:"projectName,omitempty" norman:"type=reference[/v3/schemas/project]"`
-	ExternalID  string            `json:"externalId"`
-	Answers     map[string]string `json:"answers"`
-	Digest      string            `json:"digest"`
-	ValuesYaml  string            `json:"valuesYaml,omitempty"`
-	Files       map[string]string `json:"files,omitempty"`
+	ProjectName        string            `json:"projectName,omitempty" norman:"type=reference[/v3/schemas/project]"`
+	ExternalID         string            `json:"externalId"`
+	Answers            map[string]string `json:"answers"`
+	AnswersForceString map[string]bool   `json:"answersForceString"`
+	Digest             string            `json:"digest"`
+	ValuesYaml         string            `json:"valuesYaml,omitempty"`
+	Files              map[string]string `json:"files,omitempty"`
 }
 
 func (a *AppRevisionStatus) ObjClusterName() string {
@@ -119,11 +121,12 @@ func (a *AppRevisionStatus) ObjClusterName() string {
 }
 
 type AppUpgradeConfig struct {
-	ExternalID   string            `json:"externalId,omitempty"`
-	Answers      map[string]string `json:"answers,omitempty"`
-	ForceUpgrade bool              `json:"forceUpgrade,omitempty"`
-	Files        map[string]string `json:"files,omitempty"`
-	ValuesYaml   string            `json:"valuesYaml,omitempty"`
+	ExternalID         string            `json:"externalId,omitempty"`
+	Answers            map[string]string `json:"answers,omitempty"`
+	AnswersForceString map[string]bool   `json:"answersForceString,omitempty"`
+	ForceUpgrade       bool              `json:"forceUpgrade,omitempty"`
+	Files              map[string]string `json:"files,omitempty"`
+	ValuesYaml         string            `json:"valuesYaml,omitempty"`
 }
 
 type RollbackRevision struct {

--- a/pkg/apis/project.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/project.cattle.io/v3/zz_generated_deepcopy.go
@@ -190,6 +190,13 @@ func (in *AppRevisionStatus) DeepCopyInto(out *AppRevisionStatus) {
 			(*out)[key] = val
 		}
 	}
+	if in.AnswersForceString != nil {
+		in, out := &in.AnswersForceString, &out.AnswersForceString
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Files != nil {
 		in, out := &in.Files, &out.Files
 		*out = make(map[string]string, len(*in))
@@ -223,6 +230,13 @@ func (in *AppSpec) DeepCopyInto(out *AppSpec) {
 	if in.Answers != nil {
 		in, out := &in.Answers, &out.Answers
 		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.AnswersForceString != nil {
+		in, out := &in.AnswersForceString, &out.AnswersForceString
+		*out = make(map[string]bool, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
@@ -274,6 +288,13 @@ func (in *AppUpgradeConfig) DeepCopyInto(out *AppUpgradeConfig) {
 	if in.Answers != nil {
 		in, out := &in.Answers, &out.Answers
 		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.AnswersForceString != nil {
+		in, out := &in.AnswersForceString, &out.AnswersForceString
+		*out = make(map[string]bool, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -112,6 +112,7 @@ func DeployApp(mgmtAppClient projv3.AppInterface, projectID string, createOrUpda
 	} else {
 		app = app.DeepCopy()
 		app.Spec.Answers = createOrUpdateApp.Spec.Answers
+		app.Spec.AnswersForceString = createOrUpdateApp.Spec.AnswersForceString
 
 		// clean up status
 		if forceRedeploy {

--- a/pkg/client/generated/management/v3/zz_generated_answer.go
+++ b/pkg/client/generated/management/v3/zz_generated_answer.go
@@ -1,14 +1,16 @@
 package client
 
 const (
-	AnswerType           = "answer"
-	AnswerFieldClusterID = "clusterId"
-	AnswerFieldProjectID = "projectId"
-	AnswerFieldValues    = "values"
+	AnswerType                   = "answer"
+	AnswerFieldClusterID         = "clusterId"
+	AnswerFieldProjectID         = "projectId"
+	AnswerFieldValues            = "values"
+	AnswerFieldValuesForceString = "valuesForceString"
 )
 
 type Answer struct {
-	ClusterID string            `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
-	ProjectID string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
-	Values    map[string]string `json:"values,omitempty" yaml:"values,omitempty"`
+	ClusterID         string            `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
+	ProjectID         string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
+	Values            map[string]string `json:"values,omitempty" yaml:"values,omitempty"`
+	ValuesForceString map[string]bool   `json:"valuesForceString,omitempty" yaml:"valuesForceString,omitempty"`
 }

--- a/pkg/client/generated/management/v3/zz_generated_monitoring_input.go
+++ b/pkg/client/generated/management/v3/zz_generated_monitoring_input.go
@@ -1,12 +1,14 @@
 package client
 
 const (
-	MonitoringInputType         = "monitoringInput"
-	MonitoringInputFieldAnswers = "answers"
-	MonitoringInputFieldVersion = "version"
+	MonitoringInputType                    = "monitoringInput"
+	MonitoringInputFieldAnswers            = "answers"
+	MonitoringInputFieldAnswersForceString = "answersForceString"
+	MonitoringInputFieldVersion            = "version"
 )
 
 type MonitoringInput struct {
-	Answers map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
-	Version string            `json:"version,omitempty" yaml:"version,omitempty"`
+	Answers            map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersForceString map[string]bool   `json:"answersForceString,omitempty" yaml:"answersForceString,omitempty"`
+	Version            string            `json:"version,omitempty" yaml:"version,omitempty"`
 }

--- a/pkg/client/generated/management/v3/zz_generated_monitoring_output.go
+++ b/pkg/client/generated/management/v3/zz_generated_monitoring_output.go
@@ -1,12 +1,14 @@
 package client
 
 const (
-	MonitoringOutputType         = "monitoringOutput"
-	MonitoringOutputFieldAnswers = "answers"
-	MonitoringOutputFieldVersion = "version"
+	MonitoringOutputType                    = "monitoringOutput"
+	MonitoringOutputFieldAnswers            = "answers"
+	MonitoringOutputFieldAnswersForceString = "answersForceString"
+	MonitoringOutputFieldVersion            = "version"
 )
 
 type MonitoringOutput struct {
-	Answers map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
-	Version string            `json:"version,omitempty" yaml:"version,omitempty"`
+	Answers            map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersForceString map[string]bool   `json:"answersForceString,omitempty" yaml:"answersForceString,omitempty"`
+	Version            string            `json:"version,omitempty" yaml:"version,omitempty"`
 }

--- a/pkg/client/generated/project/v3/zz_generated_app.go
+++ b/pkg/client/generated/project/v3/zz_generated_app.go
@@ -8,6 +8,7 @@ const (
 	AppType                      = "app"
 	AppFieldAnnotations          = "annotations"
 	AppFieldAnswers              = "answers"
+	AppFieldAnswersForceString   = "answersForceString"
 	AppFieldAppRevisionID        = "appRevisionId"
 	AppFieldAppliedFiles         = "appliedFiles"
 	AppFieldConditions           = "conditions"
@@ -41,6 +42,7 @@ type App struct {
 	types.Resource
 	Annotations          map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Answers              map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersForceString   map[string]bool   `json:"answersForceString,omitempty" yaml:"answersForceString,omitempty"`
 	AppRevisionID        string            `json:"appRevisionId,omitempty" yaml:"appRevisionId,omitempty"`
 	AppliedFiles         map[string]string `json:"appliedFiles,omitempty" yaml:"appliedFiles,omitempty"`
 	Conditions           []AppCondition    `json:"conditions,omitempty" yaml:"conditions,omitempty"`

--- a/pkg/client/generated/project/v3/zz_generated_app_revision_status.go
+++ b/pkg/client/generated/project/v3/zz_generated_app_revision_status.go
@@ -1,20 +1,22 @@
 package client
 
 const (
-	AppRevisionStatusType            = "appRevisionStatus"
-	AppRevisionStatusFieldAnswers    = "answers"
-	AppRevisionStatusFieldDigest     = "digest"
-	AppRevisionStatusFieldExternalID = "externalId"
-	AppRevisionStatusFieldFiles      = "files"
-	AppRevisionStatusFieldProjectID  = "projectId"
-	AppRevisionStatusFieldValuesYaml = "valuesYaml"
+	AppRevisionStatusType                    = "appRevisionStatus"
+	AppRevisionStatusFieldAnswers            = "answers"
+	AppRevisionStatusFieldAnswersForceString = "answersForceString"
+	AppRevisionStatusFieldDigest             = "digest"
+	AppRevisionStatusFieldExternalID         = "externalId"
+	AppRevisionStatusFieldFiles              = "files"
+	AppRevisionStatusFieldProjectID          = "projectId"
+	AppRevisionStatusFieldValuesYaml         = "valuesYaml"
 )
 
 type AppRevisionStatus struct {
-	Answers    map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
-	Digest     string            `json:"digest,omitempty" yaml:"digest,omitempty"`
-	ExternalID string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
-	Files      map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
-	ProjectID  string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
-	ValuesYaml string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
+	Answers            map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersForceString map[string]bool   `json:"answersForceString,omitempty" yaml:"answersForceString,omitempty"`
+	Digest             string            `json:"digest,omitempty" yaml:"digest,omitempty"`
+	ExternalID         string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
+	Files              map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
+	ProjectID          string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
+	ValuesYaml         string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }

--- a/pkg/client/generated/project/v3/zz_generated_app_spec.go
+++ b/pkg/client/generated/project/v3/zz_generated_app_spec.go
@@ -1,32 +1,34 @@
 package client
 
 const (
-	AppSpecType                   = "appSpec"
-	AppSpecFieldAnswers           = "answers"
-	AppSpecFieldAppRevisionID     = "appRevisionId"
-	AppSpecFieldDescription       = "description"
-	AppSpecFieldExternalID        = "externalId"
-	AppSpecFieldFiles             = "files"
-	AppSpecFieldMultiClusterAppID = "multiClusterAppId"
-	AppSpecFieldProjectID         = "projectId"
-	AppSpecFieldPrune             = "prune"
-	AppSpecFieldTargetNamespace   = "targetNamespace"
-	AppSpecFieldTimeout           = "timeout"
-	AppSpecFieldValuesYaml        = "valuesYaml"
-	AppSpecFieldWait              = "wait"
+	AppSpecType                    = "appSpec"
+	AppSpecFieldAnswers            = "answers"
+	AppSpecFieldAnswersForceString = "answersForceString"
+	AppSpecFieldAppRevisionID      = "appRevisionId"
+	AppSpecFieldDescription        = "description"
+	AppSpecFieldExternalID         = "externalId"
+	AppSpecFieldFiles              = "files"
+	AppSpecFieldMultiClusterAppID  = "multiClusterAppId"
+	AppSpecFieldProjectID          = "projectId"
+	AppSpecFieldPrune              = "prune"
+	AppSpecFieldTargetNamespace    = "targetNamespace"
+	AppSpecFieldTimeout            = "timeout"
+	AppSpecFieldValuesYaml         = "valuesYaml"
+	AppSpecFieldWait               = "wait"
 )
 
 type AppSpec struct {
-	Answers           map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
-	AppRevisionID     string            `json:"appRevisionId,omitempty" yaml:"appRevisionId,omitempty"`
-	Description       string            `json:"description,omitempty" yaml:"description,omitempty"`
-	ExternalID        string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
-	Files             map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
-	MultiClusterAppID string            `json:"multiClusterAppId,omitempty" yaml:"multiClusterAppId,omitempty"`
-	ProjectID         string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
-	Prune             bool              `json:"prune,omitempty" yaml:"prune,omitempty"`
-	TargetNamespace   string            `json:"targetNamespace,omitempty" yaml:"targetNamespace,omitempty"`
-	Timeout           int64             `json:"timeout,omitempty" yaml:"timeout,omitempty"`
-	ValuesYaml        string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
-	Wait              bool              `json:"wait,omitempty" yaml:"wait,omitempty"`
+	Answers            map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersForceString map[string]bool   `json:"answersForceString,omitempty" yaml:"answersForceString,omitempty"`
+	AppRevisionID      string            `json:"appRevisionId,omitempty" yaml:"appRevisionId,omitempty"`
+	Description        string            `json:"description,omitempty" yaml:"description,omitempty"`
+	ExternalID         string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
+	Files              map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
+	MultiClusterAppID  string            `json:"multiClusterAppId,omitempty" yaml:"multiClusterAppId,omitempty"`
+	ProjectID          string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
+	Prune              bool              `json:"prune,omitempty" yaml:"prune,omitempty"`
+	TargetNamespace    string            `json:"targetNamespace,omitempty" yaml:"targetNamespace,omitempty"`
+	Timeout            int64             `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	ValuesYaml         string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
+	Wait               bool              `json:"wait,omitempty" yaml:"wait,omitempty"`
 }

--- a/pkg/client/generated/project/v3/zz_generated_app_upgrade_config.go
+++ b/pkg/client/generated/project/v3/zz_generated_app_upgrade_config.go
@@ -1,18 +1,20 @@
 package client
 
 const (
-	AppUpgradeConfigType              = "appUpgradeConfig"
-	AppUpgradeConfigFieldAnswers      = "answers"
-	AppUpgradeConfigFieldExternalID   = "externalId"
-	AppUpgradeConfigFieldFiles        = "files"
-	AppUpgradeConfigFieldForceUpgrade = "forceUpgrade"
-	AppUpgradeConfigFieldValuesYaml   = "valuesYaml"
+	AppUpgradeConfigType                    = "appUpgradeConfig"
+	AppUpgradeConfigFieldAnswers            = "answers"
+	AppUpgradeConfigFieldAnswersForceString = "answersForceString"
+	AppUpgradeConfigFieldExternalID         = "externalId"
+	AppUpgradeConfigFieldFiles              = "files"
+	AppUpgradeConfigFieldForceUpgrade       = "forceUpgrade"
+	AppUpgradeConfigFieldValuesYaml         = "valuesYaml"
 )
 
 type AppUpgradeConfig struct {
-	Answers      map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
-	ExternalID   string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
-	Files        map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
-	ForceUpgrade bool              `json:"forceUpgrade,omitempty" yaml:"forceUpgrade,omitempty"`
-	ValuesYaml   string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
+	Answers            map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersForceString map[string]bool   `json:"answersForceString,omitempty" yaml:"answersForceString,omitempty"`
+	ExternalID         string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
+	Files              map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
+	ForceUpgrade       bool              `json:"forceUpgrade,omitempty" yaml:"forceUpgrade,omitempty"`
+	ValuesYaml         string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }

--- a/pkg/controllers/managementuserlegacy/alert/deployer/deployer.go
+++ b/pkg/controllers/managementuserlegacy/alert/deployer/deployer.go
@@ -326,6 +326,7 @@ func (d *appDeployer) deploy(appName, appTargetNamespace, systemProjectID string
 		if app.Spec.Answers[WebhookReceiverEnable] != enableWebhookReceiver {
 			copy := app.DeepCopy()
 			copy.Spec.Answers[WebhookReceiverEnable] = enableWebhookReceiver
+			delete(copy.Spec.AnswersForceString, WebhookReceiverEnable)
 			_, err := d.appsGetter.Apps(systemProjectName).Update(copy)
 			if err != nil {
 				return false, fmt.Errorf("failed to update %q App, %v", appName, err)

--- a/pkg/controllers/managementuserlegacy/alert/deployer/upgradeimpl.go
+++ b/pkg/controllers/managementuserlegacy/alert/deployer/upgradeimpl.go
@@ -150,6 +150,7 @@ func (l *AlertService) Upgrade(currentVersion string) (string, error) {
 	newApp := app.DeepCopy()
 	newApp.Spec.ExternalID = newExternalID
 	newApp.Spec.Answers["operator.enabled"] = "false"
+	delete(newApp.Spec.AnswersForceString, "operator.enabled")
 
 	if !reflect.DeepEqual(newApp, app) {
 		// check cluster ready before upgrade, because helm will not retry if got cluster not ready error

--- a/pkg/controllers/managementuserlegacy/helm/common/common.go
+++ b/pkg/controllers/managementuserlegacy/helm/common/common.go
@@ -17,8 +17,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
-	v32 "github.com/rancher/rancher/pkg/apis/project.cattle.io/v3"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/project.cattle.io/v3"
+	v3 "github.com/rancher/rancher/pkg/apis/project.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/jailer"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
@@ -157,14 +156,14 @@ func InstallCharts(tempDirs *HelmPath, port string, obj *v3.App) error {
 	commands = append(commands, setValues...)
 	commands = append(commands, tempDirs.AppDirInJail)
 
-	if v32.AppConditionForceUpgrade.IsUnknown(obj) {
+	if v3.AppConditionForceUpgrade.IsUnknown(obj) {
 		commands = append(commands, forceUpgradeStr)
 		// don't leave force recreate on the object
-		v32.AppConditionForceUpgrade.True(obj)
+		v3.AppConditionForceUpgrade.True(obj)
 	}
 	var cmd *exec.Cmd
 	// switch userTriggeredAction back
-	v32.AppConditionUserTriggeredAction.Unknown(obj)
+	v3.AppConditionUserTriggeredAction.Unknown(obj)
 	if IsHelm3(obj.Status.HelmVersion) {
 		cmd = exec.Command(HelmV3, commands...)
 	} else {
@@ -185,10 +184,10 @@ func InstallCharts(tempDirs *HelmPath, port string, obj *v3.App) error {
 		// if the first install failed, the second install would have error message like `has no deployed releases`, then the
 		// original error is masked. We need to filter out the message and always return the last one if error matches this pattern
 		if strings.Contains(stderrBuf.String(), "has no deployed releases") {
-			if !v32.AppConditionForceUpgrade.IsUnknown(obj) {
-				v32.AppConditionForceUpgrade.Unknown(obj)
+			if !v3.AppConditionForceUpgrade.IsUnknown(obj) {
+				v3.AppConditionForceUpgrade.Unknown(obj)
 			}
-			return errors.New(v32.AppConditionInstalled.GetMessage(obj))
+			return errors.New(v3.AppConditionInstalled.GetMessage(obj))
 		}
 		return errors.Errorf("failed to install app %s. %s", obj.Name, stderrBuf.String())
 	}

--- a/pkg/controllers/managementuserlegacy/helm/controller.go
+++ b/pkg/controllers/managementuserlegacy/helm/controller.go
@@ -362,6 +362,7 @@ func (l *Lifecycle) createAppRevision(obj *v3.App, template, notes string, faile
 	}
 	release.Spec.ProjectName = obj.Spec.ProjectName
 	release.Status.Answers = obj.Spec.Answers
+	release.Status.AnswersForceString = obj.Spec.AnswersForceString
 	release.Status.ExternalID = obj.Spec.ExternalID
 	release.Status.ValuesYaml = obj.Spec.ValuesYaml
 	release.Status.Files = obj.Spec.Files
@@ -413,14 +414,14 @@ func (l *Lifecycle) writeKubeConfig(obj *v3.App, kubePath string, remove bool) (
 
 func isSame(obj *v3.App, revision *v3.AppRevision) bool {
 	if obj.Spec.ExternalID != "" {
-		if revision.Status.ExternalID == obj.Spec.ExternalID && reflect.DeepEqual(revision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(revision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
+		if revision.Status.ExternalID == obj.Spec.ExternalID && reflect.DeepEqual(revision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(revision.Status.AnswersForceString, obj.Spec.AnswersForceString) && reflect.DeepEqual(revision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
 			return true
 		}
 		return false
 	}
 
 	if obj.Status.AppliedFiles != nil {
-		if reflect.DeepEqual(obj.Status.AppliedFiles, obj.Spec.Files) && reflect.DeepEqual(revision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(revision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
+		if reflect.DeepEqual(obj.Status.AppliedFiles, obj.Spec.Files) && reflect.DeepEqual(revision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(revision.Status.AnswersForceString, obj.Spec.AnswersForceString) && reflect.DeepEqual(revision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
 			return true
 		}
 		return false

--- a/pkg/controllers/managementuserlegacy/logging/deployer/appdeployer.go
+++ b/pkg/controllers/managementuserlegacy/logging/deployer/appdeployer.go
@@ -93,19 +93,19 @@ func (d *AppDeployer) deploy(app *projectv3.App, systemWriteKeys []string) error
 		return errors.New("stale app " + app.Namespace + ":" + app.Name + " still on terminating")
 	}
 
-	new := current.DeepCopy()
+	newApp := current.DeepCopy()
 	if len(systemWriteKeys) != 0 {
-		if new.Spec.Answers == nil {
-			new.Spec.Answers = make(map[string]string)
+		if newApp.Spec.Answers == nil {
+			newApp.Spec.Answers = make(map[string]string)
 		}
 
 		for _, v := range systemWriteKeys {
-			new.Spec.Answers[v] = app.Spec.Answers[v]
+			newApp.Spec.Answers[v] = app.Spec.Answers[v]
 		}
 	}
 
-	if !reflect.DeepEqual(current.Spec, new.Spec) {
-		_, err = d.AppsGetter.Apps(app.Namespace).Update(new)
+	if !reflect.DeepEqual(current.Spec, newApp.Spec) {
+		_, err = d.AppsGetter.Apps(app.Namespace).Update(newApp)
 		if err != nil {
 			return errors.Wrapf(err, "failed to update app %s", app.Name)
 		}

--- a/pkg/controllers/managementuserlegacy/monitoring/clusterHandler.go
+++ b/pkg/controllers/managementuserlegacy/monitoring/clusterHandler.go
@@ -359,18 +359,6 @@ func (ch *clusterHandler) deployApp(
 	// e.g. "true", "false", "123", "2379"
 	var knownUnforcedStringKeys []string
 
-	detectNotForcedStringKeys := func(answers map[string]string) []string {
-		var notForcedStringKeys []string
-		for k := range answers {
-			// all boolean keys must NOT be forced to be a string
-			if k == "true" || k == "false" {
-				notForcedStringKeys = append(notForcedStringKeys, k)
-			}
-			// if any default values are numbers, add a check here to ensure those number values are NOT forced as a string
-		}
-		return notForcedStringKeys
-	}
-
 	knownUnforcedStringKeys = append(knownUnforcedStringKeys, detectNotForcedStringKeys(optionalAppAnswers)...)
 	knownUnforcedStringKeys = append(knownUnforcedStringKeys, detectNotForcedStringKeys(mustAppAnswers)...)
 

--- a/pkg/controllers/managementuserlegacy/monitoring/operatorHandler.go
+++ b/pkg/controllers/managementuserlegacy/monitoring/operatorHandler.go
@@ -177,18 +177,6 @@ func deploySystemMonitor(cluster *mgmtv3.Cluster, app *appHandler, catalogManage
 	// e.g. "true", "false", "123", "2379"
 	var knownUnforcedStringKeys []string
 
-	detectNotForcedStringKeys := func(answers map[string]string) []string {
-		var notForcedStringKeys []string
-		for k := range answers {
-			// all boolean keys must NOT be forced to be a string
-			if k == "true" || k == "false" {
-				notForcedStringKeys = append(notForcedStringKeys, k)
-			}
-			// if any default values are numbers, add a check here to ensure those number values are NOT forced as a string
-		}
-		return notForcedStringKeys
-	}
-
 	knownUnforcedStringKeys = append(knownUnforcedStringKeys, detectNotForcedStringKeys(appAnswers)...)
 	knownUnforcedStringKeys = append(knownUnforcedStringKeys, detectNotForcedStringKeys(mustAppAnswers)...)
 

--- a/pkg/controllers/managementuserlegacy/monitoring/projectHandler.go
+++ b/pkg/controllers/managementuserlegacy/monitoring/projectHandler.go
@@ -203,18 +203,6 @@ func (ph *projectHandler) deployApp(appName, appTargetNamespace string, appProje
 	// e.g. "true", "false", "123", "2379"
 	var knownUnforcedStringKeys []string
 
-	detectNotForcedStringKeys := func(answers map[string]string) []string {
-		var notForcedStringKeys []string
-		for k := range answers {
-			// all boolean keys must NOT be forced to be a string
-			if k == "true" || k == "false" {
-				notForcedStringKeys = append(notForcedStringKeys, k)
-			}
-			// if any default values are numbers, add a check here to ensure those number values are NOT forced as a string
-		}
-		return notForcedStringKeys
-	}
-
 	knownUnforcedStringKeys = append(knownUnforcedStringKeys, detectNotForcedStringKeys(optionalAppAnswers)...)
 	knownUnforcedStringKeys = append(knownUnforcedStringKeys, detectNotForcedStringKeys(mustAppAnswers)...)
 

--- a/pkg/controllers/managementuserlegacy/monitoring/util.go
+++ b/pkg/controllers/managementuserlegacy/monitoring/util.go
@@ -1,0 +1,23 @@
+package monitoring
+
+import (
+	"regexp"
+)
+
+var (
+	numberRegex = regexp.MustCompile("^[0-9]+$")
+)
+
+// detectNotForcedStringKeys builds a list of known keys that should NOT be
+// forced to a string, e.g. keys that are required to be "true", "false", "123",
+// "2379"
+func detectNotForcedStringKeys(answers map[string]string) []string {
+	var notForcedStringKeys []string
+	for k, v := range answers {
+		// all keys with boolean or number values must NOT be forced to be a string
+		if v == "true" || v == "false" || numberRegex.MatchString(v) {
+			notForcedStringKeys = append(notForcedStringKeys, k)
+		}
+	}
+	return notForcedStringKeys
+}


### PR DESCRIPTION
Add field to AppSpec allowing forcing answers to use the equivalent of `--set-string` in the Helm CLI. No breaking API changes, all changed behaviors are opt-in.

Additional commit removes references to norman's deprecated App type, replacing with proper v3 App type.

Linked issue #26088.