### PR TITLE
[release/v2.6] remove the skipping of CRD charts

### DIFF
--- a/scripts/package
+++ b/scripts/package
@@ -57,13 +57,9 @@ if [ ! -d $CHART_REPO_DIR ]; then
     for TGZ_PATH in $LATEST_TGZ_PATHS; do
         TGZ_REL_PATH=$CHART_REPO_DIR/$TGZ_PATH
         TGZ_EXTRACT_PATH=$(dirname $CHART_REPO_DIR/${TGZ_PATH##released/})
-        if [[ $TGZ_PATH == *crd*.tgz ]]; then
-            echo "Skipped CRD: $TGZ_REL_PATH"
-        else
-            echo "Extract: $TGZ_REL_PATH to $TGZ_EXTRACT_PATH"
-            mkdir -p $TGZ_EXTRACT_PATH
-            tar -xf $TGZ_REL_PATH -C $TGZ_EXTRACT_PATH
-        fi
+        echo "Extract: $TGZ_REL_PATH to $TGZ_EXTRACT_PATH"
+        mkdir -p $TGZ_EXTRACT_PATH
+        tar -xf $TGZ_REL_PATH -C $TGZ_EXTRACT_PATH
     done
 
     # Remove index to force building a virtual index like system charts


### PR DESCRIPTION
#33995

remove the skipping of CRD charts which may contain images that need to be in the rancher-images.txt file for airgap