### PR TITLE
[release/v2.6] Updated fields that previously used Duration to use string, to fix an unmarshaling error

### DIFF
--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_duration.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_duration.go
@@ -1,10 +1,8 @@
 package client
 
 const (
-	DurationType          = "duration"
-	DurationFieldDuration = "duration"
+	DurationType = "duration"
 )
 
 type Duration struct {
-	Duration string `json:"duration,omitempty" yaml:"duration,omitempty"`
 }

--- a/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_machine_spec.go
+++ b/tests/framework/clients/rancher/generated/cluster/v1beta1/zz_generated_machine_spec.go
@@ -17,8 +17,8 @@ type MachineSpec struct {
 	ClusterName         string           `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
 	FailureDomain       string           `json:"failureDomain,omitempty" yaml:"failureDomain,omitempty"`
 	InfrastructureRef   *ObjectReference `json:"infrastructureRef,omitempty" yaml:"infrastructureRef,omitempty"`
-	NodeDeletionTimeout *Duration        `json:"nodeDeletionTimeout,omitempty" yaml:"nodeDeletionTimeout,omitempty"`
-	NodeDrainTimeout    *Duration        `json:"nodeDrainTimeout,omitempty" yaml:"nodeDrainTimeout,omitempty"`
+	NodeDeletionTimeout string           `json:"nodeDeletionTimeout,omitempty" yaml:"nodeDeletionTimeout,omitempty"`
+	NodeDrainTimeout    string           `json:"nodeDrainTimeout,omitempty" yaml:"nodeDrainTimeout,omitempty"`
 	ProviderID          string           `json:"providerID,omitempty" yaml:"providerID,omitempty"`
 	Version             string           `json:"version,omitempty" yaml:"version,omitempty"`
 }

--- a/tests/framework/clients/rancher/generated/provisioning/v1/zz_generated_duration.go
+++ b/tests/framework/clients/rancher/generated/provisioning/v1/zz_generated_duration.go
@@ -1,10 +1,8 @@
 package client
 
 const (
-	DurationType          = "duration"
-	DurationFieldDuration = "duration"
+	DurationType = "duration"
 )
 
 type Duration struct {
-	Duration string `json:"duration,omitempty" yaml:"duration,omitempty"`
 }

--- a/tests/framework/clients/rancher/generated/provisioning/v1/zz_generated_rke_machine_pool.go
+++ b/tests/framework/clients/rancher/generated/provisioning/v1/zz_generated_rke_machine_pool.go
@@ -30,7 +30,7 @@ type RKEMachinePool struct {
 	ControlPlaneRole             bool                         `json:"controlPlaneRole,omitempty" yaml:"controlPlaneRole,omitempty"`
 	DisplayName                  string                       `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	DrainBeforeDelete            bool                         `json:"drainBeforeDelete,omitempty" yaml:"drainBeforeDelete,omitempty"`
-	DrainBeforeDeleteTimeout     *Duration                    `json:"drainBeforeDeleteTimeout,omitempty" yaml:"drainBeforeDeleteTimeout,omitempty"`
+	DrainBeforeDeleteTimeout     string                       `json:"drainBeforeDeleteTimeout,omitempty" yaml:"drainBeforeDeleteTimeout,omitempty"`
 	EtcdRole                     bool                         `json:"etcdRole,omitempty" yaml:"etcdRole,omitempty"`
 	Labels                       map[string]string            `json:"labels,omitempty" yaml:"labels,omitempty"`
 	MachineDeploymentAnnotations map[string]string            `json:"machineDeploymentAnnotations,omitempty" yaml:"machineDeploymentAnnotations,omitempty"`
@@ -39,12 +39,12 @@ type RKEMachinePool struct {
 	MaxUnhealthy                 string                       `json:"maxUnhealthy,omitempty" yaml:"maxUnhealthy,omitempty"`
 	Name                         string                       `json:"name,omitempty" yaml:"name,omitempty"`
 	NodeConfig                   *ObjectReference             `json:"machineConfigRef,omitempty" yaml:"machineConfigRef,omitempty"`
-	NodeStartupTimeout           *Duration                    `json:"nodeStartupTimeout,omitempty" yaml:"nodeStartupTimeout,omitempty"`
+	NodeStartupTimeout           string                       `json:"nodeStartupTimeout,omitempty" yaml:"nodeStartupTimeout,omitempty"`
 	Paused                       bool                         `json:"paused,omitempty" yaml:"paused,omitempty"`
 	Quantity                     *int64                       `json:"quantity,omitempty" yaml:"quantity,omitempty"`
 	RollingUpdate                *RKEMachinePoolRollingUpdate `json:"rollingUpdate,omitempty" yaml:"rollingUpdate,omitempty"`
 	Taints                       []Taint                      `json:"taints,omitempty" yaml:"taints,omitempty"`
-	UnhealthyNodeTimeout         *Duration                    `json:"unhealthyNodeTimeout,omitempty" yaml:"unhealthyNodeTimeout,omitempty"`
+	UnhealthyNodeTimeout         string                       `json:"unhealthyNodeTimeout,omitempty" yaml:"unhealthyNodeTimeout,omitempty"`
 	UnhealthyRange               string                       `json:"unhealthyRange,omitempty" yaml:"unhealthyRange,omitempty"`
 	WorkerRole                   bool                         `json:"workerRole,omitempty" yaml:"workerRole,omitempty"`
 }

--- a/tests/framework/pkg/schemas/cluster.x-k8s.io.machines/v1beta1/schema.go
+++ b/tests/framework/pkg/schemas/cluster.x-k8s.io.machines/v1beta1/schema.go
@@ -2,8 +2,7 @@ package schema
 
 import (
 	"github.com/rancher/norman/types"
-	provisioningSchema "github.com/rancher/rancher/tests/framework/pkg/schemas/provisioning.cattle.io/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	m "github.com/rancher/norman/types/mapper"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -19,8 +18,9 @@ var (
 )
 
 func clusterMachineTypes(schemas *types.Schemas) *types.Schemas {
-	return schemas.
-		MustImportAndCustomize(&Version, metav1.Duration{}, func(schema *types.Schema) {}, provisioningSchema.Duration{}).
+	return schemas.AddMapperForType(&Version, capi.MachineSpec{},
+		&m.ChangeType{Field: "nodeDeletionTimeout", Type: "string"},
+		&m.ChangeType{Field: "nodeDrainTimeout", Type: "string"}).
 		MustImportAndCustomize(&Version, capi.Machine{}, func(schema *types.Schema) {
 			schema.ID = "cluster.x-k8s.io.machine"
 		})

--- a/tests/framework/pkg/schemas/provisioning.cattle.io/v1/schema.go
+++ b/tests/framework/pkg/schemas/provisioning.cattle.io/v1/schema.go
@@ -4,7 +4,6 @@ import (
 	"github.com/rancher/norman/types"
 	m "github.com/rancher/norman/types/mapper"
 	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -23,8 +22,11 @@ func clusterTypes(schemas *types.Schemas) *types.Schemas {
 		m.Drop{Field: "chartValues"},
 		&m.ChangeType{Field: "machineGlobalConfig", Type: "MachineGlobalConfig"}).
 		MustImport(&Version, MachineGlobalConfig{}).
-		MustImportAndCustomize(&Version, metav1.Duration{}, func(schema *types.Schema) {}, Duration{}).
-		MustImportAndCustomize(&Version, v1.RKEConfig{}, func(schema *types.Schema) {}).
+		AddMapperForType(&Version, v1.RKEMachinePool{},
+			&m.ChangeType{Field: "drainBeforeDeleteTimeout", Type: "string"},
+			&m.ChangeType{Field: "nodeStartupTimeout", Type: "string"},
+			&m.ChangeType{Field: "unhealthyNodeTimeout", Type: "string"}).
+		MustImportAndCustomize(&Version, v1.RKEMachinePool{}, func(schema *types.Schema) {}).
 		MustImportAndCustomize(&Version, v1.Cluster{}, func(schema *types.Schema) {
 			schema.ID = "provisioning.cattle.io.cluster"
 		})

--- a/tests/framework/pkg/schemas/provisioning.cattle.io/v1/types.go
+++ b/tests/framework/pkg/schemas/provisioning.cattle.io/v1/types.go
@@ -1,10 +1,5 @@
 package schema
 
-// Duration is a replacement struct for the Duration in the "k8s.io/apimachinery/pkg/apis/meta/v1" package
-type Duration struct {
-	Duration string `json:"duration,omitempty" yaml:"duration,omitempty"`
-}
-
 // MachineGlobalConfig is struct that defines the CNI for a RKEConfig need to provision a v1 cluster
 type MachineGlobalConfig struct {
 	CNI string `json:"cni,omitempty" yaml:"cni,omitempty"`


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Since the native Duration type used to generate the appropriate types for the provisioning and cluster clients, doesn't use a native type, and has `protobuf` tag, it doesn't get generated appropriately and cause unmarshaling errors. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updated schemas to change the field types to strings to fix the error.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->