### PR TITLE
[release/v2.7] Set force cgroup env for k3s agent as well

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -39,7 +39,12 @@ eval "$(grep '^ENV CATTLE_WINS_AGENT' package/Dockerfile | awk '{print "export "
 eval "$(grep '^ENV CATTLE_CSI_PROXY_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 eval "$(grep '^ENV CATTLE_KDM_BRANCH' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 
-export SOME_K8S_VERSION=$(curl https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.6/data/data.json | jq -r ".$DIST.channels[0].latest")
+if [ "$DIST" = "rke2" ]; then
+    export SOME_K8S_VERSION="v1.22.13+rke2r1"
+else
+    export SOME_K8S_VERSION=$(curl https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.6/data/data.json | jq -r ".$DIST.channels[0].latest")
+fi
+
 echo "Starting rancher server for provisioning-tests using $SOME_K8S_VERSION"
 touch /tmp/rancher.log
 

--- a/tests/integration/pkg/nodeconfig/nodeconfig.go
+++ b/tests/integration/pkg/nodeconfig/nodeconfig.go
@@ -99,6 +99,10 @@ write_files:
     Type=exec
   path: /etc/systemd/system/k3s.service.d/10-delegate.conf
 - content: |
+    [Service]
+    Type=exec
+  path: /etc/systemd/system/k3s-agent.service.d/10-delegate.conf
+- content: |
     NOTIFY_SOCKET=
     INVOCATION_ID=
   path: /etc/default/rke2-server
@@ -109,7 +113,12 @@ write_files:
 - content: |
     NOTIFY_SOCKET=
     INVOCATION_ID=
-  path: /etc/default/k3s`
+  path: /etc/default/k3s
+- content: |
+    NOTIFY_SOCKET=
+    INVOCATION_ID=
+  path: /etc/default/k3s-agent`
+
 	podConfigClient := clients.Dynamic.Resource(schema.GroupVersionResource{
 		Group:    "rke-machine-config.cattle.io",
 		Version:  "v1",

--- a/tests/integration/pkg/systemdnode/systemnode.go
+++ b/tests/integration/pkg/systemdnode/systemnode.go
@@ -109,6 +109,11 @@ INVOCATION_ID=
 					},
 					{
 						Name:      "systemd",
+						MountPath: "/usr/local/lib/systemd/system/k3s-agent.service.d/10-delegate.conf",
+						SubPath:   "dropin",
+					},
+					{
+						Name:      "systemd",
 						MountPath: "/etc/default/rke2-server",
 						SubPath:   "disable",
 					},
@@ -120,6 +125,11 @@ INVOCATION_ID=
 					{
 						Name:      "systemd",
 						MountPath: "/etc/default/k3s",
+						SubPath:   "disable",
+					},
+					{
+						Name:      "systemd",
+						MountPath: "/etc/default/k3s-agent",
 						SubPath:   "disable",
 					},
 				},


### PR DESCRIPTION
* k3s agent setup changed systemd detection in https://github.com/k3s-io/k3s/pull/5851, and the version that gets determined to test in KDM got bumped was bumped to version that includes that fix (backported). This started to fail the tests.
* the system-agent-installer-rke2 image built for the version that got bumped in KDM does not contain all artifacts, so the test would never succeed (rancher-system-agent -> plan -> extract from image -> failing to find checksum file). You can see the curl failures in the build for the image https://drone-publish.rancher.io/rancher/system-agent-installer-rke2/286/1/2

Logs from rancher-system-agent:

```
Nov 02 13:07:21 test-single-node-all-roles-with-delete-pool-0-6aadef12-f9hhh rancher-system-agent[243]: time="2022-11-02T13:07:21Z" level=info msg="[844eab03640474361066edd13c7723c4ad3cc409d72a02b7eec1a60af1dbb8a6_0:stdout]: [INFO]  staging local checksums from /var/lib/rancher/agent/work/20221102-130720/844eab03640474361066edd13c7723c4ad3cc409d72a02b7eec1a60af1dbb8a6_0/sha256sum-amd64.txt"
Nov 02 13:07:21 test-single-node-all-roles-with-delete-pool-0-6aadef12-f9hhh rancher-system-agent[243]: time="2022-11-02T13:07:21Z" level=info msg="[844eab03640474361066edd13c7723c4ad3cc409d72a02b7eec1a60af1dbb8a6_0:stderr]: cp: cannot stat '/var/lib/rancher/agent/work/20221102-130720/844eab03640474361066edd13c7723c4ad3cc409d72a02b7eec1a60af1dbb8a6_0/sha256sum-amd64.txt': No such file or directory" 
Nov 02 13:07:21 test-single-node-all-roles-with-delete-pool-0-6aadef12-f9hhh rancher-system-agent[243]: time="2022-11-02T13:07:21Z" level=info msg="[Applyinator] Command sh [-c run.sh] finished with err: <nil> and exit code: 1"
```