### PR TITLE
[v2.6] Add K3S provisioning support for node driver/custom clusters

### DIFF
--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -140,8 +140,8 @@ func NewRKE1ClusterConfig(clusterName, cni, kubernetesVersion string, client *ra
 	return clusterConfig
 }
 
-// NewRKE2ClusterConfig is a constructor for a apisV1.Cluster object, to be used by the rancher.Client.Provisioning client.
-func NewRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretName, kubernetesVersion string, machinePools []provisioning.RKEMachinePool) *provisioning.Cluster {
+// NewK3SRKE2ClusterConfig is a constructor for a apisV1.Cluster object, to be used by the rancher.Client.Provisioning client.
+func NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretName, kubernetesVersion string, machinePools []provisioning.RKEMachinePool) *provisioning.Cluster {
 	//metav1.ObjectMeta
 	objectMeta := &provisioning.ObjectMeta{
 		Name:      clusterName,
@@ -241,9 +241,9 @@ func CreateRKE1Cluster(client *rancher.Client, rke1Cluster *management.Cluster) 
 	return cluster, nil
 }
 
-// CreateRKE2Cluster is a "helper" functions that takes a rancher client, and the rke2 cluster config as parameters. This function
+// CreateK3SRKE2Cluster is a "helper" functions that takes a rancher client, and the rke2 cluster config as parameters. This function
 // registers a delete cluster fuction with a wait.WatchWait to ensure the cluster is removed cleanly.
-func CreateRKE2Cluster(client *rancher.Client, rke2Cluster *provisioning.Cluster) (*provisioning.Cluster, error) {
+func CreateK3SRKE2Cluster(client *rancher.Client, rke2Cluster *provisioning.Cluster) (*provisioning.Cluster, error) {
 	cluster, err := client.Provisioning.Cluster.Create(rke2Cluster)
 	if err != nil {
 		return nil, err

--- a/tests/framework/extensions/machinepools/machinepools.go
+++ b/tests/framework/extensions/machinepools/machinepools.go
@@ -28,8 +28,8 @@ func CreateMachineConfig(resource string, machinePoolConfig *unstructured.Unstru
 	return dynamic.Resource(groupVersionResource).Namespace(machinePoolConfig.GetNamespace()).Create(context.TODO(), machinePoolConfig, metav1.CreateOptions{})
 }
 
-// NewRKEMachinePool is a constructor that sets up a apisV1.RKEMachinePool object to be used to provision a cluster.
-func NewRKEMachinePool(controlPlaneRole, etcdRole, workerRole bool, poolName string, quantity int64, machineConfig *unstructured.Unstructured) provisioning.RKEMachinePool {
+// NewMachinePool is a constructor that sets up a apisV1.RKEMachinePool object to be used to provision a cluster.
+func NewMachinePool(controlPlaneRole, etcdRole, workerRole bool, poolName string, quantity int64, machineConfig *unstructured.Unstructured) provisioning.RKEMachinePool {
 	machineConfigRef := &provisioning.ObjectReference{
 		Kind: machineConfig.GetKind(),
 		Name: machineConfig.GetName(),
@@ -52,7 +52,7 @@ type NodeRoles struct {
 	Quantity     int64 `json:"quantity" yaml:"quantity"`
 }
 
-// RKEMachinePoolSetup is a helper method that will loop and setup muliple node pools with the defined node roles from the `nodeRoles` parameter
+// MachinePoolSetup is a helper method that will loop and setup muliple node pools with the defined node roles from the `nodeRoles` parameter
 // `machineConfig` is the *unstructured.Unstructured created by CreateMachineConfig
 // `nodeRoles` would be in this format
 //   []NodeRoles{
@@ -70,10 +70,10 @@ type NodeRoles struct {
 //   },
 //  }
 
-func RKEMachinePoolSetup(nodeRoles []NodeRoles, machineConfig *unstructured.Unstructured) []provisioning.RKEMachinePool {
+func MachinePoolSetup(nodeRoles []NodeRoles, machineConfig *unstructured.Unstructured) []provisioning.RKEMachinePool {
 	machinePools := []provisioning.RKEMachinePool{}
 	for index, roles := range nodeRoles {
-		machinePool := NewRKEMachinePool(roles.ControlPlane, roles.Etcd, roles.Worker, "pool"+strconv.Itoa(index), roles.Quantity, machineConfig)
+		machinePool := NewMachinePool(roles.ControlPlane, roles.Etcd, roles.Worker, "pool"+strconv.Itoa(index), roles.Quantity, machineConfig)
 		machinePools = append(machinePools, machinePool)
 	}
 

--- a/tests/v2/validation/provisioning/k3s/README.md
+++ b/tests/v2/validation/provisioning/k3s/README.md
@@ -1,0 +1,185 @@
+
+# K3S Provisioning Configs
+
+For your config, you will need everything in the Prerequisites section on the previous readme, [Define your test](#provisioning-input), and at least one [Cloud Credential](#cloud-credentials) and [Node Driver Machine Config](#machine-k3s-config) or [Custom Cluster Template](#custom-cluster), which should match what you have specified in `provisioningInput`. 
+
+Your GO test_package should be set to `provisioning/k3s`.
+Your GO suite should be set to `-run ^TestK3SProvisioningTestSuite$`.
+Please see below for more details for your config. 
+
+1. [Prerequisites](../README.md)
+2. [Define your test](#provisioning-input)
+3. [Cloud Credential](#cloud-credentials)
+4. [Configure providers to use for Node Driver Clusters](#machine-k3s-config)
+5. [Configuring Custom Clusters](#custom-cluster)
+6. [Back to general provisioning](../README.md)
+
+## Provisioning Input
+provisioningInput is needed to the run the K3S tests, specifically kubernetesVersion and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". 
+
+**nodeProviders is only needed for custom cluster tests; the framework only supports custom clusters through aws/ec2 instances.**
+
+```json
+"provisioningInput": {
+    "nodesAndRoles": [
+      {
+        "etcd": true,
+        "controlplane": true,
+        "worker": true,
+        "quantity": 1,
+      },
+      {
+        "worker": true,
+        "quantity": 1,
+      }
+    ],
+    "kubernetesVersion": ["v1.24.4+k3s1"],
+    "cni": ["calico"],
+    "providers": ["linode", "aws", "azure", "harvester"],
+    "nodeProviders": ["ec2"]
+  }
+```
+
+## Cloud Credentials
+These are the inputs needed for the different node provider cloud credentials, inlcuding linode, aws, digital ocean, harvester, azure, and google.
+
+### Digital Ocean
+```json
+"digitalOceanCredentials": {
+   "accessToken": ""
+  },
+```
+### Linode
+```json
+"linodeCredentials": {
+   "token": ""
+  },
+```
+### Azure
+```json
+"azureCredentials": {
+   "clientId": "",
+   "clientSecret": "",
+     "subscriptionId": "",
+     "environment": "AzurePublicCloud"
+  },
+```
+### AWS
+```json
+"awsCredentials": {
+   "secretKey": "",
+   "accessKey": "",
+   "defaultRegion": ""
+  },
+```
+### Harvester
+```json
+"harvesterCredentials": {
+   "clusterId": "",
+   "clusterType": "",
+   "kubeconfigContent": ""
+},
+```
+### Google
+```json
+"googleCredentials": {
+    "authEncodedJson": ""
+}
+```
+
+## Machine K3S Config
+Machine K3S config is the final piece needed for the config to run K3S provisioning tests.
+
+### AWS K3S Machine Config
+```json
+"awsMachineConfig": {
+    "region": "us-east-2",
+    "ami": "",
+    "instanceType": "t3a.medium",
+    "sshUser": "ubuntu",
+    "vpcId": "",
+    "volumeType": "gp2",
+    "zone": "a",
+    "retries": "5",
+    "rootSize": "16",
+    "securityGroup": ["rancher-nodes"]
+},
+```
+### Linode K3S Machine Config
+```json
+"linodeMachineConfig": {
+  "authorizedUsers": "",
+  "createPrivateIp": false,
+  "dockerPort": "2376",
+  "image": "linode/ubuntu20.04",
+  "instanceType": "g6-standard-2",
+  "region": "us-west",
+  "rootPass": "",
+  "sshPort": "22",
+  "sshUser": "",
+  "stackscript": "",
+  "stackscriptData": "",
+  "swapSize": "512",
+  "tags": "",
+  "uaPrefix": ""
+},
+```
+### Azure K3S Machine Config
+```json
+"azureMachineConfig": {
+  "availabilitySet": "docker-machine",
+  "diskSize": "30",
+  "environment": "AzurePublicCloud",
+  "faultDomainCount": "3",
+  "image": "canonical:UbuntuServer:18.04-LTS:latest",
+  "location": "westus",
+  "managedDisks": false,
+  "noPublicIp": false,
+  "nsg": "",
+  "openPort": ["6443/tcp", "2379/tcp", "2380/tcp", "8472/udp", "4789/udp", "9796/tcp", "10256/tcp", "10250/tcp", "10251/tcp", "10252/tcp"],
+  "resourceGroup": "docker-machine",
+  "size": "Standard_D2_v2",
+  "sshUser": "docker-user",
+  "staticPublicIp": false,
+  "storageType": "Standard_LRS",
+  "subnet": "docker-machine",
+  "subnetPrefix": "192.168.0.0/16",
+  "updateDomainCount": "5",
+  "usePrivateIp": false,
+  "vnet": "docker-machine-vnet"
+},
+```
+### Harvester K3S Machine Config
+```json
+"harvesterMachineConfig": {
+  "diskSize": "40",
+  "cpuCount": "2",
+  "memorySize": "8",
+  "networkName": "default/ctw-network-1",
+  "imageName": "default/image-rpj98",
+  "vmNamespace": "default",
+  "sshUser": "ubuntu",
+  "diskBus": "virtio"
+}
+```
+
+## Custom Cluster
+For custom clusters, the below config is needed, only AWS/EC2 will work.
+**Ensure you have nodeProviders in provisioningInput**
+
+```json
+ "awsEC2Config": {
+    "region": "us-east-2",
+    "instanceType": "t3a.medium",
+    "awsRegionAZ": "",
+    "awsAMI": "",
+    "awsSecurityGroups": [""],
+    "awsAccessKeyID": "",
+    "awsSecretAccessKey": "",
+    "awsSSHKeyName": "",
+    "awsCICDInstanceTag": "",
+    "awsIAMProfile": "",
+    "awsUser": "ubuntu",
+    "volumeSize": 50
+  },
+```

--- a/tests/v2/validation/provisioning/k3s/providers.go
+++ b/tests/v2/validation/provisioning/k3s/providers.go
@@ -1,0 +1,73 @@
+package k3s
+
+import (
+	"fmt"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/aws"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/azure"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/harvester"
+	"github.com/rancher/rancher/tests/framework/extensions/cloudcredentials/linode"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	awsProviderName       = "aws"
+	azureProviderName     = "azure"
+	harvesterProviderName = "harvester"
+	linodeProviderName    = "linode"
+)
+
+type CloudCredFunc func(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error)
+type MachinePoolFunc func(generatedPoolName, namespace string) *unstructured.Unstructured
+
+type Provider struct {
+	Name            string
+	MachineConfig   string
+	MachinePoolFunc MachinePoolFunc
+	CloudCredFunc   CloudCredFunc
+}
+
+// CreateProvider returns all machine and cloud credential
+// configs in the form of a Provider struct. Accepts a
+// string of the name of the provider.
+func CreateProvider(name string) Provider {
+	switch {
+	case name == awsProviderName:
+		provider := Provider{
+			Name:            name,
+			MachineConfig:   machinepools.AWSResourceConfig,
+			MachinePoolFunc: machinepools.NewAWSMachineConfig,
+			CloudCredFunc:   aws.CreateAWSCloudCredentials,
+		}
+		return provider
+	case name == azureProviderName:
+		provider := Provider{
+			Name:            name,
+			MachineConfig:   machinepools.AzureResourceConfig,
+			MachinePoolFunc: machinepools.NewAzureMachineConfig,
+			CloudCredFunc:   azure.CreateAzureCloudCredentials,
+		}
+		return provider
+	case name == linodeProviderName:
+		provider := Provider{
+			Name:            name,
+			MachineConfig:   machinepools.LinodeResourceConfig,
+			MachinePoolFunc: machinepools.NewLinodeMachineConfig,
+			CloudCredFunc:   linode.CreateLinodeCloudCredentials,
+		}
+		return provider
+	case name == harvesterProviderName:
+		provider := Provider{
+			Name:            name,
+			MachineConfig:   machinepools.HarvesterResourceConfig,
+			MachinePoolFunc: machinepools.NewHarvesterMachineConfig,
+			CloudCredFunc:   harvester.CreateHarvesterCloudCredentials,
+		}
+		return provider
+	default:
+		panic(fmt.Sprintf("Provider:%v not found", name))
+	}
+}

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
@@ -1,0 +1,270 @@
+package k3s
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
+	"github.com/rancher/rancher/tests/framework/extensions/users"
+	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	namespace = "fleet-default"
+)
+
+type K3SNodeDriverProvisioningTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	session            *session.Session
+	standardUserClient *rancher.Client
+	kubernetesVersions []string
+	providers          []string
+}
+
+func (k *K3SNodeDriverProvisioningTestSuite) TearDownSuite() {
+	k.session.Cleanup()
+}
+
+func (k *K3SNodeDriverProvisioningTestSuite) SetupSuite() {
+	testSession := session.NewSession(k.T())
+	k.session = testSession
+
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+
+	k.kubernetesVersions = clustersConfig.KubernetesVersions
+	k.providers = clustersConfig.Providers
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(k.T(), err)
+
+	k.client = client
+
+	enabled := true
+	var testuser = provisioning.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(k.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(k.T(), err)
+
+	k.standardUserClient = standardUserClient
+}
+
+func (k *K3SNodeDriverProvisioningTestSuite) ProvisioningK3SCluster(provider Provider) {
+	providerName := " Node Provider: " + provider.Name
+	nodeRoles0 := []machinepools.NodeRoles{
+		{
+			ControlPlane: true,
+			Etcd:         true,
+			Worker:       true,
+			Quantity:     1,
+		},
+	}
+
+	nodeRoles1 := []machinepools.NodeRoles{
+		{
+			ControlPlane: true,
+			Etcd:         false,
+			Worker:       false,
+			Quantity:     1,
+		},
+		{
+			ControlPlane: false,
+			Etcd:         true,
+			Worker:       false,
+			Quantity:     1,
+		},
+		{
+			ControlPlane: false,
+			Etcd:         false,
+			Worker:       true,
+			Quantity:     1,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		nodeRoles []machinepools.NodeRoles
+		client    *rancher.Client
+	}{
+		{"1 Node all roles Admin User", nodeRoles0, k.client},
+		{"1 Node all roles Standard User", nodeRoles0, k.standardUserClient},
+		{"3 nodes - 1 role per node Admin User", nodeRoles1, k.client},
+		{"3 nodes - 1 role per node Standard User", nodeRoles1, k.standardUserClient},
+	}
+
+	var name string
+	for _, tt := range tests {
+		subSession := k.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(k.T(), err)
+
+		cloudCredential, err := provider.CloudCredFunc(client)
+		require.NoError(k.T(), err)
+		for _, kubeVersion := range k.kubernetesVersions {
+			name = tt.name + providerName + " Kubernetes version: " + kubeVersion
+			k.Run(name, func() {
+				testSession := session.NewSession(k.T())
+				defer testSession.Cleanup()
+
+				testSessionClient, err := tt.client.WithSession(testSession)
+				require.NoError(k.T(), err)
+
+				clusterName := provisioning.AppendRandomString(provider.Name)
+				generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
+				machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
+
+				machineConfigResp, err := machinepools.CreateMachineConfig(provider.MachineConfig, machinePoolConfig, testSessionClient)
+				require.NoError(k.T(), err)
+
+				machinePools := machinepools.MachinePoolSetup(tt.nodeRoles, machineConfigResp)
+
+				cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", cloudCredential.ID, kubeVersion, machinePools)
+
+				clusterResp, err := clusters.CreateK3SRKE2Cluster(testSessionClient, cluster)
+				require.NoError(k.T(), err)
+
+				kubeProvisioningClient, err := k.client.GetKubeAPIProvisioningClient()
+				require.NoError(k.T(), err)
+
+				result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+					FieldSelector:  "metadata.name=" + clusterName,
+					TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+				})
+				require.NoError(k.T(), err)
+
+				checkFunc := clusters.IsProvisioningClusterReady
+
+				err = wait.WatchWait(result, checkFunc)
+				assert.NoError(k.T(), err)
+				assert.Equal(k.T(), clusterName, clusterResp.ObjectMeta.Name)
+
+				clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+				require.NoError(k.T(), err)
+				assert.NotEmpty(k.T(), clusterToken)
+			})
+		}
+	}
+}
+
+func (k *K3SNodeDriverProvisioningTestSuite) ProvisioningK3SClusterDynamicInput(provider Provider, nodesAndRoles []machinepools.NodeRoles) {
+	providerName := " Node Provider: " + provider.Name
+	tests := []struct {
+		name   string
+		client *rancher.Client
+	}{
+		{"Admin User", k.client},
+		{"Standard User", k.standardUserClient},
+	}
+
+	var name string
+	for _, tt := range tests {
+		subSession := k.session.NewSession()
+		defer subSession.Cleanup()
+
+		client, err := tt.client.WithSession(subSession)
+		require.NoError(k.T(), err)
+
+		cloudCredential, err := provider.CloudCredFunc(client)
+		require.NoError(k.T(), err)
+
+		for _, kubeVersion := range k.kubernetesVersions {
+			name = tt.name + providerName + " Kubernetes version: " + kubeVersion
+			k.Run(name, func() {
+				testSession := session.NewSession(k.T())
+				defer testSession.Cleanup()
+
+				testSessionClient, err := tt.client.WithSession(testSession)
+				require.NoError(k.T(), err)
+
+				clusterName := provisioning.AppendRandomString(provider.Name)
+				generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
+				machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
+
+				machineConfigResp, err := machinepools.CreateMachineConfig(provider.MachineConfig, machinePoolConfig, testSessionClient)
+				require.NoError(k.T(), err)
+
+				machinePools := machinepools.MachinePoolSetup(nodesAndRoles, machineConfigResp)
+
+				cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", cloudCredential.ID, kubeVersion, machinePools)
+
+				clusterResp, err := clusters.CreateK3SRKE2Cluster(testSessionClient, cluster)
+				require.NoError(k.T(), err)
+
+				kubeProvisioningClient, err := k.client.GetKubeAPIProvisioningClient()
+				require.NoError(k.T(), err)
+
+				result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+					FieldSelector:  "metadata.name=" + clusterName,
+					TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+				})
+				require.NoError(k.T(), err)
+
+				checkFunc := clusters.IsProvisioningClusterReady
+
+				err = wait.WatchWait(result, checkFunc)
+				assert.NoError(k.T(), err)
+				assert.Equal(k.T(), clusterName, clusterResp.ObjectMeta.Name)
+
+				clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+				require.NoError(k.T(), err)
+				assert.NotEmpty(k.T(), clusterToken)
+			})
+		}
+	}
+}
+
+func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioning() {
+	for _, providerName := range k.providers {
+		provider := CreateProvider(providerName)
+		k.ProvisioningK3SCluster(provider)
+	}
+}
+
+func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningDynamicInput() {
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+	nodesAndRoles := clustersConfig.NodesAndRoles
+
+	if len(nodesAndRoles) == 0 {
+		k.T().Skip()
+	}
+
+	for _, providerName := range k.providers {
+		provider := CreateProvider(providerName)
+		k.ProvisioningK3SClusterDynamicInput(provider, nodesAndRoles)
+	}
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestK3SProvisioningTestSuite(t *testing.T) {
+	suite.Run(t, new(K3SNodeDriverProvisioningTestSuite))
+}

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -149,11 +149,11 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2Cluster(provider P
 					machineConfigResp, err := machinepools.CreateMachineConfig(provider.MachineConfig, machinePoolConfig, testSessionClient)
 					require.NoError(r.T(), err)
 
-					machinePools := machinepools.RKEMachinePoolSetup(tt.nodeRoles, machineConfigResp)
+					machinePools := machinepools.MachinePoolSetup(tt.nodeRoles, machineConfigResp)
 
-					cluster := clusters.NewRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, machinePools)
+					cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, machinePools)
 
-					clusterResp, err := clusters.CreateRKE2Cluster(testSessionClient, cluster)
+					clusterResp, err := clusters.CreateK3SRKE2Cluster(testSessionClient, cluster)
 					require.NoError(r.T(), err)
 
 					kubeProvisioningClient, err := r.client.GetKubeAPIProvisioningClient()
@@ -219,11 +219,11 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2ClusterDynamicInpu
 					machineConfigResp, err := machinepools.CreateMachineConfig(provider.MachineConfig, machinePoolConfig, testSessionClient)
 					require.NoError(r.T(), err)
 
-					machinePools := machinepools.RKEMachinePoolSetup(nodesAndRoles, machineConfigResp)
+					machinePools := machinepools.MachinePoolSetup(nodesAndRoles, machineConfigResp)
 
-					cluster := clusters.NewRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, machinePools)
+					cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, machinePools)
 
-					clusterResp, err := clusters.CreateRKE2Cluster(testSessionClient, cluster)
+					clusterResp, err := clusters.CreateK3SRKE2Cluster(testSessionClient, cluster)
 					require.NoError(r.T(), err)
 
 					kubeProvisioningClient, err := r.client.GetKubeAPIProvisioningClient()
@@ -309,11 +309,11 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2CNICluster(provide
 					machineConfigResp, err := machinepools.CreateMachineConfig(provider.MachineConfig, machinePoolConfig, testSessionClient)
 					require.NoError(r.T(), err)
 
-					machinePools := machinepools.RKEMachinePoolSetup(tt.nodeRoles, machineConfigResp)
+					machinePools := machinepools.MachinePoolSetup(tt.nodeRoles, machineConfigResp)
 
-					cluster := clusters.NewRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, machinePools)
+					cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, machinePools)
 
-					clusterResp, err := clusters.CreateRKE2Cluster(testSessionClient, cluster)
+					clusterResp, err := clusters.CreateK3SRKE2Cluster(testSessionClient, cluster)
 					require.NoError(r.T(), err)
 
 					kubeProvisioningClient, err := r.client.GetKubeAPIProvisioningClient()


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [k3s Provisioning tests](https://github.com/rancher/qa-tasks/issues/495)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
As of now, the Go test framework only has test cases for RKE1 and RKE2. As we look towards pushing K3S to become GA, it is only right that we account for that in our testing as well. This includes node drivers and custom clusters, just as we currently do for RKE1 and RKE2.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This PR adds support for K3S provisioning for both node drivers and custom clusters. Essentially, majority of the functionality is taken from RKE2, with the exception that CNI is removed, as K3S does not utilize CNI.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Locally, validated that a 1 node all roles provisions for both the admin and standard user for node provisioned cluster AND custom cluster.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Offline Jenkins jobs will be handed to the reviewers prior to approval of the PR.