### PR TITLE
Swap go-version for blang/semver in catalog version validation

### DIFF
--- a/pkg/catalog/manager/manager_test.go
+++ b/pkg/catalog/manager/manager_test.go
@@ -53,17 +53,152 @@ func TestLatestAvailableTemplateVersion(t *testing.T) {
 		},
 	}
 
+	templateWithoutMinRancherVersion := &v3.CatalogTemplate{
+		Spec: v3.TemplateSpec{
+			Versions: []v3.TemplateVersionSpec{
+				{
+					ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.16",
+					Version:           "0.12.16",
+					RancherMaxVersion: "v2.3.0",
+				},
+				{
+					ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.15",
+					Version:           "0.12.15",
+					RancherMaxVersion: "v2.2.0",
+				},
+				{
+					ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.14",
+					Version:           "0.12.14",
+					RancherMaxVersion: "v2.1.0",
+				},
+			},
+		},
+	}
+
+	templateWithoutMaxRancherVersion := &v3.CatalogTemplate{
+		Spec: v3.TemplateSpec{
+			Versions: []v3.TemplateVersionSpec{
+				{
+					ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.16",
+					Version:           "0.12.16",
+					RancherMinVersion: "v2.2.0",
+				},
+				{
+					ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.15",
+					Version:           "0.12.15",
+					RancherMinVersion: "v2.1.0",
+				},
+				{
+					ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.14",
+					Version:           "0.12.14",
+					RancherMinVersion: "v2.0.0",
+				},
+			},
+		},
+	}
+
+	templateWithMinPrerelease := &v3.CatalogTemplate{
+		Spec: v3.TemplateSpec{
+			Versions: []v3.TemplateVersionSpec{
+				{
+					ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.16",
+					Version:           "0.12.16",
+					RancherMinVersion: "v2.2.1-rc1",
+					RancherMaxVersion: "v2.2.2",
+				},
+				{
+					ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.15",
+					Version:           "0.12.15",
+					RancherMinVersion: "v2.2.0-rc1",
+					RancherMaxVersion: "v2.2.1",
+				},
+				{
+					ExternalID: "catalog://?catalog=library&template=artifactory-ha&version=0.12.14",
+					Version:    "0.12.14",
+				},
+			},
+		},
+	}
+
+	templateWith99MaxPatchVersion := &v3.CatalogTemplate{
+		Spec: v3.TemplateSpec{
+			Versions: []v3.TemplateVersionSpec{
+				{
+					ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.16",
+					Version:           "0.12.16",
+					RancherMinVersion: "v2.3.0-alpha1",
+					RancherMaxVersion: "v2.3.99",
+				},
+				{
+					ExternalID:        "catalog://?catalog=library&template=artifactory-ha&version=0.12.15",
+					Version:           "0.12.15",
+					RancherMinVersion: "v2.2.0-alpha1",
+					RancherMaxVersion: "v2.2.99",
+				},
+				{
+					ExternalID: "catalog://?catalog=library&template=artifactory-ha&version=0.12.14",
+					Version:    "0.12.14",
+				},
+			},
+		},
+	}
+
+	testLatestAvailableTemplateVersion(t, "v2.0.1", "0.12.14", template)
+	testLatestAvailableTemplateVersion(t, "v2.0.2-beta", "0.12.14", template)
+	testLatestAvailableTemplateVersion(t, "v2.1.0-alpha1", "0.12.14", template)
 	testLatestAvailableTemplateVersion(t, "v2.1.0", "0.12.15", template)
+	testLatestAvailableTemplateVersion(t, "v2.2.5", "0.12.16", template)
 	testLatestAvailableTemplateVersion(t, "dev", "0.12.16", template)
 	testLatestAvailableTemplateVersion(t, "master", "0.12.16", template)
 	testLatestAvailableTemplateVersion(t, "master-head", "0.12.16", template)
 	testLatestAvailableTemplateVersion(t, "", "0.12.16", template)
 
+	testLatestAvailableTemplateVersion(t, "v2.0.1", "0.12.16", templateWithoutRancherVersion)
+	testLatestAvailableTemplateVersion(t, "v2.0.2-beta", "0.12.16", templateWithoutRancherVersion)
+	testLatestAvailableTemplateVersion(t, "v2.1.0-alpha1", "0.12.16", templateWithoutRancherVersion)
 	testLatestAvailableTemplateVersion(t, "v2.1.0", "0.12.16", templateWithoutRancherVersion)
