### PR TITLE
[release/v2.6] Fix host network policies for Calico CNI (RKE1/2)

### DIFF
--- a/pkg/controllers/managementuser/networkpolicy/netpol.go
+++ b/pkg/controllers/managementuser/networkpolicy/netpol.go
@@ -7,9 +7,12 @@ import (
 	"sort"
 
 	"github.com/rancher/rancher/pkg/controllers/managementagent/nslabels"
+	cluster2 "github.com/rancher/rancher/pkg/controllers/provisioningv2/cluster"
+	rancherv1 "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	typescorev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	rnetworkingv1 "github.com/rancher/rancher/pkg/generated/norman/networking.k8s.io/v1"
+	rkecluster "github.com/rancher/rke/cluster"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	knetworkingv1 "k8s.io/api/networking/v1"
@@ -32,6 +35,8 @@ const (
 )
 
 type netpolMgr struct {
+	clusterLister    v3.ClusterLister
+	clusters         rancherv1.ClusterCache
 	nsLister         typescorev1.NamespaceLister
 	nodeLister       typescorev1.NodeLister
 	pods             typescorev1.PodInterface
@@ -162,15 +167,51 @@ func (npmgr *netpolMgr) programNetworkPolicy(projectID string, clusterNamespace 
 	return nil
 }
 
+const (
+	calicoIPIPTunnelAddrAnno  = "projectcalico.org/IPv4IPIPTunnelAddr"
+	calicoVXLANTunnelAddrAnno = "projectcalico.org/IPv4VXLANTunnelAddr"
+)
+
 func (npmgr *netpolMgr) handleHostNetwork(clusterNamespace string) error {
 	nodes, err := npmgr.nodeLister.List("", labels.Everything())
 	if err != nil {
 		return fmt.Errorf("couldn't list nodes err=%v", err)
 	}
 
+	cni, err := npmgr.getClusterCNI(clusterNamespace)
+	if err != nil {
+		return err
+	}
+
 	logrus.Debugf("netpolMgr: handleHostNetwork: processing %d nodes", len(nodes))
 	np := generateNodesNetworkPolicy()
+
+	// This for loop builds CNI specific host network policies to allow traffic from ingress controllers through to endpoints.
+	// Calico nodes require special handling. Calico has the following routing modes: IP in IP, VXLAN, and Direct.
+	// RKE1 deploys calico with IP in IP routing, while RKE2 deploys calico with VXLAN routing.
+	// When calico sends traffic to pods, the source IP address changes to either the IPIP tunnel address or the VXLAN tunnel address,
+	// depending on the routing mode. These are the IPs that the host network policy needs to use.
+	var policies []knetworkingv1.NetworkPolicyPeer
 	for _, node := range nodes {
+		// for calico, we get the IPs for the hn-nodes policy from the tunnel address annotations, which are managed by calico-node
+		if cni == rkecluster.CalicoNetworkPlugin { // RKE1/2 use the same "calico" value
+			tunnelAddr, ok := node.Annotations[calicoIPIPTunnelAddrAnno]
+			if !ok {
+				tunnelAddr = node.Annotations[calicoVXLANTunnelAddrAnno]
+			}
+			if tunnelAddr == "" {
+				logrus.Debugf("netpolMgr: handleHostNetwork: calico: node=%+v", node)
+				logrus.Errorf("netpolMgr: handleHostNetwork: calico: couldn't get tunnel address for node %v err=%v", node.Name, err)
+				continue
+			}
+			ipBlock := knetworkingv1.IPBlock{
+				CIDR: tunnelAddr + "/32",
+			}
+			policies = append(policies, knetworkingv1.NetworkPolicyPeer{IPBlock: &ipBlock})
+			continue
+		}
+
+		// other CNIs
 		podCIDRFirstIP, _, err := net.ParseCIDR(node.Spec.PodCIDR)
 		if err != nil {
 			logrus.Debugf("netpolMgr: handleHostNetwork: node=%+v", node)
@@ -180,8 +221,11 @@ func (npmgr *netpolMgr) handleHostNetwork(clusterNamespace string) error {
 		ipBlock := knetworkingv1.IPBlock{
 			CIDR: podCIDRFirstIP.String() + "/32",
 		}
-		np.Spec.Ingress[0].From = append(np.Spec.Ingress[0].From, knetworkingv1.NetworkPolicyPeer{IPBlock: &ipBlock})
+		policies = append(policies, knetworkingv1.NetworkPolicyPeer{IPBlock: &ipBlock})
 	}
+
+	// set the policies on the resource
+	np.Spec.Ingress[0].From = policies
 
 	// An empty ingress rule allows all traffic to the namespace
 	// so we need to skip creating the network policy here if that's what we have.
@@ -236,6 +280,46 @@ func (npmgr *netpolMgr) handleHostNetwork(clusterNamespace string) error {
 	return nil
 }
 
+// getClusterCNI returns the cluster's CNI name if it is found or an api error
+func (npmgr *netpolMgr) getClusterCNI(clusterName string) (string, error) {
+	cluster, err := npmgr.clusterLister.Get("", clusterName)
+	if err != nil {
+		return "", err
+	}
+
+	if cluster.Spec.Rke2Config != nil {
+		return npmgr.getRKE2ClusterCNI(cluster)
+	}
+
+	if cluster.Spec.RancherKubernetesEngineConfig != nil {
+		return cluster.Spec.RancherKubernetesEngineConfig.Network.Plugin, nil
+	}
+
+	return "", nil
+}
+
+// getRKE2ClusterCNI returns the RKE2 cluster CNI name if it is found, or an api error
+func (npmgr *netpolMgr) getRKE2ClusterCNI(mgmtCluster *v3.Cluster) (string, error) {
+	clusters, err := npmgr.clusters.GetByIndex(cluster2.ByCluster, mgmtCluster.Name)
+	if err != nil {
+		return "", err
+	}
+	if len(clusters) != 1 {
+		return "", fmt.Errorf("could not map to v1.Cluster for v3.Cluster: %s", mgmtCluster.Name)
+	}
+
+	cluster := clusters[0]
+	if rke := cluster.Spec.RKEConfig; rke != nil && rke.MachineGlobalConfig.Data["cni"] != "" {
+		cni, ok := rke.MachineGlobalConfig.Data["cni"].(string)
+		if !ok {
+			return "", nil
+		}
+		return cni, nil
+	}
+
+	return "", nil
+}
+
 func (npmgr *netpolMgr) getSystemNSInfo(clusterNamespace string) (map[string]bool, string, error) {
 	systemNamespaces := map[string]bool{}
 	set := labels.Set(map[string]string{systemProjectLabel: "true"})
@@ -277,7 +361,10 @@ func generateDefaultNamespaceNetworkPolicy(aNS *corev1.Namespace, projectID stri
 		ObjectMeta: v1.ObjectMeta{
 			Name:      defaultNamespacePolicyName,
 			Namespace: aNS.Name,
-			Labels:    labels.Set(map[string]string{nslabels.ProjectIDFieldLabel: projectID}),
+			Labels: map[string]string{
+				nslabels.ProjectIDFieldLabel: projectID,
+				creatorLabel:                 creatorNorman,
+			},
 		},
 		Spec: knetworkingv1.NetworkPolicySpec{
 			// An empty PodSelector selects all pods in this Namespace.
@@ -310,7 +397,10 @@ func generateAllowAllNetworkPolicy(ns *corev1.Namespace, systemProjectID string)
 		ObjectMeta: v1.ObjectMeta{
 			Name:      defaultSystemProjectNamespacePolicyName,
 			Namespace: ns.Name,
-			Labels:    labels.Set(map[string]string{nslabels.ProjectIDFieldLabel: systemProjectID}),
+			Labels: map[string]string{
+				nslabels.ProjectIDFieldLabel: systemProjectID,
+				creatorLabel:                 creatorNorman,
+			},
 		},
 		Spec: knetworkingv1.NetworkPolicySpec{
 			// An empty PodSelector selects all pods in this Namespace.
@@ -333,6 +423,9 @@ func generateNodesNetworkPolicy() *knetworkingv1.NetworkPolicy {
 	return &knetworkingv1.NetworkPolicy{
 		ObjectMeta: v1.ObjectMeta{
 			Name: hostNetworkPolicyName,
+			Labels: map[string]string{
+				creatorLabel: creatorNorman,
+			},
 		},
 		Spec: knetworkingv1.NetworkPolicySpec{
 			PodSelector: v1.LabelSelector{},

--- a/pkg/controllers/managementuser/networkpolicy/register.go
+++ b/pkg/controllers/managementuser/networkpolicy/register.go
@@ -16,7 +16,8 @@ func Register(ctx context.Context, cluster *config.UserContext) {
 	projectLister := cluster.Management.Management.Projects(cluster.ClusterName).Controller().Lister()
 	projects := cluster.Management.Management.Projects(cluster.ClusterName)
 	clusterLister := cluster.Management.Management.Clusters("").Controller().Lister()
-	clusters := cluster.Management.Management.Clusters("")
+	mgmtClusters := cluster.Management.Management.Clusters("")
+	clusters := cluster.Management.Wrangler.Provisioning.Cluster().Cache()
 
 	nodeLister := cluster.Core.Nodes("").Controller().Lister()
 	nsLister := cluster.Core.Namespaces("").Controller().Lister()
@@ -29,7 +30,7 @@ func Register(ctx context.Context, cluster *config.UserContext) {
 	npLister := cluster.Networking.NetworkPolicies("").Controller().Lister()
 	npClient := cluster.Networking
 
-	npmgr := &netpolMgr{nsLister, nodeLister, pods, projects,
+	npmgr := &netpolMgr{clusterLister, clusters, nsLister, nodeLister, pods, projects,
 		npLister, npClient, projectLister, cluster.ClusterName}
 	ps := &projectSyncer{pnpLister, pnps, projects, clusterLister, cluster.ClusterName}
 	nss := &nsSyncer{npmgr, clusterLister, serviceLister, podLister,
@@ -39,9 +40,9 @@ func Register(ctx context.Context, cluster *config.UserContext) {
 	serviceHandler := &serviceHandler{npmgr, clusterLister, cluster.ClusterName}
 	nodeHandler := &nodeHandler{npmgr, clusterLister, cluster.ClusterName}
 	clusterHandler := &clusterHandler{cluster, pnpLister, podLister,
-		serviceLister, projectLister, clusters, pnps, npmgr, cluster.ClusterName}
+		serviceLister, projectLister, mgmtClusters, pnps, npmgr, cluster.ClusterName}
 
-	clusterNetAnnHandler := &clusterNetAnnHandler{clusters, cluster.ClusterName}
+	clusterNetAnnHandler := &clusterNetAnnHandler{mgmtClusters, cluster.ClusterName}
 
 	projects.Controller().AddClusterScopedHandler(ctx, "projectSyncer", cluster.ClusterName, ps.Sync)
 	pnps.AddClusterScopedHandler(ctx, "projectNetworkPolicySyncer", cluster.ClusterName, pnpsyncer.Sync)
@@ -50,7 +51,7 @@ func Register(ctx context.Context, cluster *config.UserContext) {
 	services.AddHandler(ctx, "serviceHandler", serviceHandler.Sync)
 
 	cluster.Management.Management.Nodes(cluster.ClusterName).Controller().AddHandler(ctx, "nodeHandler", nodeHandler.Sync)
-	clusters.AddHandler(ctx, "clusterHandler", clusterHandler.Sync)
+	mgmtClusters.AddHandler(ctx, "clusterHandler", clusterHandler.Sync)
 
-	clusters.AddHandler(ctx, "clusterNetAnnHandler", clusterNetAnnHandler.Sync)
+	mgmtClusters.AddHandler(ctx, "clusterNetAnnHandler", clusterNetAnnHandler.Sync)
 }


### PR DESCRIPTION
Issue: 
- https://github.com/rancher/rancher/issues/33979

This PR is needed for 2 reasons:
- Ingress traffic from nodes to workloads was not making it through due to misconfigured hn-nodes NetworkPolicies for RKE1/2 clusters deployed with Calico CNI
- Labels not always getting added to Rancher managed NetworkPolicy resources. Added explicit setting of labels so that we always properly select NetworkPolicy resources for deletion when disabling PNI