### PR TITLE
[release/v2.6] Add script to check if to skip CI for UI bumps

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -3,6 +3,13 @@ set -e
 
 cd $(dirname $0)
 
+if ./only-ui-bumps.sh; then
+    ./build
+    ./package
+    ./chart/ci
+    exit 0
+fi
+
 ./validate
 ./build
 ./test

--- a/scripts/only-ui-bumps.sh
+++ b/scripts/only-ui-bumps.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+echo "Checking if we can skip CI"
+# Can only compare diff if branch is set
+if [ -n "${DRONE_BRANCH}" ]; then
+    echo "Environment variable DRONE_BRANCH is ${DRONE_BRANCH}"
+    # Check if there is only one changed file and if its 'package/Dockerfile'
+    if [ $(git diff ${DRONE_BRANCH} --name-only | wc -l) -eq 1 ] && [ $(git diff ${DRONE_BRANCH} --name-only) = "package/Dockerfile" ]; then
+        echo "Only package/Dockerfile changes found"
+        # Check if only CATTLE_UI_VERSION and CATTLE_DASHBOARD_UI_VERSION are changed in 'package/Dockerfile'
+        if [ -z "$(git diff -U0 ${DRONE_BRANCH} package/Dockerfile | tail -n +5 | grep -v ^@@ | egrep -v "CATTLE_UI_VERSION|CATTLE_DASHBOARD_UI_VERSION")" ]; then
+            echo "Skipping CI because it is only UI/dashboard change"
+            exit 0
+        fi
+    fi
+fi
+echo "Not all conditions met to skip CI"
+exit 1

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e
+if ./scripts/only-ui-bumps.sh; then
+    exit 0
+fi
 
 cleanup()
 {

--- a/scripts/provisioning-tests-rke
+++ b/scripts/provisioning-tests-rke
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e
+if ./scripts/only-ui-bumps.sh; then
+    exit 0
+fi
 
 cd $(dirname $0)/..
 


### PR DESCRIPTION
We now have a workflow to bump environment variable values automatically, so we can tie tagging a UI or dashboard release to creating a PR in `rancher/rancher`. The idea was to skip CI for those PRs because it takes a lot of time and it makes no sense to build the whole thing for a bump of UI or dashboard. But it seems that skipping CI will not kick off a Drone build (which is expected) but GitHub has Drone check marked as required so it will set the state to `Expected` but it will never get a response from Drone as the build is not kicked off.

To still be able to save time, I added a script that checks if we are only bumping UI or dashboard and skip time consuming scripts that are not needed in this case. Although this doesn't save time for tagging (we need to figure that out next), at least doing the prep for a new RC will be faster.