### PR TITLE
Add hardening config for rancher provisioned rke2 clusters

### DIFF
--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rancher/norman/types"
@@ -208,8 +209,7 @@ func NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretN
 		CloudCredentialSecretName: cloudCredentialSecretName,
 		KubernetesVersion:         kubernetesVersion,
 		LocalClusterAuthEndpoint:  localClusterAuthEndpoint,
-
-		RKEConfig: rkeConfig,
+		RKEConfig:                 rkeConfig,
 	}
 
 	v1Cluster := &apisV1.Cluster{
@@ -225,28 +225,41 @@ func NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretN
 func HardenK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretName, kubernetesVersion string, machinePools []apisV1.RKEMachinePool) *apisV1.Cluster {
 	v1Cluster := NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretName, kubernetesVersion, machinePools)
 
-	v1Cluster.Spec.RKEConfig.MachineGlobalConfig.Data["kube-apiserver-arg"] = []string{
-		"enable-admission-plugins=NodeRestriction,PodSecurityPolicy,ServiceAccount",
-		"audit-policy-file=/var/lib/rancher/k3s/server/audit.yaml",
-		"audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log",
-		"audit-log-maxage=30",
-		"audit-log-maxbackup=10",
-		"audit-log-maxsize=100",
-		"request-timeout=300s",
-		"service-account-lookup=true",
-	}
+	if strings.Contains(kubernetesVersion, "k3s") {
+		v1Cluster.Spec.RKEConfig.MachineGlobalConfig.Data["kube-apiserver-arg"] = []string{
+			"enable-admission-plugins=NodeRestriction,PodSecurityPolicy,ServiceAccount",
+			"audit-policy-file=/var/lib/rancher/k3s/server/audit.yaml",
+			"audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log",
+			"audit-log-maxage=30",
+			"audit-log-maxbackup=10",
+			"audit-log-maxsize=100",
+			"request-timeout=300s",
+			"service-account-lookup=true",
+		}
 
-	v1Cluster.Spec.RKEConfig.MachineSelectorConfig = []rkev1.RKESystemConfig{
-		{
-			Config: rkev1.GenericMap{
-				Data: map[string]interface{}{
-					"kubelet-arg": []string{
-						"make-iptables-util-chains=true",
+		v1Cluster.Spec.RKEConfig.MachineSelectorConfig = []rkev1.RKESystemConfig{
+			{
+				Config: rkev1.GenericMap{
+					Data: map[string]interface{}{
+						"kubelet-arg": []string{
+							"make-iptables-util-chains=true",
+						},
+						"protect-kernel-defaults": true,
 					},
-					"protect-kernel-defaults": true,
 				},
 			},
-		},
+		}
+	} else {
+		v1Cluster.Spec.RKEConfig.MachineSelectorConfig = []rkev1.RKESystemConfig{
+			{
+				Config: rkev1.GenericMap{
+					Data: map[string]interface{}{
+						"profile":                 "cis-1.6",
+						"protect-kernel-defaults": true,
+					},
+				},
+			},
+		}
 	}
 
 	return v1Cluster

--- a/tests/framework/extensions/hardening/rke2/account-update.sh
+++ b/tests/framework/extensions/hardening/rke2/account-update.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+for namespace in $(kubectl get namespaces -A -o=jsonpath="{.items[*]['metadata.name']}"); do
+  echo -n "Patching namespace $namespace - "
+  kubectl patch serviceaccount default -n ${namespace} -p "$(cat /var/lib/rancher/rke2/server/account-update.yaml)"
+done

--- a/tests/framework/extensions/hardening/rke2/account-update.yaml
+++ b/tests/framework/extensions/hardening/rke2/account-update.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+automountServiceAccountToken: false

--- a/tests/framework/extensions/hardening/rke2/harden_nodes.go
+++ b/tests/framework/extensions/hardening/rke2/harden_nodes.go
@@ -1,0 +1,76 @@
+package hardening
+
+import (
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
+	"github.com/sirupsen/logrus"
+	"strings"
+)
+
+func HardeningNodes(client *rancher.Client, hardened bool, nodes []*nodes.Node, nodeRoles []string) error {
+	for key, node := range nodes {
+		logrus.Infof("Setting kernel parameters on node %s", node.NodeID)
+		_, err := node.ExecuteCommand("sudo bash -c 'echo vm.panic_on_oom=0 >> /etc/sysctl.d/90-kubelet.conf'")
+		if err != nil {
+			return err
+		}
+		_, err = node.ExecuteCommand("sudo bash -c 'echo vm.overcommit_memory=1 >> /etc/sysctl.d/90-kubelet.conf'")
+		if err != nil {
+			return err
+		}
+		_, err = node.ExecuteCommand("sudo bash -c 'echo kernel.panic=10 >> /etc/sysctl.d/90-kubelet.conf'")
+		if err != nil {
+			return err
+		}
+		_, err = node.ExecuteCommand("sudo bash -c 'echo kernel.panic_on_oops=1 >> /etc/sysctl.d/90-kubelet.conf'")
+		if err != nil {
+			return err
+		}
+		_, err = node.ExecuteCommand("sudo bash -c 'sysctl -p /etc/sysctl.d/90-kubelet.conf'")
+		if err != nil {
+			return err
+		}
+		if strings.Contains(nodeRoles[key], "--etcd") {
+			_, err = node.ExecuteCommand("sudo useradd -r -c \"etcd user\" -s /sbin/nologin -M etcd -U")
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func PostHardeningConfig(client *rancher.Client, hardened bool, nodes []*nodes.Node, nodeRoles []string) error {
+	for key, node := range nodes {
+
+		if strings.Contains(nodeRoles[key], "--controlplane") {
+			dir_local := "/go/src/github.com/rancher/rancher/tests/framework/extensions/hardening/rke2"
+			err := node.SCPFileToNode(dir_local+"/account-update.yaml", "/home/"+node.SSHUser+"/account-update.yaml")
+			if err != nil {
+				return err
+			}
+			err = node.SCPFileToNode(dir_local+"/account-update.sh", "/home/"+node.SSHUser+"/account-update.sh")
+			if err != nil {
+				return err
+			}
+			_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/account-update.yaml /var/lib/rancher/rke2/server/account-update.yaml'")
+			if err != nil {
+				return err
+			}
+			_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/account-update.sh /var/lib/rancher/rke2/server/account-update.sh'")
+			if err != nil {
+				return err
+			}
+			_, err = node.ExecuteCommand("sudo bash -c 'chmod +x /var/lib/rancher/rke2/server/account-update.sh'")
+			if err != nil {
+				return err
+			}
+			_, err = node.ExecuteCommand("sudo bash -c 'export KUBECONFIG=/etc/rancher/rke2/rke2.yaml && /var/lib/rancher/rke2/server/account-update.sh'")
+			if err != nil {
+				return err
+			}
+			break
+		}
+	}
+	return nil
+}

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -10,6 +10,7 @@ import (
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	hardening "github.com/rancher/rancher/tests/framework/extensions/hardening/rke2"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/tokenregistration"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
@@ -30,6 +31,7 @@ type CustomClusterProvisioningTestSuite struct {
 	client             *rancher.Client
 	session            *session.Session
 	standardUserClient *rancher.Client
+	provisioning       *provisioning.Config
 	kubernetesVersions []string
 	cnis               []string
 	nodeProviders      []string
@@ -49,6 +51,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	c.kubernetesVersions = clustersConfig.KubernetesVersions
 	c.cnis = clustersConfig.CNIs
 	c.nodeProviders = clustersConfig.NodeProviders
+	c.provisioning = clustersConfig
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(c.T(), err)
@@ -92,12 +95,13 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 	tests := []struct {
 		name      string
 		nodeRoles []string
+		hardening *provisioning.Config
 		client    *rancher.Client
 	}{
-		{"1 Node all roles Admin User", nodeRoles0, c.client},
-		{"1 Node all roles Standard User", nodeRoles0, c.standardUserClient},
-		{"3 nodes - 1 role per node Admin User", nodeRoles1, c.client},
-		{"3 nodes - 1 role per node Standard User", nodeRoles1, c.standardUserClient},
+		{"1 Node all roles Admin User", nodeRoles0, c.provisioning, c.client},
+		{"1 Node all roles Standard User", nodeRoles0, c.provisioning, c.standardUserClient},
+		{"3 nodes - 1 role per node Admin User", nodeRoles1, c.provisioning, c.client},
+		{"3 nodes - 1 role per node Standard User", nodeRoles1, c.provisioning, c.standardUserClient},
 	}
 	var name string
 	for _, tt := range tests {
@@ -125,7 +129,6 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 
 					client, err = client.ReLogin()
 					require.NoError(c.T(), err)
-
 					customCluster, err := client.Steve.SteveType(clusters.ProvisioningSteveResouceType).ByID(clusterResp.ID)
 					require.NoError(c.T(), err)
 
@@ -163,6 +166,21 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
 					require.NoError(c.T(), err)
 					assert.NotEmpty(c.T(), clusterToken)
+
+					if tt.hardening.Hardened {
+						err = hardening.HardeningNodes(client, tt.hardening.Hardened, nodes, tt.nodeRoles)
+						require.NoError(c.T(), err)
+
+						hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, nil)
+
+						hardenClusterResp, err := clusters.UpdateK3SRKE2Cluster(client, clusterResp, hardenCluster)
+						require.NoError(c.T(), err)
+						assert.Equal(c.T(), clusterName, hardenClusterResp.ObjectMeta.Name)
+						
+						err = hardening.PostHardeningConfig(client, tt.hardening.Hardened, nodes, tt.nodeRoles)
+						require.NoError(c.T(), err)
+
+					}
 				})
 			}
 		}
@@ -191,11 +209,12 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynami
 	numOfNodes := len(rolesPerNode)
 
 	tests := []struct {
-		name   string
-		client *rancher.Client
+		name      string
+		client    *rancher.Client
+		hardening *provisioning.Config
 	}{
-		{"Admin User", c.client},
-		{"Standard User", c.standardUserClient},
+		{"Admin User", c.client, c.provisioning},
+		{"Standard User", c.standardUserClient, c.provisioning},
 	}
 
 	var name string
@@ -261,6 +280,22 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynami
 					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
 					require.NoError(c.T(), err)
 					assert.NotEmpty(c.T(), clusterToken)
+
+					if tt.hardening.Hardened {
+						err = hardening.HardeningNodes(client, tt.hardening.Hardened, nodes, rolesPerNode)
+						require.NoError(c.T(), err)
+
+						hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, nil)
+
+						hardenClusterResp, err := clusters.UpdateK3SRKE2Cluster(client, clusterResp, hardenCluster)
+						require.NoError(c.T(), err)
+						assert.Equal(c.T(), clusterName, hardenClusterResp.ObjectMeta.Name)
+
+						err = hardening.PostHardeningConfig(client, tt.hardening.Hardened, nodes, rolesPerNode)
+						require.NoError(c.T(), err)
+
+					}
+
 				})
 			}
 		}


