### PR TITLE
[2.6] Set the source on settings

### DIFF
--- a/pkg/controllers/dashboardapi/settings/settings.go
+++ b/pkg/controllers/dashboardapi/settings/settings.go
@@ -91,6 +91,7 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 				Default: setting.Default,
 			}
 			if value != "" {
+				newSetting.Source = "env"
 				newSetting.Value = value
 			}
 			if newSetting.Value == "" {
@@ -110,6 +111,10 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 			update := false
 			if obj.Default != setting.Default {
 				obj.Default = setting.Default
+				update = true
+			}
+			if value != "" && obj.Source != "env" {
+				obj.Source = "env"
 				update = true
 			}
 			if value != "" && obj.Value != value {

--- a/pkg/controllers/dashboardapi/settings/settings.go
+++ b/pkg/controllers/dashboardapi/settings/settings.go
@@ -80,7 +80,7 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 
 	for name, setting := range settingsMap {
 		key := settings.GetEnvKey(name)
-		value := os.Getenv(key)
+		envValue := os.Getenv(key)
 
 		obj, err := s.settings.Get(setting.Name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
@@ -90,9 +90,9 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 				},
 				Default: setting.Default,
 			}
-			if value != "" {
+			if envValue != "" {
 				newSetting.Source = "env"
-				newSetting.Value = value
+				newSetting.Value = envValue
 			}
 			if newSetting.Value == "" {
 				fallback[newSetting.Name] = newSetting.Default
@@ -113,12 +113,12 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 				obj.Default = setting.Default
 				update = true
 			}
-			if value != "" && obj.Source != "env" {
+			if envValue != "" && obj.Source != "env" {
 				obj.Source = "env"
 				update = true
 			}
-			if value != "" && obj.Value != value {
-				obj.Value = value
+			if envValue != "" && obj.Value != envValue {
+				obj.Value = envValue
 				update = true
 			}
 			if obj.Value == "" {


### PR DESCRIPTION
**Issue**
When an environment variable is used for settings, we want to know that it was set by an ENV var

**Solution**
Set the existing settings.Source field to "ENV" when an environment variable is used. This will help users know when env vars were used and will help them understand where to make settings changes. 

**Note:** I ran `go generate` and see that there were some files not generated. https://github.com/rancher/rancher/pull/34345 looks like it could've been from this. 