### PR TITLE
Changed func ExecuteCommand to use session.Output

### DIFF
--- a/tests/framework/pkg/nodes/nodes.go
+++ b/tests/framework/pkg/nodes/nodes.go
@@ -37,10 +37,13 @@ type ExternalNodeConfig struct {
 }
 
 // ExecuteCommand executes `command` in the specific node created.
-func (n *Node) ExecuteCommand(command string) error {
+func (n *Node) ExecuteCommand(command string) (string, error) {
 	signer, err := ssh.ParsePrivateKey(n.SSHKey)
+	var output []byte
+	var output_string string
+
 	if err != nil {
-		return err
+		return output_string, err
 	}
 
 	auths := []ssh.AuthMethod{ssh.PublicKeys([]ssh.Signer{signer}...)}
@@ -54,15 +57,17 @@ func (n *Node) ExecuteCommand(command string) error {
 
 	client, err := ssh.Dial("tcp", n.PublicIPAddress+":22", cfg)
 	if err != nil {
-		return err
+		return output_string, err
 	}
 
 	session, err := client.NewSession()
 	if err != nil {
-		return err
+		return output_string, err
 	}
 
-	return session.Run(command)
+	output, err = session.Output(command)
+	output_string = string(output)
+	return output_string, err
 }
 
 // GetSSHKey reads in the ssh file from the .ssh directory, returns the key in []byte format

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -129,8 +129,9 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 						c.T().Logf("Execute Registration Command for node %s", node.NodeID)
 						command := fmt.Sprintf("%s %s", token.InsecureNodeCommand, tt.nodeRoles[key])
 
-						err = node.ExecuteCommand(command)
+						output, err := node.ExecuteCommand(command)
 						require.NoError(c.T(), err)
+						c.T().Logf(output)
 					}
 
 					kubeProvisioningClient, err := c.client.GetKubeAPIProvisioningClient()
@@ -216,8 +217,9 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynami
 						c.T().Logf("Execute Registration Command for node %s", node.NodeID)
 						command := fmt.Sprintf("%s %s", token.InsecureNodeCommand, rolesPerNode[key])
 
-						err = node.ExecuteCommand(command)
+						output, err := node.ExecuteCommand(command)
 						require.NoError(c.T(), err)
+						c.T().Logf(output)
 					}
 
 					kubeProvisioningClient, err := c.client.GetKubeAPIProvisioningClient()


### PR DESCRIPTION
Changed func ExecuteCommand to use session.Output instead of session.Run so we can also get an output of the command executed.