### PR TITLE
add cattle-fleet-system to the namespace list

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -145,7 +145,7 @@ postDelete:
     repository: %POST_DELETE_IMAGE_NAME%
     tag: %POST_DELETE_IMAGE_TAG%
   namespaceList:
-    - fleet-system
+    - cattle-fleet-system
     - cattle-system
     - rancher-operator-system
   # Number of seconds to wait for an app to be uninstalled


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/33986

`cattle-fleet-system` is the new namespace Fleet is installed in rancher v2.6, we need to add it to the `namespaceList` such that the post-delete-hook job will uninstall apps in this namespace 


`fleet-system` is removed because:
- it will not exist in a fresh installation of rancher v2.6
- and it will be cleaned up by Rancher in the case of upgrading Rancher from v2.5 to v2.6 


TODO:

- [ ] forward port to the master branch 