### PR TITLE
[2.4] Fix the additionalOption key read by rancher globaldns controller to add annotation-filter command param to external-dns

### DIFF
--- a/pkg/controllers/management/globaldns/globaldns_handler.go
+++ b/pkg/controllers/management/globaldns/globaldns_handler.go
@@ -27,7 +27,7 @@ import (
 const (
 	GlobaldnsController    = "mgmt-global-dns-controller"
 	annotationIngressClass = "kubernetes.io/ingress.class"
-	annotationFilter       = "annotation-filter"
+	annotationFilter       = "annotationFilter"
 	annotationDNSTTL       = "external-dns.alpha.kubernetes.io/ttl"
 	defaultIngressClass    = "rancher-external-dns"
 )


### PR DESCRIPTION
Backport for PR https://github.com/rancher/rancher/pull/30839 
Fix the additionalOption key read by rancher globaldns controller to add annotation-filter command param to external-dns