### PR TITLE
[2.6.3] Rip out etcd binary

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,7 +5,6 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 ENV CATTLE_HELM_VERSION v2.16.8-rancher1
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher73
 ENV CATTLE_K3S_VERSION v1.22.3+k3s1
-ENV CATTLE_ETCD_VERSION v3.5.0
 # version used by helm plugin install script
 ENV CATTLE_HELM_UNITTEST_VERSION v0.1.7-rancher3
 # helm 3 version
@@ -41,10 +40,9 @@ ENV HELM_URL_V2_amd64=https://github.com/rancher/helm/releases/download/${CATTLE
     TILLER_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller \
     TILLER_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller-arm64 \
     TILLER_URL=TILLER_URL_${ARCH} \
-    K3S_URL_amd64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s \
-    K3S_URL_arm64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s-arm64 \
-    K3S_URL=K3S_URL_${ARCH} \
-    ETCD_URL=https://github.com/etcd-io/etcd/releases/download/${CATTLE_ETCD_VERSION}/etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}.tar.gz \
+    K3S_DOWNLOAD_URL_amd64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s \
+    K3S_DOWNLOAD_URL_arm64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s-arm64 \
+    K3S_DOWNLOAD_URL=K3S_DOWNLOAD_URL_${ARCH} \
     KUSTOMIZE_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
 
 RUN curl -sLf ${KUSTOMIZE_URL} | tar -xzf - -C /usr/bin
@@ -64,8 +62,7 @@ RUN mkdir /usr/tmp && \
     mv /usr/tmp/helm /usr/bin/helm_v3 && \
     chmod +x /usr/bin/kustomize
 
-RUN curl -sLf ${!K3S_URL} -o /usr/bin/k3s && \
-    curl -sfL ${ETCD_URL} | tar xvzf - --strip-components=1 -C /usr/bin/ etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcd && \
+RUN curl -sLf ${!K3S_DOWNLOAD_URL} -o /usr/bin/k3s && \
     chmod +x /usr/bin/k3s && \
     mkdir -p /go/src/github.com/rancher/rancher/.kube && \
     ln -s /etc/rancher/k3s/k3s.yaml /go/src/github.com/rancher/rancher/.kube/k3s.yaml

--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/rancher/lasso v0.0.0-20210709145333-6c6cd7fd6607
 	github.com/rancher/lasso/controller-runtime v0.0.0-20210608205930-775fcaf2f523
 	github.com/rancher/machine v0.15.0-rancher73
-	github.com/rancher/norman v0.0.0-20211029152448-85ac7aa15a91
+	github.com/rancher/norman v0.0.0-20211103153832-33e911789833
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a

--- a/go.sum
+++ b/go.sum
@@ -1105,8 +1105,8 @@ github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77/go.mod h1:wpITyDPTi/Na
 github.com/rancher/norman v0.0.0-20200517050325-f53cae161640/go.mod h1:92rz/7QN7DOeLQZlJY/8aFBOmF085igIVguR0wpxLas=
 github.com/rancher/norman v0.0.0-20200820172041-261460ee9088/go.mod h1:W9LfZ96OfjkWSGTy2DUqYPt47Jpzrs7eM0i3AAx6fOI=
 github.com/rancher/norman v0.0.0-20210423002317-8e6ffc77a819/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
-github.com/rancher/norman v0.0.0-20211029152448-85ac7aa15a91 h1:qjqrM2IquBZSiFETqpADUxafriXT9i3rzQnyzU74/oE=
-github.com/rancher/norman v0.0.0-20211029152448-85ac7aa15a91/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
+github.com/rancher/norman v0.0.0-20211103153832-33e911789833 h1:faXz+Jc4w9UCHrGB/8tVzmEaXMWpKAij3bDOdfnClRs=
+github.com/rancher/norman v0.0.0-20211103153832-33e911789833/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
 github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e h1:j6+HqCET/NLPBtew2m5apL7jWw/PStQ7iGwXjgAqdvo=
 github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e/go.mod h1:XbYHTPaXuw8ZY9bylhYKQh/nJxDaTKk3YhAxPl4Qy/k=
 github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a h1:6xqYlVz4uAXBa/AuNAG0bhMusIXVh74dc1bbYOAe+HY=

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.suse.com/suse/sle15:15.3
 RUN zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
     useradd rancher && \
-    mkdir -p /var/lib/rancher/etcd /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \
+    mkdir -p /var/lib/rancher /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \
     chown -R rancher /var/lib/rancher /var/lib/cattle /usr/local/bin
 
 RUN mkdir /root/.kube && \
@@ -81,10 +81,10 @@ ENV HELM_URL_V2_amd64=https://github.com/rancher/helm/releases/download/${CATTLE
     TILLER_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller \
     TILLER_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller-arm64 \
     TILLER_URL=TILLER_URL_${ARCH} \
-    K3S_URL_amd64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s \
-    K3S_URL_arm64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s-arm64 \
-    K3S_URL=K3S_URL_${ARCH} \
     ETCD_URL=https://github.com/etcd-io/etcd/releases/download/${CATTLE_ETCD_VERSION}/etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}.tar.gz \
