### PR TITLE
Fixed Duration Struct in the Generated V1 Provisioning Client

### DIFF
--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_aci_network_provider.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_aci_network_provider.go
@@ -1,134 +1,156 @@
 package client
 
 const (
-	AciNetworkProviderType                          = "aciNetworkProvider"
-	AciNetworkProviderFieldAEP                      = "aep"
-	AciNetworkProviderFieldApicHosts                = "apicHosts"
-	AciNetworkProviderFieldApicRefreshTime          = "apicRefreshTime"
-	AciNetworkProviderFieldApicUserCrt              = "apicUserCrt"
-	AciNetworkProviderFieldApicUserKey              = "apicUserKey"
-	AciNetworkProviderFieldApicUserName             = "apicUserName"
-	AciNetworkProviderFieldCApic                    = "capic"
-	AciNetworkProviderFieldControllerLogLevel       = "controllerLogLevel"
-	AciNetworkProviderFieldDropLogEnable            = "dropLogEnable"
-	AciNetworkProviderFieldDynamicExternalSubnet    = "externDynamic"
-	AciNetworkProviderFieldEnableEndpointSlice      = "enableEndpointSlice"
-	AciNetworkProviderFieldEncapType                = "encapType"
-	AciNetworkProviderFieldEpRegistry               = "epRegistry"
-	AciNetworkProviderFieldGbpPodSubnet             = "gbpPodSubnet"
-	AciNetworkProviderFieldHostAgentLogLevel        = "hostAgentLogLevel"
-	AciNetworkProviderFieldImagePullPolicy          = "imagePullPolicy"
-	AciNetworkProviderFieldImagePullSecret          = "imagePullSecret"
-	AciNetworkProviderFieldInfraVlan                = "infraVlan"
-	AciNetworkProviderFieldInstallIstio             = "installIstio"
-	AciNetworkProviderFieldIstioProfile             = "istioProfile"
-	AciNetworkProviderFieldKafkaBrokers             = "kafkaBrokers"
-	AciNetworkProviderFieldKafkaClientCrt           = "kafkaClientCrt"
-	AciNetworkProviderFieldKafkaClientKey           = "kafkaClientKey"
-	AciNetworkProviderFieldKubeAPIVlan              = "kubeApiVlan"
-	AciNetworkProviderFieldL3Out                    = "l3out"
-	AciNetworkProviderFieldL3OutExternalNetworks    = "l3outExternalNetworks"
-	AciNetworkProviderFieldMaxNodesSvcGraph         = "maxNodesSvcGraph"
-	AciNetworkProviderFieldMcastRangeEnd            = "mcastRangeEnd"
-	AciNetworkProviderFieldMcastRangeStart          = "mcastRangeStart"
-	AciNetworkProviderFieldNoPriorityClass          = "noPriorityClass"
-	AciNetworkProviderFieldNodeSubnet               = "nodeSubnet"
-	AciNetworkProviderFieldOVSMemoryLimit           = "ovsMemoryLimit"
-	AciNetworkProviderFieldOpflexAgentLogLevel      = "opflexLogLevel"
-	AciNetworkProviderFieldOpflexClientSSL          = "opflexClientSsl"
-	AciNetworkProviderFieldOpflexMode               = "opflexMode"
-	AciNetworkProviderFieldOpflexServerPort         = "opflexServerPort"
-	AciNetworkProviderFieldOverlayVRFName           = "overlayVrfName"
-	AciNetworkProviderFieldPBRTrackingNonSnat       = "pbrTrackingNonSnat"
-	AciNetworkProviderFieldPodSubnetChunkSize       = "podSubnetChunkSize"
-	AciNetworkProviderFieldRunGbpContainer          = "runGbpContainer"
-	AciNetworkProviderFieldRunOpflexServerContainer = "runOpflexServerContainer"
-	AciNetworkProviderFieldServiceGraphSubnet       = "nodeSvcSubnet"
-	AciNetworkProviderFieldServiceMonitorInterval   = "serviceMonitorInterval"
-	AciNetworkProviderFieldServiceVlan              = "serviceVlan"
-	AciNetworkProviderFieldSnatContractScope        = "snatContractScope"
-	AciNetworkProviderFieldSnatNamespace            = "snatNamespace"
-	AciNetworkProviderFieldSnatPortRangeEnd         = "snatPortRangeEnd"
-	AciNetworkProviderFieldSnatPortRangeStart       = "snatPortRangeStart"
-	AciNetworkProviderFieldSnatPortsPerNode         = "snatPortsPerNode"
-	AciNetworkProviderFieldStaticExternalSubnet     = "externStatic"
-	AciNetworkProviderFieldSubnetDomainName         = "subnetDomainName"
-	AciNetworkProviderFieldSystemIdentifier         = "systemId"
-	AciNetworkProviderFieldTenant                   = "tenant"
-	AciNetworkProviderFieldToken                    = "token"
-	AciNetworkProviderFieldUseAciAnywhereCRD        = "useAciAnywhereCrd"
-	AciNetworkProviderFieldUseAciCniPriorityClass   = "useAciCniPriorityClass"
-	AciNetworkProviderFieldUseHostNetnsVolume       = "useHostNetnsVolume"
-	AciNetworkProviderFieldUseOpflexServerVolume    = "useOpflexServerVolume"
-	AciNetworkProviderFieldUsePrivilegedContainer   = "usePrivilegedContainer"
-	AciNetworkProviderFieldVRFName                  = "vrfName"
-	AciNetworkProviderFieldVRFTenant                = "vrfTenant"
-	AciNetworkProviderFieldVmmController            = "vmmController"
-	AciNetworkProviderFieldVmmDomain                = "vmmDomain"
+	AciNetworkProviderType                                   = "aciNetworkProvider"
+	AciNetworkProviderFieldAEP                               = "aep"
+	AciNetworkProviderFieldApicHosts                         = "apicHosts"
+	AciNetworkProviderFieldApicRefreshTickerAdjust           = "apicRefreshTickerAdjust"
+	AciNetworkProviderFieldApicRefreshTime                   = "apicRefreshTime"
+	AciNetworkProviderFieldApicSubscriptionDelay             = "apicSubscriptionDelay"
+	AciNetworkProviderFieldApicUserCrt                       = "apicUserCrt"
+	AciNetworkProviderFieldApicUserKey                       = "apicUserKey"
+	AciNetworkProviderFieldApicUserName                      = "apicUserName"
+	AciNetworkProviderFieldCApic                             = "capic"
+	AciNetworkProviderFieldControllerLogLevel                = "controllerLogLevel"
+	AciNetworkProviderFieldDisablePeriodicSnatGlobalInfoSync = "disablePeriodicSnatGlobalInfoSync"
+	AciNetworkProviderFieldDisableWaitForNetwork             = "disableWaitForNetwork"
+	AciNetworkProviderFieldDropLogEnable                     = "dropLogEnable"
+	AciNetworkProviderFieldDurationWaitForNetwork            = "durationWaitForNetwork"
+	AciNetworkProviderFieldDynamicExternalSubnet             = "externDynamic"
+	AciNetworkProviderFieldEnableEndpointSlice               = "enableEndpointSlice"
+	AciNetworkProviderFieldEncapType                         = "encapType"
+	AciNetworkProviderFieldEpRegistry                        = "epRegistry"
+	AciNetworkProviderFieldGbpPodSubnet                      = "gbpPodSubnet"
+	AciNetworkProviderFieldHostAgentLogLevel                 = "hostAgentLogLevel"
+	AciNetworkProviderFieldImagePullPolicy                   = "imagePullPolicy"
+	AciNetworkProviderFieldImagePullSecret                   = "imagePullSecret"
+	AciNetworkProviderFieldInfraVlan                         = "infraVlan"
+	AciNetworkProviderFieldInstallIstio                      = "installIstio"
+	AciNetworkProviderFieldIstioProfile                      = "istioProfile"
+	AciNetworkProviderFieldKafkaBrokers                      = "kafkaBrokers"
+	AciNetworkProviderFieldKafkaClientCrt                    = "kafkaClientCrt"
+	AciNetworkProviderFieldKafkaClientKey                    = "kafkaClientKey"
+	AciNetworkProviderFieldKubeAPIVlan                       = "kubeApiVlan"
+	AciNetworkProviderFieldL3Out                             = "l3out"
+	AciNetworkProviderFieldL3OutExternalNetworks             = "l3outExternalNetworks"
+	AciNetworkProviderFieldMTUHeadRoom                       = "mtuHeadRoom"
+	AciNetworkProviderFieldMaxNodesSvcGraph                  = "maxNodesSvcGraph"
+	AciNetworkProviderFieldMcastRangeEnd                     = "mcastRangeEnd"
+	AciNetworkProviderFieldMcastRangeStart                   = "mcastRangeStart"
+	AciNetworkProviderFieldMultusDisable                     = "multusDisable"
+	AciNetworkProviderFieldNoPriorityClass                   = "noPriorityClass"
+	AciNetworkProviderFieldNodePodIfEnable                   = "nodePodIfEnable"
+	AciNetworkProviderFieldNodeSubnet                        = "nodeSubnet"
+	AciNetworkProviderFieldOVSMemoryLimit                    = "ovsMemoryLimit"
+	AciNetworkProviderFieldOpflexAgentLogLevel               = "opflexLogLevel"
+	AciNetworkProviderFieldOpflexClientSSL                   = "opflexClientSsl"
+	AciNetworkProviderFieldOpflexDeviceDeleteTimeout         = "opflexDeviceDeleteTimeout"
+	AciNetworkProviderFieldOpflexMode                        = "opflexMode"
+	AciNetworkProviderFieldOpflexServerPort                  = "opflexServerPort"
+	AciNetworkProviderFieldOverlayVRFName                    = "overlayVrfName"
+	AciNetworkProviderFieldPBRTrackingNonSnat                = "pbrTrackingNonSnat"
+	AciNetworkProviderFieldPodSubnetChunkSize                = "podSubnetChunkSize"
+	AciNetworkProviderFieldRunGbpContainer                   = "runGbpContainer"
+	AciNetworkProviderFieldRunOpflexServerContainer          = "runOpflexServerContainer"
+	AciNetworkProviderFieldServiceGraphSubnet                = "nodeSvcSubnet"
+	AciNetworkProviderFieldServiceMonitorInterval            = "serviceMonitorInterval"
+	AciNetworkProviderFieldServiceVlan                       = "serviceVlan"
+	AciNetworkProviderFieldSnatContractScope                 = "snatContractScope"
+	AciNetworkProviderFieldSnatNamespace                     = "snatNamespace"
+	AciNetworkProviderFieldSnatPortRangeEnd                  = "snatPortRangeEnd"
+	AciNetworkProviderFieldSnatPortRangeStart                = "snatPortRangeStart"
+	AciNetworkProviderFieldSnatPortsPerNode                  = "snatPortsPerNode"
+	AciNetworkProviderFieldSriovEnable                       = "sriovEnable"
+	AciNetworkProviderFieldStaticExternalSubnet              = "externStatic"
+	AciNetworkProviderFieldSubnetDomainName                  = "subnetDomainName"
+	AciNetworkProviderFieldSystemIdentifier                  = "systemId"
+	AciNetworkProviderFieldTenant                            = "tenant"
+	AciNetworkProviderFieldToken                             = "token"
+	AciNetworkProviderFieldUseAciAnywhereCRD                 = "useAciAnywhereCrd"
+	AciNetworkProviderFieldUseAciCniPriorityClass            = "useAciCniPriorityClass"
+	AciNetworkProviderFieldUseClusterRole                    = "useClusterRole"
+	AciNetworkProviderFieldUseHostNetnsVolume                = "useHostNetnsVolume"
+	AciNetworkProviderFieldUseOpflexServerVolume             = "useOpflexServerVolume"
+	AciNetworkProviderFieldUsePrivilegedContainer            = "usePrivilegedContainer"
+	AciNetworkProviderFieldVRFName                           = "vrfName"
+	AciNetworkProviderFieldVRFTenant                         = "vrfTenant"
+	AciNetworkProviderFieldVmmController                     = "vmmController"
+	AciNetworkProviderFieldVmmDomain                         = "vmmDomain"
 )
 
 type AciNetworkProvider struct {
-	AEP                      string   `json:"aep,omitempty" yaml:"aep,omitempty"`
-	ApicHosts                []string `json:"apicHosts,omitempty" yaml:"apicHosts,omitempty"`
-	ApicRefreshTime          string   `json:"apicRefreshTime,omitempty" yaml:"apicRefreshTime,omitempty"`
-	ApicUserCrt              string   `json:"apicUserCrt,omitempty" yaml:"apicUserCrt,omitempty"`
-	ApicUserKey              string   `json:"apicUserKey,omitempty" yaml:"apicUserKey,omitempty"`
-	ApicUserName             string   `json:"apicUserName,omitempty" yaml:"apicUserName,omitempty"`
-	CApic                    string   `json:"capic,omitempty" yaml:"capic,omitempty"`
-	ControllerLogLevel       string   `json:"controllerLogLevel,omitempty" yaml:"controllerLogLevel,omitempty"`
-	DropLogEnable            string   `json:"dropLogEnable,omitempty" yaml:"dropLogEnable,omitempty"`
-	DynamicExternalSubnet    string   `json:"externDynamic,omitempty" yaml:"externDynamic,omitempty"`
-	EnableEndpointSlice      string   `json:"enableEndpointSlice,omitempty" yaml:"enableEndpointSlice,omitempty"`
-	EncapType                string   `json:"encapType,omitempty" yaml:"encapType,omitempty"`
-	EpRegistry               string   `json:"epRegistry,omitempty" yaml:"epRegistry,omitempty"`
-	GbpPodSubnet             string   `json:"gbpPodSubnet,omitempty" yaml:"gbpPodSubnet,omitempty"`
-	HostAgentLogLevel        string   `json:"hostAgentLogLevel,omitempty" yaml:"hostAgentLogLevel,omitempty"`
-	ImagePullPolicy          string   `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
-	ImagePullSecret          string   `json:"imagePullSecret,omitempty" yaml:"imagePullSecret,omitempty"`
-	InfraVlan                string   `json:"infraVlan,omitempty" yaml:"infraVlan,omitempty"`
-	InstallIstio             string   `json:"installIstio,omitempty" yaml:"installIstio,omitempty"`
-	IstioProfile             string   `json:"istioProfile,omitempty" yaml:"istioProfile,omitempty"`
-	KafkaBrokers             []string `json:"kafkaBrokers,omitempty" yaml:"kafkaBrokers,omitempty"`
-	KafkaClientCrt           string   `json:"kafkaClientCrt,omitempty" yaml:"kafkaClientCrt,omitempty"`
-	KafkaClientKey           string   `json:"kafkaClientKey,omitempty" yaml:"kafkaClientKey,omitempty"`
-	KubeAPIVlan              string   `json:"kubeApiVlan,omitempty" yaml:"kubeApiVlan,omitempty"`
-	L3Out                    string   `json:"l3out,omitempty" yaml:"l3out,omitempty"`
-	L3OutExternalNetworks    []string `json:"l3outExternalNetworks,omitempty" yaml:"l3outExternalNetworks,omitempty"`
-	MaxNodesSvcGraph         string   `json:"maxNodesSvcGraph,omitempty" yaml:"maxNodesSvcGraph,omitempty"`
-	McastRangeEnd            string   `json:"mcastRangeEnd,omitempty" yaml:"mcastRangeEnd,omitempty"`
-	McastRangeStart          string   `json:"mcastRangeStart,omitempty" yaml:"mcastRangeStart,omitempty"`
-	NoPriorityClass          string   `json:"noPriorityClass,omitempty" yaml:"noPriorityClass,omitempty"`
-	NodeSubnet               string   `json:"nodeSubnet,omitempty" yaml:"nodeSubnet,omitempty"`
-	OVSMemoryLimit           string   `json:"ovsMemoryLimit,omitempty" yaml:"ovsMemoryLimit,omitempty"`
-	OpflexAgentLogLevel      string   `json:"opflexLogLevel,omitempty" yaml:"opflexLogLevel,omitempty"`
-	OpflexClientSSL          string   `json:"opflexClientSsl,omitempty" yaml:"opflexClientSsl,omitempty"`
-	OpflexMode               string   `json:"opflexMode,omitempty" yaml:"opflexMode,omitempty"`
-	OpflexServerPort         string   `json:"opflexServerPort,omitempty" yaml:"opflexServerPort,omitempty"`
-	OverlayVRFName           string   `json:"overlayVrfName,omitempty" yaml:"overlayVrfName,omitempty"`
-	PBRTrackingNonSnat       string   `json:"pbrTrackingNonSnat,omitempty" yaml:"pbrTrackingNonSnat,omitempty"`
-	PodSubnetChunkSize       string   `json:"podSubnetChunkSize,omitempty" yaml:"podSubnetChunkSize,omitempty"`
-	RunGbpContainer          string   `json:"runGbpContainer,omitempty" yaml:"runGbpContainer,omitempty"`
-	RunOpflexServerContainer string   `json:"runOpflexServerContainer,omitempty" yaml:"runOpflexServerContainer,omitempty"`
-	ServiceGraphSubnet       string   `json:"nodeSvcSubnet,omitempty" yaml:"nodeSvcSubnet,omitempty"`
-	ServiceMonitorInterval   string   `json:"serviceMonitorInterval,omitempty" yaml:"serviceMonitorInterval,omitempty"`
-	ServiceVlan              string   `json:"serviceVlan,omitempty" yaml:"serviceVlan,omitempty"`
-	SnatContractScope        string   `json:"snatContractScope,omitempty" yaml:"snatContractScope,omitempty"`
-	SnatNamespace            string   `json:"snatNamespace,omitempty" yaml:"snatNamespace,omitempty"`
-	SnatPortRangeEnd         string   `json:"snatPortRangeEnd,omitempty" yaml:"snatPortRangeEnd,omitempty"`
-	SnatPortRangeStart       string   `json:"snatPortRangeStart,omitempty" yaml:"snatPortRangeStart,omitempty"`
-	SnatPortsPerNode         string   `json:"snatPortsPerNode,omitempty" yaml:"snatPortsPerNode,omitempty"`
-	StaticExternalSubnet     string   `json:"externStatic,omitempty" yaml:"externStatic,omitempty"`
-	SubnetDomainName         string   `json:"subnetDomainName,omitempty" yaml:"subnetDomainName,omitempty"`
-	SystemIdentifier         string   `json:"systemId,omitempty" yaml:"systemId,omitempty"`
-	Tenant                   string   `json:"tenant,omitempty" yaml:"tenant,omitempty"`
-	Token                    string   `json:"token,omitempty" yaml:"token,omitempty"`
-	UseAciAnywhereCRD        string   `json:"useAciAnywhereCrd,omitempty" yaml:"useAciAnywhereCrd,omitempty"`
-	UseAciCniPriorityClass   string   `json:"useAciCniPriorityClass,omitempty" yaml:"useAciCniPriorityClass,omitempty"`
-	UseHostNetnsVolume       string   `json:"useHostNetnsVolume,omitempty" yaml:"useHostNetnsVolume,omitempty"`
-	UseOpflexServerVolume    string   `json:"useOpflexServerVolume,omitempty" yaml:"useOpflexServerVolume,omitempty"`
-	UsePrivilegedContainer   string   `json:"usePrivilegedContainer,omitempty" yaml:"usePrivilegedContainer,omitempty"`
-	VRFName                  string   `json:"vrfName,omitempty" yaml:"vrfName,omitempty"`
-	VRFTenant                string   `json:"vrfTenant,omitempty" yaml:"vrfTenant,omitempty"`
-	VmmController            string   `json:"vmmController,omitempty" yaml:"vmmController,omitempty"`
-	VmmDomain                string   `json:"vmmDomain,omitempty" yaml:"vmmDomain,omitempty"`
+	AEP                               string   `json:"aep,omitempty" yaml:"aep,omitempty"`
+	ApicHosts                         []string `json:"apicHosts,omitempty" yaml:"apicHosts,omitempty"`
+	ApicRefreshTickerAdjust           string   `json:"apicRefreshTickerAdjust,omitempty" yaml:"apicRefreshTickerAdjust,omitempty"`
+	ApicRefreshTime                   string   `json:"apicRefreshTime,omitempty" yaml:"apicRefreshTime,omitempty"`
+	ApicSubscriptionDelay             string   `json:"apicSubscriptionDelay,omitempty" yaml:"apicSubscriptionDelay,omitempty"`
+	ApicUserCrt                       string   `json:"apicUserCrt,omitempty" yaml:"apicUserCrt,omitempty"`
+	ApicUserKey                       string   `json:"apicUserKey,omitempty" yaml:"apicUserKey,omitempty"`
+	ApicUserName                      string   `json:"apicUserName,omitempty" yaml:"apicUserName,omitempty"`
+	CApic                             string   `json:"capic,omitempty" yaml:"capic,omitempty"`
+	ControllerLogLevel                string   `json:"controllerLogLevel,omitempty" yaml:"controllerLogLevel,omitempty"`
+	DisablePeriodicSnatGlobalInfoSync string   `json:"disablePeriodicSnatGlobalInfoSync,omitempty" yaml:"disablePeriodicSnatGlobalInfoSync,omitempty"`
+	DisableWaitForNetwork             string   `json:"disableWaitForNetwork,omitempty" yaml:"disableWaitForNetwork,omitempty"`
+	DropLogEnable                     string   `json:"dropLogEnable,omitempty" yaml:"dropLogEnable,omitempty"`
+	DurationWaitForNetwork            string   `json:"durationWaitForNetwork,omitempty" yaml:"durationWaitForNetwork,omitempty"`
+	DynamicExternalSubnet             string   `json:"externDynamic,omitempty" yaml:"externDynamic,omitempty"`
+	EnableEndpointSlice               string   `json:"enableEndpointSlice,omitempty" yaml:"enableEndpointSlice,omitempty"`
+	EncapType                         string   `json:"encapType,omitempty" yaml:"encapType,omitempty"`
+	EpRegistry                        string   `json:"epRegistry,omitempty" yaml:"epRegistry,omitempty"`
+	GbpPodSubnet                      string   `json:"gbpPodSubnet,omitempty" yaml:"gbpPodSubnet,omitempty"`
+	HostAgentLogLevel                 string   `json:"hostAgentLogLevel,omitempty" yaml:"hostAgentLogLevel,omitempty"`
+	ImagePullPolicy                   string   `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
+	ImagePullSecret                   string   `json:"imagePullSecret,omitempty" yaml:"imagePullSecret,omitempty"`
+	InfraVlan                         string   `json:"infraVlan,omitempty" yaml:"infraVlan,omitempty"`
+	InstallIstio                      string   `json:"installIstio,omitempty" yaml:"installIstio,omitempty"`
+	IstioProfile                      string   `json:"istioProfile,omitempty" yaml:"istioProfile,omitempty"`
+	KafkaBrokers                      []string `json:"kafkaBrokers,omitempty" yaml:"kafkaBrokers,omitempty"`
+	KafkaClientCrt                    string   `json:"kafkaClientCrt,omitempty" yaml:"kafkaClientCrt,omitempty"`
+	KafkaClientKey                    string   `json:"kafkaClientKey,omitempty" yaml:"kafkaClientKey,omitempty"`
+	KubeAPIVlan                       string   `json:"kubeApiVlan,omitempty" yaml:"kubeApiVlan,omitempty"`
+	L3Out                             string   `json:"l3out,omitempty" yaml:"l3out,omitempty"`
+	L3OutExternalNetworks             []string `json:"l3outExternalNetworks,omitempty" yaml:"l3outExternalNetworks,omitempty"`
+	MTUHeadRoom                       string   `json:"mtuHeadRoom,omitempty" yaml:"mtuHeadRoom,omitempty"`
+	MaxNodesSvcGraph                  string   `json:"maxNodesSvcGraph,omitempty" yaml:"maxNodesSvcGraph,omitempty"`
+	McastRangeEnd                     string   `json:"mcastRangeEnd,omitempty" yaml:"mcastRangeEnd,omitempty"`
+	McastRangeStart                   string   `json:"mcastRangeStart,omitempty" yaml:"mcastRangeStart,omitempty"`
+	MultusDisable                     string   `json:"multusDisable,omitempty" yaml:"multusDisable,omitempty"`
+	NoPriorityClass                   string   `json:"noPriorityClass,omitempty" yaml:"noPriorityClass,omitempty"`
+	NodePodIfEnable                   string   `json:"nodePodIfEnable,omitempty" yaml:"nodePodIfEnable,omitempty"`
+	NodeSubnet                        string   `json:"nodeSubnet,omitempty" yaml:"nodeSubnet,omitempty"`
+	OVSMemoryLimit                    string   `json:"ovsMemoryLimit,omitempty" yaml:"ovsMemoryLimit,omitempty"`
+	OpflexAgentLogLevel               string   `json:"opflexLogLevel,omitempty" yaml:"opflexLogLevel,omitempty"`
+	OpflexClientSSL                   string   `json:"opflexClientSsl,omitempty" yaml:"opflexClientSsl,omitempty"`
+	OpflexDeviceDeleteTimeout         string   `json:"opflexDeviceDeleteTimeout,omitempty" yaml:"opflexDeviceDeleteTimeout,omitempty"`
+	OpflexMode                        string   `json:"opflexMode,omitempty" yaml:"opflexMode,omitempty"`
+	OpflexServerPort                  string   `json:"opflexServerPort,omitempty" yaml:"opflexServerPort,omitempty"`
+	OverlayVRFName                    string   `json:"overlayVrfName,omitempty" yaml:"overlayVrfName,omitempty"`
+	PBRTrackingNonSnat                string   `json:"pbrTrackingNonSnat,omitempty" yaml:"pbrTrackingNonSnat,omitempty"`
+	PodSubnetChunkSize                string   `json:"podSubnetChunkSize,omitempty" yaml:"podSubnetChunkSize,omitempty"`
+	RunGbpContainer                   string   `json:"runGbpContainer,omitempty" yaml:"runGbpContainer,omitempty"`
+	RunOpflexServerContainer          string   `json:"runOpflexServerContainer,omitempty" yaml:"runOpflexServerContainer,omitempty"`
+	ServiceGraphSubnet                string   `json:"nodeSvcSubnet,omitempty" yaml:"nodeSvcSubnet,omitempty"`
+	ServiceMonitorInterval            string   `json:"serviceMonitorInterval,omitempty" yaml:"serviceMonitorInterval,omitempty"`
+	ServiceVlan                       string   `json:"serviceVlan,omitempty" yaml:"serviceVlan,omitempty"`
+	SnatContractScope                 string   `json:"snatContractScope,omitempty" yaml:"snatContractScope,omitempty"`
+	SnatNamespace                     string   `json:"snatNamespace,omitempty" yaml:"snatNamespace,omitempty"`
+	SnatPortRangeEnd                  string   `json:"snatPortRangeEnd,omitempty" yaml:"snatPortRangeEnd,omitempty"`
+	SnatPortRangeStart                string   `json:"snatPortRangeStart,omitempty" yaml:"snatPortRangeStart,omitempty"`
+	SnatPortsPerNode                  string   `json:"snatPortsPerNode,omitempty" yaml:"snatPortsPerNode,omitempty"`
+	SriovEnable                       string   `json:"sriovEnable,omitempty" yaml:"sriovEnable,omitempty"`
+	StaticExternalSubnet              string   `json:"externStatic,omitempty" yaml:"externStatic,omitempty"`
+	SubnetDomainName                  string   `json:"subnetDomainName,omitempty" yaml:"subnetDomainName,omitempty"`
+	SystemIdentifier                  string   `json:"systemId,omitempty" yaml:"systemId,omitempty"`
+	Tenant                            string   `json:"tenant,omitempty" yaml:"tenant,omitempty"`
+	Token                             string   `json:"token,omitempty" yaml:"token,omitempty"`
+	UseAciAnywhereCRD                 string   `json:"useAciAnywhereCrd,omitempty" yaml:"useAciAnywhereCrd,omitempty"`
+	UseAciCniPriorityClass            string   `json:"useAciCniPriorityClass,omitempty" yaml:"useAciCniPriorityClass,omitempty"`
+	UseClusterRole                    string   `json:"useClusterRole,omitempty" yaml:"useClusterRole,omitempty"`
+	UseHostNetnsVolume                string   `json:"useHostNetnsVolume,omitempty" yaml:"useHostNetnsVolume,omitempty"`
+	UseOpflexServerVolume             string   `json:"useOpflexServerVolume,omitempty" yaml:"useOpflexServerVolume,omitempty"`
+	UsePrivilegedContainer            string   `json:"usePrivilegedContainer,omitempty" yaml:"usePrivilegedContainer,omitempty"`
+	VRFName                           string   `json:"vrfName,omitempty" yaml:"vrfName,omitempty"`
+	VRFTenant                         string   `json:"vrfTenant,omitempty" yaml:"vrfTenant,omitempty"`
+	VmmController                     string   `json:"vmmController,omitempty" yaml:"vmmController,omitempty"`
+	VmmDomain                         string   `json:"vmmDomain,omitempty" yaml:"vmmDomain,omitempty"`
 }

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_catalog.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_catalog.go
@@ -8,6 +8,7 @@ const (
 	CatalogType                      = "catalog"
 	CatalogFieldAnnotations          = "annotations"
 	CatalogFieldBranch               = "branch"
+	CatalogFieldCatalogSecrets       = "catalogSecrets"
 	CatalogFieldCommit               = "commit"
 	CatalogFieldConditions           = "conditions"
 	CatalogFieldCreated              = "created"
@@ -34,6 +35,7 @@ type Catalog struct {
 	types.Resource
 	Annotations          map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Branch               string             `json:"branch,omitempty" yaml:"branch,omitempty"`
+	CatalogSecrets       *CatalogSecrets    `json:"catalogSecrets,omitempty" yaml:"catalogSecrets,omitempty"`
 	Commit               string             `json:"commit,omitempty" yaml:"commit,omitempty"`
 	Conditions           []CatalogCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 	Created              string             `json:"created,omitempty" yaml:"created,omitempty"`

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_catalog_secrets.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_catalog_secrets.go
@@ -1,0 +1,10 @@
+package client
+
+const (
+	CatalogSecretsType                  = "catalogSecrets"
+	CatalogSecretsFieldCredentialSecret = "credentialSecret"
+)
+
+type CatalogSecrets struct {
+	CredentialSecret string `json:"credentialSecret,omitempty" yaml:"credentialSecret,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_catalog_spec.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_catalog_spec.go
@@ -1,22 +1,24 @@
 package client
 
 const (
-	CatalogSpecType             = "catalogSpec"
-	CatalogSpecFieldBranch      = "branch"
-	CatalogSpecFieldCatalogKind = "catalogKind"
-	CatalogSpecFieldDescription = "description"
-	CatalogSpecFieldHelmVersion = "helmVersion"
-	CatalogSpecFieldPassword    = "password"
-	CatalogSpecFieldURL         = "url"
-	CatalogSpecFieldUsername    = "username"
+	CatalogSpecType                = "catalogSpec"
+	CatalogSpecFieldBranch         = "branch"
+	CatalogSpecFieldCatalogKind    = "catalogKind"
+	CatalogSpecFieldCatalogSecrets = "catalogSecrets"
+	CatalogSpecFieldDescription    = "description"
+	CatalogSpecFieldHelmVersion    = "helmVersion"
+	CatalogSpecFieldPassword       = "password"
+	CatalogSpecFieldURL            = "url"
+	CatalogSpecFieldUsername       = "username"
 )
 
 type CatalogSpec struct {
-	Branch      string `json:"branch,omitempty" yaml:"branch,omitempty"`
-	CatalogKind string `json:"catalogKind,omitempty" yaml:"catalogKind,omitempty"`
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-	HelmVersion string `json:"helmVersion,omitempty" yaml:"helmVersion,omitempty"`
-	Password    string `json:"password,omitempty" yaml:"password,omitempty"`
-	URL         string `json:"url,omitempty" yaml:"url,omitempty"`
-	Username    string `json:"username,omitempty" yaml:"username,omitempty"`
+	Branch         string          `json:"branch,omitempty" yaml:"branch,omitempty"`
+	CatalogKind    string          `json:"catalogKind,omitempty" yaml:"catalogKind,omitempty"`
+	CatalogSecrets *CatalogSecrets `json:"catalogSecrets,omitempty" yaml:"catalogSecrets,omitempty"`
+	Description    string          `json:"description,omitempty" yaml:"description,omitempty"`
+	HelmVersion    string          `json:"helmVersion,omitempty" yaml:"helmVersion,omitempty"`
+	Password       string          `json:"password,omitempty" yaml:"password,omitempty"`
+	URL            string          `json:"url,omitempty" yaml:"url,omitempty"`
+	Username       string          `json:"username,omitempty" yaml:"username,omitempty"`
 }

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster.go
@@ -26,6 +26,7 @@ const (
 	ClusterFieldCapabilities                         = "capabilities"
 	ClusterFieldCapacity                             = "capacity"
 	ClusterFieldCertificatesExpiration               = "certificatesExpiration"
+	ClusterFieldClusterSecrets                       = "clusterSecrets"
 	ClusterFieldClusterTemplateAnswers               = "answers"
 	ClusterFieldClusterTemplateID                    = "clusterTemplateId"
 	ClusterFieldClusterTemplateQuestions             = "questions"
@@ -109,6 +110,7 @@ type Cluster struct {
 	Capabilities                         *Capabilities                  `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
 	Capacity                             map[string]string              `json:"capacity,omitempty" yaml:"capacity,omitempty"`
 	CertificatesExpiration               map[string]CertExpiration      `json:"certificatesExpiration,omitempty" yaml:"certificatesExpiration,omitempty"`
+	ClusterSecrets                       *ClusterSecrets                `json:"clusterSecrets,omitempty" yaml:"clusterSecrets,omitempty"`
 	ClusterTemplateAnswers               *Answer                        `json:"answers,omitempty" yaml:"answers,omitempty"`
 	ClusterTemplateID                    string                         `json:"clusterTemplateId,omitempty" yaml:"clusterTemplateId,omitempty"`
 	ClusterTemplateQuestions             []Question                     `json:"questions,omitempty" yaml:"questions,omitempty"`

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_catalog.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_catalog.go
@@ -8,6 +8,7 @@ const (
 	ClusterCatalogType                      = "clusterCatalog"
 	ClusterCatalogFieldAnnotations          = "annotations"
 	ClusterCatalogFieldBranch               = "branch"
+	ClusterCatalogFieldCatalogSecrets       = "catalogSecrets"
 	ClusterCatalogFieldClusterID            = "clusterId"
 	ClusterCatalogFieldCommit               = "commit"
 	ClusterCatalogFieldConditions           = "conditions"
@@ -36,6 +37,7 @@ type ClusterCatalog struct {
 	types.Resource
 	Annotations          map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Branch               string             `json:"branch,omitempty" yaml:"branch,omitempty"`
+	CatalogSecrets       *CatalogSecrets    `json:"catalogSecrets,omitempty" yaml:"catalogSecrets,omitempty"`
 	ClusterID            string             `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
 	Commit               string             `json:"commit,omitempty" yaml:"commit,omitempty"`
 	Conditions           []CatalogCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_secrets.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_secrets.go
@@ -1,0 +1,24 @@
+package client
+
+const (
+	ClusterSecretsType                       = "clusterSecrets"
+	ClusterSecretsFieldAADClientCertSecret   = "aadClientCertSecret"
+	ClusterSecretsFieldAADClientSecret       = "aadClientSecret"
+	ClusterSecretsFieldOpenStackSecret       = "openStackSecret"
+	ClusterSecretsFieldPrivateRegistrySecret = "privateRegistrySecret"
+	ClusterSecretsFieldS3CredentialSecret    = "s3CredentialSecret"
+	ClusterSecretsFieldVirtualCenterSecret   = "virtualCenterSecret"
+	ClusterSecretsFieldVsphereSecret         = "vsphereSecret"
+	ClusterSecretsFieldWeavePasswordSecret   = "weavePasswordSecret"
+)
+
+type ClusterSecrets struct {
+	AADClientCertSecret   string `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
+	AADClientSecret       string `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
+	OpenStackSecret       string `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
+	PrivateRegistrySecret string `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
+	S3CredentialSecret    string `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
+	VirtualCenterSecret   string `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
+	VsphereSecret         string `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
+	WeavePasswordSecret   string `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_spec.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_spec.go
@@ -7,6 +7,7 @@ const (
 	ClusterSpecFieldAgentImageOverride                  = "agentImageOverride"
 	ClusterSpecFieldAmazonElasticContainerServiceConfig = "amazonElasticContainerServiceConfig"
 	ClusterSpecFieldAzureKubernetesServiceConfig        = "azureKubernetesServiceConfig"
+	ClusterSpecFieldClusterSecrets                      = "clusterSecrets"
 	ClusterSpecFieldClusterTemplateAnswers              = "answers"
 	ClusterSpecFieldClusterTemplateID                   = "clusterTemplateId"
 	ClusterSpecFieldClusterTemplateQuestions            = "questions"
@@ -42,6 +43,7 @@ type ClusterSpec struct {
 	AgentImageOverride                  string                         `json:"agentImageOverride,omitempty" yaml:"agentImageOverride,omitempty"`
 	AmazonElasticContainerServiceConfig map[string]interface{}         `json:"amazonElasticContainerServiceConfig,omitempty" yaml:"amazonElasticContainerServiceConfig,omitempty"`
 	AzureKubernetesServiceConfig        map[string]interface{}         `json:"azureKubernetesServiceConfig,omitempty" yaml:"azureKubernetesServiceConfig,omitempty"`
+	ClusterSecrets                      *ClusterSecrets                `json:"clusterSecrets,omitempty" yaml:"clusterSecrets,omitempty"`
 	ClusterTemplateAnswers              *Answer                        `json:"answers,omitempty" yaml:"answers,omitempty"`
 	ClusterTemplateID                   string                         `json:"clusterTemplateId,omitempty" yaml:"clusterTemplateId,omitempty"`
 	ClusterTemplateQuestions            []Question                     `json:"questions,omitempty" yaml:"questions,omitempty"`

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_spec_base.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_spec_base.go
@@ -4,6 +4,7 @@ const (
 	ClusterSpecBaseType                                     = "clusterSpecBase"
 	ClusterSpecBaseFieldAgentEnvVars                        = "agentEnvVars"
 	ClusterSpecBaseFieldAgentImageOverride                  = "agentImageOverride"
+	ClusterSpecBaseFieldClusterSecrets                      = "clusterSecrets"
 	ClusterSpecBaseFieldDefaultClusterRoleForProjectMembers = "defaultClusterRoleForProjectMembers"
 	ClusterSpecBaseFieldDefaultPodSecurityPolicyTemplateID  = "defaultPodSecurityPolicyTemplateId"
 	ClusterSpecBaseFieldDesiredAgentImage                   = "desiredAgentImage"
@@ -21,6 +22,7 @@ const (
 type ClusterSpecBase struct {
 	AgentEnvVars                        []EnvVar                       `json:"agentEnvVars,omitempty" yaml:"agentEnvVars,omitempty"`
 	AgentImageOverride                  string                         `json:"agentImageOverride,omitempty" yaml:"agentImageOverride,omitempty"`
+	ClusterSecrets                      *ClusterSecrets                `json:"clusterSecrets,omitempty" yaml:"clusterSecrets,omitempty"`
 	DefaultClusterRoleForProjectMembers string                         `json:"defaultClusterRoleForProjectMembers,omitempty" yaml:"defaultClusterRoleForProjectMembers,omitempty"`
 	DefaultPodSecurityPolicyTemplateID  string                         `json:"defaultPodSecurityPolicyTemplateId,omitempty" yaml:"defaultPodSecurityPolicyTemplateId,omitempty"`
 	DesiredAgentImage                   string                         `json:"desiredAgentImage,omitempty" yaml:"desiredAgentImage,omitempty"`

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_project_catalog.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_project_catalog.go
@@ -8,6 +8,7 @@ const (
 	ProjectCatalogType                      = "projectCatalog"
 	ProjectCatalogFieldAnnotations          = "annotations"
 	ProjectCatalogFieldBranch               = "branch"
+	ProjectCatalogFieldCatalogSecrets       = "catalogSecrets"
 	ProjectCatalogFieldCommit               = "commit"
 	ProjectCatalogFieldConditions           = "conditions"
 	ProjectCatalogFieldCreated              = "created"
@@ -36,6 +37,7 @@ type ProjectCatalog struct {
 	types.Resource
 	Annotations          map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Branch               string             `json:"branch,omitempty" yaml:"branch,omitempty"`
+	CatalogSecrets       *CatalogSecrets    `json:"catalogSecrets,omitempty" yaml:"catalogSecrets,omitempty"`
 	Commit               string             `json:"commit,omitempty" yaml:"commit,omitempty"`
 	Conditions           []CatalogCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 	Created              string             `json:"created,omitempty" yaml:"created,omitempty"`

--- a/tests/framework/clients/rancher/generated/provisioning/v1/zz_generated_duration.go
+++ b/tests/framework/clients/rancher/generated/provisioning/v1/zz_generated_duration.go
@@ -1,8 +1,10 @@
 package client
 
 const (
-	DurationType = "duration"
+	DurationType          = "duration"
+	DurationFieldDuration = "duration"
 )
 
 type Duration struct {
+	Duration string `json:"duration,omitempty" yaml:"duration,omitempty"`
 }

--- a/tests/framework/pkg/schemas/provisioning.cattle.io/v1/schema.go
+++ b/tests/framework/pkg/schemas/provisioning.cattle.io/v1/schema.go
@@ -23,8 +23,8 @@ func clusterTypes(schemas *types.Schemas) *types.Schemas {
 		m.Drop{Field: "chartValues"},
 		&m.ChangeType{Field: "machineGlobalConfig", Type: "MachineGlobalConfig"}).
 		MustImport(&Version, MachineGlobalConfig{}).
-		MustImportAndCustomize(&Version, v1.RKEConfig{}, func(schema *types.Schema) {}).
 		MustImportAndCustomize(&Version, metav1.Duration{}, func(schema *types.Schema) {}, Duration{}).
+		MustImportAndCustomize(&Version, v1.RKEConfig{}, func(schema *types.Schema) {}).
 		MustImportAndCustomize(&Version, v1.Cluster{}, func(schema *types.Schema) {
 			schema.ID = "provisioning.cattle.io.cluster"
 		})


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> When the structs for the v1 Provisioning client were generated, Duration was coming up as empty struct. This was because of the original struct was using protobuf instead of json to unmarshall the API response.
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. --> When using the provisioning to do a get or list, it would return an unmarshall error. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. --> Fixed the order of importing the appropriate structs. Also included some v3 updates, as the generation code is all together.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. --> Locally provisioned a cluster, and did a list call.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->