### PR TITLE
[release/v2.6] - Adding 2.7 in the logic to use --privileged with Docker

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -2133,7 +2133,9 @@ def set_url_password_token(rancher_url, server_url=None, version=""):
         rancher_url + "/v3-public/localproviders/local?action=login"
     rpassword = 'admin'
     print(auth_url)
-    if version.find("master") > -1 or version.find("2.6") > -1:
+    if "master" in version or \
+            "2.6" in version or \
+            "2.7" in version:
         rpassword = ADMIN_PASSWORD
         print("on 2.6 or later")
     retries = 5

--- a/tests/validation/tests/v3_api/test_custom_host_reg.py
+++ b/tests/validation/tests/v3_api/test_custom_host_reg.py
@@ -44,9 +44,10 @@ def test_delete_keypair():
 
 
 def test_deploy_rancher_server():
-    if "v2.5" in  RANCHER_SERVER_VERSION or \
-        "master" in RANCHER_SERVER_VERSION or \
-        "v2.6" in RANCHER_SERVER_VERSION:
+    if "v2.5" in RANCHER_SERVER_VERSION or \
+            "master" in RANCHER_SERVER_VERSION or \
+            "v2.6" in RANCHER_SERVER_VERSION or \
+            "v2.7" in RANCHER_SERVER_VERSION:
         RANCHER_SERVER_CMD = \
             'sudo docker run -d --privileged --name="rancher-server" ' \
             '--restart=unless-stopped -p 80:80 -p 443:443  ' \


### PR DESCRIPTION
## Problem
Automation is not using `--privileged` flag when deploying Rancher using Docker because there's no `--privileged` flag
 
## Solution

Add Rancher version 2.7 to the Docker Rancher deployment logic
 