### PR TITLE
Add sync back to check for user-node-remove, add tests

### DIFF
--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/rancher/rancher/pkg/agent/clean"
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	util "github.com/rancher/rancher/pkg/cluster"
 	"github.com/rancher/rancher/pkg/dialer"
 	"github.com/rancher/rancher/pkg/features"
@@ -28,9 +28,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-const cleanupPodLabel = "rke.cattle.io/cleanup-node"
+const (
+	cleanupPodLabel                    = "rke.cattle.io/cleanup-node"
+	userNodeRemoveAnnotationPrefix     = "lifecycle.cattle.io/create.user-node-remove_"
+	userNodeRemoveCleanupAnnotationOld = "nodes.management.cattle.io/user-node-remove-cleanup"
+)
 
-func (m *Lifecycle) deleteV1Node(node *v32.Node) (runtime.Object, error) {
+func (m *Lifecycle) deleteV1Node(node *v3.Node) (runtime.Object, error) {
 	logrus.Debugf("Deleting v1.node for [%v] node", node.Status.NodeName)
 	if nodehelper.IgnoreNode(node.Status.NodeName, node.Status.NodeLabels) {
 		logrus.Debugf("Skipping v1.node removal for [%v] node", node.Status.NodeName)
@@ -71,7 +75,7 @@ func (m *Lifecycle) deleteV1Node(node *v32.Node) (runtime.Object, error) {
 	return node, nil
 }
 
-func (m *Lifecycle) drainNode(node *v32.Node) error {
+func (m *Lifecycle) drainNode(node *v3.Node) error {
 	nodeCopy := node.DeepCopy() // copy for cache protection as we do no updating but need things set for the drain
 	cluster, err := m.clusterLister.Get("", nodeCopy.Namespace)
 	if err != nil {
@@ -136,7 +140,7 @@ func (m *Lifecycle) drainNode(node *v32.Node) error {
 	})
 }
 
-func (m *Lifecycle) cleanRKENode(node *v32.Node) error {
+func (m *Lifecycle) cleanRKENode(node *v3.Node) error {
 	if !features.RKE1CustomNodeCleanup.Enabled() {
 		return nil
 	}
@@ -149,7 +153,7 @@ func (m *Lifecycle) cleanRKENode(node *v32.Node) error {
 		return err
 	}
 
-	if cluster.Status.Driver != v32.ClusterDriverRKE {
+	if cluster.Status.Driver != v3.ClusterDriverRKE {
 		return nil // not an rke node, bail out
 	}
 
@@ -240,7 +244,7 @@ func (m *Lifecycle) waitUntilJobDeletes(userContext *config.UserContext, nodeNam
 		"delete")
 }
 
-func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, cluster *v32.Cluster, node *v32.Node) (*batchv1.Job, error) {
+func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, cluster *v3.Cluster, node *v3.Node) (*batchv1.Job, error) {
 	nodeLabel := "cattle.io/node"
 
 	// find if someone else already kicked this job off
@@ -393,11 +397,30 @@ func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, cluster *v
 	return userContext.K8sClient.BatchV1().Jobs("default").Create(context.TODO(), &job, metav1.CreateOptions{})
 }
 
+func (m *Lifecycle) userNodeRemoveCleanup(obj *v3.Node) (runtime.Object, error) {
+	newObj := obj.DeepCopy()
+	newObj.SetFinalizers(removeFinalizerWithPrefix(newObj.GetFinalizers(), userNodeRemoveFinalizerPrefix))
+
+	if newObj.DeletionTimestamp == nil {
+		annos := newObj.GetAnnotations()
+		if annos == nil {
+			annos = make(map[string]string)
+		} else {
+			annos = removeAnnotationWithPrefix(annos, userNodeRemoveAnnotationPrefix)
+			delete(annos, userNodeRemoveCleanupAnnotationOld)
+		}
+
+		annos[userNodeRemoveCleanupAnnotation] = "true"
+		newObj.SetAnnotations(annos)
+	}
+	return m.nodeClient.Update(newObj)
+}
+
 func removeFinalizerWithPrefix(finalizers []string, prefix string) []string {
 	var nf []string
 	for _, finalizer := range finalizers {
 		if strings.HasPrefix(finalizer, prefix) {
-			logrus.Debugf("a finalizer with prefix %s will be removed", prefix)
+			logrus.Debugf("finalizer with prefix %s will be removed", prefix)
 			continue
 		}
 		nf = append(nf, finalizer)

--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -420,7 +420,7 @@ func removeFinalizerWithPrefix(finalizers []string, prefix string) []string {
 	var nf []string
 	for _, finalizer := range finalizers {
 		if strings.HasPrefix(finalizer, prefix) {
-			logrus.Debugf("finalizer with prefix %s will be removed", prefix)
+			logrus.Debugf("finalizer with prefix [%s] will be removed", prefix)
 			continue
 		}
 		nf = append(nf, finalizer)
@@ -431,7 +431,7 @@ func removeFinalizerWithPrefix(finalizers []string, prefix string) []string {
 func removeAnnotationWithPrefix(annotations map[string]string, prefix string) map[string]string {
 	for k := range annotations {
 		if strings.HasPrefix(k, prefix) {
-			logrus.Debugf("annotation with prefix %s will be removed", prefix)
+			logrus.Debugf("annotation with prefix [%s] will be removed", prefix)
 			delete(annotations, k)
 		}
 	}

--- a/pkg/controllers/management/node/cleanup_test.go
+++ b/pkg/controllers/management/node/cleanup_test.go
@@ -1,0 +1,101 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveFinalizers(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "empty input",
+			prefix:   "test_prefix",
+			input:    []string{},
+			expected: nil,
+		},
+		{
+			name:     "nil input",
+			prefix:   "test_prefix",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty prefix",
+			prefix:   "",
+			input:    []string{"testing.cattle.io/a_test"},
+			expected: nil,
+		},
+		{
+			name:     "match",
+			prefix:   "testing.cattle.io/a_",
+			input:    []string{"testing.cattle.io/a_test"},
+			expected: nil,
+		},
+		{
+			name:     "no match",
+			prefix:   "testing.cattle.io/b_",
+			input:    []string{"testing.cattle.io/a_test"},
+			expected: []string{"testing.cattle.io/a_test"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+			actual := removeFinalizerWithPrefix(tt.input, tt.prefix)
+			a.Equal(tt.expected, actual)
+		})
+	}
+}
+
+func TestRemoveAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		input    map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "empty input",
+			prefix:   "test_prefix",
+			input:    map[string]string{},
+			expected: map[string]string{},
+		},
+		{
+			name:     "nil input",
+			prefix:   "test_prefix",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty prefix",
+			prefix:   "",
+			input:    map[string]string{"testing.cattle.io/a_test": "true"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "match",
+			prefix:   "testing.cattle.io/a_",
+			input:    map[string]string{"testing.cattle.io/a_test": "true"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "no match",
+			prefix:   "testing.cattle.io/b_",
+			input:    map[string]string{"testing.cattle.io/a_test": "true"},
+			expected: map[string]string{"testing.cattle.io/a_test": "true"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+			actual := removeAnnotationWithPrefix(tt.input, tt.prefix)
+			a.Equal(tt.expected, actual)
+		})
+	}
+}

--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	cond "github.com/rancher/norman/condition"
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	kd "github.com/rancher/rancher/pkg/controllers/management/kontainerdrivermetadata"
 	"github.com/rancher/rancher/pkg/controllers/management/secretmigrator"
 	"github.com/rancher/rancher/pkg/controllers/managementagent/podresources"
@@ -161,17 +161,17 @@ func (n *nodeSyncer) needUpdate(_ string, node *corev1.Node) (bool, error) {
 	return true, nil
 }
 
-func (m *nodesSyncer) sync(key string, _ *v32.Node) (runtime.Object, error) {
+func (m *nodesSyncer) sync(key string, _ *apimgmtv3.Node) (runtime.Object, error) {
 	if key == fmt.Sprintf("%s/%s", m.clusterNamespace, AllNodeKey) {
 		return nil, m.reconcileAll()
 	}
 	return nil, nil
 }
 
-func (m *nodesSyncer) updateNodeAndNode(node *corev1.Node, obj *v32.Node) (*corev1.Node, *v32.Node, error) {
+func (m *nodesSyncer) updateNodeAndNode(node *corev1.Node, obj *apimgmtv3.Node) (*corev1.Node, *apimgmtv3.Node, error) {
 	node, err := m.nodeClient.Update(node)
 	if err != nil {
-		// Return v32.Node is nil because it hasn't been persisted and therefor out of sync with cache
+		// Return apimgmtv3.Node is nil because it hasn't been persisted and therefor out of sync with cache
 		// so we don't want to return it from the handler
 		return node, nil, err
 	}
@@ -185,7 +185,7 @@ func (m *nodesSyncer) updateNodeAndNode(node *corev1.Node, obj *v32.Node) (*core
 	return node, obj, nil
 }
 
-func (m *nodesSyncer) updateLabels(node *corev1.Node, obj *v32.Node, nodePlan rketypes.RKEConfigNodePlan) (*corev1.Node, *v32.Node, error) {
+func (m *nodesSyncer) updateLabels(node *corev1.Node, obj *apimgmtv3.Node, nodePlan rketypes.RKEConfigNodePlan) (*corev1.Node, *apimgmtv3.Node, error) {
 	finalMap, changed := computeDelta(node.Labels, nodePlan.Labels, obj.Spec.MetadataUpdate.Labels, onlyKubeLabels)
 	if !changed {
 		return node, obj, nil
@@ -201,13 +201,13 @@ func (m *nodesSyncer) updateLabels(node *corev1.Node, obj *v32.Node, nodePlan rk
 
 	node.Labels = finalMap
 
-	obj.Spec.MetadataUpdate.Labels = v32.MapDelta{}
+	obj.Spec.MetadataUpdate.Labels = apimgmtv3.MapDelta{}
 
 	return m.updateNodeAndNode(node, obj)
 }
 
 // For any key that already exist in the plan, we should update or delete. For others, do not touch the plan.
-func computePlanDelta(planValues map[string]string, delta v32.MapDelta) (map[string]string, bool) {
+func computePlanDelta(planValues map[string]string, delta apimgmtv3.MapDelta) (map[string]string, bool) {
 	update := false
 	for k, v := range delta.Add {
 		if planValues[k] != "" {
@@ -226,7 +226,7 @@ func computePlanDelta(planValues map[string]string, delta v32.MapDelta) (map[str
 
 }
 
-func (m *nodesSyncer) updateAnnotations(node *corev1.Node, obj *v32.Node, nodePlan rketypes.RKEConfigNodePlan) (*corev1.Node, *v32.Node, error) {
+func (m *nodesSyncer) updateAnnotations(node *corev1.Node, obj *apimgmtv3.Node, nodePlan rketypes.RKEConfigNodePlan) (*corev1.Node, *apimgmtv3.Node, error) {
 	finalMap, changed := computeDelta(node.Annotations, nodePlan.Annotations, obj.Spec.MetadataUpdate.Annotations, allowAllPolicy)
 	if !changed {
 		return node, obj, nil
@@ -234,12 +234,12 @@ func (m *nodesSyncer) updateAnnotations(node *corev1.Node, obj *v32.Node, nodePl
 
 	node, obj = node.DeepCopy(), obj.DeepCopy()
 	node.Annotations = finalMap
-	obj.Spec.MetadataUpdate.Annotations = v32.MapDelta{}
+	obj.Spec.MetadataUpdate.Annotations = apimgmtv3.MapDelta{}
 
 	return m.updateNodeAndNode(node, obj)
 }
 
-func (m *nodesSyncer) syncLabels(_ string, obj *v32.Node) (runtime.Object, error) {
+func (m *nodesSyncer) syncLabels(_ string, obj *apimgmtv3.Node) (runtime.Object, error) {
 	if obj == nil {
 		return nil, nil
 	}
@@ -273,7 +273,7 @@ func allowAllPolicy(_ string) bool {
 
 // computeDelta will return the final updated map to apply and a boolean indicating whether there are changes to be applied.
 // If the boolean is false, the caller need not take any action as the data is already in sync.
-func computeDelta(currentState map[string]string, planValues map[string]string, delta v32.MapDelta, canChangeValue canChangeValuePolicy) (map[string]string, bool) {
+func computeDelta(currentState map[string]string, planValues map[string]string, delta apimgmtv3.MapDelta, canChangeValue canChangeValuePolicy) (map[string]string, bool) {
 	result := map[string]string{}
 	changed := false
 
@@ -308,13 +308,13 @@ func computeDelta(currentState map[string]string, planValues map[string]string, 
 	return result, changed
 }
 
-func (m *nodesSyncer) getNodePlan(node *v32.Node) (rketypes.RKEConfigNodePlan, error) {
+func (m *nodesSyncer) getNodePlan(node *apimgmtv3.Node) (rketypes.RKEConfigNodePlan, error) {
 	cluster, err := m.clusterLister.Get("", node.Namespace)
 	if err != nil {
 		return rketypes.RKEConfigNodePlan{}, err
 	}
 
-	if cluster.Status.Driver != v32.ClusterDriverRKE || cluster.Status.AppliedSpec.RancherKubernetesEngineConfig == nil {
+	if cluster.Status.Driver != apimgmtv3.ClusterDriverRKE || cluster.Status.AppliedSpec.RancherKubernetesEngineConfig == nil {
 		return rketypes.RKEConfigNodePlan{}, nil
 	}
 
@@ -403,8 +403,8 @@ func (m *nodesSyncer) reconcileAll() error {
 	if err != nil {
 		return err
 	}
-	machineMap := make(map[string]*v32.Node)
-	toDelete := make(map[string]*v32.Node)
+	machineMap := make(map[string]*apimgmtv3.Node)
+	toDelete := make(map[string]*apimgmtv3.Node)
 	for _, machine := range machines {
 		node, err := nodehelper.GetNodeForMachine(machine, m.nodeLister)
 		if err != nil {
@@ -445,16 +445,15 @@ func (m *nodesSyncer) reconcileAll() error {
 	return nil
 }
 
-func (m *nodesSyncer) reconcileNodeForNode(machine *v32.Node, node *corev1.Node, nodeCache *NodeCache) error {
+func (m *nodesSyncer) reconcileNodeForNode(machine *apimgmtv3.Node, node *corev1.Node, nodeCache *NodeCache) error {
 	if machine == nil {
 		return m.createNode(node, nodeCache)
 	}
 	return m.updateNode(machine, node)
 }
 
-func (m *nodesSyncer) removeNode(machine *v32.Node) error {
+func (m *nodesSyncer) removeNode(machine *apimgmtv3.Node) error {
 	if machine.DeletionTimestamp != nil {
-
 		return nil
 	}
 	if machine.Annotations == nil {
@@ -473,7 +472,7 @@ func (m *nodesSyncer) removeNode(machine *v32.Node) error {
 	return nil
 }
 
-func (m *nodesSyncer) updateNode(existing *v32.Node, node *corev1.Node) error {
+func (m *nodesSyncer) updateNode(existing *apimgmtv3.Node, node *corev1.Node) error {
 	toUpdate, err := m.convertNodeToMachine(node, existing)
 	if err != nil {
 		return err
@@ -494,7 +493,7 @@ func (m *nodesSyncer) updateNode(existing *v32.Node, node *corev1.Node) error {
 func (m *nodesSyncer) createNode(node *corev1.Node, nodeCache *NodeCache) error {
 	// respect user defined name or label
 	if nodehelper.IgnoreNode(node.Name, node.Labels) {
-		logrus.Debugf("Skipping v32.Node creation for [%v] node", node.Name)
+		logrus.Debugf("Skipping apimgmtv3.Node creation for [%v] node", node.Name)
 		return nil
 	}
 
@@ -524,18 +523,18 @@ func (m *nodesSyncer) createNode(node *corev1.Node, nodeCache *NodeCache) error 
 	return nil
 }
 
-func (m *nodesSyncer) getMachineForNodeFromCache(node *corev1.Node) (*v32.Node, error) {
+func (m *nodesSyncer) getMachineForNodeFromCache(node *corev1.Node) (*apimgmtv3.Node, error) {
 	return nodehelper.GetMachineForNode(node, m.clusterNamespace, m.machineLister)
 }
 
 type NodeCache struct {
-	all    []*v32.Node
-	byName map[string][]*v32.Node
+	all    []*apimgmtv3.Node
+	byName map[string][]*apimgmtv3.Node
 }
 
-func (n *NodeCache) Add(machine *v32.Node) {
+func (n *NodeCache) Add(machine *apimgmtv3.Node) {
 	if n.byName == nil {
-		n.byName = map[string][]*v32.Node{}
+		n.byName = map[string][]*apimgmtv3.Node{}
 	}
 	if name, ok := machine.Labels[nodehelper.LabelNodeName]; ok {
 		n.byName[name] = append(n.byName[name], machine)
@@ -543,7 +542,7 @@ func (n *NodeCache) Add(machine *v32.Node) {
 	n.all = append(n.all, machine)
 }
 
-func (m *nodesSyncer) getMachineForNode(node *corev1.Node, nodeCache *NodeCache) (*v32.Node, error) {
+func (m *nodesSyncer) getMachineForNode(node *corev1.Node, nodeCache *NodeCache) (*apimgmtv3.Node, error) {
 	if len(nodeCache.all) == 0 {
 		machines, err := m.machines.List(metav1.ListOptions{})
 		if err != nil {
@@ -570,7 +569,7 @@ func (m *nodesSyncer) getMachineForNode(node *corev1.Node, nodeCache *NodeCache)
 	return nil, nil
 }
 
-func resetConditions(machine *v32.Node) *v32.Node {
+func resetConditions(machine *apimgmtv3.Node) *apimgmtv3.Node {
 	if machine.Status.InternalNodeStatus.Conditions == nil {
 		return machine
 	}
@@ -589,7 +588,7 @@ func resetConditions(machine *v32.Node) *v32.Node {
 	return updated
 }
 
-func objectsAreEqual(existing *v32.Node, toUpdate *v32.Node) bool {
+func objectsAreEqual(existing *apimgmtv3.Node, toUpdate *apimgmtv3.Node) bool {
 	// we are updating spec and status only, so compare them
 	toUpdateToCompare := resetConditions(toUpdate)
 	existingToCompare := resetConditions(existing)
@@ -682,12 +681,12 @@ func statusEqualTest(proposed, existing corev1.NodeStatus) bool {
 	return true
 }
 
-func cleanStatus(machine *v32.Node) {
+func cleanStatus(machine *apimgmtv3.Node) {
 	var conditions []corev1.NodeCondition
 	for _, condition := range machine.Status.InternalNodeStatus.Conditions {
 		if condition.Type == "Ready" {
 			conditions = append(conditions, condition)
-			readyCondition := v32.NodeCondition{
+			readyCondition := apimgmtv3.NodeCondition{
 				Type:               cond.Cond(condition.Type),
 				Status:             condition.Status,
 				LastTransitionTime: condition.LastTransitionTime.String(),
@@ -738,12 +737,12 @@ func getResourceList(annotation string, node *corev1.Node) corev1.ResourceList {
 	return result
 }
 
-func (m *nodesSyncer) convertNodeToMachine(node *corev1.Node, existing *v32.Node) (*v32.Node, error) {
-	var machine *v32.Node
+func (m *nodesSyncer) convertNodeToMachine(node *corev1.Node, existing *apimgmtv3.Node) (*apimgmtv3.Node, error) {
+	var machine *apimgmtv3.Node
 	if existing == nil {
-		machine = &v32.Node{
-			Spec:   v32.NodeSpec{},
-			Status: v32.NodeStatus{},
+		machine = &apimgmtv3.Node{
+			Spec:   apimgmtv3.NodeSpec{},
+			Status: apimgmtv3.NodeStatus{},
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "machine-"},
 		}
@@ -791,8 +790,8 @@ func (m *nodesSyncer) convertNodeToMachine(node *corev1.Node, existing *v32.Node
 	}
 	machine.Labels[nodehelper.LabelNodeName] = node.Name
 	cleanStatus(machine)
-	v32.NodeConditionRegistered.True(machine)
-	v32.NodeConditionRegistered.Message(machine, "registered with kubernetes")
+	apimgmtv3.NodeConditionRegistered.True(machine)
+	apimgmtv3.NodeConditionRegistered.Message(machine, "registered with kubernetes")
 	return machine, nil
 }
 
@@ -827,7 +826,7 @@ func (m *nodesSyncer) isClusterRestoring() (bool, error) {
 	return false, nil
 }
 
-func determineNodeRoles(machine *v32.Node) {
+func determineNodeRoles(machine *apimgmtv3.Node) {
 	if machine.Status.NodeLabels != nil {
 		_, etcd := machine.Status.NodeLabels["node-role.kubernetes.io/etcd"]
 		_, control := machine.Status.NodeLabels["node-role.kubernetes.io/controlplane"]

--- a/pkg/nodeconfig/config.go
+++ b/pkg/nodeconfig/config.go
@@ -9,9 +9,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/types/values"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/encryptedstore"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/jailer"
 	"github.com/sirupsen/logrus"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
@@ -94,7 +94,7 @@ func (m *NodeConfig) Cleanup() error {
 }
 
 func (m *NodeConfig) Remove() error {
-	m.Cleanup()
+	_ = m.Cleanup()
 	logrus.Debugf("Removing [%v]", m.id)
 	return m.store.Remove(m.id)
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->https://github.com/rancher/rancher/issues/38442
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The `user-node-remove` handler has been removed, but the finalizer is not being cleaned up.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

If the node-controller finalizer has already run for the node (or was never present in the first place), the remove handler won't run again. Because of this, we need to add sync back, but ignore the annotation if the object is already being deleted.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

I tested by setting the finalizer on the object, on a previous version of rancher, deleting the node, then upgrading, which caused the finalizer to be removed correctly.