### PR TITLE
Added OnRemove bindings and annotations

### DIFF
--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -35,6 +35,7 @@ const (
 
 	rolesCircularSoftLimit = 100
 	rolesCircularHardLimit = 500
+	clusterNameLabel       = "cluster.cattle.io/name"
 )
 
 var commonClusterAndProjectMgmtPlaneResources = map[string]bool{
@@ -159,7 +160,8 @@ func (m *manager) ensureClusterMembershipBinding(roleName, rtbNsAndName string, 
 		crbName := pkgrbac.NameForClusterRoleBinding(roleRef, subject) // use deterministic name for crb
 		_, err = m.mgmt.RBAC.ClusterRoleBindings("").Create(&v1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: crbName,
+				Name:        crbName,
+				Annotations: map[string]string{clusterNameLabel: cluster.Name},
 				Labels: map[string]string{
 					rtbNsAndName: MembershipBindingOwner,
 				},
@@ -336,6 +338,7 @@ func (m *manager) createMembershipRole(resourceType, roleName string, makeOwner 
 		},
 	}
 	if clusterRole {
+		objectMeta.Annotations = map[string]string{clusterNameLabel: metaObj.GetName()}
 		toCreate = &v1.ClusterRole{
 			ObjectMeta: objectMeta,
 			Rules:      rules,

--- a/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
+++ b/pkg/controllers/management/authprovisioningv2/authprovisioningv2.go
@@ -31,6 +31,8 @@ type handler struct {
 	roleCache                            rbacv1.RoleCache
 	roleController                       rbacv1.RoleController
 	roleBindingController                rbacv1.RoleBindingController
+	clusterRoleController                rbacv1.ClusterRoleController
+	clusterRoleBindingController         rbacv1.ClusterRoleBindingController
 	clusterRoleCache                     rbacv1.ClusterRoleCache
 	roleTemplateController               mgmtcontrollers.RoleTemplateController
 	clusterRoleTemplateBindings          mgmtcontrollers.ClusterRoleTemplateBindingCache
@@ -38,6 +40,7 @@ type handler struct {
 	projectRoleTemplateBindingController mgmtcontrollers.ProjectRoleTemplateBindingController
 	roleTemplatesCache                   mgmtcontrollers.RoleTemplateCache
 	clusters                             provisioningcontrollers.ClusterCache
+	mgmtClusters                         mgmtcontrollers.ClusterCache
 	crdCache                             apiextcontrollers.CustomResourceDefinitionCache
 	dynamic                              *dynamic.Controller
 	resources                            map[schema.GroupVersionKind]resourceMatch
@@ -60,6 +63,8 @@ func Register(ctx context.Context, clients *wrangler.Context, management *config
 		roleCache:                            clients.RBAC.Role().Cache(),
 		roleController:                       clients.RBAC.Role(),
 		roleBindingController:                clients.RBAC.RoleBinding(),
+		clusterRoleController:                clients.RBAC.ClusterRole(),
+		clusterRoleBindingController:         clients.RBAC.ClusterRoleBinding(),
 		clusterRoleCache:                     clients.RBAC.ClusterRole().Cache(),
 		roleTemplateController:               clients.Mgmt.RoleTemplate(),
 		clusterRoleTemplateBindings:          clients.Mgmt.ClusterRoleTemplateBinding().Cache(),
@@ -67,6 +72,7 @@ func Register(ctx context.Context, clients *wrangler.Context, management *config
 		projectRoleTemplateBindingController: clients.Mgmt.ProjectRoleTemplateBinding(),
 		roleTemplatesCache:                   clients.Mgmt.RoleTemplate().Cache(),
 		clusters:                             clients.Provisioning.Cluster().Cache(),
+		mgmtClusters:                         clients.Mgmt.Cluster().Cache(),
 		crdCache:                             clients.CRD.CustomResourceDefinition().Cache(),
 		dynamic:                              clients.Dynamic,
 		apply: clients.Apply.WithCacheTypes(
@@ -88,6 +94,10 @@ func Register(ctx context.Context, clients *wrangler.Context, management *config
 	clients.Mgmt.RoleTemplate().OnChange(ctx, "auth-prov-v2-roletemplate", h.OnChange)
 	clients.Mgmt.ClusterRoleTemplateBinding().OnChange(ctx, "auth-prov-v2-crtb", h.OnCRTB)
 	clients.Mgmt.ProjectRoleTemplateBinding().OnChange(ctx, "auth-prov-v2-prtb", h.OnPRTB)
+	clients.RBAC.Role().OnRemove(ctx, "auth-prov-v2-role", h.OnRemoveRole)
+	clients.RBAC.RoleBinding().OnRemove(ctx, "auth-prov-v2-rb", h.OnRemoveRoleBinding)
+	clients.RBAC.ClusterRole().OnRemove(ctx, "auth-prov-v2-crole", h.OnRemoveClusterRole)
+	clients.RBAC.ClusterRoleBinding().OnRemove(ctx, "auth-prov-v2-crb", h.OnRemoveClusterRoleBinding)
 	clients.Provisioning.Cluster().OnChange(ctx, "auth-prov-v2-cluster", h.OnCluster)
 	clients.CRD.CustomResourceDefinition().OnChange(ctx, "auth-prov-v2-crd", h.OnCRD)
 	if features.RKE2.Enabled() {

--- a/pkg/controllers/management/authprovisioningv2/crtb.go
+++ b/pkg/controllers/management/authprovisioningv2/crtb.go
@@ -76,8 +76,9 @@ func (h *handler) OnCRTB(key string, crtb *v3.ClusterRoleTemplateBinding) (*v3.C
 		// Example: crt-cluster1-creator-cluster-owner-blxbujr34t
 		roleBinding := &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name.SafeConcatName("crt", cluster.Name, crtb.Name, hashedSubject),
-				Namespace: cluster.Namespace,
+				Name:        name.SafeConcatName("crt", cluster.Name, crtb.Name, hashedSubject),
+				Namespace:   cluster.Namespace,
+				Annotations: map[string]string{clusterNameLabel: cluster.GetName(), clusterNamespaceLabel: cluster.GetNamespace()},
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,
@@ -94,8 +95,9 @@ func (h *handler) OnCRTB(key string, crtb *v3.ClusterRoleTemplateBinding) (*v3.C
 		// Example: r-cluster1-view-crtb-foo-wn5d5n7udr
 		roleBinding := &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name.SafeConcatName(clusterViewName(cluster), crtb.Name, hashedSubject),
-				Namespace: cluster.Namespace,
+				Name:        name.SafeConcatName(clusterViewName(cluster), crtb.Name, hashedSubject),
+				Namespace:   cluster.Namespace,
+				Annotations: map[string]string{clusterNameLabel: cluster.GetName(), clusterNamespaceLabel: cluster.GetNamespace()},
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,

--- a/pkg/controllers/management/authprovisioningv2/mocks_test.go
+++ b/pkg/controllers/management/authprovisioningv2/mocks_test.go
@@ -1,0 +1,253 @@
+package authprovisioningv2
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	provisioningv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	managementv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	provisioningcontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	rbacv1 "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
+	"github.com/rancher/wrangler/pkg/generic"
+	v1 "k8s.io/api/rbac/v1"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+type mockCluster struct{}
+
+func (m mockCluster) Get(namespace, name string) (*provisioningv1.Cluster, error) {
+	if name == "deleted" {
+		return nil, apierror.NewNotFound(schema.GroupResource{}, name)
+	}
+	if name == "deleting" {
+		c := &provisioningv1.Cluster{}
+		c.DeletionTimestamp = &metav1.Time{}
+		return c, nil
+	}
+	if name == "other error" {
+		return nil, errors.New("other error")
+	}
+	return &provisioningv1.Cluster{}, nil
+}
+func (m mockCluster) List(namespace string, selector labels.Selector) ([]*provisioningv1.Cluster, error) {
+	return nil, nil
+}
+func (m mockCluster) AddIndexer(indexName string, indexer provisioningcontrollers.ClusterIndexer) {}
+func (m mockCluster) GetByIndex(indexName, key string) ([]*provisioningv1.Cluster, error) {
+	return nil, nil
+}
+
+type mockMgmtCluster struct{}
+
+func (m mockMgmtCluster) Get(name string) (*v3.Cluster, error) {
+	if name == "deleted" {
+		return nil, apierror.NewNotFound(schema.GroupResource{}, name)
+	}
+	if name == "deleting" {
+		c := &v3.Cluster{}
+		c.DeletionTimestamp = &metav1.Time{}
+		return c, nil
+	}
+	if name == "other error" {
+		return nil, errors.New("other error")
+	}
+	return &v3.Cluster{}, nil
+}
+func (m mockMgmtCluster) List(selector labels.Selector) ([]*v3.Cluster, error) {
+	return []*v3.Cluster{}, nil
+}
+func (m mockMgmtCluster) AddIndexer(indexName string, indexer managementv3.ClusterIndexer) {}
+func (m mockMgmtCluster) GetByIndex(indexName, key string) ([]*v3.Cluster, error) {
+	return []*v3.Cluster{}, nil
+}
+
+type mockRoleController struct{}
+
+func (m mockRoleController) OnRemove(ctx context.Context, name string, sync rbacv1.RoleHandler) {}
+func (m mockRoleController) OnChange(ctx context.Context, name string, sync rbacv1.RoleHandler) {}
+func (m mockRoleController) Enqueue(namespace, name string)                                     {}
+func (m mockRoleController) EnqueueAfter(namespace, name string, duration time.Duration)        {}
+func (m mockRoleController) Cache() rbacv1.RoleCache {
+	return nil
+}
+func (m mockRoleController) Create(*v1.Role) (*v1.Role, error) {
+	return nil, nil
+}
+func (m mockRoleController) Update(*v1.Role) (*v1.Role, error) {
+	return nil, nil
+}
+func (m mockRoleController) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+	return nil
+}
+func (m mockRoleController) Get(namespace, name string, options metav1.GetOptions) (*v1.Role, error) {
+	return nil, nil
+}
+func (m mockRoleController) List(namespace string, opts metav1.ListOptions) (*v1.RoleList, error) {
+	return nil, nil
+}
+func (m mockRoleController) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+	return nil, nil
+}
+func (m mockRoleController) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Role, err error) {
+	return nil, nil
+}
+func (m mockRoleController) Informer() cache.SharedIndexInformer {
+	return nil
+}
+func (m mockRoleController) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"}
+}
+func (m mockRoleController) AddGenericHandler(ctx context.Context, name string, handler generic.Handler) {
+}
+func (m mockRoleController) AddGenericRemoveHandler(ctx context.Context, name string, handler generic.Handler) {
+}
+func (m mockRoleController) Updater() generic.Updater {
+	return nil
+}
+
+type mockRoleBindingController struct{}
+
+func (m mockRoleBindingController) OnRemove(ctx context.Context, name string, sync rbacv1.RoleBindingHandler) {
+}
+func (m mockRoleBindingController) OnChange(ctx context.Context, name string, sync rbacv1.RoleBindingHandler) {
+}
+func (m mockRoleBindingController) Enqueue(namespace, name string)                              {}
+func (m mockRoleBindingController) EnqueueAfter(namespace, name string, duration time.Duration) {}
+func (m mockRoleBindingController) Cache() rbacv1.RoleBindingCache {
+	return nil
+}
+func (m mockRoleBindingController) Create(*v1.RoleBinding) (*v1.RoleBinding, error) {
+	return nil, nil
+}
+func (m mockRoleBindingController) Update(*v1.RoleBinding) (*v1.RoleBinding, error) {
+	return nil, nil
+}
+func (m mockRoleBindingController) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+	return nil
+}
+func (m mockRoleBindingController) Get(namespace, name string, options metav1.GetOptions) (*v1.RoleBinding, error) {
+	return nil, nil
+}
+func (m mockRoleBindingController) List(namespace string, opts metav1.ListOptions) (*v1.RoleBindingList, error) {
+	return nil, nil
+}
+func (m mockRoleBindingController) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+	return nil, nil
+}
+func (m mockRoleBindingController) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.RoleBinding, err error) {
+	return nil, nil
+}
+func (m mockRoleBindingController) Informer() cache.SharedIndexInformer {
+	return nil
+}
+func (m mockRoleBindingController) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"}
+}
+func (m mockRoleBindingController) AddGenericHandler(ctx context.Context, name string, handler generic.Handler) {
+}
+func (m mockRoleBindingController) AddGenericRemoveHandler(ctx context.Context, name string, handler generic.Handler) {
+}
+func (m mockRoleBindingController) Updater() generic.Updater {
+	return nil
+}
+
+type mockClusterRoleController struct{}
+
+func (m mockClusterRoleController) OnRemove(ctx context.Context, name string, sync rbacv1.ClusterRoleHandler) {
+}
+func (m mockClusterRoleController) OnChange(ctx context.Context, name string, sync rbacv1.ClusterRoleHandler) {
+}
+func (m mockClusterRoleController) Enqueue(name string)                              {}
+func (m mockClusterRoleController) EnqueueAfter(name string, duration time.Duration) {}
+func (m mockClusterRoleController) Cache() rbacv1.ClusterRoleCache {
+	return nil
+}
+func (m mockClusterRoleController) Create(*v1.ClusterRole) (*v1.ClusterRole, error) {
+	return nil, nil
+}
+func (m mockClusterRoleController) Update(*v1.ClusterRole) (*v1.ClusterRole, error) {
+	return nil, nil
+}
+func (m mockClusterRoleController) Delete(name string, options *metav1.DeleteOptions) error {
+	return nil
+}
+func (m mockClusterRoleController) Get(name string, options metav1.GetOptions) (*v1.ClusterRole, error) {
+	return nil, nil
+}
+func (m mockClusterRoleController) List(opts metav1.ListOptions) (*v1.ClusterRoleList, error) {
+	return nil, nil
+}
+func (m mockClusterRoleController) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	return nil, nil
+}
+func (m mockClusterRoleController) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ClusterRole, err error) {
+	return nil, nil
+}
+func (m mockClusterRoleController) Informer() cache.SharedIndexInformer {
+	return nil
+}
+func (m mockClusterRoleController) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"}
+}
+func (m mockClusterRoleController) AddGenericHandler(ctx context.Context, name string, handler generic.Handler) {
+}
+func (m mockClusterRoleController) AddGenericRemoveHandler(ctx context.Context, name string, handler generic.Handler) {
+}
+func (m mockClusterRoleController) Updater() generic.Updater {
+	return nil
+}
+
+type mockClusterRoleBindingController struct{}
+
+func (m mockClusterRoleBindingController) OnRemove(ctx context.Context, name string, sync rbacv1.ClusterRoleBindingHandler) {
+}
+func (m mockClusterRoleBindingController) OnChange(ctx context.Context, name string, sync rbacv1.ClusterRoleBindingHandler) {
+}
+func (m mockClusterRoleBindingController) Enqueue(name string) {}
+func (m mockClusterRoleBindingController) EnqueueAfter(name string, duration time.Duration) {
+}
+func (m mockClusterRoleBindingController) Cache() rbacv1.ClusterRoleBindingCache {
+	return nil
+}
+func (m mockClusterRoleBindingController) Create(*v1.ClusterRoleBinding) (*v1.ClusterRoleBinding, error) {
+	return nil, nil
+}
+func (m mockClusterRoleBindingController) Update(*v1.ClusterRoleBinding) (*v1.ClusterRoleBinding, error) {
+	return nil, nil
+}
+func (m mockClusterRoleBindingController) Delete(name string, options *metav1.DeleteOptions) error {
+	return nil
+}
+func (m mockClusterRoleBindingController) Get(name string, options metav1.GetOptions) (*v1.ClusterRoleBinding, error) {
+	return nil, nil
+}
+func (m mockClusterRoleBindingController) List(opts metav1.ListOptions) (*v1.ClusterRoleBindingList, error) {
+	return nil, nil
+}
+func (m mockClusterRoleBindingController) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	return nil, nil
+}
+func (m mockClusterRoleBindingController) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ClusterRoleBinding, err error) {
+	return nil, nil
+}
+func (m mockClusterRoleBindingController) Informer() cache.SharedIndexInformer {
+	return nil
+}
+func (m mockClusterRoleBindingController) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"}
+}
+func (m mockClusterRoleBindingController) AddGenericHandler(ctx context.Context, name string, handler generic.Handler) {
+}
+func (m mockClusterRoleBindingController) AddGenericRemoveHandler(ctx context.Context, name string, handler generic.Handler) {
+}
+func (m mockClusterRoleBindingController) Updater() generic.Updater {
+	return nil
+}

