### PR TITLE
Prevent user from re-using the bootstrap password

### DIFF
--- a/pkg/auth/api/user/user_actions_test.go
+++ b/pkg/auth/api/user/user_actions_test.go
@@ -6,52 +6,66 @@ import (
 
 func TestValidatePassword(t *testing.T) {
 	tests := []struct {
-		name       string
-		username   string
-		password   string
-		expectsErr bool
+		name        string
+		username    string
+		currentpass string
+		password    string
+		expectsErr  bool
 	}{
 		{
-			name:       "password too short",
-			username:   "admin",
-			password:   "tooshort",
-			expectsErr: true,
+			name:        "password too short",
+			username:    "admin",
+			currentpass: "currentpassword",
+			password:    "tooshort",
+			expectsErr:  true,
 		},
 		{
-			name:       "username equals password min length",
-			username:   "passwordpass",
-			password:   "passwordpass",
-			expectsErr: true,
+			name:        "username equals password min length",
+			username:    "passwordpass",
+			currentpass: "currentpassword",
+			password:    "passwordpass",
+			expectsErr:  true,
 		},
 		{
-			name:       "username and password almost match",
-			username:   "administrator",
-			password:   "administrator1",
-			expectsErr: false,
+			name:        "username and password almost match",
+			username:    "administrator",
+			currentpass: "currentpassword",
+			password:    "administrator1",
+			expectsErr:  false,
 		},
 		{
-			name:       "12 byte password, 6 runes",
-			username:   "admin",
-			password:   "пароль",
-			expectsErr: true,
+			name:        "12 byte password, 6 runes",
+			username:    "admin",
+			currentpass: "currentpassword",
+			password:    "пароль",
+			expectsErr:  true,
 		},
 		{
-			name:       "23 byte password, 12 runes",
-			username:   "admin",
-			password:   "абвгдеёжзий1",
-			expectsErr: false,
+			name:        "23 byte password, 12 runes",
+			username:    "admin",
+			currentpass: "currentpassword",
+			password:    "абвгдеёжзий1",
+			expectsErr:  false,
 		},
 		{
-			name:       "username equals password min length unicode",
-			username:   "абвгдеёжзий1",
-			password:   "абвгдеёжзий1",
-			expectsErr: true,
+			name:        "username equals password min length unicode",
+			username:    "абвгдеёжзий1",
+			currentpass: "currentpassword",
+			password:    "абвгдеёжзий1",
+			expectsErr:  true,
+		},
+		{
+			name:        "new password matches current password",
+			username:    "admin",
+			currentpass: "myfavoritepassword",
+			password:    "myfavoritepassword",
+			expectsErr:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validatePassword(tt.username, tt.password, 12)
+			err := validatePassword(tt.username, tt.currentpass, tt.password, 12)
 			if err != nil && !tt.expectsErr {
 				t.Errorf("Received unexpected error: %v", err)
 			} else if err == nil && tt.expectsErr {

--- a/pkg/auth/api/user/user_store.go
+++ b/pkg/auth/api/user/user_store.go
@@ -118,7 +118,7 @@ func (s *userStore) Create(apiContext *types.APIContext, schema *types.Schema, d
 		return nil, errors.New("invalid password")
 	}
 
-	if err := validatePassword(username, password, settings.PasswordMinLength.GetInt()); err != nil {
+	if err := validatePassword(username, "", password, settings.PasswordMinLength.GetInt()); err != nil {
 		return nil, httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())
 	}
 


### PR DESCRIPTION
This will also prevent re-use of the existing password on the changepassword action api call.

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
We now compare the existing password with the proposed new password, if they match, we reject it.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Tried re-using bootstrap password as well as other current password, both rejected as designed.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Added unit test to verify this funcitonality

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->