### PR TITLE
WIP: issue-25487 (slow secrets)

### DIFF
--- a/tests/integration/suite/test_workloads.py
+++ b/tests/integration/suite/test_workloads.py
@@ -39,6 +39,8 @@ def test_workload_image_change_private_registry(admin_pc):
             'image': 'testuser/testimage',
         }])
 
+    print(workload.imagePullSecrets)
+
     assert workload.name == name
     assert len(workload.imagePullSecrets) == 1
     for secret in workload.imagePullSecrets:
@@ -54,7 +56,6 @@ def test_workload_image_change_private_registry(admin_pc):
     for container in workload.containers:
         assert container['image'] == 'quay.io/testuser/testimage'
 
-    print(workload.imagePullSecrets)
     assert len(workload.imagePullSecrets) == 1
 
     assert workload.imagePullSecrets[0]['name'] == registry2_name

--- a/tests/integration/suite/test_workloads.py
+++ b/tests/integration/suite/test_workloads.py
@@ -54,6 +54,7 @@ def test_workload_image_change_private_registry(admin_pc):
     for container in workload.containers:
         assert container['image'] == 'quay.io/testuser/testimage'
 
+    print(workload.imagePullSecrets)
     assert len(workload.imagePullSecrets) == 1
 
     assert workload.imagePullSecrets[0]['name'] == registry2_name

--- a/tests/integration/suite/test_workloads.py
+++ b/tests/integration/suite/test_workloads.py
@@ -39,6 +39,7 @@ def test_workload_image_change_private_registry(admin_pc):
             'image': 'testuser/testimage',
         }])
 
+    import json
     print(json.dumps(workload.imagePullSecrets))
 
     assert workload.name == name

--- a/tests/integration/suite/test_workloads.py
+++ b/tests/integration/suite/test_workloads.py
@@ -39,7 +39,7 @@ def test_workload_image_change_private_registry(admin_pc):
             'image': 'testuser/testimage',
         }])
 
-    print(workload.imagePullSecrets)
+    print(json.dumps(workload.imagePullSecrets))
 
     assert workload.name == name
     assert len(workload.imagePullSecrets) == 1


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/25487

Note: this pr will require a companion frontend issue, I will create it if this solution is accepted.

# Problem
When users have  a large number of helm charts (30+) and multiple releases of these charts there are many large secrets returned when they list secrets. 

# Solution
This pr adds an optional query parameter to only return the latest release of a given chart.  This dramatically decreases the response times for listing secrets.  By default the endpoint will still return all secrets.

# Testing
1. clean install of rancher
2. navigate to any project and observe the load time of the page
3. install many charts into this project `for ((i=1;i<=30;i++)); do helm install test-chart-$i bitnami/nginx; done;`
4. upgrade each chart multiple times `for ((i=1;i<=10;i++)); do for c in $(helm list -o json | jq -r ".[] | .name" ); do helm upgrade $c bitnami/nginx; done done`
5. navigate to the project page again
6. observe only the helm release secrets are the latest ones and the page still loads in a reasonable amount of time

I tested with 30 chart installations, this number was mentioned in the original issue, each with 10 releases, the default max history in helm.  Before the charts were installed `/v3/project/<project id>/namespacedsecrets` would respond in ~ 700 ms.  After installing the charts and generating the released the response times rose to ~15000 ms.  setting `exclude_old_helm_releases=true` dropped the response time to ~2800 ms.  I also tested with returning no releases but found the difference to be negligible.
