### PR TITLE
Automation - Add test to push Windows images to Private Registry

### DIFF
--- a/tests/validation/lib/node.py
+++ b/tests/validation/lib/node.py
@@ -91,6 +91,8 @@ class Node(object):
                     self.public_ip_address, username=self.ssh_user,
                     key_filename=self.ssh_key_path, port=int(self.ssh_port))
 
+            transport = self._ssh_client.get_transport()
+            transport.set_keepalive(30)
             result = self._ssh_client.exec_command(command)
             if result and len(result) == 3 and result[1].readable():
                 result = [str(result[1].read(), 'utf-8'),


### PR DESCRIPTION
This is WIP. I've done local testing but I will use the freeform jenkins do further tests.

- Detect the bastion node information using its AWS instance ID
- Create a Windows server VM with a provided AMI
- The test detects the SAC version of the VM automatically. Used when re tagging from registry.
- Save images to local windows docker
- Load images to registry
- Re-tag the images from the registry