### PR TITLE
[2.6.6] Update default ui-dashboard-index setting

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -89,7 +89,7 @@ var (
 	UIFeedBackForm                      = NewSetting("ui-feedback-form", "")
 	UIIndex                             = NewSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
 	UIPath                              = NewSetting("ui-path", "/usr/share/rancher/ui")
-	UIDashboardIndex                    = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/release-2.6.5/index.html")
+	UIDashboardIndex                    = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/latest/index.html")
 	UIDashboardPath                     = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
 	UIPreferred                         = NewSetting("ui-preferred", "vue")
 	UIOfflinePreferred                  = NewSetting("ui-offline-preferred", "dynamic")


### PR DESCRIPTION
- The PR reverts https://github.com/rancher/rancher/pull/37662
- Ensure the dashboard served up in rancher builds with a version ending in `-head` tracks the `master` (`2.6.6`) dashboard branch 