### PR TITLE
[2.5] Fix the problem of handler registration failure caused by inconsistent context

### DIFF
--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -229,7 +229,7 @@ func (m *Manager) doStart(rec *record, clusterOwner bool) (exit error) {
 		defer close(done)
 
 		logrus.Debugf("[clustermanager] creating AccessControl for cluster %v", rec.cluster.ClusterName)
-		rec.accessControl = rbac.NewAccessControl(rec.ctx, rec.cluster.ClusterName, rec.cluster.RBACw)
+		rec.accessControl = rbac.NewAccessControl(transaction, rec.cluster.ClusterName, rec.cluster.RBACw)
 
 		err := rec.cluster.Start(rec.ctx)
 		if err == nil {


### PR DESCRIPTION
In Rancher HA mode, each replica will create an [access control cache](https://github.com/rancher/rancher/blob/release/v2.5/pkg/clustermanager/manager.go#L232) for each downstream cluster no matter it's the clusterOwner or not. In access control cache, we start a [handler](https://github.com/rancher/steve/blob/7224dc21013de5499e17cd065dfccef9400bc077/pkg/accesscontrol/role_revision_index.go#L18) here to handle role revisions change when clusterrole/role changed at the downstream cluster. 

For further investigation, I found some inconsistent context to start the access control cache. 
1. https://github.com/rancher/rancher/blob/release/v2.5/pkg/clustermanager/manager.go#L480
2. https://github.com/rancher/rancher/blob/release/v2.5/pkg/clustermanager/manager.go#L457
3. https://github.com/rancher/rancher/blob/release/v2.5/pkg/clustermanager/manager.go#L95

Sometimes it using context.Background() to new AccessControl, but sometimes it using ctx which inherited from wrangler context(This context is a HandlerTransaction context). When it using context.Background() to create an access control cache, the handler could start correctly, so that some replicas got the correct result. If it using ctx which inherited from wrangler context(ReigsterHandler type), the handler in access control cache will never start.

Then I found the HandlerTransaction context for steve controller. 
- When we called [RegisterHandler](https://github.com/rancher/lasso/blob/master/pkg/controller/sharedcontroller.go#L111) here, if the ctx is HandlerTransaction type, will add handler function to [todo list](https://github.com/rancher/lasso/blob/6c6cd7fd6607e280ef3addec9901a8f4dbb12295/pkg/controller/transaction.go#L27), if not, it will start handler function [directly](https://github.com/rancher/lasso/blob/6c6cd7fd6607e280ef3addec9901a8f4dbb12295/pkg/controller/transaction.go#L20).
- If the ctx is HandlerTransaction type, we can call [Commit](https://github.com/rancher/lasso/blob/6c6cd7fd6607e280ef3addec9901a8f4dbb12295/pkg/controller/transaction.go#L37) function to start all handlers here.

So if it using ctx which inherited from wrangler context and has already called Commit function when rancher started, all handlers register after that will never start.

We create a new [HandlerTransaction](https://github.com/rancher/rancher/blob/08ad9f793a2345478a26a514fca021c8e648f2f3/pkg/clustermanager/manager.go#L214) here to start cluster controllers but not using this transaction to create access control. I think it's better to use the same context to register handlers to make sure all handlers can be started consistently.

https://github.com/rancher/rancher/issues/31982