### PR TITLE
Remove unused Thrift direct dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module github.com/rancher/rancher
 go 1.16
 
 replace (
-	git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
-
 	github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible // oras dep requires a replace is set
 	github.com/docker/docker => github.com/docker/docker v20.10.6+incompatible // oras dep requires a replace is set
 


### PR DESCRIPTION
```
% go mod why -m github.com/apache/thrift  
# github.com/apache/thrift
(main module does not need module github.com/apache/thrift)
```

The remaining Thrift in [`go.sum`](https://github.com/macedogm/rancher/blob/108719c435c029f5f719c37bd39126a7729b4f47/go.sum#L179) is imported through another dependency, but not shipped:
```
go.opencensus.io@v0.20.1 github.com/apache/thrift@v0.12.0
```

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>