### PR TITLE
kubectl-websocket-fix

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -2642,7 +2642,7 @@ def create_connection(url, subprotocols):
         url=url,
         sslopt={"cert_reqs": ssl.CERT_NONE},
         subprotocols=subprotocols,
-        timeout=10,
+        timeout=20,
         cookie="R_SESS=" + USER_TOKEN
     )
     assert ws.connected, "failed to build the websocket"


### PR DESCRIPTION
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

test_websocket_launch_kubectl was failing with timeout when running with the other tests. 

## Solution
Increasing the timeout fixed the error.