### PR TITLE
Don't try to cleanup node if it does not exist

### DIFF
--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -196,10 +196,7 @@ func (m *Lifecycle) waitUntilJobCompletes(userContext *config.UserContext, job *
 
 		logrus.Infof("[node-cleanup] job %s finished, continuing to delete v3 node", job.Name)
 		return true, nil
-	}); err != nil {
-		if err.Error() == "timed out waiting for the condition" {
-			return nil // gave it 30s and it timed out so move to delete v1 node
-		}
+	}); err != nil && err.Error() != "timed out waiting for the condition" {
 		return err
 	}
 


### PR DESCRIPTION
If the cleanup job timed out (like if the VM was deleted), then the node
will still exist in the cluster but it will have a Not Ready status.
Therefore, the cleanup job will get created to tolerate this status, but
the pod will never be scheduled because the VM was deleted.

After this change, if the cleanup job times out, then it will be
deleted.

Issue:
https://github.com/rancher/rancher/issues/35334