### PR TITLE
enable the downloading of dapper on the Darwin ARM64 platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,11 @@
 TARGETS := $(shell ls scripts)
 
 .dapper:
-	@if [[ `uname -s` = "Darwin" && `uname -m` = "arm64" ]]; then\
-		echo "Dapper download is not supported on ARM Macs, you need to build it and add it as .dapper in this directory";\
-		exit 0;\
-	else\
-		echo Downloading dapper;\
-		curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp;\
-		chmod +x .dapper.tmp;\
-		./.dapper.tmp -v;\
-		mv .dapper.tmp .dapper;\
-	fi
+	@echo Downloading dapper
+	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
+	@@chmod +x .dapper.tmp
+	@./.dapper.tmp -v
+	@mv .dapper.tmp .dapper
 
 $(TARGETS): .dapper
 	@if [[ "$@" = "post-release-checks" ]] || [[ "$@" = "list-gomod-updates" ]] || [[ "$@" = "check-chart-kdm-source-values" ]]; then\


### PR DESCRIPTION

Dapper is available on the Darwin ARM64 platform since v0.6.0: https://github.com/rancher/dapper/releases/tag/v0.6.0
This PR is to reenable the downloading of dapper on the Darwin ARM64 platform. 