### PR TITLE
Fix S3 support for etcd snapshots

### DIFF
--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -151,6 +151,10 @@ func New(ctx context.Context, clients *wrangler.Context) *Planner {
 		kubeconfig:                    kubeconfig.New(clients),
 		etcdRestore:                   newETCDRestore(clients, store),
 		etcdCreate:                    newETCDCreate(clients, store),
+		etcdArgs: s3Args{
+			prefix:      "etcd-",
+			secretCache: clients.Core.Secret().Cache(),
+		},
 	}
 }
 

--- a/pkg/provisioningv2/rke2/planner/s3args.go
+++ b/pkg/provisioningv2/rke2/planner/s3args.go
@@ -7,7 +7,6 @@ import (
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2/machineprovision"
-	namespaces "github.com/rancher/rancher/pkg/namespace"
 	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/kv"
 )
@@ -90,9 +89,6 @@ func getS3Credential(secretCache corecontrollers.SecretCache, namespace, name, r
 	secret, err := machineprovision.GetCloudCredentialSecret(secretCache, namespace, name)
 	if err != nil {
 		return result, fmt.Errorf("failed to lookup etcdSnapshotCloudCredentialName: %w", err)
-	}
-	if secret.Type != "provisioning.cattle.io/cloud-credential" && secret.Namespace != namespaces.GlobalNamespace {
-		return result, fmt.Errorf("expected secret of type provisioning.cattle.io/cloud-credential, got [%s]", secret.Type)
 	}
 
 	data := map[string][]byte{}


### PR DESCRIPTION
Previously, enabling S3 config for etcd snapshots caused Rancher to
panic because of an uninitialized struct.

Additionally, Rancher expected the cloud credential for the S3
credentials to either be of a certain type or in a certain namespace.
This is no longer needed and the check for this has been removed.

Issue:
https://github.com/rancher/rancher/issues/33950