### PR TITLE
Fix SAML unauthorized log message

### DIFF
--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -318,7 +318,7 @@ func (s *Provider) HandleSamlAssertion(w http.ResponseWriter, r *http.Request, a
 		return
 	}
 	if !allowed {
-		log.Errorf("SAML: User does not have access %v", err)
+		log.Errorf("SAML: User [%s] is not an authorized user or is not a member of an authorized group", userPrincipal.Name)
 		http.Redirect(w, r, redirectURL+"errorCode=403", http.StatusFound)
 		return
 	}


### PR DESCRIPTION
`err` is checked for nil on the lines above and is guaranteed to be nil
in this log message, so don't use it. Add more wording to indicate that
it could be a group membership problem and to align better with the
wording in the UI.

SURE-4509