### PR TITLE
[2.7]Jenkins pipeline for pre and post rancher upgrade testing

### DIFF
--- a/tests/framework/extensions/charts/gatekeeperconfig.go
+++ b/tests/framework/extensions/charts/gatekeeperconfig.go
@@ -1,0 +1,37 @@
+package charts
+
+import "gopkg.in/yaml.v2"
+
+// GenerateGatekeeperConfigYaml generates the yaml for a config for OPA gatekeeper https://open-policy-agent.github.io/gatekeeper/website/docs/exempt-namespaces#exempting-namespaces-from-gatekeeper-using-config-resource
+func GenerateGatekeeperConfigYaml(excludedNamespaces []string, processes []string, name string, namespace string, apiVersion string, kind string) (string, error) {
+	confMatch := ConfigMatch{
+		{ExcludedNamespaces: excludedNamespaces,
+			Processes: processes},
+	}
+
+	confSpec := ConfigSpec{
+		Match: confMatch,
+	}
+
+	confMetadata := Metadata{
+		Name:      name,
+		Namespace: namespace,
+	}
+
+	confYaml := ConfigYaml{
+		ApiVersion: apiVersion,
+		Kind:       kind,
+		Metadata:   confMetadata,
+		Spec:       confSpec,
+	}
+
+	yamlData, err := yaml.Marshal(&confYaml)
+	if err != nil {
+		return "", err
+	}
+
+	yamlString := string(yamlData)
+
+	return yamlString, err
+
+}

--- a/tests/framework/extensions/charts/gatekeeperresources.go
+++ b/tests/framework/extensions/charts/gatekeeperresources.go
@@ -1,0 +1,62 @@
+package charts
+
+// These are the structs used to generate the yaml for OPA Gatekeeper Constraints and Configs
+// Constraints are what Gatekeeper uses to describe and enforce specific policies in a cluster. More on Constraints: https://open-policy-agent.github.io/gatekeeper/website/docs/howto
+// Configs define clusterwide rules for Gatekeeper. More on Configs: https://open-policy-agent.github.io/gatekeeper/website/docs/exempt-namespaces
+
+// Metadata struct can be shared by Configs and Constraints
+type Metadata struct {
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+}
+
+// ConfigYaml all the structs that make up a gatekeeper Config are nested in this struct, Configs and Constraints are similar K8s objects, but require different Specs
+type ConfigYaml struct {
+	ApiVersion string     `yaml:"apiVersion"`
+	Kind       string     `yaml:"kind"`
+	Metadata   Metadata   `yaml:"metadata"`
+	Spec       ConfigSpec `yaml:"spec"`
+}
+
+// ConfigSpec spec field for ConfigYaml, it contains different fields than ConstraintSpec
+type ConfigSpec struct {
+	Match ConfigMatch `yaml:"match"`
+}
+
+// ConfigMatch match field for ConfigYaml, it contains different fields than ConstraintMatch
+type ConfigMatch []struct {
+	ExcludedNamespaces []string `yaml:"excludedNamespaces"`
+	Processes          []string `yaml:"processes"`
+}
+
+// ConstraintYaml All the structs that make up a gatekeeper Constraint are nested in this struct, Configs and Constraints are similar K8s objects, but require different Specs
+type ConstraintYaml struct {
+	ApiVersion string         `yaml:"apiVersion"`
+	Kind       string         `yaml:"kind"`
+	Metadata   Metadata       `yaml:"metadata"`
+	Spec       ConstraintSpec `yaml:"spec"`
+}
+
+// ConstraintSpec spec field for ConstraintYaml, it contains different fields than ConfigSpec
+type ConstraintSpec struct {
+	EnforcementAction string               `yaml:"enforcementAction"`
+	Match             ConstraintMatch      `yaml:"match"`
+	Parameters        ConstraintParameters `yaml:"parameters"`
+}
+
+// ConstraintMatch match field for ConstraintYaml, it contains different fields than ConfigMatch
+type ConstraintMatch struct {
+	ExcludedNamespaces []string        `yaml:"excludedNamespaces"`
+	Kinds              ConstraintKinds `yaml:"kinds"`
+}
+
+// ConstraintKinds field
+type ConstraintKinds []struct {
+	ApiGroups []string `yaml:"apiGroups"`
+	Kinds     []string `yaml:"kinds"`
+}
+
+// ConstraintParameters field
+type ConstraintParameters struct {
+	Namespaces []string `yaml:"namespaces"`
+}

