### PR TITLE
increase timeout

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -1421,6 +1421,7 @@ def validate_cluster_state(client, cluster,
                            nodes_not_in_active_state=[],
                            timeout=MACHINE_TIMEOUT):
     start_time = time.time()
+    timeout = start_time + timeout
     if check_intermediate_state:
         cluster = wait_for_condition(
             client, cluster,
@@ -1481,7 +1482,11 @@ def delete_node(aws_nodes):
 
 def cluster_cleanup(client, cluster, aws_nodes=None):
     if RANCHER_CLEANUP_CLUSTER:
+        start = time.time()
         client.delete(cluster)
+        if cluster.rancherKubernetesEngineConfig.cloudProvider.name == "azure":
+            time.sleep(20)
+            print("-------sleep time after cluster deletion--------", time.time() - start)
         if aws_nodes is not None:
             delete_node(aws_nodes)
     else:


### PR DESCRIPTION
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

As per the analysis mentioned on the confluence page, **rancher-v3_ontag_az_certification** job fails to remove all the resources created for the testing. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Made changes in the timeout parameter.
This PR serves the purpose to fix this issue.
 