### PR TITLE
Allow node driver download in air-gapped environments

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -79,10 +79,13 @@ RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACH
     curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin && \
     curl -LO https://github.com/linode/docker-machine-driver-linode/releases/download/${DOCKER_MACHINE_LINODE_VERSION}/docker-machine-driver-linode_linux-amd64.zip && \
     unzip docker-machine-driver-linode_linux-amd64.zip -d /opt/drivers/management-state/bin && \
+    mkdir -p /usr/share/rancher/ui/assets/ && \
+    cp /opt/drivers/management-state/bin/docker-machine-driver-linode /usr/share/rancher/ui/assets/ && \
     rm docker-machine-driver-linode_linux-amd64.zip
 
 RUN curl -LO https://releases.rancher.com/harvester-node-driver/${DOCKER_MACHINE_HARVESTER_VERSION}/docker-machine-driver-harvester-amd64.tar.gz && \
     tar -xf docker-machine-driver-harvester-amd64.tar.gz -C /opt/drivers/management-state/bin && \
+    cp /opt/drivers/management-state/bin/docker-machine-driver-harvester /usr/share/rancher/ui/assets/ && \
     rm docker-machine-driver-harvester-amd64.tar.gz
 
 ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \

--- a/pkg/controllers/management/drivers/dynamic_driver.go
+++ b/pkg/controllers/management/drivers/dynamic_driver.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/sirupsen/logrus"
 )
 
@@ -38,6 +39,18 @@ func (d *DynamicDriver) Install() error {
 		return nil
 	}
 
+	if err := d.copyTo(d.binName()); err != nil {
+		return err
+	}
+
+	if os.Getenv("CATTLE_DEV_MODE") != "" {
+		return nil
+	}
+
+	return d.copyTo(fmt.Sprintf("%s/assets/%s", settings.UIPath.Get(), d.DriverName))
+}
+
+func (d *BaseDriver) copyTo(dest string) error {
 	binaryPath := d.binName()
 	tmpPath := binaryPath + "-tmp"
 	f, err := os.OpenFile(tmpPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
@@ -58,10 +71,11 @@ func (d *DynamicDriver) Install() error {
 		return errors.Wrapf(err, "Couldn't copy %v to %v", d.srcBinName(), tmpPath)
 	}
 
-	err = os.Rename(tmpPath, binaryPath)
+	err = os.Rename(tmpPath, dest)
 	if err != nil {
-		return errors.Wrapf(err, "Couldn't copy driver %v to %v", d.Name(), binaryPath)
+		return errors.Wrapf(err, "Couldn't copy driver %v to %v", d.Name(), dest)
 	}
+
 	return nil
 }
 

--- a/pkg/provisioningv2/rke2/installer/installer.go
+++ b/pkg/provisioningv2/rke2/installer/installer.go
@@ -22,7 +22,7 @@ const (
 
 var (
 	localAgentInstallScripts = []string{
-		"/usr/share/rancher/ui/assets" + SystemAgentInstallPath,
+		settings.UIPath.Get() + "/assets" + SystemAgentInstallPath,
 		"." + SystemAgentInstallPath,
 	}
 	localWindowsRke2InstallScripts = []string{


### PR DESCRIPTION
The harvester node driver is bundled in Rancher in order to provide support for
air-gapped installs of Rancher to provision Harvester clusters. However, the
download URL passed to the create job was still the external URL. This wouldn't
allow Harvester clusters to be created in air-gapped environments.

After this change, any enabled node driver will be copied to the appropriate
location so that the create job can download it directly from Rancher.

Issue:
https://github.com/rancher/rancher/issues/36488