### PR TITLE
[v2.5] Update impersonation role based on user attributes

### DIFF
--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -281,11 +281,11 @@ func (p *UpgradeProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 func (r *RemoteService) getImpersonatorAccountToken(user user.Info) (string, error) {
 	i := impersonation.New(user, r.clusterContext)
 
-	sa, err := i.SetUpImpersonation()
+	err := i.SetUpImpersonation()
 	if err != nil {
 		return "", fmt.Errorf("error setting up impersonation for user %s: %w", user.GetUID(), err)
 	}
-	saToken, err := i.GetToken(sa)
+	saToken, err := i.GetToken()
 	if err != nil {
 		return "", fmt.Errorf("error getting service account token: %w", err)
 	}

--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -92,6 +92,7 @@ func Register(ctx context.Context, workload *config.UserContext) {
 		clusterLister:       workload.Management.Management.Clusters("").Controller().Lister(),
 		projectLister:       workload.Management.Management.Projects(workload.ClusterName).Controller().Lister(),
 		userLister:          workload.Management.Management.Users("").Controller().Lister(),
+		userAttributeLister: workload.Management.Management.UserAttributes("").Controller().Lister(),
 		crtbs:               workload.Management.Management.ClusterRoleTemplateBindings(""),
 		prtbs:               workload.Management.Management.ProjectRoleTemplateBindings(""),
 		clusterName:         workload.ClusterName,
@@ -139,6 +140,7 @@ type manager struct {
 	clusterLister       v3.ClusterLister
 	projectLister       v3.ProjectLister
 	userLister          v3.UserLister
+	userAttributeLister v3.UserAttributeLister
 	crtbs               v3.ClusterRoleTemplateBindingInterface
 	prtbs               v3.ProjectRoleTemplateBindingInterface
 	clusterName         string

--- a/pkg/controllers/managementuser/rbac/impersonation_handler.go
+++ b/pkg/controllers/managementuser/rbac/impersonation_handler.go
@@ -17,6 +17,17 @@ func (m *manager) getUser(username, groupname string) (user.Info, error) {
 	if groupname != "" {
 		groups = append(groups, groupname)
 	}
+	attribs, err := m.userAttributeLister.Get("", username)
+	if err != nil {
+		return &user.DefaultInfo{}, err
+	}
+	if attribs != nil {
+		for _, gps := range attribs.GroupPrincipals {
+			for _, principal := range gps.Items {
+				groups = append(groups, principal.Name)
+			}
+		}
+	}
 	user := &user.DefaultInfo{
 		UID:    u.GetName(),
 		Name:   u.Username,
@@ -40,8 +51,7 @@ func (m *manager) ensureServiceAccountImpersonator(username, groupname string) e
 	}
 	logrus.Debugf("ensuring service account impersonator for %s", user.GetUID())
 	i := impersonation.New(user, m.workload)
-	_, err = i.SetUpImpersonation()
-	return err
+	return i.SetUpImpersonation()
 }
 
 func (m *manager) deleteServiceAccountImpersonator(username string) error {


### PR DESCRIPTION
Problem 1: When the cluster role for the impersonation service account
was created by the role template binding controller, it only added rules
for two basic authenticated groups and optionally a group derived from
the role template binding, and ignored potential groups the user is
associated with in an external provider. This meant that a user logging
in through an external provider would be blocked from impersonating
their service account due to insufficient permissions.

Solution 1: This change updates the role template binding controller to
get the true known groups for the user from the attribute lister.

Problem 2: If the user's Extras attributes changed, such as what happens
when a local user becomes associated with an external provider, the
roles' rules were never be updated. This meant that even though the
groups from the provider were up to date in the role rules, the
userextras/username may be mismatched. It also means that if the user's
groups in the external provider changed at some point after the initial
role creation, they would become mismatched with the allowed groups in
the role.

Solution 2: In the impersonation package, check that the groups and user
extras in the UserInfo object match the rules for groups and extras in
the role, and update them if they do not match. When the setup is run
from the role template binding controller, the user data will come from
the role template, and when the setup is run from the proxy server, the
user data comes from the request token.

Backport of https://github.com/rancher/rancher/pull/33957

https://github.com/rancher/rancher/issues/33958