### PR TITLE
fixed concurrency limit being ignored on upgrade

### DIFF
--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -552,11 +552,11 @@ func (p *Planner) reconcile(controlPlane *rkev1.RKEControlPlane, secret plan.Sec
 		} else if !equality.Semantic.DeepEqual(entry.Plan.Plan, plan) {
 			outOfSync = append(outOfSync, entry.Machine.Name)
 			// Conditions
-			// 1. If plan is not in sync then there is no harm in updating it to something else because
-			//    the node will have already been considered unavailable.
+			// 1. If the node is already draining then the plan is out of sync.  There is no harm in updating it if
+			// the node is currently drained.
 			// 2. concurrency == 0 which means infinite concurrency.
 			// 3. unavailable < concurrency meaning we have capacity to make something unavailable
-			if isUnavailable(entry) || concurrency == 0 || unavailable < concurrency {
+			if isInDrain(entry.Machine) || concurrency == 0 || unavailable < concurrency {
 				if !isUnavailable(entry) {
 					unavailable++
 				}


### PR DESCRIPTION
#35999 

# Problem
When pre-drain hooks are configured rancher will ignore any concurrency limits set on node upgrade.  

# Solution
The planner was considering machines with stale plans to be unavailable and triggering a drain on them.  The node hooks cause the machine drain controller to send more updates than it would on machine without.  I think this was causing the events to be pushed to the controller with stale plans causing the nodes to be drained even when the concurrency limit had been reached.   Instead the planner checks if the node is explicitly being drained before updating it.   I don't think this problem was unique to clusters with pre drain hooks but I think the hooks caused enough churn to cause this issue reliably. 

# Testing

- single node cluster
- 3 controlplane
- 5 controlplane
- 3 worker

For all these cases I set a concurrency limit of 1 and did not observer the limit exceeded after applying my changes.