### PR TITLE
[Backport] Upgrade bootstrapping to use wins v0.1.0 and whitelist Monitoring V2 processes

### DIFF
--- a/package/windows/Dockerfile.agent
+++ b/package/windows/Dockerfile.agent
@@ -12,7 +12,7 @@ RUN $URL = 'https://github.com/StefanScherer/docker-cli-builder/releases/downloa
     \
     Write-Host 'Complete.'
 # download wins
-RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe'; \
+RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.1.0/wins.exe'; \
     \
     Write-Host ('Downloading Wins from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \

--- a/package/windows/Dockerfile.agent.20H2
+++ b/package/windows/Dockerfile.agent.20H2
@@ -15,7 +15,7 @@ RUN $URL = 'https://github.com/StefanScherer/docker-cli-builder/releases/downloa
     \
     Write-Host 'Complete.'
 # download wins
-RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe'; \
+RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.1.0/wins.exe'; \
     \
     Write-Host ('Downloading Wins from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \

--- a/package/windows/bootstrap.ps1
+++ b/package/windows/bootstrap.ps1
@@ -285,6 +285,7 @@ catch
             "$($CATTLE_PREFIX_PATH)etc\kubernetes\bin\kubelet.exe"
             "$($CATTLE_PREFIX_PATH)etc\nginx\nginx.exe"
             "$($CATTLE_PREFIX_PATH)opt\bin\flanneld.exe"
+            "$($CATTLE_PREFIX_PATH)etc\rancher\wins\wins-upgrade.exe"
         )
     }
 } | ConvertTo-Json -Compress -Depth 32 | Out-File -NoNewline -Encoding utf8 -Force -FilePath "$($CATTLE_PREFIX_PATH)etc\rancher\wins\config"

--- a/package/windows/bootstrap.ps1
+++ b/package/windows/bootstrap.ps1
@@ -286,6 +286,7 @@ catch
             "$($CATTLE_PREFIX_PATH)etc\nginx\nginx.exe"
             "$($CATTLE_PREFIX_PATH)opt\bin\flanneld.exe"
             "$($CATTLE_PREFIX_PATH)etc\rancher\wins\wins-upgrade.exe"
+            "$($CATTLE_PREFIX_PATH)etc\windows-exporter\windows-exporter.exe"
         )
         proxyPorts = @(
             9796

--- a/package/windows/bootstrap.ps1
+++ b/package/windows/bootstrap.ps1
@@ -287,6 +287,9 @@ catch
             "$($CATTLE_PREFIX_PATH)opt\bin\flanneld.exe"
             "$($CATTLE_PREFIX_PATH)etc\rancher\wins\wins-upgrade.exe"
         )
+        proxyPorts = @(
+            "9796"
+        )
     }
 } | ConvertTo-Json -Compress -Depth 32 | Out-File -NoNewline -Encoding utf8 -Force -FilePath "$($CATTLE_PREFIX_PATH)etc\rancher\wins\config"
 

--- a/package/windows/bootstrap.ps1
+++ b/package/windows/bootstrap.ps1
@@ -288,7 +288,7 @@ catch
             "$($CATTLE_PREFIX_PATH)etc\rancher\wins\wins-upgrade.exe"
         )
         proxyPorts = @(
-            "9796"
+            9796
         )
     }
 } | ConvertTo-Json -Compress -Depth 32 | Out-File -NoNewline -Encoding utf8 -Force -FilePath "$($CATTLE_PREFIX_PATH)etc\rancher\wins\config"


### PR DESCRIPTION
All the commits on this are cherry-picked backports with annotations to the commits on master. No changes introduced.

Related Issue: https://github.com/rancher/rancher/issues/31499