### PR TITLE
Adding fixes for hardened local cluster

### DIFF
--- a/tests/validation/tests/v3_api/resource/sysctl-config
+++ b/tests/validation/tests/v3_api/resource/sysctl-config
@@ -1,5 +1,5 @@
-sysctl vm.overcommit_memory=1
-sysctl vm.panic_on_oom=0
-sysctl kernel.panic=10
-sysctl kernel.panic_on_oops=1
-sysctl kernel.keys.root_maxbytes=25000000
+sudo sysctl vm.overcommit_memory=1
+sudo sysctl vm.panic_on_oom=0
+sudo sysctl kernel.panic=10
+sudo sysctl kernel.panic_on_oops=1
+sudo sysctl kernel.keys.root_maxbytes=25000000


### PR DESCRIPTION
Was missing sudo in the sysctl commands, and hence the commands never ran on the nodes. And rke up resulted in failure. Kubelet on the nodes were in a state of panic. 