### PR TITLE
fix the issue that waitForServiceAccount times out  

### DIFF
--- a/pkg/impersonation/impersonation.go
+++ b/pkg/impersonation/impersonation.go
@@ -351,7 +351,15 @@ func (i *Impersonator) waitForServiceAccount(sa *corev1.ServiceAccount) (*corev1
 		if err != nil {
 			return false, err
 		}
-		if len(ret.Secrets) > 0 {
+		secretName := serviceaccounttoken.ServiceAccountSecretName(sa)
+		secret, err := i.clusterContext.Core.Secrets(ImpersonationNamespace).Get(secretName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if _, found := secret.Data[corev1.ServiceAccountTokenKey]; found {
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/38198 


Problem:
The function waitForServiceAccount checks the length of Secrets on the service account to determine if the service account is ready. 
However, starting from k8s 1.24, there is no service account token secret being auto-generated, so the length is always 0. 
As a result, we see the following error in rancher logs 
```
2022/07/06 03:35:53 [ERROR] error syncing 'p-8mdtt/creator-project-owner': handler cluster-prtb-sync: couldn't ensure service account impersonator: failed to get secret for service account: cattle-impersonation-system/cattle-impersonation-user-4n6jv, error: timed out waiting for the condition, requeuing
2022/07/06 03:35:53 [ERROR] error syncing 'c-q69rl/creator-cluster-owner': handler cluster-crtb-sync: couldn't ensure service account impersonator: failed to get secret for service account: cattle-impersonation-system/cattle-impersonation-user-4n6jv, error: timed out waiting for the condition, requeuing
```


Fix:
instead of checking the length of that specific field, we now check the secret we created for the service account. 
Because we always create the secret, the new logic works regardless of the cluster version. 


Tests:
I run the local build on local cluster versions 1.23 and 1.24 and do not see the mentioned error anymore. 