### PR TITLE
Set condition messages for "Provisioned" condition

### DIFF
--- a/pkg/controllers/management/gke/gke_cluster_handler.go
+++ b/pkg/controllers/management/gke/gke_cluster_handler.go
@@ -164,7 +164,7 @@ func (e *gkeOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 		e.ClusterEnqueueAfter(cluster.Name, enqueueTime)
 		if failureMessage == "" {
 			logrus.Infof("waiting for cluster GKE [%s] to finish creating", cluster.Name)
-			return e.SetUnknown(cluster, apimgmtv3.ClusterConditionProvisioned, "")
+			return e.SetUnknown(cluster, apimgmtv3.ClusterConditionProvisioned, "creating")
 		}
 		logrus.Infof("waiting for cluster GKE [%s] create failure to be resolved", cluster.Name)
 		return e.SetFalse(cluster, apimgmtv3.ClusterConditionProvisioned, failureMessage)
@@ -272,7 +272,7 @@ func (e *gkeOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 			} else {
 				logrus.Infof("waiting for cluster create [%s] to start", cluster.Name)
 			}
-			return e.SetUnknown(cluster, apimgmtv3.ClusterConditionProvisioned, "")
+			return e.SetUnknown(cluster, apimgmtv3.ClusterConditionProvisioned, "waiting")
 		}
 		logrus.Infof("waiting for cluster GKE [%s] pre-create failure to be resolved", cluster.Name)
 		return e.SetFalse(cluster, apimgmtv3.ClusterConditionProvisioned, failureMessage)


### PR DESCRIPTION
Without this patch, the changes in how wrangler summarizes
conditions[1][2] causes the condition type, in this case "Provisioned",
to be rendered as the cluster transition message. Since this string
doesn't match the display state "Provisioning", the transition message
is displayed underneath the display state. Setting an non-empty message
on the condition makes this slightly less confusing.

[1] https://github.com/rancher/wrangler/commit/3eba78f45e7d61364efd11d73334641c17305b4c
[2] https://github.com/rancher/wrangler/commit/3533ace946aaf8cc64ae4be9ead3221c35975884

https://github.com/rancher/rancher/issues/32165