### PR TITLE
[2.5.9] Update default `ui-dashboard-index` setting

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -68,7 +68,7 @@ var (
 	UIFeedBackForm                    = NewSetting("ui-feedback-form", "")
 	UIIndex                           = NewSetting("ui-index", "https://releases.rancher.com/ui/latest-2.5/index.html")
 	UIPath                            = NewSetting("ui-path", "/usr/share/rancher/ui")
-	UIDashboardIndex                  = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/latest/index.html")
+	UIDashboardIndex                  = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/v2.5.8/index.html")
 	UIDashboardPath                   = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
 	UIPreferred                       = NewSetting("ui-preferred", "ember")
 	UIOfflinePreferred                = NewSetting("ui-offline-preferred", "dynamic")


### PR DESCRIPTION
- This 2.5 branch was pointing to the latest Dashboard (2.6)
- Normally this should point to the latest 2.5.9 dev build, however the Dashboard hasn't branched for 2.5.9 and 2.5.8 has been released
- ui-dashboard-index, I think, by default, is only used in builds that aren't releases (pkg/settings/setting.go IsRelease)
- Builds that are releases use the correct v2.5.8 reference already (CATTLE_DASHBOARD_UI_VERSION v2.5.8)