### PR TITLE
Improve machine provisioning messages

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/machineprovision/args.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/args.go
@@ -49,6 +49,7 @@ type driverArgs struct {
 
 	DriverName          string
 	ImageName           string
+	CapiMachineName     string
 	MachineName         string
 	MachineNamespace    string
 	MachineGVK          schema.GroupVersionKind
@@ -161,6 +162,7 @@ func (h *handler) getArgsEnvAndStatus(infraObj *infraObject, args map[string]int
 
 	return driverArgs{
 		DriverName:          driver,
+		CapiMachineName:     machine.Name,
 		MachineName:         infraObj.meta.GetName(),
 		MachineNamespace:    infraObj.meta.GetNamespace(),
 		MachineGVK:          infraObj.obj.GetObjectKind().GroupVersionKind(),

--- a/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
@@ -170,7 +170,7 @@ func (h *handler) OnJobChange(key string, job *batchv1.Job) (*batchv1.Job, error
 		return job, err
 	}
 
-	newStatus, err := h.getMachineStatus(job, job.Spec.Template.Labels[InfraJobRemove] == "true")
+	newStatus, err := h.getMachineStatus(job)
 	if err != nil {
 		return job, err
 	}
@@ -189,9 +189,9 @@ func (h *handler) OnJobChange(key string, job *batchv1.Job) (*batchv1.Job, error
 	return job, nil
 }
 
-func (h *handler) getMachineStatus(job *batchv1.Job, remove bool) (rkev1.RKEMachineStatus, error) {
+func (h *handler) getMachineStatus(job *batchv1.Job) (rkev1.RKEMachineStatus, error) {
 	condType := createJobConditionType
-	if remove {
+	if job.Spec.Template.Labels[InfraJobRemove] == "true" {
 		condType = deleteJobConditionType
 	}
 	if !job.Status.CompletionTime.IsZero() {
@@ -232,25 +232,20 @@ func (h *handler) getMachineStatus(job *batchv1.Job, remove bool) (rkev1.RKEMach
 		}
 
 		if lastPod != nil {
-			return getMachineStatusFromPod(lastPod, job.Spec.Template.Labels[InfraMachineKind], condType), nil
+			return getMachineStatusFromPod(lastPod, condType), nil
 		}
-	}
-
-	message := CreatingMachineMessage(job.Spec.Template.Labels[InfraMachineKind])
-	if condType != createJobConditionType {
-		message = DeletingMachineMessage(job.Spec.Template.Labels[InfraMachineKind])
 	}
 
 	return rkev1.RKEMachineStatus{Conditions: []genericcondition.GenericCondition{
 		{
 			Type:    "Ready",
 			Status:  corev1.ConditionFalse,
-			Message: message,
+			Message: ExecutingMachineMessage(job.Spec.Template.Labels, job.Namespace),
 		},
 	}}, nil
 }
 
-func getMachineStatusFromPod(pod *corev1.Pod, kind, condType string) rkev1.RKEMachineStatus {
+func getMachineStatusFromPod(pod *corev1.Pod, condType string) rkev1.RKEMachineStatus {
 	reason := string(capierrors.CreateMachineError)
 	if condType == deleteJobConditionType {
 		reason = string(capierrors.DeleteMachineError)
@@ -275,10 +270,7 @@ func getMachineStatusFromPod(pod *corev1.Pod, kind, condType string) rkev1.RKEMa
 	for _, containerStatus := range pod.Status.ContainerStatuses {
 		if containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode != 0 {
 			failureMessage := strings.TrimSpace(containerStatus.State.Terminated.Message)
-			message := FailedMachineCreateMessage(kind, reason, failureMessage)
-			if condType != createJobConditionType {
-				message = FailedMachineDeleteMessage(kind, reason, failureMessage)
-			}
+			message := FailedMachineMessage(pod.Labels, pod.Namespace, reason, failureMessage)
 			return rkev1.RKEMachineStatus{
 				Conditions: []genericcondition.GenericCondition{
 					{
@@ -714,18 +706,32 @@ func shouldCleanupObjects(job *batchv1.Job, d data.Object) bool {
 	return false
 }
 
-func FailedMachineDeleteMessage(kind, failureReason, failureMessage string) string {
-	return fmt.Sprintf("failed deleting server (%s) in infrastructure provider: %s: %s", kind, failureReason, failureMessage)
+func FailedMachineMessage(podLabels map[string]string, namespace, failureReason, failureMessage string) string {
+	verb := "creating"
+	if podLabels[InfraJobRemove] == "true" {
+		verb = "deleting"
+	}
+	return fmt.Sprintf("failed %s server [%s/%s] of kind (%s) for machine %s in infrastructure provider: %s: %s",
+		verb,
+		namespace,
+		podLabels[InfraMachineName],
+		podLabels[InfraMachineKind],
+		podLabels[CapiMachineName],
+		failureReason,
+		failureMessage,
+	)
 }
 
-func FailedMachineCreateMessage(kind, failureReason, failureMessage string) string {
-	return fmt.Sprintf("failed creating server (%s) in infrastructure provider: %s: %s", kind, failureReason, failureMessage)
-}
-
-func CreatingMachineMessage(kind string) string {
-	return fmt.Sprintf("creating server (%s) in infrastructure provider", kind)
-}
-
-func DeletingMachineMessage(kind string) string {
-	return fmt.Sprintf("deleting server (%s) in infrastructure provider", kind)
+func ExecutingMachineMessage(podLabels map[string]string, namespace string) string {
+	verb := "creating"
+	if podLabels[InfraJobRemove] == "true" {
+		verb = "deleting"
+	}
+	return fmt.Sprintf("%s server [%s/%s] of kind (%s) for machine %s in infrastructure provider",
+		verb,
+		namespace,
+		podLabels[InfraMachineName],
+		podLabels[InfraMachineKind],
+		podLabels[CapiMachineName],
+	)
 }

--- a/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/template.go
@@ -18,6 +18,7 @@ const (
 	InfraMachineKind    = "rke.cattle.io/infra-machine-kind"
 	InfraMachineName    = "rke.cattle.io/infra-machine-name"
 	InfraJobRemove      = "rke.cattle.io/infra-remove"
+	CapiMachineName     = "rke.cattle.io/capi-machine-name"
 
 	pathToMachineFiles = "/path/to/machine/files"
 	sslCertDir         = "/etc/rancher/ssl"
@@ -190,6 +191,7 @@ func objects(ready bool, args driverArgs) []runtime.Object {
 		InfraMachineKind:    args.MachineGVK.Kind,
 		InfraMachineName:    args.MachineName,
 		InfraJobRemove:      strconv.FormatBool(!args.BootstrapRequired),
+		CapiMachineName:     args.CapiMachineName,
 	}
 
 	job := &batchv1.Job{


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36287

## Problem
The infrastructure and CAPI machines have different names. This makes
identifying machine provisioning logs difficult to match with the machines to
which they belong.

## Solution
This change adds more details to the machine provisioning and error messages to
make this easier.

## Testing
Provisioned RKE2 clusters to ensure more detailed messages are logged and appear in the UI.