### PR TITLE
Bump aks-operator to 1.0.1-rc17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.15.0
-	github.com/rancher/aks-operator v1.0.1-rc14
+	github.com/rancher/aks-operator v1.0.1-rc17
 	github.com/rancher/apiserver v0.0.0-20210716201731-fcd925c99ba8
 	github.com/rancher/channelserver v0.5.1-0.20210618172430-5cbefd383369
 	github.com/rancher/dynamiclistener v0.3.1-0.20210616080009-9865ae859c7f

--- a/go.sum
+++ b/go.sum
@@ -959,8 +959,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rackspace/gophercloud v0.0.0-20150408191457-ce0f487f6747/go.mod h1:4bJ1FwuaBZ6dt1VcDX5/O662mwR8GWqS4l68H6hkoYQ=
-github.com/rancher/aks-operator v1.0.1-rc14 h1:WxZ0VtUuYnIs1NWy/2c+cmm9gBVcpZ9grCanOla6Yu4=
-github.com/rancher/aks-operator v1.0.1-rc14/go.mod h1:V43rw+oKpjQ2tlIITgejlatpNBGi61DdB+RldJyrh/8=
+github.com/rancher/aks-operator v1.0.1-rc17 h1:UatoRTErHxmAcVOtDD0ca3sQDW2FbeKZeGazM2HYXY4=
+github.com/rancher/aks-operator v1.0.1-rc17/go.mod h1:qYQJbQSSZZBxyP/Bptr3vdqP9u6aCAgokhUgeXpBbJU=
 github.com/rancher/apiserver v0.0.0-20201023000256-1a0a904f9197/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
 github.com/rancher/apiserver v0.0.0-20210716201731-fcd925c99ba8 h1:ZLEBNhJqfXrpjYdvtbevNl/Gh+Kjs/BF+vQ7mxjlxts=
 github.com/rancher/apiserver v0.0.0-20210716201731-fcd925c99ba8/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -6,13 +6,12 @@ replace k8s.io/client-go => k8s.io/client-go v0.21.0
 
 require (
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/aks-operator v1.0.1-rc14
+	github.com/rancher/aks-operator v1.0.1-rc17
 	github.com/rancher/eks-operator v1.1.1-rc3
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210608014113-99e848822739
 	github.com/rancher/gke-operator v1.1.1-rc7
 	github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133
 	github.com/rancher/rke v1.3.0-rc8
-	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210424054953-634d28b7def3
 	github.com/rancher/wrangler v0.8.1-0.20210618171953-ab479ee75244
 	github.com/sirupsen/logrus v1.7.0
 	k8s.io/api v0.21.0

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -656,8 +656,8 @@ github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULU
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
-github.com/rancher/aks-operator v1.0.1-rc14 h1:WxZ0VtUuYnIs1NWy/2c+cmm9gBVcpZ9grCanOla6Yu4=
-github.com/rancher/aks-operator v1.0.1-rc14/go.mod h1:V43rw+oKpjQ2tlIITgejlatpNBGi61DdB+RldJyrh/8=
+github.com/rancher/aks-operator v1.0.1-rc17 h1:UatoRTErHxmAcVOtDD0ca3sQDW2FbeKZeGazM2HYXY4=
+github.com/rancher/aks-operator v1.0.1-rc17/go.mod h1:qYQJbQSSZZBxyP/Bptr3vdqP9u6aCAgokhUgeXpBbJU=
 github.com/rancher/eks-operator v1.1.1-rc3 h1:I52WG985NvawYW7mKTlv1SpeucOkYtk8nathPiqtItU=
 github.com/rancher/eks-operator v1.1.1-rc3/go.mod h1:hoVQqXsC02Yk3Xy5jGH/rqJX5KUVvvQBrYAJdRh+kgQ=
 github.com/rancher/fleet/pkg/apis v0.0.0-20210608014113-99e848822739 h1:EjFWJZH42LoYCRV56ZPNzaiIPO6cfFDP7+LlyY3b20Y=
@@ -675,9 +675,6 @@ github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133 h1:X1Tn2q3iDekvqajJ
 github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
 github.com/rancher/rke v1.3.0-rc8 h1:PuUJZSD3dfObL10FHZgr4FSKu9DkiGS2D7nyhkZ6PAY=
 github.com/rancher/rke v1.3.0-rc8/go.mod h1:8teMbZiv6i0IwNzsIjmaqbLIDEBZmvFv1j+1P7uUgyY=
-github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210424054953-634d28b7def3 h1:Ja/AEVsfVaVQvQ/5bl1uSWNzpnrsigrXnwCPB/8bDSM=
-github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210424054953-634d28b7def3/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
-github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=


### PR DESCRIPTION
Take over of https://github.com/rancher/rancher/pull/33652 to fix conflict.
issue: https://github.com/rancher/rancher/issues/33446