### PR TITLE
Fix disabling RKE2 feature flag

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/norman/types/values"
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	util "github.com/rancher/rancher/pkg/cluster"
+	"github.com/rancher/rancher/pkg/controllers/management/imported"
 	kd "github.com/rancher/rancher/pkg/controllers/management/kontainerdrivermetadata"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/apps/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -1055,7 +1056,7 @@ func (p *Provisioner) k3sBasedClusterConfig(cluster *v3.Cluster, nodes []*v3.Nod
 		cluster.Status.Driver == apimgmtv3.ClusterDriverK3os ||
 		cluster.Status.Driver == apimgmtv3.ClusterDriverRke2 ||
 		cluster.Status.Driver == apimgmtv3.ClusterDriverRancherD ||
-		IsAdministratedByProvisioningCluster(cluster) {
+		imported.IsAdministratedByProvisioningCluster(cluster) {
 		return nil //no-op
 	}
 	isEmbedded := cluster.Status.Driver == apimgmtv3.ClusterDriverLocal
@@ -1098,12 +1099,8 @@ func (p *Provisioner) k3sBasedClusterConfig(cluster *v3.Cluster, nodes []*v3.Nod
 	return nil
 }
 
-func IsAdministratedByProvisioningCluster(cluster *v3.Cluster) bool {
-	return cluster.Status.Driver == apimgmtv3.ClusterDriverImported && cluster.Annotations["provisioning.cattle.io/administrated"] == "true"
-}
-
 func reconcileACE(cluster *v3.Cluster) {
-	if IsAdministratedByProvisioningCluster(cluster) || cluster.Status.Driver == apimgmtv3.ClusterDriverRke2 || cluster.Status.Driver == apimgmtv3.ClusterDriverK3s {
+	if imported.IsAdministratedByProvisioningCluster(cluster) || cluster.Status.Driver == apimgmtv3.ClusterDriverRke2 || cluster.Status.Driver == apimgmtv3.ClusterDriverK3s {
 		cluster.Status.AppliedSpec.LocalClusterAuthEndpoint = cluster.Spec.LocalClusterAuthEndpoint
 	}
 }

--- a/pkg/controllers/management/imported/imported.go
+++ b/pkg/controllers/management/imported/imported.go
@@ -1,0 +1,7 @@
+package imported
+
+import v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+
+func IsAdministratedByProvisioningCluster(cluster *v3.Cluster) bool {
+	return cluster.Status.Driver == v3.ClusterDriverImported && cluster.Annotations["provisioning.cattle.io/administrated"] == "true"
+}

--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rancher/norman/httperror"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/clustermanager"
-	"github.com/rancher/rancher/pkg/controllers/management/clusterprovisioner"
+	"github.com/rancher/rancher/pkg/controllers/management/imported"
 	"github.com/rancher/rancher/pkg/controllers/managementagent/nslabels"
 	"github.com/rancher/rancher/pkg/controllers/managementuserlegacy/helm"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -75,7 +75,7 @@ func (c *ClusterLifecycleCleanup) Remove(obj *v3.Cluster) (runtime.Object, error
 		obj.Status.Driver == v32.ClusterDriverK3os ||
 		obj.Status.Driver == v32.ClusterDriverRke2 ||
 		obj.Status.Driver == v32.ClusterDriverRancherD ||
-		(obj.Status.Driver == v32.ClusterDriverImported && !clusterprovisioner.IsAdministratedByProvisioningCluster(obj)) ||
+		(obj.Status.Driver == v32.ClusterDriverImported && !imported.IsAdministratedByProvisioningCluster(obj)) ||
 		(obj.Status.AKSStatus.UpstreamSpec != nil && obj.Status.AKSStatus.UpstreamSpec.Imported) ||
 		(obj.Status.EKSStatus.UpstreamSpec != nil && obj.Status.EKSStatus.UpstreamSpec.Imported) ||
 		(obj.Status.GKEStatus.UpstreamSpec != nil && obj.Status.GKEStatus.UpstreamSpec.Imported) {

--- a/pkg/controllers/provisioningv2/cluster/remove.go
+++ b/pkg/controllers/provisioningv2/cluster/remove.go
@@ -117,6 +117,10 @@ func (h *handler) doClusterRemove(cluster *v1.Cluster) (string, error) {
 				if !apierrors.IsNotFound(err) {
 					return fmt.Sprintf("waiting for cluster [%s] to delete", cluster.Status.ClusterName), nil
 				}
+			} else {
+				if err = h.updateFeatureLockedValue(false); err != nil {
+					return "", err
+				}
 			}
 		}
 	}

--- a/pkg/features/migrate.go
+++ b/pkg/features/migrate.go
@@ -2,6 +2,7 @@ package features
 
 import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/controllers/management/imported"
 	managementv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	v1 "github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -12,7 +13,7 @@ var (
 	t = true
 )
 
-func MigrateFeatures(featuresClient managementv3.FeatureClient, crdClient v1.CustomResourceDefinitionClient) error {
+func MigrateFeatures(featuresClient managementv3.FeatureClient, crdClient v1.CustomResourceDefinitionClient, mgmtClusterClient managementv3.ClusterClient) error {
 	features, err := featuresClient.List(metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -28,6 +29,10 @@ func MigrateFeatures(featuresClient managementv3.FeatureClient, crdClient v1.Cus
 			hasLegacy = true
 		case MCM.Name():
 			if err := enableMCMIfPreviouslyEnabled(&feature, featuresClient, crdClient); err != nil {
+				return err
+			}
+		case RKE2.Name():
+			if err := enableRKE2IfClustersExist(&feature, featuresClient, mgmtClusterClient); err != nil {
 				return err
 			}
 		}
@@ -61,4 +66,28 @@ func enableMCMIfPreviouslyEnabled(feature *v3.Feature, featuresClient management
 	}
 
 	return SetFeature(featuresClient, MCM.Name(), true)
+}
+
+func enableRKE2IfClustersExist(feature *v3.Feature, featuresClient managementv3.FeatureClient, mgmtClusterClient managementv3.ClusterClient) error {
+	if feature.Spec.Value == nil || *feature.Spec.Value {
+		return nil
+	}
+
+	clusters, err := mgmtClusterClient.List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, c := range clusters.Items {
+		if imported.IsAdministratedByProvisioningCluster(&c) {
+			feature = feature.DeepCopy()
+			feature.Spec.Value = &[]bool{true}[0]
+			feature.Status.LockedValue = feature.Spec.Value
+
+			_, err = featuresClient.Update(feature)
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -131,7 +131,7 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		return nil, err
 	}
 
-	if err := features.MigrateFeatures(wranglerContext.Mgmt.Feature(), wranglerContext.CRD.CustomResourceDefinition()); err != nil {
+	if err := features.MigrateFeatures(wranglerContext.Mgmt.Feature(), wranglerContext.CRD.CustomResourceDefinition(), wranglerContext.Mgmt.Cluster()); err != nil {
 		return nil, fmt.Errorf("migrating features: %w", err)
 	}
 	features.InitializeFeatures(wranglerContext.Mgmt.Feature(), opts.Features)


### PR DESCRIPTION
Firstly, the provisioning cluster indexer was mistakenly put behind the RKE2
feature flag. This caused an issue when deleting RKE1/imported clusters
when RKE2 feature flag was turned off.  This change puts it behind the
ProvisioningV2 feature flag.

In addition, the change adds logic to keep track of when the RKE2
feature flag can be disabled. That is, if there are RKE2 provisioned
clusters then a user should not be able to disable the RKE2 feature
flag. An annotation is added to the feature for easy tracking, and the
annotation is checked on startup and added if necessary so that RKE2
provisioning works as expected.

Issues:
https://github.com/rancher/rancher/issues/35179
https://github.com/rancher/rancher/issues/35180