### PR TITLE
[2.6] Support pulling system imagelist cache from bundled charts

### DIFF
--- a/pkg/data/management/catalog_data.go
+++ b/pkg/data/management/catalog_data.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/catalog/manager"
+	"github.com/rancher/rancher/pkg/catalog/utils"
 
 	"github.com/rancher/rancher/pkg/controllers/managementuserlegacy/helm/common"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -171,6 +173,9 @@ func syncCatalogs(management *config.ManagementContext) error {
 }
 
 func doAddCatalogs(management *config.ManagementContext, name, url, branch, helmVersion string, bundledMode bool) error {
+	var obj *v3.Catalog
+	var err error
+
 	catalogClient := management.Management.Catalogs("")
 
 	kind := helm.KindHelmGit
@@ -178,11 +183,11 @@ func doAddCatalogs(management *config.ManagementContext, name, url, branch, helm
 		kind = helm.KindHelmInternal
 	}
 
-	_, err := catalogClient.Get(name, metav1.GetOptions{})
+	obj, err = catalogClient.Get(name, metav1.GetOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	} else if errors.IsNotFound(err) {
-		obj := &v3.Catalog{
+		obj = &v3.Catalog{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
@@ -193,9 +198,17 @@ func doAddCatalogs(management *config.ManagementContext, name, url, branch, helm
 				HelmVersion: helmVersion,
 			},
 		}
-		if _, err := catalogClient.Create(obj); err != nil {
+		if obj, err = catalogClient.Create(obj); err != nil {
 			return err
 		}
+	}
+
+	if bundledMode && obj.Name == utils.SystemLibraryName {
+		// force update the catalog cache on every startup; this ensures that setups using bundledMode can load new image
+		// into the ConfigMap when the bundled system-chart is updated (e.g. during Rancher upgrades) upon restarting Rancher
+		configMapInterface := management.Core.ConfigMaps("")
+		configMapLister := configMapInterface.Controller().Lister()
+		return manager.CreateOrUpdateSystemCatalogImageCache(obj, configMapInterface, configMapLister, true, true)
 	}
 
 	return nil

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -349,19 +349,16 @@ func getSourcesList(imageSources map[string]bool) string {
 	return strings.Join(sources, ",")
 }
 
-func CreateCatalogImageListConfigMap(cm *v1.ConfigMap, catalog *v3.Catalog) (err error) {
+func AddImagesToImageListConfigMap(cm *v1.ConfigMap, chartPath string) (err error) {
 	var windowsImages []string
 	var linuxImages []string
 
-	catalogHash := libhelm.CatalogSHA256Hash(catalog)
-	catalogChartPath := filepath.Join(libhelm.CatalogCache, catalogHash)
-
-	windowsImages, _, err = GetImages(catalogChartPath, "", nil, []string{}, nil, Windows)
+	windowsImages, _, err = GetImages(chartPath, "", nil, []string{}, nil, Windows)
 	if err != nil {
 		return
 	}
 
-	linuxImages, _, err = GetImages(catalogChartPath, "", nil, []string{}, nil, Linux)
+	linuxImages, _, err = GetImages(chartPath, "", nil, []string{}, nil, Linux)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Backports changes from https://github.com/rancher/rancher/pull/34225.

Related Issue: https://github.com/rancher/rancher/issues/34172

(cherry picked from commit 6142dc4f23c9962bccaa565e305a5303705ed466)