### PR TITLE
[2.5] convert sync handler to env vars

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -234,8 +234,8 @@ func redeployAgent(cluster *v3.Cluster, desiredAgent, desiredAuth string, desire
 		return true
 	}
 
-	if !reflect.DeepEqual(cluster.Spec.AgentEnvVars, cluster.Status.AppliedAgentEnvVars) {
-		logrus.Infof("clusterDeploy: redeployAgent: redeploy Rancher agents due to agent env vars mismatched for [%s], was [%v] and will be [%v]", cluster.Name, cluster.Spec.AgentEnvVars, cluster.Status.AppliedAgentEnvVars)
+	if !reflect.DeepEqual(append(settings.DefaultAgentSettingsAsEnvVars(), cluster.Spec.AgentEnvVars...), cluster.Status.AppliedAgentEnvVars) {
+		logrus.Infof("clusterDeploy: redeployAgent: redeploy Rancher agents due to agent env vars mismatched for [%s], was [%v] and will be [%v]", cluster.Name, cluster.Status.AppliedAgentEnvVars, cluster.Spec.AgentEnvVars)
 		return true
 	}
 
@@ -376,7 +376,8 @@ func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
 	if cluster.Annotations[AgentForceDeployAnn] == "true" {
 		cluster.Annotations[AgentForceDeployAnn] = "false"
 	}
-	cluster.Status.AppliedAgentEnvVars = cluster.Spec.AgentEnvVars
+
+	cluster.Status.AppliedAgentEnvVars = append(settings.DefaultAgentSettingsAsEnvVars(), cluster.Spec.AgentEnvVars...)
 
 	return nil
 }

--- a/pkg/controllers/management/controller.go
+++ b/pkg/controllers/management/controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/management/rbac"
 	"github.com/rancher/rancher/pkg/controllers/management/restrictedadminrbac"
 	"github.com/rancher/rancher/pkg/controllers/management/rkeworkerupgrader"
+	"github.com/rancher/rancher/pkg/controllers/management/settings"
 	"github.com/rancher/rancher/pkg/controllers/management/usercontrollers"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/wrangler"
