### PR TITLE
Replace all invalid characters for v2prov snapshots with -

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/plansecret/plansecret.go
+++ b/pkg/controllers/provisioningv2/rke2/plansecret/plansecret.go
@@ -294,14 +294,14 @@ func generateEtcdSnapshotFromListOutput(input string) (*snapshot, error) {
 	switch len(snapshotData) {
 	case 3:
 		return &snapshot{
-			Name:    snapshotData[0],
+			Name:    sb.InvalidKeyChars.ReplaceAllString(snapshotData[0], "-"),
 			Size:    snapshotData[1],
 			Created: snapshotData[2],
 			S3:      true,
 		}, nil
 	case 4:
 		return &snapshot{
-			Name:     snapshotData[0],
+			Name:     sb.InvalidKeyChars.ReplaceAllString(snapshotData[0], "-"),
 			Location: snapshotData[1],
 			Size:     snapshotData[2],
 			Created:  snapshotData[3],


### PR DESCRIPTION
## Issue:

https://github.com/rancher/rancher/issues/38304
 
## Problem
When using S3 snapshots with RKE2/K3s downstream clusters, it is possible to have S3 objects that have "invalid" snapshot file names. This PR makes a change to the various snapshot handling controllers to allow Rancher to properly handle invalid characters in snapshot file names, and not stall out processing if there are snapshot files that are completely invalid.

## Solution

 
## Testing
Create a v2prov cluster with S3-backed snapshots, and create an object in the bucket/folder with an invalid name, like `cluster-name-c-xx-rs-cwn4m_2022-03-24T20:07:42Z.zip`.

For a freshly provisioned K3s/RKE2 cluster, make sure you "snapshot now" to force K3s/RKE2 to create the corresponding `etcd-snapshots` configmap to backpopulate snapshot data. Once this is done, observe the snapshots that get created and observe that the bad-file-name snapshot gets created.

## Engineering Testing
### Manual Testing
I tested this with a bad snapshot object name.

### Automated Testing
None.

## QA Testing Considerations
None.

### Regressions Considerations
We need to make sure snapshot backpopulate still functions correctly.