### PR TITLE
Add support to specify AMI IDs for the EC2 node driver

### DIFF
--- a/tests/framework/extensions/machinepools/amazonec2_machine_config.go
+++ b/tests/framework/extensions/machinepools/amazonec2_machine_config.go
@@ -15,6 +15,7 @@ const (
 // AWSMachineConfig is configuration needed to create an rke-machine-config.cattle.io.amazonec2config
 type AWSMachineConfig struct {
 	Region        string   `json:"region" yaml:"region"`
+	AMI	      string   `json:"ami" yaml:"ami"`
 	InstanceType  string   `json:"instanceType" yaml:"instanceType"`
 	SSHUser       string   `json:"sshUser" yaml:"sshUser"`
 	VPCID         string   `json:"vpcId" yaml:"vpcId"`
@@ -37,6 +38,7 @@ func NewAWSMachineConfig(generatedPoolName, namespace string) *unstructured.Unst
 	machineConfig.SetGenerateName(generatedPoolName)
 	machineConfig.SetNamespace(namespace)
 	machineConfig.Object["region"] = awsMachineConfig.Region
+	machineConfig.Object["ami"] = awsMachineConfig.AMI
 	machineConfig.Object["instanceType"] = awsMachineConfig.InstanceType
 	machineConfig.Object["sshUser"] = awsMachineConfig.SSHUser
 	machineConfig.Object["type"] = AWSPoolType

--- a/tests/v2/validation/provisioning/README.md
+++ b/tests/v2/validation/provisioning/README.md
@@ -91,6 +91,7 @@ Machine RKE pool config is the last thing need for the RKE2 provisioning tests
 ```json
 "awsMachineConfig": {
     "region": "us-east-2",
+    "ami": "",
     "instanceType": "t3a.medium",
     "sshUser": "ubuntu",
     "vpcId": "",


### PR DESCRIPTION
**PR Description**

This PR adds support for EC2 images to be specified when testing with the Go automation framework. If you choose to not set this optional parameter, then the prior behavior of the default AMI per AWS region still maintains; this simply offers more configuration choice.

Tested with multiple quick start / community AMIs for the following distros:

- Ubuntu 20.04: PASS
- SUSE 15SP3: PASS
- Ubuntu 22.04: PASS
     - Not supported, but the automation should still allow to pass, which it did.