### PR TITLE
Add provisioning cluster permissions on PRTB

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -6,12 +6,10 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"github.com/rancher/rancher/pkg/controllers/management/authprovisioningv2"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	pkgrbac "github.com/rancher/rancher/pkg/rbac"
-	"github.com/rancher/wrangler/pkg/apply"
 	"github.com/sirupsen/logrus"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -92,7 +90,7 @@ func (c *crtbLifecycle) Remove(obj *v3.ClusterRoleTemplateBinding) (runtime.Obje
 		return nil, err
 	}
 
-	err := c.removeAuthV2Permissions(obj)
+	err := c.mgr.removeAuthV2Permissions(authprovisioningv2.CRTBRoleBindingID, obj)
 	return nil, err
 }
 
@@ -204,32 +202,6 @@ func (c *crtbLifecycle) removeMGMTClusterScopedPrivilegesInProjectNamespace(bind
 		}
 	}
 	return nil
-}
-
-// removeAuthV2Permissions finds any roleBindings based off the owner annotation from the incoming binding.
-// This is similar to an ownerReference but this is used across namespaces which ownerReferences does not support.
-func (c *crtbLifecycle) removeAuthV2Permissions(binding *v3.ClusterRoleTemplateBinding) error {
-	// Get the selector for the dependent roleBindings
-	selector, err := apply.GetSelectorFromOwner("", binding)
-	if err != nil {
-		return err
-	}
-
-	roleBindings, err := c.mgr.rbLister.List("", selector)
-	if err != nil {
-		return err
-	}
-
-	var returnErr error
-	for _, binding := range roleBindings {
-		err := c.mgr.rbClient.DeleteNamespaced(binding.Namespace, binding.Name, &metav1.DeleteOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			// Combine all errors so we try our best to delete everything in the first run
-			returnErr = multierror.Append(returnErr, err)
-		}
-	}
-
-	return returnErr
 }
 
 func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) error {

--- a/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
+++ b/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/pkg/apply"
 	apiextcontrollers "github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io/v1"
+	rbacv1 "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -23,9 +24,12 @@ const (
 
 type handler struct {
 	roleLocker                           locker.Locker
+	roleCache                            rbacv1.RoleCache
+	roleController                       rbacv1.RoleController
 	roleTemplateController               mgmtcontrollers.RoleTemplateController
 	clusterRoleTemplateBindings          mgmtcontrollers.ClusterRoleTemplateBindingCache
 	clusterRoleTemplateBindingController mgmtcontrollers.ClusterRoleTemplateBindingController
+	projectRoleTemplateBindingController mgmtcontrollers.ProjectRoleTemplateBindingController
 	roleTemplates                        mgmtcontrollers.RoleTemplateCache
 	clusters                             provisioningcontrollers.ClusterCache
 	crdCache                             apiextcontrollers.CustomResourceDefinitionCache
@@ -39,9 +43,12 @@ type handler struct {
 
 func Register(ctx context.Context, clients *wrangler.Context) error {
 	h := &handler{
+		roleCache:                            clients.RBAC.Role().Cache(),
+		roleController:                       clients.RBAC.Role(),
 		roleTemplateController:               clients.Mgmt.RoleTemplate(),
 		clusterRoleTemplateBindings:          clients.Mgmt.ClusterRoleTemplateBinding().Cache(),
 		clusterRoleTemplateBindingController: clients.Mgmt.ClusterRoleTemplateBinding(),
+		projectRoleTemplateBindingController: clients.Mgmt.ProjectRoleTemplateBinding(),
 		roleTemplates:                        clients.Mgmt.RoleTemplate().Cache(),
 		clusters:                             clients.Provisioning.Cluster().Cache(),
 		crdCache:                             clients.CRD.CustomResourceDefinition().Cache(),
@@ -63,6 +70,8 @@ func Register(ctx context.Context, clients *wrangler.Context) error {
 	h.dynamic.OnChange(ctx, "auth-prov-v2-trigger", h.gvkMatcher, h.OnClusterObjectChanged)
 	clients.Mgmt.RoleTemplate().OnChange(ctx, "auth-prov-v2-roletemplate", h.OnChange)
 	clients.Mgmt.ClusterRoleTemplateBinding().OnChange(ctx, "auth-prov-v2-crtb", h.OnCRTB)
+	clients.Mgmt.ProjectRoleTemplateBinding().OnChange(ctx, "auth-prov-v2-prtb", h.OnPRTB)
+	clients.Provisioning.Cluster().OnChange(ctx, "auth-prov-v2-cluster", h.OnCluster)
 	clients.CRD.CustomResourceDefinition().OnChange(ctx, "auth-prov-v2-crd", h.OnCRD)
 	clients.Provisioning.Cluster().Cache().AddIndexer(byClusterName, func(obj *v1.Cluster) ([]string, error) {
 		return []string{obj.Status.ClusterName}, nil

--- a/pkg/controllers/management/authprovisioningv2/cluster.go
+++ b/pkg/controllers/management/authprovisioningv2/cluster.go
@@ -1,0 +1,63 @@
+package authprovisioningv2
+
+import (
+	"reflect"
+
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// OnCluster creates the role required for users assigned through PRTBs to be able to see the
+// provisioning cluster resource
+func (h *handler) OnCluster(key string, cluster *v1.Cluster) (*v1.Cluster, error) {
+	if cluster == nil || cluster.DeletionTimestamp != nil {
+		return cluster, nil
+	}
+
+	roleName := clusterViewName(cluster)
+	role := &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: cluster.APIVersion,
+					Kind:       cluster.Kind,
+					Name:       cluster.Name,
+					UID:        cluster.UID,
+				},
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{cluster.GroupVersionKind().Group},
+				Resources:     []string{"clusters"},
+				ResourceNames: []string{cluster.Name},
+				Verbs:         []string{"get"},
+			},
+		},
+	}
+
+	existingRole, err := h.roleCache.Get(cluster.Namespace, roleName)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, err
+		}
+
+		if _, err := h.roleController.Create(role); err != nil && !k8serrors.IsAlreadyExists(err) {
+			return nil, err
+		}
+		return cluster, nil
+	}
+
+	if !reflect.DeepEqual(existingRole.Rules, role.Rules) {
+		existingRole = existingRole.DeepCopy()
+		existingRole.Rules = role.Rules
+		_, err := h.roleController.Update(existingRole)
+		return nil, err
+	}
+	return cluster, nil
+}

--- a/pkg/controllers/management/authprovisioningv2/prtb.go
+++ b/pkg/controllers/management/authprovisioningv2/prtb.go
@@ -1,0 +1,92 @@
+package authprovisioningv2
+
+import (
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/rbac"
+	"github.com/rancher/wrangler/pkg/name"
+	"github.com/sirupsen/logrus"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const PRTBRoleBindingID = "auth-prov-v2-prtb-rolebinding"
+
+func (h *handler) OnPRTB(key string, prtb *v3.ProjectRoleTemplateBinding) (*v3.ProjectRoleTemplateBinding, error) {
+	if prtb == nil || prtb.DeletionTimestamp != nil || prtb.RoleTemplateName == "" || prtb.ProjectName == "" {
+		return prtb, nil
+	}
+
+	parts := strings.SplitN(prtb.ProjectName, ":", 2)
+	if len(parts) < 2 {
+		return prtb, errors.Errorf("cannot determine project and cluster from %v", prtb.ProjectName)
+	}
+
+	clusterName := parts[0]
+
+	clusters, err := h.clusters.GetByIndex(byClusterName, clusterName)
+	if err != nil {
+		return prtb, err
+	}
+
+	if len(clusters) == 0 {
+		// When no provisioning cluster is found, enqueue the PRTB to wait for
+		// the provisioning cluster to be created. If we don't try again
+		// permissions for the provisioning objects won't be created until an
+		// update to the PRTB happens again.
+		logrus.Debugf("[auth-prov-v2-prtb] No provisioning cluster found for cluster %v, enqueuing PRTB %v ", prtb.ClusterName, prtb.Name)
+		h.clusterRoleTemplateBindingController.EnqueueAfter(prtb.Namespace, prtb.Name, 10*time.Second)
+		return prtb, nil
+	}
+
+	cluster := clusters[0]
+
+	err = h.ensureClusterViewBinding(cluster, prtb)
+
+	return prtb, err
+}
+
+func (h *handler) ensureClusterViewBinding(cluster *v1.Cluster, prtb *v3.ProjectRoleTemplateBinding) error {
+	// The roleBinding name format: r-cluster-<cluster name>-view-<prtb name>
+	// Example: r-cluster1-view-prtb-foo
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.SafeConcatName(clusterViewName(cluster), prtb.Name),
+			Namespace: cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: cluster.APIVersion,
+					Kind:       cluster.Kind,
+					Name:       cluster.Name,
+					UID:        cluster.UID,
+				},
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     clusterViewName(cluster),
+		},
+	}
+
+	subject, err := rbac.BuildSubjectFromRTB(prtb)
+	if err != nil {
+		return err
+	}
+
+	roleBinding.Subjects = []rbacv1.Subject{subject}
+
+	return h.roleBindingApply.
+		WithListerNamespace(cluster.Namespace).
+		WithSetID(PRTBRoleBindingID).
+		WithOwner(prtb).
+		ApplyObjects(roleBinding)
+}
+
+func clusterViewName(cluster *v1.Cluster) string {
+	return name.SafeConcatName("r-cluster", cluster.Name, "view")
+}


### PR DESCRIPTION
Problem:
When a user is added to a project through a PRTB they are not able to
see the provisioning cluster object

Solution:
Add a handler to create a role and binding in the provisioning cluster
namespace granting permissions to get the cluster object.
This adds an owner reference to the cluster for the role and binding
with a cleanup in the PRTB lifecycle on remove to remove the binding
when the PRTB is deleted.

https://github.com/rancher/rancher/issues/32414