### PR TITLE
Bump kontainer-engine-driver-lke to v0.0.4

### DIFF
--- a/pkg/data/management/kontainerdriver_data.go
+++ b/pkg/data/management/kontainerdriver_data.go
@@ -102,8 +102,8 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 	}
 	if err := creator.addCustomDriver(
 		"linodekubernetesengine",
-		"https://github.com/linode/kontainer-engine-driver-lke/releases/download/v0.0.3/kontainer-engine-driver-lke-linux-amd64",
-		"02fa95d24a1c6f9c520307e24a543c1777ed21fc3a4f060434e067806578e647",
+		"https://github.com/linode/kontainer-engine-driver-lke/releases/download/v0.0.4/kontainer-engine-driver-lke-linux-amd64",
+		"5609314fe7ff7339a7c8292738d36ccf5a25460f79ca094db72eb6ccf722bc27",
 		"",
 		false,
 		"api.linode.com",


### PR DESCRIPTION
This pull request bumps the LKE kontainer-engine driver to [v0.0.4](https://github.com/linode/kontainer-engine-driver-lke/releases/tag/v0.0.4). This version resolves an issue that would prevent LKE clusters running Kubernetes >= 1.22 from being created or managed in Rancher.

This fix specifically switches the cluster service account creation routine to RBAC v1 from RBAC v1beta1, which was [removed in Kubernetes v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122).

The corresponding change can be found [here](https://github.com/linode/kontainer-engine-driver-lke/pull/11/commits/57f6b5f9f65c65004241332ed41b45a6607806b0#diff-3a710ab6a1dd3264a76a1e4c4c3ebcee14762ef3a66f707726e17fd5fa255715R25).
