### PR TITLE
Only send PrivateClusterConfig for private clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/rancher/dynamiclistener v0.3.1-0.20210616080009-9865ae859c7f
 	github.com/rancher/eks-operator v1.1.1-rc3
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210608014113-99e848822739
-	github.com/rancher/gke-operator v1.1.1-rc3
+	github.com/rancher/gke-operator v1.1.1-rc5
 	github.com/rancher/kubernetes-provider-detector v0.1.2
 	github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08
 	github.com/rancher/lasso/controller-runtime v0.0.0-20210608205930-775fcaf2f523

--- a/go.sum
+++ b/go.sum
@@ -977,8 +977,8 @@ github.com/rancher/eks-operator v1.1.1-rc3 h1:I52WG985NvawYW7mKTlv1SpeucOkYtk8na
 github.com/rancher/eks-operator v1.1.1-rc3/go.mod h1:hoVQqXsC02Yk3Xy5jGH/rqJX5KUVvvQBrYAJdRh+kgQ=
 github.com/rancher/fleet/pkg/apis v0.0.0-20210608014113-99e848822739 h1:EjFWJZH42LoYCRV56ZPNzaiIPO6cfFDP7+LlyY3b20Y=
 github.com/rancher/fleet/pkg/apis v0.0.0-20210608014113-99e848822739/go.mod h1:RKVnqsx+c9juaMp74p54zxCvQfMZw2KVCzkowaLtUmQ=
-github.com/rancher/gke-operator v1.1.1-rc3 h1:2nhGQoSfC7hZ2o1TFFWmVlgJ1tVJeJJAohcQTFnO5hk=
-github.com/rancher/gke-operator v1.1.1-rc3/go.mod h1:sO79ki/wksclGtziLqarrvRx8+l15+BPisFHHMjrIe0=
+github.com/rancher/gke-operator v1.1.1-rc5 h1:tAiFGmhcqyB9fXd37wRX1mrhlQ+H7xlV/iKqekj7Z40=
+github.com/rancher/gke-operator v1.1.1-rc5/go.mod h1:sO79ki/wksclGtziLqarrvRx8+l15+BPisFHHMjrIe0=
 github.com/rancher/helm/v3 v3.5.4-rancher.1 h1:TlvhucjCyHdnXw4uClSWJmv/p7onCP6dMXsBlIQSp6A=
 github.com/rancher/helm/v3 v3.5.4-rancher.1/go.mod h1:6eTBYLWEHt3JqXZPyHoYvb9/B7wPKHT3tjWnMfjen9w=
 github.com/rancher/kubernetes-provider-detector v0.1.2 h1:iFfmmcZiGya6s3cS4Qxksyqqw5hPbbIDHgKJ2Y44XKM=

--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -734,6 +734,10 @@ func (v *Validator) validateGKEConfig(request *types.APIContext, cluster map[str
 		return err
 	}
 
+	if err := validateGKEPrivateClusterConfig(clusterSpec); err != nil {
+		return err
+	}
+
 	region, regionOk := gkeConfig["region"]
 	zone, zoneOk := gkeConfig["zone"]
 	if (!regionOk || region == "") && (!zoneOk || zone == "") {
@@ -883,6 +887,13 @@ func validateGKEClusterName(client v3.ClusterInterface, spec *v32.ClusterSpec) e
 			continue
 		}
 		return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf("cluster already exists for GKE cluster [%s] "+msgSuffix, name))
