### PR TITLE
Update build-server: Force rebuilding of packages

### DIFF
--- a/scripts/build-server
+++ b/scripts/build-server
@@ -13,7 +13,7 @@ RKE_VERSION="$(grep -m1 'github.com/rancher/rke' go.mod | awk '{print $2}')"
 # Inject Setting values
 DEFAULT_VALUES="{\"rke-version\":\"${RKE_VERSION}\"}"
 
-CGO_ENABLED=0 go build -i -tags k8s \
+CGO_ENABLED=0 go build -a -i -tags k8s \
   -ldflags \
   "-X github.com/rancher/rancher/pkg/version.Version=$VERSION
    -X github.com/rancher/rancher/pkg/version.GitCommit=$COMMIT


### PR DESCRIPTION
Attempting to fix cache holding corrupt (reverted) types.

Alternatively we could use `go clean`