### PR TITLE
[v2.5] Add Imported field to GKE upstream spec builder

### DIFF
--- a/pkg/controllers/management/clusterupstreamrefresher/gke_upstream_spec.go
+++ b/pkg/controllers/management/clusterupstreamrefresher/gke_upstream_spec.go
@@ -25,6 +25,7 @@ func BuildGKEUpstreamSpec(secretsCache wranglerv1.SecretCache, cluster *mgmtv3.C
 	upstreamSpec.Zone = cluster.Spec.GKEConfig.Zone
 	upstreamSpec.GoogleCredentialSecret = cluster.Spec.GKEConfig.GoogleCredentialSecret
 	upstreamSpec.ProjectID = cluster.Spec.GKEConfig.ProjectID
+	upstreamSpec.Imported = cluster.Spec.GKEConfig.Imported
 
 	return upstreamSpec, nil
 }


### PR DESCRIPTION
Without this patch, if a GKE cluster is imported to Rancher, and then a
change from GKE is synced back to the cluster in Rancher, "imported"
will flip back to false, and the guard in gke-operator that prevents
sending a DELETE request to imported clusters that are removed from
Rancher gets thwarted. This change fixes the upstream spec builder
function in the cluster refresher to always use the config spec value
for the Imported attribute.

https://github.com/rancher/rancher/issues/32065