### PR TITLE
remove outdated AGENT_IMAGE setting

### DIFF
--- a/package/run.sh
+++ b/package/run.sh
@@ -108,8 +108,6 @@ check_x509_cert()
     fi
 }
 
-AGENT_IMAGE=${AGENT_IMAGE:-ubuntu:14.04}
-
 export CATTLE_ADDRESS
 export CATTLE_AGENT_CONNECT
 export CATTLE_INTERNAL_ADDRESS


### PR DESCRIPTION
this setting is no longer in use, its last reference was removed in
https://github.com/rancher/rancher/commit/c08790d40a7565f6e64b1b942ac625fab41fa92f#diff-d0dab9599d947b7177a6ef7453f6ccc55151b7c70d52ad2ada1ba78caa438093L58
