### PR TITLE
[release/v2.6] Add script to show/check rc/final-rc chart/kdm src

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -109,7 +109,7 @@ RUN curl -sLf ${YQ_URL} -o /usr/bin/yq && chmod +x /usr/bin/yq
 RUN zypper install -y python3-tox python3-base python3 libffi-devel libopenssl-devel
 
 ENV HELM_HOME /root/.helm
-ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_COMMIT DRONE_BRANCH SYSTEM_CHART_DEFAULT_BRANCH FOSSA_API_KEY GOGET_MODULE GOGET_VERSION RELEASE_ACTION
+ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_COMMIT DRONE_BRANCH SYSTEM_CHART_DEFAULT_BRANCH FOSSA_API_KEY GOGET_MODULE GOGET_VERSION RELEASE_ACTION RELEASE_TYPE
 ENV DAPPER_SOURCE /go/src/github.com/rancher/rancher/
 ENV DAPPER_OUTPUT ./bin ./dist ./go.mod ./go.sum ./pkg/apis/go.mod ./pkg/apis/go.sum ./pkg/client/go.mod ./pkg/client/go.sum ./scripts/package ./pkg/settings/setting.go ./package/Dockerfile ./Dockerfile.dapper
 ENV DAPPER_DOCKER_SOCKET true

--- a/scripts/check-chart-kdm-source-values
+++ b/scripts/check-chart-kdm-source-values
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Without RELEASE_TYPE set, it will show the values for each.
+# With RELEASE_TYPE set to 'rc' or 'final-rc', it will compare the values to the expected ones and report CORRECT or INCORRECT
+
+case $RELEASE_TYPE in
+  rc)
+    REQUIRED_VALUE="dev-v2.6"
+    ;;
+  final-rc)
+    REQUIRED_VALUE="release-v2.6"
+    ;;
+esac
+
+if [ -n "${RELEASE_TYPE}" ]; then
+   echo "RELEASE_TYPE is ${RELEASE_TYPE}"
+   echo "Going to check for ${REQUIRED_VALUE}"
+fi
+
+# scripts/package
+for PKGENV in SYSTEM_CHART_DEFAULT_BRANCH CHART_DEFAULT_BRANCH; do
+   FOUND_VALUE=$(grep ^${PKGENV} scripts/package | awk -F':-' '{ print $2 }' | sed 's/.$//' | sed 's/"//g')
+   if [ -n "${RELEASE_TYPE}" ]; then
+      echo -n "${PKGENV}: ${FOUND_VALUE} in scripts/package: "
+      if [ "${FOUND_VALUE}" != "${REQUIRED_VALUE}" ]; then
+        echo "INCORRECT (should be ${REQUIRED_VALUE})"
+      else
+        echo "CORRECT"
+      fi
+   else
+      echo "* ${PKGENV}: ${FOUND_VALUE} (\`scripts/package\`)"
+   fi
+done
+
+# package/Dockerfile
+for DFARG in SYSTEM_CHART_DEFAULT_BRANCH CHART_DEFAULT_BRANCH CATTLE_KDM_BRANCH; do
+   FOUND_VALUE=$(grep ^"ARG ${DFARG}" package/Dockerfile | awk -F'=' '{ print $2 }')
+   if [ -n "${RELEASE_TYPE}" ]; then
+      echo -n "${DFARG}: ${FOUND_VALUE} in package/Dockerfile: "
+      if [ "${FOUND_VALUE}" != "${REQUIRED_VALUE}" ]; then
+        echo "INCORRECT (should be ${REQUIRED_VALUE})"
+      else
+        echo "CORRECT"
+      fi
+   else
+      echo "* ${DFARG}: ${FOUND_VALUE} (\`package/Dockerfile\`)"
+   fi
+done
+
+# Dockerfile.dapper
+for DFDENV in CATTLE_KDM_BRANCH; do
+   FOUND_VALUE=$(grep ^"ENV ${DFDENV}" Dockerfile.dapper| awk -F'=' '{ print $2 }')
+   if [ -n "${RELEASE_TYPE}" ]; then
+      echo -n "${DFDENV}: ${FOUND_VALUE} in Dockerfile.dapper: "
+      if [ "${FOUND_VALUE}" != "${REQUIRED_VALUE}" ]; then
+        echo "INCORRECT (should be ${REQUIRED_VALUE})"
+      else
+        echo "CORRECT"
+      fi
+   else
+      echo "* ${DFDENV}: ${FOUND_VALUE} (\`Dockerfile.dapper\`)"
+   fi
+done
+
+# pkg/settings/setting.go
+for PKGSETTING in KDMBranch ChartDefaultBranch; do
+   FOUND_VALUE=$(grep ^"\\s*${PKGSETTING}" pkg/settings/setting.go | awk -F', ' '{ print $2 }' | sed 's/)//' | sed 's/"//g')
+   if [ -n "${RELEASE_TYPE}" ]; then
+      echo -n "${PKGSETTING}: ${FOUND_VALUE} in pkg/settings/setting.go: "
+      if [ "${FOUND_VALUE}" != "${REQUIRED_VALUE}" ]; then
+        echo "INCORRECT (should be ${REQUIRED_VALUE})"
+      else
+        echo "CORRECT"
+      fi
+   else
+      echo "* ${PKGSETTING}: ${FOUND_VALUE} (\`pkg/settings/setting.go\`)"
+   fi
+done

