### PR TITLE
Don't drain etcd nodes

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
@@ -300,7 +300,8 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 			machineDeploymentLabels[k] = v
 		}
 		machineSpecAnnotations := map[string]string{}
-		if !machinePool.DrainBeforeDelete {
+		// Ignore drain if DrainBeforeDelete is unset or the pool is for etcd nodes
+		if !machinePool.DrainBeforeDelete || machinePool.EtcdRole {
 			machineSpecAnnotations[capi.ExcludeNodeDrainingAnnotation] = "true"
 		}
 


### PR DESCRIPTION
Draining etcd nodes causes issues in RKE2, where some pods are unhealthy. This PR never drains etcd nodes, which is the current approach in RKE1.
Related Issue: #35274 