### PR TITLE
Update health check command as per etcdctl v3 API

### DIFF
--- a/tests/validation/requirements.txt
+++ b/tests/validation/requirements.txt
@@ -11,3 +11,4 @@ kubernetes==12.0.1
 paramiko==2.6.0
 python-digitalocean==1.13.2
 PyYAML==5.4.1
+packaging==20.9


### PR DESCRIPTION
**Adding this fix for rke_support_matrix job**

**Issue:**
- The etcdctl health check command `ETCDCTL_API=2 etcdctl --endpoints "https://127.0.0.1:2379"  --ca-file /etc/kubernetes/ssl/kube-ca.pem --cert-file  $ETCDCTL_CERT --key-file  $ETCDCTL_KEY cluster-health` fails for k8s 1.22 clusters. Because of which rke_support_matrix jenkins job also fails.
Hence updated the command (to use etcdctl v3) for k8s 1.22 clusters : `ETCDCTL_API=3 etcdctl endpoint health --cluster` and based on it's output changed the assert conditions as well.

- Verified the changes locally using these [steps](https://github.com/rancher/rancher/tree/release/v2.6/tests/validation/tests/rke) and the test case `pytest -k "test_install_config_1"` got passed. **Used RKE v1.3.4-rc1**
- **Note:** For k8s version 1.21 and less, `ETCDCTL_API=2` command will be executed and for higher version `ETCDCTL_API=3` would be executed.