### PR TITLE
cni_providers_test.go will test all the cni providers with a 3 etcd, …

### DIFF
--- a/tests/framework/extensions/workloads/podstatus.go
+++ b/tests/framework/extensions/workloads/podstatus.go
@@ -1,0 +1,59 @@
+package workloads
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// PodGroupVersion is the required Group Version for accessing pods in a cluster,
+// using the dynamic client.
+var PodGroupVersionResource = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "pods",
+}
+
+// StatusPods is a helper function that uses the dynamic client to list pods on a namespace for a specific cluster with its list options.
+func StatusPods(client *rancher.Client, clusterID string, listOpts metav1.ListOptions) ([]string, []error) {
+	var podList []corev1.Pod
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, []error{err}
+	}
+	podResource := dynamicClient.Resource(PodGroupVersionResource)
+	pods, err := podResource.List(context.TODO(), listOpts)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	for _, unstructuredPod := range pods.Items {
+		newPod := &corev1.Pod{}
+		err := scheme.Scheme.Convert(&unstructuredPod, newPod, unstructuredPod.GroupVersionKind())
+		if err != nil {
+			return nil, []error{err}
+		}
+
+		podList = append(podList, *newPod)
+	}
+
+	var podResults []string
+	var podErrors []error
+	podResults = append(podResults, "pods Status:\n")
+
+	for _, pod := range podList {
+		podStatus := pod.Status.Phase
+		if podStatus == "Succeeded" || podStatus == "Running" {
+			podResults = append(podResults, fmt.Sprintf("INFO: %s: %s\n", pod.Name, podStatus))
+		} else {
+			podErrors = append(podErrors, fmt.Errorf("ERROR: %s: %s", pod.Name, podStatus))
+		}
+	}
+	return podResults, podErrors
+}


### PR DESCRIPTION
### Issue
[RKE2 cluster provisioning with different network providers](https://github.com/rancher/qa-tasks/issues/387)

### Problem

Manually testing provisioning clusters with all CNI providers takes too much time (3+ hours). Even after provisioning there are additional checks to check that workloads are active/running and network checks. We need a way to bring down time used up to do these checks to focus our efforts on other testing as well.

### Solution
A new provisioning test was added in `tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go`
- `ProvisioningRKE2CNICluster()` will provision clusters with every CNI provider as both `Admin` and `Standard` user

A new helper function was created in `tests/framework/extensions/workloads/podstatus.go`
- helper function uses the dynamic client to grab all pods in specified cluster (Cluster ID must be passed into the function) and then confirms that pods are running/succeeded and there are no errors.

### Engineering Testing
**Manual Testing**
Manually provisioned RKE2 clusters with all different network providers as admin user and standard user

**Automated Testing**
Ran Jenkins job and passed results to reviewers offline.