### PR TITLE
v1 chart installation for targeted/provisoned clusters

### DIFF
--- a/tests/v2/validation/resource/terraform/README.md
+++ b/tests/v2/validation/resource/terraform/README.md
@@ -1,0 +1,78 @@
+# Terraform Chart Installations
+
+Scripts to target an existing cluster for chart installations or to provision a cluster with charts installed
+
+---
+#### NOTES
+- Leaving v2 chart versions blank ("") will install the latest version in scope for release catalog
+- v1 target clusters require manual installation of v1 cluster-monitoring, v1 provisioned clusters will include v1 cluster-monitoring
+- v1 Istio is deprecated after 2.5x, this chart can be installed using a supported version
+- v2 Rancher Backups will always be installed into the local cluster, proper permissions are required `is_admin = 1` will indicate sufficent access to install v2 Rancher Backups, `is_admin = 0` will skip this chart installation
+- v2 Neuvector requires a cluster type parameter, use `docker_install = true` for RKE1 and `k3s_install = true` for RKE2 target clusters. Provisioned clusters will be RKE1 docker installations via node template
+- v2 Neuvector is not in scope for 2.5x (Partner Charts) `rancher_version_26_or_higher = 1` will install v2 Neuvector, while  `rancher_version_26_or_higher = 0` will skip this chart installation
+___
+
+## Setup
+To run locally you will need to:
+- create a file titled `terraform.tfvars` nested inside the folder of the script to be exected
+- add desired values to corresponding environment variables
+
+Sample `terraform.tfvars` for v1 charts
+```
+rancher_api_url = ""
+rancher_token_key = ""
+project_id = ""
+cluster_provider = ""
+cluster_name = ""
+ami = ""
+ami_user = ""
+node_name = ""
+vpc_id = ""
+zone = "" 
+aws_region = ""
+root_size = ""
+instance_type = ""
+worker_count = 
+k8s_version = ""
+istio_version = ""
+```
+
+Sample `terraform.tfvars` for v2 charts
+```
+rancher_api_url = ""
+rancher_token_key = ""
+cluster_id = ""
+project_id = ""
+monitoring_version = ""
+alerting_version = ""
+kiali_version = ""
+tracing_version = ""
+istio_version = ""
+logging_version = ""
+cis_version = ""
+gatekeeper_version = ""
+longhorn_version = ""
+backup_version = ""
+neuvector_version = ""
+rancher_version_26_or_higher = 1
+is_admin = 0
+docker_install = true
+k3s_install = false
+cluster_provider = ""
+cluster_name = ""
+ami = ""
+ami_user = ""
+node_name = ""
+vpc_id = ""
+zone = "" 
+aws_region = ""
+root_size = ""
+instance_type = ""
+worker_count = 
+k8s_version = "" 
+```
+___
+## To Execute
+Run the following commands from inside the desired folder to initiate the script:
+- `terraform init`
+- `terraform apply`

--- a/tests/v2/validation/resource/terraform/v1charts/Dockerfile.v1charts
+++ b/tests/v2/validation/resource/terraform/v1charts/Dockerfile.v1charts
@@ -1,0 +1,17 @@
+FROM golang:1.18
+
+# Configure Go
+ENV GOPATH /go
+ENV PATH ${PATH}:/go/bin
+
+ENV WORKSPACE ${GOPATH}/src/github.com/rancher/rancher
+
+WORKDIR $WORKSPACE/tests/v2/validation/resource/terraform/v1charts
+
+COPY [".", "$WORKSPACE"]
+RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && chmod +x ./kubectl \
+    && mv ./kubectl /go/bin
+
+RUN go mod init main
+RUN go mod tidy

