### PR TITLE
[release/v2.5] PNI - only delete Rancher created NetworkPolicy resources

### DIFF
--- a/pkg/controllers/managementuser/networkpolicy/clusterHandler.go
+++ b/pkg/controllers/managementuser/networkpolicy/clusterHandler.go
@@ -3,9 +3,8 @@ package networkpolicy
 import (
 	"fmt"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/rancher/norman/types/convert"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/nodesyncer"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -129,8 +128,14 @@ func (ch *clusterHandler) createNetworkPolicies(cluster *v3.Cluster) error {
 	//skipping nssyncer, projectSyncer + nodehandler would result into handling nssyncer as well
 }
 
+const creatorLabel = "cattle.io/creator"
+
+// deleteNetworkPolicies removes Rancher created NetworkPolicy resources from the downstream cluster and
+// removes ProjectNetworkPolicy resources from the management cluster
 func (ch *clusterHandler) deleteNetworkPolicies(cluster *v3.Cluster) error {
-	nps, err := ch.npmgr.npLister.List("", labels.NewSelector())
+	// consider nps for deletion if they were created by Rancher, i.e. they have a label: "cattle.io/creator": "norman"
+	set := labels.Set(map[string]string{creatorLabel: "norman"})
+	nps, err := ch.npmgr.npLister.List("", set.AsSelector())
 	if err != nil {
 		return fmt.Errorf("npLister: %v", err)
 	}


### PR DESCRIPTION
When disabling PNI for a cluster, we should only delete NetworkPolicy resources in the downstream cluster that Rancher created. This change implements that behavior so that we don't also delete user created NetworkPolicy resources when disabling PNI.

I opted for a label based approach here as opposed to using NetworkPolicy names or some other approach.

I've tested this with user network policies created via kubectl and via Cluster Explorer UI. In both cases any user created NetworkPolicy resources are not deleted when PNI is disabled and the Rancher created policies are deleted, as expected.

Issue:
- https://github.com/rancher/rancher/issues/30135