### PR TITLE
default the password to admin rather than a random value

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -15,7 +15,6 @@ import (
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/wrangler"
-	"github.com/rancher/wrangler/pkg/randomtoken"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
@@ -509,7 +508,7 @@ func BootstrapAdmin(management *wrangler.Context) (string, error) {
 		// Config map does not exist and no users, attempt to create the default admin user
 		bootstrapPassword := os.Getenv("CATTLE_BOOTSTRAP_PASSWORD")
 		if bootstrapPassword == "" {
-			bootstrapPassword, err = randomtoken.Generate()
+			bootstrapPassword = "admin"
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
Randomizing the admin password makes it difficult to setup rancher.  Users can still specify the initial password when the setup rancher with `CATTLE_BOOTSTRAP_PASSWORD` or `bootstrapPassword` in the helm chart.