### PR TITLE
Patchset to support SLE BCI

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,5 +1,4 @@
-FROM ubuntu:20.04
-# FROM arm=armhf/ubuntu:20.04 arm64=arm64v8/ubuntu:20.04
+FROM registry.suse.com/suse/sle15:15.3
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
@@ -16,9 +15,8 @@ ENV KUSTOMIZE_VERSION v3.10.0
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
 ENV CATTLE_KDM_BRANCH=dev-v2.6
 
-RUN apt-get update && \
-    apt-get install -y gcc ca-certificates git wget curl vim less file xz-utils unzip iproute2 && \
-    rm -f /bin/sh && ln -s /bin/bash /bin/sh
+RUN zypper ar --refresh --priority 100 'https://updates.suse.com/SUSE/Products/SLE-BCI/$releasever_major-SP$releasever_minor/$basearch/product/' SLE_BCI && \
+    zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl tar vim less file xz gzip sed gawk iproute2 iptables
 
 RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin
 
@@ -28,7 +26,11 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLAN
 RUN curl -sLf https://storage.googleapis.com/golang/go1.16.4.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local
 
 RUN if [ "${ARCH}" == "amd64" ]; then \
-    curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.40.1; \
+        curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.40.1; \
+    fi
+# workaround for https://bugzilla.suse.com/show_bug.cgi?id=1183043
+RUN if [ "${ARCH}" == "arm64" ]; then \
+        zypper -n install binutils-gold ; \
     fi
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
@@ -82,8 +84,7 @@ RUN curl -sLf ${YQ_URL} -o /usr/bin/yq && chmod +x /usr/bin/yq
 ENV KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/${ARCH}/kubectl
 RUN curl -sLf ${KUBECTL_URL} -o /usr/bin/kubectl && chmod +x /usr/bin/kubectl
 
-RUN apt-get update && \
-    apt-get install -y tox python3.8 python3-dev python3.8-dev libffi-dev libssl-dev
+RUN zypper install -y python3-tox python3-base python3 libffi-devel libopenssl-devel
 
 ENV HELM_HOME /root/.helm
 ENV DAPPER_ENV REPO TAG DRONE_TAG SYSTEM_CHART_DEFAULT_BRANCH

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,14 +1,18 @@
-FROM ubuntu:18.04
-RUN apt-get update && apt-get install -y git curl ca-certificates unzip xz-utils && \
+FROM registry.suse.com/suse/sle15:15.3
+
+RUN zypper -n ar --refresh --priority 100 'https://updates.suse.com/SUSE/Products/SLE-BCI/$releasever_major-SP$releasever_minor/$basearch/product/' SLE_BCI && \
+    zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk && \
+    zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
+    rpm -e libsolv-tools zypper libzypp container-suseconnect ; \
     useradd rancher && \
     mkdir -p /var/lib/rancher/etcd /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \
     chown -R rancher /var/lib/rancher /var/lib/cattle /usr/local/bin
+
 RUN mkdir /root/.kube && \
     ln -s /etc/rancher/k3s/k3s.yaml /root/.kube/k3s.yaml  && \
     ln -s /etc/rancher/k3s/k3s.yaml /root/.kube/config && \
     ln -s /usr/bin/rancher /usr/bin/reset-password && \
-    ln -s /usr/bin/rancher /usr/bin/ensure-default-admin && \
-    rm -f /bin/sh && ln -s /bin/bash /bin/sh
+    ln -s /usr/bin/rancher /usr/bin/ensure-default-admin
 WORKDIR /var/lib/rancher
 
 ARG ARCH=amd64

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -2,17 +2,18 @@ ARG RANCHER_TAG=dev
 ARG RANCHER_REPO=rancher
 FROM ${RANCHER_REPO}/rancher:${RANCHER_TAG} as rancher
 
-FROM ubuntu:18.04
+FROM registry.suse.com/suse/sle15:15.3
 ARG ARCH=amd64
 
-RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 ENV KUBECTL_VERSION v1.20.7
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl ca-certificates jq iproute2 vim-tiny less bash-completion sysstat acl ssh iptables && \
+# sysstat is left out until systemd dependency is stripped
+RUN zypper -n ar --refresh --priority 100 'https://updates.suse.com/SUSE/Products/SLE-BCI/$releasever_major-SP$releasever_minor/$basearch/product/' SLE_BCI && \
+    zypper -n install --no-recommends curl ca-certificates jq hostname iproute2 vim-small less bash-completion acl openssh-clients tar gzip xz gawk && \
+    zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
+    rpm -e libsolv-tools zypper libzypp container-suseconnect ; \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
-    chmod +x /usr/bin/kubectl && \
-    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    chmod +x /usr/bin/kubectl
+
 ENV LOGLEVEL_VERSION v0.1.3
 
 RUN curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin

--- a/package/jailer.sh
+++ b/package/jailer.sh
@@ -22,11 +22,12 @@ mkdir -p /opt/jail/$NAME/bin
 # Copy over required files to the jail
 if [[ -d /lib64 ]]; then
   cp -r /lib64 /opt/jail/$NAME
+  cp -r /usr/lib64 /opt/jail/$NAME/usr
 fi
 
 cp -r /lib /opt/jail/$NAME
 cp -r /usr/lib /opt/jail/$NAME/usr
-cp /etc/ssl/certs/ca-certificates.crt /opt/jail/$NAME/etc/ssl/certs
+cp /var/lib/ca-certificates/ca-bundle.pem /opt/jail/$NAME/etc/ssl/certs
 cp /etc/resolv.conf /opt/jail/$NAME/etc/
 cp /etc/passwd /opt/jail/$NAME/etc/
 cp /etc/hosts /opt/jail/$NAME/etc/


### PR DESCRIPTION
Support for SUSE BCI

Removed Leap 15.3 repo

All packages are now available via the BCI repository hence the Leap
15.3 repo added temporarily to support migration can now be removed.

Explicitly requesting gawk

awk is installed via the package gawk which is available via
patterns-base-minimal_base. When moving away from Leap 15.3 repo
that got lost hence we have to explicitly call its installation.

Explicitely call glibc-devel installation

Added glibc-devel-static to buld rancherd

Moved to SLE BCI image and repository

Use zypper internals

Use zypper internal product and architecture handling instead of hardcoding
them in repository URL. This will facilitate easy handling of newly
available versions.

Do not run 'zypper update'

In first attempt of translating from Ubuntu to SUSE there was a mistake made
where 'apt-get update' was translated to 'zypper update'. However, that
should have translated to 'zypper refresh'.
This patch fixes that.

add parameter to support SLE_BCI

Update package/Dockerfile.agent

improve zypper call

Co-authored-by: Dirk Mueller <dmueller@suse.com>

Update package/Dockerfile

improve zypper call

Co-authored-by: Dirk Mueller <dmueller@suse.com>

Fixup install command

Set default to SLE BCI image