### PR TITLE
Bump kontainer-engine-driver-lke v0.0.4 -> v0.0.6

### DIFF
--- a/pkg/data/management/kontainerdriver_data.go
+++ b/pkg/data/management/kontainerdriver_data.go
@@ -102,8 +102,8 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 	}
 	if err := creator.addCustomDriver(
 		"linodekubernetesengine",
-		"https://github.com/linode/kontainer-engine-driver-lke/releases/download/v0.0.4/kontainer-engine-driver-lke-linux-amd64",
-		"5609314fe7ff7339a7c8292738d36ccf5a25460f79ca094db72eb6ccf722bc27",
+		"https://github.com/linode/kontainer-engine-driver-lke/releases/download/v0.0.6/kontainer-engine-driver-lke-linux-amd64",
+		"233cbd550a93ded322906b9fc6ebc88b8791e53d31f0d21d501feb0bad77461c",
 		"",
 		false,
 		"api.linode.com",


### PR DESCRIPTION
This change updates the Linode Kubernetes Engine cluster driver to `v0.0.6`. This version introduces some stability improvements (retries to significantly reduce provisioning failures) and a nullable `HighAvailability` create/update field. 

Specifically, intermittent K8s polling connection issues now triggers a retry within the driver rather than throwing an error to Rancher.

`v0.0.4` -> `v0.0.6` contains no breaking changes.

Thanks in advance! 🙂 

https://github.com/rancher/rancher/issues/38120