### PR TITLE
[2.5] Fix EKS nodegroup deletion on AWS API error

### DIFF
--- a/pkg/controllers/management/clusterupstreamrefresher/eks_upstream_spec.go
+++ b/pkg/controllers/management/clusterupstreamrefresher/eks_upstream_spec.go
@@ -44,6 +44,9 @@ func BuildEKSUpstreamSpec(secretsCache wranglerv1.SecretCache, cluster *mgmtv3.C
 		&eks.ListNodegroupsInput{
 			ClusterName: aws.String(cluster.Spec.EKSConfig.DisplayName),
 		})
+	if err != nil {
+		return nil, err
+	}
 
 	// gather upstream node groups states
 	var nodeGroupStates []*eks.DescribeNodegroupOutput


### PR DESCRIPTION
In the current implementation, an error was not checked, which led to all
nodegroups being deleted when an error was received from the AWS API when
listing nodegroups. Now, the error is checked and no deletion should occur.

In addition, to avoid setting the upstreamSpec to nil on refresh, each config on
 the `upstreamConfig` object is nil-checked. At least one of them should not be
 nil for the refresh to proceed.

Issue:
https://github.com/rancher/rancher/issues/35809

Original PR:
https://github.com/rancher/rancher/pull/35810