### PR TITLE
Preserve v3 cluster fields on a v1 cluster apply

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -223,7 +223,7 @@ func (h *handler) createToken(_ string, cluster *v3.Cluster) (*v3.Cluster, error
 }
 
 func (h *handler) createOrUpdateCluster(cluster *v1.Cluster, status v1.ClusterStatus) ([]runtime.Object, v1.ClusterStatus, error) {
-	mgmtCluster, err := h.mgmtClusterCache.Get(cluster.Name)
+	mgmtCluster, err := h.mgmtClusters.Get(cluster.Name, metav1.GetOptions{})
 	if h.isLegacyCluster(cluster) {
 		if err != nil {
 			// For legacy clusters, if the mgmt cluster does not exist we must immediately return

--- a/pkg/controllers/provisioningv2/cluster/import.go
+++ b/pkg/controllers/provisioningv2/cluster/import.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/wrangler/pkg/apply"
@@ -19,10 +18,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func (h *handler) createClusterAndDeployAgent(cluster *v1.Cluster, status v1.ClusterStatus) ([]runtime.Object, v1.ClusterStatus, error) {
-	objs, status, err := h.createCluster(cluster, status, v3.ClusterSpec{
-		ImportedConfig: &v3.ImportedConfig{},
-	})
+func (h *handler) createOrUpdateClusterAndDeployAgent(cluster *v1.Cluster, status v1.ClusterStatus) ([]runtime.Object, v1.ClusterStatus, error) {
+	objs, status, err := h.createOrUpdateCluster(cluster, status)
 	if err != nil {
 		return nil, status, err
 	}


### PR DESCRIPTION
On trying to update a v3 cluster (e.g. enabling Monitoring V1 by setting `enableClusterMonitoring: true`) that is owned by a v1 cluster, the v1 cluster object gets re-enqueued since a related resource to it has been changed. This is the case for RKE2 provisioned clusters and any imported cluster that was imported via the Dashboard UI.

Since the v1 cluster gets re-enqueued, a wrangler apply is re-executed, causing the v3 cluster to be regenerated again. This effectively erases the results of trying to update the v3 cluster in the first place.

As a result, this fix ensures that on a re-apply, we preserve the v3 cluster spec that already exists if it exists, which ensures that any fields that cannot be directly translated from the v1 spec (e.g. legacy fields) continue to be preserved.

Related Issue: https://github.com/rancher/rancher/issues/32969