### PR TITLE
Update controller names to be unique

### DIFF
--- a/pkg/controllers/dashboard/helm/apps.go
+++ b/pkg/controllers/dashboard/helm/apps.go
@@ -44,8 +44,8 @@ func RegisterApps(ctx context.Context,
 		secretCache:         secrets.Cache(),
 		configMapCache:      configMap.Cache(),
 	}
-	configMap.OnChange(ctx, "helm-app", r.OnConfigMapChange)
-	secrets.OnChange(ctx, "helm-app", r.OnSecretChange)
+	configMap.OnChange(ctx, "helm-app-configmap", r.OnConfigMapChange)
+	secrets.OnChange(ctx, "helm-app-secret", r.OnSecretChange)
 	catalogv1.RegisterAppStatusHandler(ctx, apps, "", "helm-app-status", r.appStatus)
 	relatedresource.Watch(ctx, "helm-app",
 		relatedresource.OwnerResolver(true, "v1", "ConfigMap"),

--- a/pkg/controllers/provisioningv2/fleetworkspace/controller.go
+++ b/pkg/controllers/provisioningv2/fleetworkspace/controller.go
@@ -50,14 +50,14 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 			AllowClusterScoped: true,
 		})
 
-	clients.Fleet.Cluster().OnChange(ctx, "workspace-backport",
+	clients.Fleet.Cluster().OnChange(ctx, "workspace-backport-cluster",
 		func(s string, obj *fleet.Cluster) (*fleet.Cluster, error) {
 			if obj == nil {
 				return nil, nil
 			}
 			return obj, h.onFleetObject(obj)
 		})
-	clients.Fleet.Bundle().OnChange(ctx, "workspace-backport",
+	clients.Fleet.Bundle().OnChange(ctx, "workspace-backport-bundle",
 		func(s string, obj *fleet.Bundle) (*fleet.Bundle, error) {
 			if obj == nil {
 				return nil, nil

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -56,7 +56,7 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 		h.dynamicSchema = clients.Mgmt.DynamicSchema().Cache()
 	}
 
-	clients.Dynamic.OnChange(ctx, "rke", matchRKENodeGroup, h.infraWatch)
+	clients.Dynamic.OnChange(ctx, "rke-dynamic", matchRKENodeGroup, h.infraWatch)
 	clients.Provisioning.Cluster().Cache().AddIndexer(byNodeInfra, byNodeInfraIndex)
 
 	rocontrollers.RegisterClusterGeneratingHandler(ctx,

--- a/pkg/controllers/provisioningv2/rke2/rkecluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/rkecluster/controller.go
@@ -27,7 +27,7 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 		rkeControlPlanes: clients.RKE.RKEControlPlane().Cache(),
 	}
 
-	clients.RKE.RKECluster().OnChange(ctx, "rke", h.UpdateSpec)
+	clients.RKE.RKECluster().OnChange(ctx, "rke-cluster", h.UpdateSpec)
 	rkecontroller.RegisterRKEClusterStatusHandler(ctx,
 		clients.RKE.RKECluster(),
 		"Defined",

--- a/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
@@ -55,7 +55,7 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 	clients.RKE.CustomMachine().OnChange(ctx, "unmanaged-machine", h.onUnmanagedMachineHealth)
 	clients.RKE.CustomMachine().OnRemove(ctx, "unmanaged-machine", h.onUnmanagedMachineOnRemove)
 	clients.RKE.CustomMachine().OnChange(ctx, "unmanaged-health", h.onUnmanagedMachineChange)
-	clients.Core.Secret().OnChange(ctx, "unmanaged-machine", h.onSecretChange)
+	clients.Core.Secret().OnChange(ctx, "unmanaged-machine-secret", h.onSecretChange)
 }
 
 type handler struct {


### PR DESCRIPTION
Problem:
Some controllers have the same name, this makes following controller
execution and troubleshooting harder in both logs and metrics

Solution:
Update controller names to be unique