### PR TITLE
Fix group handling for impersonation

### DIFF
--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -288,7 +288,7 @@ func (r *RemoteService) getImpersonatorAccountToken(user user.Info) (string, err
 		return "", err
 	}
 
-	i, err := impersonation.New(user, "", clusterContext)
+	i, err := impersonation.New(user, clusterContext)
 	if err != nil {
 		return "", fmt.Errorf("error creating impersonation for user %s: %w", user.GetUID(), err)
 	}

--- a/pkg/controllers/managementuser/rbac/crtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/crtb_handler.go
@@ -68,8 +68,10 @@ func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding) error {
 		return errors.Wrapf(err, "couldn't ensure cluster bindings %v", binding)
 	}
 
-	if err := c.m.ensureServiceAccountImpersonator(binding.UserName, binding.GroupName); err != nil {
-		return errors.Wrapf(err, "couldn't ensure service account impersonator")
+	if binding.UserName != "" {
+		if err := c.m.ensureServiceAccountImpersonator(binding.UserName); err != nil {
+			return errors.Wrapf(err, "couldn't ensure service account impersonator")
+		}
 	}
 
 	return nil

--- a/pkg/controllers/managementuser/rbac/impersonation_handler.go
+++ b/pkg/controllers/managementuser/rbac/impersonation_handler.go
@@ -40,9 +40,9 @@ func (m *manager) getUser(username, groupname string) (user.Info, error) {
 	return user, nil
 }
 
-func (m *manager) ensureServiceAccountImpersonator(username, groupname string) error {
+func (m *manager) ensureServiceAccountImpersonator(username string) error {
 	logrus.Debugf("ensuring service account impersonator for %s", username)
-	i, err := impersonation.New(&user.DefaultInfo{UID: username}, groupname, m.workload)
+	i, err := impersonation.New(&user.DefaultInfo{UID: username}, m.workload)
 	if apierrors.IsNotFound(err) {
 		logrus.Warnf("could not find user %s, will not create impersonation account on cluster", username)
 		return nil

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -116,8 +116,10 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 		}
 	}
 
-	if err := p.m.ensureServiceAccountImpersonator(binding.UserName, binding.GroupName); err != nil {
-		return errors.Wrapf(err, "couldn't ensure service account impersonator")
+	if binding.UserName != "" {
+		if err := p.m.ensureServiceAccountImpersonator(binding.UserName); err != nil {
+			return errors.Wrapf(err, "couldn't ensure service account impersonator")
+		}
 	}
 
 	return p.reconcileProjectAccessToGlobalResources(binding, roles)

--- a/pkg/impersonation/impersonation_test.go
+++ b/pkg/impersonation/impersonation_test.go
@@ -55,7 +55,6 @@ func Test_getUser(t *testing.T) {
 					},
 				},
 			},
-			groupName: "project:abc",
 			userGetFunc: func(_, _ string) (*v3.User, error) {
 				return &v3.User{
 					ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
@@ -99,7 +98,6 @@ func Test_getUser(t *testing.T) {
 					"github_org://456",
 					"openldap_group://cn=group1,dc=example,dc=org",
 					"openldap_group://cn=group2,dc=example,dc=org",
-					"project:abc",
 					"system:authenticated",
 					"system:cattle:authenticated",
 				},
@@ -127,7 +125,7 @@ func Test_getUser(t *testing.T) {
 					GetFunc: tt.userAttribGetFunc,
 				},
 			}
-			got, err := impersonator.getUser(tt.userInfo, tt.groupName)
+			got, err := impersonator.getUser(tt.userInfo)
 			assert.Nil(t, err)
 			assert.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
When CRTBs and PRTBs are created, they are either created for Users or
Groups, not both. Impersonation only needs to be set up for a user, and
the impersonation account must be able to impersonate the groups that
are found in the user's attributes. This change ensures that we don't
try to create an impersonation account for a group and removes unneeded
code for when an account is being created for a user.

https://github.com/rancher/rancher/issues/36054