### PR TITLE
[Backport 2.5] Include labels on global secret create in Cluster Manager for default namespace

### DIFF
--- a/pkg/controllers/managementuser/secret/secret.go
+++ b/pkg/controllers/managementuser/secret/secret.go
@@ -246,12 +246,14 @@ func getNamespacedSecret(obj *corev1.Secret, namespace string) *corev1.Secret {
 	namespacedSecret.Namespace = namespace
 	namespacedSecret.Type = obj.Type
 	namespacedSecret.Annotations = make(map[string]string)
-	copyMap(obj.Annotations, namespacedSecret.Annotations)
+	namespacedSecret.Labels = make(map[string]string)
+	copyMap(namespacedSecret.Annotations, obj.Annotations)
+	copyMap(namespacedSecret.Labels, obj.Labels)
 	namespacedSecret.Annotations[userSecretAnnotation] = "true"
 	return namespacedSecret
 }
 
-func copyMap(src map[string]string, dst map[string]string) {
+func copyMap(dst map[string]string, src map[string]string) {
 	for k, v := range src {
 		dst[k] = v
 	}


### PR DESCRIPTION
Backport from PR [#34923](https://github.com/rancher/rancher/pull/34923)
Issue [#33689 ](https://github.com/rancher/rancher/issues/33689)
Linked backport issue [#35158](https://github.com/rancher/rancher/issues/35158)