### PR TITLE
Fix git repo SSH URLs with custom usernames

### DIFF
--- a/pkg/catalogv2/git/download_test.go
+++ b/pkg/catalogv2/git/download_test.go
@@ -1,0 +1,37 @@
+package git
+
+import (
+	"testing"
+
+	assertlib "github.com/stretchr/testify/assert"
+)
+
+func Test_isGitSSH(t *testing.T) {
+	testCases := []struct {
+		gitURL   string
+		expected bool
+	}{
+		// True cases
+		{"customusername@github.com:user/repo.git", true},
+		{"customusername@gitlab.com:user/repo.git", true},
+		{"customusername@gitlab.com:user/repo", true},
+		{"customusername@gitlab.com:user/repo-with-dashes.git", true},
+		{"git@github.com:user/repo.git", true},
+		{"git@gitlab.com:user/repo-with-dashes.git", true},
+		{"git@gitlab.com:user/repo", true},
+		// False cases
+		{"https://github.com/user/repo.git", false},
+		{"http://gitlab.com/user/repo.git", false},
+		{"http://gitlab.com/user/repo", false},
+		{"http://gitlab.com", false},
+		{"git@gitlab.com", false},
+	}
+	assert := assertlib.New(t)
+	for _, tc := range testCases {
+		actual, err := isGitSSH(tc.gitURL)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		assert.Equalf(tc.expected, actual, "testcase: %v", tc)
+	}
+}


### PR DESCRIPTION
Issue: SURE-3512, https://github.com/rancher/rancher/issues/35135

Our existing logic for git repo SSH URL validation only allows URLs with the prefix `git@`, but users may have a username different than `git`. This PR modifies that logic to allow URLs with other usernames such as `gitrepos@`