### PR TITLE
Add node-ip and node-eternal-ip to config

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
@@ -162,6 +162,12 @@ func (h *handler) createMachineObjects(capiCluster *capi.Cluster, machineName st
 	if val := data.String("node-name"); val != "" {
 		labels[planner.NodeNameLabel] = val
 	}
+	if address := data.String("address"); address != "" {
+		annotations[planner.AddressAnnotation] = address
+	}
+	if internalAddress := data.String("internal-address"); internalAddress != "" {
+		annotations[planner.InternalAddressAnnotation] = internalAddress
+	}
 
 	labels["rke.cattle.io/machine-id"] = data.String("id")
 

--- a/pkg/provisioningv2/rke2/configserver/custom.go
+++ b/pkg/provisioningv2/rke2/configserver/custom.go
@@ -35,13 +35,7 @@ func (r *RKE2ConfigServer) findMachineByClusterToken(req *http.Request) (string,
 		return "", "", err
 	}
 
-	data := map[string]interface{}{}
-	for k, v := range req.Header {
-		if strings.HasPrefix(k, headerPrefix) {
-			data[strings.ToLower(strings.TrimPrefix(k, headerPrefix))] = v
-		}
-	}
-	data["id"] = machineID
+	data := dataFromHeaders(req)
 
 	if len(tokens) == 0 {
 		return "", "", nil
@@ -116,4 +110,15 @@ func (r *RKE2ConfigServer) waitReady(secret *corev1.Secret) (*corev1.Secret, err
 func machineRequestSecretName(name string) string {
 	hash := sha256.Sum256([]byte(name))
 	return "custom-" + hex.EncodeToString(hash[:])[:12]
+}
+
+func dataFromHeaders(req *http.Request) map[string]interface{} {
+	data := make(map[string]interface{})
+	for k, v := range req.Header {
+		if strings.HasPrefix(k, headerPrefix) {
+			data[strings.ToLower(strings.TrimPrefix(k, headerPrefix))] = v
+		}
+	}
+
+	return data
 }

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -62,6 +62,9 @@ const (
 	LabelsAnnotation = "rke.cattle.io/labels"
 	TaintsAnnotation = "rke.cattle.io/taints"
 
+	AddressAnnotation         = "rke.cattle.io/address"
+	InternalAddressAnnotation = "rke.cattle.io/internal-address"
+
 	SecretTypeMachinePlan = "rke.cattle.io/machine-plan"
 
 	authnWebhookFileName = "/var/lib/rancher/%s/kube-api-authn-webhook.yaml"
@@ -765,6 +768,16 @@ func addToken(config map[string]interface{}, machine *capi.Machine, secret plan.
 	}
 }
 
+func addAddresses(config map[string]interface{}, machine *capi.Machine) {
+	if data := machine.Annotations[AddressAnnotation]; data != "" {
+		config["node-external-ip"] = data
+	}
+
+	if data := machine.Annotations[InternalAddressAnnotation]; data != "" {
+		config["node-ip"] = data
+	}
+}
+
 func addLabels(config map[string]interface{}, machine *capi.Machine) error {
 	var labels []string
 	if data := machine.Annotations[LabelsAnnotation]; data != "" {
@@ -841,6 +854,7 @@ func (p *Planner) addConfigFile(nodePlan plan.NodePlan, controlPlane *rkev1.RKEC
 	addRoleConfig(config, controlPlane, machine, initNode, joinServer)
 	addLocalClusterAuthenticationEndpointConfig(config, controlPlane, machine)
 	addToken(config, machine, secret)
+	addAddresses(config, machine)
 
 	if err := addLabels(config, machine); err != nil {
 		return nodePlan, err


### PR DESCRIPTION
If the --address and/or --internal-address flags were passed to the
system-agent-installer for a custom node, then result was ignored by
Rancher.

After this change, Rancher will look for these values in the config
secret and pass them to the config when bootstrapping the node.

Issue:
https://github.com/rancher/rancher/issues/33404