### PR TITLE
Add refresh token support for oidc provider and keycloak client

### DIFF
--- a/pkg/auth/providers/keycloakoidc/keycloak_client.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_client.go
@@ -36,7 +36,7 @@ type KeyCloakClient struct {
 	httpClient *http.Client
 }
 
-func (k *KeyCloakClient) searchPrincipals(searchTerm, principalType string, accessToken string, config *v32.OIDCConfig) ([]account, error) {
+func (k *KeyCloakClient) searchPrincipals(searchTerm, principalType string, config *v32.OIDCConfig) ([]account, error) {
 	var accounts []account
 	sURL, err := getSearchURL(config.Issuer)
 	if err != nil {
@@ -47,7 +47,7 @@ func (k *KeyCloakClient) searchPrincipals(searchTerm, principalType string, acce
 		searchURL := fmt.Sprintf("%s/%ss?search=%s", sURL, UserType, searchTerm)
 		search := URLEncoded(searchURL)
 
-		b, statusCode, err := k.getFromKeyCloak(accessToken, search)
+		b, statusCode, err := k.getFromKeyCloak(search)
 		if err != nil {
 			logrus.Errorf("[keycloak oidc]: GET request failed, got status code: %d. url: %s, err: %s",
 				statusCode, search, err)
@@ -67,7 +67,7 @@ func (k *KeyCloakClient) searchPrincipals(searchTerm, principalType string, acce
 		searchURL := fmt.Sprintf("%s/%ss?search=%s", sURL, GroupType, searchTerm)
 		search := URLEncoded(searchURL)
 
-		b, statusCode, err := k.getFromKeyCloak(accessToken, search)
+		b, statusCode, err := k.getFromKeyCloak(search)
 		if err != nil {
 			logrus.Errorf("[keycloak oidc]: GET request failed, got status code: %d. url: %s, err: %s",
 				statusCode, search, err)
@@ -103,14 +103,14 @@ func getSubGroups(group Group) []Group {
 	return groups
 }
 
-func (k *KeyCloakClient) getFromKeyCloakByID(principalID, accessToken, searchType string, config *v32.OIDCConfig) (account, error) {
+func (k *KeyCloakClient) getFromKeyCloakByID(principalID, searchType string, config *v32.OIDCConfig) (account, error) {
 	sURL, err := getSearchURL(config.Issuer)
 	if err != nil {
 		return account{}, nil
 	}
 	searchURL := fmt.Sprintf("%s/%s/%s", sURL, searchType, principalID)
 	search := URLEncoded(searchURL)
-	b, statusCode, err := k.getFromKeyCloak(accessToken, search)
+	b, statusCode, err := k.getFromKeyCloak(search)
 	if err != nil {
 		return account{}, fmt.Errorf("[keycloak oidc]: GET request failed, got status code: %d. url: %s, err: %s",
 			statusCode, search, err)
@@ -142,15 +142,11 @@ func URLEncoded(str string) string {
 	return u.String()
 }
 
-func (k *KeyCloakClient) getFromKeyCloak(accessToken, url string) ([]byte, int, error) {
+func (k *KeyCloakClient) getFromKeyCloak(url string) ([]byte, int, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, 500, err
 	}
-	if accessToken == "" {
-		return nil, 500, fmt.Errorf("[keycloak oidc]: GET request failed, missing authorization token")
-	}
-	req.Header.Add("Authorization", "Bearer "+accessToken)
 	req.Header.Add("Accept", "application/json")
 	resp, err := k.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
**Issue**
https://github.com/rancher/rancher/issues/33314

**Problem**
Access token was expiring and never getting refreshed

**Solution**
Utilize the oauth2 library to auto refresh the token when needed. 

- Secret is now storing all token values instead of only the access token
- Secret is being unmarshalled to be used as the token for the aouth2Config.TokenSource
- Secret is being unmarshalled and used for the creation of the keycloak client using the oauth2config client so that the token will be refresh if needed each time the client is created. 
