### PR TITLE
Bump Prometheus Operator APIs to v0.48.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/oracle/oci-go-sdk v18.0.0+incompatible
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.44.1
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.48.0
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -912,8 +912,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
-github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.44.1 h1:E7dpj/bFlP8REMa60VzUZwmmtxLICMKW1hRoXVVkGy0=
-github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.44.1/go.mod h1:3WYi4xqXxGGXWDdQIITnLNmuDzO5n6wYva9spVhR4fg=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.48.0 h1:klFBev4UPGvhr3GF2b73Q1omlzZVONAhLwDhcQX0+4E=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.48.0/go.mod h1:3WYi4xqXxGGXWDdQIITnLNmuDzO5n6wYva9spVhR4fg=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=

--- a/pkg/client/generated/project/v3/zz_generated_metadata_config.go
+++ b/pkg/client/generated/project/v3/zz_generated_metadata_config.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	MetadataConfigType              = "metadataConfig"
+	MetadataConfigFieldSend         = "send"
+	MetadataConfigFieldSendInterval = "sendInterval"
+)
+
+type MetadataConfig struct {
+	Send         bool   `json:"send,omitempty" yaml:"send,omitempty"`
+	SendInterval string `json:"sendInterval,omitempty" yaml:"sendInterval,omitempty"`
+}

