### PR TITLE
Initialize app cache in hostedcluster controller

### DIFF
--- a/pkg/controllers/dashboard/hostedcluster/controller.go
+++ b/pkg/controllers/dashboard/hostedcluster/controller.go
@@ -67,6 +67,7 @@ func Register(ctx context.Context, wContext *wrangler.Context) error {
 		apps:         wContext.Project.App(),
 		projectCache: wContext.Mgmt.Project().Cache(),
 		secrets:      wContext.Core.Secret().Cache(),
+		appCache:     wContext.Project.App().Cache(),
 	}
 
 	wContext.Mgmt.Cluster().OnChange(ctx, "cluster-provisioning-operator", h.onClusterChange)


### PR DESCRIPTION
Without this, the cluster change handler segfaults the first time it
tries to look up the legacy operator app.

https://github.com/rancher/rancher/issues/33693