### PR TITLE
[master] Update rancher-images generator to support system charts min/max

### DIFF
--- a/pkg/api/norman/customization/kontainerdriver/actionhandler.go
+++ b/pkg/api/norman/customization/kontainerdriver/actionhandler.go
@@ -158,16 +158,17 @@ func (lh ListHandler) LinkHandler(apiContext *types.APIContext, next types.Reque
 	}
 	systemCatalogHash := helmlib.CatalogSHA256Hash(systemCatalog)
 	systemCatalogChartPath := filepath.Join(helmlib.CatalogCache, systemCatalogHash)
+	rancherVersion := kd.GetRancherVersion()
 
 	var targetImages []string
 	switch apiContext.ID {
 	case linuxImages:
-		targetImages, _, err = image.GetImages(systemCatalogChartPath, "", []string{}, []string{}, rkeSysImages, image.Linux)
+		targetImages, _, err = image.GetImages(systemCatalogChartPath, "", rancherVersion, []string{}, []string{}, rkeSysImages, image.Linux)
 		if err != nil {
 			return httperror.WrapAPIError(err, httperror.ServerError, "error getting image list for linux platform")
 		}
 	case windowsImages:
-		targetImages, _, err = image.GetImages(systemCatalogChartPath, "", []string{}, []string{}, rkeSysImages, image.Windows)
+		targetImages, _, err = image.GetImages(systemCatalogChartPath, "", rancherVersion, []string{}, []string{}, rkeSysImages, image.Windows)
 		if err != nil {
 			return httperror.WrapAPIError(err, httperror.ServerError, "error getting image list for windows platform")
 		}

--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -91,12 +91,12 @@ func run(systemChartPath, chartPath string, imagesFromArgs []string) error {
 
 	k3sUpgradeImages := getK3sUpgradeImages(rancherVersion, data.K3S)
 
-	targetImages, targetImagesAndSources, err := img.GetImages(systemChartPath, chartPath, k3sUpgradeImages, imagesFromArgs, linuxInfo.RKESystemImages, img.Linux)
+	targetImages, targetImagesAndSources, err := img.GetImages(systemChartPath, chartPath, rancherVersion, k3sUpgradeImages, imagesFromArgs, linuxInfo.RKESystemImages, img.Linux)
 	if err != nil {
 		return err
 	}
 
-	targetWindowsImages, targetWindowsImagesAndSources, err := img.GetImages(systemChartPath, chartPath, []string{}, []string{getWindowsAgentImage()}, windowsInfo.RKESystemImages, img.Windows)
+	targetWindowsImages, targetWindowsImagesAndSources, err := img.GetImages(systemChartPath, chartPath, rancherVersion, []string{}, []string{getWindowsAgentImage()}, windowsInfo.RKESystemImages, img.Windows)
 	if err != nil {
 		return err
 	}

--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -226,8 +226,6 @@ func imagesText(arch string, targetImages []string) error {
 		if err != nil {
 			return err
 		}
-
-		log.Println("Image:", image)
 		fmt.Fprintln(save, image)
 	}
 

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -3,6 +3,7 @@ package image
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -151,13 +152,15 @@ func pickImagesFromValuesYAML(imagesSet map[string]map[string]bool, chartVersion
 		return err
 	}
 
+	var imagesFound []string
 	walkthroughMap(chartValues, func(inputMap map[interface{}]interface{}) {
-		generateImages(chartNameAndVersion, inputMap, imagesSet, osType)
+		generateImages(chartNameAndVersion, inputMap, imagesSet, &imagesFound, osType)
 	})
+	log.Printf("Images found in %s: %+v", path, imagesFound)
 	return nil
 }
 
-func generateImages(chartNameAndVersion string, inputMap map[interface{}]interface{}, output map[string]map[string]bool, osType OSType) {
+func generateImages(chartNameAndVersion string, inputMap map[interface{}]interface{}, output map[string]map[string]bool, imagesFound *[]string, osType OSType) {
 	repo, ok := inputMap["repository"].(string)
 	if !ok {
 		return
@@ -168,6 +171,7 @@ func generateImages(chartNameAndVersion string, inputMap map[interface{}]interfa
 	}
 
 	imageName := fmt.Sprintf("%s:%v", repo, tag)
+	*imagesFound = append(*imagesFound, imageName)
 
 	// By default, images are added to the generic images list ("linux"). For Windows and multi-OS
 	// images to be considered, they must use a comma-delineated list (e.g. "os: windows",


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/31568

Some definitions before the explanation to make sure it's clear
chart = rancher-monitoring, rancher-logging, etc
version = rancher-monitoring/0.1.0, rancher-logging/v0.1.0

This PR adds support to the rancher-images.txt generator to pick images in system charts based on the `rancher_min_version` and `rancher_max_version` set in the questions.yaml.

Old behavior:
Pick images from the latest version of each chart only

New behavior:
Pick images from the latest version of each chart regardless of min/max and rancherVersion.
If the rancherVersion is a valid semver, then pick images of the remaining versions based on their min/max. A questions.yaml with a `rancher_min_version` is now required, whereas `rancher_max_version` remains optional. We change the rancherVersion to 2.6.99 (set somewhere in kdm) when it runs as dev or master, so the only case this doesn't execute is when rancherVersion is an empty string or a commit hash.

Testing:
Ran a local drone build with tag v2.5.8-rc4 before and after my changes (including changes from [this PR](https://github.com/rancher/system-charts/pull/444) to update missing min/max in system charts): [diff here](https://www.diffchecker.com/Tgukkypq) (expires in 30 days from 4/15/2021). Images added are from rancher-monitoring v1 v0.1.5

Commit `Update rancher images generator logging`: Changes in this commit can be removed if you as a reviewer don't like it. I added a log a while back so that we could see in the drone's logs which images are being added to the file, but this is not helpful because we are logging them right before we write to the rancher-images.txt file and you could just check the file. The new log will print the images found in each chart and subchart, and the path to the `values.yaml` where they were found which I believe to be a lot more helpful when debugging issues related to missing images.
Old log example:
```
2021/04/12 17:29:47 Image: rancher/pipeline-jenkins-server:v0.1.4
2021/04/12 17:29:47 Image: rancher/pipeline-tools:v0.1.15
2021/04/12 17:29:47 Image: rancher/prom-alertmanager:v0.21.0
```
New log example:
```
2021/04/06 15:23:52 Images found in testbuild/system-charts/charts/rancher-external-dns/v0.1.2/values.yaml: [rancher/kubernetes-external-dns:v0.7.3]
2021/04/06 15:23:53 Images found in testbuild/system-charts/charts/rancher-gatekeeper-operator/0.1.0/values.yaml: [rancher/istio-kubectl:1.4.6 rancher/opa-gatekeeper:v3.1.0-beta.7]
2021/04/06 15:23:55 Images found in testbuild/system-charts/charts/rancher-gke-operator/1.0.100/values.yaml: [rancher/gke-operator:v1.0.1-rc4]
2021/04/06 15:23:55 Images found in testbuild/system-charts/charts/rancher-istio/1.5.901/charts/certmanager/values.yaml: []
```