### PR TITLE
Audit changes for logging user info from auth provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/rancher/lasso v0.0.0-20210408231703-9ddd9378d08d
 	github.com/rancher/lasso/controller-runtime v0.0.0-20210219163000-fcdfcec12969
 	github.com/rancher/machine v0.15.0-rancher25
-	github.com/rancher/norman v0.0.0-20210423002317-8e6ffc77a819
+	github.com/rancher/norman v0.0.0-20210504005327-7b74a9f308a7
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a

--- a/go.sum
+++ b/go.sum
@@ -974,8 +974,9 @@ github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77 h1:k+vzmkZQsH06rZnDr+p
 github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
 github.com/rancher/norman v0.0.0-20200517050325-f53cae161640/go.mod h1:92rz/7QN7DOeLQZlJY/8aFBOmF085igIVguR0wpxLas=
 github.com/rancher/norman v0.0.0-20200820172041-261460ee9088/go.mod h1:W9LfZ96OfjkWSGTy2DUqYPt47Jpzrs7eM0i3AAx6fOI=
-github.com/rancher/norman v0.0.0-20210423002317-8e6ffc77a819 h1:K3pICsdBbzOHoOyWdEjCxd8vApLpk8qwBI5VNCQQsM0=
 github.com/rancher/norman v0.0.0-20210423002317-8e6ffc77a819/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
+github.com/rancher/norman v0.0.0-20210504005327-7b74a9f308a7 h1:zlqr/vmfYVWV083/d5yosV6LLcis7CiByuMqXfLNiHA=
+github.com/rancher/norman v0.0.0-20210504005327-7b74a9f308a7/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
 github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e h1:j6+HqCET/NLPBtew2m5apL7jWw/PStQ7iGwXjgAqdvo=
 github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e/go.mod h1:XbYHTPaXuw8ZY9bylhYKQh/nJxDaTKk3YhAxPl4Qy/k=
 github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a h1:6xqYlVz4uAXBa/AuNAG0bhMusIXVh74dc1bbYOAe+HY=

