### PR TITLE
Revert rke2 version hardcoding and use KDM dev-v2.7

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -39,11 +39,7 @@ eval "$(grep '^ENV CATTLE_WINS_AGENT' package/Dockerfile | awk '{print "export "
 eval "$(grep '^ENV CATTLE_CSI_PROXY_AGENT' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 eval "$(grep '^ENV CATTLE_KDM_BRANCH' package/Dockerfile | awk '{print "export " $2 "=" $3}')"
 
-if [ "$DIST" = "rke2" ]; then
-    export SOME_K8S_VERSION="v1.22.13+rke2r1"
-else
-    export SOME_K8S_VERSION=$(curl https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.6/data/data.json | jq -r ".$DIST.channels[0].latest")
-fi
+export SOME_K8S_VERSION=$(curl https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/dev-v2.7/data/data.json | jq -r ".$DIST.channels[0].latest")
 
 echo "Starting rancher server for provisioning-tests using $SOME_K8S_VERSION"
 touch /tmp/rancher.log


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/39484

As part of a workaround to get provisioning tests to pass, RKE2 was hard coded to an older version. This PR reverts that change, and also bumps the consumed version of KDM to dev-v2.7