### PR TITLE
Changes setting name for kubeconfig TTL.

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -144,7 +144,7 @@ var (
 
 	// KubeconfigDefaultTokenTTLMinutes is the default time to live applied to kubeconfigs created for users.
 	// This setting will take effect regardless of the kubeconfig-generate-token status.
-	KubeconfigDefaultTokenTTLMinutes = NewSetting("kubeconfig-default-ttl-minutes", "0") // 0 TTL = never expire
+	KubeconfigDefaultTokenTTLMinutes = NewSetting("kubeconfig-default-token-ttl-minutes", "0") // 0 TTL = never expire
 
 	// KubeconfigGenerateToken determines whether the UI will return a generate token with kubeconfigs.
 	// If set to false the kubeconfig will contain a command to login to Rancher.


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/38456
 
## Problem
The setting name was misleading
 
## Solution
Update the name.
 
## Testing
Verify endpoints are available for the new name.