### PR TITLE
Adding changes for supporting Windows cluster in Support Matrix checks

### DIFF
--- a/tests/validation/lib/aws.py
+++ b/tests/validation/lib/aws.py
@@ -30,6 +30,10 @@ AWS_DEFAULT_AMI = "ami-0d5d9d301c853a04a"
 AWS_DEFAULT_USER = "ubuntu"
 AWS_AMI = os.environ.get("AWS_AMI", AWS_DEFAULT_AMI)
 AWS_USER = os.environ.get("AWS_USER", AWS_DEFAULT_USER)
+WINDOWS_AWS_AMI = os.environ.get(
+    "WINDOWS_AWS_AMI", "ami-0d6f7eaedf946c299" #Windows 2019 AMI
+    ) 
+WINDOWS_AWS_USER = "Administrator"
 AWS_VOLUME_SIZE = os.environ.get("AWS_VOLUME_SIZE", "50")
 AWS_INSTANCE_TYPE = os.environ.get("AWS_INSTANCE_TYPE", 't3a.medium')
 

--- a/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_support_matrix
+++ b/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_support_matrix
@@ -30,6 +30,7 @@ node {
   if ("${env.branch}" != "null" && "${env.branch}" != "") {
     branch = "${env.branch}"
   }
+  def WINDOWS_PYTEST_OPTIONS = "-k \"test_ingress or test_rbac or test_sa or test_secrets or test_service_discovery or test_workload\""
 
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
     withFolderProperties {
@@ -184,6 +185,15 @@ node {
                       string(name: 'RANCHER_VALIDATE_RESOURCES_PREFIX', value: "${RANCHER_VALIDATE_RESOURCES_PREFIX}"),
                       string(name: 'RANCHER_CREATE_RESOURCES_PREFIX', value: "${RANCHER_CREATE_RESOURCES_PREFIX}"),
                     ]
+                    if (cluster_arr[i].contains("windows")) {
+                      RANCHER_TEST_OS = "windows"
+                      params.add(string(name: 'RANCHER_TEST_OS', value: "${RANCHER_TEST_OS}"))
+                      params.add(string(name: 'RANCHER_TEST_IMAGE', value: "${RANCHER_TEST_IMAGE}"))
+                      params.add(string(name: 'RANCHER_TEST_IMAGE_OS_BASE', value: "${RANCHER_TEST_IMAGE_OS_BASE}"))
+                      params.add(string(name: 'RANCHER_TEST_IMAGE_NGINX', value: "${RANCHER_TEST_IMAGE_NGINX}"))
+                      params.add(string(name: 'PYTEST_OPTIONS', value: "${WINDOWS_PYTEST_OPTIONS}"))
+
+                    }
                     echo "Params are: ${params}"
                     jobs["test-${i}"] = { build job: 'rancher-v3_needs_cluster', parameters: params }
                   }

--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -215,6 +215,10 @@ def is_windows(os_type=TEST_OS):
     return os_type == "windows"
 
 
+def random_clustername(name="test"):
+    return name + "-" + str(random_int(10000, 99999))
+
+
 def get_cluster_client_for_token_v1(cluster_id, token):
     url = CATTLE_TEST_URL + "/k8s/clusters/" + cluster_id + "/v1/schemas"
     return rancher.Client(url=url, token=token, verify=False)

--- a/tests/validation/tests/v3_api/test_custom_host_reg.py
+++ b/tests/validation/tests/v3_api/test_custom_host_reg.py
@@ -2,6 +2,7 @@ from .test_auth import enable_ad, load_setup_data, enable_openldap, \
     OPENLDAP_AUTH_USER_PASSWORD, enable_freeipa, FREEIPA_AUTH_USER_PASSWORD
 from .common import *  # NOQA
 import ast
+from lib.aws import WINDOWS_AWS_AMI, WINDOWS_AWS_USER
 
 AGENT_REG_CMD = os.environ.get('RANCHER_AGENT_REG_CMD', "")
 HOST_COUNT = int(os.environ.get('RANCHER_HOST_COUNT', 1))
@@ -23,8 +24,13 @@ K8S_VERSION = os.environ.get('RANCHER_K8S_VERSION', "")
 
 
 def test_add_custom_host():
-    aws_nodes = AmazonWebServices().create_multiple_nodes(
-        HOST_COUNT, random_test_name("testsa" + HOST_NAME))
+    if TEST_OS == "windows":
+        aws_nodes = AmazonWebServices().create_multiple_nodes(
+            HOST_COUNT, random_test_name("testsa" + HOST_NAME),
+            ami=WINDOWS_AWS_AMI,ssh_user=WINDOWS_AWS_USER)
+    else:
+        aws_nodes = AmazonWebServices().create_multiple_nodes(
+            HOST_COUNT, random_test_name("testsa" + HOST_NAME))
     if AGENT_REG_CMD != "":
         for aws_node in aws_nodes:
             additional_options = " --address " + aws_node.public_ip_address + \

--- a/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
+++ b/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
@@ -1145,6 +1145,7 @@ def create_custom_host_from_nodes(nodes, node_roles,
         else evaluate_clustername()
 
     if windows:
+        cluster_name=random_clustername("windows")
         if windows_flannel_backend == "host-gw":
             config = rke_config_windows_host_gw_aws_provider
         else:


### PR DESCRIPTION
Current Support Matrix job will be used to bring up Windows VXLAN and HostGW clusters and run validation tests on them. 