### PR TITLE
migrate from deprecated norman objects to proper v3

### DIFF
--- a/pkg/api/norman/customization/clusterregistrationtokens/import.go
+++ b/pkg/api/norman/customization/clusterregistrationtokens/import.go
@@ -1,6 +1,7 @@
 package clusterregistrationtokens
 
 import (
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -40,7 +41,7 @@ func (ch *ClusterImport) ClusterImportHandler(resp http.ResponseWriter, req *htt
 		authImage = authImages[0]
 	}
 
-	var cluster *v3.Cluster
+	var cluster *v32.Cluster
 	if clusterID != "" {
 		cluster, _ = ch.Clusters.Get(clusterID, metav1.GetOptions{})
 	}

--- a/pkg/api/norman/customization/clusterregistrationtokens/import.go
+++ b/pkg/api/norman/customization/clusterregistrationtokens/import.go
@@ -1,12 +1,12 @@
 package clusterregistrationtokens
 
 import (
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"net/http"
 
 	"github.com/gorilla/mux"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/urlbuilder"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/image"
 	schema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"

--- a/pkg/catalogv2/content/content_test.go
+++ b/pkg/catalogv2/content/content_test.go
@@ -199,7 +199,7 @@ func TestFilterReleasesSemver(t *testing.T) {
 				},
 			}
 			contentManager := Manager{}
-			settings.ServerVersion.Set(tt.rancherVersion)
+			assert.NoError(t, settings.ServerVersion.Set(tt.rancherVersion))
 			contentManager.filterReleases(&filteredIndexFile, nil, false)
 			result := reflect.DeepEqual(indexFile, filteredIndexFile)
 			assert.Equal(t, tt.expectedPass, result)
@@ -336,7 +336,7 @@ func TestFilteringReleases(t *testing.T) {
 				},
 			}
 			contentManager := Manager{}
-			settings.ServerVersion.Set(tt.rancherVersion)
+			assert.NoError(t, settings.ServerVersion.Set(tt.rancherVersion))
 			kubeVersion, _ := semver.NewVersion(tt.kubernetesVersion)
 			contentManager.filterReleases(&filteredIndexFile, kubeVersion, tt.skipFiltering)
 			result := reflect.DeepEqual(indexFile, filteredIndexFile)
