### PR TITLE
introduce version restriction for k3s upgrade images starting with 1.21.0

### DIFF
--- a/pkg/image/export/main.go
+++ b/pkg/image/export/main.go
@@ -97,7 +97,11 @@ func run(systemChartsPath, chartsPath string, imagesFromArgs []string) error {
 	}
 
 	externalImages := make(map[string][]string)
-	k3sUpgradeImages, err := ext.GetExternalImages(rancherVersion, data.K3S, ext.K3S, nil)
+	k3sUpgradeImages, err := ext.GetExternalImages(rancherVersion, data.K3S, ext.K3S, &semver.Version{
+		Major: 1,
+		Minor: 21,
+		Patch: 0,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix for issue: https://github.com/rancher/rancher/issues/37742

There was already a semver version set for rke2 images when building the image lists but there was not one set for k3s images. This change brings the same 1.21+ version restriction for k3s upgrade images for system agent.

To verify this change, once the first rc is generated for Rancher 2.6.6 the list of `rancher/system-agent-installer-k3s` images should not have any versions prior to 1.21 included.