### PR TITLE
[v2.6] Add support for hardening K3s custom clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -168,6 +168,8 @@ require (
 
 require github.com/google/gnostic v0.5.7-v3refs
 
+require github.com/kr/fs v0.1.0 // indirect
+
 require (
 	cloud.google.com/go/compute v1.6.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
@@ -297,6 +299,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
+	github.com/pkg/sftp v1.13.5
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1020,6 +1020,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kortschak/utter v1.0.1/go.mod h1:vSmSjbyrlKjjsL71193LmzBOKgwePk9DH6uFaWHIInc=
+github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -1321,6 +1322,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
+github.com/pkg/sftp v1.13.5 h1:a3RLUqkyjYRtBTZJZ1VRrKbN3zhuPLlUc3sphVz81go=
+github.com/pkg/sftp v1.13.5/go.mod h1:wHDZ0IZX6JcBYRK1TH9bcVq8G7TLpVHYIGJRFnmPfxg=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/tests/framework/extensions/hardening/k3s/audit.yaml
+++ b/tests/framework/extensions/hardening/k3s/audit.yaml
@@ -1,0 +1,4 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: Metadata

--- a/tests/framework/extensions/hardening/k3s/harden_nodes.go
+++ b/tests/framework/extensions/hardening/k3s/harden_nodes.go
@@ -1,0 +1,79 @@
+package hardening
+
+import (
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
+	"github.com/sirupsen/logrus"
+)
+
+func HardeningNodes(client *rancher.Client, hardened bool, nodes []*nodes.Node, nodeRoles []string) error {
+	for key, node := range nodes {
+		logrus.Infof("Setting kernel parameters on node %s", node.NodeID)
+		_, err := node.ExecuteCommand("sudo setenforce 1")
+		if err != nil {
+			return err
+		}
+		_, err = node.ExecuteCommand("sudo bash -c 'echo vm.panic_on_oom=0 >> /etc/sysctl.conf'")
+		if err != nil {
+			return err
+		}
+		_, err = node.ExecuteCommand("sudo bash -c 'echo kernel.panic=10 >> /etc/sysctl.conf'")
+		if err != nil {
+			return err
+		}
+		_, err = node.ExecuteCommand("sudo bash -c 'echo kernel.panic_on_oops=1 >> /etc/sysctl.conf'")
+		if err != nil {
+			return err
+		}
+		_, err = node.ExecuteCommand("sudo bash -c 'echo kernel.keys.root_maxbytes=25000000 >> /etc/sysctl.conf'")
+		if err != nil {
+			return err
+		}
+		_, err = node.ExecuteCommand("sudo bash -c 'sysctl -p /etc/sysctl.conf'")
+		if err != nil {
+			return err
+		}
+
+		if nodeRoles[key] == "--etcd --controlplane --worker" || nodeRoles[key] == "--controlplane" || nodeRoles[key] == " --controlplane" {
+			logrus.Infof("Copying over files to node %s", node.NodeID)
+			dir := "/go/src/github.com/rancher/rancher/tests/framework/extensions/hardening/k3s"
+			err = node.SCPFileToNode(dir+"/audit.yaml", "/home/"+node.SSHUser+"/audit.yaml")
+			if err != nil {
+				return err
+			}
+			err = node.SCPFileToNode(dir+"/psp.yaml", "/home/"+node.SSHUser+"/psp.yaml")
+			if err != nil {
+				return err
+			}
+			err = node.SCPFileToNode(dir+"/system-policy.yaml", "/home/"+node.SSHUser+"/system-policy.yaml")
+			if err != nil {
+				return err
+			}
+
+			logrus.Infof("Applying hardened YAML files to node: %s", node.NodeID)
+			_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/audit.yaml /var/lib/rancher/k3s/server/audit.yaml'")
+			if err != nil {
+				return err
+			}
+			_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/psp.yaml /var/lib/rancher/k3s/psp.yaml'")
+			if err != nil {
+				return err
+			}
+			_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/system-policy.yaml /var/lib/rancher/k3s/system-policy.yaml'")
+			if err != nil {
+				return err
+			}
+
+			_, err = node.ExecuteCommand("sudo bash -c 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml && kubectl apply -f /var/lib/rancher/k3s/psp.yaml'")
+			if err != nil {
+				return err
+			}
+			_, err = node.ExecuteCommand("sudo bash -c 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml && kubectl apply -f /var/lib/rancher/k3s/system-policy.yaml'")
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/tests/framework/extensions/hardening/k3s/psp.yaml
+++ b/tests/framework/extensions/hardening/k3s/psp.yaml
@@ -1,0 +1,36 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: restricted-psp
+spec:
+  privileged: false                # CIS - 5.2.1
+  allowPrivilegeEscalation: false  # CIS - 5.2.5
+  requiredDropCapabilities:        # CIS - 5.2.7/8/9
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'csi'
+    - 'persistentVolumeClaim'
+    - 'ephemeral'
+  hostNetwork: false               # CIS - 5.2.4
+  hostIPC: false                   # CIS - 5.2.3
+  hostPID: false                   # CIS - 5.2.2
+  runAsUser:
+    rule: 'MustRunAsNonRoot'       # CIS - 5.2.6
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false

--- a/tests/framework/extensions/hardening/k3s/system-policy.yaml
+++ b/tests/framework/extensions/hardening/k3s/system-policy.yaml
@@ -1,0 +1,117 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: restricted-psp
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'csi'
+    - 'persistentVolumeClaim'
+    - 'ephemeral'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:restricted-psp
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - restricted-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: default:restricted-psp
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:restricted-psp
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: system-unrestricted-psp
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-unrestricted-node-psp-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system-unrestricted-psp-role
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system-unrestricted-psp-role
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - system-unrestricted-psp
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/tests/v2/validation/provisioning/config.go
+++ b/tests/v2/validation/provisioning/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	CNIs               []string                 `json:"cni" yaml:"cni"`
 	Providers          []string                 `json:"providers" yaml:"providers"`
 	NodeProviders      []string                 `json:"nodeProviders" yaml:"nodeProviders"`
+	Hardened           bool                     `json:"hardened" yaml:"hardened"`
 }
 
 func AppendRandomString(baseClusterName string) string {

--- a/tests/v2/validation/provisioning/k3s/README.md
+++ b/tests/v2/validation/provisioning/k3s/README.md
@@ -36,7 +36,8 @@ provisioningInput is needed to the run the K3S tests, specifically kubernetesVer
     "kubernetesVersion": ["v1.24.4+k3s1"],
     "cni": ["calico"],
     "providers": ["linode", "aws", "azure", "harvester"],
-    "nodeProviders": ["ec2"]
+    "nodeProviders": ["ec2"],
+    "hardened": true
   }
 ```
 

--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -10,6 +10,7 @@ import (
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	hardening "github.com/rancher/rancher/tests/framework/extensions/hardening/k3s"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/tokenregistration"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
@@ -28,6 +29,7 @@ import (
 type CustomClusterProvisioningTestSuite struct {
 	suite.Suite
 	client             *rancher.Client
+	provisioning       *provisioning.Config
 	session            *session.Session
 	standardUserClient *rancher.Client
 	kubernetesVersions []string
@@ -47,6 +49,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 
 	c.kubernetesVersions = clustersConfig.KubernetesVersions
 	c.nodeProviders = clustersConfig.NodeProviders
+	c.provisioning = clustersConfig
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(c.T(), err)
@@ -90,12 +93,13 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningK3SCustomCluster(extern
 	tests := []struct {
 		name      string
 		nodeRoles []string
+		hardening *provisioning.Config
 		client    *rancher.Client
 	}{
-		{"1 Node all roles Admin User", nodeRoles0, c.client},
-		{"1 Node all roles Standard User", nodeRoles0, c.standardUserClient},
-		{"3 nodes - 1 role per node Admin User", nodeRoles1, c.client},
-		{"3 nodes - 1 role per node Standard User", nodeRoles1, c.standardUserClient},
+		{"1 Node all roles Admin User", nodeRoles0, c.provisioning, c.client},
+		{"1 Node all roles Standard User", nodeRoles0, c.provisioning, c.standardUserClient},
+		{"3 nodes - 1 role per node Admin User", nodeRoles1, c.provisioning, c.client},
+		{"3 nodes - 1 role per node Standard User", nodeRoles1, c.provisioning, c.standardUserClient},
 	}
 	var name string
 	for _, tt := range tests {
@@ -159,6 +163,17 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningK3SCustomCluster(extern
 				clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
 				require.NoError(c.T(), err)
 				assert.NotEmpty(c.T(), clusterToken)
+
+				if tt.hardening.Hardened {
+					err = hardening.HardeningNodes(client, tt.hardening.Hardened, nodes, tt.nodeRoles)
+					require.NoError(c.T(), err)
+
+					hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, nil)
+
+					hardenClusterResp, err := clusters.UpdateK3SRKE2Cluster(client, clusterResp, hardenCluster)
+					require.NoError(c.T(), err)
+					assert.Equal(c.T(), clusterName, hardenClusterResp.ObjectMeta.Name)
+				}
 			})
 		}
 	}
@@ -186,11 +201,12 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningK3SCustomClusterDynamic
 	numOfNodes := len(rolesPerNode)
 
 	tests := []struct {
-		name   string
-		client *rancher.Client
+		name      string
+		client    *rancher.Client
+		hardening *provisioning.Config
 	}{
-		{"Admin User", c.client},
-		{"Standard User", c.standardUserClient},
+		{"Admin User", c.client, c.provisioning},
+		{"Standard User", c.standardUserClient, c.provisioning},
 	}
 
 	var name string
@@ -254,6 +270,17 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningK3SCustomClusterDynamic
 				clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
 				require.NoError(c.T(), err)
 				assert.NotEmpty(c.T(), clusterToken)
+
+				if tt.hardening.Hardened {
+					err = hardening.HardeningNodes(client, tt.hardening.Hardened, nodes, rolesPerNode)
+					require.NoError(c.T(), err)
+
+					hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, nil)
+
+					hardenClusterResp, err := clusters.UpdateK3SRKE2Cluster(client, clusterResp, hardenCluster)
+					require.NoError(c.T(), err)
+					assert.Equal(c.T(), clusterName, hardenClusterResp.ObjectMeta.Name)
+				}
 			})
 		}
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Add support for provisioning k3s hardened Rancher managed Custom clusters](https://github.com/rancher/qa-tasks/issues/500)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Currently, the Go test framework allows for provisioning K3s custom clusters. By default, these are non-hardened clusters. In realistic customer environments, hardened clusters are at the forefront, so we need to be able to support this in our testing. This PR addresses this problem by providing the option to harden the custom K3s clusters.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This is a multi-step solution, please find a summary of the changes incorporated:

1. There needed to be an option available to select whether or not the user wishes to harden the cluster. This is done by adding a new `Hardened` bool type in the `config.go` struct.  Inside the user's `cattle-config.yaml`, they will have to define a new `hardened` value and set it to true or false.
2. In the `custom_clusters_test.go` file, new functions `CheckClusterHardening`, `HardenK3SRKE2ClusterConfig` and `UpdateK3SRKE2Cluster` are referenced. We will break each down in the subsequent steps, consequently.
3. `CheckClusterHardening` is found in the new `hardening/harden_nodes.go`. The point of the file is it will check the new `Hardened` value as mentioned in step 1. If user says yes, harden the node following appropriate hardening steps.
4. Once step 3 is finished, `HardenK3SRKE2ClusterConfig` will update the cluster's configuration to harden the cluster.
5. Once step 4 is finished, `UpdateK3SRKE2Cluster` will call upon the Steve client's update function to complete the changes to actually harden the K3s custom cluster.

As of now, this change only goes to the non-dynamic test function. This is because we would have to refactor the nodeRoles to use `machinepools.NodeRoles` and that was getting a bit messy when I was testing this locally. We can always change that if we want.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Tested against 1 role w/admin and standard user, 3 role w/admin and standard users.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Offline Jenkins jobs will be given to the reviewers.