### PR TITLE
Add JWT to k8s service proxy requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,6 +146,7 @@ require (
 	google.golang.org/grpc v1.40.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
+	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.7.1
 	k8s.io/api v0.22.3

--- a/pkg/clusterrouter/router.go
+++ b/pkg/clusterrouter/router.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/rancher/pkg/clusterrouter/proxy"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/jwt"
 	"github.com/rancher/rancher/pkg/types/config/dialer"
 	"k8s.io/client-go/rest"
 )
@@ -15,8 +16,8 @@ type Router struct {
 	serverFactory *factory
 }
 
-func New(localConfig *rest.Config, lookup ClusterLookup, dialer dialer.Factory, clusterLister v3.ClusterLister, clusterContextGetter proxy.ClusterContextGetter) http.Handler {
-	serverFactory := newFactory(localConfig, dialer, lookup, clusterLister, clusterContextGetter)
+func New(localConfig *rest.Config, lookup ClusterLookup, dialer dialer.Factory, clusterLister v3.ClusterLister, clusterContextGetter proxy.ClusterContextGetter, jwt *jwt.Signer) http.Handler {
+	serverFactory := newFactory(localConfig, dialer, lookup, clusterLister, clusterContextGetter, jwt)
 	return &Router{
 		serverFactory: serverFactory,
 	}

--- a/pkg/jwt/jwt.go
+++ b/pkg/jwt/jwt.go
@@ -1,0 +1,147 @@
+package jwt
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+	"github.com/rancher/dynamiclistener/cert"
+	namespaces "github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/settings"
+	"gopkg.in/square/go-jose.v2"
+	corev1 "k8s.io/api/core/v1"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const (
+	JWKeySecretName        = "cattle-jwt-key"
+	rsaKeySize             = 2048
+	rsaPrivateKeyBlockType = "RSA PRIVATE KEY"
+	jwksContentType        = "application/jwk-set+json"
+	headerCacheControl     = "Cache-Control"
+	headerContentType      = "Content-Type"
+	cacheControl           = "public, max-age=3600"
+)
+
+type Signer struct {
+	privateKey *rsa.PrivateKey
+	jwksBytes  []byte
+}
+
+func (s *Signer) ServeJWKS(resp http.ResponseWriter, req *http.Request) {
+	resp.Header().Set(headerContentType, jwksContentType)
+	resp.Header().Set(headerCacheControl, cacheControl)
+	resp.Write(s.jwksBytes)
+}
+
+func (s *Signer) SignUser(info user.Info, audience string) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"aud":    audience,
+		"exp":    time.Now().Add(time.Duration(settings.JWTProxyExpirationSeconds.GetInt()) * time.Second).Unix(),
+		"iat":    time.Now().Unix(),
+		"sub":    info.GetName(),
+		"iss":    "Rancher",
+		"groups": info.GetGroups(),
+		"extra":  info.GetExtra(),
+	})
+	return token.SignedString(s.privateKey)
+}
+
+func (s *Signer) newKey() ([]byte, error) {
+	key, err := rsa.GenerateKey(cryptorand.Reader, rsaKeySize)
+	if err != nil {
+		return nil, err
+	}
+
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  rsaPrivateKeyBlockType,
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}), nil
+}
+
+func (s *Signer) saveNewKey(ctx context.Context, secrets v1.SecretsGetter) (*corev1.Secret, error) {
+	privateKey, err := s.newKey()
+	if err != nil {
+		return nil, err
+	}
+	key, err := secrets.Secrets(namespaces.System).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      JWKeySecretName,
+			Namespace: namespaces.System,
+		},
+		Data: map[string][]byte{
+			"key": privateKey,
+		},
+	}, metav1.CreateOptions{})
+	if apierror.IsAlreadyExists(err) {
+		return secrets.Secrets(namespaces.System).Get(ctx, JWKeySecretName, metav1.GetOptions{})
+	}
+	return key, err
+}
+
+func (s *Signer) decodeKey(secret *corev1.Secret) error {
+	privateKey, err := cert.ParsePrivateKeyPEM(secret.Data["key"])
+	if err != nil {
+		return err
+	}
+	rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
+	if !ok {
+		return fmt.Errorf("key found in %s/%s is not a RSA private key", rsaPrivateKey)
+	}
+	s.privateKey = rsaPrivateKey
+	return nil
+}
+
+func New(ctx context.Context, secrets v1.SecretsGetter) (*Signer, error) {
+	s := &Signer{}
+	key, err := secrets.Secrets(namespaces.System).Get(ctx, JWKeySecretName, metav1.GetOptions{})
+	if apierror.IsNotFound(err) {
+		key, err = s.saveNewKey(ctx, secrets)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return s, s.decodeKey(key)
+}
+
+func (s *Signer) saveJWKS() error {
+	keyID, err := keyID(s.privateKey.PublicKey)
+	if err != nil {
+		return err
+	}
+
+	jwkBytes, err := json.Marshal(&jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{
+				Algorithm: string(jose.RS256),
+				Key:       s.privateKey.PublicKey,
+				KeyID:     keyID,
+				Use:       "sig",
+			},
+		},
+	})
+	s.jwksBytes = jwkBytes
+	return err
+}
+
+func keyID(publicKey rsa.PublicKey) (string, error) {
+	data, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		return "", err
+	}
+
+	hash := sha256.Sum256(data)
+	return base64.RawURLEncoding.EncodeToString(hash[:]), nil
+}

--- a/pkg/k8sproxy/k8s_proxy.go
+++ b/pkg/k8sproxy/k8s_proxy.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/rancher/rancher/pkg/clusterrouter"
 	"github.com/rancher/rancher/pkg/clusterrouter/proxy"
+	"github.com/rancher/rancher/pkg/jwt"
 	"github.com/rancher/rancher/pkg/k8slookup"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/types/config/dialer"
 )
 
-func New(scaledContext *config.ScaledContext, dialer dialer.Factory, clusterContextGetter proxy.ClusterContextGetter) http.Handler {
+func New(scaledContext *config.ScaledContext, dialer dialer.Factory, clusterContextGetter proxy.ClusterContextGetter, jwtSigner *jwt.Signer) http.Handler {
 	return clusterrouter.New(&scaledContext.RESTConfig, k8slookup.New(scaledContext, true), dialer,
 		scaledContext.Management.Clusters("").Controller().Lister(),
-		clusterContextGetter)
+		clusterContextGetter, jwtSigner)
 }

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -121,6 +121,7 @@ var (
 	HideLocalCluster                    = NewSetting("hide-local-cluster", "false")
 	MachineProvisionImage               = NewSetting("machine-provision-image", "rancher/machine:v0.15.0-rancher75")
 	SystemFeatureChartRefreshSeconds    = NewSetting("system-feature-chart-refresh-seconds", "900")
+	JWTProxyExpirationSeconds           = NewSetting("jwt-proxy-expiration-seconds", "300")
 
 	FleetMinVersion          = NewSetting("fleet-min-version", "")
 	RancherWebhookMinVersion = NewSetting("rancher-webhook-min-version", "")


### PR DESCRIPTION
Requests that go through /k8s/clusters/id URLs for service proxies will
now have a header X-Cattle-Auth-Jwt that will contain a signed JWT
of the current user.  This way k8s services can know who is logged into
Rancher.  Also the public key of the JWT will be available at the standard
/openid/v1/jwks URL.