### PR TITLE
Fix a linter issue blocking the CI

### DIFF
--- a/pkg/auth/providers/azure/clients/ad_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ad_graph_client.go
@@ -120,7 +120,7 @@ func (c *azureADGraphClient) LoginUser(_ *v32.AzureADConfig, _ *v32.AzureADLogin
 }
 
 // NewADGraphClientFromCredential configures the SPT, user, and group clients using a credential.
-func NewADGraphClientFromCredential(config *v32.AzureADConfig, credential *v32.AzureADLogin) (*azureADGraphClient, error) {
+func NewADGraphClientFromCredential(config *v32.AzureADConfig, credential *v32.AzureADLogin) (AzureClient, error) {
 	var c azureADGraphClient
 	logrus.Debug("[AZURE_PROVIDER] Started token swap with AzureAD")
 	oauthConfig, err := adal.NewOAuthConfig(config.Endpoint, config.TenantID)
@@ -160,7 +160,7 @@ func NewADGraphClientFromCredential(config *v32.AzureADConfig, credential *v32.A
 
 // NewAzureADGraphClientFromADALToken returns an Azure AD Graph client.
 // It sets up the SPT, user and group client using an access token to Azure AD Graph API.
-func NewAzureADGraphClientFromADALToken(config *v32.AzureADConfig, adalTokenSecret string) (*azureADGraphClient, error) {
+func NewAzureADGraphClientFromADALToken(config *v32.AzureADConfig, adalTokenSecret string) (AzureClient, error) {
 	adalToken, err := unmarshalADALToken(adalTokenSecret)
 	if err != nil {
 		return nil, err

--- a/pkg/auth/providers/azure/clients/ms_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client.go
@@ -257,7 +257,7 @@ func (c AccessTokenCache) Export(cache cache.Marshaler, key string) {
 // NewMSGraphClient returns a client of the Microsoft Graph API. It attempts to get an access token to the API.
 // It first tries to fetch the token from the refresh token, if the access token is found in the database.
 // If that fails, it tries to acquire it directly from the auth provider with the credential (application secret in Azure).
-func NewMSGraphClient(config *v32.AzureADConfig, secrets corev1.SecretInterface) (*azureMSGraphClient, error) {
+func NewMSGraphClient(config *v32.AzureADConfig, secrets corev1.SecretInterface) (AzureClient, error) {
 	c := &azureMSGraphClient{}
 	cred, err := confidential.NewCredFromSecret(config.ApplicationSecret)
 	if err != nil {


### PR DESCRIPTION
Fixing a linter issue that was not caught in the pervious PR CI run due to the `build` stage not having run, giving a fake pass.

There were three instances of a linter error like this: `unexported-return: exported func NewADGraphClientFromCredential returns unexported type *clients.azureADGraphClient, which can be annoying to use (revive)`

We may want to think about this rule - whether it warrants an exception to our golang-ci config.