### PR TITLE
Add agent args to environment for instruction

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagent.go
+++ b/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagent.go
@@ -165,6 +165,9 @@ func installer(envs []rkev1.EnvVar, allWorkers bool, secretName, generation stri
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "system-agent-upgrader",
 			Namespace: namespaces.System,
+			Annotations: map[string]string{
+				"upgrade.cattle.io/digest": "spec.upgrade.envs",
+			},
 		},
 		Spec: upgradev1.PlanSpec{
 			Concurrency: 10,


### PR DESCRIPTION
When passing the system-agent-install instruction to the machine, none
of the agent arguments were being added to the environment. This made it
impossible to use the agent args to pass things like the PROXY
environment variables to the system-agent-installer.

After this change, the agent args are passed to the environment for the
system-agent-installer and it will pull out RKE2_ and _PROXY environment
variables.

Issues:
https://github.com/rancher/rancher/issues/32633
https://github.com/rancher/rancher/issues/34908