### PR TITLE
Fix unmarsal empty .dockerconfigjson error

### DIFF
--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -59,7 +59,7 @@ func GeneratePrivateRegistryDockerConfig(privateRegistry *rketypes.PrivateRegist
 		}
 		return base64.URLEncoding.EncodeToString(encodedJSON), nil
 	}
-	if registrySecret != nil {
+	if registrySecret != nil && len(registrySecret.Data[".dockerconfigjson"]) != 0 {
 		privateRegistry = privateRegistry.DeepCopy()
 		dockerCfg := credentialprovider.DockerConfigJSON{}
 		if dockerConfigJSON := registrySecret.Data[".dockerconfigjson"]; len(dockerConfigJSON) > 0 {


### PR DESCRIPTION
If we don't set `.dockerconfigjson` in `registrySecret`, we will have error to unmarshal an empty string.

related issue: https://github.com/harvester/harvester/issues/2046