### PR TITLE
Add operation permission to standard user so they can see logs

### DIFF
--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -49,6 +49,7 @@ import (
 	appsv1 "github.com/rancher/wrangler/pkg/generated/controllers/apps/v1"
 	"github.com/rancher/wrangler/pkg/generated/controllers/batch"
 	batchv1 "github.com/rancher/wrangler/pkg/generated/controllers/batch/v1"
+	"github.com/rancher/wrangler/pkg/generated/controllers/rbac"
 	"github.com/rancher/wrangler/pkg/generic"
 	"github.com/rancher/wrangler/pkg/leader"
 	"github.com/rancher/wrangler/pkg/schemes"
@@ -219,6 +220,11 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 		return nil, err
 	}
 
+	rbac, err := rbac.NewFactoryFromConfigWithOptions(restConfig, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	adminReg, err := admissionreg.NewFactoryFromConfigWithOptions(restConfig, opts)
 	if err != nil {
 		return nil, err
@@ -274,6 +280,7 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 
 	helmop := helmop.NewOperations(cg,
 		helm.Catalog().V1(),
+		rbac.Rbac().V1(),
 		content,
 		steveControllers.Core.Pod())
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/34277

Add operation permission to standard users, as they should be able to use rke2 cluster template(helm chart), install and see helm operation logs.

The implemetation is changed so that when user creates operation through action, the corresponding role and rolebinding that only allow user to get this operation will be created along with operation. This only gives user ability to see operations that were created by itself.