### PR TITLE
Check RBAC status of an AKS cluster

### DIFF
--- a/pkg/api/norman/customization/aks/listers.go
+++ b/pkg/api/norman/customization/aks/listers.go
@@ -220,6 +220,7 @@ func listVirtualNetworks(ctx context.Context, cap *Capabilities) ([]byte, int, e
 type clustersResponseBody struct {
 	ResourceGroup string `json:"resourceGroup"`
 	ClusterName   string `json:"clusterName"`
+	RBACEnabled   bool   `json:"rbacEnabled"`
 }
 
 func listClusters(ctx context.Context, cap *Capabilities) ([]byte, int, error) {
@@ -239,6 +240,7 @@ func listClusters(ctx context.Context, cap *Capabilities) ([]byte, int, error) {
 		for _, cluster := range clusterList.Values() {
 			tmpCluster := clustersResponseBody{
 				ClusterName: to.String(cluster.Name),
+				RBACEnabled: to.Bool(cluster.EnableRBAC),
 			}
 			if cluster.ID != nil {
 				match := matchResourceGroup.FindStringSubmatch(to.String(cluster.ID))

--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -364,6 +364,7 @@ type SaveAsTemplateOutput struct {
 type AKSStatus struct {
 	UpstreamSpec          *aksv1.AKSClusterConfigSpec `json:"upstreamSpec"`
 	PrivateRequiresTunnel *bool                       `json:"privateRequiresTunnel"`
+	RBACEnabled           *bool                       `json:"rbacEnabled"`
 }
 
 type EKSStatus struct {

--- a/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -80,6 +80,11 @@ func (in *AKSStatus) DeepCopyInto(out *AKSStatus) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RBACEnabled != nil {
+		in, out := &in.RBACEnabled, &out.RBACEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/client/generated/management/v3/zz_generated_aks_status.go
+++ b/pkg/client/generated/management/v3/zz_generated_aks_status.go
@@ -3,10 +3,12 @@ package client
 const (
 	AKSStatusType                       = "aksStatus"
 	AKSStatusFieldPrivateRequiresTunnel = "privateRequiresTunnel"
+	AKSStatusFieldRBACEnabled           = "rbacEnabled"
 	AKSStatusFieldUpstreamSpec          = "upstreamSpec"
 )
 
 type AKSStatus struct {
 	PrivateRequiresTunnel *bool                 `json:"privateRequiresTunnel,omitempty" yaml:"privateRequiresTunnel,omitempty"`
+	RBACEnabled           *bool                 `json:"rbacEnabled,omitempty" yaml:"rbacEnabled,omitempty"`
 	UpstreamSpec          *AKSClusterConfigSpec `json:"upstreamSpec,omitempty" yaml:"upstreamSpec,omitempty"`
 }

--- a/pkg/controllers/management/aks/aks_cluster_handler.go
+++ b/pkg/controllers/management/aks/aks_cluster_handler.go
@@ -171,6 +171,15 @@ func (e *aksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 			return cluster, err
 		}
 
+		if cluster.Status.AKSStatus.RBACEnabled == nil {
+			enabled, ok := status["rbacEnabled"].(bool)
+			if ok {
+				cluster = cluster.DeepCopy()
+				cluster.Status.AKSStatus.RBACEnabled = &enabled
+				return e.ClusterClient.Update(cluster)
+			}
+		}
+
 		if cluster.Status.APIEndpoint == "" {
 			return e.RecordCAAndAPIEndpoint(cluster)
 		}


### PR DESCRIPTION
It is possible to create an AKS cluster with RBAC disabled. In order to
display a warning message to users when RBAC is disabled, it status of
RBAC is put on the status of the cluster.

Also, the aksListClusters proxy endpoint also includes whether the RBAC
is enabled for each cluster. This would allow a warning message to be
displayed when registering AKS clusters.

Issue:
https://github.com/rancher/rancher/issues/27670