### PR TITLE
Ensure rancher-machine image is added to images.txt

### DIFF
--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -313,6 +313,7 @@ func setRequirementImages(osType OSType, imagesSet map[string]map[string]bool) {
 	switch osType {
 	case Linux:
 		addSourceToImage(imagesSet, settings.ShellImage.Get(), coreLabel)
+		addSourceToImage(imagesSet, settings.MachineProvisionImage.Get(), coreLabel)
 		addSourceToImage(imagesSet, "busybox", coreLabel)
 	}
 }


### PR DESCRIPTION
The rancher-machine image was mistakenly left out of the images.txt
file. This change will include it.

Issue:
https://github.com/rancher/rancher/issues/34986