### PR TITLE
Update k3s and rke2 terraform to use user home directory for scripts

### DIFF
--- a/tests/validation/.gitignore
+++ b/tests/validation/.gitignore
@@ -102,3 +102,12 @@ ENV/
 # Local test generation
 .DS_store
 .ssh
+
+# Terraform
+.terraform
+*.terraform.*
+*.terraform
+.terraform.*
+*.tfstate
+*.tfstate.*
+.tfstate.*

--- a/tests/validation/tests/v3_api/resource/terraform/k3s/master/install_k3s_master.sh
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/master/install_k3s_master.sh
@@ -82,6 +82,10 @@ else
   fi
 fi
 
+if [ "${1}" = "*micro*" ]; then
+    systemctl enable k3s --now
+fi
+
 export PATH=$PATH:/usr/local/bin
 timeElapsed=0
 while ! $(kubectl get nodes >/dev/null 2>&1) && [[ $timeElapsed -lt 300 ]]

--- a/tests/validation/tests/v3_api/resource/terraform/k3s/master/join_k3s_master.sh
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/master/join_k3s_master.sh
@@ -68,3 +68,7 @@ else
         fi
     fi
 fi
+
+if [ "${1}" = "*micro*" ]; then
+    systemctl enable k3s --now
+fi

--- a/tests/validation/tests/v3_api/resource/terraform/k3s/worker/join_k3s_agent.sh
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/worker/join_k3s_agent.sh
@@ -43,4 +43,9 @@ else
       curl -sfL https://get.k3s.io | sh -s - agent --node-external-ip=${6}
     fi
 fi
