### PR TITLE
[2.6] Bump OKE cluster driver to v1.8.3 (support for k8s 1.24+)

### DIFF
--- a/pkg/data/management/kontainerdriver_data.go
+++ b/pkg/data/management/kontainerdriver_data.go
@@ -92,8 +92,8 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 	}
 	if err := creator.addCustomDriver(
 		"oraclecontainerengine",
-		"https://github.com/rancher-plugins/kontainer-engine-driver-oke/releases/download/v1.7.1/kontainer-engine-driver-oke-linux",
-		"5a708bfc01c67558adc887258615900082263ca7d6f4160efb1a58501b0cc608",
+		"https://github.com/rancher-plugins/kontainer-engine-driver-oke/releases/download/v1.8.3/kontainer-engine-driver-oke-linux",
+		"7bfde567e6d478f1da8d36531f765d348bff1cd3abe83c70ddf7766f46112170",
 		"",
 		false,
 		"*.oraclecloud.com",


### PR DESCRIPTION
This PR updates [OKE Cluster Driver](https://github.com/rancher-plugins/kontainer-engine-driver-oke) in the 2.6 release branch to use OKE cluster driver version `v1.8.3`, that has multiple bug fixes and supports a new flag for specifying [cloud-init](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengusingcustomcloudinitscripts.htm) for OKE nodes via `--node-user-data-contents`.

Related Issues:
- https://github.com/rancher-plugins/kontainer-engine-driver-oke/issues/46
- https://github.com/rancher-plugins/kontainer-engine-driver-oke/issues/54
- https://github.com/rancher-plugins/kontainer-engine-driver-oke/issues/59

Related PRs:
- https://github.com/rancher/ui/pull/4856
- https://github.com/rancher/terraform-provider-rancher2/pull/940
- https://github.com/rancher/rancher/pull/39254