### PR TITLE
Fix k3s upgrade dev image export

### DIFF
--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -195,15 +195,15 @@ func (h *handler) deployK3sBasedUpgradeController(clusterName string, isK3s, isR
 // isNewerVersion returns true if updated versions semver is newer and false if its
 // semver is older. If semver is equal then metadata is alphanumerically compared.
 func IsNewerVersion(prevVersion, updatedVersion string) (bool, error) {
-	parseErrMsg := "failed to parse version: %v"
+	parseErrMsg := "failed to parse version [%s]: %v"
 	prevVer, err := semver.NewVersion(strings.TrimPrefix(prevVersion, "v"))
 	if err != nil {
-		return false, fmt.Errorf(parseErrMsg, err)
+		return false, fmt.Errorf(parseErrMsg, prevVersion, err)
 	}
 
 	updatedVer, err := semver.NewVersion(strings.TrimPrefix(updatedVersion, "v"))
 	if err != nil {
-		return false, fmt.Errorf(parseErrMsg, err)
+		return false, fmt.Errorf(parseErrMsg, updatedVersion, err)
 	}
 
 	switch updatedVer.Compare(*prevVer) {

--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -267,35 +267,46 @@ func getK3sUpgradeImages(rancherVersion string, k3sData map[string]interface{}) 
 			continue
 		}
 
-		if rancherVersion != "dev" {
-			maxVersion, _ := releaseMap["maxChannelServerVersion"].(string)
-			maxVersion = strings.TrimPrefix(maxVersion, "v")
-			if maxVersion == "" {
-				continue
-			}
-			minVersion, _ := releaseMap["minChannelServerVersion"].(string)
-			minVersion = strings.Trim(minVersion, "v")
-			if minVersion == "" {
-				continue
-			}
+		maxVersion, _ := releaseMap["maxChannelServerVersion"].(string)
+		maxVersion = strings.TrimPrefix(maxVersion, "v")
+		if maxVersion == "" {
+			continue
+		}
+		minVersion, _ := releaseMap["minChannelServerVersion"].(string)
+		minVersion = strings.Trim(minVersion, "v")
+		if minVersion == "" {
+			continue
+		}
 
-			versionGTMin, err := k3sbasedupgrade.IsNewerVersion(minVersion, rancherVersion)
-			if err != nil {
-				continue
-			}
-			if rancherVersion != minVersion && !versionGTMin {
-				// rancher version not equal to or greater than minimum supported rancher version
-				continue
-			}
+		var versionGTMin bool
+		var err error
+		if rancherVersion == kd.RancherVersionDev {
+			versionGTMin, err = k3sbasedupgrade.IsNewerVersion(minVersion, rancherVersion+".999")
+		} else {
+			versionGTMin, err = k3sbasedupgrade.IsNewerVersion(minVersion, rancherVersion)
+		}
+		if err != nil {
+			logrus.Errorf("%v", err)
+			continue
+		}
+		if rancherVersion != minVersion && !versionGTMin {
+			// rancher version not equal to or greater than minimum supported rancher version
+			continue
+		}
 
-			versionLTMax, err := k3sbasedupgrade.IsNewerVersion(rancherVersion, maxVersion)
-			if err != nil {
-				continue
-			}
-			if rancherVersion != maxVersion && !versionLTMax {
-				// rancher version not equal to or greater than maximum supported rancher version
-				continue
-			}
+		var versionLTMax bool
+		if rancherVersion == kd.RancherVersionDev {
+			versionLTMax, err = k3sbasedupgrade.IsNewerVersion(rancherVersion+".0", maxVersion)
+		} else {
+			versionLTMax, err = k3sbasedupgrade.IsNewerVersion(rancherVersion, maxVersion)
+		}
+		if err != nil {
+			logrus.Errorf("%v", err)
+			continue
+		}
+		if rancherVersion != maxVersion && !versionLTMax {
+			// rancher version not equal to or greater than maximum supported rancher version
+			continue
 		}
 
 		compatibleReleases = append(compatibleReleases, version)


### PR DESCRIPTION
Prior, using export script with TAG set to dev, master, or a
value equal to kd.RancherVersionDev would result in no k3s
upgrade or related images being added to the images text.
This is because kd.RancherVersionDev does not contain a
valid semver version. This happens to dev and master because
those values are overwritten with the value of
kd.RancherVersionDev if detected. Now, versions are used for
comparison that match the minor and major version of
kd.RancherVersionDev and will match any constraints that
could be met by any version that would also have matching
major and minor versions.