### PR TITLE
RestrictedAdmin can manage admin user and also unreverting restrictedAdmin feature 

### DIFF
--- a/pkg/api/norman/server/managementstored/setup.go
+++ b/pkg/api/norman/server/managementstored/setup.go
@@ -367,7 +367,10 @@ func Catalog(schemas *types.Schemas, managementContext *config.ScaledContext) {
 	schema.CollectionFormatter = catalog.CollectionFormatter
 	schema.LinkHandler = handler.ExportYamlHandler
 	schema.Validator = catalog.Validator
-	schema.Store = catalogStore.Wrap(schema.Store)
+	users := managementContext.Management.Users("")
+	grbLister := managementContext.Management.GlobalRoleBindings("").Controller().Lister()
+	grLister := managementContext.Management.GlobalRoles("").Controller().Lister()
+	schema.Store = catalogStore.Wrap(schema.Store, users, grbLister, grLister)
 }
 
 func ProjectCatalog(schemas *types.Schemas, managementContext *config.ScaledContext) {
@@ -379,7 +382,10 @@ func ProjectCatalog(schemas *types.Schemas, managementContext *config.ScaledCont
 	schema.ActionHandler = handler.RefreshProjectCatalogActionHandler
 	schema.CollectionFormatter = catalog.CollectionFormatter
 	schema.Validator = catalog.Validator
-	schema.Store = catalogStore.Wrap(schema.Store)
+	users := managementContext.Management.Users("")
+	grbLister := managementContext.Management.GlobalRoleBindings("").Controller().Lister()
+	grLister := managementContext.Management.GlobalRoles("").Controller().Lister()
+	schema.Store = catalogStore.Wrap(schema.Store, users, grbLister, grLister)
 }
 
 func ClusterCatalog(schemas *types.Schemas, managementContext *config.ScaledContext) {
@@ -391,7 +397,10 @@ func ClusterCatalog(schemas *types.Schemas, managementContext *config.ScaledCont
 	schema.ActionHandler = handler.RefreshClusterCatalogActionHandler
 	schema.CollectionFormatter = catalog.CollectionFormatter
 	schema.Validator = catalog.Validator
-	schema.Store = catalogStore.Wrap(schema.Store)
+	users := managementContext.Management.Users("")
+	grbLister := managementContext.Management.GlobalRoleBindings("").Controller().Lister()
+	grLister := managementContext.Management.GlobalRoles("").Controller().Lister()
+	schema.Store = catalogStore.Wrap(schema.Store, users, grbLister, grLister)
 }
 
 func ClusterRegistrationTokens(schemas *types.Schemas, management *config.ScaledContext) {
@@ -478,6 +487,8 @@ func User(ctx context.Context, schemas *types.Schemas, management *config.Scaled
 		UserClient:               management.Management.Users(""),
 		GlobalRoleBindingsClient: management.Management.GlobalRoleBindings(""),
 		UserAuthRefresher:        providerrefresh.NewUserAuthRefresher(ctx, management),
+		GlobalRoleBindingsLister: management.Management.GlobalRoleBindings("").Controller().Lister(),
+		GlobalRoleLister:         management.Management.GlobalRoles("").Controller().Lister(),
 	}
 
 	schema.Formatter = handler.UserFormatter

--- a/pkg/api/norman/server/managementstored/setup.go
+++ b/pkg/api/norman/server/managementstored/setup.go
@@ -487,10 +487,7 @@ func User(ctx context.Context, schemas *types.Schemas, management *config.Scaled
 		UserClient:               management.Management.Users(""),
 		GlobalRoleBindingsClient: management.Management.GlobalRoleBindings(""),
 		UserAuthRefresher:        providerrefresh.NewUserAuthRefresher(ctx, management),
-		GlobalRoleBindingsLister: management.Management.GlobalRoleBindings("").Controller().Lister(),
-		GlobalRoleLister:         management.Management.GlobalRoles("").Controller().Lister(),
 	}
-
 	schema.Formatter = handler.UserFormatter
 	schema.CollectionFormatter = handler.CollectionFormatter
 	schema.ActionHandler = handler.Actions

--- a/pkg/api/norman/store/catalog/store.go
+++ b/pkg/api/norman/store/catalog/store.go
@@ -7,16 +7,24 @@ import (
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	c "github.com/rancher/rancher/pkg/api/norman/customization/catalog"
+	gaccess "github.com/rancher/rancher/pkg/api/norman/customization/globalnamespaceaccess"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 )
 
 type Store struct {
 	types.Store
+	Users     v3.UserInterface
+	GrbLister v3.GlobalRoleBindingLister
+	GrLister  v3.GlobalRoleLister
 }
 
-func Wrap(store types.Store) types.Store {
+func Wrap(store types.Store, users v3.UserInterface, grbLister v3.GlobalRoleBindingLister, grLister v3.GlobalRoleLister) types.Store {
 	return &Store{
-		store,
+		Store:     store,
+		Users:     users,
+		GrbLister: grbLister,
+		GrLister:  grLister,
 	}
 }
 
@@ -37,11 +45,26 @@ func (s *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 		return nil, err
 	}
 	if isSystemCatalog {
-		if strings.ToLower(settings.SystemCatalog.Get()) == "bundled" {
+		isRestrictedAdmin, err := s.isRestrictedAdmin(apiContext)
+		if err != nil {
+			return nil, err
+		}
+		if strings.ToLower(settings.SystemCatalog.Get()) == "bundled" || isRestrictedAdmin {
 			return nil, httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprint("not allowed to edit system-library catalog"))
 		}
 	}
 	return s.Store.Update(apiContext, schema, data, id)
+}
+
+func (s *Store) isRestrictedAdmin(apiContext *types.APIContext) (bool, error) {
+	ma := gaccess.MemberAccess{
+		Users:     s.Users,
+		GrLister:  s.GrLister,
+		GrbLister: s.GrbLister,
+	}
+	callerID := apiContext.Request.Header.Get(gaccess.ImpersonateUserHeader)
+
+	return ma.IsRestrictedAdmin(callerID)
 }
 
 // isSystemCatalog checks whether the catalog is the the system catalog maintained by rancher

--- a/pkg/auth/api/user/user_actions.go
+++ b/pkg/auth/api/user/user_actions.go
@@ -8,12 +8,10 @@ import (
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/parse"
 	"github.com/rancher/norman/types"
-	gaccess "github.com/rancher/rancher/pkg/api/norman/customization/globalnamespaceaccess"
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
 	"github.com/rancher/rancher/pkg/auth/settings"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -23,12 +21,6 @@ func (h *Handler) UserFormatter(apiContext *types.APIContext, resource *types.Ra
 
 	if canRefresh := h.userCanRefresh(apiContext); canRefresh {
 		resource.AddAction(apiContext, "refreshauthprovideraccess")
-	}
-
-	//restrictedAdmin should not see changePassword and setPassword for GlobalAdmin user
-	if h.isAdminResource(resource.ID) && h.isRestrictedAdmin(apiContext) {
-		delete(resource.Actions, "setpassword")
-		delete(resource.Actions, "changepassword")
 	}
 }
 
@@ -43,8 +35,6 @@ type Handler struct {
 	UserClient               v3.UserInterface
 	GlobalRoleBindingsClient v3.GlobalRoleBindingInterface
 	UserAuthRefresher        providerrefresh.UserAuthRefresher
-	GlobalRoleBindingsLister v3.GlobalRoleBindingLister
-	GlobalRoleLister         v3.GlobalRoleLister
 }
 
 func (h *Handler) Actions(actionName string, action *types.Action, apiContext *types.APIContext) error {
@@ -179,31 +169,4 @@ func (h *Handler) refreshAttributes(actionName string, action *types.Action, req
 
 func (h *Handler) userCanRefresh(request *types.APIContext) bool {
 	return request.AccessControl.CanDo(v3.UserGroupVersionKind.Group, v3.UserResource.Name, "create", request, nil, request.Schema) == nil
-}
-
-func (h *Handler) isRestrictedAdmin(apiContext *types.APIContext) bool {
-	ma := gaccess.MemberAccess{
-		Users:     h.UserClient,
-		GrLister:  h.GlobalRoleLister,
-		GrbLister: h.GlobalRoleBindingsLister,
-	}
-	callerID := apiContext.Request.Header.Get(gaccess.ImpersonateUserHeader)
-	isRestrictedAdmin, err := ma.IsRestrictedAdmin(callerID)
-	if err != nil {
-		logrus.Errorf("error checking if resource is restrictedAdmin %v", err)
-	}
-	return isRestrictedAdmin
-}
-
-func (h *Handler) isAdminResource(resourceID string) bool {
-	ma := gaccess.MemberAccess{
-		Users:     h.UserClient,
-		GrLister:  h.GlobalRoleLister,
-		GrbLister: h.GlobalRoleBindingsLister,
-	}
-	isAdminResource, err := ma.IsAdmin(resourceID)
-	if err != nil {
-		logrus.Errorf("error checking if resource is admin %v", err)
-	}
-	return isAdminResource
 }

--- a/pkg/auth/api/user/user_store.go
+++ b/pkg/auth/api/user/user_store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/store/transform"
 	"github.com/rancher/norman/types"
+	gaccess "github.com/rancher/rancher/pkg/api/norman/customization/globalnamespaceaccess"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
@@ -25,6 +26,9 @@ type userStore struct {
 	mu          sync.Mutex
 	userIndexer cache.Indexer
 	userManager user.Manager
+	users       v3.UserInterface
+	grbLister   v3.GlobalRoleBindingLister
+	grLister    v3.GlobalRoleLister
 }
 
 func SetUserStore(schema *types.Schema, mgmt *config.ScaledContext) {
@@ -33,12 +37,18 @@ func SetUserStore(schema *types.Schema, mgmt *config.ScaledContext) {
 		userByUsernameIndex: userByUsername,
 	}
 	userInformer.AddIndexers(userIndexers)
+	users := mgmt.Management.Users("")
+	grbLister := mgmt.Management.GlobalRoleBindings("").Controller().Lister()
+	grLister := mgmt.Management.GlobalRoles("").Controller().Lister()
 
 	store := &userStore{
 		Store:       schema.Store,
 		mu:          sync.Mutex{},
 		userIndexer: userInformer.GetIndexer(),
 		userManager: mgmt.UserManager,
+		users:       users,
+		grbLister:   grbLister,
+		grLister:    grLister,
 	}
 
 	t := &transform.Store{
@@ -194,6 +204,19 @@ func (s *userStore) Update(apiContext *types.APIContext, schema *types.Schema, d
 		return nil, httperror.NewAPIError(httperror.InvalidAction, "You cannot deactivate yourself")
 	}
 
+	isAdminResource, err := s.isAdminResource(id)
+	if err != nil {
+		return nil, err
+	}
+	if isAdminResource {
+		isRestrictedAdmin, err := s.isRestrictedAdmin(apiContext)
+		if err != nil {
+			return nil, err
+		}
+		if isRestrictedAdmin {
+			return nil, httperror.NewAPIError(httperror.InvalidAction, "you cannot edit this user")
+		}
+	}
 	return s.Store.Update(apiContext, schema, data, id)
 }
 
@@ -207,6 +230,19 @@ func (s *userStore) Delete(apiContext *types.APIContext, schema *types.Schema, i
 		return nil, httperror.NewAPIError(httperror.InvalidAction, "You cannot delete yourself")
 	}
 
+	isAdminResource, err := s.isAdminResource(id)
+	if err != nil {
+		return nil, err
+	}
+	if isAdminResource {
+		isRestrictedAdmin, err := s.isRestrictedAdmin(apiContext)
+		if err != nil {
+			return nil, err
+		}
+		if isRestrictedAdmin {
+			return nil, httperror.NewAPIError(httperror.InvalidAction, "you cannot delete this user")
+		}
+	}
 	return s.Store.Delete(apiContext, schema, id)
 }
 
@@ -217,4 +253,23 @@ func getUser(apiContext *types.APIContext) (string, error) {
 	}
 
 	return user, nil
+}
+
+func (s *userStore) isRestrictedAdmin(apiContext *types.APIContext) (bool, error) {
+	ma := gaccess.MemberAccess{
+		Users:     s.users,
+		GrLister:  s.grLister,
+		GrbLister: s.grbLister,
+	}
+	callerID := apiContext.Request.Header.Get(gaccess.ImpersonateUserHeader)
+	return ma.IsRestrictedAdmin(callerID)
+}
+
+func (s *userStore) isAdminResource(id string) (bool, error) {
+	ma := gaccess.MemberAccess{
+		Users:     s.users,
+		GrLister:  s.grLister,
+		GrbLister: s.grbLister,
+	}
+	return ma.IsAdmin(id)
 }

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -87,10 +87,22 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	restrictedAdminRole := addUserRules(rb.addRole("Restricted Admin", "restricted-admin"))
 	restrictedAdminRole.
 		addRule().apiGroups("management.cattle.io").resources("clustertemplates").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("clustertemplaterevisions").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("globalroles", "globalrolebindings").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("users", "userattribute", "groups", "groupmembers").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("*").
-		addRule().apiGroups("management.cattle.io").resources("fleetworkspaces").verbs("*")
+		addRule().apiGroups("management.cattle.io").resources("fleetworkspaces").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("authconfigs").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("kontainerdrivers").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("roletemplates").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("catalogs", "templates", "templateversions").verbs("*")
+
+	// restricted-admin can edit settings if rancher is bootstrapped with restricted-admin role
+	if settings.RestrictedDefaultAdmin.Get() == "true" {
+		restrictedAdminRole.
+			addRule().apiGroups("management.cattle.io").resources("settings").verbs("*")
+	}
 
 	userRole := addUserRules(rb.addRole("User", "user"))
 	userRole.addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("get", "list", "watch")


### PR DESCRIPTION
Earlier added the check to avoid RestrictedAdmin editing Admin user. But this check is not needed since any user having "manage users" permissions can edit an Admin user.

Since RestrictedAdmin can manage users, they can update the globalAdmin and other admin users.

This PR is removing these checks, also this will avoid the GlobalRoleBinding CRD issue when MCM is disabled.
https://github.com/rancher/rancher/issues/33125