### PR TITLE
Replace downloaded K3s binary with rancher/k3s Docker image

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -4,7 +4,7 @@ ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 ENV CATTLE_HELM_VERSION v2.16.8-rancher1
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher73
-ENV CATTLE_K3S_VERSION v1.21.7+k3s1
+ENV CATTLE_K3S_VERSION v1.22.5+k3s1
 # version used by helm plugin install script
 ENV CATTLE_HELM_UNITTEST_VERSION v0.1.7-rancher3
 # helm 3 version
@@ -40,9 +40,6 @@ ENV HELM_URL_V2_amd64=https://github.com/rancher/helm/releases/download/${CATTLE
     TILLER_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller \
     TILLER_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller-arm64 \
     TILLER_URL=TILLER_URL_${ARCH} \
-    K3S_DOWNLOAD_URL_amd64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s \
-    K3S_DOWNLOAD_URL_arm64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s-arm64 \
-    K3S_DOWNLOAD_URL=K3S_DOWNLOAD_URL_${ARCH} \
     KUSTOMIZE_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
 
 RUN curl -sLf ${KUSTOMIZE_URL} | tar -xzf - -C /usr/bin
@@ -62,9 +59,48 @@ RUN mkdir /usr/tmp && \
     mv /usr/tmp/helm /usr/bin/helm_v3 && \
     chmod +x /usr/bin/kustomize
 
-RUN curl -sLf ${!K3S_DOWNLOAD_URL} -o /usr/bin/k3s && \
-    chmod +x /usr/bin/k3s && \
-    mkdir -p /go/src/github.com/rancher/rancher/.kube && \
+# Set up K3s: copy the necessary binaries from the K3s image.
+COPY --from=rancher/k3s:v1.22.5-k3s1 \
+    /bin/blkid \
+    /bin/charon \
+    /bin/cni \
+    /bin/conntrack \
+    /bin/containerd \
+    /bin/containerd-shim-runc-v2 \
+    /bin/ethtool \
+    /bin/ip \
+    /bin/ipset \
+    /bin/losetup \
+    /bin/pigz \
+    /bin/runc \
+    /bin/swanctl \
+    /bin/which \
+    /bin/aux/xtables-legacy-multi \
+/usr/bin/
+
+RUN ln -s /usr/bin/cni /usr/bin/bridge && \
+    ln -s /usr/bin/cni /usr/bin/flannel && \
+    ln -s /usr/bin/cni /usr/bin/host-local && \
+    ln -s /usr/bin/cni /usr/bin/loopback && \
+    ln -s /usr/bin/cni /usr/bin/portmap && \
+    ln -s /usr/bin/containerd /usr/bin/crictl && \
+    ln -s /usr/bin/containerd /usr/bin/ctr && \
+    ln -s /usr/bin/containerd /usr/bin/k3s && \
+    ln -s /usr/bin/containerd /usr/bin/k3s-agent && \
+    ln -s /usr/bin/containerd /usr/bin/k3s-etcd-snapshot && \
+    ln -s /usr/bin/containerd /usr/bin/k3s-server && \
+    ln -s /usr/bin/containerd /usr/bin/kubectl && \
+    ln -s /usr/bin/pigz /usr/bin/unpigz && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-save && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-restore && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-translate && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-save && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-restore && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-translate
+
+RUN mkdir -p /go/src/github.com/rancher/rancher/.kube && \
     ln -s /etc/rancher/k3s/k3s.yaml /go/src/github.com/rancher/rancher/.kube/k3s.yaml
 
 RUN curl -sLf https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s-images.txt -o /usr/tmp/k3s-images.txt
@@ -72,8 +108,6 @@ RUN curl -sLf https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERS
 ENV YQ_URL=https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_${ARCH}
 RUN curl -sLf ${YQ_URL} -o /usr/bin/yq && chmod +x /usr/bin/yq
 
-ENV KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/v1.21.7/bin/linux/${ARCH}/kubectl
-RUN curl -sLf ${KUBECTL_URL} -o /usr/bin/kubectl && chmod +x /usr/bin/kubectl
 
 RUN zypper install -y python3-tox python3-base python3 libffi-devel libopenssl-devel
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -27,10 +27,10 @@ ENV CATTLE_CHART_DEFAULT_BRANCH=$CHART_DEFAULT_BRANCH
 ENV CATTLE_PARTNER_CHART_DEFAULT_BRANCH=$PARTNER_CHART_DEFAULT_BRANCH
 ENV CATTLE_RKE2_CHART_DEFAULT_BRANCH=$RKE2_CHART_DEFAULT_BRANCH
 ENV CATTLE_HELM_VERSION v2.16.8-rancher1
-ENV CATTLE_K3S_VERSION v1.21.7+k3s1
+ENV CATTLE_K3S_VERSION v1.22.5+k3s1
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher73
 ENV CATTLE_MACHINE_PROVISION_IMAGE rancher/machine:${CATTLE_MACHINE_VERSION}
