### PR TITLE
Allow automation to run on cis hardened clusters

### DIFF
--- a/tests/validation/tests/Dockerfiles/unprivileged-testcontainer/Dockerfile
+++ b/tests/validation/tests/Dockerfiles/unprivileged-testcontainer/Dockerfile
@@ -1,0 +1,20 @@
+FROM nginxinc/nginx-unprivileged as base
+MAINTAINER Max Ross https://github.com/rancher-max
+
+USER root
+RUN apt-get update
+
+RUN apt-get install -y wget
+RUN apt-get install -y curl
+RUN apt-get install -y iptables
+RUN apt-get install -y dnsutils
+RUN apt-get install -y iputils-ping
+
+COPY ./run.sh /scripts/run.sh
+RUN chmod 777 /scripts/run.sh
+RUN chmod 777 /usr/share/nginx/html
+
+USER 101
+
+ENTRYPOINT [ "/scripts/run.sh" ]
+CMD ["nginx", "-g", "daemon off;"]

--- a/tests/validation/tests/Dockerfiles/unprivileged-testcontainer/run.sh
+++ b/tests/validation/tests/Dockerfiles/unprivileged-testcontainer/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ -z "$CONTAINER_NAME" ]; then
+    hostname > /usr/share/nginx/html/name.html
+    hostname > /usr/share/nginx/html/service1.html
+    hostname > /usr/share/nginx/html/service2.html
+else
+    echo ${CONTAINER_NAME} > /usr/share/nginx/html/name.html
+    echo ${CONTAINER_NAME} > /usr/share/nginx/html/service1.html
+    echo ${CONTAINER_NAME} > /usr/share/nginx/html/service2.html
+fi
+exec "$@"

--- a/tests/validation/tests/v3_api/test_certificate.py
+++ b/tests/validation/tests/v3_api/test_certificate.py
@@ -23,7 +23,7 @@ from .common import (ApiError, CLUSTER_MEMBER, CLUSTER_OWNER, create_kubeconfig,
                      random_test_name, rbac_get_namespace, rbac_get_project,
                      rbac_get_user_token_by_role, TEST_IMAGE, USER_TOKEN,
                      validate_ingress_using_endpoint, validate_workload,
-                     wait_for_ingress_to_active, base64)
+                     wait_for_ingress_to_active, base64, TEST_IMAGE_PORT)
 from lib.aws import AmazonWebServices
 from pathlib import Path
 import pytest
@@ -122,7 +122,7 @@ class TestCertificate:
         path = "/name.html"
         rule = {"host": host,
                 "paths": [{"path": path, "workloadIds": [self.workload.id],
-                           "targetPort": "80"}]}
+                           "targetPort": TEST_IMAGE_PORT}]}
         tls = {"certificateId": self.certificate_valid.id, "hosts": [host]}
         validate_workload(self.p_client, self.workload, "deployment",
                           self.ns.name)
