### PR TITLE
[Forwardport v2.6] Fix namespaces not being moved to System project on upgrade (part 2)

### DIFF
--- a/pkg/controllers/managementuser/rbac/project_handler.go
+++ b/pkg/controllers/managementuser/rbac/project_handler.go
@@ -43,7 +43,8 @@ func (p *pLifecycle) Create(project *v3.Project) (runtime.Object, error) {
 }
 
 func (p *pLifecycle) Updated(project *v3.Project) (runtime.Object, error) {
-	return nil, nil
+	err := p.ensureNamespacesAssigned(project)
+	return project, err
 }
 
 func (p *pLifecycle) Remove(project *v3.Project) (runtime.Object, error) {

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -197,10 +197,8 @@ func forceSystemNamespaceAssignment(configMapController controllerv1.ConfigMapCo
 	}
 
 	for i := range clusterList.Items {
-		c := &clusterList.Items[i]
-
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			c, err = clusterClient.Get(c.Name, metav1.GetOptions{})
+			c, err := clusterClient.Get(clusterList.Items[i].Name, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Forwardport of #35322, which is a backport of #34885, which is a forward port of #34527, addressing some issues that were missed in the original PR. A specific commit was lost as a result of a force push, which actually performed the system project assignment logic.

Related Issue: #32898