### PR TITLE
Generated the new cluster.x-k8s.io client

### DIFF
--- a/tests/framework/clients/rancher/client.go
+++ b/tests/framework/clients/rancher/client.go
@@ -13,6 +13,7 @@ import (
 	frameworkDynamic "github.com/rancher/rancher/tests/framework/clients/dynamic"
 	"github.com/rancher/rancher/tests/framework/clients/ec2"
 	"github.com/rancher/rancher/tests/framework/clients/rancher/catalog"
+	cluster "github.com/rancher/rancher/tests/framework/clients/rancher/generated/cluster/v1beta1"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	provisioning "github.com/rancher/rancher/tests/framework/clients/rancher/generated/provisioning/v1"
 
@@ -37,6 +38,8 @@ type Client struct {
 	Provisioning *provisioning.Client
 	// Client used to access catalog.cattle.io v1 API resources (apps, charts, etc.)
 	Catalog *catalog.Client
+	// Client used to access cluster.x-k8s.io.machine v1 API
+	Cluster *cluster.Client
 	// Config used to test against a rancher instance
 	RancherConfig *Config
 	restConfig    *rest.Config
@@ -77,6 +80,13 @@ func NewClient(bearerToken string, session *session.Session) (*Client, error) {
 	}
 
 	c.Provisioning.Ops.Session = session
+
+	c.Cluster, err = cluster.NewClient(clientOptsV1(restConfig, c.RancherConfig))
+	if err != nil {
+		return nil, err
+	}
+
+	c.Cluster.Ops.Session = session
 
 	catalogClient, err := catalog.NewForConfig(restConfig, session)
 	if err != nil {

--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_bootstrap.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_bootstrap.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	BootstrapType                = "bootstrap"
+	BootstrapFieldConfigRef      = "configRef"
+	BootstrapFieldDataSecretName = "dataSecretName"
+)
+
+type Bootstrap struct {
+	ConfigRef      *ObjectReference `json:"configRef,omitempty" yaml:"configRef,omitempty"`
+	DataSecretName string           `json:"dataSecretName,omitempty" yaml:"dataSecretName,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_client.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_client.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"github.com/rancher/rancher/tests/framework/pkg/clientbase"
+)
+
+type Client struct {
+	clientbase.APIBaseClient
+
+	Machine MachineOperations
+}
+
+func NewClient(opts *clientbase.ClientOpts) (*Client, error) {
+	baseClient, err := clientbase.NewAPIClient(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &Client{
+		APIBaseClient: baseClient,
+	}
+
+	client.Machine = newMachineClient(client)
+
+	return client, nil
+}

--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_cluster.x-k8s.io.machine.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_cluster.x-k8s.io.machine.go
@@ -1,0 +1,110 @@
+package client
+
+import (
+	"github.com/rancher/norman/types"
+)
+
+const (
+	MachineType            = "cluster.x-k8s.io.machine"
+	MachineFieldCreatorID  = "creatorId"
+	MachineFieldObjectMeta = "metadata"
+	MachineFieldSpec       = "spec"
+	MachineFieldStatus     = "status"
+)
+
+type Machine struct {
+	types.Resource
+	CreatorID  string         `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	ObjectMeta *ObjectMeta    `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Spec       *MachineSpec   `json:"spec,omitempty" yaml:"spec,omitempty"`
+	Status     *MachineStatus `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+type MachineCollection struct {
+	types.Collection
+	Data   []Machine `json:"data,omitempty"`
+	client *MachineClient
+}
+
+type MachineClient struct {
+	apiClient *Client
+}
+
+type MachineOperations interface {
+	List(opts *types.ListOpts) (*MachineCollection, error)
+	ListAll(opts *types.ListOpts) (*MachineCollection, error)
+	Create(opts *Machine) (*Machine, error)
+	Update(existing *Machine, updates interface{}) (*Machine, error)
+	Replace(existing *Machine) (*Machine, error)
+	ByID(id string) (*Machine, error)
+	Delete(container *Machine) error
+}
+
+func newMachineClient(apiClient *Client) *MachineClient {
+	return &MachineClient{
+		apiClient: apiClient,
+	}
+}
+
+func (c *MachineClient) Create(container *Machine) (*Machine, error) {
+	resp := &Machine{}
+	err := c.apiClient.Ops.DoCreate(MachineType, container, resp)
+	return resp, err
+}
+
+func (c *MachineClient) Update(existing *Machine, updates interface{}) (*Machine, error) {
+	resp := &Machine{}
+	err := c.apiClient.Ops.DoUpdate(MachineType, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *MachineClient) Replace(obj *Machine) (*Machine, error) {
+	resp := &Machine{}
+	err := c.apiClient.Ops.DoReplace(MachineType, &obj.Resource, obj, resp)
+	return resp, err
+}
+
+func (c *MachineClient) List(opts *types.ListOpts) (*MachineCollection, error) {
+	resp := &MachineCollection{}
+	err := c.apiClient.Ops.DoList(MachineType, opts, resp)
+	resp.client = c
+	return resp, err
+}
+
+func (c *MachineClient) ListAll(opts *types.ListOpts) (*MachineCollection, error) {
+	resp := &MachineCollection{}
+	resp, err := c.List(opts)
+	if err != nil {
+		return resp, err
+	}
+	data := resp.Data
+	for next, err := resp.Next(); next != nil && err == nil; next, err = next.Next() {
+		data = append(data, next.Data...)
+		resp = next
+		resp.Data = data
+	}
+	if err != nil {
+		return resp, err
+	}
+	return resp, err
+}
+
+func (cc *MachineCollection) Next() (*MachineCollection, error) {
+	if cc != nil && cc.Pagination != nil && cc.Pagination.Next != "" {
+		resp := &MachineCollection{}
+		err := cc.client.apiClient.Ops.DoNext(cc.Pagination.Next, resp)
+		resp.client = cc.client
+		return resp, err
+	}
+	return nil, nil
+}
+
+func (c *MachineClient) ByID(id string) (*Machine, error) {
+	resp := &Machine{}
+	err := c.apiClient.Ops.DoByID(MachineType, id, resp)
+	return resp, err
+}
+
+func (c *MachineClient) Delete(container *Machine) error {
+	return c.apiClient.Ops.DoResourceDelete(MachineType, &container.Resource)
+}

--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_condition.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_condition.go
@@ -1,0 +1,20 @@
+package client
+
+const (
+	ConditionType                    = "condition"
+	ConditionFieldLastTransitionTime = "lastTransitionTime"
+	ConditionFieldMessage            = "message"
+	ConditionFieldReason             = "reason"
+	ConditionFieldSeverity           = "severity"
+	ConditionFieldStatus             = "status"
+	ConditionFieldType               = "type"
+)
+
+type Condition struct {
+	LastTransitionTime string `json:"lastTransitionTime,omitempty" yaml:"lastTransitionTime,omitempty"`
+	Message            string `json:"message,omitempty" yaml:"message,omitempty"`
+	Reason             string `json:"reason,omitempty" yaml:"reason,omitempty"`
+	Severity           string `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Status             string `json:"status,omitempty" yaml:"status,omitempty"`
+	Type               string `json:"type,omitempty" yaml:"type,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_duration.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_duration.go
@@ -1,0 +1,10 @@
+package client
+
+const (
+	DurationType          = "duration"
+	DurationFieldDuration = "duration"
+)
+
+type Duration struct {
+	Duration string `json:"duration,omitempty" yaml:"duration,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_machine_address.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_machine_address.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	MachineAddressType         = "machineAddress"
+	MachineAddressFieldAddress = "address"
+	MachineAddressFieldType    = "type"
+)
+
+type MachineAddress struct {
+	Address string `json:"address,omitempty" yaml:"address,omitempty"`
+	Type    string `json:"type,omitempty" yaml:"type,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_machine_spec.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_machine_spec.go
@@ -1,0 +1,24 @@
+package client
+
+const (
+	MachineSpecType                     = "machineSpec"
+	MachineSpecFieldBootstrap           = "bootstrap"
+	MachineSpecFieldClusterName         = "clusterName"
+	MachineSpecFieldFailureDomain       = "failureDomain"
+	MachineSpecFieldInfrastructureRef   = "infrastructureRef"
+	MachineSpecFieldNodeDeletionTimeout = "nodeDeletionTimeout"
+	MachineSpecFieldNodeDrainTimeout    = "nodeDrainTimeout"
+	MachineSpecFieldProviderID          = "providerID"
+	MachineSpecFieldVersion             = "version"
+)
+
+type MachineSpec struct {
+	Bootstrap           *Bootstrap       `json:"bootstrap,omitempty" yaml:"bootstrap,omitempty"`
+	ClusterName         string           `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
+	FailureDomain       string           `json:"failureDomain,omitempty" yaml:"failureDomain,omitempty"`
+	InfrastructureRef   *ObjectReference `json:"infrastructureRef,omitempty" yaml:"infrastructureRef,omitempty"`
+	NodeDeletionTimeout *Duration        `json:"nodeDeletionTimeout,omitempty" yaml:"nodeDeletionTimeout,omitempty"`
+	NodeDrainTimeout    *Duration        `json:"nodeDrainTimeout,omitempty" yaml:"nodeDrainTimeout,omitempty"`
+	ProviderID          string           `json:"providerID,omitempty" yaml:"providerID,omitempty"`
+	Version             string           `json:"version,omitempty" yaml:"version,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_machine_status.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_machine_status.go
@@ -1,0 +1,30 @@
+package client
+
+const (
+	MachineStatusType                     = "machineStatus"
+	MachineStatusFieldAddresses           = "addresses"
+	MachineStatusFieldBootstrapReady      = "bootstrapReady"
+	MachineStatusFieldConditions          = "conditions"
+	MachineStatusFieldFailureMessage      = "failureMessage"
+	MachineStatusFieldFailureReason       = "failureReason"
+	MachineStatusFieldInfrastructureReady = "infrastructureReady"
+	MachineStatusFieldLastUpdated         = "lastUpdated"
+	MachineStatusFieldNodeInfo            = "nodeInfo"
+	MachineStatusFieldNodeRef             = "nodeRef"
+	MachineStatusFieldObservedGeneration  = "observedGeneration"
+	MachineStatusFieldPhase               = "phase"
+)
+
+type MachineStatus struct {
+	Addresses           []MachineAddress `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+	BootstrapReady      bool             `json:"bootstrapReady,omitempty" yaml:"bootstrapReady,omitempty"`
+	Conditions          []Condition      `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	FailureMessage      string           `json:"failureMessage,omitempty" yaml:"failureMessage,omitempty"`
+	FailureReason       string           `json:"failureReason,omitempty" yaml:"failureReason,omitempty"`
+	InfrastructureReady bool             `json:"infrastructureReady,omitempty" yaml:"infrastructureReady,omitempty"`
+	LastUpdated         string           `json:"lastUpdated,omitempty" yaml:"lastUpdated,omitempty"`
+	NodeInfo            *NodeSystemInfo  `json:"nodeInfo,omitempty" yaml:"nodeInfo,omitempty"`
+	NodeRef             *ObjectReference `json:"nodeRef,omitempty" yaml:"nodeRef,omitempty"`
+	ObservedGeneration  int64            `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
+	Phase               string           `json:"phase,omitempty" yaml:"phase,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_node_system_info.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_node_system_info.go
@@ -1,0 +1,28 @@
+package client
+
+const (
+	NodeSystemInfoType                         = "nodeSystemInfo"
+	NodeSystemInfoFieldArchitecture            = "architecture"
+	NodeSystemInfoFieldBootID                  = "bootID"
+	NodeSystemInfoFieldContainerRuntimeVersion = "containerRuntimeVersion"
+	NodeSystemInfoFieldKernelVersion           = "kernelVersion"
+	NodeSystemInfoFieldKubeProxyVersion        = "kubeProxyVersion"
+	NodeSystemInfoFieldKubeletVersion          = "kubeletVersion"
+	NodeSystemInfoFieldMachineID               = "machineID"
+	NodeSystemInfoFieldOSImage                 = "osImage"
+	NodeSystemInfoFieldOperatingSystem         = "operatingSystem"
+	NodeSystemInfoFieldSystemUUID              = "systemUUID"
+)
+
+type NodeSystemInfo struct {
+	Architecture            string `json:"architecture,omitempty" yaml:"architecture,omitempty"`
+	BootID                  string `json:"bootID,omitempty" yaml:"bootID,omitempty"`
+	ContainerRuntimeVersion string `json:"containerRuntimeVersion,omitempty" yaml:"containerRuntimeVersion,omitempty"`
+	KernelVersion           string `json:"kernelVersion,omitempty" yaml:"kernelVersion,omitempty"`
+	KubeProxyVersion        string `json:"kubeProxyVersion,omitempty" yaml:"kubeProxyVersion,omitempty"`
+	KubeletVersion          string `json:"kubeletVersion,omitempty" yaml:"kubeletVersion,omitempty"`
+	MachineID               string `json:"machineID,omitempty" yaml:"machineID,omitempty"`
+	OSImage                 string `json:"osImage,omitempty" yaml:"osImage,omitempty"`
+	OperatingSystem         string `json:"operatingSystem,omitempty" yaml:"operatingSystem,omitempty"`
+	SystemUUID              string `json:"systemUUID,omitempty" yaml:"systemUUID,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_object_meta.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_object_meta.go
@@ -1,0 +1,28 @@
+package client
+
+const (
+	ObjectMetaType                 = "objectMeta"
+	ObjectMetaFieldAnnotations     = "annotations"
+	ObjectMetaFieldCreated         = "created"
+	ObjectMetaFieldFinalizers      = "finalizers"
+	ObjectMetaFieldLabels          = "labels"
+	ObjectMetaFieldName            = "name"
+	ObjectMetaFieldNamespace       = "namespace"
+	ObjectMetaFieldOwnerReferences = "ownerReferences"
+	ObjectMetaFieldRemoved         = "removed"
+	ObjectMetaFieldSelfLink        = "selfLink"
+	ObjectMetaFieldUUID            = "uuid"
+)
+
+type ObjectMeta struct {
+	Annotations     map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Created         string            `json:"created,omitempty" yaml:"created,omitempty"`
+	Finalizers      []string          `json:"finalizers,omitempty" yaml:"finalizers,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name            string            `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace       string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	OwnerReferences []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Removed         string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	SelfLink        string            `json:"selfLink,omitempty" yaml:"selfLink,omitempty"`
+	UUID            string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_object_reference.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_object_reference.go
@@ -1,0 +1,22 @@
+package client
+
+const (
+	ObjectReferenceType                 = "objectReference"
+	ObjectReferenceFieldAPIVersion      = "apiVersion"
+	ObjectReferenceFieldFieldPath       = "fieldPath"
+	ObjectReferenceFieldKind            = "kind"
+	ObjectReferenceFieldName            = "name"
+	ObjectReferenceFieldNamespace       = "namespace"
+	ObjectReferenceFieldResourceVersion = "resourceVersion"
+	ObjectReferenceFieldUID             = "uid"
+)
+
+type ObjectReference struct {
+	APIVersion      string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	FieldPath       string `json:"fieldPath,omitempty" yaml:"fieldPath,omitempty"`
+	Kind            string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Name            string `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace       string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	ResourceVersion string `json:"resourceVersion,omitempty" yaml:"resourceVersion,omitempty"`
+	UID             string `json:"uid,omitempty" yaml:"uid,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_owner_reference.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_owner_reference.go
@@ -1,0 +1,20 @@
+package client
+
+const (
+	OwnerReferenceType                    = "ownerReference"
+	OwnerReferenceFieldAPIVersion         = "apiVersion"
+	OwnerReferenceFieldBlockOwnerDeletion = "blockOwnerDeletion"
+	OwnerReferenceFieldController         = "controller"
+	OwnerReferenceFieldKind               = "kind"
+	OwnerReferenceFieldName               = "name"
+	OwnerReferenceFieldUID                = "uid"
+)
+
+type OwnerReference struct {
+	APIVersion         string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	BlockOwnerDeletion *bool  `json:"blockOwnerDeletion,omitempty" yaml:"blockOwnerDeletion,omitempty"`
+	Controller         *bool  `json:"controller,omitempty" yaml:"controller,omitempty"`
+	Kind               string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Name               string `json:"name,omitempty" yaml:"name,omitempty"`
+	UID                string `json:"uid,omitempty" yaml:"uid,omitempty"`
+}

--- a/tests/framework/codegen/main.go
+++ b/tests/framework/codegen/main.go
@@ -9,6 +9,7 @@ import (
 
 	managementSchema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
 	"github.com/rancher/rancher/tests/framework/codegen/generator"
+	clusterMachineSchema "github.com/rancher/rancher/tests/framework/pkg/schemas/cluster.x-k8s.io.machines/v1beta1"
 	provisioningSchema "github.com/rancher/rancher/tests/framework/pkg/schemas/provisioning.cattle.io/v1"
 )
 
@@ -17,6 +18,8 @@ func main() {
 	generator.GenerateClient(managementSchema.Schemas, map[string]bool{
 		"userAttribute": true,
 	})
+
+	generator.GenerateClient(clusterMachineSchema.Schemas, map[string]bool{})
 
 	generator.GenerateClient(provisioningSchema.Schemas, map[string]bool{})
 

--- a/tests/framework/extensions/sshkeys/downloadsshkeys.go
+++ b/tests/framework/extensions/sshkeys/downloadsshkeys.go
@@ -1,0 +1,49 @@
+package sshkeys
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+)
+
+const (
+	privateKeySSHKeyRegExPattern = `----BEGIN RSA PRIVATE KEY-{3,}\n([\s\S]*?)\n-{3,}END RSA PRIVATE KEY-----`
+)
+
+// DownloadSSHKeys is a helper function that takes a client, the machinePoolNodeName to download
+// the ssh key for a particular node.
+func DownloadSSHKeys(client *rancher.Client, machinePoolNodeName string) (string, error) {
+	machinePoolNodeNameName := fmt.Sprintf("fleet-default/%s", machinePoolNodeName)
+	machine, err := client.Cluster.Machine.ByID(machinePoolNodeNameName)
+	if err != nil {
+		return "", err
+	}
+
+	sshKeyLink := machine.Links["sshkeys"]
+
+	req, err := http.NewRequest("GET", sshKeyLink, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Add("Authorization", "Bearer "+client.RancherConfig.AdminToken)
+
+	resp, err := client.Management.APIBaseClient.Ops.Client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	privateSSHKeyRegEx := regexp.MustCompile(privateKeySSHKeyRegExPattern)
+	privateSSHKey := privateSSHKeyRegEx.FindString(string(bodyBytes))
+
+	return privateSSHKey, err
+}

--- a/tests/framework/pkg/schemas/cluster.x-k8s.io.machines/v1beta1/mapper.go
+++ b/tests/framework/pkg/schemas/cluster.x-k8s.io.machines/v1beta1/mapper.go
@@ -7,9 +7,9 @@ import (
 	"github.com/rancher/rancher/pkg/schemas/mapper"
 )
 
-// ProvisioningSchemas is a schema that defines a mapper so the Provisioning Client can
+// ClusterMachineSchemas is a schema that defines a mapper so the Clusters Client can
 // be generated in the correct structure
-func ProvisioningSchemas(version *types.APIVersion) *types.Schemas {
+func ClusterMachineSchemas(version *types.APIVersion) *types.Schemas {
 	schemas := factory.Schemas(version)
 	schemas.DefaultMappers = func() []types.Mapper {
 		mappers := []types.Mapper{

--- a/tests/framework/pkg/schemas/cluster.x-k8s.io.machines/v1beta1/schema.go
+++ b/tests/framework/pkg/schemas/cluster.x-k8s.io.machines/v1beta1/schema.go
@@ -1,0 +1,27 @@
+package schema
+
+import (
+	"github.com/rancher/norman/types"
+	provisioningSchema "github.com/rancher/rancher/tests/framework/pkg/schemas/provisioning.cattle.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+var (
+	Version = types.APIVersion{
+		Version: capi.GroupVersion.Version,
+		Group:   capi.GroupVersion.Group,
+		Path:    "/v1",
+	}
+
+	Schemas = ClusterMachineSchemas(&Version).
+		Init(clusterMachineTypes)
+)
+
+func clusterMachineTypes(schemas *types.Schemas) *types.Schemas {
+	return schemas.
+		MustImportAndCustomize(&Version, metav1.Duration{}, func(schema *types.Schema) {}, provisioningSchema.Duration{}).
+		MustImportAndCustomize(&Version, capi.Machine{}, func(schema *types.Schema) {
+			schema.ID = "cluster.x-k8s.io.machine"
+		})
+}

--- a/tests/framework/pkg/schemas/provisioning.cattle.io/v1/types.go
+++ b/tests/framework/pkg/schemas/provisioning.cattle.io/v1/types.go
@@ -1,9 +1,11 @@
 package schema
 
+// Duration is a replacement struct for the Duration in the "k8s.io/apimachinery/pkg/apis/meta/v1" package
 type Duration struct {
 	Duration string `json:"duration,omitempty" yaml:"duration,omitempty"`
 }
 
+// MachineGlobalConfig is struct that defines the CNI for a RKEConfig need to provision a v1 cluster
 type MachineGlobalConfig struct {
 	CNI string `json:"cni,omitempty" yaml:"cni,omitempty"`
 }


### PR DESCRIPTION

 ## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Needed to add support to the automation framework to be able to download ssh keys from a specific machine pool node on rancher.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
I generated the cluster.x-k8s.io client, and also implemented a helper to download the private ssh key from the machine pool node. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->