### PR TITLE
Fix planner address issues

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/bootstrap/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/bootstrap/controller.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
-	"fmt"
 
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2"
@@ -336,31 +335,10 @@ func getLabelsAndAnnotationsForPlanSecret(bootstrap *rkev1.RKEBootstrap, machine
 		labels[k] = v
 	}
 
-	annotations := make(map[string]string, len(bootstrap.Annotations)+1)
-	annotations[rke2.JoinURLAnnotation] = getMachineJoinURL(machine)
+	annotations := make(map[string]string, len(bootstrap.Annotations))
 	for k, v := range bootstrap.Annotations {
 		annotations[k] = v
 	}
 
 	return labels, annotations
-}
-
-func getMachineJoinURL(machine *capi.Machine) string {
-	if machine.Status.NodeInfo == nil {
-		return ""
-	}
-
-	address := ""
-	for _, machineAddress := range machine.Status.Addresses {
-		switch machineAddress.Type {
-		case capi.MachineInternalIP:
-			address = machineAddress.Address
-		case capi.MachineExternalIP:
-			if address == "" {
-				address = machineAddress.Address
-			}
-		}
-	}
-
-	return fmt.Sprintf("https://%s:%d", address, rke2.GetRuntimeSupervisorPort(machine.Status.NodeInfo.KubeletVersion))
 }

