### PR TITLE
Add fix for test_nfs flaky test

### DIFF
--- a/tests/validation/tests/v3_api/test_nfs.py
+++ b/tests/validation/tests/v3_api/test_nfs.py
@@ -107,7 +107,7 @@ def test_nfs_wl_upgrade():
                               "subPath": sub_path,
                               "name": "vol1"
                               }],
-            "environment": {"REASON": "upgrade"}
+            "env": {"REASON": "upgrade"}
             }]
     p_client.update(wl, containers=con)
     wl = wait_for_wl_to_active(p_client, wl)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Below test fails from the `rancher-v3_additional_tests` jenkins job:
- test_nfs.test_nfs_wl_upgrade
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
It was failing due the k8s deprecated field. Logs from the jenkins job:

`rancher.ApiError: (ApiError(...), 'InvalidBodyContent : field `environment` is deprecated, please use Kubernetes native field `env` for the container\'s environment variables\n\t{\'baseType\': \'error\', \'code\': \'InvalidBodyContent\', \'message\': "field `environment` is deprecated, please use Kubernetes native field `env` for the container\'s environment variables", \'status\': 422, \'type\': \'error\'}')`
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updated the `environment` field to `env`.
 