### PR TITLE
[release/v2.5] Only show -rc components/images in components file

### DIFF
--- a/scripts/create-components-file.sh
+++ b/scripts/create-components-file.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This script will create a txt file which will be used to print components versions on tag
+# This script will create a txt file with -rc images/components which will be used as (pre) release description by Drone
 set -e -x
 
 echo "Creating ./bin/rancher-components.txt"
@@ -10,15 +10,14 @@ mkdir -p bin
 
 COMPONENTSFILE=./bin/rancher-components.txt
 
-echo "# Components" > $COMPONENTSFILE
+echo "# Images with -rc" > $COMPONENTSFILE
 
-printf '%s\n' "$(grep "_VERSION" ./package/Dockerfile | grep ENV | egrep -v "http|\\$" | grep CATTLE |sed 's/CATTLE_//g' | sed 's/=/ /g' | grep UI | awk '{ print $2,$3 }')" >> $COMPONENTSFILE
+printf '%s\n' "$(grep -h "\-rc" ./bin/rancher-images.txt ./bin/rancher-windows-images.txt | awk -F: '{ print $1,$2 }')" >> $COMPONENTSFILE
 
-printf '%s\n' "$(grep "rancher/" ./go.mod | egrep -v "\./"  | egrep "rke|machine" | sort -r |  awk -F'/' '{ print $NF }' | awk '$1 = toupper($1)')" >> $COMPONENTSFILE
+echo "# Components with -rc" >> $COMPONENTSFILE
 
-printf '%s\n' "$(grep "_VERSION" ./package/Dockerfile | grep ENV | egrep -v "http|\\$" | grep CATTLE |sed 's/CATTLE_//g' | sed 's/=/ /g' | grep -v UI | awk '{ print $2,$3 }' | sort)" >> $COMPONENTSFILE
+printf '%s\n' "$(grep "_VERSION" ./package/Dockerfile | grep ENV | egrep -v "http|\\$" | grep CATTLE |sed 's/CATTLE_//g' | sed 's/=/ /g' |  awk '{ print $2,$3 }' | sort | grep "\-rc")" >> $COMPONENTSFILE
 
-printf '%s\n' "$(grep "rancher/" ./go.mod | egrep -v "\./"  | egrep -v "rke|machine|\/pkg\/apis|\/pkg\/client|^module" | grep -v "=>" | awk -F'/' '{ print $NF }' | awk '$1 = toupper($1)' | sort)" >> $COMPONENTSFILE
-
+printf '%s\n' "$(grep "rancher/" ./go.mod | egrep -v "\./"  | egrep -v "\/pkg\/apis|\/pkg\/client|^module" | grep -v "=>" | awk -F'/' '{ print $NF }' | awk '$1 = toupper($1)' | sort | grep "\-rc")" >> $COMPONENTSFILE
 
 echo "Done creating ./bin/rancher-components.txt"

--- a/scripts/package
+++ b/scripts/package
@@ -3,8 +3,6 @@ set -e
 
 ./k3s-images.sh
 
-./create-components-file.sh
-
 source $(dirname $0)/version
 
 ARCH=${ARCH:-"amd64"}
@@ -75,3 +73,5 @@ if [ ${ARCH} == amd64 ]; then
     cp -vf rancherd build/rancherd/bundle/bin
     tar czf rancherd-${ARCH}.tar.gz -C build/rancherd/bundle .
 fi
+
+../scripts/create-components-file.sh


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/36033

Test run:
```
# cat bin/rancher-components.txt 
# Images with -rc
rancher/backup-restore-operator v1.2.1-rc1
rancher/rancher-webhook v0.1.3-rc1
# Components with -rc
DASHBOARD_UI_VERSION v2.5.12-rc2
RANCHER_WEBHOOK_MIN_VERSION 0.1.300-rc1
UI_VERSION 2.5.12-rc2
```