### PR TITLE
Copy ingress-ip-domain by the copy-settings controller

### DIFF
--- a/pkg/controllers/managementuser/settings/controller.go
+++ b/pkg/controllers/managementuser/settings/controller.go
@@ -13,7 +13,8 @@ import (
 
 var (
 	toCopy = map[string]bool{
-		settings.InstallUUID.Name: true,
+		settings.InstallUUID.Name:     true,
+		settings.IngressIPDomain.Name: true,
 	}
 )
 


### PR DESCRIPTION
Copy setting ingress-ip-domain to the downstream cluster to make the cattle ingress controller read its value.

Issues: 
- https://github.com/rancher/rancher/issues/32500
- https://github.com/rancher/rancher/issues/24018