### PR TITLE
Fix panic on refresh; properly parse principal ID before getting a user

### DIFF
--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -86,7 +86,11 @@ func (ap *azureProvider) RefetchGroupPrincipals(principalID, secret string) ([]v
 
 	logrus.Debug("[AZURE_PROVIDER] Started getting user info from AzureAD")
 
-	userPrincipal, err := azureClient.GetUser(principalID)
+	parsed, err := clients.ParsePrincipalID(principalID)
+	if err != nil {
+		return nil, err
+	}
+	userPrincipal, err := azureClient.GetUser(parsed["ID"])
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/providers/azure/clients/ad_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ad_graph_client.go
@@ -142,13 +142,11 @@ func NewADGraphClientFromCredential(config *v32.AzureADConfig, credential *v32.A
 		credential.Code,
 		config.RancherURL,
 		config.GraphEndpoint,
-		nil,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	spt.SetRefreshCallbacks(nil)
 	if err := spt.Refresh(); err != nil {
 		return nil, err
 	}
@@ -181,8 +179,7 @@ func NewAzureADGraphClientFromADALToken(config *v32.AzureADConfig, adalTokenSecr
 		config.ApplicationID,
 		config.GraphEndpoint,
 		adalToken,
-		secret,
-		nil)
+		secret)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Main issue: https://github.com/rancher/rancher/issues/29306
Direct issues: https://github.com/rancher/rancher/issues/37969 and https://github.com/rancher/rancher/issues/38067

The PR does two things:
1. Sets refresh callbacks on service principle token (SPT) explicitly to nil. This had been accidentally removed when a major refactoring of the old Azure AD client was taking place. The nil-pointer panic happened in the third-party SDK if this refresh callback is not set to nil. It would happen on periodic principal refresh that Rancher does to see if an Azure user known to Rancher still exists in Azure.
 
2. Properly parses the principal ID and extracts the actual user ID for the old flow via Azure AD Graph.