### PR TITLE
No unzip

### DIFF
--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -8,7 +8,7 @@ ARG ARCH=amd64
 RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 ENV KUBECTL_VERSION v1.20.7
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl ca-certificates jq iproute2 vim-tiny less bash-completion unzip sysstat acl ssh iptables && \
+    apt-get install -y --no-install-recommends git curl ca-certificates jq iproute2 vim-tiny less bash-completion sysstat acl ssh iptables && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl && \
     DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
@@ -18,7 +18,7 @@ ENV LOGLEVEL_VERSION v0.1.3
 RUN curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin
 ENV KUBEPROMPT_VERSION v1.0.10
 
-RUN curl -sL https://github.com/c-bata/kube-prompt/releases/download/${KUBEPROMPT_VERSION}/kube-prompt_${KUBEPROMPT_VERSION}_linux_${ARCH}.zip > /usr/bin/kube-prompt.zip && unzip /usr/bin/kube-prompt.zip -d /usr/bin
+RUN curl -sL https://github.com/c-bata/kube-prompt/releases/download/${KUBEPROMPT_VERSION}/kube-prompt_${KUBEPROMPT_VERSION}_linux_${ARCH}.zip | gunzip -d -c - > /usr/bin/kube-prompt && chmod +x /usr/bin/kube-prompt
 ARG VERSION=dev
 LABEL io.cattle.agent true
 ENV AGENT_IMAGE rancher/rancher-agent:${VERSION}


### PR DESCRIPTION
When *.zip consist of exactly one file, you can use gunzip
for it, so we don't need unzip in the container.

Bonus for not leaving a stray *.zip behind inside the container,
saving twice on size.
