### PR TITLE
[v2.6] Back-Port #39300: Ensure ProvV2 indexers are registered for all replicas

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -92,9 +92,6 @@ func Register(
 			clients.Mgmt.Cluster()),
 	}
 
-	clients.Provisioning.Cluster().Cache().AddIndexer(ByCluster, byClusterIndex)
-	clients.Provisioning.Cluster().Cache().AddIndexer(ByCloudCred, byCloudCredentialIndex)
-
 	mgmtcontrollers.RegisterClusterGeneratingHandler(ctx,
 		clients.Mgmt.Cluster(),
 		clients.Apply.WithCacheTypes(clients.Provisioning.Cluster()),
@@ -130,6 +127,11 @@ func Register(
 
 	clients.Mgmt.Cluster().OnRemove(ctx, "mgmt-cluster-remove", h.OnMgmtClusterRemove)
 	clients.Provisioning.Cluster().OnRemove(ctx, "provisioning-cluster-remove", h.OnClusterRemove)
+}
+
+func RegisterIndexers(config *wrangler.Context) {
+	config.Provisioning.Cluster().Cache().AddIndexer(ByCluster, byClusterIndex)
+	config.Provisioning.Cluster().Cache().AddIndexer(ByCloudCred, byCloudCredentialIndex)
 }
 
 func byClusterIndex(obj *v1.Cluster) ([]string, error) {

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/dashboard/apiservice"
 	"github.com/rancher/rancher/pkg/controllers/dashboardapi"
 	managementauth "github.com/rancher/rancher/pkg/controllers/management/auth"
+	provisioningv2 "github.com/rancher/rancher/pkg/controllers/provisioningv2/cluster"
 	crds "github.com/rancher/rancher/pkg/crds/dashboard"
 	dashboarddata "github.com/rancher/rancher/pkg/data/dashboard"
 	"github.com/rancher/rancher/pkg/features"
@@ -145,6 +146,11 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 	podsecuritypolicytemplate.RegisterIndexers(wranglerContext)
 	kontainerdriver.RegisterIndexers(wranglerContext)
 	managementauth.RegisterWranglerIndexers(wranglerContext)
+
+	if features.ProvisioningV2.Enabled() {
+		// ensure indexers are registered for all replicas
+		provisioningv2.RegisterIndexers(wranglerContext)
+	}
 
 	if err := crds.Create(ctx, restConfig); err != nil {
 		return nil, err


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39300, https://github.com/rancher/rancher/issues/39717
 
This is a back port of https://github.com/rancher/rancher/pull/39622. More detailed description and testing steps can be found in the original PR.