### PR TITLE
Fixes circular roles prevention filling up logs

### DIFF
--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -372,7 +372,7 @@ func (m *manager) gatherRolesRecurse(rt *v3.RoleTemplate, roleTemplates map[stri
 			return errors.Wrapf(err, "couldn't get RoleTemplate %s", rtName)
 		}
 		if err := m.gatherRoles(subRT, roleTemplates, depthCounter); err != nil {
-			return errors.Wrapf(err, "couldn't gather RoleTemplate %s", rtName)
+			return err
 		}
 	}
 


### PR DESCRIPTION
Previous logging would result in a lot of logs when a recursive role was encountered. Addressing re-opening of https://github.com/rancher/rancher/issues/38419

## Issue: 
Logging and errors resulting from circular roles fills up logs.
 
## Problem
The error gets wrapped before returning in a recursive function.
 
## Solution
Just return the error.
 
## Testing
Debug and printed err to confirm it is no longer a big string.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
n/a