### PR TITLE
Apps migration

### DIFF
--- a/pkg/catalogv2/helmop/operation_test.go
+++ b/pkg/catalogv2/helmop/operation_test.go
@@ -1,0 +1,112 @@
+package helmop
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testCase struct {
+	commands Commands
+	expected map[string][]byte
+	failMsg  string
+}
+
+func Test_Render(t *testing.T) {
+	asserts := assert.New(t)
+
+	testCases := []testCase{
+		{
+			commands: Commands{
+				Command{
+					Operation: "upgrade",
+					ChartFile:  "test-chart-v1.1.0.tgz",
+					Chart:      []byte("test-chart"),
+					Kustomize:  true,
+					ReleaseName: "test1",
+				},
+			},
+			expected: map[string][]byte{
+				"operation000": []byte(strings.Join([]string{"upgrade", "--post-renderer=/home/shell/kustomize.sh", "test1", "/home/shell/helm-run/test-chart-v1.1.0.tgz"}, "\x00")),
+				"kustomization000.yaml": []byte(fmt.Sprintf(kustomization, "000")),
+				"transform000.yaml": []byte(fmt.Sprintf(transform, "test1")),
+				"test-chart-v1.1.0.tgz": []byte("test-chart"),
+			},
+			failMsg: "kustomize enabled test case failed",
+		},
+		{
+			commands: Commands{
+				Command{
+					Operation: "upgrade",
+					ValuesFile: "values-test-chart-v1.1.0.yaml",
+					Values: []byte("{\"a\":\"a\"}"),
+					ChartFile:  "test-chart-v1.1.0.tgz",
+					Chart:      []byte("test-chart"),
+					Kustomize:  false,
+					ReleaseName: "test2",
+				},
+			},
+			expected: map[string][]byte{
+				"operation000": []byte(strings.Join([]string{"upgrade", "--values=/home/shell/helm/values-test-chart-v1.1.0.yaml", "test2", "/home/shell/helm/test-chart-v1.1.0.tgz"}, "\x00")),
+				"test-chart-v1.1.0.tgz": []byte("test-chart"),
+				"values-test-chart-v1.1.0.yaml": []byte("{\"a\":\"a\"}"),
+			},
+			failMsg: "values yaml test case failed",
+		},
+		{
+			commands: Commands{
+				Command{
+					Operation: "upgrade",
+					ChartFile:  "test-chart-v1.1.0.tgz",
+					Chart:      []byte("test-chart"),
+					Kustomize:  false,
+					ReleaseName: "test3",
+				},
+			},
+			expected: map[string][]byte{
+				"operation000": []byte(strings.Join([]string{"upgrade", "test3", "/home/shell/helm/test-chart-v1.1.0.tgz"}, "\x00")),
+				"test-chart-v1.1.0.tgz": []byte("test-chart"),
+			},
+			failMsg: "default test case failed",
+		},
+		{
+			commands: Commands{
+				Command{
+					Operation: "install",
+					ChartFile:  "test-chart-v1.1.0.tgz",
+					Chart:      []byte("test-chart"),
+					Kustomize:  false,
+					ReleaseName: "test4",
+				},
+			},
+			expected: map[string][]byte{
+				"operation000": []byte(strings.Join([]string{"install", "test4", "/home/shell/helm/test-chart-v1.1.0.tgz"}, "\x00")),
+				"test-chart-v1.1.0.tgz": []byte("test-chart"),
+			},
+			failMsg: "install test case failed",
+		},
+		{
+			commands: Commands{
+				Command{
+					Operation: "uninstall",
+					ChartFile:  "test-chart-v1.1.0.tgz",
+					Chart:      []byte("test-chart"),
+					Kustomize:  false,
+					ReleaseName: "test5",
+				},
+			},
+			expected: map[string][]byte{
+				"operation000": []byte(strings.Join([]string{"uninstall", "test5", "/home/shell/helm/test-chart-v1.1.0.tgz"}, "\x00")),
+				"test-chart-v1.1.0.tgz": []byte("test-chart"),
+			},
+			failMsg: "uninstall test case failed",
+		},
+	}
+	for _, testCase := range testCases {
+		actual, err := testCase.commands.Render()
+		asserts.Nil(err, "error encountered: %v", err)
+		asserts.Equal(testCase.expected, actual, testCase.failMsg)
+	}
+}

--- a/pkg/controllers/managementuserlegacy/helm/common/common.go
+++ b/pkg/controllers/managementuserlegacy/helm/common/common.go
@@ -368,7 +368,7 @@ func createKustomizeFiles(tempDirs *HelmPath, labelValue string) error {
 	// the file to the "injail" location
 	if os.Getenv("CATTLE_DEV_MODE") != "" {
 		kpath = filepath.Join(tempDirs.InJailPath, "/kustomize.sh")
-		err = os.Link("./package/kustomize.sh", kpath)
+		err = os.Link("./kustomize.sh", kpath)
 		if err != nil {
 			err = os.Link(filepath.Join(os.Getenv("DAPPER_SOURCE"), "package/kustomize.sh"), kpath)
 			if err != nil {

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -104,7 +104,7 @@ var (
 	PartnerChartDefaultBranch         = NewSetting("partner-chart-default-branch", "main")
 	RKE2ChartDefaultBranch            = NewSetting("rke2-chart-default-branch", "main")
 	FleetDefaultWorkspaceName         = NewSetting("fleet-default-workspace-name", fleetconst.ClustersDefaultNamespace) // fleetWorkspaceName to assign to clusters with none
-	ShellImage                        = NewSetting("shell-image", "rancher/shell:v0.1.10")
+	ShellImage                        = NewSetting("shell-image", "rancher/shell:v0.1.13")
 	IgnoreNodeName                    = NewSetting("ignore-node-name", "") // nodes to ignore when syncing v1.node to v3.node
 	NoDefaultAdmin                    = NewSetting("no-default-admin", "")
 	RestrictedDefaultAdmin            = NewSetting("restricted-default-admin", "false") // When bootstrapping the admin for the first time, give them the global role restricted-admin


### PR DESCRIPTION
**Problem:**
Customers want to be able to migrate apps.project to dashboard apps (apps.catalog). This is blocked by two issues:
Helm3 apps that were installed by creating an app.project may
have had some of their resources changed with kustomize. Some
of these changes were to matchLabel selectors which are
immutable. This caused any updates to a migrated app to
result in an error because the manifests that were
being applied would try to remove the matchLabels, which
cannot be changed.

Need to be able to delete outdated apps (apps.project) without uninstalling resources.

**Solution:**
Now, migrated apps will continue using
kustomize to make the same changes to the manifests as
before.

Add annotation that skips helm uninstall. Revisions will still
be deleted and app will be removed from namespace's app
annotation. This is instended to be used as part of the
upgrade process from apps.project to apps.catalog.

**Depends on(merge first):**
https://github.com/rancher/shell/pull/16

**Issues:**
https://github.com/rancher/rancher/issues/34700
https://github.com/rancher/rancher/issues/34701