### PR TITLE
add wait to createSecretForServiceAccount

### DIFF
--- a/pkg/agent/cluster/cluster.go
+++ b/pkg/agent/cluster/cluster.go
@@ -8,13 +8,11 @@ import (
 	"os"
 	"path"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/serviceaccounttoken"
 	"github.com/rancher/wrangler/pkg/kubeconfig"
-	"github.com/sirupsen/logrus"
 	coreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -79,18 +77,6 @@ func getTokenFromAPI() ([]byte, []byte, error) {
 	secret, err := serviceaccounttoken.CreateSecretForServiceAccount(context.Background(), k8s, sa)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create secret for service account %s/%s: %w", namespace.System, "cattle", err)
-	}
-	for {
-		if tokenBytes, ok := secret.Data[coreV1.ServiceAccountTokenKey]; !ok || len(tokenBytes) == 0 {
-			logrus.Infof("Waiting for service account token key to be populated for secret %s/%s", secret.Namespace, secret.Name)
-			time.Sleep(2 * time.Second)
-			secret, err = serviceaccounttoken.CreateSecretForServiceAccount(context.Background(), k8s, sa)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to create secret for service account %s/%s: %w", namespace.System, "cattle", err)
-			}
-		} else {
-			break
-		}
 	}
 	return []byte(cm.Data["ca.crt"]), []byte(secret.Data[coreV1.ServiceAccountTokenKey]), nil
 }

--- a/pkg/api/norman/customization/monitor/handler_utils.go
+++ b/pkg/api/norman/customization/monitor/handler_utils.go
@@ -6,16 +6,16 @@ import (
 	"strings"
 	"time"
 
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/serviceaccounttoken"
-
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/managementagent/workload"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/ref"
+	"github.com/rancher/rancher/pkg/serviceaccounttoken"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -192,7 +192,7 @@ func getAuthToken(userContext *config.UserContext, appName, namespace string) (s
 		return "", fmt.Errorf("get secret from service account %s:%s for monitor failed: %v", namespace, appName, err)
 	}
 
-	return string(secret.Data["token"]), nil
+	return string(secret.Data[v1.ServiceAccountTokenKey]), nil
 }
 
 func parseMetricParams(userContext *config.UserContext, nodeLister v3.NodeLister, resourceType, clusterName, projectName string, metricParams map[string]string) (map[string]string, error) {

--- a/pkg/tunnelserver/peermanager.go
+++ b/pkg/tunnelserver/peermanager.go
@@ -81,8 +81,7 @@ func getTokenFromToken(ctx context.Context, tokenBytes []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	return secret.Data["token"], nil
+	return secret.Data[v1.ServiceAccountTokenKey], nil
 }
 
 func startPeerManager(ctx context.Context, endpoints corecontrollers.EndpointsController, server *remotedialer.Server) (peermanager.PeerManager, error) {


### PR DESCRIPTION
**Problem**
Peermanager in HA uses token from service account secret on startup. It doesn't error out or complain if the token is empty and uses it as is here https://github.com/rancher/rancher/blob/release/v2.6/pkg/tunnelserver/peermanager.go#L113. This results into cluster not found errors because we cannot find the cluster by token for tunnel authentication. 

```
2022/07/06 03:38:02 [ERROR] error syncing '_all_': handler user-controllers-controller: failed to start user controllers for cluster c-m-mfhzj6w6: ClusterUnavailable 503: cluster not found, requeuing
2022/07/06 03:39:20 [ERROR] Failed to handle tunnel request from remote address 10.42.1.4:34690 (X-Forwarded-For: 18.224.63.142): response 401: failed authentication
```

**Solution**
Adding wait to not return secret until token exists in data. All calls to create should wait for token to be populated now. 

**Issue**
https://github.com/rancher/rancher/issues/38199
https://github.com/rancher/rancher/issues/38247
https://github.com/rancher/rancher/issues/38222