### PR TITLE
Add kubernetes version check to aksUpgrades endpoint

### DIFF
--- a/pkg/api/norman/customization/aks/listers.go
+++ b/pkg/api/norman/customization/aks/listers.go
@@ -158,7 +158,14 @@ func listKubernetesUpgradeVersions(ctx context.Context, clusterLister mgmtv3.Clu
 		return nil, http.StatusBadRequest, fmt.Errorf("invalid cluster id")
 	}
 
-	resp.CurrentVersion = *cluster.Spec.AKSConfig.KubernetesVersion
+	if cluster.Spec.AKSConfig.KubernetesVersion != nil {
+		resp.CurrentVersion = *cluster.Spec.AKSConfig.KubernetesVersion
+	} else {
+		if cluster.Status.AKSStatus.UpstreamSpec == nil || cluster.Status.AKSStatus.UpstreamSpec.KubernetesVersion == nil {
+			return nil, http.StatusBadRequest, fmt.Errorf("kubernetes version of the cluster cannot be determined")
+		}
+		resp.CurrentVersion = *cluster.Status.AKSStatus.UpstreamSpec.KubernetesVersion
+	}
 
 	// get the client for aks container service
 	clientContainer, err := NewContainerServiceClient(cap)


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36690 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable.  If this is a new feature describe why we need this feature and how it will be used. -->
 
We never check whether `kubernetesVersion` is set in the `aksConfig` and if it's nil, the `aksUpgrades` endpoint was failing to return a list of valid Kubernetes upgrade versions.

## Solution
 
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

I added a check to make sure if `kubernetesVersion` isn't set, use the current version set in `aksStatus`.
 
## Testing
 
<!-- Describe what, if any, testing you did.  If you added tests describe what cases they cover and do not cover. -->

* Create an AKS cluster in Azure portal
* Import the AKS cluster using the Rancher UI
* Go to Cluster Management -> Edit Config for your imported cluster and check that you can edit the configuration and then save it, and the cluster updates