### PR TITLE
[release/v2.6] Skip provtest CI when local repo branch is used

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ platform:
   arch: amd64
 
 steps:
-- name: provisioning-tests
+- name: provisioning-tests-pr
   image: rancher/dapper:v0.5.8
   commands:
   - dapper provisioning-tests
@@ -17,8 +17,25 @@ steps:
     path: /var/run/docker.sock
   when:
     event:
-    - push
     - pull_request
+- name: provisioning-tests-push
+  image: rancher/dapper:v0.5.8
+  commands:
+  - dapper provisioning-tests
+  privileged: true
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/master"
+        - "refs/heads/release/v*"
+        - "refs/tags/v*"
+    event:
+    - push
 
 volumes:
 - name: docker
@@ -38,7 +55,7 @@ platform:
   arch: amd64
 
 steps:
-- name: provisioning-tests
+- name: provisioning-tests-pr
   image: rancher/dapper:v0.5.8
   commands:
   - dapper provisioning-tests-rke
@@ -48,8 +65,25 @@ steps:
     path: /var/run/docker.sock
   when:
     event:
-    - push
     - pull_request
+- name: provisioning-tests-push
+  image: rancher/dapper:v0.5.8
+  commands:
+  - dapper provisioning-tests-rke
+  privileged: true
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/master"
+        - "refs/heads/release/v*"
+        - "refs/tags/v*"
+    event:
+    - push
 
 volumes:
 - name: docker


### PR DESCRIPTION
This fix is similar to https://github.com/rancher/rancher/pull/37806.

As more and more automation is going to be used, the "waste" of running CI on `drone-publish` is growing. We already scoped most of the steps in the previously linked PR, this PR also scopes the `provisioning-tests` to only when it is actually needed (`pull_request` or `push` to specific branches). This saves cost and time on each PR created using automation.