### PR TITLE
[2.6] updating airgap to allow helm

### DIFF
--- a/tests/validation/tests/v3_api/test_airgap_ha.py
+++ b/tests/validation/tests/v3_api/test_airgap_ha.py
@@ -29,6 +29,9 @@ HOST_NAME = os.environ.get('RANCHER_HOST_NAME', "testsa")
 AG_HOST_NAME = HOST_NAME
 RANCHER_AG_INTERNAL_HOSTNAME = AG_HOST_NAME + "-internal.qa.rancher.space"
 RANCHER_AG_HOSTNAME = AG_HOST_NAME + ".qa.rancher.space"
+RANCHER_HELM_REPO = os.environ.get("RANCHER_HELM_REPO", "latest")
+RANCHER_HELM_URL = os.environ.get("RANCHER_HELM_URL", "https://releases.rancher.com/server-charts/")
+RANCHER_SOURCE_REGISTRY = os.environ.get("RANCHER_SOURCE_REGISTRY", "")
 
 RESOURCE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                             'resource')
@@ -224,15 +227,17 @@ def add_rancher_images_to_private_registry(
             RANCHER_SERVER_VERSION)
     bastion_node.execute_command(get_images_command)
 
-    # Remove the "docker save" and "docker load" lines to save time
+    # comment out the "docker save" and "docker load" lines to save time
     edit_save_and_load_command = \
-        "sudo sed -i '58d' rancher-save-images.sh && " \
-        "sudo sed -i '76d' rancher-load-images.sh && " \
+        "sudo sed -i -e 's/docker save /# docker/g' rancher-save-images.sh && " \
+        "sudo sed -i -e 's/docker load /# docker/g' rancher-load-images.sh && " \
         "chmod +x rancher-save-images.sh && chmod +x rancher-load-images.sh"
     bastion_node.execute_command(edit_save_and_load_command)
 
     save_images_command = \
         "./rancher-save-images.sh --image-list ./rancher-images.txt"
+    if len(RANCHER_SOURCE_REGISTRY) > 0:
+        save_images_command += " --source-registry {}".format(RANCHER_SOURCE_REGISTRY)
     save_res = bastion_node.execute_command(save_images_command)
 
     if push_images:
@@ -243,11 +248,15 @@ def add_rancher_images_to_private_registry(
                 "--registry {}".format(
                     bastion_node.host_name, PRIVATE_REGISTRY_USERNAME,
                     PRIVATE_REGISTRY_PASSWORD, bastion_node.host_name)
+            if len(RANCHER_SOURCE_REGISTRY) > 0:
+                load_images_command += " --source-registry {}".format(RANCHER_SOURCE_REGISTRY)
             load_res = bastion_node.execute_command(load_images_command)
         else:
             load_images_command = \
                 "./rancher-load-images.sh --image-list ./rancher-images.txt " \
                 "--registry {}".format(noauth_reg_name)
+            if len(RANCHER_SOURCE_REGISTRY) > 0:
+                load_images_command += " --source-registry {}".format(RANCHER_SOURCE_REGISTRY)
             load_res = bastion_node.execute_command(load_images_command)
         print(load_res)
     else:
@@ -337,16 +346,19 @@ def setup_airgap_rancher(bastion_node, number_of_nodes=NUMBER_OF_INSTANCES):
     assert bastion_node.execute_command(
         '/snap/bin/helm')[0].find("Flags:") > -1, \
         "helm is not installed correctly"
+    
+    repo_name = "rancher-" + RANCHER_HELM_REPO
+    repo_url = RANCHER_HELM_URL + RANCHER_HELM_REPO
     bastion_node.execute_command(
-        '/snap/bin/helm repo add rancher-latest'
-        ' https://releases.rancher.com/server-charts/latest')
+        '/snap/bin/helm repo add ' + repo_name + ' ' + repo_url)
     assert bastion_node.execute_command(
         "/snap/bin/helm repo list")[0].find("rancher") > -1, \
         "helm was unable to add rancher repo"
     bastion_node.execute_command(
-        "/snap/bin/helm fetch rancher-latest/rancher")
+        "/snap/bin/helm fetch " + repo_name + "/rancher")
     bastion_node.execute_command(
-        "/snap/bin/helm fetch rancher-latest/rancher --version={}".format(
+        "/snap/bin/helm fetch {}/rancher --version={}".format(
+            repo_name,
             RANCHER_SERVER_VERSION))
     # remove `v` from the version tag for helm formatting
     new_rancher_version = RANCHER_SERVER_VERSION


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/528
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
airgap currently has no way to test various versions of rancher. only what is on rancher-latest 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
make the install variable
also updated the sed script so that we don't zip/unzip all the images (takes a lot of time and space that isn't necessary)
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
the scripts were tested locally as part of another issue
the helm changes have been tested as part of the ha_deploy python job, as these changes are the same. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->