### PR TITLE
Bump rke for fix where addon jobs are stuck in removing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20220107175045-b2d660c628d5
-	github.com/rancher/rke v1.3.3
+	github.com/rancher/rke v1.3.5-0.20220106161232-6efce927fbaf
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20220104194938-7fe97fb76fc6
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007

--- a/go.sum
+++ b/go.sum
@@ -1198,8 +1198,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8w
 github.com/rancher/remotedialer v0.2.6-0.20220104192242-f3837f8d649a/go.mod h1:vq3LvyOFnLcwMiCE1KdW3foPd6g5kAjZOtOb7JqGHck=
 github.com/rancher/remotedialer v0.2.6-0.20220107175045-b2d660c628d5 h1:tSAUzs2NaqdOx5ZzrPCkg72chM/LzqqEVLCOcYxMvUk=
 github.com/rancher/remotedialer v0.2.6-0.20220107175045-b2d660c628d5/go.mod h1:vq3LvyOFnLcwMiCE1KdW3foPd6g5kAjZOtOb7JqGHck=
-github.com/rancher/rke v1.3.3 h1:XZ3zQ1hhra4bO6a3Wep7hO+fUcDs7TBi1/FdBDEDqB4=
-github.com/rancher/rke v1.3.3/go.mod h1:4StVBXSN7EbrfoWE7nI2AAf/N1td8qSyQMDRyR6nGAg=
+github.com/rancher/rke v1.3.5-0.20220106161232-6efce927fbaf h1:fqParzrdncjI2zP27j8uy2nJDz8zid+ob5UmI6NSz+0=
+github.com/rancher/rke v1.3.5-0.20220106161232-6efce927fbaf/go.mod h1:4StVBXSN7EbrfoWE7nI2AAf/N1td8qSyQMDRyR6nGAg=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
 github.com/rancher/steve v0.0.0-20220104194938-7fe97fb76fc6 h1:D67VHSxKkfXd30O3338js/7XVqbRxFH3KryeEwPxG2E=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210918015053-5a141a6b18f0
 	github.com/rancher/gke-operator v1.1.2
 	github.com/rancher/norman v0.0.0-20211201154850-abe17976423e
-	github.com/rancher/rke v1.3.3
+	github.com/rancher/rke v1.3.5-0.20220106161232-6efce927fbaf
 	github.com/rancher/wrangler v0.8.10
 	github.com/sirupsen/logrus v1.8.1
 	k8s.io/api v0.22.3

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -705,8 +705,8 @@ github.com/rancher/machine v0.15.0-rancher63/go.mod h1:qXYNumxy0J08MO/mh/jNjyRuE
 github.com/rancher/norman v0.0.0-20200517050325-f53cae161640/go.mod h1:92rz/7QN7DOeLQZlJY/8aFBOmF085igIVguR0wpxLas=
 github.com/rancher/norman v0.0.0-20211201154850-abe17976423e h1:ozsbzsCJpKULwrTcqEDddL9aYy8Cdt5s6gAm6BZQKp4=
 github.com/rancher/norman v0.0.0-20211201154850-abe17976423e/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
-github.com/rancher/rke v1.3.3 h1:XZ3zQ1hhra4bO6a3Wep7hO+fUcDs7TBi1/FdBDEDqB4=
-github.com/rancher/rke v1.3.3/go.mod h1:4StVBXSN7EbrfoWE7nI2AAf/N1td8qSyQMDRyR6nGAg=
+github.com/rancher/rke v1.3.5-0.20220106161232-6efce927fbaf h1:fqParzrdncjI2zP27j8uy2nJDz8zid+ob5UmI6NSz+0=
+github.com/rancher/rke v1.3.5-0.20220106161232-6efce927fbaf/go.mod h1:4StVBXSN7EbrfoWE7nI2AAf/N1td8qSyQMDRyR6nGAg=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=


### PR DESCRIPTION
Related Issue: https://github.com/rancher/rancher/issues/35750

This PR bumps the version of rke to one that includes the fix for clusters reporting as active after an upgrade when removing old addons had failed. Now, a cluster will correctly transition to the `error` state.