### PR TITLE
Add validation test for helm-operation pods

### DIFF
--- a/tests/v2/validation/charts/gatekeeper_test.go
+++ b/tests/v2/validation/charts/gatekeeper_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/charts"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -205,6 +206,18 @@ func (g *GateKeeperTestSuite) TestUpGradeGatekeeperChart() {
 	// Compare rancher-gatekeeper versions
 	chartVersionPostUpgrade := gatekeeperChartPostUpgrade.ChartDetails.Spec.Chart.Metadata.Version
 	require.Equal(g.T(), g.gatekeeperChartInstallOptions.Version, chartVersionPostUpgrade)
+}
+
+func (g *GateKeeperTestSuite) TestVerifyNoPendingHelmOp() {
+	subSession := g.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := g.client.WithSession(subSession)
+	require.NoError(g.T(), err)
+
+	g.T().Log("Asserting that all helm-operation-xxxx pods terminated")
+	done := workloads.WaitPodTerminated(client, g.project.ClusterID, "helm-operation-")
+	require.True(g.T(), done)
 }
 
 func TestGateKeeperTestSuite(t *testing.T) {

--- a/tests/v2/validation/charts/istio_test.go
+++ b/tests/v2/validation/charts/istio_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/charts"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/deployments"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
@@ -313,6 +314,18 @@ func (i *IstioTestSuite) TestUpgradeIstioChart() {
 		i.T().Logf("Comparing image and app versions: \n container image: %v \n istio version: %v and actual: %v\n", deployment.Spec.Template.Spec.Containers[0].Image, istioVersionPostUpgrade, imageVersion)
 		require.Equalf(i.T(), istioVersionPostUpgrade, imageVersion, "Pilot & Ingressgateways images don't use the correct istio image version")
 	}
+}
+
+func (i *IstioTestSuite) TestVerifyNoPendingHelmOp() {
+	subSession := i.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := i.client.WithSession(subSession)
+	require.NoError(i.T(), err)
+
+	i.T().Log("Asserting that all helm-operation-xxxx pods terminated")
+	done := workloads.WaitPodTerminated(client, i.project.ClusterID, "helm-operation-")
+	require.True(i.T(), done)
 }
 
 func TestIstioTestSuite(t *testing.T) {

--- a/tests/v2/validation/charts/monitoring_test.go
+++ b/tests/v2/validation/charts/monitoring_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/projects"
 	"github.com/rancher/rancher/tests/framework/extensions/secrets"
 	"github.com/rancher/rancher/tests/framework/extensions/services"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -278,6 +279,18 @@ func (m *MonitoringTestSuite) TestUpgradeMonitoringChart() {
 	// Compare rancher monitoring versions
 	chartVersionPostUpgrade := monitoringChartPostUpgrade.ChartDetails.Spec.Chart.Metadata.Version
 	assert.Equal(m.T(), m.chartInstallOptions.Version, chartVersionPostUpgrade)
+}
+
+func (m *MonitoringTestSuite) TestVerifyNoPendingHelmOp() {
+	subSession := m.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := m.client.WithSession(subSession)
+	require.NoError(m.T(), err)
+
+	m.T().Log("Asserting that all helm-operation-xxxx pods terminated")
+	done := workloads.WaitPodTerminated(client, m.project.ClusterID, "helm-operation-")
+	require.True(m.T(), done)
 }
 
 func TestMonitoringTestSuite(t *testing.T) {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/38873 and PR https://github.com/rancher/rancher/pull/38868
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
This PR is adding only the validation tests to check if all `helm-operation-xxxxx` pods have been successfully terminated. The tests was missing from PR https://github.com/rancher/rancher/pull/38868.

After successfully installing any chart through the Rancher UI (Apps menu) the `proxy` container of the `helm-operation-xxxxx` pod is not properly terminated and it receives status `NotReady`. This happens because we migrated the old `rancher/shell` image from Alpine to SLE-BCI (in v2.6.7 - https://github.com/rancher/rancher/pull/38622) and it doesn't contains the `killall` command (from `psmisc` program) used by [Helm operations](https://github.com/rancher/rancher/blob/v2.6.8/pkg/controllers/dashboard/helm/operations.go#L136).

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This PR modifies [Helm operations](https://github.com/rancher/rancher/blob/v2.6.8/pkg/controllers/dashboard/helm/operations.go#L136) to use the `pkill` command instead of `killall`.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
To reproduce this issue, install any valid chart from Apps and wait for it to finish the installation. The `proxy` container from `helm-operation-xxxxx` pod will not be terminated.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Install any valid chart from Apps and wait for it to finish the installation. All `helm-operation-xxxxx` pods must be properly terminated.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
**Rancher v2.6.6 test == PASS**
1. Install a test cluster with Rancher `v2.6.6`.
2. Configure env var `CATTLE_TEST_CONFIG` to point to the test cluster.
3. `cd tests/v2/validation/charts`
4. `go test -v`
5. The tests `TestVerifyNoPendingHelmOp` must `PASS`.

**Rancher v2.6.8 test == FAIL**
1. Install a test cluster with Rancher `v2.6.8`.
2. Configure env var `CATTLE_TEST_CONFIG` to point to the test cluster.
3. `cd tests/v2/validation/charts`
4. `go test -v`
5. The tests `TestVerifyNoPendingHelmOp` must `FAIL`.

**Rancher v2.6-head test == PASS**
1. Install a test cluster with Rancher `v2.6-head`.
2. Configure env var `CATTLE_TEST_CONFIG` to point to the test cluster.
3. `cd tests/v2/validation/charts`
4. `go test -v`
5. The tests `TestVerifyNoPendingHelmOp` must `PASS`.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
No regression is expected.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>