### PR TITLE
Allow taints to apply to k3s clusters

### DIFF
--- a/pkg/provisioningv2/rke2/planner/agent.go
+++ b/pkg/provisioningv2/rke2/planner/agent.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
-	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2"
 	"github.com/rancher/rancher/pkg/systemtemplate"
 )
 
@@ -33,7 +32,7 @@ func (p *Planner) generateClusterAgentManifest(controlPlane *rkev1.RKEControlPla
 		return nil, err
 	}
 
-	taints, err := getTaints(entry, rke2.GetRuntime(controlPlane.Spec.KubernetesVersion))
+	taints, err := getTaints(entry)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provisioningv2/rke2/planner/config.go
+++ b/pkg/provisioningv2/rke2/planner/config.go
@@ -352,12 +352,12 @@ func addLabels(config map[string]interface{}, entry *planEntry) error {
 	return nil
 }
 
-func addTaints(config map[string]interface{}, entry *planEntry, runtime string) error {
+func addTaints(config map[string]interface{}, entry *planEntry) error {
 	var (
 		taintString []string
 	)
 
-	taints, err := getTaints(entry, runtime)
+	taints, err := getTaints(entry)
 	if err != nil {
 		return err
 	}
@@ -443,15 +443,14 @@ func (p *Planner) addConfigFile(nodePlan plan.NodePlan, controlPlane *rkev1.RKEC
 	addRoleConfig(config, controlPlane, entry, initNode, joinServer)
 	addLocalClusterAuthenticationEndpointConfig(config, controlPlane, entry)
 	addToken(config, entry, tokensSecret)
+
 	if err := addAddresses(p.secretCache, config, entry); err != nil {
 		return nodePlan, config, err
 	}
 	if err := addLabels(config, entry); err != nil {
 		return nodePlan, config, err
 	}
-
-	runtime := rke2.GetRuntime(controlPlane.Spec.KubernetesVersion)
-	if err := addTaints(config, entry, runtime); err != nil {
+	if err := addTaints(config, entry); err != nil {
 		return nodePlan, config, err
 	}
 
@@ -507,7 +506,7 @@ func (p *Planner) addConfigFile(nodePlan plan.NodePlan, controlPlane *rkev1.RKEC
 
 	nodePlan.Files = append(nodePlan.Files, plan.File{
 		Content: base64.StdEncoding.EncodeToString(configData),
-		Path:    fmt.Sprintf(ConfigYamlFileName, runtime),
+		Path:    fmt.Sprintf(ConfigYamlFileName, rke2.GetRuntime(controlPlane.Spec.KubernetesVersion)),
 	})
 
 	return nodePlan, config, nil

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -853,7 +853,7 @@ func PruneEmpty(config map[string]interface{}) {
 }
 
 // getTaints returns a slice of taints for the machine in question
-func getTaints(entry *planEntry, runtime string) (result []corev1.Taint, _ error) {
+func getTaints(entry *planEntry) (result []corev1.Taint, _ error) {
 	data := entry.Metadata.Annotations[rke2.TaintsAnnotation]
 	if data != "" {
 		if err := json.Unmarshal([]byte(data), &result); err != nil {
@@ -861,15 +861,14 @@ func getTaints(entry *planEntry, runtime string) (result []corev1.Taint, _ error
 		}
 	}
 
-	if runtime == rke2.RuntimeRKE2 {
-		if isEtcd(entry) && !isWorker(entry) {
+	if !isWorker(entry) {
+		if isEtcd(entry) {
 			result = append(result, corev1.Taint{
 				Key:    "node-role.kubernetes.io/etcd",
 				Effect: corev1.TaintEffectNoExecute,
 			})
 		}
-
-		if isControlPlane(entry) && !isWorker(entry) {
+		if isControlPlane(entry) {
 			result = append(result, corev1.Taint{
 				Key:    "node-role.kubernetes.io/control-plane",
 				Effect: corev1.TaintEffectNoSchedule,


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->#38681
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

k3s clusters did not have taints applied to etcd/controlplane nodes.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Ensure k3s clusters also have taints applied to also have taints.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Manually tested by provisioning all 7 permutations of node roles:

| etcd               | controlplane       | worker             | node-role.kubernetes.io/control-plane=:NoSchedule | node-role.kubernetes.io/etcd=:NoExecute |
|--------------------|--------------------|--------------------|---------------------------------------------------|-----------------------------------------|
| :heavy_check_mark: |                    |                    |                                                   | :heavy_check_mark:                      |
|                    | :heavy_check_mark: |                    | :heavy_check_mark:                                |                                         |
|                    |                    | :heavy_check_mark: |                                                   |                                         |
| :heavy_check_mark: | :heavy_check_mark: |                    | :heavy_check_mark:                                | :heavy_check_mark:                      |
| :heavy_check_mark: |                    | :heavy_check_mark: |                                                   |                                         |
|                    | :heavy_check_mark: | :heavy_check_mark: |                                                   |                                         |
| :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |                                                   |                                         |