### PR TITLE
Automation - fix test of  etcd backup create for RKE1 clusters

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -2249,6 +2249,8 @@ def validate_backup_create(namespace, backup_info, backup_mode=None):
     validate_ingress(p_client, cluster, [backup_info["workload"]], host, path)
 
     # Perform Backup
+    user_client = get_user_client()
+    cluster = user_client.reload(cluster)
     backup = cluster.backupEtcd()
     backup_info["backupname"] = backup['metadata']['name']
     wait_for_backup_to_active(cluster, backup_info["backupname"])

--- a/tests/validation/tests/v3_api/test_bkp_restore_local.py
+++ b/tests/validation/tests/v3_api/test_bkp_restore_local.py
@@ -9,6 +9,7 @@ backup_info = {"backupname": None, "backup_id": None, "workload": None,
 
 rbac_roles = [CLUSTER_MEMBER, PROJECT_OWNER, PROJECT_MEMBER, PROJECT_READ_ONLY]
 
+
 def test_bkp_restore_local_create():
     validate_backup_create(namespace, backup_info)
 
@@ -50,6 +51,7 @@ def test_rbac_bkp_restore_create(role):
         user_cluster.backupEtcd()
     assert e.value.error.status == 403
     assert e.value.error.code == 'PermissionDenied'
+
 
 @if_test_rbac
 def test_rbac_bkp_restore_list_cluster_owner():


### PR DESCRIPTION
After some testing locally I had to reload the cluster state before triggering an etcdBackup.
This was consistently failing in Jenkins