### PR TITLE
Bump python k8s client

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -10,6 +10,6 @@ pytest-xdist==1.28.0
 pyyaml==5.1
 netaddr==0.7.19
 requests==2.21.0
-kubernetes==11.0.0b2
+kubernetes==12.0.1
 jinja2>=2.10
 cryptography==2.6.1

--- a/tests/integration/suite/conftest.py
+++ b/tests/integration/suite/conftest.py
@@ -435,8 +435,7 @@ def raw_remove_custom_resource(admin_mc, request):
                     version,
                     metadata["namespace"],
                     crd.spec.names.plural,
-                    metadata["name"],
-                    {})
+                    metadata["name"])
             except ApiException as e:
                 body = json.loads(e.body)
                 if body["code"] not in WAIT_HTTP_ERROR_CODES:

--- a/tests/integration/suite/test_cluster.py
+++ b/tests/integration/suite/test_cluster.py
@@ -85,7 +85,7 @@ def test_cluster_node_count(admin_mc, remove_resource,
     # Delete a node
     k8s_dynamic_client.delete_namespaced_custom_object(
         "management.cattle.io", "v3", cluster.id, 'nodes',
-        dynamic_nt1['metadata']['name'], {})
+        dynamic_nt1['metadata']['name'])
 
     node_count = 1
     wait_for(lambda: _check_node_count(cluster, node_count),

--- a/tests/validation/requirements.txt
+++ b/tests/validation/requirements.txt
@@ -7,6 +7,6 @@ cryptography==2.8
 flake8==3.5.0
 invoke==1.2.0
 Jinja2==2.10.3
-kubernetes==7.0.0
+kubernetes==12.0.1
 paramiko==2.6.0
 python-digitalocean==1.13.2

--- a/tests/validation/requirements_v3api.txt
+++ b/tests/validation/requirements_v3api.txt
@@ -5,7 +5,7 @@ cryptography==2.8
 flake8==3.5.0
 invoke==1.2.0
 Jinja2==2.10.3
-kubernetes==7.0.0
+kubernetes==12.0.1
 netaddr==0.7.19
 paramiko==2.6.0
 PyJWT==1.6.4


### PR DESCRIPTION
In https://drone-pr.rancher.io/rancher/rancher/15276/1/2 I ran into:

```
if conditions is None:
--
1312 | >           raise ValueError("Invalid value for `conditions`, must not be `None`")  # noqa: E501
1313 | E           ValueError: Invalid value for `conditions`, must not be `None`
1314 |  
1315 | ../.tox/rancher/lib/python3.8/site-packages/kubernetes/client/models/v1beta1_custom_resource_definition_status.py:101: ValueError
```

Which should be fixed in this version (https://github.com/kubernetes-client/python/issues/1022)