### PR TITLE
Add ui-favicon setting to support custom favicon for the UI

### DIFF
--- a/pkg/data/dashboard/rbac.go
+++ b/pkg/data/dashboard/rbac.go
@@ -20,7 +20,7 @@ func addUnauthenticatedRoles(apply apply.Apply) error {
 						Verbs:         []string{"get"},
 						APIGroups:     []string{"management.cattle.io"},
 						Resources:     []string{"settings"},
-						ResourceNames: []string{"first-login", "ui-pl", "ui-banners", "ui-brand"},
+						ResourceNames: []string{"first-login", "ui-pl", "ui-banners", "ui-brand", "ui-favicon"},
 					},
 				},
 			},

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -91,6 +91,7 @@ var (
 	UIPath                              = NewSetting("ui-path", "/usr/share/rancher/ui")
 	UIDashboardIndex                    = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/latest/index.html")
 	UIDashboardPath                     = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
+	UIFavicon                           = NewSetting("ui-favicon", "")
 	UIPreferred                         = NewSetting("ui-preferred", "vue")
 	UIOfflinePreferred                  = NewSetting("ui-offline-preferred", "dynamic")
 	UIIssues                            = NewSetting("ui-issues", "")


### PR DESCRIPTION
This PR adds a new setting `ui-favicon` and adds this to the unauthenticated list, so that this setting is retrievable by the UI before the user has logged in.

This is in support of UI ticket - https://github.com/rancher/dashboard/issues/5067 - to allow users to configure a custom favicon for Rancher.