### PR TITLE
changes for agent env vars

### DIFF
--- a/pkg/api/norman/customization/clusterregistrationtokens/formatter_test.go
+++ b/pkg/api/norman/customization/clusterregistrationtokens/formatter_test.go
@@ -24,6 +24,7 @@ xxx
 func TestFormatter(t *testing.T) {
 	testCases := []struct {
 		caseName                    string
+		clusterID                   string
 		presetAgentImage            string
 		presetCertCAs               string
 		presetServerURL             string
@@ -34,17 +35,19 @@ func TestFormatter(t *testing.T) {
 	}{
 		{
 			caseName:         "default",
+			clusterID:        "c-xxxx",
 			presetAgentImage: testAgentImage,
 			presetCertCAs:    testCertCAs,
 			presetServerURL:  "https://fake-server.rancher.io",
 			requestURL:       "https://fake-test.rancher.io/v3/clusterregistrationtokens",
 			requestToken:     "fake-token",
 			outputShouldEqual: map[string]interface{}{
-				"insecureCommand": fmt.Sprintf(insecureCommandFormat, "https://fake-server.rancher.io/v3/import/fake-token.yaml"),
-				"command":         fmt.Sprintf(commandFormat, "https://fake-server.rancher.io/v3/import/fake-token.yaml"),
+				"insecureCommand": fmt.Sprintf(insecureCommandFormat, "https://fake-server.rancher.io/v3/import/fake-token_c-xxxx.yaml"),
+				"command":         fmt.Sprintf(commandFormat, "https://fake-server.rancher.io/v3/import/fake-token_c-xxxx.yaml"),
 				"token":           "fake-token",
-				"manifestUrl":     "https://fake-server.rancher.io/v3/import/fake-token.yaml",
-				"nodeCommand": fmt.Sprintf(nodeCommandFormat,
+				"clusterId":       "c-xxxx",
+				"manifestUrl":     "https://fake-server.rancher.io/v3/import/fake-token_c-xxxx.yaml",
+				"nodeCommand": fmt.Sprintf(nodeCommandFormat, "",
 					"rancher/rancher-agent:test",
 					"https://fake-server.rancher.io",
 					"fake-token",
@@ -60,6 +63,7 @@ func TestFormatter(t *testing.T) {
 		},
 		{
 			caseName:                    "with private registry setting",
+			clusterID:                   "c-xxxx",
 			presetAgentImage:            testAgentImage,
 			presetCertCAs:               testCertCAs,
 			presetServerURL:             "https://fake-server.rancher.io",
@@ -67,11 +71,12 @@ func TestFormatter(t *testing.T) {
 			requestURL:                  "https://fake-test.rancher.io/v3/clusterregistrationtokens",
 			requestToken:                "fake-token",
 			outputShouldEqual: map[string]interface{}{
-				"insecureCommand": fmt.Sprintf(insecureCommandFormat, "https://fake-server.rancher.io/v3/import/fake-token.yaml"),
-				"command":         fmt.Sprintf(commandFormat, "https://fake-server.rancher.io/v3/import/fake-token.yaml"),
+				"insecureCommand": fmt.Sprintf(insecureCommandFormat, "https://fake-server.rancher.io/v3/import/fake-token_c-xxxx.yaml"),
+				"command":         fmt.Sprintf(commandFormat, "https://fake-server.rancher.io/v3/import/fake-token_c-xxxx.yaml"),
 				"token":           "fake-token",
-				"manifestUrl":     "https://fake-server.rancher.io/v3/import/fake-token.yaml",
-				"nodeCommand": fmt.Sprintf(nodeCommandFormat,
+				"clusterId":       "c-xxxx",
+				"manifestUrl":     "https://fake-server.rancher.io/v3/import/fake-token_c-xxxx.yaml",
+				"nodeCommand": fmt.Sprintf(nodeCommandFormat, "",
 					"fake-registry.rancher.io:443/rancher/rancher-agent:test",
 					"https://fake-server.rancher.io",
 					"fake-token",
@@ -87,17 +92,19 @@ func TestFormatter(t *testing.T) {
 		},
 		{
 			caseName:         "without server URL setting",
+			clusterID:        "c-xxxx",
 			presetAgentImage: testAgentImage,
 			presetCertCAs:    testCertCAs,
 			presetServerURL:  "",
 			requestURL:       "https://fake-test.rancher.io/v3/clusterregistrationtokens",
 			requestToken:     "fake-token",
 			outputShouldEqual: map[string]interface{}{
-				"insecureCommand": fmt.Sprintf(insecureCommandFormat, "https://fake-test.rancher.io/v3/import/fake-token.yaml"),
-				"command":         fmt.Sprintf(commandFormat, "https://fake-test.rancher.io/v3/import/fake-token.yaml"),
+				"insecureCommand": fmt.Sprintf(insecureCommandFormat, "https://fake-test.rancher.io/v3/import/fake-token_c-xxxx.yaml"),
+				"command":         fmt.Sprintf(commandFormat, "https://fake-test.rancher.io/v3/import/fake-token_c-xxxx.yaml"),
 				"token":           "fake-token",
-				"manifestUrl":     "https://fake-test.rancher.io/v3/import/fake-token.yaml",
-				"nodeCommand": fmt.Sprintf(nodeCommandFormat,
+				"clusterId":       "c-xxxx",
+				"manifestUrl":     "https://fake-test.rancher.io/v3/import/fake-token_c-xxxx.yaml",
+				"nodeCommand": fmt.Sprintf(nodeCommandFormat, "",
 					"rancher/rancher-agent:test",
 					"https://fake-test.rancher.io",
 					"fake-token",
@@ -128,7 +135,7 @@ func TestFormatter(t *testing.T) {
 		// prepare
 		fakeAPIContext, err := newFakeAPIContext(cs.requestURL)
 		assert.Nilf(err, "%s could not new fake APIContext", cs.caseName)
-		fakeRawResource, err := newFakeRawResource(cs.requestToken)
+		fakeRawResource, err := newFakeRawResource(cs.requestToken, cs.clusterID)
 		assert.Nilf(err, "%s could not new fake RawResource", cs.caseName)
 
 		// verify
@@ -156,9 +163,10 @@ func newFakeAPIContext(url string) (*types.APIContext, error) {
 	return apiContext, nil
 }
 
-func newFakeRawResource(token string) (*types.RawResource, error) {
+func newFakeRawResource(token, clusterID string) (*types.RawResource, error) {
 	values := map[string]interface{}{
-		"token": token,
+		"token":     token,
+		"clusterId": clusterID,
 	}
 
 	rawResource := &types.RawResource{

--- a/pkg/api/norman/customization/clusterregistrationtokens/import.go
+++ b/pkg/api/norman/customization/clusterregistrationtokens/import.go
@@ -6,15 +6,22 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/urlbuilder"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/image"
 	schema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/systemtemplate"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ClusterImportHandler(resp http.ResponseWriter, req *http.Request) {
+type ClusterImport struct {
+	Clusters v3.ClusterInterface
+}
+
+func (ch *ClusterImport) ClusterImportHandler(resp http.ResponseWriter, req *http.Request) {
 	resp.Header().Set("Content-Type", "text/plain")
 	token := mux.Vars(req)["token"]
+	clusterID := mux.Vars(req)["clusterId"]
 
 	urlBuilder, err := urlbuilder.New(req, schema.Version, types.NewSchemas())
 	if err != nil {
@@ -30,8 +37,13 @@ func ClusterImportHandler(resp http.ResponseWriter, req *http.Request) {
 		authImage = authImages[0]
 	}
 
+	var cluster *v3.Cluster
+	if clusterID != "" {
+		cluster, _ = ch.Clusters.Get(clusterID, metav1.GetOptions{})
+	}
+
 	if err := systemtemplate.SystemTemplate(resp, image.Resolve(settings.AgentImage.Get()), authImage, "", token, url,
-		false, nil, nil, nil); err != nil {
+		false, cluster, nil, nil); err != nil {
 		resp.WriteHeader(500)
 		resp.Write([]byte(err.Error()))
 	}

--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -101,7 +101,7 @@ type ClusterSpecBase struct {
 	DesiredAgentImage                    string                                  `json:"desiredAgentImage"`
 	DesiredAuthImage                     string                                  `json:"desiredAuthImage"`
 	AgentImageOverride                   string                                  `json:"agentImageOverride"`
-	AgentEnvVars                         []v1.EnvVar                             `json:"agentEnvVars"`
+	AgentEnvVars                         []v1.EnvVar                             `json:"agentEnvVars,omitempty"`
 	RancherKubernetesEngineConfig        *rketypes.RancherKubernetesEngineConfig `json:"rancherKubernetesEngineConfig,omitempty"`
 	DefaultPodSecurityPolicyTemplateName string                                  `json:"defaultPodSecurityPolicyTemplateName,omitempty" norman:"type=reference[podSecurityPolicyTemplate]"`
 	DefaultClusterRoleForProjectMembers  string                                  `json:"defaultClusterRoleForProjectMembers,omitempty" norman:"type=reference[roleTemplate]"`
@@ -147,6 +147,7 @@ type ClusterStatus struct {
 	Driver                               string                      `json:"driver"`
 	Provider                             string                      `json:"provider"`
 	AgentImage                           string                      `json:"agentImage"`
+	AppliedAgentEnvVars                  []v1.EnvVar                 `json:"appliedAgentEnvVars,omitempty"`
 	AgentFeatures                        map[string]bool             `json:"agentFeatures,omitempty"`
 	AuthImage                            string                      `json:"authImage"`
 	ComponentStatuses                    []ClusterComponentStatus    `json:"componentStatuses,omitempty"`

--- a/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -2312,6 +2312,13 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 		*out = make([]ClusterCondition, len(*in))
 		copy(*out, *in)
 	}
+	if in.AppliedAgentEnvVars != nil {
+		in, out := &in.AppliedAgentEnvVars, &out.AppliedAgentEnvVars
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.AgentFeatures != nil {
 		in, out := &in.AgentFeatures, &out.AgentFeatures
 		*out = make(map[string]bool, len(*in))

--- a/pkg/client/generated/management/v3/zz_generated_cluster.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster.go
@@ -13,6 +13,7 @@ const (
 	ClusterFieldAgentImageOverride                   = "agentImageOverride"
 	ClusterFieldAllocatable                          = "allocatable"
 	ClusterFieldAnnotations                          = "annotations"
+	ClusterFieldAppliedAgentEnvVars                  = "appliedAgentEnvVars"
 	ClusterFieldAppliedEnableNetworkPolicy           = "appliedEnableNetworkPolicy"
 	ClusterFieldAppliedPodSecurityPolicyTemplateName = "appliedPodSecurityPolicyTemplateId"
 	ClusterFieldAppliedSpec                          = "appliedSpec"
@@ -80,6 +81,7 @@ type Cluster struct {
 	AgentImageOverride                   string                         `json:"agentImageOverride,omitempty" yaml:"agentImageOverride,omitempty"`
 	Allocatable                          map[string]string              `json:"allocatable,omitempty" yaml:"allocatable,omitempty"`
 	Annotations                          map[string]string              `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	AppliedAgentEnvVars                  []EnvVar                       `json:"appliedAgentEnvVars,omitempty" yaml:"appliedAgentEnvVars,omitempty"`
 	AppliedEnableNetworkPolicy           bool                           `json:"appliedEnableNetworkPolicy,omitempty" yaml:"appliedEnableNetworkPolicy,omitempty"`
 	AppliedPodSecurityPolicyTemplateName string                         `json:"appliedPodSecurityPolicyTemplateId,omitempty" yaml:"appliedPodSecurityPolicyTemplateId,omitempty"`
 	AppliedSpec                          *ClusterSpec                   `json:"appliedSpec,omitempty" yaml:"appliedSpec,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_cluster_status.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_status.go
@@ -6,6 +6,7 @@ const (
 	ClusterStatusFieldAgentFeatures                        = "agentFeatures"
 	ClusterStatusFieldAgentImage                           = "agentImage"
 	ClusterStatusFieldAllocatable                          = "allocatable"
+	ClusterStatusFieldAppliedAgentEnvVars                  = "appliedAgentEnvVars"
 	ClusterStatusFieldAppliedEnableNetworkPolicy           = "appliedEnableNetworkPolicy"
 	ClusterStatusFieldAppliedPodSecurityPolicyTemplateName = "appliedPodSecurityPolicyTemplateId"
 	ClusterStatusFieldAppliedSpec                          = "appliedSpec"
@@ -36,6 +37,7 @@ type ClusterStatus struct {
 	AgentFeatures                        map[string]bool             `json:"agentFeatures,omitempty" yaml:"agentFeatures,omitempty"`
 	AgentImage                           string                      `json:"agentImage,omitempty" yaml:"agentImage,omitempty"`
 	Allocatable                          map[string]string           `json:"allocatable,omitempty" yaml:"allocatable,omitempty"`
+	AppliedAgentEnvVars                  []EnvVar                    `json:"appliedAgentEnvVars,omitempty" yaml:"appliedAgentEnvVars,omitempty"`
 	AppliedEnableNetworkPolicy           bool                        `json:"appliedEnableNetworkPolicy,omitempty" yaml:"appliedEnableNetworkPolicy,omitempty"`
 	AppliedPodSecurityPolicyTemplateName string                      `json:"appliedPodSecurityPolicyTemplateId,omitempty" yaml:"appliedPodSecurityPolicyTemplateId,omitempty"`
 	AppliedSpec                          *ClusterSpec                `json:"appliedSpec,omitempty" yaml:"appliedSpec,omitempty"`

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -237,18 +237,8 @@ func redeployAgent(cluster *v3.Cluster, desiredAgent, desiredAuth string, desire
 		return true
 	}
 
-	agentEnvVarsChanged := false
-	desiredAgentEnvVars := cluster.Spec.AgentEnvVars
-	currentAgentEnvVars := cluster.Status.AppliedAgentEnvVars
-
-	if (desiredAgentEnvVars == nil && currentAgentEnvVars != nil) || (desiredAgentEnvVars != nil && currentAgentEnvVars == nil) {
-		agentEnvVarsChanged = true
-	}
-	if desiredAgentEnvVars != nil && currentAgentEnvVars != nil && !reflect.DeepEqual(desiredAgentEnvVars, currentAgentEnvVars) {
-		agentEnvVarsChanged = true
-	}
-	if agentEnvVarsChanged {
-		logrus.Infof("clusterDeploy: redeployAgent: redeploy Rancher agents due to agent env vars mismatched for [%s], was [%v] and will be [%v]", cluster.Name, currentAgentEnvVars, desiredAgentEnvVars)
+	if !reflect.DeepEqual(cluster.Spec.AgentEnvVars, cluster.Status.AppliedAgentEnvVars) {
+		logrus.Infof("clusterDeploy: redeployAgent: redeploy Rancher agents due to agent env vars mismatched for [%s], was [%v] and will be [%v]", cluster.Name, cluster.Spec.AgentEnvVars, cluster.Status.AppliedAgentEnvVars)
 		return true
 	}
 

--- a/pkg/multiclustermanager/routes.go
+++ b/pkg/multiclustermanager/routes.go
@@ -40,6 +40,7 @@ func router(ctx context.Context, localClusterEnabled bool, scaledContext *config
 		k8sProxy             = k8sProxyPkg.New(scaledContext, scaledContext.Dialer)
 		connectHandler       = scaledContext.Dialer.(*rancherdialer.Factory).TunnelServer
 		connectConfigHandler = rkenodeconfigserver.Handler(scaledContext.Dialer.(*rancherdialer.Factory).TunnelAuthorizer, scaledContext)
+		clusterImport        = clusterregistrationtokens.ClusterImport{Clusters: scaledContext.Management.Clusters("")}
 	)
 
 	tokenAPI, err := tokens.NewAPIHandler(ctx, scaledContext, norman.ConfigureAPIUI)
@@ -70,7 +71,7 @@ func router(ctx context.Context, localClusterEnabled bool, scaledContext *config
 	unauthed.Handle("/v3/connect/config", connectConfigHandler)
 	unauthed.Handle("/v3/connect", connectHandler)
 	unauthed.Handle("/v3/connect/register", connectHandler)
-	unauthed.Handle("/v3/import/{token}.yaml", http.HandlerFunc(clusterregistrationtokens.ClusterImportHandler))
+	unauthed.Handle("/v3/import/{token}_{clusterId}.yaml", http.HandlerFunc(clusterImport.ClusterImportHandler))
 	unauthed.Handle("/v3/settings/cacerts", managementAPI).MatcherFunc(onlyGet)
 	unauthed.Handle("/v3/settings/first-login", managementAPI).MatcherFunc(onlyGet)
 	unauthed.Handle("/v3/settings/ui-banners", managementAPI).MatcherFunc(onlyGet)

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -267,6 +267,9 @@ spec:
           value: "true"
         - name: CATTLE_AGENT_CONNECT
           value: "true"
+      {{- if .AgentEnvVars}}
+{{ .AgentEnvVars | indent 8 }}
+      {{- end }}
         volumeMounts:
         - name: cattle-credentials
           mountPath: /cattle-credentials


### PR DESCRIPTION
- added `AgentEnvVars` to node-agent template, same as cluster-agent 
- added `AppliedAgentEnvVars` to cluster status and redeploy agents if changed from spec 
- passing env vars to node registration command generated for custom clusters 
- passing env vars for deployAgent by node driver clusters 
- passing clusterID to the import url generated for imported clusters so `http://server_IP/v3/import/{token}_{clusterID}.yaml` has the env vars added by user on the cluster object 

https://github.com/rancher/rancher/issues/24876
https://github.com/rancher/rancher/issues/29961
https://github.com/rancher/rancher/issues/31370