### PR TITLE
[release/v2.6] Check if all container images exist on tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -358,6 +358,23 @@ steps:
       exclude:
       - "refs/tags/*-*"
 
+- name: check-release-images-exists
+  image: rancher/dapper:v0.5.8
+  commands:
+  - dapper check-release-images-exist
+  privileged: true
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/tags/v*"
+    event:
+    - tag
+
 volumes:
 - name: docker
   host:

--- a/scripts/check-release-images-exist
+++ b/scripts/check-release-images-exist
@@ -1,0 +1,37 @@
+#!/bin/bash
+# This script checks if all images in the (pre) release are available in Docker Hub by checking the existence of a manifest
+# This script does not guarantee that all archs for that image are available
+cd $(dirname $0)
+
+./build
+./package
+
+cd ./..
+
+TEMP_FILE=$(mktemp)
+
+if [ -n "${DRONE_TAG}" ]; then
+  if [ -s ./bin/rancher-images.txt ]; then
+    for rancherimage in $(cat ./bin/rancher-images.txt); do
+      echo "INFO: Checking if image [${rancherimage}] exists"
+      if ! docker manifest inspect ${rancherimage} >/dev/null; then
+        echo "ERROR: Image [${rancherimage}] does not exist"
+        echo "${rancherimage}" >> $TEMP_FILE
+      else
+        echo "OK: Image [${rancherimage}] does exist"
+      fi
+    done
+  else
+    echo "ERROR: ./bin/rancher-images.txt does not exist or is empty"
+    exit 1
+  fi
+
+  if [ -s $TEMP_FILE ]; then
+    echo "ERROR: Summary of missing image(s):"
+    cat $TEMP_FILE
+    exit 1
+  else
+    echo "OK: All images exist"
+    exit 0
+  fi
+fi


### PR DESCRIPTION
We've had a few occurrences of missing images, and adding this check will make sure that each (pre) release, we will check the existence of at least the manifest of the image, it will not guarantee all the architectures are present but thats "automatically" handled by https://github.com/rancher/image-mirror/.

This is added as last step so it does not delay the (pre) release as it will take a while (~ 30 minutes).

When we integrate with Slack, we can send a notification when the release and release artifacts are ready and if there are images missing after its finished checking.