### PR TITLE
populate server-version setting with env var for cluster agent

### DIFF
--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -44,6 +44,7 @@ type context struct {
 	PrivateRegistryConfig string
 	Tolerations           string
 	ClusterRegistry       string
+	ServerVersion         string
 }
 
 var (
@@ -122,6 +123,7 @@ func SystemTemplate(resp io.Writer, agentImage, authImage, namespace, token, url
 		PrivateRegistryConfig: privateRegistryConfig,
 		Tolerations:           tolerations,
 		ClusterRegistry:       clusterRegistry,
+		ServerVersion:         settings.ServerVersion.Get(),
 	}
 
 	return t.Execute(resp, context)

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -210,6 +210,8 @@ spec:
             value: "true"
           - name: CATTLE_CLUSTER_REGISTRY
             value: "{{.ClusterRegistry}}" 
+          - name: CATTLE_SERVER_VERSION
+            value: "{{.ServerVersion}}"
       {{- if .AgentEnvVars}}
 {{ .AgentEnvVars | indent 10 }}
       {{- end }}


### PR DESCRIPTION
Downstream clusters need to have the same `server-version` setting as their upstream in order to view the correct feature charts version for the current rancher installation. The `CATTLE_SERVER_VERSION` environment variable is now passed down through an environment variable when the cluster agent is deployed to ensure that the downstream cluster agent uses the correct version.

Related Issue: https://github.com/rancher/rancher/issues/34875
