### PR TITLE
 Added job for v2 chart installations on targeted/provisioned clusters

### DIFF
--- a/tests/v2/validation/resource/terraform/v1charts/Dockerfile.v1charts
+++ b/tests/v2/validation/resource/terraform/v1charts/Dockerfile.v1charts
@@ -1,0 +1,14 @@
+FROM golang:1.16
+
+# Configure Go
+ENV GOPATH /go
+ENV PATH ${PATH}:/go/bin
+
+ENV WORKSPACE ${GOPATH}/src/github.com/rancher/rancher
+
+WORKDIR $WORKSPACE/tests/v2/validation/resource/terraform/v1charts
+
+COPY [".", "$WORKSPACE"]
+
+RUN go mod init main
+RUN go mod tidy

--- a/tests/v2/validation/resource/terraform/v1charts/Jenkinsfile
+++ b/tests/v2/validation/resource/terraform/v1charts/Jenkinsfile
@@ -1,0 +1,133 @@
+// Job Params
+// Requires: PYTEST_OPTIONS, CATTLE_TEST_URL, ADMIN_TOKEN
+// Optional: AWS_SSH_PEM_KEY, AWS_SSH_KEY_NAME, DEBUG
+
+node {
+  def job_name = "${JOB_NAME}"
+  if (job_name.contains('/')) { 
+    job_names = job_name.split('/')
+    job_name = job_names[job_names.size() - 1] 
+  }
+  def testContainer = "${job_name}${env.BUILD_NUMBER}_test"
+
+  def imageName = "rancher-validation-${job_name}${env.BUILD_NUMBER}"
+  def envFile = ".env"
+  def RANCHER_API_URL = "${env.RANCHER_API_URL}"
+  def RANCHER_TOKEN_KEY = "${env.RANCHER_TOKEN_KEY}"
+  def hostname_prefix = "${env.HOSTNAME_PREFIX}"
+  def worker_count = "${env.WORKER_COUNT}"
+  def TF_VERSION = "${env.TF_VERSION}"
+  def AWS_AMI = "${env.AWS_AMI}"
+  def AWS_AMI_USER = "${env.AWS_AMI_USER}"
+  def k8s_version = "${env.K8S_VERSION}"
+  def suffix = "-tf-cluster-0"
+  def etcd_suffix = "-tf-etcd-0"
+  def cp_suffix = "-tf-controlplane-0"
+  def worker_suffix = "-tf-worker-0"
+  def aws_cluster_name = "-aws-tf-charts"
+  def do_cluster_name = "-do-tf-charts"
+  def AWS_ACCESS_KEY = "${env.AWS_ACCESS_KEY}"
+  def AWS_SECRET_KEY = "${env.AWS_SECRET_KEY}"
+  def DO_ACCESS_KEY = "${env.DO_ACCESS_KEY}"
+
+  def branch = "release/v2.6"
+  if ("${env.branch}" != "null" && "${env.branch}" != "") {
+    branch = "${env.branch}"
+  }
+
+  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+    withFolderProperties {
+      paramsMap = []
+      params.each {
+        paramsMap << "$it.key=$it.value"
+      }
+      withEnv(paramsMap) {
+      withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                        string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+                        string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                        string(credentialsId: 'DO_ACCESSKEY', variable: 'DO_ACCESSKEY'),
+                        string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                        string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD')
+                        ]) {
+                          
+        stage('Checkout') {
+          deleteDir()
+          checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: "*/${branch}"]],
+                    extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                    userRemoteConfigs: scm.userRemoteConfigs
+                  ])
+        }
+
+        dir ("./") {
+
+          stage('Configure and Build') {
+            if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
+              dir(".ssh") {
+                def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
+                writeFile file: AWS_SSH_KEY_NAME, text: decoded
+              }
+            }
+
+            sh "./tests/v2/validation/resource/terraform/v1charts/configure.sh"
+            sh "./tests/v2/validation/resource/terraform/v1charts/build.sh"
+          }
+
+          try {
+            stage('Run Chart Installation') {
+
+              if (AWS_ACCESS_KEY != "") {
+                sh "docker run --name ${testContainer} -t --env-file ${envFile} " + 
+                "${imageName} sh -c \"export TF_VAR_rancher_api_url=${RANCHER_API_URL}" + 
+                "&& export TF_VAR_rancher_token_key=${RANCHER_TOKEN_KEY}" + 
+                "&& export TF_VAR_aws_access_key=${AWS_ACCESS_KEY}" + 
+                "&& export TF_VAR_aws_secret_key=${AWS_SECRET_KEY}" + 
+                "&& export provider=aws" + 
+                "&& export tfversion=${TF_VERSION}" + 
+                "&& export TF_VAR_cluster_name=${hostname_prefix}"+"$aws_cluster_name" + 
+                "&& export TF_VAR_hostname_prefix_etcd=${hostname_prefix}"+"$etcd_suffix" + 
+                "&& export TF_VAR_hostname_prefix_cp=${hostname_prefix}"+"$cp_suffix" + 
+                "&& export TF_VAR_hostname_prefix_worker=${hostname_prefix}"+"$worker_suffix" + 
+                "&& export TF_VAR_worker_count=${worker_count}" + 
+                "&& export TF_VAR_ami=${AWS_AMI}" +  
+                "&& export TF_VAR_ami_user=${AWS_AMI_USER}" + 
+                "&& export TF_VAR_k8s_version=${k8s_version}" +
+                "&& go run .\""
+              }
+
+              if (DO_ACCESS_KEY != "") { 
+                sh "docker run --name ${testContainer} -t --env-file ${envFile} " + 
+                "${imageName} sh -c \"export TF_VAR_rancher_api_url=${RANCHER_API_URL}" + 
+                "&& export TF_VAR_rancher_token_key=${RANCHER_TOKEN_KEY}" + 
+                "&& export provider=do" + 
+                "&& export tfversion=${TF_VERSION}" + 
+                "&& export TF_VAR_cluster_name=${hostname_prefix}"+"$do_cluster_name" + 
+                "&& export TF_VAR_hostname_prefix_etcd=${hostname_prefix}"+"$etcd_suffix" + 
+                "&& export TF_VAR_hostname_prefix_cp=${hostname_prefix}"+"$cp_suffix" + 
+                "&& export TF_VAR_hostname_prefix_worker=${hostname_prefix}"+"$worker_suffix" + 
+                "&& export TF_VAR_do_access_token=${DO_ACCESS_KEY}" + 
+                "&& export TF_VAR_worker_count=${worker_count}" + 
+                "&& go run .\""
+              }
+            }
+          } catch(err) {
+            echo 'Test run had failures. Collecting results...'
+          }
+
+          try {
+            stage('Cleanup') {
+              sh "docker rm -v ${testContainer}"
+              sh "docker rmi ${imageName}"
+            }
+          } catch(err){
+            sh "docker stop ${testContainer}"
+            sh "docker rm -v ${testContainer}"
+            sh "docker rmi ${imageName}"
+          }
+        }
+      }
+    }
+  } 
+  }
+}

