### PR TITLE
Move pod aggregration logic from nodesyncer to agent

### DIFF
--- a/pkg/controllers/managementagent/controllers.go
+++ b/pkg/controllers/managementagent/controllers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/managementagent/externalservice"
 	"github.com/rancher/rancher/pkg/controllers/managementagent/ingress"
 	"github.com/rancher/rancher/pkg/controllers/managementagent/nslabels"
+	"github.com/rancher/rancher/pkg/controllers/managementagent/podresources"
 	"github.com/rancher/rancher/pkg/controllers/managementagent/servicemonitor"
 	"github.com/rancher/rancher/pkg/controllers/managementagent/targetworkloadservice"
 	"github.com/rancher/rancher/pkg/controllers/managementagent/workload"
@@ -26,6 +27,7 @@ func Register(ctx context.Context, cluster *config.UserOnlyContext) error {
 	externalservice.Register(ctx, cluster)
 	ingress.Register(ctx, cluster)
 	nslabels.Register(ctx, cluster)
+	podresources.Register(ctx, cluster)
 	targetworkloadservice.Register(ctx, cluster)
 	workload.Register(ctx, cluster)
 

--- a/pkg/controllers/managementagent/podresources/register.go
+++ b/pkg/controllers/managementagent/podresources/register.go
@@ -1,0 +1,146 @@
+package podresources
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	"github.com/rancher/rancher/pkg/types/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	RequestsAnnotation = "management.cattle.io/pod-requests"
+	LimitsAnnotation   = "management.cattle.io/pod-limits"
+)
+
+func Register(ctx context.Context, workload *config.UserOnlyContext) {
+	p := podResources{
+		podLister: workload.Core.Pods("").Controller().Lister(),
+		nodes:     workload.Core.Nodes(""),
+	}
+
+	workload.Core.Nodes("").AddHandler(ctx, "podresource", p.onChange)
+}
+
+type podResources struct {
+	podLister v1.PodLister
+	nodes     v1.NodeInterface
+}
+
+func (p *podResources) onChange(key string, node *corev1.Node) (runtime.Object, error) {
+	if node == nil {
+		return node, nil
+	}
+
+	p.nodes.Controller().EnqueueAfter("", node.Name, 15*time.Second)
+
+	pods, err := p.getNonTerminatedPods(node)
+	if err != nil {
+		return nil, err
+	}
+
+	requests, limits, err := getPodResourceAnnotations(pods)
+	if err != nil {
+		return nil, err
+	}
+
+	if node.Annotations[RequestsAnnotation] != requests ||
+		node.Annotations[LimitsAnnotation] != limits {
+		node := node.DeepCopy()
+		if node.Annotations == nil {
+			node.Annotations = map[string]string{}
+		}
+		node.Annotations[RequestsAnnotation] = requests
+		node.Annotations[LimitsAnnotation] = limits
+		return p.nodes.Update(node)
+	}
+
+	return node, nil
+}
+
+func (p *podResources) getNonTerminatedPods(node *corev1.Node) ([]*corev1.Pod, error) {
+	var pods []*corev1.Pod
+	fromCache, err := p.podLister.List("", labels.NewSelector())
+	if err != nil {
+		return pods, err
+	}
+
+	for _, pod := range fromCache {
+		if pod.Spec.NodeName != node.Name {
+			continue
+		}
+		// kubectl uses this cache to filter out the pods
+		if pod.Status.Phase == "Succeeded" || pod.Status.Phase == "Failed" {
+			continue
+		}
+		pods = append(pods, pod)
+	}
+	return pods, nil
+}
+
+func getPodResourceAnnotations(pods []*corev1.Pod) (string, string, error) {
+	requests, limits := aggregateRequestAndLimitsForNode(pods)
+	requestsBytes, err := json.Marshal(requests)
+	if err != nil {
+		return "", "", err
+	}
+
+	limitsBytes, err := json.Marshal(limits)
+	return string(requestsBytes), string(limitsBytes), err
+}
+
+func aggregateRequestAndLimitsForNode(pods []*corev1.Pod) (map[corev1.ResourceName]resource.Quantity, map[corev1.ResourceName]resource.Quantity) {
+	requests, limits := map[corev1.ResourceName]resource.Quantity{}, map[corev1.ResourceName]resource.Quantity{}
+	for _, pod := range pods {
+		podRequests, podLimits := getPodData(pod)
+		addMap(podRequests, requests)
+		addMap(podLimits, limits)
+	}
+	if pods != nil {
+		requests[corev1.ResourcePods] = *resource.NewQuantity(int64(len(pods)), resource.DecimalSI)
+	}
+	return requests, limits
+}
+
+func getPodData(pod *corev1.Pod) (map[corev1.ResourceName]resource.Quantity, map[corev1.ResourceName]resource.Quantity) {
+	requests, limits := map[corev1.ResourceName]resource.Quantity{}, map[corev1.ResourceName]resource.Quantity{}
+	for _, container := range pod.Spec.Containers {
+		addMap(container.Resources.Requests, requests)
+		addMap(container.Resources.Limits, limits)
+	}
+
+	for _, container := range pod.Spec.InitContainers {
+		addMapForInit(container.Resources.Requests, requests)
+		addMapForInit(container.Resources.Limits, limits)
+	}
+	return requests, limits
+}
+
+func addMap(data1 map[corev1.ResourceName]resource.Quantity, data2 map[corev1.ResourceName]resource.Quantity) {
+	for name, quantity := range data1 {
+		if value, ok := data2[name]; !ok {
+			data2[name] = quantity.DeepCopy()
+		} else {
+			value.Add(quantity)
+			data2[name] = value
+		}
+	}
+}
+
+func addMapForInit(data1 map[corev1.ResourceName]resource.Quantity, data2 map[corev1.ResourceName]resource.Quantity) {
+	for name, quantity := range data1 {
+		value, ok := data2[name]
+		if !ok {
+			data2[name] = quantity.DeepCopy()
+			continue
+		}
+		if quantity.Cmp(value) > 0 {
+			data2[name] = quantity.DeepCopy()
+		}
+	}
+}

