### PR TITLE
Remove private endpoint check when deploying agent

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -15,7 +15,6 @@ import (
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	util "github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/clustermanager"
-	"github.com/rancher/rancher/pkg/dialer"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/image"
 	"github.com/rancher/rancher/pkg/kubectl"
@@ -219,11 +218,6 @@ func getDesiredImage(cluster *v3.Cluster) string {
 }
 
 func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
-	if dialer.HasOnlyPrivateAPIEndpoint(cluster) {
-		logrus.Debugf("clusterDeploy: deployAgent: cluster [%s] is private so agent cannot be deployed automatically", cluster.Name)
-		return nil
-	}
-
 	if cluster.Spec.Internal {
 		return nil
 	}


### PR DESCRIPTION
When an EKS cluster is created with private-only API endpoint, the user is responsible for deploying the cluster agent. There was a check to try to ensure that the cluster agent was not deployed by Rancher. However, this check is not needed because, in this scenario, there are no nodes detected before the cluster agent is deployed.

Issue:
https://github.com/rancher/rancher/issues/29907

Related PRs:
https://github.com/rancher/rancher/pull/30328
https://github.com/rancher/rancher/pull/30120