### PR TITLE
Remove quotas from namespaces when they are removed from project

### DIFF
--- a/pkg/controllers/managementuser/resourcequota/resource_quota_common.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_common.go
@@ -40,6 +40,7 @@ func convertResourceLimitResourceQuotaSpec(limit *v32.ResourceQuotaLimit) (*core
 	return quotaSpec, err
 }
 
+// convertProjectResourceLimitToResourceList tries to convert a Rancher-defined resource quota limit to its native Kubernetes notation.
 func convertProjectResourceLimitToResourceList(limit *v32.ResourceQuotaLimit) (corev1.ResourceList, error) {
 	in, err := json.Marshal(limit)
 	if err != nil {

--- a/tests/framework/extensions/resourcequotas/list.go
+++ b/tests/framework/extensions/resourcequotas/list.go
@@ -1,0 +1,43 @@
+package resourcequotas
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ResourceQuotaList is a struct that contains a list of resource quotas.
+type ResourceQuotaList struct {
+	Items []corev1.ResourceQuota
+}
+
+// ListResourceQuotas is a helper function that uses the dynamic client to list resource quotas in a cluster with its list options.
+func ListResourceQuotas(client *rancher.Client, clusterID string, namespace string, listOpts metav1.ListOptions) (*ResourceQuotaList, error) {
+	resourceQuotaList := new(ResourceQuotaList)
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceQuotaResource := dynamicClient.Resource(ResourceQuotaGroupVersionResource).Namespace(namespace)
+	quotas, err := resourceQuotaResource.List(context.TODO(), listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, unstructuredQuota := range quotas.Items {
+		newQuota := &corev1.ResourceQuota{}
+		err := scheme.Scheme.Convert(&unstructuredQuota, newQuota, unstructuredQuota.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		resourceQuotaList.Items = append(resourceQuotaList.Items, *newQuota)
+	}
+
+	return resourceQuotaList, nil
+}

--- a/tests/framework/extensions/resourcequotas/resourcequotas.go
+++ b/tests/framework/extensions/resourcequotas/resourcequotas.go
@@ -1,0 +1,35 @@
+package resourcequotas
+
+import (
+	"fmt"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ResourceQuotaGroupVersionResource is the required Group Version Resource for accessing resource quotas in a cluster,
+// using the dynamic client.
+var ResourceQuotaGroupVersionResource = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "resourcequotas",
+}
+
+// GetResourceQuotaByName is a helper function that returns the resource quota by name in a specific cluster.
+func GetResourceQuotaByName(client *rancher.Client, clusterID, name string) (*corev1.ResourceQuota, error) {
+	resourceQuotaList, err := ListResourceQuotas(client, clusterID, "", metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for i, q := range resourceQuotaList.Items {
+		if name == q.Name {
+			quota := &resourceQuotaList.Items[i]
+			return quota, nil
+		}
+	}
+
+	return nil, fmt.Errorf("quota %s not found in %s cluster", name, clusterID)
+}

--- a/tests/v2/integration/resource_quota_test.go
+++ b/tests/v2/integration/resource_quota_test.go
@@ -1,0 +1,268 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/extensions/resourcequotas"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ResourceQuotaSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+}
+
+func (s *ResourceQuotaSuite) TearDownSuite() {
+	s.session.Cleanup()
+}
+
+func (s *ResourceQuotaSuite) SetupSuite() {
+	testSession := session.NewSession(s.T())
+	s.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	s.Require().NoError(err)
+	s.client = client
+}
+
+func (s *ResourceQuotaSuite) TestCreateNamespaceWithQuotaInProject() {
+	subSession := s.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := s.client.WithSession(subSession)
+	s.Require().NoError(err)
+
+	projectLimit := &management.ResourceQuotaLimit{
+		LimitsCPU: "500m",
+	}
+	namespaceDefaultLimit := &management.ResourceQuotaLimit{
+		LimitsCPU: "200m",
+	}
+
+	projectConfig := &management.Project{
+		ClusterID: "local",
+		Name:      "TestProject",
+		ResourceQuota: &management.ProjectResourceQuota{
+			Limit: projectLimit,
+		},
+		NamespaceDefaultResourceQuota: &management.NamespaceResourceQuota{
+			Limit: namespaceDefaultLimit,
+		},
+	}
+	testProject, err := client.Management.Project.Create(projectConfig)
+	s.Require().NoError(err)
+
+	namespace, err := namespaces.CreateNamespace(client, "ns1", "", map[string]string{}, map[string]string{}, testProject)
+	s.Require().NoError(err)
+	s.Require().NotNil(namespace)
+
+	quotas, err := resourcequotas.ListResourceQuotas(client, "local", "ns1", metav1.ListOptions{})
+	s.Require().NoError(err)
+	s.Require().NotNil(quotas)
+	s.Require().Lenf(quotas.Items, 1, "Expected 1 quota in a new namespace, but got %d", len(quotas.Items))
+
+	resourceList := quotas.Items[0].Spec.Hard
+	want := v1.ResourceList{
+		v1.ResourceLimitsCPU: resource.MustParse("200m"),
+	}
+	s.Require().Equal(want, resourceList)
+	s.Require().NoError(err)
+}
+
+func (s *ResourceQuotaSuite) TestCreateNamespaceWithOverriddenQuotaInProject() {
+	subSession := s.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := s.client.WithSession(subSession)
+	s.Require().NoError(err)
+
+	projectConfig := &management.Project{
+		ClusterID: "local",
+		Name:      "TestProject",
+		ResourceQuota: &management.ProjectResourceQuota{
+			Limit: &management.ResourceQuotaLimit{
+				LimitsCPU: "500m",
+			},
+		},
+		NamespaceDefaultResourceQuota: &management.NamespaceResourceQuota{
+			Limit: &management.ResourceQuotaLimit{
+				LimitsCPU: "200m",
+			},
+		},
+	}
+	testProject, err := client.Management.Project.Create(projectConfig)
+	s.Require().NoError(err)
+
+	annotations1 := map[string]string{
+		"field.cattle.io/resourceQuota": "{\"limit\":{\"limitsCpu\":\"190m\"}}",
+	}
+	namespace, err := namespaces.CreateNamespace(client, "ns1", "", map[string]string{}, annotations1, testProject)
+	s.Require().NoError(err)
+	s.Require().NotNil(namespace)
+
+	annotations2 := map[string]string{
+		"field.cattle.io/resourceQuota": "{\"limit\":{\"limitsCpu\":\"400m\", \"configMaps\":\"50\"}}",
+	}
+	namespace, err = namespaces.CreateNamespace(client, "ns2", "", map[string]string{}, annotations2, testProject)
+	s.Require().NoError(err)
+	s.Require().NotNil(namespace)
+
+	quotas, err := resourcequotas.ListResourceQuotas(client, "local", "ns1", metav1.ListOptions{})
+	s.Require().NoError(err)
+	s.Require().NotNil(quotas)
+	s.Require().Lenf(quotas.Items, 1, "Expected 1 quota in ns1, but got %d", len(quotas.Items))
+
+	resourceList := quotas.Items[0].Spec.Hard
+	want := v1.ResourceList{
+		v1.ResourceLimitsCPU: resource.MustParse("190m"),
+	}
+	s.Require().Equal(want, resourceList)
+	s.Require().NoError(err)
+
+	quotas, err = resourcequotas.ListResourceQuotas(client, "local", "ns2", metav1.ListOptions{})
+	s.Require().NoError(err)
+	s.Require().NotNil(quotas)
+	s.Require().Lenf(quotas.Items, 1, "Expected 1 quota in ns2, but got %d", len(quotas.Items))
+
+	resourceList = quotas.Items[0].Spec.Hard
+	want = v1.ResourceList{
+		v1.ResourceLimitsCPU: resource.MustParse("0"),
+	}
+	s.Require().Equal(want, resourceList)
+	s.Require().NoError(err)
+}
+
+func (s *ResourceQuotaSuite) TestRemoveQuotaFromProjectWithNamespacePropagation() {
+	subSession := s.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := s.client.WithSession(subSession)
+	s.Require().NoError(err)
+
+	projectLimit := &management.ResourceQuotaLimit{
+		LimitsCPU:  "500m",
+		ConfigMaps: "10",
+	}
+	namespaceDefaultLimit := &management.ResourceQuotaLimit{
+		LimitsCPU:  "200m",
+		ConfigMaps: "5",
+	}
+
+	projectConfig := &management.Project{
+		ClusterID: "local",
+		Name:      "TestProject",
+		ResourceQuota: &management.ProjectResourceQuota{
+			Limit: projectLimit,
+		},
+		NamespaceDefaultResourceQuota: &management.NamespaceResourceQuota{
+			Limit: namespaceDefaultLimit,
+		},
+	}
+	testProject, err := client.Management.Project.Create(projectConfig)
+	s.Require().NoError(err)
+
+	namespace, err := namespaces.CreateNamespace(client, "ns1", "", map[string]string{}, map[string]string{}, testProject)
+	s.Require().NoError(err)
+	s.Require().NotNil(namespace)
+
+	testProject.ResourceQuota.Limit.LimitsCPU = ""
+	testProject.NamespaceDefaultResourceQuota.Limit.LimitsCPU = ""
+
+	_, err = client.Management.Project.Replace(testProject)
+	s.Require().NoError(err)
+
+	// Allow the controller to update the resource quotas after the project has been updated.
+	time.Sleep(2 * time.Second)
+
+	quotas, err := resourcequotas.ListResourceQuotas(client, "local", "ns1", metav1.ListOptions{})
+	s.Require().NoError(err)
+	s.Require().NotNil(quotas)
+	s.Require().Lenf(quotas.Items, 1, "Expected 1 quota in the namespace, but got %d", len(quotas.Items))
+
+	resourceList := quotas.Items[0].Spec.Hard
+	want := v1.ResourceList{
+		v1.ResourceConfigMaps: resource.MustParse("5"),
+	}
+	s.Require().Equal(want, resourceList, "Expected the CPU limits to be removed, but config maps limit to remain")
+	s.Require().NoError(err)
+
+	// Now remove the last resource limit from the project.
+	testProject.ResourceQuota.Limit.ConfigMaps = ""
+	testProject.NamespaceDefaultResourceQuota.Limit.ConfigMaps = ""
+
+	_, err = client.Management.Project.Replace(testProject)
+	s.Require().NoError(err)
+
+	time.Sleep(2 * time.Second)
+	quotas, err = resourcequotas.ListResourceQuotas(client, "local", "ns1", metav1.ListOptions{})
+	s.Require().NoError(err)
+	s.Require().NotNil(quotas)
+	s.Require().Lenf(quotas.Items, 0, "Expected no quotas in the namespace, but got %d", len(quotas.Items))
+}
+
+func (s *ResourceQuotaSuite) TestAddQuotaFromProjectWithNamespacePropagation() {
+	subSession := s.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := s.client.WithSession(subSession)
+	s.Require().NoError(err)
+
+	projectLimit := &management.ResourceQuotaLimit{
+		LimitsCPU: "500m",
+	}
+	namespaceDefaultLimit := &management.ResourceQuotaLimit{
+		LimitsCPU: "200m",
+	}
+
+	projectConfig := &management.Project{
+		ClusterID: "local",
+		Name:      "TestProject",
+		ResourceQuota: &management.ProjectResourceQuota{
+			Limit: projectLimit,
+		},
+		NamespaceDefaultResourceQuota: &management.NamespaceResourceQuota{
+			Limit: namespaceDefaultLimit,
+		},
+	}
+	testProject, err := client.Management.Project.Create(projectConfig)
+	s.Require().NoError(err)
+
+	namespace, err := namespaces.CreateNamespace(client, "ns1", "", map[string]string{}, map[string]string{}, testProject)
+	s.Require().NoError(err)
+	s.Require().NotNil(namespace)
+
+	testProject.ResourceQuota.Limit.Secrets = "20"
+	testProject.NamespaceDefaultResourceQuota.Limit.Secrets = "10"
+
+	_, err = client.Management.Project.Replace(testProject)
+	s.Require().NoError(err)
+
+	// Allow the controller to update the resource quotas after the project has been updated.
+	time.Sleep(2 * time.Second)
+
+	quotas, err := resourcequotas.ListResourceQuotas(client, "local", "ns1", metav1.ListOptions{})
+	s.Require().NoError(err)
+	s.Require().NotNil(quotas)
+	s.Require().Lenf(quotas.Items, 1, "Expected 1 quota in the namespace, but got %d", len(quotas.Items))
+
+	resourceList := quotas.Items[0].Spec.Hard
+	want := v1.ResourceList{
+		v1.ResourceLimitsCPU: resource.MustParse("200m"),
+		v1.ResourceSecrets:   resource.MustParse("10"),
+	}
+	s.Require().Equal(want, resourceList)
+	s.Require().NoError(err)
+}
+
+func TestResourceQuotaTestSuite(t *testing.T) {
+	suite.Run(t, new(ResourceQuotaSuite))
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/38010
 
## Problem
When users remove a resource quota from a project, it still exists and is associated with existing namespaces inside the project.
 
## Solution
In these cases, when Rancher computes the new resource quota, it needs to include only those resources on the quota that are defined with some limit value on the project. If the project quota does not define a limit for some resource, then ignore the resource quota requested. Keep the current behavior where the requested amount trumps the default one, if the default exists in the project.

**Note:** this breaks current behavior, one that we discourage and should mention in the docs. Specifically, the updated logic will prevent users from **adding** new quota resource in their override via Kubectl. Rancher will honor only those resource overrides that actually have a corresponding default on the project quota.
 We should encourage users to instead add regular Kubernetes resource quotas for any custom limits for resources in their namespaces.

## Testing
To reproduce, create a new project with a limit on any resource along with a namespace default limit. Then add a namespace to the project, ensuring that the namespace contains a new quota with the default limit. Remove the limit from the project. Observe that the limit is still present on the namespace's quota.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
Integration tests:
1. Create a project with a default quota for one resource, add a namespace to it.
2. Create a project with a default quota for one resource, add two namespace, each providing a quota override.
3. Create a project with a default quota for one resource, add a namespace to it. Then add another limit on the project and ensure the limit is added to existing namespaces' quotas.
4. **(this issue)**. Create a project with a default quota for one resource, add a namespace to it. Then remove limit on the project and ensure the limit is removed from existing namespaces' quotas.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->