### PR TITLE
Trigger user attribute refresh for empty extras

### DIFF
--- a/pkg/auth/providerrefresh/refresher.go
+++ b/pkg/auth/providerrefresh/refresher.go
@@ -251,6 +251,21 @@ func (r *refresher) refreshAttributes(attribs *v3.UserAttribute) (*v3.UserAttrib
 
 		attribs.GroupPrincipals[providerName] = v32.Principals{Items: newGroupPrincipals}
 
+		if principalID != "" && len(loginTokens[providerName]) > 0 {
+			// A user is 1:1 with its principal for a given provider, no need to get principals from tokens beyond the first one
+			userPrincipal, err := providers.GetPrincipal(principalID, *loginTokens[providerName][0])
+			if err != nil {
+				return nil, err
+			}
+			userExtraInfo := providers.GetUserExtraAttributes(providerName, userPrincipal)
+			if userExtraInfo != nil {
+				if attribs.ExtraByProvider == nil {
+					attribs.ExtraByProvider = make(map[string]map[string][]string)
+				}
+				attribs.ExtraByProvider[providerName] = userExtraInfo
+			}
+		}
+
 		canAccessProvider := false
 
 		if principalID != "" {

--- a/pkg/controllers/management/auth/user_attribute_handler.go
+++ b/pkg/controllers/management/auth/user_attribute_handler.go
@@ -28,6 +28,10 @@ func (ua *UserAttributeController) sync(key string, obj *v3.UserAttribute) (runt
 		return nil, nil
 	}
 
+	if obj.ExtraByProvider == nil {
+		obj.NeedsRefresh = true
+	}
+
 	if !obj.NeedsRefresh {
 		return obj, nil
 	}


### PR DESCRIPTION
In d9ba4df ExtraByProvider was added to UserAttributes and would be
refreshed when a new login token was created. With 4fa4285 the
impersonation code began depending on ExtraByProvider existing in
UserAttributes. However, if the UserAttributes was created before
d9ba4df, it would not have ExtraByProvider unless a new token triggered
adding it, for example by logging out and logging back in. The effect is
that if a Rancher server was created prior to v2.6.2 (prior to d9ba4df)
and then upgraded to v2.6.5 (includes 4fa4285) then users would lose
access to their downstream clusters because the impersonation
clusterrole would be missing the provider extras. This change ensures
that if ExtraByProvider is empty, the refresh is triggered by a
controller instead of waiting for the user to get a new token.

https://github.com/rancher/rancher/issues/37894