### PR TITLE
Add RKE2 images to airgap, make airgap image generation amd64 only

### DIFF
--- a/pkg/api/norman/customization/kontainerdriver/actionhandler.go
+++ b/pkg/api/norman/customization/kontainerdriver/actionhandler.go
@@ -162,12 +162,12 @@ func (lh ListHandler) LinkHandler(apiContext *types.APIContext, next types.Reque
 	var targetImages []string
 	switch apiContext.ID {
 	case linuxImages:
-		targetImages, _, err = image.GetImages(systemCatalogChartPath, "", []string{}, []string{}, rkeSysImages, image.Linux)
+		targetImages, _, err = image.GetImages(systemCatalogChartPath, "", nil, []string{}, rkeSysImages, image.Linux)
 		if err != nil {
 			return httperror.WrapAPIError(err, httperror.ServerError, "error getting image list for linux platform")
 		}
 	case windowsImages:
-		targetImages, _, err = image.GetImages(systemCatalogChartPath, "", []string{}, []string{}, rkeSysImages, image.Windows)
+		targetImages, _, err = image.GetImages(systemCatalogChartPath, "", nil, []string{}, rkeSysImages, image.Windows)
 		if err != nil {
 			return httperror.WrapAPIError(err, httperror.ServerError, "error getting image list for windows platform")
 		}

--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -4,18 +4,16 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
-	"github.com/rancher/rancher/pkg/controllers/management/k3sbasedupgrade"
+	"github.com/coreos/go-semver/semver"
 	kd "github.com/rancher/rancher/pkg/controllers/management/kontainerdrivermetadata"
 	img "github.com/rancher/rancher/pkg/image"
+	ext "github.com/rancher/rancher/pkg/image/external"
 	"github.com/rancher/rke/types/image"
 	"github.com/rancher/rke/types/kdm"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -89,14 +87,35 @@ func run(systemChartPath, chartPath string, imagesFromArgs []string) error {
 		data.K8sVersionInfo,
 	)
 
-	k3sUpgradeImages := getK3sUpgradeImages(rancherVersion, data.K3S)
+	externalImages := make(map[string][]string)
+	k3sUpgradeImages, err := ext.GetExternalImages(rancherVersion, data.K3S, ext.K3S, nil)
+	if err != nil {
+		return err
+	}
+	if k3sUpgradeImages != nil {
+		externalImages["k3sUpgrade"] = k3sUpgradeImages
+	}
 
-	targetImages, targetImagesAndSources, err := img.GetImages(systemChartPath, chartPath, k3sUpgradeImages, imagesFromArgs, linuxInfo.RKESystemImages, img.Linux)
+	// RKE2 Provisioning will only be supported on Kubernetes v1.21+. In addition, only RKE2
+	// releases corresponding to Kubernetes v1.21+ include the "rke2-images-all" file that we need.
+	rke2AllImages, err := ext.GetExternalImages(rancherVersion, data.RKE2, ext.RKE2, &semver.Version{
+		Major: 1,
+		Minor: 21,
+		Patch: 0,
+	})
+	if err != nil {
+		return err
+	}
+	if rke2AllImages != nil {
+		externalImages["rke2All"] = rke2AllImages
+	}
+
+	targetImages, targetImagesAndSources, err := img.GetImages(systemChartPath, chartPath, externalImages, imagesFromArgs, linuxInfo.RKESystemImages, img.Linux)
 	if err != nil {
 		return err
 	}
 
-	targetWindowsImages, targetWindowsImagesAndSources, err := img.GetImages(systemChartPath, chartPath, []string{}, []string{getWindowsAgentImage()}, windowsInfo.RKESystemImages, img.Windows)
+	targetWindowsImages, targetWindowsImagesAndSources, err := img.GetImages(systemChartPath, chartPath, nil, []string{getWindowsAgentImage()}, windowsInfo.RKESystemImages, img.Windows)
 	if err != nil {
 		return err
 	}
@@ -297,110 +316,6 @@ func getWindowsAgentImage() string {
 		return ""
 	}
 	return fmt.Sprintf("%s/rancher-agent:%s", repo, tag)
-}
-
-// getK3sUpgradeImages returns k3s-upgrade images for every k3s release that supports
-// current rancher version
-func getK3sUpgradeImages(rancherVersion string, k3sData map[string]interface{}) []string {
-	logrus.Infof("generating k3s image list...")
-	k3sImagesMap := make(map[string]bool)
-	releases, _ := k3sData["releases"].([]interface{})
-	var compatibleReleases []string
-
-	for _, release := range releases {
-		releaseMap, _ := release.(map[string]interface{})
-		version, _ := releaseMap["version"].(string)
-		if version == "" {
-			continue
-		}
-
-		if rancherVersion != "dev" {
-			maxVersion, _ := releaseMap["maxChannelServerVersion"].(string)
-			maxVersion = strings.TrimPrefix(maxVersion, "v")
-			if maxVersion == "" {
-				continue
-			}
-			minVersion, _ := releaseMap["minChannelServerVersion"].(string)
-			minVersion = strings.Trim(minVersion, "v")
-			if minVersion == "" {
-				continue
-			}
-
-			versionGTMin, err := k3sbasedupgrade.IsNewerVersion(minVersion, rancherVersion)
-			if err != nil {
-				continue
-			}
-			if rancherVersion != minVersion && !versionGTMin {
-				// rancher version not equal to or greater than minimum supported rancher version
-				continue
-			}
-
-			versionLTMax, err := k3sbasedupgrade.IsNewerVersion(rancherVersion, maxVersion)
-			if err != nil {
-				continue
-			}
-			if rancherVersion != maxVersion && !versionLTMax {
-				// rancher version not equal to or greater than maximum supported rancher version
-				continue
-			}
-		}
-
-		compatibleReleases = append(compatibleReleases, version)
-	}
-
-	for _, release := range compatibleReleases {
-		// registries don't allow +, so image names will have these substituted
-		upgradeImage := fmt.Sprintf("rancher/k3s-upgrade:%s", strings.Replace(release, "+", "-", -1))
-		k3sImagesMap[upgradeImage] = true
-
-		images, err := downloadK3sSupportingImages(release)
-		if err != nil {
-			logrus.Infof("could not find supporting images for k3s release [%s]: %v", release, err)
-			continue
-		}
-
-		supportingImages := strings.Split(images, "\n")
-		if supportingImages[len(supportingImages)-1] == "" {
-			supportingImages = supportingImages[:len(supportingImages)-1]
-		}
-
-		for _, imageName := range supportingImages {
-			imageName = strings.TrimPrefix(imageName, "docker.io/")
-			k3sImagesMap[imageName] = true
-		}
-	}
-
-	var k3sImages []string
-	for imageName := range k3sImagesMap {
-		k3sImages = append(k3sImages, imageName)
-	}
-
-	sort.Strings(k3sImages)
-	logrus.Infof("finished generating k3s image list...")
-	return k3sImages
-}
-
-// DownloadK3s supporting images attempt to download k3s-images.txt files that contains a list
-// of its dependencies.
-func downloadK3sSupportingImages(release string) (string, error) {
-	url := fmt.Sprintf("https://github.com/rancher/k3s/releases/download/%s/k3s-images.txt", release)
-
-	resp, err := http.Get(url)
-	if err != nil {
-		return "", err
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("failed to get url: %v", string(body))
-	}
-	defer resp.Body.Close()
-
-	if err != nil {
-		return "", err
-	}
-
-	return string(body), nil
 }
 
 func getScript(arch, fileType string) string {

--- a/pkg/image/external/external.go
+++ b/pkg/image/external/external.go
@@ -1,0 +1,154 @@
+package external
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/rancher/rancher/pkg/controllers/management/k3sbasedupgrade"
+	"github.com/sirupsen/logrus"
+)
+
+type Source string
+
+const (
+	K3S  Source = "k3s"
+	RKE2 Source = "rke2"
+)
+
+func GetExternalImages(rancherVersion string, externalData map[string]interface{}, source Source, minimumKubernetesVersion *semver.Version) ([]string, error) {
+	if source != K3S && source != RKE2 {
+		return nil, fmt.Errorf("invalid source provided: %s", source)
+	}
+
+	logrus.Infof("generating %s image list...", source)
+	externalImagesMap := make(map[string]bool)
+	releases, _ := externalData["releases"].([]interface{})
+
+	var compatibleReleases []string
+
+	for _, release := range releases {
+		releaseMap, _ := release.(map[string]interface{})
+		version, _ := releaseMap["version"].(string)
+		if version == "" {
+			continue
+		}
+
+		// Skip the release if a minimum Kubernetes version is provided and is not met.
+		if minimumKubernetesVersion != nil {
+			versionSemVer, err := semver.NewVersion(strings.TrimPrefix(version, "v"))
+			if err != nil {
+				continue
+			}
+			if versionSemVer.LessThan(*minimumKubernetesVersion) {
+				continue
+			}
+		}
+
+		if rancherVersion != "dev" {
+			maxVersion, _ := releaseMap["maxChannelServerVersion"].(string)
+			maxVersion = strings.TrimPrefix(maxVersion, "v")
+			if maxVersion == "" {
+				continue
+			}
+			minVersion, _ := releaseMap["minChannelServerVersion"].(string)
+			minVersion = strings.Trim(minVersion, "v")
+			if minVersion == "" {
+				continue
+			}
+
+			versionGTMin, err := k3sbasedupgrade.IsNewerVersion(minVersion, rancherVersion)
+			if err != nil {
+				continue
+			}
+			if rancherVersion != minVersion && !versionGTMin {
+				// Rancher version not equal to or greater than minimum supported rancher version.
+				continue
+			}
+
+			versionLTMax, err := k3sbasedupgrade.IsNewerVersion(rancherVersion, maxVersion)
+			if err != nil {
+				continue
+			}
+			if rancherVersion != maxVersion && !versionLTMax {
+				// Rancher version not equal to or greater than maximum supported rancher version.
+				continue
+			}
+		}
+
+		logrus.Debugf("[%s] adding compatible release: %s", source, version)
+		compatibleReleases = append(compatibleReleases, version)
+	}
+
+	if compatibleReleases == nil || len(compatibleReleases) < 1 {
+		logrus.Infof("skipping image generation since no compatible releases were found for version: %s", rancherVersion)
+		return nil, nil
+	}
+
+	for _, release := range compatibleReleases {
+		// Registries don't allow "+", so image names will have these substituted.
+		upgradeImage := fmt.Sprintf("rancher/%s-upgrade:%s", source, strings.Replace(release, "+", "-", -1))
+		externalImagesMap[upgradeImage] = true
+
+		images, err := downloadExternalSupportingImages(release, source)
+		if err != nil {
+			logrus.Infof("could not find supporting images for %s release [%s]: %v", source, release, err)
+			continue
+		}
+
+		supportingImages := strings.Split(images, "\n")
+		if supportingImages[len(supportingImages)-1] == "" {
+			supportingImages = supportingImages[:len(supportingImages)-1]
+		}
+
+		for _, imageName := range supportingImages {
+			imageName = strings.TrimPrefix(imageName, "docker.io/")
+			externalImagesMap[imageName] = true
+		}
+	}
+
+	var externalImages []string
+	for imageName := range externalImagesMap {
+		logrus.Debugf("[%s] adding image: %s", source, imageName)
+		externalImages = append(externalImages, imageName)
+	}
+
+	sort.Strings(externalImages)
+	logrus.Infof("finished generating %s image list...", source)
+	return externalImages, nil
+}
+
+func downloadExternalSupportingImages(release string, source Source) (string, error) {
+	var url string
+	switch source {
+	case RKE2:
+		// The "images-all" file is only provided for RKE2 amd64 images. This may be subject to change.
+		url = fmt.Sprintf("https://github.com/rancher/rke2/releases/download/%s/rke2-images-all.linux-amd64.txt", release)
+	case K3S:
+		url = fmt.Sprintf("https://github.com/k3s-io/k3s/releases/download/%s/k3s-images.txt", release)
+	default:
+		// This function should never be called with an invalid source, but we will anticipate this
+		// error for safety.
+		return "", fmt.Errorf("invalid source provided for download: %s", source)
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("failed to get url: %v", string(body))
+	}
+	defer resp.Body.Close()
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -176,7 +176,7 @@ func walkthroughMap(data interface{}, walkFunc func(map[interface{}]interface{})
 	}
 }
 
-func GetImages(systemChartPath, chartPath string, k3sUpgradeImages, imagesFromArgs []string, rkeSystemImages map[string]rketypes.RKESystemImages, osType OSType) ([]string, []string, error) {
+func GetImages(systemChartPath, chartPath string, externalImages map[string][]string, imagesFromArgs []string, rkeSystemImages map[string]rketypes.RKESystemImages, osType OSType) ([]string, []string, error) {
 	// fetch images from system charts
 	imagesSet := make(map[string]map[string]bool)
 	if systemChartPath != "" {
@@ -204,8 +204,9 @@ func GetImages(systemChartPath, chartPath string, k3sUpgradeImages, imagesFromAr
 	// set rancher images from args
 	setImages("rancher", imagesFromArgs, imagesSet)
 
-	// set images for k3s-upgrade
-	setImages("k3sUpgrade", k3sUpgradeImages, imagesSet)
+	for source, sourceImages := range externalImages {
+		setImages(source, sourceImages, imagesSet)
+	}
 
 	convertMirroredImages(imagesSet)
 

--- a/pkg/image/resolve_test.go
+++ b/pkg/image/resolve_test.go
@@ -355,7 +355,7 @@ func TestGetImages(t *testing.T) {
 
 	assert := assertlib.New(t)
 	for _, cs := range testCases {
-		images, imageSources, err := GetImages(cs.inputSystemChartPath, cs.inputChartPath, []string{}, cs.inputImagesFromArgs, cs.inputRkeSystemImages, cs.inputOsType)
+		images, imageSources, err := GetImages(cs.inputSystemChartPath, cs.inputChartPath, nil, cs.inputImagesFromArgs, cs.inputRkeSystemImages, cs.inputOsType)
 		assert.Nilf(err, "%s, failed to get images", cs.caseName)
 		assert.Subset(images, cs.outputShouldContainImages, cs.caseName)
 		for _, nc := range cs.outputShouldNotContainImages {

--- a/scripts/k3s-images.sh
+++ b/scripts/k3s-images.sh
@@ -5,6 +5,8 @@ cd $(dirname $0)/..
 
 mkdir -p bin
 
+# This is used for downloading the tar file and not the images text file.
+# Referenced in test: tests/validation/tests/v3_api/test_airgap.py
 if [ -e /usr/tmp/k3s-images.txt ]; then
     images=$(grep -e 'docker.io/rancher/pause' -e 'docker.io/rancher/coredns-coredns' /usr/tmp/k3s-images.txt)
     xargs -n1 docker pull <<< "${images}"

--- a/scripts/package
+++ b/scripts/package
@@ -69,9 +69,10 @@ if [ ! -d $CHART_REPO_DIR ]; then
     rm -f $INDEX_PATH $CHART_REPO_DIR/assets/index.yaml
 fi
 
-TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go $SYSTEM_CHART_REPO_DIR $CHART_REPO_DIR/assets $IMAGE $AGENT_IMAGE $RUNTIME_IMAGE
-
 if [ ${ARCH} == amd64 ]; then
+    # Move this out of ARCH check for local dev on non-amd64 hardware.
+    TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go $SYSTEM_CHART_REPO_DIR $CHART_REPO_DIR/assets $IMAGE $AGENT_IMAGE $RUNTIME_IMAGE
+
     # rancherd tarball
     rm -rf build/rancherd/bundle
     mkdir -p build/rancherd/bundle


### PR DESCRIPTION
This PR refactors the existing k3s image code to be generic, and then adds RKE2 images for airgap. Since RKE2 and k3s use the same KDM scheme and versioning scheme, the code can be interchangeable.

**Relevant issue:** https://github.com/rancher/rancher/issues/32403

```
% go test
Cloning repository https://github.com/rancher/system-charts.git (branch: dev) into /var/folders/7f/gwr4k3d15xvg9mhqq87dr6fc0000gp/T/system-charts769112054
Cloned repository https://github.com/rancher/system-charts.git (branch: dev) into /var/folders/7f/gwr4k3d15xvg9mhqq87dr6fc0000gp/T/system-charts769112054
Checking out commit 7c183b98ceb8a7a50892cdb9a991fe627a782fe6
Checked out commit 7c183b98ceb8a7a50892cdb9a991fe627a782fe6
Cloning repository https://github.com/rancher/charts.git (branch: dev-v2.5) into /var/folders/7f/gwr4k3d15xvg9mhqq87dr6fc0000gp/T/charts267237085
Cloned repository https://github.com/rancher/charts.git (branch: dev-v2.5) into /var/folders/7f/gwr4k3d15xvg9mhqq87dr6fc0000gp/T/charts267237085
Checking out commit 3887f667bf6d8663032b7bd298d74d46018183ca
Checked out commit 3887f667bf6d8663032b7bd298d74d46018183ca
Cloning repository https://github.com/rancher/system-charts.git (branch: dev) into /var/folders/7f/gwr4k3d15xvg9mhqq87dr6fc0000gp/T/system-charts858436248
Cloned repository https://github.com/rancher/system-charts.git (branch: dev) into /var/folders/7f/gwr4k3d15xvg9mhqq87dr6fc0000gp/T/system-charts858436248
Checking out commit 7c183b98ceb8a7a50892cdb9a991fe627a782fe6
Checked out commit 7c183b98ceb8a7a50892cdb9a991fe627a782fe6
Cloning repository https://github.com/rancher/charts.git (branch: dev-v2.5) into /var/folders/7f/gwr4k3d15xvg9mhqq87dr6fc0000gp/T/charts443402007
Cloned repository https://github.com/rancher/charts.git (branch: dev-v2.5) into /var/folders/7f/gwr4k3d15xvg9mhqq87dr6fc0000gp/T/charts443402007
Checking out commit 3887f667bf6d8663032b7bd298d74d46018183ca
Checked out commit 3887f667bf6d8663032b7bd298d74d46018183ca
PASS
ok      github.com/rancher/rancher/pkg/image    36.879s
```