### PR TITLE
Leave out bootstrap secret if it is optional

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/machineprovision/args.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/args.go
@@ -45,7 +45,7 @@ type driverArgs struct {
 	EnvSecret           *corev1.Secret
 	StateSecretName     string
 	BootstrapSecretName string
-	BootstrapOptional   bool
+	BootstrapRequired   bool
 	Args                []string
 }
 
@@ -135,7 +135,7 @@ func (h *handler) getArgsEnvAndStatus(meta metav1.Object, data data.Object, args
 		EnvSecret:           secret,
 		StateSecretName:     secretName,
 		BootstrapSecretName: bootstrapName,
-		BootstrapOptional:   !create,
+		BootstrapRequired:   create,
 		Args:                cmd,
 		RKEMachineStatus: rkev1.RKEMachineStatus{
 			Ready:                     data.String("spec", "providerID") != "" && data.Bool("status", "jobComplete"),

--- a/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
@@ -340,7 +340,7 @@ func (h *handler) OnRemove(key string, obj runtime.Object) (runtime.Object, erro
 	}
 
 	if cond := getCondition(infraObj.data, deleteJobConditionType); cond != nil {
-		job, err := h.jobs.Get(infraObj.meta.GetNamespace(), getJobName(infraObj.meta.GetName()))
+		job, err := h.jobs.Get(infraObj.meta.GetNamespace(), GetJobName(infraObj.meta.GetName()))
 		if apierror.IsNotFound(err) {
 			// If the deletion job condition has been set on the infrastructure object and the deletion job has been removed,
 			// then we don't want to create another deletion job.

--- a/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
@@ -458,7 +458,7 @@ func (h *handler) run(infraObj *infraObject, create bool, jobBackoffLimit int32)
 		return infraObj.obj, err
 	}
 
-	if dArgs.BootstrapSecretName == "" && !dArgs.BootstrapOptional {
+	if dArgs.BootstrapSecretName == "" && dArgs.BootstrapRequired {
 		return infraObj.obj,
 			h.dynamic.EnqueueAfter(infraObj.obj.GetObjectKind().GroupVersionKind(), infraObj.meta.GetNamespace(), infraObj.meta.GetName(), 2*time.Second)
 	}

--- a/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
@@ -25,7 +25,7 @@ var (
 	oneThousand int64 = 1000
 )
 
-func getJobName(name string) string {
+func GetJobName(name string) string {
 	return name2.SafeConcatName(name, "machine", "provision")
 }
 
@@ -45,7 +45,7 @@ func objects(ready bool, args driverArgs) []runtime.Object {
 
 	volumes := make([]corev1.Volume, 0, 2)
 	volumeMounts := make([]corev1.VolumeMount, 0, 2)
-	saName := getJobName(args.MachineName)
+	saName := GetJobName(args.MachineName)
 
 	if args.BootstrapRequired {
 		volumes = append(volumes, corev1.Volume{

--- a/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
@@ -9,7 +9,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
@@ -30,22 +29,23 @@ func getJobName(name string) string {
 	return name2.SafeConcatName(name, "machine", "provision")
 }
 
-func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, args driverArgs, filesSecret *corev1.Secret, jobBackoffLimit int32) []runtime.Object {
-	volumes := make([]corev1.Volume, 0, 2)
-	volumeMounts := make([]corev1.VolumeMount, 0, 2)
-	machineGVK := schema.FromAPIVersionAndKind(typeMeta.GetAPIVersion(), typeMeta.GetKind())
-	saName := getJobName(meta.GetName())
+func objects(ready bool, args driverArgs) []runtime.Object {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      args.StateSecretName,
-			Namespace: meta.GetNamespace(),
+			Namespace: args.MachineNamespace,
 		},
 		Type: "rke.cattle.io/machine-state",
 	}
 
 	if ready {
+		// If the machine is ready, then we only need the secret.
 		return []runtime.Object{secret}
 	}
+
+	volumes := make([]corev1.Volume, 0, 2)
+	volumeMounts := make([]corev1.VolumeMount, 0, 2)
+	saName := getJobName(args.MachineName)
 
 	if args.BootstrapRequired {
 		volumes = append(volumes, corev1.Volume{
@@ -65,10 +65,10 @@ func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, 
 		})
 	}
 
-	if filesSecret != nil {
-		if filesSecret.Name == "" {
-			filesSecret.Name = saName
-			filesSecret.Namespace = meta.GetNamespace()
+	if args.FilesSecret != nil {
+		if args.FilesSecret.Name == "" {
+			args.FilesSecret.Name = saName
+			args.FilesSecret.Namespace = args.MachineNamespace
 		}
 
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
@@ -77,15 +77,15 @@ func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, 
 			MountPath: pathToMachineFiles,
 		})
 
-		keysToPaths := make([]corev1.KeyToPath, 0, len(filesSecret.Data))
-		for file := range filesSecret.Data {
+		keysToPaths := make([]corev1.KeyToPath, 0, len(args.FilesSecret.Data))
+		for file := range args.FilesSecret.Data {
 			keysToPaths = append(keysToPaths, corev1.KeyToPath{Key: file, Path: file})
 		}
 		volumes = append(volumes, corev1.Volume{
 			Name: "machine-files",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  filesSecret.Name,
+					SecretName:  args.FilesSecret.Name,
 					Items:       keysToPaths,
 					DefaultMode: &[]int32{0644}[0],
 				},
@@ -96,13 +96,13 @@ func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, 
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      saName,
-			Namespace: meta.GetNamespace(),
+			Namespace: args.MachineNamespace,
 		},
 	}
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      saName,
-			Namespace: meta.GetNamespace(),
+			Namespace: args.MachineNamespace,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -116,13 +116,13 @@ func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, 
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      saName,
-			Namespace: meta.GetNamespace(),
+			Namespace: args.MachineNamespace,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
 				Name:      saName,
-				Namespace: meta.GetNamespace(),
+				Namespace: args.MachineNamespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -134,13 +134,13 @@ func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, 
 	rb2 := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name2.SafeConcatName(saName, "extension"),
-			Namespace: meta.GetNamespace(),
+			Namespace: args.MachineNamespace,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
 				Name:      saName,
-				Namespace: meta.GetNamespace(),
+				Namespace: args.MachineNamespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -152,17 +152,17 @@ func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      saName,
-			Namespace: meta.GetNamespace(),
+			Namespace: args.MachineNamespace,
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: &jobBackoffLimit,
+			BackoffLimit: &args.BackoffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						InfraMachineGroup:   machineGVK.Group,
-						InfraMachineVersion: machineGVK.Version,
-						InfraMachineKind:    machineGVK.Kind,
-						InfraMachineName:    meta.GetName(),
+						InfraMachineGroup:   args.MachineGVK.Group,
+						InfraMachineVersion: args.MachineGVK.Version,
+						InfraMachineKind:    args.MachineGVK.Kind,
+						InfraMachineName:    args.MachineName,
 						InfraJobRemove:      strconv.FormatBool(!args.BootstrapRequired),
 					},
 				},
@@ -217,7 +217,7 @@ func (h *handler) objects(ready bool, typeMeta metav1.Type, meta metav1.Object, 
 		sa,
 		role,
 		rb,
-		filesSecret,
+		args.FilesSecret,
 		rb2,
 		job,
 	}

--- a/tests/integration/pkg/cluster/clusters.go
+++ b/tests/integration/pkg/cluster/clusters.go
@@ -8,6 +8,7 @@ import (
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	provisioningv1api "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2/machineprovision"
 	"github.com/rancher/rancher/pkg/provisioningv2/rke2/planner"
 	"github.com/rancher/rancher/tests/integration/pkg/clients"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
@@ -18,8 +19,10 @@ import (
 	"github.com/rancher/wrangler/pkg/condition"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
@@ -81,7 +84,7 @@ func Machines(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*ca
 	})
 }
 
-func WaitFor(clients *clients.Clients, c *provisioningv1api.Cluster) (_ *provisioningv1api.Cluster, err error) {
+func WaitForCreate(clients *clients.Clients, c *provisioningv1api.Cluster) (_ *provisioningv1api.Cluster, err error) {
 	defer func() {
 		if err != nil {
 			c, newErr := clients.Provisioning.Cluster().Get(c.Namespace, c.Name, metav1.GetOptions{})
@@ -112,7 +115,7 @@ func WaitFor(clients *clients.Clients, c *provisioningv1api.Cluster) (_ *provisi
 				"machines": machines,
 				"plans":    plans,
 			})
-			err = fmt.Errorf("wait failed on %s: %w", data, err)
+			err = fmt.Errorf("creation wait failed on %s: %w", data, err)
 		}
 	}()
 
@@ -160,6 +163,108 @@ func WaitFor(clients *clients.Clients, c *provisioningv1api.Cluster) (_ *provisi
 	})
 	if err != nil {
 		return nil, fmt.Errorf("mgmt cluster is not ready: %w", err)
+	}
+
+	return c, nil
+}
+
+func WaitForDelete(clients *clients.Clients, c *provisioningv1api.Cluster) (_ *provisioningv1api.Cluster, err error) {
+	defer func() {
+		if err != nil {
+			newC, newErr := clients.Provisioning.Cluster().Get(c.Namespace, c.Name, metav1.GetOptions{})
+			if apierrors.IsNotFound(newErr) {
+				newC = nil
+			} else if newErr != nil {
+				logrus.Errorf("failed to get cluster %s/%s to print error: %v", c.Namespace, c.Name, err)
+				return
+			}
+
+			machines, newErr := Machines(clients, c)
+			if newErr != nil {
+				logrus.Errorf("failed to get machines for %s/%s to print error: %v", c.Namespace, c.Name, err)
+			}
+
+			mgmtCluster, newErr := clients.Mgmt.Cluster().Get(c.Status.ClusterName, metav1.GetOptions{})
+			if apierrors.IsNotFound(newErr) {
+				mgmtCluster = nil
+			} else if newErr != nil {
+				logrus.Errorf("failed to get mgmt cluster %s/%s to print error: %v", c.Namespace, c.Name, err)
+			}
+
+			capiCluster, newErr := clients.CAPI.Cluster().Get(c.Namespace, c.Name, metav1.GetOptions{})
+			if apierrors.IsNotFound(newErr) {
+				capiCluster = nil
+			} else if newErr != nil {
+				logrus.Errorf("failed to get capi cluster %s/%s to print error: %v", c.Namespace, c.Name, err)
+			}
+
+			data, _ := json.Marshal(map[string]interface{}{
+				"cluster":     newC,
+				"mgmtCluster": mgmtCluster,
+				"capiCluster": capiCluster,
+				"machines":    machines,
+			})
+			err = fmt.Errorf("deletion wait failed on %s: %w", data, err)
+		}
+	}()
+
+	err = wait.Object(clients.Ctx, clients.Provisioning.Cluster().Watch, c, func(obj runtime.Object) (bool, error) {
+		c = obj.(*provisioningv1api.Cluster)
+		return !c.DeletionTimestamp.IsZero(), nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cluster not deleted: %w", err)
+	}
+
+	machines, err := Machines(clients, c)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, machine := range machines.Items {
+		gvk := schema.FromAPIVersionAndKind(machine.Spec.InfrastructureRef.APIVersion, machine.Spec.InfrastructureRef.Kind)
+		gvr := schema.GroupVersionResource{
+			Group:    gvk.Group,
+			Version:  gvk.Version,
+			Resource: strings.ToLower(gvk.Kind) + "s",
+		}
+		if err := wait.EnsureDoesNotExist(clients.Ctx, func() (runtime.Object, error) {
+			return clients.Dynamic.Resource(gvr).Namespace(machine.Spec.InfrastructureRef.Namespace).Get(clients.Ctx, machine.Spec.InfrastructureRef.Name, metav1.GetOptions{})
+		}); err != nil {
+			return nil, fmt.Errorf("infra machine %s/%s not deleted: %w", machine.Spec.InfrastructureRef.Namespace, machine.Spec.InfrastructureRef.Name, err)
+		}
+
+		if machine.Spec.Bootstrap.ConfigRef != nil {
+			if err := wait.EnsureDoesNotExist(clients.Ctx, func() (runtime.Object, error) {
+				return clients.RKE.RKEBootstrap().Get(machine.Spec.Bootstrap.ConfigRef.Namespace, machine.Spec.Bootstrap.ConfigRef.Name, metav1.GetOptions{})
+			}); err != nil {
+				return nil, fmt.Errorf("bootstrap config %s/%s not deleted: %w", machine.Spec.Bootstrap.ConfigRef.Namespace, machine.Spec.Bootstrap.ConfigRef.Name, err)
+			}
+		}
+
+		if err := wait.EnsureDoesNotExist(clients.Ctx, func() (runtime.Object, error) {
+			return clients.Batch.Job().Get(machine.Namespace, machineprovision.GetJobName(machine.Name), metav1.GetOptions{})
+		}); err != nil {
+			return nil, fmt.Errorf("machine provision job %s/%s not deleted: %w", machine.Namespace, machineprovision.GetJobName(machine.Name), err)
+		}
+
+		if err := wait.EnsureDoesNotExist(clients.Ctx, func() (runtime.Object, error) {
+			return clients.CAPI.Machine().Get(machine.Namespace, machine.Name, metav1.GetOptions{})
+		}); err != nil {
+			return nil, fmt.Errorf("machine not deleted: %w", err)
+		}
+	}
+
+	if err := wait.EnsureDoesNotExist(clients.Ctx, func() (runtime.Object, error) {
+		return clients.Mgmt.Cluster().Get(c.Status.ClusterName, metav1.GetOptions{})
+	}); err != nil {
+		return nil, fmt.Errorf("mgmt cluster not cleaned up: %w", err)
+	}
+
+	if err := wait.EnsureDoesNotExist(clients.Ctx, func() (runtime.Object, error) {
+		return clients.Provisioning.Cluster().Get(c.Namespace, c.Name, metav1.GetOptions{})
+	}); err != nil {
+		return nil, fmt.Errorf("cluster not cleaned up: %w", err)
 	}
 
 	return c, nil

--- a/tests/integration/pkg/tests/custom/custom_test.go
+++ b/tests/integration/pkg/tests/custom/custom_test.go
@@ -59,7 +59,7 @@ func TestCustomOneNode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = cluster.WaitFor(clients, c)
+	_, err = cluster.WaitForCreate(clients, c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestCustomThreeNode(t *testing.T) {
 		}
 	}
 
-	_, err = cluster.WaitFor(clients, c)
+	_, err = cluster.WaitForCreate(clients, c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,7 +180,7 @@ func TestCustomUniqueRoles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = cluster.WaitFor(clients, c)
+	_, err = cluster.WaitForCreate(clients, c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -248,7 +248,7 @@ func TestCustomThreeNodeWithTaints(t *testing.T) {
 		}
 	}
 
-	_, err = cluster.WaitFor(clients, c)
+	_, err = cluster.WaitForCreate(clients, c)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/integration/pkg/tests/machineprovisioning/machine_test.go
+++ b/tests/integration/pkg/tests/machineprovisioning/machine_test.go
@@ -20,7 +20,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
-func TestSingleNodeAllRoles(t *testing.T) {
+func TestSingleNodeAllRolesWithDelete(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)
@@ -44,7 +44,7 @@ func TestSingleNodeAllRoles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err = cluster.WaitFor(clients, c)
+	c, err = cluster.WaitForCreate(clients, c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,9 +75,20 @@ func TestSingleNodeAllRoles(t *testing.T) {
 	// This shouldn't be one, fix when node args starts returning what is from the config file
 	assert.Greater(t, len(args), 10)
 	assert.Len(t, machine.Status.Addresses, 2)
+
+	// Delete the cluster and wait for cleanup.
+	err = clients.Provisioning.Cluster().Delete(c.Namespace, c.Name, &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err = cluster.WaitForDelete(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func TestThreeNodesAllRoles(t *testing.T) {
+func TestThreeNodesAllRolesWithDelete(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)
@@ -101,13 +112,24 @@ func TestThreeNodesAllRoles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err = cluster.WaitFor(clients, c)
+	c, err = cluster.WaitForCreate(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the cluster and wait for cleanup.
+	err = clients.Provisioning.Cluster().Delete(c.Namespace, c.Name, &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err = cluster.WaitForDelete(clients, c)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestFiveNodesUniqueRoles(t *testing.T) {
+func TestFiveNodesUniqueRolesWithDelete(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)
@@ -139,13 +161,24 @@ func TestFiveNodesUniqueRoles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err = cluster.WaitFor(clients, c)
+	c, err = cluster.WaitForCreate(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the cluster and wait for cleanup.
+	err = clients.Provisioning.Cluster().Delete(c.Namespace, c.Name, &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err = cluster.WaitForDelete(clients, c)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestFourNodesServerAndWorkerRoles(t *testing.T) {
+func TestFourNodesServerAndWorkerRolesWithDelete(t *testing.T) {
 	t.Parallel()
 	clients, err := clients.New()
 	if err != nil {
@@ -175,7 +208,18 @@ func TestFourNodesServerAndWorkerRoles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err = cluster.WaitFor(clients, c)
+	c, err = cluster.WaitForCreate(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the cluster and wait for cleanup.
+	err = clients.Provisioning.Cluster().Delete(c.Namespace, c.Name, &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err = cluster.WaitForDelete(clients, c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +280,7 @@ func TestDrain(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err = cluster.WaitFor(clients, c)
+	c, err = cluster.WaitForCreate(clients, c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -298,7 +342,7 @@ func TestDrain(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err = cluster.WaitFor(clients, c)
+	c, err = cluster.WaitForCreate(clients, c)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/integration/pkg/wait/wait.go
+++ b/tests/integration/pkg/wait/wait.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,11 +46,7 @@ func doWatch(ctx context.Context, watchFunc watchFunc, cb func(obj runtime.Objec
 				return false, nil
 			}
 			switch event.Type {
-			case watch.Added:
-				fallthrough
-			case watch.Modified:
-				fallthrough
-			case watch.Deleted:
+			case watch.Added, watch.Modified, watch.Deleted:
 				done, err := cb(event.Object)
 				if err != nil || done {
 					return true, err
@@ -69,7 +66,7 @@ func retryWatch(ctx context.Context, watchFunc watchFunc, cb func(obj runtime.Ob
 	}
 }
 
-func Object(ctx context.Context, watchFunc WatchFunc, obj runtime.Object, cb func(obj runtime.Object) (bool, error)) (err error) {
+func Object(ctx context.Context, watchFunc WatchFunc, obj runtime.Object, cb func(obj runtime.Object) (bool, error)) error {
 	if done, err := cb(obj); err != nil || done {
 		return err
 	}
@@ -85,4 +82,24 @@ func Object(ctx context.Context, watchFunc WatchFunc, obj runtime.Object, cb fun
 			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
 		})
 	}, cb)
+}
+
+func EnsureDoesNotExist(ctx context.Context, getter func() (runtime.Object, error)) error {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(defaults.WatchTimeoutSeconds)*time.Second)
+	defer cancel()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for deletion: %w", ctx.Err())
+		case <-ticker.C:
+			_, err := getter()
+			if apierrors.IsNotFound(err) {
+				return nil
+			} else if err != nil {
+				return err
+			}
+		}
+	}
 }


### PR DESCRIPTION
When provisioning a machine, if the bootstrap secret is optional and not found,
then the name will be changed. This causes Wrangler Apply to delete the job and
recreate it with the new name, which in turn may cause the job to hang because
the process of create -> delete -> create is too fast for Kubernetes to handle.

Now, the volume and volume mount are only include if the bootstrap secret is
required. This keeps the job from being deleted and recreated when the bootstrap
secret cannot be found.

In addition, this change also adds tests for deleting clusters. Now, after we ensure
a cluster is created successfully, the cluster is deleted and we ensure the cluster
is cleaned up successfully.

Related Issue:
https://github.com/rancher/rancher/issues/35795