### PR TITLE
Fix panic for AKS when no upgrades are available

### DIFF
--- a/pkg/api/norman/customization/aks/listers.go
+++ b/pkg/api/norman/customization/aks/listers.go
@@ -428,6 +428,10 @@ func encodeOutput(result interface{}) ([]byte, int, error) {
 func upgradeableVersionsMap(upgradeProfile containerservice.OrchestratorVersionProfile) map[string]bool {
 	rval := make(map[string]bool, 0)
 
+	if upgradeProfile.Upgrades == nil {
+		// already on latest version, no upgrades available
+		return rval
+	}
 	for _, profile := range *upgradeProfile.Upgrades {
 		rval[*profile.OrchestratorVersion] = true
 	}


### PR DESCRIPTION
If an AKS cluster is already on the latest version, then the
orchestrator Upgrades field will be nil. This patch ensures that case is
handled correctly to avoid a nil dereference error.

https://github.com/rancher/rancher/issues/34901