### PR TITLE
Add lock to uninstall to avoid launching multiple uninstall pod

### DIFF
--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -57,9 +57,12 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 		return setting, nil
 	}
 
+	h.Lock()
 	if err := h.manager.Uninstall(fleetUninstallChart.ReleaseNamespace, fleetUninstallChart.ChartName); err != nil {
+		h.Unlock()
 		return nil, err
 	}
+	h.Unlock()
 
 	err := h.manager.Ensure(fleetCRDChart.ReleaseNamespace, fleetCRDChart.ChartName, settings.FleetMinVersion.Get(), nil)
 	if err != nil {


### PR DESCRIPTION
https://github.com/rancher/fleet/issues/419

During the `cattle-fleet-system` namespace migration we need to run uninstall to make sure the previous release in old namespace is removed. The uninstall operation can't be run in parrallel due to the issue above.