### PR TITLE
Update golangci-lint to v1.40.1

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -2,9 +2,12 @@
     "linters": {
         "disable-all": true,
         "enable": [
-            "govet",
-            "golint",
-            "goimports"
+           "govet",
+           "revive",
+           "goimports",
+           "misspell",
+           "ineffassign",
+           "gofmt"
         ]
     },
     "linters-settings": {
@@ -42,6 +45,18 @@
             {
                 "path":"pkg/apis/management.cattle.io/v3/zz_generated_list_types.go",
                 "text":".*lobalDns.*"
+            },
+            {
+                "linters": "revive",
+                "text": "should have comment"
+            },
+            {
+                "linters": "revive",
+                "text": "should be of the form"
+            },
+            {
+                "linters": "typecheck",
+                "text": "imported but not used as apierrors"
             }
         ]
     }

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -28,7 +28,7 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLAN
 RUN wget -O - https://storage.googleapis.com/golang/go1.16.4.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local
 
 RUN if [ "${ARCH}" == "amd64" ]; then \
-    curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.27.0; \
+    curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.40.1; \
     fi
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \

--- a/pkg/agent/clean/binding.go
+++ b/pkg/agent/clean/binding.go
@@ -289,7 +289,7 @@ func (bc *bindingsCleanup) dedupeRB(roleBindings []k8srbacv1.RoleBinding) (int, 
 }
 
 func (bc *bindingsCleanup) checkIfDeterministicCRBExists(sampleBinding k8srbacv1.ClusterRoleBinding) (bool, string, error) {
-	var deterministicFound bool = false
+	var deterministicFound bool
 	crbName, err := getDeterministicBindingName(sampleBinding)
 	if err != nil {
 		return deterministicFound, "", err
@@ -302,7 +302,7 @@ func (bc *bindingsCleanup) checkIfDeterministicCRBExists(sampleBinding k8srbacv1
 }
 
 func (bc *bindingsCleanup) checkIfDeterministicRBExists(sampleBinding k8srbacv1.RoleBinding) (bool, string, error) {
-	var deterministicFound bool = false
+	var deterministicFound bool
 	rbName, err := getDeterministicBindingName(sampleBinding)
 	if err != nil {
 		return deterministicFound, "", err

--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -80,11 +80,7 @@ func (v *Validator) Validator(request *types.APIContext, schema *types.Schema, d
 		return err
 	}
 
-	if err := v.validateGKEConfig(request, data, &clusterSpec); err != nil {
-		return err
-	}
-
-	return nil
+	return v.validateGKEConfig(request, data, &clusterSpec)
 }
 
 func (v *Validator) validateScheduledClusterScan(spec *mgmtclient.Cluster) error {
@@ -315,11 +311,7 @@ func (v *Validator) accessTemplate(request *types.APIContext, spec *mgmtclient.C
 	}
 
 	var ctMap map[string]interface{}
-	if err := access.ByID(request, &mgmtSchema.Version, mgmtclient.ClusterTemplateType, clusterTempRev.Spec.ClusterTemplateName, &ctMap); err != nil {
-		return err
-	}
-
-	return nil
+	return access.ByID(request, &mgmtSchema.Version, mgmtclient.ClusterTemplateType, clusterTempRev.Spec.ClusterTemplateName, &ctMap)
 }
 
 // validateGenericEngineConfig allows for additional validation of clusters that depend on Kontainer Engine or Rancher Machine driver

--- a/pkg/api/norman/customization/kontainerdriver/actionhandler.go
+++ b/pkg/api/norman/customization/kontainerdriver/actionhandler.go
@@ -90,6 +90,9 @@ func (a ActionHandler) refresh(apiContext *types.APIContext) error {
 
 	setting.Annotations[forceRefreshAnnotation] = strconv.FormatInt(time.Now().Unix(), 10)
 	_, err = a.MetadataHandler.Settings.Update(setting)
+	if err != nil {
+		return err
+	}
 	apiContext.WriteResponse(http.StatusOK, response)
 	return nil
 }

--- a/pkg/api/norman/store/password/store.go
+++ b/pkg/api/norman/store/password/store.go
@@ -138,10 +138,7 @@ func (p *PasswordStore) replacePasswords(sepData, data, existing map[string]inte
 	*/
 	if len(data) == 0 {
 		// nothing to put in data, delete existing secret for this path
-		if err := p.deleteExistingSecrets(sepData, existing); err != nil {
-			return err
-		}
-		return nil
+		return p.deleteExistingSecrets(sepData, existing)
 	}
 	for sepKey, sepVal := range sepData {
 		if convert.ToString(sepVal) == separator {

--- a/pkg/auth/providerrefresh/refresher.go
+++ b/pkg/auth/providerrefresh/refresher.go
@@ -199,7 +199,7 @@ func (r *refresher) refreshAttributes(attribs *v3.UserAttribute) (*v3.UserAttrib
 				break
 			}
 		}
-		newGroupPrincipals := []v3.Principal{}
+		var newGroupPrincipals []v3.Principal
 
 		// If there is no principalID for the provider, there is no reason to go through the refetch process
 		if principalID != "" {

--- a/pkg/auth/providers/keycloakoidc/keycloak_client.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_client.go
@@ -32,23 +32,23 @@ type Group struct {
 	Subgroups []Group `json:"subGroups,omitempty"`
 }
 
-//KClient implements a httpclient for keycloak
-type KClient struct {
+//KeyCloakClient implements a httpclient for keycloak
+type KeyCloakClient struct {
 	httpClient *http.Client
 }
 
-func (k *KClient) newClient(config *v32.OIDCConfig) (KClient, error) {
-	kClient := KClient{}
+func (k *KeyCloakClient) newClient(config *v32.OIDCConfig) (KeyCloakClient, error) {
+	keyCloakClient := KeyCloakClient{}
 	if config.Certificate != "" && config.PrivateKey != "" {
-		err := oidc.GetClientWithCertKey(kClient.httpClient, config.Certificate, config.PrivateKey)
+		err := oidc.GetClientWithCertKey(keyCloakClient.httpClient, config.Certificate, config.PrivateKey)
 		if err != nil {
-			return KClient{}, err
+			return KeyCloakClient{}, err
 		}
 	}
-	return kClient, nil
+	return keyCloakClient, nil
 }
 
-func (k *KClient) searchPrincipals(searchTerm, principalType string, accessToken string, config *v32.OIDCConfig) ([]account, error) {
+func (k *KeyCloakClient) searchPrincipals(searchTerm, principalType string, accessToken string, config *v32.OIDCConfig) ([]account, error) {
 	var accounts []account
 	sURL, err := getSearchURL(config.Issuer)
 	if err != nil {
@@ -119,7 +119,7 @@ func getSubGroups(group Group) []Group {
 	return groups
 }
 
-func (k *KClient) getFromKeyCloakByID(principalID, accessToken, searchType string, config *v32.OIDCConfig) (account, error) {
+func (k *KeyCloakClient) getFromKeyCloakByID(principalID, accessToken, searchType string, config *v32.OIDCConfig) (account, error) {
 	sURL, err := getSearchURL(config.Issuer)
 	if err != nil {
 		return account{}, nil
@@ -158,8 +158,8 @@ func URLEncoded(str string) string {
 	return u.String()
 }
 
-func (k *KClient) getFromKeyCloak(accessToken, url string, config *v32.OIDCConfig) ([]byte, int, error) {
-	kHTTPClient, err := k.newClient(config)
+func (k *KeyCloakClient) getFromKeyCloak(accessToken, url string, config *v32.OIDCConfig) ([]byte, int, error) {
+	keyCloakHTTPClient, err := k.newClient(config)
 	if err != nil {
 		logrus.Errorf("[keycloak oidc]: error creating new http client: %v", err)
 		return nil, 500, err
@@ -170,7 +170,7 @@ func (k *KClient) getFromKeyCloak(accessToken, url string, config *v32.OIDCConfi
 	}
 	req.Header.Add("Authorization", "token "+accessToken)
 	req.Header.Add("Accept", "application/json")
-	resp, err := kHTTPClient.httpClient.Do(req)
+	resp, err := keyCloakHTTPClient.httpClient.Do(req)
 	if err != nil {
 		logrus.Errorf("[keycloak oidc]: received error from keycloak: %v", err)
 		return nil, resp.StatusCode, err

--- a/pkg/auth/providers/keycloakoidc/keycloak_provider.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider.go
@@ -26,13 +26,13 @@ const (
 )
 
 type keyCloakOIDCProvider struct {
-	kClient *KClient
+	keyCloakClient *KeyCloakClient
 	oidc.OpenIDCProvider
 }
 
 func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.Manager, tokenMGR *tokens.Manager) common.AuthProvider {
 	return &keyCloakOIDCProvider{
-		&KClient{
+		&KeyCloakClient{
 			httpClient: &http.Client{},
 		},
 		oidc.OpenIDCProvider{
@@ -67,8 +67,8 @@ func (k *keyCloakOIDCProvider) SearchPrincipals(searchValue, principalType strin
 		}
 		accessToken = token.ProviderInfo["access_token"]
 	}
-	oidc.GetClientWithCertKey(k.kClient.httpClient, config.Certificate, config.PrivateKey)
-	accts, err := k.kClient.searchPrincipals(searchValue, principalType, accessToken, config)
+	oidc.GetClientWithCertKey(k.keyCloakClient.httpClient, config.Certificate, config.PrivateKey)
+	accts, err := k.keyCloakClient.searchPrincipals(searchValue, principalType, accessToken, config)
 	if err != nil {
 		logrus.Errorf("[keycloak oidc] problem searching keycloak: %v", err)
 	}
@@ -133,8 +133,8 @@ func (k *keyCloakOIDCProvider) GetPrincipal(principalID string, token v3.Token) 
 	if principalType == GroupType {
 		searchType = "groups"
 	}
-	oidc.GetClientWithCertKey(k.kClient.httpClient, config.Certificate, config.PrivateKey)
-	acct, err := k.kClient.getFromKeyCloakByID(externalID, searchType, accessToken, config)
+	oidc.GetClientWithCertKey(k.keyCloakClient.httpClient, config.Certificate, config.PrivateKey)
+	acct, err := k.keyCloakClient.getFromKeyCloakByID(externalID, searchType, accessToken, config)
 	if err != nil {
 		return v3.Principal{}, err
 	}

--- a/pkg/auth/providers/oidc/oidc_client.go
+++ b/pkg/auth/providers/oidc/oidc_client.go
@@ -28,12 +28,10 @@ func GetClientWithCertKey(httpClient *http.Client, certificate, key string) erro
 	}
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM([]byte(certificate))
-	httpClient = &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs:      caCertPool,
-				Certificates: []tls.Certificate{keyPair},
-			},
+	httpClient.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:      caCertPool,
+			Certificates: []tls.Certificate{keyPair},
 		},
 	}
 	return nil

--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -405,6 +405,11 @@ func (s *Provider) HandleSamlAssertion(w http.ResponseWriter, r *http.Request, a
 			}
 
 			keyBytes, err := base64.StdEncoding.DecodeString(publicKey)
+			if err != nil {
+				log.Errorf("SAML: base64 DecodeString error %v", err)
+				http.Redirect(w, r, redirectURL+"errorCode=500", http.StatusFound)
+				return
+			}
 			pubKey := &rsa.PublicKey{}
 			err = json.Unmarshal(keyBytes, pubKey)
 			if err != nil {

--- a/pkg/auth/requests/authenticate.go
+++ b/pkg/auth/requests/authenticate.go
@@ -190,7 +190,7 @@ func (a *tokenAuthenticator) TokenFromRequest(req *http.Request) (*v3.Token, err
 		lookupUsingClient = true
 	}
 
-	storedToken := &v3.Token{}
+	var storedToken *v3.Token
 	if lookupUsingClient {
 		storedToken, err = a.tokenClient.Get(tokenName, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -49,11 +49,7 @@ var (
 
 func RegisterIndexer(ctx context.Context, apiContext *config.ScaledContext) error {
 	informer := apiContext.Management.Users("").Controller().Informer()
-	if err := informer.AddIndexers(map[string]cache.IndexFunc{userPrincipalIndex: userPrincipalIndexer}); err != nil {
-		return err
-	}
-
-	return nil
+	return informer.AddIndexers(map[string]cache.IndexFunc{userPrincipalIndex: userPrincipalIndexer})
 }
 
 func NewManager(ctx context.Context, apiContext *config.ScaledContext) *Manager {
@@ -174,7 +170,7 @@ func (m *Manager) getToken(tokenAuthValue string) (*v3.Token, int, error) {
 		lookupUsingClient = true
 	}
 
-	storedToken := &v3.Token{}
+	var storedToken *v3.Token
 	if lookupUsingClient {
 		storedToken, err = m.tokensClient.Get(tokenName, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/catalog/manager/manager.go
+++ b/pkg/catalog/manager/manager.go
@@ -205,10 +205,7 @@ func (m *Manager) ValidateChartCompatibility(template *v3.CatalogTemplateVersion
 	if err := m.ValidateRancherVersion(template); err != nil {
 		return err
 	}
-	if err := m.ValidateKubeVersion(template, clusterName); err != nil {
-		return err
-	}
-	return nil
+	return m.ValidateKubeVersion(template, clusterName)
 }
 
 func (m *Manager) ValidateKubeVersion(template *v3.CatalogTemplateVersion, clusterName string) error {

--- a/pkg/catalog/manager/traverse.go
+++ b/pkg/catalog/manager/traverse.go
@@ -282,7 +282,7 @@ func (m *Manager) traverseAndUpdate(helm *helmlib.Helm, commit string, cmt *Cata
 		if _, err := m.updateCatalogInfo(cmt, catalogType, "", false, true); err != nil {
 			return err
 		}
-		logrus.Error(fmt.Sprintf("failed to sync templates. Multiple error(s) occured: %v", invalidChartErrors))
+		logrus.Error(fmt.Sprintf("failed to sync templates. Multiple error(s) occurred: %v", invalidChartErrors))
 		return &controller.ForgetError{Err: errors.Errorf("failed to sync templates. Multiple error(s) occurred: %v", invalidChartErrors)}
 	}
 	if len(errstrings) > 0 {

--- a/pkg/catalogv2/http/download.go
+++ b/pkg/catalogv2/http/download.go
@@ -59,6 +59,9 @@ func Icon(secret *corev1.Secret, repoURL string, caBundle []byte, insecureSkipTL
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
 	return ioutil.NopCloser(bytes.NewBuffer(data)), path.Ext(u.String()), nil
 }
 

--- a/pkg/controllers/dashboardapi/settings/settings.go
+++ b/pkg/controllers/dashboardapi/settings/settings.go
@@ -17,11 +17,7 @@ func Register(settingController managementcontrollers.SettingController) error {
 		settingCache: settingController.Cache(),
 	}
 
-	if err := settings.SetProvider(sp); err != nil {
-		return err
-	}
-
-	return nil
+	return settings.SetProvider(sp)
 }
 
 type settingsProvider struct {

--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -855,7 +855,7 @@ func (p *Provisioner) getSpec(cluster *v3.Cluster) (*apimgmtv3.ClusterSpec, erro
 		return nil, err
 	}
 
-	newSpec, newConfig, err := p.getConfig(true, censoredSpec, driverName, cluster.Name)
+	_, newConfig, err := p.getConfig(true, censoredSpec, driverName, cluster.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -864,7 +864,7 @@ func (p *Provisioner) getSpec(cluster *v3.Cluster) (*apimgmtv3.ClusterSpec, erro
 		return nil, nil
 	}
 
-	newSpec, _, err = p.getConfig(true, cluster.Spec, driverName, cluster.Name)
+	newSpec, _, err := p.getConfig(true, cluster.Spec, driverName, cluster.Name)
 
 	return newSpec, err
 }

--- a/pkg/controllers/management/clusterupstreamrefresher/eks_upstream_spec.go
+++ b/pkg/controllers/management/clusterupstreamrefresher/eks_upstream_spec.go
@@ -44,6 +44,9 @@ func BuildEKSUpstreamSpec(secretsCache wranglerv1.SecretCache, cluster *mgmtv3.C
 		&eks.ListNodegroupsInput{
 			ClusterName: aws.String(cluster.Spec.EKSConfig.DisplayName),
 		})
+	if err != nil {
+		return nil, err
+	}
 
 	// gather upstream node groups states
 	var nodeGroupStates []*eks.DescribeNodegroupOutput

--- a/pkg/controllers/management/etcdbackup/etcdbackup.go
+++ b/pkg/controllers/management/etcdbackup/etcdbackup.go
@@ -228,7 +228,9 @@ func (c *Controller) etcdSaveWithBackoff(b *v3.EtcdBackup) (runtime.Object, erro
 			}
 			return true, nil
 		})
-
+		if err != nil {
+			return b, err
+		}
 		return b, inErr
 	})
 	if err != nil {
@@ -395,7 +397,6 @@ func GetS3Client(sbc *rketypes.S3BackupConfig, timeout int, dialer dialer.Dialer
 	if sbc == nil {
 		return nil, fmt.Errorf("Can't find S3 backup target configuration")
 	}
-	var s3Client = &minio.Client{}
 	var creds *credentials.Credentials
 	var tr http.RoundTripper = &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,

--- a/pkg/controllers/management/kontainerdrivermetadata/data.go
+++ b/pkg/controllers/management/kontainerdrivermetadata/data.go
@@ -199,10 +199,7 @@ func (md *MetadataController) saveAllServiceOptions(linuxSvcOptions map[string]r
 		return err
 	}
 	// save windows options
-	if err := md.saveServiceOptions(windowsSvcOptions, localWindowsSvcOptions, Windows); err != nil {
-		return err
-	}
-	return nil
+	return md.saveServiceOptions(windowsSvcOptions, localWindowsSvcOptions, Windows)
 }
 
 func (md *MetadataController) saveServiceOptions(k8sVersionServiceOptions map[string]rketypes.KubernetesServicesOptions,
@@ -750,7 +747,7 @@ func getUserSettings(userSettings map[string]string, defaultK8sVersions map[stri
 
 func getDefaultK8sVersion(rancherDefaultK8sVersions map[string]string, k8sCurrVersions []string, rancherVersion string) (string, error) {
 	defaultK8sVersion, ok := rancherDefaultK8sVersions["user"]
-	if defaultK8sVersion != "" {
+	if ok && defaultK8sVersion != "" {
 		found := false
 		for _, k8sVersion := range k8sCurrVersions {
 			if k8sVersion == defaultK8sVersion {

--- a/pkg/controllers/management/rbac/rbac.go
+++ b/pkg/controllers/management/rbac/rbac.go
@@ -51,7 +51,7 @@ func CreateRoleAndRoleBinding(resource, kind, name, namespace, apiVersion, creat
 		return err
 	}
 
-	// Create a roleBinding referring the role with everything access, and containing creator of the resouce, along with
+	// Create a roleBinding referring the role with everything access, and containing creator of the resource, along with
 	// any members that have everything access
 	var ownerAccessSubjects, readOnlyAccessSubjects, memberAccessSubjects []k8srbacv1.Subject
 	ownerAccessSubjects = append(ownerAccessSubjects, k8srbacv1.Subject{Kind: "User", Name: creatorID, APIGroup: rbacv1.GroupName})

--- a/pkg/controllers/managementapi/controllers.go
+++ b/pkg/controllers/managementapi/controllers.go
@@ -57,8 +57,5 @@ func registerIndexers(ctx context.Context, scaledContext *config.ScaledContext) 
 	if err := podsecuritypolicy.RegisterIndexers(ctx, scaledContext); err != nil {
 		return err
 	}
-	if err := podsecuritypolicy2.RegisterIndexers(ctx, scaledContext); err != nil {
-		return err
-	}
-	return nil
+	return podsecuritypolicy2.RegisterIndexers(ctx, scaledContext)
 }

--- a/pkg/controllers/managementapi/usercontrollers/usercontroller.go
+++ b/pkg/controllers/managementapi/usercontrollers/usercontroller.go
@@ -108,11 +108,7 @@ func (u *userControllersController) setPeers(peers *tpeermanager.Peers) error {
 		sort.Strings(u.peers.IDs)
 	}
 
-	if err := u.peersSync(); err != nil {
-		return err
-	}
-
-	return nil
+	return u.peersSync()
 }
 
 func (u *userControllersController) peersSync() error {

--- a/pkg/controllers/managementlegacy/multiclusterapp/controller_multiclusterapp.go
+++ b/pkg/controllers/managementlegacy/multiclusterapp/controller_multiclusterapp.go
@@ -531,10 +531,7 @@ func (m *MCAppManager) delete(appsToDelete []*pv3.App) error {
 			return nil
 		})
 	}
-	if err := g.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return g.Wait()
 }
 
 func (m *MCAppManager) updateCondition(mcappToUpdate *v3.MultiClusterApp, setCondition func(mcapp *v3.MultiClusterApp)) (*v3.MultiClusterApp, error) {
@@ -613,7 +610,7 @@ func (m *MCAppManager) createAnswerMap(answers []v32.Answer) (map[string]map[str
 			// Using k8s labels.Merge, since by definition:
 			// Merge combines given maps, and does not check for any conflicts between the maps. In case of conflicts, second map (labels2) wins
 			// And we want project level keys to override keys from global level for that project
-			projectLabels := make(map[string]string)
+			var projectLabels map[string]string
 			if val, ok := answerMap[clusterName]; ok {
 				projectLabels = labels.Merge(val, a.Values)
 			} else {

--- a/pkg/controllers/managementuser/rbac/cluster_handler.go
+++ b/pkg/controllers/managementuser/rbac/cluster_handler.go
@@ -45,7 +45,7 @@ type clusterHandler struct {
 }
 
 func (h *clusterHandler) sync(key string, obj *v3.Cluster) (runtime.Object, error) {
-	// We recieve clusters with no data, when that happens no checks will work so just ignore them
+	// We receive clusters with no data, when that happens no checks will work so just ignore them
 	if key == "" || obj == nil || obj.Name == "" {
 		return nil, nil
 	}

--- a/pkg/controllers/managementuser/rbac/globalrole_handler.go
+++ b/pkg/controllers/managementuser/rbac/globalrole_handler.go
@@ -47,11 +47,7 @@ func RegisterIndexers(ctx context.Context, scaledContext *config.ScaledContext) 
 	crtbIndexers := map[string]cache.IndexFunc{
 		rtbByClusterAndRoleTemplateIndex: rtbByClusterAndRoleTemplateName,
 	}
-	if err := crtbInformer.AddIndexers(crtbIndexers); err != nil {
-		return err
-	}
-
-	return nil
+	return crtbInformer.AddIndexers(crtbIndexers)
 }
 
 func newGlobalRoleBindingHandler(workload *config.UserContext) v3.GlobalRoleBindingHandlerFunc {

--- a/pkg/controllers/managementuserlegacy/alert/watcher/cluster_scan.go
+++ b/pkg/controllers/managementuserlegacy/alert/watcher/cluster_scan.go
@@ -133,10 +133,7 @@ func (csw *ClusterScanWatcher) sendAlert(cs *v3.ClusterScan, alertRule *v3.Clust
 	data["component_name"] = cs.Name
 	data["logs"] = csw.getAlertMessage(cs, alertRule)
 
-	if err := csw.alertManager.SendAlert(data); err != nil {
-		return err
-	}
-	return nil
+	return csw.alertManager.SendAlert(data)
 }
 
 func (csw *ClusterScanWatcher) getAlertMessage(cs *v3.ClusterScan, alertRule *v3.ClusterAlertRule) string {

--- a/pkg/controllers/managementuserlegacy/cis/clusterScanHandler.go
+++ b/pkg/controllers/managementuserlegacy/cis/clusterScanHandler.go
@@ -442,7 +442,7 @@ func (csh *cisScanHandler) deleteApp(appInfo *appInfo) error {
 func (csh *cisScanHandler) ensureCleanup(cs *v3.ClusterScan) error {
 	var err error
 
-	// Delete the dameonset
+	// Delete the DaemonSet
 	dss, e := csh.dsLister.List(v32.DefaultNamespaceForCis, labels.Everything())
 	if e != nil {
 		err = multierror.Append(err, fmt.Errorf("cis: ensureCleanup: error listing ds: %v", e))
@@ -461,8 +461,8 @@ func (csh *cisScanHandler) ensureCleanup(cs *v3.ClusterScan) error {
 	}
 
 	// Delete cms
-	cms, err := csh.cmLister.List(v32.DefaultNamespaceForCis, labels.Everything())
-	if err != nil {
+	cms, e := csh.cmLister.List(v32.DefaultNamespaceForCis, labels.Everything())
+	if e != nil {
 		err = multierror.Append(err, fmt.Errorf("cis: ensureCleanup: error listing cm: %v", e))
 	} else {
 		for _, cm := range cms {

--- a/pkg/controllers/managementuserlegacy/cis/utils.go
+++ b/pkg/controllers/managementuserlegacy/cis/utils.go
@@ -92,7 +92,7 @@ func createSecurityScanNamespace(nsClient rcorev1.NamespaceInterface, projectLis
 			},
 		},
 	}
-	if ns, err = nsClient.Create(ns); err != nil && !kerrors.IsAlreadyExists(err) {
+	if _, err = nsClient.Create(ns); err != nil && !kerrors.IsAlreadyExists(err) {
 		return fmt.Errorf("error while creating namespace %v: %v", nsName, err)
 	}
 	return nil

--- a/pkg/controllers/managementuserlegacy/helm/common/common.go
+++ b/pkg/controllers/managementuserlegacy/helm/common/common.go
@@ -142,7 +142,7 @@ func InstallCharts(tempDirs *HelmPath, port string, obj *v3.App) error {
 	if err != nil {
 		return err
 	}
-	commands := make([]string, 0)
+	var commands []string
 	if IsHelm3(obj.Status.HelmVersion) {
 		err = createKustomizeFiles(tempDirs, obj.Name)
 		if err != nil {

--- a/pkg/controllers/managementuserlegacy/istio/metricExpression.go
+++ b/pkg/controllers/managementuserlegacy/istio/metricExpression.go
@@ -64,10 +64,7 @@ func yamlToObject(yml string, obj interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err := json.Unmarshal(jsondata, obj); err != nil {
-		return err
-	}
-	return nil
+	return json.Unmarshal(jsondata, obj)
 }
 
 var (

--- a/pkg/controllers/managementuserlegacy/monitoring/metricExpression.go
+++ b/pkg/controllers/managementuserlegacy/monitoring/metricExpression.go
@@ -77,10 +77,7 @@ func yamlToObject(yml string, obj interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err := json.Unmarshal(jsondata, obj); err != nil {
-		return err
-	}
-	return nil
+	return json.Unmarshal(jsondata, obj)
 }
 
 func generate(text string, data templateData) (string, error) {

--- a/pkg/controllers/managementuserlegacy/pipeline/controller/project/project.go
+++ b/pkg/controllers/managementuserlegacy/pipeline/controller/project/project.go
@@ -154,10 +154,7 @@ func (l *Syncer) addPipelineSetting(settingName string, value string, obj *v3.Pr
 }
 
 func (l *Syncer) ensureSystemAccount(obj *v3.Project) error {
-	if err := l.systemAccountManager.GetOrCreateProjectSystemAccount(ref.Ref(obj)); err != nil {
-		return err
-	}
-	return nil
+	return l.systemAccountManager.GetOrCreateProjectSystemAccount(ref.Ref(obj))
 }
 
 func (l *Syncer) cleanInternalRegistryEntry(projectID string) error {

--- a/pkg/data/dashboard/add.go
+++ b/pkg/data/dashboard/add.go
@@ -41,9 +41,5 @@ func Add(ctx context.Context, wrangler *wrangler.Context, addLocal, removeLocal,
 		return err
 	}
 
-	if err := addUnauthenticatedRoles(wrangler.Apply); err != nil {
-		return err
-	}
-
-	return nil
+	return addUnauthenticatedRoles(wrangler.Apply)
 }

--- a/pkg/data/management/kontainerdriver_data.go
+++ b/pkg/data/management/kontainerdriver_data.go
@@ -111,18 +111,14 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 		return err
 	}
 
-	if err := creator.addCustomDriver(
+	return creator.addCustomDriver(
 		"opentelekomcloudcontainerengine",
 		"https://otc-rancher.obs.eu-de.otc.t-systems.com/cluster/driver/1.0.2/kontainer-engine-driver-otccce_linux_amd64.tar.gz",
 		"f2c0a8d1195cd51ae1ccdeb4a8defd2c3147b9a2c7510b091be0c12028740f5f",
 		"https://otc-rancher.obs.eu-de.otc.t-systems.com/cluster/ui/v1.0.3/component.js",
 		false,
 		"*.otc.t-systems.com",
-	); err != nil {
-		return err
-	}
-
-	return nil
+	)
 }
 
 func cleanupImportDriver(creator driverCreator) error {

--- a/pkg/kontainer-engine/cmd/ls.go
+++ b/pkg/kontainer-engine/cmd/ls.go
@@ -27,7 +27,7 @@ func lsCluster(ctx *cli.Context) error {
 	writer := utils.NewTableWriter([][]string{
 		{"NAME", "Name"},
 		{"DRIVER", "DriverName"},
-		{"VERISON", "Version"},
+		{"VERSION", "Version"},
 		{"ENDPOINT", "Endpoint"},
 		{"NODE_COUNT", "NodeCount"},
 		{"STATUS", "Status"},

--- a/pkg/kontainer-engine/drivers/aks/aks_driver.go
+++ b/pkg/kontainer-engine/drivers/aks/aks_driver.go
@@ -1390,11 +1390,7 @@ func (d *Driver) RemoveLegacyServiceAccount(ctx context.Context, info *types.Clu
 		return err
 	}
 
-	if err = util.DeleteLegacyServiceAccountAndRoleBinding(clientset); err != nil {
-		return err
-	}
-
-	return nil
+	return util.DeleteLegacyServiceAccountAndRoleBinding(clientset)
 }
 
 func logClusterConfig(config containerservice.ManagedCluster) {

--- a/pkg/kontainer-engine/service/service.go
+++ b/pkg/kontainer-engine/service/service.go
@@ -62,15 +62,13 @@ func (c controllerConfigGetter) GetConfig() (types.DriverOptions, error) {
 		IntOptions:         make(map[string]int64),
 		StringSliceOptions: make(map[string]*types.StringSlice),
 	}
-	data := map[string]interface{}{}
 	switch c.driverName {
 	case ImportDriverName:
 		config, err := toMap(c.clusterSpec.ImportedConfig, "json")
 		if err != nil {
 			return driverOptions, err
 		}
-		data = config
-		flatten(data, &driverOptions)
+		flatten(config, &driverOptions)
 	case RancherKubernetesEngineDriverName:
 		config, err := yaml.Marshal(c.clusterSpec.RancherKubernetesEngineConfig)
 		if err != nil {
@@ -82,10 +80,8 @@ func (c controllerConfigGetter) GetConfig() (types.DriverOptions, error) {
 		if err != nil {
 			return driverOptions, err
 		}
-		data = config
-		flatten(data, &driverOptions)
+		flatten(config, &driverOptions)
 	}
-
 	driverOptions.StringOptions["name"] = c.clusterName
 	displayName := c.clusterSpec.DisplayName
 	if displayName == "" {

--- a/pkg/pipeline/engine/jenkins/convert.go
+++ b/pkg/pipeline/engine/jenkins/convert.go
@@ -134,8 +134,9 @@ func (c *jenkinsPipelineConverter) configPublishStepContainer(container *v1.Cont
 	m := utils.GetEnvVarMap(c.execution)
 	config.Tag = substituteEnvVar(m, config.Tag)
 
-	registry, repo, tag := utils.SplitImageTag(config.Tag)
+	_, repo, tag := utils.SplitImageTag(config.Tag)
 
+	var registry string
 	if config.PushRemote {
 		registry = config.Registry
 	} else {

--- a/pkg/pipeline/engine/jenkins/engine.go
+++ b/pkg/pipeline/engine/jenkins/engine.go
@@ -161,11 +161,11 @@ func (j *Engine) RunPipelineExecution(execution *v3.PipelineExecution) error {
 }
 
 func (j *Engine) preparePipeline(execution *v3.PipelineExecution) error {
+	var registry string
 	for _, stage := range execution.Spec.PipelineConfig.Stages {
 		for _, step := range stage.Steps {
 			if step.PublishImageConfig != nil {
 				//prepare docker credential for publishimage step
-				registry := utils.DefaultRegistry
 				if step.PublishImageConfig.PushRemote && step.PublishImageConfig.Registry != "" {
 					registry = step.PublishImageConfig.Registry
 				} else {
@@ -454,10 +454,7 @@ func (j *Engine) successStep(execution *v3.PipelineExecution, stage int, step in
 		}
 	}
 
-	if err := j.saveStepLogToMinio(execution, stage, step); err != nil {
-		return err
-	}
-	return nil
+	return j.saveStepLogToMinio(execution, stage, step)
 }
 
 func (j *Engine) failStep(execution *v3.PipelineExecution, stage int, step int, jenkinsStage Stage) error {

--- a/pkg/provisioningv2/rke2/planner/s3args.go
+++ b/pkg/provisioningv2/rke2/planner/s3args.go
@@ -33,7 +33,7 @@ func (s *s3Args) ToArgs(s3 *rkev1.ETCDSnapshotS3, controlPlane *rkev1.RKEControl
 		credName = controlPlane.Spec.ETCD.S3.CloudCredentialName
 	}
 
-	s3Cred, err = getS3Credential(s.secretCache, controlPlane.Namespace, s3.CloudCredentialName, s3.Region)
+	s3Cred, err = getS3Credential(s.secretCache, controlPlane.Namespace, credName, s3.Region)
 	if err != nil {
 		return
 	}

--- a/scripts/validate
+++ b/scripts/validate
@@ -8,10 +8,10 @@ tox -e flake8
 
 cd ../..
 
-if ! command -v golangci-lint; then	echo Running: go fmt	
-    echo Skipping validation: no golangci-lint available	test -z "$(go fmt ./... | tee /dev/stderr)"
-    exit	
-fi	
+if ! command -v golangci-lint; then
+    echo "Skipping validation on ARCH's other than linux amd64"
+    exit
+fi
 
 echo Running: golangci-lint
 golangci-lint run


### PR DESCRIPTION
This updates golangci-lint to latest released version + syncs up `.golangci.json` with `rancher/go-skel`. There were quite a few changes so I might have messed up on some.

Summary after updating:

```
pkg/catalog/manager/traverse.go:285:73: `occured` is a misspelling of `occurred` (misspell)
                logrus.Error(fmt.Sprintf("failed to sync templates. Multiple error(s) occured: %v", invalidChartErrors))
                                                                                      ^      
pkg/kontainer-engine/cmd/ls.go:30:5: `VERISON` is a misspelling of `VERSION` (misspell)
                {"VERISON", "Version"},
                  ^                                                                                                                                            
pkg/controllers/management/rbac/rbac.go:54:99: `resouce` is a misspelling of `resource` (misspell)
        // Create a roleBinding referring the role with everything access, and containing creator of the resouce, along with
                                                                                                         ^
pkg/controllers/managementuser/rbac/cluster_handler.go:48:8: `recieve` is a misspelling of `receive` (misspell)
        // We recieve clusters with no data, when that happens no checks will work so just ignore them
              ^                                                                                                                                                
pkg/kontainer-engine/drivers/aks/aks_driver.go:1267:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
        if err = util.DeleteLegacyServiceAccountAndRoleBinding(clientset); err != nil {
                return err                                                                                                                                     
        }                                                       
pkg/controllers/dashboardapi/settings/settings.go:20:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
        if err := settings.SetProvider(sp); err != nil {
                return err  
        }                                  
pkg/catalog/manager/manager.go:208:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
        if err := m.ValidateKubeVersion(template, clusterName); err != nil {
                return err
        }
pkg/auth/providers/keycloakoidc/keycloak_client.go:41:2: var-naming: don't use leading k in Go names; var kClient should be client (revive)
        kClient := KClient{}
        ^
pkg/auth/providers/keycloakoidc/keycloak_client.go:162:2: var-naming: don't use leading k in Go names; var kHTTPClient should be hTTPClient (revive)
        kHTTPClient, err := k.newClient(config)
        ^
pkg/auth/providers/keycloakoidc/keycloak_provider.go:29:2: var-naming: don't use leading k in Go names; struct field kClient should be client (revive)
        kClient *KClient
        ^
pkg/agent/clean/binding.go:292:25: var-declaration: should omit type bool from declaration of var deterministicFound; it will be inferred from the right-hand side (revive)
        var deterministicFound bool = false
                               ^
pkg/agent/clean/binding.go:305:25: var-declaration: should omit type bool from declaration of var deterministicFound; it will be inferred from the right-hand side (revive)
        var deterministicFound bool = false
                               ^
pkg/controllers/managementuserlegacy/helm/common/common.go:145:2: ineffectual assignment to commands (ineffassign)
        commands := make([]string, 0)
        ^
pkg/catalogv2/http/download.go:61:8: ineffectual assignment to err (ineffassign)
        data, err := ioutil.ReadAll(resp.Body)
              ^
pkg/auth/tokens/manager.go:177:2: ineffectual assignment to storedToken (ineffassign)
        storedToken := &v3.Token{}
        ^
pkg/auth/providers/oidc/oidc_client.go:31:2: ineffectual assignment to httpClient (ineffassign)
        httpClient = &http.Client{
        ^
pkg/auth/providers/saml/saml_client.go:407:14: ineffectual assignment to err (ineffassign)
                        keyBytes, err := base64.StdEncoding.DecodeString(publicKey)
                                  ^
pkg/auth/providerrefresh/refresher.go:230:8: ineffectual assignment to newGroupPrincipals (ineffassign)
                                                        newGroupPrincipals = existingPrincipals
                                                        ^
pkg/controllers/management/kontainerdrivermetadata/data.go:752:21: ineffectual assignment to ok (ineffassign)
        defaultK8sVersion, ok := rancherDefaultK8sVersions["user"]
                           ^
pkg/kontainer-engine/service/service.go:65:2: ineffectual assignment to data (ineffassign)
        data := map[string]interface{}{}
        ^
pkg/controllers/management/clusterprovisioner/provisioner.go:858:2: ineffectual assignment to newSpec (ineffassign)
        newSpec, newConfig, err := p.getConfig(true, censoredSpec, driverName, cluster.Name)
        ^
pkg/controllers/managementuserlegacy/cis/clusterScanHandler.go:460:3: ineffectual assignment to err (ineffassign)
                err = multierror.Append(err, fmt.Errorf("cis: ensureCleanup: error deleting pod %v: %v", podName, e))
                ^
pkg/controllers/managementuserlegacy/cis/utils.go:95:5: ineffectual assignment to ns (ineffassign)
        if ns, err = nsClient.Create(ns); err != nil && !kerrors.IsAlreadyExists(err) {
           ^
pkg/pipeline/engine/jenkins/convert.go:137:2: ineffectual assignment to registry (ineffassign)
        registry, repo, tag := utils.SplitImageTag(config.Tag)
        ^
pkg/pipeline/engine/jenkins/engine.go:168:5: ineffectual assignment to registry (ineffassign)
                                registry := utils.DefaultRegistry
                                ^
pkg/auth/requests/authenticate.go:193:2: ineffectual assignment to storedToken (ineffassign)
        storedToken := &v3.Token{}
        ^
pkg/provisioningv2/rke2/planner/s3args.go:33:3: ineffectual assignment to credName (ineffassign)
                credName = controlPlane.Spec.ETCD.S3.CloudCredentialName
                ^
pkg/controllers/management/etcdbackup/etcdbackup.go:398:6: ineffectual assignment to s3Client (ineffassign)
        var s3Client = &minio.Client{}
            ^
pkg/controllers/managementlegacy/multiclusterapp/controller_multiclusterapp.go:616:4: ineffectual assignment to projectLabels (ineffassign)
                        projectLabels := make(map[string]string)
                        ^
```