### PR TITLE
Re-enqueue infra machine if provider ID set with jobComplete false

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/machineprovision/args.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/args.go
@@ -62,6 +62,16 @@ func (h *handler) getArgsEnvAndStatus(infraObj *infraObject, args map[string]int
 		filesSecret                          *corev1.Secret
 	)
 
+	if infraObj.data.String("spec", "providerID") != "" && !infraObj.data.Bool("status", "jobComplete") {
+		// If the providerID is set, but jobComplete is false, then we need to re-enqueue the job so the proper status is set from that handler.
+		job, err := h.getJobFromInfraMachine(infraObj)
+		if err != nil {
+			return driverArgs{}, err
+		}
+		h.jobController.Enqueue(infraObj.meta.GetNamespace(), job.Name)
+		return driverArgs{}, generic.ErrSkip
+	}
+
 	nd, err := h.nodeDriverCache.Get(driver)
 	if !create && apierror.IsNotFound(err) {
 		url = infraObj.data.String("status", "driverURL")

--- a/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
@@ -149,22 +149,26 @@ func objects(ready bool, args driverArgs) []runtime.Object {
 			Name:     "rke2-machine-provisioner",
 		},
 	}
+
+	labels := map[string]string{
+		InfraMachineGroup:   args.MachineGVK.Group,
+		InfraMachineVersion: args.MachineGVK.Version,
+		InfraMachineKind:    args.MachineGVK.Kind,
+		InfraMachineName:    args.MachineName,
+		InfraJobRemove:      strconv.FormatBool(!args.BootstrapRequired),
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      saName,
 			Namespace: args.MachineNamespace,
+			Labels:    labels,
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit: &args.BackoffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						InfraMachineGroup:   args.MachineGVK.Group,
-						InfraMachineVersion: args.MachineGVK.Version,
-						InfraMachineKind:    args.MachineGVK.Kind,
-						InfraMachineName:    args.MachineName,
-						InfraJobRemove:      strconv.FormatBool(!args.BootstrapRequired),
-					},
+					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
 					Volumes: append(volumes, corev1.Volume{


### PR DESCRIPTION
There is a possible race that could cause the jobComplete field to be false
(indicating that the creation job has not finished successfully), but the
providerID field set (indicating that the machine is running and has been
bootstrapped). These are contradictory states.

This change will re-enqueue the job if the infrastructure machine gets into this
state, which will set the jobComplete field and re-enqueue the infrastructure
machine to be processed again.

In addition, it is possible for the `GetJobName` to return a different
value every time if the infrastructure machine name is too long. This
change mitigates that by using labels to get the job.

Issue: https://github.com/rancher/rancher/issues/36547