### PR TITLE
Cleanup RKE state directory

### DIFF
--- a/pkg/kontainer-engine/drivers/rke/rke_driver.go
+++ b/pkg/kontainer-engine/drivers/rke/rke_driver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/rke/log"
 	"github.com/rancher/rke/pki"
 	v3 "github.com/rancher/rke/types"
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -469,10 +470,13 @@ func (d *Driver) save(info *types.ClusterInfo, stateDir string) *types.ClusterIn
 }
 
 func (d *Driver) cleanup(stateDir string) {
+	logrus.Tracef("cleanup called for stateDir: [%s]", stateDir)
 	if strings.HasSuffix(stateDir, "/cluster.yml") && !strings.Contains(stateDir, "..") {
-		os.Remove(stateDir)
-		os.Remove(kubeConfig(stateDir))
-		os.Remove(filepath.Dir(stateDir))
+		logrus.Debugf("cleanup: going to remove state directory: [%s]", filepath.Dir(stateDir))
+		err := os.RemoveAll(filepath.Dir(stateDir))
+		if err != nil {
+			logrus.Errorf("cleanup: error while deleting directory [%s], %v", filepath.Dir(stateDir), err)
+		}
 	}
 }
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/21976

When adding logging, this was the output for the current code:

```
2021/05/07 22:11:52 [DEBUG] Going to remove state directories: [management-state/rke/rke-445186939/cluster.yml] [management-state/rke/rke-445186939/kube_config_cluster.yml] [management-state/rke/rke-445186939]                                                                                                             
2021/05/07 22:11:52 [ERROR] Error while deleting [management-state/rke/rke-445186939/cluster.yml], remove management-state/rke/rke-445186939/cluster.yml: no such file or directory                                                                                                                                           
2021/05/07 22:11:52 [ERROR] Error while deleting [management-state/rke/rke-445186939], remove management-state/rke/rke-445186939: directory not empty  
```

Which I guess is because the code was never edited to take care of the state file that got added at some point. I also changed from removing every individual file to removing the directory and everything in it.