### PR TITLE
[release/v2.6] Check if only UI bumps are in commits to skip CI

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -109,7 +109,7 @@ RUN curl -sLf ${YQ_URL} -o /usr/bin/yq && chmod +x /usr/bin/yq
 RUN zypper install -y python3-tox python3-base python3 libffi-devel libopenssl-devel
 
 ENV HELM_HOME /root/.helm
-ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_COMMIT DRONE_BRANCH SYSTEM_CHART_DEFAULT_BRANCH FOSSA_API_KEY GOGET_MODULE GOGET_VERSION RELEASE_ACTION RELEASE_TYPE POSTRELEASE_RANCHER_VERSION POSTRELEASE_RANCHER_STABLE
+ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_COMMIT DRONE_BRANCH DRONE_BUILD_EVENT SYSTEM_CHART_DEFAULT_BRANCH FOSSA_API_KEY GOGET_MODULE GOGET_VERSION RELEASE_ACTION RELEASE_TYPE POSTRELEASE_RANCHER_VERSION POSTRELEASE_RANCHER_STABLE
 ENV DAPPER_SOURCE /go/src/github.com/rancher/rancher/
 ENV DAPPER_OUTPUT ./bin ./dist ./go.mod ./go.sum ./pkg/apis/go.mod ./pkg/apis/go.sum ./pkg/client/go.mod ./pkg/client/go.sum ./scripts/package ./pkg/settings/setting.go ./package/Dockerfile ./Dockerfile.dapper
 ENV DAPPER_DOCKER_SOCKET true

--- a/scripts/only-ui-bumps.sh
+++ b/scripts/only-ui-bumps.sh
@@ -1,17 +1,36 @@
 #!/bin/bash
 echo "Checking if we can skip CI"
-# Can only compare diff if branch is set
-if [ -n "${DRONE_BRANCH}" ]; then
-    echo "Environment variable DRONE_BRANCH is ${DRONE_BRANCH}"
-    # Check if there is only one changed file and if its 'package/Dockerfile'
-    if [ $(git diff ${DRONE_BRANCH} --name-only | wc -l) -eq 1 ] && [ $(git diff ${DRONE_BRANCH} --name-only) = "package/Dockerfile" ]; then
-        echo "Only package/Dockerfile changes found"
-        # Check if only CATTLE_UI_VERSION and CATTLE_DASHBOARD_UI_VERSION are changed in 'package/Dockerfile'
-        if [ -z "$(git diff -U0 ${DRONE_BRANCH} package/Dockerfile | tail -n +5 | grep -v ^@@ | egrep -v "CATTLE_UI_VERSION|CATTLE_DASHBOARD_UI_VERSION")" ]; then
-            echo "Skipping CI because it is only UI/dashboard change"
-            exit 0
+echo "Environment variable DRONE_BUILD_EVENT is ${DRONE_BUILD_EVENT}"
+# Only run check if Drone build event is 'push' or 'pull_request'
+if [ "${DRONE_BUILD_EVENT}" = "push" ] || [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
+    # In case of pull_ request, we can diff from latest commit (as Drone merges the changes as one commit)
+    if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
+        # Check if there is only one changed file and if its 'package/Dockerfile'
+        if [ $(git diff HEAD~1 --name-only | wc -l) -eq 1 ] && [ $(git diff HEAD~1 --name-only) = "package/Dockerfile" ]; then
+            echo "Only package/Dockerfile changes found"
+            # Check if only CATTLE_UI_VERSION and CATTLE_DASHBOARD_UI_VERSION are changed in 'package/Dockerfile'
+            if [ -z "$(git diff -U0 HEAD~1 package/Dockerfile | tail -n +5 | grep -v ^@@ | egrep -v "CATTLE_UI_VERSION|CATTLE_DASHBOARD_UI_VERSION")" ]; then
+                echo "Skipping CI because it is only UI/dashboard change"
+                exit 0
+            fi
+        fi
+    # In case of push, we need to get the diff from Drone's environment variables
+    elif [ "${DRONE_BUILD_EVENT}" = "push" ]; then
+        # Check for required environment variables
+        if [ -z "${DRONE_COMMIT_BEFORE}" ] || [ -z "${DRONE_COMMIT_AFTER}" ]; then
+            echo "Required environment variables not present; DRONE_COMMIT_BEFORE: ${DRONE_COMMIT_BEFORE}, DRONE_COMMIT_AFTER: ${DRONE_COMMIT_AFTER}"
+            exit 1
+        fi
+        # Check if there is only one changed file and if its 'package/Dockerfile'
+        if [ $(git diff $DRONE_COMMIT_BEFORE $DRONE_COMMIT_AFTER --name-only | wc -l) -eq 1 ] && [ $(git diff $DRONE_COMMIT_BEFORE $DRONE_COMMIT_AFTER --name-only) = "package/Dockerfile" ]; then
+            echo "Only package/Dockerfile changes found"
+            # Check if only CATTLE_UI_VERSION and CATTLE_DASHBOARD_UI_VERSION are changed in 'package/Dockerfile'
+            if [ -z "$(git diff -U0 $DRONE_COMMIT_BEFORE $DRONE_COMMIT_AFTER package/Dockerfile | tail -n +5 | grep -v ^@@ | egrep -v "CATTLE_UI_VERSION|CATTLE_DASHBOARD_UI_VERSION")" ]; then
+                echo "Skipping CI because it is only UI/dashboard change"
+                exit 0
+            fi
         fi
     fi
 fi
-echo "Not all conditions met to skip CI"
+echo "Not skipping CI, not an only UI/dashboard change"
 exit 1


### PR DESCRIPTION
Initially the check was created to diff against the branch it was being merged into, but after merging, I checked how the repository was cloned (see http://drone-publish.rancher.io/rancher/rancher/8161/1/1) and it seems to clone the repository and then merge the changes onto the branch.

So for this logic to work, we need to diff against the last commit (`HEAD~1`) and use that as the source to see if we can skip. As we don't need the branch check anymore, I changed it to checking for `DRONE_BUILD_EVENT` being `push` or `pull_request`.

For the `push` event, we need to check the before and after commit, and compare those to get the actual diff.