--- a/tests/v2/validation/resource/terraform/v1charts/aws/main.tf
+++ b/tests/v2/validation/resource/terraform/v1charts/aws/main.tf
@@ -1,0 +1,204 @@
+#Cluster creation with v1 charts installed
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    rancher2 = {
+      source = "rancher/rancher2"
+    }
+
+  }
+}
+
+provider "rancher2" {
+  api_url   = var.rancher_api_url
+  token_key = var.rancher_token_key
+}
+
+resource "rancher2_cluster" "custom" {
+  name = var.cluster_name
+  description = "Rancher v1 Charts Cluster"
+  rke_config {
+    kubernetes_version = var.k8s_version
+    network {
+      plugin = "canal"
+    }
+  }  
+  enable_cluster_monitoring = true
+  cluster_monitoring_input {
+    answers = {
+      "exporter-kubelets.https" = true
+      "exporter-node.enabled" = true
+      "exporter-node.ports.metrics.port" = 9796
+      "exporter-node.resources.limits.cpu" = "200m"
+      "exporter-node.resources.limits.memory" = "200Mi"
+      "grafana.persistence.enabled" = false
+      "grafana.persistence.size" = "10Gi"
+      "grafana.persistence.storageClass" = "default"
+      "operator.resources.limits.memory" = "500Mi"
+      "prometheus.persistence.enabled" = "false"
+      "prometheus.persistence.size" = "50Gi"
+      "prometheus.persistence.storageClass" = "default"
+      "prometheus.persistent.useReleaseName" = "true"
+      "prometheus.resources.core.limits.cpu" = "1000m",
+      "prometheus.resources.core.limits.memory" = "1500Mi"
+      "prometheus.resources.core.requests.cpu" = "750m"
+      "prometheus.resources.core.requests.memory" = "750Mi"
+      "prometheus.retention" = "12h"
+    }
+  }
+}
+
+resource "rancher2_node_template" "node-template" {
+  name = "tf-aws-node-template"
+  description = "TF AWS node template"
+
+  amazonec2_config {
+    access_key = var.aws_access_key
+    secret_key = var.aws_secret_key
+    ami =  var.ami
+    region = var.aws_region
+    security_group = var.security_groups
+    subnet_id = var.subnet
+    vpc_id = var.vpc_id
+    zone = var.zone
+    root_size = var.root_size
+    instance_type = var.instance_type
+  }
+}
+
+resource "rancher2_node_pool" "cp-node-pool" {
+  cluster_id =  rancher2_cluster.custom.id
+  name = "tf-cp-node-pool"
+  hostname_prefix = var.hostname_prefix_cp
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = 1
+  control_plane = true
+  etcd = false
+  worker = false
+}
+
+resource "rancher2_node_pool" "etcd-node-pool" {
+  cluster_id =  rancher2_cluster.custom.id
+  name = "tf-etcd-node-pool"
+  hostname_prefix = var.hostname_prefix_etcd
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = 1
+  control_plane = false
+  etcd = true
+  worker = false
+}
+
+resource "rancher2_node_pool" "worker-node-pool" {
+  cluster_id =  rancher2_cluster.custom.id
+  name = "tf-worker-node-pool"
+  hostname_prefix = var.hostname_prefix_worker
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = var.worker_count
+  control_plane = false
+  etcd = false
+  worker = true
+}
+
+resource "rancher2_cluster_sync" "custom-sync" {
+  cluster_id = rancher2_cluster.custom.id
+}
+
+resource "rancher2_namespace" "istio-namespace" {
+  name = "istio-system"
+  project_id = rancher2_cluster_sync.custom-sync.system_project_id
+  description = "istio namespace"
+}
+
+resource "rancher2_app" "istio" {
+  catalog_name = "system-library"
+  name = "cluster-istio"
+  description = "Terraform app acceptance test"
+  project_id = rancher2_cluster_sync.custom-sync.system_project_id
+  template_name = "rancher-istio"
+  template_version = "1.5.901"
+  target_namespace = rancher2_namespace.istio-namespace.id
+  answers = {
+    "certmanager.enabled" = false
+    "enableCRDs" = true
+    "galley.enabled" = true
+    "gateways.enabled" = false
+    "gateways.istio-ingressgateway.resources.limits.cpu" = "2000m"
+    "gateways.istio-ingressgateway.resources.limits.memory" = "1024Mi"
+    "gateways.istio-ingressgateway.resources.requests.cpu" = "100m"
+    "gateways.istio-ingressgateway.resources.requests.memory" = "128Mi"
+    "gateways.istio-ingressgateway.type" = "NodePort"
+    "global.monitoring.type" = "cluster-monitoring"
+    "global.rancher.clusterId" = rancher2_cluster_sync.custom-sync.cluster_id
+    "istio_cni.enabled" = false
+    "istiocoredns.enabled" = false
+    "kiali.enabled" = true
+    "mixer.enabled" = true
+    "mixer.policy.enabled" = true
+    "mixer.policy.resources.limits.cpu" = "4800m"
+    "mixer.policy.resources.limits.memory" = "4096Mi"
+    "mixer.policy.resources.requests.cpu" = "1000m"
+    "mixer.policy.resources.requests.memory" = "1024Mi"
+    "mixer.telemetry.resources.limits.cpu" = "4800m",
+    "mixer.telemetry.resources.limits.memory" = "4096Mi"
+    "mixer.telemetry.resources.requests.cpu" = "1000m"
+    "mixer.telemetry.resources.requests.memory" = "1024Mi"
+    "mtls.enabled" = false
+    "nodeagent.enabled" = false
+    "pilot.enabled" = true
+    "pilot.resources.limits.cpu" = "1000m"
+    "pilot.resources.limits.memory" = "4096Mi"
+    "pilot.resources.requests.cpu" = "500m"
+    "pilot.resources.requests.memory" = "2048Mi"
+    "pilot.traceSampling" = "1"
+    "security.enabled" = true
+    "sidecarInjectorWebhook.enabled" = true
+    "tracing.enabled" = true
+    "tracing.jaeger.resources.limits.cpu" = "500m"
+    "tracing.jaeger.resources.limits.memory" = "1024Mi"
+    "tracing.jaeger.resources.requests.cpu" = "100m"
+    "tracing.jaeger.resources.requests.memory" = "100Mi"
+  }
+}
+
+resource "rancher2_cluster_logging" "cluster-logging" {
+  name = "cluster-logging"
+  cluster_id = rancher2_cluster.custom.id
+  kind = "syslog"
+  syslog_config {
+    endpoint = var.rancher_api_url
+    protocol = "udp"
+    severity = "notice"
+    ssl_verify = false
+  }
+}
+
+resource "rancher2_namespace" "longhorn-system-namespace" {
+  name = "longhorn-system"
+  project_id = rancher2_cluster_sync.custom-sync.system_project_id
+  description = "longhorn-system namespace"
+}
+
+resource "rancher2_app" "longhorn-system" {
+  catalog_name = "library"
+  name = "longhorn"
+  description = "Terraform app acceptance test"
+  project_id = rancher2_cluster_sync.custom-sync.system_project_id
+  template_name = "longhorn"
+  target_namespace = rancher2_namespace.longhorn-system-namespace.id
+  answers = {
+    "image.defaultImage" = true
+    "privateRegistry.registryUrl" = ""
+    "privateRegistry.registryUser" = ""
+    "privateRegistry.registryPasswd" = ""
+    "privateRegistry.registrySecret" = ""
+    "longhorn.default_setting" = false
+    "persistence.defaultClass" = true
+    "persistence.reclaimPolicy" = "Delete"
+    "persistence.defaultClassReplicaCount" = "3"
+    "persistence.recurringJobSelector.enable" = false
+    "persistence.backingImage.enable" = false
+    "ingress.enabled" = false
+    "service.ui.type" = "Rancher-Proxy"
+    "enablePSP" = true
+  }
+}

