### PR TITLE
Update UI and charts tags for v2.6.2-rc1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /var/lib/rancher
 ARG ARCH=amd64
 ARG IMAGE_REPO=rancher
 ARG SYSTEM_CHART_DEFAULT_BRANCH=release-v2.6
-ARG CHART_DEFAULT_BRANCH=release-v2.6
+ARG CHART_DEFAULT_BRANCH=release-v2.6.1
 ARG PARTNER_CHART_DEFAULT_BRANCH=main
 ARG RKE2_CHART_DEFAULT_BRANCH=main
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
@@ -104,8 +104,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry /usr/bin/k3s /usr/bin/kubectl && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-ENV CATTLE_UI_VERSION 2.6.1
-ENV CATTLE_DASHBOARD_UI_VERSION v2.6.1
+ENV CATTLE_UI_VERSION 2.6.2-rc2
+ENV CATTLE_DASHBOARD_UI_VERSION v2.6.2-rc2
 ENV CATTLE_CLI_VERSION v2.4.13
 
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -98,7 +98,7 @@ var (
 	ClusterTemplateEnforcement        = NewSetting("cluster-template-enforcement", "false")
 	InitialDockerRootDir              = NewSetting("initial-docker-root-dir", "/var/lib/docker")
 	SystemCatalog                     = NewSetting("system-catalog", "external") // Options are 'external' or 'bundled'
-	ChartDefaultBranch                = NewSetting("chart-default-branch", "release-v2.6")
+	ChartDefaultBranch                = NewSetting("chart-default-branch", "release-v2.6.1")
 	PartnerChartDefaultBranch         = NewSetting("partner-chart-default-branch", "main")
 	RKE2ChartDefaultBranch            = NewSetting("rke2-chart-default-branch", "main")
 	FleetDefaultWorkspaceName         = NewSetting("fleet-default-workspace-name", "fleet-default") // fleetWorkspaceName to assign to clusters with none

--- a/scripts/package
+++ b/scripts/package
@@ -7,7 +7,7 @@ ARCH=${ARCH:-"amd64"}
 SYSTEM_CHART_REPO_DIR=build/system-charts
 SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"release-v2.6"}
 CHART_REPO_DIR=build/charts
-CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"release-v2.6"}
+CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"release-v2.6.1"}
 
 cd $(dirname $0)/../package
 


### PR DESCRIPTION
Note to reviewers: the UI tags RC number is ahead of the Rancher RC number.