### PR TITLE
Apply SingleStack default to dnsRecord

### DIFF
--- a/pkg/api/norman/store/service/service.go
+++ b/pkg/api/norman/store/service/service.go
@@ -35,7 +35,7 @@ func (p *Store) Create(apiContext *types.APIContext, schema *types.Schema, data 
 	}
 	// Check for unset ipFamilyPolicy, for headless services this defaults to dual stack but will not function if the cluster does not have dual stack properly configured (IPv6 CIDRs)
 	// If its not explicitly configured in the request, we default to SingleStack
-	if schema.ID == "service" {
+	if schema.ID == "service" || schema.ID == "dnsRecord" {
 		logrus.Tracef("Service: Create: data [%v]", data)
 		if val, ok := data["kind"]; ok {
 			if val == "ClusterIP" {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/33085

Although `dnsRecord` does not seem to be exposed to the user in the UI, the automated tests that use this type were failing.