### PR TITLE
[v2.7] Add RKE1 node scaling

### DIFF
--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -133,6 +133,7 @@ func NewRKE1ClusterConfig(clusterName, cni, kubernetesVersion string, client *ra
 				MTU:     0,
 				Options: map[string]string{},
 			},
+			Version: kubernetesVersion,
 		},
 	}
 
@@ -202,6 +203,11 @@ func CreateRKE1Cluster(client *rancher.Client, rke1Cluster *management.Cluster) 
 	}
 
 	cluster, err := client.Management.Cluster.Create(rke1Cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err = client.ReLogin()
 	if err != nil {
 		return nil, err
 	}

--- a/tests/framework/extensions/rke1/nodepools/nodepools.go
+++ b/tests/framework/extensions/rke1/nodepools/nodepools.go
@@ -2,10 +2,54 @@ package rke1
 
 import (
 	"strconv"
+	"time"
 
+	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
+
+// IsNodeReady is a helper method that will loop and check if the node is ready in the RKE1 cluster.
+// It will return an error if the node is not ready after set amount of time.
+func IsNodeReady(client *rancher.Client, nodePool *management.NodePool, ClusterID string) error {
+	err := wait.Poll(500*time.Millisecond, 30*time.Minute, func() (bool, error) {
+		nodes, err := client.Management.Node.List(&types.ListOpts{
+			Filters: map[string]interface{}{
+				"clusterId":  ClusterID,
+				"nodePoolId": nodePool.ID,
+			},
+		})
+		if err != nil {
+			return false, err
+		}
+
+		const active = "active"
+
+		for _, node := range nodes.Data {
+			node, err := client.Management.Node.ByID(node.ID)
+			if err != nil {
+				return false, err
+			}
+
+			if node.State == active {
+				return true, nil
+			}
+
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
 
 type NodeRoles struct {
 	ControlPlane bool  `json:"controlplane,omitempty" yaml:"controlplane,omitempty"`
@@ -14,7 +58,7 @@ type NodeRoles struct {
 	Quantity     int64 `json:"quantity" yaml:"quantity"`
 }
 
-// RKE1NodePoolSetup is a helper method that will loop and setup muliple node pools with the defined node roles from the `nodeRoles` parameter
+// NodePoolSetup is a helper method that will loop and setup muliple node pools with the defined node roles from the `nodeRoles` parameter
 // `nodeRoles` would be in this format
 //
 //	  []map[string]bool{
@@ -31,7 +75,7 @@ type NodeRoles struct {
 //		   Quantity:     1,
 //	  },
 //	 }
-func RKE1NodePoolSetup(client *rancher.Client, nodeRoles []NodeRoles, ClusterID, NodeTemplateID string) (*management.NodePool, error) {
+func NodePoolSetup(client *rancher.Client, nodeRoles []NodeRoles, ClusterID, NodeTemplateID string) (*management.NodePool, error) {
 	nodePoolConfig := management.NodePool{
 		ClusterID:               ClusterID,
 		DeleteNotReadyAfterSecs: 0,
@@ -53,4 +97,49 @@ func RKE1NodePoolSetup(client *rancher.Client, nodeRoles []NodeRoles, ClusterID,
 	}
 
 	return &nodePoolConfig, nil
+}
+
+// ScaleWorkerNodePool is a helper method that will add a worker node pool to the existing RKE1 cluster. Once done, it will scale
+// the worker node pool to add a worker node, scale it back down to remove the worker node, and then delete the worker node pool.
+func ScaleWorkerNodePool(client *rancher.Client, nodeRoles []NodeRoles, ClusterID, NodeTemplateID string) error {
+	nodePoolConfig := management.NodePool{
+		ClusterID:               ClusterID,
+		ControlPlane:            false,
+		DeleteNotReadyAfterSecs: 0,
+		Etcd:                    false,
+		HostnamePrefix:          "auto-rke1-scale-test",
+		NodeTemplateID:          NodeTemplateID,
+		Quantity:                1,
+		Worker:                  true,
+	}
+
+	nodePool, err := client.Management.NodePool.Create(&nodePoolConfig)
+	if err != nil {
+		return err
+	}
+
+	IsNodeReady(client, nodePool, ClusterID)
+
+	nodePoolConfig.Quantity = 2
+
+	updatedPool, err := client.Management.NodePool.Update(nodePool, &nodePoolConfig)
+	if err != nil {
+		return err
+	}
+
+	IsNodeReady(client, updatedPool, ClusterID)
+
+	nodePoolConfig.Quantity = 1
+
+	_, err = client.Management.NodePool.Update(updatedPool, &nodePoolConfig)
+	if err != nil {
+		return err
+	}
+
+	err = client.Management.NodePool.Delete(nodePool)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -140,13 +140,10 @@ func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1Cluster(provider P
 					clusterResp, err := clusters.CreateRKE1Cluster(testSessionClient, cluster)
 					require.NoError(r.T(), err)
 
-					client, err = client.ReLogin()
-					require.NoError(r.T(), err)
-
 					nodeTemplateResp, err := provider.NodeTemplateFunc(client)
 					require.NoError(r.T(), err)
 
-					nodePool, err := nodepools.RKE1NodePoolSetup(testSessionClient, tt.nodeRoles, clusterResp.ID, nodeTemplateResp.ID)
+					nodePool, err := nodepools.NodePoolSetup(testSessionClient, tt.nodeRoles, clusterResp.ID, nodeTemplateResp.ID)
 					require.NoError(r.T(), err)
 
 					nodePoolName := nodePool.Name
@@ -168,6 +165,9 @@ func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1Cluster(provider P
 					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
 					require.NoError(r.T(), err)
 					assert.NotEmpty(r.T(), clusterToken)
+
+					err = nodepools.ScaleWorkerNodePool(testSessionClient, tt.nodeRoles, clusterResp.ID, nodeTemplateResp.ID)
+					require.NoError(r.T(), err)
 				})
 			}
 		}
@@ -210,13 +210,10 @@ func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1ClusterDynamicInpu
 					clusterResp, err := clusters.CreateRKE1Cluster(testSessionClient, cluster)
 					require.NoError(r.T(), err)
 
-					client, err = client.ReLogin()
-					require.NoError(r.T(), err)
-
 					nodeTemplateResp, err := provider.NodeTemplateFunc(client)
 					require.NoError(r.T(), err)
 
-					nodePool, err := nodepools.RKE1NodePoolSetup(testSessionClient, nodesAndRoles, clusterResp.ID, nodeTemplateResp.ID)
+					nodePool, err := nodepools.NodePoolSetup(testSessionClient, nodesAndRoles, clusterResp.ID, nodeTemplateResp.ID)
 					require.NoError(r.T(), err)
 
 					nodePoolName := nodePool.Name
@@ -238,6 +235,9 @@ func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1ClusterDynamicInpu
 					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
 					require.NoError(r.T(), err)
 					assert.NotEmpty(r.T(), clusterToken)
+
+					err = nodepools.ScaleWorkerNodePool(testSessionClient, nodesAndRoles, clusterResp.ID, nodeTemplateResp.ID)
+					require.NoError(r.T(), err)
 				})
 			}
 		}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

[[RKE1] Scale up/down nodes](https://github.com/rancher/qa-tasks/issues/461)

[In automation framework rke1 extension doesn't use k8's version parameter](https://github.com/rancher/rancher/issues/38961)
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

**_Problem 1_**
In the test framework, there is currently no scaling tests for RKE1 or RKE2. Scaling is a fundamental Kubernetes operation and it is crucial that we have routine testing for this.

**_Problem 2_**
In the existing `clusters.go`, there was no field to properly set the Kubernetes version; it was left up to the user-defined `cattle-config.yaml` file. This needed to be properly defined.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

_**Solution 1**_
`nodepools.go` was modified to include new `ScaleWorkerNodePool` that performs the following:

- Creates new worker node pool
- Increases quantity from 1 to 2 to scale upwards to include worker node
- Decreases quantity from 2 back to 1 to scale downwards to remove a worker node
- Deletes the new worker node pool

_**Solution 2**_
`clusters.go` was given a new field to include the Kubernetes version.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
I performed manual testing with 1 node and 3 node, just as the admin user. This was successful; a full automated run will be ran once the PR is up.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Offline Jenkins runs will be conducted and results handed to the reviewers.