### PR TITLE
Handle flapping value between rancher and fleet

### DIFF
--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
@@ -108,8 +108,10 @@ func (h *handler) createCluster(cluster *v1.Cluster, status v1.ClusterStatus) ([
 	}
 
 	agentNamespace := ""
+	clientSecret := status.ClientSecretName
 	if mgmtCluster.Spec.Internal {
 		agentNamespace = "cattle-fleet-local-system"
+		clientSecret = "local-cluster"
 	}
 
 	return []runtime.Object{&fleet.Cluster{
@@ -119,7 +121,7 @@ func (h *handler) createCluster(cluster *v1.Cluster, status v1.ClusterStatus) ([
 			Labels:    labels,
 		},
 		Spec: fleet.ClusterSpec{
-			KubeConfigSecret: status.ClientSecretName,
+			KubeConfigSecret: clientSecret,
 			AgentEnvVars:     mgmtCluster.Spec.AgentEnvVars,
 			AgentNamespace:   agentNamespace,
 		},


### PR DESCRIPTION
When fleet bootstraps the local cluster it uses a non standard secret name
"local-cluster" because the loopback connect is handled different from
any other cluster. Due to a race condition on start it was possible that
Rancher would first create fleet-local/local cluster with no kubeconfig
secret.  If the kubeconfig secret is blank fleet would try to generate
one and would fail for the local cluster.  Instead if rancher creates
the local cluster first ensure that we also set the non standard secret
"local-cluster".