### PR TITLE
Set GroupPrincipals at token create time

### DIFF
--- a/pkg/auth/tokens/manager.go
+++ b/pkg/auth/tokens/manager.go
@@ -668,12 +668,13 @@ func (m *Manager) NewLoginToken(userID string, userPrincipal v3.Principal, group
 	}
 
 	token := &v3.Token{
-		UserPrincipal: userPrincipal,
-		IsDerived:     false,
-		TTLMillis:     ttl,
-		UserID:        userID,
-		AuthProvider:  provider,
-		Description:   description,
+		UserPrincipal:   userPrincipal,
+		GroupPrincipals: groupPrincipals,
+		IsDerived:       false,
+		TTLMillis:       ttl,
+		UserID:          userID,
+		AuthProvider:    provider,
+		Description:     description,
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				TokenKindLabel: "session",


### PR DESCRIPTION
In order to avoid having a null GroupPrincipals at token create time, explicitly set the value that is passed to the NewLoginToken call.

## Issue: <!-- link the issue or issues this PR resolves here -->
[#39107](https://github.com/rancher/rancher/issues/39107)
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
GroupPrincipals is not explicitly set at token creation time, which can lead to if having a null (invalid) value instead of [].
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updated the NewLoginToken function to use the value for GroupPrincipals that was passed in.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
The provided steps worked to expose the problem and no longer show a problem after this fix is applied.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
After the change, I was able to deploy a fresh cluster and update the description of a token without needing to also change the value of GroupPrincipals, which was already set to []

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->