### PR TITLE
Exclude ClusterMonitorGraphList and ProjectMonitorGraphList from norman typers

### DIFF
--- a/pkg/api/scheme/scheme.go
+++ b/pkg/api/scheme/scheme.go
@@ -104,6 +104,8 @@ func init() {
 	// unstructured object and allow the missing fields to be included.
 	Scheme.ExcludeGVK(management.SchemeGroupVersion.WithKind("ClusterList"))
 	Scheme.ExcludeGVK(management.SchemeGroupVersion.WithKind("NodeTemplateList"))
+	Scheme.ExcludeGVK(management.SchemeGroupVersion.WithKind("ClusterMonitorGraphList"))
+	Scheme.ExcludeGVK(management.SchemeGroupVersion.WithKind("ProjectMonitorGraphList"))
 }
 
 func addKnownTypes(scheme *runtime.Scheme) error {


### PR DESCRIPTION
This commit excludes ClusterMonitorGraphList and ProjectMonitorGraphList from norman typers.

Related to https://github.com/rancher/rancher/pull/34847.

Related Issue: https://github.com/rancher/rancher/issues/35760