### PR TITLE
Dynamically choose Ingress proxy store

### DIFF
--- a/pkg/api/norman/server/userstored/setup.go
+++ b/pkg/api/norman/server/userstored/setup.go
@@ -27,7 +27,6 @@ import (
 	clusterClient "github.com/rancher/rancher/pkg/client/generated/cluster/v3"
 	client "github.com/rancher/rancher/pkg/client/generated/project/v3"
 	"github.com/rancher/rancher/pkg/clustermanager"
-	"github.com/rancher/rancher/pkg/ingresswrapper"
 	clusterschema "github.com/rancher/rancher/pkg/schemas/cluster.cattle.io/v3"
 	schema "github.com/rancher/rancher/pkg/schemas/project.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
@@ -42,11 +41,7 @@ func Setup(ctx context.Context, mgmt *config.ScaledContext, clusterManager *clus
 	addProxyStore(ctx, schemas, mgmt, client.CronJobType, "batch/v1beta1", workload.NewCustomizeStore)
 	addProxyStore(ctx, schemas, mgmt, client.DaemonSetType, "apps/v1", workload.NewCustomizeStore)
 	addProxyStore(ctx, schemas, mgmt, client.DeploymentType, "apps/v1", workload.NewCustomizeStore)
-	if ingresswrapper.ServerSupportsIngressV1(mgmt.K8sClient) {
-		addProxyStore(ctx, schemas, mgmt, client.IngressType, "networking.k8s.io/v1", ingress.Wrap)
-	} else {
-		addProxyStore(ctx, schemas, mgmt, client.IngressType, "extensions/v1beta1", ingress.Wrap)
-	}
+	addProxyStore(ctx, schemas, mgmt, client.IngressType, "networking.k8s.io/v1", ingress.Wrap(clusterManager, mgmt))
 	addProxyStore(ctx, schemas, mgmt, client.JobType, "batch/v1", workload.NewCustomizeStore)
 	addProxyStore(ctx, schemas, mgmt, client.PersistentVolumeClaimType, "v1", nil)
 	addProxyStore(ctx, schemas, mgmt, client.PodType, "v1", func(store types.Store) types.Store {


### PR DESCRIPTION
Without this change, the norman store proxy setup chooses the Ingress
API to register based on the local cluster context at startup. It does
not know about other clusters at this point and can't register different
APIs on a cluster-by-cluster basis. This causes a problem when the local
cluster is version 1.18 (does not support networking.k8s.io/v1/Ingress)
and the downstream cluster is 1.22 (does not support
extensions/v1beta1/Ingress) or vice versa, where when the user tries to
navigate to the downstream cluster the wrong Ingress API will have been
registered and the Watch will fail with a 404 error.

This change addresses the problem by first statically registering the
networking.k8s.io/v1/Ingress API into the schema store on the assumption
that this will be used most of the time, and then adding an additional
Store object to be used dynamically during the request when the actual
cluster version is detected.

https://github.com/rancher/rancher/issues/35636
https://github.com/rancher/rancher/issues/35764