### PR TITLE
Put more logs in provisioning log

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/provisioninglog/provisioninglog.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioninglog/provisioninglog.go
@@ -83,6 +83,12 @@ func (h *handler) recordMessage(provCluster *provv1.Cluster, cm *corev1.ConfigMa
 	error := rke2.Provisioned.IsFalse(provCluster)
 	done := rke2.Provisioned.IsTrue(provCluster)
 
+	if done && msg == "" {
+		done = rke2.Updated.IsTrue(provCluster)
+		msg = rke2.Updated.GetMessage(provCluster)
+		error = rke2.Updated.IsFalse(provCluster)
+	}
+
 	if done && msg == "" && provCluster.Status.Ready {
 		msg = "provisioning done"
 	}


### PR DESCRIPTION
The original intention of the provisioning log was to put all logs related to
cluster provisioning in the log. When we switched to using the `Updated`
condition, this was not the case.

After this change, provisioning all provisioning logs will be included.