### PR TITLE
Check for cluster connection when public access disabled

### DIFF
--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -344,8 +344,9 @@ type SaveAsTemplateOutput struct {
 }
 
 type EKSStatus struct {
-	UpstreamSpec   *eksv1.EKSClusterConfigSpec `json:"upstreamSpec"`
-	VirtualNetwork string                      `json:"virtualNetwork"`
-	Subnets        []string                    `json:"subnets"`
-	SecurityGroups []string                    `json:"securityGroups"`
+	UpstreamSpec          *eksv1.EKSClusterConfigSpec `json:"upstreamSpec"`
+	VirtualNetwork        string                      `json:"virtualNetwork"`
+	Subnets               []string                    `json:"subnets"`
+	SecurityGroups        []string                    `json:"securityGroups"`
+	PrivateRequiresTunnel *bool                       `json:"privateRequiresTunnel"`
 }

--- a/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -3113,6 +3113,11 @@ func (in *EKSStatus) DeepCopyInto(out *EKSStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.PrivateRequiresTunnel != nil {
+		in, out := &in.PrivateRequiresTunnel, &out.PrivateRequiresTunnel
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/client/generated/management/v3/zz_generated_eks_status.go
+++ b/pkg/client/generated/management/v3/zz_generated_eks_status.go
@@ -1,16 +1,18 @@
 package client
 
 const (
-	EKSStatusType                = "eksStatus"
-	EKSStatusFieldSecurityGroups = "securityGroups"
-	EKSStatusFieldSubnets        = "subnets"
-	EKSStatusFieldUpstreamSpec   = "upstreamSpec"
-	EKSStatusFieldVirtualNetwork = "virtualNetwork"
+	EKSStatusType                       = "eksStatus"
+	EKSStatusFieldPrivateRequiresTunnel = "privateRequiresTunnel"
+	EKSStatusFieldSecurityGroups        = "securityGroups"
+	EKSStatusFieldSubnets               = "subnets"
+	EKSStatusFieldUpstreamSpec          = "upstreamSpec"
+	EKSStatusFieldVirtualNetwork        = "virtualNetwork"
 )
 
 type EKSStatus struct {
-	SecurityGroups []string              `json:"securityGroups,omitempty" yaml:"securityGroups,omitempty"`
-	Subnets        []string              `json:"subnets,omitempty" yaml:"subnets,omitempty"`
-	UpstreamSpec   *EKSClusterConfigSpec `json:"upstreamSpec,omitempty" yaml:"upstreamSpec,omitempty"`
-	VirtualNetwork string                `json:"virtualNetwork,omitempty" yaml:"virtualNetwork,omitempty"`
+	PrivateRequiresTunnel *bool                 `json:"privateRequiresTunnel,omitempty" yaml:"privateRequiresTunnel,omitempty"`
+	SecurityGroups        []string              `json:"securityGroups,omitempty" yaml:"securityGroups,omitempty"`
+	Subnets               []string              `json:"subnets,omitempty" yaml:"subnets,omitempty"`
+	UpstreamSpec          *EKSClusterConfigSpec `json:"upstreamSpec,omitempty" yaml:"upstreamSpec,omitempty"`
+	VirtualNetwork        string                `json:"virtualNetwork,omitempty" yaml:"virtualNetwork,omitempty"`
 }

--- a/pkg/dialer/factory.go
+++ b/pkg/dialer/factory.go
@@ -75,9 +75,13 @@ func IsPublicCloudDriver(cluster *v3.Cluster) bool {
 func HasOnlyPrivateAPIEndpoint(cluster *v3.Cluster) bool {
 	switch cluster.Status.Driver {
 	case v32.ClusterDriverEKS:
-		return cluster.Status.EKSStatus.UpstreamSpec != nil &&
+		if cluster.Status.EKSStatus.UpstreamSpec != nil &&
 			cluster.Status.EKSStatus.UpstreamSpec.PublicAccess != nil &&
-			!*cluster.Status.EKSStatus.UpstreamSpec.PublicAccess
+			*cluster.Status.EKSStatus.UpstreamSpec.PublicAccess {
+			return false
+		}
+		return cluster.Status.EKSStatus.PrivateRequiresTunnel != nil &&
+			*cluster.Status.EKSStatus.PrivateRequiresTunnel
 	default:
 		return false
 	}


### PR DESCRIPTION
If public access is disabled, it is no longer assumed that Rancher cannot communicate with the cluster API. Instead, Rancher attempts to contact the API. If this is successful, then Rancher can communicate with the cluster as normal (through the API access endpoint) instead of tunneling.

This is most important on cluster creation/import. In this case, since Rancher can still communicate with the API endpoint, the user does not need to run the import command that is displayed.

Issue:
https://github.com/rancher/rancher/issues/30403