### PR TITLE
Gather all referenced roleTemplates on role create

### DIFF
--- a/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
+++ b/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
@@ -26,11 +26,12 @@ type handler struct {
 	roleLocker                           locker.Locker
 	roleCache                            rbacv1.RoleCache
 	roleController                       rbacv1.RoleController
+	clusterRoleCache                     rbacv1.ClusterRoleCache
 	roleTemplateController               mgmtcontrollers.RoleTemplateController
 	clusterRoleTemplateBindings          mgmtcontrollers.ClusterRoleTemplateBindingCache
 	clusterRoleTemplateBindingController mgmtcontrollers.ClusterRoleTemplateBindingController
 	projectRoleTemplateBindingController mgmtcontrollers.ProjectRoleTemplateBindingController
-	roleTemplates                        mgmtcontrollers.RoleTemplateCache
+	roleTemplatesCache                   mgmtcontrollers.RoleTemplateCache
 	clusters                             provisioningcontrollers.ClusterCache
 	crdCache                             apiextcontrollers.CustomResourceDefinitionCache
 	dynamic                              *dynamic.Controller
@@ -45,11 +46,12 @@ func Register(ctx context.Context, clients *wrangler.Context) error {
 	h := &handler{
 		roleCache:                            clients.RBAC.Role().Cache(),
 		roleController:                       clients.RBAC.Role(),
+		clusterRoleCache:                     clients.RBAC.ClusterRole().Cache(),
 		roleTemplateController:               clients.Mgmt.RoleTemplate(),
 		clusterRoleTemplateBindings:          clients.Mgmt.ClusterRoleTemplateBinding().Cache(),
 		clusterRoleTemplateBindingController: clients.Mgmt.ClusterRoleTemplateBinding(),
 		projectRoleTemplateBindingController: clients.Mgmt.ProjectRoleTemplateBinding(),
-		roleTemplates:                        clients.Mgmt.RoleTemplate().Cache(),
+		roleTemplatesCache:                   clients.Mgmt.RoleTemplate().Cache(),
 		clusters:                             clients.Provisioning.Cluster().Cache(),
 		crdCache:                             clients.CRD.CustomResourceDefinition().Cache(),
 		dynamic:                              clients.Dynamic,

--- a/pkg/controllers/management/authprovisioningv2/binding.go
+++ b/pkg/controllers/management/authprovisioningv2/binding.go
@@ -18,7 +18,7 @@ func (h *handler) OnCRTB(key string, crtb *v3.ClusterRoleTemplateBinding) (*v3.C
 		return crtb, nil
 	}
 
-	rt, err := h.roleTemplates.Get(crtb.RoleTemplateName)
+	rt, err := h.roleTemplatesCache.Get(crtb.RoleTemplateName)
 	if err != nil {
 		return crtb, err
 	}
@@ -74,7 +74,11 @@ func (h *handler) OnCRTB(key string, crtb *v3.ClusterRoleTemplateBinding) (*v3.C
 }
 
 func (h *handler) isClusterIndexed(rt *v3.RoleTemplate) (bool, error) {
-	for _, rule := range rt.Rules {
+	rules, err := rbac.RulesFromTemplate(h.clusterRoleCache, h.roleTemplatesCache, rt)
+	if err != nil {
+		return false, err
+	}
+	for _, rule := range rules {
 		if len(rule.NonResourceURLs) > 0 || len(rule.ResourceNames) > 0 {
 			continue
 		}


### PR DESCRIPTION
Problem:
Authv2 only gathers the rules on the roleTemplate, ignoring the
referenced roleTemplate field.

Solution:
Gather all rules for all referenced roleTemplates

https://github.com/rancher/rancher/issues/33998