### PR TITLE
Add New Settings for RKE2/K3S Default Versions 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/prometheus/common v0.32.1
 	github.com/rancher/aks-operator v1.0.4
 	github.com/rancher/apiserver v0.0.0-20220223185512-c4e289f92e46
-	github.com/rancher/channelserver v0.5.1-0.20220217142715-90ef7d38f3f8
+	github.com/rancher/channelserver v0.5.1-0.20220405170618-28c9b37deff1
 	github.com/rancher/dynamiclistener v0.3.1-0.20210616080009-9865ae859c7f
 	github.com/rancher/eks-operator v1.1.3
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210918015053-5a141a6b18f0

--- a/go.sum
+++ b/go.sum
@@ -1240,8 +1240,8 @@ github.com/rancher/apiserver v0.0.0-20201023000256-1a0a904f9197/go.mod h1:8W0Ewa
 github.com/rancher/apiserver v0.0.0-20210922180056-297b6df8d714/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
 github.com/rancher/apiserver v0.0.0-20220223185512-c4e289f92e46 h1:yUIRY3C0guO3qgWLojYSBZ+mbKMyjAVMNrWH7f7+APw=
 github.com/rancher/apiserver v0.0.0-20220223185512-c4e289f92e46/go.mod h1:cnLj3AnKR96wADHmJMS4msdCl1PMkXVbcSuPkfDbVWA=
-github.com/rancher/channelserver v0.5.1-0.20220217142715-90ef7d38f3f8 h1:vOhxMryJW8NkoCXUKHvYWHw4LpJ2OKYpDws4CdeN8Lw=
-github.com/rancher/channelserver v0.5.1-0.20220217142715-90ef7d38f3f8/go.mod h1:6hdl+500DWTtg4sKC7/CYJjRU7CFCsH+lnfxIle8JHM=
+github.com/rancher/channelserver v0.5.1-0.20220405170618-28c9b37deff1 h1:NMYQzCtLEEaJZ2xleLzDixN6Y+yO9ShzgsjHDg4zOrk=
+github.com/rancher/channelserver v0.5.1-0.20220405170618-28c9b37deff1/go.mod h1:dZ4saGTw1S0RwX8ivPijBIR+2obRpfFuO2NkDHUKKXg=
 github.com/rancher/client-go v1.23.3-rancher2 h1:99raSqSdtNF1aQCJ45r/1t8KZmld6AkA4+nsfalnA98=
 github.com/rancher/client-go v1.23.3-rancher2/go.mod h1:47oMd+YvAOqZM7pcQ6neJtBiFH7alOyfunYN48VsmwE=
 github.com/rancher/dynamiclistener v0.2.1-0.20200714201033-9c1939da3af9/go.mod h1:qr0QfhwzcVCR+Ao9WyfnE+jmOpfEAdRhXtNOZGJ3nCQ=
@@ -1450,7 +1450,7 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
-github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+github.com/urfave/cli/v2 v2.4.0/go.mod h1:NX9W0zmTvedE5oDoOMs2RTC8RvdK98NTYZE5LbaEYPg=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
 github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=

--- a/pkg/channelserver/channelserver.go
+++ b/pkg/channelserver/channelserver.go
@@ -3,11 +3,14 @@ package channelserver
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/rancher/channelserver/pkg/config"
 	"github.com/rancher/channelserver/pkg/model"
 	"github.com/rancher/channelserver/pkg/server"
@@ -114,8 +117,8 @@ func GetReleaseConfigByRuntime(ctx context.Context, runtime string) *config.Conf
 			config.StringSource("/var/lib/rancher-data/driver-metadata/data.json"),
 		}
 		configs = map[string]*config.Config{
-			"k3s":  config.NewConfig(ctx, "k3s", &DynamicInterval{"k3s"}, getChannelServerArg(), urls),
-			"rke2": config.NewConfig(ctx, "rke2", &DynamicInterval{"rke2"}, getChannelServerArg(), urls),
+			"k3s":  config.NewConfig(ctx, "k3s", &DynamicInterval{"k3s"}, getChannelServerArg(), "rancher", urls),
+			"rke2": config.NewConfig(ctx, "rke2", &DynamicInterval{"rke2"}, getChannelServerArg(), "rancher", urls),
 		}
 	})
 	return configs[runtime]
