### PR TITLE
Update parallelism to reduce server load

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -111,7 +111,7 @@ done
 
 echo Running provisioning-tests
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-go test -v -timeout 60m ./tests/integration/pkg/tests/... || {
+go test -v -parallel 1 -failfast -timeout 60m ./tests/integration/pkg/tests/... || {
     echo -e "-----RANCHER-LOG-DUMP-START-----"
     cat /tmp/rancher.log | gzip | base64 -w 0
     echo -e "\n-----RANCHER-LOG-DUMP-END-----"


### PR DESCRIPTION
Given the instance sizes we are running the reduced parallelism can help CI have a reduced load at any one time.

## Issue: #39045
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

CI is having issues with timeouts, OOM, or something else in the k3s provisioning tests.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Reducing the parallelism to 50% of the vCPUs.