--- a/pkg/controllers/management/authprovisioningv2/prtb.go
+++ b/pkg/controllers/management/authprovisioningv2/prtb.go
@@ -62,8 +62,9 @@ func (h *handler) ensureClusterViewBinding(cluster *v1.Cluster, prtb *v3.Project
 	// Example: r-cluster1-view-prtb-bar-foo-wn5d5n7udr
 	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.SafeConcatName(clusterViewName(cluster), prtb.Namespace, prtb.Name, hashSubject(subject)),
-			Namespace: cluster.Namespace,
+			Name:        name.SafeConcatName(clusterViewName(cluster), prtb.Namespace, prtb.Name, hashSubject(subject)),
+			Namespace:   cluster.Namespace,
+			Annotations: map[string]string{clusterNameLabel: cluster.GetName(), clusterNamespaceLabel: cluster.GetNamespace()},
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: cluster.APIVersion,

--- a/pkg/controllers/management/authprovisioningv2/role_test.go
+++ b/pkg/controllers/management/authprovisioningv2/role_test.go
@@ -1,0 +1,307 @@
+package authprovisioningv2
+
+import (
+	"testing"
+
+	"github.com/rancher/wrangler/pkg/generic"
+	v1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	simpleHandler = &handler{
+		roleController:               mockRoleController{},
+		roleBindingController:        mockRoleBindingController{},
+		clusters:                     mockCluster{},
+		mgmtClusters:                 mockMgmtCluster{},
+		clusterRoleController:        mockClusterRoleController{},
+		clusterRoleBindingController: mockClusterRoleBindingController{},
+	}
+
+	clusterDeletingAnnotationLabel = "deleting"
+	clusterDeletedAnnotationLabel  = "deleted"
+	genericAnnotationLabel         = "clusternamespace"
+	clusterErrorAnnotationLabel    = "other error"
+	noAnnotation                   = map[string]string{}
+)
+
+func Test_handler_hasClusterAnnotationsAndDeletionTimestamp(t *testing.T) {
+	funcName := "handler.hasClusterAnnotationsAndDeletionTimestamp()"
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantErr     bool
+		want        bool
+	}{
+		// Enqueued (returned generic.ErrSkip)
+		{
+			name:        "Cluster not deleted, should requeue",
+			annotations: createNameAndNamespaceAnnotation(clusterDeletingAnnotationLabel),
+			wantErr:     false,
+			want:        true,
+		},
+		// Other cluster error (clusters.get return err other than IsNotFound)
+		{
+			name:        "Cluster cache returned unexpected error",
+			annotations: createNameAndNamespaceAnnotation(clusterErrorAnnotationLabel),
+			wantErr:     true,
+			want:        false,
+		},
+		// cluster is not found (clusters.get returns IsNotFound err)
+		{
+			name:        "Cluster deleted, can delete",
+			annotations: createNameAndNamespaceAnnotation(clusterDeletedAnnotationLabel),
+			wantErr:     false,
+			want:        false,
+		},
+		// non-cluster deletion (cluster has no DeletionTimestamp)
+		{
+			name:        "Other removal reason, can delete",
+			annotations: createNameAndNamespaceAnnotation(genericAnnotationLabel),
+			wantErr:     false,
+			want:        false,
+		},
+		// no annotations
+		{
+			name:        "non-annotated, can delete",
+			annotations: noAnnotation,
+			wantErr:     false,
+			want:        false,
+		},
+	}
+	isClusterArg := true
+	for i := 0; i < 2; i++ {
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// first returned value is always the same role object as the role argument
+				enqueue, err := simpleHandler.hasAnnotationsForDeletingCluster(tt.annotations, isClusterArg)
+				if enqueue != tt.want {
+					t.Errorf("%v returned %v, wanted %v", funcName, enqueue, tt.want)
+				}
+				if err == nil && tt.wantErr {
+					t.Errorf("%v got nil error, wanted %v", funcName, tt.want)
+					return
+				}
+				if err != nil && !tt.wantErr {
+					t.Errorf("%v got error = %v, but wanted none", funcName, err)
+					return
+				}
+				if err != nil && tt.wantErr {
+					if tt.want && err != generic.ErrSkip {
+						t.Errorf("%v wanted ErrSkip, got err = %v", funcName, err)
+					}
+				}
+			})
+		}
+		isClusterArg = !isClusterArg
+	}
+}
+
+func Test_OnRemoveRole(t *testing.T) {
+	funcName := "OnRemoveRole()"
+	tests := []struct {
+		name        string
+		role        *v1.Role
+		wantEnqueue bool
+		wantErr     bool
+	}{
+		{
+			name: "Want enqueue",
+			role: &v1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: createNameAndNamespaceAnnotation(clusterDeletingAnnotationLabel),
+				},
+			},
+			wantEnqueue: true,
+			wantErr:     false,
+		},
+		{
+			name:        "Want no error",
+			role:        &v1.Role{},
+			wantEnqueue: false,
+			wantErr:     false,
+		},
+		{
+			name: "Want error",
+			role: &v1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: createNameAndNamespaceAnnotation(clusterErrorAnnotationLabel),
+				},
+			},
+			wantEnqueue: false,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := simpleHandler.OnRemoveRole("", tt.role)
+			if tt.wantEnqueue && err != generic.ErrSkip {
+				t.Errorf("%v wanted enqueue, got err = %v", funcName, err)
+				return
+			}
+			if err != nil && !tt.wantEnqueue && !tt.wantErr {
+				t.Errorf("%v wanted no error, got err = %v", funcName, err)
+			}
+		})
+	}
+}
+
+func Test_OnRemoveRoleBinding(t *testing.T) {
+	funcName := "OnRemoveRoleBinding()"
+	tests := []struct {
+		name        string
+		role        *v1.RoleBinding
+		wantEnqueue bool
+		wantErr     bool
+	}{
+		{
+			name: "Want enqueue",
+			role: &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: createNameAndNamespaceAnnotation(clusterDeletingAnnotationLabel),
+				},
+			},
+			wantEnqueue: true,
+			wantErr:     false,
+		},
+		{
+			name:        "Want no error",
+			role:        &v1.RoleBinding{},
+			wantEnqueue: false,
+			wantErr:     false,
+		},
+		{
+			name: "Want error",
+			role: &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: createNameAndNamespaceAnnotation(clusterErrorAnnotationLabel),
+				},
+			},
+			wantEnqueue: false,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := simpleHandler.OnRemoveRoleBinding("", tt.role)
+			if tt.wantEnqueue && err != generic.ErrSkip {
+				t.Errorf("%v wanted enqueue, got err = %v", funcName, err)
+				return
+			}
+			if err != nil && !tt.wantEnqueue && !tt.wantErr {
+				t.Errorf("%v wanted no error, got err = %v", funcName, err)
+			}
+		})
+	}
+}
+
+func Test_OnRemoveClusterRole(t *testing.T) {
+	funcName := "OnRemoveClusterRole()"
+	tests := []struct {
+		name        string
+		role        *v1.ClusterRole
+		wantEnqueue bool
+		wantErr     bool
+	}{
+		{
+			name: "Want enqueue",
+			role: &v1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: createNameAnnotation(clusterDeletingAnnotationLabel),
+				},
+			},
+			wantEnqueue: true,
+			wantErr:     false,
+		},
+		{
+			name:        "Want no error",
+			role:        &v1.ClusterRole{},
+			wantEnqueue: false,
+			wantErr:     false,
+		},
+		{
+			name: "Want error",
+			role: &v1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: createNameAnnotation(clusterErrorAnnotationLabel),
+				},
+			},
+			wantEnqueue: false,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := simpleHandler.OnRemoveClusterRole("", tt.role)
+			if tt.wantEnqueue && err != generic.ErrSkip {
+				t.Errorf("%v wanted enqueue, got err = %v", funcName, err)
+				return
+			}
+			if err != nil && !tt.wantEnqueue && !tt.wantErr {
+				t.Errorf("%v wanted no error, got err = %v", funcName, err)
+			}
+		})
+	}
+}
+
+func Test_OnRemoveClusterRoleBinding(t *testing.T) {
+	funcName := "OnRemoveClusterRoleBinding()"
+	tests := []struct {
+		name        string
+		role        *v1.ClusterRoleBinding
+		wantEnqueue bool
+		wantErr     bool
+	}{
+		{
+			name: "Want enqueue",
+			role: &v1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: createNameAnnotation(clusterDeletingAnnotationLabel),
+				},
+			},
+			wantEnqueue: true,
+			wantErr:     false,
+		},
+		{
+			name:        "Want no error",
+			role:        &v1.ClusterRoleBinding{},
+			wantEnqueue: false,
+			wantErr:     false,
+		},
+		{
+			name: "Want error",
+			role: &v1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: createNameAnnotation(clusterErrorAnnotationLabel),
+				},
+			},
+			wantEnqueue: false,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := simpleHandler.OnRemoveClusterRoleBinding("", tt.role)
+			if tt.wantEnqueue && err != generic.ErrSkip {
+				t.Errorf("%v wanted enqueue, got err = %v", funcName, err)
+				return
+			}
+			if err != nil && !tt.wantEnqueue && !tt.wantErr {
+				t.Errorf("%v wanted no error, got err = %v", funcName, err)
+			}
+		})
+	}
+}
+
+func createNameAndNamespaceAnnotation(n string) map[string]string {
+	return map[string]string{clusterNameLabel: n, clusterNamespaceLabel: n}
+}
+
+func createNameAnnotation(n string) map[string]string {
+	return map[string]string{clusterNameLabel: n}
+}


### PR DESCRIPTION
## Issue: 
 https://github.com/rancher/rancher/issues/36072

## Problem
Cluster role was being deleted before the cluster was fully deleted, leading to the final signal not being sent to the frontend saying the cluster was deleted.
 
## Solution
Added an OnRemove handler for the cluster role and cluster binding which re-queues the deletion of the role and binding until the cluster is fully deleted.
 
## Engineering Testing
### Manual Testing
Follow repro steps in issue.

### Automated Testing
Adding tests