### PR TITLE
Fix ectd-disable-snapshots flag

### DIFF
--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -549,7 +549,7 @@ func (p *Planner) addETCD(config map[string]interface{}, controlPlane *rkev1.RKE
 	}
 
 	if controlPlane.Spec.ETCD.DisableSnapshots {
-		config["etcd-disable-snapshot"] = true
+		config["etcd-disable-snapshots"] = true
 	}
 	if controlPlane.Spec.ETCD.SnapshotRetention > 0 {
 		config["etcd-snapshot-retention"] = controlPlane.Spec.ETCD.SnapshotRetention


### PR DESCRIPTION
The flag for RKE2 uses plural snapshots; Rancher was passing it as
singular. This fix adds to the 's'

Issue:
https://github.com/rancher/rancher/issues/34175