--- a/scripts/create-components-file.sh
+++ b/scripts/create-components-file.sh
@@ -31,4 +31,8 @@ if [[ -f "$K8SVERSIONSFILE" ]]; then
     cat $K8SVERSIONSFILE >> $COMPONENTSFILE
 fi
 
+echo "# Chart/KDM sources" >> $COMPONENTSFILE
+
+bash ./scripts/check-chart-kdm-source-values >> $COMPONENTSFILE
+
 echo "Done creating ./bin/rancher-components.txt"


### PR DESCRIPTION
One of the first steps in the current release process is to check the charts/KDM sources, and if they are set correctly based on if its a regular RC or the final RC. We implemented a script to change these values, but we still have to manually check the values that are set. This script can be run as a replacement of that step. Without `RELEASE_TYPE` set, it will show the values (and this will be used in the `rancher-components.txt` file).

`RELEASE_TYPE` can be `rc` or `final-rc` and will check if the values are correct based on this.

This PR results in current `release/v2.6` in the following `rancher-components.txt` file content:

```
# Images with -rc
rancher/rancher-webhook v0.2.6-rc3
# Components with -rc
# Min version components with -rc
RANCHER_WEBHOOK_MIN_VERSION 1.0.5+up0.2.6-rc3
# RKE Kubernetes versions
v1.18.20-rancher1-3
v1.19.16-rancher1-5
v1.20.15-rancher1-3
v1.21.12-rancher1-1
v1.22.9-rancher1-1
v1.23.6-rancher1-1
# Chart/KDM sources
* SYSTEM_CHART_DEFAULT_BRANCH: dev-v2.6 (`scripts/package`)
* CHART_DEFAULT_BRANCH: dev-v2.6 (`scripts/package`)
* SYSTEM_CHART_DEFAULT_BRANCH: dev-v2.6 (`package/Dockerfile`)
* CHART_DEFAULT_BRANCH: dev-v2.6 (`package/Dockerfile`)
* CATTLE_KDM_BRANCH: dev-v2.6 (`package/Dockerfile`)
* CATTLE_KDM_BRANCH: dev-v2.6 (`Dockerfile.dapper`)
* KDMBranch: dev-v2.6 (`pkg/settings/setting.go`)
* ChartDefaultBranch: dev-v2.6 (`pkg/settings/setting.go`)
```