### PR TITLE
We need not pull the memberof attribute of a group when listing groups during user login

### DIFF
--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -264,7 +264,7 @@ func (p *adProvider) getGroupPrincipalsFromSearch(searchBase string, filter stri
 	search := ldapv2.NewSearchRequest(searchBase,
 		ldapv2.ScopeWholeSubtree, ldapv2.NeverDerefAliases, 0, 0, false,
 		filter,
-		ldap.GetGroupSearchAttributes(MemberOfAttribute, ObjectClass, config), nil)
+		ldap.GetGroupSearchAttributes(config, ObjectClass), nil)
 
 	serviceAccountUsername := ldap.GetUserExternalID(config.ServiceAccountUsername, config.DefaultLoginDomain)
 	err := lConn.Bind(serviceAccountUsername, config.ServiceAccountPassword)
@@ -380,7 +380,7 @@ func (p *adProvider) getPrincipal(distinguishedName string, scope string, config
 		search = ldapv2.NewSearchRequest(distinguishedName,
 			ldapv2.ScopeBaseObject, ldapv2.NeverDerefAliases, 0, 0, false,
 			filter,
-			ldap.GetGroupSearchAttributes(MemberOfAttribute, ObjectClass, config), nil)
+			ldap.GetGroupSearchAttributes(config, MemberOfAttribute, ObjectClass), nil)
 	}
 
 	result, err := lConn.Search(search)
@@ -471,7 +471,7 @@ func (p *adProvider) searchLdap(query string, scope string, config *v32.ActiveDi
 		search = ldapv2.NewSearchRequest(searchDomain,
 			ldapv2.ScopeWholeSubtree, ldapv2.NeverDerefAliases, 0, 0, false,
 			query,
-			ldap.GetGroupSearchAttributes(MemberOfAttribute, ObjectClass, config), nil)
+			ldap.GetGroupSearchAttributes(config, MemberOfAttribute, ObjectClass), nil)
 	}
 
 	// Bind before query

--- a/pkg/auth/providers/common/ldap/ldap_util.go
+++ b/pkg/auth/providers/common/ldap/ldap_util.go
@@ -139,13 +139,13 @@ func GetUserSearchAttributes(memberOfAttribute, ObjectClass string, config *v32.
 	return userSearchAttributes
 }
 
-func GetGroupSearchAttributes(memberOfAttribute, ObjectClass string, config *v32.ActiveDirectoryConfig) []string {
-	groupSeachAttributes := []string{memberOfAttribute,
-		ObjectClass,
+func GetGroupSearchAttributes(config *v32.ActiveDirectoryConfig, searchAttributes ...string) []string {
+	groupSeachAttributes := []string{
 		config.GroupObjectClass,
 		config.UserLoginAttribute,
 		config.GroupNameAttribute,
 		config.GroupSearchAttribute}
+	groupSeachAttributes = append(groupSeachAttributes, searchAttributes...)
 	return groupSeachAttributes
 }
 


### PR DESCRIPTION
When a user logs in, we pull all the groups that he is a memberOf. While pulling details of each group, the attribute "memberOf" of a group that lists all the parent groups of this group, need not be synced from the AD as we only need the group DN and some important attributes.
This saves some time needed to sync the groups of a user during login, particularly significant if the user is part of large number(1000) of groups.

The query to gather parent groups when nested groups are enabled, remains unchanged by this fix.

https://github.com/rancher/rancher/issues/30869