### PR TITLE
[QA-Tests] Add and enhance airgap automation for k3s and rke2

### DIFF
--- a/tests/validation/tests/v3_api/resource/airgap/registries.yaml
+++ b/tests/validation/tests/v3_api/resource/airgap/registries.yaml
@@ -12,6 +12,4 @@ configs:
       username: $USERNAME
       password: $PASSWORD
     tls:
-      cert_file: /home/ubuntu/cert.pem
-      key_file:  /home/ubuntu/key.pem
       ca_file: /home/ubuntu/ca.pem

--- a/tests/validation/tests/v3_api/scripts/configure.sh
+++ b/tests/validation/tests/v3_api/scripts/configure.sh
@@ -5,7 +5,7 @@ set -eu
 
 DEBUG="${DEBUG:-false}"
 
-env | egrep '^(ARM_|CATTLE_|ADMIN|USER|DO|RANCHER_|AWS_|DEBUG|LOGLEVEL|DEFAULT_|OS_|DOCKER_|CLOUD_|KUBE|BUILD_NUMBER|RKE_|AZURE).*\=.+' | sort > .env
+env | egrep '^(ARM_|CATTLE_|ADMIN|USER|DO|RANCHER_|K3S_|RKE2_|AWS_|DEBUG|LOGLEVEL|DEFAULT_|OS_|DOCKER_|CLOUD_|KUBE|BUILD_NUMBER|RKE_|AZURE).*\=.+' | sort > .env
 
 if [ "false" != "${DEBUG}" ]; then
     cat .env

--- a/tests/validation/tests/v3_api/test_airgap.py
+++ b/tests/validation/tests/v3_api/test_airgap.py
@@ -7,7 +7,7 @@ from lib.aws import AWS_USER
 from .common import (
     ADMIN_PASSWORD, AmazonWebServices, run_command, wait_for_status_code,
     TEST_IMAGE, TEST_IMAGE_NGINX, TEST_IMAGE_OS_BASE, readDataFile,
-    DEFAULT_CLUSTER_STATE_TIMEOUT
+    DEFAULT_CLUSTER_STATE_TIMEOUT, compare_versions
 )
 from .test_custom_host_reg import (
     random_test_name, RANCHER_SERVER_VERSION, HOST_NAME, AGENT_REG_CMD
@@ -16,7 +16,6 @@ from .test_create_ha import (
     set_url_and_password,
     RANCHER_HA_CERT_OPTION, RANCHER_VALID_TLS_CERT, RANCHER_VALID_TLS_KEY
 )
-from .test_import_k3s_cluster import (RANCHER_K3S_VERSION)
 
 PRIVATE_REGISTRY_USERNAME = os.environ.get("RANCHER_BASTION_USERNAME")
 PRIVATE_REGISTRY_PASSWORD = \
@@ -25,7 +24,8 @@ BASTION_ID = os.environ.get("RANCHER_BASTION_ID", "")
 NUMBER_OF_INSTANCES = int(os.environ.get("RANCHER_AIRGAP_INSTANCE_COUNT", "1"))
 IMAGE_LIST = os.environ.get("RANCHER_IMAGE_LIST", ",".join(
     [TEST_IMAGE, TEST_IMAGE_NGINX, TEST_IMAGE_OS_BASE])).split(",")
-ARCH = os.environ.get("RANCHER_ARCH", "amd64")
+TARBALL_TYPE = os.environ.get("K3S_TARBALL_TYPE", "tar.gz")
+ARCH = os.environ.get("K3S_ARCH", "amd64")
 
 AG_HOST_NAME = random_test_name(HOST_NAME)
 RANCHER_AG_INTERNAL_HOSTNAME = AG_HOST_NAME + "-internal.qa.rancher.space"
@@ -68,7 +68,7 @@ def test_deploy_airgap_rancher(check_hostname_length):
 
 
 def test_prepare_airgap_nodes():
-    bastion_node = get_bastion_node(BASTION_ID)
+    bastion_node = get_bastion_node()
     ag_nodes = prepare_airgap_node(bastion_node, NUMBER_OF_INSTANCES)
     assert len(ag_nodes) == NUMBER_OF_INSTANCES
 
@@ -87,7 +87,7 @@ def test_prepare_airgap_nodes():
 
 
 def test_deploy_airgap_nodes():
-    bastion_node = get_bastion_node(BASTION_ID)
+    bastion_node = get_bastion_node()
     ag_nodes = prepare_airgap_node(bastion_node, NUMBER_OF_INSTANCES)
     assert len(ag_nodes) == NUMBER_OF_INSTANCES
 
@@ -113,76 +113,8 @@ def test_deploy_airgap_nodes():
             bastion_node.host_name) in result[1]
 
 
