### PR TITLE
[2.5] Fix for machine_cpu_cores being removed from cadvisor metrics

### DIFF
--- a/pkg/controllers/managementuser/alert/initdata.go
+++ b/pkg/controllers/managementuser/alert/initdata.go
@@ -284,7 +284,7 @@ var entries = []entry{
 					},
 					MetricRule: &v32.MetricRule{
 						Description:    "The cpu load is higher than 100",
-						Expression:     `sum(node_load1) by (node)  / sum(machine_cpu_cores) by (node) * 100`,
+						Expression:     `sum(node_load1) by (node)  / sum(kube_node_status_capacity{resource="cpu"}) by (node) * 100`,
 						Comparison:     manager.ComparisonGreaterThan,
 						Duration:       "3m",
 						ThresholdValue: 100,


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/29860 to 2.5.x.

Related Issue: https://github.com/rancher/rancher/issues/29292