### PR TITLE
[release/v2.6] Add release docs

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -109,7 +109,7 @@ RUN curl -sLf ${YQ_URL} -o /usr/bin/yq && chmod +x /usr/bin/yq
 RUN zypper install -y python3-tox python3-base python3 libffi-devel libopenssl-devel
 
 ENV HELM_HOME /root/.helm
-ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_COMMIT DRONE_BRANCH SYSTEM_CHART_DEFAULT_BRANCH FOSSA_API_KEY GOGET_MODULE GOGET_VERSION RELEASE_ACTION RELEASE_TYPE
+ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_COMMIT DRONE_BRANCH SYSTEM_CHART_DEFAULT_BRANCH FOSSA_API_KEY GOGET_MODULE GOGET_VERSION RELEASE_ACTION RELEASE_TYPE POSTRELEASE_RANCHER_VERSION POSTRELEASE_RANCHER_STABLE
 ENV DAPPER_SOURCE /go/src/github.com/rancher/rancher/
 ENV DAPPER_OUTPUT ./bin ./dist ./go.mod ./go.sum ./pkg/apis/go.mod ./pkg/apis/go.sum ./pkg/client/go.mod ./pkg/client/go.sum ./scripts/package ./pkg/settings/setting.go ./package/Dockerfile ./Dockerfile.dapper
 ENV DAPPER_DOCKER_SOCKET true

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,11 @@ TARGETS := $(shell ls scripts)
 	fi
 
 $(TARGETS): .dapper