-def test_deploy_airgap_k3s_private_registry():
-    bastion_node = get_bastion_node(BASTION_ID)
-
-    failures = add_k3s_images_to_private_registry(bastion_node,
-                                                  RANCHER_K3S_VERSION)
-    assert failures == [], "Failed to add images: {}".format(failures)
-    ag_nodes = prepare_airgap_k3s(bastion_node, NUMBER_OF_INSTANCES,
-                                  'private_registry')
-    assert len(ag_nodes) == NUMBER_OF_INSTANCES
-
-    print(
-        '{} airgapped k3s instance(s) created.\n'
-        'Connect to these and run commands by connecting to bastion node, '
-        'then connecting to these:\n'
-        'ssh -i {}.pem {}@NODE_PRIVATE_IP'.format(
-            NUMBER_OF_INSTANCES, bastion_node.ssh_key_name, AWS_USER))
-    for ag_node in ag_nodes:
-        assert ag_node.private_ip_address is not None
-        assert ag_node.public_ip_address is None
-
-    deploy_airgap_k3s_cluster(bastion_node, ag_nodes)
-
-    wait_for_airgap_pods_ready(bastion_node, ag_nodes)
-
-    # Optionally add k3s cluster to Rancher server
-    if AGENT_REG_CMD:
-        print("Adding to rancher server")
-        result = run_command_on_airgap_node(bastion_node, ag_nodes[0],
-                                            AGENT_REG_CMD)
-        assert "deployment.apps/cattle-cluster-agent created" in result
-
-
-def test_deploy_airgap_k3s_tarball():
-    bastion_node = get_bastion_node(BASTION_ID)
-    add_k3s_tarball_to_bastion(bastion_node, RANCHER_K3S_VERSION)
-
-    ag_nodes = prepare_airgap_k3s(bastion_node, NUMBER_OF_INSTANCES, 'tarball')
-    assert len(ag_nodes) == NUMBER_OF_INSTANCES
-
-    print(
-        '{} airgapped k3s instance(s) created.\n'
-        'Connect to these and run commands by connecting to bastion node, '
-        'then connecting to these:\n'
-        'ssh -i {}.pem {}@NODE_PRIVATE_IP'.format(
-            NUMBER_OF_INSTANCES, bastion_node.ssh_key_name, AWS_USER))
-    for ag_node in ag_nodes:
-        assert ag_node.private_ip_address is not None
-        assert ag_node.public_ip_address is None
-
-    deploy_airgap_k3s_cluster(bastion_node, ag_nodes)
-
-    wait_for_airgap_pods_ready(bastion_node, ag_nodes)
-
-    # Optionally add k3s cluster to Rancher server
-    if AGENT_REG_CMD:
-        print("Adding to rancher server")
-        for num, ag_node in enumerate(ag_nodes):
-            prepare_private_registry_on_k3s_node(bastion_node, ag_node)
-            restart_k3s = 'sudo systemctl restart k3s-agent'
-            if num == 0:
-                restart_k3s = 'sudo systemctl restart k3s && ' \
-                              'sudo chmod 644 /etc/rancher/k3s/k3s.yaml'
-            run_command_on_airgap_node(bastion_node, ag_node, restart_k3s)
-        result = run_command_on_airgap_node(bastion_node, ag_nodes[0],
-                                            AGENT_REG_CMD)
-        assert "deployment.apps/cattle-cluster-agent created" in result
-
-
 def test_add_rancher_images_to_private_registry():
-    bastion_node = get_bastion_node(BASTION_ID)
+    bastion_node = get_bastion_node()
     save_res, load_res = add_rancher_images_to_private_registry(bastion_node)
     assert "Image pull success: rancher/rancher:{}".format(
         RANCHER_SERVER_VERSION) in save_res[0]
@@ -191,7 +123,7 @@ def test_add_rancher_images_to_private_registry():
 
 
 def test_add_images_to_private_registry():
-    bastion_node = get_bastion_node(BASTION_ID)
+    bastion_node = get_bastion_node()
     failures = add_images_to_private_registry(bastion_node, IMAGE_LIST)
     assert failures == [], "Failed to add images: {}".format(failures)
 
@@ -211,6 +143,43 @@ def setup_rancher_server():
     auth_url = base_url + "/v3-public/localproviders/local?action=login"
     wait_for_status_code(url=auth_url, expected_code=200)
     set_url_and_password(base_url, "https://" + RANCHER_AG_INTERNAL_HOSTNAME, version=RANCHER_SERVER_VERSION)
+
+
+def deploy_noauth_bastion_server():
+    node_name = AG_HOST_NAME + "-noauthbastion"
+    # Create Bastion Server in AWS
+    bastion_node = AmazonWebServices().create_node(node_name)
+    setup_ssh_key(bastion_node)
+
+    # Generate self signed certs
+    generate_certs_command = \
+        'mkdir -p certs && sudo openssl req -newkey rsa:4096 -nodes -sha256 ' \
+        '-keyout certs/domain.key -x509 -days 365 -out certs/domain.crt ' \
+        '-subj "/C=US/ST=AZ/O=Rancher QA/CN={0}" ' \
+        '-addext "subjectAltName = DNS:{0}"'.format(bastion_node.host_name)
+    bastion_node.execute_command(generate_certs_command)
+
+    # Ensure docker uses the certs that were generated
+    update_docker_command = \
+        'sudo mkdir -p /etc/docker/certs.d/{0} && ' \
+        'sudo cp ~/certs/domain.crt /etc/docker/certs.d/{0}/ca.crt && ' \
+        'sudo service docker restart'.format(bastion_node.host_name)
+    bastion_node.execute_command(update_docker_command)
+
+    # Run private registry
+    run_private_registry_command = \
+        'sudo docker run -d --restart=always --name registry ' \
+        '-v "$(pwd)"/certs:/certs -e REGISTRY_HTTP_ADDR=0.0.0.0:443 ' \
+        '-e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt ' \
+        '-e REGISTRY_HTTP_TLS_KEY=/certs/domain.key -p 443:443 registry:2'
+    bastion_node.execute_command(run_private_registry_command)
+    time.sleep(5)
+
+    print("Bastion Server Details:\nNAME: {}\nHOST NAME: {}\n"
+          "INSTANCE ID: {}\n".format(node_name, bastion_node.host_name,
+                                     bastion_node.provider_node_id))
+
+    return bastion_node
 
 
 def deploy_bastion_server():
@@ -314,41 +283,6 @@ def add_rancher_images_to_private_registry(bastion_node, push_images=True):
     return save_res, load_res
 
 
-def add_k3s_tarball_to_bastion(bastion_node, k3s_version):
-    # Get k3s files associated with the specified version
-    k3s_binary = 'k3s'
-    if ARCH == 'arm64':
-        k3s_binary = 'k3s-arm64'
-
-    get_tarball_command = \
-        'wget -O k3s-airgap-images-{1}.tar https://github.com/rancher/k3s/' \
-        'releases/download/{0}/k3s-airgap-images-{1}.tar && ' \
-        'wget -O k3s-install.sh https://get.k3s.io/ && ' \
-        'wget -O k3s https://github.com/rancher/k3s/' \
-        'releases/download/{0}/{2}'.format(k3s_version, ARCH, k3s_binary)
-    bastion_node.execute_command(get_tarball_command)
-
-
-def add_k3s_images_to_private_registry(bastion_node, k3s_version):
-    # Get k3s files associated with the specified version
-    k3s_binary = 'k3s'
-    if ARCH == 'arm64':
-        k3s_binary = 'k3s-arm64'
-
-    get_images_command = \
-        'wget -O k3s-images.txt https://github.com/rancher/k3s/' \
-        'releases/download/{0}/k3s-images.txt && ' \
-        'wget -O k3s-install.sh https://get.k3s.io/ && ' \
-        'wget -O k3s https://github.com/rancher/k3s/' \
-        'releases/download/{0}/{1}'.format(k3s_version, k3s_binary)
-    bastion_node.execute_command(get_images_command)
-
-    images = bastion_node.execute_command(
-        'cat k3s-images.txt')[0].strip().split("\n")
-    assert images
-    return add_cleaned_images(bastion_node, images)
-
-
 def add_cleaned_images(bastion_node, images):
     failures = []
     for image in images:
