### PR TITLE
add extra plan sync prior to setting the machineJoinURL

### DIFF
--- a/pkg/provisioningv2/rke2/planner/store.go
+++ b/pkg/provisioningv2/rke2/planner/store.go
@@ -323,6 +323,8 @@ func (p *PlanStore) UpdatePlan(entry *planEntry, plan plan.NodePlan, maxFailures
 		secret.Data = map[string][]byte{}
 	}
 
+	rke2.CopyPlanMetadataToSecret(secret, entry.Metadata)
+
 	// if there are no probes, clear the statuses of the probes so as to prevent false positives
 	if len(plan.Probes) == 0 {
 		delete(secret.Data, "probe-statuses")


### PR DESCRIPTION
Currently, plans are synced twice in a typical v2prov machine provisioning cycle; once during the initNode process and later when setting the machineJoinURL. 

This change adds an additional plan sync earlier on. One situation this should address is when a plan has been generated for a machine but the machine does not have the UID label assigned to it yet. This appears to cause provisioning of a v2prov machine to become infinitely stuck as it specifically fails during this [check](https://github.com/rancher/rancher/blob/release/v2.6/pkg/controllers/provisioningv2/rke2/machinenodelookup/controller.go#L98-L105) with no way to recover due to the label from the plan not being synced until after the providerID would be set.

```console
2022/02/23 21:44:21 [DEBUG] Searching for providerID for selector rke.cattle.io/machine=0d9054c5-514e-43c2-97e2-8d2194ef44c8 in cluster fleet-default/ross, machine ross-rke2-linux-6f469c4549-ccrdm: {"Code":{"Code":"Forbidden","Status":403},"Message":"clusters.management.cattle.io \"c-m-lrmtzv7x\" is forbidden: User \"u-gzayglvnxq\" cannot get resource \"clusters\" in API group \"management.cattle.io\" at the cluster scope","Cause":null,"FieldName":""} (get nodes)
2022/02/23 21:44:32 [DEBUG] Cannot retrieve CRD with metadata only client, falling back to slower listing
2022/02/23 21:44:32 [DEBUG] Infrastructure provider is not ready, requeuing
2022/02/23 21:44:32 [DEBUG] Cannot reconcile Machine's Node, no valid ProviderID yet
2022/02/23 21:44:32 [DEBUG] Cannot retrieve CRD with metadata only client, falling back to slower listing
2022/02/23 21:44:32 [DEBUG] Cannot retrieve CRD with metadata only client, falling back to slower listing
2022/02/23 21:44:32 [DEBUG] Unable to retrieve Node status, missing NodeRef
```