### PR TITLE
Add Location to /meta/aksClusters list

### DIFF
--- a/pkg/api/norman/customization/aks/listers.go
+++ b/pkg/api/norman/customization/aks/listers.go
@@ -221,6 +221,7 @@ type clustersResponseBody struct {
 	ResourceGroup string `json:"resourceGroup"`
 	ClusterName   string `json:"clusterName"`
 	RBACEnabled   bool   `json:"rbacEnabled"`
+	Location      string `json:"location"`
 }
 
 func listClusters(ctx context.Context, cap *Capabilities) ([]byte, int, error) {
@@ -241,6 +242,7 @@ func listClusters(ctx context.Context, cap *Capabilities) ([]byte, int, error) {
 			tmpCluster := clustersResponseBody{
 				ClusterName: to.String(cluster.Name),
 				RBACEnabled: to.Bool(cluster.EnableRBAC),
+				Location:    to.String(cluster.Location),
 			}
 			if cluster.ID != nil {
 				match := matchResourceGroup.FindStringSubmatch(to.String(cluster.ID))


### PR DESCRIPTION
Add the AKS cluster's location to the list of cluster objects returned
by /meta/aksClusters. This can be used by the UI to set the
ResourceLocation field when importing a cluster.

https://github.com/rancher/rancher/issues/33534