### PR TITLE
Add donotuse tag for testing Docker image promote

### DIFF
--- a/scripts/promote-docker-image.sh
+++ b/scripts/promote-docker-image.sh
@@ -29,8 +29,8 @@ fi
 source_tag=$1
 destination_tag=$2
 
-if [[ ! $destination_tag =~ ^(stable|latest)$ ]]; then
-  echo "Docker tag needs to be stable or latest, not ${destination_tag}"
+if [[ ! $destination_tag =~ ^(stable|latest|donotuse)$ ]]; then
+  echo "Docker tag needs to be stable or latest (or donotuse for testing), not ${destination_tag}"
   exit 1
 fi
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/33633

We need to test this functionality and this allows us to use `rancher/rancher:donotuse` to use as tag to test and still indicate for others they cant be used. I wanted to add `testing` but that indicates it might be a testing image or something.

I guess ideally this should be a different org but this is what we have today.