### PR TITLE
pkg/catalogv2/git: fix dropped err

### DIFF
--- a/pkg/catalogv2/git/index.go
+++ b/pkg/catalogv2/git/index.go
@@ -27,6 +27,9 @@ func buildOrGetIndex(dir string) (*repo.IndexFile, error) {
 	)
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.Name() == "index.yaml" {
 			if indexPath == "" || len(path) < len(indexPath) {
 				if index, err := repo.LoadIndexFile(path); err == nil {


### PR DESCRIPTION
This fixes an `err` variable that is passed into a `filepath.Walk()` but then dropped.