### PR TITLE
Check error type before logging

### DIFF
--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -517,7 +517,9 @@ func updateStatusAnnotation(hasPRTBs bool, namespace *v1.Namespace, mgr *manager
 		if err == nil {
 			break
 		}
-		logrus.Warnf("error updating ns %v status: %v", ns.Name, err)
+		if !apierrors.IsConflict(err) {
+			logrus.Warnf("error updating ns %v status: %v", ns.Name, err)
+		}
 	}
 
 }


### PR DESCRIPTION
Problem:
The warn message will log multiple times on startup or new namespace
creation with conflict errors

Solution:
Wrap the log to check the type of error before logging. The framework
normally hides these errors and retries so this should not log with a
conflict error