### PR TITLE
adding csi proxy to ui assets + version setting to control it

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -56,6 +56,7 @@ ENV CATTLE_KDM_BRANCH ${CATTLE_KDM_BRANCH}
 ENV HELM_VERSION v3.8.0
 ENV KUSTOMIZE_VERSION v4.4.1
 ENV CATTLE_WINS_AGENT_VERSION v0.2.0
+ENV CATTLE_CSI_PROXY_AGENT_VERSION v1.0.0
 ENV CATTLE_SYSTEM_AGENT_VERSION v0.2.3
 ENV CATTLE_SYSTEM_AGENT_UPGRADE_IMAGE rancher/system-agent:${CATTLE_SYSTEM_AGENT_VERSION}-suc
 ENV CATTLE_SYSTEM_UPGRADE_CONTROLLER_CHART_VERSION 100.0.2+up0.3.2
@@ -211,6 +212,7 @@ RUN mkdir -p /usr/share/rancher/ui && \
     curl -sfL https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/install.sh -o system-agent-install.sh && \
     curl -sfL https://raw.githubusercontent.com/rancher/rke2/master/windows/rke2-install.ps1 -o rke2-install.ps1 && \
     curl -sfL https://github.com/rancher/wins/releases/download/${CATTLE_WINS_AGENT_VERSION}/wins.exe -O && \
+    curl -sfL https://acs-mirror.azureedge.net/csi-proxy/${CATTLE_CSI_PROXY_AGENT_VERSION}/binaries/csi-proxy-${CATTLE_CSI_PROXY_AGENT_VERSION}.tar.gz -O && \
     curl -sfL https://raw.githubusercontent.com/rancher/wins/main/install.ps1 -o wins-agent-install.ps1
 
 ENV CATTLE_CLI_URL_DARWIN  https://releases.rancher.com/cli2/${CATTLE_CLI_VERSION}/rancher-darwin-amd64-${CATTLE_CLI_VERSION}.tar.gz

--- a/pkg/provisioningv2/rke2/installer/installer.go
+++ b/pkg/provisioningv2/rke2/installer/installer.go
@@ -119,6 +119,17 @@ func WindowsInstallScript(ctx context.Context, token string, envVars []corev1.En
 		}
 	}
 
+	csiProxyURL := settings.CSIProxyAgentURL.Get()
+	csiProxyVersion := "v1.0.0"
+	if settings.CSIProxyAgentVersion.Get() != "" {
+		csiProxyVersion = settings.CSIProxyAgentVersion.Get()
+		if settings.ServerURL.Get() != "" {
+			csiProxyURL = fmt.Sprintf("$env:CSI_PROXY_URL=\"%s/assets/csi-proxy-%%[1]s.tar.gz\"", settings.ServerURL.Get())
+		} else if defaultHost != "" {
+			csiProxyURL = fmt.Sprintf("$env:CSI_PROXY_URL=\"https://%s/assets/csi-proxy-%%[1]s.tar.gz\"", defaultHost)
+		}
+	}
+
 	ca := systemtemplate.CAChecksum()
 	if v, ok := ctx.Value(tls.InternalAPI).(bool); ok && v {
 		ca = systemtemplate.InternalCAChecksum()
@@ -150,11 +161,11 @@ func WindowsInstallScript(ctx context.Context, token string, envVars []corev1.En
 %s
 
 # Enables CSI Proxy
-$env:CSI_PROXY_URL = "https://acs-mirror.azureedge.net/csi-proxy/%%[1]s/binaries/csi-proxy-%%[1]s.tar.gz"
-$env:CSI_PROXY_VERSION = "v1.0.0"
+$env:CSI_PROXY_URL = "%s"
+$env:CSI_PROXY_VERSION = "%s"
 $env:CSI_PROXY_KUBELET_PATH = "C:/var/lib/rancher/rke2/bin/kubelet.exe"
 
 Invoke-WinsInstaller @PSBoundParameters
 exit 0
-`, data, envVarBuf.String(), binaryURL, server, ca, token)), nil
+`, data, envVarBuf.String(), binaryURL, server, ca, token, csiProxyURL, csiProxyVersion)), nil
 }

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -71,6 +71,8 @@ var (
 	ServerVersion                       = NewSetting("server-version", "dev")
 	SystemAgentVersion                  = NewSetting("system-agent-version", "")
 	WinsAgentVersion                    = NewSetting("wins-agent-version", "")
+	CSIProxyAgentVersion                = NewSetting("csi-proxy-agent-version", "")
+	CSIProxyAgentURL                    = NewSetting("csi-proxy-agent-version", "https://acs-mirror.azureedge.net/csi-proxy/%%[1]s/binaries/csi-proxy-%%[1]s.tar.gz")
 	SystemAgentInstallScript            = NewSetting("system-agent-install-script", "https://raw.githubusercontent.com/rancher/system-agent/main/install.sh")
 	WindowsRke2InstallScript            = NewSetting("windows-rke2-install-script", "https://raw.githubusercontent.com/rancher/wins/main/install.ps1")
 	SystemAgentInstallerImage           = NewSetting("system-agent-installer-image", "rancher/system-agent-installer-")

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -37,6 +37,7 @@ export TB_ORG=${TB_ORG}
 
 eval "$(grep '^ENV CATTLE_SYSTEM_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 eval "$(grep '^ENV CATTLE_WINS_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
+eval "$(grep '^ENV CATTLE_CSI_PROXY_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 eval "$(grep '^ENV CATTLE_KDM_BRANCH' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 
 # One day, we should be able to pull the latest version of K3s/RKE2 out of KDM for the branch we have. We cannot currently due to https://github.com/k3s-io/k3s/issues/4784

--- a/tests/integration/pkg/tests/custom/custom_test.go
+++ b/tests/integration/pkg/tests/custom/custom_test.go
@@ -48,6 +48,22 @@ func TestWinsAgentVersion(t *testing.T) {
 	assert.True(t, setting.Value == os.Getenv("CATTLE_WINS_AGENT_VERSION"))
 }
 
+func TestCSIProxyAgentVersion(t *testing.T) {
+	clients, err := clients.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clients.Close()
+
+	setting, err := clients.Mgmt.Setting().Get("csi-proxy-agent-version", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotEmpty(t, setting.Value)
+	assert.True(t, setting.Value == os.Getenv("CATTLE_CSI_PROXY_AGENT_VERSION"))
+}
+
 func TestCustomOneNode(t *testing.T) {
 	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
 		t.Skip()


### PR DESCRIPTION
Problem: if airgapped and you try to install CSI Proxy you will be met with an outbound call to an azure endpoint to download the node in wins. This needs to be configured so we can use the ui assets server in rancher to allow the wins install script to get configured to point at the rancher assets server to pull CSI Proxy.

Fix: Add two settings for proxy url and version, default version to be the azure endpoint and pass v1.0.0 in the dockerfile to lock the version in the assets server.

This is a sister PR to https://github.com/rancher/rancher/pull/36909 which got wins.exe into the ui assets server.