--- a/tests/v2/validation/resource/terraform/v1charts/aws/variables.tf
+++ b/tests/v2/validation/resource/terraform/v1charts/aws/variables.tf
@@ -1,0 +1,113 @@
+variable "rancher_api_url" {
+  type    = string
+  default = ""
+}
+
+variable "rancher_token_key" {
+  type    = string
+  default = ""
+}
+
+variable "ami" {
+  type        = string
+  default     = "ami-001ed96da090fdb2c"
+  description = "ami to use"
+}
+
+variable "subnet" {
+  type        = string
+  default     = ""
+  description = "subnet to use"
+}
+
+variable "security_groups" {
+  type        = list
+  default     = []
+  description = "security group ids to use"
+}
+
+variable "ami_user" {
+  type        = string
+  default     = "ubuntu"
+  description = "User for the ami (used for ssh provisioning)"
+}
+
+variable "node_name" {
+  type        = string
+  default     = "tf-charts"
+  description = "AWS node name"
+}
+
+variable "vpc_id" {
+  type        = string
+  default     = "vpc-bfccf4d7"
+  description = "AWS VPC ID"
+}
+
+variable "zone" {
+  type        = string
+  default     = ""
+  description = "AWS Zone"
+}
+
+variable "root_size" {
+  type        = string
+  default     = "80"
+  description = "AWS Root Size"
+}
+
+variable "instance_type" {
+  type        = string
+  default     = "t3.xlarge"
+  description = "AWS Instance Type"
+}
+
+variable "aws_access_key" {
+  type        = string
+  description = "AWS Access Key"
+}
+
+variable "aws_secret_key" {
+  type        = string
+  description = "AWS Secret Key"
+}
+
+variable "aws_region" {
+  type        = string
+  default     = "us-east-2"
+  description = "AWS Region"
+}
+variable "cluster_name" {
+  type        = string
+  default     = "aws-tf-charts"
+  description = "Cluster name"
+}
+variable "hostname_prefix_cp" {
+  type        = string
+  default     = "tf-controlplane-0"
+  description = "Hostname Prefix for EC2 Instances"
+}
+
+variable "hostname_prefix_etcd" {
+  type        = string
+  default     = "tf-etcd-0"
+  description = "Hostname Prefix for EC2 Instances"
+}
+
+variable "hostname_prefix_worker" {
+  type        = string
+  default     = "tf-worker-0"
+  description = "Hostname Prefix for EC2 Instances"
+}
+
+variable "worker_count" {
+  type        = number
+  default     = 3
+  description = "Worker count for cluster"
+}
+
+variable "k8s_version" {
+  type        = string
+  default     = ""
+  description = "Kubernetes Version"
+}

--- a/tests/v2/validation/resource/terraform/v1charts/build.sh
+++ b/tests/v2/validation/resource/terraform/v1charts/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -x
+set -eu
+
+DEBUG="${DEBUG:-false}"
+RKE_VERSION="${RKE_VERSION:-v1.0.2}"
+RANCHER_HELM_VERSION="${RANCHER_HELM_VERSION:-v3.6.0}"
+KUBECTL_VERSION="${KUBECTL_VERSION:-v1.16.6}"
+CLI_VERSION="${CLI_VERSION:-v2.4.5}"
+SONOBUOY_VERSION="${SONOBUOY_VERSION:-0.18.2}"
+TERRAFORM_VERSION="${TERRAFORM_VERSION:-0.12.10}"
+
+TRIM_JOB_NAME=$(basename "$JOB_NAME")
+
+if [ "false" != "${DEBUG}" ]; then
+    echo "Environment:"
+    env | sort
+fi
+
+count=0
+while [[ 3 -gt $count ]]; do
+    docker build -q -f tests/v2/validation/resource/terraform/v1charts/Dockerfile.v1charts --build-arg CLI_VERSION="$CLI_VERSION" --build-arg RKE_VERSION="$RKE_VERSION" --build-arg RANCHER_HELM_VERSION="$RANCHER_HELM_VERSION" --build-arg KUBECTL_VERSION="$KUBECTL_VERSION" --build-arg SONOBUOY_VERSION="$SONOBUOY_VERSION" --build-arg TERRAFORM_VERSION="$TERRAFORM_VERSION" -t rancher-validation-"${TRIM_JOB_NAME}""${BUILD_NUMBER}" .
+    if [[ $? -eq 0 ]]; then break; fi
+    count=$(($count + 1))
+    echo "Repeating failed Docker build ${count} of 3..."
+done

--- a/tests/v2/validation/resource/terraform/v1charts/configure.sh
+++ b/tests/v2/validation/resource/terraform/v1charts/configure.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -x
+set -eu
+
+DEBUG="${DEBUG:-false}"
+
+env | egrep '^(ARM_|CATTLE_|ADMIN|USER|DO|RANCHER_|AWS_|DEBUG|LOGLEVEL|DEFAULT_|OS_|DOCKER_|CLOUD_|KUBE|BUILD_NUMBER|AZURE).*\=.+' | sort > .env
+
+if [ "false" != "${DEBUG}" ]; then
+    cat .env
+fi

--- a/tests/v2/validation/resource/terraform/v1charts/do/main.tf
+++ b/tests/v2/validation/resource/terraform/v1charts/do/main.tf
@@ -1,0 +1,199 @@
+#Cluster creation with v1 charts installed
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    rancher2 = {
+      source = "rancher/rancher2"
+    }
+
+  }
+}
+
+provider "rancher2" {
+  api_url   = var.rancher_api_url
+  token_key = var.rancher_token_key
+}
+
+resource "rancher2_cluster" "custom" {
+  name = var.cluster_name
+  description = "Rancher v1 Charts Cluster"
+  rke_config {
+    kubernetes_version = var.k8s_version
+    network {
+      plugin = "canal"
+    }
+  }  
+  enable_cluster_monitoring = true
+  cluster_monitoring_input {
+    answers = {
+      "exporter-kubelets.https" = true
+      "exporter-node.enabled" = true
+      "exporter-node.ports.metrics.port" = 9796
+      "exporter-node.resources.limits.cpu" = "200m"
+      "exporter-node.resources.limits.memory" = "200Mi"
+      "grafana.persistence.enabled" = false
+      "grafana.persistence.size" = "10Gi"
+      "grafana.persistence.storageClass" = "default"
+      "operator.resources.limits.memory" = "500Mi"
+      "prometheus.persistence.enabled" = "false"
+      "prometheus.persistence.size" = "50Gi"
+      "prometheus.persistence.storageClass" = "default"
+      "prometheus.persistent.useReleaseName" = "true"
+      "prometheus.resources.core.limits.cpu" = "1000m",
+      "prometheus.resources.core.limits.memory" = "1500Mi"
+      "prometheus.resources.core.requests.cpu" = "750m"
+      "prometheus.resources.core.requests.memory" = "750Mi"
+      "prometheus.retention" = "12h"
+    }
+  }
+}
+
+resource "rancher2_node_template" "node-template" {
+  name = "tf-do-node-template"
+  description = "TF DO node template"
+  engine_install_url = "https://releases.rancher.com/install-docker/20.10.sh"
+  
+  digitalocean_config {
+    access_token = var.do_access_token
+    region = var.region
+    size = var.size
+    image = var.image
+  }
+}
+
+resource "rancher2_node_pool" "cp-node-pool" {
+  cluster_id =  rancher2_cluster.custom.id
+  name = "tf-cp-node-pool"
+  hostname_prefix = var.hostname_prefix_cp
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = 1
+  control_plane = true
+  etcd = false
+  worker = false
+}
+
+resource "rancher2_node_pool" "etcd-node-pool" {
+  cluster_id =  rancher2_cluster.custom.id
+  name = "tf-etcd-node-pool"
+  hostname_prefix = var.hostname_prefix_etcd
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = 1
+  control_plane = false
+  etcd = true
+  worker = false
+}
+
+resource "rancher2_node_pool" "worker-node-pool" {
+  cluster_id =  rancher2_cluster.custom.id
+  name = "tf-worker-node-pool"
+  hostname_prefix = var.hostname_prefix_worker
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = var.worker_count
+  control_plane = false
+  etcd = false
+  worker = true
+}
+
+resource "rancher2_cluster_sync" "custom-sync" {
+  cluster_id = rancher2_cluster.custom.id
+}
+
+resource "rancher2_namespace" "istio-namespace" {
+  name = "istio-system"
+  project_id = rancher2_cluster_sync.custom-sync.system_project_id
+  description = "istio namespace"
+}
+
+resource "rancher2_app" "istio" {
+  catalog_name = "system-library"
+  name = "cluster-istio"
+  description = "Terraform app acceptance test"
+  project_id = rancher2_cluster_sync.custom-sync.system_project_id
+  template_name = "rancher-istio"
+  template_version = "1.5.901"
+  target_namespace = rancher2_namespace.istio-namespace.id
+  answers = {
+    "certmanager.enabled" = false
+    "enableCRDs" = true
+    "galley.enabled" = true
+    "gateways.enabled" = false
+    "gateways.istio-ingressgateway.resources.limits.cpu" = "2000m"
+    "gateways.istio-ingressgateway.resources.limits.memory" = "1024Mi"
+    "gateways.istio-ingressgateway.resources.requests.cpu" = "100m"
+    "gateways.istio-ingressgateway.resources.requests.memory" = "128Mi"
+    "gateways.istio-ingressgateway.type" = "NodePort"
+    "global.monitoring.type" = "cluster-monitoring"
+    "global.rancher.clusterId" = rancher2_cluster_sync.custom-sync.cluster_id
+    "istio_cni.enabled" = false
+    "istiocoredns.enabled" = false
+    "kiali.enabled" = true
+    "mixer.enabled" = true
+    "mixer.policy.enabled" = true
+    "mixer.policy.resources.limits.cpu" = "4800m"
+    "mixer.policy.resources.limits.memory" = "4096Mi"
+    "mixer.policy.resources.requests.cpu" = "1000m"
+    "mixer.policy.resources.requests.memory" = "1024Mi"
+    "mixer.telemetry.resources.limits.cpu" = "4800m",
+    "mixer.telemetry.resources.limits.memory" = "4096Mi"
+    "mixer.telemetry.resources.requests.cpu" = "1000m"
+    "mixer.telemetry.resources.requests.memory" = "1024Mi"
+    "mtls.enabled" = false
+    "nodeagent.enabled" = false
+    "pilot.enabled" = true
+    "pilot.resources.limits.cpu" = "1000m"
+    "pilot.resources.limits.memory" = "4096Mi"
+    "pilot.resources.requests.cpu" = "500m"
+    "pilot.resources.requests.memory" = "2048Mi"
+    "pilot.traceSampling" = "1"
+    "security.enabled" = true
+    "sidecarInjectorWebhook.enabled" = true
+    "tracing.enabled" = true
+    "tracing.jaeger.resources.limits.cpu" = "500m"
+    "tracing.jaeger.resources.limits.memory" = "1024Mi"
+    "tracing.jaeger.resources.requests.cpu" = "100m"
+    "tracing.jaeger.resources.requests.memory" = "100Mi"
+  }
+}
+
+resource "rancher2_cluster_logging" "cluster-logging" {
+  name = "cluster-logging"
+  cluster_id = rancher2_cluster.custom.id
+  kind = "syslog"
+  syslog_config {
+    endpoint = var.rancher_api_url
+    protocol = "udp"
+    severity = "notice"
+    ssl_verify = false
+  }
+}
+
+resource "rancher2_namespace" "longhorn-system-namespace" {
+  name = "longhorn-system"
+  project_id = rancher2_cluster_sync.custom-sync.system_project_id
+  description = "longhorn-system namespace"
+}
+
+resource "rancher2_app" "longhorn-system" {
+  catalog_name = "library"
+  name = "longhorn"
+  description = "Terraform app acceptance test"
+  project_id = rancher2_cluster_sync.custom-sync.system_project_id
+  template_name = "longhorn"
+  target_namespace = rancher2_namespace.longhorn-system-namespace.id
+  answers = {
+    "image.defaultImage" = true
+    "privateRegistry.registryUrl" = ""
+    "privateRegistry.registryUser" = ""
+    "privateRegistry.registryPasswd" = ""
+    "privateRegistry.registrySecret" = ""
+    "longhorn.default_setting" = false
+    "persistence.defaultClass" = true
+    "persistence.reclaimPolicy" = "Delete"
+    "persistence.defaultClassReplicaCount" = "3"
+    "persistence.recurringJobSelector.enable" = false
+    "persistence.backingImage.enable" = false
+    "ingress.enabled" = false
+    "service.ui.type" = "Rancher-Proxy"
+    "enablePSP" = true
+  }
+}

