### PR TITLE
[2.6] Update restricted-admin to use cluster-owner role

### DIFF
--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -250,5 +250,5 @@ func gatherRules(clusterRoles k8srbacv1.ClusterRoleCache, roleTemplates v32.Role
 }
 
 func ProvisioningClusterAdminName(cluster *provv1.Cluster) string {
-	return name.SafeConcatName("r-cluster", cluster.Name, "admin")
+	return name.SafeConcatName("crt", cluster.Name, "cluster-owner")
 }


### PR DESCRIPTION
Problem:
restricted-admin does not have access to the v2 provisioning resources
in the management cluster

Solution:
Tie restricted-admin to the cluster-owner role that is created with all
clusters which grants the v2 provisioning permissions for resources
marked as cluster indexed.

https://github.com/rancher/rancher/issues/34509