### PR TITLE
pkg/data/management: fix dropped error

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -501,6 +501,9 @@ func BootstrapAdmin(management *wrangler.Context, createClusterRoleBinding bool)
 			users, err := management.Mgmt.User().List(v1.ListOptions{
 				LabelSelector: set.String(),
 			})
+			if err != nil {
+				return "", err
+			}
 
 			bindings, err := management.RBAC.ClusterRoleBinding().List(v1.ListOptions{LabelSelector: set.String()})
 			if err != nil {


### PR DESCRIPTION
This fixes a dropped error variable in `pkg/data/management`.