### PR TITLE
Automation - Adding AMI packer templates

### DIFF
--- a/tests/validation/tests/packer/centos-no-selinux-no-docker.pkr.hcl
+++ b/tests/validation/tests/packer/centos-no-selinux-no-docker.pkr.hcl
@@ -1,0 +1,65 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "centos-${env("OS_VERSION")}-no-selinux-no-docker"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "centos" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      # sample string from the API
+      # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20210224
+      name                = "*CentOS*${var.os_version}.*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # CentOS AMI Owner
+    owners      = ["125523088429"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "centos"
+  run_tags = {
+    "Name" = "centos-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.centos"]
+
+  provisioner "shell" {
+    inline = [
+      "sudo yum remove docker docker-client docker-client-latest docker-common docker-latest docker-latest-logrotate docker-logrotatedocker-engine",
+      "sudo sed -i \"s/SELINUX=enforcing/SELINUX=disabled/\" /etc/selinux/config",
+      "sudo setenforce 0",
+      "sudo reboot",
+    ]
+    expect_disconnect = true
+  }
+  provisioner "shell" {
+    inline = [
+      "selstatus=$(sudo getenforce) && if (($selstatus != \"Disabled\")); then exit 1; fi",
+      "echo 'SELINUX DISABLED'"
+    ]
+    pause_before = "60s"
+    max_retries  = 2
+  }
+}

--- a/tests/validation/tests/packer/centos-selinux-docker-rpm.pkr.hcl
+++ b/tests/validation/tests/packer/centos-selinux-docker-rpm.pkr.hcl
@@ -1,0 +1,67 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "centos-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}-selinux-on-rpm"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "centos" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      # sample string from the API
+      # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20210224
+      name                = "*CentOS*${var.os_version}.*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # CentOS AMI Owner
+    owners      = ["125523088429"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "centos"
+  run_tags = {
+    "Name" = "centos-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.centos"]
+
+  provisioner "shell" {
+    inline = [
+      "curl https://releases.rancher.com/install-docker/${var.docker_version}.sh | sh",
+      "sudo usermod -aG docker $USER",
+      "sudo systemctl enable docker",
+      "echo '{\"selinux-enabled\": true}' | sudo tee /etc/docker/daemon.json",
+      "sudo service docker start",
+      "sudo getenforce",
+      "sudo systemctl status docker",
+      "sudo docker info",
+      "sudo bash -c \"cat << EOF > /etc/yum.repos.d/rancher-testing.repo\n[rancher-testing]\nname=Rancher Testing\nbaseurl=https://rpm-testing.rancher.io/rancher/testing/centos/8/noarch\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm-testing.rancher.io/public.key\nEOF\"",
+      "sudo yum -y install rancher-selinux"
+    ]
+  }
+}

--- a/tests/validation/tests/packer/centos-selinux-docker-rpm7.pkr.hcl
+++ b/tests/validation/tests/packer/centos-selinux-docker-rpm7.pkr.hcl
@@ -1,0 +1,67 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "centos-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}-selinux-on-rpm"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "centos" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      # sample string from the API
+      # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20210224
+      name                = "*CentOS*${var.os_version}.*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # CentOS AMI Owner
+    owners      = ["125523088429"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "centos"
+  run_tags = {
+    "Name" = "centos-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.centos"]
+
+  provisioner "shell" {
+    inline = [
+      "curl https://releases.rancher.com/install-docker/${var.docker_version}.sh | sh",
+      "sudo usermod -aG docker $USER",
+      "sudo systemctl enable docker",
+      "echo '{\"selinux-enabled\": true}' | sudo tee /etc/docker/daemon.json",
+      "sudo service docker start",
+      "sudo getenforce",
+      "sudo systemctl status docker",
+      "sudo docker info",
+      "sudo bash -c \"cat << EOF > /etc/yum.repos.d/rancher-testing.repo\n[rancher-testing]\nname=Rancher Testing\nbaseurl=https://rpm-testing.rancher.io/rancher/testing/centos/7/noarch\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm-testing.rancher.io/public.key\nEOF\"",
+      "sudo yum -y install rancher-selinux"
+    ]
+  }
+}