### PR DESCRIPTION
## Issue: https://github.com/rancher/qa-tasks/issues/417
 
## Problem
Currently, the Go test framework allows for provisioning RKE2 custom clusters. By default, these are non-hardened clusters. In realistic customer environments, hardened clusters are at the forefront, so we need to be able to support this in our testing. This PR addresses this problem by providing the option to harden the custom RKE2 clusters.



## Solution

This is a multi-step solution, please find a summary of the changes incorporated:
- There needed to be an option available to select whether or not the user wishes to harden the cluster. This is done by adding a new Hardened bool type in the config.go struct. Inside the user's cattle-config.yaml, they will have to define a new hardened value and set it to true or false.
- In the custom_clusters_test.go file, new functions HardenNodes, HardenK3SRKE2ClusterConfig and UpdateK3SRKE2Cluster are referenced. We will break each down in the subsequent steps, consequently.
- HardenNodes is found in the new hardening/harden_nodes.go. The point of the file is it will check the new Hardened value as mentioned in step 1. If user says yes, harden the node following appropriate hardening steps.
- Once step 3 is finished, HardenK3SRKE2ClusterConfig will update the cluster's configuration to harden the cluster.
- Once step 4 is finished, UpdateK3SRKE2Cluster will call upon the Steve client's update function to complete the changes to actually harden the K3s custom cluster.
