### PR TITLE
[WIP] Add libopenssl1_1-hmac to BCI images

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -15,7 +15,7 @@ ENV KUSTOMIZE_VERSION v3.10.0
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
 ENV CATTLE_KDM_BRANCH=dev-v2.6
 
-RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables jq
+RUN zypper -n install libopenssl1_1-hmac gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables jq
 RUN zypper install -y -f docker-20.10.6_ce-6.49.3
 
 RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.suse.com/suse/sle15:15.3
 
-RUN zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim && \
+RUN zypper -n install libopenssl1_1-hmac git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
     useradd rancher && \
     mkdir -p /var/lib/rancher/etcd /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -6,7 +6,7 @@ FROM registry.suse.com/suse/sle15:15.3
 ARG ARCH=amd64
 
 ENV KUBECTL_VERSION v1.21.3
-RUN zypper -n install --no-recommends curl ca-certificates jq git-core hostname iproute2 vim-small less \
+RUN zypper -n install --no-recommends libopenssl1_1-hmac curl ca-certificates jq git-core hostname iproute2 vim-small less \
 	bash-completion acl openssh-clients tar gzip xz gawk sysstat && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \


### PR DESCRIPTION
I've not tested this at all, but I wanted to get the PR up as a theoretical way forward, in the hopes someone else will take it over.

Self-tests for OpenSSL were failing because this package was missing.

Assuming this works, would address https://github.com/rancher/rancher/issues/34580

@nikkelma figured this out and POCed this in a simple container. 