### PR TITLE
Changed EKS nodegroup error message

### DIFF
--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -232,7 +232,10 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 			}
 		}
 
-		addNgMessage := "Cannot deploy agent without nodegroups. Add a nodegroup."
+		// cluster must have at least one managed nodegroup. It is possible for a cluster
+		// agent to be deployed without one, but having a managed nodegroup makes it easy
+		// for rancher to validate its ability to do so.
+		addNgMessage := "Cluster must have at least one managed nodegroup."
 		noNodeGroupsOnSpec := len(cluster.Spec.EKSConfig.NodeGroups) == 0
 		noNodeGroupsOnUpstreamSpec := len(cluster.Status.EKSStatus.UpstreamSpec.NodeGroups) == 0
 		if (cluster.Spec.EKSConfig.NodeGroups != nil && noNodeGroupsOnSpec) || (cluster.Spec.EKSConfig.NodeGroups == nil && noNodeGroupsOnUpstreamSpec) {


### PR DESCRIPTION
**Problem:**
Prior, error message did not specify that managed nodegroups were
necessary. This confused users who had cluster with non-managed
nodegroups. The message also states the agent cannot be deployed
which isn't true; it is possible the agent will deploy with a
non-managed nodegroup.

**Solution:**
Now, the message has been revised to be
more accurate and a comment has been added to explain some of
the reasoning behind the requirement.

**Issue:**
https://github.com/rancher/rancher/issues/30041