### PR TITLE
[2.6.6] Only check cattle-system for existing plans

### DIFF
--- a/pkg/controllers/management/k3sbasedupgrade/deployPlans.go
+++ b/pkg/controllers/management/k3sbasedupgrade/deployPlans.go
@@ -73,7 +73,7 @@ func (h *handler) deployPlans(cluster *v3.Cluster, isK3s, isRke2 bool) error {
 			}
 			plan.Spec.NodeSelector.MatchExpressions = append(plan.Spec.NodeSelector.MatchExpressions, lsr)
 
-			_, err = planClient.Update(context.TODO(), &plan, metav1.UpdateOptions{})
+			_, err = planConfig.Plans(plan.Namespace).Update(context.TODO(), &plan, metav1.UpdateOptions{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Root cause

Rancher was checking all namespaces for plans, and trying to update ones not currently managed by rancher in order to force rancher to manage them. By reusing the same client (created using `metav1.NamespaceAll`, the generated client (wrangler uses the kubernetes client generator) uses the namespace of the client in the API request, which is always empty so the object cannot be updated. 

### What was fixed, or what changes have occurred

Now rancher will create a separate client for the namespace it finds existing plans in, and disables all plans not managed by rancher.

### Areas or cases that should be tested

Creating plans manually in any namespace should result in them being disabled, unless they are explicitly managed by rancher.
 
### What areas could experience regressions?

Currently, all non rancher-managed plans will be disabled once an upgrade is started, due to uncertainty around what other plans could exist and possible implications they may have during an upgrade.

### Are the repro steps accurate/minimal?

- Deploy suc in a custom cluster in any namespace other than cattle-system
- Create a plan in this namespace
- When the custom cluster is upgraded, all other plans should be disabled

Related Issue: https://github.com/rancher/rancher/issues/36607

SURE-4141