### PR TITLE
Validate actual cluster names in GKE

### DIFF
--- a/pkg/api/norman/server/managementstored/setup.go
+++ b/pkg/api/norman/server/managementstored/setup.go
@@ -283,6 +283,7 @@ func Clusters(schemas *types.Schemas, managementContext *config.ScaledContext, c
 		Users:                         managementContext.Management.Users(""),
 		GrbLister:                     managementContext.Management.GlobalRoleBindings("").Controller().Lister(),
 		GrLister:                      managementContext.Management.GlobalRoles("").Controller().Lister(),
+		Secrets:                       managementContext.Core.Secrets(""),
 		CisConfigClient:               managementContext.Management.CisConfigs(namespace.GlobalNamespace),
 		CisConfigLister:               managementContext.Management.CisConfigs(namespace.GlobalNamespace).Controller().Lister(),
 		CisBenchmarkVersionClient:     managementContext.Management.CisBenchmarkVersions(namespace.GlobalNamespace),


### PR DESCRIPTION
Currently, the validateGKEClusterName validator checks the new cluster
name against the names and locations of clusters that Rancher already
knows about, and does not account for any potential clusters that exist
in GKE but have not been registered with Rancher. If the user creates a
cluster with the same name as another cluster in the same region or zone
that isn't known to Rancher, it will start to provision it but meet a
400 response from GKE. Since the clusterName field isn't editable, the
problem isn't fixable after the fact and the only option is to delete
and recreate the cluster. This commit changes the validator to actually
query GKE for current clusters instead of just the cluster list in
Rancher. This will provide a more accurate view of the current clusters
and will allow the user to correct the mistake before provisioning has
started.

https://github.com/rancher/rancher/issues/32292