### PR TITLE
[Validation] - Add trace logging to single node and HA installs for automation

### DIFF
--- a/tests/validation/tests/v3_api/test_airgap.py
+++ b/tests/validation/tests/v3_api/test_airgap.py
@@ -568,7 +568,7 @@ def deploy_airgap_rancher(bastion_node):
             '-v ${{PWD}}/privkey.pem:/etc/rancher/ssl/key.pem ' \
             '-e CATTLE_SYSTEM_DEFAULT_REGISTRY={} ' \
             '-e CATTLE_SYSTEM_CATALOG=bundled ' \
-            '{}/rancher/rancher:{} --no-cacerts'.format(
+            '{}/rancher/rancher:{} --no-cacerts --trace'.format(
                 privileged, bastion_node.host_name, bastion_node.host_name,
                 RANCHER_SERVER_VERSION)
     else:
@@ -576,7 +576,7 @@ def deploy_airgap_rancher(bastion_node):
             'sudo docker run -d {} --restart=unless-stopped ' \
             '-p 80:80 -p 443:443 ' \
             '-e CATTLE_SYSTEM_DEFAULT_REGISTRY={} ' \
-            '-e CATTLE_SYSTEM_CATALOG=bundled {}/rancher/rancher:{}'.format(
+            '-e CATTLE_SYSTEM_CATALOG=bundled {}/rancher/rancher:{} --trace'.format(
                 privileged, bastion_node.host_name, bastion_node.host_name,
                 RANCHER_SERVER_VERSION)
     deploy_result = run_command_on_airgap_node(bastion_node, ag_node,

--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -305,6 +305,13 @@ def install_rancher(type=RANCHER_HA_CERT_OPTION, repo=RANCHER_HELM_REPO,
     run_command_with_stderr(helm_rancher_cmd)
     time.sleep(120)
 
+    # set trace logging
+    set_trace_cmd = "kubectl -n cattle-system get pods -l app=rancher " + \
+        "--no-headers -o custom-columns=name:.metadata.name | " + \
+        "while read rancherpod; do kubectl -n cattle-system " + \
+        "exec $rancherpod -c rancher -- loglevel --set trace; done"
+    run_command_with_stderr(set_trace_cmd)
+
 
 def create_tls_secrets(valid_cert):
     cert_path = DATA_SUBDIR + "/tls.crt"

--- a/tests/validation/tests/v3_api/test_custom_host_reg.py
+++ b/tests/validation/tests/v3_api/test_custom_host_reg.py
@@ -54,7 +54,7 @@ def test_deploy_rancher_server():
             'sudo docker run -d --name="rancher-server" ' \
             '--restart=unless-stopped -p 80:80 -p 443:443  ' \
             'rancher/rancher'
-    RANCHER_SERVER_CMD += ":" + RANCHER_SERVER_VERSION
+    RANCHER_SERVER_CMD += ":" + RANCHER_SERVER_VERSION + " --trace"
     print(RANCHER_SERVER_CMD)
     aws_nodes = AmazonWebServices().create_multiple_nodes(
         1, random_test_name("testsa" + HOST_NAME))

--- a/tests/validation/tests/v3_api/test_proxy.py
+++ b/tests/validation/tests/v3_api/test_proxy.py
@@ -145,7 +145,7 @@ def deploy_proxy_rancher(bastion_node):
         '-e HTTPS_PROXY={} ' \
         '-e NO_PROXY="localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,' \
         'cattle-system.svc" ' \
-        'rancher/rancher:{}'.format(
+        'rancher/rancher:{} --trace'.format(
             proxy_url, proxy_url,
             RANCHER_SERVER_VERSION)
 

--- a/tests/validation/tests/v3_api/test_upgrade.py
+++ b/tests/validation/tests/v3_api/test_upgrade.py
@@ -620,7 +620,8 @@ def upgrade_rancher_server(serverIp,
 
     runCommand = "docker run -d --volumes-from rancher-data " \
                  "--restart=unless-stopped " \
-                 "-p 80:80 -p 443:443 " + upgradeImage + ":" + upgradeVersion
+                 "-p 80:80 -p 443:443 " + upgradeImage + ":" + upgradeVersion + \
+                 " --trace"
     print(exec_shell_command(serverIp, 22, runCommand, "",
           sshUser, sshKeyPath))
 


### PR DESCRIPTION
Add trace logging to single node Docker installs through `--trace` flag in `docker run`, and through `kubectl` with a Helm install. 