### PR TITLE
Don't delete system namespace from controller

### DIFF
--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -181,11 +181,6 @@ func (c *ClusterLifecycleCleanup) cleanupImportedCluster(cluster *v3.Cluster) er
 		return err
 	}
 
-	err = userContext.Core.Namespaces("").Delete("cattle-system", &metav1.DeleteOptions{})
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Without this change, cleanupImportedCluster always deletes the
cattle-system namespace of the imported cluster, which is not always
desireable if the imported cluster is a rancher cluster. This was not
evident before f420749b because if the controller failed to get a
cluster context for the deleted cluster then it wouldn't get as far as
deleting the cluster. The controller does not need to delete the
namespace itself because the cluster agent cleanup job takes care of
it[1] and is smart enough not to delete the namespace if rancher is
running in it. This change fixes the problem by removing the deletion
from the controller and leaving it up to the agent to handle.

[1] https://github.com/rancher/rancher/blob/0dd1ce6547cbb3253a8c6f48f5d538c98e7c567d/pkg/agent/clean/cluster.go#L99-L127

https://github.com/rancher/rancher/issues/33800