### PR TITLE
Use "labels" for custom node labels

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
@@ -166,7 +166,7 @@ func (h *handler) createMachineObjects(capiCluster *capi.Cluster, machineName st
 	labels["rke.cattle.io/machine-id"] = data.String("id")
 
 	labelsMap := map[string]string{}
-	for _, str := range strings.Split(data.String("label"), ",") {
+	for _, str := range strings.Split(data.String("labels"), ",") {
 		k, v := kv.Split(str, "=")
 		if k == "" {
 			continue


### PR DESCRIPTION
The system-agent-installer passes the node labels as "labels." Rancher
was looking for the "label" entry in the secret data and was missing the
labels that were passed. Now, Rancher will look for labels under the
"labels" entry in the secret and labels are added to the node
successfully.

Issue:
https://github.com/rancher/rancher/issues/33455