### PR TITLE
Fix potential panic error when decompressing helm release data

### DIFF
--- a/pkg/catalogv2/helm/helm2.go
+++ b/pkg/catalogv2/helm/helm2.go
@@ -144,7 +144,7 @@ func decodeHelm2(data string) (*rspb.Release, error) {
 	// For backwards compatibility with releases that were stored before
 	// compression was introduced we skip decompression if the
 	// gzip magic header is not found
-	if bytes.Equal(b[0:3], magicGzip) {
+	if len(b) >= 3 && bytes.Equal(b[0:3], magicGzip) {
 		r, err := gzip.NewReader(bytes.NewReader(b))
 		if err != nil {
 			return nil, err

--- a/pkg/catalogv2/helm/helm3.go
+++ b/pkg/catalogv2/helm/helm3.go
@@ -121,7 +121,7 @@ func decodeHelm3(data string) (*release.Release, error) {
 	// For backwards compatibility with releases that were stored before
 	// compression was introduced we skip decompression if the
 	// gzip magic header is not found
-	if bytes.Equal(b[0:3], magicGzip) {
+	if len(b) >= 3 && bytes.Equal(b[0:3], magicGzip) {
 		r, err := gzip.NewReader(bytes.NewReader(b))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
(cherry picked from commit f51b2297b896eabf66a4d2bcf7fdc5535b8f4ebc)