### PR TITLE
Support pulling system imagelist cache from bundled charts

### DIFF
--- a/pkg/data/management/catalog_data.go
+++ b/pkg/data/management/catalog_data.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/catalog/manager"
+	"github.com/rancher/rancher/pkg/catalog/utils"
 
 	"github.com/rancher/rancher/pkg/controllers/managementuserlegacy/helm/common"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -171,6 +173,9 @@ func syncCatalogs(management *config.ManagementContext) error {
 }
 
 func doAddCatalogs(management *config.ManagementContext, name, url, branch, helmVersion string, bundledMode bool) error {
+	var obj *v3.Catalog
+	var err error
+
 	catalogClient := management.Management.Catalogs("")
 
 	kind := helm.KindHelmGit
@@ -178,11 +183,11 @@ func doAddCatalogs(management *config.ManagementContext, name, url, branch, helm
 		kind = helm.KindHelmInternal
 	}
 
-	_, err := catalogClient.Get(name, metav1.GetOptions{})
+	obj, err = catalogClient.Get(name, metav1.GetOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	} else if errors.IsNotFound(err) {
-		obj := &v3.Catalog{
+		obj = &v3.Catalog{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
@@ -193,9 +198,16 @@ func doAddCatalogs(management *config.ManagementContext, name, url, branch, helm
 				HelmVersion: helmVersion,
 			},
 		}
-		if _, err := catalogClient.Create(obj); err != nil {
+		if obj, err = catalogClient.Create(obj); err != nil {
 			return err
 		}
+	}
+
+	if bundledMode && obj.Name == utils.SystemLibraryName {
+		// force update the catalog cache on every startup
+		configMapInterface := management.Core.ConfigMaps("")
+		configMapLister := configMapInterface.Controller().Lister()
+		return manager.CreateOrUpdateSystemCatalogImageCache(obj, configMapInterface, configMapLister, true, true)
 	}
 
 	return nil

--- a/pkg/data/management/catalog_data.go
+++ b/pkg/data/management/catalog_data.go
@@ -204,7 +204,8 @@ func doAddCatalogs(management *config.ManagementContext, name, url, branch, helm
 	}
 
 	if bundledMode && obj.Name == utils.SystemLibraryName {
-		// force update the catalog cache on every startup
+		// force update the catalog cache on every startup; this ensures that setups using bundledMode can load new image
+		// into the ConfigMap when the bundled system-chart is updated (e.g. during Rancher upgrades) upon restarting Rancher
 		configMapInterface := management.Core.ConfigMaps("")
 		configMapLister := configMapInterface.Controller().Lister()
 		return manager.CreateOrUpdateSystemCatalogImageCache(obj, configMapInterface, configMapLister, true, true)

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -349,19 +349,16 @@ func getSourcesList(imageSources map[string]bool) string {
 	return strings.Join(sources, ",")
 }
 
-func CreateCatalogImageListConfigMap(cm *v1.ConfigMap, catalog *v3.Catalog) (err error) {
+func AddImagesToImageListConfigMap(cm *v1.ConfigMap, chartPath string) (err error) {
 	var windowsImages []string
 	var linuxImages []string
 
-	catalogHash := libhelm.CatalogSHA256Hash(catalog)
-	catalogChartPath := filepath.Join(libhelm.CatalogCache, catalogHash)
-
-	windowsImages, _, err = GetImages(catalogChartPath, "", nil, []string{}, nil, Windows)
+	windowsImages, _, err = GetImages(chartPath, "", nil, []string{}, nil, Windows)
 	if err != nil {
 		return
 	}
 
-	linuxImages, _, err = GetImages(catalogChartPath, "", nil, []string{}, nil, Linux)
+	linuxImages, _, err = GetImages(chartPath, "", nil, []string{}, nil, Linux)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Currently, **for system-charts only**, we use the same scripts we use to generate the rancher-images.txt in order to produce a ConfigMap called `system-library-catalog-image-list` in the `cattle-system` namespace.

This ConfigMap contains a list of images that were extracted from system-charts stored in `management-state/catalog-cache/{HASH-OF-CATALOG}`.

However, for air-gapped setups, the system-charts do not get pulled into this directory. Instead, they only exist as packaged in the Rancher [Dockerfile](https://github.com/rancher/rancher/blob/522c7764153e4cfee6161895ae44efaa59d611d9/package/Dockerfile#L53) under `/var/lib/rancher-data/local-catalogs/system-library`. So the creation of the ConfigMap fails, triggering the 500 error seen on the ticket.

The fix pushed out in this PR modifies the functions that are used to create this ConfigMap to strip it into an exported helper function. This helper function is then added into the `doAddCatalogs` step of a Rancher startup (which is triggered every time the MCM controller starts).

Related Issue: https://github.com/rancher/rancher/issues/34172