### PR TITLE
fix health check serialization

### DIFF
--- a/pkg/apis/provisioning.cattle.io/v1/rke.go
+++ b/pkg/apis/provisioning.cattle.io/v1/rke.go
@@ -24,7 +24,7 @@ type RKEMachinePool struct {
 	MachineDeploymentAnnotations map[string]string            `json:"machineDeploymentAnnotations,omitempty"`
 	NodeStartupTimeout           *metav1.Duration             `json:"nodeStartupTimeout,omitempty"`
 	UnhealthyNodeTimeout         *metav1.Duration             `json:"unhealthyNodeTimeout,omitempty"`
-	MaxUnhealthy                 *intstr.IntOrString          `json:"maxUnhealthy,omitempty"`
+	MaxUnhealthy                 *string                      `json:"maxUnhealthy,omitempty"`
 	UnhealthyRange               *string                      `json:"unhealthyRange,omitempty"`
 	MachineOS                    string                       `json:"machineOS,omitempty"`
 }

--- a/pkg/apis/provisioning.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/provisioning.cattle.io/v1/zz_generated_deepcopy.go
@@ -269,7 +269,7 @@ func (in *RKEMachinePool) DeepCopyInto(out *RKEMachinePool) {
 	}
 	if in.MaxUnhealthy != nil {
 		in, out := &in.MaxUnhealthy, &out.MaxUnhealthy
-		*out = new(intstr.IntOrString)
+		*out = new(string)
 		**out = **in
 	}
 	if in.UnhealthyRange != nil {

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -410,6 +411,12 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 
 // deploymentHealthChecks Health checks will mark a machine as failed if it has any of the conditions below for the duration of the given timeout. https://cluster-api.sigs.k8s.io/tasks/healthcheck.html#what-is-a-machinehealthcheck
 func deploymentHealthChecks(machineDeployment *capi.MachineDeployment, machinePool rancherv1.RKEMachinePool) *capi.MachineHealthCheck {
+	var maxUnhealthy *intstr.IntOrString
+	if machinePool.MaxUnhealthy != nil {
+		maxUnhealthy = new(intstr.IntOrString)
+		*maxUnhealthy = intstr.Parse(*machinePool.MaxUnhealthy)
+	}
+
 	return &capi.MachineHealthCheck{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      machineDeployment.Name,
@@ -434,7 +441,7 @@ func deploymentHealthChecks(machineDeployment *capi.MachineDeployment, machinePo
 					Timeout: *machinePool.UnhealthyNodeTimeout,
 				},
 			},
-			MaxUnhealthy:       machinePool.MaxUnhealthy,
+			MaxUnhealthy:       maxUnhealthy,
 			UnhealthyRange:     machinePool.UnhealthyRange,
 			NodeStartupTimeout: machinePool.NodeStartupTimeout,
 		},


### PR DESCRIPTION
#35275

# Problem
rancher returns an error when parsing the max unhealthy in node pools because int's are parsed as strings.

# Solution
accept maxUnhealthy as a string and parse into to string inside rancher.