### PR TITLE
node labels: update DO image and size

### DIFF
--- a/tests/validation/tests/v3_api/test_node_label.py
+++ b/tests/validation/tests/v3_api/test_node_label.py
@@ -537,8 +537,8 @@ def test_node_label_node_template_edit():
                                       cloudCredentialId=do_cloud_credential.id,
                                       digitaloceanConfig=
                                       {"region": "nyc3",
-                                       "size": "2gb",
-                                       "image": "ubuntu-16-04-x64"})
+                                       "size": "s-2vcpu-2gb-intel",
+                                       "image": "ubuntu-18-04-x64"})
     node_template_new = client.wait_success(node_template_new)
     assert test_label in node_template_new["labels"], \
         "Label is not set on node template"
@@ -593,8 +593,8 @@ def test_node_label_node_template_delete():
                                       cloudCredentialId=do_cloud_credential.id,
                                       digitaloceanConfig=
                                       {"region": "nyc3",
-                                       "size": "2gb",
-                                       "image": "ubuntu-16-04-x64"})
+                                       "size": "s-2vcpu-2gb-intel",
+                                       "image": "ubuntu-18-04-x64"})
     node_template_new = client.wait_success(node_template_new)
     assert test_label not in node_template_new["labels"], \
         "Label is available on the node template"


### PR DESCRIPTION
`test_node_label_node_template_edit` was failing
after investigation turned out when we update a node template we use a non-existent DO image and size 
- we pass `ubuntu-16-04-x64` but DO does not support it anymore 
<img width="2142" alt="tests failed" src="https://user-images.githubusercontent.com/40282141/137611706-93023fcd-ce4f-4543-8684-d590ca349ce1.png">



I updated `test_node_label_node_template_edit` and `test_node_label_node_template_delete` to use the same values we use when we create a node template in `create_node_template_label`
- image: `ubuntu-18-04-x64`
- size: `s-2vcpu-2gb-intel`

both tests pass now 
<img width="626" alt="tests passed" src="https://user-images.githubusercontent.com/40282141/137611632-6e0c543d-88ea-4c23-be4a-27c1828c8f9a.png">


