### PR TITLE
Refactor RKE1 cluster cleanup and support static/dynamic nodepools

### DIFF
--- a/tests/framework/extensions/rke1/nodepools/nodepools.go
+++ b/tests/framework/extensions/rke1/nodepools/nodepools.go
@@ -1,21 +1,55 @@
 package rke1
 
 import (
+	"strconv"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
-	rke1 "github.com/rancher/rancher/tests/framework/extensions/clusters"
 )
 
-func NewRKE1NodePoolConfig(ClusterID string, NodeTemplateID string) *management.NodePool {
-	nodePoolConfig := &management.NodePool{
+type NodeRoles struct {
+	ControlPlane bool  `json:"controlplane,omitempty" yaml:"controlplane,omitempty"`
+	Etcd         bool  `json:"etcd,omitempty" yaml:"etcd,omitempty"`
+	Worker       bool  `json:"worker,omitempty" yaml:"worker,omitempty"`
+	Quantity     int64 `json:"quantity" yaml:"quantity"`
+}
+
+// RKE1NodePoolSetup is a helper method that will loop and setup muliple node pools with the defined node roles from the `nodeRoles` parameter
+// `nodeRoles` would be in this format
+//   []map[string]bool{
+//   {
+// 	   ControlPlane: true,
+// 	   Etcd:         false,
+// 	   Worker:       false,
+//	   Quantity:     1,
+//   },
+//   {
+// 	   ControlPlane: false,
+// 	   Etcd:         true,
+// 	   Worker:       false,
+//	   Quantity:     1,
+//   },
+//  }
+func RKE1NodePoolSetup(client *rancher.Client, nodeRoles []NodeRoles, ClusterID, NodeTemplateID string) *management.NodePool {
+	nodePoolConfig := management.NodePool{
 		ClusterID:               ClusterID,
-		ControlPlane:            true,
 		DeleteNotReadyAfterSecs: 0,
-		Etcd:                    true,
-		HostnamePrefix:          rke1.RKE1AppendRandomString("rke1"),
 		NodeTemplateID:          NodeTemplateID,
-		Quantity:                1,
-		Worker:                  true,
 	}
 
-	return nodePoolConfig
+	for index, roles := range nodeRoles {
+		nodePoolConfig.ControlPlane = roles.ControlPlane
+		nodePoolConfig.Etcd = roles.Etcd
+		nodePoolConfig.Worker = roles.Worker
+		nodePoolConfig.Quantity = roles.Quantity
+		nodePoolConfig.HostnamePrefix = "auto-rke1-" + strconv.Itoa(index)
+
+		_, err := client.Management.NodePool.Create(&nodePoolConfig)
+
+		if err != nil {
+			return nil
+		}
+	}
+
+	return &nodePoolConfig
 }

--- a/tests/v2/validation/provisioning/README.md
+++ b/tests/v2/validation/provisioning/README.md
@@ -6,25 +6,24 @@ These are the examples of the configurations needed to run the provisioning pack
 ---
 
 ### Provisioning Input
-provisioningInput is needed to the run the RKE2 tests, specifically kubernetesVersion, cni, and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". nodeProviders is only needed for node provider cluster tests; the framework only supports custom clusters through aws/ec2 instances.
+provisioningInput is needed to the run the RKE1 tests, specifically kubernetesVersion, cni, and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". nodeProviders is only needed for node provider cluster tests.
 
 ```json
 "provisioningInput": {
-    "nodesAndRoles": [
-       {
-         "etcd": true,
-         "controlplane": true,
-         "worker": true,
-         "quantity": 1,
-       },
-       {
-         "worker": true,
-         "quantity": 2,
-       }
-     ],
-    "kubernetesVersion": ["v1.21.6+rke2r1"],
-    "cni": ["calico"],
-    "providers": ["linode", "aws", "do", "harvester"],
+    "nodesAndRoles": [ 
+      {
+        "etcd": true,
+        "controlplane": true,
+        "worker": true,
+        "quantity": 1,
+      },
+      {
+        "worker": true,
+        "quantity": 2,
+      }
+    ],
+    "kubernetesVersion": ["v1.24.2-rancher1-1"],
+    "providers": ["linode", "aws", "azure", "harvester"],
     "nodeProviders": ["ec2"]
   }
 ```

--- a/tests/v2/validation/provisioning/config.go
+++ b/tests/v2/validation/provisioning/config.go
@@ -1,18 +1,19 @@
-package rke2
+package provisioning
 
 import (
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
+	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
 	"github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 )
 
 const (
-	namespace               = "fleet-default"
 	defaultRandStringLength = 5
 	ConfigurationFileKey    = "provisioningInput"
 )
 
 type Config struct {
 	NodesAndRoles      []machinepools.NodeRoles `json:"nodesAndRoles" yaml:"nodesAndRoles" default:"[]"`
+	NodesAndRolesRKE1  []nodepools.NodeRoles    `json:"nodesAndRolesRKE1" yaml:"nodesAndRolesRKE1" default:"[]"`
 	KubernetesVersions []string                 `json:"kubernetesVersion" yaml:"kubernetesVersion"`
 	CNIs               []string                 `json:"cni" yaml:"cni"`
 	Providers          []string                 `json:"providers" yaml:"providers"`

--- a/tests/v2/validation/provisioning/hosted/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/hosted_provisioning_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
-	hostedconfig "github.com/rancher/rancher/tests/v2/validation/provisioning/rke2"
+	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -44,7 +44,7 @@ func (h *HostedClusterProvisioningTestSuite) SetupSuite() {
 	h.client = client
 
 	enabled := true
-	var testuser = hostedconfig.AppendRandomString("testuser-")
+	var testuser = provisioning.AppendRandomString("testuser-")
 	user := &management.User{
 		Username: testuser,
 		Password: "rancherrancher123!",
@@ -83,7 +83,7 @@ func (h *HostedClusterProvisioningTestSuite) TestProvisioningHostedGKECluster() 
 			cloudCredential, err := google.CreateGoogleCloudCredentials(client)
 			require.NoError(h.T(), err)
 
-			clusterName := hostedconfig.AppendRandomString("gkehostcluster")
+			clusterName := provisioning.AppendRandomString("gkehostcluster")
 			clusterResp, err := gke.CreateGKEHostedCluster(client, clusterName, cloudCredential.ID, false, false, false, false, map[string]string{})
 			require.NoError(h.T(), err)
 
@@ -124,7 +124,7 @@ func (h *HostedClusterProvisioningTestSuite) TestProvisioningHostedAKSCluster() 
 			cloudCredential, err := azure.CreateAzureCloudCredentials(client)
 			require.NoError(h.T(), err)
 
-			clusterName := hostedconfig.AppendRandomString("ekshostcluster")
+			clusterName := provisioning.AppendRandomString("ekshostcluster")
 			clusterResp, err := aks.CreateAKSHostedCluster(client, clusterName, cloudCredential.ID, false, false, false, false, map[string]string{})
 			require.NoError(h.T(), err)
 
@@ -165,7 +165,7 @@ func (h *HostedClusterProvisioningTestSuite) TestProvisioningHostedEKSCluster() 
 			cloudCredential, err := aws.CreateAWSCloudCredentials(client)
 			require.NoError(h.T(), err)
 
-			clusterName := hostedconfig.AppendRandomString("ekshostcluster")
+			clusterName := provisioning.AppendRandomString("ekshostcluster")
 			clusterResp, err := eks.CreateEKSHostedCluster(client, clusterName, cloudCredential.ID, false, false, false, false, map[string]string{})
 			require.NoError(h.T(), err)
 

--- a/tests/v2/validation/provisioning/rke1/providers.go
+++ b/tests/v2/validation/provisioning/rke1/providers.go
@@ -8,7 +8,6 @@ import (
 	aws "github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates/aws"
 	azure "github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates/azure"
 	linode "github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates/linode"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (
@@ -18,7 +17,6 @@ const (
 )
 
 type NodeTemplateFunc func(rancherClient *rancher.Client) (*nodetemplates.NodeTemplate, error)
-type MachinePoolFunc func(generatedPoolName, namespace string) *unstructured.Unstructured
 
 type Provider struct {
 	Name             string

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
-	rkeconfig "github.com/rancher/rancher/tests/v2/validation/provisioning/rke2"
+	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -37,8 +37,8 @@ func (r *RKE1NodeDriverProvisioningTestSuite) SetupSuite() {
 	testSession := session.NewSession(r.T())
 	r.session = testSession
 
-	clustersConfig := new(rkeconfig.Config)
-	config.LoadConfig(rkeconfig.ConfigurationFileKey, clustersConfig)
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 
 	r.kubernetesVersions = clustersConfig.KubernetesVersions
 	r.cnis = clustersConfig.CNIs
@@ -50,7 +50,7 @@ func (r *RKE1NodeDriverProvisioningTestSuite) SetupSuite() {
 	r.client = client
 
 	enabled := true
-	var testuser = rkeconfig.AppendRandomString("testuser-")
+	var testuser = provisioning.AppendRandomString("testuser-")
 	user := &management.User{
 		Username: testuser,
 		Password: "rancherrancher123!",
@@ -58,7 +58,7 @@ func (r *RKE1NodeDriverProvisioningTestSuite) SetupSuite() {
 		Enabled:  &enabled,
 	}
 
-	newUser, err := users.CreateUserWithRole(client, user, "clusters-create", "user")
+	newUser, err := users.CreateUserWithRole(client, user, "user")
 	require.NoError(r.T(), err)
 
 	newUser.Password = user.Password
@@ -70,6 +70,103 @@ func (r *RKE1NodeDriverProvisioningTestSuite) SetupSuite() {
 }
 
 func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1Cluster(provider Provider) {
+	providerName := " Node Provider: " + provider.Name
+	nodeRoles0 := []nodepools.NodeRoles{
+		{
+			ControlPlane: true,
+			Etcd:         true,
+			Worker:       true,
+			Quantity:     1,
+		},
+	}
+
+	nodeRoles1 := []nodepools.NodeRoles{
+		{
+			ControlPlane: true,
+			Etcd:         false,
+			Worker:       false,
+			Quantity:     1,
+		},
+		{
+			ControlPlane: false,
+			Etcd:         true,
+			Worker:       false,
+			Quantity:     1,
+		},
+		{
+			ControlPlane: false,
+			Etcd:         false,
+			Worker:       true,
+			Quantity:     1,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		nodeRoles []nodepools.NodeRoles
+		client    *rancher.Client
+	}{
+		{"1 Node all roles Admin User", nodeRoles0, r.client},
+		{"1 Node all roles Standard User", nodeRoles0, r.standardUserClient},
+		{"3 nodes - 1 role per node Admin User", nodeRoles1, r.client},
+		{"3 nodes - 1 role per node Standard User", nodeRoles1, r.standardUserClient},
+	}
+
+	var name string
+	for _, tt := range tests {
+		subSession := r.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(r.T(), err)
+
+		for _, kubeVersion := range r.kubernetesVersions {
+			name = tt.name + providerName + " Kubernetes version: " + kubeVersion
+			for _, cni := range r.cnis {
+				name += " cni: " + cni
+				r.Run(name, func() {
+					testSession := session.NewSession(r.T())
+					defer testSession.Cleanup()
+
+					testSessionClient, err := tt.client.WithSession(testSession)
+					require.NoError(r.T(), err)
+
+					clusterName := provisioning.AppendRandomString(provider.Name)
+
+					cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, testSessionClient)
+
+					clusterResp, err := clusters.CreateRKE1Cluster(testSessionClient, cluster)
+					require.NoError(r.T(), err)
+
+					client, err = client.ReLogin()
+					require.NoError(r.T(), err)
+
+					nodeTemplateResp, err := provider.NodeTemplateFunc(client)
+
+					nodePool := nodepools.RKE1NodePoolSetup(testSessionClient, tt.nodeRoles, clusterResp.ID, nodeTemplateResp.ID)
+
+					nodePoolName := nodePool.Name
+
+					opts := metav1.ListOptions{
+						FieldSelector:  "metadata.name=" + clusterResp.ID,
+						TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+					}
+					watchInterface, err := r.client.GetManagementWatchInterface(management.ClusterType, opts)
+					require.NoError(r.T(), err)
+
+					checkFunc := clusters.IsHostedProvisioningClusterReady
+
+					err = wait.WatchWait(watchInterface, checkFunc)
+					require.NoError(r.T(), err)
+					assert.Equal(r.T(), clusterName, clusterResp.Name)
+					assert.Equal(r.T(), nodePoolName, nodePool.Name)
+				})
+			}
+		}
+	}
+}
+
+func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1ClusterDynamicInput(provider Provider, nodesAndRoles []nodepools.NodeRoles) {
 	providerName := " Node Provider: " + provider.Name
 	tests := []struct {
 		name   string
@@ -98,21 +195,21 @@ func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1Cluster(provider P
 					testSessionClient, err := tt.client.WithSession(testSession)
 					require.NoError(r.T(), err)
 
-					clusterName := clusters.RKE1AppendRandomString("rke1")
+					clusterName := provisioning.AppendRandomString(provider.Name)
 
 					cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, testSessionClient)
 
-					clusterResp, err := client.Management.Cluster.Create(cluster)
+					clusterResp, err := clusters.CreateRKE1Cluster(testSessionClient, cluster)
+					require.NoError(r.T(), err)
+
+					client, err = client.ReLogin()
 					require.NoError(r.T(), err)
 
 					nodeTemplateResp, err := provider.NodeTemplateFunc(client)
 
-					nodePool := nodepools.NewRKE1NodePoolConfig(clusterResp.ID, nodeTemplateResp.ID)
+					nodePool := nodepools.RKE1NodePoolSetup(testSessionClient, nodesAndRoles, clusterResp.ID, nodeTemplateResp.ID)
 
-					nodePoolResp, err := r.client.Management.NodePool.Create(nodePool)
-					require.NoError(r.T(), err)
-
-					nodePoolName := nodePoolResp.Name
+					nodePoolName := nodePool.Name
 
 					opts := metav1.ListOptions{
 						FieldSelector:  "metadata.name=" + clusterResp.ID,
@@ -126,7 +223,7 @@ func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1Cluster(provider P
 					err = wait.WatchWait(watchInterface, checkFunc)
 					require.NoError(r.T(), err)
 					assert.Equal(r.T(), clusterName, clusterResp.Name)
-					assert.Equal(r.T(), nodePoolName, nodePoolResp.Name)
+					assert.Equal(r.T(), nodePoolName, nodePool.Name)
 				})
 			}
 		}
@@ -137,6 +234,21 @@ func (r *RKE1NodeDriverProvisioningTestSuite) TestProvisioning() {
 	for _, providerName := range r.providers {
 		provider := CreateProvider(providerName)
 		r.ProvisioningRKE1Cluster(provider)
+	}
+}
+
+func (r *RKE1NodeDriverProvisioningTestSuite) TestProvisioningDynamicInput() {
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+	nodesAndRoles := clustersConfig.NodesAndRolesRKE1
+
+	if len(nodesAndRoles) == 0 {
+		r.T().Skip()
+	}
+
+	for _, providerName := range r.providers {
+		provider := CreateProvider(providerName)
+		r.ProvisioningRKE1ClusterDynamicInput(provider, nodesAndRoles)
 	}
 }
 

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -39,8 +40,8 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	testSession := session.NewSession(c.T())
 	c.session = testSession
 
-	clustersConfig := new(Config)
-	config.LoadConfig(ConfigurationFileKey, clustersConfig)
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 
 	c.kubernetesVersions = clustersConfig.KubernetesVersions
 	c.cnis = clustersConfig.CNIs
@@ -52,7 +53,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	c.client = client
 
 	enabled := true
-	var testuser = AppendRandomString("testuser-")
+	var testuser = provisioning.AppendRandomString("testuser-")
 	user := &management.User{
 		Username: testuser,
 		Password: "rancherrancher123!",
@@ -72,6 +73,8 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 }
 
 func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(externalNodeProvider ExternalNodeProvider) {
+	namespace := "fleet-default"
+
 	nodeRoles0 := []string{
 		"--etcd --controlplane --worker",
 	}
@@ -109,7 +112,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 					nodes, err := externalNodeProvider.NodeCreationFunc(client, numNodes)
 					require.NoError(c.T(), err)
 
-					clusterName := AppendRandomString(externalNodeProvider.Name)
+					clusterName := provisioning.AppendRandomString(externalNodeProvider.Name)
 
 					cluster := clusters.NewRKE2ClusterConfig(clusterName, namespace, cni, "", kubeVersion, nil)
 
@@ -154,6 +157,8 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 }
 
 func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynamicInput(externalNodeProvider ExternalNodeProvider, nodesAndRoles []machinepools.NodeRoles) {
+	namespace := "fleet-default"
+
 	rolesPerNode := []string{}
 
 	for _, nodes := range nodesAndRoles {
@@ -196,7 +201,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynami
 					nodes, err := externalNodeProvider.NodeCreationFunc(client, numOfNodes)
 					require.NoError(c.T(), err)
 
-					clusterName := AppendRandomString(externalNodeProvider.Name)
+					clusterName := provisioning.AppendRandomString(externalNodeProvider.Name)
 
 					cluster := clusters.NewRKE2ClusterConfig(clusterName, namespace, cni, "", kubeVersion, nil)
 
@@ -248,8 +253,8 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningCustomCluster() {
 }
 
 func (c *CustomClusterProvisioningTestSuite) TestProvisioningCustomClusterDynamicInput() {
-	clustersConfig := new(Config)
-	config.LoadConfig(ConfigurationFileKey, clustersConfig)
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 	nodesAndRoles := clustersConfig.NodesAndRoles
 
 	if len(nodesAndRoles) == 0 {

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -14,10 +14,15 @@ import (
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	namespace = "fleet-default"
 )
 
 type RKE2NodeDriverProvisioningTestSuite struct {
@@ -38,8 +43,8 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 	testSession := session.NewSession(r.T())
 	r.session = testSession
 
-	clustersConfig := new(Config)
-	config.LoadConfig(ConfigurationFileKey, clustersConfig)
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 
 	r.kubernetesVersions = clustersConfig.KubernetesVersions
 	r.cnis = clustersConfig.CNIs
@@ -51,7 +56,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 	r.client = client
 
 	enabled := true
-	var testuser = AppendRandomString("testuser-")
+	var testuser = provisioning.AppendRandomString("testuser-")
 	user := &management.User{
 		Username: testuser,
 		Password: "rancherrancher123!",
@@ -134,7 +139,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2Cluster(provider P
 					testSessionClient, err := tt.client.WithSession(testSession)
 					require.NoError(r.T(), err)
 
-					clusterName := AppendRandomString(provider.Name)
+					clusterName := provisioning.AppendRandomString(provider.Name)
 					generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
 					machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
 
@@ -200,7 +205,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2ClusterDynamicInpu
 					testSessionClient, err := tt.client.WithSession(testSession)
 					require.NoError(r.T(), err)
 
-					clusterName := AppendRandomString(provider.Name)
+					clusterName := provisioning.AppendRandomString(provider.Name)
 					generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
 					machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
 
@@ -242,8 +247,8 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioning() {
 }
 
 func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningDynamicInput() {
-	clustersConfig := new(Config)
-	config.LoadConfig(ConfigurationFileKey, clustersConfig)
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 	nodesAndRoles := clustersConfig.NodesAndRoles
 
 	if len(nodesAndRoles) == 0 {


### PR DESCRIPTION
## Issues: <!-- link the issue or issues this PR resolves here --> 
[RKE1 cluster cleanup needs to occur before second cluster creation, not after all clusters are created](https://github.com/rancher/qa-tasks/issues/452)

[rke1/provisioning_node_driver_test.go should add test cases to allow cluster creation and distribute roles amongst three nodes](https://github.com/rancher/qa-tasks/issues/453)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
**Problem 1**
The `rke1/provisioning_ node_driver_test.go` test case had an issue where all of the clusters would be deleted AFTER all of the clusters were provisioned. This is incorrect behavior and we want clusters to clean up immediately after they are successfully provisioned.

This is the behavior the `rke2/provisioning_node_driver_test.go` exhibits, so we should ensure parity.

**Problem 2**
Before this PR, the RKE1 `provisioning_node_driver_test.go` would not allow nodepools to be both static and dynamic when creating cluster; it only was static. This is an issue because this does not encapsulate the test cases we want and what we see in RKE2.

Now, RKE1 has this functionality and more or less, just like RKE2 does, so more parity is being captured here.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
**Solution 1**
Created new `CreateRKE1Cluster` function in `tests/framework/extensions/clusters/clusters.go` that handles creating the cluster AND deleting the cluster. The function makes use of the `GetManagementWatchInterface` function to monitor the cluster's status in order to properly handle this.

**Solution 2**
Refactored the `nodepools.go` file to use new `RKE1NodePoolSetup` function that does the following:

- Creates `nodePoolConfig` variable that is assigned to `management.NodePool`
- The `nodeRoles` is iterated over each of the cluster's roles and a NodePool is created based upon the `nodePoolConfig`; this allows static and dynamic cluster creation

Then, the `provisioning_node_driver_test.go` calls this function instead of creating the actual NodePool in this file itself, providing further abstraction, which is ultimately much cleaner and easier to understand.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
- Local testing on client machine
- Automated Jenkins run showing the success (given to reviewers offline for review)