--- a/pkg/apis/cluster.cattle.io/v3/types.go
+++ b/pkg/apis/cluster.cattle.io/v3/types.go
@@ -14,10 +14,11 @@ type ClusterUserAttribute struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Groups       []string `json:"groups,omitempty"`
-	LastRefresh  string   `json:"lastRefresh,omitempty"`
-	NeedsRefresh bool     `json:"needsRefresh"`
-	Enabled      bool     `json:"enabled"`
+	Groups       []string            `json:"groups,omitempty"`
+	LastRefresh  string              `json:"lastRefresh,omitempty"`
+	NeedsRefresh bool                `json:"needsRefresh"`
+	Enabled      bool                `json:"enabled"`
+	Extra        map[string][]string `json:"extra,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/cluster.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/cluster.cattle.io/v3/zz_generated_deepcopy.go
@@ -95,6 +95,21 @@ func (in *ClusterUserAttribute) DeepCopyInto(out *ClusterUserAttribute) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Extra != nil {
+		in, out := &in.Extra, &out.Extra
+		*out = make(map[string][]string, len(*in))
+		for key, val := range *in {
+			var outVal []string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
+		}
+	}
 	return
 }
 

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/rancher/eks-operator v1.0.6-rc1
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210428191153-f414eab0e4de
 	github.com/rancher/gke-operator v1.0.1
-	github.com/rancher/norman v0.0.0-20210423002317-8e6ffc77a819
+	github.com/rancher/norman v0.0.0-20210504005327-7b74a9f308a7
 	github.com/rancher/rke v1.3.0-rc1.0.20210503155726-c25848db1e86
 	github.com/rancher/wrangler v0.8.1-0.20210429171250-3bef7a4bfeef
 	github.com/sirupsen/logrus v1.7.0

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -664,8 +664,8 @@ github.com/rancher/lasso v0.0.0-20200905045615-7fcb07d6a20b/go.mod h1:OhBBBO1pBw
 github.com/rancher/lasso v0.0.0-20210408231703-9ddd9378d08d h1:vfjPEF6M7Jf1/zK1xF7z2drLfniooKcgDQdoXO5+U7w=
 github.com/rancher/lasso v0.0.0-20210408231703-9ddd9378d08d/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
 github.com/rancher/norman v0.0.0-20200517050325-f53cae161640/go.mod h1:92rz/7QN7DOeLQZlJY/8aFBOmF085igIVguR0wpxLas=
-github.com/rancher/norman v0.0.0-20210423002317-8e6ffc77a819 h1:K3pICsdBbzOHoOyWdEjCxd8vApLpk8qwBI5VNCQQsM0=
-github.com/rancher/norman v0.0.0-20210423002317-8e6ffc77a819/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
+github.com/rancher/norman v0.0.0-20210504005327-7b74a9f308a7 h1:zlqr/vmfYVWV083/d5yosV6LLcis7CiByuMqXfLNiHA=
+github.com/rancher/norman v0.0.0-20210504005327-7b74a9f308a7/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
 github.com/rancher/rke v1.3.0-rc1.0.20210503155726-c25848db1e86 h1:pYGXFJf1ruCs6ztZ1WGmFZfqZaybWDcuGVGKU1bUyXA=
 github.com/rancher/rke v1.3.0-rc1.0.20210503155726-c25848db1e86/go.mod h1:8teMbZiv6i0IwNzsIjmaqbLIDEBZmvFv1j+1P7uUgyY=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=

--- a/pkg/auth/audit/audit.go
+++ b/pkg/auth/audit/audit.go
@@ -58,8 +58,9 @@ type log struct {
 var userKey struct{}
 
 type User struct {
-	Name  string   `json:"name,omitempty"`
-	Group []string `json:"group,omitempty"`
+	Name  string              `json:"name,omitempty"`
+	Group []string            `json:"group,omitempty"`
+	Extra map[string][]string `json:"extra,omitempty"`
 	// RequestUser is the --as user
 	RequestUser string `json:"requestUser,omitempty"`
 	// RequestGroups is the --as-group list
@@ -71,6 +72,7 @@ func getUserInfo(req *http.Request) *User {
 	return &User{
 		Name:  user.GetName(),
 		Group: user.GetGroups(),
+		Extra: user.GetExtra(),
 	}
 }
 

--- a/pkg/auth/providers/activedirectory/activedirectory_provider.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_provider.go
@@ -228,3 +228,10 @@ func (p *adProvider) getDNAndScopeFromPrincipalID(principalID string) (string, s
 	externalID := strings.TrimPrefix(parts[1], "//")
 	return externalID, scope, nil
 }
+
+func (p *adProvider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+	extras := make(map[string][]string)
+	extras["principalid"] = []string{token.UserPrincipal.Name}
+	extras["username"] = []string{token.UserPrincipal.LoginName}
+	return extras
+}

--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -587,3 +587,10 @@ func UpdateGroupCacheSize(size string) {
 	}
 	groupCache.Resize(i)
 }
+
+func (ap *azureProvider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+	extras := make(map[string][]string)
+	extras["principalid"] = []string{token.UserPrincipal.Name}
+	extras["username"] = []string{token.UserPrincipal.LoginName}
+	return extras
+}

--- a/pkg/auth/providers/common/provider.go
+++ b/pkg/auth/providers/common/provider.go
@@ -16,4 +16,5 @@ type AuthProvider interface {
 	TransformToAuthProvider(authConfig map[string]interface{}) (map[string]interface{}, error)
 	RefetchGroupPrincipals(principalID string, secret string) ([]v3.Principal, error)
 	CanAccessWithGroupProviders(userPrincipalID string, groups []v3.Principal) (bool, error)
+	GetUserExtraAttributes(token *v3.Token) map[string][]string
 }

--- a/pkg/auth/providers/github/github_provider.go
+++ b/pkg/auth/providers/github/github_provider.go
@@ -408,3 +408,10 @@ func (g *ghProvider) CanAccessWithGroupProviders(userPrincipalID string, groupPr
 	}
 	return allowed, nil
 }
+
+func (g *ghProvider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+	extras := make(map[string][]string)
+	extras["principalid"] = []string{token.UserPrincipal.Name}
+	extras["username"] = []string{token.UserPrincipal.LoginName}
+	return extras
+}

--- a/pkg/auth/providers/googleoauth/goauth_provider.go
+++ b/pkg/auth/providers/googleoauth/goauth_provider.go
@@ -427,3 +427,10 @@ func (g *googleOauthProvider) getDirectoryService(ctx context.Context, userEmail
 	}
 	return srv, nil
 }
+
+func (g *googleOauthProvider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+	extras := make(map[string][]string)
+	extras["principalid"] = []string{token.UserPrincipal.Name}
+	extras["username"] = []string{token.UserPrincipal.LoginName}
+	return extras
+}

--- a/pkg/auth/providers/ldap/ldap_provider.go
+++ b/pkg/auth/providers/ldap/ldap_provider.go
@@ -369,3 +369,10 @@ func (p *ldapProvider) samlSearchGetPrincipal(
 		config.GroupObjectClass,
 		config.GroupNameAttribute)
 }
+
+func (p *ldapProvider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+	extras := make(map[string][]string)
+	extras["principalid"] = []string{token.UserPrincipal.Name}
+	extras["username"] = []string{token.UserPrincipal.LoginName}
+	return extras
+}

--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -445,3 +445,10 @@ func (l *Provider) CanAccessWithGroupProviders(userPrincipalID string, groupPrin
 
 	return false, nil
 }
+
+func (l *Provider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+	extras := make(map[string][]string)
+	extras["principalid"] = []string{token.UserPrincipal.Name}
+	extras["username"] = []string{token.UserPrincipal.LoginName}
+	return extras
+}

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -395,3 +395,10 @@ func (s *Provider) hasLdapGroupSearch() bool {
 	}
 	return false
 }
+
+func (s *Provider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+	extras := make(map[string][]string)
+	extras["principalid"] = []string{token.UserPrincipal.Name}
+	extras["username"] = []string{token.UserPrincipal.LoginName}
+	return extras
+}

--- a/pkg/auth/requests/chained.go
+++ b/pkg/auth/requests/chained.go
@@ -16,14 +16,16 @@ type chainedAuth struct {
 	auths []Authenticator
 }
 
-func (c *chainedAuth) Authenticate(req *http.Request) (authed bool, user string, groups []string, err error) {
+func (c *chainedAuth) Authenticate(req *http.Request) (*AuthenticatorResponse, error) {
 	for _, auth := range c.auths {
-		authed, user, groups, err := auth.Authenticate(req)
-		if err != nil || authed {
-			return authed, user, groups, err
+		authResponse, err := auth.Authenticate(req)
+		if err != nil || authResponse.IsAuthed {
+			return authResponse, err
 		}
 	}
-	return false, "", nil, nil
+	return &AuthenticatorResponse{
+		Extras: make(map[string][]string),
+	}, nil
 }
 
 func (c *chainedAuth) TokenFromRequest(req *http.Request) (*v3.Token, error) {

--- a/pkg/auth/requests/impersonate.go
+++ b/pkg/auth/requests/impersonate.go
@@ -81,10 +81,13 @@ func (h *impersonatingAuth) Authenticate(req *http.Request) (k8sUser.Info, bool,
 		groups = append(groups, k8sUser.AllAuthenticated)
 	}
 
+	extra := userInfo.GetExtra()
+
 	return &k8sUser.DefaultInfo{
 		Name:   user,
 		UID:    user,
 		Groups: groups,
+		Extra:  extra,
 	}, true, nil
 }
 

--- a/pkg/client/generated/cluster/v3/zz_generated_cluster_user_attribute.go
+++ b/pkg/client/generated/cluster/v3/zz_generated_cluster_user_attribute.go
@@ -6,6 +6,7 @@ const (
 	ClusterUserAttributeFieldCreated         = "created"
 	ClusterUserAttributeFieldCreatorID       = "creatorId"
 	ClusterUserAttributeFieldEnabled         = "enabled"
+	ClusterUserAttributeFieldExtra           = "extra"
 	ClusterUserAttributeFieldGroups          = "groups"
 	ClusterUserAttributeFieldLabels          = "labels"
 	ClusterUserAttributeFieldLastRefresh     = "lastRefresh"
@@ -18,17 +19,18 @@ const (
 )
 
 type ClusterUserAttribute struct {
-	Annotations     map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Created         string            `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID       string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	Enabled         bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Groups          []string          `json:"groups,omitempty" yaml:"groups,omitempty"`
-	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	LastRefresh     string            `json:"lastRefresh,omitempty" yaml:"lastRefresh,omitempty"`
-	Name            string            `json:"name,omitempty" yaml:"name,omitempty"`
-	NamespaceId     string            `json:"namespaceId,omitempty" yaml:"namespaceId,omitempty"`
-	NeedsRefresh    bool              `json:"needsRefresh,omitempty" yaml:"needsRefresh,omitempty"`
-	OwnerReferences []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	Removed         string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	UUID            string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Annotations     map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Created         string              `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID       string              `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Enabled         bool                `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Extra           map[string][]string `json:"extra,omitempty" yaml:"extra,omitempty"`
+	Groups          []string            `json:"groups,omitempty" yaml:"groups,omitempty"`
+	Labels          map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
+	LastRefresh     string              `json:"lastRefresh,omitempty" yaml:"lastRefresh,omitempty"`
+	Name            string              `json:"name,omitempty" yaml:"name,omitempty"`
+	NamespaceId     string              `json:"namespaceId,omitempty" yaml:"namespaceId,omitempty"`
+	NeedsRefresh    bool                `json:"needsRefresh,omitempty" yaml:"needsRefresh,omitempty"`
+	OwnerReferences []OwnerReference    `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Removed         string              `json:"removed,omitempty" yaml:"removed,omitempty"`
+	UUID            string              `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }


### PR DESCRIPTION
Adding in "Impersonate-Extra-" headers to log user's principalId and username from the external IDP. 
This needs a fix in norman proxy_store as well. So includes a vendor update for new norman change https://github.com/rancher/norman/pull/396

https://github.com/rancher/rancher/issues/31166

