### PR TITLE
Fix sle version to 15.3.17.8.1

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/suse/sle15:15.3
+FROM registry.suse.com/suse/sle15:15.3.17.8.1
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/suse/sle15:15.3
+FROM registry.suse.com/suse/sle15:15.3.17.8.1
 
 RUN zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -2,7 +2,7 @@ ARG RANCHER_TAG=dev
 ARG RANCHER_REPO=rancher
 FROM ${RANCHER_REPO}/rancher:${RANCHER_TAG} as rancher
 
-FROM registry.suse.com/suse/sle15:15.3
+FROM registry.suse.com/suse/sle15:15.3.17.8.1
 ARG ARCH=amd64
 
 ENV KUBECTL_VERSION v1.21.3


### PR DESCRIPTION
Pin sle version to `15.3.17.8.1` to avoid breaking changes in the future

Environment
-
install: docker

Verification
-
- Installed helm charts
- Tested provision a downstream cluster with Digital Ocean (cluster failed at agent image pull due to not being able to find corresponding tag, will re-verify on merge into master)