### PR TITLE
Explicitly sort app revisions by creation timestamp

### DIFF
--- a/pkg/controllers/managementuser/helm/controller.go
+++ b/pkg/controllers/managementuser/helm/controller.go
@@ -356,7 +356,10 @@ func (l *Lifecycle) pruneOldRevisions(obj *v3.App) {
 		logrus.Warnf("[helm-controller] Failed to list revisions for app %s: %v", projectName, err)
 		return
 	}
-
+	// Sort revisions by creation timestamp, starting with the oldest.
+	sort.Slice(revisions.Items, func(i, j int) bool {
+		return revisions.Items[i].CreationTimestamp.Before(&revisions.Items[j].CreationTimestamp)
+	})
 	if len(revisions.Items) > obj.Spec.MaxRevisionCount {
 		logrus.Tracef("[helm-controller] App %s is exceeding the maximum (%d) number of stored revisions", obj.Name, obj.Spec.MaxRevisionCount)
 		deleteCount := len(revisions.Items) - obj.Spec.MaxRevisionCount


### PR DESCRIPTION
This is a code change for a reopened issue [20654](https://github.com/rancher/rancher/issues/20654).

App revisions on retrieval and listing were sorted by creation timestamp. My code used to rely on that behavior. It appears to have changed, but I don't know how or where. So it's best to explicitly sort app revisions by creation timestamp and delete the oldest revisions, as needed, according to this order.