### PR TITLE
Stop deploying agent in planner after agent is deployed

### DIFF
--- a/pkg/apis/rke.cattle.io/v1/controlplane.go
+++ b/pkg/apis/rke.cattle.io/v1/controlplane.go
@@ -49,4 +49,5 @@ type RKEControlPlaneStatus struct {
 	ConfigGeneration              int64                               `json:"configGeneration,omitempty"`
 	Initialized                   bool                                `json:"initialized,omitempty"`
 	AgentConnected                bool                                `json:"agentConnected,omitempty"`
+	AgentDeployed                 bool                                `json:"agentDeployed,omitempty"`
 }

--- a/pkg/controllers/provisioningv2/rke2/rkecontrolplane/controlplane.go
+++ b/pkg/controllers/provisioningv2/rke2/rkecontrolplane/controlplane.go
@@ -80,6 +80,7 @@ func (h *handler) OnChange(obj *rkev1.RKEControlPlane, status rkev1.RKEControlPl
 	status.Ready = rke2.Ready.IsTrue(cluster)
 	status.Initialized = rke2.Ready.IsTrue(cluster)
 	status.AgentConnected = rke2.AgentConnected.IsTrue(cluster)
+	status.AgentDeployed = rke2.AgentDeployed.IsTrue(cluster)
 	return status, nil
 }
 

