### PR TITLE
[release/v2.6] Add specific watch for secrets in rke2configserver to ensure v2prov provisioning timeliness, Bump embedded K3s to v1.24.4+k3s1

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -4,7 +4,7 @@ ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 ENV CATTLE_HELM_VERSION v2.16.8-rancher2
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher95
-ENV CATTLE_K3S_VERSION v1.24.1+k3s1
+ENV CATTLE_K3S_VERSION v1.24.4+k3s1
 # version used by helm plugin install script
 ENV CATTLE_HELM_UNITTEST_VERSION v0.1.7-rancher4
 # helm 3 version
@@ -56,7 +56,7 @@ RUN mkdir /usr/tmp && \
     chmod +x /usr/bin/kustomize
 
 # Set up K3s: copy the necessary binaries from the K3s image.
-COPY --from=rancher/k3s:v1.24.1-k3s1 \
+COPY --from=rancher/k3s:v1.24.4-k3s1 \
     /bin/blkid \
     /bin/charon \
     /bin/cni \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -28,7 +28,7 @@ ENV CATTLE_PARTNER_CHART_DEFAULT_BRANCH=$PARTNER_CHART_DEFAULT_BRANCH
 ENV CATTLE_RKE2_CHART_DEFAULT_BRANCH=$RKE2_CHART_DEFAULT_BRANCH
 ENV CATTLE_HELM_VERSION v2.16.8-rancher2
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher95
-ENV CATTLE_K3S_VERSION v1.24.1+k3s1
+ENV CATTLE_K3S_VERSION v1.24.4+k3s1
 ENV CATTLE_MACHINE_PROVISION_IMAGE rancher/machine:${CATTLE_MACHINE_VERSION}
 ENV CATTLE_ETCD_VERSION v3.5.1
 ENV LOGLEVEL_VERSION v0.1.5
@@ -114,7 +114,7 @@ RUN curl ${HELM_URL_V3} | tar xvzf - --strip-components=1 -C /usr/bin && \
     chmod +x /usr/bin/kustomize
 
 # Set up K3s: copy the necessary binaries from the K3s image.
-COPY --from=rancher/k3s:v1.24.1-k3s1 \
+COPY --from=rancher/k3s:v1.24.4-k3s1 \
     /bin/blkid \
     /bin/charon \
     /bin/cni \

--- a/pkg/controllers/provisioningv2/rke2/bootstrap/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/bootstrap/controller.go
@@ -30,8 +30,6 @@ import (
 
 const (
 	rkeBootstrapName = "rke.cattle.io/rkebootstrap-name"
-	roleBootstrap    = "bootstrap"
-	rolePlan         = "plan"
 )
 
 type handler struct {
@@ -161,7 +159,7 @@ func (h *handler) assignPlanSecret(machine *capi.Machine, bootstrap *rkev1.RKEBo
 			Labels: map[string]string{
 				rke2.MachineNameLabel: machine.Name,
 				rkeBootstrapName:      bootstrap.Name,
-				rke2.RoleLabel:        rolePlan,
+				rke2.RoleLabel:        rke2.RolePlan,
 				rke2.PlanSecret:       secretName,
 			},
 		},
@@ -260,7 +258,7 @@ func (h *handler) assignBootStrapSecret(machine *capi.Machine, bootstrap *rkev1.
 			Labels: map[string]string{
 				rke2.MachineNameLabel: machine.Name,
 				rkeBootstrapName:      bootstrap.Name,
-				rke2.RoleLabel:        roleBootstrap,
+				rke2.RoleLabel:        rke2.RoleBootstrap,
 			},
 		},
 	}

--- a/pkg/serviceaccounttoken/secret.go
+++ b/pkg/serviceaccounttoken/secret.go
@@ -2,9 +2,9 @@ package serviceaccounttoken
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"github.com/rancher/wrangler/pkg/name"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
@@ -75,5 +75,5 @@ func SecretTemplate(sa *v1.ServiceAccount) *v1.Secret {
 
 // ServiceAccountSecretName returns the secret name for the given Service Account.
 func ServiceAccountSecretName(sa *v1.ServiceAccount) string {
-	return fmt.Sprintf("%s-token", sa.Name)
+	return name.SafeConcatName(sa.Name, "token")
 }

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -111,7 +111,7 @@ done
 
 echo Running provisioning-tests
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-go test -v -timeout 60m ./tests/integration/pkg/tests/... || {
+go test -v -failfast -timeout 60m ./tests/integration/pkg/tests/... || {
     echo -e "-----RANCHER-LOG-DUMP-START-----"
     cat /tmp/rancher.log | gzip | base64 -w 0
     echo -e "\n-----RANCHER-LOG-DUMP-END-----"


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/38916
 
## Problem
With K8s v1.24+, service account tokens are now created by Rancher if they do not exist (as the token-controller no longer automatically creates service account tokens). Before this PR, Rancher would open a watch for service accounts, relying on the `.secrets` field of the service account to contain the service account token (as this was populated by the token-controller). The secrets field is no longer populated, so opening a watch for service accounts is no longer a valid approach for waiting for service account token.
 
## Solution
Now, Rancher will watch for the service account, then once it finds a valid service account, open a watch for secrets that specifically correspond to the service account.
 
## Testing

## Engineering Testing
### Manual Testing
Create a v2prov custom cluster in v2.6.8, and observe that running the curl script takes 60+ seconds due to curl timeout after `Generating cattle id`.

After this change, there should be no delay.

### Automated Testing
The v2prov custom integration tests will test this code thoroughly.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->