### PR TITLE
Fix provisioning machine files permissions

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
@@ -70,7 +70,7 @@ func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, 
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  filesSecret.Name,
 					Items:       keysToPaths,
-					DefaultMode: &[]int32{0600}[0],
+					DefaultMode: &[]int32{0644}[0],
 				},
 			},
 		})


### PR DESCRIPTION
A previous update changed the machine-provisioning job to run as a
non-root user, as well as updating permissions to volumes to ensure the
new user can access the appropriate files. There was one volume that was
missed, and this change updates the permissions of that volume to allow
the machine-provisioning job to access the files it needs.

Issue:
https://github.com/rancher/rancher/issues/34373