### PR TITLE
Automation - Upgrading pip before installing dependencies

### DIFF
--- a/tests/validation/Dockerfile.v3api
+++ b/tests/validation/Dockerfile.v3api
@@ -42,4 +42,6 @@ RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERS
     ./aws/install && \
     curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
     cd $WORKSPACE && \
+    pip install --upgrade pip && \
     pip install -r requirements_v3api.txt
+


### PR DESCRIPTION
Some python libraries require a newer version of pip to retrieve their binaries instead of compiling them.
This fix the docker build error on the automation validation.