### PR TITLE
Implemented EC2 library, for node instance creation and deletion

### DIFF
--- a/tests/framework/clients/ec2/client.go
+++ b/tests/framework/clients/ec2/client.go
@@ -1,0 +1,36 @@
+package ec2
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+)
+
+type EC2Client struct {
+	SVC    *ec2.EC2
+	Config *AWSEC2Config
+}
+
+func NewEC2Client() (*EC2Client, error) {
+	awsEC2Config := new(AWSEC2Config)
+
+	config.LoadConfig(ConfigurationFileKey, awsEC2Config)
+
+	credential := credentials.NewStaticCredentials(awsEC2Config.AWSAccessKeyID, awsEC2Config.AWSSecretAccessKey, "")
+	sess, err := session.NewSession(&aws.Config{
+		Credentials: credential,
+		Region:      aws.String(awsEC2Config.Region)},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create EC2 service client
+	svc := ec2.New(sess)
+	return &EC2Client{
+		SVC:    svc,
+		Config: awsEC2Config,
+	}, nil
+}

--- a/tests/framework/clients/ec2/config.go
+++ b/tests/framework/clients/ec2/config.go
@@ -1,0 +1,18 @@
+package ec2
+
+const ConfigurationFileKey = "awsEC2Config"
+
+type AWSEC2Config struct {
+	Region             string   `json:"region" yaml:"region"`
+	InstanceType       string   `json:"instanceType" yaml:"instanceType"`
+	AWSRegionAZ        string   `json:"awsRegionAZ" yaml:"awsRegionAZ"`
+	AWSAMI             string   `json:"awsAMI" yaml:"awsAMI"`
+	AWSSecurityGroups  []string `json:"awsSecurityGroups" yaml:"awsSecurityGroups"`
+	AWSAccessKeyID     string   `json:"awsAccessKeyID" yaml:"awsAccessKeyID"`
+	AWSSecretAccessKey string   `json:"awsSecretAccessKey" yaml:"awsSecretAccessKey"`
+	AWSSSHKeyName      string   `json:"awsSSHKeyName" yaml:"awsSSHKeyName"`
+	AWSCICDInstanceTag string   `json:"awsCICDInstanceTag" yaml:"awsCICDInstanceTag"`
+	AWSIAMProfile      string   `json:"awsIAMProfile" yaml:"awsIAMProfile"`
+	AWSUser            string   `json:"awsUser" yaml:"awsUser"`
+	VolumeSize         int      `json:"volumeSize" yaml:"volumeSize"`
+}

--- a/tests/framework/clients/rancher/client.go
+++ b/tests/framework/clients/rancher/client.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	frameworkDynamic "github.com/rancher/rancher/tests/framework/clients/dynamic"
+	"github.com/rancher/rancher/tests/framework/clients/ec2"
 	"github.com/rancher/rancher/tests/framework/clients/rancher/catalog"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/clients/rancher/provisioning"
@@ -150,6 +151,10 @@ func (c *Client) GetDownStreamClusterClient(clusterName string) (dynamic.Interfa
 		return nil, err
 	}
 	return dynamic, nil
+}
+
+func (c *Client) GetEC2Client() (*ec2.EC2Client, error) {
+	return ec2.NewEC2Client()
 }
 
 // GetManagementWatchInterface is a functions used to get a watch.Interface from a resource created by the Management Client.

