### PR TITLE
Fix secretmigrator assemblers and s3 snapshots

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/driver.go
+++ b/pkg/controllers/management/clusterprovisioner/driver.go
@@ -126,6 +126,10 @@ func (p *Provisioner) driverRestore(cluster *v3.Cluster, spec v32.ClusterSpec, s
 	defer logger.Close()
 
 	spec = cleanRKE(spec)
+	spec, err := secretmigrator.AssembleS3Credential(cluster, spec, p.SecretLister)
+	if err != nil {
+		return "", "", "", err
+	}
 
 	newCluster, err := p.Clusters.Update(cluster)
 	if err != nil {

--- a/pkg/controllers/management/secretmigrator/assemblers.go
+++ b/pkg/controllers/management/secretmigrator/assemblers.go
@@ -59,7 +59,7 @@ func AssembleS3Credential(cluster *apimgmtv3.Cluster, spec apimgmtv3.ClusterSpec
 	if err != nil {
 		return spec, err
 	}
-	spec.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.S3BackupConfig.SecretKey = string(s3Cred.Data["secretKey"])
+	spec.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.S3BackupConfig.SecretKey = string(s3Cred.Data[secretKey])
 	return spec, nil
 }
 
@@ -80,7 +80,7 @@ func AssembleWeaveCredential(cluster *apimgmtv3.Cluster, spec apimgmtv3.ClusterS
 	if err != nil {
 		return spec, err
 	}
-	spec.RancherKubernetesEngineConfig.Network.WeaveNetworkProvider.Password = string(registrySecret.Data["password"])
+	spec.RancherKubernetesEngineConfig.Network.WeaveNetworkProvider.Password = string(registrySecret.Data[secretKey])
 	return spec, nil
 }
 
@@ -101,7 +101,7 @@ func AssembleSMTPCredential(notifier *apimgmtv3.Notifier, secretLister v1.Secret
 		return &notifier.Spec, err
 	}
 	spec := notifier.Spec.DeepCopy()
-	spec.SMTPConfig.Password = string(smtpSecret.Data["password"])
+	spec.SMTPConfig.Password = string(smtpSecret.Data[secretKey])
 	return spec, nil
 }
 
@@ -122,7 +122,7 @@ func AssembleWechatCredential(notifier *apimgmtv3.Notifier, secretLister v1.Secr
 		return &notifier.Spec, err
 	}
 	spec := notifier.Spec.DeepCopy()
-	spec.WechatConfig.Secret = string(wechatSecret.Data["secret"])
+	spec.WechatConfig.Secret = string(wechatSecret.Data[secretKey])
 	return spec, nil
 }
 
@@ -143,7 +143,7 @@ func AssembleDingtalkCredential(notifier *apimgmtv3.Notifier, secretLister v1.Se
 		return &notifier.Spec, err
 	}
 	spec := notifier.Spec.DeepCopy()
-	spec.DingtalkConfig.Secret = string(secret.Data["credential"])
+	spec.DingtalkConfig.Secret = string(secret.Data[secretKey])
 	return spec, nil
 }
 
@@ -160,7 +160,7 @@ func (m *Migrator) AssembleGithubPipelineConfigCredential(config apiprjv3.Github
 	if err != nil {
 		return config, err
 	}
-	config.ClientSecret = string(secret.Data["credential"])
+	config.ClientSecret = string(secret.Data[secretKey])
 	return config, nil
 }
 
@@ -177,7 +177,7 @@ func (m *Migrator) AssembleGitlabPipelineConfigCredential(config apiprjv3.Gitlab
 	if err != nil {
 		return config, err
 	}
-	config.ClientSecret = string(secret.Data["credential"])
+	config.ClientSecret = string(secret.Data[secretKey])
 	return config, nil
 }
 
@@ -194,7 +194,7 @@ func (m *Migrator) AssembleBitbucketCloudPipelineConfigCredential(config apiprjv
 	if err != nil {
 		return config, err
 	}
-	config.ClientSecret = string(secret.Data["credential"])
+	config.ClientSecret = string(secret.Data[secretKey])
 	return config, nil
 }
 
@@ -211,6 +211,6 @@ func (m *Migrator) AssembleBitbucketServerPipelineConfigCredential(config apiprj
 	if err != nil {
 		return config, err
 	}
-	config.PrivateKey = string(secret.Data["credential"])
+	config.PrivateKey = string(secret.Data[secretKey])
 	return config, nil
 }

--- a/pkg/controllers/management/secretmigrator/catalog/assemblers.go
+++ b/pkg/controllers/management/secretmigrator/catalog/assemblers.go
@@ -7,6 +7,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const secretKey = "credential"
+
 // AssembleDingtalkCredential looks up the Dingtalk Secret and inserts the keys into the Notifier.
 // It returns a new copy of the Notifier without modifying the original. The Notifier is never updated.
 func AssembleCatalogCredential(catalog *apimgmtv3.Catalog, secretLister v1.SecretLister) (apimgmtv3.CatalogSpec, error) {
@@ -21,6 +23,6 @@ func AssembleCatalogCredential(catalog *apimgmtv3.Catalog, secretLister v1.Secre
 		return catalog.Spec, err
 	}
 	spec := catalog.Spec.DeepCopy()
-	spec.Password = string(secret.Data["credential"])
+	spec.Password = string(secret.Data[secretKey])
 	return *spec, nil
 }

--- a/pkg/controllers/management/secretmigrator/clusters.go
+++ b/pkg/controllers/management/secretmigrator/clusters.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	secretNamespace             = namespace.GlobalNamespace
+	secretKey                   = "credential"
 	S3BackupAnswersPath         = "rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.secretKey"
 	WeavePasswordAnswersPath    = "rancherKubernetesEngineConfig.network.weaveNetworkProvider.password"
 	RegistryPasswordAnswersPath = "rancherKubernetesEngineConfig.privateRegistries[%d].password"
@@ -653,7 +654,7 @@ func (m *Migrator) createOrUpdateSecretForCredential(secretName, secretValue str
 		return nil, nil
 	}
 	data := map[string]string{
-		"credential": secretValue,
+		secretKey: secretValue,
 	}
 	secret, err := m.createOrUpdateSecret(secretName, data, owner, kind, field)
 	if err != nil {


### PR DESCRIPTION
An early draft of the secretmigrator controller used resource-specific
keys when creating the secrets, and when that was refactored the
assemblers were never updated, so for example the S3 secret assembler
was looking for a key 'secretKey' in the secret data, when it was
actually stored under the 'credential' key.

This also fixes the etcdbackup controller to use the assembled
BackupConfig, instead of the BackupConfig from the newly fetched Cluster
which does not have the credential on it.

https://github.com/rancher/rancher/issues/36660