### PR TITLE
Ensure that Rancher serves the right Windows install script when airgapped

### DIFF
--- a/pkg/provisioningv2/rke2/installer/installer.go
+++ b/pkg/provisioningv2/rke2/installer/installer.go
@@ -26,8 +26,8 @@ var (
 		"." + SystemAgentInstallPath,
 	}
 	localWindowsRke2InstallScripts = []string{
-		"./wins-install.ps1",
-	}
+		settings.UIPath.Get() + "/assets" + WindowsRke2InstallPath,
+		"." + WindowsRke2InstallPath}
 )
 
 func installScript(setting settings.Setting, files []string) ([]byte, error) {

--- a/pkg/provisioningv2/rke2/installer/server_test.go
+++ b/pkg/provisioningv2/rke2/installer/server_test.go
@@ -50,3 +50,49 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		})
 	}
 }
+
+func TestHandler_ServeHTTPAirgap(t *testing.T) {
+	type scriptArgs struct {
+		path string
+		body string
+	}
+	tests := []struct {
+		name string
+		args scriptArgs
+	}{
+		{
+			name: "Retrieve Linux script in mock airgap",
+			args: scriptArgs{
+				path: "/system-agent-install.sh",
+				body: "#!/usr/bin/env sh",
+			},
+		},
+		{
+			name: "Retrieve Windows script in mock airgap",
+			args: scriptArgs{
+				path: "/wins-agent-install.ps1",
+				body: "Invoke-WinsInstaller @PSBoundParameters",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// arrange
+			a := assert.New(t)
+			req, err := http.NewRequest(http.MethodGet, tt.args.path, nil)
+			a.Nil(err)
+			rr := httptest.NewRecorder()
+			handler := handler{}
+			air := httptest.NewUnstartedServer(&handler)
+
+			// act
+			air.Config.Handler.ServeHTTP(rr, req)
+			defer air.Config.Close()
+
+			// assert
+			a.Equal(rr.Code, http.StatusOK)
+			a.Contains(rr.Body.String(), tt.args.body)
+
+		})
+	}
+}


### PR DESCRIPTION
Currently, Rancher is attempting to serve a `wins-install.ps1` script when airgapped and the remote script is not available. This PR addresses this by switching to serving `wins-agent-install.ps1` instead as well as adding unit tests that attempt to mock airgap by testing with an unstarted http test server, to mimic an airgap setup.