### PR TITLE
List 2.6 as stable/latest in README

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -23,11 +23,11 @@ jobs:
        latest25=$(yq  '.entries.rancher[].appVersion | select(test("^v2.5") and select(. != "*-rc*"))' 'latest.index.yaml' | head -1)
        stable25=$(yq  '.entries.rancher[].appVersion | select(test("^v2.5") and select(. != "*-rc*"))' 'stable.index.yaml' | head -1)
        echo "* v2.6" > $tmpfile
-       echo "  * Latest - ${latest26} - `rancher/rancher:latest` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/${latest26})." >> $tmpfile
-       echo "  * Stable - ${stable26} - `rancher/rancher:stable` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/${stable26})." >> $tmpfile
+       echo "  * Latest - ${latest26} - \`rancher/rancher:${latest26}\` / \`rancher/rancher:latest\` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/${latest26})." >> $tmpfile
+       echo "  * Stable - ${stable26} - \`rancher/rancher:${stable26}\` / \`rancher/rancher:stable\` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/${stable26})." >> $tmpfile
        echo "* v2.5" >> $tmpfile
-       echo "  * Latest - ${latest25} - `rancher/rancher:latest` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/${latest25})." >> $tmpfile
-       echo "  * Stable - ${stable25} - `rancher/rancher:stable` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/${stable25})." >> $tmpfile
+       echo "  * Latest - ${latest25} - \`rancher/rancher:${latest25}\` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/${latest25})." >> $tmpfile
+       echo "  * Stable - ${stable25} - \`rancher/rancher:${stable25}\` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/${stable25})." >> $tmpfile
        sed -e '/## Latest Release/r '"$tmpfile"'' -e 's/CURRENTYEAR/'"$(date +%Y)"'/g' README-template.md > README.md
     - name: Check for repository changes
       run: |


### PR DESCRIPTION
[Previous auto created PR](https://github.com/rancher/rancher/pull/38415/files) did not render correctly for backticks and had tags for 2.5 listed which only applies to 2.6