### PR TITLE
Set system-default-registry for K3S clusters

### DIFF
--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -662,9 +662,9 @@ func (p *Planner) addETCD(config map[string]interface{}, controlPlane *rkev1.RKE
 func addDefaults(config map[string]interface{}, controlPlane *rkev1.RKEControlPlane, machine *capi.Machine) {
 	if rancherruntime.GetRuntime(controlPlane.Spec.KubernetesVersion) == rancherruntime.RuntimeRKE2 {
 		config["cni"] = "calico"
-		if settings.SystemDefaultRegistry.Get() != "" {
-			config["system-default-registry"] = settings.SystemDefaultRegistry.Get()
-		}
+	}
+	if settings.SystemDefaultRegistry.Get() != "" {
+		config["system-default-registry"] = settings.SystemDefaultRegistry.Get()
 	}
 }
 


### PR DESCRIPTION
An if-statement kept the system-default-registry setting from being added to the
config for K3S clusters. This was a mistake. This change will set the
system-default-registry setting regardless of runtime.

Issue:
https://github.com/rancher/rancher/issues/35922