### PR TITLE
[2.5] Handle already exists errors during startup

### DIFF
--- a/pkg/controllers/dashboardapi/settings/settings.go
+++ b/pkg/controllers/dashboardapi/settings/settings.go
@@ -106,7 +106,9 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 			}
 			if s.install {
 				_, err := s.settings.Create(newSetting)
-				if err != nil {
+				// Rancher will race in an HA setup to try and create the settings
+				// so if it exists just move on.
+				if err != nil && !errors.IsAlreadyExists(err) {
 					return err
 				}
 			}

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -22,9 +22,11 @@ import (
 	"github.com/rancher/wrangler/pkg/generated/controllers/core"
 	corev1controllers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
@@ -57,8 +59,26 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 
 	migrateConfig(ctx, restConfig, opts)
 
-	if err := server.ListenAndServe(ctx, httpsPort, httpPort, handler, opts); err != nil {
-		return err
+	backoff := wait.Backoff{
+		Duration: 100 * time.Millisecond,
+		Factor:   2,
+		Steps:    3,
+	}
+
+	// Try listen and serve over if there is an already exist error which comes from
+	// creating the ca. Rancher will hit this error during HA startup as all servers
+	// will race to create the ca secret.
+	err = wait.ExponentialBackoff(backoff, func() (bool, error) {
+		if err := server.ListenAndServe(ctx, httpsPort, httpPort, handler, opts); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to ListenAndServe")
 	}
 
 	internalPort := 0
@@ -66,15 +86,26 @@ func ListenAndServe(ctx context.Context, restConfig *rest.Config, handler http.H
 		internalPort = httpsPort + 1
 	}
 
-	if err := server.ListenAndServe(ctx, internalPort, 0, handler, &server.ListenOpts{
+	serverOptions := &server.ListenOpts{
 		Storage:       opts.Storage,
 		Secrets:       opts.Secrets,
 		CAName:        "tls-rancher-internal-ca",
 		CANamespace:   "cattle-system",
 		CertNamespace: "cattle-system",
 		CertName:      "tls-rancher-internal",
-	}); err != nil {
-		return err
+	}
+
+	err = wait.ExponentialBackoff(backoff, func() (bool, error) {
+		if err := server.ListenAndServe(ctx, internalPort, 0, handler, serverOptions); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to ListenAndServe for fleet")
 	}
 
 	if err := core.Start(ctx, 5); err != nil {


### PR DESCRIPTION
Problem:
In an HA setup ranchers will race to attempt to create things, including
settings and ca cert secrets. This can cause rancher to fatal and
restart the pod.

Solution:
Handle the error and either try again in the case of setting up
listeners or ignore it when creating settings.

https://github.com/rancher/rancher/issues/32116