### PR TITLE
[v2.7] Add Configuration Hooks for ProvV2

### DIFF
--- a/pkg/apis/provisioning.cattle.io/v1/rke.go
+++ b/pkg/apis/provisioning.cattle.io/v1/rke.go
@@ -28,6 +28,7 @@ type RKEMachinePool struct {
 	MaxUnhealthy                 *string                      `json:"maxUnhealthy,omitempty"`
 	UnhealthyRange               *string                      `json:"unhealthyRange,omitempty"`
 	MachineOS                    string                       `json:"machineOS,omitempty"`
+	Hooks                        []string                     `json:"hooks,omitempty"`
 }
 
 type RKEMachinePoolRollingUpdate struct {

--- a/pkg/apis/provisioning.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/provisioning.cattle.io/v1/zz_generated_deepcopy.go
@@ -288,6 +288,11 @@ func (in *RKEMachinePool) DeepCopyInto(out *RKEMachinePool) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Hooks != nil {
+		in, out := &in.Hooks, &out.Hooks
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
@@ -645,7 +645,7 @@ func constructFilesSecret(driver string, config map[string]interface{}) *corev1.
 					fileName = "id_rsa"
 				}
 
-				// The ending newline gets stripped, add em back
+				// The ending newline gets stripped, add them back
 				if !strings.HasSuffix(fileContents, "\n") {
 					fileContents = fileContents + "\n"
 				}

--- a/pkg/provisioningv2/rke2/installer/hooks.go
+++ b/pkg/provisioningv2/rke2/installer/hooks.go
@@ -1,0 +1,33 @@
+package installer
+
+// GetLinuxHook accepts a string indicating a hooks name
+// and returns the value of that hook. If the given
+// name does not belong to any defined hooks then an
+// empty string is returned.
+func GetLinuxHook(hookName string) string {
+	switch hookName {
+	case "disable-network-manager-cloud-setup":
+		return disableNetworkManagerCloudSetupHook()
+	}
+	return ""
+}
+
+// GetWindowsHook accepts a string indicating a hooks name
+// and returns the value of that hook. If the given
+// name does not belong to any defined hooks then any
+// empty string is returned.
+func GetWindowsHook(hookName string) string {
+	return "" // additional hooks for Windows systems can be defined here.
+}
+
+// disableNetworkManagerCloudSetupHook returns two commands
+// which disable the nm-cloud-setup.timer & nm-cloud-setup.service
+// processes if they are present on a linux system. These services
+// interfere with CNI's on some OS's, such as RHEL. This
+// hook will have no effect if the services are not present on the system.
+func disableNetworkManagerCloudSetupHook() string {
+	return `
+sudo systemctl list-units --all | grep -Fq nm-cloud-setup.timer; if [ $? -eq 0 ]; then sudo systemctl disable nm-cloud-setup.timer; fi
+sudo systemctl list-units --all | grep -Fq nm-cloud-setup.service; if [ $? -eq 0 ]; then sudo systemctl disable nm-cloud-setup.service; fi
+`
+}

--- a/pkg/provisioningv2/rke2/installer/installer.go
+++ b/pkg/provisioningv2/rke2/installer/installer.go
@@ -55,7 +55,7 @@ func installScript(setting settings.Setting, files []string) ([]byte, error) {
 	return ioutil.ReadAll(resp.Body)
 }
 
-func LinuxInstallScript(ctx context.Context, token string, envVars []corev1.EnvVar, defaultHost string) ([]byte, error) {
+func LinuxInstallScript(ctx context.Context, token string, envVars []corev1.EnvVar, defaultHost string, hooks []string) ([]byte, error) {
 	data, err := installScript(
 		settings.SystemAgentInstallScript,
 		localAgentInstallScripts)
@@ -91,18 +91,34 @@ func LinuxInstallScript(ctx context.Context, token string, envVars []corev1.EnvV
 	if settings.ServerURL.Get() != "" {
 		server = fmt.Sprintf("CATTLE_SERVER=%s", settings.ServerURL.Get())
 	}
+
+	// build all the user defined hooks. Each hook is a set of commands
+	// that can be used to configure a node.
+	// Each hook will be added in the following format
+	//
+	// #HOOK_NAME
+	// HOOK_VALUE
+	combinedHooks := ""
+	if len(hooks) > 0 {
+		combinedHooks = "#user specified hooks\n"
+		for _, hookName := range hooks {
+			if hookValue := GetLinuxHook(hookName); hookValue != "" {
+				combinedHooks = fmt.Sprintf("%s\n#%s%s", combinedHooks, hookName, hookValue)
+			}
+		}
+	}
 	return []byte(fmt.Sprintf(`#!/usr/bin/env sh
 %s
 %s
 %s
 %s
 %s
-
 %s
-`, envVarBuf.String(), binaryURL, server, ca, token, data)), nil
+%s
+`, combinedHooks, envVarBuf.String(), binaryURL, server, ca, token, data)), nil
 }
 
-func WindowsInstallScript(ctx context.Context, token string, envVars []corev1.EnvVar, defaultHost string) ([]byte, error) {
+func WindowsInstallScript(ctx context.Context, token string, envVars []corev1.EnvVar, defaultHost string, hooks []string) ([]byte, error) {
 	data, err := installScript(
 		settings.WinsAgentInstallScript,
 		localWindowsRke2InstallScripts)
@@ -152,8 +168,24 @@ func WindowsInstallScript(ctx context.Context, token string, envVars []corev1.En
 		server = fmt.Sprintf("$env:CATTLE_SERVER=\"%s\"", settings.ServerURL.Get())
 	}
 
+	// build all the user defined hooks. Each hook is a set of commands
+	// that can be used to configure a node.
+	// Each hook will be added in the following format
+	//
+	// #HOOK_NAME
+	// HOOK_VALUE
+	combinedHooks := ""
+	if len(hooks) > 0 {
+		combinedHooks = "#user specified hooks\n"
+		for _, hookName := range hooks {
+			if hookValue := GetWindowsHook(hookName); hookValue != "" {
+				combinedHooks = fmt.Sprintf("%s\n#%s%s", combinedHooks, hookName, hookValue)
+			}
+		}
+	}
 	return []byte(fmt.Sprintf(`%s
 
+%s
 %s
 %s
 %s
@@ -167,5 +199,5 @@ $env:CSI_PROXY_KUBELET_PATH = "C:/var/lib/rancher/rke2/bin/kubelet.exe"
 
 Invoke-WinsInstaller @PSBoundParameters
 exit 0
-`, data, envVarBuf.String(), binaryURL, server, ca, token, csiProxyURL, csiProxyVersion)), nil
+`, data, combinedHooks, envVarBuf.String(), binaryURL, server, ca, token, csiProxyURL, csiProxyVersion)), nil
 }

--- a/pkg/provisioningv2/rke2/installer/installer_test.go
+++ b/pkg/provisioningv2/rke2/installer/installer_test.go
@@ -27,7 +27,7 @@ func TestInstaller_WindowsInstallScript(t *testing.T) {
 
 	CACertEncoded := systemtemplate.CAChecksum()
 
-	script, err := WindowsInstallScript(context.TODO(), "test", []corev1.EnvVar{}, "localhost")
+	script, err := WindowsInstallScript(context.TODO(), "test", []corev1.EnvVar{}, "localhost", nil)
 
 	// assert
 	a.Nil(err)

--- a/pkg/provisioningv2/rke2/installer/server.go
+++ b/pkg/provisioningv2/rke2/installer/server.go
@@ -14,9 +14,9 @@ func (s *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	switch req.URL.Path {
 	case SystemAgentInstallPath:
-		content, err = LinuxInstallScript(req.Context(), "", nil, req.Host)
+		content, err = LinuxInstallScript(req.Context(), "", nil, req.Host, nil)
 	case WindowsRke2InstallPath:
-		content, err = WindowsInstallScript(req.Context(), "", nil, req.Host)
+		content, err = WindowsInstallScript(req.Context(), "", nil, req.Host, nil)
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/38790
 
## Problem
When provisioning nodes using the RHEL operating system the node will fail to fully provision due to two NetworkManager services interfering with the CNI's configuration. This results in the node indefinitely staying in the `Waiting for probes` stage (or some other similar failure condition). This issue was fixed for RKE1 clusters via change in `rancher-machine` (see https://github.com/rancher/rancher/issues/36526). However, this solution is not applicable for ProvV2 as all configuration is done via cloud-init. 
 
## Solution
Allow the user to specify predefined configuration _hooks_ within the yaml of a machine pool. These hooks denote particular commands that will be added to the install script passed to the downstream node. Currently, cloud-init is used to install the rancher system-agent for ProvV2. This PR adds additional commands after the installation of the agent is complete. 

The contents of each hook are defined within Rancher source code, ensuring that arbitrary commands cannot be injected within the cloud-init script. The included hook performs the same configuration step that is performed when provisioning RKE1 clusters using RHEL, which allows the default RHEL AMI to be used without any prior configuration. More hooks can be added as needed, so other pre-configuration issues with particular OS's can be automatically resolved. 

When building the install script, Rancher does not know what particular OS is being used, so these hooks must be manually configured. This differs from the behavior of RKE1 provisioning, however from what I am able to tell it cannot be avoided. 

To use these new hooks the user must modify the YAML of a particular machine pool to denote which hooks should be applied to the install script. For example, the following YAML will disable the `nm-cloud-setup.service` and `nm-cloud-setup.timer` using `systemctl`.

```yaml
machinePools:
    - controlPlaneRole: true
      etcdRole: true
      hooks:
      - disable-network-manager
      machineConfigRef:
        kind: <CONFIG_TYPE>
        name: <CONFIG_NAME>
      name: <POOL_NAME>
      quantity: 1
      unhealthyNodeTimeout: 0s
      workerRole: true
```
 
Specifying this hook will add the following logic to the install script, after the system-agent is installed.
```
sudo systemctl list-units --all | grep -Fq nm-cloud-setup.timer; if [ $? -eq 0 ]; then sudo systemctl disable nm-cloud-setup.timer; fi
sudo systemctl list-units --all | grep -Fq nm-cloud-setup.service; if [ $? -eq 0 ]; then sudo systemctl disable nm-cloud-setup.service; fi
```

Machines must be reprovisioned/recreated if this hook is added to the YAML after a machine has already been created in an infrastructure provider. 

## Testing
+ Begin to create an RKE2 cluster within the Rancher UI
+ Create three machine pools
   + Two of the pools will use a RHEL AMI. One pool should have the `etcd` and `control-plane` roles and the other should just have the `worker` role. 
   + One of the pools will use the default Ubuntu AMI. This pool should just have the `worker` role. 
+ After creating the three pools, click on the `Edit as YAML` button in the lower right hand corner
+ Add the `disable-network-manager` hook to the first pool configured with a RHEL AMI, do not define any hooks for the other two pools
+ Create the cluster after modifying the YAML 
+ Observe that the RHEL pool with the hook defined provisions and becomes available, and that the RHEL pool which does not have the hook defined does not come up or become available. Ensure that the Ubuntu pool comes up and becomes without the need to specify any hooks. 


## Engineering Testing
### Manual Testing
I've done the above testing and have used the new hook to provision a new RHEL 8.6 cluster. I observed it come up and become useable. Machine pools within the same cluster which did not have this hook specified did not come up successfully, as expected. Machine pools which used OS's which did not need any pre-configuration were provisioned and became available as expected.

## QA Testing Considerations
This fix should address many RHEL versions which do not provision successfully by default, so testing should not be limited to just RHEL 8.6. 
 
### Regressions Considerations
None that I can think of. 