### PR TITLE
Remove instructions to add BCI repo

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -15,8 +15,7 @@ ENV KUSTOMIZE_VERSION v3.10.0
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
 ENV CATTLE_KDM_BRANCH=dev-v2.6
 
-RUN zypper ar --refresh --priority 100 'https://updates.suse.com/SUSE/Products/SLE-BCI/$releasever_major-SP$releasever_minor/$basearch/product/' SLE_BCI && \
-    zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl tar vim less file xz gzip sed gawk iproute2 iptables
+RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl tar vim less file xz gzip sed gawk iproute2 iptables
 
 RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,6 @@
 FROM registry.suse.com/suse/sle15:15.3
 
-RUN zypper -n ar --refresh --priority 100 'https://updates.suse.com/SUSE/Products/SLE-BCI/$releasever_major-SP$releasever_minor/$basearch/product/' SLE_BCI && \
-    zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk && \
+RUN zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
     rpm -e libsolv-tools zypper libzypp container-suseconnect ; \
     useradd rancher && \

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -7,8 +7,7 @@ ARG ARCH=amd64
 
 ENV KUBECTL_VERSION v1.20.7
 # sysstat is left out until systemd dependency is stripped
-RUN zypper -n ar --refresh --priority 100 'https://updates.suse.com/SUSE/Products/SLE-BCI/$releasever_major-SP$releasever_minor/$basearch/product/' SLE_BCI && \
-    zypper -n install --no-recommends curl ca-certificates jq hostname iproute2 vim-small less bash-completion acl openssh-clients tar gzip xz gawk && \
+RUN zypper -n install --no-recommends curl ca-certificates jq hostname iproute2 vim-small less bash-completion acl openssh-clients tar gzip xz gawk && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
     rpm -e libsolv-tools zypper libzypp container-suseconnect ; \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \


### PR DESCRIPTION
With the latest revision of the SLE BCI the repository is pre-configured
within the image hence no need to add it via the "zypper addrepo"
instructions.