### PR TITLE
restore registries and upgradestrategy for v2prov etcd snapshot restore

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -207,6 +207,14 @@ func reconcileClusterSpecEtcdRestore(cluster *rancherv1.Cluster, desiredSpec ran
 		changed = true
 		cluster.Spec.RKEConfig.ChartValues = desiredSpec.RKEConfig.ChartValues
 	}
+	if !equality.Semantic.DeepEqual(cluster.Spec.RKEConfig.Registries, desiredSpec.RKEConfig.Registries) {
+		changed = true
+		cluster.Spec.RKEConfig.Registries = desiredSpec.RKEConfig.Registries
+	}
+	if !equality.Semantic.DeepEqual(cluster.Spec.RKEConfig.UpgradeStrategy, desiredSpec.RKEConfig.UpgradeStrategy) {
+		changed = true
+		cluster.Spec.RKEConfig.UpgradeStrategy = desiredSpec.RKEConfig.UpgradeStrategy
+	}
 	if cluster.Spec.RKEConfig.AdditionalManifest != desiredSpec.RKEConfig.AdditionalManifest {
 		changed = true
 		cluster.Spec.RKEConfig.AdditionalManifest = desiredSpec.RKEConfig.AdditionalManifest


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/37682

This PR will restore registries and upgradestrategy during a `v2prov` etcd snapshot restore with "all" selected.