### PR TITLE
Adding rancher/mirrored-pause to expected image list for win/linux

### DIFF
--- a/pkg/image/resolve_test.go
+++ b/pkg/image/resolve_test.go
@@ -263,6 +263,7 @@ func TestGetImages(t *testing.T) {
 	bothImages := []string{
 		selectFirstEntry(linuxInfo.RKESystemImages).NginxProxy, // from system
 		"rancher/fluentd:v0.1.16",                              // from chart
+		"rancher/mirrored-pause:3.6",
 	}
 	bothSources := []string{
 		"rancher/fluentd:v0.1.16 rancher-logging:0.1.2",


### PR DESCRIPTION
Fixes a test that would occasionally fail - windows and linux now use the same mirrored-pause image, so this needs to be added to the `bothImages` slice.