-	testLatestAvailableTemplateVersion(t, "dev", "0.12.16", templateWithoutRancherVersion)
+	testLatestAvailableTemplateVersion(t, "v2.2.5", "0.12.16", templateWithoutRancherVersion)
 	testLatestAvailableTemplateVersion(t, "master", "0.12.16", templateWithoutRancherVersion)
 	testLatestAvailableTemplateVersion(t, "master-head", "0.12.16", templateWithoutRancherVersion)
 	testLatestAvailableTemplateVersion(t, "", "0.12.16", templateWithoutRancherVersion)
+
+	testLatestAvailableTemplateVersion(t, "v2.0.1", "0.12.16", templateWithoutMinRancherVersion)
+	testLatestAvailableTemplateVersion(t, "v2.0.2-beta", "0.12.16", templateWithoutMinRancherVersion)
+	testLatestAvailableTemplateVersion(t, "v2.1.0-alpha1", "0.12.16", templateWithoutMinRancherVersion)
+	testLatestAvailableTemplateVersion(t, "v2.1.0", "0.12.16", templateWithoutMinRancherVersion)
+	testLatestAvailableTemplateVersion(t, "v2.2.5", "0.12.16", templateWithoutMinRancherVersion)
+	testLatestAvailableTemplateVersion(t, "dev", "0.12.16", templateWithoutMinRancherVersion)
+	testLatestAvailableTemplateVersion(t, "master", "0.12.16", templateWithoutMinRancherVersion)
+	testLatestAvailableTemplateVersion(t, "master-head", "0.12.16", templateWithoutMinRancherVersion)
+	testLatestAvailableTemplateVersion(t, "", "0.12.16", templateWithoutMinRancherVersion)
+
+	testLatestAvailableTemplateVersion(t, "v2.0.1", "0.12.14", templateWithoutMaxRancherVersion)
+	testLatestAvailableTemplateVersion(t, "v2.0.2-beta", "0.12.14", templateWithoutMaxRancherVersion)
+	testLatestAvailableTemplateVersion(t, "v2.1.0-alpha1", "0.12.14", templateWithoutMaxRancherVersion)
+	testLatestAvailableTemplateVersion(t, "v2.1.0", "0.12.15", templateWithoutMaxRancherVersion)
+	testLatestAvailableTemplateVersion(t, "v2.2.5", "0.12.16", templateWithoutMaxRancherVersion)
+	testLatestAvailableTemplateVersion(t, "dev", "0.12.16", templateWithoutMaxRancherVersion)
+	testLatestAvailableTemplateVersion(t, "master", "0.12.16", templateWithoutMaxRancherVersion)
+	testLatestAvailableTemplateVersion(t, "master-head", "0.12.16", templateWithoutMaxRancherVersion)
+	testLatestAvailableTemplateVersion(t, "", "0.12.16", templateWithoutMaxRancherVersion)
+
+	testLatestAvailableTemplateVersion(t, "v2.2.0-0", "0.12.14", templateWithMinPrerelease)
+	testLatestAvailableTemplateVersion(t, "v2.2.0-alpha1", "0.12.14", templateWithMinPrerelease)
+	testLatestAvailableTemplateVersion(t, "v2.2.0-rc1", "0.12.15", templateWithMinPrerelease)
+	testLatestAvailableTemplateVersion(t, "v2.2.0", "0.12.15", templateWithMinPrerelease)
+	testLatestAvailableTemplateVersion(t, "v2.2.1-0", "0.12.15", templateWithMinPrerelease)
+	testLatestAvailableTemplateVersion(t, "v2.2.1-alpha1", "0.12.15", templateWithMinPrerelease)
+	testLatestAvailableTemplateVersion(t, "v2.2.1-rc1", "0.12.16", templateWithMinPrerelease)
+	testLatestAvailableTemplateVersion(t, "v2.2.1", "0.12.16", templateWithMinPrerelease)
+
+	testLatestAvailableTemplateVersion(t, "v2.2.0-0", "0.12.14", templateWith99MaxPatchVersion)
+	testLatestAvailableTemplateVersion(t, "v2.2.0-alpha1", "0.12.15", templateWith99MaxPatchVersion)
+	testLatestAvailableTemplateVersion(t, "v2.2.0-rc1", "0.12.15", templateWith99MaxPatchVersion)
+	testLatestAvailableTemplateVersion(t, "v2.2.0", "0.12.15", templateWith99MaxPatchVersion)
+	testLatestAvailableTemplateVersion(t, "v2.3.0-0", "0.12.14", templateWith99MaxPatchVersion)
+	testLatestAvailableTemplateVersion(t, "v2.3.0-alpha1", "0.12.16", templateWith99MaxPatchVersion)
+	testLatestAvailableTemplateVersion(t, "v2.3.0-rc1", "0.12.16", templateWith99MaxPatchVersion)
+	testLatestAvailableTemplateVersion(t, "v2.3.0", "0.12.16", templateWith99MaxPatchVersion)
 }
 
 func testLatestAvailableTemplateVersion(t *testing.T, serverVersion, expectedCatalogVersion string, template *v3.CatalogTemplate) {

--- a/tests/integration/suite/test_app.py
+++ b/tests/integration/suite/test_app.py
@@ -311,23 +311,27 @@ def test_app_create_validation(admin_mc, admin_pc, custom_catalog,
         }]
     }
 
