### PR TITLE
Fix docker-runtime-publish

### DIFF
--- a/cmd/rancherd/go.mod
+++ b/cmd/rancherd/go.mod
@@ -65,7 +65,7 @@ replace (
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/k3s v1.20.3-0.20210311183900-69f96d622580
-	github.com/rancher/rke2 v1.20.6-0.20210402014303-e3d8dc388a5a // v1.20.5+rke2r1 ... If you update this, also update RKE2_VERSION in rancher/scripts/version
+	github.com/rancher/rke2 v1.20.6-0.20210402014303-e3d8dc388a5a // v1.20.5+rke2r1 ... If you update this, also update RKE2_VERSION in rancher/package/Dockerfile.runtime
 	github.com/rancher/wrangler v0.6.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/urfave/cli v1.22.2

--- a/package/Dockerfile.runtime
+++ b/package/Dockerfile.runtime
@@ -1,3 +1,5 @@
-ARG RKE2_VERSION
+ARG RKE2_VERSION=v1.20.5-rke2r1
+# If you are changing RKE2_VERSION here, be sure to also change in rancher/cmd/rancherd/go.mod
+# And change the 3 RKE2 environment variables in rancher/scripts/build-rancherd below RKE2_VERSION
 FROM rancher/rke2-runtime:${RKE2_VERSION}
 COPY rancher.yaml rancher-namespace.yaml /charts/

--- a/scripts/build-rancherd
+++ b/scripts/build-rancherd
@@ -14,6 +14,12 @@ if [ ! -z $DRONE_BRANCH ] && [ -z $DRONE_TAG ];then
 fi
 echo "RUNTIME_TAG: $RUNTIME_TAG"
 
+RKE2_VERSION=$(grep 'ARG RKE2_VERSION=' ../../package/Dockerfile.runtime | sed 's/.*RKE2_VERSION=//')
+# These variables come from https://github.com/rancher/rke2/blob/$RKE2_VERSION/scripts/version.sh for the RKE2_VERSION
+RKE2_ETCD_VERSION=${RKE2_ETCD_VERSION:-v3.4.13-k3s1}
+RKE2_IMAGE_BUILD_VERSION=${RKE2_IMAGE_BUILD_VERSION:-build20210223}
+RKE2_PAUSE_VERSION=${RKE2_PAUSE_VERSION:-3.2}
+
 go build -o ../../bin/rancherd-${ARCH} \
     -ldflags '-w -s -extldflags "-static"
     -X github.com/rancher/rke2/pkg/images.KubernetesVersion='${RKE2_VERSION}'-'${ARCH}'

--- a/scripts/package
+++ b/scripts/package
@@ -27,7 +27,7 @@ docker build --build-arg VERSION=${TAG} --build-arg ARCH=${ARCH} --build-arg IMA
 
 docker build --build-arg VERSION=${TAG} --build-arg ARCH=${ARCH} --build-arg RANCHER_TAG=${TAG} --build-arg RANCHER_REPO=${REPO} -t ${AGENT_IMAGE} -f Dockerfile.agent .
 if [ "${ARCH}" == amd64 ]; then
-    docker build --build-arg RKE2_VERSION=${RKE2_VERSION} -t ${RUNTIME_IMAGE} -f Dockerfile.runtime .
+    docker build -t ${RUNTIME_IMAGE} -f Dockerfile.runtime .
 fi
 
 mkdir -p ../dist

--- a/scripts/version
+++ b/scripts/version
@@ -64,13 +64,6 @@ if [ "$AGENT_TAG" = dev ]; then
     AGENT_TAG="master-head"
 fi
 
-# If you’re changing this, also change rancher/cmd/rancherd/go.mod
-# Also, when changing RKE2_VERSION here, be sure to pull the variables that follow from https://github.com/rancher/rke2/blob/$RKE2_VERSION/scripts/version.sh
-RKE2_VERSION=v1.20.5-rke2r1
-RKE2_ETCD_VERSION=${RKE2_ETCD_VERSION:-v3.4.13-k3s1}
-RKE2_IMAGE_BUILD_VERSION=${RKE2_IMAGE_BUILD_VERSION:-build20210223}
-RKE2_PAUSE_VERSION=${RKE2_PAUSE_VERSION:-3.2}
-
 echo "ARCH: $ARCH"
 echo "CHART_REPO: $CHART_REPO"
 echo "CHART_VERSION: $CHART_VERSION"


### PR DESCRIPTION
A previous change moved the RKE2_VERSION in the environment variable
file. This caused a problem with the docker-publish-runtime drone
pipeline because this environment file is not used there.

This change moves the RKE2_VERSION back to the
package/Dockerfile.runtime and adds comments to future updaters on how
to handle updating.

Previous PR:
https://github.com/rancher/rancher/pull/32442

Issue:
https://github.com/rancher/rancher/issues/31375