### PR TITLE
[v2.6.0] ISSUE-33743 delete dashboard tokens on 2.6 upgrade

### DIFF
--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -1,0 +1,75 @@
+package rancher
+
+import (
+	"github.com/mcuadros/go-version"
+	"github.com/rancher/rancher/pkg/auth/tokens"
+	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	rancherversion "github.com/rancher/rancher/pkg/version"
+	controllerv1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	cattleNamespace          = "cattle-system"
+	forceUpgradeLogoutConfig = "forceupgradelogout"
+	rancherVersionKey        = "rancherVersion"
+)
+
+// forceUpgradeLogout will delete all dashboard tokens forcing a logout.  This is useful when there is a major frontend
+// upgrade and we want all users to be sent to a central point.  This function will check for the `forceUpgradeLogoutConfig`
+// configuration map and only run if the last migrated version is lower than the given `migrationVersion`.
+func forceUpgradeLogout(configMapController controllerv1.ConfigMapController, tokenController v3.TokenController, migrationVersion string) error {
+	cm, err := configMapController.Cache().Get(cattleNamespace, forceUpgradeLogoutConfig)
+	if err != nil && !k8serror.IsNotFound(err) {
+		return err
+	}
+
+	// if this is the first ever migration initialize the configmap
+	if cm == nil {
+		cm = &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      forceUpgradeLogoutConfig,
+				Namespace: cattleNamespace,
+			},
+			Data: make(map[string]string, 1),
+		}
+	}
+
+	// we only want to migrate if the previous installation was earlier than the migration version
+	if lastMigration, ok := cm.Data[rancherVersionKey]; ok {
+		if lastMigration == "dev" || version.Compare(migrationVersion, lastMigration, "<=") {
+			return nil
+		}
+	}
+
+	logrus.Infof("Detected %s upgrade, forcing logout for all web users", migrationVersion)
+
+	// list all tokens that were created for the dashboard
+	allTokens, err := tokenController.Cache().List(labels.SelectorFromSet(labels.Set{tokens.TokenKindLabel: "session"}))
+	if err != nil {
+		logrus.Error("Failed to list tokens for upgrade forced logout")
+		return err
+	}
+
+	// log out all the dashboard users forcing them to be redirected to the login page
+	for _, token := range allTokens {
+		err = tokenController.Delete(token.ObjectMeta.Name, &metav1.DeleteOptions{})
+		if err != nil && !k8serror.IsNotFound(err) {
+			logrus.Errorf("Failed to delete token [%s] for upgrade forced logout", token.Name)
+		}
+	}
+
+	// record the migration being completed
+	cm.Data[rancherVersionKey] = rancherversion.Version
+	if cm.ObjectMeta.GetResourceVersion() != "" {
+		_, err = configMapController.Update(cm)
+	} else {
+		_, err = configMapController.Create(cm)
+	}
+
+	return err
+}

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -225,9 +225,12 @@ func (r *Rancher) Start(ctx context.Context) error {
 		if err := dashboarddata.Add(ctx, r.Wrangler, localClusterEnabled(r.opts), r.opts.AddLocal == "false", r.opts.Embedded); err != nil {
 			return err
 		}
-		return r.Wrangler.StartWithTransaction(ctx, func(ctx context.Context) error {
-			return dashboard.Register(ctx, r.Wrangler)
-		})
+
+		if err := r.Wrangler.StartWithTransaction(ctx, func(ctx context.Context) error { return dashboard.Register(ctx, r.Wrangler) }); err != nil {
+			return err
+		}
+
+		return forceUpgradeLogout(r.Wrangler.Core.ConfigMap(), r.Wrangler.Mgmt.Token(), "v2.6.0")
 	})
 
 	if err := r.authServer.Start(ctx, false); err != nil {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/33743

# PROBLEM
With v2.6.0 rancher is shipping a new frontend.  Any user that is on the old ember ui while rancher is upgraded will not be directed to the new dashboard until they choose to logout.  This could cause some confusion after the upgrade.

# SOLUTION
When we upgrade to v2.6.0 we need to invalidate all the ember ui tokens.  This will force a logout and send all the users to a central point allowing the frontend to redirect them.  When the rancher app starts we will invalidate all the frontend tokens and then create a config map with the current rancher version.  On the next startup we will check for that configmap and as long as the stored version is greater than v2.6.0 we will not invalidate any tokens.

# TESTING

- [x] installed rancher v2.5.8 on single node cluster with helm and logged into the ember ui.  Redeploy the helm chart with an image with these changes that thinks it is v2.6.0. Tokens were invalidated.  After that the rancher pod was restarted and no tokens were invalidated. 
- [x] installed rancher v2.5.8 on an ha cluster with helm and logged into the ember ui.  Redeploy the helm chart with an image with these changes that thinks it is v2.6.0. Tokens were invalidated.  After that the rancher pod was restarted and no tokens were invalidated.
- [x] installed rancher v2.5.8 with fake v2.6.0 image on single node cluster with helm and logged into the ember ui.  Restart the rancher pods. Tokens were not invalidated.
- [x] tested docker run with container restart.