### PR TITLE
updates to windows dockerfiles tp work on both docker and containerd

### DIFF
--- a/tests/validation/tests/Dockerfiles/windows/metrics/Dockerfile
+++ b/tests/validation/tests/Dockerfiles/windows/metrics/Dockerfile
@@ -1,7 +1,6 @@
 ARG SERVERCORE
 
 FROM mcr.microsoft.com/windows/servercore:$SERVERCORE as builder
-MAINTAINER logan "https://github.com/loganhz"
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 ENV NODE_VERSION 10.16.0
 RUN $URL = ('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION); \
@@ -19,10 +18,8 @@ RUN $URL = ('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VE
     \
     Write-Host 'Complete.'
 
-FROM mcr.microsoft.com/powershell:nanoserver-$SERVERCORE
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-COPY --from=builder /nodejs /nodejs
 COPY ["app.js", "c:/web/"]
 EXPOSE 8080
 WORKDIR /web
-CMD Start-Process -NoNewWindow -Wait -FilePath c:/nodejs/node.exe -ArgumentList c:/web/app.js
+CMD ["powershell", "Start-Process", "-NoNewWindow", "-Wait", "-FilePath", "c:/nodejs/node.exe", "-ArgumentList", "c:/web/app.js"]

--- a/tests/validation/tests/Dockerfiles/windows/nginx/Dockerfile
+++ b/tests/validation/tests/Dockerfiles/windows/nginx/Dockerfile
@@ -1,7 +1,6 @@
 ARG SERVERCORE
 
 FROM mcr.microsoft.com/windows/servercore:$SERVERCORE
-MAINTAINER frank "https://github.com/thxcode"
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 ENV NGINX_WORKDIR "c:\\Program Files\\nginx"
 ENV NGINX_VERSION "1.16.0"
@@ -12,6 +11,4 @@ RUN [Environment]::SetEnvironmentVariable('PATH', ('{0};{1}' -f $env:NGINX_WORKD
 	Move-Item $env:ProgramFiles\nginx-* $env:NGINX_WORKDIR
 EXPOSE 80 443
 WORKDIR $NGINX_WORKDIR
-CMD Start-Process -NoNewWindow -FilePath nginx.exe ; \
-	Add-Content logs\access.log 'nginx started...' ; \
-	Get-Content -Wait logs\access.log
+CMD ["powershell", "Start-Process", "-NoNewWindow", "-FilePath", "nginx.exe", ";",  "Add-Content", "logs/access.log", "'nginx started...'", ";", "Get-Content", "-Wait", "logs/access.log", ";"]

--- a/tests/validation/tests/Dockerfiles/windows/testcontainer/Dockerfile
+++ b/tests/validation/tests/Dockerfiles/windows/testcontainer/Dockerfile
@@ -1,7 +1,6 @@
 ARG SERVERCORE
 
 FROM mcr.microsoft.com/windows/servercore:$SERVERCORE
-MAINTAINER orangedeng "https://github.com/orangedeng"
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 RUN Add-WindowsFeature Web-Server; \
     Invoke-WebRequest -UseBasicParsing -Uri "https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe" -OutFile "c:\svcm.exe"


### PR DESCRIPTION
per this issue https://github.com/containerd/containerd/issues/6300 and a bunch of testing it looks like the way we were doing things with our test images was the CMD style that worked in docker and we needed to update to the string array format for containerd to work properly. additionally removed maintainers that no longer work at rancher