### PR TITLE
[v2.5] Fix for lastRefreshTime in clusterupstreamrefresher

### DIFF
--- a/pkg/controllers/management/clusterupstreamrefresher/cluster_upstream_refresher.go
+++ b/pkg/controllers/management/clusterupstreamrefresher/cluster_upstream_refresher.go
@@ -129,7 +129,7 @@ func getProviderRefreshInterval(provider string) (time.Duration, error) {
 // true when upstream cluster should be refreshed
 func shouldRefreshCluster(refreshInterval time.Duration, lastRefreshTime string) (bool, error) {
 	if lastRefreshTime == "" {
-		return false, fmt.Errorf("lastRefreshTime is required")
+		return false, nil
 	}
 
 	lastRefreshUnix, err := strconv.ParseInt(lastRefreshTime, 10, 64)


### PR DESCRIPTION
For the first time when clusterLastRefreshTime annotation doesn't
exist yet, don't report error about lastRefreshTime.

(cherry picked from commit f54aecb537baf18d86f0e6637187313d5c15f3d1)