### PR TITLE
ignore vendor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+vendor
 /.dapper
 /bin
 /dist


### PR DESCRIPTION
I vendor dependencies in my repos to speed up indexing in goland.