### PR TITLE
Add istio p0 & upgrade validation test cases including their helpers

### DIFF
--- a/tests/framework/clients/rancher/config.go
+++ b/tests/framework/clients/rancher/config.go
@@ -3,10 +3,11 @@ package rancher
 const ConfigurationFileKey = "rancher"
 
 type Config struct {
-	Host       string `yaml:"host"`
-	AdminToken string `yaml:"adminToken"`
-	Insecure   *bool  `yaml:"insecure" default:"true"`
-	Cleanup    *bool  `yaml:"cleanup" default:"true"`
-	CAFile     string `yaml:"caFile" default:""`
-	CACerts    string `yaml:"caCerts" default:""`
+	Host        string `yaml:"host"`
+	AdminToken  string `yaml:"adminToken"`
+	Insecure    *bool  `yaml:"insecure" default:"true"`
+	Cleanup     *bool  `yaml:"cleanup" default:"true"`
+	CAFile      string `yaml:"caFile" default:""`
+	CACerts     string `yaml:"caCerts" default:""`
+	ClusterName string `yaml:"clusterName" default:""`
 }

--- a/tests/framework/extensions/charts/charts.go
+++ b/tests/framework/extensions/charts/charts.go
@@ -1,0 +1,257 @@
+package charts
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/daemonsets"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/deployments"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	appv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// InstallOptions is a struct of the required options to install a chart.
+type InstallOptions struct {
+	Version     string
+	ClusterID   string
+	ClusterName string
+	ProjectID   string
+}
+
+// payloadOpts is a private struct that contains the options for the chart payloads.
+// It is used to avoid passing the same options to different functions while using the chart helpers.
+type payloadOpts struct {
+	InstallOptions
+	Name      string
+	Host      string
+	Namespace string
+}
+
+// RancherIstioOpts is a struct of the required options to install Rancher Istio with desired chart values.
+type RancherIstioOpts struct {
+	IngressGateways bool
+	EgressGateways  bool
+	Pilot           bool
+	Telemetry       bool
+	Kiali           bool
+	Tracing         bool
+	CNI             bool
+}
+
+// RancherMonitoringOpts is a struct of the required options to install Rancher Monitoring with desired chart values.
+type RancherMonitoringOpts struct {
+	IngressNginx         bool
+	RKEControllerManager bool
+	RKEEtcd              bool
+	RKEProxy             bool
+	RKEScheduler         bool
+}
+
+// GetChartCaseEndpointResult is a struct that GetChartCaseEndpoint helper function returns.
+// It contains the boolean for healthy response and the request body.
+type GetChartCaseEndpointResult struct {
+	Ok   bool
+	Body string
+}
+
+// ChartStatus is a struct that GetChartStatus helper function returns.
+// It contains the boolean for is already installed and the chart information.
+type ChartStatus struct {
+	IsAlreadyInstalled bool
+	ChartDetails       *catalogv1.App
+}
+
+// GetChartStatus is a helper function that takes client, clusterID, chartNamespace and chartName as args,
+// uses admin catalog client to check if chart is already installed, if the chart is already installed returns chart information.
+func GetChartStatus(client *rancher.Client, clusterID, chartNamespace, chartName string) (*ChartStatus, error) {
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	if err != nil {
+		return nil, err
+	}
+	adminCatalogClient, err := adminClient.GetClusterCatalogClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	chartList, err := adminCatalogClient.Apps(chartNamespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, chart := range chartList.Items {
+		if chart.Name == chartName {
+			return &ChartStatus{
+				IsAlreadyInstalled: true,
+				ChartDetails:       &chart,
+			}, nil
+		}
+	}
+
+	return &ChartStatus{
+		IsAlreadyInstalled: false,
+		ChartDetails:       nil,
+	}, nil
+}
+
+// WatchAndWaitDeployments is a helper function that watches the deployments
+// sequentially in a specific namespace and waits until number of expected replicas is equal to number of available replicas.
+func WatchAndWaitDeployments(client *rancher.Client, clusterID, namespace string, listOptions metav1.ListOptions) error {
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	if err != nil {
+		return err
+	}
+	adminDynamicClient, err := adminClient.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return err
+	}
+	adminDeploymentResource := adminDynamicClient.Resource(deployments.DeploymentGroupVersionResource).Namespace(namespace)
+
+	deployments, err := adminDeploymentResource.List(context.TODO(), listOptions)
+	if err != nil {
+		return err
+	}
+
+	var deploymentList []appv1.Deployment
+
+	for _, unstructuredDeployment := range deployments.Items {
+		newDeployment := &appv1.Deployment{}
+		err := scheme.Scheme.Convert(&unstructuredDeployment, newDeployment, unstructuredDeployment.GroupVersionKind())
+		if err != nil {
+			return err
+		}
+
+		deploymentList = append(deploymentList, *newDeployment)
+	}
+
+	for _, deployment := range deploymentList {
+		watchAppInterface, err := adminDeploymentResource.Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + deployment.Name,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+		if err != nil {
+			return err
+		}
+
+		wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+			deploymentsUnstructured := event.Object.(*unstructured.Unstructured)
+			deployment := &appv1.Deployment{}
+
+			err = scheme.Scheme.Convert(deploymentsUnstructured, deployment, deploymentsUnstructured.GroupVersionKind())
+			if err != nil {
+				return false, err
+			}
+
+			if *deployment.Spec.Replicas == deployment.Status.AvailableReplicas {
+				return true, nil
+			}
+			return false, nil
+		})
+	}
+
+	return nil
+}
+
+// WatchAndWaitDaemonSets is a helper function that watches the DaemonSets
+// sequentially in a specific namespace and waits until number of available DeamonSets is equal to number of desired scheduled Daemonsets.
+func WatchAndWaitDaemonSets(client *rancher.Client, clusterID, namespace string, listOptions metav1.ListOptions) error {
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	if err != nil {
+		return err
+	}
+	adminDynamicClient, err := adminClient.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return err
+	}
+	adminDaemonSetResource := adminDynamicClient.Resource(daemonsets.DaemonSetGroupVersionResource).Namespace(namespace)
+
+	daemonSets, err := adminDaemonSetResource.List(context.TODO(), listOptions)
+	if err != nil {
+		return err
+	}
+
+	var daemonSetList []appv1.DaemonSet
+
+	for _, unstructuredDaemonSet := range daemonSets.Items {
+		newDaemonSet := &appv1.DaemonSet{}
+		err := scheme.Scheme.Convert(&unstructuredDaemonSet, newDaemonSet, unstructuredDaemonSet.GroupVersionKind())
+		if err != nil {
+			return err
+		}
+
+		daemonSetList = append(daemonSetList, *newDaemonSet)
+	}
+
+	for _, daemonSet := range daemonSetList {
+		watchAppInterface, err := adminDaemonSetResource.Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + daemonSet.Name,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+		if err != nil {
+			return err
+		}
+
+		wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+			daemonsetsUnstructured := event.Object.(*unstructured.Unstructured)
+			daemonset := &appv1.DaemonSet{}
+
+			err = scheme.Scheme.Convert(daemonsetsUnstructured, daemonset, daemonsetsUnstructured.GroupVersionKind())
+			if err != nil {
+				return false, err
+			}
+
+			if daemonset.Status.DesiredNumberScheduled == daemonset.Status.NumberAvailable {
+				return true, nil
+			}
+			return false, nil
+		})
+	}
+
+	return nil
+}
+
+// GetChartCaseEndpoint is a helper function that takes host path and TLS option as args,
+// applies TLS option and authorization to management client' method that returns a boolean for healthy response and the request body.
+func GetChartCaseEndpoint(client *rancher.Client, host, path string, isWithTLS bool) (*GetChartCaseEndpointResult, error) {
+	protocol := "http"
+
+	if isWithTLS {
+		protocol = "https"
+	}
+
+	url := fmt.Sprintf("%s://%s/%s", protocol, host, path)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Authorization", "Bearer "+client.RancherConfig.AdminToken)
+
+	resp, err := client.Management.APIBaseClient.Ops.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	bodyString := string(bodyBytes)
+
+	isHealthy := resp.StatusCode == http.StatusOK
+
+	return &GetChartCaseEndpointResult{
+		Ok:   isHealthy,
+		Body: bodyString,
+	}, nil
+}

