### PR TITLE
[2.7] Fix registries within the cluster agent manifest for Prov V2

### DIFF
--- a/pkg/apis/management.cattle.io/v3/cluster_types.go
+++ b/pkg/apis/management.cattle.io/v3/cluster_types.go
@@ -85,6 +85,9 @@ const (
 	ClusterDriverEKS      = "EKS"
 	ClusterDriverGKE      = "GKE"
 	ClusterDriverRancherD = "rancherd"
+
+	ClusterPrivateRegistrySecret = "PrivateRegistrySecret"
+	ClusterPrivateRegistryURL    = "PrivateRegistryURL"
 )
 
 // +genclient
@@ -400,6 +403,7 @@ type GKEStatus struct {
 
 type ClusterSecrets struct {
 	PrivateRegistrySecret string `json:"privateRegistrySecret,omitempty" norman:"nocreate,noupdate"`
+	PrivateRegistryURL    string `json:"privateRegistryURL,omitempty" norman:"nocreate,noupdate"`
 	S3CredentialSecret    string `json:"s3CredentialSecret,omitempty" norman:"nocreate,noupdate"`
 	WeavePasswordSecret   string `json:"weavePasswordSecret,omitempty" norman:"nocreate,noupdate"`
 	VsphereSecret         string `json:"vsphereSecret,omitempty" norman:"nocreate,noupdate"`

--- a/pkg/client/generated/management/v3/zz_generated_cluster_secrets.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_secrets.go
@@ -6,6 +6,7 @@ const (
 	ClusterSecretsFieldAADClientSecret       = "aadClientSecret"
 	ClusterSecretsFieldOpenStackSecret       = "openStackSecret"
 	ClusterSecretsFieldPrivateRegistrySecret = "privateRegistrySecret"
+	ClusterSecretsFieldPrivateRegistryURL    = "privateRegistryURL"
 	ClusterSecretsFieldS3CredentialSecret    = "s3CredentialSecret"
 	ClusterSecretsFieldVirtualCenterSecret   = "virtualCenterSecret"
 	ClusterSecretsFieldVsphereSecret         = "vsphereSecret"
@@ -17,6 +18,7 @@ type ClusterSecrets struct {
 	AADClientSecret       string `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
 	OpenStackSecret       string `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
 	PrivateRegistrySecret string `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
+	PrivateRegistryURL    string `json:"privateRegistryURL,omitempty" yaml:"privateRegistryURL,omitempty"`
 	S3CredentialSecret    string `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
 	VirtualCenterSecret   string `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
 	VsphereSecret         string `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`

--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -34,6 +34,22 @@ func GetPrivateRepo(cluster *v3.Cluster) *rketypes.PrivateRegistry {
 	return nil
 }
 
+// TransformProvV2RegistryCredentialsToDockerConfigJSON transforms a ProvV2 registry secret into a credentialprovider.DockerConfigJSON secret
+func TransformProvV2RegistryCredentialsToDockerConfigJSON(url string, registryCredentials *corev1.Secret) (map[string][]byte, error) {
+	username := string(registryCredentials.Data["username"])
+	password := string(registryCredentials.Data["password"])
+	authConfig := credentialprovider.DockerConfigJSON{
+		Auths: credentialprovider.DockerConfig{
+			url: credentialprovider.DockerConfigEntry{
+				Username: username,
+				Password: password,
+			},
+		},
+	}
+	j, err := json.Marshal(authConfig)
+	return map[string][]byte{".dockerconfigjson": j}, err
+}
+
 func GenerateClusterPrivateRegistryDockerConfig(cluster *v3.Cluster) (string, error) {
 	if cluster == nil {
 		return "", nil
@@ -41,8 +57,8 @@ func GenerateClusterPrivateRegistryDockerConfig(cluster *v3.Cluster) (string, er
 	return GeneratePrivateRegistryDockerConfig(GetPrivateRepo(cluster), nil)
 }
 
-// This method generates base64 encoded credentials for the registry
-func GeneratePrivateRegistryDockerConfig(privateRegistry *rketypes.PrivateRegistry, registrySecret *corev1.Secret) (string, error) {
+// GeneratePrivateRegistryDockerConfig generates base64 encoded credentials for the provided registry
+func GeneratePrivateRegistryDockerConfig(privateRegistry *rketypes.PrivateRegistry, registrySecret []byte) (string, error) {
 	if privateRegistry == nil {
 		return "", nil
 	}
@@ -62,17 +78,15 @@ func GeneratePrivateRegistryDockerConfig(privateRegistry *rketypes.PrivateRegist
 	if registrySecret != nil {
 		privateRegistry = privateRegistry.DeepCopy()
 		dockerCfg := credentialprovider.DockerConfigJSON{}
-		if dockerConfigJSON := registrySecret.Data[".dockerconfigjson"]; len(dockerConfigJSON) > 0 {
-			err := json.Unmarshal(dockerConfigJSON, &dockerCfg)
+		if len(registrySecret) > 0 {
+			err := json.Unmarshal(registrySecret, &dockerCfg) // check to see if registrySecret is in the correct format
 			if err != nil {
 				logrus.Debug("Failed to parse dockerconfig for registry secret: " + err.Error())
 				return "", err
 			}
-		}
-
-		if reg, ok := dockerCfg.Auths[privateRegistry.URL]; ok {
-			privateRegistry.User = reg.Username
-			privateRegistry.Password = reg.Password
+			if _, ok := dockerCfg.Auths[privateRegistry.URL]; ok {
+				return base64.URLEncoding.EncodeToString(registrySecret), nil
+			}
 		}
 	}
 	if privateRegistry.User == "" || privateRegistry.Password == "" {

--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -349,11 +349,11 @@ func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, cluster *v
 	}
 
 	var imagePullSecrets []corev1.LocalObjectReference
-	if cluster.GetSecret("PrivateRegistrySecret") != "" {
-		privateRegistries, err := m.credLister.Get(namespace.GlobalNamespace, cluster.GetSecret("PrivateRegistrySecret"))
+	if registrySecret := cluster.GetSecret(v3.ClusterPrivateRegistrySecret); registrySecret != "" {
+		privateRegistries, err := m.credLister.Get(namespace.GlobalNamespace, registrySecret)
 		if err != nil {
 			return nil, err
-		} else if url, err := util.GeneratePrivateRegistryDockerConfig(util.GetPrivateRepo(cluster), privateRegistries); err != nil {
+		} else if url, err := util.GeneratePrivateRegistryDockerConfig(util.GetPrivateRepo(cluster), privateRegistries.Data[".dockerconfigjson"]); err != nil {
 			return nil, err
 		} else if url != "" {
 			imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{Name: "cattle-private-registry"})

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -277,6 +277,9 @@ func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus,
 	spec.DesiredAgentImage = image.ResolveWithCluster(settings.AgentImage.Get(), cluster)
 	spec.DesiredAuthImage = image.ResolveWithCluster(settings.AuthImage.Get(), cluster)
 
+	spec.ClusterSecrets.PrivateRegistrySecret = image.GetPrivateRepoSecretFromCluster(cluster)
+	spec.ClusterSecrets.PrivateRegistryURL = image.GetPrivateRepoURLFromCluster(cluster)
+
 	spec.AgentEnvVars = nil
 	for _, env := range cluster.Spec.AgentEnvVars {
 		spec.AgentEnvVars = append(spec.AgentEnvVars, corev1.EnvVar{

--- a/pkg/provisioningv2/rke2/planner/agent.go
+++ b/pkg/provisioningv2/rke2/planner/agent.go
@@ -4,8 +4,13 @@ import (
 	"fmt"
 	"sort"
 
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	util "github.com/rancher/rancher/pkg/cluster"
+	"github.com/rancher/rancher/pkg/fleet"
 	"github.com/rancher/rancher/pkg/systemtemplate"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // generateClusterAgentManifest generates a cluster agent manifest
@@ -37,5 +42,22 @@ func (p *Planner) generateClusterAgentManifest(controlPlane *rkev1.RKEControlPla
 		return nil, err
 	}
 
-	return systemtemplate.ForCluster(mgmtCluster, tokens[0].Status.Token, taints)
+	var formattedPrivateRegistry map[string][]byte
+	privateRegistrySecret := mgmtCluster.GetSecret(v3.ClusterPrivateRegistrySecret)
+	privateRegistryURL := mgmtCluster.GetSecret(v3.ClusterPrivateRegistryURL)
+	if privateRegistrySecret != "" && privateRegistryURL != "" {
+		// cluster level registry has been defined and should be used when generating agent manifest.
+		// This ensures images pulled by the agent (e.g. shell) come from the correct registry.
+		privateRegistries, err := p.secretClient.Get(fleet.ClustersDefaultNamespace, privateRegistrySecret, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		// transform the registry secrets for ProvV2 as they only have 'username' and 'password' fields, but SystemTemplate expects the credentialprovider.DockerConfigJSON type
+		formattedPrivateRegistry, err = util.TransformProvV2RegistryCredentialsToDockerConfigJSON(privateRegistryURL, privateRegistries)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return systemtemplate.ForCluster(mgmtCluster, tokens[0].Status.Token, taints, formattedPrivateRegistry)
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/38897, relates to https://github.com/rancher/rancher/issues/35189
 
## Problem
When deploying RKE2/K3s clusters which have a cluster level private registry configured, the cluster agent manifest did not incorporate that registry. Instead, the global system-default-registry was used. This resulted in images created by the cluster agent (namely the `shell` image when creating the `dashboard-shell` container) being pulled from the incorrect registry, which has implications for clusters which only have access to the cluster level registry. This issue is apart of a larger set of issues regarding the use of cluster level private registries and their precedence over the global system-default-registry. 

This issue only occurs with RKE2/K3s clusters.

## Root Cause
The location of the private registry details differs between the `v3.Cluster` objects for RKE1 and RKE2/K3s. 

This results in the inability to determine if an RKE2/K3s cluster has a cluster level registry configured when generating the cluster agent manifest during the call to `SystemTemplate` within `pkg/systemtemplate/import.go`. 

Due to this, the `settings.SystemDefaultRegistry` was always being applied, causing images to be pulled incorrectly. 
 
## Solution
When creating the `v3.Cluster` object for RKE2/K3s clusters, add a reference to the private registry URL and the secret containing the system-default-registry credentials. The secret is created by the UI, and the registry URL can be found on the `v1.Cluster` object. Then, when generating cluster agent manifests, utilize these references to ensure that cluster level registries for RKE2/K3s are honored. 

These references are held in the `ClusterSecrets` section of the object so as to avoid spec changes as much as possible. A new field has been added to track the URL of the cluster default registry. With these new references, `pkg/controllers/management/clusterdeploy/clusterdeploy.go` and `pkg/systemtemplate/import.go` can determine the cluster level private registry for both RKE1 and RKE2/K3s. 

if there is a better place to put these references, other than the `ClusterSecrets`, let me know. My main intent was to modify the object as little as possible to include these new references. 

 
## Testing
+ Configure two private registries, one with no authentication and another with authentication
   + non-authenticated registry will serve as the global registry 
   + authenticated registry will serve as the cluster level private registry 
+ In the global settings, set the `system-default-registry` to the URL of your unauthenticated registry
+ Begin to create an RKE2/K3s cluster
+ Before creating the RKE2/K3s cluster, go to the `Registries` section of the Cluster configuration screen and supply the authenticated registries URL, username, and password.
+ Create the cluster and wait for it to become available
+ Navigate to the cluster workload page, and select all namespaces 
+ Select the `pods` view to see all running pods 
+ In the top right corner, press the `Kubectl Shell` button to create a new `dashboard-shell` container 
+ Look for the new contain in the `pods` view and see that the image is pulled from the cluster level private registry.



## Engineering Testing
### Manual Testing
I have manually tested the following scenarios, all of which have passed. 

+ RKE1 cluster provisioning with only a global system-default-registry configured
  + all images are pulled from the correct repository, including the `shell` image for the `dashboard-shell` container
+ RKE1 cluster provisioning with both a global system-default-registry and cluster level private registry configured:
  + all images are pulled from the correct repository, including the `shell` image for the `dashboard-shell` container
+ RKE2 & K3s cluster provisioning with only a global system-default-registry configured
  + all images are pulled from the correct repository, including the `shell` image for the `dashboard-shell` container
+ RKE2 & K3s cluster provisioning with both a global system-default-registry and cluster level private registry configured:
  + all images are pulled from the correct repository, including the `shell` image for the `dashboard-shell` container
  + The cluster agent manifest has the correct environment variables and the associated registry secret has the correct configuration. 
+ Scaling RKE1 node pools up and down
+ Scaling RKE2 & K3s node pools up and down 

### Automated Testing
No automated testing was added 

## QA Testing Considerations
The private registries must be loaded with the correct images for the k8's version that you want to use. My testing was done against registries loaded with 2.6.7 images.
 
### Regressions Considerations
RKE2/K3s clusters are treated as imported clusters, so additional testing around importing existing clusters should be done to ensure no regressions have been introduced. I've done brief testing of imported clusters with these changes and did not notice any issues.