### PR TITLE
Ensure proper job cleanup

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
@@ -30,7 +30,7 @@ func getJobName(name string) string {
 	return name2.SafeConcatName(name, "machine", "provision")
 }
 
-func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, args driverArgs, filesSecret *corev1.Secret, jobBackoffLimit int32) ([]runtime.Object, error) {
+func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, args driverArgs, filesSecret *corev1.Secret, jobBackoffLimit int32) []runtime.Object {
 	var volumes []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
 	machineGVK := schema.FromAPIVersionAndKind(typeMeta.GetAPIVersion(), typeMeta.GetKind())
@@ -44,7 +44,7 @@ func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, 
 	}
 
 	if ready {
-		return []runtime.Object{secret}, nil
+		return []runtime.Object{secret}
 	}
 
 	if args.BootstrapOptional && args.BootstrapSecretName == "" {
@@ -225,5 +225,5 @@ func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, 
 		filesSecret,
 		rb2,
 		job,
-	}, nil
+	}
 }


### PR DESCRIPTION
There were a few issues related to job cleanup on deletion. Jobs were getting
deleted and recreated too quickly. In addition, jobs were being leftover after
deletion that was exacerbating the problem.

After this change, jobs should not be left over and machine deletion should not
hang because Wrangler will be able to clean up old jobs before creating new
ones.

Issue:
https://github.com/rancher/rancher/issues/35823