### PR TITLE
Bump management controller workers to 50

### DIFF
--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -166,7 +166,7 @@ func (w *Context) Start(ctx context.Context) error {
 		return err
 	}
 
-	if err := w.ControllerFactory.Start(ctx, 5); err != nil {
+	if err := w.ControllerFactory.Start(ctx, 50); err != nil {
 		return err
 	}
 	w.leadership.Start(ctx)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/30346

This was 50 in v2.4 (https://github.com/rancher/types/blob/release/v2.4/config/context.go#L379), thanks to Dan for looking into it. It being at 5 was causing the controller to provision 5 machines and only continue when 1 machine was finished.