--- a/tests/v2/validation/resource/terraform/v1charts/do/variables.tf
+++ b/tests/v2/validation/resource/terraform/v1charts/do/variables.tf
@@ -1,0 +1,58 @@
+variable "rancher_api_url" {
+  type    = string
+  default = ""
+}
+variable "rancher_token_key" {
+  type    = string
+  default = ""
+}
+variable "do_access_token" {
+  type    = string
+  default = ""
+}
+variable "region" {
+  type        = string
+  default     = "sfo3"
+  description = "DO zone"
+}
+variable "size" {
+  type        = string
+  default     = "s-4vcpu-8gb"
+  description = "DO instance size"
+}
+variable "image" {
+  type        = string
+  default     = "ubuntu-20-04-x64"
+  description = "DO image for droplet"
+}
+variable "cluster_name" {
+  type        = string
+  default     = "do-tf-charts"
+  description = "Cluster name"
+}
+variable "hostname_prefix_cp" {
+  type        = string
+  default     = "tf-controlplane-0"
+  description = "Hostname Prefix for control plane droplet"
+}
+variable "hostname_prefix_etcd" {
+  type        = string
+  default     = "tf-etcd-0"
+  description = "Hostname Prefix for etcd droplet"
+}
+
+variable "hostname_prefix_worker" {
+  type        = string
+  default     = "tf-worker-0"
+  description = "Hostname Prefix for worker droplet"
+}
+variable "worker_count" {
+  type        = number
+  default     = 3
+  description = "Worker count for cluster"
+}
+variable "k8s_version" {
+  type        = string
+  default     = ""
+  description = "Kubernetes Version"
+}

--- a/tests/v2/validation/resource/terraform/v1charts/test.go
+++ b/tests/v2/validation/resource/terraform/v1charts/test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hc-install/product"
+	"github.com/hashicorp/hc-install/releases"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+func main() {
+	installer := &releases.ExactVersion{
+		Product: product.Terraform,
+		Version: version.Must(version.NewVersion(os.Getenv("tfversion"))),
+	}
+
+	execPath, err := installer.Install(context.Background())
+	if err != nil {
+		log.Fatalf("error installing Terraform: %s", err)
+	}
+
+	workingDir := os.Getenv("provider")
+	tf, err := tfexec.NewTerraform(workingDir, execPath)
+	if err != nil {
+		log.Fatalf("error running NewTerraform: %s", err)
+	}
+
+	err = tf.Init(context.Background(), tfexec.Upgrade(true))
+	if err != nil {
+		log.Fatalf("error running Init: %s", err)
+	}
+
+	err = tf.Apply(context.Background())
+	if err != nil {
+		log.Fatalf("error running Apply: %s", err)
+	}
+
+	state, err := tf.Show(context.Background())
+	if err != nil {
+		log.Fatalf("error running Show: %s", err)
+	}
+
+	fmt.Println("Using v" + state.FormatVersion + "\nChart installations initiated") // "0.1"
+
+}

--- a/tests/v2/validation/resource/terraform/v2charts/Dockerfile.v2charts
+++ b/tests/v2/validation/resource/terraform/v2charts/Dockerfile.v2charts
@@ -1,0 +1,14 @@
+FROM golang:1.16
+
+# Configure Go
+ENV GOPATH /go
+ENV PATH ${PATH}:/go/bin
+
+ENV WORKSPACE ${GOPATH}/src/github.com/rancher/rancher
+
+WORKDIR $WORKSPACE/tests/v2/validation/resource/terraform/v2charts
+
+COPY [".", "$WORKSPACE"]
+
+RUN go mod init main
+RUN go mod tidy

