### PR TITLE
WIP: Add hostname prefix validation to ha deploy

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -28,42 +28,42 @@ DEFAULT_APP_DELETION_TIMEOUT = 360
 DEFAULT_APP_V2_TIMEOUT = 60
 
 CATTLE_API_URL = CATTLE_TEST_URL + "/v3"
-CATTLE_AUTH_URL = \
-    CATTLE_TEST_URL + "/v3-public/localproviders/local?action=login"
+CATTLE_AUTH_URL = CATTLE_TEST_URL + "/v3-public/localproviders/local?action=login"
 
 DNS_REGEX = "(https*://)(.*[^/])"
 
-USER_PASSWORD = os.environ.get('USER_PASSWORD', "None")
-ADMIN_PASSWORD = os.environ.get('ADMIN_PASSWORD', "None")
+USER_PASSWORD = os.environ.get("USER_PASSWORD", "None")
+ADMIN_PASSWORD = os.environ.get("ADMIN_PASSWORD", "None")
 
-kube_fname = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                          "k8s_kube_config")
-MACHINE_TIMEOUT = float(os.environ.get('RANCHER_MACHINE_TIMEOUT', "1200"))
+kube_fname = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "k8s_kube_config"
+)
+MACHINE_TIMEOUT = float(os.environ.get("RANCHER_MACHINE_TIMEOUT", "1200"))
 
-HARDENED_CLUSTER = ast.literal_eval(
-    os.environ.get('RANCHER_HARDENED_CLUSTER', "False"))
-TEST_OS = os.environ.get('RANCHER_TEST_OS', "linux")
-TEST_IMAGE = os.environ.get('RANCHER_TEST_IMAGE', "ranchertest/mytestcontainer")
-TEST_IMAGE_PORT = os.environ.get('RANCHER_TEST_IMAGE_PORT', "80")
-TEST_IMAGE_NGINX = os.environ.get('RANCHER_TEST_IMAGE_NGINX', "nginx")
-TEST_IMAGE_OS_BASE = os.environ.get('RANCHER_TEST_IMAGE_OS_BASE', "ubuntu")
+HARDENED_CLUSTER = ast.literal_eval(os.environ.get("RANCHER_HARDENED_CLUSTER", "False"))
+TEST_OS = os.environ.get("RANCHER_TEST_OS", "linux")
+TEST_IMAGE = os.environ.get("RANCHER_TEST_IMAGE", "ranchertest/mytestcontainer")
+TEST_IMAGE_PORT = os.environ.get("RANCHER_TEST_IMAGE_PORT", "80")
+TEST_IMAGE_NGINX = os.environ.get("RANCHER_TEST_IMAGE_NGINX", "nginx")
+TEST_IMAGE_OS_BASE = os.environ.get("RANCHER_TEST_IMAGE_OS_BASE", "ubuntu")
 if TEST_OS == "windows":
     DEFAULT_TIMEOUT = 300
 skip_test_windows_os = pytest.mark.skipif(
-    TEST_OS == "windows",
-    reason='Tests Skipped for including Windows nodes cluster')
+    TEST_OS == "windows", reason="Tests Skipped for including Windows nodes cluster"
+)
 skip_test_hardened = pytest.mark.skipif(
-    HARDENED_CLUSTER,
-    reason='Tests Skipped due to being a hardened cluster')
+    HARDENED_CLUSTER, reason="Tests Skipped due to being a hardened cluster"
+)
 
-UPDATE_KDM = ast.literal_eval(os.environ.get('RANCHER_UPDATE_KDM', "False"))
+UPDATE_KDM = ast.literal_eval(os.environ.get("RANCHER_UPDATE_KDM", "False"))
 KDM_URL = os.environ.get("RANCHER_KDM_URL", "")
 CLUSTER_NAME = os.environ.get("RANCHER_CLUSTER_NAME", "")
-RANCHER_CLEANUP_CLUSTER = \
-    ast.literal_eval(os.environ.get('RANCHER_CLEANUP_CLUSTER', "True"))
+RANCHER_CLEANUP_CLUSTER = ast.literal_eval(
+    os.environ.get("RANCHER_CLEANUP_CLUSTER", "True")
+)
 env_file = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)),
-    "rancher_env.config")
+    os.path.dirname(os.path.realpath(__file__)), "rancher_env.config"
+)
 
 AWS_SSH_KEY_NAME = os.environ.get("AWS_SSH_KEY_NAME")
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
@@ -76,23 +76,21 @@ AWS_ZONE = os.environ.get("AWS_ZONE")
 AWS_IAM_PROFILE = os.environ.get("AWS_IAM_PROFILE", "")
 AWS_S3_BUCKET_NAME = os.environ.get("AWS_S3_BUCKET_NAME", "")
 AWS_S3_BUCKET_FOLDER_NAME = os.environ.get("AWS_S3_BUCKET_FOLDER_NAME", "")
-LINODE_ACCESSKEY = os.environ.get('RANCHER_LINODE_ACCESSKEY', "None")
+LINODE_ACCESSKEY = os.environ.get("RANCHER_LINODE_ACCESSKEY", "None")
 NFS_SERVER_MOUNT_PATH = "/nfs"
 
-TEST_RBAC = ast.literal_eval(os.environ.get('RANCHER_TEST_RBAC', "False"))
-if_test_rbac = pytest.mark.skipif(TEST_RBAC is False,
-                                  reason='rbac tests are skipped')
+TEST_RBAC = ast.literal_eval(os.environ.get("RANCHER_TEST_RBAC", "False"))
+if_test_rbac = pytest.mark.skipif(TEST_RBAC is False, reason="rbac tests are skipped")
 
 TEST_ALL_SNAPSHOT = ast.literal_eval(
-    os.environ.get('RANCHER_TEST_ALL_SNAPSHOT', "False")
+    os.environ.get("RANCHER_TEST_ALL_SNAPSHOT", "False")
 )
-if_test_all_snapshot = \
-    pytest.mark.skipif(TEST_ALL_SNAPSHOT is False,
-                       reason='Snapshots check tests are skipped')
-DATA_SUBDIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                           'resource')
+if_test_all_snapshot = pytest.mark.skipif(
+    TEST_ALL_SNAPSHOT is False, reason="Snapshots check tests are skipped"
+)
+DATA_SUBDIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "resource")
 # As of release 2.4 default rke scan profile is "rke-cis-1.4"
-CIS_SCAN_PROFILE = os.environ.get('RANCHER_CIS_SCAN_PROFILE', "rke-cis-1.4")
+CIS_SCAN_PROFILE = os.environ.get("RANCHER_CIS_SCAN_PROFILE", "rke-cis-1.4")
 
 # here are all supported roles for RBAC testing
 CLUSTER_MEMBER = "cluster-member"
@@ -114,14 +112,10 @@ rbac_data = {
         PROJECT_OWNER: {},
         PROJECT_MEMBER: {},
         PROJECT_READ_ONLY: {},
-    }
+    },
 }
 
-auth_rbac_data = {
-    "project": None,
-    "namespace": None,
-    "users": {}
-}
+auth_rbac_data = {"project": None, "namespace": None, "users": {}}
 
 # here are the global role templates used for
 # testing globalRoleBinding and groupRoleBinding
@@ -130,17 +124,9 @@ TEMPLATE_MANAGE_CATALOG = {
     "rules": [
         {
             "type": "/v3/schemas/policyRule",
-            "apiGroups": [
-                "management.cattle.io"
-            ],
-            "verbs": [
-                "*"
-            ],
-            "resources": [
-                "catalogs",
-                "templates",
-                "templateversions"
-            ]
+            "apiGroups": ["management.cattle.io"],
+            "verbs": ["*"],
+            "resources": ["catalogs", "templates", "templateversions"],
         }
     ],
     "name": "gr-test-manage-catalog",
@@ -151,66 +137,73 @@ TEMPLATE_LIST_CLUSTER = {
     "rules": [
         {
             "type": "/v3/schemas/policyRule",
-            "apiGroups": [
-                "management.cattle.io"
-            ],
-            "verbs": [
-                "get",
-                "list",
-                "watch"
-            ],
-            "resources": [
-                "clusters"
-            ]
+            "apiGroups": ["management.cattle.io"],
+            "verbs": ["get", "list", "watch"],
+            "resources": ["clusters"],
         }
     ],
     "name": "gr-test-list-cluster",
 }
 
 # this is used when testing users from a auth provider
-AUTH_PROVIDER = os.environ.get('RANCHER_AUTH_PROVIDER', "")
+AUTH_PROVIDER = os.environ.get("RANCHER_AUTH_PROVIDER", "")
 if AUTH_PROVIDER not in ["activeDirectory", "freeIpa", "openLdap", ""]:
-    pytest.fail("Invalid RANCHER_AUTH_PROVIDER. Please provide one of: "
-                "activeDirectory, freeIpa, or openLdap (case sensitive).")
+    pytest.fail(
+        "Invalid RANCHER_AUTH_PROVIDER. Please provide one of: "
+        "activeDirectory, freeIpa, or openLdap (case sensitive)."
+    )
 NESTED_GROUP_ENABLED = ast.literal_eval(
-    os.environ.get('RANCHER_NESTED_GROUP_ENABLED', "False"))
+    os.environ.get("RANCHER_NESTED_GROUP_ENABLED", "False")
+)
 # Admin Auth username and the shared password for all auth users
-AUTH_USER_PASSWORD = os.environ.get('RANCHER_AUTH_USER_PASSWORD', "")
+AUTH_USER_PASSWORD = os.environ.get("RANCHER_AUTH_USER_PASSWORD", "")
 
 # the link to log in as an auth user
-LOGIN_AS_AUTH_USER_URL = \
-    CATTLE_TEST_URL + "/v3-public/" \
-    + AUTH_PROVIDER + "Providers/" \
-    + AUTH_PROVIDER.lower() + "?action=login"
+LOGIN_AS_AUTH_USER_URL = (
+    CATTLE_TEST_URL
+    + "/v3-public/"
+    + AUTH_PROVIDER
+    + "Providers/"
+    + AUTH_PROVIDER.lower()
+    + "?action=login"
+)
 CATTLE_AUTH_PRINCIPAL_URL = CATTLE_TEST_URL + "/v3/principals?action=search"
 
 # This is used for nested group when a third part Auth is enabled
-nested_group = {
-    "auth_info": None,
-    "users": None,
-    "group_dic": None,
-    "groups": None
-}
+nested_group = {"auth_info": None, "users": None, "group_dic": None, "groups": None}
 auth_requirements = not AUTH_PROVIDER or not AUTH_USER_PASSWORD
 if_test_group_rbac = pytest.mark.skipif(
     auth_requirements,
-    reason='Group RBAC tests are skipped.'
-           'Required AUTH env variables '
-           'have not been set.'
+    reason="Group RBAC tests are skipped."
+    "Required AUTH env variables "
+    "have not been set.",
 )
 
 # -----------------------------------------------------------------------------
 # global variables from test_create_ha.py
+
+
+class InvalidConfigurationError(Exception):
+    """
+    Raise this if there are issues with any of the configuration inputs.
+    """
+
+    pass
+
+
 test_run_id = "test" + str(random.randint(10000, 99999))
-RANCHER_HOSTNAME_PREFIX = os.environ.get("RANCHER_HOSTNAME_PREFIX",
-                                         test_run_id)
+RANCHER_HOSTNAME_PREFIX = os.environ.get("RANCHER_HOSTNAME_PREFIX", test_run_id).lower()
+if "-" in RANCHER_HOSTNAME_PREFIX:
+    raise InvalidConfigurationError("invalid char(s) found in hostname prefix")
+
 CERT_MANAGER_VERSION = os.environ.get("RANCHER_CERT_MANAGER_VERSION", "v1.0.1")
 # -----------------------------------------------------------------------------
 
 # this is used for testing rbac v2
 test_rbac_v2 = os.environ.get("RANCHER_TEST_RBAC_V2", "False")
-if_test_rbac_v2 = pytest.mark.skipif(test_rbac_v2 != "True",
-                                     reason='test for rbac v2 is skipped')
+if_test_rbac_v2 = pytest.mark.skipif(
+    test_rbac_v2 != "True", reason="test for rbac v2 is skipped"
+)
 
 
 def is_windows(os_type=TEST_OS):
@@ -235,19 +228,19 @@ def get_client_for_token(token, url=CATTLE_API_URL):
 
 
 def get_project_client_for_token(project, token):
-    p_url = project.links['self'] + '/schemas'
+    p_url = project.links["self"] + "/schemas"
     p_client = rancher.Client(url=p_url, token=token, verify=False)
     return p_client
 
 
 def get_cluster_client_for_token(cluster, token):
-    c_url = cluster.links['self'] + '/schemas'
+    c_url = cluster.links["self"] + "/schemas"
     c_client = rancher.Client(url=c_url, token=token, verify=False)
     return c_client
 
 
 def up(cluster, token):
-    c_url = cluster.links['self'] + '/schemas'
+    c_url = cluster.links["self"] + "/schemas"
     c_client = rancher.Client(url=c_url, token=token, verify=False)
     return c_client
 
@@ -257,26 +250,30 @@ def wait_state(client, obj, state, timeout=DEFAULT_TIMEOUT):
     return client.reload(obj)
 
 
-def wait_for_condition(client, resource, check_function, fail_handler=None,
-                       timeout=DEFAULT_TIMEOUT):
+def wait_for_condition(
+    client, resource, check_function, fail_handler=None, timeout=DEFAULT_TIMEOUT
+):
     start = time.time()
     resource = client.reload(resource)
     while not check_function(resource):
         if time.time() - start > timeout:
-            exceptionMsg = 'Timeout waiting for ' + resource.baseType + \
-                           ' to satisfy condition: ' + \
-                           inspect.getsource(check_function)
+            exceptionMsg = (
+                "Timeout waiting for "
+                + resource.baseType
+                + " to satisfy condition: "
+                + inspect.getsource(check_function)
+            )
             if fail_handler:
                 exceptionMsg = exceptionMsg + fail_handler(resource)
             raise Exception(exceptionMsg)
-        time.sleep(.5)
+        time.sleep(0.5)
         resource = client.reload(resource)
     return resource
 
 
 def get_setting_value_by_name(name):
     settings_url = CATTLE_API_URL + "/settings/" + name
-    head = {'Authorization': 'Bearer ' + ADMIN_TOKEN}
+    head = {"Authorization": "Bearer " + ADMIN_TOKEN}
     response = requests.get(settings_url, verify=False, headers=head)
     return response.json()["value"]
 
@@ -292,7 +289,7 @@ def compare_versions(v1, v2):
 
 
 def create_project_and_ns(token, cluster, project_name=None, ns_name=None):
-    server_url = cluster.links['self'].split("/clusters")[0]
+    server_url = cluster.links["self"].split("/clusters")[0]
     client = get_client_for_token(token, server_url)
     p = create_project(client, cluster, project_name)
     c_client = get_cluster_client_for_token(cluster, token)
@@ -303,38 +300,36 @@ def create_project_and_ns(token, cluster, project_name=None, ns_name=None):
 def create_project(client, cluster, project_name=None):
     if project_name is None:
         project_name = random_name()
-    p = client.create_project(name=project_name,
-                              clusterId=cluster.id)
+    p = client.create_project(name=project_name, clusterId=cluster.id)
     time.sleep(5)
     p = wait_until_available(client, p)
-    assert p.state == 'active'
+    assert p.state == "active"
     return p
 
 
 def create_project_with_pspt(client, cluster, pspt):
-    p = client.create_project(name=random_name(),
-                              clusterId=cluster.id)
+    p = client.create_project(name=random_name(), clusterId=cluster.id)
     p = wait_until_available(client, p)
-    assert p.state == 'active'
+    assert p.state == "active"
     return set_pspt_for_project(p, client, pspt)
 
 
 def set_pspt_for_project(project, client, pspt):
     project.setpodsecuritypolicytemplate(podSecurityPolicyTemplateId=pspt.id)
     project = wait_until_available(client, project)
-    assert project.state == 'active'
+    assert project.state == "active"
     return project
 
 
 def create_ns(client, cluster, project, ns_name=None):
     if ns_name is None:
         ns_name = random_name()
-    ns = client.create_namespace(name=ns_name,
-                                 clusterId=cluster.id,
-                                 projectId=project.id)
+    ns = client.create_namespace(
+        name=ns_name, clusterId=cluster.id, projectId=project.id
+    )
     wait_for_ns_to_become_active(client, ns)
     ns = client.reload(ns)
-    assert ns.state == 'active'
+    assert ns.state == "active"
     return ns
 
 
@@ -343,7 +338,8 @@ def assign_members_to_cluster(client, user, cluster, role_template_id):
         clusterId=cluster.id,
         roleTemplateId=role_template_id,
         subjectKind="User",
-        userId=user.id)
+        userId=user.id,
+    )
     return crtb
 
 
@@ -352,23 +348,18 @@ def assign_members_to_project(client, user, project, role_template_id):
         projectId=project.id,
         roleTemplateId=role_template_id,
         subjectKind="User",
-        userId=user.id)
+        userId=user.id,
+    )
     return prtb
 
 
 def change_member_role_in_cluster(client, user, crtb, role_template_id):
-    crtb = client.update(
-        crtb,
-        roleTemplateId=role_template_id,
-        userId=user.id)
+    crtb = client.update(crtb, roleTemplateId=role_template_id, userId=user.id)
     return crtb
 
 
 def change_member_role_in_project(client, user, prtb, role_template_id):
