### PR TITLE
QA Automation: updating ami version, allow 2.6 docker installs

### DIFF
--- a/tests/validation/tests/v3_api/test_custom_host_reg.py
+++ b/tests/validation/tests/v3_api/test_custom_host_reg.py
@@ -44,7 +44,9 @@ def test_delete_keypair():
 
 
 def test_deploy_rancher_server():
-    if "v2.5" in  RANCHER_SERVER_VERSION or "master" in RANCHER_SERVER_VERSION:
+    if "v2.5" in  RANCHER_SERVER_VERSION or \
+        "master" in RANCHER_SERVER_VERSION or \
+        "v2.6" in RANCHER_SERVER_VERSION:
         RANCHER_SERVER_CMD = \
             'sudo docker run -d --privileged --name="rancher-server" ' \
             '--restart=unless-stopped -p 80:80 -p 443:443  ' \


### PR DESCRIPTION
* ami was removed (?) from aws, updated to later version
* also allow `privileged` docker install of 2.6