### PR TITLE
[master] Add cleanup to the agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.trash-cache
 /trash.lock
 /.idea
+/cmd/agent/agent
 /package/data.json
 /package/rancher
 /package/rancher.yaml

--- a/cleanup/binding-clean.sh
+++ b/cleanup/binding-clean.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# set -x
+set -e
+
+CLEAR='\033[0m'
+RED='\033[0;31m'
+
+# Location of the yaml to use to deploy the cleanup job
+yaml_url=https://raw.githubusercontent.com/rancher/rancher/master/cleanup/binding-clean.yaml
+
+# 120 is equal to a minute as the sleep is half a second
+timeout=120
+
+# Agent image to use in the yaml file
+agent_image="$1"
+
+show_usage() {
+  if [ -n "$1" ]; then
+    echo -e "${RED}👉 $1${CLEAR}\n";
+  fi
+	echo -e "Usage: $0 [AGENT_IMAGE] [FLAGS]"
+	echo "AGENT_IMAGE is a required argument"
+	echo ""
+	echo "Flags:"
+	echo -e "\t-dry-run Display the resources that would will be updated without making changes"
+}
+
+if [ $# -lt 1 ]
+then
+	show_usage "AGENT_IMAGE is a required argument"
+	exit 1
+fi
+
+if [[ $1 == "-h" ||$1 == "--help" ]]
+then
+	show_usage
+	exit 0
+fi
+
+# Pull the yaml and replace the agent_image holder with the passed in image
+yaml=$(curl --insecure -sfL $yaml_url | sed -e 's=agent_image='"$agent_image"'=')
+
+if [ "$2" = "-dry-run" ]
+then
+    # Uncomment the env var for dry-run mode
+    yaml=$(sed -e 's/# // ' <<< "$yaml")
+fi
+
+echo "$yaml" | kubectl apply -f -
+
+# Get the pod ID to tail the logs
+pod_id=$(kubectl get pod -l job-name=cattle-cleanup-job -o jsonpath="{.items[0].metadata.name}")
+
+declare -i count=0
+until kubectl logs $pod_id -f
+do
+    if [ $count -gt $timeout ]
+    then
+        echo "Timout reached, check the job by running kubectl get jobs"
+        exit 1
+    fi
+    sleep 0.5
+    count+=1
+done
+
+# Cleanup after it completes successfully
+echo "$yaml" | kubectl delete -f -

--- a/cleanup/binding-clean.yaml
+++ b/cleanup/binding-clean.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cattle-cleanup-sa
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cattle-cleanup-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cattle-cleanup-role
+subjects:
+  - kind: ServiceAccount
+    name: cattle-cleanup-sa
+    namespace: default
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cattle-cleanup-job
+  namespace: default
+  labels:
+    rancher-cleanup: "true"
+spec:
+  backoffLimit: 6
+  completions: 1
+  parallelism: 1
+  selector:
+  template:
+    metadata:
+      creationTimestamp: null
+    spec:
+      containers:
+        - env:
+            - name: BINDING_CLEANUP
+              value: "true"
+            # - name: DRY_RUN
+              # value: "true"
+          image: agent_image
+          imagePullPolicy: Always
+          command: ["agent"]
+          name: cleanup-agent
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: OnFailure
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccountName: cattle-cleanup-sa
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cattle-cleanup-role
+  namespace: default
+rules:
+  - apiGroups:
+      - management.cattle.io
+    resources:
+      - clusterroletemplatebindings
+      - projectroletemplatebindings
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - clusterrolebindings
+    verbs:
+      - list
+      - get
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - list
+      - get
+      - delete

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -58,6 +58,8 @@ func main() {
 
 	if os.Getenv("CLUSTER_CLEANUP") == "true" {
 		err = clean.Cluster()
+	} else if os.Getenv("BINDING_CLEANUP") == "true" {
+		err = clean.Bindings()
 	} else {
 		err = run()
 	}

--- a/pkg/agent/clean/binding.go
+++ b/pkg/agent/clean/binding.go
@@ -1,0 +1,299 @@
+// +build !windows
+
+/*
+Clean duplicates bindings found in a management cluster. This will collect all
+PRTBs and CRTBs, create the labels used to identify the k8s resources that correspond
+to those and check for duplicates. If they are found delete all but 1.
+This is technically safe as rancher will recreate any CRB or RB that is deleted that
+should not have been.
+*/
+
+package clean
+
+import (
+	"context"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/controllers/management/auth"
+	"github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io"
+	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
+	"github.com/rancher/wrangler/pkg/generated/controllers/rbac"
+	v1 "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
+	"github.com/rancher/wrangler/pkg/ratelimit"
+	"github.com/rancher/wrangler/pkg/start"
+	"github.com/sirupsen/logrus"
+	k8srbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	crtbType = "crtb"
+	prtbType = "prtb"
+)
+
+type bindingsCleanup struct {
+	crtbs               v3.ClusterRoleTemplateBindingClient
+	prtbs               v3.ProjectRoleTemplateBindingClient
+	clusterRoleBindings v1.ClusterRoleBindingClient
+	roleBindings        v1.RoleBindingClient
+}
+
+func Bindings() error {
+	logrus.Info("Starting bindings cleanup")
+	if os.Getenv("DRY_RUN") == "true" {
+		logrus.Info("DRY_RUN is true, no objects will be deleted/modified")
+		dryRun = true
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	if err != nil {
+		panic(err)
+	}
+
+	// No one wants to be slow
+	config.RateLimiter = ratelimit.None
+
+	rancherManagement, err := management.NewFactoryFromConfig(config)
+	if err != nil {
+		return err
+	}
+
+	k8srbac, err := rbac.NewFactoryFromConfig(config)
+	if err != nil {
+		return err
+	}
+
+	starters := []start.Starter{rancherManagement, k8srbac}
+
+	ctx := context.Background()
+	if err := start.All(ctx, 5, starters...); err != nil {
+		return err
+	}
+
+	bc := bindingsCleanup{
+		crtbs:               rancherManagement.Management().V3().ClusterRoleTemplateBinding(),
+		prtbs:               rancherManagement.Management().V3().ProjectRoleTemplateBinding(),
+		clusterRoleBindings: k8srbac.Rbac().V1().ClusterRoleBinding(),
+		roleBindings:        k8srbac.Rbac().V1().RoleBinding(),
+	}
+
+	return bc.clean()
+}
+
+func (bc *bindingsCleanup) clean() error {
+	crtbs, err := bc.crtbs.List("", metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	prtbs, err := bc.prtbs.List("", metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	// The label's key and value changes depending on the rancher version
+	var rancher25 bool
+
+	// Check if we have the updated label, this indicates we are running on rancher 2.5+
+	if len(crtbs.Items) > 0 {
+		if _, ok := crtbs.Items[0].Labels[auth.RtbCrbRbLabelsUpdated]; ok {
+			rancher25 = true
+		}
+	} else if len(prtbs.Items) > 0 {
+		if _, ok := prtbs.Items[0].Labels[auth.RtbCrbRbLabelsUpdated]; ok {
+			rancher25 = true
+		}
+	} else {
+		logrus.Info("No clusterRoleTemplateBindings or projectRoleTemplateBindings found, exiting.")
+		return nil
+	}
+
+	var waitGroup sync.WaitGroup
+
+	waitGroup.Add(2)
+	go func() {
+		if err := bc.cleanCRTB(rancher25, crtbs.Items); err != nil {
+			logrus.Error(err)
+		}
+		waitGroup.Done()
+	}()
+
+	go func() {
+		if err := bc.cleanPRTB(rancher25, prtbs.Items); err != nil {
+			logrus.Error(err)
+		}
+		waitGroup.Done()
+	}()
+	waitGroup.Wait()
+	return nil
+}
+
+func (bc *bindingsCleanup) cleanCRTB(newLabel bool, crtbs []apiv3.ClusterRoleTemplateBinding) error {
+	var objectMetas []metav1.ObjectMeta
+	for _, crtb := range crtbs {
+		objectMetas = append(objectMetas, crtb.ObjectMeta)
+	}
+
+	return bc.cleanObjectDuplicates(crtbType, newLabel, objectMetas)
+}
+
+func (bc *bindingsCleanup) cleanPRTB(newLabel bool, prtbs []apiv3.ProjectRoleTemplateBinding) error {
+	var objectMetas []metav1.ObjectMeta
+	for _, prtb := range prtbs {
+		objectMetas = append(objectMetas, prtb.ObjectMeta)
+	}
+
+	return bc.cleanObjectDuplicates(prtbType, newLabel, objectMetas)
+}
+
+func (bc *bindingsCleanup) cleanObjectDuplicates(bindingType string, newLabel bool, objMetas []metav1.ObjectMeta) error {
+	// Uppercase so the logging looks pretty
+	bindingUpper := strings.ToUpper(bindingType)
+
+	var returnErr error
+	var totalCRBDupes, totalRoleDupes int
+
+	for _, meta := range objMetas {
+		labels := createLabelSelectors(newLabel, meta, bindingType)
+		for _, label := range labels {
+			var CRBduplicates, RBDupes int
+
+			crbs, err := bc.clusterRoleBindings.List(metav1.ListOptions{LabelSelector: label})
+			if err != nil {
+				multierror.Append(returnErr, err)
+			}
+
+			if len(crbs.Items) > 1 {
+				CRBduplicates += len(crbs.Items) - 1
+				if err := bc.dedupeCRB(crbs.Items); err != nil {
+					multierror.Append(returnErr, err)
+				}
+			}
+
+			roleBindings, err := bc.roleBindings.List("", metav1.ListOptions{LabelSelector: label})
+			if err != nil {
+				multierror.Append(returnErr, err)
+			}
+
+			if len(roleBindings.Items) > 1 {
+				roleDuplicates, err := bc.dedupeRB(roleBindings.Items)
+				if err != nil {
+					multierror.Append(returnErr, err)
+				}
+				RBDupes += roleDuplicates
+			}
+			if CRBduplicates > 0 || RBDupes > 0 {
+				totalCRBDupes += CRBduplicates
+				totalRoleDupes += RBDupes
+				logrus.Infof("%v %v label:%v Duplicates: CRB:%v RB:%v", bindingUpper, meta.Name, label, CRBduplicates, RBDupes)
+			}
+		}
+	}
+	logrus.Infof("Total %v duplicate clusterRoleBindings %v, roleBindings %v", bindingUpper, totalCRBDupes, totalRoleDupes)
+	return returnErr
+}
+
+func (bc *bindingsCleanup) dedupeCRB(bindings []k8srbacv1.ClusterRoleBinding) error {
+	// Sort by creation timestamp so we keep the oldest
+	sort.Sort(crbByCreation(bindings))
+
+	// Leave the first one alone, we only need the duplicates
+	duplicates := bindings[1:]
+
+	for _, binding := range duplicates {
+		if !dryRun {
+			if err := bc.clusterRoleBindings.Delete(binding.Name, &metav1.DeleteOptions{}); err != nil {
+				logrus.Errorf("error attempting to delete CRB %v %v", binding.Name, err)
+			}
+		} else {
+			logrus.Infof("DryRun enabled, clusterRoleBinding %v would be deleted", binding.Name)
+		}
+	}
+	return nil
+}
+
+func (bc *bindingsCleanup) dedupeRB(roleBindings []k8srbacv1.RoleBinding) (int, error) {
+	// roleBindings need to be sorted by namespace. The list gets all of the roleBindings
+	// with the correct label but we do the processing here to limit the amount of API
+	// calls this has to do. Sorting off namespace here is much faster than doing a
+	// call per namespace per label (and gentler on the API).
+	var duplicatesFound int
+
+	bindingMap := make(map[string][]k8srbacv1.RoleBinding)
+	for _, b := range roleBindings {
+		bindingMap[b.Namespace] = append(bindingMap[b.Namespace], b)
+	}
+
+	for _, bindings := range bindingMap {
+		// Sort by creation timestamp so we keep the oldest
+		sort.Sort(roleBindingByCreation(bindings))
+		// Leave the first one alone, we only need the duplicates
+		duplicates := bindings[1:]
+		for _, binding := range duplicates {
+			duplicatesFound++
+			if !dryRun {
+				if err := bc.roleBindings.Delete(binding.Namespace, binding.Name, &metav1.DeleteOptions{}); err != nil {
+					logrus.Errorf("error attempting to delete RB %v %v", binding.Name, err)
+				}
+			} else {
+				logrus.Infof("DryRun enabled, roleBinding %v in namespace %v would be deleted", binding.Name, binding.Namespace)
+			}
+		}
+	}
+	return duplicatesFound, nil
+}
+
+// createLabelSelectors creates the labels required to list both clusterRoleBindings and
+// roleBindings. See https://github.com/rancher/rancher/pull/28423#issue-468992149 for an explanation
+// of the labels.
+func createLabelSelectors(newLabel bool, obj metav1.ObjectMeta, objType string) []string {
+	var labelSelectors []string
+	var key string
+
+	// newLabel determines if we are using the newer rancher 2.5 style labels
+	if newLabel {
+		key = pkgrbac.GetRTBLabel(obj)
+		labelSelectors = append(labelSelectors, key+"="+auth.MembershipBindingOwner)
+	} else {
+		key = string(obj.UID)
+		labelSelectors = append(labelSelectors, key+"="+auth.MembershipBindingOwnerLegacy)
+	}
+
+	switch objType {
+	case crtbType:
+		labelSelectors = append(labelSelectors, key+"="+auth.CrtbInProjectBindingOwner)
+	case prtbType:
+		labelSelectors = append(labelSelectors, key+"="+auth.PrtbInClusterBindingOwner)
+	}
+
+	return labelSelectors
+}
+
+type crbByCreation []k8srbacv1.ClusterRoleBinding
+
+func (n crbByCreation) Len() int      { return len(n) }
+func (n crbByCreation) Swap(i, j int) { n[i], n[j] = n[j], n[i] }
+
+func (n crbByCreation) Less(i, j int) bool {
+	s := n[i].ObjectMeta.CreationTimestamp
+	t := n[j].ObjectMeta.CreationTimestamp
+	return s.Before(&t)
+}
+
+type roleBindingByCreation []k8srbacv1.RoleBinding
+
+func (n roleBindingByCreation) Len() int      { return len(n) }
+func (n roleBindingByCreation) Swap(i, j int) { n[i], n[j] = n[j], n[i] }
+
+func (n roleBindingByCreation) Less(i, j int) bool {
+	s := n[i].ObjectMeta.CreationTimestamp
+	t := n[j].ObjectMeta.CreationTimestamp
+	return s.Before(&t)
+}

--- a/pkg/agent/clean/binding_windows.go
+++ b/pkg/agent/clean/binding_windows.go
@@ -1,0 +1,5 @@
+package clean
+
+func Bindings() error {
+	return nil
+}

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -20,19 +20,19 @@ const (
 	2.5 onwards, instead of the roleTemplateBinding's UID, a combination of its namespace and name will be used in this label.
 	CRB/RBs on clusters upgraded from 2.4.x to 2.5 will continue to carry the original label with UID. To ensure permissions are managed properly on upgrade,
 	we need to change the label value as well.
-	So the older label value, membershipBindingOwnerLegacy (<=2.4.x) will continue to be "memberhsip-binding-owner" (notice the spelling mistake),
-	and the new label, membershipBindingOwner will be "membership-binding-owner" (a different label value with the right spelling)*/
-	membershipBindingOwnerLegacy = "memberhsip-binding-owner"
-	membershipBindingOwner       = "membership-binding-owner"
+	So the older label value, MembershipBindingOwnerLegacy (<=2.4.x) will continue to be "memberhsip-binding-owner" (notice the spelling mistake),
+	and the new label, MembershipBindingOwner will be "membership-binding-owner" (a different label value with the right spelling)*/
+	MembershipBindingOwnerLegacy = "memberhsip-binding-owner"
+	MembershipBindingOwner       = "membership-binding-owner"
 	clusterResource              = "clusters"
 	membershipBindingOwnerIndex  = "auth.management.cattle.io/membership-binding-owner"
-	crtbInProjectBindingOwner    = "crtb-in-project-binding-owner"
-	prtbInClusterBindingOwner    = "prtb-in-cluster-binding-owner"
+	CrtbInProjectBindingOwner    = "crtb-in-project-binding-owner"
+	PrtbInClusterBindingOwner    = "prtb-in-cluster-binding-owner"
 	rbByOwnerIndex               = "auth.management.cattle.io/rb-by-owner"
 	rbByRoleAndSubjectIndex      = "auth.management.cattle.io/crb-by-role-and-subject"
 	ctrbMGMTController           = "mgmt-auth-crtb-controller"
 	rtbLabelUpdated              = "auth.management.cattle.io/rtb-label-updated"
-	rtbCrbRbLabelsUpdated        = "auth.management.cattle.io/crb-rb-labels-updated"
+	RtbCrbRbLabelsUpdated        = "auth.management.cattle.io/crb-rb-labels-updated"
 )
 
 var clusterManagmentPlaneResources = map[string]string{
@@ -184,7 +184,7 @@ func (c *crtbLifecycle) removeMGMTClusterScopedPrivilegesInProjectNamespace(bind
 	}
 	bindingKey := pkgrbac.GetRTBLabel(binding.ObjectMeta)
 	for _, p := range projects {
-		set := labels.Set(map[string]string{bindingKey: crtbInProjectBindingOwner})
+		set := labels.Set(map[string]string{bindingKey: CrtbInProjectBindingOwner})
 		rbs, err := c.mgr.rbLister.List(p.Name, set.AsSelector())
 		if err != nil {
 			return err
@@ -205,7 +205,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 	    2. CRTB.UID is label key for the RB, CRTB.UID=crtb-in-project-binding-owner (in the namespace of each project in the cluster that the user has access to)
 	Using above labels, list the CRB and RB and update them to add a label with ns+name of CRTB
 	*/
-	if binding.Labels[rtbCrbRbLabelsUpdated] == "true" {
+	if binding.Labels[RtbCrbRbLabelsUpdated] == "true" {
 		return nil
 	}
 
@@ -215,7 +215,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 		return err
 	}
 
-	set := labels.Set(map[string]string{string(binding.UID): membershipBindingOwnerLegacy})
+	set := labels.Set(map[string]string{string(binding.UID): MembershipBindingOwnerLegacy})
 	crbs, err := c.mgr.crbLister.List(v1.NamespaceAll, set.AsSelector().Add(requirements...))
 	if err != nil {
 		return err
@@ -230,7 +230,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 			if crbToUpdate.Labels == nil {
 				crbToUpdate.Labels = make(map[string]string)
 			}
-			crbToUpdate.Labels[bindingKey] = membershipBindingOwner
+			crbToUpdate.Labels[bindingKey] = MembershipBindingOwner
 			crbToUpdate.Labels[rtbLabelUpdated] = "true"
 			_, err := c.mgr.crbClient.Update(crbToUpdate)
 			return err
@@ -240,7 +240,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 		}
 	}
 
-	set = map[string]string{string(binding.UID): crtbInProjectBindingOwner}
+	set = map[string]string{string(binding.UID): CrtbInProjectBindingOwner}
 	rbs, err := c.mgr.rbLister.List(v1.NamespaceAll, set.AsSelector().Add(requirements...))
 	if err != nil {
 		return err
@@ -255,7 +255,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 			if rbToUpdate.Labels == nil {
 				rbToUpdate.Labels = make(map[string]string)
 			}
-			rbToUpdate.Labels[bindingKey] = crtbInProjectBindingOwner
+			rbToUpdate.Labels[bindingKey] = CrtbInProjectBindingOwner
 			rbToUpdate.Labels[rtbLabelUpdated] = "true"
 			_, err := c.mgr.rbClient.Update(rbToUpdate)
 			return err
@@ -276,7 +276,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 		if crtbToUpdate.Labels == nil {
 			crtbToUpdate.Labels = make(map[string]string)
 		}
-		crtbToUpdate.Labels[rtbCrbRbLabelsUpdated] = "true"
+		crtbToUpdate.Labels[RtbCrbRbLabelsUpdated] = "true"
 		_, err := c.mgr.crtbs.Update(crtbToUpdate)
 		return err
 	})

--- a/pkg/controllers/management/auth/indexes.go
+++ b/pkg/controllers/management/auth/indexes.go
@@ -49,7 +49,7 @@ func indexByMembershipBindingOwner(obj interface{}) ([]string, error) {
 	ns := meta.GetNamespace()
 	var keys []string
 	for k, v := range meta.GetLabels() {
-		if v == membershipBindingOwner {
+		if v == MembershipBindingOwner {
 			keys = append(keys, strings.Join([]string{ns, k}, "/"))
 		}
 	}

--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -144,7 +144,7 @@ func (m *manager) ensureClusterMembershipBinding(roleName, rtbNsAndName string, 
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "clusterrolebinding-",
 				Labels: map[string]string{
-					rtbNsAndName: membershipBindingOwner,
+					rtbNsAndName: MembershipBindingOwner,
 				},
 			},
 			Subjects: []v1.Subject{subject},
@@ -167,7 +167,7 @@ func (m *manager) ensureClusterMembershipBinding(roleName, rtbNsAndName string, 
 	if crb.Labels == nil {
 		crb.Labels = map[string]string{}
 	}
-	crb.Labels[rtbNsAndName] = membershipBindingOwner
+	crb.Labels[rtbNsAndName] = MembershipBindingOwner
 	logrus.Infof("[%v] Updating clusterRoleBinding %v for cluster membership in cluster %v for subject %v", m.controller, crb.Name, cluster.Name, subject.Name)
 	_, err = m.mgmt.RBAC.ClusterRoleBindings("").Update(crb)
 	return err
@@ -217,7 +217,7 @@ func (m *manager) ensureProjectMembershipBinding(roleName, rtbNsAndName, namespa
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "rolebinding-",
 				Labels: map[string]string{
-					rtbNsAndName: membershipBindingOwner,
+					rtbNsAndName: MembershipBindingOwner,
 				},
 			},
 			Subjects: []v1.Subject{subject},
@@ -240,7 +240,7 @@ func (m *manager) ensureProjectMembershipBinding(roleName, rtbNsAndName, namespa
 	if rb.Labels == nil {
 		rb.Labels = map[string]string{}
 	}
-	rb.Labels[rtbNsAndName] = membershipBindingOwner
+	rb.Labels[rtbNsAndName] = MembershipBindingOwner
 	logrus.Infof("[%v] Updating roleBinding %v for project membership in project %v for subject %v", m.controller, rb.Name, project.Name, subject.Name)
 	_, err = m.mgmt.RBAC.RoleBindings(namespace).Update(rb)
 	return err
@@ -365,9 +365,9 @@ func (m *manager) reconcileMembershipBindingForDelete(namespace, roleToKeep, rtb
 		}
 		var otherOwners bool
 		for k, v := range objMeta.GetLabels() {
-			if k == rtbNsAndName && v == membershipBindingOwner {
+			if k == rtbNsAndName && v == MembershipBindingOwner {
 				delete(objMeta.GetLabels(), k)
-			} else if v == membershipBindingOwner {
+			} else if v == MembershipBindingOwner {
 				// Another rtb is also linked to this roleBinding so don't delete
 				otherOwners = true
 			}
@@ -500,7 +500,7 @@ func (m *manager) grantManagementClusterScopedPrivilegesInProjectNamespace(roleT
 						ObjectMeta: metav1.ObjectMeta{
 							Name: bindingName,
 							Labels: map[string]string{
-								bindingKey: crtbInProjectBindingOwner,
+								bindingKey: CrtbInProjectBindingOwner,
 							},
 						},
 						Subjects: []v1.Subject{subject},
@@ -520,7 +520,7 @@ func (m *manager) grantManagementClusterScopedPrivilegesInProjectNamespace(roleT
 	}
 
 	currentRBs := map[string]*v1.RoleBinding{}
-	set := labels.Set(map[string]string{bindingKey: crtbInProjectBindingOwner})
+	set := labels.Set(map[string]string{bindingKey: CrtbInProjectBindingOwner})
 	current, err := m.rbLister.List(projectNamespace, set.AsSelector())
 	if err != nil {
 		return err
@@ -561,7 +561,7 @@ func (m *manager) grantManagementProjectScopedPrivilegesInClusterNamespace(roleT
 						ObjectMeta: metav1.ObjectMeta{
 							Name: bindingName,
 							Labels: map[string]string{
-								bindingKey: prtbInClusterBindingOwner,
+								bindingKey: PrtbInClusterBindingOwner,
 							},
 						},
 						Subjects: []v1.Subject{subject},
@@ -581,7 +581,7 @@ func (m *manager) grantManagementProjectScopedPrivilegesInClusterNamespace(roleT
 	}
 
 	currentRBs := map[string]*v1.RoleBinding{}
-	set := labels.Set(map[string]string{bindingKey: prtbInClusterBindingOwner})
+	set := labels.Set(map[string]string{bindingKey: PrtbInClusterBindingOwner})
 	current, err := m.rbLister.List(clusterNamespace, set.AsSelector())
 	if err != nil {
 		return err

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -196,7 +196,7 @@ func (p *prtbLifecycle) reconcileBindings(binding *v3.ProjectRoleTemplateBinding
 // removeMGMTProjectScopedPrivilegesInClusterNamespace revokes access that project roles were granted to certain cluster scoped resources like
 // catalogtemplates, when the prtb is deleted, by deleting the rolebinding created for this prtb in the cluster's namespace
 func (p *prtbLifecycle) removeMGMTProjectScopedPrivilegesInClusterNamespace(binding *v3.ProjectRoleTemplateBinding, clusterName string) error {
-	set := labels.Set(map[string]string{pkgrbac.GetRTBLabel(binding.ObjectMeta): prtbInClusterBindingOwner})
+	set := labels.Set(map[string]string{pkgrbac.GetRTBLabel(binding.ObjectMeta): PrtbInClusterBindingOwner})
 	rbs, err := p.mgr.rbLister.List(clusterName, set.AsSelector())
 	if err != nil {
 		return err
@@ -219,7 +219,7 @@ func (p *prtbLifecycle) reconcileLabels(binding *v3.ProjectRoleTemplateBinding) 
 	    2. PRTB.UID is label key for the RB, PRTB.UID=memberhsip-binding-owner
 	    3. PRTB.UID is label key for RB, PRTB.UID=prtb-in-cluster-binding-owner
 	*/
-	if binding.Labels[rtbCrbRbLabelsUpdated] == "true" {
+	if binding.Labels[RtbCrbRbLabelsUpdated] == "true" {
 		return nil
 	}
 
@@ -229,7 +229,7 @@ func (p *prtbLifecycle) reconcileLabels(binding *v3.ProjectRoleTemplateBinding) 
 		return err
 	}
 	bindingKey := pkgrbac.GetRTBLabel(binding.ObjectMeta)
-	set := labels.Set(map[string]string{string(binding.UID): membershipBindingOwnerLegacy})
+	set := labels.Set(map[string]string{string(binding.UID): MembershipBindingOwnerLegacy})
 	crbs, err := p.mgr.crbLister.List(v1.NamespaceAll, set.AsSelector().Add(requirements...))
 	if err != nil {
 		return err
@@ -243,7 +243,7 @@ func (p *prtbLifecycle) reconcileLabels(binding *v3.ProjectRoleTemplateBinding) 
 			if crbToUpdate.Labels == nil {
 				crbToUpdate.Labels = make(map[string]string)
 			}
-			crbToUpdate.Labels[bindingKey] = membershipBindingOwner
+			crbToUpdate.Labels[bindingKey] = MembershipBindingOwner
 			crbToUpdate.Labels[rtbLabelUpdated] = "true"
 			_, err := p.mgr.crbClient.Update(crbToUpdate)
 			return err
@@ -253,7 +253,7 @@ func (p *prtbLifecycle) reconcileLabels(binding *v3.ProjectRoleTemplateBinding) 
 		}
 	}
 
-	for _, prtbLabel := range []string{membershipBindingOwner, prtbInClusterBindingOwner} {
+	for _, prtbLabel := range []string{MembershipBindingOwner, PrtbInClusterBindingOwner} {
 		set = map[string]string{string(binding.UID): prtbLabel}
 		rbs, err := p.mgr.rbLister.List(v1.NamespaceAll, set.AsSelector().Add(requirements...))
 		if err != nil {
@@ -290,7 +290,7 @@ func (p *prtbLifecycle) reconcileLabels(binding *v3.ProjectRoleTemplateBinding) 
 		if prtbToUpdate.Labels == nil {
 			prtbToUpdate.Labels = make(map[string]string)
 		}
-		prtbToUpdate.Labels[rtbCrbRbLabelsUpdated] = "true"
+		prtbToUpdate.Labels[RtbCrbRbLabelsUpdated] = "true"
 		_, err := p.mgr.prtbs.Update(prtbToUpdate)
 		return err
 	})


### PR DESCRIPTION
This will add the ability for the agent to be ran as a job using a script and k8s manifest to cleanup duplicate roleBindings and clusterRoleBindings.

There is nothing added to rancher yet to use this code, it can only be used externally through the script.

Related to #29932 but this does not fix the issue, just allows a cleanup to be done on the management cluster.