### PR TITLE
Add better support for upgrading local cluster

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/machinedrain/machinedrain.go
+++ b/pkg/controllers/provisioningv2/rke2/machinedrain/machinedrain.go
@@ -84,7 +84,12 @@ func (h *handler) undrain(machine *capi.Machine) (*capi.Machine, error) {
 
 	c := drain.NewCordonHelper(node)
 
-	if updateRequired := c.UpdateIfRequired(false); !updateRequired {
+	if !c.UpdateIfRequired(false) {
+		if machine.Annotations[planner.UnCordonAnnotation] != "" {
+			machine = machine.DeepCopy()
+			delete(machine.Annotations, planner.UnCordonAnnotation)
+			return h.machines.Update(machine)
+		}
 		return machine, nil
 	}
 

--- a/pkg/provisioningv2/rke2/configserver/server.go
+++ b/pkg/provisioningv2/rke2/configserver/server.go
@@ -17,6 +17,7 @@ import (
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	"github.com/rancher/rancher/pkg/provisioningv2/rke2/planner"
 	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/rancher/pkg/tls"
 	"github.com/rancher/rancher/pkg/wrangler"
 	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -116,8 +117,13 @@ func (r *RKE2ConfigServer) connectAgent(planSecret string, secret *v1.Secret, rw
 	}
 
 	if url == "" {
-		_, pem = settings.InternalServerURL.Get(), settings.InternalCACerts.Get()
+		pem = settings.InternalCACerts.Get()
 		url = fmt.Sprintf("https://%s", req.Host)
+		if strings.TrimSpace(pem) != "" {
+			ca = []byte(pem)
+		}
+	} else if v, ok := req.Context().Value(tls.InternalAPI).(bool); ok && v {
+		pem = settings.InternalCACerts.Get()
 		if strings.TrimSpace(pem) != "" {
 			ca = []byte(pem)
 		}

--- a/pkg/provisioningv2/rke2/installer/server.go
+++ b/pkg/provisioningv2/rke2/installer/server.go
@@ -14,9 +14,9 @@ func (s *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	switch req.URL.Path {
 	case SystemAgentInstallPath:
-		content, err = LinuxInstallScript("", nil, req.Host)
+		content, err = LinuxInstallScript(req.Context(), "", nil, req.Host)
 	case WindowsRke2InstallPath:
-		content, err = WindowsInstallScript("", nil, req.Host)
+		content, err = WindowsInstallScript(req.Context(), "", nil, req.Host)
 	}
 
 	if err != nil {

--- a/pkg/provisioningv2/rke2/planner/drain.go
+++ b/pkg/provisioningv2/rke2/planner/drain.go
@@ -24,7 +24,7 @@ func DrainHash(data []byte) string {
 
 func (p *Planner) drain(machine *capi.Machine, clusterPlan *plan.Plan, options rkev1.DrainOptions) (bool, error) {
 	// We never drain a single node cluster
-	if !options.Enabled || len(clusterPlan.Machines) == 1 {
+	if !options.Enabled || len(clusterPlan.Machines) == 1 || machine == nil || machine.Status.NodeRef == nil {
 		return true, nil
 	}
 

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -1066,7 +1066,7 @@ func (p *Planner) addConfigFile(nodePlan plan.NodePlan, controlPlane *rkev1.RKEC
 
 	nodePlan.Files = append(nodePlan.Files, plan.File{
 		Content: base64.StdEncoding.EncodeToString(configData),
-		Path:    fmt.Sprintf(ConfigYamlFileName, rancherruntime.GetRuntime(controlPlane.Spec.KubernetesVersion)),
+		Path:    fmt.Sprintf(ConfigYamlFileName, runtime),
 	})
 
 	return nodePlan, nil


### PR DESCRIPTION
When the local cluster is provisioned via rancherd, a hostPort is used.
When Rancher is contacted via the hostPort, the internal-cacerts setting
is used instead of the regular cacerts setting. This was causing issues
with system-agent trying to verify Rancher's CA. After this change, The
install script logic with provide the corresponding CA as necessary.

In addition, when certificates were being regenerated on Kubernetes
upgrade, the clusterIP was being used but not the hostIP. This again was
causing issues with system-agent verifying Rancher's CA because the SAN
did not include the hostIP when hostPort was enabled.

Finally, once machines were "uncordoned" the annotation was never
getting removed. This change will remove the annotation after the node
is uncordoned.

Issue:
https://github.com/rancher/rancher/issues/35310