@@ -146,7 +146,7 @@ class TestCertificate:
         path = "/name.html"
         rule = {"host": host,
                 "paths": [{"path": path, "workloadIds": [self.workload.id],
-                           "targetPort": "80"}]
+                           "targetPort": TEST_IMAGE_PORT}]
                 }
         tls = {"certificateId": self.certificate_all_ns_valid.id,
                "hosts": [host]
@@ -186,7 +186,7 @@ class TestCertificate:
         path = "/name.html"
         rule = {"host": host,
                 "paths": [{"path": path, "workloadIds": [self.workload_2.id],
-                           "targetPort": "80"}]
+                           "targetPort": TEST_IMAGE_PORT}]
                 }
         tls = {"certificateId": self.certificate_all_ns_valid.id,
                "hosts": [host]
@@ -214,7 +214,7 @@ class TestCertificate:
         path = "/name.html"
         rule = {"host": host,
                 "paths": [{"path": path, "workloadIds": [self.workload.id],
-                           "targetPort": "80"}]}
+                           "targetPort": TEST_IMAGE_PORT}]}
         tls = {"certificateId": self.certificate_ssc.id, "hosts": [host]}
         self.ingress = self.p_client.create_ingress(
             name=ingress_name, namespaceId=self.ns.id, rules=[rule], tls=[tls]
@@ -239,7 +239,7 @@ class TestCertificate:
         path = "/name.html"
         rule = {"host": host,
                 "paths": [{"path": path, "workloadIds": [self.workload.id],
-                           "targetPort": "80"}]
+                           "targetPort": TEST_IMAGE_PORT}]
                 }
         tls = {"certificateId": self.certificate_all_ns_ssc.id, "hosts": [host]}
         self.ingress = self.p_client.create_ingress(
@@ -277,7 +277,7 @@ class TestCertificate:
         path = "/name.html"
         rule = {"host": host,
                 "paths": [{"path": path, "workloadIds": [self.workload_2.id],
-                           "targetPort": "80"}]
+                           "targetPort": TEST_IMAGE_PORT}]
                 }
         tls = {"certificateId": self.certificate_all_ns_ssc.id, "hosts": [host]}
         self.ingress = self.p_client.create_ingress(
@@ -305,10 +305,10 @@ class TestCertificate:
         path = "/name.html"
         rule_1 = {"host": host_1,
                   "paths": [{"path": path, "workloadIds": [self.workload.id],
-                             "targetPort": "80"}]}
+                             "targetPort": TEST_IMAGE_PORT}]}
         rule_2 = {"host": host_2,
                   "paths": [{"path": path, "workloadIds": [self.workload.id],
-                             "targetPort": "80"}]}
+                             "targetPort": TEST_IMAGE_PORT}]}
         tls = {"certificateId": self.certificate_ssc.id, "hosts": [host_1]}
         tls_2 = {"certificateId": self.certificate_ssc.id, "hosts": [host_2]}
         self.ingress = self.p_client.create_ingress(
@@ -342,11 +342,11 @@ class TestCertificate:
         path = "/name.html"
         rule_1 = {"host": host_1,
                   "paths": [{"path": path, "workloadIds": [self.workload.id],
-                             "targetPort": "80"}]
+                             "targetPort": TEST_IMAGE_PORT}]
                   }
         rule_2 = {"host": host_2,
                   "paths": [{"path": path, "workloadIds": [self.workload.id],
-                             "targetPort": "80"}]
+                             "targetPort": TEST_IMAGE_PORT}]
                   }
         tls = {"certificateId": self.certificate_all_ns_ssc.id,
                "hosts": [host_1]}

--- a/tests/validation/tests/v3_api/test_ingress.py
+++ b/tests/validation/tests/v3_api/test_ingress.py
@@ -16,6 +16,7 @@ from .common import PROJECT_READ_ONLY
 from .common import PROJECT_OWNER
 from .common import PROJECT_MEMBER
 from .common import TEST_IMAGE
+from .common import TEST_IMAGE_PORT
 from .common import random_test_name
 from .common import validate_workload
 from .common import get_schedulable_nodes
