### PR TITLE
Add RBAC rule for cleanup job user

### DIFF
--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -210,6 +210,13 @@ func (c *ClusterLifecycleCleanup) createCleanupClusterRole(userContext *config.U
 			APIGroups: []string{"batch"},
 			Resources: []string{"jobs"},
 		},
+		// The job checks for the presence of the rancher service first
+		rbacV1.PolicyRule{
+			Verbs:         []string{"get"},
+			APIGroups:     []string{""},
+			Resources:     []string{"services"},
+			ResourceNames: []string{"rancher"},
+		},
 	}
 	clusterRole := rbacV1.ClusterRole{
 		ObjectMeta: meta,


### PR DESCRIPTION
The cleanup job service account now needs to be able to look up the
presence of the rancher service in the cluster and fails to perform any
cleanup if it does not have permission. This change adds the appropriate
RBAC rule to the main cluster role for the cleanup job.

Forward port of https://github.com/rancher/rancher/pull/34421

https://github.com/rancher/rancher/issues/33800