### PR TITLE
Add validation test for etcd backup and restore with k8s upgrade

### DIFF
--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	ProvisioningSteveResouceType = "provisioning.cattle.io.cluster"
+	FleetSteveResourceType       = "fleet.cattle.io.cluster"
 )
 
 // GetClusterIDByName is a helper function that returns the cluster ID by name

--- a/tests/framework/extensions/workloads/template.go
+++ b/tests/framework/extensions/workloads/template.go
@@ -1,7 +1,9 @@
 package workloads
 
 import (
+	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NewContainer is a contructor that creates a container for a pod template i.e. corev1.PodTemplateSpec
@@ -16,12 +18,31 @@ func NewContainer(containerName, image string, imagePullPolicy corev1.PullPolicy
 }
 
 // NewPodTemplate is a constructor that creates the pod template for all types of workloads e.g. cronjobs, daemonsets, deployments, and batch jobs
-func NewPodTemplate(containers []corev1.Container, volumes []corev1.Volume, imagePullSecrets []corev1.LocalObjectReference) corev1.PodTemplateSpec {
+func NewPodTemplate(containers []corev1.Container, volumes []corev1.Volume, imagePullSecrets []corev1.LocalObjectReference, labels map[string]string) corev1.PodTemplateSpec {
 	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: labels,
+		},
 		Spec: corev1.PodSpec{
 			Containers:       containers,
 			Volumes:          volumes,
 			ImagePullSecrets: imagePullSecrets,
 		},
 	}
+}
+
+func NewDeploymentTemplate(deploymentName string, namespace string, podSpec corev1.PodTemplateSpec, matchLabels map[string]string) *appv1.Deployment {
+	return &appv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: namespace,
+		},
+		Spec: appv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: matchLabels,
+			},
+			Template: podSpec,
+		},
+	}
+
 }

