### PR TITLE
Enqueue CAPI machines when deleting to set statuses

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -52,8 +52,9 @@ type handler struct {
 	kubeconfigManager *kubeconfig.Manager
 	apply             apply.Apply
 
-	capiClusters capicontrollers.ClusterCache
-	capiMachines capicontrollers.MachineCache
+	capiClustersCache capicontrollers.ClusterCache
+	capiClusters      capicontrollers.ClusterClient
+	capiMachinesCache capicontrollers.MachineCache
 }
 
 func Register(
@@ -67,8 +68,9 @@ func Register(
 		clusters:          clients.Provisioning.Cluster(),
 		clusterCache:      clients.Provisioning.Cluster().Cache(),
 		secretCache:       clients.Core.Secret().Cache(),
-		capiClusters:      clients.CAPI.Cluster().Cache(),
-		capiMachines:      clients.CAPI.Machine().Cache(),
+		capiClustersCache: clients.CAPI.Cluster().Cache(),
+		capiClusters:      clients.CAPI.Cluster(),
+		capiMachinesCache: clients.CAPI.Machine().Cache(),
 		kubeconfigManager: kubeconfig.New(clients),
 		apply: clients.Apply.WithCacheTypes(
 			clients.Provisioning.Cluster(),


### PR DESCRIPTION
The code seemed to intend to wait for the CAPI objects to be cleaned up
before deleting the provisioning cluster. However, the provisioning 
cluster was deleted immediately. This caused issues when creating a 
cluster with the same name after deletion.

In addition, if the provisioning cluster is in a bad state on creation,
then the CAPI objects will get created, but the finalizer will not be 
put on the provisioning cluster. Therefore, it will be impossible to 
delete the CAPI objects on provisioning cluster deletion. Instead, the 
controller will ensure that the provisioning cluster can be successfully
updated in its current state before trying to apply the CAPI objects.

Lastly, if the machinestatus controller detects that the bootstrap 
object has been deleted, then it will update the status of the machine 
to reflect that and allow the CAPI machine controller to continue with 
deletion.

Issue:
https://github.com/rancher/rancher/issues/34264