### PR TITLE
Correctly parse taints for custom clusters

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
@@ -13,10 +13,10 @@ import (
 	rocontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	rkecontroller "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/provisioningv2/rke2/planner"
+	"github.com/rancher/rancher/pkg/taints"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/pkg/apply"
 	"github.com/rancher/wrangler/pkg/data"
-	"github.com/rancher/wrangler/pkg/data/convert"
 	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/kv"
 	corev1 "k8s.io/api/core/v1"
@@ -185,32 +185,13 @@ func (h *handler) createMachineObjects(capiCluster *capi.Cluster, machineName st
 		annotations[planner.LabelsAnnotation] = string(data)
 	}
 
-	var taints []corev1.Taint
-	for _, taint := range convert.ToStringSlice(data["taints"]) {
-		for _, taint := range strings.Split(taint, ",") {
-			parts := strings.Split(taint, ":")
-			switch len(parts) {
-			case 1:
-				taints = append(taints, corev1.Taint{
-					Key: parts[0],
-				})
-			case 2:
-				taints = append(taints, corev1.Taint{
-					Key:   parts[0],
-					Value: parts[1],
-				})
-			case 3:
-				taints = append(taints, corev1.Taint{
-					Key:    parts[0],
-					Value:  parts[1],
-					Effect: corev1.TaintEffect(parts[2]),
-				})
-			}
-		}
+	var coreTaints []corev1.Taint
+	for _, taint := range data.StringSlice("taints") {
+		coreTaints = append(coreTaints, taints.GetTaintsFromStrings(strings.Split(taint, ","))...)
 	}
 
-	if len(taints) > 0 {
-		data, err := json.Marshal(taints)
+	if len(coreTaints) > 0 {
+		data, err := json.Marshal(coreTaints)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/integration/pkg/tests/custom/custom_test.go
+++ b/tests/integration/pkg/tests/custom/custom_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/rancher/tests/integration/pkg/cluster"
 	"github.com/rancher/rancher/tests/integration/pkg/systemdnode"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestCustomOneNode(t *testing.T) {
@@ -192,4 +193,83 @@ func TestCustomUniqueRoles(t *testing.T) {
 	assert.Equal(t, worker, 1)
 	assert.Equal(t, etcd, 3)
 	assert.Equal(t, controlPlane, 1)
+}
+
+func TestCustomThreeNodeWithTaints(t *testing.T) {
+	clients, err := clients.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clients.Close()
+
+	c, err := cluster.New(clients, &provisioningv1.Cluster{
+		Spec: provisioningv1.ClusterSpec{
+			RKEConfig: &provisioningv1.RKEConfig{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	command, err := cluster.CustomCommand(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotEmpty(t, command)
+
+	for i := 0; i < 3; i++ {
+		var taint string
+		// Put a taint on one of the nodes.
+		if i == 1 {
+			taint = " --taint key=value:NoExecute"
+		}
+		_, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --worker --etcd --controlplane --label rancher=awesome"+taint)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err = cluster.WaitFor(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machines, err := cluster.Machines(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var taintFound bool
+	assert.Len(t, machines.Items, 3)
+	for _, m := range machines.Items {
+		assert.Equal(t, m.Labels[planner.WorkerRoleLabel], "true")
+		assert.Equal(t, m.Labels[planner.ControlPlaneRoleLabel], "true")
+		assert.Equal(t, m.Labels[planner.EtcdRoleLabel], "true")
+
+		assert.NotEmpty(t, m.Annotations[planner.LabelsAnnotation])
+		var labels map[string]string
+		if err := json.Unmarshal([]byte(m.Annotations[planner.LabelsAnnotation]), &labels); err != nil {
+			t.Error(err)
+		}
+		assert.Equal(t, labels, map[string]string{"rancher": "awesome"})
+
+		if len(m.Annotations[planner.TaintsAnnotation]) != 0 {
+			// Only one node should have the taint
+			assert.False(t, taintFound)
+
+			var taints []corev1.Taint
+			if err := json.Unmarshal([]byte(m.Annotations[planner.TaintsAnnotation]), &taints); err != nil {
+				t.Error(err)
+			}
+
+			assert.Equal(t, len(taints), 1)
+			assert.Equal(t, taints[0].Key, "key")
+			assert.Equal(t, taints[0].Value, "value")
+			assert.Equal(t, taints[0].Effect, corev1.TaintEffect("NoExecute"))
+			taintFound = true
+		}
+	}
+
+	assert.True(t, taintFound)
 }


### PR DESCRIPTION
The taints for custom clusters are passed as `key=value:Effect`.
However, the parsing of the taint strings were expecting something of
the form `key:value:Effect`.

This change correctly parses the taints for custom clusters.

Issue:
https://github.com/rancher/rancher/issues/33419