### PR TITLE
fixed bootstrap password being deleted on upgrade

### DIFF
--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,6 +1,15 @@
-{{- /* Create the secret only if we set the value and the value does not already exist */ -}}
-{{- $exists := lookup "v1" "Secret" .Release.Namespace "bootstrap-secret" }}
-{{- if and .Values.bootstrapPassword (not $exists) }}
+{{/* Use the bootstrap password from values.yaml if an existing secret is not found */}}
+{{- $bootstrapPassword := .Values.bootstrapPassword -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "bootstrap-secret" -}}
+{{- if $existingSecret -}}
+    {{- if $existingSecret.data -}}
+        {{- if $existingSecret.data.bootstrapPassword -}}
+            {{- $bootstrapPassword = $existingSecret.data.bootstrapPassword | b64dec -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{/* If a bootstrap password was found in the values or an existing password was found create the secret */}}
+{{- if $bootstrapPassword }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,5 +17,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  bootstrapPassword: {{ .Values.bootstrapPassword | b64enc | quote }}
+  bootstrapPassword: {{ $bootstrapPassword | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
#34686

When upgrading from 2.6.0+ the bootstrap secret was being deleted because helm did not render the template unless the password was set.  This update copies the value of an existing secret if it is found and stops the secret from being deleted.

