### PR TITLE
Fix check for gke and eks configs

### DIFF
--- a/pkg/api/norman/customization/cluster/formatter.go
+++ b/pkg/api/norman/customization/cluster/formatter.go
@@ -108,7 +108,7 @@ func (f *Formatter) Formatter(request *types.APIContext, resource *types.RawReso
 		resource.AddAction(request, v32.ClusterActionViewMonitoring)
 	}
 
-	if gkeConfig, ok := resource.Values["googleKubernetesEngineConfig"]; ok {
+	if gkeConfig, ok := resource.Values["googleKubernetesEngineConfig"]; ok && gkeConfig != nil {
 		configMap, ok := gkeConfig.(map[string]interface{})
 		if !ok {
 			logrus.Errorf("could not convert gke config to map")
@@ -122,7 +122,7 @@ func (f *Formatter) Formatter(request *types.APIContext, resource *types.RawReso
 		setTrueIfNil(configMap, "enableNetworkPolicyConfig")
 	}
 
-	if eksConfig, ok := resource.Values["amazonElasticContainerServiceConfig"]; ok {
+	if eksConfig, ok := resource.Values["amazonElasticContainerServiceConfig"]; ok && eksConfig != nil {
 		configMap, ok := eksConfig.(map[string]interface{})
 		if !ok {
 			logrus.Errorf("could not convert eks config to map")


### PR DESCRIPTION
In Formatter function keys googleKubernetesEngineConfig
and amazonElasticContainerServiceConfig exist, but values
are for them are nil.

Issue https://github.com/rancher/rancher/issues/32887