### PR TITLE
fixed bad query parameter for saml error messages

### DIFF
--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -331,7 +331,7 @@ func (s *Provider) HandleSamlAssertion(w http.ResponseWriter, r *http.Request, a
 			http.Redirect(w, r, redirectURL+"errorCode=500", http.StatusFound)
 			return
 		} else if err != nil && user != nil {
-			http.Redirect(w, r, redirectURL+"errorCode=422&errMsg="+err.Error(), http.StatusFound)
+			http.Redirect(w, r, redirectURL+"errorCode=422&errorMsg="+err.Error(), http.StatusFound)
 			return
 		}
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/13666#issuecomment-946110511
https://github.com/rancher/rancher/issues/13666

# Problem
when using test an apply on saml based auth providers the login window would not display a meaningful error message for user principal conflicts

# Solution
fixed the redirect query parameter.