### PR TITLE
Validate against using windows node pools for AKS

### DIFF
--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -449,13 +449,16 @@ func validateAKSNodePools(spec *v32.ClusterSpec) error {
 		return nil
 	}
 	if len(nodePools) == 0 {
-		return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf("must have at least one nodepool"))
+		return httperror.NewAPIError(httperror.InvalidBodyContent, "must have at least one nodepool")
 	}
 
 	for _, np := range nodePools {
 		name := np.Name
 		if to.String(name) == "" {
-			return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf("nodePool Name cannot be an empty string"))
+			return httperror.NewAPIError(httperror.InvalidBodyContent, "nodePool Name cannot be an empty string")
+		}
+		if np.OsType == "Windows" {
+			return httperror.NewAPIError(httperror.InvalidBodyContent, "windows node pools are not supported")
 		}
 	}
 

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -2,7 +2,9 @@ module github.com/rancher/rancher/pkg/apis
 
 go 1.14
 
-replace k8s.io/client-go => k8s.io/client-go v0.21.0
+replace (
+	k8s.io/client-go => k8s.io/client-go v0.21.0
+)
 
 require (
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
Windows node pools do not currently work with Rancher charts, so add a
validator to ensure "Windows" is not set for the node pools OS Type, and
update the schema to remove windows-related fields.

Depends on https://github.com/rancher/aks-operator/pull/17

https://github.com/rancher/rancher/issues/32586