--- a/tests/framework/extensions/charts/opaconstraint.go
+++ b/tests/framework/extensions/charts/opaconstraint.go
@@ -1,0 +1,49 @@
+package charts
+
+import (
+	"gopkg.in/yaml.v2"
+)
+
+// GenerateGatekeeperConstraintYaml takes inputs to generate the yaml for an OPA Gatekeeper Constraint from an OPA Constraint Template. This can be used to dynamically generate OPA Constraints based on test data
+func GenerateGatekeeperConstraintYaml(apiGroups []string, excludedNamespaces []string, kinds []string, name string, namespaces []string, enforcementAction string, apiVersion string, kind string) (string, error) {
+
+	nSKinds := ConstraintKinds{
+		{ApiGroups: apiGroups},
+		{Kinds: kinds},
+	}
+
+	nSMetadata := Metadata{
+		Name: name,
+	}
+
+	nSParameters := ConstraintParameters{
+		Namespaces: namespaces,
+	}
+
+	nSMatch := ConstraintMatch{
+		ExcludedNamespaces: excludedNamespaces,
+		Kinds:              nSKinds,
+	}
+
+	nSSpec := ConstraintSpec{
+		EnforcementAction: enforcementAction,
+		Match:             nSMatch,
+		Parameters:        nSParameters,
+	}
+
+	allowedNamespaces := ConstraintYaml{
+		ApiVersion: apiVersion,
+		Kind:       kind,
+		Metadata:   nSMetadata,
+		Spec:       nSSpec,
+	}
+
+	yamlData, err := yaml.Marshal(&allowedNamespaces)
+	if err != nil {
+		return "", err
+	}
+
+	yamlString := string(yamlData)
+
+	return yamlString, err
+}

