### PR TITLE
Explicitly set Graph Endpoint for new Graph SDK client

### DIFF
--- a/pkg/auth/providers/azure/clients/ms_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/cache"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+	"github.com/manicminer/hamilton/environments"
 	"github.com/manicminer/hamilton/msgraph"
 	"github.com/manicminer/hamilton/odata"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -285,11 +286,13 @@ func NewMSGraphClient(config *v32.AzureADConfig, secrets corev1.SecretInterface)
 	authorizer := authorizer{authResult: authResult}
 
 	userClient := msgraph.NewUsersClient(config.TenantID)
+	userClient.BaseClient.Endpoint = environments.ApiEndpoint(config.GraphEndpoint)
 	userClient.BaseClient.Authorizer = &authorizer
 	userClient.BaseClient.ApiVersion = msgraph.Version10
 	userClient.BaseClient.DisableRetries = true
 
 	groupClient := msgraph.NewGroupsClient(config.TenantID)
+	groupClient.BaseClient.Endpoint = environments.ApiEndpoint(config.GraphEndpoint)
 	groupClient.BaseClient.Authorizer = &authorizer
 	groupClient.BaseClient.ApiVersion = msgraph.Version10
 	groupClient.BaseClient.DisableRetries = true


### PR DESCRIPTION
Related to https://github.com/rancher/rancher/issues/29306, there has been an issue found by QA in their tests of China endpoints for Microsoft Azure AD.
Issue: https://github.com/rancher/rancher/issues/38022

The SDK client we use implicitly sets the global Graph Endpoint value in its constructor. This PR explicitly sets the Graph Endpoint necessary at runtime. The global (https://graph.microsoft.com) is not the only Graph Endpoint, since there is also one for China and other regions. The code now passes it from the auth config to this base contractor for the client.