### PR TITLE
Adds decompression and error handling to the audit logger.

### DIFF
--- a/pkg/auth/audit/logwriter.go
+++ b/pkg/auth/audit/logwriter.go
@@ -7,7 +7,7 @@ import (
 )
 
 type LogWriter struct {
-	Level  int
+	Level  Level
 	Output *lumberjack.Logger
 }
 
@@ -21,8 +21,8 @@ func (l *LogWriter) Start(ctx context.Context) {
 	}()
 }
 
-func NewLogWriter(path string, level, maxAge, maxBackup, maxSize int) *LogWriter {
-	if path == "" || level == levelNull {
+func NewLogWriter(path string, level Level, maxAge, maxBackup, maxSize int) *LogWriter {
+	if path == "" || level == LevelNull {
 		return nil
 	}
 

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -197,7 +197,7 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		return nil, err
 	}
 
-	auditLogWriter := audit.NewLogWriter(opts.AuditLogPath, opts.AuditLevel, opts.AuditLogMaxage, opts.AuditLogMaxbackup, opts.AuditLogMaxsize)
+	auditLogWriter := audit.NewLogWriter(opts.AuditLogPath, audit.Level(opts.AuditLevel), opts.AuditLogMaxage, opts.AuditLogMaxbackup, opts.AuditLogMaxsize)
 	auditFilter, err := audit.NewAuditLogMiddleware(auditLogWriter)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Issue: #38323
 
## Problem
The audit logger silently fails when attempting to marshal gzip data to JSON.
 
## Solution
The audit logger should decode encoded response messages and log errors to Rancher.
