### PR TITLE
[v2.5] Added downstream k8s cluster psp annotations from Rancher psp template

### DIFF
--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/binding.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/binding.go
@@ -3,6 +3,7 @@ package podsecuritypolicy
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -130,6 +131,13 @@ func (l *lifecycle) createPolicy(obj *v3.PodSecurityPolicyTemplateProjectBinding
 	objectMeta.Annotations = make(map[string]string)
 	objectMeta.Annotations[podSecurityPolicyTemplateParentAnnotation] = template.Name
 	objectMeta.Annotations[podSecurityPolicyTemplateVersionAnnotation] = template.ResourceVersion
+
+	// Setting annotations that doesn't contains podSecurityPolicyTemplateFilterAnnotation
+	for k, v := range template.Annotations {
+		if !strings.Contains(k, podSecurityPolicyTemplateFilterAnnotation) {
+			objectMeta.Annotations[k] = v
+		}
+	}
 
 	psp := &v1beta13.PodSecurityPolicy{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/cluster.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/cluster.go
@@ -3,6 +3,7 @@ package podsecuritypolicy
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -75,6 +76,13 @@ func (m *clusterManager) sync(key string, obj *v3.Cluster) (runtime.Object, erro
 				objectMeta.Annotations = make(map[string]string)
 				objectMeta.Annotations[podSecurityPolicyTemplateParentAnnotation] = template.Name
 				objectMeta.Annotations[podSecurityPolicyTemplateVersionAnnotation] = template.ResourceVersion
+
+				// Setting annotations that doesn't contains podSecurityPolicyTemplateFilterAnnotation
+				for k, v := range template.Annotations {
+					if !strings.Contains(k, podSecurityPolicyTemplateFilterAnnotation) {
+						objectMeta.Annotations[k] = v
+					}
+				}
 
 				psp := &v1beta13.PodSecurityPolicy{
 					TypeMeta: metav1.TypeMeta{

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/metadata.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/metadata.go
@@ -5,6 +5,7 @@ const (
 	apiVersion                                 = "policy/v1beta1"
 	podSecurityPolicyTemplateParentAnnotation  = "serviceaccount.cluster.cattle.io/pod-security"
 	podSecurityPolicyTemplateVersionAnnotation = "serviceaccount.cluster.cattle.io/pod-security-version"
+	podSecurityPolicyTemplateFilterAnnotation  = ".cattle.io/"
 	projectIDAnnotation                        = "field.cattle.io/projectId"
 	podSecurityPolicy                          = "PodSecurityPolicy"
 	podSecurityPolicyTemplateUpgrade           = "cleanup.cattle.io/psptUpgrade"

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/template.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/template.go
@@ -85,6 +85,13 @@ func (p *psptHandler) sync(key string, obj *v3.PodSecurityPolicyTemplate) (runti
 			newPolicy.Spec = obj.Spec
 			newPolicy.Annotations[podSecurityPolicyTemplateVersionAnnotation] = obj.ResourceVersion
 
+			// Setting annotations that doesn't contains podSecurityPolicyTemplateFilterAnnotation
+			for k, v := range obj.Annotations {
+				if !strings.Contains(k, podSecurityPolicyTemplateFilterAnnotation) {
+					newPolicy.Annotations[k] = v
+				}
+			}
+
 			_, err = p.policies.Update(newPolicy)
 			if err != nil {
 				return nil, fmt.Errorf("error updating psp: %v", err)


### PR DESCRIPTION
Issue https://github.com/rancher/rancher/issues/22093

This PR add the feature to apply annotations defined at Rancher psp template to applied downstream cluster psp. Just annotations that its name doesn't contain `.cattle.io/` will be applied.