### PR TITLE
add GKE compatibility

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -57,11 +57,12 @@ kubectl create namespace cattle-system
 
 The Rancher management server is designed to be secure by default and requires SSL/TLS configuration.
 
-There are three recommended options for the source of the certificate used for TLS termination at the Rancher server:
+There are four recommended options for the source of the certificate used for TLS termination at the Rancher server:
 
 - [Rancher-generated TLS certificate](https://rancher.com/docs/rancher/v2.x/en/installation/k8s-install/helm-rancher/#4-choose-your-ssl-configuration)
 - [Let’s Encrypt](https://rancher.com/docs/rancher/v2.x/en/installation/k8s-install/helm-rancher/#4-choose-your-ssl-configuration)
 - [Bring your own certificate](https://rancher.com/docs/rancher/v2.x/en/installation/k8s-install/helm-rancher/#4-choose-your-ssl-configuration)
+- Use a [Google Managed Certificate](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs) which will be provisioned as part of the ingress.
 
 #### Install cert-manager
 
@@ -79,7 +80,7 @@ helm install rancher rancher-latest/rancher \
 ```
 
 - [Let’s Encrypt](https://rancher.com/docs/rancher/v2.x/en/installation/k8s-install/helm-rancher/#6-install-rancher-with-helm-and-your-chosen-certificate-option)
-  
+
 ```bash
 helm install rancher rancher-latest/rancher \
   --namespace cattle-system \
@@ -95,6 +96,15 @@ helm install rancher rancher-latest/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set ingress.tls.source=secret
+```
+
+- Google Managed Certificate
+
+```bash
+helm install rancher rancher-latest/rancher \
+  --namespace cattle-system \
+  --set hostname=rancher.my.org \
+  --set ingress.tls.source=google
 ```
 
 *If you are using a Private CA signed certificate , add **--set privateCA=true** to the command:`*
@@ -152,7 +162,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 | Parameter                 | Default Value | Description                                                                                  |
 | ------------------------- | ------------- | -------------------------------------------------------------------------------------------- |
 | `hostname`                | " "           | ***string*** - the Fully Qualified Domain Name for your Rancher Server                       |
-| `ingress.tls.source`      | "rancher"     | ***string*** - Where to get the cert for the ingress. - "***rancher, letsEncrypt, secret***" |
+| `ingress.tls.source`      | "rancher"     | ***string*** - Where to get the cert for the ingress. - "***rancher, letsEncrypt, secret, google***" |
 | `letsEncrypt.email`       | " "           | ***string*** - Your email address                                                            |
 | `letsEncrypt.environment` | "production"  | ***string*** - Valid options: "***staging, production***"                                    |
 | `privateCA`               | false         | ***bool*** - Set to true if your cert is signed by a private CA                              |
@@ -180,6 +190,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 | `ingress.enabled`              | true                                                  | ***bool*** - install ingress resource
 | `ingress.extraAnnotations`     | {}                                                    | ***map*** - additional annotations to customize the ingress                                                                                                                                                  |
 | `ingress.configurationSnippet` | " "                                                   | ***string*** - Add additional Nginx configuration. Can be used for proxy configuration. Note: *Available as of v2.0.15, v2.1.10 and v2.2.4*                                                                  |
+| `ingress.staticipname` | " "                                                   | ***string*** - The name of a static ip in your cloud provider which you have reserved. Sets `kubernetes.io/ingress.global-static-ip-name` if your cloud provider supports it.|
 | `letsEncrypt.ingress.class`    | " "                                                   | ***string*** - optional ingress class for the cert-manager acmesolver ingress that responds to the Let’s *Encrypt ACME challenges*                                                                           |
 | `proxy`                        | " "                                                   | ***string** - HTTP[S] proxy server for Rancher                                                                                                                                                               |
 | `noProxy`                      | "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16" | ***string*** - comma separated list of hostnames or ip address not to use the proxy                                                                                                                          |

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -26,7 +26,7 @@ metadata:
   {{- end }}
   {{- if .Values.ingress.tls.staticipname }}
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.tls.staticipname }}
-  {{-end }}
+  {{- end }}
   {{- if ne .Values.ingress.tls.source "secret" }}
     {{- $certmanagerVer :=  split "." .Values.certmanager.version -}}
     {{- if or (.Capabilities.APIVersions.Has "certmanager.k8s.io/v1alpha1") (and (gt (len $certmanagerVer._0) 0) (eq (int $certmanagerVer._0) 0) (lt (int $certmanagerVer._1) 11)) }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
 {{ include "rancher.labels" . | indent 4 }}
   annotations:
+  # All nginx annotations get silently ignored by the google XLB
 {{- if .Values.ingress.configurationSnippet }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {{- template "configurationSnippet" . }}
@@ -17,6 +18,15 @@ metadata:
 {{- if eq .Values.tls "external" }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false" # turn off ssl redirect for external.
 {{- else }}
+  {{- if .Values.ingress.tls.source "google" }}
+    # needed to disable NEGs from ruining rancher
+    kubernetes.io/ingress.class: gce
+    # hardcoded name of the managed certificate resource in issuer-google.yaml
+    networking.gke.io/managed-certificates: rancher-ingress
+  {{- end }}
+  {{- if .Values.ingress.tls.staticipname }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.tls.staticipname }}
+  {{-end }}
   {{- if ne .Values.ingress.tls.source "secret" }}
     {{- $certmanagerVer :=  split "." .Values.certmanager.version -}}
     {{- if or (.Capabilities.APIVersions.Has "certmanager.k8s.io/v1alpha1") (and (gt (len $certmanagerVer._0) 0) (eq (int $certmanagerVer._0) 0) (lt (int $certmanagerVer._1) 11)) }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
 {{- if eq .Values.tls "external" }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false" # turn off ssl redirect for external.
 {{- else }}
-  {{- if .Values.ingress.tls.source "google" }}
+  {{- if eq .Values.ingress.tls.source "google" }}
     # needed to disable NEGs from ruining rancher
     kubernetes.io/ingress.class: gce
     # hardcoded name of the managed certificate resource in issuer-google.yaml

--- a/chart/templates/issuer-google.yaml
+++ b/chart/templates/issuer-google.yaml
@@ -1,0 +1,11 @@
+{{- if eq .Values.tls "ingress" -}}
+  {{- if eq .Values.ingress.tls.source "google" -}}
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: rancher-ingress
+spec:
+  domains:
+    - {{ .Values.hostname }}
+  {{- end -}}
+{{- end -}}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    # Disable NEGs which use /healthz as the healthcheck by default
+    # Avoids a lot of extra google centeric configuration
+    cloud.google.com/neg: '{"ingress": false}'
   name: {{ template "rancher.fullname" . }}
   labels:
 {{ include "rancher.labels" . | indent 4 }}
@@ -16,3 +20,7 @@ spec:
     name: https-internal
   selector:
     app: {{ template "rancher.fullname" . }}
+{{- if eq .Values.ingress.tls.source "google" -}}
+  # Assumes a private cluster per best practices
+  type: NodePort
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -66,8 +66,10 @@ ingress:
   #   more_set_input_headers "X-Forwarded-Host: {{ .Values.hostname }}";
 
   tls:
-    # options: rancher, letsEncrypt, secret
+    # options: rancher, letsEncrypt, secret, google
     source: rancher
+  # Creates the ability to have a global IP address reserved
+  staticipname: ""
 
 ### LetsEncrypt config ###
 # ProTip: The production environment only allows you to register a name 5 times a week.
@@ -119,7 +121,7 @@ systemDefaultRegistry: ""
 useBundledSystemChart: false
 
 # Certmanager version compatibility
-certmanager: 
+certmanager:
   version: ""
 
 # Rancher custom logos persistence
@@ -132,7 +134,7 @@ customLogos:
   volumeKind: persistentVolumeClaim
   ## Use an existing volume. Custom logos should be copied to the volume by the user
   # volumeName: custom-logos
-  ## Just for volumeKind: persistentVolumeClaim 
+  ## Just for volumeKind: persistentVolumeClaim
   ## To disables dynamic provisioning, set storageClass: "" or storageClass: "-"
   # storageClass: "-"
   accessMode: ReadWriteOnce


### PR DESCRIPTION
# Problem 
I want to use a private GKE cluster to install Rancher, and would like to use google magic for TLS.

# New Functionality
`.Values.ingress.tls.source` - accepts `google` as a string now, which will create a google managed certificate and adjust the ingress and services accordingly.

`.Values.ingress.staticipname` - adds an annotation to allow kubernetes to use a static reserved IP in your cloud. Not google specific.

# Gotchas
* Google _really_ wants to use NEGs and may deprecate turning them off in the future.
* This assumes you followed google best practices of provisioning a private cluster (see the use of `NodePort` in the ingress)
