### PR TITLE
Add missing Discovery field to KEv2 operators

### DIFF
--- a/pkg/controllers/management/aks/aks_cluster_handler.go
+++ b/pkg/controllers/management/aks/aks_cluster_handler.go
@@ -66,6 +66,7 @@ func Register(ctx context.Context, wContext *wrangler.Context, mgmtCtx *config.M
 		SystemAccountManager: systemaccount.NewManager(mgmtCtx),
 		DynamicClient:        aksCCDynamicClient,
 		ClientDialer:         mgmtCtx.Dialer,
+		Discovery:            wContext.K8s.Discovery(),
 	}}
 
 	wContext.Mgmt.Cluster().OnChange(ctx, "aks-operator-controller", e.onClusterChange)

--- a/pkg/controllers/management/gke/gke_cluster_handler.go
+++ b/pkg/controllers/management/gke/gke_cluster_handler.go
@@ -70,6 +70,7 @@ func Register(ctx context.Context, wContext *wrangler.Context, mgmtCtx *config.M
 		SystemAccountManager: systemaccount.NewManager(mgmtCtx),
 		DynamicClient:        gkeCCDynamicClient,
 		ClientDialer:         mgmtCtx.Dialer,
+		Discovery:            wContext.K8s.Discovery(),
 	}}
 
 	wContext.Mgmt.Cluster().OnChange(ctx, "gke-operator-controller", e.onClusterChange)


### PR DESCRIPTION
The Discovery field was mistakenly not set for AKS and GKE operators.

Issue:
https://github.com/rancher/rancher/issues/31592