### PR TITLE
Use management context for catalog secrets

### DIFF
--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -216,7 +216,7 @@ func (m *Manager) doStart(rec *record, clusterOwner bool) (exit error) {
 
 	transaction := controller.NewHandlerTransaction(rec.ctx)
 	if clusterOwner {
-		if err := clusterController.Register(transaction, rec.cluster, rec.clusterRec, m); err != nil {
+		if err := clusterController.Register(transaction, m.ScaledContext, rec.cluster, rec.clusterRec, m); err != nil {
 			transaction.Rollback()
 			return err
 		}

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func Register(ctx context.Context, cluster *config.UserContext, clusterRec *managementv3.Cluster, kubeConfigGetter common.KubeConfigGetter) error {
+func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.UserContext, clusterRec *managementv3.Cluster, kubeConfigGetter common.KubeConfigGetter) error {
 	rbac.Register(ctx, cluster)
 	healthsyncer.Register(ctx, cluster)
 	networkpolicy.Register(ctx, cluster)
@@ -63,7 +63,7 @@ func Register(ctx context.Context, cluster *config.UserContext, clusterRec *mana
 	cluster.Core.Secrets("").Controller()
 	cluster.Core.ServiceAccounts("").Controller()
 
-	return managementuserlegacy.Register(ctx, cluster, clusterRec, kubeConfigGetter)
+	return managementuserlegacy.Register(ctx, mgmt, cluster, clusterRec, kubeConfigGetter)
 }
 
 func RegisterFollower(ctx context.Context, cluster *config.UserContext, kubeConfigGetter common.KubeConfigGetter, clusterManager healthsyncer.ClusterControllerLifecycle) error {

--- a/pkg/controllers/managementuserlegacy/controllers.go
+++ b/pkg/controllers/managementuserlegacy/controllers.go
@@ -18,8 +18,8 @@ import (
 	"github.com/rancher/rancher/pkg/types/config"
 )
 
-func Register(ctx context.Context, cluster *config.UserContext, clusterRec *managementv3.Cluster, kubeConfigGetter common.KubeConfigGetter) error {
-	helm.Register(ctx, cluster, kubeConfigGetter)
+func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.UserContext, clusterRec *managementv3.Cluster, kubeConfigGetter common.KubeConfigGetter) error {
+	helm.Register(ctx, mgmt, cluster, kubeConfigGetter)
 	logging.Register(ctx, cluster)
 	cis.Register(ctx, cluster)
 	pipeline.Register(ctx, cluster)

--- a/pkg/controllers/managementuserlegacy/helm/controller.go
+++ b/pkg/controllers/managementuserlegacy/helm/controller.go
@@ -44,9 +44,9 @@ const (
 	defaultMaxRevisionCount   = 10
 )
 
-func Register(ctx context.Context, user *config.UserContext, kubeConfigGetter common.KubeConfigGetter) {
+func Register(ctx context.Context, mgmt *config.ScaledContext, user *config.UserContext, kubeConfigGetter common.KubeConfigGetter) {
 	starter := user.DeferredStart(ctx, func(ctx context.Context) error {
-		registerDeferred(ctx, user, kubeConfigGetter)
+		registerDeferred(ctx, mgmt, user, kubeConfigGetter)
 		return nil
 	})
 
@@ -56,7 +56,7 @@ func Register(ctx context.Context, user *config.UserContext, kubeConfigGetter co
 	})
 }
 
-func registerDeferred(ctx context.Context, user *config.UserContext, kubeConfigGetter common.KubeConfigGetter) {
+func registerDeferred(ctx context.Context, mgmt *config.ScaledContext, user *config.UserContext, kubeConfigGetter common.KubeConfigGetter) {
 	appClient := user.Management.Project.Apps("")
 	stackLifecycle := &Lifecycle{
 		KubeConfigGetter:      kubeConfigGetter,
@@ -77,7 +77,7 @@ func registerDeferred(ctx context.Context, user *config.UserContext, kubeConfigG
 		AppsLister:            user.Management.Project.Apps("").Controller().Lister(),
 		NsLister:              user.Core.Namespaces("").Controller().Lister(),
 		NsClient:              user.Core.Namespaces(""),
-		SecretLister:          user.Core.Secrets("").Controller().Lister(),
+		SecretLister:          mgmt.Core.Secrets("").Controller().Lister(),
 	}
 	appClient.AddClusterScopedLifecycle(ctx, "helm-controller", user.ClusterName, stackLifecycle)
 


### PR DESCRIPTION
Without this patch, the secret assembler for Catalogs was trying to use
the secret lister from the UserContext which is not populated with
secrets from the management cluster. This was causing apps to not be
able to find the secret when deployed on downstream, non-local clusters.
This change passes the ScaledContext down to the helm controller so that
the secretmigrator assembler can use the correct secret lister.

https://github.com/rancher/rancher/issues/36723