### PR TITLE
After creating an app revision on install/upgrade, prune old revisions

### DIFF
--- a/pkg/apis/project.cattle.io/v3/app_types.go
+++ b/pkg/apis/project.cattle.io/v3/app_types.go
@@ -38,6 +38,7 @@ type AppSpec struct {
 	Prune               bool              `json:"prune,omitempty"`
 	MultiClusterAppName string            `json:"multiClusterAppName,omitempty" norman:"type=reference[/v3/schemas/multiclusterapp]"`
 	ValuesYaml          string            `json:"valuesYaml,omitempty"`
+	MaxRevisionCount    int               `json:"maxRevisionCount,omitempty"`
 }
 
 func (a *AppSpec) ObjClusterName() string {

--- a/pkg/controllers/managementuser/helm/controller.go
+++ b/pkg/controllers/managementuser/helm/controller.go
@@ -39,6 +39,7 @@ const (
 	creatorIDAnn              = "field.cattle.io/creatorId"
 	MultiClusterAppIDSelector = "mcapp"
 	projectIDFieldLabel       = "field.cattle.io/projectId"
+	defaultMaxRevisionCount   = 10
 )
 
 func Register(ctx context.Context, user *config.UserContext, kubeConfigGetter common.KubeConfigGetter) {
@@ -319,6 +320,7 @@ func (l *Lifecycle) Remove(obj *v3.App) (runtime.Object, error) {
 }
 
 func (l *Lifecycle) Run(obj *v3.App, template string, tempDirs *hCommon.HelmPath) error {
+	defer l.pruneOldRevisions(obj)
 	err := l.writeKubeConfig(obj, tempDirs.KubeConfigFull, false)
 	if err != nil {
 		return err
@@ -334,6 +336,33 @@ func (l *Lifecycle) Run(obj *v3.App, template string, tempDirs *hCommon.HelmPath
 		return err
 	}
 	return l.createAppRevision(obj, template, notes, false)
+}
+
+// pruneOldRevisions checks if the total number of app revisions does not exceed the set maximum.
+// If it does, the method deletes the oldest revision(s) to maintain the maximum number of revisions and no more.
+func (l *Lifecycle) pruneOldRevisions(obj *v3.App) {
+	if obj.Spec.MaxRevisionCount < 1 {
+		obj.Spec.MaxRevisionCount = defaultMaxRevisionCount
+	}
+	_, projectName := ref.Parse(obj.Spec.ProjectName)
+	appRevisionClient := l.AppRevisionGetter.AppRevisions(projectName)
+	revisions, err := appRevisionClient.List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", appLabel, obj.Name),
+	})
+	if err != nil {
+		logrus.Tracef("[helm-controller] Failed to list revisions for app %s: %v", projectName, err)
+		return
+	}
+
+	if len(revisions.Items) > obj.Spec.MaxRevisionCount {
+		logrus.Tracef("[helm-controller] App %s is exceeding the maximum (%d) number of stored revisions", obj.Name, obj.Spec.MaxRevisionCount)
+		deleteCount := len(revisions.Items) - obj.Spec.MaxRevisionCount
+		for _, revision := range revisions.Items[:deleteCount] {
+			if err := appRevisionClient.Delete(revision.Name, &metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+				logrus.Tracef("[helm-controller] Failed to delete app revision %s: %v", revision.Name, err)
+			}
+		}
+	}
 }
 
 func (l *Lifecycle) createAppRevision(obj *v3.App, template, notes string, failed bool) error {

--- a/pkg/controllers/managementuser/helm/controller.go
+++ b/pkg/controllers/managementuser/helm/controller.go
@@ -350,7 +350,7 @@ func (l *Lifecycle) pruneOldRevisions(obj *v3.App) {
 		LabelSelector: fmt.Sprintf("%s=%s", appLabel, obj.Name),
 	})
 	if err != nil {
-		logrus.Tracef("[helm-controller] Failed to list revisions for app %s: %v", projectName, err)
+		logrus.Warnf("[helm-controller] Failed to list revisions for app %s: %v", projectName, err)
 		return
 	}
 
@@ -359,7 +359,7 @@ func (l *Lifecycle) pruneOldRevisions(obj *v3.App) {
 		deleteCount := len(revisions.Items) - obj.Spec.MaxRevisionCount
 		for _, revision := range revisions.Items[:deleteCount] {
 			if err := appRevisionClient.Delete(revision.Name, &metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-				logrus.Tracef("[helm-controller] Failed to delete app revision %s: %v", revision.Name, err)
+				logrus.Warnf("[helm-controller] Failed to delete app revision %s: %v", revision.Name, err)
 			}
 		}
 	}


### PR DESCRIPTION
Issue [#20654](https://github.com/rancher/rancher/issues/20654)
The Helm controller will now limit the number of app revisions per app. By default, up to 10 revisions will be kept in etcd per app.
Users will be able to set the limit themselves. But only on app installation and only by modifying the API request.

This affects new apps and existing apps. For existing apps, a new upgrade/rollback will trigger the pruning of old app revisions. For example, if an app has 200 revisions stored in etcd, then on the next app change, a new revision will be created and 191 of the old ones will be deleted, so Rancher will maintain only the 10 newest revisions (by default) at all times.