### PR TITLE
Omit GroupPrincipals if field is empty

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -19,7 +19,7 @@ type Token struct {
 
 	Token           string            `json:"token" norman:"writeOnly,noupdate"`
 	UserPrincipal   Principal         `json:"userPrincipal" norman:"type=reference[principal]"`
-	GroupPrincipals []Principal       `json:"groupPrincipals" norman:"type=array[reference[principal]]"`
+	GroupPrincipals []Principal       `json:"groupPrincipals,omitempty" norman:"type=array[reference[principal]]"`
 	ProviderInfo    map[string]string `json:"providerInfo,omitempty"`
 	UserID          string            `json:"userId" norman:"type=reference[user]"`
 	AuthProvider    string            `json:"authProvider"`


### PR DESCRIPTION
Added omitempty to the defintion of the GroupPrincipals field in the Token struct.  This will prevent that field from showing GroupPrincipals: null when a token is created without GroupPrincipals set.

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/39107
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Currently, it is possible for a Token to be generated with the GroupPrincipals field set to null in the yaml. When someone tries to update that token, the effort will fail since null is not a valid value. To make their update stick, they would need to change GroupPrincipals to be [] (or another valid value) as part of their update.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
The GroupPrincipals field is now set to "omitempty" in the definition of the Token struct, so it will just not be present if it is not set rather than defaulting it to null.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
I've ran many clusters and created many tokens with this update. In all cases, the GroupPrincipals field is no longer included in the object and all of the created tokens can be updated without incident.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
Install Rancher
Verify that all tokens do NOT include GroupPrincipals: null in the yaml. Unless you created a token that specifically has GroupPrincipals, that field will NOT be present at all in the token object.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->