### PR TITLE
[v2.7.1] Ensure ProvV2 indexers are registered for all replicas

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -92,9 +92,6 @@ func Register(
 			clients.Mgmt.Cluster()),
 	}
 
-	clients.Provisioning.Cluster().Cache().AddIndexer(ByCluster, byClusterIndex)
-	clients.Provisioning.Cluster().Cache().AddIndexer(ByCloudCred, byCloudCredentialIndex)
-
 	// Register a generating handler in order to generate clusters.provisioning.cattle.io/v1 objects based on
 	// clusters.management.cattle.io/v3 (legacy) cluster objects.
 	mgmtcontrollers.RegisterClusterGeneratingHandler(ctx,
@@ -134,6 +131,11 @@ func Register(
 
 	clients.Mgmt.Cluster().OnRemove(ctx, "mgmt-cluster-remove", h.OnMgmtClusterRemove)
 	clients.Provisioning.Cluster().OnRemove(ctx, "provisioning-cluster-remove", h.OnClusterRemove)
+}
+
+func RegisterIndexers(config *wrangler.Context) {
+	config.Provisioning.Cluster().Cache().AddIndexer(ByCluster, byClusterIndex)
+	config.Provisioning.Cluster().Cache().AddIndexer(ByCloudCred, byCloudCredentialIndex)
 }
 
 func byClusterIndex(obj *v1.Cluster) ([]string, error) {

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/dashboard/apiservice"
 	"github.com/rancher/rancher/pkg/controllers/dashboardapi"
 	managementauth "github.com/rancher/rancher/pkg/controllers/management/auth"
+	provisioningv2 "github.com/rancher/rancher/pkg/controllers/provisioningv2/cluster"
 	crds "github.com/rancher/rancher/pkg/crds/dashboard"
 	dashboarddata "github.com/rancher/rancher/pkg/data/dashboard"
 	"github.com/rancher/rancher/pkg/features"
@@ -145,6 +146,11 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 	podsecuritypolicytemplate.RegisterIndexers(wranglerContext)
 	kontainerdriver.RegisterIndexers(wranglerContext)
 	managementauth.RegisterWranglerIndexers(wranglerContext)
+
+	if features.ProvisioningV2.Enabled() {
+		// ensure indexers are registered for all replicas
+		provisioningv2.RegisterIndexers(wranglerContext)
+	}
 
 	if err := crds.Create(ctx, restConfig); err != nil {
 		return nil, err


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39300
 
## Problem
When deleting cloud credentials an error would intermittently appear stating `Index with name by-cloud-cred does not exist`, and the cloud credential would not be deleted. This issue only reproduces in HA setups. 

## Solution
The root cause of this issue is, as the error mentions, a missing indexer in the provisioning cluster cache. This indexer is used to determine if any provisioning clusters are currently using the cloud credential being deleted. The reason that this issue only appears in HA setups is that only the leader pod will actually register the indexer. In cases where there is only one replica, or the Rancher server is being run in docker/IDE, this issue will not reproduce.

The indexer is registered as apart of other prov v2 controllers, which are only active on the leader pod. When the UI makes the request to delete the cloud credential it is not guaranteed that the request will always go to the leader pod.  In cases where the request is routed to a non-leader pod, this error will occur. 

The solution to this is to have all replicas register the indexer upon server start if the provisioning v2 feature is enabled. I've also fixed some casing issues and made the error message returned during a generic cache error more user friendly. 

## Testing
+ Create an HA cluster
+ Create AWS cloud credentials
+ Create an RKE2 cluster on AWS
+ Once the RKE2 cluster has become available, attempt to delete the cloud credentials 
+ Observe that the `index with name by-cloud-cred does not exist` error does not intermittently appear, and instead the message `Cloud credential is currently referenced by provisioning cluster XXX` appears

## Engineering Testing
### Manual Testing
I've built a custom image of Rancher with my changes and used it in an HA setup, I did not see the error appear anymore. 

### Automated Testing
N/A

## QA Testing Considerations
This requires an HA setup. When reproducing the issue the error should appear more frequently when more Rancher replica's are added to the deployment.
 
### Regressions Considerations
None I can think of