### PR TITLE
Change impersonation service account retrieval

### DIFF
--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -281,11 +281,11 @@ func (p *UpgradeProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 func (r *RemoteService) getImpersonatorAccountToken(user user.Info) (string, error) {
 	i := impersonation.New(user, r.clusterContext)
 
-	err := i.SetUpImpersonation()
+	sa, err := i.SetUpImpersonation()
 	if err != nil {
 		return "", fmt.Errorf("error setting up impersonation for user %s: %w", user.GetUID(), err)
 	}
-	saToken, err := i.GetToken()
+	saToken, err := i.GetToken(sa)
 	if err != nil {
 		return "", fmt.Errorf("error getting service account token: %w", err)
 	}

--- a/pkg/controllers/managementuser/rbac/impersonation_handler.go
+++ b/pkg/controllers/managementuser/rbac/impersonation_handler.go
@@ -51,7 +51,8 @@ func (m *manager) ensureServiceAccountImpersonator(username, groupname string) e
 	}
 	logrus.Debugf("ensuring service account impersonator for %s", user.GetUID())
 	i := impersonation.New(user, m.workload)
-	return i.SetUpImpersonation()
+	_, err = i.SetUpImpersonation()
+	return err
 }
 
 func (m *manager) deleteServiceAccountImpersonator(username string) error {


### PR DESCRIPTION
This change does three things:
1) Partially revert the refactor done in 8d413413 so that the service
   account only needs to be retrieved once in total if it exists,
   instead of as two steps in SetUpImpersonation and GetToken
2) Fix waitForServiceAccount to use the cache instead of the client
3) Add trace logs to help debug future caching problems

https://github.com/rancher/rancher/issues/34042
https://github.com/rancher/rancher/issues/34187