### PR TITLE
[2.5] Fix unable to view namespace yaml

### DIFF
--- a/pkg/api/norman/customization/namespace/link.go
+++ b/pkg/api/norman/customization/namespace/link.go
@@ -76,6 +76,7 @@ func (s *yamlLinkHandler) LinkHandler(apiContext *types.APIContext, next types.R
 			req.SetHeader(k, v...)
 		}
 		req.SetHeader("Accept", "*/*")
+		req.SetHeader("Accept-Encoding", "identity")
 
 		r, err := req.Do(apiContext.Request.Context()).Get()
 		if err != nil {


### PR DESCRIPTION
**Problem:**

some namespace gets error `invalid character '\x1f' looking for beginning of value` when editing YAML.

**Solution:**

If the content of the resource is too large, the returned content will be compressed by gzip, add the request header `Accept-Encoding: identity` to prevent compression.

**Relate issue:**

https://github.com/rancher/rancher/issues/26390