### PR TITLE
Removing hardcoded node pool quantity

### DIFF
--- a/tests/framework/extensions/machinepools/machinepools.go
+++ b/tests/framework/extensions/machinepools/machinepools.go
@@ -46,25 +46,35 @@ func NewRKEMachinePool(controlPlaneRole, etcdRole, workerRole bool, poolName str
 	}
 }
 
+type NodeRoles struct {
+	ControlPlane bool  `json:"controlplane,omitempty" yaml:"controlplane,omitempty"`
+	Etcd         bool  `json:"etcd,omitempty" yaml:"etcd,omitempty"`
+	Worker       bool  `json:"worker,omitempty" yaml:"worker,omitempty"`
+	Quantity     int32 `json:"quantity" yaml:"quantity"`
+}
+
 // RKEMachinePoolSetup is a helper method that will loop and setup muliple node pools with the defined node roles from the `nodeRoles` parameter
 // `machineConfig` is the *unstructured.Unstructured created by CreateMachineConfig
 // `nodeRoles` would be in this format
 //   []map[string]bool{
 //   {
-// 	   "controlplane": true,
-// 	   "etcd":         false,
-//     "worker":       false,
+// 	   ControlPlane: true,
+// 	   Etcd:         false,
+//     Worker:       false,
+//	   Quantity:     1,
 //   },
 //   {
-// 	   "controlplane": false,
-// 	   "etcd":         true,
-// 	   "worker":       false,
+// 	   ControlPlane: false,
+// 	   Etcd:         true,
+//     Worker:       false,
+//	   Quantity:     1,
 //   },
 //  }
-func RKEMachinePoolSetup(nodeRoles []map[string]bool, machineConfig *unstructured.Unstructured) []apisV1.RKEMachinePool {
+
+func RKEMachinePoolSetup(nodeRoles []NodeRoles, machineConfig *unstructured.Unstructured) []apisV1.RKEMachinePool {
 	machinePools := []apisV1.RKEMachinePool{}
 	for index, roles := range nodeRoles {
-		machinePool := NewRKEMachinePool(roles["controlplane"], roles["etcd"], roles["worker"], "pool"+strconv.Itoa(index), 1, machineConfig)
+		machinePool := NewRKEMachinePool(roles.ControlPlane, roles.Etcd, roles.Worker, "pool"+strconv.Itoa(index), roles.Quantity, machineConfig)
 		machinePools = append(machinePools, machinePool)
 	}
 

--- a/tests/framework/extensions/workloads/podstatus.go
+++ b/tests/framework/extensions/workloads/podstatus.go
@@ -1,0 +1,59 @@
+package workloads
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// PodGroupVersion is the required Group Version for accessing pods in a cluster,
+// using the dynamic client.
+var PodGroupVersionResource = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "pods",
+}
+
+// StatusPods is a helper function that uses the dynamic client to list pods on a namespace for a specific cluster with its list options.
+func StatusPods(client *rancher.Client, clusterID string, listOpts metav1.ListOptions) ([]string, []error) {
+	var podList []corev1.Pod
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, []error{err}
+	}
+	podResource := dynamicClient.Resource(PodGroupVersionResource)
+	pods, err := podResource.List(context.TODO(), listOpts)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	for _, unstructuredPod := range pods.Items {
+		newPod := &corev1.Pod{}
+		err := scheme.Scheme.Convert(&unstructuredPod, newPod, unstructuredPod.GroupVersionKind())
+		if err != nil {
+			return nil, []error{err}
+		}
+
+		podList = append(podList, *newPod)
+	}
+
+	var podResults []string
+	var podErrors []error
+	podResults = append(podResults, "pods Status:\n")
+
+	for _, pod := range podList {
+		podStatus := pod.Status.Phase
+		if podStatus == "Succeeded" || podStatus == "Running" {
+			podResults = append(podResults, fmt.Sprintf("INFO: %s: %s\n", pod.Name, podStatus))
+		} else {
+			podErrors = append(podErrors, fmt.Errorf("ERROR: %s: %s", pod.Name, podStatus))
+		}
+	}
+	return podResults, podErrors
+}

