### PR TITLE
Remove MachineTemplate status from CRD

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/dynamicschema/dynamicschema.go
+++ b/pkg/controllers/provisioningv2/rke2/dynamicschema/dynamicschema.go
@@ -74,7 +74,7 @@ func addMachineSchema(name string, specSchema, statusSchema *schemas.Schema, all
 	})
 }
 
-func addMachineTemplateSchema(name string, specSchema, statusSchema *schemas.Schema, allSchemas *schemas.Schemas) (string, error) {
+func addMachineTemplateSchema(name string, specSchema *schemas.Schema, allSchemas *schemas.Schemas) (string, error) {
 	templateTemplateSpecSchemaID := name + "MachineTemplateTemplateSpec"
 	err := allSchemas.AddSchema(schemas.Schema{
 		ID: templateTemplateSpecSchemaID,
@@ -111,9 +111,6 @@ func addMachineTemplateSchema(name string, specSchema, statusSchema *schemas.Sch
 			"spec": {
 				Type: templateSpecSchemaID,
 			},
-			"status": {
-				Type: statusSchema.ID,
-			},
 		},
 	})
 }
@@ -139,7 +136,7 @@ func getSchemas(name string, spec *v3.DynamicSchemaSpec) (string, string, string
 		return "", "", "", nil, err
 	}
 
-	templateID, err := addMachineTemplateSchema(name, specSchema, statusSchema, allSchemas)
+	templateID, err := addMachineTemplateSchema(name, specSchema, allSchemas)
 	if err != nil {
 		return "", "", "", nil, err
 	}
@@ -251,6 +248,8 @@ func (h *handler) OnChange(obj *v3.DynamicSchema, status v3.DynamicSchemaStatus)
 		if err != nil {
 			return nil, status, err
 		}
+
+		_, ok := props.Properties["status"]
 		crd := crd.CRD{
 			GVK: schema.GroupVersionKind{
 				Group:   machineAPIGroup,
@@ -262,7 +261,7 @@ func (h *handler) OnChange(obj *v3.DynamicSchema, status v3.DynamicSchemaStatus)
 				"cluster.x-k8s.io/v1alpha4":      "v1",
 				"auth.cattle.io/cluster-indexed": "true",
 			},
-			Status: true,
+			Status: ok,
 		}
 
 		if nodeConfigID == id {


### PR DESCRIPTION
The status of a MachineTemplate was not being used and was causing
issues with backup/restore. Since this status was not being used, it is
removed.

Issue:
https://github.com/rancher/rancher/issues/33684