### PR TITLE
[2.5] Fix rancher agent docker auth config when using private registry

### DIFF
--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -4,10 +4,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 
-	"github.com/docker/docker/api/types"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	rketypes "github.com/rancher/rke/types"
+	"k8s.io/kubernetes/pkg/credentialprovider"
 )
 
 func GetPrivateRepoURL(cluster *v3.Cluster) string {
@@ -43,9 +43,13 @@ func GeneratePrivateRegistryDockerConfig(privateRegistry *rketypes.PrivateRegist
 	if privateRegistry == nil || privateRegistry.User == "" || privateRegistry.Password == "" {
 		return "", nil
 	}
-	authConfig := types.AuthConfig{
-		Username: privateRegistry.User,
-		Password: privateRegistry.Password,
+	authConfig := credentialprovider.DockerConfigJSON{
+		Auths: credentialprovider.DockerConfig{
+			privateRegistry.URL: credentialprovider.DockerConfigEntry{
+				Username: privateRegistry.User,
+				Password: privateRegistry.Password,
+			},
+		},
 	}
 	encodedJSON, err := json.Marshal(authConfig)
 	if err != nil {


### PR DESCRIPTION
Issue #27306
Issue #30628
Issue #33128

Required by PR https://github.com/rancher/rancher/pull/33166

When using private registry with auth, Rancher is creating/updating the `cattle-system/cattle-private-registry` secret containing `.dockerconfigjson`,  to be used by rancher cluster and node agents to be able to pull images. This secret is not working properly due to `.dockerconfigjson` is generated in a bad format. This issue was "hided" due to rancher cluster and node agents can't pull images by themselves config, but at the end they are able to use the cluster level private registry config.

This PR updates the `GeneratePrivateRegistryDockerConfig` function to use proper k8s secret `.dockerconfigjson` format so rancher cluster and node agents are able to pull docker image  by themselves config