### PR TITLE
add the permission for creating PSP to support uninstalling the rancher-webhook app in hardened cluster

### DIFF
--- a/chart/templates/post-delete-hook-cluster-role.yaml
+++ b/chart/templates/post-delete-hook-cluster-role.yaml
@@ -32,7 +32,7 @@ rules:
     verbs: [ "get", "list", "delete" ]
   - apiGroups: [ "policy" ]
     resources: [ "podsecuritypolicies" ]
-    verbs: [ "use", "delete" ]
+    verbs: [ "use", "delete", "create" ]
   - apiGroups: [ "networking.k8s.io" ]
     resources: [ "ingresses" ]
     verbs: [ "delete" ]


### PR DESCRIPTION
Backports https://github.com/rancher/rancher/pull/34286

Related Issue: https://github.com/rancher/rancher/issues/33724

(cherry picked from commit 6a529225f0b3d9e3d51d7714e7aea026f01d80c0)