### PR TITLE
add contract labels for rkeclusters.rke.cattle.io

### DIFF
--- a/pkg/crds/provisioningv2/crds.go
+++ b/pkg/crds/provisioningv2/crds.go
@@ -69,6 +69,9 @@ func rke2() []crd.CRD {
 				WithColumn("Kubeconfig", ".status.clientSecretName")
 		}),
 		newRKECRD(&rkev1.RKECluster{}, func(c crd.CRD) crd.CRD {
+			c.Labels = map[string]string{
+				"cluster.x-k8s.io/v1alpha4": "v1",
+			}
 			return clusterIndexed(c)
 		}),
 		newRKECRD(&rkev1.RKEControlPlane{}, func(c crd.CRD) crd.CRD {


### PR DESCRIPTION

`
2021/06/14 12:16:51 [ERROR] Reconciler error: cannot find any versions matching contract "cluster.x-k8s.io/v1alpha4" for CRD rkeclusters.rke.cattle.io as contract version label(s) are either missing or empty 
`

