### PR TITLE
[master] pick which node to scaledown in a pool

### DIFF
--- a/pkg/apis/management.cattle.io/v3/machine_types.go
+++ b/pkg/apis/management.cattle.io/v3/machine_types.go
@@ -239,6 +239,7 @@ type NodeSpec struct {
 	DesiredNodeUnschedulable string          `json:"desiredNodeUnschedulable,omitempty"`
 	NodeDrainInput           *NodeDrainInput `json:"nodeDrainInput,omitempty"`
 	MetadataUpdate           MetadataUpdate  `json:"metadataUpdate,omitempty"`
+	ScaledownTime            string          `json:"scaledownTime,omitempty"`
 }
 
 type NodePlan struct {

--- a/pkg/client/generated/management/v3/zz_generated_node.go
+++ b/pkg/client/generated/management/v3/zz_generated_node.go
@@ -41,6 +41,7 @@ const (
 	NodeFieldRemoved              = "removed"
 	NodeFieldRequested            = "requested"
 	NodeFieldRequestedHostname    = "requestedHostname"
+	NodeFieldScaledownTime        = "scaledownTime"
 	NodeFieldSshUser              = "sshUser"
 	NodeFieldState                = "state"
 	NodeFieldTaints               = "taints"
@@ -90,6 +91,7 @@ type Node struct {
 	Removed              string                    `json:"removed,omitempty" yaml:"removed,omitempty"`
 	Requested            map[string]string         `json:"requested,omitempty" yaml:"requested,omitempty"`
 	RequestedHostname    string                    `json:"requestedHostname,omitempty" yaml:"requestedHostname,omitempty"`
+	ScaledownTime        string                    `json:"scaledownTime,omitempty" yaml:"scaledownTime,omitempty"`
 	SshUser              string                    `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
 	State                string                    `json:"state,omitempty" yaml:"state,omitempty"`
 	Taints               []Taint                   `json:"taints,omitempty" yaml:"taints,omitempty"`
@@ -124,6 +126,8 @@ type NodeOperations interface {
 	ActionCordon(resource *Node) error
 
 	ActionDrain(resource *Node, input *NodeDrainInput) error
+
+	ActionScaledown(resource *Node) error
 
 	ActionStopDrain(resource *Node) error
 
@@ -206,6 +210,11 @@ func (c *NodeClient) ActionCordon(resource *Node) error {
 
 func (c *NodeClient) ActionDrain(resource *Node, input *NodeDrainInput) error {
 	err := c.apiClient.Ops.DoAction(NodeType, "drain", &resource.Resource, input, nil)
+	return err
+}
+
+func (c *NodeClient) ActionScaledown(resource *Node) error {
+	err := c.apiClient.Ops.DoAction(NodeType, "scaledown", &resource.Resource, nil, nil)
 	return err
 }
 

--- a/pkg/client/generated/management/v3/zz_generated_node_spec.go
+++ b/pkg/client/generated/management/v3/zz_generated_node_spec.go
@@ -18,6 +18,7 @@ const (
 	NodeSpecFieldPodCidrs                 = "podCidrs"
 	NodeSpecFieldProviderId               = "providerId"
 	NodeSpecFieldRequestedHostname        = "requestedHostname"
+	NodeSpecFieldScaledownTime            = "scaledownTime"
 	NodeSpecFieldTaints                   = "taints"
 	NodeSpecFieldUnschedulable            = "unschedulable"
 	NodeSpecFieldUpdateTaintsFromAPI      = "updateTaintsFromAPI"
@@ -41,6 +42,7 @@ type NodeSpec struct {
 	PodCidrs                 []string        `json:"podCidrs,omitempty" yaml:"podCidrs,omitempty"`
 	ProviderId               string          `json:"providerId,omitempty" yaml:"providerId,omitempty"`
 	RequestedHostname        string          `json:"requestedHostname,omitempty" yaml:"requestedHostname,omitempty"`
+	ScaledownTime            string          `json:"scaledownTime,omitempty" yaml:"scaledownTime,omitempty"`
 	Taints                   []Taint         `json:"taints,omitempty" yaml:"taints,omitempty"`
 	Unschedulable            bool            `json:"unschedulable,omitempty" yaml:"unschedulable,omitempty"`
 	UpdateTaintsFromAPI      *bool           `json:"updateTaintsFromAPI,omitempty" yaml:"updateTaintsFromAPI,omitempty"`

--- a/pkg/controllers/management/nodepool/nodepool.go
+++ b/pkg/controllers/management/nodepool/nodepool.go
@@ -7,24 +7,31 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/ref"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rke/services"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var (
 	nameRegexp = regexp.MustCompile("^(.*?)([0-9]+)$")
+)
+
+const (
+	ReconcileAnnotation  = "nodepool.cattle.io/reconcile"
+	DeleteNodeAnnotation = "nodepool.cattle.io/delete-node"
 )
 
 type Controller struct {
@@ -56,15 +63,66 @@ func (c *Controller) Create(nodePool *v3.NodePool) (runtime.Object, error) {
 	return nodePool, nil
 }
 
+func (c *Controller) needsReconcile(nodePool *v3.NodePool) bool {
+	changed, _, err := c.createOrCheckNodes(nodePool, true)
+	if err != nil {
+		logrus.Debugf("[nodepoool] error checking pool for reconciliation: %s", err)
+	}
+
+	return changed
+}
+
+func (c *Controller) reconcile(nodePool *v3.NodePool) {
+	_, qty, err := c.createOrCheckNodes(nodePool, false)
+	if err != nil {
+		logrus.Errorf("[nodepool] reconcile erorr, create or check nodes: %s", err)
+	}
+
+	if qty != nodePool.Spec.Quantity {
+		nodePool.Spec.Quantity = qty
+	}
+
+	_, err = c.setReconcileAnnotation(nodePool, "")
+	if err != nil {
+		logrus.Errorf("[nodepool] error updating reconcile annotation to updated: %s", err)
+	}
+}
+
 func (c *Controller) Updated(nodePool *v3.NodePool) (runtime.Object, error) {
 	obj, err := v32.NodePoolConditionUpdated.Do(nodePool, func() (runtime.Object, error) {
-		return nodePool, c.reconcile(nodePool)
+		anno, _ := nodePool.Annotations[ReconcileAnnotation]
+		if anno == "" {
+			go c.deleteBadNodes(nodePool)
+			if c.needsReconcile(nodePool) {
+				logrus.Debugf("[nodepool] reconcile needed for %s", nodePool.Name)
+				np, err := c.setReconcileAnnotation(nodePool, "updating")
+				if err != nil {
+					return nodePool, err
+				}
+				go c.reconcile(np)
+				return nil, nil
+			}
+		} else if strings.HasPrefix(anno, "updating/") {
+			// gate updating the node pool to every 20s
+			pieces := strings.Split(anno, "/")
+			t, err := time.Parse(time.RFC3339, pieces[1])
+			if err != nil || int(time.Since(t)/time.Second) > 20 {
+				nodePool.Annotations[ReconcileAnnotation] = ""
+				return c.NodePools.Update(nodePool)
+			}
+			// go routine is already running to update the cluster so wait
+			return nil, nil
+		}
+
+		// pool doesn't need to reconcile, nothing to do
+		return nil, nil
 	})
+
 	return obj.(*v3.NodePool), err
 }
 
 func (c *Controller) Remove(nodePool *v3.NodePool) (runtime.Object, error) {
-	logrus.Infof("Deleting nodePool [%s]", nodePool.Name)
+	logrus.Infof("[nodepool] deleting %s", nodePool.Name)
 
 	allNodes, err := c.nodes(nodePool, false)
 	if err != nil {
@@ -77,13 +135,86 @@ func (c *Controller) Remove(nodePool *v3.NodePool) (runtime.Object, error) {
 			continue
 		}
 
-		err := c.deleteNode(node, time.Duration(0))
-		if err != nil {
+		if err := c.deleteNode(node, 0); err != nil {
 			return nil, err
 		}
 	}
 
 	return nodePool, nil
+}
+
+func (c *Controller) setReconcileAnnotation(nodePool *v3.NodePool, anno string) (*v3.NodePool, error) {
+	backoff := wait.Backoff{
+		Duration: 500 * time.Millisecond,
+		Factor:   1,
+		Jitter:   0,
+		Steps:    6,
+	}
+
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		newPool, err := c.NodePools.GetNamespaced(nodePool.Namespace, nodePool.Name, metav1.GetOptions{})
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return false, err
+			}
+			return false, nil
+		}
+
+		if anno == "updating" {
+			// Add a timestamp for comparison since this anno was added
+			anno = anno + "/" + time.Now().Format(time.RFC3339)
+		}
+
+		newPool.Annotations[ReconcileAnnotation] = anno
+		newPool.Spec.Quantity = nodePool.Spec.Quantity // incase the pool size changed during reconcile
+		newPool, err = c.NodePools.Update(newPool)
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		nodePool = newPool
+		return true, nil
+	})
+	if err != nil {
+		return nodePool, fmt.Errorf("[nodepool] Failed to update nodePool annotation [%s]: %v", nodePool.Name, err)
+	}
+	return nodePool, nil
+}
+
+func (c *Controller) setDeleteNodeAnnotation(node *v3.Node) (*v3.Node, error) {
+	backoff := wait.Backoff{
+		Duration: 500 * time.Millisecond,
+		Factor:   1,
+		Jitter:   0,
+		Steps:    6,
+	}
+
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		newNode, err := c.Nodes.GetNamespaced(node.Namespace, node.Name, metav1.GetOptions{})
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return false, err
+			}
+			return false, nil
+		}
+
+		newNode.Annotations[DeleteNodeAnnotation] = "true"
+		newNode, err = c.Nodes.Update(newNode)
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		node = newNode
+		return true, nil
+	})
+	if err != nil {
+		return node, fmt.Errorf("[nodeprool] Failed to update node delete annotation [%s]: %v", node.Name, err)
+	}
+	return node, nil
 }
 
 func (c *Controller) machineChanged(key string, machine *v3.Node) (runtime.Object, error) {
@@ -121,42 +252,59 @@ func (c *Controller) createNode(name string, nodePool *v3.NodePool, simulate boo
 		},
 	}
 
+	delete(newNode.Annotations, ReconcileAnnotation)
 	if simulate {
 		return newNode, nil
 	}
 
-	return c.Nodes.Create(newNode)
+	n, err := c.Nodes.Create(newNode)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("[nodepool] node created %s", n.Name)
+	return n, nil
 }
 
 func (c *Controller) deleteNode(node *v3.Node, duration time.Duration) error {
-	f := metav1.DeletePropagationBackground
-
-	if duration > time.Duration(0) {
-		go func() {
-			time.Sleep(duration)
-			c.Nodes.DeleteNamespaced(node.Namespace, node.Name, &metav1.DeleteOptions{
-				PropagationPolicy: &f,
-			})
-		}()
-		return nil
-	}
-
-	return c.Nodes.DeleteNamespaced(node.Namespace, node.Name, &metav1.DeleteOptions{
-		PropagationPolicy: &f,
-	})
-}
-
-func (c *Controller) reconcile(nodePool *v3.NodePool) error {
-	changed, err := c.createOrCheckNodes(nodePool, true)
+	newNode, err := c.setDeleteNodeAnnotation(node)
 	if err != nil {
 		return err
 	}
 
-	if changed {
-		_, err = c.createOrCheckNodes(nodePool, false)
+	if duration > time.Duration(0) {
+		go func() {
+			time.Sleep(duration)
+			c.deleteNodeBackoffAndRetry(newNode)
+		}()
+		return nil
 	}
 
-	return err
+	return c.deleteNodeBackoffAndRetry(newNode)
+}
+
+func (c *Controller) deleteNodeBackoffAndRetry(node *v3.Node) error {
+	backoff := wait.Backoff{
+		Duration: 500 * time.Millisecond,
+		Factor:   1,
+		Jitter:   0,
+		Steps:    6,
+	}
+
+	logrus.Debugf("[nodepool] attempting to delete node %s", node.Name)
+	f := metav1.DeletePropagationBackground
+	return wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := c.Nodes.DeleteNamespaced(node.Namespace, node.Name, &metav1.DeleteOptions{
+			PropagationPolicy: &f,
+		})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, nil
+		}
+		return true, nil
+	})
 }
 
 func parsePrefix(fullPrefix string) (prefix string, minLength, start int) {
@@ -187,7 +335,24 @@ func (c *Controller) nodes(nodePool *v3.NodePool, simulate bool) ([]*v3.Node, er
 	return nodes, nil
 }
 
-func (c *Controller) createOrCheckNodes(nodePool *v3.NodePool, simulate bool) (bool, error) {
+func (c *Controller) deleteBadNodes(nodePool *v3.NodePool) {
+	allNodes, err := c.nodes(nodePool, false)
+	if err != nil {
+		logrus.Errorf("[nodepool] error pulling nodes for bad node deletion: %s", err)
+	}
+
+	for _, node := range allNodes {
+		if anno, ok := node.Annotations[DeleteNodeAnnotation]; ok && anno == "true" {
+			return
+		}
+		if v32.NodeConditionProvisioned.IsFalse(node) || v32.NodeConditionInitialized.IsFalse(node) || v32.NodeConditionConfigSaved.IsFalse(node) {
+			logrus.Debugf("[nodepool] bad node found: %s", node.Name)
+			_ = c.deleteNode(node, 2*time.Minute)
+		}
+	}
+}
+
+func (c *Controller) createOrCheckNodes(nodePool *v3.NodePool, simulate bool) (bool, int, error) {
 	var (
 		err                 error
 		byName              = map[string]*v3.Node{}
@@ -198,23 +363,37 @@ func (c *Controller) createOrCheckNodes(nodePool *v3.NodePool, simulate bool) (b
 
 	allNodes, err := c.nodes(nodePool, simulate)
 	if err != nil {
-		return false, err
+		return false, nodePool.Spec.Quantity, err
 	}
 
+	quantity := nodePool.Spec.Quantity
 	for _, node := range allNodes {
 		byName[node.Spec.RequestedHostname] = node
 
 		_, nodePoolName := ref.Parse(node.Spec.NodePoolName)
-		if nodePoolName != nodePool.Name {
+		if nodePoolName != nodePool.Name || node.DeletionTimestamp != nil {
 			continue
 		}
 
-		if v32.NodeConditionProvisioned.IsFalse(node) || v32.NodeConditionInitialized.IsFalse(node) || v32.NodeConditionConfigSaved.IsFalse(node) {
-			changed = true
-			if !simulate {
-				_ = c.deleteNode(node, 2*time.Minute)
+		if node.Spec.ScaledownTime != "" {
+			scaledown, err := time.Parse(time.RFC3339, node.Spec.ScaledownTime)
+			if err != nil {
+				logrus.Errorf("[nodepool] failed to parse scaledown time, is it in RFC3339? %s: %s", node.Spec.ScaledownTime, err)
+			} else {
+				if scaledown.Before(time.Now()) {
+					changed = true
+					if !simulate {
+						logrus.Debugf("[nodepool] scaling down, removing node %s", node.Name)
+						if err = c.deleteNode(node, 0); err != nil {
+							return false, quantity, err
+						}
+					}
+					quantity--
+					continue
+				}
 			}
 		}
+
 		// remove unreachable node with the unreachable taint & status of Ready being Unknown
 		q := getUnreachableTaint(node.Spec.InternalNodeSpec.Taints)
 		if q != nil && deleteNotReadyAfter > 0 {
@@ -224,7 +403,7 @@ func (c *Controller) createOrCheckNodes(nodePool *v3.NodePool, simulate bool) (b
 				if time.Since(start) > deleteNotReadyAfter {
 					err = c.deleteNode(node, 0)
 					if err != nil {
-						return false, err
+						return false, quantity, err
 					}
 				} else {
 					c.mutex.Lock()
@@ -240,13 +419,11 @@ func (c *Controller) createOrCheckNodes(nodePool *v3.NodePool, simulate bool) (b
 		nodes = append(nodes, node)
 	}
 
-	quantity := nodePool.Spec.Quantity
 	if quantity < 0 {
 		quantity = 0
 	}
 
 	prefix, minLength, start := parsePrefix(nodePool.Spec.HostnamePrefix)
-
 	for i := start; len(nodes) < quantity; i++ {
 		ia := strconv.Itoa(i)
 		name := prefix + ia
@@ -261,7 +438,7 @@ func (c *Controller) createOrCheckNodes(nodePool *v3.NodePool, simulate bool) (b
 		changed = true
 		newNode, err := c.createNode(name, nodePool, simulate)
 		if err != nil {
-			return false, err
+			return false, quantity, err
 		}
 
 		byName[newNode.Spec.RequestedHostname] = newNode
@@ -287,12 +464,12 @@ func (c *Controller) createOrCheckNodes(nodePool *v3.NodePool, simulate bool) (b
 			changed = true
 			_, err := c.updateNodeRoles(n, nodePool, simulate)
 			if err != nil {
-				return false, err
+				return false, quantity, err
 			}
 		}
 	}
 
-	return changed, nil
+	return changed, quantity, nil
 }
 
 func needRoleUpdate(node *v3.Node, nodePool *v3.NodePool) bool {
@@ -325,7 +502,7 @@ func needRoleUpdate(node *v3.Node, nodePool *v3.NodePool) bool {
 
 	r := !reflect.DeepEqual(nodeRolesMap, poolRolesMap)
 	if r {
-		logrus.Debugf("updating machine [%s] roles: nodepoolRoles: {%+v} node roles: {%+v}", node.Name, poolRolesMap, nodeRolesMap)
+		logrus.Debugf("[nodepool] updating machine [%s] roles: nodepoolRoles: {%+v} node roles: {%+v}", node.Name, poolRolesMap, nodeRolesMap)
 	}
 	return r
 }

--- a/pkg/schemas/management.cattle.io/v3/schema.go
+++ b/pkg/schemas/management.cattle.io/v3/schema.go
@@ -415,6 +415,7 @@ func nodeTypes(schemas *types.Schemas) *types.Schemas {
 			schema.ResourceActions["cordon"] = types.Action{}
 			schema.ResourceActions["uncordon"] = types.Action{}
 			schema.ResourceActions["stopDrain"] = types.Action{}
+			schema.ResourceActions["scaledown"] = types.Action{}
 			schema.ResourceActions["drain"] = types.Action{
 				Input: "nodeDrainInput",
 			}

--- a/tests/integration/suite/common.py
+++ b/tests/integration/suite/common.py
@@ -67,7 +67,8 @@ def auth_check(schema, id, access, props=None):
 
     for i in ['created', 'removed', 'transitioning', 'transitioningProgress',
               'removeTime', 'transitioningMessage', 'id', 'uuid', 'kind',
-              'state', 'creatorId', 'finalizers', 'ownerReferences', 'type']:
+              'state', 'creatorId', 'finalizers', 'ownerReferences', 'type',
+              'scaledownTime']:
         if i not in props and i in schema_type.resourceFields.keys():
             props[i] = 'r'
 

--- a/tests/integration/suite/test_node.py
+++ b/tests/integration/suite/test_node.py
@@ -46,6 +46,7 @@ def test_node_fields(admin_mc):
         'sshUser': 'r',
         'imported': 'cru',
         'dockerInfo': 'r',
+        'scaledownTime': 'cru'
     }
 
     for name in cclient.schema.types['node'].resourceFields.keys():


### PR DESCRIPTION
Problem: scaling down a nodepool only allows for the +/- buttons or spec.quantity field to change, the nodepool reconciles and adds/removes nodes numerically from low to high. Allow for the ability to flag nodes for scaledown and remove them from the pool and decrement the quantity.
Solution: added node.spec.scaledown which is an RFC3339 date for when the node should be pulled from the pool. added a scaledown action which sets the scaledown time to now. nodepool will reconcile and pull the node marked for scaledown after the scaledown time. 

https://github.com/rancher/rancher/issues/22871