### PR TITLE
[release/v2.7] Surround ipv6 address in brackets for join URL

### DIFF
--- a/pkg/provisioningv2/rke2/planner/store_test.go
+++ b/pkg/provisioningv2/rke2/planner/store_test.go
@@ -1,0 +1,41 @@
+package planner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoinURLFromAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		address  string
+		port     int
+		expected string
+	}{
+		{
+			name:     "ipv4",
+			address:  "127.0.0.1",
+			port:     9345,
+			expected: "https://127.0.0.1:9345",
+		},
+		{
+			name:     "ipv6",
+			address:  "::ffff:7f00:1",
+			port:     9345,
+			expected: "https://[::ffff:7f00:1]:9345",
+		},
+		{
+			name:     "hostname",
+			address:  "testing.rancher.io",
+			port:     9345,
+			expected: "https://testing.rancher.io:9345",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, joinURLFromAddress(tt.address, tt.port))
+		})
+	}
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->https://github.com/rancher/rancher/issues/39038
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The join URL that control plane nodes would use to join a cluster would always be an ipv4 address, scraped from the etcd leader. The join URL that worker nodes would use would instead be the first controlplane node's last `InternalIP` address (or `ExternalIP` if no suitable `InternalIP` is found) as shown in it's status, like so:
```
status:
  addresses:
  - address: 165.227.189.32
    type: InternalIP
  - address: 2604:a880:800:10::7c6:7001
    type: InternalIP
  - address: jhyde-rke2-test-controlplane-838bba1c-8fhkh
    type: Hostname
```
In this case, the ipv6 address was being used, but it was being rendered as `https://2604:a880:800:10::7c6:7001:9345`, with `9345` being appended as the port. This is an invalid URL, as ipv6 hosts must be enclosed with `[]` like so: `https://[2604:a880:800:10::7c6:7001]:9345`

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Enclose ipv6 addresses with brackets.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Create a 3 node (1 etcd, 1 controlplane, 1 worker) cluster on Digital Ocean with ipv6 enabled. The worker node will get stuck in `waiting for probes: calico, kubelet`

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Nodes do get stuck in this state, but that's not what this PR is fixing. I need to investigate whether or not it's possible to fix downstream worker nodes by overwriting their plans, since it seems like we purposefully wait for the node plan to reconcile, but the `rke2-server` will become inactive. 

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

I added unit tests to ensure that both hostnames and ipv4 addresses are left untouched.