### PR TITLE
Add file with components versions as release asset

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -194,6 +194,8 @@ steps:
     - "bin/rancher-*"
     - "bin/rancherd-*"
     prerelease: true
+    title: "Pre-release ${DRONE_TAG}"
+    note: ./bin/rancher-components.txt
   when:
     event:
     - tag

--- a/scripts/create-components-file.sh
+++ b/scripts/create-components-file.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# This script will create a txt file which will be used to print components versions on tag
+set -e -x
+
+echo "Creating ./bin/rancher-components.txt"
+
+cd $(dirname $0)/..
+
+mkdir -p bin
+
+COMPONENTSFILE=./bin/rancher-components.txt
+
+echo "# Components" > $COMPONENTSFILE
+
+printf '%s\n' "$(grep "_VERSION" ./package/Dockerfile | grep ENV | egrep -v "http|\\$" | grep CATTLE |sed 's/CATTLE_//g' | sed 's/=/ /g' | grep UI | awk '{ print $2,$3 }')" >> $COMPONENTSFILE
+
+printf '%s\n' "$(grep "rancher/" ./go.mod | egrep -v "\./"  | egrep "rke|machine" | sort -r |  awk -F'/' '{ print $NF }' | awk '$1 = toupper($1)')" >> $COMPONENTSFILE
+
+printf '%s\n' "$(grep "_VERSION" ./package/Dockerfile | grep ENV | egrep -v "http|\\$" | grep CATTLE |sed 's/CATTLE_//g' | sed 's/=/ /g' | grep -v UI | awk '{ print $2,$3 }' | sort)" >> $COMPONENTSFILE
+
+printf '%s\n' "$(grep "rancher/" ./go.mod | egrep -v "\./"  | egrep -v "rke|machine|\/pkg\/apis|\/pkg\/client|^module" | grep -v "=>" | awk -F'/' '{ print $NF }' | awk '$1 = toupper($1)' | sort)" >> $COMPONENTSFILE
+
+
+echo "Done creating ./bin/rancher-components.txt"

--- a/scripts/package
+++ b/scripts/package
@@ -13,6 +13,8 @@ cd $(dirname $0)/../package
 
 ../scripts/k3s-images.sh
 
+../scripts/create-components-file.sh
+
 cp ../bin/rancher.yaml ../bin/rancher-namespace.yaml ../bin/rancher ../bin/agent ../bin/data.json ../bin/k3s-airgap-images.tar .
 
 IMAGE=${REPO}/rancher:${TAG}


### PR DESCRIPTION
This is to save time for the release captain to announce the created release candidate with all the components. The idea is to create the file `./bin/rancher-components.txt` (which is also going to be uploaded as an asset to track and check versions), use that as the source for the release notes in the Drone GitHub release plugin. By subscribing to the RSS feed of the created releases, we can get a notification on a pre-release and because the content of the release notes are the components, you can view them in Slack directly.

The way it comes together is basically by grepping in `./package/Dockerfile` and `go.mod` with UI, RKE and MACHINE on top because they are the most used/changed and this makes sure it will be on top in the message (so you dont have to scroll down)

We can extend it to actual release if we like it.