### PR TITLE
adding /v3/connect/cluster-info endpoint for windows rke2 installer

### DIFF
--- a/pkg/api/steve/additionalapi.go
+++ b/pkg/api/steve/additionalapi.go
@@ -25,6 +25,7 @@ func AdditionalAPIsPreMCM(config *wrangler.Context) func(http.Handler) http.Hand
 		mux.UseEncodedPath()
 		mux.Handle(configserver.ConnectAgent, connectHandler)
 		mux.Handle(configserver.ConnectConfigYamlPath, connectHandler)
+		mux.Handle(configserver.ConnectClusterInfo, connectHandler)
 		mux.Handle(installer.SystemAgentInstallPath, installer.Handler)
 		mux.Handle(installer.WindowsRke2InstallPath, installer.Handler)
 		return func(next http.Handler) http.Handler {

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -55,7 +55,7 @@ const (
 	ControlPlaneRoleLabel      = "rke.cattle.io/control-plane-role"
 	MachineUIDLabel            = "rke.cattle.io/machine"
 	MachineIDLabel             = "rke.cattle.io/machine-id"
-	capiMachineLabel           = "cluster.x-k8s.io/cluster-name"
+	CapiMachineLabel           = "cluster.x-k8s.io/cluster-name"
 
 	MachineNameLabel      = "rke.cattle.io/machine-name"
 	MachineNamespaceLabel = "rke.cattle.io/machine-namespace"

--- a/pkg/provisioningv2/rke2/planner/store.go
+++ b/pkg/provisioningv2/rke2/planner/store.go
@@ -65,7 +65,7 @@ func (p *PlanStore) Load(cluster *capi.Cluster) (*plan.Plan, error) {
 	}
 
 	machines, err := p.machineCache.List(cluster.Namespace, labels.SelectorFromSet(map[string]string{
-		capiMachineLabel: cluster.Name,
+		CapiMachineLabel: cluster.Name,
 	}))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
rke2 windows install script needs a way to pull the rke2 version for the cluster so we can test RCs and general get data pushed down to the installer from KDM. As of today we force the Stable release and this let's us get around that.