--- a/tests/v2/validation/resource/terraform/v1charts/Jenkinsfile
+++ b/tests/v2/validation/resource/terraform/v1charts/Jenkinsfile
@@ -1,0 +1,130 @@
+// Job Params
+// Provisioning Requirements: RANCHER_API_URL, RANCHER_TOKEN_KEY, HOSTNAME_PREFIX, WORKER_COUNT, AWS_AMI, AWS_AMI_USER
+// Target Requirements: RANCHER_API_URL, RANCHER_TOKEN_KEY, CLUSTER_ID, PROJECT_ID
+
+node {
+  def job_name = "${JOB_NAME}"
+  if (job_name.contains('/')) { 
+    job_names = job_name.split('/')
+    job_name = job_names[job_names.size() - 1] 
+  }
+  def testContainer = "${job_name}${env.BUILD_NUMBER}_test"
+  def imageName = "rancher-validation-${job_name}${env.BUILD_NUMBER}"
+  def envFile = ".env"
+  def rancher_api_url = "${env.RANCHER_API_URL}"
+  def rancher_token_key = "${env.RANCHER_TOKEN_KEY}"
+  def hostname_prefix = "${env.HOSTNAME_PREFIX}"
+  def worker_count = "${env.WORKER_COUNT}"
+  def tf_version = "${env.TF_VERSION}"
+  def aws_ami = "${env.AWS_AMI}"
+  def aws_ami_user = "${env.AWS_AMI_USER}"
+  def k8s_version = "${env.K8S_VERSION}"
+  def cluster_id = "${env.CLUSTER_ID}"
+  def project_id = "${env.PROJECT_ID}"
+  def suffix = "-tf-cluster-0"
+  def etcd_suffix = "-tf-etcd-0"
+  def cp_suffix = "-tf-controlplane-0"
+  def worker_suffix = "-tf-worker-0"
+  def aws_cluster_name = "-aws-tf-v1charts"
+
+  def branch = "release/v2.6"
+  if ("${env.branch}" != "null" && "${env.branch}" != "") {
+    branch = "${env.branch}"
+  }
+
+  def endpoint = RANCHER_API_URL.split("://")[1] + ":514"
+  def istio_version = "${env.ISTIO_VERSION}"
+
+  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+    withFolderProperties {
+      paramsMap = []
+      params.each {
+        paramsMap << "$it.key=$it.value"
+      }
+      withEnv(paramsMap) {
+      withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                        string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+                        string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                        string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                        string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD')
+                        ]) {
+                          
+        stage('Checkout') {
+          deleteDir()
+          checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: "*/${branch}"]],
+                    extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                    userRemoteConfigs: scm.userRemoteConfigs
+                  ])
+        }
+
+        dir ("./") {
+
+          stage('Configure and Build') {
+            if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
+              dir(".ssh") {
+                def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
+                writeFile file: AWS_SSH_KEY_NAME, text: decoded
+              }
+            }
+
+            sh "./tests/v2/validation/resource/terraform/v1charts/configure.sh"
+            sh "./tests/v2/validation/resource/terraform/v1charts/build.sh"
+          }
+
+          try {
+            stage('Run Chart Installation') {
+              if (cluster_id == "") {
+                  sh "docker run --name ${testContainer} -t --env-file ${envFile} " + 
+                  "${imageName} sh -c \"export TF_VAR_rancher_api_url=${rancher_api_url}" + 
+                  "&& export TF_VAR_rancher_token_key=${rancher_token_key}" + 
+                  "&& export TF_VAR_aws_access_key=${AWS_ACCESS_KEY_ID}" + 
+                  "&& export TF_VAR_aws_secret_key=${AWS_SECRET_ACCESS_KEY}" + 
+                  "&& export provider=aws" + 
+                  "&& export tfversion=${tf_version}" + 
+                  "&& export TF_VAR_cluster_name=${hostname_prefix}"+"$aws_cluster_name" + 
+                  "&& export TF_VAR_hostname_prefix_etcd=${hostname_prefix}"+"$etcd_suffix" + 
+                  "&& export TF_VAR_hostname_prefix_cp=${hostname_prefix}"+"$cp_suffix" + 
+                  "&& export TF_VAR_hostname_prefix_worker=${hostname_prefix}"+"$worker_suffix" + 
+                  "&& export TF_VAR_worker_count=${worker_count}" + 
+                  "&& export TF_VAR_ami=${aws_ami}" +  
+                  "&& export TF_VAR_ami_user=${aws_ami_user}" + 
+                  "&& export TF_VAR_k8s_version=${k8s_version}" +
+                  "&& export TF_VAR_logging_endpoint=${endpoint}" +
+                  "&& export TF_VAR_istio_version=${istio_version}" +
+                  "&& go run .\""
+            } else {
+                sh "docker run --name ${testContainer} -t --env-file ${envFile} " + 
+                "${imageName} sh -c \"export TF_VAR_rancher_api_url=${rancher_api_url}" + 
+                "&& export TF_VAR_rancher_token_key=${rancher_token_key}" + 
+                "&& export provider=target" + 
+                "&& export TF_VAR_istio_version=${istio_version}" + 
+                "&& export TF_VAR_cluster_id=${cluster_id}" + 
+                "&& export TF_VAR_project_id=${project_id}" + 
+                "&& export TF_VAR_logging_endpoint=${endpoint}" +
+                "&& export TF_VAR_istio_version=${istio_version}" +
+                "&& export tfversion=${tf_version}" + 
+                "&& go run .\""
+              }
+            }
+          } catch(err) {
+            echo 'Test run had failures. Collecting results...'
+          }
+
+          try {
+            stage('Cleanup') {
+              sh "docker rm -v ${testContainer}"
+              sh "docker rmi ${imageName}"
+            }
+          } catch(err){
+            sh "docker stop ${testContainer}"
+            sh "docker rm -v ${testContainer}"
+            sh "docker rmi ${imageName}"
+          }
+        }
+      }
+    }
+  } 
+  }
+}

