### PR TITLE
Also run c_rehash on startup

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -160,6 +160,10 @@ spec:
           name: tls-ca-additional-volume
           subPath: ca-additional.pem
           readOnly: true
+        - mountPath: /etc/rancher/ssl/ca-additional.pem
+          name: tls-ca-additional-volume
+          subPath: ca-additional.pem
+          readOnly: true
 {{- end }}
 {{- if .Values.privateCA }}
         # Pass CA cert into rancher for private CA

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -9,4 +9,7 @@ rm -f /var/lib/rancher/k3s/server/cred/node-passwd
 if [ -x "$(command -v update-ca-certificates)" ]; then
   update-ca-certificates
 fi
+if [ -x "$(command -v c_rehash)" ]; then
+  c_rehash
+fi
 exec tini -- rancher --http-listen-port=80 --https-listen-port=443 --audit-log-path=${AUDIT_LOG_PATH} --audit-level=${AUDIT_LEVEL} --audit-log-maxage=${AUDIT_LOG_MAXAGE} --audit-log-maxbackup=${AUDIT_LOG_MAXBACKUP} --audit-log-maxsize=${AUDIT_LOG_MAXSIZE} "${@}"


### PR DESCRIPTION
A previous change moved the ca-additional.pem files to
/etc/pki/trust/anchors/ diretory. However, while this does allow the
additional trusted CAs to be detected in some instances, other
applications (like git) read the SSL_CERT_DIR environment variable.
Since this variable is set in the Rancher container, the additional
trusted CAs should also be put in the referenced directory
(/etc/rancher/ssl) and c_rehash run on startup.

Issues:
https://github.com/rancher/rancher/issues/33398
https://github.com/rancher/rancher/issues/31846#issuecomment-885053870