### PR TITLE
Update log entry from info to error

### DIFF
--- a/pkg/controllers/managementuserlegacy/alert/watcher/syscomponent.go
+++ b/pkg/controllers/managementuserlegacy/alert/watcher/syscomponent.go
@@ -42,7 +42,7 @@ func (w *SysComponentWatcher) watch(ctx context.Context, interval time.Duration)
 	for range ticker.Context(ctx, interval) {
 		err := w.watchRule()
 		if err != nil {
-			logrus.Infof("Failed to watch system component, error: %v", err)
+			logrus.Errorf("Failed to watch system component, error: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
Update log entry from info to error for the component status message for better log file parsing 

Present logging :
```
[INFO] Failed to watch system component, error: Get "https://192.168.64.1:443/api/v1/componentstatuses": net/http: TLS handshake timeout
```
This supposed to be 
```
[ERROR] Failed to watch system component, error: Get "https://192.168.64.1:443/api/v1/componentstatuses": net/http: TLS handshake timeout
```