### PR TITLE
Add kubeconfig tokens expiration

### DIFF
--- a/pkg/api/norman/customization/cluster/actionhandler.go
+++ b/pkg/api/norman/customization/cluster/actionhandler.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	gaccess "github.com/rancher/rancher/pkg/api/norman/customization/globalnamespaceaccess"

--- a/pkg/api/norman/customization/cluster/actions_kubeconfig.go
+++ b/pkg/api/norman/customization/cluster/actions_kubeconfig.go
@@ -42,7 +42,7 @@ func (a ActionHandler) GenerateKubeconfigActionHandler(actionName string, action
 
 	generateToken := strings.EqualFold(settings.KubeconfigGenerateToken.Get(), "true")
 	if generateToken {
-		// generate token and place it in kubeconfig, token doesn't expire
+		// generate token and place it in kubeconfig
 		if endpointEnabled {
 			tokenKey, err = a.ensureClusterToken(cluster.ID, apiContext)
 		} else {


### PR DESCRIPTION
Looks like kubeconfig tokens expiration works fine, only the configuration is not propagated.

Closes https://github.com/rancher/rancher/issues/37906