### PR TITLE
Fix cluster shell and helm operation

### DIFF
--- a/pkg/api/steve/clusters/shell.go
+++ b/pkg/api/steve/clusters/shell.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 	"time"
 
 	"github.com/rancher/rancher/pkg/settings"
@@ -69,6 +70,11 @@ func (s *shell) proxyRequest(rw http.ResponseWriter, req *http.Request, pod *v1.
 		Director: func(req *http.Request) {
 			req.URL = attachURL
 			req.Host = attachURL.Host
+			for key := range req.Header {
+				if strings.HasPrefix(key, "Impersonate-Extra-") {
+					delete(req.Header, key)
+				}
+			}
 			delete(req.Header, "Impersonate-Group")
 			delete(req.Header, "Impersonate-User")
 			delete(req.Header, "Authorization")

--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -162,6 +162,11 @@ func (s *Operations) proxyLogRequest(rw http.ResponseWriter, req *http.Request, 
 		Director: func(req *http.Request) {
 			req.URL = logURL
 			req.Host = logURL.Host
+			for key := range req.Header {
+				if strings.HasPrefix(key, "Impersonate-Extra-") {
+					delete(req.Header, key)
+				}
+			}
 			delete(req.Header, "Impersonate-Group")
 			delete(req.Header, "Impersonate-User")
 			delete(req.Header, "Authorization")


### PR DESCRIPTION
Remove Impersonate-Extra- Header that were sent through proxy header.
This is not allowed in k8s api server as requests can't only have extra
header without users.