### PR TITLE
don't remove service account for imported clusters

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -85,16 +85,16 @@ func (cd *clusterDeploy) sync(key string, cluster *v3.Cluster) (runtime.Object, 
 		err, updateErr error
 	)
 
+	if cluster.Status.Driver == v32.ClusterDriverImported && clusterconnected.Connected.IsFalse(cluster) {
+		return cluster, nil
+	}
+
 	if cluster == nil || cluster.DeletionTimestamp != nil {
 		// remove the system account user created for this cluster
 		if err := cd.systemAccountManager.RemoveSystemAccount(key); err != nil {
 			return nil, err
 		}
 		return nil, nil
-	}
-
-	if cluster.Status.Driver == v32.ClusterDriverImported && clusterconnected.Connected.IsFalse(cluster) {
-		return cluster, nil
 	}
 
 	original := cluster


### PR DESCRIPTION
https://github.com/rancher/rancher/pull/35545 introduced logic to show the right cluster condition disconnected when agent isn't connected. 

clusterDeploy logic was changed to not sync if cluster's agent is disconnected for imported clusters. But it is done after the service account is removed and no new service account is created [here](https://github.com/rancher/rancher/blob/release/v2.6/pkg/controllers/management/clusterdeploy/clusterdeploy.go#L144) because we return early.  