### PR TITLE
Adding validation for cluster owner and cluster member v1 endpoints

### DIFF
--- a/tests/framework/extensions/namespaces/namespaces.go
+++ b/tests/framework/extensions/namespaces/namespaces.go
@@ -1,6 +1,7 @@
 package namespaces
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
@@ -43,4 +44,21 @@ func GetNamespaceByName(client *rancher.Client, clusterID, namespaceName string)
 	}
 
 	return namespace, nil
+}
+
+// DeleteNamespace is a helper function to delete  a namespaces from a cluster from a given project.
+func DeleteNamespace(client *rancher.Client, namespace string, clusterID string) error {
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return err
+	}
+	namespaceResource := dynamicClient.Resource(NamespaceGroupVersionResource)
+	err = namespaceResource.Delete(context.TODO(), namespace, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	return err
+
 }

--- a/tests/framework/extensions/projects/projects.go
+++ b/tests/framework/extensions/projects/projects.go
@@ -33,3 +33,19 @@ func GetProjectByName(client *rancher.Client, clusterID, projectName string) (*m
 
 	return project, nil
 }
+
+// GetProjectList is a helper function that returns all the project in a specific cluster
+func GetProjectList(client *rancher.Client, clusterID string) (*management.ProjectCollection, error) {
+	var projectsList *management.ProjectCollection
+
+	projectsList, err := client.Management.Project.List(&types.ListOpts{
+		Filters: map[string]interface{}{
+			"clusterId": clusterID,
+		},
+	})
+	if err != nil {
+		return projectsList, err
+	}
+
+	return projectsList, nil
+}

