### PR TITLE
Add generation field to ETCDSnapshotCreate

### DIFF
--- a/pkg/apis/rke.cattle.io/v1/etcd.go
+++ b/pkg/apis/rke.cattle.io/v1/etcd.go
@@ -16,6 +16,8 @@ type ETCDSnapshotCreate struct {
 	Name     string          `json:"name,omitempty"`
 	NodeName string          `json:"nodeName,omitempty"`
 	S3       *ETCDSnapshotS3 `json:"s3,omitempty"`
+	// Changing the Generation is the only thing required to initiate a snapshot creation.
+	Generation int `json:"generation,omitempty"`
 }
 
 type ETCDSnapshot struct {


### PR DESCRIPTION
Previously, the UI would put a blank ETCDSnapshotCreate object on the
cluster spec when the user wanted to create an on-demand snapshot. This
caused an issue where multiple on-demand snapshots could not be created
this way because the backend would not detect any changes (the
ETCDSnapshotCreate object would remain blank).

After this change, the UI will update the generation field when a new
on-demand snapshot should be created and the backend will detect this.

Issue:
https://github.com/rancher/rancher/issues/32391