### PR TITLE
Skip app tests on hardened clusters

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -53,6 +53,9 @@ if TEST_OS == "windows":
 skip_test_windows_os = pytest.mark.skipif(
     TEST_OS == "windows",
     reason='Tests Skipped for including Windows nodes cluster')
+skip_test_hardened = pytest.mark.skipif(
+    HARDENED_CLUSTER,
+    reason='Tests Skipped due to being a hardened cluster')
 
 UPDATE_KDM = ast.literal_eval(os.environ.get('RANCHER_UPDATE_KDM', "False"))
 KDM_URL = os.environ.get("RANCHER_KDM_URL", "")

--- a/tests/validation/tests/v3_api/test_upgrade.py
+++ b/tests/validation/tests/v3_api/test_upgrade.py
@@ -124,6 +124,7 @@ def test_validate_existing_wl_with_secret():
 # It's hard to find an App to support Windows case for now.
 # Could we make an App to support both Windows and Linux?
 @skip_test_windows_os
+@skip_test_hardened
 @if_post_upgrade
 @pytest.mark.run(order=2)
 def test_validate_existing_catalog_app():
@@ -167,6 +168,7 @@ def test_modify_workload_validate_secret():
 # It's hard to find an App to support Windows case for now.
 # Could we make an App to support both Windows and Linux?
 @skip_test_windows_os
+@skip_test_hardened
 @if_post_upgrade
 @pytest.mark.run(order=3)
 def test_modify_catalog_app():
@@ -214,7 +216,7 @@ def test_create_and_validate_ingress_xip_io_wl():
 
 # It's hard to find an App to support Windows case for now.
 # Could we make an App to support both Windows and Linux?
-@skip_test_windows_os
+@skip_test_hardened
 @pytest.mark.run(order=5)
 def test_create_and_validate_catalog_app():
     create_and_validate_catalog_app()


### PR DESCRIPTION
Most apps will not deploy on a hardened cluster due to the nature of its security, so better to just skip these tests during the pre/post upgrade checks.