### PR TITLE
Revert display name change for catalogs-manage GlobalRole

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -61,7 +61,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("*")
 	rb.addRole("Manage Cluster Drivers", "kontainerdrivers-manage").
 		addRule().apiGroups("management.cattle.io").resources("kontainerdrivers").verbs("*")
-	rb.addRole("Legacy Manage Catalogs", "catalogs-manage").
+	rb.addRole("Manage Catalogs", "catalogs-manage").
 		addRule().apiGroups("management.cattle.io").resources("catalogs", "templates", "templateversions").verbs("*")
 	rb.addRole("Use Catalog Templates", "catalogs-use").
 		addRule().apiGroups("management.cattle.io").resources("templates", "templateversions").verbs("get", "list", "watch")


### PR DESCRIPTION
Issue:
- https://github.com/rancher/rancher/issues/34592

Dashboard uses translations to pick the display name for the GlobalRoles in the user create view. The display name field of the role resource is only used by Ember UI, so it should remain as it was, i.e. without "Legacy". The `catalogs-manage` global role grants: 
```
rules:
- apiGroups:
  - management.cattle.io
  resources:
  - catalogs
  - templates
  - templateversions
  verbs:
  - '*'
```
The display name still needs to be changed in rancher/dashboard since the above role doesn't apply to dashboard based catalog resources (`*.catalog.cattle.io`).

The permission changes in the [previous PR](https://github.com/rancher/rancher/pull/35265) are still valid.