### PR TITLE
Order map keys for managed charts

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/common.go
+++ b/pkg/controllers/provisioningv2/rke2/common.go
@@ -310,3 +310,12 @@ func CopyMapWithExcludes(destination map[string]string, source map[string]string
 		}
 	}
 }
+
+func SortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/provisioningv2/rke2/planner/config.go
+++ b/pkg/provisioningv2/rke2/planner/config.go
@@ -203,8 +203,8 @@ func (p *Planner) addChartConfigs(nodePlan plan.NodePlan, controlPlane *rkev1.RK
 	}
 
 	var chartConfigs []runtime.Object
-	for chart, values := range chartValues {
-		valuesMap := convert.ToMapInterface(values)
+	for _, chart := range rke2.SortedKeys(chartValues) {
+		valuesMap := convert.ToMapInterface(chartValues[chart])
 		if valuesMap == nil {
 			valuesMap = map[string]interface{}{}
 		}

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -521,7 +521,7 @@ func (p *Planner) reconcile(controlPlane *rkev1.RKEControlPlane, tokensSecret pl
 					} else if entry.Metadata.Annotations[rke2.DrainDoneAnnotation] != "" {
 						messages[entry.Machine.Name] = append(messages[entry.Machine.Name], "drain completed")
 					} else if planStatusMessage == "" {
-						messages[entry.Machine.Name] = append(messages[entry.Machine.Name], "waiting for plan to be applied")
+						messages[entry.Machine.Name] = append(messages[entry.Machine.Name], WaitingPlanStatusMessage)
 					}
 				} else {
 					// In this case, it is true that ((ok == true && err != nil) || (ok == false && err == nil))


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36772

## Problem
Ranging over maps does not guarantee key order, so the contents, and hence the
checksum of the managed chart file could be different on different runs through
the planner and causes machines to look like they are provisioning when they shouldn't be.

## Solution
The change orders the keys of the map to ensure consistent output.

## Testing
Provisioned RKE2 clusters with multus CNI so that managed charts were sent in the plan to the downstream nodes.