### PR TITLE
Check for nil clusterSpec in kev2 refresher

### DIFF
--- a/pkg/controllers/management/clusterupstreamrefresher/cluster_upstream_refresher.go
+++ b/pkg/controllers/management/clusterupstreamrefresher/cluster_upstream_refresher.go
@@ -119,7 +119,6 @@ func getProviderAndReadyStatus(cluster *mgmtv3.Cluster) (string, bool) {
 // getProviderRefreshInterval returns the duration that should pass between
 // refreshing a cluster created by the given cloud provider.
 func getProviderRefreshInterval(provider string) (time.Duration, error) {
-
 	providerRefreshInterval := settings.GetSettingByID(fmt.Sprintf(refreshSettingFormat, strings.ToLower(provider)))
 	if providerRefreshInterval == "" {
 		return 300 * time.Second, nil
@@ -147,7 +146,6 @@ func nextRefreshTime(refreshInterval time.Duration, lastRefreshTime string) (tim
 }
 
 func (c *clusterRefreshController) refreshClusterUpstreamSpec(cluster *mgmtv3.Cluster, cloudDriver string) (*mgmtv3.Cluster, error) {
-
 	logrus.Infof("checking cluster [%s] upstream state for changes", cluster.Name)
 
 	// In this call, it is possible to get errors back with non-nil upstreamSpec.
@@ -157,14 +155,16 @@ func (c *clusterRefreshController) refreshClusterUpstreamSpec(cluster *mgmtv3.Cl
 	upstreamConfig, err := getComparableUpstreamSpec(c.secretsCache, c.secretClient, cluster)
 	if err != nil {
 		var syncFailed string
-		if upstreamConfig == nil {
+		if upstreamConfig == nil || (upstreamConfig.gkeConfig == nil && upstreamConfig.eksConfig == nil && upstreamConfig.aksConfig == nil) {
 			syncFailed = ": syncing failed"
 		}
 		cluster = cluster.DeepCopy()
 		apimgmtv3.ClusterConditionUpdated.False(cluster)
 		apimgmtv3.ClusterConditionUpdated.Message(cluster, fmt.Sprintf("[Syncing error%s] %s", syncFailed, err.Error()))
 
-		if upstreamConfig == nil {
+		// Only continue if one of the configs on upstreamConfig is not nil.
+		// Otherwise, an error occurred and no syncing should occur.
+		if upstreamConfig == nil || (upstreamConfig.gkeConfig == nil && upstreamConfig.eksConfig == nil && upstreamConfig.aksConfig == nil) {
 			return c.updateCluster(cluster)
 		}
 	} else if strings.Contains(apimgmtv3.ClusterConditionUpdated.GetMessage(cluster), "[Syncing error") {
@@ -266,7 +266,6 @@ func (c *clusterRefreshController) refreshClusterUpstreamSpec(cluster *mgmtv3.Cl
 }
 
 func (c *clusterRefreshController) updateCluster(cluster *mgmtv3.Cluster) (*mgmtv3.Cluster, error) {
-
 	if cluster.Annotations == nil {
 		cluster.Annotations = make(map[string]string)
 	}


### PR DESCRIPTION
Previously, when an error was received in the upstream refresher, only the
`upstreamConfig` was nil-checked. However, if retrieving the upstreamSpec
failed, then `upstreamConfig` would not be nil, but the corresponding cluster
config would be. Therefore, in addition to checking the `upstreamConfig` for
nilness, the individual cluster configs are also checked. At least one of them
should be non-nil for syncing to proceed.

Issue:
https://github.com/rancher/rancher/issues/35804