### PR TITLE
don't set clusterConditionReady to true if connected is false

### DIFF
--- a/pkg/controllers/managementuser/healthsyncer/healthsyncer.go
+++ b/pkg/controllers/managementuser/healthsyncer/healthsyncer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types/slice"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/controllers/management/clusterconnected"
 	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
@@ -137,6 +138,12 @@ func (h *HealthSyncer) updateClusterHealth() error {
 	cluster := oldCluster.DeepCopy()
 	if !v32.ClusterConditionProvisioned.IsTrue(cluster) {
 		logrus.Debugf("Skip updating cluster health - cluster [%s] not provisioned yet", h.clusterName)
+		return nil
+	}
+
+	// cluster condition ready is set to false if connected is false, return to avoid setting it to true incorrectly
+	if clusterconnected.Connected.IsFalse(cluster) {
+		logrus.Debugf("Skip updating cluster condition ready - cluster agent for [%s] isn't connected yet", h.clusterName)
 		return nil
 	}
 


### PR DESCRIPTION
**Issue:**
Cluster state switches between Active and Unavailable (agent disconnected) after provisioning https://github.com/rancher/rancher/issues/35640 

**Problem**
We set clusterConditionReady and connected to false if cluster agent isn't connected (steve session for cluster doesn't exist https://github.com/rancher/rancher/blob/release/v2.6/pkg/controllers/management/clusterconnected/clusterconnected.go#L111) in https://github.com/rancher/rancher/pull/35545. Health syncer tries to get component status and updates cluster conditionReady to true even
if session doesn't exist. So the cluster state keeps switching between active and agent disconnected.

**Solution:**
If cluster agent isn't connected, we shouldn't set the cluster condition ready to true.