### PR TITLE
Don't check for deletionTimestamp when reconciling machines

### DIFF
--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -410,7 +410,7 @@ func (m *nodesSyncer) reconcileAll() error {
 		if err != nil {
 			return err
 		}
-		if node == nil || machine.DeletionTimestamp != nil {
+		if node == nil {
 			logrus.Debugf("Failed to get node for machine [%s], preparing to delete", machine.Name)
 			toDelete[machine.Name] = machine
 			continue


### PR DESCRIPTION
Just want `release/v2.6` and `release/v2.7` to be in line when I merge https://github.com/rancher/rancher/pull/39016, this check didn't do anything useful.