--- a/pkg/provisioningv2/rke2/planner/instructions.go
+++ b/pkg/provisioningv2/rke2/planner/instructions.go
@@ -65,7 +65,7 @@ func generateInstallInstruction(controlPlane *rkev1.RKEControlPlane, entry *plan
 // addInstallInstructionWithRestartStamp will generate an instruction and append it to the node plan that executes the `run.sh` or `run.ps1`
 // from the installer image based on the control plane configuration. It will generate a restart stamp based on the
 // passed in configuration to determine whether it needs to start/restart the service being managed.
-func (p *Planner) addInstallInstructionWithRestartStamp(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, entry *planEntry) (plan.NodePlan, error) {
+func (p *Planner) addInstallInstructionWithRestartStamp(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, entry *planEntry) plan.NodePlan {
 	var restartStampEnv string
 	stamp := restartStamp(nodePlan, controlPlane, getInstallerImage(controlPlane))
 	switch entry.Metadata.Labels[rke2.CattleOSLabel] {
@@ -76,6 +76,40 @@ func (p *Planner) addInstallInstructionWithRestartStamp(nodePlan plan.NodePlan, 
 	}
 	instEnv := []string{restartStampEnv}
 	nodePlan.Instructions = append(nodePlan.Instructions, generateInstallInstruction(controlPlane, entry, instEnv))
+	return nodePlan
+}
+
+// addApplyClusterAgentPeriodicInstruction removes the cattle-cluster-agent manifest, if it exists.
+// After it is installed once, the cattle-cluster-agent should be managed by Rancher.
+func (p *Planner) addApplyClusterAgentPeriodicInstruction(controlPlane *rkev1.RKEControlPlane, nodePlan plan.NodePlan, entry *planEntry) (plan.NodePlan, error) {
+	if !controlPlane.Status.AgentDeployed && isControlPlane(entry) {
+		runtime := rke2.GetRuntime(controlPlane.Spec.KubernetesVersion)
+		var kubectlCmd string
+		if runtime == rke2.RuntimeK3S {
+			kubectlCmd = "k3s kubectl"
+		} else {
+			kubectlCmd = "/var/lib/rancher/rke2/bin/kubectl"
+		}
+
+		manifest, err := p.generateClusterAgentManifest(controlPlane, entry)
+		if err != nil {
+			return nodePlan, err
+		}
+
+		nodePlan.PeriodicInstructions = append(nodePlan.PeriodicInstructions, plan.PeriodicInstruction{
+			Name:    "apply-cluster-agent-manifest",
+			Command: "sh",
+			Args: []string{
+				"-c",
+				// We need to check for the deployment to ensure that this command doesn't overwrite the deployment when the Rancher controllers take over.
+				// We have to do the printf "%%b" thing here because the manifest has new lines in it. They need to be unescaped when running the command.
+				fmt.Sprintf(`if ! $(%s -n cattle-system get deployment cattle-cluster-agent); then printf "%%b\n" %q | %[1]s apply -f - || true; else exit 0; fi`, kubectlCmd, manifest),
+			},
+			Env:           []string{fmt.Sprintf("KUBECONFIG=/etc/rancher/%s/%[1]s.yaml", runtime)},
+			PeriodSeconds: 15,
+		})
+	}
+
 	return nodePlan, nil
 }
 
@@ -94,7 +128,7 @@ func (p *Planner) generateInstallInstructionWithSkipStart(controlPlane *rkev1.RK
 	return generateInstallInstruction(controlPlane, entry, instEnv)
 }
 
-func (p *Planner) addInitNodePeriodicInstruction(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane) (plan.NodePlan, error) {
+func (p *Planner) addInitNodePeriodicInstruction(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane) plan.NodePlan {
 	nodePlan.PeriodicInstructions = append(nodePlan.PeriodicInstructions, []plan.PeriodicInstruction{
 		{
 			Name:    captureAddressInstructionName,
@@ -119,10 +153,10 @@ func (p *Planner) addInitNodePeriodicInstruction(nodePlan plan.NodePlan, control
 			PeriodSeconds: 600,
 		},
 	}...)
-	return nodePlan, nil
+	return nodePlan
 }
 
-func (p *Planner) addEtcdSnapshotListLocalPeriodicInstruction(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane) (plan.NodePlan, error) {
+func (p *Planner) addEtcdSnapshotListLocalPeriodicInstruction(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane) plan.NodePlan {
 	nodePlan.PeriodicInstructions = append(nodePlan.PeriodicInstructions, plan.PeriodicInstruction{
 		Name:    "etcd-snapshot-list-local",
 		Command: "sh",
@@ -134,10 +168,10 @@ func (p *Planner) addEtcdSnapshotListLocalPeriodicInstruction(nodePlan plan.Node
 		},
 		PeriodSeconds: 600,
 	})
-	return nodePlan, nil
+	return nodePlan
 }
 
-func (p *Planner) addEtcdSnapshotListS3PeriodicInstruction(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane) (plan.NodePlan, error) {
+func (p *Planner) addEtcdSnapshotListS3PeriodicInstruction(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane) plan.NodePlan {
 	nodePlan.PeriodicInstructions = append(nodePlan.PeriodicInstructions, plan.PeriodicInstruction{
 		Name:    "etcd-snapshot-list-s3",
 		Command: "sh",
@@ -149,5 +183,5 @@ func (p *Planner) addEtcdSnapshotListS3PeriodicInstruction(nodePlan plan.NodePla
 		},
 		PeriodSeconds: 600,
 	})
-	return nodePlan, nil
+	return nodePlan
 }

--- a/pkg/provisioningv2/rke2/planner/instructions_test.go
+++ b/pkg/provisioningv2/rke2/planner/instructions_test.go
@@ -144,10 +144,9 @@ func TestPlanner_addInstallInstructionWithRestartStamp(t *testing.T) {
 			entry := createTestPlanEntry(tt.args.os)
 
 			// act
-			p, err := planner.addInstallInstructionWithRestartStamp(plan.NodePlan{}, controlPlane, entry)
+			p := planner.addInstallInstructionWithRestartStamp(plan.NodePlan{}, controlPlane, entry)
 
 			// assert
-			a.Nil(err)
 			a.NotNil(p)
 			a.Equal(entry.Metadata.Labels[rke2.CattleOSLabel], tt.args.os)
 			a.NotZero(len(p.Instructions))

--- a/pkg/provisioningv2/rke2/planner/manifests.go
+++ b/pkg/provisioningv2/rke2/planner/manifests.go
@@ -29,12 +29,6 @@ func (p *Planner) getControlPlaneManifests(controlPlane *rkev1.RKEControlPlane, 
 		return nil, nil
 	}
 
-	clusterAgent, err := p.getClusterAgentManifestFile(controlPlane, rke2.GetRuntime(controlPlane.Spec.KubernetesVersion), entry)
-	if err != nil {
-		return nil, err
-	}
-	result = append(result, clusterAgent)
-
 	// if we have a nil snapshotMetadata object, it's probably because the annotation didn't exist on the controlplane object. this is not breaking though so don't block.
 	snapshotMetadata := getEtcdSnapshotExtraMetadata(controlPlane, rke2.GetRuntime(controlPlane.Spec.KubernetesVersion))
 	if snapshotMetadata == nil {
@@ -62,20 +56,6 @@ func getEtcdSnapshotExtraMetadata(controlPlane *rkev1.RKEControlPlane, runtime s
 	}
 	logrus.Errorf("rkecluster %s/%s: unable to find cluster spec annotation for control plane", controlPlane.Spec.ClusterName, controlPlane.Namespace)
 	return nil
-}
-
-// getClusterAgentManifestFile returns a plan.File that contains the cluster agent manifest.
-func (p *Planner) getClusterAgentManifestFile(controlPlane *rkev1.RKEControlPlane, runtime string, entry *planEntry) (plan.File, error) {
-	data, err := p.generateClusterAgentManifest(controlPlane, entry)
-	if err != nil {
-		return plan.File{}, err
-	}
-
-	return plan.File{
-		Content: base64.StdEncoding.EncodeToString(data),
-		Path:    fmt.Sprintf("/var/lib/rancher/%s/server/manifests/rancher/cluster-agent.yaml", runtime),
-		Dynamic: true,
-	}, nil
 }
 
 // getAddons returns a plan.File that contains the content of the defined additional manifests.

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -884,7 +884,7 @@ func (p *Planner) desiredPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret 
 		return nodePlan, err
 	}
 
-	return nodePlan, nil
+	return addRemoveOldClusterAgentManifestInstruction(controlPlane, nodePlan, entry), nil
 }
 
 func getInstallerImage(controlPlane *rkev1.RKEControlPlane) string {

--- a/pkg/provisioningv2/rke2/planner/planner_test.go
+++ b/pkg/provisioningv2/rke2/planner/planner_test.go
@@ -71,10 +71,9 @@ func TestPlanner_addInstruction(t *testing.T) {
 			entry := createTestPlanEntry(tt.args.os)
 
 			// act
-			p, err := planner.addInstallInstructionWithRestartStamp(plan.NodePlan{}, controlPlane, entry)
+			p := planner.addInstallInstructionWithRestartStamp(plan.NodePlan{}, controlPlane, entry)
 
 			// assert
-			a.Nil(err)
 			a.NotNil(p)
 			a.Equal(entry.Metadata.Labels[rke2.CattleOSLabel], tt.args.os)
 			a.NotZero(len(p.Instructions))


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/37465

## Problem
The RKE2 planner would include the manifest for the cluster agent in the
plan for a node. This causes the cluster to go into an updating state on
Rancher upgrade, which is unexpected.

## Solution
After this change, the planner will not include the cluster agent
manifest file. Instead, the cluster agent will be deployed via a periodic 
instruction that is only included until the cluster agent is deployed.

## Testing
Updating Rancher and rancher-agent with deployed RKE2 clusters.