### PR TITLE
Point charts to release-v2.6.8 branch

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /var/lib/rancher
 ARG ARCH=amd64
 ARG IMAGE_REPO=rancher
 ARG SYSTEM_CHART_DEFAULT_BRANCH=release-v2.6
-ARG CHART_DEFAULT_BRANCH=release-v2.6
+ARG CHART_DEFAULT_BRANCH=release-v2.6.8
 ARG PARTNER_CHART_DEFAULT_BRANCH=main
 ARG RKE2_CHART_DEFAULT_BRANCH=main
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -107,7 +107,7 @@ var (
 	ClusterTemplateEnforcement          = NewSetting("cluster-template-enforcement", "false")
 	InitialDockerRootDir                = NewSetting("initial-docker-root-dir", "/var/lib/docker")
 	SystemCatalog                       = NewSetting("system-catalog", "external") // Options are 'external' or 'bundled'
-	ChartDefaultBranch                  = NewSetting("chart-default-branch", "release-v2.6")
+	ChartDefaultBranch                  = NewSetting("chart-default-branch", "release-v2.6.8")
 	PartnerChartDefaultBranch           = NewSetting("partner-chart-default-branch", "main")
 	RKE2ChartDefaultBranch              = NewSetting("rke2-chart-default-branch", "main")
 	FleetDefaultWorkspaceName           = NewSetting("fleet-default-workspace-name", fleetconst.ClustersDefaultNamespace) // fleetWorkspaceName to assign to clusters with none

--- a/scripts/package
+++ b/scripts/package
@@ -7,7 +7,7 @@ ARCH=${ARCH:-"amd64"}
 SYSTEM_CHART_REPO_DIR=build/system-charts
 SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"release-v2.6"}
 CHART_REPO_DIR=build/charts
-CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"release-v2.6"}
+CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"release-v2.6.8"}
 
 cd $(dirname $0)/../package
 


### PR DESCRIPTION
Modifies Rancher in this particular release/v2.6.8 branch to use https://github.com/rancher/charts/tree/release-v2.6.8 as the release branch. 

This PR will later be reverted once release/v2.6.8 is merged into release/v2.6.