### PR TITLE
Remove periods from machine name passed to machine job

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/machineprovision/args.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/args.go
@@ -127,7 +127,10 @@ func (h *handler) getArgsEnvAndStatus(meta metav1.Object, data data.Object, args
 	} else {
 		cmd = append(cmd, "rm", "-y")
 	}
-	cmd = append(cmd, meta.GetName())
+
+	// cloud-init will split the hostname on '.' and set the hostname to the first chunk. This causes an issue where all
+	// nodes in a machine pool may have the same node name in Kubernetes. Converting the '.' to '-' here prevents this.
+	cmd = append(cmd, strings.ReplaceAll(meta.GetName(), ".", "-"))
 
 	return driverArgs{
 		DriverName:          driver,


### PR DESCRIPTION
For certain cloud providers, the name of the machine passed to
rancher-machine gets set to the hostname for the machine. This hostname
is then used when deploying RKE2/K3S.

If the hostname of a machine has a period in it, cloud-init will split
the hostname on '.' and set the hostname of the machine to the first
chunk. For example, if the name of the machine is
'my.really.good.machine', then cloud-init will set the hostname to 'my'.
This causes a problem in provisioningv2 if the user puts a period in the
name of a machine pool. Then all the corresponding nodes in that machine
pool will have the same name because of the chunking behavior.

This change will replace all periods in the machine name passed to
rancher-machine to dashes to avoid this problem.

Issue:
https://github.com/rancher/rancher/issues/34997