### PR TITLE
Configurable topologyKey

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
                 operator: In
                 values:
                 - {{ template "rancher.fullname" . }}
-            topologyKey: kubernetes.io/hostname
+            topologyKey: {{ .Values.topologyKey | default "kubernetes.io/hostname" }}
 {{- else }}
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
@@ -52,7 +52,7 @@ spec:
                   operator: In
                   values:
                   - {{ template "rancher.fullname" . }}
-              topologyKey: kubernetes.io/hostname
+              topologyKey: {{ .Values.topologyKey | default "kubernetes.io/hostname" }}
 {{- end }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,6 +4,7 @@
 additionalTrustedCAs: false
 
 antiAffinity: preferred
+topologyKey: kubernetes.io/hostname
 
 # Audit Logs https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/
 # The audit log is piped to the console of the rancher-audit-log container in the rancher pod.


### PR DESCRIPTION
This PR allows a configurable topologyKey. Our k8s nodes are located in different racks, each rack contains multiple nodes. We wanted to make sure only one instance of rancher runs within a rack. 