--- a/pkg/client/generated/project/v3/zz_generated_prometheus.go
+++ b/pkg/client/generated/project/v3/zz_generated_prometheus.go
@@ -22,6 +22,7 @@ const (
 	PrometheusFieldDescription                        = "description"
 	PrometheusFieldDisableCompaction                  = "disableCompaction"
 	PrometheusFieldEnableAdminAPI                     = "enableAdminAPI"
+	PrometheusFieldEnableFeatures                     = "enableFeatures"
 	PrometheusFieldEnforcedNamespaceLabel             = "enforcedNamespaceLabel"
 	PrometheusFieldEnforcedSampleLimit                = "enforcedSampleLimit"
 	PrometheusFieldEnforcedTargetLimit                = "enforcedTargetLimit"
@@ -106,6 +107,7 @@ type Prometheus struct {
 	Description                        string                             `json:"description,omitempty" yaml:"description,omitempty"`
 	DisableCompaction                  bool                               `json:"disableCompaction,omitempty" yaml:"disableCompaction,omitempty"`
 	EnableAdminAPI                     bool                               `json:"enableAdminAPI,omitempty" yaml:"enableAdminAPI,omitempty"`
+	EnableFeatures                     []string                           `json:"enableFeatures,omitempty" yaml:"enableFeatures,omitempty"`
 	EnforcedNamespaceLabel             string                             `json:"enforcedNamespaceLabel,omitempty" yaml:"enforcedNamespaceLabel,omitempty"`
 	EnforcedSampleLimit                *int64                             `json:"enforcedSampleLimit,omitempty" yaml:"enforcedSampleLimit,omitempty"`
 	EnforcedTargetLimit                *int64                             `json:"enforcedTargetLimit,omitempty" yaml:"enforcedTargetLimit,omitempty"`

--- a/pkg/client/generated/project/v3/zz_generated_prometheus_spec.go
+++ b/pkg/client/generated/project/v3/zz_generated_prometheus_spec.go
@@ -14,6 +14,7 @@ const (
 	PrometheusSpecFieldContainers                         = "containers"
 	PrometheusSpecFieldDisableCompaction                  = "disableCompaction"
 	PrometheusSpecFieldEnableAdminAPI                     = "enableAdminAPI"
+	PrometheusSpecFieldEnableFeatures                     = "enableFeatures"
 	PrometheusSpecFieldEnforcedNamespaceLabel             = "enforcedNamespaceLabel"
 	PrometheusSpecFieldEnforcedSampleLimit                = "enforcedSampleLimit"
 	PrometheusSpecFieldEnforcedTargetLimit                = "enforcedTargetLimit"
@@ -83,6 +84,7 @@ type PrometheusSpec struct {
 	Containers                         []Container                        `json:"containers,omitempty" yaml:"containers,omitempty"`
 	DisableCompaction                  bool                               `json:"disableCompaction,omitempty" yaml:"disableCompaction,omitempty"`
 	EnableAdminAPI                     bool                               `json:"enableAdminAPI,omitempty" yaml:"enableAdminAPI,omitempty"`
+	EnableFeatures                     []string                           `json:"enableFeatures,omitempty" yaml:"enableFeatures,omitempty"`
 	EnforcedNamespaceLabel             string                             `json:"enforcedNamespaceLabel,omitempty" yaml:"enforcedNamespaceLabel,omitempty"`
 	EnforcedSampleLimit                *int64                             `json:"enforcedSampleLimit,omitempty" yaml:"enforcedSampleLimit,omitempty"`
 	EnforcedTargetLimit                *int64                             `json:"enforcedTargetLimit,omitempty" yaml:"enforcedTargetLimit,omitempty"`

--- a/pkg/client/generated/project/v3/zz_generated_remote_write_spec.go
+++ b/pkg/client/generated/project/v3/zz_generated_remote_write_spec.go
@@ -5,6 +5,8 @@ const (
 	RemoteWriteSpecFieldBasicAuth           = "basicAuth"
 	RemoteWriteSpecFieldBearerToken         = "bearerToken"
 	RemoteWriteSpecFieldBearerTokenFile     = "bearerTokenFile"
+	RemoteWriteSpecFieldHeaders             = "headers"
+	RemoteWriteSpecFieldMetadataConfig      = "metadataConfig"
 	RemoteWriteSpecFieldName                = "name"
 	RemoteWriteSpecFieldProxyURL            = "proxyUrl"
 	RemoteWriteSpecFieldQueueConfig         = "queueConfig"
@@ -15,14 +17,16 @@ const (
 )
 
 type RemoteWriteSpec struct {
-	BasicAuth           *BasicAuth      `json:"basicAuth,omitempty" yaml:"basicAuth,omitempty"`
-	BearerToken         string          `json:"bearerToken,omitempty" yaml:"bearerToken,omitempty"`
-	BearerTokenFile     string          `json:"bearerTokenFile,omitempty" yaml:"bearerTokenFile,omitempty"`
-	Name                string          `json:"name,omitempty" yaml:"name,omitempty"`
-	ProxyURL            string          `json:"proxyUrl,omitempty" yaml:"proxyUrl,omitempty"`
-	QueueConfig         *QueueConfig    `json:"queueConfig,omitempty" yaml:"queueConfig,omitempty"`
-	RemoteTimeout       string          `json:"remoteTimeout,omitempty" yaml:"remoteTimeout,omitempty"`
-	TLSConfig           *TLSConfig      `json:"tlsConfig,omitempty" yaml:"tlsConfig,omitempty"`
-	URL                 string          `json:"url,omitempty" yaml:"url,omitempty"`
-	WriteRelabelConfigs []RelabelConfig `json:"writeRelabelConfigs,omitempty" yaml:"writeRelabelConfigs,omitempty"`
+	BasicAuth           *BasicAuth        `json:"basicAuth,omitempty" yaml:"basicAuth,omitempty"`
+	BearerToken         string            `json:"bearerToken,omitempty" yaml:"bearerToken,omitempty"`
+	BearerTokenFile     string            `json:"bearerTokenFile,omitempty" yaml:"bearerTokenFile,omitempty"`
+	Headers             map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+	MetadataConfig      *MetadataConfig   `json:"metadataConfig,omitempty" yaml:"metadataConfig,omitempty"`
+	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`
+	ProxyURL            string            `json:"proxyUrl,omitempty" yaml:"proxyUrl,omitempty"`
+	QueueConfig         *QueueConfig      `json:"queueConfig,omitempty" yaml:"queueConfig,omitempty"`
+	RemoteTimeout       string            `json:"remoteTimeout,omitempty" yaml:"remoteTimeout,omitempty"`
+	TLSConfig           *TLSConfig        `json:"tlsConfig,omitempty" yaml:"tlsConfig,omitempty"`
+	URL                 string            `json:"url,omitempty" yaml:"url,omitempty"`
+	WriteRelabelConfigs []RelabelConfig   `json:"writeRelabelConfigs,omitempty" yaml:"writeRelabelConfigs,omitempty"`
 }

--- a/pkg/client/generated/project/v3/zz_generated_thanos_spec.go
+++ b/pkg/client/generated/project/v3/zz_generated_thanos_spec.go
@@ -15,6 +15,7 @@ const (
 	ThanosSpecFieldSHA                     = "sha"
 	ThanosSpecFieldTag                     = "tag"
 	ThanosSpecFieldTracingConfig           = "tracingConfig"
+	ThanosSpecFieldTracingConfigFile       = "tracingConfigFile"
 	ThanosSpecFieldVersion                 = "version"
 )
 
@@ -32,5 +33,6 @@ type ThanosSpec struct {
 	SHA                     string                `json:"sha,omitempty" yaml:"sha,omitempty"`
 	Tag                     string                `json:"tag,omitempty" yaml:"tag,omitempty"`
 	TracingConfig           *SecretKeySelector    `json:"tracingConfig,omitempty" yaml:"tracingConfig,omitempty"`
+	TracingConfigFile       string                `json:"tracingConfigFile,omitempty" yaml:"tracingConfigFile,omitempty"`
 	Version                 string                `json:"version,omitempty" yaml:"version,omitempty"`
 }


### PR DESCRIPTION
This change is necessary since https://github.com/rancher/charts/pull/1274 bumped the Prometheus Operator APIs used in Monitoring V2.

Accordingly, we need to bump Rancher to prevent the packaged Monitoring V1 controllers from overwriting newly introduced fields for ServiceMonitors, Prometheis, Alertmanagers, and PrometheusRules (this has introduced weird edge cases in the past).

Related Issue: https://github.com/rancher/rancher/issues/32519