### PR TITLE
[2.6] Fix an error on the ca-checksum parameter

### DIFF
--- a/pkg/controllers/dashboard/clusterregistrationtoken/status.go
+++ b/pkg/controllers/dashboard/clusterregistrationtoken/status.go
@@ -198,7 +198,7 @@ func ShareMntCommand(nodeName, token string, cluster *v3.Cluster) ([]string, err
 
 	ca := systemtemplate.CAChecksum()
 	if ca != "" {
-		cmd = append(cmd, fmt.Sprintf("--ca-checksum %s", ca))
+		cmd = append(cmd, "--ca-checksum", ca)
 	}
 
 	return cmd, nil


### PR DESCRIPTION
**Rancher Server Setup**
- Rancher version: 2.6.0
- Installation option (Docker install/Helm Chart): Helm Chart
   - If Helm Chart, Kubernetes Cluster and version (RKE1, RKE2, k3s, EKS, etc): EKS

**Information about the Cluster**
- Kubernetes version: v1.20.10-rancher1-2
- Cluster Type (Local/Downstream): Infrastructure Provider - Amazon EC2

**Describe the bug**
Nodes are unreachable after a restart.

**To Reproduce**

- Have a rancher server with a private certificate
- Restart a worker node

**Result**

The node is not ready:

```
ip-10-0-6-219.ec2.internal   NotReady   worker              161m   v1.20.10
```

**Expected Result**

The node should attach automatically.

**Screenshots**
![image](https://user-images.githubusercontent.com/1159396/132547756-00a7a40b-2be4-4375-873d-503846aaddda.png)

**Additional context**

The error only occurs in clusters created after the update 2.6.0 rancher.

**Error**
The "share-mnt" container has a certificate error:
![image](https://user-images.githubusercontent.com/1159396/132549071-f39e8663-a230-41c9-810a-0ef0e414d3e5.png)

There is the "ca-checksum" parameter defined but there is no log: "Value from $CATTLE_SERVER/v3/settings/cacerts is an x509 certificate" (https://github.com/rancher/rancher/blob/release/v2.6/package/run.sh#L239)

By comparing the containers of v2.5.8 and 2.6.0, I noticed a difference in the parameters:

* v2.5.8:
```
        "Args": [
            "--no-register",
            "--only-write-certs",
            "--node-name",
            "rke-rbu-wkr2",
            "--server",
            "https://rancher...",
            "--token",
            "smdqbt8v6wp5flfpcnks6hkkqhwkwmfqbm525qk6sqp9t5sv8nkgj",
            "--ca-checksum",
            "9c4c1e8e71ddcc00dba450ee2ccf631ac2fc218dd1a8b01dbf9176519765685"
        ],
```

* v2.6.0:
```
        "Args": [
            "--no-register",
            "--only-write-certs",
            "--node-name",
            "rke-rbu-wkr2",
            "--server",
            "https://rancher...",
            "--token",
            "smdqbt8v6wp5flfpcnks6hkkqhwkwmfqbm525qk6sqp9t5sv8nkgj",
            "--ca-checksum 9c4c1e8e71ddcc00dba450ee2ccf631ac2fc218dd1a8b01dbf9176519765685"
        ],
```

If the "--ca-checksum" parameter is in the same argument as the value. It doesn't use the "--ca-checksum" parameter:

* 1 argument:
```
[rancher@rke-rbu-wkr3 kubernetes]$ docker run --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run  rancher/rancher-agent:v2.6.0 --no-register --only-write-certs --node-name rke-rbu-wkr3 --server https://rancher..<...> --token smdqbt8v6wp5flfpcnks6hkkqhwkwmfqbm525qk6sqp9t5sv8nkgjb "--ca-checksum 9c4c1e8e71ddcc00dba450ee2ccf631ac2fc218dd1a8b01dbf91765197656855"
INFO: Arguments: --no-register --only-write-certs --node-name rke-rbu-wkr3 --server https://rancher..<...> --token REDACTED --ca-checksum 9c4c1e8e71ddcc00dba450ee2ccf631ac2fc218dd1a8b01dbf91765197656855
INFO: Environment: CATTLE_ADDRESS=10.0.6.217 CATTLE_AGENT_CONNECT=true CATTLE_INTERNAL_ADDRESS= CATTLE_NODE_NAME=rke-rbu-wkr3 CATTLE_SERVER=https://rancher.<...> CATTLE_TOKEN=REDACTED CATTLE_WRITE_CERT_ONLY=true
INFO: Using resolv.conf: domain ec2.internal nameserver 10.0.0.2
INFO: https://rancher.<...>/ping is accessible
INFO: rancher.<...> resolves to <...>
time="2021-09-08T15:20:58Z" level=info msg="Listening on /tmp/log.sock"
time="2021-09-08T15:20:58Z" level=info msg="Rancher agent version v2.6.0 is starting"
time="2021-09-08T15:20:58Z" level=info msg="Option customConfig=map[address:10.0.6.217 internalAddress: label:map[] roles:[] taints:[]]"
time="2021-09-08T15:20:58Z" level=info msg="Option etcd=false"
time="2021-09-08T15:20:58Z" level=info msg="Option controlPlane=false"
time="2021-09-08T15:20:58Z" level=info msg="Option worker=false"
time="2021-09-08T15:20:58Z" level=info msg="Option requestedHostname=rke-rbu-wkr3"
time="2021-09-08T15:20:58Z" level=info msg="Option dockerInfo={EY2H:VSXI:I7GH:MZ27:AH7N:JLBM:CL3X:JDDJ:7GJ4:HINL:A62D:3DGN 27 2 0 25 12 overlay2 [[Backing Filesystem extfs] [Supports d_type true] [Native Overlay Diff true]] [] {[local] [bridge host macvlan null overlay] [] []} true true true false true true true true false true true true false 29 true 55 2021-09-08T15:20:58.914101672Z json-file cgroupfs  1 4.14.138-rancher RancherOS v1.5.4  linux x86_64 https://index.docker.io/v1/ 0xc0012f27e0 4 16673710080 [] /var/lib/docker    rke-rbu-wkr3 [provider=amazonec2] false 17.03.2-ce   map[runc:{docker-runc [] <nil>}] runc {  inactive false  [] 0 0 0xc001a002c0 []} false  docker-init {4ab9917febca54791c5f071a9d1f404867857fcc 4ab9917febca54791c5f071a9d1f404867857fcc} {ae16ac34cda712253fdf199632fd6b5ec5645e27 54296cf40ad8143b62dbcaa1d90e520a2136ddfe} {949e6fa 949e6fa} [name=seccomp,profile=default]  [] []}"
time="2021-09-08T15:20:58Z" level=info msg="Connecting to wss://rancher.<...>/v3/connect with token starting with smdqbt8v6wp5flfpcnks6hkkqhw"
time="2021-09-08T15:20:58Z" level=info msg="Connecting to proxy" url="wss://rancher.<...>/v3/connect"
time="2021-09-08T15:20:59Z" level=info msg="attempting to stop the share-mnt container so it can reboot on startup"
time="2021-09-08T15:20:59Z" level=error msg="Error response from daemon: Cannot kill container c2e04f9a923ad0404ba7860892c10a17ca9f2eec82f8776203c617345e1f556f: Container c2e04f9a923ad0404ba7860892c10a17ca9f2eec82f8776203c617345e1f556f is not running"
```

* 2 arguments:

```
[rancher@rke-rbu-wkr3 kubernetes]$ docker run --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run  rancher/rancher-agent:v2.6.0 --no-register --only-write-certs --node-name rke-rbu-wkr3 --server https://rancher.<...> --token smdqbt8v6wp5flfpcnks6hkkqhwkwmfqbm525qk6sqp9t5sv8nkgjb --ca-checksum 9c4c1e8e71ddcc00dba450ee2ccf631ac2fc218dd1a8b01dbf91765197656855
INFO: Arguments: --no-register --only-write-certs --node-name rke-rbu-wkr3 --server https://rancher.<...> --token REDACTED --ca-checksum 9c4c1e8e71ddcc00dba450ee2ccf631ac2fc218dd1a8b01dbf91765197656855
INFO: Environment: CATTLE_ADDRESS=10.0.6.217 CATTLE_AGENT_CONNECT=true CATTLE_INTERNAL_ADDRESS= CATTLE_NODE_NAME=rke-rbu-wkr3 CATTLE_SERVER=https://rancher.<...> CATTLE_TOKEN=REDACTED CATTLE_WRITE_CERT_ONLY=true
INFO: Using resolv.conf: domain ec2.internal nameserver 10.0.0.2
INFO: https://rancher.<...>/ping is accessible
INFO: rancher.<...> resolves to <...>
INFO: Value from https://rancher.<...>/v3/settings/cacerts is an x509 certificate
time="2021-09-08T15:20:50Z" level=info msg="Listening on /tmp/log.sock"
time="2021-09-08T15:20:50Z" level=info msg="Rancher agent version v2.6.0 is starting"
time="2021-09-08T15:20:50Z" level=info msg="Option dockerInfo={EY2H:VSXI:I7GH:MZ27:AH7N:JLBM:CL3X:JDDJ:7GJ4:HINL:A62D:3DGN 26 2 0 24 12 overlay2 [[Backing Filesystem extfs] [Supports d_type true] [Native Overlay Diff true]] [] {[local] [bridge host macvlan null overlay] [] []} true true true false true true true true false true true true false 33 true 53 2021-09-08T15:20:50.969713489Z json-file cgroupfs  1 4.14.138-rancher RancherOS v1.5.4  linux x86_64 https://index.docker.io/v1/ 0xc00174c000 4 16673710080 [] /var/lib/docker    rke-rbu-wkr3 [provider=amazonec2] false 17.03.2-ce   map[runc:{docker-runc [] <nil>}] runc {  inactive false  [] 0 0 0xc0017382c0 []} false  docker-init {4ab9917febca54791c5f071a9d1f404867857fcc 4ab9917febca54791c5f071a9d1f404867857fcc} {ae16ac34cda712253fdf199632fd6b5ec5645e27 54296cf40ad8143b62dbcaa1d90e520a2136ddfe} {949e6fa 949e6fa} [name=seccomp,profile=default]  [] []}"
time="2021-09-08T15:20:50Z" level=info msg="Option customConfig=map[address:10.0.6.217 internalAddress: label:map[] roles:[] taints:[]]"
time="2021-09-08T15:20:50Z" level=info msg="Option etcd=false"
time="2021-09-08T15:20:50Z" level=info msg="Option controlPlane=false"
time="2021-09-08T15:20:50Z" level=info msg="Option worker=false"
time="2021-09-08T15:20:50Z" level=info msg="Option requestedHostname=rke-rbu-wkr3"
time="2021-09-08T15:20:51Z" level=info msg="Connecting to wss://rancher.<...>/v3/connect with token starting with smdqbt8v6wp5flfpcnks6hkkqhw"
time="2021-09-08T15:20:51Z" level=info msg="Connecting to proxy" url="wss://rancher.<...>/v3/connect"
time="2021-09-08T15:20:51Z" level=info msg="attempting to stop the share-mnt container so it can reboot on startup"
time="2021-09-08T15:20:51Z" level=error msg="Error response from daemon: Cannot kill container c2e04f9a923ad0404ba7860892c10a17ca9f2eec82f8776203c617345e1f556f: Container c2e04f9a923ad0404ba7860892c10a17ca9f2eec82f8776203c617345e1f556f is not running"
```