### PR TITLE
bump rke2 version to v1.18.16+rke2r1

### DIFF
--- a/cmd/rancherd/go.mod
+++ b/cmd/rancherd/go.mod
@@ -65,7 +65,7 @@ replace (
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/k3s v1.19.2-0.20201028222356-523ccaf3f22a
-	github.com/rancher/rke2 v1.18.13-0.20201207193710-1d6e826b9fdf // v1.18.12+rke2r2 ... If you update this, also update rancher/package/Dockerfile.runtime
+	github.com/rancher/rke2 v1.18.17-0.20210219234255-fb4b8760be7b // v1.18.16+rke2r1 ... If you update this, also update rancher/package/Dockerfile.runtime
 	github.com/rancher/wrangler v0.6.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/urfave/cli v1.22.2

--- a/cmd/rancherd/go.sum
+++ b/cmd/rancherd/go.sum
@@ -728,10 +728,8 @@ github.com/rancher/kubernetes/staging/src/k8s.io/sample-apiserver v1.19.0-k3s1/g
 github.com/rancher/moq v0.0.0-20190404221404-ee5226d43009/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/remotedialer v0.2.0 h1:xD7t3K6JYwTdAsxmGtTHQMkEkFgKouQ1foLxVW424Dc=
 github.com/rancher/remotedialer v0.2.0/go.mod h1:tkU8ZvrR5lRgaKWaX71nAy6daeqvPFx/lJEnbW7tXSI=
-github.com/rancher/rke2 v1.18.13-0.20201116190518-b63f92a2b66e h1:0f5DPgfBH8+Y1mG7To5nmcu69+F5eaElqmCwIG24T+k=
-github.com/rancher/rke2 v1.18.13-0.20201116190518-b63f92a2b66e/go.mod h1:hQ5acWquDxv8rc7Nv1gXYEaZ2at4D6OwHdvlH7TxQLQ=
-github.com/rancher/rke2 v1.18.13-0.20201207193710-1d6e826b9fdf h1:YjHm/U2dMEUtYFCrLzto42IcsjVONfXoF2a7pcttIx4=
-github.com/rancher/rke2 v1.18.13-0.20201207193710-1d6e826b9fdf/go.mod h1:hQ5acWquDxv8rc7Nv1gXYEaZ2at4D6OwHdvlH7TxQLQ=
+github.com/rancher/rke2 v1.18.17-0.20210219234255-fb4b8760be7b h1:GAMvYOxthuMoZzOsjFDQZRDPNwImtVjjOsfvzFJuruY=
+github.com/rancher/rke2 v1.18.17-0.20210219234255-fb4b8760be7b/go.mod h1:hQ5acWquDxv8rc7Nv1gXYEaZ2at4D6OwHdvlH7TxQLQ=
 github.com/rancher/wrangler v0.1.4/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rancher/wrangler v0.4.0/go.mod h1:1cR91WLhZgkZ+U4fV9nVuXqKurWbgXcIReU4wnQvTN8=
 github.com/rancher/wrangler v0.6.0/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=

--- a/package/Dockerfile.runtime
+++ b/package/Dockerfile.runtime
@@ -1,4 +1,4 @@
-ARG RKE2_VERSION=v1.18.12-rke2r2
+ARG RKE2_VERSION=v1.18.16-rke2r1
 # if you’re changing this, also change rancher/cmd/rancherd/go.mod
 FROM rancher/rke2-runtime:${RKE2_VERSION}
 COPY rancher.yaml rancher-namespace.yaml /charts/


### PR DESCRIPTION
**Problem**
Need to bump rke2 1.18 to latest 1.18 version

**Solution**
Bump RKE2 to v1.18.16+rke2r1

**Backport**
https://github.com/rancher/rancher/pull/31466

**Issue**
#30492