### PR TITLE
Update OCI node driver to v1.0.2.

### DIFF
--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -107,8 +107,8 @@ func addMachineDrivers(management *config.ManagementContext) error {
 		"/assets/rancher-ui-driver-linode/component.js", "b31b6a504c59ee758d2dda83029fe4a85b3f5601e22dfa58700a5e6c8f450dc7", []string{"api.linode.com"}, linodeBuiltin, linodeBuiltin, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(OCIDriver, "https://github.com/rancher-plugins/rancher-machine-driver-oci/releases/download/v1.0.1/docker-machine-driver-oci-linux",
-		"", "6867f59e9f33bdbce34b5bf9476c48d2edc2ef4bca8a2ef82ccaa1de57af811c", []string{"*.oraclecloud.com"}, false, false, management); err != nil {
+	if err := addMachineDriver(OCIDriver, "https://github.com/rancher-plugins/rancher-machine-driver-oci/releases/download/v1.0.2/docker-machine-driver-oci-linux",
+		"", "972a163b29149db5b3b78524353eaa703b4dab1243d533af4713869ed0f7fdf8", []string{"*.oraclecloud.com"}, false, false, management); err != nil {
 		return err
 	}
 	if err := addMachineDriver(OpenstackDriver, "local://", "", "", nil, false, true, management); err != nil {


### PR DESCRIPTION
This MR updates [OCI Node Driver](https://github.com/rancher-plugins/rancher-machine-driver-oci) to version `v1.0.2`, which defaults its OS to OL7.9 and had been tested successfully against OS OL8.2.

Related Issues:
rancher/rancher#23045
rancher/rancher#29253