--- a/tests/v2/validation/rbac/rbac.go
+++ b/tests/v2/validation/rbac/rbac.go
@@ -1,0 +1,91 @@
+package rbac
+
+import (
+	"sort"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	collection "github.com/rancher/rancher/tests/framework/clients/rancher/generated/provisioning/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/extensions/projects"
+	"github.com/rancher/rancher/tests/framework/extensions/users"
+	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
+	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const roleOwner = "cluster-owner"
+const roleMember = "cluster-member"
+
+//Helper function to create users
+func createUser(client *rancher.Client) (*management.User, error) {
+	enabled := true
+	var username = provisioning.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: username,
+		Password: testpassword,
+		Name:     username,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	if err != nil {
+		return newUser, err
+	}
+
+	newUser.Password = user.Password
+	return newUser, err
+}
+
+//Gets the list of projects and return the names of the projects as a slice
+func listProjects(client *rancher.Client, clusterID string) (projectNames []string, err error) {
+	projectList, err := projects.GetProjectList(client, clusterID)
+	if err != nil {
+		return projectNames, err
+	}
+
+	projectNames = make([]string, len(projectList.Data))
+
+	for idx, project := range projectList.Data {
+		projectNames[idx] = project.Name
+	}
+	sort.Strings(projectNames)
+	return projectNames, err
+}
+
+//(client *rancher.Client, clusterID string, listOpts metav1.ListOptions
+
+//Gets the list of namespaces and return the names of the namespaces as a slice
+func getNamespaces(client *rancher.Client, clusterID string) (namespace []string, err error) {
+	namespaceList, err := namespaces.ListNamespaces(client, clusterID, metav1.ListOptions{})
+	if err != nil {
+		return namespace, err
+	}
+
+	namespace = make([]string, len(namespaceList.Items))
+	for idx, ns := range namespaceList.Items {
+		namespace[idx] = ns.GetName()
+	}
+	sort.Strings(namespace)
+	return namespace, err
+}
+
+func createProject(client *rancher.Client, clusterID string) (createProject *management.Project, err error) {
+	projectName := provisioning.AppendRandomString("testproject-")
+	projectConfig := &management.Project{
+		ClusterID: clusterID,
+		Name:      projectName,
+	}
+
+	createProject, err = client.Management.Project.Create(projectConfig)
+	return createProject, err
+
+}
+
+func listClusters(client *rancher.Client) (clusterList *collection.ClusterCollection, err error) {
+	clusterList, err = client.Provisioning.Cluster.List(&types.ListOpts{})
+	return clusterList, err
+
+}

--- a/tests/v2/validation/rbac/rbac_test.go
+++ b/tests/v2/validation/rbac/rbac_test.go
@@ -1,0 +1,247 @@
+package rbac
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/extensions/users"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type RBTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	standardUser       *management.User
+	standardUserClient *rancher.Client
+	session            *session.Session
+	cluster            *management.Cluster
+	adminProject       *management.Project
+}
+
+func (rb *RBTestSuite) TearDownSuite() {
+	rb.session.Cleanup()
+}
+
+func (rb *RBTestSuite) SetupSuite() {
+	testSession := session.NewSession(rb.T())
+	rb.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(rb.T(), err)
+
+	rb.client = client
+
+	//Get cluster name from the config file and append cluster details in rb
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(rb.T(), clusterName, "Cluster name to install should be set")
+	clusterID, err := clusters.GetClusterIDByName(rb.client, clusterName)
+	require.NoError(rb.T(), err, "Error getting cluster ID")
+	rb.cluster, err = rb.client.Management.Cluster.ByID(clusterID)
+	require.NoError(rb.T(), err)
+
+}
+
+func (rb *RBTestSuite) ValidateListCluster(role string) {
+
+	//Testcase1 Verify cluster members - Owner/member are able to list clusters
+	clusterList, err := listClusters(rb.standardUserClient)
+	require.NoError(rb.T(), err)
+	assert.Equal(rb.T(), 1, len(clusterList.Data))
+	assert.Equal(rb.T(), rb.cluster.ID, clusterList.Data[0].Status.ClusterName)
+}
+
+func (rb *RBTestSuite) ValidateListProjects(role string) {
+
+	//Testcase2 Verify members of cluster are able to list the projects in a cluster
+	//Get project list as an admin
+	projectlistAdmin, err := listProjects(rb.client, rb.cluster.ID)
+	require.NoError(rb.T(), err)
+	//Get project list as a cluster owner/member
+	projectlistClusterMembers, err := listProjects(rb.standardUserClient, rb.cluster.ID)
+	require.NoError(rb.T(), err)
+	switch role {
+	case roleOwner:
+		//assert length of projects list obtained as an admin and a cluster owner are equal
+		assert.Equal(rb.T(), len(projectlistAdmin), len(projectlistClusterMembers))
+		//assert projects values obtained as an admin and the cluster owner are the same
+		assert.Equal(rb.T(), projectlistAdmin, projectlistClusterMembers)
+	case roleMember:
+		//assert projects list obtained as a cluster member is empty
+		assert.Equal(rb.T(), 0, len(projectlistClusterMembers))
+	}
+}
+
+func (rb *RBTestSuite) ValidateCreateProjects(role string) {
+
+	//Testcase3 Validate if cluster members can create a project in the downstream cluster
+	createProjectAsClusterMembers, err := createProject(rb.client, rb.cluster.ID)
+	require.NoError(rb.T(), err)
+	log.Info("Created project as a ", role, " is ", createProjectAsClusterMembers.Name)
+	require.NoError(rb.T(), err)
+	actualStatus := fmt.Sprintf("%v", rb.adminProject.State)
+	assert.Equal(rb.T(), "active", actualStatus)
+
+}
+
+func (rb *RBTestSuite) ValidateNS(role string) {
+
+	//Testcase4 Validate if cluster members can create namespaces in project they are not owner of
+	log.Info("Testcase4 - Validating if ", role, " can create namespace in a project they are not owner of. ")
+	namespaceName := provisioning.AppendRandomString("testns-")
+	createdNamespace, err := namespaces.CreateNamespace(rb.standardUserClient, namespaceName, "{}", map[string]string{}, map[string]string{}, rb.adminProject)
+	switch role {
+	case roleOwner:
+		require.NoError(rb.T(), err)
+		log.Info("Created a namespace as cluster Owner: ", createdNamespace.Name)
+		assert.Equal(rb.T(), namespaceName, createdNamespace.Name)
+		actualStatus := fmt.Sprintf("%v", createdNamespace.Status.Phase)
+		assert.Equal(rb.T(), "Active", actualStatus)
+	case roleMember:
+		require.Error(rb.T(), err)
+		//assert cluster member gets an error when creating a namespace in a project they are not owner of
+		errMessage := strings.Split(err.Error(), ":")[0]
+		assert.Equal(rb.T(), "namespaces is forbidden", errMessage)
+	}
+
+	//Testcase5 Validate if cluster members are able to list all the namespaces in a cluster
+	log.Info("Testcase5 - Validating if ", role, " can lists all namespaces in a cluster.")
+	//Get the list of namespaces as and admin client
+	namespaceListAdmin, err := getNamespaces(rb.client, rb.cluster.ID)
+	require.NoError(rb.T(), err)
+	//Get the list of namespaces as an admin client
+	namespaceListClusterMembers, err := getNamespaces(rb.standardUserClient, rb.cluster.ID)
+
+	switch role {
+	case roleOwner:
+		require.NoError(rb.T(), err)
+		//Length of namespace list for admin and cluster owner should match
+		assert.Equal(rb.T(), len(namespaceListAdmin), len(namespaceListClusterMembers))
+		//Namespaces obtained as admin and cluster owner should be same
+		assert.Equal(rb.T(), namespaceListAdmin, namespaceListClusterMembers)
+	case roleMember:
+		require.Error(rb.T(), err)
+		errMessage := strings.Split(err.Error(), ":")[0]
+		//assert cluster member is not able to list namespaces
+		assert.Equal(rb.T(), "namespaces is forbidden", errMessage)
+	}
+
+	//Testcase6 Validate if cluster members are able to delete the namespace in the project they are not owner of
+	log.Info("Testcase6 - Validating if ", role, " can delete a namespace from a project they are not owner of.")
+	err = namespaces.DeleteNamespace(rb.standardUserClient, namespaceName, rb.cluster.ID)
+	switch role {
+	case roleOwner:
+		require.NoError(rb.T(), err)
+	case roleMember:
+		require.Error(rb.T(), err)
+	}
+}
+
+func (rb *RBTestSuite) ValidateDeleteProject(role string) {
+
+	//Testcase7 Validate if cluster members are able to delete the project they are not owner of
+	err := rb.standardUserClient.Management.Project.Delete(rb.adminProject)
+
+	switch role {
+	case roleOwner:
+		require.NoError(rb.T(), err)
+	case roleMember:
+		require.Error(rb.T(), err)
+		errStatus := strings.Split(err.Error(), ".")[1]
+		rgx := regexp.MustCompile(`\[(.*?)\]`)
+		errorMsg := rgx.FindStringSubmatch(errStatus)
+		assert.Equal(rb.T(), "403 Forbidden", errorMsg[1])
+	}
+}
+
+func (rb *RBTestSuite) ValidateRemoveClusterRoles(role string) {
+
+	//Testcase8 Remove added cluster member from the cluster as an admin
+	err := users.RemoveClusterRoleFromUser(rb.client, rb.standardUser)
+	require.NoError(rb.T(), err)
+
+}
+
+func (rb *RBTestSuite) TestRBAC() {
+	tests := []struct {
+		name        string
+		clusterRole string
+	}{
+		{"Cluster Owner", "cluster-owner"},
+		{"Cluster Member", "cluster-member"},
+	}
+	for _, tt := range tests {
+		rb.Run("Set up User with Cluster Role "+tt.name, func() {
+			newUser, err := createUser(rb.client)
+			require.NoError(rb.T(), err)
+			rb.standardUser = newUser
+			rb.T().Logf("Created user: %v", rb.standardUser.Username)
+			rb.standardUserClient, err = rb.client.AsUser(newUser)
+			require.NoError(rb.T(), err)
+
+			subSession := rb.session.NewSession()
+			defer subSession.Cleanup()
+
+			createProjectAsAdmin, err := createProject(rb.client, rb.cluster.ID)
+			rb.adminProject = createProjectAsAdmin
+			require.NoError(rb.T(), err)
+		})
+
+		//Verify standard users cannot list any clusters
+		rb.Run("Test case Validate standard users cannot list any downstream clusters before adding the cluster role "+tt.name, func() {
+			_, err := listClusters(rb.standardUserClient)
+			require.Error(rb.T(), err)
+			assert.Equal(rb.T(), "Resource type [provisioning.cattle.io.cluster] is not listable", err.Error())
+		})
+
+		rb.Run("Adding user as "+tt.name+" to the downstream cluster.", func() {
+			//Adding created user to the downstream clusters with the specified roles.
+			err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.standardUser, tt.clusterRole)
+			require.NoError(rb.T(), err)
+			rb.standardUserClient, err = rb.standardUserClient.ReLogin()
+			require.NoError(rb.T(), err)
+		})
+
+		rb.T().Logf("Starting validations for %v", tt.clusterRole)
+
+		rb.Run("Testcase1 - Validating the cluster count obtained as the role "+tt.name, func() {
+			rb.ValidateListCluster(tt.clusterRole)
+		})
+
+		rb.Run("Testcase2 - Validating if members with role "+tt.name+" are able to list all projects", func() {
+			rb.ValidateListProjects(tt.clusterRole)
+		})
+
+		rb.Run("Testcase3 - Validating if members with role "+tt.name+" is able to create a project in the cluster", func() {
+			rb.ValidateCreateProjects(tt.clusterRole)
+
+		})
+
+		rb.Run("Test ase 4 through 6 - Validate namespaces checks for members with role "+tt.name, func() {
+			rb.ValidateNS(tt.clusterRole)
+
+		})
+		rb.Run("Testcase7 - Validating if member with role "+tt.name+" can delete a project they are not owner of ", func() {
+			rb.ValidateDeleteProject(tt.clusterRole)
+		})
+
+		rb.Run("Testcase8 - Validating if member with role "+tt.name+" is removed from the cluster and returns nil clusters", func() {
+			rb.ValidateRemoveClusterRoles(tt.clusterRole)
+		})
+
+	}
+}
+
+func TestRBACTestSuite(t *testing.T) {
+	suite.Run(t, new(RBTestSuite))
+}


### PR DESCRIPTION

 
## Problem
Currently we do not have test suite to validate the P0 use cases for cluster owners/ cluster members that touches v1 endpoints 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
In this PR we are creating a test suite that covers P0 test cases for RBAC cluster owner and cluster member that touches v1 endpoints. Following are the test scenarios covered in the PR:

### Automated Testing

**Cluster Owner:**

1. Standard user cannot list downstream cluster
2. Cluster owner can list the downstream cluster
3. Cluster owner should be able to list projects the user does not own
4. Cluster owner should be able to list namespaces the user does not own
5. Cluster owner should be able to create namespaces in Projects the user does not own
6. Cluster owner should be able to create Projects in the cluster
7. Cluster owner should be able to delete the namespaces they are not owner
8. Cluster owner should be able to delete the projects they are not owner

**Cluster Member:**

1. Cluster member owner can list the downstream cluster
2. Cluster member should NOT be able to list projects the user does not own 
3. Cluster member should NOT be able to list namespaces the user does not own 
4. Cluster member should NOT be able to create namespaces in Projects the user does not own
5. Cluster member should be able to create Projects in the cluster 
6. Cluster Member should be able to delete the namespaces they are not owner
7. Cluster Member should be able to delete the projects they are not owner
