### PR TITLE
More elegantly create and manage v2prov snapshots

### DIFF
--- a/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
+++ b/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
@@ -14,6 +14,7 @@ import (
 	rkev1controllers "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/wrangler/pkg/name"
+	"github.com/rancher/wrangler/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -21,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 var (
@@ -31,10 +33,10 @@ var (
 )
 
 const (
-	StorageLabelKey = "etcdsnapshot.rke.io/storage"
-	SnapshotNameKey = "etcdsnapshot.rke.io/snapshot-file-name"
-	StorageS3       = "s3"
-	StorageLocal    = "local"
+	StorageAnnotationKey = "etcdsnapshot.rke.io/storage"
+	SnapshotNameKey      = "etcdsnapshot.rke.io/snapshot-file-name"
+	StorageS3            = "s3"
+	StorageLocal         = "local"
 )
 
 type handler struct {
@@ -45,6 +47,8 @@ type handler struct {
 	etcdSnapshotCache rkev1controllers.ETCDSnapshotCache
 	etcdSnapshots     rkev1controllers.ETCDSnapshotClient
 	machineCache      capicontrollers.MachineCache
+	activeConfigMap   string
+	v1ClusterName     string
 }
 
 // Register sets up the v2provisioning snapshot backpopulate controller. This controller is responsible for monitoring
@@ -60,6 +64,17 @@ func Register(ctx context.Context, userContext *config.UserContext) {
 	}
 
 	userContext.Core.ConfigMaps("kube-system").Controller().AddHandler(ctx, "snapshotbackpopulate", h.OnChange)
+	relatedresource.Watch(ctx, "snapshot-reconcile-trigger", func(namespace, name string, obj runtime.Object) ([]relatedresource.Key, error) {
+		logrus.Tracef("[snapshotbackpopulate] triggering reconcile on object %s/%s - cluster: %s configmap: %s", namespace, name, h.v1ClusterName, h.activeConfigMap)
+		if snapshot, ok := obj.(*rkev1.ETCDSnapshot); ok && snapshot.Spec.ClusterName == h.v1ClusterName && h.activeConfigMap != "" {
+			logrus.Tracef("[snapshotbackpopulate] attempting to set related resource key %s", h.activeConfigMap)
+			return []relatedresource.Key{{
+				Namespace: "kube-system",
+				Name:      h.activeConfigMap,
+			}}, nil
+		}
+		return nil, nil
+	}, userContext.Core.ConfigMaps("kube-system").Controller(), userContext.Management.Wrangler.RKE.ETCDSnapshot())
 }
 
 func (h *handler) OnChange(key string, configMap *corev1.ConfigMap) (runtime.Object, error) {
@@ -71,12 +86,20 @@ func (h *handler) OnChange(key string, configMap *corev1.ConfigMap) (runtime.Obj
 		return configMap, nil
 	}
 
+	if h.activeConfigMap == "" {
+		h.activeConfigMap = configMap.Name
+	}
+
 	clusters, err := h.clusterCache.GetByIndex(cluster2.ByCluster, h.clusterName)
 	if err != nil || len(clusters) != 1 {
 		return configMap, fmt.Errorf("error while retrieving cluster %s from cache via index: %w", h.clusterName, err)
 	}
 
 	cluster := clusters[0]
+
+	if h.v1ClusterName == "" {
+		h.v1ClusterName = cluster.Name
+	}
 
 	logrus.Infof("[snapshotbackpopulate] rkecluster %s/%s: processing configmap %s/%s", cluster.Namespace, cluster.Name, configMap.Namespace, configMap.Name)
 
@@ -95,12 +118,15 @@ func (h *handler) OnChange(key string, configMap *corev1.ConfigMap) (runtime.Obj
 		return configMap, fmt.Errorf("error while listing existing etcd snapshots for cluster %s: %w", cluster.Name, err)
 	}
 
+	// currentEtcdSnapshotsToKeep is a map of etcd snapshots snapshot objects we have retrieved from the management cluster.
 	currentEtcdSnapshotsToKeep := map[string]*rkev1.ETCDSnapshot{}
-	// iterate over the current etcd snapshots
-	// if the current etcd snapshot is NOT found in the actual etcd snapshots list, we delete it
-	// otherwise, we add it to the desired etcd snapshots map
+
+	// iterate over the current etcd snapshots objects retrieved from the management cluster
+	// if snapshot object is not found in the etcd snapshot configmap, mark it missing. if it is a local snapshot
+	// and no machine can be found for it, go ahead and delete it.
+	// if the snapshot object is found in the configmap, add it to the currentEtcdSnapshotsToKeep for reconciliation
 	for _, existingSnapshotCR := range currentEtcdSnapshots {
-		storageLocation, ok := existingSnapshotCR.GetAnnotations()[StorageLabelKey]
+		storageLocation, ok := existingSnapshotCR.GetAnnotations()[StorageAnnotationKey]
 		if !ok {
 			storageLocation = StorageLocal
 			if existingSnapshotCR.SnapshotFile.NodeName == StorageS3 {
@@ -108,13 +134,24 @@ func (h *handler) OnChange(key string, configMap *corev1.ConfigMap) (runtime.Obj
 			}
 		}
 		snapshotKey := existingSnapshotCR.SnapshotFile.Name + storageLocation
+		// check to see if the snapshot CR we have is found in the etcd-snapshots configmap, and if it is not found in the configmap, mark it as missing
 		if _, ok := actualEtcdSnapshots[snapshotKey]; !ok {
+			// the snapshot custom resource we are processing does not exist in the configmap
 			if storageLocation != StorageS3 {
 				// check to make sure the machine actually exists for the snapshot
-				listSuccessful, machine, err := rke2.GetMachineFromNode(h.machineCache, existingSnapshotCR.SnapshotFile.NodeName, cluster)
+				var listSuccessful bool
+				var machine *capi.Machine
+
+				if existingSnapshotCR.Labels[rke2.MachineIDLabel] == "" {
+					logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: snapshot %s/%s was missing machine ID label: %s", cluster.Namespace, cluster.Name, existingSnapshotCR.Namespace, existingSnapshotCR.Name, rke2.MachineIDLabel)
+					// If the machineID label was not set, fall back to looking up the machine by node name, as this may be a snapshot from an earlier version of Rancher that created local snapshots using the snapshotbackpopulate controller, which means the snapshot should not have the machine ID label.
+					listSuccessful, machine, err = rke2.GetMachineFromNode(h.machineCache, existingSnapshotCR.SnapshotFile.NodeName, cluster)
+				} else {
+					listSuccessful, machine, err = rke2.GetMachineByID(h.machineCache, existingSnapshotCR.Labels[rke2.MachineIDLabel], cluster)
+				}
 				if listSuccessful && machine == nil && err != nil {
 					// delete the CR because we don't have a corresponding machine for it
-					logrus.Infof("[snapshotbackpopulate] rkecluster %s/%s: deleting snapshot %s as corresponding machine was not found", cluster.Namespace, cluster.Name, existingSnapshotCR.Name)
+					logrus.Infof("[snapshotbackpopulate] rkecluster %s/%s: deleting snapshot %s as corresponding machine (ID: %s) was not found", cluster.Namespace, cluster.Name, existingSnapshotCR.Name, existingSnapshotCR.Labels[rke2.MachineIDLabel])
 					if err := h.etcdSnapshots.Delete(existingSnapshotCR.Namespace, existingSnapshotCR.Name, &metav1.DeleteOptions{}); err != nil {
 						if !apierrors.IsNotFound(err) {
 							return configMap, err
@@ -123,7 +160,7 @@ func (h *handler) OnChange(key string, configMap *corev1.ConfigMap) (runtime.Obj
 					continue
 				}
 			}
-			// indicate that it should be OK to delete the etcd object
+			// indicate that it should be OK to delete the etcd snapshot object
 			// don't delete the snapshots here because our configmap can be outdated. we will reconcile based on the system-agent output via the periodic output
 			logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: updating status missing=true on etcd snapshot %s/%s as it was not found in the actual snapshot config map", cluster.Namespace, cluster.Name, existingSnapshotCR.Namespace, existingSnapshotCR.Name)
 			logrus.Tracef("[snapshotbackpopulate] rkecluster %s/%s: etcd snapshot was %s/%s: %+v", cluster.Namespace, cluster.Name, existingSnapshotCR.Namespace, existingSnapshotCR.Name, existingSnapshotCR)
@@ -137,60 +174,107 @@ func (h *handler) OnChange(key string, configMap *corev1.ConfigMap) (runtime.Obj
 		currentEtcdSnapshotsToKeep[snapshotKey] = existingSnapshotCR
 	}
 
-	// iterate over the actual etcd snapshots that are in the management cluster
-	// if the snapshot is found in the desired etcd snapshots, check to see if an update needs to be made
-	// otherwise, create the etcd snapshot CR
+	// iterate over the snapshots that are listed in the downstream cluster configmap
+	// if the snapshot is found in the list of snapshots objects that exist in the management cluster, check to see if the etcdsnapshot object needs to be reconciled with more accurate information.
+	// if the snapshot is not found in the list of snapshot objects that exist in the management cluster and the snapshot is an S3 snapshot, create it in the management cluster.
 	for snapshotKey, cmGeneratedSnapshot := range actualEtcdSnapshots {
 		if snapshot, ok := currentEtcdSnapshotsToKeep[snapshotKey]; ok {
-			if !equality.Semantic.DeepEqual(cmGeneratedSnapshot.SnapshotFile, snapshot.SnapshotFile) || !equality.Semantic.DeepEqual(cmGeneratedSnapshot.Status, snapshot.Status) || !equality.Semantic.DeepEqual(cmGeneratedSnapshot.Spec, snapshot.Spec) {
-				logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: updating etcd snapshot %s/%s as it differed from the actual snapshot config map %v vs %v", cluster.Namespace, cluster.Name, snapshot.Namespace, snapshot.Name, cmGeneratedSnapshot.SnapshotFile, snapshot.SnapshotFile)
-				logrus.Tracef("[snapshotbackpopulate] rkecluster %s/%s: updating etcd snapshot %s/%s: %+v", cluster.Namespace, cluster.Name, cmGeneratedSnapshot.Namespace, cmGeneratedSnapshot.Name, cmGeneratedSnapshot)
-				snapshot = snapshot.DeepCopy()
-				// keep a copy of the metadata and message
-				md := snapshot.SnapshotFile.Metadata
-				msg := snapshot.SnapshotFile.Message
+			// the snapshot CR exists in the management cluster. check to see if the configmap data needs to be set on the snapshot.
+			logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: checking to see if etcdsnapshot %s/%s needs to be updated", cluster.Namespace, cluster.Name, snapshot.Namespace, snapshot.Name)
+			logrus.Tracef("[snapshotbackpopulate] rkecluster %s/%s: comparing etcd snapshot %s/%s: %+v : %+v", cluster.Namespace, cluster.Name, snapshot.Namespace, snapshot.Name, cmGeneratedSnapshot, snapshot)
+			snapshot = snapshot.DeepCopy()
+			var updated bool
+			if !equality.Semantic.DeepEqual(snapshot.SnapshotFile, cmGeneratedSnapshot.SnapshotFile) {
+				logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: snapshot %s/%s SnapshotFile contents differed from configmap", cluster.Namespace, cluster.Name, snapshot.Namespace, snapshot.Name)
+				originalSnapshotFile := snapshot.SnapshotFile
 				snapshot.SnapshotFile = cmGeneratedSnapshot.SnapshotFile
-				// restore the metadata and message as those may have been lost
-				snapshot.SnapshotFile.Metadata = md
-				snapshot.SnapshotFile.Message = msg
+				if originalSnapshotFile.Metadata != "" && snapshot.SnapshotFile.Metadata == "" {
+					snapshot.SnapshotFile.Metadata = originalSnapshotFile.Metadata
+				}
+				if originalSnapshotFile.Message != "" && snapshot.SnapshotFile.Message == "" {
+					snapshot.SnapshotFile.Message = originalSnapshotFile.Message
+				}
+				if !equality.Semantic.DeepEqual(snapshot.SnapshotFile, originalSnapshotFile) {
+					updated = true
+					logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: snapshot %s/%s SnapshotFile contents were different, triggering update", cluster.Namespace, cluster.Name, snapshot.Namespace, snapshot.Name)
+					logrus.Tracef("[snapshotbackpopulate] rkecluster %s/%s: snapshot %s/%s SnapshotFile contents %+v vs %+V", cluster.Namespace, cluster.Name, snapshot.Namespace, snapshot.Name, originalSnapshotFile, snapshot.SnapshotFile)
+				}
+			}
+			if snapshot.Spec.ClusterName != cmGeneratedSnapshot.Spec.ClusterName {
+				logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: snapshot %s/%s clusterName did not match %s vs %s", cluster.Namespace, cluster.Name, snapshot.Namespace, snapshot.Name, snapshot.Spec.ClusterName, cmGeneratedSnapshot.Spec.ClusterName)
+				snapshot.Spec.ClusterName = cmGeneratedSnapshot.Spec.ClusterName
+				updated = true
+			}
+			if newLabels, labelsUpdated := reconcileStringMaps(snapshot.Labels, cmGeneratedSnapshot.Labels, []string{rke2.ClusterNameLabel, rke2.NodeNameLabel, rke2.MachineIDLabel}); labelsUpdated {
+				logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: snapshot %s/%s labels did not match", cluster.Namespace, cluster.Name, snapshot.Namespace, snapshot.Name)
+				snapshot.Labels = newLabels
+				updated = true
+			}
+			if newAnnotations, annotationsUpdated := reconcileStringMaps(snapshot.Labels, cmGeneratedSnapshot.Labels, []string{SnapshotNameKey}); annotationsUpdated {
+				logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: snapshot %s/%s annotations did not match", cluster.Namespace, cluster.Name, snapshot.Namespace, snapshot.Name)
+				snapshot.Annotations = newAnnotations
+				updated = true
+			}
+			if updated {
+				logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: updating etcdsnapshot %s/%s", cluster.Namespace, cluster.Name, snapshot.Namespace, snapshot.Name)
 				snapshot, err = h.etcdSnapshots.Update(snapshot)
 				if err != nil {
 					return configMap, fmt.Errorf("rkecluster %s/%s: error while updating etcd snapshot %s/%s: %w", cluster.Namespace, cluster.Name, snapshot.Namespace, snapshot.Name, err)
 				}
-				if snapshot.Status.Missing {
-					snapshot.Status.Missing = false
-					// the kube-apiserver only accepts status updates on deliberate subresource status updates which is why we have to double-call an update here if the missing is set incorrectly
-					if _, err := h.etcdSnapshots.UpdateStatus(snapshot); err != nil && !apierrors.IsNotFound(err) {
-						return configMap, fmt.Errorf("rkecluster %s/%s: error while setting status missing=false on etcd snapshot %s/%s: %w", cluster.Namespace, cluster.Name, snapshot.Namespace, snapshot.Name, err)
-					}
+			}
+			if snapshot.Status.Missing {
+				// if we get to this point and the snapshot object missing status is true, reset it to false as we know it is no longer missing.
+				snapshot.Status.Missing = false
+				// the kube-apiserver only accepts status updates on deliberate subresource status updates which is why we have to double-call an update here if the missing is set incorrectly
+				if _, err := h.etcdSnapshots.UpdateStatus(snapshot); err != nil && !apierrors.IsNotFound(err) {
+					return configMap, fmt.Errorf("rkecluster %s/%s: error while setting status missing=false on etcd snapshot %s/%s: %w", cluster.Namespace, cluster.Name, snapshot.Namespace, snapshot.Name, err)
 				}
 			}
 		} else {
-			// create the snapshot in the mgmt cluster
-			logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: creating etcd snapshot %s/%s as it differed from the actual snapshot config map", cluster.Namespace, cluster.Name, cmGeneratedSnapshot.Namespace, cmGeneratedSnapshot.Name)
-			logrus.Tracef("[snapshotbackpopulate] rkecluster %s/%s: creating etcd snapshot %s/%s: %+v", cluster.Namespace, cluster.Name, cmGeneratedSnapshot.Namespace, cmGeneratedSnapshot.Name, cmGeneratedSnapshot)
+			// create the snapshot in the mgmt cluster if it is an s3 snapshot
+			// we only create S3 snapshots in the snapshotbackpopulate controller.
+			// local snapshots are created by the `plansecret` controller based on real output of the snapshot data, and then updated by this controller.
+			if cmGeneratedSnapshot.SnapshotFile.Location != "s3" {
+				logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: not creating etcd snapshot %s/%s as it is on a local node", cluster.Namespace, cluster.Name, cmGeneratedSnapshot.Namespace, cmGeneratedSnapshot.Name)
+				continue
+			}
+			logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: creating s3 etcd snapshot %s/%s as it differed from the actual snapshot config map", cluster.Namespace, cluster.Name, cmGeneratedSnapshot.Namespace, cmGeneratedSnapshot.Name)
+			logrus.Tracef("[snapshotbackpopulate] rkecluster %s/%s: creating s3 etcd snapshot %s/%s: %+v", cluster.Namespace, cluster.Name, cmGeneratedSnapshot.Namespace, cmGeneratedSnapshot.Name, cmGeneratedSnapshot)
 			_, err = h.etcdSnapshots.Create(&cmGeneratedSnapshot)
 			if err != nil {
 				if apierrors.IsAlreadyExists(err) {
-					logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: duplicate snapshot found when creating snapshot %s/%s", cluster.Namespace, cluster.Name, cmGeneratedSnapshot.Namespace, cmGeneratedSnapshot.Name)
+					logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: duplicate snapshot found when creating s3 snapshot %s/%s", cluster.Namespace, cluster.Name, cmGeneratedSnapshot.Namespace, cmGeneratedSnapshot.Name)
 					continue
 				}
-				return configMap, fmt.Errorf("rkecluster %s/%s: error while creating etcd snapshot %s/%s: %w", cluster.Namespace, cluster.Name, cmGeneratedSnapshot.Namespace, cmGeneratedSnapshot.Name, err)
+				return configMap, fmt.Errorf("rkecluster %s/%s: error while creating s3 etcd snapshot %s/%s: %w", cluster.Namespace, cluster.Name, cmGeneratedSnapshot.Namespace, cmGeneratedSnapshot.Name, err)
 			}
 		}
 	}
 	return configMap, nil
 }
 
+func reconcileStringMaps(original map[string]string, new map[string]string, keys []string) (map[string]string, bool) {
+	ret := original
+	var updated bool
+	for _, key := range keys {
+		if ret[key] == "" && new[key] != "" {
+			ret[key] = new[key]
+			updated = true
+		}
+	}
+	return ret, updated
+}
+
+// configMapToSnapshots parses the given configmap and returns a map of etcd snapshots. The snapshotbackpopulate controller will only create snapshots from this map that are located in S3.
+// The snapshots will have 2 or 3 labels, 2 if they are S3 snapshots (cluster name and node name), and 3 if they are local snapshots. They will always have 2 annotations.
 func (h *handler) configMapToSnapshots(configMap *corev1.ConfigMap, cluster *provv1.Cluster) (map[string]rkev1.ETCDSnapshot, error) {
 	result := map[string]rkev1.ETCDSnapshot{}
 	for k, v := range configMap.Data {
 		file := &snapshotFile{}
 		if err := json.Unmarshal([]byte(v), file); err != nil {
-			logrus.Errorf("invalid non-json value in %s/%s for key %s in cluster %s", configMap.Namespace, configMap.Name, k, h.clusterName)
+			logrus.Errorf("invalid non-json value in %s/%s for key %s in cluster %s", configMap.Namespace, configMap.Name, k, cluster.Name)
 			return nil, nil
 		}
-		// Validate that the corresponding machine for the node exists before creating the snapshot
 		snapshot := rkev1.ETCDSnapshot{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cluster.Namespace,
@@ -199,8 +283,8 @@ func (h *handler) configMapToSnapshots(configMap *corev1.ConfigMap, cluster *pro
 					rke2.NodeNameLabel:    file.NodeName,
 				},
 				Annotations: map[string]string{
-					SnapshotNameKey: file.Name,
-					StorageLabelKey: StorageLocal,
+					SnapshotNameKey:      file.Name,
+					StorageAnnotationKey: StorageLocal,
 				},
 				OwnerReferences: []metav1.OwnerReference{},
 			},
@@ -220,6 +304,7 @@ func (h *handler) configMapToSnapshots(configMap *corev1.ConfigMap, cluster *pro
 		}
 		fileSuffix := StorageLocal
 		if file.S3 != nil {
+			// if the snapshot is an S3 snapshot, set the corresponding S3-related figures.
 			fileSuffix = StorageS3
 			snapshot.SnapshotFile.S3 = &rkev1.ETCDSnapshotS3{
 				Endpoint:      file.S3.Endpoint,
@@ -229,23 +314,6 @@ func (h *handler) configMapToSnapshots(configMap *corev1.ConfigMap, cluster *pro
 				Region:        file.S3.Region,
 				Folder:        file.S3.Folder,
 			}
-			snapshot.Annotations[StorageLabelKey] = StorageS3
-		} else {
-			listSuccessful, machine, err := rke2.GetMachineFromNode(h.machineCache, file.NodeName, cluster)
-			if listSuccessful && err != nil {
-				logrus.Errorf("error getting machine from node (%s) for snapshot (%s/%s): %v", file.NodeName, snapshot.Namespace, snapshot.Name, err)
-				continue // don't add this snapshot to the list as we can't actually correlate it to an existing node
-			}
-			snapshot.OwnerReferences = append(snapshot.OwnerReferences, metav1.OwnerReference{
-				APIVersion:         machine.APIVersion,
-				Kind:               machine.Kind,
-				Name:               machine.Name,
-				UID:                machine.UID,
-				Controller:         &[]bool{true}[0],
-				BlockOwnerDeletion: &[]bool{true}[0],
-			})
-		}
-		if len(snapshot.OwnerReferences) == 0 {
 			snapshot.OwnerReferences = []metav1.OwnerReference{{
 				APIVersion:         cluster.APIVersion,
 				Kind:               cluster.Kind,
@@ -254,6 +322,16 @@ func (h *handler) configMapToSnapshots(configMap *corev1.ConfigMap, cluster *pro
 				Controller:         &[]bool{true}[0],
 				BlockOwnerDeletion: &[]bool{true}[0],
 			}}
+			snapshot.Annotations[StorageAnnotationKey] = StorageS3
+		} else {
+			listSuccessful, machine, err := rke2.GetMachineFromNode(h.machineCache, file.NodeName, cluster)
+			if listSuccessful && err != nil {
+				logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: error getting machine from node (%s) for snapshot (%s/%s): %v", cluster.Namespace, cluster.Name, file.NodeName, snapshot.Namespace, snapshot.Name, err)
+			} else if listSuccessful && machine != nil && machine.Labels[rke2.MachineIDLabel] == "" {
+				logrus.Debugf("[snapshotbackpopulate] rkecluster %s/%s: machine (%s/%s) for snapshot %s on node: %s had empty Machine ID label", cluster.Namespace, cluster.Name, machine.Namespace, machine.Name, file.Name, file.NodeName)
+			} else {
+				snapshot.Labels[rke2.MachineIDLabel] = machine.Labels[rke2.MachineIDLabel]
+			}
 		}
 		snapshot.Name = name.SafeConcatName(cluster.Name, snapshot.SnapshotFile.Name, fileSuffix)
 		result[snapshot.SnapshotFile.Name+fileSuffix] = snapshot

--- a/pkg/controllers/provisioningv2/rke2/common.go
+++ b/pkg/controllers/provisioningv2/rke2/common.go
@@ -281,6 +281,21 @@ func GetMachineFromNode(machineCache capicontrollers.MachineCache, nodeName stri
 	return true, nil, fmt.Errorf("unable to find node %s in machines", nodeName)
 }
 
+// GetMachineByID attempts to find the corresponding machine for an etcd snapshot that is found in the configmap. If the machine list is successful, it will return true on the boolean, otherwise, it can be assumed that a false, nil, and defined error indicate the machine does not exist.
+func GetMachineByID(machineCache capicontrollers.MachineCache, machineID string, cluster *provv1.Cluster) (bool, *capi.Machine, error) {
+	machines, err := machineCache.List(cluster.Namespace, labels.SelectorFromSet(map[string]string{
+		ClusterNameLabel: cluster.Name,
+		MachineIDLabel:   machineID,
+	}))
+	if err != nil || len(machines) > 1 {
+		return false, nil, err
+	}
+	if len(machines) == 1 {
+		return true, machines[0], nil
+	}
+	return true, nil, fmt.Errorf("unable to find machine by ID %s for cluster %s", machineID, cluster.Name)
+}
+
 func CopyPlanMetadataToSecret(secret *corev1.Secret, metadata *plan.Metadata) {
 	if metadata == nil {
 		return

--- a/pkg/controllers/provisioningv2/rke2/plansecret/plansecret.go
+++ b/pkg/controllers/provisioningv2/rke2/plansecret/plansecret.go
@@ -204,7 +204,7 @@ func (h *handler) reconcileEtcdSnapshotList(secret *corev1.Secret, s3 bool, list
 		indexedEtcdSnapshots[v.Name] = v
 	}
 
-	if !s3 && machine != nil {
+	if !s3 {
 		for k, v := range etcdSnapshotsOnNode {
 			if _, ok := indexedEtcdSnapshots[k]; !ok {
 				// create the etcdsnapshot object as it was not in the list of etcdsnapshots and not an S3 snapshot

--- a/pkg/controllers/provisioningv2/rke2/plansecret/plansecret.go
+++ b/pkg/controllers/provisioningv2/rke2/plansecret/plansecret.go
@@ -204,7 +204,7 @@ func (h *handler) reconcileEtcdSnapshotList(secret *corev1.Secret, s3 bool, list
 		indexedEtcdSnapshots[v.Name] = v
 	}
 
-	if !s3 {
+	if !s3 && machine.Status.NodeRef != nil {
 		for k, v := range etcdSnapshotsOnNode {
 			if _, ok := indexedEtcdSnapshots[k]; !ok {
 				// create the etcdsnapshot object as it was not in the list of etcdsnapshots and not an S3 snapshot
@@ -231,9 +231,6 @@ func (h *handler) reconcileEtcdSnapshotList(secret *corev1.Secret, s3 bool, list
 						Location: v.Location,
 						NodeName: machine.Status.NodeRef.Name,
 					},
-				}
-				if machine.Status.NodeRef != nil {
-					snapshot.SnapshotFile.NodeName = machine.Status.NodeRef.Name
 				}
 				snapshot.Name = name.SafeConcatName(cnl, snapshot.SnapshotFile.Name, sb.StorageLocal)
 				logrus.Debugf("[plansecret] machine %s/%s: creating etcd snapshot %s for cluster %s", machine.Namespace, machine.Name, snapshot.Name, cnl)

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -885,7 +885,7 @@ func (p *Planner) desiredPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret 
 		if err != nil {
 			return nodePlan, err
 		}
-		if controlPlane != nil && controlPlane.Spec.ETCD != nil && S3Enabled(controlPlane.Spec.ETCD.S3) {
+		if controlPlane != nil && controlPlane.Spec.ETCD != nil && S3Enabled(controlPlane.Spec.ETCD.S3) && isInitNode(entry) {
 			nodePlan, err = p.addEtcdSnapshotListS3PeriodicInstruction(nodePlan, controlPlane)
 			if err != nil {
 				return nodePlan, err


### PR DESCRIPTION
Today, etcd snapshots are currently created and maintained by the `snapshotbackpopulate` controller. 

It is possible that the `nodeName` of a node changes, which can throw accountability off. This was causing the issue https://github.com/rancher/rancher/issues/37052 to occur.

This PR changes snapshot creation and maintenance behavior to being properly split between two controllers.

There are two cases of snapshots to consider -- snapshots that are local and snapshots that are stored in S3.

In the local case, snapshots will be created by the `plansecret` controller using the minimal amount of information found from the output of the `etcd-snapshot ls` command, and then populated using the `snapshotbackpopulate` controller.

In the case of S3, snapshots will always be created and maintained by the `snapshotbackpopulate` controller.

Notably, in the case of S3, we will always create and maintain snapshots using the `snapshotbackpopulate` controller, but will only delete S3 snapshots using the `plansecret` controller based on the output of the init node periodic list.

In all cases, etcd snapshots should only be deleted by the `plansecret` controller, unless no machine can be found either by label or node for an existing snapshot object.