### PR TITLE
Ensure keycloak oidc and oidc tokens refresh, and update store

### DIFF
--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -97,7 +98,7 @@ func (o *OpenIDCProvider) LoginUser(ctx context.Context, oauthLoginInfo *v32.OID
 			return userPrincipal, nil, "", userClaimInfo, err
 		}
 	}
-	userInfo, oauth2Token, err := o.getUserInfo(&ctx, config, oauthLoginInfo.Code, &userClaimInfo)
+	userInfo, oauth2Token, err := o.getUserInfo(&ctx, config, oauthLoginInfo.Code, &userClaimInfo, "")
 	if err != nil {
 		return userPrincipal, groupPrincipals, "", userClaimInfo, err
 	}
@@ -202,8 +203,14 @@ func (o *OpenIDCProvider) RefetchGroupPrincipals(principalID string, secret stri
 		logrus.Errorf("[generic oidc] refetchGroupPrincipals: error fetching OIDCConfig: %v", err)
 		return groupPrincipals, err
 	}
+	// need to get the user information so that the refreshed token can be saved using the username / userID
+	user, err := o.UserMGR.GetUserByPrincipalID(principalID)
+	if err != nil {
+		logrus.Errorf("[generic oidc] refetchGroupPrincipals: error getting user by principalID: %v", err)
+		return groupPrincipals, err
+	}
 	//do not need userInfo or oauth2Token since we are only processing groups
-	_, _, err = o.getUserInfo(&o.CTX, config, secret, &claimInfo)
+	_, _, err = o.getUserInfo(&o.CTX, config, secret, &claimInfo, user.Name)
 	if err != nil {
 		return groupPrincipals, err
 	}
@@ -359,7 +366,7 @@ func (o *OpenIDCProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map
 	return extras
 }
 
-func (o *OpenIDCProvider) getUserInfo(ctx *context.Context, config *v32.OIDCConfig, authCode string, claimInfo *ClaimInfo) (*oidc.UserInfo, *oauth2.Token, error) {
+func (o *OpenIDCProvider) getUserInfo(ctx *context.Context, config *v32.OIDCConfig, authCode string, claimInfo *ClaimInfo, userName string) (*oidc.UserInfo, *oauth2.Token, error) {
 	var userInfo *oidc.UserInfo
 	var oauth2Token *oauth2.Token
 	var err error
@@ -389,16 +396,24 @@ func (o *OpenIDCProvider) getUserInfo(ctx *context.Context, config *v32.OIDCConf
 	if !oauth2Token.Valid() {
 		// since token is not valid, the TokenSource func will attempt to refresh the access token
 		// if the refresh token has not expired
-		logrus.Debugf("[generic oidc] saveOIDCConfig: attempting to refresh access token")
+		logrus.Debugf("[generic oidc] getUserInfo: attempting to refresh access token")
 	}
-	logrus.Debugf("[generic oidc] saveOIDCConfig: getting user info")
-	userInfo, err = provider.UserInfo(updatedContext, oauthConfig.TokenSource(updatedContext, oauth2Token))
+	reusedToken, err := oauth2.ReuseTokenSource(oauth2Token, oauthConfig.TokenSource(updatedContext, oauth2Token)).Token()
+	if err != nil {
+		return userInfo, oauth2Token, err
+	}
+	if !reflect.DeepEqual(oauth2Token, reusedToken) {
+		o.UpdateToken(reusedToken, userName)
+	}
+	logrus.Debugf("[generic oidc] getUserInfo: getting user info")
+	userInfo, err = provider.UserInfo(updatedContext, oauthConfig.TokenSource(updatedContext, reusedToken))
 	if err != nil {
 		return userInfo, oauth2Token, err
 	}
 	if err := userInfo.Claims(&claimInfo); err != nil {
 		return userInfo, oauth2Token, err
 	}
+
 	return userInfo, oauth2Token, nil
 }
 
@@ -446,4 +461,16 @@ func (o *OpenIDCProvider) getGroupsFromClaimInfo(claimInfo ClaimInfo) []v3.Princ
 		}
 	}
 	return groupPrincipals
+}
+
+func (o *OpenIDCProvider) UpdateToken(refreshedToken *oauth2.Token, userID string) error {
+	var err error
+	logrus.Debugf("[generic oidc] UpdateToken: access token has been refreshed")
+	marshalledToken, err := json.Marshal(refreshedToken)
+	if err != nil {
+		return err
+	}
+	logrus.Debugf("[generic oidc] UpdateToken: saving refreshed access token")
+	o.TokenMGR.UpdateSecret(userID, o.Name, string(marshalledToken))
+	return err
 }


### PR DESCRIPTION
**Issue**
https://github.com/rancher/rancher/issues/33916

**Problem**
Keycloak OIDC and OIDC providers refresh the access token, but do not store the refreshed token so once the initial access token is expired for the session, all calls will get a fresh token. This just causes more calls to happen than need to. 

**Solution**
For Keycloak OIDC, use a different method to get the access token than was being used previously. One the token is fetched, validate if it is different than the one that was fetched from the secret. If it is different, then update the secret to have the new token.

For OIDC, I left the existing calls for the tokens, but I store the token that was passed in as a separate var and validate it against the one that is returned from the existing call. If it is different, then update the secret. 