### PR TITLE
Exclude alertrule and alertgroup from norman typers

### DIFF
--- a/pkg/api/scheme/scheme.go
+++ b/pkg/api/scheme/scheme.go
@@ -97,6 +97,10 @@ func init() {
 	Scheme.ExcludeGVK(management.SchemeGroupVersion.WithKind("NodeTemplateList"))
 	Scheme.ExcludeGVK(management.SchemeGroupVersion.WithKind("ClusterMonitorGraphList"))
 	Scheme.ExcludeGVK(management.SchemeGroupVersion.WithKind("ProjectMonitorGraphList"))
+	Scheme.ExcludeGVK(management.SchemeGroupVersion.WithKind("ClusterAlertRuleList"))
+	Scheme.ExcludeGVK(management.SchemeGroupVersion.WithKind("ClusterAlertGroupList"))
+	Scheme.ExcludeGVK(management.SchemeGroupVersion.WithKind("ProjectAlertRuleList"))
+	Scheme.ExcludeGVK(management.SchemeGroupVersion.WithKind("ProjectAlertGroupList"))
 }
 
 func addKnownTypes(scheme *runtime.Scheme) error {


### PR DESCRIPTION
This draft PR can address this UI issue:

<img width="794" alt="截屏2022-01-19 下午11 09 11" src="https://user-images.githubusercontent.com/998984/150158256-60182451-14bb-4517-bfce-b7551a09a2c4.png">
