### PR TITLE
[Backport v2.5] Fix namespaces not being moved to System project on upgrade

### DIFF
--- a/pkg/controllers/managementuser/rbac/project_handler.go
+++ b/pkg/controllers/managementuser/rbac/project_handler.go
@@ -44,7 +44,8 @@ func (p *pLifecycle) Create(project *v3.Project) (runtime.Object, error) {
 }
 
 func (p *pLifecycle) Updated(project *v3.Project) (runtime.Object, error) {
-	return nil, nil
+	err := p.ensureNamespacesAssigned(project)
+	return project, err
 }
 
 func (p *pLifecycle) Remove(project *v3.Project) (runtime.Object, error) {

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -198,10 +198,8 @@ func (r *Rancher) Start(ctx context.Context) error {
 		if err := forceSystemAndDefaultProjectCreation(r.Wrangler.Core.ConfigMap(), r.Wrangler.Mgmt.Cluster()); err != nil {
 			return err
 		}
-		if err := forceSystemNamespaceAssignment(r.Wrangler.Core.ConfigMap(), r.Wrangler.Mgmt.Cluster()); err != nil {
-			return err
-		}
-		return nil
+
+		return forceSystemNamespaceAssignment(r.Wrangler.Core.ConfigMap(), r.Wrangler.Mgmt.Cluster())
 	})
 
 	if err := r.authServer.Start(ctx, false); err != nil {


### PR DESCRIPTION
Backport of #34885, which is a forward port of #34527, addressing some issues that were missed in the original PR (namely, the `retry.RetryOnConflict` logic would never succeed if it failed the first time).

Related Issue: https://github.com/rancher/rancher/issues/32898