### PR TITLE
Add spec.upgrade.envFrom to SUC upgrade watch

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagent.go
+++ b/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagent.go
@@ -167,7 +167,7 @@ func installer(envs []rkev1.EnvVar, allWorkers bool, secretName, generation stri
 			Name:      "system-agent-upgrader",
 			Namespace: namespaces.System,
 			Annotations: map[string]string{
-				"upgrade.cattle.io/digest": "spec.upgrade.envs",
+				"upgrade.cattle.io/digest": "spec.upgrade.envs,spec.upgrade.envFrom",
 			},
 		},
 		Spec: upgradev1.PlanSpec{


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36062

## Problem
When Rancher is migrated, a new service-account token is created for
system-agent. However, this new service-account was not being deployed to the
downstream nodes because SUC wouldn't detect that the change occurred.

## Solution
After this change, SUC will be told to watch spec.upgrade.envFrom for changes
and deploy a new plan when this field changes. This field is the correct one for
SUC to watch because the secret name contains a hash of the service-account
token that needs to be updated.

## Testing
I deployed a cluster with multiple nodes and took a backup with the backup-restore operator. Then, I migrated to a new cluster, restored the backup with backup-restore operator, and installed Rancher. The system-agent got the new service-account token and reconciled the plan successfully.