### PR TITLE
Allow TF to ssh into 22.04 nodes

### DIFF
--- a/tests/v2/validation/provisioning/rke1/README.md
+++ b/tests/v2/validation/provisioning/rke1/README.md
@@ -54,7 +54,7 @@ RKE1 specifically needs a node template config to run properly. These are the in
     "iamInstanceProfile": "EngineeringUsersUS",
     "insecureTransport": false,
     "instanceType": "t2.2xlarge",
-    "keypairName": "jenkins-rke-validation",
+    "keypairName": "your-ssh-key",
     "kmsKey": "",
     "monitoring": false,
     "privateAddressOnly": false,

--- a/tests/validation/tests/v3_api/resource/airgap/config_yamls/config_body.yaml
+++ b/tests/validation/tests/v3_api/resource/airgap/config_yamls/config_body.yaml
@@ -3,4 +3,4 @@
         - controlplane
         - etcd
         - worker
-      ssh_key_path: /home/ubuntu/jenkins-rke-validation.pem
+      ssh_key_path: /home/ubuntu/jenkins-elliptic-validation.pem

--- a/tests/validation/tests/v3_api/resource/terraform/k3s/master/instances_server.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/master/instances_server.tf
@@ -71,7 +71,7 @@ resource "aws_instance" "master" {
   subnet_id              = var.subnets
   availability_zone      = var.availability_zone
   vpc_security_group_ids = [var.sg_id]
-  key_name               = "jenkins-rke-validation"
+  key_name               = "jenkins-elliptic-validation"
   tags = {
     Name                 = "${var.resource_name}-server"
   }
@@ -186,7 +186,7 @@ resource "aws_instance" "master2-ha" {
   subnet_id              = var.subnets
   availability_zone      = var.availability_zone
   vpc_security_group_ids = [var.sg_id]
-  key_name               = "jenkins-rke-validation"
+  key_name               = "jenkins-elliptic-validation"
   depends_on             = [aws_instance.master]
   tags = {
     Name                 = "${var.resource_name}-servers"

--- a/tests/validation/tests/v3_api/resource/terraform/k3s/worker/instances_worker.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/worker/instances_worker.tf
@@ -18,7 +18,7 @@ resource "aws_instance" "worker" {
   subnet_id              = var.subnets
   availability_zone      = var.availability_zone
   vpc_security_group_ids = [var.sg_id]
-  key_name               = "jenkins-rke-validation"
+  key_name               = "jenkins-elliptic-validation"
   tags = {
     Name                 = "${var.resource_name}-worker"
   }

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/master/instances_server.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/master/instances_server.tf
@@ -15,7 +15,7 @@ resource "aws_instance" "master" {
   subnet_id = var.subnets
   availability_zone = var.availability_zone
   vpc_security_group_ids = ["${var.sg_id}"]
-  key_name = "jenkins-rke-validation"
+  key_name = "jenkins-elliptic-validation"
   tags = {
     Name = "${var.resource_name}-server"
     "kubernetes.io/cluster/clusterid" = "owned"
@@ -75,7 +75,7 @@ resource "aws_instance" "master2" {
   subnet_id = var.subnets
   availability_zone = var.availability_zone
   vpc_security_group_ids = ["${var.sg_id}"]
-  key_name = "jenkins-rke-validation"
+  key_name = "jenkins-elliptic-validation"
   tags = {
     Name = "${var.resource_name}-servers"
     "kubernetes.io/cluster/clusterid" = "owned"

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/worker/instances_worker.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/worker/instances_worker.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "worker" {
   vpc_security_group_ids = [
     "${var.sg_id}"
   ]
-  key_name = "jenkins-rke-validation"
+  key_name = "jenkins-elliptic-validation"
   tags = {
     Name = "${var.resource_name}-worker"
     "kubernetes.io/cluster/clusterid" = "owned"

--- a/tests/validation/tests/v3_api/test_upgrade.py
+++ b/tests/validation/tests/v3_api/test_upgrade.py
@@ -614,7 +614,7 @@ def validate_worklaods_with_secret(workload_name1, workload_name2):
 
 
 def upgrade_rancher_server(serverIp,
-                           sshKeyPath=".ssh/jenkins-rke-validation.pem",
+                           sshKeyPath=".ssh/jenkins-elliptic-validation.pem",
                            containerName="rancher-server"):
     if serverIp.startswith('https://'):
         serverIp = serverIp[8:]


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/505
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
rke2 clusters in jenkins fail to create when using ubuntu 22.04 but not other (older) versions. 
upon further investigation, this was due to an incompatibility with TF when sshing into 22.04 node(s)
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
created an elliptic-based ssh key in aws to use. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
tested in jenkins (see thread) and locally

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

this PR updates _ALL_ jenkins ssh keys to use the new key. This will require an update in jenkins and all engineers using jenkins to acquire the new key. 