### PR TITLE
Pass  the config from scaledContext to the bindings cleanup code 

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -59,7 +59,7 @@ func main() {
 	if os.Getenv("CLUSTER_CLEANUP") == "true" {
 		err = clean.Cluster()
 	} else if os.Getenv("BINDING_CLEANUP") == "true" {
-		err = clean.Bindings()
+		err = clean.Bindings(nil)
 	} else {
 		err = run()
 	}

--- a/pkg/agent/clean/binding_windows.go
+++ b/pkg/agent/clean/binding_windows.go
@@ -1,5 +1,9 @@
 package clean
 
-func Bindings() error {
+import (
+	restclient "k8s.io/client-go/rest"
+)
+
+func Bindings(clientConfig *restclient.Config) error {
 	return nil
 }

--- a/pkg/data/management/bindings_cleanup.go
+++ b/pkg/data/management/bindings_cleanup.go
@@ -3,15 +3,15 @@ package management
 import (
 	"context"
 
+	"github.com/rancher/rancher/pkg/agent/clean"
+	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/rancher/rancher/pkg/agent/clean"
-	"github.com/rancher/rancher/pkg/wrangler"
 )
 
-func CleanupDuplicateBindings(wContext *wrangler.Context) {
+func CleanupDuplicateBindings(scaledContext *config.ScaledContext, wContext *wrangler.Context) {
 	//check if duplicate binding cleanup has run already
 	logrus.Info("CleanupDuplicateBindings, checking configmap")
 	if adminConfig, err := wContext.K8s.CoreV1().ConfigMaps(cattleNamespace).Get(context.TODO(), bootstrapAdminConfig, v1.GetOptions{}); err != nil {
@@ -28,7 +28,7 @@ func CleanupDuplicateBindings(wContext *wrangler.Context) {
 		}
 		// run cleanup
 		logrus.Info("Calling Duplicate CRB and RB cleanup")
-		err = clean.Bindings()
+		err = clean.Bindings(&scaledContext.RESTConfig)
 		if err != nil {
 			logrus.Warnf("Error in cleaning up Duplicate CRB and RB: %v", err)
 			return

--- a/pkg/multiclustermanager/app.go
+++ b/pkg/multiclustermanager/app.go
@@ -211,7 +211,7 @@ func (m *mcm) Start(ctx context.Context) error {
 		providerrefresh.StartRefreshDaemon(ctx, m.ScaledContext, management)
 		managementdata.CleanupOrphanedSystemUsers(ctx, management)
 		clusterupstreamrefresher.MigrateEksRefreshCronSetting(m.wranglerContext)
-		managementdata.CleanupDuplicateBindings(m.wranglerContext)
+		managementdata.CleanupDuplicateBindings(m.ScaledContext, m.wranglerContext)
 		logrus.Infof("Rancher startup complete")
 		return nil
 	})


### PR DESCRIPTION
For standalone setups the inclusterconfig is not found hence the config from rancher's scaledcontext should be passed.

https://github.com/rancher/rancher/issues/32105

Tested with standalone, HA setups as well as the agent cleanup script.