### PR TITLE
Remove windows plan placeholder

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/machinestatus/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/machinestatus/controller.go
@@ -200,11 +200,6 @@ func (h *handler) OnChange(_ string, machine *capi.Machine) (*capi.Machine, erro
 		return machine, err
 	}
 
-	// This is a temporary solution until RKE2 Windows nodes support system-agent functionality.
-	if os, ok := machine.GetLabels()["cattle.io/os"]; ok && os == "windows" {
-		return h.setMachineCondition(machine, &machineStatus{cond: Provisioned, status: corev1.ConditionTrue, reason: "WindowsNode", message: "windows nodes don't currently support plans"})
-	}
-
 	if status.status == "" {
 		status.status, status.reason, status.message = planner.GetPlanStatusReasonMessage(machine, plan)
 	}


### PR DESCRIPTION
Remove the temporary solution that was in place until RKE2 Windows nodes supported system-agent functionality.