### PR TITLE
Reenable provisioning tests

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -39,9 +39,8 @@ eval "$(grep '^ENV CATTLE_WINS_AGENT' package/Dockerfile | awk '{print "export "
 eval "$(grep '^ENV CATTLE_CSI_PROXY_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 eval "$(grep '^ENV CATTLE_KDM_BRANCH' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 
-export SOME_K8S_VERSION=$(curl https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/c974bcd1461419789c59066038fc69dce34168d0/data/data.json | jq -r ".$DIST.channels[0].latest")
-
-echo Starting rancher server for provisioning-tests
+export SOME_K8S_VERSION=$(curl https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.6/data/data.json | jq -r ".$DIST.channels[0].latest")
+echo "Starting rancher server for provisioning-tests using $SOME_K8S_VERSION"
 touch /tmp/rancher.log
 
 mkdir -p /var/lib/rancher/$DIST/agent/images
@@ -49,6 +48,7 @@ grep PodTestImage ./tests/integration/pkg/defaults/defaults.go | cut -f2 -d'"' >
 grep MachineProvisionImage ./pkg/settings/setting.go | cut -f4 -d'"' >> /var/lib/rancher/$DIST/agent/images/pull.txt
 mkdir -p /usr/share/rancher/ui/assets
 curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/rancher-system-agent-amd64 -o /usr/share/rancher/ui/assets/rancher-system-agent-amd64
+curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/system-agent-uninstall.sh -o /usr/share/rancher/ui/assets/system-agent-uninstall.sh
 
 mkdir -p /image-assets
 curl -sLf https://github.com/$TB_ORG/$DIST/releases/download/$SOME_K8S_VERSION/$DIST$AIRGAP-images$LINUX-amd64.tar.gz -o /image-assets/$DIST$AIRGAP-images$LINUX-amd64.tar.gz
@@ -114,11 +114,11 @@ while ! kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n catt
 done
 #kill $TPID
 
-# echo Running provisioning-tests
-# export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-# go test -v -timeout 60m ./tests/integration/pkg/tests/... || {
-#     echo -e "-----RANCHER-LOG-DUMP-START-----"
-#     cat /tmp/rancher.log | gzip | base64 -w 0
-#     echo -e "\n-----RANCHER-LOG-DUMP-END-----"
-#     exit 1
-# }
+echo Running provisioning-tests
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+go test -v -timeout 60m ./tests/integration/pkg/tests/... || {
+    echo -e "-----RANCHER-LOG-DUMP-START-----"
+    cat /tmp/rancher.log | gzip | base64 -w 0
+    echo -e "\n-----RANCHER-LOG-DUMP-END-----"
+    exit 1
+}

--- a/scripts/provisioning-tests-rke
+++ b/scripts/provisioning-tests-rke
@@ -6,4 +6,4 @@ fi
 
 cd $(dirname $0)/..
 
-# DIST=rke2 ./scripts/provisioning-tests
+DIST=rke2 ./scripts/provisioning-tests


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->https://github.com/rancher/rancher/issues/38048
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The provisioning-tests where failing because the system-agent uninstall script couldn't be pulled.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Running the `provisioning-tests` requires us to manually install the `system-agent-uninstall.sh` script ahead of time. Big thanks to @Oats87 on this one, since provisioning-tests were hopelessly broken for me running locally.

Also unpinned KDM (now running with `dev-v2.6` again) and added the current k3s/rke2 version being tested to the logs.

## Engineering Testing
### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Reenable the provisioning-tests, and watch CI pass.