### PR TITLE
Add --etcd-s3=false when restoring a local snapshot and make snapshot CRD names lower case

### DIFF
--- a/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
+++ b/pkg/controllers/managementuser/snapshotbackpopulate/snapshotbackpopulate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
@@ -329,7 +330,7 @@ func (h *handler) configMapToSnapshots(configMap *corev1.ConfigMap, cluster *pro
 				snapshot.Labels[rke2.MachineIDLabel] = machine.Labels[rke2.MachineIDLabel]
 			}
 		}
-		snapshot.Name = name.SafeConcatName(cluster.Name, InvalidKeyChars.ReplaceAllString(snapshot.SnapshotFile.Name, "-"), fileSuffix)
+		snapshot.Name = name.SafeConcatName(cluster.Name, strings.ToLower(InvalidKeyChars.ReplaceAllString(snapshot.SnapshotFile.Name, "-")), fileSuffix)
 		result[snapshot.SnapshotFile.Name+fileSuffix] = snapshot
 	}
 	return result

--- a/pkg/controllers/provisioningv2/rke2/plansecret/plansecret.go
+++ b/pkg/controllers/provisioningv2/rke2/plansecret/plansecret.go
@@ -294,14 +294,14 @@ func generateEtcdSnapshotFromListOutput(input string) (*snapshot, error) {
 	switch len(snapshotData) {
 	case 3:
 		return &snapshot{
-			Name:    sb.InvalidKeyChars.ReplaceAllString(snapshotData[0], "-"),
+			Name:    strings.ToLower(sb.InvalidKeyChars.ReplaceAllString(snapshotData[0], "-")),
 			Size:    snapshotData[1],
 			Created: snapshotData[2],
 			S3:      true,
 		}, nil
 	case 4:
 		return &snapshot{
-			Name:     sb.InvalidKeyChars.ReplaceAllString(snapshotData[0], "-"),
+			Name:     strings.ToLower(sb.InvalidKeyChars.ReplaceAllString(snapshotData[0], "-")),
 			Location: snapshotData[1],
 			Size:     snapshotData[2],
 			Created:  snapshotData[3],

--- a/pkg/provisioningv2/rke2/planner/etcdrestore.go
+++ b/pkg/provisioningv2/rke2/planner/etcdrestore.go
@@ -81,7 +81,7 @@ func (p *Planner) generateEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControl
 	}
 
 	if snapshot.SnapshotFile.S3 == nil {
-		args = append(args, fmt.Sprintf("--cluster-reset-restore-path=db/snapshots/%s", snapshot.SnapshotFile.Name))
+		args = append(args, fmt.Sprintf("--cluster-reset-restore-path=db/snapshots/%s", snapshot.SnapshotFile.Name), "--etcd-s3=false")
 	} else {
 		args = append(args, fmt.Sprintf("--cluster-reset-restore-path=%s", snapshot.SnapshotFile.Name))
 	}


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/38304
https://github.com/rancher/rancher/issues/38338
 
## Problem
When restoring an etcd snapshot that is local on a cluster that is S3 enabled, the config mile argument for `--etcd-s3` overrides the snapshot path and causes an issue when doing the restore.

Also, if a snapshot file name had capital letters in it, it was not usable as a snapshot CR name.

## Solution
When performing a local snapshot restore, set `--etcd-s3=false`
Convert snapshot names to lower case
 
## Testing
Perform a snapshot restore from a snapshot that exists locally, on a cluster that is S3 enabled.

## Engineering Testing
### Manual Testing
Tested a local snapshot restore on an S3 enabled cluster. 

### Automated Testing
N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
We should ensure etcd restore continues to work across both S3 and non-S3 clusters for v2prov.