### PR TITLE
Don't create bootstrap secrets if it doesn't exist

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -543,20 +543,11 @@ func BootstrapAdmin(management *wrangler.Context) (string, error) {
 		}
 
 		// persist the secret
-		bootstrapPasswordSecret.StringData = map[string]string{"bootstrapPassword": bootstrapPassword}
 		if bootstrapPasswordSecret.ObjectMeta.GetResourceVersion() != "" {
-			_, err = management.K8s.CoreV1().Secrets(cattleNamespace).Update(context.TODO(), bootstrapPasswordSecret, v1.UpdateOptions{})
-		} else {
-			// initialize the secret
-			bootstrapPasswordSecret.ObjectMeta = v1.ObjectMeta{
-				Name:      bootstrapPasswordSecretName,
-				Namespace: cattleNamespace,
+			bootstrapPasswordSecret.StringData = map[string]string{"bootstrapPassword": bootstrapPassword}
+			if _, err := management.K8s.CoreV1().Secrets(cattleNamespace).Update(context.TODO(), bootstrapPasswordSecret, v1.UpdateOptions{}); err != nil {
+				return "", err
 			}
-			_, err = management.K8s.CoreV1().Secrets(cattleNamespace).Create(context.TODO(), bootstrapPasswordSecret, v1.CreateOptions{})
-		}
-
-		if err != nil {
-			return "", err
 		}
 
 		hash, _ := bcrypt.GenerateFromPassword([]byte(bootstrapPassword), bcrypt.DefaultCost)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/32711

We do not need to create bootstrap secret in single docker install, as it is only served for users to view random generated password in helm HA install. Creating the secret will cause migration problem mentioned in the issue.

cc @nickgerace Figured this might be the best way to fix it.