### PR TITLE
Simplify Azure AD auth config migration; update login, token, auth endpoints for China

### DIFF
--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -1,3 +1,4 @@
+// Package azure provides functions and types to register and use Azure AD as the auth provider in Rancher.
 package azure
 
 import (


### PR DESCRIPTION
Main issue: https://github.com/rancher/rancher/issues/29306
Direct issue: https://github.com/rancher/rancher/issues/38022

This fully synchronizes the endpoints defined in the UI initially when Azure AD is set up on a fresh v2.6.6+ setup (https://github.com/rancher/dashboard/issues/5671) with the endpoints defined by the backend on endpoint upgrade (only relevant for China endpoints).

The auth config update is reorganized for better readability.

The end scenario (which I tested and verified) is the following: whether you upgrade the endpoints (Global or China) or start anew with the new endpoints already defined (without the need to upgrade them), the resulting auth configs in both cases should be the same.

Specifically, we're interested in Endpoint (login endpoint), Graph Endpoint, Auth Endpoint, Token Endpoint fields of the auth config - those should be the same whether you migrate or start with a fresh setup.