### PR TITLE
Drop unnecessary cluster spec fields to prevent unnecessary plan thrashing

### DIFF
--- a/pkg/apis/provisioning.cattle.io/v1/rke.go
+++ b/pkg/apis/provisioning.cattle.io/v1/rke.go
@@ -63,6 +63,11 @@ type RKEMachinePoolRollingUpdate struct {
 	MaxSurge *intstr.IntOrString `json:"maxSurge,omitempty"`
 }
 
+// Note: if you add new fields to the RKEConfig, please ensure that you check
+// `pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go` file and
+// drop the fields when saving a copy of the cluster spec on etcd snapshots, otherwise,
+// operations using the new fields will cause unnecessary plan thrashing.
+
 type RKEConfig struct {
 	rkev1.RKEClusterSpecCommon
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/37613

There is a potential issue where utility operations cause unnecessary thrashing of the controlplane nodes (i.e. unnecessary draining).

This PR removes storage of the various utility fields for the RKE config struct to ensure that the RKE config does not change unnecessarily on operations like etcd snapshot creation.