### PR TITLE
Rely on Windows manifests instead of manual tags

### DIFF
--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -788,15 +788,19 @@ if (-not (Test-Path $image_list))
 
 $fullname_images = @()
 Get-Content -Force -Path $image_list | ForEach-Object {
-    if ($_) {
-        $fullname_image = ('{0}-windows-{1}' -f $_, $os_release_id)
-		echo "Pulling $fullname_image"
-		
+	if ($_) {
+		$fullname_image = $_
+		echo "Pulling: $fullname_image"
 		docker pull $fullname_image
+		if (!$?) {
+			$fullname_image = ('{0}-windows-{1}' -f $fullname_image, $os_release_id)
+			echo "Pulling with windows-VERSION suffix: $fullname_image"
+			docker pull $fullname_image
+		}
 		if ($?) {
 			$fullname_images += @($fullname_image)
 		}
-    }
+	}
 }
 
 if (-not $fullname_images)


### PR DESCRIPTION
~~This is a greedy solution that falls back to `-amd64` if the first pull without the arch is unsuccessful.~~

EDIT: talked out a better solution with @luthermonson. We will now assume there is a manifest since the original implementation predates manifests with Windows, but if an error occurs, we will fallback to the old method.

Relevant issues:
- https://github.com/rancher/rancher/issues/32016
- https://github.com/rancher/rancher/issues/28721

Proof of concept:
```powershell
PS > 1,2,3 | %{ $foo = $_; write-host $foo }
1
2
3
```