### PR TITLE
Bump kubernetes provider detector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/rancher/eks-operator v1.1.1-rc3
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210608014113-99e848822739
 	github.com/rancher/gke-operator v1.1.1-rc7
-	github.com/rancher/kubernetes-provider-detector v0.1.2
+	github.com/rancher/kubernetes-provider-detector v0.1.3
 	github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08
 	github.com/rancher/lasso/controller-runtime v0.0.0-20210608205930-775fcaf2f523
 	github.com/rancher/machine v0.15.0-rancher60

--- a/go.sum
+++ b/go.sum
@@ -981,8 +981,9 @@ github.com/rancher/gke-operator v1.1.1-rc7 h1:/dxARKFnpnbl0KCx8ANnVpuqbqI/V7gM/n
 github.com/rancher/gke-operator v1.1.1-rc7/go.mod h1:sO79ki/wksclGtziLqarrvRx8+l15+BPisFHHMjrIe0=
 github.com/rancher/helm/v3 v3.5.4-rancher.1 h1:TlvhucjCyHdnXw4uClSWJmv/p7onCP6dMXsBlIQSp6A=
 github.com/rancher/helm/v3 v3.5.4-rancher.1/go.mod h1:6eTBYLWEHt3JqXZPyHoYvb9/B7wPKHT3tjWnMfjen9w=
-github.com/rancher/kubernetes-provider-detector v0.1.2 h1:iFfmmcZiGya6s3cS4Qxksyqqw5hPbbIDHgKJ2Y44XKM=
 github.com/rancher/kubernetes-provider-detector v0.1.2/go.mod h1:ypuJS7kP7rUiAn330xG46mj+Nhvym05GM8NqMVekpH0=
+github.com/rancher/kubernetes-provider-detector v0.1.3 h1:OvXPsvNfKAOFKqDbq1rddg0ubRkNITF8FfqIiM0f0og=
+github.com/rancher/kubernetes-provider-detector v0.1.3/go.mod h1:ypuJS7kP7rUiAn330xG46mj+Nhvym05GM8NqMVekpH0=
 github.com/rancher/lasso v0.0.0-20200427171700-e0509f89f319/go.mod h1:6Dw19z1lDIpL887eelVjyqH/mna1hfR61ddCFOG78lw=
 github.com/rancher/lasso v0.0.0-20200515155337-a34e1e26ad91/go.mod h1:G6Vv2aj6xB2YjTVagmu4NkhBvbE8nBcGykHRENH6arI=
 github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=


### PR DESCRIPTION
Problem:
We should be able to filter harvester clusters by the provider detector.

Solution:
Bump Kubernetes provider detector to v0.1.3 to support harvester provider detector.

Related Issue:
https://github.com/rancher/dashboard/issues/3466
