### PR TITLE
[AKS] Move AKSv2 monitoring function to operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.15.0
-	github.com/rancher/aks-operator v1.0.1-rc6
+	github.com/rancher/aks-operator v1.0.1-rc8
 	github.com/rancher/apiserver v0.0.0-20210519053359-f943376c4b42
 	github.com/rancher/channelserver v0.5.1-0.20210421200213-5495c5f6e430
 	github.com/rancher/dynamiclistener v0.2.1-0.20201110045217-9b1b7d3132e8
@@ -133,7 +133,7 @@ require (
 	github.com/yvasiyarov/go-metrics v0.0.0-20150112132944-c25f46c4b940 // indirect
 	github.com/yvasiyarov/gorelic v0.0.7 // indirect
 	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect
-	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
+	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	golang.org/x/net v0.0.0-20210315170653-34ac3e1c2000
 	golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a

--- a/go.sum
+++ b/go.sum
@@ -959,8 +959,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rackspace/gophercloud v0.0.0-20150408191457-ce0f487f6747/go.mod h1:4bJ1FwuaBZ6dt1VcDX5/O662mwR8GWqS4l68H6hkoYQ=
-github.com/rancher/aks-operator v1.0.1-rc6 h1:ML5nh0509YiTKESJknXa8FsDrtKQThvFbZ/jWUFxdUU=
-github.com/rancher/aks-operator v1.0.1-rc6/go.mod h1:c3rHKpVkpWhPCgcMQue5BfDAhrSUrvXK33JHFKgdU+w=
+github.com/rancher/aks-operator v1.0.1-rc8 h1:Q3zuXQJxQ27sEwYCzygPgxSKYoK92j4ZpP4SW9nvgfs=
+github.com/rancher/aks-operator v1.0.1-rc8/go.mod h1:+dQx02zGIw833pMpbiTmyuKPpoUuU+j9z4fNQu9jcLo=
 github.com/rancher/apiserver v0.0.0-20201023000256-1a0a904f9197/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
 github.com/rancher/apiserver v0.0.0-20210519053359-f943376c4b42 h1:yjpulamf2dZz62++nQQaFjZv+qv5aR4Uwm3uj39AJ8Y=
 github.com/rancher/apiserver v0.0.0-20210519053359-f943376c4b42/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
@@ -1261,8 +1261,9 @@ golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a h1:kr2P4QFmQr29mSLA43kwrOcgcReGTfbE9N577tCTuBc=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -6,7 +6,7 @@ replace k8s.io/client-go => k8s.io/client-go v0.21.0
 
 require (
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/aks-operator v1.0.1-rc6
+	github.com/rancher/aks-operator v1.0.1-rc8
 	github.com/rancher/eks-operator v1.0.6-rc1
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210428191153-f414eab0e4de
 	github.com/rancher/gke-operator v1.1.1-rc1

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -656,8 +656,8 @@ github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULU
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
-github.com/rancher/aks-operator v1.0.1-rc6 h1:ML5nh0509YiTKESJknXa8FsDrtKQThvFbZ/jWUFxdUU=
-github.com/rancher/aks-operator v1.0.1-rc6/go.mod h1:c3rHKpVkpWhPCgcMQue5BfDAhrSUrvXK33JHFKgdU+w=
+github.com/rancher/aks-operator v1.0.1-rc8 h1:Q3zuXQJxQ27sEwYCzygPgxSKYoK92j4ZpP4SW9nvgfs=
+github.com/rancher/aks-operator v1.0.1-rc8/go.mod h1:+dQx02zGIw833pMpbiTmyuKPpoUuU+j9z4fNQu9jcLo=
 github.com/rancher/eks-operator v1.0.6-rc1 h1:VY2lLcaHtBMByd7pq7px4fB+GW0cd0cfessODbmH+Tc=
 github.com/rancher/eks-operator v1.0.6-rc1/go.mod h1:GB2kyPtIN0r+DGlUcDgEUMsB4qRwZH7OKsraemZT+GA=
 github.com/rancher/fleet/pkg/apis v0.0.0-20210428191153-f414eab0e4de h1:k8019s2eb27ACgl8qoAJjZW9i5+0437bcDwNtoBMszo=
@@ -826,6 +826,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/client/generated/management/v3/zz_generated_aks_cluster_config_spec.go
+++ b/pkg/client/generated/management/v3/zz_generated_aks_cluster_config_spec.go
@@ -8,11 +8,15 @@ const (
 	AKSClusterConfigSpecFieldBaseURL                     = "baseUrl"
 	AKSClusterConfigSpecFieldClusterName                 = "clusterName"
 	AKSClusterConfigSpecFieldDNSPrefix                   = "dnsPrefix"
+	AKSClusterConfigSpecFieldHTTPApplicationRouting      = "httpApplicationRouting"
 	AKSClusterConfigSpecFieldImported                    = "imported"
 	AKSClusterConfigSpecFieldKubernetesVersion           = "kubernetesVersion"
 	AKSClusterConfigSpecFieldLinuxAdminUsername          = "linuxAdminUsername"
 	AKSClusterConfigSpecFieldLinuxSSHPublicKey           = "sshPublicKey"
 	AKSClusterConfigSpecFieldLoadBalancerSKU             = "loadBalancerSku"
+	AKSClusterConfigSpecFieldLogAnalyticsWorkspaceGroup  = "logAnalyticsWorkspaceGroup"
+	AKSClusterConfigSpecFieldLogAnalyticsWorkspaceName   = "logAnalyticsWorkspaceName"
+	AKSClusterConfigSpecFieldMonitoring                  = "monitoring"
 	AKSClusterConfigSpecFieldNetworkDNSServiceIP         = "dnsServiceIp"
 	AKSClusterConfigSpecFieldNetworkDockerBridgeCIDR     = "dockerBridgeCidr"
 	AKSClusterConfigSpecFieldNetworkPlugin               = "networkPlugin"
@@ -27,8 +31,6 @@ const (
 	AKSClusterConfigSpecFieldTags                        = "tags"
 	AKSClusterConfigSpecFieldVirtualNetwork              = "virtualNetwork"
 	AKSClusterConfigSpecFieldVirtualNetworkResourceGroup = "virtualNetworkResourceGroup"
-	AKSClusterConfigSpecFieldWindowsAdminPassword        = "windowsAdminPassword"
-	AKSClusterConfigSpecFieldWindowsAdminUsername        = "windowsAdminUsername"
 )
 
 type AKSClusterConfigSpec struct {
@@ -38,11 +40,15 @@ type AKSClusterConfigSpec struct {
 	BaseURL                     *string           `json:"baseUrl,omitempty" yaml:"baseUrl,omitempty"`
 	ClusterName                 string            `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
 	DNSPrefix                   *string           `json:"dnsPrefix,omitempty" yaml:"dnsPrefix,omitempty"`
+	HTTPApplicationRouting      *bool             `json:"httpApplicationRouting,omitempty" yaml:"httpApplicationRouting,omitempty"`
 	Imported                    bool              `json:"imported,omitempty" yaml:"imported,omitempty"`
 	KubernetesVersion           *string           `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
 	LinuxAdminUsername          *string           `json:"linuxAdminUsername,omitempty" yaml:"linuxAdminUsername,omitempty"`
 	LinuxSSHPublicKey           *string           `json:"sshPublicKey,omitempty" yaml:"sshPublicKey,omitempty"`
 	LoadBalancerSKU             *string           `json:"loadBalancerSku,omitempty" yaml:"loadBalancerSku,omitempty"`
+	LogAnalyticsWorkspaceGroup  string            `json:"logAnalyticsWorkspaceGroup,omitempty" yaml:"logAnalyticsWorkspaceGroup,omitempty"`
+	LogAnalyticsWorkspaceName   string            `json:"logAnalyticsWorkspaceName,omitempty" yaml:"logAnalyticsWorkspaceName,omitempty"`
+	Monitoring                  *bool             `json:"monitoring,omitempty" yaml:"monitoring,omitempty"`
 	NetworkDNSServiceIP         *string           `json:"dnsServiceIp,omitempty" yaml:"dnsServiceIp,omitempty"`
 	NetworkDockerBridgeCIDR     *string           `json:"dockerBridgeCidr,omitempty" yaml:"dockerBridgeCidr,omitempty"`
 	NetworkPlugin               *string           `json:"networkPlugin,omitempty" yaml:"networkPlugin,omitempty"`
@@ -57,6 +63,4 @@ type AKSClusterConfigSpec struct {
 	Tags                        map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 	VirtualNetwork              *string           `json:"virtualNetwork,omitempty" yaml:"virtualNetwork,omitempty"`
 	VirtualNetworkResourceGroup *string           `json:"virtualNetworkResourceGroup,omitempty" yaml:"virtualNetworkResourceGroup,omitempty"`
-	WindowsAdminPassword        *string           `json:"windowsAdminPassword,omitempty" yaml:"windowsAdminPassword,omitempty"`
-	WindowsAdminUsername        *string           `json:"windowsAdminUsername,omitempty" yaml:"windowsAdminUsername,omitempty"`
 }

--- a/pkg/kontainer-engine/drivers/aks/aks_driver.go
+++ b/pkg/kontainer-engine/drivers/aks/aks_driver.go
@@ -2,7 +2,6 @@ package aks
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -11,19 +10,19 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-10-01/containerservice"
-	"github.com/Azure/azure-sdk-for-go/services/preview/operationalinsights/mgmt/2015-11-01-preview/operationalinsights"
+	"github.com/Azure/azure-sdk-for-go/services/operationalinsights/mgmt/2020-08-01/operationalinsights"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/rancher/aks-operator/pkg/aks"
 	"github.com/rancher/rancher/pkg/kontainer-engine/drivers/options"
 	"github.com/rancher/rancher/pkg/kontainer-engine/drivers/util"
 	"github.com/rancher/rancher/pkg/kontainer-engine/types"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v2"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -716,7 +715,8 @@ func (d *Driver) createOrUpdate(ctx context.Context, options *types.DriverOption
 		},
 	}
 	if driverState.AddonEnableMonitoring {
-		logAnalyticsWorkspaceResourceID, err := d.ensureLogAnalyticsWorkspaceForMonitoring(ctx, operationInsightsWorkspaceClient, driverState)
+		logAnalyticsWorkspaceResourceID, err := aks.CheckLogAnalyticsWorkspaceForMonitoring(ctx, operationInsightsWorkspaceClient,
+			driverState.Location, driverState.ResourceGroup, driverState.LogAnalyticsWorkspaceResourceGroup, driverState.LogAnalyticsWorkspace)
 		if err != nil {
 			return info, err
 		}
@@ -919,132 +919,6 @@ func (state state) hasLinuxProfile() bool {
 func (state state) hasHTTPApplicationRoutingSupport() bool {
 	// HttpApplicationRouting is not supported in azure china cloud
 	return !strings.HasPrefix(state.Location, "china")
-}
-
-func (d *Driver) ensureLogAnalyticsWorkspaceForMonitoring(ctx context.Context, client *operationalinsights.WorkspacesClient, state state) (workspaceID string, err error) {
-	// Please keep in sync with
-	// https://github.com/Azure/azure-cli/blob/release/src/azure-cli/azure/cli/command_modules/acs/custom.py#L1996
-
-	locationToOmsRegionCodeMap := map[string]string{
-		"australiasoutheast": "ASE",
-		"australiaeast":      "EAU",
-		"australiacentral":   "CAU",
-		"canadacentral":      "CCA",
-		"centralindia":       "CIN",
-		"centralus":          "CUS",
-		"eastasia":           "EA",
-		"eastus":             "EUS",
-		"eastus2":            "EUS2",
-		"eastus2euap":        "EAP",
-		"francecentral":      "PAR",
-		"japaneast":          "EJP",
-		"koreacentral":       "SE",
-		"northeurope":        "NEU",
-		"southcentralus":     "SCUS",
-		"southeastasia":      "SEA",
-		"uksouth":            "SUK",
-		"usgovvirginia":      "USGV",
-		"westcentralus":      "EUS",
-		"westeurope":         "WEU",
-		"westus":             "WUS",
-		"westus2":            "WUS2",
-		// mapping for azure china cloud
-		"chinaeast":   "EAST2",
-		"chinaeast2":  "EAST2",
-		"chinanorth":  "EAST2",
-		"chinanorth2": "EAST2",
-	}
-	regionToOmsRegionMap := map[string]string{
-		"australiacentral":   "australiacentral",
-		"australiacentral2":  "australiacentral",
-		"australiaeast":      "australiaeast",
-		"australiasoutheast": "australiasoutheast",
-		"brazilsouth":        "southcentralus",
-		"canadacentral":      "canadacentral",
-		"canadaeast":         "canadacentral",
-		"centralus":          "centralus",
-		"centralindia":       "centralindia",
-		"eastasia":           "eastasia",
-		"eastus":             "eastus",
-		"eastus2":            "eastus2",
-		"francecentral":      "francecentral",
-		"francesouth":        "francecentral",
-		"japaneast":          "japaneast",
-		"japanwest":          "japaneast",
-		"koreacentral":       "koreacentral",
-		"koreasouth":         "koreacentral",
-		"northcentralus":     "eastus",
-		"northeurope":        "northeurope",
-		"southafricanorth":   "westeurope",
-		"southafricawest":    "westeurope",
-		"southcentralus":     "southcentralus",
-		"southeastasia":      "southeastasia",
-		"southindia":         "centralindia",
-		"uksouth":            "uksouth",
-		"ukwest":             "uksouth",
-		"westcentralus":      "eastus",
-		"westeurope":         "westeurope",
-		"westindia":          "centralindia",
-		"westus":             "westus",
-		"westus2":            "westus2",
-		// mapping for azure china cloud
-		"chinaeast":   "chinaeast2",
-		"chinaeast2":  "chinaeast2",
-		"chinanorth":  "chinaeast2",
-		"chinanorth2": "chinaeast2",
-	}
-
-	workspaceRegion, ok := regionToOmsRegionMap[state.Location]
-	if !ok {
-		return "", fmt.Errorf("region %s not supported for Log Analytics workspace", state.Location)
-	}
-	workspaceRegionCode, ok := locationToOmsRegionCodeMap[workspaceRegion]
-	if !ok {
-		return "", fmt.Errorf("region %s not supported for Log Analytics workspace", workspaceRegion)
-	}
-
-	workspaceResourceGroup := state.LogAnalyticsWorkspaceResourceGroup
-	if workspaceResourceGroup == "" {
-		workspaceResourceGroup = state.ResourceGroup
-	}
-
-	workspaceName := state.LogAnalyticsWorkspace
-	if workspaceName == "" {
-		workspaceName = fmt.Sprintf("%s-%s", state.ResourceGroup, workspaceRegionCode)
-	}
-	if len(workspaceName) > 63 {
-		workspaceName = generateUniqueLogWorkspace(workspaceName)
-	}
-
-	if gotRet, gotErr := client.Get(ctx, workspaceResourceGroup, workspaceName); gotErr == nil {
-		return *gotRet.ID, nil
-	}
-
-	logrus.Infof("[azurekubernetesservice] Create Azure Log Analytics Workspace %q on Resource Group %q", workspaceName, workspaceResourceGroup)
-
-	asyncRet, asyncErr := client.CreateOrUpdate(ctx, workspaceResourceGroup, workspaceName, operationalinsights.Workspace{
-		Location: to.StringPtr(workspaceRegion),
-		WorkspaceProperties: &operationalinsights.WorkspaceProperties{
-			Sku: &operationalinsights.Sku{
-				Name: operationalinsights.Standalone,
-			},
-		},
-	})
-	if asyncErr != nil {
-		return "", asyncErr
-	}
-
-	err = wait.Poll(5*time.Second, 30*time.Second, func() (bool, error) {
-		ret, err := asyncRet.Result(*client)
-		if err != nil {
-			return false, err
-		}
-
-		workspaceID = *ret.ID
-		return true, nil
-	})
-
-	return
 }
 
 func (d *Driver) resourceGroupExists(ctx context.Context, client *resources.GroupsClient, groupName string) (bool, error) {
@@ -1431,13 +1305,4 @@ func (d *Driver) GetK8SCapabilities(ctx context.Context, _ *types.DriverOptions)
 			HealthCheckSupported: true,
 		},
 	}, nil
-}
-
-func generateUniqueLogWorkspace(workspaceName string) string {
-	s := workspaceName[0:46]
-	h := sha256.New()
-	h.Write([]byte(workspaceName))
-	hexHash := h.Sum(nil)
-	shaString := fmt.Sprintf("%x", hexHash)
-	return fmt.Sprintf("%s-%s", s, shaString[0:16])
 }

--- a/pkg/kontainer-engine/drivers/aks/aks_driver_test.go
+++ b/pkg/kontainer-engine/drivers/aks/aks_driver_test.go
@@ -7,25 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_generateUniqueLogWorkspace(t *testing.T) {
-	tests := []struct {
-		name          string
-		workspaceName string
-		want          string
-	}{
-		{
-			name:          "basic test",
-			workspaceName: "ThisIsAValidInputklasjdfkljasjgireqahtawjsfklakjghrehtuirqhjfhwjkdfhjkawhfdjkhafvjkahg",
-			want:          "ThisIsAValidInputklasjdfkljasjgireqahtawjsfkla-fb8fb22278d8eb98",
-		},
-	}
-	for _, tt := range tests {
-		got := generateUniqueLogWorkspace(tt.workspaceName)
-		assert.Equal(t, tt.want, got)
-		assert.Len(t, got, 63)
-	}
-}
-
 // Test that the default LoadBalancerSKU is an empty string. We need this to maintain compatibility
 // with older AKS clusters without the LoadBalancerSKU field set upon creation.
 func TestLoadBalancerSKUDefault(t *testing.T) {


### PR DESCRIPTION
In AKSv2 CheckLogAnalyticsWorkspaceForMonitoring has improved function
with updated metadate. This will be maintained in aks-operator.

Issue: https://github.com/rancher/rancher/issues/32967