### PR TITLE
[v2.5] remove docker 1.10 cli from agent

### DIFF
--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -4,16 +4,11 @@ FROM ${RANCHER_REPO}/rancher:${RANCHER_TAG} as rancher
 
 FROM ubuntu:18.04
 ARG ARCH=amd64
-ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
-    DOCKER_URL_arm64=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64 \
-    DOCKER_URL=DOCKER_URL_${ARCH}
 
 RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 ENV KUBECTL_VERSION v1.19.7
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git curl ca-certificates jq iproute2 vim-tiny less bash-completion unzip sysstat acl ssh && \
-    curl -sLf ${!DOCKER_URL} > /usr/bin/docker && \
-    chmod +x /usr/bin/docker && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl && \
     DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
@@ -26,7 +21,6 @@ ENV KUBEPROMPT_VERSION v1.0.10
 RUN curl -sL https://github.com/c-bata/kube-prompt/releases/download/${KUBEPROMPT_VERSION}/kube-prompt_${KUBEPROMPT_VERSION}_linux_${ARCH}.zip > /usr/bin/kube-prompt.zip && unzip /usr/bin/kube-prompt.zip -d /usr/bin
 ARG VERSION=dev
 LABEL io.cattle.agent true
-ENV DOCKER_API_VERSION 1.24
 ENV AGENT_IMAGE rancher/rancher-agent:${VERSION}
 ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
 COPY --from=rancher /var/lib/rancher-data /var/lib/rancher-data

--- a/package/share-root.sh
+++ b/package/share-root.sh
@@ -2,7 +2,4 @@
 set -x
 
 trap 'exit 0' SIGTERM
-ID=$(grep :devices: /proc/self/cgroup | head -n1 | awk -F/ '{print $NF}' | sed -e 's/docker-\(.*\)\.scope/\1/')
 bash -c "$1"
-
-docker kill --signal=SIGTERM $ID


### PR DESCRIPTION
We are abusing the downloads of the docker 1.10 cli as we only use it in one scenario which is basically deprecated. Basically this was a fix for non-shared mounted root directories. We are more or less convinced this isn't a thing any more so we're dropping this shared-mount.sh fix as it was the only thing actually using the docker cli in the agent.

To confirm your linux distro is fine you do a quick 

```
findmnt -o TARGET,PROPAGATION /
```

and you should see

```
TARGET PROPAGATION
/      shared
```

https://github.com/rancher/rancher/issues/32052