### PR TITLE
Scan released directory for images

### DIFF
--- a/scripts/package
+++ b/scripts/package
@@ -43,7 +43,7 @@ if [ ! -d build/system-charts ]; then
     git clone --depth=1 --no-tags --branch $SYSTEM_CHART_DEFAULT_BRANCH https://github.com/rancher/system-charts $SYSTEM_CHART_REPO_DIR
 fi
 
-if [ ! -d build/charts ]; then
+if [ ! -d $CHART_REPO_DIR ]; then
     INDEX_PATH=$CHART_REPO_DIR/index.yaml
     git clone --branch $CHART_DEFAULT_BRANCH https://github.com/rancher/charts $CHART_REPO_DIR
 
@@ -53,11 +53,13 @@ if [ ! -d build/charts ]; then
     # Extract the tarballs in the list, skip extracting CRD charts
     for TGZ_PATH in $LATEST_TGZ_PATHS; do
         TGZ_REL_PATH=$CHART_REPO_DIR/$TGZ_PATH
+        TGZ_EXTRACT_PATH=$(dirname $CHART_REPO_DIR/${TGZ_PATH##released/})
         if [[ $TGZ_PATH == *crd*.tgz ]]; then
             echo "Skipped CRD: $TGZ_REL_PATH"
         else
-            echo "Extract: $TGZ_REL_PATH"
-            tar -xf $TGZ_REL_PATH -C $(dirname $TGZ_REL_PATH)
+            echo "Extract: $TGZ_REL_PATH to $TGZ_EXTRACT_PATH"
+            mkdir -p $TGZ_EXTRACT_PATH
+            tar -xf $TGZ_REL_PATH -C $TGZ_EXTRACT_PATH
         fi
     done
 


### PR DESCRIPTION
Some of the images in rancher/charts index.yaml file are linked via the
released/assets directory instead of just the assets directory. Any of
these images in the released directory were not getting scanned by the
image exporter because the package script is explicitly using the assets
directory.

Now, in the case that the index.yaml file links to the released/
directory, the tarfile is explicitly extracted to the assets directory
to be included in the export.

Co-authored-by: Brenda Rearden <brenda@rancher.com>

Issue:
https://github.com/rancher/rancher/issues/31995