### PR TITLE
Add support for listing update aks versions

### DIFF
--- a/pkg/api/norman/customization/aks/handler.go
+++ b/pkg/api/norman/customization/aks/handler.go
@@ -40,6 +40,7 @@ type Capabilities struct {
 	ClientID         string `json:"clientId"`
 	ClientSecret     string `json:"clientSecret"`
 	ResourceLocation string `json:"region"`
+	CurrentVersion   string `json:"currentVersion"`
 }
 
 // AKS handler lists available resources in Azure API
@@ -239,10 +240,8 @@ func (h *handler) getCloudCredential(req *http.Request, cap *Capabilities, credI
 	if cap.AuthBaseURL == "" {
 		cap.AuthBaseURL = azure.PublicCloud.ActiveDirectoryEndpoint
 	}
-	region := req.URL.Query().Get("region")
-	if region != "" {
-		cap.ResourceLocation = region
-	}
+	cap.ResourceLocation = req.URL.Query().Get("region")
+	cap.CurrentVersion = req.URL.Query().Get("currentVersion")
 
 	return http.StatusOK, nil
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/34161

Problem:
In AKS you cannot skip minor version updates.  Currently we list all available versions in the upgrade drop down.  This lets users attempt to upgrade to version that is too high causing the cluster to go into a constant error state.

Solution:
 I added the `current_version` parameter to the `/meta/aksVersions` endpoint.  When set the endpoint will only return versions available for upgrade from the current version.  There will need to be a companion dashboard issue for this.  The available versions are derived from the AKS API results.
 
 Testing:
 
 ```bash
 $ curl -s --insecure -H "Authorization: bearer $RANCHER_KEY" "https://localhost:8443/meta/aksVersions?cloudCredentialId=cattle-global-data%3Acc-6dgcx&region=eastus" | jq
[
  "1.18.17",
  "1.18.19",
  "1.19.11",
  "1.19.13",
  "1.20.7",
  "1.20.9",
  "1.21.1",
  "1.21.2"
]
 ```
 
 ```bash
$ curl -s --insecure -H "Authorization: bearer $RANCHER_KEY" "https://localhost:8443/meta/aksVersions?cloudCredentialId=cattle-global-data%3Acc-6dgcx&region=eastus&current_version=1.18.17" | jq
[
  "1.18.19",
  "1.19.11",
  "1.19.13"
]

 ```