### PR TITLE
Add fix for configmap related flaky tests

### DIFF
--- a/tests/validation/tests/v3_api/test_configmaps.py
+++ b/tests/validation/tests/v3_api/test_configmaps.py
@@ -510,7 +510,9 @@ def create_and_validate_workload_with_configmap_as_env_variable(p_client,
     }]
     con = [{"name": "test",
             "image": TEST_IMAGE,
-            "environmentFrom": environmentdata}]
+            "envFrom": [{"configMapRef": {
+                "name": configmapname}}]
+            }]
 
     workload = p_client.create_workload(name=workload_name,
                                         containers=con,


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 Below test related to `test_configmaps` fails in the `rancher-v3_additional_tests` job:
- test_cmap_create_single_ns_env_variable
- test_cmap_edit_single_ns
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The tests fails because of the deprecated field:
```
rancher.ApiError: (ApiError(...), 'InvalidBodyContent : field `environmentFrom` is deprecated, please use Kubernetes native fields `env` and `valueFrom` for the container\'s environment variables\n\t{\'baseType\': \'error\', \'code\': \'InvalidBodyContent\', \'message\': "field `environmentFrom` is deprecated, please use Kubernetes native fields `env` and `valueFrom` for the container\'s environment variables", \'status\': 422, \'type\': \'error\'}')
```
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
- Updated the environmentFrom field to envFrom.
 
