### PR TITLE
[2.5] skip remove nodes for non-custom cluster

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -224,6 +224,11 @@ func (m *Lifecycle) getNodePool(nodePoolName string) (*v3.NodePool, error) {
 }
 
 func (m *Lifecycle) Remove(obj *v3.Node) (runtime.Object, error) {
+	// skip remove nodes for non-custom cluster
+	if obj.Spec.NodeTemplateName == "" && obj.Spec.CustomConfig == nil {
+		return obj, nil
+	}
+
 	if obj.Status.NodeTemplateSpec == nil {
 		return m.deleteV1Node(obj)
 	}


### PR DESCRIPTION
We should skip deleting k8s cluster node for non-custom cluster. We add a formatter function to remove delete node actions for non-custom cluster [here](https://github.com/rancher/rancher/blob/release/v2.5/pkg/api/norman/customization/node/node.go#L58) but not skip it in node controller. 

https://github.com/rancher/rancher/issues/32284