### PR TITLE
[2.5] Backport built-in OTC CCE driver for v2.5

### DIFF
--- a/pkg/data/management/kontainerdriver_data.go
+++ b/pkg/data/management/kontainerdriver_data.go
@@ -101,6 +101,17 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 		return err
 	}
 
+	if err := creator.addCustomDriver(
+		"opentelekomcloudcontainerengine",
+		"https://otc-rancher.obs.eu-de.otc.t-systems.com/cluster/driver/1.0.2/kontainer-engine-driver-otccce_linux_amd64.tar.gz",
+		"f2c0a8d1195cd51ae1ccdeb4a8defd2c3147b9a2c7510b091be0c12028740f5f",
+		"https://otc-rancher.obs.eu-de.otc.t-systems.com/cluster/ui/v1.0.3/component.js",
+		false,
+		"*.otc.t-systems.com",
+	); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/tests/integration/suite/test_rbac.py
+++ b/tests/integration/suite/test_rbac.py
@@ -577,14 +577,14 @@ def ns_count(client, count):
 
 def test_appropriate_users_can_see_kontainer_drivers(user_factory):
     kds = user_factory().client.list_kontainer_driver()
-    assert len(kds) == 9
+    assert len(kds) == 10
 
     kds = user_factory('clusters-create').client.list_kontainer_driver()
-    assert len(kds) == 9
+    assert len(kds) == 10
 
     kds = user_factory('kontainerdrivers-manage').client. \
         list_kontainer_driver()
-    assert len(kds) == 9
+    assert len(kds) == 10
 
     kds = user_factory('settings-manage').client.list_kontainer_driver()
     assert len(kds) == 0


### PR DESCRIPTION
Add built-in `opentelekomcloudcontainerengine` to `release/v2.5`

Backport of PR https://github.com/rancher/rancher/pull/30286, as requested by @dramich in the [comment](https://github.com/rancher/rancher/pull/30286#issuecomment-738156970)