### PR TITLE
Move document ending to if statment

### DIFF
--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -217,10 +217,9 @@ spec:
         secret:
           secretName: cattle-credentials-{{.TokenKey}}
           defaultMode: 320
+{{ if .IsRKE }}
 
 ---
-
-{{ if .IsRKE }}
 
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
Problem:
Currently, this will leave a --- at the end of the document which
indicates another document is coming. This causes the k8s python client
to break as it expects another document

Solution:
Move the if check for the next section so the --- is only added if it's
needed

https://github.com/rancher/rancher/issues/31252