--- a/tests/v2/validation/resource/terraform/v1charts/aws/main.tf
+++ b/tests/v2/validation/resource/terraform/v1charts/aws/main.tf
@@ -1,0 +1,233 @@
+#Cluster creation with v1 charts installed
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    rancher2 = {
+      source = "rancher/rancher2"
+    }
+
+  }
+}
+
+provider "rancher2" {
+  api_url   = var.rancher_api_url
+  token_key = var.rancher_token_key
+}
+
+resource "rancher2_cluster" "custom" {
+  name = var.cluster_name
+  description = "Rancher v1 Charts Cluster"
+  rke_config {
+    kubernetes_version = var.k8s_version
+    network {
+      plugin = "canal"
+    }
+  }
+  enable_cluster_monitoring = true
+  cluster_monitoring_input {
+    answers = {
+      "exporter-kubelets.https" = true
+      "exporter-node.enabled" = true
+      "exporter-node.ports.metrics.port" = 9796
+      "exporter-node.resources.limits.cpu" = "200m"
+      "exporter-node.resources.limits.memory" = "200Mi"
+      "grafana.persistence.enabled" = false
+      "grafana.persistence.size" = "10Gi"
+      "grafana.persistence.storageClass" = "default"
+      "operator.resources.limits.memory" = "500Mi"
+      "prometheus.persistence.enabled" = "false"
+      "prometheus.persistence.size" = "50Gi"
+      "prometheus.persistence.storageClass" = "default"
+      "prometheus.persistent.useReleaseName" = "true"
+      "prometheus.resources.core.limits.cpu" = "1000m",
+      "prometheus.resources.core.limits.memory" = "1500Mi"
+      "prometheus.resources.core.requests.cpu" = "750m"
+      "prometheus.resources.core.requests.memory" = "750Mi"
+      "prometheus.retention" = "12h"
+    }
+  }
+}
+
+resource "rancher2_node_template" "node-template" {
+  name = "tf-aws-node-template"
+  description = "TF AWS node template"
+
+  amazonec2_config {
+    access_key = var.aws_access_key
+    secret_key = var.aws_secret_key
+    ami =  var.ami
+    region = var.aws_region
+    security_group = var.security_groups
+    subnet_id = var.subnet
+    vpc_id = var.vpc_id
+    zone = var.zone
+    root_size = var.root_size
+    instance_type = var.instance_type
+  }
+}
+
+resource "rancher2_node_pool" "cp-node-pool" {
+  cluster_id =  rancher2_cluster.custom.id
+  name = "tf-cp-node-pool"
+  hostname_prefix = var.hostname_prefix_cp
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = 2
+  control_plane = true
+  etcd = false
+  worker = false
+}
+
+resource "rancher2_node_pool" "etcd-node-pool" {
+  cluster_id =  rancher2_cluster.custom.id
+  name = "tf-etcd-node-pool"
+  hostname_prefix = var.hostname_prefix_etcd
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = 3
+  control_plane = false
+  etcd = true
+  worker = false
+}
+
+resource "rancher2_node_pool" "worker-node-pool" {
+  cluster_id =  rancher2_cluster.custom.id
+  name = "tf-worker-node-pool"
+  hostname_prefix = var.hostname_prefix_worker
+  node_template_id = rancher2_node_template.node-template.id
+  quantity = var.worker_count
+  control_plane = false
+  etcd = false
+  worker = true
+}
+
+resource "rancher2_cluster_sync" "v1charts-sync" {
+  cluster_id = rancher2_cluster.custom.id
+  wait_catalogs = true
+  state_confirm = 60
+}
+
+resource "local_file" "sync_kube_config" {
+    depends_on = [rancher2_cluster_sync.v1charts-sync]
+    content  = rancher2_cluster_sync.v1charts-sync.kube_config
+    filename = "kube_config_provisioned_cluster.yaml"
+}
+
+resource "rancher2_namespace" "istio-namespace" {
+  name = "istio-system"
+  project_id = rancher2_cluster_sync.v1charts-sync.system_project_id
+  description = "istio namespace"
+}
+
+resource "rancher2_app" "istio" {
+  catalog_name = "system-library"
+  name = "cluster-istio"
+  description = "Terraform app acceptance test"
+  project_id = rancher2_cluster_sync.v1charts-sync.system_project_id
+  template_name = "rancher-istio"
+  template_version = var.istio_version
+  target_namespace = rancher2_namespace.istio-namespace.id
+  answers = {
+    "certmanager.enabled" = false
+    "enableCRDs" = true
+    "galley.enabled" = true
+    "gateways.enabled" = false
+    "gateways.istio-ingressgateway.resources.limits.cpu" = "2000m"
+    "gateways.istio-ingressgateway.resources.limits.memory" = "1024Mi"
+    "gateways.istio-ingressgateway.resources.requests.cpu" = "100m"
+    "gateways.istio-ingressgateway.resources.requests.memory" = "128Mi"
+    "gateways.istio-ingressgateway.type" = "NodePort"
+    "global.monitoring.type" = "cluster-monitoring"
+    "global.rancher.clusterId" = rancher2_cluster_sync.v1charts-sync.cluster_id
+    "istio_cni.enabled" = false
+    "istiocoredns.enabled" = false
+    "kiali.enabled" = true
+    "mixer.enabled" = true
+    "mixer.policy.enabled" = true
+    "mixer.policy.resources.limits.cpu" = "4800m"
+    "mixer.policy.resources.limits.memory" = "4096Mi"
+    "mixer.policy.resources.requests.cpu" = "1000m"
+    "mixer.policy.resources.requests.memory" = "1024Mi"
+    "mixer.telemetry.resources.limits.cpu" = "4800m",
+    "mixer.telemetry.resources.limits.memory" = "4096Mi"
+    "mixer.telemetry.resources.requests.cpu" = "1000m"
+    "mixer.telemetry.resources.requests.memory" = "1024Mi"
+    "mtls.enabled" = false
+    "nodeagent.enabled" = false
+    "pilot.enabled" = true
+    "pilot.resources.limits.cpu" = "1000m"
+    "pilot.resources.limits.memory" = "4096Mi"
+    "pilot.resources.requests.cpu" = "500m"
+    "pilot.resources.requests.memory" = "2048Mi"
+    "pilot.traceSampling" = "1"
+    "security.enabled" = true
+    "sidecarInjectorWebhook.enabled" = true
+    "tracing.enabled" = true
+    "tracing.jaeger.resources.limits.cpu" = "500m"
+    "tracing.jaeger.resources.limits.memory" = "1024Mi"
+    "tracing.jaeger.resources.requests.cpu" = "100m"
+    "tracing.jaeger.resources.requests.memory" = "100Mi"
+  }
+}
+
+resource "rancher2_cluster_logging" "cluster-logging" {
+  name = "cluster-logging"
+  cluster_id = rancher2_cluster.custom.id
+  kind = "syslog"
+  syslog_config {
+    endpoint = var.logging_endpoint
+    protocol = "udp"
+    severity = "notice"
+    ssl_verify = false
+  }
+}
+
+resource "rancher2_namespace" "longhorn-system-namespace" {
+  name = "longhorn-system"
+  project_id = rancher2_cluster_sync.v1charts-sync.system_project_id
+  description = "longhorn-system namespace"
+}
+
+resource "null_resource" "longhorn-iscsi-nfs" {
+  depends_on = [rancher2_cluster_sync.v1charts-sync,local_file.sync_kube_config,rancher2_namespace.longhorn-system-namespace]
+  provisioner "local-exec" {
+    environment = {
+      KUBECONFIG = "kube_config_provisioned_cluster.yaml"
+    }
+    command = "kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.3.0/deploy/prerequisite/longhorn-iscsi-installation.yaml --namespace=longhorn-system && kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.3.0/deploy/prerequisite/longhorn-nfs-installation.yaml --namespace=longhorn-system"
+  }
+}
+
+resource "rancher2_app" "longhorn-system" {
+  catalog_name = "library"
+  name = "longhorn"
+  description = "Terraform app acceptance test"
+  project_id = rancher2_cluster_sync.v1charts-sync.system_project_id
+  template_name = "longhorn"
+  target_namespace = rancher2_namespace.longhorn-system-namespace.id
+  answers = {
+    "image.defaultImage" = true
+    "privateRegistry.registryUrl" = ""
+    "privateRegistry.registryUser" = ""
+    "privateRegistry.registryPasswd" = ""
+    "privateRegistry.registrySecret" = ""
+    "longhorn.default_setting" = false
+    "persistence.defaultClass" = true
+    "persistence.reclaimPolicy" = "Delete"
+    "persistence.defaultClassReplicaCount" = "3"
+    "persistence.recurringJobSelector.enable" = false
+    "persistence.backingImage.enable" = false
+    "ingress.enabled" = false
+    "service.ui.type" = "Rancher-Proxy"
+    "enablePSP" = true
+  }
+  depends_on = [null_resource.longhorn-iscsi-nfs]
+}
+
+resource "null_resource" "longhorn-statefulset-example" {
+  depends_on = [rancher2_app.longhorn-system]
+  provisioner "local-exec" {
+    environment = {
+      KUBECONFIG = "kube_config_provisioned_cluster.yaml"
+    }
+    command = "kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/statefulset.yaml"
+  }
+}

