### PR TITLE
fix error when upgrading helm chart

### DIFF
--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -6,7 +6,7 @@ metadata:
 type: Opaque
 data:
   {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "bootstrap-secret" }}
-  {{- if $existingSecret }}
+  {{- if and $existingSecret $existingSecret.data }}
   bootstrapPassword: {{ $existingSecret.data.bootstrapPassword }}
   {{- else }}
   bootstrapPassword: {{ .Values.bootstrapPassword | b64enc | quote }}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/34227

Fixed helm failing to upgrade when the default password has not yet been initalized.