### PR TITLE
Fix cluster cleanup race

### DIFF
--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -36,11 +36,15 @@ func (m *Lifecycle) deleteV1Node(node *v3.Node) (runtime.Object, error) {
 		return node, nil
 	}
 
-	userClient, err := m.clusterManager.UserContext(node.Namespace)
+	cluster, err := m.clusterLister.Get("", node.Namespace)
 	if err != nil {
 		if kerror.IsNotFound(err) {
 			return node, nil
 		}
+		return node, err
+	}
+	userClient, err := m.clusterManager.UserContextFromCluster(cluster)
+	if err != nil {
 		return node, err
 	}
 
@@ -136,11 +140,8 @@ func (m *Lifecycle) cleanRKENode(node *v3.Node) error {
 		return nil // not an rke node, bail out
 	}
 
-	userContext, err := m.clusterManager.UserContext(node.Namespace)
+	userContext, err := m.clusterManager.UserContextFromCluster(cluster)
 	if err != nil {
-		if kerror.IsNotFound(err) {
-			return nil
-		}
 		return err
 	}
 

--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -98,7 +98,7 @@ func (c *ClusterLifecycleCleanup) Remove(obj *v3.Cluster) (runtime.Object, error
 }
 
 func (c *ClusterLifecycleCleanup) cleanupLocalCluster(obj *v3.Cluster) error {
-	userContext, err := c.Manager.UserContext(obj.Name)
+	userContext, err := c.Manager.UserContextFromCluster(obj)
 	if err != nil {
 		return err
 	}
@@ -129,7 +129,7 @@ func (c *ClusterLifecycleCleanup) Updated(obj *v3.Cluster) (runtime.Object, erro
 }
 
 func (c *ClusterLifecycleCleanup) cleanupImportedCluster(cluster *v3.Cluster) error {
-	userContext, err := c.Manager.UserContext(cluster.Name)
+	userContext, err := c.Manager.UserContextFromCluster(cluster)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There is a race condition where the cluster object on the local cluster
is being deleted, but the cluster agent on the downstream cluster is not
yet cleaned up, and without this change the controller won't get a
kubeconfig for the deleted cluster and won't be able to create the
cleanup job.

To fix this for RKE1, an exception was made in ToRESTConfig to have it
return a kubeconfig even as the cluster was being deleted, as long as
the driver was RKE1. This doesn't help for the case where the driver is
"Imported" or "RKE2". It's also problematic because it means that
controllers will be unnecessarily started when the cluster is being
deleted.

This change moves the deletion check out of ToRESTConfig and into the
internal controller handling methods, and reworks the imported cluster
cleanup and node cleanup handlers to use clustermanager.ToRESTConfig and
config.NewUserContext, circumventing clustermanager.UserContext which
starts controllers. With the deletion check moved out of ToRESTConfig,
cleanup handlers can safely use it to get credentials for the cluster
and launch cleanup jobs.

https://github.com/rancher/rancher/issues/34486