### PR TITLE
Fix 33478

### DIFF
--- a/pkg/controllers/managementuser/nodesyncer/nodetaints.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodetaints.go
@@ -28,7 +28,7 @@ func (m *nodesSyncer) syncTaints(key string, obj *v3.Node) (runtime.Object, erro
 		return obj, nil
 	}
 	node, err := nodehelper.GetNodeForMachine(obj, m.nodeLister)
-	if err != nil {
+	if err != nil || node == nil {
 		return obj, err
 	}
 	toAdd, toDel := taints.GetToDiffTaints(node.Spec.Taints, obj.Spec.DesiredNodeTaints)


### PR DESCRIPTION
Have syncTaints deal with a nil node the same way syncLabels does.  Else rancher crashes if GetNodeForMachine returns a nil node.

https://github.com/rancher/rancher/issues/33478