### PR TITLE
Fix imported cluster cleanup race

### DIFF
--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -254,9 +254,10 @@ func ToRESTConfig(cluster *v3.Cluster, context *config.ScaledContext) (*rest.Con
 		return nil, nil
 	}
 
-	// rke1 custom clusters need cleanup and the cluster delete is being paused by cluster-scoped-gc
+	// rke1 custom clusters and imported clusters need to be cleaned up, and the cluster delete is being paused by cluster-scoped-gc
 	// allow a rest config since the nodes still exist and we need to start jobs on them for cleanup
-	if cluster.DeletionTimestamp != nil && cluster.Status.Driver != v32.ClusterDriverRKE {
+	_, hasGC := cluster.GetAnnotations()["lifecycle.cattle.io/create.cluster-scoped-gc"]
+	if cluster.DeletionTimestamp != nil && !hasGC {
 		return nil, nil
 	}
 


### PR DESCRIPTION
There is a race condition where the cluster object on the local cluster
is being deleted, but the cluster agent on the downstream cluster is not
yet cleaned up, and without this change the controller won't get a
kubeconfig for the deleted cluster and won't be able to create the
cleanup job. This change expands the exception made for RKE1 in the rest
config getter to any cluster with the `cluster-scoped-gc` lifecycle
annotation so that even if the cluster is being deleted we can still get
a kubeconfig for it to launch the cleanup job.

https://github.com/rancher/rancher/issues/34486