### PR TITLE
Check for initnode mark existence before blindly returning ErrSkip

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/planner/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/planner/controller.go
@@ -52,12 +52,14 @@ func Register(ctx context.Context, clients *wrangler.Context, planner *planner.P
 }
 
 func (h *handler) OnChange(cluster *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus) (rkev1.RKEControlPlaneStatus, error) {
+	logrus.Debugf("[planner] rkecluster %s/%s: handler OnChange called", cluster.Namespace, cluster.Name)
 	if !cluster.DeletionTimestamp.IsZero() {
 		return status, nil
 	}
 
 	status.ObservedGeneration = cluster.Generation
 
+	logrus.Debugf("[planner] rkecluster %s/%s: calling planner process", cluster.Namespace, cluster.Name)
 	err := h.planner.Process(cluster)
 	var errWaiting planner.ErrWaiting
 	if errors.As(err, &errWaiting) {

--- a/pkg/provisioningv2/rke2/planner/initnode.go
+++ b/pkg/provisioningv2/rke2/planner/initnode.go
@@ -14,6 +14,10 @@ import (
 // clearInitNodeMark removes the init node label on the given machine and updates the machine directly against the api
 // server, effectively immediately demoting it from being an init node
 func (p *Planner) clearInitNodeMark(entry *planEntry) error {
+	if entry.Metadata.Labels[rke2.InitNodeLabel] == "" {
+		return nil
+	}
+
 	if err := p.store.removePlanSecretLabel(entry, rke2.InitNodeLabel); err != nil {
 		return err
 	}

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -177,8 +177,12 @@ func (p *Planner) getCAPICluster(controlPlane *rkev1.RKEControlPlane) (*capi.Clu
 }
 
 func (p *Planner) Process(controlPlane *rkev1.RKEControlPlane) error {
+	logrus.Debugf("[planner] rkecluster %s/%s: attempting to lock %s for processing", controlPlane.Namespace, controlPlane.Name, string(controlPlane.UID))
 	p.locker.Lock(string(controlPlane.UID))
-	defer p.locker.Unlock(string(controlPlane.UID))
+	defer func() error {
+		logrus.Debugf("[planner] rkecluster %s/%s: unlocking %s", controlPlane.Namespace, controlPlane.Name, string(controlPlane.UID))
+		return p.locker.Unlock(string(controlPlane.UID))
+	}()
 
 	cluster, err := p.getCAPICluster(controlPlane)
 	if err != nil || !cluster.DeletionTimestamp.IsZero() {


### PR DESCRIPTION
It appears that the planner was always receiving an ErrSkip when electing/designating init nodes, due to a change in behavior where we started to not validate that the label didn't exist before deleting it. This is an attempt to fix this issue, which should unblock the planner and allow forward progress.

https://github.com/rancher/rancher/issues/36794
https://github.com/rancher/rancher/issues/36694
https://github.com/rancher/rancher/issues/36773

Signed-off-by: Chris Kim <oats87g@gmail.com>