### PR TITLE
[V2.7] Only Regenerate Kubelet Serving Certificate When Necessary  

### DIFF
--- a/cmd/agent/agent_test.go
+++ b/cmd/agent/agent_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"github.com/stretchr/testify/assert"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestKubeletCertificateNeedsRegeneration(t *testing.T) {
+
+	correctIPAddress := "167.71.188.113"
+	correctHostName := "cert-test1"
+	testCertExpiryTime := time.Now().AddDate(10, 0, 3)
+
+	type testcase struct {
+		testName      string
+		testIPAddress string
+		testHostName  string
+		testTime      time.Time
+		want          bool
+	}
+
+	testCases := []testcase{
+		{
+			testName:      "All Cert Properties Are Valid",
+			testIPAddress: correctIPAddress,
+			testHostName:  correctHostName,
+			testTime:      time.Now(),
+			want:          false,
+		},
+		{
+			testName:      "Cert Contains Invalid IP Address",
+			testIPAddress: "192.168.1.1",
+			testHostName:  correctHostName,
+			testTime:      time.Now(),
+			want:          true,
+		},
+		{
+			testName:      "Cert Contains Invalid Hostname",
+			testIPAddress: correctIPAddress,
+			testHostName:  "different-hostname",
+			testTime:      time.Now(),
+			want:          true,
+		},
+		{
+			testName:      "Cert Will Expire In Less Than Three Days",
+			testIPAddress: correctIPAddress,
+			testHostName:  correctHostName,
+			testTime:      time.Now().AddDate(10, 0, 1), // ~ 48 hours until expiry
+			want:          true,
+		},
+	}
+	t.Log("generating test certificate...")
+	testCert, err := createTestCert([]net.IP{net.ParseIP(correctIPAddress)}, []string{correctHostName}, testCertExpiryTime)
+	assert.Equal(t, nil, err)
+	t.Log("successfully generated test certificate")
+	for _, c := range testCases {
+		t.Run(c.testName, func(t *testing.T) {
+			got, err := KubeletCertificateNeedsRegeneration(c.testIPAddress, c.testHostName, testCert, c.testTime)
+			assert.Equal(t, nil, err)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+// createTestCert creates a self-signed certificate for use in tests, it incorporates the given ipAddress's, hostNames, and expiry time
+func createTestCert(ipAddress []net.IP, hostname []string, notAfter time.Time) (tls.Certificate, error) {
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(2022),
+		Subject: pkix.Name{
+			Organization:  []string{"Rancher"},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"Green Pastures"},
+			StreetAddress: []string{"123 Cattle Drive"},
+			PostalCode:    []string{"94016"},
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		SubjectKeyId: []byte{5, 4, 1, 6, 8},
+		DNSNames:     hostname,
+		IPAddresses:  ipAddress,
+	}
+
+	certPriv, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	privKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, cert, &certPriv.PublicKey, privKey)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	certPem := new(bytes.Buffer)
+	certPrivPem := new(bytes.Buffer)
+	if err = pem.Encode(certPem, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	}); err != nil {
+		return tls.Certificate{}, err
+	}
+	if err = pem.Encode(certPrivPem, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certPriv),
+	}); err != nil {
+		return tls.Certificate{}, err
+	}
+
+	return tls.X509KeyPair(certPem.Bytes(), certPrivPem.Bytes())
+}


### PR DESCRIPTION
## Issue: #36025
 
## Problem
A denial of service is encountered when many clusters configured with `generate_serving_certificate` connect to the Rancher server at the same time. This is due to the fact that Rancher cannot intelligently determine if a certificate must be regenerated or not as kubelet certificates are not stored or tracked by the Rancher server. This resulted in Rancher always regenerating the kubelet certificate whenever the node agent reconnects with the Rancher server. At scale, this behavior results in all CPU time being dedicated to generating certificates. Additionally, Rancher was regenerating all of the nodes certificates for each node, resulting in many unused certificates being placed on each node and additional CPU resources being consumed. 
 
## Solution
Before attempting to reconnect with the Rancher server, the node agent will first find and inspect the kubelet serving certificate stored locally and determine if it needs to be regenerated. If the certificate needs to be regenerated, either because the SAN is out of date, the IP address is out of date, or the certificate will expire within three days, then a value is specified in the header of the reconnection attempt which will indicate that the certificate needs to be regenerated.
 
## Testing
when  `generate_serving_certificate` is enabled for the clusters kubelet service, the new kubelet certificate will be generated under these conditions 

1. The certificate does not already exist 
2. The certificate will expire in three days or less 
3. The hostname name included in the certificate does not match the nodes hostname name
4. The IP address included in the certificate does not match the current IP address of the node

Some of these conditions are hard to test, such as the expiry time which is set to 10 years in the future. The two cases below cover the main goal of this ticket. 

---
#### Test Environment / Setup
+ This issue requires that you have the ability to stop/scale down rancher to 0 pods. We are interested in the reconnection process once an existing Rancher server is brought back online. Any setup in which you can restart Rancher will work, but an HA setup will likely be the easiest configuration.
+ Create an RKE1 cluster with three nodes 
  + one of the nodes will have the etcd control plane roles 
  + two of the nodes will only have the worker role 
+ Before creating the cluster, edit the YAML and find the `services` section. Add the `generate_serving_certificate` [as described in this documentation ](https://rancher.com/docs/rke/latest/en/config-options/services/#kubelet)
+ Create the cluster and wait for all nodes to come online. Once they've come online, double check the config YAML and ensure that `generate_serving_certificate` is set to `true`. 

#### 1) Certificate should not regenerate on each reconnection

+ SSH into one of the worker only nodes and navigate to `/etc/kubernetes/ssl`. You should see several `.pem` files with the following naming convention `kube-kubelet-<IP_ADDRESS>.pem` and `kube-kubelet-<IP_ADDRESS>-key.pem`. Mark the time at which these files were created using `ls -l`. Make sure you mark the file which belongs to current node you are SSH'd into 
+ Scale down / restart the rancher server and wait for all nodes to reconnect
+ Ensure that no certificates have been updated by checking the file creation time

#### 2) Certificate should be recreated when deleted
+ SSH into one of the worker only nodes and navigate to `/etc/kubernetes/ssl`. Delete the `kube-kubelet` certificate and key which belongs to the node you are SSH'd into (the file name will include the nodes IP address)
+ scale down / restart the rancher server and wait for all nodes to reconnect 
+ ensure that the deleted files have been recreated and are present on the node
+ Also ensure that no other certificate files have been updated or modified

## Engineering Testing
### Manual Testing
I've done the above steps during development to ensure that the new node agent logic works as desired. 

### Automated Testing
N/A

## QA Testing Considerations
You will need an HA rancher server or any other type of Rancher server which can be restarted.
 
### Regressions Considerations
Any features or functionalities which require the proper configuration of the kubelet serving certificate. 