### PR TITLE
[release/v2.6] Set force cgroup env for k3s agent as well

### DIFF
--- a/tests/integration/pkg/nodeconfig/nodeconfig.go
+++ b/tests/integration/pkg/nodeconfig/nodeconfig.go
@@ -99,6 +99,10 @@ write_files:
     Type=exec
   path: /etc/systemd/system/k3s.service.d/10-delegate.conf
 - content: |
+    [Service]
+    Type=exec
+  path: /etc/systemd/system/k3s-agent.service.d/10-delegate.conf
+- content: |
     NOTIFY_SOCKET=
     INVOCATION_ID=
   path: /etc/default/rke2-server
@@ -109,7 +113,12 @@ write_files:
 - content: |
     NOTIFY_SOCKET=
     INVOCATION_ID=
-  path: /etc/default/k3s`
+  path: /etc/default/k3s
+- content: |
+    NOTIFY_SOCKET=
+    INVOCATION_ID=
+  path: /etc/default/k3s-agent`
+
 	podConfigClient := clients.Dynamic.Resource(schema.GroupVersionResource{
 		Group:    "rke-machine-config.cattle.io",
 		Version:  "v1",

--- a/tests/integration/pkg/systemdnode/systemnode.go
+++ b/tests/integration/pkg/systemdnode/systemnode.go
@@ -109,6 +109,11 @@ INVOCATION_ID=
 					},
 					{
 						Name:      "systemd",
+						MountPath: "/usr/local/lib/systemd/system/k3s-agent.service.d/10-delegate.conf",
+						SubPath:   "dropin",
+					},
+					{
+						Name:      "systemd",
 						MountPath: "/etc/default/rke2-server",
 						SubPath:   "disable",
 					},
@@ -120,6 +125,11 @@ INVOCATION_ID=
 					{
 						Name:      "systemd",
 						MountPath: "/etc/default/k3s",
+						SubPath:   "disable",
+					},
+					{
+						Name:      "systemd",
+						MountPath: "/etc/default/k3s-agent",
 						SubPath:   "disable",
 					},
 				},


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39485
 
Partial backport of https://github.com/rancher/rancher/pull/39479

We don't need to modify the KDM data as we are leaving KDM to dev-v2.6 on `release/v2.6`