### PR TITLE
Fixing bugs related to group bindings to admin/restricted admin

### DIFF
--- a/pkg/controllers/management/restrictedadminrbac/project.go
+++ b/pkg/controllers/management/restrictedadminrbac/project.go
@@ -29,7 +29,6 @@ func (r *rbaccontroller) projectRBACSync(key string, project *apimgmtv3.Project)
 	}
 	for _, x := range grbs {
 		grb, _ := x.(*v3.GlobalRoleBinding)
-		restrictedAdminUserName := grb.UserName
 		rbName := fmt.Sprintf("%s-%s", grb.Name, rbac.RestrictedAdminProjectRoleBinding)
 		rb, err := r.rbLister.Get(project.Name, rbName)
 		if err != nil && !k8serrors.IsNotFound(err) {
@@ -58,10 +57,7 @@ func (r *rbaccontroller) projectRBACSync(key string, project *apimgmtv3.Project)
 				Kind: "ClusterRole",
 			},
 			Subjects: []k8srbac.Subject{
-				{
-					Kind: "User",
-					Name: restrictedAdminUserName,
-				},
+				rbac.GetGRBSubject(grb),
 			},
 		})
 		if err != nil && !k8serrors.IsAlreadyExists(err) {

--- a/pkg/controllers/managementuser/rbac/cluster_handler.go
+++ b/pkg/controllers/managementuser/rbac/cluster_handler.go
@@ -96,10 +96,7 @@ func (h *clusterHandler) doSync(cluster *v3.Cluster) error {
 						Name: bindingName,
 					},
 					Subjects: []k8srbac.Subject{
-						{
-							Kind: "User",
-							Name: grb.UserName,
-						},
+						rbac.GetGRBSubject(grb),
 					},
 					RoleRef: k8srbac.RoleRef{
 						Name: "cluster-admin",

--- a/pkg/controllers/managementuser/rbac/globalrole_handler.go
+++ b/pkg/controllers/managementuser/rbac/globalrole_handler.go
@@ -181,11 +181,8 @@ func (c *grbHandler) ensureProvisioningClusterAdminBinding(obj *v3.GlobalRoleBin
 
 	provCluster := pClusters[0]
 
-	subject := k8srbac.Subject{
-		Kind: "User",
-		Name: obj.UserName,
-	}
-	rbName := name.SafeConcatName(rbac.ProvisioningClusterAdminName(provCluster), subject.Name)
+	subject := rbac.GetGRBSubject(obj)
+	rbName := name.SafeConcatName(rbac.ProvisioningClusterAdminName(provCluster), rbac.GetGRBTargetKey(obj))
 
 	existingRb, err := c.rbLister.Get(provCluster.Namespace, rbName)
 	if err != nil && !apierrors.IsNotFound(err) {


### PR DESCRIPTION
Fixing several areas where the subject of rolebindings was assumed
to be a user so that they can properly handle group roles, both in
the subject and in the naming of the role