### PR TITLE
Use name and type string from struct for keycloak oidc & oidc

### DIFF
--- a/pkg/auth/providers/keycloakoidc/keycloak_provider.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider.go
@@ -36,6 +36,8 @@ func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.
 			httpClient: &http.Client{},
 		},
 		oidc.OpenIDCProvider{
+			Name:        Name,
+			Type:        client.KeyCloakOIDCConfigType,
 			CTX:         ctx,
 			AuthConfigs: mgmtCtx.Management.AuthConfigs(""),
 			Secrets:     mgmtCtx.Core.Secrets(""),
@@ -47,10 +49,6 @@ func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.
 
 func (k *keyCloakOIDCProvider) GetName() string {
 	return Name
-}
-
-func (k *keyCloakOIDCProvider) GetType() string {
-	return client.KeyCloakConfigType
 }
 
 func (k *keyCloakOIDCProvider) SearchPrincipals(searchValue, principalType string, token v3.Token) ([]v3.Principal, error) {

--- a/pkg/auth/providers/oidc/oidc_actions.go
+++ b/pkg/auth/providers/oidc/oidc_actions.go
@@ -22,7 +22,7 @@ func (o *OpenIDCProvider) Formatter(apiContext *types.APIContext, resource *type
 }
 
 func (o *OpenIDCProvider) ActionHandler(actionName string, action *types.Action, request *types.APIContext) error {
-	handled, err := common.HandleCommonAction(actionName, action, request, o.GetName(), o.AuthConfigs)
+	handled, err := common.HandleCommonAction(actionName, action, request, o.Name, o.AuthConfigs)
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func (o *OpenIDCProvider) ActionHandler(actionName string, action *types.Action,
 func (o *OpenIDCProvider) ConfigureTest(actionName string, action *types.Action, request *types.APIContext) error {
 	//verify body has all required fields
 	input, err := handler.ParseAndValidateActionBody(request, request.Schemas.Schema(&managementschema.Version,
-		o.getType()))
+		o.Type))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Issue(s)**
https://github.com/rancher/rancher/issues/32990
https://github.com/rancher/rancher/issues/32941
https://github.com/rancher/rancher/issues/32936

**Problem**
The type and name are not being set properly with `.GetName()` and `.GetType()` which is resulting in both Keycloak OIDC and OIDC providers to become enabled. Both of these being enabled at the same time causes

1. The login screen not to know which auth provider to show to the user
2. Once they become enabled, there is no way to disable them because the disable doesn't have the correct Name of the provider to disable it. 

**Solution**
Set the name and type values on the OIDCProvider struct so that the values are correct at time of configuration and it doesn't rely on inheritance to call the correct function. 