### PR TITLE
[release/v2.6] Add target to automate go get

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -135,9 +135,9 @@ RUN curl -sLf ${YQ_URL} -o /usr/bin/yq && chmod +x /usr/bin/yq
 RUN zypper install -y python3-tox python3-base python3 libffi-devel libopenssl-devel
 
 ENV HELM_HOME /root/.helm
-ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_COMMIT DRONE_BRANCH SYSTEM_CHART_DEFAULT_BRANCH FOSSA_API_KEY
+ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_COMMIT DRONE_BRANCH SYSTEM_CHART_DEFAULT_BRANCH FOSSA_API_KEY GOGET_MODULE GOGET_VERSION
 ENV DAPPER_SOURCE /go/src/github.com/rancher/rancher/
-ENV DAPPER_OUTPUT ./bin ./dist
+ENV DAPPER_OUTPUT ./bin ./dist ./go.mod ./go.sum ./pkg/apis/go.mod ./pkg/apis/go.sum ./pkg/client/go.mod ./pkg/client/go.sum
 ENV DAPPER_DOCKER_SOCKET true
 ENV DAPPER_RUN_ARGS "-v rancher2-go16-pkg-1:/go/pkg -v rancher2-go16-cache-1:/root/.cache/go-build --privileged"
 ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache

--- a/scripts/go-get
+++ b/scripts/go-get
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+MODULE=$GOGET_MODULE
+VERSION=$GOGET_VERSION
+
+SUBDIRS="pkg/apis pkg/client"
+
+go get -d "${MODULE}@${VERSION}"
+go mod tidy
+go mod verify
+
+for SUBDIR in $SUBDIRS; do
+    if grep -q $MODULE "${SUBDIR}/go.mod"; then
+        cd $SUBDIR
+        go get -d "${MODULE}@${VERSION}"
+        go mod tidy
+        go mod verify
+        cd -
+    fi
+done


### PR DESCRIPTION
This is to automate `go get` from any module that we use in Rancher. Most commonly used is `rancher/rke`, so we can use this make target in a GitHub Actions workflow to automatically update `rancher/rke` library in this repository after a tag has been created.

This could be a 100% Actions workflow (meaning that Dapper is not involved) but in this way, people can also use it locally if needed:

```
GOGET_MODULE=github.com/rancher/rke GOGET_VERSION=v1.3.10-rcX make go-get
```