### PR TITLE
Refreshing a catalog should clean up catalog-cache at the same time

### DIFF
--- a/pkg/controllers/managementapi/catalog/catalog.go
+++ b/pkg/controllers/managementapi/catalog/catalog.go
@@ -78,7 +78,7 @@ func contains(catalogs []*v3.Catalog, c *v3.Catalog) bool {
 }
 
 func (c *CacheCleaner) cleanUpCatalogs(targetCatalogs []*v3.Catalog) error {
-	logrus.Debug("Catalog-cache running cleanUpWithTarget")
+	logrus.Debug("Catalog-cache running cleanUpCatalogs")
 	catalogCacheFiles, err := readDirNames(helmlib.CatalogCache)
 	if err != nil && !os.IsNotExist(err) {
 		return err

--- a/pkg/controllers/managementapi/catalog/catalog.go
+++ b/pkg/controllers/managementapi/catalog/catalog.go
@@ -106,22 +106,28 @@ func (c *CacheCleaner) cleanUpCatalogs(targetCatalogs []*v3.Catalog) error {
 	if err != nil {
 		return err
 	}
+
 	for _, catalog := range catalogs.Items {
 		allCatalogs = append(allCatalogs, &catalog)
 	}
-
 	for _, clusterCatalog := range clusterCatalogs.Items {
 		allCatalogs = append(allCatalogs, &clusterCatalog.Catalog)
 	}
-
 	for _, projectCatalog := range projectCatalogs.Items {
 		allCatalogs = append(allCatalogs, &projectCatalog.Catalog)
+	}
+
+	if len(targetCatalogs) == 0 {
+		for _, catalog := range allCatalogs {
+			catalogHashes[helmlib.CatalogSHA256Hash(catalog)] = true
+		}
 	}
 	for _, catalog := range targetCatalogs {
 		if contains(allCatalogs, catalog) {
 			catalogHashes[helmlib.CatalogSHA256Hash(catalog)] = true
 		}
 	}
+
 	var cleanupCount int
 	cleanupCount += cleanupPath(helmlib.CatalogCache, catalogCacheFiles, catalogHashes)
 	cleanupCount += cleanupPath(helmlib.IconCache, iconCacheFiles, catalogHashes)

--- a/pkg/controllers/managementapi/catalog/catalog.go
+++ b/pkg/controllers/managementapi/catalog/catalog.go
@@ -143,7 +143,7 @@ func (c *CacheCleaner) Cleanup() error {
 }
 
 func (c *CacheCleaner) CleanTarget(catalog *v3.Catalog) error {
-	logrus.Debug("Catalog-cache running cleanTarget:%v", catalog.Name)
+	logrus.Debugf("Catalog-cache running cleanTarget:%v", catalog.Name)
 	return c.cleanUpCatalogs([]*v3.Catalog{catalog})
 }
 


### PR DESCRIPTION
Currently when invoking api /v3/catalogs/{catalogName}?action=refresh, it fails to clean catalog-cache, a workaround many users have used so far is to delete all files under `/var/lib/rancher/management-state/catalog-cache`. 