### PR TITLE
Fix API redirect for paths with //

### DIFF
--- a/pkg/api/steve/aggregation/aggregation.go
+++ b/pkg/api/steve/aggregation/aggregation.go
@@ -65,6 +65,7 @@ func (h *aggregationHandler) next(notFound http.Handler) http.Handler {
 
 func (h *aggregationHandler) setEntries(routes []routeEntry) {
 	mux := mux.NewRouter()
+	mux.UseEncodedPath()
 	for _, entry := range routes {
 		if entry.prefix != "" {
 			mux.PathPrefix(entry.prefix).Handler(h.makeHandler(entry.uuid))


### PR DESCRIPTION
For #32117

Currently requests to `/principals/local%3A%2F%2Fu-lr7ts?sort=name` (`/principals/local://u-lr7ts?sort=name`) respond with redirect (301) to `/principals/local:/u-lr7ts?sort=name` which in turn responds with 500 (error message is `users.management.cattle.io "" not found`).

The fix is to change all mux-es in the API handler chain to not redirect requests containing multiple `/`s which is a default mux behavior.

Note that this is a regression as v2.5.8 release handles such requests correctly.
Also, note browser caches 301 HTTP responses, so if testing the fix on users the issue was reproduced previously, make sure to clear browser's cache beforehand.

**Edit after additional investigation:**
Only URL-encoded requests (like `/principals/local%3A%2F%2Fu-lr7ts?sort=name` and NOT `/principals/local://u-lr7ts?sort=name`) are handled without redirect in v2.5.8.
However, both return redirect on `master`. This is due to additional `aggregationMiddleware` added to Rancher's HTTP handler chain (to handle `/fleet/webhook` route). It may be an option to move this handler down the chain after the one that handles API, however unlike other handlers using mux, this handler did not set `mux.UseEncodedPath`. So, to fix issue, a call to `mux.UseEncodedPath` was added.