### PR TITLE
[release/v2.6] add k8s versions txt file

### DIFF
--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/coreos/go-semver/semver"
@@ -86,6 +87,13 @@ func run(systemChartPath, chartPath string, imagesFromArgs []string) error {
 		data.K8sVersionWindowsServiceOptions,
 		data.K8sVersionInfo,
 	)
+
+	var k8sVersions []string
+	for k := range linuxInfo.RKESystemImages {
+		k8sVersions = append(k8sVersions, k)
+	}
+	sort.Strings(k8sVersions)
+	writeSliceToFile(filepath.Join(os.Getenv("HOME"), "bin", "rancher-rke-k8s-versions.txt"), k8sVersions)
 
 	externalImages := make(map[string][]string)
 	k3sUpgradeImages, err := ext.GetExternalImages(rancherVersion, data.K3S, ext.K3S, nil)
@@ -248,6 +256,22 @@ func imagesText(arch string, targetImages []string) error {
 
 		log.Println("Image:", image)
 		fmt.Fprintln(save, image)
+	}
+
+	return nil
+}
+
+func writeSliceToFile(filename string, versions []string) error {
+	log.Printf("Creating %s\n", filename)
+	save, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer save.Close()
+	save.Chmod(0755)
+
+	for _, version := range versions {
+		fmt.Fprintln(save, version)
 	}
 
 	return nil

--- a/scripts/create-components-file.sh
+++ b/scripts/create-components-file.sh
@@ -20,4 +20,11 @@ printf '%s\n' "$(grep "_VERSION" ./package/Dockerfile | grep ENV | egrep -v "htt
 
 printf '%s\n' "$(grep "rancher/" ./go.mod | egrep -v "\./"  | egrep -v "\/pkg\/apis|\/pkg\/client|^module" | grep -v "=>" | awk -F'/' '{ print $NF }' | awk '$1 = toupper($1)' | sort | grep "\-rc")" >> $COMPONENTSFILE
 
+K8SVERSIONSFILE=./bin/rancher-rke-k8s-versions.txt
+
+if [[ -f "$K8SVERSIONSFILE" ]]; then
+    echo "# RKE Kubernetes versions" >> $COMPONENTSFILE
+    cat $K8SVERSIONSFILE >> $COMPONENTSFILE
+fi
+
 echo "Done creating ./bin/rancher-components.txt"


### PR DESCRIPTION
This will:
- Create `rancher-rke-k8s-versions.txt` with RKE Kubernetes versions included in the (pre) release
- Add the content of this file to `rancher-components.txt` which is used for pre-release release notes

Example on current code:

```
# RKE Kubernetes versions                                                                                                                                                                                                                                                                                                     
v1.19.16-rancher1-3                                                                                                                                                                                                                                                                                                           
v1.20.14-rancher2-1                                                                                                                                                                                                                                                                                                           
v1.21.8-rancher2-1                                                                                                                                                                                                                                                                                                            
v1.22.5-rancher2-1
```