### PR TITLE
Adding terraform version param for validation tools

### DIFF
--- a/tests/validation/Dockerfile.v3api
+++ b/tests/validation/Dockerfile.v3api
@@ -8,6 +8,7 @@ ARG RKE_VERSION=v1.0.2
 ARG CLI_VERSION=v2.3.2
 ARG RANCHER_HELM_VERSION=v3.3.4
 ARG SONOBUOY_VERSION=0.18.2
+ARG TERRAFORM_VERSION=0.12.10
 
 
 COPY [".", "$WORKSPACE"]
@@ -26,10 +27,10 @@ RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERS
     tar -x -f helm-$RANCHER_HELM_VERSION-linux-amd64.tar.gz && \
     mv linux-amd64/helm /bin/helm_v3 && \
     chmod +x /bin/helm_v3 && \
-    wget https://releases.hashicorp.com/terraform/0.12.10/terraform_0.12.10_linux_amd64.zip && \
+    wget https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_"$TERRAFORM_VERSION"_linux_amd64.zip && \
     apt-get update && \
     apt-get install unzip && \
-    unzip terraform_0.12.10_linux_amd64.zip && \
+    unzip terraform_"$TERRAFORM_VERSION"_linux_amd64.zip && \
     chmod u+x terraform && \
     mv terraform /usr/local/bin && \
     wget "https://github.com/vmware-tanzu/sonobuoy/releases/download/v$SONOBUOY_VERSION/sonobuoy_$SONOBUOY_VERSION"_linux_amd64.tar.gz && \

--- a/tests/validation/tests/v3_api/scripts/build.sh
+++ b/tests/validation/tests/v3_api/scripts/build.sh
@@ -9,8 +9,9 @@ RANCHER_HELM_VERSION="${RANCHER_HELM_VERSION:-v3.3.4}"
 KUBECTL_VERSION="${KUBECTL_VERSION:-v1.16.6}"
 CLI_VERSION="${CLI_VERSION:-v2.4.5}"
 SONOBUOY_VERSION="${SONOBUOY_VERSION:-0.18.2}"
+TERRAFORM_VERSION="${TERRAFORM_VERSION:-0.12.10}"
 
-TRIM_JOB_NAME=$(basename $JOB_NAME)
+TRIM_JOB_NAME=$(basename "$JOB_NAME")
 
 if [ "false" != "${DEBUG}" ]; then
     echo "Environment:"
@@ -21,7 +22,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../" && pwd )"
 
 count=0
 while [[ 3 -gt $count ]]; do    
-    docker build -q -f Dockerfile.v3api --build-arg CLI_VERSION=$CLI_VERSION --build-arg RKE_VERSION=$RKE_VERSION --build-arg RANCHER_HELM_VERSION=$RANCHER_HELM_VERSION --build-arg KUBECTL_VERSION=$KUBECTL_VERSION --build-arg SONOBUOY_VERSION=$SONOBUOY_VERSION -t rancher-validation-${TRIM_JOB_NAME}${BUILD_NUMBER} .
+    docker build -q -f Dockerfile.v3api --build-arg CLI_VERSION="$CLI_VERSION" --build-arg RKE_VERSION="$RKE_VERSION" --build-arg RANCHER_HELM_VERSION="$RANCHER_HELM_VERSION" --build-arg KUBECTL_VERSION="$KUBECTL_VERSION" --build-arg SONOBUOY_VERSION="$SONOBUOY_VERSION" --build-arg TERRAFORM_VERSION="$TERRAFORM_VERSION" -t rancher-validation-"${TRIM_JOB_NAME}""${BUILD_NUMBER}" .
 
     if [[ $? -eq 0 ]]; then break; fi
     count=$(($count + 1))


### PR DESCRIPTION
Just parameterize the terraform version.
I passed a shellcheck linter on it too.

Tested locally

```
➜  validation git:(terraform_tools_parameter) ✗ tests/v3_api/scripts/build.sh
+ set -eu
+ DEBUG=false
+ RKE_VERSION=v1.0.2
+ RANCHER_HELM_VERSION=v3.3.4
+ KUBECTL_VERSION=v1.16.6
+ CLI_VERSION=v2.4.5
+ SONOBUOY_VERSION=0.18.2
+ TERRAFORM_VERSION=0.13.6
+ JOB_NAME=testizaac1
+ BUILD_NUMBER=1
++ basename testizaac1
+ TRIM_JOB_NAME=testizaac1
+ '[' false '!=' false ']'
+++ dirname tests/v3_api/scripts/build.sh
++ cd tests/v3_api/scripts/../../../
++ pwd
+ cd /Users/izaac/repos/rancher-izaac/tests/validation
+ count=0
+ [[ 3 -gt 0 ]]
+ docker build -q -f Dockerfile.v3api --build-arg CLI_VERSION=v2.4.5 --build-arg RKE_VERSION=v1.0.2 --build-arg RANCHER_HELM_VERSION=v3.3.4 --build-arg KUBECTL_VERSION=v1.16.6 --build-arg SONOBUOY_VERSION=0.18.2 --build-arg TERRAFORM_VERSION=0.13.6 -t rancher-validation-testizaac11 .
sha256:ffc595b19f7c1a019c75672ee59e23fb1a359fb33989231b5a309d439d73b464
+ [[ 0 -eq 0 ]]
+ break

➜  validation git:(terraform_tools_parameter) ✗ docker run rancher-validation-testizaac11 terraform version
Terraform v0.13.6

Your version of Terraform is out of date! The latest version
is 0.14.7. You can update by downloading from https://www.terraform.io/downloads.html
```