### PR TITLE
Fix helm upgrade for bootstrap password

### DIFF
--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -7,7 +7,11 @@ type: Opaque
 data:
   {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "bootstrap-secret" }}
   {{- if and $existingSecret $existingSecret.data }}
+    {{- if $existingSecret.data.bootstrapPassword }}
   bootstrapPassword: {{ $existingSecret.data.bootstrapPassword }}
+    {{- else }}
+  bootstrapPassword: {{ .Values.bootstrapPassword | default "" | b64enc | quote }}
+    {{- end }}
   {{- else }}
-  bootstrapPassword: {{ .Values.bootstrapPassword | b64enc | quote }}
+  bootstrapPassword: {{ .Values.bootstrapPassword | default "" | b64enc | quote }}
   {{- end }}


### PR DESCRIPTION
This handles upgrade when bootstrapPassword is no in the values and
also if the bootstrap secret exists and has no data or empty
bootstrapPassword field