### PR TITLE
Better handling of still running etcd backups

### DIFF
--- a/pkg/controllers/management/etcdbackup/etcdbackup.go
+++ b/pkg/controllers/management/etcdbackup/etcdbackup.go
@@ -486,8 +486,7 @@ func getBackupCompletedTime(o runtime.Object) time.Time {
 }
 
 func getBackupCreatedTime(o runtime.Object) (time.Time, error) {
-	t, err := time.Parse(time.RFC3339, rketypes.BackupConditionCreated.GetLastUpdated(o))
-	return t, err
+	return time.Parse(time.RFC3339, rketypes.BackupConditionCreated.GetLastUpdated(o))
 }
 
 func getExpiredBackups(retention, intervalHours int, backups []*v3.EtcdBackup) []*v3.EtcdBackup {

--- a/pkg/controllers/management/etcdbackup/etcdbackup.go
+++ b/pkg/controllers/management/etcdbackup/etcdbackup.go
@@ -179,7 +179,7 @@ func (c *Controller) doClusterBackupSync(cluster *v3.Cluster) error {
 		for _, clusterBackup := range clusterBackups {
 			// cluster backup is younger than its timeout and completion is unknown
 			// therefore, it's currently running
-			if time.Since(getBackupCreatedTime(clusterBackup)) < clusterTimeout && rketypes.BackupConditionCompleted.IsUnknown(clusterBackup) {
+			if time.Since(getBackupCreatedTime(clusterBackup)) < clusterTimeout && !rketypes.BackupConditionCompleted.IsTrue(clusterBackup) {
 				logrus.Debugf("[etcd-backup] cluster [%s] is currently creating a backup, skipping", cluster.Name)
 				return nil
 			}


### PR DESCRIPTION
TLDR: Adds a check for backups that are currently running.

If a user sets the backup timeout to 10 minutes due to a slow S3-alike or similar, the backup will still be running during the next tick of the check interval. The cluster backup sync function will see that the last **completed** backup was longer than the backup interval (ignoring the one that's currently running) so it'll start a new backup and bulldoze the running one.

My addition basically checks that if since a backup's creation time is less than the backup config's timeout and "completed" is unknown. Then skip until the next iteration.

#34890