### PR TITLE
Update k3s hardened install to be in line with docs

### DIFF
--- a/tests/validation/tests/v3_api/resource/terraform/k3s/master/audit.yaml
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/master/audit.yaml
@@ -1,0 +1,4 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: Metadata

--- a/tests/validation/tests/v3_api/resource/terraform/k3s/master/cis_masterconfig.yaml
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/master/cis_masterconfig.yaml
@@ -1,6 +1,7 @@
 secrets-encryption: true
 kube-apiserver-arg:
-  - 'audit-log-path=/var/lib/rancher/k3s/server/logs/audit-log'
+  - 'audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log'
+  - 'audit-policy-file=/var/lib/rancher/k3s/server/audit.yaml'
   - 'audit-log-maxage=30'
   - 'audit-log-maxbackup=10'
   - 'audit-log-maxsize=100'

--- a/tests/validation/tests/v3_api/resource/terraform/k3s/master/install_k3s_master.sh
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/master/install_k3s_master.sh
@@ -25,10 +25,12 @@ then
   echo -e "vm.overcommit_memory=1" >>/etc/sysctl.d/90-kubelet.conf
   echo -e "kernel.panic=10" >>/etc/sysctl.d/90-kubelet.conf
   echo -e "kernel.panic_on_oops=1" >>/etc/sysctl.d/90-kubelet.conf
+  echo -e "kernel.keys.root_maxbytes=25000000" >>/etc/sysctl.d/90-kubelet.conf
   sysctl -p /etc/sysctl.d/90-kubelet.conf
   systemctl restart systemd-sysctl
   mkdir -p /var/lib/rancher/k3s/server/manifests
   cat /tmp/policy.yaml > /var/lib/rancher/k3s/server/manifests/policy.yaml
+  cat /tmp/audit.yaml > /var/lib/rancher/k3s/server/audit.yaml
 
   if [[ "${4}" == *"v1.18"* ]] || [[ "${4}" == *"v1.19"* ]] || [[ "${4}" == *"v1.20"* ]]
   then

--- a/tests/validation/tests/v3_api/resource/terraform/k3s/master/instances_server.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/master/instances_server.tf
@@ -92,6 +92,11 @@ resource "aws_instance" "master" {
   }
 
   provisioner "file" {
+    source = "audit.yaml"
+    destination = "/tmp/audit.yaml"
+  }
+
+  provisioner "file" {
     source = "v120ingresspolicy.yaml"
     destination = "/tmp/v120ingresspolicy.yaml"
   }
@@ -183,6 +188,10 @@ resource "aws_instance" "master2-ha" {
   provisioner "file" {
     source = "policy.yaml"
     destination = "/tmp/policy.yaml"
+  }
+  provisioner "file" {
+    source = "audit.yaml"
+    destination = "/tmp/audit.yaml"
   }
 
   provisioner "file" {

--- a/tests/validation/tests/v3_api/resource/terraform/k3s/master/join_k3s_master.sh
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/master/join_k3s_master.sh
@@ -24,10 +24,12 @@ then
   echo -e "vm.overcommit_memory=1" >>/etc/sysctl.d/90-kubelet.conf
   echo -e "kernel.panic=10" >>/etc/sysctl.d/90-kubelet.conf
   echo -e "kernel.panic_on_oops=1" >>/etc/sysctl.d/90-kubelet.conf
+  echo -e "kernel.keys.root_maxbytes=25000000" >>/etc/sysctl.d/90-kubelet.conf
   sysctl -p /etc/sysctl.d/90-kubelet.conf
   systemctl restart systemd-sysctl
   mkdir -p /var/lib/rancher/k3s/server/manifests
   cat /tmp/policy.yaml > /var/lib/rancher/k3s/server/manifests/policy.yaml
+  cat /tmp/audit.yaml > /var/lib/rancher/k3s/server/audit.yaml
   if [[ "${4}" == *"v1.18"* ]] || [[ "${4}" == *"v1.19"* ]] || [[ "${4}" == *"v1.20"* ]]
   then
     cat /tmp/v120ingresspolicy.yaml > /var/lib/rancher/k3s/server/manifests/v120ingresspolicy.yaml

--- a/tests/validation/tests/v3_api/resource/terraform/k3s/master/policy.yaml
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/master/policy.yaml
@@ -19,7 +19,7 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: cis1.5-compliant-psp
+  name: restricted-psp
 spec:
   privileged: false
   allowPrivilegeEscalation: false
@@ -31,7 +31,9 @@ spec:
     - 'projected'
     - 'secret'
     - 'downwardAPI'
+    - 'csi'
     - 'persistentVolumeClaim'
+    - 'ephemeral'
   hostNetwork: false
   hostIPC: false
   hostPID: false
@@ -54,7 +56,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: psp:restricted
+  name: psp:restricted-psp
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 rules:
@@ -62,18 +64,18 @@ rules:
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
-  - cis1.5-compliant-psp
+  - restricted-psp
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: default:restricted
+  name: default:restricted-psp
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: psp:restricted
+  name: psp:restricted-psp
 subjects:
 - kind: Group
   name: system:authenticated
@@ -194,7 +196,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: svclb-traefik
+      svccontroller.k3s.cattle.io/svcname: traefik
   ingress:
   - {}
   policyTypes:

--- a/tests/validation/tests/v3_api/resource/terraform/k3s/worker/join_k3s_agent.sh
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/worker/join_k3s_agent.sh
@@ -20,6 +20,7 @@ then
   echo -e "vm.overcommit_memory=1" >>/etc/sysctl.d/90-kubelet.conf
   echo -e "kernel.panic=10" >>/etc/sysctl.d/90-kubelet.conf
   echo -e "kernel.panic_on_oops=1" >>/etc/sysctl.d/90-kubelet.conf
+  echo -e "kernel.keys.root_maxbytes=25000000" >>/etc/sysctl.d/90-kubelet.conf
   sysctl -p /etc/sysctl.d/90-kubelet.conf
   systemctl restart systemd-sysctl
 fi


### PR DESCRIPTION
## Issue
N/A
 
## Problem
Automation for K3s hardened installs did not include audit policy. Also, a recent change to the k3s codebase changed the label for required network policies, so it needs to be updated to allow svclb to work in hardened environments.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
- Update the network policy applied to k3s in automated tests
- Include audit policy file and args required for the check
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
I've run this in my local environment to ensure the test runs and works as expected