--- a/tests/v2/validation/resource/terraform/v1charts/aws/variables.tf
+++ b/tests/v2/validation/resource/terraform/v1charts/aws/variables.tf
@@ -1,0 +1,119 @@
+variable "rancher_api_url" {
+  type    = string
+  default = ""
+}
+
+variable "rancher_token_key" {
+  type    = string
+  default = ""
+}
+
+variable "ami" {
+  type        = string
+  default     = "ami-0452941f41a1b0608"
+  description = "ami to use"
+}
+
+variable "subnet" {
+  type        = string
+  default     = ""
+  description = "subnet to use"
+}
+
+variable "security_groups" {
+  type        = list
+  default     = []
+  description = "security group ids to use"
+}
+
+variable "ami_user" {
+  type        = string
+  default     = "ec2-user"
+  description = "User for the ami (used for ssh provisioning)"
+}
+
+variable "vpc_id" {
+  type        = string
+  default     = "vpc-bfccf4d7"
+  description = "AWS VPC ID"
+}
+
+variable "zone" {
+  type        = string
+  default     = ""
+  description = "AWS Zone"
+}
+
+variable "root_size" {
+  type        = string
+  default     = "80"
+  description = "AWS Root Size"
+}
+
+variable "instance_type" {
+  type        = string
+  default     = "t3.xlarge"
+  description = "AWS Instance Type"
+}
+
+variable "aws_access_key" {
+  type        = string
+  description = "AWS Access Key"
+}
+
+variable "aws_secret_key" {
+  type        = string
+  description = "AWS Secret Key"
+}
+
+variable "aws_region" {
+  type        = string
+  default     = "us-east-2"
+  description = "AWS Region"
+}
+variable "cluster_name" {
+  type        = string
+  default     = "v1charts-admin"
+  description = "Cluster name"
+}
+variable "hostname_prefix_cp" {
+  type        = string
+  default     = "tf-controlplane-0"
+  description = "Hostname Prefix for EC2 Instances"
+}
+
+variable "hostname_prefix_etcd" {
+  type        = string
+  default     = "tf-etcd-0"
+  description = "Hostname Prefix for EC2 Instances"
+}
+
+variable "hostname_prefix_worker" {
+  type        = string
+  default     = "tf-worker-0"
+  description = "Hostname Prefix for EC2 Instances"
+}
+
+variable "worker_count" {
+  type        = number
+  default     = 3
+  description = "Worker count for cluster"
+}
+
+variable "k8s_version" {
+  type        = string
+  default     = "v1.20.15-rancher1-1"
+  description = "Kubernetes Version"
+}
+
+variable "logging_endpoint" {
+  type        = string
+  default     = ""
+  description = "Default loggin endpoint"
+}
+
+variable "istio_version" {
+  type        = string
+  default     = "1.5.901"
+  description = "Default Istio version"
+}

