### PR TITLE
[2.6] Make sure aks/eks/gke chart are up-to-date

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -113,6 +113,7 @@ var (
 	GKEUpstreamRefresh                = NewSetting("gke-refresh", "300")
 	HideLocalCluster                  = NewSetting("hide-local-cluster", "false")
 	MachineProvisionImage             = NewSetting("machine-provision-image", "rancher/machine:v0.15.0-rancher66")
+	SystemFeatureChartRefreshSeconds  = NewSetting("system-feature-chart-refresh-seconds", "900")
 
 	FleetMinVersion          = NewSetting("fleet-min-version", "")
 	RancherWebhookMinVersion = NewSetting("rancher-webhook-min-version", "")

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -279,7 +279,7 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 		RESTMapper:      restMapper,
 	}
 
-	systemCharts, err := system.NewManager(ctx, restClientGetter, content, helmop, steveControllers.Core.Pod())
+	systemCharts, err := system.NewManager(ctx, restClientGetter, content, helmop, steveControllers.Core.Pod(), mgmt.Management().V3().Setting())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit adds the ability to configure systemFeatureChart refresh
interval(interval to check and make sure system-chart are up-to-date).
Also it adds the ability to triggering redeploying operator chart if chart
is deleted manually and there is a cluster change event.

backport of https://github.com/rancher/rancher/pull/33879

#31592