### PR TITLE
Set CATTLE_UI_BRAND to empty string for community installs

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -169,6 +169,9 @@ ENV CATTLE_CLI_VERSION v2.7.0-rc1
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV CATTLE_API_UI_VERSION 1.1.9
 
+# Explicitly set the branding to an empty string for non-suse branded installs
+ENV CATTLE_UI_BRAND=
+
 RUN mkdir -p /var/log/auditlog
 ENV AUDIT_LOG_PATH /var/log/auditlog/rancher-api-audit.log
 ENV AUDIT_LOG_MAXAGE 10

--- a/pkg/controllers/dashboardapi/settings/settings.go
+++ b/pkg/controllers/dashboardapi/settings/settings.go
@@ -113,11 +113,15 @@ func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error
 				obj.Default = setting.Default
 				update = true
 			}
-			if envValue != "" && obj.Source != "env" {
+			if envValue != "" && obj.Source != "env" && envValue != obj.Default {
 				obj.Source = "env"
 				update = true
 			}
-			if envValue != "" && obj.Value != envValue {
+			if envValue == obj.Default {
+				obj.Source = ""
+				update = true
+			}
+			if obj.Value != envValue {
 				obj.Value = envValue
 				update = true
 			}


### PR DESCRIPTION
Explicitly setting the CATTLE_UI_BRAND env var to an empty string will force an update of the value at start-time which will allow for proper transitioning between
community and non-community installs of Rancher.

## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/39456
 
## Problem
When upgrading from a non-community version of rancher to a community version, the upgrade is successful and the private registry details are reset. However, the non-community version's branding persists.
 
## Solution
When building the community image, we will now set the CATTLE_BRAND_UI env var to an empty string.  This is different than leaving it unset and will force the value to be updated.
 
## Testing
Manually tested by eng

## Engineering Testing
### Manual Testing
Start a cluster and install Rancher Prime
Note that the logo in the dashboard is the prime logo.
"upgrade" to a non-prime version of rancher (ie:  shut down rancher prime container and start a non-prime rancher)
Verify that the branding logo has changed back to the community logo.
"upgrade" back to Rancher Prime
Note that the logo is the prime logo.

### Automated Testing
N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->