+	}
+	return nil
+}
+
+func validateGKEPrivateClusterConfig(spec *v32.ClusterSpec) error {
+	if spec.GKEConfig.PrivateClusterConfig != nil && spec.GKEConfig.PrivateClusterConfig.EnablePrivateEndpoint && !spec.GKEConfig.PrivateClusterConfig.EnablePrivateNodes {
+		return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf("private endpoint requires private nodes"))
 	}
 	return nil
 }

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/rancher/aks-operator v1.0.1-rc9
 	github.com/rancher/eks-operator v1.1.1-rc3
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210608014113-99e848822739
-	github.com/rancher/gke-operator v1.1.1-rc3
+	github.com/rancher/gke-operator v1.1.1-rc5
 	github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133
 	github.com/rancher/rke v1.3.0-rc7
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210424054953-634d28b7def3

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -662,8 +662,8 @@ github.com/rancher/eks-operator v1.1.1-rc3 h1:I52WG985NvawYW7mKTlv1SpeucOkYtk8na
 github.com/rancher/eks-operator v1.1.1-rc3/go.mod h1:hoVQqXsC02Yk3Xy5jGH/rqJX5KUVvvQBrYAJdRh+kgQ=
 github.com/rancher/fleet/pkg/apis v0.0.0-20210608014113-99e848822739 h1:EjFWJZH42LoYCRV56ZPNzaiIPO6cfFDP7+LlyY3b20Y=
 github.com/rancher/fleet/pkg/apis v0.0.0-20210608014113-99e848822739/go.mod h1:RKVnqsx+c9juaMp74p54zxCvQfMZw2KVCzkowaLtUmQ=
-github.com/rancher/gke-operator v1.1.1-rc3 h1:2nhGQoSfC7hZ2o1TFFWmVlgJ1tVJeJJAohcQTFnO5hk=
-github.com/rancher/gke-operator v1.1.1-rc3/go.mod h1:sO79ki/wksclGtziLqarrvRx8+l15+BPisFHHMjrIe0=
+github.com/rancher/gke-operator v1.1.1-rc5 h1:tAiFGmhcqyB9fXd37wRX1mrhlQ+H7xlV/iKqekj7Z40=
+github.com/rancher/gke-operator v1.1.1-rc5/go.mod h1:sO79ki/wksclGtziLqarrvRx8+l15+BPisFHHMjrIe0=
 github.com/rancher/lasso v0.0.0-20200427171700-e0509f89f319/go.mod h1:6Dw19z1lDIpL887eelVjyqH/mna1hfR61ddCFOG78lw=
 github.com/rancher/lasso v0.0.0-20200515155337-a34e1e26ad91/go.mod h1:G6Vv2aj6xB2YjTVagmu4NkhBvbE8nBcGykHRENH6arI=
 github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=

--- a/pkg/kontainer-engine/drivers/gke/gke_driver.go
+++ b/pkg/kontainer-engine/drivers/gke/gke_driver.go
@@ -554,6 +554,10 @@ func (s *state) validate() error {
 		return fmt.Errorf("minNodeCount in the NodePool must be >= 1 and <= maxNodeCount")
 	}
 
+	if s.PrivateClusterConfig != nil && s.PrivateClusterConfig.EnablePrivateEndpoint && !s.PrivateClusterConfig.EnablePrivateNodes {
+		return fmt.Errorf("private endpoint requires private nodes")
+	}
+
 	return nil
 }
 
@@ -746,7 +750,10 @@ func (d *Driver) generateClusterCreateRequest(state state) *raw.CreateClusterReq
 		request.Cluster.MasterAuthorizedNetworksConfig = state.MasterAuthorizedNetworksConfig
 	}
 
-	request.Cluster.PrivateClusterConfig = state.PrivateClusterConfig
+	if state.PrivateClusterConfig != nil && state.PrivateClusterConfig.EnablePrivateNodes {
+		request.Cluster.PrivateClusterConfig = state.PrivateClusterConfig
+	}
+
 	request.Cluster.IpAllocationPolicy = state.IPAllocationPolicy
 	if request.Cluster.IpAllocationPolicy.UseIpAliases == true &&
 		request.Cluster.IpAllocationPolicy.ClusterIpv4CidrBlock != "" {


### PR DESCRIPTION
GKE rolled out a change that denies setting PrivateClusterConfig on
Cluster objects if they are not using private nodes. Update
kontainer-engine (to handle GKEv1) and gke-operator (GKEv2) (TODO) to
conform to this.

Depends on https://github.com/rancher/gke-operator/pull/56

https://github.com/rancher/rancher/issues/33241