### PR TITLE
Register settings controller in downstream

### DIFF
--- a/pkg/controllers/dashboardapi/controller.go
+++ b/pkg/controllers/dashboardapi/controller.go
@@ -14,5 +14,5 @@ func Register(ctx context.Context, wrangler *wrangler.Context) error {
 	mcmstart.Register(ctx, wrangler.Mgmt.Feature(), wrangler.MultiClusterManager)
 	feature.Register(ctx, wrangler.Mgmt.Feature())
 	helm.RegisterReposForFollowers(ctx, wrangler.Core.Secret().Cache(), wrangler.Catalog.ClusterRepo())
-	return settings.Register(wrangler.Mgmt.Setting(), !wrangler.Agent)
+	return settings.Register(wrangler.Mgmt.Setting())
 }

--- a/pkg/controllers/dashboardapi/settings/settings.go
+++ b/pkg/controllers/dashboardapi/settings/settings.go
@@ -11,11 +11,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Register(settingController managementcontrollers.SettingController, install bool) error {
+func Register(settingController managementcontrollers.SettingController) error {
 	sp := &settingsProvider{
 		settings:     settingController,
 		settingCache: settingController.Cache(),
-		install:      install,
 	}
 
 	if err := settings.SetProvider(sp); err != nil {
@@ -28,7 +27,6 @@ func Register(settingController managementcontrollers.SettingController, install
 type settingsProvider struct {
 	settings     managementcontrollers.SettingClient
 	settingCache managementcontrollers.SettingCache
-	install      bool
 	fallback     map[string]string
 }
 
@@ -86,7 +84,7 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 
 	for name, setting := range settingsMap {
 		key := settings.GetEnvKey(name)
-		value := os.Getenv(key)
+		envValue := os.Getenv(key)
 
 		obj, err := s.settings.Get(setting.Name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
@@ -96,21 +94,20 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 				},
 				Default: setting.Default,
 			}
-			if value != "" {
-				newSetting.Value = value
+			if envValue != "" {
+				newSetting.Source = "env"
+				newSetting.Value = envValue
 			}
 			if newSetting.Value == "" {
 				fallback[newSetting.Name] = newSetting.Default
 			} else {
 				fallback[newSetting.Name] = newSetting.Value
 			}
-			if s.install {
-				_, err := s.settings.Create(newSetting)
-				// Rancher will race in an HA setup to try and create the settings
-				// so if it exists just move on.
-				if err != nil && !errors.IsAlreadyExists(err) {
-					return err
-				}
+			_, err := s.settings.Create(newSetting)
+			// Rancher will race in an HA setup to try and create the settings
+			// so if it exists just move on.
+			if err != nil && !errors.IsAlreadyExists(err) {
+				return err
 			}
 		} else if err != nil {
 			return err
@@ -120,8 +117,12 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 				obj.Default = setting.Default
 				update = true
 			}
-			if value != "" && obj.Value != value {
-				obj.Value = value
+			if envValue != "" && obj.Source != "env" {
+				obj.Source = "env"
+				update = true
+			}
+			if envValue != "" && obj.Value != envValue {
+				obj.Value = envValue
 				update = true
 			}
 			if obj.Value == "" {
@@ -129,7 +130,7 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 			} else {
 				fallback[obj.Name] = obj.Value
 			}
-			if update && s.install {
+			if update {
 				_, err := s.settings.Update(obj)
 				if err != nil {
 					return err


### PR DESCRIPTION
Absorbs partial changes from https://github.com/rancher/rancher/commit/261ce1344cda47126431636540b5fb6c08dcea7d#

Due to a change introduced in https://github.com/rancher/rancher/pull/35508, we need to ensure that the settings controller is started in downstream so that the downstream are capable of getting the InstallUUID setting to allow it to add chart repositories.

Related Issue: https://github.com/rancher/rancher/issues/35820