### PR TITLE
Add role_based_access_control_enabled to AKS

### DIFF
--- a/tests/validation/tests/v3_api/resource/terraform/aks/aks.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/aks/aks.tf
@@ -26,6 +26,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   dns_prefix          = "taaks${random_string.random.result}"
   kubernetes_version  = var.kubernetes_version
   sku_tier            = "Paid"
+  role_based_access_control_enabled = true
 
   default_node_pool {
     name            = "taaks${random_string.random.result}"


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> N/A
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
With previous changes done to the `aks.tf` file, RBAC was not defined to be set to true. As per the AKS documentation, we should ensure that it is enabled to follow best practices.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Added `role_based_access_control_enabled` parameter to ensure that RBAC is set to true.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Locally tested that a Rancher server is stood up with AKS as the local cluster. Once done, provisioned an RKE1 cluster and validated that came up successfully.