### PR TITLE
Update Rancher webhook min version in Dockerfile

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -40,7 +40,7 @@ ENV KUSTOMIZE_VERSION v3.5.4
 # System charts minimal version
 ENV CATTLE_FLEET_MIN_VERSION=0.3.900
 ENV CATTLE_RANCHER_OPERATOR_MIN_VERSION=0.1.400
-ENV CATTLE_RANCHER_WEBHOOK_MIN_VERSION=0.1.400-rc1
+ENV CATTLE_RANCHER_WEBHOOK_MIN_VERSION=0.1.400
 
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/library && \


### PR DESCRIPTION
Update Rancher webhook min version in Dockerfile to remove `-rc1`