### PR TITLE
[v2.6] Update RKE & regenerate Azure Cloud-provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8
-	github.com/rancher/rke v1.3.15
+	github.com/rancher/rke v1.3.16-0.20221024210557-dbb4aa40e21d
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20220805200026-647cba2be744
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007

--- a/go.sum
+++ b/go.sum
@@ -1437,8 +1437,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8w
 github.com/rancher/remotedialer v0.2.6-0.20220104192242-f3837f8d649a/go.mod h1:vq3LvyOFnLcwMiCE1KdW3foPd6g5kAjZOtOb7JqGHck=
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8 h1:leqh0chjBsXhKWebxxFd5QPcoQLu51EpaHo04ce0o+8=
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
-github.com/rancher/rke v1.3.15 h1:I2RtkaYc11zEmy2M2mYWSaXaz7ahH+fBzePMXlG1Aww=
-github.com/rancher/rke v1.3.15/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
+github.com/rancher/rke v1.3.16-0.20221024210557-dbb4aa40e21d h1:+xuhH3nRZ6DHJ6eZVmNoF7ni842clC5IiMd7f2+DbzQ=
+github.com/rancher/rke v1.3.16-0.20221024210557-dbb4aa40e21d/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
 github.com/rancher/steve v0.0.0-20220805200026-647cba2be744 h1:ENNT3KJy5kdmmYc2OVdicWfpEyiLYkfu1TqiSElaXUQ=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20220916041858-eae202f68985
 	github.com/rancher/gke-operator v1.1.4
 	github.com/rancher/norman v0.0.0-20220627222520-b74009fac3ff
-	github.com/rancher/rke v1.3.15
+	github.com/rancher/rke v1.3.16-0.20221024210557-dbb4aa40e21d
 	github.com/rancher/wrangler v1.0.1-0.20220520195731-8eeded9bae2a
 	github.com/sirupsen/logrus v1.8.1
 	k8s.io/api v0.24.5

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -598,8 +598,8 @@ github.com/rancher/lasso v0.0.0-20220627205005-00d9c8e9dda6 h1:il7Q4YfIuB4BIjzi7
 github.com/rancher/lasso v0.0.0-20220627205005-00d9c8e9dda6/go.mod h1:sMLCrn5NBypoWCc7wf9pNdzXOZ+HBlO0RHIppPmLOCA=
 github.com/rancher/norman v0.0.0-20220627222520-b74009fac3ff h1:XmFUzjxTkuOMaK5Emezfjb9fTcZKi3SVi8xY2nPOAHs=
 github.com/rancher/norman v0.0.0-20220627222520-b74009fac3ff/go.mod h1:9zlHK0aLVQManRI6bpzRmuxAlTE70JKsN3JJ+PonHVk=
-github.com/rancher/rke v1.3.15 h1:I2RtkaYc11zEmy2M2mYWSaXaz7ahH+fBzePMXlG1Aww=
-github.com/rancher/rke v1.3.15/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
+github.com/rancher/rke v1.3.16-0.20221024210557-dbb4aa40e21d h1:+xuhH3nRZ6DHJ6eZVmNoF7ni842clC5IiMd7f2+DbzQ=
+github.com/rancher/rke v1.3.16-0.20221024210557-dbb4aa40e21d/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
 github.com/rancher/wrangler v0.8.10/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=

--- a/pkg/client/generated/management/v3/zz_generated_azure_cloud_provider.go
+++ b/pkg/client/generated/management/v3/zz_generated_azure_cloud_provider.go
@@ -26,6 +26,7 @@ const (
 	AzureCloudProviderFieldSecurityGroupName            = "securityGroupName"
 	AzureCloudProviderFieldSubnetName                   = "subnetName"
 	AzureCloudProviderFieldSubscriptionID               = "subscriptionId"
+	AzureCloudProviderFieldTags                         = "tags"
 	AzureCloudProviderFieldTenantID                     = "tenantId"
 	AzureCloudProviderFieldUseInstanceMetadata          = "useInstanceMetadata"
 	AzureCloudProviderFieldUseManagedIdentityExtension  = "useManagedIdentityExtension"
@@ -60,6 +61,7 @@ type AzureCloudProvider struct {
 	SecurityGroupName            string `json:"securityGroupName,omitempty" yaml:"securityGroupName,omitempty"`
 	SubnetName                   string `json:"subnetName,omitempty" yaml:"subnetName,omitempty"`
 	SubscriptionID               string `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
+	Tags                         string `json:"tags,omitempty" yaml:"tags,omitempty"`
 	TenantID                     string `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
 	UseInstanceMetadata          bool   `json:"useInstanceMetadata,omitempty" yaml:"useInstanceMetadata,omitempty"`
 	UseManagedIdentityExtension  bool   `json:"useManagedIdentityExtension,omitempty" yaml:"useManagedIdentityExtension,omitempty"`


### PR DESCRIPTION
## Issue: #26955
 
## Problem
The Azure cloud provider was updated in RKE recently, (https://github.com/rancher/rke/pull/2580), but the recent RC containing the change was not brought into Rancher. This prevents terraform support of this new field.
 
## Solution
This PR updates the RKE version used by Rancher to `1.4.0-rc4`, which includes the additional field in the Azure Cloud Provider. `go generate` has been run to update the generated types used by Rancher. This change is needed for terraform support, the goal of #26955 is to provide the ability to add tags to VM instances and supporting infrastructure using both the UI and terraform. 

This bump increases the minor version of RKE1 from `3` to `4`. As far as I can tell this is okay, and haven't seen any issues with it, but let me know if there is a reason why we do not want to pull in `1.4` and want to stick with `1.3`.

## Engineering Testing
### Manual Testing
I created an RKE1 cluster without issue


Note: Currently, terraform still pulls its Rancher dependencies from v2.6. I'm holding off on raising a similar PR to v2.7 as 
1.  v2.7 is in code freeze 
2. The missing field / RKE bump will very likely be handled during the release process
3. terraform doesn't pull its dependencies from v2.7, so it is not a blocker for the Azure node templates issue.
