### PR TITLE
PR for Windows automation 

### DIFF
--- a/tests/validation/tests/v3_api/resource/terraform/rke2/windows_worker/instances_worker.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/windows_worker/instances_worker.tf
@@ -1,0 +1,37 @@
+resource "aws_instance" "windows_worker" {
+  depends_on = [
+    var.dependency
+  ]
+  ami                    = var.aws_ami
+  instance_type          = var.ec2_instance_class
+  count                  = var.no_of_windows_worker_nodes
+  iam_instance_profile   = "${var.iam_role}"
+  get_password_data      = true
+  user_data              = templatefile("join-rke2.tftpl", {serverIP: "${local.master_ip}", token: "${local.node_token}", version: "${var.rke2_version}"})
+  subnet_id              = var.subnets
+  availability_zone      = var.availability_zone
+  vpc_security_group_ids = ["${var.sg_id}"]
+  key_name               = var.access_key_name
+  tags = {
+    Name = "${var.resource_name}-windows-worker"
+    "kubernetes.io/cluster/clusterid" = "owned"
+  }
+}
+
+data "local_file" "master_ip" {
+  depends_on = [var.dependency]
+  filename = "/tmp/${var.resource_name}_master_ip"
+}
+
+locals {
+  master_ip = trimspace("${data.local_file.master_ip.content}")
+}
+
+data "local_file" "token" {
+  depends_on = [var.dependency]
+  filename = "/tmp/${var.resource_name}_nodetoken"
+}
+
+locals {
+  node_token = trimspace("${data.local_file.token.content}")
+}

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/windows_worker/join-rke2.tftpl
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/windows_worker/join-rke2.tftpl
@@ -1,0 +1,11 @@
+<powershell>
+# Set default shell to powershell
+New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Start-Service sshd
+Set-Service -Name sshd -StartupType 'Automatic'
+Write-Output "[INFO] Dowloading quickstart script..."
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/rancher/rke2/master/windows/rke2-quickstart.ps1 -Outfile C:\Users\Administrator\rke2-quickstart.ps1
+Invoke-Expression -Command "C:\Users\Administrator\rke2-quickstart.ps1 -ServerIP ${serverIP} -Token ${token} -Version ${version}"
+</powershell>
+

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/windows_worker/outputs.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/windows_worker/outputs.tf
@@ -1,0 +1,9 @@
+output "windows_worker_ips" {
+  value = join(",", aws_instance.windows_worker.*.public_ip)
+}
+
+output "windows_worker_password_decrypted" {
+  value = [
+    for agent in aws_instance.windows_worker : rsadecrypt(agent.password_data, file(var.access_key))
+  ]
+}

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/windows_worker/variables.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/windows_worker/variables.tf
@@ -1,0 +1,26 @@
+variable "access_key" {}
+variable "access_key_name" {}
+variable "availability_zone" {}
+variable "aws_ami" {}
+variable "aws_user" {}
+variable "cluster_type" {}
+variable "dependency" {
+  type    = any
+  default = null
+}
+variable "ec2_instance_class" {}
+variable "iam_role" {}
+variable "node_os" {}
+variable "no_of_windows_worker_nodes" {}
+variable "password" {
+  default = "password"
+}
+variable "region" {}
+variable "resource_name" {}
+variable "rke2_version" {}
+variable "sg_id" {}
+variable "subnets" {}
+variable "username" {
+  default = "username"
+}
+variable "vpc_id" {}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/qa-tasks/issues/151
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Currently there is no support to add Windows node as agent to a rke2 standalone cluster. The process of adding the agent is tedious and time consuming, specially during rke2 patch or minor release validation.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This PR adds the ability to automatically add Windows node as agent to a rke2 cluster
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->