### PR TITLE
[2.5] Use management context for catalog secrets

### DIFF
--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -213,7 +213,7 @@ func (m *Manager) doStart(rec *record, clusterOwner bool) (exit error) {
 
 	transaction := controller.NewHandlerTransaction(rec.ctx)
 	if clusterOwner {
-		if err := clusterController.Register(transaction, rec.cluster, rec.clusterRec, m); err != nil {
+		if err := clusterController.Register(transaction, m.ScaledContext, rec.cluster, rec.clusterRec, m); err != nil {
 			transaction.Rollback()
 			return err
 		}

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -33,10 +33,10 @@ import (
 	"github.com/rancher/rancher/pkg/types/config"
 )
 
-func Register(ctx context.Context, cluster *config.UserContext, clusterRec *managementv3.Cluster, kubeConfigGetter common.KubeConfigGetter) error {
+func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.UserContext, clusterRec *managementv3.Cluster, kubeConfigGetter common.KubeConfigGetter) error {
 	rbac.Register(ctx, cluster)
 	healthsyncer.Register(ctx, cluster)
-	helm.Register(ctx, cluster, kubeConfigGetter)
+	helm.Register(ctx, mgmt, cluster, kubeConfigGetter)
 	logging.Register(ctx, cluster)
 	networkpolicy.Register(ctx, cluster)
 	cis.Register(ctx, cluster)

--- a/pkg/controllers/managementuser/helm/controller.go
+++ b/pkg/controllers/managementuser/helm/controller.go
@@ -42,7 +42,7 @@ const (
 	defaultMaxRevisionCount   = 10
 )
 
-func Register(ctx context.Context, user *config.UserContext, kubeConfigGetter common.KubeConfigGetter) {
+func Register(ctx context.Context, mgmt *config.ScaledContext, user *config.UserContext, kubeConfigGetter common.KubeConfigGetter) {
 	appClient := user.Management.Project.Apps("")
 	stackLifecycle := &Lifecycle{
 		KubeConfigGetter:      kubeConfigGetter,
@@ -63,7 +63,7 @@ func Register(ctx context.Context, user *config.UserContext, kubeConfigGetter co
 		AppsLister:            user.Management.Project.Apps("").Controller().Lister(),
 		NsLister:              user.Core.Namespaces("").Controller().Lister(),
 		NsClient:              user.Core.Namespaces(""),
-		SecretLister:          user.Core.Secrets("").Controller().Lister(),
+		SecretLister:          mgmt.Core.Secrets("").Controller().Lister(),
 	}
 	appClient.AddClusterScopedLifecycle(ctx, "helm-controller", user.ClusterName, stackLifecycle)
 


### PR DESCRIPTION
Without this patch, the secret assembler for Catalogs was trying to use
the secret lister from the UserContext which is not populated with
secrets from the management cluster. This was causing apps to not be
able to find the secret when deployed on downstream, non-local clusters.
This change passes the ScaledContext down to the helm controller so that
the secretmigrator assembler can use the correct secret lister.

Backport https://github.com/rancher/rancher/pull/36745