### PR TITLE
Create check for cert and key to avoid error

### DIFF
--- a/pkg/auth/providers/keycloakoidc/keycloak_client.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_client.go
@@ -9,15 +9,14 @@ import (
 	"strings"
 
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/auth/providers/oidc"
 	"github.com/sirupsen/logrus"
 )
 
 //account defines properties an account in keycloak has
 type account struct {
-	ID            int    `json:"id,omitempty"`
+	ID            string `json:"id,omitempty"`
 	Email         string `json:"email,omitempty"`
-	EmailVerified string `json:"emailVerified,omitempty"`
+	EmailVerified bool   `json:"emailVerified,omitempty"`
 	Username      string `json:"username,omitempty"`
 	Enabled       bool   `json:"enabled,omitempty"`
 	Name          string `json:"firstName,omitempty"`
@@ -27,7 +26,7 @@ type account struct {
 
 //Group defines properties a group in keycloak has
 type Group struct {
-	ID        int     `json:"id,omitempty"`
+	ID        string  `json:"id,omitempty"`
 	Name      string  `json:"name,omitempty"`
 	Subgroups []Group `json:"subGroups,omitempty"`
 }
@@ -35,12 +34,6 @@ type Group struct {
 //KeyCloakClient implements a httpclient for keycloak
 type KeyCloakClient struct {
 	httpClient *http.Client
-}
-
-func newClient(config *v32.OIDCConfig) (*KeyCloakClient, error) {
-	keyCloakClient := &KeyCloakClient{}
-	err := oidc.GetClientWithCertKey(keyCloakClient.httpClient, config.Certificate, config.PrivateKey)
-	return keyCloakClient, err
 }
 
 func (k *KeyCloakClient) searchPrincipals(searchTerm, principalType string, accessToken string, config *v32.OIDCConfig) ([]account, error) {
@@ -161,7 +154,7 @@ func (k *KeyCloakClient) getFromKeyCloak(accessToken, url string) ([]byte, int, 
 	if accessToken == "" {
 		return nil, 500, fmt.Errorf("[keycloak oidc]: GET request failed, missing authorization token")
 	}
-	req.Header.Add("Authorization", "token "+accessToken)
+	req.Header.Add("Authorization", "Bearer "+accessToken)
 	req.Header.Add("Accept", "application/json")
 	resp, err := k.httpClient.Do(req)
 	if err != nil {
@@ -177,5 +170,4 @@ func (k *KeyCloakClient) getFromKeyCloak(accessToken, url string) ([]byte, int, 
 		return b, resp.StatusCode, err
 	}
 	return b, resp.StatusCode, nil
-
 }

--- a/pkg/auth/providers/keycloakoidc/keycloak_client.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_client.go
@@ -37,15 +37,10 @@ type KeyCloakClient struct {
 	httpClient *http.Client
 }
 
-func (k *KeyCloakClient) newClient(config *v32.OIDCConfig) (KeyCloakClient, error) {
-	keyCloakClient := KeyCloakClient{}
-	if config.Certificate != "" && config.PrivateKey != "" {
-		err := oidc.GetClientWithCertKey(keyCloakClient.httpClient, config.Certificate, config.PrivateKey)
-		if err != nil {
-			return KeyCloakClient{}, err
-		}
-	}
-	return keyCloakClient, nil
+func newClient(config *v32.OIDCConfig) (*KeyCloakClient, error) {
+	keyCloakClient := &KeyCloakClient{}
+	err := oidc.GetClientWithCertKey(keyCloakClient.httpClient, config.Certificate, config.PrivateKey)
+	return keyCloakClient, err
 }
 
 func (k *KeyCloakClient) searchPrincipals(searchTerm, principalType string, accessToken string, config *v32.OIDCConfig) ([]account, error) {
@@ -59,7 +54,7 @@ func (k *KeyCloakClient) searchPrincipals(searchTerm, principalType string, acce
 		searchURL := fmt.Sprintf("%s/%ss?search=%s", sURL, UserType, searchTerm)
 		search := URLEncoded(searchURL)
 
-		b, statusCode, err := k.getFromKeyCloak(accessToken, search, config)
+		b, statusCode, err := k.getFromKeyCloak(accessToken, search)
 		if statusCode == 401 {
 			return nil, nil
 		}
@@ -81,7 +76,7 @@ func (k *KeyCloakClient) searchPrincipals(searchTerm, principalType string, acce
 		searchURL := fmt.Sprintf("%s/%ss?search=%s", sURL, GroupType, searchTerm)
 		search := URLEncoded(searchURL)
 
-		b, statusCode, err := k.getFromKeyCloak(accessToken, search, config)
+		b, statusCode, err := k.getFromKeyCloak(accessToken, search)
 		if statusCode == 401 {
 			return nil, nil
 		}
@@ -126,7 +121,7 @@ func (k *KeyCloakClient) getFromKeyCloakByID(principalID, accessToken, searchTyp
 	}
 	searchURL := fmt.Sprintf("%s/%s/%s", sURL, searchType, principalID)
 	search := URLEncoded(searchURL)
-	b, statusCode, err := k.getFromKeyCloak(accessToken, search, config)
+	b, statusCode, err := k.getFromKeyCloak(accessToken, search)
 	if err != nil {
 		return account{}, fmt.Errorf("[keycloak oidc]: GET request failed, got status code: %d. url: %s, err: %s",
 			statusCode, search, err)
@@ -158,23 +153,22 @@ func URLEncoded(str string) string {
 	return u.String()
 }
 
-func (k *KeyCloakClient) getFromKeyCloak(accessToken, url string, config *v32.OIDCConfig) ([]byte, int, error) {
-	keyCloakHTTPClient, err := k.newClient(config)
-	if err != nil {
-		logrus.Errorf("[keycloak oidc]: error creating new http client: %v", err)
-		return nil, 500, err
-	}
+func (k *KeyCloakClient) getFromKeyCloak(accessToken, url string) ([]byte, int, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, 500, err
 	}
+	if accessToken == "" {
+		return nil, 500, fmt.Errorf("[keycloak oidc]: GET request failed, missing authorization token")
+	}
 	req.Header.Add("Authorization", "token "+accessToken)
 	req.Header.Add("Accept", "application/json")
-	resp, err := keyCloakHTTPClient.httpClient.Do(req)
+	resp, err := k.httpClient.Do(req)
 	if err != nil {
 		logrus.Errorf("[keycloak oidc]: received error from keycloak: %v", err)
 		return nil, resp.StatusCode, err
 	}
+	defer resp.Body.Close()
 	b, err := ioutil.ReadAll(resp.Body)
 	switch resp.StatusCode {
 	case 200:
@@ -183,4 +177,5 @@ func (k *KeyCloakClient) getFromKeyCloak(accessToken, url string, config *v32.OI
 		return b, resp.StatusCode, err
 	}
 	return b, resp.StatusCode, nil
+
 }

--- a/pkg/auth/providers/keycloakoidc/keycloak_provider.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider.go
@@ -2,7 +2,6 @@ package keycloakoidc
 
 import (
 	"context"
-	"net/http"
 	"strconv"
 	"strings"
 
@@ -26,15 +25,11 @@ const (
 )
 
 type keyCloakOIDCProvider struct {
-	keyCloakClient *KeyCloakClient
 	oidc.OpenIDCProvider
 }
 
 func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.Manager, tokenMGR *tokens.Manager) common.AuthProvider {
 	return &keyCloakOIDCProvider{
-		&KeyCloakClient{
-			httpClient: &http.Client{},
-		},
 		oidc.OpenIDCProvider{
 			Name:        Name,
 			Type:        client.KeyCloakOIDCConfigType,
@@ -59,7 +54,11 @@ func (k *keyCloakOIDCProvider) SearchPrincipals(searchValue, principalType strin
 	if err != nil {
 		return principals, err
 	}
-
+	keyCloakClient, err := newClient(config)
+	if err != nil {
+		logrus.Errorf("[keycloak oidc]: error creating new http client: %v", err)
+		return principals, err
+	}
 	accessToken, err := k.TokenMGR.GetSecret(token.UserID, token.AuthProvider, []*v3.Token{&token})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -67,8 +66,7 @@ func (k *keyCloakOIDCProvider) SearchPrincipals(searchValue, principalType strin
 		}
 		accessToken = token.ProviderInfo["access_token"]
 	}
-	oidc.GetClientWithCertKey(k.keyCloakClient.httpClient, config.Certificate, config.PrivateKey)
-	accts, err := k.keyCloakClient.searchPrincipals(searchValue, principalType, accessToken, config)
+	accts, err := keyCloakClient.searchPrincipals(searchValue, principalType, accessToken, config)
 	if err != nil {
 		logrus.Errorf("[keycloak oidc] problem searching keycloak: %v", err)
 	}
@@ -111,6 +109,11 @@ func (k *keyCloakOIDCProvider) GetPrincipal(principalID string, token v3.Token) 
 	if err != nil {
 		return v3.Principal{}, err
 	}
+	keyCloakClient, err := newClient(config)
+	if err != nil {
+		logrus.Errorf("[keycloak oidc]: error creating new http client: %v", err)
+		return v3.Principal{}, err
+	}
 	accessToken, err := k.TokenMGR.GetSecret(token.UserID, token.AuthProvider, []*v3.Token{&token})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -133,8 +136,7 @@ func (k *keyCloakOIDCProvider) GetPrincipal(principalID string, token v3.Token) 
 	if principalType == GroupType {
 		searchType = "groups"
 	}
-	oidc.GetClientWithCertKey(k.keyCloakClient.httpClient, config.Certificate, config.PrivateKey)
-	acct, err := k.keyCloakClient.getFromKeyCloakByID(externalID, searchType, accessToken, config)
+	acct, err := keyCloakClient.getFromKeyCloakByID(externalID, searchType, accessToken, config)
 	if err != nil {
 		return v3.Principal{}, err
 	}

--- a/pkg/auth/providers/oidc/oidc_client.go
+++ b/pkg/auth/providers/oidc/oidc_client.go
@@ -22,17 +22,19 @@ func (o *OpenIDCProvider) AddCertKeyToContext(ctx *context.Context, certificate,
 }
 
 func GetClientWithCertKey(httpClient *http.Client, certificate, key string) error {
-	keyPair, err := tls.X509KeyPair([]byte(certificate), []byte(key))
-	if err != nil {
-		return err
-	}
-	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM([]byte(certificate))
-	httpClient.Transport = &http.Transport{
-		TLSClientConfig: &tls.Config{
-			RootCAs:      caCertPool,
-			Certificates: []tls.Certificate{keyPair},
-		},
+	if certificate != "" && key != "" {
+		keyPair, err := tls.X509KeyPair([]byte(certificate), []byte(key))
+		if err != nil {
+			return err
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM([]byte(certificate))
+		httpClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      caCertPool,
+				Certificates: []tls.Certificate{keyPair},
+			},
+		}
 	}
 	return nil
 }

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -306,18 +306,18 @@ func (o *OpenIDCProvider) saveOIDCConfig(config *v32.OIDCConfig) error {
 	config.ObjectMeta = storedOidcConfig.ObjectMeta
 
 	if config.PrivateKey != "" {
-		field := strings.ToLower(client.OIDCConfigFieldPrivateKey)
-		if err = common.CreateOrUpdateSecrets(o.Secrets, config.PrivateKey, field, strings.ToLower(config.Type)); err != nil {
+		privateKeyField := strings.ToLower(client.OIDCConfigFieldPrivateKey)
+		if err = common.CreateOrUpdateSecrets(o.Secrets, config.PrivateKey, privateKeyField, strings.ToLower(config.Type)); err != nil {
 			return err
 		}
-		config.PrivateKey = common.GetName(config.Type, field)
+		config.PrivateKey = common.GetName(config.Type, privateKeyField)
 	}
 
-	field := strings.ToLower(client.OIDCConfigFieldClientSecret)
-	if err := common.CreateOrUpdateSecrets(o.Secrets, convert.ToString(config.ClientSecret), field, strings.ToLower(config.Type)); err != nil {
+	secretField := strings.ToLower(client.OIDCConfigFieldClientSecret)
+	if err := common.CreateOrUpdateSecrets(o.Secrets, convert.ToString(config.ClientSecret), secretField, strings.ToLower(config.Type)); err != nil {
 		return err
 	}
-	config.ClientSecret = common.GetName(config.Type, field)
+	config.ClientSecret = common.GetName(config.Type, secretField)
 
 	logrus.Debugf("[generic oidc] updating config")
 	_, err = o.AuthConfigs.ObjectClient().Update(config.ObjectMeta.Name, config)

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -317,6 +317,7 @@ func (o *OpenIDCProvider) saveOIDCConfig(config *v32.OIDCConfig) error {
 	if err := common.CreateOrUpdateSecrets(o.Secrets, convert.ToString(config.ClientSecret), field, strings.ToLower(config.Type)); err != nil {
 		return err
 	}
+	config.ClientSecret = common.GetName(config.Type, field)
 
 	logrus.Debugf("[generic oidc] updating config")
 	_, err = o.AuthConfigs.ObjectClient().Update(config.ObjectMeta.Name, config)

--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -630,7 +630,8 @@ var uaBackoff = wait.Backoff{
 
 func (m *Manager) NewLoginToken(userID string, userPrincipal v3.Principal, groupPrincipals []v3.Principal, providerToken string, ttl int64, description string) (v3.Token, string, error) {
 	provider := userPrincipal.Provider
-	if (provider == "github" || provider == "azuread" || provider == "googleoauth") && providerToken != "" {
+	// Providers that use oauth need to create a secret for storing the access token.
+	if (provider == "github" || provider == "azuread" || provider == "googleoauth" || provider == "oidc" || provider == "keycloakoidc") && providerToken != "" {
 		err := m.CreateSecret(userID, provider, providerToken)
 		if err != nil {
 			return v3.Token{}, "", fmt.Errorf("unable to create secret: %s", err)


### PR DESCRIPTION
**Issue**
https://github.com/rancher/rancher/issues/33036

**Problem**
Client created as part of configuring Keycloak is not being used for the http call
The cert and key values are not being checked before attempting to add them to the http client
Http client is nil
Copy paste resulted in auth type of "token" being used

**Solution**
Remove the new client that is being created and use the one that is part of the keycloakClient
Ensure that cert and key are checked prior to attempting to add them to the http client tls settings 
Add code to set the http client when its created. 
Change so auth type of "bearer" is being used. 