--- a/tests/framework/extensions/charts/payloads.go
+++ b/tests/framework/extensions/charts/payloads.go
@@ -1,0 +1,112 @@
+package charts
+
+import (
+	"time"
+
+	"github.com/rancher/rancher/pkg/api/steve/catalog/types"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// newChartUninstallAction is a private constructor that creates a default payload for chart uninstall action with all disabled options.
+func newChartUninstallAction() *types.ChartUninstallAction {
+	return &types.ChartUninstallAction{
+		DisableHooks: false,
+		DryRun:       false,
+		KeepHistory:  false,
+		Timeout:      nil,
+		Description:  "",
+	}
+}
+
+// newChartInstallAction is a private constructor that creates a payload for chart install action with given namespace, projectId and chartInstalls.
+func newChartInstallAction(namespace, projectId string, chartInstalls []types.ChartInstall) *types.ChartInstallAction {
+	return &types.ChartInstallAction{
+		DisableHooks:             false,
+		Timeout:                  &metav1.Duration{Duration: 600 * time.Second},
+		Wait:                     true,
+		Namespace:                namespace,
+		ProjectID:                projectId,
+		DisableOpenAPIValidation: false,
+		Charts:                   chartInstalls,
+	}
+}
+
+// newChartUpgradeAction is a private constructor that creates a payload for chart upgrade action with given namespace and chartUpgrades.
+func newChartUpgradeAction(namespace string, chartUpgrades []types.ChartUpgrade) *types.ChartUpgradeAction {
+	return &types.ChartUpgradeAction{
+		DisableHooks:             false,
+		Timeout:                  &metav1.Duration{Duration: 600 * time.Second},
+		Wait:                     true,
+		Namespace:                namespace,
+		DisableOpenAPIValidation: false,
+		Force:                    false,
+		CleanupOnFail:            false,
+		Charts:                   chartUpgrades,
+	}
+}
+
+// newChartInstallAction is a private constructor that creates a chart install with given chart values that can be used for chart install action.
+func newChartInstall(name, version, clusterId, clusterName, host string, chartValues map[string]interface{}) *types.ChartInstall {
+	chartInstall := types.ChartInstall{
+		Annotations: map[string]string{
+			"catalog.cattle.io/ui-source-repo":      "rancher-charts",
+			"catalog.cattle.io/ui-source-repo-type": "cluster",
+		},
+		ChartName:   name,
+		ReleaseName: name,
+		Version:     version,
+		Values: v3.MapStringInterface{
+			"global": map[string]interface{}{
+				"cattle": map[string]string{
+					"clusterId":             clusterId,
+					"clusterName":           clusterName,
+					"rkePathPrefix":         "",
+					"rkeWindowsPathPrefix":  "",
+					"systemDefaultRegistry": "",
+					"url":                   host,
+				},
+				"systemDefaultRegistry": "",
+			},
+		},
+	}
+
+	for k, v := range chartValues {
+		chartInstall.Values[k] = v
+	}
+
+	return &chartInstall
+}
+
+// newChartUpgradeAction is a private constructor that creates a chart upgrade with given chart values that can be used for chart upgrade action.
+func newChartUpgrade(name, version, clusterId, clusterName, host string, chartValues map[string]interface{}) *types.ChartUpgrade {
+	chartUpgrade := types.ChartUpgrade{
+		Annotations: map[string]string{
+			"catalog.cattle.io/ui-source-repo":      "rancher-charts",
+			"catalog.cattle.io/ui-source-repo-type": "cluster",
+		},
+		ChartName:   name,
+		ReleaseName: name,
+		Version:     version,
+		Values: v3.MapStringInterface{
+			"global": map[string]interface{}{
+				"cattle": map[string]string{
+					"clusterId":             clusterId,
+					"clusterName":           clusterName,
+					"rkePathPrefix":         "",
+					"rkeWindowsPathPrefix":  "",
+					"systemDefaultRegistry": "",
+					"url":                   host,
+				},
+				"systemDefaultRegistry": "",
+			},
+		},
+		ResetValues: false,
+	}
+
+	for k, v := range chartValues {
+		chartUpgrade.Values[k] = v
+	}
+
+	return &chartUpgrade
+}

--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/api/scheme"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
@@ -15,6 +16,22 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/watch"
 )
