### PR TITLE
Update HA local cluster deployment test to include RKE2 #36426 

### DIFF
--- a/tests/validation/tests/v3_api/resource/terraform/rke2/master/instances_server.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/master/instances_server.tf
@@ -262,7 +262,7 @@ resource "aws_lb_listener" "aws_nlb_listener_443" {
 
 resource "aws_route53_record" "aws_route53" {
   zone_id            = "${data.aws_route53_zone.selected.zone_id}"
-  name               = "${var.resource_name}-route53"
+  name               = "${var.resource_name}"
   type               = "CNAME"
   ttl                = "300"
   records            = ["${aws_lb.aws_nlb[0].dns_name}"]

--- a/tests/validation/tests/v3_api/test_import_rke2_cluster.py
+++ b/tests/validation/tests/v3_api/test_import_rke2_cluster.py
@@ -58,8 +58,7 @@ def test_create_rancherd_multiple_control_cluster():
 def test_create_rke2_multiple_control_cluster():
     cluster_version = RANCHER_RKE2_VERSION
     cluster_type = "rke2"
-    rke2_clusterfilepath = create_rke2_multiple_control_cluster(cluster_type, \
-                                                                cluster_version)
+    create_rke2_multiple_control_cluster(cluster_type, cluster_version)
 
 
 def test_import_rke2_multiple_control_cluster():
@@ -133,11 +132,11 @@ def create_rke2_multiple_control_cluster(cluster_type, cluster_version):
                                   'iam_role': RANCHER_IAM_ROLE,
                                   'volume_size': AWS_VOLUME_SIZE})
 
-    print("Joining worker nodes")
-    tf.init()
-    tf.plan(out="plan_worker.out")
-    print(tf.apply("--auto-approve"))
-    print("\n\n")
+        print("Joining worker nodes")
+        tf.init()
+        tf.plan(out="plan_worker.out")
+        print(tf.apply("--auto-approve"))
+        print("\n\n")
     cmd = "cp /tmp/" + RANCHER_HOSTNAME_PREFIX + "_kubeconfig " + \
           rke2_clusterfilepath
     os.system(cmd)


### PR DESCRIPTION
Few changes made here:
- Remove unnecessary `-route53` addition to name of route53 resource on rke2 clusters that create LB
- Remove unnecessary environment variable `RANCHER_K3S_VERSION` from `test_create_ha.py`
- Add RKE2 as a valid local cluster type
- Fix a check that was only valid for RKE1
- Provide a one-click URL at the end of the test output to open the rancher UI that this creates
- Only run terraform for worker node for rke2 clusters when the count is greater than 0 (k3s already does this correctly)