### PR TITLE
[HELM] Implement configurable lifecycle hook preStop sleep duration.

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -142,6 +142,15 @@ spec:
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8}}
 {{- end }}
+{{- if gt (int .Values.preStopSleepDuration) 0 }}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - "/usr/bin/sh"
+                - "-c"
+                - "/usr/bin/sleep {{ .Values.preStopSleepDuration }}"
+{{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -155,3 +155,6 @@ postDelete:
 
 # Set a bootstrap password. If leave empty, a random password will be generated.
 bootstrapPassword: ""
+
+# Configure a sleep duration on a preStop lifecycle hook.
+preStopSleepDuration: 0


### PR DESCRIPTION
Fixes: https://github.com/rancher/rancher/issues/36789

When used in combination with the aws-lb-controller (or any other
controller that implements a pod-readiness-gate) this will ensure that
any in-flight requests are correctly drained before the pod is
terminated.

The configured value should be greater than the LB deregistration delay value.

Example:

If you are using the default 300s deregistration delay for an AWS ALB/NLB,
then the preStop sleep duration value should be greater than 300.

Related issue:
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2366

Signed-off-by: Kris Gambirazzi <kris.gambirazzi@transferwise.com>