### PR TITLE
Pull Rancher images from private registry in RKE2 clusters

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -15,7 +15,9 @@ import (
 	mgmtcontrollers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	rocontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	rkecontrollers "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/provisioningv2/image"
 	"github.com/rancher/rancher/pkg/provisioningv2/kubeconfig"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/pkg/apply"
@@ -272,6 +274,8 @@ func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus,
 	spec.DefaultPodSecurityPolicyTemplateName = cluster.Spec.DefaultPodSecurityPolicyTemplateName
 	spec.DefaultClusterRoleForProjectMembers = cluster.Spec.DefaultClusterRoleForProjectMembers
 	spec.EnableNetworkPolicy = cluster.Spec.EnableNetworkPolicy
+	spec.DesiredAgentImage = image.ResolveWithCluster(settings.AgentImage.Get(), cluster)
+	spec.DesiredAuthImage = image.ResolveWithCluster(settings.AuthImage.Get(), cluster)
 
 	spec.AgentEnvVars = nil
 	for _, env := range cluster.Spec.AgentEnvVars {

--- a/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
+++ b/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
@@ -5,6 +5,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	rancherv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	namespaces "github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/provisioningv2/image"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/wrangler/pkg/name"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +31,7 @@ func (h *handler) OnChangeInstallSUC(cluster *rancherv1.Cluster, status rancherv
 				Data: map[string]interface{}{
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
-							"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
+							"systemDefaultRegistry": image.GetPrivateRepoURLFromCluster(cluster),
 						},
 					},
 				},

--- a/pkg/provisioningv2/image/resolve.go
+++ b/pkg/provisioningv2/image/resolve.go
@@ -1,0 +1,88 @@
+package image
+
+import (
+	"path"
+	"strings"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/settings"
+)
+
+func ResolveWithControlPlane(image string, cp *rkev1.RKEControlPlane) string {
+	return resolve(GetPrivateRepoURLFromControlPlane(cp), image)
+}
+
+func ResolveWithCluster(image string, cluster *v1.Cluster) string {
+	return resolve(GetPrivateRepoURLFromCluster(cluster), image)
+
+}
+
+func resolve(reg, image string) string {
+	if reg != "" && !strings.HasPrefix(image, reg) {
+		//Images from Dockerhub Library repo, we add rancher prefix when using private registry
+		if !strings.Contains(image, "/") {
+			image = "rancher/" + image
+		}
+		return path.Join(reg, image)
+	}
+
+	return image
+}
+
+func GetPrivateRepoURLFromCluster(cluster *v1.Cluster) string {
+	if cluster != nil && cluster.Spec.RKEConfig != nil {
+		return getPrivateRepoURL(cluster.Spec.RKEConfig.MachineGlobalConfig, cluster.Spec.RKEConfig.MachineSelectorConfig)
+	}
+
+	return settings.SystemDefaultRegistry.Get()
+}
+
+func GetPrivateRepoURLFromControlPlane(cp *rkev1.RKEControlPlane) string {
+	if cp != nil {
+		return getPrivateRepoURL(cp.Spec.MachineGlobalConfig, cp.Spec.MachineSelectorConfig)
+	}
+
+	return settings.SystemDefaultRegistry.Get()
+}
+
+func getPrivateRepoURL(machineGlobalConfig rkev1.GenericMap, machineSelectorConfig []rkev1.RKESystemConfig) string {
+	for key, val := range machineGlobalConfig.Data {
+		if val, ok := val.(string); ok && key == "system-default-registry" {
+			return val
+		}
+	}
+
+	for _, config := range machineSelectorConfig {
+		if registryVal, ok := config.Config.Data["system-default-registry"]; config.MachineLabelSelector == nil && ok {
+			if registry, ok := registryVal.(string); ok {
+				return registry
+			}
+		}
+	}
+
+	return settings.SystemDefaultRegistry.Get()
+}
+
+func GetDesiredAgentImage(cp *rkev1.RKEControlPlane, mgmtCluster *v3.Cluster) string {
+	desiredAgent := mgmtCluster.Spec.DesiredAgentImage
+	if mgmtCluster.Spec.AgentImageOverride != "" {
+		desiredAgent = mgmtCluster.Spec.AgentImageOverride
+	}
+	if desiredAgent == "" || desiredAgent == "fixed" {
+		desiredAgent = ResolveWithControlPlane(settings.AgentImage.Get(), cp)
+	}
+	return desiredAgent
+}
+
+func GetDesiredAuthImage(cp *rkev1.RKEControlPlane, mgmtCluster *v3.Cluster) string {
+	var desiredAuth string
+	if mgmtCluster.Spec.LocalClusterAuthEndpoint.Enabled {
+		desiredAuth = mgmtCluster.Spec.DesiredAuthImage
+		if desiredAuth == "" || desiredAuth == "fixed" {
+			desiredAuth = ResolveWithControlPlane(settings.AuthImage.Get(), cp)
+		}
+	}
+	return desiredAuth
+}

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -22,6 +22,7 @@ import (
 	mgmtcontrollers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	ranchercontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	rkecontrollers "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/provisioningv2/image"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/pkg/condition"
@@ -895,9 +896,9 @@ func (p *Planner) desiredPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret 
 
 func getInstallerImage(controlPlane *rkev1.RKEControlPlane) string {
 	runtime := rke2.GetRuntime(controlPlane.Spec.KubernetesVersion)
-	image := settings.SystemAgentInstallerImage.Get()
-	image = image + runtime + ":" + strings.ReplaceAll(controlPlane.Spec.KubernetesVersion, "+", "-")
-	return settings.PrefixPrivateRegistry(image)
+	installerImage := settings.SystemAgentInstallerImage.Get()
+	installerImage = installerImage + runtime + ":" + strings.ReplaceAll(controlPlane.Spec.KubernetesVersion, "+", "-")
+	return image.ResolveWithControlPlane(installerImage, controlPlane)
 }
 
 func isEtcd(entry *planEntry) bool {


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36137

## Problem
There were a few images like rancher-agent, system-agent, and
system-upgrade-controller that were not being pulled from the private registry
setup in an RKE2 cluster.

## Solution
This change adds image resolvers, similar to those for v3 clusters, to ensure
that the images are being pulled from private registries whenever one is defined
for Rancher images.

## Testing
Provisioning RKE2 cluster with private registry and ensure that all images (except for fleet-agent) are pulled from the private registry.