### PR TITLE
[Validation] - Jenkins - override folder properties with job parameters

### DIFF
--- a/tests/validation/tests/v3_api/Jenkinsfile
+++ b/tests/validation/tests/v3_api/Jenkinsfile
@@ -23,6 +23,11 @@ node {
 
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
     withFolderProperties {
+      paramsMap = []
+      params.each {
+        paramsMap << "$it.key=$it.value"
+      }
+      withEnv(paramsMap) {
       withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
                         string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
                         string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'RANCHER_EKS_ACCESS_KEY'),
@@ -118,5 +123,6 @@ node {
         }
       }
     }
+  } 
   }
 }

--- a/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test
+++ b/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test
@@ -32,6 +32,11 @@ node {
 
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
     withFolderProperties {
+      paramsMap = []
+      params.each {
+        paramsMap << "$it.key=$it.value"
+      }
+      withEnv(paramsMap) {
       withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
                         string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
                         string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'RANCHER_EKS_ACCESS_KEY'),
@@ -195,6 +200,7 @@ node {
           } // finally
         } // dir 
       } // creds
+      } //env
     } // folder properties
   } // wrap 
 } // node

--- a/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_support_matrix
+++ b/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_support_matrix
@@ -33,6 +33,11 @@ node {
 
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
     withFolderProperties {
+      paramsMap = []
+      params.each {
+        paramsMap << "$it.key=$it.value"
+      }
+      withEnv(paramsMap) {
       withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
                         string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
                         string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'RANCHER_EKS_ACCESS_KEY'),
@@ -238,6 +243,7 @@ node {
           } // finally
         } // dir
       } // creds
+      } // env
     } // folder properties
   } // wrap
 } // node

--- a/tests/validation/tests/v3_api/Jenkinsfile_provisioning_tests
+++ b/tests/validation/tests/v3_api/Jenkinsfile_provisioning_tests
@@ -21,6 +21,11 @@ if ("${env.branch}" != "null" && "${env.branch}" != "") {
 node {
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
     withFolderProperties {
+      paramsMap = []
+      params.each {
+        paramsMap << "$it.key=$it.value"
+      }
+      withEnv(paramsMap) {
       withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
                         string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
                         string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
@@ -112,6 +117,7 @@ node {
             sh "docker rmi ${imageName}"
           }
         }
+      }
       }
     }  
   }


### PR DESCRIPTION
Currently in Jenkins, folder properties are overriding parameters set in the jobs. 

This PR applies the parameters after the folder properties are resolved, preventing the folder properties from incorrectly overriding the job parameters. 