### PR TITLE
Update `rancher/shell` version to non-rc `v0.1.18`

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -111,7 +111,7 @@ var (
 	PartnerChartDefaultBranch           = NewSetting("partner-chart-default-branch", "main")
 	RKE2ChartDefaultBranch              = NewSetting("rke2-chart-default-branch", "main")
 	FleetDefaultWorkspaceName           = NewSetting("fleet-default-workspace-name", fleetconst.ClustersDefaultNamespace) // fleetWorkspaceName to assign to clusters with none
-	ShellImage                          = NewSetting("shell-image", "rancher/shell:v0.1.18-rc8")
+	ShellImage                          = NewSetting("shell-image", "rancher/shell:v0.1.18")
 	IgnoreNodeName                      = NewSetting("ignore-node-name", "") // nodes to ignore when syncing v1.node to v3.node
 	NoDefaultAdmin                      = NewSetting("no-default-admin", "")
 	RestrictedDefaultAdmin              = NewSetting("restricted-default-admin", "false") // When bootstrapping the admin for the first time, give them the global role restricted-admin

--- a/tests/framework/extensions/clusters/import.go
+++ b/tests/framework/extensions/clusters/import.go
@@ -139,7 +139,7 @@ func ImportCluster(client *rancher.Client, cluster *apisV1.Cluster, rest *rest.C
 					Containers: []corev1.Container{
 						{
 							Name:    "kubectl",
-							Image:   "rancher/shell:v0.1.18-rc8",
+							Image:   "rancher/shell:v0.1.18",
 							Command: []string{"/bin/sh", "-c"},
 							Args: []string{
 								fmt.Sprintf("wget -qO- --tries=10 --no-check-certificate %s | kubectl apply -f - ;", token.ManifestURL),

--- a/tests/v2/validation/charts/monitoring.go
+++ b/tests/v2/validation/charts/monitoring.go
@@ -367,7 +367,7 @@ func createAlertWebhookReceiverDeployment(client *rancher.Client, clusterID, nam
 			Containers: []corev1.Container{
 				{
 					Name:    "kubectl",
-					Image:   "rancher/shell:v0.1.18-rc8",
+					Image:   "rancher/shell:v0.1.18",
 					Command: []string{"/bin/sh", "-c"},
 					Args: []string{
 						fmt.Sprintf(


### PR DESCRIPTION
Update `rancher/shell` version to non-rc `v0.1.18`.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>