### PR TITLE
Update OKE cluster driver to v1.8.1.

### DIFF
--- a/pkg/data/management/kontainerdriver_data.go
+++ b/pkg/data/management/kontainerdriver_data.go
@@ -92,8 +92,8 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 	}
 	if err := creator.addCustomDriver(
 		"oraclecontainerengine",
-		"https://github.com/rancher-plugins/kontainer-engine-driver-oke/releases/download/v1.7.1/kontainer-engine-driver-oke-linux",
-		"5a708bfc01c67558adc887258615900082263ca7d6f4160efb1a58501b0cc608",
+		"https://github.com/rancher-plugins/kontainer-engine-driver-oke/releases/download/v1.8.1/kontainer-engine-driver-oke-linux",
+		"57db1d61f75660adacab4c03bc7909eed8eab8755796bf19cca05adc9852271f",
 		"",
 		false,
 		"*.oraclecloud.com",


### PR DESCRIPTION
This MR updates [OKE Cluster Driver](https://github.com/rancher-plugins/kontainer-engine-driver-oke) to version `v1.8.1`, that supports a new flag for specifying [cloud-init](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengusingcustomcloudinitscripts.htm) for OKE nodes via `--node-user-data-contents`.

Related Issues:
- https://github.com/rancher-plugins/kontainer-engine-driver-oke/issues/46