--- a/tests/v2/validation/provisioning/cni_providers_test.go
+++ b/tests/v2/validation/provisioning/cni_providers_test.go
@@ -1,0 +1,174 @@
+package provisioning
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
+	"github.com/rancher/rancher/tests/framework/extensions/users"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type RKE2CNIProvisioningTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	session            *session.Session
+	standardUserClient *rancher.Client
+	kubernetesVersions []string
+	cnis               []string
+	providers          []string
+}
+
+func (r *RKE2CNIProvisioningTestSuite) TearDownSuite() {
+	r.session.Cleanup()
+}
+
+func (r *RKE2CNIProvisioningTestSuite) SetupSuite() {
+	testSession := session.NewSession(r.T())
+	r.session = testSession
+
+	clustersConfig := new(Config)
+	config.LoadConfig(ConfigurationFileKey, clustersConfig)
+
+	r.kubernetesVersions = clustersConfig.KubernetesVersions
+	r.cnis = []string{"canal", "cilium", "calico", "multus,canal", "multus,cilium", "multus,calico"}
+	r.providers = clustersConfig.Providers
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(r.T(), err)
+
+	r.client = client
+
+	enabled := true
+	var testuser = AppendRandomString("testuser-")
+	user := &management.User{
+		Username: testuser,
+		Password: "rancherrancher123!",
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "clusters-create", "user")
+	require.NoError(r.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(r.T(), err)
+
+	r.standardUserClient = standardUserClient
+}
+
+func (r *RKE2CNIProvisioningTestSuite) ProvisioningRKE2Cluster(provider Provider) {
+	providerName := " Node Provider: " + provider.Name
+
+	nodeRoles1 := []machinepools.NodeRoles{
+		{
+			ControlPlane: true,
+			Etcd:         false,
+			Worker:       false,
+			Quantity:     2,
+		},
+		{
+			ControlPlane: false,
+			Etcd:         true,
+			Worker:       false,
+			Quantity:     3,
+		},
+		{
+			ControlPlane: false,
+			Etcd:         false,
+			Worker:       true,
+			Quantity:     3,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		nodeRoles []machinepools.NodeRoles
+		client    *rancher.Client
+	}{
+		{"3 etcd 2 cp 3 worker nodes Admin User", nodeRoles1, r.client},
+		{"3 etcd 2 cp 3 worker nodes Standard User", nodeRoles1, r.standardUserClient},
+	}
+
+	var name string
+	for _, tt := range tests {
+		subSession := r.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(r.T(), err)
+
+		cloudCredential, err := provider.CloudCredFunc(client)
+		require.NoError(r.T(), err)
+		for _, kubeVersion := range r.kubernetesVersions {
+			name = tt.name + providerName + " Kubernetes version: " + kubeVersion
+			for _, cni := range r.cnis {
+				name += " cni: " + cni
+				r.Run(name, func() {
+					testSession := session.NewSession(r.T())
+
+					testSessionClient, err := tt.client.WithSession(testSession)
+					require.NoError(r.T(), err)
+
+					clusterName := AppendRandomString(provider.Name)
+					generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
+					machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
+
+					machineConfigResp, err := machinepools.CreateMachineConfig(provider.MachineConfig, machinePoolConfig, testSessionClient)
+					require.NoError(r.T(), err)
+
+					machinePools := machinepools.RKEMachinePoolSetup(tt.nodeRoles, machineConfigResp)
+
+					cluster := clusters.NewRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, machinePools)
+
+					clusterResp, err := clusters.CreateRKE2Cluster(testSessionClient, cluster)
+					require.NoError(r.T(), err)
+
+					result, err := r.client.Provisioning.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+						FieldSelector:  "metadata.name=" + clusterName,
+						TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+					})
+					require.NoError(r.T(), err)
+
+					checkFunc := clusters.IsProvisioningClusterReady
+
+					err = wait.WatchWait(result, checkFunc)
+					assert.NoError(r.T(), err)
+					assert.Equal(r.T(), clusterName, clusterResp.Name)
+
+					clusterID, err := clusters.GetClusterIDByName(r.client, clusterName)
+					assert.NoError(r.T(), err)
+					podResults, podErrors := workloads.StatusPods(client, clusterID, metav1.ListOptions{})
+					fmt.Print(podResults, podErrors)
+				})
+			}
+		}
+	}
+}
+
+func (r *RKE2CNIProvisioningTestSuite) TestProvisioning() {
+	for _, providerName := range r.providers {
+		provider := CreateProvider(providerName)
+		r.ProvisioningRKE2Cluster(provider)
+	}
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestCNIProvisioningTestSuite(t *testing.T) {
+	suite.Run(t, new(RKE2CNIProvisioningTestSuite))
+}

--- a/tests/v2/validation/provisioning/config.go
+++ b/tests/v2/validation/provisioning/config.go
@@ -1,9 +1,7 @@
 package provisioning
 
 import (
-	"strings"
-
-	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 )
 
@@ -14,36 +12,14 @@ const (
 )
 
 type Config struct {
-	NodesAndRoles      string   `json:"nodesAndRoles" yaml:"nodesAndRoles" default:""`
-	KubernetesVersions []string `json:"kubernetesVersion" yaml:"kubernetesVersion"`
-	CNIs               []string `json:"cni" yaml:"cni"`
-	Providers          []string `json:"providers" yaml:"providers"`
-	NodeProviders      []string `json:"nodeProviders" yaml:"nodeProviders"`
+	NodesAndRoles      []machinepools.NodeRoles `json:"nodesAndRoles" yaml:"nodesAndRoles" default:"[]"`
+	KubernetesVersions []string                 `json:"kubernetesVersion" yaml:"kubernetesVersion"`
+	CNIs               []string                 `json:"cni" yaml:"cni"`
+	Providers          []string                 `json:"providers" yaml:"providers"`
+	NodeProviders      []string                 `json:"nodeProviders" yaml:"nodeProviders"`
 }
 
 func AppendRandomString(baseClusterName string) string {
 	clusterName := "auto-" + baseClusterName + "-" + namegenerator.RandStringLower(defaultRandStringLength)
 	return clusterName
-}
-
-// NodesAndRolesInput is a helper function that reads the nodesAndRoles entry in the config file and returns it in the form
-// of a list of map[string]bool
-func NodesAndRolesInput() []map[string]bool {
-	clustersConfig := new(Config)
-
-	config.LoadConfig(ConfigurationFileKey, clustersConfig)
-	nodeRolesBoolSliceMap := []map[string]bool{}
-
-	rolesSlice := strings.Split(clustersConfig.NodesAndRoles, "|")
-	for _, roles := range rolesSlice {
-		nodeRoles := strings.Split(roles, ",")
-		nodeRoleBoolMap := map[string]bool{}
-		for _, nodeRole := range nodeRoles {
-			nodeRoleBoolMap[nodeRole] = true
-
-		}
-		nodeRolesBoolSliceMap = append(nodeRolesBoolSliceMap, nodeRoleBoolMap)
-	}
-
-	return nodeRolesBoolSliceMap
 }

--- a/tests/v2/validation/provisioning/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/custom_cluster_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/tokenregistration"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
@@ -144,13 +145,19 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 	}
 }
 
