### PR TITLE
Adding permission for project owners to modify podsecuritypolicytemplateprojectbindings

### DIFF
--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -37,10 +37,11 @@ var projectManagmentPlaneResources = map[string]string{
 	"secrets":                     "",
 }
 var prtbClusterManagmentPlaneResources = map[string]string{
-	"notifiers":               "management.cattle.io",
-	"clustercatalogs":         "management.cattle.io",
-	"catalogtemplates":        "management.cattle.io",
-	"catalogtemplateversions": "management.cattle.io",
+	"notifiers":                                "management.cattle.io",
+	"clustercatalogs":                          "management.cattle.io",
+	"catalogtemplates":                         "management.cattle.io",
+	"catalogtemplateversions":                  "management.cattle.io",
+	"podsecuritypolicytemplateprojectbindings": "management.cattle.io",
 }
 
 type prtbLifecycle struct {

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -259,6 +259,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("projectmonitorgraphs").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("catalogtemplates").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("catalogtemplateversions").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplateprojectbindings").verbs("*").
 		addRule().apiGroups("monitoring.cattle.io").resources("prometheus").verbs("view").
 		addRule().apiGroups("monitoring.coreos.com").resources("prometheuses", "prometheusrules", "servicemonitors").verbs("*").
 		addRule().apiGroups("networking.istio.io").resources("destinationrules", "envoyfilters", "gateways", "serviceentries", "sidecars", "virtualservices").verbs("*").


### PR DESCRIPTION
Added podsecuritypolicytemplateprojectbindings.management.cattle.io permissions to the set of rules that are added to the project-owner rolebinding.

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/32127

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
If a (non-admin) project owner tried to modify the project's settings, even if the settings succeeded (like modifying resource quotas), the user would still see an error because the UI also makes a call to setpodsecuritypolicytemplateprojectbindings.  The error shown would look similar to this
`error creating binding: Forbidden 403: podsecuritypolicytemplateprojectbindings.management.cattle.io is forbidden: User "u-5tzkm" cannot create resource "podsecuritypolicytemplateprojectbindings" in API group "management.cattle.io" in the namespace "c-82nlk"`
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
It was determined that non-admin project owners SHOULD be able to perform this action, so the fix is to add the permission to the project-owner role that is bound to the user.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
The steps in the issue are valid, but an even easier way to see the problem is to skip the setting of resource quotas and to just try to edit the Pod Security Policy dropdown to a new value and then try to save the results.  If the rbac update worked properly, the user will no longer see the error.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
I performed manual testing of this by modifying the Pod Security Policy and Adding/Removing/Editing resource quotas.  Several permutations of edits/non-edits/deletions/etc were performed over several iterations.


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
I can't think of any special cases beyond the original reproducer and the steps I noted in the manual testing.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->