### PR TITLE
Fix migration of machines on Rancher upgrade

### DIFF
--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -400,7 +400,7 @@ func migrateCAPIMachineLabelsAndAnnotationsToPlanSecret(w *wrangler.Context) err
 						if changed, err := insertOrUpdateCondition(d, summary.NewCondition("Ready", "True", "", "")); err != nil {
 							return err
 						} else if changed {
-							_, err = w.Dynamic.Update(&unstructured.Unstructured{Object: d})
+							_, err = w.Dynamic.UpdateStatus(&unstructured.Unstructured{Object: d})
 							return err
 						}
 						return err


### PR DESCRIPTION
Migrations were added to infrastructure and CAPI machines on Rancher upgrade.
However, there were both broken.

The infrastructure migrations were attempted to be done on an unstructured
struct. The migrations would fail because the unstructured struct doesn't have
the expected layout; there is an object field in the way. Therefore, this
migration is switched to the same condition setting as in the machine-provision
controller.

The CAPI machine migration was broken for a different reason. Because the
conversion webhook for CAPI objects is embedded in rancher-webhook, the
migration would require rancher-webhook to be upgraded before it would complete.
However, this could not happen because the migration would fail and cause
Rancher to restart.

Instead of migrating (which added a label to the machine objects), a change is
made in the controller that cleans up the control plane machines to look for
machines with either the CAPI cluster name label or the RKE2 cluster name label.

Issue:
https://github.com/rancher/rancher/issues/36924