### PR TITLE
[2.6.6] Adding Storage-Opts and Log-Opts to NodeCommonParams

### DIFF
--- a/pkg/apis/management.cattle.io/v3/machine_types.go
+++ b/pkg/apis/management.cattle.io/v3/machine_types.go
@@ -255,6 +255,8 @@ type NodeCommonParams struct {
 	EngineInstallURL         string            `json:"engineInstallURL,omitempty"`
 	DockerVersion            string            `json:"dockerVersion,omitempty"`
 	EngineOpt                map[string]string `json:"engineOpt,omitempty"`
+	StorageOpt               map[string]string `json:"storageOpt,omitempty"`
+	LogOpt                   map[string]string `json:"logOpt,omitempty"`
 	EngineInsecureRegistry   []string          `json:"engineInsecureRegistry,omitempty"`
 	EngineRegistryMirror     []string          `json:"engineRegistryMirror,omitempty"`
 	EngineLabel              map[string]string `json:"engineLabel,omitempty"`

--- a/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -6084,6 +6084,20 @@ func (in *NodeCommonParams) DeepCopyInto(out *NodeCommonParams) {
 			(*out)[key] = val
 		}
 	}
+	if in.StorageOpt != nil {
+		in, out := &in.StorageOpt, &out.StorageOpt
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.LogOpt != nil {
+		in, out := &in.LogOpt, &out.LogOpt
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.EngineInsecureRegistry != nil {
 		in, out := &in.EngineInsecureRegistry, &out.EngineInsecureRegistry
 		*out = make([]string, len(*in))

--- a/pkg/client/generated/management/v3/zz_generated_node_template.go
+++ b/pkg/client/generated/management/v3/zz_generated_node_template.go
@@ -23,12 +23,14 @@ const (
 	NodeTemplateFieldEngineRegistryMirror     = "engineRegistryMirror"
 	NodeTemplateFieldEngineStorageDriver      = "engineStorageDriver"
 	NodeTemplateFieldLabels                   = "labels"
+	NodeTemplateFieldLogOpt                   = "logOpt"
 	NodeTemplateFieldName                     = "name"
 	NodeTemplateFieldNodeTaints               = "nodeTaints"
 	NodeTemplateFieldOwnerReferences          = "ownerReferences"
 	NodeTemplateFieldRemoved                  = "removed"
 	NodeTemplateFieldState                    = "state"
 	NodeTemplateFieldStatus                   = "status"
+	NodeTemplateFieldStorageOpt               = "storageOpt"
 	NodeTemplateFieldTransitioning            = "transitioning"
 	NodeTemplateFieldTransitioningMessage     = "transitioningMessage"
 	NodeTemplateFieldUUID                     = "uuid"
@@ -54,12 +56,14 @@ type NodeTemplate struct {
 	EngineRegistryMirror     []string            `json:"engineRegistryMirror,omitempty" yaml:"engineRegistryMirror,omitempty"`
 	EngineStorageDriver      string              `json:"engineStorageDriver,omitempty" yaml:"engineStorageDriver,omitempty"`
 	Labels                   map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
+	LogOpt                   map[string]string   `json:"logOpt,omitempty" yaml:"logOpt,omitempty"`
 	Name                     string              `json:"name,omitempty" yaml:"name,omitempty"`
 	NodeTaints               []Taint             `json:"nodeTaints,omitempty" yaml:"nodeTaints,omitempty"`
 	OwnerReferences          []OwnerReference    `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
 	Removed                  string              `json:"removed,omitempty" yaml:"removed,omitempty"`
 	State                    string              `json:"state,omitempty" yaml:"state,omitempty"`
 	Status                   *NodeTemplateStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	StorageOpt               map[string]string   `json:"storageOpt,omitempty" yaml:"storageOpt,omitempty"`
 	Transitioning            string              `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
 	TransitioningMessage     string              `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
 	UUID                     string              `json:"uuid,omitempty" yaml:"uuid,omitempty"`

--- a/pkg/client/generated/management/v3/zz_generated_node_template_spec.go
+++ b/pkg/client/generated/management/v3/zz_generated_node_template_spec.go
@@ -16,7 +16,9 @@ const (
 	NodeTemplateSpecFieldEngineOpt                = "engineOpt"
 	NodeTemplateSpecFieldEngineRegistryMirror     = "engineRegistryMirror"
 	NodeTemplateSpecFieldEngineStorageDriver      = "engineStorageDriver"
+	NodeTemplateSpecFieldLogOpt                   = "logOpt"
 	NodeTemplateSpecFieldNodeTaints               = "nodeTaints"
+	NodeTemplateSpecFieldStorageOpt               = "storageOpt"
 	NodeTemplateSpecFieldUseInternalIPAddress     = "useInternalIpAddress"
 )
 
@@ -35,6 +37,8 @@ type NodeTemplateSpec struct {
 	EngineOpt                map[string]string `json:"engineOpt,omitempty" yaml:"engineOpt,omitempty"`
 	EngineRegistryMirror     []string          `json:"engineRegistryMirror,omitempty" yaml:"engineRegistryMirror,omitempty"`
 	EngineStorageDriver      string            `json:"engineStorageDriver,omitempty" yaml:"engineStorageDriver,omitempty"`
+	LogOpt                   map[string]string `json:"logOpt,omitempty" yaml:"logOpt,omitempty"`
 	NodeTaints               []Taint           `json:"nodeTaints,omitempty" yaml:"nodeTaints,omitempty"`
+	StorageOpt               map[string]string `json:"storageOpt,omitempty" yaml:"storageOpt,omitempty"`
 	UseInternalIPAddress     *bool             `json:"useInternalIpAddress,omitempty" yaml:"useInternalIpAddress,omitempty"`
 }

--- a/pkg/controllers/management/node/utils.go
+++ b/pkg/controllers/management/node/utils.go
@@ -59,6 +59,8 @@ func buildCreateCommand(node *v3.Node, configMap map[string]interface{}) []strin
 
 	cmd = append(cmd, buildEngineOpts("--engine-install-url", []string{node.Status.NodeTemplateSpec.EngineInstallURL})...)
 	cmd = append(cmd, buildEngineOpts("--engine-opt", mapToSlice(node.Status.NodeTemplateSpec.EngineOpt))...)
+	cmd = append(cmd, buildEngineOpts("--engine-opt", storageOptMapToSlice(node.Status.NodeTemplateSpec.StorageOpt))...)
+	cmd = append(cmd, buildEngineOpts("--engine-opt", logOptMapToSlice(node.Status.NodeTemplateSpec.LogOpt))...)
 	cmd = append(cmd, buildEngineOpts("--engine-env", mapToSlice(node.Status.NodeTemplateSpec.EngineEnv))...)
 	cmd = append(cmd, buildEngineOpts("--engine-insecure-registry", node.Status.NodeTemplateSpec.EngineInsecureRegistry)...)
 	cmd = append(cmd, buildEngineOpts("--engine-label", mapToSlice(node.Status.NodeTemplateSpec.EngineLabel))...)
@@ -107,9 +109,25 @@ func buildEngineOpts(name string, values []string) []string {
 }
 
 func mapToSlice(m map[string]string) []string {
-	var ret []string
+	ret := make([]string, len(m))
 	for k, v := range m {
 		ret = append(ret, fmt.Sprintf("%s=%s", k, v))
+	}
+	return ret
+}
+
+func storageOptMapToSlice(m map[string]string) []string {
+	ret := make([]string, len(m))
+	for k, v := range m {
+		ret = append(ret, fmt.Sprintf("storage-opt %s=%s", k, v))
+	}
+	return ret
+}
+
+func logOptMapToSlice(m map[string]string) []string {
+	ret := make([]string, len(m))
+	for k, v := range m {
+		ret = append(ret, fmt.Sprintf("log-opt %s=%s", k, v))
 	}
 	return ret
 }


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/28859
 
# Problem
 
When creating Node Templates in the UI, users were unable to provide the `--storage-opt` and `--log-opt` flags multiple times within the `Engine Options` field. This prevented users from being able to manage their storage driver and log driver configurations within the UI.
 
# Solution
 
Add two new fields to the `NodeCommonParams`: `StorageOpt` and `LogOpt`, which will contain the storage-driver and log-driver configuration. These two new fields are used to pass the `--storage-opt` and `--log-opt` flag to rancher-machine as many times as needed.
 
# Testing
 
Testing this PR without the associated UI elements is a bit tricky, here are the steps I've done to verify this PR is working as expected: 


1. In the Rancher UI go to the Node Templates section (cluster management -> RKE1 Configuration -> Node Templates)
2. Start to create a new node template for your desired cloud provider
3. For storage-driver, input `devicemapper`
4. Before pressing save, right click and inspect the page (right click -> inspect) 
5. Go to the `Network` section
6. Press `Save` in the rancher UI
7. There should be a new item in the `Network` section, titled `nodetemplate`, right click it and copy it as cURL
8. Paste the curl request into a text editor, and add the following fields to the JSON payload

```
"storageOpt": {
    "dm.directlvm_device_force": "false"
  },
"logOpt": {
    "max-file": "2",
    "max-size": "10m"
  },
```

9. Send the CURL request using your terminal
10. Create a new cluster using this updated node template
11. observe the cluster go into an `active` state 
12. To verify that the docker daemon received these storage and log options, SSH into the node and run this command `cat /etc/systemd/system/docker.service.d/10-machine.conf` and look at the `ExecStart` section of that file for these new flags