### PR TITLE
Bump rancher-csp-adapter to v1.0.0

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -55,7 +55,7 @@ ENV CATTLE_SYSTEM_UPGRADE_CONTROLLER_CHART_VERSION 100.0.2+up0.3.2
 # System charts minimal version
 ENV CATTLE_FLEET_MIN_VERSION=100.0.4+up0.3.10-rc5
 ENV CATTLE_RANCHER_WEBHOOK_MIN_VERSION=1.0.5+up0.2.6
-ENV CATTLE_CSP_ADAPTER_MIN_VERSION=1.0.0+up1.0.0-rc4
+ENV CATTLE_CSP_ADAPTER_MIN_VERSION=1.0.0
 
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/library && \


### PR DESCRIPTION
Bump rancher-csp-adapter to non-rc'd version for initial release. 

Depends on rancher/charts#2028