### PR TITLE
Cleanup roleBindings for provisioning clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20210727161021-f588bcef30d4
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
-	github.com/rancher/wrangler v0.8.4-0.20210729214659-5e75fca61cb2
+	github.com/rancher/wrangler v0.8.4
 	github.com/robfig/cron v1.1.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/segmentio/kafka-go v0.0.0-20190411192201-218fd49cff39

--- a/go.sum
+++ b/go.sum
@@ -1050,8 +1050,8 @@ github.com/rancher/wrangler v0.8.0/go.mod h1:zSV5oh3+YZboilwcJmFHO3J6FZba82BTQft
 github.com/rancher/wrangler v0.8.1-0.20210423003607-f71a90542852/go.mod h1:zSV5oh3+YZboilwcJmFHO3J6FZba82BTQft1b6ijx2I=
 github.com/rancher/wrangler v0.8.1-0.20210506052526-673b7f8692d9/go.mod h1:aj/stIidTzU6UEKKRB8JyrrqNMJAfDMziL1+zhG8lc0=
 github.com/rancher/wrangler v0.8.3/go.mod h1:dKEaHNB4izxmPUtpq1Hvr3z3Oh+9k5pCZyFO9sUhlaY=
-github.com/rancher/wrangler v0.8.4-0.20210729214659-5e75fca61cb2 h1:ja7zS/MtLRAs4ZgCIlocJg3c74qWpvRneQWEkSF3g9Q=
-github.com/rancher/wrangler v0.8.4-0.20210729214659-5e75fca61cb2/go.mod h1:dKEaHNB4izxmPUtpq1Hvr3z3Oh+9k5pCZyFO9sUhlaY=
+github.com/rancher/wrangler v0.8.4 h1:aGMqLQHtn9yB8vw584TO8x/tvZMiaY7Yyi37Fp22UFU=
+github.com/rancher/wrangler v0.8.4/go.mod h1:dKEaHNB4izxmPUtpq1Hvr3z3Oh+9k5pCZyFO9sUhlaY=
 github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e/go.mod h1:2lcWR98q8HU3U4mVETnXc8quNG0uXxrt8vKd6cAa/30=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rancher/gke-operator v1.1.1-rc10
 	github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133
 	github.com/rancher/rke v1.3.0-rc10
-	github.com/rancher/wrangler v0.8.4-0.20210729214659-5e75fca61cb2
+	github.com/rancher/wrangler v0.8.4
 	github.com/sirupsen/logrus v1.7.0
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -726,8 +726,8 @@ github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224/go.mod h1:I7qe4
 github.com/rancher/wrangler v0.7.3-0.20201020003736-e86bc912dfac/go.mod h1:goezjesEKwMxHLfltdjg9DW0xWV7txQee6vOuSDqXAI=
 github.com/rancher/wrangler v0.8.1-0.20210506052526-673b7f8692d9/go.mod h1:aj/stIidTzU6UEKKRB8JyrrqNMJAfDMziL1+zhG8lc0=
 github.com/rancher/wrangler v0.8.3/go.mod h1:dKEaHNB4izxmPUtpq1Hvr3z3Oh+9k5pCZyFO9sUhlaY=
-github.com/rancher/wrangler v0.8.4-0.20210729214659-5e75fca61cb2 h1:ja7zS/MtLRAs4ZgCIlocJg3c74qWpvRneQWEkSF3g9Q=
-github.com/rancher/wrangler v0.8.4-0.20210729214659-5e75fca61cb2/go.mod h1:dKEaHNB4izxmPUtpq1Hvr3z3Oh+9k5pCZyFO9sUhlaY=
+github.com/rancher/wrangler v0.8.4 h1:aGMqLQHtn9yB8vw584TO8x/tvZMiaY7Yyi37Fp22UFU=
+github.com/rancher/wrangler v0.8.4/go.mod h1:dKEaHNB4izxmPUtpq1Hvr3z3Oh+9k5pCZyFO9sUhlaY=
 github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e/go.mod h1:2lcWR98q8HU3U4mVETnXc8quNG0uXxrt8vKd6cAa/30=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/pkg/controllers/management/authprovisioningv2/binding.go
+++ b/pkg/controllers/management/authprovisioningv2/binding.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (h *handler) OnCRTB(key string, crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
-	if crtb == nil || (crtb.UserName == "" && crtb.GroupName == "") || crtb.RoleTemplateName == "" {
+	if crtb == nil || crtb.DeletionTimestamp != nil || (crtb.UserName == "" && crtb.GroupName == "") || crtb.RoleTemplateName == "" {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Problem:
The roleBindings for provisioning clusters were not being cleaned up
when the CRTB that triggered the creation was deleted

Solution:
Add a cleanup in the CRTB remove finalizer to go find all dependent
roleBindings and delete them.

https://github.com/rancher/rancher/issues/32414