### PR TITLE
adding dnspolicy and tolerations to shell/helm

### DIFF
--- a/pkg/api/steve/clusters/shell.go
+++ b/pkg/api/steve/clusters/shell.go
@@ -103,6 +103,7 @@ func (s *shell) createPod() *v1.Pod {
 			Namespace:    s.namespace,
 		},
 		Spec: v1.PodSpec{
+			DNSPolicy:                     "Default",
 			TerminationGracePeriodSeconds: new(int64),
 			RestartPolicy:                 v1.RestartPolicyNever,
 			NodeSelector: map[string]string{
@@ -114,6 +115,18 @@ func (s *shell) createPod() *v1.Pod {
 					Operator: "Equal",
 					Value:    "linux",
 					Effect:   "NoSchedule",
+				},
+				{
+					Key:      "node-role.kubernetes.io/controlplane",
+					Operator: "Equal",
+					Value:    "true",
+					Effect:   "NoSchedule",
+				},
+				{
+					Key:      "node-role.kubernetes.io/etcd",
+					Operator: "Equal",
+					Value:    "true",
+					Effect:   "NoExecute",
 				},
 			},
 			Containers: []v1.Container{

--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -732,6 +732,7 @@ func (s *Operations) createPod(secretData map[string][]byte) (*v1.Pod, *podimper
 			Namespace:    s.namespace,
 		},
 		Spec: v1.PodSpec{
+			DNSPolicy: "Default",
 			Volumes: []v1.Volume{
 				{
 					Name: "data",
@@ -753,6 +754,18 @@ func (s *Operations) createPod(secretData map[string][]byte) (*v1.Pod, *podimper
 					Operator: "Equal",
 					Value:    "linux",
 					Effect:   "NoSchedule",
+				},
+				{
+					Key:      "node-role.kubernetes.io/controlplane",
+					Operator: "Equal",
+					Value:    "true",
+					Effect:   "NoSchedule",
+				},
+				{
+					Key:      "node-role.kubernetes.io/etcd",
+					Operator: "Equal",
+					Value:    "true",
+					Effect:   "NoExecute",
 				},
 			},
 			Containers: []v1.Container{

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -161,6 +161,7 @@ spec:
                 - "true"
             weight: 1
       serviceAccountName: cattle
+      dnsPolicy: Default
       tolerations:
       {{- if .Tolerations }}
       # Tolerations added based on found taints on controlplane nodes


### PR DESCRIPTION
Problem: boot a cluster with only etcd and controlplane nodes, with no worker coredns doesn't come up and the cluster-agent can not talk back to the rancher server url and make the cluster accessible. additionally, targeting for the shell fails due to taints.
Fix: Add dnspolicy default to the cluster-agent so when it boots it will use the node's dns settings. Add tolerations to the shell/helmop for controlplane nodes so the pods will assign and the tunnels will com up.

https://github.com/rancher/rancher/issues/31244