--- a/pkg/controllers/provisioningv2/rke2/common.go
+++ b/pkg/controllers/provisioningv2/rke2/common.go
@@ -70,16 +70,17 @@ const (
 	RKEMachineAPIVersion           = "rke-machine.cattle.io/v1"
 	RKEAPIVersion                  = "rke.cattle.io/v1"
 
-	Provisioned    = condition.Cond("Provisioned")
-	Updated        = condition.Cond("Updated")
-	Reconciled     = condition.Cond("Reconciled")
-	Ready          = condition.Cond("Ready")
-	Waiting        = condition.Cond("Waiting")
-	Pending        = condition.Cond("Pending")
-	Removed        = condition.Cond("Removed")
-	AgentDeployed  = condition.Cond("AgentDeployed")
-	AgentConnected = condition.Cond("Connected")
-	PlanApplied    = condition.Cond("PlanApplied")
+	Provisioned         = condition.Cond("Provisioned")
+	Updated             = condition.Cond("Updated")
+	Reconciled          = condition.Cond("Reconciled")
+	Ready               = condition.Cond("Ready")
+	Waiting             = condition.Cond("Waiting")
+	Pending             = condition.Cond("Pending")
+	Removed             = condition.Cond("Removed")
+	AgentDeployed       = condition.Cond("AgentDeployed")
+	AgentConnected      = condition.Cond("Connected")
+	PlanApplied         = condition.Cond("PlanApplied")
+	InfrastructureReady = condition.Cond(capi.InfrastructureReadyCondition)
 
 	RuntimeK3S  = "k3s"
 	RuntimeRKE2 = "rke2"

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -359,7 +359,7 @@ func (h *handler) setProvisionedStatusFromMachineInfra(cluster *rancherv1.Cluste
 	}
 
 	for _, machine := range machines {
-		if !machine.DeletionTimestamp.IsZero() || condition.Cond(capi.InfrastructureReadyCondition).IsTrue(machine) {
+		if !machine.DeletionTimestamp.IsZero() || rke2.InfrastructureReady.IsTrue(machine) {
 			continue
 		}
 

--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -3,6 +3,7 @@ package management
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"reflect"
 	"strings"
 
@@ -105,7 +106,7 @@ func addMachineDrivers(management *config.ManagementContext) error {
 	}
 	linodeBuiltin := true
 	if dl := os.Getenv("CATTLE_DEV_MODE"); dl != "" {
-		linodeBuiltin = false
+		linodeBuiltin = isCommandAvailable("docker-machine-driver-linode")
 	}
 	if err := addMachineDriver(Linodedriver, "https://github.com/linode/docker-machine-driver-linode/releases/download/v0.1.8/docker-machine-driver-linode_linux-amd64.zip", "/assets/rancher-ui-driver-linode/component.js", "b31b6a504c59ee758d2dda83029fe4a85b3f5601e22dfa58700a5e6c8f450dc7", []string{"api.linode.com"}, linodeBuiltin, linodeBuiltin, false, management); err != nil {
 		return err
@@ -214,4 +215,8 @@ func addMachineDriver(name, url, uiURL, checksum string, whitelist []string, act
 	})
 
 	return err
+}
+
+func isCommandAvailable(name string) bool {
+	return exec.Command("command", "-v", name).Run() == nil
 }

--- a/pkg/provisioningv2/rke2/planner/config.go
+++ b/pkg/provisioningv2/rke2/planner/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rancher/wrangler/pkg/kv"
 	"github.com/rancher/wrangler/pkg/yaml"
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -276,21 +277,30 @@ func addToken(config map[string]interface{}, entry *planEntry, tokensSecret plan
 	}
 }
 
-func addAddresses(secrets corecontrollers.SecretCache, config map[string]interface{}, entry *planEntry) {
+func addAddresses(secrets corecontrollers.SecretCache, config map[string]interface{}, entry *planEntry) error {
 	internalIPAddress := entry.Metadata.Annotations[rke2.InternalAddressAnnotation]
 	ipAddress := entry.Metadata.Annotations[rke2.AddressAnnotation]
 	internalAddressProvided, addressProvided := internalIPAddress != "", ipAddress != ""
 
-	secret, err := secrets.Get(entry.Machine.Spec.InfrastructureRef.Namespace, rke2.MachineStateSecretName(entry.Machine.Spec.InfrastructureRef.Name))
-	if err == nil && len(secret.Data["extractedConfig"]) != 0 {
+	// If this is a provisioned node (not a custom node), then get the IP addresses from the machine driver config.
+	if entry.Machine.Spec.InfrastructureRef.APIVersion == rke2.RKEMachineAPIVersion && (!internalAddressProvided || !addressProvided) {
+		secret, err := secrets.Get(entry.Machine.Spec.InfrastructureRef.Namespace, rke2.MachineStateSecretName(entry.Machine.Spec.InfrastructureRef.Name))
+		if apierrors.IsNotFound(err) || (secret != nil && len(secret.Data["extractedConfig"]) == 0) {
+			return errIgnore(fmt.Sprintf("waiting for machine %s/%s driver config to be saved", entry.Machine.Namespace, entry.Machine.Name))
+		} else if err != nil {
+			return fmt.Errorf("error getting machine state secret for machine %s/%s: %w", entry.Machine.Namespace, entry.Machine.Name, err)
+		}
+
 		driverConfig, err := nodeconfig.ExtractConfigJSON(base64.StdEncoding.EncodeToString(secret.Data["extractedConfig"]))
-		if err == nil && len(driverConfig) != 0 {
-			if !addressProvided {
-				ipAddress = convert.ToString(values.GetValueN(driverConfig, "Driver", "IPAddress"))
-			}
-			if !internalAddressProvided {
-				internalIPAddress = convert.ToString(values.GetValueN(driverConfig, "Driver", "PrivateIPAddress"))
-			}
+		if err != nil || len(driverConfig) == 0 {
+			return fmt.Errorf("error getting machine state JSON for machine %s/%s: %w", entry.Machine.Namespace, entry.Machine.Name, err)
+		}
+
+		if !addressProvided {
+			ipAddress = convert.ToString(values.GetValueN(driverConfig, "Driver", "IPAddress"))
+		}
+		if !internalAddressProvided {
+			internalIPAddress = convert.ToString(values.GetValueN(driverConfig, "Driver", "PrivateIPAddress"))
 		}
 	}
 
@@ -309,6 +319,8 @@ func addAddresses(secrets corecontrollers.SecretCache, config map[string]interfa
 	if convert.ToString(config["cloud-provider-name"]) == "" && (addressProvided || setNodeExternalIP) {
 		config["node-external-ip"] = append(convert.ToStringSlice(config["node-external-ip"]), ipAddress)
 	}
+
+	return nil
 }
 
 func addLabels(config map[string]interface{}, entry *planEntry) error {
@@ -394,8 +406,9 @@ func (p *Planner) addConfigFile(nodePlan plan.NodePlan, controlPlane *rkev1.RKEC
 	addRoleConfig(config, controlPlane, entry, initNode, joinServer)
 	addLocalClusterAuthenticationEndpointConfig(config, controlPlane, entry)
 	addToken(config, entry, tokensSecret)
-	addAddresses(p.secretCache, config, entry)
-
+	if err := addAddresses(p.secretCache, config, entry); err != nil {
+		return nodePlan, config, err
+	}
 	if err := addLabels(config, entry); err != nil {
 		return nodePlan, config, err
 	}

--- a/pkg/provisioningv2/rke2/planner/store.go
+++ b/pkg/provisioningv2/rke2/planner/store.go
@@ -319,9 +319,9 @@ func (p *PlanStore) UpdatePlan(entry *planEntry, plan plan.NodePlan, maxFailures
 	}
 
 	secret = secret.DeepCopy()
-
 	if secret.Data == nil {
-		secret.Data = map[string][]byte{}
+		// Create the map with enough storage for what is needed.
+		secret.Data = make(map[string][]byte, 6)
 	}
 
 	rke2.CopyPlanMetadataToSecret(secret, entry.Metadata)
@@ -438,15 +438,19 @@ func (p *PlanStore) setMachineJoinURL(entry *planEntry, capiCluster *capi.Cluste
 }
 
 func getJoinURLFromOutput(entry *planEntry, capiCluster *capi.Cluster, rkeControlPlane *rkev1.RKEControlPlane) (string, error) {
-	if entry.Plan == nil || !IsEtcdOnlyInitNode(entry) {
+	if entry.Plan == nil || !IsEtcdOnlyInitNode(entry) || capiCluster.Spec.ControlPlaneRef == nil || rkeControlPlane == nil {
 		return "", nil
 	}
 
 	var address []byte
-	if ca, ok := entry.Plan.PeriodicOutput["capture-address"]; ok && ca.ExitCode == 0 && ca.LastSuccessfulRunTime != "" {
-		address = ca.Stdout
-	} else {
+	var name string
+	if ca := entry.Plan.PeriodicOutput[captureAddressInstructionName]; ca.ExitCode != 0 || ca.LastSuccessfulRunTime == "" {
 		return "", nil
+	} else if etcdNameOutput := entry.Plan.PeriodicOutput[etcdNameInstructionName]; etcdNameOutput.ExitCode != 0 || etcdNameOutput.LastSuccessfulRunTime == "" {
+		return "", nil
+	} else {
+		address = ca.Stdout
+		name = string(bytes.TrimSpace(etcdNameOutput.Stdout))
 	}
 
 	var str string
@@ -468,29 +472,27 @@ func getJoinURLFromOutput(entry *planEntry, capiCluster *capi.Cluster, rkeContro
 		return "", err
 	}
 
-	if len(dbInfo.Members) == 0 {
-		return "", nil
+	for _, member := range dbInfo.Members {
+		if member.Name != name {
+			continue
+		}
+
+		u, err := url.Parse(member.ClientURLs[0])
+		if err != nil {
+			return "", err
+		}
+
+		return fmt.Sprintf("https://%s:%d", u.Hostname(), rke2.GetRuntimeSupervisorPort(rkeControlPlane.Spec.KubernetesVersion)), nil
 	}
 
-	if len(dbInfo.Members[0].ClientURLs) == 0 {
-		return "", nil
-	}
-
-	u, err := url.Parse(dbInfo.Members[0].ClientURLs[0])
-	if err != nil {
-		return "", err
-	}
-
-	if capiCluster.Spec.ControlPlaneRef == nil || rkeControlPlane == nil {
-		return "", nil
-	}
-
-	return fmt.Sprintf("https://%s:%d", u.Hostname(), rke2.GetRuntimeSupervisorPort(rkeControlPlane.Spec.KubernetesVersion)), nil
+	// No need to error here because once the plan secret is updated, then this will be retried.
+	return "", nil
 }
 
 type dbinfo struct {
 	Members []member `json:"members,omitempty"`
 }
 type member struct {
+	Name       string   `json:"name,omitempty"`
 	ClientURLs []string `json:"clientURLs,omitempty"`
 }

--- a/pkg/provisioningv2/rke2/planner/store.go
+++ b/pkg/provisioningv2/rke2/planner/store.go
@@ -326,10 +326,8 @@ func (p *PlanStore) UpdatePlan(entry *planEntry, plan plan.NodePlan, maxFailures
 
 	rke2.CopyPlanMetadataToSecret(secret, entry.Metadata)
 
-	// if there are no probes, clear the statuses of the probes to prevent false positives
-	if len(plan.Probes) == 0 {
-		delete(secret.Data, "probe-statuses")
-	}
+	// If the plan is being updated, then delete the probe-statuses so their healthy status will be reported as healthy only when they pass.
+	delete(secret.Data, "probe-statuses")
 
 	secret.Data["plan"] = data
 	if maxFailures > 0 || maxFailures == -1 {


### PR DESCRIPTION
Issues: 
https://github.com/rancher/rancher/issues/37500
https://github.com/rancher/rancher/issues/37501
https://github.com/rancher/rancher/issues/37502

There were several issues related to IP addresses that were causing issues with
RKE2 provisioning and multiple etcd-only nodes.

1. If there were multiple etcd-only nodes, then joinURL may change and be for
another node when the scraping happens. The reason was that the clientURLs would
be listed for each etcd node. When Rancher was scraping it, it was taking the
first one no matter what which may have been for another node.

The fix here is to add an addition periodic instruction to "cat" the db name
file and use it to identify the clientURL with the correct node.

2. The machine plan for the bootstrap node may have been created before the
machine had finished being created and the config saved to the machine state
secret. This would cause the plan to be missing IP addresses. Then, then next
plan would have the IP addresses, causing the cluster to look like it was
re-provisioning. If the user enabled the "drain on upgrade" feature, then the
nodes would all drain and their plan updated.

The fix here is to wait to assign a bootstrap node until we know that the
machine has finished creating, so that the machine state has the IP addresses,
if they are going to be available. Note that Rancher will not error if no IP
addresses are found because there may not be any depending on the provider.

3. Join URLs were being set in multiple places.

The fix here is to only set them in one place.

4. When getting the control plane join URL, Rancher was taking the URL from the
first control plane node that it found a join URL on. This could cause the join
URL to change after the node is bootstrapped.

The first control plane join URL is returned, regardless if it is set. This
ensures that join URL won't change after it is set on initial bootstrapping.

Additionally, the system-agent will not set the probes as failed on the first failure
if the failure threshold is greater than 1. This is proper and expected.

However, if the plan is updated, we don't want to wait for the
failure-threshold. If the probes pass on the first try, then
system-agent will update them as such and Rancher will move on. However,
if the probes fail on the first try after the plan is updated, then
system-agent won't set the probe as successful and Rancher will wait for
successful probes before moving on.

## Testing
Deployed clusters of various types in Linode to ensure the referenced issues were working as expected.