### PR TITLE
Fix json ami configuration

### DIFF
--- a/tests/framework/extensions/machinepools/amazonec2_machine_config.go
+++ b/tests/framework/extensions/machinepools/amazonec2_machine_config.go
@@ -15,7 +15,7 @@ const (
 // AWSMachineConfig is configuration needed to create an rke-machine-config.cattle.io.amazonec2config
 type AWSMachineConfig struct {
 	Region        string   `json:"region" yaml:"region"`
-	AMI           string   `json:"region" yaml:"ami"`
+	AMI           string   `json:"ami" yaml:"ami"`
 	InstanceType  string   `json:"instanceType" yaml:"instanceType"`
 	SSHUser       string   `json:"sshUser" yaml:"sshUser"`
 	VPCID         string   `json:"vpcId" yaml:"vpcId"`


### PR DESCRIPTION
**PR Description**
There was a small issue in my earlier PR https://github.com/rancher/rancher/pull/37884 in where the json for the new `AMI` variable duplicated `region` instead of `ami`. This is a small update to fix that so that the change properly works.