### PR TITLE
[2.5] fix issue with 2004SAC missing from manifest

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -410,7 +410,7 @@ steps:
     pull: always
     image: rancher/dapper:v0.5.4
     commands:
-      - dapper.exe -f Dockerfile-windows.dapper -d ci
+      - dapper.exe -f Dockerfile-windows-1809.dapper -d ci
     volumes:
       - name: docker_pipe
         path: \\\\.\\pipe\\docker_engine
@@ -529,7 +529,7 @@ steps:
     pull: always
     image: rancher/dapper:v0.5.4
     commands:
-      - dapper.exe -f Dockerfile-windows.dapper -d ci
+      - dapper.exe -f Dockerfile-windows-2004.dapper -d ci
     volumes:
       - name: docker_pipe
         path: \\\\.\\pipe\\docker_engine
@@ -647,7 +647,7 @@ steps:
     pull: always
     image: rancher/dapper:v0.5.4
     commands:
-      - dapper.exe -f Dockerfile-windows.dapper -d ci
+      - dapper.exe -f Dockerfile-windows-20H2.dapper -d ci
     volumes:
       - name: docker_pipe
         path: \\\\.\\pipe\\docker_engine

--- a/Dockerfile-windows-1809.dapper
+++ b/Dockerfile-windows-1809.dapper
@@ -1,4 +1,4 @@
-FROM rancher/golang:1.14-windowsservercore
+FROM rancher/golang:1.14-windowsservercore-1809
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG DAPPER_HOST_ARCH

--- a/Dockerfile-windows-2004.dapper
+++ b/Dockerfile-windows-2004.dapper
@@ -1,0 +1,62 @@
+FROM rancher/golang:1.14-windowsservercore-2004
+SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ARG DAPPER_HOST_ARCH
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
+
+RUN pushd c:\; \
+    $URL = 'https://github.com/StefanScherer/docker-cli-builder/releases/download/18.09.6/docker.exe'; \
+    \
+    Write-Host ('Downloading docker from {0} ...' -f $URL); \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\Windows\docker.exe -Uri $URL; \
+    \
+    Write-Host 'Complete.'; \
+    popd;
+
+RUN pushd c:\; \
+    $URL = 'https://github.com/golangci/golangci-lint/releases/download/v1.16.0/golangci-lint-1.16.0-windows-amd64.zip'; \
+    \
+    Write-Host ('Downloading golangci from {0} ...' -f $URL); \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\golangci-lint.zip -Uri $URL; \
+    \
+    Write-Host 'Expanding ...'; \
+    Expand-Archive -Path c:\golangci-lint.zip -DestinationPath c:\; \
+    \
+    Write-Host 'Cleaning ...'; \
+    Remove-Item -Force -Recurse -Path c:\golangci-lint.zip; \
+    \
+    Write-Host 'Updating PATH ...'; \
+    [Environment]::SetEnvironmentVariable('PATH', ('c:\golangci-lint-1.16.0-windows-amd64\;{0}' -f $env:PATH), [EnvironmentVariableTarget]::Machine); \
+    \
+    Write-Host 'Complete.'; \
+    popd;
+
+# upgrade git
+RUN pushd c:\; \
+    $URL = 'https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip'; \
+    \
+    Write-Host ('Downloading git from {0} ...' -f $URL); \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\git.zip -Uri $URL; \
+    \
+    Write-Host 'Expanding ...'; \
+    Expand-Archive -Force -Path c:\git.zip -DestinationPath c:\git\.; \
+    \
+    Write-Host 'Cleaning ...'; \
+    Remove-Item -Force -Recurse -Path c:\git.zip; \
+    \
+    Write-Host 'Complete.'; \
+    popd;
+
+ENV DAPPER_ENV REPO TAG DRONE_TAG
+ENV DAPPER_SOURCE /gopath/src/github.com/rancher/rancher
+ENV DAPPER_OUTPUT ./bin
+ENV DAPPER_DOCKER_SOCKET true
+ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
+ENV HOME ${DAPPER_SOURCE}
+
+WORKDIR ${DAPPER_SOURCE}
+ENTRYPOINT ["powershell", "-NoLogo", "-NonInteractive", "-File", "./scripts/windows/entry.ps1"]
+CMD ["ci"]