-    prtb = client.update(
-        prtb,
-        roleTemplateId=role_template_id,
-        userId=user.id)
+    prtb = client.update(prtb, roleTemplateId=role_template_id, userId=user.id)
     return prtb
 
 
@@ -388,11 +379,16 @@ def validate_psp_error_worklaod(p_client, workload, error_message):
     assert error_message in workload.transitioningMessage
 
 
-def validate_all_workload_image_from_rancher(project_client, ns, pod_count=1,
-                                             ignore_pod_count=False,
-                                             deployment_list=None,
-                                             daemonset_list=None,
-                                             cronjob_list=None, job_list=None):
+def validate_all_workload_image_from_rancher(
+    project_client,
+    ns,
+    pod_count=1,
+    ignore_pod_count=False,
+    deployment_list=None,
+    daemonset_list=None,
+    cronjob_list=None,
+    job_list=None,
+):
     if cronjob_list is None:
         cronjob_list = []
     if daemonset_list is None:
@@ -404,46 +400,77 @@ def validate_all_workload_image_from_rancher(project_client, ns, pod_count=1,
     workload_list = deployment_list + daemonset_list + cronjob_list + job_list
 
     wls = [dep.name for dep in project_client.list_workload(namespaceId=ns.id).data]
-    assert len(workload_list) == len(wls), \
-        "Expected {} workload(s) to be present in {} namespace " \
+    assert len(workload_list) == len(wls), (
+        "Expected {} workload(s) to be present in {} namespace "
         "but there were {}".format(len(workload_list), ns.name, len(wls))
+    )
 
     for workload_name in workload_list:
-        workloads = project_client.list_workload(name=workload_name,
-                                                 namespaceId=ns.id).data
-        assert len(workloads) == workload_list.count(workload_name), \
-            "Expected {} workload(s) to be present with name {} " \
-            "but there were {}".format(workload_list.count(workload_name),
-                                       workload_name, len(workloads))
+        workloads = project_client.list_workload(
+            name=workload_name, namespaceId=ns.id
+        ).data
+        assert len(workloads) == workload_list.count(workload_name), (
+            "Expected {} workload(s) to be present with name {} "
+            "but there were {}".format(
+                workload_list.count(workload_name), workload_name, len(workloads)
+            )
+        )
         for workload in workloads:
             for container in workload.containers:
                 assert str(container.image).startswith("rancher/")
             if workload_name in deployment_list:
-                validate_workload(project_client, workload, "deployment",
-                                  ns.name, pod_count=pod_count,
-                                  ignore_pod_count=ignore_pod_count)
+                validate_workload(
+                    project_client,
+                    workload,
+                    "deployment",
+                    ns.name,
+                    pod_count=pod_count,
+                    ignore_pod_count=ignore_pod_count,
+                )
                 deployment_list.remove(workload_name)
             if workload_name in daemonset_list:
-                validate_workload(project_client, workload, "daemonSet",
-                                  ns.name, pod_count=pod_count,
-                                  ignore_pod_count=ignore_pod_count)
+                validate_workload(
+                    project_client,
+                    workload,
+                    "daemonSet",
+                    ns.name,
+                    pod_count=pod_count,
+                    ignore_pod_count=ignore_pod_count,
+                )
                 daemonset_list.remove(workload_name)
             if workload_name in cronjob_list:
-                validate_workload(project_client, workload, "cronJob",
-                                  ns.name, pod_count=pod_count,
-                                  ignore_pod_count=ignore_pod_count)
+                validate_workload(
+                    project_client,
+                    workload,
+                    "cronJob",
+                    ns.name,
+                    pod_count=pod_count,
+                    ignore_pod_count=ignore_pod_count,
+                )
                 cronjob_list.remove(workload_name)
             if workload_name in job_list:
-                validate_workload(project_client, workload, "job",
-                                  ns.name, pod_count=pod_count,
-                                  ignore_pod_count=ignore_pod_count)
+                validate_workload(
+                    project_client,
+                    workload,
+                    "job",
+                    ns.name,
+                    pod_count=pod_count,
+                    ignore_pod_count=ignore_pod_count,
+                )
                 job_list.remove(workload_name)
     # Final assertion to ensure all expected workloads have been validated
     assert not deployment_list + daemonset_list + cronjob_list
 
 
-def validate_workload(p_client, workload, type, ns_name, pod_count=1,
-                      wait_for_cron_pods=60, ignore_pod_count=False):
+def validate_workload(
+    p_client,
+    workload,
+    type,
+    ns_name,
+    pod_count=1,
+    wait_for_cron_pods=60,
+    ignore_pod_count=False,
+):
     workload = wait_for_wl_to_active(p_client, workload)
     assert workload.state == "active"
     # For cronjob, wait for the first pod to get created after
@@ -467,9 +494,9 @@ def validate_workload(p_client, workload, type, ns_name, pod_count=1,
         p = wait_for_pod_to_running(p_client, pod, job_type=job_type)
         assert p["status"]["phase"] == expected_status
 
-
     wl_result = execute_kubectl_cmd(
-        "get " + type + " " + workload.name + " -n " + ns_name)
+        "get " + type + " " + workload.name + " -n " + ns_name
+    )
     if type == "deployment" or type == "statefulSet":
         assert wl_result["status"]["readyReplicas"] == len(pods)
     if type == "daemonSet":
@@ -480,8 +507,7 @@ def validate_workload(p_client, workload, type, ns_name, pod_count=1,
         assert wl_result["status"]["succeeded"] == len(pods)
 
 
-def validate_workload_with_sidekicks(p_client, workload, type, ns_name,
-                                     pod_count=1):
+def validate_workload_with_sidekicks(p_client, workload, type, ns_name, pod_count=1):
     workload = wait_for_wl_to_active(p_client, workload)
     assert workload.state == "active"
     pods = wait_for_pods_in_workload(p_client, workload, pod_count)
@@ -489,7 +515,8 @@ def validate_workload_with_sidekicks(p_client, workload, type, ns_name,
     for pod in pods:
         wait_for_pod_to_running(p_client, pod)
     wl_result = execute_kubectl_cmd(
-        "get " + type + " " + workload.name + " -n " + ns_name)
+        "get " + type + " " + workload.name + " -n " + ns_name
+    )
     assert wl_result["status"]["readyReplicas"] == pod_count
     for key, value in workload.workloadLabels.items():
         label = key + "=" + value
@@ -539,12 +566,10 @@ def validate_workload_image(client, workload, expectedImage, ns):
     validate_pod_images(expectedImage, workload, ns.name)
 
 
-def execute_kubectl_cmd(cmd, json_out=True, stderr=False,
-                        kubeconfig=kube_fname):
-    command = 'kubectl --kubeconfig {0} {1}'.format(
-        kubeconfig, cmd)
+def execute_kubectl_cmd(cmd, json_out=True, stderr=False, kubeconfig=kube_fname):
+    command = "kubectl --kubeconfig {0} {1}".format(kubeconfig, cmd)
     if json_out:
-        command += ' -o json'
+        command += " -o json"
     print("run cmd: \t{0}".format(command))
 
     if stderr:
@@ -573,8 +598,7 @@ def run_command_with_stderr(command, log_out=True):
         print("run cmd: \t{0}".format(command))
 
     try:
-        output = subprocess.check_output(command, shell=True,
-                                         stderr=subprocess.PIPE)
+        output = subprocess.check_output(command, shell=True, stderr=subprocess.PIPE)
         returncode = 0
     except subprocess.CalledProcessError as e:
         output = e.stderr
@@ -595,9 +619,8 @@ def wait_for_wl_to_active(client, workload, timeout=DEFAULT_TIMEOUT):
     wl = workloads[0]
     while wl.state != "active":
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to active")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to active")
+        time.sleep(0.5)
         workloads = client.list_workload(uuid=workload.uuid).data
         assert len(workloads) == 1
         wl = workloads[0]
@@ -611,26 +634,23 @@ def wait_for_ingress_to_active(client, ingress, timeout=DEFAULT_TIMEOUT):
     wl = ingresses[0]
     while wl.state != "active":
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to active")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to active")
+        time.sleep(0.5)
         ingresses = client.list_ingress(uuid=ingress.uuid).data
         assert len(ingresses) == 1
         wl = ingresses[0]
     return wl
 
 
-def wait_for_wl_transitioning(client, workload, timeout=DEFAULT_TIMEOUT,
-                              state="error"):
+def wait_for_wl_transitioning(client, workload, timeout=DEFAULT_TIMEOUT, state="error"):
     start = time.time()
     workloads = client.list_workload(uuid=workload.uuid).data
     assert len(workloads) == 1
     wl = workloads[0]
     while wl.transitioning != state:
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to active")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to active")
+        time.sleep(0.5)
         workloads = client.list_workload(uuid=workload.uuid).data
         assert len(workloads) == 1
         wl = workloads[0]
@@ -646,11 +666,10 @@ def wait_for_pod_to_running(client, pod, timeout=DEFAULT_TIMEOUT, job_type=False
         expected_state = "succeeded"
     else:
         expected_state = "running"
-    while p.state != expected_state :
+    while p.state != expected_state:
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to active")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to active")
+        time.sleep(0.5)
         pods = client.list_pod(uuid=pod.uuid).data
         assert len(pods) == 1
         p = pods[0]
@@ -666,12 +685,15 @@ def get_schedulable_nodes(cluster, client=None, os_type=TEST_OS):
         if node.worker and (not node.unschedulable):
             for key, val in node.labels.items():
                 # Either one of the labels should be present on the node
-                if key == 'kubernetes.io/os' or key == 'beta.kubernetes.io/os':
+                if key == "kubernetes.io/os" or key == "beta.kubernetes.io/os":
                     if val == os_type:
                         schedulable_nodes.append(node)
                         break
         # Including master in list of nodes as master is also schedulable
-        if ('k3s' in cluster.version["gitVersion"] or 'rke2' in cluster.version["gitVersion"]) and node.controlPlane:
+        if (
+            "k3s" in cluster.version["gitVersion"]
+            or "rke2" in cluster.version["gitVersion"]
+        ) and node.controlPlane:
             schedulable_nodes.append(node)
     return schedulable_nodes
 
@@ -711,11 +733,10 @@ def get_role_nodes(cluster, role, client=None):
     return node_list
 
 
-def validate_ingress(p_client, cluster, workloads, host, path,
-                     insecure_redirect=False):
+def validate_ingress(p_client, cluster, workloads, host, path, insecure_redirect=False):
     time.sleep(10)
     curl_args = " "
-    if (insecure_redirect):
+    if insecure_redirect:
         curl_args = " -L --insecure "
     if len(host) > 0:
         curl_args += " --header 'Host: " + host + "'"
@@ -725,36 +746,34 @@ def validate_ingress(p_client, cluster, workloads, host, path,
         host_ip = resolve_node_ip(node)
         url = "http://" + host_ip + path
         if not insecure_redirect:
-            wait_until_ok(url, timeout=300, headers={
-                "Host": host
-            })
+            wait_until_ok(url, timeout=300, headers={"Host": host})
         cmd = curl_args + " " + url
         validate_http_response(cmd, target_name_list)
 
 
-def validate_ingress_using_endpoint(p_client, ingress, workloads,
-                                    timeout=300,
-                                    certcheck=False, is_insecure=False):
+def validate_ingress_using_endpoint(
+    p_client, ingress, workloads, timeout=300, certcheck=False, is_insecure=False
+):
     target_name_list = get_target_names(p_client, workloads)
     start = time.time()
     fqdn_available = False
     url = None
     while not fqdn_available:
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for endpoint to be available")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for endpoint to be available")
+        time.sleep(0.5)
         ingress_list = p_client.list_ingress(uuid=ingress.uuid).data
         assert len(ingress_list) == 1
         ingress = ingress_list[0]
-        if hasattr(ingress, 'publicEndpoints'):
+        if hasattr(ingress, "publicEndpoints"):
             for public_endpoint in ingress.publicEndpoints:
-                if public_endpoint["hostname"].startswith(ingress.name) \
-                        or certcheck:
+                if public_endpoint["hostname"].startswith(ingress.name) or certcheck:
                     fqdn_available = True
-                    url = \
-                        public_endpoint["protocol"].lower() + "://" + \
-                        public_endpoint["hostname"]
+                    url = (
+                        public_endpoint["protocol"].lower()
+                        + "://"
+                        + public_endpoint["hostname"]
+                    )
                     if "path" in public_endpoint.keys():
                         url += public_endpoint["path"]
     time.sleep(10)
@@ -779,13 +798,12 @@ def get_endpoint_url_for_workload(p_client, workload, timeout=600):
     start = time.time()
     while not fqdn_available:
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for endpoint to be available")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for endpoint to be available")
+        time.sleep(0.5)
         workload_list = p_client.list_workload(uuid=workload.uuid).data
         assert len(workload_list) == 1
         workload = workload_list[0]
-        if hasattr(workload, 'publicEndpoints'):
+        if hasattr(workload, "publicEndpoints"):
             assert len(workload.publicEndpoints) > 0
             url = "http://"
             url = url + workload.publicEndpoints[0]["addresses"][0] + ":"
@@ -797,10 +815,10 @@ def get_endpoint_url_for_workload(p_client, workload, timeout=600):
 def wait_until_lb_is_active(url, timeout=300):
     start = time.time()
     while check_for_no_access(url):
-        time.sleep(.5)
+        time.sleep(0.5)
         print("No access yet")
         if time.time() - start > timeout:
-            raise Exception('Timed out waiting for LB to become active')
+            raise Exception("Timed out waiting for LB to become active")
     return
 
 
@@ -816,22 +834,19 @@ def check_for_no_access(url, verify=False):
 def wait_until_active(url, timeout=120):
     start = time.time()
     while check_for_no_access(url):
-        time.sleep(.5)
+        time.sleep(0.5)
         print("No access yet")
         if time.time() - start > timeout:
-            raise Exception('Timed out waiting for url '
-                            'to become active')
+            raise Exception("Timed out waiting for url " "to become active")
     return
 
 
 def wait_until_ok(url, timeout=120, headers={}):
     start = time.time()
     while not check_if_ok(url, headers=headers):
-        time.sleep(.5)
+        time.sleep(0.5)
         if time.time() - start > timeout:
-            raise Exception(
-                'Timed out waiting for {0} to become ok'.format(url)
-            )
+            raise Exception("Timed out waiting for {0} to become ok".format(url))
     return
 
 
@@ -843,10 +858,8 @@ def wait_for_status_code(url, expected_code=200, timeout=DEFAULT_TIMEOUT):
         r = requests.get(url, verify=False)
         if time.time() - start > timeout:
             raise Exception(
-                'Timed out waiting for status code {0}'
-                ', actual code {1}'.format(
-                    expected_code, r.status_code
-                )
+                "Timed out waiting for status code {0}"
+                ", actual code {1}".format(expected_code, r.status_code)
             )
     return
 
@@ -862,8 +875,7 @@ def check_if_ok(url, verify=False, headers={}):
         return False
 
 
-def validate_http_response(cmd, target_name_list, client_pod=None,
-                           insecure=False):
+def validate_http_response(cmd, target_name_list, client_pod=None, insecure=False):
     if client_pod is None and cmd.startswith("http://"):
         wait_until_active(cmd, 60)
     target_hit_list = target_name_list[:]
