### PR TITLE
Add impersonator account on downstream clusters

### DIFF
--- a/pkg/auth/requests/filter.go
+++ b/pkg/auth/requests/filter.go
@@ -47,7 +47,9 @@ func (h authHeaderHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 
 	for key, extras := range userInfo.GetExtra() {
 		for _, s := range extras {
-			req.Header.Add("Impersonate-Extra-"+key, s)
+			if s != "" {
+				req.Header.Add("Impersonate-Extra-"+key, s)
+			}
 		}
 	}
 

--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -16,12 +15,16 @@ import (
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	dialer2 "github.com/rancher/rancher/pkg/dialer"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/kontainer-engine/drivers/gke"
+	"github.com/rancher/rancher/pkg/impersonation"
+	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/types/config/dialer"
+	"github.com/rancher/wrangler/pkg/schemas/validation"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/proxy"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/rest"
 )
 
@@ -31,12 +34,13 @@ type RemoteService struct {
 	cluster   *v3.Cluster
 	transport transportGetter
 	url       urlGetter
-	auth      authGetter
 
-	factory       dialer.Factory
-	clusterLister v3.ClusterLister
-	caCert        string
-	httpTransport *http.Transport
+	factory        dialer.Factory
+	clusterLister  v3.ClusterLister
+	caCert         string
+	localAuth      string
+	httpTransport  *http.Transport
+	clusterContext *config.UserContext
 }
 
 var (
@@ -61,11 +65,11 @@ func prefix(cluster *v3.Cluster) string {
 	return "/k8s/clusters/" + cluster.Name
 }
 
-func New(localConfig *rest.Config, cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory) (*RemoteService, error) {
+func New(localConfig *rest.Config, cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContext *config.UserContext) (*RemoteService, error) {
 	if cluster.Spec.Internal {
 		return NewLocal(localConfig, cluster)
 	}
-	return NewRemote(cluster, clusterLister, factory)
+	return NewRemote(cluster, clusterLister, factory, clusterContext)
 }
 
 func NewLocal(localConfig *rest.Config, cluster *v3.Cluster) (*RemoteService, error) {
@@ -92,17 +96,15 @@ func NewLocal(localConfig *rest.Config, cluster *v3.Cluster) (*RemoteService, er
 		transport: transportGetter,
 	}
 	if localConfig.BearerToken != "" {
-		rs.auth = func() (string, error) { return "Bearer " + localConfig.BearerToken, nil }
+		rs.localAuth = "Bearer " + localConfig.BearerToken
 	} else if localConfig.Password != "" {
-		rs.auth = func() (string, error) {
-			return "Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", localConfig.Username, localConfig.Password))), nil
-		}
+		rs.localAuth = "Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", localConfig.Username, localConfig.Password)))
 	}
 
 	return rs, nil
 }
 
