### PR TITLE
Ensure RKE2/K3s Pull System Images From Correct Registry

### DIFF
--- a/pkg/provisioningv2/rke2/planner/config.go
+++ b/pkg/provisioningv2/rke2/planner/config.go
@@ -114,7 +114,12 @@ func addRoleConfig(config map[string]interface{}, controlPlane *rkev1.RKEControl
 	}
 
 	if sdr := settings.SystemDefaultRegistry.Get(); sdr != "" && !isOnlyWorker(entry) {
-		config["system-default-registry"] = sdr
+		// only pass the global system-default-registry if we have not defined a different registry for system-images within the UI.
+		// registries.yaml should take precedence over the global default registry.
+		clusterRegistries := controlPlane.Spec.RKEClusterSpecCommon.Registries
+		if clusterRegistries == nil || (clusterRegistries != nil && len(clusterRegistries.Configs) == 0) {
+			config["system-default-registry"] = sdr
+		}
 	}
 
 	// If this is a control-plane node, then we need to set arguments/(and for RKE2, volume mounts) to allow probes


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/38890
 
## Problem
System images for RKE2 and K3s clusters were being pulled incorrectly when both a global level private registry and a cluster level private registry are defined. It is expected that all system images will be pulled from the cluster level private registry if it has been defined, however a number of system images for RKE2/K3s are being pulled from the global registry.

Rancher populates the `/etc/rancher/rke2/registries.yaml` file with the name and credentials of the cluster level registry defined in the UI before the cluster is created. Rancher also passes the `--system-default-registry` to RKE2/K3s during initial provisioning. In the case where both are defined, the `--system-default-registry` flag was overriding the registry defined in `registries.yaml` for system-images, which is not desired behavior.
 
## Solution
Do not pass the `--system-default-registry` flag if a cluster level registry is defined. This ensures that all image pulls (including system images) first attempt to pull the image from the cluster level private registry (`defined within registries.yaml`), and if an image is not present there it will attempt to pull from docker hub. If a user has properly configured their cluster level registry using the `rancher-images.txt` file, then all system images will be pulled from the cluster-level-registry properly. Currently, global level registries must be unauthenticated, so users who have both defined may still pull from the global level registry if they provide the FQDN.
 
## Testing
1. Create 1 unauthenticated and 1 authenticated registry containing all system images for a released version of Rancher (2.6.7 for example)
  1a. The unauthenticated registry will act as your global level registry 
  1b. The authenticated registry will act as your cluster level registry 
2. Change the global system-default-registry in the Rancher global settings to point to your unauthenticated registry 
3. Begin to create an RKE2 cluster, ensuring you chose the correct version of k8's for the images loaded into your registries
4. In the `Cluster Configuration` section, select `Registries`
5. The `Pull images for Rancher from a private registry` option should already be selected, and the value should default to your global level registry. Change the value to point to your cluster level registry.
6. For `Authentication` select `Create a basic HTTP Auth Secret` and pass in the username and password of your authenticated registry 
7. Create the cluster

## Engineering Testing
### Manual Testing
I've done the steps detailed above for both RKE2 and K3s clusters. 

### Automated Testing
No automated testing has been added

## QA Testing Considerations
Testing this will require the use of two private registries, one without authentication and another with authentication. KDM updates may mean that some images for the latest k8's release are not in your registry, ensure you use a k8's version that is supported by your registries.
 
### Regressions Considerations
While unlikely, it should be tested what the behavior is when only a global level registry is set. I've done smoke testing around this and have not found any problems. 