### PR TITLE
Set kubeVersion range in rancher charts

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,6 +3,7 @@ name: rancher
 description: Install Rancher Server to manage Kubernetes clusters across providers.
 version: %VERSION%
 appVersion: %APP_VERSION%
+kubeVersion: < 1.22.0-0
 home: https://rancher.com
 icon: https://github.com/rancher/ui/blob/master/public/assets/images/logos/welcome-cow.svg
 keywords:

--- a/cmd/rancherd/chart/Chart.yaml
+++ b/cmd/rancherd/chart/Chart.yaml
@@ -3,6 +3,7 @@ name: rancher
 description: Internal rancher chart used by rancherd
 version: %VERSION%
 appVersion: %APP_VERSION%
+kubeVersion: < 1.22.0-0
 home: https://rancher.com
 icon: https://github.com/rancher/ui/blob/master/public/assets/images/logos/welcome-cow.svg
 keywords:


### PR DESCRIPTION
Rancher does not yet run on kubernetes 1.22, so ensure the charts comply
with that.

https://github.com/rancher/rancher/issues/33777