### PR TITLE
[v2.6.1] Clean up imported hosted provider clusters

### DIFF
--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -75,7 +75,10 @@ func (c *ClusterLifecycleCleanup) Remove(obj *v3.Cluster) (runtime.Object, error
 		obj.Status.Driver == v32.ClusterDriverK3s ||
 		obj.Status.Driver == v32.ClusterDriverK3os ||
 		obj.Status.Driver == v32.ClusterDriverRke2 ||
-		obj.Status.Driver == v32.ClusterDriverRancherD {
+		obj.Status.Driver == v32.ClusterDriverRancherD ||
+		(obj.Status.AKSStatus.UpstreamSpec != nil && obj.Status.AKSStatus.UpstreamSpec.Imported) ||
+		(obj.Status.EKSStatus.UpstreamSpec != nil && obj.Status.EKSStatus.UpstreamSpec.Imported) ||
+		(obj.Status.GKEStatus.UpstreamSpec != nil && obj.Status.GKEStatus.UpstreamSpec.Imported) {
 		err = c.cleanupImportedCluster(obj)
 	}
 	if err != nil {


### PR DESCRIPTION
Without this change, imported KEv2 clusters would skip cleaning up the
cluster agents upon cluster deletion. This was because the driver would
be set to e.g. "GKE" rather than "Imported". This change ensures the
lifecycle controller checks the cluster config for the "imported"
attribute.

Backport of https://github.com/rancher/rancher/pull/34562

https://github.com/rancher/rancher/issues/34561