### PR TITLE
[Forward port] Update restricted-admin to use cluster-owner role

### DIFF
--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -250,5 +250,5 @@ func gatherRules(clusterRoles k8srbacv1.ClusterRoleCache, roleTemplates v32.Role
 }
 
 func ProvisioningClusterAdminName(cluster *provv1.Cluster) string {
-	return name.SafeConcatName("r-cluster", cluster.Name, "admin")
+	return name.SafeConcatName("crt", cluster.Name, "cluster-owner")
 }


### PR DESCRIPTION
Forward porting PR https://github.com/rancher/rancher/pull/34517

Issue https://github.com/rancher/rancher/issues/34509

Problem:
restricted-admin does not have access to the v2 provisioning resources
in the management cluster

Solution:
Tie restricted-admin to the cluster-owner role that is created with all
clusters which grants the v2 provisioning permissions for resources
marked as cluster indexed.