+
+// GetClusterIDByName is a helper function that returns the cluster ID by name
+func GetClusterIDByName(client *rancher.Client, clusterName string) (string, error) {
+	clusterList, err := client.Management.Cluster.List(&types.ListOpts{})
+	if err != nil {
+		return "", err
+	}
+
+	for _, cluster := range clusterList.Data {
+		if cluster.Name == clusterName {
+			return cluster.ID, nil
+		}
+	}
+
+	return "", nil
+}
 
 // IsProvisioningClusterReady is basic check function that would be used for the wait.WatchWait func in pkg/wait.
 // This functions just waits until a cluster becomes ready.

--- a/tests/framework/extensions/workloads/deployments/list.go
+++ b/tests/framework/extensions/workloads/deployments/list.go
@@ -1,0 +1,37 @@
+package deployments
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	appv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ListDeployments is a helper function that uses the dynamic client to list deployments on a namespace for a specific cluster with its list options.
+func ListDeployments(client *rancher.Client, clusterID, namespace string, listOpts metav1.ListOptions) ([]appv1.Deployment, error) {
+	var deploymentList []appv1.Deployment
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	deploymentResource := dynamicClient.Resource(DeploymentGroupVersionResource).Namespace(namespace)
+	deployments, err := deploymentResource.List(context.TODO(), listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, unstructuredDeployment := range deployments.Items {
+		newDeployment := &appv1.Deployment{}
+		err := scheme.Scheme.Convert(&unstructuredDeployment, newDeployment, unstructuredDeployment.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		deploymentList = append(deploymentList, *newDeployment)
+	}
+
+	return deploymentList, nil
+}

--- a/tests/v2/validation/charts/demobookapp.yaml
+++ b/tests/v2/validation/charts/demobookapp.yaml
@@ -1,0 +1,270 @@
+# Copyright 2017 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+##################################################################################################
+# Details service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: details
+  labels:
+    app: details
+    service: details
+spec:
+  ports:
+    - port: 9080
+      name: http
+  selector:
+    app: details
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: details-v1
+  labels:
+    app: details
+    version: v1
+spec:
+  selector:
+    matchLabels:
+      app: details
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: details
+        version: v1
+    spec:
+      containers:
+        - name: details
+          image: istio/examples-bookinfo-details-v1:1.13.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9080
+---
+##################################################################################################
+# Ratings service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratings
+  labels:
+    app: ratings
+    service: ratings
+spec:
+  ports:
+    - port: 9080
+      name: http
+  selector:
+    app: ratings
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratings-v1
+  labels:
+    app: ratings
+    version: v1
+spec:
+  selector:
+    matchLabels:
+      app: ratings
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ratings
+        version: v1
+    spec:
+      containers:
+        - name: ratings
+          image: istio/examples-bookinfo-ratings-v1:1.13.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9080
+---
+##################################################################################################
+# Reviews service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews
+  labels:
+    app: reviews
+    service: reviews
+spec:
+  ports:
+    - port: 9080
+      name: http
+  selector:
+    app: reviews
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v1
+  labels:
+    app: reviews
+    version: v1
+spec:
+  selector:
+    matchLabels:
+      app: reviews
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v1
+    spec:
+      containers:
+        - name: reviews
+          image: istio/examples-bookinfo-reviews-v1:1.13.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v2
+  labels:
+    app: reviews
+    version: v2
+spec:
+  selector:
+    matchLabels:
+      app: reviews
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v2
+    spec:
+      containers:
+        - name: reviews
+          image: istio/examples-bookinfo-reviews-v2:1.13.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v3
+  labels:
+    app: reviews
+    version: v3
+spec:
+  selector:
+    matchLabels:
+      app: reviews
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v3
+    spec:
+      containers:
+        - name: reviews
+          image: istio/examples-bookinfo-reviews-v3:1.13.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9080
+---
+##################################################################################################
+# Productpage services
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: productpage
+  labels:
+    app: productpage
+    service: productpage
+spec:
+  ports:
+    - port: 9080
+      name: http
+  selector:
+    app: productpage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: productpage-v1
+  labels:
+    app: productpage
+    version: v1
+spec:
+  selector:
+    matchLabels:
+      app: productpage
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: productpage
+        version: v1
+    spec:
+      containers:
+        - name: productpage
+          image: istio/examples-bookinfo-productpage-v1:1.13.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9080
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: bookinfo-gateway
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: bookinfo
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - bookinfo-gateway
+  http:
+    - match:
+        - uri:
+            exact: /productpage
+        - uri:
+            exact: /login
+        - uri:
+            exact: /logout
+        - uri:
+            prefix: /api/v1/products
+      route:
+        - destination:
+            host: productpage
+            port:
+              number: 9080

--- a/tests/v2/validation/charts/istio.go
+++ b/tests/v2/validation/charts/istio.go
@@ -1,0 +1,73 @@
+package charts
+
+import (
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/charts"
+)
+
+const (
+	// Project that example app and charts are installed in
+	exampleAppProjectName = "demo-project"
+	// Namespace that example app objects are installed in
+	exampleAppNamespaceName = "demo-namespace"
+
+	// Example app port and path to be checked
+	exampleAppPort            = "31380"
+	exampleAppProductPagePath = "productpage"
+
+	// Example app different review bodies to be checked
+	firstReviewBodyPart  = `<small>Reviewer1</small></blockquote>`
+	secondReviewBodyPart = `<fontcolor="black"><!--fullstars:-->`
+	thirdReviewBodyPart  = `<fontcolor="red"><!--fullstars:-->`
+)
+
+var (
+	// Rancher istio chart kiali path
+	kialiPath = "api/v1/namespaces/istio-system/services/http:kiali:20001/proxy/kiali/"
+	// Rancher istio chart tracing path
+	tracingPath = "api/v1/namespaces/istio-system/services/http:tracing:16686/proxy/jaeger/search"
+)
+
+// chartInstallOptions is a private struct that has istio and monitoring charts install options
+type chartInstallOptions struct {
+	monitoring *charts.InstallOptions
+	istio      *charts.InstallOptions
+}
+
+// chartFeatureOptions is a private struct that has istio and monitoring charts feature options
+type chartFeatureOptions struct {
+	monitoring *charts.RancherMonitoringOpts
+	istio      *charts.RancherIstioOpts
+}
+
+// getChartCaseEndpointUntilBodyHas is a private helper function
+// that awaits the body of the response until the desired string is found
+func getChartCaseEndpointUntilBodyHas(client *rancher.Client, host, path, bodyPart string) (bool, error) {
+	trimAllSpaces := func(str string) string {
+		return strings.Map(func(r rune) rune {
+			if unicode.IsSpace(r) {
+				return -1
+			}
+			return r
+		}, str)
+	}
+
+	timeout := 30 * time.Second
+	for start := time.Now(); time.Since(start) < timeout; {
+		result, err := charts.GetChartCaseEndpoint(client, host, path, false)
+		if err != nil {
+			return false, err
+		}
+
+		trimmedBody := trimAllSpaces(result.Body)
+		if strings.Contains(trimmedBody, bodyPart) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/tests/v2/validation/charts/istio_test.go
+++ b/tests/v2/validation/charts/istio_test.go
@@ -1,0 +1,320 @@
+package charts
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/charts"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/deployments"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type IstioTestSuite struct {
+	suite.Suite
+	client              *rancher.Client
+	session             *session.Session
+	project             *management.Project
+	chartInstallOptions *chartInstallOptions
+	chartFeatureOptions *chartFeatureOptions
+}
+
+func (i *IstioTestSuite) TearDownSuite() {
+	i.session.Cleanup()
+}
+
+func (i *IstioTestSuite) SetupSuite() {
+	testSession := session.NewSession(i.T())
+	i.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(i.T(), err)
+
+	i.client = client
+
+	// Get clusterName from config yaml
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(i.T(), clusterName, "Cluster name to install is not set")
+
+	// Get clusterID with clusterName
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(i.T(), err)
+
+	// Change kiali and jaeger paths if it's not local cluster
+	if clusterID != clusterName {
+		kialiPath = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, kialiPath)
+		tracingPath = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, tracingPath)
+	}
+
+	// Get latest versions of monitoring & istio charts
+	latestIstioVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherIstioName)
+	require.NoError(i.T(), err)
+	latestMonitoringVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherMonitoringName)
+	require.NoError(i.T(), err)
+
+	// Create project
+	projectConfig := &management.Project{
+		ClusterID: clusterID,
+		Name:      exampleAppProjectName,
+	}
+	createdProject, err := client.Management.Project.Create(projectConfig)
+	require.NoError(i.T(), err)
+	require.Equal(i.T(), createdProject.Name, exampleAppProjectName)
+	i.project = createdProject
+
+	i.chartInstallOptions = &chartInstallOptions{
+		monitoring: &charts.InstallOptions{
+			ClusterName: clusterName,
+			ClusterID:   clusterID,
+			Version:     latestMonitoringVersion,
+			ProjectID:   createdProject.ID,
+		},
+		istio: &charts.InstallOptions{
+			ClusterName: clusterName,
+			ClusterID:   clusterID,
+			Version:     latestIstioVersion,
+			ProjectID:   createdProject.ID,
+		},
+	}
+
+	i.chartFeatureOptions = &chartFeatureOptions{
+		monitoring: &charts.RancherMonitoringOpts{
+			IngressNginx:         true,
+			RKEControllerManager: true,
+			RKEEtcd:              true,
+			RKEProxy:             true,
+			RKEScheduler:         true,
+		},
+		istio: &charts.RancherIstioOpts{
+			IngressGateways: true,
+			EgressGateways:  false,
+			Pilot:           true,
+			Telemetry:       true,
+			Kiali:           true,
+			Tracing:         true,
+			CNI:             false,
+		},
+	}
+}
+
+func (i *IstioTestSuite) TestIstioChart() {
+	subSession := i.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := i.client.WithSession(subSession)
+	require.NoError(i.T(), err)
+
+	i.T().Log("Installing monitoring chart with the latest version")
+	err = charts.InstallRancherMonitoringChart(client, i.chartInstallOptions.monitoring, i.chartFeatureOptions.monitoring)
+	require.NoError(i.T(), err)
+
+	i.T().Log("Waiting monitoring chart deployments to have expected number of available replicas")
+	err = charts.WatchAndWaitDeployments(client, i.project.ClusterID, charts.RancherMonitoringNamespace, metav1.ListOptions{})
+	require.NoError(i.T(), err)
+
+	i.T().Log("Waiting monitoring chart DaemonSets to have expected number of available nodes")
+	err = charts.WatchAndWaitDaemonSets(client, i.project.ClusterID, charts.RancherMonitoringNamespace, metav1.ListOptions{})
+	require.NoError(i.T(), err)
+
+	i.T().Log("Installing istio chart with the latest version")
+	err = charts.InstallRancherIstioChart(client, i.chartInstallOptions.istio, i.chartFeatureOptions.istio)
+	require.NoError(i.T(), err)
+
+	i.T().Log("Waiting istio chart deployments to have expected number of available replicas")
+	err = charts.WatchAndWaitDeployments(client, i.project.ClusterID, charts.RancherIstioNamespace, metav1.ListOptions{})
+	require.NoError(i.T(), err)
+
+	i.T().Log("Waiting istio chart DaemonSets to have expected number of available nodes")
+	err = charts.WatchAndWaitDaemonSets(client, i.project.ClusterID, charts.RancherIstioNamespace, metav1.ListOptions{})
+	require.NoError(i.T(), err)
+
+	i.T().Log("Creating namespace with istio injection enabled option for the example app")
+	createdNamespace, err := namespaces.CreateNamespace(client, exampleAppNamespaceName, "{}", map[string]string{"istio-injection": "enabled"}, map[string]string{}, i.project)
+	require.NoError(i.T(), err)
+	require.Equal(i.T(), exampleAppNamespaceName, createdNamespace.Name)
+
+	i.T().Log("Importing example app objects to the namespace")
+	readYamlFile, err := os.ReadFile("./demobookapp.yaml")
+	require.NoError(i.T(), err)
+	yamlInput := &management.ImportClusterYamlInput{
+		DefaultNamespace: exampleAppNamespaceName,
+		YAML:             string(readYamlFile),
+	}
+	cluster, err := client.Management.Cluster.ByID(i.project.ClusterID)
+	require.NoError(i.T(), err)
+	_, err = client.Management.Cluster.ActionImportYaml(cluster, yamlInput)
+	require.NoError(i.T(), err)
+
+	i.T().Log("Waiting example app deployments to have expected number of available replicas")
+	err = charts.WatchAndWaitDeployments(client, i.project.ClusterID, exampleAppNamespaceName, metav1.ListOptions{})
+	require.NoError(i.T(), err)
+
+	i.T().Log("Validating kiali and jaeger endpoints are accessible")
+	kialiResult, err := charts.GetChartCaseEndpoint(client, client.RancherConfig.Host, kialiPath, true)
+	require.NoError(i.T(), err)
+	require.True(i.T(), kialiResult.Ok)
+
+	tracingResult, err := charts.GetChartCaseEndpoint(client, client.RancherConfig.Host, tracingPath, true)
+	require.NoError(i.T(), err)
+	require.True(i.T(), tracingResult.Ok)
+
+	// Get a random worker node' public external IP of a specific cluster
+	nodeCollection, err := client.Management.Node.List(&types.ListOpts{Filters: map[string]interface{}{
+		"clusterId": i.project.ClusterID,
+	}})
+	require.NoError(i.T(), err)
+	workerNodePublicIPs := []string{}
+	for _, node := range nodeCollection.Data {
+		workerNodePublicIPs = append(workerNodePublicIPs, node.Annotations["rke.cattle.io/external-ip"])
+	}
+	randWorkerNodePublicIP := workerNodePublicIPs[rand.Intn(len(workerNodePublicIPs))]
+	istioGatewayHost := randWorkerNodePublicIP + ":" + exampleAppPort
+
+	i.T().Log("Validating example app is accessible")
+	exampleAppResult, err := charts.GetChartCaseEndpoint(client, istioGatewayHost, exampleAppProductPagePath, false)
+	require.NoError(i.T(), err)
+	require.True(i.T(), exampleAppResult.Ok)
+
+	i.T().Log("Validating example app has three different reviews bodies")
+	doesContainFirstPart, err := getChartCaseEndpointUntilBodyHas(client, istioGatewayHost, exampleAppProductPagePath, firstReviewBodyPart)
+	require.NoError(i.T(), err)
+	require.True(i.T(), doesContainFirstPart)
+
+	doesContainSecondPart, err := getChartCaseEndpointUntilBodyHas(client, istioGatewayHost, exampleAppProductPagePath, secondReviewBodyPart)
+	require.NoError(i.T(), err)
+	require.True(i.T(), doesContainSecondPart)
+
+	doesContainThirdPart, err := getChartCaseEndpointUntilBodyHas(client, istioGatewayHost, exampleAppProductPagePath, thirdReviewBodyPart)
+	require.NoError(i.T(), err)
+	require.True(i.T(), doesContainThirdPart)
+}
+
+func (i *IstioTestSuite) TestUpgradeIstioChart() {
+	subSession := i.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := i.client.WithSession(subSession)
+	require.NoError(i.T(), err)
+
+	i.T().Log("Checking if the monitoring chart is installed")
+	monitoringChart, err := charts.GetChartStatus(client, i.project.ClusterID, charts.RancherMonitoringNamespace, charts.RancherMonitoringName)
+	require.NoError(i.T(), err)
+
+	if !monitoringChart.IsAlreadyInstalled {
+		i.T().Log("Installing monitoring chart with the latest version")
+		err = charts.InstallRancherMonitoringChart(client, i.chartInstallOptions.monitoring, i.chartFeatureOptions.monitoring)
+		require.NoError(i.T(), err)
+
+		i.T().Log("Waiting monitoring chart deployments to have expected number of available replicas")
+		err = charts.WatchAndWaitDeployments(client, i.project.ClusterID, charts.RancherMonitoringNamespace, metav1.ListOptions{})
+		require.NoError(i.T(), err)
+
+		i.T().Log("Waiting monitoring chart DaemonSets to have expected number of available nodes")
+		err = charts.WatchAndWaitDaemonSets(client, i.project.ClusterID, charts.RancherMonitoringNamespace, metav1.ListOptions{})
+		require.NoError(i.T(), err)
+	}
+
+	// Change istio install option version to previous version of the latest version
+	versionsList, err := client.Catalog.GetListChartVersions(charts.RancherIstioName)
+	require.NoError(i.T(), err)
+	require.Greaterf(i.T(), len(versionsList), 2, "There should be at least 2 versions of the istio chart")
+	versionLatest := versionsList[0]
+	versionBeforeLatest := versionsList[1]
+	i.chartInstallOptions.istio.Version = versionBeforeLatest
+
+	i.T().Log("Checking if the istio chart is installed with one of the previous versions")
+	initialIstioChart, err := charts.GetChartStatus(client, i.project.ClusterID, charts.RancherIstioNamespace, charts.RancherIstioName)
+	require.NoError(i.T(), err)
+
+	if initialIstioChart.IsAlreadyInstalled && initialIstioChart.ChartDetails.Spec.Chart.Metadata.Version == versionLatest {
+		i.T().Skip("Skipping the upgrade case, istio chart is already installed with the latest version")
+	}
+
+	if !initialIstioChart.IsAlreadyInstalled {
+		i.T().Log("Installing istio chart with the last but one version")
+		err = charts.InstallRancherIstioChart(client, i.chartInstallOptions.istio, i.chartFeatureOptions.istio)
+		require.NoError(i.T(), err)
+
+		i.T().Log("Waiting istio chart deployments to have expected number of available replicas")
+		err = charts.WatchAndWaitDeployments(client, i.project.ClusterID, charts.RancherIstioNamespace, metav1.ListOptions{})
+		require.NoError(i.T(), err)
+
+		i.T().Log("Waiting istio chart DaemonSets to have expected number of available nodes")
+		err = charts.WatchAndWaitDaemonSets(client, i.project.ClusterID, charts.RancherIstioNamespace, metav1.ListOptions{})
+		require.NoError(i.T(), err)
+	}
+
+	istioChartPreUpgrade, err := charts.GetChartStatus(client, i.project.ClusterID, charts.RancherIstioNamespace, charts.RancherIstioName)
+	require.NoError(i.T(), err)
+
+	// Validate current version of rancheristio is one of the versions before latest
+	chartVersionPreUpgrade := istioChartPreUpgrade.ChartDetails.Spec.Chart.Metadata.Version
+	require.Contains(i.T(), versionsList[1:], chartVersionPreUpgrade)
+
+	// List deployments that have the istio app version as label
+	istioVersionPreUpgrade := istioChartPreUpgrade.ChartDetails.Spec.Chart.Metadata.AppVersion
+	deploymentListPreUpgrade, err := deployments.ListDeployments(client, i.project.ClusterID, charts.RancherIstioNamespace, metav1.ListOptions{
+		LabelSelector:  "operator.istio.io/version=" + istioVersionPreUpgrade,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	require.NoError(i.T(), err)
+	require.Equalf(i.T(), 2, len(deploymentListPreUpgrade), "Pilot & Ingressgateways deployments don't have the correct istio version labels")
+
+	for _, deployment := range deploymentListPreUpgrade {
+		imageVersion := strings.Split(deployment.Spec.Template.Spec.Containers[0].Image, ":")[1]
+		i.T().Logf("Comparing image and app versions: \n container image version: %v \n istio version: %v and actual: %v\n", deployment.Spec.Template.Spec.Containers[0].Image, istioVersionPreUpgrade, imageVersion)
+		require.Equalf(i.T(), istioVersionPreUpgrade, imageVersion, "Pilot & Ingressgateways images don't use the correct istio image version")
+	}
+
+	i.chartInstallOptions.istio.Version, err = client.Catalog.GetLatestChartVersion(charts.RancherIstioName)
+	require.NoError(i.T(), err)
+
+	i.T().Log("Upgrading istio chart with the latest version")
+	err = charts.UpgradeRancherIstioChart(client, i.chartInstallOptions.istio, i.chartFeatureOptions.istio)
+	require.NoError(i.T(), err)
+
+	i.T().Log("Waiting istio chart deployments to have expected number of available replicas after upgrade")
+	err = charts.WatchAndWaitDeployments(client, i.project.ClusterID, charts.RancherIstioNamespace, metav1.ListOptions{})
+	require.NoError(i.T(), err)
+
+	i.T().Log("Waiting istio chart DaemonSets to have expected number of available nodes after upgrade")
+	err = charts.WatchAndWaitDaemonSets(client, i.project.ClusterID, charts.RancherIstioNamespace, metav1.ListOptions{})
+	require.NoError(i.T(), err)
+
+	istioChartPostUpgrade, err := charts.GetChartStatus(client, i.project.ClusterID, charts.RancherIstioNamespace, charts.RancherIstioName)
+	require.NoError(i.T(), err)
+
+	// Compare rancheristio versions
+	chartVersionPostUpgrade := istioChartPostUpgrade.ChartDetails.Spec.Chart.Metadata.Version
+	require.Equal(i.T(), i.chartInstallOptions.istio.Version, chartVersionPostUpgrade)
+
+	// List deployments that have the istio app version as label
+	istioVersionPostUpgrade := istioChartPostUpgrade.ChartDetails.Spec.Chart.Metadata.AppVersion
+	deploymentListPostUpgrade, err := deployments.ListDeployments(client, i.project.ClusterID, charts.RancherIstioNamespace, metav1.ListOptions{
+		LabelSelector:  "operator.istio.io/version=" + istioVersionPostUpgrade,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	require.NoError(i.T(), err)
+	require.Equalf(i.T(), 2, len(deploymentListPostUpgrade), "Pilot & Ingressgateways deployments don't have the correct istio version labels")
+
+	for _, deployment := range deploymentListPostUpgrade {
+		imageVersion := strings.Split(deployment.Spec.Template.Spec.Containers[0].Image, ":")[1]
+		i.T().Logf("Comparing image and app versions: \n container image: %v \n istio version: %v and actual: %v\n", deployment.Spec.Template.Spec.Containers[0].Image, istioVersionPostUpgrade, imageVersion)
+		require.Equalf(i.T(), istioVersionPostUpgrade, imageVersion, "Pilot & Ingressgateways images don't use the correct istio image version")
+	}
+}
+
+func TestIstioTestSuite(t *testing.T) {
+	suite.Run(t, new(IstioTestSuite))
+}


### PR DESCRIPTION
**Framework Updates**

- Implemented:
  - Payload structs to generate catalog client payloads
  - Install & upgrade rancher Istio chart helpers as well as their specific payload helpers with chart values options
  - Watch and wait helper to wait for deployments in a given namespace
  - A custom request helper built on top of the management client
  - Cluster id getter with the given cluster name
  - List deployments helper with the given namespace and list options
- Refactored:
  - Get the latest chart version method of catalog client, created get list chart versions method from the same logic
  - Rancher config to add the ability to point the desired cluster for chart installations
  - Rancher monitoring chart install helper to remove hardcoded payloads

**Validation Tests**

- Implemented: 
  - Istio p0 & upgrade cases
    - Private wait desired body helper built on top of the custom request helper for Istio cases
    - Example app YAML file for Istio p0 case