### PR TITLE
Updated the provisioning client to hit the steve API endpoint.

### DIFF
--- a/tests/framework/clients/rancher/provisioning/client.go
+++ b/tests/framework/clients/rancher/provisioning/client.go
@@ -13,10 +13,12 @@ type Client struct {
 	ts *session.Session
 }
 
-// Cluster is a struct that embedds ClusterInterface and has session.Session as an attribute to keep track of the resources created by ClusterInterface
-type Cluster struct {
+// Clusters is a struct that embedds the RESTClient and has session.Session and the namespace as an attribute to keep track of the resources created by the RESTClient
+type Clusters struct {
 	provisionClientV1.ClusterInterface
-	ts *session.Session
+	client rest.Interface
+	ts     *session.Session
+	ns     string
 }
 
 // NewForConfig creates a new ProvisioningV1Client for the given config. It also takes session.Session as parameter to track the resources
@@ -31,6 +33,6 @@ func NewForConfig(c *rest.Config, ts *session.Session) (*Client, error) {
 }
 
 // Clusters takes a namespace a returns a Cluster object that is used for the CRUD of a pkg/apis/provisioning.cattle.io/v1 Cluster
-func (p *Client) Clusters(namespace string) *Cluster {
-	return &Cluster{p.ProvisioningV1Interface.Clusters(namespace), p.ts}
+func (p *Client) Clusters(namespace string) *Clusters {
+	return &Clusters{p.ProvisioningV1Interface.Clusters(namespace), p.RESTClient(), p.ts, namespace}
 }

--- a/tests/framework/clients/rancher/provisioning/cluster.go
+++ b/tests/framework/clients/rancher/provisioning/cluster.go
@@ -2,22 +2,147 @@ package provisioning
 
 import (
 	"context"
+	"time"
 
-	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	scheme "github.com/rancher/rancher/pkg/generated/clientset/versioned/scheme"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
-// Create is ClusterInterface's Create function, that is being overwritten to register its delete function to the session.Session
-// that is being reference.
-func (c *Cluster) Create(ctx context.Context, cluster *apisV1.Cluster, opts metav1.CreateOptions) (*apisV1.Cluster, error) {
+const (
+	rancherProvisioningClustersURL = "v1/provisioning.cattle.io.clusters/"
+)
+
+// Get takes name of the cluster, and returns the corresponding cluster object, and an error if there is any.
+func (c *Clusters) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.Cluster, err error) {
+	result = &v1.Cluster{}
+	url := rancherProvisioningClustersURL + c.ns
+
+	err = c.client.Get().
+		AbsPath(url).
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Clusters that match those selectors.
+func (c *Clusters) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ClusterList, err error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
+	result = &v1.ClusterList{}
+	url := rancherProvisioningClustersURL + c.ns
+
+	err = c.client.Get().
+		AbsPath(url).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// Create takes the representation of a cluster and creates it. Returns the server's representation of the cluster, and an error, if there is any.
+// It register its delete function to the session.Session that is being reference.
+func (c *Clusters) Create(ctx context.Context, cluster *v1.Cluster, opts metav1.CreateOptions) (result *v1.Cluster, err error) {
 	c.ts.RegisterCleanupFunc(func() error {
 		err := c.Delete(context.TODO(), cluster.GetName(), metav1.DeleteOptions{})
 		if errors.IsNotFound(err) {
 			return nil
 		}
-
 		return err
 	})
-	return c.ClusterInterface.Create(ctx, cluster, opts)
+
+	result = &v1.Cluster{}
+	url := rancherProvisioningClustersURL + c.ns
+
+	err = c.client.Post().
+		AbsPath(url).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(cluster).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// Update takes the representation of a cluster and updates it. Returns the server's representation of the cluster, and an error, if there is any.
+func (c *Clusters) Update(ctx context.Context, cluster *v1.Cluster, opts metav1.UpdateOptions) (result *v1.Cluster, err error) {
+	result = &v1.Cluster{}
+	url := rancherProvisioningClustersURL + c.ns
+
+	err = c.client.Put().
+		AbsPath(url).
+		Name(cluster.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(cluster).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *Clusters) UpdateStatus(ctx context.Context, cluster *v1.Cluster, opts metav1.UpdateOptions) (result *v1.Cluster, err error) {
+	result = &v1.Cluster{}
+	url := rancherProvisioningClustersURL + c.ns
+
+	err = c.client.Put().
+		AbsPath(url).
+		Name(cluster.Name).
+		SubResource("status").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(cluster).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// Delete takes name of the cluster and deletes it. Returns an error if one occurs.
+func (c *Clusters) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	url := rancherProvisioningClustersURL + c.ns
+
+	return c.client.Delete().
+		AbsPath(url).
+		Name(name).
+		Body(&opts).
+		Do(ctx).
+		Error()
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *Clusters) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	var timeout time.Duration
+	if listOpts.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
+	}
+	url := rancherProvisioningClustersURL + c.ns
+
+	return c.client.Delete().
+		AbsPath(url).
+		VersionedParams(&listOpts, scheme.ParameterCodec).
+		Timeout(timeout).
+		Body(&opts).
+		Do(ctx).
+		Error()
+}
+
+// Patch applies the patch and returns the patched cluster.
+func (c *Clusters) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Cluster, err error) {
+	result = &v1.Cluster{}
+	url := rancherProvisioningClustersURL + c.ns
+
+	err = c.client.Patch(pt).
+		AbsPath(url).
+		Name(name).
+		SubResource(subresources...).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(data).
+		Do(ctx).
+		Into(result)
+	return
 }


### PR DESCRIPTION
**Background** 
When using the provisioning client we were not getting the Steve API endpoint but rather the Kubernetes API. So when attempting to do some calls it would fail differently in comparison to the rancher monitoring UI.

**Updates**
- Over wrote most of the API calls to hit the steve API endpoint
- For now just not including watch was we need to monitor the cluster resource using the Kubernetes API
- We get an unknown error during clean up for a standard user, which is expected because the user no longer has the proper RBAC to view the resource it had just deleted
- We also get an expected error when cleaning up the rke-machine-config.cattle.io resource, because now when we delete the cluster using the steve API endpoint, the rke-machine-config.cattle.io resource gets deleted as well. 