### PR TITLE
Check impersonation role bindings in setup

### DIFF
--- a/pkg/impersonation/impersonation.go
+++ b/pkg/impersonation/impersonation.go
@@ -63,7 +63,11 @@ func (i *Impersonator) SetUpImpersonation() (*corev1.ServiceAccount, error) {
 	if err != nil {
 		return nil, err
 	}
-	if role != nil {
+	roleBinding, err := i.getRoleBinding()
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	if role != nil && roleBinding != nil {
 		sa, err := i.getServiceAccount()
 		// in case the role exists but we were interrupted before creating the service account, proceed to create resources
 		if err == nil || !apierrors.IsNotFound(err) {
@@ -283,6 +287,11 @@ func (i *Impersonator) rulesForUser() []rbacv1.PolicyRule {
 		})
 	}
 	return rules
+}
+
+func (i *Impersonator) getRoleBinding() (*rbacv1.ClusterRoleBinding, error) {
+	name := ImpersonationPrefix + i.user.GetUID()
+	return i.clusterContext.RBAC.ClusterRoleBindings("").Controller().Lister().Get("", name)
 }
 
 func (i *Impersonator) createRoleBinding(role *rbacv1.ClusterRole, sa *corev1.ServiceAccount) error {


### PR DESCRIPTION
Impersonation needs three resources: clusterroles, clusterrolebindings,
and serviceaccounts. Without this patch, we assume that if the
clusterrole exists, the clusterrolebinding also exists. In some cases,
if packets were dropped during creation or if the clusterrolebinding was
deliberately or accidentally deleted, the clusterrolebinding might not
exist and a proxy request would fail due to lack of permissions. This
patch ensures the setup is more resilient against missing resources.

https://github.com/rancher/rancher/issues/37733