### PR TITLE
[v2.7.1] Remove windows images from rancher-images.txt

### DIFF
--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -99,32 +99,31 @@ func GatherTargetImagesAndSources(systemChartsPath, chartsPath string, imagesFro
 		return ImageTargetsAndSources{}, fmt.Errorf("%s: %w", "could not write rancher-rke-k8s-versions.txt file", err)
 	}
 
-	externalImages := make(map[string][]string)
-	k3sUpgradeImages, err := ext.GetExternalImages(rancherVersion, data.K3S, ext.K3S, &semver.Version{
+	k8sVersion1_21_0 := &semver.Version{
 		Major: 1,
 		Minor: 21,
 		Patch: 0,
-	})
+	}
+
+	externalLinuxImages := make(map[string][]string)
+
+	k3sUpgradeImages, err := ext.GetExternalImages(rancherVersion, data.K3S, ext.K3S, k8sVersion1_21_0, img.Linux)
 	if err != nil {
 		return ImageTargetsAndSources{}, fmt.Errorf("%s: %w", "could not get external images for K3s", err)
 	}
 	if k3sUpgradeImages != nil {
-		externalImages["k3sUpgrade"] = k3sUpgradeImages
+		externalLinuxImages["k3sUpgrade"] = k3sUpgradeImages
 	}
 
 	// RKE2 Provisioning will only be supported on Kubernetes v1.21+. In addition, only RKE2
-	// releases corresponding to Kubernetes v1.21+ include the "rke2-images-all" file that we need.
-	rke2AllImages, err := ext.GetExternalImages(rancherVersion, data.RKE2, ext.RKE2, &semver.Version{
-		Major: 1,
-		Minor: 21,
-		Patch: 0,
-	})
+	// releases corresponding to Kubernetes v1.21+ include the "rke2-images-all.linux-amd64.txt" file that we need.
+	rke2LinuxImages, err := ext.GetExternalImages(rancherVersion, data.RKE2, ext.RKE2, k8sVersion1_21_0, img.Linux)
 	if err != nil {
 		return ImageTargetsAndSources{}, fmt.Errorf("%s: %w", "could not get external images for RKE2", err)
 
 	}
-	if rke2AllImages != nil {
-		externalImages["rke2All"] = rke2AllImages
+	if rke2LinuxImages != nil {
+		externalLinuxImages["rke2All"] = rke2LinuxImages
 	}
 
 	sort.Strings(imagesFromArgs)
@@ -142,7 +141,7 @@ func GatherTargetImagesAndSources(systemChartsPath, chartsPath string, imagesFro
 		OsType:           img.Linux,
 		RancherVersion:   rancherVersion,
 	}
-	targetImages, targetImagesAndSources, err := img.GetImages(exportConfig, externalImages, linuxImagesFromArgs, linuxInfo.RKESystemImages)
+	targetImages, targetImagesAndSources, err := img.GetImages(exportConfig, externalLinuxImages, linuxImagesFromArgs, linuxInfo.RKESystemImages)
 	if err != nil {
 		return ImageTargetsAndSources{}, err
 	}


### PR DESCRIPTION
## Issue: #39510
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
`rancher-images.txt` contains Windows-only images which causes issues when users try to pull images using this file in Linux environment.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Only fetch the Linux images from the RKE2 releases when we're producing the Linux images list.

The list of images downloaded from RKE2 is the amd64 list. Hopefully those images all have multi-arch manifests, but if not, we might need to revisit this code to add proper s390x and arm64 support.
 
`rancher-images.txt` diff:
```diff
@@ -239,8 +239,6 @@ rancher/nginx-ingress-controller:nginx-1.2.1-hardened7
 rancher/nginx-ingress-controller:nginx-1.2.1-hardened9
 rancher/nginx-ingress-controller:nginx-1.2.1-rancher1
 rancher/pause:3.6
-rancher/pause:3.6-windows-1809-amd64
-rancher/pause:3.6-windows-ltsc2022-amd64
 rancher/prom-alertmanager:v0.21.0
 rancher/prom-node-exporter:v1.0.1
 rancher/prom-prometheus:v2.18.2
@@ -258,13 +256,9 @@ rancher/rke-tools:v0.1.87
 rancher/rke2-cloud-provider:v0.0.3-build20211118
 rancher/rke2-cloud-provider:v1.25.3-build20221017
 rancher/rke2-runtime:v1.23.10-rke2r1
-rancher/rke2-runtime:v1.23.10-rke2r1-windows-amd64
 rancher/rke2-runtime:v1.23.13-rke2r1
-rancher/rke2-runtime:v1.23.13-rke2r1-windows-amd64
 rancher/rke2-runtime:v1.24.4-rke2r1
-rancher/rke2-runtime:v1.24.4-rke2r1-windows-amd64
 rancher/rke2-runtime:v1.24.7-rke2r1
-rancher/rke2-runtime:v1.24.7-rke2r1-windows-amd64
 rancher/rke2-upgrade:v1.23.10-rke2r1
 rancher/rke2-upgrade:v1.23.13-rke2r1
 rancher/rke2-upgrade:v1.24.4-rke2r1
```

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
I disabled `./test`, `./validate` and `./chart/ci` in `scripts/ci` and used `make ci` to test the generation of the images lists. Then verified manually the Windows images were no longer present in the Linux lists. 

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Updated some unit tests.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->