### PR TITLE
Reduce logging verbosity when installing feature charts.

### DIFF
--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -111,7 +112,9 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 
 	// add priority class value
 	if priorityClassName, err := h.chartsConfig.GetPriorityClassName(); err != nil {
-		logrus.Warnf("Failed to get rancher priorityClassName: %v", err)
+		if !apierror.IsNotFound(err) {
+			logrus.Warnf("Failed to get rancher priorityClassName for '%s': %v", fleetChart.ChartName, err)
+		}
 	} else {
 		fleetChartValues[chart.PriorityClassKey] = priorityClassName
 		gitjobChartValues[chart.PriorityClassKey] = priorityClassName

--- a/pkg/controllers/dashboard/hostedcluster/controller.go
+++ b/pkg/controllers/dashboard/hostedcluster/controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -132,7 +133,9 @@ func (h handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster, 
 	}
 	// add priority class value
 	if priorityClassName, err := h.chartsConfig.GetPriorityClassName(); err != nil {
-		logrus.Warnf("Failed to get rancher priorityClassName: %v", err)
+		if !apierror.IsNotFound(err) {
+			logrus.Warnf("Failed to get rancher priorityClassName for %q: %v", toInstallChart.ChartName, err)
+		}
 	} else {
 		chartValues[chart.PriorityClassKey] = priorityClassName
 	}

--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/wrangler/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -102,7 +103,9 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 				}
 				// add priority class value.
 				if priorityClassName, err := h.chartsConfig.GetPriorityClassName(); err != nil {
-					logrus.Warnf("Failed to get rancher priorityClassName: %v", err)
+					if !apierror.IsNotFound(err) {
+						logrus.Warnf("Failed to get rancher priorityClassName for 'rancher-webhook': %v", err)
+					}
 				} else {
 					values[chart.PriorityClassKey] = priorityClassName
 				}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/37927
Specifically addresses this comment: https://github.com/rancher/rancher/issues/37927#issuecomment-1263542957
## Problem
If a user is using rancher via docker, the new rancher-config configMap is not installed causing a warning message when feature charts attempt a lookup on the map. This can fill the logs since feature charts are ensured every 5 minutes.
 
## Solution
Only log the error if it is not a NotFound error.
 
## Testing
Fresh install rancher via docker.
Wait 5 minutes
Verify that the logs do not contain the message `Failed to get rancher priorityClassName`
