### PR TITLE
Fixed snapshot RBAC for RKE2 cluster-owner

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -52,7 +52,8 @@ var clusterManagmentPlaneResources = map[string]string{
 	"nodepools":                   "management.cattle.io",
 	"notifiers":                   "management.cattle.io",
 	"podsecuritypolicytemplateprojectbindings": "management.cattle.io",
-	"projects": "management.cattle.io",
+	"projects":      "management.cattle.io",
+	"etcdsnapshots": "rke.cattle.io",
 }
 
 type crtbLifecycle struct {


### PR DESCRIPTION
Snapshots get stored in the local cluster under the `fleet-default`
namespace. Because of this, roles get access to individual
snapshots. If no snapshots are stored, the users do
not have access to view or create snapshots in the UI.
Users now have access to the `etcdsnapshots.rke.cattle.io`
in the namespace of the cluster. Making the CRD visible in
the schema when no snapshots are present.

#37630 