### PR TITLE
Allow cloud credential usage for owned clusters

### DIFF
--- a/pkg/api/norman/customization/aks/listers.go
+++ b/pkg/api/norman/customization/aks/listers.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/mcuadros/go-version"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 )
 
@@ -147,13 +147,13 @@ type UpgradeVersionsResponse struct {
 }
 
 // listKubernetesUpgradeVersions lists all kubernetes versions listed by AKS Container Service and marks which ones the
-//given cluster can be upgraded to.  A version's `Enabled` flag is true if the cluster can be upgraded to the version
-//in its current state.
-func listKubernetesUpgradeVersions(ctx context.Context, clusterLister v3.ClusterLister, cap *Capabilities) ([]byte, int, error) {
+// given cluster can be upgraded to.  A version's `Enabled` flag is true if the cluster can be upgraded to the version
+// in its current state.
+func listKubernetesUpgradeVersions(ctx context.Context, clusterLister mgmtv3.ClusterCache, cap *Capabilities) ([]byte, int, error) {
 	var resp UpgradeVersionsResponse
 
 	// load the target cluster, if the cluster is not found we cannot proceed
-	cluster, err := clusterLister.Get("", cap.ClusterID)
+	cluster, err := clusterLister.Get(cap.ClusterID)
 	if err != nil {
 		return nil, http.StatusBadRequest, fmt.Errorf("invalid cluster id")
 	}

--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -358,7 +358,7 @@ func (v *Validator) validateAKSConfig(request *types.APIContext, cluster map[str
 
 	// check user's access to cloud credential
 	if azureCredential, ok := aksConfig["azureCredentialSecret"].(string); ok {
-		if err := validateAKSCredentialAuth(request, azureCredential, prevCluster); err != nil {
+		if err := validateCredentialAuth(request, azureCredential); err != nil {
 			return err
 		}
 	}
@@ -390,35 +390,6 @@ func (v *Validator) validateAKSConfig(request *types.APIContext, cluster map[str
 	region, regionOk := aksConfig["resourceLocation"]
 	if !regionOk || region == "" {
 		return httperror.NewAPIError(httperror.InvalidBodyContent, "must provide region")
-	}
-
-	return nil
-}
-
-// validateAKSCredentialAuth validates that a user has access to the credential they are setting and the credential
-// they are overwriting. If there is no previous credential such as during a create or the old credential cannot
-// be found, the auth check will succeed as long as the user can access the new credential.
-func validateAKSCredentialAuth(request *types.APIContext, credential string, prevCluster *v3.Cluster) error {
-	var accessCred mgmtclient.CloudCredential
-	credentialErr := "error accessing cloud credential"
-	if err := access.ByID(request, &mgmtSchema.Version, mgmtclient.CloudCredentialType, credential, &accessCred); err != nil {
-		return httperror.NewAPIError(httperror.NotFound, credentialErr)
-	}
-
-	if prevCluster == nil || prevCluster.Spec.AKSConfig == nil {
-		return nil
-	}
-
-	// validate the user has access to the old cloud credential before allowing them to change it
-	credential = prevCluster.Spec.AKSConfig.AzureCredentialSecret
-	if err := access.ByID(request, &mgmtSchema.Version, mgmtclient.CloudCredentialType, credential, &accessCred); err != nil {
-		if apiError, ok := err.(*httperror.APIError); ok {
-			if apiError.Code.Status == httperror.NotFound.Status {
-				// old cloud credential doesn't exist anymore, anyone can change it
-				return nil
-			}
-		}
-		return httperror.NewAPIError(httperror.NotFound, credentialErr)
 	}
 
 	return nil
@@ -531,7 +502,7 @@ func (v *Validator) validateEKSConfig(request *types.APIContext, cluster map[str
 
 	// check user's access to cloud credential
 	if amazonCredential, ok := eksConfig["amazonCredentialSecret"].(string); ok {
-		if err := validateEKSCredentialAuth(request, amazonCredential, prevCluster); err != nil {
+		if err := validateCredentialAuth(request, amazonCredential); err != nil {
 			return err
 		}
 	}
@@ -627,36 +598,13 @@ func validateEKSKubernetesVersion(spec *v32.ClusterSpec, prevCluster *v3.Cluster
 	return nil
 }
 
-// validateEKSCredentialAuth validates that a user has access to the credential they are setting and the credential
-// they are overwriting. If there is no previous credential such as during a create or the old credential cannot
-// be found, the auth check will succeed as long as the user can access the new credential.
-func validateEKSCredentialAuth(request *types.APIContext, credential string, prevCluster *v3.Cluster) error {
+// validateCredentialAuth validates that a user has access to the credential they are setting.
+func validateCredentialAuth(request *types.APIContext, credential string) error {
 	var accessCred mgmtclient.CloudCredential
 	credentialErr := "error accessing cloud credential"
 	if err := access.ByID(request, &mgmtSchema.Version, mgmtclient.CloudCredentialType, credential, &accessCred); err != nil {
 		return httperror.NewAPIError(httperror.NotFound, credentialErr)
 	}
-
-	if prevCluster == nil {
-		return nil
-	}
-
-	if prevCluster.Spec.EKSConfig == nil {
-		return nil
-	}
-
-	// validate the user has access to the old cloud credential before allowing them to change it
-	credential = prevCluster.Spec.EKSConfig.AmazonCredentialSecret
-	if err := access.ByID(request, &mgmtSchema.Version, mgmtclient.CloudCredentialType, credential, &accessCred); err != nil {
-		if apiError, ok := err.(*httperror.APIError); ok {
-			if apiError.Code.Status == httperror.NotFound.Status {
-				// old cloud credential doesn't exist anymore, anyone can change it
-				return nil
-			}
-		}
-		return httperror.NewAPIError(httperror.NotFound, credentialErr)
-	}
-
 	return nil
 }
 
@@ -733,7 +681,7 @@ func (v *Validator) validateGKEConfig(request *types.APIContext, cluster map[str
 
 	// check user's access to cloud credential
 	if googleCredential, ok := gkeConfig["googleCredentialSecret"].(string); ok {
-		if err := validateGKECredentialAuth(request, googleCredential, prevCluster); err != nil {
+		if err := validateCredentialAuth(request, googleCredential); err != nil {
 			return err
 		}
 	}
@@ -793,39 +741,6 @@ func (v *Validator) validateGKENetworkPolicy(clusterSpec *v32.ClusterSpec, prevC
 			httperror.InvalidBodyContent,
 			"Network Policy support must be enabled on GKE cluster in order to enable Project Network Isolation",
 		)
-	}
-
-	return nil
-}
-
-// validateGKECredentialAuth validates that a user has access to the credential they are setting and the credential
-// they are overwriting. If there is no previous credential such as during a create or the old credential cannot
-// be found, the auth check will succeed as long as the user can access the new credential.
-func validateGKECredentialAuth(request *types.APIContext, credential string, prevCluster *v3.Cluster) error {
-	var accessCred mgmtclient.CloudCredential
-	credentialErr := "error accessing cloud credential"
-	if err := access.ByID(request, &mgmtSchema.Version, mgmtclient.CloudCredentialType, credential, &accessCred); err != nil {
-		return httperror.NewAPIError(httperror.NotFound, credentialErr)
-	}
-
-	if prevCluster == nil {
-		return nil
-	}
-
-	if prevCluster.Spec.GKEConfig == nil {
-		return nil
-	}
-
-	// validate the user has access to the old cloud credential before allowing them to change it
-	credential = prevCluster.Spec.GKEConfig.GoogleCredentialSecret
-	if err := access.ByID(request, &mgmtSchema.Version, mgmtclient.CloudCredentialType, credential, &accessCred); err != nil {
-		if apiError, ok := err.(*httperror.APIError); ok {
-			if apiError.Code.Status == httperror.NotFound.Status {
-				// old cloud credential doesn't exist anymore, anyone can change it
-				return nil
-			}
-		}
-		return httperror.NewAPIError(httperror.NotFound, credentialErr)
 	}
 
 	return nil

--- a/pkg/controllers/dashboard/hostedcluster/controller.go
+++ b/pkg/controllers/dashboard/hostedcluster/controller.go
@@ -64,7 +64,7 @@ type handler struct {
 	secrets      v1.SecretController
 }
 
-func Register(ctx context.Context, wContext *wrangler.Context) error {
+func Register(ctx context.Context, wContext *wrangler.Context) {
 	h := &handler{
 		manager:      wContext.SystemChartsManager,
 		apps:         wContext.Project.App(),
@@ -75,8 +75,6 @@ func Register(ctx context.Context, wContext *wrangler.Context) error {
 
 	wContext.Mgmt.Cluster().OnChange(ctx, "cluster-provisioning-operator", h.onClusterChange)
 	wContext.Core.Secret().OnChange(ctx, "watch-helm-release", h.onSecretChange)
-
-	return nil
 }
 
 func (h handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster, error) {

--- a/pkg/controllers/management/cluster/indexers.go
+++ b/pkg/controllers/management/cluster/indexers.go
@@ -1,0 +1,30 @@
+package cluster
+
+import (
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/types/config"
+)
+
+const ByCloudCredential = "byCloudCredential"
+
+func RegisterIndexers(context *config.ScaledContext) {
+	context.Wrangler.Mgmt.Cluster().Cache().AddIndexer(ByCloudCredential, byCloudCredentialIndexer)
+}
+
+func byCloudCredentialIndexer(obj *v3.Cluster) ([]string, error) {
+	switch {
+	case obj.Spec.EKSConfig != nil:
+		if obj.Spec.EKSConfig.AmazonCredentialSecret != "" {
+			return []string{obj.Spec.EKSConfig.AmazonCredentialSecret}, nil
+		}
+	case obj.Spec.AKSConfig != nil:
+		if obj.Spec.AKSConfig.AzureCredentialSecret != "" {
+			return []string{obj.Spec.AKSConfig.AzureCredentialSecret}, nil
+		}
+	case obj.Spec.GKEConfig != nil:
+		if obj.Spec.GKEConfig.GoogleCredentialSecret != "" {
+			return []string{obj.Spec.GKEConfig.GoogleCredentialSecret}, nil
+		}
+	}
+	return nil, nil
+}

--- a/pkg/controllers/managementapi/controllers.go
+++ b/pkg/controllers/managementapi/controllers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/controllers/management/auth"
+	v3cluster "github.com/rancher/rancher/pkg/controllers/management/cluster"
 	podsecuritypolicy2 "github.com/rancher/rancher/pkg/controllers/management/podsecuritypolicy"
 	"github.com/rancher/rancher/pkg/controllers/managementapi/catalog"
 	"github.com/rancher/rancher/pkg/controllers/managementapi/dynamicschema"
@@ -59,5 +60,6 @@ func registerIndexers(ctx context.Context, scaledContext *config.ScaledContext) 
 		return err
 	}
 	cluster.RegisterIndexers(scaledContext)
+	v3cluster.RegisterIndexers(scaledContext)
 	return nil
 }

--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -428,7 +428,7 @@ type createFn func(objectMeta metav1.ObjectMeta, subjects []rbacv1.Subject, role
 type listFn func(ns string, selector labels.Selector) ([]interface{}, error)
 type convertFn func(i interface{}) (string, string, []rbacv1.Subject)
 
-func (m *manager) ensureBindings(ns string, roles map[string]*v3.RoleTemplate, binding interface{}, client *objectclient.ObjectClient,
+func (m *manager) ensureBindings(ns string, roles map[string]*v3.RoleTemplate, binding metav1.Object, client *objectclient.ObjectClient,
 	create createFn, list listFn, convert convertFn) error {
 	meta, err := meta.Accessor(binding)
 	if err != nil {

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -37,6 +37,7 @@ import (
 
 const (
 	ByCluster        = "by-cluster"
+	ByCloudCred      = "by-cloud-cred"
 	creatorIDAnn     = "field.cattle.io/creatorId"
 	administratedAnn = "provisioning.cattle.io/administrated"
 )
@@ -125,6 +126,7 @@ func Register(
 func RegisterIndexers(context *config.ScaledContext) {
 	if features.ProvisioningV2.Enabled() {
 		context.Wrangler.Provisioning.Cluster().Cache().AddIndexer(ByCluster, byClusterIndex)
+		context.Wrangler.Provisioning.Cluster().Cache().AddIndexer(ByCloudCred, byCloudCredentialIndex)
 	}
 }
 
@@ -133,6 +135,13 @@ func byClusterIndex(obj *v1.Cluster) ([]string, error) {
 		return nil, nil
 	}
 	return []string{obj.Status.ClusterName}, nil
+}
+
+func byCloudCredentialIndex(obj *v1.Cluster) ([]string, error) {
+	if obj.Spec.CloudCredentialSecretName == "" {
+		return nil, nil
+	}
+	return []string{obj.Spec.CloudCredentialSecretName}, nil
 }
 
 func (h *handler) clusterWatch(namespace, name string, obj runtime.Object) ([]relatedresource.Key, error) {

--- a/pkg/httpproxy/proxy.go
+++ b/pkg/httpproxy/proxy.go
@@ -9,6 +9,11 @@ import (
 	"strings"
 	"time"
 
+	prov "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/controllers/management/cluster"
+	provcluster "github.com/rancher/rancher/pkg/controllers/provisioningv2/cluster"
+	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	provv1 "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
@@ -57,7 +62,8 @@ type proxy struct {
 	prefix             string
 	validHostsSupplier Supplier
 	credentials        v1.SecretInterface
-	clusters           v3.ClusterInterface
+	mgmtClustersCache  mgmtv3.ClusterCache
+	provClustersCache  provv1.ClusterCache
 	authorizer         authorizer.Authorizer
 }
 
@@ -100,7 +106,8 @@ func NewProxy(prefix string, validHosts Supplier, scaledContext *config.ScaledCo
 		prefix:             prefix,
 		validHostsSupplier: validHosts,
 		credentials:        scaledContext.Core.Secrets(""),
-		clusters:           scaledContext.Management.Clusters(""),
+		mgmtClustersCache:  scaledContext.Wrangler.Mgmt.Cluster().Cache(),
+		provClustersCache:  scaledContext.Wrangler.Provisioning.Cluster().Cache(),
 	}
 
 	return &httputil.ReverseProxy{
@@ -214,10 +221,7 @@ func (p *proxy) secretGetter(req *http.Request, cAuth string) SecretGetter {
 		}
 		unauthorizedErr := fmt.Errorf("unauthorized %s to %s/%s: %s", user.GetName(), namespace, name, reason)
 		if decision != authorizer.DecisionAllow {
-			if clusterID == "" {
-				return nil, unauthorizedErr
-			}
-			decision, err = p.checkCluster(req, user, clusterID, fmt.Sprintf("%s:%s", namespace, name))
+			decision, err = p.checkIndirectAccessViaCluster(req, user, clusterID, fmt.Sprintf("%s:%s", namespace, name))
 			if err != nil {
 				return nil, err
 			}
@@ -229,17 +233,69 @@ func (p *proxy) secretGetter(req *http.Request, cAuth string) SecretGetter {
 	}
 }
 
-func (p *proxy) checkCluster(req *http.Request, user user.Info, clusterID, credID string) (authorizer.Decision, error) {
-	cluster, err := p.clusters.Controller().Lister().Get("", clusterID)
-	if err != nil {
+// checkIndirectAccessViaCluster checks if the user has access to the cloud credential via being owner of a cluster associated to the cloud credential.
+// Currently, only EKS and provisioningv2 clusters are supported because those clusters have a cloud credential associated to them.
+// GKE and AKS clusters also have cloud credential associated to them, but those are checked via specific proxies (not the meta proxy).
+func (p *proxy) checkIndirectAccessViaCluster(req *http.Request, user user.Info, clusterID, credID string) (authorizer.Decision, error) {
+	var (
+		mgmtClusters []*v3.Cluster
+		provClusters []*prov.Cluster
+		err          error
+	)
+	if clusterID == "" {
+		// If no clusterID is passed, then we check all clusters that the user has access to and are associated to the cloud credential.
+		// Both management and provisioning clusters should be checked.
+		mgmtClusters, err = p.mgmtClustersCache.GetByIndex(cluster.ByCloudCredential, credID)
+		if err != nil {
+			return authorizer.DecisionDeny, err
+		}
+
+		provClusters, err = p.provClustersCache.GetByIndex(provcluster.ByCloudCred, credID)
+		if err != nil {
+			return authorizer.DecisionDeny, err
+		}
+	} else {
+		if c, err := p.mgmtClustersCache.Get(clusterID); err == nil {
+			mgmtClusters = []*v3.Cluster{c}
+		} else {
+			return authorizer.DecisionDeny, err
+		}
+		provClusters, err = p.provClustersCache.GetByIndex(provcluster.ByCluster, clusterID)
+		if err != nil {
+			return authorizer.DecisionDeny, err
+		}
+	}
+	if len(mgmtClusters)+len(provClusters) == 0 {
 		return authorizer.DecisionDeny, err
 	}
-	if cluster.Spec.EKSConfig == nil {
-		return authorizer.DecisionDeny, nil
+
+	for _, c := range mgmtClusters {
+		if c.Spec.EKSConfig == nil || c.Spec.EKSConfig.AmazonCredentialSecret != credID {
+			continue
+		}
+
+		decision, err := p.checkAccessToV3ClusterWithID(req, user, c.Name)
+		if err == nil && decision == authorizer.DecisionAllow {
+			return decision, nil
+		}
 	}
-	if cluster.Spec.EKSConfig.AmazonCredentialSecret != credID {
-		return authorizer.DecisionDeny, nil
+
+	for _, c := range provClusters {
+		if c.Spec.CloudCredentialSecretName != credID {
+			continue
+		}
+
+		// Check that the user has access to the management cluster associated to the provisioning cluster.
+		// If a user has access to the management cluster, then the user has access to the provisioning cluster.
+		decision, err := p.checkAccessToV3ClusterWithID(req, user, c.Status.ClusterName)
+		if err == nil && decision == authorizer.DecisionAllow {
+			return decision, nil
+		}
 	}
+	return authorizer.DecisionDeny, nil
+}
+
+func (p *proxy) checkAccessToV3ClusterWithID(req *http.Request, user user.Info, clusterID string) (authorizer.Decision, error) {
 	decision, _, err := p.authorizer.Authorize(req.Context(), authorizer.AttributesRecord{
 		User:            user,
 		Verb:            "update",
@@ -249,6 +305,7 @@ func (p *proxy) checkCluster(req *http.Request, user user.Info, clusterID, credI
 		Name:            clusterID,
 		ResourceRequest: true,
 	})
+
 	return decision, err
 }
 

--- a/pkg/rbac/common_test.go
+++ b/pkg/rbac/common_test.go
@@ -8,11 +8,12 @@ import (
 	"github.com/rancher/norman/types"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_BuildSubjectFromRTB(t *testing.T) {
 	type testCase struct {
-		from  interface{}
+		from  metav1.Object
 		to    rbacv1.Subject
 		iserr bool
 	}


### PR DESCRIPTION
If a user is an owner of a cluster, then they should be allowed to use
the cloud credential associated to that cluster in the meta proxy. This
really only applies to KEv2 and RKE2/K3S provisioned clusters because
those clusters have cloud credentials associated to them.

In addition, if a user is a owner of a cluster, they should also be able
to change the cloud credential associated to a cluster to a cloud
credential they own regardless if they have access to the old cloud
credential.

This PR also fixes an obscure issue when running Rancher in a debugger (see the second commit message for details).

Issues:
https://github.com/rancher/rancher/issues/35413
https://github.com/rancher/rancher/issues/34800