### PR TITLE
Add auth provisioning permissions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.15.0
 	github.com/rancher/aks-operator v1.0.1-rc17
-	github.com/rancher/apiserver v0.0.0-20210716201731-fcd925c99ba8
+	github.com/rancher/apiserver v0.0.0-20210727155917-6a723678dd3d
 	github.com/rancher/channelserver v0.5.1-0.20210618172430-5cbefd383369
 	github.com/rancher/dynamiclistener v0.3.1-0.20210616080009-9865ae859c7f
 	github.com/rancher/eks-operator v1.1.1-rc3
@@ -113,7 +113,7 @@ require (
 	github.com/rancher/remotedialer v0.2.6-0.20210318171128-d1ebd5202be4
 	github.com/rancher/rke v1.3.0-rc9
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
-	github.com/rancher/steve v0.0.0-20210716202438-924c6d7021bc
+	github.com/rancher/steve v0.0.0-20210727161021-f588bcef30d4
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210424054953-634d28b7def3
 	github.com/rancher/wrangler v0.8.1-0.20210618171953-ab479ee75244
 	github.com/robfig/cron v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -972,8 +972,8 @@ github.com/rackspace/gophercloud v0.0.0-20150408191457-ce0f487f6747/go.mod h1:4b
 github.com/rancher/aks-operator v1.0.1-rc17 h1:UatoRTErHxmAcVOtDD0ca3sQDW2FbeKZeGazM2HYXY4=
 github.com/rancher/aks-operator v1.0.1-rc17/go.mod h1:qYQJbQSSZZBxyP/Bptr3vdqP9u6aCAgokhUgeXpBbJU=
 github.com/rancher/apiserver v0.0.0-20201023000256-1a0a904f9197/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
-github.com/rancher/apiserver v0.0.0-20210716201731-fcd925c99ba8 h1:ZLEBNhJqfXrpjYdvtbevNl/Gh+Kjs/BF+vQ7mxjlxts=
-github.com/rancher/apiserver v0.0.0-20210716201731-fcd925c99ba8/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
+github.com/rancher/apiserver v0.0.0-20210727155917-6a723678dd3d h1:mRiUiDgpF+b6QCI9rJpanYNCnZ5VJgPnD5HNtj/bX+Y=
+github.com/rancher/apiserver v0.0.0-20210727155917-6a723678dd3d/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
 github.com/rancher/channelserver v0.5.1-0.20210618172430-5cbefd383369 h1:1FLFZrLqnI4oJSI9dLnQfPBQIYrXI4yvKRkfujVnqiQ=
 github.com/rancher/channelserver v0.5.1-0.20210618172430-5cbefd383369/go.mod h1:1/9aBa8mXEIinRiT6Qlv/zbt6Nv9uorv+kFVNYvpmiI=
 github.com/rancher/client-go v0.21.0-rancher.1 h1:WVy7jpVmdjIRVkgXpBRlNx4jnGkLCFS1Qu/hUFCOGN4=
@@ -1023,8 +1023,8 @@ github.com/rancher/rke v1.3.0-rc9 h1:kMNNZ/ltSwYLOl9AKBQNXZ6aK7bVOD+h5LtO9pnX5XE
 github.com/rancher/rke v1.3.0-rc9/go.mod h1:HAdRKAo7OI5YvFSSP40ezrad1pXA7IuJgAW7S5PYg6Y=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
-github.com/rancher/steve v0.0.0-20210716202438-924c6d7021bc h1:GXNr4Phrlqusx6I9DgshVGr8PZfgzhVDlAJlQiegIRY=
-github.com/rancher/steve v0.0.0-20210716202438-924c6d7021bc/go.mod h1:7YsGcw3zWlzahebzD4484KAgUtxrkDKiVgzCP3uiLi4=
+github.com/rancher/steve v0.0.0-20210727161021-f588bcef30d4 h1:VxBbaxfb/ht40QoZZG0Ka0J5Cm88Pd8vlbZdJHF2ePs=
+github.com/rancher/steve v0.0.0-20210727161021-f588bcef30d4/go.mod h1:e8RsIdpZ1FHzJLBuU99dPI1C3SDUILk1r17s9q7WedM=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210424054953-634d28b7def3 h1:Ja/AEVsfVaVQvQ/5bl1uSWNzpnrsigrXnwCPB/8bDSM=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210424054953-634d28b7def3/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=

--- a/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
+++ b/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
@@ -62,6 +62,7 @@ func Register(ctx context.Context, clients *wrangler.Context) error {
 	h.dynamic.AddIndexer(clusterIndexed, h.gvkMatcher, indexByCluster)
 	h.dynamic.OnChange(ctx, "auth-prov-v2-trigger", h.gvkMatcher, h.OnClusterObjectChanged)
 	clients.Mgmt.RoleTemplate().OnChange(ctx, "auth-prov-v2", h.OnChange)
+	clients.Mgmt.ClusterRoleTemplateBinding().OnChange(ctx, "auth-prov-v2-crtb", h.OnCRTB)
 	clients.CRD.CustomResourceDefinition().OnChange(ctx, "auth-prov-v2-crd", h.OnCRD)
 	clients.Provisioning.Cluster().Cache().AddIndexer(byClusterName, func(obj *v1.Cluster) ([]string, error) {
 		return []string{obj.Status.ClusterName}, nil


### PR DESCRIPTION
Pull in the updated api server so lists don't fail with a 403
Remove the owner reference for roleBindings created for the provisioning cluster. The CRTB lives in another namespace so it can't be used as the owner. 
Update the naming convention of the roleBinding to be unique based on the CRTB name