### PR TITLE
Display drain errors on machine

### DIFF
--- a/pkg/apis/rke.cattle.io/v1/cluster.go
+++ b/pkg/apis/rke.cattle.io/v1/cluster.go
@@ -90,7 +90,7 @@ type DrainOptions struct {
 }
 
 type DrainHook struct {
-	// Annotation This annotation will need to be populated on the capi.Machine with the value from the annotation
+	// Annotation This annotation will need to be populated on the machine-plan secret with the value from the annotation
 	// "rke.cattle.io/pre-drain" before the planner will continue with drain the specific node.  The annotation
 	// "rke.cattle.io/pre-drain" is used for pre-drain and "rke.cattle.io/post-drain" is used for post drain.
 	Annotation string `json:"annotation,omitempty"`

--- a/pkg/controllers/provisioningv2/rke2/common.go
+++ b/pkg/controllers/provisioningv2/rke2/common.go
@@ -34,6 +34,7 @@ const (
 	ControlPlaneRoleLabel     = "rke.cattle.io/control-plane-role"
 	DrainAnnotation           = "rke.cattle.io/drain-options"
 	DrainDoneAnnotation       = "rke.cattle.io/drain-done"
+	DrainErrorAnnotation      = "rke.cattle.io/drain-error"
 	EtcdRoleLabel             = "rke.cattle.io/etcd-role"
 	InitNodeLabel             = "rke.cattle.io/init-node"
 	InitNodeMachineIDLabel    = "rke.cattle.io/init-node-machine-id"
@@ -74,6 +75,7 @@ const (
 	Waiting     = condition.Cond("Waiting")
 	Pending     = condition.Cond("Pending")
 	Removed     = condition.Cond("Removed")
+	Updated     = condition.Cond("Updated")
 
 	RuntimeK3S  = "k3s"
 	RuntimeRKE2 = "rke2"

--- a/pkg/controllers/provisioningv2/rke2/common.go
+++ b/pkg/controllers/provisioningv2/rke2/common.go
@@ -75,7 +75,6 @@ const (
 	Waiting     = condition.Cond("Waiting")
 	Pending     = condition.Cond("Pending")
 	Removed     = condition.Cond("Removed")
-	Updated     = condition.Cond("Updated")
 
 	RuntimeK3S  = "k3s"
 	RuntimeRKE2 = "rke2"

--- a/pkg/controllers/provisioningv2/rke2/machinedrain/machinedrain.go
+++ b/pkg/controllers/provisioningv2/rke2/machinedrain/machinedrain.go
@@ -246,7 +246,7 @@ func (h *handler) updateSecretAnnotation(secret *corev1.Secret, annotation, valu
 	var err error
 	return secret, retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		secret, err = h.secrets.Get(secret.Namespace, secret.Name, metav1.GetOptions{})
-		if err != nil {
+		if err != nil || secret.Annotations[annotation] == value {
 			return err
 		}
 		secret = secret.DeepCopy()

--- a/pkg/controllers/provisioningv2/rke2/machinedrain/machinedrain.go
+++ b/pkg/controllers/provisioningv2/rke2/machinedrain/machinedrain.go
@@ -3,6 +3,7 @@ package machinedrain
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"time"
 
@@ -72,7 +73,7 @@ func (h *handler) OnChange(_ string, secret *corev1.Secret) (*corev1.Secret, err
 		if secret, updateErr = h.secrets.Update(secret); updateErr != nil && err == nil {
 			err = updateErr
 		} else if updateErr != nil {
-			logrus.Errorf("Failed to update secret %s/%s with drain error annotation: %v", secret.Namespace, secret.Name, updateErr)
+			err = fmt.Errorf("failed to update secret (%v) after drain error: %v", updateErr, err)
 		}
 	}()
 

--- a/pkg/controllers/provisioningv2/rke2/planner/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/planner/controller.go
@@ -39,7 +39,7 @@ func Register(ctx context.Context, clients *wrangler.Context, planner *planner.P
 				}}, nil
 			}
 		} else if machine, ok := obj.(*capi.Machine); ok {
-			clusterName := machine.Labels[rke2.ClusterNameLabel]
+			clusterName := machine.Labels[capi.ClusterLabelName]
 			if clusterName != "" {
 				return []relatedresource.Key{{
 					Namespace: machine.Namespace,

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
@@ -345,6 +345,7 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 					ObjectMeta: capi.ObjectMeta{
 						Labels: map[string]string{
 							capi.ClusterLabelName:           capiCluster.Name,
+							rke2.ClusterNameLabel:           capiCluster.Name,
 							capi.MachineDeploymentLabelName: machineDeploymentName,
 							rke2.RKEMachinePoolNameLabel:    machinePool.Name,
 						},

--- a/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
@@ -168,6 +168,7 @@ func (h *handler) createMachineObjects(capiCluster *capi.Cluster, machineName st
 
 	labels[rke2.MachineIDLabel] = data.String("id")
 	labels[rke2.ClusterNameLabel] = capiCluster.Name
+	labels[capi.ClusterLabelName] = capiCluster.Name
 
 	labelsMap := map[string]string{}
 	for _, str := range strings.Split(data.String("labels"), ",") {
@@ -365,10 +366,11 @@ func (h *handler) onUnmanagedMachineOnRemove(key string, customMachine *rkev1.Cu
 	return customMachine, nil
 }
 
-func (h *handler) onUnmanagedMachineChange(key string, machine *rkev1.CustomMachine) (*rkev1.CustomMachine, error) {
+func (h *handler) onUnmanagedMachineChange(_ string, machine *rkev1.CustomMachine) (*rkev1.CustomMachine, error) {
 	if machine != nil && !machine.Status.Ready && machine.Spec.ProviderID != "" {
 		machine = machine.DeepCopy()
 		machine.Status.Ready = true
+		rke2.Ready.SetStatus(machine, "True")
 		return h.unmanagedMachine.UpdateStatus(machine)
 	}
 	return machine, nil

--- a/pkg/provisioningv2/rke2/planner/drain.go
+++ b/pkg/provisioningv2/rke2/planner/drain.go
@@ -2,6 +2,8 @@ package planner
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/rancher/norman/types/convert"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
@@ -75,6 +77,11 @@ func (p *Planner) drain(oldPlan *plan.NodePlan, newPlan plan.NodePlan, entry *pl
 		return false, p.store.updatePlanSecretLabelsAndAnnotations(entry)
 	}
 
+	if err := checkForDrainError(entry, "draining"); err != nil {
+		// This is the only place true and an error is returned to indicate that draining is ongoing, but there is an error.
+		return true, err
+	}
+
 	return entry.Metadata.Annotations[rke2.DrainDoneAnnotation] == optionString, nil
 }
 
@@ -85,5 +92,21 @@ func (p *Planner) undrain(entry *planEntry) (bool, error) {
 		return false, p.store.updatePlanSecretLabelsAndAnnotations(entry)
 	}
 
+	if err := checkForDrainError(entry, "undraining"); err != nil {
+		// This is the only place true and an error is returned to indicate that draining is ongoing, but there is an error.
+		return true, err
+	}
+
+	// The annotations will be removed when undrain is done
 	return entry.Metadata.Annotations[rke2.UnCordonAnnotation] == "", nil
+}
+
+func checkForDrainError(entry *planEntry, drainStep string) error {
+	// During draining, the cattle-cluster-agent could get rescheduled. This causes connection issues with the downstream cluster.
+	// Since these connection issues are expected, they aren't returned here as an error.
+	// The string will be in the annotation for debugging purposes.
+	if errStr := entry.Metadata.Annotations[rke2.DrainErrorAnnotation]; errStr != "" && !strings.Contains(errStr, "error trying to reach service") {
+		return fmt.Errorf("error %s machine %s: %s", drainStep, entry.Machine.Name, errStr)
+	}
+	return nil
 }

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -208,7 +208,7 @@ func (p *Planner) applyToMachineCondition(clusterPlan *plan.Plan, machineNames [
 func atMostThree(names []string) string {
 	sort.Strings(names)
 	if len(names) > 3 {
-		return strings.Join(names[:3], ",")
+		return fmt.Sprintf("%s and %d more", strings.Join(names[:3], ","), len(names)-3)
 	}
 	return strings.Join(names, ",")
 }

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -261,10 +261,10 @@ func (p *Planner) getCAPICluster(controlPlane *rkev1.RKEControlPlane) (*capi.Clu
 func (p *Planner) Process(controlPlane *rkev1.RKEControlPlane) error {
 	logrus.Debugf("[planner] rkecluster %s/%s: attempting to lock %s for processing", controlPlane.Namespace, controlPlane.Name, string(controlPlane.UID))
 	p.locker.Lock(string(controlPlane.UID))
-	defer func() error {
-		logrus.Debugf("[planner] rkecluster %s/%s: unlocking %s", controlPlane.Namespace, controlPlane.Name, string(controlPlane.UID))
-		return p.locker.Unlock(string(controlPlane.UID))
-	}()
+	defer func(namespace, name, uid string) error {
+		logrus.Debugf("[planner] rkecluster %s/%s: unlocking %s", namespace, name, uid)
+		return p.locker.Unlock(uid)
+	}(controlPlane.Namespace, controlPlane.Name, string(controlPlane.UID))
 
 	cluster, err := p.getCAPICluster(controlPlane)
 	if err != nil || !cluster.DeletionTimestamp.IsZero() {

--- a/pkg/provisioningv2/rke2/planner/probe.go
+++ b/pkg/provisioningv2/rke2/planner/probe.go
@@ -15,7 +15,7 @@ var allProbes = map[string]plan.Probe{
 		InitialDelaySeconds: 1,
 		TimeoutSeconds:      5,
 		SuccessThreshold:    1,
-		FailureThreshold:    2,
+		FailureThreshold:    1,
 		HTTPGetAction: plan.HTTPGetAction{
 			URL: "http://127.0.0.1:9099/liveness",
 		},
@@ -24,7 +24,7 @@ var allProbes = map[string]plan.Probe{
 		InitialDelaySeconds: 1,
 		TimeoutSeconds:      5,
 		SuccessThreshold:    1,
-		FailureThreshold:    2,
+		FailureThreshold:    1,
 		HTTPGetAction: plan.HTTPGetAction{
 			URL: "http://127.0.0.1:2381/health",
 		},
@@ -33,7 +33,7 @@ var allProbes = map[string]plan.Probe{
 		InitialDelaySeconds: 1,
 		TimeoutSeconds:      5,
 		SuccessThreshold:    1,
-		FailureThreshold:    2,
+		FailureThreshold:    1,
 		HTTPGetAction: plan.HTTPGetAction{
 			URL:        "https://127.0.0.1:6443/readyz",
 			CACert:     "/var/lib/rancher/%s/server/tls/server-ca.crt",
@@ -45,7 +45,7 @@ var allProbes = map[string]plan.Probe{
 		InitialDelaySeconds: 1,
 		TimeoutSeconds:      5,
 		SuccessThreshold:    1,
-		FailureThreshold:    2,
+		FailureThreshold:    1,
 		HTTPGetAction: plan.HTTPGetAction{
 			URL: "https://127.0.0.1:%s/healthz",
 		},
@@ -54,7 +54,7 @@ var allProbes = map[string]plan.Probe{
 		InitialDelaySeconds: 1,
 		TimeoutSeconds:      5,
 		SuccessThreshold:    1,
-		FailureThreshold:    2,
+		FailureThreshold:    1,
 		HTTPGetAction: plan.HTTPGetAction{
 			URL: "https://127.0.0.1:%s/healthz",
 		},
@@ -63,7 +63,7 @@ var allProbes = map[string]plan.Probe{
 		InitialDelaySeconds: 1,
 		TimeoutSeconds:      5,
 		SuccessThreshold:    1,
-		FailureThreshold:    2,
+		FailureThreshold:    1,
 		HTTPGetAction: plan.HTTPGetAction{
 			URL: "http://127.0.0.1:10248/healthz",
 		},

--- a/pkg/provisioningv2/rke2/planner/probe.go
+++ b/pkg/provisioningv2/rke2/planner/probe.go
@@ -15,7 +15,7 @@ var allProbes = map[string]plan.Probe{
 		InitialDelaySeconds: 1,
 		TimeoutSeconds:      5,
 		SuccessThreshold:    1,
-		FailureThreshold:    1,
+		FailureThreshold:    2,
 		HTTPGetAction: plan.HTTPGetAction{
 			URL: "http://127.0.0.1:9099/liveness",
 		},
@@ -24,7 +24,7 @@ var allProbes = map[string]plan.Probe{
 		InitialDelaySeconds: 1,
 		TimeoutSeconds:      5,
 		SuccessThreshold:    1,
-		FailureThreshold:    1,
+		FailureThreshold:    2,
 		HTTPGetAction: plan.HTTPGetAction{
 			URL: "http://127.0.0.1:2381/health",
 		},
@@ -33,7 +33,7 @@ var allProbes = map[string]plan.Probe{
 		InitialDelaySeconds: 1,
 		TimeoutSeconds:      5,
 		SuccessThreshold:    1,
-		FailureThreshold:    1,
+		FailureThreshold:    2,
 		HTTPGetAction: plan.HTTPGetAction{
 			URL:        "https://127.0.0.1:6443/readyz",
 			CACert:     "/var/lib/rancher/%s/server/tls/server-ca.crt",
@@ -45,7 +45,7 @@ var allProbes = map[string]plan.Probe{
 		InitialDelaySeconds: 1,
 		TimeoutSeconds:      5,
 		SuccessThreshold:    1,
-		FailureThreshold:    1,
+		FailureThreshold:    2,
 		HTTPGetAction: plan.HTTPGetAction{
 			URL: "https://127.0.0.1:%s/healthz",
 		},
@@ -54,7 +54,7 @@ var allProbes = map[string]plan.Probe{
 		InitialDelaySeconds: 1,
 		TimeoutSeconds:      5,
 		SuccessThreshold:    1,
-		FailureThreshold:    1,
+		FailureThreshold:    2,
 		HTTPGetAction: plan.HTTPGetAction{
 			URL: "https://127.0.0.1:%s/healthz",
 		},
@@ -63,7 +63,7 @@ var allProbes = map[string]plan.Probe{
 		InitialDelaySeconds: 1,
 		TimeoutSeconds:      5,
 		SuccessThreshold:    1,
-		FailureThreshold:    1,
+		FailureThreshold:    2,
 		HTTPGetAction: plan.HTTPGetAction{
 			URL: "http://127.0.0.1:10248/healthz",
 		},

--- a/pkg/provisioningv2/rke2/planner/store.go
+++ b/pkg/provisioningv2/rke2/planner/store.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	NoAgentPlanStatusMessage = "agent to check in and apply initial plan"
-	WaitingPlanStatusMessage = "plan to be applied"
+	NoAgentPlanStatusMessage = "waiting for agent to check in and apply initial plan"
+	WaitingPlanStatusMessage = "waiting for plan to be applied"
 	FailedPlanStatusMessage  = "failure while applying plan"
 )
 
@@ -112,11 +112,11 @@ func (p *PlanStore) Load(cluster *capi.Cluster, rkeControlPlane *rkev1.RKEContro
 
 func noPlanMessage(entry *planEntry) string {
 	if isEtcd(entry) {
-		return "bootstrap etcd to be available"
+		return "waiting for bootstrap etcd to be available"
 	} else if isControlPlane(entry) {
-		return "etcd to be available"
+		return "waiting for etcd to be available"
 	} else {
-		return "control plane to be available"
+		return "waiting for control plane to be available"
 	}
 }
 
@@ -130,7 +130,7 @@ func probesMessage(plan *plan.Node) string {
 		}
 	}
 	sort.Strings(unhealthy)
-	return "probes: " + strings.Join(unhealthy, ", ")
+	return "waiting for probes: " + strings.Join(unhealthy, ", ")
 }
 
 func getPlanStatusReasonMessage(entry *planEntry) string {
@@ -269,7 +269,7 @@ func isRKEBootstrap(machine *capi.Machine) bool {
 		machine.Spec.Bootstrap.ConfigRef.Kind == "RKEBootstrap"
 }
 
-// getPlanSecretFromachine returns the plan secret from the secretsCache for the given machine, or an error if the plan secret is not available
+// getPlanSecretFromMachine returns the plan secret from the secretsCache for the given machine, or an error if the plan secret is not available
 func (p *PlanStore) getPlanSecretFromMachine(machine *capi.Machine) (*corev1.Secret, error) {
 	if machine == nil {
 		return nil, fmt.Errorf("machine was nil")


### PR DESCRIPTION
Issues:
https://github.com/rancher/rancher/issues/36506
https://github.com/rancher/rancher/issues/36782
https://github.com/rancher/rancher/issues/35999
https://github.com/rancher/rancher/issues/36776
https://github.com/rancher/rancher/issues/36763

## Problems
During provisioning and upgrading, there were no statuses being put on the machine objects. Therefore, if there was a problem with a specific machine, one would have to look at the cluster status, find the machine name, and look at that specific machine to attempt to understand what was happening. This change adds the status (to either Provisioned or Updated conditions) so the proper status is shown directly in the UI. (#36782)

Now, that we are properly showing statuses on the machine objects, we can now show errors statuses as well when they occur. That way a user doesn't have to comb through the logs or connect to the VM/node directly. (#36506)

These statuses now make using the upgrade strategy more reliable. Since the statuses are being directly put on the machines, Rancher is able to calculate the unavailable nodes in a more robust way to ensure that, for example, if a control plane node is still upgrading then the worker nodes will not upgrade. (#35999)

Also, consider the case above with etcd nodes. An etcd node is always the bootstrap node. So, when upgrading a cluster, the boostrap node would get upgraded first. After the bootstrap node is upgraded, then the remaining etcd nodes are upgraded. Since Rancher was mistakenly not waiting for nodes to be upgraded before moving onto the next group of nodes, multiple etcd nodes could be upgrading at the same time. This is dangerous and could cause data integrity issues. Thus, the robustness of determining when to move onto the next group of nodes also fixes this problem. For good measure, Rancher will now only upgrade one etcd node at a time. (#36776)

Lastly, Windows nodes report a different kubelet version from linux nodes (they don't have the +rke2rx on the end). A check for kubelet version was added in a different PR to delay upgrading worker nodes before control plane nodes were completed. This change is no longer needed with the above enhancements and this will fix #36763

## Testing
I tested provisioning, upgrading, and deleting of the following types of clusters.
- single node all roles with and without draining enabled
- one node all roles and one node worker-only with and without draining enabled
- 3 etcd nodes 2 control plane nodes and 1 worker node with draining enabled
- one node all roles and one node worker-only with draining enabled, but misconfigured. I ensured that the error appeared in the UI. Then fixed the draining misconfiguration so that draining and upgrading would continue.