### PR TITLE
[release/v2.6] Add more logging on failed tunnel requests

### DIFF
--- a/pkg/tunnelserver/chain.go
+++ b/pkg/tunnelserver/chain.go
@@ -1,6 +1,7 @@
 package tunnelserver
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/rancher/remotedialer"
@@ -12,7 +13,13 @@ type Authorizers struct {
 }
 
 func ErrorWriter(rw http.ResponseWriter, req *http.Request, code int, err error) {
-	logrus.Errorf("Failed to handling tunnel request from %s: response %d: %v", req.RemoteAddr, code, err)
+	fullAddress := req.RemoteAddr
+	forwardedFor := req.Header.Get("X-Forwarded-For")
+	if forwardedFor != "" {
+		fullAddress = fmt.Sprintf("%s (X-Forwarded-For: %s)", req.RemoteAddr, forwardedFor)
+	}
+	logrus.Errorf("Failed to handling tunnel request from remote address %s: response %d: %v", fullAddress, code, err)
+	logrus.Tracef("ErrorWriter: response code: %d, request: %v", code, req)
 	remotedialer.DefaultErrorWriter(rw, req, code, err)
 }
 


### PR DESCRIPTION
While debugging failed requests, it helps to add the forwarded address so you can directly see what the origin of the request is.

In trace, we can dump the whole request to debug what the client is sending to use it to compare with what we are seeing.