### PR TITLE
Put cloned-from annotations on machine templates

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/common.go
+++ b/pkg/controllers/provisioningv2/rke2/common.go
@@ -50,9 +50,14 @@ const (
 	UnCordonAnnotation         = "rke.cattle.io/uncordon"
 	WorkerRoleLabel            = "rke.cattle.io/worker-role"
 
+	MachineTemplateClonedFromGroupVersionAnn = "rke.cattle.io/cloned-from-group-version"
+	MachineTemplateClonedFromKindAnn         = "rke.cattle.io/cloned-from-kind"
+	MachineTemplateClonedFromNameAnn         = "rke.cattle.io/cloned-from-name"
+
 	CattleOSLabel = "cattle.io/os"
 
-	RKEMachineAPIVersion = "rke-machine.cattle.io/v1"
+	DefaultMachineConfigAPIVersion = "rke-machine-config.cattle.io/v1"
+	RKEMachineAPIVersion           = "rke-machine.cattle.io/v1"
 
 	Provisioned = condition.Cond("Provisioned")
 	Ready       = condition.Cond("Ready")

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -27,8 +27,7 @@ import (
 )
 
 const (
-	byNodeInfra                    = "by-node-infra"
-	defaultMachineConfigAPIVersion = "rke-machine-config.cattle.io/v1"
+	byNodeInfra = "by-node-infra"
 )
 
 type handler struct {
@@ -112,13 +111,13 @@ func byNodeInfraIndex(obj *rancherv1.Cluster) ([]string, error) {
 
 func toInfraRefKey(ref corev1.ObjectReference, namespace string) string {
 	if ref.APIVersion == "" {
-		ref.APIVersion = defaultMachineConfigAPIVersion
+		ref.APIVersion = rke2.DefaultMachineConfigAPIVersion
 	}
 	return fmt.Sprintf("%s/%s/%s/%s", ref.APIVersion, ref.Kind, namespace, ref.Name)
 }
 
 func matchRKENodeGroup(gvk schema.GroupVersionKind) bool {
-	return gvk.GroupVersion().String() == defaultMachineConfigAPIVersion &&
+	return gvk.GroupVersion().String() == rke2.DefaultMachineConfigAPIVersion &&
 		strings.HasSuffix(gvk.Kind, "Config")
 }
 

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
@@ -136,7 +136,7 @@ func toMachineTemplate(machinePoolName string, cluster *rancherv1.Cluster, machi
 	apiVersion := machinePool.NodeConfig.APIVersion
 	kind := machinePool.NodeConfig.Kind
 	if apiVersion == "" {
-		apiVersion = defaultMachineConfigAPIVersion
+		apiVersion = rke2.DefaultMachineConfigAPIVersion
 	}
 
 	gvk := schema.FromAPIVersionAndKind(apiVersion, kind)
@@ -182,6 +182,11 @@ func toMachineTemplate(machinePoolName string, cluster *rancherv1.Cluster, machi
 			"kind":       strings.TrimSuffix(kind, "Config") + "MachineTemplate",
 			"apiVersion": rke2.RKEMachineAPIVersion,
 			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					rke2.MachineTemplateClonedFromGroupVersionAnn: gvk.GroupVersion().String(),
+					rke2.MachineTemplateClonedFromKindAnn:         gvk.Kind,
+					rke2.MachineTemplateClonedFromNameAnn:         machinePool.NodeConfig.Name,
+				},
 				"name":      machinePoolName,
 				"namespace": cluster.Namespace,
 				"labels": map[string]interface{}{

--- a/tests/integration/pkg/cluster/clusters.go
+++ b/tests/integration/pkg/cluster/clusters.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
@@ -89,6 +90,16 @@ func New(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*provisi
 
 func Machines(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*capi.MachineList, error) {
 	return clients.CAPI.Machine().List(cluster.Namespace, metav1.ListOptions{
+		LabelSelector: "cluster.x-k8s.io/cluster-name=" + cluster.Name,
+	})
+}
+
+func PodInfraMachines(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*unstructured.UnstructuredList, error) {
+	return clients.Dynamic.Resource(schema.GroupVersionResource{
+		Group:    "rke-machine.cattle.io",
+		Version:  "v1",
+		Resource: "podmachines",
+	}).Namespace(cluster.Namespace).List(clients.Ctx, metav1.ListOptions{
 		LabelSelector: "cluster.x-k8s.io/cluster-name=" + cluster.Name,
 	})
 }


### PR DESCRIPTION
CAPI identifies which templates certain objects are cloned from. For example,
CAPI will identify that an infrastructure machine is cloned from a specific
machine template.

This change will do the same for machine templates: it will identify which
machine config a machine template is cloned from.

Issue:
https://github.com/rancher/rancher/issues/35452