### PR TITLE
Add creatorID anno and provisioning cluster perms

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -256,12 +256,7 @@ func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus,
 		newCluster.Annotations[k] = v
 	}
 
-	userName, err := h.kubeconfigManager.EnsureUser(cluster.Namespace, cluster.Name)
-	if err != nil {
-		return nil, status, err
-	}
-
-	newCluster.Annotations[creatorIDAnn] = userName
+	delete(cluster.Annotations, creatorIDAnn)
 
 	normalizedCluster, err := NormalizeCluster(newCluster)
 	if err != nil {

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -450,6 +450,8 @@ func addUserRules(role *roleBuilder) *roleBuilder {
 		addRule().apiGroups("management.cattle.io").resources("features").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("templates", "templateversions", "catalogs").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("clusters").verbs("create").
+		addRule().apiGroups("provisioning.cattle.io").resources("clusters").verbs("create").
+		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("kontainerdrivers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("nodetemplates").verbs("create").


### PR DESCRIPTION
The webhook adds a creatorIDAnn to the provisioning cluster so the controller will copy that over to the v3 cluster and drop the annotation from the  provisioning cluster. 

Add permissions for a standard user to create  provisioning clusters and any rke-machine-config.cattle.io

https://github.com/rancher/rancher/issues/32414