### PR TITLE
Changing cluster/project roles so they persist until cluster delete

### DIFF
--- a/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
+++ b/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
@@ -88,6 +88,8 @@ func Register(ctx context.Context, clients *wrangler.Context, management *config
 	clients.Mgmt.RoleTemplate().OnChange(ctx, "auth-prov-v2-roletemplate", h.OnChange)
 	clients.Mgmt.ClusterRoleTemplateBinding().OnChange(ctx, "auth-prov-v2-crtb", h.OnCRTB)
 	clients.Mgmt.ProjectRoleTemplateBinding().OnChange(ctx, "auth-prov-v2-prtb", h.OnPRTB)
+	clients.RBAC.Role().OnRemove(ctx, "auth-prov-v2-role", h.OnRemoveRole)
+	clients.RBAC.RoleBinding().OnRemove(ctx, "auth-prov-v2-rb", h.OnRemoveRoleBinding)
 	clients.Provisioning.Cluster().OnChange(ctx, "auth-prov-v2-cluster", h.OnCluster)
 	clients.CRD.CustomResourceDefinition().OnChange(ctx, "auth-prov-v2-crd", h.OnCRD)
 	if features.RKE2.Enabled() {

--- a/pkg/controllers/management/authprovisioningv2/crtb.go
+++ b/pkg/controllers/management/authprovisioningv2/crtb.go
@@ -76,8 +76,9 @@ func (h *handler) OnCRTB(key string, crtb *v3.ClusterRoleTemplateBinding) (*v3.C
 		// Example: crt-cluster1-creator-cluster-owner-blxbujr34t
 		roleBinding := &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name.SafeConcatName("crt", cluster.Name, crtb.Name, hashedSubject),
-				Namespace: cluster.Namespace,
+				Name:        name.SafeConcatName("crt", cluster.Name, crtb.Name, hashedSubject),
+				Namespace:   cluster.Namespace,
+				Annotations: createClusterRBACAnnotations(cluster),
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,
@@ -94,8 +95,9 @@ func (h *handler) OnCRTB(key string, crtb *v3.ClusterRoleTemplateBinding) (*v3.C
 		// Example: r-cluster1-view-crtb-foo-wn5d5n7udr
 		roleBinding := &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name.SafeConcatName(clusterViewName(cluster), crtb.Name, hashedSubject),
-				Namespace: cluster.Namespace,
+				Name:        name.SafeConcatName(clusterViewName(cluster), crtb.Name, hashedSubject),
+				Namespace:   cluster.Namespace,
+				Annotations: createClusterRBACAnnotations(cluster),
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,
@@ -111,6 +113,7 @@ func (h *handler) OnCRTB(key string, crtb *v3.ClusterRoleTemplateBinding) (*v3.C
 		WithListerNamespace(cluster.Namespace).
 		WithSetID(CRTBRoleBindingID).
 		WithOwner(crtb).
+		WithSetOwnerReference(false, false).
 		ApplyObjects(bindings...)
 }
 

--- a/pkg/controllers/management/authprovisioningv2/prtb.go
+++ b/pkg/controllers/management/authprovisioningv2/prtb.go
@@ -62,8 +62,9 @@ func (h *handler) ensureClusterViewBinding(cluster *v1.Cluster, prtb *v3.Project
 	// Example: r-cluster1-view-prtb-bar-foo-wn5d5n7udr
 	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.SafeConcatName(clusterViewName(cluster), prtb.Namespace, prtb.Name, hashSubject(subject)),
-			Namespace: cluster.Namespace,
+			Name:        name.SafeConcatName(clusterViewName(cluster), prtb.Namespace, prtb.Name, hashSubject(subject)),
+			Namespace:   cluster.Namespace,
+			Annotations: createClusterRBACAnnotations(cluster),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: cluster.APIVersion,
@@ -86,6 +87,7 @@ func (h *handler) ensureClusterViewBinding(cluster *v1.Cluster, prtb *v3.Project
 		WithListerNamespace(cluster.Namespace).
 		WithSetID(PRTBRoleBindingID).
 		WithOwner(prtb).
+		WithSetOwnerReference(false, false).
 		ApplyObjects(roleBinding)
 }
 


### PR DESCRIPTION
Changes CRTBs and PRTBs so that they persist until the cluster is
fully deleted. This allows users to see deletion messages as
the cluster is removed and to see the cluster gone on the UI
