### PR TITLE
Ignore resourceQuotas and apps in undefined projects

### DIFF
--- a/pkg/controllers/managementuser/resourcequota/resource_quota_common.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_common.go
@@ -2,14 +2,13 @@ package resourcequota
 
 import (
 	"encoding/json"
-	"strings"
-
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 
 	"github.com/rancher/norman/types/convert"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/ref"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -157,12 +156,17 @@ func getProjectResourceQuotaLimit(ns *corev1.Namespace, projectLister v3.Project
 	if projectID == "" {
 		return nil, "", nil
 	}
-	projectNamespace, projectName := getProjectNamespaceName(projectID)
+	projectNamespace, projectName := ref.Parse(projectID)
 	if projectName == "" {
 		return nil, "", nil
 	}
 	project, err := projectLister.Get(projectNamespace, projectName)
 	if err != nil || project.Spec.ResourceQuota == nil {
+		if errors.IsNotFound(err) {
+			// If Rancher is unaware of a project, we should ignore trying to get the resource quota limit
+			// A non-existent project is likely managed by another Rancher (e.g. Hosted Rancher)
+			return nil, "", nil
+		}
 		return nil, "", err
 	}
 	return &project.Spec.ResourceQuota.Limit, projectID, nil
@@ -173,12 +177,17 @@ func getProjectNamespaceDefaultQuota(ns *corev1.Namespace, projectLister v3.Proj
 	if projectID == "" {
 		return nil, nil
 	}
-	projectNamespace, projectName := getProjectNamespaceName(projectID)
+	projectNamespace, projectName := ref.Parse(projectID)
 	if projectName == "" {
 		return nil, nil
 	}
 	project, err := projectLister.Get(projectNamespace, projectName)
 	if err != nil || project.Spec.ResourceQuota == nil {
+		if errors.IsNotFound(err) {
+			// If Rancher is unaware of a project, we should ignore trying to get the default namespace quota
+			// A non-existent project is likely managed by another Rancher (e.g. Hosted Rancher)
+			return nil, nil
+		}
 		return nil, err
 	}
 	return project.Spec.NamespaceDefaultResourceQuota, nil
@@ -195,6 +204,11 @@ func getProjectContainerDefaultLimit(ns *corev1.Namespace, projectLister v3.Proj
 	}
 	project, err := projectLister.Get(projectNamespace, projectName)
 	if err != nil || project.Spec.ResourceQuota == nil {
+		if errors.IsNotFound(err) {
+			// If Rancher is unaware of a project, we should ignore trying to get the default container limit
+			// A non-existent project is likely managed by another Rancher (e.g. Hosted Rancher)
+			return nil, nil
+		}
 		return nil, err
 	}
 	return project.Spec.ContainerDefaultResourceLimit, nil
@@ -234,17 +248,6 @@ func getProjectID(ns *corev1.Namespace) string {
 		return ns.Annotations[projectIDAnnotation]
 	}
 	return ""
-}
-
-func getProjectNamespaceName(projectID string) (string, string) {
-	if projectID == "" {
-		return "", ""
-	}
-	parts := strings.Split(projectID, ":")
-	if len(parts) == 2 {
-		return parts[0], parts[1]
-	}
-	return "", ""
 }
 
 func convertPodResourceLimitToLimitRangeSpec(podResourceLimit *v32.ContainerResourceLimit) (*corev1.LimitRangeSpec, error) {

--- a/pkg/controllers/managementuserlegacy/helm/state.go
+++ b/pkg/controllers/managementuserlegacy/helm/state.go
@@ -66,6 +66,11 @@ func (s *AppStateCalculator) sync(key string, obj *util.Workload) error {
 		}
 		app, err := s.appLister.Get(projectNS, label)
 		if err != nil {
+			if errors.IsNotFound(err) {
+				// If Rancher is unaware of an app, we should ignore tracking its state
+				// A non-existent app is likely managed by another Rancher (e.g. Hosted Rancher)
+				return nil
+			}
 			if !errors.IsNotFound(err) {
 				return err
 			}


### PR DESCRIPTION
This PR modifies the resourceQuota and appState controllers to ignore apps & projects that are not found on trying to update. This is specifically meant to mitigate CPU spikes we see in a Hosted Rancher setup.

Specifically, it encodes the following logic:
- [AppState] If a workload with an annotation that appears to point to a v3 app that is **not** tracked by our management cluster is found, we should ignore updating the app state since it's probably managed by another Rancher.
- [ResourceQuota] If a namespace with an annotation that appears to point to a v3 project that is **not** tracked by our management cluster is found, we should ignore updating the resource quota since it's probably managed by another Rancher.

---

I also made a minor change to use `ref.Parse` instead of an unnecessary helper function.

---

Depends on the fix from https://github.com/rancher/rancher/pull/34860 to resolve the first issue.

Related Issue: https://github.com/rancher/rancher/issues/34833, https://github.com/rancher/rancher/issues/34889, https://github.com/rancher/rancher/issues/34746