### PR TITLE
[2.6] [Helm Chart] Add Pod label support

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -40,6 +40,9 @@ app: {{ template "rancher.fullname" . }}
 chart: {{ template "rancher.chartname" . }}
 heritage: {{ .Release.Service }}
 release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels }}
+{{- end }}
 {{- end }}
 
 # Windows Support

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       labels:
         app: {{ template "rancher.fullname" . }}
         release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+  {{ toYaml .Values.podLabels | indent 6 }}
+{{- end }}
     spec:
       serviceAccountName: {{ template "rancher.fullname" . }}
 {{- if .Values.imagePullSecrets }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -26,12 +26,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      labels:
-        app: {{ template "rancher.fullname" . }}
-        release: {{ .Release.Name }}
-{{- if .Values.podLabels }}
-  {{ toYaml .Values.podLabels | indent 6 }}
-{{- end }}
+      labels: {{ include "rancher.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "rancher.fullname" . }}
 {{- if .Values.imagePullSecrets }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -106,6 +106,9 @@ replicas: 3
 # Set pod resource requests/limits for Rancher.
 resources: {}
 
+# Set custom pod labels for Rancher pods.
+podLabels: {}
+
 #
 # tls
 #   Where to offload the TLS/SSL encryption


### PR DESCRIPTION
This change adds the ability to specify additional pod labels for Rancher `Deployment` object. I have verified that the change works by generating Kubernetes manifest via `helm template .`