### PR TITLE
[release/v2.5] Fix CIS scan when PNI is enabled

### DIFF
--- a/pkg/api/norman/customization/namespace/namespace.go
+++ b/pkg/api/norman/customization/namespace/namespace.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/norman/types/convert"
 	client "github.com/rancher/rancher/pkg/client/generated/cluster/v3"
 	"github.com/rancher/rancher/pkg/clustermanager"
+	"github.com/rancher/rancher/pkg/controllers/managementagent/nslabels"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/helm"
 	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/ref"
@@ -21,8 +22,7 @@ import (
 )
 
 var (
-	projectIDFieldLabel = "field.cattle.io/projectId"
-	namespaceOwnerMap   = cache.NewLRUExpireCache(1000)
+	namespaceOwnerMap = cache.NewLRUExpireCache(1000)
 )
 
 func updateNamespaceOwnerMap(apiContext *types.APIContext) error {
@@ -102,9 +102,10 @@ func (w ActionWrapper) ActionHandler(actionName string, action *types.Action, ap
 			return errors.New("namespace is currently being used")
 		}
 		if projectID == "" {
-			delete(ns.Annotations, projectIDFieldLabel)
+			delete(ns.Annotations, nslabels.ProjectIDFieldLabel)
+			delete(ns.Labels, nslabels.ProjectIDFieldLabel)
 		} else {
-			ns.Annotations[projectIDFieldLabel] = convert.ToString(actionInput["projectId"])
+			ns.Annotations[nslabels.ProjectIDFieldLabel] = convert.ToString(actionInput["projectId"])
 		}
 		if _, err := nsClient.Update(ns); err != nil {
 			return err

--- a/pkg/controllers/managementuser/networkpolicy/clusterHandler.go
+++ b/pkg/controllers/managementuser/networkpolicy/clusterHandler.go
@@ -128,13 +128,11 @@ func (ch *clusterHandler) createNetworkPolicies(cluster *v3.Cluster) error {
 	//skipping nssyncer, projectSyncer + nodehandler would result into handling nssyncer as well
 }
 
-const creatorLabel = "cattle.io/creator"
-
 // deleteNetworkPolicies removes Rancher created NetworkPolicy resources from the downstream cluster and
 // removes ProjectNetworkPolicy resources from the management cluster
 func (ch *clusterHandler) deleteNetworkPolicies(cluster *v3.Cluster) error {
 	// consider nps for deletion if they were created by Rancher, i.e. they have a label: "cattle.io/creator": "norman"
-	set := labels.Set(map[string]string{creatorLabel: "norman"})
+	set := labels.Set(map[string]string{creatorLabel: creatorNorman})
 	nps, err := ch.npmgr.npLister.List("", set.AsSelector())
 	if err != nil {
 		return fmt.Errorf("npLister: %v", err)

--- a/pkg/controllers/managementuser/networkpolicy/nssyncer.go
+++ b/pkg/controllers/managementuser/networkpolicy/nssyncer.go
@@ -65,8 +65,9 @@ func (nss *nsSyncer) syncOnMove(nsName string, projectID string, movedToNone boo
 		return fmt.Errorf("nsSyncer: error getting systemNamespaces %v", err)
 	}
 	if movedToNone {
-		nss.npmgr.delete(nsName, "np-default")
-		nss.npmgr.delete(nsName, "hn-nodes")
+		nss.npmgr.delete(nsName, defaultNamespacePolicyName)
+		nss.npmgr.delete(nsName, hostNetworkPolicyName)
+		nss.npmgr.delete(nsName, defaultSystemProjectNamespacePolicyName)
 	}
 	if err = nss.syncNodePortServices(systemNamespaces, nsName, movedToNone); err != nil {
 		return fmt.Errorf("nsSyncer: error syncing services %v", err)


### PR DESCRIPTION
Issue: 
- https://github.com/rancher/rancher/issues/30211

The fix is to add an "allow all traffic" NetworkPolicy resource to each system project namespace. See the linked issue for further details on the fix

Passing scan:
![cis-scan-with-pni](https://user-images.githubusercontent.com/8824599/114109707-ac62d880-988a-11eb-9a14-17703ab2830c.png)

Controller test cases:

### Namespace Creation

1. Create namespace in no project
    - Expected: no rancher network policies added
    - Result: [PASS]
2. Create namespace in default project
    - Expected: non system project network policies added, hn-nodes and np-default
    - Result: [PASS]
3. Create namespace in system project 
    - Expected: system project network policies added, np-default-allow-all
    - Result: [PASS]
4. Create new project and create namespace in it
    - Expected: non system project network policies added, hn-nodes and np-default
    - Result: [PASS]

### Namespace Moving

NOTE: I fixed a bug related to moving namespaces, and that fix is a pre-requisite for these tests.

1. Move namespace w/ no network policies from no project to non system project
    - Initial: no network policies
    - Expected: hn-nodes and np-default
    - Result: [PASS]
2. Move namespace w/ user network policies from no project to non system project
    - Initial: user network policies
    - Expected: hn-nodes and np-default added, user netowrk policies retained
    - Result: [PASS]
3. Move namespace w/ no network policies from no project to system project
    - Initial: no network policies
    - Expected: np-default-allow-all
    - Result: [PASS] 
4. Move namespace w/ user network policies from no project to system project
    - Initial: user network policies
    - Expected: np-default-allow-all not added, user network policies retained
    - Result: [PASS]
5. Move namespace w/ no user network policies from default project to system project
    - Initial: hn-nodes, np-default
    - Expected: hn-nodes and np-default deleted, np-default-allow-all added
    - Result: [PASS]
6. Move namespace w/ user network policies from default project to system project
    - Initial: hn-nodes, np-default, and user network policies
    - Expected: hn-nodes and np-default deleted, np-default-allow-all not added, user network policies retained
    - Result: [PASS]
7. Move namespace w/ no user network policies from system project to default project
    - Initial: np-default-allow-all
    - Expected: np-default-allow-all deleted, hn-nodes np-default added
    - Result: [PASS]
8. Move namespace w/ user network policies from system project to default project
    - Initial: user network policies
    - Expected: hn-nodes np-default added, user network policies retained
    - Result: [PASS]

### Namespace Deletion

All of these cases work because the network policies are namespace scoped and will get deleted with the namespace.