### PR TITLE
Update automation to allow 2.6 installs, and newer AMI

### DIFF
--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -76,9 +76,11 @@ func RegisterFollower(ctx context.Context, cluster *config.UserContext, kubeConf
 	cluster.Core.Namespaces("").Controller()
 	cluster.Core.Services("").Controller()
 	cluster.RBAC.ClusterRoleBindings("").Controller()
+	cluster.RBAC.ClusterRoles("").Controller()
 	cluster.RBAC.RoleBindings("").Controller()
 	cluster.Core.Endpoints("").Controller()
 	cluster.APIAggregation.APIServices("").Controller()
 	cluster.Core.Secrets("").Controller()
+	cluster.Core.ServiceAccounts("").Controller()
 	return nil
 }

--- a/tests/validation/lib/aws.py
+++ b/tests/validation/lib/aws.py
@@ -26,7 +26,7 @@ AWS_CICD_INSTANCE_TAG = os.environ.get("AWS_CICD_INSTANCE_TAG",
                                        'rancher-validation')
 AWS_IAM_PROFILE = os.environ.get("AWS_IAM_PROFILE", "")
 # by default the public Ubuntu 18.04 AMI is used
-AWS_DEFAULT_AMI = "ami-0d5d9d301c853a04a"
+AWS_DEFAULT_AMI = "ami-039411dfb55cec992"
 AWS_DEFAULT_USER = "ubuntu"
 AWS_AMI = os.environ.get("AWS_AMI", AWS_DEFAULT_AMI)
 AWS_USER = os.environ.get("AWS_USER", AWS_DEFAULT_USER)

--- a/tests/validation/tests/v3_api/test_custom_host_reg.py
+++ b/tests/validation/tests/v3_api/test_custom_host_reg.py
@@ -44,7 +44,9 @@ def test_delete_keypair():
 
 
 def test_deploy_rancher_server():
-    if "v2.5" in  RANCHER_SERVER_VERSION or "master" in RANCHER_SERVER_VERSION:
+    if "v2.5" in  RANCHER_SERVER_VERSION or \
+        "master" in RANCHER_SERVER_VERSION or \
+        "v2.6" in RANCHER_SERVER_VERSION:
         RANCHER_SERVER_CMD = \
             'sudo docker run -d --privileged --name="rancher-server" ' \
             '--restart=unless-stopped -p 80:80 -p 443:443  ' \


### PR DESCRIPTION
* ami was removed (?) from aws, updated to later version
* also allow `privileged` docker install of 2.6