--- a/tests/validation/tests/packer/centos-selinux-docker.pkr.hcl
+++ b/tests/validation/tests/packer/centos-selinux-docker.pkr.hcl
@@ -1,0 +1,65 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "centos-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}-selinux-on"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "centos" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      # sample string from the API
+      # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20210224
+      name                = "*CentOS*${var.os_version}.*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # CentOS AMI Owner
+    owners      = ["125523088429"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "centos"
+  run_tags = {
+    "Name" = "centos-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.centos"]
+
+  provisioner "shell" {
+    inline = [
+      "curl https://releases.rancher.com/install-docker/${var.docker_version}.sh | sh",
+      "sudo usermod -aG docker $USER",
+      "sudo systemctl enable docker",
+      "echo '{\"selinux-enabled\": true}' | sudo tee /etc/docker/daemon.json",
+      "sudo service docker start",
+      "sudo getenforce",
+      "sudo systemctl status docker",
+      "sudo docker info"
+    ]
+  }
+}

--- a/tests/validation/tests/packer/centos-selinux-no-docker-rpm.pkr.hcl
+++ b/tests/validation/tests/packer/centos-selinux-no-docker-rpm.pkr.hcl
@@ -1,0 +1,59 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "centos-${env("OS_VERSION")}-selinux-no-docker-rpm"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "centos" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      # sample string from the API
+      # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20210224
+      name                = "*CentOS*${var.os_version}.*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # CentOS AMI Owner
+    owners      = ["125523088429"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "centos"
+  run_tags = {
+    "Name" = "centos-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.centos"]
+
+  provisioner "shell" {
+    inline = [
+      "sudo bash -c \"cat << EOF > /etc/yum.repos.d/rancher-testing.repo\n[rancher-testing]\nname=Rancher Testing\nbaseurl=https://rpm-testing.rancher.io/rancher/testing/centos/8/noarch\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm-testing.rancher.io/public.key\nEOF\"",
+      "sudo yum -y install rancher-selinux"
+    ]
+  }
+}

--- a/tests/validation/tests/packer/centos-selinux-no-docker-rpm7.pkr.hcl
+++ b/tests/validation/tests/packer/centos-selinux-no-docker-rpm7.pkr.hcl
@@ -1,0 +1,59 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "centos-${env("OS_VERSION")}-selinux-no-docker-rpm"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "centos" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      # sample string from the API
+      # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20210224
+      name                = "*CentOS*${var.os_version}.*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # CentOS AMI Owner
+    owners      = ["125523088429"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "centos"
+  run_tags = {
+    "Name" = "centos-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.centos"]
+
+  provisioner "shell" {
+    inline = [
+      "sudo bash -c \"cat << EOF > /etc/yum.repos.d/rancher-testing.repo\n[rancher-testing]\nname=Rancher Testing\nbaseurl=https://rpm-testing.rancher.io/rancher/testing/centos/7/noarch\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm-testing.rancher.io/public.key\nEOF\"",
+      "sudo yum -y install rancher-selinux"
+    ]
+  }
+}

--- a/tests/validation/tests/packer/centos-selinux-rpm.pkr.hcl
+++ b/tests/validation/tests/packer/centos-selinux-rpm.pkr.hcl
@@ -1,0 +1,55 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "centos-${env("OS_VERSION")}-selinux-on-rpm"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "centos" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      # sample string from the API
+      # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20210224
+      name                = "*CentOS*${var.os_version}.*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # CentOS AMI Owner
+    owners      = ["125523088429"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "centos"
+  run_tags = {
+    "Name" = "centos-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.centos"]
+
+  provisioner "shell" {
+    inline = [
+      "sudo getenforce",
+      "sudo bash -c \"cat << EOF > /etc/yum.repos.d/rancher-testing.repo\n[rancher-testing]\nname=Rancher Testing\nbaseurl=https://rpm-testing.rancher.io/rancher/testing/centos/8/noarch\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm-testing.rancher.io/public.key\nEOF\"",
+      "sudo yum -y install rancher-selinux"
+    ]
+  }
+}

--- a/tests/validation/tests/packer/centos-selinux-rpm7.pkr.hcl
+++ b/tests/validation/tests/packer/centos-selinux-rpm7.pkr.hcl
@@ -1,0 +1,54 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "centos-${env("OS_VERSION")}-selinux-on-rpm"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "centos" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      # sample string from the API
+      # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20210224
+      name                = "*CentOS*${var.os_version}.*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # CentOS AMI Owner
+    owners      = ["125523088429"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "centos"
+  run_tags = {
+    "Name" = "centos-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.centos"]
+
+  provisioner "shell" {
+    inline = [
+      "sudo bash -c \"cat << EOF > /etc/yum.repos.d/rancher-testing.repo\n[rancher-testing]\nname=Rancher Testing\nbaseurl=https://rpm-testing.rancher.io/rancher/testing/centos/7/noarch\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm-testing.rancher.io/public.key\nEOF\"",
+      "sudo yum -y install rancher-selinux"
+    ]
+  }
+}

