### PR TITLE
[2.6.2 Backport] Fix nil dereference for cluster cleanup

### DIFF
--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -102,6 +102,10 @@ func (c *ClusterLifecycleCleanup) cleanupLocalCluster(obj *v3.Cluster) error {
 	if err != nil {
 		return err
 	}
+	if userContext == nil {
+		logrus.Debugf("could not get context for local cluster, skipping cleanup")
+		return nil
+	}
 
 	err = cleanupNamespaces(userContext.K8sClient)
 	if err != nil {
@@ -132,6 +136,10 @@ func (c *ClusterLifecycleCleanup) cleanupImportedCluster(cluster *v3.Cluster) er
 	userContext, err := c.Manager.UserContextFromCluster(cluster)
 	if err != nil {
 		return err
+	}
+	if userContext == nil {
+		logrus.Debugf("could not get context for imported cluster, skipping cleanup")
+		return nil
 	}
 
 	role, err := c.createCleanupClusterRole(userContext)


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/35145

https://github.com/rancher/rancher/issues/35160