### PR TITLE
Migrate etcdbackup retry from rancher to rke

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8
-	github.com/rancher/rke v1.3.12-0.20220520141546-b42ebdc40272
+	github.com/rancher/rke v1.3.13-rc1
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20220614001854-22b03d364d83
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
@@ -276,7 +276,7 @@ require (
 	github.com/onsi/gomega v1.17.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
-	github.com/opencontainers/runc v1.1.1 // indirect
+	github.com/opencontainers/runc v1.1.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1311,8 +1311,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8w
 github.com/rancher/remotedialer v0.2.6-0.20220104192242-f3837f8d649a/go.mod h1:vq3LvyOFnLcwMiCE1KdW3foPd6g5kAjZOtOb7JqGHck=
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8 h1:leqh0chjBsXhKWebxxFd5QPcoQLu51EpaHo04ce0o+8=
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
-github.com/rancher/rke v1.3.12-0.20220520141546-b42ebdc40272 h1:MqkMm5oVsoRgcDoLmvoj0E+4fFsdfFA/gm3HYHrI9MM=
-github.com/rancher/rke v1.3.12-0.20220520141546-b42ebdc40272/go.mod h1:t+VWWY6Cxs1OjRXRFQv+gZNWSfmFor9UReReDjYOnWs=
+github.com/rancher/rke v1.3.13-rc1 h1:lIg77TSHjxaqFDEcTMJqhKe+cyoXdI/KrLhz8naquFs=
+github.com/rancher/rke v1.3.13-rc1/go.mod h1:LwUwfCzbt74yf6Jc8qTJ99H5iOTHNbhTee7QcWktc0w=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
 github.com/rancher/steve v0.0.0-20220614001854-22b03d364d83 h1:ceEmEdZZu3r9sMtxVFYc03k3Mm5hX7a6m0V8sLINy2g=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20210918015053-5a141a6b18f0
 	github.com/rancher/gke-operator v1.1.3
 	github.com/rancher/norman v0.0.0-20220621173721-cba80063e705
-	github.com/rancher/rke v1.3.12-0.20220520141546-b42ebdc40272
+	github.com/rancher/rke v1.3.13-rc1
 	github.com/rancher/wrangler v0.8.11-0.20220411195911-c2b951ab3480
 	github.com/sirupsen/logrus v1.8.1
 	k8s.io/api v0.23.3

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -671,7 +671,7 @@ github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQ
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
-github.com/opencontainers/runc v1.1.1/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
+github.com/opencontainers/runc v1.1.2/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
@@ -750,8 +750,8 @@ github.com/rancher/machine v0.15.0-rancher63/go.mod h1:qXYNumxy0J08MO/mh/jNjyRuE
 github.com/rancher/norman v0.0.0-20220406153559-82478fb169cb/go.mod h1:gDEwYUxOknJaOG1jjcH40PQ8U8xnvB+sHph5VirKINY=
 github.com/rancher/norman v0.0.0-20220621173721-cba80063e705 h1:KyMXS1PgBxeCwdVWnYQbkKrJCghdgLfNmJTzWh/+514=
 github.com/rancher/norman v0.0.0-20220621173721-cba80063e705/go.mod h1:1G96Zmvnx1FSzCwr/9I6weg/247dH5mDyT2ng/cR7ug=
-github.com/rancher/rke v1.3.12-0.20220520141546-b42ebdc40272 h1:MqkMm5oVsoRgcDoLmvoj0E+4fFsdfFA/gm3HYHrI9MM=
-github.com/rancher/rke v1.3.12-0.20220520141546-b42ebdc40272/go.mod h1:t+VWWY6Cxs1OjRXRFQv+gZNWSfmFor9UReReDjYOnWs=
+github.com/rancher/rke v1.3.13-rc1 h1:lIg77TSHjxaqFDEcTMJqhKe+cyoXdI/KrLhz8naquFs=
+github.com/rancher/rke v1.3.13-rc1/go.mod h1:LwUwfCzbt74yf6Jc8qTJ99H5iOTHNbhTee7QcWktc0w=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
 github.com/rancher/wrangler v0.6.2-0.20200829053106-7e1dd4260224/go.mod h1:I7qe4DZNMOLKVa9ax7DJdBZ0XtKOppLF/dalhPX3vaE=

--- a/pkg/controllers/management/etcdbackup/etcdbackup.go
+++ b/pkg/controllers/management/etcdbackup/etcdbackup.go
@@ -117,11 +117,10 @@ func (c *Controller) Create(b *v3.EtcdBackup) (runtime.Object, error) {
 	}
 
 	if next := nextBackup(backups); next == nil || next.Name == b.Name {
-		bObj, err := c.createBackupForCluster(b, cluster)
+		b, err = c.createBackupForCluster(b, cluster)
 		if err != nil {
-			return bObj, fmt.Errorf("[etcd-backup] failed to perform etcd backup: %v", err)
+			return b, fmt.Errorf("[etcd-backup] failed to perform etcd backup: %v", err)
 		}
-		return bObj, nil
 	}
 
 	return b, nil
@@ -268,7 +267,7 @@ func IsBackupRecurring(backup *v3.EtcdBackup) bool {
 	return !backup.Spec.Manual
 }
 
-func (c *Controller) createBackupForCluster(b *v3.EtcdBackup, cluster *v3.Cluster) (runtime.Object, error) {
+func (c *Controller) createBackupForCluster(b *v3.EtcdBackup, cluster *v3.Cluster) (*v3.EtcdBackup, error) {
 	var err error
 	if b.DeletionTimestamp != nil || rketypes.BackupConditionCreated.IsUnknown(b) {
 		b.Spec.Filename = generateBackupFilename(b.Name, cluster.Spec.RancherKubernetesEngineConfig.Services.Etcd.BackupConfig)
@@ -281,8 +280,8 @@ func (c *Controller) createBackupForCluster(b *v3.EtcdBackup, cluster *v3.Cluste
 			return b, err
 		}
 	}
-	bObj, saveErr := c.etcdSaveWithBackoff(b)
-	b, err = c.backupClient.Update(bObj.(*v3.EtcdBackup))
+	b, saveErr := c.etcdSave(b)
+	b, err = c.backupClient.Update(b)
 	if err != nil {
 		return b, err
 	}
@@ -291,7 +290,7 @@ func (c *Controller) createBackupForCluster(b *v3.EtcdBackup, cluster *v3.Cluste
 		if !b.Spec.Manual {
 			_ = c.rotateFailedBackups(cluster)
 		}
-		return b, fmt.Errorf("failed to perform etcd backup: %v", saveErr)
+		return b, saveErr
 	}
 
 	if !b.Spec.Manual {
@@ -358,8 +357,8 @@ func (c *Controller) createNewBackup(cluster *v3.Cluster) (*v3.EtcdBackup, error
 	return c.backupClient.Create(newBackup)
 }
 
-func (c *Controller) etcdSaveWithBackoff(b *v3.EtcdBackup) (runtime.Object, error) {
-	backoff := getBackoff()
+// etcdSave will utilize RKE to take a snapshot on each of the nodes.
+func (c *Controller) etcdSave(b *v3.EtcdBackup) (*v3.EtcdBackup, error) {
 	kontainerDriver, err := c.KontainerDriverLister.Get("", service.RancherKubernetesEngineDriverName)
 	if err != nil {
 		return b, err
@@ -377,25 +376,19 @@ func (c *Controller) etcdSaveWithBackoff(b *v3.EtcdBackup) (runtime.Object, erro
 		if err != nil {
 			return b, err
 		}
-		var inErr error
-		err = wait.ExponentialBackoff(backoff, func() (bool, error) {
-			if inErr = c.backupDriver.ETCDSave(c.ctx, cluster.Name, kontainerDriver, spec, snapshotName); inErr != nil {
-				log.Warnf("%v", inErr)
-				return false, nil
-			}
-			return true, nil
-		})
-		if err != nil {
-			return b, err
+		// no need to retry, RKE will retry for us
+		if err = c.backupDriver.ETCDSave(c.ctx, cluster.Name, kontainerDriver, spec, snapshotName); err != nil {
+			log.Warnf("%v", err)
 		}
-		return b, inErr
+		return b, err
 	})
+	b = bObj.(*v3.EtcdBackup)
 	if err != nil {
-		rketypes.BackupConditionCompleted.False(bObj)
-		rketypes.BackupConditionCompleted.ReasonAndMessageFromError(bObj, err)
-		return bObj, err
+		rketypes.BackupConditionCompleted.False(b)
+		rketypes.BackupConditionCompleted.ReasonAndMessageFromError(b, err)
+		return b, err
 	}
-	return bObj, nil
+	return b, nil
 }
 
 func (c *Controller) etcdRemoveSnapshotWithBackoff(b *v3.EtcdBackup) error {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/37639

Removed retry logic for etcd snapshot from rancher, as it will be implemented in rke-tools and controlled from rke.

Depends on https://github.com/rancher/rke-tools/pull/153 and subsequent KDM update, and then https://github.com/rancher/rke/pull/2952.