### PR TITLE
Allow local cluster to deploy monitoring

### DIFF
--- a/pkg/controllers/managementagent/monitoring/clusterHandler.go
+++ b/pkg/controllers/managementagent/monitoring/clusterHandler.go
@@ -56,7 +56,7 @@ func (ch *clusterHandler) sync(key string, cluster *mgmtv3.Cluster) (runtime.Obj
 		return cluster, nil
 	}
 
-	if !v32.ClusterConditionAgentDeployed.IsTrue(cluster) {
+	if !cluster.Spec.Internal && !v32.ClusterConditionAgentDeployed.IsTrue(cluster) {
 		return cluster, nil
 	}
 

--- a/pkg/controllers/managementagent/monitoring/operatorHandler.go
+++ b/pkg/controllers/managementagent/monitoring/operatorHandler.go
@@ -33,7 +33,7 @@ func (h *operatorHandler) syncCluster(key string, obj *mgmtv3.Cluster) (runtime.
 		return obj, nil
 	}
 
-	if !v32.ClusterConditionAgentDeployed.IsTrue(obj) {
+	if !obj.Spec.Internal && !v32.ClusterConditionAgentDeployed.IsTrue(obj) {
 		return obj, nil
 	}
 
@@ -70,7 +70,7 @@ func (h *operatorHandler) syncProject(key string, project *mgmtv3.Project) (runt
 		return nil, errors.Wrapf(err, "failed to find Cluster %s", clusterID)
 	}
 
-	if !v32.ClusterConditionAgentDeployed.IsTrue(cluster) {
+	if !cluster.Spec.Internal && !v32.ClusterConditionAgentDeployed.IsTrue(cluster) {
 		return project, nil
 	}
 


### PR DESCRIPTION
As part of the rewrite for 2.5, it seems like we stopped deploying the agent onto local clusters:
https://github.com/rancher/rancher/blob/2161018b5c1ffa489b299a039df508b43d41d5e0/pkg/controllers/management/clusterdeploy/clusterdeploy.go#L251-L254

As a result, Rancher local clusters that were spun up after https://github.com/rancher/rancher/commit/079c473dea8d6b47043d1a4ace158c86b03b1bee no longer have the condition AgentDeployed set to true (checked against 2.4.8, where this is set to true for a local cluster).

Since this change has been made, we also need to modify the Monitoring V1 logic to allow it to be deployed onto a local cluster whether or not AgentDeployed is true.

Updated Summary: https://github.com/rancher/rancher/issues/30537#issuecomment-747734831

Related Issue: https://github.com/rancher/rancher/issues/30537

We should also double check if this was the root cause of https://github.com/rancher/rancher/issues/29328.