### PR TITLE
Update Dashboard reference to point to master

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -79,7 +79,7 @@ var (
 	UIFeedBackForm                    = NewSetting("ui-feedback-form", "")
 	UIIndex                           = NewSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
 	UIPath                            = NewSetting("ui-path", "/usr/share/rancher/ui")
-	UIDashboardIndex                  = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/release-2.6/index.html")
+	UIDashboardIndex                  = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/latest/index.html")
 	UIDashboardPath                   = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
 	UIPreferred                       = NewSetting("ui-preferred", "vue")
 	UIOfflinePreferred                = NewSetting("ui-offline-preferred", "dynamic")


### PR DESCRIPTION
- rancher/rancher 2.6.x branches from release/v2.6
- rancher/dashboard 2.6.x branches from master
- To ensure Rancher `v2.6-head` serves latest 2.6 dashboard UIDashboardIndex needs to point to dashboard master
- This does not affect any Rancher build not ending in `-head` built from this branch