### PR TITLE
Update ingress-nginx chart version and include necessary values for k3s

### DIFF
--- a/tests/validation/tests/v3_api/resource/terraform/k3s/master/nginx-ingress.yaml
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/master/nginx-ingress.yaml
@@ -12,7 +12,7 @@ spec:
   chart: ingress-nginx
   repo: https://kubernetes.github.io/ingress-nginx
   targetNamespace: ingress-nginx
-  version: v3.15.2
+  version: v4.0.19
   set:
   valuesContent: |-
     fullnameOverride: ingress-nginx
@@ -20,6 +20,9 @@ spec:
       kind: DaemonSet
       admissionWebhooks:
         failurePolicy: Ignore
+      dnsPolicy: ClusterFirstWithHostNet
+      watchIngressWithoutClass: true
+      allowSnippetAnnotations: false
       hostNetwork: true
       hostPort:
         enabled: true
@@ -29,8 +32,6 @@ spec:
         enabled: false
       metrics:
         enabled: true
-        serviceMonitor:
-          enabled: true
       config:
         use-forwarded-headers: "true"
         server-tokens: "false"


### PR DESCRIPTION
Removed the serviceMonitor part because it now requires CRDs to be installed manually, otherwise the helm chart fails to install with the following error: `Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"`. I don't think we need this part so I just removed it.