### PR TITLE
Add option to override initialDelay and period

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -147,14 +147,30 @@ spec:
           httpGet:
             path: /healthz
             port: 80
+          {{- if .Values.livenessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{.Values.livenessProbe.initialDelaySeconds}}
+          {{- else }}
           initialDelaySeconds: 60
+          {{- end }}
+          {{- if .Values.livenessProbe.periodSeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          {{- else }}
           periodSeconds: 30
+          {{- end }}
         readinessProbe:
           httpGet:
             path: /healthz
             port: 80
+          {{- if .Values.readinessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{.Values.readinessProbe.initialDelaySeconds}}
+          {{- else }}
           initialDelaySeconds: 5
+          {{- end }}
+          {{- if .Values.readinessProbe.periodSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          {{- else }}
           periodSeconds: 30
+          {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -349,3 +349,51 @@ tests:
     - equal:
         path: spec.template.spec.priorityClassName
         value: "rancher-critical"
+- it: should default livenessProbe initialDelaySeconds to 60
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+        value: 60
+- it: should default livenessProbe periodSeconds to 30
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+        value: 30
+- it: should default readinessProbe initialDelaySeconds to 5
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+        value: 5
+- it: should default readinessProbe periodSeconds to 30
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+        value: 30
+- it: should set livenessProbe initialDelaySeconds to 90
+  set:
+    livenessProbe.initialDelaySeconds: 90
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+        value: 90
+- it: should set livenessProbe periodSeconds to 60
+  set:
+    livenessProbe.periodSeconds: 60
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+        value: 60
+- it: should set readinessProbe initialDelaySeconds to 20
+  set:
+    readinessProbe.initialDelaySeconds: 20
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+        value: 20
+- it: should set readinessProbe periodSeconds to 60
+  set:
+    readinessProbe.periodSeconds: 60
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+        value: 60

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -161,3 +161,10 @@ postDelete:
 
 # Set a bootstrap password. If leave empty, a random password will be generated.
 bootstrapPassword: ""
+
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 30
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 30


### PR DESCRIPTION
Adds values to the chart for rancher server to override the livenessProbe and readinessProbe's initialDelaySeconds and periodSeconds

## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/38177
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
In some situations the liveness probe does not report within the default time, this makes it easier to expand that window.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Added values to the helm chart that override the default values

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Added helm tests