### PR TITLE
Automation to allow rancher2 provider TF cluster resources to be tested with Terratest + Go

### DIFF
--- a/tests/terratest/README.md
+++ b/tests/terratest/README.md
@@ -1,0 +1,43 @@
+# rancher-terratest
+
+Automated tests for Terraform rancher2 provider using Terratest
+
+Provisioning and Scaling:
+- AWS Node driver
+  - RKE1
+  - RKE2
+  - K3s
+- Linode Node driver
+  - RKE1
+  - RKE2
+  - K3s
+- Hosted
+  - AKS
+  - EKS
+
+Kubernetes Upgrade:
+- AWS Node driver
+  - RKE2
+  - K3s
+- Linode Node driver
+  - RKE2
+  - K3s
+
+
+Functions:
+- **CleanupConfigTF**:
+  - parameters - (`module string`);
+  - description - cleans main.tf of desired module
+- **SetConfigTF**: 
+  - parameters - (`module string`, `k8sVersion string`, `nodepools []models.Nodepool`; returns `bool`
+  - description - sets config of desired module and overwrites existing main.tf
+- **WaitForActiveCluster**:
+  - parameters - (`t *testing.T`, `client *rancher.Client`, `clusterID string`, `module string`)
+  - description - waits until cluster is in an active state
+
+
+Note: 
+- Tests that timeout will not have cleaned up resources
+- Extending the test timeout is a best practice; default is 10m
+- To extend timeout, add `-timeout <int>m` when running tests
+  - e.g. `go test <testfile>.go -timeout 45m` || `go test <testfile>.go -timeout 1h`

--- a/tests/terratest/components/V2LinodeMachineConfig.go
+++ b/tests/terratest/components/V2LinodeMachineConfig.go
@@ -1,0 +1,12 @@
+package components
+
+var V2LinodeMachineConfig = `resource "rancher2_machine_config_v2" "rancher2_machine_config_v2" {
+  generate_name = var.machine_config_name
+  linode_config {
+	image     = var.image
+	region    = var.region
+	root_pass = var.root_pass
+	token     = var.linode_token
+  }
+}
+` 

--- a/tests/terratest/components/aksClusterPrefix.go
+++ b/tests/terratest/components/aksClusterPrefix.go
@@ -1,0 +1,10 @@
+package components
+
+var AKSClusterPrefix = `resource "rancher2_cluster" "rancher2_cluster" {
+  name = var.cluster_name
+  aks_config_v2 {
+    cloud_credential_id = rancher2_cloud_credential.rancher2_cloud_credential.id
+    resource_group = var.resource_group
+    resource_location = var.resource_location
+    dns_prefix = var.dns_prefix
+    kubernetes_version = "`

--- a/tests/terratest/components/aksClusterSpecs1.go
+++ b/tests/terratest/components/aksClusterSpecs1.go
@@ -1,0 +1,5 @@
+package components
+
+var AKSClusterSpecs1 = `"
+    network_plugin = var.network_plugin
+` 

--- a/tests/terratest/components/aksClusterSuffix.go
+++ b/tests/terratest/components/aksClusterSuffix.go
@@ -1,0 +1,5 @@
+package components
+
+var AKSClusterSuffix = `  }
+}
+` 

--- a/tests/terratest/components/aksNodePoolBody.go
+++ b/tests/terratest/components/aksNodePoolBody.go
@@ -1,0 +1,4 @@
+package components
+
+var AKSNodePoolBody = `"
+      count = `

--- a/tests/terratest/components/aksNodePoolBody2.go
+++ b/tests/terratest/components/aksNodePoolBody2.go
@@ -1,0 +1,4 @@
+package components
+
+var AKSNodePoolBody2 = `
+      orchestrator_version = "` 

--- a/tests/terratest/components/aksNodePoolPrefix.go
+++ b/tests/terratest/components/aksNodePoolPrefix.go
@@ -1,0 +1,5 @@
+package components
+
+var AKSNodePoolPrefix = `    node_pools {
+	    availability_zones = var.availability_zones
+	    name = "pool` 

--- a/tests/terratest/components/aksNodePoolSuffix.go
+++ b/tests/terratest/components/aksNodePoolSuffix.go
@@ -1,0 +1,7 @@
+package components
+
+var AKSNodePoolSuffix = `"
+      os_disk_size_gb = var.os_disk_size_gb
+      vm_size = var.vm_size
+    }
+` 

--- a/tests/terratest/components/azureCloudCredentials.go
+++ b/tests/terratest/components/azureCloudCredentials.go
@@ -1,0 +1,11 @@
+package components
+
+var AzureCloudCredentials = `resource "rancher2_cloud_credential" "rancher2_cloud_credential" {
+  name = var.cloud_credential_name
+  azure_credential_config {
+  client_id       = var.azure_client_id
+	client_secret   = var.azure_client_secret
+	subscription_id = var.azure_subscription_id
+  }
+}
+` 

--- a/tests/terratest/components/dataCloudCredentials.go
+++ b/tests/terratest/components/dataCloudCredentials.go
@@ -1,0 +1,6 @@
+package components
+
+var DataCloudCredentials = `data "rancher2_cloud_credential" "rancher2_cloud_credential" {
+  name = var.cloud_credential_name
+}
+` 

--- a/tests/terratest/components/eksClusterPrefix.go
+++ b/tests/terratest/components/eksClusterPrefix.go
@@ -1,0 +1,8 @@
+package components
+
+var EKSClusterPrefix = `resource "rancher2_cluster" "rancher2_cluster" {
+  name = var.cluster_name
+  eks_config_v2 {
+    cloud_credential_id = rancher2_cloud_credential.rancher2_cloud_credential.id
+	  region = var.aws_region
+	  kubernetes_version = "`

--- a/tests/terratest/components/eksClusterSpecs1.go
+++ b/tests/terratest/components/eksClusterSpecs1.go
@@ -1,0 +1,7 @@
+package components
+
+var EKSClusterSpecs1 = `"
+    subnets = var.aws_subnets
+    security_groups = var.aws_security_groups
+    private_access = var.private_access
+    public_access = var.public_access`

--- a/tests/terratest/components/eksClusterSuffix.go
+++ b/tests/terratest/components/eksClusterSuffix.go
@@ -1,0 +1,6 @@
+package components
+
+var EKSClusterSuffix = `
+  }
+}
+`

--- a/tests/terratest/components/eksNodePoolBody.go
+++ b/tests/terratest/components/eksNodePoolBody.go
@@ -1,0 +1,4 @@
+package components
+
+var EKSNodePoolBody = `"
+      instance_type = "`

--- a/tests/terratest/components/eksNodePoolBody1.go
+++ b/tests/terratest/components/eksNodePoolBody1.go
@@ -1,0 +1,4 @@
+package components
+
+var EKSNodePoolBody1 = `"
+      desired_size = `

--- a/tests/terratest/components/eksNodePoolBody2.go
+++ b/tests/terratest/components/eksNodePoolBody2.go
@@ -1,0 +1,4 @@
+package components
+
+var EKSNodePoolBody2 = `
+      max_size = `

--- a/tests/terratest/components/eksNodePoolBody3.go
+++ b/tests/terratest/components/eksNodePoolBody3.go
@@ -1,0 +1,4 @@
+package components
+
+var EKSNodePoolBody3 = `
+      min_size = `

--- a/tests/terratest/components/eksNodePoolPrefix.go
+++ b/tests/terratest/components/eksNodePoolPrefix.go
@@ -1,0 +1,5 @@
+package components
+
+var EKSNodePoolPrefix = `
+    node_groups {
+	    name = "${var.hostname_prefix}-tf-pool`

--- a/tests/terratest/components/eksNodePoolSuffix.go
+++ b/tests/terratest/components/eksNodePoolSuffix.go
@@ -1,0 +1,4 @@
+package components
+
+var EKSNodePoolSuffix = `
+    }`

--- a/tests/terratest/components/gkeCloudCredentials.go
+++ b/tests/terratest/components/gkeCloudCredentials.go
@@ -1,0 +1,9 @@
+package components
+
+var GkeCloudCredentials = `resource "rancher2_cloud_credential" "rancher2_cloud_credential" {
+  name = var.cloud_credential_name
+  google_credential_config {
+	auth_encoded_json = jsonencode(var.google_auth_encoded_json)
+  }
+}
+`

--- a/tests/terratest/components/gkeClusterPrefix.go
+++ b/tests/terratest/components/gkeClusterPrefix.go
@@ -1,0 +1,10 @@
+package components
+
+var GKEClusterPrefix = `resource "rancher2_cluster" "rancher2_cluster" {
+  name = var.cluster_name
+  gke_config_v2 {
+    name                     = var.cluster_name
+	  google_credential_secret = rancher2_cloud_credential.rancher2_cloud_credential.id
+	  region                   = var.gke_region
+	  project_id               = var.gke_project_id
+	  kubernetes_version       = "`

--- a/tests/terratest/components/gkeClusterSpecs.go
+++ b/tests/terratest/components/gkeClusterSpecs.go
@@ -1,0 +1,6 @@
+package components
+
+var GKEClusterSpecs = `"
+    network                  = var.gke_network
+    subnetwork               = var.gke_subnetwork
+`

--- a/tests/terratest/components/gkeClusterSuffix.go
+++ b/tests/terratest/components/gkeClusterSuffix.go
@@ -1,0 +1,4 @@
+package components
+
+var GKEClusterSuffix = `  }
+}`

--- a/tests/terratest/components/gkeNodePoolPrefix.go
+++ b/tests/terratest/components/gkeNodePoolPrefix.go
@@ -1,0 +1,4 @@
+package components
+
+var GKENodePoolPrefix = `    node_pools {
+      initial_node_count  = `

--- a/tests/terratest/components/gkeNodePoolSpecs1.go
+++ b/tests/terratest/components/gkeNodePoolSpecs1.go
@@ -1,0 +1,4 @@
+package components
+
+var GKENodePoolSpecs1 = `
+      max_pods_constraint = `

--- a/tests/terratest/components/gkeNodePoolSpecs2.go
+++ b/tests/terratest/components/gkeNodePoolSpecs2.go
@@ -1,0 +1,4 @@
+package components
+
+var GKENodePoolSpecs2 = `
+      name                = "${var.hostname_prefix}-tf-gke-pool`

--- a/tests/terratest/components/gkeNodePoolSpecs3.go
+++ b/tests/terratest/components/gkeNodePoolSpecs3.go
@@ -1,0 +1,4 @@
+package components
+
+var GKENodePoolSpecs3 = `"
+      version             = "`

--- a/tests/terratest/components/gkeNodePoolSuffix.go
+++ b/tests/terratest/components/gkeNodePoolSuffix.go
@@ -1,0 +1,5 @@
+package components
+
+var GKENodePoolSuffix = `"
+    }
+`

--- a/tests/terratest/components/provider.go
+++ b/tests/terratest/components/provider.go
@@ -1,0 +1,8 @@
+package components
+
+var Provider = `provider "rancher2" {
+  api_url   = var.rancher_api_url
+  token_key = var.rancher_admin_bearer_token
+  insecure  = true
+}
+`

--- a/tests/terratest/components/requiredProviders.go
+++ b/tests/terratest/components/requiredProviders.go
@@ -1,0 +1,11 @@
+package components
+
+var RequiredProviders = `terraform {
+  required_providers {
+	  rancher2 = {
+	    source  = "rancher/rancher2"
+	    version = "1.24.2"
+	  }
+  }
+}
+` 

--- a/tests/terratest/components/resourceEC2CloudCredentials.go
+++ b/tests/terratest/components/resourceEC2CloudCredentials.go
@@ -1,0 +1,11 @@
+package components
+
+var ResourceEC2CloudCredentials = `resource "rancher2_cloud_credential" "rancher2_cloud_credential" {
+  name = var.cloud_credential_name
+  amazonec2_credential_config {
+    access_key = var.aws_access_key
+    secret_key = var.aws_secret_key
+    default_region = var.aws_region
+  }
+}
+` 

--- a/tests/terratest/components/rke1ClusterPrefix.go
+++ b/tests/terratest/components/rke1ClusterPrefix.go
@@ -1,0 +1,7 @@
+package components
+
+var RKE1ClusterPrefix = `resource "rancher2_cluster" "rancher2_cluster" {
+  depends_on = [rancher2_node_template.rancher2_node_template]
+  name       = var.cluster_name
+  rke_config {
+    kubernetes_version = "` 

--- a/tests/terratest/components/rke1ClusterSuffix.go
+++ b/tests/terratest/components/rke1ClusterSuffix.go
@@ -1,0 +1,9 @@
+package components
+
+var RKE1ClusterSuffix = `"
+    network {
+      plugin = var.network_plugin
+    }
+  }
+}
+` 

--- a/tests/terratest/components/rke1ClusterSyncPrefix.go
+++ b/tests/terratest/components/rke1ClusterSyncPrefix.go
@@ -1,0 +1,5 @@
+package components
+
+var RKE1ClusterSyncPrefix = `resource "rancher2_cluster_sync" "rancher2_cluster_sync" {
+cluster_id    = rancher2_cluster.rancher2_cluster.id
+`

--- a/tests/terratest/components/rke1ClusterSyncSuffix.go
+++ b/tests/terratest/components/rke1ClusterSyncSuffix.go
@@ -1,0 +1,6 @@
+package components
+
+var RKE1ClusterSyncSuffix = `
+  state_confirm = 2
+}
+` 

--- a/tests/terratest/components/rke1EC2NodeTemplate.go
+++ b/tests/terratest/components/rke1EC2NodeTemplate.go
@@ -1,0 +1,18 @@
+package components
+
+var RKE1EC2NodeTemplate = `resource "rancher2_node_template" "rancher2_node_template" {
+  name               = var.node_template_name
+  amazonec2_config {
+    access_key     = var.aws_access_key
+    secret_key     = var.aws_secret_key
+	  ami            = var.aws_ami
+	  region         = var.aws_region
+	  security_group = [var.aws_security_group_name]
+	  subnet_id      = var.aws_subnet_id
+	  vpc_id         = var.aws_vpc_id
+	  zone           = var.aws_zone_letter
+	  root_size      = var.aws_root_size
+	  instance_type  = var.aws_instance_type
+  }
+}
+` 

--- a/tests/terratest/components/rke1LinodeNodeTemplate.go
+++ b/tests/terratest/components/rke1LinodeNodeTemplate.go
@@ -1,0 +1,12 @@
+package components
+
+var RKE1LinodeNodeTemplate = `resource "rancher2_node_template" "rancher2_node_template" {
+	name               = var.node_template_name
+	linode_config {
+	  image     = var.image
+	  region    = var.region
+	  root_pass = var.root_pass
+	  token     = var.linode_token
+	}
+  }
+`

--- a/tests/terratest/components/rke1NodePoolPrefix.go
+++ b/tests/terratest/components/rke1NodePoolPrefix.go
@@ -1,0 +1,3 @@
+package components
+
+var RKE1NodePoolPrefix = `resource "rancher2_node_pool" "pool` 

--- a/tests/terratest/components/rke1NodePoolSpecs1.go
+++ b/tests/terratest/components/rke1NodePoolSpecs1.go
@@ -1,0 +1,6 @@
+package components
+
+var RKE1NodePoolSpecs1 = `" {
+  depends_on       = [rancher2_cluster.rancher2_cluster]
+  cluster_id       = rancher2_cluster.rancher2_cluster.id
+  name             = "pool` 

--- a/tests/terratest/components/rke1NodePoolSpecs2.go
+++ b/tests/terratest/components/rke1NodePoolSpecs2.go
@@ -1,0 +1,4 @@
+package components
+
+var RKE1NodePoolSpecs2 = `"
+  hostname_prefix  = "${var.hostname_prefix}-tf-pool`

--- a/tests/terratest/components/rke1NodePoolSpecs25.go
+++ b/tests/terratest/components/rke1NodePoolSpecs25.go
@@ -1,0 +1,5 @@
+package components
+
+var RKE1NodePoolSpecs25 = `
+  node_template_id = rancher2_node_template.rancher2_node_template.id
+  quantity         = ` 

--- a/tests/terratest/components/rke1NodePoolSpecs3.go
+++ b/tests/terratest/components/rke1NodePoolSpecs3.go
@@ -1,0 +1,4 @@
+package components
+
+var RKE1NodePoolSpecs3 = `
+  control_plane    = ` 

--- a/tests/terratest/components/rke1NodePoolSpecs4.go
+++ b/tests/terratest/components/rke1NodePoolSpecs4.go
@@ -1,0 +1,4 @@
+package components
+
+var RKE1NodePoolSpecs4 = `
+  etcd             = ` 

--- a/tests/terratest/components/rke1NodePoolSpecs5.go
+++ b/tests/terratest/components/rke1NodePoolSpecs5.go
@@ -1,0 +1,4 @@
+package components
+
+var RKE1NodePoolSpecs5 = ` 
+  worker           = ` 

--- a/tests/terratest/components/rke1NodePoolSuffix.go
+++ b/tests/terratest/components/rke1NodePoolSuffix.go
@@ -1,0 +1,5 @@
+package components
+
+var RKE1NodePoolSuffix = ` 
+}
+` 

--- a/tests/terratest/components/v2ClusterBody.go
+++ b/tests/terratest/components/v2ClusterBody.go
@@ -1,0 +1,7 @@
+package components
+
+var V2ClusterBody = `"
+  enable_network_policy                    = var.enable_network_policy
+  default_cluster_role_for_project_members = var.default_cluster_role_for_project_members
+  rke_config {
+` 

--- a/tests/terratest/components/v2ClusterPrefix.go
+++ b/tests/terratest/components/v2ClusterPrefix.go
@@ -1,0 +1,5 @@
+package components
+
+var V2ClusterPrefix = `resource "rancher2_cluster_v2" "rancher2_cluster_v2" {
+  name                                     = var.cluster_name
+  kubernetes_version                       = "` 

--- a/tests/terratest/components/v2ClusterSuffix.go
+++ b/tests/terratest/components/v2ClusterSuffix.go
@@ -1,0 +1,5 @@
+package components
+
+var V2ClusterSuffix = `  }
+}
+` 

--- a/tests/terratest/components/v2EC2MachineConfig.go
+++ b/tests/terratest/components/v2EC2MachineConfig.go
@@ -1,0 +1,14 @@
+package components
+
+var V2EC2MachineConfig = `resource "rancher2_machine_config_v2" "rancher2_machine_config_v2" {
+  generate_name = var.machine_config_name
+  amazonec2_config {
+	ami            = var.aws_ami
+	region         = var.aws_region
+	security_group = [var.aws_security_group_name]
+	subnet_id      = var.aws_subnet_id
+	vpc_id         = var.aws_vpc_id
+	zone           = var.aws_zone_letter
+  }
+}
+` 

--- a/tests/terratest/components/v2MachinePoolSpecs3.go
+++ b/tests/terratest/components/v2MachinePoolSpecs3.go
@@ -1,0 +1,4 @@
+package components
+
+var V2MachinePoolsSpecs3 = `
+    worker_role                  = ` 

--- a/tests/terratest/components/v2MachinePoolSpecs4.go
+++ b/tests/terratest/components/v2MachinePoolSpecs4.go
@@ -1,0 +1,4 @@
+package components
+
+var V2MachinePoolsSpecs4 = `
+    quantity                     = ` 

--- a/tests/terratest/components/v2MachinePoolsPrefix.go
+++ b/tests/terratest/components/v2MachinePoolsPrefix.go
@@ -1,0 +1,4 @@
+package components
+
+var V2MachinePoolsPrefix = `    machine_pools {
+	  name                         = "pool` 

--- a/tests/terratest/components/v2MachinePoolsSpecs1.go
+++ b/tests/terratest/components/v2MachinePoolsSpecs1.go
@@ -1,0 +1,5 @@
+package components
+
+var V2MachinePoolsSpecs1 = `"
+    cloud_credential_secret_name = data.rancher2_cloud_credential.rancher2_cloud_credential.id
+    control_plane_role           = ` 

--- a/tests/terratest/components/v2MachinePoolsSpecs2.go
+++ b/tests/terratest/components/v2MachinePoolsSpecs2.go
@@ -1,0 +1,4 @@
+package components
+
+var V2MachinePoolsSpecs2 = `
+    etcd_role                    = ` 

--- a/tests/terratest/components/v2MachinePoolsSpecsSuffix.go
+++ b/tests/terratest/components/v2MachinePoolsSpecsSuffix.go
@@ -1,0 +1,9 @@
+package components
+
+var V2MachinePoolsSuffix = `
+      machine_config {
+        kind = rancher2_machine_config_v2.rancher2_machine_config_v2.kind
+        name = rancher2_machine_config_v2.rancher2_machine_config_v2.name
+      }
+    }
+` 

--- a/tests/terratest/functions/cleanupConfigTF.go
+++ b/tests/terratest/functions/cleanupConfigTF.go
@@ -1,0 +1,54 @@
+package functions
+
+import (
+	"os"
+)
+
+func CleanupConfigTF(module string) error {
+
+	path := "../../modules/"
+
+	if module == "aks" || module == "eks" || module == "gke" {
+		path = path + "hosted/"
+	}
+
+	if module == "ec2_k3s" || module == "ec2_rke1" || module == "ec2_rke2" || module == "linode_k3s" || module == "linode_rke1" || module == "linode_rke2" {
+		path = path + "node_driver/"
+	}
+
+	// TODO: Add path logic for custom clusters, once supported
+
+	file, err := os.Create(path + module + "/main.tf")
+
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	_, err = file.WriteString("// Leave blank - main.tf will be set during testing")
+
+	if err != nil {
+		return err
+	}
+
+	delete_files := [3]string{"/terraform.tfstate", "/terraform.tfstate.backup", "/.terraform.lock.hcl"}
+
+	for _, delete_file := range delete_files {
+		delete_file = path + module + delete_file
+		err = os.Remove(delete_file)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	err = os.RemoveAll(path + module + "/.terraform")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Use this to clean up terraform config files after testing - [terraform.tfstate, terraform.tfstate.backup, .terraform.lock.hcl, .terraform]

--- a/tests/terratest/functions/cleanupVarsTF.go
+++ b/tests/terratest/functions/cleanupVarsTF.go
@@ -1,0 +1,36 @@
+package functions
+
+import (
+	"os"
+)
+
+func CleanupVarsTF(module string) error {
+
+	path := "../../modules/"
+
+	if module == "aks" || module == "eks" || module == "gke" {
+		path = path + "hosted/"
+	}
+
+	if module == "ec2_k3s" || module == "ec2_rke1" || module == "ec2_rke2" || module == "linode_k3s" || module == "linode_rke1" || module == "linode_rke2" {
+		path = path + "node_driver/"
+	}
+
+	// TODO: Add path logic for custom clusters, once supported
+
+	file, err := os.Create(path + module + "/terraform.tfvars")
+
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	_, err = file.WriteString("// Leave blank - terraform.tfvars will be set during testing")
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/terratest/functions/setConfigTF.go
+++ b/tests/terratest/functions/setConfigTF.go
@@ -1,0 +1,33 @@
+package functions
+
+import (
+	"os"
+
+	"github.com/rancher/rancher/tests/terratest/components"
+	functions "github.com/rancher/rancher/tests/terratest/functions/set_modules"
+	"github.com/rancher/rancher/tests/terratest/models"
+)
+
+func SetConfigTF(module string, k8sVersion string, nodePools []models.Nodepool) (done bool, err error) {
+
+	var result bool
+	var file *os.File
+
+	config := components.RequiredProviders + components.Provider
+
+	// Hosted
+	if module == "aks" || module == "eks" || module == "gke" {
+		result, err = functions.SetHostedModules(module, k8sVersion, nodePools, result, file, config)
+		return result, err
+	}
+
+	// Node_driver
+	if module == "ec2_rke1" || module == "ec2_rke2" || module == "ec2_k3s" || module == "linode_rke1" || module == "linode_rke2" || module == "linode_k3s" {
+		result, err = functions.SetNodeDriverModules(module, k8sVersion, nodePools, result, file, config)
+		return result, err
+	}
+
+	// TODO: Add Custom
+
+	return false, err
+}

--- a/tests/terratest/functions/setVarsTF.go
+++ b/tests/terratest/functions/setVarsTF.go
@@ -1,0 +1,144 @@
+package functions
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/terratest/tests"
+)
+
+func SetVarsTF(module string) (done bool, err error) {
+
+	rancherConfig := new(rancher.Config)
+	config.LoadConfig("rancher", rancherConfig)
+
+	terraformConfig := new(tests.TerraformConfig)
+	config.LoadConfig("terraform", terraformConfig)
+
+	switch {
+	case module == "aks":
+		file, err := os.Create("../../modules/hosted/" + module + "/terraform.tfvars")
+
+		if err != nil {
+			return false, err
+		}
+
+		defer file.Close()
+
+		tfvarFile := fmt.Sprintf("rancher_api_url = \"https://%s\"\nrancher_admin_bearer_token = \"%s\"\ncloud_credential_name = \"%s\"\nazure_client_id = \"%s\"\nazure_client_secret = \"%s\"\nazure_subscription_id = \"%s\"\ncluster_name = \"%s\"\nresource_group = \"%s\"\nresource_location = \"%s\"\ndns_prefix = \"%s\"\nnetwork_plugin = \"%s\"\navailability_zones = [%s]\nos_disk_size_gb = \"%s\"\nvm_size = \"%s\"", rancherConfig.Host, rancherConfig.AdminToken, terraformConfig.CloudCredentialName, terraformConfig.AzureClientID, terraformConfig.AzureClientSecret, terraformConfig.AzureSubscriptionID, terraformConfig.ClusterName, terraformConfig.ResourceGroup, terraformConfig.ResourceLocation, terraformConfig.HostnamePrefix, terraformConfig.NetworkPlugin, terraformConfig.AvailabilityZones, terraformConfig.OSDiskSizeGB, terraformConfig.VMSize)
+		_, err = file.WriteString(tfvarFile)
+
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+
+	case module == "eks":
+		file, err := os.Create("../../modules/hosted/" + module + "/terraform.tfvars")
+
+		if err != nil {
+			return false, err
+		}
+
+		defer file.Close()
+
+		tfvarFile := fmt.Sprintf("rancher_api_url = \"https://%s\"\nrancher_admin_bearer_token = \"%s\"\ncloud_credential_name = \"%s\"\naws_access_key = \"%s\"\naws_secret_key = \"%s\"\naws_instance_type = \"%s\"\naws_region = \"%s\"\naws_subnets = [%s]\naws_security_groups = [%s]\ncluster_name = \"%s\"\nhostname_prefix = \"%s\"\npublic_access = \"%s\"\nprivate_access = \"%s\"", rancherConfig.Host, rancherConfig.AdminToken, terraformConfig.CloudCredentialName, terraformConfig.AWSAccessKey, terraformConfig.AWSSecretKey, terraformConfig.AWSInstanceType, terraformConfig.Region, terraformConfig.AWSSubnets, terraformConfig.AWSSecurityGroups, terraformConfig.ClusterName, terraformConfig.HostnamePrefix, terraformConfig.PublicAccess, terraformConfig.PrivateAccess)
+		_, err = file.WriteString(tfvarFile)
+
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+
+	case module == "gke":
+		file, err := os.Create("../../modules/hosted/" + module + "/terraform.tfvars")
+
+		if err != nil {
+			return false, err
+		}
+
+		defer file.Close()
+
+		tfvarFile := fmt.Sprintf("rancher_api_url = \"https://%s\"\nrancher_admin_bearer_token = \"%s\"\ngoogle_auth_encoded_json = \"%s\"\ncloud_credential_name = \"%s\"\ncluster_name = \"%s\"\ngke_region = \"%s\"\ngke_project_id = \"%s\"\ngke_network = \"%s\"\ngke_subnetwork = \"%s\"\nhostname_prefix = \"%s\"", rancherConfig.Host, rancherConfig.AdminToken, terraformConfig.GoogleAuthEncodedJSON, terraformConfig.CloudCredentialName, terraformConfig.ClusterName, terraformConfig.Region, terraformConfig.GKEProjectID, terraformConfig.GKENetwork, terraformConfig.GKESubnetwork, terraformConfig.HostnamePrefix)
+		_, err = file.WriteString(tfvarFile)
+
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+
+	case module == "ec2_k3s" || module == "ec2_rke2":
+		file, err := os.Create("../../modules/node_driver/" + module + "/terraform.tfvars")
+
+		if err != nil {
+			return false, err
+		}
+
+		defer file.Close()
+
+		tfvarFile := fmt.Sprintf("rancher_api_url = \"https://%s\"\nrancher_admin_bearer_token = \"%s\"\ncloud_credential_name = \"%s\"\naws_access_key = \"%s\"\naws_secret_key = \"%s\"\naws_ami = \"%s\"\naws_region = \"%s\"\naws_security_group_name = \"%s\"\naws_subnet_id = \"%s\"\naws_vpc_id = \"%s\"\naws_zone_letter = \"%s\"\nmachine_config_name = \"%s\"\ncluster_name = \"%s\"\nenable_network_policy = \"%s\"\ndefault_cluster_role_for_project_members = \"%s\"", rancherConfig.Host, rancherConfig.AdminToken, terraformConfig.CloudCredentialName, terraformConfig.AWSAccessKey, terraformConfig.AWSSecretKey, terraformConfig.Ami, terraformConfig.Region, terraformConfig.AWSSecurityGroupName, terraformConfig.AWSSubnetID, terraformConfig.AWSVpcID, terraformConfig.AWSZoneLetter, terraformConfig.MachineConfigName, terraformConfig.ClusterName, terraformConfig.EnableNetworkPolicy, terraformConfig.DefaultClusterRoleForProjectMembers)
+		_, err = file.WriteString(tfvarFile)
+
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+
+	case module == "ec2_rke1":
+		file, err := os.Create("../../modules/node_driver/" + module + "/terraform.tfvars")
+
+		if err != nil {
+			return false, err
+		}
+
+		defer file.Close()
+
+		tfvarFile := fmt.Sprintf("rancher_api_url = \"https://%s\"\nrancher_admin_bearer_token = \"%s\"\naws_access_key = \"%s\"\naws_secret_key = \"%s\"\naws_ami = \"%s\"\naws_instance_type = \"%s\"\naws_region = \"%s\"\naws_security_group_name = \"%s\"\naws_subnet_id = \"%s\"\naws_vpc_id = \"%s\"\naws_zone_letter = \"%s\"\naws_root_size = \"%s\"\ncluster_name = \"%s\"\nnetwork_plugin = \"%s\"\nnode_template_name = \"%s\"\nhostname_prefix = \"%s\"", rancherConfig.Host, rancherConfig.AdminToken, terraformConfig.AWSAccessKey, terraformConfig.AWSSecretKey, terraformConfig.Ami, terraformConfig.AWSInstanceType, terraformConfig.Region, terraformConfig.AWSSecurityGroupName, terraformConfig.AWSSubnetID, terraformConfig.AWSVpcID, terraformConfig.AWSZoneLetter, terraformConfig.AWSRootSize, terraformConfig.ClusterName, terraformConfig.NetworkPlugin, terraformConfig.NodeTemplateName, terraformConfig.HostnamePrefix)
+		_, err = file.WriteString(tfvarFile)
+
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+
+	case module == "linode_k3s" || module == "linode_rke2":
+		file, err := os.Create("../../modules/node_driver/" + module + "/terraform.tfvars")
+
+		if err != nil {
+			return false, err
+		}
+
+		defer file.Close()
+
+		tfvarFile := fmt.Sprintf("rancher_api_url = \"https://%s\"\nrancher_admin_bearer_token = \"%s\"\ncloud_credential_name = \"%s\"\nlinode_token = \"%s\"\nimage = \"%s\"\nregion = \"%s\"\nroot_pass = \"%s\"\nmachine_config_name = \"%s\"\ncluster_name = \"%s\"\nenable_network_policy = \"%s\"\ndefault_cluster_role_for_project_members = \"%s\"", rancherConfig.Host, rancherConfig.AdminToken, terraformConfig.CloudCredentialName, terraformConfig.LinodeToken, terraformConfig.LinodeImage, terraformConfig.Region, terraformConfig.LinodeRootPass, terraformConfig.MachineConfigName, terraformConfig.ClusterName, terraformConfig.EnableNetworkPolicy, terraformConfig.DefaultClusterRoleForProjectMembers)
+		_, err = file.WriteString(tfvarFile)
+
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+
+	case module == "linode_rke1":
+		file, err := os.Create("../../modules/node_driver/" + module + "/terraform.tfvars")
+
+		if err != nil {
+			return false, err
+		}
+
+		defer file.Close()
+
+		tfvarFile := fmt.Sprintf("rancher_api_url = \"https://%s\"\nrancher_admin_bearer_token = \"%s\"\nlinode_token = \"%s\"\nimage = \"%s\"\nregion = \"%s\"\nroot_pass = \"%s\"\ncluster_name = \"%s\"\nnetwork_plugin = \"%s\"\nnode_template_name = \"%s\"\nhostname_prefix = \"%s\"", rancherConfig.Host, rancherConfig.AdminToken, terraformConfig.LinodeToken, terraformConfig.LinodeImage, terraformConfig.Region, terraformConfig.LinodeRootPass, terraformConfig.ClusterName, terraformConfig.NetworkPlugin, terraformConfig.NodeTemplateName, terraformConfig.HostnamePrefix)
+		_, err = file.WriteString(tfvarFile)
+
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+
+	default:
+		return false, fmt.Errorf("invalid module provided")
+	}
+
+}

--- a/tests/terratest/functions/set_modules/setAKS.go
+++ b/tests/terratest/functions/set_modules/setAKS.go
@@ -1,0 +1,35 @@
+package functions
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/rancher/rancher/tests/terratest/components"
+	"github.com/rancher/rancher/tests/terratest/models"
+)
+
+func SetAKS(module string, k8sVersion string, nodePools []models.Nodepool, config string, file *os.File) (done bool, err error) {
+	config = config + components.AzureCloudCredentials
+	poolConfig := ``
+	num := 1
+	for _, pool := range nodePools {
+		poolNum := strconv.Itoa(num)
+		quantity := strconv.Itoa(pool.Quantity)
+		if pool.Etcd != "true" && pool.Cp != "true" && pool.Wkr != "true" {
+			return false, fmt.Errorf(`no roles selected for pool` + poolNum + `; at least one role is required`)
+		}
+		if pool.Quantity <= 0 {
+			return false, fmt.Errorf(`invalid quantity specified for pool` + poolNum + `; quantity must be greater than 0`)
+		}
+		poolConfig = poolConfig + components.AKSNodePoolPrefix + poolNum + components.AKSNodePoolBody + quantity + components.AKSNodePoolBody2 + k8sVersion + components.AKSNodePoolSuffix
+		num = num + 1
+	}
+	config = config + components.AKSClusterPrefix + k8sVersion + components.AKSClusterSpecs1 + poolConfig + components.AKSClusterSuffix
+	_, err = file.WriteString(config)
+
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/tests/terratest/functions/set_modules/setEC2RKE1.go
+++ b/tests/terratest/functions/set_modules/setEC2RKE1.go
@@ -1,0 +1,43 @@
+package functions
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/rancher/rancher/tests/terratest/components"
+	"github.com/rancher/rancher/tests/terratest/models"
+)
+
+func SetEC2RKE1(module string, k8sVersion string, nodePools []models.Nodepool, config string, file *os.File) (done bool, err error) {
+	config = config + components.RKE1ClusterPrefix + k8sVersion + components.RKE1ClusterSuffix + components.RKE1EC2NodeTemplate
+	poolConfig := ``
+	clusterSyncNodePoolIDs := `  node_pool_ids = [`
+	num := 1
+	for _, pool := range nodePools {
+		poolNum := strconv.Itoa(num)
+		quantity := strconv.Itoa(pool.Quantity)
+		if pool.Etcd != "true" && pool.Cp != "true" && pool.Wkr != "true" {
+			return false, fmt.Errorf(`no roles selected for pool` + poolNum + `; at least one role is required`)
+		}
+		if pool.Quantity <= 0 {
+			return false, fmt.Errorf(`invalid quantity specified for pool` + poolNum + `; quantity must be greater than 0`)
+		}
+		poolConfig = poolConfig + components.RKE1NodePoolPrefix + poolNum + components.RKE1NodePoolSpecs1 + poolNum + components.RKE1NodePoolSpecs2 + poolNum + `-"` + components.RKE1NodePoolSpecs25 + quantity + components.RKE1NodePoolSpecs3 + pool.Cp + components.RKE1NodePoolSpecs4 + pool.Etcd + components.RKE1NodePoolSpecs5 + pool.Wkr + components.RKE1NodePoolSuffix
+		if num != len(nodePools) {
+			clusterSyncNodePoolIDs = clusterSyncNodePoolIDs + `rancher2_node_pool.pool` + poolNum + `.id, `
+		}
+		if num == len(nodePools) {
+			clusterSyncNodePoolIDs = clusterSyncNodePoolIDs + `rancher2_node_pool.pool` + poolNum + `.id]`
+		}
+		num = num + 1
+	}
+	config = config + poolConfig + components.RKE1ClusterSyncPrefix + clusterSyncNodePoolIDs + components.RKE1ClusterSyncSuffix
+
+	_, err = file.WriteString(config)
+
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/tests/terratest/functions/set_modules/setEC2RKE2K3s.go
+++ b/tests/terratest/functions/set_modules/setEC2RKE2K3s.go
@@ -1,0 +1,36 @@
+package functions
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/rancher/rancher/tests/terratest/components"
+	"github.com/rancher/rancher/tests/terratest/models"
+)
+
+func SetEC2RKE2K3s(module string, k8sVersion string, nodePools []models.Nodepool, config string, file *os.File) (done bool, err error) {
+	config = config + components.DataCloudCredentials + components.V2EC2MachineConfig
+	poolConfig := ``
+	num := 1
+	for _, pool := range nodePools {
+		poolNum := strconv.Itoa(num)
+		quantity := strconv.Itoa(pool.Quantity)
+		if pool.Etcd != "true" && pool.Cp != "true" && pool.Wkr != "true" {
+			return false, fmt.Errorf(`no roles selected for pool` + poolNum + `; at least one role is required`)
+		}
+		if pool.Quantity <= 0 {
+			return false, fmt.Errorf(`invalid quantity specified for pool` + poolNum + `; quantity must be greater than 0`)
+		}
+		poolConfig = poolConfig + components.V2MachinePoolsPrefix + poolNum + components.V2MachinePoolsSpecs1 + pool.Cp + components.V2MachinePoolsSpecs2 + pool.Etcd + components.V2MachinePoolsSpecs3 + pool.Wkr + components.V2MachinePoolsSpecs4 + quantity + components.V2MachinePoolsSuffix
+		num = num + 1
+	}
+	config = config + components.V2ClusterPrefix + k8sVersion + components.V2ClusterBody + poolConfig + components.V2ClusterSuffix
+
+	_, err = file.WriteString(config)
+
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/tests/terratest/functions/set_modules/setEKS.go
+++ b/tests/terratest/functions/set_modules/setEKS.go
@@ -1,0 +1,34 @@
+package functions
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/rancher/rancher/tests/terratest/components"
+	"github.com/rancher/rancher/tests/terratest/models"
+)
+
+func SetEKS(module string, k8sVersion string, nodePools []models.Nodepool, config string, file *os.File) (done bool, err error) {
+	config = config + components.ResourceEC2CloudCredentials
+	poolConfig := ``
+	num := 1
+	for _, pool := range nodePools {
+		poolNum := strconv.Itoa(num)
+		desired_size := strconv.Itoa(pool.DesiredSize)
+		max_size := strconv.Itoa(pool.MaxSize)
+		min_size := strconv.Itoa(pool.MinSize)
+		if pool.DesiredSize <= 1 {
+			return false, fmt.Errorf(`invalid quantity specified for pool` + poolNum + `; quantity must be greater than 1`)
+		}
+		poolConfig = poolConfig + components.EKSNodePoolPrefix + poolNum + components.EKSNodePoolBody + pool.InstanceType + components.EKSNodePoolBody1 + desired_size + components.EKSNodePoolBody2 + max_size + components.EKSNodePoolBody3 + min_size + components.EKSNodePoolSuffix
+		num = num + 1
+	}
+	config = config + components.EKSClusterPrefix + k8sVersion + components.EKSClusterSpecs1 + poolConfig + components.EKSClusterSuffix
+	_, err = file.WriteString(config)
+
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/tests/terratest/functions/set_modules/setGKE.go
+++ b/tests/terratest/functions/set_modules/setGKE.go
@@ -1,0 +1,33 @@
+package functions
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/rancher/rancher/tests/terratest/components"
+	"github.com/rancher/rancher/tests/terratest/models"
+)
+
+func SetGKE(module string, k8sVersion string, nodePools []models.Nodepool, config string, file *os.File) (done bool, err error) {
+	config = config + components.GkeCloudCredentials
+	poolConfig := ``
+	num := 1
+	for _, pool := range nodePools {
+		poolNum := strconv.Itoa(num)
+		quantity := strconv.Itoa(pool.Quantity)
+		max_pods_contraint := strconv.Itoa(pool.MaxPodsContraint)
+		if pool.Quantity <= 0 {
+			return false, fmt.Errorf(`invalid quantity specified for pool` + poolNum + `; quantity must be greater than 0`)
+		}
+		poolConfig = poolConfig + components.GKENodePoolPrefix + quantity + components.GKENodePoolSpecs1 + max_pods_contraint + components.GKENodePoolSpecs2 + poolNum + components.GKENodePoolSpecs3 + k8sVersion + components.GKENodePoolSuffix
+		num = num + 1
+	}
+	config = config + components.GKEClusterPrefix + k8sVersion + components.GKEClusterSpecs + poolConfig + components.GKEClusterSuffix
+	_, err = file.WriteString(config)
+
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/tests/terratest/functions/set_modules/setHostedModules.go
+++ b/tests/terratest/functions/set_modules/setHostedModules.go
@@ -1,0 +1,35 @@
+package functions
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rancher/rancher/tests/terratest/models"
+)
+
+func SetHostedModules(module string, k8sVersion string, nodePools []models.Nodepool, result bool, file *os.File, config string) (done bool, err error) {
+	file, err = os.Create("../../modules/hosted/" + module + "/main.tf")
+
+	if err != nil {
+		return false, err
+	}
+
+	defer file.Close()
+
+	switch {
+	case module == "aks":
+		result, err = SetAKS(module, k8sVersion, nodePools, config, file)
+		return result, err
+
+	case module == "eks":
+		result, err = SetEKS(module, k8sVersion, nodePools, config, file)
+		return result, err
+
+	case module == "gke":
+		result, err = SetGKE(module, k8sVersion, nodePools, config, file)
+		return result, err
+
+	default:
+		return false, fmt.Errorf("invalid hosted module provided")
+	}
+}

--- a/tests/terratest/functions/set_modules/setLinodeRKE1.go
+++ b/tests/terratest/functions/set_modules/setLinodeRKE1.go
@@ -1,0 +1,43 @@
+package functions
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/rancher/rancher/tests/terratest/components"
+	"github.com/rancher/rancher/tests/terratest/models"
+)
+
+func SetLinodeRKE1(module string, k8sVersion string, nodePools []models.Nodepool, config string, file *os.File) (done bool, err error) {
+	config = config + components.RKE1ClusterPrefix + k8sVersion + components.RKE1ClusterSuffix + components.RKE1LinodeNodeTemplate
+	poolConfig := ``
+	clusterSyncNodePoolIDs := `  node_pool_ids = [`
+	num := 1
+	for _, pool := range nodePools {
+		poolNum := strconv.Itoa(num)
+		quantity := strconv.Itoa(pool.Quantity)
+		if pool.Etcd != "true" && pool.Cp != "true" && pool.Wkr != "true" {
+			return false, fmt.Errorf(`no roles selected for pool` + poolNum + `; at least one role is required`)
+		}
+		if pool.Quantity <= 0 {
+			return false, fmt.Errorf(`invalid quantity specified for pool` + poolNum + `; quantity must be greater than 0`)
+		}
+		poolConfig = poolConfig + components.RKE1NodePoolPrefix + poolNum + components.RKE1NodePoolSpecs1 + poolNum + components.RKE1NodePoolSpecs2 + poolNum + `-"` + components.RKE1NodePoolSpecs25 + quantity + components.RKE1NodePoolSpecs3 + pool.Cp + components.RKE1NodePoolSpecs4 + pool.Etcd + components.RKE1NodePoolSpecs5 + pool.Wkr + components.RKE1NodePoolSuffix
+		if num != len(nodePools) {
+			clusterSyncNodePoolIDs = clusterSyncNodePoolIDs + `rancher2_node_pool.pool` + poolNum + `.id, `
+		}
+		if num == len(nodePools) {
+			clusterSyncNodePoolIDs = clusterSyncNodePoolIDs + `rancher2_node_pool.pool` + poolNum + `.id]`
+		}
+		num = num + 1
+	}
+	config = config + poolConfig + components.RKE1ClusterSyncPrefix + clusterSyncNodePoolIDs + components.RKE1ClusterSyncSuffix
+
+	_, err = file.WriteString(config)
+
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/tests/terratest/functions/set_modules/setLinodeRKE2K3s.go
+++ b/tests/terratest/functions/set_modules/setLinodeRKE2K3s.go
@@ -1,0 +1,36 @@
+package functions
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/rancher/rancher/tests/terratest/components"
+	"github.com/rancher/rancher/tests/terratest/models"
+)
+
+func SetLinodeRKE2K3s(module string, k8sVersion string, nodePools []models.Nodepool, config string, file *os.File) (done bool, err error) {
+	config = config + components.DataCloudCredentials + components.V2LinodeMachineConfig
+	poolConfig := ``
+	num := 1
+	for _, pool := range nodePools {
+		poolNum := strconv.Itoa(num)
+		quantity := strconv.Itoa(pool.Quantity)
+		if pool.Etcd != "true" && pool.Cp != "true" && pool.Wkr != "true" {
+			return false, fmt.Errorf(`no roles selected for pool` + poolNum + `; at least one role is required`)
+		}
+		if pool.Quantity <= 0 {
+			return false, fmt.Errorf(`invalid quantity specified for pool` + poolNum + `; quantity must be greater than 0`)
+		}
+		poolConfig = poolConfig + components.V2MachinePoolsPrefix + poolNum + components.V2MachinePoolsSpecs1 + pool.Cp + components.V2MachinePoolsSpecs2 + pool.Etcd + components.V2MachinePoolsSpecs3 + pool.Wkr + components.V2MachinePoolsSpecs4 + quantity + components.V2MachinePoolsSuffix
+		num = num + 1
+	}
+	config = config + components.V2ClusterPrefix + k8sVersion + components.V2ClusterBody + poolConfig + components.V2ClusterSuffix
+
+	_, err = file.WriteString(config)
+
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/tests/terratest/functions/set_modules/setNodeDriverModules.go
+++ b/tests/terratest/functions/set_modules/setNodeDriverModules.go
@@ -1,0 +1,39 @@
+package functions
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rancher/rancher/tests/terratest/models"
+)
+
+func SetNodeDriverModules(module string, k8sVersion string, nodePools []models.Nodepool, result bool, file *os.File, config string) (done bool, err error) {
+	file, err = os.Create("../../modules/node_driver/" + module + "/main.tf")
+
+	if err != nil {
+		return false, err
+	}
+
+	defer file.Close()
+
+	switch {
+	case module == "ec2_rke1":
+		result, err = SetEC2RKE1(module, k8sVersion, nodePools, config, file)
+		return result, err
+
+	case module == "ec2_rke2" || module == "ec2_k3s":
+		result, err = SetEC2RKE2K3s(module, k8sVersion, nodePools, config, file)
+		return result, err
+
+	case module == "linode_rke1":
+		result, err = SetLinodeRKE1(module, k8sVersion, nodePools, config, file)
+		return result, err
+
+	case module == "linode_rke2" || module == "linode_k3s":
+		result, err = SetLinodeRKE2K3s(module, k8sVersion, nodePools, config, file)
+		return result, err
+
+	default:
+		return false, fmt.Errorf("invalid node_driver module provided")
+	}
+}

--- a/tests/terratest/functions/waitForActiveCluster.go
+++ b/tests/terratest/functions/waitForActiveCluster.go
@@ -1,0 +1,143 @@
+package functions
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func WaitForActiveCluster(t *testing.T, client *rancher.Client, clusterID string, module string) {
+
+	if module == "aks" || module == "eks" {
+		// Check for updating/waiting cluster state
+		err := wait.Poll(100*time.Millisecond, 30*time.Minute, func() (done bool, err error) {
+			cluster, err := client.Management.Cluster.ByID(clusterID)
+			require.NoError(t, err)
+
+			if err != nil {
+				return false, err
+			}
+
+			if cluster.State == "updating" {
+				return true, nil
+			}
+
+			if cluster.State == "waiting" {
+				return true, nil
+			}
+
+			return false, nil
+		})
+		require.NoError(t, err)
+
+		// Check for active cluster state
+		err = wait.Poll(500*time.Millisecond, 30*time.Minute, func() (done bool, err error) {
+			cluster, err := client.Management.Cluster.ByID(clusterID)
+			require.NoError(t, err)
+
+			if err != nil {
+				return false, err
+			}
+
+			if cluster.State == "active" {
+				return true, nil
+			}
+
+			return false, nil
+		})
+		require.NoError(t, err)
+		time.Sleep(10 * time.Second)
+	}
+
+	if module == "ec2_k3s" || module == "ec2_rke1" || module == "ec2_rke2" || module == "linode_k3s" || module == "linode_rke1" || module == "linode_rke2" {
+		// Check cluster state is waiting/updating
+		err := wait.Poll(100*time.Millisecond, 30*time.Minute, func() (done bool, err error) {
+			cluster, err := client.Management.Cluster.ByID(clusterID)
+			require.NoError(t, err)
+
+			if err != nil {
+				return false, err
+			}
+
+			if cluster.State == "waiting" {
+				return true, nil
+			}
+
+			if cluster.State == "updating" {
+				return true, nil
+			}
+
+			return false, nil
+		})
+		require.NoError(t, err)
+
+		// Check cluster state is active
+		err = wait.Poll(500*time.Millisecond, 30*time.Minute, func() (done bool, err error) {
+			cluster, err := client.Management.Cluster.ByID(clusterID)
+			require.NoError(t, err)
+
+			if err != nil {
+				return false, err
+			}
+
+			if cluster.State == "active" {
+				return true, nil
+			}
+
+			return false, nil
+		})
+		require.NoError(t, err)
+
+		// Check individal node state is active
+		nodes, err := client.Management.Node.List(&types.ListOpts{
+			Filters: map[string]interface{}{
+				"clusterId": clusterID,
+			},
+		})
+		require.NoError(t, err)
+
+		for _, node := range nodes.Data {
+
+			if node.State != "active" {
+				err = wait.Poll(500*time.Millisecond, 30*time.Minute, func() (done bool, err error) {
+					n, err := client.Management.Node.ByID(node.ID)
+					require.NoError(t, err)
+
+					if err != nil {
+						return false, err
+					}
+
+					if n.State == "active" {
+						return true, nil
+					}
+
+					return false, nil
+				})
+				require.NoError(t, err)
+
+			}
+		}
+
+		// Confirm cluster state active
+		err = wait.Poll(500*time.Millisecond, 30*time.Minute, func() (done bool, err error) {
+			cluster, err := client.Management.Cluster.ByID(clusterID)
+			require.NoError(t, err)
+
+			if err != nil {
+				return false, err
+			}
+
+			if cluster.State == "active" {
+				return true, nil
+			}
+
+			return false, nil
+		})
+		require.NoError(t, err)
+		time.Sleep(10 * time.Second)
+	}
+}

--- a/tests/terratest/models/nodepool.go
+++ b/tests/terratest/models/nodepool.go
@@ -1,0 +1,13 @@
+package models
+
+type Nodepool struct {
+	Quantity         int    `json:"quantity" yaml:"quantity"`
+	Etcd             string `json:"etcd" yaml:"etcd"`
+	Cp               string `json:"cp" yaml:"cp"`
+	Wkr              string `json:"wkr" yaml:"wkr"`
+	InstanceType     string `json:"instanceType" yaml:"instanceType"`
+	DesiredSize      int    `json:"desiredSize" yaml:"desiredSize"`
+	MaxSize          int    `json:"maxSize" yaml:"maxSize"`
+	MinSize          int    `json:"minSize" yaml:"minSize"`
+	MaxPodsContraint int    `json:"maxPodsContraint" yaml:"maxPodsContraint"`
+}

--- a/tests/terratest/modules/hosted/aks/main.tf
+++ b/tests/terratest/modules/hosted/aks/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/tests/terratest/modules/hosted/aks/outputs.tf
+++ b/tests/terratest/modules/hosted/aks/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_name" {
+  value = rancher2_cluster.rancher2_cluster.name
+}

