### PR TITLE
set local k3s to 1.22.7

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-ARG K3S_BUILDER=rancher/k3s:v1.23.3-k3s1
+ARG K3S_BUILDER=rancher/k3s:v1.22.7-k3s1
 
 # Use binaries from k3s root for s390x as k3s is not available on s390x
 FROM registry.suse.com/bci/golang:1.17 AS k3s_root
@@ -18,7 +18,7 @@ ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 ENV CATTLE_HELM_VERSION v2.16.8-rancher1
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher81
-ENV CATTLE_K3S_VERSION v1.23.3+k3s1
+ENV CATTLE_K3S_VERSION v1.22.7+k3s1
 # version used by helm plugin install script
 ENV CATTLE_HELM_UNITTEST_VERSION v0.1.7-rancher3
 # helm 3 version
@@ -83,7 +83,6 @@ COPY --from=k3s_builder \
     /bin/ethtool \
     /bin/ip \
     /bin/ipset \
-    /bin/k3s \
     /bin/losetup \
     /bin/pigz \
     /bin/runc \
@@ -100,12 +99,13 @@ RUN if [ "${ARCH}" != "s390x" ]; then \
         ln -s /usr/bin/cni /usr/bin/host-local && \
         ln -s /usr/bin/cni /usr/bin/loopback && \
         ln -s /usr/bin/cni /usr/bin/portmap && \
-        ln -s /usr/bin/k3s /usr/bin/crictl && \
-        ln -s /usr/bin/k3s /usr/bin/ctr && \
-        ln -s /usr/bin/k3s /usr/bin/k3s-agent && \
-        ln -s /usr/bin/k3s /usr/bin/k3s-etcd-snapshot && \
-        ln -s /usr/bin/k3s /usr/bin/k3s-server && \
-        ln -s /usr/bin/k3s /usr/bin/kubectl && \
+        ln -s /usr/bin/containerd /usr/bin/crictl && \
+        ln -s /usr/bin/containerd /usr/bin/ctr && \
+        ln -s /usr/bin/containerd /usr/bin/k3s && \
+        ln -s /usr/bin/containerd /usr/bin/k3s-agent && \
+        ln -s /usr/bin/containerd /usr/bin/k3s-etcd-snapshot && \
+        ln -s /usr/bin/containerd /usr/bin/k3s-server && \
+        ln -s /usr/bin/containerd /usr/bin/kubectl && \
         ln -s /usr/bin/pigz /usr/bin/unpigz && \
         ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables && \
         ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-save && \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-ARG K3S_BUILDER=rancher/k3s:v1.23.3-k3s1
+ARG K3S_BUILDER=rancher/k3s:v1.22.7-k3s1
 
 # Use binaries from k3s root for s390x as k3s is not available on s390x
 FROM registry.suse.com/suse/sle15:15.3 AS k3s_root
@@ -42,7 +42,7 @@ ENV CATTLE_PARTNER_CHART_DEFAULT_BRANCH=$PARTNER_CHART_DEFAULT_BRANCH
 ENV CATTLE_RKE2_CHART_DEFAULT_BRANCH=$RKE2_CHART_DEFAULT_BRANCH
 ENV CATTLE_HELM_VERSION v2.16.8-rancher1
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher81
-ENV CATTLE_K3S_VERSION v1.23.3+k3s1
+ENV CATTLE_K3S_VERSION v1.22.7+k3s1
 ENV CATTLE_MACHINE_PROVISION_IMAGE rancher/machine:${CATTLE_MACHINE_VERSION}
 ENV CATTLE_ETCD_VERSION v3.5.1
 ENV LOGLEVEL_VERSION v0.1.5
@@ -133,7 +133,6 @@ COPY --from=k3s_builder \
     /bin/ethtool \
     /bin/ip \
     /bin/ipset \
-    /bin/k3s \
     /bin/losetup \
     /bin/pigz \
     /bin/runc \
@@ -148,12 +147,13 @@ RUN if [ "${ARCH}" != "s390x" ]; then \
         ln -s /usr/bin/cni /usr/bin/host-local && \
         ln -s /usr/bin/cni /usr/bin/loopback && \
         ln -s /usr/bin/cni /usr/bin/portmap && \
-        ln -s /usr/bin/k3s /usr/bin/crictl && \
-        ln -s /usr/bin/k3s /usr/bin/ctr && \
-        ln -s /usr/bin/k3s /usr/bin/k3s-agent && \
-        ln -s /usr/bin/k3s /usr/bin/k3s-etcd-snapshot && \
-        ln -s /usr/bin/k3s /usr/bin/k3s-server && \
-        ln -s /usr/bin/k3s /usr/bin/kubectl && \
+        ln -s /usr/bin/containerd /usr/bin/crictl && \
+        ln -s /usr/bin/containerd /usr/bin/ctr && \
+        ln -s /usr/bin/containerd /usr/bin/k3s && \
+        ln -s /usr/bin/containerd /usr/bin/k3s-agent && \
+        ln -s /usr/bin/containerd /usr/bin/k3s-etcd-snapshot && \
+        ln -s /usr/bin/containerd /usr/bin/k3s-server && \
+        ln -s /usr/bin/containerd /usr/bin/kubectl && \
         ln -s /usr/bin/pigz /usr/bin/unpigz && \
         ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables && \
         ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-save && \

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -5,7 +5,7 @@ FROM ${RANCHER_REPO}/rancher:${RANCHER_TAG} as rancher
 FROM registry.suse.com/bci/golang:1.17
 ARG ARCH=amd64
 
-ENV KUBECTL_VERSION v1.23.3
+ENV KUBECTL_VERSION v1.22.7
 RUN zypper -n install --no-recommends curl ca-certificates jq git-core hostname iproute2 vim-small less \
 	bash-completion acl openssh-clients tar gzip xz gawk sysstat && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \


### PR DESCRIPTION
1.23 is experimental for 2.6.4, so setting default to 1.22. Changing packaged binaries back to containerd because it was
an update specific to 1.23 k3s. 