@@ -441,12 +375,98 @@ def prepare_airgap_node(bastion_node, number_of_nodes):
                 ag_node.private_ip_address)
         bastion_node.execute_command(ag_node_restart_docker)
 
+        ag_node_user_own_docker = \
+            'ssh -i "{0}.pem" -o StrictHostKeyChecking=no {1}@{2} ' \
+            '"sudo chown {1}:{1} /home/{1}/.docker -R && ' \
+            'sudo chmod g+rwx "/home/{1}/.docker" -R"'.format(
+                bastion_node.ssh_key_name, AWS_USER,
+                ag_node.private_ip_address)
+        bastion_node.execute_command(ag_node_user_own_docker)
+
         print("Airgapped Instance Details:\nNAME: {}-{}\nPRIVATE IP: {}\n"
               "".format(node_name, num, ag_node.private_ip_address))
     return ag_nodes
 
 
-def prepare_private_registry_on_k3s_node(bastion_node, ag_node):
+def copy_certs_to_node(bastion_node, ag_node):
+    ag_node_copy_certs = \
+        'scp -i "{0}.pem" -o StrictHostKeyChecking=no certs/* ' \
+        '{1}@{2}:~/'.format(bastion_node.ssh_key_name, AWS_USER,
+                            ag_node.private_ip_address)
+    bastion_node.execute_command(ag_node_copy_certs)
+
+
+# Note this only works on Ubuntu currently. There is a future enhancement
+# to enable this to work for any OS.
+def trust_certs_on_node(bastion_node, ag_node):
+    ag_node_update_certs = \
+        'sudo cp domain.crt ' \
+        '/usr/local/share/ca-certificates/domain.crt && ' \
+        'sudo update-ca-certificates'
+    run_command_on_airgap_node(bastion_node, ag_node,
+                               ag_node_update_certs)
+
+
+def add_tarball_to_node(bastion_node, ag_node, tar_file, cluster_type):
+    ag_node_copy_tarball = \
+        'scp -i "{0}.pem" -o StrictHostKeyChecking=no ./{3} ' \
+        '{1}@{2}:~/{3}'.format(bastion_node.ssh_key_name, AWS_USER,
+                               ag_node.private_ip_address, tar_file)
+    bastion_node.execute_command(ag_node_copy_tarball)
+    ag_node_add_tarball_to_dir = \
+        'sudo mkdir -p /var/lib/rancher/{0}/agent/images/ && ' \
+        'sudo cp ./{1} /var/lib/rancher/{0}/agent/images/'.format(cluster_type,
+                                                                  tar_file)
+    run_command_on_airgap_node(bastion_node, ag_node,
+                               ag_node_add_tarball_to_dir)
+
+
+def prepare_private_registry(bastion_node, version):
+    if 'k3s' in version:
+        # Get k3s files associated with the specified version
+        k3s_binary = 'k3s'
+        if ARCH == 'arm64':
+            k3s_binary = 'k3s-arm64'
+
+        get_images_command = \
+            'wget -O k3s-images.txt https://github.com/k3s-io/k3s/' \
+            'releases/download/{0}/k3s-images.txt && ' \
+            'wget -O k3s-install.sh https://get.k3s.io/ && ' \
+            'wget -O k3s https://github.com/k3s-io/k3s/' \
+            'releases/download/{0}/{1}'.format(version, k3s_binary)
+        bastion_node.execute_command(get_images_command)
+
+        images = bastion_node.execute_command(
+            'cat k3s-images.txt')[0].strip().split("\n")
+    elif 'rke2' in version:
+        stripped_version = re.search("v(\d+.\d+.\d+)", version).group(1)
+        if compare_versions(stripped_version, "1.21.2") < 0:
+            get_images_command = \
+                'wget -O rke2-images.txt https://github.com/rancher/rke2/' \
+                'releases/download/{0}/rke2-images.linux-amd64.txt && ' \
+                'wget -O rke2 https://github.com/rancher/rke2/' \
+                'releases/download/{0}/rke2.linux-amd64'.format(version)
+        else:
+            get_images_command = \
+                'wget -O rke2-images.txt https://github.com/rancher/rke2/' \
+                'releases/download/{0}/rke2-images-all.linux-amd64.txt && ' \
+                'wget -O rke2 https://github.com/rancher/rke2/' \
+                'releases/download/{0}/rke2.linux-amd64'.format(version)
+        bastion_node.execute_command(get_images_command)
+
+        images = bastion_node.execute_command(
+            'cat rke2-images.txt')[0].strip().split("\n")
+    else:
+        images = False
+        pytest.fail("{} is not valid. Please provide a valid "
+                    "k3s or rke2 version.".format(version))
+
+    assert images
+    failures = add_cleaned_images(bastion_node, images)
+    assert failures == [], "Failed to add images: {}".format(failures)
+
+
+def prepare_registries_mirror_on_node(bastion_node, ag_node, cluster_type):
     # Ensure registry file has correct data
     reg_file = readDataFile(RESOURCE_DIR, "airgap/registries.yaml")
     reg_file = reg_file.replace("$PRIVATE_REG", bastion_node.host_name)
@@ -454,91 +474,84 @@ def prepare_private_registry_on_k3s_node(bastion_node, ag_node):
     reg_file = reg_file.replace("$PASSWORD", PRIVATE_REGISTRY_PASSWORD)
     # Add registry file to node
     ag_node_create_dir = \
-        'sudo mkdir -p /etc/rancher/k3s && ' \
-        'sudo chown {} /etc/rancher/k3s'.format(AWS_USER)
+        'sudo mkdir -p /etc/rancher/{0} && ' \
+        'sudo chown {1} /etc/rancher/{0}'.format(cluster_type, AWS_USER)
     run_command_on_airgap_node(bastion_node, ag_node,
                                ag_node_create_dir)
     write_reg_file_command = \
-        "cat <<EOT >> /etc/rancher/k3s/registries.yaml\n{}\nEOT".format(
-            reg_file)
+        "cat <<EOT >> /etc/rancher/{}/registries.yaml\n{}\nEOT".format(
+            cluster_type, reg_file)
     run_command_on_airgap_node(bastion_node, ag_node,
                                write_reg_file_command)
 
 