--- a/tests/v2/validation/resource/terraform/v2charts/Jenkinsfile
+++ b/tests/v2/validation/resource/terraform/v2charts/Jenkinsfile
@@ -1,0 +1,177 @@
+// Job Params
+// Requires: PYTEST_OPTIONS, CATTLE_TEST_URL, ADMIN_TOKEN
+// Optional: AWS_SSH_PEM_KEY, AWS_SSH_KEY_NAME, DEBUG
+
+node {
+  def job_name = "${JOB_NAME}"
+  if (job_name.contains('/')) { 
+    job_names = job_name.split('/')
+    job_name = job_names[job_names.size() - 1] 
+  }
+  def testContainer = "${job_name}${env.BUILD_NUMBER}_test"
+
+  def imageName = "rancher-validation-${job_name}${env.BUILD_NUMBER}"
+  def envFile = ".env"
+  def RANCHER_API_URL = "${env.RANCHER_API_URL}"
+  def RANCHER_TOKEN_KEY = "${env.RANCHER_TOKEN_KEY}"
+  def TF_VERSION = "${env.TF_VERSION}"
+  def AWS_ACCESS_KEY = "${env.AWS_ACCESS_KEY}"
+  def AWS_SECRET_KEY = "${env.AWS_SECRET_KEY}"
+  def DO_ACCESS_KEY = "${env.DO_ACCESS_KEY}"
+  def monitoring_version = "${env.RANCHER_MONITORING_V2_VERSION}"
+  def logging_version = "${env.RANCHER_LOGGING_V2_VERSION}"
+  def kiali_version = "${env.RANCHER_KIALI_V2_VERSION}"
+  def istio_version = "${env.RANCHER_ISTIO_V2_VERSION}"
+  def cis_version = "${env.RANCHER_CIS_V2_VERSION}"
+  def gatekeeper_version = "${env.RANCHER_GATEKEEPER_V2_VERSION}"
+  def backup_version = "${env.RANCHER_BACKUP_V2_VERSION}"
+  def longhorn_version = "${env.RANCHER_LONGHORN_V2_VERSION}"
+  def cluster_id = "${env.cluster_id}"
+  def project_id = "${env.project_id}"
+  def hostname_prefix = "${env.HOSTNAME_PREFIX}"
+  def worker_count = "${env.WORKER_COUNT}"
+  def AWS_AMI = "${env.AWS_AMI}"
+  def AWS_AMI_USER = "${env.AWS_AMI_USER}"
+  def k8s_version = "${env.K8S_VERSION}"
+  def suffix = "-tf-cluster-0"
+  def etcd_suffix = "-tf-etcd-0"
+  def cp_suffix = "-tf-controlplane-0"
+  def worker_suffix = "-tf-worker-0"
+  def aws_cluster_name = "-aws-tf-charts"
+  def do_cluster_name = "-do-tf-charts"
+
+  def branch = "release/v2.6"
+  if ("${env.branch}" != "null" && "${env.branch}" != "") {
+    branch = "${env.branch}"
+  }
+
+  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+    withFolderProperties {
+      paramsMap = []
+      params.each {
+        paramsMap << "$it.key=$it.value"
+      }
+      withEnv(paramsMap) {
+      withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                        string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+                        string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                        string(credentialsId: 'DO_ACCESSKEY', variable: 'DO_ACCESSKEY'),
+                        string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                        string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD')
+                        ]) {
+                          
+        stage('Checkout') {
+          deleteDir()
+          checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: "*/${branch}"]],
+                    extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                    userRemoteConfigs: scm.userRemoteConfigs
+                  ])
+        }
+
+        dir ("./") {
+          stage('Configure and Build') {
+            if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
+              dir(".ssh") {
+                def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
+                writeFile file: AWS_SSH_KEY_NAME, text: decoded
+              }
+            }
+
+            sh "./tests/v2/validation/resource/terraform/v2charts/configure.sh"
+            sh "./tests/v2/validation/resource/terraform/v2charts/build.sh"
+          }
+
+          try {
+            stage('Run Chart Installation') {
+                if (cluster_id == "") {
+                  if (AWS_ACCESS_KEY != "") {
+                    sh "docker run --name ${testContainer} -t --env-file ${envFile} " + 
+                    "${imageName} sh -c \"export TF_VAR_rancher_api_url=${RANCHER_API_URL}" + 
+                    "&& export TF_VAR_rancher_token_key=${RANCHER_TOKEN_KEY}" + 
+                    "&& export TF_VAR_aws_access_key=${AWS_ACCESS_KEY}" + 
+                    "&& export TF_VAR_aws_secret_key=${AWS_SECRET_KEY}" + 
+                    "&& export provider=provision/aws" + 
+                    "&& export tfversion=${TF_VERSION}" + 
+                    "&& export TF_VAR_cluster_name=${hostname_prefix}"+"$aws_cluster_name" + 
+                    "&& export TF_VAR_hostname_prefix_etcd=${hostname_prefix}"+"$etcd_suffix" + 
+                    "&& export TF_VAR_hostname_prefix_cp=${hostname_prefix}"+"$cp_suffix" + 
+                    "&& export TF_VAR_hostname_prefix_worker=${hostname_prefix}"+"$worker_suffix" + 
+                    "&& export TF_VAR_worker_count=${worker_count}" + 
+                    "&& export TF_VAR_ami=${AWS_AMI}" +  
+                    "&& export TF_VAR_ami_user=${AWS_AMI_USER}" + 
+                    "&& export TF_VAR_k8s_version=${k8s_version}" +
+                    "&& export TF_VAR_monitoring_version=${monitoring_version}" + 
+                    "&& export TF_VAR_logging_version=${logging_version}" + 
+                    "&& export TF_VAR_kiali_versiony=${kiali_version}" + 
+                    "&& export TF_VAR_istio_version=${istio_version}" + 
+                    "&& export TF_VAR_cis_version=${cis_version}" +
+                    "&& export TF_VAR_longhorn_version=${longhorn_version}" + 
+                    "&& export TF_VAR_backup_version=${backup_version}" + 
+                    "&& export TF_VAR_gatekeeper_version=${gatekeeper_version}" +
+                    "&& go run .\""
+                  }
+
+                  if (DO_ACCESS_KEY != "") { 
+                    sh "docker run --name ${testContainer} -t --env-file ${envFile} " + 
+                    "${imageName} sh -c \"export TF_VAR_rancher_api_url=${RANCHER_API_URL}" + 
+                    "&& export TF_VAR_rancher_token_key=${RANCHER_TOKEN_KEY}" + 
+                    "&& export provider=provision/do" + 
+                    "&& export tfversion=${TF_VERSION}" + 
+                    "&& export TF_VAR_cluster_name=${hostname_prefix}"+"$do_cluster_name" + 
+                    "&& export TF_VAR_hostname_prefix_etcd=${hostname_prefix}"+"$etcd_suffix" + 
+                    "&& export TF_VAR_hostname_prefix_cp=${hostname_prefix}"+"$cp_suffix" + 
+                    "&& export TF_VAR_hostname_prefix_worker=${hostname_prefix}"+"$worker_suffix" + 
+                    "&& export TF_VAR_do_access_token=${DO_ACCESS_KEY}" + 
+                    "&& export TF_VAR_worker_count=${worker_count}" + 
+                    "&& export TF_VAR_k8s_version=${k8s_version}" +
+                    "&& export TF_VAR_monitoring_version=${monitoring_version}" + 
+                    "&& export TF_VAR_logging_version=${logging_version}" + 
+                    "&& export TF_VAR_kiali_versiony=${kiali_version}" + 
+                    "&& export TF_VAR_istio_version=${istio_version}" + 
+                    "&& export TF_VAR_cis_version=${cis_version}" +
+                    "&& export TF_VAR_longhorn_version=${longhorn_version}" + 
+                    "&& export TF_VAR_backup_version=${backup_version}" + 
+                    "&& export TF_VAR_gatekeeper_version=${gatekeeper_version}" +
+                    "&& go run .\""
+                  }
+                } else {
+                  sh "docker run --name ${testContainer} -t --env-file ${envFile} " + 
+                  "${imageName} sh -c \"export TF_VAR_rancher_api_url=${RANCHER_API_URL}" + 
+                  "&& export TF_VAR_rancher_token_key=${RANCHER_TOKEN_KEY}" + 
+                  "&& export provider=target" + 
+                  "&& export TF_VAR_monitoring_version=${monitoring_version}" + 
+                  "&& export TF_VAR_logging_version=${logging_version}" + 
+                  "&& export TF_VAR_kiali_versiony=${kiali_version}" + 
+                  "&& export TF_VAR_istio_version=${istio_version}" + 
+                  "&& export TF_VAR_cis_version=${cis_version}" +
+                  "&& export TF_VAR_longhorn_version=${longhorn_version}" + 
+                  "&& export TF_VAR_backup_version=${backup_version}" + 
+                  "&& export TF_VAR_gatekeeper_version=${gatekeeper_version}" +
+                  "&& export TF_VAR_cluster_id=${cluster_id}" + 
+                  "&& export TF_VAR_project_id=${project_id}" + 
+                  "&& export tfversion=${TF_VERSION}" + 
+                  "&& go run .\""
+                }
+            }
+          } catch(err) {
+            echo 'Test run had failures. Collecting results...'
+          }
+
+          try {
+            stage('Cleanup') {
+              sh "docker rm -v ${testContainer}"
+              sh "docker rmi ${imageName}"
+            }
+          } catch(err){
+            sh "docker stop ${testContainer}"
+            sh "docker rm -v ${testContainer}"
+            sh "docker rmi ${imageName}"
+          }
+        }
+      }
+    }
+  } 
+  }
+}

