### PR TITLE
Check if matching dashboard app exists

### DIFF
--- a/pkg/api/norman/customization/app/app.go
+++ b/pkg/api/norman/customization/app/app.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 
 	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/httperror"
@@ -15,7 +16,7 @@ import (
 	"github.com/rancher/rancher/pkg/catalog/manager"
 	clusterv3 "github.com/rancher/rancher/pkg/client/generated/cluster/v3"
 	projectv3 "github.com/rancher/rancher/pkg/client/generated/project/v3"
-	"github.com/rancher/rancher/pkg/controllers/managementlegacy/compose/common"
+	"github.com/rancher/rancher/pkg/clustermanager"
 	hcommon "github.com/rancher/rancher/pkg/controllers/managementuserlegacy/helm/common"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	pv3 "github.com/rancher/rancher/pkg/generated/norman/project.cattle.io/v3"
@@ -29,10 +30,10 @@ import (
 
 type Wrapper struct {
 	Clusters              v3.ClusterInterface
+	ClusterManager        *clustermanager.Manager
 	CatalogManager        manager.CatalogManager
 	TemplateVersionClient v3.CatalogTemplateVersionInterface
 	TemplateVersionLister v3.CatalogTemplateVersionLister
-	KubeConfigGetter      common.KubeConfigGetter
 	AppGetter             pv3.AppsGetter
 	UserLister            v3.UserLister
 	UserManager           user.Manager
@@ -63,6 +64,14 @@ func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 }
 
 func (w Wrapper) Validator(request *types.APIContext, schema *types.Schema, data map[string]interface{}) error {
+	projectID := convert.ToString(data["projectId"])
+	clusterID := strings.Split(projectID, ":")[0]
+	targetNamespace := convert.ToString(data["targetNamespace"])
+	appID := convert.ToString(data["name"])
+	if err := w.ValidateDashboardAppDoesNotExist(clusterID, appID, targetNamespace, request); err != nil {
+		return err
+	}
+
 	externalID := convert.ToString(data["externalId"])
 	if externalID == "" {
 		return nil
@@ -75,7 +84,6 @@ func (w Wrapper) Validator(request *types.APIContext, schema *types.Schema, data
 	if err != nil {
 		return err
 	}
-	targetNamespace := convert.ToString(data["targetNamespace"])
 	if templateVersion.Spec.RequiredNamespace != "" && templateVersion.Spec.RequiredNamespace != targetNamespace {
 		return httperror.NewAPIError(httperror.InvalidType, "template's requiredNamespace doesn't match catalog app's target namespace")
 	}
@@ -87,6 +95,33 @@ func (w Wrapper) Validator(request *types.APIContext, schema *types.Schema, data
 	}
 	if ns.Name == "" {
 		return httperror.NewAPIError(httperror.InvalidReference, fmt.Sprintf("target namespace %v is not assigned to the current project %v", targetNamespace, data["projectId"]))
+	}
+
+	return nil
+}
+
+// ValidateDashboardAppDoesNotExist validates that a request is not attempting
+// to create an apps.project.cattle.io with an ID that matches an
+// apps.catalog.cattle.io in a namespace that matches its targetNamespace.
+func (w Wrapper) ValidateDashboardAppDoesNotExist(clusterName, appID, ns string, request *types.APIContext) error {
+	if request.Method != http.MethodPost {
+		return nil
+	}
+
+	couldNotValidateErrFormat := "could not determine whether an apps.catalog.cattle.io with same ID and namespace currently exists: %v"
+	clusterContext, err := w.ClusterManager.UserContext(clusterName)
+	if err != nil {
+		return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf(couldNotValidateErrFormat, err))
+	}
+
+	appClient := clusterContext.Catalog.V1().App()
+	if _, err := appClient.Get(ns, appID, metav1.GetOptions{}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf(couldNotValidateErrFormat, err))
+		}
+	} else {
+		return httperror.NewAPIError(httperror.Conflict, fmt.Sprintf("an apps.catalog.cattle.io already exists with"+
+			" ID [%s] in namespace [%s]", appID, ns))
 	}
 
 	return nil

--- a/pkg/api/norman/server/managementstored/setup.go
+++ b/pkg/api/norman/server/managementstored/setup.go
@@ -66,7 +66,6 @@ import (
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/clusterrouter"
 	md "github.com/rancher/rancher/pkg/controllers/management/kontainerdrivermetadata"
-	"github.com/rancher/rancher/pkg/controllers/managementlegacy/compose/common"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/nodeconfig"
 	sourcecodeproviders "github.com/rancher/rancher/pkg/pipeline/providers"
@@ -520,7 +519,7 @@ func NodeTypes(schemas *types.Schemas, management *config.ScaledContext) error {
 	return nil
 }
 
-func App(schemas *types.Schemas, management *config.ScaledContext, kubeConfigGetter common.KubeConfigGetter) {
+func App(schemas *types.Schemas, management *config.ScaledContext, clusterManager *clustermanager.Manager) {
 	schema := schemas.Schema(&projectschema.Version, projectclient.AppType)
 	store := &appStore.Store{
 		Store:                 schema.Store,
@@ -532,10 +531,10 @@ func App(schemas *types.Schemas, management *config.ScaledContext, kubeConfigGet
 	schema.Store = store
 	wrapper := app.Wrapper{
 		Clusters:              management.Management.Clusters(""),
+		ClusterManager:        clusterManager,
 		CatalogManager:        management.CatalogManager,
 		TemplateVersionClient: management.Management.CatalogTemplateVersions(""),
 		TemplateVersionLister: management.Management.CatalogTemplateVersions("").Controller().Lister(),
-		KubeConfigGetter:      kubeConfigGetter,
 		AppGetter:             management.Project,
 		UserLister:            management.Management.Users("").Controller().Lister(),
 		UserManager:           management.UserManager,

--- a/pkg/types/config/context.go
+++ b/pkg/types/config/context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/norman/store/proxy"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/catalog/manager"
+	"github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io"
 	apiregistrationv1 "github.com/rancher/rancher/pkg/generated/norman/apiregistration.k8s.io/v1"
 	appsv1 "github.com/rancher/rancher/pkg/generated/norman/apps/v1"
 	autoscaling "github.com/rancher/rancher/pkg/generated/norman/autoscaling/v2beta2"
@@ -222,6 +223,7 @@ type UserContext struct {
 	APIAggregation apiregistrationv1.Interface
 	Apps           appsv1.Interface
 	Autoscaling    autoscaling.Interface
+	Catalog        catalog.Interface
 	Project        projectv3.Interface
 	Core           corev1.Interface
 	RBAC           rbacv1.Interface
@@ -520,6 +522,12 @@ func NewUserContext(scaledContext *ScaledContext, config rest.Config, clusterNam
 		return nil, err
 	}
 	context.RBACw = rbacw.Rbac().V1()
+
+	ctlg, err := catalog.NewFactoryFromConfigWithOptions(&context.RESTConfig, &catalog.FactoryOptions{SharedControllerFactory: controllerFactory})
+	if err != nil {
+		return nil, err
+	}
+	context.Catalog = ctlg.Catalog()
 
 	dynamicConfig := config
 	if dynamicConfig.NegotiatedSerializer == nil {


### PR DESCRIPTION
**Problem:**
Prior, if a dashboard app already existed with the same ID in a
namespace that matched the targetNamespace of the
apps.project.cattle.io being created, they would be linked to
the same helm resources. This means changing one changed the
other.

**Solution:**
Now, an apps.project.cattle.io cannot be created if
a apps.catalog.cattle.io already exists with the same ID in
a namespace matching its targetNamespace.

**Issue:**
https://github.com/rancher/rancher/issues/35684