--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -2,6 +2,7 @@ package nodesyncer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
@@ -10,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	kd "github.com/rancher/rancher/pkg/controllers/management/kontainerdrivermetadata"
+	"github.com/rancher/rancher/pkg/controllers/managementagent/podresources"
 	"github.com/rancher/rancher/pkg/controllers/managementlegacy/compose/common"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -46,7 +48,6 @@ type nodesSyncer struct {
 	machineLister        v3.NodeLister
 	nodeLister           v1.NodeLister
 	nodeClient           v1.NodeInterface
-	podLister            v1.PodLister
 	clusterNamespace     string
 	clusterLister        v3.ClusterLister
 	serviceOptionsLister v3.RkeK8sServiceOptionLister
@@ -78,7 +79,6 @@ func Register(ctx context.Context, cluster *config.UserContext, kubeConfigGetter
 		machineLister:        cluster.Management.Management.Nodes(cluster.ClusterName).Controller().Lister(),
 		nodeLister:           cluster.Core.Nodes("").Controller().Lister(),
 		nodeClient:           cluster.Core.Nodes(""),
-		podLister:            cluster.Core.Pods("").Controller().Lister(),
 		clusterLister:        cluster.Management.Management.Clusters("").Controller().Lister(),
 		serviceOptionsLister: cluster.Management.Management.RkeK8sServiceOptions("").Controller().Lister(),
 		serviceOptions:       cluster.Management.Management.RkeK8sServiceOptions(""),
@@ -148,11 +148,7 @@ func (n *nodeSyncer) needUpdate(key string, node *corev1.Node) (bool, error) {
 		}
 		return true, nil
 	}
-	nodeToPodMap, err := n.nodesSyncer.getNonTerminatedPods()
-	if err != nil {
-		return false, err
-	}
-	toUpdate, err := n.nodesSyncer.convertNodeToMachine(node, existing, nodeToPodMap)
+	toUpdate, err := n.nodesSyncer.convertNodeToMachine(node, existing)
 	if err != nil {
 		return false, err
 	}
@@ -415,17 +411,12 @@ func (m *nodesSyncer) reconcileAll() error {
 		}
 		machineMap[node.Name] = machine
 	}