@@ -878,9 +890,11 @@ def validate_http_response(cmd, target_name_list, client_pod=None,
             result = run_command(curl_cmd)
         else:
             if is_windows():
-                wget_cmd = 'powershell -NoLogo -NonInteractive -Command ' \
-                           '"& {{ (Invoke-WebRequest -UseBasicParsing -Uri ' \
-                           '{0}).Content }}"'.format(cmd)
+                wget_cmd = (
+                    "powershell -NoLogo -NonInteractive -Command "
+                    '"& {{ (Invoke-WebRequest -UseBasicParsing -Uri '
+                    '{0}).Content }}"'.format(cmd)
+                )
             else:
                 wget_cmd = "wget -qO- " + cmd
             result = kubectl_pod_exec(client_pod, wget_cmd)
@@ -894,47 +908,58 @@ def validate_http_response(cmd, target_name_list, client_pod=None,
     assert len(target_hit_list) == 0
 
 
-def validate_cluster(client, cluster, intermediate_state="provisioning",
-                     check_intermediate_state=True, skipIngresscheck=True,
-                     nodes_not_in_active_state=[], k8s_version="",
-                     userToken=USER_TOKEN, timeout=MACHINE_TIMEOUT):
+def validate_cluster(
+    client,
+    cluster,
+    intermediate_state="provisioning",
+    check_intermediate_state=True,
+    skipIngresscheck=True,
+    nodes_not_in_active_state=[],
+    k8s_version="",
+    userToken=USER_TOKEN,
+    timeout=MACHINE_TIMEOUT,
+):
     # Allow sometime for the "cluster_owner" CRTB to take effect
     time.sleep(5)
     cluster = validate_cluster_state(
-        client, cluster,
+        client,
+        cluster,
         check_intermediate_state=check_intermediate_state,
         intermediate_state=intermediate_state,
         nodes_not_in_active_state=nodes_not_in_active_state,
-        timeout=timeout)
+        timeout=timeout,
+    )
     create_kubeconfig(cluster)
     if k8s_version != "":
         check_cluster_version(cluster, k8s_version)
-    if hasattr(cluster, 'rancherKubernetesEngineConfig'):
+    if hasattr(cluster, "rancherKubernetesEngineConfig"):
         check_cluster_state(len(get_role_nodes(cluster, "etcd", client)))
     # check all workloads under the system project are active
     # wait for workloads to be active
     # time.sleep(DEFAULT_TIMEOUT)
     print("checking if workloads under the system project are active")
-    sys_project = client.list_project(name='System',
-                                      clusterId=cluster.id).data[0]
+    sys_project = client.list_project(name="System", clusterId=cluster.id).data[0]
     sys_p_client = get_project_client_for_token(sys_project, userToken)
     for wl in sys_p_client.list_workload().data:
-        """to  help run KDM job faster (when there are many clusters), 
+        """to  help run KDM job faster (when there are many clusters),
         timeout=300 is set"""
         wait_for_wl_to_active(sys_p_client, wl, timeout=300)
     # Create Daemon set workload and have an Ingress with Workload
     # rule pointing to this daemonSet
     project, ns = create_project_and_ns(userToken, cluster)
     p_client = get_project_client_for_token(project, userToken)
-    con = [{"name": "test1",
-            "image": TEST_IMAGE}]
+    con = [{"name": "test1", "image": TEST_IMAGE}]
     name = random_test_name("default")
-    workload = p_client.create_workload(name=name,
-                                        containers=con,
-                                        namespaceId=ns.id,
-                                        daemonSetConfig={})
-    validate_workload(p_client, workload, "daemonSet", ns.name,
-                      len(get_schedulable_nodes(cluster, client)))
+    workload = p_client.create_workload(
+        name=name, containers=con, namespaceId=ns.id, daemonSetConfig={}
+    )
+    validate_workload(
+        p_client,
+        workload,
+        "daemonSet",
+        ns.name,
+        len(get_schedulable_nodes(cluster, client)),
+    )
     if not skipIngresscheck:
         pods = p_client.list_pod(workloadId=workload["id"]).data
         scale = len(pods)
@@ -942,31 +967,29 @@ def validate_cluster(client, cluster, intermediate_state="provisioning",
         validate_service_discovery(workload, scale, p_client, ns, pods)
         host = "test" + str(random_int(10000, 99999)) + ".com"
         path = "/name.html"
-        rule = {"host": host,
-                "paths":
-                    [{"workloadIds": [workload.id],
-                      "targetPort": TEST_IMAGE_PORT}]}
-        ingress = p_client.create_ingress(name=name,
-                                          namespaceId=ns.id,
-                                          rules=[rule])
+        rule = {
+            "host": host,
+            "paths": [{"workloadIds": [workload.id], "targetPort": TEST_IMAGE_PORT}],
+        }
+        ingress = p_client.create_ingress(name=name, namespaceId=ns.id, rules=[rule])
         wait_for_ingress_to_active(p_client, ingress)
         validate_ingress(p_client, cluster, [workload], host, path)
     return cluster
 
 
 def check_cluster_version(cluster, version):
-    cluster_k8s_version = \
-        cluster.appliedSpec["rancherKubernetesEngineConfig"][
-            "kubernetesVersion"]
-    assert cluster_k8s_version == version, \
-        "cluster_k8s_version: " + cluster_k8s_version + \
-        " Expected: " + version
-    expected_k8s_version = version[:version.find("-rancher")]
+    cluster_k8s_version = cluster.appliedSpec["rancherKubernetesEngineConfig"][
+        "kubernetesVersion"
+    ]
+    assert cluster_k8s_version == version, (
+        "cluster_k8s_version: " + cluster_k8s_version + " Expected: " + version
+    )
+    expected_k8s_version = version[: version.find("-rancher")]
     k8s_version = execute_kubectl_cmd("version")
     kubectl_k8s_version = k8s_version["serverVersion"]["gitVersion"]
-    assert kubectl_k8s_version == expected_k8s_version, \
-        "kubectl version: " + kubectl_k8s_version + \
-        " Expected: " + expected_k8s_version
+    assert kubectl_k8s_version == expected_k8s_version, (
+        "kubectl version: " + kubectl_k8s_version + " Expected: " + expected_k8s_version
+    )
 
 
 def check_cluster_state(etcd_count):
@@ -987,8 +1010,7 @@ def check_cluster_state(etcd_count):
 
 def validate_dns_record(pod, record, expected, port=TEST_IMAGE_PORT):
     # requires pod with `dig` available - TEST_IMAGE
-    host = '{0}.{1}.svc.cluster.local'.format(
-        record["name"], record["namespaceId"])
+    host = "{0}.{1}.svc.cluster.local".format(record["name"], record["namespaceId"])
     validate_dns_entry(pod, host, expected, port=port)
 
 
@@ -999,9 +1021,9 @@ def validate_dns_entry(pod, host, expected, port=TEST_IMAGE_PORT):
 
     # requires pod with `dig` available - TEST_IMAGE
     if HARDENED_CLUSTER:
-        cmd = 'curl -vs {}:{} 2>&1'.format(host, port)
+        cmd = "curl -vs {}:{} 2>&1".format(host, port)
     else:
-        cmd = 'ping -c 1 -W 1 {0}'.format(host)
+        cmd = "ping -c 1 -W 1 {0}".format(host)
     cmd_output = kubectl_pod_exec(pod, cmd)
 
     connectivity_validation_pass = False
@@ -1016,7 +1038,7 @@ def validate_dns_entry(pod, host, expected, port=TEST_IMAGE_PORT):
     else:
         assert " 0% packet loss" in str(cmd_output)
 
-    dig_cmd = 'dig {0} +short'.format(host)
+    dig_cmd = "dig {0} +short".format(host)
     dig_output = kubectl_pod_exec(pod, dig_cmd)
 
     for expected_value in expected:
@@ -1025,7 +1047,7 @@ def validate_dns_entry(pod, host, expected, port=TEST_IMAGE_PORT):
 
 def validate_dns_entry_windows(pod, host, expected):
     def ping_check():
-        ping_cmd = 'ping -w 1 -n 1 {0}'.format(host)
+        ping_cmd = "ping -w 1 -n 1 {0}".format(host)
         ping_output = kubectl_pod_exec(pod, ping_cmd)
         ping_validation_pass = False
         for expected_value in expected:
@@ -1034,12 +1056,13 @@ def validate_dns_entry_windows(pod, host, expected):
                 break
         return ping_validation_pass and (" (0% loss)" in str(ping_output))
 
-    wait_for(callback=ping_check,
-             timeout_message="Failed to ping {0}".format(host))
+    wait_for(callback=ping_check, timeout_message="Failed to ping {0}".format(host))
 
     def dig_check():
-        dig_cmd = 'powershell -NoLogo -NonInteractive -Command ' \
-                  '"& {{ (Resolve-DnsName {0}).IPAddress }}"'.format(host)
+        dig_cmd = (
+            "powershell -NoLogo -NonInteractive -Command "
+            '"& {{ (Resolve-DnsName {0}).IPAddress }}"'.format(host)
+        )
         dig_output = kubectl_pod_exec(pod, dig_cmd)
         dig_validation_pass = True
         for expected_value in expected:
@@ -1048,8 +1071,7 @@ def validate_dns_entry_windows(pod, host, expected):
                 break
         return dig_validation_pass
 
-    wait_for(callback=dig_check,
-             timeout_message="Failed to resolve {0}".format(host))
+    wait_for(callback=dig_check, timeout_message="Failed to resolve {0}".format(host))
 
 
 def validate_dns_record_deleted(client, dns_record, timeout=DEFAULT_TIMEOUT):
@@ -1062,18 +1084,22 @@ def validate_dns_record_deleted(client, dns_record, timeout=DEFAULT_TIMEOUT):
     """
     time.sleep(2)
     start = time.time()
-    records = client.list_dns_record(name=dns_record.name, ).data
+    records = client.list_dns_record(
+        name=dns_record.name,
+    ).data
     while len(records) != 0:
         if time.time() - start > timeout:
             raise AssertionError(
                 "Timed out waiting for record {} to be deleted"
-                "".format(dns_record.name))
-        time.sleep(.5)
-        records = client.list_dns_record(name=dns_record.name, ).data
+                "".format(dns_record.name)
+            )
+        time.sleep(0.5)
+        records = client.list_dns_record(
+            name=dns_record.name,
+        ).data
 
 
-def wait_for_nodes_to_become_active(client, cluster, exception_list=[],
-                                    retry_count=0):
+def wait_for_nodes_to_become_active(client, cluster, exception_list=[], retry_count=0):
     nodes = client.list_node(clusterId=cluster.id).data
     node_auto_deleted = False
     for node in nodes:
@@ -1085,8 +1111,7 @@ def wait_for_nodes_to_become_active(client, cluster, exception_list=[],
                 retry_count += 1
                 print("Retry Count:" + str(retry_count))
     if node_auto_deleted and retry_count < 5:
-        wait_for_nodes_to_become_active(client, cluster, exception_list,
-                                        retry_count)
+        wait_for_nodes_to_become_active(client, cluster, exception_list, retry_count)
 
 
 def wait_for_node_status(client, node, state):
@@ -1103,8 +1128,7 @@ def wait_for_node_status(client, node, state):
         return None
     while node_status != state:
         if time.time() - start > MACHINE_TIMEOUT:
-            raise AssertionError(
-                "Timed out waiting for state to get to active")
+            raise AssertionError("Timed out waiting for state to get to active")
         time.sleep(5)
         nodes = client.list_node(uuid=uuid).data
         node_count = len(nodes)
@@ -1123,42 +1147,42 @@ def wait_for_node_to_be_deleted(client, node, timeout=300):
     node_count = len(nodes)
     while node_count != 0:
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for node delete")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for node delete")
+        time.sleep(0.5)
         nodes = client.list_node(uuid=uuid).data
         node_count = len(nodes)
 
 
-def wait_for_cluster_node_count(client, cluster, expected_node_count,
-                                timeout=300):
+def wait_for_cluster_node_count(client, cluster, expected_node_count, timeout=300):
     start = time.time()
     nodes = client.list_node(clusterId=cluster.id).data
     node_count = len(nodes)
     while node_count != expected_node_count:
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to active")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to active")
+        time.sleep(0.5)
         nodes = client.list_node(clusterId=cluster.id).data
         node_count = len(nodes)
 
 
 def get_custom_host_registration_cmd(client, cluster, roles, node):
     allowed_roles = ["etcd", "worker", "controlplane"]
-    cluster_tokens = client.list_cluster_registration_token(
-        clusterId=cluster.id).data
+    cluster_tokens = client.list_cluster_registration_token(clusterId=cluster.id).data
     if len(cluster_tokens) > 0:
         cluster_token = cluster_tokens[0]
     else:
         cluster_token = create_custom_host_registration_token(client, cluster)
 
-    additional_options = " --address " + node.public_ip_address + \
-                         " --internal-address " + node.private_ip_address
+    additional_options = (
+        " --address "
+        + node.public_ip_address
+        + " --internal-address "
+        + node.private_ip_address
+    )
 
-    if 'Administrator' == node.ssh_user:
+    if "Administrator" == node.ssh_user:
         cmd = cluster_token.windowsNodeCommand
-        cmd = cmd.replace('| iex', '--worker' + additional_options + ' | iex ')
+        cmd = cmd.replace("| iex", "--worker" + additional_options + " | iex ")
     else:
         cmd = cluster_token.nodeCommand
         for role in roles:
@@ -1172,10 +1196,9 @@ def get_custom_host_registration_cmd(client, cluster, roles, node):
 def create_custom_host_registration_token(client, cluster):
     # Allow sometime for the "cluster_owner" CRTB to take effect
     time.sleep(5)
-    cluster_token = client.create_cluster_registration_token(
-        clusterId=cluster.id)
+    cluster_token = client.create_cluster_registration_token(clusterId=cluster.id)
     cluster_token = client.wait_success(cluster_token)
-    assert cluster_token.state == 'active'
+    assert cluster_token.state == "active"
     return cluster_token
 
 
@@ -1190,7 +1213,7 @@ def get_cluster_type(client, cluster):
         "amazonElasticContainerServiceConfig",
         "azureKubernetesServiceConfig",
         "googleKubernetesEngineConfig",
-        "rancherKubernetesEngineConfig"
+        "rancherKubernetesEngineConfig",
     ]
     if "rancherKubernetesEngineConfig" in cluster:
         nodes = client.list_node(clusterId=cluster.id).data
@@ -1211,13 +1234,15 @@ def delete_cluster(client, cluster):
         print(cluster_type)
         if get_cluster_type(client, cluster) in ["Imported", "Custom"]:
             filters = [
-                {'Name': 'tag:Name',
-                 'Values': ['testcustom*', 'teststress*', 'testsa*']}]
+                {
+                    "Name": "tag:Name",
+                    "Values": ["testcustom*", "teststress*", "testsa*"],
+                }
+            ]
             ip_filter = {}
             ip_list = []
-            ip_filter['Name'] = \
-                'network-interface.addresses.association.public-ip'
-            ip_filter['Values'] = ip_list
+            ip_filter["Name"] = "network-interface.addresses.association.public-ip"
+            ip_filter["Values"] = ip_list
             filters.append(ip_filter)
             for node in nodes:
                 host_ip = resolve_node_ip(node)
@@ -1238,8 +1263,9 @@ def delete_cluster(client, cluster):
     client.delete(cluster)
 
 
-def check_connectivity_between_workloads(p_client1, workload1, p_client2,
-                                         workload2, allow_connectivity=True):
+def check_connectivity_between_workloads(
+    p_client1, workload1, p_client2, workload2, allow_connectivity=True
+):
     wl1_pods = p_client1.list_pod(workloadId=workload1.id).data
     wl2_pods = p_client2.list_pod(workloadId=workload2.id).data
     for pod in wl1_pods:
@@ -1258,9 +1284,9 @@ def check_connectivity_between_pods(pod1, pod2, allow_connectivity=True):
     pod_ip = pod2.status.podIp
 
     if is_windows():
-        cmd = 'ping -w 1 -n 1 {0}'.format(pod_ip)
+        cmd = "ping -w 1 -n 1 {0}".format(pod_ip)
     elif HARDENED_CLUSTER:
-        cmd = 'curl -I {}:{}'.format(pod_ip, TEST_IMAGE_PORT)
+        cmd = "curl -I {}:{}".format(pod_ip, TEST_IMAGE_PORT)
     else:
         cmd = "ping -c 1 -W 1 " + pod_ip
 
@@ -1309,17 +1335,17 @@ def wait_for_ns_to_become_active(client, ns, timeout=DEFAULT_TIMEOUT):
     ns = nss[0]
     while ns.state != "active":
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to active")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to active")
+        time.sleep(0.5)
         nss = client.list_namespace(uuid=ns.uuid).data
         assert len(nss) == 1
         ns = nss[0]
     return ns
 
 
-def wait_for_pod_images(p_client, workload, ns_name, expectedimage, numofpods,
-                        timeout=DEFAULT_TIMEOUT):
+def wait_for_pod_images(
+    p_client, workload, ns_name, expectedimage, numofpods, timeout=DEFAULT_TIMEOUT
+):
     start = time.time()
 
     for key, value in workload.workloadLabels.items():
@@ -1332,24 +1358,23 @@ def wait_for_pod_images(p_client, workload, ns_name, expectedimage, numofpods,
         podimage = pod["spec"]["containers"][0]["image"]
         while podimage != expectedimage:
             if time.time() - start > timeout:
-                raise AssertionError(
-                    "Timed out waiting for correct pod images")
-            time.sleep(.5)
+                raise AssertionError("Timed out waiting for correct pod images")
+            time.sleep(0.5)
             pods = execute_kubectl_cmd(get_pods)
             pod = pods["items"][x]
             podimage = pod["spec"]["containers"][0]["image"]
 
 
-def wait_for_pods_in_workload(p_client, workload, pod_count,
-                              timeout=DEFAULT_TIMEOUT):
+def wait_for_pods_in_workload(p_client, workload, pod_count, timeout=DEFAULT_TIMEOUT):
     start = time.time()
     pods = p_client.list_pod(workloadId=workload.id).data
     while len(pods) != pod_count:
         if time.time() - start > timeout:
             raise AssertionError(
                 "Timed out waiting for pods in workload {}. Expected {}. "
-                "Got {}".format(workload.name, pod_count, len(pods)))
-        time.sleep(.5)
+                "Got {}".format(workload.name, pod_count, len(pods))
+            )
+        time.sleep(0.5)
         pods = p_client.list_pod(workloadId=workload.id).data
     return pods
 
@@ -1377,27 +1402,35 @@ def get_global_admin_client_and_cluster():
     return client, cluster
 
 
-def validate_cluster_state(client, cluster,
-                           check_intermediate_state=True,
-                           intermediate_state="provisioning",
-                           nodes_not_in_active_state=[],
-                           timeout=MACHINE_TIMEOUT):
+def validate_cluster_state(
+    client,
+    cluster,
+    check_intermediate_state=True,
+    intermediate_state="provisioning",
+    nodes_not_in_active_state=[],
+    timeout=MACHINE_TIMEOUT,
+):
     start_time = time.time()
     if check_intermediate_state:
         cluster = wait_for_condition(
-            client, cluster,
+            client,
+            cluster,
             lambda x: x.state == intermediate_state,
-            lambda x: 'State is: ' + x.state,
-            timeout=timeout)
+            lambda x: "State is: " + x.state,
+            timeout=timeout,
+        )
         assert cluster.state == intermediate_state
     cluster = wait_for_condition(
-        client, cluster,
+        client,
+        cluster,
         lambda x: x.state == "active",
-        lambda x: 'State is: ' + x.state,
-        timeout=timeout)
+        lambda x: "State is: " + x.state,
+        timeout=timeout,
+    )
     assert cluster.state == "active"
