### PR TITLE
updates for k3s-upgrader based on updated system-upgrade-controller

### DIFF
--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -171,7 +171,7 @@ func (h *handler) deployK3sBasedUpgradeController(clusterName string, isK3s, isR
 			if !v33.AppConditionForceUpgrade.IsUnknown(app) {
 				v33.AppConditionForceUpgrade.Unknown(app)
 			}
-			logrus.Warnln("force redeploying system-ugrade-controller")
+			logrus.Warnln("force redeploying system-upgrade-controller")
 			if _, err = appClient.Update(app); err != nil {
 				return err
 			}

--- a/pkg/controllers/management/k3sbasedupgrade/template.go
+++ b/pkg/controllers/management/k3sbasedupgrade/template.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io"
 	planv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubectl/pkg/describe"
 )
 
 const k3sMasterPlanName = "k3s-master-plan"
 const k3sWorkerPlanName = "k3s-worker-plan"
-const systemUpgradeServiceAccount = "system-upgrade"
+const systemUpgradeServiceAccount = "system-upgrade-controller"
 const k3supgradeImage = "rancher/k3s-upgrade"
 const rke2upgradeImage = "rancher/rke2-upgrade"
 const rke2MasterPlanName = "rke2-master-plan"
@@ -58,6 +59,10 @@ func generateMasterPlan(version string, concurrency int, drain bool, upgradeImag
 		}},
 	}
 
+	masterPlan.Spec.Tolerations = []corev1.Toleration{{
+		Operator: corev1.TolerationOpExists,
+	}}
+
 	return masterPlan
 }
 
@@ -87,6 +92,10 @@ func generateWorkerPlan(version string, concurrency int, drain bool, upgradeImag
 		}},
 	}
 
+	workerPlan.Spec.Tolerations = []corev1.Toleration{{
+		Operator: corev1.TolerationOpExists,
+	}}
+
 	return workerPlan
 }
 
@@ -110,6 +119,11 @@ func configureMasterPlan(masterPlan planv1.Plan, version string, concurrency int
 			Values:   []string{"true"},
 		}},
 	}
+
+	masterPlan.Spec.Tolerations = []corev1.Toleration{{
+		Operator: corev1.TolerationOpExists,
+	}}
+
 	return masterPlan
 }
 
@@ -136,6 +150,10 @@ func configureWorkerPlan(workerPlan planv1.Plan, version string, concurrency int
 			Operator: metav1.LabelSelectorOpDoesNotExist,
 		}},
 	}
+
+	workerPlan.Spec.Tolerations = []corev1.Toleration{{
+		Operator: corev1.TolerationOpExists,
+	}}
 
 	return workerPlan
 }


### PR DESCRIPTION
Forward port https://github.com/rancher/rancher/pull/34376 
Adding tolerate all to plans, bound by strong affinity to node names.
Updating svc account name based on updated suc chart.

https://github.com/rancher/rancher/issues/32050