### PR TITLE
Only add projectID to Fleet NS when system project exists

### DIFF
--- a/pkg/controllers/managementagent/nslabels/labels.go
+++ b/pkg/controllers/managementagent/nslabels/labels.go
@@ -71,7 +71,9 @@ func (nsh *namespaceHandler) addProjectIDLabelToNamespace(ns *corev1.Namespace, 
 		return fmt.Errorf("cannot add label to nil namespace")
 	}
 	if ns.Labels[ProjectIDFieldLabel] != projectID {
-		nsh.updateProjectIDLabelForSecrets(projectID, ns.Name, clusterID)
+		if err := nsh.updateProjectIDLabelForSecrets(projectID, ns.Name, clusterID); err != nil {
+			logrus.Trace(err)
+		}
 		logrus.Infof("namespaceHandler: addProjectIDLabelToNamespace: adding label %v=%v to namespace=%v", ProjectIDFieldLabel, projectID, ns.Name)
 		nscopy := ns.DeepCopy()
 		if nscopy.Labels == nil {

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -93,7 +93,15 @@ func (n *nsLifecycle) syncNS(obj *v1.Namespace) (bool, error) {
 		if err != nil {
 			return false, errors.Wrapf(err, "failed to add namespace %s to system project", obj.Name)
 		}
-		obj.Annotations[projectIDAnnotation] = fmt.Sprintf("%v:%v", n.m.clusterName, systemProjectName)
+
+		// When there is no system project, we should not set this annotation as a result because the project name
+		// is empty. If the annotation already exists, and there is no system project, then we need to delete the
+		// annotation.
+		if systemProjectName != "" {
+			obj.Annotations[projectIDAnnotation] = fmt.Sprintf("%v:%v", n.m.clusterName, systemProjectName)
+		} else {
+			delete(obj.Annotations, projectIDAnnotation)
+		}
 	}
 	hasPRTBs, err := n.ensurePRTBAddToNamespace(obj)
 	if err != nil {

--- a/pkg/controllers/managementuser/secret/secret.go
+++ b/pkg/controllers/managementuser/secret/secret.go
@@ -102,6 +102,10 @@ func (n *NamespaceController) sync(key string, obj *corev1.Namespace) (runtime.O
 	if obj.Annotations[projectIDLabel] != "" {
 		parts := strings.Split(obj.Annotations[projectIDLabel], ":")
 		if len(parts) == 2 {
+			if parts[1] == "" {
+				logrus.Debugf("[NamspaceController|sync] empty project name found in obj.Annotations[projectIDLabel] for cluster: %s", parts[0])
+				return nil, nil
+			}
 			// on the management side, secret's namespace name equals to project name
 			secrets, err := n.managementSecrets.List(parts[1], labels.NewSelector())
 			if err != nil {


### PR DESCRIPTION
Relevant issues:
- This PR partially addresses: https://github.com/rancher/rancher/issues/34746
- This PR primarily addresses: https://github.com/rancher/rancher/issues/34776

## Description

There are two fixes and one "bonus" here. Of the former, one is the actual and the other is preventative.

## Actual
Fleet namespaces will not longer have the projectID annotation if the system project does not exist.
- We've observed handlers using this malformed annotation (e.g. `"local:"` instead of `local:<system-project-id>`).
- When it's removed, the namespace is no longer loaded into the cluster secrets creation sync: https://github.com/rancher/rancher/blob/ebcb2321e254a9d172a130613a1a2d6e06d23248/pkg/controllers/managementuser/secret/secret.go#L102
- Without this PR, an empty string is loaded into the management secrets "List" call, causing significant CPU usage with the following loop running upon every reconciliation of the namespace: https://github.com/rancher/rancher/blob/ebcb2321e254a9d172a130613a1a2d6e06d23248/pkg/controllers/managementuser/secret/secret.go#L110-L127

## Preventative
We will not create management secrets if the projectID is empty.
- This is a safeguard for other namespaces that may have the same bug in the future: https://github.com/rancher/rancher/blob/ebcb2321e254a9d172a130613a1a2d6e06d23248/pkg/controllers/managementuser/secret/secret.go#L105-L108
- We could create and return a new error above (I'd be happy to change it to do so; "testing" it would involve undoing the Fleet change and then re-adding it afterwards for an A/B comparison)

## Bonus
There's an unhandled error that we plan on addressing in another PR.
- For now, I've added it to a trace log so that it's not completely hidden: https://github.com/rancher/rancher/pull/34754/files#diff-51209acaa8140b964a493d6ab61469493b6fc09d9f0583ef3d586cda2fe31849R74-R76

Original comment containing the above: https://github.com/rancher/rancher/pull/34754#issuecomment-921058555