### PR TITLE
Fixed snapshot RBAC for RKE2 clusters

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -52,7 +52,8 @@ var clusterManagmentPlaneResources = map[string]string{
 	"nodepools":                   "management.cattle.io",
 	"notifiers":                   "management.cattle.io",
 	"podsecuritypolicytemplateprojectbindings": "management.cattle.io",
-	"projects": "management.cattle.io",
+	"projects":      "management.cattle.io",
+	"etcdsnapshots": "rke.cattle.io",
 }
 
 type crtbLifecycle struct {

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -229,7 +229,8 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch")
 
 	rb.addRoleTemplate("Manage Cluster Backups", "backups-manage", "cluster", false, false, false).
-		addRule().apiGroups("management.cattle.io").resources("etcdbackups").verbs("*")
+		addRule().apiGroups("management.cattle.io").resources("etcdbackups").verbs("*").
+		addRule().apiGroups("rke.cattle.io").resources("etcdsnapshots").verbs("get", "list", "watch")
 
 	rb.addRoleTemplate("Manage Navlinks", "navlinks-manage", "cluster", false, false, false).
 		addRule().apiGroups("ui.cattle.io").resources("navlinks").verbs("*")


### PR DESCRIPTION
Snapshots get stored in the local cluster under the `fleet-default`
namespace. Because of this, roles get access to individual
snapshots. If no snapshots are stored, the users do
not have access to view or create snapshots in the UI.
Users now have access to the `etcdsnapshots.rke.cattle.io`
in the namespace of the cluster. Making the CRD visible in
the schema when no snapshots are present.
#37630

The "Manage Cluster Backup" role also did not have the
`etcdsnapshots.rke.cattle.io` rule in its template.
#37752