### PR TITLE
Change to partial token info logging / full token trace logging

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -349,7 +349,8 @@ func run(ctx context.Context) error {
 		if !isConnect() {
 			wsURL += "/register"
 		}
-		logrus.Infof("Connecting to %s with token %s", wsURL, token)
+		logrus.Infof("Connecting to %s with token starting with %s", wsURL, token[:len(token)/2])
+		logrus.Tracef("Connecting to %s with token %s", wsURL, token)
 		remotedialer.ClientConnect(ctx, wsURL, headers, nil, func(proto, address string) bool {
 			switch proto {
 			case "tcp":


### PR DESCRIPTION
(Not more than) half of token is logged at info level now. Full token logging is now at trace level.
Replaces https://github.com/rancher/rancher/pull/32851