### PR TITLE
re-enable rke provisioning tests for PRs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -48,9 +48,6 @@ steps:
   - name: docker
     path: /var/run/docker.sock
   when:
-    instance:
-      include:
-      - drone-publish.rancher.io
     event:
     - push
     - pull_request


### PR DESCRIPTION
RKE provisioning tests are currently only running on drone-publish and not on drone-pr. This re-enables them to run on all PRs, same as the k3s provisioning tests.

Drone PR showing the k3s provisioning tests running but the RKE tests not running
https://drone-pr.rancher.io/rancher/rancher/19234/2/1