### PR TITLE
[2.5.8] handle the system default registry in post-delete-hook-job better

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -33,3 +33,13 @@ chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 heritage: {{ .Release.Service }}
 release: {{ .Release.Name }}
 {{- end }}
+
+{{- define "system_default_registry" -}}
+{{- if .Values.systemDefaultRegistry -}}
+  {{- if hasSuffix "/" .Values.systemDefaultRegistry -}}
+    {{- printf "%s" .Values.systemDefaultRegistry -}}
+  {{- else -}}
+    {{- printf "%s/" .Values.systemDefaultRegistry -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/post-delete-hook-job.yaml
+++ b/chart/templates/post-delete-hook-job.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: {{ template "rancher.name" . }}-post-delete
-          image: "{{ .Values.systemDefaultRegistry }}{{ .Values.postDelete.image.repository }}:{{ .Values.postDelete.image.tag }}"
+          image: "{{ include "system_default_registry" . }}{{ .Values.postDelete.image.repository }}:{{ .Values.postDelete.image.tag }}"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/32436

Add a template function to better handle the system default registry in post-delete-hook-job 

Note:
A forward PR to rancher/master will be made after this PR is approved. 