### PR TITLE
Fix ingress template for `helm template` command

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -41,7 +41,7 @@ spec:
     http:
       paths:
       - backend:
-          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+          {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
           service:
             name: {{ template "rancher.fullname" . }}
             port:
@@ -50,7 +50,7 @@ spec:
           serviceName: {{ template "rancher.fullname" . }}
           servicePort: 80
           {{- end }}
-        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+        {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
         pathType: ImplementationSpecific
         {{- end }}
 {{- if eq .Values.tls "ingress" }}


### PR DESCRIPTION
Without this patch, the `helm template` command generates Ingress
resources that use the `networking.k8s.io/v1beta1` APIVersion. This is
because the `helm template` command does not populate the
`Capabilities.APIVersions` set with real available resources, it only
creates a fake set of API versions that does not include resources, so
it does not have `networking.k8s.io/v1/Ingress` in the set. Since the
fake set also does not include `networking.k8s.io/v1beta1/Ingress`, we
can assume in that case that we are running in `helm template` and we
should default to the v1 version.

https://github.com/rancher/rancher/issues/30053