### PR TITLE
Fix conflict errors for impersonation cluster role

### DIFF
--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -288,7 +288,10 @@ func (r *RemoteService) getImpersonatorAccountToken(user user.Info) (string, err
 		return "", err
 	}
 
-	i := impersonation.New(user, clusterContext)
+	i, err := impersonation.New(user, "", clusterContext)
+	if err != nil {
+		return "", fmt.Errorf("error creating impersonation for user %s: %w", user.GetUID(), err)
+	}
 
 	sa, err := i.SetUpImpersonation()
 	if err != nil {

--- a/pkg/controllers/managementuser/rbac/impersonation_handler.go
+++ b/pkg/controllers/managementuser/rbac/impersonation_handler.go
@@ -41,7 +41,8 @@ func (m *manager) getUser(username, groupname string) (user.Info, error) {
 }
 
 func (m *manager) ensureServiceAccountImpersonator(username, groupname string) error {
-	user, err := m.getUser(username, groupname)
+	logrus.Debugf("ensuring service account impersonator for %s", username)
+	i, err := impersonation.New(&user.DefaultInfo{UID: username}, groupname, m.workload)
 	if apierrors.IsNotFound(err) {
 		logrus.Warnf("could not find user %s, will not create impersonation account on cluster", username)
 		return nil
@@ -49,8 +50,6 @@ func (m *manager) ensureServiceAccountImpersonator(username, groupname string) e
 	if err != nil {
 		return err
 	}
-	logrus.Debugf("ensuring service account impersonator for %s", user.GetUID())
-	i := impersonation.New(user, m.workload)
 	_, err = i.SetUpImpersonation()
 	return err
 }

--- a/pkg/impersonation/impersonation.go
+++ b/pkg/impersonation/impersonation.go
@@ -3,6 +3,7 @@ package impersonation
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 
 	"github.com/rancher/rancher/pkg/types/config"
@@ -14,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -27,8 +29,16 @@ type Impersonator struct {
 	clusterContext *config.UserContext
 }
 
-func New(user user.Info, clusterContext *config.UserContext) Impersonator {
-	return Impersonator{user: user, clusterContext: clusterContext}
+func New(userInfo user.Info, group string, clusterContext *config.UserContext) (Impersonator, error) {
+	user, err := getUser(clusterContext, userInfo, group)
+	if err != nil {
+		return Impersonator{}, err
+	}
+
+	return Impersonator{
+		user:           user,
+		clusterContext: clusterContext,
+	}, nil
 }
 
 func (i *Impersonator) SetUpImpersonation() (*corev1.ServiceAccount, error) {
@@ -167,17 +177,27 @@ func (i *Impersonator) createNamespace() error {
 
 func (i *Impersonator) checkAndUpdateRole(rules []rbacv1.PolicyRule) (*rbacv1.ClusterRole, error) {
 	name := ImpersonationPrefix + i.user.GetUID()
-	role, err := i.clusterContext.RBAC.ClusterRoles("").Controller().Lister().Get("", name)
-	if apierrors.IsNotFound(err) {
-		return nil, nil
-	}
+	var role *rbacv1.ClusterRole
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var err error
+		role, err = i.clusterContext.RBAC.ClusterRoles("").Controller().Lister().Get("", name)
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if !reflect.DeepEqual(role.Rules, rules) {
+			role.Rules = rules
+			role, err = i.clusterContext.RBAC.ClusterRoles("").Update(role)
+			return err
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	if !reflect.DeepEqual(role.Rules, rules) {
-		role.Rules = rules
-		return i.clusterContext.RBAC.ClusterRoles("").Update(role)
-	}
+
 	return role, nil
 }
 
@@ -322,4 +342,57 @@ func (i *Impersonator) waitForServiceAccount(sa *corev1.ServiceAccount) (*corev1
 		return nil, fmt.Errorf("failed to get secret for service account: %s/%s, error: %w", sa.Namespace, sa.Name, err)
 	}
 	return ret, nil
+}
+
+func getUser(clusterContext *config.UserContext, userInfo user.Info, groupName string) (user.Info, error) {
+	u, err := clusterContext.Management.Management.Users("").Controller().Lister().Get("", userInfo.GetUID())
+	if err != nil {
+		return &user.DefaultInfo{}, err
+	}
+
+	groups := []string{"system:authenticated", "system:cattle:authenticated"}
+	if groupName != "" {
+		groups = append(groups, groupName)
+	}
+	attribs, err := clusterContext.Management.Management.UserAttributes("").Controller().Lister().Get("", userInfo.GetUID())
+	if err != nil && !apierrors.IsNotFound(err) {
+		return &user.DefaultInfo{}, err
+	}
+	if attribs != nil {
+		for _, gps := range attribs.GroupPrincipals {
+			for _, groupPrincipal := range gps.Items {
+				if !isInList(groupPrincipal.Name, groups) {
+					groups = append(groups, groupPrincipal.Name)
+				}
+			}
+		}
+	}
+	// sort to make comparable
+	sort.Strings(groups)
+
+	extras := userInfo.GetExtra()
+	// sort to make comparable
+	if _, ok := extras["username"]; ok {
+		sort.Strings(extras["username"])
+	}
+	if _, ok := extras["principalid"]; ok {
+		sort.Strings(extras["principalid"])
+	}
+
+	user := &user.DefaultInfo{
+		UID:    u.GetName(),
+		Name:   u.Username,
+		Groups: groups,
+		Extra:  extras,
+	}
+	return user, nil
+}
+
+func isInList(item string, list []string) bool {
+	for _, s := range list {
+		if item == s {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/impersonation/impersonation_test.go
+++ b/pkg/impersonation/impersonation_test.go
@@ -1,0 +1,135 @@
+package impersonation
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func Test_getUser(t *testing.T) {
+	tests := []struct {
+		name              string
+		userInfo          user.Info
+		groupName         string
+		userGetFunc       func(_, _ string) (*v3.User, error)
+		userAttribGetFunc func(_, _ string) (*v3.UserAttribute, error)
+		want              user.Info
+	}{
+		{
+			name:     "plain local user",
+			userInfo: &user.DefaultInfo{Name: "user-abcde"},
+			userGetFunc: func(_, _ string) (*v3.User, error) {
+				return &v3.User{
+					ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+					Username:   "admin",
+				}, nil
+			},
+			userAttribGetFunc: func(_, _ string) (*v3.UserAttribute, error) {
+				return nil, nil
+			},
+			want: &user.DefaultInfo{
+				UID:  "user-abcde",
+				Name: "admin",
+				Groups: []string{
+					"system:authenticated",
+					"system:cattle:authenticated",
+				},
+			},
+		},
+		{
+			name: "multi auth provider user",
+			userInfo: &user.DefaultInfo{
+				Name: "user-abcde",
+				Extra: map[string][]string{
+					"username": []string{
+						"user1",
+						"admin",
+					},
+					"principalid": []string{
+						"openldap_user://uid=user1,dc=example,dc=org",
+						"github_user://890",
+					},
+				},
+			},
+			groupName: "project:abc",
+			userGetFunc: func(_, _ string) (*v3.User, error) {
+				return &v3.User{
+					ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+					Username:   "admin",
+				}, nil
+			},
+			userAttribGetFunc: func(_, _ string) (*v3.UserAttribute, error) {
+				return &v3.UserAttribute{
+					GroupPrincipals: map[string]v3.Principals{
+						"github": v3.Principals{
+							Items: []v3.Principal{
+								{
+									ObjectMeta: metav1.ObjectMeta{Name: "github_org://456"},
+								},
+								{
+									ObjectMeta: metav1.ObjectMeta{Name: "github_org://123"},
+								},
+							},
+						},
+						"openldap": v3.Principals{
+							Items: []v3.Principal{
+								{
+									ObjectMeta: metav1.ObjectMeta{Name: "openldap_group://cn=group1,dc=example,dc=org"},
+								},
+								{
+									ObjectMeta: metav1.ObjectMeta{Name: "openldap_group://cn=group2,dc=example,dc=org"},
+								},
+								{
+									ObjectMeta: metav1.ObjectMeta{Name: "openldap_group://cn=group2,dc=example,dc=org"},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+			want: &user.DefaultInfo{
+				UID:  "user-abcde",
+				Name: "admin",
+				Groups: []string{
+					"github_org://123",
+					"github_org://456",
+					"openldap_group://cn=group1,dc=example,dc=org",
+					"openldap_group://cn=group2,dc=example,dc=org",
+					"project:abc",
+					"system:authenticated",
+					"system:cattle:authenticated",
+				},
+				Extra: map[string][]string{
+					"username": []string{
+						"admin",
+						"user1",
+					},
+					"principalid": []string{
+						"github_user://890",
+						"openldap_user://uid=user1,dc=example,dc=org",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impersonator := Impersonator{
+				userLister: &fakes.UserListerMock{
+					GetFunc: tt.userGetFunc,
+				},
+				userAttributeLister: &fakes.UserAttributeListerMock{
+					GetFunc: tt.userAttribGetFunc,
+				},
+			}
+			got, err := impersonator.getUser(tt.userInfo, tt.groupName)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Without this patch, requests made on a downstream cluster through the
impersonation proxy can sometimes fail when the impersonation cluster
role fails to update. This is more likely to happen when there are a
high volume of requests. This change addresses the issue in two ways:

1) Reduce the need to update the cluster role by ensuring that the
   resources in the role rules are sorted so that equality comparison is
   meaningful.
2) Retry the update when a conflict is encountered so that a single
   conflict error isn't fatal to the request.

https://github.com/rancher/rancher/issues/34671