-ENV CATTLE_ETCD_VERSION v3.4.13
+ENV CATTLE_ETCD_VERSION v3.5.1
 ENV LOGLEVEL_VERSION v0.1.3
 ENV TINI_VERSION v0.18.0
 ENV TELEMETRY_VERSION v0.5.16
@@ -83,9 +83,6 @@ ENV HELM_URL_V2_amd64=https://github.com/rancher/helm/releases/download/${CATTLE
     TILLER_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller-arm64 \
     TILLER_URL=TILLER_URL_${ARCH} \
     ETCD_URL=https://github.com/etcd-io/etcd/releases/download/${CATTLE_ETCD_VERSION}/etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}.tar.gz \
-    K3S_DOWNLOAD_URL_amd64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s \
-    K3S_DOWNLOAD_URL_arm64=https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s-arm64 \
-    K3S_DOWNLOAD_URL=K3S_DOWNLOAD_URL_${ARCH} \
     KUSTOMIZE_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
 
 RUN curl -sLf ${KUSTOMIZE_URL} | tar -xzf - -C /usr/bin
@@ -102,13 +99,52 @@ RUN curl ${HELM_URL_V3} | tar xvzf - --strip-components=1 -C /usr/bin && \
     mv /usr/bin/helm /usr/bin/helm_v3 && \
     chmod +x /usr/bin/kustomize
 
+# Set up K3s: copy the necessary binaries from the K3s image.
+COPY --from=rancher/k3s:v1.22.5-k3s1 \
+    /bin/blkid \
+    /bin/charon \
+    /bin/cni \
+    /bin/conntrack \
+    /bin/containerd \
+    /bin/containerd-shim-runc-v2 \
+    /bin/ethtool \
+    /bin/ip \
+    /bin/ipset \
+    /bin/losetup \
+    /bin/pigz \
+    /bin/runc \
+    /bin/swanctl \
+    /bin/which \
+    /bin/aux/xtables-legacy-multi \
+/usr/bin/
+
+RUN ln -s /usr/bin/cni /usr/bin/bridge && \
+    ln -s /usr/bin/cni /usr/bin/flannel && \
+    ln -s /usr/bin/cni /usr/bin/host-local && \
+    ln -s /usr/bin/cni /usr/bin/loopback && \
+    ln -s /usr/bin/cni /usr/bin/portmap && \
+    ln -s /usr/bin/containerd /usr/bin/crictl && \
+    ln -s /usr/bin/containerd /usr/bin/ctr && \
+    ln -s /usr/bin/containerd /usr/bin/k3s && \
+    ln -s /usr/bin/containerd /usr/bin/k3s-agent && \
+    ln -s /usr/bin/containerd /usr/bin/k3s-etcd-snapshot && \
+    ln -s /usr/bin/containerd /usr/bin/k3s-server && \
+    ln -s /usr/bin/containerd /usr/bin/kubectl && \
+    ln -s /usr/bin/pigz /usr/bin/unpigz && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-save && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-restore && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-translate && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-save && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-restore && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-translate
+
 RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
-    curl -sLf ${!K3S_DOWNLOAD_URL} > /usr/bin/k3s && \
     mkdir -p /var/lib/rancher/k3s/agent/images/ && \
     curl -sfL ${ETCD_URL} | tar xvzf - --strip-components=1 -C /usr/bin/ etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcdctl && \
     curl -sLf https://github.com/rancher/telemetry/releases/download/${TELEMETRY_VERSION}/telemetry-${ARCH} > /usr/bin/telemetry && \
-    curl -sLf https://storage.googleapis.com/kubernetes-release/release/${CATTLE_K3S_VERSION%+*}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
-    chmod +x /usr/bin/tini /usr/bin/telemetry /usr/bin/k3s /usr/bin/kubectl && \
+    chmod +x /usr/bin/tini /usr/bin/telemetry && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
 ENV CATTLE_UI_VERSION 2.6.3

--- a/scripts/k3s-images.sh
+++ b/scripts/k3s-images.sh
@@ -8,7 +8,7 @@ mkdir -p bin
 # This is used for downloading the tar file and not the images text file.
 # Referenced in test: tests/validation/tests/v3_api/test_airgap.py
 if [ -e /usr/tmp/k3s-images.txt ]; then
-    images=$(grep -e 'docker.io/rancher/pause' -e 'docker.io/rancher/coredns-coredns' /usr/tmp/k3s-images.txt)
+    images=$(grep -e 'docker.io/rancher/mirrored-pause' -e 'docker.io/rancher/mirrored-coredns-coredns' /usr/tmp/k3s-images.txt)
     xargs -n1 docker pull <<< "${images}"
     docker save -o ./bin/k3s-airgap-images.tar ${images}
 else


### PR DESCRIPTION
SURE-3522
[GitHub Issue](https://github.com/rancher/rancher/issues/35101)

Currently, the Dockerfiles download K3s as a binary that is a self-extracting archive from the main K3s repo. When a container is run, the binary starts extracting various files it needs at runtime (kubectl, cni and containerd dependencies, for example).

This PR modifies the Dockefiles, so that at build time they download the already extracted binaries from a dedicated K3s image, rather than the archive. The unnecessary extraction is then eliminated.