### PR TITLE
[2.5] Wait for rancher agent daemonset rollout before update cluster

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -305,7 +305,7 @@ func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
 			logrus.Tracef("clusterDeploy: deployAgent: applying agent YAML for cluster [%s], try #%d: %v", cluster.Name, i+1, string(output))
 			output, err = kubectl.Apply(yaml, kubeConfig)
 			if err == nil {
-				logrus.Tracef("clusterDeploy: deployAgent: successfully applied agent YAML for cluster [%s], try #%d", cluster.Name, i+1)
+				logrus.Debugf("clusterDeploy: deployAgent: successfully applied agent YAML for cluster [%s], try #%d", cluster.Name, i+1)
 				break
 			}
 			logrus.Debugf("clusterDeploy: deployAgent: error while applying agent YAML for cluster [%s], try #%d", cluster.Name, i+1)
@@ -337,6 +337,22 @@ func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
 				}
 				logrus.Debugf("Ignored '%s' error during delete cattle-node-agent DaemonSet", dsNotFoundError)
 			}
+		} else if strings.ToLower(settings.AgentRolloutWait.Get()) == "true" {
+			// Check for agent daemonset rollout if parameter is set and driverv32.ClusterDriverRKE
+			timeout := settings.AgentRolloutTimeout.Get()
+			_, err = time.ParseDuration(timeout)
+			if err != nil {
+				logrus.Warnf("[deployAgent] agent-rollout-timeout setting must be in Duration format. Using default: 300s")
+				timeout = "300s"
+			}
+			logrus.Debugf("clusterDeploy: deployAgent: waiting rollout agent daemonset for cluster [%s]", cluster.Name)
+			output, err := kubectl.RolloutStatusWithNamespace("cattle-system", "ds/cattle-node-agent", timeout, kubeConfig)
+			if err != nil {
+				logrus.Debugf("clusterDeploy: deployAgent: timeout waiting rollout agent daemonset for cluster [%s]: %v", cluster.Name, err)
+				return cluster, errors.WithMessage(types.NewErrors(err, errors.New(formatKubectlApplyOutput(string(output)))), "Timeout waiting rollout agent daemonset")
+			}
+			logrus.Debugf("clusterDeploy: deployAgent: successfully rollout agent daemonset for cluster [%s]", cluster.Name)
+			v32.ClusterConditionAgentDeployed.Message(cluster, "Successfully rollout agent daemonset")
 		}
 		v32.ClusterConditionAgentDeployed.Message(cluster, string(output))
 		return cluster, nil

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -49,6 +49,25 @@ func ApplyWithNamespace(yaml []byte, namespace string, kubeConfig *clientcmdapi.
 	return runWithHTTP2(cmd)
 }
 
+func RolloutStatusWithNamespace(namespace, name, timeout string, kubeConfig *clientcmdapi.Config) ([]byte, error) {
+	kubeConfigFile, err := writeKubeConfig(kubeConfig)
+	defer cleanup(kubeConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command("kubectl",
+		"--kubeconfig",
+		kubeConfigFile.Name(),
+		"-n",
+		namespace,
+		"rollout",
+		"status",
+		name,
+		"--timeout",
+		timeout)
+	return runWithHTTP2(cmd)
+}
+
 func Delete(yaml []byte, kubeConfig *clientcmdapi.Config) ([]byte, error) {
 	kubeConfigFile, yamlFile, err := writeData(kubeConfig, yaml)
 	defer cleanup(kubeConfigFile, yamlFile)

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -20,6 +20,8 @@ var (
 	InjectDefaults string
 
 	AgentImage                        = NewSetting("agent-image", "rancher/rancher-agent:master-head")
+	AgentRolloutTimeout               = NewSetting("agent-rollout-timeout", "300s")
+	AgentRolloutWait                  = NewSetting("agent-rollout-wait", "true")
 	AuthImage                         = NewSetting("auth-image", v32.ToolsSystemImages.AuthSystemImages.KubeAPIAuth)
 	AuthTokenMaxTTLMinutes            = NewSetting("auth-token-max-ttl-minutes", "0") // never expire
 	AuthorizationCacheTTLSeconds      = NewSetting("authorization-cache-ttl-seconds", "10")

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -218,6 +218,11 @@ spec:
         secret:
           secretName: cattle-credentials-{{.TokenKey}}
           defaultMode: 320
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
 {{ if .IsRKE }}
 
 ---
@@ -315,7 +320,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 25%
+      maxUnavailable: 50%
 
 {{- end }}
 
@@ -413,7 +418,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 25%
+      maxUnavailable: 50%
 {{- end }}
 
 {{- if .AuthImage}}


### PR DESCRIPTION
Issue https://github.com/rancher/rancher/issues/27306
Issue https://github.com/rancher/rancher/issues/30628
Issue https://github.com/rancher/rancher/issues/33128

Requires PR https://github.com/rancher/rancher/pull/33165

The root cause of these issues seems to be related with the way that rancher agents are updated. Eventually, the rancher agent becomes updated in the middle of a node plan execution, making that the node plan execution aborts and the rancher agent is never restarted. 

This PR add the option to check that the `cattle-node-agent` daemonset has been properly updated and rollout, before continue with the cluster update. This is assuring that the rancher agent is updated and running before the cluster provision to avoid its updated during a node plan execution. This also add some reliability to the cluster update process due to if the new rancher agent config is not working properly the cluster will not be updated and still ready and working

Also, added 2 new rancher setting to allow the config if cluster update should wait for rancher agent daemonset:
* `agent-rollout-wait`: Wait for agent rollout. Default: "true" 
* `agent-rollout-timeout`: Timeout waiting for agent rollout. Default: "300s" 

With the PR applied, the cluster update behaviour can be changed based on `agent-rollout-wait` setting:
* `agent-rollout-wait="false"`: Current behaviour
  cluster updated by user -> agent deployment NO wait for rollout (client tunnel) -> cluster update (rke up - eventually, agent rollout occurs in the middle of this execution causing the issue) -> cluster active/error
* `agent-rollout-wait="true"`: Proposed behaviour
  cluster updated by user -> agent deployment wait for rollout (client tunnel) -> cluster update (rke up - agent is already rollout) -> cluster active
  On tests done on this scenario, the cluster update seems safer and "easier" to recover in that way. When update a cluster, if a new agent config is not working, the agent rollout is timeout and the cluster update is stopped. The cluster became on error on ui, but the k8s is perfectly working due to has not been updated. To recover the state, editing the cluster undoing the last changes and saving, makes that the agent is redeployed with previous working config.

