### PR TITLE
Implemented kubeconfig helpers.

### DIFF
--- a/tests/framework/extensions/kubeconfig/contexts.go
+++ b/tests/framework/extensions/kubeconfig/contexts.go
@@ -1,0 +1,16 @@
+package kubeconfig
+
+import (
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// GetContexts is a helper function the lists the contexts of a kubeconfig
+func GetContexts(clientConfig *clientcmd.ClientConfig) (map[string]*api.Context, error) {
+	rawConfig, err := (*clientConfig).RawConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return rawConfig.Contexts, nil
+}

--- a/tests/framework/extensions/kubeconfig/kubeconfig.go
+++ b/tests/framework/extensions/kubeconfig/kubeconfig.go
@@ -1,0 +1,28 @@
+package kubeconfig
+
+import (
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// GetKubeconfig generates a kubeconfig froma specific cluster, and returns it in the form of a *clientcmd.ClientConfig
+func GetKubeconfig(client *rancher.Client, clusterID string) (*clientcmd.ClientConfig, error) {
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeConfig, err := client.Management.Cluster.ActionGenerateKubeconfig(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	configBytes := []byte(kubeConfig.Config)
+
+	clientConfig, err := clientcmd.NewClientConfigFromBytes(configBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clientConfig, nil
+}


### PR DESCRIPTION
**Framework updates**
Implemented helper to retrieve the kubeconfig from a cluster.
Implemented helper to get the contexts from the kubeconfig of a cluster
Implemented elper to switch the context, that instantiates a dynamic client with an updated current-context.