### PR TITLE
Ec2 node library and custom cluster tests

### DIFF
--- a/tests/framework/clients/ec2/client.go
+++ b/tests/framework/clients/ec2/client.go
@@ -1,0 +1,38 @@
+package ec2
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+)
+
+type EC2Client struct {
+	SVC    *ec2.EC2
+	Config *AWSEC2Config
+}
+
+// NewEC2Client is a constructor that creates an *EC2Client which a wrapper for an "github.com/aws/aws-sdk-go/service/ec2" session and
+// the aws ec2 confit.
+func NewEC2Client() (*EC2Client, error) {
+	awsEC2Config := new(AWSEC2Config)
+
+	config.LoadConfig(ConfigurationFileKey, awsEC2Config)
+
+	credential := credentials.NewStaticCredentials(awsEC2Config.AWSAccessKeyID, awsEC2Config.AWSSecretAccessKey, "")
+	sess, err := session.NewSession(&aws.Config{
+		Credentials: credential,
+		Region:      aws.String(awsEC2Config.Region)},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create EC2 service client
+	svc := ec2.New(sess)
+	return &EC2Client{
+		SVC:    svc,
+		Config: awsEC2Config,
+	}, nil
+}

--- a/tests/framework/clients/ec2/config.go
+++ b/tests/framework/clients/ec2/config.go
@@ -1,0 +1,18 @@
+package ec2
+
+const ConfigurationFileKey = "awsEC2Config"
+
+type AWSEC2Config struct {
+	Region             string   `json:"region" yaml:"region"`
+	InstanceType       string   `json:"instanceType" yaml:"instanceType"`
+	AWSRegionAZ        string   `json:"awsRegionAZ" yaml:"awsRegionAZ"`
+	AWSAMI             string   `json:"awsAMI" yaml:"awsAMI"`
+	AWSSecurityGroups  []string `json:"awsSecurityGroups" yaml:"awsSecurityGroups"`
+	AWSAccessKeyID     string   `json:"awsAccessKeyID" yaml:"awsAccessKeyID"`
+	AWSSecretAccessKey string   `json:"awsSecretAccessKey" yaml:"awsSecretAccessKey"`
+	AWSSSHKeyName      string   `json:"awsSSHKeyName" yaml:"awsSSHKeyName"`
+	AWSCICDInstanceTag string   `json:"awsCICDInstanceTag" yaml:"awsCICDInstanceTag"`
+	AWSIAMProfile      string   `json:"awsIAMProfile" yaml:"awsIAMProfile"`
+	AWSUser            string   `json:"awsUser" yaml:"awsUser"`
+	VolumeSize         int      `json:"volumeSize" yaml:"volumeSize"`
+}

--- a/tests/framework/clients/rancher/client.go
+++ b/tests/framework/clients/rancher/client.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	frameworkDynamic "github.com/rancher/rancher/tests/framework/clients/dynamic"
+	"github.com/rancher/rancher/tests/framework/clients/ec2"
 	"github.com/rancher/rancher/tests/framework/clients/rancher/catalog"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/clients/rancher/provisioning"
@@ -150,6 +151,10 @@ func (c *Client) GetDownStreamClusterClient(clusterName string) (dynamic.Interfa
 		return nil, err
 	}
 	return dynamic, nil
+}
+
+func (c *Client) GetEC2Client() (*ec2.EC2Client, error) {
+	return ec2.NewEC2Client()
 }
 
 // GetManagementWatchInterface is a functions used to get a watch.Interface from a resource created by the Management Client.

