### PR TITLE
Check if serviceAccountTokenSecret exists and remove hardcoded passwords

### DIFF
--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -13,6 +13,7 @@ import (
 	provisioning "github.com/rancher/rancher/tests/framework/clients/rancher/generated/provisioning/v1"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -66,6 +67,27 @@ func IsHostedProvisioningClusterReady(event watch.Event) (ready bool, err error)
 	}
 
 	return false, nil
+}
+
+// Verify if a serviceAccountTokenSecret exists or not in the cluster.
+func CheckServiceAccountTokenSecret(client *rancher.Client, clusterName string) (success bool, err error) {
+	clusterID, err := GetClusterIDByName(client, clusterName)
+	if err != nil {
+		return false, err
+	}
+
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	if err != nil {
+		return false, err
+	}
+
+	if cluster.ServiceAccountTokenSecret != "" {
+		logrus.Infof("serviceAccountTokenSecret in this cluster is: %s", cluster.ServiceAccountTokenSecret)
+		return true, nil
+	} else {
+		logrus.Infof("serviceAccountTokenSecret does not exist in this cluster!")
+		return false, nil
+	}
 }
 
 // NewRKE1lusterConfig is a constructor for a v3.Cluster object, to be used by the rancher.Client.Provisioning client.

--- a/tests/framework/extensions/users/passwordgenerator/passwordgenerator.go
+++ b/tests/framework/extensions/users/passwordgenerator/passwordgenerator.go
@@ -1,0 +1,13 @@
+package users
+
+import (
+	"github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+)
+
+const (
+	defaultPasswordLength = 12
+)
+
+func GenerateUserPassword(password string) string {
+	return namegenerator.RandStringLower(defaultPasswordLength)
+}

--- a/tests/v2/validation/provisioning/hosted/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/hosted_provisioning_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/clusters/eks"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters/gke"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
+	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
@@ -45,9 +46,10 @@ func (h *HostedClusterProvisioningTestSuite) SetupSuite() {
 
 	enabled := true
 	var testuser = provisioning.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
-		Password: "rancherrancher123!",
+		Password: testpassword,
 		Name:     testuser,
 		Enabled:  &enabled,
 	}
@@ -100,6 +102,9 @@ func (h *HostedClusterProvisioningTestSuite) TestProvisioningHostedGKECluster() 
 			require.NoError(h.T(), err)
 			assert.Equal(h.T(), clusterName, clusterResp.Name)
 
+			clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+			require.NoError(h.T(), err)
+			assert.NotEmpty(h.T(), clusterToken)
 		})
 	}
 }
@@ -141,6 +146,9 @@ func (h *HostedClusterProvisioningTestSuite) TestProvisioningHostedAKSCluster() 
 			require.NoError(h.T(), err)
 			assert.Equal(h.T(), clusterName, clusterResp.Name)
 
+			clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+			require.NoError(h.T(), err)
+			assert.NotEmpty(h.T(), clusterToken)
 		})
 	}
 }
@@ -182,6 +190,9 @@ func (h *HostedClusterProvisioningTestSuite) TestProvisioningHostedEKSCluster() 
 			require.NoError(h.T(), err)
 			assert.Equal(h.T(), clusterName, clusterResp.Name)
 
+			clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+			require.NoError(h.T(), err)
+			assert.NotEmpty(h.T(), clusterToken)
 		})
 	}
 }

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -10,6 +10,7 @@ import (
 	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
 	"github.com/rancher/rancher/tests/framework/extensions/tokenregistration"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
+	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
@@ -53,9 +54,10 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 
 	enabled := true
 	var testuser = provisioning.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
-		Password: "rancherrancher123!",
+		Password: testpassword,
 		Name:     testuser,
 		Enabled:  &enabled,
 	}
@@ -146,6 +148,10 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE1CustomCluster(exter
 					err = wait.WatchWait(watchInterface, checkFunc)
 					require.NoError(c.T(), err)
 					assert.Equal(c.T(), clusterName, clusterResp.Name)
+
+					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+					require.NoError(c.T(), err)
+					assert.NotEmpty(c.T(), clusterToken)
 				})
 			}
 		}
@@ -232,6 +238,10 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE1CustomClusterDynami
 					err = wait.WatchWait(watchInterface, checkFunc)
 					require.NoError(c.T(), err)
 					assert.Equal(c.T(), clusterName, clusterResp.Name)
+
+					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+					require.NoError(c.T(), err)
+					assert.NotEmpty(c.T(), clusterToken)
 				})
 			}
 		}

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
+	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
@@ -51,9 +52,10 @@ func (r *RKE1NodeDriverProvisioningTestSuite) SetupSuite() {
 
 	enabled := true
 	var testuser = provisioning.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
-		Password: "rancherrancher123!",
+		Password: testpassword,
 		Name:     testuser,
 		Enabled:  &enabled,
 	}
