### PR TITLE
ForceUpdate allow 1 minute time drift

### DIFF
--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -287,7 +287,7 @@ func shouldRefresh(spec *catalog.RepoSpec, status *catalog.RepoStatus) bool {
 	if status.IndexConfigMapName == "" {
 		return true
 	}
-	if spec.ForceUpdate != nil && spec.ForceUpdate.After(status.DownloadTime.Time) && spec.ForceUpdate.Time.Before(time.Now()) {
+	if spec.ForceUpdate != nil && spec.ForceUpdate.After(status.DownloadTime.Time) && spec.ForceUpdate.Time.Before(time.Now().Add(time.Minute)) {
 		return true
 	}
 	refreshTime := time.Now().Add(-interval)


### PR DESCRIPTION
**Problem:**
Because the [Rancher dashboard](https://github.com/rancher/dashboard/blob/ea5592322c26305e42d53dc5436a3b04e091f376/models/catalog.cattle.io.clusterrepo.js#L33) sends the client's current time as value for `ClusterRepo.spec.ForceUpdate`. Slight time differences between client and server can cause `spec.ForceUpdate.Time.Before(time.Now())` to prevent a ForceUpdate of a ClusterRepo when the client is running a second ahead.

**Solution:**
Allowing one minute of time drift prevents en queueing the requested immediate update.

**Issue:**
https://github.com/rancher/rancher/issues/35864