### PR TITLE
set default serviceAccountName to k3s upgrader plan on updates

### DIFF
--- a/pkg/controllers/management/k3sbasedupgrade/template.go
+++ b/pkg/controllers/management/k3sbasedupgrade/template.go
@@ -124,6 +124,8 @@ func configureMasterPlan(masterPlan planv1.Plan, version string, concurrency int
 		Operator: corev1.TolerationOpExists,
 	}}
 
+	masterPlan.Spec.ServiceAccountName = genericPlan.Spec.ServiceAccountName
+
 	return masterPlan
 }
 
@@ -154,6 +156,8 @@ func configureWorkerPlan(workerPlan planv1.Plan, version string, concurrency int
 	workerPlan.Spec.Tolerations = []corev1.Toleration{{
 		Operator: corev1.TolerationOpExists,
 	}}
+
+	workerPlan.Spec.ServiceAccountName = genericPlan.Spec.ServiceAccountName
 
 	return workerPlan
 }


### PR DESCRIPTION
Issue:
Starting Rancher v2.6.0, serviceAccountName for k3s upgrader genericPlan was updated. But genericPlan is used only for creates (generateMasterPlan and generateWorkerPlan). On updates (configureMasterPlan and configureWorkerPlan), it picks the name from existing plan so it gets the old svc account name if the plans were created before Rancher 2.6.

https://github.com/rancher/rancher/issues/35797