### PR TITLE
Always start the Secrets controller

### DIFF
--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -51,6 +51,8 @@ func Register(ctx context.Context, cluster *config.UserContext, clusterRec *mana
 
 	// register controller for API
 	cluster.APIAggregation.APIServices("").Controller()
+	// register secrets controller for impersonation
+	cluster.Core.Secrets("").Controller()
 
 	if clusterRec.Spec.LocalClusterAuthEndpoint.Enabled {
 		err := clusterauthtoken.CRDSetup(ctx, cluster.UserOnlyContext())


### PR DESCRIPTION
The impersonation mechanism relies on the Secrets controller being
started on the user context when a proxy request is made. Before
6b2e1359, the controller was incidentally being started as part of
registering other controllers. With 6b2e1359, the certsexpiration
controller was the last to always start it on startup and now only
conditionally starts it for RKE clusters. This change adds back the
Secrets controller startup to the cluster context unconditionally so
that it is ready the first time impersonation.GetToken is called.

https://github.com/rancher/rancher/issues/35593