### PR TITLE
[2.7] Fix hardened cluster environment value in HA creation validation test

### DIFF
--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -12,7 +12,7 @@ from .test_rke_cluster_provisioning import AZURE_CLIENT_ID, AZURE_CLIENT_SECRET,
 # RANCHER_HA_KUBECONFIG and RANCHER_HA_HOSTNAME are provided
 # when installing Rancher into a k3s setup
 RANCHER_HA_KUBECONFIG = os.environ.get("RANCHER_HA_KUBECONFIG")
-RANCHER_HA_HARDENED = os.environ.get("RANCHER_HA_HARDENED", "False")
+RANCHER_HA_HARDENED = ast.literal_eval(os.environ.get("RANCHER_HA_HARDENED", "False"))
 RANCHER_HA_HOSTNAME = os.environ.get(
     "RANCHER_HA_HOSTNAME", RANCHER_HOSTNAME_PREFIX + ".qa.rancher.space")
 resource_prefix = RANCHER_HA_HOSTNAME.split(".qa.rancher.space")[0]
@@ -140,7 +140,7 @@ def test_install_rancher_ha(precheck_certificate_options):
         assert False, "check the logs in console for details"
 
     print_kubeconfig(kubeconfig_path)
-    if (RANCHER_HA_HARDENED.upper() == "TRUE" and RANCHER_LOCAL_CLUSTER_TYPE == "RKE") and RANCHER_HA_KUBECONFIG == "" and RANCHER_HA_HOSTNAME=="":
+    if (RANCHER_HA_HARDENED and RANCHER_LOCAL_CLUSTER_TYPE == "RKE") and RANCHER_HA_KUBECONFIG == "" and RANCHER_HA_HOSTNAME=="":
         prepare_hardened_cluster(profile, kubeconfig_path)
     if RANCHER_LOCAL_CLUSTER_TYPE == "RKE":
         check_rke_ingress_rollout()


### PR DESCRIPTION
For the validation test CI runs, HA cluster creation uses the hardened environment variable as a string, and the condition accepts the hardened option as always true.

**Modified**

- Wrapped `RANCHER_HA_HARDENED` environment variable with `ast.literal.eval()`
- Removed string comparisons related with `RANCHER_HA_HARDENED` environment variable