### PR TITLE
Stop planner controller for deleted clusters

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/planner/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/planner/controller.go
@@ -50,6 +50,10 @@ func Register(ctx context.Context, clients *wrangler.Context, planner *planner.P
 }
 
 func (h *handler) OnChange(cluster *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus) (rkev1.RKEControlPlaneStatus, error) {
+	if !cluster.DeletionTimestamp.IsZero() {
+		return status, nil
+	}
+
 	status.ObservedGeneration = cluster.Generation
 
 	err := h.planner.Process(cluster)

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -190,7 +190,7 @@ func (p *Planner) Process(controlPlane *rkev1.RKEControlPlane) error {
 	defer p.locker.Unlock(string(controlPlane.UID))
 
 	cluster, err := p.getCAPICluster(controlPlane)
-	if err != nil {
+	if err != nil || !cluster.DeletionTimestamp.IsZero() {
 		return err
 	}
 


### PR DESCRIPTION
The planner would run for a deleted cluster. When the etcd nodes were removed,
this would cause Rancher logs to be spammed by "waiting for bootstrap node"
logs.

With this change, the planner will no longer consider clusters that are deleted.

Issue:
https://github.com/rancher/rancher/issues/35730