### PR TITLE
Properly correlate local snapshot to node when cloudprovider changes …

### DIFF
--- a/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
+++ b/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
@@ -146,7 +146,7 @@ func (h *handler) OnChange(key string, configMap *corev1.ConfigMap) (runtime.Obj
 					// If the machineID label was not set, fall back to looking up the machine by node name, as this may be a snapshot from an earlier version of Rancher that created local snapshots using the snapshotbackpopulate controller, which means the snapshot should not have the machine ID label.
 					listSuccessful, machine, err = rke2.GetMachineFromNode(h.machineCache, existingSnapshotCR.SnapshotFile.NodeName, cluster)
 				} else {
-					listSuccessful, machine, err = rke2.GetMachineByID(h.machineCache, existingSnapshotCR.Labels[rke2.MachineIDLabel], cluster)
+					listSuccessful, machine, err = rke2.GetMachineByID(h.machineCache, existingSnapshotCR.Labels[rke2.MachineIDLabel], cluster.Namespace, cluster.Name)
 				}
 				if listSuccessful && machine == nil && err != nil {
 					// delete the CR because we don't have a corresponding machine for it

--- a/pkg/controllers/provisioningv2/rke2/common.go
+++ b/pkg/controllers/provisioningv2/rke2/common.go
@@ -283,9 +283,9 @@ func GetMachineFromNode(machineCache capicontrollers.MachineCache, nodeName stri
 }
 
 // GetMachineByID attempts to find the corresponding machine for an etcd snapshot that is found in the configmap. If the machine list is successful, it will return true on the boolean, otherwise, it can be assumed that a false, nil, and defined error indicate the machine does not exist.
-func GetMachineByID(machineCache capicontrollers.MachineCache, machineID string, cluster *provv1.Cluster) (bool, *capi.Machine, error) {
-	machines, err := machineCache.List(cluster.Namespace, labels.SelectorFromSet(map[string]string{
-		ClusterNameLabel: cluster.Name,
+func GetMachineByID(machineCache capicontrollers.MachineCache, machineID, clusterNamespace, clusterName string) (bool, *capi.Machine, error) {
+	machines, err := machineCache.List(clusterNamespace, labels.SelectorFromSet(map[string]string{
+		ClusterNameLabel: clusterName,
 		MachineIDLabel:   machineID,
 	}))
 	if err != nil || len(machines) > 1 {
@@ -294,7 +294,7 @@ func GetMachineByID(machineCache capicontrollers.MachineCache, machineID string,
 	if len(machines) == 1 {
 		return true, machines[0], nil
 	}
-	return true, nil, fmt.Errorf("unable to find machine by ID %s for cluster %s", machineID, cluster.Name)
+	return true, nil, fmt.Errorf("unable to find machine by ID %s for cluster %s", machineID, clusterName)
 }
 
 func CopyPlanMetadataToSecret(secret *corev1.Secret, metadata *plan.Metadata) {

--- a/pkg/provisioningv2/rke2/planner/etcdrestore.go
+++ b/pkg/provisioningv2/rke2/planner/etcdrestore.go
@@ -48,7 +48,11 @@ func (p *Planner) runEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControlPlane
 		}
 	} else {
 		logrus.Infof("rkecluster %s/%s re-electing specific init node for etcd snapshot restore", controlPlane.Namespace, controlPlane.Spec.ClusterName)
-		joinServer, err = p.designateInitNode(controlPlane, clusterPlan, snapshot.SnapshotFile.NodeName)
+		listSuccessful, machine, err := rke2.GetMachineByID(p.machinesCache, snapshot.Labels[rke2.MachineIDLabel], controlPlane.Namespace, controlPlane.Name)
+		if !listSuccessful || machine == nil || machine.Spec.InfrastructureRef.Name == "" || err != nil {
+			return fmt.Errorf("unable to retrieve nodeName for machine on snapshot: %s/%s", snapshot.Namespace, snapshot.Name)
+		}
+		joinServer, err = p.designateInitNode(controlPlane, clusterPlan, machine.Spec.InfrastructureRef.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/provisioningv2/rke2/planner/etcdrestore.go
+++ b/pkg/provisioningv2/rke2/planner/etcdrestore.go
@@ -50,7 +50,7 @@ func (p *Planner) runEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControlPlane
 		logrus.Infof("rkecluster %s/%s re-electing specific init node for etcd snapshot restore", controlPlane.Namespace, controlPlane.Spec.ClusterName)
 		listSuccessful, machine, err := rke2.GetMachineByID(p.machinesCache, snapshot.Labels[rke2.MachineIDLabel], controlPlane.Namespace, controlPlane.Name)
 		if !listSuccessful || machine == nil || machine.Spec.InfrastructureRef.Name == "" || err != nil {
-			return fmt.Errorf("unable to retrieve nodeName for machine on snapshot: %s/%s", snapshot.Namespace, snapshot.Name)
+			return fmt.Errorf("unable to retrieve nodeName for machine on snapshot: %s/%s err: %v", snapshot.Namespace, snapshot.Name, err)
 		}
 		joinServer, err = p.designateInitNode(controlPlane, clusterPlan, machine.Spec.InfrastructureRef.Name)
 		if err != nil {

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -128,6 +128,7 @@ type Planner struct {
 	secretClient                  corecontrollers.SecretClient
 	secretCache                   corecontrollers.SecretCache
 	machines                      capicontrollers.MachineClient
+	machinesCache                 capicontrollers.MachineCache
 	clusterRegistrationTokenCache mgmtcontrollers.ClusterRegistrationTokenCache
 	capiClient                    capicontrollers.ClusterClient
 	capiClusters                  capicontrollers.ClusterCache
@@ -148,6 +149,7 @@ func New(ctx context.Context, clients *wrangler.Context) *Planner {
 		ctx:                           ctx,
 		store:                         store,
 		machines:                      clients.CAPI.Machine(),
+		machinesCache:                 clients.CAPI.Machine().Cache(),
 		secretClient:                  clients.Core.Secret(),
 		secretCache:                   clients.Core.Secret().Cache(),
 		clusterRegistrationTokenCache: clients.Mgmt.ClusterRegistrationToken().Cache(),


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/37641

Upon etcd snapshot restore, a local snapshot node name was blindly trusted as the node to designate. This is not a valid procedure, as we must ensure we correlate the snapshot to the correct machine rather than the node that is listed from the config map in the snapshot. 

This is primarily due to the cloud provider being able to change node names, which can cause problems down the line for restore.