### PR TITLE
Bump UI, webhook to final release for 2.6.3-patch1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -46,7 +46,7 @@ ENV CATTLE_SYSTEM_AGENT_UPGRADE_IMAGE rancher/system-agent:${CATTLE_SYSTEM_AGENT
 
 # System charts minimal version
 ENV CATTLE_FLEET_MIN_VERSION=100.0.2+up0.3.8
-ENV CATTLE_RANCHER_WEBHOOK_MIN_VERSION=1.0.3+up0.2.4-rc7
+ENV CATTLE_RANCHER_WEBHOOK_MIN_VERSION=1.0.3+up0.2.4
 
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/library && \
@@ -110,8 +110,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry /usr/bin/k3s /usr/bin/kubectl && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-ENV CATTLE_UI_VERSION 2.6.3-patch1-rc1
-ENV CATTLE_DASHBOARD_UI_VERSION v2.6.3-patch1-rc3
+ENV CATTLE_UI_VERSION 2.6.3-patch1
+ENV CATTLE_DASHBOARD_UI_VERSION v2.6.3-patch1
 ENV CATTLE_CLI_VERSION v2.6.0
 
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.


### PR DESCRIPTION
- [x] No other RCs in https://github.com/rancher/rancher/releases/download/v2.6.3-patch1-rc2/rancher-images.txt
- [x] No changes needed to charts branches