### PR TITLE
Add NodeDrainTimeout in MachineTemplateSpec

### DIFF
--- a/pkg/apis/provisioning.cattle.io/v1/rke.go
+++ b/pkg/apis/provisioning.cattle.io/v1/rke.go
@@ -15,6 +15,7 @@ type RKEMachinePool struct {
 	ControlPlaneRole             bool                         `json:"controlPlaneRole,omitempty"`
 	WorkerRole                   bool                         `json:"workerRole,omitempty"`
 	DrainBeforeDelete            bool                         `json:"drainBeforeDelete,omitempty"`
+	DrainBeforeDeleteTimeout     *metav1.Duration             `json:"drainBeforeDeleteTimeout,omitempty"`
 	NodeConfig                   *corev1.ObjectReference      `json:"machineConfigRef,omitempty" wrangler:"required"`
 	Name                         string                       `json:"name,omitempty" wrangler:"required"`
 	DisplayName                  string                       `json:"displayName,omitempty"`

--- a/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
@@ -405,8 +405,7 @@ func (h *handler) OnRemove(key string, obj runtime.Object) (runtime.Object, erro
 		}
 	}
 
-	if _, nodeDrainExcluded := machine.Annotations[capi.ExcludeNodeDrainingAnnotation]; !removed ||
-		(!nodeDrainExcluded && !drainingSucceededCondition.IsTrue(machine) && drainingSucceededCondition.GetReason(machine) != capi.DrainingFailedReason) {
+	if !removed {
 		if err = h.dynamic.EnqueueAfter(obj.GetObjectKind().GroupVersionKind(), infraObj.meta.GetNamespace(), infraObj.meta.GetName(), 5*time.Second); err != nil {
 			return obj, err
 		}

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
@@ -362,6 +362,7 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 							},
 						},
 						InfrastructureRef: infraRef,
+						NodeDrainTimeout:  machinePool.DrainBeforeDeleteTimeout,
 					},
 				},
 				Paused: machinePool.Paused,


### PR DESCRIPTION
## Description

CAPI supports the `NodeDrainTimeout` field on a machine as the duration draining should be attempted before giving up and deleting the infrastructure machine, which will allow deletion of the node to proceed. If the node drain timeout is 0, the infrastructure machine will not be deleted until the node drains successfully.

Related Issue: https://github.com/rancher/rancher/issues/36631