-func NewRemote(cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory) (*RemoteService, error) {
+func NewRemote(cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContext *config.UserContext) (*RemoteService, error) {
 	if !v32.ClusterConditionProvisioned.IsTrue(cluster) {
 		return nil, httperror.NewAPIError(httperror.ClusterUnavailable, "cluster not provisioned")
 	}
@@ -120,21 +122,12 @@ func NewRemote(cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dial
 		return *u, nil
 	}
 
-	authGetter := func() (string, error) {
-		newCluster, err := clusterLister.Get("", cluster.Name)
-		if err != nil {
-			return "", err
-		}
-
-		return "Bearer " + newCluster.Status.ServiceAccountToken, nil
-	}
-
 	return &RemoteService{
-		cluster:       cluster,
-		url:           urlGetter,
-		auth:          authGetter,
-		clusterLister: clusterLister,
-		factory:       factory,
+		cluster:        cluster,
+		url:            urlGetter,
+		clusterLister:  clusterLister,
+		factory:        factory,
+		clusterContext: clusterContext,
 	}, nil
 }
 
@@ -228,22 +221,20 @@ func (r *RemoteService) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if r.cluster.Status.Driver == "googleKubernetesEngine" && r.cluster.Spec.GenericEngineConfig != nil {
-		cred, _ := (*r.cluster.Spec.GenericEngineConfig)["credential"].(string)
-		transport, err = gke.Oauth2Transport(context.Background(), transport, cred)
-		if err != nil {
-			er.Error(rw, req, fmt.Errorf("unable to retrieve token source for GKE oauth2: %v", err))
-			return
-		}
-	} else if r.auth == nil {
+	if r.cluster.Spec.Internal && r.localAuth == "" {
 		req.Header.Del("Authorization")
 	} else {
-		token, err := r.auth()
-		if err != nil {
-			er.Error(rw, req, err)
+		userInfo, authed := request.UserFrom(req.Context())
+		if !authed {
+			er.Error(rw, req, validation.Unauthorized)
 			return
 		}
-		req.Header.Set("Authorization", token)
+		token, err := r.getImpersonatorAccountToken(userInfo)
+		if err != nil && !strings.Contains(err.Error(), dialer2.ErrAgentDisconnected.Error()) {
+			er.Error(rw, req, fmt.Errorf("unable to create impersonator account: %w", err))
+			return
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	if httpstream.IsUpgradeRequest(req) {
@@ -283,4 +274,21 @@ func (p *UpgradeProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	httpProxy := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: p.Location.Scheme, Host: p.Location.Host})
 	httpProxy.Transport = p.Transport
 	httpProxy.ServeHTTP(rw, newReq)
+}
+
+// getImpersonatorAccountToken creates, if not already present, a service account and role bindings
+// whose only permission is to impersonate the given user, and returns the bearer token for the account.
+func (r *RemoteService) getImpersonatorAccountToken(user user.Info) (string, error) {
+	i := impersonation.New(user, r.clusterContext)
+
+	sa, err := i.SetUpImpersonation()
+	if err != nil {
+		return "", fmt.Errorf("error setting up impersonation for user %s: %w", user.GetUID(), err)
+	}
+	saToken, err := i.GetToken(sa)
+	if err != nil {
+		return "", fmt.Errorf("error getting service account token: %w", err)
+	}
+
+	return saToken, nil
 }

--- a/pkg/clusterrouter/router.go
+++ b/pkg/clusterrouter/router.go
@@ -14,8 +14,8 @@ type Router struct {
 	serverFactory *factory
 }
 
-func New(localConfig *rest.Config, lookup ClusterLookup, dialer dialer.Factory, clusterLister v3.ClusterLister) http.Handler {
-	serverFactory := newFactory(localConfig, dialer, lookup, clusterLister)
+func New(localConfig *rest.Config, lookup ClusterLookup, dialer dialer.Factory, clusterLister v3.ClusterLister, clusterContextGetter ClusterContextGetter) http.Handler {
+	serverFactory := newFactory(localConfig, dialer, lookup, clusterLister, clusterContextGetter)
 	return &Router{
 		serverFactory: serverFactory,
 	}

--- a/pkg/controllers/managementuser/rbac/crtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/crtb_handler.go
@@ -68,6 +68,10 @@ func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding) error {
 		return errors.Wrapf(err, "couldn't ensure cluster bindings %v", binding)
 	}
 
+	if err := c.m.ensureServiceAccountImpersonator(binding.UserName, binding.GroupName); err != nil {
+		return errors.Wrapf(err, "couldn't ensure service account impersonator")
+	}
+
 	return nil
 }
 
@@ -85,6 +89,10 @@ func (c *crtbLifecycle) ensureCRTBDelete(binding *v3.ClusterRoleTemplateBinding)
 				return errors.Wrapf(err, "error deleting clusterrolebinding %v", rb.Name)
 			}
 		}
+	}
+
+	if err := c.m.deleteServiceAccountImpersonator(binding.UserName); err != nil {
+		return errors.Wrap(err, "error deleting service account impersonator")
 	}
 
 	return nil

--- a/pkg/controllers/managementuser/rbac/globalrole_handler.go
+++ b/pkg/controllers/managementuser/rbac/globalrole_handler.go
@@ -38,6 +38,7 @@ func RegisterIndexers(ctx context.Context, scaledContext *config.ScaledContext) 
 		rtbByClusterAndRoleTemplateIndex: rtbByClusterAndRoleTemplateName,
 		prtbByUIDIndex:                   prtbByUID,
 		prtbByNsAndNameIndex:             prtbByNsName,
+		rtbByClusterAndUserIndex:         rtbByClusterAndUserNotDeleting,
 	}
 	if err := prtbInformer.AddIndexers(prtbIndexers); err != nil {
 		return err
@@ -46,6 +47,7 @@ func RegisterIndexers(ctx context.Context, scaledContext *config.ScaledContext) 
 	crtbInformer := scaledContext.Management.ClusterRoleTemplateBindings("").Controller().Informer()
 	crtbIndexers := map[string]cache.IndexFunc{
 		rtbByClusterAndRoleTemplateIndex: rtbByClusterAndRoleTemplateName,
+		rtbByClusterAndUserIndex:         rtbByClusterAndUserNotDeleting,
 	}
 	return crtbInformer.AddIndexers(crtbIndexers)
 }

