### PR TITLE
Kill all child processes that are owned by k3s if Rancher fails

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -40,6 +40,10 @@ run_rancher()
               echo Rancher died after tests started, aborting
               exit 1
             fi
+            set +e
+            echo Attempting to kill K3s
+            pkill -e k3s
+            set -e
             PID=-1
             sleep 5
         fi


### PR DESCRIPTION
Continuation of https://github.com/rancher/rancher/pull/36143

As a continuation of my conquest to fix the flaky testing in Rancher, I discovered that there is a condition in which Rancher can die (concurrent map read write on rancher startup and `panic: indexer conflict: map[byPod:{}]`, I'm looking at you)

When this happens, the K3s processes that are started under the parent Rancher process are NOT cleaned up/killed, and instead, the K3s processes get inherited by PID 1. This is not good, and is why when subsequent attempts to start rancher end up with the `bind address already in use` message.

This PR adds functionality to properly clean up the K3s processes if Rancher fails.

Realistically, this should probably be fixed properly in norman, but for now, this bandaid will have to do to make CI more reliable.

Line ~1924 and further in this run show what can happen: https://drone-pr.rancher.io/rancher/rancher/20345/4/2