### PR TITLE
filter releases by the "catalog.cattle.io/kube-version" annotation

### DIFF
--- a/pkg/catalogv2/content/content.go
+++ b/pkg/catalogv2/content/content.go
@@ -218,7 +218,15 @@ func (c *Manager) filterReleases(index *repo.IndexFile, k8sVersion *semver.Versi
 					logrus.Errorf("failed to parse constraint version %s: %v", constraintStr, err)
 				}
 			}
-
+			if constraintStr, ok := version.Annotations["catalog.cattle.io/kube-version"]; ok {
+				if constraint, err := semver.NewConstraint(constraintStr); err == nil {
+					if !constraint.Check(k8sVersion) {
+						continue
+					}
+				} else {
+					logrus.Errorf("failed to parse constraint kube-version %s from annotation: %v", constraintStr, err)
+				}
+			}
 			if version.KubeVersion != "" {
 				if constraint, err := semver.NewConstraint(version.KubeVersion); err == nil {
 					if !constraint.Check(k8sVersion) {

--- a/pkg/catalogv2/content/content_test.go
+++ b/pkg/catalogv2/content/content_test.go
@@ -341,3 +341,176 @@ func TestFilteringReleases(t *testing.T) {
 		})
 	}
 }
+func TestFilteringReleaseKubeVersionAnnotation(t *testing.T) {
+	tests := []struct {
+		testName                    string
+		chartVersionAnnotation      string
+		rancherVersion              string
+		ChartKubeVersionAnnotation string
+		kubernetesVersion           string
+		skipFiltering               bool
+		expectedPass                bool
+	}{
+		{
+			"Index with chart that has no filters and skips filtering",
+			"",
+			"",
+			"",
+			"",
+			true,
+			true,
+		},
+		{
+			"Index with chart that has kube-version annotation filter and skips filtering",
+			"",
+			"v2.5.0+123",
+			"1.18 - 1.20",
+			"v1.21.0",
+			true,
+			true,
+		},
+		{
+			"Index with chart that has kube-version annotation filter - case 1",
+			"",
+			"v2.5.0+123",
+			"1.18 - 1.20",
+			"v1.21.0",
+			false,
+			false,
+		},
+		{
+			"Index with chart that has kube-version annotation filter - case 2",
+			"",
+			"v2.5.0+123",
+			"1.18 - 1.21",
+			"v1.21.0",
+			false,
+			true,
+		},
+		{
+			"Index with chart that has kube-version annotation filter - case 3",
+			"",
+			"v2.5.0+123",
+			" = 1.20",
+			"v1.21.0",
+			false,
+			false,
+		},
+		{
+			"Index with chart that has kube-version annotation filter - case 4",
+			"",
+			"v2.5.0+123",
+			" = 1.21.1",
+			"v1.21.0",
+			false,
+			false,
+		},
+		{
+			"Index with chart that has kube-version annotation filter - case 5",
+			"",
+			"v2.5.0+123",
+			" >= 1.21",
+			"v1.21.0",
+			false,
+			true,
+		},
+		{
+			"Index with chart that has kube-version annotation filter - case 6",
+			"",
+			"v2.5.0+123",
+			" <= 1.22",
+			"v1.21.0",
+			false,
+			true,
+		},
+		{
+			"Index with chart that has kube-version annotation filter - case 7",
+			"",
+			"v2.5.0+123",
+			" < 1.22.0-0",
+			"v1.21.0",
+			false,
+			true,
+		},
+		{
+			"Index with chart that has kube-version annotation filter - case 7",
+			"",
+			"v2.5.0+123",
+			">= 1.19, <= 1.21",
+			"v1.21.0",
+			false,
+			true,
+		},
+		{
+			"Index with chart that has kube-version annotation filter - case 8",
+			"",
+			"v2.5.0+123",
+			" >= 1.19, <= 1.20",
+			"v1.21.0",
+			false,
+			false,
+		},
+		{
+			"Index with chart that has kube-version annotation filter - case 9",
+			"",
+			"v2.5.0+123",
+			" >= 1.19.0-0 < 1.22.0",
+			"v1.21.0",
+			false,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			indexFile := repo.IndexFile{
+				Entries: map[string]repo.ChartVersions{
+					"test-chart": {
+						{
+							Metadata: &chart.Metadata{
+								Name:    "test-chart",
+								Version: "1.0.0",
+								Annotations: map[string]string{
+									"catalog.cattle.io/rancher-version": tt.chartVersionAnnotation,
+									"catalog.cattle.io/kube-version": tt.ChartKubeVersionAnnotation,
+								},
+							},
+							URLs:    nil,
+							Created: time.Time{},
+							Removed: false,
+							Digest:  "",
+						},
+					},
+				},
+			}
+			filteredIndexFile := repo.IndexFile{
+				Entries: map[string]repo.ChartVersions{
+					"test-chart": {
+						{
+							Metadata: &chart.Metadata{
+								Name:    "test-chart",
+								Version: "1.0.0",
+								Annotations: map[string]string{
+									"catalog.cattle.io/rancher-version": tt.chartVersionAnnotation,
+									"catalog.cattle.io/kube-version": tt.ChartKubeVersionAnnotation,
+								},
+							},
+							URLs:    nil,
+							Created: time.Time{},
+							Removed: false,
+							Digest:  "",
+						},
+					},
+				},
+			}
+			contentManager := Manager{}
+			settings.ServerVersion.Set(tt.rancherVersion)
+			kubeVersion, _ := semver.NewVersion(tt.kubernetesVersion)
+			contentManager.filterReleases(&filteredIndexFile, kubeVersion, tt.skipFiltering)
+			result := reflect.DeepEqual(indexFile, filteredIndexFile)
+			assert.Equal(t, tt.expectedPass, result)
+			if result != tt.expectedPass {
+				t.Logf("Expected %v, got %v for %s with chart kubeVersion annotation %s", tt.expectedPass, result, kubeVersion, tt.ChartKubeVersionAnnotation)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/35613

Fix:
add the support for filtering releases by the `catalog.cattle.io/kube-version` annotation