### PR TITLE
fix remote server panic for local cluster

### DIFF
--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -225,8 +225,10 @@ func (r *RemoteService) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if r.cluster.Spec.Internal && r.localAuth == "" {
-		req.Header.Del("Authorization")
+	if r.cluster.Spec.Internal {
+		if r.localAuth == "" {
+			req.Header.Del("Authorization")
+		}
 	} else {
 		userInfo, authed := request.UserFrom(req.Context())
 		if !authed {


### PR DESCRIPTION
This panic only affects local cluster in Rancher HA mode. We are using `rest.InClusterConfig` to get client config for HA mode which got a non-empty `BearerToken` and set `localAuth` [here](https://github.com/rancher/rancher/blob/release/v2.6/pkg/clusterrouter/proxy/proxy_server.go#L103). 

`getImpersonatorAccountToken` check is added for handle downstream cluster(https://github.com/rancher/rancher/commit/48f1e1ac3d23c3d8fc809f4af510114aa719d647), we need to skip it if cluster is local, or `clusterContextGetter` is nil for local [RemoteService](https://github.com/rancher/rancher/blob/release/v2.6/pkg/clusterrouter/proxy/proxy_server.go#L108)

For example, when I try API `/v3/project/local:p-ttkb2/workloads/deployment:cattle-system:rancher/yaml`, we will got panic errors below:
```
2022/01/27 01:48:15 [ERROR] Panic serving api request:
--
Thu, Jan 27 2022 9:48:15 am | goroutine 45395 [running]:
Thu, Jan 27 2022 9:48:15 am | runtime/debug.Stack(0xc001ece258, 0x3edfe60, 0x7308920)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/runtime/debug/stack.go:24 +0x9f
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/norman/api.(*Server).ServeHTTP.func1(0x4fa98b8, 0xc00c42df70)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/cnrancher/pandaria-norman@v0.0.0-20220125041607-6ae9f21f4d2e/api/server.go:179 +0x85
Thu, Jan 27 2022 9:48:15 am | panic(0x3edfe60, 0x7308920)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/runtime/panic.go:965 +0x1b9
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/clusterrouter/proxy.(*RemoteService).getImpersonatorAccountToken(0xc00906ab80, 0x4fbb588, 0xc008c3cf00, 0x4fbb588, 0xc008c3cf00, 0xc001ece601, 0x13)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/clusterrouter/proxy/proxy_server.go:286 +0x46
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/clusterrouter/proxy.(*RemoteService).ServeHTTP(0xc00906ab80, 0x4fa98b8, 0xc00c42df70, 0xc007664100)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/clusterrouter/proxy/proxy_server.go:236 +0x34c
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/clusterrouter.(*Router).ServeHTTP(0xc00104d920, 0x4fa98b8, 0xc00c42df70, 0xc007664100)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/clusterrouter/router.go:42 +0x14d
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/api/norman/customization/yaml.(*yamlLinkHandler).LinkHandler(0xc000b30900, 0xc007e84480, 0x0, 0xc0064bb0e0, 0xc00dddc680)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/api/norman/customization/yaml/link.go:65 +0x45b
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/norman/api/handler.ListHandler(0xc007e84480, 0x49a46d8, 0x0, 0x0)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/cnrancher/pandaria-norman@v0.0.0-20220125041607-6ae9f21f4d2e/api/handler/list.go:34 +0x182
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/norman/api.(*Server).handle(0xc0050c66c0, 0x4fa98b8, 0xc00c42df70, 0xc007664000, 0x40b86c, 0x43152c0, 0xc00c42df70)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/cnrancher/pandaria-norman@v0.0.0-20220125041607-6ae9f21f4d2e/api/server.go:253 +0x28c
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/norman/api.(*Server).ServeHTTP(0xc0050c66c0, 0x4fa98b8, 0xc00c42df70, 0xc007664000)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/cnrancher/pandaria-norman@v0.0.0-20220125041607-6ae9f21f4d2e/api/server.go:184 +0x7d
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/apiserver/pkg/middleware.ContentType.func1(0x4f98038, 0xc0064ba8a0, 0xc007664000)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/rancher/apiserver@v0.0.0-20211025232108-df28932a5627/pkg/middleware/content.go:33 +0x93
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc002af43c0, 0x4f98038, 0xc0064ba8a0, 0xc007664000)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/apiserver/pkg/middleware.Gzip.func1(0x4fa8b98, 0xc0091144a8, 0xc007664000)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/rancher/apiserver@v0.0.0-20211025232108-df28932a5627/pkg/middleware/gzip.go:60 +0x1e3
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc002af43d8, 0x4fa8b98, 0xc0091144a8, 0xc007664000)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/auth/requests.authHeaderHandler.ServeHTTP(0x4f3e5e0, 0xc002af43d8, 0x4fa8b98, 0xc0091144a8, 0xc007664000)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/auth/requests/filter.go:64 +0x93f
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/rbac.NewAccessControlHandler.func1.1(0x4fa8b98, 0xc0091144a8, 0xc002637f00)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/rbac/user_based.go:33 +0x1c7
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc00c431d40, 0x4fa8b98, 0xc0091144a8, 0xc002637f00)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/steve/pkg/auth.ToMiddleware.func1.1(0x4fa8b98, 0xc0091144a8, 0xc002637e00)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/cnrancher/steve@v0.0.0-20211203072619-15ea5fd0ee32/pkg/auth/filter.go:167 +0x1c7
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc0064ba780, 0x4fa8b98, 0xc0091144a8, 0xc002637e00)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | github.com/gorilla/mux.(*Router).ServeHTTP(0xc0050c6780, 0x4fa8b98, 0xc0091144a8, 0xc002637900)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0xd3
Thu, Jan 27 2022 9:48:15 am | github.com/gorilla/mux.(*Router).ServeHTTP(0xc0050c60c0, 0x4fa8b98, 0xc0091144a8, 0xc002637500)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0xd3
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/multiclustermanager.(*DeferredServer).Middleware.func1(0x4fa8b98, 0xc0091144a8, 0xc002637500)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/multiclustermanager/deferred.go:115 +0x9d
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc00107f8a0, 0x4fa8b98, 0xc0091144a8, 0xc002637500)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | github.com/gorilla/mux.(*Router).ServeHTTP(0xc00242e540, 0x4fa8b98, 0xc0091144a8, 0xc002637200)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0xd3
Thu, Jan 27 2022 9:48:15 am | github.com/gorilla/mux.(*Router).ServeHTTP(0xc00ce34c00, 0x4fa8b98, 0xc0091144a8, 0xc002636f00)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0xd3
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/api/steve/aggregation.(*aggregationHandler).Middleware.func1(0x4fa8b98, 0xc0091144a8, 0xc002636f00)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/api/steve/aggregation/aggregation.go:52 +0x6e
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc00107f8c0, 0x4fa8b98, 0xc0091144a8, 0xc002636f00)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | github.com/gorilla/mux.(*Router).ServeHTTP(0xc00242e480, 0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0xd3
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/api/steve/proxy.NewProxyMiddleware.func1.1(0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/api/steve/proxy/proxy.go:76 +0x65
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc00107f8e0, 0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/api/steve/proxy.RewriteLocalCluster.func1(0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/api/steve/proxy/proxy.go:43 +0xf2
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc0027f39b0, 0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/websocket.websocketHandler.ServeHTTP(0x4f3e5e0, 0xc0027f39b0, 0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/websocket/handler.go:35 +0xa2
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/apiserver/pkg/middleware.ContentTypeOptions.func1(0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/rancher/apiserver@v0.0.0-20211025232108-df28932a5627/pkg/middleware/cache.go:47 +0x131
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc0027f39c8, 0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/auth.SetXAPICattleAuthHeader.func1(0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/auth/server.go:180 +0x2ac
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc0027f39e0, 0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/multiclustermanager/grpc.(*Handler).ServeHTTP.func1(0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/multiclustermanager/grpc/handler.go:82 +0x162
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc009619d20, 0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | golang.org/x/net/http2/h2c.h2cHandler.ServeHTTP(0x4f3e5e0, 0xc009619d20, 0xc008c3cec0, 0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/golang.org/x/net@v0.0.0-20210913180222-943fd674d43e/http2/h2c/h2c.go:104 +0x44b
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/multiclustermanager/grpc.(*Handler).ServeHTTP(0xc008c3ce00, 0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/multiclustermanager/grpc/handler.go:84 +0xfd
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/multiclustermanager.(*DeferredServer).Grpc.func1(0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/multiclustermanager/deferred.go:153 +0xa5
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc00107f900, 0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/rancher/pkg/auth/audit.auditHandler.ServeHTTP(0x4f3e5e0, 0xc00107f900, 0x0, 0xc0017a9ea0, 0x4fa8b98, 0xc0091144a8, 0xc002636b00)
Thu, Jan 27 2022 9:48:15 am | /go/src/github.com/rancher/rancher/pkg/auth/audit/filter.go:57 +0x5cc
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/steve/pkg/auth.ToMiddleware.func1.1(0x4fa8b98, 0xc0091144a8, 0xc007280100)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/cnrancher/steve@v0.0.0-20211203072619-15ea5fd0ee32/pkg/auth/filter.go:167 +0x1c7
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc002291890, 0x4fa8b98, 0xc0091144a8, 0xc007280100)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | github.com/rancher/dynamiclistener.HTTPRedirect.func1(0x4fa8b98, 0xc0091144a8, 0xc007280100)
Thu, Jan 27 2022 9:48:15 am | /go/pkg/mod/github.com/rancher/dynamiclistener@v0.3.1-0.20211104200948-cd5d71f2fe95/redirect.go:20 +0xa4
Thu, Jan 27 2022 9:48:15 am | net/http.HandlerFunc.ServeHTTP(0xc005c7b008, 0x4fa8b98, 0xc0091144a8, 0xc007280100)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2049 +0x44
Thu, Jan 27 2022 9:48:15 am | net/http.serverHandler.ServeHTTP(0xc000a562a0, 0x4fa8b98, 0xc0091144a8, 0xc007280100)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:2867 +0xa3
Thu, Jan 27 2022 9:48:15 am | net/http.initALPNRequest.ServeHTTP(0x4fb84c0, 0xc009de03c0, 0xc006ed0700, 0xc000a562a0, 0x4fa8b98, 0xc0091144a8, 0xc007280100)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/server.go:3439 +0x8d
Thu, Jan 27 2022 9:48:15 am | net/http.(*http2serverConn).runHandler(0xc009d9e000, 0xc0091144a8, 0xc007280100, 0xc005911110)
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/h2_bundle.go:5732 +0x8b
Thu, Jan 27 2022 9:48:15 am | created by net/http.(*http2serverConn).processHeaders
Thu, Jan 27 2022 9:48:15 am | /usr/local/go/src/net/http/h2_bundle.go:5462 +0x505
```