### PR TITLE
Add ability to create cloud creds for any node driver 

### DIFF
--- a/pkg/apis/management.cattle.io/v3/machine_types.go
+++ b/pkg/apis/management.cattle.io/v3/machine_types.go
@@ -310,15 +310,18 @@ type Condition struct {
 }
 
 type NodeDriverSpec struct {
-	DisplayName      string   `json:"displayName"`
-	Description      string   `json:"description"`
-	URL              string   `json:"url" norman:"required"`
-	ExternalID       string   `json:"externalId"`
-	Builtin          bool     `json:"builtin"`
-	Active           bool     `json:"active"`
-	Checksum         string   `json:"checksum"`
-	UIURL            string   `json:"uiUrl"`
-	WhitelistDomains []string `json:"whitelistDomains,omitempty"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+	URL         string `json:"url" norman:"required"`
+	ExternalID  string `json:"externalId"`
+	Builtin     bool   `json:"builtin"`
+	Active      bool   `json:"active"`
+	// If AddCloudCredential is true, then the cloud credential schema is created
+	// regardless of whether the node driver is active.
+	AddCloudCredential bool     `json:"addCloudCredential"`
+	Checksum           string   `json:"checksum"`
+	UIURL              string   `json:"uiUrl"`
+	WhitelistDomains   []string `json:"whitelistDomains,omitempty"`
 }
 
 type PublicEndpoint struct {

--- a/pkg/client/generated/management/v3/zz_generated_node_driver.go
+++ b/pkg/client/generated/management/v3/zz_generated_node_driver.go
@@ -7,6 +7,7 @@ import (
 const (
 	NodeDriverType                      = "nodeDriver"
 	NodeDriverFieldActive               = "active"
+	NodeDriverFieldAddCloudCredential   = "addCloudCredential"
 	NodeDriverFieldAnnotations          = "annotations"
 	NodeDriverFieldBuiltin              = "builtin"
 	NodeDriverFieldChecksum             = "checksum"
@@ -31,6 +32,7 @@ const (
 type NodeDriver struct {
 	types.Resource
 	Active               bool              `json:"active,omitempty" yaml:"active,omitempty"`
+	AddCloudCredential   bool              `json:"addCloudCredential,omitempty" yaml:"addCloudCredential,omitempty"`
 	Annotations          map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Builtin              bool              `json:"builtin,omitempty" yaml:"builtin,omitempty"`
 	Checksum             string            `json:"checksum,omitempty" yaml:"checksum,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_node_driver_spec.go
+++ b/pkg/client/generated/management/v3/zz_generated_node_driver_spec.go
@@ -1,26 +1,28 @@
 package client
 
 const (
-	NodeDriverSpecType                  = "nodeDriverSpec"
-	NodeDriverSpecFieldActive           = "active"
-	NodeDriverSpecFieldBuiltin          = "builtin"
-	NodeDriverSpecFieldChecksum         = "checksum"
-	NodeDriverSpecFieldDescription      = "description"
-	NodeDriverSpecFieldDisplayName      = "displayName"
-	NodeDriverSpecFieldExternalID       = "externalId"
-	NodeDriverSpecFieldUIURL            = "uiUrl"
-	NodeDriverSpecFieldURL              = "url"
-	NodeDriverSpecFieldWhitelistDomains = "whitelistDomains"
+	NodeDriverSpecType                    = "nodeDriverSpec"
+	NodeDriverSpecFieldActive             = "active"
+	NodeDriverSpecFieldAddCloudCredential = "addCloudCredential"
+	NodeDriverSpecFieldBuiltin            = "builtin"
+	NodeDriverSpecFieldChecksum           = "checksum"
+	NodeDriverSpecFieldDescription        = "description"
+	NodeDriverSpecFieldDisplayName        = "displayName"
+	NodeDriverSpecFieldExternalID         = "externalId"
+	NodeDriverSpecFieldUIURL              = "uiUrl"
+	NodeDriverSpecFieldURL                = "url"
+	NodeDriverSpecFieldWhitelistDomains   = "whitelistDomains"
 )
 
 type NodeDriverSpec struct {
-	Active           bool     `json:"active,omitempty" yaml:"active,omitempty"`
-	Builtin          bool     `json:"builtin,omitempty" yaml:"builtin,omitempty"`
-	Checksum         string   `json:"checksum,omitempty" yaml:"checksum,omitempty"`
-	Description      string   `json:"description,omitempty" yaml:"description,omitempty"`
-	DisplayName      string   `json:"displayName,omitempty" yaml:"displayName,omitempty"`
-	ExternalID       string   `json:"externalId,omitempty" yaml:"externalId,omitempty"`
-	UIURL            string   `json:"uiUrl,omitempty" yaml:"uiUrl,omitempty"`
-	URL              string   `json:"url,omitempty" yaml:"url,omitempty"`
-	WhitelistDomains []string `json:"whitelistDomains,omitempty" yaml:"whitelistDomains,omitempty"`
+	Active             bool     `json:"active,omitempty" yaml:"active,omitempty"`
+	AddCloudCredential bool     `json:"addCloudCredential,omitempty" yaml:"addCloudCredential,omitempty"`
+	Builtin            bool     `json:"builtin,omitempty" yaml:"builtin,omitempty"`
+	Checksum           string   `json:"checksum,omitempty" yaml:"checksum,omitempty"`
+	Description        string   `json:"description,omitempty" yaml:"description,omitempty"`
+	DisplayName        string   `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	ExternalID         string   `json:"externalId,omitempty" yaml:"externalId,omitempty"`
+	UIURL              string   `json:"uiUrl,omitempty" yaml:"uiUrl,omitempty"`
+	URL                string   `json:"url,omitempty" yaml:"url,omitempty"`
+	WhitelistDomains   []string `json:"whitelistDomains,omitempty" yaml:"whitelistDomains,omitempty"`
 }

--- a/pkg/controllers/management/drivers/nodedriver/machine_driver.go
+++ b/pkg/controllers/management/drivers/nodedriver/machine_driver.go
@@ -90,7 +90,7 @@ func (m *Lifecycle) Create(obj *v3.NodeDriver) (runtime.Object, error) {
 func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 	driverLock.Lock()
 	defer driverLock.Unlock()
-	if !obj.Spec.Active {
+	if !obj.Spec.Active && !obj.Spec.AddCloudCredential {
 		return obj, nil
 	}
 
@@ -108,9 +108,6 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 	if driver.Exists() && err == nil && !forceUpdate {
 		// add credential schema
 		credFields := map[string]v32.Field{}
-		if err != nil {
-			logrus.Errorf("error getting schema %v", err)
-		}
 		pubCredFields, privateCredFields, passwordFields, defaults := getCredFields(obj.Annotations)
 		for name, field := range existingSchema.Spec.ResourceFields {
 			if SSHKeyFields[name] || passwordFields[name] || privateCredFields[name] {
@@ -361,7 +358,7 @@ func (m *Lifecycle) Updated(obj *v3.NodeDriver) (runtime.Object, error) {
 	}
 
 	if err := m.createOrUpdateNodeForEmbeddedTypeCredential(credentialConfigSchemaName(obj.Spec.DisplayName),
-		obj.Spec.DisplayName+"credentialConfig", obj.Spec.Active); err != nil {
+		obj.Spec.DisplayName+"credentialConfig", obj.Spec.Active || obj.Spec.AddCloudCredential); err != nil {
 		return obj, err
 	}
 

--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -53,89 +53,78 @@ var driverDefaults = map[string]map[string]string{
 }
 
 type machineDriverCompare struct {
-	builtin     bool
-	url         string
-	uiURL       string
-	checksum    string
-	name        string
-	whitelist   []string
-	annotations map[string]string
+	builtin            bool
+	addCloudCredential bool
+	url                string
+	uiURL              string
+	checksum           string
+	name               string
+	whitelist          []string
+	annotations        map[string]string
 }
 
 func addMachineDrivers(management *config.ManagementContext) error {
-	if err := addMachineDriver("pinganyunecs", "https://drivers.rancher.cn/node-driver-pinganyun/0.3.0/docker-machine-driver-pinganyunecs-linux.tgz",
-		"https://drivers.rancher.cn/node-driver-pinganyun/0.3.0/component.js", "f84ccec11c2c1970d76d30150916933efe8ca49fe4c422c8954fc37f71273bb5",
-		[]string{"drivers.rancher.cn"}, false, false, management); err != nil {
+	if err := addMachineDriver("pinganyunecs", "https://drivers.rancher.cn/node-driver-pinganyun/0.3.0/docker-machine-driver-pinganyunecs-linux.tgz", "https://drivers.rancher.cn/node-driver-pinganyun/0.3.0/component.js", "f84ccec11c2c1970d76d30150916933efe8ca49fe4c422c8954fc37f71273bb5", []string{"drivers.rancher.cn"}, false, false, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver("aliyunecs", "https://drivers.rancher.cn/node-driver-aliyun/1.0.4/docker-machine-driver-aliyunecs.tgz",
-		"", "5990d40d71c421a85563df9caf069466f300cd75723effe4581751b0de9a6a0e", []string{"ecs.aliyuncs.com"}, false, false, management); err != nil {
+	if err := addMachineDriver("aliyunecs", "https://drivers.rancher.cn/node-driver-aliyun/1.0.4/docker-machine-driver-aliyunecs.tgz", "", "5990d40d71c421a85563df9caf069466f300cd75723effe4581751b0de9a6a0e", []string{"ecs.aliyuncs.com"}, false, false, false, management); err != nil {
 		return err
 	}
 	if err := addMachineDriver(Amazonec2driver, "local://", "", "",
 		[]string{"iam.amazonaws.com", "iam.us-gov.amazonaws.com", "iam.%.amazonaws.com.cn", "ec2.%.amazonaws.com", "ec2.%.amazonaws.com.cn", "eks.%.amazonaws.com", "eks.%.amazonaws.com.cn", "kms.%.amazonaws.com", "kms.%.amazonaws.com.cn"},
-		true, true, management); err != nil {
+		true, true, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(Azuredriver, "local://", "", "", nil, true, true, management); err != nil {
+	if err := addMachineDriver(Azuredriver, "local://", "", "", nil, true, true, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver("cloudca", "https://github.com/cloud-ca/docker-machine-driver-cloudca/files/2446837/docker-machine-driver-cloudca_v2.0.0_linux-amd64.zip",
-		"https://objects-east.cloud.ca/v1/5ef827605f884961b94881e928e7a250/ui-driver-cloudca/v2.1.2/component.js", "2a55efd6d62d5f7fd27ce877d49596f4",
-		[]string{"objects-east.cloud.ca"}, false, false, management); err != nil {
+	if err := addMachineDriver("cloudca", "https://github.com/cloud-ca/docker-machine-driver-cloudca/files/2446837/docker-machine-driver-cloudca_v2.0.0_linux-amd64.zip", "https://objects-east.cloud.ca/v1/5ef827605f884961b94881e928e7a250/ui-driver-cloudca/v2.1.2/component.js", "2a55efd6d62d5f7fd27ce877d49596f4", []string{"objects-east.cloud.ca"}, false, false, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver("cloudscale", "https://github.com/cloudscale-ch/docker-machine-driver-cloudscale/releases/download/v1.2.0/docker-machine-driver-cloudscale_v1.2.0_linux_amd64.tar.gz",
-		"https://objects.rma.cloudscale.ch/cloudscale-rancher-v2-ui-driver/component.js", "e33fbd6c2f87b1c470bcb653cc8aa50baf914a9d641a2f18f86a07c398cfb544",
-		[]string{"objects.rma.cloudscale.ch"}, false, false, management); err != nil {
+	if err := addMachineDriver("cloudscale", "https://github.com/cloudscale-ch/docker-machine-driver-cloudscale/releases/download/v1.2.0/docker-machine-driver-cloudscale_v1.2.0_linux_amd64.tar.gz", "https://objects.rma.cloudscale.ch/cloudscale-rancher-v2-ui-driver/component.js", "e33fbd6c2f87b1c470bcb653cc8aa50baf914a9d641a2f18f86a07c398cfb544", []string{"objects.rma.cloudscale.ch"}, false, false, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(DigitalOceandriver, "local://", "", "", []string{"api.digitalocean.com"}, true, true, management); err != nil {
+	if err := addMachineDriver(DigitalOceandriver, "local://", "", "", []string{"api.digitalocean.com"}, true, true, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(ExoscaleDriver, "local://", "", "", []string{"api.exoscale.ch"}, false, true, management); err != nil {
+	if err := addMachineDriver(ExoscaleDriver, "local://", "", "", []string{"api.exoscale.ch"}, false, true, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(GoogleDriver, "local://", "", "", nil, true, true, management); err != nil {
+	if err := addMachineDriver(GoogleDriver, "local://", "", "", nil, false, true, true, management); err != nil {
 		return err
 	}
 	linodeBuiltin := true
 	if dl := os.Getenv("CATTLE_DEV_MODE"); dl != "" {
 		linodeBuiltin = false
 	}
-	if err := addMachineDriver(Linodedriver, "https://github.com/linode/docker-machine-driver-linode/releases/download/v0.1.8/docker-machine-driver-linode_linux-amd64.zip",
-		"/assets/rancher-ui-driver-linode/component.js", "b31b6a504c59ee758d2dda83029fe4a85b3f5601e22dfa58700a5e6c8f450dc7", []string{"api.linode.com"}, linodeBuiltin, linodeBuiltin, management); err != nil {
+	if err := addMachineDriver(Linodedriver, "https://github.com/linode/docker-machine-driver-linode/releases/download/v0.1.8/docker-machine-driver-linode_linux-amd64.zip", "/assets/rancher-ui-driver-linode/component.js", "b31b6a504c59ee758d2dda83029fe4a85b3f5601e22dfa58700a5e6c8f450dc7", []string{"api.linode.com"}, linodeBuiltin, linodeBuiltin, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(OCIDriver, "https://github.com/rancher-plugins/rancher-machine-driver-oci/releases/download/v1.0.1/docker-machine-driver-oci-linux",
-		"", "6867f59e9f33bdbce34b5bf9476c48d2edc2ef4bca8a2ef82ccaa1de57af811c", []string{"*.oraclecloud.com"}, false, false, management); err != nil {
+	if err := addMachineDriver(OCIDriver, "https://github.com/rancher-plugins/rancher-machine-driver-oci/releases/download/v1.0.1/docker-machine-driver-oci-linux", "", "6867f59e9f33bdbce34b5bf9476c48d2edc2ef4bca8a2ef82ccaa1de57af811c", []string{"*.oraclecloud.com"}, false, false, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(OpenstackDriver, "local://", "", "", nil, false, true, management); err != nil {
+	if err := addMachineDriver(OpenstackDriver, "local://", "", "", nil, false, true, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(OTCDriver, "https://github.com/rancher-plugins/docker-machine-driver-otc/releases/download/v2019.5.7/docker-machine-driver-otc",
-		"", "3f793ebb0ebd9477b9166ec542f77e25", nil, false, false, management); err != nil {
+	if err := addMachineDriver(OTCDriver, "https://github.com/rancher-plugins/docker-machine-driver-otc/releases/download/v2019.5.7/docker-machine-driver-otc", "", "3f793ebb0ebd9477b9166ec542f77e25", nil, false, false, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(PacketDriver, "https://github.com/packethost/docker-machine-driver-packet/releases/download/v0.2.2/docker-machine-driver-packet_linux-amd64.zip",
-		"https://packethost.github.io/ui-driver-packet/1.0.2/component.js", "e03c6bc9406c811e03e9bc2c39f43e6cc8c02d1615bd0e0b8ee1b38be6fe201c", []string{"api.packet.net", "packethost.github.io"}, false, false, management); err != nil {
+	if err := addMachineDriver(PacketDriver, "https://github.com/packethost/docker-machine-driver-packet/releases/download/v0.2.2/docker-machine-driver-packet_linux-amd64.zip", "https://packethost.github.io/ui-driver-packet/1.0.2/component.js", "e03c6bc9406c811e03e9bc2c39f43e6cc8c02d1615bd0e0b8ee1b38be6fe201c", []string{"api.packet.net", "packethost.github.io"}, false, false, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(PhoenixNAPDriver, "https://github.com/phoenixnap/docker-machine-driver-pnap/releases/download/v0.1.0/docker-machine-driver-pnap_0.1.0_linux_amd64.zip",
-		"", "5f25a7fbcaca0710b7290216464ca8433fa3d683b59d5e4e674bef2d0a3ff6c7", []string{"api.securedservers.com"}, false, false, management); err != nil {
+	if err := addMachineDriver(PhoenixNAPDriver, "https://github.com/phoenixnap/docker-machine-driver-pnap/releases/download/v0.1.0/docker-machine-driver-pnap_0.1.0_linux_amd64.zip", "", "5f25a7fbcaca0710b7290216464ca8433fa3d683b59d5e4e674bef2d0a3ff6c7", []string{"api.securedservers.com"}, false, false, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(RackspaceDriver, "local://", "", "", nil, false, true, management); err != nil {
+	if err := addMachineDriver(RackspaceDriver, "local://", "", "", nil, false, true, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(SoftLayerDriver, "local://", "", "", nil, false, true, management); err != nil {
+	if err := addMachineDriver(SoftLayerDriver, "local://", "", "", nil, false, true, false, management); err != nil {
 		return err
 	}
-	return addMachineDriver(Vmwaredriver, "local://", "", "", nil, true, true, management)
+	return addMachineDriver(Vmwaredriver, "local://", "", "", nil, true, true, false, management)
 }
 
-func addMachineDriver(name, url, uiURL, checksum string, whitelist []string, active, builtin bool, management *config.ManagementContext) error {
+func addMachineDriver(name, url, uiURL, checksum string, whitelist []string, active, builtin, addCloudCredential bool, management *config.ManagementContext) error {
 	lister := management.Management.NodeDrivers("").Controller().Lister()
 	cli := management.Management.NodeDrivers("")
 	m, _ := lister.Get("", name)
@@ -158,26 +147,29 @@ func addMachineDriver(name, url, uiURL, checksum string, whitelist []string, act
 	}
 	if m != nil {
 		old := machineDriverCompare{
-			builtin:     m.Spec.Builtin,
-			url:         m.Spec.URL,
-			uiURL:       m.Spec.UIURL,
-			checksum:    m.Spec.Checksum,
-			name:        m.Spec.DisplayName,
-			whitelist:   m.Spec.WhitelistDomains,
-			annotations: m.Annotations,
+			builtin:            m.Spec.Builtin,
+			addCloudCredential: m.Spec.AddCloudCredential,
+			url:                m.Spec.URL,
+			uiURL:              m.Spec.UIURL,
+			checksum:           m.Spec.Checksum,
+			name:               m.Spec.DisplayName,
+			whitelist:          m.Spec.WhitelistDomains,
+			annotations:        m.Annotations,
 		}
 		new := machineDriverCompare{
-			builtin:     builtin,
-			url:         url,
-			uiURL:       uiURL,
-			checksum:    checksum,
-			name:        name,
-			whitelist:   whitelist,
-			annotations: annotations,
+			builtin:            builtin,
+			addCloudCredential: addCloudCredential,
+			url:                url,
+			uiURL:              uiURL,
+			checksum:           checksum,
+			name:               name,
+			whitelist:          whitelist,
+			annotations:        annotations,
 		}
 		if !reflect.DeepEqual(new, old) {
 			logrus.Infof("Updating node driver %v", name)
 			m.Spec.Builtin = builtin
+			m.Spec.AddCloudCredential = addCloudCredential
 			m.Spec.URL = url
 			m.Spec.UIURL = uiURL
 			m.Spec.Checksum = checksum
@@ -197,13 +189,14 @@ func addMachineDriver(name, url, uiURL, checksum string, whitelist []string, act
 			Annotations: annotations,
 		},
 		Spec: v32.NodeDriverSpec{
-			Active:           active,
-			Builtin:          builtin,
-			URL:              url,
-			UIURL:            uiURL,
-			DisplayName:      name,
-			Checksum:         checksum,
-			WhitelistDomains: whitelist,
+			Active:             active,
+			Builtin:            builtin,
+			AddCloudCredential: addCloudCredential,
+			URL:                url,
+			UIURL:              uiURL,
+			DisplayName:        name,
+			Checksum:           checksum,
+			WhitelistDomains:   whitelist,
 		},
 	})
 


### PR DESCRIPTION
A previous PR (31548) added support for Google cloud credential.
However, this made the unsupported Google node driver active. In order
to deactivate the node driver and create the cloud credential schema for
the Google driver, a new field is added to the NodeDriverSpec:
AddCloudCredentialByDefault. If this is `true` for any node driver, then
the driver is downloaded, if necessary, and the cloud credential schema
created. This would work for any node driver, not just the built-ins.

Issue:
https://github.com/rancher/rancher/issues/31858