### PR TITLE
Adding support for tolerations

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -49,11 +49,14 @@ Windows cluster will add default taint for linux nodes,
 add below linux tolerations to workloads could be scheduled to those linux nodes
 */}}
 
-{{- define "linux-node-tolerations" -}}
+{{- define "rancher-tolerations" -}}
 - key: "cattle.io/os"
   value: "linux"
   effect: "NoSchedule"
   operator: "Equal"
+{{ if gt (len .Values.tolerations) 0 -}}
+  {{- toYaml .Values.tolerations -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "linux-node-selector-terms" -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms: {{ include "linux-node-selector-terms" . | nindent 14 }}
-      tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
+      tolerations: {{- include "rancher-tolerations" . | trim | nindent 8 }}
       containers:
       - image: {{ .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.rancherImagePullPolicy }}

--- a/chart/templates/post-delete-hook-job.yaml
+++ b/chart/templates/post-delete-hook-job.yaml
@@ -18,6 +18,7 @@ spec:
     spec:
       serviceAccountName: {{ template "rancher.fullname" . }}-post-delete
       restartPolicy: OnFailure
+      tolerations: {{- include "rancher-tolerations" . | trim | nindent 8 }}
       containers:
         - name: {{ template "rancher.name" . }}-post-delete
           image: "{{ include "system_default_registry" . }}{{ .Values.postDelete.image.repository }}:{{ .Values.postDelete.image.tag }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -93,6 +93,9 @@ rancherImage: rancher/rancher
 # rancher/rancher image tag. https://hub.docker.com/r/rancher/rancher/tags/
 # Defaults to .Chart.appVersion
 # rancherImageTag: v2.0.7
+tolerations: []
+# Additional tolerations for the rancher deployment
+# See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ for more info on taints/tolerations
 
 # Override imagePullPolicy for rancher server images
 # options: Always, Never, IfNotPresent

--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -98,6 +98,13 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 
 	gitjobChartValues := make(map[string]interface{})
 
+	rancherTolerations := settings.GetFormattedRancherTolerations()
+	if len(rancherTolerations) > 0 {
+		// if we have tolerations on the rancher deployment, persist them to fleet as well
+		gitjobChartValues["tolerations"] = rancherTolerations
+		fleetChartValues["tolerations"] = rancherTolerations
+	}
+
 	if envVal, ok := os.LookupEnv("HTTP_PROXY"); ok {
 		fleetChartValues["proxy"] = envVal
 		gitjobChartValues["proxy"] = envVal

--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -24,7 +24,7 @@ var (
 			ChartName:         "rancher-webhook",
 			MinVersionSetting: settings.RancherWebhookMinVersion,
 			Values: func() map[string]interface{} {
-				return map[string]interface{}{
+				values := map[string]interface{}{
 					"capi": map[string]interface{}{
 						"enabled": features.EmbeddedClusterAPI.Enabled(),
 					},
@@ -32,6 +32,11 @@ var (
 						"enabled": features.MCM.Enabled(),
 					},
 				}
+				rancherTolerations := settings.GetFormattedRancherTolerations()
+				if len(rancherTolerations) > 0 {
+					values["tolerations"] = rancherTolerations
+				}
+				return values
 			},
 			Enabled: func() bool {
 				return features.MCM.Enabled() || features.EmbeddedClusterAPI.Enabled()

--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -281,6 +281,7 @@ func (c *ClusterLifecycleCleanup) createCleanupJob(userContext *config.UserConte
 			Template: coreV1.PodTemplateSpec{
 				Spec: coreV1.PodSpec{
 					ServiceAccountName: sa,
+					Tolerations:        settings.GetRancherTolerations(),
 					Containers: []coreV1.Container{
 						coreV1.Container{
 							Name:  "cleanup-agent",


### PR DESCRIPTION
Adds option to specify tolerations in the helm chart, and
configures ranchers to use these tolerations in other components
such as fleet/webhook that it deploys