### PR TITLE
Wait for commands spawned by Rancher

### DIFF
--- a/pkg/controllers/management/drivers/dynamic_driver.go
+++ b/pkg/controllers/management/drivers/dynamic_driver.go
@@ -80,9 +80,13 @@ func (d *BaseDriver) Executable() error {
 	if err != nil {
 		return fmt.Errorf("Driver %s not found", binaryPath)
 	}
-	err = exec.Command(binaryPath).Start()
+	cmd := exec.Command(binaryPath)
+	err = cmd.Start()
 	if err != nil {
 		return errors.Wrapf(err, "Driver binary %s couldn't execute", binaryPath)
 	}
+
+	// We don't care about the exit code, just want to make sure we can execute the binary
+	_ = cmd.Wait()
 	return nil
 }

--- a/pkg/kontainer-engine/service/service.go
+++ b/pkg/kontainer-engine/service/service.go
@@ -392,6 +392,7 @@ type RunningDriver struct {
 
 	listenAddress string
 	cancel        context.CancelFunc
+	cmd           *exec.Cmd
 }
 
 func (r *RunningDriver) Start() (string, error) {
@@ -458,6 +459,7 @@ func (r *RunningDriver) Start() (string, error) {
 		time.Sleep(5 * time.Second)
 
 		r.listenAddress = listenAddress
+		r.cmd = cmd
 	}
 
 	logrus.Infof("kontainerdriver %v listening on address %v", r.Name, r.listenAddress)
@@ -491,6 +493,11 @@ func (r *RunningDriver) Stop() {
 		r.Server.Stop()
 	} else {
 		r.cancel()
+	}
+
+	if r.cmd != nil {
+		_ = r.cmd.Wait()
+		r.cmd = nil
 	}
 
 	logrus.Infof("kontainerdriver %v stopped", r.Name)


### PR DESCRIPTION
When enabling node and kontainer-engine drivers, Rancher wasn't waiting for the
command which caused zombie processes in the rancher pod.

After this change, Rancher will wait for these processes and will not cause
zombie processes to appear.

Issue:
https://github.com/rancher/rancher/issues/25443