-	nodeToPodMap, err := m.getNonTerminatedPods()
-	if err != nil {
-		return err
-	}
-
 	nodeCache := &NodeCache{}
 
 	// reconcile machines for existing nodes
 	for name, node := range nodeMap {
 		machine := machineMap[name]
-		err = m.reconcileNodeForNode(machine, node, nodeCache, nodeToPodMap)
+		err = m.reconcileNodeForNode(machine, node, nodeCache)
 		if err != nil {
 			return err
 		}
@@ -448,11 +439,11 @@ func (m *nodesSyncer) reconcileAll() error {
 	return nil
 }
 
-func (m *nodesSyncer) reconcileNodeForNode(machine *v3.Node, node *corev1.Node, nodeCache *NodeCache, pods map[string][]*corev1.Pod) error {
+func (m *nodesSyncer) reconcileNodeForNode(machine *v3.Node, node *corev1.Node, nodeCache *NodeCache) error {
 	if machine == nil {
-		return m.createNode(node, nodeCache, pods)
+		return m.createNode(node, nodeCache)
 	}
-	return m.updateNode(machine, node, pods)
+	return m.updateNode(machine, node)
 }
 
 func (m *nodesSyncer) removeNode(machine *v3.Node) error {
@@ -472,8 +463,8 @@ func (m *nodesSyncer) removeNode(machine *v3.Node) error {
 	return nil
 }
 
-func (m *nodesSyncer) updateNode(existing *v3.Node, node *corev1.Node, pods map[string][]*corev1.Pod) error {
-	toUpdate, err := m.convertNodeToMachine(node, existing, pods)
+func (m *nodesSyncer) updateNode(existing *v3.Node, node *corev1.Node) error {
+	toUpdate, err := m.convertNodeToMachine(node, existing)
 	if err != nil {
 		return err
 	}
@@ -490,7 +481,7 @@ func (m *nodesSyncer) updateNode(existing *v3.Node, node *corev1.Node, pods map[
 	return nil
 }
 
-func (m *nodesSyncer) createNode(node *corev1.Node, nodeCache *NodeCache, pods map[string][]*corev1.Pod) error {
+func (m *nodesSyncer) createNode(node *corev1.Node, nodeCache *NodeCache) error {
 	// respect user defined name or label
 	if nodehelper.IgnoreNode(node.Name, node.Labels) {
 		logrus.Debugf("Skipping v3.node creation for [%v] node", node.Name)
@@ -505,7 +496,7 @@ func (m *nodesSyncer) createNode(node *corev1.Node, nodeCache *NodeCache, pods m
 	if existing != nil {
 		return nil
 	}
-	machine, err := m.convertNodeToMachine(node, existing, pods)
+	machine, err := m.convertNodeToMachine(node, existing)
 	if err != nil {
 		return err
 	}
@@ -680,7 +671,37 @@ func statusEqualTest(proposed, existing corev1.NodeStatus) bool {
 	return true
 }
 
-func (m *nodesSyncer) convertNodeToMachine(node *corev1.Node, existing *v3.Node, pods map[string][]*corev1.Pod) (*v3.Node, error) {
+func cleanStatus(machine *v3.Node) {
+	var conditions []corev1.NodeCondition
+	for _, condition := range machine.Status.InternalNodeStatus.Conditions {
+		if condition.Type == "Ready" {
+			conditions = append(conditions, condition)
+		}
+	}
+
+	machine.Status.InternalNodeStatus.Config = nil
+	machine.Status.InternalNodeStatus.VolumesInUse = nil
+	machine.Status.InternalNodeStatus.VolumesAttached = nil
+	machine.Status.InternalNodeStatus.Images = nil
+	machine.Status.InternalNodeStatus.Conditions = conditions
+
+	delete(machine.Status.NodeAnnotations, podresources.RequestsAnnotation)
+	delete(machine.Status.NodeAnnotations, podresources.LimitsAnnotation)
+}
+
+func getResourceList(annotation string, node *corev1.Node) corev1.ResourceList {
+	val := node.Annotations[annotation]
+	if val == "" {
+		return nil
+	}
+	result := corev1.ResourceList{}
+	if err := json.Unmarshal([]byte(val), &result); err != nil {
+		return corev1.ResourceList{}
+	}
+	return result
+}
+
+func (m *nodesSyncer) convertNodeToMachine(node *corev1.Node, existing *v3.Node) (*v3.Node, error) {
 	var machine *v3.Node
 	if existing == nil {
 		machine = &v3.Node{
@@ -701,7 +722,8 @@ func (m *nodesSyncer) convertNodeToMachine(node *corev1.Node, existing *v3.Node,
 		machine.Status.InternalNodeStatus = *node.Status.DeepCopy()
 	}
 
-	requests, limits := aggregateRequestAndLimitsForNode(pods[node.Name])
+	requests := getResourceList(podresources.RequestsAnnotation, node)
+	limits := getResourceList(podresources.LimitsAnnotation, node)
 	if machine.Status.Requested == nil {
 		machine.Status.Requested = corev1.ResourceList{}
 	}
@@ -725,47 +747,10 @@ func (m *nodesSyncer) convertNodeToMachine(node *corev1.Node, existing *v3.Node,
 		machine.Labels = map[string]string{}
 	}
 	machine.Labels[nodehelper.LabelNodeName] = node.Name
+	cleanStatus(machine)
 	v32.NodeConditionRegistered.True(machine)
 	v32.NodeConditionRegistered.Message(machine, "registered with kubernetes")
 	return machine, nil
-}
-
-func (m *nodesSyncer) getNonTerminatedPods() (map[string][]*corev1.Pod, error) {
-	pods := make(map[string][]*corev1.Pod)
-	fromCache, err := m.podLister.List("", labels.NewSelector())
-	if err != nil {
-		return pods, err
-	}
-
-	for _, pod := range fromCache {
-		if pod.Spec.NodeName == "" {
-			continue
-		}
-		// kubectl uses this cache to filter out the pods
-		if pod.Status.Phase == "Succeeded" || pod.Status.Phase == "Failed" {
-			continue
-		}
-		var nodePods []*corev1.Pod
-		if fromMap, ok := pods[pod.Spec.NodeName]; ok {
-			nodePods = fromMap
-		}
-		nodePods = append(nodePods, pod)
-		pods[pod.Spec.NodeName] = nodePods
-	}
-	return pods, nil
-}
-
-func aggregateRequestAndLimitsForNode(pods []*corev1.Pod) (map[corev1.ResourceName]resource.Quantity, map[corev1.ResourceName]resource.Quantity) {
-	requests, limits := map[corev1.ResourceName]resource.Quantity{}, map[corev1.ResourceName]resource.Quantity{}
-	for _, pod := range pods {
-		podRequests, podLimits := getPodData(pod)
-		addMap(podRequests, requests)
-		addMap(podLimits, limits)
-	}
-	if pods != nil {
-		requests[corev1.ResourcePods] = *resource.NewQuantity(int64(len(pods)), resource.DecimalSI)
-	}
-	return requests, limits
 }
 
 func isEqual(data1 map[corev1.ResourceName]resource.Quantity, data2 map[corev1.ResourceName]resource.Quantity) bool {
@@ -785,44 +770,6 @@ func isEqual(data1 map[corev1.ResourceName]resource.Quantity, data2 map[corev1.R
 		}
 	}
 	return true
-}
-
-func getPodData(pod *corev1.Pod) (map[corev1.ResourceName]resource.Quantity, map[corev1.ResourceName]resource.Quantity) {
-	requests, limits := map[corev1.ResourceName]resource.Quantity{}, map[corev1.ResourceName]resource.Quantity{}
-	for _, container := range pod.Spec.Containers {
-		addMap(container.Resources.Requests, requests)
-		addMap(container.Resources.Limits, limits)
-	}
-
-	for _, container := range pod.Spec.InitContainers {
-		addMapForInit(container.Resources.Requests, requests)
-		addMapForInit(container.Resources.Limits, limits)
-	}
-	return requests, limits
-}
-
-func addMap(data1 map[corev1.ResourceName]resource.Quantity, data2 map[corev1.ResourceName]resource.Quantity) {
-	for name, quantity := range data1 {
-		if value, ok := data2[name]; !ok {
-			data2[name] = quantity.DeepCopy()
-		} else {
-			value.Add(quantity)
-			data2[name] = value
-		}
-	}
-}
-
-func addMapForInit(data1 map[corev1.ResourceName]resource.Quantity, data2 map[corev1.ResourceName]resource.Quantity) {
-	for name, quantity := range data1 {
-		value, ok := data2[name]
-		if !ok {
-			data2[name] = quantity.DeepCopy()
-			continue
-		}
-		if quantity.Cmp(value) > 0 {
-			data2[name] = quantity.DeepCopy()
-		}
-	}
 }
 
 func (m *nodesSyncer) isClusterRestoring() (bool, error) {


### PR DESCRIPTION
The moved logic is responsible for setting the Limits and Requests fields on the v3.Node.Status.
