### PR TITLE
Only send PrivateClusterConfig for private clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/rancher/apiserver v0.0.0-20210209001659-a17289640582
 	github.com/rancher/dynamiclistener v0.2.1-0.20200910203214-85f32491cb09
 	github.com/rancher/eks-operator v1.0.9
-	github.com/rancher/gke-operator v1.1.1-rc3
+	github.com/rancher/gke-operator v1.1.1-rc5
 	github.com/rancher/kubernetes-provider-detector v0.1.2
 	github.com/rancher/lasso v0.0.0-20210408231703-9ddd9378d08d
 	github.com/rancher/machine v0.15.0-rancher25

--- a/go.sum
+++ b/go.sum
@@ -926,8 +926,8 @@ github.com/rancher/dynamiclistener v0.2.1-0.20200910203214-85f32491cb09 h1:Rh+7v
 github.com/rancher/dynamiclistener v0.2.1-0.20200910203214-85f32491cb09/go.mod h1:qr0QfhwzcVCR+Ao9WyfnE+jmOpfEAdRhXtNOZGJ3nCQ=
 github.com/rancher/eks-operator v1.0.9 h1:5w50dL0AsR0+lMqs6AehlOkQr/a5BTaQEP77cBS2Qgs=
 github.com/rancher/eks-operator v1.0.9/go.mod h1:a8P4ayqagpQPyCVAUd+MpqJpobusyzinawD5krWlsUk=
-github.com/rancher/gke-operator v1.1.1-rc3 h1:2nhGQoSfC7hZ2o1TFFWmVlgJ1tVJeJJAohcQTFnO5hk=
-github.com/rancher/gke-operator v1.1.1-rc3/go.mod h1:sO79ki/wksclGtziLqarrvRx8+l15+BPisFHHMjrIe0=
+github.com/rancher/gke-operator v1.1.1-rc5 h1:tAiFGmhcqyB9fXd37wRX1mrhlQ+H7xlV/iKqekj7Z40=
+github.com/rancher/gke-operator v1.1.1-rc5/go.mod h1:sO79ki/wksclGtziLqarrvRx8+l15+BPisFHHMjrIe0=
 github.com/rancher/helm/v3 v3.3.0-rancher1 h1:i9uzKgPbt15FTn0rHMt22sA4rdHPq4iJ8gmohSWPR1o=
 github.com/rancher/helm/v3 v3.3.0-rancher1/go.mod h1:qUawjWz9THVCBVsNPJ/Q20VNEyrK7kN6lYf5loyp194=
 github.com/rancher/kubernetes-provider-detector v0.1.2 h1:iFfmmcZiGya6s3cS4Qxksyqqw5hPbbIDHgKJ2Y44XKM=

--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -589,6 +589,10 @@ func (v *Validator) validateGKEConfig(request *types.APIContext, cluster map[str
 		return err
 	}
 
+	if err := validateGKEPrivateClusterConfig(clusterSpec); err != nil {
+		return err
+	}
+
 	region, regionOk := gkeConfig["region"]
 	zone, zoneOk := gkeConfig["zone"]
 	if (!regionOk || region == "") && (!zoneOk || zone == "") {
@@ -715,6 +719,13 @@ func validateGKEClusterName(client v3.ClusterInterface, spec *v32.ClusterSpec) e
 			continue
 		}
 		return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf("cluster already exists for GKE cluster [%s] "+msgSuffix, name))
+	}
+	return nil
+}
+
+func validateGKEPrivateClusterConfig(spec *v32.ClusterSpec) error {
+	if spec.GKEConfig.PrivateClusterConfig != nil && spec.GKEConfig.PrivateClusterConfig.EnablePrivateEndpoint && !spec.GKEConfig.PrivateClusterConfig.EnablePrivateNodes {
+		return httperror.NewAPIError(httperror.InvalidBodyContent, fmt.Sprintf("private endpoint requires private nodes"))
 	}
 	return nil
 }

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -10,7 +10,7 @@ replace (
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/eks-operator v1.0.9
-	github.com/rancher/gke-operator v1.1.1-rc3
+	github.com/rancher/gke-operator v1.1.1-rc5
 	github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133
 	github.com/rancher/rke v1.2.8
 	github.com/rancher/wrangler v0.7.3-0.20210331224822-5bd357588083

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -506,8 +506,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/rancher/eks-operator v1.0.9 h1:5w50dL0AsR0+lMqs6AehlOkQr/a5BTaQEP77cBS2Qgs=
 github.com/rancher/eks-operator v1.0.9/go.mod h1:a8P4ayqagpQPyCVAUd+MpqJpobusyzinawD5krWlsUk=
-github.com/rancher/gke-operator v1.1.1-rc3 h1:2nhGQoSfC7hZ2o1TFFWmVlgJ1tVJeJJAohcQTFnO5hk=
-github.com/rancher/gke-operator v1.1.1-rc3/go.mod h1:sO79ki/wksclGtziLqarrvRx8+l15+BPisFHHMjrIe0=
+github.com/rancher/gke-operator v1.1.1-rc5 h1:tAiFGmhcqyB9fXd37wRX1mrhlQ+H7xlV/iKqekj7Z40=
+github.com/rancher/gke-operator v1.1.1-rc5/go.mod h1:sO79ki/wksclGtziLqarrvRx8+l15+BPisFHHMjrIe0=
 github.com/rancher/lasso v0.0.0-20200427171700-e0509f89f319/go.mod h1:6Dw19z1lDIpL887eelVjyqH/mna1hfR61ddCFOG78lw=
 github.com/rancher/lasso v0.0.0-20200515155337-a34e1e26ad91/go.mod h1:G6Vv2aj6xB2YjTVagmu4NkhBvbE8nBcGykHRENH6arI=
 github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=

--- a/pkg/kontainer-engine/drivers/gke/gke_driver.go
+++ b/pkg/kontainer-engine/drivers/gke/gke_driver.go
@@ -554,6 +554,10 @@ func (s *state) validate() error {
 		return fmt.Errorf("minNodeCount in the NodePool must be >= 1 and <= maxNodeCount")
 	}
 
+	if s.PrivateClusterConfig != nil && s.PrivateClusterConfig.EnablePrivateEndpoint && !s.PrivateClusterConfig.EnablePrivateNodes {
+		return fmt.Errorf("private endpoint requires private nodes")
+	}
+
 	return nil
 }
 
@@ -746,7 +750,10 @@ func (d *Driver) generateClusterCreateRequest(state state) *raw.CreateClusterReq
 		request.Cluster.MasterAuthorizedNetworksConfig = state.MasterAuthorizedNetworksConfig
 	}
 
-	request.Cluster.PrivateClusterConfig = state.PrivateClusterConfig
+	if state.PrivateClusterConfig != nil && state.PrivateClusterConfig.EnablePrivateNodes {
+		request.Cluster.PrivateClusterConfig = state.PrivateClusterConfig
+	}
+
 	request.Cluster.IpAllocationPolicy = state.IPAllocationPolicy
 	if request.Cluster.IpAllocationPolicy.UseIpAliases == true &&
 		request.Cluster.IpAllocationPolicy.ClusterIpv4CidrBlock != "" {


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/33318

Depends on https://github.com/rancher/rancher/pull/32502 since gke-operator changes depend on norman update