### PR TITLE
Adding rbac for restrictedAdmin to access Provisioning Clusters

### DIFF
--- a/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
+++ b/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
@@ -27,6 +27,7 @@ type handler struct {
 	roleLocker                           locker.Locker
 	roleCache                            rbacv1.RoleCache
 	roleController                       rbacv1.RoleController
+	roleBindingController                rbacv1.RoleBindingController
 	clusterRoleCache                     rbacv1.ClusterRoleCache
 	roleTemplateController               mgmtcontrollers.RoleTemplateController
 	clusterRoleTemplateBindings          mgmtcontrollers.ClusterRoleTemplateBindingCache
@@ -54,6 +55,7 @@ func Register(ctx context.Context, clients *wrangler.Context) error {
 	h := &handler{
 		roleCache:                            clients.RBAC.Role().Cache(),
 		roleController:                       clients.RBAC.Role(),
+		roleBindingController:                clients.RBAC.RoleBinding(),
 		clusterRoleCache:                     clients.RBAC.ClusterRole().Cache(),
 		roleTemplateController:               clients.Mgmt.RoleTemplate(),
 		clusterRoleTemplateBindings:          clients.Mgmt.ClusterRoleTemplateBinding().Cache(),

--- a/pkg/controllers/management/authprovisioningv2/prtb.go
+++ b/pkg/controllers/management/authprovisioningv2/prtb.go
@@ -39,7 +39,7 @@ func (h *handler) OnPRTB(key string, prtb *v3.ProjectRoleTemplateBinding) (*v3.P
 		// permissions for the provisioning objects won't be created until an
 		// update to the PRTB happens again.
 		logrus.Debugf("[auth-prov-v2-prtb] No provisioning cluster found for cluster %v, enqueuing PRTB %v ", prtb.ClusterName, prtb.Name)
-		h.clusterRoleTemplateBindingController.EnqueueAfter(prtb.Namespace, prtb.Name, 10*time.Second)
+		h.projectRoleTemplateBindingController.EnqueueAfter(prtb.Namespace, prtb.Name, 10*time.Second)
 		return prtb, nil
 	}
 

--- a/pkg/controllers/management/restrictedadminrbac/register.go
+++ b/pkg/controllers/management/restrictedadminrbac/register.go
@@ -3,6 +3,7 @@ package restrictedadminrbac
 import (
 	"context"
 
+	provisioningcontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/rancher/pkg/types/config"
@@ -24,6 +25,7 @@ type rbaccontroller struct {
 	crbLister           v1.ClusterRoleBindingLister
 	clusterRoleBindings v1.ClusterRoleBindingInterface
 	fleetworkspaces     v3.FleetWorkspaceInterface
+	provClusters        provisioningcontrollers.ClusterCache
 }
 
 const (
@@ -46,6 +48,7 @@ func Register(ctx context.Context, management *config.ManagementContext, wrangle
 		crbLister:           management.RBAC.ClusterRoleBindings("").Controller().Lister(),
 		clusterRoleBindings: management.RBAC.ClusterRoleBindings(""),
 		fleetworkspaces:     management.Management.FleetWorkspaces(""),
+		provClusters:        wrangler.Provisioning.Cluster().Cache(),
 	}
 
 	r.clusters.AddHandler(ctx, "restrictedAdminsRBACCluster", r.clusterRBACSync)

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types"
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	v32 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/ref"
 	k8srbacv1 "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
+	"github.com/rancher/wrangler/pkg/name"
 	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -245,4 +247,8 @@ func gatherRules(clusterRoles k8srbacv1.ClusterRoleCache, roleTemplates v32.Role
 		}
 	}
 	return rules, nil
+}
+
+func ProvisioningClusterAdminName(cluster *provv1.Cluster) string {
+	return name.SafeConcatName("r-cluster", cluster.Name, "admin")
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/34185

Adding rbac permissions for restrictedAdmin users to be able to access the provisioning Cluster. This has been added to two places:
1) In the cluster sync, to create a rolebinding to the cluster-admin role created for the provisioning cluster for all restrictedAdmin subjects
2) In the GRB sync, when a new restrictedAdmin user is added, we create a rolebinding to the  cluster-admin role created for the provisioning cluster for this user