### PR TITLE
Update AKS handler logic so imported clusters don't overwrite upstream fields

### DIFF
--- a/pkg/controllers/management/aks/aks_cluster_handler.go
+++ b/pkg/controllers/management/aks/aks_cluster_handler.go
@@ -35,9 +35,9 @@ import (
 )
 
 const (
-	aksAPIGroup         = "aks.cattle.io"
-	aksV1               = "aks.cattle.io/v1"
-	enqueueTime         = time.Second * 5
+	aksAPIGroup = "aks.cattle.io"
+	aksV1       = "aks.cattle.io/v1"
+	enqueueTime = time.Second * 5
 )
 
 type aksOperatorController struct {

--- a/pkg/controllers/management/aks/aks_cluster_handler.go
+++ b/pkg/controllers/management/aks/aks_cluster_handler.go
@@ -152,8 +152,8 @@ func (e *aksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 			if cluster.Status.AKSStatus.UpstreamSpec == nil {
 				return e.setInitialUpstreamSpec(cluster)
 			}
-			if !reflect.DeepEqual(cluster.Status.AKSStatus.UpstreamSpec, &cluster.Spec.AKSConfig) {
-				logrus.Infof("found imported cluster [%s], copying upstream state to AKSConfig", cluster.Name)
+			if !reflect.DeepEqual(cluster.Status.AKSStatus.UpstreamSpec, cluster.Spec.AKSConfig) {
+				logrus.Infof("Found imported cluster [%s], copying upstream state to AKSConfig", cluster.Name)
 				cluster = cluster.DeepCopy()
 				cluster.Spec.AKSConfig = cluster.Status.AKSStatus.UpstreamSpec
 			}

--- a/pkg/controllers/management/clusterupstreamrefresher/aks_upstream_spec.go
+++ b/pkg/controllers/management/clusterupstreamrefresher/aks_upstream_spec.go
@@ -9,6 +9,8 @@ import (
 	wranglerv1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 )
 
+// BuildAKSUpstreamSpec calls the AKS operator to build an upstream spec with all the data from the upstream cluster
+// and return it.
 func BuildAKSUpstreamSpec(secretsCache wranglerv1.SecretCache, secretClient wranglerv1.SecretClient, cluster *mgmtv3.Cluster) (*aksv1.AKSClusterConfigSpec, error) {
 	ctx := context.Background()
 	upstreamSpec, err := akscontroller.BuildUpstreamClusterState(ctx, secretsCache, secretClient, cluster.Spec.AKSConfig)


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/37681 <!-- link the issue or issues this PR resolves here --> 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable.  If this is a new feature describe why we need this feature and how it will be used. -->

When importing AKS cluster, the AKS handler in rancher creates an `AKSClusterConfig` object that is the object both rancher and the operator look at when checking for updates. On import, the AKS handler creates a new, mostly empty `AKSClusterConfig` object for the managed cluster without the majority of any preconfigured data that may already be present for the cluster in AKS. Then, any fields set to nil in the `AKSClusterConfig` object will overwrite data in AKS on the next update after provisioning.
 
## Solution
 
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

* Updated the AKS handler in rancher to copy the `spec.Status.AKSStatus.UpstreamSpec` to `spec.AKSConfig` so fields from the existing AKS cluster will be pulled into Rancher on import.

* Updated comments to be clearer
 
## Testing
 
<!-- Describe what, if any, testing you did.  If you added tests describe what cases they cover and do not cover. -->

This issue requires a lot of testing because it touches all parts of provisioning an AKS cluster. Here's the basic test plan I used to smoke test my changes.

Test plan
1. Provisioned (via the Rancher UI kubernetes v1.23.5)
	a. 1 node AKS cluster
	b. 1 node AKS. Update auth IP range to 0.0.0.0/0 in Azure. Check that no config was overwritten in AKS/change was propogated as expected
	c. 1 node AKS cluster. Update HTTP Application Routing in rancher UI. Check that no config was overwritten in AKS
2. Import
	a. 3 node AKS cluster created via CLI with UDR and firewall. Check that no config was overwritten in AKS (agent pool, network). Update kubernetes version for the cluster configuration
	b. 3 node AKS cluster created via Azure portal