### PR TITLE
Delete Nodes during the cluster-scope garbage collection

### DIFF
--- a/pkg/controllers/management/clustergc/cluster_scoped_gc.go
+++ b/pkg/controllers/management/clustergc/cluster_scoped_gc.go
@@ -75,15 +75,15 @@ func (c *gcLifecycle) waitForNodeRemoval(cluster *v3.Cluster) error {
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
-	var wait bool
+	var waitForNodeDelete bool
 	for _, n := range nodes {
 		// trigger the deletion of node for a custom cluster
 		if n.Status.NodeTemplateSpec == nil && n.DeletionTimestamp == nil {
 			_ = c.mgmt.Management.Nodes(n.Namespace).Delete(n.Name, &metav1.DeleteOptions{})
-			wait = true
+			waitForNodeDelete = true
 		}
 	}
-	if wait {
+	if waitForNodeDelete {
 		logrus.Debugf("[cluster-scoped-gc] custom cluster %s still has rke1 nodes, checking again in 15s", cluster.Name)
 		c.mgmt.Management.Clusters("").Controller().EnqueueAfter(cluster.Namespace, cluster.Name, 15*time.Second)
 		return generic.ErrSkip

--- a/pkg/controllers/management/clustergc/cluster_scoped_gc.go
+++ b/pkg/controllers/management/clustergc/cluster_scoped_gc.go
@@ -75,13 +75,18 @@ func (c *gcLifecycle) waitForNodeRemoval(cluster *v3.Cluster) error {
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
-
+	var wait bool
 	for _, n := range nodes {
-		if n.Status.NodeTemplateSpec == nil {
-			logrus.Debugf("[cluster-scoped-gc] cluster %s still has rke1 node %s, checking again to delete in 15s", cluster.Name, n.Name)
-			c.mgmt.Management.Clusters("").Controller().EnqueueAfter(cluster.Namespace, cluster.Name, 15*time.Second)
-			return generic.ErrSkip
+		// trigger the deletion of node for a custom cluster
+		if n.Status.NodeTemplateSpec == nil && n.DeletionTimestamp == nil {
+			_ = c.mgmt.Management.Nodes(n.Namespace).Delete(n.Name, &metav1.DeleteOptions{})
+			wait = true
 		}
+	}
+	if wait {
+		logrus.Debugf("[cluster-scoped-gc] custom cluster %s still has rke1 nodes, checking again in 15s", cluster.Name)
+		c.mgmt.Management.Clusters("").Controller().EnqueueAfter(cluster.Namespace, cluster.Name, 15*time.Second)
+		return generic.ErrSkip
 	}
 
 	return nil


### PR DESCRIPTION
**Issue:** [#36877](https://github.com/rancher/rancher/issues/36877)

**Problem:** 
The deletion of `Nodes` is triggered by the deletion of the namespace for holding the cluster's resources: https://github.com/rancher/rancher/blob/520235ade2f0db8a8789b98209f2dad577d4e95e/pkg/controllers/management/auth/project_cluster_handler.go#L249
But the namespace never be deleted because the `Remove` function for the cluster's lifecycle returns before deleting the namespace because the there are always more than two finalizers in the `Cluster` object : https://github.com/rancher/rancher/blob/520235ade2f0db8a8789b98209f2dad577d4e95e/pkg/controllers/management/auth/project_cluster_handler.go#L231-L236

The purpose of checking the number of finalizer is to make sure rbac stuff is deleted last. 

 As the result, the deletion of the cluster is stuck because we never trigger the deletion of nodes.

**Fix:** 
Trigger and wait for nodes to be deleted at the beginning of the cluster-scope garbage collection for custom clusters. By doing so, we unblock the deletion of nodes and meanwhile keep RBACs to be deleted last. 


**Tests:**
I have tested provisioning and removing RKE1 custom clusters as both admin and restricted admin. Clusters were removed successfully.
