### PR TITLE
Set default image:tag for RKE2 in rancherd

### DIFF
--- a/cmd/rancherd/go.mod
+++ b/cmd/rancherd/go.mod
@@ -65,7 +65,7 @@ replace (
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/k3s v1.20.3-0.20210311183900-69f96d622580
-	github.com/rancher/rke2 v1.20.6-0.20210402014303-e3d8dc388a5a // v1.20.5+rke2r1 ... If you update this, also update rancher/package/Dockerfile.runtime
+	github.com/rancher/rke2 v1.20.6-0.20210402014303-e3d8dc388a5a // v1.20.5+rke2r1 ... If you update this, also update RKE2_VERSION in rancher/scripts/version
 	github.com/rancher/wrangler v0.6.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/urfave/cli v1.22.2

--- a/package/Dockerfile.runtime
+++ b/package/Dockerfile.runtime
@@ -1,4 +1,3 @@
-ARG RKE2_VERSION=v1.20.5-rke2r1
-# if you’re changing this, also change rancher/cmd/rancherd/go.mod
+ARG RKE2_VERSION
 FROM rancher/rke2-runtime:${RKE2_VERSION}
 COPY rancher.yaml rancher-namespace.yaml /charts/

--- a/scripts/build-rancherd
+++ b/scripts/build-rancherd
@@ -14,11 +14,14 @@ if [ ! -z $DRONE_BRANCH ] && [ -z $DRONE_TAG ];then
 fi
 echo "RUNTIME_TAG: $RUNTIME_TAG"
 
-K8S_VERSION=$(grep 'ARG RKE2_VERSION=' ../../package/Dockerfile.runtime | sed 's/.*RKE2_VERSION=//')
 go build -o ../../bin/rancherd-${ARCH} \
     -ldflags '-w -s -extldflags "-static"
-    -X github.com/rancher/rke2/pkg/images.KubernetesVersion='$K8S_VERSION'-'$ARCH'
+    -X github.com/rancher/rke2/pkg/images.KubernetesVersion='${RKE2_VERSION}'-'${ARCH}'
     -X github.com/rancher/rke2/pkg/images.RuntimeImageName=rancher-runtime
+    -X github.com/rancher/rke2/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:'${RKE2_ETCD_VERSION}'-'${RKE2_IMAGE_BUILD_VERSION}'
+    -X github.com/rancher/rke2/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:'${RKE2_VERSION}'
+    -X github.com/rancher/rke2/pkg/images.DefaultPauseImage=rancher/pause:'${RKE2_PAUSE_VERSION}'
+    -X github.com/rancher/rke2/pkg/images.DefaultRuntimeImage=rancher/rke2-runtime:'${RKE2_VERSION}'
     -X github.com/rancher/k3s/pkg/version.Program=rke2
     -X github.com/rancher/k3s/pkg/version.Version='$RUNTIME_TAG \
     -tags "netgo osusergo selinux no_stage static_build sqlite_omit_load_extension"

--- a/scripts/package
+++ b/scripts/package
@@ -27,7 +27,7 @@ docker build --build-arg VERSION=${TAG} --build-arg ARCH=${ARCH} --build-arg IMA
 
 docker build --build-arg VERSION=${TAG} --build-arg ARCH=${ARCH} --build-arg RANCHER_TAG=${TAG} --build-arg RANCHER_REPO=${REPO} -t ${AGENT_IMAGE} -f Dockerfile.agent .
 if [ "${ARCH}" == amd64 ]; then
-    docker build -t ${RUNTIME_IMAGE} -f Dockerfile.runtime .
+    docker build --build-arg RKE2_VERSION=${RKE2_VERSION} -t ${RUNTIME_IMAGE} -f Dockerfile.runtime .
 fi
 
 mkdir -p ../dist

--- a/scripts/version
+++ b/scripts/version
@@ -64,6 +64,13 @@ if [ "$AGENT_TAG" = dev ]; then
     AGENT_TAG="master-head"
 fi
 
+# If you’re changing this, also change rancher/cmd/rancherd/go.mod
+# Also, when changing RKE2_VERSION here, be sure to pull the variables that follow from https://github.com/rancher/rke2/blob/$RKE2_VERSION/scripts/version.sh
+RKE2_VERSION=v1.20.5-rke2r1
+RKE2_ETCD_VERSION=${RKE2_ETCD_VERSION:-v3.4.13-k3s1}
+RKE2_IMAGE_BUILD_VERSION=${RKE2_IMAGE_BUILD_VERSION:-build20210223}
+RKE2_PAUSE_VERSION=${RKE2_PAUSE_VERSION:-3.2}
+
 echo "ARCH: $ARCH"
 echo "CHART_REPO: $CHART_REPO"
 echo "CHART_VERSION: $CHART_VERSION"


### PR DESCRIPTION
RKE2 changed the way it sets default images and tags. This change
introduces the necessary environment variables from the RKE2 repo
necessary to set the default images and tags. These will need to be
updated when updating RKE2 version going forward.

Issue:
https://github.com/rancher/rancher/issues/31375

Related RKE2 PR:
[`2ef4906` (#715)](https://github.com/rancher/rke2/pull/715/commits/2ef4906041918071eb1c8f14a48f89834735dc8a#diff-5860f3d4051a1dbb1a2a15c593338edfd3682123f4b21cda1699a1105a3f236dR11-R22)