### PR TITLE
[Backport v2.5] Look up container limits defined in project when making new namespace via kubectl

### DIFF
--- a/pkg/controllers/managementuser/resourcequota/resource_quota_common.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_common.go
@@ -203,7 +203,7 @@ func getProjectContainerDefaultLimit(ns *corev1.Namespace, projectLister v3.Proj
 		return nil, nil
 	}
 	project, err := projectLister.Get(projectNamespace, projectName)
-	if err != nil || project.Spec.ResourceQuota == nil {
+	if err != nil {
 		if errors.IsNotFound(err) {
 			// If Rancher is unaware of a project, we should ignore trying to get the default container limit
 			// A non-existent project is likely managed by another Rancher (e.g. Hosted Rancher)

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -450,9 +450,11 @@ func (c *SyncController) getResourceLimitToUpdate(ns *corev1.Namespace) (*corev1
 		return convertPodResourceLimitToLimitRangeSpec(updatedLimit)
 	} else if nsLimit != nil {
 		return convertPodResourceLimitToLimitRangeSpec(nsLimit)
+	} else if projectLimit != nil {
+		return convertPodResourceLimitToLimitRangeSpec(projectLimit)
+	} else {
+		return nil, nil
 	}
-
-	return nil, nil
 }
 
 func completeQuota(existingQuota *v32.NamespaceResourceQuota, defaultQuota *v32.NamespaceResourceQuota) (*v32.NamespaceResourceQuota, error) {


### PR DESCRIPTION
Original issues: https://github.com/rancher/rancher/issues/27750 and https://github.com/rancher/rancher/issues/18877
Backport issue: https://github.com/rancher/rancher/issues/36599

This is a backport of two issues fixed for `v2.6.4`.