### PR TITLE
append the global private registry to the image used in the upgrade plan for K3s clusters

### DIFF
--- a/pkg/controllers/management/k3sbasedupgrade/deployPlans.go
+++ b/pkg/controllers/management/k3sbasedupgrade/deployPlans.go
@@ -37,7 +37,7 @@ func (h *handler) deployPlans(cluster *v3.Cluster, isK3s, isRke2 bool) error {
 		Version = cluster.Spec.Rke2Config.Version
 		strategy = cluster.Spec.Rke2Config.ClusterUpgradeStrategy
 	case isK3s:
-		upgradeImage = k3supgradeImage
+		upgradeImage = settings.PrefixPrivateRegistry(k3supgradeImage)
 		masterPlanName = k3sMasterPlanName
 		workerPlanName = k3sWorkerPlanName
 		Version = cluster.Spec.K3sConfig.Version


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36000

Problem:
When an upgrade of the k8s version in the imported k3s cluster is triggered, the Plan does not use the system-default-registry as the source for pulling images. As a result, the upgrade job and pod fail in pulling images as they cannot reach docker.io in the air-gapped environment.

Fixes:
Append the global private registry to the image used in the upgrade plan for RKE2 clusters

