### PR TITLE
Adding the bind-address to the kube-controller and scheduler config

### DIFF
--- a/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
+++ b/tests/validation/tests/v3_api/test_rke_cluster_provisioning.py
@@ -244,11 +244,14 @@ rke_config_cis_1_5 = {
         "kubeController": {
             "extraArgs": {
                 "feature-gates": "RotateKubeletServerCertificate=true",
+                 "bind-address": "127.0.0.1"
             },
         },
         "scheduler": {
             "image": "",
-            "extraArgs": {},
+            "extraArgs": {
+                "bind-address": "127.0.0.1"
+            },
             "extraBinds": [],
             "extraEnv": []
         },


### PR DESCRIPTION
 cis scans 1.3.7 and 1.4.2 need an additional parameter --bind-address for the `rke-cis-1.6-hardened` and `rke-cis-1.5-hardened` profile 