### PR TITLE
 Skip flaky tests that are no longer supported

### DIFF
--- a/tests/validation/tests/v3_api/test_catalog_library.py
+++ b/tests/validation/tests/v3_api/test_catalog_library.py
@@ -24,6 +24,9 @@ from .common import get_project_client_for_token
 from .common import USER_TOKEN
 from .common import get_user_client
 
+# Skipping all the tests from this module because the library_catalog charts are not supported on latest
+# rancher versions
+pytest.skip(allow_module_level=True)
 
 cluster_info = {"cluster": None, "cluster_client": None,
                 "project": None, "project_client": None,

--- a/tests/validation/tests/v3_api/test_cis_scan.py
+++ b/tests/validation/tests/v3_api/test_cis_scan.py
@@ -25,6 +25,9 @@ from .common import wait_for_cluster_node_count
 from .test_rke_cluster_provisioning import HOST_NAME, \
     POD_SECURITY_POLICY_TEMPLATE, get_cis_rke_config  # NOQA
 
+# Skipping all the tests from this module since CIS 1.5 and CIS 1.4 profile are not supported on latest k8s versions.
+pytest.skip(allow_module_level=True)
+
 scan_results = {
     "rke-cis-1.4": {
         "permissive": {"pass": 63, "skip": 15},

--- a/tests/validation/tests/v3_api/test_logging.py
+++ b/tests/validation/tests/v3_api/test_logging.py
@@ -12,6 +12,10 @@ from .common import wait_for_app_to_remove
 from .common import CATTLE_TEST_URL
 from .common import USER_TOKEN
 
+# Skipping this test module because library-fluentd-aggregator from library catalog is not supported on latest
+# rancher versions
+pytest.skip(allow_module_level=True)
+
 namespace = {"p_client": None, "ns": None, "cluster": None, "project": None,
              "name_prefix": None, "admin_client": None, "sys_p_client": None}
 fluentd_aggregator_answers = {"defaultImage": "true",

--- a/tests/validation/tests/v3_api/test_logging_e2e.py
+++ b/tests/validation/tests/v3_api/test_logging_e2e.py
@@ -15,6 +15,10 @@ from .common import get_user_client_and_cluster
 from .common import random_test_name
 from .common import wait_for_app_to_active
 
+# Skipping this test module because library-fluentd-aggregator from library catalog is not supported on latest
+# rancher versions
+pytest.skip(allow_module_level=True)
+
 namespace = {"p_client": None, "ns": None, "cluster": None, "project": None,
              "name_prefix": None, "admin_client": None, "sys_p_client": None,
              "pod": None}

--- a/tests/validation/tests/v3_api/test_monitoring.py
+++ b/tests/validation/tests/v3_api/test_monitoring.py
@@ -2,6 +2,8 @@ import pytest
 import copy
 from .common import *  # NOQA
 
+# Skipping all the tests from this module because monitoring v1 isn't supported on k8s 1.21+
+pytest.skip(allow_module_level=True)
 
 namespace = {
     "cluster": None,

--- a/tests/validation/tests/v3_api/test_multi_cluster_app.py
+++ b/tests/validation/tests/v3_api/test_multi_cluster_app.py
@@ -18,6 +18,8 @@ from .common import delete_node
 import pytest
 import time
 
+# Skipping all the tests from this module because Multi-Cluster Apps have been deprecated as of Rancher v2.5.0
+pytest.skip(allow_module_level=True)
 
 project = {}
 project_detail = {"c0_id": None, "c1_id": None, "c2_id": None,


### PR DESCRIPTION
## Issue
From _rancher-v3_additional_tests_ jenkins job below tests were failing due to incompatibility with latest rancher server versions:
- test_catalog_library
- test_cis_scan
- test_logging
- test_monitoring
- test_multi_cluster_app

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
- Added pytest.skip(allow_module_level=True) to skip all the related tests.
 
