### PR TITLE
[keycloak oidc] Add nil check, return errors

### DIFF
--- a/pkg/auth/providers/keycloakoidc/keycloak_client.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_client.go
@@ -48,12 +48,10 @@ func (k *KeyCloakClient) searchPrincipals(searchTerm, principalType string, acce
 		search := URLEncoded(searchURL)
 
 		b, statusCode, err := k.getFromKeyCloak(accessToken, search)
-		if statusCode == 401 {
-			return nil, nil
-		}
 		if err != nil {
-			return accounts, fmt.Errorf("[keycloak oidc]: GET request failed, got status code: %d. url: %s, err: %s",
+			logrus.Errorf("[keycloak oidc]: GET request failed, got status code: %d. url: %s, err: %s",
 				statusCode, search, err)
+			return accounts, err
 		}
 		if err := json.Unmarshal(b, &userAccounts); err != nil {
 			logrus.Errorf("[keycloak oidc]: received error unmarshalling search results, err: %v", err)
@@ -70,11 +68,9 @@ func (k *KeyCloakClient) searchPrincipals(searchTerm, principalType string, acce
 		search := URLEncoded(searchURL)
 
 		b, statusCode, err := k.getFromKeyCloak(accessToken, search)
-		if statusCode == 401 {
-			return nil, nil
-		}
 		if err != nil {
-			logrus.Errorf("[keycloak oidc]: GET url %v received error from github, err: %v", search, err)
+			logrus.Errorf("[keycloak oidc]: GET request failed, got status code: %d. url: %s, err: %s",
+				statusCode, search, err)
 			return accounts, err
 		}
 		if err := json.Unmarshal(b, &groups); err != nil {

--- a/pkg/auth/providers/keycloakoidc/keycloak_client.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_client.go
@@ -163,6 +163,9 @@ func (k *KeyCloakClient) getFromKeyCloak(accessToken, url string) ([]byte, int, 
 	}
 	defer resp.Body.Close()
 	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return b, resp.StatusCode, err
+	}
 	switch resp.StatusCode {
 	case 200:
 	case 201:

--- a/pkg/auth/providers/keycloakoidc/keycloak_provider.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider.go
@@ -78,6 +78,7 @@ func (k *keyCloakOIDCProvider) SearchPrincipals(searchValue, principalType strin
 	accts, err := keyCloakClient.searchPrincipals(searchValue, principalType, accessToken, config)
 	if err != nil {
 		logrus.Errorf("[keycloak oidc] problem searching keycloak: %v", err)
+		return principals, err
 	}
 	for _, acct := range accts {
 		p := k.toPrincipal(acct.Type, acct, &token)


### PR DESCRIPTION
**Issue**
https://github.com/rancher/rancher/issues/32920

**Problem**
` b, err := ioutil.ReadAll(resp.Body)` does not check for nil error after it
401 errors are being returned nil stead of just returning the error after `k.getFromKeyCloak`

**Solution**
Add nil check 
Return all errors if they exists after `k.getFromKeyCloak` is called. 