### PR TITLE
pinning v1.3.8-rc10 of rke

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20220120012928-4ea2198e0966
-	github.com/rancher/rke v1.3.8-rc9
+	github.com/rancher/rke v1.3.8-rc10
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20220218171307-a91d90251ffa
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007

--- a/go.sum
+++ b/go.sum
@@ -1285,8 +1285,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8w
 github.com/rancher/remotedialer v0.2.6-0.20220104192242-f3837f8d649a/go.mod h1:vq3LvyOFnLcwMiCE1KdW3foPd6g5kAjZOtOb7JqGHck=
 github.com/rancher/remotedialer v0.2.6-0.20220120012928-4ea2198e0966 h1:AQPsdOLQIHUJsUfJZG7hP+TruzDdkUFBKB/igAAdY6U=
 github.com/rancher/remotedialer v0.2.6-0.20220120012928-4ea2198e0966/go.mod h1:vq3LvyOFnLcwMiCE1KdW3foPd6g5kAjZOtOb7JqGHck=
-github.com/rancher/rke v1.3.8-rc9 h1:gf7zVNdOF6iIYLXvqE1t+3jmUsxGAQ2FOS1kavuL+qc=
-github.com/rancher/rke v1.3.8-rc9/go.mod h1:J5SV4k4RNHLqtDZbTm+xByz2k4j3nCdaDUgCJNTxJDo=
+github.com/rancher/rke v1.3.8-rc10 h1:TEOer+MKkBHaEZVzjp2z0u3eneoseGz//u+p+HnnBV0=
+github.com/rancher/rke v1.3.8-rc10/go.mod h1:J5SV4k4RNHLqtDZbTm+xByz2k4j3nCdaDUgCJNTxJDo=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
 github.com/rancher/steve v0.0.0-20220218171307-a91d90251ffa h1:i5Ngo1K9sv0MACsy9lqYreSiW/VqC1qz81ZGizeGUB8=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210918015053-5a141a6b18f0
 	github.com/rancher/gke-operator v1.1.3-rc1
 	github.com/rancher/norman v0.0.0-20220107203912-4feb41eafabd
-	github.com/rancher/rke v1.3.8-rc9
+	github.com/rancher/rke v1.3.8-rc10
 	github.com/rancher/wrangler v0.8.11-0.20220217210408-3ecd23dfea3b
 	github.com/sirupsen/logrus v1.8.1
 	k8s.io/api v0.23.3

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -737,8 +737,8 @@ github.com/rancher/machine v0.15.0-rancher63/go.mod h1:qXYNumxy0J08MO/mh/jNjyRuE
 github.com/rancher/norman v0.0.0-20200517050325-f53cae161640/go.mod h1:92rz/7QN7DOeLQZlJY/8aFBOmF085igIVguR0wpxLas=
 github.com/rancher/norman v0.0.0-20220107203912-4feb41eafabd h1:N04tea76urCHN5z5b6glUCdzrdFnE1ymxzveeGkNdbU=
 github.com/rancher/norman v0.0.0-20220107203912-4feb41eafabd/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
-github.com/rancher/rke v1.3.8-rc9 h1:gf7zVNdOF6iIYLXvqE1t+3jmUsxGAQ2FOS1kavuL+qc=
-github.com/rancher/rke v1.3.8-rc9/go.mod h1:J5SV4k4RNHLqtDZbTm+xByz2k4j3nCdaDUgCJNTxJDo=
+github.com/rancher/rke v1.3.8-rc10 h1:TEOer+MKkBHaEZVzjp2z0u3eneoseGz//u+p+HnnBV0=
+github.com/rancher/rke v1.3.8-rc10/go.mod h1:J5SV4k4RNHLqtDZbTm+xByz2k4j3nCdaDUgCJNTxJDo=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=


### PR DESCRIPTION
This brings in fixes for rke1 regressions across the 1.20, 1.21, 1.22, and 1.23 latest versions.

https://github.com/rancher/wins/pull/100 
https://github.com/rancher/rke-tools/pull/146 
https://github.com/rancher/kontainer-driver-metadata/pull/859
https://github.com/rancher/rke/pull/2878