### PR TITLE
add podSecurityPolicy to the post-delete-hook

### DIFF
--- a/chart/templates/post-delete-hook-cluster-role.yaml
+++ b/chart/templates/post-delete-hook-cluster-role.yaml
@@ -24,4 +24,8 @@ rules:
   - apiGroups: [ "admissionregistration.k8s.io" ]
     resources: [ "validatingwebhookconfigurations" ]
     verbs: [ "get", "list", "delete" ]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs:     ["use"]
+    resourceNames: [{{ include "rancher.fullname" . }}-post-delete ]
 {{- end }}

--- a/chart/templates/post-delete-hook-psp.yaml
+++ b/chart/templates/post-delete-hook-psp.yaml
@@ -1,0 +1,32 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "rancher.fullname" . }}-post-delete
+  labels: {{ include "rancher.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+spec:
+  privileged: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+  volumes:
+    - 'secret'
+    - 'configMap'


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/32878

Problem:
The post-delete-hook pod fails to be scheduled because it does not have and can not use any psp. 

Solution:
Add the missing permission and psp resource. 

Note:
Rancher itself can be installed and uninstalled successfully because it uses the cluster-admin clusterrole. 

Next Step:

- [ ] Backport to the v2.5 branch. 