-def prepare_airgap_k3s(bastion_node, number_of_nodes, method):
-    node_name = AG_HOST_NAME + "-k3s-airgap"
-    # Create Airgap Node in AWS
-    ag_nodes = AmazonWebServices().create_multiple_nodes(
-        number_of_nodes, node_name, public_ip=False)
-
-    for num, ag_node in enumerate(ag_nodes):
-        # Copy relevant k3s files to airgapped node
-        ag_node_copy_files = \
-            'scp -i "{0}.pem" -o StrictHostKeyChecking=no ./k3s-install.sh ' \
-            '{1}@{2}:~/install.sh && ' \
-            'scp -i "{0}.pem" -o StrictHostKeyChecking=no ./k3s ' \
-            '{1}@{2}:~/k3s && ' \
-            'scp -i "{0}.pem" -o StrictHostKeyChecking=no certs/* ' \
-            '{1}@{2}:~/'.format(bastion_node.ssh_key_name, AWS_USER,
-                                ag_node.private_ip_address)
-        bastion_node.execute_command(ag_node_copy_files)
-
-        ag_node_make_executable = \
-            'sudo mv ./k3s /usr/local/bin/k3s && ' \
-            'sudo chmod +x /usr/local/bin/k3s && sudo chmod +x install.sh'
-        run_command_on_airgap_node(bastion_node, ag_node,
-                                   ag_node_make_executable)
-
-        if method == 'private_registry':
-            prepare_private_registry_on_k3s_node(bastion_node, ag_node)
-        elif method == 'tarball':
-            ag_node_copy_tarball = \
-                'scp -i "{0}.pem" -o StrictHostKeyChecking=no ' \
-                './k3s-airgap-images-{3}.tar ' \
-                '{1}@{2}:~/k3s-airgap-images-{3}.tar'.format(
-                    bastion_node.ssh_key_name, AWS_USER,
-                    ag_node.private_ip_address, ARCH)
-            bastion_node.execute_command(ag_node_copy_tarball)
-            ag_node_add_tarball_to_dir = \
-                'sudo mkdir -p /var/lib/rancher/k3s/agent/images/ && ' \
-                'sudo cp ./k3s-airgap-images-{}.tar ' \
-                '/var/lib/rancher/k3s/agent/images/'.format(ARCH)
-            run_command_on_airgap_node(bastion_node, ag_node,
-                                       ag_node_add_tarball_to_dir)
-
-        print("Airgapped K3S Instance Details:\nNAME: {}-{}\nPRIVATE IP: {}\n"
-              "".format(node_name, num, ag_node.private_ip_address))
-    return ag_nodes
-
-
-def deploy_airgap_k3s_cluster(bastion_node, ag_nodes):
+def deploy_airgap_cluster(bastion_node, ag_nodes, k8s, server_ops, agent_ops):
     token = ""
     server_ip = ag_nodes[0].private_ip_address
+    if not any(x == k8s for x in ["k3s", "rke2"]):
+        raise ValueError("Please only use k3s or rke2, not {}".format(k8s))
     for num, ag_node in enumerate(ag_nodes):
         if num == 0:
-            # Install k3s server
-            install_k3s_server = \
-                'INSTALL_K3S_SKIP_DOWNLOAD=true ./install.sh && ' \
-                'sudo chmod 644 /etc/rancher/k3s/k3s.yaml'
-            run_command_on_airgap_node(bastion_node, ag_node,
-                                       install_k3s_server)
-            token_command = 'sudo cat /var/lib/rancher/k3s/server/node-token'
+            if k8s == "k3s":
+                install_server = \
+                    'INSTALL_K3S_SKIP_DOWNLOAD=true ./install.sh {} && sudo ' \
+                    'chmod 644 /etc/rancher/k3s/k3s.yaml'.format(server_ops)
+            else:
+                install_server = \
+                    'sudo rke2 server --write-kubeconfig-mode 644 {} ' \
+                    '> /dev/null 2>&1 &'.format(server_ops)
+
+            print("Install server command: {}".format(install_server))
+            run_command_on_airgap_node(bastion_node, ag_node, install_server)
+            time.sleep(30)
+            token_command = 'sudo cat /var/lib/rancher/{}/server/node-token'.format(k8s)
             token = run_command_on_airgap_node(bastion_node, ag_node,
                                                token_command)[0].strip()
         else:
-            install_k3s_worker = \
-                'INSTALL_K3S_SKIP_DOWNLOAD=true K3S_URL=https://{}:6443 ' \
-                'K3S_TOKEN={} ./install.sh'.format(server_ip, token)
+            if k8s == "k3s":
+                install_worker = \
+                    'INSTALL_K3S_SKIP_DOWNLOAD=true K3S_URL=https://{}:6443 ' \
+                    'K3S_TOKEN={} ./install.sh {}'.format(server_ip, token,
+                                                          agent_ops)
+            else:
+                install_worker = \
+                    'sudo rke2 agent --server https://{}:9345 ' \
+                    '--token {} {} > /dev/null 2>&1 &'.format(server_ip, token,
+                                                              agent_ops)
+            print("Install worker command: {}".format(install_worker))
             run_command_on_airgap_node(bastion_node, ag_node,
-                                       install_k3s_worker)
-    time.sleep(10)
+                                       install_worker)
+            time.sleep(15)
+    if k8s == "k3s":
+        wait_for_airgap_pods_ready(bastion_node, ag_nodes)
+    else:
+        time.sleep(60)
+        wait_for_airgap_pods_ready(bastion_node, ag_nodes,
+                                   kubectl='/var/lib/rancher/rke2/bin/kubectl',
+                                   kubeconfig='/etc/rancher/rke2/rke2.yaml')
+
+
+def optionally_add_cluster_to_rancher(bastion_node, ag_nodes, prep="none"):
+    if AGENT_REG_CMD:
+        if prep == "k3s":
+            for num, ag_node in enumerate(ag_nodes):
+                prepare_registries_mirror_on_node(bastion_node, ag_node, 'k3s')
+                restart_k3s = 'sudo systemctl restart k3s-agent'
+                if num == 0:
+                    restart_k3s = 'sudo systemctl restart k3s && ' \
+                                  'sudo chmod 644 /etc/rancher/k3s/k3s.yaml'
+                run_command_on_airgap_node(bastion_node, ag_node, restart_k3s)
+        print("Adding to rancher server")
+        result = run_command_on_airgap_node(bastion_node, ag_nodes[0],
+                                            AGENT_REG_CMD)
+        assert "deployment.apps/cattle-cluster-agent created" in result
 
 
 def deploy_airgap_rancher(bastion_node):
     ag_node = prepare_airgap_node(bastion_node, 1)[0]
     if "v2.5" in RANCHER_SERVER_VERSION or \
