### PR TITLE
[v2.5] Fix clusteroperator CAcert recorder

### DIFF
--- a/pkg/controllers/management/clusteroperator/utils.go
+++ b/pkg/controllers/management/clusteroperator/utils.go
@@ -1,7 +1,6 @@
 package clusteroperator
 
 import (
-	"encoding/base64"
 	"fmt"
 	"os"
 	"strings"
@@ -245,7 +244,7 @@ func (e *OperatorController) RecordCAAndAPIEndpoint(cluster *mgmtv3.Cluster) (*m
 			return err
 		}
 		currentCluster.Status.APIEndpoint = apiEndpoint
-		currentCluster.Status.CACert = base64.StdEncoding.EncodeToString(caSecret.Data["ca"])
+		currentCluster.Status.CACert = caCert
 		currentCluster, err = e.ClusterClient.Update(currentCluster)
 		return err
 	})


### PR DESCRIPTION
Without this change, the behavior of the CAcert recorder for the EKS
provisioner changed when the handlers for EKS and GKE were refactored
into a single clusteroperator package (a6f0b91b), causing the cert to be
recorded on the cluster status wrongly. This change reverts the common
package to use EKS's old behavior. The GKE operator will be updated to
work in the same way.

(cherry picked from commit 3250af61873c82b2fda9d90fdbd1eebcdfefa910)