### PR TITLE
Rancher Helm Chart: also add traefik annotations

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
 {{- if eq .Values.tls "external" }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false" # turn off ssl redirect for external.
+    traefik.ingress.kubernetes.io/router.tls: "false" # turn off ssl redirect for external.
 {{- else }}
   {{- if ne .Values.ingress.tls.source "secret" }}
     {{- $certmanagerVer :=  split "." .Values.certmanager.version -}}
@@ -26,6 +27,8 @@ metadata:
     cert-manager.io/issuer-kind: Issuer
     {{- end }}
   {{- end }}
+    traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+    traefik.ingress.kubernetes.io/router.tls: "true"
 {{- end }}
 {{- if .Values.ingress.includeDefaultExtraAnnotations }}
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"

--- a/chart/tests/ingress_test.yaml
+++ b/chart/tests/ingress_test.yaml
@@ -20,6 +20,8 @@ tests:
       value:
         cert-manager.io/issuer: RELEASE-NAME-rancher
         cert-manager.io/issuer-kind: Issuer
+        traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+        traefik.ingress.kubernetes.io/router.tls: "true"
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
@@ -32,6 +34,8 @@ tests:
       path: metadata.annotations
       value:
         certmanager.k8s.io/issuer: RELEASE-NAME-rancher
+        traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+        traefik.ingress.kubernetes.io/router.tls: "true"
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
@@ -43,6 +47,8 @@ tests:
       path: metadata.annotations
       value:
         certmanager.k8s.io/issuer: RELEASE-NAME-rancher
+        traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+        traefik.ingress.kubernetes.io/router.tls: "true"
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
@@ -55,6 +61,8 @@ tests:
       value:
         cert-manager.io/issuer: RELEASE-NAME-rancher
         cert-manager.io/issuer-kind: Issuer
+        traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+        traefik.ingress.kubernetes.io/router.tls: "true"
 - it: should over write proxy-connect-timeout with default cert-manager
   set:
     ingress.extraAnnotations:
@@ -65,6 +73,8 @@ tests:
       value:
         cert-manager.io/issuer: RELEASE-NAME-rancher
         cert-manager.io/issuer-kind: Issuer
+        traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+        traefik.ingress.kubernetes.io/router.tls: "true"
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
@@ -80,6 +90,8 @@ tests:
       path: metadata.annotations
       value:
         certmanager.k8s.io/issuer: RELEASE-NAME-rancher
+        traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+        traefik.ingress.kubernetes.io/router.tls: "true"
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
@@ -93,6 +105,8 @@ tests:
       path: metadata.annotations
       value:
         certmanager.k8s.io/issuer: RELEASE-NAME-rancher
+        traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+        traefik.ingress.kubernetes.io/router.tls: "true"
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
@@ -121,6 +135,8 @@ tests:
       value:
         cert-manager.io/issuer: RELEASE-NAME-rancher
         cert-manager.io/issuer-kind: Issuer
+        traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+        traefik.ingress.kubernetes.io/router.tls: "true"
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
@@ -140,6 +156,8 @@ tests:
       path: metadata.annotations
       value:
         certmanager.k8s.io/issuer: RELEASE-NAME-rancher
+        traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+        traefik.ingress.kubernetes.io/router.tls: "true"
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
@@ -157,6 +175,8 @@ tests:
       path: metadata.annotations
       value:
         certmanager.k8s.io/issuer: RELEASE-NAME-rancher
+        traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+        traefik.ingress.kubernetes.io/router.tls: "true"
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
@@ -175,6 +195,8 @@ tests:
       value:
         cert-manager.io/issuer: RELEASE-NAME-rancher
         cert-manager.io/issuer-kind: Issuer
+        traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+        traefik.ingress.kubernetes.io/router.tls: "true"
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
@@ -196,6 +218,8 @@ tests:
       path: metadata.annotations
       value:
         certmanager.k8s.io/issuer: RELEASE-NAME-rancher
+        traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+        traefik.ingress.kubernetes.io/router.tls: "true"
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
@@ -215,6 +239,8 @@ tests:
       path: metadata.annotations
       value:
         certmanager.k8s.io/issuer: RELEASE-NAME-rancher
+        traefik.ingress.kubernetes.io/router.entrypoints: "web,websecure"
+        traefik.ingress.kubernetes.io/router.tls: "true"
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"


### PR DESCRIPTION
Add traefik annotations to make ingress work with Traefik, without requiring traefik to be installed with values to enable tls

Fixes #36166