### PR TITLE
Skip cloud cred check if it is not changed

### DIFF
--- a/pkg/api/norman/customization/cluster/validator.go
+++ b/pkg/api/norman/customization/cluster/validator.go
@@ -359,7 +359,8 @@ func (v *Validator) validateAKSConfig(request *types.APIContext, cluster map[str
 	}
 
 	// check user's access to cloud credential
-	if azureCredential, ok := aksConfig["azureCredentialSecret"].(string); ok {
+	if azureCredential, ok := aksConfig["azureCredentialSecret"].(string); ok && (prevCluster == nil || azureCredential != prevCluster.Spec.AKSConfig.AzureCredentialSecret) {
+		// Only check that the user has access to the credential if the credential is being changed.
 		if err := validateCredentialAuth(request, azureCredential); err != nil {
 			return err
 		}
@@ -503,7 +504,8 @@ func (v *Validator) validateEKSConfig(request *types.APIContext, cluster map[str
 	}
 
 	// check user's access to cloud credential
-	if amazonCredential, ok := eksConfig["amazonCredentialSecret"].(string); ok {
+	if amazonCredential, ok := eksConfig["amazonCredentialSecret"].(string); ok && (prevCluster == nil || amazonCredential != prevCluster.Spec.EKSConfig.AmazonCredentialSecret) {
+		// Only check that the user has access to the credential if the credential is being changed.
 		if err := validateCredentialAuth(request, amazonCredential); err != nil {
 			return err
 		}
@@ -682,7 +684,8 @@ func (v *Validator) validateGKEConfig(request *types.APIContext, cluster map[str
 	}
 
 	// check user's access to cloud credential
-	if googleCredential, ok := gkeConfig["googleCredentialSecret"].(string); ok {
+	if googleCredential, ok := gkeConfig["googleCredentialSecret"].(string); ok && (prevCluster == nil || googleCredential != prevCluster.Spec.GKEConfig.GoogleCredentialSecret) {
+		// Only check that the user has access to the credential if the credential is being changed.
 		if err := validateCredentialAuth(request, googleCredential); err != nil {
 			return err
 		}


### PR DESCRIPTION
A cluster owner should be able to edit a cluster without changing the
cloud credential. Therefore, if the edit isn't changing the cloud
credential, then Rancher shouldn't validate that the user has access to
the cloud credential.

After this change, Rancher validates that the user has access to the
cloud credential only if they are trying to update it.

Issue:
https://github.com/rancher/rancher/issues/35413