-        "v2.6" in RANCHER_SERVER_VERSION  or \
-        "master" in RANCHER_SERVER_VERSION:
+            "v2.6" in RANCHER_SERVER_VERSION or \
+            "master" in RANCHER_SERVER_VERSION:
         privileged = "--privileged"
     else:
         privileged = ""
@@ -743,8 +756,16 @@ def create_nlb_and_add_targets(aws_nodes):
     return public_dns
 
 
-def get_bastion_node(provider_id):
-    bastion_node = AmazonWebServices().get_node(provider_id, ssh_access=True)
+def get_bastion_node(auth=True):
+    if BASTION_ID:
+        bastion_node = AmazonWebServices().get_node(BASTION_ID, ssh_access=True)
+        print("Bastion Server Details:\nHOST NAME: {}\n"
+              "INSTANCE ID: {}\n".format(bastion_node.host_name,
+                                         bastion_node.provider_node_id))
+    elif auth:
+        bastion_node = deploy_bastion_server()
+    else:
+        bastion_node = deploy_noauth_bastion_server()
     if bastion_node is None:
         pytest.fail("Did not provide a valid Provider ID for the bastion node")
     return bastion_node

--- a/tests/validation/tests/v3_api/test_k3s_airgap.py
+++ b/tests/validation/tests/v3_api/test_k3s_airgap.py
@@ -1,0 +1,111 @@
+import os
+from lib.aws import AWS_USER
+from .common import AmazonWebServices
+from .test_airgap import (AG_HOST_NAME, ARCH, NUMBER_OF_INSTANCES,
+                          TARBALL_TYPE,
+                          get_bastion_node, prepare_registries_mirror_on_node,
+                          run_command_on_airgap_node, prepare_private_registry,
+                          copy_certs_to_node, deploy_airgap_cluster,
+                          trust_certs_on_node, add_tarball_to_node,
+                          optionally_add_cluster_to_rancher)
+
+RANCHER_K3S_VERSION = os.environ.get("RANCHER_K3S_VERSION", "")
+K3S_SERVER_OPTIONS = os.environ.get("K3S_SERVER_OPTIONS", "")
+K3S_AGENT_OPTIONS = os.environ.get("K3S_AGENT_OPTIONS", "")
+
+
+def test_deploy_airgap_k3s_system_default_registry():
+    bastion_node = get_bastion_node(auth=False)
+    prepare_private_registry(bastion_node, RANCHER_K3S_VERSION)
+    ag_nodes = prepare_airgap_k3s(bastion_node, NUMBER_OF_INSTANCES,
+                                  'system_default_registry')
+    server_ops = K3S_SERVER_OPTIONS + " --system-default-registry={}".format(
+        bastion_node.host_name)
+    agent_ops = K3S_AGENT_OPTIONS + " --system-default-registry={}".format(
+        bastion_node.host_name)
+    deploy_airgap_cluster(bastion_node, ag_nodes, "k3s", server_ops, agent_ops)
+
+
+def test_deploy_airgap_k3s_private_registry():
+    bastion_node = get_bastion_node(auth=True)
+    prepare_private_registry(bastion_node, RANCHER_K3S_VERSION)
+    ag_nodes = prepare_airgap_k3s(bastion_node, NUMBER_OF_INSTANCES,
+                                  'private_registry')
+    deploy_airgap_cluster(bastion_node, ag_nodes, "k3s",
+                          K3S_SERVER_OPTIONS, K3S_AGENT_OPTIONS)
+    optionally_add_cluster_to_rancher(bastion_node, ag_nodes)
+
+
+def test_deploy_airgap_k3s_tarball():
+    bastion_node = get_bastion_node()
+    add_k3s_tarball_to_bastion(bastion_node, RANCHER_K3S_VERSION)
+    ag_nodes = prepare_airgap_k3s(bastion_node, NUMBER_OF_INSTANCES, 'tarball')
+    deploy_airgap_cluster(bastion_node, ag_nodes, "k3s",
+                          K3S_SERVER_OPTIONS, K3S_AGENT_OPTIONS)
+    optionally_add_cluster_to_rancher(bastion_node, ag_nodes, prep="k3s")
+
+
+def add_k3s_tarball_to_bastion(bastion_node, k3s_version):
+    # Get k3s files associated with the specified version
+    k3s_binary = 'k3s'
+    if ARCH == 'arm64':
+        k3s_binary = 'k3s-arm64'
+
+    get_tarball_command = \
+        'wget -O k3s-airgap-images-{1}.{3} https://github.com/k3s-io/k3s/' \
+        'releases/download/{0}/k3s-airgap-images-{1}.{3} && ' \
+        'wget -O k3s-install.sh https://get.k3s.io/ && ' \
+        'wget -O k3s https://github.com/k3s-io/k3s/' \
+        'releases/download/{0}/{2}'.format(k3s_version, ARCH, k3s_binary,
+                                           TARBALL_TYPE)
+    bastion_node.execute_command(get_tarball_command)
+
+
+def prepare_airgap_k3s(bastion_node, number_of_nodes, method):
+    node_name = AG_HOST_NAME + "-k3s-airgap"
+    # Create Airgap Node in AWS
+    ag_nodes = AmazonWebServices().create_multiple_nodes(
+        number_of_nodes, node_name, public_ip=False)
+
+    for num, ag_node in enumerate(ag_nodes):
+        # Copy relevant k3s files to airgapped node
+        ag_node_copy_files = \
+            'scp -i "{0}.pem" -o StrictHostKeyChecking=no ./k3s-install.sh ' \
+            '{1}@{2}:~/install.sh && ' \
+            'scp -i "{0}.pem" -o StrictHostKeyChecking=no ./k3s ' \
+            '{1}@{2}:~/k3s && ' \
+            'scp -i "{0}.pem" -o StrictHostKeyChecking=no certs/* ' \
+            '{1}@{2}:~/'.format(bastion_node.ssh_key_name, AWS_USER,
+                                ag_node.private_ip_address)
+        bastion_node.execute_command(ag_node_copy_files)
+
+        ag_node_make_executable = \
+            'sudo mv ./k3s /usr/local/bin/k3s && ' \
+            'sudo chmod +x /usr/local/bin/k3s && sudo chmod +x install.sh'
+        run_command_on_airgap_node(bastion_node, ag_node,
+                                   ag_node_make_executable)
+
+        if method == 'private_registry':
+            prepare_registries_mirror_on_node(bastion_node, ag_node, 'k3s')
+        elif method == 'system_default_registry':
+            copy_certs_to_node(bastion_node, ag_node)
+            trust_certs_on_node(bastion_node, ag_node)
+        elif method == 'tarball':
+            add_tarball_to_node(bastion_node, ag_node,
+                                'k3s-airgap-images-{0}.{1}'.format(
+                                    ARCH, TARBALL_TYPE), 'k3s')
+
+        print("Airgapped K3S Instance Details:\nNAME: {}-{}\nPRIVATE IP: {}\n"
+              "".format(node_name, num, ag_node.private_ip_address))
+
+    assert len(ag_nodes) == NUMBER_OF_INSTANCES
+    print(
+        '{} airgapped k3s instance(s) created.\n'
+        'Connect to these and run commands by connecting to bastion node, '
+        'then connecting to these:\n'
+        'ssh -i {}.pem {}@NODE_PRIVATE_IP'.format(
+            NUMBER_OF_INSTANCES, bastion_node.ssh_key_name, AWS_USER))
+    for ag_node in ag_nodes:
+        assert ag_node.private_ip_address is not None
+        assert ag_node.public_ip_address is None
+    return ag_nodes

