### PR TITLE
Allow walkthroughMap to walk through list entries

### DIFF
--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -146,26 +146,18 @@ func addSourceToImage(imagesSet map[string]map[string]bool, image string, source
 }
 
 func walkthroughMap(data interface{}, walkFunc func(map[interface{}]interface{})) {
-	inputMap, isMap := data.(map[interface{}]interface{})
-	if isMap {
+	if inputMap, isMap := data.(map[interface{}]interface{}); isMap {
 		// Run the walkFunc on the root node and each child node
 		walkFunc(inputMap)
 		for _, value := range inputMap {
 			walkthroughMap(value, walkFunc)
 		}
-		return
-	}
-	// Check if data is a list
-	inputList, isList := data.([]interface{})
-	if isList {
+	} else if inputList, isList := data.([]interface{}); isList {
 		// Run the walkFunc on each element in the root node, ignoring the root itself
 		for _, elem := range inputList {
 			walkthroughMap(elem, walkFunc)
 		}
-		return
 	}
-	// Element is neither a map nor a list
-	return
 }
 
 func GetImages(systemChartPath, chartPath string, k3sUpgradeImages, imagesFromArgs []string, rkeSystemImages map[string]rketypes.RKESystemImages, osType OSType) ([]string, []string, error) {

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -145,13 +145,27 @@ func addSourceToImage(imagesSet map[string]map[string]bool, image string, source
 	}
 }
 
-func walkthroughMap(inputMap map[interface{}]interface{}, walkFunc func(map[interface{}]interface{})) {
-	walkFunc(inputMap)
-	for _, value := range inputMap {
-		if v, ok := value.(map[interface{}]interface{}); ok {
-			walkthroughMap(v, walkFunc)
+func walkthroughMap(data interface{}, walkFunc func(map[interface{}]interface{})) {
+	inputMap, isMap := data.(map[interface{}]interface{})
+	if isMap {
+		// Run the walkFunc on the root node and each child node
+		walkFunc(inputMap)
+		for _, value := range inputMap {
+			walkthroughMap(value, walkFunc)
 		}
+		return
 	}
+	// Check if data is a list
+	inputList, isList := data.([]interface{})
+	if isList {
+		// Run the walkFunc on each element in the root node, ignoring the root itself
+		for _, elem := range inputList {
+			walkthroughMap(elem, walkFunc)
+		}
+		return
+	}
+	// Element is neither a map nor a list
+	return
 }
 
 func GetImages(systemChartPath, chartPath string, k3sUpgradeImages, imagesFromArgs []string, rkeSystemImages map[string]rketypes.RKESystemImages, osType OSType) ([]string, []string, error) {


### PR DESCRIPTION
Allows Rancher to pick up images embedded in lists like rancher-wins-upgrader [here](https://github.com/rancher/charts/blob/6cbef79083183ff1f0d1e3070de12b343dc61ff3/released/charts/rancher-wins-upgrader/rancher-wins-upgrader/0.0.100/values.yaml#L21-L22).

Related Issue: https://github.com/rancher/rancher/issues/32280