### PR TITLE
Correct runtime image for rancherd

### DIFF
--- a/cmd/rancherd/bundle/lib/systemd/system/rancherd-agent.env
+++ b/cmd/rancherd/bundle/lib/systemd/system/rancherd-agent.env
@@ -1,0 +1,1 @@
+HOME=/root

--- a/cmd/rancherd/bundle/lib/systemd/system/rancherd-server.env
+++ b/cmd/rancherd/bundle/lib/systemd/system/rancherd-server.env
@@ -1,0 +1,1 @@
+HOME=/root

--- a/scripts/build-rancherd
+++ b/scripts/build-rancherd
@@ -23,11 +23,10 @@ RKE2_PAUSE_VERSION=${RKE2_PAUSE_VERSION:-3.2}
 go build -o ../../bin/rancherd-${ARCH} \
     -ldflags '-w -s -extldflags "-static"
     -X github.com/rancher/rke2/pkg/images.KubernetesVersion='${RKE2_VERSION}'-'${ARCH}'
-    -X github.com/rancher/rke2/pkg/images.RuntimeImageName=rancher-runtime
     -X github.com/rancher/rke2/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:'${RKE2_ETCD_VERSION}'-'${RKE2_IMAGE_BUILD_VERSION}'
     -X github.com/rancher/rke2/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:'${RKE2_VERSION}'
     -X github.com/rancher/rke2/pkg/images.DefaultPauseImage=rancher/pause:'${RKE2_PAUSE_VERSION}'
-    -X github.com/rancher/rke2/pkg/images.DefaultRuntimeImage=rancher/rke2-runtime:'${RKE2_VERSION}'
+    -X github.com/rancher/rke2/pkg/images.DefaultRuntimeImage=rancher/rancher-runtime:'${RUNTIME_TAG}'
     -X github.com/rancher/k3s/pkg/version.Program=rke2
     -X github.com/rancher/k3s/pkg/version.Version='$RUNTIME_TAG \
     -tags "netgo osusergo selinux no_stage static_build sqlite_omit_load_extension"


### PR DESCRIPTION
There was some mixups with the RKE2 changes that caused the runtime
image to be set incorrectly.

Also, there were changes in RKE2 that caused problems with containerd
not being able to find the $HOME environment variable. That is also
fixed here.

Issue:
https://github.com/rancher/rancher/issues/31375