### PR TITLE
Add monitoringv2 p0 & upgrade validation test cases including helpers

### DIFF
--- a/tests/framework/extensions/projects/projects.go
+++ b/tests/framework/extensions/projects/projects.go
@@ -1,0 +1,34 @@
+package projects
+
+import (
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+)
+
+// GetProjectByName is a helper function that returns the project by name in a specific cluster
+func GetProjectByName(client *rancher.Client, clusterID, projectName string) (*management.Project, error) {
+	var project *management.Project
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	if err != nil {
+		return project, err
+	}
+
+	projectsList, err := adminClient.Management.Project.List(&types.ListOpts{
+		Filters: map[string]interface{}{
+			"clusterId": clusterID,
+		},
+	})
+	if err != nil {
+		return project, err
+	}
+
+	for _, p := range projectsList.Data {
+		if p.Name == projectName {
+			project = &p
+		}
+	}
+
+	return project, nil
+}

--- a/tests/framework/extensions/secrets/getsecrets.go
+++ b/tests/framework/extensions/secrets/getsecrets.go
@@ -1,0 +1,32 @@
+package secrets
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	coreV1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetSecret is a helper function that uses the dynamic client to get a specific secret in a namespace for a specific cluster.
+func GetSecret(client *rancher.Client, clusterID, namespace, secretName string, getOpts metav1.GetOptions) (*coreV1.Secret, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	secretResource := dynamicClient.Resource(SecretGroupVersionResource).Namespace(namespace)
+
+	unstructuredResp, err := secretResource.Get(context.TODO(), secretName, getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	newSecret := &coreV1.Secret{}
+	err = scheme.Scheme.Convert(unstructuredResp, newSecret, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+	return newSecret, nil
+}

--- a/tests/framework/extensions/secrets/patchsecrets.go
+++ b/tests/framework/extensions/secrets/patchsecrets.go
@@ -1,0 +1,49 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	coreV1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+)
+
+type PatchOP string
+
+const (
+	AddPatchOP     PatchOP = "add"
+	ReplacePatchOP PatchOP = "replace"
+	RemovePatchOP  PatchOP = "remove"
+)
+
+// PatchSecret is a helper function that uses the dynamic client to patch a secret in a namespace for a specific cluster.
+// Different secret operations are supported: add, replace, remove.
+func PatchSecret(client *rancher.Client, clusterID, secretName, namespace string, patchType types.PatchType, patchOp PatchOP, patchPath, patchData string, patchOpts metav1.PatchOptions) (*coreV1.Secret, error) {
+	patchJSONOperation := fmt.Sprintf(`
+	[
+	  { "op": "%v", "path": "%v", "value": "%v" }
+	]
+	`, patchOp, patchPath, patchData)
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	secretResource := dynamicClient.Resource(SecretGroupVersionResource).Namespace(namespace)
+
+	unstructuredResp, err := secretResource.Patch(context.TODO(), secretName, patchType, []byte(patchJSONOperation), patchOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	newSecret := &coreV1.Secret{}
+	err = scheme.Scheme.Convert(unstructuredResp, newSecret, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+	return newSecret, nil
+}

--- a/tests/framework/extensions/secrets/secrets.go
+++ b/tests/framework/extensions/secrets/secrets.go
@@ -20,7 +20,6 @@ var SecretGroupVersionResource = schema.GroupVersionResource{
 }
 
 // CreateSecret is a helper function that uses the dynamic client to create a secret on a namespace for a specific cluster.
-// It registers a delete fuction.
 func CreateSecret(client *rancher.Client, secret *coreV1.Secret, clusterName, namespace string) (*coreV1.Secret, error) {
 	dynamicClient, err := client.GetDownStreamClusterClient(clusterName)
 	if err != nil {

--- a/tests/framework/extensions/services/create.go
+++ b/tests/framework/extensions/services/create.go
@@ -1,0 +1,51 @@
+package services
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/unstructured"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ServiceGroupVersionResource is the required Group Version Resource for accessing services in a cluster,
+// using the dynamic client.
+var ServiceGroupVersionResource = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "services",
+}
+
+// CreateService is a helper function that uses the dynamic client to create a service in a namespace for a specific cluster.
+func CreateService(client *rancher.Client, clusterName, serviceName, namespace string, spec corev1.ServiceSpec) (*corev1.Service, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: namespace,
+		},
+		Spec: spec,
+	}
+
+	serviceResource := dynamicClient.Resource(ServiceGroupVersionResource).Namespace(namespace)
+
+	unstructuredResp, err := serviceResource.Create(context.TODO(), unstructured.MustToUnstructured(service), metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	newService := &corev1.Service{}
+	err = scheme.Scheme.Convert(unstructuredResp, newService, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	return newService, nil
+}

--- a/tests/v2/validation/charts/monitoring.go
+++ b/tests/v2/validation/charts/monitoring.go
@@ -1,0 +1,432 @@
+package charts
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/rancher/rancher/pkg/controllers/managementuserlegacy/alert/config"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/charts"
+	"github.com/rancher/rancher/tests/framework/extensions/unstructured"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/deployments"
+	"github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"gopkg.in/yaml.v2"
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	// Project that example app and charts are installed in
+	projectName = "System"
+	// Secret path that contains encoded alert manager config
+	secretPath = "alertmanager.yaml"
+	// Secret path that is used to manipulate alert manager secret with secrets helpers
+	secretPathForPatch = "/data/" + secretPath
+	// Default random string length for random name generation
+	defaultRandStringLength = 5
+	// Webhook deployment annotation key that is being watched
+	webhookReceiverAnnotationKey = "didReceiveRequestFromAlertmanager"
+	// Webhook deployment annotation value that is being watched
+	webhookReceiverAnnotationValue = "true"
+	// Kubeconfig that linked to webhook deployment
+	kubeConfig = `
+apiVersion: v1
+kind: Config
+clusters:
+- name: cluster
+  cluster:
+    certificate-authority: /run/secrets/kubernetes.io/serviceaccount/ca.crt
+    server: https://kubernetes.default
+contexts:
+- name: default
+  context:
+    cluster: cluster
+    user: user
+current-context: default
+users:
+- name: user
+  user:
+    tokenFile: /run/secrets/kubernetes.io/serviceaccount/token
+`
+)
+
+var prometheusRulesGroupVersionResource = schema.GroupVersionResource{
+	Group:    "monitoring.coreos.com",
+	Version:  "v1",
+	Resource: "prometheusrules",
+}
+
+var (
+	// Rancher monitoring chart alert manager path
+	alertManagerPath = "api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-alertmanager:9093/proxy/#/alerts"
+	// Rancher monitoring chart grafana path
+	grafanaPath = "api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"
+	// Rancher monitoring chart prometheus path
+	prometheusPath = "api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-prometheus:9090/proxy"
+	// Rancher monitoring chart prometheus graph path
+	prometheusGraphPath = prometheusPath + "/graph"
+	// Rancher monitoring chart prometheus rules path
+	prometheusRulesPath = prometheusPath + "/rules"
+	// Rancher monitoring chart prometheus targets path
+	prometheusTargetsPath = prometheusPath + "/targets"
+	// Rancher monitoring chart prometheus targets API path
+	prometheusTargetsPathAPI = prometheusPath + "/api/v1/targets"
+	// Webhook receiver kubernetes object names
+	webhookReceiverNamespaceName  = "webhook-namespace-" + namegenerator.RandStringLower(defaultRandStringLength)
+	webhookReceiverDeploymentName = "webhook-" + namegenerator.RandStringLower(defaultRandStringLength)
+	webhookReceiverServiceName    = "webhook-service-" + namegenerator.RandStringLower(defaultRandStringLength)
+	// Label that is used to identify webhook and rule
+	ruleLabel = map[string]string{"team": "qa"}
+)
+
+// getChartCaseEndpointUntilHealthyResponse is a private helper function
+// that awaits the success response from the endpoint until the timeout.
+func getChartCaseEndpointUntilHealthyResponse(client *rancher.Client, host, path string) bool {
+	timeout := 30 * time.Second
+	for start := time.Now(); time.Since(start) < timeout; {
+		result, _ := charts.GetChartCaseEndpoint(client, host, path, false)
+		if result.Ok {
+			return true
+		}
+	}
+	return false
+}
+
+// waitUnknownPrometheusTargets is a private helper function
+// that awaits the unknown Prometheus targets to be resolved until the timeout by using Prometheus API.
+func waitUnknownPrometheusTargets(client *rancher.Client) error {
+	checkUnknownPrometheusTargets := func() (bool, error) {
+		var statusInit bool
+		var unknownTargets []string
+		resultAPI, err := charts.GetChartCaseEndpoint(client, client.RancherConfig.Host, prometheusTargetsPathAPI, true)
+		if err != nil {
+			return statusInit, err
+		}
+		var mapResponse map[string]interface{}
+		if err = json.Unmarshal([]byte(resultAPI.Body), &mapResponse); err != nil {
+			return statusInit, err
+		}
+		if mapResponse["status"] != "success" {
+			return statusInit, fmt.Errorf("Fail to get targets from prometheus")
+		}
+		activeTargets := mapResponse["data"].(map[string]interface{})["activeTargets"].([]interface{})
+		if len(activeTargets) < 1 {
+			return false, fmt.Errorf("Failed to find any active targets")
+		}
+		for _, target := range activeTargets {
+			targetMap := target.(map[string]interface{})
+			if targetMap["health"].(string) == "unknown" {
+				unknownTargets = append(unknownTargets, targetMap["labels"].(map[string]interface{})["instance"].(string))
+			}
+		}
+		return len(unknownTargets) == 0, nil
+	}
+
+	timeout := 90 * time.Second
+	for start := time.Now(); time.Since(start) < timeout; {
+		result, err := checkUnknownPrometheusTargets()
+		if err != nil {
+			return err
+		}
+
+		if result {
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// checkPrometheusTargets is a private helper function
+// that checks if all active prometheus targets are healthy by using prometheus API.
+func checkPrometheusTargets(client *rancher.Client) (bool, error) {
+	var statusInit bool
+	var downTargets []string
+
+	err := waitUnknownPrometheusTargets(client)
+	if err != nil {
+		return statusInit, err
+	}
+
+	resultAPI, err := charts.GetChartCaseEndpoint(client, client.RancherConfig.Host, prometheusTargetsPathAPI, true)
+	if err != nil {
+		return statusInit, err
+	}
+
+	var mapResponse map[string]interface{}
+	if err = json.Unmarshal([]byte(resultAPI.Body), &mapResponse); err != nil {
+		return statusInit, err
+	}
+
+	if mapResponse["status"] != "success" {
+		return statusInit, fmt.Errorf("Fail to get targets from prometheus")
+	}
+
+	activeTargets := mapResponse["data"].(map[string]interface{})["activeTargets"].([]interface{})
+	if len(activeTargets) < 1 {
+		return false, fmt.Errorf("Failed to find any active targets")
+	}
+
+	for _, target := range activeTargets {
+		targetMap := target.(map[string]interface{})
+		if targetMap["health"].(string) == "down" {
+			downTargets = append(downTargets, targetMap["labels"].(map[string]interface{})["instance"].(string))
+		}
+	}
+	statusInit = len(downTargets) == 0
+
+	if !statusInit {
+		return statusInit, fmt.Errorf("All active target(s) are not healthy: %v", downTargets)
+	}
+
+	return statusInit, nil
+}
+
+// editAlertReceiver is a private helper function
+// that edits alert config structure to be used by the webhook receiver.
+func editAlertReceiver(alertConfigByte []byte, origin string, originURL *url.URL) (string, error) {
+	alertConfig := config.Config{}
+
+	err := yaml.Unmarshal(alertConfigByte, &alertConfig)
+	if err != nil {
+		return "", fmt.Errorf("Failed to unmarshal alert config: %v", err)
+	}
+
+	alertConfig.Global = &config.GlobalConfig{
+		ResolveTimeout: alertConfig.Global.ResolveTimeout,
+	}
+	alertConfig.Receivers = append(alertConfig.Receivers, &config.Receiver{
+		Name: webhookReceiverDeploymentName,
+		WebhookConfigs: []*config.WebhookConfig{
+			{
+				HTTPConfig: &config.HTTPClientConfig{
+					ProxyURL: config.URL{URL: originURL},
+				},
+				NotifierConfig: config.NotifierConfig{
+					VSendResolved: false,
+				},
+				URL: origin,
+			},
+		},
+	})
+
+	stringifiedAlertConfig := alertConfig.String()
+	encodedStringifiedAlertConfig := base64.StdEncoding.EncodeToString([]byte(stringifiedAlertConfig))
+
+	return encodedStringifiedAlertConfig, nil
+}
+
+// editAlertRoute is a private helper function
+// that edits alert config structure to be used by the webhook receiver.
+func editAlertRoute(alertConfigByte []byte, origin string, originURL *url.URL) (string, error) {
+	alertConfig := config.Config{}
+
+	err := yaml.Unmarshal(alertConfigByte, &alertConfig)
+	if err != nil {
+		return "", fmt.Errorf("Failed to unmarshal alert config: %v", err)
+	}
+
+	alertConfig.Global = &config.GlobalConfig{
+		ResolveTimeout: alertConfig.Global.ResolveTimeout,
+	}
+	alertConfig.Route.Routes = append(alertConfig.Route.Routes, &config.Route{
+		GroupWait:      alertConfig.Route.GroupWait,
+		GroupInterval:  alertConfig.Route.GroupInterval,
+		RepeatInterval: alertConfig.Route.RepeatInterval,
+		Match:          ruleLabel,
+		Receiver:       webhookReceiverDeploymentName,
+	})
+
+	stringifiedAlertConfig := alertConfig.String()
+	encodedStringifiedAlertConfig := base64.StdEncoding.EncodeToString([]byte(stringifiedAlertConfig))
+
+	return encodedStringifiedAlertConfig, nil
+}
+
+// createPrometheusRule is a private helper function
+// that creates a prometheus rule to be used by the webhook receiver.
+func createPrometheusRule(client *rancher.Client, clusterID string) error {
+	ruleName := "webhook-rule-" + namegenerator.RandStringLower(defaultRandStringLength)
+	alertName := "alert-" + namegenerator.RandStringLower(defaultRandStringLength)
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return err
+	}
+
+	prometheusRulesResource := dynamicClient.Resource(prometheusRulesGroupVersionResource).Namespace(charts.RancherMonitoringNamespace)
+	prometheusRule := &monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ruleName,
+			Namespace: charts.RancherMonitoringNamespace,
+		},
+		Spec: monitoringv1.PrometheusRuleSpec{
+			Groups: []monitoringv1.RuleGroup{
+				{
+					Name: ruleName,
+					Rules: []monitoringv1.Rule{
+						{
+							Alert:  alertName,
+							Expr:   intstr.IntOrString{Type: intstr.String, StrVal: "vector(0)"},
+							Labels: ruleLabel,
+							For:    "0s",
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err = prometheusRulesResource.Create(context.TODO(), unstructured.MustToUnstructured(prometheusRule), metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createWebhookReceiverDeployment is a private helper function that creates a service account, cluster role binding, and deployment for webhook receiver.
+// The deployment has two different containers with a shared volume, one for kubectl commands, and the other one to receive requests and write access logs to the shared empty dir volume.
+// Container that uses rancher/shell has a mounted volume to use the kubeconfig of the cluster. And it watches the access logs until a request from "alermanager" is received.
+// When the request is received it sets its deployment annotation "didReceiveRequestFromAlertmanager" to "true" while the annotations being watched by the test itself.
+func createAlertWebhookReceiverDeployment(client *rancher.Client, clusterID, namespace, deploymentName string) (*appv1.Deployment, error) {
+	serviceAccountName := "alert-receiver-sa-" + namegenerator.RandStringLower(defaultRandStringLength)
+	clusterRoleBindingName := "alert-receiver-cluster-admin-" + namegenerator.RandStringLower(defaultRandStringLength)
+	configMapName := "alert-receiver-cm-" + namegenerator.RandStringLower(defaultRandStringLength)
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create webhook receiver service account
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceAccountName,
+		},
+	}
+	_, err = dynamicClient.Resource(corev1.SchemeGroupVersion.WithResource("serviceaccounts")).Namespace(namespace).Create(context.TODO(), unstructured.MustToUnstructured(serviceAccount), metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// Create webhook receiver cluster role binding
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterRoleBindingName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccount.Name,
+				Namespace: namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+	}
+	_, err = dynamicClient.Resource(rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings")).Namespace("").Create(context.TODO(), unstructured.MustToUnstructured(clusterRoleBinding), metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// Create webhook receiver config map
+	configmap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: configMapName,
+		},
+		Data: map[string]string{
+			"config": kubeConfig,
+		},
+	}
+	_, err = dynamicClient.Resource(corev1.SchemeGroupVersion.WithResource("configmaps")).Namespace(namespace).Create(context.TODO(), unstructured.MustToUnstructured(configmap), metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// Create webhook receiver deployment
+	var runAsUser int64
+	var runAsGroup int64
+	deploymentTemplate := corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "alert-reciver-deployment",
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy:      corev1.RestartPolicyNever,
+			ServiceAccountName: serviceAccount.Name,
+			Containers: []corev1.Container{
+				{
+					Name:    "kubectl",
+					Image:   "rancher/shell:v0.1.10",
+					Command: []string{"/bin/sh", "-c"},
+					Args: []string{
+						fmt.Sprintf(
+							`until [ "$didReceiveRequestFromAlertmanager" = true ]; do if grep -q "Alertmanager" "/traefik/access.log"; then kubectl patch deployment %s -n %s --type "json" -p '[{"op":"add","path":"/metadata/annotations/%s","value":"%s"}]'; didReceiveRequestFromAlertmanager=true; sleep 5m; else sleep 10; echo "Checking logs file one more time"; fi; done`,
+							deploymentName, namespace, webhookReceiverAnnotationKey, webhookReceiverAnnotationValue,
+						),
+					},
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser:  &runAsUser,
+						RunAsGroup: &runAsGroup,
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "config", MountPath: "/root/usr/share/.kube/"},
+						{Name: "logs", MountPath: "/traefik"},
+					},
+				},
+				{
+					Name:  "traefik",
+					Image: "traefik:latest",
+					Args: []string{
+						"--entrypoints.web.address=:80", "--api.dashboard=true", "--api.insecure=true", "--accesslog=true", "--accesslog.filepath=/var/log/traefik/access.log", "--log.level=INFO", "--accesslog.fields.headers.defaultmode=keep",
+					},
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+							Protocol:      corev1.ProtocolTCP,
+						},
+						{
+							ContainerPort: 8080,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "logs", MountPath: "/var/log/traefik"},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: configmap.Name},
+						},
+					},
+				},
+				{
+					Name: "logs",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+		},
+	}
+	deployment, err := deployments.CreateDeployment(client, clusterID, deploymentName, namespace, deploymentTemplate)
+	if err != nil {
+		return deployment, err
+	}
+
+	return deployment, nil
+}

--- a/tests/v2/validation/charts/monitoring_test.go
+++ b/tests/v2/validation/charts/monitoring_test.go
@@ -1,0 +1,285 @@
+package charts
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"net/url"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/charts"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/extensions/projects"
+	"github.com/rancher/rancher/tests/framework/extensions/secrets"
+	"github.com/rancher/rancher/tests/framework/extensions/services"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+)
+
+type MonitoringTestSuite struct {
+	suite.Suite
+	client              *rancher.Client
+	session             *session.Session
+	project             *management.Project
+	chartInstallOptions *charts.InstallOptions
+	chartFeatureOptions *charts.RancherMonitoringOpts
+}
+
+func (m *MonitoringTestSuite) TearDownSuite() {
+	m.session.Cleanup()
+}
+
+func (m *MonitoringTestSuite) SetupSuite() {
+	testSession := session.NewSession(m.T())
+	m.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(m.T(), err)
+
+	m.client = client
+
+	// Get clusterName from config yaml
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(m.T(), clusterName, "Cluster name to install is not set")
+
+	// Get clusterID with clusterName
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(m.T(), err)
+
+	// Change alert manager and grafana paths if it's not local cluster
+	if clusterID != clusterName {
+		alertManagerPath = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, alertManagerPath)
+		grafanaPath = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, grafanaPath)
+		prometheusTargetsPathAPI = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, prometheusTargetsPathAPI)
+	}
+
+	// Change prometheus paths to use the clusterID
+	prometheusGraphPath = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, prometheusGraphPath)
+	prometheusRulesPath = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, prometheusRulesPath)
+	prometheusTargetsPath = fmt.Sprintf("k8s/clusters/%s/%s", clusterID, prometheusTargetsPath)
+
+	// Get latest versions of the monitoring chart
+	latestMonitoringVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherMonitoringName)
+	require.NoError(m.T(), err)
+
+	// Get project system projectId
+	project, err := projects.GetProjectByName(client, clusterID, projectName)
+	require.NoError(m.T(), err)
+
+	m.project = project
+	require.NotEmpty(m.T(), m.project)
+
+	m.chartInstallOptions = &charts.InstallOptions{
+		ClusterName: clusterName,
+		ClusterID:   clusterID,
+		Version:     latestMonitoringVersion,
+		ProjectID:   m.project.ID,
+	}
+	m.chartFeatureOptions = &charts.RancherMonitoringOpts{
+		IngressNginx:         true,
+		RKEControllerManager: true,
+		RKEEtcd:              true,
+		RKEProxy:             true,
+		RKEScheduler:         true,
+	}
+}
+
+func (m *MonitoringTestSuite) TestMonitoringChart() {
+	subSession := m.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := m.client.WithSession(subSession)
+	require.NoError(m.T(), err)
+
+	m.T().Log("Checking if the monitoring chart is already installed")
+	initialMonitoringChart, err := charts.GetChartStatus(client, m.project.ClusterID, charts.RancherMonitoringNamespace, charts.RancherMonitoringName)
+	require.NoError(m.T(), err)
+
+	if !initialMonitoringChart.IsAlreadyInstalled {
+		m.T().Log("Installing monitoring chart")
+		err = charts.InstallRancherMonitoringChart(client, m.chartInstallOptions, m.chartFeatureOptions)
+		require.NoError(m.T(), err)
+
+		m.T().Log("Waiting monitoring chart deployments to have expected number of available replicas")
+		err = charts.WatchAndWaitDeployments(client, m.project.ClusterID, charts.RancherMonitoringNamespace, metav1.ListOptions{})
+		require.NoError(m.T(), err)
+
+		m.T().Log("Waiting monitoring chart DaemonSets to have expected number of available nodes")
+		err = charts.WatchAndWaitDaemonSets(client, m.project.ClusterID, charts.RancherMonitoringNamespace, metav1.ListOptions{})
+		require.NoError(m.T(), err)
+
+		m.T().Log("Waiting monitoring chart StatefulSets to have expected number of ready replicas")
+		err = charts.WatchAndWaitStatefulSets(client, m.project.ClusterID, charts.RancherMonitoringNamespace, metav1.ListOptions{})
+		require.NoError(m.T(), err)
+	}
+
+	paths := []string{alertManagerPath, grafanaPath, prometheusGraphPath, prometheusRulesPath, prometheusTargetsPath}
+	for _, path := range paths {
+		m.T().Logf("Validating %s is accessible", path)
+		result, err := charts.GetChartCaseEndpoint(client, client.RancherConfig.Host, path, true)
+		assert.NoError(m.T(), err)
+		assert.True(m.T(), result.Ok)
+	}
+
+	m.T().Log("Validating all Prometheus active targets are up")
+	prometheusTargetsResult, err := checkPrometheusTargets(client)
+	assert.NoError(m.T(), err)
+	assert.True(m.T(), prometheusTargetsResult)
+
+	m.T().Log("Creating webhook receiver's namespace")
+	webhookReceiverNamespace, err := namespaces.CreateNamespace(client, webhookReceiverNamespaceName, "{}", map[string]string{}, map[string]string{}, m.project)
+	require.NoError(m.T(), err)
+
+	m.T().Log("Creating alert webhook receiver deployment and its resources")
+	alertWebhookReceiverDeployment, err := createAlertWebhookReceiverDeployment(client, m.project.ClusterID, webhookReceiverNamespace.Name, webhookReceiverDeploymentName)
+	require.NoError(m.T(), err)
+	assert.Equal(m.T(), alertWebhookReceiverDeployment.Name, webhookReceiverDeploymentName)
+
+	m.T().Log("Waiting webhook receiver deployment to have expected number of available replicas")
+	err = charts.WatchAndWaitDeployments(client, m.project.ClusterID, webhookReceiverNamespace.Name, metav1.ListOptions{})
+	require.NoError(m.T(), err)
+
+	m.T().Log("Creating node port service for webhook receiver deployment")
+	serviceSpec := corev1.ServiceSpec{
+		Type: corev1.ServiceTypeNodePort,
+		Ports: []corev1.ServicePort{
+			{
+				Name: "port",
+				Port: 8080,
+			},
+		},
+		Selector: alertWebhookReceiverDeployment.Spec.Template.Labels,
+	}
+	webhookReceiverService, err := services.CreateService(client, m.project.ClusterID, webhookReceiverServiceName, webhookReceiverNamespace.Name, serviceSpec)
+	require.NoError(m.T(), err)
+
+	// Get a random worker node' public external IP of a specific cluster
+	nodeCollection, err := client.Management.Node.List(&types.ListOpts{Filters: map[string]interface{}{
+		"clusterId": m.project.ClusterID,
+	}})
+	require.NoError(m.T(), err)
+	workerNodePublicIPs := []string{}
+	for _, node := range nodeCollection.Data {
+		workerNodePublicIPs = append(workerNodePublicIPs, node.Annotations["rke.cattle.io/external-ip"])
+	}
+	randWorkerNodePublicIP := workerNodePublicIPs[rand.Intn(len(workerNodePublicIPs))]
+
+	// Get URL and string versions of origin with random node' public IP
+	hostWithProtocol := fmt.Sprintf("http://%v:%v", randWorkerNodePublicIP, webhookReceiverService.Spec.Ports[0].NodePort)
+	urlOfHost, err := url.Parse(hostWithProtocol)
+	require.NoError(m.T(), err)
+
+	m.T().Logf("Getting alert manager secret")
+	alertManagerSecret, err := secrets.GetSecret(client, m.project.ClusterID, charts.RancherMonitoringNamespace, charts.RancherMonitoringAlertSecret, metav1.GetOptions{})
+	require.NoError(m.T(), err)
+
+	m.T().Logf("Editing alert manager secret receivers")
+	encodedAlertConfigWithReceiver, err := editAlertReceiver(alertManagerSecret.Data[secretPath], hostWithProtocol, urlOfHost)
+	require.NoError(m.T(), err)
+
+	patchedSecret, err := secrets.PatchSecret(client, m.project.ClusterID, charts.RancherMonitoringAlertSecret, charts.RancherMonitoringNamespace, apimachinerytypes.JSONPatchType, secrets.AddPatchOP, secretPathForPatch, encodedAlertConfigWithReceiver, metav1.PatchOptions{})
+	require.NoError(m.T(), err)
+	assert.Equal(m.T(), patchedSecret.Name, charts.RancherMonitoringAlertSecret)
+
+	m.T().Logf("Creating prometheus rule")
+	err = createPrometheusRule(client, m.project.ClusterID)
+	require.NoError(m.T(), err)
+
+	m.T().Logf("Getting alert manager secret")
+	alertManagerSecret, err = secrets.GetSecret(client, m.project.ClusterID, charts.RancherMonitoringNamespace, charts.RancherMonitoringAlertSecret, metav1.GetOptions{})
+	require.NoError(m.T(), err)
+
+	m.T().Logf("Editing alert manager secret routes")
+	encodedAlertConfigWithRoute, err := editAlertRoute(alertManagerSecret.Data[secretPath], hostWithProtocol, urlOfHost)
+	require.NoError(m.T(), err)
+
+	patchedSecret, err = secrets.PatchSecret(client, m.project.ClusterID, charts.RancherMonitoringAlertSecret, charts.RancherMonitoringNamespace, apimachinerytypes.JSONPatchType, secrets.AddPatchOP, secretPathForPatch, encodedAlertConfigWithRoute, metav1.PatchOptions{})
+	require.NoError(m.T(), err)
+	assert.Equal(m.T(), patchedSecret.Name, charts.RancherMonitoringAlertSecret)
+
+	m.T().Logf("Validating traefik is accessible externally")
+	host := fmt.Sprintf("%v:%v", randWorkerNodePublicIP, webhookReceiverService.Spec.Ports[0].NodePort)
+	result, err := charts.GetChartCaseEndpoint(client, host, "dashboard", false)
+	assert.NoError(m.T(), err)
+	assert.True(m.T(), result.Ok)
+
+	m.T().Logf("Validating alertmanager sent alert to webhook receiver")
+	err = charts.WatchAndWaitDeploymentForAnnotation(client, m.project.ClusterID, webhookReceiverNamespace.Name, alertWebhookReceiverDeployment.Name, webhookReceiverAnnotationKey, webhookReceiverAnnotationValue)
+	require.NoError(m.T(), err)
+}
+
+func (m *MonitoringTestSuite) TestUpgradeMonitoringChart() {
+	subSession := m.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := m.client.WithSession(subSession)
+	require.NoError(m.T(), err)
+
+	m.T().Log("Checking if the monitoring chart is installed with one of the previous versions")
+	initialMonitoringChart, err := charts.GetChartStatus(client, m.project.ClusterID, charts.RancherMonitoringNamespace, charts.RancherMonitoringName)
+	require.NoError(m.T(), err)
+
+	// Change monitoring install option version to previous version of the latest version
+	versionsList, err := client.Catalog.GetListChartVersions(charts.RancherMonitoringName)
+	require.NoError(m.T(), err)
+	require.Greaterf(m.T(), len(versionsList), 2, "There should be at least 2 versions of the monitoring chart")
+	versionLatest := versionsList[0]
+	versionBeforeLatest := versionsList[1]
+	m.chartInstallOptions.Version = versionBeforeLatest
+
+	if initialMonitoringChart.IsAlreadyInstalled && initialMonitoringChart.ChartDetails.Spec.Chart.Metadata.Version == versionLatest {
+		m.T().Skip("Skipping the upgrade case, monitoring chart is already installed with the latest version")
+	}
+
+	if !initialMonitoringChart.IsAlreadyInstalled {
+		m.T().Log("Installing monitoring chart with the last but one version")
+		err = charts.InstallRancherMonitoringChart(client, m.chartInstallOptions, m.chartFeatureOptions)
+		require.NoError(m.T(), err)
+
+		m.T().Log("Waiting monitoring chart deployments to have expected number of available replicas")
+		err = charts.WatchAndWaitDeployments(client, m.project.ClusterID, charts.RancherMonitoringNamespace, metav1.ListOptions{})
+		require.NoError(m.T(), err)
+
+		m.T().Log("Waiting monitoring chart DaemonSets to have expected number of available nodes")
+		err = charts.WatchAndWaitDaemonSets(client, m.project.ClusterID, charts.RancherMonitoringNamespace, metav1.ListOptions{})
+		require.NoError(m.T(), err)
+
+		m.T().Log("Waiting monitoring chart StatefulSets to have expected number of ready replicas")
+		err = charts.WatchAndWaitStatefulSets(client, m.project.ClusterID, charts.RancherMonitoringNamespace, metav1.ListOptions{})
+		require.NoError(m.T(), err)
+	}
+
+	monitoringChartPreUpgrade, err := charts.GetChartStatus(client, m.project.ClusterID, charts.RancherMonitoringNamespace, charts.RancherMonitoringName)
+	require.NoError(m.T(), err)
+
+	// Validate current version of rancher monitoring is one of the versions before latest
+	chartVersionPreUpgrade := monitoringChartPreUpgrade.ChartDetails.Spec.Chart.Metadata.Version
+	assert.Contains(m.T(), versionsList[1:], chartVersionPreUpgrade)
+
+	m.chartInstallOptions.Version, err = client.Catalog.GetLatestChartVersion(charts.RancherMonitoringName)
+	require.NoError(m.T(), err)
+
+	m.T().Log("Upgrading monitoring chart with the latest version")
+	err = charts.UpgradeRancherMonitoringChart(client, m.chartInstallOptions, m.chartFeatureOptions)
+	require.NoError(m.T(), err)
+
+	monitoringChartPostUpgrade, err := charts.GetChartStatus(client, m.project.ClusterID, charts.RancherMonitoringNamespace, charts.RancherMonitoringName)
+	require.NoError(m.T(), err)
+
+	// Compare rancher monitoring versions
+	chartVersionPostUpgrade := monitoringChartPostUpgrade.ChartDetails.Spec.Chart.Metadata.Version
+	assert.Equal(m.T(), m.chartInstallOptions.Version, chartVersionPostUpgrade)
+}
+
+func TestMonitoringTestSuite(t *testing.T) {
+	suite.Run(t, new(MonitoringTestSuite))
+}


### PR DESCRIPTION
**Extensions Updates**

- Implemented:
  - Project getter with the given project name
  - Watch and wait helpers for stateful sets and deployment annotations
  - Rancher monitoringv2 chart upgrade helper
  - Create service, secrets & patch secrets helpers
- Refactored:
  - Rancher monitoringv2 chart install helper to get the correct URL value in the payload

**Validation Tests**

Implemented:
- Monitoringv2 p0 & upgrade cases
  - Private wait healthy response helper built on top of the custom request helper for charts
  - Private wait for unknown Prometheus targets and targets check helpers built on top of the custom request helper for charts
  - Private alert config/secret manipulators for routes and receivers
  - Private Prometheus rule creation helper
  - Private webhook receiver creation and its required objects