### PR TITLE
[Backport v2.5] Bump rke for fix where addon jobs are stuck in removing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20220104192242-f3837f8d649a
-	github.com/rancher/rke v1.2.14
+	github.com/rancher/rke v1.2.17-0.20220106204151-1e040ec822da
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20220104222734-c69493b52ded
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20200825145542-a04e2061be24

--- a/go.sum
+++ b/go.sum
@@ -959,8 +959,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a h1:6xqYlVz4uAX
 github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8wJ/coee2n9ed937uPBWQArBaVlxs+5wkkS9KiyDc=
 github.com/rancher/remotedialer v0.2.6-0.20220104192242-f3837f8d649a h1:Go8MpBEeZCR0yV1ylu2/KjJBvpYomIezU58pejYCtgk=
 github.com/rancher/remotedialer v0.2.6-0.20220104192242-f3837f8d649a/go.mod h1:vq3LvyOFnLcwMiCE1KdW3foPd6g5kAjZOtOb7JqGHck=
-github.com/rancher/rke v1.2.14 h1:Deg1jIjHzQ2JH64ifElN8TxKaBh5LEVKE1gFJnlCZU4=
-github.com/rancher/rke v1.2.14/go.mod h1:osU/R8vPjgV3AwNnPamC0eOZ6aI0UfpHTyZ5K/b/vZE=
+github.com/rancher/rke v1.2.17-0.20220106204151-1e040ec822da h1:tTNnnXeeA512NzscMRQJhp8lc7M+4P0rN1mKtj3bSMg=
+github.com/rancher/rke v1.2.17-0.20220106204151-1e040ec822da/go.mod h1:osU/R8vPjgV3AwNnPamC0eOZ6aI0UfpHTyZ5K/b/vZE=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
 github.com/rancher/steve v0.0.0-20220104222734-c69493b52ded h1:XztN71ImwKIEKa0HIHqG8DPtWFLUQaIvXtch5msxlNA=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rancher/eks-operator v1.0.9
 	github.com/rancher/gke-operator v1.1.1
 	github.com/rancher/norman v0.0.0-20211029161036-d5e985ac5097
-	github.com/rancher/rke v1.2.14
+	github.com/rancher/rke v1.2.17-0.20220106204151-1e040ec822da
 	github.com/rancher/wrangler v0.7.3-0.20210331224822-5bd357588083
 	github.com/sirupsen/logrus v1.6.0
 	k8s.io/api v0.20.0

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -518,8 +518,8 @@ github.com/rancher/lasso v0.0.0-20200905045615-7fcb07d6a20b/go.mod h1:OhBBBO1pBw
 github.com/rancher/norman v0.0.0-20200517050325-f53cae161640/go.mod h1:92rz/7QN7DOeLQZlJY/8aFBOmF085igIVguR0wpxLas=
 github.com/rancher/norman v0.0.0-20211029161036-d5e985ac5097 h1:6lSt5IH/wBRLqRxDkiqJA43VLHWozIfN8M0VYs8fhjk=
 github.com/rancher/norman v0.0.0-20211029161036-d5e985ac5097/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
-github.com/rancher/rke v1.2.14 h1:Deg1jIjHzQ2JH64ifElN8TxKaBh5LEVKE1gFJnlCZU4=
-github.com/rancher/rke v1.2.14/go.mod h1:osU/R8vPjgV3AwNnPamC0eOZ6aI0UfpHTyZ5K/b/vZE=
+github.com/rancher/rke v1.2.17-0.20220106204151-1e040ec822da h1:tTNnnXeeA512NzscMRQJhp8lc7M+4P0rN1mKtj3bSMg=
+github.com/rancher/rke v1.2.17-0.20220106204151-1e040ec822da/go.mod h1:osU/R8vPjgV3AwNnPamC0eOZ6aI0UfpHTyZ5K/b/vZE=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=


### PR DESCRIPTION
Backport of #36076 
---
Related Issue: https://github.com/rancher/rancher/issues/36037

This PR bumps the version of rke to one that includes the fix for clusters reporting as active after an upgrade when removing old addons had failed. Now, a cluster will correctly transition to the error state.