### PR TITLE
Adding environment variable for SUSE to set base registry

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -142,8 +142,8 @@ var (
 	// RancherWebhookMinVersion is the minimum version of the webhook that rancher will install
 	RancherWebhookMinVersion = NewSetting("rancher-webhook-min-version", "")
 
-	// SystemDefaultRegistry is the default registry set by users when the environment variable CATTLE_SYSTEM_DEFAULT_REGISTRY
-	// is set. The environment variable CATTLE_BASE_REGISTRY is internal and used to set the base registry as set by SUSE.
+	// SystemDefaultRegistry is the default contrainer registry used for images.
+	// The environmental variable "CATTLE_BASE_REGISTRY" controls the default value of this setting.
 	SystemDefaultRegistry = NewSetting("system-default-registry", os.Getenv("CATTLE_BASE_REGISTRY"))
 
 	// Configuration to display a custom fixed banner in the header, footer, or both

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -76,7 +76,6 @@ var (
 	SystemAgentInstallerImage           = NewSetting("system-agent-installer-image", "rancher/system-agent-installer-")
 	SystemAgentUpgradeImage             = NewSetting("system-agent-upgrade-image", "")
 	WinsAgentUpgradeImage               = NewSetting("wins-agent-upgrade-image", "")
-	SystemDefaultRegistry               = NewSetting("system-default-registry", "")
 	SystemNamespaces                    = NewSetting("system-namespaces", "kube-system,kube-public,cattle-system,cattle-alerting,cattle-logging,cattle-prometheus,ingress-nginx,cattle-global-data,cattle-istio,kube-node-lease,cert-manager,cattle-global-nt,security-scan,cattle-fleet-system,cattle-fleet-local-system,calico-system,tigera-operator,cattle-impersonation-system,rancher-operator-system,cattle-csp-adapter-system,calico-apiserver")
 	SystemUpgradeControllerChartVersion = NewSetting("system-upgrade-controller-chart-version", "")
 	TelemetryOpt                        = NewSetting("telemetry-opt", "")
@@ -142,6 +141,10 @@ var (
 
 	// RancherWebhookMinVersion is the minimum version of the webhook that rancher will install
 	RancherWebhookMinVersion = NewSetting("rancher-webhook-min-version", "")
+
+	// SystemDefaultRegistry is the default registry set by users when the environment variable CATTLE_SYSTEM_DEFAULT_REGISTRY
+	// is set. The environment variable CATTLE_BASE_REGISTRY is internal and used to set the base registry as set by SUSE.
+	SystemDefaultRegistry = NewSetting("system-default-registry", os.Getenv("CATTLE_BASE_REGISTRY"))
 
 	// Configuration to display a custom fixed banner in the header, footer, or both
 	UIBanners = NewSetting("ui-banners", "{}")

--- a/pkg/settings/setting_test.go
+++ b/pkg/settings/setting_test.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -28,4 +29,28 @@ func TestIsRelease(t *testing.T) {
 		result := IsRelease()
 		a.Equal(value, result, fmt.Sprintf("Expected value [%t] for key [%s]. Got value [%t]", value, key, result))
 	}
+}
+
+// TestSystemDefaultRegistryDefault tests that the default registry is either
+// "" (an empty string) or the build time value to ensure backward compatibility.
+// Note, if CATTLE_BASE_REGISTRY is set this test in the testing environment
+// this test will fail.
+func TestSystemDefaultRegistryDefault(t *testing.T) {
+	var expect string
+	if InjectDefaults != "" {
+		defaults := map[string]string{}
+		if err := json.Unmarshal([]byte(InjectDefaults), &defaults); err != nil {
+			t.Errorf("Unable to parse InjectDefaults: %v", err)
+		}
+
+		if value, ok := settings["system-default-registry"]; ok {
+			expect = value.Get()
+		}
+	}
+
+	got := SystemDefaultRegistry.Get()
+	if got != expect {
+		t.Errorf("The System Default Registry of %q is not the expected value %q", got, expect)
+	}
+
 }

--- a/pkg/settings/setting_test.go
+++ b/pkg/settings/setting_test.go
@@ -3,6 +3,7 @@ package settings
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,19 +33,18 @@ func TestIsRelease(t *testing.T) {
 }
 
 // TestSystemDefaultRegistryDefault tests that the default registry is either
-// "" (an empty string) or the build time value to ensure backward compatibility.
-// Note, if CATTLE_BASE_REGISTRY is set this test in the testing environment
-// this test will fail.
+// the value set by the environment variable CATTLE_BASE_REGISTRY or the build
+// time value set through InjectDefaults.
 func TestSystemDefaultRegistryDefault(t *testing.T) {
-	var expect string
+	expect := os.Getenv("CATTLE_BASE_REGISTRY")
 	if InjectDefaults != "" {
 		defaults := map[string]string{}
 		if err := json.Unmarshal([]byte(InjectDefaults), &defaults); err != nil {
 			t.Errorf("Unable to parse InjectDefaults: %v", err)
 		}
 
-		if value, ok := settings["system-default-registry"]; ok {
-			expect = value.Get()
+		if value, ok := defaults["system-default-registry"]; ok {
+			expect = value
 		}
 	}
 


### PR DESCRIPTION
## Issue: #38808
 
## Problem
SUSE/Rancher needs the ability to set the default registry to pull images from. This is separate from the user setting so that user settings (especially from charts) do not overwrite this default value.
 
## Solution
Add a new environment variable that's the default value for the CATTLE_SYSTEM_DEFAULT_REGISTRY
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
N/A

### Automated Testing
An automated test was added to ensure the default value for the system default registry is the same as it was before the change when the new environment variable is not set.

No test was added for when the new environment variable was set because I didn't see a good way to inject it into the current test setup. Pointers welcome if there is a good place to do this.

## QA Testing Considerations
Testing this on a new install and an upgrade would be useful. An upgrade where CATTLE_BASE_REGISTRY starts as "" and moves to a different registry and an upgrade that starts with a specified registry and goes to "".
  
### Regressions Considerations
When the new environment variable is not set it will default to "" which is the existing value.