### PR TITLE
[v2.7] enable v2 cgroup nesting only for rancher standalone container

### DIFF
--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -13,7 +13,8 @@ fi
 # Permission granted by Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> (https://github.com/rancher/k3d/issues/493#issuecomment-827405962) #
 # Moby License Apache 2.0: https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/LICENSE                           #
 #########################################################################################################################################
-if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+# only run this if rancher is not running in kubernetes cluster
+if [ ! -e /run/secrets/kubernetes.io/serviceaccount ] && [ -f /sys/fs/cgroup/cgroup.controllers ]; then
   # move the processes from the root group to the /init group,
   # otherwise writing subtree_control fails with EBUSY.
   mkdir -p /sys/fs/cgroup/init


### PR DESCRIPTION
This PR is forward port PR. Original PR: https://github.com/rancher/rancher/pull/39286

Issue: https://github.com/rancher/rancher/issues/39283 