### PR TITLE
[Automation] - use gp3 as default volume type for ec2 instances

### DIFF
--- a/tests/validation/lib/aws.py
+++ b/tests/validation/lib/aws.py
@@ -144,7 +144,8 @@ class AmazonWebServices(CloudProviderBase):
                 "Placement": {'AvailabilityZone': AWS_REGION_AZ},
                 "BlockDeviceMappings":
                     [{"DeviceName": "/dev/sda1",
-                      "Ebs": {"VolumeSize": int(volume_size)}
+                      "Ebs": {"VolumeSize": int(volume_size),
+                              "VolumeType": "gp3"}
                       }]
                 }
 


### PR DESCRIPTION
Just moving to `gp3` volume type by default in our automation for EC2 instances.

Reference: https://aws.amazon.com/ebs/general-purpose/