--- a/tests/v2/validation/resource/terraform/v1charts/build.sh
+++ b/tests/v2/validation/resource/terraform/v1charts/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -x
+set -eu
+
+DEBUG="${DEBUG:-false}"
+RKE_VERSION="${RKE_VERSION:-v1.0.2}"
+RANCHER_HELM_VERSION="${RANCHER_HELM_VERSION:-v3.6.0}"
+KUBECTL_VERSION="${KUBECTL_VERSION:-v1.16.6}"
+CLI_VERSION="${CLI_VERSION:-v2.4.5}"
+SONOBUOY_VERSION="${SONOBUOY_VERSION:-0.18.2}"
+TERRAFORM_VERSION="${TERRAFORM_VERSION:-0.12.10}"
+
+TRIM_JOB_NAME=$(basename "$JOB_NAME")
+
+if [ "false" != "${DEBUG}" ]; then
+    echo "Environment:"
+    env | sort
+fi
+
+count=0
+while [[ 3 -gt $count ]]; do
+    docker build -q -f tests/v2/validation/resource/terraform/v1charts/Dockerfile.v1charts --build-arg CLI_VERSION="$CLI_VERSION" --build-arg RKE_VERSION="$RKE_VERSION" --build-arg RANCHER_HELM_VERSION="$RANCHER_HELM_VERSION" --build-arg KUBECTL_VERSION="$KUBECTL_VERSION" --build-arg SONOBUOY_VERSION="$SONOBUOY_VERSION" --build-arg TERRAFORM_VERSION="$TERRAFORM_VERSION" -t rancher-validation-"${TRIM_JOB_NAME}""${BUILD_NUMBER}" .
+    if [[ $? -eq 0 ]]; then break; fi
+    count=$(($count + 1))
+    echo "Repeating failed Docker build ${count} of 3..."
+done

