### PR TITLE
Add adopt and change fleet-crd to cattle-fleet-system

### DIFF
--- a/pkg/api/steve/catalog/types/rest.go
+++ b/pkg/api/steve/catalog/types/rest.go
@@ -52,6 +52,7 @@ type ChartUpgradeAction struct {
 	Namespace                string           `json:"namespace,omitempty"`
 	CleanupOnFail            bool             `json:"cleanupOnFail,omitempty"`
 	Charts                   []ChartUpgrade   `json:"charts,omitempty"`
+	ForceAdopt               bool             `json:"forceAdopt,omitempty"`
 }
 
 type ChartUpgrade struct {

--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -112,7 +112,7 @@ func (h *handler) onRepo(key string, repo *catalog.ClusterRepo) (*catalog.Cluste
 				values[k] = v
 			}
 		}
-		if err := h.manager.Ensure(chartDef.ReleaseNamespace, chartDef.ChartName, chartDef.MinVersionSetting.Get(), values); err != nil {
+		if err := h.manager.Ensure(chartDef.ReleaseNamespace, chartDef.ChartName, chartDef.MinVersionSetting.Get(), values, false); err != nil {
 			return repo, err
 		}
 	}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/32560
https://github.com/rancher/rancher/issues/33203

Add force-adopt flag so that it can adopt crd resource that were previously installed in `fleet-system`. This can help migrating fleet-crd chart from `fleet-system` to `cattle-fleet-system`.