### PR TITLE
[release/v2.7] Update validation tests' Dockerfile to use Go 1.19

### DIFF
--- a/tests/v2/validation/Dockerfile.validation
+++ b/tests/v2/validation/Dockerfile.validation
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.19
 
 # Configure Go
 ENV GOPATH /go
@@ -15,7 +15,7 @@ WORKDIR $WORKSPACE/tests/v2/validation
 COPY [".", "$WORKSPACE"]
 
 RUN go mod download && \
-    go get gotest.tools/gotestsum
+    go install gotest.tools/gotestsum@latest
 
 RUN CGO_ENABLED=0
 


### PR DESCRIPTION
Validation tests' Docker is about to become outdated, as following this #39001:

This PR contains the version update and an update to the gotestsum installation for the validation test environments.