--- a/tests/validation/tests/packer/centos.pkr.hcl
+++ b/tests/validation/tests/packer/centos.pkr.hcl
@@ -1,0 +1,59 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "centos-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "centos" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "*CentOS*${var.os_version}.*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # CentOS AMI Owner
+    owners      = ["125523088429"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "centos"
+  run_tags = {
+    "Name" = "centos-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.centos"]
+
+  provisioner "shell" {
+    inline = [
+      "curl https://releases.rancher.com/install-docker/${var.docker_version}.sh | sh",
+      "sudo usermod -aG docker $USER",
+      "sudo systemctl enable docker && sudo systemctl start docker",
+      "sudo docker info"
+    ]
+  }
+}

--- a/tests/validation/tests/packer/oraclelinux-no-selinux-no-docker.pkr.hcl
+++ b/tests/validation/tests/packer/oraclelinux-no-selinux-no-docker.pkr.hcl
@@ -1,0 +1,67 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "oraclelinux-${env("OS_VERSION")}-no-selinux-no-docker"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "oraclelinux" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "*OL${var.os_version}-*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # oraclelinux AMI Owner
+    owners      = ["131827586825"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "ec2-user"
+  run_tags = {
+    "Name" = "oraclelinux-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.oraclelinux"]
+
+  provisioner "shell" {
+    inline = [
+      "sudo systemctl stop firewalld",
+      "sudo systemctl disable firewalld",
+      "sudo systemctl stop iptables",
+      "sudo systemctl disable iptables",
+      "sudo yum remove docker docker-client docker-client-latest docker-common docker-latest docker-latest-logrotate docker-logrotatedocker-engine",
+      "sudo sed -i \"s/SELINUX=enforcing/SELINUX=disabled/\" /etc/selinux/config",
+      "sudo setenforce 0",
+      "sudo reboot",
+    ]
+    expect_disconnect = true
+  }
+  provisioner "shell" {
+    inline = [
+      "selstatus=$(sudo getenforce) && if (($selstatus != \"Disabled\")); then exit 1; fi",
+      "echo 'SELINUX DISABLED'"
+    ]
+    pause_before = "60s"
+    max_retries  = 2
+  }
+}

--- a/tests/validation/tests/packer/oraclelinux-selinux-docker-rpm.pkr.hcl
+++ b/tests/validation/tests/packer/oraclelinux-selinux-docker-rpm.pkr.hcl
@@ -1,0 +1,80 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "oraclelinux-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}-selinux-on-rpm"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "oraclelinux" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "*OL${var.os_version}-*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # oraclelinux AMI Owner
+    owners      = ["131827586825"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "ec2-user"
+  run_tags = {
+    "Name" = "oraclelinux-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.oraclelinux"]
+
+  provisioner "shell" {
+    inline       = [
+      "sudo systemctl stop firewalld",
+      "sudo systemctl disable firewalld",
+      "sudo systemctl stop iptables",
+      "sudo systemctl disable iptables",
+      "sudo sed -i \"s/SELINUX=permissive/SELINUX=enforcing/\" /etc/selinux/config",
+      "curl https://releases.rancher.com/install-docker/${var.docker_version}.sh | sh",
+      "sudo usermod -aG docker $USER",
+      "sudo systemctl enable docker",
+      "echo '{\"selinux-enabled\": true}' | sudo tee /etc/docker/daemon.json",
+      "sudo service docker start",
+      "sudo getenforce",
+      "sudo systemctl status docker",
+      "sudo docker info",
+      "sudo bash -c \"cat << EOF > /etc/yum.repos.d/rancher-testing.repo\n[rancher-testing]\nname=Rancher Testing\nbaseurl=https://rpm-testing.rancher.io/rancher/testing/centos/8/noarch\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm-testing.rancher.io/public.key\nEOF\"",
+      "sudo yum -y install rancher-selinux",
+      "sudo reboot"
+    ]
+    expect_disconnect = true
+  }
+  provisioner "shell" {
+    inline = [
+      "selstatus=$(sudo getenforce) && if (($selstatus != \"Enforcing\")); then exit 1; fi",
+      "echo 'SELINUX ENABLED'"
+    ]
+    pause_before = "60s"
+    max_retries  = 2
+  }
+}

