### PR TITLE
Be more intelligent when the cluster-agent is disconnected

### DIFF
--- a/pkg/apis/rke.cattle.io/v1/controlplane.go
+++ b/pkg/apis/rke.cattle.io/v1/controlplane.go
@@ -69,4 +69,5 @@ type RKEControlPlaneStatus struct {
 	ETCDSnapshotCreatePhase        ETCDSnapshotPhase                   `json:"etcdSnapshotCreatePhase,omitempty"`
 	ConfigGeneration               int64                               `json:"configGeneration,omitempty"`
 	Initialized                    bool                                `json:"initialized,omitempty"`
+	AgentConnected                 bool                                `json:"agentConnected,omitempty"`
 }

--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -519,7 +519,7 @@ func (m *Lifecycle) sync(key string, obj *v3.Node) (runtime.Object, error) {
 		return nil, nil
 	}
 
-	if cleanupAnnotation, ok := obj.Annotations[userNodeRemoveCleanupAnnotation]; !ok || cleanupAnnotation != "true" {
+	if obj.Annotations[userNodeRemoveCleanupAnnotation] != "true" {
 		// finalizer from user-node-remove has to be checked/cleaned
 		return m.userNodeRemoveCleanup(obj)
 	}

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/norman/types/convert"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2"
 	"github.com/rancher/rancher/pkg/features"
 	fleetconst "github.com/rancher/rancher/pkg/fleet"
 	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta1"
@@ -358,6 +359,7 @@ func (h *handler) updateStatus(objs []runtime.Object, cluster *v1.Cluster, statu
 				status.Conditions = append(status.Conditions, newCond)
 			}
 		}
+		status.AgentDeployed = rke2.AgentDeployed.IsTrue(existing)
 	}
 
 	// Never set ready back to false because we will end up deleting the secret