--- a/tests/framework/extensions/kubeapi/customresourcedefinitions/delete.go
+++ b/tests/framework/extensions/kubeapi/customresourcedefinitions/delete.go
@@ -3,6 +3,7 @@ package customresourcedefinitions
 import (
 	"context"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -30,12 +31,14 @@ func BatchDeleteCustomResourceDefinition(client *rancher.Client, clusterID strin
 
 	customResourceDefinitionResource := dynamicClient.Resource(CustomResourceDefinitions).Namespace(namespace)
 
+	var errs error
 	for _, crd := range list {
 		err = customResourceDefinitionResource.Delete(context.TODO(), crd, metav1.DeleteOptions{})
 		if err != nil {
-			return err
+			errs = multierror.Append(errs, err)
+			continue
 		}
 	}
 
-	return err
+	return errs
 }

--- a/tests/framework/pkg/environmentflag/environmentflags.go
+++ b/tests/framework/pkg/environmentflag/environmentflags.go
@@ -11,6 +11,8 @@ const (
 	KubernetesUpgradeAllClusters EnvironmentFlag = iota
 	WorkloadUpgradeAllClusters
 	UpdateClusterName
+	GatekeeperAllowedNamespaces
+	UpgradeAllClusters
 	UseExistingRegistries
 	InstallRancher
 	environmentFlagLastItem // This is used to determine the number of items in the enum

--- a/tests/framework/pkg/environmentflag/zz_environmentflags.go
+++ b/tests/framework/pkg/environmentflag/zz_environmentflags.go
@@ -11,14 +11,16 @@ func _() {
 	_ = x[KubernetesUpgradeAllClusters-0]
 	_ = x[WorkloadUpgradeAllClusters-1]
 	_ = x[UpdateClusterName-2]
-	_ = x[UseExistingRegistries-3]
-	_ = x[InstallRancher-4]
-	_ = x[environmentFlagLastItem-5]
+	_ = x[GatekeeperAllowedNamespaces-3]
+	_ = x[UpgradeAllClusters-4]
+	_ = x[UseExistingRegistries-5]
+	_ = x[InstallRancher-6]
+	_ = x[environmentFlagLastItem-7]
 }
 
-const _EnvironmentFlag_name = "KubernetesUpgradeAllClustersWorkloadUpgradeAllClustersUpdateClusterNameUseExistingRegistriesInstallRancherThis is used to determine the number of items in the enum"
+const _EnvironmentFlag_name = "KubernetesUpgradeAllClustersWorkloadUpgradeAllClustersUpdateClusterNameGatekeeperAllowedNamespacesUpgradeAllClustersUseExistingRegistriesInstallRancherThis is used to determine the number of items in the enum"
 
-var _EnvironmentFlag_index = [...]uint8{0, 28, 54, 71, 92, 106, 163}
+var _EnvironmentFlag_index = [...]uint8{0, 28, 54, 71, 98, 116, 137, 151, 208}
 
 func (i EnvironmentFlag) String() string {
 	if i < 0 || i >= EnvironmentFlag(len(_EnvironmentFlag_index)-1) {

--- a/tests/v2/validation/Jenkinsfile_pre_post_upgrade
+++ b/tests/v2/validation/Jenkinsfile_pre_post_upgrade
@@ -1,0 +1,171 @@
+#!groovy
+node {
+    def rootPath = "/go/src/github.com/rancher/rancher/tests/v2/validation/"
+    def job_name = "${JOB_NAME}"
+    if (job_name.contains('/')) { 
+      job_names = job_name.split('/')
+      job_name = job_names[job_names.size() - 1] 
+    }
+    def testContainer = "${job_name}${env.BUILD_NUMBER}_test"
+    def upgradeTestContainer = "${job_name}${env.BUILD_NUMBER}-2_test"
+    def imageName = "rancher-validation-${job_name}${env.BUILD_NUMBER}"
+    def testsDir = "github.com/rancher/rancher/tests/v2/validation/${env.TEST_PACKAGE}"
+    def testResultsOut = "results.xml"
+    def envFile = ".env"
+    def rancherConfig = "rancher_env.config"
+    def branch = "release/v2.6"
+    if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
+      branch = "${env.BRANCH}"
+    }
+    def repo = scm.userRemoteConfigs
+    if ("${env.REPO}" != "null" && "${env.REPO}" != "") {
+      repo = [[url: "${env.REPO}"]]
+    }
+    def timeout = "60m"
+    if ("${env.TIMEOUT}" != "null" && "${env.TIMEOUT}" != "") {
+      timeout = "${env.TIMEOUT}" 
+    }
+    wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+      withFolderProperties {
+        paramsMap = []
+        params.each {
+          if (it.value && it.value.trim() != "") {
+              paramsMap << "$it.key=$it.value"
+          }
+        }
+        withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                          string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+                          string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'RANCHER_EKS_ACCESS_KEY'),
+                          string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'RANCHER_EKS_SECRET_KEY'),
+                          string(credentialsId: 'DO_ACCESSKEY', variable: 'DO_ACCESSKEY'),
+                          string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                          string(credentialsId: 'RANCHER_SSH_KEY', variable: 'RANCHER_SSH_KEY'),
+                          string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                          string(credentialsId: 'AZURE_TENANT_ID', variable: 'AZURE_TENANT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_ID', variable: 'AZURE_CLIENT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'AZURE_CLIENT_SECRET'),
+                          string(credentialsId: 'AZURE_AKS_SUBSCRIPTION_ID', variable: 'RANCHER_AKS_SUBSCRIPTION_ID'),
+                          string(credentialsId: 'AZURE_TENANT_ID', variable: 'RANCHER_AKS_TENANT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_ID', variable: 'RANCHER_AKS_CLIENT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'RANCHER_AKS_SECRET_KEY'),
+                          string(credentialsId: 'RANCHER_REGISTRY_USER_NAME', variable: 'RANCHER_REGISTRY_USER_NAME'),
+                          string(credentialsId: 'RANCHER_REGISTRY_PASSWORD', variable: 'RANCHER_REGISTRY_PASSWORD'),
+                          string(credentialsId: 'RANCHER_AD_SPECIAL_CHAR_PASSWORD', variable: 'RANCHER_AD_SPECIAL_CHAR_PASSWORD'),
+                          string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                          string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_GKE_CREDENTIAL', variable: 'RANCHER_GKE_CREDENTIAL'),
+                          string(credentialsId: 'RANCHER_AUTH_USER_PASSWORD', variable: 'RANCHER_AUTH_USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_HOSTNAME_OR_IP_ADDRESS', variable: 'RANCHER_HOSTNAME_OR_IP_ADDRESS'),
+                          string(credentialsId: 'RANCHER_CA_CERTIFICATE', variable: 'RANCHER_CA_CERTIFICATE'),
+                          string(credentialsId: 'RANCHER_SERVICE_ACCOUNT_NAME', variable: 'RANCHER_SERVICE_ACCOUNT_NAME'),
+                          string(credentialsId: 'RANCHER_SERVICE_ACCOUNT_PASSWORD', variable: 'RANCHER_SERVICE_ACCOUNT_PASSWORD'),
+                          string(credentialsId: 'RANCHER_USER_SEARCH_BASE', variable: 'RANCHER_USER_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_DEFAULT_LOGIN_DOMAIN', variable: 'RANCHER_DEFAULT_LOGIN_DOMAIN'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_NAME', variable: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_NAME'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_PASSWORD', variable: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_PASSWORD'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_USER_SEARCH_BASE', variable: 'RANCHER_OPENLDAP_USER_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_AUTH_USER_PASSWORD', variable: 'RANCHER_OPENLDAP_AUTH_USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_HOSTNAME_OR_IP_ADDRESS', variable: 'RANCHER_OPENLDAP_HOSTNAME_OR_IP_ADDRESS'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_SPECIAL_CHAR_PASSWORD', variable: 'RANCHER_OPENLDAP_SPECIAL_CHAR_PASSWORD'),
+                          string(credentialsId: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_NAME', variable: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_NAME'),
+                          string(credentialsId: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_PASSWORD', variable: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_PASSWORD'),
+                          string(credentialsId: 'RANCHER_FREEIPA_USER_SEARCH_BASE', variable: 'RANCHER_FREEIPA_USER_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_FREEIPA_GROUP_SEARCH_BASE', variable: 'RANCHER_FREEIPA_GROUP_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_FREEIPA_AUTH_USER_PASSWORD', variable: 'RANCHER_FREEIPA_AUTH_USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_FREEIPA_HOSTNAME_OR_IP_ADDRESS', variable: 'RANCHER_FREEIPA_HOSTNAME_OR_IP_ADDRESS'),
+                          string(credentialsId: 'RANCHER_FREEIPA_SPECIAL_CHAR_PASSWORD', variable: 'RANCHER_FREEIPA_SPECIAL_CHAR_PASSWORD'),
+                          string(credentialsId: 'RANCHER_VALID_TLS_CERT', variable: 'RANCHER_VALID_TLS_CERT'),
+                          string(credentialsId: 'RANCHER_VALID_TLS_KEY', variable: 'RANCHER_VALID_TLS_KEY'),
+                          string(credentialsId: 'RANCHER_BYO_TLS_CERT', variable: 'RANCHER_BYO_TLS_CERT'),
+                          string(credentialsId: 'RANCHER_BYO_TLS_KEY', variable: 'RANCHER_BYO_TLS_KEY'),
+                          string(credentialsId: 'RANCHER_LINODE_ACCESSKEY', variable: "RANCHER_LINODE_ACCESSKEY")]) {
+
+        withEnv(paramsMap) {
+          stage('Checkout') {
+            deleteDir()
+            checkout([
+                      $class: 'GitSCM',
+                      branches: [[name: "*/${branch}"]],
+                      extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                      userRemoteConfigs: repo
+                    ])
+          }
+          dir ("./") {
+            try {
+              stage('Configure and Build') {
+                if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
+                  dir("./tests/v2/validation/.ssh") {
+                    def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
+                    writeFile file: AWS_SSH_KEY_NAME, text: decoded
+                  }
+                }
+
+                dir("./tests/v2/validation") {
+                  def filename = "config.yaml"
+                  def configContents = env.CONFIG
+
+                  writeFile file: filename, text: configContents
+                  env.CATTLE_TEST_CONFIG = "/go/src/github.com/rancher/rancher/tests/v2/validation/"+filename
+                }
+
+                sh "./tests/v2/validation/configure.sh"
+                sh "./tests/v2/validation/build.sh"
+              }
+              stage('Run Validation Tests') {
+                try {
+                  echo envFile
+                  sh "docker run --name ${testContainer} -t --env-file ${envFile} " +
+                  "${imageName} sh -c \"/go/bin/gotestsum --format standard-verbose --packages=${testsDir} --junitfile ${testResultsOut} -- ${GOTEST_TESTCASE} -timeout=${timeout} -v\""
+                } catch(err) {
+                  echo 'Test run had failures. Collecting results...'
+                }
+              }
+              stage('upgrade') {
+                  upgradeParams = [
+                  string(name: 'RANCHER_HA_HOSTNAME', value: "${RANCHER_HA_HOSTNAME}"),
+                  string(name: 'RANCHER_CHART_VERSION', value: "${RANCHER_CHART_VERSION}"),
+                  string(name: 'RANCHER_HA_CERT_OPTION', value: "${RANCHER_HA_CERT_OPTION}"),
+                  string(name: 'RANCHER_HA_KUBECONFIG', value: "${RANCHER_HA_KUBECONFIG}")
+                  ]
+                  build job: 'rancher-v3_ha_upgrade', parameters: upgradeParams
+              }
+                            
+              stage ('post upgrade tests') {
+                try {
+                  sh "docker run --name ${upgradeTestContainer} -t --env-file ${envFile} " +
+                    "${imageName} sh -c \"/go/bin/gotestsum --format standard-verbose --packages=${testsDir} --junitfile ${testResultsOut} -- ${GOTEST_TESTCASE_2} -timeout=${timeout} -v\""
+                } catch(err) {
+                  echo 'Test run had failures. Collecting results...'
+                }
+              }
+              stage('delete') {
+                CATTLE_TEST_URL = "http://${RANCHER_HA_HOSTNAME}"
+                deleteParams = [
+                string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"),
+
+                ]
+                build job: 'rancher-v3_ha_delete', parameters: deleteParams
+              }
+                     
+              stage('Test Report') {
+                sh "docker cp ${testContainer}:${rootPath}${testResultsOut} ."
+                step([$class: 'JUnitResultArchiver', testResults: "**/${testResultsOut}"])
+                sh "docker stop ${testContainer}"
+                sh "docker rm -v ${testContainer}"
+                sh "docker stop ${upgradeTestContainer}"
+                sh "docker rm -v ${upgradeTestContainer}"
+                sh "docker rmi -f ${imageName}"
+              }           
+            } catch(err) {           
+                sh "docker stop ${testContainer}"
+                sh "docker rm -v ${testContainer}"
+                sh "docker stop ${upgradeTestContainer}"
+                sh "docker rm -v ${upgradeTestContainer}"
+                sh "docker rmi -f ${imageName}"
+            } // catch
+          } // dir
+        } // withEnv
+      } // withCredentials
+    } // withFolderProperties
+  } // wrap
+}// node

