### PR TITLE
Grant full control to catalog.cattle.io.clusterrepos to restricted admins

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -92,6 +92,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	// restricted-admin will get cluster admin access to all downstream clusters but limited access to the local cluster
 	restrictedAdminRole := addUserRules(rb.addRole("Restricted Admin", "restricted-admin"))
 	restrictedAdminRole.
+		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("clustertemplates").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("clustertemplaterevisions").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("globalroles", "globalrolebindings").verbs("*").
@@ -111,7 +112,9 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	}
 
 	userRole := addUserRules(rb.addRole("User", "user"))
-	userRole.addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("get", "list", "watch")
+	userRole.
+		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("get", "list", "watch")
 
 	rb.addRole("User Base", "user-base").
 		addRule().apiGroups("management.cattle.io").resources("preferences").verbs("*").
@@ -451,7 +454,6 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 func addUserRules(role *roleBuilder) *roleBuilder {
 	role.
 		addRule().apiGroups("").resources("secrets").verbs("create").
-		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("principals", "roletemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("preferences").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("settings").verbs("get", "list", "watch").


### PR DESCRIPTION
Custom Resources of `catalog.cattle.io.clusterrepos` type are used to manage RKE2 templates (or rather locations such as Git repo containing these templates).
Restricted admins only have "view" type permissions to these currently. This change grants full permissions to these objects to the restricted admins.

Not the UI currently doesn't provide a way to manage these objects without full access to local cluster, so this is just backend change at this time.

For https://github.com/rancher/rancher/issues/33110