### PR TITLE
[v2.6] Register SA and ClusterRoles caches

### DIFF
--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -76,9 +76,11 @@ func RegisterFollower(ctx context.Context, cluster *config.UserContext, kubeConf
 	cluster.Core.Namespaces("").Controller()
 	cluster.Core.Services("").Controller()
 	cluster.RBAC.ClusterRoleBindings("").Controller()
+	cluster.RBAC.ClusterRoles("").Controller()
 	cluster.RBAC.RoleBindings("").Controller()
 	cluster.Core.Endpoints("").Controller()
 	cluster.APIAggregation.APIServices("").Controller()
 	cluster.Core.Secrets("").Controller()
+	cluster.Core.ServiceAccounts("").Controller()
 	return nil
 }


### PR DESCRIPTION
The impersonation mechanism needs these downstream resources cached.

Backport of https://github.com/rancher/rancher/pull/34045

https://github.com/rancher/rancher/issues/34042