### PR TITLE
Deepcopy infra machine remove

### DIFF
--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -48,7 +48,7 @@ var (
 	toDeleteCookies = []string{CookieName, CSRFCookie}
 )
 
-func RegisterIndexer(ctx context.Context, apiContext *config.ScaledContext) error {
+func RegisterIndexer(apiContext *config.ScaledContext) error {
 	informer := apiContext.Management.Users("").Controller().Informer()
 	return informer.AddIndexers(map[string]cache.IndexFunc{userPrincipalIndex: userPrincipalIndexer})
 }

--- a/pkg/controllers/management/auth/register.go
+++ b/pkg/controllers/management/auth/register.go
@@ -23,7 +23,7 @@ func RegisterWranglerIndexers(config *wrangler.Context) {
 	})
 }
 
-func RegisterIndexers(ctx context.Context, scaledContext *config.ScaledContext) error {
+func RegisterIndexers(scaledContext *config.ScaledContext) error {
 	prtbInformer := scaledContext.Management.ProjectRoleTemplateBindings("").Controller().Informer()
 	prtbIndexers := map[string]cache.IndexFunc{
 		prtbByRoleTemplateIndex: prtbByRoleTemplate,

--- a/pkg/controllers/management/podsecuritypolicy/template.go
+++ b/pkg/controllers/management/podsecuritypolicy/template.go
@@ -14,7 +14,7 @@ import (
 
 const psptpbByPSPTNameIndex = "something.something.psptpb/pspt-name"
 
-func RegisterIndexers(ctx context.Context, scaledContext *config.ScaledContext) error {
+func RegisterIndexers(scaledContext *config.ScaledContext) error {
 	psptpbInformer := scaledContext.Management.PodSecurityPolicyTemplateProjectBindings("").Controller().Informer()
 	psptpbIndexers := map[string]cache.IndexFunc{
 		psptpbByPSPTNameIndex: PSPTPBByPSPTName,

--- a/pkg/controllers/managementapi/controllers.go
+++ b/pkg/controllers/managementapi/controllers.go
@@ -24,7 +24,7 @@ import (
 )
 
 func Register(ctx context.Context, scaledContext *config.ScaledContext, clusterManager *clustermanager.Manager, server *normanapi.Server) error {
-	if err := registerIndexers(ctx, scaledContext); err != nil {
+	if err := registerIndexers(scaledContext); err != nil {
 		return err
 	}
 
@@ -37,26 +37,26 @@ func Register(ctx context.Context, scaledContext *config.ScaledContext, clusterM
 	return nil
 }
 
-func registerIndexers(ctx context.Context, scaledContext *config.ScaledContext) error {
-	if err := clusterauthtoken.RegisterIndexers(ctx, scaledContext); err != nil {
+func registerIndexers(scaledContext *config.ScaledContext) error {
+	if err := clusterauthtoken.RegisterIndexers(scaledContext); err != nil {
 		return err
 	}
-	if err := rbac.RegisterIndexers(ctx, scaledContext); err != nil {
+	if err := rbac.RegisterIndexers(scaledContext); err != nil {
 		return err
 	}
-	if err := monitoring.RegisterIndexers(ctx, scaledContext); err != nil {
+	if err := monitoring.RegisterIndexers(scaledContext); err != nil {
 		return err
 	}
-	if err := auth.RegisterIndexers(ctx, scaledContext); err != nil {
+	if err := auth.RegisterIndexers(scaledContext); err != nil {
 		return err
 	}
-	if err := tokens.RegisterIndexer(ctx, scaledContext); err != nil {
+	if err := tokens.RegisterIndexer(scaledContext); err != nil {
 		return err
 	}
-	if err := podsecuritypolicy.RegisterIndexers(ctx, scaledContext); err != nil {
+	if err := podsecuritypolicy.RegisterIndexers(scaledContext); err != nil {
 		return err
 	}
-	if err := podsecuritypolicy2.RegisterIndexers(ctx, scaledContext); err != nil {
+	if err := podsecuritypolicy2.RegisterIndexers(scaledContext); err != nil {
 		return err
 	}
 	cluster.RegisterIndexers(scaledContext)

--- a/pkg/controllers/managementuser/clusterauthtoken/register.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/register.go
@@ -14,7 +14,7 @@ import (
 
 const tokenByUserAndClusterIndex = "auth.management.cattle.io/token-by-user-and-cluster"
 
-func RegisterIndexers(ctx context.Context, scaledContext *config.ScaledContext) error {
+func RegisterIndexers(scaledContext *config.ScaledContext) error {
 	tokenInformer := scaledContext.Management.Tokens("").Controller().Informer()
 	tokenIndexers := map[string]cache.IndexFunc{
 		tokenByUserAndClusterIndex: tokenByUserAndCluster,

--- a/pkg/controllers/managementuser/rbac/globalrole_handler.go
+++ b/pkg/controllers/managementuser/rbac/globalrole_handler.go
@@ -1,7 +1,6 @@
 package rbac
 
 import (
-	"context"
 	"time"
 
 	"github.com/rancher/norman/types/slice"
@@ -25,7 +24,7 @@ const (
 	grbByUserAndRoleIndex = "authz.cluster.cattle.io/grb-by-user-and-role"
 )
 
-func RegisterIndexers(ctx context.Context, scaledContext *config.ScaledContext) error {
+func RegisterIndexers(scaledContext *config.ScaledContext) error {
 	informer := scaledContext.Management.GlobalRoleBindings("").Controller().Informer()
 	indexers := map[string]cache.IndexFunc{
 		grbByUserAndRoleIndex: grbByUserAndRole,

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/serviceaccount.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/serviceaccount.go
@@ -23,7 +23,7 @@ const psptpbByTargetProjectNameAnnotationIndex = "podsecuritypolicy.rbac.user.ca
 const roleBindingByServiceAccountIndex = "podsecuritypolicy.rbac.user.cattle.io/role-binding-by-service-account"
 const psptpbRoleBindingAnnotation = "podsecuritypolicy.rbac.user.cattle.io/psptpb-role-binding"
 
-func RegisterIndexers(ctx context.Context, scaledContext *config.ScaledContext) error {
+func RegisterIndexers(scaledContext *config.ScaledContext) error {
 	psptpbInformer := scaledContext.Management.PodSecurityPolicyTemplateProjectBindings("").Controller().Informer()
 	psptpbIndexers := map[string]cache.IndexFunc{
 		psptpbByTargetProjectNameAnnotationIndex: psptpbByTargetProjectName,

--- a/pkg/controllers/managementuserlegacy/monitoring/register.go
+++ b/pkg/controllers/managementuserlegacy/monitoring/register.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func RegisterIndexers(ctx context.Context, scaledContext *config.ScaledContext) error {
+func RegisterIndexers(scaledContext *config.ScaledContext) error {
 	prtbInformer := scaledContext.Management.ProjectRoleTemplateBindings("").Controller().Informer()
 	return prtbInformer.AddIndexers(map[string]cache.IndexFunc{
 		prtbBySA: prtbBySAFunc,


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36845

## Problem
There was an issue where a concurrent map read and write would happen. It is
difficult to diagnose, but this is one place where an unstructured object was
being modified without first deep copying the object.

## Solution
Deep copying the object before changing it should stop the panic.

## Testing
This is an intermittent issue. Previously, the panic would happen on approximately 1 out of 3 CI runs. The CI has run 6 times for this PR and no panic has been seen.