### PR TITLE
Create a v1.Cluster indexer on startup.

### DIFF
--- a/pkg/controllers/managementapi/controllers.go
+++ b/pkg/controllers/managementapi/controllers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/managementuser/rbac"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/rbac/podsecuritypolicy"
 	"github.com/rancher/rancher/pkg/controllers/managementuserlegacy/monitoring"
+	"github.com/rancher/rancher/pkg/controllers/provisioningv2/cluster"
 	"github.com/rancher/rancher/pkg/types/config"
 )
 
@@ -54,5 +55,9 @@ func registerIndexers(ctx context.Context, scaledContext *config.ScaledContext) 
 	if err := podsecuritypolicy.RegisterIndexers(ctx, scaledContext); err != nil {
 		return err
 	}
-	return podsecuritypolicy2.RegisterIndexers(ctx, scaledContext)
+	if err := podsecuritypolicy2.RegisterIndexers(ctx, scaledContext); err != nil {
+		return err
+	}
+	cluster.RegisterIndexers(scaledContext)
+	return nil
 }


### PR DESCRIPTION
Previously, the v1.Cluster indexer was created on the management plane,
but not on any of the followers. During sharding for the user management
plane, if the management plane was not selected, then the indexer would
not exist and could not be used. This would cause things like the
snapshotbackpopulate to not function.

Now, the indexer is created on startup so that every Rancher pod can
access it when necessary.

Related issue:
#32719