### PR TITLE
[release/v2.7] Adding cattle-elemental-system in the list of system namespaces in Rancher for proper backup of Elemental

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -76,7 +76,7 @@ var (
 	SystemAgentInstallerImage           = NewSetting("system-agent-installer-image", "rancher/system-agent-installer-")
 	SystemAgentUpgradeImage             = NewSetting("system-agent-upgrade-image", "")
 	WinsAgentUpgradeImage               = NewSetting("wins-agent-upgrade-image", "")
-	SystemNamespaces                    = NewSetting("system-namespaces", "kube-system,kube-public,cattle-system,cattle-alerting,cattle-logging,cattle-prometheus,ingress-nginx,cattle-global-data,cattle-istio,kube-node-lease,cert-manager,cattle-global-nt,security-scan,cattle-fleet-system,cattle-fleet-local-system,calico-system,tigera-operator,cattle-impersonation-system,rancher-operator-system,cattle-csp-adapter-system,calico-apiserver")
+	SystemNamespaces                    = NewSetting("system-namespaces", "kube-system,kube-public,cattle-system,cattle-alerting,cattle-logging,cattle-prometheus,ingress-nginx,cattle-global-data,cattle-istio,kube-node-lease,cert-manager,cattle-global-nt,security-scan,cattle-fleet-system,cattle-fleet-local-system,calico-system,tigera-operator,cattle-impersonation-system,rancher-operator-system,cattle-csp-adapter-system,calico-apiserver,cattle-elemental-system")
 	SystemUpgradeControllerChartVersion = NewSetting("system-upgrade-controller-chart-version", "")
 	TelemetryOpt                        = NewSetting("telemetry-opt", "")
 	TLSMinVersion                       = NewSetting("tls-min-version", "1.2")


### PR DESCRIPTION
## Issue: https://github.com/rancher/elemental-operator/issues/9

Elemental Operator namespace needs to be included in the system namespaces in Rancher in order for Backup to properly work.
 
## Engineering Testing
### Manual Testing
No testing on my side, 

### Automated Testing
No automated testing

## QA Testing Considerations
During 2.7 validation work, for clusters created/managed with Elemental, backup should include elemental objects.
 
### Regressions Considerations
Would be surprising