### PR TITLE
Expose rancher version endpoint

### DIFF
--- a/pkg/multiclustermanager/routes.go
+++ b/pkg/multiclustermanager/routes.go
@@ -33,6 +33,7 @@ import (
 	"github.com/rancher/rancher/pkg/telemetry"
 	"github.com/rancher/rancher/pkg/tunnelserver/mcmauthorizer"
 	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/rancher/rancher/pkg/version"
 	"github.com/rancher/steve/pkg/auth"
 )
 
@@ -85,6 +86,7 @@ func router(ctx context.Context, localClusterEnabled bool, tunnelAuthorizer *mcm
 	unauthed.Handle("/v3/settings/ui-pl", managementAPI).MatcherFunc(onlyGet)
 	unauthed.Handle("/v3/settings/ui-brand", managementAPI).MatcherFunc(onlyGet)
 	unauthed.Handle("/v3/settings/ui-default-landing", managementAPI).MatcherFunc(onlyGet)
+	unauthed.Handle("/rancherversion", version.NewVersionHandler())
 	unauthed.PathPrefix("/v1-{prefix}-release/channel").Handler(channelserver)
 	unauthed.PathPrefix("/v1-{prefix}-release/release").Handler(channelserver)
 	unauthed.PathPrefix("/v1-saml").Handler(saml.AuthHandler())

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,12 +1,54 @@
+// Package version gathers version data from variables set at build time and runtime
+// and provides access points to retrieve them.
 package version
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+)
 
 var (
 	Version   = "dev"
 	GitCommit = "HEAD"
 )
 
+const primeEnv = "RANCHER_PRIME"
+
+// Info encapsulates version metadata.
+type Info struct {
+	Version      string
+	GitCommit    string
+	RancherPrime string
+}
+
+// FriendlyVersion returns a human-readable string that can be included in log output.
 func FriendlyVersion() string {
 	return fmt.Sprintf("%s (%s)", Version, GitCommit)
+}
+
+type versionHandler struct {
+	info Info
+}
+
+// NewVersionHandler checks the runtime environment for the RANCHER_PRIME environment variable
+// and uses that along with build-time version information to create an HTTP handler.
+func NewVersionHandler() http.Handler {
+	var rancherPrime = "false"
+	if isPrime, ok := os.LookupEnv(primeEnv); ok && isPrime == "true" {
+		rancherPrime = "true"
+	}
+	return &versionHandler{info: Info{Version, GitCommit, rancherPrime}}
+}
+
+// ServeHTTP handles GET requests for version information.
+func (h *versionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	body, err := json.Marshal(h.info)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	rw.Write(body)
+	rw.WriteHeader(http.StatusOK)
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,55 @@
+package version
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionServeHTTP(t *testing.T) {
+	tests := []struct {
+		name     string
+		setPrime func()
+		cleanup  func()
+		want     string
+	}{
+		{
+			name:     "unmodified",
+			setPrime: func() {},
+			cleanup:  func() {},
+			want:     `{"Version":"dev","GitCommit":"HEAD","RancherPrime":"false"}`,
+		},
+		{
+			name:     "prime=true",
+			setPrime: func() { os.Setenv("RANCHER_PRIME", "true") },
+			cleanup:  func() { os.Unsetenv("RANCHER_PRIME") },
+			want:     `{"Version":"dev","GitCommit":"HEAD","RancherPrime":"true"}`,
+		},
+		{
+			name:     "prime=false",
+			setPrime: func() { os.Setenv("RANCHER_PRIME", "false") },
+			cleanup:  func() { os.Unsetenv("RANCHER_PRIME") },
+			want:     `{"Version":"dev","GitCommit":"HEAD","RancherPrime":"false"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setPrime()
+			defer tt.cleanup()
+			req := httptest.NewRequest(http.MethodGet, "/rancherversion", nil)
+			rr := httptest.NewRecorder()
+			handler := NewVersionHandler()
+			handler.ServeHTTP(rr, req)
+			assert.Equal(t, http.StatusOK, rr.Code)
+			resp := rr.Result()
+			body, err := io.ReadAll(resp.Body)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.want, string(body))
+		})
+	}
+}


### PR DESCRIPTION
Expose the rancher version as an unauthenticated endpoint on
/rancherversion. This now includes a flag indicating whether the build
version is Rancher "plus" or not. The version and "plus" indicator is
set at build time and cannot be overridden by an environment variable at
run time. The endpoint is /rancherversion instead of /version because
the /version endpoint is just passed through to kubernetes and gives the
local cluster kubernetes version. The endpoint is unauthenticated rather
than authenticated because the k8s /version is already exposed[1] as
well as the /v1-{k3s,rke2}-release/* endpoints, so security through
obscurity doesn't buy us much here.

[1] https://github.com/kubernetes/kubernetes/issues/84040

https://github.com/rancher/rancher/issues/38554