### PR TITLE
Force to install charts when cluster is changed

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -113,6 +113,7 @@ var (
 	GKEUpstreamRefresh                = NewSetting("gke-refresh", "300")
 	HideLocalCluster                  = NewSetting("hide-local-cluster", "false")
 	MachineProvisionImage             = NewSetting("machine-provision-image", "rancher/machine:v0.15.0-rancher66")
+	SystemFeatureChartRefreshSeconds  = NewSetting("system-feature-chart-refresh-seconds", "900")
 
 	FleetMinVersion          = NewSetting("fleet-min-version", "")
 	RancherWebhookMinVersion = NewSetting("rancher-webhook-min-version", "")

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -279,7 +279,7 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 		RESTMapper:      restMapper,
 	}
 
-	systemCharts, err := system.NewManager(ctx, restClientGetter, content, helmop, steveControllers.Core.Pod())
+	systemCharts, err := system.NewManager(ctx, restClientGetter, content, helmop, steveControllers.Core.Pod(), mgmt.Management().V3().Setting())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Addressed an issue where aks/eks/gke chart is not redeployed/upgraded when cluster is changed. https://github.com/rancher/rancher/issues/31592

This has potential overhead calls to check helm releases because cluster is changed frequently and will be triggering controller code very frequently.