### PR TITLE
[v2.5] Add linux node pool GKE cluster validator

### DIFF
--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -656,6 +656,7 @@ func validateGKENodePools(spec *v32.ClusterSpec) error {
 	}
 
 	var errors []string
+	hasRequiredLinuxPool := false
 
 	for _, np := range nodepools {
 		name := *np.Name
@@ -668,6 +669,15 @@ func validateGKENodePools(spec *v32.ClusterSpec) error {
 			errors = append(errors, fmt.Sprintf("node pool [%s] version cannot be empty", name))
 			continue
 		}
+
+		// Windows images are WINDOWS_LTSC or WINDOWS_SAC. The cluster must have at least one non-Windows node pool.
+		if !hasRequiredLinuxPool && !strings.Contains(strings.ToLower(np.Config.ImageType), "windows") {
+			hasRequiredLinuxPool = true
+		}
+	}
+
+	if !hasRequiredLinuxPool {
+		errors = append(errors, fmt.Sprintf("at least 1 Linux node pool is required"))
 	}
 
 	if len(errors) != 0 {


### PR DESCRIPTION
Windows is a supported image type for GKE node pools, but it can't be
the only type of node pool in the cluster. Without this change, it's
possible to send a cluster create or update request for an invalid
cluster with only Windows node pools. For create requests this is not
much of a problem, because GKE will send an HTTP 400 response and the
user can recreate the cluster with the correct configuration. It causes
more of a problem if the user starts with a valid cluster and then sends
an update request to delete the non-Windows node pools. Because of how
syncing works, the state of the cluster object will only reflect the
invalid Windows-only node pool configuration instead of the real state
of the cluster, so the mistake cannot be corrected. The solution is to
ensure this kind of invalid request never gets made by ensuring the
cluster object has at least one non-Linux node pool.

https://github.com/rancher/rancher/issues/32161