### PR TITLE
[WIP][2.6] Encode '+' character when download tgz file

### DIFF
--- a/pkg/catalogv2/http/download.go
+++ b/pkg/catalogv2/http/download.go
@@ -76,12 +76,12 @@ func Chart(secret *corev1.Secret, repoURL string, caBundle []byte, insecureSkipT
 	}
 	defer client.CloseIdleConnections()
 
-	u, err := url.Parse(chart.URLs[0])
+	u, err := url.Parse(getEncodedSpaceAndPlusURL(chart.URLs[0]))
 	if err != nil {
 		return nil, err
 	}
 	if !u.IsAbs() {
-		base, err := url.Parse(repoURL)
+		base, err := url.Parse(getEncodedSpaceAndPlusURL(repoURL))
 		if err != nil {
 			return nil, err
 		}
@@ -152,4 +152,13 @@ func DownloadIndex(secret *corev1.Secret, repoURL string, caBundle []byte, insec
 	}
 
 	return index, nil
+}
+
+// getEncodedSpaceAndPlusURL replaces the ' ' (space) and '+' character in URL to %20 and %2B
+// to avoid the '+' is treated as encoded space when using the functions in net/url package.
+func getEncodedSpaceAndPlusURL(u string) string {
+	u = strings.Trim(u, " ")
+	u = strings.ReplaceAll(u, "+", "%2B")
+	u = strings.ReplaceAll(u, " ", "%20")
+	return u
 }


### PR DESCRIPTION
The '+' character in URL is treated as encoded character ' ' (space) when calling `url.String()`, and some chart version is formatted with `100.0.0+up1.0.0`, so replace the character `+` to `%2B`.

## Issue: https://github.com/rancher/rancher/issues/39465
 
## Solution
Replace `+` character in url to `%2B` when downloading tgz tarball from helm repo.

Example:
from `https://<server>/assets/rancher-aks-operator/rancher-aks-operator-100.0.6+up1.0.7.tgz` 
to `https://<server>/assets/rancher-aks-operator/rancher-aks-operator-100.0.6%2Bup1.0.7.tgz`