--- a/tests/terratest/modules/hosted/aks/terraform.tfvars
+++ b/tests/terratest/modules/hosted/aks/terraform.tfvars
@@ -1,0 +1,1 @@
+// Leave blank - terraform.tfvars will be set during testing

--- a/tests/terratest/modules/hosted/aks/variables.tf
+++ b/tests/terratest/modules/hosted/aks/variables.tf
@@ -1,0 +1,19 @@
+# Rancher specific variables
+variable rancher_api_url {}
+variable rancher_admin_bearer_token {}
+
+# Azure credential variables
+variable cloud_credential_name {}
+variable azure_client_id {}
+variable azure_client_secret {}
+variable azure_subscription_id {}
+
+# AKS variables
+variable cluster_name {}
+variable resource_group {}
+variable resource_location {}
+variable dns_prefix {}
+variable network_plugin {}
+variable availability_zones {}
+variable os_disk_size_gb {}
+variable vm_size {}

--- a/tests/terratest/modules/hosted/eks/main.tf
+++ b/tests/terratest/modules/hosted/eks/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/tests/terratest/modules/hosted/eks/outputs.tf
+++ b/tests/terratest/modules/hosted/eks/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_name" {
+  value = rancher2_cluster.rancher2_cluster.name
+}

--- a/tests/terratest/modules/hosted/eks/terraform.tfvars
+++ b/tests/terratest/modules/hosted/eks/terraform.tfvars
@@ -1,0 +1,1 @@
+// Leave blank - terraform.tfvars will be set during testing

