### PR TITLE
Clean up additional rancher namespaces

### DIFF
--- a/pkg/agent/clean/cluster.go
+++ b/pkg/agent/clean/cluster.go
@@ -63,6 +63,8 @@ var (
 		"cattle-prometheus",
 		"cattle-logging",
 		"cattle-pipeline",
+		"cattle-fleet-system",
+		"cattle-impersonation-system",
 	}
 
 	getNSFuncs = []getNSFunc{

--- a/pkg/data/dashboard/cluster_data.go
+++ b/pkg/data/dashboard/cluster_data.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -37,15 +38,31 @@ func addLocalCluster(embedded bool, wrangler *wrangler.Context) error {
 		c.Status.Driver = v32.ClusterDriverLocal
 	}
 
-	// Ignore error
-	_, _ = wrangler.Core.Namespace().Create(&corev1.Namespace{
+	var err error
+	c, err = wrangler.Mgmt.Cluster().Create(c)
+	if apierrors.IsAlreadyExists(err) {
+		c, err = wrangler.Mgmt.Cluster().Get("local", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	_, err = wrangler.Core.Namespace().Create(&corev1.Namespace{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "local",
+			OwnerReferences: []v1.OwnerReference{
+				{
+					APIVersion: v32.SchemeGroupVersion.String(),
+					Kind:       c.Kind,
+					Name:       c.Name,
+					UID:        c.UID,
+				},
+			},
 		},
 	})
-
-	// Ignore error
-	_, err := wrangler.Mgmt.Cluster().Create(c)
 	if apierrors.IsAlreadyExists(err) {
 		return nil
 	}


### PR DESCRIPTION
Add two additional system namespaces to the cluster cleanup agent,
cattle-fleet-system and cattle-impersonation-system.

Ensure that the 'local' namespace has the 'local' cluster as an owner
reference. This way, running `system-tools remove` on an imported
downstream cluster will cause the 'local' namespace to be automatically
removed when the 'local' cluster is removed.

https://github.com/rancher/rancher/issues/34990