### PR TITLE
refactoring provisioning v1 tests to simplify future node drivers/providers

### DIFF
--- a/tests/v2/validation/provisioning/config.go
+++ b/tests/v2/validation/provisioning/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	NodesAndRoles      string   `json:"nodesAndRoles" yaml:"nodesAndRoles" default:""`
 	KubernetesVersions []string `json:"kubernetesVersion" yaml:"kubernetesVersion"`
 	CNIs               []string `json:"cni" yaml:"cni"`
+	Providers          []string `json:"providers" yaml:"providers"`
 }
 
 func NodesAndRolesInput() []map[string]bool {

--- a/tests/v2/validation/provisioning/providers.go
+++ b/tests/v2/validation/provisioning/providers.go
@@ -1,0 +1,63 @@
+package provisioning
+
+import (
+	"fmt"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/aws"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/digitalocean"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/harvester"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	awsProviderName       = "aws"
+	doProviderName        = "do"
+	harvesterProviderName = "harvester"
+)
+
+type CloudCredFunc func(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error)
+type MachinePoolFunc func(generatedPoolName, namespace string) *unstructured.Unstructured
+
+type Provider struct {
+	Name            string
+	MachineConfig   string
+	MachinePoolFunc MachinePoolFunc
+	CloudCredFunc   CloudCredFunc
+}
+
+// CreateProvider returns all machine and cloud credential
+// configs in the form of a Provider struct. Accepts a
+// string of the name of the provider
+func CreateProvider(name string) Provider {
+	switch {
+	case name == awsProviderName:
+		provider := Provider{
+			Name:            name,
+			MachineConfig:   machinepools.AWSResourceConfig,
+			MachinePoolFunc: machinepools.NewAWSMachineConfig,
+			CloudCredFunc:   aws.CreateAWSCloudCredentials,
+		}
+		return provider
+	case name == doProviderName:
+		provider := Provider{
+			Name:            name,
+			MachineConfig:   machinepools.DOResourceConfig,
+			MachinePoolFunc: machinepools.NewDigitalOceanMachineConfig,
+			CloudCredFunc:   digitalocean.CreateDigitalOceanCloudCredentials,
+		}
+		return provider
+	case name == harvesterProviderName:
+		provider := Provider{
+			Name:            name,
+			MachineConfig:   machinepools.HarvesterResourceConfig,
+			MachinePoolFunc: machinepools.NewHarvesterMachineConfig,
+			CloudCredFunc:   harvester.CreateHarvesterCloudCredentials,
+		}
+		return provider
+	default:
+		panic(fmt.Sprintf("Provider:%v not found", name))
+	}
+}


### PR DESCRIPTION
additional config in go:
```
provisioningInput:
  providers: ["aws", "harvester", "do", ...]
```

this will be a required field in the config file. Tests will provision for each provider listed. Currently supported are aws, do, and harvester.  