### PR TITLE
[release/v2.5] Deletion fix for HostPort and NodePort NetworkPolicy resources

### DIFF
--- a/pkg/controllers/managementuser/networkpolicy/podhandler.go
+++ b/pkg/controllers/managementuser/networkpolicy/podhandler.go
@@ -147,6 +147,9 @@ func generatePodNetworkPolicy(pod *corev1.Pod, policyName string) *knetworkingv1
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyName,
 			Namespace: pod.Namespace,
+			Labels: map[string]string{
+				creatorLabel: creatorNorman,
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: "v1",

--- a/pkg/controllers/managementuser/networkpolicy/servicehandler.go
+++ b/pkg/controllers/managementuser/networkpolicy/servicehandler.go
@@ -87,6 +87,9 @@ func generateServiceNetworkPolicy(service *corev1.Service, policyName string) *k
 		ObjectMeta: v1.ObjectMeta{
 			Name:      policyName,
 			Namespace: service.Namespace,
+			Labels: map[string]string{
+				creatorLabel: creatorNorman,
+			},
 			OwnerReferences: []v1.OwnerReference{
 				{
 					APIVersion: "v1",


### PR DESCRIPTION
Issue:
- https://github.com/rancher/rancher/issues/30135

The HostPort and NodePort specific policies were not getting the label: `cattle.io/creator: norman` added when they are created. Fix this by specifying the label in the policy generation code. This will ensure the label is always there and the policies get deleted when PNI is disabled. 