### PR TITLE
Don't block controller thread with deferred start

### DIFF
--- a/pkg/types/config/context.go
+++ b/pkg/types/config/context.go
@@ -242,6 +242,14 @@ type UserContext struct {
 }
 
 func (w *UserContext) DeferredStart(ctx context.Context, register func(ctx context.Context) error) func() error {
+	f := w.deferredStartAsync(ctx, register)
+	return func() error {
+		go f()
+		return nil
+	}
+}
+
+func (w *UserContext) deferredStartAsync(ctx context.Context, register func(ctx context.Context) error) func() error {
 	var (
 		startLock sync.Mutex
 		started   = false


### PR DESCRIPTION
If two controller goroutines both run deferred start it is possible to deadlock
as one goroutine is holding the start lock and waiting for the controllers
to start and the other gorouting is trying to get the start lock to wait
for the controllers to start.  Since both can not move forward the
controller start is deadlocked.
