### PR TITLE
Extend workload extension helpers for the validation tests

### DIFF
--- a/tests/framework/extensions/charts/charts.go
+++ b/tests/framework/extensions/charts/charts.go
@@ -56,6 +56,11 @@ type RancherMonitoringOpts struct {
 	RKEScheduler         bool
 }
 
+// RancherLoggingOpts is a struct of the required options to install Rancher Logging with desired chart values.
+type RancherLoggingOpts struct {
+	AdditionalLoggingSources bool
+}
+
 // GetChartCaseEndpointResult is a struct that GetChartCaseEndpoint helper function returns.
 // It contains the boolean for healthy response and the request body.
 type GetChartCaseEndpointResult struct {

--- a/tests/framework/extensions/charts/rancherlogging.go
+++ b/tests/framework/extensions/charts/rancherlogging.go
@@ -1,0 +1,156 @@
+package charts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/rancher/pkg/api/steve/catalog/types"
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	// Namespace that rancher logging chart is installed in
+	RancherLoggingNamespace = "cattle-logging-system"
+	// Name of the rancher logging chart
+	RancherLoggingName = "rancher-logging"
+)
+
+// InstallRancherLoggingChart is a helper function that installs the rancher-logging chart.
+func InstallRancherLoggingChart(client *rancher.Client, installOptions *InstallOptions, rancherLoggingOpts *RancherLoggingOpts) error {
+	loggingChartInstallActionPayload := &payloadOpts{
+		InstallOptions: *installOptions,
+		Name:           RancherLoggingName,
+		Host:           client.RancherConfig.Host,
+		Namespace:      RancherLoggingNamespace,
+	}
+
+	chartInstallAction := newLoggingChartInstallAction(loggingChartInstallActionPayload, rancherLoggingOpts)
+
+	catalogClient, err := client.GetClusterCatalogClient(installOptions.ClusterID)
+	if err != nil {
+		return err
+	}
+
+	// Cleanup registration
+	client.Session.RegisterCleanupFunc(func() error {
+		// UninstallAction for when uninstalling the rancher-logging chart
+		defaultChartUninstallAction := newChartUninstallAction()
+
+		err = catalogClient.UninstallChart(RancherLoggingName, RancherLoggingNamespace, defaultChartUninstallAction)
+		if err != nil {
+			return err
+		}
+
+		watchAppInterface, err := catalogClient.Apps(RancherLoggingNamespace).Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + RancherLoggingName,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+		if err != nil {
+			return err
+		}
+
+		err = wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+			if event.Type == watch.Error {
+				return false, fmt.Errorf("there was an error uninstalling rancher logging chart")
+			} else if event.Type == watch.Deleted {
+				return true, nil
+			}
+			return false, nil
+		})
+		if err != nil {
+			return err
+		}
+
+		dynamicClient, err := client.GetDownStreamClusterClient(installOptions.ClusterID)
+		if err != nil {
+			return err
+		}
+		namespaceResource := dynamicClient.Resource(namespaces.NamespaceGroupVersionResource).Namespace("")
+
+		err = namespaceResource.Delete(context.TODO(), RancherLoggingNamespace, metav1.DeleteOptions{})
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+		if err != nil {
+			return err
+		}
+		adminDynamicClient, err := adminClient.GetDownStreamClusterClient(installOptions.ClusterID)
+		if err != nil {
+			return err
+		}
+		adminNamespaceResource := adminDynamicClient.Resource(namespaces.NamespaceGroupVersionResource).Namespace("")
+
+		watchNamespaceInterface, err := adminNamespaceResource.Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + RancherLoggingNamespace,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return wait.WatchWait(watchNamespaceInterface, func(event watch.Event) (ready bool, err error) {
+			if event.Type == watch.Deleted {
+				return true, nil
+			}
+			return false, nil
+		})
+	})
+
+	err = catalogClient.InstallChart(chartInstallAction)
+	if err != nil {
+		return err
+	}
+
+	// wait for chart to be full deployed
+	watchAppInterface, err := catalogClient.Apps(RancherLoggingNamespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + RancherLoggingName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+		app := event.Object.(*catalogv1.App)
+
+		state := app.Status.Summary.State
+		if state == string(catalogv1.StatusDeployed) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// newLoggingChartInstallAction is a private helper function that returns chart install action with logging and payload options.
+func newLoggingChartInstallAction(p *payloadOpts, rancherLoggingOpts *RancherLoggingOpts) *types.ChartInstallAction {
+	loggingValues := map[string]interface{}{
+		"additionalLoggingSources": map[string]interface{}{
+			"enabled": rancherLoggingOpts.AdditionalLoggingSources,
+		},
+	}
+
+	chartInstall := newChartInstall(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, loggingValues)
+	chartInstallCRD := newChartInstall(p.Name+"-crd", p.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, nil)
+	chartInstalls := []types.ChartInstall{*chartInstallCRD, *chartInstall}
+
+	chartInstallAction := newChartInstallAction(p.Namespace, p.ProjectID, chartInstalls)
+
+	return chartInstallAction
+}

--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -35,6 +35,22 @@ func GetClusterIDByName(client *rancher.Client, clusterName string) (string, err
 	return "", nil
 }
 
+// GetClusterNameByID is a helper function that returns the cluster ID by name
+func GetClusterNameByID(client *rancher.Client, clusterID string) (string, error) {
+	clusterList, err := client.Management.Cluster.List(&types.ListOpts{})
+	if err != nil {
+		return "", err
+	}
+
+	for _, cluster := range clusterList.Data {
+		if cluster.ID == clusterID {
+			return cluster.Name, nil
+		}
+	}
+
+	return "", nil
+}
+
 // IsProvisioningClusterReady is basic check function that would be used for the wait.WatchWait func in pkg/wait.
 // This functions just waits until a cluster becomes ready.
 func IsProvisioningClusterReady(event watch.Event) (ready bool, err error) {

--- a/tests/framework/extensions/ingresses/create.go
+++ b/tests/framework/extensions/ingresses/create.go
@@ -1,0 +1,42 @@
+package ingresses
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/unstructured"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateIngress is a helper function that uses the dynamic client to create an ingress on a namespace for a specific cluster.
+func CreateIngress(client *rancher.Client, clusterID, ingressName, namespace string, ingressSpec *networkingv1.IngressSpec) (*networkingv1.Ingress, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ingressName,
+			Namespace: namespace,
+		},
+		Spec: *ingressSpec,
+	}
+
+	ingressResource := dynamicClient.Resource(IngressesGroupVersionResource).Namespace(namespace)
+
+	unstructuredResp, err := ingressResource.Create(context.TODO(), unstructured.MustToUnstructured(ingress), metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	newIngress := &networkingv1.Ingress{}
+	err = scheme.Scheme.Convert(unstructuredResp, newIngress, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	return newIngress, nil
+}

--- a/tests/framework/extensions/ingresses/ingresses.go
+++ b/tests/framework/extensions/ingresses/ingresses.go
@@ -1,0 +1,39 @@
+package ingresses
+
+import (
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// IngressesGroupVersionResource is the required Group Version Resource for accessing ingresses in a cluster,
+// using the dynamic client.
+var IngressesGroupVersionResource = schema.GroupVersionResource{
+	Group:    "networking.k8s.io",
+	Version:  "v1",
+	Resource: "ingresses",
+}
+
+// GetIngressByName is a helper function that returns the ingress by name in a specific cluster, uses ListIngresses to get the ingress.
+func GetIngressByName(client *rancher.Client, clusterID, namespaceName, ingressName string) (*networkingv1.Ingress, error) {
+	var ingress *networkingv1.Ingress
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	if err != nil {
+		return ingress, err
+	}
+
+	ingressesList, err := ListIngresses(adminClient, clusterID, namespaceName, metav1.ListOptions{})
+	if err != nil {
+		return ingress, err
+	}
+
+	for i, ingress := range ingressesList.Items {
+		if ingress.Name == ingressName {
+			return &ingressesList.Items[i], nil
+		}
+	}
+
+	return ingress, nil
+}

--- a/tests/framework/extensions/ingresses/list.go
+++ b/tests/framework/extensions/ingresses/list.go
@@ -1,0 +1,55 @@
+package ingresses
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// IngressList is a struct that contains a list of deployments.
+type IngressList struct {
+	Items []networkingv1.Ingress
+}
+
+// ListIngresses is a helper function that uses the dynamic client to list ingresses on a namespace for a specific cluster with its list options.
+func ListIngresses(client *rancher.Client, clusterID, namespace string, listOpts metav1.ListOptions) (*IngressList, error) {
+	ingressList := new(IngressList)
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	ingressResource := dynamicClient.Resource(IngressesGroupVersionResource).Namespace(namespace)
+	ingresses, err := ingressResource.List(context.TODO(), listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, unstructuredIngress := range ingresses.Items {
+		newIngress := &networkingv1.Ingress{}
+		err := scheme.Scheme.Convert(&unstructuredIngress, newIngress, unstructuredIngress.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		ingressList.Items = append(ingressList.Items, *newIngress)
+	}
+
+	return ingressList, nil
+}
+
+// Names is a method that accepts IngressList as a receiver,
+// returns each ingress name in the list as a new slice of strings.
+func (list *IngressList) Names() []string {
+	var ingressNames []string
+
+	for _, ingress := range list.Items {
+		ingressNames = append(ingressNames, ingress.Name)
+	}
+
+	return ingressNames
+}

--- a/tests/framework/extensions/namespaces/create.go
+++ b/tests/framework/extensions/namespaces/create.go
@@ -1,0 +1,125 @@
+package namespaces
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/unstructured"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	coreV1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeUnstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// CreateNamespace is a helper function that uses the dynamic client to create a namespace on a project.
+// It registers a delete function with a wait.WatchWait to ensure the namspace is deleted cleanly.
+func CreateNamespace(client *rancher.Client, namespaceName, containerDefaultResourceLimit string, labels, annotations map[string]string, project *management.Project) (*coreV1.Namespace, error) {
+	// Namespace object for a project name space
+	annotations["field.cattle.io/containerDefaultResourceLimit"] = containerDefaultResourceLimit
+	annotations["field.cattle.io/projectId"] = project.ID
+	namespace := &coreV1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        namespaceName,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+	}
+
+	dynamicClient, err := client.GetDownStreamClusterClient(project.ClusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	if err != nil {
+		return nil, err
+	}
+
+	adminDynamicClient, err := adminClient.GetDownStreamClusterClient(project.ClusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaceResource := dynamicClient.Resource(NamespaceGroupVersionResource).Namespace("")
+
+	unstructuredResp, err := namespaceResource.Create(context.TODO(), unstructured.MustToUnstructured(namespace), metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	clusterRoleResource := adminDynamicClient.Resource(rbacv1.SchemeGroupVersion.WithResource("clusterroles"))
+	projectID := strings.Split(project.ID, ":")[1]
+
+	clusterRoleWatch, err := clusterRoleResource.Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + fmt.Sprintf("%s-namespaces-edit", projectID),
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = wait.WatchWait(clusterRoleWatch, func(event watch.Event) (ready bool, err error) {
+		clusterRole := &rbacv1.ClusterRole{}
+		err = scheme.Scheme.Convert(event.Object.(*kubeUnstructured.Unstructured), clusterRole, event.Object.(*kubeUnstructured.Unstructured).GroupVersionKind())
+
+		if err != nil {
+			return false, err
+		}
+
+		for _, rule := range clusterRole.Rules {
+			for _, resourceName := range rule.ResourceNames {
+				if resourceName == namespaceName {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	client.Session.RegisterCleanupFunc(func() error {
+		err := namespaceResource.Delete(context.TODO(), unstructuredResp.GetName(), metav1.DeleteOptions{})
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		adminNamespaceResource := adminDynamicClient.Resource(NamespaceGroupVersionResource).Namespace("")
+		watchInterface, err := adminNamespaceResource.Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + unstructuredResp.GetName(),
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return wait.WatchWait(watchInterface, func(event watch.Event) (ready bool, err error) {
+			if event.Type == watch.Deleted {
+				return true, nil
+			}
+			return false, nil
+		})
+	})
+
+	newNamespace := &coreV1.Namespace{}
+	err = scheme.Scheme.Convert(unstructuredResp, newNamespace, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+	return newNamespace, nil
+}

--- a/tests/framework/extensions/namespaces/list.go
+++ b/tests/framework/extensions/namespaces/list.go
@@ -1,0 +1,55 @@
+package namespaces
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NamespaceList is a struct that contains a list of namespaces.
+type NamespaceList struct {
+	Items []corev1.Namespace
+}
+
+// ListNamespaces is a helper function that uses the dynamic client to list namespaces in a cluster with its list options.
+func ListNamespaces(client *rancher.Client, clusterID string, listOpts metav1.ListOptions) (*NamespaceList, error) {
+	namespaceList := new(NamespaceList)
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaceResource := dynamicClient.Resource(NamespaceGroupVersionResource).Namespace("")
+	namespaces, err := namespaceResource.List(context.TODO(), listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, unstructuredNamespace := range namespaces.Items {
+		newNamespace := &corev1.Namespace{}
+		err := scheme.Scheme.Convert(&unstructuredNamespace, newNamespace, unstructuredNamespace.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		namespaceList.Items = append(namespaceList.Items, *newNamespace)
+	}
+
+	return namespaceList, nil
+}
+
+// Names is a method that accepts NamespaceList as a receiver,
+// returns each namespace name in the list as a new slice of strings.
+func (list *NamespaceList) Names() []string {
+	var namespaceNames []string
+
+	for _, namespace := range list.Items {
+		namespaceNames = append(namespaceNames, namespace.Name)
+	}
+
+	return namespaceNames
+}

--- a/tests/framework/extensions/namespaces/namespaces.go
+++ b/tests/framework/extensions/namespaces/namespaces.go
@@ -1,23 +1,11 @@
 package namespaces
 
 import (
-	"context"
 	"fmt"
-	"strings"
 
-	"github.com/rancher/rancher/pkg/api/scheme"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
-	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
-	"github.com/rancher/rancher/tests/framework/extensions/unstructured"
-	"github.com/rancher/rancher/tests/framework/pkg/wait"
-	"github.com/rancher/rancher/tests/integration/pkg/defaults"
-	coreV1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
-
-	kubeUnstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -38,107 +26,21 @@ func ContainerDefaultResourceLimit(limitsCPU, limitsMemory, requestsCPU, request
 	return containerDefaultResourceLimit
 }
 
-// CreateNamespace is a helper function that uses the dynamic client to create a namespace on a project.
-// It registers a delete fuction with a wait.WatchWait to ensure the namspace is deleted cleanly.
-func CreateNamespace(client *rancher.Client, namespaceName, containerDefaultResourceLimit string, labels, annotations map[string]string, project *management.Project) (*coreV1.Namespace, error) {
-	// Namespace object for a project name space
-	annotations["field.cattle.io/containerDefaultResourceLimit"] = containerDefaultResourceLimit
-	annotations["field.cattle.io/projectId"] = project.ID
-	namespace := &coreV1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        namespaceName,
-			Annotations: annotations,
-			Labels:      labels,
-		},
-	}
+// GetNamespaceByName is a helper function that returns the namespace by name in a specific cluster, uses ListNamespaces to get the namespace.
+func GetNamespaceByName(client *rancher.Client, clusterID, namespaceName string) (*corev1.Namespace, error) {
+	var namespace *corev1.Namespace
 
-	dynamicClient, err := client.GetDownStreamClusterClient(project.ClusterID)
+	namespaceList, err := ListNamespaces(client, clusterID, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
-	if err != nil {
-		return nil, err
-	}
-
-	adminDynamicClient, err := adminClient.GetDownStreamClusterClient(project.ClusterID)
-	if err != nil {
-		return nil, err
-	}
-
-	namespaceResource := dynamicClient.Resource(NamespaceGroupVersionResource).Namespace("")
-
-	unstructuredResp, err := namespaceResource.Create(context.TODO(), unstructured.MustToUnstructured(namespace), metav1.CreateOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	clusterRoleResource := adminDynamicClient.Resource(rbacv1.SchemeGroupVersion.WithResource("clusterroles"))
-	projectID := strings.Split(project.ID, ":")[1]
-
-	clusterRoleWatch, err := clusterRoleResource.Watch(context.TODO(), metav1.ListOptions{
-		FieldSelector:  "metadata.name=" + fmt.Sprintf("%s-namespaces-edit", projectID),
-		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	err = wait.WatchWait(clusterRoleWatch, func(event watch.Event) (ready bool, err error) {
-		clusterRole := &rbacv1.ClusterRole{}
-		err = scheme.Scheme.Convert(event.Object.(*kubeUnstructured.Unstructured), clusterRole, event.Object.(*kubeUnstructured.Unstructured).GroupVersionKind())
-
-		if err != nil {
-			return false, err
+	for i, ns := range namespaceList.Items {
+		if namespaceName == ns.Name {
+			namespace = &namespaceList.Items[i]
+			break
 		}
-
-		for _, rule := range clusterRole.Rules {
-			for _, resourceName := range rule.ResourceNames {
-				if resourceName == namespaceName {
-					return true, nil
-				}
-			}
-		}
-		return false, nil
-	})
-
-	if err != nil {
-		return nil, err
 	}
 
-	client.Session.RegisterCleanupFunc(func() error {
-		err := namespaceResource.Delete(context.TODO(), unstructuredResp.GetName(), metav1.DeleteOptions{})
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-
-		adminNamespaceResource := adminDynamicClient.Resource(NamespaceGroupVersionResource).Namespace("")
-		watchInterface, err := adminNamespaceResource.Watch(context.TODO(), metav1.ListOptions{
-			FieldSelector:  "metadata.name=" + unstructuredResp.GetName(),
-			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
-		})
-
-		if err != nil {
-			return err
-		}
-
-		return wait.WatchWait(watchInterface, func(event watch.Event) (ready bool, err error) {
-			if event.Type == watch.Deleted {
-				return true, nil
-			}
-			return false, nil
-		})
-	})
-
-	newNamespace := &coreV1.Namespace{}
-	err = scheme.Scheme.Convert(unstructuredResp, newNamespace, unstructuredResp.GroupVersionKind())
-	if err != nil {
-		return nil, err
-	}
-	return newNamespace, nil
+	return namespace, nil
 }

--- a/tests/framework/extensions/projects/projects.go
+++ b/tests/framework/extensions/projects/projects.go
@@ -6,7 +6,7 @@ import (
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 )
 
-// GetProjectByName is a helper function that returns the project by name in a specific cluster
+// GetProjectByName is a helper function that returns the project by name in a specific cluster.
 func GetProjectByName(client *rancher.Client, clusterID, projectName string) (*management.Project, error) {
 	var project *management.Project
 
@@ -24,9 +24,10 @@ func GetProjectByName(client *rancher.Client, clusterID, projectName string) (*m
 		return project, err
 	}
 
-	for _, p := range projectsList.Data {
+	for i, p := range projectsList.Data {
 		if p.Name == projectName {
-			project = &p
+			project = &projectsList.Data[i]
+			break
 		}
 	}
 

--- a/tests/framework/extensions/secrets/create.go
+++ b/tests/framework/extensions/secrets/create.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/rancher/rancher/pkg/api/scheme"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
-	coreV1 "k8s.io/api/core/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/unstructured"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// GetSecret is a helper function that uses the dynamic client to get a specific secret in a namespace for a specific cluster.
-func GetSecret(client *rancher.Client, clusterID, namespace, secretName string, getOpts metav1.GetOptions) (*coreV1.Secret, error) {
+// CreateSecret is a helper function that uses the dynamic client to create a secret on a namespace for a specific cluster.
+// It registers a delete function.
+func CreateSecret(client *rancher.Client, secret *corev1.Secret, clusterID, namespace string) (*corev1.Secret, error) {
 	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
 	if err != nil {
 		return nil, err
@@ -18,12 +20,12 @@ func GetSecret(client *rancher.Client, clusterID, namespace, secretName string, 
 
 	secretResource := dynamicClient.Resource(SecretGroupVersionResource).Namespace(namespace)
 
-	unstructuredResp, err := secretResource.Get(context.TODO(), secretName, getOpts)
+	unstructuredResp, err := secretResource.Create(context.TODO(), unstructured.MustToUnstructured(secret), metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	newSecret := &coreV1.Secret{}
+	newSecret := &corev1.Secret{}
 	err = scheme.Scheme.Convert(unstructuredResp, newSecret, unstructuredResp.GroupVersionKind())
 	if err != nil {
 		return nil, err

--- a/tests/framework/extensions/secrets/list.go
+++ b/tests/framework/extensions/secrets/list.go
@@ -1,0 +1,56 @@
+package secrets
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SecretList is a struct that contains a list of secrets.
+type SecretList struct {
+	Items []corev1.Secret
+}
+
+// ListSecrets is a helper function that uses the dynamic client to list secrets in a cluster with its list options.
+func ListSecrets(client *rancher.Client, clusterID, namespace string, listOpts metav1.ListOptions) (*SecretList, error) {
+	secretList := new(SecretList)
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	secretResource := dynamicClient.Resource(SecretGroupVersionResource).Namespace(namespace)
+	secrets, err := secretResource.List(context.TODO(), listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, unstructuredSecret := range secrets.Items {
+		newSecret := &corev1.Secret{}
+
+		err := scheme.Scheme.Convert(&unstructuredSecret, newSecret, unstructuredSecret.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		secretList.Items = append(secretList.Items, *newSecret)
+	}
+
+	return secretList, nil
+}
+
+// Names is a method that accepts SecretList as a receiver,
+// returns each secret name in the list as a new slice of strings.
+func (list *SecretList) Names() []string {
+	var secretNames []string
+
+	for _, secret := range list.Items {
+		secretNames = append(secretNames, secret.Name)
+	}
+
+	return secretNames
+}

--- a/tests/framework/extensions/secrets/secrets.go
+++ b/tests/framework/extensions/secrets/secrets.go
@@ -3,12 +3,12 @@ package secrets
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/rancher/rancher/pkg/api/scheme"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
-	"github.com/rancher/rancher/tests/framework/extensions/unstructured"
 	coreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // SecretGroupVersionResource is the required Group Version Resource for accessing secrets in a cluster,
@@ -19,16 +19,16 @@ var SecretGroupVersionResource = schema.GroupVersionResource{
 	Resource: "secrets",
 }
 
-// CreateSecret is a helper function that uses the dynamic client to create a secret on a namespace for a specific cluster.
-func CreateSecret(client *rancher.Client, secret *coreV1.Secret, clusterName, namespace string) (*coreV1.Secret, error) {
-	dynamicClient, err := client.GetDownStreamClusterClient(clusterName)
+// GetSecretByName is a helper function that uses the dynamic client to get a specific secret on a namespace for a specific cluster.
+func GetSecretByName(client *rancher.Client, clusterID, namespace, secretName string, getOpts metav1.GetOptions) (*coreV1.Secret, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
 	if err != nil {
 		return nil, err
 	}
 
 	secretResource := dynamicClient.Resource(SecretGroupVersionResource).Namespace(namespace)
 
-	unstructuredResp, err := secretResource.Create(context.TODO(), unstructured.MustToUnstructured(secret), metav1.CreateOptions{})
+	unstructuredResp, err := secretResource.Get(context.TODO(), secretName, getOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/framework/extensions/services/create.go
+++ b/tests/framework/extensions/services/create.go
@@ -19,7 +19,8 @@ var ServiceGroupVersionResource = schema.GroupVersionResource{
 	Resource: "services",
 }
 
-// CreateService is a helper function that uses the dynamic client to create a service in a namespace for a specific cluster.
+// CreateSecret is a helper function that uses the dynamic client to create a secret on a namespace for a specific cluster.
+// It registers a delete fuction.
 func CreateService(client *rancher.Client, clusterName, serviceName, namespace string, spec corev1.ServiceSpec) (*corev1.Service, error) {
 	dynamicClient, err := client.GetDownStreamClusterClient(clusterName)
 	if err != nil {

--- a/tests/framework/extensions/workloads/daemonsets/list.go
+++ b/tests/framework/extensions/workloads/daemonsets/list.go
@@ -1,0 +1,56 @@
+package daemonsets
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	appv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DaemonSetList is a struct that contains a list of daemonsets.
+type DaemonSetList struct {
+	Items []appv1.DaemonSet
+}
+
+// ListDaemonsets is a helper function that uses the dynamic client to list daemonsets in a cluster with its list options.
+func ListDaemonsets(client *rancher.Client, clusterID, namespace string, listOpts metav1.ListOptions) (*DaemonSetList, error) {
+	daemonsetList := new(DaemonSetList)
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	daemonsetResource := dynamicClient.Resource(DaemonSetGroupVersionResource).Namespace(namespace)
+	daemonsets, err := daemonsetResource.List(context.TODO(), listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, unstructuredDaemonset := range daemonsets.Items {
+		newDaemonset := &appv1.DaemonSet{}
+
+		err := scheme.Scheme.Convert(&unstructuredDaemonset, newDaemonset, unstructuredDaemonset.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		daemonsetList.Items = append(daemonsetList.Items, *newDaemonset)
+	}
+
+	return daemonsetList, nil
+}
+
+// Names is a method that accepts DaemonSetList as a receiver,
+// returns each daemonset name in the list as a new slice of strings.
+func (list *DaemonSetList) Names() []string {
+	var daemonsetNames []string
+
+	for _, daemonset := range list.Items {
+		daemonsetNames = append(daemonsetNames, daemonset.Name)
+	}
+
+	return daemonsetNames
+}

--- a/tests/framework/extensions/workloads/deployments/list.go
+++ b/tests/framework/extensions/workloads/deployments/list.go
@@ -9,9 +9,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// DeploymentList is a struct that contains a list of deployments.
+type DeploymentList struct {
+	Items []appv1.Deployment
+}
+
 // ListDeployments is a helper function that uses the dynamic client to list deployments on a namespace for a specific cluster with its list options.
-func ListDeployments(client *rancher.Client, clusterID, namespace string, listOpts metav1.ListOptions) ([]appv1.Deployment, error) {
-	var deploymentList []appv1.Deployment
+func ListDeployments(client *rancher.Client, clusterID, namespace string, listOpts metav1.ListOptions) (*DeploymentList, error) {
+	deploymentList := new(DeploymentList)
 
 	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
 	if err != nil {
@@ -30,8 +35,20 @@ func ListDeployments(client *rancher.Client, clusterID, namespace string, listOp
 			return nil, err
 		}
 
-		deploymentList = append(deploymentList, *newDeployment)
+		deploymentList.Items = append(deploymentList.Items, *newDeployment)
 	}
 
 	return deploymentList, nil
+}
+
+// Names is a method that accepts DeploymentList as a receiver,
+// returns each deployment name in the list as a new slice of strings.
+func (list *DeploymentList) Names() []string {
+	var deploymentNames []string
+
+	for _, deployment := range list.Items {
+		deploymentNames = append(deploymentNames, deployment.Name)
+	}
+
+	return deploymentNames
 }

--- a/tests/v2/validation/charts/istio_test.go
+++ b/tests/v2/validation/charts/istio_test.go
@@ -269,9 +269,9 @@ func (i *IstioTestSuite) TestUpgradeIstioChart() {
 		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
 	})
 	require.NoError(i.T(), err)
-	require.Equalf(i.T(), 2, len(deploymentListPreUpgrade), "Pilot & Ingressgateways deployments don't have the correct istio version labels")
+	require.Equalf(i.T(), 2, len(deploymentListPreUpgrade.Items), "Pilot & Ingressgateways deployments don't have the correct istio version labels")
 
-	for _, deployment := range deploymentListPreUpgrade {
+	for _, deployment := range deploymentListPreUpgrade.Items {
 		imageVersion := strings.Split(deployment.Spec.Template.Spec.Containers[0].Image, ":")[1]
 		i.T().Logf("Comparing image and app versions: \n container image version: %v \n istio version: %v and actual: %v\n", deployment.Spec.Template.Spec.Containers[0].Image, istioVersionPreUpgrade, imageVersion)
 		require.Equalf(i.T(), istioVersionPreUpgrade, imageVersion, "Pilot & Ingressgateways images don't use the correct istio image version")
@@ -306,9 +306,9 @@ func (i *IstioTestSuite) TestUpgradeIstioChart() {
 		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
 	})
 	require.NoError(i.T(), err)
-	require.Equalf(i.T(), 2, len(deploymentListPostUpgrade), "Pilot & Ingressgateways deployments don't have the correct istio version labels")
+	require.Equalf(i.T(), 2, len(deploymentListPostUpgrade.Items), "Pilot & Ingressgateways deployments don't have the correct istio version labels")
 
-	for _, deployment := range deploymentListPostUpgrade {
+	for _, deployment := range deploymentListPostUpgrade.Items {
 		imageVersion := strings.Split(deployment.Spec.Template.Spec.Containers[0].Image, ":")[1]
 		i.T().Logf("Comparing image and app versions: \n container image: %v \n istio version: %v and actual: %v\n", deployment.Spec.Template.Spec.Containers[0].Image, istioVersionPostUpgrade, imageVersion)
 		require.Equalf(i.T(), istioVersionPostUpgrade, imageVersion, "Pilot & Ingressgateways images don't use the correct istio image version")

--- a/tests/v2/validation/charts/monitoring_test.go
+++ b/tests/v2/validation/charts/monitoring_test.go
@@ -179,7 +179,7 @@ func (m *MonitoringTestSuite) TestMonitoringChart() {
 	require.NoError(m.T(), err)
 
 	m.T().Logf("Getting alert manager secret")
-	alertManagerSecret, err := secrets.GetSecret(client, m.project.ClusterID, charts.RancherMonitoringNamespace, charts.RancherMonitoringAlertSecret, metav1.GetOptions{})
+	alertManagerSecret, err := secrets.GetSecretByName(client, m.project.ClusterID, charts.RancherMonitoringNamespace, charts.RancherMonitoringAlertSecret, metav1.GetOptions{})
 	require.NoError(m.T(), err)
 
 	m.T().Logf("Editing alert manager secret receivers")
@@ -195,7 +195,7 @@ func (m *MonitoringTestSuite) TestMonitoringChart() {
 	require.NoError(m.T(), err)
 
 	m.T().Logf("Getting alert manager secret")
-	alertManagerSecret, err = secrets.GetSecret(client, m.project.ClusterID, charts.RancherMonitoringNamespace, charts.RancherMonitoringAlertSecret, metav1.GetOptions{})
+	alertManagerSecret, err = secrets.GetSecretByName(client, m.project.ClusterID, charts.RancherMonitoringNamespace, charts.RancherMonitoringAlertSecret, metav1.GetOptions{})
 	require.NoError(m.T(), err)
 
 	m.T().Logf("Editing alert manager secret routes")


### PR DESCRIPTION
**Extensions Updates**

- Implemented:
  - Rancher logging v2 chart installation and its options as a struct
  - Cluster name getter with the given cluster id
  - Create & list ingress and a getter to get a specific ingress with the given name
  - List namespaces, secrets, daemon sets, and deployments
- Refactored:
  - If the `extensions/resource/resources.go` has a helper (such as a getter on top of the list call) move the resource creations to `extensions/resource/create.go`.
  - Lists return <ResourceList> struct that contains a slice of the resource, and that struct can be used to add further methods such as `Names`
  - `ByName` postfix changes all getters if they use the resource name.

**Validation Tests**

- Refactored:
  - Monitoring v2 secret getter rename
  - Istio list looping since the list return a struct rather than a slice of strings