### PR TITLE
Automation - Bumping the upstream Dockerimage version to python:3.7.12 for validation tests

### DIFF
--- a/tests/validation/Dockerfile.v3api
+++ b/tests/validation/Dockerfile.v3api
@@ -1,4 +1,4 @@
-FROM python:3.7.0
+FROM python:3.7.12
 
 ARG KUBECTL_VERSION=v1.16.6
 ENV WORKSPACE /src/rancher-validation


### PR DESCRIPTION
The curl version in `python:3.7.0` started to have issues with the `test_certificates` test suite.

The image `python:3.7.12` has a newer `curl` version that worked fine locally while running these tests.