### PR TITLE
restart daemonsets.apps kube-api-auth to resolve the unauthorized-user issue

### DIFF
--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -68,6 +68,23 @@ func RolloutStatusWithNamespace(namespace, name, timeout string, kubeConfig *cli
 	return runWithHTTP2(cmd)
 }
 
+func RolloutRestartWithNamespace(namespace, name string, kubeConfig *clientcmdapi.Config) ([]byte, error) {
+	kubeConfigFile, err := writeKubeConfig(kubeConfig)
+	defer cleanup(kubeConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command("kubectl",
+		"--kubeconfig",
+		kubeConfigFile.Name(),
+		"-n",
+		namespace,
+		"rollout",
+		"restart",
+		name)
+	return runWithHTTP2(cmd)
+}
+
 func Delete(yaml []byte, kubeConfig *clientcmdapi.Config) ([]byte, error) {
 	kubeConfigFile, yamlFile, err := writeData(kubeConfig, yaml)
 	defer cleanup(kubeConfigFile, yamlFile)


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36518

Problem:
If we create an RKE/RKE2 downstream cluster with multiple control plane nodes and with ClusterAuthEndpoint enabled, then use the secondary contexts in the kubeconfig file downloaded from Rancher UI to access the cluster, we will hit the following error with one of the secondary contexts:
```
error: You must be logged in to the server (Unauthorized)
```
meanwhile, the logs of the `kube-api-auth` pod on this control plane shows the following kind of error:
```
time="2022-02-24T21:11:46Z" level=info msg="  ...looking up token for kubeconfig-user-qmk2kdmjlt"
time="2022-02-24T21:11:46Z" level=error msg="clusteruserattributes.cluster.cattle.io \"cattle-system/user-qmk2k\" not found"
```

Solutions:
Two parts are fixed:
- in rancher/rancher, we add a restart for the pods in the daemonSet `kube-api-auth`,  a restart can mitigate the problem sometimes.
- in rancher/kube-api-auth, we update all dependencies to the latest version. A bug around cache-not-start-properly was fixed in rancher/lasso and that bug could be the cause of this issue.  [PR](https://github.com/rancher/kube-api-auth/pull/11)


Tests:
Both RKE and RKE2 clusters are tested on a Rancher setup with fixes using the customized `kube-api-auth` image. 