### PR TITLE
[v2.6] Support RANCHER_HA_HOSTNAME and RANCHER_HA_KUBECONFIG to be set with RANCHER_HA_HARDENED when set to True

### DIFF
--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -12,7 +12,7 @@ from .test_rke_cluster_provisioning import AZURE_CLIENT_ID, AZURE_CLIENT_SECRET,
 # RANCHER_HA_KUBECONFIG and RANCHER_HA_HOSTNAME are provided
 # when installing Rancher into a k3s setup
 RANCHER_HA_KUBECONFIG = os.environ.get("RANCHER_HA_KUBECONFIG")
-RANCHER_HA_HARDENED = ast.literal_eval(os.environ.get("RANCHER_HA_HARDENED", "False"))
+RANCHER_HA_HARDENED = os.environ.get("RANCHER_HA_HARDENED", "False")
 RANCHER_HA_HOSTNAME = os.environ.get(
     "RANCHER_HA_HOSTNAME", RANCHER_HOSTNAME_PREFIX + ".qa.rancher.space")
 resource_prefix = RANCHER_HA_HOSTNAME.split(".qa.rancher.space")[0]
@@ -68,6 +68,7 @@ def test_remove_rancher_ha():
 def test_install_rancher_ha(precheck_certificate_options):
     cm_install = True
     extra_settings = []
+    profile = 'rke-cis-1.5'
     if "byo-" in RANCHER_HA_CERT_OPTION:
         cm_install = False
     print("The hostname is: {}".format(RANCHER_HA_HOSTNAME))
@@ -79,7 +80,6 @@ def test_install_rancher_ha(precheck_certificate_options):
             print("RKE cluster is provisioning for the local cluster")
             nodes = create_resources()
             if RANCHER_HA_HARDENED:
-                profile = 'rke-cis-1.5'
                 node_role = [["worker", "controlplane", "etcd"]]
                 node_roles =[]
                 for role in node_role:
@@ -140,7 +140,7 @@ def test_install_rancher_ha(precheck_certificate_options):
         assert False, "check the logs in console for details"
 
     print_kubeconfig(kubeconfig_path)
-    if RANCHER_HA_HARDENED and RANCHER_LOCAL_CLUSTER_TYPE == "RKE":
+    if (RANCHER_HA_HARDENED.upper() == "TRUE" and RANCHER_LOCAL_CLUSTER_TYPE == "RKE") and RANCHER_HA_KUBECONFIG == "" and RANCHER_HA_HOSTNAME=="":
         prepare_hardened_cluster(profile, kubeconfig_path)
     if RANCHER_LOCAL_CLUSTER_TYPE == "RKE":
         check_rke_ingress_rollout()


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Fix ha_deploy](https://github.com/rancher/qa-tasks/issues/504)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When running the `test_install_rancher_ha` function from `test_create_ha.py`, there is a failure when you attempt to have environment variables `RANCHER_HA_HOSTNAME` and `RANCHER_HA_KUBECONFIG` set and `RANCHER_HA_HARDENED` is set to `True`. To get around this, a workaround is to set `RANCHER_HA_HARDENED` to `False` when these variables are present.

This should not happen and disrupts automation when trying to import an RKE1 cluster with the existing automation.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
The variable `rke-cis-1.5` needed to be declared outside of its parental conditionals. This is done so that the variable is always set and not set only in a conditional.

Additionally, there needs to be a new check in the `set_route53_with_ingress` function that looks for `RANCHER_HA_HARDENED.upper() == "TRUE" and RANCHER_LOCAL_CLUSTER_TYPE == "RKE"`. In doing that, when supplying your own RKE1 cluster and EC2 load balancer, Rancher stands up properly with a hardened local RKE1 cluster.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Validated with manual testing that I do not receive the previous error.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Offline Jenkins jobs will be given to the reviewers.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->