### PR TITLE
No gen token2

### DIFF
--- a/pkg/auth/providers/publicapi/login.go
+++ b/pkg/auth/providers/publicapi/login.go
@@ -8,31 +8,32 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/rancher/rancher/pkg/auth/providers/keycloakoidc"
-
-	"github.com/rancher/rancher/pkg/auth/providers/oidc"
-
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers"
 	"github.com/rancher/rancher/pkg/auth/providers/activedirectory"
 	"github.com/rancher/rancher/pkg/auth/providers/azure"
 	"github.com/rancher/rancher/pkg/auth/providers/github"
 	"github.com/rancher/rancher/pkg/auth/providers/googleoauth"
+	"github.com/rancher/rancher/pkg/auth/providers/keycloakoidc"
 	"github.com/rancher/rancher/pkg/auth/providers/ldap"
 	"github.com/rancher/rancher/pkg/auth/providers/local"
+	"github.com/rancher/rancher/pkg/auth/providers/oidc"
 	"github.com/rancher/rancher/pkg/auth/providers/saml"
 	"github.com/rancher/rancher/pkg/auth/settings"
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/auth/util"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3public"
+	"github.com/rancher/rancher/pkg/clustermanager"
+	"github.com/rancher/rancher/pkg/controllers/managementuser/clusterauthtoken/common"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	schema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3public"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/user"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -41,14 +42,18 @@ const (
 
 func newLoginHandler(ctx context.Context, mgmt *config.ScaledContext) *loginHandler {
 	return &loginHandler{
-		userMGR:  mgmt.UserManager,
-		tokenMGR: tokens.NewManager(ctx, mgmt),
+		scaledContext: mgmt,
+		userMGR:       mgmt.UserManager,
+		tokenMGR:      tokens.NewManager(ctx, mgmt),
+		clusterLister: mgmt.Management.Clusters("").Controller().Lister(),
 	}
 }
 
 type loginHandler struct {
-	userMGR  user.Manager
-	tokenMGR *tokens.Manager
+	scaledContext *config.ScaledContext
+	userMGR       user.Manager
+	tokenMGR      *tokens.Manager
+	clusterLister v3.ClusterLister
 }
 
 func (h *loginHandler) login(actionName string, action *types.Action, request *types.APIContext) error {
@@ -208,9 +213,68 @@ func (h *loginHandler) createLoginToken(request *types.APIContext) (v3.Token, st
 		if err != nil {
 			return v3.Token{}, "", "", err
 		}
+
+		if err := h.createClusterAuthTokenIfNeeded(token, tokenValue); err != nil {
+			logrus.Infof("Failed to create cluster auth token for cluster [%s], cluster auth endpoint may fail: %v", token.ClusterName, err)
+		}
 		return *token, tokenValue, responseType, nil
 	}
 
 	rToken, unhashedTokenKey, err := h.tokenMGR.NewLoginToken(currUser.Name, userPrincipal, groupPrincipals, providerToken, ttl, description)
 	return rToken, unhashedTokenKey, responseType, err
+}
+
+// createClusterAuthTokenIfNeeded checks if local cluster auth endpoint is enabled. If it is, a cluster auth token
+// is enabled.
+func (h *loginHandler) createClusterAuthTokenIfNeeded(token *v3.Token, tokenValue string) error {
+	clusterID := token.ClusterName
+	if clusterID == "" {
+		// Cluster ID being empty is likely because cluster auth endpoint is not being used.
+		// Custer auth token is not necessary in the aforementioned scenario.
+		return nil
+	}
+	cluster, err := h.clusterLister.Get("", clusterID)
+	if err != nil {
+		return err
+	}
+
+	if !cluster.Spec.LocalClusterAuthEndpoint.Enabled {
+		return nil
+	}
+	clusterConfig, err := clustermanager.ToRESTConfig(cluster, h.scaledContext)
+	if err != nil {
+		return err
+	}
+
+	clusterContext, err := config.NewUserContext(h.scaledContext, *clusterConfig, clusterID)
+	if err != nil {
+		return err
+	}
+
+	clusterAuthToken, err := common.NewClusterAuthToken(token, tokenValue)
+	if err != nil {
+		return err
+	}
+
+	_, err = clusterContext.Cluster.ClusterAuthTokens("").Controller().Lister().Get("cattle-system", clusterAuthToken.Name)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	if err == nil {
+		err = clusterContext.Cluster.ClusterAuthTokens("cattle-system").Delete(clusterAuthToken.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+
+	if _, err = clusterContext.Cluster.ClusterAuthTokens("cattle-system").Create(clusterAuthToken); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/auth/tokens/token_util.go
+++ b/pkg/auth/tokens/token_util.go
@@ -105,11 +105,7 @@ func ConvertTokenResource(schema *types.Schema, token v3.Token) (map[string]inte
 
 func GetKubeConfigToken(userName, responseType string, userMGR user.Manager) (*v3.Token, string, error) {
 	// create kubeconfig expiring tokens if responseType=kubeconfig in login action vs login tokens for responseType=json
-	clusterID := ""
-	responseSplit := strings.SplitN(responseType, "_", 2)
-	if len(responseSplit) == 2 {
-		clusterID = responseSplit[1]
-	}
+	clusterID := extractClusterIDFromResponseType(responseType)
 
 	logrus.Debugf("getKubeConfigToken: responseType %s", responseType)
 	name := "kubeconfig-" + userName
@@ -123,6 +119,14 @@ func GetKubeConfigToken(userName, responseType string, userMGR user.Manager) (*v
 	}
 
 	return token, tokenVal, nil
+}
+
+func extractClusterIDFromResponseType(responseType string) string {
+	responseSplit := strings.SplitN(responseType, "_", 2)
+	if len(responseSplit) != 2 {
+		return ""
+	}
+	return responseSplit[1]
 }
 
 // Given a stored token with hashed key, check if the provided (unhashed) tokenKey matches and is valid

--- a/pkg/controllers/managementuser/clusterauthtoken/token.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/token.go
@@ -1,6 +1,7 @@
 package clusterauthtoken
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 
@@ -30,11 +31,14 @@ type tokenHandler struct {
 }
 
 func (h *tokenHandler) Create(token *managementv3.Token) (runtime.Object, error) {
+	// clusterAuthToken is no longer created here because it requires the rawValue of the
+	// original token and the token could be hashed. Now, clusterAuthToken is created in
+	// the API layer right after token creation.
 	if _, err := h.clusterAuthTokenLister.Get(h.namespace, token.Name); err != nil {
 		if !errors.IsNotFound(err) {
 			return h.Updated(token)
 		}
-		return token, err
+		return token, fmt.Errorf("clusterAuthToken for token [%s] has not been created yet", token.Name)
 	}
 	return token, nil
 }


### PR DESCRIPTION
**Problems:**
1. When token has expired the kubectl with embedded CLI prompts for the token twice. Cause:
Sometimes create fails despite the delete call being made
prior. This is because it is in the process of being deleted.
Already exists errors were being ignored causing the caller
to receive a 201 even though the token was not created. It
was possible that the cluster auth token was created.
2. Cluster auth tokens are not being created when kubeconfig-generate-token setting is false.

**Solutions:**
1. Now, create will be retried if an already exists error is encountered. Controller error message now explains that cluster auth token cannot be found yet, insinuating that it is not abnormal if it is found the issue will be resolved.
2. Now, the api used by the rancher CLI attempts to create a cluster auth token.

**Notes:**
Some considerations around problem 1:
Updating the token was considered but this came with its own issues. Mainly, token expiration is calculated in multiple places as being creation timestamp + ttl. Making any changes to this widens the surface area of the fix significantly. This request is just for login tokens with kubeconfig response type.
Why retry create, doesn't that add to the roundtrip time? These are mainly used for the rancher cli and is a request that would only need to be made once a token has expired. The default ttl for these tokens is 16 hours.

**Issues:**
https://github.com/rancher/rancher/issues/33771
https://github.com/rancher/rancher/issues/34033