### PR TITLE
Enable dapper on M1 Macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,11 @@
 TARGETS := $(shell ls scripts)
 
 .dapper:
-	@if [[ `uname -s` = "Darwin" && `uname -m` = "arm64" ]]; then\
-		echo "Dapper download is not supported on ARM Macs, you need to build it and add it as .dapper in this directory";\
-		exit 0;\
-	else\
-		echo Downloading dapper;\
-		curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp;\
-		chmod +x .dapper.tmp;\
-		./.dapper.tmp -v;\
-		mv .dapper.tmp .dapper;\
-	fi
+	@echo Downloading dapper
+	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
+	@@chmod +x .dapper.tmp
+	@./.dapper.tmp -v
+	@mv .dapper.tmp .dapper
 
 $(TARGETS): .dapper
 	@if [[ "$@" = "post-release-checks" ]] || [[ "$@" = "list-gomod-updates" ]] || [[ "$@" = "check-chart-kdm-source-values" ]]; then\


### PR DESCRIPTION
## Problem
`make` currently exists on M1 Macs. Nevertheless, appears to be working fine as of September 2022.

I am unaware of the exact cause why it was blocked before, but it seems to be fixed now
 
## Solution

Revert https://github.com/rancher/rancher/pull/36487
 
## Testing
On an M1 Mac, run `make`.
