### PR TITLE
Go Automation: Harvester provisioning

### DIFF
--- a/tests/framework/extensions/cloudcredentials/cloudcredentials.go
+++ b/tests/framework/extensions/cloudcredentials/cloudcredentials.go
@@ -15,5 +15,6 @@ type CloudCredential struct {
 	Removed                      string                        `json:"removed,omitempty"`
 	AmazonEC2CredentialConfig    *AmazonEC2CredentialConfig    `json:"amazonec2credentialConfig,omitempty"`
 	DigitalOceanCredentialConfig *DigitalOceanCredentialConfig `json:"digitaloceancredentialConfig,omitempty"`
+	HarvesterCredentialConfig    *HarvesterCredentialConfig    `json:"harvestercredentialConfig,omitempty"`
 	UUID                         string                        `json:"uuid,omitempty"`
 }

--- a/tests/framework/extensions/cloudcredentials/harvester/create.go
+++ b/tests/framework/extensions/cloudcredentials/harvester/create.go
@@ -1,0 +1,29 @@
+package harvester
+
+import (
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+)
+
+const harvesterCloudCredNameBase = "harvesterCloudCredential"
+
+// CreateHarvesterCloudCredentials is a helper function that takes the rancher Client as a prameter and creates
+// a harvester cloud credential, and returns the CloudCredential response
+func CreateHarvesterCloudCredentials(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error) {
+	var harvesterCredentialConfig cloudcredentials.HarvesterCredentialConfig
+	config.LoadConfig(cloudcredentials.HarvesterCredentialConfigurationFileKey, &harvesterCredentialConfig)
+
+	cloudCredential := cloudcredentials.CloudCredential{
+		Name:                      harvesterCloudCredNameBase,
+		HarvesterCredentialConfig: &harvesterCredentialConfig,
+	}
+
+	resp := &cloudcredentials.CloudCredential{}
+	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.CloudCredentialType, cloudCredential, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/tests/framework/extensions/cloudcredentials/harvester_config.go
+++ b/tests/framework/extensions/cloudcredentials/harvester_config.go
@@ -1,0 +1,9 @@
+package cloudcredentials
+
+const HarvesterCredentialConfigurationFileKey = "harvesterCredentials"
+
+type HarvesterCredentialConfig struct {
+	ClusterId         string `json:"clusterId" yaml:"clusterId"`
+	ClusterType       string `json:"clusterType" yaml:"clusterType"`
+	KubeconfigContent string `json:"kubeconfigContent" yaml:"kubeconfigContent"`
+}

--- a/tests/framework/extensions/machinepools/harvester_machine_config.go
+++ b/tests/framework/extensions/machinepools/harvester_machine_config.go
@@ -1,0 +1,48 @@
+package machinepools
+
+import (
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	HarvesterKind                              = "HarvesterConfig"
+	HarvesterPoolType                          = "rke-machine-config.cattle.io.harvesterconfig"
+	HarvesterResourceConfig                    = "harvesterconfigs"
+	HarvesterMachingConfigConfigurationFileKey = "harvesterMachineConfig"
+)
+
+type HarvesterMachineConfig struct {
+	DiskSize    string `json:"diskSize" yaml:"diskSize"`
+	CPUCount    string `json:"cpuCount" yaml:"cpuCount"`
+	MemorySize  string `json:"memorySize" yaml:"memorySize"`
+	NetworkName string `json:"networkName" yaml:"networkName"`
+	ImageName   string `json:"imageName" yaml:"imageName"`
+	VMNamespace string `json:"vmNamespace" yaml:"vmNamespace"`
+	DiskBus     string `json:"diskBus" yaml:"diskBus"`
+	SSHUser     string `json:"sshUser" yaml:"sshUser"`
+}
+
+// NewHarvesterMachineConfig is a constructor to set up rke-machine-config.cattle.io.harvesterconfig.
+// It returns an *unstructured.Unstructured that CreateMachineConfig uses to created the rke-machine-config
+func NewHarvesterMachineConfig(generatedPoolName, namespace string) *unstructured.Unstructured {
+	var harvesterMachineConfig HarvesterMachineConfig
+	config.LoadConfig(HarvesterMachingConfigConfigurationFileKey, &harvesterMachineConfig)
+	machineConfig := &unstructured.Unstructured{}
+
+	machineConfig.SetAPIVersion("rke-machine-config.cattle.io/v1")
+	machineConfig.SetKind(HarvesterKind)
+	machineConfig.SetGenerateName(generatedPoolName)
+	machineConfig.SetNamespace(namespace)
+
+	machineConfig.Object["diskSize"] = harvesterMachineConfig.DiskSize
+	machineConfig.Object["diskBus"] = harvesterMachineConfig.DiskBus
+	machineConfig.Object["cpuCount"] = harvesterMachineConfig.CPUCount
+	machineConfig.Object["memorySize"] = harvesterMachineConfig.MemorySize
+	machineConfig.Object["networkName"] = harvesterMachineConfig.NetworkName
+	machineConfig.Object["imageName"] = harvesterMachineConfig.ImageName
+	machineConfig.Object["vmNamespace"] = harvesterMachineConfig.VMNamespace
+	machineConfig.Object["sshUser"] = harvesterMachineConfig.SSHUser
+
+	return machineConfig
+}


### PR DESCRIPTION
adding harvester node driver and dependencies

New Yaml options:
```
//below are some of the default values used. values with <> should be pulled from your setup
harvesterCredentials:
     clusterId: <>
     clusterType: "imported"
     kubeconfigContent: <>
harvesterMachineConfig:
  diskSize: "40"
  cpuCount: "2"
  memorySize: "8"
  networkName: <>
  imageName: <>
  vmNamespace: "default"
  sshUser: "ubuntu"
  diskBus: "virtio"
```

this was tested using a harvester setup for 1, 3 node all roles, and 3 node dedicated roles clusters. 