### PR TITLE
Use v2.6-head as default rancher-agent image

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -23,7 +23,7 @@ var (
 	provider       Provider
 	InjectDefaults string
 
-	AgentImage                          = NewSetting("agent-image", "rancher/rancher-agent:master-head")
+	AgentImage                          = NewSetting("agent-image", "rancher/rancher-agent:v2.6-head")
 	AgentRolloutTimeout                 = NewSetting("agent-rollout-timeout", "300s")
 	AgentRolloutWait                    = NewSetting("agent-rollout-wait", "true")
 	AuthImage                           = NewSetting("auth-image", v32.ToolsSystemImages.AuthSystemImages.KubeAPIAuth)


### PR DESCRIPTION
The master-head version of the rancher-agent is very old and does not support
Kubernetes v1.22+. This isn't a problem with "official" Rancher images because
the CATTLE_AGENT_IMAGE variable gets set to the proper values on build. However,
it does cause problems with local dev Rancher instances unless the
aforementioned environment variable is set.

This change uses the v2.6-head version of the agent to avoid problems in the
future.