### PR TITLE
Stop cluster healthcheck on etcd restore

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -13,6 +13,7 @@ import (
 	mgmtcontroller "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	rocontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	rkecontroller "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/provisioningv2/rke2/planner"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/pkg/condition"
 	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
@@ -38,6 +39,8 @@ type handler struct {
 	secretCache       corecontrollers.SecretCache
 	secretClient      corecontrollers.SecretClient
 	capiClusters      capicontrollers.ClusterCache
+	mgmtClusterCache  mgmtcontroller.ClusterCache
+	mgmtClusterClient mgmtcontroller.ClusterClient
 	rkeControlPlane   rkecontroller.RKEControlPlaneCache
 }
 
@@ -54,6 +57,8 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 
 	if features.MCM.Enabled() {
 		h.dynamicSchema = clients.Mgmt.DynamicSchema().Cache()
+		h.mgmtClusterCache = clients.Mgmt.Cluster().Cache()
+		h.mgmtClusterClient = clients.Mgmt.Cluster()
 	}
 
 	clients.Dynamic.OnChange(ctx, "rke", matchRKENodeGroup, h.infraWatch)
@@ -191,8 +196,30 @@ func (h *handler) updateClusterProvisioningStatus(cluster *rancherv1.Cluster, st
 		return status, err
 	}
 
+	if h.mgmtClusterCache != nil {
+		mgmtCluster, err := h.mgmtClusterCache.Get(cluster.Status.ClusterName)
+		if err != nil {
+			return status, err
+		}
+
+		message := Provisioned.GetMessage(cp)
+		if (message == "" && Provisioned.GetMessage(mgmtCluster) != "") || strings.Contains(message, planner.ETCDRestoreMessage) {
+			mgmtCluster = mgmtCluster.DeepCopy()
+
+			Provisioned.SetStatus(mgmtCluster, Provisioned.GetStatus(cp))
+			Provisioned.Reason(mgmtCluster, Provisioned.GetReason(cp))
+			Provisioned.Message(mgmtCluster, message)
+
+			_, err = h.mgmtClusterClient.Update(mgmtCluster)
+			if err != nil {
+				return status, err
+			}
+		}
+	}
+
 	Provisioned.SetStatus(&status, Provisioned.GetStatus(cp))
 	Provisioned.Reason(&status, Provisioned.GetReason(cp))
 	Provisioned.Message(&status, Provisioned.GetMessage(cp))
+
 	return status, nil
 }

--- a/pkg/provisioningv2/rke2/planner/etcdrestore.go
+++ b/pkg/provisioningv2/rke2/planner/etcdrestore.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
+const ETCDRestoreMessage = "etcd restore"
+
 type etcdRestore struct {
 	controlPlane rkecontroller.RKEControlPlaneClient
 	secrets      corecontrollers.SecretCache
@@ -68,7 +70,7 @@ func (e *etcdRestore) etcdRestore(controlPlane *rkev1.RKEControlPlane, clusterPl
 			if err != nil {
 				return err
 			}
-			return assignAndCheckPlan(e.store, "etcd restore", server, restorePlan, 0)
+			return assignAndCheckPlan(e.store, ETCDRestoreMessage, server, restorePlan, 0)
 		}
 	}
 


### PR DESCRIPTION
When and RKE2/K3S cluster is being restored from a backup, the
management cluster will go into an error state because the healthcheck
fails. While this is expected, it would be better if this did not
happen.

This doesn't happen for RKE1 provisioning because the Provisioned
condition gets set to Unknown. After this change, when and RKE2/K3S
cluster is being restored, the Provisioned condition on the management
cluster is set to Unknown to stop the healthcheck.

The cluster will go into an "Unavailable" state, but, again, this is
expected and will not produce the ugly red error messages in the UI.

Issue:
https://github.com/rancher/rancher/issues/34563