### PR TITLE
[2.6.2] Use u.Path instead of u.String for icon suffix

### DIFF
--- a/pkg/catalogv2/http/download.go
+++ b/pkg/catalogv2/http/download.go
@@ -62,7 +62,7 @@ func Icon(secret *corev1.Secret, repoURL string, caBundle []byte, insecureSkipTL
 	if err != nil {
 		return nil, "", err
 	}
-	return ioutil.NopCloser(bytes.NewBuffer(data)), path.Ext(u.String()), nil
+	return ioutil.NopCloser(bytes.NewBuffer(data)), path.Ext(u.Path), nil
 }
 
 func Chart(secret *corev1.Secret, repoURL string, caBundle []byte, insecureSkipTLSVerify bool, chart *repo.ChartVersion) (io.ReadCloser, error) {


### PR DESCRIPTION
Root cause of this issue is https://github.com/rancher/rancher/blob/5e3b154abc2b697bcd4124bfa7a38f0d7398ae5a/pkg/catalogv2/http/download.go#L65

`path.Ext(u.String())` does not necessarily represent the suffix since a URL with url encoded params can have elements after the file extension. e.g. in this case, the value returned for the suffix was `.svg?sanitize=true`.

The simple fix here is to replace `u.String()` with `u.Path`, which returns just the path without URL-encoded elements.

Related Issue: https://github.com/rancher/rancher/issues/32412

---

Note: Since this issue is for 2.6.2, it should not be merged until release branches are cut for 2.6.0 and 2.6.1.