@@ -162,6 +164,10 @@ func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1Cluster(provider P
 					require.NoError(r.T(), err)
 					assert.Equal(r.T(), clusterName, clusterResp.Name)
 					assert.Equal(r.T(), nodePoolName, nodePool.Name)
+
+					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+					require.NoError(r.T(), err)
+					assert.NotEmpty(r.T(), clusterToken)
 				})
 			}
 		}
@@ -228,6 +234,10 @@ func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1ClusterDynamicInpu
 					require.NoError(r.T(), err)
 					assert.Equal(r.T(), clusterName, clusterResp.Name)
 					assert.Equal(r.T(), nodePoolName, nodePool.Name)
+
+					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+					require.NoError(r.T(), err)
+					assert.NotEmpty(r.T(), clusterToken)
 				})
 			}
 		}

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/tokenregistration"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
+	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
@@ -54,9 +55,10 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 
 	enabled := true
 	var testuser = provisioning.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
-		Password: "rancherrancher123!",
+		Password: testpassword,
 		Name:     testuser,
 		Enabled:  &enabled,
 	}
@@ -151,6 +153,10 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 					err = wait.WatchWait(result, checkFunc)
 					assert.NoError(c.T(), err)
 					assert.Equal(c.T(), clusterName, clusterResp.ObjectMeta.Name)
+
+					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+					require.NoError(c.T(), err)
+					assert.NotEmpty(c.T(), clusterToken)
 				})
 			}
 		}
@@ -241,6 +247,10 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynami
 					err = wait.WatchWait(result, checkFunc)
 					assert.NoError(c.T(), err)
 					assert.Equal(c.T(), clusterName, clusterResp.ObjectMeta.Name)
+
+					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+					require.NoError(c.T(), err)
+					assert.NotEmpty(c.T(), clusterToken)
 				})
 			}
 		}

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
+	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
@@ -58,9 +59,10 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 
 	enabled := true
 	var testuser = provisioning.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
-		Password: "rancherrancher123!",
+		Password: testpassword,
 		Name:     testuser,
 		Enabled:  &enabled,
 	}
@@ -168,6 +170,10 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2Cluster(provider P
 					err = wait.WatchWait(result, checkFunc)
 					assert.NoError(r.T(), err)
 					assert.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
+
+					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+					require.NoError(r.T(), err)
+					assert.NotEmpty(r.T(), clusterToken)
 				})
 			}
 		}
@@ -234,6 +240,10 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2ClusterDynamicInpu
 					err = wait.WatchWait(result, checkFunc)
 					assert.NoError(r.T(), err)
 					assert.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
+
+					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+					require.NoError(r.T(), err)
+					assert.NotEmpty(r.T(), clusterToken)
 				})
 			}
 		}
@@ -320,6 +330,10 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2CNICluster(provide
 					err = wait.WatchWait(result, checkFunc)
 					assert.NoError(r.T(), err)
 					assert.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
+
+					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+					require.NoError(r.T(), err)
+					assert.NotEmpty(r.T(), clusterToken)
 
 					clusterID, err := clusters.GetClusterIDByName(r.client, clusterName)
 					assert.NoError(r.T(), err)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

[Create test to check if serviceAccountTokenSecret parameter appears in cluster's YAML](https://github.com/rancher/qa-tasks/issues/458)

[Update tests to have standard user passwords generated](https://github.com/rancher/rancher/issues/38659
) 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
**Problem 1**
Per the release of 2.6.7, we introduced new parameter `serviceAccountTokenSecret`. This is because previously when looking in a cluster's YAML, the `serviceAccountToken` was fully exposed. Depending on the RBAC, this could be a potential security vulnerability, so `serviceAccountTokenSecret` abstracts the token completely.

As a result, there is a need in our automation to verify that when we provision any cluster that we also check that `serviceAccountTokenSecret` not only exists in the cluster's YAML, but that we verify exactly what it is.

**Problem 2**
In all of our provisioning tests, we were hardcoding the password that the admin and standard user were using to access the supplied Rancher. This isn't good practice as we should not be exposing passwords in our test framework at all; we need to abstract and randomize this as we do with the test user.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
**Solution 1**
`clusters.go` has been given a new function `CheckServiceAccountTokenSecret` which performs a simple check to see if the parameter `serviceAccountTokenSecret` exists in the fully provisioned cluster's YAML. If yes, return the value. If no, return that it does not exist. It does not error out in the negative case, because we should check if it's that specific test that does not contain the `serviceAccountTokenSecret`.

From there, in each of the provisioning tests, added a check after the cluster is validated to be fully stood up and `Active` to then check if the `serviceAccountTokenSecret` exists.

**Solution 2**
Implemented new `passwordgenerator/passwordgenerator.go` folder/file which will reference the `namegenerator` package to create a randomized password. Then, in each provisioning tests, removed the hardcoded password and reference the `GenerateUserPassword` function found in the `passwordgenerator.go` file.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manually tested with RKE1/RKE2 node provider and custom cluster provisioning.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Jenkins runs will be run after this PR is live and will be passed directly to the PR reviewers.