### PR TITLE
check that we are not binding a user principal twice

### DIFF
--- a/pkg/auth/providers/common/usermanager.go
+++ b/pkg/auth/providers/common/usermanager.go
@@ -148,6 +148,14 @@ func (m *userManager) SetPrincipalOnCurrentUserByUserID(userID string, principal
 		return nil, err
 	}
 
+	// ensure this principal is unique to this user
+	if conflict, err := m.GetUserByPrincipalID(principal.Name); err != nil {
+		return nil, err
+	} else if conflict != nil && conflict.UID != user.UID {
+		logrus.Errorf("refusing to set principal [%s] on user [%s], principal already in use on user [%s]", principal.Name, user.DisplayName, conflict.DisplayName)
+		return user, errors.New("refusing to set principal on user that is already bound to another user")
+	}
+
 	if providerExists(user.PrincipalIDs, principal.Provider) {
 		var principalIDs []string
 		for _, id := range user.PrincipalIDs {

--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -326,9 +326,12 @@ func (s *Provider) HandleSamlAssertion(w http.ResponseWriter, r *http.Request, a
 	userID := s.clientState.GetState(r, "Rancher_UserID")
 	if userID != "" && rancherAction == testAndEnableAction {
 		user, err := s.userMGR.SetPrincipalOnCurrentUserByUserID(userID, userPrincipal)
-		if err != nil {
+		if err != nil && user == nil {
 			log.Errorf("SAML: Error setting principal on current user %v", err)
 			http.Redirect(w, r, redirectURL+"errorCode=500", http.StatusFound)
+			return
+		} else if err != nil && user != nil {
+			http.Redirect(w, r, redirectURL+"errorCode=422&errMsg="+err.Error(), http.StatusFound)
 			return
 		}
 


### PR DESCRIPTION
old PR: https://github.com/rancher/rancher/pull/33029

https://github.com/rancher/rancher/issues/13666

# Problem
When setting up an external authentication provider the user is asked to test the setup with an external user.  On success the principal for the external user is bound to the current user.  If you login with a second external user a new user is created for them.  Disabling and enabling auth with the second external user will bind their principal to the current local account.  The principal is now bound to the local account and the user created when the user authenticated normally.  There is no way to determine what users is the real one and a 500 error is returned.

# Solution 
When a provider is enabled I added a check to see if the principal is currently bound to any user other than the current local user.  If another user is found an error is returned and details are logged.  The user can then delete the conflicting account, login with the conflicting account during setup, or manually remove the principal.  I opted for a cowardly approach because the only way to correct this is to unbind the principal from the existing user and this could have implications on auditing historical data.

# Testing
1. Enable Authentication with testuser1 
2. login with testuser2
3. disable authentication
4. enable authentication and use testuser2
5. Attempt to login with testuser2

Without the patch applied you should get a 500 on step 5.  With the patch applied you should get an error on step 4 and see details in the rancher logs.  I tested this using Keycloak but this error has been reported with Active Directory and Okta as well.  I believe it will affect the following providers:

- azure
- github
- googleoauth
- ldap
- oidc
- keycloak
- Active Directory 


