### PR TITLE
Update project.cattle.io ingress schema

### DIFF
--- a/pkg/api/norman/server/userstored/setup.go
+++ b/pkg/api/norman/server/userstored/setup.go
@@ -27,6 +27,7 @@ import (
 	clusterClient "github.com/rancher/rancher/pkg/client/generated/cluster/v3"
 	client "github.com/rancher/rancher/pkg/client/generated/project/v3"
 	"github.com/rancher/rancher/pkg/clustermanager"
+	"github.com/rancher/rancher/pkg/ingresswrapper"
 	clusterschema "github.com/rancher/rancher/pkg/schemas/cluster.cattle.io/v3"
 	schema "github.com/rancher/rancher/pkg/schemas/project.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
@@ -41,8 +42,11 @@ func Setup(ctx context.Context, mgmt *config.ScaledContext, clusterManager *clus
 	addProxyStore(ctx, schemas, mgmt, client.CronJobType, "batch/v1beta1", workload.NewCustomizeStore)
 	addProxyStore(ctx, schemas, mgmt, client.DaemonSetType, "apps/v1", workload.NewCustomizeStore)
 	addProxyStore(ctx, schemas, mgmt, client.DeploymentType, "apps/v1", workload.NewCustomizeStore)
-	//TODO: Update to use networking.k8s.io/v1beta1 when k8s 1.3 is no longer supported
-	addProxyStore(ctx, schemas, mgmt, client.IngressType, "extensions/v1beta1", ingress.Wrap)
+	if ingresswrapper.ServerSupportsIngressV1(mgmt.K8sClient) {
+		addProxyStore(ctx, schemas, mgmt, client.IngressType, "networking.k8s.io/v1", ingress.Wrap)
+	} else {
+		addProxyStore(ctx, schemas, mgmt, client.IngressType, "extensions/v1beta1", ingress.Wrap)
+	}
 	addProxyStore(ctx, schemas, mgmt, client.JobType, "batch/v1", workload.NewCustomizeStore)
 	addProxyStore(ctx, schemas, mgmt, client.PersistentVolumeClaimType, "v1", nil)
 	addProxyStore(ctx, schemas, mgmt, client.PodType, "v1", func(store types.Store) types.Store {

--- a/pkg/client/generated/project/v3/zz_generated_http_ingress_path.go
+++ b/pkg/client/generated/project/v3/zz_generated_http_ingress_path.go
@@ -9,7 +9,8 @@ const (
 	HTTPIngressPathFieldPath        = "path"
 	HTTPIngressPathFieldPathType    = "pathType"
 	HTTPIngressPathFieldResource    = "resource"
-	HTTPIngressPathFieldServiceID   = "serviceId"
+	HTTPIngressPathFieldService     = "service"
+	HTTPIngressPathFieldServiceId   = "serviceId"
 	HTTPIngressPathFieldTargetPort  = "targetPort"
 	HTTPIngressPathFieldWorkloadIDs = "workloadIds"
 )
@@ -18,7 +19,8 @@ type HTTPIngressPath struct {
 	Path        string                     `json:"path,omitempty" yaml:"path,omitempty"`
 	PathType    string                     `json:"pathType,omitempty" yaml:"pathType,omitempty"`
 	Resource    *TypedLocalObjectReference `json:"resource,omitempty" yaml:"resource,omitempty"`
-	ServiceID   string                     `json:"serviceId,omitempty" yaml:"serviceId,omitempty"`
+	Service     *IngressServiceBackend     `json:"service,omitempty" yaml:"service,omitempty"`
+	ServiceId   string                     `json:"serviceId,omitempty" yaml:"serviceId,omitempty"`
 	TargetPort  intstr.IntOrString         `json:"targetPort,omitempty" yaml:"targetPort,omitempty"`
 	WorkloadIDs []string                   `json:"workloadIds,omitempty" yaml:"workloadIds,omitempty"`
 }

--- a/pkg/client/generated/project/v3/zz_generated_ingress.go
+++ b/pkg/client/generated/project/v3/zz_generated_ingress.go
@@ -7,6 +7,7 @@ import (
 const (
 	IngressType                      = "ingress"
 	IngressFieldAnnotations          = "annotations"
+	IngressFieldBackend              = "backend"
 	IngressFieldCreated              = "created"
 	IngressFieldCreatorID            = "creatorId"
 	IngressFieldDefaultBackend       = "defaultBackend"
@@ -31,6 +32,7 @@ const (
 type Ingress struct {
 	types.Resource
 	Annotations          map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Backend              *IngressBackend   `json:"backend,omitempty" yaml:"backend,omitempty"`
 	Created              string            `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID            string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	DefaultBackend       *IngressBackend   `json:"defaultBackend,omitempty" yaml:"defaultBackend,omitempty"`

--- a/pkg/client/generated/project/v3/zz_generated_ingress_backend.go
+++ b/pkg/client/generated/project/v3/zz_generated_ingress_backend.go
@@ -7,14 +7,16 @@ import (
 const (
 	IngressBackendType             = "ingressBackend"
 	IngressBackendFieldResource    = "resource"
-	IngressBackendFieldServiceID   = "serviceId"
+	IngressBackendFieldService     = "service"
+	IngressBackendFieldServiceId   = "serviceId"
 	IngressBackendFieldTargetPort  = "targetPort"
 	IngressBackendFieldWorkloadIDs = "workloadIds"
 )
 
 type IngressBackend struct {
 	Resource    *TypedLocalObjectReference `json:"resource,omitempty" yaml:"resource,omitempty"`
-	ServiceID   string                     `json:"serviceId,omitempty" yaml:"serviceId,omitempty"`
+	Service     *IngressServiceBackend     `json:"service,omitempty" yaml:"service,omitempty"`
+	ServiceId   string                     `json:"serviceId,omitempty" yaml:"serviceId,omitempty"`
 	TargetPort  intstr.IntOrString         `json:"targetPort,omitempty" yaml:"targetPort,omitempty"`
 	WorkloadIDs []string                   `json:"workloadIds,omitempty" yaml:"workloadIds,omitempty"`
 }

--- a/pkg/client/generated/project/v3/zz_generated_ingress_service_backend.go
+++ b/pkg/client/generated/project/v3/zz_generated_ingress_service_backend.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	IngressServiceBackendType      = "ingressServiceBackend"
+	IngressServiceBackendFieldName = "name"
+	IngressServiceBackendFieldPort = "port"
+)
+
+type IngressServiceBackend struct {
+	Name string              `json:"name,omitempty" yaml:"name,omitempty"`
+	Port *ServiceBackendPort `json:"port,omitempty" yaml:"port,omitempty"`
+}

--- a/pkg/client/generated/project/v3/zz_generated_ingress_spec.go
+++ b/pkg/client/generated/project/v3/zz_generated_ingress_spec.go
@@ -3,6 +3,7 @@ package client
 const (
 	IngressSpecType                  = "ingressSpec"
 	IngressSpecFieldBackend          = "backend"
+	IngressSpecFieldDefaultBackend   = "defaultBackend"
 	IngressSpecFieldIngressClassName = "ingressClassName"
 	IngressSpecFieldRules            = "rules"
 	IngressSpecFieldTLS              = "tls"
@@ -10,6 +11,7 @@ const (
 
 type IngressSpec struct {
 	Backend          *IngressBackend `json:"backend,omitempty" yaml:"backend,omitempty"`
+	DefaultBackend   *IngressBackend `json:"defaultBackend,omitempty" yaml:"defaultBackend,omitempty"`
 	IngressClassName string          `json:"ingressClassName,omitempty" yaml:"ingressClassName,omitempty"`
 	Rules            []IngressRule   `json:"rules,omitempty" yaml:"rules,omitempty"`
 	TLS              []IngressTLS    `json:"tls,omitempty" yaml:"tls,omitempty"`

--- a/pkg/client/generated/project/v3/zz_generated_service_backend_port.go
+++ b/pkg/client/generated/project/v3/zz_generated_service_backend_port.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	ServiceBackendPortType        = "serviceBackendPort"
+	ServiceBackendPortFieldName   = "name"
+	ServiceBackendPortFieldNumber = "number"
+)
+
+type ServiceBackendPort struct {
+	Name   string `json:"name,omitempty" yaml:"name,omitempty"`
+	Number int64  `json:"number,omitempty" yaml:"number,omitempty"`
+}

--- a/pkg/schemas/mapper/ingress_backend.go
+++ b/pkg/schemas/mapper/ingress_backend.go
@@ -1,0 +1,106 @@
+package mapper
+
+import (
+	"github.com/rancher/norman/types"
+	"github.com/rancher/norman/types/values"
+)
+
+// These mappers copy data from the networking.k8s.io/v1-style Ingress fields
+// to extensions/v1beta1-style Ingress fields so that when the proxy store
+// serializes them into kubernetes resources, there is no loss of data and the
+// objects are in the expected format for the API in use. The end result is
+// that some data is duplicated on the object, but extraneous fields will be
+// ignored by the proxy store.
+
+// IngressSpec mapper copies defaultBackend (type k8s.io/api/networking/v1.IngressBackend)
+// to backend (type k8s.io/api/extensions/v1beta1.IngressBackend) on Spec.
+type IngressSpec struct{}
+
+func (i IngressSpec) FromInternal(data map[string]interface{}) {
+	if _, ok := data["backend"]; ok && data["defaultBackend"] == nil {
+		data["defaultBackend"] = map[string]interface{}{
+			"targetPort": values.GetValueN(data, "backend", "servicePort"),
+			"serviceId":  values.GetValueN(data, "backend", "serviceName"),
+		}
+		delete(data, "backend")
+	}
+	return
+}
+
+func (i IngressSpec) ToInternal(data map[string]interface{}) error {
+	if backend, ok := data["backend"]; (!ok || backend == nil) && data["defaultBackend"] != nil {
+		data["backend"] = map[string]interface{}{
+			"servicePort": values.GetValueN(data, "defaultBackend", "targetPort"),
+			"serviceName": values.GetValueN(data, "defaultBackend", "serviceId"),
+		}
+	}
+	return nil
+}
+
+func (i IngressSpec) ModifySchema(schema *types.Schema, schemas *types.Schemas) error {
+	return nil
+}
+
+// IngressBackend mapper copies service fields within
+// k8s.io/api/networking/v1.IngressBackend to the equivalents in
+// k8s.io/api/extensions/v1beta1.IngressBackend.
+// Applies to the Spec.DefaultBackend and Spec.Rules[*].Backend.
+type IngressBackend struct{}
+
+func (i IngressBackend) FromInternal(data map[string]interface{}) {
+	if data == nil {
+		return
+	}
+	if serviceID, ok := data["serviceId"]; !ok || serviceID == nil {
+		data["serviceId"] = values.GetValueN(data, "serviceName")
+	}
+	if targetPort, ok := data["targetPort"]; !ok || targetPort == nil {
+		if port := values.GetValueN(data, "servicePort"); port != nil {
+			data["targetPort"] = port
+		} else if port := values.GetValueN(data, "service", "port", "number"); port != nil {
+			data["targetPort"] = port
+		} else if port := values.GetValueN(data, "service", "port", "name"); port != nil {
+			data["targetPort"] = port
+		}
+	}
+}
+
+func (i IngressBackend) ToInternal(data map[string]interface{}) error {
+	if data != nil {
+		serviceID := values.GetValueN(data, "serviceId")
+		values.PutValue(data, serviceID, "serviceName")
+		values.PutValue(data, serviceID, "service", "name")
+		port := values.GetValueN(data, "targetPort")
+		data["servicePort"] = port
+		switch port.(type) {
+		case int64:
+			values.PutValue(data, port, "service", "port", "number")
+		case string:
+			values.PutValue(data, port, "service", "port", "name")
+		}
+	}
+	return nil
+}
+
+func (i IngressBackend) ModifySchema(schema *types.Schema, schemas *types.Schemas) error {
+	return nil
+}
+
+// IngressPath mapper applies the required pathType field to
+// k8s.io/api/networking/v1.HTTPIngressPath.
+type IngressPath struct{}
+
+func (i IngressPath) FromInternal(data map[string]interface{}) {
+	return
+}
+
+func (i IngressPath) ToInternal(data map[string]interface{}) error {
+	if values.GetValueN(data, "pathType") == nil {
+		values.PutValue(data, "ImplementationSpecific", "pathType")
+	}
+	return nil
+}
+
+func (i IngressPath) ModifySchema(schema *types.Schema, schemas *types.Schemas) error {
+	return nil
+}

--- a/tests/integration/suite/test_ingress.py
+++ b/tests/integration/suite/test_ingress.py
@@ -9,6 +9,7 @@ def test_ingress_fields(admin_pc_client):
         'rules': 'cru',
         'tls': 'cru',
         'ingressClassName': 'cru',
+        'backend': 'cru',
         'defaultBackend': 'cru',
         'publicEndpoints': 'r',
         'status': 'r',
@@ -16,6 +17,7 @@ def test_ingress_fields(admin_pc_client):
 
     auth_check(admin_pc_client.schema, 'ingressBackend', '', {
         'serviceId': 'cru',
+        'service': 'cru',
         'targetPort': 'cru',
         'resource': 'cru',
         'workloadIds': 'cru',
@@ -31,6 +33,7 @@ def test_ingress_fields(admin_pc_client):
         'pathType': 'cru',
         'path': 'cru',
         'serviceId': 'cru',
+        'service': 'cru',
         'targetPort': 'cru',
         'workloadIds': 'cru',
     })

--- a/tests/integration/suite/test_ingress.py
+++ b/tests/integration/suite/test_ingress.py
@@ -1,5 +1,4 @@
 from .common import random_str, auth_check
-import pytest
 
 
 def test_ingress_fields(admin_pc_client):
@@ -39,7 +38,6 @@ def test_ingress_fields(admin_pc_client):
     })
 
 
-@pytest.mark.skip(reason='skipping for now, enable with ingress 1.22 fix')
 def test_ingress(admin_pc, admin_cc_client):
     client = admin_pc.client
 
@@ -82,7 +80,6 @@ def test_ingress(admin_pc, admin_cc_client):
     client.delete(ns)
 
 
-@pytest.mark.skip(reason='skipping for now, enable with ingress 1.22 fix')
 def test_ingress_rules_same_hostPortPath(admin_pc, admin_cc_client):
     client = admin_pc.client
 


### PR DESCRIPTION
This change updates the norman ingress store to use the
networking.k8s.io/v1 Ingress API for storing Ingress objects when
possible, and modifies the project.cattle.io schema for Ingress
resources to use the k8s.io/api/networking/v1 package. This also adds
norman mappers to copy fields where needed, such as from
"defaultBackend" to "backend", so that no matter which storage API is
used, the right data exists in the object. See the deprecation guide[1]
for notes on how the fields are translated.

[1] https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

To make this able to work with both 1.18 and 1.22 I needed to add fields to the schema, so the schema now appears to have duplicate alias fields:

![image](https://user-images.githubusercontent.com/1220710/142035411-45260a9d-a5e0-486e-a7f1-35b93518524a.png)

If everything is working correctly, then the Ember UI and terraform or other clients should be able to work without any changes, it's only when you look at the schema itself that it looks different.

https://github.com/rancher/rancher/issues/33312