### PR TITLE
No race cache migrations

### DIFF
--- a/pkg/controllers/management/agentupgrade/controller.go
+++ b/pkg/controllers/management/agentupgrade/controller.go
@@ -30,7 +30,7 @@ type handler struct {
 	daemonsetClient v1.DaemonSetInterface
 }
 
-func Register(ctx context.Context, context *config.ManagementContext) error {
+func Register(ctx context.Context, context *config.ManagementContext) {
 	h := &handler{
 		deployments:     context.Apps.Deployments(""),
 		daemonsetClient: context.Apps.DaemonSets(""),
@@ -38,7 +38,6 @@ func Register(ctx context.Context, context *config.ManagementContext) error {
 
 	context.Apps.Deployments("").Controller().AddHandler(ctx, "agent-upgrade", h.OnDeploymentChange)
 	context.Apps.DaemonSets("").Controller().AddHandler(ctx, "agent-upgrade", h.OnDaemonSetChange)
-	return nil
 }
 
 func (h *handler) OnDeploymentChange(key string, deploy *appsv1.Deployment) (runtime.Object, error) {


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36536

## Problem
Since we were using caches and indexes to try to migrate right after
Rancher starts, we we having issues where the caches and indexes aren't
populated.

## Solution
This change switches to using clients and label selectors for more
consistent results.

## Testing
I tested as in [this comment](https://github.com/rancher/rancher/issues/36536#issuecomment-1056607168) and was able to upgrade the local cluster.