### PR TITLE
Adjust values YAML systemDefaultRegistry

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
+++ b/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
@@ -29,7 +29,9 @@ func (h *handler) OnChangeInstallSUC(cluster *rancherv1.Cluster, status rancherv
 			Values: &v1alpha1.GenericMap{
 				Data: map[string]interface{}{
 					"global": map[string]interface{}{
-						"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+						"cattle": map[string]interface{}{
+							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+						},
 					},
 				},
 			},


### PR DESCRIPTION
The systemDefaultRegistry was put in at the incorrect level (global
.systemDefaultRegistry) for the latest version of the SUC chart. This change
bumps the systemDefaultRegistry to the correct level (global.cattle
.systemDefaultRegistry) so the chart picks it up properly.

Issue:
https://github.com/rancher/rancher/issues/35485