### PR TITLE
Images txt should not source blank image strings

### DIFF
--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -137,6 +137,9 @@ func generateImages(chartNameAndVersion string, inputMap map[interface{}]interfa
 }
 
 func addSourceToImage(imagesSet map[string]map[string]bool, image string, sources ...string) {
+	if image == "" {
+		return
+	}
 	if imagesSet[image] == nil {
 		imagesSet[image] = make(map[string]bool)
 	}


### PR DESCRIPTION
If you don't pass in a imageArg (like the agent) and don't set REPO env param you will error out the script. But this could happen for other reasons, and if so we should ignore the image.