--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -36,11 +36,13 @@ const (
 	prtbByUIDIndex                   = "authz.cluster.cattle.io/rtb-owner"
 	prtbByNsAndNameIndex             = "authz.cluster.cattle.io/rtb-owner-updated"
 	rtbByClusterAndRoleTemplateIndex = "authz.cluster.cattle.io/rtb-by-cluster-rt"
+	rtbByClusterAndUserIndex         = "authz.cluster.cattle.io/rtb-by-cluster-user"
 	nsByProjectIndex                 = "authz.cluster.cattle.io/ns-by-project"
 	crByNSIndex                      = "authz.cluster.cattle.io/cr-by-ns"
 	crbByRoleAndSubjectIndex         = "authz.cluster.cattle.io/crb-by-role-and-subject"
 	rtbLabelUpdated                  = "authz.cluster.cattle.io/rtb-label-updated"
 	rtbCrbRbLabelsUpdated            = "authz.cluster.cattle.io/crb-rb-labels-updated"
+	impersonationLabel               = "authz.cluster.cattle.io/impersonator"
 )
 
 func Register(ctx context.Context, workload *config.UserContext) {
@@ -89,6 +91,7 @@ func Register(ctx context.Context, workload *config.UserContext) {
 		nsController:        workload.Core.Namespaces("").Controller(),
 		clusterLister:       workload.Management.Management.Clusters("").Controller().Lister(),
 		projectLister:       workload.Management.Management.Projects(workload.ClusterName).Controller().Lister(),
+		userLister:          workload.Management.Management.Users("").Controller().Lister(),
 		crtbs:               workload.Management.Management.ClusterRoleTemplateBindings(""),
 		prtbs:               workload.Management.Management.ProjectRoleTemplateBindings(""),
 		clusterName:         workload.ClusterName,
@@ -135,6 +138,7 @@ type manager struct {
 	nsController        typescorev1.NamespaceController
 	clusterLister       v3.ClusterLister
 	projectLister       v3.ProjectLister
+	userLister          v3.UserLister
 	crtbs               v3.ClusterRoleTemplateBindingInterface
 	prtbs               v3.ProjectRoleTemplateBindingInterface
 	clusterName         string
@@ -598,6 +602,35 @@ func rtbByClusterAndRoleTemplateName(obj interface{}) ([]string, error) {
 	case *v3.ClusterRoleTemplateBinding:
 		if rtb.RoleTemplateName != "" && rtb.ClusterName != "" {
 			idx = rtb.ClusterName + "-" + rtb.RoleTemplateName
+		}
+	}
+
+	if idx == "" {
+		return []string{}, nil
+	}
+	return []string{idx}, nil
+}
+
+func rtbByClusterAndUserNotDeleting(obj interface{}) ([]string, error) {
+	meta, err := meta.Accessor(obj)
+	if err != nil {
+		return []string{}, err
+	}
+	if meta.GetDeletionTimestamp() != nil {
+		return []string{}, nil
+	}
+	var idx string
+	switch rtb := obj.(type) {
+	case *v3.ProjectRoleTemplateBinding:
+		if rtb.UserName != "" && rtb.ProjectName != "" {
+			parts := strings.SplitN(rtb.ProjectName, ":", 2)
+			if len(parts) == 2 {
+				idx = parts[0] + "-" + rtb.UserName
+			}
+		}
+	case *v3.ClusterRoleTemplateBinding:
+		if rtb.UserName != "" && rtb.ClusterName != "" {
+			idx = rtb.ClusterName + "-" + rtb.UserName
 		}
 	}
 

--- a/pkg/controllers/managementuser/rbac/impersonation_handler.go
+++ b/pkg/controllers/managementuser/rbac/impersonation_handler.go
@@ -1,0 +1,66 @@
+package rbac
+
+import (
+	"github.com/rancher/rancher/pkg/impersonation"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func (m *manager) getUser(username, groupname string) (user.Info, error) {
+	u, err := m.userLister.Get("", username)
+	if err != nil {
+		return &user.DefaultInfo{}, err
+	}
+	groups := []string{"system:authenticated", "system:cattle:authenticated"}
+	if groupname != "" {
+		groups = append(groups, groupname)
+	}
+	user := &user.DefaultInfo{
+		UID:    u.GetName(),
+		Name:   u.Username,
+		Groups: groups,
+		Extra:  map[string][]string{"username": []string{u.Username}},
+	}
+	if len(u.PrincipalIDs) > 0 {
+		user.Extra["principalid"] = u.PrincipalIDs
+	}
+	return user, nil
+}
+
+func (m *manager) ensureServiceAccountImpersonator(username, groupname string) error {
+	user, err := m.getUser(username, groupname)
+	if apierrors.IsNotFound(err) {
+		logrus.Warnf("could not find user %s, will not create impersonation account on cluster", username)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	logrus.Debugf("ensuring service account impersonator for %s", user.GetUID())
+	i := impersonation.New(user, m.workload)
+	_, err = i.SetUpImpersonation()
+	return err
+}
+
+func (m *manager) deleteServiceAccountImpersonator(username string) error {
+	crtbs, err := m.crtbIndexer.ByIndex(rtbByClusterAndUserIndex, m.workload.ClusterName+"-"+username)
+	if err != nil {
+		return err
+	}
+	prtbs, err := m.prtbIndexer.ByIndex(rtbByClusterAndUserIndex, m.workload.ClusterName+"-"+username)
+	if err != nil {
+		return err
+	}
+	if len(crtbs)+len(prtbs) > 0 {
+		return nil
+	}
+	roleName := impersonation.ImpersonationPrefix + username
+	logrus.Debugf("deleting service account impersonator for %s", username)
+	err = m.workload.RBAC.ClusterRoles("").Delete(roleName, &metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -103,6 +103,10 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 		}
 	}
 
+	if err := p.m.ensureServiceAccountImpersonator(binding.UserName, binding.GroupName); err != nil {
+		return errors.Wrapf(err, "couldn't ensure service account impersonator")
+	}
+
 	return p.reconcileProjectAccessToGlobalResources(binding, roles)
 }
 
@@ -129,6 +133,10 @@ func (p *prtbLifecycle) ensurePRTBDelete(binding *v3.ProjectRoleTemplateBinding)
 				}
 			}
 		}
+	}
+
+	if err := p.m.deleteServiceAccountImpersonator(binding.UserName); err != nil {
+		return errors.Wrap(err, "error deleting service account impersonator")
 	}
 
 	return p.reconcileProjectAccessToGlobalResourcesForDelete(binding)

