### PR TITLE
[release/v2.5] Remove noiro (Cisco ACI) images from image list

### DIFF
--- a/pkg/api/norman/customization/kontainerdriver/actionhandler.go
+++ b/pkg/api/norman/customization/kontainerdriver/actionhandler.go
@@ -125,6 +125,15 @@ func (lh ListHandler) LinkHandler(apiContext *types.APIContext, next types.Reque
 			// removing weave images since it's not supported
 			rkeSysImgCopy.WeaveNode = ""
 			rkeSysImgCopy.WeaveCNI = ""
+			// removing noiro (Cisco ACI) since it's not supported
+			rkeSysImgCopy.AciCniDeployContainer = ""
+			rkeSysImgCopy.AciHostContainer = ""
+			rkeSysImgCopy.AciOpflexContainer = ""
+			rkeSysImgCopy.AciMcastContainer = ""
+			rkeSysImgCopy.AciOpenvSwitchContainer = ""
+			rkeSysImgCopy.AciControllerContainer = ""
+			rkeSysImgCopy.AciOpflexServerContainer = ""
+			rkeSysImgCopy.AciGbpServerContainer = ""
 		case windowsImages:
 			majorVersion := util.GetTagMajorVersion(k8sVersion)
 			if mVersion.Compare(majorVersion, "v1.13", "<=") {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/30840

Backport of https://github.com/rancher/rancher/pull/30884