### PR TITLE
Fix proxyPorts to have int instead of string

### DIFF
--- a/package/windows/bootstrap.ps1
+++ b/package/windows/bootstrap.ps1
@@ -288,7 +288,7 @@ catch
             "$($CATTLE_PREFIX_PATH)etc\rancher\wins\wins-upgrade.exe"
         )
         proxyPorts = @(
-            "9796"
+            9796
         )
     }
 } | ConvertTo-Json -Compress -Depth 32 | Out-File -NoNewline -Encoding utf8 -Force -FilePath "$($CATTLE_PREFIX_PATH)etc\rancher\wins\config"


### PR DESCRIPTION
Fixes broken windows cluster provisioning due to a mistake in the config merged in https://github.com/rancher/rancher/pull/31657.

```powershell
# Broken today in master-head because of the following error in bootstrapping
PS C:\Users\Administrator> C:\etc\rancher\wins.exe srv app run
FATA[2021-03-14T00:48:56Z] failed to load config from c:\etc\rancher\wins\config: could not decode config: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go struct field WhiteListConfig.WhiteList.ProxyPorts of type int
```

Related Issue: https://github.com/rancher/rancher/issues/31499