### PR TITLE
Improved Azure login error handling

### DIFF
--- a/pkg/api/norman/customization/aks/handler.go
+++ b/pkg/api/norman/customization/aks/handler.go
@@ -186,11 +186,13 @@ func (h *handler) checkCredentials(req *http.Request) (int, error) {
 	}
 	client, err := NewSubscriptionServiceClient(cred)
 	if err != nil {
-		return http.StatusUnauthorized, fmt.Errorf("invalid credentials")
+		logrus.Errorf("[AKS] failed to create new subscription client: %v", err)
+		return http.StatusUnauthorized, fmt.Errorf("invalid credentials: %w", err)
 	}
 	_, err = client.Get(ctx, cred.SubscriptionID)
 	if err != nil {
-		return http.StatusUnauthorized, fmt.Errorf("invalid credentials")
+		logrus.Errorf("[AKS] failed to get subscription details: %v", err)
+		return http.StatusUnauthorized, fmt.Errorf("invalid credentials: %w", err)
 	}
 
 	return http.StatusOK, nil
@@ -334,8 +336,14 @@ func (h *handler) generateAPIContext(req *http.Request) *types.APIContext {
 }
 
 func handleErr(writer http.ResponseWriter, errorCode int, originalErr error) {
-	asJSON := []byte(fmt.Sprintf(`{"error":"%v"}`, originalErr))
-
 	writer.WriteHeader(errorCode)
-	writer.Write(asJSON)
+
+	payload := make(map[string]string)
+	payload["error"] = originalErr.Error()
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil { // This should not happen given fixed types on the payload - https://stackoverflow.com/a/33964549
+		logrus.Errorf("[AKS] Failed to write payload JSON: %v", err)
+		return
+	}
+	writer.Write(payloadJSON)
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39611
 
## Problem
When creating new Cloud Credentials for Azure it's impossible to get more information on what exactly is wrong with specified credentials as UI shows a generic "Authentication test failed, please check your credentials" message, response from `aksCheckCredentials` simply has `{"error":"invalid credentials"}` and Rancher server log doesn't have any relevant messages logged.
 
## Solution
* Error message returned by `aksCheckCredentials` now has Azure API error appended to it. Note the following:
	* While the messages can be pretty long, in my testing they did not include any sensitive information and were very helpful to understand what exactly is wrong with the credentials (see "testing" section below)
	* UI still shows the generic "Authentication test failed, please check your credentials" (which is OK or even a good thing)
* Added logging for these situations
* While at it, fixed encoding "error" text to JSON (having `"`s in error text resulted in invalid JSON which is actually the root cause of https://github.com/rancher/dashboard/issues/7285)
 
## Testing

## Engineering Testing
### Manual Testing
Tested various cases of invalid credentials and confirmed logged messages are at least somewhat helpful in determining the specific issue and don't contain sensitive info (Subscription ID was redacted just in case, but it's not sensitive):
* Invalid client secret value:
> {"error":"invalid credentials: azure.BearerAuthorizer#WithAuthorization: Failed to refresh the Token for request to https://management.azure.com/subscriptions/(subscription-id-redacted)?api-version=2016-06-01: StatusCode=401 -- Original Error: adal: Refresh request failed. Status Code = '401'. Response body: {\"error\":\"invalid_client\",\"error_description\":\"AADSTS7000215: Invalid client secret provided. Ensure the secret being sent in the request is the client secret value, not the client secret ID, for a secret added to app '7e22879e-9f7c-4aa8-9527-76e4c70e68c8'.\\r\\nTrace ID: 2242a94b-4c79-4013-82e6-292bdceda201\\r\\nCorrelation ID: 48db33b1-6375-4ac9-8292-11cda9c46d1d\\r\\nTimestamp: 2022-11-15 23:52:45Z\",\"error_codes\":[7000215],\"timestamp\":\"2022-11-15 23:52:45Z\",\"trace_id\":\"2242a94b-4c79-4013-82e6-292bdceda201\",\"correlation_id\":\"48db33b1-6375-4ac9-8292-11cda9c46d1d\",\"error_uri\":\"https://login.microsoftonline.com/error?code=7000215\"} Endpoint https://login.microsoftonline.com/fcf34994-aac4-4462-afaa-d83f87c5f51d/oauth2/token?api-version=1.0"}
* Invalid Client ID value:
> {"error":"invalid credentials: azure.BearerAuthorizer#WithAuthorization: Failed to refresh the Token for request to https://management.azure.com/subscriptions/(subscription-id-redacted)?api-version=2016-06-01: StatusCode=400 -- Original Error: adal: Refresh request failed. Status Code = '400'. Response body: {\"error\":\"unauthorized_client\",\"error_description\":\"AADSTS700016: Application with identifier '7e22879e-9f7c-4aa8-9527-76e4c70e68c9' was not found in the directory 'SUSE Linux s.r.o.'. This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. You may have sent your authentication request to the wrong tenant.\\r\\nTrace ID: 1bde3527-2cd9-415f-a26a-98e2f0182600\\r\\nCorrelation ID: 57dd13d8-f3e4-4ebe-8637-48109be5acf5\\r\\nTimestamp: 2022-11-15 23:55:03Z\",\"error_codes\":[700016],\"timestamp\":\"2022-11-15 23:55:03Z\",\"trace_id\":\"1bde3527-2cd9-415f-a26a-98e2f0182600\",\"correlation_id\":\"57dd13d8-f3e4-4ebe-8637-48109be5acf5\",\"error_uri\":\"https://login.microsoftonline.com/error?code=700016\"} Endpoint https://login.microsoftonline.com/fcf34994-aac4-4462-afaa-d83f87c5f51d/oauth2/token?api-version=1.0"}
* App (Client ID) doesn't have access to the specified Subscription:
> {"error":"invalid credentials: subscription.SubscriptionsClient#Get: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code=\"AuthorizationFailed\" Message=\"The client 'bccb006f-1ba0-4d6f-9866-ba027a5bef3a' with object id 'bccb006f-1ba0-4d6f-9866-ba027a5bef3a' does not have authorization to perform action 'Microsoft.Resources/subscriptions/read' over scope '/subscriptions/(subscription-id-redacted)' or the scope is invalid. If access was recently granted, please refresh your credentials.\""}
* Expired secret - did not test it as I don't have expired secret and can't create one that expired earlier than tomorrow. But the screenshot in https://github.com/rancher/dashboard/issues/7285 shows the message that will be included.

### Automated Testing
N/A

## QA Testing Considerations
Nothing beyond what's outlined above, quite a trivial change.
 
### Regressions Considerations
This should not cause any regression. However following this change, in the situation outlined in https://github.com/rancher/dashboard/issues/7285 UI now shows `[object Object]` error text that is not helpful - but not less helpful than the current `SyntaxError: Expected "," or '}' after property value in JSON at position...`. UI code needs to be improved to properly handle the returned error object.