### PR TITLE
[release/v2.6] Overwrite prerelease title and note on tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -309,6 +309,7 @@ steps:
     prerelease: true
     title: "Pre-release ${DRONE_TAG}"
     note: ./bin/rancher-components.txt
+    overwrite: true
   when:
     event:
     - tag


### PR DESCRIPTION
In case the release already exist (when the tag/release is created using the UI for example), Drone won't update it unless `overwrite: true` is specified. As we use release notes to show `-rc` components and included RKE k8s versions, we want this information in the pre release notes.