### PR TITLE
Fixing secrets in automation. 

### DIFF
--- a/tests/validation/requirements_v3api.txt
+++ b/tests/validation/requirements_v3api.txt
@@ -21,3 +21,4 @@ requests==2.22.0
 rsa==4.7.2
 websocket-client==0.57.0
 semver==2.13.0
+packaging==20.9


### PR DESCRIPTION
Automation scrips have been failing due to a breaking change that was introduced from v2.6
1. Changed the env variable to "environment" and envFrom to "environmentFrom"
2. Verify for v2.5 and below releases, env and envfrom works
3. Verify from 2.6 "environment" and "environmentFrom" works

Jenkins pass log: https://jenkins.int.rancher.io/job/rancher_qa/job/rancher-freeform/100/
https://jenkins.int.rancher.io/job/rancher_qa/job/rancher-freeform/103/