### PR TITLE
Revert deferring resource quota register

### DIFF
--- a/pkg/controllers/managementuser/resourcequota/register.go
+++ b/pkg/controllers/managementuser/resourcequota/register.go
@@ -3,10 +3,8 @@ package resourcequota
 import (
 	"context"
 
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -15,25 +13,6 @@ const (
 )
 
 func Register(ctx context.Context, cluster *config.UserContext) {
-	starter := cluster.DeferredStart(ctx, func(ctx context.Context) error {
-		registerDeferred(ctx, cluster)
-		return nil
-	})
-
-	projects := cluster.Management.Management.Projects(cluster.ClusterName)
-	projects.AddHandler(ctx, "resourcequota-deferred", func(key string, obj *v3.Project) (runtime.Object, error) {
-		if obj != nil &&
-			(obj.Spec.ResourceQuota != nil ||
-				obj.Spec.ContainerDefaultResourceLimit != nil ||
-				obj.Spec.NamespaceDefaultResourceQuota != nil) {
-			return obj, starter()
-		}
-		return obj, nil
-	})
-
-}
-
-func registerDeferred(ctx context.Context, cluster *config.UserContext) {
 	// Index for looking up Namespaces by projectID annotation
 	nsInformer := cluster.Core.Namespaces("").Controller().Informer()
 	nsIndexers := map[string]cache.IndexFunc{


### PR DESCRIPTION
**Problem:**
Controllers were being locked causing certain request to stall.


**Solution:**
This is first observed after the commit deferring resource quota
register.It may or may not be the direct cause. This is being
reverted for now to return the metrics handler to a working
state.

**Issue:**
https://github.com/rancher/rancher/issues/35880