### PR TITLE
[v2prov] don't elect init node if not found and one is designated

### DIFF
--- a/pkg/provisioningv2/rke2/planner/initnode.go
+++ b/pkg/provisioningv2/rke2/planner/initnode.go
@@ -142,6 +142,8 @@ func (p *Planner) electInitNode(rkeControlPlane *rkev1.RKEControlPlane, plan *pl
 	if initNodeFound, joinURL, _, err := p.findInitNode(rkeControlPlane, plan); (initNodeFound && err == nil) || errors.Is(err, generic.ErrSkip) {
 		logrus.Debugf("rkecluster %s/%s: init node was already elected and found with joinURL: %s", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName, joinURL)
 		return joinURL, err
+	} else if !initNodeFound && rkeControlPlane.Labels[rke2.InitNodeMachineIDLabel] != "" {
+		return "", ErrWaitingf("unable to find designated init node matching machine ID %s", rkeControlPlane.Labels[rke2.InitNodeMachineIDLabel])
 	}
 	// If the joinURL (or an errSkip) was not found, re-elect the init node.
 	logrus.Debugf("rkecluster %s/%s: performing election of init node", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/38090

If an init node was designated, Rancher was continuously trying to re-elect the init node if the init node was not found by machine ID. This was incorrect behavior, and Rancher should not elect an init node if one could not be found as it was designated.