### PR TITLE
fix formatting issues in wins install script

### DIFF
--- a/pkg/provisioningv2/rke2/installer/installer.go
+++ b/pkg/provisioningv2/rke2/installer/installer.go
@@ -127,7 +127,7 @@ func WindowsInstallScript(ctx context.Context, token string, envVars []corev1.En
 		ca = "$env:CATTLE_CA_CHECKSUM=\"" + ca + "\""
 	}
 	if token != "" {
-		token = "$env:CATTLE_ROLE_NONE=true\n$env:CATTLE_TOKEN=\"" + token + "\""
+		token = "$env:CATTLE_ROLE_NONE=\"true\"\n$env:CATTLE_TOKEN=\"" + token + "\""
 	}
 	envVarBuf := &strings.Builder{}
 	for _, envVar := range envVars {

--- a/pkg/provisioningv2/rke2/installer/installer_test.go
+++ b/pkg/provisioningv2/rke2/installer/installer_test.go
@@ -2,7 +2,11 @@ package installer
 
 import (
 	"context"
+	"fmt"
 	"testing"
+
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/rancher/pkg/systemtemplate"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -11,17 +15,27 @@ import (
 
 func TestInstaller_WindowsInstallScript(t *testing.T) {
 	// arrange
+	CACert := "uibesrwguiobsdrujigbsduigbuidbg"
 	a := assert.New(t)
 
 	// act
+	err := settings.ServerURL.Set("localhost")
+	a.Nil(err)
+
+	err = settings.CACerts.Set(CACert)
+	a.Nil(err)
+
+	CACertEncoded := systemtemplate.CAChecksum()
+
 	script, err := WindowsInstallScript(context.TODO(), "test", []corev1.EnvVar{}, "localhost")
 
 	// assert
 	a.Nil(err)
 	a.NotNil(script)
 	a.Contains(string(script), "$env:CATTLE_TOKEN=\"test\"")
-	a.Contains(string(script), "$env:CATTLE_ROLE_NONE=true")
-	a.Contains(string(script), "$env:CATTLE_ROLE_NONE=true")
+	a.Contains(string(script), "$env:CATTLE_ROLE_NONE=\"true\"")
+	a.Contains(string(script), "$env:CATTLE_SERVER=\"localhost\"")
+	a.Contains(string(script), fmt.Sprintf("$env:CATTLE_CA_CHECKSUM=\"%s\"", CACertEncoded))
 	a.Contains(string(script), "$env:CSI_PROXY_URL")
 	a.Contains(string(script), "$env:CSI_PROXY_VERSION")
 	a.Contains(string(script), "$env:CSI_PROXY_KUBELET_PATH")


### PR DESCRIPTION
This fixes a formatting issue that causes machine provisioning of windows VMs using cloudbase-init to break

current (broken): `$env:CATTLE_ROLE_NONE=true` results in

```log
2022-03-05 16:13:47.421 3872 DEBUG cloudbaseinit.plugins.common.userdatautils [-] User_data stderr:
b"C:\\install.ps1 : The term 'true' is not recognized as the name of a cmdlet, function, script file, or operable \r\nprogram. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.\r\nAt line:1 char:1\r\n+ C:\\install.
ps1\r\n+ ~~~~~~~~~~~~~~\r\n    + CategoryInfo          : ObjectNotFound: (true:String) [install.ps1], CommandNotFoundException\r\n    + FullyQualifiedErrorId : CommandNotFoundException,install.ps1\r\n \r\n" execute_user_data_script C:\Program Files\Cloudbase Solutions\Cloudbase-Init\Python\lib\site-packages\cloudbaseinit\plugins\common\userdatautils.py:94 
```

changing to`$env:CATTLE_ROLE_NONE="true"` fixes it and cloudbase-init is able to complete and the wins install script runs.