### PR TITLE
Remove token hashing setting if unused

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -71,7 +71,6 @@ var (
 	SystemDefaultRegistry             = NewSetting("system-default-registry", "")
 	SystemNamespaces                  = NewSetting("system-namespaces", "kube-system,kube-public,cattle-system,cattle-alerting,cattle-logging,cattle-pipeline,cattle-prometheus,ingress-nginx,cattle-global-data,cattle-istio,kube-node-lease,cert-manager,cattle-global-nt,security-scan,cattle-fleet-system,calico-system,tigera-operator,cattle-impersonation-system")
 	TelemetryOpt                      = NewSetting("telemetry-opt", "")
-	TokenHashing                      = NewSetting("token-hashing", "true")
 	TLSMinVersion                     = NewSetting("tls-min-version", "1.2")
 	TLSCiphers                        = NewSetting("tls-ciphers", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305")
 	UIBanners                         = NewSetting("ui-banners", "{}")


### PR DESCRIPTION
Revert "Add token-hashing setting"

This reverts commit 4380cb873b38ada140b92df8f96889a3b6d907f8.
