### PR TITLE
Wait for version upgrades before proceeding with more upgrades

### DIFF
--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -444,7 +444,7 @@ func (p *Planner) reconcile(controlPlane *rkev1.RKEControlPlane, tokensSecret pl
 					draining = append(draining, entry.Machine.Name)
 				}
 			}
-		} else if !entry.Plan.InSync {
+		} else if !entry.Plan.InSync || (entry.Machine.Status.NodeInfo != nil && entry.Machine.Status.NodeInfo.KubeletVersion != controlPlane.Spec.KubernetesVersion) {
 			outOfSync = append(outOfSync, entry.Machine.Name)
 		} else {
 			if ok, err := p.undrain(entry); err != nil {


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36505

## Problem
Currently, when upgrading an RKE2 cluster, the planner will go onto the next
machine type before the upgrade finishes. For example, the planner will move
onto upgrade worker nodes before the control plane nodes are completely
upgraded. That is because the plan was considered in-sync after the system-agent
applied it and not after the upgrade completed.

## Solution
Now, a plan will remain in-sync at the point the system-agent has applied it,
but the machine will not be considered to be in-sync until the version of the
node has been updated.

Because of this change, we must include the CAPI machines as "related resources"
so that the planner runs when the node version has been updated. This should
speed up provisioning slightly because the planner will kick off as soon as a
node has the ready state instead of waiting for other things to enqueue the
planner.

## Testing
1. Provision an RKE2 cluster from Rancher with multiple machine pools with different roles. It is easiest if the upgrade strategy is set to drain worker nodes so you can see when that starts.
2. After the cluster is active, upgrade the Kubernetes version of the cluster.
3. Watch the nodes to ensure that nothing happens to the worker nodes until the control plane nodes are upgraded completely.