@@ -349,13 +349,13 @@ func TestFilteringReleases(t *testing.T) {
 }
 func TestFilteringReleaseKubeVersionAnnotation(t *testing.T) {
 	tests := []struct {
-		testName                    string
-		chartVersionAnnotation      string
-		rancherVersion              string
+		testName                   string
+		chartVersionAnnotation     string
+		rancherVersion             string
 		ChartKubeVersionAnnotation string
-		kubernetesVersion           string
-		skipFiltering               bool
-		expectedPass                bool
+		kubernetesVersion          string
+		skipFiltering              bool
+		expectedPass               bool
 	}{
 		{
 			"Index with chart that has no filters and skips filtering",
@@ -477,7 +477,7 @@ func TestFilteringReleaseKubeVersionAnnotation(t *testing.T) {
 								Version: "1.0.0",
 								Annotations: map[string]string{
 									"catalog.cattle.io/rancher-version": tt.chartVersionAnnotation,
-									"catalog.cattle.io/kube-version": tt.ChartKubeVersionAnnotation,
+									"catalog.cattle.io/kube-version":    tt.ChartKubeVersionAnnotation,
 								},
 							},
 							URLs:    nil,
@@ -497,7 +497,7 @@ func TestFilteringReleaseKubeVersionAnnotation(t *testing.T) {
 								Version: "1.0.0",
 								Annotations: map[string]string{
 									"catalog.cattle.io/rancher-version": tt.chartVersionAnnotation,
-									"catalog.cattle.io/kube-version": tt.ChartKubeVersionAnnotation,
+									"catalog.cattle.io/kube-version":    tt.ChartKubeVersionAnnotation,
 								},
 							},
 							URLs:    nil,
@@ -509,7 +509,7 @@ func TestFilteringReleaseKubeVersionAnnotation(t *testing.T) {
 				},
 			}
 			contentManager := Manager{}
-			settings.ServerVersion.Set(tt.rancherVersion)
+			assert.NoError(t, settings.ServerVersion.Set(tt.rancherVersion))
 			kubeVersion, _ := semver.NewVersion(tt.kubernetesVersion)
 			contentManager.filterReleases(&filteredIndexFile, kubeVersion, tt.skipFiltering)
 			result := reflect.DeepEqual(indexFile, filteredIndexFile)

--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -3,8 +3,8 @@ package cluster
 import (
 	"encoding/base64"
 	"encoding/json"
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	rketypes "github.com/rancher/rke/types"
 	"github.com/rancher/rke/util"

--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -3,8 +3,8 @@ package cluster
 import (
 	"encoding/base64"
 	"encoding/json"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	rketypes "github.com/rancher/rke/types"
 	"github.com/rancher/rke/util"
@@ -13,7 +13,7 @@ import (
 	"k8s.io/kubernetes/pkg/credentialprovider"
 )
 
-func GetPrivateRepoURL(cluster *v3.Cluster) string {
+func GetPrivateRepoURL(cluster *v32.Cluster) string {
 	registry := GetPrivateRepo(cluster)
 	if registry == nil {
 		return ""
@@ -21,7 +21,7 @@ func GetPrivateRepoURL(cluster *v3.Cluster) string {
 	return registry.URL
 }
 
-func GetPrivateRepo(cluster *v3.Cluster) *rketypes.PrivateRegistry {
+func GetPrivateRepo(cluster *v32.Cluster) *rketypes.PrivateRegistry {
 	if cluster != nil && cluster.Spec.RancherKubernetesEngineConfig != nil && len(cluster.Spec.RancherKubernetesEngineConfig.PrivateRegistries) > 0 {
 		config := cluster.Spec.RancherKubernetesEngineConfig
 		return &config.PrivateRegistries[0]
@@ -34,14 +34,14 @@ func GetPrivateRepo(cluster *v3.Cluster) *rketypes.PrivateRegistry {
 	return nil
 }
 
-func GenerateClusterPrivateRegistryDockerConfig(cluster *v3.Cluster) (string, error) {
+func GenerateClusterPrivateRegistryDockerConfig(cluster *v32.Cluster) (string, error) {
 	if cluster == nil {
 		return "", nil
 	}
 	return GeneratePrivateRegistryDockerConfig(GetPrivateRepo(cluster), nil)
 }
 
-// This method generates base64 encoded credentials for the registry
+// GeneratePrivateRegistryDockerConfig This method generates base64 encoded credentials for the registry
 func GeneratePrivateRegistryDockerConfig(privateRegistry *rketypes.PrivateRegistry, registrySecret *corev1.Secret) (string, error) {
 	if privateRegistry == nil {
 		return "", nil

--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -77,7 +77,7 @@ func NewManager(httpsPort int, context *config.ScaledContext, asl accesscontrol.
 	}
 }
 
-func (m *Manager) Stop(cluster *v3.Cluster) {
+func (m *Manager) Stop(cluster *v32.Cluster) {
 	obj, ok := m.controllers.Load(cluster.UID)
 	if !ok {
 		return
@@ -87,7 +87,7 @@ func (m *Manager) Stop(cluster *v3.Cluster) {
 	m.controllers.Delete(cluster.UID)
 }
 
-func (m *Manager) Start(ctx context.Context, cluster *v3.Cluster, clusterOwner bool) error {
+func (m *Manager) Start(ctx context.Context, cluster *v32.Cluster, clusterOwner bool) error {
 	if cluster.DeletionTimestamp != nil {
 		return nil
 	}
@@ -100,7 +100,7 @@ func (m *Manager) Start(ctx context.Context, cluster *v3.Cluster, clusterOwner b
 	return err
 }
 
-func (m *Manager) RESTConfig(cluster *v3.Cluster) (rest.Config, error) {
+func (m *Manager) RESTConfig(cluster *v32.Cluster) (rest.Config, error) {
 	obj, ok := m.controllers.Load(cluster.UID)
 	if !ok {
 		return rest.Config{}, fmt.Errorf("cluster record not found %s %s", cluster.Name, cluster.UID)
@@ -120,7 +120,7 @@ func (m *Manager) markUnavailable(clusterName string) {
 	}
 }
 
-func (m *Manager) start(ctx context.Context, cluster *v3.Cluster, controllers, clusterOwner bool) (*record, error) {
+func (m *Manager) start(ctx context.Context, cluster *v32.Cluster, controllers, clusterOwner bool) (*record, error) {
 	if cluster.DeletionTimestamp != nil {
 		return nil, nil
 	}
@@ -171,7 +171,7 @@ func (m *Manager) startController(r *record, controllers, clusterOwner bool) err
 	return nil
 }
 
-func (m *Manager) changed(r *record, cluster *v3.Cluster, controllers, clusterOwner bool) bool {
+func (m *Manager) changed(r *record, cluster *v32.Cluster, controllers, clusterOwner bool) bool {
 	existing := r.clusterRec
 	if existing.Status.APIEndpoint != cluster.Status.APIEndpoint ||
 		existing.Status.ServiceAccountTokenSecret != cluster.Status.ServiceAccountTokenSecret ||
@@ -256,7 +256,7 @@ func (m *Manager) doStart(rec *record, clusterOwner bool) (exit error) {
 	}
 }
 
-func ToRESTConfig(cluster *v3.Cluster, context *config.ScaledContext, secretLister v1.SecretLister) (*rest.Config, error) {
+func ToRESTConfig(cluster *v32.Cluster, context *config.ScaledContext, secretLister v1.SecretLister) (*rest.Config, error) {
 	if cluster == nil {
 		return nil, nil
 	}
@@ -404,7 +404,7 @@ func VerifyIgnoreDNSName(caCertsPEM []byte) (func(rawCerts [][]byte, verifiedCha
 	}, nil
 }
 
-func (m *Manager) toRecord(ctx context.Context, cluster *v3.Cluster) (*record, error) {
+func (m *Manager) toRecord(ctx context.Context, cluster *v32.Cluster) (*record, error) {
 	kubeConfig, err := ToRESTConfig(cluster, m.ScaledContext, m.secretLister)
 	if kubeConfig == nil || err != nil {
 		return nil, err
@@ -491,7 +491,7 @@ func (m *Manager) UserContext(clusterName string) (*config.UserContext, error) {
 
 // UserContextFromCluster accepts a pointer to a Cluster and returns a client
 // for that cluster. It does not start any controllers.
-func (m *Manager) UserContextFromCluster(cluster *v3.Cluster) (*config.UserContext, error) {
+func (m *Manager) UserContextFromCluster(cluster *v32.Cluster) (*config.UserContext, error) {
 	kubeConfig, err := ToRESTConfig(cluster, m.ScaledContext, m.secretLister)
 	if err != nil {
 		return nil, err
@@ -536,7 +536,7 @@ func (m *Manager) ClusterName(apiContext *types.APIContext) string {
 	return clusterID
 }
 
-func (m *Manager) cluster(apiContext *types.APIContext, context types.StorageContext) (*v3.Cluster, error) {
+func (m *Manager) cluster(apiContext *types.APIContext, context types.StorageContext) (*v32.Cluster, error) {
 	switch context {
 	case types.DefaultStorageContext:
 		return nil, nil

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -61,7 +62,7 @@ type crtbLifecycle struct {
 	clusterLister v3.ClusterLister
 }
 
-func (c *crtbLifecycle) Create(obj *v3.ClusterRoleTemplateBinding) (runtime.Object, error) {
+func (c *crtbLifecycle) Create(obj *v33.ClusterRoleTemplateBinding) (runtime.Object, error) {
 	obj, err := c.reconcileSubject(obj)
 	if err != nil {
 		return nil, err
@@ -71,7 +72,7 @@ func (c *crtbLifecycle) Create(obj *v3.ClusterRoleTemplateBinding) (runtime.Obje
 	return obj, err
 }
 
-func (c *crtbLifecycle) Updated(obj *v3.ClusterRoleTemplateBinding) (runtime.Object, error) {
+func (c *crtbLifecycle) Updated(obj *v33.ClusterRoleTemplateBinding) (runtime.Object, error) {
 	obj, err := c.reconcileSubject(obj)
 	if err != nil {
 		return nil, err
@@ -83,7 +84,7 @@ func (c *crtbLifecycle) Updated(obj *v3.ClusterRoleTemplateBinding) (runtime.Obj
 	return obj, err
 }
 
-func (c *crtbLifecycle) Remove(obj *v3.ClusterRoleTemplateBinding) (runtime.Object, error) {
+func (c *crtbLifecycle) Remove(obj *v33.ClusterRoleTemplateBinding) (runtime.Object, error) {
 	if err := c.mgr.reconcileClusterMembershipBindingForDelete("", pkgrbac.GetRTBLabel(obj.ObjectMeta)); err != nil {
 		return nil, err
 	}
@@ -95,7 +96,7 @@ func (c *crtbLifecycle) Remove(obj *v3.ClusterRoleTemplateBinding) (runtime.Obje
 	return nil, err
 }
 
-func (c *crtbLifecycle) reconcileSubject(binding *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+func (c *crtbLifecycle) reconcileSubject(binding *v33.ClusterRoleTemplateBinding) (*v33.ClusterRoleTemplateBinding, error) {
 	if binding.GroupName != "" || binding.GroupPrincipalName != "" || (binding.UserPrincipalName != "" && binding.UserName != "") {
 		return binding, nil
 	}
@@ -133,7 +134,7 @@ func (c *crtbLifecycle) reconcileSubject(binding *v3.ClusterRoleTemplateBinding)
 // - ensure the subject can see the cluster in the mgmt API
 // - if the subject was granted owner permissions for the clsuter, ensure they can create/update/delete the cluster
 // - if the subject was granted privileges to mgmt plane resources that are scoped to the cluster, enforce those rules in the cluster's mgmt plane namespace
-func (c *crtbLifecycle) reconcileBindings(binding *v3.ClusterRoleTemplateBinding) error {
+func (c *crtbLifecycle) reconcileBindings(binding *v33.ClusterRoleTemplateBinding) error {
 	if binding.UserName == "" && binding.GroupPrincipalName == "" && binding.GroupName == "" {
 		return nil
 	}
@@ -183,7 +184,7 @@ func (c *crtbLifecycle) reconcileBindings(binding *v3.ClusterRoleTemplateBinding
 	return nil
 }
 
-func (c *crtbLifecycle) removeMGMTClusterScopedPrivilegesInProjectNamespace(binding *v3.ClusterRoleTemplateBinding) error {
+func (c *crtbLifecycle) removeMGMTClusterScopedPrivilegesInProjectNamespace(binding *v33.ClusterRoleTemplateBinding) error {
 	projects, err := c.mgr.projectLister.List(binding.Namespace, labels.Everything())
 	if err != nil {
 		return err
@@ -205,7 +206,7 @@ func (c *crtbLifecycle) removeMGMTClusterScopedPrivilegesInProjectNamespace(bind
 	return nil
 }
 
-func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) error {
+func (c *crtbLifecycle) reconcileLabels(binding *v33.ClusterRoleTemplateBinding) error {
 	/* Prior to 2.5, for every CRTB, following CRBs and RBs are created in the management clusters
 		1. CRTB.UID is the label key for a CRB, CRTB.UID=memberhsip-binding-owner
 	    2. CRTB.UID is label key for the RB, CRTB.UID=crtb-in-project-binding-owner (in the namespace of each project in the cluster that the user has access to)

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -2,11 +2,11 @@ package auth
 
 import (
 	"fmt"
-	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/management/authprovisioningv2"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	pkgrbac "github.com/rancher/rancher/pkg/rbac"

--- a/pkg/controllers/management/auth/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalrole_handler.go
@@ -1,12 +1,12 @@
 package auth
 
 import (
-	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"reflect"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	mgmt "github.com/rancher/rancher/pkg/apis/management.cattle.io"
+	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/rbac"

--- a/pkg/controllers/management/auth/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalrole_handler.go
@@ -1,12 +1,12 @@
 package auth
 
 import (
+	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"reflect"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	mgmt "github.com/rancher/rancher/pkg/apis/management.cattle.io"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/rbac"
@@ -41,7 +41,7 @@ type globalRoleLifecycle struct {
 	rClient  rbacv1.RoleInterface
 }
 
-func (gr *globalRoleLifecycle) Create(obj *v3.GlobalRole) (runtime.Object, error) {
+func (gr *globalRoleLifecycle) Create(obj *v33.GlobalRole) (runtime.Object, error) {
 	var returnError error
 	err := gr.reconcileGlobalRole(obj)
 	if err != nil {
@@ -54,7 +54,7 @@ func (gr *globalRoleLifecycle) Create(obj *v3.GlobalRole) (runtime.Object, error
 	return obj, returnError
 }
 
-func (gr *globalRoleLifecycle) Updated(obj *v3.GlobalRole) (runtime.Object, error) {
+func (gr *globalRoleLifecycle) Updated(obj *v33.GlobalRole) (runtime.Object, error) {
 	var returnError error
 	err := gr.reconcileGlobalRole(obj)
 	if err != nil {
@@ -67,12 +67,12 @@ func (gr *globalRoleLifecycle) Updated(obj *v3.GlobalRole) (runtime.Object, erro
 	return nil, returnError
 }
 
-func (gr *globalRoleLifecycle) Remove(obj *v3.GlobalRole) (runtime.Object, error) {
+func (gr *globalRoleLifecycle) Remove(obj *v33.GlobalRole) (runtime.Object, error) {
 	// Don't need to delete the created ClusterRole because owner reference will take care of that
 	return nil, nil
 }
 
-func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole) error {
+func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v33.GlobalRole) error {
 	crName := getCRName(globalRole)
 
 	clusterRole, _ := gr.crLister.Get("", crName)
@@ -114,7 +114,7 @@ func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole) er
 	return nil
 }
 
-func (gr *globalRoleLifecycle) reconcileCatalogRole(globalRole *v3.GlobalRole) error {
+func (gr *globalRoleLifecycle) reconcileCatalogRole(globalRole *v33.GlobalRole) error {
 	// rules which give template/template version access need to have a specific namespaced role created, since the
 	// backend resources that they grant access to are namespaced resources
 	var catalogRules []v1.PolicyRule
@@ -196,7 +196,7 @@ func (gr *globalRoleLifecycle) reconcileCatalogRole(globalRole *v3.GlobalRole) e
 	return nil
 }
 
-func getCRName(globalRole *v3.GlobalRole) string {
+func getCRName(globalRole *v33.GlobalRole) string {
 	if crName, ok := globalRole.Annotations[crNameAnnotation]; ok {
 		return crName
 	}

--- a/pkg/controllers/management/auth/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalrolebinding_handler.go
@@ -2,12 +2,12 @@ package auth
 
 import (
 	"fmt"
-	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"reflect"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/httperror"
+	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"

--- a/pkg/controllers/management/auth/legacy_grb_cleaner.go
+++ b/pkg/controllers/management/auth/legacy_grb_cleaner.go
@@ -1,10 +1,10 @@
 package auth
 
 import (
-	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"strings"
 
 	grbstore "github.com/rancher/rancher/pkg/api/norman/store/globalrolebindings"
+	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/pkg/controllers/management/auth/legacy_grb_cleaner.go
+++ b/pkg/controllers/management/auth/legacy_grb_cleaner.go
@@ -1,10 +1,10 @@
 package auth
 
 import (
+	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"strings"
 
 	grbstore "github.com/rancher/rancher/pkg/api/norman/store/globalrolebindings"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -20,7 +20,7 @@ func newLegacyGRBCleaner(m *config.ManagementContext) *grbCleaner {
 }
 
 // sync cleans up all GRBs to drop cluster-scoped lifecycle handler finalizers
-func (p *grbCleaner) sync(key string, obj *v3.GlobalRoleBinding) (runtime.Object, error) {
+func (p *grbCleaner) sync(key string, obj *v33.GlobalRoleBinding) (runtime.Object, error) {
 	if key == "" || obj == nil {
 		return nil, nil
 	}

--- a/pkg/controllers/management/auth/legacy_rt_cleaner.go
+++ b/pkg/controllers/management/auth/legacy_rt_cleaner.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"github.com/rancher/rancher/pkg/api/norman/store/roletemplate"
+	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,7 +21,7 @@ func newLegacyRTCleaner(mgmt *config.ManagementContext) *rtCleaner {
 }
 
 // sync cleans up all roleTemplates to drop cluster-scoped lifecycle handler finalizers
-func (p *rtCleaner) sync(key string, obj *v3.RoleTemplate) (runtime.Object, error) {
+func (p *rtCleaner) sync(key string, obj *v33.RoleTemplate) (runtime.Object, error) {
 	if key == "" || obj == nil {
 		return nil, nil
 	}

--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"fmt"
-	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"reflect"
 	"sort"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/types/slice"
+	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/rbac"
 	v13 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
@@ -112,7 +112,7 @@ type manager struct {
 // When a CRTB is created that gives a subject some permissions in a project or cluster, we need to create a "membership" binding
 // that gives the subject access to the the cluster custom resource itself
 // This is painfully similar to ensureProjectMemberBinding, but making one function that handles both is overly complex
-func (m *manager) ensureClusterMembershipBinding(roleName, rtbNsAndName string, cluster *v3.Cluster, makeOwner bool, subject v1.Subject) error {
+func (m *manager) ensureClusterMembershipBinding(roleName, rtbNsAndName string, cluster *v33.Cluster, makeOwner bool, subject v1.Subject) error {
 	if err := m.createClusterMembershipRole(roleName, cluster, makeOwner); err != nil {
 		return err
 	}

--- a/pkg/controllers/management/auth/project_cluster_handler_test.go
+++ b/pkg/controllers/management/auth/project_cluster_handler_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"testing"
 
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -14,7 +15,7 @@ import (
 const clusterID = "test-cluster"
 
 func TestEnqueueCrtbsOnProjectCreation(t *testing.T) {
-	existingCrtbs := []*v3.ClusterRoleTemplateBinding{
+	existingCrtbs := []*v32.ClusterRoleTemplateBinding{
 		{ObjectMeta: v1.ObjectMeta{
 			Name:      "crtb-1",
 			Namespace: clusterID,
@@ -31,7 +32,7 @@ func TestEnqueueCrtbsOnProjectCreation(t *testing.T) {
 	c := projectLifecycle{
 		mgr: &mgr{
 			crtbLister: &fakes.ClusterRoleTemplateBindingListerMock{
-				ListFunc: func(namespace string, selector labels.Selector) ([]*v3.ClusterRoleTemplateBinding, error) {
+				ListFunc: func(namespace string, selector labels.Selector) ([]*v32.ClusterRoleTemplateBinding, error) {
 					return existingCrtbs, nil
 				},
 			},
@@ -43,12 +44,12 @@ func TestEnqueueCrtbsOnProjectCreation(t *testing.T) {
 		},
 	}
 
-	newProject := v3.Project{
+	newProject := v32.Project{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "test-project",
 			Namespace: clusterID,
 		},
 	}
-	c.enqueueCrtbs(&newProject)
+	assert.NoError(t, c.enqueueCrtbs(&newProject))
 	assert.Equal(t, len(existingCrtbs), len(mockedClusterRoleTemplateBindingController.EnqueueCalls()))
 }

--- a/pkg/controllers/management/auth/role_template_lifecycle_test.go
+++ b/pkg/controllers/management/auth/role_template_lifecycle_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"testing"
 
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -15,7 +16,7 @@ const testNamespace = "test-cluster"
 const testRoleTemplateName = "fake-role-template"
 
 func TestEnqueuePrtbsOnRoleTemplateUpdate(t *testing.T) {
-	existingPrtbs := []*v3.ProjectRoleTemplateBinding{
+	existingPrtbs := []*v32.ProjectRoleTemplateBinding{
 		{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "prtb-1",
@@ -49,9 +50,9 @@ func TestEnqueuePrtbsOnRoleTemplateUpdate(t *testing.T) {
 		prtbByRoleTemplateIndex: prtbByRoleTemplate,
 	}
 	mockIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	mockIndexer.AddIndexers(indexers)
+	assert.NoError(t, mockIndexer.AddIndexers(indexers))
 	for _, obj := range existingPrtbs {
-		mockIndexer.Add(obj)
+		assert.NoError(t, mockIndexer.Add(obj))
 	}
 
 	rtl := roleTemplateLifecycle{
@@ -63,7 +64,7 @@ func TestEnqueuePrtbsOnRoleTemplateUpdate(t *testing.T) {
 		},
 	}
 
-	updatedRT := v3.RoleTemplate{
+	updatedRT := v32.RoleTemplate{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      testRoleTemplateName,
 			Namespace: testNamespace,
@@ -76,7 +77,7 @@ func TestEnqueuePrtbsOnRoleTemplateUpdate(t *testing.T) {
 }
 
 func TestEnqueueCrtbsOnRoleTemplateUpdate(t *testing.T) {
-	existingCrtbs := []*v3.ClusterRoleTemplateBinding{
+	existingCrtbs := []*v32.ClusterRoleTemplateBinding{
 		{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "crtb-1",
@@ -110,9 +111,9 @@ func TestEnqueueCrtbsOnRoleTemplateUpdate(t *testing.T) {
 		crtbByRoleTemplateIndex: crtbByRoleTemplate,
 	}
 	mockIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	mockIndexer.AddIndexers(indexers)
+	assert.NoError(t, mockIndexer.AddIndexers(indexers))
 	for _, obj := range existingCrtbs {
-		mockIndexer.Add(obj)
+		assert.NoError(t, mockIndexer.Add(obj))
 	}
 
 	rtl := roleTemplateLifecycle{
@@ -124,14 +125,13 @@ func TestEnqueueCrtbsOnRoleTemplateUpdate(t *testing.T) {
 		},
 	}
 
-	updatedRT := v3.RoleTemplate{
+	updatedRT := v32.RoleTemplate{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      testRoleTemplateName,
 			Namespace: testNamespace,
 		},
 	}
 	// Now pass in a roleTemplate with name that matches a subset of test objects
-	err := rtl.enqueueCrtbs(&updatedRT)
-	assert.Nil(t, err)
+	assert.NoError(t, rtl.enqueueCrtbs(&updatedRT))
 	assert.Equal(t, 2, len(mockCrtbController.EnqueueCalls()))
 }

--- a/pkg/controllers/management/auth/setting.go
+++ b/pkg/controllers/management/auth/setting.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
 	"github.com/rancher/rancher/pkg/auth/providers/azure"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -24,7 +25,7 @@ func newAuthSettingController(mgmt *config.ManagementContext) *SettingController
 }
 
 //sync is called periodically and on real updates
-func (n *SettingController) sync(key string, obj *v3.Setting) (runtime.Object, error) {
+func (n *SettingController) sync(key string, obj *v33.Setting) (runtime.Object, error) {
 	if obj == nil || obj.DeletionTimestamp != nil {
 		return nil, nil
 	}

--- a/pkg/controllers/management/auth/token.go
+++ b/pkg/controllers/management/auth/token.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	tokenUtil "github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/features"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -24,7 +25,7 @@ func newTokenController(mgmt *config.ManagementContext) *TokenController {
 }
 
 //sync is called periodically and on real updates
-func (n *TokenController) sync(key string, obj *v3.Token) (runtime.Object, error) {
+func (n *TokenController) sync(key string, obj *v33.Token) (runtime.Object, error) {
 	if obj == nil {
 		return nil, nil
 	}

--- a/pkg/controllers/management/auth/user.go
+++ b/pkg/controllers/management/auth/user.go
@@ -81,7 +81,7 @@ func newUserLifecycle(management *config.ManagementContext, clusterManager *clus
 }
 
 func grbByUserRefFunc(obj interface{}) ([]string, error) {
-	globalRoleBinding, ok := obj.(*v3.GlobalRoleBinding)
+	globalRoleBinding, ok := obj.(*v32.GlobalRoleBinding)
 	if !ok {
 		return []string{}, nil
 	}
@@ -90,7 +90,7 @@ func grbByUserRefFunc(obj interface{}) ([]string, error) {
 }
 
 func prtbByUserRefFunc(obj interface{}) ([]string, error) {
-	projectRoleBinding, ok := obj.(*v3.ProjectRoleTemplateBinding)
+	projectRoleBinding, ok := obj.(*v32.ProjectRoleTemplateBinding)
 	if !ok || projectRoleBinding.UserName == "" {
 		return []string{}, nil
 	}
@@ -99,7 +99,7 @@ func prtbByUserRefFunc(obj interface{}) ([]string, error) {
 }
 
 func crtbByUserRefFunc(obj interface{}) ([]string, error) {
-	clusterRoleBinding, ok := obj.(*v3.ClusterRoleTemplateBinding)
+	clusterRoleBinding, ok := obj.(*v32.ClusterRoleTemplateBinding)
 	if !ok || clusterRoleBinding.UserName == "" {
 		return []string{}, nil
 	}
@@ -108,7 +108,7 @@ func crtbByUserRefFunc(obj interface{}) ([]string, error) {
 }
 
 func tokenByUserRefFunc(obj interface{}) ([]string, error) {
-	token, ok := obj.(*v3.Token)
+	token, ok := obj.(*v32.Token)
 	if !ok {
 		return []string{}, nil
 	}
@@ -116,7 +116,7 @@ func tokenByUserRefFunc(obj interface{}) ([]string, error) {
 	return []string{token.UserID}, nil
 }
 
-func (l *userLifecycle) Create(user *v3.User) (runtime.Object, error) {
+func (l *userLifecycle) Create(user *v32.User) (runtime.Object, error) {
 	var match = false
 	for _, id := range user.PrincipalIDs {
 		if strings.HasPrefix(id, "local://") {
@@ -148,7 +148,7 @@ func (l *userLifecycle) Create(user *v3.User) (runtime.Object, error) {
 	return user, nil
 }
 
-func (l *userLifecycle) Updated(user *v3.User) (runtime.Object, error) {
+func (l *userLifecycle) Updated(user *v32.User) (runtime.Object, error) {
 	err := l.userManager.CreateNewUserClusterRoleBinding(user.Name, user.UID)
 	if err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func (l *userLifecycle) Updated(user *v3.User) (runtime.Object, error) {
 	return user, nil
 }
 
-func (l *userLifecycle) Remove(user *v3.User) (runtime.Object, error) {
+func (l *userLifecycle) Remove(user *v32.User) (runtime.Object, error) {
 	clusterRoles, err := l.getCRTBByUserName(user.Name)
 	if err != nil {
 		return nil, err
@@ -220,15 +220,15 @@ func (l *userLifecycle) Remove(user *v3.User) (runtime.Object, error) {
 	return user, nil
 }
 
-func (l *userLifecycle) getCRTBByUserName(username string) ([]*v3.ClusterRoleTemplateBinding, error) {
+func (l *userLifecycle) getCRTBByUserName(username string) ([]*v32.ClusterRoleTemplateBinding, error) {
 	obj, err := l.crtbIndexer.ByIndex(crtbByUserRefKey, username)
 	if err != nil {
 		return nil, fmt.Errorf("error getting cluster roles: %v", err)
 	}
 
-	var crtbs []*v3.ClusterRoleTemplateBinding
+	var crtbs []*v32.ClusterRoleTemplateBinding
 	for _, o := range obj {
-		crtb, ok := o.(*v3.ClusterRoleTemplateBinding)
+		crtb, ok := o.(*v32.ClusterRoleTemplateBinding)
 		if !ok {
 			return nil, fmt.Errorf("error converting obj to cluster role template binding: %v", o)
 		}
@@ -239,15 +239,15 @@ func (l *userLifecycle) getCRTBByUserName(username string) ([]*v3.ClusterRoleTem
 	return crtbs, nil
 }
 
-func (l *userLifecycle) getPRTBByUserName(username string) ([]*v3.ProjectRoleTemplateBinding, error) {
+func (l *userLifecycle) getPRTBByUserName(username string) ([]*v32.ProjectRoleTemplateBinding, error) {
 	objs, err := l.prtbIndexer.ByIndex(prtbByUserRefKey, username)
 	if err != nil {
 		return nil, fmt.Errorf("error getting indexed project roles: %v", err)
 	}
 
-	var prtbs []*v3.ProjectRoleTemplateBinding
+	var prtbs []*v32.ProjectRoleTemplateBinding
 	for _, obj := range objs {
-		prtb, ok := obj.(*v3.ProjectRoleTemplateBinding)
+		prtb, ok := obj.(*v32.ProjectRoleTemplateBinding)
 		if !ok {
 			return nil, fmt.Errorf("could not convert obj to v3.ProjectRoleTemplateBinding")
 		}
@@ -258,15 +258,15 @@ func (l *userLifecycle) getPRTBByUserName(username string) ([]*v3.ProjectRoleTem
 	return prtbs, nil
 }
 
-func (l *userLifecycle) getGRBByUserName(username string) ([]*v3.GlobalRoleBinding, error) {
+func (l *userLifecycle) getGRBByUserName(username string) ([]*v32.GlobalRoleBinding, error) {
 	objs, err := l.grbIndexer.ByIndex(grbByUserRefKey, username)
 	if err != nil {
 		return nil, fmt.Errorf("error getting indexed global roles: %v", err)
 	}
 
-	var grbs []*v3.GlobalRoleBinding
+	var grbs []*v32.GlobalRoleBinding
 	for _, obj := range objs {
-		grb, ok := obj.(*v3.GlobalRoleBinding)
+		grb, ok := obj.(*v32.GlobalRoleBinding)
 		if !ok {
 			return nil, fmt.Errorf("could not convert obj to v3.GlobalRoleBinding")
 		}
@@ -277,15 +277,15 @@ func (l *userLifecycle) getGRBByUserName(username string) ([]*v3.GlobalRoleBindi
 	return grbs, nil
 }
 
-func (l *userLifecycle) getTokensByUserName(username string) ([]*v3.Token, error) {
+func (l *userLifecycle) getTokensByUserName(username string) ([]*v32.Token, error) {
 	objs, err := l.tokenIndexer.ByIndex(tokenByUserRefKey, username)
 	if err != nil {
 		return nil, fmt.Errorf("error getting indexed tokens: %v", err)
 	}
 
-	var tokens []*v3.Token
+	var tokens []*v32.Token
 	for _, obj := range objs {
-		token, ok := obj.(*v3.Token)
+		token, ok := obj.(*v32.Token)
 		if !ok {
 			return nil, fmt.Errorf("could not convert to *v3.Token: %v", obj)
 		}
@@ -296,7 +296,7 @@ func (l *userLifecycle) getTokensByUserName(username string) ([]*v3.Token, error
 	return tokens, nil
 }
 
-func (l *userLifecycle) deleteAllCRTB(crtbs []*v3.ClusterRoleTemplateBinding) error {
+func (l *userLifecycle) deleteAllCRTB(crtbs []*v32.ClusterRoleTemplateBinding) error {
 	for _, crtb := range crtbs {
 		var err error
 		if crtb.Namespace == "" {
@@ -314,7 +314,7 @@ func (l *userLifecycle) deleteAllCRTB(crtbs []*v3.ClusterRoleTemplateBinding) er
 	return nil
 }
 
-func (l *userLifecycle) deleteAllPRTB(prtbs []*v3.ProjectRoleTemplateBinding) error {
+func (l *userLifecycle) deleteAllPRTB(prtbs []*v32.ProjectRoleTemplateBinding) error {
 	for _, prtb := range prtbs {
 		var err error
 		if prtb.Namespace == "" {
@@ -332,7 +332,7 @@ func (l *userLifecycle) deleteAllPRTB(prtbs []*v3.ProjectRoleTemplateBinding) er
 	return nil
 }
 
-func (l *userLifecycle) deleteAllGRB(grbs []*v3.GlobalRoleBinding) error {
+func (l *userLifecycle) deleteAllGRB(grbs []*v32.GlobalRoleBinding) error {
 	for _, grb := range grbs {
 		var err error
 		if grb.Namespace == "" {
@@ -351,12 +351,12 @@ func (l *userLifecycle) deleteAllGRB(grbs []*v3.GlobalRoleBinding) error {
 	return nil
 }
 
-func (l *userLifecycle) deleteClusterUserAttributes(username string, tokens []*v3.Token) error {
+func (l *userLifecycle) deleteClusterUserAttributes(username string, tokens []*v32.Token) error {
 	if len(tokens) == 0 {
 		return nil
 	}
 	// find the set of clusters associated with a list of tokens
-	set := make(map[string]*v3.Cluster)
+	set := make(map[string]*v32.Cluster)
 	for _, token := range tokens {
 		cluster, err := l.clusterLister.Get("", token.ClusterName)
 		if err != nil {
@@ -381,7 +381,7 @@ func (l *userLifecycle) deleteClusterUserAttributes(username string, tokens []*v
 	return nil
 }
 
-func (l *userLifecycle) deleteAllTokens(tokens []*v3.Token) error {
+func (l *userLifecycle) deleteAllTokens(tokens []*v32.Token) error {
 	for _, token := range tokens {
 		logrus.Infof("[%v] Deleting token %v for user %v", userController, token.Name, token.UserID)
 		err := l.tokens.DeleteNamespaced(token.Namespace, token.Name, &metav1.DeleteOptions{})
@@ -429,7 +429,7 @@ func (l *userLifecycle) deleteUserSecret(username string) error {
 	return l.secrets.DeleteNamespaced("cattle-system", username+"-secret", &metav1.DeleteOptions{})
 }
 
-func (l *userLifecycle) removeLegacyFinalizers(user *v3.User) (*v3.User, error) {
+func (l *userLifecycle) removeLegacyFinalizers(user *v32.User) (*v32.User, error) {
 	finalizers := user.GetFinalizers()
 	for i, finalizer := range finalizers {
 		if finalizer == "controller.cattle.io/cat-user-controller" {

--- a/pkg/controllers/management/auth/user_attribute_handler.go
+++ b/pkg/controllers/management/auth/user_attribute_handler.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
@@ -23,7 +24,7 @@ func newUserAttributeController(mgmt *config.ManagementContext) *UserAttributeCo
 }
 
 //sync is called periodically and on real updates
-func (ua *UserAttributeController) sync(key string, obj *v3.UserAttribute) (runtime.Object, error) {
+func (ua *UserAttributeController) sync(key string, obj *v32.UserAttribute) (runtime.Object, error) {
 	if obj == nil || obj.DeletionTimestamp != nil {
 		return nil, nil
 	}

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy.go
@@ -120,7 +120,7 @@ func (cd *clusterDeploy) sync(key string, cluster *v3.Cluster) (runtime.Object, 
 	return nil, updateErr
 }
 
-func (cd *clusterDeploy) doSync(cluster *v3.Cluster) error {
+func (cd *clusterDeploy) doSync(cluster *v32.Cluster) error {
 	logrus.Tracef("clusterDeploy: doSync called for cluster [%s]", cluster.Name)
 
 	if !v32.ClusterConditionProvisioned.IsTrue(cluster) {
@@ -185,7 +185,7 @@ func agentFeaturesChanged(desired, actual map[string]bool) bool {
 	return false
 }
 
-func redeployAgent(cluster *v3.Cluster, desiredAgent, desiredAuth string, desiredFeatures map[string]bool, desiredTaints []corev1.Taint) bool {
+func redeployAgent(cluster *v32.Cluster, desiredAgent, desiredAuth string, desiredFeatures map[string]bool, desiredTaints []corev1.Taint) bool {
 	logrus.Tracef("clusterDeploy: redeployAgent called for cluster [%s]", cluster.Name)
 	if !v32.ClusterConditionAgentDeployed.IsTrue(cluster) {
 		return true
@@ -252,7 +252,7 @@ func redeployAgent(cluster *v3.Cluster, desiredAgent, desiredAuth string, desire
 	return false
 }
 
-func getDesiredImage(cluster *v3.Cluster) string {
+func getDesiredImage(cluster *v32.Cluster) string {
 	if cluster.Spec.AgentImageOverride != "" {
 		return cluster.Spec.AgentImageOverride
 	}
@@ -260,7 +260,7 @@ func getDesiredImage(cluster *v3.Cluster) string {
 	return cluster.Spec.DesiredAgentImage
 }
 
-func (cd *clusterDeploy) getDesiredFeatures(cluster *v3.Cluster) map[string]bool {
+func (cd *clusterDeploy) getDesiredFeatures(cluster *v32.Cluster) map[string]bool {
 	return map[string]bool{
 		features.MCM.Name():                false,
 		features.MCMAgent.Name():           true,
@@ -272,7 +272,7 @@ func (cd *clusterDeploy) getDesiredFeatures(cluster *v3.Cluster) map[string]bool
 	}
 }
 
-func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
+func (cd *clusterDeploy) deployAgent(cluster *v32.Cluster) error {
 	if cluster.Spec.Internal {
 		return nil
 	}
@@ -401,7 +401,7 @@ func (cd *clusterDeploy) deployAgent(cluster *v3.Cluster) error {
 	return nil
 }
 
-func (cd *clusterDeploy) setNetworkPolicyAnn(cluster *v3.Cluster) error {
+func (cd *clusterDeploy) setNetworkPolicyAnn(cluster *v32.Cluster) error {
 	if cluster.Spec.EnableNetworkPolicy != nil {
 		return nil
 	}
@@ -415,7 +415,7 @@ func (cd *clusterDeploy) setNetworkPolicyAnn(cluster *v3.Cluster) error {
 	return nil
 }
 
-func (cd *clusterDeploy) getKubeConfig(cluster *v3.Cluster) (*clientcmdapi.Config, string, error) {
+func (cd *clusterDeploy) getKubeConfig(cluster *v32.Cluster) (*clientcmdapi.Config, string, error) {
 	logrus.Tracef("clusterDeploy: getKubeConfig called for cluster [%s]", cluster.Name)
 	systemUser, err := cd.systemAccountManager.GetSystemUser(cluster.Name)
 	if err != nil {
@@ -432,7 +432,7 @@ func (cd *clusterDeploy) getKubeConfig(cluster *v3.Cluster) (*clientcmdapi.Confi
 	return cd.clusterManager.KubeConfig(cluster.Name, token), tokenName, nil
 }
 
-func (cd *clusterDeploy) getYAML(cluster *v3.Cluster, agentImage, authImage string, features map[string]bool, taints []corev1.Taint, privateRegistries *corev1.Secret) ([]byte, error) {
+func (cd *clusterDeploy) getYAML(cluster *v32.Cluster, agentImage, authImage string, features map[string]bool, taints []corev1.Taint, privateRegistries *corev1.Secret) ([]byte, error) {
 	logrus.Tracef("clusterDeploy: getYAML: Desired agent image is [%s] for cluster [%s]", agentImage, cluster.Name)
 	logrus.Tracef("clusterDeploy: getYAML: Desired auth image is [%s] for cluster [%s]", authImage, cluster.Name)
 	logrus.Tracef("clusterDeploy: getYAML: Desired features are [%v] for cluster [%s]", features, cluster.Name)

--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -801,7 +801,7 @@ func (p *Provisioner) getConfig(reconcileRKE bool, spec apimgmtv3.ClusterSpec, d
 	return &spec, v, nil
 }
 
-func (p *Provisioner) validateDriver(cluster *v3.Cluster) (string, error) {
+func (p *Provisioner) validateDriver(cluster *apimgmtv3.Cluster) (string, error) {
 	oldDriver := cluster.Status.Driver
 
 	if oldDriver == apimgmtv3.ClusterDriverImported {
@@ -846,7 +846,7 @@ func (p *Provisioner) getSystemImages(spec apimgmtv3.ClusterSpec) (*rketypes.RKE
 		return nil, fmt.Errorf("failed to find system images for version %s: %v", version, err)
 	}
 
-	privateRegistry := util.GetPrivateRepoURL(&v3.Cluster{Spec: spec})
+	privateRegistry := util.GetPrivateRepoURL(&apimgmtv3.Cluster{Spec: spec})
 	if privateRegistry == "" {
 		return &systemImages, nil
 	}

--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -403,7 +403,7 @@ func aliasToPath(driver string, config map[string]interface{}, ns string) error 
 	return nil
 }
 
-func (m *Lifecycle) deployAgent(nodeDir string, obj *v3.Node) error {
+func (m *Lifecycle) deployAgent(nodeDir string, obj *v32.Node) error {
 	token, err := m.systemAccountManager.GetOrCreateSystemClusterToken(obj.Namespace)
 	if err != nil {
 		return err
@@ -445,7 +445,7 @@ func (m *Lifecycle) deployAgent(nodeDir string, obj *v3.Node) error {
 
 // authenticateRegistry authenticates the machine to a private registry if one is defined on the cluster
 // this enables the agent image to be pulled from the private registry
-func (m *Lifecycle) authenticateRegistry(nodeDir string, node *v3.Node, cluster *v3.Cluster) error {
+func (m *Lifecycle) authenticateRegistry(nodeDir string, node *v32.Node, cluster *v32.Cluster) error {
 	reg := util.GetPrivateRepo(cluster)
 	// if there is no private registry defined or there is a registry without credentials, return since auth is not needed
 	if reg == nil || reg.User == "" || reg.Password == "" {
@@ -471,7 +471,7 @@ func (m *Lifecycle) authenticateRegistry(nodeDir string, node *v3.Node, cluster 
 	return nil
 }
 
-func (m *Lifecycle) ready(obj *v3.Node) (*v3.Node, error) {
+func (m *Lifecycle) ready(obj *v32.Node) (*v32.Node, error) {
 	config, err := nodeconfig.NewNodeConfig(m.secretStore, obj)
 	if err != nil {
 		return obj, err

--- a/pkg/controllers/management/node/utils.go
+++ b/pkg/controllers/management/node/utils.go
@@ -132,7 +132,7 @@ func logOptMapToSlice(m map[string]string) []string {
 	return ret
 }
 
-func buildCommand(nodeDir string, node *v3.Node, cmdArgs []string) (*exec.Cmd, error) {
+func buildCommand(nodeDir string, node *v32.Node, cmdArgs []string) (*exec.Cmd, error) {
 	// only in trace because machine has sensitive details and we can't control who debugs what in there easily
 	if logrus.GetLevel() >= logrus.TraceLevel {
 		// prepend --debug to pass directly to machine

--- a/pkg/controllers/management/rkeworkerupgrader/node.go
+++ b/pkg/controllers/management/rkeworkerupgrader/node.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	nodehelper "github.com/rancher/rancher/pkg/node"
 	nodeserver "github.com/rancher/rancher/pkg/rkenodeconfigserver"

--- a/pkg/controllers/management/rkeworkerupgrader/plan.go
+++ b/pkg/controllers/management/rkeworkerupgrader/plan.go
@@ -2,11 +2,11 @@ package rkeworkerupgrader
 
 import (
 	"fmt"
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	kd "github.com/rancher/rancher/pkg/controllers/management/kontainerdrivermetadata"
 	"github.com/rancher/rancher/pkg/controllers/management/secretmigrator"
 	"github.com/rancher/rancher/pkg/librke"

--- a/pkg/controllers/management/rkeworkerupgrader/plan.go
+++ b/pkg/controllers/management/rkeworkerupgrader/plan.go
@@ -2,13 +2,13 @@ package rkeworkerupgrader
 
 import (
 	"fmt"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
 	kd "github.com/rancher/rancher/pkg/controllers/management/kontainerdrivermetadata"
 	"github.com/rancher/rancher/pkg/controllers/management/secretmigrator"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/librke"
 	nodeserver "github.com/rancher/rancher/pkg/rkenodeconfigserver"
 	rkeservices "github.com/rancher/rke/services"
@@ -16,7 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (uh *upgradeHandler) nonWorkerPlan(node *v3.Node, cluster *v3.Cluster) (*rketypes.RKEConfigNodePlan, error) {
+func (uh *upgradeHandler) nonWorkerPlan(node *v32.Node, cluster *v32.Cluster) (*rketypes.RKEConfigNodePlan, error) {
 	appliedSpec := *cluster.Status.AppliedSpec.DeepCopy()
 	var err error
 	appliedSpec, err = secretmigrator.AssembleRKEConfigSpec(cluster, appliedSpec, uh.secretLister)
@@ -74,7 +74,7 @@ func (uh *upgradeHandler) nonWorkerPlan(node *v3.Node, cluster *v3.Cluster) (*rk
 	return nil, fmt.Errorf("failed to find plan for %s", hostAddress)
 }
 
-func (uh *upgradeHandler) workerPlan(node *v3.Node, cluster *v3.Cluster) (*rketypes.RKEConfigNodePlan, error) {
+func (uh *upgradeHandler) workerPlan(node *v32.Node, cluster *v32.Cluster) (*rketypes.RKEConfigNodePlan, error) {
 	infos, err := librke.GetDockerInfo(node)
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/managementapi/usercontrollers/usercontroller.go
+++ b/pkg/controllers/managementapi/usercontrollers/usercontroller.go
@@ -8,12 +8,9 @@ import (
 	"sync"
 	"time"
 
-	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types"
+	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/metrics"
@@ -22,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var (
@@ -84,7 +82,7 @@ type userControllersController struct {
 	start         time.Time
 }
 
-func (u *userControllersController) sync(key string, cluster *v3.Cluster) (runtime.Object, error) {
+func (u *userControllersController) sync(key string, cluster *v33.Cluster) (runtime.Object, error) {
 	if cluster != nil && cluster.DeletionTimestamp != nil {
 		err := u.cleanFinalizers(key, cluster)
 		if err != nil {
@@ -140,7 +138,7 @@ func (u *userControllersController) peersSync() error {
 	return types.NewErrors(errs...)
 }
 
-func (u *userControllersController) amOwner(peers tpeermanager.Peers, cluster *v3.Cluster) bool {
+func (u *userControllersController) amOwner(peers tpeermanager.Peers, cluster *v33.Cluster) bool {
 	if !u.clustered {
 		return true
 	}
@@ -160,7 +158,7 @@ func (u *userControllersController) amOwner(peers tpeermanager.Peers, cluster *v
 	return peers.IDs[scaled] == peers.SelfID
 }
 
-func (u *userControllersController) cleanFinalizers(key string, cluster *v3.Cluster) error {
+func (u *userControllersController) cleanFinalizers(key string, cluster *v33.Cluster) error {
 	c, err := u.clusters.Get(key, metav1.GetOptions{})
 	if err != nil {
 		return err

--- a/pkg/controllers/managementuser/rbac/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler_test.go
@@ -158,16 +158,16 @@ func Test_manager_checkForGlobalResourceRules(t *testing.T) {
 			baseRule: rbacv1.PolicyRule{
 				ResourceNames: []string{"local"},
 			},
-			want:     map[string]bool{},
+			want: map[string]bool{},
 		},
 		{
 			name: "cluster_rule_roletemplate_resource_names_no_match",
 			role: &v3.RoleTemplate{
 				Rules: []v1.PolicyRule{
 					{
-						Verbs:     []string{"get"},
-						APIGroups: []string{"management.cattle.io"},
-						Resources: []string{"clusters"},
+						Verbs:         []string{"get"},
+						APIGroups:     []string{"management.cattle.io"},
+						Resources:     []string{"clusters"},
 						ResourceNames: []string{"local"},
 					},
 				},

--- a/pkg/features/feature_test.go
+++ b/pkg/features/feature_test.go
@@ -33,7 +33,7 @@ func TestApplyArgumentDefaults(t *testing.T) {
 
 func TestInitializeNil(t *testing.T) {
 	assert := assert.New(t)
-	assert.False(IsDefFalse.Enabled())
-	InitializeFeatures(nil, "isfalse=true")
-	assert.True(IsDefFalse.Enabled())
+	assert.False(Legacy.Enabled())
+	InitializeFeatures(nil, "legacy=true")
+	assert.True(Legacy.Enabled())
 }

--- a/pkg/features/feature_testdata.go
+++ b/pkg/features/feature_testdata.go
@@ -1,3 +1,4 @@
+//go:build test
 // +build test
 
 package features

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"fmt"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"path"
 	"sort"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	util "github.com/rancher/rancher/pkg/cluster"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	rketypes "github.com/rancher/rke/types"
 	img "github.com/rancher/rke/types/image"
@@ -42,7 +42,7 @@ func Resolve(image string) string {
 	return ResolveWithCluster(image, nil)
 }
 
-func ResolveWithCluster(image string, cluster *v3.Cluster) string {
+func ResolveWithCluster(image string, cluster *v32.Cluster) string {
 	reg := util.GetPrivateRepoURL(cluster)
 	if reg != "" && !strings.HasPrefix(image, reg) {
 		//Images from Dockerhub Library repo, we add rancher prefix when using private registry

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -2,13 +2,13 @@ package image
 
 import (
 	"fmt"
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"path"
 	"sort"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	util "github.com/rancher/rancher/pkg/cluster"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	"github.com/rancher/rancher/pkg/settings"

--- a/pkg/jailer/jailer_nolinux.go
+++ b/pkg/jailer/jailer_nolinux.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package jailer

--- a/pkg/kontainer-engine/cluster/cluster.go
+++ b/pkg/kontainer-engine/cluster/cluster.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	errors2 "errors"
 	"fmt"
-	"github.com/rancher/rke/log"
 	"reflect"
 
 	"github.com/rancher/rancher/pkg/kontainer-engine/logstream"
 	"github.com/rancher/rancher/pkg/kontainer-engine/types"
+	"github.com/rancher/rke/log"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 )

--- a/pkg/kontainer-engine/drivers/rke/rke_driver.go
+++ b/pkg/kontainer-engine/drivers/rke/rke_driver.go
@@ -429,7 +429,10 @@ func (d *Driver) RemoveLegacyServiceAccount(ctx context.Context, info *types.Clu
 }
 
 func (d *Driver) restore(info *types.ClusterInfo) (string, error) {
-	os.MkdirAll(rancherPath, 0700)
+	err := os.MkdirAll(rancherPath, 0700)
+	if err != nil {
+		logrus.Warnf("[restore] Unexpected error occurred when attempting to create directory (%s)", rancherPath)
+	}
 	dir, err := ioutil.TempDir(rancherPath, "rke-")
 	if err != nil {
 		return "", err
@@ -438,11 +441,17 @@ func (d *Driver) restore(info *types.ClusterInfo) (string, error) {
 	if info != nil {
 		state := info.Metadata["state"]
 		if state != "" {
-			ioutil.WriteFile(kubeConfig(dir), []byte(state), 0600)
+			err := ioutil.WriteFile(kubeConfig(dir), []byte(state), 0600)
+			if err != nil {
+				logrus.Warnf("[restore] Unexpected error occurred when attempting to write kubeConfig to (%s)", kubeConfig(dir))
+			}
 		}
 		fullState := info.Metadata["fullState"]
 		if fullState != "" {
-			ioutil.WriteFile(clusterState(dir), []byte(fullState), 0600)
+			err := ioutil.WriteFile(clusterState(dir), []byte(fullState), 0600)
+			if err != nil {
+				logrus.Warnf("[restore] Unexpected error occurred when attempting to write clusterState to (%s)", clusterState(dir))
+			}
 		}
 	}
 

--- a/pkg/kontainerdriver/driver.go
+++ b/pkg/kontainerdriver/driver.go
@@ -5,8 +5,8 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 )
 
-func GetDriver(cluster *v3.Cluster, driverLister v3.KontainerDriverLister) (string, error) {
-	var driver *v3.KontainerDriver
+func GetDriver(cluster *apimgmtv3.Cluster, driverLister v3.KontainerDriverLister) (string, error) {
+	var driver *apimgmtv3.KontainerDriver
 	var err error
 
 	if cluster.Spec.GenericEngineConfig != nil {

--- a/pkg/systemaccount/systemaccount.go
+++ b/pkg/systemaccount/systemaccount.go
@@ -61,7 +61,7 @@ type Manager struct {
 	users        v3.UserInterface
 }
 
-func (s *Manager) CreateSystemAccount(cluster *v3.Cluster) error {
+func (s *Manager) CreateSystemAccount(cluster *v32.Cluster) error {
 	user, err := s.GetSystemUser(cluster.Name)
 	if err != nil {
 		return err
@@ -73,7 +73,7 @@ func (s *Manager) CreateSystemAccount(cluster *v3.Cluster) error {
 		return nil
 	}
 
-	_, err = s.crtbs.Create(&v3.ClusterRoleTemplateBinding{
+	_, err = s.crtbs.Create(&v32.ClusterRoleTemplateBinding{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      bindingName,
 			Namespace: cluster.Name,
@@ -86,7 +86,7 @@ func (s *Manager) CreateSystemAccount(cluster *v3.Cluster) error {
 	return err
 }
 
-func (s *Manager) GetSystemUser(clusterName string) (*v3.User, error) {
+func (s *Manager) GetSystemUser(clusterName string) (*v32.User, error) {
 	return s.userManager.EnsureUser(fmt.Sprintf("system://%s", clusterName), ClusterSystemAccountPrefix+clusterName)
 }
 
@@ -99,7 +99,7 @@ func (s *Manager) GetOrCreateSystemClusterToken(clusterName string) (string, err
 		if err != nil {
 			return "", err
 		}
-		crt = &v3.ClusterRegistrationToken{
+		crt = &v32.ClusterRegistrationToken{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "system",
 				Namespace: clusterName,
@@ -139,7 +139,7 @@ func (s *Manager) GetOrCreateProjectSystemAccount(projectID string) error {
 			return err
 		}
 		// prtb does not exist in cache, attempt to create it
-		prtb := &v3.ProjectRoleTemplateBinding{
+		prtb := &v32.ProjectRoleTemplateBinding{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      bindingName,
 				Namespace: projectName,
@@ -155,11 +155,11 @@ func (s *Manager) GetOrCreateProjectSystemAccount(projectID string) error {
 	return nil
 }
 
-func (s *Manager) GetProjectSystemUser(projectName string) (*v3.User, error) {
+func (s *Manager) GetProjectSystemUser(projectName string) (*v32.User, error) {
 	return s.userManager.EnsureUser(fmt.Sprintf("system://%s", projectName), ProjectSystemAccountPrefix+projectName)
 }
 
-func (s *Manager) GetProjectPipelineSystemToken(projectName string) (*v3.Token, error) {
+func (s *Manager) GetProjectPipelineSystemToken(projectName string) (*v32.Token, error) {
 	return s.tokenLister.Get("", projectName+"-pipeline")
 }
 

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -79,7 +79,7 @@ func toFeatureString(features map[string]bool) string {
 }
 
 func SystemTemplate(resp io.Writer, agentImage, authImage, namespace, token, url string, isWindowsCluster bool,
-	cluster *v3.Cluster, features map[string]bool, taints []corev1.Taint, privateRegistries *corev1.Secret) error {
+	cluster *apimgmtv3.Cluster, features map[string]bool, taints []corev1.Taint, privateRegistries *corev1.Secret) error {
 	var tolerations, agentEnvVars string
 	d := md5.Sum([]byte(url + token + namespace))
 	tokenKey := hex.EncodeToString(d[:])[:7]
@@ -175,7 +175,7 @@ func CAChecksum() string {
 	return ""
 }
 
-func GetDesiredAgentImage(cluster *v3.Cluster) string {
+func GetDesiredAgentImage(cluster *apimgmtv3.Cluster) string {
 	logrus.Tracef("clusterDeploy: deployAgent called for [%s]", cluster.Name)
 	desiredAgent := cluster.Spec.DesiredAgentImage
 	if cluster.Spec.AgentImageOverride != "" {
@@ -188,7 +188,7 @@ func GetDesiredAgentImage(cluster *v3.Cluster) string {
 	return desiredAgent
 }
 
-func GetDesiredAuthImage(cluster *v3.Cluster) string {
+func GetDesiredAuthImage(cluster *apimgmtv3.Cluster) string {
 	var desiredAuth string
 	if cluster.Spec.LocalClusterAuthEndpoint.Enabled {
 		desiredAuth = cluster.Spec.DesiredAuthImage

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -15,7 +15,6 @@ import (
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	util "github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/features"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/image"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rke/templates"
@@ -130,7 +129,7 @@ func SystemTemplate(resp io.Writer, agentImage, authImage, namespace, token, url
 	return t.Execute(resp, context)
 }
 
-func GetDesiredFeatures(cluster *v3.Cluster) map[string]bool {
+func GetDesiredFeatures(cluster *apimgmtv3.Cluster) map[string]bool {
 	return map[string]bool{
 		features.MCM.Name():                false,
 		features.MCMAgent.Name():           true,
@@ -142,7 +141,7 @@ func GetDesiredFeatures(cluster *v3.Cluster) map[string]bool {
 	}
 }
 
-func ForCluster(cluster *v3.Cluster, token string, taints []corev1.Taint) ([]byte, error) {
+func ForCluster(cluster *apimgmtv3.Cluster, token string, taints []corev1.Taint) ([]byte, error) {
 	buf := &bytes.Buffer{}
 	err := SystemTemplate(buf, GetDesiredAgentImage(cluster),
 		GetDesiredAuthImage(cluster),

--- a/pkg/tunnelserver/mcmauthorizer/tunnel.go
+++ b/pkg/tunnelserver/mcmauthorizer/tunnel.go
@@ -74,7 +74,7 @@ func NewAuthorizer(context *config.ScaledContext) *Authorizer {
 		crtKeyIndex: auth.crtIndex,
 	})
 	if err != nil {
-		logrus.Error("[NewAuthorizer]unexpected error returned when adding Indexers " +
+		logrus.Error("[NewAuthorizer] unexpected error returned when adding Indexers " +
 			"for the management context of cluster registration tokens")
 		return nil
 	}
@@ -82,7 +82,7 @@ func NewAuthorizer(context *config.ScaledContext) *Authorizer {
 		nodeKeyIndex: auth.nodeIndex,
 	})
 	if err != nil {
-		logrus.Error("[NewAuthorizer]unexpected error returned when adding Indexers " +
+		logrus.Error("[NewAuthorizer] unexpected error returned when adding Indexers " +
 			"for the management context of nodes")
 		return nil
 	}


### PR DESCRIPTION
Attempting to fix an issue seen in provisioning where attempts to query a cluster return a 503. This may be related to service account and secret changes performed recently in preparation for k8s 1.24

```console
2022/06/28 18:41:18 [ERROR] error syncing '_all_': handler user-controllers-controller: failed to start user controllers for cluster c-m-x6tfqdtw: ClusterUnavailable 503: cluster not found, requeuing
```

We are not handling errors for two `AddIndexers` method calls for nodes and cluster registration tokens in `pkg/tunnelserver/mcmauthorizer/tunnel.go`. I have added error messages to indicate if an error is returned 