### PR TITLE
Fix s390x build

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,7 +8,7 @@ ENV K3S_ROOT_VERSION v0.11.0
 ONBUILD RUN zypper -n in tar
 ONBUILD ADD https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-${ARCH}.tar /k3s-root.tar
 ONBUILD RUN tar xvf /k3s-root.tar; \
-  touch /bin/cni /bin/containerd /bin/containerd-shim-runc-v2 /bin/runc
+  touch /bin/cni /bin/containerd /bin/containerd-shim-runc-v2 /bin/runc /bin/k3s
 
 FROM ${K3S_BUILDER} as k3s_builder
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -8,7 +8,7 @@ ENV K3S_ROOT_VERSION v0.11.0
 ONBUILD RUN zypper -n in tar
 ONBUILD ADD https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-${ARCH}.tar /k3s-root.tar
 ONBUILD RUN tar xvf /k3s-root.tar; \
-  touch /bin/cni /bin/containerd /bin/containerd-shim-runc-v2 /bin/runc
+  touch /bin/cni /bin/containerd /bin/containerd-shim-runc-v2 /bin/runc /bin/k3s
 
 FROM ${K3S_BUILDER} as k3s_builder
 


### PR DESCRIPTION
s390x build is failing because it tries to copy k3s, which is not available on s390x yet.
To fix this error we create a blank k3s file in the k3s-builder used just by s390x.