### PR TITLE
Add a dualstack-capable QA image

### DIFF
--- a/tests/validation/tests/Dockerfiles/testcontainer/Dockerfile
+++ b/tests/validation/tests/Dockerfiles/testcontainer/Dockerfile
@@ -1,5 +1,4 @@
 FROM nginx
-MAINTAINER Sangeetha Hariharan "https://github.com/sangeethah"
 
 RUN apt-get update
 
@@ -12,6 +11,8 @@ RUN apt-get install -y iputils-ping
 COPY ./run.sh /scripts/run.sh
 RUN chmod 777 /scripts/run.sh
 
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+RUN chmod 644 /etc/nginx/conf.d/default.conf
 
 ENTRYPOINT [ "/scripts/run.sh" ]
 CMD ["nginx", "-g", "daemon off;"]

--- a/tests/validation/tests/Dockerfiles/testcontainer/nginx.conf
+++ b/tests/validation/tests/Dockerfiles/testcontainer/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/tests/validation/tests/Dockerfiles/unprivileged-testcontainer/Dockerfile
+++ b/tests/validation/tests/Dockerfiles/unprivileged-testcontainer/Dockerfile
@@ -1,5 +1,4 @@
 FROM nginxinc/nginx-unprivileged as base
-MAINTAINER Max Ross https://github.com/rancher-max
 
 USER root
 RUN apt-get update
@@ -13,6 +12,9 @@ RUN apt-get install -y iputils-ping
 COPY ./run.sh /scripts/run.sh
 RUN chmod 777 /scripts/run.sh
 RUN chmod 777 /usr/share/nginx/html
+
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+RUN chmod 644 /etc/nginx/conf.d/default.conf
 
 USER 101
 

--- a/tests/validation/tests/Dockerfiles/unprivileged-testcontainer/nginx.conf
+++ b/tests/validation/tests/Dockerfiles/unprivileged-testcontainer/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
This should be built as `ranchertest/mytestcontainer:dualstack`

It can be validated for now using `maxross/mytestcontainer:dualstack`. I ran this in a dualstack capable cluster by deploying a hostport (8081) workload, then curling the ipv6 address like `curl [<redacted>]:8081/name.html`, which was successful. 

The only change between this and our main `ranchertest/mytestcontainer` image is that this specifics `listen [::]:80;` in the nginx.conf server.


Edit: This is now intended as an enhancement to both `ranchertest/mytestcontainer` and `ranchertest/mytestcontainer:unprivileged`. Those images should be retagged and pushed with these changes, and should now be valid when used with only ipv4 or with ipv4+ipv6 dualstack.

Closes: https://github.com/rancher/qa-tasks/issues/144