### PR TITLE
[2.5] Add support for creating a GKE cloud credential

### DIFF
--- a/pkg/controllers/management/drivers/nodedriver/machine_driver.go
+++ b/pkg/controllers/management/drivers/nodedriver/machine_driver.go
@@ -39,6 +39,7 @@ var (
 		"otc":           map[string]string{"privateKeyFile": "privateKeyFile"},
 		"packet":        map[string]string{"userdata": "userdata"},
 		"vmwarevsphere": map[string]string{"cloud-config": "cloudConfig"},
+		"google":        map[string]string{"authEncodedJson": "authEncodedJson"},
 	}
 	SSHKeyFields = map[string]bool{
 		"sshKeyContents": true,

--- a/pkg/controllers/management/drivers/nodedriver/utils.go
+++ b/pkg/controllers/management/drivers/nodedriver/utils.go
@@ -69,6 +69,21 @@ func ToLowerCamelCase(nodeFlagName string) (string, error) {
 }
 
 func getCreateFlagsForDriver(driver string) ([]cli.Flag, error) {
+	var flags []cli.Flag
+	// NOTE(cmurphy): There is not currently a real google machine driver, but
+	// we still want to be able to create a Google cloud credential to use with
+	// GKE. This fake driver flag allows us to go through the motions of
+	// handling the credential fields without actually needing to run the
+	// machine driver binary.
+	if driver == "google" {
+		flags = []cli.Flag{
+			&cli.StringFlag{
+				Name: "google-auth-encoded-json",
+			},
+		}
+		return flags, nil
+	}
+
 	logrus.Debug("Starting binary ", driver)
 	p, err := localbinary.NewPlugin(driver)
 	if err != nil {
@@ -93,8 +108,6 @@ func getCreateFlagsForDriver(driver string) ([]cli.Flag, error) {
 	defer rpcclient.Close()
 
 	c := rpcdriver.NewInternalClient(rpcclient)
-
-	var flags []cli.Flag
 
 	if err := c.Call(".GetCreateFlags", struct{}{}, &flags); err != nil {
 		return nil, fmt.Errorf("Error getting flags err=%v", err)

--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -68,6 +68,7 @@ var aliases = map[string]map[string]string{
 	"otc":           map[string]string{"privateKeyFile": "privateKeyFile"},
 	"packet":        map[string]string{"userdata": "userdata"},
 	"vmwarevsphere": map[string]string{"cloudConfig": "cloud-config"},
+	"google":        map[string]string{"authEncodedJson": "authEncodedJson"},
 }
 
 func Register(ctx context.Context, management *config.ManagementContext, clusterManager *clustermanager.Manager) {

--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -28,6 +28,7 @@ const (
 	RackspaceDriver    = "rackspace"
 	SoftLayerDriver    = "softlayer"
 	Vmwaredriver       = "vmwarevsphere"
+	GoogleDriver       = "google"
 )
 
 var driverData = map[string]map[string][]string{
@@ -44,6 +45,7 @@ var driverData = map[string]map[string][]string{
 	RackspaceDriver:    {"privateCredentialFields": []string{"apiKey"}},
 	SoftLayerDriver:    {"privateCredentialFields": []string{"apiKey"}},
 	Vmwaredriver:       {"publicCredentialFields": []string{"username", "vcenter", "vcenterPort"}, "privateCredentialFields": []string{"password"}},
+	GoogleDriver:       {"privateCredentialFields": []string{"authEncodedJson"}},
 }
 
 var driverDefaults = map[string]map[string]string{
@@ -92,6 +94,9 @@ func addMachineDrivers(management *config.ManagementContext) error {
 		return err
 	}
 	if err := addMachineDriver(ExoscaleDriver, "local://", "", "", []string{"api.exoscale.ch"}, false, true, management); err != nil {
+		return err
+	}
+	if err := addMachineDriver(GoogleDriver, "local://", "", "", nil, true, true, management); err != nil {
 		return err
 	}
 	linodeBuiltin := true


### PR DESCRIPTION
This patch adds the ability to create and store a CloudCredential via
the /v3/cloudcredentials API that can be used to drive GKE clusters.

By adding it to the machine driver controller, Rancher can expose this
credential type as a dynamic schema in the same way that other cloud
credentials are supported. However, since GKE is not a real machine
driver, we have to fake it by creating dummy flags for a pretend machine
driver binary.

The credential is identified by the private field "authEncodedJson"
where the value is an *escaped* string representing a JSON object for
the service account data obtained from Google. If the credential object
is provided as a regular JSON object rather than an escaped string,
Rancher will end up converting into a Go map and then to a string
representation of the map before storing it in a Secret, rather than
directly storing the JSON object that is needed to authenticate with
Google. The result is that creating a cloud credential of this type will
look like this:

```
HTTP/1.1 POST /v3/cloudcredentials

{
  "googlecredentialConfig": {
    "authEncodedJson": "{\"type\": \"service_account\",
      \"project_id\": \"my-project\",
      \"private_key_id\": \"abcdef\",
      \"private_key\": \"-----BEGIN PRIVATE KEY-----\\nABCdef==\\n-----END PRIVATE KEY-----\\n\",
      \"client_email\": \"user@my-project.iam.gserviceaccount.com\",
      \"client_id\": \"123456\",
      \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\",
      \"token_uri\": \"https://oauth2.googleapis.com/token\",
      \"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\",
      \"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/user%40project.iam.gserviceaccount.com\"}"
  }
}
```

(cherry picked from commit 7269a38314ec9628153f7e6d7819974d88d8e666)