### PR TITLE
Remove usage of snapshotbackpopulate tweaklist for reliability

### DIFF
--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -38,9 +38,7 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 	windows.Register(ctx, clusterRec, cluster)
 	nsserviceaccount.Register(ctx, cluster)
 	if features.RKE2.Enabled() {
-		if err := snapshotbackpopulate.Register(ctx, cluster); err != nil {
-			return err
-		}
+		snapshotbackpopulate.Register(ctx, cluster)
 		pspdelete.Register(ctx, cluster)
 		machinerole.Register(ctx, cluster)
 	}

--- a/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
+++ b/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
@@ -171,6 +171,10 @@ func (h *handler) OnChange(key string, configMap *corev1.ConfigMap) (runtime.Obj
 			logrus.Tracef("[snapshotbackpopulate] rkecluster %s/%s: creating etcd snapshot %s/%s: %+v", cluster.Namespace, cluster.Name, cmGeneratedSnapshot.Namespace, cmGeneratedSnapshot.Name, cmGeneratedSnapshot)
 			_, err = h.etcdSnapshots.Create(&cmGeneratedSnapshot)
 			if err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: duplicate snapshot found when creating snapshot %s/%s", cluster.Namespace, cluster.Name, cmGeneratedSnapshot.Namespace, cmGeneratedSnapshot.Name)
+					continue
+				}
 				return configMap, fmt.Errorf("rkecluster %s/%s: error while creating etcd snapshot %s/%s: %w", cluster.Namespace, cluster.Name, cmGeneratedSnapshot.Namespace, cmGeneratedSnapshot.Name, err)
 			}
 		}


### PR DESCRIPTION
This should possibly help to resolve https://github.com/rancher/rancher/issues/36948 and other weird issues we are having with the snapshotbackpopulate controller.

Also, will stop the duplicate snapshot create error message for https://github.com/rancher/rancher/issues/36711