-    wait_for_nodes_to_become_active(client, cluster,
-                                    exception_list=nodes_not_in_active_state)
+    wait_for_nodes_to_become_active(
+        client, cluster, exception_list=nodes_not_in_active_state
+    )
     timeout = 60
     start = time.time()
     while "version" not in cluster.keys():
@@ -1409,8 +1442,11 @@ def validate_cluster_state(client, cluster,
             raise Exception(msg)
     end_time = time.time()
     diff = time.strftime("%H:%M:%S", time.gmtime(end_time - start_time))
-    print("The total time for provisioning/updating the cluster {} : {}".
-          format(cluster.name, diff))
+    print(
+        "The total time for provisioning/updating the cluster {} : {}".format(
+            cluster.name, diff
+        )
+    )
     return cluster
 
 
@@ -1431,8 +1467,10 @@ def wait_until_available(client, obj, timeout=DEFAULT_TIMEOUT):
             return obj
         delta = time.time() - start
         if delta > timeout:
-            msg = 'Timeout waiting for [{}:{}] for condition after {}' \
-                  ' seconds'.format(obj.type, obj.id, delta)
+            msg = (
+                "Timeout waiting for [{}:{}] for condition after {}"
+                " seconds".format(obj.type, obj.id, delta)
+            )
             raise Exception(msg)
 
 
@@ -1476,8 +1514,7 @@ def validate_hostPort(p_client, workload, source_port, cluster):
                 break
         if len(target_name_list) > 0:
             host_ip = resolve_node_ip(node)
-            curl_cmd = " http://" + host_ip + ":" + \
-                       str(source_port) + "/name.html"
+            curl_cmd = " http://" + host_ip + ":" + str(source_port) + "/name.html"
             validate_http_response(curl_cmd, target_name_list)
 
 
@@ -1504,8 +1541,7 @@ def validate_nodePort(p_client, workload, cluster, source_port):
     print("target name list:" + str(target_name_list))
     for node in nodes:
         host_ip = resolve_node_ip(node)
-        curl_cmd = " http://" + host_ip + ":" + \
-                   str(source_port_wk) + "/name.html"
+        curl_cmd = " http://" + host_ip + ":" + str(source_port_wk) + "/name.html"
         validate_http_response(curl_cmd, target_name_list)
 
 
@@ -1514,8 +1550,7 @@ def validate_clusterIp(p_client, workload, cluster_ip, test_pods, source_port):
     target_name_list = []
     for pod in pods:
         target_name_list.append(pod["name"])
-    curl_cmd = "http://" + cluster_ip + ":" + \
-               str(source_port) + "/name.html"
+    curl_cmd = "http://" + cluster_ip + ":" + str(source_port) + "/name.html"
     for pod in test_pods:
         validate_http_response(curl_cmd, target_name_list, pod)
 
@@ -1528,9 +1563,8 @@ def wait_for_pv_to_be_available(c_client, pv_object, timeout=DEFAULT_TIMEOUT):
     pv = list[0]
     while pv.state != "available":
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to available")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to available")
+        time.sleep(0.5)
         list = c_client.list_persistent_volume(uuid=pv_object.uuid).data
         assert len(list) == 1
         pv = list[0]
@@ -1545,91 +1579,100 @@ def wait_for_pvc_to_be_bound(p_client, pvc_object, timeout=DEFAULT_TIMEOUT):
     pvc = list[0]
     while pvc.state != "bound":
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to bound")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to bound")
+        time.sleep(0.5)
         list = p_client.list_persistent_volume_claim(uuid=pvc_object.uuid).data
         assert len(list) == 1
         pvc = list[0]
     return pvc
 
 
-def create_wl_with_nfs(p_client, ns_id, pvc_name, wl_name,
-                       mount_path, sub_path, is_daemonSet=False):
-    volumes = [{"type": "volume",
-                "name": "vol1",
-                "persistentVolumeClaim": {
-                    "readOnly": "false",
-                    "type": "persistentVolumeClaimVolumeSource",
-                    "persistentVolumeClaimId": pvc_name
-                }}]
-    volumeMounts = [{"readOnly": "False",
-                     "type": "volumeMount",
-                     "mountPath": mount_path,
-                     "subPath": sub_path,
-                     "name": "vol1"
-                     }]
-    con = [{"name": "test1",
-            "image": TEST_IMAGE,
-            "volumeMounts": volumeMounts
-            }]
+def create_wl_with_nfs(
+    p_client, ns_id, pvc_name, wl_name, mount_path, sub_path, is_daemonSet=False
+):
+    volumes = [
+        {
+            "type": "volume",
+            "name": "vol1",
+            "persistentVolumeClaim": {
+                "readOnly": "false",
+                "type": "persistentVolumeClaimVolumeSource",
+                "persistentVolumeClaimId": pvc_name,
+            },
+        }
+    ]
+    volumeMounts = [
+        {
+            "readOnly": "False",
+            "type": "volumeMount",
+            "mountPath": mount_path,
+            "subPath": sub_path,
+            "name": "vol1",
+        }
+    ]
+    con = [{"name": "test1", "image": TEST_IMAGE, "volumeMounts": volumeMounts}]
     if is_daemonSet:
-        workload = p_client.create_workload(name=wl_name,
-                                            containers=con,
-                                            namespaceId=ns_id,
-                                            volumes=volumes,
-                                            daemonSetConfig={})
+        workload = p_client.create_workload(
+            name=wl_name,
+            containers=con,
+            namespaceId=ns_id,
+            volumes=volumes,
+            daemonSetConfig={},
+        )
     else:
-        workload = p_client.create_workload(name=wl_name,
-                                            containers=con,
-                                            namespaceId=ns_id,
-                                            volumes=volumes)
+        workload = p_client.create_workload(
+            name=wl_name, containers=con, namespaceId=ns_id, volumes=volumes
+        )
     return workload
 
 
 def write_content_to_file(pod, content, filename):
     cmd_write = "/bin/bash -c 'echo {1} > {0}'".format(filename, content)
     if is_windows():
-        cmd_write = \
-            'powershell -NoLogo -NonInteractive -Command ' \
+        cmd_write = (
+            "powershell -NoLogo -NonInteractive -Command "
             '"& { echo {1} > {0} }"'.format(filename, content)
+        )
     output = kubectl_pod_exec(pod, cmd_write)
-    assert output.strip().decode('utf-8') == ""
+    assert output.strip().decode("utf-8") == ""
 
 
 def validate_file_content(pod, content, filename):
     cmd_get_content = "/bin/bash -c 'cat {0}' ".format(filename)
     if is_windows():
-        cmd_get_content = 'powershell -NoLogo -NonInteractive -Command ' \
-                          '"& { cat {0} }"'.format(filename)
+        cmd_get_content = (
+            "powershell -NoLogo -NonInteractive -Command "
+            '"& { cat {0} }"'.format(filename)
+        )
     output = kubectl_pod_exec(pod, cmd_get_content)
-    assert output.strip().decode('utf-8') == content
+    assert output.strip().decode("utf-8") == content
 
 
-def wait_for_mcapp_to_active(client, multiClusterApp,
-                             timeout=DEFAULT_MULTI_CLUSTER_APP_TIMEOUT):
+def wait_for_mcapp_to_active(
+    client, multiClusterApp, timeout=DEFAULT_MULTI_CLUSTER_APP_TIMEOUT
+):
     time.sleep(5)
     # When the app is deployed it goes into Active state for a short
     # period of time and then into installing/deploying.
-    mcapps = client.list_multiClusterApp(uuid=multiClusterApp.uuid,
-                                         name=multiClusterApp.name).data
+    mcapps = client.list_multiClusterApp(
+        uuid=multiClusterApp.uuid, name=multiClusterApp.name
+    ).data
     start = time.time()
     assert len(mcapps) == 1, "Cannot find multi cluster app"
     mapp = mcapps[0]
     while mapp.state != "active":
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to active")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to active")
+        time.sleep(0.5)
         multiclusterapps = client.list_multiClusterApp(
-            uuid=multiClusterApp.uuid, name=multiClusterApp.name).data
+            uuid=multiClusterApp.uuid, name=multiClusterApp.name
+        ).data
         assert len(multiclusterapps) == 1
         mapp = multiclusterapps[0]
     return mapp
 
 
