### PR TITLE
disable harvester node driver in drone prov tests

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -16,4 +16,5 @@ export KUBECONFIG=
 export CATTLE_DEV_MODE=yes
 export CATTLE_SERVER_URL="https://$(ip route get 8.8.8.8 | awk '{print $7}'):8443"
 export CATTLE_BOOTSTRAP_PASSWORD="admin"
+export CATTLE_FEATURES="harvester=false"
 exec ../../$CMD


### PR DESCRIPTION
When running provisioning tests in Drone, the harvester node driver binary is not available and causes errors to be thrown in rancher.

I downloaded the logs from this Drone step https://drone-pr.rancher.io/rancher/rancher/22709/1/2 and then decrypted the base64 logs, showing the error was present 46 times. This is an expected error based on how rancher is run (dev mode) in the provisioning tests and the presence of the errors may confuse those who do not realize this.

```console
for CHUNK in $(grep -A1 LOG-DUMP-START logs_rancher_rancher_22709_1_2.log | grep -v LOG-DUMP); do echo -e "\n---\nSTART LOG DUMP\n---\n"; echo -n "${CHUNK}" | base64 -d | zcat; done | grep 'Driver "harvester" not found' | wc -l
46
```

```log
2022/06/24 21:27:24 [ERROR] error syncing 'harvester': handler node-driver-controller: Driver "harvester" not found. Do you have the plugin binary "docker-machine-driver-harvester" accessible in your PATH?, requeuing
```