### PR TITLE
Fix rke deploy in airgap

### DIFF
--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -289,7 +289,7 @@ func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
 	}
 	logrus.Tracef("clusterDeploy: deployAgent: desiredTaints is [%v] for cluster [%s]", desiredTaints, cluster.Name)
 
-	privateRegistries := &corev1.Secret{}
+	var privateRegistries *corev1.Secret
 	if cluster.Status.PrivateRegistrySecret != "" {
 		privateRegistries, err = cd.secretLister.Get(namespace.GlobalNamespace, cluster.Status.PrivateRegistrySecret)
 		if err != nil {


### PR DESCRIPTION
#36937 

# Problem
rke1 clusters could not be provisioned in airgap environments.

# Solution
The problem was due to a secret object being initialized as an empty object instead of a nil pointer.  When rancher was configured with a system image registry it would attempt to parse the registry secret to look for credentials.  Because this secret was an empty object instead of nil pointer it would attempt to parse an empty string as json.

# Testing
I did, it works.