### PR TITLE
Updated dynamic client

### DIFF
--- a/tests/framework/clients/dynamic/dynamic.go
+++ b/tests/framework/clients/dynamic/dynamic.go
@@ -23,6 +23,8 @@ type Client struct {
 
 // NewForConfig creates a new dynamic client or returns an error.
 func NewForConfig(ts *session.Session, inConfig *rest.Config) (dynamic.Interface, error) {
+	ts.TestingT.Logf("Dynamic Client Host:%s", inConfig.Host)
+
 	dynamicClient, err := dynamic.NewForConfig(inConfig)
 	if err != nil {
 		return nil, err

--- a/tests/framework/extensions/namespaces/namespaces.go
+++ b/tests/framework/extensions/namespaces/namespaces.go
@@ -46,7 +46,7 @@ func CreateNamespace(client *rancher.Client, namespaceName, containerDefaultReso
 		},
 	}
 
-	dynamicClient, err := client.GetRancherDynamicClient()
+	dynamicClient, err := client.GetDownStreamClusterClient(project.ClusterID)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/framework/pkg/session/session.go
+++ b/tests/framework/pkg/session/session.go
@@ -12,7 +12,7 @@ type Session struct {
 	CleanupEnabled bool
 	cleanupQueue   []CleanupFunc
 	open           bool
-	testingT       *testing.T
+	TestingT       *testing.T
 }
 
 // NewSession is a constructor instantiates a new `Session`
@@ -21,7 +21,7 @@ func NewSession(t *testing.T) *Session {
 		CleanupEnabled: true,
 		cleanupQueue:   []CleanupFunc{},
 		open:           true,
-		testingT:       t,
+		TestingT:       t,
 	}
 }
 
@@ -44,7 +44,7 @@ func (ts *Session) Cleanup() {
 		for i := len(ts.cleanupQueue) - 1; i >= 0; i-- {
 			err := ts.cleanupQueue[i]()
 			if err != nil {
-				ts.testingT.Logf("error calling cleanup function: %v", err)
+				ts.TestingT.Logf("error calling cleanup function: %v", err)
 			}
 		}
 		ts.cleanupQueue = []CleanupFunc{}
@@ -53,7 +53,7 @@ func (ts *Session) Cleanup() {
 
 // NewSession returns a `Session` who's cleanup method is registered with this `Session`
 func (ts *Session) NewSession() *Session {
-	sess := NewSession(ts.testingT)
+	sess := NewSession(ts.TestingT)
 
 	ts.RegisterCleanupFunc(func() error {
 		sess.Cleanup()


### PR DESCRIPTION
**Framework updates**

- Dynamic client not takes a testing.T object to log the host of the dynamic client.
- Removed GenerateKubeconfig from GetDownStreamClusterClient, and instead just updated the host.