### PR TITLE
Terraform rke2 standard user token fix

### DIFF
--- a/pkg/apis/provisioning.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/provisioning.cattle.io/v1/zz_generated_deepcopy.go
@@ -234,6 +234,11 @@ func (in *RKEConfig) DeepCopy() *RKEConfig {
 func (in *RKEMachinePool) DeepCopyInto(out *RKEMachinePool) {
 	*out = *in
 	in.RKECommonNodeConfig.DeepCopyInto(&out.RKECommonNodeConfig)
+	if in.DrainBeforeDeleteTimeout != nil {
+		in, out := &in.DrainBeforeDeleteTimeout, &out.DrainBeforeDeleteTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	if in.NodeConfig != nil {
 		in, out := &in.NodeConfig, &out.NodeConfig
 		*out = new(corev1.ObjectReference)

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -52,7 +52,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("").resources("secrets").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("cisconfigs").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("cisbenchmarkversions").verbs("get", "list", "watch").
-		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create").
+		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create", "get").
 		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch")
 
 	rb.addRole("Manage Node Drivers", "nodedrivers-manage").
@@ -477,7 +477,7 @@ func addUserRules(role *roleBuilder) *roleBuilder {
 		addRule().apiGroups("project.cattle.io").resources("sourcecodecredentials").verbs("*").
 		addRule().apiGroups("project.cattle.io").resources("sourcecoderepositories").verbs("*").
 		addRule().apiGroups("provisioning.cattle.io").resources("clusters").verbs("create").
-		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create")
+		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create", "get")
 
 	return role
 }


### PR DESCRIPTION
Issue: https://github.com/rancher/terraform-provider-rancher2/issues/824 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> 
 
## Problem
 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable.  If this is a new feature describe why we need this feature and how it will be used. -->

The problem was that Terraform would throw an error for RKE2 clusters provisioned with a standard user token. The cluster was being prevented from becoming active on refresh if the terraform provider couldn't look up the machine config by ID. The root cause was that RBAC was not configured to allow standard users access to the amazon EC2 machine config in `rke-machine-config.cattle.io.`
 
## Solution
 
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Fixed RBAC configuration to allow standard users access to machine config V2

* Here https://github.com/annablender/rancher/blob/17b8d9af09aeea7575618f37e8fc3d8f07a87077/pkg/data/management/role_data.go#L55
* And here https://github.com/annablender/rancher/blob/17b8d9af09aeea7575618f37e8fc3d8f07a87077/pkg/data/management/role_data.go#L480
 
## Testing
 
<!-- Describe what, if any, testing you did.  If you added tests describe what cases they cover and do not cover. -->

Verify these scenarios work _the first time_ without error
* Provision an RKE2 EC2 cluster via terraform using an admin token
* Provision an RKE2 EC2 cluster via terraform using a standard user token (click the `Create Clusters` box when creating the user. It is not added by default)