### PR TITLE
[2.6 backport] Allow admins to reconfigure existing deprecated Azure AD authconfig

### DIFF
--- a/pkg/auth/providers/azure/azure_actions.go
+++ b/pkg/auth/providers/azure/azure_actions.go
@@ -11,13 +11,10 @@ import (
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/auth/providers/azure/clients"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
-	"github.com/rancher/rancher/pkg/auth/tokens"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	managementschema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (ap *azureProvider) formatter(apiContext *types.APIContext, resource *types.RawResource) {
@@ -73,30 +70,12 @@ func (ap *azureProvider) testAndApply(actionName string, action *types.Action, r
 
 	azureADConfig := &azureADConfigApplyInput.Config
 
-	// Get the current config from the database and, if it is enabled and does not have the new auth flow annotation,
-	// do not set the annotation on the new config.
-	// This covers the case where admins had been using a deprecated Azure AD setup
-	// and must migrate to the new auth config setup after upgrading Rancher.
-	// But they may not want to migrate immediately, and could still want to reconfigure their existing, deprecated config by changing
-	// the Application Secret after rotating it, for example. This way, Rancher allows the old setup to be reconfigured.
 	currentConfig, err := ap.getAzureConfigK8s()
 	if err != nil {
 		logrus.Errorf("Failed to fetch Azure AD Config from Kubernetes: %v", err)
 		return httperror.NewAPIError(httperror.ServerError, "failed to fetch Azure AD Config from Kubernetes")
 	}
-
-	enabled := authProviderEnabled(currentConfig)
-	if !enabled || (enabled && configHasNewFlowAnnotation(currentConfig)) {
-		// This covers the case where admins upgrade Rancher to v2.6.7+ without having used Azure AD as the auth provider.
-		// In 2.6.7+, whether Azure AD is later registered or not, Rancher on startup creates the annotation on the template auth config.
-		// But in the case where the auth config had been created on Rancher startup prior to v2.6.7, the annotation would be missing.
-		// This ensures the annotation is set on initial attempt to set up Azure AD.
-		// This also covers the case where admins want to reconfigure a v2.6.7+ new auth flow setup with a new secret or app.
-		if azureADConfig.ObjectMeta.Annotations == nil {
-			azureADConfig.ObjectMeta.Annotations = make(map[string]string)
-		}
-		azureADConfig.ObjectMeta.Annotations[GraphEndpointMigratedAnnotation] = "true"
-	}
+	migrateNewFlowAnnotation(currentConfig, azureADConfig)
 
 	azureLogin := &v32.AzureADLogin{
 		Code: azureADConfigApplyInput.Code,
@@ -134,79 +113,19 @@ func (ap *azureProvider) testAndApply(actionName string, action *types.Action, r
 	return ap.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, providerToken, 0, "Token via Azure Configuration", request, userExtraInfo)
 }
 
-// migrateToMicrosoftGraph performs the migration of the registered Azure AD auth provider
-// from the deprecated Azure AD Graph API to the Microsoft Graph API.
-// It modifies the existing auth config value in the database, so that it has up-to-date endpoints to the new API.
-// Most importantly, it sets the annotation that specifies that the auth config has been migrated to use the new auth flow.
-
-// It also verifies that admins have properly configured an existing app registration's permissions
-// in the Azure portal before they update their Azure AD auth config to use the new authentication flow.
-// The method receives the current AuthConfig from the database, then updates it in-memory to use the new endpoints,
-// and creates a new test Azure client, thereby getting an access token to the Graph API.
-// Then it parses the JWT and inspects the permissions contained within. If the admins had not set those as per docs,
-// then Rancher won't find the permissions in the test token and will return an error.
-
-// If validation and applying work, then migrateToMicrosoftGraph deletes all secrets with access tokens to the
-// deprecated Azure AD Graph API.
-func (ap *azureProvider) migrateToMicrosoftGraph() error {
-	cfg, err := ap.updateConfigAndValidatePermissions()
-	if err != nil {
-		return err
-	}
-	if err = ap.applyUpdatedConfig(cfg); err != nil {
-		return err
-	}
-	ap.deleteUserAccessTokens()
-	clients.GroupCache.Purge()
-	return nil
-}
-
-func (ap *azureProvider) updateConfigAndValidatePermissions() (*v32.AzureADConfig, error) {
-	cfg, err := ap.getAzureConfigK8s()
-	if err != nil {
-		return nil, err
-	}
-	if !authProviderEnabled(cfg) {
-		return nil, httperror.NewAPIError(httperror.InvalidState, "the Azure AD auth provider is not enabled")
-	}
-
-	updateAzureADEndpoints(cfg)
-
-	// Try to get a new client, which will fetch a new access token and validate its permissions.
-	_, err = clients.NewMSGraphClient(cfg, ap.secrets)
-	if err != nil {
-		return nil, err
-	}
-	return cfg, nil
-}
-
-func (ap *azureProvider) applyUpdatedConfig(cfg *v32.AzureADConfig) error {
-	if cfg.ObjectMeta.Annotations == nil {
-		cfg.ObjectMeta.Annotations = make(map[string]string)
-	}
-	cfg.ObjectMeta.Annotations[GraphEndpointMigratedAnnotation] = "true"
-	return ap.saveAzureConfigK8s(cfg)
-}
-
-// deleteUserAccessTokens attempts to delete all secrets that contain users' access tokens used for working with
-// the deprecated Azure AD Graph API.
-// It is not possible to filter secrets easily by presence of specific key(s) in the data object. The method fetches all
-// Opaque secrets in the relevant namespace and looks at the target key in the data to find a secret that stores a user's
-// access token to delete.
-func (ap *azureProvider) deleteUserAccessTokens() {
-	secrets, err := ap.secrets.ListNamespaced(tokens.SecretNamespace, metav1.ListOptions{FieldSelector: "type=Opaque"})
-	if err != nil {
-		logrus.Errorf("failed to fetch secrets: %v", err)
+// Check the current auth config and make sure that the proposed one submitted through the API has up-to-date annotations.
+// Rancher relies on GraphEndpointMigratedAnnotation to choose the right authentication flow and Graph API.
+func migrateNewFlowAnnotation(current, proposed *v32.AzureADConfig) {
+	if isConfigDeprecated(current) {
 		return
 	}
-	// Provider name for Azure AD is the main key on secret data. This allows to identify the secrets to be deleted.
-	const key = Name
-	for _, secret := range secrets.Items {
-		if _, keyPresent := secret.Data[key]; keyPresent {
-			err := ap.secrets.DeleteNamespaced(tokens.SecretNamespace, secret.Name, &metav1.DeleteOptions{})
-			if err != nil {
-				logrus.Errorf("failed to delete secret %s:%s - %v", tokens.SecretNamespace, secret.Name, err)
-			}
-		}
+	// This covers the case where admins upgrade Rancher to v2.6.7+ without having used Azure AD as the auth provider.
+	// In 2.6.7+, whether Azure AD is later registered or not, Rancher on startup creates the annotation on the template auth config.
+	// But in the case where the auth config had been created on Rancher startup prior to v2.6.7, the annotation would be missing.
+	// This ensures the annotation is set on initial attempt to set up Azure AD.
+	// This also covers the case where admins want to reconfigure a v2.6.7+ new auth flow setup with a new secret or app.
+	if proposed.ObjectMeta.Annotations == nil {
+		proposed.ObjectMeta.Annotations = make(map[string]string)
 	}
+	proposed.ObjectMeta.Annotations[GraphEndpointMigratedAnnotation] = "true"
 }

--- a/pkg/auth/providers/azure/azure_provider_test.go
+++ b/pkg/auth/providers/azure/azure_provider_test.go
@@ -12,6 +12,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	managementschema "github.com/rancher/rancher/pkg/schemas/management.cattle.io/v3"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TestConfigureTest inspects the Redirect URL during Azure AD setup.
@@ -224,6 +225,88 @@ func TestTransformToAuthProvider(t *testing.T) {
 			url, ok := authProvider["redirectUrl"].(string)
 			assert.True(t, ok)
 			assert.Equal(t, test.expectedRedirectUrl, url)
+		})
+	}
+}
+
+func TestMigrateNewFlowAnnotation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		current            *v3.AzureADConfig
+		proposed           *v3.AzureADConfig
+		annotationExpected bool
+	}{
+		{
+			name: "new setup on Rancher v2.6.7+ after an upgrade from previous version",
+			current: &v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{
+					Enabled: false,
+				},
+				GraphEndpoint: "https://graph.microsoft.com",
+			},
+			proposed:           &v3.AzureADConfig{},
+			annotationExpected: true,
+		},
+		{
+			name: "new setup on Rancher v2.6.7+",
+			current: &v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{
+					Enabled: false,
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							GraphEndpointMigratedAnnotation: "true",
+						},
+					},
+				},
+				GraphEndpoint: "https://graph.microsoft.com",
+			},
+			proposed:           &v3.AzureADConfig{},
+			annotationExpected: true,
+		},
+		{
+			name: "reconfigure existing deprecated setup",
+			current: &v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{
+					Enabled: true,
+				},
+				GraphEndpoint: "https://graph.windows.net/",
+			},
+			proposed:           &v3.AzureADConfig{},
+			annotationExpected: false,
+		},
+		{
+			name: "reconfigure existing new setup",
+			current: &v3.AzureADConfig{
+				AuthConfig: v3.AuthConfig{
+					Enabled: true,
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							GraphEndpointMigratedAnnotation: "true",
+						},
+					},
+				},
+				GraphEndpoint: "https://graph.microsoft.com",
+			},
+			proposed:           &v3.AzureADConfig{},
+			annotationExpected: true,
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			migrateNewFlowAnnotation(test.current, test.proposed)
+			_, hasAnnotation := test.proposed.Annotations[GraphEndpointMigratedAnnotation]
+			if test.annotationExpected && !hasAnnotation {
+				assert.Fail(t, "expected annotation on the processed config, but did not find one")
+			}
+			if !test.annotationExpected && hasAnnotation {
+				assert.Fail(t, "did not expect the annotation on the processed config, but found one")
+			}
 		})
 	}
 }