@@ -66,7 +67,8 @@ def test_ingress():
     host = "test1.com"
     path = "/name.html"
     rule = {"host": host,
-            "paths": [{"workloadIds": [workload.id], "targetPort": "80"}]}
+            "paths": [{"workloadIds": [workload.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
     p_client.create_ingress(name=name,
                             namespaceId=ns.id,
                             rules=[rule])
@@ -97,9 +99,11 @@ def test_ingress_with_same_rules_having_multiple_targets():
     host = "testm1.com"
     path = "/name.html"
     rule1 = {"host": host,
-             "paths": [{"workloadIds": [workload1.id], "targetPort": "80"}]}
+             "paths": [{"workloadIds": [workload1.id],
+                        "targetPort": TEST_IMAGE_PORT}]}
     rule2 = {"host": host,
-             "paths": [{"workloadIds": [workload2.id], "targetPort": "80"}]}
+             "paths": [{"workloadIds": [workload2.id],
+                        "targetPort": TEST_IMAGE_PORT}]}
     p_client.create_ingress(name=name,
                             namespaceId=ns.id,
                             rules=[rule1, rule2])
@@ -128,7 +132,8 @@ def test_ingress_edit_target():
     host = "test2.com"
     path = "/name.html"
     rule = {"host": host,
-            "paths": [{"workloadIds": [workload1.id], "targetPort": "80"}]}
+            "paths": [{"workloadIds": [workload1.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
     ingress = p_client.create_ingress(name=name,
                                       namespaceId=ns.id,
                                       rules=[rule])
@@ -136,7 +141,8 @@ def test_ingress_edit_target():
                      [workload1], host, path)
 
     rule = {"host": host,
-            "paths": [{"workloadIds": [workload2.id], "targetPort": "80"}]}
+            "paths": [{"workloadIds": [workload2.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
     ingress = p_client.update(ingress, rules=[rule])
     validate_ingress(namespace["p_client"], namespace["cluster"],
                      [workload2], host, path)
@@ -158,7 +164,8 @@ def test_ingress_edit_host():
     host = "test3.com"
     path = "/name.html"
     rule = {"host": host,
-            "paths": [{"workloadIds": [workload.id], "targetPort": "80"}]}
+            "paths": [{"workloadIds": [workload.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
     ingress = p_client.create_ingress(name=name,
                                       namespaceId=ns.id,
                                       rules=[rule])
@@ -166,7 +173,8 @@ def test_ingress_edit_host():
                      [workload], host, path)
     host = "test4.com"
     rule = {"host": host,
-            "paths": [{"workloadIds": [workload.id], "targetPort": "80"}]}
+            "paths": [{"workloadIds": [workload.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
     ingress = p_client.update(ingress, rules=[rule])
     validate_ingress(namespace["p_client"], namespace["cluster"],
                      [workload], host, path)
@@ -188,7 +196,8 @@ def test_ingress_edit_path():
     host = "test5.com"
     path = "/name.html"
     rule = {"host": host,
-            "paths": [{"workloadIds": [workload.id], "targetPort": "80"}]}
+            "paths": [{"workloadIds": [workload.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
     ingress = p_client.create_ingress(name=name,
                                       namespaceId=ns.id,
                                       rules=[rule])
@@ -196,7 +205,8 @@ def test_ingress_edit_path():
                      [workload], host, path)
     path = "/service1.html"
     rule = {"host": host,
-            "paths": [{"workloadIds": [workload.id], "targetPort": "80"}]}
+            "paths": [{"workloadIds": [workload.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
     ingress = p_client.update(ingress, rules=[rule])
     validate_ingress(namespace["p_client"], namespace["cluster"],
                      [workload], host, path)
@@ -223,7 +233,8 @@ def test_ingress_edit_add_more_rules():
     host1 = "test6.com"
     path = "/name.html"
     rule1 = {"host": host1,
-             "paths": [{"workloadIds": [workload1.id], "targetPort": "80"}]}
+             "paths": [{"workloadIds": [workload1.id],
+                        "targetPort": TEST_IMAGE_PORT}]}
     ingress = p_client.create_ingress(name=name,
                                       namespaceId=ns.id,
                                       rules=[rule1])
@@ -232,7 +243,8 @@ def test_ingress_edit_add_more_rules():
 
     host2 = "test7.com"
     rule2 = {"host": host2,
-             "paths": [{"workloadIds": [workload2.id], "targetPort": "80"}]}
+             "paths": [{"workloadIds": [workload2.id],
+                        "targetPort": TEST_IMAGE_PORT}]}
     ingress = p_client.update(ingress, rules=[rule1, rule2])
     validate_ingress(namespace["p_client"], namespace["cluster"],
                      [workload2], host2, path)
@@ -255,7 +267,8 @@ def test_ingress_scale_up_target():
     host = "test8.com"
     path = "/name.html"
     rule = {"host": host,
-            "paths": [{"workloadIds": [workload.id], "targetPort": "80"}]}
+            "paths": [{"workloadIds": [workload.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
     p_client.create_ingress(name=name,
                             namespaceId=ns.id,
                             rules=[rule])
@@ -282,7 +295,8 @@ def test_ingress_upgrade_target():
     host = "test9.com"
     path = "/name.html"
     rule = {"host": host,
-            "paths": [{"workloadIds": [workload.id], "targetPort": "80"}]}
+            "paths": [{"workloadIds": [workload.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
     p_client.create_ingress(name=name,
                             namespaceId=ns.id,
                             rules=[rule])
@@ -311,7 +325,8 @@ def test_ingress_rule_with_only_path():
     host = ""
     path = "/service2.html"
     rule = {"host": host,
-            "paths": [{"workloadIds": [workload.id], "targetPort": "80"}]}
+            "paths": [{"workloadIds": [workload.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
     p_client.create_ingress(name=name,
                             namespaceId=ns.id,
                             rules=[rule])
@@ -333,7 +348,8 @@ def test_ingress_rule_with_only_host():
 
     host = "test10.com"
     rule = {"host": host,
-            "paths": [{"workloadIds": [workload.id], "targetPort": "80"}]}
+            "paths": [{"workloadIds": [workload.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
     p_client.create_ingress(name=name,
                             namespaceId=ns.id,
                             rules=[rule])
@@ -359,7 +375,8 @@ def test_ingress_xip_io():
     path = "/name.html"
     rule = {"host": "xip.io",
             "paths": [{"path": path,
-                       "workloadIds": [workload.id], "targetPort": "80"}]}
+                       "workloadIds": [workload.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
     ingress = p_client.create_ingress(name=name,
                                       namespaceId=ns.id,
                                       rules=[rule])
@@ -383,7 +400,8 @@ def test_rbac_ingress_create(role):
 
     host = "xip.io"
     rule = {"host": host,
-            "paths": [{"workloadIds": [workload.id], "targetPort": "80"}]}
+            "paths": [{"workloadIds": [workload.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
     if role in (CLUSTER_MEMBER, PROJECT_READ_ONLY):
         with pytest.raises(ApiError) as e:
             p_client.create_ingress(name=name,
@@ -418,10 +436,11 @@ def test_rbac_ingress_edit(role):
     host = "xip.io"
     path = "/name.html"
     rule_1 = {"host": host,
-              "paths": [{"workloadIds": [workload.id], "targetPort": "80"}]}
+              "paths": [{"workloadIds": [workload.id],
+                         "targetPort": TEST_IMAGE_PORT}]}
     rule_2 = {"host": host,
               "paths": [{"path": path, "workloadIds": [workload.id],
-                         "targetPort": "80"}]}
+                         "targetPort": TEST_IMAGE_PORT}]}
     name = random_test_name("default")
     ingress = p_client_for_c_owner.create_ingress(name=name, namespaceId=ns.id,
                                                   rules=[rule_1])
@@ -457,7 +476,8 @@ def test_rbac_ingress_delete(role):
 
     host = "xip.io"
     rule = {"host": host,
-            "paths": [{"workloadIds": [workload.id], "targetPort": "80"}]}
+            "paths": [{"workloadIds": [workload.id],
+                       "targetPort": TEST_IMAGE_PORT}]}
 
     ingress = p_client_for_c_owner.create_ingress(name=name, namespaceId=ns.id,
                                                   rules=[rule])

--- a/tests/validation/tests/v3_api/test_upgrade.py
+++ b/tests/validation/tests/v3_api/test_upgrade.py
@@ -271,7 +271,7 @@ def create_and_validate_ingress_xip_io_daemon():
     path = "/name.html"
     rule = {"host": "xip.io",
             "paths":
-                [{"workloadIds": [workload.id], "targetPort": "80",
+                [{"workloadIds": [workload.id], "targetPort": TEST_IMAGE_PORT,
                   "path": path}]}
     p_client.create_ingress(name=ingress_name1_create,
                             namespaceId=ns.id,
@@ -293,7 +293,7 @@ def create_and_validate_ingress_xip_io_wl():
     path = "/name.html"
     rule = {"host": "xip.io",
             "paths":
-                [{"workloadIds": [workload.id], "targetPort": "80",
+                [{"workloadIds": [workload.id], "targetPort": TEST_IMAGE_PORT,
                   "path": path}]}
     p_client.create_ingress(name=ingress_name2_create,
                             namespaceId=ns.id,

--- a/tests/validation/tests/v3_api/test_workload.py
+++ b/tests/validation/tests/v3_api/test_workload.py
@@ -259,7 +259,7 @@ def test_wl_with_hostPort():
     p_client = namespace["p_client"]
     ns = namespace["ns"]
     source_port = 9999
-    port = {"containerPort": 80,
+    port = {"containerPort": TEST_IMAGE_PORT,
             "type": "containerPort",
             "kind": "HostPort",
             "protocol": "TCP",
@@ -282,7 +282,7 @@ def test_wl_with_nodePort():
     p_client = namespace["p_client"]
     ns = namespace["ns"]
     source_port = 30456
-    port = {"containerPort": 80,
+    port = {"containerPort": TEST_IMAGE_PORT,
             "type": "containerPort",
             "kind": "NodePort",
             "protocol": "TCP",
@@ -305,7 +305,7 @@ def test_wl_with_clusterIp():
     p_client = namespace["p_client"]
     ns = namespace["ns"]
     source_port = 30458
-    port = {"containerPort": "80",
+    port = {"containerPort": TEST_IMAGE_PORT,
             "type": "containerPort",
             "kind": "ClusterIP",
             "protocol": "TCP",
@@ -345,7 +345,7 @@ def test_wl_with_lb():
     p_client = namespace["p_client"]
     ns = namespace["ns"]
     source_port = 9001
-    port = {"containerPort": 80,
+    port = {"containerPort": TEST_IMAGE_PORT,
             "type": "containerPort",
             "kind": "LoadBalancer",
             "protocol": "TCP",
@@ -367,7 +367,7 @@ def test_wl_with_clusterIp_scale_and_upgrade():
     p_client = namespace["p_client"]
     ns = namespace["ns"]
     source_port = 30459
-    port = {"containerPort": "80",
+    port = {"containerPort": TEST_IMAGE_PORT,
             "type": "containerPort",
             "kind": "ClusterIP",
             "protocol": "TCP",
@@ -422,7 +422,7 @@ def test_wl_with_nodePort_scale_and_upgrade():
     p_client = namespace["p_client"]
     ns = namespace["ns"]
     source_port = 30457
-    port = {"containerPort": 80,
+    port = {"containerPort": TEST_IMAGE_PORT,
             "type": "containerPort",
             "kind": "NodePort",
             "protocol": "TCP",
@@ -468,7 +468,7 @@ def test_wl_with_hostPort_scale_and_upgrade():
     p_client = namespace["p_client"]
     ns = namespace["ns"]
     source_port = 8888
-    port = {"containerPort": 80,
+    port = {"containerPort": TEST_IMAGE_PORT,
             "type": "containerPort",
             "kind": "HostPort",
             "protocol": "TCP",
@@ -517,7 +517,7 @@ def test_wl_with_lb_scale_and_upgrade():
     p_client = namespace["p_client"]
     ns = namespace["ns"]
     source_port = 9001
-    port = {"containerPort": 80,
+    port = {"containerPort": TEST_IMAGE_PORT,
             "type": "containerPort",
             "kind": "LoadBalancer",
             "protocol": "TCP",


### PR DESCRIPTION
I've built public image: `maxross/mytestcontainer:unprivileged` with the Dockerfile here. 

When running on a CIS hardened cluster, it should be run with the following parameters:
```
PYTEST_OPTIONS=-k "test_wl or test_dns_record or test_rbac or test_connectivity or test_ingress or test_secrets or test_service_discovery or test_websocket"
RANCHER_TEST_IMAGE=maxross/mytestcontainer:unprivileged
RANCHER_TEST_IMAGE_NGINX=nginxinc/nginx-unprivileged
RANCHER_TEST_IMAGE_PORT=8080
RANCHER_HARDENED_CLUSTER=True
RANCHER_SKIP_PING_CHECK_TEST=True
```
Note PYTEST_OPTIONS may include other tests as well, but I've listed what works for BOTH rke2 and rke1. For rke1, you should be able to run bkp_restore tests and CIS tests as well, though running with those options has not been fully validated with the changes here.
For rke2, run `test_ingress_xip_io` instead of `test_ingress`