### PR TITLE
Fix for docker server deployments: retry password requests

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -2084,15 +2084,29 @@ def readDataFile(data_dir, name):
         return f.read()
 
 
-def set_url_password_token(rancher_url, server_url=None):
+def set_url_password_token(rancher_url, server_url=None, version=""):
     """Returns a ManagementContext for the default global admin user."""
     auth_url = \
         rancher_url + "/v3-public/localproviders/local?action=login"
-    r = requests.post(auth_url, json={
-        'username': 'admin',
-        'password': 'admin',
-        'responseType': 'json',
-    }, verify=False)
+    rpassword = 'admin'
+    print(auth_url)
+    if version.find("master") > -1 or version.find("2.6") > -1:
+        rpassword = ADMIN_PASSWORD
+        print("on 2.6 or later")
+    retries = 5
+    for attempt in range(1,retries):
+        try:
+            r = requests.post(auth_url, json={
+            'username': 'admin',
+            'password': rpassword,
+            'responseType': 'json',
+            }, verify=False)
+        except requests.exceptions.RequestException:
+            print("password request failed. Retry attempt: ",
+                  "{} of {}".format(attempt, retries))
+            time.sleep(2)
+        else:
+            break
     print(r.json())
     token = r.json()['token']
     print(token)

--- a/tests/validation/tests/v3_api/test_airgap.py
+++ b/tests/validation/tests/v3_api/test_airgap.py
@@ -558,16 +558,20 @@ def deploy_airgap_rancher(bastion_node):
             '-v ${{PWD}}/privkey.pem:/etc/rancher/ssl/key.pem ' \
             '-e CATTLE_SYSTEM_DEFAULT_REGISTRY={} ' \
             '-e CATTLE_SYSTEM_CATALOG=bundled ' \
+            '-e CATTLE_BOOTSTRAP_PASSWORD={} ' \
             '{}/rancher/rancher:{} --no-cacerts --trace'.format(
                 privileged, bastion_node.host_name, bastion_node.host_name,
-                RANCHER_SERVER_VERSION)
+                ADMIN_PASSWORD, RANCHER_SERVER_VERSION)
     else:
         deploy_rancher_command = \
             'sudo docker run -d {} --restart=unless-stopped ' \
             '-p 80:80 -p 443:443 ' \
             '-e CATTLE_SYSTEM_DEFAULT_REGISTRY={} ' \
+            '-e CATTLE_BOOTSTRAP_PASSWORD={} ' \
             '-e CATTLE_SYSTEM_CATALOG=bundled {}/rancher/rancher:{} --trace'.format(
-                privileged, bastion_node.host_name, bastion_node.host_name,
+                privileged, bastion_node.host_name, 
+                ADMIN_PASSWORD,
+                bastion_node.host_name,
                 RANCHER_SERVER_VERSION)
     deploy_result = run_command_on_airgap_node(bastion_node, ag_node,
                                                deploy_rancher_command,

--- a/tests/validation/tests/v3_api/test_custom_host_reg.py
+++ b/tests/validation/tests/v3_api/test_custom_host_reg.py
@@ -50,7 +50,8 @@ def test_deploy_rancher_server():
         RANCHER_SERVER_CMD = \
             'sudo docker run -d --privileged --name="rancher-server" ' \
             '--restart=unless-stopped -p 80:80 -p 443:443  ' \
-            'rancher/rancher'
+            '-e CATTLE_BOOTSTRAP_PASSWORD={} ' \
+            'rancher/rancher'.format(ADMIN_PASSWORD)
     else:
         RANCHER_SERVER_CMD = \
             'sudo docker run -d --name="rancher-server" ' \
@@ -70,7 +71,8 @@ def test_deploy_rancher_server():
         "sudo docker exec rancher-server loglevel --set debug"
     aws_nodes[0].execute_command(RANCHER_SET_DEBUG_CMD)
 
-    token = set_url_password_token(RANCHER_SERVER_URL)
+    token = set_url_password_token(RANCHER_SERVER_URL,
+                                   version=RANCHER_SERVER_VERSION)
     admin_client = rancher.Client(url=RANCHER_SERVER_URL + "/v3",
                                   token=token, verify=False)
     if AUTH_PROVIDER:

--- a/tests/validation/tests/v3_api/test_proxy.py
+++ b/tests/validation/tests/v3_api/test_proxy.py
@@ -2,7 +2,7 @@ import os
 import time
 from lib.aws import AWS_USER
 from .common import (
-    AmazonWebServices, run_command
+    ADMIN_PASSWORD, AmazonWebServices, run_command
 )
 from .test_airgap import get_bastion_node
 from .test_custom_host_reg import (
@@ -144,10 +144,11 @@ def deploy_proxy_rancher(bastion_node):
         '-e HTTP_PROXY={} ' \
         '-e HTTPS_PROXY={} ' \
         '-e NO_PROXY="localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,' \
+        '-e CATTLE_BOOTSTRAP_PASSWORD={} ' \
         'cattle-system.svc" ' \
         'rancher/rancher:{} --trace'.format(
             proxy_url, proxy_url,
-            RANCHER_SERVER_VERSION)
+            ADMIN_PASSWORD, RANCHER_SERVER_VERSION)
 
     deploy_result = run_command_on_proxy_node(bastion_node, ag_node,
                                               deploy_rancher_command,


### PR DESCRIPTION
I've added the argument `-e CATTLE_BOOTSTRAP_PASSWORD=<password>` for each docker run in our automation. 
Also, it turns out that the request just needed to be retried. Jenkins job is passing