### PR TITLE
[2.7] Add post and pre upgrade resource validation tests

### DIFF
--- a/tests/framework/extensions/ingresses/ingresses.go
+++ b/tests/framework/extensions/ingresses/ingresses.go
@@ -1,0 +1,21 @@
+package ingresses
+
+import (
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/charts"
+)
+
+const (
+	IngressSteveType = "networking.k8s.io.ingress"
+)
+
+// AccessIngressExternally checks if the ingress is accessible externally,
+// it returns true if the ingress is accessible, false if it is not, and an error if there is an error.
+func AccessIngressExternally(client *rancher.Client, hostname string, isWithTLS bool) (bool, error) {
+	result, err := charts.GetChartCaseEndpoint(client, hostname, "", isWithTLS)
+	if err != nil {
+		return false, err
+	}
+
+	return result.Ok, err
+}

--- a/tests/framework/extensions/ingresses/template.go
+++ b/tests/framework/extensions/ingresses/template.go
@@ -1,0 +1,28 @@
+package ingresses
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewIngressTemplate is a constructor that creates the ingress template for ingresses
+func NewIngressTemplate(ingressName, namespaceName string, hostName string, paths []networkingv1.HTTPIngressPath) networkingv1.Ingress {
+	return networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ingressName,
+			Namespace: namespaceName,
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: hostName,
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: paths,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/tests/framework/extensions/kubeapi/workloads/daemonsets/create.go
+++ b/tests/framework/extensions/kubeapi/workloads/daemonsets/create.go
@@ -10,16 +10,7 @@ import (
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
-
-// DaemonSetGroupVersionResource is the required Group Version Resource for accessing daemon sets in a cluster,
-// using the dynamic client.
-var DaemonSetGroupVersionResource = schema.GroupVersionResource{
-	Group:    "apps",
-	Version:  "v1",
-	Resource: "daemonsets",
-}
 
 // CreateDaemonSet is a helper function that uses the dynamic client to create a daemon set on a namespace for a specific cluster.
 func CreateDaemonSet(client *rancher.Client, clusterName, daemonSetName, namespace string, template corev1.PodTemplateSpec) (*appv1.DaemonSet, error) {

--- a/tests/framework/extensions/kubeapi/workloads/daemonsets/daemonsets.go
+++ b/tests/framework/extensions/kubeapi/workloads/daemonsets/daemonsets.go
@@ -1,0 +1,41 @@
+package daemonsets
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	appv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// DaemonSetGroupVersionResource is the required Group Version Resource for accessing daemon sets in a cluster,
+// using the dynamic client.
+var DaemonSetGroupVersionResource = schema.GroupVersionResource{
+	Group:    "apps",
+	Version:  "v1",
+	Resource: "daemonsets",
+}
+
+// GetDaemonsetByName is a helper function that uses the dynamic client to get a specific daemonset on a namespace for a specific cluster.
+func GetDaemonsetByName(client *rancher.Client, clusterID, namespace, daemonsetName string) (*appv1.DaemonSet, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	daemonsetResource := dynamicClient.Resource(DaemonSetGroupVersionResource).Namespace(namespace)
+	unstructuredResp, err := daemonsetResource.Get(context.TODO(), daemonsetName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	newDaemonset := &appv1.DaemonSet{}
+	err = scheme.Scheme.Convert(unstructuredResp, newDaemonset, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	return newDaemonset, nil
+}

--- a/tests/framework/extensions/kubeapi/workloads/template.go
+++ b/tests/framework/extensions/kubeapi/workloads/template.go
@@ -11,16 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NewContainer is a contructor that creates a container for a pod template i.e. corev1.PodTemplateSpec
-func NewContainer(containerName, image string, imagePullPolicy corev1.PullPolicy, volumeMounts []corev1.VolumeMount) corev1.Container {
-	return corev1.Container{
-		Name:            containerName,
-		Image:           image,
-		ImagePullPolicy: imagePullPolicy,
-		VolumeMounts:    volumeMounts,
-	}
-}
-
 // NewImagePullSecret is a contructor that creates an image pull secret for a pod template i.e. corev1.PodTemplateSpec
 func NewImagePullSecret(client *rancher.Client, clusterName, namespace string) (*corev1.LocalObjectReference, error) {
 	k8sClient, err := client.GetDownStreamClusterClient(clusterName)
@@ -50,16 +40,4 @@ func NewImagePullSecret(client *rancher.Client, clusterName, namespace string) (
 	return &corev1.LocalObjectReference{
 		Name: newSecret.Name,
 	}, nil
-}
-
-// NewTemplate is a constructor that creates the pod template for all types of workloads e.g. cronjobs, daemonsets, deployments, and batch jobs
-func NewTemplate(containers []corev1.Container, imagePullSecret *corev1.LocalObjectReference) corev1.PodTemplateSpec {
-	return corev1.PodTemplateSpec{
-		Spec: corev1.PodSpec{
-			Containers: containers,
-			ImagePullSecrets: []corev1.LocalObjectReference{
-				*imagePullSecret,
-			},
-		},
-	}
 }

--- a/tests/framework/extensions/secrets/template.go
+++ b/tests/framework/extensions/secrets/template.go
@@ -1,0 +1,17 @@
+package secrets
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewSecretTemplate is a constructor that creates the secret template for secrets
+func NewSecretTemplate(secretName, namespaceName string, data map[string][]byte) corev1.Secret {
+	return corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespaceName,
+		},
+		Data: data,
+	}
+}

--- a/tests/framework/extensions/services/template.go
+++ b/tests/framework/extensions/services/template.go
@@ -1,0 +1,21 @@
+package services
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewServiceTemplate is a constructor that creates the service template for services
+func NewServiceTemplate(serviceName, namespaceName string, serviceType corev1.ServiceType, ports []corev1.ServicePort, selector map[string]string) corev1.Service {
+	return corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: namespaceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     serviceType,
+			Ports:    ports,
+			Selector: selector,
+		},
+	}
+}

--- a/tests/framework/extensions/workloads/daemonsets/daemonsets.go
+++ b/tests/framework/extensions/workloads/daemonsets/daemonsets.go
@@ -1,0 +1,48 @@
+package daemonsets
+
+import (
+	"fmt"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateDaemonset is a helper function that uses the v1 steve client to create a daemonset on a namespace for a specific cluster.
+func CreateDaemonset(client *rancher.Client, clusterID, daemonsetName, namespace string, template corev1.PodTemplateSpec) (*v1.SteveAPIObject, error) {
+	steveclient, err := client.Steve.ProxyDownstream(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := map[string]string{}
+	labels["workload.user.cattle.io/workloadselector"] = fmt.Sprintf("apps.daemonset-%v-%v", namespace, daemonsetName)
+
+	template.ObjectMeta = metav1.ObjectMeta{
+		Labels: labels,
+	}
+
+	template.Spec.RestartPolicy = corev1.RestartPolicyAlways
+	daemonset := &appv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      daemonsetName,
+			Namespace: namespace,
+		},
+		Spec: appv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: template,
+		},
+	}
+
+	daemonsetResp, err := steveclient.SteveType(workloads.DaemonsetSteveType).Create(daemonset)
+	if err != nil {
+		return nil, err
+	}
+
+	return daemonsetResp, nil
+}

--- a/tests/framework/extensions/workloads/template.go
+++ b/tests/framework/extensions/workloads/template.go
@@ -1,0 +1,27 @@
+package workloads
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NewContainer is a contructor that creates a container for a pod template i.e. corev1.PodTemplateSpec
+func NewContainer(containerName, image string, imagePullPolicy corev1.PullPolicy, volumeMounts []corev1.VolumeMount, envFrom []corev1.EnvFromSource) corev1.Container {
+	return corev1.Container{
+		Name:            containerName,
+		Image:           image,
+		ImagePullPolicy: imagePullPolicy,
+		VolumeMounts:    volumeMounts,
+		EnvFrom:         envFrom,
+	}
+}
+
+// NewPodTemplate is a constructor that creates the pod template for all types of workloads e.g. cronjobs, daemonsets, deployments, and batch jobs
+func NewPodTemplate(containers []corev1.Container, volumes []corev1.Volume, imagePullSecrets []corev1.LocalObjectReference) corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers:       containers,
+			Volumes:          volumes,
+			ImagePullSecrets: imagePullSecrets,
+		},
+	}
+}

