### PR TITLE
Migrate Namespaces Assigned conditions from project to cluster

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authz_types.go
+++ b/pkg/apis/management.cattle.io/v3/authz_types.go
@@ -12,12 +12,14 @@ import (
 )
 
 var (
-	NamespaceBackedResource                  condition.Cond = "BackingNamespaceCreated"
-	CreatorMadeOwner                         condition.Cond = "CreatorMadeOwner"
-	DefaultNetworkPolicyCreated              condition.Cond = "DefaultNetworkPolicyCreated"
-	ProjectConditionInitialRolesPopulated    condition.Cond = "InitialRolesPopulated"
-	ProjectConditionMonitoringEnabled        condition.Cond = "MonitoringEnabled"
-	ProjectConditionMetricExpressionDeployed condition.Cond = "MetricExpressionDeployed"
+	NamespaceBackedResource                   condition.Cond = "BackingNamespaceCreated"
+	CreatorMadeOwner                          condition.Cond = "CreatorMadeOwner"
+	DefaultNetworkPolicyCreated               condition.Cond = "DefaultNetworkPolicyCreated"
+	ProjectConditionDefaultNamespacesAssigned condition.Cond = "DefaultNamespacesAssigned"
+	ProjectConditionInitialRolesPopulated     condition.Cond = "InitialRolesPopulated"
+	ProjectConditionMonitoringEnabled         condition.Cond = "MonitoringEnabled"
+	ProjectConditionMetricExpressionDeployed  condition.Cond = "MetricExpressionDeployed"
+	ProjectConditionSystemNamespacesAssigned  condition.Cond = "SystemNamespacesAssigned"
 )
 
 // +genclient

--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -57,9 +57,9 @@ const (
 	ClusterConditionconditionDefaultProjectCreated condition.Cond = "DefaultProjectCreated"
 	// ClusterConditionconditionSystemProjectCreated true when system project has been created
 	ClusterConditionconditionSystemProjectCreated condition.Cond = "SystemProjectCreated"
-	// ClusterConditionDefaultNamespaceAssigned true when cluster's default namespace has been initially assigned
+	// Deprecated: ClusterConditionDefaultNamespaceAssigned true when cluster's default namespace has been initially assigned
 	ClusterConditionDefaultNamespaceAssigned condition.Cond = "DefaultNamespaceAssigned"
-	// ClusterConditionSystemNamespacesAssigned true when cluster's system namespaces has been initially assigned to
+	// Deprecated: ClusterConditionSystemNamespacesAssigned true when cluster's system namespaces has been initially assigned to
 	// a system project
 	ClusterConditionSystemNamespacesAssigned   condition.Cond = "SystemNamespacesAssigned"
 	ClusterConditionAddonDeploy                condition.Cond = "AddonDeploy"

--- a/pkg/controllers/managementuser/rbac/project_handler.go
+++ b/pkg/controllers/managementuser/rbac/project_handler.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	projectpkg "github.com/rancher/rancher/pkg/project"
@@ -96,41 +95,32 @@ func (p *pLifecycle) ensureNamespacesAssigned(project *v3.Project) error {
 		return nil
 	}
 
-	cluster, err := p.m.clusterLister.Get("", p.m.clusterName)
-	if err != nil {
-		return err
-	}
-	if cluster == nil {
-		return errors.Errorf("couldn't find cluster %v", p.m.clusterName)
-	}
-
 	switch projectName {
 	case projectpkg.Default:
-		if err = p.ensureDefaultNamespaceAssigned(cluster, project); err != nil {
+		if err := p.ensureDefaultNamespaceAssigned(project); err != nil {
 			return err
 		}
 	case projectpkg.System:
-		if err = p.ensureSystemNamespaceAssigned(cluster, project); err != nil {
+		if err := p.ensureSystemNamespaceAssigned(project); err != nil {
 			return err
 		}
 	default:
 		return nil
 	}
 
-	_, err = p.m.workload.Management.Management.Clusters("").Update(cluster)
-
+	_, err := p.m.workload.Management.Management.Projects(p.m.workload.ClusterName).Update(project)
 	return err
 }
 
-func (p *pLifecycle) ensureDefaultNamespaceAssigned(cluster *v3.Cluster, project *v3.Project) error {
-	_, err := v32.ClusterConditionDefaultNamespaceAssigned.DoUntilTrue(cluster, func() (runtime.Object, error) {
+func (p *pLifecycle) ensureDefaultNamespaceAssigned(project *v3.Project) error {
+	_, err := v32.ProjectConditionDefaultNamespacesAssigned.DoUntilTrue(project, func() (runtime.Object, error) {
 		return nil, p.assignNamespacesToProject(project, projectpkg.Default)
 	})
 	return err
 }
 
-func (p *pLifecycle) ensureSystemNamespaceAssigned(cluster *v3.Cluster, project *v3.Project) error {
-	_, err := v32.ClusterConditionSystemNamespacesAssigned.DoUntilTrue(cluster, func() (runtime.Object, error) {
+func (p *pLifecycle) ensureSystemNamespaceAssigned(project *v3.Project) error {
+	_, err := v32.ProjectConditionSystemNamespacesAssigned.DoUntilTrue(project, func() (runtime.Object, error) {
 		return nil, p.assignNamespacesToProject(project, projectpkg.System)
 	})
 	return err

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -254,7 +254,7 @@ func (r *Rancher) Start(ctx context.Context) error {
 			return err
 		}
 
-		if err := forceSystemNamespaceAssignment(r.Wrangler.Core.ConfigMap(), r.Wrangler.Mgmt.Cluster()); err != nil {
+		if err := forceSystemNamespaceAssignment(r.Wrangler.Core.ConfigMap(), r.Wrangler.Mgmt.Project()); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Description
-
Moved `DefaultNamespacesAssigned` and `SystemNamespacesAssigned` Conditions from cluster objects to associated default and system projects. During an upgrade, the project object may never have been updated (save for project sync), and having the cluster's status depend on the project being updated was causing issues due to the migrations having the wrangler controllers, but the project lifecycle having norman controllers. 

Info
-
Tested on HA  setup a number of times, confirmed issue was not reproducible.
Related Issue: https://github.com/rancher/rancher/issues/35411