### PR TITLE
Fix typo in rancher-tiller in jailer script

### DIFF
--- a/package/jailer.sh
+++ b/package/jailer.sh
@@ -66,7 +66,7 @@ fi
 cp -l /usr/bin/helm_v3 /opt/jail/$NAME/usr/bin
 
 # Hard link tiller into the jail
-if [[ -f /usr/bin/rancher-tiler ]]; then
+if [[ -f /usr/bin/rancher-tiller ]]; then
   cp -l /usr/bin/rancher-tiller /opt/jail/$NAME/usr/bin
 fi
 


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36469

## Problem
rancher-tiller wasn't properly being copied into the jail because of a typo. This made install legacy apps (like rancher-k3s-upgrader) impossible because rancher-tiller is required.

## Solution
Fix the typo

## Testing
1. Upgraded local K3S cluster
2. Upgraded imported K3S cluster
3. Upgraded imported RKE2 cluster