--- a/tests/v2/validation/charts/gatekeeperallowednamespaces_test.go
+++ b/tests/v2/validation/charts/gatekeeperallowednamespaces_test.go
@@ -1,0 +1,84 @@
+package charts
+
+import (
+	"os"
+	"strings"
+
+	settings "github.com/rancher/rancher/pkg/settings"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/charts"
+	namespaces "github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/pkg/environmentflag"
+	"github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (n *GateKeeperTestSuite) TestGateKeeperAllowedNamespaces() {
+	subSession := n.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := n.client.WithSession(subSession)
+	require.NoError(n.T(), err)
+
+	if !client.Flags.GetValue(environmentflag.GatekeeperAllowedNamespaces) {
+		n.T().Skip("skipping TestGateKeeperAllowedNamespaces because GatekeeperAllowedNamespaces flag not set in cattle config")
+	}
+
+	n.T().Log("Installing latest version of gatekeeper chart")
+	err = charts.InstallRancherGatekeeperChart(client, n.gatekeeperChartInstallOptions)
+	require.NoError(n.T(), err)
+
+	n.T().Log("Waiting for gatekeeper chart deployments to have expected number of available replicas")
+	err = charts.WatchAndWaitDeployments(client, n.project.ClusterID, charts.RancherGatekeeperNamespace, metav1.ListOptions{})
+	require.NoError(n.T(), err)
+
+	n.T().Log("Waiting for gatekeeper chart DaemonSets to have expected number of available nodes")
+	err = charts.WatchAndWaitDaemonSets(client, n.project.ClusterID, charts.RancherGatekeeperNamespace, metav1.ListOptions{})
+	require.NoError(n.T(), err)
+
+	n.T().Log("creating constraint template")
+	readTemplateYamlFile, err := os.ReadFile("./resources/opa-allowednamespacestemplate.yaml")
+	require.NoError(n.T(), err)
+	yamlTemplateInput := &management.ImportClusterYamlInput{
+		DefaultNamespace: charts.RancherGatekeeperNamespace,
+		YAML:             string(readTemplateYamlFile),
+	}
+
+	n.T().Log("getting list of all namespaces")
+	sysNamespaces := settings.SystemNamespaces.Get()
+	sysNamespacesSlice := strings.Split(sysNamespaces, ",")
+
+	// constraint must exclude cattle-gatekeeper-system and all namespaces that are dynamically generated during gatekeeper installation and upgrade
+	// for example: pod-impersonation-helm-op-f9pwc and cattle-impersonation-user-vhkst-token
+	n.T().Log("creating constraint")
+	yamlString, err := charts.GenerateGatekeeperConstraintYaml([]string{""},
+		[]string{"cattle-gatekeeper-system", "ingress-nginx-controller-admission", "kube-dns", "cattle-controllers", "rke-network-plugin", "extension-apiserver-authentication", "fleet-agent-lock", "udp-services", "cattle-impersonation-user*", "pod-impersonation-helm-op*", "local*", "default*", "test*", "canal*", "nginx-ingress-controller*", "rke*", "coredns*", "gatekeeper*", "calico-kube-controllers*", "kube-root*", "cattle*", "kube-root-ca*", "ingress-nginx-admission*", "metrics-server*"},
+		[]string{"Namespace"},
+		"ns-must-be-allowed", sysNamespacesSlice, "deny", "constraints.gatekeeper.sh/v1beta1", "K8sAllowedNamespaces")
+	require.NoError(n.T(), err)
+	n.T().Log(yamlString)
+
+	yamlConstraintInput := &management.ImportClusterYamlInput{
+		DefaultNamespace: charts.RancherGatekeeperNamespace,
+		YAML:             yamlString,
+	}
+
+	// get the cluster
+	cluster, err := client.Management.Cluster.ByID(n.project.ClusterID)
+	require.NoError(n.T(), err)
+
+	n.T().Log("applying constraint template")
+	_, err = client.Management.Cluster.ActionImportYaml(cluster, yamlTemplateInput)
+	require.NoError(n.T(), err)
+
+	n.T().Log("applying constraint")
+	// Use ActionImportYaml to the apply the constraint yaml file
+	_, err = client.Management.Cluster.ActionImportYaml(cluster, yamlConstraintInput)
+	require.NoError(n.T(), err)
+
+	n.T().Log("Create a namespace that doesn't have an allowed name and assert that creation fails with the expected error")
+	_, err = namespaces.CreateNamespace(client, RancherDisallowedNamespace, "{}", map[string]string{}, map[string]string{}, n.project)
+	assert.ErrorContains(n.T(), err, "admission webhook \"validation.gatekeeper.sh\" denied the request: [ns-must-be-allowed] Namespace not allowed")
+
+}

