### PR TITLE
Bump kube-api-auth version

### DIFF
--- a/pkg/apis/management.cattle.io/v3/tools_system_images.go
+++ b/pkg/apis/management.cattle.io/v3/tools_system_images.go
@@ -20,7 +20,7 @@ var (
 			KubeApply:     "rancher/pipeline-tools:v0.1.16",
 		},
 		AuthSystemImages: AuthSystemImages{
-			KubeAPIAuth: "rancher/kube-api-auth:v0.1.5",
+			KubeAPIAuth: "rancher/kube-api-auth:v0.1.6",
 		},
 	}
 )


### PR DESCRIPTION
Bump kube-api-auth version to `v0.1.6`

Related Issue: https://github.com/rancher/rancher/issues/33332