### PR TITLE
[2.6 backport] Get clusterName from rke-machine-config

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/dynamicschema/dynamicschema.go
+++ b/pkg/controllers/provisioningv2/rke2/dynamicschema/dynamicschema.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	machineAPIGroup       = "rke-machine.cattle.io"
-	machineConfigAPIGroup = "rke-machine-config.cattle.io"
+	MachineConfigAPIGroup = "rke-machine-config.cattle.io"
 )
 
 type handler struct {
@@ -265,7 +265,7 @@ func (h *handler) OnChange(obj *v3.DynamicSchema, status v3.DynamicSchemaStatus)
 		}
 
 		if nodeConfigID == id {
-			crd.GVK.Group = machineConfigAPIGroup
+			crd.GVK.Group = MachineConfigAPIGroup
 		}
 
 		crdObj, err := crd.ToCustomResourceDefinition()


### PR DESCRIPTION
Problem:
rke-machine-config does not return a clustername becuase it does not
live in the expected locations on the object

Solution:
Update getObjectClusterNames to look for the group of the object and
then find the owner reference for the provisioning cluster. These
objects are dynamic so the switch won't work as there is no concrete
type and they don't have a spec so it can't be added there on creation.

https://github.com/rancher/dashboard/issues/3785