### PR TITLE
[v2.7.1] Always allow creation of cloud credentials for AWS and Azure

### DIFF
--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -80,10 +80,10 @@ func addMachineDrivers(management *config.ManagementContext) error {
 	}
 	if err := addMachineDriver(Amazonec2driver, "local://", "", "",
 		[]string{"iam.amazonaws.com", "iam.us-gov.amazonaws.com", "iam.%.amazonaws.com.cn", "ec2.%.amazonaws.com", "ec2.%.amazonaws.com.cn", "eks.%.amazonaws.com", "eks.%.amazonaws.com.cn", "kms.%.amazonaws.com", "kms.%.amazonaws.com.cn"},
-		true, true, false, management); err != nil {
+		true, true, true, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(Azuredriver, "local://", "", "", nil, true, true, false, management); err != nil {
+	if err := addMachineDriver(Azuredriver, "local://", "", "", nil, true, true, true, management); err != nil {
 		return err
 	}
 	if err := addMachineDriver("cloudca", "https://github.com/cloud-ca/docker-machine-driver-cloudca/files/2446837/docker-machine-driver-cloudca_v2.0.0_linux-amd64.zip", "https://objects-east.cloud.ca/v1/5ef827605f884961b94881e928e7a250/ui-driver-cloudca/v2.1.2/component.js", "2a55efd6d62d5f7fd27ce877d49596f4", []string{"objects-east.cloud.ca"}, false, false, false, management); err != nil {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39399
 
## Problem
Cloud credentials for AWS and Azure are used both when creating clusters with Rancher node drivers as well as when creating clusters using Rancher cluster drivers for AKS/GKE/EKS/etc. However, the API schema for cloud credentials is altered depending on the current status of the infrastructure providers node driver. If the node driver is disabled, the API schema will be altered to no longer include the fields for that cloud provider. In the case where you only want to create EKS or AKS clusters, and want to disable the node driver for those providers, you are not able to create the required cloud credentials. 
 
## Solution
Ensure that the cloud credential API schema always includes the sections for amazon and azure by setting the `addCloudCredential` field to `true` for each of the node drivers. This field stops the schema from being altered altered when the node driver is deactivated, ensuring their presence in the api schema at all times. This approach is consistent with the current behavior for cloud credentials created for GKE. 

## Testing
+ Create a new rancher server instance 
+ navigate to `https://<CLUSTER_URL>/v3/schema/cloudcredential` and ensure that the resource fields `amazonec2credentialconfig` and `azurecredentialconfig` are present
+ Return to the UI and navigate to 'Cluster Management' section and then to 'Drivers' 
+ Under `Cluster Drivers` disable `Amazon EKS` and `Azure AKS`
+ Under `Node Drivers` disable `Amazon EC2` and `Azure`
+ navigate back to `https://<CLUSTER_URL>/v3/schema/cloudcredential` and ensure that the resource fields `amazonec2credentialconfig` and `azurecredentialconfig` are still present, even though both of the node drivers are disabled.

## Engineering Testing
### Manual Testing
I've done the test steps listed above

### Automated Testing
n/a

## QA Testing Considerations
This change will only impact an existing cluster if the version of rancher-machine is bumped, but should be testable on newly created clusters. rancher-machine will be bumped in the next release, so users will not have to do anything in order for this change to take effect. 