--- a/tests/validation/tests/v3_api/test_rke2_airgap.py
+++ b/tests/validation/tests/v3_api/test_rke2_airgap.py
@@ -1,132 +1,100 @@
 import os
-import time
 from lib.aws import AWS_USER
 from .common import AmazonWebServices
-from .test_airgap import (AG_HOST_NAME, BASTION_ID, NUMBER_OF_INSTANCES,
-                          add_cleaned_images, get_bastion_node,
-                          run_command_on_airgap_node, setup_ssh_key,
-                          wait_for_airgap_pods_ready)
+from .test_airgap import (AG_HOST_NAME, NUMBER_OF_INSTANCES, TARBALL_TYPE,
+                          get_bastion_node, prepare_registries_mirror_on_node,
+                          run_command_on_airgap_node, deploy_airgap_cluster,
+                          prepare_private_registry, copy_certs_to_node,
+                          trust_certs_on_node, add_tarball_to_node,
+                          optionally_add_cluster_to_rancher)
 
 RANCHER_RKE2_VERSION = os.environ.get("RANCHER_RKE2_VERSION", "")
-RKE2_SERVER_OPTIONS = os.environ.get("RANCHER_RKE2_SERVER_OPTIONS", "")
-RKE2_AGENT_OPTIONS = os.environ.get("RANCHER_RKE2_AGENT_OPTIONS", "")
+RKE2_SERVER_OPTIONS = os.environ.get("RKE2_SERVER_OPTIONS", "")
+RKE2_AGENT_OPTIONS = os.environ.get("RKE2_AGENT_OPTIONS", "")
 
 
-def test_deploy_airgap_rke2_private_registry():
-    bastion_node = deploy_noauth_bastion_server()
+def test_deploy_airgap_rke2_all():
+    reg_bastion_node = get_bastion_node(auth=True)
+    noauth_bastion_node = get_bastion_node(auth=False)
+    add_rke2_tarball_to_bastion(noauth_bastion_node, RANCHER_RKE2_VERSION)
+    prepare_private_registry(noauth_bastion_node, RANCHER_RKE2_VERSION)
+    prepare_private_registry(reg_bastion_node, RANCHER_RKE2_VERSION)
 
-    failures = add_rke2_images_to_private_registry(bastion_node,
-                                                   RANCHER_RKE2_VERSION)
-    assert failures == [], "Failed to add images: {}".format(failures)
-    ag_nodes = prepare_airgap_rke2(bastion_node, NUMBER_OF_INSTANCES,
-                                   'private_registry')
-    assert len(ag_nodes) == NUMBER_OF_INSTANCES
-
-    print(
-        '{} airgapped rke2 instance(s) created.\n'
-        'Connect to these and run commands by connecting to bastion node, '
-        'then connecting to these:\n'
-        'ssh -i {}.pem {}@NODE_PRIVATE_IP'.format(
-            NUMBER_OF_INSTANCES, bastion_node.ssh_key_name, AWS_USER))
+    ag_nodes = prepare_airgap_rke2(noauth_bastion_node, NUMBER_OF_INSTANCES,
+                                   'tarball+mirror+system-default')
     for ag_node in ag_nodes:
-        assert ag_node.private_ip_address is not None
-        assert ag_node.public_ip_address is None
+        copy_certs_to_node(reg_bastion_node, ag_node)
+        prepare_registries_mirror_on_node(reg_bastion_node, ag_node, 'rke2')
 
+    server_ops = RKE2_SERVER_OPTIONS + " --system-default-registry={}".format(
+        noauth_bastion_node.host_name)
+    agent_ops = RKE2_AGENT_OPTIONS + " --system-default-registry={}".format(
+        noauth_bastion_node.host_name)
+    deploy_airgap_cluster(noauth_bastion_node, ag_nodes, "rke2",
+                          server_ops, agent_ops)
+    optionally_add_cluster_to_rancher(noauth_bastion_node, ag_nodes)
+
+
+def test_deploy_airgap_rke2_system_default_registry():
+    bastion_node = get_bastion_node(auth=False)
+    prepare_private_registry(bastion_node, RANCHER_RKE2_VERSION)
+    ag_nodes = prepare_airgap_rke2(bastion_node, NUMBER_OF_INSTANCES,
+                                   'system_default_registry')
     server_ops = RKE2_SERVER_OPTIONS + " --system-default-registry={}".format(
         bastion_node.host_name)
     agent_ops = RKE2_AGENT_OPTIONS + " --system-default-registry={}".format(
         bastion_node.host_name)
+    deploy_airgap_cluster(bastion_node, ag_nodes, "rke2",
+                          server_ops, agent_ops)
 
-    deploy_airgap_rke2_cluster(bastion_node, ag_nodes, server_ops, agent_ops)
 
