### PR TITLE
Delete oldest machines on scale down

### DIFF
--- a/tests/integration/pkg/cluster/clusters.go
+++ b/tests/integration/pkg/cluster/clusters.go
@@ -94,6 +94,16 @@ func Machines(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*ca
 	})
 }
 
+func MachineSets(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*unstructured.UnstructuredList, error) {
+	return clients.Dynamic.Resource(schema.GroupVersionResource{
+		Group:    "cluster.x-k8s.io",
+		Version:  "v1beta1",
+		Resource: "machinesets",
+	}).Namespace(cluster.Namespace).List(clients.Ctx, metav1.ListOptions{
+		LabelSelector: "cluster.x-k8s.io/cluster-name=" + cluster.Name,
+	})
+}
+
 func PodInfraMachines(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*unstructured.UnstructuredList, error) {
 	return clients.Dynamic.Resource(schema.GroupVersionResource{
 		Group:    "rke-machine.cattle.io",


### PR DESCRIPTION
By default, the CAPI controllers will delete a random machine when a machine
deployment is scaled down. This is different from the RKE1 implementation, which
 deletes the oldest machine first.

After this change, a deletion policy will be added to the machine deployments
with a deletion policy to delete the oldest machine on scale down.

Issue:
https://github.com/rancher/rancher/issues/35753