### PR TITLE
[Automation] Making the AKS cluster name predictable

### DIFF
--- a/tests/validation/tests/v3_api/resource/terraform/aks/aks.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/aks/aks.tf
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "default" {
 }
 
 resource "azurerm_kubernetes_cluster" "default" {
-  name                = "testautoaks${random_string.random.result}"
+  name                = var.cluster_name
   location            = azurerm_resource_group.default.location
   resource_group_name = azurerm_resource_group.default.name
   dns_prefix          = "taaks${random_string.random.result}"

--- a/tests/validation/tests/v3_api/resource/terraform/aks/variables.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/aks/variables.tf
@@ -28,3 +28,7 @@ variable "client_id" {
 variable "client_secret" {
   default = ""
 }
+
+variable "cluster_name" {
+  default = "testautoaks"
+}

--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -451,7 +451,9 @@ def create_aks_cluster():
                    variables={'kubernetes_version': aks_k8_s_version,
                               'location': aks_location,
                               'client_id': client_id,
-                              'client_secret': client_secret})
+                              'client_secret': client_secret,
+                              'cluster_name': resource_prefix})
+
     print("Creating cluster")
     tf.init()
     print(tf.plan(out="aks_plan_server.out"))


### PR DESCRIPTION
Realized this should be predictable, I used the resource prefix from the HA automation