### PR TITLE
Switching windows images to the rancher hub account

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -741,7 +741,7 @@ clone:
 
 steps:
   - name: clone
-    image: luthermonson/drone-git:windows-2004-amd64
+    image: rancher/drone-images:git-2004
     settings:
       depth: 20
   - name: build
@@ -768,7 +768,7 @@ steps:
         - tag
 
   - name: docker-publish-head-agent
-    image: luthermonson/drone-docker:2004
+    image: rancher/drone-images:docker-2004
     settings:
       purge: false
       build_args:
@@ -796,7 +796,7 @@ steps:
         - push
 
   - name: docker-publish-agent
-    image: luthermonson/drone-docker:2004
+    image: rancher/drone-images:docker-2004
     settings:
       purge: false
       build_args:
@@ -859,7 +859,7 @@ clone:
 
 steps:
   - name: clone
-    image: luthermonson/drone-git:windows-20H2-amd64
+    image: rancher/drone-images:git-20H2
     settings:
       depth: 20
   - name: build
@@ -886,7 +886,7 @@ steps:
         - tag
 
   - name: docker-publish-head-agent
-    image: luthermonson/drone-docker:20H2
+    image: rancher/drone-images:docker-20H2
     settings:
       purge: false
       build_args:
@@ -914,7 +914,7 @@ steps:
         - push
 
   - name: docker-publish-agent
-    image: luthermonson/drone-docker:20H2
+    image: rancher/drone-images:docker-20H2
     settings:
       purge: false
       build_args:


### PR DESCRIPTION
looks like drone isn't going to get their build hosts any time soon, moving the images I made for 2004/20H2 from my personal docker up to rancher's.