### PR TITLE
[v2.5] Ignore user not found in user attribute lister

### DIFF
--- a/pkg/controllers/managementuser/rbac/impersonation_handler.go
+++ b/pkg/controllers/managementuser/rbac/impersonation_handler.go
@@ -18,7 +18,7 @@ func (m *manager) getUser(username, groupname string) (user.Info, error) {
 		groups = append(groups, groupname)
 	}
 	attribs, err := m.userAttributeLister.Get("", username)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return &user.DefaultInfo{}, err
 	}
 	if attribs != nil {


### PR DESCRIPTION
If a user has no extra attributes, for instance a local user with no
groups, then the UserAttribute lister will not find the user. This is
expected and can be ignored, as the User lister has already found the
user.

Backport of https://github.com/rancher/rancher/pull/34117

https://github.com/rancher/rancher/issues/34140