### PR TITLE
Stop creating ClusterAuthToken on kubeconfig generation if token hashing disabled

### DIFF
--- a/pkg/api/norman/customization/cluster/actions_kubeconfig.go
+++ b/pkg/api/norman/customization/cluster/actions_kubeconfig.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/pkg/features"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/kubeconfig"
+	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -65,29 +66,8 @@ func (a ActionHandler) GenerateKubeconfigActionHandler(actionName string, action
 	}
 
 	if endpointEnabled {
-		if features.TokenHashing.Enabled() {
-			clusterName := apiContext.ID
-			clusterClient, err := a.ClusterManager.UserContextNoControllers(clusterName)
-			if err != nil {
-				return err
-			}
-
-			if tokenKey != "" {
-				tokenName, tokenValue := tokens.SplitTokenParts(tokenKey)
-				// a lister is not used here because the token was recently created, therefore the lister would likely miss
-				token, err := a.TokenClient.Get(tokenName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				clusterAuthToken, err := common.NewClusterAuthToken(token, tokenValue)
-				if err != nil {
-					return err
-				}
-
-				if _, err = clusterClient.Cluster.ClusterAuthTokens("cattle-system").Create(clusterAuthToken); err != nil {
-					return err
-				}
-			}
+		if err = a.createClusterAuthTokenDownstream(apiContext.ID, tokenKey); err != nil {
+			return err
 		}
 
 		cfg, err = kubeconfig.ForClusterTokenBased(&cluster, nodes, apiContext.ID, host, tokenKey)
@@ -106,5 +86,41 @@ func (a ActionHandler) GenerateKubeconfigActionHandler(actionName string, action
 		"type":   "generateKubeconfigOutput",
 	}
 	apiContext.WriteResponse(http.StatusOK, data)
+	return nil
+}
+
+// createClusterAuthTokenDownstream will create a ClusterAuthToken in the downstream cluster if the token hashing feature flag is enabled.
+// This is required because, if the token hashing is enabled, then the controller will not be able to create the ClusterAuthToken
+// in the downstream cluster because the token is stored hashed in the local cluster.
+// If the token hashing feature flag is disabled, then this function is a no-op and the corresponding controller will create it.
+// The reason the controller will create it in the second case is that a user may want to create a kubeconfig for the cluster
+// before the cluster is active. Since the tokens are not hashed, then the controller can create the ClusterAuthToken in the downstream
+// cluster when the cluster is ready and the action handler can return successfully.
+func (a ActionHandler) createClusterAuthTokenDownstream(clusterName, tokenKey string) error {
+	if features.TokenHashing.Enabled() {
+		clusterClient, err := a.ClusterManager.UserContextNoControllers(clusterName)
+		if err != nil {
+			return err
+		}
+
+		if tokenKey != "" {
+			tokenName, tokenValue := tokens.SplitTokenParts(tokenKey)
+			// A lister is not used here because the token was recently created, therefore the lister would likely miss
+			token, err := a.TokenClient.Get(tokenName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			clusterAuthToken, err := common.NewClusterAuthToken(token, tokenValue)
+			if err != nil {
+				return err
+			}
+
+			if _, err = clusterClient.Cluster.ClusterAuthTokens(namespace.System).Create(clusterAuthToken); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }

--- a/pkg/controllers/management/feature/feature_handler.go
+++ b/pkg/controllers/management/feature/feature_handler.go
@@ -68,7 +68,7 @@ func (h *handler) refreshTokens() error {
 		return err
 	}
 	for _, token := range tokenList {
-		if token.Labels != nil && token.Labels[tokens.TokenHashed] == "true" {
+		if token.Labels[tokens.TokenHashed] == "true" {
 			continue
 		}
 		h.tokenEnqueue(token.Name, 10*time.Second)


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/37147

## Problem
A previous change added token hashing implementation. When token hashing is
enabled, then ClusterAuthToken must be created in the downstream cluster when
the kubeconfig is generated. This means that the kubeconfig cannot be generated
until the cluster is active. If token hashing is disabled, then this requirement
is not needed and the kubeconfig can be generated without requiring that the
ClusterAuthToken be created in the downstream cluster.

## Solution
This change will check the token hashing feature flag when generating a
kubeconfig and will not create the ClusterAuthToken. In addition, the
controller that would create the ClusterAuthToken in the downstream cluster is
restored to create the ClusterAuthToken if token hashing is disabled.

## Testing
Creating kubeconfigs for clusters with token-hashing enabled and disabled with the cluster in various states (Provisioning, Updating, Active).