### PR TITLE
add mkisofs to rancher image and jailer.sh

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -14,7 +14,7 @@ FROM ${K3S_BUILDER} as k3s_builder
 
 FROM registry.suse.com/suse/sle15:15.3
 
-RUN zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim netcat-openbsd && \
+RUN zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim netcat-openbsd mkisofs && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
     useradd rancher && \
     mkdir -p /var/lib/rancher /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \

--- a/package/jailer.sh
+++ b/package/jailer.sh
@@ -94,6 +94,9 @@ cp -l /bin/sh /opt/jail/$NAME/bin/
 # Hard link rm into the jail
 cp -l /bin/rm /opt/jail/$NAME/bin/
 
+# Hard link mkisofs into the jail
+cp -l /usr/bin/mkisofs /opt/jail/$NAME/bin/
+
 cd /dev
 # tar copy /dev excluding mqueue and shm
 tar cf - --exclude=mqueue --exclude=shm --exclude=pts . | (cd /opt/jail/${NAME}/dev; tar xfp -)


### PR DESCRIPTION
Fix a bug in 2.6-head where rke1 nodes cannot be provisioned due to the jailer for the cluster missing the `mkisofs` binary. This PR adds mkisofs to the rancher image and creates a hard link into the jail.