-def wait_for_app_to_active(client, app_id,
-                           timeout=DEFAULT_MULTI_CLUSTER_APP_TIMEOUT):
+def wait_for_app_to_active(client, app_id, timeout=DEFAULT_MULTI_CLUSTER_APP_TIMEOUT):
     """
     First wait for app to come in deployment state, then wait for it get
     in active state. This is to avoid wrongly conclude that app is active
@@ -1643,33 +1686,31 @@ def wait_for_app_to_active(client, app_id,
     app_data = client.list_app(id=app_id).data
     while len(app_data) == 0:
         if time.time() - start > timeout / 10:
-            raise AssertionError(
-                "Timed out waiting for listing the app from API")
-        time.sleep(.2)
+            raise AssertionError("Timed out waiting for listing the app from API")
+        time.sleep(0.2)
         app_data = client.list_app(id=app_id).data
 
     application = app_data[0]
     while application.state != "deploying":
         if time.time() - start > timeout / 3:
             break
-        time.sleep(.2)
+        time.sleep(0.2)
         app_data = client.list_app(id=app_id).data
         application = app_data[0]
     while application.state != "active":
         if time.time() - start > timeout:
             raise AssertionError(
                 "Timed out waiting for {0} to get to active,"
-                " the actual state: {1}".format(application.name,
-                                                application.state))
-        time.sleep(.5)
+                " the actual state: {1}".format(application.name, application.state)
+            )
+        time.sleep(0.5)
         app = client.list_app(id=app_id).data
         assert len(app) >= 1
         application = app[0]
     return application
 
 
-def wait_for_app_to_remove(client, app_id,
-                           timeout=DEFAULT_MULTI_CLUSTER_APP_TIMEOUT):
+def wait_for_app_to_remove(client, app_id, timeout=DEFAULT_MULTI_CLUSTER_APP_TIMEOUT):
     start = time.time()
     app_data = client.list_app(id=app_id).data
     if len(app_data) == 0:
@@ -1677,25 +1718,27 @@ def wait_for_app_to_remove(client, app_id,
     application = app_data[0]
     while application.state == "removing" or application.state == "active":
         if time.time() - start > timeout / 10:
-            raise AssertionError(
-                "Timed out waiting for app to not be installed")
-        time.sleep(.2)
+            raise AssertionError("Timed out waiting for app to not be installed")
+        time.sleep(0.2)
         app_data = client.list_app(id=app_id).data
         if len(app_data) == 0:
             break
         application = app_data[0]
 
 
-def validate_response_app_endpoint(p_client, appId,
-                                   timeout=DEFAULT_MULTI_CLUSTER_APP_TIMEOUT):
+def validate_response_app_endpoint(
+    p_client, appId, timeout=DEFAULT_MULTI_CLUSTER_APP_TIMEOUT
+):
     ingress_list = p_client.list_ingress(namespaceId=appId).data
     assert len(ingress_list) == 1
     ingress = ingress_list[0]
-    if hasattr(ingress, 'publicEndpoints'):
+    if hasattr(ingress, "publicEndpoints"):
         for public_endpoint in ingress.publicEndpoints:
-            url = \
-                public_endpoint["protocol"].lower() + "://" + \
-                public_endpoint["hostname"]
+            url = (
+                public_endpoint["protocol"].lower()
+                + "://"
+                + public_endpoint["hostname"]
+            )
             print(url)
             start = time.time()
             try:
@@ -1705,16 +1748,15 @@ def validate_response_app_endpoint(p_client, appId,
                     if r.status_code == 200:
                         return
                     if time.time() - start > timeout:
-                        raise AssertionError(
-                            "Timed out waiting response to be 200.")
-                    time.sleep(.5)
+                        raise AssertionError("Timed out waiting response to be 200.")
+                    time.sleep(0.5)
             except requests.ConnectionError:
                 print("failed to connect")
                 assert False, "failed to connect to the app"
 
 
 def resolve_node_ip(node):
-    if hasattr(node, 'externalIpAddress'):
+    if hasattr(node, "externalIpAddress"):
         node_ip = node.externalIpAddress
     else:
         node_ip = node.ipAddress
@@ -1726,7 +1768,7 @@ def provision_nfs_server():
     node.wait_for_ssh_ready()
     c_path = os.getcwd()
     cmd_path = c_path + "/tests/v3_api/scripts/nfs-setup.sh"
-    command = open(cmd_path, 'r').read()
+    command = open(cmd_path, "r").read()
     node.execute_command(command)
     return node
 
@@ -1748,9 +1790,9 @@ def get_defaut_question_answers(client, externalId):
                     elif quest["type"] == "string":
                         answer = "fake"
                     else:
-                        assert False, \
-                            "Cannot set default for types {}" \
-                            "".format(quest["type"])
+                        assert False, "Cannot set default for types {}" "".format(
+                            quest["type"]
+                        )
         return answer
 
     def check_if_question_needed(questions_and_answers, ques):
@@ -1778,8 +1820,7 @@ def get_defaut_question_answers(client, externalId):
     for ques in questions:
         add_question = True
         if "showIf" in ques.keys():
-            add_question = \
-                check_if_question_needed(questions_and_answers, ques)
+            add_question = check_if_question_needed(questions_and_answers, ques)
         if add_question:
             question = ques["variable"]
             answer = get_answer(ques)
@@ -1789,14 +1830,12 @@ def get_defaut_question_answers(client, externalId):
                     sub_questions = ques["subquestions"]
                     for sub_question in sub_questions:
                         question = sub_question["variable"]
-                        questions_and_answers[question] = \
-                            get_answer(sub_question)
+                        questions_and_answers[question] = get_answer(sub_question)
     print("questions_and_answers = {}".format(questions_and_answers))
     return questions_and_answers
 
 
-def validate_app_deletion(client, app_id,
-                          timeout=DEFAULT_APP_DELETION_TIMEOUT):
+def validate_app_deletion(client, app_id, timeout=DEFAULT_APP_DELETION_TIMEOUT):
     app_data = client.list_app(id=app_id).data
     start = time.time()
     if len(app_data) == 0:
@@ -1804,9 +1843,8 @@ def validate_app_deletion(client, app_id,
     application = app_data[0]
     while application.state == "removing":
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for app to delete")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for app to delete")
+        time.sleep(0.5)
         app_data = client.list_app(id=app_id).data
         if len(app_data) == 0:
             break
@@ -1829,13 +1867,11 @@ def validate_catalog_app(proj_client, app, external_id, answer=None):
         answers = answer
     # validate app is active
     app = wait_for_app_to_active(proj_client, app.id)
-    assert app.externalId == external_id, \
-        "the version of the app is not correct"
+    assert app.externalId == external_id, "the version of the app is not correct"
     # check if associated workloads are active
     ns = app.targetNamespace
-    parameters = external_id.split('&')
-    assert len(parameters) > 1, \
-        "Incorrect list of parameters from catalog external ID"
+    parameters = external_id.split("&")
+    assert len(parameters) > 1, "Incorrect list of parameters from catalog external ID"
     chart_prefix = parameters[len(parameters) - 2].split("=")[1]
     chart_suffix = parameters[len(parameters) - 1].split("=")[1]
     chart = chart_prefix + "-" + chart_suffix
@@ -1856,11 +1892,12 @@ def validate_catalog_app(proj_client, app, external_id, answer=None):
             chart_deployed = get_chart_info(wl.workloadLabels)
             print("Chart detail of app - {}".format(chart_deployed))
             # '-' check is to make sure chart has both app name and version.
-            if app_name in chart_deployed and '-' in chart_deployed:
+            if app_name in chart_deployed and "-" in chart_deployed:
                 assert chart_deployed == chart, "the chart version is wrong"
     # Validate_app_answers
-    assert len(answers.items() - app["answers"].items()) == 0, \
-        "Answers are not same as the original catalog answers"
+    assert (
+        len(answers.items() - app["answers"].items()) == 0
+    ), "Answers are not same as the original catalog answers"
     return app
 
 
@@ -1876,26 +1913,29 @@ def get_chart_info(workloadlabels):
     elif "helm.sh/chart" in workloadlabels.keys():
         return workloadlabels["helm.sh/chart"]
     else:
-        return ''
+        return ""
 
 
 def create_user(client, cattle_auth_url=CATTLE_AUTH_URL):
     user_name = random_name()
-    user = client.create_user(username=user_name,
-                              password=USER_PASSWORD)
-    client.create_global_role_binding(globalRoleId="user",
-                                      subjectKind="User",
-                                      userId=user.id)
+    user = client.create_user(username=user_name, password=USER_PASSWORD)
+    client.create_global_role_binding(
+        globalRoleId="user", subjectKind="User", userId=user.id
+    )
     user_token = get_user_token(user.username, USER_PASSWORD, cattle_auth_url)
     return user, user_token
 
 
 def get_user_token(username, password, cattle_auth_url=CATTLE_AUTH_URL):
-    r = requests.post(cattle_auth_url, json={
-        'username': username,
-        'password': password,
-        'responseType': 'json',
-    }, verify=False)
+    r = requests.post(
+        cattle_auth_url,
+        json={
+            "username": username,
+            "password": password,
+            "responseType": "json",
+        },
+        verify=False,
+    )
     print(r.json())
     return r.json()["token"]
 
@@ -1948,16 +1988,13 @@ def rbac_prepare():
     admin_client, cluster = get_global_admin_client_and_cluster()
     create_kubeconfig(cluster)
     # create a new project in the cluster
-    project, ns = create_project_and_ns(ADMIN_TOKEN,
-                                        cluster,
-                                        random_test_name("p-test-rbac"))
-    con = [{"name": "test1",
-            "image": TEST_IMAGE}]
+    project, ns = create_project_and_ns(
+        ADMIN_TOKEN, cluster, random_test_name("p-test-rbac")
+    )
+    con = [{"name": "test1", "image": TEST_IMAGE}]
     name = random_test_name("default")
     p_client = get_project_client_for_token(project, ADMIN_TOKEN)
-    workload = p_client.create_workload(name=name,
-                                        containers=con,
-                                        namespaceId=ns.id)
+    workload = p_client.create_workload(name=name, containers=con, namespaceId=ns.id)
     validate_workload(p_client, workload, "deployment", ns.name)
     rbac_data["workload"] = workload
     rbac_data["project"] = project
@@ -1969,44 +2006,46 @@ def rbac_prepare():
         rbac_data["users"][key]["token"] = token1
 
     # assign different role to each user
-    assign_members_to_cluster(admin_client,
-                              rbac_data["users"][CLUSTER_OWNER]["user"],
-                              cluster,
-                              CLUSTER_OWNER)
-    assign_members_to_cluster(admin_client,
-                              rbac_data["users"][CLUSTER_MEMBER]["user"],
-                              cluster,
-                              CLUSTER_MEMBER)
-    assign_members_to_project(admin_client,
-                              rbac_data["users"][PROJECT_MEMBER]["user"],
-                              project,
-                              PROJECT_MEMBER)
-    assign_members_to_project(admin_client,
-                              rbac_data["users"][PROJECT_OWNER]["user"],
-                              project,
-                              PROJECT_OWNER)
-    assign_members_to_project(admin_client,
-                              rbac_data["users"][PROJECT_READ_ONLY]["user"],
-                              project,
-                              PROJECT_READ_ONLY)
+    assign_members_to_cluster(
+        admin_client, rbac_data["users"][CLUSTER_OWNER]["user"], cluster, CLUSTER_OWNER
+    )
+    assign_members_to_cluster(
+        admin_client,
+        rbac_data["users"][CLUSTER_MEMBER]["user"],
+        cluster,
+        CLUSTER_MEMBER,
+    )
+    assign_members_to_project(
+        admin_client,
+        rbac_data["users"][PROJECT_MEMBER]["user"],
+        project,
+        PROJECT_MEMBER,
+    )
+    assign_members_to_project(
+        admin_client, rbac_data["users"][PROJECT_OWNER]["user"], project, PROJECT_OWNER
+    )
+    assign_members_to_project(
+        admin_client,
+        rbac_data["users"][PROJECT_READ_ONLY]["user"],
+        project,
+        PROJECT_READ_ONLY,
+    )
     # create kubeconfig files for each user
     for key in rbac_data["users"]:
         user_client = get_client_for_token(rbac_data["users"][key]["token"])
         _, user_cluster = get_user_client_and_cluster(user_client)
         rbac_data["users"][key]["kubeconfig"] = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)),
-            key + "_kubeconfig")
+            os.path.dirname(os.path.realpath(__file__)), key + "_kubeconfig"
+        )
         create_kubeconfig(user_cluster, rbac_data["users"][key]["kubeconfig"])
 
     # create another project that none of the above users are assigned to
-    p2, ns2 = create_project_and_ns(ADMIN_TOKEN,
-                                    cluster,
-                                    random_test_name("p-unshared"))
+    p2, ns2 = create_project_and_ns(
+        ADMIN_TOKEN, cluster, random_test_name("p-unshared")
+    )
     name = random_test_name("default")
     p_client = get_project_client_for_token(p2, ADMIN_TOKEN)
-    workload = p_client.create_workload(name=name,
-                                        containers=con,
-                                        namespaceId=ns2.id)
+    workload = p_client.create_workload(name=name, containers=con, namespaceId=ns2.id)
     validate_workload(p_client, workload, "deployment", ns2.name)
     rbac_data["p_unshared"] = p2
     rbac_data["ns_unshared"] = ns2
@@ -2014,7 +2053,7 @@ def rbac_prepare():
 
 
 def rbac_cleanup():
-    """ remove the project, namespace and users created for the RBAC tests"""
+    """remove the project, namespace and users created for the RBAC tests"""
     try:
         client = get_admin_client()
     except Exception:
@@ -2046,15 +2085,31 @@ def check_condition(condition_type, status):
     return _find_condition
 
 
-def create_catalog_external_id(catalog_name, template, version,
-                               project_cluster_id=None, catalog_type=None):
+def create_catalog_external_id(
+    catalog_name, template, version, project_cluster_id=None, catalog_type=None
+):
     if catalog_type is None:
-        return "catalog://?catalog=" + catalog_name + \
-               "&template=" + template + "&version=" + version
+        return (
+            "catalog://?catalog="
+            + catalog_name
+            + "&template="
+            + template
+            + "&version="
+            + version
+        )
     elif catalog_type == "project" or catalog_type == "cluster":
-        return "catalog://?catalog=" + project_cluster_id + "/" \
-               + catalog_name + "&type=" + catalog_type \
-               + "Catalog&template=" + template + "&version=" + version
+        return (
+            "catalog://?catalog="
+            + project_cluster_id
+            + "/"
+            + catalog_name
+            + "&type="
+            + catalog_type
+            + "Catalog&template="
+            + template
+            + "&version="
+            + version
+        )
 
 
 def wait_for_catalog_active(client, catalog, timeout=DEFAULT_CATALOG_TIMEOUT):
@@ -2066,9 +2121,8 @@ def wait_for_catalog_active(client, catalog, timeout=DEFAULT_CATALOG_TIMEOUT):
     catalog = catalog_data["data"][0]
     while catalog.state != "active":
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to active")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to active")
+        time.sleep(0.5)
         catalog_data = client.list_catalog(name=catalog.name)
         assert len(catalog_data["data"]) >= 1
         catalog = catalog_data["data"][0]
@@ -2086,19 +2140,21 @@ def readDataFile(data_dir, name):
 
 def set_url_password_token(rancher_url, server_url=None):
     """Returns a ManagementContext for the default global admin user."""
-    auth_url = \
-        rancher_url + "/v3-public/localproviders/local?action=login"
-    r = requests.post(auth_url, json={
-        'username': 'admin',
-        'password': 'admin',
-        'responseType': 'json',
-    }, verify=False)
+    auth_url = rancher_url + "/v3-public/localproviders/local?action=login"
+    r = requests.post(
+        auth_url,
+        json={
+            "username": "admin",
+            "password": "admin",
+            "responseType": "json",
+        },
+        verify=False,
+    )
     print(r.json())
-    token = r.json()['token']
+    token = r.json()["token"]
     print(token)
     # Change admin password
-    client = rancher.Client(url=rancher_url + "/v3",
-                            token=token, verify=False)
+    client = rancher.Client(url=rancher_url + "/v3", token=token, verify=False)
     admin_user = client.list_user(username="admin").data
     admin_user[0].setpassword(newPassword=ADMIN_PASSWORD)
 
@@ -2126,22 +2182,22 @@ def validate_create_catalog(token, catalog_name, branch, url, permission=True):
     client = get_client_for_token(token)
     if not permission:
         with pytest.raises(ApiError) as e:
-            client.create_catalog(name=catalog_name,
-                                  branch=branch,
-                                  url=url)
+            client.create_catalog(name=catalog_name, branch=branch, url=url)
         error_msg = "user with no permission should receive 403: Forbidden"
         error_code = e.value.error.code
         error_status = e.value.error.status
-        assert error_status == 403 and error_code == 'Forbidden', error_msg
+        assert error_status == 403 and error_code == "Forbidden", error_msg
         return None
     else:
         try:
-            client.create_catalog(name=catalog_name,
-                                  branch=branch,
-                                  url=url)
+            client.create_catalog(name=catalog_name, branch=branch, url=url)
         except ApiError as e:
-            assert False, "user with permission should receive no exception:" \
-                          + str(e.error.status) + " " + e.error.code
+            assert False, (
+                "user with permission should receive no exception:"
+                + str(e.error.status)
+                + " "
+                + e.error.code
+            )
 
     catalog_list = client.list_catalog(name=catalog_name).data
     assert len(catalog_list) == 1
@@ -2149,7 +2205,7 @@ def validate_create_catalog(token, catalog_name, branch, url, permission=True):
 
 
 def generate_template_global_role(name, new_user_default=False, template=None):
-    """ generate a template that is used for creating a global role"""
+    """generate a template that is used for creating a global role"""
     if template is None:
         template = TEMPLATE_MANAGE_CATALOG
     template = deepcopy(template)
@@ -2163,36 +2219,32 @@ def generate_template_global_role(name, new_user_default=False, template=None):
     return template
 
 
-def wait_for_backup_to_active(cluster, backupname,
-                              timeout=DEFAULT_TIMEOUT):
+def wait_for_backup_to_active(cluster, backupname, timeout=DEFAULT_TIMEOUT):
     start = time.time()
     etcdbackups = cluster.etcdBackups(name=backupname)
     assert len(etcdbackups) == 1
-    etcdbackupdata = etcdbackups['data']
-    etcdbackupstate = etcdbackupdata[0]['state']
+    etcdbackupdata = etcdbackups["data"]
+    etcdbackupstate = etcdbackupdata[0]["state"]
     while etcdbackupstate != "active":
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to active")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to active")
+        time.sleep(0.5)
         etcdbackups = cluster.etcdBackups(name=backupname)
         assert len(etcdbackups) == 1
-        etcdbackupdata = etcdbackups['data']
-        etcdbackupstate = etcdbackupdata[0]['state']
+        etcdbackupdata = etcdbackups["data"]
+        etcdbackupstate = etcdbackupdata[0]["state"]
     print("BACKUP STATE")
     print(etcdbackupstate)
     return etcdbackupstate
 
 
-def wait_for_backup_to_delete(cluster, backupname,
-                              timeout=DEFAULT_TIMEOUT):
+def wait_for_backup_to_delete(cluster, backupname, timeout=DEFAULT_TIMEOUT):
     start = time.time()
     etcdbackups = cluster.etcdBackups(name=backupname)
     while len(etcdbackups) == 1:
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for backup to be deleted")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for backup to be deleted")
+        time.sleep(0.5)
         etcdbackups = cluster.etcdBackups(name=backupname)
 
 
@@ -2202,54 +2254,60 @@ def validate_backup_create(namespace, backup_info, backup_mode=None):
     cluster = namespace["cluster"]
     name = random_test_name("default")
 
-    if not hasattr(cluster, 'rancherKubernetesEngineConfig'):
+    if not hasattr(cluster, "rancherKubernetesEngineConfig"):
         assert False, "Cluster is not of type RKE"
 
-    con = [{"name": "test1",
-            "image": TEST_IMAGE}]
-    backup_info["workload"] = p_client.create_workload(name=name,
-                                                       containers=con,
-                                                       namespaceId=ns.id,
-                                                       daemonSetConfig={})
-    validate_workload(p_client, backup_info["workload"], "daemonSet", ns.name,
-                      len(get_schedulable_nodes(cluster)))
+    con = [{"name": "test1", "image": TEST_IMAGE}]
+    backup_info["workload"] = p_client.create_workload(
+        name=name, containers=con, namespaceId=ns.id, daemonSetConfig={}
+    )
+    validate_workload(
+        p_client,
+        backup_info["workload"],
+        "daemonSet",
+        ns.name,
+        len(get_schedulable_nodes(cluster)),
+    )
     host = "test" + str(random_int(10000, 99999)) + ".com"
     namespace["host"] = host
     path = "/name.html"
-    rule = {"host": host,
-            "paths": [{"workloadIds": [backup_info["workload"].id],
-                       "targetPort": TEST_IMAGE_PORT}]}
-    p_client.create_ingress(name=name,
-                            namespaceId=ns.id,
-                            rules=[rule])
+    rule = {
+        "host": host,
+        "paths": [
+            {"workloadIds": [backup_info["workload"].id], "targetPort": TEST_IMAGE_PORT}
+        ],
+    }
+    p_client.create_ingress(name=name, namespaceId=ns.id, rules=[rule])
     validate_ingress(p_client, cluster, [backup_info["workload"]], host, path)
 
     # Perform Backup
     backup = cluster.backupEtcd()
-    backup_info["backupname"] = backup['metadata']['name']
+    backup_info["backupname"] = backup["metadata"]["name"]
     wait_for_backup_to_active(cluster, backup_info["backupname"])
 
     # Get all the backup info
     etcdbackups = cluster.etcdBackups(name=backup_info["backupname"])
-    backup_info["etcdbackupdata"] = etcdbackups['data']
-    backup_info["backup_id"] = backup_info["etcdbackupdata"][0]['id']
+    backup_info["etcdbackupdata"] = etcdbackups["data"]
+    backup_info["backup_id"] = backup_info["etcdbackupdata"][0]["id"]
 
     if backup_mode == "s3":
-        backupfileurl = backup_info["etcdbackupdata"][0]['filename']
+        backupfileurl = backup_info["etcdbackupdata"][0]["filename"]
         # Check the backup filename exists in S3
         parseurl = urlparse(backupfileurl)
         backup_info["backupfilename"] = os.path.basename(parseurl.path)
         backup_found = AmazonWebServices().s3_backup_check(
-            backup_info["backupfilename"])
+            backup_info["backupfilename"]
+        )
         assert backup_found, "the backup was not found in the S3 bucket"
-    elif backup_mode == 'filesystem':
-        for node in namespace['nodes']:
-            if 'etcd' not in node.roles:
+    elif backup_mode == "filesystem":
+        for node in namespace["nodes"]:
+            if "etcd" not in node.roles:
                 continue
-            get_filesystem_snapshots = 'ls /opt/rke/etcd-snapshots'
+            get_filesystem_snapshots = "ls /opt/rke/etcd-snapshots"
             response = node.execute_command(get_filesystem_snapshots)[0]
-            assert backup_info["etcdbackupdata"][0]['filename'] in response, \
-                "The filename doesn't match any of the files locally"
+            assert (
+                backup_info["etcdbackupdata"][0]["filename"] in response
+            ), "The filename doesn't match any of the files locally"
     return namespace, backup_info
 
 
@@ -2262,22 +2320,25 @@ def validate_backup_restore(namespace, backup_info):
 
     host = namespace["host"]
     path = "/name.html"
-    con = [{"name": "test1",
-            "image": TEST_IMAGE}]
+    con = [{"name": "test1", "image": TEST_IMAGE}]
 
     # Create workload after backup
-    testworkload = p_client.create_workload(name=name,
-                                            containers=con,
-                                            namespaceId=ns.id)
+    testworkload = p_client.create_workload(
+        name=name, containers=con, namespaceId=ns.id
+    )
 
     validate_workload(p_client, testworkload, "deployment", ns.name)
 
     # Perform Restore
     cluster.restoreFromEtcdBackup(etcdBackupId=backup_info["backup_id"])
     # After restore, validate cluster
-    validate_cluster(client, cluster, intermediate_state="updating",
-                     check_intermediate_state=True,
-                     skipIngresscheck=False)
+    validate_cluster(
+        client,
+        cluster,
+        intermediate_state="updating",
+        check_intermediate_state=True,
+        skipIngresscheck=False,
+    )
 
     # Verify the ingress created before taking the snapshot
     validate_ingress(p_client, cluster, [backup_info["workload"]], host, path)
@@ -2293,51 +2354,60 @@ def validate_backup_restore(namespace, backup_info):
 def validate_backup_delete(namespace, backup_info, backup_mode=None):
     client = get_user_client()
     cluster = namespace["cluster"]
-    client.delete(
-        cluster.etcdBackups(name=backup_info["backupname"])['data'][0]
-    )
+    client.delete(cluster.etcdBackups(name=backup_info["backupname"])["data"][0])
     wait_for_backup_to_delete(cluster, backup_info["backupname"])
-    assert len(cluster.etcdBackups(name=backup_info["backupname"])) == 0, \
-        "backup shouldn't be listed in the Cluster backups"
+    assert (
+        len(cluster.etcdBackups(name=backup_info["backupname"])) == 0
+    ), "backup shouldn't be listed in the Cluster backups"
     if backup_mode == "s3":
         # Check the backup reference is deleted in Rancher and S3
         backup_found = AmazonWebServices().s3_backup_check(
-            backup_info["backupfilename"])
+            backup_info["backupfilename"]
+        )
         assert_message = "The backup should't exist in the S3 bucket"
         assert backup_found is False, assert_message
-    elif backup_mode == 'filesystem':
-        for node in namespace['nodes']:
-            if 'etcd' not in node.roles:
+    elif backup_mode == "filesystem":
+        for node in namespace["nodes"]:
+            if "etcd" not in node.roles:
                 continue
-            get_filesystem_snapshots = 'ls /opt/rke/etcd-snapshots'
+            get_filesystem_snapshots = "ls /opt/rke/etcd-snapshots"
             response = node.execute_command(get_filesystem_snapshots)[0]
-            filename = backup_info["etcdbackupdata"][0]['filename']
-            assert filename not in response, \
-                "The file still exist in the filesystem"
+            filename = backup_info["etcdbackupdata"][0]["filename"]
+            assert filename not in response, "The file still exist in the filesystem"
 
 
 def apply_crd(ns, file, kubectl_context):
-    return execute_kubectl_cmd('apply -f ' + file + ' -n ' + ns.name,
-                               json_out=False, stderr=True,
-                               kubeconfig=kubectl_context).decode("ascii")
+    return execute_kubectl_cmd(
+        "apply -f " + file + " -n " + ns.name,
+        json_out=False,
+        stderr=True,
+        kubeconfig=kubectl_context,
+    ).decode("ascii")
 
 
 def get_crd(ns, crd_name, kubectl_context):
-    return execute_kubectl_cmd('get ' + crd_name + ' -n ' + ns.name,
-                               json_out=False, stderr=True,
-                               kubeconfig=kubectl_context).decode("ascii")
+    return execute_kubectl_cmd(
+        "get " + crd_name + " -n " + ns.name,
+        json_out=False,
+        stderr=True,
+        kubeconfig=kubectl_context,
+    ).decode("ascii")
 
 
 def delete_crd(ns, file, kubectl_context):
-    return execute_kubectl_cmd('delete -f ' + file + ' -n ' + ns.name,
-                               json_out=False, stderr=True,
-                               kubeconfig=kubectl_context).decode("ascii")
+    return execute_kubectl_cmd(
+        "delete -f " + file + " -n " + ns.name,
+        json_out=False,
+        stderr=True,
+        kubeconfig=kubectl_context,
+    ).decode("ascii")
 
 
 def prepare_auth_data():
-    name = \
-        os.path.join(os.path.dirname(os.path.realpath(__file__)) + "/resource",
-                     AUTH_PROVIDER.lower() + ".json")
+    name = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)) + "/resource",
+        AUTH_PROVIDER.lower() + ".json",
+    )
     with open(name) as reader:
         auth_data = reader.read()
     raw = json.loads(auth_data).get("nested_group_info")
@@ -2350,7 +2420,7 @@ def prepare_auth_data():
 
 
 def is_nested():
-    """ check if the provided groups are nested groups,
+    """check if the provided groups are nested groups,
     return True if at least one of the groups contains other groups
     """
     count = 0
