### PR TITLE
update tags for 2.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20210318171128-d1ebd5202be4
-	github.com/rancher/rke v1.3.0-rc20
+	github.com/rancher/rke v1.3.0
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20210819001752-8ecda307ee49
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007

--- a/go.sum
+++ b/go.sum
@@ -1031,8 +1031,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a h1:6xqYlVz4uAX
 github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8wJ/coee2n9ed937uPBWQArBaVlxs+5wkkS9KiyDc=
 github.com/rancher/remotedialer v0.2.6-0.20210318171128-d1ebd5202be4 h1:wo4G9nT0YUdHMQe6g++ojYMUvNtHoybhLJ2Ckr/L1N8=
 github.com/rancher/remotedialer v0.2.6-0.20210318171128-d1ebd5202be4/go.mod h1:dbzn9NF1JWbGEHL6Q/1KG4KFROILiY/j6wmfF1Np3fk=
-github.com/rancher/rke v1.3.0-rc20 h1:dw8CToO+kbE577aL0oYZir3or06o4q1sQt4F6QwKUMk=
-github.com/rancher/rke v1.3.0-rc20/go.mod h1:HAdRKAo7OI5YvFSSP40ezrad1pXA7IuJgAW7S5PYg6Y=
+github.com/rancher/rke v1.3.0 h1:p3fhPVq0wbbxzdwyG+6F7pHexwveTHzxeZF9AYJvG/g=
+github.com/rancher/rke v1.3.0/go.mod h1:HAdRKAo7OI5YvFSSP40ezrad1pXA7IuJgAW7S5PYg6Y=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
 github.com/rancher/steve v0.0.0-20210819001752-8ecda307ee49 h1:1jUShuIDEb4ncVptFuapbBkX09s2x2eO4vMPRDlgFrc=

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -39,7 +39,7 @@ ENV LINODE_UI_DRIVER_VERSION v0.3.0
 ENV CATTLE_KDM_BRANCH ${CATTLE_KDM_BRANCH}
 ENV HELM_VERSION v3.6.0
 ENV KUSTOMIZE_VERSION v3.10.0
-ENV CATTLE_SYSTEM_AGENT_VERSION v0.1.0-rc5
+ENV CATTLE_SYSTEM_AGENT_VERSION v0.1.0
 ENV CATTLE_SYSTEM_AGENT_UPGRADE_IMAGE rancher/system-agent:${CATTLE_SYSTEM_AGENT_VERSION}-suc
 
 # System charts minimal version
@@ -104,8 +104,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry /usr/bin/k3s /usr/bin/kubectl && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-ENV CATTLE_UI_VERSION 2.6.0-rc9
-ENV CATTLE_DASHBOARD_UI_VERSION v2.6.0-rc9
+ENV CATTLE_UI_VERSION 2.6.0
+ENV CATTLE_DASHBOARD_UI_VERSION v2.6.0
 ENV CATTLE_CLI_VERSION v2.4.12
 
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210608014113-99e848822739
 	github.com/rancher/gke-operator v1.1.1
 	github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133
-	github.com/rancher/rke v1.3.0-rc20
+	github.com/rancher/rke v1.3.0
 	github.com/rancher/wrangler v0.8.6-0.20210819203859-0babd42fbad8
 	github.com/sirupsen/logrus v1.7.0
 	k8s.io/api v0.21.2

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -717,8 +717,8 @@ github.com/rancher/machine v0.15.0-rancher63/go.mod h1:qXYNumxy0J08MO/mh/jNjyRuE
 github.com/rancher/norman v0.0.0-20200517050325-f53cae161640/go.mod h1:92rz/7QN7DOeLQZlJY/8aFBOmF085igIVguR0wpxLas=
 github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133 h1:X1Tn2q3iDekvqajJCbY2QYkEUJ51rJC9BuxS3os6nX4=
 github.com/rancher/norman v0.0.0-20210608202517-59b3523c3133/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
-github.com/rancher/rke v1.3.0-rc20 h1:dw8CToO+kbE577aL0oYZir3or06o4q1sQt4F6QwKUMk=
-github.com/rancher/rke v1.3.0-rc20/go.mod h1:HAdRKAo7OI5YvFSSP40ezrad1pXA7IuJgAW7S5PYg6Y=
+github.com/rancher/rke v1.3.0 h1:p3fhPVq0wbbxzdwyG+6F7pHexwveTHzxeZF9AYJvG/g=
+github.com/rancher/rke v1.3.0/go.mod h1:HAdRKAo7OI5YvFSSP40ezrad1pXA7IuJgAW7S5PYg6Y=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=


### PR DESCRIPTION
- webhook and fleet min versions are up to date 