### PR TITLE
Fix node deletion in RKE2 cluster

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
@@ -149,6 +149,7 @@ func (h *handler) createMachineObjects(capiCluster *capi.Cluster, machineName st
 
 	if data.Bool("role-control-plane") {
 		labels[rke2.ControlPlaneRoleLabel] = "true"
+		labels[capi.MachineControlPlaneLabelName] = "true"
 	}
 	if data.Bool("role-etcd") {
 		labels[rke2.EtcdRoleLabel] = "true"


### PR DESCRIPTION
Issue: GH-36727

Problem:
The v1 Node is not deleted when a CAPI Machine is deleted in the cluster manager UI.

Solutions:
1. Add the missing CAPI label "cluster.x-k8s.io/control-plane" to the control plane node. Otherwise, we cannot remove a node because of the errNoControlPlaneNodes error.
2. Delete the CAPI Machines which have the control plane role and are managed by an RKEControlPlane object. The deletion of the RKEControlPlane object is triggered by the deletion of the CAPI cluster.

Testing:
the following are tested on rancher which is running locally in Goland:
- provision an RKE2 custom cluster with 1 (control plane + etcd +worker) and 1 worker. First, delete the worker node, then delete the cluster 
- provision an RKE2 custom cluster with 1 (control plane + etcd +worker) and 1 worker. Delete the cluster directly 
- provision an RKE2 custom cluster with 1 control plane, 1 etcd, and 2 workers. First, delete one worker node, then delete the cluster
