### PR TITLE
[2.7] Bump OKE cluster driver to v1.8.3 (support for k8s 1.24+)

### DIFF
--- a/pkg/data/management/kontainerdriver_data.go
+++ b/pkg/data/management/kontainerdriver_data.go
@@ -92,8 +92,8 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 	}
 	if err := creator.addCustomDriver(
 		"oraclecontainerengine",
-		"https://github.com/rancher-plugins/kontainer-engine-driver-oke/releases/download/v1.7.1/kontainer-engine-driver-oke-linux",
-		"5a708bfc01c67558adc887258615900082263ca7d6f4160efb1a58501b0cc608",
+		"https://github.com/rancher-plugins/kontainer-engine-driver-oke/releases/download/v1.8.3/kontainer-engine-driver-oke-linux",
+		"7bfde567e6d478f1da8d36531f765d348bff1cd3abe83c70ddf7766f46112170",
 		"",
 		false,
 		"*.oraclecloud.com",


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
- https://github.com/rancher-plugins/kontainer-engine-driver-oke/issues/46
- https://github.com/rancher/rancher/pull/39085
- https://github.com/rancher-plugins/kontainer-engine-driver-oke/issues/59
- See also: https://github.com/rancher/rancher/pull/39085

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Previous versions of the [OKE Cluster Driver](https://github.com/rancher-plugins/kontainer-engine-driver-oke) did not have support for Kubernetes 1.24, which requires manually creating `Secrets` that contain access an token for service accounts (returning an access token for newly provisioned clusters to Rancher is part of the driver's responsibilities).

Additionally, previous versions of the OKE Cluster Driver did not have support for specifying [cloud-init](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengusingcustomcloudinitscripts.htm) for OKE nodes via `--node-user-data-contents`.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

This PR updates [OKE Cluster Driver](https://github.com/rancher-plugins/kontainer-engine-driver-oke) in the 2.7 release branch to use OKE cluster driver version `v1.8.3`, which has multiple bug fixes and supports a new flag for specifying [cloud-init](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengusingcustomcloudinitscripts.htm) for OKE nodes via `--node-user-data-contents`.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Tested creation of OKE clusters version 1.24+
- Tested creation of OKE clusters with and without cloud init. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->