-    wait_for_airgap_pods_ready(bastion_node, ag_nodes,
-                               kubectl='/var/lib/rancher/rke2/bin/kubectl',
-                               kubeconfig='/etc/rancher/rke2/rke2.yaml')
+def test_deploy_airgap_rke2_private_registry():
+    bastion_node = get_bastion_node(auth=True)
+    prepare_private_registry(bastion_node, RANCHER_RKE2_VERSION)
+    ag_nodes = prepare_airgap_rke2(bastion_node, NUMBER_OF_INSTANCES,
+                                   'private_registry')
+    deploy_airgap_cluster(bastion_node, ag_nodes, "rke2",
+                          RKE2_SERVER_OPTIONS, RKE2_AGENT_OPTIONS)
+    optionally_add_cluster_to_rancher(bastion_node, ag_nodes)
 
 
 def test_deploy_airgap_rke2_tarball():
-    bastion_node = get_bastion_node(BASTION_ID)
+    bastion_node = get_bastion_node()
     add_rke2_tarball_to_bastion(bastion_node, RANCHER_RKE2_VERSION)
-
     ag_nodes = prepare_airgap_rke2(
         bastion_node, NUMBER_OF_INSTANCES, 'tarball')
-    assert len(ag_nodes) == NUMBER_OF_INSTANCES
-
-    print(
-        '{} airgapped rke2 instance(s) created.\n'
-        'Connect to these and run commands by connecting to bastion node, '
-        'then connecting to these:\n'
-        'ssh -i {}.pem {}@NODE_PRIVATE_IP'.format(
-            NUMBER_OF_INSTANCES, bastion_node.ssh_key_name, AWS_USER))
-    for ag_node in ag_nodes:
-        assert ag_node.private_ip_address is not None
-        assert ag_node.public_ip_address is None
-
-    deploy_airgap_rke2_cluster(bastion_node, ag_nodes,
-                               RKE2_SERVER_OPTIONS, RKE2_AGENT_OPTIONS)
-
-    wait_for_airgap_pods_ready(bastion_node, ag_nodes,
-                               kubectl='/var/lib/rancher/rke2/bin/kubectl',
-                               kubeconfig='/etc/rancher/rke2/rke2.yaml')
-
-
-def deploy_noauth_bastion_server():
-    node_name = AG_HOST_NAME + "-noauthbastion"
-    # Create Bastion Server in AWS
-    bastion_node = AmazonWebServices().create_node(node_name)
-    setup_ssh_key(bastion_node)
-
-    # Generate self signed certs
-    generate_certs_command = \
-        'mkdir -p certs && sudo openssl req -newkey rsa:4096 -nodes -sha256 ' \
-        '-keyout certs/domain.key -x509 -days 365 -out certs/domain.crt ' \
-        '-subj "/C=US/ST=AZ/O=Rancher QA/CN={}"'.format(bastion_node.host_name)
-    bastion_node.execute_command(generate_certs_command)
-
-    # Ensure docker uses the certs that were generated
-    update_docker_command = \
-        'sudo mkdir -p /etc/docker/certs.d/{0} && ' \
-        'sudo cp ~/certs/domain.crt /etc/docker/certs.d/{0}/ca.crt && ' \
-        'sudo service docker restart'.format(bastion_node.host_name)
-    bastion_node.execute_command(update_docker_command)
-
-    # Run private registry
-    run_private_registry_command = \
-        'sudo docker run -d --restart=always --name registry ' \
-        '-v "$(pwd)"/certs:/certs -e REGISTRY_HTTP_ADDR=0.0.0.0:443 ' \
-        '-e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt ' \
-        '-e REGISTRY_HTTP_TLS_KEY=/certs/domain.key -p 443:443 registry:2'
-    bastion_node.execute_command(run_private_registry_command)
-    time.sleep(5)
-
-    print("Bastion Server Details:\nNAME: {}\nHOST NAME: {}\n"
-          "INSTANCE ID: {}\n".format(node_name, bastion_node.host_name,
-                                     bastion_node.provider_node_id))
-
-    return bastion_node
+    deploy_airgap_cluster(bastion_node, ag_nodes, "rke2",
+                          RKE2_SERVER_OPTIONS, RKE2_AGENT_OPTIONS)
 
 
 def add_rke2_tarball_to_bastion(bastion_node, rke2_version):
     get_tarball_command = \
-        'wget -O rke2-airgap-images.tar.gz https://github.com/rancher/rke2/' \
-        'releases/download/{0}/rke2-images.linux-amd64.tar.gz && ' \
-        'wget -O rke2 https://github.com/rancher/rke2/' \
-        'releases/download/{0}/rke2.linux-amd64'.format(rke2_version)
+        'wget -O rke2-airgap-images.{1} https://github.com/rancher/rke2/' \
+        'releases/download/{0}/rke2-images.linux-amd64.{1} && ' \
+        'wget -O rke2 https://github.com/rancher/rke2/releases/' \
+        'download/{0}/rke2.linux-amd64'.format(rke2_version, TARBALL_TYPE)
     bastion_node.execute_command(get_tarball_command)
-
-
-def add_rke2_images_to_private_registry(bastion_node, rke2_version):
-    get_images_command = \
-        'wget -O rke2-images.txt https://github.com/rancher/rke2/' \
-        'releases/download/{0}/rke2-images.linux-amd64.txt && ' \
-        'wget -O rke2 https://github.com/rancher/rke2/' \
-        'releases/download/{0}/rke2.linux-amd64'.format(rke2_version)
-    bastion_node.execute_command(get_images_command)
-
-    images = bastion_node.execute_command(
-        'cat rke2-images.txt')[0].strip().split("\n")
-    assert images
-    return add_cleaned_images(bastion_node, images)
+    if '--cni=calico' in RKE2_SERVER_OPTIONS:
+        get_calico_tarball_command = \
+            'wget -O rke2-airgap-images-calico.{1} ' \
+            'https://github.com/rancher/rke2/releases/download/{0}/' \
+            'rke2-images-calico.linux-amd64.{1}'.format(rke2_version,
+                                                        TARBALL_TYPE)
+        bastion_node.execute_command(get_calico_tarball_command)
+    elif '--cni=cilium' in RKE2_SERVER_OPTIONS:
+        get_cilium_tarball_command = \
+            'wget -O rke2-airgap-images-cilium.{1} ' \
+            'https://github.com/rancher/rke2/releases/download/{0}/' \
+            'rke2-images-cilium.linux-amd64.{1}'.format(rke2_version,
+                                                        TARBALL_TYPE)
+        bastion_node.execute_command(get_cilium_tarball_command)
+    if 'multus' in RKE2_SERVER_OPTIONS:
+        get_multus_tarball_command = \
+            'wget -O rke2-airgap-images-multus.{1} ' \
+            'https://github.com/rancher/rke2/releases/download/{0}/' \
+            'rke2-images-multus.linux-amd64.{1}'.format(rke2_version,
+                                                        TARBALL_TYPE)
+        bastion_node.execute_command(get_multus_tarball_command)
 
 
 def prepare_airgap_rke2(bastion_node, number_of_nodes, method):
