### PR TITLE
Add priorityClassName to avoid eviction

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         app: {{ template "rancher.fullname" . }}
         release: {{ .Release.Name }}
     spec:
+      priorityClassName: {{ .Values.priorityClassName }}
       serviceAccountName: {{ template "rancher.fullname" . }}
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -105,6 +105,9 @@ rancherImage: rancher/rancher
 # of available nodes in the cluster
 replicas: 3
 
+# Set priorityClassName to avoid eviction
+priorityClassName: system-node-critical
+
 # Set pod resource requests/limits for Rancher.
 resources: {}
 
@@ -121,7 +124,7 @@ systemDefaultRegistry: ""
 useBundledSystemChart: false
 
 # Certmanager version compatibility
-certmanager: 
+certmanager:
   version: ""
 
 # Rancher custom logos persistence
@@ -134,7 +137,7 @@ customLogos:
   volumeKind: persistentVolumeClaim
   ## Use an existing volume. Custom logos should be copied to the volume by the user
   # volumeName: custom-logos
-  ## Just for volumeKind: persistentVolumeClaim 
+  ## Just for volumeKind: persistentVolumeClaim
   ## To disables dynamic provisioning, set storageClass: "" or storageClass: "-"
   # storageClass: "-"
   accessMode: ReadWriteOnce


### PR DESCRIPTION
This PR adds priorityClassName option to rancher helm chart.
By default it will be set to `system-node-critical`. 
This is needed to avoid eviction.