--- a/pkg/controllers/provisioningv2/rke2/common.go
+++ b/pkg/controllers/provisioningv2/rke2/common.go
@@ -70,11 +70,13 @@ const (
 	RKEMachineAPIVersion           = "rke-machine.cattle.io/v1"
 	RKEAPIVersion                  = "rke.cattle.io/v1"
 
-	Provisioned = condition.Cond("Provisioned")
-	Ready       = condition.Cond("Ready")
-	Waiting     = condition.Cond("Waiting")
-	Pending     = condition.Cond("Pending")
-	Removed     = condition.Cond("Removed")
+	Provisioned    = condition.Cond("Provisioned")
+	Ready          = condition.Cond("Ready")
+	Waiting        = condition.Cond("Waiting")
+	Pending        = condition.Cond("Pending")
+	Removed        = condition.Cond("Removed")
+	AgentDeployed  = condition.Cond("AgentDeployed")
+	AgentConnected = condition.Cond("Connected")
 
 	RuntimeK3S  = "k3s"
 	RuntimeRKE2 = "rke2"

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -308,7 +308,7 @@ func (h *handler) updateClusterProvisioningStatus(cluster *rancherv1.Cluster, st
 	if cp == nil {
 		return status, fmt.Errorf("error while updating cluster provisioning status - rkecontrolplane was nil")
 	}
-	if cluster.DeletionTimestamp != nil && h.mgmtClusterCache != nil {
+	if h.mgmtClusterCache != nil {
 		mgmtCluster, err := h.mgmtClusterCache.Get(cluster.Status.ClusterName)
 		if err != nil {
 			return status, err

--- a/pkg/provisioningv2/capi/capi.go
+++ b/pkg/provisioningv2/capi/capi.go
@@ -61,6 +61,7 @@ func (t *connectedAgentClusterCacheClient) Get(ctx context.Context, key client.O
 	if err == nil && !rkeCP.Status.AgentConnected {
 		// If the agent is not connected, then returning a NotFound error will cause CAPI to stop its caches
 		// They will be refreshed once the agent reconnects.
+		// See the ClusterCacheReconciler: https://github.com/kubernetes-sigs/cluster-api/blob/5026786ee809c5def466049f5befd2a786fbcefa/controllers/remote/cluster_cache_reconciler.go#L60
 		return apierrors.NewNotFound(schema.GroupResource{
 			Group:    obj.GetObjectKind().GroupVersionKind().Group,
 			Resource: obj.GetObjectKind().GroupVersionKind().Kind,

--- a/pkg/provisioningv2/rke2/planner/etcdrestore.go
+++ b/pkg/provisioningv2/rke2/planner/etcdrestore.go
@@ -127,14 +127,15 @@ func (p *Planner) generateStopServiceAndKillAllPlan(controlPlane *rkev1.RKEContr
 	if err != nil {
 		return nodePlan, err
 	}
-	killAllScript := rke2.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion) + "-killall.sh"
+	runtime := rke2.GetRuntime(controlPlane.Spec.KubernetesVersion)
+	killAllScript := runtime + "-killall.sh"
 	nodePlan.Instructions = append(nodePlan.Instructions,
 		plan.OneTimeInstruction{
 			Name:    "shutdown",
 			Command: "/bin/sh",
 			Args: []string{
 				"-c",
-				fmt.Sprintf("if [ -z $(command -v %s) ] && [ -z $(command -v %s) ]; then echo %s does not appear to be installed; exit 0; else %s; fi", rke2.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion), killAllScript, rke2.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion), killAllScript),
+				fmt.Sprintf("if [ -z $(command -v %s) ] && [ -z $(command -v %s) ]; then echo %s does not appear to be installed; exit 0; else %s; fi", runtime, killAllScript, runtime, killAllScript),
 			},
 		})
 	return nodePlan, nil
@@ -171,7 +172,7 @@ func (p *Planner) runEtcdRestoreControlPlaneEtcdServiceStop(controlPlane *rkev1.
 			return err
 		}
 	}
-	servers := collect(clusterPlan, isControlPlaneEtcd)
+	servers := collect(clusterPlan, anyRole)
 	updated := false
 	for _, server := range servers {
 		stopPlan, err := p.generateStopServiceAndKillAllPlan(controlPlane, tokensSecret, server, joinServer)

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -554,6 +554,8 @@ func (p *Planner) reconcile(controlPlane *rkev1.RKEControlPlane, tokensSecret pl
 			outOfSync = append(outOfSync, entry.Machine.Name)
 			messages[entry.Machine.Name] = append(messages[entry.Machine.Name], "waiting for kubelet to update")
 		} else if tierName == controlPlaneTier && !controlPlane.Status.AgentConnected {
+			// If the control plane nodes are currently being provisioned/updated, then it should be ensured that cluster-agent is connected.
+			// Without the agent connected, the controllers running in Rancher, including CAPI, can't communicate with the downstream cluster.
 			outOfSync = append(outOfSync, entry.Machine.Name)
 			messages[entry.Machine.Name] = append(messages[entry.Machine.Name], "waiting for cluster agent to connect")
 		} else {


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/37001

## Problem
The fundamental issue being fixed here is restoring an RKE2 cluster with 1 
etcd-only node, 1 control plane node, and 1 worker node. Previously, the etcd 
and control plane nodes would be shutdown before the restore happened. The 
cluster-agent would then be rescheduled to the worker node because it wouldn't 
be updated. This caused some issues because it looked like the agent was 
connected, but Rancher couldn't use it in any way because the api-service was 
shutdown. This would cause the restore to hang because the etcd-only node's 
kubelet version was not getting updated.

## Solution
After this change, all nodes in the cluster are shutdown before the restore 
happens. This caused the cluster agent to disconnect, as desired.

However, this caused another problem: since the CAPI clients and caches connect 
through the cluster-agent, the caches would get out of sync and the kubelet 
version was not being updated on the CAPI machines for a long time (several 
minutes). This artificially slowed down the restore on all types of RKE2 
clusters.

To fix this issue, a different client is passed to the CAPI cluster cache 
reconciler that would cause the cache to be refreshed when the cluster-agent 
disconnected.

## Testing
Provisioning, updating, and restoring an RKE2 cluster with 1 etcd-only, 1 cp, and 1 worker node.