### PR TITLE
Private registry cleanup job

### DIFF
--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+const cleanupPodLabel = "rke.cattle.io/cleanup-node"
+
 func (m *Lifecycle) deleteV1Node(node *v3.Node) (runtime.Object, error) {
 	logrus.Debugf("Deleting v1.node for [%v] node", node.Status.NodeName)
 	if nodehelper.IgnoreNode(node.Status.NodeName, node.Status.NodeLabels) {
@@ -171,7 +173,7 @@ func (m *Lifecycle) cleanRKENode(node *v3.Node) error {
 		return err
 	}
 
-	return m.waitUntilJobDeletes(userContext, job)
+	return m.waitUntilJobDeletes(userContext, node.Name, job)
 }
 
 func (m *Lifecycle) waitForJobCondition(userContext *config.UserContext, job *v1.Job, condition func(*v1.Job, error) bool, logMessage string) error {
@@ -220,10 +222,20 @@ func (m *Lifecycle) waitUntilJobCompletes(userContext *config.UserContext, job *
 	)
 }
 
-func (m *Lifecycle) waitUntilJobDeletes(userContext *config.UserContext, job *v1.Job) error {
+func (m *Lifecycle) waitUntilJobDeletes(userContext *config.UserContext, nodeName string, job *v1.Job) error {
 	return m.waitForJobCondition(userContext, job, func(j *v1.Job, err error) bool {
-		if j.DeletionTimestamp.IsZero() {
-			err = userContext.BatchV1.Jobs(j.Namespace).Delete(j.Name, &metav1.DeleteOptions{PropagationPolicy: &[]metav1.DeletionPropagation{metav1.DeletePropagationForeground}[0]})
+		if err == nil {
+			if j.DeletionTimestamp.IsZero() {
+				err = userContext.BatchV1.Jobs(j.Namespace).Delete(j.Name, &metav1.DeleteOptions{PropagationPolicy: &[]metav1.DeletionPropagation{metav1.DeletePropagationForeground}[0]})
+			} else if pods, err := userContext.Core.Pods(j.Namespace).List(metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", cleanupPodLabel, nodeName)}); err != nil && !kerror.IsNotFound(err) {
+				logrus.Errorf("[node-cleanup] failed to list cleanup pods for node %s: %v", nodeName, err)
+				return false
+			} else if err == nil && len(pods.Items) > 0 {
+				if err = userContext.Core.Pods(j.Namespace).Delete(pods.Items[0].Name, &metav1.DeleteOptions{GracePeriodSeconds: &[]int64{0}[0]}); err != nil {
+					logrus.Errorf("[node-cleanup] failed to delete cleanup pod %s for node %s: %v", pods.Items[0].Name, nodeName, err)
+					return false
+				}
+			}
 		}
 		return kerror.IsNotFound(err)
 	},
@@ -257,7 +269,7 @@ func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, cluster *v
 			}
 		}
 
-		return nil, m.waitUntilJobDeletes(userContext, &existingJob.Items[0])
+		return nil, m.waitUntilJobDeletes(userContext, node.Name, &existingJob.Items[0])
 	}
 
 	meta := metav1.ObjectMeta{
@@ -352,6 +364,11 @@ func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, cluster *v
 		Spec: batchV1.JobSpec{
 			TTLSecondsAfterFinished: &fiveMin,
 			Template: coreV1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						cleanupPodLabel: node.Name,
+					},
+				},
 				Spec: coreV1.PodSpec{
 					ImagePullSecrets: imagePullSecrets,
 					RestartPolicy:    "Never",

--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -11,6 +11,7 @@ import (
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	util "github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/dialer"
+	"github.com/rancher/rancher/pkg/features"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/batch/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/kubectl"
@@ -136,6 +137,10 @@ func (m *Lifecycle) drainNode(node *v3.Node) error {
 }
 
 func (m *Lifecycle) cleanRKENode(node *v3.Node) error {
+	if !features.RKE1CustomNodeCleanup.Enabled() {
+		return nil
+	}
+
 	cluster, err := m.clusterLister.Get("", node.Namespace)
 	if err != nil {
 		if kerror.IsNotFound(err) {

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -101,6 +101,12 @@ var (
 		true,
 		true,
 		true)
+	RKE1CustomNodeCleanup = newFeature(
+		"rke1-custom-node-cleanup",
+		"Enable cleanup RKE1 custom cluster nodes when they are deleted",
+		true,
+		true,
+		true)
 )
 
 type Feature struct {


### PR DESCRIPTION
Issues:
https://github.com/rancher/rancher/issues/36981
https://github.com/rancher/rancher/issues/37079
https://github.com/rancher/rancher/issues/37063

## Problem
Add feature flag for custom RKE1 node cleanup

It is common for users to cleanup their own custom nodes when deleting
them from Rancher. This has caused issue with jobs and/or pods being
left around or nodes not being deleted properly.

## Solution
This change adds a feature flag to turn the cleanup off globally if a
user doesn't need it.

## Problem
Refactor node-cleanup job implementation

It was determined that some of the code around creating and deleting the
node-cleanup job was producing unexpected results like non-nil errors
with empty error messages. In addition, the cleanup job is being
leftover in some case.

## Solution
This code makes the error messages more descriptive and adds retries to
try to ensure that the cleanup job gets deleted.

## Problem
Add private registry information to node cleanup job

The node cleanup job ignored cluster private registry information. This caused
issues when trying to remove nodes from a custom RKE1 cluster when private
registries were enforced by something like OPA Gatekeeper.

## Solution
Now, just as with cluster agent deployment, private registry information is
added whenever needed.

## Problem
If a pod is stuck because it has been scheduled on a node that node
longer exists, then deleting the job may not be enough to delete this
pod. This would cause the job deletion to hang forever.

## Solution
This change deletes the pod with gradePeriodSeconds of 0 to force its
deletion.