### PR TITLE
[master] Don't return nil accessControl

### DIFF
--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -420,6 +420,10 @@ func (m *Manager) AccessControl(apiContext *types.APIContext, storageContext typ
 		return m.accessControl, nil
 	}
 
+	if record.accessControl == nil {
+		return nil, httperror.NewAPIError(httperror.ClusterUnavailable, "cannot determine access, cluster is unavailable")
+	}
+
 	return record.accessControl, nil
 }
 


### PR DESCRIPTION
Problem:
If the accessControl does not exist on the record rancher can panic if
attempting to list items

Solution:
Return an error if accessControl has not been created yet. This means
the cluster hasn't been contacted yet anyways

https://github.com/rancher/rancher/issues/30434