### PR TITLE
Add system agent images to package script

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -15,7 +15,7 @@ ENV KUSTOMIZE_VERSION v3.10.0
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
 ENV CATTLE_KDM_BRANCH=dev-v2.6
 
-RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl tar vim less file xz gzip sed gawk iproute2 iptables
+RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl tar vim less file xz gzip sed gawk iproute2 iptables jq
 
 RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin
 

--- a/scripts/package
+++ b/scripts/package
@@ -20,6 +20,22 @@ cp ../bin/rancher.yaml ../bin/rancher-namespace.yaml ../bin/rancher ../bin/agent
 IMAGE=${REPO}/rancher:${TAG}
 AGENT_IMAGE=${REPO}/rancher-agent:${AGENT_TAG}
 RUNTIME_IMAGE=${REPO}/rancher-runtime:${TAG}
+SYSTEM_AGENT_UPGRADE_TAG=$(grep "ENV CATTLE_SYSTEM_AGENT_VERSION" ../package/Dockerfile | awk '{ print $NF }')-suc
+SYSTEM_AGENT_UPGRADE_IMAGE=${REPO}/system-agent:${SYSTEM_AGENT_UPGRADE_TAG}
+
+# Query KDM data for RKE2 released versions where server args are defined.
+RKE2_RELEASE_VERSIONS=$(jq -r '[.rke2.releases[] | select(.serverArgs) | .version] | join(" ")' ../bin/data.json)
+# Convert versions with build metadata into valid image tags (replace + for -) and construct an array of tags.
+RKE2_RELEASE_TAGS=( $(echo $RKE2_RELEASE_VERSIONS | tr + -) )
+# Prefix image repo and name to tags.
+SYSTEM_AGENT_INSTALLER_RKE2_IMAGES=( "${RKE2_RELEASE_TAGS[@]/#/${REPO}/system-agent-installer-rke2:}" )
+
+# Query KDM data for K3S released versions where server args are defined.
+K3S_RELEASE_VERSIONS=$(jq -r '[.k3s.releases[] | select(.serverArgs) | .version] | join(" ")' ../bin/data.json)
+# Convert versions with build metadata into valid image tags (replace + for -) and construct an array of tags.
+K3S_RELEASE_TAGS=( $(echo $K3S_RELEASE_VERSIONS | tr + -) )
+# Prefix image repo and name to tags.
+SYSTEM_AGENT_INSTALLER_K3S_IMAGES=( "${K3S_RELEASE_TAGS[@]/#/${REPO}/system-agent-installer-k3s:}" )
 
 if [ ${ARCH} == arm64 ]; then
     sed -i -e '$a\' -e 'ENV ETCD_UNSUPPORTED_ARCH=arm64' Dockerfile
@@ -67,7 +83,7 @@ fi
 
 if [ ${ARCH} == amd64 ]; then
     # Move this out of ARCH check for local dev on non-amd64 hardware.
-    TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go $SYSTEM_CHART_REPO_DIR $CHART_REPO_DIR/assets $IMAGE $AGENT_IMAGE $RUNTIME_IMAGE
+    TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go $SYSTEM_CHART_REPO_DIR $CHART_REPO_DIR/assets $IMAGE $AGENT_IMAGE $RUNTIME_IMAGE $SYSTEM_AGENT_UPGRADE_IMAGE $SYSTEM_AGENT_INSTALLER_RKE2_IMAGES $SYSTEM_AGENT_INSTALLER_K3S_IMAGES
 
     # rancherd tarball
     rm -rf build/rancherd/bundle


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/32600

rancher-images.txt diff between master and this branch after running local drone builds with TAG=v2.6.0
```
--- ../rancher-images-master.txt        2021-08-19 22:39:52.000000000 -0700
+++ bin/rancher-images.txt      2021-08-19 23:00:02.000000000 -0700
@@ -203,6 +203,9 @@
 rancher/security-scan:v0.2.3
 rancher/shell:v0.1.10
 rancher/shell:v0.1.8
+rancher/system-agent-installer-k3s:v1.21.3-k3s1
+rancher/system-agent-installer-rke2:v1.21.3-rc6-rke2r2
+rancher/system-agent:v0.0.1-alpha37-suc
 rancher/system-upgrade-controller:v0.7.3
 rancher/system-upgrade-controller:v0.7.4
 rancher/tekton-utils:v0.1.2
```