### PR TITLE
[release/v2.6] Add support in cluster git repos for custom/self-signed certs

### DIFF
--- a/pkg/catalogv2/git/download.go
+++ b/pkg/catalogv2/git/download.go
@@ -3,6 +3,7 @@ package git
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/pem"
 	"fmt"
 	"net/url"
 	"os"
@@ -27,8 +28,8 @@ func gitDir(namespace, name, gitURL string) string {
 	return filepath.Join(stateDir, namespace, name, hash(gitURL))
 }
 
-func Head(secret *corev1.Secret, namespace, name, gitURL, branch string, insecureSkipTLS bool) (string, error) {
-	git, err := gitForRepo(secret, namespace, name, gitURL, insecureSkipTLS)
+func Head(secret *corev1.Secret, namespace, name, gitURL, branch string, insecureSkipTLS bool, caBundle []byte) (string, error) {
+	git, err := gitForRepo(secret, namespace, name, gitURL, insecureSkipTLS, caBundle)
 	if err != nil {
 		return "", err
 	}
@@ -36,28 +37,28 @@ func Head(secret *corev1.Secret, namespace, name, gitURL, branch string, insecur
 	return git.Head(branch)
 }
 
-func Update(secret *corev1.Secret, namespace, name, gitURL, branch string, insecureSkipTLS bool) (string, error) {
-	git, err := gitForRepo(secret, namespace, name, gitURL, insecureSkipTLS)
+func Update(secret *corev1.Secret, namespace, name, gitURL, branch string, insecureSkipTLS bool, caBundle []byte) (string, error) {
+	git, err := gitForRepo(secret, namespace, name, gitURL, insecureSkipTLS, caBundle)
 	if err != nil {
 		return "", err
 	}
 
 	if isBundled(git) && settings.SystemCatalog.Get() == "bundled" {
-		return Head(secret, namespace, name, gitURL, branch, insecureSkipTLS)
+		return Head(secret, namespace, name, gitURL, branch, insecureSkipTLS, caBundle)
 	}
 
 	commit, err := git.Update(branch)
 	if err != nil && isBundled(git) {
-		return Head(secret, namespace, name, gitURL, branch, insecureSkipTLS)
+		return Head(secret, namespace, name, gitURL, branch, insecureSkipTLS, caBundle)
 	}
 	return commit, err
 }
 
-func Ensure(secret *corev1.Secret, namespace, name, gitURL, commit string, insecureSkipTLS bool) error {
+func Ensure(secret *corev1.Secret, namespace, name, gitURL, commit string, insecureSkipTLS bool, caBundle []byte) error {
 	if commit == "" {
 		return nil
 	}
-	git, err := gitForRepo(secret, namespace, name, gitURL, insecureSkipTLS)
+	git, err := gitForRepo(secret, namespace, name, gitURL, insecureSkipTLS, caBundle)
 	if err != nil {
 		return err
 	}
@@ -69,7 +70,7 @@ func isBundled(git *git.Git) bool {
 	return strings.HasPrefix(git.Directory, staticDir)
 }
 
-func gitForRepo(secret *corev1.Secret, namespace, name, gitURL string, insecureSkipTLS bool) (*git.Git, error) {
+func gitForRepo(secret *corev1.Secret, namespace, name, gitURL string, insecureSkipTLS bool, caBundle []byte) (*git.Git, error) {
 	if !strings.HasPrefix(gitURL, "git@") {
 		u, err := url.Parse(gitURL)
 		if err != nil {
@@ -84,14 +85,28 @@ func gitForRepo(secret *corev1.Secret, namespace, name, gitURL string, insecureS
 	if settings.InstallUUID.Get() != "" {
 		headers["X-Install-Uuid"] = settings.InstallUUID.Get()
 	}
+	// convert caBundle to PEM format because git requires correct line breaks, header and footer.
+	if len(caBundle) > 0 {
+		caBundle = convertDERToPEM(caBundle)
+	}
 	return git.NewGit(dir, gitURL, &git.Options{
 		Credential:        secret,
 		Headers:           headers,
 		InsecureTLSVerify: insecureSkipTLS,
+		CABundle:          caBundle,
 	})
 }
 
 func hash(gitURL string) string {
 	b := sha256.Sum256([]byte(gitURL))
 	return hex.EncodeToString(b[:])
+}
+
+// convertDERToPEM converts a src DER certificate into PEM with line breaks, header, and footer.
+func convertDERToPEM(src []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{
+		Type:    "CERTIFICATE",
+		Headers: map[string]string{},
+		Bytes:   src,
+	})
 }

--- a/pkg/catalogv2/git/download.go
+++ b/pkg/catalogv2/git/download.go
@@ -88,6 +88,7 @@ func gitForRepo(secret *corev1.Secret, namespace, name, gitURL string, insecureS
 	// convert caBundle to PEM format because git requires correct line breaks, header and footer.
 	if len(caBundle) > 0 {
 		caBundle = convertDERToPEM(caBundle)
+		insecureSkipTLS = false
 	}
 	return git.NewGit(dir, gitURL, &git.Options{
 		Credential:        secret,

--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -186,7 +186,7 @@ func (r *repoHandler) ensure(repoSpec *catalog.RepoSpec, status catalog.RepoStat
 		return status, err
 	}
 
-	return status, git.Ensure(secret, metadata.Namespace, metadata.Name, status.URL, status.Commit, repoSpec.InsecureSkipTLSverify)
+	return status, git.Ensure(secret, metadata.Namespace, metadata.Name, status.URL, status.Commit, repoSpec.InsecureSkipTLSverify, repoSpec.CABundle)
 }
 
 func (r *repoHandler) download(repoSpec *catalog.RepoSpec, status catalog.RepoStatus, metadata *metav1.ObjectMeta, owner metav1.OwnerReference) (catalog.RepoStatus, error) {
@@ -205,7 +205,7 @@ func (r *repoHandler) download(repoSpec *catalog.RepoSpec, status catalog.RepoSt
 
 	downloadTime := metav1.Now()
 	if repoSpec.GitRepo != "" && status.IndexConfigMapName == "" {
-		commit, err = git.Head(secret, metadata.Namespace, metadata.Name, repoSpec.GitRepo, repoSpec.GitBranch, repoSpec.InsecureSkipTLSverify)
+		commit, err = git.Head(secret, metadata.Namespace, metadata.Name, repoSpec.GitRepo, repoSpec.GitBranch, repoSpec.InsecureSkipTLSverify, repoSpec.CABundle)
 		if err != nil {
 			return status, err
 		}
@@ -213,7 +213,7 @@ func (r *repoHandler) download(repoSpec *catalog.RepoSpec, status catalog.RepoSt
 		status.Branch = repoSpec.GitBranch
 		index, err = git.BuildOrGetIndex(metadata.Namespace, metadata.Name, repoSpec.GitRepo)
 	} else if repoSpec.GitRepo != "" {
-		commit, err = git.Update(secret, metadata.Namespace, metadata.Name, repoSpec.GitRepo, repoSpec.GitBranch, repoSpec.InsecureSkipTLSverify)
+		commit, err = git.Update(secret, metadata.Namespace, metadata.Name, repoSpec.GitRepo, repoSpec.GitBranch, repoSpec.InsecureSkipTLSverify, repoSpec.CABundle)
 		if err != nil {
 			return status, err
 		}


### PR DESCRIPTION
SURE-3618
Issue: https://github.com/rancher/rancher/issues/31676

Technically, the conversion to PEM is not required since you could encode the contents of a ca.pem file with the header, footer, and line breaks into base64, pass it in as `caBundle` and it will be accepted (git based requires header, footer and line breaks). However, this approach doing the conversion makes setting up git-based repos with a CA bundle match the HTTP-based repo setup from a user standpoint (see [here](https://rancher.com/docs/rancher/v2.6/en/helm-charts/#repositories)). It also allows for re-using the logic to load the chart's icons without any further modifications.