### PR TITLE
use `tini` process watchdog for agent image as well.

### DIFF
--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -30,6 +30,7 @@ ENV DOCKER_API_VERSION 1.24
 ENV AGENT_IMAGE rancher/rancher-agent:${VERSION}
 ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
 COPY --from=rancher /var/lib/rancher-data /var/lib/rancher-data
+COPY --from=rancher /usr/bin/tini /usr/bin/
 COPY agent run.sh kubectl-shell.sh shell-setup.sh share-root.sh /usr/bin/
 WORKDIR /var/lib/rancher
 ENTRYPOINT ["run.sh"]

--- a/package/run.sh
+++ b/package/run.sh
@@ -258,4 +258,4 @@ if [ -n "$CATTLE_CA_CHECKSUM" ]; then
     fi
 fi
 
-exec agent
+exec tini -- agent


### PR DESCRIPTION
fixes #30172