### PR TITLE
Add restricted-noroot PSP policy to match upstream Kubernetes restricted PSP

### DIFF
--- a/pkg/data/management/podsecuritypolicytemplate_data.go
+++ b/pkg/data/management/podsecuritypolicytemplate_data.go
@@ -13,6 +13,7 @@ import (
 
 const runAsAny = "RunAsAny"
 const mustRunAs = "MustRunAs"
+const mustRunAsNonRoot = "MustRunAsNonRoot"
 
 func addDefaultPodSecurityPolicyTemplates(management *config.ManagementContext) error {
 	pspts := management.Management.PodSecurityPolicyTemplates("")
@@ -49,7 +50,7 @@ func addDefaultPodSecurityPolicyTemplates(management *config.ManagementContext) 
 					Rule: runAsAny,
 				},
 			},
-			Description: "This is the default unrestricted Pod Security Policy Template.  It is the most permissive " +
+			Description: "This is the default unrestricted Pod Security Policy Template. It is the most permissive " +
 				"Pod Security Policy that can be created in Kubernetes and is equivalent to running Kubernetes " +
 				"without Pod Security Policies enabled.",
 		},
@@ -94,8 +95,53 @@ func addDefaultPodSecurityPolicyTemplates(management *config.ManagementContext) 
 				},
 				ReadOnlyRootFilesystem: false,
 			},
-			Description: "This is the default restricted Pod Security Policy Template.  It restricts many user " +
+			Description: "This is the default restricted Pod Security Policy Template. It restricts many user " +
 				"actions and does not allow privilege escalation.",
+		},
+		{
+			ObjectMeta: v12.ObjectMeta{
+				Name: "restricted-noroot",
+			},
+			Spec: v1beta1.PodSecurityPolicySpec{
+				Privileged:               false,
+				AllowPrivilegeEscalation: toBoolPtr(false),
+				RequiredDropCapabilities: []v1.Capability{
+					"ALL",
+				},
+				Volumes: []v1beta1.FSType{
+					"configMap",
+					"emptyDir",
+					"projected",
+					"secret",
+					"downwardAPI",
+					"csi",
+					"persistentVolumeClaim",
+				},
+				HostNetwork: false,
+				HostIPC:     false,
+				HostPID:     false,
+				RunAsUser: v1beta1.RunAsUserStrategyOptions{
+					Rule: mustRunAsNonRoot,
+				},
+				SELinux: v1beta1.SELinuxStrategyOptions{
+					Rule: runAsAny,
+				},
+				SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{
+					Rule: mustRunAs,
+					Ranges: []v1beta1.IDRange{
+						{Min: 1, Max: 65535},
+					},
+				},
+				FSGroup: v1beta1.FSGroupStrategyOptions{
+					Rule: mustRunAs,
+					Ranges: []v1beta1.IDRange{
+						{Min: 1, Max: 65535},
+					},
+				},
+				ReadOnlyRootFilesystem: false,
+			},
+			Description: "This is the restricted Pod Security Policy Template to match upstream Kubernetes restricted PSP. " +
+				"It restricts all user actions, does not allow privilege escalation and requires containers to run without root privileges.",
 		},
 	}
 	for _, policy := range policies {


### PR DESCRIPTION
Add `restricted-noroot` PSP policy to match upstream Kubernetes `restricted` PSP.

Fix https://github.com/rancher/rancher/issues/35191

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>