### PR TITLE
Update kubeVersion annotation of rancher chart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: rancher
 description: Install Rancher Server to manage Kubernetes clusters across providers.
 version: %VERSION%
 appVersion: %APP_VERSION%
-kubeVersion: < 1.24.0-0
+kubeVersion: < 1.25.0-0
 home: https://rancher.com
 icon: https://github.com/rancher/ui/blob/master/public/assets/images/logos/welcome-cow.svg
 keywords:


### PR DESCRIPTION
kubeVersion annotation for rancher chart was set to <1.24.
This annotation prevented installing the rancher chart on
newly added k8s version 1.24
Hence this commit updates to annotation to <1.25