### PR TITLE
Pin itsdangerous integration test dependency

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -13,3 +13,4 @@ requests==2.21.0
 kubernetes==12.0.1
 jinja2>=2.10
 cryptography==2.6.1
+itsdangerous==2.0.1


### PR DESCRIPTION
itsdangerous 2.1.0 removed its json module, so pin it to the last known
working version 2.0.1.