### PR TITLE
[2.6] Fix the "no basic auth credentials" error when using private registry 

### DIFF
--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/clusterregistrationtoken"
 	"github.com/rancher/rancher/pkg/controllers/management/drivers/nodedriver"
+	secretmigrator "github.com/rancher/rancher/pkg/controllers/management/secretmigrator"
 	"github.com/rancher/rancher/pkg/encryptedstore"
 	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -413,6 +414,10 @@ func (m *Lifecycle) deployAgent(nodeDir string, obj *v3.Node) error {
 		return err
 	}
 
+	cluster.Spec, err = secretmigrator.AssembleRKEConfigSpec(cluster, cluster.Spec, m.credLister)
+	if err != nil {
+		return err
+	}
 	err = m.authenticateRegistry(nodeDir, obj, cluster)
 	if err != nil {
 		return err

--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -414,11 +414,13 @@ func (m *Lifecycle) deployAgent(nodeDir string, obj *v3.Node) error {
 		return err
 	}
 
-	cluster.Spec, err = secretmigrator.AssembleRKEConfigSpec(cluster, cluster.Spec, m.credLister)
+	// make a deep copy of the cluster, so we are not modifying the original cluster object
+	clusterCopy := cluster.DeepCopy()
+	clusterCopy.Spec, err = secretmigrator.AssembleRKEConfigSpec(clusterCopy, clusterCopy.Spec, m.credLister)
 	if err != nil {
 		return err
 	}
-	err = m.authenticateRegistry(nodeDir, obj, cluster)
+	err = m.authenticateRegistry(nodeDir, obj, clusterCopy)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Issue:** https://github.com/rancher/rancher/issues/37449

**Problem:**
When rancher provisions an RKE node-driver cluster, one of the steps is to authenticate the machine to a private registry if one is defined in the cluster's spec. A [recent change](https://github.com/rancher/rancher/pull/36578) of migrating the private registry's password to a secret makes Rancher think there is no private registry in the cluster's spec, so it skips authenticating step.  As a result, the error "no basic auth credentials" is returned.

**Solution:**
The fix is to add the password to the cluster's spec before the authenticating step. The cluster object is used only within the function, so there should be no negative impact on security.

**Testing:**
Although I cannot get a setup to test the fix by creating a node-driver vSphere cluster, the following tests should indicate the fix is actually working in theory:

Steps:
- prepare a private registry that is installed with self-signed certs in an ec2 instance 
- bake an AMI that trusts the above certs for Docker 
- in another ec2 instance, run rancher 2.6.3
- in local, run rancher with my fix in GoLand
- create a node template, choose AWS, set AMI
- in both setups, create an RKE node-drive cluster, choose AWS EC2, set the private registry URL, username, and password 
 
Results:
- in rancher 2.6.3, hit the `no basic auth credentials` as the issue says 
 


- in my local setup, cluster is provisioned. Notice the following message in the logs which indicates the private registry is detected. 
`2022/04/27 17:39:22 [INFO] [node-controller-rancher-machine] private registry detected, authenticating jiaqi-amiaaaa1 to ec2-x-x-x-x.us-west-1.compute.amazonaws.com`
 


----
Need to back-port the fix to 2.5 and 2.4 

