### PR TITLE
[Keycloak oidc] Various Fixes 

### DIFF
--- a/pkg/auth/providers/keycloakoidc/keycloak_client.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_client.go
@@ -130,6 +130,9 @@ func getSubGroups(group Group) []Group {
 func (k *KeyCloakClient) getFromKeyCloakByID(principalID, principalType string, config *v32.OIDCConfig) (account, error) {
 	var searchResult account
 
+	if principalID == "" {
+		return account{}, fmt.Errorf("[keycloak oidc]: cannot perfom search with empty principalID")
+	}
 	sURL, err := getSearchURL(config.Issuer)
 	if err != nil {
 		return account{}, nil

--- a/pkg/auth/providers/keycloakoidc/keycloak_client.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_client.go
@@ -8,9 +8,9 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/rancher/norman/httperror"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 //account defines properties an account in keycloak has
@@ -204,7 +204,9 @@ func (k *KeyCloakClient) getFromKeyCloak(url string) ([]byte, int, error) {
 	case 200:
 	case 201:
 	case 403:
-		return b, resp.StatusCode, apierrors.NewUnauthorized(resp.Status)
+		return b, resp.StatusCode, httperror.NewAPIError(httperror.PermissionDenied, "access denied")
+	case 401:
+		return b, resp.StatusCode, httperror.NewAPIError(httperror.Unauthorized, "invalid token")
 	default:
 		return b, resp.StatusCode, err
 	}

--- a/pkg/auth/providers/keycloakoidc/keycloak_provider.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider.go
@@ -50,7 +50,10 @@ func (k *keyCloakOIDCProvider) GetName() string {
 }
 
 func newClient(config *v32.OIDCConfig, token *oauth2.Token) (*KeyCloakClient, error) {
-	ctx := context.Background()
+	ctx, err := oidc.AddCertKeyToContext(context.Background(), config.Certificate, config.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
 	provider, err := gooidc.NewProvider(ctx, config.Issuer)
 	if err != nil {
 		return nil, err
@@ -59,7 +62,6 @@ func newClient(config *v32.OIDCConfig, token *oauth2.Token) (*KeyCloakClient, er
 	keyCloakClient := &KeyCloakClient{
 		httpClient: oauthConfig.Client(ctx, token),
 	}
-	err = oidc.GetClientWithCertKey(keyCloakClient.httpClient, config.Certificate, config.PrivateKey)
 	return keyCloakClient, err
 }
 

--- a/pkg/auth/providers/keycloakoidc/keycloak_provider.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider.go
@@ -161,11 +161,7 @@ func (k *keyCloakOIDCProvider) GetPrincipal(principalID string, token v3.Token) 
 		return v3.Principal{}, errors.Errorf("invalid id %v", principalID)
 	}
 	principalType := parts[1]
-	searchType := "users"
-	if principalType == GroupType {
-		searchType = "groups"
-	}
-	acct, err := keyCloakClient.getFromKeyCloakByID(externalID, searchType, config)
+	acct, err := keyCloakClient.getFromKeyCloakByID(externalID, principalType, config)
 	if err != nil {
 		return v3.Principal{}, err
 	}

--- a/pkg/auth/providers/oidc/oidc_client.go
+++ b/pkg/auth/providers/oidc/oidc_client.go
@@ -9,16 +9,16 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 )
 
-func (o *OpenIDCProvider) AddCertKeyToContext(ctx *context.Context, certificate, key string) (context.Context, error) {
+func AddCertKeyToContext(ctx context.Context, certificate, key string) (context.Context, error) {
 	if certificate != "" && key != "" {
 		certKeyClient := &http.Client{}
 		err := GetClientWithCertKey(certKeyClient, certificate, key)
 		if err != nil {
 			return nil, err
 		}
-		return oidc.ClientContext(*ctx, certKeyClient), nil
+		return oidc.ClientContext(ctx, certKeyClient), nil
 	}
-	return *ctx, nil
+	return ctx, nil
 }
 
 func GetClientWithCertKey(httpClient *http.Client, certificate, key string) error {

--- a/pkg/auth/providers/oidc/oidc_client.go
+++ b/pkg/auth/providers/oidc/oidc_client.go
@@ -9,16 +9,16 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 )
 
-func (o *OpenIDCProvider) AddCertKeyToContext(ctx *context.Context, certificate, key string) error {
+func (o *OpenIDCProvider) AddCertKeyToContext(ctx *context.Context, certificate, key string) (context.Context, error) {
 	if certificate != "" && key != "" {
-		var certKeyClient http.Client
-		err := GetClientWithCertKey(&certKeyClient, certificate, key)
+		certKeyClient := &http.Client{}
+		err := GetClientWithCertKey(certKeyClient, certificate, key)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		oidc.ClientContext(*ctx, &certKeyClient)
+		return oidc.ClientContext(*ctx, certKeyClient), nil
 	}
-	return nil
+	return *ctx, nil
 }
 
 func GetClientWithCertKey(httpClient *http.Client, certificate, key string) error {

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -413,15 +413,18 @@ func (o *OpenIDCProvider) getUserInfo(ctx *context.Context, config *v32.OIDCConf
 }
 
 func ConfigToOauthConfig(endpoint oauth2.Endpoint, config *v32.OIDCConfig) oauth2.Config {
-	configScopes := strings.Split(config.Scopes, ",")
-	allScopes := []string{oidc.ScopeOpenID}
-	allScopes = append(allScopes, configScopes...)
+	hasOIDCScope := strings.Contains(config.Scopes, oidc.ScopeOpenID)
+	// scopes must be space separated in string when passed into the api
+	configScopes := strings.Split(config.Scopes, " ")
+	if !hasOIDCScope {
+		configScopes = append(configScopes, oidc.ScopeOpenID)
+	}
 
 	return oauth2.Config{
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
 		Endpoint:     endpoint,
 		RedirectURL:  config.RancherURL,
-		Scopes:       allScopes,
+		Scopes:       configScopes,
 	}
 }

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -372,7 +372,7 @@ func (o *OpenIDCProvider) getUserInfo(ctx *context.Context, config *v32.OIDCConf
 	var oauth2Token *oauth2.Token
 	var err error
 
-	updatedContext, err := o.AddCertKeyToContext(ctx, config.Certificate, config.PrivateKey)
+	updatedContext, err := AddCertKeyToContext(*ctx, config.Certificate, config.PrivateKey)
 	if err != nil {
 		return userInfo, oauth2Token, err
 	}

--- a/scripts/ci
+++ b/scripts/ci
@@ -5,6 +5,6 @@ cd $(dirname $0)
 
 ./validate
 ./build
-./test
+#./test
 ./package
-./chart/ci
+#./chart/ci

--- a/scripts/ci
+++ b/scripts/ci
@@ -5,6 +5,6 @@ cd $(dirname $0)
 
 ./validate
 ./build
-#./test
+./test
 ./package
-#./chart/ci
+./chart/ci


### PR DESCRIPTION
**Issues** 
https://github.com/rancher/rancher/issues/33337
https://github.com/rancher/rancher/issues/33314
https://github.com/rancher/dashboard/issues/3406 Scope needed to be space separated and allow for "openid" scope to be passed in instead of set in the client always. 
Certificate and Key were not being added to the context in all situations

**Solution**
Groups were not showing up on refresh because the Keycloak api relies on IDs, but we only have the name for groups. To resolve this, I am using the basic group search endpoint and then filtering down the result to only the value that has a matching name. group names are unique in keycloak, even if its a nested group. Note: since we only return 1 principal at a time for groups, we are not able to add all of the children groups if you add the parent group. 

With the newer version of Keycloak, scopes are now being validated - we were previously using comma separated scopes, but these were also being used in the UI (https://github.com/rancher/dashboard/pull/3434/files) so we switched to a space seperated string and I only add the openid scope value if it is not present

A new context was being created, but the old context was being passed around so the context with the updated values was never being used. I am now grabbing the new context and passing that value through to the other functions correctly. 

Added unauthorized error for when the token expires so that a proper error message is logged and there is no attempt in the client to parse the response. 