### PR TITLE
Update version of flask

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -2,7 +2,7 @@ git+https://github.com/rancher/client-python.git@1ecfc3e6a300f5f336da4e4416c46c5
 websocket-client==0.56.0
 PyJWT==1.7.1
 
-flask==1.1.1
+flask==2.0.2
 pytest==4.4.1
 pytest-repeat==0.8.0
 pytest-xdist==1.28.0


### PR DESCRIPTION
### Issue
Deprecation warnings are showing up due to version of flask

```
/go/src/github.com/rancher/rancher/tests/integration/.tox/rancher/lib/python3.8/site-packages/flask/json/__init__.py:31
  /go/src/github.com/rancher/rancher/tests/integration/.tox/rancher/lib/python3.8/site-packages/flask/json/__init__.py:31: DeprecationWarning: Importing 'itsdangerous.json' is deprecated and will be removed in ItsDangerous 2.1. Use Python's 'json' module instead.
    _slash_escape = "\\/" not in _json.dumps("/")
```
### Solution
Update version of flask from 1.1.1 to 2.0.2
