### PR TITLE
Whitelist windows-exporter path for Windows Monitoring

### DIFF
--- a/package/windows/bootstrap.ps1
+++ b/package/windows/bootstrap.ps1
@@ -286,6 +286,7 @@ catch
             "$($CATTLE_PREFIX_PATH)etc\nginx\nginx.exe"
             "$($CATTLE_PREFIX_PATH)opt\bin\flanneld.exe"
             "$($CATTLE_PREFIX_PATH)etc\rancher\wins\wins-upgrade.exe"
+            "$($CATTLE_PREFIX_PATH)etc\windows-exporter\windows-exporter.exe"
         )
         proxyPorts = @(
             9796


### PR DESCRIPTION
Related Issue: https://github.com/rancher/rancher/issues/31499