### PR TITLE
Add clusterrepos to catalog management roles

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -62,7 +62,8 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	rb.addRole("Manage Cluster Drivers", "kontainerdrivers-manage").
 		addRule().apiGroups("management.cattle.io").resources("kontainerdrivers").verbs("*")
 	rb.addRole("Manage Catalogs", "catalogs-manage").
-		addRule().apiGroups("management.cattle.io").resources("catalogs", "templates", "templateversions").verbs("*")
+		addRule().apiGroups("management.cattle.io").resources("catalogs", "templates", "templateversions").verbs("*").
+		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("*")
 	rb.addRole("Use Catalog Templates", "catalogs-use").
 		addRule().apiGroups("management.cattle.io").resources("templates", "templateversions").verbs("get", "list", "watch")
 	rb.addRole("Manage Users", "users-manage").
@@ -220,7 +221,8 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("clusterroletemplatebindings").verbs("get", "list", "watch")
 
 	rb.addRoleTemplate("Manage Cluster Catalogs", "clustercatalogs-manage", "cluster", false, false, true).
-		addRule().apiGroups("management.cattle.io").resources("clustercatalogs").verbs("*")
+		addRule().apiGroups("management.cattle.io").resources("clustercatalogs").verbs("*").
+		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("*")
 
 	rb.addRoleTemplate("View Cluster Catalogs", "clustercatalogs-view", "cluster", false, false, false).
 		addRule().apiGroups("management.cattle.io").resources("clustercatalogs").verbs("get", "list", "watch")


### PR DESCRIPTION
This allows subjects who are bound to the `catalogs-manage` GlobalRole to manage chart repositories.

Issue:
- https://github.com/rancher/rancher/issues/34592

Testing steps:
1. Start Rancher v2.6.0 (version without this change)
2. Create a standard user, check the "Configure Catalogs" builtin role
3. Add new user as a member to a cluster (local or downstream)
4. Log in as user and go to `Apps & Marketplace > Chart Repositories` in the cluster
5. Note that chart repositories cannot be modified in any way
6. Upgrade to this PR
7. Refresh browser, user can modify chart repositories

`catalogs-manage` GlobalRole:
```yaml
rules:
- apiGroups:
  - management.cattle.io
  resources:
  - catalogs
  - templates
  - templateversions
  verbs:
  - '*'
- apiGroups:
  - catalog.cattle.io
  resources:
  - clusterrepos
  verbs:
  - '*'
```