### PR TITLE
Prefix CAPI log messages with [CAPI]

### DIFF
--- a/pkg/provisioningv2/capi/logger/log.go
+++ b/pkg/provisioningv2/capi/logger/log.go
@@ -28,11 +28,11 @@ func (l *Logger) Enabled(level int) bool {
 }
 
 func (l *Logger) Info(level int, msg string, keysAndValues ...interface{}) {
-	l.withValues(keysAndValues...).Debug(msg)
+	l.withValues(keysAndValues...).Debug("[CAPI] " + msg)
 }
 
 func (l *Logger) Error(err error, msg string, keysAndValues ...interface{}) {
-	l.withValues(keysAndValues...).Errorf("%s: %v", msg, err)
+	l.withValues(keysAndValues...).Errorf("[CAPI] %s: %v", msg, err)
 }
 
 func (l *Logger) WithValues(keysAndValues ...interface{}) logr.LogSink {


### PR DESCRIPTION
This PR adds a `[CAPI]` prefix to log messages that are logged by the CAPI controllers in Rancher for the v2provisioning framework. 

https://github.com/rancher/rancher/issues/37981