### PR TITLE
[release/v2.7] Incrementing the version of k3s to the latest 1.24.x

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -4,7 +4,7 @@ ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 ENV CATTLE_HELM_VERSION v2.16.8-rancher2
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher95
-ENV CATTLE_K3S_VERSION v1.24.1+k3s1
+ENV CATTLE_K3S_VERSION v1.24.4+k3s1
 # version used by helm plugin install script
 ENV CATTLE_HELM_UNITTEST_VERSION v0.1.7-rancher4
 # helm 3 version
@@ -56,7 +56,7 @@ RUN mkdir /usr/tmp && \
     chmod +x /usr/bin/kustomize
 
 # Set up K3s: copy the necessary binaries from the K3s image.
-COPY --from=rancher/k3s:v1.24.1-k3s1 \
+COPY --from=rancher/k3s:v1.24.4-k3s1 \
     /bin/blkid \
     /bin/charon \
     /bin/cni \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -28,7 +28,7 @@ ENV CATTLE_PARTNER_CHART_DEFAULT_BRANCH=$PARTNER_CHART_DEFAULT_BRANCH
 ENV CATTLE_RKE2_CHART_DEFAULT_BRANCH=$RKE2_CHART_DEFAULT_BRANCH
 ENV CATTLE_HELM_VERSION v2.16.8-rancher2
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher95
-ENV CATTLE_K3S_VERSION v1.24.1+k3s1
+ENV CATTLE_K3S_VERSION v1.24.4+k3s1
 ENV CATTLE_MACHINE_PROVISION_IMAGE rancher/machine:${CATTLE_MACHINE_VERSION}
 ENV CATTLE_ETCD_VERSION v3.5.1
 ENV LOGLEVEL_VERSION v0.1.5
@@ -114,7 +114,7 @@ RUN curl ${HELM_URL_V3} | tar xvzf - --strip-components=1 -C /usr/bin && \
     chmod +x /usr/bin/kustomize
 
 # Set up K3s: copy the necessary binaries from the K3s image.
-COPY --from=rancher/k3s:v1.24.1-k3s1 \
+COPY --from=rancher/k3s:v1.24.4-k3s1 \
     /bin/blkid \
     /bin/charon \
     /bin/cni \


### PR DESCRIPTION
## Issue: #39045
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The CI system regularly has flakes. The underlying error reads:

> machine_test.go:552: Internal error occurred: failed calling webhook "rancher.cattle.io": failed to call webhook: Post "https://rancher-webhook.cattle-system.svc:443/v1/webhook/mutation?timeout=10s": EOF

This can come at various times during the k3s provisioning tests.

The k3s project has an issue for it at https://github.com/k3s-io/k3s/issues/5835

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

We have been running k3s 1.24.1. Since that time there have been fixes to the egress selector mode. That issue notes that disabling the egress selector mode or trying to update to a newer k3s may fix the problem. In the release notes for k3s it notes they have fixed bugs around this.

This PR updates the version of k3s to 1.24.4.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

It passed in CI.