### PR TITLE
Fix the additionalOption key read by rancher globaldns controller to add annotation-filter command param to external-dns

### DIFF
--- a/pkg/controllers/management/globaldns/globaldns_handler.go
+++ b/pkg/controllers/management/globaldns/globaldns_handler.go
@@ -27,7 +27,7 @@ import (
 const (
 	GlobaldnsController    = "mgmt-global-dns-controller"
 	annotationIngressClass = "kubernetes.io/ingress.class"
-	annotationFilter       = "annotation-filter"
+	annotationFilter       = "annotationFilter"
 	annotationDNSTTL       = "external-dns.alpha.kubernetes.io/ttl"
 	defaultIngressClass    = "rancher-external-dns"
 )


### PR DESCRIPTION
The goal is to add "annotation-filter" parameter for https://github.com/kubernetes-sigs/external-dns

But to set this via Rancher's globalDNSProvider, this parameter `annotationFilter` in the external-dns chart needs to be set in additionalOptions values when Rancher controller deploys the  chart https://github.com/rancher/system-charts/blob/dev-v2.5/charts/rancher-external-dns/v0.1.2/values.yaml#L88

Now the global_dns controller reads this parameter is read from  additionalOptions map and put on the dummy ingress. The controller was reading the parameter named "annotation-filter", but instead needs to read "annotationFilter"

