### PR TITLE
[release/v2.6] Bump RKE to v1.3.11-rc2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20220318232944-60e3994094da
-	github.com/rancher/rke v1.3.10
+	github.com/rancher/rke v1.3.11-rc2
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20220415184129-b23977e7f1b5
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007

--- a/go.sum
+++ b/go.sum
@@ -1288,8 +1288,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8w
 github.com/rancher/remotedialer v0.2.6-0.20220104192242-f3837f8d649a/go.mod h1:vq3LvyOFnLcwMiCE1KdW3foPd6g5kAjZOtOb7JqGHck=
 github.com/rancher/remotedialer v0.2.6-0.20220318232944-60e3994094da h1:lgWIKxaHc6oYGC21OOYyOW2/6yE7xOJ17szsL777gWg=
 github.com/rancher/remotedialer v0.2.6-0.20220318232944-60e3994094da/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
-github.com/rancher/rke v1.3.10 h1:q0C21ASzTpfVr7LyzLYel/VjMesyJiP1zFRkGl7Q3FY=
-github.com/rancher/rke v1.3.10/go.mod h1:t+VWWY6Cxs1OjRXRFQv+gZNWSfmFor9UReReDjYOnWs=
+github.com/rancher/rke v1.3.11-rc2 h1:YPfeK8gZzTfTcJof8ALto8y+jz1R3MvCavYQuKC8UQk=
+github.com/rancher/rke v1.3.11-rc2/go.mod h1:t+VWWY6Cxs1OjRXRFQv+gZNWSfmFor9UReReDjYOnWs=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
 github.com/rancher/steve v0.0.0-20220415184129-b23977e7f1b5 h1:+1shpXAvnskvlMtcjse8oOi2tyPNNDO3LtThjfRoSt0=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210918015053-5a141a6b18f0
 	github.com/rancher/gke-operator v1.1.3
 	github.com/rancher/norman v0.0.0-20220406153559-82478fb169cb
-	github.com/rancher/rke v1.3.10
+	github.com/rancher/rke v1.3.11-rc2
 	github.com/rancher/wrangler v0.8.11-0.20220411195911-c2b951ab3480
 	github.com/sirupsen/logrus v1.8.1
 	k8s.io/api v0.23.3

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -744,8 +744,8 @@ github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08/go.mod h1:9qZd/S8DqW
 github.com/rancher/machine v0.15.0-rancher63/go.mod h1:qXYNumxy0J08MO/mh/jNjyRuEc2QKDLUOZIBE5vxaZE=
 github.com/rancher/norman v0.0.0-20220406153559-82478fb169cb h1:Tr5rialcd0u13TPRFekmCzwZNalLs5lbg6JSliUD0gY=
 github.com/rancher/norman v0.0.0-20220406153559-82478fb169cb/go.mod h1:gDEwYUxOknJaOG1jjcH40PQ8U8xnvB+sHph5VirKINY=
-github.com/rancher/rke v1.3.10 h1:q0C21ASzTpfVr7LyzLYel/VjMesyJiP1zFRkGl7Q3FY=
-github.com/rancher/rke v1.3.10/go.mod h1:t+VWWY6Cxs1OjRXRFQv+gZNWSfmFor9UReReDjYOnWs=
+github.com/rancher/rke v1.3.11-rc2 h1:YPfeK8gZzTfTcJof8ALto8y+jz1R3MvCavYQuKC8UQk=
+github.com/rancher/rke v1.3.11-rc2/go.mod h1:t+VWWY6Cxs1OjRXRFQv+gZNWSfmFor9UReReDjYOnWs=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
 github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224/go.mod h1:I7qe4DZNMOLKVa9ax7DJdBZ0XtKOppLF/dalhPX3vaE=

--- a/scripts/go-get
+++ b/scripts/go-get
@@ -5,10 +5,6 @@ VERSION=$GOGET_VERSION
 
 SUBDIRS="pkg/apis pkg/client"
 
-go get -d "${MODULE}@${VERSION}"
-go mod tidy
-go mod verify
-
 for SUBDIR in $SUBDIRS; do
     if grep -q $MODULE "${SUBDIR}/go.mod"; then
         cd $SUBDIR
@@ -18,3 +14,7 @@ for SUBDIR in $SUBDIRS; do
         cd -
     fi
 done
+
+go get -d "${MODULE}@${VERSION}"
+go mod tidy
+go mod verify


### PR DESCRIPTION
Used the new make target `go-get`: `GOGET_MODULE=github.com/rancher/rke GOGET_VERSION=v1.3.11-rc2 make go-get`, but needed a reverse in order as `go.sum` didn't get cleaned up properly.

