### PR TITLE
Added support to provisioning rke2 azure node driver clusters

### DIFF
--- a/tests/framework/extensions/cloudcredentials/aws/create.go
+++ b/tests/framework/extensions/cloudcredentials/aws/create.go
@@ -9,7 +9,7 @@ import (
 
 const awsCloudCredNameBase = "awsCloudCredential"
 
-// CreateAWSCloudCredentials is a helper function that takes the rancher Client as a prameter and creates
+// CreateAWSCloudCredentials is a helper function that takes the rancher Client as a parameter and creates
 // an AWS cloud credential, and returns the CloudCredential response
 func CreateAWSCloudCredentials(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error) {
 	var amazonEC2CredentialConfig cloudcredentials.AmazonEC2CredentialConfig

--- a/tests/framework/extensions/cloudcredentials/azure/create.go
+++ b/tests/framework/extensions/cloudcredentials/azure/create.go
@@ -1,0 +1,29 @@
+package azure
+
+import (
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+)
+
+const azureCloudCredNameBase = "azureOceanCloudCredential"
+
+// CreateAzureCloudCredentials is a helper function that takes the rancher Client as a parameter and creates
+// an Azure cloud credential, and returns the CloudCredential response
+func CreateAzureCloudCredentials(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error) {
+	var azureCredentialConfig cloudcredentials.AzureCredentialConfig
+	config.LoadConfig(cloudcredentials.AzureCredentialConfigurationFileKey, &azureCredentialConfig)
+
+	cloudCredential := cloudcredentials.CloudCredential{
+		Name:                  azureCloudCredNameBase,
+		AzureCredentialConfig: &azureCredentialConfig,
+	}
+
+	resp := &cloudcredentials.CloudCredential{}
+	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.CloudCredentialType, cloudCredential, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/tests/framework/extensions/cloudcredentials/azure_config.go
+++ b/tests/framework/extensions/cloudcredentials/azure_config.go
@@ -1,0 +1,10 @@
+package cloudcredentials
+
+const AzureCredentialConfigurationFileKey = "azureCredentials"
+
+type AzureCredentialConfig struct {
+	ClientID       string `json:"clientId" yaml:"clientId"`
+	ClientSecret   string `json:"clientSecret" yaml:"clientSecret"`
+	SubscriptionID string `json:"subscriptionId" yaml:"subscriptionId"`
+	Environment    string `json:"environment" yaml:"environment"`
+}

--- a/tests/framework/extensions/cloudcredentials/cloudcredentials.go
+++ b/tests/framework/extensions/cloudcredentials/cloudcredentials.go
@@ -14,6 +14,7 @@ type CloudCredential struct {
 	Name                         string                        `json:"name,omitempty"`
 	Removed                      string                        `json:"removed,omitempty"`
 	AmazonEC2CredentialConfig    *AmazonEC2CredentialConfig    `json:"amazonec2credentialConfig,omitempty"`
+	AzureCredentialConfig        *AzureCredentialConfig        `json:"azurecredentialConfig,omitempty"`
 	DigitalOceanCredentialConfig *DigitalOceanCredentialConfig `json:"digitaloceancredentialConfig,omitempty"`
 	HarvesterCredentialConfig    *HarvesterCredentialConfig    `json:"harvestercredentialConfig,omitempty"`
 	UUID                         string                        `json:"uuid,omitempty"`

--- a/tests/framework/extensions/cloudcredentials/digitalocean/create.go
+++ b/tests/framework/extensions/cloudcredentials/digitalocean/create.go
@@ -9,7 +9,7 @@ import (
 
 const digitalOceanCloudCredNameBase = "digitalOceanCloudCredential"
 
-// CreateDigitalOceanCloudCredentials is a helper function that takes the rancher Client as a prameter and creates
+// CreateDigitalOceanCloudCredentials is a helper function that takes the rancher Client as a parameter and creates
 // a Digital Ocean cloud credential, and returns the CloudCredential response
 func CreateDigitalOceanCloudCredentials(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error) {
 	var digitalOceanCredentialConfig cloudcredentials.DigitalOceanCredentialConfig

--- a/tests/framework/extensions/cloudcredentials/harvester/create.go
+++ b/tests/framework/extensions/cloudcredentials/harvester/create.go
@@ -9,7 +9,7 @@ import (
 
 const harvesterCloudCredNameBase = "harvesterCloudCredential"
 
-// CreateHarvesterCloudCredentials is a helper function that takes the rancher Client as a prameter and creates
+// CreateHarvesterCloudCredentials is a helper function that takes the rancher Client as a parameter and creates
 // a harvester cloud credential, and returns the CloudCredential response
 func CreateHarvesterCloudCredentials(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error) {
 	var harvesterCredentialConfig cloudcredentials.HarvesterCredentialConfig

--- a/tests/framework/extensions/machinepools/azure_machine_config.go
+++ b/tests/framework/extensions/machinepools/azure_machine_config.go
@@ -1,0 +1,73 @@
+package machinepools
+
+import (
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	AzureKind                              = "AzureConfig"
+	AzurePoolType                          = "rke-machine-config.cattle.io.azureconfig"
+	AzureResourceConfig                    = "azureconfigs"
+	AzureMachingConfigConfigurationFileKey = "azureMachineConfig"
+)
+
+type AzureMachineConfig struct {
+	AvailabilitySet   string   `json:"availabilitySet" yaml:"availabilitySet"`
+	DiskSize          string   `json:"diskSize" yaml:"diskSize"`
+	DNS               string   `json:"dns,omitempty" yaml:"dns,omitempty"`
+	Environment       string   `json:"environment" yaml:"environment"`
+	FaultDomainCount  string   `json:"faultDomainCount" yaml:"faultDomainCount"`
+	Image             string   `json:"image" yaml:"image"`
+	ManagedDisks      bool     `json:"managedDisks" yaml:"managedDisks"`
+	NoPublicIP        bool     `json:"noPublicIp" yaml:"noPublicIp"`
+	NSG               string   `json:"nsg" yaml:"nsg"`
+	OpenPort          []string `json:"openPort" yaml:"openPort"`
+	PrivateIPAddress  string   `json:"privateIpAddress,omitempty" yaml:"privateIpAddress,omitempty"`
+	ResourceGroup     string   `json:"resourceGroup" yaml:"resourceGroup"`
+	Size              string   `json:"size" yaml:"size"`
+	SSHUser           string   `json:"sshUser" yaml:"sshUser"`
+	StaticPublicIP    bool     `json:"staticPublicIp" yaml:"staticPublicIp"`
+	StorageType       string   `json:"storageType" yaml:"storageType"`
+	Subnet            string   `json:"subnet" yaml:"subnet"`
+	SubnetPrefix      string   `json:"subnetPrefix" yaml:"subnetPrefix"`
+	UpdateDomainCount string   `json:"updateDomainCount" yaml:"updateDomainCount"`
+	UsePrivateIP      bool     `json:"usePrivateIp" yaml:"usePrivateIp"`
+	Vnet              string   `json:"vnet" yaml:"vnet"`
+}
+
+// NewAzureMachineConfig is a constructor to set up rke-machine-config.cattle.io.azureconfig. It returns an *unstructured.Unstructured
+// that CreateMachineConfig uses to created the rke-machine-config
+func NewAzureMachineConfig(generatedPoolName, namespace string) *unstructured.Unstructured {
+	var azureMachineConfig AzureMachineConfig
+	config.LoadConfig(AzureMachingConfigConfigurationFileKey, &azureMachineConfig)
+
+	machineConfig := &unstructured.Unstructured{}
+	machineConfig.SetAPIVersion("rke-machine-config.cattle.io/v1")
+	machineConfig.SetKind(DOKind)
+	machineConfig.SetGenerateName(generatedPoolName)
+	machineConfig.SetNamespace(namespace)
+	machineConfig.Object["availabilitySet"] = azureMachineConfig.AvailabilitySet
+	machineConfig.Object["diskSize"] = azureMachineConfig.DiskSize
+	machineConfig.Object["dns"] = azureMachineConfig.DNS
+	machineConfig.Object["environment"] = azureMachineConfig.Environment
+	machineConfig.Object["faultDomainCount"] = azureMachineConfig.FaultDomainCount
+	machineConfig.Object["image"] = azureMachineConfig.Image
+	machineConfig.Object["managedDisks"] = azureMachineConfig.ManagedDisks
+	machineConfig.Object["noPublicIp"] = azureMachineConfig.NoPublicIP
+	machineConfig.Object["nsg"] = azureMachineConfig.NSG
+	machineConfig.Object["openPort"] = azureMachineConfig.OpenPort
+	machineConfig.Object["privateIpAddress"] = azureMachineConfig.PrivateIPAddress
+	machineConfig.Object["resourceGroup"] = azureMachineConfig.ResourceGroup
+	machineConfig.Object["size"] = azureMachineConfig.Size
+	machineConfig.Object["sshUser"] = azureMachineConfig.SSHUser
+	machineConfig.Object["staticPublicIP"] = azureMachineConfig.StaticPublicIP
+	machineConfig.Object["storageType"] = azureMachineConfig.StorageType
+	machineConfig.Object["subnet"] = azureMachineConfig.Subnet
+	machineConfig.Object["subnetPrefix"] = azureMachineConfig.SubnetPrefix
+	machineConfig.Object["updateDomainCount"] = azureMachineConfig.UpdateDomainCount
+	machineConfig.Object["usePrivateIp"] = azureMachineConfig.UsePrivateIP
+	machineConfig.Object["vnet"] = azureMachineConfig.Vnet
+	machineConfig.Object["type"] = AzurePoolType
+	return machineConfig
+}

--- a/tests/v2/validation/provisioning/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/custom_cluster_test.go
@@ -68,7 +68,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	c.standardUserClient = standardUserClient
 }
 
-func (c *CustomClusterProvisioningTestSuite) Provisioning_RKE2CustomCluster(externalNodeProvider ExternalNodeProvider) {
+func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(externalNodeProvider ExternalNodeProvider) {
 	nodeRoles0 := []string{
 		"--etcd --controlplane --worker",
 	}
@@ -99,7 +99,7 @@ func (c *CustomClusterProvisioningTestSuite) Provisioning_RKE2CustomCluster(exte
 					testSession := session.NewSession(c.T())
 					defer testSession.Cleanup()
 
-					client, err := c.client.WithSession(testSession)
+					client, err := tt.client.WithSession(testSession)
 					require.NoError(c.T(), err)
 
 					numNodes := len(tt.nodeRoles)
@@ -144,7 +144,7 @@ func (c *CustomClusterProvisioningTestSuite) Provisioning_RKE2CustomCluster(exte
 	}
 }
 
-func (c *CustomClusterProvisioningTestSuite) Provisioning_RKE2CustomClusterDynamicInput(externalNodeProvider ExternalNodeProvider, nodesAndRoles []map[string]bool) {
+func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynamicInput(externalNodeProvider ExternalNodeProvider, nodesAndRoles []map[string]bool) {
 	rolesPerNode := []string{}
 
 	for _, nodes := range nodesAndRoles {
@@ -175,7 +175,7 @@ func (c *CustomClusterProvisioningTestSuite) Provisioning_RKE2CustomClusterDynam
 					testSession := session.NewSession(c.T())
 					defer testSession.Cleanup()
 
-					client, err := c.client.WithSession(testSession)
+					client, err := tt.client.WithSession(testSession)
 					require.NoError(c.T(), err)
 
 					nodes, err := externalNodeProvider.NodeCreationFunc(client, numOfNodes)
@@ -222,7 +222,7 @@ func (c *CustomClusterProvisioningTestSuite) Provisioning_RKE2CustomClusterDynam
 func (c *CustomClusterProvisioningTestSuite) TestProvisioningCustomCluster() {
 	for _, nodeProviderName := range c.nodeProviders {
 		externalNodeProvider := ExternalNodeProviderSetup(nodeProviderName)
-		c.Provisioning_RKE2CustomCluster(externalNodeProvider)
+		c.ProvisioningRKE2CustomCluster(externalNodeProvider)
 	}
 }
 
@@ -234,7 +234,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningCustomClusterDynami
 
 	for _, nodeProviderName := range c.nodeProviders {
 		externalNodeProvider := ExternalNodeProviderSetup(nodeProviderName)
-		c.Provisioning_RKE2CustomClusterDynamicInput(externalNodeProvider, nodesAndRoles)
+		c.ProvisioningRKE2CustomClusterDynamicInput(externalNodeProvider, nodesAndRoles)
 	}
 }
 

--- a/tests/v2/validation/provisioning/providers.go
+++ b/tests/v2/validation/provisioning/providers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials"
 	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/aws"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/azure"
 	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/digitalocean"
 	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/harvester"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
@@ -14,6 +15,7 @@ import (
 
 const (
 	awsProviderName       = "aws"
+	azureProviderName     = "azure"
 	doProviderName        = "do"
 	harvesterProviderName = "harvester"
 )
@@ -39,6 +41,14 @@ func CreateProvider(name string) Provider {
 			MachineConfig:   machinepools.AWSResourceConfig,
 			MachinePoolFunc: machinepools.NewAWSMachineConfig,
 			CloudCredFunc:   aws.CreateAWSCloudCredentials,
+		}
+		return provider
+	case name == azureProviderName:
+		provider := Provider{
+			Name:            name,
+			MachineConfig:   machinepools.AzureResourceConfig,
+			MachinePoolFunc: machinepools.NewAzureMachineConfig,
+			CloudCredFunc:   azure.CreateAzureCloudCredentials,
 		}
 		return provider
 	case name == doProviderName:

--- a/tests/v2/validation/provisioning/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/provisioning_node_driver_test.go
@@ -59,8 +59,10 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 		Enabled:  &enabled,
 	}
 
-	newUser, err := users.CreateUserWithRole(client, user, "user")
+	newUser, err := users.CreateUserWithRole(client, user, "clusters-create", "user")
 	require.NoError(r.T(), err)
+
+	newUser.Password = user.Password
 
 	standardUserClient, err := client.AsUser(newUser)
 	require.NoError(r.T(), err)
@@ -68,7 +70,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 	r.standardUserClient = standardUserClient
 }
 
-func (r *RKE2NodeDriverProvisioningTestSuite) Provisioning_RKE2Cluster(provider Provider) {
+func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2Cluster(provider Provider) {
 	subSession := r.session.NewSession()
 	defer subSession.Cleanup()
 
@@ -154,13 +156,15 @@ func (r *RKE2NodeDriverProvisioningTestSuite) Provisioning_RKE2Cluster(provider 
 					assert.NoError(r.T(), err)
 					assert.Equal(r.T(), clusterName, clusterResp.Name)
 
+					// time.Sleep(2 * time.Minute)
+
 				})
 			}
 		}
 	}
 }
 
-func (r *RKE2NodeDriverProvisioningTestSuite) Provisioning_RKE2ClusterDynamicInput(provider Provider, nodesAndRoles []map[string]bool) {
+func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2ClusterDynamicInput(provider Provider, nodesAndRoles []map[string]bool) {
 	subSession := r.session.NewSession()
 	defer subSession.Cleanup()
 
@@ -226,7 +230,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) Provisioning_RKE2ClusterDynamicInp
 func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioning() {
 	for _, providerName := range r.providers {
 		provider := CreateProvider(providerName)
-		r.Provisioning_RKE2Cluster(provider)
+		r.ProvisioningRKE2Cluster(provider)
 	}
 }
 
@@ -238,7 +242,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningDynamicInput() {
 
 	for _, providerName := range r.providers {
 		provider := CreateProvider(providerName)
-		r.Provisioning_RKE2ClusterDynamicInput(provider, nodesAndRoles)
+		r.ProvisioningRKE2ClusterDynamicInput(provider, nodesAndRoles)
 	}
 }
 


### PR DESCRIPTION
**Framework updates** 
- Helper for creating a cloud credential for azure 
- Helper for creating a machine config for an azure provider.
- Updates to spelling mistakes in comments in the other cloud credential helpers

**Validation updates**
- Added azure to providers
- Updates to method names to adhere to go lang naming conventions