### PR TITLE
Boostrap password tweaks

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,13 +1,22 @@
 Rancher Server has been installed.
 
-NOTE: Rancher may take several minutes to fully initialize. Please standby while Certificates are being issued and Ingress comes up.
+NOTE: Rancher may take several minutes to fully initialize. Please standby while Certificates are being issued, Containers are started and the Ingress rule comes up.
 
-Check out our docs at https://rancher.com/docs/rancher/v2.x/en/
+Check out our docs at https://rancher.com/docs/
 
-Browse to https://{{ .Values.hostname }}
+If you provided your own bootstrap password during installation, browse to https://{{ .Values.hostname }} to get started.
 
-If this is the first time you installed Rancher, run this command to get link to setup initial password:
+If this is the first time you installed Rancher, get started by running this command and clicking the URL it generates:
 
-$ echo https://{{ .Values.hostname }}/dashboard/?setup=$(kubectl get secret --namespace {{ .Release.Namespace }} bootstrap-secret -o jsonpath="{.data.bootstrapPassword}" | base64 --decode)
+```
+echo https://{{ .Values.hostname }}/dashboard/?setup=$(kubectl get secret --namespace cattle-system bootstrap-secret -o go-template='{{ "{{" }}.data.bootstrapPassword|base64decode{{ "}}" }}')
+```
+
+To get just the bootstrap password on its own, run:
+
+```
+kubectl get secret --namespace cattle-system bootstrap-secret -o go-template='{{ "{{" }}.data.bootstrapPassword|base64decode{{ "}}" }}{{ "{{" }} "\n" {{ "}}" }}'
+```
+
 
 Happy Containering!


### PR DESCRIPTION
- If the user supplied their own password, don't set `mustChangePassword` so the UI won't force them to change it.
- Show a more obvious visual block to make it easier to find the bootstrap info among all the noise `docker run ...` spits out
- Use go-template with internal base64 decode instead of piping and requiring base64 to be present in the commands
- Show the password on it's own line separate from the URL.  The UI will show the user instructions to grep it easily if they're already at the login screen but lacking the password.
- Don't log the password if the user provided it (but this was already done an hour ago..)
- If the user provided password is `admin`, the user is opting-in preserve existing 2.5 behavior (Don't show `?setup=admin` because it's redundant, `mustChangePassword=true`).