### PR TITLE
[Backport] Fixing rbac fleet handler to handle group subjects

### DIFF
--- a/pkg/controllers/management/restrictedadminrbac/fleet.go
+++ b/pkg/controllers/management/restrictedadminrbac/fleet.go
@@ -54,14 +54,14 @@ func (r *rbaccontroller) ensureRestricedAdminForFleet(key string, obj *v3.Global
 		if fw.Name == "fleet-local" {
 			continue
 		}
-		if err := r.ensureRolebinding(fw.Name, obj.UserName, obj); err != nil {
+		if err := r.ensureRolebinding(fw.Name, rbac.GetGRBSubject(obj), obj); err != nil {
 			finalError = multierror.Append(finalError, err)
 		}
 	}
 	return obj, finalError
 }
 
-func (r *rbaccontroller) ensureRolebinding(namespace, userName string, grb *v3.GlobalRoleBinding) error {
+func (r *rbaccontroller) ensureRolebinding(namespace string, subject k8srbac.Subject, grb *v3.GlobalRoleBinding) error {
 	rbName := fmt.Sprintf("%s-fleetworkspace-%s", grb.Name, rbac.RestrictedAdminClusterRoleBinding)
 	rb := &k8srbac.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -82,10 +82,7 @@ func (r *rbaccontroller) ensureRolebinding(namespace, userName string, grb *v3.G
 			Kind: "ClusterRole",
 		},
 		Subjects: []k8srbac.Subject{
-			{
-				Kind: "User",
-				Name: userName,
-			},
+			subject,
 		},
 	}
 	_, err := r.rbLister.Get(namespace, rbName)


### PR DESCRIPTION
Changing the rbac fleet handler to properly parse the subject
from the grb rather than assuming a user subject