### PR TITLE
Fix windows image lists for airgap

### DIFF
--- a/pkg/image/external/external.go
+++ b/pkg/image/external/external.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/rancher/rancher/pkg/settings"
+
 	"github.com/coreos/go-semver/semver"
 	"github.com/rancher/rancher/pkg/controllers/management/k3sbasedupgrade"
 	"github.com/sirupsen/logrus"
@@ -92,6 +94,8 @@ func GetExternalImages(rancherVersion string, externalData map[string]interface{
 		// Registries don't allow "+", so image names will have these substituted.
 		upgradeImage := fmt.Sprintf("rancher/%s-upgrade:%s", source, strings.Replace(release, "+", "-", -1))
 		externalImagesMap[upgradeImage] = true
+		systemAgentInstallerImage := fmt.Sprintf("%s%s:%s", settings.SystemAgentInstallerImage.Get(), source, strings.Replace(release, "+", "-", -1))
+		externalImagesMap[systemAgentInstallerImage] = true
 
 		images, err := downloadExternalSupportingImages(release, source)
 		if err != nil {
@@ -122,19 +126,32 @@ func GetExternalImages(rancherVersion string, externalData map[string]interface{
 }
 
 func downloadExternalSupportingImages(release string, source Source) (string, error) {
-	var url string
 	switch source {
 	case RKE2:
 		// The "images-all" file is only provided for RKE2 amd64 images. This may be subject to change.
-		url = fmt.Sprintf("https://github.com/rancher/rke2/releases/download/%s/rke2-images-all.linux-amd64.txt", release)
+		linuxImages, err := downloadExternalImageListFromURL(fmt.Sprintf("https://github.com/rancher/rke2/releases/download/%s/rke2-images-all.linux-amd64.txt", release))
+		if err != nil {
+			return "", err
+		}
+		windowsImages, err := downloadExternalImageListFromURL(fmt.Sprintf("https://github.com/rancher/rke2/releases/download/%s/rke2-images.windows-amd64.txt", release))
+		if err != nil {
+			return "", err
+		}
+		builder := strings.Builder{}
+		builder.WriteString(linuxImages)
+		builder.WriteString("\n")
+		builder.WriteString(windowsImages)
+		return builder.String(), nil
 	case K3S:
-		url = fmt.Sprintf("https://github.com/k3s-io/k3s/releases/download/%s/k3s-images.txt", release)
+		return downloadExternalImageListFromURL(fmt.Sprintf("https://github.com/k3s-io/k3s/releases/download/%s/k3s-images.txt", release))
 	default:
 		// This function should never be called with an invalid source, but we will anticipate this
 		// error for safety.
 		return "", fmt.Errorf("invalid source provided for download: %s", source)
 	}
+}
 
+func downloadExternalImageListFromURL(url string) (string, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return "", err

--- a/pkg/image/external/external.go
+++ b/pkg/image/external/external.go
@@ -7,10 +7,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/rancher/rancher/pkg/settings"
-
 	"github.com/coreos/go-semver/semver"
 	"github.com/rancher/rancher/pkg/controllers/management/k3sbasedupgrade"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/sirupsen/logrus"
 )
 
@@ -92,9 +91,9 @@ func GetExternalImages(rancherVersion string, externalData map[string]interface{
 
 	for _, release := range compatibleReleases {
 		// Registries don't allow "+", so image names will have these substituted.
-		upgradeImage := fmt.Sprintf("rancher/%s-upgrade:%s", source, strings.Replace(release, "+", "-", -1))
+		upgradeImage := fmt.Sprintf("rancher/%s-upgrade:%s", source, strings.ReplaceAll(release, "+", "-"))
 		externalImagesMap[upgradeImage] = true
-		systemAgentInstallerImage := fmt.Sprintf("%s%s:%s", settings.SystemAgentInstallerImage.Get(), source, strings.Replace(release, "+", "-", -1))
+		systemAgentInstallerImage := fmt.Sprintf("%s%s:%s", settings.SystemAgentInstallerImage.Default, source, strings.ReplaceAll(release, "+", "-"))
 		externalImagesMap[systemAgentInstallerImage] = true
 
 		images, err := downloadExternalSupportingImages(release, source)

--- a/pkg/image/external/external_test.go
+++ b/pkg/image/external/external_test.go
@@ -1,0 +1,244 @@
+package external
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/rancher/rke/types/kdm"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	k3s            = "k3s"
+	rancherVersion = "v2.6.4"
+	k3sWebVersion  = "v1.23.6+k3s1"
+	rke2WebVersion = "v1.23.6+rke2r1"
+	rke2           = "rke2"
+	rke1           = "rke1"
+	devKDM         = "https://github.com/rancher/kontainer-driver-metadata/raw/dev-v2.6/data/data.json"
+	releaseKDM     = "https://releases.rancher.com/kontainer-driver-metadata/release-v2.6/data.json"
+)
+
+func TestGetExternalImages(t *testing.T) {
+	kubeSemVer := &semver.Version{
+		Major: 1,
+		Minor: 21,
+		Patch: 0,
+	}
+
+	type args struct {
+		rancherVersion           string
+		externalData             map[string]interface{}
+		source                   Source
+		minimumKubernetesVersion *semver.Version
+		kdmUrl                   string
+		image1                   string
+		image2                   string
+		image3                   string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "k3s-test",
+			args: args{
+				rancherVersion:           rancherVersion,
+				externalData:             map[string]interface{}{},
+				source:                   k3s,
+				minimumKubernetesVersion: kubeSemVer,
+				kdmUrl:                   devKDM,
+				image1:                   "rancher/klipper-lb:v0.3.5",
+				image2:                   "rancher/mirrored-pause:3.6",
+				image3:                   "rancher/mirrored-metrics-server:v0.5.2",
+			},
+			wantErr: false,
+		},
+		{
+			name: "rke2-test",
+			args: args{
+				rancherVersion:           rancherVersion,
+				externalData:             map[string]interface{}{},
+				source:                   rke2,
+				minimumKubernetesVersion: kubeSemVer,
+				kdmUrl:                   releaseKDM,
+				image1:                   "rancher/pause:3.6",
+				image2:                   "rancher/rke2-runtime:v1.23.6-rke2r1",
+				image3:                   "rancher/rke2-cloud-provider:v0.0.3-build20211118",
+			},
+			wantErr: false,
+		},
+		{
+			name: "rke1-test-fail",
+			args: args{
+				rancherVersion:           rancherVersion,
+				externalData:             map[string]interface{}{},
+				source:                   rke1,
+				minimumKubernetesVersion: kubeSemVer,
+				kdmUrl:                   releaseKDM,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+			get, err := http.Get(tt.args.kdmUrl)
+			if err != nil {
+				t.Errorf("failed to get KDM data.json from url %v", tt.args.kdmUrl)
+			}
+			resp, err := ioutil.ReadAll(get.Body)
+			if err != nil {
+				t.Errorf("failed to read response from url %v", tt.args.kdmUrl)
+			}
+			data, err := kdm.FromData(resp)
+			if err != nil {
+				t.Error(err)
+			}
+			switch tt.args.source {
+			case rke2:
+				tt.args.externalData = data.RKE2
+			case k3s:
+				tt.args.externalData = data.K3S
+			}
+			got, err := GetExternalImages(tt.args.rancherVersion, tt.args.externalData, tt.args.source, tt.args.minimumKubernetesVersion)
+			if err != nil {
+				a.Equal(tt.wantErr, true, "GetExternalImages() errored as expected")
+			}
+			if !tt.wantErr {
+				a.NotEmpty(got)
+				a.Contains(got, tt.args.image1)
+				a.Contains(got, tt.args.image2)
+				a.Contains(got, tt.args.image3)
+			}
+		})
+	}
+}
+
+func Test_downloadExternalImageListFromURL(t *testing.T) {
+	type args struct {
+		url    string
+		image1 string
+		image2 string
+		image3 string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "k3s-url",
+			args: args{
+				url:    fmt.Sprintf("https://github.com/k3s-io/k3s/releases/download/%s/k3s-images.txt", k3sWebVersion),
+				image1: "rancher/klipper-lb:v0.3.5",
+				image2: "rancher/mirrored-pause:3.6",
+				image3: "rancher/mirrored-metrics-server:v0.5.2",
+			},
+		},
+		{
+			name: "rke2-url-linux",
+			args: args{
+				url:    fmt.Sprintf("https://github.com/rancher/rke2/releases/download/%s/rke2-images-all.linux-amd64.txt", rke2WebVersion),
+				image1: "rancher/pause:3.6",
+				image2: "rancher/rke2-runtime:v1.23.6-rke2r1",
+				image3: "rancher/rke2-cloud-provider:v0.0.3-build20211118",
+			},
+		},
+		{
+			name: "rke2-url-windows",
+			args: args{
+				url:    fmt.Sprintf("https://github.com/rancher/rke2/releases/download/%s/rke2-images.windows-amd64.txt", rke2WebVersion),
+				image1: "docker.io/rancher/rke2-runtime:v1.23.6-rke2r1-windows-amd64",
+				image2: "rancher/pause:3.6-windows-1809-amd64",
+				image3: "rancher/pause:3.6-windows-ltsc2022-amd64",
+			},
+		},
+		{
+			name: "rancher-url",
+			args: args{
+				url:    fmt.Sprintf("https://github.com/rancher/rancher/releases/download/%s/rancher-images.txt", rancherVersion),
+				image1: "fleet-agent:v0.3.9",
+				image2: "rancher/system-agent-installer-rke2:v1.23.4-rke2r2",
+				image3: "rancher/rancher-agent:" + rancherVersion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+			got, err := downloadExternalImageListFromURL(tt.args.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("downloadExternalImageListFromURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			a.NotEmpty(got)
+			a.Contains(got, tt.args.image1)
+			a.Contains(got, tt.args.image2)
+			a.Contains(got, tt.args.image3)
+		})
+	}
+}
+
+func Test_downloadExternalSupportingImages(t *testing.T) {
+	type args struct {
+		release string
+		source  Source
+		image1  string
+		image2  string
+		image3  string
+		image4  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "k3s-images",
+			args: args{
+				release: k3sWebVersion,
+				source:  k3s,
+				image1:  "rancher/klipper-lb:v0.3.5",
+				image2:  "rancher/mirrored-pause:3.6",
+				image3:  "rancher/mirrored-coredns-coredns:1.9.1",
+				image4:  "rancher/mirrored-metrics-server:v0.5.2",
+			},
+		},
+		{
+			name: "rke2-images",
+			args: args{
+				release: rke2WebVersion,
+				source:  rke2,
+				image1:  "rancher/harvester-csi-driver:v0.1.3",
+				image2:  "rancher/rke2-runtime:v1.23.6-rke2r1",
+				image3:  "rancher/rke2-runtime:v1.23.6-rke2r1-windows-amd64",
+				image4:  "rancher/rke2-cloud-provider:v0.0.3-build20211118",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
+			got, err := downloadExternalSupportingImages(url.QueryEscape(tt.args.release), tt.args.source)
+			if err != nil {
+				t.Errorf("downloadExternalSupportingImages() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			a.NotEmpty(got)
+			a.Contains(got, tt.args.image1)
+			a.Contains(got, tt.args.image2)
+			a.Contains(got, tt.args.image3)
+			a.Contains(got, tt.args.image4)
+		})
+	}
+}


### PR DESCRIPTION
### Summary
Fixes https://github.com/rancher/rancher/issues/37577


### Occurred changes and/or fixed issues
Ensures that the required images for rke2 Windows functionality in airgap are present in the published rancher images lists

### Technical notes summary
I lightly refactored external.go and broke our the download function for urls as well as simplified the downloadExternalSupportingImages function.

### Areas or cases that should be tested

The unit tests validate that the changes are working as expected. However, a full airgap validation is required to definitively know.

### Areas which could experience regressions

These changes should not regress any existing functionality.

### Screenshot/Video

Output from unit tests with latest changes:

```console
=== RUN   TestGetExternalImages
--- PASS: TestGetExternalImages (8.15s)
=== RUN   TestGetExternalImages/k3s-test
time="2022-05-04T21:54:46-04:00" level=info msg="generating k3s image list..."
time="2022-05-04T21:54:49-04:00" level=info msg="finished generating k3s image list..."
    --- PASS: TestGetExternalImages/k3s-test (2.77s)
=== RUN   TestGetExternalImages/rke2-test
time="2022-05-04T21:54:49-04:00" level=info msg="generating rke2 image list..."
time="2022-05-04T21:54:54-04:00" level=info msg="finished generating rke2 image list..."
    --- PASS: TestGetExternalImages/rke2-test (4.91s)
=== RUN   TestGetExternalImages/rke1-test-fail
    --- PASS: TestGetExternalImages/rke1-test-fail (0.47s)
=== RUN   Test_downloadExternalImageListFromURL
--- PASS: Test_downloadExternalImageListFromURL (0.33s)
=== RUN   Test_downloadExternalImageListFromURL/k3s-url
    --- PASS: Test_downloadExternalImageListFromURL/k3s-url (0.05s)
=== RUN   Test_downloadExternalImageListFromURL/rke2-url-linux
    --- PASS: Test_downloadExternalImageListFromURL/rke2-url-linux (0.05s)
=== RUN   Test_downloadExternalImageListFromURL/rke2-url-windows
    --- PASS: Test_downloadExternalImageListFromURL/rke2-url-windows (0.08s)
=== RUN   Test_downloadExternalImageListFromURL/rancher-url
    --- PASS: Test_downloadExternalImageListFromURL/rancher-url (0.15s)
=== RUN   Test_downloadExternalSupportingImages
--- PASS: Test_downloadExternalSupportingImages (0.40s)
=== RUN   Test_downloadExternalSupportingImages/k3s-images
    --- PASS: Test_downloadExternalSupportingImages/k3s-images (0.16s)
=== RUN   Test_downloadExternalSupportingImages/rke2-images
    --- PASS: Test_downloadExternalSupportingImages/rke2-images (0.24s)
PASS

Process finished with the exit code 0
```

