### PR TITLE
Support for existing ingress secret

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -52,6 +52,10 @@ spec:
   tls:
   - hosts:
     - {{ .Values.hostname }}
+    {{- if and .Values.ingress.existingSecret (eq .Values.ingress.tls.source "secret") }}
+    secretName: {{ .Values.ingress.existingSecret }}
+    {{- else }}
     secretName: tls-rancher-ingress
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -56,6 +56,7 @@ ingress:
   # Defaults to true
   # options: true, false
   enabled: true
+  existingSecret: ""
   extraAnnotations:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"


### PR DESCRIPTION
This is a small change to avoid using a hard coded name for the Ingress secret and allow using an existing one with the TLS certs.