### PR TITLE
[v2.5] Do not set unknown condition for creating cluster

### DIFF
--- a/pkg/controllers/management/clusteroperator/utils.go
+++ b/pkg/controllers/management/clusteroperator/utils.go
@@ -147,7 +147,7 @@ func (e *OperatorController) SetUnknown(cluster *mgmtv3.Cluster, condition condi
 	var err error
 	cluster, err = e.ClusterClient.Update(cluster)
 	if err != nil {
-		return cluster, fmt.Errorf("failed setting cluster [%s] condition %s unknown with message: %s", cluster.Name, condition, message)
+		return cluster, err
 	}
 	return cluster, nil
 }
@@ -162,7 +162,7 @@ func (e *OperatorController) SetTrue(cluster *mgmtv3.Cluster, condition conditio
 	var err error
 	cluster, err = e.ClusterClient.Update(cluster)
 	if err != nil {
-		return cluster, fmt.Errorf("failed setting cluster [%s] condition %s true with message: %s", cluster.Name, condition, message)
+		return cluster, err
 	}
 	return cluster, nil
 }
@@ -177,7 +177,7 @@ func (e *OperatorController) SetFalse(cluster *mgmtv3.Cluster, condition conditi
 	var err error
 	cluster, err = e.ClusterClient.Update(cluster)
 	if err != nil {
-		return cluster, fmt.Errorf("failed setting cluster [%s] condition %s false with message: %s", cluster.Name, condition, message)
+		return cluster, err
 	}
 	return cluster, nil
 }

--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -160,12 +160,6 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 	}
 	switch phase {
 	case "creating":
-		// set provisioning to unknown
-		cluster, err = e.SetUnknown(cluster, apimgmtv3.ClusterConditionProvisioned, "")
-		if err != nil {
-			return cluster, err
-		}
-
 		if cluster.Status.EKSStatus.UpstreamSpec == nil {
 			cluster, err = e.setInitialUpstreamSpec(cluster)
 			if err != nil {

--- a/pkg/controllers/management/gke/gke_cluster_handler.go
+++ b/pkg/controllers/management/gke/gke_cluster_handler.go
@@ -153,12 +153,6 @@ func (e *gkeOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 
 	switch phase {
 	case "creating":
-		// set provisioning to unknown
-		cluster, err = e.SetUnknown(cluster, apimgmtv3.ClusterConditionProvisioned, "")
-		if err != nil {
-			return cluster, err
-		}
-
 		if cluster.Status.GKEStatus.UpstreamSpec == nil {
 			cluster, err = e.setInitialUpstreamSpec(cluster)
 			if err != nil {


### PR DESCRIPTION
Without this change, if a GKE cluster creation fails for some GKE-side
reason, the state of the cluster object will appear to rapidly flip
between provisioning and failed, and the Rancher logs will be filled
with a constant stream of messages:

  2021/04/13 10:15:43 [ERROR] error syncing 'c-tcc2p': handler gke-operator-controller: failed setting cluster [] condition Provisioned false with message: creation failed for cluster cluster-name, requeuing

This is a confusing UI behavior and the volume of logs emitted has the
potential to generate large log files unexpectedly quickly.

This change removes the initial status update during the "creating"
phase. The Provisioning condition will be set a few lines later to
either Unknown or False, so the initial status update request is
superfluous. Removing it prevents a case where the cluster object might
be have been modified and the condition status cannot be set, which
causes the onClusterChange handler to error out without calling
`e.ClusterEnqueueAfter(cluster.Name, enqueueTime)` and so causes the the
handler to re-run repeatedly without a delay.

The problem was observed for GKE clusters but this fix applies to both
EKS and GKE.

This change also fixes the SetUnknown/SetFalse/SetTrue helper functions
to return the update error if there is one, instead of returning an
error string with the context of the error but not the error itself, so
that when update conflicts happen it's no longer hidden.

https://github.com/rancher/rancher/issues/32087