### PR TITLE
Update ui-dashboard-index setting

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -89,7 +89,7 @@ var (
 	UIFeedBackForm                      = NewSetting("ui-feedback-form", "")
 	UIIndex                             = NewSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
 	UIPath                              = NewSetting("ui-path", "/usr/share/rancher/ui")
-	UIDashboardIndex                    = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/release-2.6.4/index.html")
+	UIDashboardIndex                    = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/latest/index.html")
 	UIDashboardPath                     = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
 	UIPreferred                         = NewSetting("ui-preferred", "vue")
 	UIOfflinePreferred                  = NewSetting("ui-offline-preferred", "dynamic")


### PR DESCRIPTION
- As per description in #37011, this PR reverts those changes
- `rancher/rancher` `release/v2.6` tracks 2.6.5 (and later), so it should track `rancher/dashboard` `master` (2.6.5 and later)