--- a/tests/v2/validation/charts/gatekeeperallowednamespacespostupgrade_test.go
+++ b/tests/v2/validation/charts/gatekeeperallowednamespacespostupgrade_test.go
@@ -1,0 +1,34 @@
+package charts
+
+import (
+	"strings"
+
+	settings "github.com/rancher/rancher/pkg/settings"
+	namespaces "github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/pkg/environmentflag"
+	"github.com/stretchr/testify/require"
+)
+
+func (n *GateKeeperTestSuite) TestGateKeeperAllowedNamespacesPostUpgrade() {
+
+	subSession := n.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := n.client.WithSession(subSession)
+	require.NoError(n.T(), err)
+
+	if !client.Flags.GetValue(environmentflag.GatekeeperAllowedNamespaces) {
+		n.T().Skip("skipping TestGateKeeperAllowedNamespacesPostUpgrade because GatekeeperAllowedNamespaces flag not set in cattle config")
+	}
+
+	sysNamespaces := settings.SystemNamespaces.Get()
+
+	sysNamespacesSlice := strings.Split(sysNamespaces, ",")
+	for _, namespace := range sysNamespacesSlice {
+		_, err = namespaces.CreateNamespace(client, namespace, "{}", map[string]string{}, map[string]string{}, n.project)
+		if err != nil {
+			errString := "namespaces \"" + namespace + "\" already exists"
+			require.ErrorContains(n.T(), err, errString)
+		}
+	}
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/qa-tasks/issues/471 

## Problem
Customers are reporting that upgrading Rancher fails when a new namespace is added to Rancher and the customer has an OPA Gatekeeper constraint that restricts the creation of namespaces.
 
## Solution

This test creates a Jenkins pipeline that checks that Rancher can be successfully upgraded as long as the required list of namespaces is allowed by Gatekeeper. It also adds functions that create OPA constraints & Gatekeeper config objects

This solution relies on many namespaces that are necessary for rancher and gatekeeper to function being excluded from the Gatekeeper constraint. some of these are static, such as "cattle-gatekeeper-system" and some are dynamically generated, such as pod-impersonation-helm-op-xxxx or cattle-impersonation-user-xxxx-token
 
## Testing
Create a Rancher HA cluster with a downstream cluster and use it for the Jenkins pipeline

Example parameters:
```
CONFIG
rancher:
  host: hostname.qa.rancher.space
  adminToken: "token-xxxx:xxxxxxxxxx"
  cleanup: false 
  clusterName: "test-23369" 
flags:
  desiredflags: "GatekeeperAllowedNamespaces"

TEST_PACKAGE
charts

GOTEST_TESTCASE
-run ^TestGateKeeperAllowedNamespacesTestSuite$

GOTEST_TESTCASE_2
-run ^TestGateKeeperAllowedNamespacesTestSuitePostUpgrade$

```