### PR TITLE
Add better condition syncing for v2 provisioning objects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ replace (
 
 	github.com/rancher/rancher/pkg/apis => ./pkg/apis
 	github.com/rancher/rancher/pkg/client => ./pkg/client
-	github.com/rancher/wrangler => /Users/donnieadams/code/wrangler
 	helm.sh/helm/v3 => github.com/rancher/helm/v3 v3.8.0-rancher1
 	k8s.io/api => k8s.io/api v0.23.3
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.23.3
@@ -110,7 +109,7 @@ require (
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20220218171307-a91d90251ffa
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
-	github.com/rancher/wrangler v0.8.11-0.20220217210408-3ecd23dfea3b
+	github.com/rancher/wrangler v0.8.11-0.20220411195911-c2b951ab3480
 	github.com/robfig/cron v1.1.0
 	github.com/satori/go.uuid v1.2.1-0.20181016170032-d91630c85102
 	github.com/segmentio/kafka-go v0.0.0-20190411192201-218fd49cff39

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ replace (
 
 	github.com/rancher/rancher/pkg/apis => ./pkg/apis
 	github.com/rancher/rancher/pkg/client => ./pkg/client
+	github.com/rancher/wrangler => /Users/donnieadams/code/wrangler
 	helm.sh/helm/v3 => github.com/rancher/helm/v3 v3.8.0-rancher1
 	k8s.io/api => k8s.io/api v0.23.3
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.23.3

--- a/go.sum
+++ b/go.sum
@@ -507,7 +507,6 @@ github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
-github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -1296,19 +1295,6 @@ github.com/rancher/steve v0.0.0-20220218171307-a91d90251ffa h1:i5Ngo1K9sv0MACsy9
 github.com/rancher/steve v0.0.0-20220218171307-a91d90251ffa/go.mod h1:nsU/hcUN/SiRNWAe5cAGU2ug+mAft7wZfYFNcogF9vA=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
-github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=
-github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
-github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
-github.com/rancher/wrangler v0.6.2-0.20200714200521-c61fae623942/go.mod h1:8LdIqAQPHysxNlHqmKbUiDIx9ULt9IHUauh9aOnr67k=
-github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
-github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224/go.mod h1:I7qe4DZNMOLKVa9ax7DJdBZ0XtKOppLF/dalhPX3vaE=
-github.com/rancher/wrangler v0.8.0/go.mod h1:zSV5oh3+YZboilwcJmFHO3J6FZba82BTQft1b6ijx2I=
-github.com/rancher/wrangler v0.8.1-0.20210506052526-673b7f8692d9/go.mod h1:aj/stIidTzU6UEKKRB8JyrrqNMJAfDMziL1+zhG8lc0=
-github.com/rancher/wrangler v0.8.10/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
-github.com/rancher/wrangler v0.8.11-0.20211214201934-f5aa5d9f2e81/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
-github.com/rancher/wrangler v0.8.11-0.20220120160420-18c996a8e956/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
-github.com/rancher/wrangler v0.8.11-0.20220217210408-3ecd23dfea3b h1:nFwp2dz+JHH96joqSVRYelOgmTQS9K8DSC3A/d1Gc9I=
-github.com/rancher/wrangler v0.8.11-0.20220217210408-3ecd23dfea3b/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
 github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e/go.mod h1:2lcWR98q8HU3U4mVETnXc8quNG0uXxrt8vKd6cAa/30=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/go.sum
+++ b/go.sum
@@ -507,6 +507,7 @@ github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
+github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -1295,6 +1296,19 @@ github.com/rancher/steve v0.0.0-20220218171307-a91d90251ffa h1:i5Ngo1K9sv0MACsy9
 github.com/rancher/steve v0.0.0-20220218171307-a91d90251ffa/go.mod h1:nsU/hcUN/SiRNWAe5cAGU2ug+mAft7wZfYFNcogF9vA=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
+github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=
+github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
+github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
+github.com/rancher/wrangler v0.6.2-0.20200714200521-c61fae623942/go.mod h1:8LdIqAQPHysxNlHqmKbUiDIx9ULt9IHUauh9aOnr67k=
+github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
+github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224/go.mod h1:I7qe4DZNMOLKVa9ax7DJdBZ0XtKOppLF/dalhPX3vaE=
+github.com/rancher/wrangler v0.8.0/go.mod h1:zSV5oh3+YZboilwcJmFHO3J6FZba82BTQft1b6ijx2I=
+github.com/rancher/wrangler v0.8.1-0.20210506052526-673b7f8692d9/go.mod h1:aj/stIidTzU6UEKKRB8JyrrqNMJAfDMziL1+zhG8lc0=
+github.com/rancher/wrangler v0.8.10/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
+github.com/rancher/wrangler v0.8.11-0.20211214201934-f5aa5d9f2e81/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
+github.com/rancher/wrangler v0.8.11-0.20220120160420-18c996a8e956/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
+github.com/rancher/wrangler v0.8.11-0.20220411195911-c2b951ab3480 h1:DIdOsJS/aLAsyDb2BbxsGKb3+EWvXDWvEJL0EyGTPoM=
+github.com/rancher/wrangler v0.8.11-0.20220411195911-c2b951ab3480/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
 github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e/go.mod h1:2lcWR98q8HU3U4mVETnXc8quNG0uXxrt8vKd6cAa/30=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -2,10 +2,7 @@ module github.com/rancher/rancher/pkg/apis
 
 go 1.17
 
-replace (
-	github.com/rancher/wrangler => /Users/donnieadams/code/wrangler
-	k8s.io/client-go => k8s.io/client-go v0.23.3
-)
+replace k8s.io/client-go => k8s.io/client-go v0.23.3
 
 require (
 	github.com/pkg/errors v0.9.1
@@ -15,7 +12,7 @@ require (
 	github.com/rancher/gke-operator v1.1.3
 	github.com/rancher/norman v0.0.0-20220107203912-4feb41eafabd
 	github.com/rancher/rke v1.3.9
-	github.com/rancher/wrangler v0.8.11-0.20220217210408-3ecd23dfea3b
+	github.com/rancher/wrangler v0.8.11-0.20220411195911-c2b951ab3480
 	github.com/sirupsen/logrus v1.8.1
 	k8s.io/api v0.23.3
 	k8s.io/apimachinery v0.23.3

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -2,7 +2,10 @@ module github.com/rancher/rancher/pkg/apis
 
 go 1.17
 
-replace k8s.io/client-go => k8s.io/client-go v0.23.3
+replace (
+	github.com/rancher/wrangler => /Users/donnieadams/code/wrangler
+	k8s.io/client-go => k8s.io/client-go v0.23.3
+)
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -730,7 +730,6 @@ github.com/rancher/gke-operator v1.1.3/go.mod h1:7lDe4okbyZeYZppEz1i60eowLN8iiT4
 github.com/rancher/lasso v0.0.0-20200427171700-e0509f89f319/go.mod h1:6Dw19z1lDIpL887eelVjyqH/mna1hfR61ddCFOG78lw=
 github.com/rancher/lasso v0.0.0-20200515155337-a34e1e26ad91/go.mod h1:G6Vv2aj6xB2YjTVagmu4NkhBvbE8nBcGykHRENH6arI=
 github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
-github.com/rancher/lasso v0.0.0-20210408231703-9ddd9378d08d/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
 github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08 h1:NxR8Fh0eE7/5/5Zvlog9B5NVjWKqBSb1WYMUF7/IE5c=
 github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08/go.mod h1:9qZd/S8DqWzfKtjKGgSoHqGEByYmUE3qRaBaaAHwfEM=
 github.com/rancher/machine v0.15.0-rancher63/go.mod h1:qXYNumxy0J08MO/mh/jNjyRuEc2QKDLUOZIBE5vxaZE=
@@ -739,14 +738,6 @@ github.com/rancher/norman v0.0.0-20220107203912-4feb41eafabd h1:N04tea76urCHN5z5
 github.com/rancher/norman v0.0.0-20220107203912-4feb41eafabd/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
 github.com/rancher/rke v1.3.9 h1:vqXyB+hVAYO1Hz17DU5dsvB4zlrDIRfCFmRHLb2ZHzY=
 github.com/rancher/rke v1.3.9/go.mod h1:sa0/F2J4xh9XxTDNJdvBWTQ7U9XyXIE8pt3rSbvMfpI=
-github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
-github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
-github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
-github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224/go.mod h1:I7qe4DZNMOLKVa9ax7DJdBZ0XtKOppLF/dalhPX3vaE=
-github.com/rancher/wrangler v0.8.1-0.20210506052526-673b7f8692d9/go.mod h1:aj/stIidTzU6UEKKRB8JyrrqNMJAfDMziL1+zhG8lc0=
-github.com/rancher/wrangler v0.8.10/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
-github.com/rancher/wrangler v0.8.11-0.20220217210408-3ecd23dfea3b h1:nFwp2dz+JHH96joqSVRYelOgmTQS9K8DSC3A/d1Gc9I=
-github.com/rancher/wrangler v0.8.11-0.20220217210408-3ecd23dfea3b/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
 github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e/go.mod h1:2lcWR98q8HU3U4mVETnXc8quNG0uXxrt8vKd6cAa/30=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -730,6 +730,7 @@ github.com/rancher/gke-operator v1.1.3/go.mod h1:7lDe4okbyZeYZppEz1i60eowLN8iiT4
 github.com/rancher/lasso v0.0.0-20200427171700-e0509f89f319/go.mod h1:6Dw19z1lDIpL887eelVjyqH/mna1hfR61ddCFOG78lw=
 github.com/rancher/lasso v0.0.0-20200515155337-a34e1e26ad91/go.mod h1:G6Vv2aj6xB2YjTVagmu4NkhBvbE8nBcGykHRENH6arI=
 github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
+github.com/rancher/lasso v0.0.0-20210408231703-9ddd9378d08d/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
 github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08 h1:NxR8Fh0eE7/5/5Zvlog9B5NVjWKqBSb1WYMUF7/IE5c=
 github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08/go.mod h1:9qZd/S8DqWzfKtjKGgSoHqGEByYmUE3qRaBaaAHwfEM=
 github.com/rancher/machine v0.15.0-rancher63/go.mod h1:qXYNumxy0J08MO/mh/jNjyRuEc2QKDLUOZIBE5vxaZE=
@@ -738,6 +739,14 @@ github.com/rancher/norman v0.0.0-20220107203912-4feb41eafabd h1:N04tea76urCHN5z5
 github.com/rancher/norman v0.0.0-20220107203912-4feb41eafabd/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
 github.com/rancher/rke v1.3.9 h1:vqXyB+hVAYO1Hz17DU5dsvB4zlrDIRfCFmRHLb2ZHzY=
 github.com/rancher/rke v1.3.9/go.mod h1:sa0/F2J4xh9XxTDNJdvBWTQ7U9XyXIE8pt3rSbvMfpI=
+github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
+github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
+github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
+github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224/go.mod h1:I7qe4DZNMOLKVa9ax7DJdBZ0XtKOppLF/dalhPX3vaE=
+github.com/rancher/wrangler v0.8.1-0.20210506052526-673b7f8692d9/go.mod h1:aj/stIidTzU6UEKKRB8JyrrqNMJAfDMziL1+zhG8lc0=
+github.com/rancher/wrangler v0.8.10/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
+github.com/rancher/wrangler v0.8.11-0.20220411195911-c2b951ab3480 h1:DIdOsJS/aLAsyDb2BbxsGKb3+EWvXDWvEJL0EyGTPoM=
+github.com/rancher/wrangler v0.8.11-0.20220411195911-c2b951ab3480/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
 github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e/go.mod h1:2lcWR98q8HU3U4mVETnXc8quNG0uXxrt8vKd6cAa/30=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -176,7 +176,7 @@ func (p *Provisioner) Remove(cluster *v3.Cluster) (runtime.Object, error) {
 }
 
 func (p *Provisioner) Updated(cluster *v3.Cluster) (runtime.Object, error) {
-	if skipOperatorCluster("update", cluster) {
+	if skipOperatorCluster("update", cluster) || imported.IsAdministratedByProvisioningCluster(cluster) {
 		return cluster, nil
 	}
 
@@ -352,7 +352,7 @@ func setVersion(cluster *v3.Cluster) {
 
 func (p *Provisioner) update(cluster *v3.Cluster, create bool) (*v3.Cluster, error) {
 	cluster, err := p.reconcileCluster(cluster, create)
-	if err != nil {
+	if err != nil || imported.IsAdministratedByProvisioningCluster(cluster) {
 		return cluster, err
 	}
 
@@ -385,7 +385,7 @@ func (p *Provisioner) machineChanged(key string, machine *v3.Node) (runtime.Obje
 }
 
 func (p *Provisioner) Create(cluster *v3.Cluster) (runtime.Object, error) {
-	if skipOperatorCluster("create", cluster) {
+	if skipOperatorCluster("create", cluster) || imported.IsAdministratedByProvisioningCluster(cluster) {
 		return cluster, nil
 	}
 
@@ -417,7 +417,6 @@ func (p *Provisioner) provision(cluster *v3.Cluster) (*v3.Cluster, error) {
 }
 
 func (p *Provisioner) pending(cluster *v3.Cluster) (*v3.Cluster, error) {
-
 	if skipLocalK3sImported(cluster) {
 		return cluster, nil
 	}

--- a/pkg/controllers/management/imported/imported.go
+++ b/pkg/controllers/management/imported/imported.go
@@ -3,5 +3,5 @@ package imported
 import v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 
 func IsAdministratedByProvisioningCluster(cluster *v3.Cluster) bool {
-	return cluster.Status.Driver == v3.ClusterDriverImported && cluster.Annotations["provisioning.cattle.io/administrated"] == "true"
+	return (cluster.Status.Driver == v3.ClusterDriverImported || cluster.Status.Driver == "") && cluster.Annotations["provisioning.cattle.io/administrated"] == "true"
 }

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -336,9 +336,6 @@ func (h *handler) updateStatus(objs []runtime.Object, cluster *v1.Cluster, statu
 			ready = true
 		}
 		for _, messageCond := range existing.Status.Conditions {
-			if messageCond.Type == "Provisioned" && cluster.Spec.RKEConfig != nil {
-				continue
-			}
 			found := false
 			newCond := genericcondition.GenericCondition{
 				Type:               string(messageCond.Type),

--- a/pkg/controllers/provisioningv2/rke2/common.go
+++ b/pkg/controllers/provisioningv2/rke2/common.go
@@ -71,6 +71,8 @@ const (
 	RKEAPIVersion                  = "rke.cattle.io/v1"
 
 	Provisioned    = condition.Cond("Provisioned")
+	Updated        = condition.Cond("Updated")
+	Reconciled     = condition.Cond("Reconciled")
 	Ready          = condition.Cond("Ready")
 	Waiting        = condition.Cond("Waiting")
 	Pending        = condition.Cond("Pending")

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -16,8 +17,8 @@ import (
 	mgmtcontroller "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	rocontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	rkecontroller "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
-	"github.com/rancher/rancher/pkg/provisioningv2/rke2/planner"
 	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/rancher/wrangler/pkg/condition"
 	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/generic"
 	"github.com/rancher/wrangler/pkg/relatedresource"
@@ -26,8 +27,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const (
@@ -49,6 +52,7 @@ type handler struct {
 	mgmtClusterClient mgmtcontroller.ClusterClient
 	rkeControlPlane   rkecontroller.RKEControlPlaneCache
 	etcdSnapshotCache rkecontroller.ETCDSnapshotCache
+	capiMachineCache  capicontrollers.MachineCache
 }
 
 func Register(ctx context.Context, clients *wrangler.Context) {
@@ -61,6 +65,7 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 		capiClusters:      clients.CAPI.Cluster().Cache(),
 		rkeControlPlane:   clients.RKE.RKEControlPlane().Cache(),
 		etcdSnapshotCache: clients.RKE.ETCDSnapshot().Cache(),
+		capiMachineCache:  clients.CAPI.Machine().Cache(),
 	}
 
 	if features.MCM.Enabled() {
@@ -272,9 +277,12 @@ func (h *handler) OnRancherClusterChange(obj *rancherv1.Cluster, status rancherv
 			}
 		}
 		logrus.Debugf("rkecluster %s/%s: updating cluster provisioning status", obj.Namespace, obj.Name)
-		status, err = h.updateClusterProvisioningStatus(obj, status, rkeCP)
-		if err != nil && !apierror.IsNotFound(err) {
+		if status, err = h.setProvisionedStatusFromMachineInfra(obj, status, rkeCP); err != nil && !apierror.IsNotFound(err) && !errors.Is(err, generic.ErrSkip) {
 			return nil, status, err
+		} else if err == nil {
+			if status, err = h.updateClusterProvisioningStatus(obj, status, rkeCP, rke2.Updated, rke2.Ready); err != nil && !apierror.IsNotFound(err) {
+				return nil, status, err
+			}
 		}
 	}
 
@@ -304,7 +312,7 @@ func (h *handler) getRKEControlPlaneForCluster(cluster *rancherv1.Cluster) (*rke
 	return cp, nil
 }
 
-func (h *handler) updateClusterProvisioningStatus(cluster *rancherv1.Cluster, status rancherv1.ClusterStatus, cp *rkev1.RKEControlPlane) (rancherv1.ClusterStatus, error) {
+func (h *handler) updateClusterProvisioningStatus(cluster *rancherv1.Cluster, status rancherv1.ClusterStatus, cp *rkev1.RKEControlPlane, clusterCondition, cpCondition condition.Cond) (rancherv1.ClusterStatus, error) {
 	if cp == nil {
 		return status, fmt.Errorf("error while updating cluster provisioning status - rkecontrolplane was nil")
 	}
@@ -314,32 +322,63 @@ func (h *handler) updateClusterProvisioningStatus(cluster *rancherv1.Cluster, st
 			return status, err
 		}
 
-		message := rke2.Ready.GetMessage(cp)
-		if (message == "" && rke2.Ready.GetMessage(mgmtCluster) != "") || strings.Contains(message, planner.ETCDRestoreMessage) {
+		if cpCondition.GetStatus(cp) != clusterCondition.GetStatus(mgmtCluster) || cpCondition.GetMessage(cp) != clusterCondition.GetMessage(mgmtCluster) {
 			mgmtCluster = mgmtCluster.DeepCopy()
 
-			rke2.Provisioned.SetStatus(mgmtCluster, rke2.Ready.GetStatus(cp))
-			rke2.Provisioned.Reason(mgmtCluster, rke2.Ready.GetReason(cp))
-			rke2.Provisioned.Message(mgmtCluster, message)
+			clusterCondition.SetStatus(mgmtCluster, cpCondition.GetStatus(cp))
+			clusterCondition.Reason(mgmtCluster, cpCondition.GetReason(cp))
+			clusterCondition.Message(mgmtCluster, cpCondition.GetMessage(cp))
 
 			_, err = h.mgmtClusterClient.Update(mgmtCluster)
-			if err != nil {
-				return status, err
-			}
+			// Conditions will be copied from the management cluster to the provisioning cluster in another controller,
+			// so it is safe to return here.
+			return status, err
 		}
+	} else {
+		clusterCondition.SetStatus(&status, cpCondition.GetStatus(cp))
+		clusterCondition.Reason(&status, cpCondition.GetReason(cp))
+		clusterCondition.Message(&status, cpCondition.GetMessage(cp))
 	}
-
-	clusterCondition := rke2.Provisioned
-	cpCondition := rke2.Ready
-	if !cluster.DeletionTimestamp.IsZero() {
-		clusterCondition = rke2.Removed
-		cpCondition = rke2.Removed
-	}
-	clusterCondition.SetStatus(&status, cpCondition.GetStatus(cp))
-	clusterCondition.Reason(&status, cpCondition.GetReason(cp))
-	clusterCondition.Message(&status, cpCondition.GetMessage(cp))
 
 	return status, nil
+}
+
+// setProvisionedStatusFromMachineInfra sets the cluster provisioning status based on the machine infrastructure provisioning status.
+// The cluster is considered provisioned if all the machine infrastructure is provisioned.
+// This is required because the CAPI controllers used the proxied kubeconfig to communicate with the downstream cluster,
+// and this proxy is not available until the cluster's Provisioned condition is set to true.
+func (h *handler) setProvisionedStatusFromMachineInfra(cluster *rancherv1.Cluster, clusterStatus rancherv1.ClusterStatus, cp *rkev1.RKEControlPlane) (rancherv1.ClusterStatus, error) {
+	if cluster == nil || cp == nil || rke2.Provisioned.IsTrue(cluster) {
+		return clusterStatus, nil
+	}
+
+	machines, err := h.capiMachineCache.List(cluster.Namespace, labels.SelectorFromSet(labels.Set{capi.ClusterLabelName: cluster.Name}))
+	if err != nil {
+		return clusterStatus, err
+	} else if len(machines) == 0 {
+		return clusterStatus, generic.ErrSkip
+	}
+
+	for _, machine := range machines {
+		if !machine.DeletionTimestamp.IsZero() || condition.Cond(capi.InfrastructureReadyCondition).IsTrue(machine) {
+			continue
+		}
+
+		clusterStatus, err = h.updateClusterProvisioningStatus(cluster, clusterStatus, cp, rke2.Provisioned, rke2.Ready)
+		if err != nil {
+			return clusterStatus, err
+		}
+
+		return clusterStatus, generic.ErrSkip
+	}
+
+	// Set the Provisioned condition to true on the control plane and use this to set the Provisioned condition to true on the cluster objects.
+	cp = cp.DeepCopy()
+	rke2.Provisioned.SetStatus(cp, "True")
+	rke2.Provisioned.Message(cp, "")
+	rke2.Provisioned.Reason(cp, "")
+
+	return h.updateClusterProvisioningStatus(cluster, clusterStatus, cp, rke2.Provisioned, rke2.Provisioned)
 }
 
 func (h *handler) OnRemove(_ string, cluster *rancherv1.Cluster) (*rancherv1.Cluster, error) {
@@ -358,7 +397,7 @@ func (h *handler) OnRemove(_ string, cluster *rancherv1.Cluster) (*rancherv1.Clu
 
 	status := *cluster.Status.DeepCopy()
 	if rkeCP != nil {
-		status, err = h.updateClusterProvisioningStatus(cluster, status, rkeCP)
+		status, err = h.updateClusterProvisioningStatus(cluster, status, rkeCP, rke2.Removed, rke2.Removed)
 		if apierror.IsNotFound(err) {
 			return cluster, nil
 		} else if err != nil {

--- a/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
@@ -369,16 +369,16 @@ func (h *handler) onUnmanagedMachineOnRemove(key string, customMachine *rkev1.Cu
 
 func (h *handler) onUnmanagedMachineChange(_ string, machine *rkev1.CustomMachine) (*rkev1.CustomMachine, error) {
 	if machine != nil {
-		if !machine.Status.Ready && machine.Spec.ProviderID != "" {
+		if !rke2.Ready.IsTrue(machine) {
+			// CustomMachines are provisioned already, so their Ready condition should be true.
 			machine = machine.DeepCopy()
-			machine.Status.Ready = true
 			rke2.Ready.SetStatus(machine, "True")
 			rke2.Ready.Message(machine, "")
 			return h.unmanagedMachine.UpdateStatus(machine)
-		} else if machine.Spec.ProviderID == "" && !rke2.Ready.IsFalse(machine) {
+		}
+		if !machine.Status.Ready && machine.Spec.ProviderID != "" {
 			machine = machine.DeepCopy()
-			rke2.Ready.SetStatus(machine, "False")
-			rke2.Ready.Message(machine, "waiting for providerID to be set")
+			machine.Status.Ready = true
 			return h.unmanagedMachine.UpdateStatus(machine)
 		}
 	}

--- a/pkg/provisioningv2/rke2/planner/etcdcreate.go
+++ b/pkg/provisioningv2/rke2/planner/etcdcreate.go
@@ -35,7 +35,7 @@ func (p *Planner) startOrRestartEtcdSnapshotCreate(controlPlane *rkev1.RKEContro
 	return nil
 }
 
-func (p *Planner) runEtcdSnapshotCreate(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan, snapshot *rkev1.ETCDSnapshotCreate) []error {
+func (p *Planner) runEtcdSnapshotCreate(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan) []error {
 	servers := collect(clusterPlan, isEtcd)
 	if len(servers) == 0 {
 		return []error{errors.New("failed to find node to perform etcd snapshot")}
@@ -93,7 +93,7 @@ func (p *Planner) createEtcdSnapshot(controlPlane *rkev1.RKEControlPlane, cluste
 	case rkev1.ETCDSnapshotPhaseStarted:
 		var stateSet bool
 		var finErrs []error
-		if errs := p.runEtcdSnapshotCreate(controlPlane, clusterPlan, snapshot); len(errs) > 0 {
+		if errs := p.runEtcdSnapshotCreate(controlPlane, clusterPlan); len(errs) > 0 {
 			for _, err := range errs {
 				if err == nil {
 					continue


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36993

## Problem
There were issues with different pages of the UI showing different status for
the cluster based on which object it was showing (management vs. provisioning).
This change adds better syncing between the cluster objects so they have the
same conditions and statuses.

## Solution
In addition, the planner always used the Provisioned condition when
changing/applying the node plans. This was confusing, especially when a machine
was being updated. This change will use the Reconciled condition instead.

## Testing
Provisioning and upgrading clusters of all types. Making sure that the Home page and Cluster Management page.