### PR TITLE
[chart] Set maxUnavailable: 0 if replicas=1 to allow helm to wait

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -18,7 +18,11 @@ spec:
   strategy:
     rollingUpdate:
       maxSurge: 1
+{{- if (eq (int .Values.replicas) 1) }}
+      maxUnavailable: 0
+{{- else }}
       maxUnavailable: 1
+{{- end }}
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
Solves: https://github.com/rancher/rancher/issues/33133

Tested with `--set replicas=1`, and `--set replicas=3` achieving the desired outcome of helm waiting in both scenarios.

A further `helm upgrade` with `--set replicas=1` created a new Rancher pod before terminating the running pod.