### PR TITLE
Run rancher more reliably during testing

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -4,10 +4,14 @@ set -e
 cleanup()
 {
     EXIT=$?
-    set +e
+    set +ex
     echo Stopping rancher server
-    kill $PID
-    wait $PID
+    kill $RANCHER_RUN_PID
+    wait $RANCHER_RUN_PID
+    if [ $PID != -1 ]; then
+      kill $PID
+      wait $PID
+    fi
     return $EXIT
 }
 
@@ -20,20 +24,29 @@ if [ ${ARCH} == arm64 ]; then
     export ETCD_UNSUPPORTED_ARCH=arm64
 fi
 
-echo Starting rancher server
+echo Starting rancher server for test
 touch /tmp/rancher.log
-./scripts/run >/tmp/rancher.log 2>&1 &
-PID=$!
-trap cleanup exit
 
-keepalive()
+run_rancher()
 {
     while sleep 2; do
-        if [ ! -e /proc/$PID ]; then
+        if [ "$PID" != "-1" ] && [ ! -e /proc/$PID ]; then
             echo Rancher died
-            cat /tmp/rancher.log
-            ./scripts/run >/tmp/rancher.log 2>&1 &
-            PID=$!
+            echo Rancher logs were
+            tail -n 25 /tmp/rancher.log
+            echo K3s logs were:
+            tail -n 25 build/testdata/k3s.log
+            if [ "$INT_TESTS_STARTED" = "true" ]; then
+              echo Rancher died after tests started, aborting
+              exit 1
+            fi
+            PID=-1
+            sleep 5
+        fi
+        if [ "$PID" = "-1" ]; then
+          echo Starting rancher server using run
+          ./scripts/run >/tmp/rancher.log 2>&1 &
+          PID=$!
         fi
         sleep 2
     done
@@ -43,8 +56,13 @@ keepalive()
 # much
 #tail -F /tmp/rancher.log &
 #TPID=$!
+PID=-1
+run_rancher &
+RANCHER_RUN_PID=$!
+trap cleanup exit
 
-keepalive &
+echo Sleeping for 5 seconds before checking Rancher health
+sleep 5
 
 while ! curl -sf http://localhost:8080/ping; do
     sleep 2
@@ -55,7 +73,7 @@ done
 #kill $TPID
 
 echo Running tests
-
+INT_TESTS_STARTED=true
 cd ./tests/integration
 tox -e rancher -- -m "not nonparallel" -n $(nproc)
 tox -e rancher -- -m nonparallel


### PR DESCRIPTION
On CI runs, K3s was continuously failing with a `time="2022-01-13T22:57:27.410144766Z" level=fatal msg="starting kubernetes: preparing server: init cluster datastore and https: listen tcp :6443: bind: address already in use"`
or something similar. 

In my debugging of this, I have a theory that the `keepalive` loop monitoring Rancher health is not being terminated and is causing problems. Even on a graceful cleanup of Rancher, the keepalive loop is attempting to start a new Rancher, which is then providing conflicting (and unmanaged) rancher instances. 

This PR changes the method of running Rancher for testing.