### PR TITLE
Ignore deleting clusters in project_cluster_handler

### DIFF
--- a/pkg/controllers/management/auth/project_cluster_handler.go
+++ b/pkg/controllers/management/auth/project_cluster_handler.go
@@ -167,8 +167,8 @@ type clusterLifecycle struct {
 }
 
 func (l *clusterLifecycle) sync(key string, orig *v3.Cluster) (runtime.Object, error) {
-	if orig == nil {
-		return nil, nil
+	if orig == nil || !orig.DeletionTimestamp.IsZero() {
+		return orig, nil
 	}
 
 	obj := orig.DeepCopyObject()


### PR DESCRIPTION
If a cluster gets deleted, then we don't want to create namespaces and projects
for the cluster. Now, the sync handler will ignore deleting clusters to ensure
this won't happen.

Issue:
https://github.com/rancher/rancher/issues/31546