--- a/tests/validation/tests/packer/oraclelinux-selinux-docker-rpm7.pkr.hcl
+++ b/tests/validation/tests/packer/oraclelinux-selinux-docker-rpm7.pkr.hcl
@@ -1,0 +1,80 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "oraclelinux-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}-selinux-on-rpm"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "oraclelinux" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "*OL${var.os_version}-*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # oraclelinux AMI Owner
+    owners      = ["131827586825"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "ec2-user"
+  run_tags = {
+    "Name" = "oraclelinux-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.oraclelinux"]
+
+  provisioner "shell" {
+    inline       = [
+      "sudo systemctl stop firewalld",
+      "sudo systemctl disable firewalld",
+      "sudo systemctl stop iptables",
+      "sudo systemctl disable iptables",
+      "sudo sed -i \"s/SELINUX=permissive/SELINUX=enforcing/\" /etc/selinux/config",
+      "curl https://releases.rancher.com/install-docker/${var.docker_version}.sh | sh",
+      "sudo usermod -aG docker $USER",
+      "sudo systemctl enable docker",
+      "echo '{\"selinux-enabled\": true}' | sudo tee /etc/docker/daemon.json",
+      "sudo service docker start",
+      "sudo getenforce",
+      "sudo systemctl status docker",
+      "sudo docker info",
+      "sudo bash -c \"cat << EOF > /etc/yum.repos.d/rancher-testing.repo\n[rancher-testing]\nname=Rancher Testing\nbaseurl=https://rpm-testing.rancher.io/rancher/testing/centos/7/noarch\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm-testing.rancher.io/public.key\nEOF\"",
+      "sudo yum -y install rancher-selinux",
+      "sudo reboot"
+    ]
+    expect_disconnect = true
+  }
+  provisioner "shell" {
+    inline = [
+      "selstatus=$(sudo getenforce) && if (($selstatus != \"Enforcing\")); then exit 1; fi",
+      "echo 'SELINUX ENABLED'"
+    ]
+    pause_before = "60s"
+    max_retries  = 2
+  }
+}

--- a/tests/validation/tests/packer/oraclelinux-selinux-docker.pkr.hcl
+++ b/tests/validation/tests/packer/oraclelinux-selinux-docker.pkr.hcl
@@ -1,0 +1,78 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "oraclelinux-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}-selinux-on"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "oraclelinux" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "*OL${var.os_version}-*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # oraclelinux AMI Owner
+    owners      = ["131827586825"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "ec2-user"
+  run_tags = {
+    "Name" = "oraclelinux-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.oraclelinux"]
+
+  provisioner "shell" {
+    inline       = [
+      "sudo systemctl stop firewalld",
+      "sudo systemctl disable firewalld",
+      "sudo systemctl stop iptables",
+      "sudo systemctl disable iptables",
+      "sudo sed -i \"s/SELINUX=permissive/SELINUX=enforcing/\" /etc/selinux/config",
+      "curl https://releases.rancher.com/install-docker/${var.docker_version}.sh | sh",
+      "sudo usermod -aG docker $USER",
+      "sudo systemctl enable docker",
+      "echo '{\"selinux-enabled\": true}' | sudo tee /etc/docker/daemon.json",
+      "sudo service docker start",
+      "sudo getenforce",
+      "sudo systemctl status docker",
+      "sudo docker info",
+      "sudo reboot"
+    ]
+    expect_disconnect = true
+  }
+  provisioner "shell" {
+    inline = [
+      "selstatus=$(sudo getenforce) && if (($selstatus != \"Enforcing\")); then exit 1; fi",
+      "echo 'SELINUX ENABLED'"
+    ]
+    pause_before = "60s"
+    max_retries  = 2
+  }
+}

--- a/tests/validation/tests/packer/oraclelinux.pkr.hcl
+++ b/tests/validation/tests/packer/oraclelinux.pkr.hcl
@@ -1,0 +1,64 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "oraclelinux-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "oraclelinux" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "*OL${var.os_version}-*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # oraclelinux AMI Owner
+    owners      = ["131827586825"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "ec2-user"
+  run_tags = {
+    "Name" = "oraclelinux-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.oraclelinux"]
+
+  provisioner "shell" {
+    inline       = [
+      "sudo systemctl stop firewalld",
+      "sudo systemctl disable firewalld",
+      "sudo systemctl stop iptables",
+      "sudo systemctl disable iptables",
+      "curl https://releases.rancher.com/install-docker/${var.docker_version}.sh | sh",
+      "sudo usermod -aG docker $USER",
+      "sudo systemctl enable docker",
+      "sudo service docker start",
+      "sudo docker info",
+    ]
+  }
+}

