### PR TITLE
Remove legacy kev2 apps before install

### DIFF
--- a/pkg/controllers/dashboard/hostedcluster/controller.go
+++ b/pkg/controllers/dashboard/hostedcluster/controller.go
@@ -2,16 +2,22 @@ package hostedcluster
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/catalogv2/system"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/chart"
+	controllerv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	controllerprojectv3 "github.com/rancher/rancher/pkg/generated/controllers/project.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/project"
+	"github.com/rancher/rancher/pkg/ref"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
 	v1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -41,15 +47,26 @@ var (
 	}
 )
 
+var (
+	localCluster = "local"
+
+	legacyOperatorAppNameFormat = "rancher-%s-operator"
+)
+
 type handler struct {
-	manager *system.Manager
-	secrets v1.SecretCache
+	manager      *system.Manager
+	appCache     controllerprojectv3.AppCache
+	apps         controllerprojectv3.AppController
+	projectCache controllerv3.ProjectCache
+	secrets      v1.SecretCache
 }
 
 func Register(ctx context.Context, wContext *wrangler.Context) error {
 	h := &handler{
-		manager: wContext.SystemChartsManager,
-		secrets: wContext.Core.Secret().Cache(),
+		manager:      wContext.SystemChartsManager,
+		apps:         wContext.Project.App(),
+		projectCache: wContext.Mgmt.Project().Cache(),
+		secrets:      wContext.Core.Secret().Cache(),
 	}
 
 	wContext.Mgmt.Cluster().OnChange(ctx, "cluster-provisioning-operator", h.onClusterChange)
@@ -63,19 +80,27 @@ func (h handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster, 
 	}
 
 	var toInstallCrdChart, toInstallChart *chart.Definition
+	var provider string
 	if cluster.Spec.AKSConfig != nil {
 		toInstallCrdChart = &AksCrdChart
 		toInstallChart = &AksChart
+		provider = "aks"
 	} else if cluster.Spec.EKSConfig != nil {
 		toInstallCrdChart = &EksCrdChart
 		toInstallChart = &EksChart
+		provider = "eks"
 	} else if cluster.Spec.GKEConfig != nil {
 		toInstallCrdChart = &GkeCrdChart
 		toInstallChart = &GkeChart
+		provider = "gke"
 	}
 
 	if toInstallCrdChart == nil || toInstallChart == nil {
 		return cluster, nil
+	}
+
+	if err := h.removeLegacyOperatorIfExists(provider); err != nil {
+		return cluster, err
 	}
 
 	if err := h.manager.Ensure(toInstallCrdChart.ReleaseNamespace, toInstallCrdChart.ChartName, "", nil, true); err != nil {
@@ -106,6 +131,28 @@ func (h handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster, 
 	}
 
 	return cluster, nil
+}
+
+func (h handler) removeLegacyOperatorIfExists(provider string) error {
+	systemProject, err := project.GetSystemProject(localCluster, h.projectCache)
+	if err != nil {
+		return err
+	}
+
+	systemProjectID := ref.Ref(systemProject)
+	_, systemProjectName := ref.Parse(systemProjectID)
+
+	legacyOperatorAppName := fmt.Sprintf(legacyOperatorAppNameFormat, provider)
+	_, err = h.appCache.Get(systemProjectName, legacyOperatorAppName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// legacy app doesn't exist, no-op
+			return nil
+		}
+		return err
+	}
+
+	return h.apps.Delete(systemProjectName, legacyOperatorAppName, &metav1.DeleteOptions{})
 }
 
 func getAdditionalCA(secretsCache v1.SecretCache) ([]byte, error) {


### PR DESCRIPTION
**Problem:**
Prior, the old eks-operator app remained and deleting
it would cause the eks-operator deployment to get removed.
This caused both apps to be deleted and edits to no longer
work. Editing an EKS cluster would not cause the app to
redeploy either.

**Solution:**
Now, the old eks-operator app is deleted
before installing the new app. Old eks-operator app refers
to the app of type apps.project.cattle.io. Now, in v2.6+
an app of type apps.catalog.cattle.io is installed instead.

**Issue:**
https://github.com/rancher/rancher/issues/31592