### PR TITLE
Print v1 charts image versions

### DIFF
--- a/tests/validation/tests/v3_api/test_istio.py
+++ b/tests/validation/tests/v3_api/test_istio.py
@@ -190,6 +190,8 @@ def test_istio_custom_answers(skipif_unsupported_istio_version,
         daemonset_list=expected_daemonsets, job_list=expected_job_list)
 
 
+
+
 # This is split out separately from test_istio_custom_answers because
 # certmanager creates its own crds outside of istio
 @pytest.mark.skip(reason="To be removed, no support from 1.7.000")
@@ -947,10 +949,49 @@ def auth_cluster_access(request):
     return group, users, noauth_user
 
 
+def enable_monitoring_istio(client, c_client, p_client,cluster,project,additional_answers={}):
+    global ISTIO_EXTERNAL_ID
+    monitoring_answers = copy.deepcopy(C_MONITORING_ANSWERS)
+    monitoring_answers["prometheus.persistence.enabled"] = "false"
+    monitoring_answers["grafana.persistence.enabled"] = "false"
+
+    if cluster["enableClusterMonitoring"] is False:
+        client.action(cluster, "enableMonitoring",
+                      answers=monitoring_answers)
+
+    monitoring_ns = "cattle-prometheus"
+
+    istio_versions = list(client.list_template(
+        id=ISTIO_TEMPLATE_ID).data[0].versionLinks.keys())
+    istio_version = istio_versions[len(istio_versions) - 1]
+
+
+
+    if ISTIO_VERSION != "":
+        istio_version = ISTIO_VERSION
+    ISTIO_EXTERNAL_ID += istio_version
+
+    answers = {"global.rancher.clusterId": project.clusterId, **additional_answers}
+    DEFAULT_ANSWERS.update(answers)
+
+    if cluster["istioEnabled"] is False:
+        verify_admission_webhook()
+
+        ns = create_ns(c_client, cluster, project, 'istio-system')
+        app = create_and_verify_istio_app(p_client, ns, project)
+    else:
+        app = p_client.list_app(name='cluster-istio').data[0]
+        ns = c_client.list_namespace(name='istio-system').data[0]
+        update_istio_app(DEFAULT_ANSWERS, USER_TOKEN,
+                         app=app, ns=ns, project=project)
+
+    return {"ns":ns, "istio_version":istio_version, "app":app, "project":project, "istio_enabled":True,"monitoring_ns":monitoring_ns}
+
+
+
 @pytest.fixture(scope='module', autouse="True")
 def create_project_client(request):
     global DEFAULT_ANSWERS
-    global ISTIO_EXTERNAL_ID
     client, cluster = get_user_client_and_cluster()
     create_kubeconfig(cluster)
 
@@ -968,34 +1009,9 @@ def create_project_client(request):
     p_client = get_project_client_for_token(p, USER_TOKEN)
     c_client = get_cluster_client_for_token(cluster, USER_TOKEN)
 
-    istio_versions = list(client.list_template(
-        id=ISTIO_TEMPLATE_ID).data[0].versionLinks.keys())
-    istio_version = istio_versions[len(istio_versions) - 1]
 
-    if ISTIO_VERSION != "":
-        istio_version = ISTIO_VERSION
-    ISTIO_EXTERNAL_ID += istio_version
-    answers = {"global.rancher.clusterId": p.clusterId}
-    DEFAULT_ANSWERS.update(answers)
 