--- a/tests/validation/tests/packer/rancheros.pkr.hcl
+++ b/tests/validation/tests/packer/rancheros.pkr.hcl
@@ -1,0 +1,54 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "rancheros-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "rancheros" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "*rancheros-v${var.os_version}-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["605812595337"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "rancher"
+  run_tags = {
+    "Name" = "rancheros-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.rancheros"]
+
+  provisioner "shell" {
+    inline = [
+      "sudo ros engine switch docker-${var.docker_version}",
+      "sudo ros engine enable docker-${var.docker_version}"
+    ]
+  }
+}

--- a/tests/validation/tests/packer/rhel-no-selinux-no-docker.pkr.hcl
+++ b/tests/validation/tests/packer/rhel-no-selinux-no-docker.pkr.hcl
@@ -1,0 +1,63 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "rhel-${env("OS_VERSION")}-no-selinux-no-docker"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "rhel" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "*RHEL-${var.os_version}*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # rhel AMI Owner
+    owners      = ["309956199498"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "ec2-user"
+  run_tags = {
+    "Name" = "rhel-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.rhel"]
+
+  provisioner "shell" {
+    inline = [
+      "sudo yum remove docker docker-client docker-client-latest docker-common docker-latest docker-latest-logrotate docker-logrotatedocker-engine",
+      "sudo sed -i \"s/SELINUX=enforcing/SELINUX=disabled/\" /etc/selinux/config",
+      "sudo setenforce 0",
+      "sudo reboot",
+    ]
+    expect_disconnect = true
+  }
+  provisioner "shell" {
+    inline = [
+      "selstatus=$(sudo getenforce) && if (($selstatus != \"Disabled\")); then exit 1; fi",
+      "echo 'SELINUX DISABLED'"
+    ]
+    pause_before = "60s"
+    max_retries  = 2
+  }
+}