@@ -150,58 +118,48 @@ def prepare_airgap_rke2(bastion_node, number_of_nodes, method):
                                    ag_node_make_executable)
 
         if method == 'private_registry':
-            ag_node_copy_certs = \
-                'scp -i "{0}.pem" -o StrictHostKeyChecking=no certs/* ' \
-                '{1}@{2}:~/'.format(bastion_node.ssh_key_name, AWS_USER,
-                                    ag_node.private_ip_address)
-            bastion_node.execute_command(ag_node_copy_certs)
-            ag_node_update_certs = \
-                'sudo cp domain.crt ' \
-                '/usr/local/share/ca-certificates/domain.crt && ' \
-                'sudo update-ca-certificates'
-            run_command_on_airgap_node(bastion_node, ag_node,
-                                       ag_node_update_certs)
-        elif method == 'tarball':
-            ag_node_copy_tarball = \
-                'scp -i "{0}.pem" -o StrictHostKeyChecking=no ' \
-                './rke2-airgap-images.tar.gz ' \
-                '{1}@{2}:~/rke2-airgap-images.tar.gz'.format(
-                    bastion_node.ssh_key_name, AWS_USER,
-                    ag_node.private_ip_address)
-            bastion_node.execute_command(ag_node_copy_tarball)
-            ag_node_add_tarball_to_dir = \
-                'sudo mkdir -p /var/lib/rancher/rke2/agent/images/ && ' \
-                'sudo cp ./rke2-airgap-images.tar.gz ' \
-                '/var/lib/rancher/rke2/agent/images/ && sudo gunzip ' \
-                '/var/lib/rancher/rke2/agent/images/rke2-airgap-images.tar.gz'
-            run_command_on_airgap_node(bastion_node, ag_node,
-                                       ag_node_add_tarball_to_dir)
+            copy_certs_to_node(bastion_node, ag_node)
+            prepare_registries_mirror_on_node(bastion_node, ag_node, 'rke2')
+        elif method == 'system_default_registry':
+            copy_certs_to_node(bastion_node, ag_node)
+            trust_certs_on_node(bastion_node, ag_node)
+        elif method == 'tarball+mirror':
+            copy_certs_to_node(bastion_node, ag_node)
+            prepare_registries_mirror_on_node(bastion_node, ag_node, 'rke2')
+        else:
+            copy_certs_to_node(bastion_node, ag_node)
+            trust_certs_on_node(bastion_node, ag_node)
+        if 'tarball' in method:
+            add_tarball_to_node(bastion_node, ag_node,
+                                'rke2-airgap-images.{}'.format(TARBALL_TYPE),
+                                'rke2')
+            if '--cni=calico' in RKE2_SERVER_OPTIONS:
+                add_tarball_to_node(
+                    bastion_node, ag_node,
+                    'rke2-airgap-images-calico.{}'.format(TARBALL_TYPE),
+                    'rke2')
+            elif '--cni=cilium' in RKE2_SERVER_OPTIONS:
+                add_tarball_to_node(
+                    bastion_node, ag_node,
+                    'rke2-airgap-images-cilium.{}'.format(TARBALL_TYPE),
+                    'rke2')
+            if 'multus' in RKE2_SERVER_OPTIONS:
+                add_tarball_to_node(
+                    bastion_node, ag_node,
+                    'rke2-airgap-images-multus.{}'.format(TARBALL_TYPE),
+                    'rke2')
 
         print("Airgapped RKE2 Instance Details:\nNAME: {}-{}\nPRIVATE IP: {}\n"
               "".format(node_name, num, ag_node.private_ip_address))
+
+    assert len(ag_nodes) == NUMBER_OF_INSTANCES
+    print(
+        '{} airgapped rke2 instance(s) created.\n'
+        'Connect to these and run commands by connecting to bastion node, '
+        'then connecting to these:\n'
+        'ssh -i {}.pem {}@NODE_PRIVATE_IP'.format(
+            NUMBER_OF_INSTANCES, bastion_node.ssh_key_name, AWS_USER))
+    for ag_node in ag_nodes:
+        assert ag_node.private_ip_address is not None
+        assert ag_node.public_ip_address is None
     return ag_nodes
-
-
-def deploy_airgap_rke2_cluster(bastion_node, ag_nodes, server_ops, agent_ops):
-    token = ""
-    server_ip = ag_nodes[0].private_ip_address
-    for num, ag_node in enumerate(ag_nodes):
-        if num == 0:
-            # Install rke2 server
-            install_rke2_server = \
-                'sudo rke2 server --write-kubeconfig-mode 644 {} ' \
-                '> /dev/null 2>&1 &'.format(server_ops)
-            run_command_on_airgap_node(bastion_node, ag_node,
-                                       install_rke2_server)
-            time.sleep(30)
-            token_command = 'sudo cat /var/lib/rancher/rke2/server/node-token'
-            token = run_command_on_airgap_node(bastion_node, ag_node,
-                                               token_command)[0].strip()
-        else:
-            install_rke2_worker = \
-                'sudo rke2 agent --server https://{}:9345 ' \
-                '--token {} {} > /dev/null 2>&1 &'.format(
-                    server_ip, token, agent_ops)
-            run_command_on_airgap_node(bastion_node, ag_node,
-                                       install_rke2_worker)
-            time.sleep(15)


### PR DESCRIPTION
- Split rke2 and k3s airgap into separate files
- Cleanup helper functions
- Ensure the following airgap scenarios are covered for both:
  - private registry (registries.yaml)
  - system-default-registry (flag that can be passed to use a TLS-secured registry but with no username & password)
  - tarball, with the ability to pass in different types of tarballs for .tar, .gz, and .zst as desired.
  - Additional flags for any extra customization (such as `--airgap-extra-registry` or using different cni's with `--cni=calico`)