### PR TITLE
[v2.7] updating ontag to allow v2.7

### DIFF
--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -164,10 +164,18 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                       }
                       else if (rancher_version.startsWith("v2.6")){
                         if (!env.RKE_VERSION) {
-                          RKE_VERSION = "v1.3.13"
+                          RKE_VERSION = "v1.3.15"
                         }
                         if (!env.RANCHER_K3S_VERSION) {
-                          RANCHER_K3S_VERSION = "v1.24.2+k3s1"
+                          RANCHER_K3S_VERSION = "v1.24.6+k3s1"
+                        }
+                      }
+                      else if (rancher_version.startsWith("v2.7")){
+                        if (!env.RKE_VERSION) {
+                          RKE_VERSION = "v1.4.0-rc4"
+                        }
+                        if (!env.RANCHER_K3S_VERSION) {
+                          RANCHER_K3S_VERSION = "v1.24.6+k3s1"
                         }
                       }
                       params = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"),
@@ -192,7 +200,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                       jobs["custom"] = { build job: 'rancher-v3_ontag_custom_certification', parameters: params}
                       // windows note: https://github.com/rancher/dashboard/issues/6549
                       // jobs["windows"] = { build job: 'rancher-v3_ontag_windows_certification', parameters: params}
-                      if (rancher_version.startsWith("v2.6")){
+                      if (rancher_version.startsWith("v2.6") || rancher_version.startsWith("v2.7")){
                         // Rancher server 2 is used to test GKE, EKS, AKS and Imported clusters
                         jobs["eks"] = { build job: 'rancher-v3_ontag_eks_certification', parameters: params2 }
                         jobs["aks"] = { build job: 'rancher-v3_ontag_aks_certification', parameters: params2 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
ontag jobs were failing due to rules explicit to 2.6 and 2.5 in jenkinsfiles
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
add an explicit rule to set versions in 2.7
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
functional test of rke version done in jenkins (did not test jenkinsfile changes themselves)

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->