### PR TITLE
[2.6] [Helm Chart] Add Service annotation support

### DIFF
--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ template "rancher.fullname" . }}
   labels:
 {{ include "rancher.labels" . | indent 4 }}
+{{- if .Values.service.annotations }}
+  annotations:{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   ports:
   - port: 80

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -5,7 +5,8 @@ metadata:
   labels:
 {{ include "rancher.labels" . | indent 4 }}
 {{- if .Values.service.annotations }}
-  annotations:{{ toYaml .Values.service.annotations | indent 4 }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
 spec:
   ports:

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -9,14 +9,8 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
 spec:
+  type: {{ .Values.service.type }}
   ports:
-  - port: 80
-    targetPort: 80
-    protocol: TCP
-    name: http
-  - port: 443
-    targetPort: 444
-    protocol: TCP
-    name: https-internal
+{{ toYaml .Values.service.ports | indent 2 }}
   selector:
     app: {{ template "rancher.fullname" . }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -109,6 +109,16 @@ resources: {}
 # Set annotations on the Rancher service
 service:
   annotations: {}
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 443
+    targetPort: 444
+    protocol: TCP
+    name: https-internal
 
 #
 # tls

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -106,6 +106,10 @@ replicas: 3
 # Set pod resource requests/limits for Rancher.
 resources: {}
 
+# Set annotations on the Rancher service
+service:
+  annotations: {}
+
 #
 # tls
 #   Where to offload the TLS/SSL encryption


### PR DESCRIPTION
This change adds the ability to specify service annotations for the Rancher service object, allowing users to deploy Rancher in cloud environments as discussed in #26295 and discussed in https://rancher.com/docs/rancher/v2.5/en/installation/install-rancher-on-k8s/