### PR TITLE
added CATTLE_BOOTSTRAP_PASSWORD to each docker/ha install of rancher

### DIFF
--- a/tests/validation/tests/v3_api/test_airgap.py
+++ b/tests/validation/tests/v3_api/test_airgap.py
@@ -556,16 +556,20 @@ def deploy_airgap_rancher(bastion_node):
             '-v ${{PWD}}/privkey.pem:/etc/rancher/ssl/key.pem ' \
             '-e CATTLE_SYSTEM_DEFAULT_REGISTRY={} ' \
             '-e CATTLE_SYSTEM_CATALOG=bundled ' \
+            '-e CATTLE_BOOTSTRAP_PASSWORD={} ' \
             '{}/rancher/rancher:{} --no-cacerts --trace'.format(
                 privileged, bastion_node.host_name, bastion_node.host_name,
-                RANCHER_SERVER_VERSION)
+                ADMIN_PASSWORD, RANCHER_SERVER_VERSION)
     else:
         deploy_rancher_command = \
             'sudo docker run -d {} --restart=unless-stopped ' \
             '-p 80:80 -p 443:443 ' \
             '-e CATTLE_SYSTEM_DEFAULT_REGISTRY={} ' \
+            '-e CATTLE_BOOTSTRAP_PASSWORD={} ' \
             '-e CATTLE_SYSTEM_CATALOG=bundled {}/rancher/rancher:{} --trace'.format(
-                privileged, bastion_node.host_name, bastion_node.host_name,
+                privileged, bastion_node.host_name, 
+                ADMIN_PASSWORD,
+                bastion_node.host_name,
                 RANCHER_SERVER_VERSION)
     deploy_result = run_command_on_airgap_node(bastion_node, ag_node,
                                                deploy_rancher_command,

--- a/tests/validation/tests/v3_api/test_custom_host_reg.py
+++ b/tests/validation/tests/v3_api/test_custom_host_reg.py
@@ -48,7 +48,8 @@ def test_deploy_rancher_server():
         RANCHER_SERVER_CMD = \
             'sudo docker run -d --privileged --name="rancher-server" ' \
             '--restart=unless-stopped -p 80:80 -p 443:443  ' \
-            'rancher/rancher'
+            '-e CATTLE_BOOTSTRAP_PASSWORD={} ' \
+            'rancher/rancher'.format(ADMIN_PASSWORD)
     else:
         RANCHER_SERVER_CMD = \
             'sudo docker run -d --name="rancher-server" ' \
@@ -68,7 +69,7 @@ def test_deploy_rancher_server():
         "sudo docker exec rancher-server loglevel --set debug"
     aws_nodes[0].execute_command(RANCHER_SET_DEBUG_CMD)
 
-    token = set_url_password_token(RANCHER_SERVER_URL)
+    token = set_url_password_token(RANCHER_SERVER_URL, version=RANCHER_SERVER_VERSION)
     admin_client = rancher.Client(url=RANCHER_SERVER_URL + "/v3",
                                   token=token, verify=False)
     if AUTH_PROVIDER:

--- a/tests/validation/tests/v3_api/test_proxy.py
+++ b/tests/validation/tests/v3_api/test_proxy.py
@@ -2,7 +2,7 @@ import os
 import time
 from lib.aws import AWS_USER
 from .common import (
-    AmazonWebServices, run_command
+    ADMIN_PASSWORD, AmazonWebServices, run_command
 )
 from .test_airgap import get_bastion_node
 from .test_custom_host_reg import (
@@ -143,10 +143,12 @@ def deploy_proxy_rancher(bastion_node):
         '-p 80:80 -p 443:443 ' \
         '-e HTTP_PROXY={} ' \
         '-e HTTPS_PROXY={} ' \
+        '-e CATTLE_BOOTSTRAP_PASSWORD={} ' \
         '-e NO_PROXY="localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,' \
         'cattle-system.svc" ' \
         'rancher/rancher:{} --trace'.format(
             proxy_url, proxy_url,
+            ADMIN_PASSWORD,
             RANCHER_SERVER_VERSION)
 
     deploy_result = run_command_on_proxy_node(bastion_node, ag_node,


### PR DESCRIPTION
master-head now requires a password on setup, which is effecting our automation

now, there is an argument for CATTLE_BOOTSTRAP_PASSWORD which is set in each of our cases