--- a/tests/v2/validation/resource/terraform/v2charts/build.sh
+++ b/tests/v2/validation/resource/terraform/v2charts/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -x
+set -eu
+
+DEBUG="${DEBUG:-false}"
+RKE_VERSION="${RKE_VERSION:-v1.0.2}"
+RANCHER_HELM_VERSION="${RANCHER_HELM_VERSION:-v3.6.0}"
+KUBECTL_VERSION="${KUBECTL_VERSION:-v1.16.6}"
+CLI_VERSION="${CLI_VERSION:-v2.4.5}"
+SONOBUOY_VERSION="${SONOBUOY_VERSION:-0.18.2}"
+TERRAFORM_VERSION="${TERRAFORM_VERSION:-0.12.10}"
+
+TRIM_JOB_NAME=$(basename "$JOB_NAME")
+
+if [ "false" != "${DEBUG}" ]; then
+    echo "Environment:"
+    env | sort
+fi
+
+count=0
+while [[ 3 -gt $count ]]; do
+    docker build -q -f tests/v2/validation/resource/terraform/v2charts/Dockerfile.v2charts --build-arg CLI_VERSION="$CLI_VERSION" --build-arg RKE_VERSION="$RKE_VERSION" --build-arg RANCHER_HELM_VERSION="$RANCHER_HELM_VERSION" --build-arg KUBECTL_VERSION="$KUBECTL_VERSION" --build-arg SONOBUOY_VERSION="$SONOBUOY_VERSION" --build-arg TERRAFORM_VERSION="$TERRAFORM_VERSION" -t rancher-validation-"${TRIM_JOB_NAME}""${BUILD_NUMBER}" .
+    if [[ $? -eq 0 ]]; then break; fi
+    count=$(($count + 1))
+    echo "Repeating failed Docker build ${count} of 3..."
+done

--- a/tests/v2/validation/resource/terraform/v2charts/configure.sh
+++ b/tests/v2/validation/resource/terraform/v2charts/configure.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -x
+set -eu
+
+DEBUG="${DEBUG:-false}"
+
+env | egrep '^(ARM_|CATTLE_|ADMIN|USER|DO|RANCHER_|AWS_|DEBUG|LOGLEVEL|DEFAULT_|OS_|DOCKER_|CLOUD_|KUBE|BUILD_NUMBER|AZURE).*\=.+' | sort > .env
+
+if [ "false" != "${DEBUG}" ]; then
+    cat .env
+fi

--- a/tests/v2/validation/resource/terraform/v2charts/provision/aws/main.tf
+++ b/tests/v2/validation/resource/terraform/v2charts/provision/aws/main.tf
@@ -1,0 +1,192 @@
+#Cluster creation with v1 charts installed
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    rancher2 = {
+      source = "rancher/rancher2"
+    }
+
+  }
+}
+
+provider "rancher2" {
+  api_url   = var.rancher_api_url
+  token_key = var.rancher_token_key
+}
+
+resource "rancher2_cluster" "v2charts" {
+  name = var.cluster_name
+  description = "Rancher v2 Charts Cluster"
+  rke_config {
+    kubernetes_version = var.k8s_version
+    network {
+      plugin = "canal"
+    }
+  }  
+}
+
+resource "rancher2_node_template" "node-template" {
+  name = "tf-aws-node-template"
+  description = "TF AWS node template"
+
+  amazonec2_config {
+    access_key = var.aws_access_key
+    secret_key = var.aws_secret_key
+    ami =  var.ami
+    ssh_user = var.ami_user
+    region = var.aws_region
+    security_group = var.security_groups
+    subnet_id = var.subnet
+    vpc_id = var.vpc_id
+    zone = var.zone
+    root_size = var.root_size
+    instance_type = var.instance_type
+  }
+}
+
+resource "rancher2_node_pool" "cp-node-pool" {
+  cluster_id =  rancher2_cluster.v2charts.id
+  name = "tf-cp-node-pool"
+  hostname_prefix = var.hostname_prefix_cp
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = 1
+  control_plane = true
+  etcd = false
+  worker = false
+}
+
+resource "rancher2_node_pool" "etcd-node-pool" {
+  cluster_id =  rancher2_cluster.v2charts.id
+  name = "tf-etcd-node-pool"
+  hostname_prefix = var.hostname_prefix_etcd
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = 1
+  control_plane = false
+  etcd = true
+  worker = false
+}
+
+resource "rancher2_node_pool" "worker-node-pool" {
+  cluster_id =  rancher2_cluster.v2charts.id
+  name = "tf-worker-node-pool"
+  hostname_prefix = var.hostname_prefix_worker
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = var.worker_count
+  control_plane = false
+  etcd = false
+  worker = true
+}
+
+resource "rancher2_cluster_sync" "v2charts-sync" {
+  cluster_id = rancher2_cluster.v2charts.id
+  wait_catalogs = true
+  state_confirm = 30
+}
+
+
+resource "rancher2_app_v2" "monitoring" {
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-monitoring"
+  namespace = "cattle-monitoring-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-monitoring"
+  chart_version = var.monitoring_version
+  wait = true
+}
+
+resource "rancher2_app_v2" "rancher-kiali-server-crd" {
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-kiali-server-crd"
+  namespace = "istio-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-kiali-server-crd"
+  chart_version = var.kiali_version
+   depends_on = [rancher2_app_v2.monitoring]
+  wait = true
+}
+
+resource "rancher2_app_v2" "istio" {
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-istio"
+  namespace = "istio-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-istio"
+  chart_version = var.istio_version
+  depends_on = [rancher2_app_v2.monitoring,rancher2_app_v2.rancher-kiali-server-crd]
+  wait = true
+}
+
+resource "rancher2_app_v2" "logging" {
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-logging"
+  namespace = "cattle-logging-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-logging"
+  chart_version = var.logging_version
+  wait = true
+}
+
+resource "rancher2_app_v2" "cis-benchmark" {
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-cis-benchmark"
+  namespace = "cis-operator-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-cis-benchmark"
+  chart_version = var.cis_version
+  wait = true
+}
+
+resource "rancher2_app_v2" "rancher-gatekeeper" {  
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-gatekeeper"
+  namespace = "cattle-gatekeeper-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-gatekeeper"
+  chart_version = var.gatekeeper_version
+  depends_on = [rancher2_app_v2.monitoring]
+  wait = true
+}
+
+resource "rancher2_app_v2" "rancher-backup" {  
+  cluster_id = "local"
+  project_id = ""
+  name = "rancher-backup"
+  namespace = "cattle-resources-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-backup"
+  chart_version = var.backup_version
+  values = <<EOF
+persistence:
+  enabled: false
+  size: 2Gi
+  storageClass: '-'
+  volumeName: ""
+s3:
+  bucketName: ""
+  credentialSecretName: ""
+  credentialSecretNamespace: ""
+  enabled: false
+  endpoint: ""
+  endpointCA: ""
+  folder: ""
+  insecureTLSSkipVerify: false
+  region: ""
+EOF
+}
+
+resource "rancher2_app_v2" "longhorn" {  
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-longhorn"
+  namespace = "longhorn-system"
+  repo_name = "rancher-charts"
+  chart_name = "longhorn"
+  chart_version = var.longhorn_version
+  //wait = true
+}

