### PR TITLE
Distinguish imported RKE2 clusters from provisioning clusters

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -463,7 +463,7 @@ var errKeyRotationFailed = errors.New("encryption key rotation failed, please re
 
 func (p *Provisioner) reconcileCluster(cluster *v3.Cluster, create bool) (*v3.Cluster, error) {
 	if skipLocalK3sImported(cluster) {
-		if cluster.Status.Driver == apimgmtv3.ClusterDriverImported && IsOwnedByProvisioningCluster(cluster) {
+		if IsAdministratedByProvisioningCluster(cluster) {
 			cluster.Status.AppliedSpec.LocalClusterAuthEndpoint = cluster.Spec.LocalClusterAuthEndpoint
 		}
 		return cluster, nil
@@ -1057,7 +1057,7 @@ func (p *Provisioner) k3sBasedClusterConfig(cluster *v3.Cluster, nodes []*v3.Nod
 		cluster.Status.Driver == apimgmtv3.ClusterDriverK3os ||
 		cluster.Status.Driver == apimgmtv3.ClusterDriverRke2 ||
 		cluster.Status.Driver == apimgmtv3.ClusterDriverRancherD ||
-		(cluster.Status.Driver == apimgmtv3.ClusterDriverImported && IsOwnedByProvisioningCluster(cluster)) {
+		IsAdministratedByProvisioningCluster(cluster) {
 		return nil //no-op
 	}
 	isEmbedded := cluster.Status.Driver == apimgmtv3.ClusterDriverLocal
@@ -1100,6 +1100,6 @@ func (p *Provisioner) k3sBasedClusterConfig(cluster *v3.Cluster, nodes []*v3.Nod
 	return nil
 }
 
-func IsOwnedByProvisioningCluster(cluster *v3.Cluster) bool {
-	return strings.HasPrefix(cluster.Annotations["objectset.rio.cattle.io/owner-gvk"], "provisioning.cattle.io/v1, Kind=Cluster")
+func IsAdministratedByProvisioningCluster(cluster *v3.Cluster) bool {
+	return cluster.Status.Driver == apimgmtv3.ClusterDriverImported && cluster.Annotations["provisioning.cattle.io/administrated"] == "true"
 }

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"regexp"
+	"strconv"
 
 	"github.com/rancher/norman/types/convert"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -33,8 +34,9 @@ import (
 )
 
 const (
-	ByCluster    = "by-cluster"
-	creatorIDAnn = "field.cattle.io/creatorId"
+	ByCluster        = "by-cluster"
+	creatorIDAnn     = "field.cattle.io/creatorId"
+	administratedAnn = "provisioning.cattle.io/administrated"
 )
 
 var (
@@ -263,7 +265,7 @@ func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cluster.Status.ClusterName,
 			Labels:      cluster.Labels,
-			Annotations: map[string]string{},
+			Annotations: map[string]string{administratedAnn: strconv.FormatBool(cluster.Spec.RKEConfig != nil)},
 		},
 		Spec: spec,
 	}


### PR DESCRIPTION
A previous attempt was made to determine when a v3.Cluster upgrade
should be administered by management or provisioning controllers. That
change was not able to distinguish imported RKE2 clusters which should be
administered by the management controllers.

This change adds an annotation to the v3.Cluster object to better
distinguish these scenarios.

Issue:
https://github.com/rancher/rancher/issues/34546