### PR TITLE
[2.5] Try to gunzip resbody when writing auditlogs

### DIFF
--- a/pkg/auth/audit/filter.go
+++ b/pkg/auth/audit/filter.go
@@ -72,7 +72,9 @@ func (h auditHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	wr := &wrapWriter{ResponseWriter: rw, auditWriter: h.auditWriter, statusCode: http.StatusOK}
 	h.next.ServeHTTP(wr, req)
 
-	auditLog.write(user, req.Header, wr.Header(), wr.statusCode, wr.buf.Bytes())
+	if err := auditLog.write(user, req.Header, wr.Header(), wr.statusCode, wr.buf.Bytes()); err != nil {
+		logrus.Errorf("Failed to write auditlog as err: %v", err)
+	}
 }
 
 type wrapWriter struct {


### PR DESCRIPTION
Due to the change of the v2.5 handler chain, auditlog may get the data compressed by the gzip handler, which will cause the json conversion to fail.

https://github.com/rancher/rancher/issues/31453