### PR TITLE
Increasing the test watch timeout due to timeouts

### DIFF
--- a/tests/integration/pkg/defaults/defaults.go
+++ b/tests/integration/pkg/defaults/defaults.go
@@ -5,7 +5,7 @@ import "os"
 var (
 	PodTestImage        = "rancher/systemd-node:v0.0.4"
 	SomeK8sVersion      = os.Getenv("SOME_K8S_VERSION")
-	WatchTimeoutSeconds = int64(60 * 30)
+	WatchTimeoutSeconds = int64(60 * 35)
 	CommonClusterConfig = map[string]interface{}{
 		"service-cidr": "10.45.0.0/16",
 		"cluster-cidr": "10.44.0.0/16",


### PR DESCRIPTION
The tests are sometimes timing out which is causing flaky tests. This change increases the timeout period to give the tests longer to complete.

## Issue: #39045
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The k3s provisioning tests appear to be timing out.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Increase the timeout.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

This is in the tests.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->