### PR TITLE
Add k3sconfig validation

### DIFF
--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -248,6 +248,12 @@ func (v *Validator) validateK3sBasedVersionUpgrade(request *types.APIContext, sp
 		return err
 	}
 
+	if isK3s && cluster.Spec.K3sConfig == nil {
+		// prevents embedded cluster from have k3sConfig set. Embedded cluster cannot be upgraded. Non-embedded
+		// clusters' config will be set my controller.
+		return httperror.NewAPIError(httperror.InvalidBodyContent, "k3sConfig cannot be changed from nil")
+	}
+
 	// must wait for original status version to be set
 	if cluster.Status.Version == nil {
 		return upgradeNotReadyErr


### PR DESCRIPTION
**Problem:**
 Prior, it could be
set which is invalid because it is expected it will be initialized by a controller when it is detected that a cluster is a k3s cluster and the cluster is not embedded. This made it possible to set the k3sConfig and attempt upgrade an embedded k3s cluster, which is not possible.

**Solution:**
Validation has been added to prevent a k3sConfig being set on a cluster that does not have one set already.

**Issue:**
https://github.com/rancher/rancher/issues/30977