### PR TITLE
Automation python pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+files: ^tests/validation/
+repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v3.4.0
+      hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: detect-aws-credentials
+      - id: detect-private-key
+      - id: end-of-file-fixer
+    - repo: https://github.com/ambv/black
+      rev: 20.8b1
+      hooks:
+      - id: black
+        args: [--config, tests/validation/.black]
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 3.8.4
+      hooks:
+      - id: flake8
+        alias: flake8-validation
+        args: [--config, tests/validation/.flake8]
+    - repo: https://github.com/pre-commit/mirrors-autopep8
+      rev: v1.5.4
+      hooks:
+      - id: autopep8
+        args: [--global-config, tests/validation/.black, --ignore-local-config]

--- a/tests/validation/.black
+++ b/tests/validation/.black
@@ -1,0 +1,18 @@
+[tool.black]
+line-length = 88
+include = '\.pyi?$'
+exclude = '''
+/(
+ \.git
+ | \.goi?$
+ | \.tox
+ | \.venv
+ | scripts
+ | package
+ | chart
+ | dist
+)/
+'''
+[tool.autopep8]
+max_line_length = 88
+ignore = "E203,E266,E501,W503,F403,E401,F401,F405,F811"  # or ["E501", "W6"]

--- a/tests/validation/.flake8
+++ b/tests/validation/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+ignore = E203, E266, E501, W503, F403, E401, F401, F405, F811, F521
+max-line-length = 88
+select = B,C,E,F,W,T4,B9
+exclude =
+    .git,
+    tox,
+    package,
+    chart,
+    cleanup,
+    scripts
+max-complexity = 20

--- a/tests/validation/requirements_v3api.txt
+++ b/tests/validation/requirements_v3api.txt
@@ -11,7 +11,7 @@ paramiko==2.6.0
 PyJWT==1.6.4
 pytest-repeat==0.7.0
 pytest-xdist==1.23.0
-pytest==3.8.1
+pytest==3.10.1
 pytest-html==1.20.0
 pytest-ordering==0.6
 python-digitalocean==1.13.2
@@ -20,3 +20,4 @@ PyYAML==5.2
 requests==2.22.0
 rsa==4.0
 websocket-client==0.57.0
+pre-commit==2.11.1


### PR DESCRIPTION
https://github.com/rancher/qa-tasks/issues/34

- Added the Python pre-commit framework configuration file for files only under the `tests/validation` path.
- configuration files for `autopep8`, `flake8` and `black` under the `tests/validation`

Basic usage:
1. Clone the Rancher repository
2. Go to the `tests/validation` folder
3. `pip install -r requirements_v3api.txt` (or use your favorite environment manager)
4. `pre-commit install --install-hooks`
5. `pre-commit autoupdate` 

After this the pre-commit framework will detect changes in python files under `tests/validation` when a `git commit` is detected in the local repository.

```
git commit -m "test"
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check for added large files..............................................Passed
Check for merge conflicts................................................Passed
Detect AWS Credentials...................................................Passed
Detect Private Key.......................................................Passed
Fix End of Files.........................................................Passed
black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted tests/validation/tests/v3_api/test_sa.py
All done! ✨ 🍰 ✨
1 file reformatted.

flake8...................................................................Passed
autopep8.................................................................Passed
```

A change was detected by `black` and applied to the file in the commit to fix it. Let's try  `git add` and `git commit` again with the applied changes to run the checks again.

```
 git commit -m "test2"
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check for added large files..............................................Passed
Check for merge conflicts................................................Passed
Detect AWS Credentials...................................................Passed
Detect Private Key.......................................................Passed
Fix End of Files.........................................................Passed
black....................................................................Passed
flake8...................................................................Passed
autopep8.................................................................Passed
[precommit-test 171771247] test2
 1 file changed, 1 deletion(-)
```


These hooks might prove challenging when applied to large files like `common.py` for the first time as lots of formatting warnings/errors could be detected and fixes applied automatically. Over time this will allow us to focus on the test logic and not much on formatting and coding style.


For the `pytest` version bump I tested that it kept working by running an HA test locally.