+
+if [ "${1}" = "*micro*" ]; then
+    systemctl enable k3s-agent --now
+fi
+
 sleep 20

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/master/instances_server.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/master/instances_server.tf
@@ -1,3 +1,7 @@
+locals {
+  user_home = "/home/${var.aws_user}"
+}
+
 resource "aws_instance" "master" {
   ami           =  var.aws_ami
   instance_type =  var.ec2_instance_class
@@ -7,6 +11,7 @@ resource "aws_instance" "master" {
     user        = "${var.aws_user}"
     host        = self.public_ip
     private_key = "${file(var.access_key)}"
+    script_path = "${local.user_home}/terraform_caller.sh"
   }
   root_block_device {
     volume_size = var.volume_size
@@ -22,22 +27,36 @@ resource "aws_instance" "master" {
   }
   provisioner "file" {
     source      = "define_node_role.sh"
-    destination = "/tmp/define_node_role.sh"
-  }
-  provisioner "remote-exec" {
-    inline = [
-      "chmod +x /tmp/define_node_role.sh",
-      "sudo /tmp/define_node_role.sh -1 \"${var.role_order}\" ${var.all_role_nodes} ${var.etcd_only_nodes} ${var.etcd_cp_nodes} ${var.etcd_worker_nodes} ${var.cp_only_nodes} ${var.cp_worker_nodes}",
-    ]
+    destination = "${local.user_home}/define_node_role.sh"
   }
   provisioner "file" {
     source      = "install_rke2_master.sh"
-    destination = "/tmp/install_rke2_master.sh"
+    destination = "${local.user_home}/install_rke2_master.sh"
   }
   provisioner "remote-exec" {
-    inline = [
-      "chmod +x /tmp/install_rke2_master.sh",
-      "sudo /tmp/install_rke2_master.sh ${var.node_os} ${var.create_lb ? aws_route53_record.aws_route53[0].fqdn : "fake.fqdn.value"} ${var.rke2_version} ${self.public_ip} ${var.rke2_channel} ${var.cluster_type} \"${var.server_flags}\" ${var.install_mode} ${var.username} ${var.password} \"${var.install_method}\"",
+  inline = [ <<-EOT
+      sudo chmod +x ${local.user_home}/define_node_role.sh
+      sudo ${local.user_home}/define_node_role.sh -1 \
+                                                  "${var.role_order}" \
+                                                  ${var.all_role_nodes} \
+                                                  ${var.etcd_only_nodes} \
+                                                  ${var.etcd_cp_nodes} \
+                                                  ${var.etcd_worker_nodes} \
+                                                  ${var.cp_only_nodes} \
+                                                  ${var.cp_worker_nodes}
+      sudo chmod +x ${local.user_home}/install_rke2_master.sh
+      sudo ${local.user_home}/install_rke2_master.sh ${var.node_os} \
+                                                     ${var.create_lb ? aws_route53_record.aws_route53[0].fqdn : "fake.fqdn.value"} \
+                                                     ${var.rke2_version} \
+                                                     ${self.public_ip} \
+                                                     ${var.rke2_channel} \
+                                                     ${var.cluster_type} \
+                                                     "${var.server_flags}" \
+                                                     ${var.install_mode} \
+                                                     ${var.username} \
+                                                     "${var.password}" \
+                                                     ${var.install_method}
+    EOT
     ]
   }
   provisioner "local-exec" {
@@ -67,6 +86,7 @@ resource "aws_instance" "master2" {
     user        = "${var.aws_user}"
     host        = self.public_ip
     private_key = "${file(var.access_key)}"
+    script_path = "${local.user_home}/terraform_caller.sh"
   }
   root_block_device {
     volume_size = var.volume_size
@@ -83,22 +103,38 @@ resource "aws_instance" "master2" {
   depends_on       = ["aws_instance.master"]
   provisioner "file" {
     source      = "define_node_role.sh"
-    destination = "/tmp/define_node_role.sh"
-  }
-  provisioner "remote-exec" {
-    inline = [
-      "chmod +x /tmp/define_node_role.sh",
-      "sudo /tmp/define_node_role.sh ${count.index} \"${var.role_order}\" ${var.all_role_nodes} ${var.etcd_only_nodes} ${var.etcd_cp_nodes} ${var.etcd_worker_nodes} ${var.cp_only_nodes} ${var.cp_worker_nodes}",
-    ]
+    destination = "${local.user_home}/define_node_role.sh"
   }
   provisioner "file" {
     source      = "join_rke2_master.sh"
-    destination = "/tmp/join_rke2_master.sh"
+    destination = "${local.user_home}/join_rke2_master.sh"
   }
   provisioner "remote-exec" {
-    inline = [
-      "chmod +x /tmp/join_rke2_master.sh",
-      "sudo /tmp/join_rke2_master.sh ${var.node_os} ${var.create_lb ? aws_route53_record.aws_route53[0].fqdn : aws_instance.master.public_ip} ${aws_instance.master.public_ip} ${local.node_token} ${var.rke2_version} ${self.public_ip} ${var.rke2_channel} ${var.cluster_type} \"${var.server_flags}\" ${var.install_mode} ${var.username} ${var.password} \"${var.install_method}\"",
+    inline = [ <<-EOT
+        sudo chmod +x ${local.user_home}/define_node_role.sh
+        sudo ${local.user_home}/define_node_role.sh ${count.index} \
+                                                    "${var.role_order}" \
+                                                    ${var.all_role_nodes} \
+                                                    ${var.etcd_only_nodes} \
+                                                    ${var.etcd_cp_nodes} \
+                                                    ${var.etcd_worker_nodes} \
+                                                    ${var.cp_only_nodes} \
+                                                    ${var.cp_worker_nodes}
+        sudo chmod +x ${local.user_home}/join_rke2_master.sh
+        sudo ${local.user_home}/join_rke2_master.sh ${var.node_os} \
+                                                    ${var.create_lb ? aws_route53_record.aws_route53[0].fqdn : aws_instance.master.public_ip} \
+                                                    ${aws_instance.master.public_ip} \
+                                                    ${local.node_token} \
+                                                    ${var.rke2_version} \
+                                                    ${self.public_ip} \
+                                                    ${var.rke2_channel} \
+                                                    ${var.cluster_type} \
+                                                    "${var.server_flags}" \
+                                                    ${var.install_mode} \
+                                                    ${var.username} \
+                                                    "${var.password}" \
+                                                    ${var.install_method}
+      EOT
     ]
   }
 }

--- a/tests/validation/tests/v3_api/test_import_k3s_cluster.py
+++ b/tests/validation/tests/v3_api/test_import_k3s_cluster.py
@@ -168,7 +168,6 @@ def create_multiple_control_cluster():
                               'create_lb': str(K3S_CREATE_LB).lower()})
     print("Creating cluster")
     tf.init()
-    tf.plan(out="plan_server.out")
     print(tf.apply("--auto-approve"))
 
     if int(RANCHER_K3S_NO_OF_WORKER_NODES) > 0:
@@ -196,7 +195,6 @@ def create_multiple_control_cluster():
 
         print("Joining worker nodes")
         tf.init()
-        tf.plan(out="plan_worker.out")
         print(tf.apply("--auto-approve"))
 
     cmd = "cp /tmp/" + RANCHER_HOSTNAME_PREFIX + "_kubeconfig " + k3s_clusterfilepath

--- a/tests/validation/tests/v3_api/test_import_rke2_cluster.py
+++ b/tests/validation/tests/v3_api/test_import_rke2_cluster.py
@@ -149,7 +149,6 @@ def create_rke2_multiple_control_cluster(cluster_type, cluster_version):
                               'role_order': RKE2_ROLE_ORDER})
     print("Creating cluster")
     tf.init()
-    tf.plan(out="plan_server.out")
     print(tf.apply("--auto-approve"))
     print("\n\n")
     if int(RANCHER_RKE2_NO_OF_WORKER_NODES) > 0:
@@ -180,7 +179,6 @@ def create_rke2_multiple_control_cluster(cluster_type, cluster_version):
 
         print("Joining worker nodes")
         tf.init()
-        tf.plan(out="plan_worker.out")
         print(tf.apply("--auto-approve"))
         print("\n\n")
     cmd = "cp /tmp/" + RANCHER_HOSTNAME_PREFIX + "_kubeconfig " + \


### PR DESCRIPTION
This allows us to run this automation on sle micro with selinux. Previously, selinux was blocking scripts from the /tmp/ directory due to https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security-enhanced_linux/sect-security-enhanced_linux-targeted_policy-unconfined_processes.

Also remove the plans because they are unnecessary and just an extra file that gets created.