### PR TITLE
[release/v2.6] Don't error if periodic instruction output is not found

### DIFF
--- a/pkg/provisioningv2/rke2/planner/store.go
+++ b/pkg/provisioningv2/rke2/planner/store.go
@@ -431,10 +431,10 @@ func getJoinURLFromOutput(entry *planEntry, capiCluster *capi.Cluster, rkeContro
 	}
 
 	var address []byte
-	if ca, ok := entry.Plan.PeriodicOutput["capture-address"]; ok && ca.ExitCode == 0 {
+	if ca, ok := entry.Plan.PeriodicOutput["capture-address"]; ok && ca.ExitCode == 0 && ca.LastSuccessfulRunTime != "" {
 		address = ca.Stdout
 	} else {
-		return "", fmt.Errorf("could not scrape join URL from periodic output (exit code: %d, length: %d) for machine %s", ca.ExitCode, len(ca.Stdout), entry.Machine.Name)
+		return "", nil
 	}
 
 	var str string


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/36562

Per the issue linked, what appears to have been happening is:

a new etcd-only init node is elected, but originally did not have a periodic instruction for scraping the joinURL set -- the planner then attempts to load the join URL but errors out before it ever has the opportunity to set the plan to a version with the periodic instruction to scrape the join URL.