### PR TITLE
Delete CAPI cluster first

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/common.go
+++ b/pkg/controllers/provisioningv2/rke2/common.go
@@ -244,11 +244,7 @@ func DoRemoveAndUpdateStatus(obj metav1.Object, doRemove func() (string, error),
 	return err
 }
 
-func GetMachineDeletionStatus(machineCache capicontrollers.MachineCache, clusterNamespace, clusterName string) (string, error) {
-	machines, err := machineCache.List(clusterNamespace, labels.SelectorFromSet(labels.Set{capi.ClusterLabelName: clusterName}))
-	if err != nil {
-		return "", err
-	}
+func GetMachineDeletionStatus(machines []*capi.Machine) (string, error) {
 	sort.Slice(machines, func(i, j int) bool {
 		return machines[i].Name < machines[j].Name
 	})


### PR DESCRIPTION
When deleting a cluster, the controller was deleting the control plane object
first before deleting the CAPI cluster. That led to nodes being drained when a
cluster was being deleted, which is not correct.

This change deletes the CAPI cluster so that draining does not occur on deletion