### PR TITLE
Add fix for test_node_annotation flaky tests

### DIFF
--- a/tests/validation/tests/v3_api/test_node_annotation.py
+++ b/tests/validation/tests/v3_api/test_node_annotation.py
@@ -634,7 +634,7 @@ def test_rbac_node_annotation_add_kubectl(role):
                                         annotation_value)
         # cleanup annotation
         delete_node_annotation(annotation_key, node, client)
-    elif role == CLUSTER_MEMBER:
+    elif role == CLUSTER_MEMBER or role == PROJECT_OWNER:
         result = execute_kubectl_cmd(command, False, stderr=True)
         result = result.decode('ascii')
         assert "cannot patch resource \"nodes\"" in result
@@ -683,7 +683,7 @@ def test_rbac_node_annotation_delete_kubectl(role):
         time.sleep(2)
         # annotation should be deleted
         validate_annotation_deleted_on_node(user_client, node, annotation_key)
-    elif role == CLUSTER_MEMBER:
+    elif role == CLUSTER_MEMBER or role == PROJECT_OWNER:
         result = execute_kubectl_cmd(command, False, stderr=True)
         result = result.decode('ascii')
         assert "cannot patch resource \"nodes\"" in result
@@ -740,7 +740,7 @@ def test_rbac_node_annotation_edit_kubectl(role):
         validate_annotation_set_on_node(user_client, node,
                                         annotation_key,
                                         annotation_value_new)
-    elif role == CLUSTER_MEMBER:
+    elif role == CLUSTER_MEMBER or role == PROJECT_OWNER:
         result = execute_kubectl_cmd(command, False, stderr=True)
         result = result.decode('ascii')
         assert "cannot patch resource \"nodes\"" in result


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Following test cases fails from the `rancher-v3_additional_tests` jenkins job
- test_node_annotation.test_rbac_node_annotation_add_kubectl[project-owner]
- test_node_annotation.test_rbac_node_annotation_delete_kubectl[project-owner]
- test_node_annotation.test_rbac_node_annotation_edit_kubectl[project-owner]
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The assert condition for `project-owner` role was incorrect, hence during adding, editing and deleting the node annotation it was failing.
- Below is the assert error in jenkins logs:
`assert 'cannot get resource "nodes"' in 'Error from server (Forbidden): nodes "ip-<REDACTED>" is forbidden: User "u-jc7q7" cannot patch resource "nodes" in API group "" at the cluster scope\n'`
- When the role is project-owner the kubectl command fails for patch operation and not for the get operation.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 Updated the condition in code so that correct assert condition is executed when the role is project-owner.

