### PR TITLE
use machine ID directly when designating init node during etcd restore and make init node waiting message less vague

### DIFF
--- a/pkg/provisioningv2/rke2/planner/etcdrestore.go
+++ b/pkg/provisioningv2/rke2/planner/etcdrestore.go
@@ -47,12 +47,8 @@ func (p *Planner) runEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControlPlane
 			return err
 		}
 	} else {
-		logrus.Infof("rkecluster %s/%s re-electing specific init node for etcd snapshot restore", controlPlane.Namespace, controlPlane.Spec.ClusterName)
-		listSuccessful, machine, err := rke2.GetMachineByID(p.machinesCache, snapshot.Labels[rke2.MachineIDLabel], controlPlane.Namespace, controlPlane.Name)
-		if !listSuccessful || machine == nil || machine.Spec.InfrastructureRef.Name == "" || err != nil {
-			return fmt.Errorf("unable to retrieve nodeName for machine on snapshot: %s/%s err: %v", snapshot.Namespace, snapshot.Name, err)
-		}
-		joinServer, err = p.designateInitNode(controlPlane, clusterPlan, machine.Spec.InfrastructureRef.Name)
+		logrus.Infof("rkecluster %s/%s: re-electing specific init node for etcd snapshot restore", controlPlane.Namespace, controlPlane.Spec.ClusterName)
+		joinServer, err = p.designateInitNodeByMachineID(controlPlane, clusterPlan, snapshot.Labels[rke2.MachineIDLabel])
 		if err != nil {
 			return err
 		}
@@ -61,8 +57,8 @@ func (p *Planner) runEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControlPlane
 
 	for _, server := range servers {
 		if isS3 ||
-			(server.Machine.Status.NodeRef != nil &&
-				server.Machine.Status.NodeRef.Name == snapshot.SnapshotFile.NodeName) {
+			(server.Machine.Labels[rke2.MachineIDLabel] != "" && snapshot.Labels[rke2.MachineIDLabel] != "" &&
+				server.Machine.Labels[rke2.MachineIDLabel] == snapshot.Labels[rke2.MachineIDLabel]) {
 			restorePlan, err := p.generateEtcdSnapshotRestorePlan(controlPlane, snapshot, tokensSecret, server, joinServer)
 			if err != nil {
 				return err
@@ -166,11 +162,7 @@ func (p *Planner) runEtcdRestoreServiceStop(controlPlane *rkev1.RKEControlPlane,
 	var err error
 	isS3 := snapshot.SnapshotFile.S3 != nil
 	if !isS3 { // In the event that we are restoring a local snapshot, we need to reset our initNode
-		listSuccessful, machine, err := rke2.GetMachineByID(p.machinesCache, snapshot.Labels[rke2.MachineIDLabel], controlPlane.Namespace, controlPlane.Name)
-		if !listSuccessful || machine == nil || machine.Spec.InfrastructureRef.Name == "" || err != nil {
-			return fmt.Errorf("unable to retrieve nodeName for machine on snapshot: %s/%s err: %v", snapshot.Namespace, snapshot.Name, err)
-		}
-		joinServer, err = p.designateInitNode(controlPlane, clusterPlan, machine.Spec.InfrastructureRef.Name)
+		joinServer, err = p.designateInitNodeByMachineID(controlPlane, clusterPlan, snapshot.Labels[rke2.MachineIDLabel])
 		if err != nil {
 			return fmt.Errorf("error while designating init node during control plane/etcd stop: %w", err)
 		}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/37641

Upon attempts to correct forced init node designation during etcd restore, the wrong name was used (machine name vs. node name). This PR corrects this behavior, so that the machine ID is properly used.

This PR also makes the waiting message when no potential init nodes are available a little less vague, using the term `viable` rather than `possible`.