### PR TITLE
Accept preexisting incompatible app versions

### DIFF
--- a/pkg/api/norman/customization/catalog/store.go
+++ b/pkg/api/norman/customization/catalog/store.go
@@ -105,7 +105,7 @@ func (t *templateStore) isTemplateVersionCompatible(clusterName, externalID stri
 		return true
 	}
 
-	err = t.CatalogManager.ValidateRancherVersion(template)
+	err = t.CatalogManager.ValidateRancherVersion(template, "")
 	if err != nil {
 		return false
 	}

--- a/pkg/api/norman/customization/cluster/actions_monitoring.go
+++ b/pkg/api/norman/customization/cluster/actions_monitoring.go
@@ -165,5 +165,5 @@ func (a ActionHandler) validateChartCompatibility(version, clusterName string) e
 	if err != nil {
 		return err
 	}
-	return a.CatalogManager.ValidateChartCompatibility(templateVersion, clusterName)
+	return a.CatalogManager.ValidateChartCompatibility(templateVersion, clusterName, "")
 }

--- a/pkg/api/norman/customization/multiclusterapp/multi_cluster_app.go
+++ b/pkg/api/norman/customization/multiclusterapp/multi_cluster_app.go
@@ -84,7 +84,9 @@ func (w Wrapper) ActionHandler(actionName string, action *types.Action, apiConte
 			return nil
 		}
 
-		if err := w.validateChartCompatibility(revision.TemplateVersionName, obj.Spec.Targets); err != nil {
+		mcappTemplateVersionParts := strings.Split(mcApp.TemplateVersionID, "-")
+		mcappCurrentTemplateVersion := mcappTemplateVersionParts[len(mcappTemplateVersionParts)-1]
+		if err := w.validateChartCompatibility(revision.TemplateVersionName, mcappCurrentTemplateVersion, obj.Spec.Targets); err != nil {
 			return err
 		}
 
@@ -284,7 +286,7 @@ func (w Wrapper) modifyProjects(request *types.APIContext, actionName string) ([
 	return inputProjects, inputAnswers, nil
 }
 
-func (w Wrapper) validateChartCompatibility(tempVersion string, targets []v32.Target) error {
+func (w Wrapper) validateChartCompatibility(tempVersion, currentAppVersion string, targets []v32.Target) error {
 	parts := strings.Split(tempVersion, ":")
 	if len(parts) != 2 {
 		return httperror.NewAPIError(httperror.InvalidBodyContent, "invalid templateVersionId")
@@ -295,7 +297,7 @@ func (w Wrapper) validateChartCompatibility(tempVersion string, targets []v32.Ta
 		return err
 	}
 
-	if err := w.CatalogManager.ValidateRancherVersion(template); err != nil {
+	if err := w.CatalogManager.ValidateRancherVersion(template, currentAppVersion); err != nil {
 		return httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())
 	}
 


### PR DESCRIPTION
**Problem:**
Prior, if an app that was installed prior was rendered incompatible
due to a rancher upgrade, updates to the app would fail. This would
happen even if the update was not to the app version.

**Solution:**
Now, apps can
be updated if their current version is incompatible as long as they
are not updating to another incompatible app version.

**Issue:**
https://github.com/rancher/rancher/issues/35904