### PR TITLE
Adding fallback env setting for base-ui-brand

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -166,6 +166,9 @@ ENV CATTLE_UI_VERSION 2.7.0-rc8
 ENV CATTLE_DASHBOARD_UI_VERSION v2.7.0-rc8
 ENV CATTLE_CLI_VERSION v2.7.0-rc1
 
+# Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install
+ENV CATTLE_BASE_UI_BRAND=
+
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV CATTLE_API_UI_VERSION 1.1.9
 

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -153,7 +153,8 @@ var (
 	UIBanners = NewSetting("ui-banners", "{}")
 
 	// UIBrand High level 'brand' value, for example `suse`.
-	UIBrand = NewSetting("ui-brand", "")
+	// Fallback env, not a user-facing setting, used to indicate if this is a Prime install
+	UIBrand = NewSetting("ui-brand", os.Getenv("CATTLE_BASE_UI_BRAND"))
 
 	// UICommunityLinks displays community links in the UI.
 	// Deprecated in favour of UICustomLinks = NewSetting("ui-custom-links", "").


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/39456
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
We need a flag to indicate whether or not a given install is a Rancher Prime install.  It needs to default to an env var that is set in the Dockerfile, but still be able to be set by users if they prefer to use their own branding.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Introduce a new fallback env setting, base-ui-brand (not user-facing) that will pick-up the value of an env var (BASE_UI_BRAND) set by the Dockerfile at build time
 
## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manually tested resultant image to verify that the setting 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->