### PR TITLE
[v2.5] Add /meta/gkeSharedSubnets and /meta/gkeClusters routes

### DIFF
--- a/pkg/api/norman/customization/gke/handler.go
+++ b/pkg/api/norman/customization/gke/handler.go
@@ -111,6 +111,20 @@ func (h *handler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 
 		}
 		writer.Write(serialized)
+	case "gkeClusters":
+		if serialized, errCode, err = listClusters(req.Context(), capa); err != nil {
+			logrus.Debugf("[gke-handler] error getting clusters: %v", err)
+			handleErr(writer, errCode, err)
+			return
+		}
+		writer.Write(serialized)
+	case "gkeSharedSubnets":
+		if serialized, errCode, err = listSharedSubnets(req.Context(), capa); err != nil {
+			logrus.Debugf("[gke-handler] error getting shared subnets: %v", err)
+			handleErr(writer, errCode, err)
+			return
+		}
+		writer.Write(serialized)
 	default:
 		handleErr(writer, httperror.NotFound.Status, fmt.Errorf("invalid endpoint %v", resourceType))
 	}


### PR DESCRIPTION
Add /meta/gkeClusters route

Add a route to list GKE clusters for the purpose of selecting one to
import.

The function can list either regional or zonal clusters. It rejects the
request if neither region nor zone are provided, and also if both
region and zone are provided.

https://github.com/rancher/rancher/issues/31461

---

Add /meta/gkeSharedSubnets route

Add a proxy route /meta/gkeSharedSubnets for querying usable subnets
shared to a service project, where the project ID provided in the URL
query is the service project. This call looks up the host project for
the provided service project, and uses that to look up the subnets that
are shared with the service project. See the `gcloud` command line
reference example[1].

The result of this query will resemble the following:

```
$ curl -k -u $TOKEN "https://localhost:8443/meta/gkeSharedSubnets?cloudCredentialId=cattle-global-data:cc-abcde&projectId=service-project-id" | jq .
{
  "subnetworks": [
    {
      "ipCidrRange": "10.1.0.0/24",
      "network": "projects/vpc-host-309518/global/networks/vpc-host-network",
      "secondaryIpRanges": [
        {
          "ipCidrRange": "10.2.0.0/21",
          "rangeName": "pods",
          "status": "UNUSED"
        },
        {
          "ipCidrRange": "10.3.0.0/21",
          "rangeName": "services",
          "status": "UNUSED"
        }
      ],
      "subnetwork": "projects/vpc-host-309518/regions/us-west1/subnetworks/vpc-host-subnet"
    }
  ]
}
```

The UI needs to use the full path of the network and subnetwork fields
returned from this response, as well as the names and CIDR ranges of the
secondary IP ranges, to create a cluster using a shared VPC subnet.

If the project is not part of a shared VPC structure, the request will
succeed but return null. The caller needs to call /meta/gkeNetworks and
/meta/gkeSubnetworks to get the project's own list of networks and
subnetworks.

[1] https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#verify_usable_subnets

https://github.com/rancher/rancher/issues/30864