### PR TITLE
Linode node driver RKE2 Provisioning

### DIFF
--- a/tests/framework/extensions/cloudcredentials/cloudcredentials.go
+++ b/tests/framework/extensions/cloudcredentials/cloudcredentials.go
@@ -16,6 +16,7 @@ type CloudCredential struct {
 	AmazonEC2CredentialConfig    *AmazonEC2CredentialConfig    `json:"amazonec2credentialConfig,omitempty"`
 	AzureCredentialConfig        *AzureCredentialConfig        `json:"azurecredentialConfig,omitempty"`
 	DigitalOceanCredentialConfig *DigitalOceanCredentialConfig `json:"digitaloceancredentialConfig,omitempty"`
+	LinodeCredentialConfig       *LinodeCredentialConfig       `json:"linodecredentialConfig,omitempty"`
 	HarvesterCredentialConfig    *HarvesterCredentialConfig    `json:"harvestercredentialConfig,omitempty"`
 	UUID                         string                        `json:"uuid,omitempty"`
 }

--- a/tests/framework/extensions/cloudcredentials/linode/create.go
+++ b/tests/framework/extensions/cloudcredentials/linode/create.go
@@ -1,0 +1,29 @@
+package linode
+
+import (
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+)
+
+const linodeCloudCredNameBase = "linodeCloudCredential"
+
+// CreateLinodeCloudCredentials is a helper function that takes the rancher Client as a parameter and creates
+// a Linode cloud credential, and returns the CloudCredential response
+func CreateLinodeCloudCredentials(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error) {
+	var linodeCredentialConfig cloudcredentials.LinodeCredentialConfig
+	config.LoadConfig(cloudcredentials.LinodeCredentialConfigurationFileKey, &linodeCredentialConfig)
+
+	cloudCredential := cloudcredentials.CloudCredential{
+		Name:                   linodeCloudCredNameBase,
+		LinodeCredentialConfig: &linodeCredentialConfig,
+	}
+
+	resp := &cloudcredentials.CloudCredential{}
+	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.CloudCredentialType, cloudCredential, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/tests/framework/extensions/cloudcredentials/linode_config.go
+++ b/tests/framework/extensions/cloudcredentials/linode_config.go
@@ -1,0 +1,7 @@
+package cloudcredentials
+
+const LinodeCredentialConfigurationFileKey = "linodeCredentials"
+
+type LinodeCredentialConfig struct {
+	Token string `json:"token" yaml:"token"`
+}

--- a/tests/framework/extensions/machinepools/linode_machine_config.go
+++ b/tests/framework/extensions/machinepools/linode_machine_config.go
@@ -1,0 +1,60 @@
+package machinepools
+
+import (
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	LinodeKind                              = "LinodeConfig"
+	LinodePoolType                          = "rke-machine-config.cattle.io.linodeconfig"
+	LinodeResourceConfig                    = "linodeconfigs"
+	LinodeMachingConfigConfigurationFileKey = "linodeMachineConfig"
+)
+
+type LinodeMachineConfig struct {
+	AuthorizedUsers string `json:"authorizedUsers" yaml:"authorizedUsers"`
+	DockerPort      string `json:"dockerPort" yaml:"dockerPort"`
+	CreatePrivateIp bool   `json:"createPrivateIp" yaml:"createPrivateIp"`
+	Image           string `json:"image" yaml:"image"`
+	InstanceType    string `json:"instanceType" yaml:"instanceType"`
+	Region          string `json:"region" yaml:"region"`
+	RootPass        string `json:"rootPass" yaml:"rootPass"`
+	SSHPort         string `json:"sshPort" yaml:"sshPort"`
+	SSHUser         string `json:"sshUser" yaml:"sshUser"`
+	Stackscript     string `json:"stackscript" yaml:"stackscript"`
+	StackscriptData string `json:"stackscriptData" yaml:"stackscriptData"`
+	SwapSize        string `json:"swapSize" yaml:"swapSize"`
+	Tags            string `json:"tags" yaml:"tags"`
+	UAPrefix        string `json:"uaPrefix" yaml:"uaPrefix"`
+}
+
+// NewLinodeMachineConfig is a constructor to set up rke-machine-config.cattle.io.linodeconfigs. It returns an *unstructured.Unstructured
+// that CreateMachineConfig uses to created the rke-machine-config
+func NewLinodeMachineConfig(generatedPoolName, namespace string) *unstructured.Unstructured {
+	var linodeMachineConfig LinodeMachineConfig
+	config.LoadConfig(LinodeMachingConfigConfigurationFileKey, &linodeMachineConfig)
+
+	machineConfig := &unstructured.Unstructured{}
+	machineConfig.SetAPIVersion("rke-machine-config.cattle.io/v1")
+	machineConfig.SetKind(LinodeKind)
+	machineConfig.SetGenerateName(generatedPoolName)
+	machineConfig.SetNamespace(namespace)
+	machineConfig.Object["authorizedUsers"] = linodeMachineConfig.AuthorizedUsers
+	machineConfig.Object["createPrivateIp"] = linodeMachineConfig.CreatePrivateIp
+	machineConfig.Object["dockerPort"] = linodeMachineConfig.DockerPort
+	machineConfig.Object["image"] = linodeMachineConfig.Image
+	machineConfig.Object["instanceType"] = linodeMachineConfig.InstanceType
+	machineConfig.Object["region"] = linodeMachineConfig.Region
+	machineConfig.Object["rootPass"] = linodeMachineConfig.RootPass
+	machineConfig.Object["sshPort"] = linodeMachineConfig.SSHPort
+	machineConfig.Object["sshUser"] = linodeMachineConfig.SSHUser
+	machineConfig.Object["stackscript"] = linodeMachineConfig.Stackscript
+	machineConfig.Object["stackscriptData"] = linodeMachineConfig.StackscriptData
+	machineConfig.Object["swapSize"] = linodeMachineConfig.SwapSize
+	machineConfig.Object["tags"] = linodeMachineConfig.Tags
+	machineConfig.Object["token"] = ""
+	machineConfig.Object["type"] = LinodePoolType
+	machineConfig.Object["uaPrefix"] = linodeMachineConfig.UAPrefix
+	return machineConfig
+}

--- a/tests/v2/validation/provisioning/providers.go
+++ b/tests/v2/validation/provisioning/providers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/azure"
 	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/digitalocean"
 	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/harvester"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/linode"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -18,6 +19,7 @@ const (
 	azureProviderName     = "azure"
 	doProviderName        = "do"
 	harvesterProviderName = "harvester"
+	linodeProviderName    = "linode"
 )
 
 type CloudCredFunc func(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error)
@@ -32,7 +34,7 @@ type Provider struct {
 
 // CreateProvider returns all machine and cloud credential
 // configs in the form of a Provider struct. Accepts a
-// string of the name of the provider
+// string of the name of the provider.
 func CreateProvider(name string) Provider {
 	switch {
 	case name == awsProviderName:
@@ -57,6 +59,14 @@ func CreateProvider(name string) Provider {
 			MachineConfig:   machinepools.DOResourceConfig,
 			MachinePoolFunc: machinepools.NewDigitalOceanMachineConfig,
 			CloudCredFunc:   digitalocean.CreateDigitalOceanCloudCredentials,
+		}
+		return provider
+	case name == linodeProviderName:
+		provider := Provider{
+			Name:            name,
+			MachineConfig:   machinepools.LinodeResourceConfig,
+			MachinePoolFunc: machinepools.NewLinodeMachineConfig,
+			CloudCredFunc:   linode.CreateLinodeCloudCredentials,
 		}
 		return provider
 	case name == harvesterProviderName:

--- a/tests/v2/validation/provisioning/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/provisioning_node_driver_test.go
@@ -155,7 +155,6 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2Cluster(provider P
 					err = wait.WatchWait(result, checkFunc)
 					assert.NoError(r.T(), err)
 					assert.Equal(r.T(), clusterName, clusterResp.Name)
-
 				})
 			}
 		}


### PR DESCRIPTION
**Framework Updates:**
Added support for provisioing linode RKE2 clusters. Including: 
- linode cloud credential helper
- rke-machine-config.cattle.io.linodeconfig machine pool config helpers.

**Validation test updates**
 Updated provisioning validation tests to account for linode node provider.