### PR TITLE
Properly parse annotations from UI when admins edit Auth Config in the UI

### DIFF
--- a/pkg/auth/providers/azure/azure_actions.go
+++ b/pkg/auth/providers/azure/azure_actions.go
@@ -37,7 +37,7 @@ func (ap *azureProvider) actionHandler(actionName string, action *types.Action, 
 	}
 
 	if actionName == "configureTest" {
-		return ap.configureTest(actionName, action, request)
+		return ap.ConfigureTest(actionName, action, request)
 	} else if actionName == "testAndApply" {
 		return ap.testAndApply(actionName, action, request)
 	} else if actionName == "upgrade" {
@@ -47,7 +47,7 @@ func (ap *azureProvider) actionHandler(actionName string, action *types.Action, 
 	return httperror.NewAPIError(httperror.ActionNotAvailable, "")
 }
 
-func (ap *azureProvider) configureTest(actionName string, action *types.Action, request *types.APIContext) error {
+func (ap *azureProvider) ConfigureTest(actionName string, action *types.Action, request *types.APIContext) error {
 	// Verify the body has all required fields
 	input, err := handler.ParseAndValidateActionBody(request, request.Schemas.Schema(&managementschema.Version,
 		client.AzureADConfigType))

--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -392,7 +392,7 @@ func formAzureRedirectURL(config map[string]interface{}) string {
 		// Extract the annotations from the map. This is needed because of the type structure of
 		// the Azure config and the Auth config it embeds. Full deserialization does not work for
 		// fields of the embedded Kubernetes types in this case.
-		ac.ObjectMeta.Annotations = extractAnnotations(config)
+		ac.ObjectMeta.Annotations = extractAnnotationsFromAuthConfig(config)
 		if !isConfigDeprecated(&ac) {
 			// Return the redirect URL for Microsoft Graph.
 			return fmt.Sprintf(
@@ -415,23 +415,31 @@ func formAzureRedirectURL(config map[string]interface{}) string {
 	)
 }
 
-func extractAnnotations(config map[string]interface{}) map[string]string {
-	annotations := make(map[string]string)
-	metadata, ok := config["metadata"].(map[string]interface{})
-	if !ok {
-		logrus.Info("Failed to decode the 'metadata' field of the auth config.")
-		return annotations
+// extractAnnotationsFromAuthConfig tries to extract the annotations from the AuthConfig value.
+// The AuthConfig value might come from either the database (on login attempts) or from the UI (on Azure AD setup attempts).
+// In these two cases, the structure of the config is different.
+// In the former, it's "metadata.annotations.[map of annotations]".
+// In the latter, it's "annotations.[map of annotations]". The function tries to find the annotations in either structure.
+func extractAnnotationsFromAuthConfig(config map[string]interface{}) map[string]string {
+	if metadata, ok := config["metadata"].(map[string]interface{}); ok {
+		return parseAnnotations(metadata)
 	}
-	rawAnnotations, ok := metadata["annotations"].(map[string]interface{})
+	logrus.Info("Failed to decode the 'metadata' field of the AuthConfig. Attempting to decode 'annotations' at the top level.")
+	return parseAnnotations(config)
+}
+
+func parseAnnotations(m map[string]interface{}) map[string]string {
+	annotations := make(map[string]string)
+	rawAnnotations, ok := m["annotations"].(map[string]interface{})
 	if !ok {
-		logrus.Info("Failed to decode the 'annotations' field of the auth config.")
+		logrus.Info("Failed to decode the 'annotations' field of the AuthConfig.")
 		return annotations
 	}
 	for k, v := range rawAnnotations {
 		if stringValue, ok := v.(string); ok {
 			annotations[k] = stringValue
 		} else {
-			logrus.Infof("Failed to decode the annotation value of the key %q as a string (%v of type %T) on the auth config.", k, v, v)
+			logrus.Infof("Failed to decode the annotation value of the key %q as a string (%v of type %T) on the AuthConfig.", k, v, v)
 		}
 	}
 	return annotations

--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -428,9 +428,9 @@ func extractAnnotationsFromAuthConfig(config map[string]interface{}) map[string]
 	return parseAnnotations(config)
 }
 
-func parseAnnotations(m map[string]interface{}) map[string]string {
+func parseAnnotations(metadata map[string]interface{}) map[string]string {
 	annotations := make(map[string]string)
-	rawAnnotations, ok := m["annotations"].(map[string]interface{})
+	rawAnnotations, ok := metadata["annotations"].(map[string]interface{})
 	if !ok {
 		logrus.Info("Failed to decode the 'annotations' field of the AuthConfig.")
 		return annotations

--- a/pkg/auth/providers/azure/azure_provider_test.go
+++ b/pkg/auth/providers/azure/azure_provider_test.go
@@ -1,0 +1,227 @@
+package azure
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rancher/norman/api/writer"
+	"github.com/rancher/norman/types"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	managementschema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestConfigureTest inspects the Redirect URL during Azure AD setup.
+func TestConfigureTest(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                string
+		authConfig          map[string]interface{}
+		expectedRedirectURL string
+	}{
+		{
+			name: "initial setup of Azure AD with Microsoft Graph",
+			authConfig: map[string]interface{}{
+				"accessMode": "unrestricted",
+				"annotations": map[string]interface{}{
+					"auth.cattle.io/azuread-endpoint-migrated": "true",
+				},
+				"endpoint":          "https://login.microsoftonline.com/",
+				"graphEndpoint":     "https://graph.microsoft.com",
+				"tokenEndpoint":     "https://login.microsoftonline.com/tenant123/oauth2/v2.0/token",
+				"authEndpoint":      "https://login.microsoftonline.com/tenant123/oauth2/v2.0/authorize",
+				"tenantId":          "tenant123",
+				"applicationId":     "app123",
+				"applicationSecret": "secret123",
+				"rancherUrl":        "https://myrancher.com",
+			},
+			expectedRedirectURL: "https://login.microsoftonline.com/tenant123/oauth2/v2.0/authorize?client_id=app123&redirect_uri=https://myrancher.com&response_type=code&scope=openid",
+		},
+		{
+			name: "attempt to initially setup Azure AD with deprecated Azure AD Graph",
+			authConfig: map[string]interface{}{
+				"accessMode":        "unrestricted",
+				"annotations":       map[string]interface{}{},
+				"endpoint":          "https://login.microsoftonline.com/",
+				"graphEndpoint":     "https://graph.windows.net/",
+				"tokenEndpoint":     "https://login.microsoftonline.com/tenant123/oauth2/token",
+				"authEndpoint":      "https://login.microsoftonline.com/tenant123/oauth2/authorize",
+				"tenantId":          "tenant123",
+				"applicationId":     "app123",
+				"applicationSecret": "secret123",
+				"rancherUrl":        "https://myrancher.com",
+			},
+			expectedRedirectURL: "https://login.microsoftonline.com/tenant123/oauth2/authorize?client_id=app123&redirect_uri=https://myrancher.com&response_type=code&scope=openid",
+		},
+		{
+			name: "editing an existing setup of Azure AD",
+			authConfig: map[string]interface{}{
+				"enabled":    true,
+				"accessMode": "unrestricted",
+				"annotations": map[string]interface{}{
+					"auth.cattle.io/azuread-endpoint-migrated": "true",
+				},
+				"endpoint":          "https://login.microsoftonline.com/",
+				"graphEndpoint":     "https://graph.microsoft.com",
+				"tokenEndpoint":     "https://login.microsoftonline.com/tenant123/oauth2/v2.0/token",
+				"authEndpoint":      "https://login.microsoftonline.com/tenant123/oauth2/v2.0/authorize",
+				"tenantId":          "tenant123",
+				"applicationId":     "app123",
+				"applicationSecret": "secret123",
+				"rancherUrl":        "https://myrancher.com",
+			},
+			expectedRedirectURL: "https://login.microsoftonline.com/tenant123/oauth2/v2.0/authorize?client_id=app123&redirect_uri=https://myrancher.com&response_type=code&scope=openid",
+		},
+		{
+			name: "editing an existing setup of Azure AD without annotation",
+			authConfig: map[string]interface{}{
+				"enabled":           true,
+				"accessMode":        "unrestricted",
+				"endpoint":          "https://login.microsoftonline.com/",
+				"graphEndpoint":     "https://graph.windows.net/",
+				"tokenEndpoint":     "https://login.microsoftonline.com/tenant123/oauth2/token",
+				"authEndpoint":      "https://login.microsoftonline.com/tenant123/oauth2/authorize",
+				"tenantId":          "tenant123",
+				"applicationId":     "app123",
+				"applicationSecret": "secret123",
+				"rancherUrl":        "https://myrancher.com",
+			},
+			expectedRedirectURL: "https://login.microsoftonline.com/tenant123/oauth2/authorize?client_id=app123&redirect_uri=https://myrancher.com&resource=https://graph.windows.net/&scope=openid",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := json.Marshal(test.authConfig)
+			assert.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, "/v3/azureADConfigs/azuread?action=configureTest", bytes.NewReader(b))
+
+			schemas := types.NewSchemas()
+			schemas.AddSchemas(managementschema.AuthSchemas)
+
+			rw := &writer.EncodingResponseWriter{
+				ContentType: "application/json",
+				Encoder:     types.JSONEncoder,
+			}
+			rr := httptest.NewRecorder()
+			r := &types.APIContext{
+				Schemas:        schemas,
+				Request:        req,
+				Response:       rr,
+				ResponseWriter: rw,
+				Version:        &managementschema.Version,
+			}
+
+			provider := azureProvider{}
+			err = provider.ConfigureTest("configureTest", nil, r)
+			assert.NoError(t, err)
+
+			res := rr.Result()
+			defer res.Body.Close()
+
+			var output v3.AzureADConfigTestOutput
+			err = json.NewDecoder(res.Body).Decode(&output)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedRedirectURL, output.RedirectURL)
+		})
+	}
+
+}
+
+func TestTransformToAuthProvider(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                string
+		authConfig          map[string]interface{}
+		expectedRedirectUrl string
+	}{
+		{
+			name: "redirect URL for Microsoft Graph",
+			authConfig: map[string]interface{}{
+				"enabled":    true,
+				"accessMode": "unrestricted",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"auth.cattle.io/azuread-endpoint-migrated": "true",
+					},
+				},
+				"endpoint":          "https://login.microsoftonline.com/",
+				"graphEndpoint":     "https://graph.microsoft.com",
+				"tokenEndpoint":     "https://login.microsoftonline.com/tenant123/oauth2/v2.0/token",
+				"authEndpoint":      "https://login.microsoftonline.com/tenant123/oauth2/v2.0/authorize",
+				"tenantId":          "tenant123",
+				"applicationId":     "app123",
+				"applicationSecret": "secret123",
+				"rancherUrl":        "https://myrancher.com",
+			},
+			expectedRedirectUrl: "https://login.microsoftonline.com/tenant123/oauth2/v2.0/authorize?client_id=app123&redirect_uri=https://myrancher.com&response_type=code&scope=openid",
+		},
+		{
+			name: "redirect URL for Azure AD Graph",
+			authConfig: map[string]interface{}{
+				"enabled":           true,
+				"accessMode":        "unrestricted",
+				"endpoint":          "https://login.microsoftonline.com/",
+				"graphEndpoint":     "https://graph.windows.net/",
+				"tokenEndpoint":     "https://login.microsoftonline.com/tenant123/oauth2/token",
+				"authEndpoint":      "https://login.microsoftonline.com/tenant123/oauth2/authorize",
+				"tenantId":          "tenant123",
+				"applicationId":     "app123",
+				"applicationSecret": "secret123",
+				"rancherUrl":        "https://myrancher.com",
+			},
+			expectedRedirectUrl: "https://login.microsoftonline.com/tenant123/oauth2/authorize?client_id=app123&redirect_uri=https://myrancher.com&resource=https://graph.windows.net/&scope=openid",
+		},
+		{
+			name: "redirect URL for disabled auth provider with annotation",
+			authConfig: map[string]interface{}{
+				"accessMode": "unrestricted",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"auth.cattle.io/azuread-endpoint-migrated": "true",
+					},
+				},
+				"endpoint":          "https://login.microsoftonline.com/",
+				"graphEndpoint":     "https://graph.microsoft.com",
+				"tokenEndpoint":     "https://login.microsoftonline.com/tenant123/oauth2/token",
+				"authEndpoint":      "https://login.microsoftonline.com/tenant123/oauth2/v2.0/authorize",
+				"tenantId":          "tenant123",
+				"applicationId":     "app123",
+				"applicationSecret": "secret123",
+				"rancherUrl":        "https://myrancher.com",
+			},
+			expectedRedirectUrl: "https://login.microsoftonline.com/tenant123/oauth2/v2.0/authorize?client_id=app123&redirect_uri=https://myrancher.com&response_type=code&scope=openid",
+		},
+		{
+			name: "redirect URL for disabled auth provider without annotation",
+			authConfig: map[string]interface{}{
+				"enabled":           false, // Here, enabled is set to false explicitly.
+				"accessMode":        "unrestricted",
+				"endpoint":          "https://login.microsoftonline.com/",
+				"graphEndpoint":     "https://graph.windows.net/",
+				"tokenEndpoint":     "https://login.microsoftonline.com/tenant123/oauth2/token",
+				"authEndpoint":      "https://login.microsoftonline.com/tenant123/oauth2/authorize",
+				"tenantId":          "tenant123",
+				"applicationId":     "app123",
+				"applicationSecret": "secret123",
+				"rancherUrl":        "https://myrancher.com",
+			},
+			expectedRedirectUrl: "https://login.microsoftonline.com/tenant123/oauth2/authorize?client_id=app123&redirect_uri=https://myrancher.com&response_type=code&scope=openid",
+		},
+	}
+
+	var provider azureProvider
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			authProvider, err := provider.TransformToAuthProvider(test.authConfig)
+			assert.NoError(t, err)
+			url, ok := authProvider["redirectUrl"].(string)
+			assert.True(t, ok)
+			assert.Equal(t, test.expectedRedirectUrl, url)
+		})
+	}
+}

--- a/pkg/auth/providers/azure/clients/ms_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var errMSGraphNoPermissions = fmt.Errorf("missing required permissions from Microsoft Graph: need %s",
+var errMSGraphNoPermissions = fmt.Errorf("missing required Application type permissions from Microsoft Graph: need %s",
 	strings.Join(msGraphRequiredPermissions, ", "))
 
 type azureMSGraphClient struct {


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/38753

This addresses a corner case where the auth config is enabled but is re-registered (by Editing it in the UI).
Rancher now properly parses the annotations sent from the UI and correctly decides when to use the new auth flow.