### PR TITLE
fixed version checks for force logout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,6 +134,7 @@ require (
 	github.com/yvasiyarov/gorelic v0.0.7 // indirect
 	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
+	golang.org/x/mod v0.4.0
 	golang.org/x/net v0.0.0-20210315170653-34ac3e1c2000
 	golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/34149

Fixed how we decide to force a logout. All users will be logged out in ONLY the following cases:
- if the current rancher version is an rc or release and the target version is greater than the last force logout
- if the current rancher version is a `*-head` build and the last force logout version does not match the current version