### PR TITLE
[release/v2.5] Private Registry Regression Fix

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -443,8 +443,9 @@ func (m *Lifecycle) deployAgent(nodeDir string, obj *v3.Node) error {
 // this enables the agent image to be pulled from the private registry
 func (m *Lifecycle) authenticateRegistry(nodeDir string, node *v3.Node, cluster *v3.Cluster) error {
 	reg := util.GetPrivateRepo(cluster)
-	if reg == nil {
-		return nil // if there is no private registry defined, return since auth is not needed
+	// if there is no private registry defined or there is a registry without credentials, return since auth is not needed
+	if reg == nil || reg.User == "" || reg.Password == "" {
+		return nil
 	}
 
 	logrus.Infof("[node-controller-rancher-machine] private registry detected, authenticating %s to %s", node.Spec.RequestedHostname, reg.URL)


### PR DESCRIPTION
This adds a fix to check for the case where no credentials are provided to the private registry configuration for a cluster.

Issue:
- rancher/rancher#31733
