### PR TITLE
Adding CSI Proxy config to Windows RKE2 Install script.

### DIFF
--- a/pkg/provisioningv2/rke2/installer/installer.go
+++ b/pkg/provisioningv2/rke2/installer/installer.go
@@ -149,6 +149,11 @@ func WindowsInstallScript(ctx context.Context, token string, envVars []corev1.En
 %s
 %s
 
+# Enables CSI Proxy
+$env:CSI_PROXY_URL = "https://acs-mirror.azureedge.net/csi-proxy/%%[1]s/binaries/csi-proxy-%%[1]s.tar.gz"
+$env:CSI_PROXY_VERSION = "v1.0.0"
+$env:CSI_PROXY_KUBELET_PATH = "C:/var/lib/rancher/rke2/bin/kubelet.exe"
+
 Invoke-WinsInstaller @PSBoundParameters
 exit 0
 `, data, envVarBuf.String(), binaryURL, server, ca, token)), nil

--- a/pkg/provisioningv2/rke2/installer/installer_test.go
+++ b/pkg/provisioningv2/rke2/installer/installer_test.go
@@ -21,4 +21,8 @@ func TestInstaller_WindowsInstallScript(t *testing.T) {
 	a.NotNil(script)
 	a.Contains(string(script), "$env:CATTLE_TOKEN=\"test\"")
 	a.Contains(string(script), "$env:CATTLE_ROLE_NONE=true")
+	a.Contains(string(script), "$env:CATTLE_ROLE_NONE=true")
+	a.Contains(string(script), "$env:CSI_PROXY_URL")
+	a.Contains(string(script), "$env:CSI_PROXY_VERSION")
+	a.Contains(string(script), "$env:CSI_PROXY_KUBELET_PATH")
 }


### PR DESCRIPTION
Windows requires a CSI Proxy windows service to be executing on the host for enabling CSI drivers to allocate resources on Windows nodes. We have already added that capability to Wins to support installing and starting the service. The configuration for that service needs to be driven by Rancher. We are currently defaulting this to enabled by default. If we later determine to make this configurable by Rancher, then we just need to update the this code in Rancher and the corresponding unit test to test that behavior.

* https://github.com/rancher/windows/issues/114

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>