### PR TITLE
[2.6] Fix helm unittest silent regression

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -58,9 +58,6 @@ add below linux tolerations to workloads could be scheduled to those linux nodes
 
 {{- define "linux-node-selector-terms" -}}
 {{- $key := "kubernetes.io/os" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion }}
-{{- $key := "beta.kubernetes.io/os" -}}
-{{- end -}}
 - matchExpressions:
   - key: {{ $key }}
     operator: NotIn

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -51,10 +51,10 @@ tests:
       - name: CATTLE_PEER_SERVICE
         value: RELEASE-NAME-rancher
       - name: CATTLE_BOOTSTRAP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "bootstrap-secret"
-              key: "bootstrapPassword"
+        valueFrom:
+          secretKeyRef:
+            name: "bootstrap-secret"
+            key: "bootstrapPassword"
 - it: should default imagePullPolicy to IfNotPresent
   asserts:
   - equal:


### PR DESCRIPTION
Helm unittest suite is silently failing at Rancher v2.6.0-rc1 ci pipelines. The breaking change was introduced by a PR and hided by other PR:
* Merged PR https://github.com/rancher/rancher/pull/31988 was breaking the helm charts unittest. [ci log](https://drone-pr.rancher.io/rancher/rancher/14443/1/2)
* Merged PR https://github.com/rancher/rancher/pull/32749 was making silent fails (indent format issue) previous helm unittest issue. [ci log](https://drone-pr.rancher.io/rancher/rancher/17417/3/2) showed as `green` but  `chart/validate` stage is failing

```
...
-- chart/validate --
4260 | ==> Linting ../../build/chart/rancher
4261 | [WARNING] templates/ingress.yaml: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
4262 |  
4263 | 1 chart(s) linted, 0 chart(s) failed
4264 | -- chart/test --
4265 | FAIL  	../../build/chart/rancher/tests/deployment_test.yaml
4266 | - Execution Error:
4267 | yaml: line 54: mapping values are not allowed in this context
4268 |  
4269 |  
4270 | ### Chart [ rancher ] ../../build/chart/rancher
4271 |  
4272 | PASS  Test Ingress	../../build/chart/rancher/tests/ingress_test.yaml
4273 | PASS  Test Issuers	../../build/chart/rancher/tests/issuer_test.yaml
4274 | PASS  Test persistentVolumeClaim	../../build/chart/rancher/tests/pvc_test.yaml
4275 |  
4276 | Charts:      1 passed, 1 total
4277 | Test Suites: 1 failed, 1 errored, 3 passed, 4 total
4278 | Tests:       50 passed, 50 total
4279 | Snapshot:    0 passed, 0 total
4280 | Time:        70.431965ms
...
```

This PR is fixing the issue: 
* removing the `Capabilities.KubeVersion.GitVersion` check from template helper, as just applied if k8s version is pretty old (,v1.14) @aiyengar2 may that be ok for you? 
* Fixing `CATTLE_BOOTSTRAP_PASSWORD` assert yaml format on deployment test definition