--- a/tests/v2/validation/resource/terraform/v1charts/configure.sh
+++ b/tests/v2/validation/resource/terraform/v1charts/configure.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -x
+set -eu
+
+DEBUG="${DEBUG:-false}"
+
+env | egrep '^(ARM_|CATTLE_|ADMIN|USER|DO|RANCHER_|AWS_|DEBUG|LOGLEVEL|DEFAULT_|OS_|DOCKER_|CLOUD_|KUBE|BUILD_NUMBER|AZURE).*\=.+' | sort > .env
+
+if [ "false" != "${DEBUG}" ]; then
+    cat .env
+fi

--- a/tests/v2/validation/resource/terraform/v1charts/target/main.tf
+++ b/tests/v2/validation/resource/terraform/v1charts/target/main.tf
@@ -1,0 +1,149 @@
+#Target cluster for v1 charts installation
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    rancher2 = {
+      source = "rancher/rancher2"
+    }
+  }
+}
+
+provider "rancher2" {
+  api_url   = var.rancher_api_url
+  token_key = var.rancher_token_key
+}
+
+resource "rancher2_cluster_sync" "v1target-sync" {
+  cluster_id =  var.cluster_id
+}
+
+resource "local_file" "sync_kube_config" {
+    depends_on = [rancher2_cluster_sync.v1target-sync]
+    content  = rancher2_cluster_sync.v1target-sync.kube_config
+    filename = "kube_config_provisioned_cluster.yaml"
+}
+
+
+resource "rancher2_namespace" "longhorn-system-namespace" {
+  depends_on = [rancher2_cluster_sync.v1target-sync,local_file.sync_kube_config]
+  name = "longhorn-system"
+  project_id = var.project_id
+  description = "longhorn-system namespace"
+}
+
+
+resource "null_resource" "longhorn-iscsi-nfs" {
+  depends_on = [rancher2_cluster_sync.v1target-sync,local_file.sync_kube_config,rancher2_namespace.longhorn-system-namespace]
+  provisioner "local-exec" {
+    environment = {
+      KUBECONFIG = "kube_config_provisioned_cluster.yaml"
+    }
+    command = "kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.3.0/deploy/prerequisite/longhorn-iscsi-installation.yaml --namespace=longhorn-system && kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.3.0/deploy/prerequisite/longhorn-nfs-installation.yaml --namespace=longhorn-system"
+  }
+}
+
+
+resource "rancher2_app" "longhorn-system" {
+  catalog_name = "library"
+  name = "longhorn"
+  description = "Terraform app acceptance test"
+  project_id = var.project_id
+  template_name = "longhorn"
+  target_namespace = rancher2_namespace.longhorn-system-namespace.id
+  answers = {
+    "image.defaultImage" = true
+    "privateRegistry.registryUrl" = ""
+    "privateRegistry.registryUser" = ""
+    "privateRegistry.registryPasswd" = ""
+    "privateRegistry.registrySecret" = ""
+    "longhorn.default_setting" = false
+    "persistence.defaultClass" = true
+    "persistence.reclaimPolicy" = "Delete"
+    "persistence.defaultClassReplicaCount" = "3"
+    "persistence.recurringJobSelector.enable" = false
+    "persistence.backingImage.enable" = false
+    "ingress.enabled" = false
+    "service.ui.type" = "Rancher-Proxy"
+    "enablePSP" = true
+  }
+}
+
+resource "null_resource" "longhorn-statefulset-example" {
+  depends_on = [rancher2_app.longhorn-system]
+  provisioner "local-exec" {
+    environment = {
+      KUBECONFIG = "kube_config_provisioned_cluster.yaml"
+    }
+    command = "kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/statefulset.yaml"
+  }
+}
+
+resource "rancher2_cluster_logging" "cluster-logging" {
+  name = "cluster-logging"
+  cluster_id = var.cluster_id
+  kind = "syslog"
+  syslog_config {
+    endpoint = var.logging_endpoint
+    protocol = "udp"
+    severity = "notice"
+    ssl_verify = false
+  }
+}
+
+resource "rancher2_namespace" "istio-namespace" {
+  name = "istio-system"
+  project_id = var.project_id
+  description = "istio namespace"
+}
+
+
+resource "rancher2_app" "istio" {
+  catalog_name = "system-library"
+  name = "cluster-istio"
+  description = "Terraform app acceptance test"
+  project_id = var.project_id
+  template_name = "rancher-istio"
+  template_version = var.istio_version
+  target_namespace = rancher2_namespace.istio-namespace.id
+  answers = {
+    "certmanager.enabled" = false
+    "enableCRDs" = true
+    "galley.enabled" = true
+    "gateways.enabled" = false
+    "gateways.istio-ingressgateway.resources.limits.cpu" = "2000m"
+    "gateways.istio-ingressgateway.resources.limits.memory" = "1024Mi"
+    "gateways.istio-ingressgateway.resources.requests.cpu" = "100m"
+    "gateways.istio-ingressgateway.resources.requests.memory" = "128Mi"
+    "gateways.istio-ingressgateway.type" = "NodePort"
+    "global.monitoring.type" = "cluster-monitoring"
+    "global.rancher.clusterId" = var.cluster_id
+    "istio_cni.enabled" = false
+    "istiocoredns.enabled" = false
+    "kiali.enabled" = true
+    "mixer.enabled" = true
+    "mixer.policy.enabled" = true
+    "mixer.policy.resources.limits.cpu" = "4800m"
+    "mixer.policy.resources.limits.memory" = "4096Mi"
+    "mixer.policy.resources.requests.cpu" = "1000m"
+    "mixer.policy.resources.requests.memory" = "1024Mi"
+    "mixer.telemetry.resources.limits.cpu" = "4800m",
+    "mixer.telemetry.resources.limits.memory" = "4096Mi"
+    "mixer.telemetry.resources.requests.cpu" = "1000m"
+    "mixer.telemetry.resources.requests.memory" = "1024Mi"
+    "mtls.enabled" = false
+    "nodeagent.enabled" = false
+    "pilot.enabled" = true
+    "pilot.resources.limits.cpu" = "1000m"
+    "pilot.resources.limits.memory" = "4096Mi"
+    "pilot.resources.requests.cpu" = "500m"
+    "pilot.resources.requests.memory" = "2048Mi"
+    "pilot.traceSampling" = "1"
+    "security.enabled" = true
+    "sidecarInjectorWebhook.enabled" = true
+    "tracing.enabled" = true
+    "tracing.jaeger.resources.limits.cpu" = "500m"
+    "tracing.jaeger.resources.limits.memory" = "1024Mi"
+    "tracing.jaeger.resources.requests.cpu" = "100m"
+    "tracing.jaeger.resources.requests.memory" = "100Mi"
+  }
+}

