### PR TITLE
Delete RKE2 custom cluster machines

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/rkecontrolplane/controlplane.go
+++ b/pkg/controllers/provisioningv2/rke2/rkecontrolplane/controlplane.go
@@ -101,7 +101,7 @@ func (h *handler) doRemove(obj *rkev1.RKEControlPlane) func() (string, error) {
 
 		// CustomMachines are not associated to a MachineDeployment, so they have to be deleted manually.
 		for _, m := range machines {
-			if m.Spec.InfrastructureRef.APIVersion == rke2.RKEMachineAPIVersion && m.Spec.InfrastructureRef.Kind == "CustomMachine" && m.DeletionTimestamp.IsZero() {
+			if m.Spec.InfrastructureRef.APIVersion == rke2.RKEAPIVersion && m.Spec.InfrastructureRef.Kind == "CustomMachine" && m.DeletionTimestamp.IsZero() {
 				if err := h.machineClient.Delete(m.Namespace, m.Name, &metav1.DeleteOptions{}); err != nil {
 					return "", err
 				}


### PR DESCRIPTION
The API version of CustomMachines is different from all other machines used by
Rancher. This change ensures we properly detect Custom machines and delete them
properly.

Issue:
https://github.com/rancher/rancher/issues/36704