### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Open your browser to https://localhost
 Rancher can be deployed in either a single node or multi-node setup.  Please refer to the following for guides on how to get Rancher up and running.
 
 * [Single Node Install](https://rancher.com/docs/rancher/v2.x/en/installation/single-node/)
-* [High Availability (HA) Install](https://rancher.com/docs/rancher/v2.x/en/installation/ha/)
+* [High Availability (HA) Install](https://rancher.com/docs/rancher/v2.x/en/installation/install-rancher-on-k8s/)
 
 > **No internet access?**  Refer to our [Air Gap Installation](https://rancher.com/docs/rancher/v2.x/en/installation/air-gap-installation/) for instructions on how to use your own private registry to install Rancher.
 


### PR DESCRIPTION
The `/ha/` link redirects to to `/k8s-install` which no longer exists. Update the link to point to https://rancher.com/docs/rancher/v2.x/en/installation/install-rancher-on-k8s/ instead.