### PR TITLE
Deliver etcd/controlplane plans after snapshot creation to avoid drain

### DIFF
--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -293,7 +293,7 @@ func (p *Planner) Process(controlPlane *rkev1.RKEControlPlane) error {
 		joinServer       string
 	)
 
-	if errs := p.createEtcdSnapshot(controlPlane, plan); len(errs) > 0 {
+	if errs := p.createEtcdSnapshot(controlPlane, clusterSecretTokens, plan); len(errs) > 0 {
 		var errMsg string
 		for i, err := range errs {
 			if err == nil {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/37575

The reported issue was that the etcd nodes were drained after an etcd snapshot was created. This is caused due to the fact that etcd snapshot creation is done by replacing the plan on etcd nodes with an `%s etcd-snapshot` command.

Originally, we relied on the next step in the iterative `planner.Process` to reconcile the plans on the etcd nodes back to the desired state (which is just the install script of the runtime). If drain on upgrade is enabled, reconcile would attempt to drain the etcd nodes before applying the install script command. 

We are now adding an additional phase to etcd snapshot creation, which will replace the plan of etcd nodes back to the install script. This means that when the etcd snapshot creation is complete, the next reconcile commands don't need to drain the nodes as the plans are already at desired state -- we are essentially short circuiting the reconcile and resetting the plans back to their prior state.

Note, this is not going to fix the `reconciling` state of the cluster when an etcd snapshot is created. Fixing this on the backend is prohibitively difficult, and the display of reconciling is only a visual and not a cause for concern.