### PR TITLE
Capi machine clients

### DIFF
--- a/pkg/api/steve/machine/download.go
+++ b/pkg/api/steve/machine/download.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"archive/zip"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -24,6 +25,13 @@ func (s *sshClient) download(apiContext *types.APIRequest) error {
 		return err
 	}
 	if err := addFile(zw, name+"/id_rsa.pub", machineInfo.IDRSAPub); err != nil {
+		return err
+	}
+	machineConfigBytes, err := json.Marshal(machineInfo.Driver)
+	if err != nil {
+		return err
+	}
+	if err := addFile(zw, name+"/config.json", machineConfigBytes); err != nil {
 		return err
 	}
 	if err := zw.Close(); err != nil {

--- a/pkg/client/generated/cluster/v1alpha4/zz_generated_bootstrap.go
+++ b/pkg/client/generated/cluster/v1alpha4/zz_generated_bootstrap.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	BootstrapType                = "bootstrap"
+	BootstrapFieldConfigRef      = "configRef"
+	BootstrapFieldDataSecretName = "dataSecretName"
+)
+
+type Bootstrap struct {
+	ConfigRef      *ObjectReference `json:"configRef,omitempty" yaml:"configRef,omitempty"`
+	DataSecretName string           `json:"dataSecretName,omitempty" yaml:"dataSecretName,omitempty"`
+}

