### PR TITLE
[2.6.6] Set Cache-Control header default on all responses

### DIFF
--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -210,6 +210,7 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		Handler: responsewriter.Chain{
 			auth.SetXAPICattleAuthHeader,
 			responsewriter.ContentTypeOptions,
+			responsewriter.NoCache,
 			websocket.NewWebsocketHandler,
 			proxy.RewriteLocalCluster,
 			clusterProxy,


### PR DESCRIPTION
Use the apiserver NoCache middleware to set "Cache-Control: no-cache,
no-store, must-revalidate" on all Rancher endpoint responses. This
prevents problems with clients trying to use cached data that is not
properly invalidated when it becomes stale on the server.

Technically, "no-cache" and "must-revalidate" are superfluous when
"no-store" is set[1].

The header is set early in the middleware chain, and can be overridden
by another middleware or by a route handler. This happens, for instance, with
the catalog endpoint response[2].

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#preventing_storing
[2] https://github.com/rancher/rancher/blob/6c12bee2d0bee16a2854df5471aaa0cdee5b9bf1/pkg/api/norman/customization/catalog/template.go#L133

https://github.com/rancher/rancher/issues/35199