--- a/tests/terratest/modules/hosted/eks/variables.tf
+++ b/tests/terratest/modules/hosted/eks/variables.tf
@@ -1,0 +1,44 @@
+# Rancher specific variables
+variable rancher_api_url {
+  description = "host url to Rancher server"
+}
+variable rancher_admin_bearer_token {
+  description = "rancher admin bearer token"
+}
+
+# AWS specific variables
+variable aws_access_key {
+  description = "AWS Access Key"
+}
+variable aws_secret_key {
+  description = "AWS Secret Key"
+}
+variable cloud_credential_name {
+  description = "Unique name for cloud credentials, which will be created"
+}
+variable aws_instance_type {
+  description = "AWS Instance Type"
+}
+variable aws_region {
+  description = "AWS Region"
+}
+variable aws_subnets {
+  description = "AWS Subnets - format each subnet in quotes and separate with commas"
+}
+variable aws_security_groups {
+  description = "AWS Security Groups- format each security group in quotes and separate with commas"
+}
+
+# EKS specific variables
+variable cluster_name {
+  description = "Unique name for the cluster, which will be created"
+}
+variable hostname_prefix {
+    description = "Hostname prefix for the cluster resources, which will be created"
+}
+variable public_access {
+    description = "Enable public access to the cluster: 'true' or 'false'"
+}
+variable private_access {
+    description = "Enable private access to the cluster: 'true' or 'false'"
+}

