### PR TITLE
add the permission for creating PSP to support uninstalling the rancher-webhook app in hardened cluster

### DIFF
--- a/chart/templates/post-delete-hook-cluster-role.yaml
+++ b/chart/templates/post-delete-hook-cluster-role.yaml
@@ -32,7 +32,7 @@ rules:
     verbs: [ "get", "list", "delete" ]
   - apiGroups: [ "policy" ]
     resources: [ "podsecuritypolicies" ]
-    verbs: [ "use", "delete" ]
+    verbs: [ "use", "delete", "create" ]
   - apiGroups: [ "networking.k8s.io" ]
     resources: [ "ingresses" ]
     verbs: [ "delete" ]


### PR DESCRIPTION
issue rancher/rancher#34188

the post-delete-hook needs the permission to create a PSP for `rancher-webhook`'s pre-delete-hook

Note:
This PR is already tested in a hardened cluster


TODO: 

- [ ] add it to this forward-port PR https://github.com/rancher/rancher/pull/34218