### PR TITLE
refactoring of timeout change for app_to_active.

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -1678,7 +1678,6 @@ def wait_for_app_to_active(client, app_id,
     @return: app object
     """
     start = time.time()
-    timeout = start + timeout
     app_data = client.list_app(id=app_id).data
     while len(app_data) == 0:
         if time.time() - start > timeout / 10:


### PR DESCRIPTION

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
After changes in timeout parameter the wait_for_app_to_active test kept running for many hours. Hence this PR serves to refactor those changes. The changes do not affect any other test. 

