### PR TITLE
Fix comment closing tag in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -39,4 +39,4 @@ assignees: ''
 <!-- If applicable, add screenshots to help explain your problem.-->
 
 **Additional context**
-<!--Add any other context about the problem here.—>
+<!--Add any other context about the problem here.-->


### PR DESCRIPTION
Comment closing tag is missing `-` so adding anything after it doesn't show up. This change fixes this.