### PR TITLE
update cleanup for deleted clusters

### DIFF
--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -254,7 +254,9 @@ func ToRESTConfig(cluster *v3.Cluster, context *config.ScaledContext) (*rest.Con
 		return nil, nil
 	}
 
-	if cluster.DeletionTimestamp != nil {
+	// rke1 custom clusters need cleanup and the cluster delete is being paused by cluster-scoped-gc
+	// allow a rest config since the nodes still exist and we need to start jobs on them for cleanup
+	if cluster.DeletionTimestamp != nil && cluster.Status.Driver != v32.ClusterDriverRKE {
 		return nil, nil
 	}
 

--- a/pkg/controllers/management/aks/aks_cluster_handler.go
+++ b/pkg/controllers/management/aks/aks_cluster_handler.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/url"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
@@ -197,7 +196,7 @@ func (e *aksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 			cluster, err = e.generateAndSetServiceAccount(cluster)
 			if err != nil {
 				var statusErr error
-				if strings.Contains(err.Error(), fmt.Sprintf(dialer.WaitForAgentError, cluster.Name)) {
+				if err == dialer.ErrAgentDisconnected {
 					// In this case, the API endpoint is private and rancher is waiting for the import cluster command to be run.
 					cluster, statusErr = e.SetUnknown(cluster, apimgmtv3.ClusterConditionWaiting, "waiting for cluster agent to be deployed")
 					if statusErr == nil {

--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -273,7 +273,7 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 			cluster, err = e.generateAndSetServiceAccount(cluster)
 			if err != nil {
 				var statusErr error
-				if strings.Contains(err.Error(), fmt.Sprintf(dialer.WaitForAgentError, cluster.Name)) {
+				if err == dialer.ErrAgentDisconnected {
 					// In this case, the API endpoint is private and rancher is waiting for the import cluster command to be run.
 					cluster, statusErr = e.SetUnknown(cluster, apimgmtv3.ClusterConditionWaiting, "waiting for cluster agent to be deployed")
 					if statusErr == nil {

--- a/pkg/controllers/management/gke/gke_cluster_handler.go
+++ b/pkg/controllers/management/gke/gke_cluster_handler.go
@@ -216,7 +216,7 @@ func (e *gkeOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 			cluster, err = e.generateAndSetServiceAccount(cluster)
 			if err != nil {
 				var statusErr error
-				if strings.Contains(err.Error(), fmt.Sprintf(dialer.WaitForAgentError, cluster.Name)) {
+				if err == dialer.ErrAgentDisconnected {
 					// In this case, the API endpoint is private and rancher is waiting for the import cluster command to be run.
 					cluster, statusErr = e.SetUnknown(cluster, apimgmtv3.ClusterConditionWaiting, "waiting for cluster agent to be deployed")
 					if statusErr == nil {


### PR DESCRIPTION
During the cluster delete process some things go away like cluster agent and make things time out terrible and very ugly. This PR adds some checks to confirm if errors bubbling up from the dialer factory are connectivity errors and if they are then move on to deleting nodes. This PR also adds a short circuit to the clusterprovisioner to not do it's cleanup on RKE1 custom clusters as my node-cleanup process will do everything we need and is more reliable.

https://github.com/rancher/rancher/issues/26545