### PR TITLE
Automation - adding missing parameters to EKSv2 nodegroups

### DIFF
--- a/tests/validation/tests/v3_api/test_eks_v2_hosted_cluster.py
+++ b/tests/validation/tests/v3_api/test_eks_v2_hosted_cluster.py
@@ -57,8 +57,12 @@ eks_config = {
             "subnets": [],
             "tags": {},
             "labels": {},
-            "ec2SshKey": ""
-
+            "ec2SshKey": "",
+            "userData": "",
+            "resourceTags": {},
+            "requestSpotInstances": False,
+            "spotInstanceTypes": [],
+            "launchTemplate": None
         }]
     }
 
@@ -444,19 +448,3 @@ def validate_nodegroup(nodegroup_list, cluster_name):
         assert nodegroup["minSize"] \
                == eks_nodegroup["nodegroup"]["scalingConfig"]["minSize"], \
             "minSize is incorrect on the nodes"
-
-        # check instance type
-        assert nodegroup["instanceType"] \
-               == eks_nodegroup["nodegroup"]["instanceTypes"][0], \
-            "instanceType is incorrect on the nodes"
-
-        # check disk size
-        assert nodegroup["diskSize"] \
-               == eks_nodegroup["nodegroup"]["diskSize"], \
-            "diskSize is incorrect on the nodes"
-        # check ec2SshKey
-        if "ec2SshKey" in nodegroup.keys() and \
-                nodegroup["ec2SshKey"] is not "":
-            assert nodegroup["ec2SshKey"] \
-                == eks_nodegroup["nodegroup"]["remoteAccess"]["ec2SshKey"], \
-                "Ssh key is incorrect on the nodes"


### PR DESCRIPTION
EKSv2 provisioning is failing in automation.
This PR adds the missing parameters required in the `nodeGroups` block

Also the nodegroup object is not including some of the machine information so some nodegroup assertions are no longer valid:

```python
{
    'nodegroup': {
        'nodegroupName': 'test-ng-22581',
        'nodegroupArn': '<REDACTED>',
        'clusterName': 'test-auto-eks-86338',
        'version': '1.19',
        'releaseVersion': '1.19.15-20211109',
        'createdAt': datetime.datetime(2021, 11, 17, 20, 0, 59, 956000, tzinfo = tzlocal()),
        'modifiedAt': datetime.datetime(2021, 11, 17, 20, 3, 35, 962000, tzinfo = tzlocal()),
        'status': 'ACTIVE',
        'scalingConfig': {
            'minSize': 2,
            'maxSize': 2,
            'desiredSize': 2
        },
        'subnets': [<REDACTED>],
        'amiType': 'AL2_x86_64',
        'nodeRole': '<REDACTED>',
        'labels': {},
        'resources': {
            'autoScalingGroups': [{
                'name': '<REDACTED>'
            }]
        },
        'health': {
            'issues': []
        },
        'tags': {}
    }
}
```