### PR TITLE
fix ssh behind proxy 

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -14,7 +14,7 @@ FROM ${K3S_BUILDER} as k3s_builder
 
 FROM registry.suse.com/suse/sle15:15.3
 
-RUN zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim && \
+RUN zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim netcat-openbsd && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
     useradd rancher && \
     mkdir -p /var/lib/rancher /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \

--- a/package/jailer.sh
+++ b/package/jailer.sh
@@ -79,11 +79,17 @@ cp -l /usr/bin/kustomize.sh /opt/jail/$NAME
 # Hard link ssh into the jail
 cp -l /usr/bin/ssh /opt/jail/$NAME/usr/bin
 
+# Hard link nc into the jail
+cp -l /usr/bin/nc /opt/jail/$NAME/usr/bin
+
 # Hard link cat into the jail
 cp -l /bin/cat /opt/jail/$NAME/bin/
 
 # Hard link bash into the jail
 cp -l /bin/bash /opt/jail/$NAME/bin/
+
+# Hard link sh into the jail
+cp -l /bin/sh /opt/jail/$NAME/bin/
 
 # Hard link rm into the jail
 cp -l /bin/rm /opt/jail/$NAME/bin/

--- a/pkg/controllers/management/node/utils.go
+++ b/pkg/controllers/management/node/utils.go
@@ -41,14 +41,14 @@ const (
 
 func buildAgentCommand(node *v3.Node, dockerRun string) []string {
 	drun := strings.Fields(dockerRun)
-	cmd := []string{"--native-ssh", "ssh", node.Spec.RequestedHostname}
+	cmd := []string{"ssh", node.Spec.RequestedHostname}
 	cmd = append(cmd, drun...)
 	cmd = append(cmd, "-r", "-n", node.Name)
 	return cmd
 }
 
 func buildLoginCommand(node *v3.Node, login string) []string {
-	cmd := []string{"--native-ssh", "ssh", node.Spec.RequestedHostname}
+	cmd := []string{"ssh", node.Spec.RequestedHostname}
 	cmd = append(cmd, strings.Fields(login)...)
 	return cmd
 }


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/28411

add the support for provisioning cluster behind a proxy by letting rancher-machine use external ssh binary and adding dependencies to both Rancher image and the Jail directory

another part of the fix goes into rancher/machine: https://github.com/rancher/machine/pull/159