### PR TITLE
[2.6] update go jenkinsfile to use user entered variables when available instead of global ones. 

### DIFF
--- a/tests/v2/validation/Jenkinsfile
+++ b/tests/v2/validation/Jenkinsfile
@@ -28,9 +28,10 @@ node {
       withFolderProperties {
         paramsMap = []
         params.each {
-          paramsMap << "$it.key=$it.value"
+          if (it.value && it.value.trim() != "") {
+              paramsMap << "$it.key=$it.value"
+          }
         }
-        withEnv(paramsMap) {
         withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
                           string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
                           string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'RANCHER_EKS_ACCESS_KEY'),
@@ -77,6 +78,8 @@ node {
                           string(credentialsId: 'RANCHER_BYO_TLS_CERT', variable: 'RANCHER_BYO_TLS_CERT'),
                           string(credentialsId: 'RANCHER_BYO_TLS_KEY', variable: 'RANCHER_BYO_TLS_KEY'),
                           string(credentialsId: 'RANCHER_LINODE_ACCESSKEY', variable: "RANCHER_LINODE_ACCESSKEY")]) {
+          
+        withEnv(paramsMap) {
           stage('Checkout') {
             deleteDir()
             checkout([
@@ -118,11 +121,11 @@ node {
                 sh "docker stop ${testContainer}"
                 sh "docker rm -v ${testContainer}"
                 sh "docker rmi -f ${imageName}"
-              }
+              } // stage
             } // finally
           } // dir 
-        } // creds
-      } // folder properties
-    } // wrap 
-  } 
-}// node
+        } // withEnv
+      } // creds
+    } // folder properties
+  } // wrap 
+} // node


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/qa-tasks/issues/527
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 go jenkinsfile did not allow overriding of global variables
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
load global vars first, then load user entered variables. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
tested in jenkins

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->