### PR TITLE
Updates to RKE1 provisioning_node_driver_test.go

### DIFF
--- a/tests/framework/extensions/rke1/nodepools/nodepools.go
+++ b/tests/framework/extensions/rke1/nodepools/nodepools.go
@@ -1,0 +1,21 @@
+package rke1
+
+import (
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	rke1 "github.com/rancher/rancher/tests/framework/extensions/clusters"
+)
+
+func NewRKE1NodePoolConfig(ClusterID string, NodeTemplateID string) *management.NodePool {
+	nodePoolConfig := &management.NodePool{
+		ClusterID:               ClusterID,
+		ControlPlane:            true,
+		DeleteNotReadyAfterSecs: 0,
+		Etcd:                    true,
+		HostnamePrefix:          rke1.RKE1AppendRandomString("rke1"),
+		NodeTemplateID:          NodeTemplateID,
+		Quantity:                1,
+		Worker:                  true,
+	}
+
+	return nodePoolConfig
+}

--- a/tests/v2/validation/provisioning/hosted/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/hosted_provisioning_test.go
@@ -16,24 +16,25 @@ import (
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	hostedconfig "github.com/rancher/rancher/tests/v2/validation/provisioning/rke2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type HostesdClusterProvisioningTestSuite struct {
+type HostedClusterProvisioningTestSuite struct {
 	suite.Suite
 	client             *rancher.Client
 	session            *session.Session
 	standardUserClient *rancher.Client
 }
 
-func (h *HostesdClusterProvisioningTestSuite) TearDownSuite() {
+func (h *HostedClusterProvisioningTestSuite) TearDownSuite() {
 	h.session.Cleanup()
 }
 
-func (h *HostesdClusterProvisioningTestSuite) SetupSuite() {
+func (h *HostedClusterProvisioningTestSuite) SetupSuite() {
 	testSession := session.NewSession(h.T())
 	h.session = testSession
 
@@ -43,7 +44,7 @@ func (h *HostesdClusterProvisioningTestSuite) SetupSuite() {
 	h.client = client
 
 	enabled := true
-	var testuser = AppendRandomString("testuser-")
+	var testuser = hostedconfig.AppendRandomString("testuser-")
 	user := &management.User{
 		Username: testuser,
 		Password: "rancherrancher123!",
@@ -62,7 +63,7 @@ func (h *HostesdClusterProvisioningTestSuite) SetupSuite() {
 	h.standardUserClient = standardUserClient
 }
 
-func (h *HostesdClusterProvisioningTestSuite) TestProvisioningHostedGKECluster() {
+func (h *HostedClusterProvisioningTestSuite) TestProvisioningHostedGKECluster() {
 	tests := []struct {
 		name   string
 		client *rancher.Client
@@ -82,7 +83,7 @@ func (h *HostesdClusterProvisioningTestSuite) TestProvisioningHostedGKECluster()
 			cloudCredential, err := google.CreateGoogleCloudCredentials(client)
 			require.NoError(h.T(), err)
 
-			clusterName := AppendRandomString("gkehostcluster")
+			clusterName := hostedconfig.AppendRandomString("gkehostcluster")
 			clusterResp, err := gke.CreateGKEHostedCluster(client, clusterName, cloudCredential.ID, false, false, false, false, map[string]string{})
 			require.NoError(h.T(), err)
 
@@ -103,7 +104,7 @@ func (h *HostesdClusterProvisioningTestSuite) TestProvisioningHostedGKECluster()
 	}
 }
 
-func (h *HostesdClusterProvisioningTestSuite) TestProvisioningHostedAKSCluster() {
+func (h *HostedClusterProvisioningTestSuite) TestProvisioningHostedAKSCluster() {
 	tests := []struct {
 		name   string
 		client *rancher.Client
@@ -123,7 +124,7 @@ func (h *HostesdClusterProvisioningTestSuite) TestProvisioningHostedAKSCluster()
 			cloudCredential, err := azure.CreateAzureCloudCredentials(client)
 			require.NoError(h.T(), err)
 
-			clusterName := AppendRandomString("ekshostcluster")
+			clusterName := hostedconfig.AppendRandomString("ekshostcluster")
 			clusterResp, err := aks.CreateAKSHostedCluster(client, clusterName, cloudCredential.ID, false, false, false, false, map[string]string{})
 			require.NoError(h.T(), err)
 
@@ -144,7 +145,7 @@ func (h *HostesdClusterProvisioningTestSuite) TestProvisioningHostedAKSCluster()
 	}
 }
 
-func (h *HostesdClusterProvisioningTestSuite) TestProvisioningHostedEKSCluster() {
+func (h *HostedClusterProvisioningTestSuite) TestProvisioningHostedEKSCluster() {
 	tests := []struct {
 		name   string
 		client *rancher.Client
@@ -164,7 +165,7 @@ func (h *HostesdClusterProvisioningTestSuite) TestProvisioningHostedEKSCluster()
 			cloudCredential, err := aws.CreateAWSCloudCredentials(client)
 			require.NoError(h.T(), err)
 
-			clusterName := AppendRandomString("ekshostcluster")
+			clusterName := hostedconfig.AppendRandomString("ekshostcluster")
 			clusterResp, err := eks.CreateEKSHostedCluster(client, clusterName, cloudCredential.ID, false, false, false, false, map[string]string{})
 			require.NoError(h.T(), err)
 
@@ -188,5 +189,5 @@ func (h *HostesdClusterProvisioningTestSuite) TestProvisioningHostedEKSCluster()
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestHostesdClusterProvisioningTestSuite(t *testing.T) {
-	suite.Run(t, new(HostesdClusterProvisioningTestSuite))
+	suite.Run(t, new(HostedClusterProvisioningTestSuite))
 }

--- a/tests/v2/validation/provisioning/rke1/providers.go
+++ b/tests/v2/validation/provisioning/rke1/providers.go
@@ -1,4 +1,4 @@
-package provisioning
+package rke1
 
 import (
 	"fmt"

--- a/tests/v2/validation/provisioning/rke2/config.go
+++ b/tests/v2/validation/provisioning/rke2/config.go
@@ -1,4 +1,4 @@
-package provisioning
+package rke2
 
 import (
 	"strings"

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -1,4 +1,4 @@
-package provisioning
+package rke2
 
 import (
 	"context"

--- a/tests/v2/validation/provisioning/rke2/nodeproviders.go
+++ b/tests/v2/validation/provisioning/rke2/nodeproviders.go
@@ -1,4 +1,4 @@
-package provisioning
+package rke2
 
 import (
 	"fmt"

--- a/tests/v2/validation/provisioning/rke2/providers.go
+++ b/tests/v2/validation/provisioning/rke2/providers.go
@@ -1,4 +1,4 @@
-package provisioning
+package rke2
 
 import (
 	"fmt"

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -1,4 +1,4 @@
-package provisioning
+package rke2
 
 import (
 	"context"


### PR DESCRIPTION
**PR Description**
PR addressing enhancements requested in issue https://github.com/rancher/rancher/issues/38135. This PR contains the following enhancements:

- `hosted_provisioning_test.go` is moved out of `rke2` folder and is in a new `hosted` folder
     - Fixed spelling errors in the functions as well
- Created constructors for RKE1 cluster creation and node pool creation. These are moved into `clusters.go` and `nodepools.go`, respectively
- Included a standard user to test with, before only admin user was here
- Removed `fmt.println` that was in the code before
- Ensured that `rke1` and `rke2` files each refer to their respective packages. Before, they all just referred to parent package `provisioning`