--- a/tests/terratest/modules/hosted/gke/main.tf
+++ b/tests/terratest/modules/hosted/gke/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/tests/terratest/modules/hosted/gke/outputs.tf
+++ b/tests/terratest/modules/hosted/gke/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_name" {
+  value = rancher2_cluster.rancher2_cluster.name
+}

--- a/tests/terratest/modules/hosted/gke/terraform.tfvars
+++ b/tests/terratest/modules/hosted/gke/terraform.tfvars
@@ -1,0 +1,1 @@
+// Leave blank - terraform.tfvars will be set during testing

--- a/tests/terratest/modules/hosted/gke/variables.tf
+++ b/tests/terratest/modules/hosted/gke/variables.tf
@@ -1,0 +1,13 @@
+# Rancher specific variables
+variable rancher_api_url {}
+variable rancher_admin_bearer_token {}
+
+# GKE Variables
+variable "google_auth_encoded_json" {}
+variable "cloud_credential_name" {}
+variable "cluster_name" {}
+variable "gke_region" {}
+variable "gke_project_id" {}
+variable "gke_network" {}
+variable "gke_subnetwork" {}
+variable "hostname_prefix" {}

--- a/tests/terratest/modules/node_driver/ec2_k3s/main.tf
+++ b/tests/terratest/modules/node_driver/ec2_k3s/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/tests/terratest/modules/node_driver/ec2_k3s/outputs.tf
+++ b/tests/terratest/modules/node_driver/ec2_k3s/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_name" {
+  value = rancher2_cluster_v2.rancher2_cluster_v2.name
+}

