### PR TITLE
Add ui-performance setting to toggle performance settings in the UI

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -91,6 +91,7 @@ var (
 	UIDashboardIndex                    = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/latest/index.html")
 	UIDashboardPath                     = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
 	UIFavicon                           = NewSetting("ui-favicon", "")
+	UIPerformance                       = NewSetting("ui-performance", "")
 	UIPreferred                         = NewSetting("ui-preferred", "vue")
 	UIOfflinePreferred                  = NewSetting("ui-offline-preferred", "dynamic")
 	UIIssues                            = NewSetting("ui-issues", "")

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -91,7 +91,7 @@ var (
 	UIDashboardIndex                    = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/latest/index.html")
 	UIDashboardPath                     = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
 	UIFavicon                           = NewSetting("ui-favicon", "")
-	UIPerformance                       = NewSetting("ui-performance", "")
+	UIPerformance                       = NewSetting("ui-performance", "") // Experimental settings for UI functionality to improve the UX with large nunbers of resources
 	UIPreferred                         = NewSetting("ui-preferred", "vue")
 	UIOfflinePreferred                  = NewSetting("ui-offline-preferred", "dynamic")
 	UIIssues                            = NewSetting("ui-issues", "")


### PR DESCRIPTION
This PR adds a new `ui-performance` setting.

This is required by the frontend to be able to store settings that will enable/configuration new settings in the UI that will allow users to customise certain behaviours in the UI, typically when there are large amounts of resources.
