### PR TITLE
[master] Add a template function to better handle the system default registry in post-delete-hook-job

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -67,3 +67,13 @@ add below linux tolerations to workloads could be scheduled to those linux nodes
     values:
     - windows
 {{- end -}}
+
+{{- define "system_default_registry" -}}
+{{- if .Values.systemDefaultRegistry -}}
+  {{- if hasSuffix "/" .Values.systemDefaultRegistry -}}
+    {{- printf "%s" .Values.systemDefaultRegistry -}}
+  {{- else -}}
+    {{- printf "%s/" .Values.systemDefaultRegistry -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/post-delete-hook-job.yaml
+++ b/chart/templates/post-delete-hook-job.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: {{ template "rancher.name" . }}-post-delete
-          image: "{{ .Values.systemDefaultRegistry }}{{ .Values.postDelete.image.repository }}:{{ .Values.postDelete.image.tag }}"
+          image: "{{ include "system_default_registry" . }}{{ .Values.postDelete.image.repository }}:{{ .Values.postDelete.image.tag }}"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0


### PR DESCRIPTION
Issue: #32436
forward port of: https://github.com/rancher/rancher/pull/32438

Add a template function to better handle the system default registry in post-delete-hook-job