### PR TITLE
Add secret controller for cloud cred

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.15.0
 	github.com/rancher/aks-operator v1.0.1-rc14
-	github.com/rancher/apiserver v0.0.0-20210519053359-f943376c4b42
+	github.com/rancher/apiserver v0.0.0-20210716201731-fcd925c99ba8
 	github.com/rancher/channelserver v0.5.1-0.20210618172430-5cbefd383369
 	github.com/rancher/dynamiclistener v0.3.1-0.20210616080009-9865ae859c7f
 	github.com/rancher/eks-operator v1.1.1-rc3
@@ -113,7 +113,7 @@ require (
 	github.com/rancher/remotedialer v0.2.6-0.20210318171128-d1ebd5202be4
 	github.com/rancher/rke v1.3.0-rc8
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
-	github.com/rancher/steve v0.0.0-20210520191028-52f86dce9bd4
+	github.com/rancher/steve v0.0.0-20210716202438-924c6d7021bc
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210424054953-634d28b7def3
 	github.com/rancher/wrangler v0.8.1-0.20210618171953-ab479ee75244
 	github.com/robfig/cron v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -962,8 +962,8 @@ github.com/rackspace/gophercloud v0.0.0-20150408191457-ce0f487f6747/go.mod h1:4b
 github.com/rancher/aks-operator v1.0.1-rc14 h1:WxZ0VtUuYnIs1NWy/2c+cmm9gBVcpZ9grCanOla6Yu4=
 github.com/rancher/aks-operator v1.0.1-rc14/go.mod h1:V43rw+oKpjQ2tlIITgejlatpNBGi61DdB+RldJyrh/8=
 github.com/rancher/apiserver v0.0.0-20201023000256-1a0a904f9197/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
-github.com/rancher/apiserver v0.0.0-20210519053359-f943376c4b42 h1:yjpulamf2dZz62++nQQaFjZv+qv5aR4Uwm3uj39AJ8Y=
-github.com/rancher/apiserver v0.0.0-20210519053359-f943376c4b42/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
+github.com/rancher/apiserver v0.0.0-20210716201731-fcd925c99ba8 h1:ZLEBNhJqfXrpjYdvtbevNl/Gh+Kjs/BF+vQ7mxjlxts=
+github.com/rancher/apiserver v0.0.0-20210716201731-fcd925c99ba8/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
 github.com/rancher/channelserver v0.5.1-0.20210618172430-5cbefd383369 h1:1FLFZrLqnI4oJSI9dLnQfPBQIYrXI4yvKRkfujVnqiQ=
 github.com/rancher/channelserver v0.5.1-0.20210618172430-5cbefd383369/go.mod h1:1/9aBa8mXEIinRiT6Qlv/zbt6Nv9uorv+kFVNYvpmiI=
 github.com/rancher/client-go v0.21.0-rancher.1 h1:WVy7jpVmdjIRVkgXpBRlNx4jnGkLCFS1Qu/hUFCOGN4=
@@ -1012,8 +1012,8 @@ github.com/rancher/rke v1.3.0-rc8 h1:PuUJZSD3dfObL10FHZgr4FSKu9DkiGS2D7nyhkZ6PAY
 github.com/rancher/rke v1.3.0-rc8/go.mod h1:8teMbZiv6i0IwNzsIjmaqbLIDEBZmvFv1j+1P7uUgyY=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
-github.com/rancher/steve v0.0.0-20210520191028-52f86dce9bd4 h1:v+BEMbVtTqwWAalxP1QciMV3vYKF2lmsqYJEOlJ5gIQ=
-github.com/rancher/steve v0.0.0-20210520191028-52f86dce9bd4/go.mod h1:dOPyN9RLCeQyCp8hhGhDwmoitKj8IAeLjg7MpDL/Swg=
+github.com/rancher/steve v0.0.0-20210716202438-924c6d7021bc h1:GXNr4Phrlqusx6I9DgshVGr8PZfgzhVDlAJlQiegIRY=
+github.com/rancher/steve v0.0.0-20210716202438-924c6d7021bc/go.mod h1:7YsGcw3zWlzahebzD4484KAgUtxrkDKiVgzCP3uiLi4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210424054953-634d28b7def3 h1:Ja/AEVsfVaVQvQ/5bl1uSWNzpnrsigrXnwCPB/8bDSM=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210424054953-634d28b7def3/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=

--- a/pkg/controllers/provisioningv2/controllers.go
+++ b/pkg/controllers/provisioningv2/controllers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2/provisioningcluster"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2/rkecluster"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2/rkecontrolplane"
+	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2/secret"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2/unmanaged"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/provisioningv2/capi"
@@ -47,6 +48,7 @@ func Register(ctx context.Context, clients *wrangler.Context) error {
 		}
 		rkecluster.Register(ctx, clients)
 		provisioningcluster.Register(ctx, clients)
+		secret.Register(ctx, clients)
 		bootstrap.Register(ctx, clients)
 		machinenodelookup.Register(ctx, clients)
 		planner.Register(ctx, clients, rkePlanner)

--- a/pkg/controllers/provisioningv2/rke2/secret/secret.go
+++ b/pkg/controllers/provisioningv2/rke2/secret/secret.go
@@ -1,0 +1,136 @@
+package secret
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/controllers/management/rbac"
+	"github.com/rancher/rancher/pkg/wrangler"
+	wranglerv1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	rbacv1 "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
+	v1 "k8s.io/api/core/v1"
+	k8srbac "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Register(ctx context.Context, clients *wrangler.Context) {
+	h := handler{
+		roles:             clients.RBAC.Role(),
+		rolesCache:        clients.RBAC.Role().Cache(),
+		roleBindings:      clients.RBAC.RoleBinding(),
+		roleBindingsCache: clients.RBAC.RoleBinding().Cache(),
+		secrets:           clients.Core.Secret(),
+	}
+
+	clients.Core.Secret().OnChange(ctx, "provisioning-v2-secret", h.OnSecret)
+}
+
+type handler struct {
+	roles             rbacv1.RoleClient
+	rolesCache        rbacv1.RoleCache
+	roleBindings      rbacv1.RoleBindingClient
+	roleBindingsCache rbacv1.RoleBindingCache
+	secrets           wranglerv1.SecretClient
+}
+
+// OnSecret syncs a creators permissions to a provisioning cloud-credential. This is based off
+// the creator ID annotation that is added in the webhook when the secret is created. A role
+// and binding are created to grant the creator permissions and then the annotation is removed.
+func (h *handler) OnSecret(key string, secret *v1.Secret) (*v1.Secret, error) {
+	if secret == nil || secret.DeletionTimestamp != nil || secret.Type != "provisioning.cattle.io/cloud-credential" {
+		return secret, nil
+	}
+	creatorID, ok := secret.Annotations[rbac.CreatorIDAnn]
+	if !ok || creatorID == "" {
+		return secret, nil
+	}
+
+	if err := h.ensureCreatorPermissions(creatorID, secret); err != nil {
+		return secret, err
+	}
+
+	s := secret.DeepCopy()
+	delete(s.Annotations, rbac.CreatorIDAnn)
+
+	return h.secrets.Update(s)
+}
+
+func (h *handler) ensureCreatorPermissions(creatorID string, secret *v1.Secret) error {
+	name := creatorID + "-" + secret.Name
+
+	// The owner reference for the role and binding are tied to the secret since a
+	// user is not guaranteed to be a management.cattle.io user CR
+	ownerRef := metav1.OwnerReference{
+		APIVersion: v1.SchemeGroupVersion.Version,
+		Kind:       "Secret",
+		Name:       secret.Name,
+		UID:        secret.UID,
+	}
+	if err := h.ensureRole(secret.Namespace, name, ownerRef); err != nil {
+		return err
+	}
+
+	return h.ensureBinding(secret.Namespace, name, creatorID, ownerRef)
+}
+
+func (h *handler) ensureRole(namespace, name string, ownerRef metav1.OwnerReference) error {
+	_, err := h.rolesCache.Get(namespace, name)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
+
+		role := &k8srbac.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				Namespace:       namespace,
+				OwnerReferences: []metav1.OwnerReference{ownerRef},
+			},
+			Rules: []k8srbac.PolicyRule{
+				{
+					Verbs:         []string{"get", "update", "delete"},
+					APIGroups:     []string{""},
+					Resources:     []string{"secrets"},
+					ResourceNames: []string{ownerRef.Name},
+				},
+			},
+		}
+
+		if _, err := h.roles.Create(role); err != nil && !k8serrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *handler) ensureBinding(namespace, name, creatorID string, ownerRef metav1.OwnerReference) error {
+	_, err := h.roleBindingsCache.Get(namespace, name)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
+
+		binding := &k8srbac.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				Namespace:       namespace,
+				OwnerReferences: []metav1.OwnerReference{ownerRef},
+			},
+			Subjects: []k8srbac.Subject{
+				{
+					Kind: k8srbac.UserKind,
+					Name: creatorID,
+				},
+			},
+			RoleRef: k8srbac.RoleRef{
+				Kind: "Role",
+				Name: name,
+			},
+		}
+
+		if _, err := h.roleBindings.Create(binding); err != nil && !k8serrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -444,27 +444,28 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 
 func addUserRules(role *roleBuilder) *roleBuilder {
 	role.
+		addRule().apiGroups("").resources("secrets").verbs("create").
+		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("principals", "roletemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("preferences").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("settings").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("features").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("templates", "templateversions", "catalogs").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("clusters").verbs("create").
-		addRule().apiGroups("provisioning.cattle.io").resources("clusters").verbs("create").
-		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("kontainerdrivers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("nodetemplates").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("fleetworkspaces").verbs("create").
-		addRule().apiGroups("").resources("secrets").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("multiclusterapps", "globaldnses", "globaldnsproviders", "clustertemplaterevisions").verbs("create").
-		addRule().apiGroups("project.cattle.io").resources("sourcecodecredentials").verbs("*").
-		addRule().apiGroups("project.cattle.io").resources("sourcecoderepositories").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("rkek8ssystemimages").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("rkek8sserviceoptions").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("rkeaddons").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("cisconfigs").verbs("get", "list", "watch").
-		addRule().apiGroups("management.cattle.io").resources("cisbenchmarkversions").verbs("get", "list", "watch")
+		addRule().apiGroups("management.cattle.io").resources("cisbenchmarkversions").verbs("get", "list", "watch").
+		addRule().apiGroups("project.cattle.io").resources("sourcecodecredentials").verbs("*").
+		addRule().apiGroups("project.cattle.io").resources("sourcecoderepositories").verbs("*").
+		addRule().apiGroups("provisioning.cattle.io").resources("clusters").verbs("create").
+		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create")
 
 	return role
 }


### PR DESCRIPTION
Problem:
The secret created for cloud creds is created in a namespace a user
doesn't normally have access to

Solution:
Add permissions for the secret in the namespace based off the creatorID
anno the webhook will add when the secret is created

Reordered user roles by apiGroup and added the perm `addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch").` which is required for provisioning v2 cluster templates

https://github.com/rancher/rancher/issues/32414