### PR TITLE
Remove deprecated blocks and update service_principal in `test_create_ha.py` test

### DIFF
--- a/tests/validation/tests/v3_api/resource/terraform/aks/aks.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/aks/aks.tf
@@ -35,18 +35,8 @@ resource "azurerm_kubernetes_cluster" "default" {
   }
 
   service_principal {
-    client_id     = var.client_id
-    client_secret = var.client_secret
-  }
-
-  role_based_access_control {
-    enabled = true
-  }
-
-  addon_profile {
-    kube_dashboard {
-      enabled = false
-    }
+    client_id     = "id_placeholder"
+    client_secret = "secret_placeholder"
   }
 
   tags = {
@@ -56,4 +46,5 @@ resource "azurerm_kubernetes_cluster" "default" {
 
 output "kube_config" {
   value = azurerm_kubernetes_cluster.default.kube_config_raw
+  sensitive = true
 }

--- a/tests/validation/tests/v3_api/resource/terraform/aks/variables.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/aks/variables.tf
@@ -1,11 +1,11 @@
 variable "kubernetes_version" {
   description = "Azure Kubernetes Cluster K8s version"
-  default = "1.19.6"
+  default = "1.23.5"
 }
 
 variable "location" {
   description = "Azure Kubernetes location (US Central, US East, etc)"
-  default = "Central US"
+  default = "East US 2"
 }
 
 variable "node_count" {
@@ -21,12 +21,6 @@ variable "vm_size" {
 variable "disk_capacity" {
   description = "VM System Volume size"
   default = 30
-}
-variable "client_id" {
-  default = ""
-}
-variable "client_secret" {
-  default = ""
 }
 
 variable "cluster_name" {


### PR DESCRIPTION
## Issue: [test_create_ha.py results in message [Warning]: error b'Error: Unsupported block type... when specifying AKS](https://github.com/rancher/qa-tasks/issues/368)<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> 
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When running the `test_create_ha.py` function in the Python legacy framework, attempting to run the function while specifying an AKS cluster failed. The failure would include the following error:

```
[WARNING]: error: b'\nError: Unsupported block type\n\n  on aks.tf line 42, in resource "azurerm_kubernetes_cluster" "default":\n  42:   role_based_access_control {\n\nBlocks of type "role_based_access_control" are not expected here.\n\nError: Unsupported block type\n\n  on aks.tf line 46, in resource "azurerm_kubernetes_cluster" "default":\n  46:   addon_profile {\n\nBlocks of type "addon_profile" are not expected here.\n'
(1, '', '\nError: Unsupported block type\n\n  on aks.tf line 42, in resource "azurerm_kubernetes_cluster" "default":\n  42:   role_based_access_control {\n\nBlocks of type "role_based_access_control" are not expected here.\n\nError: Unsupported block type\n\n  on aks.tf line 46, in resource "azurerm_kubernetes_cluster" "default":\n  46:   addon_profile {\n\nBlocks of type "addon_profile" are not expected here.\n')
```

This is because earlier this year, Terraform made the following changes:

- The block role_based_access_control has been deprecated in favor of the (optional) property role_based_access_control_enabled and block azure_active_directory_role_based_access_control.
- addon_profile.kube_dashboard is flat out removed since Kube Dashboard is not supported for K8s versions >= 1.19.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The solution is to remove the deprecated blocks that are no longer relevant in the code. Additionally, the `service_principal` block needs to have the `client_id` and `client_secret` stored directly in `aks.tf` instead of `variables.tf` as before. Attempting to keep it as is causes failures when running the function with updated versions of Terraform (I used Terraform version 1.2.3 when testing).