@@ -69,6 +70,7 @@ func Register(ctx context.Context, management *config.ManagementContext, manager
 	rkeworkerupgrader.Register(ctx, management, manager.ScaledContext)
 	rbac.Register(ctx, management)
 	restrictedadminrbac.Register(ctx, management, wrangler)
+	settings.Register(ctx, management)
 
 	// Register last
 	auth.RegisterLate(ctx, management)

--- a/pkg/controllers/management/settings/controller.go
+++ b/pkg/controllers/management/settings/controller.go
@@ -1,0 +1,52 @@
+package settings
+
+import (
+	"context"
+
+	apis "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/rancher/pkg/types/config"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var toCopy = map[string]bool{}
+
+type handler struct {
+	cluster v3.ClusterController
+}
+
+func init() {
+	defaultSettings := settings.DefaultAgentSettings()
+
+	for _, s := range defaultSettings {
+		toCopy[s.Name] = true
+	}
+}
+
+func Register(ctx context.Context, management *config.ManagementContext) {
+	h := &handler{
+		cluster: management.Management.Clusters("").Controller(),
+	}
+
+	management.Management.Settings("").AddHandler(ctx, "copy-settings", h.onChange)
+}
+
+func (h *handler) onChange(key string, obj *apis.Setting) (runtime.Object, error) {
+	if obj == nil || !toCopy[obj.Name] {
+		return nil, nil
+	}
+
+	clusters, err := h.cluster.Lister().List("", labels.Everything())
+	if err != nil {
+		return obj, err
+	}
+	for _, c := range clusters {
+		if c.Name != "local" {
+			h.cluster.Enqueue("", c.Name)
+		}
+	}
+
+	return obj, nil
+}

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -27,7 +27,6 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/managementuser/rbac/podsecuritypolicy"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/resourcequota"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/secret"
-	"github.com/rancher/rancher/pkg/controllers/managementuser/settings"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/systemimage"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/windows"
 	managementv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -81,11 +80,6 @@ func Register(ctx context.Context, cluster *config.UserContext, clusterRec *mana
 			return err
 		}
 		err = agentupgrade.Register(ctx, cluster.UserOnlyContext())
-		if err != nil {
-			return err
-		}
-	} else {
-		err := settings.Register(ctx, cluster)
 		if err != nil {
 			return err
 		}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -11,6 +11,7 @@ import (
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	authsettings "github.com/rancher/rancher/pkg/auth/settings"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -245,4 +246,26 @@ func GetSettingByID(id string) string {
 		return s.Default
 	}
 	return provider.Get(id)
+}
+
+func DefaultAgentSettings() []Setting {
+	return []Setting{
+		ServerVersion,
+		InstallUUID,
+		IngressIPDomain,
+	}
+}
+
+func DefaultAgentSettingsAsEnvVars() []v1.EnvVar {
+	defaultAgentSettings := DefaultAgentSettings()
+	envVars := make([]v1.EnvVar, 0, len(defaultAgentSettings))
+
+	for _, s := range defaultAgentSettings {
+		envVars = append(envVars, v1.EnvVar{
+			Name:  GetEnvKey(s.Name),
+			Value: s.Get(),
+		})
+	}
+
+	return envVars
 }

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -39,6 +39,7 @@ type context struct {
 	PrivateRegistryConfig string
 	Tolerations           string
 	ClusterRegistry       string
+	ServerVersion         string
 }
 
 func toFeatureString(features map[string]bool) string {
@@ -101,6 +102,7 @@ func SystemTemplate(resp io.Writer, agentImage, authImage, namespace, token, url
 		PrivateRegistryConfig: privateRegistryConfig,
 		Tolerations:           tolerations,
 		ClusterRegistry:       clusterRegistry,
+		ServerVersion:         settings.ServerVersion.Get(),
 	}
 
 	return t.Execute(resp, context)

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -39,7 +39,6 @@ type context struct {
 	PrivateRegistryConfig string
 	Tolerations           string
 	ClusterRegistry       string
-	ServerVersion         string
 }
 
 func toFeatureString(features map[string]bool) string {
@@ -82,9 +81,12 @@ func SystemTemplate(resp io.Writer, agentImage, authImage, namespace, token, url
 		tolerations = templates.ToYAML(taints)
 	}
 
-	if cluster != nil && len(cluster.Spec.AgentEnvVars) > 0 {
-		agentEnvVars = templates.ToYAML(cluster.Spec.AgentEnvVars)
+	envVars := settings.DefaultAgentSettingsAsEnvVars()
+	if cluster != nil {
+		envVars = append(envVars, cluster.Spec.AgentEnvVars...)
 	}
+
+	agentEnvVars = templates.ToYAML(envVars)
 
 	context := &context{
 		Features:              toFeatureString(features),
@@ -102,7 +104,6 @@ func SystemTemplate(resp io.Writer, agentImage, authImage, namespace, token, url
 		PrivateRegistryConfig: privateRegistryConfig,
 		Tolerations:           tolerations,
 		ClusterRegistry:       clusterRegistry,
-		ServerVersion:         settings.ServerVersion.Get(),
 	}
 
 	return t.Execute(resp, context)

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -195,6 +195,8 @@ spec:
             value: "true"
           - name: CATTLE_CLUSTER_REGISTRY
             value: "{{.ClusterRegistry}}" 
+          - name: CATTLE_SERVER_VERSION
+            value: "{{.ServerVersion}}"
       {{- if .AgentEnvVars}}
 {{ .AgentEnvVars | indent 10 }}
       {{- end }}

--- a/pkg/systemtemplate/template.go
+++ b/pkg/systemtemplate/template.go
@@ -194,9 +194,7 @@ spec:
           - name: CATTLE_K8S_MANAGED
             value: "true"
           - name: CATTLE_CLUSTER_REGISTRY
-            value: "{{.ClusterRegistry}}" 
-          - name: CATTLE_SERVER_VERSION
-            value: "{{.ServerVersion}}"
+            value: "{{.ClusterRegistry}}"
       {{- if .AgentEnvVars}}
 {{ .AgentEnvVars | indent 10 }}
       {{- end }}


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/34982 and https://github.com/rancher/rancher/pull/34846

Summary
-
- Downstream clusters need to have the same server-version setting as their upstream in order to view the correct feature charts version for the current rancher installation. The CATTLE_SERVER_VERSION environment variable is now passed down through an environment variable when the cluster agent is deployed to ensure that the downstream cluster agent uses the correct version.

- Moved the install-uuid and ingress-ip-domain settings from the settings sync-handler to cluster-agent deployment template. Moved settings sync handler from managementuser to management and redeploy agent on settings changed.

Related Issue: https://github.com/rancher/rancher/issues/35488