@@ -2363,7 +2433,7 @@ def is_nested():
 
 
 def get_group(nested=False):
-    """ return a group or a nested group"""
+    """return a group or a nested group"""
     if nested:
         # return the name of a group that contains at least one other group
         for item in nested_group["groups"]:
@@ -2386,7 +2456,7 @@ def get_group(nested=False):
 
 
 def get_user_by_group(group, nested=False):
-    """ return the list of uses in the group or nested group
+    """return the list of uses in the group or nested group
 
     if nested is False, return the direct users in the group;
     otherwise, return all users including those from nested groups
@@ -2414,7 +2484,7 @@ def get_user_by_group(group, nested=False):
 
 
 def get_a_group_and_a_user_not_in_it(nested=False):
-    """ return a group or a nested group and a user that is not in the group"""
+    """return a group or a nested group and a user that is not in the group"""
     all_users = nested_group["users"]
     for group in nested_group["groups"]:
         group_users = get_user_by_group(group, nested)
@@ -2426,37 +2496,43 @@ def get_a_group_and_a_user_not_in_it(nested=False):
 
 
 def get_group_principal_id(group_name, token=ADMIN_TOKEN, expected_status=200):
-    """ get the group's principal id from the auth provider"""
-    headers = {'Authorization': 'Bearer ' + token}
-    r = requests.post(CATTLE_AUTH_PRINCIPAL_URL,
-                      json={'name': group_name,
-                            'principalType': 'group',
-                            'responseType': 'json'},
-                      verify=False, headers=headers)
+    """get the group's principal id from the auth provider"""
+    headers = {"Authorization": "Bearer " + token}
+    r = requests.post(
+        CATTLE_AUTH_PRINCIPAL_URL,
+        json={"name": group_name, "principalType": "group", "responseType": "json"},
+        verify=False,
+        headers=headers,
+    )
     assert r.status_code == expected_status
-    return r.json()['data'][0]["id"]
+    return r.json()["data"][0]["id"]
 
 
 def login_as_auth_user(username, password, login_url=LOGIN_AS_AUTH_USER_URL):
-    """ login with the user account from the auth provider,
+    """login with the user account from the auth provider,
     and return the user token"""
-    r = requests.post(login_url, json={
-        'username': username,
-        'password': password,
-        'responseType': 'json',
-    }, verify=False)
+    r = requests.post(
+        login_url,
+        json={
+            "username": username,
+            "password": password,
+            "responseType": "json",
+        },
+        verify=False,
+    )
     assert r.status_code in [200, 201]
     return r.json()
 
 
-def validate_service_discovery(workload, scale,
-                               p_client=None, ns=None, testclient_pods=None):
+def validate_service_discovery(
+    workload, scale, p_client=None, ns=None, testclient_pods=None
+):
     expected_ips = []
     pods = p_client.list_pod(workloadId=workload["id"]).data
     assert len(pods) == scale
     for pod in pods:
         expected_ips.append(pod["status"]["podIp"])
-    host = '{0}.{1}.svc.cluster.local'.format(workload.name, ns.id)
+    host = "{0}.{1}.svc.cluster.local".format(workload.name, ns.id)
     for pod in testclient_pods:
         validate_dns_entry(pod, host, expected_ips)
 
@@ -2481,8 +2557,9 @@ def add_role_to_user(user, role):
     project = auth_get_project()
     ns = auth_get_namespace()
     if not (project and ns):
-        project, ns = create_project_and_ns(ADMIN_TOKEN, cluster,
-                                            random_test_name("p-test-auth"))
+        project, ns = create_project_and_ns(
+            ADMIN_TOKEN, cluster, random_test_name("p-test-auth")
+        )
         auth_rbac_data["project"] = project
         auth_rbac_data["namespace"] = ns
     if role in [PROJECT_OWNER, PROJECT_MEMBER, PROJECT_READ_ONLY]:
@@ -2493,7 +2570,7 @@ def add_role_to_user(user, role):
 
 
 def auth_resource_cleanup():
-    """ remove the project and namespace created for the AUTH tests"""
+    """remove the project and namespace created for the AUTH tests"""
     client, cluster = get_global_admin_client_and_cluster()
     client.delete(auth_rbac_data["project"])
     auth_rbac_data["project"] = None
@@ -2509,9 +2586,11 @@ class WebsocketLogParse:
     the class is used for receiving and parsing the message
     received from the websocket
     """
+
     def __init__(self):
         self.lock = Lock()
-        self._last_message = ''
+        self._last_message = ""
+
     def receiver(self, socket, skip, b64=True):
         """
         run a thread to receive and save the message from the web socket
@@ -2562,9 +2641,8 @@ def wait_for_cluster_delete(client, cluster_name, timeout=DEFAULT_TIMEOUT):
     cluster_count = len(cluster)
     while cluster_count != 0:
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for cluster to get deleted")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for cluster to get deleted")
+        time.sleep(0.5)
         cluster = client.list_cluster(name=cluster_name).data
         cluster_count = len(cluster)
 
@@ -2581,7 +2659,7 @@ def create_connection(url, subprotocols):
         sslopt={"cert_reqs": ssl.CERT_NONE},
         subprotocols=subprotocols,
         timeout=10,
-        cookie="R_SESS=" + USER_TOKEN
+        cookie="R_SESS=" + USER_TOKEN,
     )
     assert ws.connected, "failed to build the websocket"
     return ws
@@ -2594,9 +2672,8 @@ def wait_for_hpa_to_active(client, hpa, timeout=DEFAULT_TIMEOUT):
     hpa = hpalist[0]
     while hpa.state != "active":
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to active")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to active")
+        time.sleep(0.5)
         hpas = client.list_horizontalPodAutoscaler(uuid=hpa.uuid).data
         assert len(hpas) == 1
         hpa = hpas[0]
@@ -2607,13 +2684,14 @@ def create_pv_pvc(client, ns, nfs_ip, cluster_client):
     pv_object = create_pv(cluster_client, nfs_ip)
 
     pvc_name = random_test_name("pvc")
-    pvc_config = {"accessModes": ["ReadWriteOnce"],
-                  "name": pvc_name,
-                  "volumeId": pv_object.id,
-                  "namespaceId": ns.id,
-                  "storageClassId": "",
-                  "resources": {"requests": {"storage": "10Gi"}}
-                  }
+    pvc_config = {
+        "accessModes": ["ReadWriteOnce"],
+        "name": pvc_name,
+        "volumeId": pv_object.id,
+        "namespaceId": ns.id,
+        "storageClassId": "",
+        "resources": {"requests": {"storage": "10Gi"}},
+    }
     pvc_object = client.create_persistent_volume_claim(pvc_config)
     pvc_object = wait_for_pvc_to_be_bound(client, pvc_object, timeout=300)
 
@@ -2622,20 +2700,22 @@ def create_pv_pvc(client, ns, nfs_ip, cluster_client):
 
 def create_pv(client, nfs_ip):
     pv_name = random_test_name("pv")
-    pv_config = {"type": "persistentVolume",
-                 "accessModes": ["ReadWriteOnce"],
-                 "name": pv_name,
-                 "nfs": {"readOnly": "false",
-                         "type": "nfsvolumesource",
-                         "path": NFS_SERVER_MOUNT_PATH,
-                         "server": nfs_ip
-                         },
-                 "capacity": {"storage": "50Gi"}
-                 }
+    pv_config = {
+        "type": "persistentVolume",
+        "accessModes": ["ReadWriteOnce"],
+        "name": pv_name,
+        "nfs": {
+            "readOnly": "false",
+            "type": "nfsvolumesource",
+            "path": NFS_SERVER_MOUNT_PATH,
+            "server": nfs_ip,
+        },
+        "capacity": {"storage": "50Gi"},
+    }
     pv_object = client.create_persistent_volume(pv_config)
-    capacitydict = pv_object['capacity']
-    assert capacitydict['storage'] == '50Gi'
-    assert pv_object['type'] == 'persistentVolume'
+    capacitydict = pv_object["capacity"]
+    assert capacitydict["storage"] == "50Gi"
+    assert pv_object["type"] == "persistentVolume"
     return pv_object
 
 
@@ -2645,24 +2725,26 @@ def delete_resource_in_AWS_by_prefix(resource_prefix):
     :return: None
     """
     # delete nodes of both local and custom clusters
-    node_filter = [{
-        'Name': 'tag:Name',
-        'Values': [resource_prefix + "-*"]
-    }]
+    node_filter = [{"Name": "tag:Name", "Values": [resource_prefix + "-*"]}]
     nodes = AmazonWebServices().get_nodes(filters=node_filter)
     if nodes is None:
         print("deleting the following instances: None")
     else:
-        print("deleting the following instances: {}"
-              .format([node.public_ip_address for node in nodes]))
+        print(
+            "deleting the following instances: {}".format(
+                [node.public_ip_address for node in nodes]
+            )
+        )
         AmazonWebServices().delete_nodes(nodes)
 
     # delete load balancer and target groups
     tg_list = []
     lb_list = []
-    lb_names = [resource_prefix + '-nlb',
-                resource_prefix + '-k3s-nlb',
-                resource_prefix + '-internal-nlb']
+    lb_names = [
+        resource_prefix + "-nlb",
+        resource_prefix + "-k3s-nlb",
+        resource_prefix + "-internal-nlb",
+    ]
     for name in lb_names:
         lb_arn = AmazonWebServices().get_lb(name)
         if lb_arn is not None:
@@ -2683,8 +2765,10 @@ def delete_resource_in_AWS_by_prefix(resource_prefix):
     AmazonWebServices().delete_db(db_name)
 
     # delete the route 53 record
-    route53_names = [resource_prefix + ".qa.rancher.space.",
-                     resource_prefix + "-internal.qa.rancher.space."]
+    route53_names = [
+        resource_prefix + ".qa.rancher.space.",
+        resource_prefix + "-internal.qa.rancher.space.",
+    ]
     for name in route53_names:
         print("deleting the route53 record (if it exists): {}".format(name))
         AmazonWebServices().delete_route_53_record(name)
@@ -2693,39 +2777,35 @@ def delete_resource_in_AWS_by_prefix(resource_prefix):
     return None
 
 
-def configure_cis_requirements(aws_nodes, profile, node_roles, client,
-                               cluster):
+def configure_cis_requirements(aws_nodes, profile, node_roles, client, cluster):
     i = 0
-    if profile == 'rke-cis-1.4':
+    if profile == "rke-cis-1.4":
         for aws_node in aws_nodes:
             aws_node.execute_command("sudo sysctl -w vm.overcommit_memory=1")
             aws_node.execute_command("sudo sysctl -w kernel.panic=10")
             aws_node.execute_command("sudo sysctl -w kernel.panic_on_oops=1")
             if node_roles[i] == ["etcd"]:
                 aws_node.execute_command("sudo useradd etcd")
-            docker_run_cmd = \
-                get_custom_host_registration_cmd(client,
-                                                 cluster,
-                                                 node_roles[i],
-                                                 aws_node)
+            docker_run_cmd = get_custom_host_registration_cmd(
+                client, cluster, node_roles[i], aws_node
+            )
             aws_node.execute_command(docker_run_cmd)
             i += 1
-    elif profile == 'rke-cis-1.5':
+    elif profile == "rke-cis-1.5":
         for aws_node in aws_nodes:
             aws_node.execute_command("sudo sysctl -w vm.overcommit_memory=1")
             aws_node.execute_command("sudo sysctl -w kernel.panic=10")
             aws_node.execute_command("sudo sysctl -w vm.panic_on_oom=0")
             aws_node.execute_command("sudo sysctl -w kernel.panic_on_oops=1")
-            aws_node.execute_command("sudo sysctl -w "
-                                     "kernel.keys.root_maxbytes=25000000")
+            aws_node.execute_command(
+                "sudo sysctl -w " "kernel.keys.root_maxbytes=25000000"
+            )
             if node_roles[i] == ["etcd"]:
                 aws_node.execute_command("sudo groupadd -g 52034 etcd")
                 aws_node.execute_command("sudo useradd -u 52034 -g 52034 etcd")
-            docker_run_cmd = \
-                get_custom_host_registration_cmd(client,
-                                                 cluster,
-                                                 node_roles[i],
-                                                 aws_node)
+            docker_run_cmd = get_custom_host_registration_cmd(
+                client, cluster, node_roles[i], aws_node
+            )
             aws_node.execute_command(docker_run_cmd)
             i += 1
     time.sleep(5)
@@ -2733,20 +2813,20 @@ def configure_cis_requirements(aws_nodes, profile, node_roles, client,
 
     # the workloads under System project to get active
     time.sleep(20)
-    if profile == 'rke-cis-1.5':
+    if profile == "rke-cis-1.5":
         create_kubeconfig(cluster)
         network_policy_file = DATA_SUBDIR + "/default-allow-all.yaml"
         account_update_file = DATA_SUBDIR + "/account_update.yaml"
         items = execute_kubectl_cmd("get namespaces -A")["items"]
         all_ns = [item["metadata"]["name"] for item in items]
         for ns in all_ns:
-            execute_kubectl_cmd("apply -f {0} -n {1}".
-                                format(network_policy_file, ns))
+            execute_kubectl_cmd("apply -f {0} -n {1}".format(network_policy_file, ns))
         namespace = ["default", "kube-system"]
         for ns in namespace:
-            execute_kubectl_cmd('patch serviceaccount default'
-                                ' -n {0} -p "$(cat {1})"'.
-                                format(ns, account_update_file))
+            execute_kubectl_cmd(
+                "patch serviceaccount default"
+                ' -n {0} -p "$(cat {1})"'.format(ns, account_update_file)
+            )
     return cluster
 
 
@@ -2788,7 +2868,7 @@ def create_service_account_configfile():
         if node.controlPlane:
             server = "https://" + node.externalIpAddress + ":6443"
             break
-    assert server is not None, 'failed to get the public ip of control plane'
+    assert server is not None, "failed to get the public ip of control plane"
 
     config = """
     apiVersion: v1
@@ -2811,8 +2891,9 @@ def create_service_account_configfile():
         token: {token}
     """
     config = config.format(server=server, ca=ca, token=token)
-    config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                               name + ".yaml")
+    config_file = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), name + ".yaml"
+    )
     with open(config_file, "w") as file:
         file.write(config)
 
@@ -2833,17 +2914,17 @@ def rbac_test_file_reader(file_path=None):
     if file_path is None:
         pytest.fail("no file is provided")
     with open(file_path) as reader:
-        test_cases = json.loads(reader.read().replace("{resource_root}",
-                                                      DATA_SUBDIR))
+        test_cases = json.loads(reader.read().replace("{resource_root}", DATA_SUBDIR))
     output = []
     for cluster_role, checks in test_cases.items():
         # create a service account for each role
         name = create_service_account_configfile()
         # create the cluster role binding
