### PR TITLE
Prefer stable cert-manager apiversion

### DIFF
--- a/chart/templates/issuer-letsEncrypt.yaml
+++ b/chart/templates/issuer-letsEncrypt.yaml
@@ -1,14 +1,14 @@
 {{- if eq .Values.tls "ingress" -}}
   {{- if eq .Values.ingress.tls.source "letsEncrypt" -}}
     {{- $certmanagerVer :=  split "." .Values.certmanager.version -}}
-    {{- if or (.Capabilities.APIVersions.Has "cert-manager.io/v1beta1") (and (gt (len $certmanagerVer._0) 0) (eq (int $certmanagerVer._0) 0) (ge (int $certmanagerVer._1) 16)) }}
+    {{- if or (.Capabilities.APIVersions.Has "cert-manager.io/v1") (and (gt (len $certmanagerVer._0) 0) (eq (int $certmanagerVer._0) 1)) }}
+apiVersion: cert-manager.io/v1
+    {{- else if or (.Capabilities.APIVersions.Has "cert-manager.io/v1beta1") (and (gt (len $certmanagerVer._0) 0) (eq (int $certmanagerVer._0) 0) (ge (int $certmanagerVer._1) 16)) }}
 apiVersion: cert-manager.io/v1beta1
     {{- else if or (.Capabilities.APIVersions.Has "cert-manager.io/v1alpha2") (and (gt (len $certmanagerVer._0) 0) (eq (int $certmanagerVer._0) 0) (ge (int $certmanagerVer._1) 11)) }}
 apiVersion: cert-manager.io/v1alpha2
     {{- else if or (.Capabilities.APIVersions.Has "certmanager.k8s.io/v1alpha1") (and (gt (len $certmanagerVer._0) 0) (eq (int $certmanagerVer._0) 0) (lt (int $certmanagerVer._1) 11)) }}
 apiVersion: certmanager.k8s.io/v1alpha1
-    {{- else }}
-apiVersion: cert-manager.io/v1
     {{- end }}
 kind: Issuer
 metadata:

--- a/chart/tests/issuer_test.yaml
+++ b/chart/tests/issuer_test.yaml
@@ -91,7 +91,10 @@ tests:
   - hasDocuments:
       count: 1
     template: issuer-rancher.yaml
-- it: should set letsEncrypt apiVersion with default cert-manager
+- it: should set letsEncrypt apiVersion with cert-manager >= 1.0.0 using capabilities
+  capabilities:
+    apiversions:
+    - cert-manager.io/v1
   set:
     ingress.tls.source: letsEncrypt
   asserts:


### PR DESCRIPTION
Use the stable v1 apiversion for cert-manager issuer when available.

This enables updating the helm-managed issuer resource before upgrading to cert-manager version >= v1.6.0.
Otherwise Helm is not able to upgrade the Rancher Helm release afterwards, because the release references an API version which was removed by applying the CRDs for the new cert-manager version.