--- a/tests/terratest/modules/node_driver/ec2_k3s/terraform.tfvars
+++ b/tests/terratest/modules/node_driver/ec2_k3s/terraform.tfvars
@@ -1,0 +1,1 @@
+// Leave blank - terraform.tfvars will be set during testing

--- a/tests/terratest/modules/node_driver/ec2_k3s/variables.tf
+++ b/tests/terratest/modules/node_driver/ec2_k3s/variables.tf
@@ -1,0 +1,20 @@
+# Rancher specific variable section.
+variable rancher_api_url {}
+variable rancher_admin_bearer_token {}
+variable cloud_credential_name {}
+
+# AWS specific variables.
+variable aws_access_key {}
+variable aws_secret_key {}
+variable aws_ami {}
+variable aws_region {}
+variable aws_security_group_name {}
+variable aws_subnet_id {}
+variable aws_vpc_id {}
+variable aws_zone_letter {}
+
+# RKE2/k3s specific variables.
+variable machine_config_name {}
+variable cluster_name {}
+variable enable_network_policy {}
+variable default_cluster_role_for_project_members {}

--- a/tests/terratest/modules/node_driver/ec2_rke1/main.tf
+++ b/tests/terratest/modules/node_driver/ec2_rke1/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/tests/terratest/modules/node_driver/ec2_rke1/outputs.tf
+++ b/tests/terratest/modules/node_driver/ec2_rke1/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_name" {
+  value = rancher2_cluster.rancher2_cluster.name
+}

--- a/tests/terratest/modules/node_driver/ec2_rke1/terraform.tfvars
+++ b/tests/terratest/modules/node_driver/ec2_rke1/terraform.tfvars
@@ -1,0 +1,1 @@
+// Leave blank - terraform.tfvars will be set during testing

--- a/tests/terratest/modules/node_driver/ec2_rke1/variables.tf
+++ b/tests/terratest/modules/node_driver/ec2_rke1/variables.tf
@@ -1,0 +1,21 @@
+# Rancher specific variable section.
+variable rancher_api_url {}
+variable rancher_admin_bearer_token {}
+
+# AWS specific variables.
+variable aws_access_key {}
+variable aws_secret_key {}
+variable aws_ami {}
+variable aws_instance_type {}
+variable aws_root_size {}
+variable aws_region {}
+variable aws_security_group_name {}
+variable aws_subnet_id {}
+variable aws_vpc_id {}
+variable aws_zone_letter {}
+
+# RKE1 specific variables.
+variable cluster_name {}
+variable network_plugin {}
+variable node_template_name {}
+variable hostname_prefix {}

