### PR TITLE
fix the issue that global private registry is not used when upgrading imported RKE2 clusters 

### DIFF
--- a/pkg/controllers/management/k3sbasedupgrade/deployPlans.go
+++ b/pkg/controllers/management/k3sbasedupgrade/deployPlans.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/management/clusterdeploy"
 	planClientset "github.com/rancher/rancher/pkg/generated/clientset/versioned/typed/upgrade.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/settings"
 	planv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +31,7 @@ func (h *handler) deployPlans(cluster *v3.Cluster, isK3s, isRke2 bool) error {
 	)
 	switch {
 	case isRke2:
-		upgradeImage = rke2upgradeImage
+		upgradeImage = settings.PrefixPrivateRegistry(rke2upgradeImage)
 		masterPlanName = rke2MasterPlanName
 		workerPlanName = rke2WorkerPlanName
 		Version = cluster.Spec.Rke2Config.Version

--- a/pkg/controllers/managementuserlegacy/helm/common/extra_args_injection.go
+++ b/pkg/controllers/managementuserlegacy/helm/common/extra_args_injection.go
@@ -35,7 +35,7 @@ func injectDefaultRegistry(obj *v3.App) map[string]string {
 		return nil
 	}
 
-	return map[string]string{"systemDefaultRegistry": reg}
+	return map[string]string{"systemDefaultRegistry": reg, "cattle.systemDefaultRegistry": reg}
 }
 
 func injectClusterInfo(obj *v3.App) map[string]string {


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/32803
Problem:
Images are not pulled from Rancher's global private registry when upgrading the k8s version of RKE2 clusters via Rancher UI, which will fail the upgrade because the cluster's nodes cannot connect to docker.io in the air-gapped environment.

Fixes:
Append the global private registry to the image used in the upgrade plan for RKE2 clusters;
Add 'global.cattle.systemDefaultRegistry:reg' to the default values passed to the app `rancher-rke2-upgrade`