--- a/pkg/impersonation/impersonation.go
+++ b/pkg/impersonation/impersonation.go
@@ -1,0 +1,256 @@
+package impersonation
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+const (
+	impersonationLabel     = "authz.cluster.cattle.io/impersonator"
+	impersonationNamespace = "cattle-impersonation-system"
+	ImpersonationPrefix    = "cattle-impersonation-"
+)
+
+type Impersonator struct {
+	user           user.Info
+	clusterContext *config.UserContext
+}
+
+func New(user user.Info, clusterContext *config.UserContext) Impersonator {
+	return Impersonator{user: user, clusterContext: clusterContext}
+}
+
+func (i *Impersonator) SetUpImpersonation() (*corev1.ServiceAccount, error) {
+	sa, err := i.checkServiceAccount()
+	if err != nil {
+		return nil, err
+	}
+	if sa != nil {
+		return sa, nil
+	}
+	err = i.createNamespace()
+	if err != nil {
+		return nil, err
+	}
+	role, err := i.createRole()
+	if err != nil {
+		return nil, err
+	}
+	sa, err = i.createServiceAccount(role)
+	if err != nil {
+		return nil, err
+	}
+	err = i.createRoleBinding(role, sa)
+	if err != nil {
+		return nil, err
+	}
+	return i.waitForServiceAccount(sa)
+}
+
+func (i *Impersonator) GetToken(sa *corev1.ServiceAccount) (string, error) {
+	if len(sa.Secrets) == 0 {
+		return "", fmt.Errorf("service account is not ready")
+	}
+	secret := sa.Secrets[0]
+	secretObj, err := i.clusterContext.Core.Secrets("").Controller().Lister().Get(impersonationNamespace, secret.Name)
+	if err != nil {
+		return "", fmt.Errorf("error getting secret: %w", err)
+	}
+	token, ok := secretObj.Data["token"]
+	if !ok {
+		return "", fmt.Errorf("error getting token: invalid secret object")
+	}
+	return string(token), nil
+}
+
+func (i *Impersonator) checkServiceAccount() (*corev1.ServiceAccount, error) {
+	name := ImpersonationPrefix + i.user.GetUID()
+	sa, err := i.clusterContext.Core.ServiceAccounts("").Controller().Lister().Get(impersonationNamespace, name)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return sa, nil
+}
+
+func (i *Impersonator) createServiceAccount(role *rbacv1.ClusterRole) (*corev1.ServiceAccount, error) {
+	name := ImpersonationPrefix + i.user.GetUID()
+	sa, err := i.clusterContext.Core.ServiceAccounts("").Controller().Lister().Get(impersonationNamespace, name)
+	if apierrors.IsNotFound(err) {
+		logrus.Debugf("impersonation: creating service account %s", name)
+		sa, err = i.clusterContext.Core.ServiceAccounts(impersonationNamespace).Create(&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					impersonationLabel: "true",
+				},
+				// Use the clusterrole as the owner for the purposes of automatic cleanup
+				OwnerReferences: []metav1.OwnerReference{{
+					Name:       role.Name,
+					UID:        role.UID,
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "ClusterRole",
+				}},
+			},
+		})
+		if apierrors.IsAlreadyExists(err) {
+			// in case cache isn't synced yet, use raw client
+			return i.clusterContext.Core.ServiceAccounts(impersonationNamespace).Get(name, metav1.GetOptions{})
+		}
+	}
+	return sa, err
+}
+
+func (i *Impersonator) createNamespace() error {
+	_, err := i.clusterContext.Core.Namespaces("").Controller().Lister().Get("", impersonationNamespace)
+	if apierrors.IsNotFound(err) {
+		logrus.Debugf("impersonation: creating namespace %s", impersonationNamespace)
+		_, err = i.clusterContext.Core.Namespaces("").Create(&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: impersonationNamespace,
+				Labels: map[string]string{
+					impersonationLabel: "true",
+				},
+			},
+		})
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+	}
+	return err
+}
+
+func (i *Impersonator) createRole() (*rbacv1.ClusterRole, error) {
+	name := ImpersonationPrefix + i.user.GetUID()
+	r, err := i.clusterContext.RBAC.ClusterRoles("").Controller().Lister().Get("", name)
+	if apierrors.IsNotFound(err) {
+		logrus.Debugf("impersonation: creating role %s", name)
+		rules := []rbacv1.PolicyRule{
+			{
+				Verbs:         []string{"impersonate"},
+				APIGroups:     []string{""},
+				Resources:     []string{"users"},
+				ResourceNames: []string{i.user.GetUID()},
+			},
+			{
+				Verbs:         []string{"impersonate"},
+				APIGroups:     []string{""},
+				Resources:     []string{"groups"},
+				ResourceNames: i.user.GetGroups(),
+			},
+		}
+
+		extras := i.user.GetExtra()
+		if principalids, ok := extras["principalid"]; ok {
+			rules = append(rules, rbacv1.PolicyRule{
+				Verbs:         []string{"impersonate"},
+				APIGroups:     []string{"authentication.k8s.io"},
+				Resources:     []string{"userextras/principalid"},
+				ResourceNames: principalids,
+			})
+		}
+		if usernames, ok := extras["username"]; ok {
+			rules = append(rules, rbacv1.PolicyRule{
+				Verbs:         []string{"impersonate"},
+				APIGroups:     []string{"authentication.k8s.io"},
+				Resources:     []string{"userextras/username"},
+				ResourceNames: usernames,
+			})
+		}
+		r, err = i.clusterContext.RBAC.ClusterRoles("").Create(&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ImpersonationPrefix + i.user.GetUID(),
+				Labels: map[string]string{
+					impersonationLabel: "true",
+				},
+			},
+			Rules:           rules,
+			AggregationRule: nil,
+		})
+		if apierrors.IsAlreadyExists(err) {
+			// in case cache isn't synced yet, use raw client
+			return i.clusterContext.RBAC.ClusterRoles("").Get(name, metav1.GetOptions{})
+		}
+	}
+	return r, err
+}
+
+func (i *Impersonator) createRoleBinding(role *rbacv1.ClusterRole, sa *corev1.ServiceAccount) error {
+	name := ImpersonationPrefix + i.user.GetUID()
+	_, err := i.clusterContext.RBAC.ClusterRoleBindings("").Controller().Lister().Get("", name)
+	if apierrors.IsNotFound(err) {
+		logrus.Debugf("impersonation: creating role binding %s", name)
+		_, err = i.clusterContext.RBAC.ClusterRoleBindings("").Create(&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				// Use the clusterrole as the owner for the purposes of automatic cleanup
+				OwnerReferences: []metav1.OwnerReference{{
+					Name:       role.Name,
+					UID:        role.UID,
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "ClusterRole",
+				}},
+				Labels: map[string]string{
+					impersonationLabel: "true",
+				},
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					APIGroup:  "",
+					Name:      sa.Name,
+					Namespace: sa.Namespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     role.Name,
+			},
+		})
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+	}
+	return err
+}
+
+func (i *Impersonator) waitForServiceAccount(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+	logrus.Debugf("impersonation: waiting for service account %s/%s to be ready", sa.Namespace, sa.Name)
+	backoff := wait.Backoff{
+		Duration: 200 * time.Millisecond,
+		Factor:   1,
+		Jitter:   0,
+		Steps:    10,
+	}
+	var ret *corev1.ServiceAccount
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		var err error
+		ret, err = i.clusterContext.Core.ServiceAccounts(sa.Namespace).Get(sa.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if len(ret.Secrets) > 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret for service account: %s/%s, error: %w", sa.Namespace, sa.Name, err)
+	}
+	return ret, nil
+}