--- a/tests/terratest/modules/node_driver/ec2_rke2/main.tf
+++ b/tests/terratest/modules/node_driver/ec2_rke2/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/tests/terratest/modules/node_driver/ec2_rke2/outputs.tf
+++ b/tests/terratest/modules/node_driver/ec2_rke2/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_name" {
+  value = rancher2_cluster_v2.rancher2_cluster_v2.name
+}

--- a/tests/terratest/modules/node_driver/ec2_rke2/terraform.tfvars
+++ b/tests/terratest/modules/node_driver/ec2_rke2/terraform.tfvars
@@ -1,0 +1,1 @@
+// Leave blank - terraform.tfvars will be set during testing

--- a/tests/terratest/modules/node_driver/ec2_rke2/variables.tf
+++ b/tests/terratest/modules/node_driver/ec2_rke2/variables.tf
@@ -1,0 +1,20 @@
+# Rancher specific variable section.
+variable rancher_api_url {}
+variable rancher_admin_bearer_token {}
+variable cloud_credential_name {}
+
+# AWS specific variables.
+variable aws_access_key {}
+variable aws_secret_key {}
+variable aws_ami {}
+variable aws_region {}
+variable aws_security_group_name {}
+variable aws_subnet_id {}
+variable aws_vpc_id {}
+variable aws_zone_letter {}
+
+# RKE2/k3s specific variables.
+variable machine_config_name {}
+variable cluster_name {}
+variable enable_network_policy {}
+variable default_cluster_role_for_project_members {}

--- a/tests/terratest/modules/node_driver/linode_k3s/main.tf
+++ b/tests/terratest/modules/node_driver/linode_k3s/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/tests/terratest/modules/node_driver/linode_k3s/outputs.tf
+++ b/tests/terratest/modules/node_driver/linode_k3s/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_name" {
+  value = rancher2_cluster_v2.rancher2_cluster_v2.name
+}

--- a/tests/terratest/modules/node_driver/linode_k3s/terraform.tfvars
+++ b/tests/terratest/modules/node_driver/linode_k3s/terraform.tfvars
@@ -1,0 +1,1 @@
+// Leave blank - terraform.tfvars will be set during testing

--- a/tests/terratest/modules/node_driver/linode_k3s/variables.tf
+++ b/tests/terratest/modules/node_driver/linode_k3s/variables.tf
@@ -1,0 +1,16 @@
+# Rancher specific variable section.
+variable rancher_api_url {}
+variable rancher_admin_bearer_token {}
+variable cloud_credential_name {}
+
+# Linode specific variables.
+variable linode_token {}
+variable image {}
+variable region {}
+variable root_pass {}
+
+# RKE2/k3s specific variables.
+variable machine_config_name {}
+variable cluster_name {}
+variable enable_network_policy {}
+variable default_cluster_role_for_project_members {}

--- a/tests/terratest/modules/node_driver/linode_rke1/main.tf
+++ b/tests/terratest/modules/node_driver/linode_rke1/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/tests/terratest/modules/node_driver/linode_rke1/outputs.tf
+++ b/tests/terratest/modules/node_driver/linode_rke1/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_name" {
+  value = rancher2_cluster.rancher2_cluster.name
+}

--- a/tests/terratest/modules/node_driver/linode_rke1/terraform.tfvars
+++ b/tests/terratest/modules/node_driver/linode_rke1/terraform.tfvars
@@ -1,0 +1,1 @@
+// Leave blank - terraform.tfvars will be set during testing

--- a/tests/terratest/modules/node_driver/linode_rke1/variables.tf
+++ b/tests/terratest/modules/node_driver/linode_rke1/variables.tf
@@ -1,0 +1,15 @@
+# Rancher specific variable section.
+variable rancher_api_url {}
+variable rancher_admin_bearer_token {}
+
+# Linode specific variables.
+variable linode_token {}
+variable image {}
+variable region {}
+variable root_pass {}
+
+# RKE1 specific variables.
+variable cluster_name {}
+variable network_plugin {}
+variable node_template_name {}
+variable hostname_prefix {}

--- a/tests/terratest/modules/node_driver/linode_rke2/main.tf
+++ b/tests/terratest/modules/node_driver/linode_rke2/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/tests/terratest/modules/node_driver/linode_rke2/outputs.tf
+++ b/tests/terratest/modules/node_driver/linode_rke2/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_name" {
+  value = rancher2_cluster_v2.rancher2_cluster_v2.name
+}

--- a/tests/terratest/modules/node_driver/linode_rke2/terraform.tfvars
+++ b/tests/terratest/modules/node_driver/linode_rke2/terraform.tfvars
@@ -1,0 +1,1 @@
+// Leave blank - terraform.tfvars will be set during testing

--- a/tests/terratest/modules/node_driver/linode_rke2/variables.tf
+++ b/tests/terratest/modules/node_driver/linode_rke2/variables.tf
@@ -1,0 +1,16 @@
+# Rancher specific variable section.
+variable rancher_api_url {}
+variable rancher_admin_bearer_token {}
+variable cloud_credential_name {}
+
+# Linode specific variables.
+variable linode_token {}
+variable image {}
+variable region {}
+variable root_pass {}
+
+# RKE2/k3s specific variables.
+variable machine_config_name {}
+variable cluster_name {}
+variable enable_network_policy {}
+variable default_cluster_role_for_project_members {}

--- a/tests/terratest/tests/config.go
+++ b/tests/terratest/tests/config.go
@@ -1,0 +1,67 @@
+package tests
+
+import "github.com/rancher/rancher/tests/terratest/models"
+
+type GoogleAuthEncodedJSON struct {
+	AuthProviderX509CertURL string `json:"auth_provider_x509_cert_url" yaml:"auth_provider_x509_cert_url"`
+	AuthURI                 string `json:"auth_uri" yaml:"auth_uri"`
+	ClientEmail             string `json:"client_email" yaml:"client_email"`
+	ClientID                string `json:"client_id" yaml:"client_id"`
+	ClientX509CertURL       string `json:"client_x509_cert_url" yaml:"client_x509_cert_url"`
+	PrivateKey              string `json:"private_key" yaml:"private_key"`
+	PrivateKeyID            string `json:"private_key_id" yaml:"private_key_id"`
+	ProjectID               string `json:"project_id" yaml:"project_id"`
+	TokenURI                string `json:"token_uri" yaml:"token_uri"`
+	Type                    string `json:"type" yaml:"type"`
+}
+
+type TerraformConfig struct {
+	Ami                                 string `json:"ami" yaml:"ami"`
+	AvailabilityZones                   string `json:"availabilityZones" yaml:"availabilityZones"`
+	AWSAccessKey                        string `json:"awsAccessKey" yaml:"awsAccessKey"`
+	AWSInstanceType                     string `json:"awsInstanceType" yaml:"awsInstanceType"`
+	AWSRootSize                         string `json:"awsRootSize" yaml:"awsRootSize"`
+	AWSSecretKey                        string `json:"awsSecretKey" yaml:"awsSecretKey"`
+	AWSSecurityGroupName                string `json:"awsSecurityGroupName" yaml:"awsSecurityGroupName"`
+	AWSSecurityGroups                   string `json:"awsSecurityGroups" yaml:"awsSecurityGroups"`
+	AWSSubnetID                         string `json:"awsSubnetID" yaml:"awsSubnetID"`
+	AWSSubnets                          string `json:"awsSubnets" yaml:"awsSubnets"`
+	AWSVpcID                            string `json:"awsVpcID" yaml:"awsVpcID"`
+	AWSZoneLetter                       string `json:"awsZoneLetter" yaml:"awsZoneLetter"`
+	AzureClientID                       string `json:"azureClientID" yaml:"azureClientID"`
+	AzureClientSecret                   string `json:"azureClientSecret" yaml:"azureClientSecret"`
+	AzureSubscriptionID                 string `json:"azureSubscriptionID" yaml:"azureSubscriptionID"`
+	CloudCredentialName                 string `json:"cloudCredentialName" yaml:"cloudCredentialName"`
+	ClusterName                         string `json:"clusterName" yaml:"clusterName"`
+	DefaultClusterRoleForProjectMembers string `json:"defaultClusterRoleForProjectMembers" yaml:"defaultClusterRoleForProjectMembers"`
+	EnableNetworkPolicy   string `json:"enableNetworkPolicy" yaml:"enableNetworkPolicy"`
+	GKENetwork            string `json:"gkeNetwork" yaml:"gkeNetwork"`
+	GKEProjectID          string `json:"gkeProjectID" yaml:"gkeProjectID"`
+	GKESubnetwork         string `json:"gkeSubnetwork" yaml:"gkeSubnetwork"`
+	GoogleAuthEncodedJSON GoogleAuthEncodedJSON
+	HostnamePrefix        string `json:"hostnamePrefix" yaml:"hostnamePrefix"`
+	LinodeImage           string `json:"linodeImage" yaml:"linodeImage"`
+	LinodeRootPass        string `json:"linodeRootPass" yaml:"linodeRootPass"`
+	LinodeToken           string `json:"linodeToken" yaml:"linodeToken"`
+	MachineConfigName     string `json:"machineConfigName" yaml:"machineConfigName"`
+	NetworkPlugin         string `json:"networkPlugin" yaml:"networkPlugin"`
+	NodeTemplateName      string `json:"nodeTemplateName" yaml:"nodeTemplateName"`
+	OSDiskSizeGB          string `json:"osDiskSizeGB" yaml:"osDiskSizeGB"`
+	PrivateAccess         string `json:"privateAccess" yaml:"privateAccess"`
+	PublicAccess          string `json:"publicAccess" yaml:"publicAccess"`
+	Region                string `json:"region" yaml:"region"`
+	ResourceGroup         string `json:"resourceGroup" yaml:"resourceGroup"`
+	ResourceLocation      string `json:"resourceLocation" yaml:"resourceLocation"`
+	VMSize                string `json:"vmSize" yaml:"vmSize"`
+}
+
+type TerratestConfig struct {
+	KubernetesVersion         string            `json:"kubernetesVersion" yaml:"kubernetesVersion"`
+	NodeCount                 int64             `json:"nodeCount" yaml:"nodeCount"`
+	Nodepools                 []models.Nodepool `json:"nodepools" yaml:"nodepools"`
+	ScaledDownNodeCount       int64             `json:"scaledDownNodeCount" yaml:"scaledDownNodeCount"`
+	ScaledDownNodepools       []models.Nodepool `json:"scaledDownNodepools" yaml:"scaledDownNodepools"`
+	ScaledUpNodeCount         int64             `json:"scaledUpNodeCount" yaml:"scaledUpNodeCount"`
+	ScaledUpNodepools         []models.Nodepool `json:"scaledUpNodepools" yaml:"scaledUpNodepools"`
+	UpgradedKubernetesVersion string            `json:"upgradedKubernetesVersion" yaml:"upgradedKubernetesVersion"`
+}

--- a/tests/terratest/tests/hosted/aks_provision_and_scale_test.go
+++ b/tests/terratest/tests/hosted/aks_provision_and_scale_test.go
@@ -1,0 +1,116 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/terratest/functions"
+	"github.com/rancher/rancher/tests/terratest/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAKSProvisionAndScale(t *testing.T) {
+	t.Parallel()
+
+	module := "aks"
+	active := "active"
+
+	clusterConfig := new(tests.TerratestConfig)
+	config.LoadConfig("terratest", clusterConfig)
+
+	expectedKubernetesVersion := `v` + clusterConfig.KubernetesVersion
+
+	// Set terraform.tfvars file
+	functions.SetVarsTF(module)
+
+	// Set initial infrastructure by building TFs declarative config file - [main.tf]
+	successful, err := functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+
+		TerraformDir: "../../modules/hosted/" + module,
+		NoColor:      true,
+	})
+
+	cleanup := func() {
+		terraform.Destroy(t, terraformOptions)
+		functions.CleanupConfigTF(module)
+		functions.CleanupVarsTF(module)
+	}
+
+	// Deploys [main.tf] infrastructure and sets up resource cleanup
+	defer cleanup()
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Grab cluster name from TF outputs
+	clusterName := terraform.Output(t, terraformOptions, "cluster_name")
+
+	// Create session, client, and grab cluster specs
+	testSession := session.NewSession(t)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.NodeCount, cluster.NodeCount)
+	assert.Equal(t, module, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, expectedKubernetesVersion, cluster.Version.GitVersion)
+
+	// Scale up cluster
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledUpNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledUpNodeCount, cluster.NodeCount)
+	assert.Equal(t, module, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, expectedKubernetesVersion, cluster.Version.GitVersion)
+
+	// Scale down cluster
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledDownNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledDownNodeCount, cluster.NodeCount)
+	assert.Equal(t, module, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, expectedKubernetesVersion, cluster.Version.GitVersion)
+
+}

