### PR TITLE
[release/v2.6] Only show unique images in components file

### DIFF
--- a/scripts/create-components-file.sh
+++ b/scripts/create-components-file.sh
@@ -12,11 +12,11 @@ COMPONENTSFILE=./bin/rancher-components.txt
 
 echo "# Images with -rc" > $COMPONENTSFILE
 
-printf '%s\n' "$(grep -h "\-rc" ./bin/rancher-images.txt ./bin/rancher-windows-images.txt | awk -F: '{ print $1,$2 }')" >> $COMPONENTSFILE
+printf '%s\n' "$(grep -h "\-rc" ./bin/rancher-images.txt ./bin/rancher-windows-images.txt | awk -F: '{ print $1,$2 }')" | sort -u >> $COMPONENTSFILE
 
 echo "# Components with -rc" >> $COMPONENTSFILE
 
-printf '%s\n' "$(grep "_VERSION" ./package/Dockerfile | grep ENV | egrep -v "http|\\$" | grep CATTLE |sed 's/CATTLE_//g' | sed 's/=/ /g' |  awk '{ print $2,$3 }' | sort | grep "\-rc")" >> $COMPONENTSFILE
+printf '%s\n' "$(grep "_VERSION" ./package/Dockerfile | grep ENV | egrep -v "http|\\$|MIN_VERSION" | grep CATTLE |sed 's/CATTLE_//g' | sed 's/=/ /g' |  awk '{ print $2,$3 }' | sort | grep "\-rc")" >> $COMPONENTSFILE
 
 printf '%s\n' "$(grep "rancher/" ./go.mod | egrep -v "\./"  | egrep -v "\/pkg\/apis|\/pkg\/client|^module" | grep -v "=>" | awk -F'/' '{ print $NF }' | awk '$1 = toupper($1)' | sort | grep "\-rc")" >> $COMPONENTSFILE
 


### PR DESCRIPTION
- Some images were shown twice as a result of being in linux and windows images
- Removed `MIN_VERSION` as those are not components but a version limitation for components