### PR TITLE
[release/v2.6] DeepCopy nodeSchema after listing from cache

### DIFF
--- a/pkg/controllers/management/drivers/nodedriver/machine_driver.go
+++ b/pkg/controllers/management/drivers/nodedriver/machine_driver.go
@@ -444,6 +444,8 @@ func (m *Lifecycle) createOrUpdateNodeForEmbeddedTypeWithParents(embeddedType, f
 		return nil
 	}
 
+	nodeSchema = nodeSchema.DeepCopy()
+
 	shouldUpdate := false
 	if embedded {
 		if nodeSchema.Spec.ResourceFields == nil {


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/38901
 
## Problem
In certain cases, it is possible to have Rancher panic due to the `machine_driver.go` controller, as it unsafely mutates objects returned from the cache.
 
## Solution
DeepCopy the object before allowing mutation.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
N/A