### PR TITLE
[2.5] Backport LKE cluster driver

### DIFF
--- a/pkg/data/management/kontainerdriver_data.go
+++ b/pkg/data/management/kontainerdriver_data.go
@@ -100,6 +100,16 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 	); err != nil {
 		return err
 	}
+	if err := creator.addCustomDriver(
+		"linodekubernetesengine",
+		"https://github.com/linode/kontainer-engine-driver-lke/releases/download/v0.0.3/kontainer-engine-driver-lke-linux-amd64",
+		"02fa95d24a1c6f9c520307e24a543c1777ed21fc3a4f060434e067806578e647",
+		"",
+		false,
+		"api.linode.com",
+	); err != nil {
+		return err
+	}
 
 	if err := creator.addCustomDriver(
 		"opentelekomcloudcontainerengine",

--- a/tests/integration/suite/test_rbac.py
+++ b/tests/integration/suite/test_rbac.py
@@ -577,14 +577,14 @@ def ns_count(client, count):
 
 def test_appropriate_users_can_see_kontainer_drivers(user_factory):
     kds = user_factory().client.list_kontainer_driver()
-    assert len(kds) == 10
+    assert len(kds) == 11
 
     kds = user_factory('clusters-create').client.list_kontainer_driver()
-    assert len(kds) == 10
+    assert len(kds) == 11
 
     kds = user_factory('kontainerdrivers-manage').client. \
         list_kontainer_driver()
-    assert len(kds) == 10
+    assert len(kds) == 11
 
     kds = user_factory('settings-manage').client.list_kontainer_driver()
     assert len(kds) == 0


### PR DESCRIPTION
This PR brings brings the changes from https://github.com/rancher/rancher/pull/30668 into the v2.5 release branch.