### PR TITLE
Move credential secret warnings to debug

### DIFF
--- a/pkg/controllers/management/secretmigrator/clusters.go
+++ b/pkg/controllers/management/secretmigrator/clusters.go
@@ -858,9 +858,9 @@ func (m *Migrator) createOrUpdateSecret(secretName, secretNamespace string, data
 func (m *Migrator) createOrUpdateSecretForCredential(secretName, secretNamespace, secretValue string, annotations map[string]string, owner runtime.Object, kind, field string) (*corev1.Secret, error) {
 	if secretValue == "" {
 		if secretName == "" {
-			logrus.Warnf("Secret name is empty")
+			logrus.Debugf("Secret name is empty")
 		}
-		logrus.Warnf("Refusing to create empty secret [%s]/[%s]", secretNamespace, secretName)
+		logrus.Debugf("Refusing to create empty secret [%s]/[%s]", secretNamespace, secretName)
 		return nil, nil
 	}
 	data := map[string]string{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->https://github.com/rancher/rancher/issues/38313
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

These log messages were appearing very often and will repeat until the service account token is populated for all cluster types.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Moved the log messages to debug.