### PR TITLE
[keycloak oidc] Change from group id to group name for searched group principals

### DIFF
--- a/pkg/auth/providers/keycloakoidc/keycloak_provider.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider.go
@@ -107,6 +107,7 @@ func (k *keyCloakOIDCProvider) toPrincipal(principalType string, acct account, t
 		}
 	} else {
 		princ.PrincipalType = GroupType
+		princ.ObjectMeta = metav1.ObjectMeta{Name: k.GetName() + "_" + principalType + "://" + acct.Name}
 		if token != nil {
 			princ.MemberOf = k.TokenMGR.IsMemberOf(*token, princ)
 		}


### PR DESCRIPTION
**Issue**
https://github.com/rancher/rancher/issues/33337

**Problem**
When a user logs in, their group information is collected from the id_token. This group information is only the name of the group they belong to. To search a specific group with the keycloak api, you have to have the group id, which is not provided on the id_token. Group principals are then added to the user using the group name as part of the principal id in rancher. When a user executes a group/user search after logging in (if they have the keycloak permissions to do so), each result returned does have the ID value included with it. If a principal was added from the search, the ID value was being used as part of the principal id in rancher. This means if a group is added by an admin, and a user with that group attempts to login, they will not have access because the rancher will be comparing a principal with a group name as the id and a principal with the actual id for the id. This will always result in an unauthorized user based on group comparisons. 

Example:
```
keycloakoidc_group://c84ba2ef23434-44a3-46343434-43-6d4439dc11 
```
compared against
```
keycloakoidc_group://testautogroupnested2
```
**Solution**
Because of the limitations of what can be returned from the id_token, I have changed the search group principal to also utilize the group name as part of the principal id to match exactly how the login principal is being set. This is a problem for groups and not users so I kept the logic specific to groups.

**Note**
I did check that group names have to be unique within a realm.
