### PR TITLE
Add minor file support to v2prov to allow for immediate plan updates

### DIFF
--- a/pkg/apis/rke.cattle.io/v1/plan/plan.go
+++ b/pkg/apis/rke.cattle.io/v1/plan/plan.go
@@ -66,6 +66,7 @@ type File struct {
 	Content string `json:"content,omitempty"`
 	Path    string `json:"path,omitempty"`
 	Dynamic bool   `json:"dynamic,omitempty"`
+	Minor   bool   `json:"minor,omitempty"` // minor signifies that the file can be changed on a node without having to cause a full-blown drain/cordon operation
 }
 
 type NodePlan struct {

--- a/pkg/provisioningv2/rke2/planner/manifests.go
+++ b/pkg/provisioningv2/rke2/planner/manifests.go
@@ -58,6 +58,7 @@ func getEtcdSnapshotExtraMetadata(controlPlane *rkev1.RKEControlPlane, runtime s
 			Content: base64.StdEncoding.EncodeToString([]byte(cm)),
 			Path:    fmt.Sprintf("/var/lib/rancher/%s/server/manifests/rancher/%s-etcd-snapshot-extra-metadata.yaml", runtime, runtime),
 			Dynamic: true,
+			Minor:   true,
 		}
 	}
 	logrus.Errorf("rkecluster %s/%s: unable to find cluster spec annotation for control plane", controlPlane.Spec.ClusterName, controlPlane.Namespace)
@@ -75,6 +76,7 @@ func (p *Planner) getClusterAgentManifestFile(controlPlane *rkev1.RKEControlPlan
 		Content: base64.StdEncoding.EncodeToString(data),
 		Path:    fmt.Sprintf("/var/lib/rancher/%s/server/manifests/rancher/cluster-agent.yaml", runtime),
 		Dynamic: true,
+		Minor:   true,
 	}, nil
 }
 


### PR DESCRIPTION
This PR adds functionality to allow v2prov to skip the conventional drain/cordon plan update operations, when a plan change is minor. Minor in this case is that the only change in the plan are files that are considered "minor", as designated by the v2prov engineering team. Currently, the two files that are minor are the etcd-metadata and cluster agent manifest files.

https://github.com/rancher/rancher/issues/37465