### PR TITLE
Updating proxy to allow node driver provisioning

### DIFF
--- a/tests/validation/tests/v3_api/resource/squid/squid.conf
+++ b/tests/validation/tests/v3_api/resource/squid/squid.conf
@@ -11,6 +11,10 @@ acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
 acl localnet src fc00::/7       # RFC 4193 local private network range
 acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
 
+acl Safe_ports port 22      # ssh
+acl Safe_ports port 2376    # docker port 
+acl SSL_ports port 22
+acl SSL_ports port 2376
 acl SSL_ports port 443
 acl SSL_ports port 6443
 acl Safe_ports port 80		# http

--- a/tests/validation/tests/v3_api/test_proxy.py
+++ b/tests/validation/tests/v3_api/test_proxy.py
@@ -22,6 +22,7 @@ SSH_KEY_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                            '.ssh')
 
 RANCHER_PROXY_PORT = os.environ.get("RANCHER_PROXY_PORT", "3131")
+RANCHER_CIDR_OVERRIDE = os.environ.get("RANCHER_CIDR_OVERRIDE", "")
 
 
 def deploy_proxy_server():
@@ -98,8 +99,8 @@ def prepare_airgap_proxy_node(bastion_node, number_of_nodes):
         proxy_info = '[Service]\nEnvironment=\"HTTP_PROXY={}\" ' \
                      '\"HTTPS_PROXY={}\" ' \
                      '\"NO_PROXY=localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,' \
-                     'cattle-system.svc\"' \
-                     .format(proxy_url, proxy_url)
+                     'cattle-system.svc,{}\"' \
+                     .format(proxy_url, proxy_url, RANCHER_CIDR_OVERRIDE)
 
         bastion_node.execute_command('echo "{}" > http-proxy.conf'
                                      .format(proxy_info))
@@ -137,17 +138,16 @@ def prepare_airgap_proxy_node(bastion_node, number_of_nodes):
 def deploy_proxy_rancher(bastion_node):
     ag_node = prepare_airgap_proxy_node(bastion_node, 1)[0]
     proxy_url = bastion_node.host_name + ":" + RANCHER_PROXY_PORT
-
     deploy_rancher_command = \
         'sudo docker run -d --privileged --restart=unless-stopped ' \
         '-p 80:80 -p 443:443 ' \
         '-e HTTP_PROXY={} ' \
         '-e HTTPS_PROXY={} ' \
         '-e NO_PROXY="localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,' \
-        'cattle-system.svc" ' \
+        'cattle-system.svc,{}" ' \
         '-e CATTLE_BOOTSTRAP_PASSWORD=\\\"{}\\\" ' \
         'rancher/rancher:{} --trace'.format(
-            proxy_url, proxy_url,
+            proxy_url, proxy_url, RANCHER_CIDR_OVERRIDE,
             ADMIN_PASSWORD, RANCHER_SERVER_VERSION)
 
     deploy_result = run_command_on_proxy_node(bastion_node, ag_node,


### PR DESCRIPTION

## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/qa-tasks/issues/486

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
our proxy was not allowing downstream node driver clusters to be created. This was due to missing parameters in the squid.conf 

We also were lacking parameters for a specific use case, where a rancher setup is behind proxy with downstream nodes behind a proxy (see https://github.com/rancher/rancher/issues/37295#issuecomment-1111380535 for more details on the use case)
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
* added new rules to squid.conf to open ports for node driver clusters
* added new parameter that appends to NO_PROXY if specified. This should allow for testing the proxy/airgap use case.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
see offline link for more details. Tested with and without the CIDR override setting. Also have supporting jenkinsjob PR ready.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->