### PR TITLE
Adding missing label to the insecure command.

### DIFF
--- a/pkg/controllers/dashboard/clusterregistrationtoken/status.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/status.go
@@ -22,7 +22,7 @@ const (
 	nodeCommandFormat                    = "sudo docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run %s %s --server %s --token %s%s"
 	rke2NodeCommandFormat                = "curl -fL %s | sudo %s sh -s - --server %s --label 'cattle.io/os=linux' --token %s%s"
 	rke2WindowsNodeCommandFormat         = `curl.exe -fL %s -o install.ps1 && powershell.exe -ExecutionPolicy Bypass -Command "./install.ps1 -Server %s -Label 'cattle.io/os=windows' -Token %s -Worker%s"`
-	rke2InsecureNodeCommandFormat        = "curl --insecure -fL %s | sudo %s sh -s - --server %s --token %s%s"
+	rke2InsecureNodeCommandFormat        = "curl --insecure -fL %s | sudo %s sh -s - --server %s --label 'cattle.io/os=linux' --token %s%s"
 	rke2InsecureWindowsNodeCommandFormat = `curl.exe --insecure -fL %s -o install.ps1 && powershell.exe -ExecutionPolicy Bypass -Command "./install.ps1 -Server %s -Label 'cattle.io/os=windows' -Token %s -Worker%s"`
 	loginCommandFormat                   = "echo \"%s\" | sudo docker login --username %s --password-stdin %s"
 	windowsNodeCommandFormat             = `PowerShell -NoLogo -NonInteractive -Command "& {docker run -v c:\:c:\host %s%s bootstrap --server %s --token %s%s%s | iex}"`

--- a/tests/integration/pkg/tests/custom/custom_test.go
+++ b/tests/integration/pkg/tests/custom/custom_test.go
@@ -62,7 +62,7 @@ func TestCustomOneNode(t *testing.T) {
 	if err := json.Unmarshal([]byte(machines.Items[0].Annotations[planner.LabelsAnnotation]), &labels); err != nil {
 		t.Error(err)
 	}
-	assert.Equal(t, labels, map[string]string{"foo": "bar", "ball": "life"})
+	assert.Equal(t, labels, map[string]string{"cattle.io/os": "linux", "foo": "bar", "ball": "life"})
 }
 
 func TestCustomThreeNode(t *testing.T) {
@@ -116,7 +116,7 @@ func TestCustomThreeNode(t *testing.T) {
 		if err := json.Unmarshal([]byte(m.Annotations[planner.LabelsAnnotation]), &labels); err != nil {
 			t.Error(err)
 		}
-		assert.Equal(t, labels, map[string]string{"rancher": "awesome"})
+		assert.Equal(t, labels, map[string]string{"cattle.io/os": "linux", "rancher": "awesome"})
 	}
 }
 
@@ -252,7 +252,7 @@ func TestCustomThreeNodeWithTaints(t *testing.T) {
 		if err := json.Unmarshal([]byte(m.Annotations[planner.LabelsAnnotation]), &labels); err != nil {
 			t.Error(err)
 		}
-		assert.Equal(t, labels, map[string]string{"rancher": "awesome"})
+		assert.Equal(t, labels, map[string]string{"cattle.io/os": "linux", "rancher": "awesome"})
 
 		if len(m.Annotations[planner.TaintsAnnotation]) != 0 {
 			// Only one node should have the taint


### PR DESCRIPTION
Noticed that the cattle label was missing from the insecure command for RKE2 registration for custom clusters.

https://github.com/rancher/rancher/issues/33977