### PR TITLE
Revert "Scope Drone steps depending on push to branch/tag"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,13 +16,10 @@ steps:
   - name: docker
     path: /var/run/docker.sock
   when:
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
     event:
     - push
     - pull_request
+    - tag
 
 volumes:
 - name: docker
@@ -51,13 +48,10 @@ steps:
   - name: docker
     path: /var/run/docker.sock
   when:
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
     event:
     - push
     - pull_request
+    - tag
 
 volumes:
 - name: docker
@@ -86,11 +80,6 @@ steps:
   - name: docker
     path: /var/run/docker.sock
   when:
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
     - pull_request
@@ -124,11 +113,6 @@ steps:
   commands:
   - "cp -r ./bin/* ./package/"
   when:
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
     - tag
@@ -351,6 +335,22 @@ steps:
       exclude:
       - "refs/tags/*-*"
 
+- name: slack_notify
+  image: plugins/slack
+  settings:
+    template: "Build {{build.link}} failed to publish an image/artifact.\n"
+    username: Drone_Publish
+    webhook:
+      from_secret: slack_webhook
+  when:
+    event:
+      exclude:
+      - pull_request
+    instance:
+    - drone-publish.rancher.io
+    status:
+    - failure
+
 volumes:
 - name: docker
   host:
@@ -378,11 +378,6 @@ steps:
   - name: docker
     path: /var/run/docker.sock
   when:
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
     - pull_request
@@ -393,11 +388,6 @@ steps:
   commands:
   - "cp -r ./bin/* ./package/"
   when:
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
     - tag
@@ -538,6 +528,22 @@ steps:
     event:
     - tag
 
+- name: slack_notify
+  image: plugins/slack
+  settings:
+    template: "Build {{build.link}} failed to publish an image/artifact.\n"
+    username: Drone_Publish
+    webhook:
+      from_secret: slack_webhook
+  when:
+    event:
+      exclude:
+      - pull_request
+    instance:
+    - drone-publish.rancher.io
+    status:
+    - failure
+
 volumes:
 - name: docker
   host:
@@ -580,11 +586,6 @@ steps:
   - name: docker
     path: /var/run/docker.sock
   when:
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
     - pull_request
@@ -596,11 +597,6 @@ steps:
   commands:
   - "cp -r ./bin/* ./package/"
   when:
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
     - tag
@@ -795,11 +791,6 @@ steps:
       - name: docker_pipe
         path: \\\\.\\pipe\\docker_engine
     when:
-      ref:
-        include:
-          - "refs/heads/master"
-          - "refs/heads/release/v*"
-          - "refs/tags/v*"
       event:
         - push
         - pull_request
@@ -810,11 +801,6 @@ steps:
     commands:
       - "cp -r ./bin/* ./package/windows/"
     when:
-      ref:
-        include:
-          - "refs/heads/master"
-          - "refs/heads/release/v*"
-          - "refs/tags/v*"
       event:
         - push
         - tag
@@ -871,6 +857,22 @@ steps:
       event:
         - tag
 
+  - name: slack_notify
+    image: plugins/slack
+    settings:
+      template: "Build {{build.link}} failed to publish an image/artifact.\n"
+      username: Drone_Publish
+      webhook:
+        from_secret: slack_webhook
+    when:
+      event:
+        exclude:
+          - pull_request
+      instance:
+        - drone-publish.rancher.io
+      status:
+        - failure
+
 volumes:
   - name: docker_pipe
     host:
@@ -908,11 +910,6 @@ steps:
       - name: docker_pipe
         path: \\\\.\\pipe\\docker_engine
     when:
-      ref:
-        include:
-          - "refs/heads/master"
-          - "refs/heads/release/v*"
-          - "refs/tags/v*"
       event:
         - push
         - pull_request
@@ -979,6 +976,22 @@ steps:
       event:
         - tag
 
+  - name: slack_notify
+    image: plugins/slack
+    settings:
+      template: "Build {{build.link}} failed to publish an image/artifact.\n"
+      username: Drone_Publish
+      webhook:
+        from_secret: slack_webhook
+    when:
+      event:
+        exclude:
+          - pull_request
+      instance:
+        - drone-publish.rancher.io
+      status:
+        - failure
+
 volumes:
   - name: docker_pipe
     host:
@@ -1006,11 +1019,6 @@ steps:
     instance:
       include:
       - drone-publish.rancher.io
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
     - tag
@@ -1028,11 +1036,6 @@ steps:
     instance:
       include:
       - drone-publish.rancher.io
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
     - tag
@@ -1050,11 +1053,6 @@ steps:
     instance:
       include:
       - drone-publish.rancher.io
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
 
@@ -1071,11 +1069,6 @@ steps:
     instance:
       include:
       - drone-publish.rancher.io
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
     - tag
@@ -1093,11 +1086,6 @@ steps:
     instance:
       include:
       - drone-publish.rancher.io
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
 
@@ -1114,11 +1102,6 @@ steps:
     instance:
       include:
       - drone-publish.rancher.io
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
 
@@ -1135,11 +1118,6 @@ steps:
     instance:
       include:
       - drone-publish.rancher.io
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
     - tag
@@ -1153,11 +1131,6 @@ steps:
   - name: docker
     path: /var/run/docker.sock
   when:
-    ref:
-      include:
-        - "refs/heads/master"
-        - "refs/heads/release/v*"
-        - "refs/tags/v*"
     event:
     - push
     - tag
@@ -1175,6 +1148,23 @@ steps:
   when:
     event:
     - tag
+
+- name: slack_notify
+  image: plugins/slack
+  settings:
+    template: "Build {{build.link}} failed to push manifests.\n"
+    username: Drone_Publish
+    webhook:
+      from_secret: slack_webhook
+  when:
+    event:
+      exclude:
+      - pull_request
+    instance:
+      include:
+      - drone-publish.rancher.io
+    status:
+      - failure
 
 volumes:
 - name: docker
@@ -1471,6 +1461,23 @@ steps:
     target:
     - promote-stable
 
+- name: slack_notify
+  image: plugins/slack
+  settings:
+    template: "Build {{build.link}} failed to promote chart.\n"
+    username: Drone_Publish
+    webhook:
+      from_secret: slack_webhook
+  when:
+    event:
+    - promote
+    target:
+    - promote-stable
+    instance:
+      - drone-publish.rancher.io
+    status:
+      - failure
+
 volumes:
 - name: docker
   host:
@@ -1509,6 +1516,23 @@ steps:
     target:
     - promote-docker-image
 
+- name: slack_notify
+  image: plugins/slack
+  settings:
+    template: "Build {{build.link}} failed to push Docker image.\n"
+    username: Drone_Publish
+    webhook:
+      from_secret: slack_webhook
+  when:
+    event:
+    - promote
+    target:
+    - promote-docker-image
+    instance:
+      - drone-publish.rancher.io
+    status:
+      - failure
+
 volumes:
 - name: docker
   host:
@@ -1517,3 +1541,4 @@ volumes:
 trigger:
   event:
   - promote
+...


### PR DESCRIPTION
This reverts commit c3deb1123080159ea73a909d072fdf931f1217e5.

Provisioning tests were turned off for more than this PR intended. Due to the PR only having one commit, I have to revert the entire commit and have @superseb address this later.

This PR will require https://github.com/rancher/rancher/pull/37892 to be merged first