### PR TITLE
[keycloak oidc] Add error message for 403 errors

### DIFF
--- a/pkg/auth/providers/keycloakoidc/keycloak_client.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_client.go
@@ -10,6 +10,7 @@ import (
 
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 //account defines properties an account in keycloak has
@@ -165,6 +166,8 @@ func (k *KeyCloakClient) getFromKeyCloak(accessToken, url string) ([]byte, int, 
 	switch resp.StatusCode {
 	case 200:
 	case 201:
+	case 403:
+		return b, resp.StatusCode, apierrors.NewUnauthorized(resp.Status)
 	default:
 		return b, resp.StatusCode, err
 	}


### PR DESCRIPTION
**Issue**
https://github.com/rancher/rancher/issues/33356
https://github.com/rancher/rancher/issues/33352

**Side Note**
The original issues report a cluster member or owner not being able to search users after being added to those roles in Rancher. This is expected for this provider. If the user does not have get / list permissions in keycloak for users and groups, they will not be able to search those from keycloak. 

**Problem**
403 response is not returning an error so the empty response body was causing errors as it was trying to be processed

**Solution**
Add a case statement for 403 responses and create an api error reponse using the keycloak response status as the value. 