-func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynamicInput(externalNodeProvider ExternalNodeProvider, nodesAndRoles []map[string]bool) {
+func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynamicInput(externalNodeProvider ExternalNodeProvider, nodesAndRoles []machinepools.NodeRoles) {
 	rolesPerNode := []string{}
 
 	for _, nodes := range nodesAndRoles {
 		var finalRoleCommand string
-		for role := range nodes {
-			finalRoleCommand += fmt.Sprintf(" --%s", role)
+		if nodes.ControlPlane == true {
+			finalRoleCommand += " --controlplane"
+		}
+		if nodes.Etcd == true {
+			finalRoleCommand += " --etcd"
+		}
+		if nodes.Worker == true {
+			finalRoleCommand += " --worker"
 		}
 		rolesPerNode = append(rolesPerNode, finalRoleCommand)
 	}
@@ -227,7 +234,10 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningCustomCluster() {
 }
 
 func (c *CustomClusterProvisioningTestSuite) TestProvisioningCustomClusterDynamicInput() {
-	nodesAndRoles := NodesAndRolesInput()
+	clustersConfig := new(Config)
+	config.LoadConfig(ConfigurationFileKey, clustersConfig)
+	nodesAndRoles := clustersConfig.NodesAndRoles
+
 	if len(nodesAndRoles) == 0 {
 		c.T().Skip()
 	}

--- a/tests/v2/validation/provisioning/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/provisioning_node_driver_test.go
@@ -72,35 +72,39 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 
 func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2Cluster(provider Provider) {
 	providerName := " Node Provider: " + provider.Name
-	nodeRoles0 := []map[string]bool{
+	nodeRoles0 := []machinepools.NodeRoles{
 		{
-			"controlplane": true,
-			"etcd":         true,
-			"worker":       true,
+			ControlPlane: true,
+			Etcd:         true,
+			Worker:       true,
+			Quantity:     1,
 		},
 	}
 
-	nodeRoles1 := []map[string]bool{
+	nodeRoles1 := []machinepools.NodeRoles{
 		{
-			"controlplane": true,
-			"etcd":         false,
-			"worker":       false,
+			ControlPlane: true,
+			Etcd:         false,
+			Worker:       false,
+			Quantity:     1,
 		},
 		{
-			"controlplane": false,
-			"etcd":         true,
-			"worker":       false,
+			ControlPlane: false,
+			Etcd:         true,
+			Worker:       false,
+			Quantity:     1,
 		},
 		{
-			"controlplane": false,
-			"etcd":         false,
-			"worker":       true,
+			ControlPlane: false,
+			Etcd:         false,
+			Worker:       true,
+			Quantity:     1,
 		},
 	}
 
 	tests := []struct {
 		name      string
-		nodeRoles []map[string]bool
+		nodeRoles []machinepools.NodeRoles
 		client    *rancher.Client
 	}{
 		{"1 Node all roles Admin User", nodeRoles0, r.client},
@@ -161,7 +165,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2Cluster(provider P
 	}
 }
 
-func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2ClusterDynamicInput(provider Provider, nodesAndRoles []map[string]bool) {
+func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2ClusterDynamicInput(provider Provider, nodesAndRoles []machinepools.NodeRoles) {
 	providerName := " Node Provider: " + provider.Name
 	tests := []struct {
 		name   string
@@ -232,7 +236,10 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioning() {
 }
 
 func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningDynamicInput() {
-	nodesAndRoles := NodesAndRolesInput()
+	clustersConfig := new(Config)
+	config.LoadConfig(ConfigurationFileKey, clustersConfig)
+	nodesAndRoles := clustersConfig.NodesAndRoles
+
 	if len(nodesAndRoles) == 0 {
 		r.T().Skip()
 	}


### PR DESCRIPTION
Removed hardcoded value for machine pools to allow users to increase node count in the pool. Changed config struct to allow for NodesAndRoles to accept quantity as a value. Adjusted all tests using RKEMachinePoolSetup helper function to adjust to the new structure.