### PR TITLE
Correcting CA checksum flag for RKE2 windows registration command.

### DIFF
--- a/pkg/controllers/dashboard/clusterregistrationtoken/status.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/status.go
@@ -37,11 +37,12 @@ func (h *handler) isRKE2(clusterID string) bool {
 }
 
 func (h *handler) assignStatus(crt *v32.ClusterRegistrationToken) (v32.ClusterRegistrationTokenStatus, error) {
-	ca := systemtemplate.CAChecksum()
+	checksum := systemtemplate.CAChecksum()
+	ca := ""
 	caWindows := ""
-	if ca != "" {
-		ca = " --ca-checksum " + ca
-		caWindows = " -CaChecksum " + ca
+	if checksum != "" {
+		ca = " --ca-checksum " + checksum
+		caWindows = " -CaChecksum " + checksum
 	}
 
 	token := crt.Status.Token


### PR DESCRIPTION
An extra and incorrect CA checksum flag is being added to the windows registration command.

Issue: https://github.com/rancher/rancher/issues/33983