--- a/tests/v2/validation/upgrade/workload.go
+++ b/tests/v2/validation/upgrade/workload.go
@@ -1,0 +1,291 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/ingresses"
+	kubeingress "github.com/rancher/rancher/tests/framework/extensions/kubeapi/ingresses"
+	"github.com/rancher/rancher/tests/framework/extensions/services"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
+	"github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kubewait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// resourceNames struct contains the names of the resources
+type resourceNames struct {
+	core           map[string]string
+	coreWithSuffix map[string]string
+	random         map[string]string
+}
+
+const (
+	ingressHostName = "sslip.io"
+
+	secretAsVolumeName = "secret-as-volume"
+
+	containerName  = "test1"
+	containerImage = "ranchertest/mytestcontainer"
+
+	servicePortNumber = 80
+	servicePortName   = "port"
+
+	volumeMountPath = "/root/usr/"
+)
+
+func getSteveID(namespaceName, resourceName string) string {
+	return fmt.Sprintf(namespaceName + "/" + resourceName)
+}
+
+// newIngressTemplate is a private constructor that returns ingress spec for specific services
+func newIngressTemplate(ingressName, namespaceName, serviceNameForBackend string) networkingv1.Ingress {
+	pathTypePrefix := networkingv1.PathTypeImplementationSpecific
+	paths := []networkingv1.HTTPIngressPath{
+		{
+			Path:     "/",
+			PathType: &pathTypePrefix,
+			Backend: networkingv1.IngressBackend{
+				Service: &networkingv1.IngressServiceBackend{
+					Name: serviceNameForBackend,
+					Port: networkingv1.ServiceBackendPort{
+						Number: servicePortNumber,
+					},
+				},
+			},
+		},
+	}
+
+	return ingresses.NewIngressTemplate(ingressName, namespaceName, ingressHostName, paths)
+}
+
+// newServiceTemplate is a private constructor that returns service spec for specific workloads
+func newServiceTemplate(serviceName, namespaceName string, selector map[string]string) corev1.Service {
+	serviceType := corev1.ServiceTypeNodePort
+	ports := []corev1.ServicePort{
+		{
+			Name: servicePortName,
+			Port: servicePortNumber,
+		},
+	}
+
+	return services.NewServiceTemplate(serviceName, namespaceName, serviceType, ports, selector)
+}
+
+// newTestContainerMinimal is a private constructor that returns container for minimal workload creations
+func newTestContainerMinimal() corev1.Container {
+	pullPolicy := corev1.PullAlways
+	return workloads.NewContainer(containerName, containerImage, pullPolicy, nil, nil)
+}
+
+// newPodTemplateWithTestContainer is a private constructor that returns pod template spec for workload creations
+func newPodTemplateWithTestContainer() corev1.PodTemplateSpec {
+	testContainer := newTestContainerMinimal()
+	containers := []corev1.Container{testContainer}
+	return workloads.NewPodTemplate(containers, nil, nil)
+}
+
+// newPodTemplateWithSecretVolume is a private constructor that returns pod template spec with volume option for workload creations
+func newPodTemplateWithSecretVolume(secretName string) corev1.PodTemplateSpec {
+	testContainer := newTestContainerMinimal()
+	testContainer.VolumeMounts = []corev1.VolumeMount{{Name: secretAsVolumeName, MountPath: volumeMountPath}}
+	containers := []corev1.Container{testContainer}
+	volumes := []corev1.Volume{
+		{
+			Name: secretAsVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretName,
+				},
+			},
+		},
+	}
+
+	return workloads.NewPodTemplate(containers, volumes, nil)
+}
+
+// newPodTemplateWithSecretEnvironmentVariable is a private constructor that returns pod template spec with envFrom option for workload creations
+func newPodTemplateWithSecretEnvironmentVariable(secretName string) corev1.PodTemplateSpec {
+	pullPolicy := corev1.PullAlways
+	envFrom := []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+			},
+		},
+	}
+	container := workloads.NewContainer(containerName, containerImage, pullPolicy, nil, envFrom)
+	containers := []corev1.Container{container}
+
+	return workloads.NewPodTemplate(containers, nil, nil)
+}
+
+// waitUntilIngressIsAccessible waits until the ingress is accessible
+func waitUntilIngressIsAccessible(client *rancher.Client, hostname string) (bool, error) {
+	err := kubewait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
+		isIngressAccessible, err := ingresses.AccessIngressExternally(client, hostname, false)
+		if err != nil {
+			return false, err
+		}
+
+		return isIngressAccessible, nil
+	})
+
+	if err != nil && strings.Contains(err.Error(), kubewait.ErrWaitTimeout.Error()) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// waitUntilIngressHostnameUpdates is a private function to wait until the ingress hostname updates
+func waitUntilIngressHostnameUpdates(client *rancher.Client, clusterID, namespace, ingressName string) error {
+	timeout := int64(60 * 5)
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	if err != nil {
+		return err
+	}
+	adminDynamicClient, err := adminClient.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return err
+	}
+	adminIngressResource := adminDynamicClient.Resource(kubeingress.IngressesGroupVersionResource).Namespace(namespace)
+
+	watchAppInterface, err := adminIngressResource.Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + ingressName,
+		TimeoutSeconds: &timeout,
+	})
+	if err != nil {
+		return err
+	}
+
+	return wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+		ingressUnstructured := event.Object.(*unstructured.Unstructured)
+		ingress := &networkingv1.Ingress{}
+
+		err = scheme.Scheme.Convert(ingressUnstructured, ingress, ingressUnstructured.GroupVersionKind())
+		if err != nil {
+			return false, err
+		}
+
+		if ingress.Spec.Rules[0].Host != ingressHostName {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+// containsItemWithPrefix returns true if the given slice contains an item with the given prefix
+func containsItemWithPrefix(slice []string, expected string) bool {
+	for _, s := range slice {
+		if checkPrefix(s, expected) {
+			return true
+		}
+	}
+	return false
+}
+
+// getItemWithPrefix returns the item with the given prefix
+func getItemWithPrefix(slice []string, expected string) string {
+	for _, s := range slice {
+		if checkPrefix(s, expected) {
+			return s
+		}
+	}
+	return ""
+}
+
+// checkPrefix checks if the given string starts with the given prefix
+func checkPrefix(name string, prefix string) bool {
+	return strings.HasPrefix(name, prefix)
+}
+
+// validateDaemonset checks daemonset available number is equal to the number of workers in the cluster
+func validateDaemonset(t *testing.T, client *rancher.Client, clusterID, namespaceName, daemonsetName string) {
+	t.Helper()
+
+	workerNodesCollection, err := client.Management.Node.List(&types.ListOpts{
+		Filters: map[string]interface{}{
+			"clusterId": clusterID,
+			"worker":    true,
+		},
+	})
+	require.NoError(t, err)
+
+	steveClient, err := client.Steve.ProxyDownstream(clusterID)
+	require.NoError(t, err)
+
+	daemonSetID := getSteveID(namespaceName, daemonsetName)
+	daemonsetResp, err := steveClient.SteveType(workloads.DaemonsetSteveType).ByID(daemonSetID)
+	require.NoError(t, err)
+
+	daemonsetStatus := &appv1.DaemonSetStatus{}
+	err = v1.ConvertToK8sType(daemonsetResp.Status, daemonsetStatus)
+	require.NoError(t, err)
+
+	assert.Equalf(t, int(daemonsetStatus.NumberAvailable), len(workerNodesCollection.Data), "Daemonset %v doesn't have the required ready", daemonsetName)
+}
+
+// newNames returns a new resourceNames struct
+// it creates a random names with random suffix for each resource by using core and coreWithSuffix names
+func newNames() *resourceNames {
+	const (
+		projectName             = "upgrade-wl-project"
+		namespaceName           = "namespace"
+		deploymentName          = "deployment"
+		daemonsetName           = "daemonset"
+		secretName              = "secret"
+		serviceName             = "service"
+		ingressName             = "ingress"
+		defaultRandStringLength = 3
+	)
+
+	names := &resourceNames{
+		core: map[string]string{
+			"projectName":    projectName,
+			"namespaceName":  namespaceName,
+			"deploymentName": deploymentName,
+			"daemonsetName":  daemonsetName,
+			"secretName":     secretName,
+			"serviceName":    serviceName,
+			"ingressName":    ingressName,
+		},
+		coreWithSuffix: map[string]string{
+			"deploymentNameForVolumeSecret":              deploymentName + "-volume-secret",
+			"deploymentNameForEnvironmentVariableSecret": deploymentName + "-envar-secret",
+			"deploymentNameForIngress":                   deploymentName + "-ingress",
+			"daemonsetNameForIngress":                    daemonsetName + "-ingress",
+			"daemonsetNameForVolumeSecret":               daemonsetName + "-volume-secret",
+			"daemonsetNameForEnvironmentVariableSecret":  daemonsetName + "-envar-secret",
+			"serviceNameForDeployment":                   serviceName + "-deployment",
+			"serviceNameForDaemonset":                    serviceName + "-daemonset",
+			"ingressNameForDeployment":                   ingressName + "-deployment",
+			"ingressNameForDaemonset":                    ingressName + "-daemonset",
+		},
+	}
+
+	names.random = map[string]string{}
+	for k, v := range names.coreWithSuffix {
+		names.random[k] = v + "-" + namegenerator.RandStringLower(defaultRandStringLength)
+	}
+	for k, v := range names.core {
+		names.random[k] = v + "-" + namegenerator.RandStringLower(defaultRandStringLength)
+	}
+
+	return names
+}

--- a/tests/v2/validation/upgrade/workload_test.go
+++ b/tests/v2/validation/upgrade/workload_test.go
@@ -1,0 +1,382 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/charts"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/ingresses"
+	"github.com/rancher/rancher/tests/framework/extensions/kubeapi/workloads/daemonsets"
+	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/extensions/projects"
+	"github.com/rancher/rancher/tests/framework/extensions/secrets"
+	"github.com/rancher/rancher/tests/framework/extensions/services"
+	"github.com/rancher/rancher/tests/framework/extensions/steve"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/deployments"
+	"github.com/rancher/rancher/tests/framework/pkg/environmentflag"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	appv1 "k8s.io/api/apps/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type UpgradeWorkloadTestSuite struct {
+	suite.Suite
+	session   *session.Session
+	client    *rancher.Client
+	project   *management.Project
+	namespace *v1.SteveAPIObject
+	names     *resourceNames
+}
+
+func (u *UpgradeWorkloadTestSuite) TearDownSuite() {
+	u.session.Cleanup()
+}
+
+func (u *UpgradeWorkloadTestSuite) SetupSuite() {
+	testSession := session.NewSession(u.T())
+	u.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(u.T(), err)
+
+	u.client = client
+
+	names := newNames()
+	u.names = names
+
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(u.T(), clusterName, "Cluster name to install resources is not set")
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(u.T(), err)
+
+	projectName := names.core["projectName"]
+	project, err := projects.GetProjectByName(client, clusterID, projectName)
+	require.NoError(u.T(), err)
+
+	u.project = project
+
+	if project == nil {
+		projectConfig := &management.Project{
+			ClusterID: clusterID,
+			Name:      projectName,
+		}
+		createdProject, err := client.Management.Project.Create(projectConfig)
+		require.NoError(u.T(), err)
+		require.Equal(u.T(), createdProject.Name, projectName)
+		u.project = createdProject
+	}
+}
+
+func (u *UpgradeWorkloadTestSuite) TestWorkloadPreUpgrade() {
+	subSession := u.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := u.client.WithSession(subSession)
+	require.NoError(u.T(), err)
+
+	steveClient, err := u.client.Steve.ProxyDownstream(u.project.ClusterID)
+	require.NoError(u.T(), err)
+
+	u.T().Logf("Creating namespace with name [%v]", u.names.random["namespaceName"])
+	createdNamespace, err := namespaces.CreateNamespace(client, u.names.random["namespaceName"], "{}", map[string]string{}, map[string]string{}, u.project)
+	require.NoError(u.T(), err)
+	assert.Equal(u.T(), createdNamespace.Name, u.names.random["namespaceName"])
+	u.namespace = createdNamespace
+
+	testContainerPodTemplate := newPodTemplateWithTestContainer()
+
+	u.T().Logf("Creating a deployment with the test container with name [%v]", u.names.random["deploymentName"])
+	createdDeployment, err := deployments.CreateDeployment(client, u.project.ClusterID, u.names.random["deploymentName"], u.namespace.Name, testContainerPodTemplate)
+	require.NoError(u.T(), err)
+	assert.Equal(u.T(), createdDeployment.Name, u.names.random["deploymentName"])
+
+	u.T().Logf("Waiting deployment [%v] to have expected number of available replicas", u.names.random["deploymentName"])
+	err = charts.WatchAndWaitDeployments(client, u.project.ClusterID, u.namespace.Name, metav1.ListOptions{})
+	require.NoError(u.T(), err)
+
+	u.T().Logf("Creating a daemonset with the test container with name [%v]", u.names.random["daemonsetName"])
+	createdDeamontSet, err := daemonsets.CreateDaemonSet(client, u.project.ClusterID, u.names.random["daemonsetName"], u.namespace.Name, testContainerPodTemplate)
+	require.NoError(u.T(), err)
+	assert.Equal(u.T(), createdDeamontSet.Name, u.names.random["daemonsetName"])
+
+	u.T().Logf("Waiting daemonset [%v] to have expected number of available replicas", u.names.random["daemonsetName"])
+	err = charts.WatchAndWaitDaemonSets(client, u.project.ClusterID, u.namespace.Name, metav1.ListOptions{})
+	require.NoError(u.T(), err)
+
+	u.T().Logf("Validating daemonset[%v] available replicas number is equal to worker nodes number in the cluster [%v]", u.names.random["daemonsetName"], u.project.ClusterID)
+	validateDaemonset(u.T(), client, u.project.ClusterID, u.namespace.Name, u.names.random["daemonsetName"])
+
+	secretTemplate := secrets.NewSecretTemplate(u.names.random["secretName"], u.namespace.Name, map[string][]byte{"test": []byte("test")})
+
+	u.T().Logf("Creating a secret with name [%v]", u.names.random["secretName"])
+	createdSecret, err := steveClient.SteveType(secrets.SecretSteveType).Create(secretTemplate)
+	require.NoError(u.T(), err)
+	assert.Equal(u.T(), createdSecret.Name, u.names.random["secretName"])
+
+	podTemplateWithSecretVolume := newPodTemplateWithSecretVolume(u.names.random["secretName"])
+
+	u.T().Logf("Creating a deployment with the test container and secret as volume with name [%v]", u.names.random["deploymentNameForVolumeSecret"])
+	createdDeploymentWithSecretVolume, err := deployments.CreateDeployment(client, u.project.ClusterID, u.names.random["deploymentNameForVolumeSecret"], u.namespace.Name, podTemplateWithSecretVolume)
+	require.NoError(u.T(), err)
+	assert.Equal(u.T(), createdDeploymentWithSecretVolume.Name, u.names.random["deploymentNameForVolumeSecret"])
+
+	u.T().Logf("Creating a daemonset with the test container and secret as volume with name [%v]", u.names.random["daemonsetNameForVolumeSecret"])
+	createdDaemonsetWithSecretVolume, err := daemonsets.CreateDaemonSet(client, u.project.ClusterID, u.names.random["daemonsetNameForVolumeSecret"], u.namespace.Name, podTemplateWithSecretVolume)
+	require.NoError(u.T(), err)
+	assert.Equal(u.T(), createdDaemonsetWithSecretVolume.Name, u.names.random["daemonsetNameForVolumeSecret"])
+
+	u.T().Logf("Waiting daemonset [%v] to have expected number of available replicas", u.names.random["daemonsetNameForVolumeSecret"])
+	err = charts.WatchAndWaitDaemonSets(client, u.project.ClusterID, u.namespace.Name, metav1.ListOptions{})
+	require.NoError(u.T(), err)
+
+	u.T().Logf("Validating daemonset [%v] available replicas number is equal to worker nodes number in the cluster [%v]", u.names.random["daemonsetNameForVolumeSecret"], u.project.ClusterID)
+	validateDaemonset(u.T(), client, u.project.ClusterID, u.namespace.Name, u.names.random["daemonsetNameForVolumeSecret"])
+
+	podTemplateWithSecretEnvironmentVariable := newPodTemplateWithSecretEnvironmentVariable(u.names.random["secretName"])
+
+	u.T().Logf("Creating a deployment with the test container and secret as environment variable with name [%v]", u.names.random["deploymentNameForEnvironmentVariableSecret"])
+	createdDeploymentEnvironmentVariableSecret, err := deployments.CreateDeployment(client, u.project.ClusterID, u.names.random["deploymentNameForEnvironmentVariableSecret"], u.namespace.Name, podTemplateWithSecretEnvironmentVariable)
+	require.NoError(u.T(), err)
+	assert.Equal(u.T(), createdDeploymentEnvironmentVariableSecret.Name, u.names.random["deploymentNameForEnvironmentVariableSecret"])
+
+	u.T().Logf("Creating a daemonset with the test container and secret as environment variable with name [%v]", u.names.random["daemonsetNameForEnvironmentVariableSecret"])
+	createdDaemonsetEnvironmentVariableSecret, err := daemonsets.CreateDaemonSet(client, u.project.ClusterID, u.names.random["daemonsetNameForEnvironmentVariableSecret"], u.namespace.Name, podTemplateWithSecretEnvironmentVariable)
+	require.NoError(u.T(), err)
+	assert.Equal(u.T(), createdDaemonsetEnvironmentVariableSecret.Name, u.names.random["daemonsetNameForEnvironmentVariableSecret"])
+
+	u.T().Logf("Waiting daemonset [%v] to have expected number of available replicas", u.names.random["daemonsetNameForEnvironmentVariableSecret"])
+	err = charts.WatchAndWaitDaemonSets(client, u.project.ClusterID, u.namespace.Name, metav1.ListOptions{})
+	require.NoError(u.T(), err)
+
+	u.T().Logf("Validating daemonset [%v] available replicas number is equal to worker nodes number in the cluster [%v]", u.names.random["daemonsetNameForEnvironmentVariableSecret"], u.project.ClusterID)
+	validateDaemonset(u.T(), client, u.project.ClusterID, u.namespace.Name, u.names.random["daemonsetNameForEnvironmentVariableSecret"])
+
+	if client.Flags.GetValue(environmentflag.Ingress) {
+		u.T().Log("Ingress tests are enabled")
+
+		u.T().Logf("Creating a deployment with the test container for ingress with name [%v]", u.names.random["deploymentNameForIngress"])
+		createdDeploymentForIngress, err := deployments.CreateDeployment(client, u.project.ClusterID, u.names.random["deploymentNameForIngress"], u.namespace.Name, testContainerPodTemplate)
+		require.NoError(u.T(), err)
+		assert.Equal(u.T(), createdDeploymentForIngress.Name, u.names.random["deploymentNameForIngress"])
+
+		deploymentForIngressSpec := &appv1.DeploymentSpec{}
+		err = v1.ConvertToK8sType(createdDeploymentForIngress.Spec, deploymentForIngressSpec)
+		require.NoError(u.T(), err)
+		serviceTemplateForDeployment := newServiceTemplate(u.names.random["serviceNameForDeployment"], u.namespace.Name, deploymentForIngressSpec.Template.Labels)
+
+		u.T().Logf("Creating a service linked to the deployment with name [%v]", u.names.random["serviceNameForDeployment"])
+		createdServiceForDeployment, err := steveClient.SteveType(services.ServiceSteveType).Create(serviceTemplateForDeployment)
+		require.NoError(u.T(), err)
+		assert.Equal(u.T(), createdServiceForDeployment.Name, u.names.random["serviceNameForDeployment"])
+
+		ingressTemplateForDeployment := newIngressTemplate(u.names.random["ingressNameForDeployment"], u.namespace.Name, u.names.random["serviceNameForDeployment"])
+
+		u.T().Logf("Creating an ingress linked to the service [%v] with name [%v]", u.names.random["serviceNameForDeployment"], u.names.random["ingressNameForDeployment"])
+		createdIngressForDeployment, err := steveClient.SteveType(ingresses.IngressSteveType).Create(ingressTemplateForDeployment)
+		require.NoError(u.T(), err)
+		assert.Equal(u.T(), createdIngressForDeployment.Name, u.names.random["ingressNameForDeployment"])
+
+		u.T().Logf("Waiting ingress [%v] hostname to be ready", u.names.random["ingressNameForDeployment"])
+		err = waitUntilIngressHostnameUpdates(client, u.project.ClusterID, u.namespace.Name, u.names.random["ingressNameForDeployment"])
+		require.NoError(u.T(), err)
+
+		u.T().Logf("Checking if ingress for deployment with name [%v] is accessible", u.names.random["ingressNameForDeployment"])
+		ingressForDeploymentID := getSteveID(u.namespace.Name, u.names.random["ingressNameForDeployment"])
+		ingressForDeploymentResp, err := steveClient.SteveType(ingresses.IngressSteveType).ByID(ingressForDeploymentID)
+		require.NoError(u.T(), err)
+		ingressForDeploymentSpec := &networkingv1.IngressSpec{}
+		err = v1.ConvertToK8sType(ingressForDeploymentResp.Spec, ingressForDeploymentSpec)
+		require.NoError(u.T(), err)
+
+		isIngressForDeploymentAccessible, err := waitUntilIngressIsAccessible(client, ingressForDeploymentSpec.Rules[0].Host)
+		require.NoError(u.T(), err)
+		assert.True(u.T(), isIngressForDeploymentAccessible)
+
+		u.T().Logf("Creating a daemonset with the test container for ingress with name [%v]", u.names.random["daemonsetNameForIngress"])
+		createdDeamontSetForIngress, err := daemonsets.CreateDaemonSet(client, u.project.ClusterID, u.names.random["daemonsetNameForIngress"], u.namespace.Name, testContainerPodTemplate)
+		require.NoError(u.T(), err)
+		assert.Equal(u.T(), createdDeamontSetForIngress.Name, u.names.random["daemonsetNameForIngress"])
+
+		serviceTemplateForDaemonset := newServiceTemplate(u.names.random["serviceNameForDaemonset"], u.namespace.Name, createdDeamontSetForIngress.Spec.Template.Labels)
+
+		u.T().Logf("Creating a service linked to the daemonset with name [%v]", u.names.random["serviceNameForDaemonset"])
+		createdServiceForDaemonset, err := steveClient.SteveType(services.ServiceSteveType).Create(serviceTemplateForDaemonset)
+		require.NoError(u.T(), err)
+		assert.Equal(u.T(), createdServiceForDaemonset.Name, u.names.random["serviceNameForDaemonset"])
+
+		ingressTemplateForDaemonset := newIngressTemplate(u.names.random["ingressNameForDaemonset"], u.namespace.Name, u.names.random["serviceNameForDaemonset"])
+
+		u.T().Logf("Creating an ingress linked to the service [%v] with name [%v]", u.names.random["serviceNameForDaemonset"], u.names.random["ingressNameForDaemonset"])
+		createdIngressForDaemonset, err := steveClient.SteveType(ingresses.IngressSteveType).Create(ingressTemplateForDaemonset)
+		require.NoError(u.T(), err)
+		assert.Equal(u.T(), createdIngressForDaemonset.Name, u.names.random["ingressNameForDaemonset"])
+
+		u.T().Logf("Waiting ingress [%v] hostname to be ready", u.names.random["ingressNameForDaemonset"])
+		err = waitUntilIngressHostnameUpdates(client, u.project.ClusterID, u.namespace.Name, u.names.random["ingressNameForDaemonset"])
+		require.NoError(u.T(), err)
+
+		u.T().Logf("Checking if ingress for daemonset with name [%v] is accessible", u.names.random["ingressNameForDaemonset"])
+		ingressForDaemonsetID := getSteveID(u.namespace.Name, u.names.random["ingressNameForDaemonset"])
+		ingressForDaemonsetResp, err := steveClient.SteveType(ingresses.IngressSteveType).ByID(ingressForDaemonsetID)
+		require.NoError(u.T(), err)
+		ingressForDaemonsetSpec := &networkingv1.IngressSpec{}
+		err = v1.ConvertToK8sType(ingressForDaemonsetResp.Spec, ingressForDaemonsetSpec)
+		require.NoError(u.T(), err)
+
+		isIngressForDaemonsetAccessible, err := waitUntilIngressIsAccessible(client, ingressForDaemonsetSpec.Rules[0].Host)
+		require.NoError(u.T(), err)
+		assert.True(u.T(), isIngressForDaemonsetAccessible)
+	}
+
+	if client.Flags.GetValue(environmentflag.Chart) {
+		u.T().Log("Charts tests are enabled")
+
+		u.T().Logf("Checking if the logging chart is installed in cluster [%v]", u.project.ClusterID)
+		loggingChart, err := charts.GetChartStatus(client, u.project.ClusterID, charts.RancherLoggingNamespace, charts.RancherLoggingName)
+		require.NoError(u.T(), err)
+
+		if !loggingChart.IsAlreadyInstalled {
+			clusterName, err := clusters.GetClusterNameByID(client, u.project.ClusterID)
+			require.NoError(u.T(), err)
+			latestLoggingVersion, err := client.Catalog.GetLatestChartVersion(charts.RancherLoggingName)
+			require.NoError(u.T(), err)
+
+			loggingChartInstallOption := &charts.InstallOptions{
+				ClusterName: clusterName,
+				ClusterID:   u.project.ClusterID,
+				Version:     latestLoggingVersion,
+				ProjectID:   u.project.ID,
+			}
+
+			loggingChartFeatureOption := &charts.RancherLoggingOpts{
+				AdditionalLoggingSources: true,
+			}
+
+			u.T().Logf("Installing logging chart with the latest version in cluster [%v] with version [%v]", u.project.ClusterID, latestLoggingVersion)
+			err = charts.InstallRancherLoggingChart(client, loggingChartInstallOption, loggingChartFeatureOption)
+			require.NoError(u.T(), err)
+		}
+	}
+}
+
+func (u *UpgradeWorkloadTestSuite) TestWorkloadPostUpgrade() {
+	subSession := u.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := u.client.WithSession(subSession)
+	require.NoError(u.T(), err)
+
+	steveClient, err := u.client.Steve.ProxyDownstream(u.project.ClusterID)
+	require.NoError(u.T(), err)
+
+	defaultListOptions := &types.ListOpts{}
+
+	namespaceList, err := steveClient.SteveType(namespaces.NamespaceSteveType).List(defaultListOptions)
+	require.NoError(u.T(), err)
+	doesNamespaceExist := containsItemWithPrefix(steve.Names(namespaceList), u.names.core["namespaceName"])
+	assert.True(u.T(), doesNamespaceExist)
+
+	if !doesNamespaceExist {
+		u.T().Skipf("Namespace with prefix %s doesn't exist", u.names.core["namespaceName"])
+	}
+
+	u.T().Logf("Checking if the namespace %s does exist", u.names.core["namespaceName"])
+	namespaceID := getItemWithPrefix(steve.Names(namespaceList), u.names.core["namespaceName"])
+	namespace, err := steveClient.SteveType(namespaces.NamespaceSteveType).ByID(namespaceID)
+	require.NoError(u.T(), err)
+	u.namespace = namespace
+
+	u.T().Logf("Checking deployments in namespace %s", u.namespace.Name)
+	deploymentList, err := steveClient.SteveType(workloads.DeploymentSteveType).List(defaultListOptions)
+	require.NoError(u.T(), err)
+	deploymentNames := []string{
+		u.names.coreWithSuffix["deploymentNameForVolumeSecret"],
+		u.names.coreWithSuffix["deploymentNameForEnvironmentVariableSecret"],
+	}
+	for _, expectedDeploymentName := range deploymentNames {
+		doesContainDeployment := containsItemWithPrefix(steve.Names(deploymentList), expectedDeploymentName)
+		assert.Truef(u.T(), doesContainDeployment, "Deployment with prefix %s doesn't exist", expectedDeploymentName)
+	}
+
+	u.T().Logf("Checking daemonsets in namespace %s", u.namespace.Name)
+	daemonsetList, err := steveClient.SteveType(workloads.DaemonsetSteveType).List(defaultListOptions)
+	require.NoError(u.T(), err)
+	daemonsetNames := []string{
+		u.names.coreWithSuffix["daemonsetName"],
+	}
+	for _, expectedDaemonsetName := range daemonsetNames {
+		doesContainDaemonset := containsItemWithPrefix(steve.Names(daemonsetList), expectedDaemonsetName)
+		assert.Truef(u.T(), doesContainDaemonset, "Daemonset with prefix %s doesn't exist", expectedDaemonsetName)
+	}
+
+	if client.Flags.GetValue(environmentflag.Ingress) {
+		u.T().Logf("Ingress tests are enabled")
+
+		u.T().Logf("Checking deployment for ingress in namespace %s", u.namespace.Name)
+		doesContainDeploymentForIngress := containsItemWithPrefix(steve.Names(deploymentList), u.names.coreWithSuffix["deploymentNameForIngress"])
+		assert.Truef(u.T(), doesContainDeploymentForIngress, "Deployment with prefix %s doesn't exist", u.names.coreWithSuffix["deploymentNameForIngress"])
+
+		u.T().Logf("Checking daemonset for ingress in namespace %s", u.namespace.Name)
+		doesContainDaemonsetForIngress := containsItemWithPrefix(steve.Names(daemonsetList), u.names.coreWithSuffix["daemonsetNameForIngress"])
+		assert.Truef(u.T(), doesContainDaemonsetForIngress, "Daemonset with prefix %s doesn't exist", u.names.coreWithSuffix["daemonsetNameForIngress"])
+
+		u.T().Logf("Checking ingresses in namespace %s", u.namespace.Name)
+		ingressList, err := steveClient.SteveType(ingresses.IngressSteveType).List(defaultListOptions)
+		require.NoError(u.T(), err)
+		ingressNames := []string{
+			u.names.coreWithSuffix["ingressNameForDeployment"],
+			u.names.coreWithSuffix["ingressNameForDaemonset"],
+		}
+		for _, expectedIngressName := range ingressNames {
+			doesContainIngress := containsItemWithPrefix(steve.Names(ingressList), expectedIngressName)
+			assert.Truef(u.T(), doesContainIngress, "Ingress with prefix %s doesn't exist", expectedIngressName)
+
+			if doesContainIngress {
+				ingressName := getItemWithPrefix(steve.Names(ingressList), expectedIngressName)
+				ingressID := getSteveID(u.namespace.Name, ingressName)
+				ingressResp, err := steveClient.SteveType(ingresses.IngressSteveType).ByID(ingressID)
+				require.NoError(u.T(), err)
+				ingressSpec := &networkingv1.IngressSpec{}
+				err = v1.ConvertToK8sType(ingressResp.Spec, ingressSpec)
+				require.NoError(u.T(), err)
+
+				u.T().Logf("Checking if the ingress %s is accessible", ingressResp.Name)
+				isIngressAcessible, err := waitUntilIngressIsAccessible(client, ingressSpec.Rules[0].Host)
+				require.NoError(u.T(), err)
+				assert.True(u.T(), isIngressAcessible)
+			}
+		}
+	}
+
+	u.T().Logf("Checking the secret in namespace %s", u.namespace.Name)
+	secretList, err := steveClient.SteveType(secrets.SecretSteveType).List(defaultListOptions)
+	require.NoError(u.T(), err)
+	doesContainSecret := containsItemWithPrefix(steve.Names(secretList), u.names.core["secretName"])
+	assert.Truef(u.T(), doesContainSecret, "Secret with prefix %s doesn't exist", u.names.core["secretName"])
+
+	if client.Flags.GetValue(environmentflag.Chart) {
+		u.T().Logf("Chart tests are enabled")
+
+		u.T().Logf("Checking if the logging chart is installed")
+		loggingChart, err := charts.GetChartStatus(client, u.project.ClusterID, charts.RancherLoggingNamespace, charts.RancherLoggingName)
+		require.NoError(u.T(), err)
+		assert.True(u.T(), loggingChart.IsAlreadyInstalled)
+	}
+
+	u.T().Logf("Running the pre-upgrade checks")
+	u.TestWorkloadPreUpgrade()
+}
+
+func TestWorkloadUpgradeTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeWorkloadTestSuite))
+}


### PR DESCRIPTION
- [x] This PR relies on  #38404 and #38171 and requires a rebase after these are reviewed and merged. 
- [x] This PR relies on #39341. And requires updates for workloads according to the changes.

**Extensions Updates**
- Implemented:
  - A function to access an ingress externally to `extensions/ingresses/ingresses.go`

**Validation Tests**
- Implemented:
  - Post-upgrade and pre-upgrade resource validation cases
  - Private wait healthy response helper built on top of the access an ingresses helper
  - Private wait ingress hostname update helper built on top of the wait package
  - Private string prefix helpers to get an item and check an item in a slice of strings
  - Private name constructor to generate random suffixes with given names