### PR TITLE
fix v1 monitoring app panic

### DIFF
--- a/pkg/controllers/managementuserlegacy/alert/deployer/upgradeimpl.go
+++ b/pkg/controllers/managementuserlegacy/alert/deployer/upgradeimpl.go
@@ -149,6 +149,9 @@ func (l *AlertService) Upgrade(currentVersion string) (string, error) {
 	}
 	newApp := app.DeepCopy()
 	newApp.Spec.ExternalID = newExternalID
+	if newApp.Spec.Answers == nil {
+		newApp.Spec.Answers = make(map[string]string)
+	}
 	newApp.Spec.Answers["operator.enabled"] = "false"
 
 	if !reflect.DeepEqual(newApp, app) {


### PR DESCRIPTION
Fix for panic in https://github.com/rancher/rancher/issues/36260

I marked this as a release blocker due to the simplicity of the reproduction steps(upgrading from Rancher v2.5 -> 2.6 and then upgrading a downstream RKE1 Windows cluster)  and that Rancher seemingly cannot recover without the cluster being deleted. 