### PR TITLE
[2.6] Retrieve the UserContext for cluster dynamically

### DIFF
--- a/pkg/clusterrouter/factory.go
+++ b/pkg/clusterrouter/factory.go
@@ -7,14 +7,9 @@ import (
 	"github.com/moby/locker"
 	"github.com/rancher/rancher/pkg/clusterrouter/proxy"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/types/config/dialer"
 	"k8s.io/client-go/rest"
 )
-
-type ClusterContextGetter interface {
-	UserContext(string) (*config.UserContext, error)
-}
 
 type factory struct {
 	dialerFactory        dialer.Factory
@@ -24,10 +19,10 @@ type factory struct {
 	serverLock           *locker.Locker
 	servers              sync.Map
 	localConfig          *rest.Config
-	clusterContextGetter ClusterContextGetter
+	clusterContextGetter proxy.ClusterContextGetter
 }
 
-func newFactory(localConfig *rest.Config, dialer dialer.Factory, lookup ClusterLookup, clusterLister v3.ClusterLister, clusterContextGetter ClusterContextGetter) *factory {
+func newFactory(localConfig *rest.Config, dialer dialer.Factory, lookup ClusterLookup, clusterLister v3.ClusterLister, clusterContextGetter proxy.ClusterContextGetter) *factory {
 	return &factory{
 		dialerFactory:        dialer,
 		serverLock:           locker.New(),
@@ -80,9 +75,5 @@ func (s *factory) get(req *http.Request) (*v3.Cluster, http.Handler, error) {
 }
 
 func (s *factory) newServer(c *v3.Cluster) (server, error) {
-	clusterContext, err := s.clusterContextGetter.UserContext(c.Name)
-	if err != nil {
-		return nil, err
-	}
-	return proxy.New(s.localConfig, c, s.clusterLister, s.dialerFactory, clusterContext)
+	return proxy.New(s.localConfig, c, s.clusterLister, s.dialerFactory, s.clusterContextGetter)
 }

--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -28,6 +28,10 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+type ClusterContextGetter interface {
+	UserContext(string) (*config.UserContext, error)
+}
+
 type RemoteService struct {
 	sync.Mutex
 
@@ -35,12 +39,12 @@ type RemoteService struct {
 	transport transportGetter
 	url       urlGetter
 
-	factory        dialer.Factory
-	clusterLister  v3.ClusterLister
-	caCert         string
-	localAuth      string
-	httpTransport  *http.Transport
-	clusterContext *config.UserContext
+	factory              dialer.Factory
+	clusterLister        v3.ClusterLister
+	caCert               string
+	localAuth            string
+	httpTransport        *http.Transport
+	clusterContextGetter ClusterContextGetter
 }
 
 var (
@@ -65,11 +69,11 @@ func prefix(cluster *v3.Cluster) string {
 	return "/k8s/clusters/" + cluster.Name
 }
 
-func New(localConfig *rest.Config, cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContext *config.UserContext) (*RemoteService, error) {
+func New(localConfig *rest.Config, cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContextGetter ClusterContextGetter) (*RemoteService, error) {
 	if cluster.Spec.Internal {
 		return NewLocal(localConfig, cluster)
 	}
-	return NewRemote(cluster, clusterLister, factory, clusterContext)
+	return NewRemote(cluster, clusterLister, factory, clusterContextGetter)
 }
 
 func NewLocal(localConfig *rest.Config, cluster *v3.Cluster) (*RemoteService, error) {
@@ -104,7 +108,7 @@ func NewLocal(localConfig *rest.Config, cluster *v3.Cluster) (*RemoteService, er
 	return rs, nil
 }
 
-func NewRemote(cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContext *config.UserContext) (*RemoteService, error) {
+func NewRemote(cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dialer.Factory, clusterContextGetter ClusterContextGetter) (*RemoteService, error) {
 	if !v32.ClusterConditionProvisioned.IsTrue(cluster) {
 		return nil, httperror.NewAPIError(httperror.ClusterUnavailable, "cluster not provisioned")
 	}
@@ -123,11 +127,11 @@ func NewRemote(cluster *v3.Cluster, clusterLister v3.ClusterLister, factory dial
 	}
 
 	return &RemoteService{
-		cluster:        cluster,
-		url:            urlGetter,
-		clusterLister:  clusterLister,
-		factory:        factory,
-		clusterContext: clusterContext,
+		cluster:              cluster,
+		url:                  urlGetter,
+		clusterLister:        clusterLister,
+		factory:              factory,
+		clusterContextGetter: clusterContextGetter,
 	}, nil
 }
 
@@ -279,7 +283,12 @@ func (p *UpgradeProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 // getImpersonatorAccountToken creates, if not already present, a service account and role bindings
 // whose only permission is to impersonate the given user, and returns the bearer token for the account.
 func (r *RemoteService) getImpersonatorAccountToken(user user.Info) (string, error) {
-	i := impersonation.New(user, r.clusterContext)
+	clusterContext, err := r.clusterContextGetter.UserContext(r.cluster.Name)
+	if err != nil {
+		return "", err
+	}
+
+	i := impersonation.New(user, clusterContext)
 
 	sa, err := i.SetUpImpersonation()
 	if err != nil {

--- a/pkg/clusterrouter/router.go
+++ b/pkg/clusterrouter/router.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/rancher/norman/httperror"
+	"github.com/rancher/rancher/pkg/clusterrouter/proxy"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config/dialer"
 	"k8s.io/client-go/rest"
@@ -14,7 +15,7 @@ type Router struct {
 	serverFactory *factory
 }
 
-func New(localConfig *rest.Config, lookup ClusterLookup, dialer dialer.Factory, clusterLister v3.ClusterLister, clusterContextGetter ClusterContextGetter) http.Handler {
+func New(localConfig *rest.Config, lookup ClusterLookup, dialer dialer.Factory, clusterLister v3.ClusterLister, clusterContextGetter proxy.ClusterContextGetter) http.Handler {
 	serverFactory := newFactory(localConfig, dialer, lookup, clusterLister, clusterContextGetter)
 	return &Router{
 		serverFactory: serverFactory,

--- a/pkg/k8sproxy/k8s_proxy.go
+++ b/pkg/k8sproxy/k8s_proxy.go
@@ -4,12 +4,13 @@ import (
 	"net/http"
 
 	"github.com/rancher/rancher/pkg/clusterrouter"
+	"github.com/rancher/rancher/pkg/clusterrouter/proxy"
 	"github.com/rancher/rancher/pkg/k8slookup"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/types/config/dialer"
 )
 
-func New(scaledContext *config.ScaledContext, dialer dialer.Factory, clusterContextGetter clusterrouter.ClusterContextGetter) http.Handler {
+func New(scaledContext *config.ScaledContext, dialer dialer.Factory, clusterContextGetter proxy.ClusterContextGetter) http.Handler {
 	return clusterrouter.New(&scaledContext.RESTConfig, k8slookup.New(scaledContext, true), dialer,
 		scaledContext.Management.Clusters("").Controller().Lister(),
 		clusterContextGetter)


### PR DESCRIPTION
When the cluster context is set for the proxy server at initialization,
it doesn't always refresh when a new request comes in. This can cause
the cache to become stale and the proxy server handler can fail to
fetch service accounts from it even though they exist in the downstream
cluster. This change pushes the cluster context getter down to the
request handling layer instead of the server creation layer so that it
is refreshed on every request.

https://github.com/rancher/rancher/issues/34187