### PR TITLE
fix for the failing tests due to timeout

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -1678,6 +1678,7 @@ def wait_for_app_to_active(client, app_id,
     @return: app object
     """
     start = time.time()
+    timeout = start + timeout
     app_data = client.list_app(id=app_id).data
     while len(app_data) == 0:
         if time.time() - start > timeout / 10:
@@ -2218,6 +2219,7 @@ def generate_template_global_role(name, new_user_default=False, template=None):
 def wait_for_backup_to_active(cluster, backupname,
                               timeout=DEFAULT_TIMEOUT):
     start = time.time()
+    timeout = start + timeout
     etcdbackups = cluster.etcdBackups(name=backupname)
     assert len(etcdbackups) == 1
     etcdbackupdata = etcdbackups['data']


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Some tests in the v3_additional_tests_long fails with timeout error.

```
wait_for_backup_to_active
wait_for_app_to_active
```
 
This PR serves to fix that by changing timeout condition.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
`timeout = start + timeout` fixes the timeout error.