--- a/tests/validation/tests/packer/rhel-selinux-docker-rpm.pkr.hcl
+++ b/tests/validation/tests/packer/rhel-selinux-docker-rpm.pkr.hcl
@@ -1,0 +1,75 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "rhel-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}-selinux-on-rpm"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "rhel" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true 
+  source_ami_filter {
+    filters = {
+      name                = "*RHEL-${var.os_version}*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # rhel AMI Owner
+    owners      = ["309956199498"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "ec2-user"
+  run_tags = {
+    "Name" = "rhel-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.rhel"]
+
+  provisioner "shell" {
+    inline = [
+      "curl https://releases.rancher.com/install-docker/${var.docker_version}.sh | sh",
+      "sudo usermod -aG docker $USER",
+      "sudo systemctl enable docker",
+      "echo '{\"selinux-enabled\": true}' | sudo tee /etc/docker/daemon.json",
+      "sudo service docker start",
+      "sudo getenforce",
+      "sudo systemctl status docker",
+      "sudo docker info",
+      "sudo bash -c \"cat << EOF > /etc/yum.repos.d/rancher-testing.repo\n[rancher-testing]\nname=Rancher Testing\nbaseurl=https://rpm-testing.rancher.io/rancher/testing/centos/8/noarch\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm-testing.rancher.io/public.key\nEOF\"",
+      "sudo yum -y install rancher-selinux",
+      "if [[ ${var.os_version} > 8.3 ]]; then sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer; fi",
+      "sudo reboot"
+    ]
+    expect_disconnect = true
+  }
+  provisioner "shell" {
+    inline = [
+      "echo 'RHEL BUILD COMPLETED'"
+    ]
+    pause_before = "60s"
+    max_retries  = 2
+  }
+}

--- a/tests/validation/tests/packer/rhel-selinux-docker-rpm7.pkr.hcl
+++ b/tests/validation/tests/packer/rhel-selinux-docker-rpm7.pkr.hcl
@@ -1,0 +1,65 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "rhel-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}-selinux-on-rpm"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "rhel" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "*RHEL-${var.os_version}*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # rhel AMI Owner
+    owners      = ["309956199498"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "ec2-user"
+  run_tags = {
+    "Name" = "rhel-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.rhel"]
+
+  provisioner "shell" {
+    inline = [
+      "curl https://releases.rancher.com/install-docker/${var.docker_version}.sh | sh",
+      "sudo usermod -aG docker $USER",
+      "sudo systemctl enable docker",
+      "echo '{\"selinux-enabled\": true}' | sudo tee /etc/docker/daemon.json",
+      "sudo service docker start",
+      "sudo getenforce",
+      "sudo systemctl status docker",
+      "sudo docker info",
+      "sudo bash -c \"cat << EOF > /etc/yum.repos.d/rancher-testing.repo\n[rancher-testing]\nname=Rancher Testing\nbaseurl=https://rpm-testing.rancher.io/rancher/testing/centos/7/noarch\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm-testing.rancher.io/public.key\nEOF\"",
+      "sudo yum -y install rancher-selinux"
+    ]
+  }
+}

--- a/tests/validation/tests/packer/rhel-selinux-docker.pkr.hcl
+++ b/tests/validation/tests/packer/rhel-selinux-docker.pkr.hcl
@@ -1,0 +1,63 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "rhel-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}-selinux-on"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "rhel" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "*RHEL-${var.os_version}*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # rhel AMI Owner
+    owners      = ["309956199498"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "ec2-user"
+  run_tags = {
+    "Name" = "rhel-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.rhel"]
+
+  provisioner "shell" {
+    inline = [
+      "curl https://releases.rancher.com/install-docker/${var.docker_version}.sh | sh",
+      "sudo usermod -aG docker $USER",
+      "sudo systemctl enable docker",
+      "echo '{\"selinux-enabled\": true}' | sudo tee /etc/docker/daemon.json",
+      "sudo service docker start",
+      "sudo getenforce",
+      "sudo systemctl status docker",
+      "sudo docker info"
+    ]
+  }
+}

--- a/tests/validation/tests/packer/rhel-selinux-no-docker-rpm.pkr.hcl
+++ b/tests/validation/tests/packer/rhel-selinux-no-docker-rpm.pkr.hcl
@@ -1,0 +1,63 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "rhel-${env("OS_VERSION")}-selinux-no-docker-rpm"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "rhel" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "*RHEL-${var.os_version}*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # rhel AMI Owner
+    owners      = ["309956199498"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "ec2-user"
+  run_tags = {
+    "Name" = "rhel-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.rhel"]
+
+  provisioner "shell" {
+    inline = [
+      "sudo getenforce",
+      "sudo bash -c \"cat << EOF > /etc/yum.repos.d/rancher-testing.repo\n[rancher-testing]\nname=Rancher Testing\nbaseurl=https://rpm-testing.rancher.io/rancher/testing/centos/8/noarch\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm-testing.rancher.io/public.key\nEOF\"",
+      "sudo yum -y install rancher-selinux",
+      "if [[ ${var.os_version} > 8.3 ]]; then sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer; fi",
+      "sudo reboot"
+    ]
+    expect_disconnect = true
+  }
+  provisioner "shell" {
+    inline = [
+      "echo 'RHEL BUILD COMPLETED'"
+    ]
+    pause_before = "60s"
+    max_retries  = 2
+  }
+}

--- a/tests/validation/tests/packer/rhel.pkr.hcl
+++ b/tests/validation/tests/packer/rhel.pkr.hcl
@@ -1,0 +1,73 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "rhel-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "rhel" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "*RHEL-${var.os_version}*x86_64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # rhel AMI Owner
+    owners      = ["309956199498"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "ec2-user"
+  run_tags = {
+    "Name" = "rhel-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.rhel"]
+
+  provisioner "shell" {
+    inline       = [
+      "curl https://releases.rancher.com/install-docker/${var.docker_version}.sh | sh",
+      "sudo usermod -aG docker $USER",
+      "sudo systemctl enable docker",
+      "sudo service docker start",
+      "sudo docker info",
+      "if [[ ${var.os_version} > 8.3 ]]; then sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer; fi",
+      # "if [[ ${var.os_version} > 8.3 ]]; then sudo systemctl stop NetworkManager.service NetworkManager-dispatcher.service NetworkManager-wait-online.service; fi",
+      # "if [[ ${var.os_version} > 8.3 ]]; then sudo systemctl disable NetworkManager.service NetworkManager-dispatcher.service NetworkManager-wait-online.service; fi",
+      # "if [[ ${var.os_version} > 8.3 ]]; then sudo systemctl list-unit-files | grep NetworkManager; fi",
+      "sudo reboot"
+    ]
+    expect_disconnect = true
+  }
+  provisioner "shell" {
+    inline = [
+      "echo 'RHEL BUILD COMPLETED'"
+    ]
+    pause_before = "60s"
+    max_retries  = 2
+  }
+}

--- a/tests/validation/tests/packer/scripts/user_data.ps1
+++ b/tests/validation/tests/packer/scripts/user_data.ps1
@@ -1,0 +1,39 @@
+<powershell>
+# Start
+Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine -Force -ErrorAction Ignore
+
+# Don't set this before Set-ExecutionPolicy as it throws an error
+$ErrorActionPreference = "stop"
+ 
+# Remove any existing Windows Management listeners
+Remove-Item -Path WSMan:\Localhost\listener\listener* -Recurse
+
+# Create self-signed cert for encrypted WinRM on port 5986
+$Cert = New-SelfSignedCertificate -CertstoreLocation Cert:\LocalMachine\My -DnsName $ENV:COMPUTERNAME
+New-Item -Path WSMan:\LocalHost\Listener -Transport HTTPS -Address * -CertificateThumbPrint $Cert.Thumbprint -Force
+
+# Configure UAC to allow privilege elevation in remote shells
+$Key = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
+$Setting = 'LocalAccountTokenFilterPolicy'
+Set-ItemProperty -Path $Key -Name $Setting -Value 1 -Force
+
+# Disable Real time monitoring
+cmd.exe /c netsh advfirewall set allprofiles state off
+ 
+# Configure WinRM to allow encrypted communication, and provide the self-signed cert to the WinRM listener
+cmd.exe /c winrm quickconfig -q
+cmd.exe /c winrm set "winrm/config" '@{MaxTimeoutms="1800000"}'
+cmd.exe /c winrm set "winrm/config/winrs" '@{MaxMemoryPerShellMB="1024"}'
+cmd.exe /c winrm set "winrm/config/service" '@{AllowUnencrypted="false"}'
+cmd.exe /c winrm set "winrm/config/client" '@{AllowUnencrypted="false"}'
+cmd.exe /c winrm set "winrm/config/service/auth" '@{Basic="true"}'
+cmd.exe /c winrm set "winrm/config/client/auth" '@{Basic="true"}'
+cmd.exe /c winrm set "winrm/config/service/auth" '@{CredSSP="true"}'
+cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTPS" "@{Port=`"5986`";Hostname=`"$($ENV:COMPUTERNAME)`";CertificateThumbprint=`"$($Cert.Thumbprint)`"}"
+cmd.exe /c netsh advfirewall firewall add rule profile=any name="Allow WinRM HTTPS" dir=in localport=5986 protocol=TCP action=allow
+
+# Restart WinRM, and set it so that it auto-launches on startup
+Stop-Service -Name "WinRM" -ErrorAction Stop
+Set-Service -Name "WinRM" -StartupType Automatic
+Start-Service -Name "WinRM" -ErrorAction Stop
+</powershell>

--- a/tests/validation/tests/packer/ubuntu-no-docker.pkr.hcl
+++ b/tests/validation/tests/packer/ubuntu-no-docker.pkr.hcl
@@ -1,0 +1,50 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "ubuntu-${env("OS_VERSION")}-no-docker"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "ubuntu" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions   = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/*/ubuntu-*-${var.os_version}-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+    }
+    most_recent = true
+    owners      = ["aws-marketplace"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "ubuntu"
+  run_tags = {
+    "Name" = "ubuntu-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.ubuntu"]
+
+  provisioner "shell" {
+    inline = [
+      "sudo ufw disable",
+      "sudo apt-get remove docker docker-engine docker.io containerd runc"
+    ]
+  }
+}

--- a/tests/validation/tests/packer/ubuntu.pkr.hcl
+++ b/tests/validation/tests/packer/ubuntu.pkr.hcl
@@ -1,0 +1,58 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "ubuntu-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "ubuntu" {
+  ami_name      = "${var.ami_name}"
+  instance_type = "t3.medium"
+  ami_regions    = ["us-east-2", "us-east-1", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/*/ubuntu-*-${var.os_version}-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+    }
+    most_recent = true
+    owners      = ["099720109477"]
+  }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 35
+    delete_on_termination = true
+  }
+  ssh_username = "ubuntu"
+  run_tags = {
+    "Name" = "ubuntu-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.ubuntu"]
+
+  provisioner "shell" {
+    inline = [
+      "sudo ufw disable",
+      "curl https://releases.rancher.com/install-docker/${var.docker_version}.sh | sh",
+      "sudo usermod -aG docker $USER",
+      "sudo systemctl enable docker && sudo systemctl start docker",
+      "sudo docker info"
+    ]
+  }
+}