+    K3S_DOWNLOAD_URL_amd64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s \
+    K3S_DOWNLOAD_URL_arm64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s-arm64 \
+    K3S_DOWNLOAD_URL=K3S_DOWNLOAD_URL_${ARCH} \
     KUSTOMIZE_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
 
 RUN curl -sLf ${KUSTOMIZE_URL} | tar -xzf - -C /usr/bin
@@ -102,9 +102,9 @@ RUN curl ${HELM_URL_V3} | tar xvzf - --strip-components=1 -C /usr/bin && \
     chmod +x /usr/bin/kustomize
 
 RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
-    curl -sLf ${!K3S_URL} > /usr/bin/k3s && \
+    curl -sLf ${!K3S_DOWNLOAD_URL} > /usr/bin/k3s && \
     mkdir -p /var/lib/rancher/k3s/agent/images/ && \
-    curl -sfL ${ETCD_URL} | tar xvzf - --strip-components=1 -C /usr/bin/ etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcd etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcdctl && \
+    curl -sfL ${ETCD_URL} | tar xvzf - --strip-components=1 -C /usr/bin/ etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcdctl && \
     curl -sLf https://github.com/rancher/telemetry/releases/download/${TELEMETRY_VERSION}/telemetry-${ARCH} > /usr/bin/telemetry && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/${CATTLE_K3S_VERSION%+*}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/tini /usr/bin/telemetry /usr/bin/k3s /usr/bin/kubectl && \
@@ -163,7 +163,6 @@ COPY data.json /var/lib/rancher-data/driver-metadata/
 
 ENV CATTLE_AGENT_IMAGE ${IMAGE_REPO}/rancher-agent:${VERSION}
 ENV CATTLE_SERVER_IMAGE ${IMAGE_REPO}/rancher
-ENV ETCD_UNSUPPORTED_ARCH=${ARCH}
 ENV ETCDCTL_API=3
 
 ENV SSL_CERT_DIR /etc/rancher/ssl

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -6,6 +6,18 @@ if [ ! -e /run/secrets/kubernetes.io/serviceaccount ] && [ ! -e /dev/kmsg ]; the
     exit 1
 fi
 rm -f /var/lib/rancher/k3s/server/cred/node-passwd
+if [ -e /var/lib/rancher/etcd ] && [ ! -e /var/lib/rancher/k3s/server/db/etcd ]; then
+  mkdir -p /var/lib/rancher/k3s/server/db
+  ln -sf /var/lib/rancher/etcd /var/lib/rancher/k3s/server/db/etcd
+  echo -n 'default' > /var/lib/rancher/k3s/server/db/etcd/name
+fi
+if [ -e /var/lib/rancher/k3s/server/db/etcd ]; then
+  k3s server --cluster-init --cluster-reset &> ./k3s-cluster-reset.log
+  if [ $? -ne 0 ]; then
+    echo "ERROR:" && cat ./k3s-cluster-reset.log
+    rm -f /var/lib/rancher/k3s/server/db/reset-flag
+  fi
+fi
 if [ -x "$(command -v update-ca-certificates)" ]; then
   update-ca-certificates
 fi

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/rancher/eks-operator v1.1.1
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210918015053-5a141a6b18f0
 	github.com/rancher/gke-operator v1.1.1
-	github.com/rancher/norman v0.0.0-20211029152448-85ac7aa15a91
+	github.com/rancher/norman v0.0.0-20211103153832-33e911789833
 	github.com/rancher/rke v1.3.3-rc2.0.20211119212717-6f1661aaa9c7
 	github.com/rancher/wrangler v0.8.9
 	github.com/sirupsen/logrus v1.8.1

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -672,8 +672,8 @@ github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08 h1:NxR8Fh0eE7/5/5Zvl
 github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08/go.mod h1:9qZd/S8DqWzfKtjKGgSoHqGEByYmUE3qRaBaaAHwfEM=
 github.com/rancher/machine v0.15.0-rancher63/go.mod h1:qXYNumxy0J08MO/mh/jNjyRuEc2QKDLUOZIBE5vxaZE=
 github.com/rancher/norman v0.0.0-20200517050325-f53cae161640/go.mod h1:92rz/7QN7DOeLQZlJY/8aFBOmF085igIVguR0wpxLas=
-github.com/rancher/norman v0.0.0-20211029152448-85ac7aa15a91 h1:qjqrM2IquBZSiFETqpADUxafriXT9i3rzQnyzU74/oE=
-github.com/rancher/norman v0.0.0-20211029152448-85ac7aa15a91/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
+github.com/rancher/norman v0.0.0-20211103153832-33e911789833 h1:faXz+Jc4w9UCHrGB/8tVzmEaXMWpKAij3bDOdfnClRs=
+github.com/rancher/norman v0.0.0-20211103153832-33e911789833/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
 github.com/rancher/rke v1.3.3-rc2.0.20211119212717-6f1661aaa9c7 h1:rStN/aIp7vcYy5jSd99Xy5XW9ywlgWlxN4wpkn3eCvY=
 github.com/rancher/rke v1.3.3-rc2.0.20211119212717-6f1661aaa9c7/go.mod h1:4StVBXSN7EbrfoWE7nI2AAf/N1td8qSyQMDRyR6nGAg=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=

