### PR TITLE
[2.6] Remove roles when roleTemplate is deleted

### DIFF
--- a/pkg/controllers/management/auth/role_template_lifecycle.go
+++ b/pkg/controllers/management/auth/role_template_lifecycle.go
@@ -3,9 +3,12 @@ package auth
 import (
 	"fmt"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/rancher/wrangler/pkg/apply"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,6 +27,8 @@ type roleTemplateLifecycle struct {
 	crtbIndexer    cache.Indexer
 	crtbClient     v3.ClusterRoleTemplateBindingInterface
 	clusters       v3.ClusterInterface
+	roles          rbacv1.RoleInterface
+	roleLister     rbacv1.RoleLister
 	clusterManager *clustermanager.Manager
 }
 
@@ -37,6 +42,8 @@ func newRoleTemplateLifecycle(management *config.ManagementContext, clusterManag
 		crtbIndexer:    crtbInformer.GetIndexer(),
 		crtbClient:     management.Management.ClusterRoleTemplateBindings(""),
 		clusters:       management.Management.Clusters(""),
+		roles:          management.RBAC.Roles(""),
+		roleLister:     management.RBAC.Roles("").Controller().Lister(),
 		clusterManager: clusterManager,
 	}
 	return rtl
@@ -99,14 +106,39 @@ func (rtl *roleTemplateLifecycle) Remove(obj *v3.RoleTemplate) (runtime.Object, 
 			}
 			continue
 		}
-
 	}
 
 	if len(allErrors) > 0 {
 		return obj, fmt.Errorf("errors deleting dowstream clusterRole: %v", allErrors)
 	}
 
-	return obj, nil
+	return obj, rtl.removeAuthV2Roles(obj)
+}
+
+// removeAuthV2Roles finds any roles based off the owner annotation from the incoming roleTemplate.
+// This is similar to an ownerReference but this is used across namespaces which ownerReferences does not support.
+func (rtl *roleTemplateLifecycle) removeAuthV2Roles(roleTemplate *v3.RoleTemplate) error {
+	// Get the selector for the dependent roles
+	selector, err := apply.GetSelectorFromOwner("auth-prov-v2-roletemplate", roleTemplate)
+	if err != nil {
+		return err
+	}
+
+	roles, err := rtl.roleLister.List("", selector)
+	if err != nil {
+		return err
+	}
+
+	var returnErr error
+	for _, role := range roles {
+		err := rtl.roles.DeleteNamespaced(role.Namespace, role.Name, &metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			// Combine all errors so we try our best to delete everything in the first run
+			returnErr = multierror.Append(returnErr, err)
+		}
+	}
+
+	return returnErr
 }
 
 // enqueue any prtbs linked to this roleTemplate in order to re-sync them via reconcileBindings

--- a/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
+++ b/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
@@ -61,7 +61,7 @@ func Register(ctx context.Context, clients *wrangler.Context) error {
 
 	h.dynamic.AddIndexer(clusterIndexed, h.gvkMatcher, indexByCluster)
 	h.dynamic.OnChange(ctx, "auth-prov-v2-trigger", h.gvkMatcher, h.OnClusterObjectChanged)
-	clients.Mgmt.RoleTemplate().OnChange(ctx, "auth-prov-v2", h.OnChange)
+	clients.Mgmt.RoleTemplate().OnChange(ctx, "auth-prov-v2-roletemplate", h.OnChange)
 	clients.Mgmt.ClusterRoleTemplateBinding().OnChange(ctx, "auth-prov-v2-crtb", h.OnCRTB)
 	clients.CRD.CustomResourceDefinition().OnChange(ctx, "auth-prov-v2-crd", h.OnCRD)
 	clients.Provisioning.Cluster().Cache().AddIndexer(byClusterName, func(obj *v1.Cluster) ([]string, error) {

--- a/pkg/controllers/management/authprovisioningv2/role.go
+++ b/pkg/controllers/management/authprovisioningv2/role.go
@@ -100,18 +100,21 @@ func (h *handler) OnClusterObjectChanged(obj runtime.Object) (runtime.Object, er
 	if err != nil {
 		return nil, err
 	}
-	meta, err := meta.Accessor(obj)
+	objMeta, err := meta.Accessor(obj)
 	if err != nil {
 		return nil, err
 	}
 	for _, clusterName := range clusterNames {
-		h.roleTemplateController.Enqueue(fmt.Sprintf("cluster/%s/%s", meta.GetNamespace(), clusterName))
+		h.roleTemplateController.Enqueue(fmt.Sprintf("cluster/%s/%s", objMeta.GetNamespace(), clusterName))
 	}
 	return obj, nil
 }
 
 func (h *handler) OnChange(key string, rt *v3.RoleTemplate) (*v3.RoleTemplate, error) {
 	if rt != nil {
+		if rt.DeletionTimestamp != nil {
+			return rt, nil
+		}
 		return rt, h.objects(rt, true, nil)
 	}
 
@@ -207,18 +210,18 @@ func (h *handler) objects(rt *v3.RoleTemplate, enqueue bool, cluster *v1.Cluster
 	return nil
 }
 
-func (h *handler) getResourceNames(rt *v3.RoleTemplate, resourceMatch resourceMatch, cluster *v1.Cluster) ([]string, error) {
+func (h *handler) getResourceNames(resourceMatch resourceMatch, cluster *v1.Cluster) ([]string, error) {
 	objs, err := h.dynamic.GetByIndex(resourceMatch.GVK, clusterIndexed, fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name))
 	if err != nil {
 		return nil, err
 	}
 	result := make([]string, 0, len(objs))
 	for _, obj := range objs {
-		meta, err := meta.Accessor(obj)
+		objMeta, err := meta.Accessor(obj)
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, meta.GetName())
+		result = append(result, objMeta.GetName())
 	}
 	return result, nil
 }
@@ -236,11 +239,19 @@ func (h *handler) createRoleForCluster(rt *v3.RoleTemplate, matches []match, clu
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      roleTemplateRoleName(rt.Name, cluster.Name),
 			Namespace: cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: cluster.APIVersion,
+					Kind:       cluster.Kind,
+					Name:       cluster.Name,
+					UID:        cluster.UID,
+				},
+			},
 		},
 	}
 
 	for _, match := range matches {
-		names, err := h.getResourceNames(rt, match.Match, cluster)
+		names, err := h.getResourceNames(match.Match, cluster)
 		if err != nil {
 			return err
 		}
@@ -257,9 +268,8 @@ func (h *handler) createRoleForCluster(rt *v3.RoleTemplate, matches []match, clu
 
 	return h.apply.
 		WithListerNamespace(role.Namespace).
-		WithSetID(cluster.Name).
+		WithSetID("auth-prov-v2-roletemplate").
 		WithOwner(rt).
-		WithSetOwnerReference(true, true).
 		ApplyObjects(&role)
 }
 


### PR DESCRIPTION
Problem:
roles not being cleaned up when a roleTemplate or cluster is deleted

Solution:
Add an owner reference to the cluster as this is more likely to get
deleted
Add a cleanup to the roleTemplate lifecycle to remove any dependent
roles

https://github.com/rancher/rancher/issues/32414