### PR TITLE
[master] Fix Helm changing app answers types

### DIFF
--- a/pkg/api/norman/customization/cluster/actions_monitoring.go
+++ b/pkg/api/norman/customization/cluster/actions_monitoring.go
@@ -30,17 +30,22 @@ func (a ActionHandler) viewMonitoring(actionName string, action *types.Action, a
 	}
 
 	// need to support `map[string]string` as entry value type in norman Builder.convertMap
-	answers, version := monitoring.GetOverwroteAppAnswersAndVersion(cluster.Annotations)
-	encodeAnswers, err := convert.EncodeToMap(answers)
+	monitoringInput := monitoring.GetMonitoringInput(cluster.Annotations)
+	encodedAnswers, err := convert.EncodeToMap(monitoringInput.Answers)
+	if err != nil {
+		return httperror.WrapAPIError(err, httperror.ServerError, "failed to parse response")
+	}
+	encodedAnswersSetString, err := convert.EncodeToMap(monitoringInput.AnswersSetString)
 	if err != nil {
 		return httperror.WrapAPIError(err, httperror.ServerError, "failed to parse response")
 	}
 	resp := map[string]interface{}{
-		"answers": encodeAnswers,
-		"type":    "monitoringOutput",
+		"answers":          encodedAnswers,
+		"answersSetString": encodedAnswersSetString,
+		"type":             "monitoringOutput",
 	}
