### PR TITLE
Update ClusterRoleBinding to rbac.authorization.k8s.io/v1

### DIFF
--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -44,7 +44,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cattle-admin-binding

--- a/tests/validation/tests/kubernetes_conformance/resources/k8s_ymls/sonobuoy-conformance.yaml
+++ b/tests/validation/tests/kubernetes_conformance/resources/k8s_ymls/sonobuoy-conformance.yaml
@@ -12,7 +12,7 @@ metadata:
   name: sonobuoy-serviceaccount
   namespace: sonobuoy
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -27,7 +27,7 @@ subjects:
   name: sonobuoy-serviceaccount
   namespace: sonobuoy
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/tests/validation/tests/rke/resources/k8s_ymls/clusterrole.yml
+++ b/tests/validation/tests/rke/resources/k8s_ymls/clusterrole.yml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   # "namespace" omitted since ClusterRoles are not namespaced
   name: read-pods-global

--- a/tests/validation/tests/rke/resources/k8s_ymls/clusterrolebinding.yml
+++ b/tests/validation/tests/rke/resources/k8s_ymls/clusterrolebinding.yml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: read-pods-global
 subjects:

--- a/tests/validation/tests/rke/resources/k8s_ymls/role.yml
+++ b/tests/validation/tests/rke/resources/k8s_ymls/role.yml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: pod-reader

--- a/tests/validation/tests/rke/resources/k8s_ymls/rolebinding.yml
+++ b/tests/validation/tests/rke/resources/k8s_ymls/rolebinding.yml
@@ -1,5 +1,5 @@
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: read-pods
   namespace: default


### PR DESCRIPTION
#### Proposed Changes ####

Update API from "rbac.authorization.k8s.io/v1beta1" to "rbac.authorization.k8s.io/v1".  This will resolve the warning "Warning: rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding"

#### Types of Changes ####

Update API in manifest.

#### Verification ####

None

#### Linked Issues ####

Refs: #30043

#### Further Comments ####

None

Signed-off-by: cclhsu <clark.hsu@suse.com>