### PR TITLE
pin kdm data for v2.6.8 patch releases

### DIFF
--- a/scripts/build-server
+++ b/scripts/build-server
@@ -21,7 +21,8 @@ CGO_ENABLED=0 go build -tags k8s \
   -o bin/rancher
 
 if  [ -n "$CATTLE_KDM_BRANCH" ]; then
-    curl -sLf https://releases.rancher.com/kontainer-driver-metadata/${CATTLE_KDM_BRANCH}/data.json > bin/data.json
+    # bypass KDM_BRANCH for patch releases, pinning local data to vendored RKE1 v1.3.13 data
+    curl -sLf https://releases.rancher.com/kontainer-driver-metadata/release-rke-v1.3.13/data.json > bin/data.json
 elif [ ! -e bin/data.json ] && [ -e ../kontainer-driver-metadata/data/data.json ]; then
     cp ../kontainer-driver-metadata/data/data.json bin/data.json
 fi


### PR DESCRIPTION
**Problem**
------ 
Local data in rancher needs to be consistent with vendored RKE1 data. Refer to https://github.com/rancher/rancher/issues/37088 for more details. This is handled by our release process for normal release tags but not patch releases which are tagged adhoc. 

**Solution** 
------ 
Pinning KDM data for patch releases. Setting it to v1.3.13, because v2.6.8 uses v1.3.13 and we want the behavior to remain the same as v2.6.8. Similar pattern as https://github.com/rancher/rancher/pull/37149 