--- a/tests/v2/validation/resource/terraform/v1charts/target/variables.tf
+++ b/tests/v2/validation/resource/terraform/v1charts/target/variables.tf
@@ -1,0 +1,29 @@
+variable "rancher_api_url" {
+  type    = string
+  default = ""
+}
+
+variable "rancher_token_key" {
+  type    = string
+  default = ""
+}
+
+variable "logging_endpoint" {
+  type        = string
+  default     = ""
+  description = "Default loggin endpoint"
+}
+
+variable "cluster_id" {
+  default = ""
+}
+
+variable "project_id" {
+  default = ""
+}
+
+variable "istio_version" {
+  type        = string
+  default     = "1.5.901"
+  description = "Default Istio version"
+}

--- a/tests/v2/validation/resource/terraform/v1charts/test.go
+++ b/tests/v2/validation/resource/terraform/v1charts/test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hc-install/product"
+	"github.com/hashicorp/hc-install/releases"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+func main() {
+	installer := &releases.ExactVersion{
+		Product: product.Terraform,
+		Version: version.Must(version.NewVersion(os.Getenv("tfversion"))),
+	}
+
+	execPath, err := installer.Install(context.Background())
+	if err != nil {
+		log.Fatalf("error installing Terraform: %s", err)
+	}
+
+	workingDir := os.Getenv("provider")
+	tf, err := tfexec.NewTerraform(workingDir, execPath)
+	if err != nil {
+		log.Fatalf("error running NewTerraform: %s", err)
+	}
+
+	err = tf.Init(context.Background(), tfexec.Upgrade(true))
+	if err != nil {
+		log.Fatalf("error running Init: %s", err)
+	}
+
+	err = tf.Apply(context.Background())
+	if err != nil {
+		log.Fatalf("error running Apply: %s", err)
+	}
+
+	state, err := tf.Show(context.Background())
+	if err != nil {
+		log.Fatalf("error running Show: %s", err)
+	}
+
+	fmt.Println("Using v" + state.FormatVersion + "\nv1 Chart installations initiated") // "0.1"
+
+}


### PR DESCRIPTION
Added v1 Charts installation scripts for test scenarios surrounding included rancher charts

Includes support for Rancher 2.5x/2.6x for targeted/provisioned clusters for admin/standard users

Charts installed:
monitoring-operator
cluster-monitoring
longhorn
cluster-istio
rancher-logging