### PR TITLE
[2.6 Backport]Add hardening config for rancher provisioned rke2 clusters

### DIFF
--- a/tests/framework/extensions/hardening/rke2/account-update.sh
+++ b/tests/framework/extensions/hardening/rke2/account-update.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+for namespace in $(kubectl get namespaces -A -o=jsonpath="{.items[*]['metadata.name']}"); do
+  echo -n "Patching namespace $namespace - "
+  kubectl patch serviceaccount default -n ${namespace} -p "$(cat /var/lib/rancher/rke2/server/account-update.yaml)"
+done

--- a/tests/framework/extensions/hardening/rke2/account-update.yaml
+++ b/tests/framework/extensions/hardening/rke2/account-update.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+automountServiceAccountToken: false

--- a/tests/framework/extensions/hardening/rke2/harden_nodes.go
+++ b/tests/framework/extensions/hardening/rke2/harden_nodes.go
@@ -1,0 +1,77 @@
+package hardening
+
+import (
+	"strings"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
+	"github.com/sirupsen/logrus"
+)
+
+func HardeningNodes(client *rancher.Client, hardened bool, nodes []*nodes.Node, nodeRoles []string) error {
+	for key, node := range nodes {
+		logrus.Infof("Setting kernel parameters on node %s", node.NodeID)
+		_, err := node.ExecuteCommand("sudo bash -c 'echo vm.panic_on_oom=0 >> /etc/sysctl.d/90-kubelet.conf'")
+		if err != nil {
+			return err
+		}
+		_, err = node.ExecuteCommand("sudo bash -c 'echo vm.overcommit_memory=1 >> /etc/sysctl.d/90-kubelet.conf'")
+		if err != nil {
+			return err
+		}
+		_, err = node.ExecuteCommand("sudo bash -c 'echo kernel.panic=10 >> /etc/sysctl.d/90-kubelet.conf'")
+		if err != nil {
+			return err
+		}
+		_, err = node.ExecuteCommand("sudo bash -c 'echo kernel.panic_on_oops=1 >> /etc/sysctl.d/90-kubelet.conf'")
+		if err != nil {
+			return err
+		}
+		_, err = node.ExecuteCommand("sudo bash -c 'sysctl -p /etc/sysctl.d/90-kubelet.conf'")
+		if err != nil {
+			return err
+		}
+		if strings.Contains(nodeRoles[key], "--etcd") {
+			_, err = node.ExecuteCommand("sudo useradd -r -c \"etcd user\" -s /sbin/nologin -M etcd -U")
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func PostHardeningConfig(client *rancher.Client, hardened bool, nodes []*nodes.Node, nodeRoles []string) error {
+	for key, node := range nodes {
+
+		if strings.Contains(nodeRoles[key], "--controlplane") {
+			dir_local := "/Users/anupamaupadhyayula/go/src/github.com/rancher/rancher/tests/framework/extensions/hardening/rke2"
+			err := node.SCPFileToNode(dir_local+"/account-update.yaml", "/home/"+node.SSHUser+"/account-update.yaml")
+			if err != nil {
+				return err
+			}
+			err = node.SCPFileToNode(dir_local+"/account-update.sh", "/home/"+node.SSHUser+"/account-update.sh")
+			if err != nil {
+				return err
+			}
+			_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/account-update.yaml /var/lib/rancher/rke2/server/account-update.yaml'")
+			if err != nil {
+				return err
+			}
+			_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/account-update.sh /var/lib/rancher/rke2/server/account-update.sh'")
+			if err != nil {
+				return err
+			}
+			_, err = node.ExecuteCommand("sudo bash -c 'chmod +x /var/lib/rancher/rke2/server/account-update.sh'")
+			if err != nil {
+				return err
+			}
+			_, err = node.ExecuteCommand("sudo bash -c 'export KUBECONFIG=/etc/rancher/rke2/rke2.yaml && /var/lib/rancher/rke2/server/account-update.sh'")
+			if err != nil {
+				return err
+			}
+			break
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/qa-tasks/issues/417
 
## Problem
Currently, the Go test framework allows for provisioning RKE2 custom clusters. By default, these are non-hardened clusters. In realistic customer environments, hardened clusters are at the forefront, so we need to be able to support this in our testing. This PR addresses this problem by providing the option to harden the custom RKE2 clusters.



## Solution

This is a multi-step solution, please find a summary of the changes incorporated:
- There needed to be an option available to select whether or not the user wishes to harden the cluster. This is done by adding a new Hardened bool type in the config.go struct. Inside the user's cattle-config.yaml, they will have to define a new hardened value and set it to true or false.
- In the custom_clusters_test.go file, new functions HardenNodes, HardenK3SRKE2ClusterConfig and UpdateK3SRKE2Cluster are referenced. We will break each down in the subsequent steps, consequently.
- HardenNodes is found in the new hardening/harden_nodes.go. The point of the file is it will check the new Hardened value as mentioned in step 1. If user says yes, harden the node following appropriate hardening steps.
- Once step 3 is finished, HardenK3SRKE2ClusterConfig will update the cluster's configuration to harden the cluster.
- Once step 4 is finished, UpdateK3SRKE2Cluster will call upon the Steve client's update function to complete the changes to actually harden the K3s custom cluster.