-        cmd = "create clusterrolebinding {} " \
-              "--clusterrole {} " \
-              "--serviceaccount {}".format(name, cluster_role,
-                                           "default:" + name)
+        cmd = (
+            "create clusterrolebinding {} "
+            "--clusterrole {} "
+            "--serviceaccount {}".format(name, cluster_role, "default:" + name)
+        )
         execute_kubectl_cmd(cmd, json_out=False)
         for command in checks["should_pass"]:
             output.append((cluster_role, command, True, name))
@@ -2865,20 +2946,22 @@ def validate_cluster_role_rbac(cluster_role, command, authorization, name):
     kubeconfig file
     """
 
-    config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                               name + ".yaml")
-    result = execute_kubectl_cmd(command,
-                                 json_out=False,
-                                 kubeconfig=config_file,
-                                 stderr=True).decode('utf_8')
+    config_file = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), name + ".yaml"
+    )
+    result = execute_kubectl_cmd(
+        command, json_out=False, kubeconfig=config_file, stderr=True
+    ).decode("utf_8")
     if authorization:
-        assert "Error from server (Forbidden)" not in result, \
-            "{} should have the authorization to run {}".format(cluster_role,
-                                                                command)
+        assert (
+            "Error from server (Forbidden)" not in result
+        ), "{} should have the authorization to run {}".format(cluster_role, command)
     else:
-        assert "Error from server (Forbidden)" in result, \
-            "{} should NOT have the authorization to run {}".format(
-                cluster_role, command)
+        assert (
+            "Error from server (Forbidden)" in result
+        ), "{} should NOT have the authorization to run {}".format(
+            cluster_role, command
+        )
 
 
 def wait_until_app_v2_deployed(client, app_name, timeout=DEFAULT_APP_V2_TIMEOUT):
@@ -2895,16 +2978,14 @@ def wait_until_app_v2_deployed(client, app_name, timeout=DEFAULT_APP_V2_TIMEOUT)
     while True:
         app_list = []
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to Deployed")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to Deployed")
+        time.sleep(0.5)
         for app in app["data"]:
             app_list.append(app["metadata"]["name"])
             if app["metadata"]["name"] == app_name:
                 if app["status"]["summary"]["state"] == "deployed":
                     return app_list
         app = client.list_catalog_cattle_io_app()
-    return
 
 
 def wait_until_app_v2_uninstall(client, app_name, timeout=DEFAULT_APP_V2_TIMEOUT):
@@ -2920,15 +3001,13 @@ def wait_until_app_v2_uninstall(client, app_name, timeout=DEFAULT_APP_V2_TIMEOUT
     while True:
         app_list = []
         if time.time() - start > timeout:
-            raise AssertionError(
-                "Timed out waiting for state to get to Uninstalled")
-        time.sleep(.5)
+            raise AssertionError("Timed out waiting for state to get to Uninstalled")
+        time.sleep(0.5)
         for app in app["data"]:
             app_list.append(app["metadata"]["name"])
         if app_name not in app_list:
             return app_list
         app = client.list_catalog_cattle_io_app()
-    return
 
 
 def check_v2_app_and_uninstall(client, chart_name):
@@ -2937,30 +3016,27 @@ def check_v2_app_and_uninstall(client, chart_name):
         if app["metadata"]["name"] == chart_name:
             response = client.action(obj=app, action_name="uninstall")
             app_list = wait_until_app_v2_uninstall(client, chart_name)
-            assert chart_name not in app_list, \
-                "App has not uninstalled"
+            assert chart_name not in app_list, "App has not uninstalled"
 
 
-def update_and_validate_kdm(kdm_url, admin_token=ADMIN_TOKEN,
-                            rancher_api_url=CATTLE_API_URL):
+def update_and_validate_kdm(
+    kdm_url, admin_token=ADMIN_TOKEN, rancher_api_url=CATTLE_API_URL
+):
     print("Updating KDM to use {}".format(kdm_url))
-    header = {'Authorization': 'Bearer ' + admin_token}
+    header = {"Authorization": "Bearer " + admin_token}
     api_url = rancher_api_url + "/settings/rke-metadata-config"
     kdm_json = {
         "name": "rke-metadata-config",
-        "value": json.dumps({
-            "refresh-interval-minutes": "1440",
-            "url": kdm_url
-        })
+        "value": json.dumps({"refresh-interval-minutes": "1440", "url": kdm_url}),
     }
     r = requests.put(api_url, verify=False, headers=header, json=kdm_json)
     r_content = json.loads(r.content)
     assert r.ok
-    assert r_content['name'] == kdm_json['name']
-    assert r_content['value'] == kdm_json['value']
+    assert r_content["name"] == kdm_json["name"]
+    assert r_content["value"] == kdm_json["value"]
     time.sleep(2)
 
     # Refresh Kubernetes Metadata
-    kdm_refresh_url = rancher_api_url + "/kontainerdrivers?action=refresh"
+    kdm_refresh_url = f"{rancher_api_url}/kontainerdrivers?action=refresh"
     response = requests.post(kdm_refresh_url, verify=False, headers=header)
     assert response.ok

--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -1,4 +1,4 @@
-from python_terraform import * # NOQA
+from python_terraform import *  # NOQA
 from pkg_resources import packaging
 
 from .common import *  # NOQA
@@ -10,7 +10,8 @@ from .test_rke_cluster_provisioning import rke_config
 # when installing Rancher into a k3s setup
 RANCHER_HA_KUBECONFIG = os.environ.get("RANCHER_HA_KUBECONFIG")
 RANCHER_HA_HOSTNAME = os.environ.get(
-    "RANCHER_HA_HOSTNAME", RANCHER_HOSTNAME_PREFIX + ".qa.rancher.space")
+    "RANCHER_HA_HOSTNAME", RANCHER_HOSTNAME_PREFIX + ".qa.rancher.space"
+)
 resource_prefix = RANCHER_HA_HOSTNAME.split(".qa.rancher.space")[0]
 RANCHER_SERVER_URL = "https://" + RANCHER_HA_HOSTNAME
 
@@ -21,8 +22,7 @@ RANCHER_HELM_REPO = os.environ.get("RANCHER_HELM_REPO", "latest")
 RANCHER_LETSENCRYPT_EMAIL = os.environ.get("RANCHER_LETSENCRYPT_EMAIL")
 # Here is the list of cert types for HA install
 # [rancher-self-signed, byo-valid, byo-self-signed, letsencrypt]
-RANCHER_HA_CERT_OPTION = os.environ.get("RANCHER_HA_CERT_OPTION",
-                                        "rancher-self-signed")
+RANCHER_HA_CERT_OPTION = os.environ.get("RANCHER_HA_CERT_OPTION", "rancher-self-signed")
 RANCHER_VALID_TLS_CERT = os.environ.get("RANCHER_VALID_TLS_CERT")
 RANCHER_VALID_TLS_KEY = os.environ.get("RANCHER_VALID_TLS_KEY")
 RANCHER_BYO_TLS_CERT = os.environ.get("RANCHER_BYO_TLS_CERT")
@@ -30,9 +30,8 @@ RANCHER_BYO_TLS_KEY = os.environ.get("RANCHER_BYO_TLS_KEY")
 RANCHER_PRIVATE_CA_CERT = os.environ.get("RANCHER_PRIVATE_CA_CERT")
 
 RANCHER_LOCAL_CLUSTER_TYPE = os.environ.get("RANCHER_LOCAL_CLUSTER_TYPE")
-RANCHER_ADD_CUSTOM_CLUSTER = os.environ.get("RANCHER_ADD_CUSTOM_CLUSTER",
-                                            "True")
-KUBERNETES_VERSION = os.environ.get("RANCHER_LOCAL_KUBERNETES_VERSION","")
+RANCHER_ADD_CUSTOM_CLUSTER = os.environ.get("RANCHER_ADD_CUSTOM_CLUSTER", "True")
+KUBERNETES_VERSION = os.environ.get("RANCHER_LOCAL_KUBERNETES_VERSION", "")
 RANCHER_K3S_VERSION = os.environ.get("RANCHER_K3S_VERSION", "")
 
 kubeconfig_path = DATA_SUBDIR + "/kube_config_cluster-ha-filled.yml"
@@ -40,8 +39,9 @@ export_cmd = "export KUBECONFIG=" + kubeconfig_path
 
 
 def test_remove_rancher_ha():
-    assert CATTLE_TEST_URL.endswith(".qa.rancher.space"), \
-        "the CATTLE_TEST_URL need to end with .qa.rancher.space"
+    assert CATTLE_TEST_URL.endswith(
+        ".qa.rancher.space"
+    ), "the CATTLE_TEST_URL need to end with .qa.rancher.space"
     if not check_if_ok(CATTLE_TEST_URL):
         print("skip deleting clusters within the setup")
     else:
@@ -51,14 +51,16 @@ def test_remove_rancher_ha():
 
         # delete clusters except the local cluster
         clusters = client.list_cluster(id_ne="local").data
-        print("deleting the following clusters: {}"
-              .format([cluster.name for cluster in clusters]))
+        print(
+            "deleting the following clusters: {}".format(
+                [cluster.name for cluster in clusters]
+            )
+        )
         for cluster in clusters:
             print("deleting the following cluster : {}".format(cluster.name))
             delete_cluster(client, cluster)
 
-    resource_prefix = \
-        CATTLE_TEST_URL.split(".qa.rancher.space")[0].split("//")[1]
+    resource_prefix = CATTLE_TEST_URL.split(".qa.rancher.space")[0].split("//")[1]
     delete_resource_in_AWS_by_prefix(resource_prefix)
 
 
@@ -79,27 +81,25 @@ def test_install_rancher_ha(precheck_certificate_options):
             create_rke_cluster(config_path)
         elif RANCHER_LOCAL_CLUSTER_TYPE == "K3S":
             print("K3S cluster is provisioning for the local cluster")
-            k3s_kubeconfig_path = \
-                create_multiple_control_cluster()
+            k3s_kubeconfig_path = create_multiple_control_cluster()
             cmd = "cp {0} {1}".format(k3s_kubeconfig_path, kubeconfig_path)
             run_command_with_stderr(cmd)
         elif RANCHER_LOCAL_CLUSTER_TYPE == "EKS":
             create_resources_eks()
-            eks_kubeconfig_path = get_eks_kubeconfig(resource_prefix +
-                                                     "-ekscluster")
+            eks_kubeconfig_path = get_eks_kubeconfig(resource_prefix + "-ekscluster")
             cmd = "cp {0} {1}".format(eks_kubeconfig_path, kubeconfig_path)
             run_command_with_stderr(cmd)
             install_eks_ingress()
             extra_settings.append(
                 "--set ingress."
-                "extraAnnotations.\"kubernetes\\.io/ingress\\.class\"=nginx"
+                'extraAnnotations."kubernetes\\.io/ingress\\.class"=nginx'
             )
         elif RANCHER_LOCAL_CLUSTER_TYPE == "AKS":
             create_aks_cluster()
             install_aks_ingress()
             extra_settings.append(
                 "--set ingress."
-                "extraAnnotations.\"kubernetes\\.io/ingress\\.class\"=nginx"
+                'extraAnnotations."kubernetes\\.io/ingress\\.class"=nginx'
             )
     else:
         write_kubeconfig()
@@ -130,8 +130,7 @@ def test_install_rancher_ha(precheck_certificate_options):
     if RANCHER_LOCAL_CLUSTER_TYPE == "AKS":
         set_route53_with_aks_ingress()
     wait_for_status_code(url=RANCHER_SERVER_URL + "/v3", expected_code=401)
-    auth_url = \
-        RANCHER_SERVER_URL + "/v3-public/localproviders/local?action=login"
+    auth_url = RANCHER_SERVER_URL + "/v3-public/localproviders/local?action=login"
     wait_for_status_code(url=auth_url, expected_code=200)
     admin_client = set_url_and_password(RANCHER_SERVER_URL)
     cluster = get_cluster_by_name(admin_client, "local")
@@ -142,28 +141,28 @@ def test_install_rancher_ha(precheck_certificate_options):
 
 
 def create_custom_cluster(admin_client):
-    auth_url = RANCHER_SERVER_URL + \
-        "/v3-public/localproviders/local?action=login"
+    auth_url = RANCHER_SERVER_URL + "/v3-public/localproviders/local?action=login"
     wait_for_status_code(url=auth_url, expected_code=200)
     user, user_token = create_user(admin_client, auth_url)
 
-    aws_nodes = \
-        AmazonWebServices().create_multiple_nodes(
-            5, random_test_name(resource_prefix + "-custom"))
-    node_roles = [["controlplane"], ["etcd"],
-                  ["worker"], ["worker"], ["worker"]]
-    client = rancher.Client(url=RANCHER_SERVER_URL + "/v3",
-                            token=user_token, verify=False)
+    aws_nodes = AmazonWebServices().create_multiple_nodes(
+        5, random_test_name(resource_prefix + "-custom")
+    )
+    node_roles = [["controlplane"], ["etcd"], ["worker"], ["worker"], ["worker"]]
+    client = rancher.Client(
+        url=RANCHER_SERVER_URL + "/v3", token=user_token, verify=False
+    )
     cluster = client.create_cluster(
         name=random_name(),
         driver="rancherKubernetesEngine",
-        rancherKubernetesEngineConfig=rke_config)
+        rancherKubernetesEngineConfig=rke_config,
+    )
     assert cluster.state == "provisioning"
     i = 0
     for aws_node in aws_nodes:
-        docker_run_cmd = \
-            get_custom_host_registration_cmd(
-                client, cluster, node_roles[i], aws_node)
+        docker_run_cmd = get_custom_host_registration_cmd(
+            client, cluster, node_roles[i], aws_node
+        )
         aws_node.execute_command(docker_run_cmd)
         i += 1
     validate_cluster(client, cluster, userToken=user_token)
@@ -188,27 +187,25 @@ def create_resources():
     lbDns = lb["LoadBalancers"][0]["DNSName"]
 
     # Upsert the route53 record -- if it exists, update, if not, insert
-    AmazonWebServices().upsert_route_53_record_cname(RANCHER_HA_HOSTNAME,
-                                                     lbDns)
+    AmazonWebServices().upsert_route_53_record_cname(RANCHER_HA_HOSTNAME, lbDns)
 
     # Create the target groups
-    tg80 = AmazonWebServices(). \
-        create_ha_target_group(80, resource_prefix + "-tg-80")
-    tg443 = AmazonWebServices(). \
-        create_ha_target_group(443, resource_prefix + "-tg-443")
+    tg80 = AmazonWebServices().create_ha_target_group(80, resource_prefix + "-tg-80")
+    tg443 = AmazonWebServices().create_ha_target_group(443, resource_prefix + "-tg-443")
     tg80Arn = tg80["TargetGroups"][0]["TargetGroupArn"]
     tg443Arn = tg443["TargetGroups"][0]["TargetGroupArn"]
 
     # Create listeners for the load balancer, to forward to the target groups
-    AmazonWebServices().create_ha_nlb_listener(loadBalancerARN=lbArn,
-                                               port=80,
-                                               targetGroupARN=tg80Arn)
-    AmazonWebServices().create_ha_nlb_listener(loadBalancerARN=lbArn,
-                                               port=443,
-                                               targetGroupARN=tg443Arn)
+    AmazonWebServices().create_ha_nlb_listener(
+        loadBalancerARN=lbArn, port=80, targetGroupARN=tg80Arn
+    )
+    AmazonWebServices().create_ha_nlb_listener(
+        loadBalancerARN=lbArn, port=443, targetGroupARN=tg443Arn
+    )
     targets = []
-    aws_nodes = AmazonWebServices().\
-        create_multiple_nodes(3, resource_prefix + "-server")
+    aws_nodes = AmazonWebServices().create_multiple_nodes(
+        3, resource_prefix + "-server"
+    )
     assert len(aws_nodes) == 3
 
     for aws_node in aws_nodes:
@@ -224,55 +221,65 @@ def create_resources():
 
 
 def install_cert_manager():
-    manifests = "https://github.com/jetstack/cert-manager/releases/download/" \
-                "{0}/cert-manager.crds.yaml".format(CERT_MANAGER_VERSION)
+    manifests = (
+        "https://github.com/jetstack/cert-manager/releases/download/"
+        "{0}/cert-manager.crds.yaml".format(CERT_MANAGER_VERSION)
+    )
     cm_repo = "https://charts.jetstack.io"
 
     run_command_with_stderr(export_cmd + " && kubectl apply -f " + manifests)
     run_command_with_stderr("helm_v3 repo add jetstack " + cm_repo)
     run_command_with_stderr("helm_v3 repo update")
-    run_command_with_stderr(export_cmd + " && " +
-                            "kubectl create namespace cert-manager")
-    run_command_with_stderr(export_cmd + " && " +
-                            "helm_v3 install cert-manager "
-                            "jetstack/cert-manager "
-                            "--namespace cert-manager "
-                            "--version {0}".format(CERT_MANAGER_VERSION))
+    run_command_with_stderr(
+        export_cmd + " && " + "kubectl create namespace cert-manager"
+    )
+    run_command_with_stderr(
+        export_cmd + " && " + "helm_v3 install cert-manager "
+        "jetstack/cert-manager "
+        "--namespace cert-manager "
+        "--version {0}".format(CERT_MANAGER_VERSION)
+    )
     time.sleep(120)
 
 
 def install_eks_ingress():
-    run_command_with_stderr(export_cmd + " && kubectl apply -f " +
-                            DATA_SUBDIR + "/eks_nlb.yml")
+    run_command_with_stderr(
+        export_cmd + " && kubectl apply -f " + DATA_SUBDIR + "/eks_nlb.yml"
+    )
 
 
 def set_route53_with_eks_ingress():
-    kubectl_ingress = "kubectl get ingress -n cattle-system -o " \
-                      "jsonpath=\"" \
-                      "{.items[0].status.loadBalancer.ingress[0].hostname}\""
-    ingress_address = run_command_with_stderr(export_cmd
-                                              + " && " +
-                                              kubectl_ingress).decode()
-    AmazonWebServices().upsert_route_53_record_cname(RANCHER_HA_HOSTNAME,
-                                                     ingress_address)
+    kubectl_ingress = (
+        "kubectl get ingress -n cattle-system -o "
+        'jsonpath="'
+        '{.items[0].status.loadBalancer.ingress[0].hostname}"'
+    )
+    ingress_address = run_command_with_stderr(
+        export_cmd + " && " + kubectl_ingress
+    ).decode()
+    AmazonWebServices().upsert_route_53_record_cname(
+        RANCHER_HA_HOSTNAME, ingress_address
+    )
     time.sleep(60)
 
 
 def set_route53_with_aks_ingress():
-    kubectl_ingress = "kubectl get svc -n ingress-nginx " \
-                      "ingress-nginx-controller -o " \
-                      "jsonpath=\"" \
-                      "{.status.loadBalancer.ingress[0].ip}\""
+    kubectl_ingress = (
+        "kubectl get svc -n ingress-nginx "
+        "ingress-nginx-controller -o "
+        'jsonpath="'
+        '{.status.loadBalancer.ingress[0].ip}"'
+    )
     time.sleep(10)
-    ingress_address = run_command_with_stderr(export_cmd
-                                              + " && " +
-                                              kubectl_ingress).decode()
+    ingress_address = run_command_with_stderr(
+        export_cmd + " && " + kubectl_ingress
+    ).decode()
 
     print("AKS INGRESS ADDRESS:")
     print(ingress_address)
-    AmazonWebServices().upsert_route_53_record_cname(RANCHER_HA_HOSTNAME,
-                                                     ingress_address,
-                                                     record_type='A')
+    AmazonWebServices().upsert_route_53_record_cname(
+        RANCHER_HA_HOSTNAME, ingress_address, record_type="A"
+    )
     time.sleep(60)
 
 
@@ -282,44 +289,59 @@ def add_repo_create_namespace(repo=RANCHER_HELM_REPO):
 
     run_command_with_stderr("helm_v3 repo add " + repo_name + " " + repo_url)
     run_command_with_stderr("helm_v3 repo update")
-    run_command_with_stderr(export_cmd + " && " +
-                            "kubectl create namespace cattle-system")
+    run_command_with_stderr(
+        export_cmd + " && " + "kubectl create namespace cattle-system"
+    )
 
 
-def install_rancher(type=RANCHER_HA_CERT_OPTION, repo=RANCHER_HELM_REPO,
-                    upgrade=False, extra_settings=None):
+def install_rancher(
+    type=RANCHER_HA_CERT_OPTION,
+    repo=RANCHER_HELM_REPO,
+    upgrade=False,
+    extra_settings=None,
+):
     operation = "install"
+    global RANCHER_HA_HOSTNAME
 
     if upgrade:
         operation = "upgrade"
 
-    helm_rancher_cmd = \
-        export_cmd + " && helm_v3 " + operation + " rancher " + \
-        "rancher-" + repo + "/rancher " + \
-        "--version " + RANCHER_CHART_VERSION + " " + \
-        "--namespace cattle-system " + \
-        "--set hostname=" + RANCHER_HA_HOSTNAME
+    helm_rancher_cmd = (
+        export_cmd
+        + " && helm_v3 "
+        + operation
+        + " rancher "
+        + "rancher-"
+        + repo
+        + "/rancher "
+        + "--version "
+        + RANCHER_CHART_VERSION
+        + " "
+        + "--namespace cattle-system "
+        + "--set hostname="
+        + RANCHER_HA_HOSTNAME
+    )
 
-    if type == 'letsencrypt':
-        helm_rancher_cmd = \
-            helm_rancher_cmd + \
-            " --set ingress.tls.source=letsEncrypt " + \
-            "--set letsEncrypt.email=" + \
-            RANCHER_LETSENCRYPT_EMAIL
-    elif type == 'byo-self-signed':
-        helm_rancher_cmd = \
-            helm_rancher_cmd + \
-            " --set ingress.tls.source=secret " + \
-            "--set privateCA=true"
-    elif type == 'byo-valid':
-        helm_rancher_cmd = \
-            helm_rancher_cmd + \
-            " --set ingress.tls.source=secret"
+    if type == "letsencrypt":
+        helm_rancher_cmd = (
+            helm_rancher_cmd
+            + " --set ingress.tls.source=letsEncrypt "
+            + "--set letsEncrypt.email="
+            + RANCHER_LETSENCRYPT_EMAIL
+        )
+    elif type == "byo-self-signed":
+        helm_rancher_cmd = (
+            helm_rancher_cmd
+            + " --set ingress.tls.source=secret "
+            + "--set privateCA=true"
+        )
+    elif type == "byo-valid":
+        helm_rancher_cmd = helm_rancher_cmd + " --set ingress.tls.source=secret"
 
     if RANCHER_IMAGE_TAG != "" and RANCHER_IMAGE_TAG is not None:
-        helm_rancher_cmd = \
-            helm_rancher_cmd + \
-            " --set rancherImageTag=" + RANCHER_IMAGE_TAG
+        helm_rancher_cmd = (
+            helm_rancher_cmd + " --set rancherImageTag=" + RANCHER_IMAGE_TAG
+        )
 
     if operation == "install":
         if type == "byo-self-signed":
@@ -338,10 +360,12 @@ def install_rancher(type=RANCHER_HA_CERT_OPTION, repo=RANCHER_HELM_REPO,
     time.sleep(120)
 
     # set trace logging
-    set_trace_cmd = "kubectl -n cattle-system get pods -l app=rancher " + \
-        "--no-headers -o custom-columns=name:.metadata.name | " + \
-        "while read rancherpod; do kubectl -n cattle-system " + \
-        "exec $rancherpod -c rancher -- loglevel --set trace; done"
+    set_trace_cmd = (
+        "kubectl -n cattle-system get pods -l app=rancher "
+        + "--no-headers -o custom-columns=name:.metadata.name | "
+        + "while read rancherpod; do kubectl -n cattle-system "
+        + "exec $rancherpod -c rancher -- loglevel --set trace; done"
+    )
     run_command_with_stderr(set_trace_cmd)
 
 
@@ -359,12 +383,16 @@ def create_tls_secrets(valid_cert):
         write_encoded_certs(key_path, RANCHER_BYO_TLS_KEY)
         write_encoded_certs(ca_path, RANCHER_PRIVATE_CA_CERT)
 
-    tls_command = export_cmd + " && kubectl -n cattle-system " \
-                               "create secret tls tls-rancher-ingress " \
-                               "--cert=" + cert_path + " --key=" + key_path
-    ca_command = export_cmd + " && kubectl -n cattle-system " \
-                              "create secret generic tls-ca " \
-                              "--from-file=" + ca_path
+    tls_command = (
+        export_cmd + " && kubectl -n cattle-system "
+        "create secret tls tls-rancher-ingress "
+        "--cert=" + cert_path + " --key=" + key_path
+    )
+    ca_command = (
+        export_cmd + " && kubectl -n cattle-system "
+        "create secret generic tls-ca "
+        "--from-file=" + ca_path
+    )
 
     run_command_with_stderr(tls_command)
 
@@ -386,8 +414,9 @@ def write_kubeconfig():
 
 def set_url_and_password(rancher_url, server_url=None):
     admin_token = set_url_password_token(rancher_url, server_url)
-    admin_client = rancher.Client(url=rancher_url + "/v3",
-                                  token=admin_token, verify=False)
+    admin_client = rancher.Client(
+        url=rancher_url + "/v3", token=admin_token, verify=False
+    )
     auth_url = rancher_url + "/v3-public/localproviders/local?action=login"
     user, user_token = create_user(admin_client, auth_url)
     env_details = "env.CATTLE_TEST_URL='" + rancher_url + "'\n"
@@ -404,23 +433,32 @@ def create_rke_cluster(config_path):
 
 def check_rke_ingress_rollout():
     rke_version = run_command_with_stderr('rke -v | cut -d " " -f 3')
-    rke_version = ''.join(rke_version.decode('utf-8').split())
+    rke_version = "".join(rke_version.decode("utf-8").split())
     print("RKE VERSION: " + rke_version)
-    k8s_version = run_command_with_stderr(export_cmd + " && " +
-                                          'kubectl version --short | grep -i server | cut -d " " -f 3')
-    k8s_version = ''.join(k8s_version.decode('utf-8').split())
+    k8s_version = run_command_with_stderr(
+        export_cmd
+        + " && "
+        + 'kubectl version --short | grep -i server | cut -d " " -f 3'
+    )
+    k8s_version = "".join(k8s_version.decode("utf-8").split())
     print("KUBERNETES VERSION: " + k8s_version)
     if packaging.version.parse(rke_version) > packaging.version.parse("v1.2"):
         if packaging.version.parse(k8s_version) >= packaging.version.parse("v1.21"):
             run_command_with_stderr(
-                export_cmd + " && " +
-                "kubectl -n ingress-nginx rollout status ds/nginx-ingress-controller")
+                export_cmd
+                + " && "
+                + "kubectl -n ingress-nginx rollout status ds/nginx-ingress-controller"
+            )
             run_command_with_stderr(
-                export_cmd + " && " +
-                "kubectl -n ingress-nginx wait --for=condition=complete job/ingress-nginx-admission-create")
+                export_cmd
+                + " && "
+                + "kubectl -n ingress-nginx wait --for=condition=complete job/ingress-nginx-admission-create"
+            )
             run_command_with_stderr(
-                export_cmd + " && " +
-                "kubectl -n ingress-nginx wait --for=condition=complete job/ingress-nginx-admission-patch")
+                export_cmd
+                + " && "
+                + "kubectl -n ingress-nginx wait --for=condition=complete job/ingress-nginx-admission-patch"
+            )
 
 
 def print_kubeconfig():
@@ -428,7 +466,8 @@ def print_kubeconfig():
     kubeconfig_contents = kubeconfig_file.read()
     kubeconfig_file.close()
     kubeconfig_contents_encoded = base64.b64encode(
-        kubeconfig_contents.encode("utf-8")).decode("utf-8")
+        kubeconfig_contents.encode("utf-8")
+    ).decode("utf-8")
     print("\n\n" + kubeconfig_contents + "\n\n")
     print("\nBase64 encoded: \n\n" + kubeconfig_contents_encoded + "\n\n")
 
@@ -441,12 +480,9 @@ def create_rke_cluster_config(aws_nodes):
     rkeconfig = rkeconfig.replace("$ip2", aws_nodes[1].public_ip_address)
     rkeconfig = rkeconfig.replace("$ip3", aws_nodes[2].public_ip_address)
 
-    rkeconfig = rkeconfig.replace("$internalIp1",
-                                  aws_nodes[0].private_ip_address)
-    rkeconfig = rkeconfig.replace("$internalIp2",
-                                  aws_nodes[1].private_ip_address)
-    rkeconfig = rkeconfig.replace("$internalIp3",
-                                  aws_nodes[2].private_ip_address)
+    rkeconfig = rkeconfig.replace("$internalIp1", aws_nodes[0].private_ip_address)
+    rkeconfig = rkeconfig.replace("$internalIp2", aws_nodes[1].private_ip_address)
+    rkeconfig = rkeconfig.replace("$internalIp3", aws_nodes[2].private_ip_address)
 
     rkeconfig = rkeconfig.replace("$user1", aws_nodes[0].ssh_user)
     rkeconfig = rkeconfig.replace("$user2", aws_nodes[1].ssh_user)
@@ -466,17 +502,21 @@ def create_rke_cluster_config(aws_nodes):
 
 def create_aks_cluster():
     tf_dir = DATA_SUBDIR + "/" + "terraform/aks"
-    aks_k8_s_version = os.environ.get('RANCHER_AKS_K8S_VERSION', '')
-    aks_location = os.environ.get('RANCHER_AKS_LOCATION', '')
-    client_id = os.environ.get('ARM_CLIENT_ID', '')
-    client_secret = os.environ.get('ARM_CLIENT_SECRET', '')
+    aks_k8_s_version = os.environ.get("RANCHER_AKS_K8S_VERSION", "")
+    aks_location = os.environ.get("RANCHER_AKS_LOCATION", "")
+    client_id = os.environ.get("ARM_CLIENT_ID", "")
+    client_secret = os.environ.get("ARM_CLIENT_SECRET", "")
 
-    tf = Terraform(working_dir=tf_dir,
-                   variables={'kubernetes_version': aks_k8_s_version,
-                              'location': aks_location,
-                              'client_id': client_id,
-                              'client_secret': client_secret,
-                              'cluster_name': resource_prefix})
+    tf = Terraform(
+        working_dir=tf_dir,
+        variables={
+            "kubernetes_version": aks_k8_s_version,
+            "location": aks_location,
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "cluster_name": resource_prefix,
+        },
+    )
 
     print("Creating cluster")
     tf.init()
@@ -490,38 +530,41 @@ def create_aks_cluster():
 
 
 def install_aks_ingress():
-    run_command_with_stderr(export_cmd + " && kubectl apply -f " +
-                            DATA_SUBDIR + "/aks_nlb.yml")
+    run_command_with_stderr(
+        export_cmd + " && kubectl apply -f " + DATA_SUBDIR + "/aks_nlb.yml"
+    )
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def precheck_certificate_options():
-    if RANCHER_HA_CERT_OPTION == 'byo-valid':
-        if RANCHER_VALID_TLS_CERT == '' or \
-           RANCHER_VALID_TLS_KEY == '' or \
-           RANCHER_VALID_TLS_CERT is None or \
-           RANCHER_VALID_TLS_KEY is None:
+    if RANCHER_HA_CERT_OPTION == "byo-valid":
+        if (
+            RANCHER_VALID_TLS_CERT == ""
+            or RANCHER_VALID_TLS_KEY == ""
+            or RANCHER_VALID_TLS_CERT is None
+            or RANCHER_VALID_TLS_KEY is None
+        ):
+            raise pytest.skip("Valid certificates not found in environment variables")
+    elif RANCHER_HA_CERT_OPTION == "byo-self-signed":
+        if (
+            RANCHER_BYO_TLS_CERT == ""
+            or RANCHER_BYO_TLS_KEY == ""
+            or RANCHER_PRIVATE_CA_CERT == ""
+            or RANCHER_BYO_TLS_CERT is None
+            or RANCHER_BYO_TLS_KEY is None
+            or RANCHER_PRIVATE_CA_CERT is None
+        ):
             raise pytest.skip(
-                'Valid certificates not found in environment variables')
-    elif RANCHER_HA_CERT_OPTION == 'byo-self-signed':
-        if RANCHER_BYO_TLS_CERT == '' or \
-           RANCHER_BYO_TLS_KEY == '' or \
-           RANCHER_PRIVATE_CA_CERT == '' or \
-           RANCHER_BYO_TLS_CERT is None or \
-           RANCHER_BYO_TLS_KEY is None or \
-           RANCHER_PRIVATE_CA_CERT is None:
-            raise pytest.skip(
-                'Self signed certificates not found in environment variables')
-    elif RANCHER_HA_CERT_OPTION == 'letsencrypt':
-        if RANCHER_LETSENCRYPT_EMAIL == '' or \
-           RANCHER_LETSENCRYPT_EMAIL is None:
-            raise pytest.skip(
-                'LetsEncrypt email is not found in environment variables')
+                "Self signed certificates not found in environment variables"
+            )
+    elif RANCHER_HA_CERT_OPTION == "letsencrypt":
+        if RANCHER_LETSENCRYPT_EMAIL == "" or RANCHER_LETSENCRYPT_EMAIL is None:
+            raise pytest.skip("LetsEncrypt email is not found in environment variables")
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def precheck_upgrade_options():
-    if RANCHER_HA_KUBECONFIG == '' or RANCHER_HA_KUBECONFIG is None:
-        raise pytest.skip('Kubeconfig is not found for upgrade!')
-    if RANCHER_HA_HOSTNAME == '' or RANCHER_HA_HOSTNAME is None:
-        raise pytest.skip('Hostname is not found for upgrade!')
+    if RANCHER_HA_KUBECONFIG == "" or RANCHER_HA_KUBECONFIG is None:
+        raise pytest.skip("Kubeconfig is not found for upgrade!")
+    if RANCHER_HA_HOSTNAME == "" or RANCHER_HA_HOSTNAME is None:
+        raise pytest.skip("Hostname is not found for upgrade!")


### PR DESCRIPTION
When running the HA deploy job, I included a hyphen in `RANCHER_HOSTNAME_PREFIX` value. This caused a bunch of stuff to run and do unnecessary work long before the test finally failed. It makes sense that we would want to validate configuration parameters such as RANCHER_HOSTNAME_PREFIX before doing any actual provisioning, deployments, etc.