### PR TITLE
[v2.7] check for hardened variable was checking boolean against string value

### DIFF
--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -79,7 +79,7 @@ def test_install_rancher_ha(precheck_certificate_options):
         if RANCHER_LOCAL_CLUSTER_TYPE == "RKE":
             print("RKE cluster is provisioning for the local cluster")
             nodes = create_resources()
-            if RANCHER_HA_HARDENED:
+            if RANCHER_HA_HARDENED.upper() == "TRUE":
                 node_role = [["worker", "controlplane", "etcd"]]
                 node_roles =[]
                 for role in node_role:
@@ -504,7 +504,7 @@ def create_rke_cluster_config(aws_nodes):
     rkeconfig = rkeconfig.replace("$AWS_SSH_KEY_NAME", AWS_SSH_KEY_NAME)
     rkeconfig = rkeconfig.replace("$KUBERNETES_VERSION", KUBERNETES_VERSION)
 
-    if RANCHER_HA_HARDENED:
+    if RANCHER_HA_HARDENED.upper() == "TRUE":
         rkeconfig_hardened = readDataFile(DATA_SUBDIR, "hardened-cluster.yml")
         rkeconfig += "\n"
         rkeconfig += rkeconfig_hardened


### PR DESCRIPTION
…ring

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution 
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
section. -->
Jenkins would use the hardened rke1 cluster.yaml when hardened == false
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
improve logic when checking hardened variable. Currently, we only checked that the variable existed (if hardened: x), likely assuming that the variable was a boolean. However it is a string, so the if statement was always true. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
tbd
