### PR TITLE
[v2.4] uncordon upgraded nodes stuck in cordoned state

### DIFF
--- a/pkg/controllers/management/rkeworkerupgrader/node.go
+++ b/pkg/controllers/management/rkeworkerupgrader/node.go
@@ -22,6 +22,8 @@ type upgradeStatus struct {
 	toProcess []*v3.Node
 	// upgrading => upgraded => uncordon
 	upgraded []*v3.Node
+	// notReady => stuck in cordoned (For unavailable nodes get new plan without NodeConditionUpgraded)
+	toUncordon []*v3.Node
 	// unavailable nodes
 	notReady []*v3.Node
 	// upgraded active nodes
@@ -159,6 +161,10 @@ func (uh *upgradeHandler) filterNodes(nodes []*v3.Node, expectedVersion int, dra
 			} else {
 				// node hasn't un-cordoned, so consider it upgrading in terms of maxUnavailable count
 				status.upgrading++
+				// node has already upgraded, but condition is not unknown, so uncordon it
+				if !v3.NodeConditionUpgraded.IsUnknown(node) && node.Spec.DesiredNodeUnschedulable != "false" {
+					status.toUncordon = append(status.toUncordon, node)
+				}
 			}
 			continue
 		}

--- a/pkg/controllers/management/rkeworkerupgrader/upgrade.go
+++ b/pkg/controllers/management/rkeworkerupgrader/upgrade.go
@@ -284,8 +284,8 @@ func (uh *upgradeHandler) upgradeCluster(cluster *v3.Cluster, nodeName string, p
 	}
 
 	logrus.Debugf("cluster [%s] worker-upgrade: workerNodeInfo: nodes %v maxAllowed %v upgrading %v notReady %v "+
-		"toProcess %v toPrepare %v done %v", cluster.Name, status.filtered, maxAllowed, status.upgrading,
-		keys(status.notReady), keys(status.toProcess), keys(status.toPrepare), keys(status.upgraded))
+		"toProcess %v toPrepare %v done %v toUncordon %v", cluster.Name, status.filtered, maxAllowed, status.upgrading,
+		keys(status.notReady), keys(status.toProcess), keys(status.toPrepare), keys(status.upgraded), keys(status.toUncordon))
 
 	for _, node := range status.upgraded {
 		if v3.NodeConditionUpgraded.IsTrue(node) {
@@ -296,6 +296,13 @@ func (uh *upgradeHandler) upgradeCluster(cluster *v3.Cluster, nodeName string, p
 			return err
 		}
 
+		logrus.Infof("cluster [%s] worker-upgrade: updated node [%s] to uncordon", clusterName, node.Name)
+	}
+
+	for _, node := range status.toUncordon {
+		if err := uh.updateNodeActive(node); err != nil {
+			return err
+		}
 		logrus.Infof("cluster [%s] worker-upgrade: updated node [%s] to uncordon", clusterName, node.Name)
 	}
 


### PR DESCRIPTION
Forward port: https://github.com/rancher/rancher/pull/31267

Problem:
An unavailable node is always reconciled to desired
state bypassing the usual cordon->upgrade->uncordon
path. If they become ready later on, node could have
already been upgraded before it's marked for upgrade
(NodeConditionUpgraded is never set). So the node
never gets uncordoned since we rely on node conditions.

https://github.com/rancher/rancher/issues/31268