### PR TITLE
[2.5] Fix associated service do not delete when deleting the ingress

### DIFF
--- a/pkg/controllers/managementagent/ingress/ingress_common.go
+++ b/pkg/controllers/managementagent/ingress/ingress_common.go
@@ -72,7 +72,7 @@ func (i *ingressService) generateNewService(obj *v1beta1.Ingress, serviceType co
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Name:       obj.Name,
-					APIVersion: "v1beta1/extensions",
+					APIVersion: obj.APIVersion,
 					UID:        obj.UID,
 					Kind:       "Ingress",
 					Controller: &controller,


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/38543
 
## Problem
the corresponding automatically created service is not deleted when deleting the ingress.
 
## Solution
use `obj.APIVersion` instead of wrong hardcoded `v1beta1/extensions`.