### PR TITLE
Wait for etcd snapshot if node is not provisioned

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/planner/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/planner/controller.go
@@ -9,16 +9,11 @@ import (
 	v1 "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/provisioningv2/rke2/planner"
 	"github.com/rancher/rancher/pkg/wrangler"
-	"github.com/rancher/wrangler/pkg/condition"
 	"github.com/rancher/wrangler/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
-)
-
-const (
-	Provisioned = condition.Cond("Provisioned")
 )
 
 type handler struct {
@@ -57,12 +52,12 @@ func (h *handler) OnChange(cluster *rkev1.RKEControlPlane, status rkev1.RKEContr
 	var errWaiting planner.ErrWaiting
 	if errors.As(err, &errWaiting) {
 		logrus.Infof("rkecluster %s/%s: %v", cluster.Namespace, cluster.Name, err)
-		Provisioned.SetStatus(&status, "Unknown")
-		Provisioned.Message(&status, err.Error())
-		Provisioned.Reason(&status, "Waiting")
+		planner.Provisioned.SetStatus(&status, "Unknown")
+		planner.Provisioned.Message(&status, err.Error())
+		planner.Provisioned.Reason(&status, "Waiting")
 		return status, nil
 	}
 
-	Provisioned.SetError(&status, "", err)
+	planner.Provisioned.SetError(&status, "", err)
 	return status, err
 }

--- a/pkg/provisioningv2/rke2/planner/etcdcreate.go
+++ b/pkg/provisioningv2/rke2/planner/etcdcreate.go
@@ -108,6 +108,10 @@ func (e *etcdCreate) createPlan(controlPlane *rkev1.RKEControlPlane, snapshot *r
 }
 
 func (e *etcdCreate) Create(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan) error {
+	if !Provisioned.IsTrue(controlPlane) && controlPlane.Status.ETCDSnapshotCreatePhase == "" {
+		return nil
+	}
+
 	if controlPlane.Spec.ETCDSnapshotCreate == nil {
 		return e.resetEtcdCreateState(controlPlane)
 	}

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rancher/rancher/pkg/provisioningv2/kubeconfig"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/rancher/wrangler/pkg/condition"
 	"github.com/rancher/wrangler/pkg/data/convert"
 	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/generic"
@@ -65,6 +66,8 @@ const (
 	SecretTypeMachinePlan = "rke.cattle.io/machine-plan"
 
 	authnWebhookFileName = "/var/lib/rancher/%s/kube-api-authn-webhook.yaml"
+
+	Provisioned = condition.Cond("Provisioned")
 )
 
 var (


### PR DESCRIPTION
If a user created a cluster with etcdSnapshotCreate set, then the
planner would try to create a snapshot before the node was provisioned.
Now, the planner will wait until the node is provisioned before
attempting to take a snapshot.

Issues:
https://github.com/rancher/rancher/issues/32874
https://github.com/rancher/rancher/issues/32391