### PR TITLE
[v2.6.10] Add sync back to check for user-node-remove, add tests

### DIFF
--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -35,19 +35,21 @@ const (
 )
 
 func (m *Lifecycle) deleteV1Node(node *v3.Node) (runtime.Object, error) {
-	logrus.Debugf("Deleting v1.node for [%v] node", node.Status.NodeName)
+	logrus.Debugf("[node-cleanup] Deleting v1.node for [%v] node", node.Status.NodeName)
 	if nodehelper.IgnoreNode(node.Status.NodeName, node.Status.NodeLabels) {
-		logrus.Debugf("Skipping v1.node removal for [%v] node", node.Status.NodeName)
+		logrus.Debugf("[node-cleanup] Skipping v1.node removal for [%v] node", node.Status.NodeName)
 		return node, nil
 	}
 
 	if node.Status.NodeName == "" {
+		logrus.Debugf("[node-cleanup] Skipping v1.node removal for machine [%v] without node name", node.Name)
 		return node, nil
 	}
 
 	cluster, err := m.clusterLister.Get("", node.Namespace)
 	if err != nil {
 		if kerror.IsNotFound(err) {
+			logrus.Debugf("[node-cleanup] Skipping v1.node removal for machine [%v] without cluster [%v]", node.Name, node.Namespace)
 			return node, nil
 		}
 		return node, err
@@ -57,7 +59,7 @@ func (m *Lifecycle) deleteV1Node(node *v3.Node) (runtime.Object, error) {
 		return node, err
 	}
 	if userClient == nil {
-		logrus.Debugf("cluster is already deleted, cannot delete RKE node")
+		logrus.Debugf("[node-cleanup] cluster is already deleted, cannot delete RKE node")
 		return node, nil
 	}
 
@@ -94,14 +96,14 @@ func (m *Lifecycle) drainNode(node *v3.Node) error {
 		return nil
 	}
 
-	logrus.Infof("node [%s] requires draining before delete", nodeCopy.Spec.RequestedHostname)
+	logrus.Infof("[node-cleanup] node [%s] requires draining before delete", nodeCopy.Spec.RequestedHostname)
 	kubeConfig, _, err := m.getKubeConfig(cluster)
 	if err != nil {
 		return fmt.Errorf("node [%s] error getting kubeConfig", nodeCopy.Spec.RequestedHostname)
 	}
 
 	if nodeCopy.Spec.NodeDrainInput == nil {
-		logrus.Debugf("node [%s] has no NodeDrainInput, creating one with 60s timeout",
+		logrus.Debugf("[node-cleanup] node [%s] has no NodeDrainInput, creating one with 60s timeout",
 			nodeCopy.Spec.RequestedHostname)
 		nodeCopy.Spec.NodeDrainInput = &rketypes.NodeDrainInput{
 			Force:           true,
@@ -118,7 +120,7 @@ func (m *Lifecycle) drainNode(node *v3.Node) error {
 		Steps:    3,
 	}
 
-	logrus.Infof("node [%s] attempting to drain, retrying up to 3 times", nodeCopy.Spec.RequestedHostname)
+	logrus.Infof("[node-cleanup] node [%s] attempting to drain, retrying up to 3 times", nodeCopy.Spec.RequestedHostname)
 	// purposefully ignoring error, if the drain fails this falls back to deleting the node as usual
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		ctx, cancel := context.WithTimeout(m.ctx, time.Duration(nodeCopy.Spec.NodeDrainInput.Timeout)*time.Second)
@@ -126,16 +128,16 @@ func (m *Lifecycle) drainNode(node *v3.Node) error {
 
 		_, msg, err := kubectl.Drain(ctx, kubeConfig, nodeCopy.Status.NodeName, nodehelper.GetDrainFlags(nodeCopy))
 		if ctx.Err() != nil {
-			logrus.Errorf("node [%s] kubectl drain failed, retrying: %s", nodeCopy.Spec.RequestedHostname, ctx.Err())
+			logrus.Errorf("[node-cleanup] node [%s] kubectl drain failed, retrying: %s", nodeCopy.Spec.RequestedHostname, ctx.Err())
 			return false, nil
 		}
 		if err != nil {
 			// kubectl failed continue on with delete any way
-			logrus.Errorf("node [%s] kubectl drain error, retrying: %s", nodeCopy.Spec.RequestedHostname, err)
+			logrus.Errorf("[node-cleanup] node [%s] kubectl drain error, retrying: %s", nodeCopy.Spec.RequestedHostname, err)
 			return false, nil
 		}
 
-		logrus.Infof("node [%s] kubectl drain response: %s", nodeCopy.Spec.RequestedHostname, msg)
+		logrus.Infof("[node-cleanup] node [%s] kubectl drain response: %s", nodeCopy.Spec.RequestedHostname, msg)
 		return true, nil
 	})
 }
@@ -162,7 +164,7 @@ func (m *Lifecycle) cleanRKENode(node *v3.Node) error {
 		return err
 	}
 	if userContext == nil {
-		logrus.Debugf("cluster is already deleted, cannot clean RKE node")
+		logrus.Debugf("[node-cleanup] cluster is already deleted, cannot clean RKE node")
 		return nil
 	}
 
@@ -420,7 +422,7 @@ func removeFinalizerWithPrefix(finalizers []string, prefix string) []string {
 	var nf []string
 	for _, finalizer := range finalizers {
 		if strings.HasPrefix(finalizer, prefix) {
-			logrus.Debugf("finalizer with prefix [%s] will be removed", prefix)
+			logrus.Debugf("[node-cleanup] finalizer with prefix [%s] will be removed", prefix)
 			continue
 		}
 		nf = append(nf, finalizer)
@@ -431,7 +433,7 @@ func removeFinalizerWithPrefix(finalizers []string, prefix string) []string {
 func removeAnnotationWithPrefix(annotations map[string]string, prefix string) map[string]string {
 	for k := range annotations {
 		if strings.HasPrefix(k, prefix) {
-			logrus.Debugf("annotation with prefix [%s] will be removed", prefix)
+			logrus.Debugf("[node-cleanup] annotation with prefix [%s] will be removed", prefix)
 			delete(annotations, k)
 		}
 	}

--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -397,12 +397,12 @@ func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, cluster *v
 	return userContext.K8sClient.BatchV1().Jobs("default").Create(context.TODO(), &job, metav1.CreateOptions{})
 }
 
-func (m *Lifecycle) userNodeRemoveCleanup(obj *v3.Node) (runtime.Object, error) {
-	newObj := obj.DeepCopy()
-	newObj.SetFinalizers(removeFinalizerWithPrefix(newObj.GetFinalizers(), userNodeRemoveFinalizerPrefix))
+func (m *Lifecycle) userNodeRemoveCleanup(obj *v3.Node) *v3.Node {
+	obj = obj.DeepCopy()
+	obj.SetFinalizers(removeFinalizerWithPrefix(obj.GetFinalizers(), userNodeRemoveFinalizerPrefix))
 
-	if newObj.DeletionTimestamp == nil {
-		annos := newObj.GetAnnotations()
+	if obj.DeletionTimestamp == nil {
+		annos := obj.GetAnnotations()
 		if annos == nil {
 			annos = make(map[string]string)
 		} else {
@@ -411,9 +411,9 @@ func (m *Lifecycle) userNodeRemoveCleanup(obj *v3.Node) (runtime.Object, error) 
 		}
 
 		annos[userNodeRemoveCleanupAnnotation] = "true"
-		newObj.SetAnnotations(annos)
+		obj.SetAnnotations(annos)
 	}
-	return m.nodeClient.Update(newObj)
+	return obj
 }
 
 func removeFinalizerWithPrefix(finalizers []string, prefix string) []string {

--- a/pkg/controllers/management/node/cleanup_test.go
+++ b/pkg/controllers/management/node/cleanup_test.go
@@ -1,0 +1,101 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveFinalizers(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "empty input",
+			prefix:   "test_prefix",
+			input:    []string{},
+			expected: nil,
+		},
+		{
+			name:     "nil input",
+			prefix:   "test_prefix",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty prefix",
+			prefix:   "",
+			input:    []string{"testing.cattle.io/a_test"},
+			expected: nil,
+		},
+		{
+			name:     "match",
+			prefix:   "testing.cattle.io/a_",
+			input:    []string{"testing.cattle.io/a_test"},
+			expected: nil,
+		},
+		{
+			name:     "no match",
+			prefix:   "testing.cattle.io/b_",
+			input:    []string{"testing.cattle.io/a_test"},
+			expected: []string{"testing.cattle.io/a_test"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+			actual := removeFinalizerWithPrefix(tt.input, tt.prefix)
+			a.Equal(tt.expected, actual)
+		})
+	}
+}
+
+func TestRemoveAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		input    map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "empty input",
+			prefix:   "test_prefix",
+			input:    map[string]string{},
+			expected: map[string]string{},
+		},
+		{
+			name:     "nil input",
+			prefix:   "test_prefix",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty prefix",
+			prefix:   "",
+			input:    map[string]string{"testing.cattle.io/a_test": "true"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "match",
+			prefix:   "testing.cattle.io/a_",
+			input:    map[string]string{"testing.cattle.io/a_test": "true"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "no match",
+			prefix:   "testing.cattle.io/b_",
+			input:    map[string]string{"testing.cattle.io/a_test": "true"},
+			expected: map[string]string{"testing.cattle.io/a_test": "true"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+			actual := removeAnnotationWithPrefix(tt.input, tt.prefix)
+			a.Equal(tt.expected, actual)
+		})
+	}
+}

--- a/pkg/controllers/management/node/utils.go
+++ b/pkg/controllers/management/node/utils.go
@@ -225,9 +225,9 @@ func (m *Lifecycle) reportStatus(stdoutReader io.Reader, stderrReader io.Reader,
 		if strings.HasPrefix(msg, debugPrefix) {
 			// calls in machine with log.Debug are all prefixed and spammy so only log
 			// under trace and don't add to the v3.NodeConditionProvisioned.Message
-			logrus.Tracef("[node-controller-rancher-machine] %v", msg)
+			logrus.Tracef("[node-controller] %v", msg)
 		} else {
-			logrus.Infof("[node-controller-rancher-machine] %v", msg)
+			logrus.Infof("[node-controller] %v", msg)
 			v32.NodeConditionProvisioned.Message(node, msg)
 		}
 
@@ -304,12 +304,12 @@ func deleteNode(nodeDir string, node *v3.Node) error {
 	scanner := bufio.NewScanner(stdoutReader)
 	for scanner.Scan() {
 		msg := scanner.Text()
-		logrus.Infof("[node-controller-rancher-machine] %v", msg)
+		logrus.Infof("[node-controller] %v", msg)
 	}
 	scanner = bufio.NewScanner(stderrReader)
 	for scanner.Scan() {
 		msg := scanner.Text()
-		logrus.Warnf("[node-controller-rancher-machine] %v", msg)
+		logrus.Warnf("[node-controller] %v", msg)
 	}
 
 	return command.Wait()

--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -410,7 +410,7 @@ func (m *nodesSyncer) reconcileAll() error {
 		if err != nil {
 			return err
 		}
-		if node == nil {
+		if node == nil || machine.DeletionTimestamp != nil {
 			logrus.Debugf("Failed to get node for machine [%s], preparing to delete", machine.Name)
 			toDelete[machine.Name] = machine
 			continue

--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -394,7 +394,7 @@ func (m *nodesSyncer) reconcileAll() error {
 		return err
 	}
 
-	nodeMap := make(map[string]*corev1.Node)
+	nodeMap := make(map[string]*corev1.Node, len(nodes))
 	for _, node := range nodes {
 		nodeMap[node.Name] = node
 	}

--- a/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
+++ b/pkg/controllers/managementuser/nodesyncer/nodessyncer.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	cond "github.com/rancher/norman/condition"
-	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	kd "github.com/rancher/rancher/pkg/controllers/management/kontainerdrivermetadata"
 	"github.com/rancher/rancher/pkg/controllers/management/secretmigrator"
 	"github.com/rancher/rancher/pkg/controllers/managementagent/podresources"
@@ -34,10 +34,7 @@ import (
 const (
 	AllNodeKey     = "_machine_all_"
 	annotationName = "management.cattle.io/nodesyncer"
-	apiUpdate      = "management.cattle.io/apiUpdate"
 )
-
-var apiUpdateMap = map[string]string{apiUpdate: "true"}
 
 type nodeSyncer struct {
 	machines         v3.NodeInterface
@@ -130,7 +127,7 @@ func (n *nodeSyncer) sync(key string, node *corev1.Node) (runtime.Object, error)
 	return nil, nil
 }
 
-func (n *nodeSyncer) needUpdate(key string, node *corev1.Node) (bool, error) {
+func (n *nodeSyncer) needUpdate(_ string, node *corev1.Node) (bool, error) {
 	if node == nil || node.DeletionTimestamp != nil {
 		return true, nil
 	}
@@ -164,17 +161,17 @@ func (n *nodeSyncer) needUpdate(key string, node *corev1.Node) (bool, error) {
 	return true, nil
 }
 
-func (m *nodesSyncer) sync(key string, machine *v3.Node) (runtime.Object, error) {
+func (m *nodesSyncer) sync(key string, _ *apimgmtv3.Node) (runtime.Object, error) {
 	if key == fmt.Sprintf("%s/%s", m.clusterNamespace, AllNodeKey) {
 		return nil, m.reconcileAll()
 	}
 	return nil, nil
 }
 
-func (m *nodesSyncer) updateNodeAndNode(node *corev1.Node, obj *v3.Node) (*corev1.Node, *v3.Node, error) {
+func (m *nodesSyncer) updateNodeAndNode(node *corev1.Node, obj *apimgmtv3.Node) (*corev1.Node, *apimgmtv3.Node, error) {
 	node, err := m.nodeClient.Update(node)
 	if err != nil {
-		// Return v3.Node is nil because it hasn't been persisted and therefor out of sync with cache
+		// Return apimgmtv3.Node is nil because it hasn't been persisted and therefor out of sync with cache
 		// so we don't want to return it from the handler
 		return node, nil, err
 	}
@@ -188,7 +185,7 @@ func (m *nodesSyncer) updateNodeAndNode(node *corev1.Node, obj *v3.Node) (*corev
 	return node, obj, nil
 }
 
-func (m *nodesSyncer) updateLabels(node *corev1.Node, obj *v3.Node, nodePlan rketypes.RKEConfigNodePlan) (*corev1.Node, *v3.Node, error) {
+func (m *nodesSyncer) updateLabels(node *corev1.Node, obj *apimgmtv3.Node, nodePlan rketypes.RKEConfigNodePlan) (*corev1.Node, *apimgmtv3.Node, error) {
 	finalMap, changed := computeDelta(node.Labels, nodePlan.Labels, obj.Spec.MetadataUpdate.Labels, onlyKubeLabels)
 	if !changed {
 		return node, obj, nil
@@ -204,13 +201,13 @@ func (m *nodesSyncer) updateLabels(node *corev1.Node, obj *v3.Node, nodePlan rke
 
 	node.Labels = finalMap
 
-	obj.Spec.MetadataUpdate.Labels = v32.MapDelta{}
+	obj.Spec.MetadataUpdate.Labels = apimgmtv3.MapDelta{}
 
 	return m.updateNodeAndNode(node, obj)
 }
 
 // For any key that already exist in the plan, we should update or delete. For others, do not touch the plan.
-func computePlanDelta(planValues map[string]string, delta v32.MapDelta) (map[string]string, bool) {
+func computePlanDelta(planValues map[string]string, delta apimgmtv3.MapDelta) (map[string]string, bool) {
 	update := false
 	for k, v := range delta.Add {
 		if planValues[k] != "" {
@@ -229,7 +226,7 @@ func computePlanDelta(planValues map[string]string, delta v32.MapDelta) (map[str
 
 }
 
-func (m *nodesSyncer) updateAnnotations(node *corev1.Node, obj *v3.Node, nodePlan rketypes.RKEConfigNodePlan) (*corev1.Node, *v3.Node, error) {
+func (m *nodesSyncer) updateAnnotations(node *corev1.Node, obj *apimgmtv3.Node, nodePlan rketypes.RKEConfigNodePlan) (*corev1.Node, *apimgmtv3.Node, error) {
 	finalMap, changed := computeDelta(node.Annotations, nodePlan.Annotations, obj.Spec.MetadataUpdate.Annotations, allowAllPolicy)
 	if !changed {
 		return node, obj, nil
@@ -237,12 +234,12 @@ func (m *nodesSyncer) updateAnnotations(node *corev1.Node, obj *v3.Node, nodePla
 
 	node, obj = node.DeepCopy(), obj.DeepCopy()
 	node.Annotations = finalMap
-	obj.Spec.MetadataUpdate.Annotations = v32.MapDelta{}
+	obj.Spec.MetadataUpdate.Annotations = apimgmtv3.MapDelta{}
 
 	return m.updateNodeAndNode(node, obj)
 }
 
-func (m *nodesSyncer) syncLabels(key string, obj *v3.Node) (runtime.Object, error) {
+func (m *nodesSyncer) syncLabels(_ string, obj *apimgmtv3.Node) (runtime.Object, error) {
 	if obj == nil {
 		return nil, nil
 	}
@@ -276,7 +273,7 @@ func allowAllPolicy(_ string) bool {
 
 // computeDelta will return the final updated map to apply and a boolean indicating whether there are changes to be applied.
 // If the boolean is false, the caller need not take any action as the data is already in sync.
-func computeDelta(currentState map[string]string, planValues map[string]string, delta v32.MapDelta, canChangeValue canChangeValuePolicy) (map[string]string, bool) {
+func computeDelta(currentState map[string]string, planValues map[string]string, delta apimgmtv3.MapDelta, canChangeValue canChangeValuePolicy) (map[string]string, bool) {
 	result := map[string]string{}
 	changed := false
 
@@ -311,13 +308,13 @@ func computeDelta(currentState map[string]string, planValues map[string]string, 
 	return result, changed
 }
 
-func (m *nodesSyncer) getNodePlan(node *v3.Node) (rketypes.RKEConfigNodePlan, error) {
+func (m *nodesSyncer) getNodePlan(node *apimgmtv3.Node) (rketypes.RKEConfigNodePlan, error) {
 	cluster, err := m.clusterLister.Get("", node.Namespace)
 	if err != nil {
 		return rketypes.RKEConfigNodePlan{}, err
 	}
 
-	if cluster.Status.Driver != v32.ClusterDriverRKE || cluster.Status.AppliedSpec.RancherKubernetesEngineConfig == nil {
+	if cluster.Status.Driver != apimgmtv3.ClusterDriverRKE || cluster.Status.AppliedSpec.RancherKubernetesEngineConfig == nil {
 		return rketypes.RKEConfigNodePlan{}, nil
 	}
 
@@ -406,8 +403,8 @@ func (m *nodesSyncer) reconcileAll() error {
 	if err != nil {
 		return err
 	}
-	machineMap := make(map[string]*v3.Node)
-	toDelete := make(map[string]*v3.Node)
+	machineMap := make(map[string]*apimgmtv3.Node)
+	toDelete := make(map[string]*apimgmtv3.Node)
 	for _, machine := range machines {
 		node, err := nodehelper.GetNodeForMachine(machine, m.nodeLister)
 		if err != nil {
@@ -448,14 +445,17 @@ func (m *nodesSyncer) reconcileAll() error {
 	return nil
 }
 
-func (m *nodesSyncer) reconcileNodeForNode(machine *v3.Node, node *corev1.Node, nodeCache *NodeCache) error {
+func (m *nodesSyncer) reconcileNodeForNode(machine *apimgmtv3.Node, node *corev1.Node, nodeCache *NodeCache) error {
 	if machine == nil {
 		return m.createNode(node, nodeCache)
 	}
 	return m.updateNode(machine, node)
 }
 
-func (m *nodesSyncer) removeNode(machine *v3.Node) error {
+func (m *nodesSyncer) removeNode(machine *apimgmtv3.Node) error {
+	if machine.DeletionTimestamp != nil {
+		return nil
+	}
 	if machine.Annotations == nil {
 		return nil
 	}
@@ -472,7 +472,7 @@ func (m *nodesSyncer) removeNode(machine *v3.Node) error {
 	return nil
 }
 
-func (m *nodesSyncer) updateNode(existing *v3.Node, node *corev1.Node) error {
+func (m *nodesSyncer) updateNode(existing *apimgmtv3.Node, node *corev1.Node) error {
 	toUpdate, err := m.convertNodeToMachine(node, existing)
 	if err != nil {
 		return err
@@ -493,7 +493,7 @@ func (m *nodesSyncer) updateNode(existing *v3.Node, node *corev1.Node) error {
 func (m *nodesSyncer) createNode(node *corev1.Node, nodeCache *NodeCache) error {
 	// respect user defined name or label
 	if nodehelper.IgnoreNode(node.Name, node.Labels) {
-		logrus.Debugf("Skipping v3.node creation for [%v] node", node.Name)
+		logrus.Debugf("Skipping apimgmtv3.Node creation for [%v] node", node.Name)
 		return nil
 	}
 
@@ -523,18 +523,18 @@ func (m *nodesSyncer) createNode(node *corev1.Node, nodeCache *NodeCache) error 
 	return nil
 }
 
-func (m *nodesSyncer) getMachineForNodeFromCache(node *corev1.Node) (*v3.Node, error) {
+func (m *nodesSyncer) getMachineForNodeFromCache(node *corev1.Node) (*apimgmtv3.Node, error) {
 	return nodehelper.GetMachineForNode(node, m.clusterNamespace, m.machineLister)
 }
 
 type NodeCache struct {
-	all    []*v3.Node
-	byName map[string][]*v3.Node
+	all    []*apimgmtv3.Node
+	byName map[string][]*apimgmtv3.Node
 }
 
-func (n *NodeCache) Add(machine *v3.Node) {
+func (n *NodeCache) Add(machine *apimgmtv3.Node) {
 	if n.byName == nil {
-		n.byName = map[string][]*v3.Node{}
+		n.byName = map[string][]*apimgmtv3.Node{}
 	}
 	if name, ok := machine.Labels[nodehelper.LabelNodeName]; ok {
 		n.byName[name] = append(n.byName[name], machine)
@@ -542,7 +542,7 @@ func (n *NodeCache) Add(machine *v3.Node) {
 	n.all = append(n.all, machine)
 }
 
-func (m *nodesSyncer) getMachineForNode(node *corev1.Node, nodeCache *NodeCache) (*v3.Node, error) {
+func (m *nodesSyncer) getMachineForNode(node *corev1.Node, nodeCache *NodeCache) (*apimgmtv3.Node, error) {
 	if len(nodeCache.all) == 0 {
 		machines, err := m.machines.List(metav1.ListOptions{})
 		if err != nil {
@@ -569,7 +569,7 @@ func (m *nodesSyncer) getMachineForNode(node *corev1.Node, nodeCache *NodeCache)
 	return nil, nil
 }
 
-func resetConditions(machine *v3.Node) *v3.Node {
+func resetConditions(machine *apimgmtv3.Node) *apimgmtv3.Node {
 	if machine.Status.InternalNodeStatus.Conditions == nil {
 		return machine
 	}
@@ -588,7 +588,7 @@ func resetConditions(machine *v3.Node) *v3.Node {
 	return updated
 }
 
-func objectsAreEqual(existing *v3.Node, toUpdate *v3.Node) bool {
+func objectsAreEqual(existing *apimgmtv3.Node, toUpdate *apimgmtv3.Node) bool {
 	// we are updating spec and status only, so compare them
 	toUpdateToCompare := resetConditions(toUpdate)
 	existingToCompare := resetConditions(existing)
@@ -681,12 +681,12 @@ func statusEqualTest(proposed, existing corev1.NodeStatus) bool {
 	return true
 }
 
-func cleanStatus(machine *v3.Node) {
+func cleanStatus(machine *apimgmtv3.Node) {
 	var conditions []corev1.NodeCondition
 	for _, condition := range machine.Status.InternalNodeStatus.Conditions {
 		if condition.Type == "Ready" {
 			conditions = append(conditions, condition)
-			readyCondition := v32.NodeCondition{
+			readyCondition := apimgmtv3.NodeCondition{
 				Type:               cond.Cond(condition.Type),
 				Status:             condition.Status,
 				LastTransitionTime: condition.LastTransitionTime.String(),
@@ -737,12 +737,12 @@ func getResourceList(annotation string, node *corev1.Node) corev1.ResourceList {
 	return result
 }
 
-func (m *nodesSyncer) convertNodeToMachine(node *corev1.Node, existing *v3.Node) (*v3.Node, error) {
-	var machine *v3.Node
+func (m *nodesSyncer) convertNodeToMachine(node *corev1.Node, existing *apimgmtv3.Node) (*apimgmtv3.Node, error) {
+	var machine *apimgmtv3.Node
 	if existing == nil {
-		machine = &v3.Node{
-			Spec:   v32.NodeSpec{},
-			Status: v32.NodeStatus{},
+		machine = &apimgmtv3.Node{
+			Spec:   apimgmtv3.NodeSpec{},
+			Status: apimgmtv3.NodeStatus{},
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "machine-"},
 		}
@@ -790,8 +790,8 @@ func (m *nodesSyncer) convertNodeToMachine(node *corev1.Node, existing *v3.Node)
 	}
 	machine.Labels[nodehelper.LabelNodeName] = node.Name
 	cleanStatus(machine)
-	v32.NodeConditionRegistered.True(machine)
-	v32.NodeConditionRegistered.Message(machine, "registered with kubernetes")
+	apimgmtv3.NodeConditionRegistered.True(machine)
+	apimgmtv3.NodeConditionRegistered.Message(machine, "registered with kubernetes")
 	return machine, nil
 }
 
@@ -826,7 +826,7 @@ func (m *nodesSyncer) isClusterRestoring() (bool, error) {
 	return false, nil
 }
 
-func determineNodeRoles(machine *v3.Node) {
+func determineNodeRoles(machine *apimgmtv3.Node) {
 	if machine.Status.NodeLabels != nil {
 		_, etcd := machine.Status.NodeLabels["node-role.kubernetes.io/etcd"]
 		_, control := machine.Status.NodeLabels["node-role.kubernetes.io/controlplane"]

--- a/pkg/nodeconfig/config.go
+++ b/pkg/nodeconfig/config.go
@@ -9,9 +9,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/types/values"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/encryptedstore"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/jailer"
 	"github.com/sirupsen/logrus"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
@@ -94,7 +94,7 @@ func (m *NodeConfig) Cleanup() error {
 }
 
 func (m *NodeConfig) Remove() error {
-	m.Cleanup()
+	_ = m.Cleanup()
 	logrus.Debugf("Removing [%v]", m.id)
 	return m.store.Remove(m.id)
 }

--- a/pkg/nodeconfig/config.go
+++ b/pkg/nodeconfig/config.go
@@ -139,7 +139,7 @@ func (m *NodeConfig) Save() error {
 		return err
 	}
 
-	if err := m.loadConfig(); err != nil {
+	if err = m.loadConfig(); err != nil {
 		return err
 	}
 
@@ -149,7 +149,7 @@ func (m *NodeConfig) Save() error {
 
 	m.cm[configKey] = extractedConfig
 
-	if err := m.store.Set(m.id, m.cm); err != nil {
+	if err = m.store.Set(m.id, m.cm); err != nil {
 		m.cm = nil
 		return err
 	}
@@ -192,7 +192,7 @@ func (m *NodeConfig) UpdateAmazonAuth(rawConfig interface{}) (bool, error) {
 	for _, file := range files {
 		if file.IsDir() {
 			configPath := filepath.Join(machines, file.Name(), "config.json")
-			b, err := ioutil.ReadFile(configPath)
+			b, err := os.ReadFile(configPath)
 			if err != nil {
 				if os.IsNotExist(err) {
 					// config.json doesn't exist, no changes needed
@@ -242,7 +242,7 @@ func (m *NodeConfig) UpdateAmazonAuth(rawConfig interface{}) (bool, error) {
 					return update, errors.WithMessage(err, "error marshaling new machine config")
 				}
 
-				if err := ioutil.WriteFile(configPath, out, 0600); err != nil {
+				if err := os.WriteFile(configPath, out, 0600); err != nil {
 					return update, errors.WithMessage(err, "error writing  new machine config")
 				}
 			}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->#38887
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

If a node is provisioned on <v2.5.1, rancher is stopped, and the node is deleted; Remove will not be called for the node causing orphaned v1.Nodes which default unmanaged v3.Nodes are then created for.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Remove the annotation on sync and v3.Node removal.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested with a 1 etcd, 1 controlplane, 1 worker. On upgrade from v2.5.1 to v2.6-head, the node is properly cleaned up.