### PR TITLE
Pass container limits from project in a new namespace if it does not override them

### DIFF
--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -450,9 +450,11 @@ func (c *SyncController) getResourceLimitToUpdate(ns *corev1.Namespace) (*corev1
 		return convertPodResourceLimitToLimitRangeSpec(updatedLimit)
 	} else if nsLimit != nil {
 		return convertPodResourceLimitToLimitRangeSpec(nsLimit)
+	} else if projectLimit != nil {
+		return convertPodResourceLimitToLimitRangeSpec(projectLimit)
+	} else {
+		return nil, nil
 	}
-
-	return nil, nil
 }
 
 func completeQuota(existingQuota *v32.NamespaceResourceQuota, defaultQuota *v32.NamespaceResourceQuota) (*v32.NamespaceResourceQuota, error) {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/27750

To enable the propagation of container default limits from a project to its new namespaces made via `kubectl` directly, we must explicitly set project limits (if defined), if the namespace itself does not provide its own (override) values.