### PR TITLE
Add oidc log message to indicate token refresh

### DIFF
--- a/pkg/auth/providers/keycloakoidc/keycloak_provider.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_provider.go
@@ -59,6 +59,12 @@ func newClient(config *v32.OIDCConfig, token *oauth2.Token) (*KeyCloakClient, er
 		return nil, err
 	}
 	oauthConfig := oidc.ConfigToOauthConfig(provider.Endpoint(), config)
+	// Valid will return false if access token is expired
+	if !token.Valid() {
+		// since token is not valid, the TokenSource func used in the Client func will attempt to refresh the access token
+		// if the refresh token has not expired
+		logrus.Debugf("[keycloak oidc] newClient: attempting to refresh access token")
+	}
 	keyCloakClient := &KeyCloakClient{
 		httpClient: oauthConfig.Client(ctx, token),
 	}

--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -381,6 +381,13 @@ func (o *OpenIDCProvider) getUserInfo(ctx *context.Context, config *v32.OIDCConf
 			return userInfo, oauth2Token, err
 		}
 	}
+	// Valid will return false if access token is expired
+	if !oauth2Token.Valid() {
+		// since token is not valid, the TokenSource func will attempt to refresh the access token
+		// if the refresh token has not expired
+		logrus.Debugf("[generic oidc] saveOIDCConfig: attempting to refresh access token")
+	}
+	logrus.Debugf("[generic oidc] saveOIDCConfig: getting user info")
 	userInfo, err = provider.UserInfo(updatedContext, oauthConfig.TokenSource(updatedContext, oauth2Token))
 	if err != nil {
 		return userInfo, oauth2Token, err


### PR DESCRIPTION
**Issue**
https://github.com/rancher/rancher/issues/33852

**Problem**
There is nothing in the logs to indicate if the original token was being used, or if a fresh token had been requested

**Solution**
Add a log message that indicates a refresh will be attempted if the token is no longer valid