### PR TITLE
[2.7] bump the RancherVersionDev to 2.7.99 

### DIFF
--- a/pkg/channelserver/channelserver.go
+++ b/pkg/channelserver/channelserver.go
@@ -44,11 +44,11 @@ func GetURLAndInterval() (string, time.Duration) {
 
 // getChannelServerArg will return with an argument to pass to channel server
 // to indicate the server version that is running. If the current version is
-// not a proper release version, the argument will be empty.
+// not a proper release version, the argument will be set to the dev version.
 func getChannelServerArg() string {
 	serverVersion := settings.ServerVersion.Get()
 	if !utils.ReleaseServerVersion(serverVersion) {
-		return ""
+		return settings.RancherVersionDev
 	}
 	return serverVersion
 }

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -16,7 +16,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-const RancherVersionDev = "2.6.99"
+const RancherVersionDev = "2.7.99"
 
 var (
 	releasePattern = regexp.MustCompile("^v[0-9]")

--- a/tests/integration/suite/test_clustertemplate.py
+++ b/tests/integration/suite/test_clustertemplate.py
@@ -972,7 +972,7 @@ def create_cluster_template_revision(client, clusterTemplateId):
                   "rancherKubernetesEngineConfig.kubernetesVersion",
                   "required": "false",
                   "type": "string",
-                  "default": "1.19.x"
+                  "default": "1.24.x"
                  }]
 
     revision_name = random_str()

--- a/tests/integration/suite/test_kontainer_drivers.py
+++ b/tests/integration/suite/test_kontainer_drivers.py
@@ -289,7 +289,7 @@ def test_kontainer_driver_links(admin_mc):
     images = get_images(url, token)
     assert "hyperkube" in images
     assert "rke-tools" in images
-    assert "kubelet-pause" in images
+    assert "mirrored-pause" in images
 
 
 def get_images(url, token):
@@ -308,6 +308,8 @@ def get_images(url, token):
             test["rke-tools"] = True
         elif "rancher/kubelet-pause" in str(line):
             test["kubelet-pause"] = True
+        elif "rancher/mirrored-pause" in str(line):
+            test["mirrored-pause"] = True
     return test
 
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> 
https://github.com/rancher/rancher/issues/39239
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

For RKE, RKE1, and K3s, the available versions in the version list are not right when creating a node-drive cluster on **v2.7-head**

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
- bump the RancherVersionDev to 2.7.99, so that the available k8s versions can be calculated correctly on 2.7-head and the dev build
- fix the server version for rke2/k3s channel server
- fix tests


## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Built and ran rancher locally and see only the latest  1.23 and 1.24 as the available version for For RKE, RKE1, and K3s

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->