### PR TITLE
Add rke2 template clusterrepos to create-clusters role

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -52,7 +52,8 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("").resources("secrets").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("cisconfigs").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("cisbenchmarkversions").verbs("get", "list", "watch").
-		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create")
+		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create").
+		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch")
 
 	rb.addRole("Manage Node Drivers", "nodedrivers-manage").
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("*")


### PR DESCRIPTION
## Description
A user with the "User-Base" global permission and the "Create new Clusters" role could not use rke2 templates, as the role did not have any rules regarding the `catalog.cattle.io.clusterrepos` resource. This PR allows a user with these permissions to `get`, `list`, and `watch` this resource for use when creating a new cluster from an rke2 template.

Also, was no longer able to reproduce https://github.com/rancher/rancher/issues/34844 with this user:
![create](https://user-images.githubusercontent.com/33796120/146440266-b7c37a73-6484-476f-9256-3620a58ed9d8.png)


Related Issues: https://github.com/rancher/rancher/issues/35177, https://github.com/rancher/rancher/issues/34844