### PR TITLE
Ensure node-cleanup pods are deleted

### DIFF
--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -201,7 +201,7 @@ func (m *Lifecycle) waitUntilJobCompletes(userContext *config.UserContext, job *
 	}
 
 	// remove the job to clean up
-	return userContext.K8sClient.BatchV1().Jobs(job.Namespace).Delete(m.ctx, job.Name, metav1.DeleteOptions{})
+	return userContext.K8sClient.BatchV1().Jobs(job.Namespace).Delete(m.ctx, job.Name, metav1.DeleteOptions{PropagationPolicy: &[]metav1.DeletionPropagation{metav1.DeletePropagationForeground}[0]})
 }
 
 func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, node *v3.Node) (*batchV1.Job, error) {


### PR DESCRIPTION
A customer is hitting an issue where nodes deleted from Cluster Explorer don't get their cleanup jobs run on them so the jobs-pods just get stuck in pending. The nodes seem to be removed from the cluster before the Job is created so the node scheduling never resolves. I've noticed that the Job gets deleted, but the pod does not.

The problem for them is that they re-add nodes with the same name as part of their patching procedure. So when they do the pod gets scheduled to that node and cleaned. This PR adds a step to clean the nodes belonging to the Job after the fact.

Issue:
https://github.com/rancher/rancher/issues/35334