--- a/tests/framework/extensions/nodes/ec2/ec2.go
+++ b/tests/framework/extensions/nodes/ec2/ec2.go
@@ -1,0 +1,151 @@
+package ec2
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
+)
+
+const (
+	nodeBaseName = "rancherautomation"
+)
+
+// CreatedNodes creates `numOfInstances` number of ec2 instances
+func CreateNodes(client *rancher.Client, numOfInstances int) ([]*nodes.Node, error) {
+	ec2Client, err := client.GetEC2Client()
+	if err != nil {
+		return nil, err
+	}
+
+	sshName := getSSHKeyName(ec2Client.Config.AWSSSHKeyName)
+
+	runInstancesInput := &ec2.RunInstancesInput{
+		ImageId:      aws.String(ec2Client.Config.AWSAMI),
+		InstanceType: aws.String(ec2Client.Config.InstanceType),
+		MinCount:     aws.Int64(int64(numOfInstances)),
+		MaxCount:     aws.Int64(int64(numOfInstances)),
+		KeyName:      aws.String(sshName),
+		BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+			{
+				DeviceName: aws.String("/dev/sda1"),
+				Ebs: &ec2.EbsBlockDevice{
+					VolumeSize: aws.Int64(int64(ec2Client.Config.VolumeSize)),
+				},
+			},
+		},
+		IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
+			Name: aws.String(ec2Client.Config.AWSIAMProfile),
+		},
+		Placement: &ec2.Placement{
+			AvailabilityZone: aws.String(ec2Client.Config.AWSRegionAZ),
+		},
+		NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
+			{
+				DeviceIndex:              aws.Int64(0),
+				AssociatePublicIpAddress: aws.Bool(true),
+				Groups:                   aws.StringSlice(ec2Client.Config.AWSSecurityGroups),
+			},
+		},
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("instance"),
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String(nodeBaseName),
+					},
+					{
+						Key:   aws.String("CICD"),
+						Value: aws.String(ec2Client.Config.AWSCICDInstanceTag),
+					},
+				},
+			},
+		},
+	}
+
+	reservation, err := ec2Client.SVC.RunInstances(runInstancesInput)
+	if err != nil {
+		return nil, err
+	}
+
+	var listOfInstanceIds []*string
+
+	for _, instance := range reservation.Instances {
+		listOfInstanceIds = append(listOfInstanceIds, instance.InstanceId)
+	}
+
+	//wait until instance is running
+	err = ec2Client.SVC.WaitUntilInstanceRunning(&ec2.DescribeInstancesInput{
+		InstanceIds: listOfInstanceIds,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	//wait until instance status is ok
+	err = ec2Client.SVC.WaitUntilInstanceStatusOk(&ec2.DescribeInstanceStatusInput{
+		InstanceIds: listOfInstanceIds,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// describe instance to get attributes=
+	describe, err := ec2Client.SVC.DescribeInstances(&ec2.DescribeInstancesInput{
+		InstanceIds: listOfInstanceIds,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	readyInstances := describe.Reservations[0].Instances
+
+	sshKey, err := nodes.GetSSHKey(ec2Client.Config.AWSSSHKeyName)
+	if err != nil {
+		return nil, err
+	}
+
+	var ec2Nodes []*nodes.Node
+
+	for _, readyInstance := range readyInstances {
+		ec2Node := &nodes.Node{
+			NodeID:          *readyInstance.InstanceId,
+			PublicIPAddress: *readyInstance.PublicIpAddress,
+			SSHUser:         ec2Client.Config.AWSUser,
+			SSHKey:          sshKey,
+		}
+		ec2Nodes = append(ec2Nodes, ec2Node)
+	}
+
+	client.Session.RegisterCleanupFunc(func() error {
+		return DeleteNodes(client, ec2Nodes)
+	})
+
+	return ec2Nodes, nil
+}
+
+// DeleteNodes terminates ec2 instances that have been created.
+func DeleteNodes(client *rancher.Client, nodes []*nodes.Node) error {
+	ec2Client, err := client.GetEC2Client()
+	if err != nil {
+		return err
+	}
+	var instanceIDs []*string
+
+	for _, node := range nodes {
+		instanceIDs = append(instanceIDs, aws.String(node.NodeID))
+	}
+
+	_, err = ec2Client.SVC.TerminateInstances(&ec2.TerminateInstancesInput{
+		InstanceIds: instanceIDs,
+	})
+	return err
+}
+
+func getSSHKeyName(sshKeyName string) string {
+	stringSlice := strings.Split(sshKeyName, ".")
+	return stringSlice[0]
+}

--- a/tests/framework/extensions/tokenregistration/tokenregistration.go
+++ b/tests/framework/extensions/tokenregistration/tokenregistration.go
@@ -1,0 +1,39 @@
+package tokenregistration
+
+import (
+	"time"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+// GetTokenRegistration is function thatm gets a specific ClusterRegistrationToken using a Client object with a specified clusterStatusName and token name.
+// It is done using a poll wait to make sure the tokens have been created by rancher.
+func GetRegistrationToken(client *rancher.Client, clusterId string) (*management.ClusterRegistrationToken, error) {
+	var clusterRegistrationTokens []management.ClusterRegistrationToken
+
+	kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
+		collection, err := client.Management.ClusterRegistrationToken.List(&types.ListOpts{
+			Filters: map[string]interface{}{
+				"clusterId": clusterId,
+			},
+		})
+
+		if err != nil {
+			return false, err
+		}
+
+		if len(collection.Data) == 0 {
+			return false, err
+		}
+
+		clusterRegistrationTokens = collection.Data
+		return true, nil
+	})
+
+	registrationToken := clusterRegistrationTokens[0]
+
+	return &registrationToken, nil
+}

--- a/tests/framework/pkg/nodes/nodes.go
+++ b/tests/framework/pkg/nodes/nodes.go
@@ -1,0 +1,70 @@
+package nodes
+
+import (
+	"io/ioutil"
+	"os/user"
+	"path/filepath"
+
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	ExternalNodeConfigConfigurationFileKey = "externalNodes"
+	sshPath                                = ".ssh"
+)
+
+type Node struct {
+	NodeID          string `json:"nodeID" yaml:"nodeID"`
+	PublicIPAddress string `json:"publicIPAddress" yaml:"publicIPAddress"`
+	SSHUser         string `json:"sshUser" yaml:"sshUser"`
+	SSHKeyName      string `json:"sshKeyName" yaml:"sshKeyName"`
+	SSHKey          []byte
+}
+
+type ExternalNodeConfig struct {
+	Nodes map[int][]*Node `json:"nodes" yaml:"nodes"`
+}
+
+// ExecuteCommand executes `command` in the specific node created.
+func (n *Node) ExecuteCommand(command string) error {
+	signer, err := ssh.ParsePrivateKey(n.SSHKey)
+	if err != nil {
+		return err
+	}
+
+	auths := []ssh.AuthMethod{ssh.PublicKeys([]ssh.Signer{signer}...)}
+
+	cfg := &ssh.ClientConfig{
+		User:            n.SSHUser,
+		Auth:            auths,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	cfg.SetDefaults()
+
+	client, err := ssh.Dial("tcp", n.PublicIPAddress+":22", cfg)
+	if err != nil {
+		return err
+	}
+
+	session, err := client.NewSession()
+	if err != nil {
+		return err
+	}
+
+	return session.Run(command)
+}
+
+func GetSSHKey(sshKeyname string) ([]byte, error) {
+	user, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+
+	keyPath := filepath.Join(user.HomeDir, sshPath, sshKeyname)
+	content, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return content, nil
+}

--- a/tests/v2/validation/provisioning/config.go
+++ b/tests/v2/validation/provisioning/config.go
@@ -4,17 +4,30 @@ import (
 	"strings"
 
 	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 )
 
-const ConfigurationFileKey = "provisioningInput"
+const (
+	namespace               = "fleet-default"
+	defaultRandStringLength = 5
+	ConfigurationFileKey    = "provisioningInput"
+)
 
 type Config struct {
 	NodesAndRoles      string   `json:"nodesAndRoles" yaml:"nodesAndRoles" default:""`
 	KubernetesVersions []string `json:"kubernetesVersion" yaml:"kubernetesVersion"`
 	CNIs               []string `json:"cni" yaml:"cni"`
 	Providers          []string `json:"providers" yaml:"providers"`
+	NodeProviders      []string `json:"nodeProviders" yaml:"nodeProviders"`
 }
 
+func AppendRandomString(baseClusterName string) string {
+	clusterName := "auto-" + baseClusterName + "-" + namegenerator.RandStringLower(defaultRandStringLength)
+	return clusterName
+}
+
+// NodesAndRolesInput is a helper function that reads the nodesAndRoles entry in the config file and returns it in the form
+// of a list of map[string]bool
 func NodesAndRolesInput() []map[string]bool {
 	clustersConfig := new(Config)
 

--- a/tests/v2/validation/provisioning/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/custom_cluster_test.go
@@ -1,0 +1,245 @@
+package provisioning
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/tokenregistration"
+	"github.com/rancher/rancher/tests/framework/extensions/users"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type CustomClusterProvisioningTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	session            *session.Session
+	standardUserClient *rancher.Client
+	kubernetesVersions []string
+	cnis               []string
+	nodeProviders      []string
+}
+
+func (c *CustomClusterProvisioningTestSuite) TearDownSuite() {
+	c.session.Cleanup()
+}
+
+func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
+	testSession := session.NewSession(c.T())
+	c.session = testSession
+
+	clustersConfig := new(Config)
+	config.LoadConfig(ConfigurationFileKey, clustersConfig)
+
+	c.kubernetesVersions = clustersConfig.KubernetesVersions
+	c.cnis = clustersConfig.CNIs
+	c.nodeProviders = clustersConfig.NodeProviders
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(c.T(), err)
+
+	c.client = client
+
+	enabled := true
+	var testuser = AppendRandomString("testuser-")
+	user := &management.User{
+		Username: testuser,
+		Password: "rancherrancher123!",
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(c.T(), err)
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(c.T(), err)
+
+	c.standardUserClient = standardUserClient
+}
+
+func (c *CustomClusterProvisioningTestSuite) Provisioning_RKE2CustomCluster(externalNodeProvider ExternalNodeProvider) {
+	nodeRoles0 := []string{
+		"--etcd --controlplane --worker",
+	}
+
+	nodeRoles1 := []string{
+		"--etcd",
+		"--controlplane",
+		"--worker",
+	}
+
+	tests := []struct {
+		name      string
+		nodeRoles []string
+		client    *rancher.Client
+	}{
+		{"1 Node all roles Admin User", nodeRoles0, c.client},
+		{"1 Node all roles Standard User", nodeRoles0, c.standardUserClient},
+		{"3 nodes - 1 role per node Admin User", nodeRoles1, c.client},
+		{"3 nodes - 1 role per node Standard User", nodeRoles1, c.standardUserClient},
+	}
+	var name string
+	for _, tt := range tests {
+		for _, kubeVersion := range c.kubernetesVersions {
+			name = tt.name + " Kubernetes version: " + kubeVersion
+			for _, cni := range c.cnis {
+				name += " cni: " + cni
+				c.Run(name, func() {
+					testSession := session.NewSession(c.T())
+					defer testSession.Cleanup()
+
+					client, err := c.client.WithSession(testSession)
+					require.NoError(c.T(), err)
+
+					numNodes := len(tt.nodeRoles)
+					nodes, err := externalNodeProvider.NodeCreationFunc(client, numNodes)
+					require.NoError(c.T(), err)
+
+					clusterName := AppendRandomString(externalNodeProvider.Name)
+
+					cluster := clusters.NewRKE2ClusterConfig(clusterName, namespace, cni, "", kubeVersion, nil)
+
+					clusterResp, err := clusters.CreateRKE2Cluster(client, cluster)
+					require.NoError(c.T(), err)
+
+					customCluster, err := client.Provisioning.Clusters(namespace).Get(context.TODO(), clusterResp.Name, metav1.GetOptions{})
+					require.NoError(c.T(), err)
+
+					token, err := tokenregistration.GetRegistrationToken(client, customCluster.Status.ClusterName)
+					require.NoError(c.T(), err)
+
+					for key, node := range nodes {
+						c.T().Logf("Execute Registration Command for node %s", node.NodeID)
+						command := fmt.Sprintf("%s %s", token.InsecureNodeCommand, tt.nodeRoles[key])
+
+						err = node.ExecuteCommand(command)
+						require.NoError(c.T(), err)
+					}
+
+					result, err := client.Provisioning.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+						FieldSelector:  "metadata.name=" + clusterName,
+						TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+					})
+					require.NoError(c.T(), err)
+
+					checkFunc := clusters.IsProvisioningClusterReady
+
+					err = wait.WatchWait(result, checkFunc)
+					assert.NoError(c.T(), err)
+					assert.Equal(c.T(), clusterName, clusterResp.Name)
+				})
+			}
+		}
+	}
+}
+
+func (c *CustomClusterProvisioningTestSuite) Provisioning_RKE2CustomClusterDynamicInput(externalNodeProvider ExternalNodeProvider, nodesAndRoles []map[string]bool) {
+	rolesPerNode := []string{}
+
+	for _, nodes := range nodesAndRoles {
+		var finalRoleCommand string
+		for role := range nodes {
+			finalRoleCommand += fmt.Sprintf(" --%s", role)
+		}
+		rolesPerNode = append(rolesPerNode, finalRoleCommand)
+	}
+
+	numOfNodes := len(rolesPerNode)
+
+	tests := []struct {
+		name   string
+		client *rancher.Client
+	}{
+		{"Admin User", c.client},
+		{"Standard User", c.standardUserClient},
+	}
+
+	var name string
+	for _, tt := range tests {
+		for _, kubeVersion := range c.kubernetesVersions {
+			name = tt.name + " Kubernetes version: " + kubeVersion
+			for _, cni := range c.cnis {
+				name += " cni: " + cni
+				c.Run(name, func() {
+					testSession := session.NewSession(c.T())
+					defer testSession.Cleanup()
+
+					client, err := c.client.WithSession(testSession)
+					require.NoError(c.T(), err)
+
+					nodes, err := externalNodeProvider.NodeCreationFunc(client, numOfNodes)
+					require.NoError(c.T(), err)
+
+					clusterName := AppendRandomString(externalNodeProvider.Name)
+
+					cluster := clusters.NewRKE2ClusterConfig(clusterName, namespace, cni, "", kubeVersion, nil)
+
+					clusterResp, err := clusters.CreateRKE2Cluster(client, cluster)
+					require.NoError(c.T(), err)
+
+					customCluster, err := client.Provisioning.Clusters(namespace).Get(context.TODO(), clusterResp.Name, metav1.GetOptions{})
+					require.NoError(c.T(), err)
+
+					token, err := tokenregistration.GetRegistrationToken(client, customCluster.Status.ClusterName)
+					require.NoError(c.T(), err)
+
+					for key, node := range nodes {
+						c.T().Logf("Execute Registration Command for node %s", node.NodeID)
+						command := fmt.Sprintf("%s %s", token.InsecureNodeCommand, rolesPerNode[key])
+
+						err = node.ExecuteCommand(command)
+						require.NoError(c.T(), err)
+					}
+
+					result, err := client.Provisioning.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+						FieldSelector:  "metadata.name=" + clusterName,
+						TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+					})
+					require.NoError(c.T(), err)
+
+					checkFunc := clusters.IsProvisioningClusterReady
+
+					err = wait.WatchWait(result, checkFunc)
+					assert.NoError(c.T(), err)
+					assert.Equal(c.T(), clusterName, clusterResp.Name)
+				})
+			}
+		}
+	}
+}
+
+func (c *CustomClusterProvisioningTestSuite) TestProvisioningCustomCluster() {
+	for _, nodeProviderName := range c.nodeProviders {
+		externalNodeProvider := ExternalNodeProviderSetup(nodeProviderName)
+		c.Provisioning_RKE2CustomCluster(externalNodeProvider)
+	}
+}
+
+func (c *CustomClusterProvisioningTestSuite) TestProvisioningCustomClusterDynamicInput() {
+	nodesAndRoles := NodesAndRolesInput()
+	if len(nodesAndRoles) == 0 {
+		c.T().Skip()
+	}
+
+	for _, nodeProviderName := range c.nodeProviders {
+		externalNodeProvider := ExternalNodeProviderSetup(nodeProviderName)
+		c.Provisioning_RKE2CustomClusterDynamicInput(externalNodeProvider, nodesAndRoles)
+	}
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestCustomClusterProvisioningTestSuite(t *testing.T) {
+	suite.Run(t, new(CustomClusterProvisioningTestSuite))
+}

--- a/tests/v2/validation/provisioning/nodeproviders.go
+++ b/tests/v2/validation/provisioning/nodeproviders.go
@@ -1,0 +1,56 @@
+package provisioning
+
+import (
+	"fmt"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/nodes/ec2"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
+)
+
+const (
+	ec2NodeProviderName = "ec2"
+	fromConfig          = "config"
+)
+
+type NodeCreationFunc func(client *rancher.Client, numOfInstances int) ([]*nodes.Node, error)
+
+type ExternalNodeProvider struct {
+	Name             string
+	NodeCreationFunc NodeCreationFunc
+}
+
+// ExternalNodeProviderSetup is a helper function that setups an ExternalNodeProvider object is a wrapper
+// for the specific outside node provider node creator function
+func ExternalNodeProviderSetup(providerType string) ExternalNodeProvider {
+	switch providerType {
+	case ec2NodeProviderName:
+		return ExternalNodeProvider{
+			Name:             providerType,
+			NodeCreationFunc: ec2.CreateNodes,
+		}
+	case fromConfig:
+		return ExternalNodeProvider{
+			Name: providerType,
+			NodeCreationFunc: func(client *rancher.Client, numOfInstances int) ([]*nodes.Node, error) {
+				var nodeConfig nodes.ExternalNodeConfig
+				config.LoadConfig(nodes.ExternalNodeConfigConfigurationFileKey, &nodeConfig)
+
+				nodesList := nodeConfig.Nodes[numOfInstances]
+				for _, node := range nodesList {
+					sshKey, err := nodes.GetSSHKey(node.SSHKeyName)
+					if err != nil {
+						return nil, err
+					}
+
+					node.SSHKey = sshKey
+				}
+				return nodesList, nil
+			},
+		}
+	default:
+		panic(fmt.Sprintf("Node Provider:%v not found", providerType))
+	}
+
+}

--- a/tests/v2/validation/provisioning/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/provisioning_node_driver_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
-	"github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
@@ -29,16 +28,6 @@ type RKE2NodeDriverProvisioningTestSuite struct {
 	kubernetesVersions []string
 	cnis               []string
 	providers          []string
-}
-
-const (
-	namespace               = "fleet-default"
-	defaultRandStringLength = 5
-)
-
-func AppendRandomString(baseClusterName string) string {
-	clusterName := "auto-" + baseClusterName + "-" + namegenerator.RandStringLower(5)
-	return clusterName
 }
 
 func (r *RKE2NodeDriverProvisioningTestSuite) TearDownSuite() {
@@ -80,7 +69,6 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 }
 
 func (r *RKE2NodeDriverProvisioningTestSuite) Provisioning_RKE2Cluster(provider Provider) {
-
 	subSession := r.session.NewSession()
 	defer subSession.Cleanup()
 
@@ -173,7 +161,6 @@ func (r *RKE2NodeDriverProvisioningTestSuite) Provisioning_RKE2Cluster(provider 
 }
 
 func (r *RKE2NodeDriverProvisioningTestSuite) Provisioning_RKE2ClusterDynamicInput(provider Provider, nodesAndRoles []map[string]bool) {
-
 	subSession := r.session.NewSession()
 	defer subSession.Cleanup()
 
@@ -237,9 +224,9 @@ func (r *RKE2NodeDriverProvisioningTestSuite) Provisioning_RKE2ClusterDynamicInp
 }
 
 func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioning() {
-	for provider_name := range r.providers {
-		provider_struct := CreateProvider(r.providers[provider_name])
-		r.Provisioning_RKE2Cluster(provider_struct)
+	for _, providerName := range r.providers {
+		provider := CreateProvider(providerName)
+		r.Provisioning_RKE2Cluster(provider)
 	}
 }
 
@@ -249,9 +236,9 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningDynamicInput() {
 		r.T().Skip()
 	}
 
-	for provider_name := range r.providers {
-		provider_struct := CreateProvider(r.providers[provider_name])
-		r.Provisioning_RKE2ClusterDynamicInput(provider_struct, nodesAndRoles)
+	for _, providerName := range r.providers {
+		provider := CreateProvider(providerName)
+		r.Provisioning_RKE2ClusterDynamicInput(provider, nodesAndRoles)
 	}
 }
 


### PR DESCRIPTION
**Framework updates:**
- EC2 client for the aforementioned creation/deletion of nodes.
- EC2 extension for creating and deleting nodes
- Node library to be used by any provider. Including reading from a config for an already existing external node setup.
- Cluster token registration extension to facilitate getting the registration token

**Validation Tests:**
- Custom cluster tests that are not just dependent ec2 node provider.
- Helpers in the v2/validation/provisioning directory to setup the different kind of node providers. Currently only support EC2 and already existing node configuration information in the config file.