@@ -127,4 +130,71 @@ func NewHandler(ctx context.Context) http.Handler {
 		"v1-k3s-release":  GetReleaseConfigByRuntime(ctx, "k3s"),
 		"v1-rke2-release": GetReleaseConfigByRuntime(ctx, "rke2"),
 	})
+}
+
+func GetDefaultByRuntimeAndServerVersion(ctx context.Context, runtime, serverVersion string) string {
+	version, err := getDefaultFromAppDefaultsByRuntimeAndServerVersion(ctx, runtime, serverVersion)
+	if err != nil {
+		logrus.Debugf("[channelserver] fallback to use the default channel due to: %v", err)
+		version = getDefaultFromChannel(ctx, runtime, "default")
+	}
+	return version
+}
+
+func getDefaultFromAppDefaultsByRuntimeAndServerVersion(ctx context.Context, runtime, serverVersion string) (string, error) {
+	var defaultVersionRange string
+	serverVersionParsed, err := semver.ParseTolerant(serverVersion)
+	if err != nil {
+		return "", fmt.Errorf("fails to parse the server version: %v", err)
+	}
+	config := GetReleaseConfigByRuntime(ctx, runtime)
+	appDefaults := config.AppDefaultsConfig().AppDefaults
+	if len(appDefaults) == 0 {
+		return "", fmt.Errorf("no %s appDefaults is found for %s", runtime, serverVersion)
+	}
+	// We use the first entry from the list. We do not expect the list contains more than one entry.
+	for _, appDefault := range appDefaults[0].Defaults {
+		avrParsed, err := semver.ParseRange(appDefault.AppVersion)
+		if err != nil {
+			return "", fmt.Errorf("faild to parse %s appVersionRange for %s: %v", runtime, serverVersion, err)
+		}
+		if avrParsed(serverVersionParsed) {
+			defaultVersionRange = appDefault.DefaultVersion
+			continue
+		}
+	}
+	if defaultVersionRange == "" {
+		return "", fmt.Errorf("no matching %s defaultVersionRange is found for %s", runtime, serverVersion)
+	}
+	dvrParsed, err := semver.ParseRange(defaultVersionRange)
+	if err != nil {
+		return "", fmt.Errorf("faild to parse %s defaultVersionRange for %s: %v", runtime, serverVersion, err)
+	}
+
+	var candidate []string
+	for _, release := range config.ReleasesConfig().Releases {
+		version, err := semver.ParseTolerant(release.Version)
+		if err != nil {
+			logrus.Debugf("fails to parse the release version %s: %v", release.Version, err)
+			continue
+		}
+		if dvrParsed(version) {
+			candidate = append(candidate, release.Version)
+		}
+	}
+	if len(candidate) == 0 {
+		return "", fmt.Errorf("no %s version is found for %s", runtime, serverVersion)
+	}
+	sort.Strings(candidate)
+	return candidate[len(candidate)-1], nil
+}
+
+func getDefaultFromChannel(ctx context.Context, runtime, channelName string) string {
+	config := GetReleaseConfigByRuntime(ctx, runtime)
+	for _, c := range config.ChannelsConfig().Channels {
+		if c.Name == channelName {
+			return c.Latest
+		}
+	}
+	return ""
 }

