### PR TITLE
change the kubeVersion in Chart.yaml to allow Rancher to be installed into k8s 1.22 cluster

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: rancher
 description: Install Rancher Server to manage Kubernetes clusters across providers.
 version: %VERSION%
 appVersion: %APP_VERSION%
-kubeVersion: < 1.22.0-0
+kubeVersion: < 1.23.0-0
 home: https://rancher.com
 icon: https://github.com/rancher/ui/blob/master/public/assets/images/logos/welcome-cow.svg
 keywords:


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/34058

lift the `kubeVersion` in Chart.yaml to allow Rancher to be installed into k8s 1.22 cluster

Dependent:
- https://github.com/rancher/rancher/pull/35117