### PR TITLE
[2.6.4] improve the error message for encryption key rotation error.

### DIFF
--- a/pkg/api/norman/store/cluster/cluster_store.go
+++ b/pkg/api/norman/store/cluster/cluster_store.go
@@ -1295,7 +1295,7 @@ func validateKeyRotation(data map[string]interface{}) error {
 	rotateEncryptionKeyEnabled, _ := values.GetValue(data, "rancherKubernetesEngineConfig", "rotateEncryptionKey")
 	if rotateEncryptionKeyEnabled != nil && rotateEncryptionKeyEnabled == true {
 		if secretsEncryptionEnabled != nil && secretsEncryptionEnabled == false {
-			return fmt.Errorf("unable to rotate encryption key when encryption configuration is disabled")
+			return fmt.Errorf("unable to rotate encryption key when secrets encryption is disabled")
 		}
 	}
 	return nil


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36333

Problem:
RKE has the limitation that we cannot enable the Encryption Key Rotation and Secrets Encryption at the same time when editing an existing cluster. Rancher UI shows the following message that lacks details when we do that. 
  ![image.png](https://zube.io/files/rancher/533ab7077d257c555c6c4b2b93868f6e-image.png)

Solution:
1. The error message returned from the underlying RKE is now appended to the message, so users can see exactly what goes wrong and how to resolve the error.  
2. We need bump the rke dependent after  https://github.com/rancher/rke/pull/2854 is merged 

Tests:
Steps:
- provision a one-node RKE1 cluster
- wait for the cluster to be ready 
- edit the cluster -> edit as YAML -> set `rotateEncryptionKey: true` and `secretsEncryptionConfig.enable: true`

Results:
 the following message shows in Rancher UI: 
`Encryption key rotation failed, please restore your cluster from backup if needed: can't rotate encryption keys: Secrets Encryption needs to be enabled first. Please disable Key Rotation and update the cluster`
 

<img width="1323" alt="Screen Shot 2022-03-01 at 4 45 24 PM" src="https://user-images.githubusercontent.com/6218999/156269133-63ba57cb-8f16-465b-a3af-bd6b88cf52ec.png">

 