--- a/tests/terratest/tests/hosted/eks_provision_and_scale_test.go
+++ b/tests/terratest/tests/hosted/eks_provision_and_scale_test.go
@@ -1,0 +1,194 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/terratest/functions"
+	"github.com/rancher/rancher/tests/terratest/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestEKSProvisionAndScale(t *testing.T) {
+	t.Parallel()
+
+	module := "eks"
+	active := "active"
+
+	clusterConfig := new(tests.TerratestConfig)
+	config.LoadConfig("terratest", clusterConfig)
+
+	// Set terraform.tfvars file
+	functions.SetVarsTF(module)
+
+	// Set initial infrastructure by building TFs declarative config file - [main.tf]
+	successful, err := functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+
+		TerraformDir: "../../modules/hosted/" + module,
+		NoColor:      true,
+	})
+
+	cleanup := func() {
+		terraform.Destroy(t, terraformOptions)
+		functions.CleanupConfigTF(module)
+		functions.CleanupVarsTF(module)
+	}
+
+	// Deploys [main.tf] infrastructure and sets up resource cleanup
+	defer cleanup()
+	terraform.InitAndApply(t, terraformOptions)
+
+	time.Sleep(1 * time.Second)
+
+	// Grab cluster name from TF outputs
+	clusterName := terraform.Output(t, terraformOptions, "cluster_name")
+
+	// Create session, client, and grab cluster specs
+	testSession := session.NewSession(t)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.NodeCount, cluster.NodeCount)
+	assert.Equal(t, module, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+
+	// Scale up cluster
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledUpNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for active cluster state
+	err = wait.Poll(500*time.Millisecond, 30*time.Minute, func() (done bool, err error) {
+		cluster, err := client.Management.Cluster.ByID(clusterID)
+		require.NoError(t, err)
+
+		if err != nil {
+			return false, err
+		}
+
+		if cluster.State == "active" {
+			return true, nil
+		}
+
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	// Wait for nodes to scale up
+	err = wait.Poll(500*time.Millisecond, 30*time.Minute, func() (done bool, err error) {
+		cluster, err := client.Management.Cluster.ByID(clusterID)
+		require.NoError(t, err)
+
+		if err != nil {
+			return false, err
+		}
+
+		if cluster.NodeCount == clusterConfig.ScaledUpNodeCount {
+			return true, nil
+		}
+
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	// Wait for active cluster state
+	err = wait.Poll(500*time.Millisecond, 30*time.Minute, func() (done bool, err error) {
+		cluster, err := client.Management.Cluster.ByID(clusterID)
+		require.NoError(t, err)
+
+		if err != nil {
+			return false, err
+		}
+
+		if cluster.State == "active" {
+			return true, nil
+		}
+
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledUpNodeCount, cluster.NodeCount)
+	assert.Equal(t, module, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+
+	// Scale down cluster
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledDownNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for nodes to scale down
+	err = wait.Poll(500*time.Millisecond, 30*time.Minute, func() (done bool, err error) {
+		cluster, err := client.Management.Cluster.ByID(clusterID)
+		require.NoError(t, err)
+
+		if err != nil {
+			return false, err
+		}
+
+		if cluster.NodeCount == clusterConfig.ScaledDownNodeCount {
+			return true, nil
+		}
+
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	// Wait for active cluster state
+	err = wait.Poll(500*time.Millisecond, 30*time.Minute, func() (done bool, err error) {
+		cluster, err := client.Management.Cluster.ByID(clusterID)
+		require.NoError(t, err)
+
+		if err != nil {
+			return false, err
+		}
+
+		if cluster.State == "active" {
+			return true, nil
+		}
+
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledDownNodeCount, cluster.NodeCount)
+	assert.Equal(t, module, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+
+}

--- a/tests/terratest/tests/hosted/gke_provision_test.go
+++ b/tests/terratest/tests/hosted/gke_provision_test.go
@@ -1,0 +1,74 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/terratest/functions"
+	"github.com/rancher/rancher/tests/terratest/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGKEProvisionAndScale(t *testing.T) {
+	t.Parallel()
+
+	module := "gke"
+	active := "active"
+
+	clusterConfig := new(tests.TerratestConfig)
+	config.LoadConfig("terratest", clusterConfig)
+
+	expectedKubernetesVersion := `v` + clusterConfig.KubernetesVersion
+
+	// Set terraform.tfvars file
+	functions.SetVarsTF(module)
+
+	// Set initial infrastructure by building TFs declarative config file - [main.tf]
+	successful, err := functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+
+		TerraformDir: "../../modules/hosted/" + module,
+		NoColor:      true,
+	})
+
+	cleanup := func() {
+		terraform.Destroy(t, terraformOptions)
+		functions.CleanupConfigTF(module)
+		functions.CleanupVarsTF(module)
+	}
+
+	// Deploys [main.tf] infrastructure and sets up resource cleanup
+	defer cleanup()
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Grab cluster name from TF outputs
+	clusterName := terraform.Output(t, terraformOptions, "cluster_name")
+
+	// Create session, client, and grab cluster specs
+	testSession := session.NewSession(t)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.NodeCount, cluster.NodeCount)
+	assert.Equal(t, module, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, expectedKubernetesVersion, cluster.Version.GitVersion)
+
+}

--- a/tests/terratest/tests/node_driver/ec2_k3s_kubernetes_upgrade_test.go
+++ b/tests/terratest/tests/node_driver/ec2_k3s_kubernetes_upgrade_test.go
@@ -1,0 +1,92 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/terratest/functions"
+	"github.com/rancher/rancher/tests/terratest/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEC2K3sK8sUpgrade(t *testing.T) {
+	t.Parallel()
+
+	module   := "ec2_k3s"
+	provider := "k3s"
+	active   := "active"
+
+	clusterConfig := new(tests.TerratestConfig)
+	config.LoadConfig("terratest", clusterConfig)
+
+	// Set terraform.tfvars file
+	functions.SetVarsTF(module)
+
+	// Set initial infrastructure by building TFs declarative config file - [main.tf]
+	successful, err := functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+
+		TerraformDir: "../../modules/node_driver/" + module,
+		NoColor:      true,
+	})
+
+	cleanup := func() {
+		terraform.Destroy(t, terraformOptions)
+		functions.CleanupConfigTF(module)
+		functions.CleanupVarsTF(module)
+	}
+
+	// Deploys [main.tf] infrastructure and sets up resource cleanup
+	defer cleanup()
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Grab cluster name from TF outputs
+	clusterName := terraform.Output(t, terraformOptions, "cluster_name")
+
+	// Create session, client, and grab cluster specs
+	testSession := session.NewSession(t)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+	// Upgrade kubernetes version
+	successful, err = functions.SetConfigTF(module, clusterConfig.UpgradedKubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.UpgradedKubernetesVersion, cluster.Version.GitVersion)
+
+}

--- a/tests/terratest/tests/node_driver/ec2_k3s_provision_and_scale_test.go
+++ b/tests/terratest/tests/node_driver/ec2_k3s_provision_and_scale_test.go
@@ -1,0 +1,115 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/terratest/functions"
+	"github.com/rancher/rancher/tests/terratest/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEC2K3sProvisionAndScale(t *testing.T) {
+	t.Parallel()
+
+	module   := "ec2_k3s"
+	provider := "k3s"
+	active   := "active"
+
+	clusterConfig := new(tests.TerratestConfig)
+	config.LoadConfig("terratest", clusterConfig)
+
+	// Set terraform.tfvars file
+	functions.SetVarsTF(module)
+
+	// Set initial infrastructure by building TFs declarative config file - [main.tf]
+	successful, err := functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+
+		TerraformDir: "../../modules/node_driver/" + module,
+		NoColor:      true,
+	})
+
+	cleanup := func() {
+		terraform.Destroy(t, terraformOptions)
+		functions.CleanupConfigTF(module)
+		functions.CleanupVarsTF(module)
+	}
+
+	// Deploys [main.tf] infrastructure and sets up resource cleanup
+	defer cleanup()
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Grab cluster name from TF outputs
+	clusterName := terraform.Output(t, terraformOptions, "cluster_name")
+
+	// Create session, client, and grab cluster specs
+	testSession := session.NewSession(t)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.NodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+	// Scale to HA setup - 3 node pools: [3 etcd], [2 cp], [3 wkr]
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledUpNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledUpNodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+	// Scale Wkr pool to one - 3 node pools: [3 etcd], [2 cp], [1 wkr]
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledDownNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledDownNodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+}

--- a/tests/terratest/tests/node_driver/ec2_rke1_provision_and_scale_test.go
+++ b/tests/terratest/tests/node_driver/ec2_rke1_provision_and_scale_test.go
@@ -1,0 +1,119 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/terratest/functions"
+	"github.com/rancher/rancher/tests/terratest/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEC2Rke1ProvisionAndScale(t *testing.T) {
+	t.Parallel()
+
+	module   := "ec2_rke1"
+	provider := "rke"
+	active   := "active" 
+
+	clusterConfig := new(tests.TerratestConfig)
+	config.LoadConfig("terratest", clusterConfig)
+
+	// Set terraform.tfvars file
+	functions.SetVarsTF(module)
+	
+	k8sVersion := clusterConfig.KubernetesVersion[:len(clusterConfig.KubernetesVersion)-11]
+
+	successful, err := functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+
+		TerraformDir: "../../modules/node_driver/" + module,
+		NoColor:      true,
+	})
+
+	cleanup := func() {
+		terraform.Destroy(t, terraformOptions)
+		functions.CleanupConfigTF(module)
+		functions.CleanupVarsTF(module)
+	}
+
+	// Deploys [main.tf] infrastructure and sets up resource cleanup
+	defer cleanup()
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Grab cluster name from TF outputs
+	clusterName := terraform.Output(t, terraformOptions, "cluster_name")
+
+	// Create session, client, and grab cluster specs
+	testSession := session.NewSession(t)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+	
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.NodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, k8sVersion, cluster.Version.GitVersion)
+
+	// Scale to HA setup - 3 node pools: [3 etcd], [2 cp], [3 wkr]
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledUpNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledUpNodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, k8sVersion, cluster.Version.GitVersion)
+
+	// Scale Wkr pool to one - 3 node pools: [3 etcd], [2 cp], [1 wkr]
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledDownNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledDownNodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, k8sVersion, cluster.Version.GitVersion)
+
+}

--- a/tests/terratest/tests/node_driver/ec2_rke2_kubernetes_upgrade_test.go
+++ b/tests/terratest/tests/node_driver/ec2_rke2_kubernetes_upgrade_test.go
@@ -1,0 +1,92 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/terratest/functions"
+	"github.com/rancher/rancher/tests/terratest/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEC2Rke2K8sUpgrade(t *testing.T) {
+	t.Parallel()
+
+	module   := "ec2_rke2"
+	provider := "rke2"
+	active   := "active"
+
+	clusterConfig := new(tests.TerratestConfig)
+	config.LoadConfig("terratest", clusterConfig)
+
+	// Set terraform.tfvars file
+	functions.SetVarsTF(module)
+
+	// Set initial infrastructure by building TFs declarative config file - [main.tf]
+	successful, err := functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+
+		TerraformDir: "../../modules/node_driver/" + module,
+		NoColor:      true,
+	})
+
+	cleanup := func() {
+		terraform.Destroy(t, terraformOptions)
+		functions.CleanupConfigTF(module)
+		functions.CleanupVarsTF(module)
+	}
+
+	// Deploys [main.tf] infrastructure and sets up resource cleanup
+	defer cleanup()
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Grab cluster name from TF outputs
+	clusterName := terraform.Output(t, terraformOptions, "cluster_name")
+
+	// Create session, client, and grab cluster specs
+	testSession := session.NewSession(t)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+	// Upgrade kubernetes version
+	successful, err = functions.SetConfigTF(module, clusterConfig.UpgradedKubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.UpgradedKubernetesVersion, cluster.Version.GitVersion)
+	
+}

