### PR TITLE
Audit log enhancements for Kubectl access path

### DIFF
--- a/pkg/api/norman/customization/cluster/shell.go
+++ b/pkg/api/norman/customization/cluster/shell.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/rancher/pkg/user"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/transport"
@@ -35,8 +36,16 @@ func (s *ShellLinkHandler) LinkHandler(apiContext *types.APIContext, next types.
 	if minutes, err := strconv.ParseInt(settings.AuthUserSessionTTLMinutes.Get(), 10, 64); err == nil {
 		shellTTL = minutes * 60 * 1000 // convert minutes to milliseconds
 	}
-
-	token, err := userManager.EnsureToken("kubectl-shell-"+userID, "Access to kubectl shell in the browser", "kubectl-shell", userID, &shellTTL, true)
+	input := user.TokenInput{
+		TokenName:    "kubectl-shell-" + userID,
+		Description:  "Access to kubectl shell in the browser",
+		Kind:         "kubectl-shell",
+		UserName:     userID,
+		AuthProvider: "local",
+		TTL:          &shellTTL,
+		Randomize:    true,
+	}
+	token, err := userManager.EnsureToken(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/apis/cluster.cattle.io/v3/types.go
+++ b/pkg/apis/cluster.cattle.io/v3/types.go
@@ -14,11 +14,11 @@ type ClusterUserAttribute struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Groups       []string                       `json:"groups,omitempty"`
-	LastRefresh  string                         `json:"lastRefresh,omitempty"`
-	NeedsRefresh bool                           `json:"needsRefresh"`
-	Enabled      bool                           `json:"enabled"`
-	Extra        map[string]map[string][]string `json:"extra,omitempty"`
+	Groups          []string                       `json:"groups,omitempty"`
+	LastRefresh     string                         `json:"lastRefresh,omitempty"`
+	NeedsRefresh    bool                           `json:"needsRefresh"`
+	Enabled         bool                           `json:"enabled"`
+	ExtraByProvider map[string]map[string][]string `json:"extraByProvider,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/cluster.cattle.io/v3/types.go
+++ b/pkg/apis/cluster.cattle.io/v3/types.go
@@ -14,11 +14,11 @@ type ClusterUserAttribute struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Groups       []string            `json:"groups,omitempty"`
-	LastRefresh  string              `json:"lastRefresh,omitempty"`
-	NeedsRefresh bool                `json:"needsRefresh"`
-	Enabled      bool                `json:"enabled"`
-	Extra        map[string][]string `json:"extra,omitempty"`
+	Groups       []string                       `json:"groups,omitempty"`
+	LastRefresh  string                         `json:"lastRefresh,omitempty"`
+	NeedsRefresh bool                           `json:"needsRefresh"`
+	Enabled      bool                           `json:"enabled"`
+	Extra        map[string]map[string][]string `json:"extra,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/cluster.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/cluster.cattle.io/v3/zz_generated_deepcopy.go
@@ -97,15 +97,25 @@ func (in *ClusterUserAttribute) DeepCopyInto(out *ClusterUserAttribute) {
 	}
 	if in.Extra != nil {
 		in, out := &in.Extra, &out.Extra
-		*out = make(map[string][]string, len(*in))
+		*out = make(map[string]map[string][]string, len(*in))
 		for key, val := range *in {
-			var outVal []string
+			var outVal map[string][]string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
 				in, out := &val, &outVal
-				*out = make([]string, len(*in))
-				copy(*out, *in)
+				*out = make(map[string][]string, len(*in))
+				for key, val := range *in {
+					var outVal []string
+					if val == nil {
+						(*out)[key] = nil
+					} else {
+						in, out := &val, &outVal
+						*out = make([]string, len(*in))
+						copy(*out, *in)
+					}
+					(*out)[key] = outVal
+				}
 			}
 			(*out)[key] = outVal
 		}

--- a/pkg/apis/cluster.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/cluster.cattle.io/v3/zz_generated_deepcopy.go
@@ -95,8 +95,8 @@ func (in *ClusterUserAttribute) DeepCopyInto(out *ClusterUserAttribute) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.Extra != nil {
-		in, out := &in.Extra, &out.Extra
+	if in.ExtraByProvider != nil {
+		in, out := &in.ExtraByProvider, &out.ExtraByProvider
 		*out = make(map[string]map[string][]string, len(*in))
 		for key, val := range *in {
 			var outVal map[string][]string

--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -92,7 +92,7 @@ type UserAttribute struct {
 	GroupPrincipals map[string]Principals // the value is a []Principal, but code generator cannot handle slice as a value
 	LastRefresh     string
 	NeedsRefresh    bool
-	Extra           map[string]map[string][]string
+	ExtraByProvider map[string]map[string][]string // extra information for the user to print in audit logs, stored per authProvider. example: map[openldap:map[principalid:[openldap_user://uid=testuser1,ou=dev,dc=us-west-2,dc=compute,dc=internal]]]
 }
 
 type Principals struct {

--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -92,6 +92,7 @@ type UserAttribute struct {
 	GroupPrincipals map[string]Principals // the value is a []Principal, but code generator cannot handle slice as a value
 	LastRefresh     string
 	NeedsRefresh    bool
+	Extra           map[string]map[string][]string
 }
 
 type Principals struct {

--- a/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -10179,8 +10179,8 @@ func (in *UserAttribute) DeepCopyInto(out *UserAttribute) {
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
-	if in.Extra != nil {
-		in, out := &in.Extra, &out.Extra
+	if in.ExtraByProvider != nil {
+		in, out := &in.ExtraByProvider, &out.ExtraByProvider
 		*out = make(map[string]map[string][]string, len(*in))
 		for key, val := range *in {
 			var outVal map[string][]string

--- a/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -10179,6 +10179,31 @@ func (in *UserAttribute) DeepCopyInto(out *UserAttribute) {
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
+	if in.Extra != nil {
+		in, out := &in.Extra, &out.Extra
+		*out = make(map[string]map[string][]string, len(*in))
+		for key, val := range *in {
+			var outVal map[string][]string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make(map[string][]string, len(*in))
+				for key, val := range *in {
+					var outVal []string
+					if val == nil {
+						(*out)[key] = nil
+					} else {
+						in, out := &val, &outVal
+						*out = make([]string, len(*in))
+						copy(*out, *in)
+					}
+					(*out)[key] = outVal
+				}
+			}
+			(*out)[key] = outVal
+		}
+	}
 	return
 }
 

--- a/pkg/auth/providers/activedirectory/activedirectory_actions.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_actions.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/mitchellh/mapstructure"
 	"github.com/rancher/norman/api/handler"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -96,7 +95,9 @@ func (p *adProvider) testAndApply(actionName string, action *types.Action, reque
 		return err
 	}
 
-	return p.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, "", 0, "Token via AD Configuration", request)
+	userExtraInfo := p.GetUserExtraAttributes(userPrincipal)
+
+	return p.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, "", 0, "Token via AD Configuration", request, userExtraInfo)
 }
 
 func (p *adProvider) saveActiveDirectoryConfig(config *v32.ActiveDirectoryConfig) error {

--- a/pkg/auth/providers/activedirectory/activedirectory_provider.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_provider.go
@@ -229,9 +229,9 @@ func (p *adProvider) getDNAndScopeFromPrincipalID(principalID string) (string, s
 	return externalID, scope, nil
 }
 
-func (p *adProvider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+func (p *adProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{token.UserPrincipal.Name}
-	extras["username"] = []string{token.UserPrincipal.LoginName}
+	extras["principalid"] = []string{userPrincipal.Name}
+	extras["username"] = []string{userPrincipal.LoginName}
 	return extras
 }

--- a/pkg/auth/providers/activedirectory/activedirectory_provider.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_provider.go
@@ -231,7 +231,11 @@ func (p *adProvider) getDNAndScopeFromPrincipalID(principalID string) (string, s
 
 func (p *adProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{userPrincipal.Name}
-	extras["username"] = []string{userPrincipal.LoginName}
+	if userPrincipal.Name != "" {
+		extras[common.UserAttributePrincipalID] = []string{userPrincipal.Name}
+	}
+	if userPrincipal.LoginName != "" {
+		extras[common.UserAttributeUserName] = []string{userPrincipal.LoginName}
+	}
 	return extras
 }

--- a/pkg/auth/providers/azure/azure_actions.go
+++ b/pkg/auth/providers/azure/azure_actions.go
@@ -6,12 +6,11 @@ import (
 	"net/http"
 	"strings"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/api/handler"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	managementschema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
@@ -97,5 +96,7 @@ func (ap *azureProvider) testAndApply(actionName string, action *types.Action, r
 		return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf("Failed to save azure config: %v", err))
 	}
 
-	return ap.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, providerToken, 0, "Token via Azure Configuration", request)
+	userExtraInfo := ap.GetUserExtraAttributes(userPrincipal)
+
+	return ap.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, providerToken, 0, "Token via Azure Configuration", request, userExtraInfo)
 }

--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -588,9 +588,9 @@ func UpdateGroupCacheSize(size string) {
 	groupCache.Resize(i)
 }
 
-func (ap *azureProvider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+func (ap *azureProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{token.UserPrincipal.Name}
-	extras["username"] = []string{token.UserPrincipal.LoginName}
+	extras["principalid"] = []string{userPrincipal.Name}
+	extras["username"] = []string{userPrincipal.LoginName}
 	return extras
 }

--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -590,7 +590,11 @@ func UpdateGroupCacheSize(size string) {
 
 func (ap *azureProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{userPrincipal.Name}
-	extras["username"] = []string{userPrincipal.LoginName}
+	if userPrincipal.Name != "" {
+		extras[common.UserAttributePrincipalID] = []string{userPrincipal.Name}
+	}
+	if userPrincipal.LoginName != "" {
+		extras[common.UserAttributeUserName] = []string{userPrincipal.LoginName}
+	}
 	return extras
 }

--- a/pkg/auth/providers/common/provider.go
+++ b/pkg/auth/providers/common/provider.go
@@ -16,5 +16,5 @@ type AuthProvider interface {
 	TransformToAuthProvider(authConfig map[string]interface{}) (map[string]interface{}, error)
 	RefetchGroupPrincipals(principalID string, secret string) ([]v3.Principal, error)
 	CanAccessWithGroupProviders(userPrincipalID string, groups []v3.Principal) (bool, error)
-	GetUserExtraAttributes(token *v3.Token) map[string][]string
+	GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string
 }

--- a/pkg/auth/providers/common/provider.go
+++ b/pkg/auth/providers/common/provider.go
@@ -7,6 +7,11 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 )
 
+const (
+	UserAttributePrincipalID = "principalid"
+	UserAttributeUserName    = "username"
+)
+
 type AuthProvider interface {
 	GetName() string
 	AuthenticateUser(ctx context.Context, input interface{}) (v3.Principal, []v3.Principal, string, error)

--- a/pkg/auth/providers/common/usermanager.go
+++ b/pkg/auth/providers/common/usermanager.go
@@ -222,19 +222,19 @@ func (m *userManager) CheckAccess(accessMode string, allowedPrincipalIDs []strin
 }
 
 // creates tokens with 0 ttl and returns token in 'token.Name:token.Token' format
-func (m *userManager) EnsureToken(tokenName, description, kind, userName string, ttl *int64, randomize bool) (string, error) {
-	return m.EnsureClusterToken("", tokenName, description, kind, userName, ttl, randomize)
+func (m *userManager) EnsureToken(input user.TokenInput) (string, error) {
+	return m.EnsureClusterToken("", input)
 }
 
-func (m *userManager) EnsureClusterToken(clusterName, tokenName, description, kind, userName string, ttl *int64, randomize bool) (string, error) {
-	if strings.HasPrefix(tokenName, "token-") {
+func (m *userManager) EnsureClusterToken(clusterName string, input user.TokenInput) (string, error) {
+	if strings.HasPrefix(input.TokenName, "token-") {
 		return "", errors.New("token names can't start with token-")
 	}
 
 	var err error
 	var token *v3.Token
-	if !randomize {
-		token, err = m.tokenLister.Get("", tokenName)
+	if !input.Randomize {
+		token, err = m.tokenLister.Get("", input.TokenName)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return "", err
 		}
@@ -252,32 +252,33 @@ func (m *userManager) EnsureClusterToken(clusterName, tokenName, description, ki
 
 	token = &v3.Token{
 		ObjectMeta: v1.ObjectMeta{
-			Name: tokenName,
+			Name: input.TokenName,
 			Labels: map[string]string{
-				tokens.UserIDLabel:    userName,
-				tokens.TokenKindLabel: kind,
+				tokens.UserIDLabel:    input.UserName,
+				tokens.TokenKindLabel: input.Kind,
 			},
 		},
-		TTLMillis:    0,
-		Description:  description,
-		UserID:       userName,
-		AuthProvider: "local",
-		IsDerived:    true,
-		Token:        key,
-		ClusterName:  clusterName,
+		TTLMillis:     0,
+		Description:   input.Description,
+		UserID:        input.UserName,
+		AuthProvider:  input.AuthProvider,
+		UserPrincipal: input.UserPrincipal,
+		IsDerived:     true,
+		Token:         key,
+		ClusterName:   clusterName,
 	}
-	if ttl != nil {
-		token.TTLMillis = *ttl
+	if input.TTL != nil {
+		token.TTLMillis = *input.TTL
 	}
-	if randomize {
+	if input.Randomize {
 		token.ObjectMeta.Name = ""
-		token.ObjectMeta.GenerateName = tokenName
+		token.ObjectMeta.GenerateName = input.TokenName
 	}
 	err = tokens.ConvertTokenKeyToHash(token)
 	if err != nil {
 		return "", err
 	}
-	logrus.Infof("Creating token for user %v", userName)
+	logrus.Infof("Creating token for user %v", input.UserName)
 	token, err = m.tokens.Create(token)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return "", err
@@ -286,7 +287,7 @@ func (m *userManager) EnsureClusterToken(clusterName, tokenName, description, ki
 	return token.Name + ":" + key, nil
 }
 
-func (m *userManager) newTokenForKubeconfig(clusterName, tokenName, description, kind, userName string, ttl time.Duration) (string, error) {
+func (m *userManager) newTokenForKubeconfig(clusterName, tokenName, description, kind, userName, authProvider string, ttl time.Duration, userPrincipal v3.Principal) (string, error) {
 	tokenTTL, err := tokens.ValidateMaxTTL(ttl)
 	if err != nil {
 		return "", fmt.Errorf("failed to validate token ttl %v", err)
@@ -294,7 +295,17 @@ func (m *userManager) newTokenForKubeconfig(clusterName, tokenName, description,
 
 	ttlMilli := tokenTTL.Milliseconds()
 	logrus.Infof("Creating token for user %v", userName)
-	key, err := m.EnsureClusterToken(clusterName, tokenName, description, kind, userName, &ttlMilli, false)
+	input := user.TokenInput{
+		TokenName:     tokenName,
+		Description:   description,
+		Kind:          kind,
+		UserName:      userName,
+		AuthProvider:  authProvider,
+		TTL:           &ttlMilli,
+		Randomize:     false,
+		UserPrincipal: userPrincipal,
+	}
+	key, err := m.EnsureClusterToken(clusterName, input)
 	if err != nil {
 		return "", err
 	}
@@ -302,14 +313,14 @@ func (m *userManager) newTokenForKubeconfig(clusterName, tokenName, description,
 }
 
 // creates kubeconfig tokens with KubeconfigTokenTTL and regenerates if existing token expired
-func (m *userManager) GetKubeconfigToken(clusterName, tokenName, description, kind, userName string) (*v3.Token, string, error) {
+func (m *userManager) GetKubeconfigToken(clusterName, tokenName, description, kind, userName, authProvider string, userPrincipal v3.Principal) (*v3.Token, string, error) {
 
 	tokenTTL, err := tokens.ParseTokenTTL(settings.KubeconfigTokenTTLMinutes.Get())
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to parse setting [%s]: %v", settings.KubeconfigTokenTTLMinutes.Name, err)
 	}
 
-	fullCreatedToken, err := m.newTokenForKubeconfig(clusterName, tokenName, description, kind, userName, tokenTTL)
+	fullCreatedToken, err := m.newTokenForKubeconfig(clusterName, tokenName, description, kind, userName, authProvider, tokenTTL, userPrincipal)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/auth/providers/github/github_provider.go
+++ b/pkg/auth/providers/github/github_provider.go
@@ -409,9 +409,9 @@ func (g *ghProvider) CanAccessWithGroupProviders(userPrincipalID string, groupPr
 	return allowed, nil
 }
 
-func (g *ghProvider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+func (g *ghProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{token.UserPrincipal.Name}
-	extras["username"] = []string{token.UserPrincipal.LoginName}
+	extras["principalid"] = []string{userPrincipal.Name}
+	extras["username"] = []string{userPrincipal.LoginName}
 	return extras
 }

--- a/pkg/auth/providers/github/github_provider.go
+++ b/pkg/auth/providers/github/github_provider.go
@@ -411,7 +411,11 @@ func (g *ghProvider) CanAccessWithGroupProviders(userPrincipalID string, groupPr
 
 func (g *ghProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{userPrincipal.Name}
-	extras["username"] = []string{userPrincipal.LoginName}
+	if userPrincipal.Name != "" {
+		extras[common.UserAttributePrincipalID] = []string{userPrincipal.Name}
+	}
+	if userPrincipal.LoginName != "" {
+		extras[common.UserAttributeUserName] = []string{userPrincipal.LoginName}
+	}
 	return extras
 }

--- a/pkg/auth/providers/github/githubconfig_actions.go
+++ b/pkg/auth/providers/github/githubconfig_actions.go
@@ -6,12 +6,11 @@ import (
 	"net/http"
 	"strings"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 )
@@ -132,5 +131,7 @@ func (g *ghProvider) testAndApply(actionName string, action *types.Action, reque
 		return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf("Failed to save github config: %v", err))
 	}
 
-	return g.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, providerInfo, 0, "Token via Github Configuration", request)
+	userExtraInfo := g.GetUserExtraAttributes(userPrincipal)
+
+	return g.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, providerInfo, 0, "Token via Github Configuration", request, userExtraInfo)
 }

--- a/pkg/auth/providers/googleoauth/goauth_provider.go
+++ b/pkg/auth/providers/googleoauth/goauth_provider.go
@@ -428,9 +428,9 @@ func (g *googleOauthProvider) getDirectoryService(ctx context.Context, userEmail
 	return srv, nil
 }
 
-func (g *googleOauthProvider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+func (g *googleOauthProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{token.UserPrincipal.Name}
-	extras["username"] = []string{token.UserPrincipal.LoginName}
+	extras["principalid"] = []string{userPrincipal.Name}
+	extras["username"] = []string{userPrincipal.LoginName}
 	return extras
 }

--- a/pkg/auth/providers/googleoauth/goauth_provider.go
+++ b/pkg/auth/providers/googleoauth/goauth_provider.go
@@ -430,7 +430,11 @@ func (g *googleOauthProvider) getDirectoryService(ctx context.Context, userEmail
 
 func (g *googleOauthProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{userPrincipal.Name}
-	extras["username"] = []string{userPrincipal.LoginName}
+	if userPrincipal.Name != "" {
+		extras[common.UserAttributePrincipalID] = []string{userPrincipal.Name}
+	}
+	if userPrincipal.LoginName != "" {
+		extras[common.UserAttributeUserName] = []string{userPrincipal.LoginName}
+	}
 	return extras
 }

--- a/pkg/auth/providers/googleoauth/goauthconfig_actions.go
+++ b/pkg/auth/providers/googleoauth/goauthconfig_actions.go
@@ -6,10 +6,9 @@ import (
 	"net/http"
 	"strings"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	"golang.org/x/oauth2"
@@ -110,7 +109,9 @@ func (g *googleOauthProvider) testAndApply(actionName string, action *types.Acti
 		return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf("testAndApply: Failed to save google oauth config: %v", err))
 	}
 
-	return g.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, providerInfo, 0, "Token via Google OAuth Configuration", request)
+	userExtraInfo := g.GetUserExtraAttributes(userPrincipal)
+
+	return g.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, providerInfo, 0, "Token via Google OAuth Configuration", request, userExtraInfo)
 
 }
 

--- a/pkg/auth/providers/ldap/ldap_actions.go
+++ b/pkg/auth/providers/ldap/ldap_actions.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/mitchellh/mapstructure"
 	"github.com/rancher/norman/api/handler"
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/providers/common/ldap"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
@@ -99,7 +98,10 @@ func (p *ldapProvider) testAndApply(actionName string, action *types.Action, req
 	if err != nil {
 		return err
 	}
-	return p.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, "", 0, "Token via LDAP Configuration", request)
+
+	userExtraInfo := p.GetUserExtraAttributes(userPrincipal)
+
+	return p.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, "", 0, "Token via LDAP Configuration", request, userExtraInfo)
 }
 
 func (p *ldapProvider) saveLDAPConfig(config *v3.LdapConfig) error {

--- a/pkg/auth/providers/ldap/ldap_provider.go
+++ b/pkg/auth/providers/ldap/ldap_provider.go
@@ -370,9 +370,9 @@ func (p *ldapProvider) samlSearchGetPrincipal(
 		config.GroupNameAttribute)
 }
 
-func (p *ldapProvider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+func (p *ldapProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{token.UserPrincipal.Name}
-	extras["username"] = []string{token.UserPrincipal.LoginName}
+	extras["principalid"] = []string{userPrincipal.Name}
+	extras["username"] = []string{userPrincipal.LoginName}
 	return extras
 }

--- a/pkg/auth/providers/ldap/ldap_provider.go
+++ b/pkg/auth/providers/ldap/ldap_provider.go
@@ -372,7 +372,11 @@ func (p *ldapProvider) samlSearchGetPrincipal(
 
 func (p *ldapProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{userPrincipal.Name}
-	extras["username"] = []string{userPrincipal.LoginName}
+	if userPrincipal.Name != "" {
+		extras[common.UserAttributePrincipalID] = []string{userPrincipal.Name}
+	}
+	if userPrincipal.LoginName != "" {
+		extras[common.UserAttributeUserName] = []string{userPrincipal.LoginName}
+	}
 	return extras
 }

--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -446,9 +446,9 @@ func (l *Provider) CanAccessWithGroupProviders(userPrincipalID string, groupPrin
 	return false, nil
 }
 
-func (l *Provider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+func (l *Provider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{token.UserPrincipal.Name}
-	extras["username"] = []string{token.UserPrincipal.LoginName}
+	extras["principalid"] = []string{userPrincipal.Name}
+	extras["username"] = []string{userPrincipal.LoginName}
 	return extras
 }

--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -448,7 +448,11 @@ func (l *Provider) CanAccessWithGroupProviders(userPrincipalID string, groupPrin
 
 func (l *Provider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{userPrincipal.Name}
-	extras["username"] = []string{userPrincipal.LoginName}
+	if userPrincipal.Name != "" {
+		extras[common.UserAttributePrincipalID] = []string{userPrincipal.Name}
+	}
+	if userPrincipal.LoginName != "" {
+		extras[common.UserAttributeUserName] = []string{userPrincipal.LoginName}
+	}
 	return extras
 }

--- a/pkg/auth/providers/oidc/oidc_actions.go
+++ b/pkg/auth/providers/oidc/oidc_actions.go
@@ -100,5 +100,7 @@ func (o *OpenIDCProvider) TestAndApply(actionName string, action *types.Action, 
 		return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf("Failed to save azure config: %v", err))
 	}
 
-	return o.TokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, providerToken, 0, "Token via OIDC Configuration", request)
+	userExtraInfo := o.GetUserExtraAttributes(userPrincipal)
+
+	return o.TokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, providerToken, 0, "Token via OIDC Configuration", request, userExtraInfo)
 }

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -353,10 +353,10 @@ func (o *OpenIDCProvider) IsThisUserMe(me v3.Principal, other v3.Principal) bool
 	return false
 }
 
-func (o *OpenIDCProvider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+func (o *OpenIDCProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{token.UserPrincipal.Name}
-	extras["username"] = []string{token.UserPrincipal.LoginName}
+	extras["principalid"] = []string{userPrincipal.Name}
+	extras["username"] = []string{userPrincipal.LoginName}
 	return extras
 }
 

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -355,8 +355,12 @@ func (o *OpenIDCProvider) IsThisUserMe(me v3.Principal, other v3.Principal) bool
 
 func (o *OpenIDCProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{userPrincipal.Name}
-	extras["username"] = []string{userPrincipal.LoginName}
+	if userPrincipal.Name != "" {
+		extras[common.UserAttributePrincipalID] = []string{userPrincipal.Name}
+	}
+	if userPrincipal.LoginName != "" {
+		extras[common.UserAttributeUserName] = []string{userPrincipal.LoginName}
+	}
 	return extras
 }
 

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -205,6 +205,6 @@ func RefetchGroupPrincipals(principalID string, providerName string, secret stri
 	return providers[providerName].RefetchGroupPrincipals(principalID, secret)
 }
 
-func GetUserExtraAttributes(providerName string, token *v3.Token) map[string][]string {
-	return providers[providerName].GetUserExtraAttributes(token)
+func GetUserExtraAttributes(providerName string, userPrincipal v3.Principal) map[string][]string {
+	return providers[providerName].GetUserExtraAttributes(userPrincipal)
 }

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -31,7 +31,7 @@ var (
 	LocalProvider          = "local"
 	providersByType        = make(map[string]common.AuthProvider)
 	confMu                 sync.Mutex
-	userExtraAttributesMap = map[string]bool{"principalid": true, "username": true}
+	userExtraAttributesMap = map[string]bool{common.UserAttributePrincipalID: true, common.UserAttributeUserName: true}
 )
 
 func GetProvider(providerName string) (common.AuthProvider, error) {

--- a/pkg/auth/providers/publicapi/login.go
+++ b/pkg/auth/providers/publicapi/login.go
@@ -211,6 +211,7 @@ func (h *loginHandler) createLoginToken(request *types.APIContext) (v3.Token, st
 		return *token, tokenValue, responseType, nil
 	}
 
-	rToken, unhashedTokenKey, err := h.tokenMGR.NewLoginToken(currUser.Name, userPrincipal, groupPrincipals, providerToken, ttl, description)
+	userExtraInfo := providers.GetUserExtraAttributes(providerName, userPrincipal)
+	rToken, unhashedTokenKey, err := h.tokenMGR.NewLoginToken(currUser.Name, userPrincipal, groupPrincipals, providerToken, ttl, description, userExtraInfo)
 	return rToken, unhashedTokenKey, responseType, err
 }

--- a/pkg/auth/providers/publicapi/login.go
+++ b/pkg/auth/providers/publicapi/login.go
@@ -204,7 +204,7 @@ func (h *loginHandler) createLoginToken(request *types.APIContext) (v3.Token, st
 	}
 
 	if strings.HasPrefix(responseType, tokens.KubeconfigResponseType) {
-		token, tokenValue, err := tokens.GetKubeConfigToken(currUser.Name, responseType, h.userMGR)
+		token, tokenValue, err := tokens.GetKubeConfigToken(currUser.Name, userPrincipal.Provider, responseType, h.userMGR, userPrincipal)
 		if err != nil {
 			return v3.Token{}, "", "", err
 		}
@@ -212,6 +212,7 @@ func (h *loginHandler) createLoginToken(request *types.APIContext) (v3.Token, st
 	}
 
 	userExtraInfo := providers.GetUserExtraAttributes(providerName, userPrincipal)
+
 	rToken, unhashedTokenKey, err := h.tokenMGR.NewLoginToken(currUser.Name, userPrincipal, groupPrincipals, providerToken, ttl, description, userExtraInfo)
 	return rToken, unhashedTokenKey, responseType, err
 }

--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -397,7 +397,7 @@ func (s *Provider) HandleSamlAssertion(w http.ResponseWriter, r *http.Request, a
 			responseType := s.clientState.GetState(r, "Rancher_ResponseType")
 			publicKey := s.clientState.GetState(r, "Rancher_PublicKey")
 
-			token, tokenValue, err := tokens.GetKubeConfigToken(user.Name, responseType, s.userMGR)
+			token, tokenValue, err := tokens.GetKubeConfigToken(user.Name, userPrincipal.Provider, responseType, s.userMGR, userPrincipal)
 			if err != nil {
 				log.Errorf("SAML: getToken error %v", err)
 				http.Redirect(w, r, redirectURL+"errorCode=500", http.StatusFound)

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -396,9 +396,9 @@ func (s *Provider) hasLdapGroupSearch() bool {
 	return false
 }
 
-func (s *Provider) GetUserExtraAttributes(token *v3.Token) map[string][]string {
+func (s *Provider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{token.UserPrincipal.Name}
-	extras["username"] = []string{token.UserPrincipal.LoginName}
+	extras["principalid"] = []string{userPrincipal.Name}
+	extras["username"] = []string{userPrincipal.LoginName}
 	return extras
 }

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -398,7 +398,11 @@ func (s *Provider) hasLdapGroupSearch() bool {
 
 func (s *Provider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
 	extras := make(map[string][]string)
-	extras["principalid"] = []string{userPrincipal.Name}
-	extras["username"] = []string{userPrincipal.LoginName}
+	if userPrincipal.Name != "" {
+		extras[common.UserAttributePrincipalID] = []string{userPrincipal.Name}
+	}
+	if userPrincipal.LoginName != "" {
+		extras[common.UserAttributeUserName] = []string{userPrincipal.LoginName}
+	}
 	return extras
 }

--- a/pkg/auth/tokens/token_util.go
+++ b/pkg/auth/tokens/token_util.go
@@ -103,7 +103,7 @@ func ConvertTokenResource(schema *types.Schema, token v3.Token) (map[string]inte
 	return tokenData, nil
 }
 
-func GetKubeConfigToken(userName, responseType string, userMGR user.Manager) (*v3.Token, string, error) {
+func GetKubeConfigToken(userName, authProvider, responseType string, userMGR user.Manager, userPrincipal v3.Principal) (*v3.Token, string, error) {
 	// create kubeconfig expiring tokens if responseType=kubeconfig in login action vs login tokens for responseType=json
 	clusterID := ""
 	responseSplit := strings.SplitN(responseType, "_", 2)
@@ -117,7 +117,7 @@ func GetKubeConfigToken(userName, responseType string, userMGR user.Manager) (*v
 		name = fmt.Sprintf("kubeconfig-%s.%s", userName, clusterID)
 	}
 
-	token, tokenVal, err := userMGR.GetKubeconfigToken(clusterID, name, "Kubeconfig token", "kubeconfig", userName)
+	token, tokenVal, err := userMGR.GetKubeconfigToken(clusterID, name, "Kubeconfig token", "kubeconfig", userName, authProvider, userPrincipal)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/client/generated/cluster/v3/zz_generated_cluster_user_attribute.go
+++ b/pkg/client/generated/cluster/v3/zz_generated_cluster_user_attribute.go
@@ -19,18 +19,18 @@ const (
 )
 
 type ClusterUserAttribute struct {
-	Annotations     map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Created         string              `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID       string              `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	Enabled         bool                `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Extra           map[string][]string `json:"extra,omitempty" yaml:"extra,omitempty"`
-	Groups          []string            `json:"groups,omitempty" yaml:"groups,omitempty"`
-	Labels          map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
-	LastRefresh     string              `json:"lastRefresh,omitempty" yaml:"lastRefresh,omitempty"`
-	Name            string              `json:"name,omitempty" yaml:"name,omitempty"`
-	NamespaceId     string              `json:"namespaceId,omitempty" yaml:"namespaceId,omitempty"`
-	NeedsRefresh    bool                `json:"needsRefresh,omitempty" yaml:"needsRefresh,omitempty"`
-	OwnerReferences []OwnerReference    `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	Removed         string              `json:"removed,omitempty" yaml:"removed,omitempty"`
-	UUID            string              `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Annotations     map[string]string              `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Created         string                         `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID       string                         `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Enabled         bool                           `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Extra           map[string]map[string][]string `json:"extra,omitempty" yaml:"extra,omitempty"`
+	Groups          []string                       `json:"groups,omitempty" yaml:"groups,omitempty"`
+	Labels          map[string]string              `json:"labels,omitempty" yaml:"labels,omitempty"`
+	LastRefresh     string                         `json:"lastRefresh,omitempty" yaml:"lastRefresh,omitempty"`
+	Name            string                         `json:"name,omitempty" yaml:"name,omitempty"`
+	NamespaceId     string                         `json:"namespaceId,omitempty" yaml:"namespaceId,omitempty"`
+	NeedsRefresh    bool                           `json:"needsRefresh,omitempty" yaml:"needsRefresh,omitempty"`
+	OwnerReferences []OwnerReference               `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Removed         string                         `json:"removed,omitempty" yaml:"removed,omitempty"`
+	UUID            string                         `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }

--- a/pkg/client/generated/cluster/v3/zz_generated_cluster_user_attribute.go
+++ b/pkg/client/generated/cluster/v3/zz_generated_cluster_user_attribute.go
@@ -6,7 +6,7 @@ const (
 	ClusterUserAttributeFieldCreated         = "created"
 	ClusterUserAttributeFieldCreatorID       = "creatorId"
 	ClusterUserAttributeFieldEnabled         = "enabled"
-	ClusterUserAttributeFieldExtra           = "extra"
+	ClusterUserAttributeFieldExtraByProvider = "extraByProvider"
 	ClusterUserAttributeFieldGroups          = "groups"
 	ClusterUserAttributeFieldLabels          = "labels"
 	ClusterUserAttributeFieldLastRefresh     = "lastRefresh"
@@ -23,7 +23,7 @@ type ClusterUserAttribute struct {
 	Created         string                         `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID       string                         `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	Enabled         bool                           `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Extra           map[string]map[string][]string `json:"extra,omitempty" yaml:"extra,omitempty"`
+	ExtraByProvider map[string]map[string][]string `json:"extraByProvider,omitempty" yaml:"extraByProvider,omitempty"`
 	Groups          []string                       `json:"groups,omitempty" yaml:"groups,omitempty"`
 	Labels          map[string]string              `json:"labels,omitempty" yaml:"labels,omitempty"`
 	LastRefresh     string                         `json:"lastRefresh,omitempty" yaml:"lastRefresh,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_user_attribute.go
+++ b/pkg/client/generated/management/v3/zz_generated_user_attribute.go
@@ -5,7 +5,7 @@ const (
 	UserAttributeFieldAnnotations     = "annotations"
 	UserAttributeFieldCreated         = "created"
 	UserAttributeFieldCreatorID       = "creatorId"
-	UserAttributeFieldExtra           = "extra"
+	UserAttributeFieldExtraByProvider = "extraByProvider"
 	UserAttributeFieldGroupPrincipals = "groupPrincipals"
 	UserAttributeFieldLabels          = "labels"
 	UserAttributeFieldLastRefresh     = "lastRefresh"
@@ -21,7 +21,7 @@ type UserAttribute struct {
 	Annotations     map[string]string              `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Created         string                         `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID       string                         `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	Extra           map[string]map[string][]string `json:"extra,omitempty" yaml:"extra,omitempty"`
+	ExtraByProvider map[string]map[string][]string `json:"extraByProvider,omitempty" yaml:"extraByProvider,omitempty"`
 	GroupPrincipals map[string]Principal           `json:"groupPrincipals,omitempty" yaml:"groupPrincipals,omitempty"`
 	Labels          map[string]string              `json:"labels,omitempty" yaml:"labels,omitempty"`
 	LastRefresh     string                         `json:"lastRefresh,omitempty" yaml:"lastRefresh,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_user_attribute.go
+++ b/pkg/client/generated/management/v3/zz_generated_user_attribute.go
@@ -5,6 +5,7 @@ const (
 	UserAttributeFieldAnnotations     = "annotations"
 	UserAttributeFieldCreated         = "created"
 	UserAttributeFieldCreatorID       = "creatorId"
+	UserAttributeFieldExtra           = "extra"
 	UserAttributeFieldGroupPrincipals = "groupPrincipals"
 	UserAttributeFieldLabels          = "labels"
 	UserAttributeFieldLastRefresh     = "lastRefresh"
@@ -17,16 +18,17 @@ const (
 )
 
 type UserAttribute struct {
-	Annotations     map[string]string    `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Created         string               `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID       string               `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	GroupPrincipals map[string]Principal `json:"groupPrincipals,omitempty" yaml:"groupPrincipals,omitempty"`
-	Labels          map[string]string    `json:"labels,omitempty" yaml:"labels,omitempty"`
-	LastRefresh     string               `json:"lastRefresh,omitempty" yaml:"lastRefresh,omitempty"`
-	Name            string               `json:"name,omitempty" yaml:"name,omitempty"`
-	NeedsRefresh    bool                 `json:"needsRefresh,omitempty" yaml:"needsRefresh,omitempty"`
-	OwnerReferences []OwnerReference     `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	Removed         string               `json:"removed,omitempty" yaml:"removed,omitempty"`
-	UUID            string               `json:"uuid,omitempty" yaml:"uuid,omitempty"`
-	UserName        string               `json:"userName,omitempty" yaml:"userName,omitempty"`
+	Annotations     map[string]string              `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Created         string                         `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID       string                         `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Extra           map[string]map[string][]string `json:"extra,omitempty" yaml:"extra,omitempty"`
+	GroupPrincipals map[string]Principal           `json:"groupPrincipals,omitempty" yaml:"groupPrincipals,omitempty"`
+	Labels          map[string]string              `json:"labels,omitempty" yaml:"labels,omitempty"`
+	LastRefresh     string                         `json:"lastRefresh,omitempty" yaml:"lastRefresh,omitempty"`
+	Name            string                         `json:"name,omitempty" yaml:"name,omitempty"`
+	NeedsRefresh    bool                           `json:"needsRefresh,omitempty" yaml:"needsRefresh,omitempty"`
+	OwnerReferences []OwnerReference               `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Removed         string                         `json:"removed,omitempty" yaml:"removed,omitempty"`
+	UUID            string                         `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	UserName        string                         `json:"userName,omitempty" yaml:"userName,omitempty"`
 }

--- a/pkg/controllers/managementuser/clusterauthtoken/user_attribute.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/user_attribute.go
@@ -42,6 +42,7 @@ func (h *userAttributeHandler) Sync(key string, userAttribute *managementv3.User
 	}
 	clusterUserAttribute = clusterUserAttribute.DeepCopy()
 	clusterUserAttribute.Groups = groups
+	clusterUserAttribute.Extra = userAttribute.Extra
 	clusterUserAttribute.LastRefresh = userAttribute.LastRefresh
 	clusterUserAttribute.NeedsRefresh = userAttribute.NeedsRefresh
 
@@ -68,5 +69,13 @@ func compareUserAttributeClusterUserAttribute(userAttribute managementv3.UserAtt
 		lastRefresh:  clusterUserAttribute.LastRefresh,
 		needsRefresh: clusterUserAttribute.NeedsRefresh,
 	}
-	return groups, reflect.DeepEqual(current, old)
+	if !reflect.DeepEqual(current, old) {
+		return groups, false
+	}
+
+	if !reflect.DeepEqual(userAttribute.Extra, clusterUserAttribute.Extra) {
+		return groups, false
+	}
+
+	return groups, true
 }

--- a/pkg/controllers/managementuser/clusterauthtoken/user_attribute.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/user_attribute.go
@@ -15,6 +15,7 @@ type userAttributeCompare struct {
 	lastRefresh  string
 	needsRefresh bool
 	enabled      bool
+	extra        map[string]map[string][]string
 }
 
 type userAttributeHandler struct {
@@ -42,7 +43,7 @@ func (h *userAttributeHandler) Sync(key string, userAttribute *managementv3.User
 	}
 	clusterUserAttribute = clusterUserAttribute.DeepCopy()
 	clusterUserAttribute.Groups = groups
-	clusterUserAttribute.Extra = userAttribute.Extra
+	clusterUserAttribute.ExtraByProvider = userAttribute.ExtraByProvider
 	clusterUserAttribute.LastRefresh = userAttribute.LastRefresh
 	clusterUserAttribute.NeedsRefresh = userAttribute.NeedsRefresh
 
@@ -63,19 +64,13 @@ func compareUserAttributeClusterUserAttribute(userAttribute managementv3.UserAtt
 		groups:       groups,
 		lastRefresh:  userAttribute.LastRefresh,
 		needsRefresh: userAttribute.NeedsRefresh,
+		extra:        userAttribute.ExtraByProvider,
 	}
 	old := userAttributeCompare{
 		groups:       clusterUserAttribute.Groups,
 		lastRefresh:  clusterUserAttribute.LastRefresh,
 		needsRefresh: clusterUserAttribute.NeedsRefresh,
+		extra:        clusterUserAttribute.ExtraByProvider,
 	}
-	if !reflect.DeepEqual(current, old) {
-		return groups, false
-	}
-
-	if !reflect.DeepEqual(userAttribute.Extra, clusterUserAttribute.Extra) {
-		return groups, false
-	}
-
-	return groups, true
+	return groups, reflect.DeepEqual(current, old)
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/types/config"
+	ruser "github.com/rancher/rancher/pkg/user"
 	"github.com/rancher/wrangler/pkg/ticker"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
@@ -134,7 +135,16 @@ func createToken(management *config.ScaledContext) (string, error) {
 	}
 	for _, user := range users {
 		if user.DisplayName == adminRole {
-			token, err := management.UserManager.EnsureToken("telemetry", "telemetry token", "telemetry", user.Name, nil, false)
+			input := ruser.TokenInput{
+				TokenName:    "telemetry",
+				Description:  "telemetry token",
+				Kind:         "telemetry",
+				UserName:     user.Name,
+				AuthProvider: "local",
+				TTL:          nil,
+				Randomize:    false,
+			}
+			token, err := management.UserManager.EnsureToken(input)
 			if err != nil {
 				return "", errors.Wrapf(err, "Can't create token for telemetry. Err: %v. Retry after 5 seconds", err)
 			}

--- a/pkg/user/manager.go
+++ b/pkg/user/manager.go
@@ -6,16 +6,27 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 )
 
+type TokenInput struct {
+	TokenName     string
+	Description   string
+	Kind          string
+	UserName      string
+	AuthProvider  string
+	TTL           *int64
+	Randomize     bool
+	UserPrincipal v3.Principal
+}
+
 type Manager interface {
 	SetPrincipalOnCurrentUser(apiContext *types.APIContext, principal v3.Principal) (*v3.User, error)
 	GetUser(apiContext *types.APIContext) string
-	EnsureToken(tokenName, description, kind, userName string, ttl *int64, randomize bool) (string, error)
-	EnsureClusterToken(clusterName, tokenName, description, kind, userName string, ttl *int64, randomize bool) (string, error)
+	EnsureToken(input TokenInput) (string, error)
+	EnsureClusterToken(clusterName string, input TokenInput) (string, error)
 	DeleteToken(tokenName string) error
 	EnsureUser(principalName, displayName string) (*v3.User, error)
 	CheckAccess(accessMode string, allowedPrincipalIDs []string, userPrincipalID string, groups []v3.Principal) (bool, error)
 	SetPrincipalOnCurrentUserByUserID(userID string, principal v3.Principal) (*v3.User, error)
 	CreateNewUserClusterRoleBinding(userName string, userUID apitypes.UID) error
 	GetUserByPrincipalID(principalName string) (*v3.User, error)
-	GetKubeconfigToken(clusterName, tokenName, description, kind, userName string) (*v3.Token, string, error)
+	GetKubeconfigToken(clusterName, tokenName, description, kind, userName, authProvider string, userPrincipal v3.Principal) (*v3.Token, string, error)
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/33126

This fix is to support audit logging from kubectl access which use kubeconfig tokens. In case of kubeconfig, the AuthProvider is always set to "local", the userPrincipal is not found and is missing information. Hence the audit log data is not seen. 
As a fix, the kubeconfig token is now fixed to carry the correct authProvider going forward.

Another part of the fix is instead reading extraInfo from user's login token, this is now read from userattributes where the extra info is saved after user logs in. This information can be found using the userId extracted from any token.
The userAttributes.Extra is also saved to ClusterUserAttributes.Extra field.

The process of finding the extra attributes for the user will be:
- Check if  extra attributes are found in userattributes for the token's provider
- If the token's provider is empty or is local, then add all extraAttributes into the Audit entry to cover all IDP values 
- Fallback is read from token if found, or otherwise read from the user object

