### PR TITLE
Fix Cluster Templates - private registry support without override option enabled

### DIFF
--- a/pkg/api/norman/store/cluster/cluster_store.go
+++ b/pkg/api/norman/store/cluster/cluster_store.go
@@ -435,6 +435,7 @@ func loadDataFromTemplate(clusterTemplateRevision *v3.ClusterTemplateRevision, c
 	// The key in the map is used to preserve the order of registries
 	registryMap := make(map[int]map[string]interface{})
 	existingRegistries := convert.ToMapSlice(convert.ToMapInterface(existingCluster[managementv3.ClusterSpecFieldRancherKubernetesEngineConfig])[managementv3.RancherKubernetesEngineConfigFieldPrivateRegistries])
+	privateRegistryOverride := false
 	for i, registry := range existingRegistries {
 		registryMap[i] = registry
 	}
@@ -492,6 +493,7 @@ func loadDataFromTemplate(clusterTemplateRevision *v3.ClusterTemplateRevision, c
 		}
 		keyParts := strings.Split(question.Variable, ".")
 		if strings.HasPrefix(question.Variable, "rancherKubernetesEngineConfig.privateRegistries") {
+			privateRegistryOverride = true
 			// for example: question.Variable = rancherKubernetesEngineConfig.privateRegistries[0].url
 			index, err := getIndexFromQuestion(question.Variable)
 			if err != nil {
@@ -515,7 +517,7 @@ func loadDataFromTemplate(clusterTemplateRevision *v3.ClusterTemplateRevision, c
 		}
 		revisionQuestions = append(revisionQuestions, questionMap)
 	}
-	if len(registryMap) > 0 {
+	if len(registryMap) > 0 && privateRegistryOverride {
 		registries, err := convertRegistryMapToSliceInOrder(registryMap)
 		if err != nil {
 			return nil, httperror.WrapAPIError(err, httperror.ServerError, "Error processing clusterTemplate answers to private registry")


### PR DESCRIPTION
Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/37708

# Problem
 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable.  If this is a new feature describe why we need this feature and how it will be used. -->
 
For REK clusters that are created from a cluster template revision,  the private registry info ( url, username, or password) from the existing cluster is always used when updating the cluster, this causes the problem in this very specific scenario: if the private registry info is changed in the newly-applied cluster template revision AND those fields are not marked as "allow user override", the new values will never be applied. 


# Solution
 
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
The private registry info from the existing cluster is used only when the "allow user override" is enabled for the private registry info in the cluster template revision; otherwise, apply the values from the revision. 


# Testing

Steps (exactly same to the one in the issue):
- Create an RKE1 cluster template with a private registry configured without enabling any override functionality on the private registry.
- Create a cluster using this cluster template
- Create a cluster template revision and modify the credentials or URL of the private registry, notice that the override functionality is still disabled
- Edit the cluster and use the newly created cluster template revision
 
Results:
New private registry settings are applied 


---

# Original Post

Partially fixes #37708

Repro:

1. Create cluster template with a private registry configured without enabling any override functionality on the private registry.
2. Create a cluster using this cluster template
3. Create a cluster template revision and modify the credentials of the private registry
4. Edit the cluster and use the newly created cluster template revision
5. New private registry settings won't be applied

With this pr the private registry override code won't be applied if override is not enabled in the selected cluster template revision.