### PR TITLE
[2.6] Prefix RKE2 Windows node commands with "PowerShell"

### DIFF
--- a/pkg/controllers/dashboard/clusterregistrationtoken/status.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/status.go
@@ -21,9 +21,9 @@ const (
 	insecureCommandFormat                = "curl --insecure -sfL %s | kubectl apply -f -"
 	nodeCommandFormat                    = "sudo docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run %s %s --server %s --token %s%s"
 	rke2NodeCommandFormat                = "curl -fL %s | sudo %s sh -s - --server %s --label 'cattle.io/os=linux' --token %s%s"
-	rke2WindowsNodeCommandFormat         = `curl.exe -fL %s -o install.ps1; Set-ExecutionPolicy Bypass -Scope Process -Force; ./install.ps1 -Server %s -Label 'cattle.io/os=windows' -Token %s -Worker%s`
+	rke2WindowsNodeCommandFormat         = `PowerShell curl.exe -fL %s -o install.ps1; Set-ExecutionPolicy Bypass -Scope Process -Force; ./install.ps1 -Server %s -Label 'cattle.io/os=windows' -Token %s -Worker%s`
 	rke2InsecureNodeCommandFormat        = "curl --insecure -fL %s | sudo %s sh -s - --server %s --label 'cattle.io/os=linux' --token %s%s"
-	rke2InsecureWindowsNodeCommandFormat = `curl.exe --insecure -fL %s -o install.ps1; Set-ExecutionPolicy Bypass -Scope Process -Force; ./install.ps1 -Server %s -Label 'cattle.io/os=windows' -Token %s -Worker%s`
+	rke2InsecureWindowsNodeCommandFormat = `PowerShell curl.exe --insecure -fL %s -o install.ps1; Set-ExecutionPolicy Bypass -Scope Process -Force; ./install.ps1 -Server %s -Label 'cattle.io/os=windows' -Token %s -Worker%s`
 	loginCommandFormat                   = "echo \"%s\" | sudo docker login --username %s --password-stdin %s"
 	windowsNodeCommandFormat             = `PowerShell -NoLogo -NonInteractive -Command "& {docker run -v c:\:c:\host %s%s bootstrap --server %s --token %s%s%s | iex}"`
 )


### PR DESCRIPTION
This prefixes commands for windows registration with `PowerShell` so that the command can be run from either CMD or PowerShell. 

rancher/dashboard#3952

Backports PR #34369 into release/v2.6