### PR TITLE
[2.6.2 Backport] Unpin SLE BCI and docker version

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/suse/sle15:15.3.17.8.1
+FROM registry.suse.com/suse/sle15:15.3
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
@@ -16,7 +16,7 @@ ENV KUSTOMIZE_VERSION v3.10.0
 ENV CATTLE_KDM_BRANCH=release-v2.6
 
 RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables jq
-RUN zypper install -y -f docker-20.10.6_ce-6.49.3
+RUN zypper install -y -f docker
 
 RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/suse/sle15:15.3.17.8.1
+FROM registry.suse.com/suse/sle15:15.3
 
 RUN zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -2,7 +2,7 @@ ARG RANCHER_TAG=dev
 ARG RANCHER_REPO=rancher
 FROM ${RANCHER_REPO}/rancher:${RANCHER_TAG} as rancher
 
-FROM registry.suse.com/suse/sle15:15.3.17.8.1
+FROM registry.suse.com/suse/sle15:15.3
 ARG ARCH=amd64
 
 ENV KUBECTL_VERSION v1.21.3


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/35157 for 2.6.2