--- a/pkg/client/generated/cluster/v1alpha4/zz_generated_client.go
+++ b/pkg/client/generated/cluster/v1alpha4/zz_generated_client.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"github.com/rancher/norman/clientbase"
+)
+
+type Client struct {
+	clientbase.APIBaseClient
+
+	Machine MachineOperations
+}
+
+func NewClient(opts *clientbase.ClientOpts) (*Client, error) {
+	baseClient, err := clientbase.NewAPIClient(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &Client{
+		APIBaseClient: baseClient,
+	}
+
+	client.Machine = newMachineClient(client)
+
+	return client, nil
+}

--- a/pkg/client/generated/cluster/v1alpha4/zz_generated_condition.go
+++ b/pkg/client/generated/cluster/v1alpha4/zz_generated_condition.go
@@ -1,0 +1,20 @@
+package client
+
+const (
+	ConditionType                    = "condition"
+	ConditionFieldLastTransitionTime = "lastTransitionTime"
+	ConditionFieldMessage            = "message"
+	ConditionFieldReason             = "reason"
+	ConditionFieldSeverity           = "severity"
+	ConditionFieldStatus             = "status"
+	ConditionFieldType               = "type"
+)
+
+type Condition struct {
+	LastTransitionTime string `json:"lastTransitionTime,omitempty" yaml:"lastTransitionTime,omitempty"`
+	Message            string `json:"message,omitempty" yaml:"message,omitempty"`
+	Reason             string `json:"reason,omitempty" yaml:"reason,omitempty"`
+	Severity           string `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Status             string `json:"status,omitempty" yaml:"status,omitempty"`
+	Type               string `json:"type,omitempty" yaml:"type,omitempty"`
+}

--- a/pkg/client/generated/cluster/v1alpha4/zz_generated_duration.go
+++ b/pkg/client/generated/cluster/v1alpha4/zz_generated_duration.go
@@ -1,0 +1,8 @@
+package client
+
+const (
+	DurationType = "duration"
+)
+
+type Duration struct {
+}

--- a/pkg/client/generated/cluster/v1alpha4/zz_generated_machine.go
+++ b/pkg/client/generated/cluster/v1alpha4/zz_generated_machine.go
@@ -1,0 +1,140 @@
+package client
+
+import (
+	"github.com/rancher/norman/types"
+)
+
+const (
+	MachineType                      = "machine"
+	MachineFieldAnnotations          = "annotations"
+	MachineFieldBootstrap            = "bootstrap"
+	MachineFieldClusterName          = "clusterName"
+	MachineFieldCreated              = "created"
+	MachineFieldCreatorID            = "creatorId"
+	MachineFieldFailureDomain        = "failureDomain"
+	MachineFieldInfrastructureRef    = "infrastructureRef"
+	MachineFieldLabels               = "labels"
+	MachineFieldName                 = "name"
+	MachineFieldNodeDrainTimeout     = "nodeDrainTimeout"
+	MachineFieldOwnerReferences      = "ownerReferences"
+	MachineFieldProviderID           = "providerID"
+	MachineFieldRemoved              = "removed"
+	MachineFieldState                = "state"
+	MachineFieldStatus               = "status"
+	MachineFieldTransitioning        = "transitioning"
+	MachineFieldTransitioningMessage = "transitioningMessage"
+	MachineFieldUUID                 = "uuid"
+	MachineFieldVersion              = "version"
+)
+
+type Machine struct {
+	types.Resource
+	Annotations          map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Bootstrap            *Bootstrap        `json:"bootstrap,omitempty" yaml:"bootstrap,omitempty"`
+	ClusterName          string            `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
+	Created              string            `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID            string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	FailureDomain        string            `json:"failureDomain,omitempty" yaml:"failureDomain,omitempty"`
+	InfrastructureRef    *ObjectReference  `json:"infrastructureRef,omitempty" yaml:"infrastructureRef,omitempty"`
+	Labels               map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name                 string            `json:"name,omitempty" yaml:"name,omitempty"`
+	NodeDrainTimeout     *Duration         `json:"nodeDrainTimeout,omitempty" yaml:"nodeDrainTimeout,omitempty"`
+	OwnerReferences      []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	ProviderID           string            `json:"providerID,omitempty" yaml:"providerID,omitempty"`
+	Removed              string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	State                string            `json:"state,omitempty" yaml:"state,omitempty"`
+	Status               *MachineStatus    `json:"status,omitempty" yaml:"status,omitempty"`
+	Transitioning        string            `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+	TransitioningMessage string            `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
+	UUID                 string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Version              string            `json:"version,omitempty" yaml:"version,omitempty"`
+}
+
+type MachineCollection struct {
+	types.Collection
+	Data   []Machine `json:"data,omitempty"`
+	client *MachineClient
+}
+
+type MachineClient struct {
+	apiClient *Client
+}
+
+type MachineOperations interface {
+	List(opts *types.ListOpts) (*MachineCollection, error)
+	ListAll(opts *types.ListOpts) (*MachineCollection, error)
+	Create(opts *Machine) (*Machine, error)
+	Update(existing *Machine, updates interface{}) (*Machine, error)
+	Replace(existing *Machine) (*Machine, error)
+	ByID(id string) (*Machine, error)
+	Delete(container *Machine) error
+}
+
+func newMachineClient(apiClient *Client) *MachineClient {
+	return &MachineClient{
+		apiClient: apiClient,
+	}
+}
+
+func (c *MachineClient) Create(container *Machine) (*Machine, error) {
+	resp := &Machine{}
+	err := c.apiClient.Ops.DoCreate(MachineType, container, resp)
+	return resp, err
+}
+
+func (c *MachineClient) Update(existing *Machine, updates interface{}) (*Machine, error) {
+	resp := &Machine{}
+	err := c.apiClient.Ops.DoUpdate(MachineType, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *MachineClient) Replace(obj *Machine) (*Machine, error) {
+	resp := &Machine{}
+	err := c.apiClient.Ops.DoReplace(MachineType, &obj.Resource, obj, resp)
+	return resp, err
+}
+
+func (c *MachineClient) List(opts *types.ListOpts) (*MachineCollection, error) {
+	resp := &MachineCollection{}
+	err := c.apiClient.Ops.DoList(MachineType, opts, resp)
+	resp.client = c
+	return resp, err
+}
+
+func (c *MachineClient) ListAll(opts *types.ListOpts) (*MachineCollection, error) {
+	resp := &MachineCollection{}
+	resp, err := c.List(opts)
+	if err != nil {
+		return resp, err
+	}
+	data := resp.Data
+	for next, err := resp.Next(); next != nil && err == nil; next, err = next.Next() {
+		data = append(data, next.Data...)
+		resp = next
+		resp.Data = data
+	}
+	if err != nil {
+		return resp, err
+	}
+	return resp, err
+}
+
+func (cc *MachineCollection) Next() (*MachineCollection, error) {
+	if cc != nil && cc.Pagination != nil && cc.Pagination.Next != "" {
+		resp := &MachineCollection{}
+		err := cc.client.apiClient.Ops.DoNext(cc.Pagination.Next, resp)
+		resp.client = cc.client
+		return resp, err
+	}
+	return nil, nil
+}
+
+func (c *MachineClient) ByID(id string) (*Machine, error) {
+	resp := &Machine{}
+	err := c.apiClient.Ops.DoByID(MachineType, id, resp)
+	return resp, err
+}
+
+func (c *MachineClient) Delete(container *Machine) error {
+	return c.apiClient.Ops.DoResourceDelete(MachineType, &container.Resource)
+}

--- a/pkg/client/generated/cluster/v1alpha4/zz_generated_machine_address.go
+++ b/pkg/client/generated/cluster/v1alpha4/zz_generated_machine_address.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	MachineAddressType         = "machineAddress"
+	MachineAddressFieldAddress = "address"
+	MachineAddressFieldType    = "type"
+)
+
+type MachineAddress struct {
+	Address string `json:"address,omitempty" yaml:"address,omitempty"`
+	Type    string `json:"type,omitempty" yaml:"type,omitempty"`
+}

--- a/pkg/client/generated/cluster/v1alpha4/zz_generated_machine_spec.go
+++ b/pkg/client/generated/cluster/v1alpha4/zz_generated_machine_spec.go
@@ -1,0 +1,22 @@
+package client
+
+const (
+	MachineSpecType                   = "machineSpec"
+	MachineSpecFieldBootstrap         = "bootstrap"
+	MachineSpecFieldClusterName       = "clusterName"
+	MachineSpecFieldFailureDomain     = "failureDomain"
+	MachineSpecFieldInfrastructureRef = "infrastructureRef"
+	MachineSpecFieldNodeDrainTimeout  = "nodeDrainTimeout"
+	MachineSpecFieldProviderID        = "providerID"
+	MachineSpecFieldVersion           = "version"
+)
+
+type MachineSpec struct {
+	Bootstrap         *Bootstrap       `json:"bootstrap,omitempty" yaml:"bootstrap,omitempty"`
+	ClusterName       string           `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
+	FailureDomain     string           `json:"failureDomain,omitempty" yaml:"failureDomain,omitempty"`
+	InfrastructureRef *ObjectReference `json:"infrastructureRef,omitempty" yaml:"infrastructureRef,omitempty"`
+	NodeDrainTimeout  *Duration        `json:"nodeDrainTimeout,omitempty" yaml:"nodeDrainTimeout,omitempty"`
+	ProviderID        string           `json:"providerID,omitempty" yaml:"providerID,omitempty"`
+	Version           string           `json:"version,omitempty" yaml:"version,omitempty"`
+}

--- a/pkg/client/generated/cluster/v1alpha4/zz_generated_machine_status.go
+++ b/pkg/client/generated/cluster/v1alpha4/zz_generated_machine_status.go
@@ -1,0 +1,30 @@
+package client
+
+const (
+	MachineStatusType                     = "machineStatus"
+	MachineStatusFieldAddresses           = "addresses"
+	MachineStatusFieldBootstrapReady      = "bootstrapReady"
+	MachineStatusFieldConditions          = "conditions"
+	MachineStatusFieldFailureMessage      = "failureMessage"
+	MachineStatusFieldFailureReason       = "failureReason"
+	MachineStatusFieldInfrastructureReady = "infrastructureReady"
+	MachineStatusFieldLastUpdated         = "lastUpdated"
+	MachineStatusFieldNodeRef             = "nodeRef"
+	MachineStatusFieldObservedGeneration  = "observedGeneration"
+	MachineStatusFieldPhase               = "phase"
+	MachineStatusFieldVersion             = "version"
+)
+
+type MachineStatus struct {
+	Addresses           []MachineAddress `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+	BootstrapReady      bool             `json:"bootstrapReady,omitempty" yaml:"bootstrapReady,omitempty"`
+	Conditions          []Condition      `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	FailureMessage      string           `json:"failureMessage,omitempty" yaml:"failureMessage,omitempty"`
+	FailureReason       string           `json:"failureReason,omitempty" yaml:"failureReason,omitempty"`
+	InfrastructureReady bool             `json:"infrastructureReady,omitempty" yaml:"infrastructureReady,omitempty"`
+	LastUpdated         string           `json:"lastUpdated,omitempty" yaml:"lastUpdated,omitempty"`
+	NodeRef             *ObjectReference `json:"nodeRef,omitempty" yaml:"nodeRef,omitempty"`
+	ObservedGeneration  int64            `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
+	Phase               string           `json:"phase,omitempty" yaml:"phase,omitempty"`
+	Version             string           `json:"version,omitempty" yaml:"version,omitempty"`
+}

--- a/pkg/client/generated/cluster/v1alpha4/zz_generated_object_meta.go
+++ b/pkg/client/generated/cluster/v1alpha4/zz_generated_object_meta.go
@@ -1,0 +1,28 @@
+package client
+
+const (
+	ObjectMetaType                 = "objectMeta"
+	ObjectMetaFieldAnnotations     = "annotations"
+	ObjectMetaFieldCreated         = "created"
+	ObjectMetaFieldFinalizers      = "finalizers"
+	ObjectMetaFieldLabels          = "labels"
+	ObjectMetaFieldName            = "name"
+	ObjectMetaFieldNamespace       = "namespace"
+	ObjectMetaFieldOwnerReferences = "ownerReferences"
+	ObjectMetaFieldRemoved         = "removed"
+	ObjectMetaFieldSelfLink        = "selfLink"
+	ObjectMetaFieldUUID            = "uuid"
+)
+
+type ObjectMeta struct {
+	Annotations     map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Created         string            `json:"created,omitempty" yaml:"created,omitempty"`
+	Finalizers      []string          `json:"finalizers,omitempty" yaml:"finalizers,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name            string            `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace       string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	OwnerReferences []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Removed         string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	SelfLink        string            `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
+	UUID            string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}

--- a/pkg/client/generated/cluster/v1alpha4/zz_generated_object_reference.go
+++ b/pkg/client/generated/cluster/v1alpha4/zz_generated_object_reference.go
@@ -1,0 +1,22 @@
+package client
+
+const (
+	ObjectReferenceType                 = "objectReference"
+	ObjectReferenceFieldAPIVersion      = "apiVersion"
+	ObjectReferenceFieldFieldPath       = "fieldPath"
+	ObjectReferenceFieldKind            = "kind"
+	ObjectReferenceFieldName            = "name"
+	ObjectReferenceFieldNamespace       = "namespace"
+	ObjectReferenceFieldResourceVersion = "resourceVersion"
+	ObjectReferenceFieldUID             = "uid"
+)
+
+type ObjectReference struct {
+	APIVersion      string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	FieldPath       string `json:"fieldPath,omitempty" yaml:"fieldPath,omitempty"`
+	Kind            string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Name            string `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace       string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	ResourceVersion string `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
+	UID             string `json:"uid,omitempty" yaml:"uid,omitempty"`
+}

--- a/pkg/client/generated/cluster/v1alpha4/zz_generated_owner_reference.go
+++ b/pkg/client/generated/cluster/v1alpha4/zz_generated_owner_reference.go
@@ -1,0 +1,20 @@
+package client
+
+const (
+	OwnerReferenceType                    = "ownerReference"
+	OwnerReferenceFieldAPIVersion         = "apiVersion"
+	OwnerReferenceFieldBlockOwnerDeletion = "blockOwnerDeletion"
+	OwnerReferenceFieldController         = "controller"
+	OwnerReferenceFieldKind               = "kind"
+	OwnerReferenceFieldName               = "name"
+	OwnerReferenceFieldUID                = "uid"
+)
+
+type OwnerReference struct {
+	APIVersion         string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	BlockOwnerDeletion *bool  `json:"blockOwnerDeletion,omitempty" yaml:"blockOwnerDeletion,omitempty"`
+	Controller         *bool  `json:"controller,omitempty" yaml:"controller,omitempty"`
+	Kind               string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Name               string `json:"name,omitempty" yaml:"name,omitempty"`
+	UID                string `json:"uid,omitempty" yaml:"uid,omitempty"`
+}

--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -7,9 +7,11 @@ import (
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/rancher/norman/types"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/codegen/generator"
 	clusterSchema "github.com/rancher/rancher/pkg/schemas/cluster.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/schemas/factory"
 	managementSchema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
 	publicSchema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3public"
 	projectSchema "github.com/rancher/rancher/pkg/schemas/project.cattle.io/v3"
@@ -114,6 +116,11 @@ func main() {
 			},
 		},
 	})
