### PR TITLE
pin kdm data to rke v1.3.11 for v2.6.6

### DIFF
--- a/scripts/build-server
+++ b/scripts/build-server
@@ -21,7 +21,8 @@ CGO_ENABLED=0 go build -tags k8s \
   -o bin/rancher
 
 if  [ -n "$CATTLE_KDM_BRANCH" ]; then
-    curl -sLf https://releases.rancher.com/kontainer-driver-metadata/${CATTLE_KDM_BRANCH}/data.json > bin/data.json
+    # bypass KDM_BRANCH for v2.6.6, pinning local data to vendored RKE1 v1.3.11 data
+    curl -sLf https://releases.rancher.com/kontainer-driver-metadata/release-rke-v1.3.11/data.json > bin/data.json
 elif [ ! -e bin/data.json ] && [ -e ../kontainer-driver-metadata/data/data.json ]; then
     cp ../kontainer-driver-metadata/data/data.json bin/data.json
 fi

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -36,7 +36,7 @@ eval "$(grep '^ENV CATTLE_WINS_AGENT' package/Dockerfile | awk '{print "export "
 eval "$(grep '^ENV CATTLE_CSI_PROXY_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 eval "$(grep '^ENV CATTLE_KDM_BRANCH' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 
-export SOME_K8S_VERSION=$(curl https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/$CATTLE_KDM_BRANCH/data/data.json | jq -r ".$DIST.channels[0].latest")
+export SOME_K8S_VERSION=$(curl https://releases.rancher.com/kontainer-driver-metadata/release-rke-v1.3.11/data.json | jq -r ".$DIST.channels[0].latest")
 
 echo Starting rancher server for provisioning-tests
 touch /tmp/rancher.log


### PR DESCRIPTION
**Problem**
We released KDM out of band and RKE v1.3.12 after Rancher v2.6.5. Rancher v2.6.6 is still using RKE v1.3.11 so the local data during build time for v2.6.6 needs to be consistent with RKE v1.3.11 copy. Reference: https://github.com/rancher/rancher/pull/37149 

**Solution**
Pinning KDM data to [release-rke-v1.3.11](https://github.com/rancher/kontainer-driver-metadata/tree/release-rke-v1.3.11) based off of https://github.com/rancher/kontainer-driver-metadata/pull/905. 

**Testing**
Verify the versions from RKE v1.3.12 show up as out of band versions for Rancher v2.6.6 same as v2.6.5: 
https://github.com/rancher/rke/releases/tag/v1.3.12 