### PR TITLE
[2.4] Fix clustertemplate condition and add retries

### DIFF
--- a/pkg/api/customization/clustertemplate/cluster_template.go
+++ b/pkg/api/customization/clustertemplate/cluster_template.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -134,17 +135,21 @@ func (w Wrapper) updateEnabledFlagOnRevision(apiContext *types.APIContext, enabl
 	if err != nil {
 		//if conflict update, retry by loading from the store
 		if apierrors.IsConflict(err) {
-			revisionFromStore, err := w.ClusterTemplateRevisions.GetNamespaced(namespace.GlobalNamespace, revision.ObjectMeta.Name, v1.GetOptions{})
-			if err != nil {
-				return httperror.WrapAPIError(err, httperror.ServerError, "failed to load clusterTemplateRevision from store")
-			}
-			revisionStoreCopy := revisionFromStore.DeepCopy()
-			revisionStoreCopy.Spec.Enabled = &enabledFlag
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				revisionFromStore, err := w.ClusterTemplateRevisions.GetNamespaced(namespace.GlobalNamespace, revision.ObjectMeta.Name, v1.GetOptions{})
+				if err != nil {
+					return httperror.WrapAPIError(err, httperror.ServerError, "failed to load clusterTemplateRevision from store")
+				}
+				revisionStoreCopy := revisionFromStore.DeepCopy()
+				revisionStoreCopy.Spec.Enabled = &enabledFlag
 
-			_, err = w.ClusterTemplateRevisions.Update(revisionStoreCopy)
+				_, err = w.ClusterTemplateRevisions.Update(revisionStoreCopy)
+				return err
+			})
 			if err != nil {
 				return httperror.WrapAPIError(err, httperror.ServerError, fmt.Sprintf("failed to set enabled flag to %v on clusterTemplateRevision", enabledFlag))
 			}
+			return nil
 		}
 		return httperror.WrapAPIError(err, httperror.ServerError, fmt.Sprintf("failed to set enabled flag to %v on clusterTemplateRevision", enabledFlag))
 	}

--- a/pkg/controllers/management/secretmigrator/clustertemplaterevisions.go
+++ b/pkg/controllers/management/secretmigrator/clustertemplaterevisions.go
@@ -15,7 +15,7 @@ func (h *handler) syncTemplate(key string, clusterTemplateRevision *v3.ClusterTe
 		logrus.Tracef("[secretmigrator] clusterTemplateRevision %s already migrated", clusterTemplateRevision.Name)
 		return clusterTemplateRevision, nil
 	}
-	obj, err := v3.ClusterConditionSecretsMigrated.Do(clusterTemplateRevision, func() (runtime.Object, error) {
+	obj, err := v3.ClusterTemplateRevisionConditionSecretsMigrated.Do(clusterTemplateRevision, func() (runtime.Object, error) {
 		// privateRegistries
 		if clusterTemplateRevision.Status.PrivateRegistrySecret == "" {
 			logrus.Tracef("[secretmigrator] migrating private registry secrets for clusterTemplateRevision %s", clusterTemplateRevision.Name)


### PR DESCRIPTION
Add retries to the clustertemplaterevision action handler in case it
gets caught trying to update the CTR at the same time as the
secretmigrator controller.

Backport https://github.com/rancher/rancher/pull/37096
https://github.com/rancher/rancher/issues/37107