### PR TITLE
Prevent panic seen intermittently while logging in with SAML

### DIFF
--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -59,6 +59,8 @@ func InitializeSamlServiceProvider(configToSet *v32.SamlConfig, name string) err
 	var err error
 	var ok bool
 
+	log.Debugf("SAML [InitializeSamlServiceProvider]: Validating input for provider %v", name)
+
 	if configToSet.IDPMetadataContent == "" {
 		return fmt.Errorf("SAML: Cannot initialize saml SP properly, missing IDP URL/metadata in the config %v", configToSet)
 	}
@@ -115,7 +117,12 @@ func InitializeSamlServiceProvider(configToSet *v32.SamlConfig, name string) err
 		}
 	}
 
-	provider := SamlProviders[name]
+	provider, ok := SamlProviders[name]
+	if !ok {
+		return fmt.Errorf("SAML [InitializeSamlServiceProvider]: Provider %v not configured", name)
+	}
+
+	log.Debugf("SAML [InitializeSamlServiceProvider]: Initializing provider %v", name)
 
 	rancherAPIHost := strings.TrimRight(configToSet.RancherAPIHost, "/")
 	samlURL := rancherAPIHost + "/v1-saml/"

--- a/pkg/auth/providers/saml/saml_handlers.go
+++ b/pkg/auth/providers/saml/saml_handlers.go
@@ -73,7 +73,7 @@ func (s *Provider) HandleSamlLogin(w http.ResponseWriter, r *http.Request) (stri
 	if r.URL.Path == serviceProvider.AcsURL.Path {
 		return "", fmt.Errorf("don't wrap Middleware with RequireAccount")
 	}
-
+	log.Debugf("SAML [HandleSamlLogin]: Creating authentication request for %v", s.name)
 	binding := saml.HTTPRedirectBinding
 	bindingLocation := serviceProvider.GetSSOBindingLocation(binding)
 

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -115,6 +115,15 @@ func PerformSamlLogin(name string, apiContext *types.APIContext, input interface
 	finalRedirectURL := login.FinalRedirectURL
 
 	if provider, ok := SamlProviders[name]; ok {
+		if provider == nil {
+			logrus.Errorf("SAML: Provider %v not initialized", name)
+			return fmt.Errorf("SAML: Provider %v not initialized", name)
+		}
+		if provider.clientState == nil {
+			logrus.Errorf("SAML: Provider %v clientState not set", name)
+			return fmt.Errorf("SAML: Provider %v clientState not set", name)
+		}
+		logrus.Debugf("SAML [PerformSamlLogin]: Setting clientState for SAML service provider %v", name)
 		provider.clientState.SetState(apiContext.Response, apiContext.Request, "Rancher_FinalRedirectURL", finalRedirectURL)
 		provider.clientState.SetState(apiContext.Response, apiContext.Request, "Rancher_Action", loginAction)
 		provider.clientState.SetState(apiContext.Response, apiContext.Request, "Rancher_PublicKey", login.PublicKey)
@@ -125,6 +134,7 @@ func PerformSamlLogin(name string, apiContext *types.APIContext, input interface
 		if err != nil {
 			return err
 		}
+		logrus.Debugf("SAML [PerformSamlLogin]: Redirecting to the identity provider login page at %v", idpRedirectURL)
 		data := map[string]interface{}{
 			"idpRedirectUrl": idpRedirectURL,
 			"type":           "samlLoginOutput",


### PR DESCRIPTION
On HA setups when SAML is configured, at times login throws a 404 with this panic in the logs:
```
2021/01/21 21:00:38 [ERROR] Panic serving api request:
22/01/2021 10:00:38 am goroutine 485670 [running]:
22/01/2021 10:00:38 am runtime/debug.Stack(0xc002b1fdc0, 0x3c26060, 0x7390960)
22/01/2021 10:00:38 am 	/usr/local/go/src/runtime/debug/stack.go:24 +0x9d
22/01/2021 10:00:38 am github.com/rancher/norman/api.(*Server).ServeHTTP.func1(0x4e78ba0, 0xc024211360)
22/01/2021 10:00:38 am 	/go/pkg/mod/github.com/rancher/norman@v0.0.0-20200930000340-693d65aaffe3/api/server.go:175 +0x7a
22/01/2021 10:00:38 am panic(0x3c26060, 0x7390960)
22/01/2021 10:00:38 am 	/usr/local/go/src/runtime/panic.go:969 +0x166
22/01/2021 10:00:38 am github.com/rancher/rancher/pkg/auth/providers/saml.PerformSamlLogin(0x44d8204, 0x4, 0xc0143dcfc0, 0x3c5dd00, 0xc023368680, 0x0, 0x0)
22/01/2021 10:00:38 am 	/go/src/github.com/rancher/rancher/pkg/auth/providers/saml/saml_provider.go:118 +0xc7
22/01/2021 10:00:38 am github.com/rancher/rancher/pkg/auth/providers/publicapi.(*loginHandler).createLoginToken(0xc00efb2780, 0xc0143dcfc0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
22/01/2021 10:00:38 am 	/go/src/github.com/rancher/rancher/pkg/auth/providers/publicapi/login.go:172 +0x905
22/01/2021 10:00:38 am github.com/rancher/rancher/pkg/auth/providers/publicapi.(*loginHandler).login(0xc00efb2780, 0xc00678bb6a, 0x5, 0xc014471420, 0xc0143dcfc0, 0xc00482e5a0, 0xc0197ba4b0)
22/01/2021 10:00:38 am 	/go/src/github.com/rancher/rancher/pkg/auth/providers/publicapi/login.go:57 +0x152
22/01/2021 10:00:38 am github.com/rancher/norman/api.handleAction(0xc014471420, 0xc0143dcfc0, 0x0, 0x0)
22/01/2021 10:00:38 am 	/go/pkg/mod/github.com/rancher/norman@v0.0.0-20200930000340-693d65aaffe3/api/server.go:263 +0x62
```
The panic is at [line 118](https://github.com/rancher/rancher/blob/master/pkg/auth/providers/saml/saml_provider.go#L118). The provider and the clientState for cookies should have been set by this point. This PR is to prevent that panic and add error message to further see and investigate what hasn't been initialized. 