### PR TITLE
Allow node config updates to update cluster

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -116,7 +116,7 @@ func toInfraRefKey(ref corev1.ObjectReference, namespace string) string {
 }
 
 func matchRKENodeGroup(gvk schema.GroupVersionKind) bool {
-	return gvk.Group == defaultMachineConfigAPIVersion &&
+	return gvk.GroupVersion().String() == defaultMachineConfigAPIVersion &&
 		strings.HasSuffix(gvk.Kind, "Config")
 }
 


### PR DESCRIPTION
Updating a node config should cause the cluster to be reconciled. Before
this updated, the matcher that was supposed to cause this to happen was
misconfigured: it was comparing a group with a group-version which will
always fail.

In addition, if a cluster is created with all node misconfigured, then
the cluster was unable to be reconciled because the init node would
never become available. Now, the init node is changed if the initially
elected init node failed for some reason.

Finally, deleting machines in a running cluster was buggy because CAPI
will drain the nodes by default. This change will wait to delete the
infrastructure in the provider until the node drain completes or fails.

Issue:
https://github.com/rancher/rancher/issues/34914