--- a/pkg/client/generated/management/v3/zz_generated_cloud_provider.go
+++ b/pkg/client/generated/management/v3/zz_generated_cloud_provider.go
@@ -5,6 +5,7 @@ const (
 	CloudProviderFieldAWSCloudProvider       = "awsCloudProvider"
 	CloudProviderFieldAzureCloudProvider     = "azureCloudProvider"
 	CloudProviderFieldCustomCloudProvider    = "customCloudProvider"
+	CloudProviderFieldHarvesterCloudProvider = "harvesterCloudProvider"
 	CloudProviderFieldName                   = "name"
 	CloudProviderFieldOpenstackCloudProvider = "openstackCloudProvider"
 	CloudProviderFieldVsphereCloudProvider   = "vsphereCloudProvider"
@@ -14,6 +15,7 @@ type CloudProvider struct {
 	AWSCloudProvider       *AWSCloudProvider       `json:"awsCloudProvider,omitempty" yaml:"awsCloudProvider,omitempty"`
 	AzureCloudProvider     *AzureCloudProvider     `json:"azureCloudProvider,omitempty" yaml:"azureCloudProvider,omitempty"`
 	CustomCloudProvider    string                  `json:"customCloudProvider,omitempty" yaml:"customCloudProvider,omitempty"`
+	HarvesterCloudProvider *HarvesterCloudProvider `json:"harvesterCloudProvider,omitempty" yaml:"harvesterCloudProvider,omitempty"`
 	Name                   string                  `json:"name,omitempty" yaml:"name,omitempty"`
 	OpenstackCloudProvider *OpenstackCloudProvider `json:"openstackCloudProvider,omitempty" yaml:"openstackCloudProvider,omitempty"`
 	VsphereCloudProvider   *VsphereCloudProvider   `json:"vsphereCloudProvider,omitempty" yaml:"vsphereCloudProvider,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_harvester_cloud_provider.go
+++ b/pkg/client/generated/management/v3/zz_generated_harvester_cloud_provider.go
@@ -1,0 +1,10 @@
+package client
+
+const (
+	HarvesterCloudProviderType             = "harvesterCloudProvider"
+	HarvesterCloudProviderFieldCloudConfig = "cloudConfig"
+)
+
+type HarvesterCloudProvider struct {
+	CloudConfig string `json:"cloudConfig,omitempty" yaml:"cloudConfig,omitempty"`
+}

--- a/scripts/etcd.sh
+++ b/scripts/etcd.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/ssl/kube-ca.pem --cert /etc/kubernetes/ssl/kube-apiserver.pem --key /etc/kubernetes/ssl/kube-apiserver-key.pem "$@"

--- a/scripts/validate
+++ b/scripts/validate
@@ -34,7 +34,7 @@ fi
 badmodule="false"
 while read -r module tag; do
   # Get tag from module in ./go.mod
-  roottag=$(cat go.mod | sed '1,/require/d' | grep "${module} " | awk '{ print $2 }')
+  roottag=$(cat go.mod | sed '1,/^require/d' | grep "${module} " | awk '{ print $2 }')
   echo "${module}:"
   echo "${tag} (./pkg/apis/go.mod)"
   echo "${roottag} (./go.mod)"


### PR DESCRIPTION
Issue [33850](https://github.com/rancher/rancher/issues/33850). Exploratory issue that removes the downloaded etcd binary and starts Rancher single node k3s cluster with embedded etcd.

## Testing template

#### Design plan

- Rip etcd binary and env vars out of rancher/rancher Dockerfile.dapper and package/Dockerfile
- Update the Norman API
    - Remove handler function RunETCD that starts etcd
    - Remove —datastore-endpoint
    - Start k3s server with —cluster-init (which will use embedded etcd)

#### What was fixed, or what changes have occurred

- Remove etcd binary and env vars
- Update K3S_URL in Dockerfile to avoid overwriting k3s server url during setup
- Update go.mod to reference changes in Norman API (the k3s server initialization is done in the Norman API and that's where the other half of these changes are)
- Fix bug in the validate script
- Add missing /var/lib/rancher directory

#### Areas or cases that should be tested

- Spin up a custom Rancher image v2.6 and test if 1) the local cluster is stable, 2) a deployment can be created, 3) a downstream cluster can be created. I used a custom image modified for local dev that can be pulled from docker hub _annablender/rancher:k3s-embedded-etcd_.
- Drop into the Rancher container and ping the embedded etcd endpoint "curl -i localhost:2379." If running, you'll establish a connection and receive empty data
- K3s single node upgrade
- Persisted data upgrade
- Backup and restore
- Use etcdctl with flag --endpoints=https://<node ip>:2379 to test embedded etcd