### PR TITLE
Added a fix for service discovery related error.

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -1000,6 +1000,19 @@ def validate_dns_record(pod, record, expected, port=TEST_IMAGE_PORT):
         record["name"], record["namespaceId"])
     validate_dns_entry(pod, host, expected, port=port)
 
+def retry_dig(host, pod, expected, retry_count=3):
+    for i in range(0, retry_count):
+        dig_cmd = 'dig {0} +short'.format(host)
+        dig_output = kubectl_pod_exec(pod, dig_cmd)
+        decode_dig = dig_output.decode('utf-8')
+        split_dig = decode_dig.splitlines()
+        dig_length = len(split_dig)
+        expected_length = len(expected)
+        if dig_length >= expected_length:
+            return dig_output
+        elif dig_length < expected_length:
+            time.sleep(3)
+    pytest.fail(f"failed to get the expected number of dns hosts from dig")
 
 def validate_dns_entry(pod, host, expected, port=TEST_IMAGE_PORT):
     if is_windows():
@@ -1025,8 +1038,7 @@ def validate_dns_entry(pod, host, expected, port=TEST_IMAGE_PORT):
     else:
         assert " 0% packet loss" in str(cmd_output)
 
-    dig_cmd = 'dig {0} +short'.format(host)
-    dig_output = kubectl_pod_exec(pod, dig_cmd)
+    dig_output = retry_dig(host, pod, expected)
 
     for expected_value in expected:
         assert expected_value in str(dig_output), \


### PR DESCRIPTION
 tests.v3_api.test_service_discovery.test_dns_record_type_multiple_workloads

Above test fails almost always while running the **rancher-v3_ontag_custom_certification**. 
Here is a link to the above failed job. - jenkns 77

In this PR I've added the possible fix for the test failure.

Here is a link to the passing test with the fix - 620 - freeform
