### PR TITLE
Add roles and rolebindings when creating rke-machine-configs

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -47,7 +47,7 @@ ENV CATTLE_SYSTEM_UPGRADE_CONTROLLER_CHART_VERSION 100.0.1+up0.3.1
 
 # System charts minimal version
 ENV CATTLE_FLEET_MIN_VERSION=100.0.2+up0.3.8
-ENV CATTLE_RANCHER_WEBHOOK_MIN_VERSION=1.0.3+up0.2.4-rc3
+ENV CATTLE_RANCHER_WEBHOOK_MIN_VERSION=1.0.3+up0.2.4-rc4
 
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/library && \

--- a/pkg/controllers/management/authprovisioningv2/machineconfigs.go
+++ b/pkg/controllers/management/authprovisioningv2/machineconfigs.go
@@ -1,0 +1,79 @@
+package authprovisioningv2
+
+import (
+	"strings"
+
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/controllers/management/nodetemplate"
+	"github.com/rancher/rancher/pkg/controllers/management/rbac"
+	"github.com/rancher/wrangler/pkg/data"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func validMachineConfigGVK(gvk schema.GroupVersionKind) bool {
+	return gvk.Group == "rke-machine-config.cattle.io" &&
+		gvk.Version == "v1" &&
+		strings.HasSuffix(gvk.Kind, "Config")
+}
+
+func (h *handler) OnMachineConfigChange(obj runtime.Object) (runtime.Object, error) {
+	if obj == nil {
+		return nil, nil
+	}
+
+	objMeta, err := meta.Accessor(obj)
+	if err != nil || !objMeta.GetDeletionTimestamp().IsZero() {
+		return nil, err
+	}
+
+	// if owner bindings annotation is present, the node template is in the proper namespace and has had
+	// its creator rolebindings created
+	annotations := objMeta.GetAnnotations()
+	if annotations != nil && annotations[nodetemplate.OwnerBindingsAnno] == "true" {
+		return obj, nil
+	}
+
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	creatorID, ok := annotations[rbac.CreatorIDAnn]
+	if !ok {
+		// If the creatorID annotation is not present, then the roles and rolebindings cannot be created.
+		// We don't error here because there could be existing machine configs without this annotation.
+		return obj, nil
+	}
+
+	apiVersion, kind := gvk.ToAPIVersionAndKind()
+	resourceName := strings.ToLower(kind)
+	if strings.HasSuffix(resourceName, "config") {
+		resourceName += "s"
+	}
+	// Create Role and RBs if they do not exist
+	if err := rbac.CreateRoleAndRoleBinding(resourceName, kind, objMeta.GetName(), objMeta.GetNamespace(), apiVersion, creatorID, []string{gvk.Group},
+		objMeta.GetUID(),
+		[]v32.Member{}, h.mgmtCtx); err != nil {
+		return nil, err
+	}
+
+	dynamicMachineConfig, err := h.dynamic.Get(gvk, objMeta.GetNamespace(), objMeta.GetName())
+	if err != nil {
+		return nil, err
+	}
+
+	objData, err := data.Convert(dynamicMachineConfig.DeepCopyObject())
+	if err != nil {
+		return nil, err
+	}
+
+	anns := objData.Map("metadata", "annotations")
+	// owner bindings annotation is meant to prevent bindings from being created again if they have been removed from creator
+	anns[nodetemplate.OwnerBindingsAnno] = "true"
+	objData.SetNested(anns, "metadata", "annotations")
+
+	if _, err = h.dynamic.Update(&unstructured.Unstructured{Object: objData}); err != nil {
+		return nil, err
+	}
+
+	return h.dynamic.Get(gvk, objMeta.GetNamespace(), objMeta.GetName())
+}

--- a/pkg/controllers/management/nodetemplate/nodetemplate.go
+++ b/pkg/controllers/management/nodetemplate/nodetemplate.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	ownerBindingsAnno = "ownerBindingsCreated"
+	OwnerBindingsAnno = "ownerBindingsCreated"
 	vmwaredriver      = "vmwarevsphere"
 )
 
@@ -78,7 +78,7 @@ func (nt *nodeTemplateController) sync(key string, nodeTemplate *v3.NodeTemplate
 
 	// if owner bindings annotation is present, the node template is in the proper namespace and has had
 	// its creator rolebindings created
-	if nodeTemplate.Annotations != nil && nodeTemplate.Annotations[ownerBindingsAnno] == "true" {
+	if nodeTemplate.Annotations != nil && nodeTemplate.Annotations[OwnerBindingsAnno] == "true" {
 		return nodeTemplate, nil
 	}
 
@@ -115,7 +115,7 @@ func (nt *nodeTemplateController) sync(key string, nodeTemplate *v3.NodeTemplate
 
 	annotations := dynamicNodeTemplate.GetAnnotations()
 	// owner bindings annotation is meant to prevent bindings from being created again if they have been removed from creator
-	annotations[ownerBindingsAnno] = "true"
+	annotations[OwnerBindingsAnno] = "true"
 	dynamicNodeTemplate.SetAnnotations(annotations)
 
 	if _, err = nt.ntDynamicClient.Namespace(namespace.NodeTemplateGlobalNamespace).Update(context.TODO(), dynamicNodeTemplate, metav1.UpdateOptions{}); err != nil {

--- a/pkg/controllers/management/rbac/rbac.go
+++ b/pkg/controllers/management/rbac/rbac.go
@@ -234,7 +234,7 @@ func GetRoleNameAndVerbs(roleAccess string, resourceName string, resourceType st
 	case NodeTemplateResource:
 		resourceName += "-nt-"
 	default:
-		resourceName += "-" + resourceName + "-"
+		resourceName += "-" + resourceType + "-"
 	}
 	switch roleAccess {
 	case OwnerAccess:
@@ -288,7 +288,7 @@ func buildSubjectForMember(member v32.Member, managementContext *config.Manageme
 	}
 
 	if name == "*" {
-		//member.GroupPrincipalName = subjectWithAllUsers.Name
+		// member.GroupPrincipalName = subjectWithAllUsers.Name
 		return subjectWithAllUsers, nil
 	}
 

--- a/pkg/controllers/management/wrangler.go
+++ b/pkg/controllers/management/wrangler.go
@@ -28,7 +28,7 @@ func RegisterWrangler(ctx context.Context, wranglerContext *wrangler.Context, ma
 	clusterconnected.Register(ctx, wranglerContext)
 
 	if features.ProvisioningV2.Enabled() {
-		if err := authprovisioningv2.Register(ctx, wranglerContext); err != nil {
+		if err := authprovisioningv2.Register(ctx, wranglerContext, management); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Currently, if a standard user creates a rke-machine-config, they won't have
access to modify it until it is associated to a provisioning cluster that
the user owns. This creates issues in the UI when using the "Edit as YAML"
during cluster creation.

Now, roles and rolebindings will be added for rke-machine-configs when they are
created. This also requires changes to rancher-webhook (to add the creatorID).

Issue:
https://github.com/rancher/rancher/issues/35868