--- a/pkg/controllers/management/kontainerdrivermetadata/data.go
+++ b/pkg/controllers/management/kontainerdrivermetadata/data.go
@@ -1,6 +1,7 @@
 package kontainerdrivermetadata
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -13,6 +14,7 @@ import (
 	mVersion "github.com/mcuadros/go-version"
 	"github.com/rancher/norman/types/convert"
 	setting2 "github.com/rancher/rancher/pkg/api/norman/store/setting"
+	"github.com/rancher/rancher/pkg/channelserver"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
@@ -59,6 +61,8 @@ var rancherUpdateSettingMap = map[string]settings.Setting{
 	settings.UIKubernetesSupportedVersions.Name:     settings.UIKubernetesSupportedVersions,
 	settings.KubernetesVersionToSystemImages.Name:   settings.KubernetesVersionToSystemImages,
 	settings.KubernetesVersionToServiceOptions.Name: settings.KubernetesVersionToServiceOptions,
+	settings.Rke2DefaultVersion.Name:                settings.Rke2DefaultVersion,
+	settings.K3sDefaultVersion.Name:                 settings.K3sDefaultVersion,
 }
 
 func (md *MetadataController) loadDataFromLocal() (kdm.Data, error) {
@@ -682,6 +686,9 @@ func toUpdate(maxVersionForMajorK8sVersion map[string]string, deprecated map[str
 	uiSupported := fmt.Sprintf(">=%s.x <=%s.x", minVersion, maxVersion)
 	uiDefaultRange := fmt.Sprintf("<=%s.x", maxVersion)
 
+	rke2DefaultVersion := channelserver.GetDefaultByRuntimeAndServerVersion(context.TODO(), "rke2", rancherVersion)
+	k3sDefaultVersion := channelserver.GetDefaultByRuntimeAndServerVersion(context.TODO(), "k3s", rancherVersion)
+
 	return map[string]string{
 		settings.KubernetesVersionsCurrent.Name:         strings.Join(k8sVersionsCurrent, ","),
 		settings.KubernetesVersion.Name:                 defaultK8sVersion,
@@ -690,6 +697,8 @@ func toUpdate(maxVersionForMajorK8sVersion map[string]string, deprecated map[str
 		settings.UIKubernetesSupportedVersions.Name:     uiSupported,
 		settings.KubernetesVersionToSystemImages.Name:   k8sCurrRKEdata,
 		settings.KubernetesVersionToServiceOptions.Name: k8sSvcOptionData,
+		settings.Rke2DefaultVersion.Name:                rke2DefaultVersion,
+		settings.K3sDefaultVersion.Name:                 k3sDefaultVersion,
 	}, nil
 }
 

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -126,6 +126,9 @@ var (
 
 	FleetMinVersion          = NewSetting("fleet-min-version", "")
 	RancherWebhookMinVersion = NewSetting("rancher-webhook-min-version", "")
+
+	Rke2DefaultVersion = NewSetting("rke2-default-version", "")
+	K3sDefaultVersion  = NewSetting("k3s-default-version", "")
 )
 
 func FullShellImage() string {


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36827

# Problem
The default rke2/k3s version should be configurable per rancher version. 
Both the default rke2/k3s version and rancher version need to be a range so we do not need to add a new entry each time when we release a new rancher version. 

# Solution
Rancher will get the version ranges from the channelserver, calculate the default versions for the current rancher version, and expose them as new `Settings` items: 
- `rke2-default-version`
- `k3s-default-version`

And they are available under the `/v1/management.cattle.io.settings` endpoint automatically. 

# Dependency
We need to add the support for `appDefaults` to the channelsesrver : https://github.com/rancher/channelserver/pull/17
 

# Testing  
- the correct default versions show up in the settings after rancher runs up 
- the correct default versions show up in the settings when the external KDM is not accessible or out-of-date. This is to simulate the airgap environment.
- the default versions are updated correctly after corresponding values are updated in the KDM 


# Note
~To make the CI pass, this PR replaces the rancher/channelserver module with my fork.  It will be switched back once the above PR to the channel server is merged.~
Update: the PR in rancher/channelsever was merged and we switched back to use the latest commit for it.