### PR TITLE
add checks for no-existing IndexConfigMapNamespace in repo.status

### DIFF
--- a/pkg/controllers/dashboard/helm/register.go
+++ b/pkg/controllers/dashboard/helm/register.go
@@ -11,7 +11,8 @@ func Register(ctx context.Context, wrangler *wrangler.Context) {
 		wrangler.Apply,
 		wrangler.Core.Secret().Cache(),
 		wrangler.Catalog.ClusterRepo(),
-		wrangler.Core.ConfigMap())
+		wrangler.Core.ConfigMap(),
+		wrangler.Core.ConfigMap().Cache())
 	RegisterApps(ctx,
 		wrangler.Apply,
 		wrangler.ControllerFactory.SharedCacheFactory().SharedClientFactory(),

--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -20,6 +20,7 @@ import (
 	name2 "github.com/rancher/wrangler/pkg/name"
 	"helm.sh/helm/v3/pkg/repo"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -33,22 +34,25 @@ var (
 )
 
 type repoHandler struct {
-	secrets      corev1controllers.SecretCache
-	clusterRepos catalogcontrollers.ClusterRepoController
-	configMaps   corev1controllers.ConfigMapClient
-	apply        apply.Apply
+	secrets        corev1controllers.SecretCache
+	clusterRepos   catalogcontrollers.ClusterRepoController
+	configMaps     corev1controllers.ConfigMapClient
+	configMapCache corev1controllers.ConfigMapCache
+	apply          apply.Apply
 }
 
 func RegisterRepos(ctx context.Context,
 	apply apply.Apply,
 	secrets corev1controllers.SecretCache,
 	clusterRepos catalogcontrollers.ClusterRepoController,
-	configMap corev1controllers.ConfigMapController) {
+	configMap corev1controllers.ConfigMapController,
+	configMapCache corev1controllers.ConfigMapCache) {
 	h := &repoHandler{
-		secrets:      secrets,
-		clusterRepos: clusterRepos,
-		configMaps:   configMap,
-		apply:        apply.WithCacheTypes(configMap).WithStrictCaching().WithSetOwnerReference(false, false),
+		secrets:        secrets,
+		clusterRepos:   clusterRepos,
+		configMaps:     configMap,
+		configMapCache: configMapCache,
+		apply:          apply.WithCacheTypes(configMap).WithStrictCaching().WithSetOwnerReference(false, false),
 	}
 
 	catalogcontrollers.RegisterClusterRepoStatusHandler(ctx, clusterRepos,
@@ -75,6 +79,10 @@ func (r *repoHandler) ClusterRepoDownloadEnsureStatusHandler(repo *catalog.Clust
 }
 
 func (r *repoHandler) ClusterRepoDownloadStatusHandler(repo *catalog.ClusterRepo, status catalog.RepoStatus) (catalog.RepoStatus, error) {
+	err := r.ensureIndexConfigMap(repo, &status)
+	if err != nil {
+		return status, err
+	}
 	if !shouldRefresh(&repo.Spec, &status) {
 		r.clusterRepos.EnqueueAfter(repo.Name, interval)
 		return status, nil
@@ -245,6 +253,25 @@ func (r *repoHandler) download(repoSpec *catalog.RepoSpec, status catalog.RepoSt
 	status.DownloadTime = downloadTime
 	status.Commit = commit
 	return status, nil
+}
+
+func (r *repoHandler) ensureIndexConfigMap(repo *catalog.ClusterRepo, status *catalog.RepoStatus) error {
+	// Charts from the clusterRepo will be unavailable if the IndexConfigMap recorded in the status does not exist.
+	// By resetting the value of IndexConfigMapName, IndexConfigMapNamespace, IndexConfigMapResourceVersion to "",
+	// the method shouldRefresh will return true and trigger the rebuild of the IndexConfigMap and accordingly update the status.
+	if repo.Spec.GitRepo != "" && status.IndexConfigMapName != "" {
+		_, err := r.configMapCache.Get(status.IndexConfigMapNamespace, status.IndexConfigMapName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				status.IndexConfigMapName = ""
+				status.IndexConfigMapNamespace = ""
+				status.IndexConfigMapResourceVersion = ""
+				return nil
+			}
+			return err
+		}
+	}
+	return nil
 }
 
 func shouldRefresh(spec *catalog.RepoSpec, status *catalog.RepoStatus) bool {


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/34193

Cause: https://github.com/rancher/rancher/issues/34193#issuecomment-897984502

Fix:
 add the logic to check and rebuild the missing IndexConfigMap: if the IndexConfigMap does not exist in the cluster, reset the value of `IndexConfigMapName`, `IndexConfigMapNamespace`, `IndexConfigMapResourceVersion` to `""` such that the method `shouldRefresh` will returns `true` and trigger a rebuild of the index file. 

TODO after merging:

- [ ] backport to 2.5
- [ ] forwardport to master
