### PR TITLE
add WorkloadID selector only if service is created by norman

### DIFF
--- a/pkg/controllers/managementagent/targetworkloadservice/target_workload_service.go
+++ b/pkg/controllers/managementagent/targetworkloadservice/target_workload_service.go
@@ -29,6 +29,8 @@ import (
 
 const (
 	WorkloadIDLabelPrefix = "workloadID"
+	creatorLabelKey       = "cattle.io/creator"
+	creatorNorman         = "norman"
 )
 
 var workloadServiceUUIDToWorkloadIDs sync.Map
@@ -72,6 +74,11 @@ func (c *Controller) sync(key string, obj *corev1.Service) (runtime.Object, erro
 		// delete from the workload map
 		workloadServiceUUIDToWorkloadIDs.Delete(key)
 		return nil, nil
+	}
+
+	// add WorkloadID selector only if service is created by norman
+	if obj.Labels == nil || obj.Labels[creatorLabelKey] != creatorNorman {
+		return obj, nil
 	}
 
 	workloadIDs := getServiceWorkloadIDs(obj)


### PR DESCRIPTION
**Issue:** 
Services stopped working in v2.6-head because they have an extra selector `workloadID_`. 
https://github.com/rancher/rancher/issues/34948 

**NOTE:** 
This issue doesn't happen in v2.6.0 because the controller would error out here https://github.com/rancher/rancher/blob/release/v2.6/pkg/controllers/managementagent/targetworkloadservice/target_workload_service.go#L123 due to an existing bug. This bug was recently fixed in UI so the logic now proceeds and adds selector the service.  

**Root cause:** 
Vue UI creates services for workloads itself vs backend used to create different type of services in Ember. The default service created for Ember always had Noop annotation https://github.com/rancher/rancher/blob/release/v2.6/pkg/controllers/managementagent/workload/workload.go#L249 so this controller wouldn't try to add selector to the service. https://github.com/rancher/rancher/blob/release/v2.6/pkg/controllers/managementagent/targetworkloadservice/target_workload_service.go#L115 (This selector is for a specific use case where we could create service pointing to another workload in Ember). 

**Fix:** 
This logic only needs to run for services created by norman for Ember, so look for `"cattle.io/creator":norman` label and return if not present. 

**Validation:**
- Tested that service works with the fix in Vue 
- Tested that service continues to work in Ember 