### PR TITLE
Revert "Merge pull request #31041 from rmweir/k3s-upgrade-dev-export"

### DIFF
--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -195,15 +195,15 @@ func (h *handler) deployK3sBasedUpgradeController(clusterName string, isK3s, isR
 // isNewerVersion returns true if updated versions semver is newer and false if its
 // semver is older. If semver is equal then metadata is alphanumerically compared.
 func IsNewerVersion(prevVersion, updatedVersion string) (bool, error) {
-	parseErrMsg := "failed to parse version: %v"
+	parseErrMsg := "failed to parse version [%s]: %v"
 	prevVer, err := semver.NewVersion(strings.TrimPrefix(prevVersion, "v"))
 	if err != nil {
-		return false, fmt.Errorf(parseErrMsg, err)
+		return false, fmt.Errorf(parseErrMsg, prevVersion, err)
 	}
 
 	updatedVer, err := semver.NewVersion(strings.TrimPrefix(updatedVersion, "v"))
 	if err != nil {
-		return false, fmt.Errorf(parseErrMsg, err)
+		return false, fmt.Errorf(parseErrMsg, updatedVersion, err)
 	}
 
 	switch updatedVer.Compare(*prevVer) {

--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -195,15 +195,15 @@ func (h *handler) deployK3sBasedUpgradeController(clusterName string, isK3s, isR
 // isNewerVersion returns true if updated versions semver is newer and false if its
 // semver is older. If semver is equal then metadata is alphanumerically compared.
 func IsNewerVersion(prevVersion, updatedVersion string) (bool, error) {
-	parseErrMsg := "failed to parse version [%s]: %v"
+	parseErrMsg := "failed to parse version: %v"
 	prevVer, err := semver.NewVersion(strings.TrimPrefix(prevVersion, "v"))
 	if err != nil {
-		return false, fmt.Errorf(parseErrMsg, prevVersion, err)
+		return false, fmt.Errorf(parseErrMsg, err)
 	}
 
 	updatedVer, err := semver.NewVersion(strings.TrimPrefix(updatedVersion, "v"))
 	if err != nil {
-		return false, fmt.Errorf(parseErrMsg, updatedVersion, err)
+		return false, fmt.Errorf(parseErrMsg, err)
 	}
 
 	switch updatedVer.Compare(*prevVer) {

--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -267,46 +267,35 @@ func getK3sUpgradeImages(rancherVersion string, k3sData map[string]interface{}) 
 			continue
 		}
 
-		maxVersion, _ := releaseMap["maxChannelServerVersion"].(string)
-		maxVersion = strings.TrimPrefix(maxVersion, "v")
-		if maxVersion == "" {
-			continue
-		}
-		minVersion, _ := releaseMap["minChannelServerVersion"].(string)
-		minVersion = strings.Trim(minVersion, "v")
-		if minVersion == "" {
-			continue
-		}
+		if rancherVersion != "dev" {
+			maxVersion, _ := releaseMap["maxChannelServerVersion"].(string)
+			maxVersion = strings.TrimPrefix(maxVersion, "v")
+			if maxVersion == "" {
+				continue
+			}
+			minVersion, _ := releaseMap["minChannelServerVersion"].(string)
+			minVersion = strings.Trim(minVersion, "v")
+			if minVersion == "" {
+				continue
+			}
 
-		var versionGTMin bool
-		var err error
-		if rancherVersion == kd.RancherVersionDev {
-			versionGTMin, err = k3sbasedupgrade.IsNewerVersion(minVersion, rancherVersion+".999")
-		} else {
-			versionGTMin, err = k3sbasedupgrade.IsNewerVersion(minVersion, rancherVersion)
-		}
-		if err != nil {
-			logrus.Errorf("%v", err)
-			continue
-		}
-		if rancherVersion != minVersion && !versionGTMin {
-			// rancher version not equal to or greater than minimum supported rancher version
-			continue
-		}
+			versionGTMin, err := k3sbasedupgrade.IsNewerVersion(minVersion, rancherVersion)
+			if err != nil {
+				continue
+			}
+			if rancherVersion != minVersion && !versionGTMin {
+				// rancher version not equal to or greater than minimum supported rancher version
+				continue
+			}
 
-		var versionLTMax bool
-		if rancherVersion == kd.RancherVersionDev {
-			versionLTMax, err = k3sbasedupgrade.IsNewerVersion(rancherVersion+".0", maxVersion)
-		} else {
-			versionLTMax, err = k3sbasedupgrade.IsNewerVersion(rancherVersion, maxVersion)
-		}
-		if err != nil {
-			logrus.Errorf("%v", err)
-			continue
-		}
-		if rancherVersion != maxVersion && !versionLTMax {
-			// rancher version not equal to or greater than maximum supported rancher version
-			continue
+			versionLTMax, err := k3sbasedupgrade.IsNewerVersion(rancherVersion, maxVersion)
+			if err != nil {
+				continue
+			}
+			if rancherVersion != maxVersion && !versionLTMax {
+				// rancher version not equal to or greater than maximum supported rancher version
+				continue
+			}
 		}
 
 		compatibleReleases = append(compatibleReleases, version)

--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -281,6 +281,7 @@ func getK3sUpgradeImages(rancherVersion string, k3sData map[string]interface{}) 
 
 			versionGTMin, err := k3sbasedupgrade.IsNewerVersion(minVersion, rancherVersion)
 			if err != nil {
+				logrus.Errorf("%v", err)
 				continue
 			}
 			if rancherVersion != minVersion && !versionGTMin {
@@ -290,6 +291,7 @@ func getK3sUpgradeImages(rancherVersion string, k3sData map[string]interface{}) 
 
 			versionLTMax, err := k3sbasedupgrade.IsNewerVersion(rancherVersion, maxVersion)
 			if err != nil {
+				logrus.Errorf("%v", err)
 				continue
 			}
 			if rancherVersion != maxVersion && !versionLTMax {


### PR DESCRIPTION
**Problem:**
This fix no longer works because it depends on the default dev version being an incomplete semver version but a recent change has updated it to a complete version. The aforementioned change also solves the same issue that this fix did, the only difference being that it will now only include images that have constraints compatible with a .99 patch version.

**Solution:**
Revert fix and rely on the new fix instead: https://github.com/rancher/rancher/pull/31084

**Notes:**
Original fix was to address: https://github.com/rancher/rancher/issues/31061