### PR TITLE
[v2.7.1] Add the cluster-id to log messages during cluster creation

### DIFF
--- a/pkg/controllers/management/node/utils.go
+++ b/pkg/controllers/management/node/utils.go
@@ -225,9 +225,9 @@ func (m *Lifecycle) reportStatus(stdoutReader io.Reader, stderrReader io.Reader,
 		if strings.HasPrefix(msg, debugPrefix) {
 			// calls in machine with log.Debug are all prefixed and spammy so only log
 			// under trace and don't add to the v3.NodeConditionProvisioned.Message
-			logrus.Tracef("[node-controller] %v", msg)
+			logrus.Tracef("[node-controller] [cluster-id: %s] %v", node.ObjClusterName(), msg)
 		} else {
-			logrus.Infof("[node-controller] %v", msg)
+			logrus.Infof("[node-controller] [cluster-id: %s] %v", node.ObjClusterName(), msg)
 			v32.NodeConditionProvisioned.Message(node, msg)
 		}
 


### PR DESCRIPTION
## Issue: 
#21637 
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Add the cluster-id to log messages during cluster creation in order to make trouble shooting easier.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Add the Node's cluster id to the logs when forwarding messages coming from the driver.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
1. Create a new cluster with the UI and look at the logs produced in stdout/stderr.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->