### PR TITLE
[v2.7.1] Ensure node deletion even if drain fails to complete

### DIFF
--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -121,8 +121,10 @@ func (m *Lifecycle) drainNode(node *v3.Node) error {
 	}
 
 	logrus.Infof("[node-cleanup] node [%s] attempting to drain, retrying up to 3 times", nodeCopy.Spec.RequestedHostname)
-	// purposefully ignoring error, if the drain fails this falls back to deleting the node as usual
-	return wait.ExponentialBackoff(backoff, func() (bool, error) {
+	// purposefully ignoring kubectl.drain error. However, if the node fails to drain after 3 attempts
+	// wait.ExponentialBackoff will still return a wait.ErrWaitTimeout error, which must also be ignored.
+	// Otherwise, the node will not actually delete and resources will be orphaned in the provider.
+	_ = wait.ExponentialBackoff(backoff, func() (bool, error) {
 		ctx, cancel := context.WithTimeout(m.ctx, time.Duration(nodeCopy.Spec.NodeDrainInput.Timeout)*time.Second)
 		defer cancel()
 
@@ -132,7 +134,6 @@ func (m *Lifecycle) drainNode(node *v3.Node) error {
 			return false, nil
 		}
 		if err != nil {
-			// kubectl failed continue on with delete any way
 			logrus.Errorf("[node-cleanup] node [%s] kubectl drain error, retrying: %s", nodeCopy.Spec.RequestedHostname, err)
 			return false, nil
 		}
@@ -140,6 +141,7 @@ func (m *Lifecycle) drainNode(node *v3.Node) error {
 		logrus.Infof("[node-cleanup] node [%s] kubectl drain response: %s", nodeCopy.Spec.RequestedHostname, msg)
 		return true, nil
 	})
+	return nil // always return nil so the node is deleted regardless of drain outcome
 }
 
 func (m *Lifecycle) cleanRKENode(node *v3.Node) error {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39557
 
## Problem
In situations where a node is set to be drained before deletion, but that drain operation consistently fails, the node and its related resources will not be deleted from the infrastructure provider. This is due to how we handle errors returned from a `wait.ExponentialBackoff` call. While the function we pass to the exponential backoff never returns an error, an error (`wait.ErrWaitTimeout`) can still be returned if the operation is not completed in the specified amount of time. This prevents the node from being deleted for RKE1 clusters.
 
## Solution
Explicitly drop that error so that the node is always deleted regardless of the drain operations outcome. This change aligns behavior with the existing comments regarding deletion after drain. 
 
## Testing
This can be tested by creating a cluster with an invalid drain configuration (using a podDisruptionBudget) and observing that resources are still cleaned up. This can be tested by either deleting the entire cluster, or deleting a node within a node-pool which has `drain before delete` enabled. 

+ Begin creating an RKE1 cluster with two node pools. 1 Node pool will have the `etcd` & `cp` role, and 1 will be a worker only pool
+ Enable `Drain Before Delete` for the worker only node pool
+ Under `Advanced Options` enable `drain nodes`
+ Create the cluster and wait for it to become available
+ Enter the cluster explore page and create a new deployment 
   + The image for the deployment isn't important, I used `nginx:latest` 
   + The number of replicas for the deployment must be `1`
   + A label named `app` must be added to the deployment, and its value must be `test`
+ Create a deployment and PodDisruptionBudget by adding the following manifest to the cluster using the `import YAML` button
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: draindeployment
  labels:
    app: test
spec:
  replicas: 1
  selector:
    matchLabels:
      app: test
  template:
    metadata:
      labels:
        app: test
    spec:
      containers:
      - name: test
        image: nginx:latest

---
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
  name: drain-pdb
spec:
  minAvailable: 1
  selector:
    matchLabels:
      app: test
```
+ After creating the pod disruption budget delete the cluster (or any node within the worker node pool which has drain before delete enabled)
+ Observe the node get properly cleaned up and not stuck in a deleting phase, also observe that all resources are deleted from the infrastructure provider.

## Engineering Testing
### Manual Testing
I've done the tests above and have confirmed that the cluster gets fully deleted and nodes with invalid configurations preventing pod draining will still get cleaned up.

## QA Testing Considerations
+ Ensure that the PDB is configured correctly. 
+ It's not totally necessary to delete the entire cluster to validate the fix, you can also delete a single node from the pool to verify the fix (or reproduce the old behavior). 
+ The cluster / node will eventually be removed from the UI, its important you check the cloud provider for dangling resources.
 
### Regressions Considerations
None that I can think of.