### PR TITLE
Add helper function to get node information and also get nodeIPs

### DIFF
--- a/tests/framework/extensions/nodes/nodes.go
+++ b/tests/framework/extensions/nodes/nodes.go
@@ -1,0 +1,59 @@
+package nodes
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// NodeGroupVersionResource is the required Group Version Resource for accessing nodes in a cluster,
+// using the dynamic client.
+var NodeGroupVersionResource = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "nodes",
+}
+
+// GetNodes returns nodes with metav1.TypeMeta, metav1.ObjectMeta, NodeSpec, and NodeStatus to be used to gather more information from nodes
+func GetNodes(client *rancher.Client, clusterID string, listOpts metav1.ListOptions) ([]corev1.Node, error) {
+	var nodesList []corev1.Node
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeResource := dynamicClient.Resource(NodeGroupVersionResource)
+	nodes, err := nodeResource.List(context.TODO(), listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, unstructuredNode := range nodes.Items {
+		newNode := &corev1.Node{}
+		err := scheme.Scheme.Convert(&unstructuredNode, newNode, unstructuredNode.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		nodesList = append(nodesList, *newNode)
+	}
+
+	return nodesList, err
+}
+
+// GetNodeIP returns node IP, user needs to pass which type they want ExternalIP, InternalIP, Hostname, check core/v1/types.go
+func GetNodeIP(node *corev1.Node, nodeAddressType corev1.NodeAddressType) string {
+	nodeAddressList := node.Status.Addresses
+	for _, ip := range nodeAddressList {
+		if ip.Type == nodeAddressType {
+			return ip.Address
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
This is a part of getting automation put in for qa-task [462](https://github.com/rancher/qa-tasks/issues/462)
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Currently, there is no helper function to get node information and nodeIPs. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Creating a helper function to get node information and get nodeIPs would help improve testing and also expand testing.
- GetNodes() will return a list of nodes corev1.Node
- GetNodeIP() will return node IP list. User will have to pass which address type they want such as External IP, Internal IP, etc.


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manual Testing on local machine was done. Automated testing was not done because I would have to also change another file to add these helper functions into already existing tests. This PR will allow me to move onto getting ssh keys qa-task [462](https://github.com/rancher/qa-tasks/issues/462)