### PR TITLE
Allow hosted and imported clusters to enable PNI

### DIFF
--- a/pkg/api/norman/store/cluster/cluster_store.go
+++ b/pkg/api/norman/store/cluster/cluster_store.go
@@ -700,21 +700,20 @@ func getSupportedK8sVersion(k8sVersionRequest string) (string, error) {
 
 func validateNetworkFlag(data map[string]interface{}, create bool) error {
 	enableNetworkPolicy := values.GetValueN(data, "enableNetworkPolicy")
-	rkeConfig := values.GetValueN(data, "rancherKubernetesEngineConfig")
-
 	if enableNetworkPolicy == nil && create {
 		// setting default values for new clusters if value not passed
 		values.PutValue(data, false, "enableNetworkPolicy")
 	} else if value := convert.ToBool(enableNetworkPolicy); value {
-		if rkeConfig == nil {
+		rke2Config := values.GetValueN(data, "rke2Config")
+		k3sConfig := values.GetValueN(data, "k3sConfig")
+		if rke2Config != nil || k3sConfig != nil {
 			if create {
 				values.PutValue(data, false, "enableNetworkPolicy")
 				return nil
 			}
-			return fmt.Errorf("enableNetworkPolicy should be false for non-RKE clusters")
+			return fmt.Errorf("enableNetworkPolicy should be false for k3s or rke2 clusters")
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
This PR is for changes in validation logic for the `enableNetworkPolicy` boolean on cluster objects. The changes will allow for enabling of PNI on hosted and imported clusters.

In the cluster store, we do not have access to kontainer driver information, so the cluster type has to be inferred from *Config objects. By disallowing only for rke2 and k3s, we are effectively allowing this value to be set for other clusters.

These changes satisfy backend validation changes for these issues:
- https://github.com/rancher/rancher/issues/33016
- https://github.com/rancher/rancher/issues/32834
- https://github.com/rancher/rancher/issues/32833
- https://github.com/rancher/rancher/issues/32832