### PR TITLE
Make Azure tenantId optional in cloud credential

### DIFF
--- a/pkg/controllers/management/drivers/nodedriver/machine_driver.go
+++ b/pkg/controllers/management/drivers/nodedriver/machine_driver.go
@@ -108,7 +108,7 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 	if driver.Exists() && err == nil && !forceUpdate {
 		// add credential schema
 		credFields := map[string]v32.Field{}
-		pubCredFields, privateCredFields, passwordFields, defaults := getCredFields(obj.Annotations)
+		pubCredFields, privateCredFields, passwordFields, defaults, optionals := getCredFields(obj.Annotations)
 		for name, field := range existingSchema.Spec.ResourceFields {
 			if SSHKeyFields[name] || passwordFields[name] || privateCredFields[name] {
 				if field.Type != "password" {
@@ -119,7 +119,7 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 			// even if forceUpdate is false, calculate credFields to check if credSchema needs to be updated
 			if privateCredFields[name] || pubCredFields[name] {
 				credField := field
-				credField.Required = true
+				credField.Required = !optionals[name]
 				if val, ok := defaults[name]; ok {
 					credField = updateDefault(credField, val, field.Type)
 				}
@@ -183,7 +183,7 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 	}
 	credFields := map[string]v32.Field{}
 	resourceFields := map[string]v32.Field{}
-	pubCredFields, privateCredFields, passwordFields, defaults := getCredFields(obj.Annotations)
+	pubCredFields, privateCredFields, passwordFields, defaults, optionals := getCredFields(obj.Annotations)
 	for _, flag := range flags {
 		name, field, err := FlagToField(flag)
 		if err != nil {
@@ -203,7 +203,7 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 
 		if pubCredFields[name] || privateCredFields[name] {
 			credField := field
-			credField.Required = true
+			credField.Required = !optionals[name]
 			if val, ok := defaults[name]; ok {
 				credField = updateDefault(credField, val, field.Type)
 			}
@@ -467,7 +467,7 @@ func (m *Lifecycle) createOrUpdateNodeForEmbeddedTypeWithParents(embeddedType, f
 	return nil
 }
 
-func getCredFields(annotations map[string]string) (map[string]bool, map[string]bool, map[string]bool, map[string]string) {
+func getCredFields(annotations map[string]string) (map[string]bool, map[string]bool, map[string]bool, map[string]string, map[string]bool) {
 	getMap := func(fields string) map[string]bool {
 		data := map[string]bool{}
 		for _, field := range strings.Split(fields, ",") {
@@ -488,7 +488,8 @@ func getCredFields(annotations map[string]string) (map[string]bool, map[string]b
 	return getMap(annotations["publicCredentialFields"]),
 		getMap(annotations["privateCredentialFields"]),
 		getMap(annotations["passwordFields"]),
-		getDefaults(annotations["defaults"])
+		getDefaults(annotations["defaults"]),
+		getMap(annotations["optionalCredentialFields"])
 }
 
 func credentialConfigSchemaName(driverName string) string {

--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -33,7 +33,7 @@ const (
 
 var driverData = map[string]map[string][]string{
 	Amazonec2driver:    {"publicCredentialFields": []string{"accessKey"}, "privateCredentialFields": []string{"secretKey"}},
-	Azuredriver:        {"publicCredentialFields": []string{"clientId", "subscriptionId", "tenantId"}, "privateCredentialFields": []string{"clientSecret"}},
+	Azuredriver:        {"publicCredentialFields": []string{"clientId", "subscriptionId", "tenantId"}, "privateCredentialFields": []string{"clientSecret"}, "optionalCredentialFields": []string{"tenantId"}},
 	DigitalOceandriver: {"privateCredentialFields": []string{"accessToken"}},
 	ExoscaleDriver:     {"privateCredentialFields": []string{"apiSecretKey"}},
 	Linodedriver:       {"privateCredentialFields": []string{"token"}, "passwordFields": []string{"rootPass"}},


### PR DESCRIPTION
d4f32aca added `tenantId` as a public credential field for the dynamically
generated `azurecredentialconfig` schema. The corresponding machine driver
change[1] can optionally accept a tenant ID but can fall back on its
original lookup behavior if none is provided. Without this change,
Rancher sets the new field as required and breaks backwards
compatibility. This change adds a new "optional" category to the machine
driver data to allow the credential not to be marked as required.

[1] https://github.com/rancher/machine/pull/133

https://github.com/rancher/rancher/issues/32897