### PR TITLE
Add a skipFilter bool so that not all calls occur on a filtered index

### DIFF
--- a/pkg/api/steve/catalog/content.go
+++ b/pkg/api/steve/catalog/content.go
@@ -117,7 +117,7 @@ func (i *contentDownload) serveChart(apiContext *types.APIRequest, rw http.Respo
 	}
 
 	namespace, name := nsAndName(apiContext)
-	chart, err := i.contentManager.Chart(namespace, name, chartName, version)
+	chart, err := i.contentManager.Chart(namespace, name, chartName, version, true)
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,8 @@ func (i *contentDownload) serveChart(apiContext *types.APIRequest, rw http.Respo
 }
 
 func (i *contentDownload) getIndex(apiContext *types.APIRequest) (*repo.IndexFile, error) {
-	return i.contentManager.Index(nsAndName(apiContext))
+	namespace, name := nsAndName(apiContext)
+	return i.contentManager.Index(namespace, name, false)
 }
 
 func nsAndName(apiContext *types.APIRequest) (string, string) {

--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -543,7 +543,7 @@ func addAnnotations(data []byte, annotations map[string]string) ([]byte, error) 
 }
 
 func (s *Operations) getChartCommand(namespace, name, chartName, chartVersion string, annotations map[string]string, values map[string]interface{}) (Command, error) {
-	chart, err := s.contentManager.Chart(namespace, name, chartName, chartVersion)
+	chart, err := s.contentManager.Chart(namespace, name, chartName, chartVersion, true)
 	if err != nil {
 		return Command{}, err
 	}

--- a/pkg/catalogv2/system/system.go
+++ b/pkg/catalogv2/system/system.go
@@ -231,7 +231,7 @@ func (m *Manager) Remove(namespace, name, minVersion string) {
 }
 
 func (m *Manager) install(namespace, name, minVersion string, values map[string]interface{}, forceAdopt bool) error {
-	index, err := m.content.Index("", "rancher-charts")
+	index, err := m.content.Index("", "rancher-charts", true)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/provisioningv2/managedchart/managedchart.go
+++ b/pkg/controllers/provisioningv2/managedchart/managedchart.go
@@ -84,7 +84,7 @@ func (h *handler) OnRepoChange(key string, _ *v1.ClusterRepo) (*v1.ClusterRepo, 
 }
 
 func (h *handler) OnChange(mcc *v3.ManagedChart, status v3.ManagedChartStatus) ([]runtime.Object, v3.ManagedChartStatus, error) {
-	chart, err := h.charts.Chart("", mcc.Spec.RepoName, mcc.Spec.Chart, mcc.Spec.Version)
+	chart, err := h.charts.Chart("", mcc.Spec.RepoName, mcc.Spec.Chart, mcc.Spec.Version, true)
 	if err != nil {
 		return nil, status, err
 	}


### PR DESCRIPTION
**Issue**
https://github.com/rancher/rancher/issues/34919

**Problem**
rancher-version filtering is causing errors when upgrading to newer versions of rancher where the currently installed chart is not longer supported in the new rancher version. When the user goes to edit/upgrade their install, an error is showing because the chart info is filtered out of the api response. 

**Solution**
Add a flag so that only the index filter charts based on chart annotations. This will allow specific chart get calls to return the chart information if it still exists in the chart repository. 


