### PR TITLE
Use the system python3 selected version for integration tests

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -2,7 +2,6 @@ git+https://github.com/rancher/client-python.git@1ecfc3e6a300f5f336da4e4416c46c5
 websocket-client==0.56.0
 PyJWT==1.7.1
 
-flake8==3.7.7
 flask==1.1.1
 pytest==4.4.1
 pytest-repeat==0.8.0

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -1,14 +1,16 @@
 [tox]
 envlist = flake8,rancher
 
+[testenv]
+basepython = python3
+
 [testenv:flake8]
-basepython = python3.8
-deps=-rrequirements.txt
-changedir={toxinidir}
-commands=flake8 suite
+deps =
+    flake8===3.7.9
+changedir = {toxinidir}
+commands = flake8 suite
 
 [testenv:rancher]
-basepython = python3.8
-deps=-rrequirements.txt
-changedir=suite
-commands=pytest --durations=20 -rfE -v {posargs}
+deps = -rrequirements.txt
+changedir = suite
+commands = pytest --durations=20 -rfE -v {posargs}


### PR DESCRIPTION
The python 3.x version is controlled by the Dockerfile selection already
so we can make tox use the generic "python3" version, especially for
flake8 which is version agnostic.