### PR TITLE
Implement automation for split node roles on rke2

### DIFF
--- a/tests/validation/tests/v3_api/resource/terraform/rke2/master/define_node_role.sh
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/master/define_node_role.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# This script defines which role this node will be and writes that to a file
+# that is readable by rke2
+
+
+if [ $# != 8 ]; then
+  echo "Usage: define_node_roles.sh node_index role_order all_role_nodes etcd_only_nodes etcd_cp_nodes etcd_worker_nodes cp_only_nodes cp_worker_nodes"
+  exit 1
+fi
+
+let node_index=$1+1
+role_order=$2
+all_role_nodes=$3
+etcd_only_nodes=$4
+etcd_cp_nodes=$5
+etcd_worker_nodes=$6
+cp_only_nodes=$7
+cp_worker_nodes=$8
+
+# Set the desired role into an array based on the index
+order_array=($(echo "$role_order" | tr ',' '\n'))
+role_array=()
+for order_num in "${order_array[@]}"
+do
+  if [[ "$order_num" = "1" ]]
+  then
+    until [ $all_role_nodes -le "0" ]
+    do
+       role_array+=("all-roles")
+       let "all_role_nodes-=1"
+    done
+  elif [[ "$order_num" = "2" ]]
+  then
+    until [ $etcd_only_nodes -le "0" ]
+    do
+       role_array+=("etcd-only")
+       let "etcd_only_nodes-=1"
+    done
+  elif [[ "$order_num" = "3" ]]
+  then
+    until [ $etcd_cp_nodes -le "0" ]
+    do
+       role_array+=("etcd-cp")
+       let "etcd_cp_nodes-=1"
+    done
+  elif [[ "$order_num" = "4" ]]
+  then
+    until [ $etcd_worker_nodes -le "0" ]
+    do
+       role_array+=("etcd-worker")
+       let "etcd_worker_nodes-=1"
+    done
+  elif [[ "$order_num" = "5" ]]
+  then
+    until [ $cp_only_nodes -le "0" ]
+    do
+       role_array+=("cp-only")
+       let "cp_only_nodes-=1"
+    done
+  elif [[ "$order_num" = "6" ]]
+  then
+    until [ $cp_worker_nodes -le "0" ]
+    do
+       role_array+=("cp-worker")
+       let "cp_worker_nodes-=1"
+    done
+  fi
+done
+
+# Get role based on which node is being created
+role="${role_array[$node_index]}"
+echo "Writing config for a ${role} node."
+
+# Write config
+mkdir -p /etc/rancher/rke2/config.yaml.d
+if [[ $role == "etcd-only" ]]
+then
+cat << EOF > /etc/rancher/rke2/config.yaml.d/role_config.yaml
+disable-apiserver: true
+disable-controller-manager: true
+disable-scheduler: true
+node-taint:
+  - node-role.kubernetes.io/etcd:NoExecute
+EOF
+
+elif [[ $role == "etcd-cp" ]]
+then
+cat << EOF > /etc/rancher/rke2/config.yaml.d/role_config.yaml
+node-taint:
+  - node-role.kubernetes.io/control-plane:NoSchedule
+  - node-role.kubernetes.io/etcd:NoExecute
+EOF
+
+elif [[ $role == "etcd-worker" ]]
+then
+cat << EOF > /etc/rancher/rke2/config.yaml.d/role_config.yaml
+disable-apiserver: true
+disable-controller-manager: true
+disable-scheduler: true
+EOF
+
+elif [[ $role == "cp-only" ]]
+then
+cat << EOF > /etc/rancher/rke2/config.yaml.d/role_config.yaml
+disable-etcd: true
+node-taint:
+  - node-role.kubernetes.io/control-plane:NoSchedule
+EOF
+
+elif [[ $role == "cp-worker" ]]
+then
+cat << EOF > /etc/rancher/rke2/config.yaml.d/role_config.yaml
+disable-etcd: true
+EOF
+fi

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/master/install_rke2_master.sh
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/master/install_rke2_master.sh
@@ -78,60 +78,20 @@ else
    sudo systemctl start rancherd-server
 fi
 
-export KUBECONFIG=/etc/rancher/rke2/rke2.yaml PATH=$PATH:/var/lib/rancher/rke2/bin
-
 timeElapsed=0
-while ! `kubectl get nodes >/dev/null 2>&1` && [[ $timeElapsed -lt 300 ]]
+while [[ $timeElapsed -lt 600 ]]
 do
-   sleep 5
-   timeElapsed=`expr $timeElapsed + 5`
-done
-
-IFS=$'\n'
-timeElapsed=0
-while [[ $timeElapsed -lt 540 ]]
-do
-   notready=false
-   for rec in `kubectl get nodes`
-   do
-      if [[ "$rec" == *"NotReady"* ]]
-      then
-         notready=true
-      fi
-  done
+  notready=false
+  if [[ ! -f /var/lib/rancher/rke2/server/node-token ]] || [[ ! -f /etc/rancher/rke2/rke2.yaml ]]
+  then
+    notready=true
+  fi
   if [[ $notready == false ]]
   then
-     break
+    break
   fi
-  sleep 20
-  timeElapsed=`expr $timeElapsed + 20`
-done
-
-IFS=$'\n'
-timeElapsed=0
-while [[ $timeElapsed -lt 540 ]]
-do
-   helmPodsNR=false
-   systemPodsNR=false
-   for rec in `kubectl get pods -A --no-headers`
-   do
-      if [[ "$rec" == *"helm-install"* ]] && [[ "$rec" != *"Completed"* ]]
-      then
-         helmPodsNR=true
-      elif [[ "$rec" != *"helm-install"* ]] && [[ "$rec" != *"Running"* ]]
-      then
-         systemPodsNR=true
-      else
-         echo ""
-      fi
-   done
-
-   if [[ $systemPodsNR == false ]] && [[ $helmPodsNR == false ]]
-   then
-      break
-   fi
-   sleep 20
-   timeElapsed=`expr $timeElapsed + 20`
+  sleep 5
+  timeElapsed=`expr $timeElapsed + 5`
 done
 
 cat /etc/rancher/rke2/config.yaml> /tmp/joinflags

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/master/variables.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/master/variables.tf
@@ -29,3 +29,17 @@ variable "create_lb" {
   description = "Create Network Load Balancer if set to true"
   type = bool
 }
+variable "split_roles" {
+  description = "When true, server nodes may be a mix of etcd, cp, and worker"
+  type = bool
+}
+variable "role_order" {
+  description = "Comma separated order of how to bring the nodes up when split roles"
+  type = string
+}
+variable "all_role_nodes" {}
+variable "etcd_only_nodes" {}
+variable "etcd_cp_nodes" {}
+variable "etcd_worker_nodes" {}
+variable "cp_only_nodes" {}
+variable "cp_worker_nodes" {}


### PR DESCRIPTION
This PR allows for our rke2 cluster creation automation to be run using either:
- The default approach (server and agent nodes, where server nodes have ALL roles)
- Split node roles (server and agent nodes, but server nodes can be any of 6 possibilities: all roles, etcd-only, etcd-cp, etcd-worker, cp-only, or cp-worker)

Most of the logic added does just that using `define_node_role.sh` which gets run as part of the terraform script. This file places the configuration for the defined node role in a yaml on the node in `/etc/rancher/rke2/config.yaml.d`, so when using split roles there are actually 2 defined configuration yamls: one for general configuration args (`/etc/rancher/rke2/config.yaml`) and one for the role configuration (`/etc/rancher/rke2/config.yaml.d/role_config.yaml`).

As part of this, it means that the initial server node might never be "ready" before other nodes join since it can be etcd-only, so the apiserver will not be part. Therefore, I changed the logic in the main bash script to, instead of waiting for the node and pods to be ready using kubectl, it now just waits for the relevant files to be created. We still do a check at the very end in python to make sure that **all** nodes and pods are ready, so this actually should speed up our general tests somewhat.

An example set of environment variables to use this new code would be:
```
RKE2_SPLIT_ROLES=True 
RKE2_ETCD_ONLY_NODES=3 
RKE2_ETCD_CP_NODES=1 
RKE2_ETCD_WORKER_NODES=1 
RKE2_CP_ONLY_NODES=2 
RKE2_CP_WORKER_NODES=1 
RANCHER_RKE2_NO_OF_SERVER_NODES=2 
RANCHER_RKE2_NO_OF_WORKER_NODES=1 
RKE2_ROLE_ORDER=2,5,4,6,3,1
```
The parameters should be self explanatory, but the RKE2_ROLE_ORDER parameter above defines the order to bring up the nodes. In this case that means it will bring them up like the following (type of node: count of nodes): 
```
{
  RKE2_ETCD_ONLY_NODES: 3,
  RKE2_CP_ONLY_NODES: 2,
  RKE2_ETCD_WORKER_NODES: 1,
  RKE2_CP_WORKER_NODES: 1,
  RKE2_ETCD_CP_NODES: 1,
  RANCHER_RKE2_NO_OF_SERVER_NODES: 2
}
# Note that RANCHER_RKE2_NO_OF_SERVER_NODES = all roles
```

One error I'd like to explicitly call out here is that I am running into https://github.com/k3s-io/k3s/issues/5348 when using a configuration like above because the IP that the worker node will try to join is that of an ETCD_ONLY node. I am purposely not writing code to explicitly get around that, because having this automation in place in the future would make something like this known.