### PR TITLE
Issue-35694: Support ingressClassName in Helm Values

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -36,6 +36,9 @@ metadata:
 {{ toYaml .Values.ingress.extraAnnotations | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
   rules:
   - host: {{ .Values.hostname }}  # hostname to access rancher server
     http:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -64,6 +64,9 @@ ingress:
   # configurationSnippet: |
   #   more_set_input_headers "X-Forwarded-Host: {{ .Values.hostname }}";
 
+  # className can be set to specify which IngressClass will be used by the created Ingress
+  className: ""
+
   tls:
     # options: rancher, letsEncrypt, secret
     source: rancher


### PR DESCRIPTION
Relating to issue [GitHub Issue #35694](https://github.com/rancher/rancher/issues/35694) as identified in [this reddit thread](https://www.reddit.com/r/rancher/comments/qw9nho/is_the_helm_installer_broken/)

This PR adds 3 lines of Jinja2 template to the ingress.yaml spec so users may specify a `ingressClassName` in their `values.yaml` file or with `--set`, for example `ingressClassName: nginx` or `--set ingressClassName=nginx`.

This change remedies an issue where the Ingress created by `helm install` returns 404's when no default IngressClass is found by the Ingress resource. This occurs on a fresh `kubeadm` install that uses the `Nginx` ingress controller.

This also enables support for users choosing which of multiple possible Ingress classes to use when installing
with Helm.