### PR TITLE
[2.5] Fix to properly remove vSphere vCenter server entries

### DIFF
--- a/pkg/api/norman/store/cluster/cluster_store.go
+++ b/pkg/api/norman/store/cluster/cluster_store.go
@@ -43,8 +43,10 @@ import (
 	rkeservices "github.com/rancher/rke/services"
 	rketypes "github.com/rancher/rke/types"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/dynamic"
 )
 
 const (
@@ -63,6 +65,7 @@ type Store struct {
 	NodeLister                    v3.NodeLister
 	ClusterLister                 v3.ClusterLister
 	DialerFactory                 dialer.Factory
+	ClusterClient                 dynamic.ResourceInterface
 }
 
 type transformer struct {
@@ -136,6 +139,14 @@ func GetClusterStore(schema *types.Schema, mgmt *config.ScaledContext, clusterMa
 		NodeLister:                    mgmt.Management.Nodes("").Controller().Lister(),
 		DialerFactory:                 mgmt.Dialer,
 	}
+
+	dynamicClient, err := dynamic.NewForConfig(&mgmt.RESTConfig)
+	if err != nil {
+		logrus.Warnf("GetClusterStore error creating K8s dynamic client: %v", err)
+	} else {
+		s.ClusterClient = dynamicClient.Resource(v3.ClusterGroupVersionResource)
+	}
+
 	schema.Store = s
 	return s
 }
@@ -544,21 +555,19 @@ func (r *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 		return nil, err
 	}
 
-	// Replace rancherKubernetesEngineConfig.cloudProvider.vsphereCloudProvider.virtualCenter value to properly update virtualCenter removal
+	// When any rancherKubernetesEngineConfig.cloudProvider.vsphereCloudProvider.virtualCenter has been removed, updating cluster using k8s dynamic client to properly
+	// replace cluster spec. This is required due to r.Store.Update is merging this data instead of replacing it, https://github.com/rancher/rancher/issues/27306
 	if newVCenter, ok := values.GetValue(data, "rancherKubernetesEngineConfig", "cloudProvider", "vsphereCloudProvider", "virtualCenter"); ok && newVCenter != nil {
-		oldVCenter, ok := values.GetValue(existingCluster, "rancherKubernetesEngineConfig", "cloudProvider", "vsphereCloudProvider", "virtualCenter")
-		if ok && oldVCenter != nil && !reflect.DeepEqual(newVCenter, oldVCenter) {
-			newData := map[string]interface{}{}
-			for k, v := range data {
-				newData[k] = v
+		if oldVCenter, ok := values.GetValue(existingCluster, "rancherKubernetesEngineConfig", "cloudProvider", "vsphereCloudProvider", "virtualCenter"); ok && oldVCenter != nil {
+			if oldVCenterMap, oldOk := oldVCenter.(map[string]interface{}); oldOk && oldVCenterMap != nil {
+				if newVCenterMap, newOk := newVCenter.(map[string]interface{}); newOk && newVCenterMap != nil {
+					for k := range oldVCenterMap {
+						if _, ok := newVCenterMap[k]; !ok && oldVCenterMap[k] != nil {
+							return r.updateClusterByK8sclient(apiContext.Request.Context(), id, updatedName, data)
+						}
+					}
+				}
 			}
-			// Update virtualCenter value to nil
-			values.PutValue(newData, nil, "rancherKubernetesEngineConfig", "cloudProvider", "vsphereCloudProvider", "virtualCenter")
-			if _, err := r.Store.Update(apiContext, schema, newData, id); err != nil {
-				return nil, err
-			}
-			// Set virtualCenter value to newVCenter
-			values.PutValue(data, newVCenter, "rancherKubernetesEngineConfig", "cloudProvider", "vsphereCloudProvider", "virtualCenter")
 		}
 	}
 
@@ -607,6 +616,35 @@ func (r *Store) getDynamicField(data map[string]interface{}) (string, error) {
 	}
 
 	return "", nil
+}
+
+func (r *Store) updateClusterByK8sclient(ctx context.Context, id, name string, data map[string]interface{}) (map[string]interface{}, error) {
+	logrus.Tracef("Updating cluster [%s] using K8s dynamic client", id)
+	if r.ClusterClient == nil {
+		return nil, fmt.Errorf("Error updating the cluster: k8s client is nil")
+	}
+
+	object, err := r.ClusterClient.Get(ctx, id, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("Error updating the cluster: %v", err)
+	}
+
+	// Replacing name by displayName to properly update cluster using k8s format
+	values.PutValue(data, name, "displayName")
+	values.RemoveValue(data, "name")
+
+	// Setting data as cluster spec before update
+	object.Object["spec"] = data
+	object, err = r.ClusterClient.Update(ctx, object, metav1.UpdateOptions{})
+	if err != nil || object == nil {
+		return nil, fmt.Errorf("Error updating the cluster: %v", err)
+	}
+
+	// Replacing displayName by name to properly return updated data using API format
+	values.PutValue(object.Object, name, "spec", "name")
+	values.RemoveValue(object.Object, "spec", "displayName")
+
+	return object.Object["spec"].(map[string]interface{}), nil
 }
 
 func canUseClusterName(apiContext *types.APIContext, requestedName string) error {


### PR DESCRIPTION
Issue https://github.com/rancher/rancher/issues/27306
Issue https://github.com/rancher/rancher/issues/30628
Issue https://github.com/rancher/rancher/issues/33128

Related to issue comment, https://github.com/rancher/rancher/issues/27306#issuecomment-832985239, the previous fix were not working fine on edge cases. When a cluster has been updated (updating rancherKubernetesEngineConfig.cloudProvider.vsphereCloudProvider.virtualCenter data), eventually the changes where not propagated properly to all k8s nodes. Also at affected nodes, the rancher agent became stopped without automatic recover. If rancher agent is manually run at affected nodes, the cluster use to recover itself. Similar behaviour observed for issues, https://github.com/rancher/rancher/issues/30628, https://github.com/rancher/rke/issues/2496 (trying to modify other rancherKubernetesEngineConfig data) 

The root cause of the issues seems to be related with the way that rancher agents are updated. Eventually, the rancher agent becomes updated in the middle of a node plan execution, making that the node plan execution aborts and the rancher agent is never restarted. Also, we found another related rancher agent config issue when using private registry with auth. The `cattle-private-registry` secret containing `.dockerconfigjson`  is wrong formatted when generated, so rancher agent is unable to pull docker image from private registry by itself. It needs private registry auth config at rke cluster level before work.

This PR fix proposal:
* <del>Fix rancher agent docker auth config when used private registry
  Create/Update `cattle-private-registry` secret containing `.dockerconfigjson` using proper format so rancher agent is able to pull docker image from private registry by itself</del> This code has been splitted into PR https://github.com/rancher/rancher/pull/33165
* <del>Wait for rancher agent daemonset rollout before update cluster
  Check that the `cattle-node-agent` daemonset has been properly updated and rollout, before continue with the cluster update. This is assuring that the rancher agent is updated and running before the cluster provision to avoid its updated during a node plan execution. This also add some security to the cluster update process due to if the new rancher agent config is not working properlly the cluster will not be updated and still ready and working</del> This code has been splitted into PR https://github.com/rancher/rancher/pull/33166
* Fix to properly remove vSphere vCenter server entries:
  The previous fix PR https://github.com/rancher/rancher/pull/30694, has been refactored to <del>just replace `rancherKubernetesEngineConfig.cloudProvider.vsphereCloudProvider.virtualCenter` entries if any virtualCenter has been removed.</del> to use k8s dynamic client to properly replace cluster data, if any `rancherKubernetesEngineConfig.cloudProvider.vsphereCloudProvider.virtualCenter` has been removed. 

The fix has been build and tested on all 3 mentioned issues scenarios and seems to work fine. 