-    set_server_version(client, "2.4.2-beta2")
+    server_version = "2.4.2-beta2"
+    set_server_version(client, server_version)
 
     # First try requires a min of 2.5.0 so an error should be returned
     with pytest.raises(ApiError) as e:
         app1 = admin_pc.client.create_app(app_data)
         remove_resource(app1)
     assert e.value.error.status == 422
-    assert e.value.error.message == 'rancher min version not met'
+    assert 'incompatible rancher version [%s] for template' % server_version \
+        in e.value.error.message
 
-    set_server_version(client, "2.7.1")
+    server_version = "2.7.1"
+    set_server_version(client, server_version)
 
     # Second try requires a max of 2.7.0 so an error should be returned
     with pytest.raises(ApiError) as e:
         app1 = admin_pc.client.create_app(app_data)
         remove_resource(app1)
     assert e.value.error.status == 422
-    assert e.value.error.message == 'rancher max version exceeded'
+    assert 'incompatible rancher version [%s] for template' % server_version \
+        in e.value.error.message
 
     set_server_version(client, "2.5.1-rc4")
 
@@ -387,7 +391,8 @@ def test_app_update_validation(admin_mc, admin_pc, custom_catalog,
         }]
     }
 
-    set_server_version(client, "2.4.2-rc3")
+    server_version = "2.4.2-rc3"
+    set_server_version(client, server_version)
 
     # Launch the app version 2.3.1 with rancher 2.4.2-rc3
     app1 = admin_pc.client.create_app(app_data)
@@ -407,15 +412,18 @@ def test_app_update_validation(admin_mc, admin_pc, custom_catalog,
     with pytest.raises(ApiError) as e:
         app1 = client.action(**upgrade_dict)
     assert e.value.error.status == 422
-    assert e.value.error.message == 'rancher min version not met'
+    assert 'incompatible rancher version [%s] for template' % server_version \
+        in e.value.error.message
 
-    set_server_version(client, "2.7.1")
+    server_version = "2.7.1"
+    set_server_version(client, server_version)
 
     # # Second try requires a max of 2.7.0 so an error should be returned
     with pytest.raises(ApiError) as e:
         app1 = client.action(**upgrade_dict)
     assert e.value.error.status == 422
-    assert e.value.error.message == 'rancher max version exceeded'
+    assert 'incompatible rancher version [%s] for template' % server_version \
+        in e.value.error.message
 
 
 @pytest.mark.nonparallel
@@ -523,23 +531,25 @@ def test_app_rollback_validation(admin_mc, admin_pc, custom_catalog,
         'forceUpgrade': False,
     }
 
-    set_server_version(client, "2.6.1")
+    server_version = "2.6.1"
+    set_server_version(client, server_version)
 
     # Rollback requires a max of 2.6.0 so an error should be returned
     with pytest.raises(ApiError) as e:
         client.action(**rollback_dict)
     assert e.value.error.status == 422
-    assert e.value.error.message == 'rancher max version exceeded'
+    assert 'incompatible rancher version [%s] for template' % server_version \
+        in e.value.error.message
 
-    set_server_version(client, "2.0.0-rc3")
+    server_version = "2.0.0-rc3"
+    set_server_version(client, server_version)
 
     # Second try requires a min of 2.4.1 so an error should be returned
     with pytest.raises(ApiError) as e:
         client.action(**rollback_dict)
-
-    msg = e.value.error
-    assert e.value.error.message == 'rancher min version not met', msg
     assert e.value.error.status == 422
+    assert 'incompatible rancher version [%s] for template' % server_version \
+        in e.value.error.message
 
 
 def test_app_has_helmversion(admin_pc, admin_mc, remove_resource):


### PR DESCRIPTION
Replace `go-version` check with `blang/semver`. 

Elected to use `blang/semver` as opposed to `Masterminds/semver` because the former was already being used in the file, and does handle prerelease correctly (after removing v prefix). Also updated unit tests to include `-0` in min and max versions, as well as add tests for max/min only present.

Related Issue: https://github.com/rancher/rancher/issues/32930