### PR TITLE
Refresh ExtrasByProvider from derived tokens

### DIFF
--- a/pkg/auth/providerrefresh/refresher.go
+++ b/pkg/auth/providerrefresh/refresher.go
@@ -148,7 +148,8 @@ func (r *refresher) triggerUserRefresh(userName string, force bool) {
 
 func (r *refresher) refreshAttributes(attribs *v3.UserAttribute) (*v3.UserAttribute, error) {
 	var (
-		derivedTokens         []*v3.Token
+		derivedTokenList      []*v3.Token
+		derivedTokens         map[string][]*v3.Token
 		loginTokenList        []*v3.Token
 		loginTokens           map[string][]*v3.Token
 		canLogInAtAll         bool
@@ -163,6 +164,7 @@ func (r *refresher) refreshAttributes(attribs *v3.UserAttribute) (*v3.UserAttrib
 	}
 
 	loginTokens = make(map[string][]*v3.Token)
+	derivedTokens = make(map[string][]*v3.Token)
 
 	allTokens, err := r.tokenLister.List("", labels.Everything())
 	if err != nil {
@@ -171,6 +173,7 @@ func (r *refresher) refreshAttributes(attribs *v3.UserAttribute) (*v3.UserAttrib
 
 	for providerName := range providers.ProviderNames {
 		loginTokens[providerName] = []*v3.Token{}
+		derivedTokens[providerName] = []*v3.Token{}
 	}
 
 	for _, token := range allTokens {
@@ -179,7 +182,8 @@ func (r *refresher) refreshAttributes(attribs *v3.UserAttribute) (*v3.UserAttrib
 		}
 
 		if token.IsDerived {
-			derivedTokens = append(derivedTokens, token)
+			derivedTokens[token.AuthProvider] = append(derivedTokens[token.AuthProvider], token)
+			derivedTokenList = append(derivedTokenList, token)
 		} else {
 			loginTokens[token.AuthProvider] = append(loginTokens[token.AuthProvider], token)
 			loginTokenList = append(loginTokenList, token)
@@ -233,14 +237,12 @@ func (r *refresher) refreshAttributes(attribs *v3.UserAttribute) (*v3.UserAttrib
 						if existingPrincipals != nil {
 							newGroupPrincipals = existingPrincipals
 						}
-						continue
+					} else {
+						// In the case that the user explicitly cannot login at all to this provider
+						// (e.g. they no longer exist) we pretend they have no principal with this provider
+						// so that their login tokens get blanked out
+						principalID = ""
 					}
-
-					// In the case that the user explicitly cannot login at all to this provider
-					// (e.g. they no longer exist) we pretend they have no principal with this provider
-					// so that their login tokens get blanked out
-					principalID = ""
-
 				}
 			}
 		}
@@ -251,24 +253,9 @@ func (r *refresher) refreshAttributes(attribs *v3.UserAttribute) (*v3.UserAttrib
 
 		attribs.GroupPrincipals[providerName] = v32.Principals{Items: newGroupPrincipals}
 
-		if principalID != "" && len(loginTokens[providerName]) > 0 {
-			// A user is 1:1 with its principal for a given provider, no need to get principals from tokens beyond the first one
-			userPrincipal, err := providers.GetPrincipal(principalID, *loginTokens[providerName][0])
-			if err != nil {
-				return nil, err
-			}
-			userExtraInfo := providers.GetUserExtraAttributes(providerName, userPrincipal)
-			if userExtraInfo != nil {
-				if attribs.ExtraByProvider == nil {
-					attribs.ExtraByProvider = make(map[string]map[string][]string)
-				}
-				attribs.ExtraByProvider[providerName] = userExtraInfo
-			}
-		}
-
 		canAccessProvider := false
 
-		if principalID != "" {
+		if principalID != "" && !errorConfirmingLogins {
 			// We want to verify that the user still has rancher access
 			canStillAccess, err := providers.CanAccessWithGroupProviders(providerName, principalID, newGroupPrincipals)
 			if err != nil {
@@ -281,8 +268,31 @@ func (r *refresher) refreshAttributes(attribs *v3.UserAttribute) (*v3.UserAttrib
 			}
 		}
 
+		// Update extras if either the user has an active login token, or an API token/kubeconfig token and is still active in the auth provider.
+		// If the user cannot access the auth provider, the derived tokens are deactivated below and should not be used to determine extra attributes.
+		if principalID != "" && (len(loginTokens[providerName]) > 0 || (len(derivedTokens[providerName]) > 0 && (canAccessProvider || errorConfirmingLogins))) {
+			// A user is 1:1 with its principal for a given provider, no need to get principals from tokens beyond the first one
+			var token v3.Token
+			if len(loginTokens[providerName]) > 0 {
+				token = *loginTokens[providerName][0]
+			} else {
+				token = *derivedTokens[providerName][0]
+			}
+			userPrincipal, err := providers.GetPrincipal(principalID, token)
+			if err != nil {
+				return nil, err
+			}
+			userExtraInfo := providers.GetUserExtraAttributes(providerName, userPrincipal)
+			if userExtraInfo != nil {
+				if attribs.ExtraByProvider == nil {
+					attribs.ExtraByProvider = make(map[string]map[string][]string)
+				}
+				attribs.ExtraByProvider[providerName] = userExtraInfo
+			}
+		}
+
 		// If the user doesn't have access through this provider, we want to remove their login tokens for this provider
-		if !canAccessProvider {
+		if !canAccessProvider && !errorConfirmingLogins {
 			for _, token := range loginTokens[providerName] {
 				err := r.tokens.Delete(token.Name, &metav1.DeleteOptions{})
 				if err != nil {
@@ -300,7 +310,8 @@ func (r *refresher) refreshAttributes(attribs *v3.UserAttribute) (*v3.UserAttrib
 		return attribs, nil
 	}
 
-	for _, token := range derivedTokens {
+	// user has been deactivated, disable their tokens
+	for _, token := range derivedTokenList {
 		token.Enabled = falsePointer
 		_, err := r.tokenMGR.UpdateToken(token)
 		if err != nil {

--- a/pkg/auth/providerrefresh/refresher_test.go
+++ b/pkg/auth/providerrefresh/refresher_test.go
@@ -1,0 +1,402 @@
+package providerrefresh
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rancher/norman/types"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers"
+	"github.com/rancher/rancher/pkg/auth/providers/common"
+	"github.com/rancher/rancher/pkg/auth/providers/saml"
+	"github.com/rancher/rancher/pkg/auth/tokens"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func Test_refreshAttributes(t *testing.T) {
+	tests := []struct {
+		name    string
+		user    *v3.User
+		attribs *v3.UserAttribute
+		tokens  []*v3.Token
+		enabled bool
+		want    *v3.UserAttribute
+	}{
+		{
+			name: "local user no tokens",
+			user: &v3.User{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+				Username:   "admin",
+				PrincipalIDs: []string{
+					"local://user-abcde",
+				},
+			},
+			attribs: &v3.UserAttribute{
+				ObjectMeta:      metav1.ObjectMeta{Name: "user-abcde"},
+				GroupPrincipals: map[string]v3.Principals{},
+				ExtraByProvider: map[string]map[string][]string{},
+			},
+			tokens:  []*v3.Token{},
+			enabled: true,
+			want: &v3.UserAttribute{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+				GroupPrincipals: map[string]v3.Principals{
+					"local":      v3.Principals{},
+					"shibboleth": v3.Principals{},
+				},
+				ExtraByProvider: map[string]map[string][]string{},
+			},
+		},
+		{
+			name: "local user with login token",
+			user: &v3.User{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+				Username:   "admin",
+				PrincipalIDs: []string{
+					"local://user-abcde",
+				},
+			},
+			attribs: &v3.UserAttribute{
+				ObjectMeta:      metav1.ObjectMeta{Name: "user-abcde"},
+				GroupPrincipals: map[string]v3.Principals{},
+				ExtraByProvider: map[string]map[string][]string{},
+			},
+			tokens: []*v3.Token{
+				{
+					UserID:       "user-abcde",
+					IsDerived:    false,
+					AuthProvider: providers.LocalProvider,
+					UserPrincipal: v3.Principal{
+						Provider: providers.LocalProvider,
+						ExtraInfo: map[string]string{
+							common.UserAttributePrincipalID: "local://user-abcde",
+							common.UserAttributeUserName:    "admin",
+						},
+					},
+				},
+			},
+			enabled: true,
+			want: &v3.UserAttribute{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+				GroupPrincipals: map[string]v3.Principals{
+					"local":      v3.Principals{},
+					"shibboleth": v3.Principals{},
+				},
+				ExtraByProvider: map[string]map[string][]string{
+					providers.LocalProvider: map[string][]string{
+						common.UserAttributePrincipalID: []string{"local://user-abcde"},
+						common.UserAttributeUserName:    []string{"admin"},
+					},
+				},
+			},
+		},
+		{
+			name: "local user with derived token",
+			user: &v3.User{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+				Username:   "admin",
+				PrincipalIDs: []string{
+					"local://user-abcde",
+				},
+			},
+			attribs: &v3.UserAttribute{
+				ObjectMeta:      metav1.ObjectMeta{Name: "user-abcde"},
+				GroupPrincipals: map[string]v3.Principals{},
+				ExtraByProvider: map[string]map[string][]string{},
+			},
+			tokens: []*v3.Token{
+				{
+					UserID:       "user-abcde",
+					IsDerived:    true,
+					AuthProvider: providers.LocalProvider,
+					UserPrincipal: v3.Principal{
+						Provider: providers.LocalProvider,
+						ExtraInfo: map[string]string{
+							common.UserAttributePrincipalID: "local://user-abcde",
+							common.UserAttributeUserName:    "admin",
+						},
+					},
+				},
+			},
+			enabled: true,
+			want: &v3.UserAttribute{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+				GroupPrincipals: map[string]v3.Principals{
+					"local":      v3.Principals{},
+					"shibboleth": v3.Principals{},
+				},
+				ExtraByProvider: map[string]map[string][]string{
+					providers.LocalProvider: map[string][]string{
+						common.UserAttributePrincipalID: []string{"local://user-abcde"},
+						common.UserAttributeUserName:    []string{"admin"},
+					},
+				},
+			},
+		},
+		{
+			name: "user with derived token disabled in provider",
+			user: &v3.User{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+				Username:   "admin",
+				PrincipalIDs: []string{
+					"local://user-abcde",
+				},
+			},
+			attribs: &v3.UserAttribute{
+				ObjectMeta:      metav1.ObjectMeta{Name: "user-abcde"},
+				GroupPrincipals: map[string]v3.Principals{},
+				ExtraByProvider: map[string]map[string][]string{},
+			},
+			tokens: []*v3.Token{
+				{
+					UserID:       "user-abcde",
+					IsDerived:    true,
+					AuthProvider: providers.LocalProvider,
+					UserPrincipal: v3.Principal{
+						Provider: providers.LocalProvider,
+						ExtraInfo: map[string]string{
+							common.UserAttributePrincipalID: "local://user-abcde",
+							common.UserAttributeUserName:    "admin",
+						},
+					},
+				},
+			},
+			enabled: false,
+			want: &v3.UserAttribute{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+				GroupPrincipals: map[string]v3.Principals{
+					"local":      v3.Principals{},
+					"shibboleth": v3.Principals{},
+				},
+				ExtraByProvider: map[string]map[string][]string{},
+			},
+		},
+		{
+			name: "user with login and derived tokens",
+			user: &v3.User{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+				Username:   "admin",
+				PrincipalIDs: []string{
+					"local://user-abcde",
+				},
+			},
+			attribs: &v3.UserAttribute{
+				ObjectMeta:      metav1.ObjectMeta{Name: "user-abcde"},
+				GroupPrincipals: map[string]v3.Principals{},
+				ExtraByProvider: map[string]map[string][]string{},
+			},
+			tokens: []*v3.Token{
+				{
+					UserID:       "user-abcde",
+					IsDerived:    false,
+					AuthProvider: providers.LocalProvider,
+					UserPrincipal: v3.Principal{
+						ExtraInfo: map[string]string{
+							common.UserAttributePrincipalID: "local://user-abcde",
+							common.UserAttributeUserName:    "admin",
+						},
+					},
+				},
+				{
+					UserID:       "user-abcde",
+					IsDerived:    true,
+					AuthProvider: providers.LocalProvider,
+					UserPrincipal: v3.Principal{
+						ExtraInfo: map[string]string{
+							common.UserAttributePrincipalID: "local://user-vwxyz",
+							common.UserAttributeUserName:    "nimda",
+						},
+					},
+				},
+			},
+			enabled: true,
+			want: &v3.UserAttribute{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+				GroupPrincipals: map[string]v3.Principals{
+					"local":      v3.Principals{},
+					"shibboleth": v3.Principals{},
+				},
+				ExtraByProvider: map[string]map[string][]string{
+					providers.LocalProvider: map[string][]string{
+						common.UserAttributePrincipalID: []string{"local://user-abcde"},
+						common.UserAttributeUserName:    []string{"admin"},
+					},
+				},
+			},
+		},
+		{
+			name: "shibboleth user",
+			user: &v3.User{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+				Username:   "admin",
+				PrincipalIDs: []string{
+					"shibboleth_user://user1",
+				},
+			},
+			attribs: &v3.UserAttribute{
+				ObjectMeta:      metav1.ObjectMeta{Name: "user-abcde"},
+				GroupPrincipals: map[string]v3.Principals{},
+				ExtraByProvider: map[string]map[string][]string{},
+			},
+			tokens: []*v3.Token{
+				{
+					UserID:       "user-abcde",
+					IsDerived:    true,
+					AuthProvider: saml.ShibbolethName,
+					UserPrincipal: v3.Principal{
+						Provider: saml.ShibbolethName,
+						ExtraInfo: map[string]string{
+							common.UserAttributePrincipalID: "shibboleth_user://user1",
+							common.UserAttributeUserName:    "user1",
+						},
+					},
+				},
+			},
+			enabled: true,
+			want: &v3.UserAttribute{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-abcde"},
+				GroupPrincipals: map[string]v3.Principals{
+					"local":      v3.Principals{},
+					"shibboleth": v3.Principals{},
+				},
+				ExtraByProvider: map[string]map[string][]string{
+					saml.ShibbolethName: map[string][]string{
+						common.UserAttributePrincipalID: []string{"shibboleth_user://user1"},
+						common.UserAttributeUserName:    []string{"user1"},
+					},
+				},
+			},
+		},
+	}
+
+	providers.ProviderNames = map[string]bool{
+		providers.LocalProvider: true,
+		saml.ShibbolethName:     true,
+	}
+	for _, tt := range tests {
+		tokenUpdateCalled := false
+		t.Run(tt.name, func(t *testing.T) {
+			providers.Providers = map[string]common.AuthProvider{
+				providers.LocalProvider: &mockLocalProvider{
+					canAccess: tt.enabled,
+				},
+				saml.ShibbolethName: &mockShibbolethProvider{},
+			}
+			r := &refresher{
+				tokenLister: &fakes.TokenListerMock{
+					ListFunc: func(_ string, _ labels.Selector) ([]*v3.Token, error) {
+						return tt.tokens, nil
+					},
+				},
+				userLister: &fakes.UserListerMock{
+					GetFunc: func(_, _ string) (*v3.User, error) {
+						return tt.user, nil
+					},
+				},
+				tokens: &fakes.TokenInterfaceMock{
+					DeleteFunc: func(_ string, _ *metav1.DeleteOptions) error {
+						return nil
+					},
+				},
+				tokenMGR: tokens.NewMockedManager(&fakes.TokenInterfaceMock{
+					UpdateFunc: func(_ *v3.Token) (*v3.Token, error) {
+						tokenUpdateCalled = true
+						return nil, nil
+					},
+				}),
+			}
+			got, err := r.refreshAttributes(tt.attribs)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.want, got)
+			assert.NotEqual(t, tt.enabled, tokenUpdateCalled)
+		})
+	}
+}
+
+type mockLocalProvider struct {
+	canAccess bool
+}
+
+func (p *mockLocalProvider) GetName() string {
+	panic("not implemented")
+}
+
+func (p *mockLocalProvider) AuthenticateUser(ctx context.Context, input interface{}) (v3.Principal, []v3.Principal, string, error) {
+	panic("not implemented")
+}
+
+func (p *mockLocalProvider) SearchPrincipals(name, principalType string, myToken v3.Token) ([]v3.Principal, error) {
+	panic("not implemented")
+}
+
+func (p *mockLocalProvider) GetPrincipal(principalID string, token v3.Token) (v3.Principal, error) {
+	return token.UserPrincipal, nil
+}
+
+func (p *mockLocalProvider) CustomizeSchema(schema *types.Schema) {
+	panic("not implemented")
+}
+
+func (p *mockLocalProvider) TransformToAuthProvider(authConfig map[string]interface{}) (map[string]interface{}, error) {
+	panic("not implemented")
+}
+
+func (p *mockLocalProvider) RefetchGroupPrincipals(principalID string, secret string) ([]v3.Principal, error) {
+	return []v3.Principal{}, nil
+}
+
+func (p *mockLocalProvider) CanAccessWithGroupProviders(userPrincipalID string, groups []v3.Principal) (bool, error) {
+	return p.canAccess, nil
+}
+
+func (p *mockLocalProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
+	return map[string][]string{
+		common.UserAttributePrincipalID: []string{userPrincipal.ExtraInfo[common.UserAttributePrincipalID]},
+		common.UserAttributeUserName:    []string{userPrincipal.ExtraInfo[common.UserAttributeUserName]},
+	}
+}
+
+type mockShibbolethProvider struct{}
+
+func (p *mockShibbolethProvider) GetName() string {
+	panic("not implemented")
+}
+
+func (p *mockShibbolethProvider) AuthenticateUser(ctx context.Context, input interface{}) (v3.Principal, []v3.Principal, string, error) {
+	panic("not implemented")
+}
+
+func (p *mockShibbolethProvider) SearchPrincipals(name, principalType string, myToken v3.Token) ([]v3.Principal, error) {
+	panic("not implemented")
+}
+
+func (p *mockShibbolethProvider) GetPrincipal(principalID string, token v3.Token) (v3.Principal, error) {
+	return token.UserPrincipal, nil
+}
+
+func (p *mockShibbolethProvider) CustomizeSchema(schema *types.Schema) {
+	panic("not implemented")
+}
+
+func (p *mockShibbolethProvider) TransformToAuthProvider(authConfig map[string]interface{}) (map[string]interface{}, error) {
+	panic("not implemented")
+}
+
+func (p *mockShibbolethProvider) RefetchGroupPrincipals(principalID string, secret string) ([]v3.Principal, error) {
+	return []v3.Principal{}, errors.New("Not implemented")
+}
+
+func (p *mockShibbolethProvider) CanAccessWithGroupProviders(userPrincipalID string, groups []v3.Principal) (bool, error) {
+	return true, nil
+}
+
+func (p *mockShibbolethProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
+	return map[string][]string{
+		common.UserAttributePrincipalID: []string{userPrincipal.ExtraInfo[common.UserAttributePrincipalID]},
+		common.UserAttributeUserName:    []string{userPrincipal.ExtraInfo[common.UserAttributeUserName]},
+	}
+}

--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -27,7 +27,7 @@ var (
 	ProviderNames          = make(map[string]bool)
 	ProvidersWithSecrets   = make(map[string]bool)
 	UnrefreshableProviders = make(map[string]bool)
-	providers              = make(map[string]common.AuthProvider)
+	Providers              = make(map[string]common.AuthProvider)
 	LocalProvider          = "local"
 	providersByType        = make(map[string]common.AuthProvider)
 	confMu                 sync.Mutex
@@ -35,7 +35,7 @@ var (
 )
 
 func GetProvider(providerName string) (common.AuthProvider, error) {
-	if provider, ok := providers[providerName]; ok {
+	if provider, ok := Providers[providerName]; ok {
 		if provider != nil {
 			return provider, nil
 		}
@@ -56,95 +56,95 @@ func Configure(ctx context.Context, mgmt *config.ScaledContext) {
 
 	p = local.Configure(ctx, mgmt, tokenMGR)
 	ProviderNames[local.Name] = true
-	providers[local.Name] = p
+	Providers[local.Name] = p
 	providersByType[client.LocalConfigType] = p
 	providersByType[publicclient.LocalProviderType] = p
 
 	p = github.Configure(ctx, mgmt, userMGR, tokenMGR)
 	ProviderNames[github.Name] = true
 	ProvidersWithSecrets[github.Name] = true
-	providers[github.Name] = p
+	Providers[github.Name] = p
 	providersByType[client.GithubConfigType] = p
 	providersByType[publicclient.GithubProviderType] = p
 
 	p = azure.Configure(ctx, mgmt, userMGR, tokenMGR)
 	ProviderNames[azure.Name] = true
 	ProvidersWithSecrets[azure.Name] = true
-	providers[azure.Name] = p
+	Providers[azure.Name] = p
 	providersByType[client.AzureADConfigType] = p
 	providersByType[publicclient.AzureADProviderType] = p
 
 	p = activedirectory.Configure(ctx, mgmt, userMGR, tokenMGR)
 	ProviderNames[activedirectory.Name] = true
-	providers[activedirectory.Name] = p
+	Providers[activedirectory.Name] = p
 	providersByType[client.ActiveDirectoryConfigType] = p
 	providersByType[publicclient.ActiveDirectoryProviderType] = p
 
 	p = ldap.Configure(ctx, mgmt, userMGR, tokenMGR, ldap.OpenLdapName)
 	ProviderNames[ldap.OpenLdapName] = true
-	providers[ldap.OpenLdapName] = p
+	Providers[ldap.OpenLdapName] = p
 	providersByType[client.OpenLdapConfigType] = p
 	providersByType[publicclient.OpenLdapProviderType] = p
 
 	p = ldap.Configure(ctx, mgmt, userMGR, tokenMGR, ldap.FreeIpaName)
 	ProviderNames[ldap.FreeIpaName] = true
-	providers[ldap.FreeIpaName] = p
+	Providers[ldap.FreeIpaName] = p
 	providersByType[client.FreeIpaConfigType] = p
 	providersByType[publicclient.FreeIpaProviderType] = p
 
 	p = saml.Configure(ctx, mgmt, userMGR, tokenMGR, saml.PingName)
 	ProviderNames[saml.PingName] = true
 	UnrefreshableProviders[saml.PingName] = true
-	providers[saml.PingName] = p
+	Providers[saml.PingName] = p
 	providersByType[client.PingConfigType] = p
 	providersByType[publicclient.PingProviderType] = p
 
 	p = saml.Configure(ctx, mgmt, userMGR, tokenMGR, saml.ADFSName)
 	ProviderNames[saml.ADFSName] = true
 	UnrefreshableProviders[saml.ADFSName] = true
-	providers[saml.ADFSName] = p
+	Providers[saml.ADFSName] = p
 	providersByType[client.ADFSConfigType] = p
 	providersByType[publicclient.ADFSProviderType] = p
 
 	p = saml.Configure(ctx, mgmt, userMGR, tokenMGR, saml.KeyCloakName)
 	ProviderNames[saml.KeyCloakName] = true
 	UnrefreshableProviders[saml.KeyCloakName] = true
-	providers[saml.KeyCloakName] = p
+	Providers[saml.KeyCloakName] = p
 	providersByType[client.KeyCloakConfigType] = p
 	providersByType[publicclient.KeyCloakProviderType] = p
 
 	p = saml.Configure(ctx, mgmt, userMGR, tokenMGR, saml.OKTAName)
 	ProviderNames[saml.OKTAName] = true
 	UnrefreshableProviders[saml.OKTAName] = true
-	providers[saml.OKTAName] = p
+	Providers[saml.OKTAName] = p
 	providersByType[client.OKTAConfigType] = p
 	providersByType[publicclient.OKTAProviderType] = p
 
 	p = saml.Configure(ctx, mgmt, userMGR, tokenMGR, saml.ShibbolethName)
 	ProviderNames[saml.ShibbolethName] = true
 	UnrefreshableProviders[saml.ShibbolethName] = false
-	providers[saml.ShibbolethName] = p
+	Providers[saml.ShibbolethName] = p
 	providersByType[client.ShibbolethConfigType] = p
 	providersByType[publicclient.ShibbolethProviderType] = p
 
 	p = googleoauth.Configure(ctx, mgmt, userMGR, tokenMGR)
 	ProviderNames[googleoauth.Name] = true
 	ProvidersWithSecrets[googleoauth.Name] = true
-	providers[googleoauth.Name] = p
+	Providers[googleoauth.Name] = p
 	providersByType[client.GoogleOauthConfigType] = p
 	providersByType[publicclient.GoogleOAuthProviderType] = p
 
 	p = oidc.Configure(ctx, mgmt, userMGR, tokenMGR)
 	ProviderNames[oidc.Name] = true
 	ProvidersWithSecrets[oidc.Name] = true
-	providers[oidc.Name] = p
+	Providers[oidc.Name] = p
 	providersByType[client.OIDCConfigType] = p
 	providersByType[publicclient.OIDCProviderType] = p
 
 	p = keycloakoidc.Configure(ctx, mgmt, userMGR, tokenMGR)
 	ProviderNames[keycloakoidc.Name] = true
 	ProvidersWithSecrets[keycloakoidc.Name] = true
-	providers[keycloakoidc.Name] = p
+	Providers[keycloakoidc.Name] = p
 	providersByType[client.KeyCloakOIDCConfigType] = p
 	providersByType[publicclient.KeyCloakOIDCProviderType] = p
 }
@@ -157,14 +157,14 @@ func IsValidUserExtraAttribute(key string) bool {
 }
 
 func AuthenticateUser(ctx context.Context, input interface{}, providerName string) (v3.Principal, []v3.Principal, string, error) {
-	return providers[providerName].AuthenticateUser(ctx, input)
+	return Providers[providerName].AuthenticateUser(ctx, input)
 }
 
 func GetPrincipal(principalID string, myToken v3.Token) (v3.Principal, error) {
-	principal, err := providers[myToken.AuthProvider].GetPrincipal(principalID, myToken)
+	principal, err := Providers[myToken.AuthProvider].GetPrincipal(principalID, myToken)
 
 	if err != nil && myToken.AuthProvider != LocalProvider {
-		p2, e2 := providers[LocalProvider].GetPrincipal(principalID, myToken)
+		p2, e2 := Providers[LocalProvider].GetPrincipal(principalID, myToken)
 		if e2 == nil {
 			return p2, nil
 		}
@@ -177,15 +177,15 @@ func SearchPrincipals(name, principalType string, myToken v3.Token) ([]v3.Princi
 	if myToken.AuthProvider == "" {
 		return []v3.Principal{}, fmt.Errorf("[SearchPrincipals] no authProvider specified in token")
 	}
-	if providers[myToken.AuthProvider] == nil {
+	if Providers[myToken.AuthProvider] == nil {
 		return []v3.Principal{}, fmt.Errorf("[SearchPrincipals] authProvider %v not initialized", myToken.AuthProvider)
 	}
-	principals, err := providers[myToken.AuthProvider].SearchPrincipals(name, principalType, myToken)
+	principals, err := Providers[myToken.AuthProvider].SearchPrincipals(name, principalType, myToken)
 	if err != nil {
 		return principals, err
 	}
 	if myToken.AuthProvider != LocalProvider {
-		lp := providers[LocalProvider]
+		lp := Providers[LocalProvider]
 		if lpDedupe, _ := lp.(*local.Provider); lpDedupe != nil {
 			localPrincipals, err := lpDedupe.SearchPrincipalsDedupe(name, principalType, myToken, principals)
 			if err != nil {
@@ -198,13 +198,13 @@ func SearchPrincipals(name, principalType string, myToken v3.Token) ([]v3.Princi
 }
 
 func CanAccessWithGroupProviders(providerName string, userPrincipalID string, groups []v3.Principal) (bool, error) {
-	return providers[providerName].CanAccessWithGroupProviders(userPrincipalID, groups)
+	return Providers[providerName].CanAccessWithGroupProviders(userPrincipalID, groups)
 }
 
 func RefetchGroupPrincipals(principalID string, providerName string, secret string) ([]v3.Principal, error) {
-	return providers[providerName].RefetchGroupPrincipals(principalID, secret)
+	return Providers[providerName].RefetchGroupPrincipals(principalID, secret)
 }
 
 func GetUserExtraAttributes(providerName string, userPrincipal v3.Principal) map[string][]string {
-	return providers[providerName].GetUserExtraAttributes(userPrincipal)
+	return Providers[providerName].GetUserExtraAttributes(userPrincipal)
 }

--- a/pkg/auth/tokens/test_utils.go
+++ b/pkg/auth/tokens/test_utils.go
@@ -1,0 +1,12 @@
+package tokens
+
+import (
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+)
+
+// NewMockedManager returns a token manager with mocked clients to be used in other packages' tests.
+func NewMockedManager(tokensClient *fakes.TokenInterfaceMock) *Manager { // add other clients, indexers, listers as needed
+	return &Manager{
+		tokensClient: tokensClient,
+	}
+}


### PR DESCRIPTION
If a user has no fresh UI login tokens, they may still need to log in using a kubeconfig or API token. Without this change, if the provider refresher happens to have run, ExtraByProvider will become empty, which will cause requests to fail because the impersonation logic depends on extras found in UserAttributes. This change ensures that extras are refreshed either from login tokens or derived tokens, as long as the user still has access to the provider.

## Issue: https://github.com/rancher/rancher/issues/36096 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The problem this PR addresses is that the refresher may set the `ExtraByProvider` field in a `UserAttribute` resource to empty, `{}`. if the user has no active login tokens. Login tokens come from logging into the UI, but some users rarely or never log into the UI, for example automated Jenkins or Terraform users. Impersonation uses `ExtraByProvider` to set impersonation clusterrole rules, so if it is empty the user will run into a "Forbidden" error.

Some users have reported seeing the `ExtraByProvider` field as `null` rather than `{}`, which would have the same effect on user requests. If the refresher is run, this should correct that issue too, but it does not address why the field would get into that state in the first place.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
The refresher needs to also check "derived" tokens, such as the ones from generated kubeconfigs, for user extras. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
* Create a new user
* Add user as an owner on a non-local cluster
* Log in as that user and generate a kubeconfig for the cluster
* On the local cluster, delete the user's userattributes `kubectl delete userattributes u-XXXX`
* Log out and log back in as admin
* Click "refresh group membership" in the user management page for that user
* User should still be able to authenticate to the downstream cluster with the downloaded kubeconfig
* `ExtraByProvider` in userattribute resource should contain principalid and username for enabled providers

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
* Test with multiple auth providers, especially Shibboleth and other SAML providers
* Test upgrading from v2.6.2 to v2.6-head/v2.7-head
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
* Shibboleth needs special consideration because it is labeled as a refreshable provider in contrast with other SAML providers.
* Ensure that disabling/removing a user in an auth provider deactivates the user in Rancher as before this change