### PR TITLE
Add new status for machines that are being deleted

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/machinestatus/machinestatus.go
+++ b/pkg/controllers/provisioningv2/rke2/machinestatus/machinestatus.go
@@ -255,6 +255,9 @@ func (h *handler) getInfraMachineState(capiMachine *capi.Machine) (status corev1
 	gvk := schema.FromAPIVersionAndKind(capiMachine.Spec.InfrastructureRef.APIVersion, capiMachine.Spec.InfrastructureRef.Kind)
 	machine, err := h.dynamic.Get(gvk, capiMachine.Namespace, capiMachine.Spec.InfrastructureRef.Name)
 	if apierror.IsNotFound(err) {
+		if capiMachine.DeletionTimestamp != nil {
+			return corev1.ConditionUnknown, "MachineDeleted", "machine is being deleted", "", nil
+		}
 		return corev1.ConditionUnknown, "NoMachineDefined", "waiting for machine to be defined", "", nil
 	} else if err != nil {
 		return "", "", "", "", err


### PR DESCRIPTION
When a machine is being deleted, sometime the UI will show a status of
"waiting for machine to be defined." This is inaccurate for a machine
that is being deleted.

This change will display an accurate message in this case.

Issue:
https://github.com/rancher/rancher/issues/34235