### PR TITLE
Only log cause if debugging is enabled

### DIFF
--- a/pkg/auth/providers/local/local_auth_provider.go
+++ b/pkg/auth/providers/local/local_auth_provider.go
@@ -109,17 +109,19 @@ func (l *Provider) AuthenticateUser(ctx context.Context, input interface{}) (v3.
 	username := localInput.Username
 	pwd := localInput.Password
 
+	authFailedError := httperror.NewAPIError(httperror.Unauthorized, "authentication failed")
 	user, err := l.getUser(username)
-
 	if err != nil {
 		// If the user don't exist the password is evaluated
 		// to avoid user enumeration via timing attack (time based side-channel).
 		bcrypt.CompareHashAndPassword(l.invalidHash, []byte(pwd))
-		return v3.Principal{}, nil, "", err
+		logrus.Debugf("Get User [%s] failed during Authentication: %v", username, err)
+		return v3.Principal{}, nil, "", authFailedError
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(pwd)); err != nil {
-		return v3.Principal{}, nil, "", httperror.WrapAPIError(err, httperror.Unauthorized, "authentication failed")
+		logrus.Debugf("Authentication failed for User [%s]: %v", username, err)
+		return v3.Principal{}, nil, "", authFailedError
 	}
 
 	principalID := getLocalPrincipalID(user)


### PR DESCRIPTION
**Problem:**
Prior, the WrapAPIError function was being used which set the
Cause field as the underlying error causing the issue. When
the Cause field gets set, it is automatically logged. In this
case the error is very specific to the package it comes from
and can cause confusion. Specifically it has caused confusion
because the error mentions a hashed password which is being
mistakenly interpreted as referring to the token hashing
feature.

**Solution:**
Now, the WrapAPIError function is no longer being
used and the underlying error will only be logged if debug is
enabled.