### PR TITLE
Make an annotation the only variable in Azure AD auth flow choice

### DIFF
--- a/pkg/auth/data/authconfig_data.go
+++ b/pkg/auth/data/authconfig_data.go
@@ -74,9 +74,15 @@ func AuthConfigs(management *config.ManagementContext) error {
 }
 
 func addAuthConfig(name, aType string, enabled bool, management *config.ManagementContext) error {
+	annotations := make(map[string]string)
+	if name == azure.Name {
+		annotations[azure.GraphEndpointMigratedAnnotation] = "true"
+	}
+
 	_, err := management.Management.AuthConfigs("").ObjectClient().Create(&v3.AuthConfig{
 		ObjectMeta: v1.ObjectMeta{
-			Name: name,
+			Name:        name,
+			Annotations: annotations,
 		},
 		Type:    aType,
 		Enabled: enabled,

--- a/pkg/auth/providers/azure/config.go
+++ b/pkg/auth/providers/azure/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rancher/norman/types/slice"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 )
@@ -19,20 +18,34 @@ const (
 	chinaAzureMSLoginEndpoint = "https://login.partner.microsoftonline.cn/"
 )
 
+// GraphEndpointMigratedAnnotation is the main piece of data based on which Rancher decides to use either the
+// deprecated authentication flow via Azure AD Graph or the new one via Microsoft Graph.
+// If the annotation is missing on the Auth Config object, or is present with a value of anything other than "true",
+// then Rancher uses the old, deprecated flow. If the annotation is present and set to "true", Rancher uses the new flow.
+const GraphEndpointMigratedAnnotation = "auth.cattle.io/azuread-endpoint-migrated"
+
 func authProviderEnabled(config *v32.AzureADConfig) bool {
 	return config.Enabled && config.GraphEndpoint != ""
 }
 
-func graphEndpointDeprecated(endpoint string) bool {
-	deprecatedEndpoints := []string{globalAzureADGraphEndpoint, chinaAzureADGraphEndpoint}
-	return slice.ContainsString(deprecatedEndpoints, endpoint)
+func isConfigDeprecated(cfg *v32.AzureADConfig) bool {
+	if !cfg.Enabled {
+		return false
+	}
+	v, ok := cfg.ObjectMeta.Annotations[GraphEndpointMigratedAnnotation]
+	if !ok || v != "true" {
+		logrus.Tracef("Could not find the %s annotation that specifies whether the Graph Endpoint has been migrated, or its value is not \"true\" - Rancher will use the old endpoint.",
+			GraphEndpointMigratedAnnotation)
+		return true
+	}
+	return false
 }
 
-func updateAzureADConfig(c *v32.AzureADConfig) {
+func updateAzureADEndpoints(c *v32.AzureADConfig) {
 	if isConfigForChina(c) {
-		updateConfigForChina(c)
+		updateEndpointsForChina(c)
 	} else {
-		updateConfigForGlobal(c)
+		updateEndpointsForGlobal(c)
 	}
 }
 
@@ -40,9 +53,9 @@ func isConfigForChina(c *v32.AzureADConfig) bool {
 	return strings.HasSuffix(c.GraphEndpoint, ".cn") || strings.HasSuffix(c.GraphEndpoint, ".cn/")
 }
 
-func updateConfigForGlobal(c *v32.AzureADConfig) {
+func updateEndpointsForGlobal(c *v32.AzureADConfig) {
 	if c.GraphEndpoint != globalAzureADGraphEndpoint {
-		logrus.Infoln("Refusing to upgrade because the Graph Endpoint is not deprecated.")
+		logrus.Infof("Refusing to upgrade because the Graph Endpoint %s is not deprecated.", c.GraphEndpoint)
 		return
 	}
 	// Update the Graph Endpoint.
@@ -52,9 +65,9 @@ func updateConfigForGlobal(c *v32.AzureADConfig) {
 	c.TokenEndpoint = fmt.Sprintf("%s%s/oauth2/v2.0/token", c.Endpoint, c.TenantID)
 }
 
-func updateConfigForChina(c *v32.AzureADConfig) {
+func updateEndpointsForChina(c *v32.AzureADConfig) {
 	if c.GraphEndpoint != chinaAzureADGraphEndpoint {
-		logrus.Infoln("Refusing to upgrade because the Graph Endpoint is not deprecated.")
+		logrus.Infof("Refusing to upgrade because the Graph Endpoint %s is not deprecated.", c.GraphEndpoint)
 		return
 	}
 	// Update the Graph Endpoint.


### PR DESCRIPTION
Related to https://github.com/rancher/rancher/issues/29306

UI issue with background: https://github.com/rancher/dashboard/issues/6236

The main problem is as follows: when admins upgrade Rancher to v2.6.7, while having a custom Azure AD endpoint, they will not see the banner in the UI because the UI (and the backend) only checks if the config has one of the two known old endpoints (for Global and China). Therefore, Rancher will assume it needs to use the new authentication flow via Microsoft Graph, since a custom endpoint (by virtue of being able to hold any value) cannot be known to be deprecated. As a result, admins won't even see the warning about the change and, most importantly, a reminder to add the necessary permissions to the app in Azure. This means Rancher will use the new authentication flow without notifying the admins first, which is dangerous because they will not have prepared the Azure app for that.

We want users of Global, China, Custom endpoints to see the upgrade message and button when admins upgrade Rancher, so there are no surprises and automatic endpoint updates.

This PR makes a change to how Rancher determines if an Azure AD setup uses deprecated endpoints.
Instead of looking at endpoints themselves, Rancher will now put and read a special annotation on the auth config object.