### PR TITLE
[2.6]Adding additional test cases to the rbac suite

### DIFF
--- a/tests/framework/extensions/users/users.go
+++ b/tests/framework/extensions/users/users.go
@@ -49,11 +49,16 @@ func AddProjectMember(rancherClient *rancher.Client, project *management.Project
 
 	name := strings.Split(project.ID, ":")[1]
 
+	adminClient, err := rancher.NewClient(rancherClient.RancherConfig.AdminToken, rancherClient.Session)
+	if err != nil {
+		return err
+	}
+
 	opts := metav1.ListOptions{
 		FieldSelector:  "metadata.name=" + name,
 		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
 	}
-	watchInterface, err := rancherClient.GetManagementWatchInterface(management.ProjectType, opts)
+	watchInterface, err := adminClient.GetManagementWatchInterface(management.ProjectType, opts)
 	if err != nil {
 		return err
 	}

--- a/tests/v2/validation/rbac/rbac.go
+++ b/tests/v2/validation/rbac/rbac.go
@@ -16,6 +16,7 @@ import (
 
 const roleOwner = "cluster-owner"
 const roleMember = "cluster-member"
+const roleProjectOwner = "project-owner"
 
 func createUser(client *rancher.Client) (*management.User, error) {
 	enabled := true


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/qa-tasks/issues/538
 
## Problem
We are automating a few additional rbac test cases to run during release testing 
1. As a cluster owner, add another user as a cluster owner
2. As a cluster owner, add a user as Project Owner
3. As a cluster owner, add cluster member to a project as a project owner 

## Solution
In this PR we are using the existing rbac test suite that covers additional test cases for RBAC cluster owner listed above.
This PR also includes a fix to add an admin dynamic client for watchinterface, which would otherwise fail if we pass a standard user to the function. We are dynamically getting the admin client token and using it for the watch interface in the users.go function. 