--- a/pkg/k8sproxy/k8s_proxy.go
+++ b/pkg/k8sproxy/k8s_proxy.go
@@ -9,7 +9,8 @@ import (
 	"github.com/rancher/rancher/pkg/types/config/dialer"
 )
 
-func New(scaledContext *config.ScaledContext, dialer dialer.Factory) http.Handler {
+func New(scaledContext *config.ScaledContext, dialer dialer.Factory, clusterContextGetter clusterrouter.ClusterContextGetter) http.Handler {
 	return clusterrouter.New(&scaledContext.RESTConfig, k8slookup.New(scaledContext, true), dialer,
-		scaledContext.Management.Clusters("").Controller().Lister())
+		scaledContext.Management.Clusters("").Controller().Lister(),
+		clusterContextGetter)
 }

--- a/pkg/multiclustermanager/routes.go
+++ b/pkg/multiclustermanager/routes.go
@@ -38,7 +38,7 @@ import (
 
 func router(ctx context.Context, localClusterEnabled bool, tunnelAuthorizer *mcmauthorizer.Authorizer, scaledContext *config.ScaledContext, clusterManager *clustermanager.Manager) (func(http.Handler) http.Handler, error) {
 	var (
-		k8sProxy             = k8sProxyPkg.New(scaledContext, scaledContext.Dialer)
+		k8sProxy             = k8sProxyPkg.New(scaledContext, scaledContext.Dialer, clusterManager)
 		connectHandler       = scaledContext.Dialer.(*rancherdialer.Factory).TunnelServer
 		connectConfigHandler = rkenodeconfigserver.Handler(tunnelAuthorizer, scaledContext)
 		clusterImport        = clusterregistrationtokens.ClusterImport{Clusters: scaledContext.Management.Clusters("")}


### PR DESCRIPTION
Create an impersonator service account when cluster and project role
templates are created on downstream clusters. Check for it and create it
upon receiving a proxy request if necessary.