### PR TITLE
[Backport v2.6.3-patch1] Embedded etcd migration fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -202,16 +202,6 @@ func initLogs(c *cli.Context, cfg rancher.Options) {
 	logserver.StartServerWithDefaults()
 }
 
-func migrateETCDlocal() {
-	if _, err := os.Stat("etcd"); err != nil {
-		return
-	}
-
-	// Purposely ignoring errors
-	_ = os.Mkdir("management-state", 0700)
-	_ = os.Symlink("../etcd", "management-state/etcd")
-}
-
 func run(cli *cli.Context, cfg rancher.Options) error {
 	logrus.Infof("Rancher version %s is starting", version.FriendlyVersion())
 	logrus.Infof("Rancher arguments %+v", cfg)
@@ -220,8 +210,6 @@ func run(cli *cli.Context, cfg rancher.Options) error {
 	if cfg.AddLocal != "true" && cfg.AddLocal != "auto" {
 		logrus.Fatal("add-local flag must be set to 'true', see Rancher 2.5.0 release notes for more information")
 	}
-
-	migrateETCDlocal()
 
 	embedded, clientConfig, err := k8s.GetConfig(ctx, cfg.K8sMode, kubeConfig)
 	if err != nil {

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -6,9 +6,9 @@ if [ ! -e /run/secrets/kubernetes.io/serviceaccount ] && [ ! -e /dev/kmsg ]; the
     exit 1
 fi
 rm -f /var/lib/rancher/k3s/server/cred/node-passwd
-if [ -e /var/lib/rancher/etcd ] && [ ! -e /var/lib/rancher/k3s/server/db/etcd ]; then
+if [ -e /var/lib/rancher/management-state/etcd ] && [ ! -e /var/lib/rancher/k3s/server/db/etcd ]; then
   mkdir -p /var/lib/rancher/k3s/server/db
-  ln -sf /var/lib/rancher/etcd /var/lib/rancher/k3s/server/db/etcd
+  ln -sf /var/lib/rancher/management-state/etcd /var/lib/rancher/k3s/server/db/etcd
   echo -n 'default' > /var/lib/rancher/k3s/server/db/etcd/name
 fi
 if [ -e /var/lib/rancher/k3s/server/db/etcd ]; then


### PR DESCRIPTION
Address #35955

For an upgrade in k3s single node, I updated the etcd migration code to migrate old etcd data to embedded etcd from /var/lib/rancher/management-state/etcd to /var/lib/rancher/k3s/server/db/etcd, instead of from /var/lib/rancher/etcd. The /var/lib/rancher/etcd dir gets overwritten if you upgrade a Rancher container that has bind mounted volumes.

Customers were losing downstream clusters on upgrade. Now, if you upgrade single node in Docker all cluster data will be preserved, even if you just update the Rancher version of a container with bind mounted volumes.