### PR TITLE
Improve debug logging for "Permission denied"

### DIFF
--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -110,6 +110,7 @@ func (p *ldapProvider) getPrincipalsFromSearchResult(result *ldapv3.SearchResult
 	userAttributes := entry.Attributes
 
 	if !p.permissionCheck(userAttributes, config) {
+		logrus.Debug("Now checking {%v} access permission", userAttributes)
 		return v3.Principal{}, nil, fmt.Errorf("Permission denied")
 	}
 


### PR DESCRIPTION
permissionCheck has no logging. 
Adding debug log for permissionCheck will help to find the cause of permission denied errors easily.