### PR TITLE
[Backport v2.5] Better handling of still running etcd backups

### DIFF
--- a/pkg/controllers/management/etcdbackup/etcdbackup.go
+++ b/pkg/controllers/management/etcdbackup/etcdbackup.go
@@ -173,6 +173,24 @@ func (c *Controller) doClusterBackupSync(cluster *v3.Cluster) error {
 		return nil
 	}
 
+	// check for backups in progress
+	if cluster.Spec.RancherKubernetesEngineConfig != nil {
+		clusterTimeout := time.Duration(cluster.Spec.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.Timeout) * time.Second
+		for _, clusterBackup := range clusterBackups {
+			backupCreationTime, err := getBackupCreatedTime(clusterBackup)
+			if err != nil {
+				logrus.Errorf("[etcd-backup] cluster [%s] backup [%s] is missing creation time: %v", cluster.Name, clusterBackup.Name, err)
+				continue
+			}
+			// cluster backup is younger than its timeout and completion is unknown
+			// therefore, it's currently running
+			if time.Since(backupCreationTime) < clusterTimeout && !rketypes.BackupConditionCompleted.IsTrue(clusterBackup) {
+				logrus.Debugf("[etcd-backup] cluster [%s] is currently creating a backup, skipping", cluster.Name)
+				return nil
+			}
+		}
+	}
+
 	newestBackup := clusterBackups[0]
 	for _, clusterBackup := range clusterBackups[1:] {
 		if getBackupCompletedTime(clusterBackup).After(getBackupCompletedTime(newestBackup)) {
@@ -464,6 +482,10 @@ func getBucketLookupType(endpoint string) minio.BucketLookupType {
 func getBackupCompletedTime(o runtime.Object) time.Time {
 	t, _ := time.Parse(time.RFC3339, rketypes.BackupConditionCompleted.GetLastUpdated(o))
 	return t
+}
+
+func getBackupCreatedTime(o runtime.Object) (time.Time, error) {
+	return time.Parse(time.RFC3339, rketypes.BackupConditionCreated.GetLastUpdated(o))
 }
 
 func getExpiredBackups(retention, intervalHours int, backups []*v3.EtcdBackup) []*v3.EtcdBackup {


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/35132
Issue: https://github.com/rancher/rancher/issues/36038

Original PR description:

TLDR: Adds a check for backups that are currently running.

If a user sets the backup timeout to 10 minutes due to a slow S3-alike or similar, the backup will still be running during the next tick of the check interval. The cluster backup sync function will see that the last completed backup was longer than the backup interval (ignoring the one that's currently running) so it'll start a new backup and bulldoze the running one.

My addition basically checks that if since a backup's creation time is less than the backup config's timeout and "completed" is unknown. Then skip until the next iteration.

#34890