### PR TITLE
Skip ingress rollout check for k3s/rke2 clusters

### DIFF
--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -144,6 +144,8 @@ def test_install_rancher_ha(precheck_certificate_options):
         prepare_hardened_cluster(profile, kubeconfig_path)
     if RANCHER_LOCAL_CLUSTER_TYPE == "RKE":
         check_rke_ingress_rollout()
+    elif RANCHER_LOCAL_CLUSTER_TYPE in ["K3S", "RKE2"]:
+        print("Skipping ingress rollout check for k3s and rke2 clusters")
     else:
         check_ingress_rollout()
     if cm_install:


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
N/A
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The HA create job is failing for k3s/rke2 due to a recent change that I think this will fix
 
