### PR TITLE
Reenable provisioning tests

### DIFF
--- a/pkg/controllers/management/drivers/nodedriver/machine_driver.go
+++ b/pkg/controllers/management/drivers/nodedriver/machine_driver.go
@@ -38,6 +38,7 @@ var (
 		"openstack":     {"cacert": "cacert", "privateKeyFile": "privateKeyFile", "userDataFile": "userDataFile"},
 		"otc":           {"privateKeyFile": "privateKeyFile"},
 		"packet":        {"userdata": "userdata"},
+		"pod":           {"userdata": "userdata"},
 		"vmwarevsphere": {"cloud-config": "cloudConfig"},
 		"google":        {"authEncodedJson": "authEncodedJson"},
 	}

--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -65,6 +65,7 @@ var SchemaToDriverFields = map[string]map[string]string{
 	"openstack":     {"cacert": "cacert", "privateKeyFile": "privateKeyFile", "userDataFile": "userDataFile"},
 	"otc":           {"privateKeyFile": "privateKeyFile"},
 	"packet":        {"userdata": "userdata"},
+	"pod":           {"userdata": "userdata"},
 	"vmwarevsphere": {"cloudConfig": "cloud-config"},
 	"google":        {"authEncodedJson": "authEncodedJson"},
 }

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -39,9 +39,8 @@ eval "$(grep '^ENV CATTLE_WINS_AGENT' package/Dockerfile | awk '{print "export "
 eval "$(grep '^ENV CATTLE_CSI_PROXY_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 eval "$(grep '^ENV CATTLE_KDM_BRANCH' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 
-export SOME_K8S_VERSION=$(curl https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/c974bcd1461419789c59066038fc69dce34168d0/data/data.json | jq -r ".$DIST.channels[0].latest")
-
-echo Starting rancher server for provisioning-tests
+export SOME_K8S_VERSION=$(curl https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.6/data/data.json | jq -r ".$DIST.channels[0].latest")
+echo "Starting rancher server for provisioning-tests using $SOME_K8S_VERSION"
 touch /tmp/rancher.log
 
 mkdir -p /var/lib/rancher/$DIST/agent/images
@@ -49,6 +48,7 @@ grep PodTestImage ./tests/integration/pkg/defaults/defaults.go | cut -f2 -d'"' >
 grep MachineProvisionImage ./pkg/settings/setting.go | cut -f4 -d'"' >> /var/lib/rancher/$DIST/agent/images/pull.txt
 mkdir -p /usr/share/rancher/ui/assets
 curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/rancher-system-agent-amd64 -o /usr/share/rancher/ui/assets/rancher-system-agent-amd64
+curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/system-agent-uninstall.sh -o /usr/share/rancher/ui/assets/system-agent-uninstall.sh
 
 mkdir -p /image-assets
 curl -sLf https://github.com/$TB_ORG/$DIST/releases/download/$SOME_K8S_VERSION/$DIST$AIRGAP-images$LINUX-amd64.tar.gz -o /image-assets/$DIST$AIRGAP-images$LINUX-amd64.tar.gz
@@ -114,11 +114,11 @@ while ! kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n catt
 done
 #kill $TPID
 
-# echo Running provisioning-tests
-# export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-# go test -v -timeout 60m ./tests/integration/pkg/tests/... || {
-#     echo -e "-----RANCHER-LOG-DUMP-START-----"
-#     cat /tmp/rancher.log | gzip | base64 -w 0
-#     echo -e "\n-----RANCHER-LOG-DUMP-END-----"
-#     exit 1
-# }
+echo Running provisioning-tests
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+go test -v -timeout 60m ./tests/integration/pkg/tests/... || {
+    echo -e "-----RANCHER-LOG-DUMP-START-----"
+    cat /tmp/rancher.log | gzip | base64 -w 0
+    echo -e "\n-----RANCHER-LOG-DUMP-END-----"
+    exit 1
+}

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -50,11 +50,6 @@ mkdir -p /usr/share/rancher/ui/assets
 curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/rancher-system-agent-amd64 -o /usr/share/rancher/ui/assets/rancher-system-agent-amd64
 curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/system-agent-uninstall.sh -o /usr/share/rancher/ui/assets/system-agent-uninstall.sh
 
-mkdir -p /image-assets
-curl -sLf https://github.com/$TB_ORG/$DIST/releases/download/$SOME_K8S_VERSION/$DIST$AIRGAP-images$LINUX-amd64.tar.gz -o /image-assets/$DIST$AIRGAP-images$LINUX-amd64.tar.gz
-echo Decompressing airgap tarball
-gzip -d /image-assets/$DIST$AIRGAP-images$LINUX-amd64.tar.gz
-
 run_rancher()
 {
     RESTART_COUNT=0

--- a/scripts/provisioning-tests-rke
+++ b/scripts/provisioning-tests-rke
@@ -6,4 +6,4 @@ fi
 
 cd $(dirname $0)/..
 
-# DIST=rke2 ./scripts/provisioning-tests
+DIST=rke2 ./scripts/provisioning-tests

--- a/tests/integration/pkg/defaults/defaults.go
+++ b/tests/integration/pkg/defaults/defaults.go
@@ -3,7 +3,7 @@ package defaults
 import "os"
 
 var (
-	PodTestImage        = "rancher/systemd-node:v0.0.2"
+	PodTestImage        = "rancher/systemd-node:v0.0.4"
 	SomeK8sVersion      = os.Getenv("SOME_K8S_VERSION")
 	WatchTimeoutSeconds = int64(60 * 30)
 	CommonClusterConfig = map[string]interface{}{

--- a/tests/integration/pkg/nodeconfig/nodeconfig.go
+++ b/tests/integration/pkg/nodeconfig/nodeconfig.go
@@ -78,6 +78,38 @@ func NewPodConfig(clients *clients.Clients, namespace string) (*corev1.ObjectRef
 	podConfig.SetNamespace(namespace)
 	podConfig.SetGenerateName("pod-config-")
 	podConfig.Object["image"] = defaults.PodTestImage
+	// We are providing custom userdata to force K3s/RKE2 to use the cgroupfs cgroup driver, rather than systemd
+	// We must also drop-in replace the type of service for systemd as we are clearing the notify socket which would
+	// normally cause systemd to hang waiting for the unit to activate. Eventually, when
+	// https://github.com/rancher/rke2/issues/3240 is resolved, we should be able to roll back this workaround. If the
+	// linked github issue is resolved, we should roll back this change here as well as in
+	// tests/integration/pkg/systemdnode.
+	podConfig.Object["userdata"] = `#cloud-config
+write_files:
+- content: |
+    [Service]
+    Type=exec
+  path: /etc/systemd/system/rke2-server.service.d/10-delegate.conf
+- content: |
+    [Service]
+    Type=exec
+  path: /etc/systemd/system/rke2-agent.service.d/10-delegate.conf
+- content: |
+    [Service]
+    Type=exec
+  path: /etc/systemd/system/k3s.service.d/10-delegate.conf
+- content: |
+    NOTIFY_SOCKET=
+    INVOCATION_ID=
+  path: /etc/default/rke2-server
+- content: |
+    NOTIFY_SOCKET=
+    INVOCATION_ID=
+  path: /etc/default/rke2-agent
+- content: |
+    NOTIFY_SOCKET=
+    INVOCATION_ID=
+  path: /etc/default/k3s`
 	podConfigClient := clients.Dynamic.Resource(schema.GroupVersionResource{
 		Group:    "rke-machine-config.cattle.io",
 		Version:  "v1",

--- a/tests/integration/pkg/systemdnode/systemnode.go
+++ b/tests/integration/pkg/systemdnode/systemnode.go
@@ -1,15 +1,14 @@
 package systemdnode
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/rancher/rancher/tests/integration/pkg/clients"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// New is used to create a new instance of systemd-node as a pod in a Kubernetes cluster. Notably, this is used for the
+// v2prov integration tests for custom clusters to simulate custom cluster nodes.
 func New(clients *clients.Clients, namespace, script string) (*corev1.Pod, error) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -25,7 +24,31 @@ func New(clients *clients.Clients, namespace, script string) (*corev1.Pod, error
 		return nil, err
 	}
 
-	imagesPath := fmt.Sprintf("/var/lib/rancher/%s/agent/images", os.Getenv("DIST"))
+	// We are providing the following files/configmap in order to force K3s/RKE2 to use the cgroupfs cgroup driver,
+	// rather than systemd.
+	// We must also drop-in replace the type of service for systemd as we are clearing the notify socket which would
+	// normally cause systemd to hang waiting for the unit to activate. Eventually, when
+	// https://github.com/rancher/rke2/issues/3240 is resolved, we should be able to roll back this workaround. If the
+	// linked github issue is resolved, we should roll back this change here as well as in
+	// tests/integration/pkg/nodeconfig.
+	cmConfigure := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    namespace,
+			GenerateName: "test-node-configure-systemd-",
+		},
+		Data: map[string]string{
+			"dropin": `[Service]
+Type=exec
+`,
+			"disable": `NOTIFY_SOCKET=
+INVOCATION_ID=
+`},
+	}
+	cmConfigure, err = clients.Core.ConfigMap().Create(cmConfigure)
+	if err != nil {
+		return nil, err
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    namespace,
@@ -44,44 +67,16 @@ func New(clients *clients.Clients, namespace, script string) (*corev1.Pod, error
 					},
 				},
 				{
-					Name: "image-assets",
+					Name: "systemd",
 					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/image-assets",
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: cmConfigure.Name,
+							},
 						},
 					},
 				},
-				{
-					Name: "agent-images",
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
-				},
 			},
-			InitContainers: []corev1.Container{{
-				Name:  "copy-image-assets",
-				Image: defaults.PodTestImage,
-				SecurityContext: &corev1.SecurityContext{
-					Privileged: &[]bool{true}[0],
-				},
-				Command: []string{
-					"/bin/sh",
-				},
-				Args: []string{
-					"-c",
-					"cp -rf /image-assets/* /image-assets-destination",
-				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      "image-assets",
-						MountPath: "/image-assets",
-					},
-					{
-						Name:      "agent-images",
-						MountPath: "/image-assets-destination",
-					},
-				},
-			}},
 			Containers: []corev1.Container{{
 				Name:  "container",
 				Image: defaults.PodTestImage,
@@ -98,8 +93,34 @@ func New(clients *clients.Clients, namespace, script string) (*corev1.Pod, error
 						SubPath:   "user-data",
 					},
 					{
-						Name:      "agent-images",
-						MountPath: imagesPath,
+						Name:      "systemd",
+						MountPath: "/usr/local/lib/systemd/system/rke2-server.service.d/10-delegate.conf",
+						SubPath:   "dropin",
+					},
+					{
+						Name:      "systemd",
+						MountPath: "/usr/local/lib/systemd/system/rke2-agent.service.d/10-delegate.conf",
+						SubPath:   "dropin",
+					},
+					{
+						Name:      "systemd",
+						MountPath: "/usr/local/lib/systemd/system/k3s.service.d/10-delegate.conf",
+						SubPath:   "dropin",
+					},
+					{
+						Name:      "systemd",
+						MountPath: "/etc/default/rke2-server",
+						SubPath:   "disable",
+					},
+					{
+						Name:      "systemd",
+						MountPath: "/etc/default/rke2-agent",
+						SubPath:   "disable",
+					},
+					{
+						Name:      "systemd",
+						MountPath: "/etc/default/k3s",
+						SubPath:   "disable",
 					},
 				},
 			}},


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/38048
 
## Problem
The provisioning-tests stopped working at some point for K3s/RKE2. They were disabled in CI, rather than debugged.
 
## Solution
This PR fixes the provisioning tests to allow them to work again.

This PR is a continuation of https://github.com/rancher/rancher/pull/38531