-	./.dapper $@
+	@if [[ "$@" = "post-release-checks" ]] || [[ "$@" = "list-gomod-updates" ]] || [[ "$@" = "check-chart-kdm-source-values" ]]; then\
+		./.dapper -q --no-out $@;\
+	else\
+		./.dapper $@;\
+	fi
 
 .DEFAULT_GOAL := ci
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,161 @@
+# Releasing Rancher
+
+This page should include everything needed to create a release candidate or release.
+
+## Check chart and KDM sources
+
+Run `make check-chart-kdm-source-values` with the environment variable `RELEASE_TYPE` set to the type of release you are trying to create.
+
+For release candidate:
+
+```
+RELEASE_TYPE=rc make check-chart-kdm-source-values
+```
+
+For final rc and release:
+
+```
+RELEASE_TYPE=final-rc make check-chart-kdm-source-values
+```
+
+There should be no lines showing `INCORRECT`. You can use `make change-final-rc-values` to set the values correctly.
+
+For release candidate:
+
+```
+RELEASE_ACTION=revert make change-final-rc-values
+```
+
+For final rc and release:
+
+```
+RELEASE_ACTION=release make change-final-rc-values
+```
+
+Run `make check-chart-kdm-source-values` with `RELEASE_TYPE` correctly set to check the values again.
+
+## Check open PRs for versions bumps
+
+Pull requests are created automatically when versions of components that Rancher uses are tagged. You can [list open pull requests that have been automatically created](https://github.com/rancher/rancher/pulls?q=is%3Apr+label%3Astatus%2Fauto-created+is%3Aopen), and make sure they are merged. 
+
+## Check for Go module updates
+
+Run `make list-gomod-updates` to list all Rancher Go modules that have updated versions available. Create pull requests to update Go modules using the GitHub Actions workflow [Go Get](https://github.com/rancher/rancher/actions/workflows/go-get.yml)
+
+Example output:
+
+```
+github.com/rancher/apiserver needs update (have: v0.0.0-20220223185512-c4e289f92e46, available: v0.0.0-20220513144301-4808910b5d4d)
+github.com/rancher/dynamiclistener needs update (have: v0.3.1-0.20210616080009-9865ae859c7f, available: v0.3.3)
+github.com/rancher/fleet/pkg/apis needs update (have: v0.0.0-20210918015053-5a141a6b18f0, available: v0.0.0-20220521053957-26e7c98cdb47)
+github.com/rancher/lasso needs update (have: v0.0.0-20220412224715-5f3517291ad4, available: v0.0.0-20220519004610-700f167d8324)
+github.com/rancher/lasso/controller-runtime needs update (have: v0.0.0-20220303220250-a429cb5cb9c9, available: v0.0.0-20220519004610-700f167d8324)
+github.com/rancher/machine needs update (have: v0.15.0-rancher86, available: v0.15.0-rancher9)
+github.com/rancher/norman needs update (have: v0.0.0-20220517230400-5a324b6fc6b1, available: v0.0.0-20220520225714-4cc2f5a97011)
+github.com/rancher/rdns-server needs update (have: v0.0.0-20180802070304-bf662911db6a, available: v0.5.8)
+github.com/rancher/security-scan needs update (have: v0.1.7-0.20200222041501-f7377f127168, available: v0.2.7)
+github.com/rancher/steve needs update (have: v0.0.0-20220415184129-b23977e7f1b5, available: v0.0.0-20220503004032-53511a06ff37)
+github.com/rancher/system-upgrade-controller/pkg/apis needs update (have: v0.0.0-20210727200656-10b094e30007, available: v0.0.0-20220502195742-7eb95a99eb25)
+github.com/rancher/wrangler needs update (have: v0.8.11-0.20220411195911-c2b951ab3480, available: v1.0.0)
+```
+
+## Create tag and push
+
+In this example, the tag is v2.6.6-rc1
+
+```
+cd rancher
+git remote add rancher-release git@github.com:rancher/rancher.git
+git checkout rancher-release/release/v2.6
+git tag v2.6.6-rc1
+git push rancher-release v2.6.6-rc1
+```
+
+Wait for the Drone build to complete, see [Drone Publish](https://drone-publish.rancher.io/rancher/rancher) for status.
+
+## Start the Drone build for image scanning
+
+When the Drone build has completed, start a [Drone build for image scanning](https://github.com/rancher/image-scanning/#triggering-a-scan).
+
+# Additional steps for final release candidate
+
+These are the steps required for creating a final release candidate. The final release candidate is a copy of the actual release, except that we tag it as v2.X.X-rcX. All components and configuration should have a non-rc tag, and point to the release branch. (`release-v2.X` instead of `dev-v2.X`)
+
+## Check for rc components
+
+Check the previous release candidate on the [GitHub releases page](https://github.com/rancher/rancher/releases). It should show all the rc components found in that release candidate, make sure they are corrected before tagging the final release candidate. The file used for this information for each release (candidate) is `rancher-components.txt`.
+
+# Additional steps for release
+
+## Create the release tag and push
+
+Make sure the branch is up-to-date with the remote, in this example, the branch is `release/v2.6` and the release tag is `v2.6.6`
+
+```
+cd rancher
+git remote add rancher-release git@github.com:rancher/rancher.git
+git checkout rancher-release/release/v2.6
+git push rancher-release v2.6.6
+```
+
+Wait for the Drone build to complete, see [Drone Publish](https://drone-publish.rancher.io/rancher/rancher) for status.
+
+## Promote Docker image to latest
+
+Run `./scripts/promote-docker-image.sh` with the created tag as first argument and `latest` as second argument. In this example, the tag is `v2.6.6`.
+
+```
+./scripts/promote-docker-image.sh v2.6.6 latest
+```
+
+## Add release notes to GitHub release page
+
+Add the release notes to the GitHub release found on the [GitHub releases page](https://github.com/rancher/rancher/releases).
+
+## Run release check script
+
+Run `make post-release-checks` with environment variable `POSTRELEASE_RANCHER` set to the created tag. In this example, the tag is `v2.6.6`.
+
+```
+POSTRELEASE_RANCHER_VERSION=v2.6.6 make post-release-checks
+```
+
+This will check Docker images `rancher/rancher:v2.6.6`, `rancher/rancher:latest`, and check the `rancher-latest` Helm chart repository.
+
+## Post an announcement on Rancher Forums
+
+Go to https://forums.rancher.com/c/announcements/12 and create a new topic for the release with the release notes.
+
+## Update README.md in `rancher/rancher` repository
+
+Create a pull request to update the README using the GitHub Actions workflow [Update README](https://github.com/rancher/rancher/actions/workflows/update-readme.yml).
+
+# Additional steps for promoting a release to stable
+
+## Promote Docker image to stable
+
+Run `./scripts/promote-docker-image.sh` with the created tag as first argument and `stable` as second argument. In this example, the tag is `v2.6.6`.
+
+```
+./scripts/promote-docker-image.sh v2.6.6 stable
+```
+
+## Promote Helm chart to stable
+
+Run `./scripts/chart/promote-to-stable.sh` with the created tag as first argument. In this example, the tag is `v2.6.6`.
+
+```
+./scripts/chart/promote-to-stable.sh v2.6.6
+```
+
+## Run release check script
+
+Run `make post-release-checks` with environment variable `POSTRELEASE_RANCHER` set to the created tag and `POSTRELEASE_RANCHER_STABLE` set to `true`. In this example, the tag is `v2.6.6`.
+
+```
+POSTRELEASE_RANCHER_VERSION=v2.6.6 POSTRELEASE_RANCHER_STABLE=true make post-release-checks
+```
+
+## Update README.md in `rancher/rancher` repository
+
+Create a pull request to update the README using the GitHub Actions workflow [Update README](https://github.com/rancher/rancher/actions/workflows/update-readme.yml).

--- a/scripts/list-gomod-updates
+++ b/scripts/list-gomod-updates
@@ -1,0 +1,6 @@
+#!/bin/bash
+gomodfile=$(mktemp)
+echo "Gathering go module list with updates available"
+go list -u -m -json all > "$gomodfile"
+
+jq -r 'select(.Update != null) | select(.Indirect != true) | select(.Path | test("rancher")?) | "\(.Path) needs update (Have: \(.Version), Available: \(.Update.Version))"' "$gomodfile"

--- a/scripts/post-release-checks
+++ b/scripts/post-release-checks
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+if [ -z "$POSTRELEASE_RANCHER_VERSION" ]; then
+  echo "Usage: POSTRELEASE_RANCHER_VERSION=<version> $0"
+  exit 1
+fi
+
+echo "Checking Docker image versions for ${POSTRELEASE_RANCHER_VERSION}"
+
+docker pull -q rancher/rancher:"${POSTRELEASE_RANCHER_VERSION}"
+FOUND_VERSION=$(docker run --rm --entrypoint bash rancher/rancher:"${POSTRELEASE_RANCHER_VERSION}" -c "rancher --version" | awk -F" " '{ print $3 }')
+
+if [ "${POSTRELEASE_RANCHER_VERSION}" != "${FOUND_VERSION}" ]; then
+  echo "ERROR: Found version in Docker image is unexpected (want: ${POSTRELEASE_RANCHER_VERSION}, found: ${FOUND_VERSION})"
+else
+  echo "OK: Found version in Docker image is expected (want: ${POSTRELEASE_RANCHER_VERSION}, found: ${FOUND_VERSION})"
+fi
+
+docker pull -q rancher/rancher:latest
+FOUND_LATEST_VERSION=$(docker run --rm --entrypoint bash rancher/rancher:latest -c "rancher --version" | awk -F" " '{ print $3 }')
+
+if [ "${POSTRELEASE_RANCHER_VERSION}" != "${FOUND_LATEST_VERSION}" ]; then
+  echo "ERROR: Found version in latest Docker image is unexpected (want: ${POSTRELEASE_RANCHER_VERSION}, found: ${FOUND_LATEST_VERSION})"
+else
+  echo "OK: Found version in latest Docker image is expected (want: ${POSTRELEASE_RANCHER_VERSION}, found: ${FOUND_LATEST_VERSION})"
+fi
+
+if [ "$1" = "stable" ]; then
+  docker pull -q rancher/rancher:stable
+  FOUND_STABLE_VERSION=$(docker run --rm --entrypoint bash rancher/rancher:stable -c "rancher --version" | awk -F" " '{ print $3 }')
+
+  if [ "${POSTRELEASE_RANCHER_VERSION}" != "${FOUND_STABLE_VERSION}" ]; then
+    echo "ERROR: Found version in stable Docker image is unexpected (want: ${POSTRELEASE_RANCHER_VERSION}, found: ${FOUND_STABLE_VERSION})"
+  else
+    echo "OK: Found version in stable Docker image is expected (want: ${POSTRELEASE_RANCHER_VERSION}, found: ${FOUND_STABLE_VERSION})"
+  fi
+fi
+
+# Check if Helm binary available in PATH
+if type helm_v3 >/dev/null; then
+  HELM_BINARY="helm_v3"
+  if [[ $(${HELM_BINARY} version --short | awk -F'.' '{ print $1}') != "v3" ]]; then
+    echo "Helm version does not start with v3"
+    exit 1
+  fi
+else
+  if type helm >/dev/null; then
+    HELM_BINARY="helm"
+  else
+    echo "Unable to find helm binary"
+    exit 1
+  fi
+fi
+
+LATEST_REPO="rancher-latest"
+
+echo "Checking ${LATEST_REPO} Helm chart repository for ${POSTRELEASE_RANCHER_VERSION}"
+
+${HELM_BINARY} repo add ${LATEST_REPO} https://releases.rancher.com/server-charts/latest > /dev/null 2>&1
+${HELM_BINARY} repo update > /dev/null 2>&1
+
+FOUND_HELMCHART_VERSION=$(${HELM_BINARY} search repo ${LATEST_REPO}/rancher -o json | jq -r .[].app_version)
+
+if [ "${POSTRELEASE_RANCHER_VERSION}" != "${FOUND_HELMCHART_VERSION}" ]; then
+  echo "ERROR: Found version in ${LATEST_REPO} chart repository is unexpected (want: ${POSTRELEASE_RANCHER_VERSION}, found: ${FOUND_HELMCHART_VERSION})"
+else
+  echo "OK: Found version in ${LATEST_REPO} chart repository is expected (want: ${POSTRELEASE_RANCHER_VERSION}, found: ${FOUND_HELMCHART_VERSION})"
+fi
+
+if [ "$POSTRELEASE_RANCHER_STABLE" = "true" ]; then
+  STABLE_REPO="rancher-stable"
+  echo "Checking ${STABLE_REPO} Helm chart repository for ${POSTRELEASE_RANCHER_VERSION}"
+
+  ${HELM_BINARY} repo add ${STABLE_REPO} https://releases.rancher.com/server-charts/stable > /dev/null 2>&1
+  ${HELM_BINARY} repo update > /dev/null 2>&1
+
+  FOUND_HELMCHART_STABLE_VERSION=$(${HELM_BINARY} search repo ${STABLE_REPO}/rancher -o json | jq -r .[].app_version)
+
+  if [ "${POSTRELEASE_RANCHER_VERSION}" != "${FOUND_HELMCHART_STABLE_VERSION}" ]; then
+    echo "ERROR: Found version in ${STABLE_REPO} chart repository is unexpected (want: ${POSTRELEASE_RANCHER_VERSION}, found: ${FOUND_HELMCHART_STABLE_VERSION})"
+  else
+    echo "OK: Found version in ${STABLE_REPO} chart repository is expected (want: ${POSTRELEASE_RANCHER_VERSION}, found: ${FOUND_HELMCHART_STABLE_VERSION})"
+  fi
+fi


### PR DESCRIPTION
* Adds script to show Go modules updates from `rancher`
* Adds script to do post release checks, also added a distinction between check actions and actual builds. This will cause `dapper` to be run using `-q --no-out` to have a clearer output from the checks.
* Adds release steps into `docs/` folder, this should be the foundation of keeping changes in the repository and when something was changed/automated