### PR TITLE
[release/v2.7] Fix scripts references for 2.7

### DIFF
--- a/scripts/change-final-rc-values
+++ b/scripts/change-final-rc-values
@@ -6,12 +6,12 @@ fi
 
 case $RELEASE_ACTION in
   release)
-    CURRENT_BRANCH="dev-v2.6"
-    NEW_BRANCH="release-v2.6"
+    CURRENT_BRANCH="dev-v2.7"
+    NEW_BRANCH="release-v2.7"
     ;;
   revert)
-    CURRENT_BRANCH="release-v2.6"
-    NEW_BRANCH="dev-v2.6"
+    CURRENT_BRANCH="release-v2.7"
+    NEW_BRANCH="dev-v2.7"
     ;;
   *)
     echo "Not a valid RELEASE_ACTION (${RELEASE_ACTION}), needs to be 'release' or 'revert'"
@@ -21,9 +21,9 @@ esac
 echo "RELEASE_ACTION is ${RELEASE_ACTION}"
 echo "Going to change ${CURRENT_BRANCH} to ${NEW_BRANCH}"
 
-# scripts/package
+# scripts/package-env
 for PKGENV in SYSTEM_CHART_DEFAULT_BRANCH CHART_DEFAULT_BRANCH; do
-   sed -i "/^${PKGENV}/ s/${CURRENT_BRANCH}/${NEW_BRANCH}/" scripts/package
+   sed -i "/^${PKGENV}/ s/${CURRENT_BRANCH}/${NEW_BRANCH}/" scripts/package-env
 done
 
 # package/Dockerfile

--- a/scripts/check-chart-kdm-source-values
+++ b/scripts/check-chart-kdm-source-values
@@ -4,10 +4,10 @@
 
 case $RELEASE_TYPE in
   rc)
-    REQUIRED_VALUE="dev-v2.6"
+    REQUIRED_VALUE="dev-v2.7"
     ;;
   final-rc)
-    REQUIRED_VALUE="release-v2.6"
+    REQUIRED_VALUE="release-v2.7"
     ;;
 esac
 
@@ -16,18 +16,18 @@ if [ -n "${RELEASE_TYPE}" ]; then
    echo "Going to check for ${REQUIRED_VALUE}"
 fi
 
-# scripts/package
+# scripts/package-env
 for PKGENV in SYSTEM_CHART_DEFAULT_BRANCH CHART_DEFAULT_BRANCH; do
-   FOUND_VALUE=$(grep ^${PKGENV} scripts/package | awk -F':-' '{ print $2 }' | sed 's/.$//' | sed 's/"//g')
+   FOUND_VALUE=$(grep ^${PKGENV} scripts/package-env | awk -F':-' '{ print $2 }' | sed 's/.$//' | sed 's/"//g')
    if [ -n "${RELEASE_TYPE}" ]; then
-      echo -n "${PKGENV}: ${FOUND_VALUE} in scripts/package: "
+      echo -n "${PKGENV}: ${FOUND_VALUE} in scripts/package-env: "
       if [ "${FOUND_VALUE}" != "${REQUIRED_VALUE}" ]; then
         echo "INCORRECT (should be ${REQUIRED_VALUE})"
       else
         echo "CORRECT"
       fi
    else
-      echo "* ${PKGENV}: ${FOUND_VALUE} (\`scripts/package\`)"
+      echo "* ${PKGENV}: ${FOUND_VALUE} (\`scripts/package-env\`)"
    fi
 done
 


### PR DESCRIPTION
* `scripts/package` variables were changed to `scripts/package-env` in https://github.com/rancher/rancher/pull/39191
* Other `scripts` reference to 2.6 changed to 2.7