### PR TITLE
Use additional CAs when getting AKS service account

### DIFF
--- a/pkg/controllers/management/aks/aks_cluster_handler.go
+++ b/pkg/controllers/management/aks/aks_cluster_handler.go
@@ -2,6 +2,7 @@ package aks
 
 import (
 	"context"
+	"encoding/base64"
 	stderrors "errors"
 	"fmt"
 	"net"
@@ -433,5 +434,13 @@ func (e *aksOperatorController) getRestConfig(cluster *mgmtv3.Cluster) (*rest.Co
 	if err != nil {
 		return nil, err
 	}
+
+	// Get the CACert from the cluster because it will have any additional CAs added to Rancher.
+	certFromCluster, err := base64.StdEncoding.DecodeString(cluster.Status.CACert)
+	if err != nil {
+		return nil, err
+	}
+
+	restConfig.CAData = certFromCluster
 	return restConfig, nil
 }


### PR DESCRIPTION
Before this change, the AKS controller in Rancher would try to get the
service account by using the kubeconfig from AKS. This caused an issue
if any additional CAs are needed (like in a proxy setup).

This fix will ensure that the additional CAs are used when getting the
service account and resolve the unsigned cert errors.

Issue:
https://github.com/rancher/rancher/issues/31846