### PR TITLE
[master] Handle already exists errors during startup

### DIFF
--- a/pkg/controllers/dashboardapi/settings/settings.go
+++ b/pkg/controllers/dashboardapi/settings/settings.go
@@ -103,7 +103,9 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 				fallback[newSetting.Name] = newSetting.Value
 			}
 			_, err := s.settings.Create(newSetting)
-			if err != nil {
+			// Rancher will race in an HA setup to try and create the settings
+			// so if it exists just move on.
+			if err != nil && !errors.IsAlreadyExists(err) {
 				return err
 			}
 		} else if err != nil {


### PR DESCRIPTION
Problem:
In an HA setup ranchers will race to attempt to create things, including
settings and ca cert secrets. This can cause rancher to fatal and
restart the pod.

Solution:
Handle the error and either try again in the case of setting up
listeners or ignore it when creating settings.

https://github.com/rancher/rancher/issues/32116
forward port of https://github.com/rancher/rancher/pull/32163