### PR TITLE
Restart cluster controllers on RKE2 ACE change

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -463,6 +463,9 @@ var errKeyRotationFailed = errors.New("encryption key rotation failed, please re
 
 func (p *Provisioner) reconcileCluster(cluster *v3.Cluster, create bool) (*v3.Cluster, error) {
 	if skipLocalK3sImported(cluster) {
+		if cluster.Status.Driver == apimgmtv3.ClusterDriverImported && IsOwnedByProvisioningCluster(cluster) {
+			cluster.Status.AppliedSpec.LocalClusterAuthEndpoint = cluster.Spec.LocalClusterAuthEndpoint
+		}
 		return cluster, nil
 	}
 


### PR DESCRIPTION
In order to successfully enable ACE on an RKE2 cluster that was created
with ACE disabled, the cluster controllers must be restarted. This
change allows the controllers to detect when they should be restarted
because of an ACE change.

Issue:
https://github.com/rancher/rancher/issues/34500