--- a/Dockerfile-windows-20H2.dapper
+++ b/Dockerfile-windows-20H2.dapper
@@ -1,0 +1,62 @@
+FROM rancher/golang:1.14-windowsservercore-20H2
+SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ARG DAPPER_HOST_ARCH
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
+
+RUN pushd c:\; \
+    $URL = 'https://github.com/StefanScherer/docker-cli-builder/releases/download/18.09.6/docker.exe'; \
+    \
+    Write-Host ('Downloading docker from {0} ...' -f $URL); \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\Windows\docker.exe -Uri $URL; \
+    \
+    Write-Host 'Complete.'; \
+    popd;
+
+RUN pushd c:\; \
+    $URL = 'https://github.com/golangci/golangci-lint/releases/download/v1.16.0/golangci-lint-1.16.0-windows-amd64.zip'; \
+    \
+    Write-Host ('Downloading golangci from {0} ...' -f $URL); \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\golangci-lint.zip -Uri $URL; \
+    \
+    Write-Host 'Expanding ...'; \
+    Expand-Archive -Path c:\golangci-lint.zip -DestinationPath c:\; \
+    \
+    Write-Host 'Cleaning ...'; \
+    Remove-Item -Force -Recurse -Path c:\golangci-lint.zip; \
+    \
+    Write-Host 'Updating PATH ...'; \
+    [Environment]::SetEnvironmentVariable('PATH', ('c:\golangci-lint-1.16.0-windows-amd64\;{0}' -f $env:PATH), [EnvironmentVariableTarget]::Machine); \
+    \
+    Write-Host 'Complete.'; \
+    popd;
+
+# upgrade git
+RUN pushd c:\; \
+    $URL = 'https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip'; \
+    \
+    Write-Host ('Downloading git from {0} ...' -f $URL); \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\git.zip -Uri $URL; \
+    \
+    Write-Host 'Expanding ...'; \
+    Expand-Archive -Force -Path c:\git.zip -DestinationPath c:\git\.; \
+    \
+    Write-Host 'Cleaning ...'; \
+    Remove-Item -Force -Recurse -Path c:\git.zip; \
+    \
+    Write-Host 'Complete.'; \
+    popd;
+
+ENV DAPPER_ENV REPO TAG DRONE_TAG
+ENV DAPPER_SOURCE /gopath/src/github.com/rancher/rancher
+ENV DAPPER_OUTPUT ./bin
+ENV DAPPER_DOCKER_SOCKET true
+ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
+ENV HOME ${DAPPER_SOURCE}
+
+WORKDIR ${DAPPER_SOURCE}
+ENTRYPOINT ["powershell", "-NoLogo", "-NonInteractive", "-File", "./scripts/windows/entry.ps1"]
+CMD ["ci"]


### PR DESCRIPTION
Switch from pointing to the manifest for each Windows dapperfile `rancher/golang:1.14-windowsservercore` to the specific build version image `rancher/golang:1.14-windowsservercore-2004` as the manifest only has the 1809 and 20H2 versions.

Dapper cannot consume build-args when being run directly without a build step, which is how we are currently using it. This caused us to need to make a Dapper file for each Windows build version.

This unblocks 2.5.12 drone issues that keep popping up.


```
docker manifest inspect rancher/golang:1.14-windowsservercore
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 4233,
         "digest": "sha256:04be1ec81c0b0fad82a0d31338cb1416665e71ef70b78b1918c7f087e039ea0e",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.2300"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 4234,
         "digest": "sha256:c9be10a0faeea727bd73d935e8dfb2b323df4d373585254995a05a46fc5b64ee",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.19042.1348"
         }
      }
   ]
}
```