### PR TITLE
Fix missing entry in go.sum for aks-operator

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1240,7 +1240,6 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rackspace/gophercloud v0.0.0-20150408191457-ce0f487f6747/go.mod h1:4bJ1FwuaBZ6dt1VcDX5/O662mwR8GWqS4l68H6hkoYQ=
-github.com/rancher/aks-operator v1.0.5/go.mod h1:4AAOJmPqW41ko6L6cy7BOWbHEko7Yjcho1YP+KPAt+Y=
 github.com/rancher/aks-operator v1.0.6-rc1 h1:yuKBDvogufJrF3I80axoRyiwoiH9AKzTGBlUofZ3iso=
 github.com/rancher/aks-operator v1.0.6-rc1/go.mod h1:4AAOJmPqW41ko6L6cy7BOWbHEko7Yjcho1YP+KPAt+Y=
 github.com/rancher/apiserver v0.0.0-20201023000256-1a0a904f9197/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=


### PR DESCRIPTION
HEAD of release/v2.6 branch currently has a dirty status in Drone CI due to a go.sum change that was missed in a previous https://github.com/rancher/rancher/commit/dbddead8c39f38dc83f5da8bf18cdcd5c449a5eb and is brought in when a go mod tidy is run during CI. This PR addresses that and should resolve CI issues in combination with https://github.com/rancher/rancher/pull/37891 once it is merged.

```
git diff go.sum
diff --git a/go.sum b/go.sum
diff --git a/go.sum b/go.sum
--- a/go.sum
+++ b/go.sum
@@ -1240,7 +1240,6 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rackspace/gophercloud v0.0.0-20150408191457-ce0f487f6747/go.mod h1:4bJ1FwuaBZ6dt1VcDX5/O662mwR8GWqS4l68H6hkoYQ=
-github.com/rancher/aks-operator v1.0.5/go.mod h1:4AAOJmPqW41ko6L6cy7BOWbHEko7Yjcho1YP+KPAt+Y=
 github.com/rancher/aks-operator v1.0.6-rc1 h1:yuKBDvogufJrF3I80axoRyiwoiH9AKzTGBlUofZ3iso=
 github.com/rancher/aks-operator v1.0.6-rc1/go.mod h1:4AAOJmPqW41ko6L6cy7BOWbHEko7Yjcho1YP+KPAt+Y=
 github.com/rancher/apiserver v0.0.0-20201023000256-1a0a904f9197/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
```