### PR TITLE
Added retention for failed snapshots

### DIFF
--- a/pkg/controllers/management/etcdbackup/etcdbackup.go
+++ b/pkg/controllers/management/etcdbackup/etcdbackup.go
@@ -162,6 +162,24 @@ func (c *Controller) clusterBackupSync(ctx context.Context, interval time.Durati
 	return nil
 }
 
+type FilterFunc = func(backup *v3.EtcdBackup) bool
+
+// filterBackups will test each backup within backups to determine if the filter validates (i.e. returns true) for the
+// given backup. If any filter is false, the backup is considered invalid.
+func filterBackups(backups []*v3.EtcdBackup, filter ...FilterFunc) []*v3.EtcdBackup {
+	ret := make([]*v3.EtcdBackup, 0)
+OUTER:
+	for _, backup := range backups {
+		for _, f := range filter {
+			if !f(backup) {
+				continue OUTER
+			}
+		}
+		ret = append(ret, backup)
+	}
+	return ret
+}
+
 func (c *Controller) runWaitingBackups(cluster *v3.Cluster) error {
 	if cluster == nil || cluster.DeletionTimestamp != nil {
 		return nil
@@ -204,7 +222,9 @@ func (c *Controller) createRecurringBackup(cluster *v3.Cluster) error {
 	if err != nil {
 		return err
 	}
-	recurringBackups := getRecurringBackups(backups)
+
+	recurringBackups := filterBackups(backups, IsBackupRecurring)
+	chronologicalSort(recurringBackups)
 
 	// cluster has no recurring backups, we need to create initial backup
 	if len(recurringBackups) == 0 {
@@ -241,7 +261,11 @@ func (c *Controller) createRecurringBackup(cluster *v3.Cluster) error {
 		log.Debugf("[etcd-backup] new backup created: %s", newBackup.Name)
 	}
 
-	return c.rotateExpiredBackups(cluster, recurringBackups)
+	return nil
+}
+
+func IsBackupRecurring(backup *v3.EtcdBackup) bool {
+	return !backup.Spec.Manual
 }
 
 func (c *Controller) createBackupForCluster(b *v3.EtcdBackup, cluster *v3.Cluster) (runtime.Object, error) {
@@ -264,13 +288,14 @@ func (c *Controller) createBackupForCluster(b *v3.EtcdBackup, cluster *v3.Cluste
 	}
 
 	if saveErr != nil {
+		if !b.Spec.Manual {
+			_ = c.rotateFailedBackups(cluster)
+		}
 		return b, fmt.Errorf("failed to perform etcd backup: %v", saveErr)
 	}
-	// try to rotate old backups on successful recurring backup, if not clusterBackupSync will take care of it
+
 	if !b.Spec.Manual {
-		if backups, err := c.getBackupsList(cluster); err == nil {
-			_ = c.rotateExpiredBackups(cluster, getRecurringBackups(backups))
-		}
+		_ = c.rotateSuccessfulBackups(cluster)
 	}
 	return b, nil
 }
@@ -400,15 +425,44 @@ func (c *Controller) etcdRemoveSnapshotWithBackoff(b *v3.EtcdBackup) error {
 	})
 }
 
-// rotateExpiredBackups removes backups that are older than the expiration period, while retaining the desired number of etcd backups.
-// This function expects backups to be sorted from newest to oldest. In practice this function should only delete the last backup,
-func (c *Controller) rotateExpiredBackups(cluster *v3.Cluster, backups []*v3.EtcdBackup) error {
+func (c *Controller) rotateSuccessfulBackups(cluster *v3.Cluster) error {
+	log.Infof("[etcd-backup] Rotating successful recurring backups")
+	return c.rotateBackups(cluster, IsBackupCompleted)
+}
+
+func IsBackupCompleted(backup *v3.EtcdBackup) bool {
+	return rketypes.BackupConditionCompleted.IsTrue(backup)
+}
+
+func (c *Controller) rotateFailedBackups(cluster *v3.Cluster) error {
+	log.Infof("[etcd-backup] Rotating failed recurring backups")
+	return c.rotateBackups(cluster, IsBackupFailed)
+}
+
+func IsBackupFailed(backup *v3.EtcdBackup) bool {
+	return rketypes.BackupConditionCompleted.IsFalse(backup)
+}
+
+func (c *Controller) rotateBackups(cluster *v3.Cluster, filter FilterFunc) error {
 	retention := cluster.Spec.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig.Retention
-	backups = getCompletedBackups(backups)
+	backups, err := c.getBackupsList(cluster)
+	if err != nil {
+		return err
+	}
+	backups = filterBackups(backups, IsBackupRecurring, filter)
 	if len(backups) <= retention {
 		return nil
 	}
-	for _, backup := range backups[retention:] {
+	chronologicalSort(backups)
+
+	if err = c.removeBackups(backups[retention:]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) removeBackups(backups []*v3.EtcdBackup) error {
+	for _, backup := range backups {
 		if err := c.backupClient.DeleteNamespaced(backup.Namespace, backup.Name, &metav1.DeleteOptions{}); err != nil {
 			return err
 		}
@@ -577,18 +631,10 @@ func GetS3Client(sbc *rketypes.S3BackupConfig, timeout int, dialer dialer.Dialer
 	return s3Client, nil
 }
 
-// getRecurringBackups returns the list of recurring backups, sorted newest to oldest by time the backup started
-func getRecurringBackups(backups []*v3.EtcdBackup) []*v3.EtcdBackup {
-	retList := []*v3.EtcdBackup{}
-	for _, backup := range backups {
-		if !backup.Spec.Manual {
-			retList = append(retList, backup)
-		}
-	}
-	sort.Slice(retList, func(i, j int) bool {
-		return getBackupCreatedTime(retList[i]).After(getBackupCreatedTime(retList[j]))
+func chronologicalSort(backups []*v3.EtcdBackup) {
+	sort.Slice(backups, func(i, j int) bool {
+		return getBackupCreatedTime(backups[i]).After(getBackupCreatedTime(backups[j]))
 	})
-	return retList
 }
 
 func (c *Controller) getBackupsList(cluster *v3.Cluster) ([]*v3.EtcdBackup, error) {
@@ -614,17 +660,6 @@ func getBackupCompletedTime(o runtime.Object) time.Time {
 func getBackupCreatedTime(o runtime.Object) time.Time {
 	t, _ := time.Parse(time.RFC3339, rketypes.BackupConditionCreated.GetLastUpdated(o))
 	return t
-}
-
-// getCompletedBackups returns the list of completed backups
-func getCompletedBackups(backups []*v3.EtcdBackup) []*v3.EtcdBackup {
-	completedList := []*v3.EtcdBackup{}
-	for _, backup := range backups {
-		if rketypes.BackupConditionCompleted.IsTrue(backup) {
-			completedList = append(completedList, backup)
-		}
-	}
-	return completedList
 }
 
 func shouldBackup(cluster *v3.Cluster) bool {

--- a/pkg/controllers/management/etcdbackup/etcdbackup_test.go
+++ b/pkg/controllers/management/etcdbackup/etcdbackup_test.go
@@ -1,0 +1,80 @@
+package etcdbackup
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	rketypes "github.com/rancher/rke/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_filterBackups(t *testing.T) {
+	recurring := &v3.EtcdBackup{}
+	manual := &v3.EtcdBackup{
+		Spec: rketypes.EtcdBackupSpec{
+			Manual: true,
+		},
+	}
+	failed := &v3.EtcdBackup{}
+	rketypes.BackupConditionCompleted.False(failed)
+	completed := &v3.EtcdBackup{}
+	rketypes.BackupConditionCompleted.True(completed)
+
+	tests := []struct {
+		name     string
+		input    []*v3.EtcdBackup
+		expected []*v3.EtcdBackup
+		filters  []FilterFunc
+	}{
+		{
+			name: "recurring",
+			input: []*v3.EtcdBackup{
+				manual, recurring,
+			},
+			expected: []*v3.EtcdBackup{
+				recurring,
+			},
+			filters: []FilterFunc{
+				IsBackupRecurring,
+			},
+		}, {
+			name: "completed",
+			input: []*v3.EtcdBackup{
+				completed, failed,
+			},
+			expected: []*v3.EtcdBackup{
+				completed,
+			},
+			filters: []FilterFunc{
+				IsBackupCompleted,
+			},
+		}, {
+			name: "failed",
+			input: []*v3.EtcdBackup{
+				completed, failed,
+			},
+			expected: []*v3.EtcdBackup{
+				failed,
+			},
+			filters: []FilterFunc{
+				IsBackupFailed,
+			},
+		}, {
+			name: "recurring and completed",
+			input: []*v3.EtcdBackup{
+				recurring, manual, completed, failed,
+			},
+			expected: []*v3.EtcdBackup{
+				completed,
+			},
+			filters: []FilterFunc{
+				IsBackupRecurring, IsBackupCompleted,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, filterBackups(tt.input, tt.filters...))
+		})
+	}
+}


### PR DESCRIPTION
## Background

Previously, retention was limited to the total number of recurring etcd backups, which could leave a cluster without any successful etcd backups if the cluster entered a bad state (for example, if the etcd container was stopped on the downstream node, a backup would never be taken, but it would be counted towards the total). An attempt was made to remediate this by not removing failed recurring backups, temporarily. This PR follows parity with RKE2, by using the retention set for the cluster as the number of successful backups to keep, as well as the number of failed backups to keep (e.x. a retention of 5 means potential of 5 successful and 5 failed backups).

## Additional notes

Some minor refactoring and improvements have been made, mostly notably that we no longer rotate backups in cluster sync, but rather immediately after the backup is attempted.

Related Issue: https://github.com/rancher/rancher/issues/36492