### PR TITLE
Handle System/Default projects for hosted Rancher

### DIFF
--- a/pkg/controllers/management/auth/project_cluster_handler.go
+++ b/pkg/controllers/management/auth/project_cluster_handler.go
@@ -266,14 +266,10 @@ func (m *mgr) createProject(name string, cond condition.Cond, obj runtime.Object
 			return obj, nil
 		}
 
-		creatorID, ok := metaAccessor.GetAnnotations()[creatorIDAnn]
-		if !ok {
-			logrus.Warnf("Cluster %v has no creatorId annotation. Cannot create %s project", metaAccessor.GetName(), name)
-			return obj, nil
-		}
-
-		annotation := map[string]string{
-			creatorIDAnn: creatorID,
+		annotation := make(map[string]string)
+		creatorID := metaAccessor.GetAnnotations()[creatorIDAnn]
+		if creatorID != "" {
+			annotation[creatorIDAnn] = creatorID
 		}
 
 		if name == project.System {


### PR DESCRIPTION
If the creatorID annotation was missing from the local cluster object,
then Rancher would skip creating the System and Default projects. After
this change, these projects will get created regardless of the
existence of the creatorID annotation.
    
Also, when `app.EnsureAppProjectName` was called in preparation for
installing an app, it reassigns the namespace to the project if the
namespace annotation is not the expected projectID. This change does not
reassign the cattle-system namespace in such cases. This is to attempt
to keep the cattle-system namespace in the host cluster's tenant System
project.

Issues:
https://github.com/rancher/rancher/issues/33053
https://github.com/rancher/rancher/issues/32149