### PR TITLE
Allow container default limits propagation in absence of project resource quotas

### DIFF
--- a/pkg/controllers/managementuser/resourcequota/resource_quota_common.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_common.go
@@ -203,7 +203,7 @@ func getProjectContainerDefaultLimit(ns *corev1.Namespace, projectLister v3.Proj
 		return nil, nil
 	}
 	project, err := projectLister.Get(projectNamespace, projectName)
-	if err != nil || project.Spec.ResourceQuota == nil {
+	if err != nil {
 		if errors.IsNotFound(err) {
 			// If Rancher is unaware of a project, we should ignore trying to get the default container limit
 			// A non-existent project is likely managed by another Rancher (e.g. Hosted Rancher)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/18877

This allows container default limits defined in a project to be propagated to new namespaces (which don't override them) even if the project does not have resource quotas defined.

This is a quick solution that works, however, I have noticed two things in my tests, but they are insignificant.
1. Sometimes the propagated limits are duplicated on the namespace. This does not affect anything, just looks strange.
2. Having created a new namespace with propagated container default limits, one can see that they are missing in the UI. This could be a UI issue from before.
