### PR TITLE
Dockerfile.agent: readd sysstat

### DIFF
--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -6,8 +6,8 @@ FROM registry.suse.com/suse/sle15:15.3
 ARG ARCH=amd64
 
 ENV KUBECTL_VERSION v1.20.7
-# sysstat is left out until systemd dependency is stripped
-RUN zypper -n install --no-recommends curl ca-certificates jq git-core hostname iproute2 vim-small less bash-completion acl openssh-clients tar gzip xz gawk && \
+RUN zypper -n install --no-recommends curl ca-certificates jq git-core hostname iproute2 vim-small less \
+	bash-completion acl openssh-clients tar gzip xz gawk sysstat && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
     rpm -e libsolv-tools zypper libzypp container-suseconnect ; \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \


### PR DESCRIPTION
With the switch to SLE Base Container the sysstat dependency
has been temporarily removed as it had excessive dependencies, which
have now been fixed.