--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
@@ -1,0 +1,189 @@
+package rke2
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rancher/norman/types"
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
+	"github.com/sirupsen/logrus"
+	appv1 "k8s.io/api/apps/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	localClusterName             = "local"
+	wloadBeforeRestore           = "wload-before-restore"
+	ingressName                  = "ingress"
+	wloadServiceName             = "wload-service"
+	wloadAfterRestore            = "wload-after-restore"
+	ProvisioningSteveResouceType = "provisioning.cattle.io.cluster"
+)
+
+func createSnapshot(client *rancher.Client, clustername string, generation int, namespace string) error {
+	clusterObj, existingSteveAPIObj, err := getProvisioningClusterByName(client, clustername, namespace)
+	if err != nil {
+		return err
+	}
+
+	clusterObj.Spec.RKEConfig.ETCDSnapshotCreate = &rkev1.ETCDSnapshotCreate{
+		Generation: generation,
+	}
+
+	_, err = client.Steve.SteveType(clusters.ProvisioningSteveResouceType).Update(existingSteveAPIObj, clusterObj)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func restoreSnapshot(client *rancher.Client, clustername string, name string,
+	generation int, restoreconfig string, namespace string) error {
+
+	clusterObj, existingSteveAPIObj, err := getProvisioningClusterByName(client, clustername, namespace)
+	if err != nil {
+		return err
+	}
+
+	clusterObj.Spec.RKEConfig.ETCDSnapshotRestore = &rkev1.ETCDSnapshotRestore{
+		Name:             name,
+		Generation:       generation,
+		RestoreRKEConfig: restoreconfig,
+	}
+
+	_, err = client.Steve.SteveType(clusters.ProvisioningSteveResouceType).Update(existingSteveAPIObj, clusterObj)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getSnapshots(client *rancher.Client,
+	localClusterID string) ([]v1.SteveAPIObject, error) {
+
+	steveclient, err := client.Steve.ProxyDownstream(localClusterID)
+	if err != nil {
+		return nil, err
+	}
+	snapshotSteveObjList, err := steveclient.SteveType("rke.cattle.io.etcdsnapshot").List(&types.ListOpts{})
+	if err != nil {
+		return nil, err
+	}
+
+	return snapshotSteveObjList.Data, nil
+
+}
+
+func createRKE2NodeDriverCluster(client *rancher.Client, provider *Provider, clusterName string, k8sVersion string, namespace string, cni string) (*v1.SteveAPIObject, error) {
+
+	nodeRoles := []machinepools.NodeRoles{
+		{
+			ControlPlane: true,
+			Etcd:         false,
+			Worker:       false,
+			Quantity:     2,
+		},
+		{
+			ControlPlane: false,
+			Etcd:         true,
+			Worker:       false,
+			Quantity:     3,
+		},
+		{
+			ControlPlane: false,
+			Etcd:         false,
+			Worker:       true,
+			Quantity:     3,
+		},
+	}
+
+	cloudCredential, err := provider.CloudCredFunc(client)
+	if err != nil {
+		return nil, err
+	}
+	generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
+	machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
+
+	machineConfigResp, err := client.Steve.SteveType(provider.MachineConfigPoolResourceSteveType).Create(machinePoolConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	machinePools := machinepools.RKEMachinePoolSetup(nodeRoles, machineConfigResp)
+
+	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, k8sVersion, machinePools)
+
+	return clusters.CreateK3SRKE2Cluster(client, cluster)
+
+}
+
+func getProvisioningClusterByName(client *rancher.Client, clusterName string, namespace string) (*apisV1.Cluster, *v1.SteveAPIObject, error) {
+	clusterObj, err := client.Steve.SteveType(ProvisioningSteveResouceType).ByID(namespace + "/" + clusterName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cluster := new(apisV1.Cluster)
+	err = v1.ConvertToK8sType(clusterObj, &cluster)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cluster, clusterObj, nil
+}
+
+func upgradeClusterK8sVersion(client *rancher.Client, clustername string, k8sUpgradedVersion string, namespaceName string) error {
+	clusterObj, existingSteveAPIObj, err := getProvisioningClusterByName(client, clustername, namespaceName)
+	if err != nil {
+		return err
+	}
+
+	clusterObj.Spec.KubernetesVersion = k8sUpgradedVersion
+
+	_, err = client.Steve.SteveType(clusters.ProvisioningSteveResouceType).Update(existingSteveAPIObj, clusterObj)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createDeployment(deployment *appv1.Deployment, steveclient *v1.Client, client *rancher.Client, clusterID string) (*v1.SteveAPIObject, error) {
+	deploymentResp2, err := steveclient.SteveType(workloads.DeploymentSteveType).Create(deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("created a deployment(%v, deployment).............", deployment.Name)
+
+	logrus.Infof("creating watch over w2.............")
+	err = kwait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+		steveclient, err := client.Steve.ProxyDownstream(clusterID)
+		if err != nil {
+			return false, nil
+		}
+		deploymentResp, err := steveclient.SteveType(workloads.DeploymentSteveType).ByID(deployment.Namespace + "/" + deployment.Name)
+		if err != nil {
+			return false, nil
+		}
+		deployment := &appv1.Deployment{}
+		err = v1.ConvertToK8sType(deploymentResp.JSONResp, deployment)
+		if err != nil {
+			return false, nil
+		}
+		if *deployment.Spec.Replicas == deployment.Status.AvailableReplicas {
+			return true, nil
+		}
+		return false, nil
+	})
+	return deploymentResp2, err
+
+}

--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
@@ -1,0 +1,323 @@
+package rke2
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	provisioningV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/ingresses"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubeProvisioning "github.com/rancher/rancher/tests/framework/clients/provisioning"
+	networkingv1 "k8s.io/api/networking/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	defaultNamespace = "default"
+)
+
+type RKE2EtcdSnapshotRestoreTestSuite struct {
+	suite.Suite
+	session            *session.Session
+	client             *rancher.Client
+	ns                 string
+	kubernetesVersions []string
+	cnis               []string
+	providers          []string
+	nodesAndRoles      []machinepools.NodeRoles
+}
+
+func (r *RKE2EtcdSnapshotRestoreTestSuite) TearDownSuite() {
+	r.session.Cleanup()
+}
+
+func (r *RKE2EtcdSnapshotRestoreTestSuite) SetupSuite() {
+	testSession := session.NewSession(r.T())
+	r.session = testSession
+
+	r.ns = defaultNamespace
+
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+
+	r.kubernetesVersions = clustersConfig.KubernetesVersions
+	r.cnis = clustersConfig.CNIs
+	r.providers = clustersConfig.Providers
+	r.nodesAndRoles = clustersConfig.NodesAndRoles
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(r.T(), err)
+
+	r.client = client
+
+}
+
+func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithK8sUpgrade(provider *Provider) {
+	initialK8sVersion := r.kubernetesVersions[0]
+	logrus.Infof("running etcd snapshot restore test.............")
+	subSession := r.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := r.client.WithSession(subSession)
+	require.NoError(r.T(), err)
+
+	logrus.Infof("creating kube provisioning client.............")
+	kubeProvisioningClient, err := r.client.GetKubeAPIProvisioningClient()
+	require.NoError(r.T(), err)
+	logrus.Infof("kube provisioning client created.............")
+
+	clusterName := provisioning.AppendRandomString(provider.Name)
+
+	logrus.Infof("creating rke2Cluster.............")
+	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0])
+	require.NoError(r.T(), err)
+	require.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
+	logrus.Infof("rke2Cluster create request successful.............")
+
+	logrus.Infof("creating watch over cluster.............")
+	r.watchAndWaitForCluster(kubeProvisioningClient, clusterName)
+	logrus.Infof("cluster is up and running.............")
+
+	// Get clusterID by clusterName
+	logrus.Info("getting cluster id.............")
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(r.T(), err)
+	logrus.Info("got cluster id.............", clusterID)
+
+	logrus.Info("getting local cluster id.............")
+	localClusterID, err := clusters.GetClusterIDByName(client, localClusterName)
+	require.NoError(r.T(), err)
+	logrus.Info("got local cluster id.............", localClusterID)
+
+	logrus.Infof("creating watch over pods.............")
+	r.watchAndWaitForPods(client, clusterID)
+	logrus.Infof("All pods are up and running.............")
+
+	// creating the workload W1
+	logrus.Infof("creating a workload(nginx deployment).............")
+
+	wloadBeforeRestoreLabels := map[string]string{}
+	wloadBeforeRestoreLabels["workload.user.cattle.io/workloadselector"] = fmt.Sprintf("apps.deployment-%v-%v", r.ns, wloadBeforeRestore)
+
+	containerTemplate := workloads.NewContainer("ngnix", "nginx", v1.PullAlways, []v1.VolumeMount{}, []v1.EnvFromSource{})
+	podTemplate := workloads.NewPodTemplate([]v1.Container{containerTemplate}, []v1.Volume{}, []v1.LocalObjectReference{}, wloadBeforeRestoreLabels)
+	deploymentBeforeBackup := workloads.NewDeploymentTemplate(wloadBeforeRestore, r.ns, podTemplate, wloadBeforeRestoreLabels)
+
+	// creating steve client
+	steveclient, err := client.Steve.ProxyDownstream(clusterID)
+	require.NoError(r.T(), err)
+
+	deploymentResp, err := createDeployment(deploymentBeforeBackup, steveclient, client, clusterID)
+	require.NoError(r.T(), err)
+	require.Equal(r.T(), deploymentBeforeBackup.Name, deploymentResp.ObjectMeta.Name)
+	logrus.Infof("%v is ready.............", deploymentBeforeBackup.Name)
+
+	// creating the ingress1
+	logrus.Infof("creating an ingress.............")
+
+	exactPath := networkingv1.PathTypeExact
+	paths := []networkingv1.HTTPIngressPath{
+		{
+			Path:     "/index.html",
+			PathType: &exactPath,
+			Backend: networkingv1.IngressBackend{
+				Service: &networkingv1.IngressServiceBackend{
+					Name: wloadServiceName,
+					Port: networkingv1.ServiceBackendPort{
+						Number: 80,
+					},
+				},
+			},
+		},
+	}
+	ingressBeforeBackup := ingresses.NewIngressTemplate(ingressName, r.ns, "", paths)
+
+	ingressResp, err := steveclient.SteveType(ingresses.IngressSteveType).Create(ingressBeforeBackup)
+	require.NoError(r.T(), err)
+
+	require.Equal(r.T(), ingressName, ingressResp.ObjectMeta.Name)
+	logrus.Infof("created an ingress.............")
+
+	logrus.Infof("creating a snapshot of the cluster.............")
+	err = createSnapshot(client, clusterName, 1, r.ns)
+	require.NoError(r.T(), err)
+	logrus.Infof("created a snapshot of the cluster.............")
+
+	logrus.Infof("creating watch over cluster after creating a snapshot.............")
+	r.watchAndWaitForCluster(kubeProvisioningClient, clusterName)
+	logrus.Infof("cluster is active again.............")
+
+	var snapshotToBeRestored string
+
+	err = kwait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+		snapshotList, err := getSnapshots(client, localClusterID)
+		if err != nil {
+			return false, err
+		}
+		totalClusterSnapShots := 0
+		for _, snapshot := range snapshotList {
+			if strings.Contains(snapshot.ObjectMeta.Name, clusterName) {
+				if snapshotToBeRestored == "" {
+					snapshotToBeRestored = snapshot.Name
+				}
+				totalClusterSnapShots++
+			}
+		}
+		if totalClusterSnapShots == etcdnodeCount {
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(r.T(), err)
+
+	logrus.Infof("creating a workload(w2, deployment).............")
+	wloadAfterBackupLabels := map[string]string{}
+	wloadAfterBackupLabels["workload.user.cattle.io/workloadselector"] = fmt.Sprintf("apps.deployment-%v-%v", r.ns, wloadAfterRestore)
+	containerTemplate2 := workloads.NewContainer("ngnix", "nginx", v1.PullAlways, []v1.VolumeMount{}, []v1.EnvFromSource{})
+	podTemplate2 := workloads.NewPodTemplate([]v1.Container{containerTemplate2}, []v1.Volume{}, []v1.LocalObjectReference{}, wloadAfterBackupLabels)
+	deploymentAfterBackup := workloads.NewDeploymentTemplate(wloadAfterRestore, r.ns, podTemplate2, wloadAfterBackupLabels)
+
+	deploymentResp, err = createDeployment(deploymentAfterBackup, steveclient, client, clusterID)
+	require.NoError(r.T(), err)
+	require.Equal(r.T(), deploymentAfterBackup.Name, deploymentResp.ObjectMeta.Name)
+	logrus.Infof("%v is ready.............", deploymentAfterBackup.Name)
+
+	logrus.Infof("upgrading cluster k8s version.............")
+	k8sUpgradedVersion := r.kubernetesVersions[1]
+	err = upgradeClusterK8sVersion(client, clusterName, k8sUpgradedVersion, r.ns)
+	require.NoError(r.T(), err)
+	r.watchAndWaitForCluster(kubeProvisioningClient, clusterName)
+	logrus.Infof("cluster is active again.............")
+
+	cluster, _, err := getProvisioningClusterByName(client, clusterName, r.ns)
+	require.NoError(r.T(), err)
+	require.Equal(r.T(), k8sUpgradedVersion, cluster.Spec.KubernetesVersion)
+
+	logrus.Infof("restoring snapshot.............")
+	require.NoError(r.T(), restoreSnapshot(client, clusterName, snapshotToBeRestored, 1, "all", r.ns))
+	logrus.Infof("successfully submitted restoration request.............")
+
+	logrus.Infof("creating watch over cluster after restore.............")
+	r.watchAndWaitForCluster(kubeProvisioningClient, clusterName)
+	logrus.Infof("cluster is active again.............")
+
+	logrus.Infof("creating watch over pods.............")
+	r.watchAndWaitForPods(client, clusterID)
+	logrus.Infof("All pods are up and running.............")
+
+	logrus.Infof("fetching deployment list to validate restore.............")
+	deploymentList, err := steveclient.SteveType(workloads.DeploymentSteveType).List(&types.ListOpts{
+		Filters: map[string]interface{}{
+			"fieldSelector": "metadata.namespace=" + r.ns,
+		}})
+	require.NoError(r.T(), err)
+	require.Equal(r.T(), 1, len(deploymentList.Data))
+	require.Equal(r.T(), wloadBeforeRestore, deploymentList.Data[0].ObjectMeta.Name)
+	logrus.Infof(" deployment list validated successfully.............")
+
+	logrus.Infof("fetching ingresses list to validate restore.............")
+	ingressResp, err = steveclient.SteveType(ingresses.IngressSteveType).ByID(r.ns + "/" + ingressBeforeBackup.Name)
+	require.NoError(r.T(), err)
+	require.NotNil(r.T(), ingressResp)
+	logrus.Infof("ingress validated successfully.............")
+
+	cluster, _, err = getProvisioningClusterByName(client, clusterName, r.ns)
+	require.NoError(r.T(), err)
+	require.Equal(r.T(), initialK8sVersion, cluster.Spec.KubernetesVersion)
+}
+
+func (r *RKE2EtcdSnapshotRestoreTestSuite) watchAndWaitForCluster(kubeProvisioningClient *kubeProvisioning.Client, clusterName string) {
+	err := kwait.Poll(5*time.Second, 2*time.Minute, func() (done bool, err error) {
+		clusterResp, err := r.client.Steve.SteveType(ProvisioningSteveResouceType).ByID(r.ns + "/" + clusterName)
+		if err != nil {
+			return false, err
+		}
+		state := clusterResp.ObjectMeta.State.Name
+		return state != "active", nil
+	})
+	require.NoError(r.T(), err)
+	logrus.Infof("waiting for cluster to be up.............")
+	result, err := kubeProvisioningClient.Clusters(r.ns).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + clusterName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	require.NoError(r.T(), err)
+
+	checkFunc := clusters.IsProvisioningClusterReady
+	err = wait.WatchWait(result, checkFunc)
+	require.NoError(r.T(), err)
+}
+
+func (r *RKE2EtcdSnapshotRestoreTestSuite) watchAndWaitForPods(client *rancher.Client, clusterID string) {
+	logrus.Infof("waiting for all Pods to be up.............")
+	err := kwait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+		steveClient, err := client.Steve.ProxyDownstream(clusterID)
+		if err != nil {
+			return false, nil
+		}
+		pods, err := steveClient.SteveType(pods.PodResourceSteveType).List(&types.ListOpts{})
+		if err != nil {
+			return false, nil
+		}
+		isIngressControllerPodPresent := false
+		isKubeControllerManagerPresent := false
+		for _, pod := range pods.Data {
+			podStatus := &v1.PodStatus{}
+			err = provisioningV1.ConvertToK8sType(pod.Status, podStatus)
+			if err != nil {
+				return false, err
+			}
+			if !isIngressControllerPodPresent && strings.Contains(pod.ObjectMeta.Name, "ingress-nginx-controller") {
+				isIngressControllerPodPresent = true
+			}
+			if !isKubeControllerManagerPresent && strings.Contains(pod.ObjectMeta.Name, "kube-controller-manager") {
+				isKubeControllerManagerPresent = true
+			}
+
+			phase := podStatus.Phase
+			if phase != v1.PodRunning && phase != v1.PodSucceeded {
+				return false, nil
+			}
+
+		}
+		if isIngressControllerPodPresent && isKubeControllerManagerPresent {
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(r.T(), err)
+}
+func TestEtcdSnapshotRestore(t *testing.T) {
+	suite.Run(t, new(RKE2EtcdSnapshotRestoreTestSuite))
+}
+
+func (r *RKE2EtcdSnapshotRestoreTestSuite) TestEtcdSnapshotRestoreWithK8sUpgrade() {
+	logrus.Infof("checking for valid k8s versions and cnis in the configuration....")
+	require.GreaterOrEqual(r.T(), len(r.kubernetesVersions), 2)
+	require.GreaterOrEqual(r.T(), len(r.cnis), 1)
+	for _, providerName := range r.providers {
+		provider := CreateProvider(providerName)
+		r.EtcdSnapshotRestoreWithK8sUpgrade(&provider)
+	}
+}

--- a/tests/v2/validation/provisioning/rke2/providers.go
+++ b/tests/v2/validation/provisioning/rke2/providers.go
@@ -20,6 +20,7 @@ const (
 	doProviderName        = "do"
 	harvesterProviderName = "harvester"
 	linodeProviderName    = "linode"
+	etcdnodeCount         = 3
 )
 
 type CloudCredFunc func(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error)

--- a/tests/v2/validation/upgrade/workload.go
+++ b/tests/v2/validation/upgrade/workload.go
@@ -97,7 +97,7 @@ func newTestContainerMinimal() corev1.Container {
 func newPodTemplateWithTestContainer() corev1.PodTemplateSpec {
 	testContainer := newTestContainerMinimal()
 	containers := []corev1.Container{testContainer}
-	return workloads.NewPodTemplate(containers, nil, nil)
+	return workloads.NewPodTemplate(containers, nil, nil, nil)
 }
 
 // newPodTemplateWithSecretVolume is a private constructor that returns pod template spec with volume option for workload creations
@@ -116,7 +116,7 @@ func newPodTemplateWithSecretVolume(secretName string) corev1.PodTemplateSpec {
 		},
 	}
 
-	return workloads.NewPodTemplate(containers, volumes, nil)
+	return workloads.NewPodTemplate(containers, volumes, nil, nil)
 }
 
 // newPodTemplateWithSecretEnvironmentVariable is a private constructor that returns pod template spec with envFrom option for workload creations
@@ -132,7 +132,7 @@ func newPodTemplateWithSecretEnvironmentVariable(secretName string) corev1.PodTe
 	container := workloads.NewContainer(containerName, containerImage, pullPolicy, nil, envFrom)
 	containers := []corev1.Container{container}
 
-	return workloads.NewPodTemplate(containers, nil, nil)
+	return workloads.NewPodTemplate(containers, nil, nil, nil)
 }
 
 // waitUntilIngressIsAccessible waits until the ingress is accessible


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/406
 
**Note:** 
- This validation test takes around 20 mins to complete which is more than default timeout for the test that's why we need to  use `-timeout` option with value either greater than 20mins or 0. Similar to below command
`go test providers.go etcd_bkp_restore_test.go -v -timeout 0`
- Also it will also require at least two k8s version in ascending order in the cattle config file and at least one CNI provider as per below:
```
provisioningInput:  
   kubernetesVersion: 
    - v1.22.13+rke2r1
    - v1.23.10+rke2r1
  cni:
    - calico
```