### PR TITLE
Update aws-iam-authenticator to v0.5.9 from Rancher's fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ replace (
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.24.2
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.24.2
 
-	sigs.k8s.io/aws-iam-authenticator => github.com/rancher/aws-iam-authenticator v0.5.8-0.20220627182452-0c10ccba0af4
+	sigs.k8s.io/aws-iam-authenticator => github.com/rancher/aws-iam-authenticator v0.5.9-0.20220713170329-78acb8c83863
 	sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.0-beta.0
 )
 
@@ -160,7 +160,7 @@ require (
 	k8s.io/kubectl v0.24.2
 	k8s.io/kubernetes v1.21.0
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
-	sigs.k8s.io/aws-iam-authenticator v0.5.1
+	sigs.k8s.io/aws-iam-authenticator v0.5.9
 	sigs.k8s.io/cluster-api v1.2.0-beta.0
 	sigs.k8s.io/controller-runtime v0.12.1
 	sigs.k8s.io/yaml v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1311,8 +1311,8 @@ github.com/rancher/apiserver v0.0.0-20201023000256-1a0a904f9197/go.mod h1:8W0Ewa
 github.com/rancher/apiserver v0.0.0-20210922180056-297b6df8d714/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
 github.com/rancher/apiserver v0.0.0-20220610164457-643f1d19e3fc h1:HI7akTmd5SBNbupaalwYWbkz7vSUKgpazrnL42oi+aA=
 github.com/rancher/apiserver v0.0.0-20220610164457-643f1d19e3fc/go.mod h1:sG6OmZ4yEWeQ9JmGjnp8WgQAk9D9z4hivMFsUUh9QF8=
-github.com/rancher/aws-iam-authenticator v0.5.8-0.20220627182452-0c10ccba0af4 h1:Uzx1tTkJzTlg2f8XVkJ3SK3J42Z7dO/ol9xnh3A/FrA=
-github.com/rancher/aws-iam-authenticator v0.5.8-0.20220627182452-0c10ccba0af4/go.mod h1:6dId2LCc8oHqeBzP6E8ndp4DflhKTxYLb5ZXwI4YmFA=
+github.com/rancher/aws-iam-authenticator v0.5.9-0.20220713170329-78acb8c83863 h1:7cVEMgwyiVhLyu/Ywuw58mkkh9cWpFE3+X8IrWncBxU=
+github.com/rancher/aws-iam-authenticator v0.5.9-0.20220713170329-78acb8c83863/go.mod h1:6dId2LCc8oHqeBzP6E8ndp4DflhKTxYLb5ZXwI4YmFA=
 github.com/rancher/channelserver v0.5.1-0.20220405170618-28c9b37deff1 h1:NMYQzCtLEEaJZ2xleLzDixN6Y+yO9ShzgsjHDg4zOrk=
 github.com/rancher/channelserver v0.5.1-0.20220405170618-28c9b37deff1/go.mod h1:dZ4saGTw1S0RwX8ivPijBIR+2obRpfFuO2NkDHUKKXg=
 github.com/rancher/client-go v1.24.0-rancher1 h1:3Hr+QgZRbTo3RF8evVwGd8hn2ZFO6UMUMnRth2CbJcI=


### PR DESCRIPTION
Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>