### PR TITLE
Copy tls-ca-additional secret to fleet-default ns

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
@@ -164,7 +164,7 @@ func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, 
 							Name: "tls-ca-additional-volume",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName:  "tls-ca-additional-volume",
+									SecretName:  "tls-ca-additional",
 									DefaultMode: &[]int32{0444}[0],
 									Optional:    &[]bool{true}[0],
 								},

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -250,7 +250,11 @@ func (r *Rancher) Start(ctx context.Context) error {
 			return err
 		}
 
-		return forceSystemAndDefaultProjectCreation(r.Wrangler.Core.ConfigMap(), r.Wrangler.Mgmt.Cluster())
+		if err := forceSystemAndDefaultProjectCreation(r.Wrangler.Core.ConfigMap(), r.Wrangler.Mgmt.Cluster()); err != nil {
+			return err
+		}
+
+		return copyCAAdditionalSecret(r.Wrangler.Core.Secret())
 	})
 
 	if err := r.authServer.Start(ctx, false); err != nil {


### PR DESCRIPTION
When Rancher is behind a proxy with a certificate, a tls-ca-additional
secret should be created by the user in the cattle-system namespace.
However, the machine provisioning job (for both creation and deletion)
needs this secret as well. Since this job runs in the fleet-default
namespace, the secret must also exists in this namespace.

This change will look for such a secret in the cattle-system namespace
and copy it to the fleet-default namespace on startup.

Issue:
https://github.com/rancher/rancher/issues/33919