### PR TITLE
Add debug log for permissionCheck 

### DIFF
--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -110,7 +110,7 @@ func (p *ldapProvider) getPrincipalsFromSearchResult(result *ldapv3.SearchResult
 	userAttributes := entry.Attributes
 
 	if !p.permissionCheck(userAttributes, config) {
-		logrus.Debug("Now checking {%v} access permission", userAttributes)
+		logrus.Debugf("permissionCheck: user attributes: %v ", userAttributes)
 		return v3.Principal{}, nil, fmt.Errorf("Permission denied")
 	}
 


### PR DESCRIPTION
permissionCheck has no logging.
Adding debug log for permissionCheck will help to find the cause of permission denied errors easily.