### PR TITLE
Split rancher.yaml into multiple doc

### DIFF
--- a/package/Dockerfile.runtime
+++ b/package/Dockerfile.runtime
@@ -1,4 +1,4 @@
 ARG RKE2_VERSION=v1.18.12-rke2r2
 # if you’re changing this, also change rancher/cmd/rancherd/go.mod
 FROM rancher/rke2-runtime:${RKE2_VERSION}
-COPY rancher.yaml /charts/
+COPY rancher.yaml rancher-namespace.yaml /charts/

--- a/scripts/build-rancherd
+++ b/scripts/build-rancherd
@@ -31,3 +31,5 @@ cd ../..
 ./scripts/chart/package
 
 sed -e "s|%{CHART_CONTENT}%|$(base64 -w0 ./bin/chart/*/rancher-${CHART_VERSION}.tgz)|g" ./scripts/rancher.yaml.tmpl > ./bin/rancher.yaml
+cp ./scripts/rancher-namespace.yaml.tmpl ./bin/rancher-namespace.yaml
+

--- a/scripts/package
+++ b/scripts/package
@@ -13,7 +13,7 @@ CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"dev-v2.5"}
 
 cd $(dirname $0)/../package
 
-cp ../bin/rancher.yaml ../bin/rancher ../bin/agent ../bin/data.json ../bin/k3s-airgap-images.tar .
+cp ../bin/rancher.yaml ../bin/rancher-namespace.yaml ../bin/rancher ../bin/agent ../bin/data.json ../bin/k3s-airgap-images.tar .
 
 IMAGE=${REPO}/rancher:${TAG}
 AGENT_IMAGE=${REPO}/rancher-agent:${AGENT_TAG}

--- a/scripts/rancher-namespace.yaml.tmpl
+++ b/scripts/rancher-namespace.yaml.tmpl
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cattle-system

--- a/scripts/rancher.yaml.tmpl
+++ b/scripts/rancher.yaml.tmpl
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cattle-system
----
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
 metadata:
@@ -11,4 +6,3 @@ metadata:
 spec:
   targetNamespace: cattle-system
   chartContent: %{CHART_CONTENT}%
----


### PR DESCRIPTION
Due to the limitation https://github.com/rancher/rke2/issues/527 we can
not use multi-doc yaml for airgap installation