### PR TITLE
Set PeerManager to run in clustered mode

### DIFF
--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -321,6 +321,7 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 		CachedDiscovery:         cache,
 		RESTMapper:              restMapper,
 		leadership:              leadership,
+		PeerManager:             peerManager,
 		RESTClientGetter:        restClientGetter,
 		CatalogContentManager:   content,
 		HelmOperations:          helmop,


### PR DESCRIPTION
Previously, the PeerManager in the wrangler context was not set. This
caused the cluster controllers to run on every node instead of in a
clustered/shard mode. The symptom of this was that too many v3.Nodes
were getting created when deploying RKE2/K3S clusters in an HA setup.
    
Now, the PeerManger will be set and the cluster controllers will run as
expected.

Issues:
https://github.com/rancher/rancher/issues/33991
https://github.com/rancher/rancher/issues/33020