### PR TITLE
Bump kube-api-auth version

### DIFF
--- a/pkg/apis/management.cattle.io/v3/tools_system_images.go
+++ b/pkg/apis/management.cattle.io/v3/tools_system_images.go
@@ -20,7 +20,7 @@ var (
 			KubeApply:     "rancher/pipeline-tools:v0.1.16",
 		},
 		AuthSystemImages: AuthSystemImages{
-			KubeAPIAuth: "rancher/kube-api-auth:v0.1.6",
+			KubeAPIAuth: "rancher/kube-api-auth:v0.1.7",
 		},
 	}
 )


### PR DESCRIPTION
Bump kube-api-auth version. Related to https://github.com/rancher/kube-api-auth/pull/10.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>