### PR TITLE
Removing GKE from OnTag. Add rules for 2.5 v. 2.6.

### DIFF
--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -154,6 +154,22 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                   try {
                       jobs = [:]
                       println "Branch: ${branch}"
+                      if (rancher_version.startsWith("v2.5")){
+                        if (!env.RKE_VERSION) {
+                          RKE_VERSION = "v1.2.22"
+                        }
+                        if (!env.RANCHER_K3S_VERSION) {
+                          RANCHER_K3S_VERSION = "v1.20.15+k3s1"
+                        }
+                      }
+                      else if (rancher_version.startsWith("v2.6")){
+                        if (!env.RKE_VERSION) {
+                          RKE_VERSION = "v1.3.13"
+                        }
+                        if (!env.RANCHER_K3S_VERSION) {
+                          RANCHER_K3S_VERSION = "v1.24.2+k3s1"
+                        }
+                      }
                       params = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"),
                                 string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN}"),
                                 string(name: 'USER_TOKEN', value: "${USER_TOKEN}"),
@@ -164,6 +180,8 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                                   string(name: 'ADMIN_TOKEN', value: "${ADMIN_TOKEN_2}"),
                                   string(name: 'USER_TOKEN', value: "${USER_TOKEN_2}"),
                                   string(name: 'RANCHER_SERVER_VERSION', value: "${rancher_version}"),
+                                  string(name: 'RKE_VERSION', value: "${RKE_VERSION}"),
+                                  string(name: 'RANCHER_K3S_VERSION', value: "${RANCHER_K3S_VERSION}"),
                                   string(name: 'BRANCH', value: branch) ]
 
                       // Rancher server 1 is used to test RKE clusters
@@ -172,12 +190,16 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                       jobs["ec2"] = { build job: 'rancher-v3_ontag_ec2_certification', parameters: params }
                       jobs["az"] = { build job: 'rancher-v3_ontag_az_certification', parameters: params }
                       jobs["custom"] = { build job: 'rancher-v3_ontag_custom_certification', parameters: params}
-                      jobs["windows"] = { build job: 'rancher-v3_ontag_windows_certification', parameters: params}
-
-                      // Rancher server 2 is used to test GKE, EKS, AKS and Imported clusters
-                      jobs["gke"] = { build job: 'rancher-v3_ontag_gke_certification', parameters: params2 }
-                      jobs["eks"] = { build job: 'rancher-v3_ontag_eks_certification', parameters: params2 }
-                      jobs["aks"] = { build job: 'rancher-v3_ontag_aks_certification', parameters: params2 }
+                      // windows note: https://github.com/rancher/dashboard/issues/6549
+                      // jobs["windows"] = { build job: 'rancher-v3_ontag_windows_certification', parameters: params}
+                      if (rancher_version.startsWith("v2.6")){
+                        // Rancher server 2 is used to test GKE, EKS, AKS and Imported clusters
+                        jobs["eks"] = { build job: 'rancher-v3_ontag_eks_certification', parameters: params2 }
+                        jobs["aks"] = { build job: 'rancher-v3_ontag_aks_certification', parameters: params2 }
+                        // gke note: https://github.com/rancher/qa-tasks/issues/429
+                        // jobs["gke"] = { build job: 'rancher-v3_ontag_gke_certification', parameters: params2 }
+                        
+                      }
                       jobs["import"] = { build job: 'rancher-v3_ontag_import_certification', parameters: params2}
                       jobs["importk3s"] = { build job: 'rancher-v3_ontag_import_k3s_certification', parameters: params2}
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/qa-tasks/issues/429 tackling in 2 sets (one in fixes, another in adding rke2)
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
ontag was broken. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
We are removing GKE for now. Some other fixes include a check in the jenkinsfile for 2.5 or 2.6, and setting versions to run based on the rancher version. This will allow the user to set RKE_VERSION and RANCHER_K3S_VERSION, as well as has some defaults set in jenkinsfile for 2.5 and 2.6. 
 
## Testing
Tested in jenkins, will send runs separately. 