+
+	clusterAPIVersion := &types.APIVersion{Group: capi.GroupVersion.Group, Version: capi.GroupVersion.Version, Path: "/v1"}
+	generator.GenerateClient(factory.Schemas(clusterAPIVersion).Init(func(schemas *types.Schemas) *types.Schemas {
+		return schemas.MustImport(clusterAPIVersion, capi.Machine{})
+	}), nil)
 
 	generator.GenerateComposeType(projectSchema.Schemas, managementSchema.Schemas, clusterSchema.Schemas)
 	generator.Generate(managementSchema.Schemas, map[string]bool{

--- a/pkg/controllers/management/clusterprovisioner/store.go
+++ b/pkg/controllers/management/clusterprovisioner/store.go
@@ -14,7 +14,7 @@ const (
 )
 
 func NewPersistentStore(namespaces v1.NamespaceInterface, secretsGetter v1.SecretsGetter) cluster.PersistentStore {
-	store, err := encryptedstore.NewGenericEncrypedStore("c-", "", namespaces, secretsGetter)
+	store, err := encryptedstore.NewGenericEncryptedStore("c-", "", namespaces, secretsGetter)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/pkg/encryptedstore/secrets_store.go
+++ b/pkg/encryptedstore/secrets_store.go
@@ -23,7 +23,7 @@ type GenericEncryptedStore struct {
 	secretLister v1.SecretLister
 }
 
-func NewGenericEncrypedStore(prefix, namespace string, namespaceInterface v1.NamespaceInterface, secretsGetter v1.SecretsGetter) (*GenericEncryptedStore, error) {
+func NewGenericEncryptedStore(prefix, namespace string, namespaceInterface v1.NamespaceInterface, secretsGetter v1.SecretsGetter) (*GenericEncryptedStore, error) {
 	if namespace == "" {
 		namespace = defaultNamespace
 	}

--- a/pkg/nodeconfig/config.go
+++ b/pkg/nodeconfig/config.go
@@ -32,7 +32,7 @@ type NodeConfig struct {
 }
 
 func NewStore(namespaceInterface v1.NamespaceInterface, secretsGetter v1.SecretsGetter) (*encryptedstore.GenericEncryptedStore, error) {
-	return encryptedstore.NewGenericEncrypedStore("mc-", "", namespaceInterface, secretsGetter)
+	return encryptedstore.NewGenericEncryptedStore("mc-", "", namespaceInterface, secretsGetter)
 }
 
 func NewNodeConfig(store *encryptedstore.GenericEncryptedStore, node *v3.Node) (*NodeConfig, error) {


### PR DESCRIPTION
 In order to use the CLI to get the SSH keys for machines, clients need
to be generated. This change sets up the clients to be generated with
`go generate`.

In addition to this change, the `config.json` file from the machine
state is also included in the response to the get request for SSH keys.
This is necessary because the SSH user information is stored there and
needed to connect.

Issue:
https://github.com/rancher/rancher/issues/35203