### PR TITLE
bump the image tag of kube-api-auth to v0.1.8

### DIFF
--- a/pkg/apis/management.cattle.io/v3/tools_system_images.go
+++ b/pkg/apis/management.cattle.io/v3/tools_system_images.go
@@ -20,7 +20,7 @@ var (
 			KubeApply:     "rancher/pipeline-tools:v0.1.16",
 		},
 		AuthSystemImages: AuthSystemImages{
-			KubeAPIAuth: "rancher/kube-api-auth:v0.1.7",
+			KubeAPIAuth: "rancher/kube-api-auth:v0.1.8",
 		},
 	}
 )


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36518

Problem:
If we create an RKE/RKE2 downstream cluster with multiple control plane nodes and with ClusterAuthEndpoint enabled, then use the secondary contexts in the kubeconfig file downloaded from Rancher UI to access the cluster, we will hit the following error with one of the secondary contexts:
```
error: You must be logged in to the server (Unauthorized)
```
meanwhile, the logs of the `kube-api-auth` pod on this control plane show the following kind of error:
```
time="2022-02-24T21:11:46Z" level=info msg="  ...looking up token for kubeconfig-user-qmk2kdmjlt"
time="2022-02-24T21:11:46Z" level=error msg="clusteruserattributes.cluster.cattle.io \"cattle-system/user-qmk2k\" not found"
```

Solution:
It turns out to be a bug in `rancher/kube-api-auth`, and it is fixed by [this PR]( https://github.com/rancher/kube-api-auth/pull/11), please check the PR's description for more details. 

Here we bump the image tag of `kube-api-auth` to v0.1.8 which contains the fix. 

Tests:
Both RKE and RKE2 clusters are tested on a Rancher setup using the new image. 

