### PR TITLE
[Backport 2.6] Temporarily bypassing plan status checks for RKE2 Windows nodes.

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/machinestatus/machinestatus.go
+++ b/pkg/controllers/provisioningv2/rke2/machinestatus/machinestatus.go
@@ -195,6 +195,11 @@ func (h *handler) OnChange(key string, machine *capi.Machine) (*capi.Machine, er
 		return machine, err
 	}
 
+	// This is a temporary solution until RKE2 Windows nodes support system-agent functionality.
+	if os, ok := machine.GetLabels()["cattle.io/os"]; ok && os == "windows" {
+		return h.setMachineCondition(machine, Provisioned, corev1.ConditionTrue, "WindowsNode", "windows nodes don't currently support plans")
+	}
+
 	if status == "" {
 		status, reason, message = planner.GetPlanStatusReasonMessage(machine, plan)
 	}

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -489,7 +489,7 @@ func (p *Planner) reconcile(controlPlane *rkev1.RKEControlPlane, secret plan.Sec
 					draining = append(draining, entry.Machine.Name)
 				}
 			}
-		} else if !entry.Plan.InSync {
+		} else if !entry.Plan.InSync && entry.Machine.Labels["cattle.io/os"] != "windows" {
 			outOfSync = append(outOfSync, entry.Machine.Name)
 		} else {
 			if ok, err := p.undrain(entry.Machine); err != nil {


### PR DESCRIPTION
This PR is to temporarily bypass plan checks for RKE2 Windows nodes.

See:  https://github.com/rancher/rancher/issues/34173