### PR TITLE
Remove user-node-remove on node remove

### DIFF
--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -35,19 +35,21 @@ const (
 )
 
 func (m *Lifecycle) deleteV1Node(node *v3.Node) (runtime.Object, error) {
-	logrus.Debugf("Deleting v1.node for [%v] node", node.Status.NodeName)
+	logrus.Debugf("[node-cleanup] Deleting v1.node for [%v] node", node.Status.NodeName)
 	if nodehelper.IgnoreNode(node.Status.NodeName, node.Status.NodeLabels) {
-		logrus.Debugf("Skipping v1.node removal for [%v] node", node.Status.NodeName)
+		logrus.Debugf("[node-cleanup] Skipping v1.node removal for [%v] node", node.Status.NodeName)
 		return node, nil
 	}
 
 	if node.Status.NodeName == "" {
+		logrus.Debugf("[node-cleanup] Skipping v1.node removal for machine [%v] without node name", node.Name)
 		return node, nil
 	}
 
 	cluster, err := m.clusterLister.Get("", node.Namespace)
 	if err != nil {
 		if kerror.IsNotFound(err) {
+			logrus.Debugf("[node-cleanup] Skipping v1.node removal for machine [%v] without cluster [%v]", node.Name, node.Namespace)
 			return node, nil
 		}
 		return node, err
@@ -57,7 +59,7 @@ func (m *Lifecycle) deleteV1Node(node *v3.Node) (runtime.Object, error) {
 		return node, err
 	}
 	if userClient == nil {
-		logrus.Debugf("cluster is already deleted, cannot delete RKE node")
+		logrus.Debugf("[node-cleanup] cluster is already deleted, cannot delete RKE node")
 		return node, nil
 	}
 
@@ -94,14 +96,14 @@ func (m *Lifecycle) drainNode(node *v3.Node) error {
 		return nil
 	}
 
-	logrus.Infof("node [%s] requires draining before delete", nodeCopy.Spec.RequestedHostname)
+	logrus.Infof("[node-cleanup] node [%s] requires draining before delete", nodeCopy.Spec.RequestedHostname)
 	kubeConfig, _, err := m.getKubeConfig(cluster)
 	if err != nil {
 		return fmt.Errorf("node [%s] error getting kubeConfig", nodeCopy.Spec.RequestedHostname)
 	}
 
 	if nodeCopy.Spec.NodeDrainInput == nil {
-		logrus.Debugf("node [%s] has no NodeDrainInput, creating one with 60s timeout",
+		logrus.Debugf("[node-cleanup] node [%s] has no NodeDrainInput, creating one with 60s timeout",
 			nodeCopy.Spec.RequestedHostname)
 		nodeCopy.Spec.NodeDrainInput = &rketypes.NodeDrainInput{
 			Force:           true,
@@ -118,7 +120,7 @@ func (m *Lifecycle) drainNode(node *v3.Node) error {
 		Steps:    3,
 	}
 
-	logrus.Infof("node [%s] attempting to drain, retrying up to 3 times", nodeCopy.Spec.RequestedHostname)
+	logrus.Infof("[node-cleanup] node [%s] attempting to drain, retrying up to 3 times", nodeCopy.Spec.RequestedHostname)
 	// purposefully ignoring error, if the drain fails this falls back to deleting the node as usual
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		ctx, cancel := context.WithTimeout(m.ctx, time.Duration(nodeCopy.Spec.NodeDrainInput.Timeout)*time.Second)
@@ -126,16 +128,16 @@ func (m *Lifecycle) drainNode(node *v3.Node) error {
 
 		_, msg, err := kubectl.Drain(ctx, kubeConfig, nodeCopy.Status.NodeName, nodehelper.GetDrainFlags(nodeCopy))
 		if ctx.Err() != nil {
-			logrus.Errorf("node [%s] kubectl drain failed, retrying: %s", nodeCopy.Spec.RequestedHostname, ctx.Err())
+			logrus.Errorf("[node-cleanup] node [%s] kubectl drain failed, retrying: %s", nodeCopy.Spec.RequestedHostname, ctx.Err())
 			return false, nil
 		}
 		if err != nil {
 			// kubectl failed continue on with delete any way
-			logrus.Errorf("node [%s] kubectl drain error, retrying: %s", nodeCopy.Spec.RequestedHostname, err)
+			logrus.Errorf("[node-cleanup] node [%s] kubectl drain error, retrying: %s", nodeCopy.Spec.RequestedHostname, err)
 			return false, nil
 		}
 
-		logrus.Infof("node [%s] kubectl drain response: %s", nodeCopy.Spec.RequestedHostname, msg)
+		logrus.Infof("[node-cleanup] node [%s] kubectl drain response: %s", nodeCopy.Spec.RequestedHostname, msg)
 		return true, nil
 	})
 }
@@ -162,7 +164,7 @@ func (m *Lifecycle) cleanRKENode(node *v3.Node) error {
 		return err
 	}
 	if userContext == nil {
-		logrus.Debugf("cluster is already deleted, cannot clean RKE node")
+		logrus.Debugf("[node-cleanup] cluster is already deleted, cannot clean RKE node")
 		return nil
 	}
 
@@ -420,7 +422,7 @@ func removeFinalizerWithPrefix(finalizers []string, prefix string) []string {
 	var nf []string
 	for _, finalizer := range finalizers {
 		if strings.HasPrefix(finalizer, prefix) {
-			logrus.Debugf("finalizer with prefix [%s] will be removed", prefix)
+			logrus.Debugf("[node-cleanup] finalizer with prefix [%s] will be removed", prefix)
 			continue
 		}
 		nf = append(nf, finalizer)
@@ -431,7 +433,7 @@ func removeFinalizerWithPrefix(finalizers []string, prefix string) []string {
 func removeAnnotationWithPrefix(annotations map[string]string, prefix string) map[string]string {
 	for k := range annotations {
 		if strings.HasPrefix(k, prefix) {
-			logrus.Debugf("annotation with prefix [%s] will be removed", prefix)
+			logrus.Debugf("[node-cleanup] annotation with prefix [%s] will be removed", prefix)
 			delete(annotations, k)
 		}
 	}

--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -397,7 +397,7 @@ func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, cluster *v
 	return userContext.K8sClient.BatchV1().Jobs("default").Create(context.TODO(), &job, metav1.CreateOptions{})
 }
 
-func (m *Lifecycle) userNodeRemoveCleanup(obj *v3.Node) (*v3.Node, error) {
+func (m *Lifecycle) userNodeRemoveCleanup(obj *v3.Node) *v3.Node {
 	newObj := obj.DeepCopy()
 	newObj.SetFinalizers(removeFinalizerWithPrefix(newObj.GetFinalizers(), userNodeRemoveFinalizerPrefix))
 
@@ -411,9 +411,8 @@ func (m *Lifecycle) userNodeRemoveCleanup(obj *v3.Node) (*v3.Node, error) {
 		}
 
 		annos[userNodeRemoveCleanupAnnotation] = "true"
-		newObj.SetAnnotations(annos)
 	}
-	return m.nodeClient.Update(newObj)
+	return newObj
 }
 
 func removeFinalizerWithPrefix(finalizers []string, prefix string) []string {

--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -398,11 +398,11 @@ func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, cluster *v
 }
 
 func (m *Lifecycle) userNodeRemoveCleanup(obj *v3.Node) *v3.Node {
-	newObj := obj.DeepCopy()
-	newObj.SetFinalizers(removeFinalizerWithPrefix(newObj.GetFinalizers(), userNodeRemoveFinalizerPrefix))
+	obj = obj.DeepCopy()
+	obj.SetFinalizers(removeFinalizerWithPrefix(obj.GetFinalizers(), userNodeRemoveFinalizerPrefix))
 
-	if newObj.DeletionTimestamp == nil {
-		annos := newObj.GetAnnotations()
+	if obj.DeletionTimestamp == nil {
+		annos := obj.GetAnnotations()
 		if annos == nil {
 			annos = make(map[string]string)
 		} else {
@@ -411,8 +411,9 @@ func (m *Lifecycle) userNodeRemoveCleanup(obj *v3.Node) *v3.Node {
 		}
 
 		annos[userNodeRemoveCleanupAnnotation] = "true"
+		obj.SetAnnotations(annos)
 	}
-	return newObj
+	return obj
 }
 
 func removeFinalizerWithPrefix(finalizers []string, prefix string) []string {

--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -397,7 +397,7 @@ func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, cluster *v
 	return userContext.K8sClient.BatchV1().Jobs("default").Create(context.TODO(), &job, metav1.CreateOptions{})
 }
 
-func (m *Lifecycle) userNodeRemoveCleanup(obj *v3.Node) (runtime.Object, error) {
+func (m *Lifecycle) userNodeRemoveCleanup(obj *v3.Node) (*v3.Node, error) {
 	newObj := obj.DeepCopy()
 	newObj.SetFinalizers(removeFinalizerWithPrefix(newObj.GetFinalizers(), userNodeRemoveFinalizerPrefix))
 

--- a/pkg/controllers/management/node/controller.go
+++ b/pkg/controllers/management/node/controller.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base32"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -223,71 +222,80 @@ func (m *Lifecycle) getNodePool(nodePoolName string) (*apimgmtv3.NodePool, error
 	return m.nodePoolLister.Get(ns, p)
 }
 
-func (m *Lifecycle) Remove(obj *apimgmtv3.Node) (runtime.Object, error) {
-	if obj.Status.NodeTemplateSpec == nil {
-		if err := m.cleanRKENode(obj); err != nil {
-			return obj, err
+func (m *Lifecycle) Remove(machine *apimgmtv3.Node) (obj runtime.Object, err error) {
+	if machine.Annotations[userNodeRemoveCleanupAnnotation] != "true" {
+		// if a node is provisioned on <v2.5.1, rancher is stopped, and the node is deleted; the user-node-remove finalizer
+		// should just be removed here.
+		if machine, err = m.userNodeRemoveCleanup(machine); err != nil {
+			return machine, err
 		}
-
-		return m.deleteV1Node(obj)
 	}
 
-	newObj, err := apimgmtv3.NodeConditionRemoved.DoUntilTrue(obj, func() (runtime.Object, error) {
-		found, err := m.isNodeInAppliedSpec(obj)
+	if machine.Status.NodeTemplateSpec == nil {
+		if err = m.cleanRKENode(machine); err != nil {
+			return machine, err
+		}
+
+		return m.deleteV1Node(machine)
+	}
+
+	obj, err = apimgmtv3.NodeConditionRemoved.DoUntilTrue(machine, func() (runtime.Object, error) {
+		found, err := m.isNodeInAppliedSpec(machine)
 		if err != nil {
-			return obj, err
+			return machine, err
 		}
 		if found {
-			return obj, errors.New("waiting for node to be removed from cluster")
+			return machine, errors.New("waiting for node to be removed from cluster")
 		}
 
 		if !m.devMode {
-			err := jailer.CreateJail(obj.Namespace)
+			err = jailer.CreateJail(machine.Namespace)
 			if err != nil {
 				return nil, errors.WithMessage(err, "node remove jail error")
 			}
 		}
 
-		config, err := nodeconfig.NewNodeConfig(m.secretStore, obj)
+		config, err := nodeconfig.NewNodeConfig(m.secretStore, machine)
 		if err != nil {
-			return obj, err
+			return machine, err
 		}
 
-		if err := config.Restore(); err != nil {
-			return obj, err
+		if err = config.Restore(); err != nil {
+			return machine, err
 		}
 
 		defer config.Remove()
 
-		err = m.refreshNodeConfig(config, obj)
+		err = m.refreshNodeConfig(config, machine)
 		if err != nil {
-			return nil, errors.WithMessagef(err, "unable to refresh config for node %v", obj.Name)
+			return nil, errors.WithMessagef(err, "unable to refresh config for node %v", machine.Name)
 		}
 
-		mExists, err := nodeExists(config.Dir(), obj)
+		exists, err := nodeExists(config.Dir(), machine)
 		if err != nil {
-			return obj, err
+			return machine, err
 		}
 
-		if mExists {
-			logrus.Infof("Removing node %s", obj.Spec.RequestedHostname)
-			if err := m.drainNode(obj); err != nil {
-				return obj, err
+		if exists {
+			logrus.Infof("Removing node %s", machine.Spec.RequestedHostname)
+			if err = m.drainNode(machine); err != nil {
+				return machine, err
 			}
-			if err := deleteNode(config.Dir(), obj); err != nil {
-				return obj, err
+			if err = deleteNode(config.Dir(), machine); err != nil {
+				return machine, err
 			}
-			logrus.Infof("Removing node %s done", obj.Spec.RequestedHostname)
+			logrus.Infof("Removing node %s done", machine.Spec.RequestedHostname)
 		}
 
-		return obj, nil
+		return machine, nil
 	})
 
+	machine = obj.(*apimgmtv3.Node)
 	if err != nil {
-		return newObj.(*apimgmtv3.Node), err
+		return machine, err
 	}
 
-	return m.deleteV1Node(newObj.(*apimgmtv3.Node))
+	return m.deleteV1Node(machine)
 }
 
 func (m *Lifecycle) provision(driverConfig, nodeDir string, obj *apimgmtv3.Node) (*apimgmtv3.Node, error) {
@@ -328,11 +336,11 @@ func (m *Lifecycle) provision(driverConfig, nodeDir string, obj *apimgmtv3.Node)
 		return obj, err
 	}
 
-	if err := cmd.Wait(); err != nil {
+	if err = cmd.Wait(); err != nil {
 		return obj, err
 	}
 
-	if err := m.deployAgent(nodeDir, obj); err != nil {
+	if err = m.deployAgent(nodeDir, obj); err != nil {
 		return obj, err
 	}
 
@@ -386,7 +394,7 @@ func aliasToPath(driver string, config map[string]interface{}, ns string) error 
 					return err
 				}
 				fullPath := path.Join(fileDir, fileName)
-				err = ioutil.WriteFile(fullPath, []byte(fileContents), 0600)
+				err = os.WriteFile(fullPath, []byte(fileContents), 0600)
 				if err != nil {
 					return err
 				}
@@ -520,17 +528,16 @@ outer:
 	return obj, err
 }
 
-func (m *Lifecycle) sync(_ string, obj *apimgmtv3.Node) (runtime.Object, error) {
-	if obj == nil {
+func (m *Lifecycle) sync(_ string, machine *apimgmtv3.Node) (runtime.Object, error) {
+	if machine == nil {
 		return nil, nil
 	}
 
-	if obj.Annotations[userNodeRemoveCleanupAnnotation] != "true" {
-		// finalizer from user-node-remove has to be checked/cleaned
-		return m.userNodeRemoveCleanup(obj)
+	if machine.Annotations[userNodeRemoveCleanupAnnotation] != "true" {
+		return m.userNodeRemoveCleanup(machine)
 	}
 
-	return obj, nil
+	return machine, nil
 }
 
 func (m *Lifecycle) Updated(obj *apimgmtv3.Node) (runtime.Object, error) {

--- a/pkg/controllers/management/node/utils.go
+++ b/pkg/controllers/management/node/utils.go
@@ -225,9 +225,9 @@ func (m *Lifecycle) reportStatus(stdoutReader io.Reader, stderrReader io.Reader,
 		if strings.HasPrefix(msg, debugPrefix) {
 			// calls in machine with log.Debug are all prefixed and spammy so only log
 			// under trace and don't add to the v3.NodeConditionProvisioned.Message
-			logrus.Tracef("[node-controller-rancher-machine] %v", msg)
+			logrus.Tracef("[node-controller] %v", msg)
 		} else {
-			logrus.Infof("[node-controller-rancher-machine] %v", msg)
+			logrus.Infof("[node-controller] %v", msg)
 			v32.NodeConditionProvisioned.Message(node, msg)
 		}
 
@@ -304,12 +304,12 @@ func deleteNode(nodeDir string, node *v3.Node) error {
 	scanner := bufio.NewScanner(stdoutReader)
 	for scanner.Scan() {
 		msg := scanner.Text()
-		logrus.Infof("[node-controller-rancher-machine] %v", msg)
+		logrus.Infof("[node-controller] %v", msg)
 	}
 	scanner = bufio.NewScanner(stderrReader)
 	for scanner.Scan() {
 		msg := scanner.Text()
-		logrus.Warnf("[node-controller-rancher-machine] %v", msg)
+		logrus.Warnf("[node-controller] %v", msg)
 	}
 
 	return command.Wait()

--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -394,7 +394,7 @@ func (m *nodesSyncer) reconcileAll() error {
 		return err
 	}
 
-	nodeMap := make(map[string]*corev1.Node)
+	nodeMap := make(map[string]*corev1.Node, len(nodes))
 	for _, node := range nodes {
 		nodeMap[node.Name] = node
 	}

--- a/pkg/nodeconfig/config.go
+++ b/pkg/nodeconfig/config.go
@@ -139,7 +139,7 @@ func (m *NodeConfig) Save() error {
 		return err
 	}
 
-	if err := m.loadConfig(); err != nil {
+	if err = m.loadConfig(); err != nil {
 		return err
 	}
 
@@ -149,7 +149,7 @@ func (m *NodeConfig) Save() error {
 
 	m.cm[configKey] = extractedConfig
 
-	if err := m.store.Set(m.id, m.cm); err != nil {
+	if err = m.store.Set(m.id, m.cm); err != nil {
 		m.cm = nil
 		return err
 	}
@@ -192,7 +192,7 @@ func (m *NodeConfig) UpdateAmazonAuth(rawConfig interface{}) (bool, error) {
 	for _, file := range files {
 		if file.IsDir() {
 			configPath := filepath.Join(machines, file.Name(), "config.json")
-			b, err := ioutil.ReadFile(configPath)
+			b, err := os.ReadFile(configPath)
 			if err != nil {
 				if os.IsNotExist(err) {
 					// config.json doesn't exist, no changes needed
@@ -242,7 +242,7 @@ func (m *NodeConfig) UpdateAmazonAuth(rawConfig interface{}) (bool, error) {
 					return update, errors.WithMessage(err, "error marshaling new machine config")
 				}
 
-				if err := ioutil.WriteFile(configPath, out, 0600); err != nil {
+				if err := os.WriteFile(configPath, out, 0600); err != nil {
 					return update, errors.WithMessage(err, "error writing  new machine config")
 				}
 			}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->#38442
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

If a node is provisioned on <v2.5.1, rancher is stopped, and the node is deleted; Remove will not be called for the node causing orphaned v1.Nodes which default unmanaged v3.Nodes are then created for.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Remove the annotation on sync and v3.Node removal.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested with a 1 etcd, 1 controlplane, 1 worker. On upgrade from v2.5.1 to v2.7-head, the node is properly cleaned up.