### PR TITLE
Prevent circular role inheretance causing a crash

### DIFF
--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -147,7 +147,7 @@ func (c *crtbLifecycle) reconcileBindings(binding *v3.ClusterRoleTemplateBinding
 		return errors.Errorf("cannot create binding because cluster %v was not found", clusterName)
 	}
 	// if roletemplate is not builtin, check if it's inherited/cloned
-	isOwnerRole, err := c.mgr.checkReferencedRoles(binding.RoleTemplateName, clusterContext)
+	isOwnerRole, err := c.mgr.checkReferencedRoles(binding.RoleTemplateName, clusterContext, 0)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/management/auth/manager_test.go
+++ b/pkg/controllers/management/auth/manager_test.go
@@ -1,0 +1,93 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	fakes "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var roles = map[string]*v3.RoleTemplate{
+	"recursive1": {
+		RoleTemplateNames: []string{"recursive2"},
+	},
+	"recursive2": {
+		RoleTemplateNames: []string{"recursive1"},
+	},
+	"non-recursive": {},
+	"inherit non-recursive": {
+		RoleTemplateNames: []string{"non-recursive"},
+	},
+}
+
+func Test_checkReferencedRoles(t *testing.T) {
+	manager := &manager{
+		rtLister: &fakes.RoleTemplateListerMock{
+			GetFunc: roleListerGetFunc,
+		},
+	}
+
+	type args struct {
+		rtName       string
+		rtContext    string
+		depthCounter int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Non-recursive role, none inherited",
+			args: args{
+				rtName:       "non-recursive",
+				rtContext:    "",
+				depthCounter: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Non-recursive role, inherits another",
+			args: args{
+				rtName:       "inherit non-recursive",
+				rtContext:    "",
+				depthCounter: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Recursive role",
+			args: args{
+				rtName:       "recursive1",
+				rtContext:    "",
+				depthCounter: 0,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := manager.checkReferencedRoles(tt.args.rtName, tt.args.rtContext, tt.args.depthCounter)
+			if tt.wantErr {
+				assert.Error(t, err, "expected an error, got none")
+			} else {
+				assert.NoError(t, err, fmt.Sprintf("expected no error, got: %v", err))
+			}
+		})
+	}
+}
+
+func roleListerGetFunc(ns, name string) (*v3.RoleTemplate, error) {
+	role, ok := roles[name]
+	if !ok {
+		return nil, errors.NewNotFound(schema.GroupResource{
+			Group:    v3.RoleTemplateGroupVersionKind.Group,
+			Resource: v3.RoleTemplateGroupVersionResource.Resource,
+		}, name)
+	}
+	return role, nil
+}

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -171,7 +171,7 @@ func (p *prtbLifecycle) reconcileBindings(binding *v3.ProjectRoleTemplateBinding
 
 	roleName := strings.ToLower(fmt.Sprintf("%v-clustermember", clusterName))
 	// if roletemplate is not builtin, check if it's inherited/cloned
-	isOwnerRole, err := p.mgr.checkReferencedRoles(binding.RoleTemplateName, projectContext)
+	isOwnerRole, err := p.mgr.checkReferencedRoles(binding.RoleTemplateName, projectContext, 0)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/managementuser/rbac/crtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/crtb_handler.go
@@ -56,7 +56,7 @@ func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding) error {
 	}
 
 	roles := map[string]*v3.RoleTemplate{}
-	if err := c.m.gatherRoles(rt, roles); err != nil {
+	if err := c.m.gatherRoles(rt, roles, 0); err != nil {
 		return err
 	}
 

--- a/pkg/controllers/managementuser/rbac/handler_base_test.go
+++ b/pkg/controllers/managementuser/rbac/handler_base_test.go
@@ -1,0 +1,94 @@
+package rbac
+
+import (
+	"fmt"
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	fakes "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var roles = map[string]*v3.RoleTemplate{
+	"recursive1": {
+		RoleTemplateNames: []string{"recursive2"},
+	},
+	"recursive2": {
+		RoleTemplateNames: []string{"recursive1"},
+	},
+	"non-recursive": {},
+	"inherit non-recursive": {
+		RoleTemplateNames: []string{"non-recursive"},
+	},
+}
+
+func Test_gatherRoles(t *testing.T) {
+	manager := &manager{
+		rtLister: &fakes.RoleTemplateListerMock{
+			GetFunc: roleListerGetFunc,
+		},
+	}
+	emptyRoleTemplates := make(map[string]*v3.RoleTemplate)
+	type args struct {
+		rt            *v3.RoleTemplate
+		roleTemplates map[string]*v3.RoleTemplate
+		depthCounter  int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Non-recursive role, none inherited",
+			args: args{
+				rt:            roles["non-recursive"],
+				roleTemplates: emptyRoleTemplates,
+				depthCounter:  0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Non-recursive role, inherits another",
+			args: args{
+				rt:            roles["inherit non-recursive"],
+				roleTemplates: emptyRoleTemplates,
+				depthCounter:  0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Recursive role",
+			args: args{
+				rt:            roles["recursive1"],
+				roleTemplates: emptyRoleTemplates,
+				depthCounter:  0,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := manager.gatherRoles(tt.args.rt, tt.args.roleTemplates, tt.args.depthCounter)
+			if tt.wantErr {
+				assert.Error(t, err, "expected an error, received none")
+			} else {
+				assert.NoError(t, err, fmt.Sprintf("expected no err, got %v", err))
+			}
+		})
+	}
+}
+
+func roleListerGetFunc(ns, name string) (*v3.RoleTemplate, error) {
+	role, ok := roles[name]
+	if !ok {
+		return nil, errors.NewNotFound(schema.GroupResource{
+			Group:    v3.RoleTemplateGroupVersionKind.Group,
+			Resource: v3.RoleTemplateGroupVersionResource.Resource,
+		}, name)
+	}
+	return role, nil
+}

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -238,7 +238,7 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 		}
 
 		roles := map[string]*v3.RoleTemplate{}
-		if err := n.m.gatherRoles(rt, roles); err != nil {
+		if err := n.m.gatherRoles(rt, roles, 0); err != nil {
 			return false, err
 		}
 

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -101,7 +101,7 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 		return errors.Wrapf(err, "couldn't list namespaces with project ID %v", binding.ProjectName)
 	}
 	roles := map[string]*v3.RoleTemplate{}
-	if err := p.m.gatherRoles(rt, roles); err != nil {
+	if err := p.m.gatherRoles(rt, roles, 0); err != nil {
 		return err
 	}
 

--- a/pkg/controllers/managementuser/rbac/roletemplate_handler.go
+++ b/pkg/controllers/managementuser/rbac/roletemplate_handler.go
@@ -55,7 +55,7 @@ func (c *rtSync) sync(key string, obj *v3.RoleTemplate) (runtime.Object, error) 
 
 func (c *rtSync) syncRT(template *v3.RoleTemplate, usedInProjects bool, prtbs []interface{}, crtbs []interface{}) error {
 	roles := map[string]*v3.RoleTemplate{}
-	if err := c.m.gatherRoles(template, roles); err != nil {
+	if err := c.m.gatherRoles(template, roles, 0); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is in addition to the validation done in #38419

## Issue: 
#38419

## Problem
Roles referencing a role that references the first role cause a stack overflow when attempting to gather all the roles related to the role.
 
## Solution
Track how many time the function has recursed. At the soft-limit of 100, a warning is logged. The upper limit originally discussed was 1000, but that still caused a stack overflow before reaching that limit so I've lowered it to 500.
 
## Testing


## Engineering Testing
### Manual Testing
Created a roletemplate and used it to on a user. Got the expected output.