### PR TITLE
Don't include system-default-registry in worker-only plan

### DIFF
--- a/pkg/provisioningv2/rke2/planner/config.go
+++ b/pkg/provisioningv2/rke2/planner/config.go
@@ -64,9 +64,6 @@ func addDefaults(config map[string]interface{}, controlPlane *rkev1.RKEControlPl
 	if rke2.GetRuntime(controlPlane.Spec.KubernetesVersion) == rke2.RuntimeRKE2 {
 		config["cni"] = "calico"
 	}
-	if settings.SystemDefaultRegistry.Get() != "" {
-		config["system-default-registry"] = settings.SystemDefaultRegistry.Get()
-	}
 }
 
 func addUserConfig(config map[string]interface{}, controlPlane *rkev1.RKEControlPlane, entry *planEntry) error {
@@ -109,6 +106,10 @@ func addRoleConfig(config map[string]interface{}, controlPlane *rkev1.RKEControl
 		config["disable-controller-manager"] = true
 	} else if isOnlyControlPlane(entry) {
 		config["disable-etcd"] = true
+	}
+
+	if sdr := settings.SystemDefaultRegistry.Get(); sdr != "" && !isOnlyWorker(entry) {
+		config["system-default-registry"] = sdr
 	}
 
 	// If this is a control-plane node, then we need to set arguments/(and for RKE2, volume mounts) to allow probes

--- a/pkg/provisioningv2/rke2/planner/manifests.go
+++ b/pkg/provisioningv2/rke2/planner/manifests.go
@@ -38,7 +38,7 @@ func (p *Planner) getControlPlaneManifests(controlPlane *rkev1.RKEControlPlane, 
 	// if we have a nil snapshotMetadata object, it's probably because the annotation didn't exist on the controlplane object. this is not breaking though so don't block.
 	snapshotMetadata := getEtcdSnapshotExtraMetadata(controlPlane, rke2.GetRuntime(controlPlane.Spec.KubernetesVersion))
 	if snapshotMetadata == nil {
-		logrus.Errorf("Error while generating etcd snapshot extra metadata manifest for cluster %s: %v", controlPlane.ClusterName, err)
+		logrus.Errorf("Error while generating etcd snapshot extra metadata manifest for cluster %s", controlPlane.ClusterName)
 	} else {
 		result = append(result, *snapshotMetadata)
 	}


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/37301

## Problem
The system-default-registry configuration was added to all RKE2/K3S plans if the
setting was non-empty. The caused a problem with K3S worker-only nodes because
K3S agent binary would error for the unexpected parameter.

## Solution
This change only includes the system-default registry parameter for
non-worker-only nodes.