### PR TITLE
Delete fleet-crd chart in post delete hook

### DIFF
--- a/chart/scripts/post-delete-hook.sh
+++ b/chart/scripts/post-delete-hook.sh
@@ -70,6 +70,15 @@ for namespace in ${namespaces}; do
   done
 done
 
+echo "Cleaning up Fleet resources..."
+for namespace in "cattle-fleet-system" "fleet-system"; do
+  for app in $(helm list -n "${namespace}" -q); do
+    if [[ "${app}" = "fleet-crd" ]] && [[ ! $(helm uninstall "${app}" -n "${namespace}") ]]; then
+      failed=("${failed[@]}" "${app}")
+    fi
+  done
+done
+
 echo "------ Summary ------"
 if [[ ${#succeeded[@]} -ne 0 ]]; then
   echo "Succeeded to uninstall the following apps:" "${succeeded[@]}"


### PR DESCRIPTION
This _does_ contain copied code from the other loop, but in order for the UX to be consistent, this PR deletes remaining Fleet resources (in this case, just the Fleet CRD chart) after all other Rancher resources are deleted. The alternative would be to delete the `fleet-crd` chart if found in the main loop, but that might create confusion since no other CRD charts are uninstalled.

Relevant issue: https://github.com/rancher/rancher/issues/34330