### PR TITLE
redeploy cluster agent for imported clusters even if connected is false

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	util "github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/clustermanager"
-	"github.com/rancher/rancher/pkg/controllers/management/clusterconnected"
 	"github.com/rancher/rancher/pkg/features"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/image"
@@ -91,10 +90,6 @@ func (cd *clusterDeploy) sync(key string, cluster *v3.Cluster) (runtime.Object, 
 			return nil, err
 		}
 		return nil, nil
-	}
-
-	if cluster.Status.Driver == v32.ClusterDriverImported && clusterconnected.Connected.IsFalse(cluster) {
-		return cluster, nil
 	}
 
 	original := cluster


### PR DESCRIPTION
**Issue:** 
Not able to import rke1 clusters https://github.com/rancher/rancher/issues/35650

**Problem** 
For the first cluster agent deployed through template generated by cluster import handler, [CATTLE_FEATURES is empty ](https://github.com/rancher/rancher/blob/release/v2.6/pkg/api/norman/customization/clusterregistrationtokens/import.go#L49) so rancher isn't running. Without secret and aggregation controllers running, session with clientKey `"stv-cluster-{clusterName}"` never gets added for clusters.

hasSession will always remain false until cluster agent is redeployed (during redeploy, CATTLE_FEATURES is set) and then connected becomes true. But [we blocked redeploy if connected is false](https://github.com/rancher/rancher/blob/release/v2.6/pkg/controllers/management/clusterdeploy/clusterdeploy.go#L96 ) in https://github.com/rancher/rancher/pull/35545, so that's why imported cluster never becomes active. 

**Solution**
Redeploy agent for imported clusters even when cluster condition connected is false. 

**Other solution**
Pass CATTLE_FEATURES for the first agent generated by cluster import handler during cluster registration. I didn't opt for this solution because I don't see any merit in starting to run rancher controllers for this agent when the cluster agent is going to get redeployed by rancher anyway. Also, this logic was recently added for 2.6.3 vs agent has been running without CATTLE_FEATURES since support for it was added. So inclined towards removing this code block. 