--- a/tests/v2/validation/resource/terraform/v2charts/provision/aws/variables.tf
+++ b/tests/v2/validation/resource/terraform/v2charts/provision/aws/variables.tf
@@ -1,0 +1,155 @@
+variable "rancher_api_url" {
+  type    = string
+  default = ""
+}
+
+variable "rancher_token_key" {
+  type    = string
+  default = ""
+}
+
+variable "ami" {
+  type        = string
+  default     = "ami-001ed96da090fdb2c"
+  description = "ami to use"
+}
+
+variable "subnet" {
+  type        = string
+  default     = ""
+  description = "subnet to use"
+}
+
+variable "security_groups" {
+  type        = list
+  default     = []
+  description = "security group ids to use"
+}
+
+variable "ami_user" {
+  type        = string
+  default     = "ubuntu"
+  description = "User for the ami (used for ssh provisioning)"
+}
+
+variable "node_name" {
+  type        = string
+  default     = "tf-charts"
+  description = "AWS node name"
+}
+
+variable "vpc_id" {
+  type        = string
+  default     = "vpc-bfccf4d7"
+  description = "AWS VPC ID"
+}
+
+variable "zone" {
+  type        = string
+  default     = ""
+  description = "AWS Zone"
+}
+
+variable "root_size" {
+  type        = string
+  default     = "80"
+  description = "AWS Root Size"
+}
+
+variable "instance_type" {
+  type        = string
+  default     = "t3.xlarge"
+  description = "AWS Instance Type"
+}
+
+variable "aws_access_key" {
+  type        = string
+  description = "AWS Access Key"
+}
+
+variable "aws_secret_key" {
+  type        = string
+  description = "AWS Secret Key"
+}
+
+variable "aws_region" {
+  type        = string
+  default     = "us-east-2"
+  description = "AWS Region"
+}
+variable "cluster_name" {
+  type        = string
+  default     = "aws-tf-v2charts"
+  description = "Cluster name"
+}
+variable "hostname_prefix_cp" {
+  type        = string
+  default     = "tf-controlplane-0"
+  description = "Hostname Prefix for EC2 Instances"
+}
+
+variable "hostname_prefix_etcd" {
+  type        = string
+  default     = "tf-etcd-0"
+  description = "Hostname Prefix for EC2 Instances"
+}
+
+variable "hostname_prefix_worker" {
+  type        = string
+  default     = "tf-worker-0"
+  description = "Hostname Prefix for EC2 Instances"
+}
+
+variable "worker_count" {
+  type        = number
+  default     = 3
+  description = "Worker count for cluster"
+}
+
+variable "k8s_version" {
+  type        = string
+  default     = ""
+  description = "Kubernetes Version"
+}
+
+variable "cluster_id" {
+  default = ""
+}
+variable "monitoring_version" {
+  default = ""
+}
+
+variable "kiali_version" {
+  default = ""
+}
+
+variable "istio_version" {
+  default = ""
+}
+
+variable "logging_version" {
+  default = ""
+}
+
+variable "cis_version" {
+  default = ""
+}
+
+variable "gatekeeper_version" {
+  default = ""
+}
+variable "backup_version" {
+  default = ""
+}
+
+variable "longhorn_version" {
+  default = ""
+}
+
+variable "project_id" {
+  default = ""
+}
+
+variable "cluster_provider" {
+  default = ""
+}

--- a/tests/v2/validation/resource/terraform/v2charts/provision/do/main.tf
+++ b/tests/v2/validation/resource/terraform/v2charts/provision/do/main.tf
@@ -1,0 +1,184 @@
+#Cluster creation with v1 charts installed
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    rancher2 = {
+      source = "rancher/rancher2"
+    }
+
+  }
+}
+
+provider "rancher2" {
+  api_url   = var.rancher_api_url
+  token_key = var.rancher_token_key
+}
+
+resource "rancher2_cluster" "v2charts" {
+  name = var.cluster_name
+  description = "Rancher v2 Charts Cluster"
+  rke_config {
+    kubernetes_version = var.k8s_version
+    network {
+      plugin = "canal"
+    }
+  }  
+}
+
+resource "rancher2_node_template" "node-template" {
+  name = "tf-do-node-template"
+  description = "TF DO node template"
+  engine_install_url = "https://releases.rancher.com/install-docker/20.10.sh"
+  
+  digitalocean_config {
+    access_token = var.do_access_token
+    region = var.region
+    size = var.size
+    image = var.image
+  }
+}
+
+resource "rancher2_node_pool" "cp-node-pool" {
+  cluster_id =  rancher2_cluster.v2charts.id
+  name = "tf-cp-node-pool"
+  hostname_prefix = var.hostname_prefix_cp
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = 1
+  control_plane = true
+  etcd = false
+  worker = false
+}
+
+resource "rancher2_node_pool" "etcd-node-pool" {
+  cluster_id =  rancher2_cluster.v2charts.id
+  name = "tf-etcd-node-pool"
+  hostname_prefix = var.hostname_prefix_etcd
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = 1
+  control_plane = false
+  etcd = true
+  worker = false
+}
+
+resource "rancher2_node_pool" "worker-node-pool" {
+  cluster_id =  rancher2_cluster.v2charts.id
+  name = "tf-worker-node-pool"
+  hostname_prefix = var.hostname_prefix_worker
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = var.worker_count
+  control_plane = false
+  etcd = false
+  worker = true
+}
+
+resource "rancher2_cluster_sync" "v2charts-sync" {
+  cluster_id = rancher2_cluster.v2charts.id
+  wait_catalogs = true
+  state_confirm = 30
+}
+
+resource "rancher2_app_v2" "monitoring" {
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-monitoring"
+  namespace = "cattle-monitoring-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-monitoring"
+  chart_version = var.monitoring_version
+  wait = true
+}
+
+resource "rancher2_app_v2" "rancher-kiali-server-crd" {
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-kiali-server-crd"
+  namespace = "istio-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-kiali-server-crd"
+  chart_version = var.kiali_version
+   depends_on = [rancher2_app_v2.monitoring]
+}
+
+resource "rancher2_app_v2" "istio" {
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-istio"
+  namespace = "istio-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-istio"
+  chart_version = var.istio_version
+  depends_on = [rancher2_app_v2.monitoring,rancher2_app_v2.rancher-kiali-server-crd]
+}
+
+resource "rancher2_app_v2" "logging" {
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-logging"
+  namespace = "cattle-logging-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-logging"
+  chart_version = var.logging_version
+  wait = true
+}
+
+resource "rancher2_app_v2" "cis-benchmark" {
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-cis-benchmark"
+  namespace = "cis-operator-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-cis-benchmark"
+  chart_version = var.cis_version
+  wait = true
+}
+
+
+resource "rancher2_app_v2" "rancher-gatekeeper" {  
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-gatekeeper"
+  namespace = "cattle-gatekeeper-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-gatekeeper"
+  chart_version = var.gatekeeper_version
+  depends_on = [rancher2_app_v2.monitoring]
+  wait = true
+}
+
+resource "rancher2_app_v2" "rancher-backup" {  
+  cluster_id = "local"
+  project_id = ""
+  name = "rancher-backup"
+  namespace = "cattle-resources-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-backup"
+  chart_version = var.backup_version
+  values = <<EOF
+persistence:
+  enabled: false
+  size: 2Gi
+  storageClass: '-'
+  volumeName: ""
+s3:
+  bucketName: ""
+  credentialSecretName: ""
+  credentialSecretNamespace: ""
+  enabled: false
+  endpoint: ""
+  endpointCA: ""
+  folder: ""
+  insecureTLSSkipVerify: false
+  region: ""
+EOF
+}
+
+resource "rancher2_app_v2" "longhorn" {  
+  cluster_id = rancher2_cluster.v2charts.id
+  project_id = rancher2_cluster_sync.v2charts-sync.system_project_id
+  name = "rancher-longhorn"
+  namespace = "longhorn-system"
+  repo_name = "rancher-charts"
+  chart_name = "longhorn"
+  chart_version = var.longhorn_version
+  wait = true
+}

