### PR TITLE
Fix the issue of missing images in rancher-images.txt

### DIFF
--- a/scripts/package
+++ b/scripts/package
@@ -83,7 +83,7 @@ fi
 
 if [ ${ARCH} == amd64 ]; then
     # Move this out of ARCH check for local dev on non-amd64 hardware.
-    TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go $SYSTEM_CHART_REPO_DIR $CHART_REPO_DIR/assets $IMAGE $AGENT_IMAGE $RUNTIME_IMAGE $SYSTEM_AGENT_UPGRADE_IMAGE $SYSTEM_AGENT_INSTALLER_RKE2_IMAGES $SYSTEM_AGENT_INSTALLER_K3S_IMAGES
+    TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go $SYSTEM_CHART_REPO_DIR $CHART_REPO_DIR/assets $IMAGE $AGENT_IMAGE $RUNTIME_IMAGE $SYSTEM_AGENT_UPGRADE_IMAGE ${SYSTEM_AGENT_INSTALLER_RKE2_IMAGES[@]} ${SYSTEM_AGENT_INSTALLER_K3S_IMAGES[@]}
 
     # rancherd tarball
     rm -rf build/rancherd/bundle


### PR DESCRIPTION
If we want to print the array completely in the shell, we should use ${xxx[@]} instead of ${xxx}.

Example:
```
tt=( "1 2 3 4 5" )

echo ${tt}
# output: 1 2 3 4 5

echo ${tt[@]}
# output: 1 2 3 4 5
```
It does not seem to make a difference, however, if we do this:
```
tt=( `echo 1+ 2+ 3+ 4+ 5+ | tr + -` )

echo ${tt}
# output: 1-

echo ${tt[@]}
# output: 1- 2- 3- 4- 5-
```

This happens to cause some images to be missing, as shown in the figure:
<img width="535" alt="截屏2021-11-12 上午11 55 47" src="https://user-images.githubusercontent.com/998984/141406620-e5467194-95bf-415d-a1eb-bc74e81218bc.png">

