### PR TITLE
Update the Go toolchain version for the Windows Drone pipelines

### DIFF
--- a/Dockerfile-windows-1809.dapper
+++ b/Dockerfile-windows-1809.dapper
@@ -1,4 +1,4 @@
-FROM rancher/golang:1.14-windowsservercore-1809
+FROM rancher/golang:1.16-windowsservercore-1809
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG DAPPER_HOST_ARCH

--- a/Dockerfile-windows-2004.dapper
+++ b/Dockerfile-windows-2004.dapper
@@ -1,4 +1,4 @@
-FROM rancher/golang:1.14-windowsservercore-2004
+FROM rancher/golang:1.16-windowsservercore-2004
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG DAPPER_HOST_ARCH


### PR DESCRIPTION
default-windows-1809 and 2004 pipelines in Drone use the Go 1.14 version of the toolchain, and we have a 3rd-party package used in release/v2.5 that uses code from the stdlib of Go 1.16. The build fails because Go 1.14 fails to compile that package.
https://drone-pr.rancher.io/rancher/rancher/23039/3/2