### PR TITLE
Add agent args to environment for instruction

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagent.go
+++ b/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagent.go
@@ -165,6 +165,9 @@ func installer(envs []rkev1.EnvVar, allWorkers bool, secretName, generation stri
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "system-agent-upgrader",
 			Namespace: namespaces.System,
+			Annotations: map[string]string{
+				"upgrade.cattle.io/digest": "spec.upgrade.envs",
+			},
 		},
 		Spec: upgradev1.PlanSpec{
 			Concurrency: 10,

--- a/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
+++ b/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
@@ -25,7 +25,7 @@ func (h *handler) OnChangeInstallSUC(cluster *rancherv1.Cluster, status rancherv
 			DefaultNamespace: namespaces.System,
 			RepoName:         "rancher-charts",
 			Chart:            "system-upgrade-controller",
-			Version:          "100.0.0",
+			Version:          "100.0.1",
 			Values: &v1alpha1.GenericMap{
 				Data: map[string]interface{}{
 					"global": map[string]interface{}{

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -817,13 +817,19 @@ func restartStamp(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, i
 func (p *Planner) addInstruction(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, machine *capi.Machine) (plan.NodePlan, error) {
 	image := getInstallerImage(controlPlane)
 
+	agentArgs := make([]string, 0, len(controlPlane.Spec.AgentEnvVars))
+	for _, arg := range controlPlane.Spec.AgentEnvVars {
+		if arg.Value == "" {
+			continue
+		}
+		agentArgs = append(agentArgs, fmt.Sprintf("%s=%s", arg.Name, arg.Value))
+	}
+
 	instruction := plan.Instruction{
 		Image:   image,
 		Command: "sh",
 		Args:    []string{"-c", "run.sh"},
-		Env: []string{
-			fmt.Sprintf("RESTART_STAMP=%s", restartStamp(nodePlan, controlPlane, image)),
-		},
+		Env:     append(agentArgs, fmt.Sprintf("RESTART_STAMP=%s", restartStamp(nodePlan, controlPlane, image))),
 	}
 
 	if isOnlyWorker(machine) {


### PR DESCRIPTION
When passing the system-agent-install instruction to the machine, none
of the agent arguments were being added to the environment. This made it
impossible to use the agent args to pass things like the PROXY
environment variables to the system-agent-installer.

After this change, the agent args are passed to the environment for the
system-agent-installer and it will pull out RKE2_ and _PROXY environment
variables.

This also includes a bump of the system-upgrade-controller that handles
environment variables for upgrades.

Issues:
https://github.com/rancher/rancher/issues/32633
https://github.com/rancher/rancher/issues/34908

This is the same PR as the reverted PR https://github.com/rancher/rancher/pull/34922 except that this PR also bumps the version of system-upgrade-controller