### PR TITLE
[v2.6] allow rancher install from different helm URL

### DIFF
--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -22,6 +22,7 @@ RANCHER_CHART_VERSION = os.environ.get("RANCHER_CHART_VERSION")
 RANCHER_HELM_EXTRA_SETTINGS = os.environ.get("RANCHER_HELM_EXTRA_SETTINGS")
 RANCHER_IMAGE_TAG = os.environ.get("RANCHER_IMAGE_TAG")
 RANCHER_HELM_REPO = os.environ.get("RANCHER_HELM_REPO", "latest")
+RANCHER_HELM_URL = os.environ.get("RANCHER_HELM_URL", "https://releases.rancher.com/server-charts/")
 RANCHER_LETSENCRYPT_EMAIL = os.environ.get("RANCHER_LETSENCRYPT_EMAIL")
 # Here is the list of cert types for HA install
 # [rancher-self-signed, byo-valid, byo-self-signed, letsencrypt]
@@ -323,9 +324,9 @@ def set_route53_with_ingress():
     time.sleep(60)
 
 
-def add_repo_create_namespace(repo=RANCHER_HELM_REPO):
+def add_repo_create_namespace(repo=RANCHER_HELM_REPO, url=RANCHER_HELM_URL):
     repo_name = "rancher-" + repo
-    repo_url = "https://releases.rancher.com/server-charts/" + repo
+    repo_url = url + repo
 
     run_command_with_stderr("helm_v3 repo add " + repo_name + " " + repo_url)
     run_command_with_stderr("helm_v3 repo update")


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/515
backport of https://github.com/rancher/rancher/pull/39482
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 currently, rancher helm URL was hard coded. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This PR will allow different URLs for a rancher install to be used.
Introduced `RANCHER_HELM_URL` variable with previous hardcoded value as the default. 
supporting PR in job builder
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->