### PR TITLE
Avoid a panic when a user adds a chart catalog containing a blank Helm chart

### DIFF
--- a/pkg/api/norman/customization/catalog/store.go
+++ b/pkg/api/norman/customization/catalog/store.go
@@ -16,6 +16,7 @@ import (
 	managementschema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/sirupsen/logrus"
 )
 
 type templateStore struct {
@@ -52,14 +53,18 @@ func GetTemplateStore(ctx context.Context, managementContext *config.ScaledConte
 func (t *templateStore) extractVersionLinks(apiContext *types.APIContext, resource map[string]interface{}) map[string]interface{} {
 	schema := apiContext.Schemas.Schema(&managementschema.Version, client.TemplateVersionType)
 	r := map[string]interface{}{}
-	versionMap, ok := resource[client.CatalogTemplateFieldVersions].([]interface{})
+	versionMaps, ok := resource[client.CatalogTemplateFieldVersions].([]interface{})
 	if ok {
-		for _, version := range versionMap {
+		for _, version := range versionMaps {
 			revision := ""
 			if v, ok := version.(map[string]interface{})["revision"].(int64); ok {
 				revision = strconv.FormatInt(v, 10)
 			}
-			versionString := version.(map[string]interface{})["version"].(string)
+			versionString, ok := version.(map[string]interface{})["version"].(string)
+			if !ok {
+				logrus.Trace("[templateStore] failed type assertion for field \"version\" for CatalogTemplateFieldVersion")
+				continue
+			}
 			versionID := fmt.Sprintf("%v-%v", resource["id"], versionString)
 			if revision != "" {
 				versionID = fmt.Sprintf("%v-%v", resource["id"], revision)


### PR DESCRIPTION
Relevant issue: rancher/rancher#28776 

This is relevant only for the old UI. A blank chart is one whose `Chart.yaml` is missing the `version` field. The `name` field is also required, but its lack is already properly handled.