### PR TITLE
Added deepcopy when modifying node roles for nonWorker

### DIFF
--- a/pkg/controllers/management/rkeworkerupgrader/plan.go
+++ b/pkg/controllers/management/rkeworkerupgrader/plan.go
@@ -21,7 +21,7 @@ func (uh *upgradeHandler) nonWorkerPlan(node *v3.Node, cluster *v3.Cluster) (*rk
 	if err != nil {
 		return nil, err
 	}
-	rkeConfig := appliedSpec.RancherKubernetesEngineConfig
+	rkeConfig := appliedSpec.RancherKubernetesEngineConfig.DeepCopy()
 	rkeConfig.Nodes = []rketypes.RKEConfigNode{
 		*node.Status.NodeConfig,
 	}
@@ -86,7 +86,7 @@ func (uh *upgradeHandler) workerPlan(node *v3.Node, cluster *v3.Cluster) (*rkety
 		return nil, err
 	}
 
-	rkeConfig := appliedSpec.RancherKubernetesEngineConfig
+	rkeConfig := appliedSpec.RancherKubernetesEngineConfig.DeepCopy()
 	nodeserver.FilterHostForSpec(rkeConfig, node)
 
 	logrus.Debugf("The number of nodes sent to the plan: %v", len(rkeConfig.Nodes))


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/36860

Sometimes the `cluster` parameter will be updated in the apiserver (outside of this function), so a `DeepCopy()` is required to prevent modifying the cluster (and thus rewriting the first node to have all roles).