-    monitoring_answers = copy.deepcopy(C_MONITORING_ANSWERS)
-    monitoring_answers["prometheus.persistence.enabled"] = "false"
-    monitoring_answers["grafana.persistence.enabled"] = "false"
-
-    if cluster["enableClusterMonitoring"] is False:
-        client.action(cluster, "enableMonitoring",
-                      answers=monitoring_answers)
-
-    if cluster["istioEnabled"] is False:
-        verify_admission_webhook()
-
-        ns = create_ns(c_client, cluster, p, 'istio-system')
-        app = create_and_verify_istio_app(p_client, ns, p)
-    else:
-        app = p_client.list_app(name='cluster-istio').data[0]
-        ns = c_client.list_namespace(name='istio-system').data[0]
-        update_istio_app(DEFAULT_ANSWERS, USER_TOKEN,
-                         app=app, ns=ns, project=p)
+    istio_ = enable_monitoring_istio(client,c_client,p_client,cluster,p)
 
     istio_project, app_ns = create_project_and_ns(
         USER_TOKEN, cluster,
@@ -1006,7 +1022,7 @@ def create_project_client(request):
     app_client = get_project_client_for_token(istio_project, USER_TOKEN)
 
     istio_gateway_wl = p_client.by_id_workload('deployment:' +
-                                               ns.name +
+                                               istio_["ns"].name +
                                                ':istio-ingressgateway')
     assert istio_gateway_wl is not None
     endpoints = istio_gateway_wl['publicEndpoints'][0]
@@ -1015,10 +1031,11 @@ def create_project_client(request):
     namespace["gateway_url"] = gateway_url
     namespace["app_ns"] = app_ns
     namespace["app_client"] = app_client
-    namespace["system_ns"] = ns
+    namespace["system_ns"] = istio_["ns"]
     namespace["system_project"] = p
-    namespace["istio_version"] = istio_version
-    namespace["istio_app"] = app
+    namespace["istio_version"] = istio_["istio_version"]
+    namespace["istio_app"] = istio_["app"]
+
 
     def fin():
         client = get_user_client()

--- a/tests/validation/tests/v3_api/test_print_v1_chart.py
+++ b/tests/validation/tests/v3_api/test_print_v1_chart.py
@@ -1,0 +1,151 @@
+import re
+import os
+
+import pytest
+from .common import create_kubeconfig
+from .common import get_cluster_client_for_token
+from .common import get_project_client_for_token
+from .common import get_user_client
+from .common import get_cluster_by_name
+from .common import USER_TOKEN
+from .test_rke_cluster_provisioning import create_and_validate_custom_host
+from .common import validate_app_deletion
+from .test_istio import enable_monitoring_istio
+from .test_istio import get_system_client
+
+
+user_token = get_system_client(USER_TOKEN)
+istio_ns = ""
+monitoring_ns = ""
+additional_answers = {
+    "kiali.enabled": "true",
+    "tracing.enabled": "true",
+    "gateways.istio-egressgateway.enabled": "true",
+    "gateways.istio-ilbgateway.enabled": "true",
+    "gateways.istio-ingressgateway.sds.enabled": "true",
+    "global.proxy.accessLogFile": "/dev/stdout",
+    "istiocoredns.enabled": "true",
+    "kiali.prometheusAddr": "http://prometheus:9090",
+    "nodeagent.enabled": "true",
+    "nodeagent.env.CA_ADDR": "istio-citadel:8060",
+    "nodeagent.env.CA_PROVIDER": "Citadel",
+    "prometheus.enabled": "true",
+}
+istio_expected_images = {"istio-citadel": "v1.5.9",
+                         "istio-galley": "v1.5.9",
+                         "istio-proxyv2": "v1.5.9",
+                         "istio-pilot": "v1.5.9",
+                         "istio-mixer": "v1.5.9",
+                         "istio-sidecar_injector": "v1.5.9",
+                         "jaegertracing-all-in-one": "v1.14",
+                         "kiali-kiali": "v1.17",
+                         "istio-node-agent-k8s": "v1.5.9",
+                         "coredns-coredns": "v1.6.9",
+                         "prom-prometheus": "v2.18.2"
+                         }
+monitoring_expected_images = {"prometheus": "v2.18.2",
+                              "prometheus-operator": "v0.39.0",
+                              "prometheus-config-reloader": "v0.39.0",
+                              "prometheus-auth": "v0.2.1",
+                              "node-exporter": "v1.0.1",
+                              "kube-state-metrics": "v1.9.7",
+                              "configmap-reload": "v0.3.0",
+                              "grafana": "v7.1.5"}
+
+
+def get_wk(ns_):
+    data_ = user_token.list_workload(namespaceId=ns_).data
+    container_images = list(set([c.image for wks in data_ for c in wks.containers if len(data_) >= 0 if c.image]))
+
+    wk_image = dict()
+    # splitting them on ":" to separate them to image and version
+    for image in container_images:
+        if image.startswith('rancher/'):
+            img, ver = image.replace('rancher/', '').split(":")
+            # Add 'v' to version if missing
+            wk_image[img] = ver if ver.startswith("v") else 'v' + ver
+    return wk_image
+
+
+def print_wk(wk, expected_images):
+    for w, ver in wk.items():
+        if w in expected_images.keys():
+            try:
+                assert ver == expected_images[w]
+                print( "\n\nVersion of the image {} is {}".format(w, ver)+"\n\n" )
+            except AssertionError:
+                print('\033[2;31;43 ERROR')
+                print("\n\nVersion of the image {} is {} but the expected version is {}".format(w, ver,expected_images[w])+"\n\n")
+                continue
+
+
+@pytest.mark.skipif(False, reason="Only testing monitoring")
+def test_istio():
+    if istio_ns == '':
+        raise Exception("No namespace is detected uh-oh!")
+    istio_wk = get_wk(istio_ns)
+    print_wk(istio_wk, istio_expected_images)
+
+
+@pytest.mark.skipif(False, reason="Only testing istio")
+def test_monitoring():
+    image_name = 'prometheus-auth'
+    if monitoring_ns == '':
+        raise Exception("No namespace is detected uh-oh!")
+    monitoring_wk = get_wk(monitoring_ns)
+    monitoring_wk_final = {}
+    # Some of the images names in release testing document differ
+    # from that of the installed. To be in unison, removing the extra string in the installed
+    for image in monitoring_wk.keys():
+        if image != image_name:
+            img = re.sub(r'^.*?-', '', image)
+            monitoring_wk_final[img] = monitoring_wk[image]
+        else:
+            monitoring_wk_final[image] = monitoring_wk[image]
+    print_wk(monitoring_wk_final, monitoring_expected_images)
+
+
+@pytest.fixture(scope='module', autouse="True")
+def create_project_client(request):
+    global user_token
+    global istio_ns
+    global monitoring_ns
+
+    client = get_user_client()
+
+    cluster_name = os.environ.get('RANCHER_CLUSTER_NAME')
+
+    if cluster_name == "":
+        node_roles = [["controlplane"], ["etcd"],
+                      ["worker"], ["worker"], ["worker"], ["worker"]]
+        cluster,nodes = create_and_validate_custom_host(node_roles)
+    else:
+        cluster = get_cluster_by_name(client,cluster_name)
+
+    create_kubeconfig(cluster)
+    projects = client.list_project(name='System', clusterId=cluster.id)
+    if len(projects.data) == 0:
+        raise AssertionError(
+            "System project not found in the cluster " + cluster.name)
+    p = projects.data[0]
+    p_client = get_project_client_for_token(p, USER_TOKEN)
+    c_client = get_cluster_client_for_token(cluster, USER_TOKEN)
+
+    istio_enabled = enable_monitoring_istio(client, c_client, p_client, cluster, p,
+                                            additional_answers=additional_answers)
+    istio_ns = istio_enabled["ns"].name
+    monitoring_ns = istio_enabled["monitoring_ns"]
+
+    def fin():
+        client = get_user_client()
+        # delete istio app
+        app = p_client.list_app(name='cluster-istio').data[0]
+        p_client.delete(app)
+        validate_app_deletion(p_client, app.id)
+        # delete istio ns
+        p_client.delete(istio_ns)
+        # disable cluster monitoring
+        c = client.reload(cluster)
+        if c["enableClusterMonitoring"] is True:
+            client.action(c, "disableMonitoring")
+    request.addfinalizer(fin)

--- a/tests/validation/tests/v3_api/test_secrets.py
+++ b/tests/validation/tests/v3_api/test_secrets.py
@@ -1,12 +1,14 @@
 import base64
 from rancher import ApiError
 import pytest
+from packaging import version
 
 from .common import *  # NOQA
 
 CLUSTER_NAME = os.environ.get("CLUSTER_NAME", "")
 
 namespace = {"p_client": None, "ns": None, "cluster": None, "project": None}
+rancher_version_26 = False
 
 
 def test_secret_create_all_ns():
@@ -611,6 +613,7 @@ def rbac_secret_list(p_client):
 
 @pytest.fixture(scope='module', autouse="True")
 def create_project_client(request):
+    global rancher_version_26
     client, cluster = get_user_client_and_cluster()
     create_kubeconfig(cluster)
     p, ns = create_project_and_ns(USER_TOKEN, cluster, "testsecret")
@@ -622,6 +625,13 @@ def create_project_client(request):
     namespace["cluster"] = cluster
     namespace["project"] = p
     namespace["c_client"] = c_client
+    rancher_version = get_setting_value_by_name('server-version')
+
+    #Checks if rancher version is greater than v26
+
+    if rancher_version.startswith('v'):
+        if version.parse(rancher_version[:4]) > version.parse('v2.5') or rancher_version.startswith("master"):
+            rancher_version_26 = True
 
     def fin():
         client = get_user_client()
@@ -738,14 +748,26 @@ def create_and_validate_workload_with_secret_as_env_variable(p_client, secret,
     # Create Workload with secret as env variable
     secretName = secret['name']
 
-    environmentdata = [{
-        "source": "secret",
-        "sourceKey": None,
-        "sourceName": secretName
-    }]
+    #Checking if rancher version is 26 and above.
+
+    if rancher_version_26:
+        env_str = "envFrom"
+        environmentdata = [{
+            "secretRef" : {
+               "name": secretName,
+                "optional":False
+            }
+        }]
+    else:
+        env_str = "environmentFrom"
+        environmentdata = [{
+            "source": "secret",
+            "sourceKey": None,
+            "sourceName": secretName
+        }]
     con = [{"name": "test",
             "image": TEST_IMAGE,
-            "environmentFrom": environmentdata}]
+            env_str: environmentdata}]
 
     workload = p_client.create_workload(name=name,
                                         containers=con,

--- a/tests/validation/tests/v3_api/test_secrets.py
+++ b/tests/validation/tests/v3_api/test_secrets.py
@@ -1,14 +1,12 @@
 import base64
 from rancher import ApiError
 import pytest
-from packaging import version
 
 from .common import *  # NOQA
 
 CLUSTER_NAME = os.environ.get("CLUSTER_NAME", "")
 
 namespace = {"p_client": None, "ns": None, "cluster": None, "project": None}
-rancher_version_26 = False
 
 
 def test_secret_create_all_ns():
@@ -613,7 +611,6 @@ def rbac_secret_list(p_client):
 
 @pytest.fixture(scope='module', autouse="True")
 def create_project_client(request):
-    global rancher_version_26
     client, cluster = get_user_client_and_cluster()
     create_kubeconfig(cluster)
     p, ns = create_project_and_ns(USER_TOKEN, cluster, "testsecret")
@@ -625,13 +622,6 @@ def create_project_client(request):
     namespace["cluster"] = cluster
     namespace["project"] = p
     namespace["c_client"] = c_client
-    rancher_version = get_setting_value_by_name('server-version')
-
-    #Checks if rancher version is greater than v26
-
-    if rancher_version.startswith('v'):
-        if version.parse(rancher_version[:4]) > version.parse('v2.5') or rancher_version.startswith("master"):
-            rancher_version_26 = True
 
     def fin():
         client = get_user_client()
@@ -748,26 +738,14 @@ def create_and_validate_workload_with_secret_as_env_variable(p_client, secret,
     # Create Workload with secret as env variable
     secretName = secret['name']
 
-    #Checking if rancher version is 26 and above.
-
-    if rancher_version_26:
-        env_str = "envFrom"
-        environmentdata = [{
-            "secretRef" : {
-               "name": secretName,
-                "optional":False
-            }
-        }]
-    else:
-        env_str = "environmentFrom"
-        environmentdata = [{
-            "source": "secret",
-            "sourceKey": None,
-            "sourceName": secretName
-        }]
+    environmentdata = [{
+        "source": "secret",
+        "sourceKey": None,
+        "sourceName": secretName
+    }]
     con = [{"name": "test",
             "image": TEST_IMAGE,
-            env_str: environmentdata}]
+            "environmentFrom": environmentdata}]
 
     workload = p_client.create_workload(name=name,
                                         containers=con,


### PR DESCRIPTION
Added a new file test_print to validate the versions expected and the installed apps. 
Added enabling istio and monitoring from fixture to a separate method to reuse the code in test_print_v1 to enable istio and monitoring


Ref: https://github.com/rancher/qa-tasks/issues/101
Passlog: 
[passlog-print_v1_charts.txt](https://github.com/rancher/rancher/files/6897946/passlog-print_v1_charts.txt)
