### PR TITLE
Automation - rebuilt ubuntu-18.04 for validation tests

### DIFF
--- a/tests/validation/lib/aws.py
+++ b/tests/validation/lib/aws.py
@@ -26,7 +26,7 @@ AWS_CICD_INSTANCE_TAG = os.environ.get("AWS_CICD_INSTANCE_TAG",
                                        'rancher-validation')
 AWS_IAM_PROFILE = os.environ.get("AWS_IAM_PROFILE", "")
 # by default the public Ubuntu 18.04 AMI is used
-AWS_DEFAULT_AMI = "ami-0d5d9d301c853a04a"
+AWS_DEFAULT_AMI = "ami-0c3357e45c1a0eebe"
 AWS_DEFAULT_USER = "ubuntu"
 AWS_AMI = os.environ.get("AWS_AMI", AWS_DEFAULT_AMI)
 AWS_USER = os.environ.get("AWS_USER", AWS_DEFAULT_USER)


### PR DESCRIPTION
Rebuilt the Ubuntu 18.04 image to fix the tests execution as the AMI used was pointing to other AMI without pre-installed Docker.