### PR TITLE
Updating csp adapter min version to 1.0.0-rc3

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -55,7 +55,7 @@ ENV CATTLE_SYSTEM_UPGRADE_CONTROLLER_CHART_VERSION 100.0.3+up0.3.2
 # System charts minimal version
 ENV CATTLE_FLEET_MIN_VERSION=100.0.3+up0.3.9
 ENV CATTLE_RANCHER_WEBHOOK_MIN_VERSION=1.0.5+up0.2.6-rc5
-ENV CATTLE_CSP_ADAPTER_MIN_VERSION=1.0.0+up1.0.0-rc2
+ENV CATTLE_CSP_ADAPTER_MIN_VERSION=1.0.0+up1.0.0-rc3
 
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/library && \


### PR DESCRIPTION
Updating the csp adapter min version in line with the latest chart version. Needs to go in about the same time as rancher/charts#1970