--- a/tests/v2/validation/resource/terraform/v2charts/provision/do/variables.tf
+++ b/tests/v2/validation/resource/terraform/v2charts/provision/do/variables.tf
@@ -1,0 +1,100 @@
+variable "rancher_api_url" {
+  type    = string
+  default = ""
+}
+variable "rancher_token_key" {
+  type    = string
+  default = ""
+}
+variable "do_access_token" {
+  type    = string
+  default = ""
+}
+variable "region" {
+  type        = string
+  default     = "sfo3"
+  description = "DO zone"
+}
+variable "size" {
+  type        = string
+  default     = "s-4vcpu-8gb"
+  description = "DO instance size"
+}
+variable "image" {
+  type        = string
+  default     = "ubuntu-20-04-x64"
+  description = "DO image for droplet"
+}
+variable "cluster_name" {
+  type        = string
+  default     = "do-tf-v1charts"
+  description = "Cluster name"
+}
+variable "hostname_prefix_cp" {
+  type        = string
+  default     = "tf-controlplane-0"
+  description = "Hostname Prefix for control plane droplet"
+}
+variable "hostname_prefix_etcd" {
+  type        = string
+  default     = "tf-etcd-0"
+  description = "Hostname Prefix for etcd droplet"
+}
+
+variable "hostname_prefix_worker" {
+  type        = string
+  default     = "tf-worker-0"
+  description = "Hostname Prefix for worker droplet"
+}
+variable "worker_count" {
+  type        = number
+  default     = 3
+  description = "Worker count for cluster"
+}
+variable "k8s_version" {
+  type        = string
+  default     = ""
+  description = "Kubernetes Version"
+}
+
+variable "cluster_id" {
+  default = ""
+}
+variable "monitoring_version" {
+  default = ""
+}
+
+variable "kiali_version" {
+  default = ""
+}
+
+variable "istio_version" {
+  default = ""
+}
+
+variable "logging_version" {
+  default = ""
+}
+
+variable "cis_version" {
+  default = ""
+}
+
+variable "gatekeeper_version" {
+  default = ""
+}
+variable "backup_version" {
+  default = ""
+}
+
+variable "longhorn_version" {
+  default = ""
+}
+
+variable "project_id" {
+  default = ""
+}
+
+variable "cluster_provider" {
+  default = ""
+}

--- a/tests/v2/validation/resource/terraform/v2charts/target/main.tf
+++ b/tests/v2/validation/resource/terraform/v2charts/target/main.tf
@@ -1,0 +1,123 @@
+#Cluster creation with v1 charts installed
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    rancher2 = {
+      source = "rancher/rancher2"
+    }
+
+  }
+}
+
+provider "rancher2" {
+  api_url   = var.rancher_api_url
+  token_key = var.rancher_token_key
+}
+
+resource "rancher2_app_v2" "monitoring" {
+  cluster_id = var.cluster_id
+  project_id = var.project_id
+  name = "rancher-monitoring"
+  namespace = "cattle-monitoring-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-monitoring"
+  chart_version = var.monitoring_version
+  wait = true
+}
+
+resource "rancher2_app_v2" "rancher-kiali-server-crd" {
+  cluster_id = var.cluster_id
+  project_id = var.project_id
+  name = "rancher-kiali-server-crd"
+  namespace = "istio-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-kiali-server-crd"
+  chart_version = var.kiali_version
+   depends_on = [rancher2_app_v2.monitoring]
+  wait = true
+}
+
+resource "rancher2_app_v2" "istio" {
+  cluster_id = var.cluster_id
+  project_id = var.project_id
+  name = "rancher-istio"
+  namespace = "istio-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-istio"
+  chart_version = var.istio_version
+
+  depends_on = [rancher2_app_v2.monitoring,rancher2_app_v2.rancher-kiali-server-crd]
+  wait = true
+}
+
+resource "rancher2_app_v2" "logging" {
+  cluster_id = var.cluster_id
+  project_id = var.project_id
+  name = "rancher-logging"
+  namespace = "cattle-logging-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-logging"
+  chart_version = var.logging_version
+  wait = true
+}
+
+resource "rancher2_app_v2" "cis-benchmark" {
+  cluster_id = var.cluster_id
+  project_id = var.project_id
+  name = "rancher-cis-benchmark"
+  namespace = "cis-operator-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-cis-benchmark"
+  chart_version = var.cis_version
+  wait = true
+}
+
+resource "rancher2_app_v2" "rancher-gatekeeper" {  
+  cluster_id = var.cluster_id
+  project_id = var.project_id
+  name = "rancher-gatekeeper"
+  namespace = "cattle-gatekeeper-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-gatekeeper"
+  chart_version = var.gatekeeper_version
+  depends_on = [rancher2_app_v2.monitoring]
+  wait = true
+}
+
+resource "rancher2_app_v2" "rancher-backup" {  
+  cluster_id = "local"
+  project_id = ""
+  name = "rancher-backup"
+  namespace = "cattle-resources-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-backup"
+  chart_version = var.backup_version
+  values = <<EOF
+persistence:
+  enabled: false
+  size: 2Gi
+  storageClass: '-'
+  volumeName: ""
+s3:
+  bucketName: ""
+  credentialSecretName: ""
+  credentialSecretNamespace: ""
+  enabled: false
+  endpoint: ""
+  endpointCA: ""
+  folder: ""
+  insecureTLSSkipVerify: false
+  region: ""
+EOF
+}
+
+resource "rancher2_app_v2" "longhorn" {  
+  cluster_id = var.cluster_id
+  project_id = var.project_id
+  name = "rancher-longhorn"
+  namespace = "longhorn-system"
+  repo_name = "rancher-charts"
+  chart_name = "longhorn"
+  chart_version = var.longhorn_version
+  //wait = true
+}

--- a/tests/v2/validation/resource/terraform/v2charts/target/variables.tf
+++ b/tests/v2/validation/resource/terraform/v2charts/target/variables.tf
@@ -1,0 +1,49 @@
+variable "rancher_api_url" {
+  type    = string
+  default = ""
+}
+
+variable "rancher_token_key" {
+  type    = string
+  default = ""
+}
+
+variable "cluster_id" {
+  default = ""
+}
+variable "monitoring_version" {
+  default = ""
+}
+
+variable "kiali_version" {
+  default = ""
+}
+
+variable "istio_version" {
+  default = ""
+}
+
+variable "logging_version" {
+  default = ""
+}
+
+variable "cis_version" {
+  default = ""
+}
+variable "gatekeeper_version" {
+  default = ""
+}
+variable "backup_version" {
+  default = ""
+}
+
+variable "longhorn_version" {
+  default = ""
+}
+variable "project_id" {
+  default = ""
+}
+
+variable "cluster_provider" {
+  default = ""
+}

--- a/tests/v2/validation/resource/terraform/v2charts/test.go
+++ b/tests/v2/validation/resource/terraform/v2charts/test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hc-install/product"
+	"github.com/hashicorp/hc-install/releases"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+func main() {
+	installer := &releases.ExactVersion{
+		Product: product.Terraform,
+		Version: version.Must(version.NewVersion(os.Getenv("tfversion"))),
+	}
+
+	execPath, err := installer.Install(context.Background())
+	if err != nil {
+		log.Fatalf("error installing Terraform: %s", err)
+	}
+
+	workingDir := os.Getenv("provider")
+	tf, err := tfexec.NewTerraform(workingDir, execPath)
+	if err != nil {
+		log.Fatalf("error running NewTerraform: %s", err)
+	}
+
+	err = tf.Init(context.Background(), tfexec.Upgrade(true))
+	if err != nil {
+		log.Fatalf("error running Init: %s", err)
+	}
+
+	err = tf.Apply(context.Background())
+	if err != nil {
+		log.Fatalf("error running Apply: %s", err)
+	}
+
+	state, err := tf.Show(context.Background())
+	if err != nil {
+		log.Fatalf("error running Show: %s", err)
+	}
+
+	fmt.Println("Using v" + state.FormatVersion + "\nChart installations initiated") // "0.1"
+
+}


### PR DESCRIPTION
Only V2 Charts Installed

Added Jenkins job for test scenarios surrounding included rancher charts.

Support for targeting clusters and use of DO and AWS when provisioning, scripts utilize GO to run Terraform for Rancher node template for cluster creation

Charts installed:
CIS
ISTIO
KIALI
LOGGING
MONITORING
LONGHORN
OPA GATEKEEPER
BACKUPS