--- a/tests/framework/pkg/nodes/ec2/ec2.go
+++ b/tests/framework/pkg/nodes/ec2/ec2.go
@@ -1,0 +1,133 @@
+package ec2
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
+)
+
+func CreateNodes(client *rancher.Client, nodeNameBase string, publicIp bool, numOfInstancs int64) ([]*nodes.Node, error) {
+	ec2Client, err := client.GetEC2Client()
+	if err != nil {
+		return nil, err
+	}
+
+	sshName := nodes.GetSSHKeyName(ec2Client.Config.AWSSSHKeyName)
+
+	runInstancesInput := &ec2.RunInstancesInput{
+		ImageId:      aws.String(ec2Client.Config.AWSAMI),
+		InstanceType: aws.String(ec2Client.Config.InstanceType),
+		MinCount:     aws.Int64(numOfInstancs),
+		MaxCount:     aws.Int64(numOfInstancs),
+		KeyName:      aws.String(sshName),
+		BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+			{
+				DeviceName: aws.String("/dev/sda1"),
+				Ebs: &ec2.EbsBlockDevice{
+					VolumeSize: aws.Int64(int64(ec2Client.Config.VolumeSize)),
+				},
+			},
+		},
+		IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
+			Name: aws.String(ec2Client.Config.AWSIAMProfile),
+		},
+		Placement: &ec2.Placement{
+			AvailabilityZone: aws.String(ec2Client.Config.AWSRegionAZ),
+		},
+		NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
+			{
+				DeviceIndex:              aws.Int64(0),
+				AssociatePublicIpAddress: aws.Bool(publicIp),
+				Groups:                   aws.StringSlice(ec2Client.Config.AWSSecurityGroups),
+			},
+		},
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("instance"),
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String(nodeNameBase),
+					},
+					{
+						Key:   aws.String("CICD"),
+						Value: aws.String(ec2Client.Config.AWSCICDInstanceTag),
+					},
+				},
+			},
+		},
+	}
+
+	reservation, err := ec2Client.SVC.RunInstances(runInstancesInput)
+	if err != nil {
+		return nil, err
+	}
+
+	var listOfInstanceIds []*string
+
+	for _, instance := range reservation.Instances {
+		listOfInstanceIds = append(listOfInstanceIds, instance.InstanceId)
+	}
+
+	//wait until instance is running
+	err = ec2Client.SVC.WaitUntilInstanceRunning(&ec2.DescribeInstancesInput{
+		InstanceIds: listOfInstanceIds,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	//wait until instance status is ok
+	err = ec2Client.SVC.WaitUntilInstanceStatusOk(&ec2.DescribeInstanceStatusInput{
+		InstanceIds: listOfInstanceIds,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// describe instance to get attributes=
+	describe, err := ec2Client.SVC.DescribeInstances(&ec2.DescribeInstancesInput{
+		InstanceIds: listOfInstanceIds,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	readyInstances := describe.Reservations[0].Instances
+
+	sshKey, err := nodes.GetSSHKey(ec2Client.Config.AWSSSHKeyName)
+	if err != nil {
+		return nil, err
+	}
+
+	var ec2Nodes []*nodes.Node
+
+	for _, readyInstance := range readyInstances {
+		ec2Node := &nodes.Node{
+			NodeID:          *readyInstance.InstanceId,
+			PublicIPAddress: *readyInstance.PublicIpAddress,
+			SSHUser:         ec2Client.Config.AWSUser,
+			SSHKey:          sshKey,
+		}
+		ec2Nodes = append(ec2Nodes, ec2Node)
+	}
+
+	return ec2Nodes, nil
+}
+
+func DeleteNodes(client *rancher.Client, nodes []*nodes.Node) (*ec2.TerminateInstancesOutput, error) {
+	ec2Client, err := client.GetEC2Client()
+	if err != nil {
+		return nil, err
+	}
+	var instanceIDs []*string
+
+	for _, node := range nodes {
+		instanceIDs = append(instanceIDs, aws.String(node.NodeID))
+	}
+
+	return ec2Client.SVC.TerminateInstances(&ec2.TerminateInstancesInput{
+		InstanceIds: instanceIDs,
+	})
+}

--- a/tests/framework/pkg/nodes/nodes.go
+++ b/tests/framework/pkg/nodes/nodes.go
@@ -1,0 +1,73 @@
+package nodes
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	SSHConfigConfigurationFileKey = "sshConfig"
+)
+
+type Node struct {
+	NodeID          string `json:"nodeID" yaml:"nodeID"`
+	PublicIPAddress string `json:"publicIPAddress" yaml:"publicIPAddress"`
+	SSHUser         string `json:"sshUser" yaml:"sshUser"`
+	SSHName         string `json:"sshName" yaml:"sshName"`
+	SSHKey          []byte
+}
+
+type ExternalNodeConfig struct {
+	PathToSSHKEY string  `json:"pathToSSHKEY" yaml:"pathToSSHKEY"`
+	Nodes        []*Node `json:"nodes" yaml:"nodes"`
+}
+
+func (n *Node) ExecuteCommand(command string) error {
+	signer, err := ssh.ParsePrivateKey(n.SSHKey)
+	if err != nil {
+		return err
+	}
+
+	auths := []ssh.AuthMethod{ssh.PublicKeys([]ssh.Signer{signer}...)}
+
+	cfg := &ssh.ClientConfig{
+		User:            n.SSHUser,
+		Auth:            auths,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	cfg.SetDefaults()
+
+	client, err := ssh.Dial("tcp", n.PublicIPAddress+":22", cfg)
+	if err != nil {
+		return err
+	}
+
+	session, err := client.NewSession()
+	if err != nil {
+		return err
+	}
+
+	return session.Run(command)
+}
+
+func GetSSHKeyName(sshKeyName string) string {
+	stringSlice := strings.Split(sshKeyName, ".")
+	return stringSlice[0]
+}
+
+func GetSSHKey(sshKeyname string) ([]byte, error) {
+	var nodeConfig ExternalNodeConfig
+	config.LoadConfig(SSHConfigConfigurationFileKey, &nodeConfig)
+
+	keyPath := filepath.Join(nodeConfig.PathToSSHKEY, sshKeyname)
+	content, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return content, nil
+}


### PR DESCRIPTION
**Framework updates**
- EC2 client for the aforementioned creation/deletion of nodes.
- EC2 extension for creating and deleting nodes
- Node library to be used by any provider. Including reading from a config for an already existing external node setup.