--- a/tests/terratest/tests/node_driver/ec2_rke2_provision_and_scale_test.go
+++ b/tests/terratest/tests/node_driver/ec2_rke2_provision_and_scale_test.go
@@ -1,0 +1,115 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/terratest/functions"
+	"github.com/rancher/rancher/tests/terratest/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEC2Rke2ProvisionAndScale(t *testing.T) {
+	t.Parallel()
+
+	module   := "ec2_rke2"
+	provider := "rke2"
+	active   := "active"
+
+	clusterConfig := new(tests.TerratestConfig)
+	config.LoadConfig("terratest", clusterConfig)
+
+	// Set terraform.tfvars file
+	functions.SetVarsTF(module)
+	
+	// Set initial infrastructure by building TFs declarative config file - [main.tf]
+	successful, err := functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+
+		TerraformDir: "../../modules/node_driver/" + module,
+		NoColor:      true,
+	})
+
+	cleanup := func() {
+		terraform.Destroy(t, terraformOptions)
+		functions.CleanupConfigTF(module)
+		functions.CleanupVarsTF(module)
+	}
+
+	// Deploys [main.tf] infrastructure and sets up resource cleanup
+	defer cleanup()
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Grab cluster name from TF outputs
+	clusterName := terraform.Output(t, terraformOptions, "cluster_name")
+
+	// Create session, client, and grab cluster specs
+	testSession := session.NewSession(t)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.NodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+	// Scale to HA setup - 3 node pools: [3 etcd], [2 cp], [3 wkr]
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledUpNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledUpNodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion,cluster.Version.GitVersion)
+
+	// Scale Wkr pool to one - 3 node pools: [3 etcd], [2 cp], [1 wkr]
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledDownNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledDownNodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+}

--- a/tests/terratest/tests/node_driver/linode_k3s_kubernetes_upgrade_test.go
+++ b/tests/terratest/tests/node_driver/linode_k3s_kubernetes_upgrade_test.go
@@ -1,0 +1,92 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/terratest/functions"
+	"github.com/rancher/rancher/tests/terratest/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinodeK3sK8sUpgrade(t *testing.T) {
+	t.Parallel()
+
+	module   := "linode_k3s"
+	provider := "k3s"
+	active   := "active"
+
+	clusterConfig := new(tests.TerratestConfig)
+	config.LoadConfig("terratest", clusterConfig)
+
+	// Set terraform.tfvars file
+	functions.SetVarsTF(module)
+
+	// Set initial infrastructure by building TFs declarative config file - [main.tf]
+	successful, err := functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+
+		TerraformDir: "../../modules/node_driver/" + module,
+		NoColor:      true,
+	})
+
+	cleanup := func() {
+		terraform.Destroy(t, terraformOptions)
+		functions.CleanupConfigTF(module)
+		functions.CleanupVarsTF(module)
+	}
+
+	// Deploys [main.tf] infrastructure and sets up resource cleanup
+	defer cleanup()
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Grab cluster name from TF outputs
+	clusterName := terraform.Output(t, terraformOptions, "cluster_name")
+
+	// Create session, client, and grab cluster specs
+	testSession := session.NewSession(t)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+	// Upgrade kubernetes version
+	successful, err = functions.SetConfigTF(module, clusterConfig.UpgradedKubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.UpgradedKubernetesVersion, cluster.Version.GitVersion)
+
+}

--- a/tests/terratest/tests/node_driver/linode_k3s_provision_and_scale_test.go
+++ b/tests/terratest/tests/node_driver/linode_k3s_provision_and_scale_test.go
@@ -1,0 +1,115 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/terratest/functions"
+	"github.com/rancher/rancher/tests/terratest/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinodeK3sProvisionAndScale(t *testing.T) {
+	t.Parallel()
+
+	module   := "linode_k3s"
+	provider := "k3s"
+	active   := "active"
+
+	clusterConfig := new(tests.TerratestConfig)
+	config.LoadConfig("terratest", clusterConfig)
+
+	// Set terraform.tfvars file
+	functions.SetVarsTF(module)
+
+	// Set initial infrastructure by building TFs declarative config file - [main.tf]
+	successful, err := functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+
+		TerraformDir: "../../modules/node_driver/" + module,
+		NoColor:      true,
+	})
+
+	cleanup := func() {
+		terraform.Destroy(t, terraformOptions)
+		functions.CleanupConfigTF(module)
+		functions.CleanupVarsTF(module)
+	}
+
+	// Deploys [main.tf] infrastructure and sets up resource cleanup
+	defer cleanup()
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Grab cluster name from TF outputs
+	clusterName := terraform.Output(t, terraformOptions, "cluster_name")
+
+	// Create session, client, and grab cluster specs
+	testSession := session.NewSession(t)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.NodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+	// Scale to HA setup - 3 node pools: [3 etcd], [2 cp], [3 wkr]
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledUpNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledUpNodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+	// Scale Wkr pool to one - 3 node pools: [3 etcd], [2 cp], [1 wkr]
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledDownNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledDownNodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+}

--- a/tests/terratest/tests/node_driver/linode_rke1_provision_and_scale_test.go
+++ b/tests/terratest/tests/node_driver/linode_rke1_provision_and_scale_test.go
@@ -1,0 +1,119 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/terratest/functions"
+	"github.com/rancher/rancher/tests/terratest/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinodeRke1ProvisionAndScale(t *testing.T) {
+	t.Parallel()
+
+	module   := "linode_rke1"
+	provider := "rke"
+	active   := "active" 
+
+	clusterConfig := new(tests.TerratestConfig)
+	config.LoadConfig("terratest", clusterConfig)
+
+	// Set terraform.tfvars file
+	functions.SetVarsTF(module)
+
+	k8sVersion := clusterConfig.KubernetesVersion[:len(clusterConfig.KubernetesVersion)-11]
+
+	successful, err := functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+
+		TerraformDir: "../../modules/node_driver/" + module,
+		NoColor:      true,
+	})
+
+	cleanup := func() {
+		terraform.Destroy(t, terraformOptions)
+		functions.CleanupConfigTF(module)
+		functions.CleanupVarsTF(module)
+	}
+
+	// Deploys [main.tf] infrastructure and sets up resource cleanup
+	defer cleanup()
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Grab cluster name from TF outputs
+	clusterName := terraform.Output(t, terraformOptions, "cluster_name")
+
+	// Create session, client, and grab cluster specs
+	testSession := session.NewSession(t)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+	
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.NodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, k8sVersion, cluster.Version.GitVersion)
+
+	// Scale to HA setup - 3 node pools: [3 etcd], [2 cp], [3 wkr]
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledUpNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledUpNodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, k8sVersion, cluster.Version.GitVersion)
+
+	// Scale Wkr pool to one - 3 node pools: [3 etcd], [2 cp], [1 wkr]
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledDownNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledDownNodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, k8sVersion, cluster.Version.GitVersion)
+
+}

--- a/tests/terratest/tests/node_driver/linode_rke2_kubernetes_upgrade_test.go
+++ b/tests/terratest/tests/node_driver/linode_rke2_kubernetes_upgrade_test.go
@@ -1,0 +1,92 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/terratest/functions"
+	"github.com/rancher/rancher/tests/terratest/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinodeRke2K8sUpgrade(t *testing.T) {
+	t.Parallel()
+
+	module   := "linode_rke2"
+	provider := "rke2"
+	active   := "active"
+
+	clusterConfig := new(tests.TerratestConfig)
+	config.LoadConfig("terratest", clusterConfig)
+
+	// Set terraform.tfvars file
+	functions.SetVarsTF(module)
+
+	// Set initial infrastructure by building TFs declarative config file - [main.tf]
+	successful, err := functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+
+		TerraformDir: "../../modules/node_driver/" + module,
+		NoColor:      true,
+	})
+
+	cleanup := func() {
+		terraform.Destroy(t, terraformOptions)
+		functions.CleanupConfigTF(module)
+		functions.CleanupVarsTF(module)
+	}
+
+	// Deploys [main.tf] infrastructure and sets up resource cleanup
+	defer cleanup()
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Grab cluster name from TF outputs
+	clusterName := terraform.Output(t, terraformOptions, "cluster_name")
+
+	// Create session, client, and grab cluster specs
+	testSession := session.NewSession(t)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+	// Upgrade kubernetes version
+	successful, err = functions.SetConfigTF(module, clusterConfig.UpgradedKubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.UpgradedKubernetesVersion, cluster.Version.GitVersion)
+	
+}

--- a/tests/terratest/tests/node_driver/linode_rke2_provision_and_scale_test.go
+++ b/tests/terratest/tests/node_driver/linode_rke2_provision_and_scale_test.go
@@ -1,0 +1,115 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/terratest/functions"
+	"github.com/rancher/rancher/tests/terratest/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinodeRke2ProvisionAndScale(t *testing.T) {
+	t.Parallel()
+
+	module   := "linode_rke2"
+	provider := "rke2"
+	active   := "active"
+
+	clusterConfig := new(tests.TerratestConfig)
+	config.LoadConfig("terratest", clusterConfig)
+
+	// Set terraform.tfvars file
+	functions.SetVarsTF(module)
+
+	// Set initial infrastructure by building TFs declarative config file - [main.tf]
+	successful, err := functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.Nodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+
+		TerraformDir: "../../modules/node_driver/" + module,
+		NoColor:      true,
+	})
+
+	cleanup := func() {
+		terraform.Destroy(t, terraformOptions)
+		functions.CleanupConfigTF(module)
+		functions.CleanupVarsTF(module)
+	}
+
+	// Deploys [main.tf] infrastructure and sets up resource cleanup
+	defer cleanup()
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Grab cluster name from TF outputs
+	clusterName := terraform.Output(t, terraformOptions, "cluster_name")
+
+	// Create session, client, and grab cluster specs
+	testSession := session.NewSession(t)
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(t, err)
+
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.NodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+	// Scale to HA setup - 3 node pools: [3 etcd], [2 cp], [3 wkr]
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledUpNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledUpNodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+	// Scale Wkr pool to one - 3 node pools: [3 etcd], [2 cp], [1 wkr]
+	successful, err = functions.SetConfigTF(module, clusterConfig.KubernetesVersion, clusterConfig.ScaledDownNodepools)
+	require.NoError(t, err)
+	assert.Equal(t, true, successful)
+
+	terraform.Apply(t, terraformOptions)
+
+	// Wait for cluster
+	functions.WaitForActiveCluster(t, client, clusterID, module)
+
+	// Update cluster object
+	cluster, err = client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	// Test cluster
+	assert.Equal(t, clusterName, cluster.Name)
+	assert.Equal(t, clusterConfig.ScaledDownNodeCount, cluster.NodeCount)
+	assert.Equal(t, provider, cluster.Provider)
+	assert.Equal(t, active, cluster.State)
+	assert.Equal(t, clusterConfig.KubernetesVersion, cluster.Version.GitVersion)
+
+}


### PR DESCRIPTION
Automation to allow rancher2 provider TF cluster resources to be tested with Terratest + Go:
- refactored away from static .tfvars files to be dynamically created/destroyed with each test; 
- refactored away from config.go to supply configurations via yml

## Issue: 
Automate tests for terraform rancher2 provider clusters' for terraform releases
 
## Problem
No automation exists for this
 
## Solution
Created a framework w/ Go to allow testing automation of rancher2 provider cluster resources
 
## Testing
All tests have been thoroughly tested during development.

GKE module has been implemented, however, no tests have been created yet.  When implementing GKE tests, it will be necessary to observe behavior, and modify functions to account for GKE module. [e.g. `waitForActiveCluster()`]

## Engineering Testing
### Manual Testing
N/A

### Automated Testing
Ran each test, ensuring expected behavior and accurate results

## QA Testing Considerations
N/A
 
### Regressions Considerations
None