### PR TITLE
OpenLDAP re-bind SA as fallback

### DIFF
--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -73,6 +73,19 @@ func (p *ldapProvider) loginUser(credential *v32.BasicLogin, config *v3.LdapConf
 		fmt.Sprintf("(%v=%v)", ObjectClass, config.UserObjectClass),
 		operationalAttrList, nil)
 	opResult, err := lConn.Search(searchOpRequest)
+
+	// If no object is found, try again using SA
+	if err != nil && ldapv3.IsErrorWithCode(err, ldapv3.LDAPResultNoSuchObject) {
+		// Re-bind SA
+		err = ldap.AuthenticateServiceAccountUser(serviceAccountPassword, serviceAccountUserName, "", lConn)
+		if err != nil {
+			return v3.Principal{}, nil, err
+		}
+
+		// Re-execute the search
+		opResult, err = lConn.Search(searchOpRequest)
+	}
+
 	if err != nil {
 		return v3.Principal{}, nil, httperror.WrapAPIError(err, httperror.Unauthorized, "authentication failed") // need to reload this error
 	}

--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -74,9 +74,9 @@ func (p *ldapProvider) loginUser(credential *v32.BasicLogin, config *v3.LdapConf
 		operationalAttrList, nil)
 	opResult, err := lConn.Search(searchOpRequest)
 
-	// If no object is found, try again using SA
+	// If no object is found, try again using the service account
 	if err != nil && ldapv3.IsErrorWithCode(err, ldapv3.LDAPResultNoSuchObject) {
-		// Re-bind SA
+		// Re-bind the service account
 		err = ldap.AuthenticateServiceAccountUser(serviceAccountPassword, serviceAccountUserName, "", lConn)
 		if err != nil {
 			return v3.Principal{}, nil, httperror.WrapAPIError(err, httperror.Unauthorized, "authentication failed")

--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -79,7 +79,7 @@ func (p *ldapProvider) loginUser(credential *v32.BasicLogin, config *v3.LdapConf
 		// Re-bind SA
 		err = ldap.AuthenticateServiceAccountUser(serviceAccountPassword, serviceAccountUserName, "", lConn)
 		if err != nil {
-			return v3.Principal{}, nil, err
+			return v3.Principal{}, nil, httperror.WrapAPIError(err, httperror.Unauthorized, "authentication failed")
 		}
 
 		// Re-execute the search


### PR DESCRIPTION
## Issue: #25165 / #35259 / #17854
 
## Problem
LDAP searches are done with user credentials, which fails when that user does not have "LDAP bind DN" (error 32 "No Such Object").
 
## Solution
Re-bind the service account when this error occurs as discussed in the PR #34951.