--- a/tests/validation/tests/packer/windows.pkr.hcl
+++ b/tests/validation/tests/packer/windows.pkr.hcl
@@ -1,0 +1,99 @@
+variable "os_version" {
+  type = string
+  default = "${env("OS_VERSION")}"
+}
+
+variable "ami_name" {
+  type = string
+  default = "Windows-${env("OS_VERSION")}-docker-${env("DOCKER_VERSION")}-packer"
+}
+
+variable "docker_version" {
+  type = string
+  default = "${env("DOCKER_VERSION")}"
+}
+
+variable "winrm_username" {
+  type = string
+  default = "Administrator"
+}
+
+variable "aws_ssh_key" {
+  type = string
+  description = "This is the public ssh key: ssh-keygen -y -f aws.pem > your_pub_key.pub"
+  default = "${env("AWS_SSH_KEY")}"
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "windows" {
+  ami_name          = "${var.ami_name}"
+  instance_type     = "t3.xlarge"
+  ami_regions       = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  force_deregister = true
+  force_delete_snapshot = true
+  source_ami_filter {
+    filters = {
+      name                = "*Windows*Server-${var.os_version}*ContainersLatest*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+      is-public           = true
+    }
+    most_recent = true
+    # Windows AMI Owner
+    owners      = ["amazon"]
+  }
+  launch_block_device_mappings {
+    device_name           = "/dev/sda1"
+    volume_size           = 50
+    delete_on_termination = true
+  }
+  user_data_file = "./scripts/user_data.ps1"
+  communicator   = "winrm"
+  winrm_username = "${var.winrm_username}"
+  winrm_port     = 5986
+  winrm_timeout  = "5m"
+  winrm_use_ssl  = true
+  winrm_insecure = true
+  run_tags = {
+    "Name" = "Windows-${var.os_version}-packer-${local.timestamp}"
+  }
+}
+
+
+build {
+  sources = ["source.amazon-ebs.windows"]
+
+  provisioner "powershell" {
+    inline = [
+      "Set-Content -Path C:\\ProgramData\\ssh\\administrators_authorized_keys -Value '${var.aws_ssh_key}'",
+      "$acl = Get-Acl C:\\ProgramData\\ssh\\administrators_authorized_keys",
+      "$acl.SetAccessRuleProtection($true, $false)",
+      "$administratorsRule = New-Object system.security.accesscontrol.filesystemaccessrule(\"Administrators\",\"FullControl\",\"Allow\")",
+      "$systemRule = New-Object system.security.accesscontrol.filesystemaccessrule(\"SYSTEM\",\"FullControl\",\"Allow\")",
+      "$acl.SetAccessRule($administratorsRule)",
+      "$acl.SetAccessRule($systemRule)",
+      "$acl | Set-Acl",
+      "Get-WindowsCapability -Online | ? Name -like 'OpenSSH*'",
+      "Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0",
+      "Start-Service sshd",
+      "Set-Service -Name sshd -StartupType 'Automatic'",      
+      "$launchConfig = Get-Content -Path C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Config\\LaunchConfig.json | ConvertFrom-Json",
+      "$launchConfig.adminPasswordType = 'Random'",
+      "$launchConfig",
+      "Set-Content -Value ($launchConfig | ConvertTo-Json) -Path C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Config\\LaunchConfig.json",
+      "iwr -outf docker-install.ps1 https://gist.githubusercontent.com/thxCode/cd8ec26795a56eb120b57675f0c067cf/raw/34b05ce095d99e7539d330760c2d880179cc971a/docker-install.ps1; ./docker-install.ps1 -Version ${var.docker_version}",
+    ]
+    elevated_user = "SYSTEM"
+    elevated_password = ""
+  }
+  provisioner "powershell" {
+    inline = [
+      "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\InitializeInstance.ps1 -Schedule",
+      "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\SysprepInstance.ps1"
+    ]
+    pause_before = "60s"
+    max_retries  = 2  
+  }
+}


### PR DESCRIPTION
This is an initial PR for https://github.com/rancher/qa-tasks/issues/27 

- To start adding packer templates for our test AMIs

We can use environment variables to set some of the dynamic values in the templates.

- `OS_VERSION=18.04`
- `DOCKER_VERSION=19.03.15` (on windows `19.03`)

Windows only
- `AWS_SSH_KEY=<>` for windows key base auth.
  - This is the public ssh key: `ssh-keygen -y -f aws.pem > your_pub_key.pub`


Packer version: 1.7.0

Usage:
- Set the environment variables and run
-`packer build file.pkr.hcl`
- AMI will be created on all US regions by default