### PR TITLE
Add rke2 support for drain before delete

### DIFF
--- a/pkg/apis/provisioning.cattle.io/v1/rke.go
+++ b/pkg/apis/provisioning.cattle.io/v1/rke.go
@@ -13,6 +13,7 @@ type RKEMachinePool struct {
 	EtcdRole                     bool                         `json:"etcdRole,omitempty"`
 	ControlPlaneRole             bool                         `json:"controlPlaneRole,omitempty"`
 	WorkerRole                   bool                         `json:"workerRole,omitempty"`
+	DrainBeforeDelete            bool                         `json:"drainBeforeDelete,omitempty"`
 	NodeConfig                   *corev1.ObjectReference      `json:"machineConfigRef,omitempty" wrangler:"required"`
 	Name                         string                       `json:"name,omitempty" wrangler:"required"`
 	DisplayName                  string                       `json:"displayName,omitempty"`

--- a/pkg/controllers/management/nodepool/nodepool.go
+++ b/pkg/controllers/management/nodepool/nodepool.go
@@ -75,7 +75,7 @@ func (c *Controller) needsReconcile(nodePool *v3.NodePool, nodes []*v3.Node) boo
 func (c *Controller) reconcile(nodePool *v3.NodePool, nodes []*v3.Node) {
 	_, qty, err := c.createOrCheckNodes(nodePool, nodes, false)
 	if err != nil {
-		logrus.Errorf("[nodepool] reconcile erorr, create or check nodes: %s", err)
+		logrus.Errorf("[nodepool] reconcile error, create or check nodes: %s", err)
 	}
 
 	if qty != nodePool.Spec.Quantity {

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
@@ -280,6 +280,10 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 		for k, v := range machinePool.MachineDeploymentLabels {
 			machineDeploymentLabels[k] = v
 		}
+		machineSpecAnnotations := map[string]string{}
+		if !machinePool.DrainBeforeDelete {
+			machineSpecAnnotations[capi.ExcludeNodeDrainingAnnotation] = "true"
+		}
 
 		machineDeployment := &capi.MachineDeployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -299,7 +303,7 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 							capi.ClusterLabelName:           capiCluster.Name,
 							capi.MachineDeploymentLabelName: machinePoolName,
 						},
-						Annotations: map[string]string{},
+						Annotations: machineSpecAnnotations,
 					},
 					Spec: capi.MachineSpec{
 						ClusterName: capiCluster.Name,


### PR DESCRIPTION
## Description

CAPI (cluster API) drains nodes on deletion by default, although it is possible to force a node not to drain by adding the `ExcludeNodeDrainingAnnotation` annotation (e.g.  `machine.cluster.x-k8s.io/exclude-node-draining: true`). This PR adds that annotation to the `MachineTemplateSpec` in the `MachineDeployment`, which will apply to each machine created. This creates parity with RKE1 "Drain Before Delete", by allowing users the option to apply a drainage policy to each machine pool.

Related Issue: #35274 