### PR TITLE
[v2.7] add cgroupv2 script for k3s

### DIFF
--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -6,6 +6,22 @@ if [ ! -e /run/secrets/kubernetes.io/serviceaccount ] && [ ! -e /dev/kmsg ]; the
     echo "ERROR: Rancher must be ran with the --privileged flag when running outside of Kubernetes"
     exit 1
 fi
+
+#########################################################################################################################################
+# DISCLAIMER                                                                                                                            #
+# Copied from https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/hack/dind#L28-L37                              #
+# Permission granted by Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> (https://github.com/rancher/k3d/issues/493#issuecomment-827405962) #
+# Moby License Apache 2.0: https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/LICENSE                           #
+#########################################################################################################################################
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+  # move the processes from the root group to the /init group,
+  # otherwise writing subtree_control fails with EBUSY.
+  mkdir -p /sys/fs/cgroup/init
+  xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+  # enable controllers
+  sed -e 's/ / +/g' -e 's/^/+/' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
+fi
+
 rm -f /var/lib/rancher/k3s/server/cred/node-passwd
 if [ -e /var/lib/rancher/management-state/etcd ] && [ ! -e /var/lib/rancher/k3s/server/db/etcd ]; then
   mkdir -p /var/lib/rancher/k3s/server/db


### PR DESCRIPTION
Adding script to entrypoint per https://github.com/rancher/rancher/issues/36238#issuecomment-1222658982 to support cgroups v2. This will allow running docker install out of the box without user changes. 

Issue: 
https://github.com/rancher/rancher/issues/36238 