### PR TITLE
Update Dashboard reference to point to master

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -80,7 +80,7 @@ var (
 	UIFeedBackForm                    = NewSetting("ui-feedback-form", "")
 	UIIndex                           = NewSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
 	UIPath                            = NewSetting("ui-path", "/usr/share/rancher/ui")
-	UIDashboardIndex                  = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/release-2.6/index.html")
+	UIDashboardIndex                  = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/latest/index.html")
 	UIDashboardPath                   = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
 	UIPreferred                       = NewSetting("ui-preferred", "vue")
 	UIOfflinePreferred                = NewSetting("ui-offline-preferred", "dynamic")


### PR DESCRIPTION
- Following 2.6 branch master can now point back at rancher/dashboard master
- This has been done for UIDashboardIndex which is used for versions ending in `-head`
- The embedded version (CATTLE_DASHBOARD_UI_VERSION) can stay the same