### PR TITLE
Support RKE1 custom clusters and Harvester provisioning

### DIFF
--- a/tests/framework/extensions/rke1/nodepools/nodepools.go
+++ b/tests/framework/extensions/rke1/nodepools/nodepools.go
@@ -30,7 +30,7 @@ type NodeRoles struct {
 //	   Quantity:     1,
 //   },
 //  }
-func RKE1NodePoolSetup(client *rancher.Client, nodeRoles []NodeRoles, ClusterID, NodeTemplateID string) *management.NodePool {
+func RKE1NodePoolSetup(client *rancher.Client, nodeRoles []NodeRoles, ClusterID, NodeTemplateID string) (*management.NodePool, error) {
 	nodePoolConfig := management.NodePool{
 		ClusterID:               ClusterID,
 		DeleteNotReadyAfterSecs: 0,
@@ -47,9 +47,9 @@ func RKE1NodePoolSetup(client *rancher.Client, nodeRoles []NodeRoles, ClusterID,
 		_, err := client.Management.NodePool.Create(&nodePoolConfig)
 
 		if err != nil {
-			return nil
+			return nil, err
 		}
 	}
 
-	return &nodePoolConfig
+	return &nodePoolConfig, nil
 }

--- a/tests/framework/extensions/rke1/nodetemplates/harvester/create.go
+++ b/tests/framework/extensions/rke1/nodetemplates/harvester/create.go
@@ -1,0 +1,30 @@
+package nodetemplates
+
+import (
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+)
+
+const harvesterNodeTemplateNameBase = "harvesterNodeConfig"
+
+// CreateHarvesterNodeTemplate is a helper function that takes the rancher Client as a parameter and creates
+// an Harvester node template and returns the NodeTemplate response
+func CreateHarvesterNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.NodeTemplate, error) {
+	var harvesterNodeTemplateConfig nodetemplates.HarvesterNodeTemplateConfig
+	config.LoadConfig(nodetemplates.HarvesterNodeTemplateConfigurationFileKey, &harvesterNodeTemplateConfig)
+
+	nodeTemplate := nodetemplates.NodeTemplate{
+		EngineInstallURL:            "https://releases.rancher.com/install-docker/20.10.sh",
+		Name:                        harvesterNodeTemplateNameBase,
+		HarvesterNodeTemplateConfig: &harvesterNodeTemplateConfig,
+	}
+
+	resp := &nodetemplates.NodeTemplate{}
+	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/tests/framework/extensions/rke1/nodetemplates/harvester_config.go
+++ b/tests/framework/extensions/rke1/nodetemplates/harvester_config.go
@@ -1,0 +1,30 @@
+package nodetemplates
+
+// The json/yaml config key for the Harvester node template config
+const HarvesterNodeTemplateConfigurationFileKey = "harvesterNodeTemplate"
+
+// HarvesterNodeTemplateConfig is configuration need to create a Harvester node template
+type HarvesterNodeTemplateConfig struct {
+	CloudConfig       string `json:"cloudConfig" yaml:"cloudConfig"`
+	ClusterID         string `json:"clusterId" yaml:"clusterId"`
+	ClusterType       string `json:"clusterType" yaml:"clusterType"`
+	CPUCount          string `json:"cpuCount" yaml:"cpuCount"`
+	DiskBus           string `json:"diskBus" yaml:"diskBus"`
+	DiskSize          string `json:"diskSize" yaml:"diskSize"`
+	ImageName         string `json:"imageName" yaml:"imageName"`
+	KeyPairName       string `json:"keyPairName" yaml:"keyPairName"`
+	KubeconfigContent string `json:"kubeconfigContent" yaml:"kubeconfigContent"`
+	MemorySize        string `json:"memorySize" yaml:"memorySize"`
+	NetworkData       string `json:"networkData" yaml:"networkData"`
+	NetworkModel      string `json:"networkModel" yaml:"networkModel"`
+	NetworkName       string `json:"networkName" yaml:"networkName"`
+	NetworkType       string `json:"networkType" yaml:"networkType"`
+	SSHPassword       string `json:"sshPassword" yaml:"sshPassword"`
+	SSHPort           string `json:"sshPort" yaml:"sshPort"`
+	SSHPrivateKeyPath string `json:"sshPrivateKeyPath" yaml:"sshPrivateKeyPath"`
+	SSHUser           string `json:"sshUser" yaml:"sshUser"`
+	Type              string `json:"type" yaml:"type"`
+	UserData          string `json:"userData" yaml:"userData"`
+	VMAffinity        string `json:"vmAffinity" yaml:"vmAffinity"`
+	VMNamespace       string `json:"vmNamespace" yaml:"vmNamespace"`
+}

--- a/tests/framework/extensions/rke1/nodetemplates/nodetemplates.go
+++ b/tests/framework/extensions/rke1/nodetemplates/nodetemplates.go
@@ -26,6 +26,7 @@ type NodeTemplate struct {
 	Label                       map[string]string            `json:"label,omitempty" yaml:"label,omitempty"`
 	AmazonEC2NodeTemplateConfig *AmazonEC2NodeTemplateConfig `json:"amazonec2Config" yaml:"amazonec2Config,omitempty"`
 	AzureNodeTemplateConfig     *AzureNodeTemplateConfig     `json:"azureConfig" yaml:"azureConfig,omitempty"`
+	HarvesterNodeTemplateConfig *HarvesterNodeTemplateConfig `json:"harvesterConfig" yaml:"harvesterConfig,omitempty"`
 	LinodeNodeTemplateConfig    *LinodeNodeTemplateConfig    `json:"linodeConfig" yaml:"linodeConfig,omitempty"`
 	Name                        string                       `json:"name,omitempty" yaml:"name,omitempty"`
 	NamespaceId                 string                       `json:"namespaceId,omitempty" yaml:"namespaceId,omitempty"`

--- a/tests/v2/validation/provisioning/README.md
+++ b/tests/v2/validation/provisioning/README.md
@@ -6,7 +6,7 @@ These are the examples of the configurations needed to run the provisioning pack
 ---
 
 ### Provisioning Input
-provisioningInput is needed to the run the RKE1 tests, specifically kubernetesVersion, cni, and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". nodeProviders is only needed for node provider cluster tests.
+provisioningInput is needed to the run the RKE1 tests, specifically kubernetesVersion, cni, and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". nodeProviders is only needed for node provider cluster tests; the framework only supports custom clusters through aws/ec2 instances.
 
 ```json
 "provisioningInput": {
@@ -26,6 +26,26 @@ provisioningInput is needed to the run the RKE1 tests, specifically kubernetesVe
     "providers": ["linode", "aws", "azure", "harvester"],
     "nodeProviders": ["ec2"]
   }
+```
+
+### AWS/EC2 Config
+For custom clusters, the below config is needed, only AWS/EC2. It is important to note that you MUST use an AMI that already has Docker installed and the service is enabled on boot; otherwise, this will not work.
+
+```json
+ "awsEC2Config": {
+    "region": "us-east-2",
+    "instanceType": "t3a.medium",
+    "awsRegionAZ": "",
+    "awsAMI": "",
+    "awsSecurityGroups": [""],
+    "awsAccessKeyID": "",
+    "awsSecretAccessKey": "",
+    "awsSSHKeyName": "",
+    "awsCICDInstanceTag": "",
+    "awsIAMProfile": "",
+    "awsUser": "ubuntu",
+    "volumeSize": 50
+  },
 ```
 
 ## Node Template Configs
@@ -116,6 +136,34 @@ RKE1 specifically needs a node template config to run properly. These are the in
 }
 ```
 
+### Harvester
+```json
+"harvesterNodeTemplate": {
+    "cloudConfig": "",
+    "clusterId": "",
+    "clusterType": "",
+    "cpuCount": "2",
+    "diskBus": "virtio",
+    "diskSize": "40",
+    "imageName": "default/image-gchq8",
+    "keyPairName": "",
+    "kubeconfigContent": "",
+    "memorySize": "4",
+    "networkData": "",
+    "networkModel": "virtio",
+    "networkName": "",
+    "networkType": "dhcp",
+    "sshPassword": "",
+    "sshPort": "22",
+    "sshPrivateKeyPath": "",
+    "sshUser": "ubuntu",
+    "type": "harvesterConfig",
+    "userData": "",
+    "vmAffinity": "",
+    "vmNamespace": "default"
+}
+```
+
 ### Linode
 ```json
 "linodeNodeTemplate:" { 
@@ -168,7 +216,7 @@ provisioningInput is needed to the run the RKE2 tests, specifically kubernetesVe
 ```
 
 ### AWS/EC2 Config
-For custom clusters the below config is needed, only AWS/EC2 
+For custom clusters, the below config is needed, only AWS/EC2 will work.
 
 ```json
  "awsEC2Config": {

--- a/tests/v2/validation/provisioning/nodeproviders.go
+++ b/tests/v2/validation/provisioning/nodeproviders.go
@@ -1,4 +1,4 @@
-package rke2
+package provisioning
 
 import (
 	"fmt"

--- a/tests/v2/validation/provisioning/rke1/providers.go
+++ b/tests/v2/validation/provisioning/rke1/providers.go
@@ -7,13 +7,15 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates"
 	aws "github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates/aws"
 	azure "github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates/azure"
+	harvester "github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates/harvester"
 	linode "github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates/linode"
 )
 
 const (
-	awsProviderName    = "aws"
-	azureProviderName  = "azure"
-	linodeProviderName = "linode"
+	awsProviderName       = "aws"
+	azureProviderName     = "azure"
+	harvesterProviderName = "harvester"
+	linodeProviderName    = "linode"
 )
 
 type NodeTemplateFunc func(rancherClient *rancher.Client) (*nodetemplates.NodeTemplate, error)
@@ -38,6 +40,12 @@ func CreateProvider(name string) Provider {
 		provider := Provider{
 			Name:             name,
 			NodeTemplateFunc: azure.CreateAzureNodeTemplate,
+		}
+		return provider
+	case name == harvesterProviderName:
+		provider := Provider{
+			Name:             name,
+			NodeTemplateFunc: harvester.CreateHarvesterNodeTemplate,
 		}
 		return provider
 	case name == linodeProviderName:

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -142,8 +142,10 @@ func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1Cluster(provider P
 					require.NoError(r.T(), err)
 
 					nodeTemplateResp, err := provider.NodeTemplateFunc(client)
+					require.NoError(r.T(), err)
 
-					nodePool := nodepools.RKE1NodePoolSetup(testSessionClient, tt.nodeRoles, clusterResp.ID, nodeTemplateResp.ID)
+					nodePool, err := nodepools.RKE1NodePoolSetup(testSessionClient, tt.nodeRoles, clusterResp.ID, nodeTemplateResp.ID)
+					require.NoError(r.T(), err)
 
 					nodePoolName := nodePool.Name
 
@@ -206,8 +208,10 @@ func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1ClusterDynamicInpu
 					require.NoError(r.T(), err)
 
 					nodeTemplateResp, err := provider.NodeTemplateFunc(client)
+					require.NoError(r.T(), err)
 
-					nodePool := nodepools.RKE1NodePoolSetup(testSessionClient, nodesAndRoles, clusterResp.ID, nodeTemplateResp.ID)
+					nodePool, err := nodepools.RKE1NodePoolSetup(testSessionClient, nodesAndRoles, clusterResp.ID, nodeTemplateResp.ID)
+					require.NoError(r.T(), err)
 
 					nodePoolName := nodePool.Name
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

[[RKE1] Add support for Harvester for RKE1 cluster provisioning](https://github.com/rancher/qa-tasks/issues/454)

[[RKE1] Create custom_cluster_test.go test case for RKE1 cluster provisioning](https://github.com/rancher/qa-tasks/issues/456)
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

As part of the broader effort to have parity between RKE1 and RKE2, there are two additional items that have yet to be implemented:

- Harvester cluster provisioning
- Custom cluster provisioning

Both of these functionalities need to be present to provide additional test coverage, but also to be more on parity with the existing RKE2 tests. This PR addresses both of those and adds the functionality.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
For Harvester support, added the following:

- `tests/framework/extensions/rke1/nodetemplates/harvester/create.go`
- `tests/framework/extensions/rke1/nodetemplates/harvester_config.go`
- New Harvester entry in `tests/framework/extensions/rke1/nodetemplates/nodetemplates.go`
- New Harvester entry in `tests/v2/validation/provisioning/rke1/providers.go`

For custom cluster support, added the following:

- `tests/v2/validation/provisioning/rke1/custom_cluster_test.go`

Additionally, I moved `nodeproviders.go` into the parent directory `provisioning` as now both RKE1 and RKE2 use the file.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manually created custom clusters with new `rke1/custom_cluster_test.go` file and created Harvester clusters with `rke1/provisioning_node_driver_test.go` file.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Will run Jenkins jobs and pass them to the reviewers offline.