### PR TITLE
Limit norman API use of downstream cluster caches

### DIFF
--- a/pkg/api/norman/customization/cluster/actions_kubeconfig.go
+++ b/pkg/api/norman/customization/cluster/actions_kubeconfig.go
@@ -65,7 +65,7 @@ func (a ActionHandler) GenerateKubeconfigActionHandler(actionName string, action
 
 	if endpointEnabled {
 		clusterName := apiContext.ID
-		clusterClient, err := a.ClusterManager.UserContext(clusterName)
+		clusterClient, err := a.ClusterManager.UserContextNoControllers(clusterName)
 		if err != nil {
 			return err
 		}

--- a/pkg/api/norman/customization/cluster/actions_yaml.go
+++ b/pkg/api/norman/customization/cluster/actions_yaml.go
@@ -178,7 +178,7 @@ func (a ActionHandler) processYAML(apiContext *types.APIContext, clusterName, pr
 }
 
 func (a ActionHandler) findOrCreateProjectNamespaces(apiContext *types.APIContext, namespaces []string, clusterName, projectName string) (corev1.NamespaceInterface, error) {
-	userCtx, err := a.ClusterManager.UserContext(clusterName)
+	userCtx, err := a.ClusterManager.UserContextNoControllers(clusterName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/norman/customization/cluster/shell.go
+++ b/pkg/api/norman/customization/cluster/shell.go
@@ -25,7 +25,7 @@ type ShellLinkHandler struct {
 }
 
 func (s *ShellLinkHandler) LinkHandler(apiContext *types.APIContext, next types.RequestHandler) error {
-	context, err := s.ClusterManager.UserContext(apiContext.ID)
+	context, err := s.ClusterManager.UserContextNoControllers(apiContext.ID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/norman/customization/clusterscan/clusterscan.go
+++ b/pkg/api/norman/customization/clusterscan/clusterscan.go
@@ -90,7 +90,7 @@ func (h Handler) LinkHandler(apiContext *types.APIContext, next types.RequestHan
 
 	clusterID, clusterScanID := ref.Parse(cs["id"].(string))
 
-	clusterContext, err := h.ClusterManager.UserContext(clusterID)
+	clusterContext, err := h.ClusterManager.UserContextNoControllers(clusterID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/norman/customization/logging/action.go
+++ b/pkg/api/norman/customization/logging/action.go
@@ -174,14 +174,14 @@ func (h *Handler) testLoggingTarget(ctx context.Context, clusterName string, tar
 }
 
 func (h *Handler) dryRunLoggingTarget(apiContext *types.APIContext, level, clusterName, projectID string, target v33.LoggingTargets) error {
-	context, err := h.clusterManager.UserContext(clusterName)
+	context, err := h.clusterManager.UserContextNoControllers(clusterName)
 	if err != nil {
 		return err
 	}
 
-	podLister := context.Core.Pods(metav1.NamespaceAll).Controller().Lister()
+	pods := context.Core.Pods(metav1.NamespaceAll)
 	namespaces := context.Core.Namespaces(metav1.NamespaceAll)
-	testerDeployer := deployer.NewTesterDeployer(context.Management, h.appsGetter, h.appLister, h.projectLister, podLister, h.projectLoggingLister, namespaces, h.templateLister)
+	testerDeployer := deployer.NewTesterDeployer(context.Management, h.appsGetter, h.appLister, h.projectLister, pods, h.projectLoggingLister, namespaces, h.templateLister)
 	configGenerator := configsyncer.NewConfigGenerator(metav1.NamespaceAll, h.projectLoggingLister, namespaces.Controller().Lister())
 
 	var dryRunConfigBuf []byte

--- a/pkg/api/norman/customization/monitor/cluster_graph_action.go
+++ b/pkg/api/norman/customization/monitor/cluster_graph_action.go
@@ -66,7 +66,7 @@ func (h *ClusterGraphHandler) QuerySeriesAction(actionName string, action *types
 	}
 
 	clusterName := inputParser.ClusterName
-	userContext, err := h.clustermanager.UserContext(clusterName)
+	userContext, err := h.clustermanager.UserContextNoControllers(clusterName)
 	if err != nil {
 		return fmt.Errorf("get usercontext failed, %v", err)
 	}

--- a/pkg/api/norman/customization/monitor/handler_utils.go
+++ b/pkg/api/norman/customization/monitor/handler_utils.go
@@ -124,18 +124,16 @@ func (p *projectGraphInputParser) parseFilter() error {
 }
 
 type authChecker struct {
-	ProjectID          string
-	Input              *v32.QueryGraphInput
-	UserContext        *config.UserContext
-	WorkloadController workload.CommonController
+	ProjectID   string
+	Input       *v32.QueryGraphInput
+	UserContext *config.UserContext
 }
 
 func newAuthChecker(ctx context.Context, userContext *config.UserContext, input *v32.QueryGraphInput, projectID string) *authChecker {
 	return &authChecker{
-		ProjectID:          projectID,
-		Input:              input,
-		UserContext:        userContext,
-		WorkloadController: workload.NewWorkloadController(ctx, userContext.UserOnlyContext(), nil),
+		ProjectID:   projectID,
+		Input:       input,
+		UserContext: userContext,
 	}
 }
 

--- a/pkg/api/norman/customization/monitor/metric_action.go
+++ b/pkg/api/norman/customization/monitor/metric_action.go
@@ -82,7 +82,7 @@ func (h *MetricHandler) Action(actionName string, action *types.Action, apiConte
 			return err
 		}
 
-		userContext, err := h.clustermanager.UserContext(clusterName)
+		userContext, err := h.clustermanager.UserContextNoControllers(clusterName)
 		if err != nil {
 			return fmt.Errorf("get usercontext failed, %v", err)
 		}
@@ -137,7 +137,7 @@ func (h *MetricHandler) Action(actionName string, action *types.Action, apiConte
 			return fmt.Errorf("clusterName is empty")
 		}
 
-		userContext, err := h.clustermanager.UserContext(clusterName)
+		userContext, err := h.clustermanager.UserContextNoControllers(clusterName)
 		if err != nil {
 			return fmt.Errorf("get usercontext failed, %v", err)
 		}
@@ -185,7 +185,7 @@ func (h *MetricHandler) Action(actionName string, action *types.Action, apiConte
 			return fmt.Errorf("clusterName is empty")
 		}
 
-		userContext, err := h.clustermanager.UserContext(clusterName)
+		userContext, err := h.clustermanager.UserContextNoControllers(clusterName)
 		if err != nil {
 			return fmt.Errorf("get usercontext failed, %v", err)
 		}

--- a/pkg/api/norman/customization/monitor/project_graph_action.go
+++ b/pkg/api/norman/customization/monitor/project_graph_action.go
@@ -58,7 +58,7 @@ func (h *ProjectGraphHandler) QuerySeriesAction(actionName string, action *types
 	}
 
 	clusterName := inputParser.ClusterName
-	userContext, err := h.clustermanager.UserContext(clusterName)
+	userContext, err := h.clustermanager.UserContextNoControllers(clusterName)
 	if err != nil {
 		return fmt.Errorf("get usercontext failed, %v", err)
 	}

--- a/pkg/api/norman/customization/namespace/link.go
+++ b/pkg/api/norman/customization/namespace/link.go
@@ -50,7 +50,7 @@ func (s *yamlLinkHandler) LinkHandler(apiContext *types.APIContext, next types.R
 
 	clusterName := s.clusterManagement.ClusterName(apiContext)
 
-	userContext, err := s.clusterManagement.UserContext(clusterName)
+	userContext, err := s.clusterManagement.UserContextNoControllers(clusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/norman/customization/namespace/namespace.go
+++ b/pkg/api/norman/customization/namespace/namespace.go
@@ -74,7 +74,7 @@ func (w ActionWrapper) ActionHandler(actionName string, action *types.Action, ap
 	case "move":
 		clusterID := w.ClusterManager.ClusterName(apiContext)
 		_, projectID := ref.Parse(convert.ToString(actionInput["projectId"]))
-		userContext, err := w.ClusterManager.UserContext(clusterID)
+		userContext, err := w.ClusterManager.UserContextNoControllers(clusterID)
 		if err != nil {
 			if !kerrors.IsNotFound(err) {
 				return err

--- a/pkg/api/norman/customization/persistentvolumeclaim/validator.go
+++ b/pkg/api/norman/customization/persistentvolumeclaim/validator.go
@@ -17,7 +17,7 @@ type Validator struct {
 
 func (v *Validator) Validator(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
 	clusterName := v.ClusterManager.ClusterName(request)
-	c, err := v.ClusterManager.UserContext(clusterName)
+	c, err := v.ClusterManager.UserContextNoControllers(clusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/norman/customization/pipeline/pipeline_execution_log.go
+++ b/pkg/api/norman/customization/pipeline/pipeline_execution_log.go
@@ -50,7 +50,7 @@ func (h *ExecutionHandler) handleLog(apiContext *types.APIContext) error {
 		return err
 	}
 	clusterName, _ := ref.Parse(execution.Spec.ProjectName)
-	userContext, err := h.ClusterManager.UserContext(clusterName)
+	userContext, err := h.ClusterManager.UserContextNoControllers(clusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -62,11 +62,11 @@ type record struct {
 	cancel        context.CancelFunc
 }
 
-func NewManager(httpsPort int, context *config.ScaledContext, rbacControllers rbacv1.Interface, asl accesscontrol.AccessSetLookup) *Manager {
+func NewManager(httpsPort int, context *config.ScaledContext, asl accesscontrol.AccessSetLookup) *Manager {
 	return &Manager{
 		httpsPort:     httpsPort,
 		ScaledContext: context,
-		accessControl: rbac.NewAccessControlWithASL("", rbacControllers, asl),
+		accessControl: rbac.NewAccessControlWithASL("", asl),
 		clusterLister: context.Management.Clusters("").Controller().Lister(),
 		clusters:      context.Management.Clusters(""),
 		startSem:      semaphore.NewWeighted(int64(settings.ClusterControllerStartCount.GetInt())),
@@ -447,6 +447,20 @@ func (m *Manager) APIExtClient(apiContext *types.APIContext, storageContext type
 	return m.ScaledContext.APIExtClient, nil
 }
 
+// UserContextNoControllers accepts a cluster name and returns a client for that cluster,
+// no controllers are started for that cluster in the process.
+func (m *Manager) UserContextNoControllers(clusterName string) (*config.UserContext, error) {
+	cluster, err := m.clusterLister.Get("", clusterName)
+	if err != nil {
+		return nil, err
+	}
+	ctx, err := m.UserContextFromCluster(cluster)
+	if ctx == nil && err == nil {
+		return nil, fmt.Errorf("cluster context %s is unavaiblable", clusterName)
+	}
+	return ctx, err
+}
+
 // UserContext accepts a cluster name and returns a client for that cluster,
 // starting all controllers for that cluster in the process.
 func (m *Manager) UserContext(clusterName string) (*config.UserContext, error) {
@@ -565,7 +579,7 @@ func (m *Manager) GetHTTPSPort() int {
 
 func (m *Manager) SubjectAccessReviewForCluster(req *http.Request) (authv1.SubjectAccessReviewInterface, error) {
 	clusterID := clusterrouter.GetClusterID(req)
-	userContext, err := m.UserContext(clusterID)
+	userContext, err := m.UserContextNoControllers(clusterID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/management/auth/user.go
+++ b/pkg/controllers/management/auth/user.go
@@ -369,7 +369,7 @@ func (l *userLifecycle) deleteClusterUserAttributes(username string, tokens []*v
 	}
 
 	for _, cluster := range set {
-		userCtx, err := l.clusterManager.UserContext(cluster.Name)
+		userCtx, err := l.clusterManager.UserContextNoControllers(cluster.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -445,7 +445,7 @@ func (cd *clusterDeploy) getYAML(cluster *v3.Cluster, agentImage, authImage stri
 }
 
 func (cd *clusterDeploy) getClusterAgentImage(name string) (string, error) {
-	uc, err := cd.clusterManager.UserContext(name)
+	uc, err := cd.clusterManager.UserContextNoControllers(name)
 	if err != nil {
 		return "", err
 	}
@@ -468,7 +468,7 @@ func (cd *clusterDeploy) getClusterAgentImage(name string) (string, error) {
 }
 
 func (cd *clusterDeploy) getNodeAgentImage(name string) (string, error) {
-	uc, err := cd.clusterManager.UserContext(name)
+	uc, err := cd.clusterManager.UserContextNoControllers(name)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controllers/management/clusterstats/statsaggregator.go
+++ b/pkg/controllers/management/clusterstats/statsaggregator.go
@@ -172,7 +172,7 @@ func (s *StatsAggregator) aggregate(cluster *v3.Cluster, clusterName string) err
 
 func (s *StatsAggregator) updateVersion(cluster *v3.Cluster) bool {
 	updated := false
-	userContext, err := s.ClusterManager.UserContext(cluster.Name)
+	userContext, err := s.ClusterManager.UserContextNoControllers(cluster.Name)
 	if err == nil {
 		callWithTimeout(func() {
 			// This has the tendency to timeout

--- a/pkg/controllers/management/k3sbasedupgrade/deployPlans.go
+++ b/pkg/controllers/management/k3sbasedupgrade/deployPlans.go
@@ -43,7 +43,7 @@ func (h *handler) deployPlans(cluster *v3.Cluster, isK3s, isRke2 bool) error {
 		strategy = cluster.Spec.K3sConfig.ClusterUpgradeStrategy
 	}
 	// access downstream cluster
-	clusterCtx, err := h.manager.UserContext(cluster.Name)
+	clusterCtx, err := h.manager.UserContextNoControllers(cluster.Name)
 	if err != nil {
 		return err
 

--- a/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
+++ b/pkg/controllers/management/k3sbasedupgrade/k3sbased_upgrade_handler.go
@@ -95,7 +95,7 @@ func (h *handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster,
 // deployK3sBaseUpgradeController creates a rancher k3s/rke2 upgrader controller if one does not exist.
 // Updates k3s upgrader controller if one exists and is not the newest available version.
 func (h *handler) deployK3sBasedUpgradeController(clusterName string, isK3s, isRke2 bool) error {
-	userCtx, err := h.manager.UserContext(clusterName)
+	userCtx, err := h.manager.UserContextNoControllers(clusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/managementuserlegacy/logging/deployer/testerdeployer.go
+++ b/pkg/controllers/managementuserlegacy/logging/deployer/testerdeployer.go
@@ -27,12 +27,12 @@ type TesterDeployer struct {
 	systemAccountManager *systemaccount.Manager
 }
 
-func NewTesterDeployer(mgmtCtx *config.ManagementContext, appsGetter projectv3.AppsGetter, appLister projectv3.AppLister, projectLister mgmtv3.ProjectLister, podLister v1.PodLister, projectLoggingLister mgmtv3.ProjectLoggingLister, namespaces v1.NamespaceInterface, templateLister mgmtv3.CatalogTemplateLister) *TesterDeployer {
+func NewTesterDeployer(mgmtCtx *config.ManagementContext, appsGetter projectv3.AppsGetter, appLister projectv3.AppLister, projectLister mgmtv3.ProjectLister, pods v1.PodInterface, projectLoggingLister mgmtv3.ProjectLoggingLister, namespaces v1.NamespaceInterface, templateLister mgmtv3.CatalogTemplateLister) *TesterDeployer {
 	appDeployer := &AppDeployer{
 		AppsGetter: appsGetter,
 		AppsLister: appLister,
 		Namespaces: namespaces,
-		PodLister:  podLister,
+		Pods:       pods,
 	}
 
 	return &TesterDeployer{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -106,7 +106,7 @@ func (h *metricsHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 // if getting 'local'. The count would show as 0 for a downstream cluster since the CR that backs the project only
 // lives in management.
 func (h *metricsHandler) getClusterObjectCount(clusterID string, rw http.ResponseWriter, req *http.Request) {
-	cluster, err := h.clusterManager.UserContext(clusterID)
+	cluster, err := h.clusterManager.UserContextNoControllers(clusterID)
 	if err != nil {
 		var (
 			normanError *httperror.APIError

--- a/pkg/multiclustermanager/app.go
+++ b/pkg/multiclustermanager/app.go
@@ -89,7 +89,7 @@ func buildScaledContext(ctx context.Context, wranglerContext *wrangler.Context, 
 	systemTokens := systemtokens.NewSystemTokensFromScale(scaledContext)
 	scaledContext.SystemTokens = systemTokens
 
-	manager := clustermanager.NewManager(cfg.HTTPSListenPort, scaledContext, wranglerContext.RBAC, wranglerContext.ASL)
+	manager := clustermanager.NewManager(cfg.HTTPSListenPort, scaledContext, wranglerContext.ASL)
 
 	scaledContext.AccessControl = manager
 	scaledContext.ClientGetter = manager

--- a/pkg/multiclustermanager/deferred.go
+++ b/pkg/multiclustermanager/deferred.go
@@ -133,7 +133,7 @@ func (s *DeferredServer) K8sClient(clusterName string) (kubernetes.Interface, er
 	if mcm == nil {
 		return nil, nil
 	}
-	clusterContext, err := mcm.clusterManager.UserContext(clusterName)
+	clusterContext, err := mcm.clusterManager.UserContextNoControllers(clusterName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pipeline/engine/engine.go
+++ b/pkg/pipeline/engine/engine.go
@@ -16,10 +16,7 @@ type PipelineEngine interface {
 }
 
 func New(cluster *config.UserContext, useCache bool) PipelineEngine {
-	serviceLister := cluster.Core.Services("").Controller().Lister()
-	podLister := cluster.Core.Pods("").Controller().Lister()
 	secrets := cluster.Core.Secrets("")
-	secretLister := secrets.Controller().Lister()
 	managementSecretLister := cluster.Management.Core.Secrets("").Controller().Lister()
 	sourceCodeCredentials := cluster.Management.Project.SourceCodeCredentials("")
 	sourceCodeCredentialLister := sourceCodeCredentials.Controller().Lister()
@@ -29,18 +26,21 @@ func New(cluster *config.UserContext, useCache bool) PipelineEngine {
 
 	engine := &jenkins.Engine{
 		UseCache:                   useCache,
-		ServiceLister:              serviceLister,
-		PodLister:                  podLister,
 		Secrets:                    secrets,
-		SecretLister:               secretLister,
 		ManagementSecretLister:     managementSecretLister,
 		SourceCodeCredentials:      sourceCodeCredentials,
 		SourceCodeCredentialLister: sourceCodeCredentialLister,
 		PipelineLister:             pipelineLister,
 		PipelineSettingLister:      pipelineSettingLister,
-
-		Dialer:      dialer,
-		ClusterName: cluster.ClusterName,
+		Dialer:                     dialer,
+		ClusterName:                cluster.ClusterName,
+	}
+	if useCache {
+		engine.ServiceLister = cluster.Core.Services("").Controller().Lister()
+		engine.PodLister = cluster.Core.Pods("").Controller().Lister()
+		engine.SecretLister = secrets.Controller().Lister()
+	} else {
+		engine.Services = cluster.Core.Services("")
 	}
 	return engine
 }

--- a/pkg/pipeline/engine/jenkins/minio.go
+++ b/pkg/pipeline/engine/jenkins/minio.go
@@ -22,10 +22,21 @@ type minioClient struct {
 }
 
 func (j *Engine) getMinioURL(ns string) (string, error) {
-	MinioName := utils.MinioName
-	svc, err := j.ServiceLister.Get(ns, MinioName)
-	if err != nil {
-		return "", err
+	var (
+		MinioName = utils.MinioName
+		svc       *corev1.Service
+		err       error
+	)
+	if j.UseCache {
+		svc, err = j.ServiceLister.Get(ns, MinioName)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		svc, err = j.Services.GetNamespaced(ns, MinioName, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
 	}
 
 	ip := svc.Spec.ClusterIP

--- a/pkg/rbac/access_control.go
+++ b/pkg/rbac/access_control.go
@@ -10,10 +10,10 @@ import (
 
 func NewAccessControl(ctx context.Context, clusterName string, rbacClient v1.Interface) types.AccessControl {
 	asl := accesscontrol.NewAccessStore(ctx, true, rbacClient)
-	return NewAccessControlWithASL(clusterName, rbacClient, asl)
+	return NewAccessControlWithASL(clusterName, asl)
 }
 
-func NewAccessControlWithASL(clusterName string, rbacClient v1.Interface, asl accesscontrol.AccessSetLookup) types.AccessControl {
+func NewAccessControlWithASL(clusterName string, asl accesscontrol.AccessSetLookup) types.AccessControl {
 	return newContextBased(func(ctx *types.APIContext) (types.AccessControl, bool) {
 		cache, ok := ctx.Request.Context().Value(contextKey{}).(*accessControlCache)
 		if !ok {


### PR DESCRIPTION
The norman API layer should no use any caches from the down stream cluster.  This causes scaling issues.

#35565