### PR TITLE
Ensure correct system-agent version used in tests

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -3,11 +3,15 @@ set -e
 
 cd $(dirname $0)/..
 
+eval "$(grep '^ENV CATTLE_SYSTEM_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
+
 echo Starting rancher server
 mkdir -p /var/lib/rancher/k3s/agent/images
 grep PodTestImage ./tests/integration/pkg/defaults/defaults.go | cut -f2 -d'"' > /var/lib/rancher/k3s/agent/images/pull.txt
 grep MachineProvisionImage ./pkg/settings/setting.go | cut -f4 -d'"' >> /var/lib/rancher/k3s/agent/images/pull.txt
 touch /tmp/rancher.log
+mkdir -p /usr/share/rancher/ui/assets
+curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/rancher-system-agent-amd64 -o /usr/share/rancher/ui/assets/rancher-system-agent-amd64
 ./scripts/run >/tmp/rancher.log 2>&1 &
 PID=$!
 
@@ -25,7 +29,6 @@ done
 
 echo Running tests
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-eval "$(grep '^ENV CATTLE_SYSTEM_AGENT_VERSION' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 go test -v -timeout 40m ./tests/integration/pkg/tests/... || {
     cat /tmp/rancher.log | gzip | base64
     exit 1

--- a/tests/integration/pkg/tests/custom/custom_test.go
+++ b/tests/integration/pkg/tests/custom/custom_test.go
@@ -2,6 +2,7 @@ package custom
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 
 	provisioningv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
@@ -11,7 +12,24 @@ import (
 	"github.com/rancher/rancher/tests/integration/pkg/systemdnode"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestSystemAgentVersion(t *testing.T) {
+	clients, err := clients.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clients.Close()
+
+	setting, err := clients.Mgmt.Setting().Get("system-agent-version", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotEmpty(t, setting.Value)
+	assert.True(t, setting.Value == os.Getenv("CATTLE_SYSTEM_AGENT_VERSION"))
+}
 
 func TestCustomOneNode(t *testing.T) {
 	clients, err := clients.New()


### PR DESCRIPTION
The provisioning tests should use the correct version of the
system-agent. This change includes a test that checks for the expected
variable in the install script to ensure the correct version is used.

Issue:
https://github.com/rancher/rancher/issues/34437