### PR TITLE
[2.5] Fix clustertemplate condition and add retries

### DIFF
--- a/pkg/controllers/management/secretmigrator/clustertemplaterevisions.go
+++ b/pkg/controllers/management/secretmigrator/clustertemplaterevisions.go
@@ -16,7 +16,7 @@ func (h *handler) syncTemplate(key string, clusterTemplateRevision *v3.ClusterTe
 		logrus.Tracef("[secretmigrator] clusterTemplateRevision %s already migrated", clusterTemplateRevision.Name)
 		return clusterTemplateRevision, nil
 	}
-	obj, err := apimgmtv3.ClusterConditionSecretsMigrated.Do(clusterTemplateRevision, func() (runtime.Object, error) {
+	obj, err := apimgmtv3.ClusterTemplateRevisionConditionSecretsMigrated.Do(clusterTemplateRevision, func() (runtime.Object, error) {
 		// privateRegistries
 		if clusterTemplateRevision.Status.PrivateRegistrySecret == "" {
 			logrus.Tracef("[secretmigrator] migrating private registry secrets for clusterTemplateRevision %s", clusterTemplateRevision.Name)


### PR DESCRIPTION
Add retries to the clustertemplaterevision action handler in case it
gets caught trying to update the CTR at the same time as the
secretmigrator controller.

Backport https://github.com/rancher/rancher/pull/37096
https://github.com/rancher/rancher/issues/37107