### PR TITLE
Support checking rancher-version constraints against Rancher prereleases

### DIFF
--- a/pkg/catalogv2/content/content.go
+++ b/pkg/catalogv2/content/content.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
@@ -178,13 +179,31 @@ func (c *Manager) filterReleases(index *repo.IndexFile, k8sVersion *semver.Versi
 		logrus.Errorf("failed to parse server version %s: %v", settings.ServerVersion.Get(), err)
 		return index
 	}
+	rancherVersionWithoutPrerelease, err := rancherVersion.SetPrerelease("")
+	if err != nil {
+		logrus.Errorf("failed to remove prerelease from %s: %v", settings.ServerVersion.Get(), err)
+		return index
+	}
 
 	for rel, versions := range index.Entries {
 		newVersions := make([]*repo.ChartVersion, 0, len(versions))
 		for _, version := range versions {
 			if constraintStr, ok := version.Annotations["catalog.cattle.io/rancher-version"]; ok {
 				if constraint, err := semver.NewConstraint(constraintStr); err == nil {
-					if !constraint.Check(rancherVersion) {
+					satisfiesConstraint, errs := constraint.Validate(rancherVersion)
+					// Check if the reason for failure is because it is ignroing prereleases
+					constraintDoesNotMatchPrereleases := false
+					for _, err := range errs {
+						// Comes from error in https://github.com/Masterminds/semver/blob/60c7ae8a99210a90a9457d5de5f6dcbc4dab8e64/constraints.go#L93
+						if strings.Contains(err.Error(), "the constraint is only looking for release versions") {
+							constraintDoesNotMatchPrereleases = true
+							break
+						}
+					}
+					if constraintDoesNotMatchPrereleases {
+						satisfiesConstraint = constraint.Check(&rancherVersionWithoutPrerelease)
+					}
+					if !satisfiesConstraint {
 						continue
 					}
 				} else {

--- a/pkg/catalogv2/content/content_test.go
+++ b/pkg/catalogv2/content/content_test.go
@@ -21,7 +21,7 @@ func TestFilterReleases(t *testing.T) {
 		{
 			"rancher version in range comparison with `>= <`style comparison",
 			">= 2.5.0-alpha3 <2.6.0",
-			"v2.5.0+123", //SemVer comparisons using constraints without a prerelease comparator will skip prerelease versions
+			"v2.5.0+123",
 			true,
 		},
 		{
@@ -91,16 +91,22 @@ func TestFilterReleases(t *testing.T) {
 			false,
 		},
 		{
+			"rancher prerelease version in range comparison with `>= <`style comparison",
+			">= 2.5.0-alpha3 <2.6.0-0",
+			"v2.5.0-alpha4", //SemVer comparisons using constraints with prerelease will be evaluated using an ASCII sort order, per the spec
+			true,
+		},
+		{
 			"rancher version out of range comparison with `> <`style comparison",
 			">2.5.0 <2.6.0",
-			"v2.5.3-alpha3", //SemVer comparisons using constraints without a prerelease comparator will skip prerelease versions
-			false,
+			"v2.5.3-alpha3",
+			true,
 		},
 		{
 			"rancher version out of range comparison with `> <=`style comparison",
 			"> 2.5.0-alpha <=2.6.0",
-			"v2.5.1-alpha", //SemVer comparisons using constraints without a prerelease comparator will skip prerelease versions
-			false,
+			"v2.5.1-alpha",
+			true,
 		},
 		{
 			"rancher version out of range comparison with `>= <=`style comparison",
@@ -129,7 +135,7 @@ func TestFilterReleases(t *testing.T) {
 		{
 			"rancher version out of range comparison with `>=` style comparison",
 			">= 2.4.3",
-			"v2.4.2-alpha1", //SemVer comparisons using constraints without a prerelease comparator will skip prerelease versions
+			"v2.4.2-alpha1",
 			false,
 		},
 		{


### PR DESCRIPTION
The package used to make semver comparisions for catalog v2, e.g. https://github.com/Masterminds/semver, has a known constraint when it comes to working with prerelease versions, as described in https://github.com/Masterminds/semver#working-with-prerelease-versions:

```
SemVer comparisons using constraints without a prerelease comparator will skip prerelease versions. 
```

As a result, if the `catalog.cattle.io/rancher-version` is set to something like `< v2.6.3`, something like `v2.5.9-rcXX` will automatically fail due to the fact that it has a pre-release identifier attached to it (namely `-rcXX`).

Therefore, the fix put forward in this PR first checks to see if the Rancher version is valid for the given constraint; if the output of the validation indicates that it is invalid because the constraint does not match against pre-release versions, it will try to validate against a version with the pre-release omitted.

Related Issue: https://github.com/rancher/rancher/issues/36120