### PR TITLE
Rancher resource requests and limits can't go back to zero.

### DIFF
--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -715,6 +715,19 @@ func (m *nodesSyncer) convertNodeToMachine(node *corev1.Node, existing *v3.Node,
 	for name, quantity := range limits {
 		machine.Status.Limits[name] = quantity
 	}
+
+	for name := range machine.Status.Requested {
+		if _, ok := requests[name]; !ok {
+			machine.Status.Requested[name] = *resource.NewQuantity(int64(0), resource.DecimalSI)
+		}
+	}
+
+	for name := range machine.Status.Limits {
+		if _, ok := limits[name]; !ok {
+			machine.Status.Limits[name] = *resource.NewQuantity(int64(0), resource.DecimalSI)
+		}
+	}
+
 	machine.Status.NodeLabels = node.Labels
 	determineNodeRoles(machine)
 	machine.Status.NodeAnnotations = node.Annotations


### PR DESCRIPTION
Rancher resource requests and limits can't go back to zero.

For example, if I unassign all the requests/limits of cpu/memory in the cluster. The k8s api shows that the requests and limits are back to zero. But when looking at the rancher api, the requests and limits won't go back to zero, does not match the values in the k8s cluster.

The reason is that the nodessyncer doesn't remove non-existed previous machine.Status.Requested/machine.Status.Limits. It just updates the current value. 

In this pr, I fixed this problem. 