### PR TITLE
Run update-ca-certificates before launching Rancher

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -151,11 +151,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
 {{- if .Values.additionalTrustedCAs }}
-        - mountPath: /etc/ssl/certs/ca-additional.pem
-          name: tls-ca-additional-volume
-          subPath: ca-additional.pem
-          readOnly: true
-        - mountPath: /etc/rancher/ssl/ca-additional.pem
+        - mountPath: /etc/pki/trust/anchors/ca-additional.pem
           name: tls-ca-additional-volume
           subPath: ca-additional.pem
           readOnly: true

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -6,4 +6,7 @@ if [ ! -e /run/secrets/kubernetes.io/serviceaccount ] && [ ! -e /dev/kmsg ]; the
     exit 1
 fi
 rm -f /var/lib/rancher/k3s/server/cred/node-passwd
+if [ -x "$(command -v update-ca-certificates)" ]; then
+  update-ca-certificates
+fi
 exec tini -- rancher --http-listen-port=80 --https-listen-port=443 --audit-log-path=${AUDIT_LOG_PATH} --audit-level=${AUDIT_LEVEL} --audit-log-maxage=${AUDIT_LOG_MAXAGE} --audit-log-maxbackup=${AUDIT_LOG_MAXBACKUP} --audit-log-maxsize=${AUDIT_LOG_MAXSIZE} "${@}"

--- a/package/jailer.sh
+++ b/package/jailer.sh
@@ -11,7 +11,7 @@ fi
 
 # Build the jail directory structure
 mkdir -p /opt/jail/$NAME/dev
-mkdir -p /opt/jail/$NAME/etc/ssl/certs
+mkdir -p /opt/jail/$NAME/etc/ssl
 mkdir -p /opt/jail/$NAME/usr/bin
 mkdir -p /opt/jail/$NAME/management-state/node/nodes
 mkdir -p /opt/jail/$NAME/var/lib/rancher/management-state/bin
@@ -27,7 +27,7 @@ fi
 
 cp -r /lib /opt/jail/$NAME
 cp -r /usr/lib /opt/jail/$NAME/usr
-cp /var/lib/ca-certificates/ca-bundle.pem /opt/jail/$NAME/etc/ssl/certs
+cp /var/lib/ca-certificates/ca-bundle.pem /opt/jail/$NAME/etc/ssl
 cp /etc/resolv.conf /opt/jail/$NAME/etc/
 cp /etc/passwd /opt/jail/$NAME/etc/
 cp /etc/hosts /opt/jail/$NAME/etc/
@@ -44,11 +44,11 @@ if [ -d /var/lib/rancher/management-state/bin ] && [ "$(ls -A /var/lib/rancher/m
 fi
 
 if [[ -f /etc/ssl/certs/ca-additional.pem ]]; then
-  cp /etc/ssl/certs/ca-additional.pem /opt/jail/$NAME/etc/ssl/certs
+  cp /etc/ssl/certs/ca-additional.pem /opt/jail/$NAME/etc/ssl
 fi
 
 if [[ -f /etc/rancher/ssl/cacerts.pem ]]; then
-  cp /etc/rancher/ssl/cacerts.pem /opt/jail/$NAME/etc/ssl/certs
+  cp /etc/rancher/ssl/cacerts.pem /opt/jail/$NAME/etc/ssl
 fi
 
 # Hard link driver binaries


### PR DESCRIPTION
The new SLE image requires update-ca-certificates be run before
additional trusted CAs are recognized. Therefore, the command is
run prior to launch Rancher.
    
In addition, the location of the mounted certificate is changed to the
location specified in the docs: /etc/pki/trust/anchors/

Finally, the jailer also copies the certificate information to /etc/ssl
instead of /etc/ssl/certs because the Go libraries expect the certs to
be there.

Issue:
https://github.com/rancher/rancher/issues/33398