### PR TITLE
Disallow deleting cloud credential referenced by provisioning cluster

### DIFF
--- a/pkg/api/norman/server/managementstored/setup.go
+++ b/pkg/api/norman/server/managementstored/setup.go
@@ -472,7 +472,9 @@ func SecretTypes(ctx context.Context, schemas *types.Schemas, management *config
 	credSchema := schemas.Schema(&managementschema.Version, client.CloudCredentialType)
 	credSchema.Store = cred.Wrap(mgmtSecretSchema.Store,
 		management.Core.Namespaces(""),
-		management.Management.NodeTemplates("").Controller().Lister())
+		management.Management.NodeTemplates("").Controller().Lister(),
+		management.Wrangler.Provisioning.Cluster().Cache(),
+	)
 	credSchema.Validator = cred.Validator
 }
 


### PR DESCRIPTION
Currently, it is possible to delete a cloud credential if it is referenced by a
provisioning cluster. This causes issues if a user wants to add or delete nodes
after the cloud credential is gone.

After this change, Rancher will prevent a user from deleting a cloud credential
if it is referenced by a provisioning cluster.

Issue:
https://github.com/rancher/rancher/issues/36294