### PR TITLE
Do not set kev1 state to Upgrading during etcdsave and post-check

### DIFF
--- a/pkg/kontainer-engine/cluster/backup.go
+++ b/pkg/kontainer-engine/cluster/backup.go
@@ -20,9 +20,6 @@ func (c *Cluster) ETCDRestore(ctx context.Context, snapshotName string) error {
 	if err != nil {
 		return err
 	}
-	if err := c.PersistStore.PersistStatus(*c, Updating); err != nil {
-		return err
-	}
 	info, err := c.Driver.ETCDRestore(ctx, toInfo(c), driverOpts, snapshotName)
 	if err != nil {
 		return err

--- a/pkg/kontainer-engine/cluster/cluster.go
+++ b/pkg/kontainer-engine/cluster/cluster.go
@@ -154,10 +154,6 @@ func (c *Cluster) GenerateServiceAccount(ctx context.Context) error {
 		return err
 	}
 
-	if err := c.PersistStore.PersistStatus(*c, Updating); err != nil {
-		return err
-	}
-
 	// receive cluster info back
 	info, err := c.Driver.PostCheck(ctx, toInfo(c))
 	if err != nil {


### PR DESCRIPTION
The kev1 state secret is quite large and we do extra writes every time
we do an etcd backup or during the post-check phase of provisioning. There
is no disadvantage to just not updating the state and leaving it as Running.

https://github.com/rancher/rancher/issues/35547