### PR TITLE
[HELM] Bump chart apiVersion as it is not Helm 2 compatible

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: rancher
 description: Install Rancher Server to manage Kubernetes clusters across providers.
 version: %VERSION%


### PR DESCRIPTION
The current chart version is not compatible with Helm 2, so the chart apiVersion should be moved to `v2`.

Attempting to template the chart with Helm 2 results in the following error:
```
$ helm template rancher/chart
Error: parse error in "rancher/templates/secret.yaml": template: rancher/templates/secret.yaml:3: function "lookup" not defined
```