### PR TITLE
[WIP] Optimize RTB lifecycle updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,10 @@ replace (
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.2
+
+	github.com/rancher/norman => github.com/cmurphy/norman v0.0.0-20220607034221-57ba232d48d4
 	github.com/rancher/rancher/pkg/apis => ./pkg/apis
 	github.com/rancher/rancher/pkg/client => ./pkg/client
-
 	github.com/rancher/steve => github.com/cmurphy/steve v0.0.0-20220520222108-78aeca15ab90
 	helm.sh/helm/v3 => github.com/rancher/helm/v3 v3.8.0-rancher1
 	k8s.io/api => k8s.io/api v0.23.3
@@ -98,7 +99,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210918015053-5a141a6b18f0
 	github.com/rancher/gke-operator v1.1.3
 	github.com/rancher/kubernetes-provider-detector v0.1.5
-	github.com/rancher/lasso v0.0.0-20220412224715-5f3517291ad4
+	github.com/rancher/lasso v0.0.0-20220519004610-700f167d8324
 	github.com/rancher/lasso/controller-runtime v0.0.0-20220303220250-a429cb5cb9c9
 	github.com/rancher/machine v0.15.0-rancher87
 	github.com/rancher/norman v0.0.0-20220517230400-5a324b6fc6b1

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,10 @@ replace (
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e
 	github.com/matryer/moq => github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.2
-
 	github.com/rancher/rancher/pkg/apis => ./pkg/apis
 	github.com/rancher/rancher/pkg/client => ./pkg/client
+
+	github.com/rancher/steve => github.com/cmurphy/steve v0.0.0-20220520222108-78aeca15ab90
 	helm.sh/helm/v3 => github.com/rancher/helm/v3 v3.8.0-rancher1
 	k8s.io/api => k8s.io/api v0.23.3
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.23.3

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ replace (
 	github.com/rancher/norman => github.com/cmurphy/norman v0.0.0-20220607034221-57ba232d48d4
 	github.com/rancher/rancher/pkg/apis => ./pkg/apis
 	github.com/rancher/rancher/pkg/client => ./pkg/client
-	github.com/rancher/steve => github.com/cmurphy/steve v0.0.0-20220520222108-78aeca15ab90
+	github.com/rancher/steve => github.com/cmurphy/steve v0.0.0-20220610001841-b0067c4241d0
 	helm.sh/helm/v3 => github.com/rancher/helm/v3 v3.8.0-rancher1
 	k8s.io/api => k8s.io/api v0.23.3
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.23.3

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313/go.mod h1:P1wt9Z3DP8O6W3rvwCt0REIlshg1InHImaLW0t3ObY0=
+github.com/cmurphy/steve v0.0.0-20220520222108-78aeca15ab90 h1:ivo7hP3HqINE64iCkHXJ6ydNnwBRGaJN+A2BjTNqrtw=
+github.com/cmurphy/steve v0.0.0-20220520222108-78aeca15ab90/go.mod h1:C5mNeTSJN1wOfcZ83JkJGgsNu3Lbwl7uiZBu8/IseWc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -1295,8 +1297,6 @@ github.com/rancher/rke v1.3.12-0.20220520141546-b42ebdc40272 h1:MqkMm5oVsoRgcDoL
 github.com/rancher/rke v1.3.12-0.20220520141546-b42ebdc40272/go.mod h1:t+VWWY6Cxs1OjRXRFQv+gZNWSfmFor9UReReDjYOnWs=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
-github.com/rancher/steve v0.0.0-20220415184129-b23977e7f1b5 h1:+1shpXAvnskvlMtcjse8oOi2tyPNNDO3LtThjfRoSt0=
-github.com/rancher/steve v0.0.0-20220415184129-b23977e7f1b5/go.mod h1:C5mNeTSJN1wOfcZ83JkJGgsNu3Lbwl7uiZBu8/IseWc=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313/go.mod h1:P1wt9Z3DP8O6W3rvwCt0REIlshg1InHImaLW0t3ObY0=
 github.com/cmurphy/norman v0.0.0-20220607034221-57ba232d48d4 h1:Um5v0OB9BjWAF/yPmu4xbRydbHWHR07uEww24yxmHks=
 github.com/cmurphy/norman v0.0.0-20220607034221-57ba232d48d4/go.mod h1:1G96Zmvnx1FSzCwr/9I6weg/247dH5mDyT2ng/cR7ug=
-github.com/cmurphy/steve v0.0.0-20220520222108-78aeca15ab90 h1:ivo7hP3HqINE64iCkHXJ6ydNnwBRGaJN+A2BjTNqrtw=
-github.com/cmurphy/steve v0.0.0-20220520222108-78aeca15ab90/go.mod h1:C5mNeTSJN1wOfcZ83JkJGgsNu3Lbwl7uiZBu8/IseWc=
+github.com/cmurphy/steve v0.0.0-20220610001841-b0067c4241d0 h1:E6yMZQHMElSQPGgNj7NHDAoQsmDe+TQdJZaBpjsKr6w=
+github.com/cmurphy/steve v0.0.0-20220610001841-b0067c4241d0/go.mod h1:C5mNeTSJN1wOfcZ83JkJGgsNu3Lbwl7uiZBu8/IseWc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313/go.mod h1:P1wt9Z3DP8O6W3rvwCt0REIlshg1InHImaLW0t3ObY0=
+github.com/cmurphy/norman v0.0.0-20220607034221-57ba232d48d4 h1:Um5v0OB9BjWAF/yPmu4xbRydbHWHR07uEww24yxmHks=
+github.com/cmurphy/norman v0.0.0-20220607034221-57ba232d48d4/go.mod h1:1G96Zmvnx1FSzCwr/9I6weg/247dH5mDyT2ng/cR7ug=
 github.com/cmurphy/steve v0.0.0-20220520222108-78aeca15ab90 h1:ivo7hP3HqINE64iCkHXJ6ydNnwBRGaJN+A2BjTNqrtw=
 github.com/cmurphy/steve v0.0.0-20220520222108-78aeca15ab90/go.mod h1:C5mNeTSJN1wOfcZ83JkJGgsNu3Lbwl7uiZBu8/IseWc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -1272,8 +1274,8 @@ github.com/rancher/lasso v0.0.0-20200820172840-0e4cc0ef5cb0/go.mod h1:OhBBBO1pBw
 github.com/rancher/lasso v0.0.0-20210408231703-9ddd9378d08d/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
 github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08/go.mod h1:9qZd/S8DqWzfKtjKGgSoHqGEByYmUE3qRaBaaAHwfEM=
 github.com/rancher/lasso v0.0.0-20220303220127-8cf5555ec03c/go.mod h1:T6WoUopOHBWTGjnphruTJAgoZ+dpm6llvn6GDYaa7Kw=
-github.com/rancher/lasso v0.0.0-20220412224715-5f3517291ad4 h1:Z/fJWD6j3p28Cdn9aOigjecoWeOafiOmIAEstEAjpBM=
-github.com/rancher/lasso v0.0.0-20220412224715-5f3517291ad4/go.mod h1:T6WoUopOHBWTGjnphruTJAgoZ+dpm6llvn6GDYaa7Kw=
+github.com/rancher/lasso v0.0.0-20220519004610-700f167d8324 h1:yi3gGq+tBqkMppIY2gLDidDMtxr6ajcoWxJ6HaLI0TA=
+github.com/rancher/lasso v0.0.0-20220519004610-700f167d8324/go.mod h1:T6WoUopOHBWTGjnphruTJAgoZ+dpm6llvn6GDYaa7Kw=
 github.com/rancher/lasso/controller-runtime v0.0.0-20220303220250-a429cb5cb9c9 h1:tRTK111i2glNni4Dnu8T3oNK/o2D4Zi+Z2Prx/7zqK0=
 github.com/rancher/lasso/controller-runtime v0.0.0-20220303220250-a429cb5cb9c9/go.mod h1:ObsWVtqMsTmIL1xeM2WGvwV4XTHLL8LuB9vDc+uUXtk=
 github.com/rancher/machine v0.15.0-rancher63/go.mod h1:qXYNumxy0J08MO/mh/jNjyRuEc2QKDLUOZIBE5vxaZE=
@@ -1281,11 +1283,6 @@ github.com/rancher/machine v0.15.0-rancher87 h1:u0C28+qvfbf30KdVd0HA12FugeWI0isA
 github.com/rancher/machine v0.15.0-rancher87/go.mod h1:OhMgOZILBwQSrxJxM3DJOuzumQHlswO4IrFZ46kAyZs=
 github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77 h1:k+vzmkZQsH06rZnDr+phskSixG9ByNj9gVdzHcc8nxw=
 github.com/rancher/moq v0.0.0-20200712062324-13d1f37d2d77/go.mod h1:wpITyDPTi/Na5h73XkbuEf2AP9fbgrIGqqxVzFhYD6U=
-github.com/rancher/norman v0.0.0-20210423002317-8e6ffc77a819/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
-github.com/rancher/norman v0.0.0-20211201154850-abe17976423e/go.mod h1:hhnf77V2lmZD7cvUqi4vTBpIs3KpHNL/AmuN0MqEClI=
-github.com/rancher/norman v0.0.0-20220406153559-82478fb169cb/go.mod h1:gDEwYUxOknJaOG1jjcH40PQ8U8xnvB+sHph5VirKINY=
-github.com/rancher/norman v0.0.0-20220517230400-5a324b6fc6b1 h1:ZzKTdVYDi4o/6F3v7nWL3b1q+0kEyNxHMvhMHN6YQQ8=
-github.com/rancher/norman v0.0.0-20220517230400-5a324b6fc6b1/go.mod h1:gDEwYUxOknJaOG1jjcH40PQ8U8xnvB+sHph5VirKINY=
 github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e h1:j6+HqCET/NLPBtew2m5apL7jWw/PStQ7iGwXjgAqdvo=
 github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e/go.mod h1:XbYHTPaXuw8ZY9bylhYKQh/nJxDaTKk3YhAxPl4Qy/k=
 github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a h1:6xqYlVz4uAXBa/AuNAG0bhMusIXVh74dc1bbYOAe+HY=

--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -62,7 +62,7 @@ type record struct {
 	cancel        context.CancelFunc
 }
 
-func NewManager(httpsPort int, context *config.ScaledContext, asl accesscontrol.AccessSetLookup) *Manager {
+func NewManager(httpsPort int, context *config.ScaledContext, asl accesscontrol.AccessSetForSchemaLookup) *Manager {
 	return &Manager{
 		httpsPort:     httpsPort,
 		ScaledContext: context,

--- a/pkg/multiclustermanager/app.go
+++ b/pkg/multiclustermanager/app.go
@@ -89,7 +89,7 @@ func buildScaledContext(ctx context.Context, wranglerContext *wrangler.Context, 
 	systemTokens := systemtokens.NewSystemTokensFromScale(scaledContext)
 	scaledContext.SystemTokens = systemTokens
 
-	manager := clustermanager.NewManager(cfg.HTTPSListenPort, scaledContext, wranglerContext.ASL)
+	manager := clustermanager.NewManager(cfg.HTTPSListenPort, scaledContext, wranglerContext.ASLForSchema)
 
 	scaledContext.AccessControl = manager
 	scaledContext.ClientGetter = manager

--- a/pkg/rbac/access_control.go
+++ b/pkg/rbac/access_control.go
@@ -13,8 +13,8 @@ func NewAccessControl(ctx context.Context, clusterName string, rbacClient v1.Int
 	return NewAccessControlWithASL(clusterName, asl)
 }
 
-func NewAccessControlWithASL(clusterName string, asl accesscontrol.AccessSetLookup) types.AccessControl {
-	return newContextBased(func(ctx *types.APIContext) (types.AccessControl, bool) {
+func NewAccessControlWithASL(clusterName string, asl accesscontrol.AccessSetForSchemaLookup) types.AccessControl {
+	return newContextBased(func(ctx *types.APIContext, schema *types.Schema) (types.AccessControl, bool) {
 		cache, ok := ctx.Request.Context().Value(contextKey{}).(*accessControlCache)
 		if !ok {
 			return nil, false
@@ -32,7 +32,7 @@ func NewAccessControlWithASL(clusterName string, asl accesscontrol.AccessSetLook
 
 		cache.Lock()
 		defer cache.Unlock()
-		ac = newUserLookupAccess(ctx, asl)
+		ac = newUserLookupAccess(ctx, schema, asl)
 		cache.cache[clusterName] = ac
 		return ac, true
 	})

--- a/pkg/rbac/context_access_control.go
+++ b/pkg/rbac/context_access_control.go
@@ -12,7 +12,7 @@ type contextBased struct {
 	lookup contextLookup
 }
 
-type contextLookup func(ctx *types.APIContext) (types.AccessControl, bool)
+type contextLookup func(ctx *types.APIContext, schema *types.Schema) (types.AccessControl, bool)
 
 func newContextBased(lookup contextLookup) types.AccessControl {
 	return &contextBased{
@@ -21,7 +21,7 @@ func newContextBased(lookup contextLookup) types.AccessControl {
 }
 
 func (c *contextBased) Expire(apiContext *types.APIContext, schema *types.Schema) {
-	ac, ok := c.lookup(apiContext)
+	ac, ok := c.lookup(apiContext, schema)
 	if !ok {
 		return
 	}
@@ -31,7 +31,7 @@ func (c *contextBased) Expire(apiContext *types.APIContext, schema *types.Schema
 }
 
 func (c *contextBased) CanCreate(apiContext *types.APIContext, schema *types.Schema) error {
-	ac, ok := c.lookup(apiContext)
+	ac, ok := c.lookup(apiContext, schema)
 	if ok {
 		return ac.CanCreate(apiContext, schema)
 	}
@@ -39,7 +39,7 @@ func (c *contextBased) CanCreate(apiContext *types.APIContext, schema *types.Sch
 }
 
 func (c *contextBased) CanList(apiContext *types.APIContext, schema *types.Schema) error {
-	ac, ok := c.lookup(apiContext)
+	ac, ok := c.lookup(apiContext, schema)
 	if ok {
 		return ac.CanList(apiContext, schema)
 	}
@@ -47,7 +47,7 @@ func (c *contextBased) CanList(apiContext *types.APIContext, schema *types.Schem
 }
 
 func (c *contextBased) CanGet(apiContext *types.APIContext, schema *types.Schema) error {
-	ac, ok := c.lookup(apiContext)
+	ac, ok := c.lookup(apiContext, schema)
 	if ok {
 		return ac.CanGet(apiContext, schema)
 	}
@@ -55,7 +55,7 @@ func (c *contextBased) CanGet(apiContext *types.APIContext, schema *types.Schema
 }
 
 func (c *contextBased) CanUpdate(apiContext *types.APIContext, obj map[string]interface{}, schema *types.Schema) error {
-	ac, ok := c.lookup(apiContext)
+	ac, ok := c.lookup(apiContext, schema)
 	if ok {
 		return ac.CanUpdate(apiContext, obj, schema)
 	}
@@ -63,7 +63,7 @@ func (c *contextBased) CanUpdate(apiContext *types.APIContext, obj map[string]in
 }
 
 func (c *contextBased) CanDelete(apiContext *types.APIContext, obj map[string]interface{}, schema *types.Schema) error {
-	ac, ok := c.lookup(apiContext)
+	ac, ok := c.lookup(apiContext, schema)
 	if ok {
 		return ac.CanDelete(apiContext, obj, schema)
 	}
@@ -71,7 +71,7 @@ func (c *contextBased) CanDelete(apiContext *types.APIContext, obj map[string]in
 }
 
 func (c *contextBased) CanDo(apiGroup, resource, verb string, apiContext *types.APIContext, obj map[string]interface{}, schema *types.Schema) error {
-	ac, ok := c.lookup(apiContext)
+	ac, ok := c.lookup(apiContext, schema)
 	if ok {
 		return ac.CanDo(apiGroup, resource, verb, apiContext, obj, schema)
 	}
@@ -79,7 +79,7 @@ func (c *contextBased) CanDo(apiGroup, resource, verb string, apiContext *types.
 }
 
 func (c *contextBased) Filter(apiContext *types.APIContext, schema *types.Schema, obj map[string]interface{}, context map[string]string) map[string]interface{} {
-	ac, ok := c.lookup(apiContext)
+	ac, ok := c.lookup(apiContext, schema)
 	if ok {
 		return ac.Filter(apiContext, schema, obj, context)
 	}
@@ -87,7 +87,7 @@ func (c *contextBased) Filter(apiContext *types.APIContext, schema *types.Schema
 }
 
 func (c *contextBased) FilterList(apiContext *types.APIContext, schema *types.Schema, obj []map[string]interface{}, context map[string]string) []map[string]interface{} {
-	ac, ok := c.lookup(apiContext)
+	ac, ok := c.lookup(apiContext, schema)
 	if ok {
 		return ac.FilterList(apiContext, schema, obj, context)
 	}

--- a/pkg/rbac/user_based.go
+++ b/pkg/rbac/user_based.go
@@ -35,14 +35,14 @@ func NewAccessControlHandler() auth.Middleware {
 	}
 }
 
-func newUserLookupAccess(ctx *types.APIContext, accessStore accesscontrol.AccessSetLookup) types.AccessControl {
+func newUserLookupAccess(ctx *types.APIContext, schema *types.Schema, accessStore accesscontrol.AccessSetForSchemaLookup) types.AccessControl {
 	userName := ctx.Request.Header.Get(transport.ImpersonateUserHeader)
 	groups := ctx.Request.Header[transport.ImpersonateGroupHeader]
 	user := &user2.DefaultInfo{
 		Name:   userName,
 		Groups: groups,
 	}
-	accessSet := accessStore.AccessFor(user)
+	accessSet := accessStore.AccessForSchema(user, schema)
 	return &userCachedAccess{
 		access: accessSet,
 	}

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -119,6 +119,7 @@ type Context struct {
 	Provisioning        provisioningv1.Interface
 
 	ASL                     accesscontrol.AccessSetLookup
+	ASLForSchema            accesscontrol.AccessSetForSchemaLookup
 	ClientConfig            clientcmd.ClientConfig
 	CachedDiscovery         discovery.CachedDiscoveryInterface
 	RESTMapper              meta.RESTMapper
@@ -337,6 +338,7 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 		Batch:                   batch.Batch().V1(),
 		ControllerFactory:       controllerFactory,
 		ASL:                     asl,
+		ASLForSchema:            asl,
 		ClientConfig:            clientConfig,
 		MultiClusterManager:     noopMCM{},
 		CachedDiscovery:         cache,


### PR DESCRIPTION
When there are a large volume of projects and therefore a large volume
of role template bindings, running reflect.DeepEquals on controller
updates, even though there are only on the order of 5-10 rules in each
role template, starts to use a high proportion of memory. This change
introduces a different way of comparing the rules that shifts the
compute and memory burden toward the role template. The role template
controller now computes a checksum representing the rules and sets it as
an annotation on the resource. The RTB update then checks the checksum
to see whether it has changed since the last update, instead of checking
the rules directly.