### PR TITLE
[2.5] Fix Chart Repo shouldRefresh logic for inconsistent repo definitions

### DIFF
--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -198,7 +198,7 @@ func (r *repoHandler) download(repoSpec *catalog.RepoSpec, status catalog.RepoSt
 }
 
 func shouldRefresh(spec *catalog.RepoSpec, status *catalog.RepoStatus) bool {
-	if status.Branch != spec.GitBranch {
+	if spec.GitRepo != "" && status.Branch != spec.GitBranch {
 		return true
 	}
 	if spec.URL != "" && spec.URL != status.URL {

--- a/pkg/controllers/dashboard/helm/repo_test.go
+++ b/pkg/controllers/dashboard/helm/repo_test.go
@@ -1,0 +1,211 @@
+package helm
+
+import (
+	"testing"
+	"time"
+
+	catalog "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestShouldRefresh(t *testing.T) {
+	tests := []struct {
+		name           string
+		spec           *catalog.RepoSpec
+		status         *catalog.RepoStatus
+		expectedResult bool
+	}{
+		{
+			"http repo - spec equals status",
+			&catalog.RepoSpec{
+				URL: "https://example.com",
+			},
+			&catalog.RepoStatus{
+				URL:                "https://example.com",
+				IndexConfigMapName: "configmap",
+				DownloadTime: metav1.Time{
+					Time: time.Now(),
+				},
+			},
+			false,
+		},
+		{
+			"http repo - url changed",
+			&catalog.RepoSpec{
+				URL: "https://changed-url.com",
+			},
+			&catalog.RepoStatus{
+				URL:                "https://example.com",
+				IndexConfigMapName: "configmap",
+				DownloadTime: metav1.Time{
+					Time: time.Now(),
+				},
+			},
+			true,
+		},
+		{
+			"http repo - missing indexConfigMap",
+			&catalog.RepoSpec{
+				URL: "https://example.com",
+			},
+			&catalog.RepoStatus{
+				URL:                "https://example.com",
+				IndexConfigMapName: "",
+				DownloadTime: metav1.Time{
+					Time: time.Now(),
+				},
+			},
+			true,
+		},
+		{
+			"http repo - download not so long ago",
+			&catalog.RepoSpec{
+				URL: "https://example.com",
+			},
+			&catalog.RepoStatus{
+				URL:                "https://example.com",
+				IndexConfigMapName: "configmap",
+				DownloadTime: metav1.Time{
+					Time: time.Now().Add(-1 * time.Minute),
+				},
+			},
+			false,
+		},
+		{
+			"http repo - download to long ago",
+			&catalog.RepoSpec{
+				URL: "https://example.com",
+			},
+			&catalog.RepoStatus{
+				URL:                "https://example.com",
+				IndexConfigMapName: "configmap",
+				DownloadTime: metav1.Time{
+					Time: time.Now().Add(-6 * time.Minute),
+				},
+			},
+			true,
+		},
+		{
+			"http repo - force update",
+			&catalog.RepoSpec{
+				URL: "https://example.com",
+				ForceUpdate: &metav1.Time{
+					Time: time.Now(),
+				},
+			},
+			&catalog.RepoStatus{
+				URL:                "https://example.com",
+				IndexConfigMapName: "configmap",
+				DownloadTime: metav1.Time{
+					Time: time.Now().Add(-1 * time.Minute),
+				},
+			},
+			true,
+		},
+		{
+			"http repo - force update older than download time",
+			&catalog.RepoSpec{
+				URL: "https://example.com",
+				ForceUpdate: &metav1.Time{
+					Time: time.Now().Add(-2 * time.Minute),
+				},
+			},
+			&catalog.RepoStatus{
+				URL:                "https://example.com",
+				IndexConfigMapName: "configmap",
+				DownloadTime: metav1.Time{
+					Time: time.Now().Add(-1 * time.Minute),
+				},
+			},
+			false,
+		},
+		{
+			"http repo - force update in the future",
+			&catalog.RepoSpec{
+				URL: "https://example.com",
+				ForceUpdate: &metav1.Time{
+					Time: time.Now().Add(2 * time.Minute),
+				},
+			},
+			&catalog.RepoStatus{
+				URL:                "https://example.com",
+				IndexConfigMapName: "configmap",
+				DownloadTime: metav1.Time{
+					Time: time.Now(),
+				},
+			},
+			false,
+		},
+		{
+			"git repo - spec equals status",
+			&catalog.RepoSpec{
+				GitBranch: "master",
+				GitRepo:   "git.example.com",
+			},
+			&catalog.RepoStatus{
+				Branch:             "master",
+				URL:                "git.example.com",
+				IndexConfigMapName: "configmap",
+				DownloadTime: metav1.Time{
+					Time: time.Now(),
+				},
+			},
+			false,
+		},
+		{
+			"git repo - branch changed",
+			&catalog.RepoSpec{
+				GitBranch: "main",
+				GitRepo:   "git.example.com",
+			},
+			&catalog.RepoStatus{
+				Branch:             "master",
+				URL:                "git.example.com",
+				IndexConfigMapName: "configmap",
+				DownloadTime: metav1.Time{
+					Time: time.Now(),
+				},
+			},
+			true,
+		},
+		{
+			"git repo - repo changed",
+			&catalog.RepoSpec{
+				GitBranch: "master",
+				GitRepo:   "newgit.example.com",
+			},
+			&catalog.RepoStatus{
+				Branch:             "master",
+				URL:                "git.example.com",
+				IndexConfigMapName: "configmap",
+				DownloadTime: metav1.Time{
+					Time: time.Now(),
+				},
+			},
+			true,
+		},
+		{
+			"http repo - spec equals status, but unnecessary git branch in spec",
+			&catalog.RepoSpec{
+				URL:       "https://example.com",
+				GitBranch: "master",
+			},
+			&catalog.RepoStatus{
+				URL:                "https://example.com",
+				IndexConfigMapName: "configmap",
+				DownloadTime: metav1.Time{
+					Time: time.Now(),
+				},
+			},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldRefresh(tt.spec, tt.status)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
When the RepoSpec of a chart repo contains a git branch and an http url, shouldRefresh returns always true, because the unnecessary branch is never set in the RepoStatus. As a result the agent refreshes the repo every 4 seconds. This puts a high load on the agent as well as etcd and causes significant network traffic.

This can happen when a Repo is created manually through the Kubernetes API or with Terraform. The rancher2 terraform provider currently even sets gitBranch to "master" by default, even if a http url is set.

Signed-off-by: Bastian Hofmann <bashofmann@gmail.com>

https://github.com/rancher/rancher/issues/23256