-	if version != "" {
-		resp["version"] = version
+	if monitoringInput.Version != "" {
+		resp["version"] = monitoringInput.Version
 	}
 
 	apiContext.WriteResponse(http.StatusOK, resp)

--- a/pkg/api/norman/customization/multiclusterapp/multi_cluster_app.go
+++ b/pkg/api/norman/customization/multiclusterapp/multi_cluster_app.go
@@ -258,9 +258,10 @@ func (w Wrapper) modifyProjects(request *types.APIContext, actionName string) ([
 	}
 	for _, a := range updateMultiClusterAppTargetsInput.Answers {
 		inputAnswers = append(inputAnswers, v32.Answer{
-			ProjectName: a.ProjectID,
-			ClusterName: a.ClusterID,
-			Values:      a.Values,
+			ProjectName:     a.ProjectID,
+			ClusterName:     a.ClusterID,
+			Values:          a.Values,
+			ValuesSetString: a.ValuesSetString,
 		})
 	}
 	// check if the input includes answers, and if they are only for the input projects

--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -312,13 +312,15 @@ type IngressCapabilities struct {
 }
 
 type MonitoringInput struct {
-	Version string            `json:"version,omitempty"`
-	Answers map[string]string `json:"answers,omitempty"`
+	Version          string            `json:"version,omitempty"`
+	Answers          map[string]string `json:"answers,omitempty"`
+	AnswersSetString map[string]string `json:"answersSetString,omitempty"`
 }
 
 type MonitoringOutput struct {
-	Version string            `json:"version,omitempty"`
-	Answers map[string]string `json:"answers,omitempty"`
+	Version          string            `json:"version,omitempty"`
+	Answers          map[string]string `json:"answers,omitempty"`
+	AnswersSetString map[string]string `json:"answersSetString,omitempty"`
 }
 
 type RestoreFromEtcdBackupInput struct {

--- a/pkg/apis/management.cattle.io/v3/multi_cluster_app.go
+++ b/pkg/apis/management.cattle.io/v3/multi_cluster_app.go
@@ -63,9 +63,10 @@ func (t *Target) ObjClusterName() string {
 }
 
 type Answer struct {
-	ProjectName string            `json:"projectName,omitempty" norman:"type=reference[project]"`
-	ClusterName string            `json:"clusterName,omitempty" norman:"type=reference[cluster]"`
-	Values      map[string]string `json:"values,omitempty" norman:"required"`
+	ProjectName     string            `json:"projectName,omitempty" norman:"type=reference[project]"`
+	ClusterName     string            `json:"clusterName,omitempty" norman:"type=reference[cluster]"`
+	Values          map[string]string `json:"values,omitempty" norman:"required"`
+	ValuesSetString map[string]string `json:"valuesSetString,omitempty"`
 }
 
 func (a *Answer) ObjClusterName() string {

--- a/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -427,6 +427,13 @@ func (in *Answer) DeepCopyInto(out *Answer) {
 			(*out)[key] = val
 		}
 	}
+	if in.ValuesSetString != nil {
+		in, out := &in.ValuesSetString, &out.ValuesSetString
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -5689,6 +5696,13 @@ func (in *MonitoringInput) DeepCopyInto(out *MonitoringInput) {
 			(*out)[key] = val
 		}
 	}
+	if in.AnswersSetString != nil {
+		in, out := &in.AnswersSetString, &out.AnswersSetString
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -5707,6 +5721,13 @@ func (in *MonitoringOutput) DeepCopyInto(out *MonitoringOutput) {
 	*out = *in
 	if in.Answers != nil {
 		in, out := &in.Answers, &out.Answers
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.AnswersSetString != nil {
+		in, out := &in.AnswersSetString, &out.AnswersSetString
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/pkg/apis/project.cattle.io/v3/app_types.go
+++ b/pkg/apis/project.cattle.io/v3/app_types.go
@@ -32,6 +32,7 @@ type AppSpec struct {
 	ExternalID          string            `json:"externalId,omitempty"`
 	Files               map[string]string `json:"files,omitempty"`
 	Answers             map[string]string `json:"answers,omitempty"`
+	AnswersSetString    map[string]string `json:"answersSetString,omitempty"`
 	Wait                bool              `json:"wait,omitempty"`
 	Timeout             int               `json:"timeout,omitempty" norman:"min=1,default=300"`
 	AppRevisionName     string            `json:"appRevisionName,omitempty" norman:"type=reference[/v3/project/schemas/apprevision]"`
@@ -103,12 +104,13 @@ func (a *AppRevisionSpec) ObjClusterName() string {
 }
 
 type AppRevisionStatus struct {
-	ProjectName string            `json:"projectName,omitempty" norman:"type=reference[/v3/schemas/project]"`
-	ExternalID  string            `json:"externalId"`
-	Answers     map[string]string `json:"answers"`
-	Digest      string            `json:"digest"`
-	ValuesYaml  string            `json:"valuesYaml,omitempty"`
-	Files       map[string]string `json:"files,omitempty"`
+	ProjectName      string            `json:"projectName,omitempty" norman:"type=reference[/v3/schemas/project]"`
+	ExternalID       string            `json:"externalId"`
+	Answers          map[string]string `json:"answers"`
+	AnswersSetString map[string]string `json:"answersSetString"`
+	Digest           string            `json:"digest"`
+	ValuesYaml       string            `json:"valuesYaml,omitempty"`
+	Files            map[string]string `json:"files,omitempty"`
 }
 
 func (a *AppRevisionStatus) ObjClusterName() string {
@@ -119,11 +121,12 @@ func (a *AppRevisionStatus) ObjClusterName() string {
 }
 
 type AppUpgradeConfig struct {
-	ExternalID   string            `json:"externalId,omitempty"`
-	Answers      map[string]string `json:"answers,omitempty"`
-	ForceUpgrade bool              `json:"forceUpgrade,omitempty"`
-	Files        map[string]string `json:"files,omitempty"`
-	ValuesYaml   string            `json:"valuesYaml,omitempty"`
+	ExternalID       string            `json:"externalId,omitempty"`
+	Answers          map[string]string `json:"answers,omitempty"`
+	AnswersSetString map[string]string `json:"answersSetString,omitempty"`
+	ForceUpgrade     bool              `json:"forceUpgrade,omitempty"`
+	Files            map[string]string `json:"files,omitempty"`
+	ValuesYaml       string            `json:"valuesYaml,omitempty"`
 }
 
 type RollbackRevision struct {

--- a/pkg/apis/project.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/project.cattle.io/v3/zz_generated_deepcopy.go
@@ -190,6 +190,13 @@ func (in *AppRevisionStatus) DeepCopyInto(out *AppRevisionStatus) {
 			(*out)[key] = val
 		}
 	}
+	if in.AnswersSetString != nil {
+		in, out := &in.AnswersSetString, &out.AnswersSetString
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Files != nil {
 		in, out := &in.Files, &out.Files
 		*out = make(map[string]string, len(*in))
@@ -222,6 +229,13 @@ func (in *AppSpec) DeepCopyInto(out *AppSpec) {
 	}
 	if in.Answers != nil {
 		in, out := &in.Answers, &out.Answers
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.AnswersSetString != nil {
+		in, out := &in.AnswersSetString, &out.AnswersSetString
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
@@ -273,6 +287,13 @@ func (in *AppUpgradeConfig) DeepCopyInto(out *AppUpgradeConfig) {
 	*out = *in
 	if in.Answers != nil {
 		in, out := &in.Answers, &out.Answers
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.AnswersSetString != nil {
+		in, out := &in.AnswersSetString, &out.AnswersSetString
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/pkg/app/utils.go
+++ b/pkg/app/utils.go
@@ -112,6 +112,7 @@ func DeployApp(mgmtAppClient projv3.AppInterface, projectID string, createOrUpda
 	} else {
 		app = app.DeepCopy()
 		app.Spec.Answers = createOrUpdateApp.Spec.Answers
+		app.Spec.AnswersSetString = createOrUpdateApp.Spec.AnswersSetString
 
 		// clean up status
 		if forceRedeploy {

--- a/pkg/client/generated/management/v3/zz_generated_answer.go
+++ b/pkg/client/generated/management/v3/zz_generated_answer.go
@@ -1,14 +1,16 @@
 package client
 
 const (
-	AnswerType           = "answer"
-	AnswerFieldClusterID = "clusterId"
-	AnswerFieldProjectID = "projectId"
-	AnswerFieldValues    = "values"
+	AnswerType                 = "answer"
+	AnswerFieldClusterID       = "clusterId"
+	AnswerFieldProjectID       = "projectId"
+	AnswerFieldValues          = "values"
+	AnswerFieldValuesSetString = "valuesSetString"
 )
 
 type Answer struct {
-	ClusterID string            `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
-	ProjectID string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
-	Values    map[string]string `json:"values,omitempty" yaml:"values,omitempty"`
+	ClusterID       string            `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
+	ProjectID       string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
+	Values          map[string]string `json:"values,omitempty" yaml:"values,omitempty"`
+	ValuesSetString map[string]string `json:"valuesSetString,omitempty" yaml:"valuesSetString,omitempty"`
 }

--- a/pkg/client/generated/management/v3/zz_generated_bastion_host.go
+++ b/pkg/client/generated/management/v3/zz_generated_bastion_host.go
@@ -1,24 +1,26 @@
 package client
 
 const (
-	BastionHostType              = "bastionHost"
-	BastionHostFieldAddress      = "address"
-	BastionHostFieldPort         = "port"
-	BastionHostFieldSSHAgentAuth = "sshAgentAuth"
-	BastionHostFieldSSHCert      = "sshCert"
-	BastionHostFieldSSHCertPath  = "sshCertPath"
-	BastionHostFieldSSHKey       = "sshKey"
-	BastionHostFieldSSHKeyPath   = "sshKeyPath"
-	BastionHostFieldUser         = "user"
+	BastionHostType                    = "bastionHost"
+	BastionHostFieldAddress            = "address"
+	BastionHostFieldIgnoreProxyEnvVars = "ignoreProxyEnvVars"
+	BastionHostFieldPort               = "port"
+	BastionHostFieldSSHAgentAuth       = "sshAgentAuth"
+	BastionHostFieldSSHCert            = "sshCert"
+	BastionHostFieldSSHCertPath        = "sshCertPath"
+	BastionHostFieldSSHKey             = "sshKey"
+	BastionHostFieldSSHKeyPath         = "sshKeyPath"
+	BastionHostFieldUser               = "user"
 )
 
 type BastionHost struct {
-	Address      string `json:"address,omitempty" yaml:"address,omitempty"`
-	Port         string `json:"port,omitempty" yaml:"port,omitempty"`
-	SSHAgentAuth bool   `json:"sshAgentAuth,omitempty" yaml:"sshAgentAuth,omitempty"`
-	SSHCert      string `json:"sshCert,omitempty" yaml:"sshCert,omitempty"`
-	SSHCertPath  string `json:"sshCertPath,omitempty" yaml:"sshCertPath,omitempty"`
-	SSHKey       string `json:"sshKey,omitempty" yaml:"sshKey,omitempty"`
-	SSHKeyPath   string `json:"sshKeyPath,omitempty" yaml:"sshKeyPath,omitempty"`
-	User         string `json:"user,omitempty" yaml:"user,omitempty"`
+	Address            string `json:"address,omitempty" yaml:"address,omitempty"`
+	IgnoreProxyEnvVars bool   `json:"ignoreProxyEnvVars,omitempty" yaml:"ignoreProxyEnvVars,omitempty"`
+	Port               string `json:"port,omitempty" yaml:"port,omitempty"`
+	SSHAgentAuth       bool   `json:"sshAgentAuth,omitempty" yaml:"sshAgentAuth,omitempty"`
+	SSHCert            string `json:"sshCert,omitempty" yaml:"sshCert,omitempty"`
+	SSHCertPath        string `json:"sshCertPath,omitempty" yaml:"sshCertPath,omitempty"`
+	SSHKey             string `json:"sshKey,omitempty" yaml:"sshKey,omitempty"`
+	SSHKeyPath         string `json:"sshKeyPath,omitempty" yaml:"sshKeyPath,omitempty"`
+	User               string `json:"user,omitempty" yaml:"user,omitempty"`
 }

--- a/pkg/client/generated/management/v3/zz_generated_monitoring_input.go
+++ b/pkg/client/generated/management/v3/zz_generated_monitoring_input.go
@@ -1,12 +1,14 @@
 package client
 
 const (
-	MonitoringInputType         = "monitoringInput"
-	MonitoringInputFieldAnswers = "answers"
-	MonitoringInputFieldVersion = "version"
+	MonitoringInputType                  = "monitoringInput"
+	MonitoringInputFieldAnswers          = "answers"
+	MonitoringInputFieldAnswersSetString = "answersSetString"
+	MonitoringInputFieldVersion          = "version"
 )
 
 type MonitoringInput struct {
-	Answers map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
-	Version string            `json:"version,omitempty" yaml:"version,omitempty"`
+	Answers          map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersSetString map[string]string `json:"answersSetString,omitempty" yaml:"answersSetString,omitempty"`
+	Version          string            `json:"version,omitempty" yaml:"version,omitempty"`
 }

--- a/pkg/client/generated/management/v3/zz_generated_monitoring_output.go
+++ b/pkg/client/generated/management/v3/zz_generated_monitoring_output.go
@@ -1,12 +1,14 @@
 package client
 
 const (
-	MonitoringOutputType         = "monitoringOutput"
-	MonitoringOutputFieldAnswers = "answers"
-	MonitoringOutputFieldVersion = "version"
+	MonitoringOutputType                  = "monitoringOutput"
+	MonitoringOutputFieldAnswers          = "answers"
+	MonitoringOutputFieldAnswersSetString = "answersSetString"
+	MonitoringOutputFieldVersion          = "version"
 )
 
 type MonitoringOutput struct {
-	Answers map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
-	Version string            `json:"version,omitempty" yaml:"version,omitempty"`
+	Answers          map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersSetString map[string]string `json:"answersSetString,omitempty" yaml:"answersSetString,omitempty"`
+	Version          string            `json:"version,omitempty" yaml:"version,omitempty"`
 }

--- a/pkg/client/generated/management/v3/zz_generated_rancher_kubernetes_engine_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_rancher_kubernetes_engine_config.go
@@ -11,6 +11,7 @@ const (
 	RancherKubernetesEngineConfigFieldCloudProvider       = "cloudProvider"
 	RancherKubernetesEngineConfigFieldClusterName         = "clusterName"
 	RancherKubernetesEngineConfigFieldDNS                 = "dns"
+	RancherKubernetesEngineConfigFieldEnableCRIDockerd    = "enableCRIDockerd"
 	RancherKubernetesEngineConfigFieldIgnoreDockerVersion = "ignoreDockerVersion"
 	RancherKubernetesEngineConfigFieldIngress             = "ingress"
 	RancherKubernetesEngineConfigFieldMonitoring          = "monitoring"
@@ -40,6 +41,7 @@ type RancherKubernetesEngineConfig struct {
 	CloudProvider       *CloudProvider       `json:"cloudProvider,omitempty" yaml:"cloudProvider,omitempty"`
 	ClusterName         string               `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
 	DNS                 *DNSConfig           `json:"dns,omitempty" yaml:"dns,omitempty"`
+	EnableCRIDockerd    *bool                `json:"enableCRIDockerd,omitempty" yaml:"enableCRIDockerd,omitempty"`
 	IgnoreDockerVersion *bool                `json:"ignoreDockerVersion,omitempty" yaml:"ignoreDockerVersion,omitempty"`
 	Ingress             *IngressConfig       `json:"ingress,omitempty" yaml:"ingress,omitempty"`
 	Monitoring          *MonitoringConfig    `json:"monitoring,omitempty" yaml:"monitoring,omitempty"`

--- a/pkg/client/generated/project/v3/zz_generated_app.go
+++ b/pkg/client/generated/project/v3/zz_generated_app.go
@@ -8,6 +8,7 @@ const (
 	AppType                      = "app"
 	AppFieldAnnotations          = "annotations"
 	AppFieldAnswers              = "answers"
+	AppFieldAnswersSetString     = "answersSetString"
 	AppFieldAppRevisionID        = "appRevisionId"
 	AppFieldAppliedFiles         = "appliedFiles"
 	AppFieldConditions           = "conditions"
@@ -41,6 +42,7 @@ type App struct {
 	types.Resource
 	Annotations          map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Answers              map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersSetString     map[string]string `json:"answersSetString,omitempty" yaml:"answersSetString,omitempty"`
 	AppRevisionID        string            `json:"appRevisionId,omitempty" yaml:"appRevisionId,omitempty"`
 	AppliedFiles         map[string]string `json:"appliedFiles,omitempty" yaml:"appliedFiles,omitempty"`
 	Conditions           []AppCondition    `json:"conditions,omitempty" yaml:"conditions,omitempty"`

--- a/pkg/client/generated/project/v3/zz_generated_app_revision_status.go
+++ b/pkg/client/generated/project/v3/zz_generated_app_revision_status.go
@@ -1,20 +1,22 @@
 package client
 
 const (
-	AppRevisionStatusType            = "appRevisionStatus"
-	AppRevisionStatusFieldAnswers    = "answers"
-	AppRevisionStatusFieldDigest     = "digest"
-	AppRevisionStatusFieldExternalID = "externalId"
-	AppRevisionStatusFieldFiles      = "files"
-	AppRevisionStatusFieldProjectID  = "projectId"
-	AppRevisionStatusFieldValuesYaml = "valuesYaml"
+	AppRevisionStatusType                  = "appRevisionStatus"
+	AppRevisionStatusFieldAnswers          = "answers"
+	AppRevisionStatusFieldAnswersSetString = "answersSetString"
+	AppRevisionStatusFieldDigest           = "digest"
+	AppRevisionStatusFieldExternalID       = "externalId"
+	AppRevisionStatusFieldFiles            = "files"
+	AppRevisionStatusFieldProjectID        = "projectId"
+	AppRevisionStatusFieldValuesYaml       = "valuesYaml"
 )
 
 type AppRevisionStatus struct {
-	Answers    map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
-	Digest     string            `json:"digest,omitempty" yaml:"digest,omitempty"`
-	ExternalID string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
-	Files      map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
-	ProjectID  string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
-	ValuesYaml string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
+	Answers          map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersSetString map[string]string `json:"answersSetString,omitempty" yaml:"answersSetString,omitempty"`
+	Digest           string            `json:"digest,omitempty" yaml:"digest,omitempty"`
+	ExternalID       string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
+	Files            map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
+	ProjectID        string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
+	ValuesYaml       string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }

--- a/pkg/client/generated/project/v3/zz_generated_app_spec.go
+++ b/pkg/client/generated/project/v3/zz_generated_app_spec.go
@@ -3,6 +3,7 @@ package client
 const (
 	AppSpecType                   = "appSpec"
 	AppSpecFieldAnswers           = "answers"
+	AppSpecFieldAnswersSetString  = "answersSetString"
 	AppSpecFieldAppRevisionID     = "appRevisionId"
 	AppSpecFieldDescription       = "description"
 	AppSpecFieldExternalID        = "externalId"
@@ -18,6 +19,7 @@ const (
 
 type AppSpec struct {
 	Answers           map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersSetString  map[string]string `json:"answersSetString,omitempty" yaml:"answersSetString,omitempty"`
 	AppRevisionID     string            `json:"appRevisionId,omitempty" yaml:"appRevisionId,omitempty"`
 	Description       string            `json:"description,omitempty" yaml:"description,omitempty"`
 	ExternalID        string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`

--- a/pkg/client/generated/project/v3/zz_generated_app_upgrade_config.go
+++ b/pkg/client/generated/project/v3/zz_generated_app_upgrade_config.go
@@ -1,18 +1,20 @@
 package client
 
 const (
-	AppUpgradeConfigType              = "appUpgradeConfig"
-	AppUpgradeConfigFieldAnswers      = "answers"
-	AppUpgradeConfigFieldExternalID   = "externalId"
-	AppUpgradeConfigFieldFiles        = "files"
-	AppUpgradeConfigFieldForceUpgrade = "forceUpgrade"
-	AppUpgradeConfigFieldValuesYaml   = "valuesYaml"
+	AppUpgradeConfigType                  = "appUpgradeConfig"
+	AppUpgradeConfigFieldAnswers          = "answers"
+	AppUpgradeConfigFieldAnswersSetString = "answersSetString"
+	AppUpgradeConfigFieldExternalID       = "externalId"
+	AppUpgradeConfigFieldFiles            = "files"
+	AppUpgradeConfigFieldForceUpgrade     = "forceUpgrade"
+	AppUpgradeConfigFieldValuesYaml       = "valuesYaml"
 )
 
 type AppUpgradeConfig struct {
-	Answers      map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
-	ExternalID   string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
-	Files        map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
-	ForceUpgrade bool              `json:"forceUpgrade,omitempty" yaml:"forceUpgrade,omitempty"`
-	ValuesYaml   string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
+	Answers          map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	AnswersSetString map[string]string `json:"answersSetString,omitempty" yaml:"answersSetString,omitempty"`
+	ExternalID       string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
+	Files            map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
+	ForceUpgrade     bool              `json:"forceUpgrade,omitempty" yaml:"forceUpgrade,omitempty"`
+	ValuesYaml       string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }

--- a/pkg/controllers/managementlegacy/multiclusterapp/controller_multiclusterapp.go
+++ b/pkg/controllers/managementlegacy/multiclusterapp/controller_multiclusterapp.go
@@ -94,7 +94,7 @@ func (m *MCAppManager) sync(key string, mcapp *v3.MultiClusterApp) (runtime.Obje
 	}
 	systemUserName := systemUser.Name
 
-	answerMap, err := m.createAnswerMap(mcapp.Spec.Answers)
+	answersMap, err := m.createAnswersMap(mcapp.Spec.Answers)
 	if err != nil {
 		return mcapp, err
 	}
@@ -129,7 +129,7 @@ func (m *MCAppManager) sync(key string, mcapp *v3.MultiClusterApp) (runtime.Obje
 		}
 	}
 
-	resp, err := m.createApps(mcapp, externalID, answerMap, systemUserName, batchSize, toUpdate)
+	resp, err := m.createApps(mcapp, externalID, answersMap, systemUserName, batchSize, toUpdate)
 	if err != nil {
 		return resp.object, err
 	}
@@ -152,7 +152,7 @@ func (m *MCAppManager) sync(key string, mcapp *v3.MultiClusterApp) (runtime.Obje
 	}
 
 	for i, app := range resp.updateApps {
-		if _, err := m.updateApp(app, answerMap, externalID, resp.projects[i]); err != nil {
+		if _, err := m.updateApp(app, answersMap, externalID, resp.projects[i]); err != nil {
 			return mcapp, err
 		}
 		resp.remaining--
@@ -178,7 +178,7 @@ type Response struct {
 	count      int
 }
 
-func (m *MCAppManager) createApps(mcapp *v3.MultiClusterApp, externalID string, answerMap map[string]map[string]string,
+func (m *MCAppManager) createApps(mcapp *v3.MultiClusterApp, externalID string, answersMap map[string]scopeAnswers,
 	creatorID string, batchSize int, toUpdate bool) (*Response, error) {
 
 	var mcappToUpdate *v3.MultiClusterApp
@@ -214,7 +214,9 @@ func (m *MCAppManager) createApps(mcapp *v3.MultiClusterApp, externalID string, 
 			}
 			appUpdated := false
 			if app.Spec.ExternalID == externalID {
-				if reflect.DeepEqual(app.Spec.Answers, getAnswerMap(answerMap, t.ProjectName)) {
+				answers, answersSetString := getScopeAnswers(answersMap, t.ProjectName)
+				if reflect.DeepEqual(app.Spec.Answers, answers) &&
+					reflect.DeepEqual(app.Spec.AnswersSetString, answersSetString) {
 					appUpdated = true
 				}
 			}
@@ -234,7 +236,7 @@ func (m *MCAppManager) createApps(mcapp *v3.MultiClusterApp, externalID string, 
 			continue
 		}
 		if batchSize > 0 {
-			appName, mcapp, err := m.createApp(mcapp, answerMap, ann, set, projectNS, creatorID, externalID, t.ProjectName)
+			appName, mcapp, err := m.createApp(mcapp, answersMap, ann, set, projectNS, creatorID, externalID, t.ProjectName)
 			if err != nil {
 				return resp, fmt.Errorf("error %v in creating multiclusterapp: %v", err, mcapp)
 			}
@@ -266,9 +268,11 @@ func (m *MCAppManager) createApps(mcapp *v3.MultiClusterApp, externalID string, 
 	return resp, nil
 }
 
-func (m *MCAppManager) updateApp(app *pv3.App, answerMap map[string]map[string]string, externalID string, projectName string) (*pv3.App, error) {
+func (m *MCAppManager) updateApp(app *pv3.App, answersMap map[string]scopeAnswers, externalID string, projectName string) (*pv3.App, error) {
 	app = app.DeepCopy()
-	app.Spec.Answers = getAnswerMap(answerMap, projectName)
+	answers, answersSetString := getScopeAnswers(answersMap, projectName)
+	app.Spec.Answers = answers
+	app.Spec.AnswersSetString = answersSetString
 	app.Spec.ExternalID = externalID
 	updatedObj, err := m.apps.Update(app)
 	if err != nil && apierrors.IsConflict(err) {
@@ -279,7 +283,9 @@ func (m *MCAppManager) updateApp(app *pv3.App, answerMap map[string]map[string]s
 				return latestObj, err
 			}
 			latestToUpdate := latestObj.DeepCopy()
-			latestToUpdate.Spec.Answers = getAnswerMap(answerMap, projectName)
+			answers, answersSetString := getScopeAnswers(answersMap, projectName)
+			latestToUpdate.Spec.Answers = answers
+			latestToUpdate.Spec.AnswersSetString = answersSetString
 			latestToUpdate.Spec.ExternalID = externalID
 			updated, err := m.apps.Update(latestToUpdate)
 			if err != nil && apierrors.IsConflict(err) {
@@ -377,7 +383,7 @@ func (m *MCAppManager) toUpdate(mcapp *v3.MultiClusterApp) (bool, error) {
 	return true, nil
 }
 
-func (m *MCAppManager) createApp(mcapp *v3.MultiClusterApp, answerMap map[string]map[string]string, ann map[string]string,
+func (m *MCAppManager) createApp(mcapp *v3.MultiClusterApp, answersMap map[string]scopeAnswers, ann map[string]string,
 	set map[string]string, projectNS string, creatorID string, externalID string, projectName string) (string, *v3.MultiClusterApp, error) {
 	nsName := getAppNamespaceName(mcapp.Name, projectNS)
 	app, err := m.appLister.Get(projectNS, nsName)
@@ -385,6 +391,7 @@ func (m *MCAppManager) createApp(mcapp *v3.MultiClusterApp, answerMap map[string
 		if !apierrors.IsNotFound(err) {
 			return "", mcapp, err
 		}
+		answers, answersSetString := getScopeAnswers(answersMap, projectName)
 		toCreate := pv3.App{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        nsName,
@@ -397,7 +404,8 @@ func (m *MCAppManager) createApp(mcapp *v3.MultiClusterApp, answerMap map[string
 				TargetNamespace:     nsName,
 				ExternalID:          externalID,
 				MultiClusterAppName: mcapp.Name,
-				Answers:             getAnswerMap(answerMap, projectName),
+				Answers:             answers,
+				AnswersSetString:    answersSetString,
 				Wait:                mcapp.Spec.Wait,
 				Timeout:             mcapp.Spec.Timeout,
 			},
@@ -409,26 +417,6 @@ func (m *MCAppManager) createApp(mcapp *v3.MultiClusterApp, answerMap map[string
 		}
 	}
 	return app.Name, mcapp, nil
-}
-
-func getAnswerMap(answerMap map[string]map[string]string, projectName string) map[string]string {
-	// find answers for this project, if not found then try finding for the cluster this project belongs to, else finally use the global scoped answer
-	answers := map[string]string{}
-	if len(answerMap) > 0 {
-		if ans, ok := answerMap[projectName]; ok {
-			return ans
-		}
-		// find the answers for the cluster of this project
-		split := strings.SplitN(projectName, ":", 2)
-		clusterName := split[0]
-		if ans, ok := answerMap[clusterName]; ok {
-			return ans
-		}
-		if ans, ok := answerMap[globalScopeAnswersKey]; ok {
-			return ans
-		}
-	}
-	return answers
 }
 
 // deleteApps finds all apps created by this multiclusterapp and deletes them
@@ -574,54 +562,85 @@ func setInstalledDone(mcapp *v3.MultiClusterApp) {
 	v32.MultiClusterAppConditionInstalled.Message(mcapp, "")
 }
 
-func (m *MCAppManager) createAnswerMap(answers []v32.Answer) (map[string]map[string]string, error) {
-	// create a map, where key is the projectID or clusterID, or "global" if neither is provided, and value is the actual answer values
-	// Global scoped answers will have all questions. Project/cluster scoped will only have override keys. So we'll first create a global map,
-	// and then merge with project/cluster map
-	answerMap := make(map[string]map[string]string)
-	globalAnswersMap := make(map[string]string)
-	for _, a := range answers {
-		if a.ProjectName == "" && a.ClusterName == "" {
-			globalAnswersMap = a.Values
-			answerMap[globalScopeAnswersKey] = make(map[string]string)
-			answerMap[globalScopeAnswersKey] = a.Values
+type scopeAnswers struct {
+	answers          map[string]string
+	answersSetString map[string]string
+}
+
+func getScopeAnswers(answersMap map[string]scopeAnswers, projectName string) (map[string]string, map[string]string) {
+	// Find answers for this project, if not found then try finding for the cluster this project belongs to, else finally use the global scoped answers
+	if len(answersMap) > 0 {
+		if a, ok := answersMap[projectName]; ok {
+			return a.answers, a.answersSetString
+		}
+		// Find the answers for the cluster of this project
+		clusterName := strings.SplitN(projectName, ":", 2)[0]
+		if a, ok := answersMap[clusterName]; ok {
+			return a.answers, a.answersSetString
+		}
+		if a, ok := answersMap[globalScopeAnswersKey]; ok {
+			return a.answers, a.answersSetString
 		}
 	}
+	return map[string]string{}, map[string]string{}
+}
 
+func (m *MCAppManager) createAnswersMap(answers []v32.Answer) (map[string]scopeAnswers, error) {
+	// This function creates a map where keys are the scope of the answers (ProjectName, ClusterName, or "global"), and
+	// the values are scopeAnswers structs containing the answers and answersSetString. Global answers apply to all scopes,
+	// whereas project and cluster answers will override the global scope. Therefore we create a global map first and then
+	// merge with the project/cluster map.
+	var globalAnswers scopeAnswers
+	var answersMap = make(map[string]scopeAnswers)
+
+	for _, a := range answers {
+		if a.ProjectName == "" && a.ClusterName == "" {
+			globalAnswers = scopeAnswers{
+				answers:          a.Values,
+				answersSetString: a.ValuesSetString,
+			}
+			answersMap[globalScopeAnswersKey] = scopeAnswers{
+				answers:          a.Values,
+				answersSetString: a.ValuesSetString,
+			}
+		}
+	}
 	for _, a := range answers {
 		if a.ClusterName != "" {
 			// Using k8s labels.Merge, since by definition:
 			// Merge combines given maps, and does not check for any conflicts between the maps. In case of conflicts, second map (labels2) wins
 			// And we want cluster level keys to override keys from global/cluster for that cluster
-			clusterLabels := labels.Merge(globalAnswersMap, a.Values)
-			answerMap[a.ClusterName] = make(map[string]string)
-			answerMap[a.ClusterName] = clusterLabels
+			answersMap[a.ClusterName] = scopeAnswers{
+				answers:          labels.Merge(globalAnswers.answers, a.Values),
+				answersSetString: labels.Merge(globalAnswers.answersSetString, a.ValuesSetString),
+			}
 		}
 	}
-
 	for _, a := range answers {
 		if a.ProjectName != "" {
-			// check if answers for the cluster of this project are provided
+			// Check if answers for the cluster of this project are provided
 			split := strings.SplitN(a.ProjectName, ":", 2)
 			if len(split) != 2 {
-				return answerMap, fmt.Errorf("error in splitting project name: %v", a.ProjectName)
+				return answersMap, fmt.Errorf("error in splitting project name: %v", a.ProjectName)
 			}
 			clusterName := split[0]
 			// Using k8s labels.Merge, since by definition:
 			// Merge combines given maps, and does not check for any conflicts between the maps. In case of conflicts, second map (labels2) wins
 			// And we want project level keys to override keys from global level for that project
-			var projectLabels map[string]string
-			if val, ok := answerMap[clusterName]; ok {
-				projectLabels = labels.Merge(val, a.Values)
+			if clusterAnswers, ok := answersMap[clusterName]; ok {
+				answersMap[a.ProjectName] = scopeAnswers{
+					answers:          labels.Merge(clusterAnswers.answers, a.Values),
+					answersSetString: labels.Merge(clusterAnswers.answersSetString, a.ValuesSetString),
+				}
 			} else {
-				projectLabels = labels.Merge(globalAnswersMap, a.Values)
+				answersMap[a.ProjectName] = scopeAnswers{
+					answers:          labels.Merge(globalAnswers.answers, a.Values),
+					answersSetString: labels.Merge(globalAnswers.answersSetString, a.ValuesSetString),
+				}
 			}
-			answerMap[a.ProjectName] = make(map[string]string)
-			answerMap[a.ProjectName] = projectLabels
 		}
 	}
-
-	return answerMap, nil
+	return answersMap, nil
 }
 
 // getExternalID gets the TemplateVersion.Spec.ExternalID field

--- a/pkg/controllers/managementuserlegacy/helm/common/common.go
+++ b/pkg/controllers/managementuserlegacy/helm/common/common.go
@@ -210,36 +210,44 @@ func getTimeoutArgs(app *v3.App) []string {
 	return timeoutArgs
 }
 
+// Convert answers map into a slice of "k=v" formatted values with escaped commas (Required by Helm)
+func answersMapToValuesSlice(answers, extraArgs map[string]string) []string {
+	var slice []string
+	for k, v := range answers {
+		if _, ok := extraArgs[k]; ok {
+			continue
+		}
+		slice = append(slice, fmt.Sprintf("%s=%s", k, escapeCommas(v)))
+	}
+	for k, v := range extraArgs {
+		slice = append(slice, fmt.Sprintf("%s=%s", k, escapeCommas(v)))
+	}
+	return slice
+}
+
 func GenerateAnswerSetValues(app *v3.App, tempDir *HelmPath, extraArgs map[string]string) ([]string, error) {
-	setValues := []string{}
-	// a user-supplied values file will overridden default values.yaml
+	var values []string
+	// A user-supplied values.yaml will override the default values.yaml
 	if app.Spec.ValuesYaml != "" {
 		custom := "custom-values.yaml"
 		valuesYaml := filepath.Join(tempDir.FullPath, custom)
 		if err := ioutil.WriteFile(valuesYaml, []byte(app.Spec.ValuesYaml), 0755); err != nil {
-			return setValues, err
+			return values, err
 		}
-		setValues = append(setValues, "--values", filepath.Join(tempDir.InJailPath, custom))
+		values = append(values, "--values", filepath.Join(tempDir.InJailPath, custom))
 	}
-	// `--set` values will overridden the user-supplied values.yaml file
+	// Values in --set args will override values in the user-supplied values.yaml
 	if app.Spec.Answers != nil || extraArgs != nil {
-		answers := app.Spec.Answers
-		var values = []string{}
-		for k, v := range answers {
-			if _, ok := extraArgs[k]; ok {
-				continue
-			}
-			// helm will only accept escaped commas in values
-			escapedValue := fmt.Sprintf("%s=%s", k, escapeCommas(v))
-			values = append(values, escapedValue)
-		}
-		for k, v := range extraArgs {
-			escapedValue := fmt.Sprintf("%s=%s", k, escapeCommas(v))
-			values = append(values, escapedValue)
-		}
-		setValues = append(setValues, "--set", strings.Join(values, ","))
+		setValues := answersMapToValuesSlice(app.Spec.Answers, extraArgs)
+		values = append(values, "--set", strings.Join(setValues, ","))
 	}
-	return setValues, nil
+	// Values in --set-string args will override values in --set args because
+	// Helm gives presedence to the right-most set flag
+	if app.Spec.AnswersSetString != nil {
+		setStringValues := answersMapToValuesSlice(app.Spec.AnswersSetString, map[string]string{})
+		values = append(values, "--set-string", strings.Join(setStringValues, ","))
+	}
+	return values, nil
 }
 
 func DeleteCharts(tempDirs *HelmPath, port string, obj *v3.App) error {

--- a/pkg/controllers/managementuserlegacy/helm/controller.go
+++ b/pkg/controllers/managementuserlegacy/helm/controller.go
@@ -362,6 +362,7 @@ func (l *Lifecycle) createAppRevision(obj *v3.App, template, notes string, faile
 	}
 	release.Spec.ProjectName = obj.Spec.ProjectName
 	release.Status.Answers = obj.Spec.Answers
+	release.Status.AnswersSetString = obj.Spec.AnswersSetString
 	release.Status.ExternalID = obj.Spec.ExternalID
 	release.Status.ValuesYaml = obj.Spec.ValuesYaml
 	release.Status.Files = obj.Spec.Files
@@ -413,14 +414,20 @@ func (l *Lifecycle) writeKubeConfig(obj *v3.App, kubePath string, remove bool) (
 
 func isSame(obj *v3.App, revision *v3.AppRevision) bool {
 	if obj.Spec.ExternalID != "" {
-		if revision.Status.ExternalID == obj.Spec.ExternalID && reflect.DeepEqual(revision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(revision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
+		if revision.Status.ExternalID == obj.Spec.ExternalID &&
+			reflect.DeepEqual(revision.Status.Answers, obj.Spec.Answers) &&
+			reflect.DeepEqual(revision.Status.AnswersSetString, obj.Spec.AnswersSetString) &&
+			reflect.DeepEqual(revision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
 			return true
 		}
 		return false
 	}
 
 	if obj.Status.AppliedFiles != nil {
-		if reflect.DeepEqual(obj.Status.AppliedFiles, obj.Spec.Files) && reflect.DeepEqual(revision.Status.Answers, obj.Spec.Answers) && reflect.DeepEqual(revision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
+		if reflect.DeepEqual(obj.Status.AppliedFiles, obj.Spec.Files) &&
+			reflect.DeepEqual(revision.Status.Answers, obj.Spec.Answers) &&
+			reflect.DeepEqual(revision.Status.AnswersSetString, obj.Spec.AnswersSetString) &&
+			reflect.DeepEqual(revision.Status.ValuesYaml, obj.Spec.ValuesYaml) {
 			return true
 		}
 		return false

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -207,34 +207,40 @@ grafana.persistence.accessMode       	| ReadWriteOnce
 grafana.persistence.size             	| 50Gi
 
 */
-func OverwriteAppAnswersAndCatalogID(rawAnswers map[string]string, annotations map[string]string,
-	catalogTemplateLister mgmtv3.CatalogTemplateLister, catalogManager manager.CatalogManager, clusterName string) (map[string]string, string, error) {
-	overwriteAnswers, version := GetOverwroteAppAnswersAndVersion(annotations)
-	for specialKey, value := range overwriteAnswers {
+func OverwriteAppAnswersAndCatalogID(
+	rawAnswers,
+	rawAnswersSetString map[string]string,
+	annotations map[string]string,
+	catalogTemplateLister mgmtv3.CatalogTemplateLister,
+	catalogManager manager.CatalogManager,
+	clusterName string,
+) (map[string]string, map[string]string, string, error) {
+	monitoringInput := GetMonitoringInput(annotations)
+	resolveSpecialAnswersKeys(rawAnswers, monitoringInput.Answers)
+	resolveSpecialAnswersKeys(rawAnswersSetString, monitoringInput.AnswersSetString)
+	catalogID, err := GetMonitoringCatalogID(monitoringInput.Version, catalogTemplateLister, catalogManager, clusterName)
+	return rawAnswers, rawAnswersSetString, catalogID, err
+}
+
+func resolveSpecialAnswersKeys(rawAnswers, answers map[string]string) {
+	for specialKey, value := range answers {
 		if strings.HasPrefix(specialKey, "_tpl-") {
 			trr := tplRegexp.translate(value)
-			for suffixKey, value := range overwriteAnswers {
+			for suffixKey, value := range answers {
 				if strings.HasPrefix(suffixKey, trr.middlePrefix) {
 					for _, prefixKey := range trr.roots {
 						actualKey := fmt.Sprintf("%s.%s", prefixKey, suffixKey)
-
 						rawAnswers[actualKey] = value
 					}
-
-					delete(overwriteAnswers, suffixKey)
+					delete(answers, suffixKey)
 				}
 			}
-
-			delete(overwriteAnswers, specialKey)
+			delete(answers, specialKey)
 		}
 	}
-
-	for key, value := range overwriteAnswers {
+	for key, value := range answers {
 		rawAnswers[key] = value
 	}
-	catalogID, err := GetMonitoringCatalogID(version, catalogTemplateLister, catalogManager, clusterName)
-
-	return rawAnswers, catalogID, err
 }
 
 func GetMonitoringCatalogID(version string, catalogTemplateLister mgmtv3.CatalogTemplateLister, catalogManager manager.CatalogManager, clusterName string) (string, error) {
@@ -288,16 +294,16 @@ func (tr *templateRegexp) translate(value string) *templateRegexpResult {
 	return captures
 }
 
-func GetOverwroteAppAnswersAndVersion(annotations map[string]string) (map[string]string, string) {
+func GetMonitoringInput(annotations map[string]string) v32.MonitoringInput {
 	overwritingAppAnswers := annotations[cattleOverwriteAppAnswersAnnotationKey]
 	if len(overwritingAppAnswers) != 0 {
 		var appOverwriteInput v32.MonitoringInput
 		err := json.Unmarshal([]byte(overwritingAppAnswers), &appOverwriteInput)
 		if err == nil {
-			return appOverwriteInput.Answers, appOverwriteInput.Version
+			return appOverwriteInput
 		}
 		logrus.Errorf("failed to parse app overwrite input from %q, %v", overwritingAppAnswers, err)
 	}
 
-	return map[string]string{}, ""
+	return v32.MonitoringInput{}
 }


### PR DESCRIPTION
Problem:
When we install an app using Helm install, we pass all user provided answers as args to Helm's `--set` which changes will change a value of a quoted string `"true"` to a boolean `true` and break if the app expects a quoted string.

Solution:
Pass the answers that should keep the quoted string type as args to Helm's `--set-string`. Since both changing to the correct type and preserving the value as a quoted string are desirable outcomes depending on the situation, it should be up to the user to decide. For that reason the answers has been split into `answers` (keeps current behavior) and `answersSetString` (keeps its quoted string type). The expectation from the UI perspective is that the user will be able to choose which flag to use (A checkbox next to each answer text field maybe?), and the UI will add the value to the correct map.

Issues: https://github.com/rancher/rancher/issues/26088, https://github.com/rancher/rancher/issues/31109, https://github.com/rancher/rancher/issues/22532