### PR TITLE
[keycloak oidc] Add nested group support, fix 500 error on nil response

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -413,14 +413,15 @@ type AuthSystemImages struct {
 type OIDCConfig struct {
 	AuthConfig `json:",inline" mapstructure:",squash"`
 
-	ClientID     string `json:"clientId" norman:"required"`
-	ClientSecret string `json:"clientSecret,omitempty" norman:"required,type=password"`
-	Scopes       string `json:"scope", norman:"required,notnullable"`
-	AuthEndpoint string `json:"authEndpoint,omitempty" norman:"required,notnullable"`
-	Issuer       string `json:"issuer" norman:"required,notnullable"`
-	Certificate  string `json:"certificate,omitempty"`
-	PrivateKey   string `json:"privateKey" norman:"type=password"`
-	RancherURL   string `json:"rancherUrl" norman:"required,notnullable"`
+	ClientID           string `json:"clientId" norman:"required"`
+	ClientSecret       string `json:"clientSecret,omitempty" norman:"required,type=password"`
+	Scopes             string `json:"scope", norman:"required,notnullable"`
+	AuthEndpoint       string `json:"authEndpoint,omitempty" norman:"required,notnullable"`
+	Issuer             string `json:"issuer" norman:"required,notnullable"`
+	Certificate        string `json:"certificate,omitempty"`
+	PrivateKey         string `json:"privateKey" norman:"type=password"`
+	RancherURL         string `json:"rancherUrl" norman:"required,notnullable"`
+	GroupSearchEnabled *bool  `json:"groupSearchEnabled"`
 }
 
 type OIDCTestOutput struct {

--- a/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -6837,6 +6837,11 @@ func (in *OIDCApplyInput) DeepCopy() *OIDCApplyInput {
 func (in *OIDCConfig) DeepCopyInto(out *OIDCConfig) {
 	*out = *in
 	in.AuthConfig.DeepCopyInto(&out.AuthConfig)
+	if in.GroupSearchEnabled != nil {
+		in, out := &in.GroupSearchEnabled, &out.GroupSearchEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/auth/providers/keycloakoidc/keycloak_provider.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider.go
@@ -146,12 +146,6 @@ func (k *keyCloakOIDCProvider) GetPrincipal(principalID string, token v3.Token) 
 		}
 		oauthToken.AccessToken = token.ProviderInfo["access_token"]
 	}
-
-	keyCloakClient, err := newClient(config, oauthToken)
-	if err != nil {
-		logrus.Errorf("[keycloak oidc]: error creating new http client: %v", err)
-		return v3.Principal{}, err
-	}
 	var externalID string
 	parts := strings.SplitN(principalID, ":", 2)
 	if len(parts) != 2 {
@@ -163,6 +157,11 @@ func (k *keyCloakOIDCProvider) GetPrincipal(principalID string, token v3.Token) 
 		return v3.Principal{}, errors.Errorf("invalid id %v", principalID)
 	}
 	principalType := parts[1]
+	keyCloakClient, err := newClient(config, oauthToken)
+	if err != nil {
+		logrus.Errorf("[keycloak oidc]: error creating new http client: %v", err)
+		return v3.Principal{}, err
+	}
 	acct, err := keyCloakClient.getFromKeyCloakByID(externalID, principalType, config)
 	if err != nil {
 		return v3.Principal{}, err

--- a/pkg/auth/providers/keycloakoidc/keycloak_provider.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider.go
@@ -86,12 +86,12 @@ func (k *keyCloakOIDCProvider) SearchPrincipals(searchValue, principalType strin
 	}
 	keyCloakClient, err := newClient(config, oauthToken)
 	if err != nil {
-		logrus.Errorf("[keycloak oidc]: error creating new http client: %v", err)
+		logrus.Errorf("[keycloak oidc] SsearchPrincipals: error creating new http client: %v", err)
 		return principals, err
 	}
 	accts, err := keyCloakClient.searchPrincipals(searchValue, principalType, config)
 	if err != nil {
-		logrus.Errorf("[keycloak oidc] problem searching keycloak: %v", err)
+		logrus.Errorf("[keycloak oidc] SearchPrincipals: problem searching keycloak: %v", err)
 		return principals, err
 	}
 	for _, acct := range accts {
@@ -159,7 +159,7 @@ func (k *keyCloakOIDCProvider) GetPrincipal(principalID string, token v3.Token) 
 	principalType := parts[1]
 	keyCloakClient, err := newClient(config, oauthToken)
 	if err != nil {
-		logrus.Errorf("[keycloak oidc]: error creating new http client: %v", err)
+		logrus.Errorf("[keycloak oidc] GetPrincipal: error creating new http client: %v", err)
 		return v3.Principal{}, err
 	}
 	acct, err := keyCloakClient.getFromKeyCloakByID(externalID, principalType, config)

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -43,7 +43,7 @@ type OpenIDCProvider struct {
 	TokenMGR    *tokens.Manager
 }
 
-type claimInfo struct {
+type ClaimInfo struct {
 	Subject           string   `json:"sub"`
 	Name              string   `json:"name"`
 	PreferredUsername string   `json:preferred_username`
@@ -81,44 +81,45 @@ func (o *OpenIDCProvider) AuthenticateUser(ctx context.Context, input interface{
 	if !ok {
 		return v3.Principal{}, nil, "", fmt.Errorf("unexpected input type")
 	}
-	return o.LoginUser(ctx, login, nil)
+	userPrincipal, groupPrincipals, providerToken, _, err := o.LoginUser(ctx, login, nil)
+	return userPrincipal, groupPrincipals, providerToken, err
 }
 
-func (o *OpenIDCProvider) LoginUser(ctx context.Context, oauthLoginInfo *v32.OIDCLogin, config *v32.OIDCConfig) (v3.Principal, []v3.Principal, string, error) {
+func (o *OpenIDCProvider) LoginUser(ctx context.Context, oauthLoginInfo *v32.OIDCLogin, config *v32.OIDCConfig) (v3.Principal, []v3.Principal, string, ClaimInfo, error) {
 	var userPrincipal v3.Principal
 	var groupPrincipals []v3.Principal
-	var claimInfo claimInfo
+	var userClaimInfo ClaimInfo
 	var err error
 
 	if config == nil {
 		config, err = o.GetOIDCConfig()
 		if err != nil {
-			return userPrincipal, nil, "", err
+			return userPrincipal, nil, "", userClaimInfo, err
 		}
 	}
-	userInfo, oauth2Token, err := o.getUserInfo(&ctx, config, oauthLoginInfo.Code, &claimInfo)
+	userInfo, oauth2Token, err := o.getUserInfo(&ctx, config, oauthLoginInfo.Code, &userClaimInfo)
 	if err != nil {
-		return userPrincipal, groupPrincipals, "", err
+		return userPrincipal, groupPrincipals, "", userClaimInfo, err
 	}
-	userPrincipal = o.userToPrincipal(userInfo, claimInfo)
+	userPrincipal = o.userToPrincipal(userInfo, userClaimInfo)
 	userPrincipal.Me = true
-	groupPrincipals = o.getGroupsFromClaimInfo(claimInfo)
+	groupPrincipals = o.getGroupsFromClaimInfo(userClaimInfo)
 
-	logrus.Debugf("[generic oidc] loginuser: Checking user's access to Rancher")
+	logrus.Debugf("[generic oidc] loginuser: checking user's access to rancher")
 	allowed, err := o.UserMGR.CheckAccess(config.AccessMode, config.AllowedPrincipalIDs, userPrincipal.Name, groupPrincipals)
 	if err != nil {
-		return userPrincipal, groupPrincipals, "", err
+		return userPrincipal, groupPrincipals, "", userClaimInfo, err
 	}
 	if !allowed {
-		return userPrincipal, groupPrincipals, "", httperror.NewAPIError(httperror.Unauthorized, "unauthorized")
+		return userPrincipal, groupPrincipals, "", userClaimInfo, httperror.NewAPIError(httperror.Unauthorized, "unauthorized")
 	}
 	// save entire oauthToken because it contains refresh_token and token expiry time
 	// will use with oauth2.Client and with TokenSource to ensure auto refresh of tokens occurs for api calls
 	oauthToken, err := json.Marshal(oauth2Token)
 	if err != nil {
-		return userPrincipal, groupPrincipals, "", err
+		return userPrincipal, groupPrincipals, "", userClaimInfo, err
 	}
-	return userPrincipal, groupPrincipals, string(oauthToken), nil
+	return userPrincipal, groupPrincipals, string(oauthToken), userClaimInfo, nil
 }
 
 func (o *OpenIDCProvider) SearchPrincipals(searchValue, principalType string, token v3.Token) ([]v3.Principal, error) {
@@ -157,10 +158,10 @@ func (o *OpenIDCProvider) GetPrincipal(principalID string, token v3.Token) (v3.P
 
 	principalType := parts[1]
 	if externalID == "" && principalType == "" {
-		return p, fmt.Errorf("[generic oidc]: invalid id %v", principalID)
+		return p, fmt.Errorf("invalid id %v", principalID)
 	}
 	if principalType != UserType && principalType != GroupType {
-		return p, fmt.Errorf("[generic oidc]: invalid principal type")
+		return p, fmt.Errorf("invalid principal type")
 	}
 	if principalID == UserType {
 		p = v3.Principal{
@@ -194,11 +195,11 @@ func (o *OpenIDCProvider) getRedirectURL(config map[string]interface{}) string {
 
 func (o *OpenIDCProvider) RefetchGroupPrincipals(principalID string, secret string) ([]v3.Principal, error) {
 	var groupPrincipals []v3.Principal
-	var claimInfo claimInfo
+	var claimInfo ClaimInfo
 
 	config, err := o.GetOIDCConfig()
 	if err != nil {
-		logrus.Errorf("[generic oidc]: error fetching OIDCConfig: %v", err)
+		logrus.Errorf("[generic oidc] refetchGroupPrincipals: error fetching OIDCConfig: %v", err)
 		return groupPrincipals, err
 	}
 	//do not need userInfo or oauth2Token since we are only processing groups
@@ -212,7 +213,7 @@ func (o *OpenIDCProvider) RefetchGroupPrincipals(principalID string, secret stri
 func (o *OpenIDCProvider) CanAccessWithGroupProviders(userPrincipalID string, groupPrincipals []v3.Principal) (bool, error) {
 	config, err := o.GetOIDCConfig()
 	if err != nil {
-		logrus.Errorf("[generic oidc]: error fetching OIDCConfig: %v", err)
+		logrus.Errorf("[generic oidc] canAccessWithGroupProviders: error fetching OIDCConfig: %v", err)
 		return false, err
 	}
 	allowed, err := o.UserMGR.CheckAccess(config.AccessMode, config.AllowedPrincipalIDs, userPrincipalID, groupPrincipals)
@@ -222,7 +223,7 @@ func (o *OpenIDCProvider) CanAccessWithGroupProviders(userPrincipalID string, gr
 	return allowed, nil
 }
 
-func (o *OpenIDCProvider) userToPrincipal(userInfo *oidc.UserInfo, claimInfo claimInfo) v3.Principal {
+func (o *OpenIDCProvider) userToPrincipal(userInfo *oidc.UserInfo, claimInfo ClaimInfo) v3.Principal {
 	displayName := claimInfo.Name
 	if displayName == "" {
 		displayName = userInfo.Email
@@ -292,7 +293,7 @@ func (o *OpenIDCProvider) saveOIDCConfig(config *v32.OIDCConfig) error {
 	}
 	config.ClientSecret = common.GetName(config.Type, secretField)
 
-	logrus.Debugf("[generic oidc] updating config")
+	logrus.Debugf("[generic oidc] saveOIDCConfig: updating config")
 	_, err = o.AuthConfigs.ObjectClient().Update(config.ObjectMeta.Name, config)
 	return err
 }
@@ -300,12 +301,12 @@ func (o *OpenIDCProvider) saveOIDCConfig(config *v32.OIDCConfig) error {
 func (o *OpenIDCProvider) GetOIDCConfig() (*v32.OIDCConfig, error) {
 	authConfigObj, err := o.AuthConfigs.ObjectClient().UnstructuredClient().Get(o.Name, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("[generic oidc]: failed to retrieve OIDCConfig, error: %v", err)
+		return nil, fmt.Errorf("failed to retrieve OIDCConfig, error: %v", err)
 	}
 
 	u, ok := authConfigObj.(runtime.Unstructured)
 	if !ok {
-		return nil, fmt.Errorf("[generic oidc]: failed to retrieve OIDCConfig, cannot read k8s Unstructured data")
+		return nil, fmt.Errorf("failed to retrieve OIDCConfig, cannot read k8s Unstructured data")
 	}
 	storedOidcConfigMap := u.UnstructuredContent()
 
@@ -314,9 +315,8 @@ func (o *OpenIDCProvider) GetOIDCConfig() (*v32.OIDCConfig, error) {
 
 	metadataMap, ok := storedOidcConfigMap["metadata"].(map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("[generic oidc]: failed to retrieve OIDCConfig metadata, cannot read k8s Unstructured data")
+		return nil, fmt.Errorf("failed to retrieve OIDCConfig metadata, cannot read k8s Unstructured data")
 	}
-
 	objectMeta := &metav1.ObjectMeta{}
 	mapstructure.Decode(metadataMap, objectMeta)
 	storedOidcConfig.ObjectMeta = *objectMeta
@@ -355,7 +355,7 @@ func (o *OpenIDCProvider) GetUserExtraAttributes(token *v3.Token) map[string][]s
 	return extras
 }
 
-func (o *OpenIDCProvider) getUserInfo(ctx *context.Context, config *v32.OIDCConfig, authCode string, claimInfo *claimInfo) (*oidc.UserInfo, *oauth2.Token, error) {
+func (o *OpenIDCProvider) getUserInfo(ctx *context.Context, config *v32.OIDCConfig, authCode string, claimInfo *ClaimInfo) (*oidc.UserInfo, *oauth2.Token, error) {
 	var userInfo *oidc.UserInfo
 	var oauth2Token *oauth2.Token
 	var err error
@@ -413,7 +413,7 @@ func ConfigToOauthConfig(endpoint oauth2.Endpoint, config *v32.OIDCConfig) oauth
 	}
 }
 
-func (o *OpenIDCProvider) getGroupsFromClaimInfo(claimInfo claimInfo) []v3.Principal {
+func (o *OpenIDCProvider) getGroupsFromClaimInfo(claimInfo ClaimInfo) []v3.Principal {
 	var groupPrincipals []v3.Principal
 
 	if claimInfo.FullGroupPath != nil {

--- a/pkg/client/generated/management/v3/zz_generated_key_cloak_oidcconfig.go
+++ b/pkg/client/generated/management/v3/zz_generated_key_cloak_oidcconfig.go
@@ -12,6 +12,7 @@ const (
 	KeyCloakOIDCConfigFieldCreated             = "created"
 	KeyCloakOIDCConfigFieldCreatorID           = "creatorId"
 	KeyCloakOIDCConfigFieldEnabled             = "enabled"
+	KeyCloakOIDCConfigFieldGroupSearchEnabled  = "groupSearchEnabled"
 	KeyCloakOIDCConfigFieldIssuer              = "issuer"
 	KeyCloakOIDCConfigFieldLabels              = "labels"
 	KeyCloakOIDCConfigFieldName                = "name"
@@ -35,6 +36,7 @@ type KeyCloakOIDCConfig struct {
 	Created             string            `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	GroupSearchEnabled  *bool             `json:"groupSearchEnabled,omitempty" yaml:"groupSearchEnabled,omitempty"`
 	Issuer              string            `json:"issuer,omitempty" yaml:"issuer,omitempty"`
 	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_oidc_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_oidc_config.go
@@ -12,6 +12,7 @@ const (
 	OIDCConfigFieldCreated             = "created"
 	OIDCConfigFieldCreatorID           = "creatorId"
 	OIDCConfigFieldEnabled             = "enabled"
+	OIDCConfigFieldGroupSearchEnabled  = "groupSearchEnabled"
 	OIDCConfigFieldIssuer              = "issuer"
 	OIDCConfigFieldLabels              = "labels"
 	OIDCConfigFieldName                = "name"
@@ -35,6 +36,7 @@ type OIDCConfig struct {
 	Created             string            `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	GroupSearchEnabled  *bool             `json:"groupSearchEnabled,omitempty" yaml:"groupSearchEnabled,omitempty"`
 	Issuer              string            `json:"issuer,omitempty" yaml:"issuer,omitempty"`
 	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_private_registry.go
+++ b/pkg/client/generated/management/v3/zz_generated_private_registry.go
@@ -1,16 +1,18 @@
 package client
 
 const (
-	PrivateRegistryType           = "privateRegistry"
-	PrivateRegistryFieldIsDefault = "isDefault"
-	PrivateRegistryFieldPassword  = "password"
-	PrivateRegistryFieldURL       = "url"
-	PrivateRegistryFieldUser      = "user"
+	PrivateRegistryType                  = "privateRegistry"
+	PrivateRegistryFieldCredentialPlugin = "credentialPlugin"
+	PrivateRegistryFieldIsDefault        = "isDefault"
+	PrivateRegistryFieldPassword         = "password"
+	PrivateRegistryFieldURL              = "url"
+	PrivateRegistryFieldUser             = "user"
 )
 
 type PrivateRegistry struct {
-	IsDefault bool   `json:"isDefault,omitempty" yaml:"isDefault,omitempty"`
-	Password  string `json:"password,omitempty" yaml:"password,omitempty"`
-	URL       string `json:"url,omitempty" yaml:"url,omitempty"`
-	User      string `json:"user,omitempty" yaml:"user,omitempty"`
+	CredentialPlugin map[string]string `json:"credentialPlugin,omitempty" yaml:"credentialPlugin,omitempty"`
+	IsDefault        bool              `json:"isDefault,omitempty" yaml:"isDefault,omitempty"`
+	Password         string            `json:"password,omitempty" yaml:"password,omitempty"`
+	URL              string            `json:"url,omitempty" yaml:"url,omitempty"`
+	User             string            `json:"user,omitempty" yaml:"user,omitempty"`
 }

--- a/pkg/client/generated/management/v3/zz_generated_rke_system_images.go
+++ b/pkg/client/generated/management/v3/zz_generated_rke_system_images.go
@@ -30,6 +30,7 @@ const (
 	RKESystemImagesFieldFlannelCNI                = "flannelCni"
 	RKESystemImagesFieldIngress                   = "ingress"
 	RKESystemImagesFieldIngressBackend            = "ingressBackend"
+	RKESystemImagesFieldIngressWebhook            = "ingressWebhook"
 	RKESystemImagesFieldKubeDNS                   = "kubedns"
 	RKESystemImagesFieldKubeDNSAutoscaler         = "kubednsAutoscaler"
 	RKESystemImagesFieldKubeDNSSidecar            = "kubednsSidecar"
@@ -73,6 +74,7 @@ type RKESystemImages struct {
 	FlannelCNI                string `json:"flannelCni,omitempty" yaml:"flannelCni,omitempty"`
 	Ingress                   string `json:"ingress,omitempty" yaml:"ingress,omitempty"`
 	IngressBackend            string `json:"ingressBackend,omitempty" yaml:"ingressBackend,omitempty"`
+	IngressWebhook            string `json:"ingressWebhook,omitempty" yaml:"ingressWebhook,omitempty"`
 	KubeDNS                   string `json:"kubedns,omitempty" yaml:"kubedns,omitempty"`
 	KubeDNSAutoscaler         string `json:"kubednsAutoscaler,omitempty" yaml:"kubednsAutoscaler,omitempty"`
 	KubeDNSSidecar            string `json:"kubednsSidecar,omitempty" yaml:"kubednsSidecar,omitempty"`


### PR DESCRIPTION
**Issue(s)**
https://github.com/rancher/rancher/issues/33337
https://github.com/rancher/rancher/issues/33314
https://github.com/rancher/rancher/issues/33782

**Problems**
1. A user's groups do not include parent groups
2. When token is expired,  the resp from a get request is nil so panic occurs when resp.statuscode is hit
3. Scope has empty scopes in it occasionally causing invalid scope error
4. Logging vs error messages were very inconsistent

**Solution**
1. Add support for additional mapper to be added to the keycloak client, so when the userInfo is returned, the full path results are included in the response. The full paths are then parsed and included in a user's group principals
2. The statusCode was not being used in a meaningful way, so I removed it. The error that is returned includes error code. 
3. Remove empty values from scope slice
4. Made logging and error messages consistent within keycloak oidc and generic oidc

**Design Discussion**
Two designs were discussed for the nested group fix. 
- Adding a mapper to the keycloak client so that the full group path would be returned on the oidc userInfo endpoint and the full path would be parsed to get the parent groups
- Adding a AdminServiceAccount, whose credentials would be used to call the keycloak /users/{userid}/groups endpoint to get the group information and the full path would be parsed to get the parent groups

After additional discussion with original submitters of the PRD, the user who is configuring the keycloak oidc auth provider in rancher will have access to manage the client in keycloak. This means it is preferable to go the mapper route as Non Person Entity Accounts are not the preferable implementation. If this needs to undergo further discussion in a larger design meeting, we can delay the nested group implementation till after 2.6. 