--- a/pkg/auth/providers/azure/azure_provider_test.go
+++ b/pkg/auth/providers/azure/azure_provider_test.go
@@ -29,6 +29,7 @@ func TestConfigureTest(t *testing.T) {
 				"annotations": map[string]interface{}{
 					"auth.cattle.io/azuread-endpoint-migrated": "true",
 				},
+				"enabled":           false,
 				"endpoint":          "https://login.microsoftonline.com/",
 				"graphEndpoint":     "https://graph.microsoft.com",
 				"tokenEndpoint":     "https://login.microsoftonline.com/tenant123/oauth2/v2.0/token",
@@ -45,6 +46,7 @@ func TestConfigureTest(t *testing.T) {
 			authConfig: map[string]interface{}{
 				"accessMode":        "unrestricted",
 				"annotations":       map[string]interface{}{},
+				"enabled":           false,
 				"endpoint":          "https://login.microsoftonline.com/",
 				"graphEndpoint":     "https://graph.windows.net/",
 				"tokenEndpoint":     "https://login.microsoftonline.com/tenant123/oauth2/token",

--- a/pkg/auth/providers/azure/config.go
+++ b/pkg/auth/providers/azure/config.go
@@ -32,11 +32,12 @@ func isConfigDeprecated(cfg *v32.AzureADConfig) bool {
 	if !cfg.Enabled {
 		return false
 	}
-	v, ok := cfg.ObjectMeta.Annotations[GraphEndpointMigratedAnnotation]
-	if !ok || v != "true" {
-		logrus.Tracef("Could not find the %s annotation that specifies whether the Graph Endpoint has been migrated, or its value is not \"true\" - Rancher will use the old endpoint.",
-			GraphEndpointMigratedAnnotation)
-		return true
+	return !configHasNewFlowAnnotation(cfg)
+}
+
+func configHasNewFlowAnnotation(cfg *v32.AzureADConfig) bool {
+	if cfg.ObjectMeta.Annotations != nil {
+		return cfg.ObjectMeta.Annotations[GraphEndpointMigratedAnnotation] == "true"
 	}
 	return false
 }

--- a/pkg/auth/providers/azure/config.go
+++ b/pkg/auth/providers/azure/config.go
@@ -29,10 +29,7 @@ func authProviderEnabled(config *v32.AzureADConfig) bool {
 }
 
 func isConfigDeprecated(cfg *v32.AzureADConfig) bool {
-	if !cfg.Enabled {
-		return false
-	}
-	return !configHasNewFlowAnnotation(cfg)
+	return authProviderEnabled(cfg) && !configHasNewFlowAnnotation(cfg)
 }
 
 func configHasNewFlowAnnotation(cfg *v32.AzureADConfig) bool {

--- a/pkg/auth/providers/azure/migrate.go
+++ b/pkg/auth/providers/azure/migrate.go
@@ -1,0 +1,87 @@
+package azure
+
+import (
+	"github.com/rancher/norman/httperror"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers/azure/clients"
+	"github.com/rancher/rancher/pkg/auth/tokens"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// migrateToMicrosoftGraph performs the migration of the registered Azure AD auth provider
+// from the deprecated Azure AD Graph API to the Microsoft Graph API.
+// It modifies the existing auth config value in the database, so that it has up-to-date endpoints to the new API.
+// Most importantly, it sets the annotation that specifies that the auth config has been migrated to use the new auth flow.
+
+// It also verifies that admins have properly configured an existing app registration's permissions
+// in the Azure portal before they update their Azure AD auth config to use the new authentication flow.
+// The method receives the current AuthConfig from the database, then updates it in-memory to use the new endpoints,
+// and creates a new test Azure client, thereby getting an access token to the Graph API.
+// Then it parses the JWT and inspects the permissions contained within. If the admins had not set those as per docs,
+// then Rancher won't find the permissions in the test token and will return an error.
+
+// If validation and applying work, then migrateToMicrosoftGraph deletes all secrets with access tokens to the
+// deprecated Azure AD Graph API.
+func (ap *azureProvider) migrateToMicrosoftGraph() error {
+	cfg, err := ap.updateConfigAndValidatePermissions()
+	if err != nil {
+		return err
+	}
+	if err = ap.applyUpdatedConfig(cfg); err != nil {
+		return err
+	}
+	ap.deleteUserAccessTokens()
+	clients.GroupCache.Purge()
+	return nil
+}
+
+func (ap *azureProvider) updateConfigAndValidatePermissions() (*v32.AzureADConfig, error) {
+	cfg, err := ap.getAzureConfigK8s()
+	if err != nil {
+		return nil, err
+	}
+	if !authProviderEnabled(cfg) {
+		return nil, httperror.NewAPIError(httperror.InvalidState, "the Azure AD auth provider is not enabled")
+	}
+
+	updateAzureADEndpoints(cfg)
+
+	// Try to get a new client, which will fetch a new access token and validate its permissions.
+	_, err = clients.NewMSGraphClient(cfg, ap.secrets)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func (ap *azureProvider) applyUpdatedConfig(cfg *v32.AzureADConfig) error {
+	if cfg.ObjectMeta.Annotations == nil {
+		cfg.ObjectMeta.Annotations = make(map[string]string)
+	}
+	cfg.ObjectMeta.Annotations[GraphEndpointMigratedAnnotation] = "true"
+	return ap.saveAzureConfigK8s(cfg)
+}
+
+// deleteUserAccessTokens attempts to delete all secrets that contain users' access tokens used for working with
+// the deprecated Azure AD Graph API.
+// It is not possible to filter secrets easily by presence of specific key(s) in the data object. The method fetches all
+// Opaque secrets in the relevant namespace and looks at the target key in the data to find a secret that stores a user's
+// access token to delete.
+func (ap *azureProvider) deleteUserAccessTokens() {
+	secrets, err := ap.secrets.ListNamespaced(tokens.SecretNamespace, metav1.ListOptions{FieldSelector: "type=Opaque"})
+	if err != nil {
+		logrus.Errorf("failed to fetch secrets: %v", err)
+		return
+	}
+	// Provider name for Azure AD is the main key on secret data. This allows to identify the secrets to be deleted.
+	const key = Name
+	for _, secret := range secrets.Items {
+		if _, keyPresent := secret.Data[key]; keyPresent {
+			err := ap.secrets.DeleteNamespaced(tokens.SecretNamespace, secret.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				logrus.Errorf("failed to delete secret %s:%s - %v", tokens.SecretNamespace, secret.Name, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39002
 
## Problem
Rancher picks the new auth flow in cases where it should pick the old. Specifically, when admins have a deprecated Azure AD setup in Rancher v2.6.7+ and when they want to simply reconfigure their existing setup (by changing the Application Secret, for example). 
 
## Solution
On `testAndApply`, implement the annotation-setting logic so that it behaves in the following way:
Before setting or not setting an annotation on a new auth config, fetch an existing config from the database. Inspect this config.
1. If it is disabled, then use the new auth flow and thus set the annotation on the new config.
2. If it is enabled and has the annotation, also use the new auth flow and thus set the annotation on the new config.
3. If it is enabled and **does not** have the annotation, use the old auth flow and and thus **do not** set the annotation on the new config.
 
## Testing
1. On v2.6.6 Rancher server, enable Azure AD auth config with standard endpoints.
4. Upgrade the rancher server to v2.6-head.
5. Do not update the endpoints but click on edit config.
6. Input a new Application Secret value and save.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->