### PR TITLE
Update Dashboard references to handle 2.6 branch

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -106,7 +106,7 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
 ENV CATTLE_UI_VERSION 2.5.2-rc8.1
-ENV CATTLE_DASHBOARD_UI_VERSION v2.5.2-rc5
+ENV CATTLE_DASHBOARD_UI_VERSION release-2.6
 ENV CATTLE_CLI_VERSION v2.4.12-rc2
 
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -79,7 +79,7 @@ var (
 	UIFeedBackForm                    = NewSetting("ui-feedback-form", "")
 	UIIndex                           = NewSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
 	UIPath                            = NewSetting("ui-path", "/usr/share/rancher/ui")
-	UIDashboardIndex                  = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/latest/index.html")
+	UIDashboardIndex                  = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/release-2.6/index.html")
 	UIDashboardPath                   = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
 	UIPreferred                       = NewSetting("ui-preferred", "vue")
 	UIOfflinePreferred                = NewSetting("ui-offline-preferred", "dynamic")


### PR DESCRIPTION
- The dashboard has branched 2.6 from master
- This change ensures both the dashboard embedded and served bits reference the 2.6 bits
- When rancher branches for 2.6 I'll come back and change `UIDashboardIndex` in master to point to dashboard latest again
- When there are rancher 2.6 RCs `CATTLE_DASHBOARD_UI_VERSION` will need updating by the release captain as per usual