### PR TITLE
[2.6.4] Update default ui-dashboard-index setting

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -89,7 +89,7 @@ var (
 	UIFeedBackForm                      = NewSetting("ui-feedback-form", "")
 	UIIndex                             = NewSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
 	UIPath                              = NewSetting("ui-path", "/usr/share/rancher/ui")
-	UIDashboardIndex                    = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/latest/index.html")
+	UIDashboardIndex                    = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/release-2.6.4/index.html")
 	UIDashboardPath                     = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
 	UIPreferred                         = NewSetting("ui-preferred", "vue")
 	UIOfflinePreferred                  = NewSetting("ui-offline-preferred", "dynamic")


### PR DESCRIPTION
- Ensure the dashboard served up in rancher builds with version ending in `-head` tracks the 2.6.4 dashboard (lastest/master dashboard now tracks 2.6.5)
- When `rancher/rancher` branches for 2.6.5 we'll revert this change in that new branch