### PR TITLE
Generate a random password when rancher starts up

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -6,4 +6,8 @@ Check out our docs at https://rancher.com/docs/rancher/v2.x/en/
 
 Browse to https://{{ .Values.hostname }}
 
+If this is the first time you installed Rancher, run this command to get link to setup initial password:
+
+$ echo https://{{ .Values.hostname }}/dashboard/?setup=$(kubectl get secret --namespace {{ .Release.Namespace }} bootstrap-secret -o jsonpath="{.data.bootstrapPassword}" | base64 --decode)
+
 Happy Containering!

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -115,6 +115,11 @@ spec:
         - name: CATTLE_RESTRICTED_DEFAULT_ADMIN
           value: "true"
 {{- end}}
+        - name: CATTLE_BOOTSTRAP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "bootstrap-secret"
+              key: "bootstrapPassword"
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}
 {{- end }}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "bootstrap-secret"
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "bootstrap-secret" }}
+  {{- if $existingSecret }}
+  bootstrapPassword: {{ $existingSecret.data.bootstrapPassword }}
+  {{- else }}
+  bootstrapPassword: {{ default (randAlphaNum 16) .Values.bootstrapPassword | b64enc | quote }}
+  {{- end }}

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -50,6 +50,11 @@ tests:
         value: NAMESPACE
       - name: CATTLE_PEER_SERVICE
         value: RELEASE-NAME-rancher
+      - name: CATTLE_BOOTSTRAP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "bootstrap-secret"
+              key: "bootstrapPassword"
 - it: should default imagePullPolicy to IfNotPresent
   asserts:
   - equal:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -152,3 +152,6 @@ postDelete:
   timeout: 120
   # by default, the job will fail if it fail to uninstall any of the apps
   ignoreTimeoutError: false
+
+# Set a bootstrap password. If leave empty, a random password will be generated.
+# bootstrapPassword: ""

--- a/scripts/chart/validate
+++ b/scripts/chart/validate
@@ -9,4 +9,9 @@ if [[ $? > 0 ]]; then
     exit 1
 fi
 
-helm lint ../../build/chart/rancher
+if which helm_v3 >/dev/null 2>&1
+then
+    helm_v3 lint ../../build/chart/rancher
+else
+    helm lint ../../build/chart/rancher
+fi

--- a/scripts/run
+++ b/scripts/run
@@ -15,4 +15,5 @@ cd build/testdata
 export KUBECONFIG=
 export CATTLE_DEV_MODE=yes
 export CATTLE_SERVER_URL="https://$(ip route get 8.8.8.8 | awk '{print $7}'):8443"
+export CATTLE_BOOTSTRAP_PASSWORD="admin"
 exec ../../$CMD


### PR DESCRIPTION
Adds ability to specify bootstrap password when rancher start. This adds a new Environmental variable `CATTLE_BOOTSTRAP_PASSWORD`.

1. For single docker install, user can specify password by passing `-e CATTLE_BOOTSTRAP_PASSWORD=password` to docker. If it is not specified, the password will generated randomly and user needs to grap it from docker logs.

2. For helm HA install, user can specify that with .Values.bootstrapPassword. The password will be stored in k8s secrets and there is instruction of how to retrieve password on note.txt after rancher is installed. Same that if user don't specify in values.yaml, it will be randomly generated.