### PR TITLE
Add optional filter on AzureAD auth group memberships

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -243,14 +243,15 @@ type GoogleOauthConfigApplyInput struct {
 type AzureADConfig struct {
 	AuthConfig `json:",inline" mapstructure:",squash"`
 
-	Endpoint          string `json:"endpoint,omitempty" norman:"default=https://login.microsoftonline.com/,required,notnullable"`
-	GraphEndpoint     string `json:"graphEndpoint,omitempty" norman:"required,notnullable"`
-	TokenEndpoint     string `json:"tokenEndpoint,omitempty" norman:"required,notnullable"`
-	AuthEndpoint      string `json:"authEndpoint,omitempty" norman:"required,notnullable"`
-	TenantID          string `json:"tenantId,omitempty" norman:"required,notnullable"`
-	ApplicationID     string `json:"applicationId,omitempty" norman:"required,notnullable"`
-	ApplicationSecret string `json:"applicationSecret,omitempty" norman:"required,type=password"`
-	RancherURL        string `json:"rancherUrl,omitempty" norman:"required,notnullable"`
+	Endpoint               string `json:"endpoint,omitempty" norman:"default=https://login.microsoftonline.com/,required,notnullable"`
+	GraphEndpoint          string `json:"graphEndpoint,omitempty" norman:"required,notnullable"`
+	TokenEndpoint          string `json:"tokenEndpoint,omitempty" norman:"required,notnullable"`
+	AuthEndpoint           string `json:"authEndpoint,omitempty" norman:"required,notnullable"`
+	TenantID               string `json:"tenantId,omitempty" norman:"required,notnullable"`
+	ApplicationID          string `json:"applicationId,omitempty" norman:"required,notnullable"`
+	ApplicationSecret      string `json:"applicationSecret,omitempty" norman:"required,type=password"`
+	RancherURL             string `json:"rancherUrl,omitempty" norman:"required,notnullable"`
+	GroupMembershipsFilter string `json:"groupMembershipsFilter,omitempty"`
 }
 
 type AzureADConfigTestOutput struct {

--- a/pkg/auth/providers/azure/azure_provider.go
+++ b/pkg/auth/providers/azure/azure_provider.go
@@ -98,7 +98,7 @@ func (ap *azureProvider) RefetchGroupPrincipals(principalID, secret string) ([]v
 
 	logrus.Debug("[AZURE_PROVIDER] Completed getting user info from AzureAD")
 
-	userGroups, err := azureClient.ListGroupMemberships(clients.GetPrincipalID(userPrincipal))
+	userGroups, err := azureClient.ListGroupMemberships(clients.GetPrincipalID(userPrincipal), cfg.GroupMembershipsFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/providers/azure/clients/ad_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ad_graph_client.go
@@ -74,7 +74,7 @@ func (c *azureADGraphClient) ListGroups(filter string) ([]v3.Principal, error) {
 }
 
 // ListGroupMemberships takes a user ID and fetches the user's group principals as strings IDs from the Azure AD Graph API.
-func (c *azureADGraphClient) ListGroupMemberships(id string) ([]string, error) {
+func (c *azureADGraphClient) ListGroupMemberships(id string, filter string) ([]string, error) {
 	securityEnabledOnly := false
 	params := graphrbac.UserGetMemberGroupsParameters{
 		SecurityEnabledOnly: &securityEnabledOnly,
@@ -101,7 +101,7 @@ func (c *azureADGraphClient) LoginUser(_ *v32.AzureADConfig, _ *v32.AzureADLogin
 	userPrincipal.Me = true
 	logrus.Debug("[AZURE_PROVIDER] Completed getting user info from AzureAD")
 
-	userGroups, err := c.ListGroupMemberships(GetPrincipalID(userPrincipal))
+	userGroups, err := c.ListGroupMemberships(GetPrincipalID(userPrincipal), "")
 	if err != nil {
 		return v3.Principal{}, nil, "", err
 	}

--- a/pkg/auth/providers/azure/clients/client.go
+++ b/pkg/auth/providers/azure/clients/client.go
@@ -20,7 +20,7 @@ type AzureClient interface {
 	ListUsers(filter string) ([]v3.Principal, error)
 	GetGroup(id string) (v3.Principal, error)
 	ListGroups(filter string) ([]v3.Principal, error)
-	ListGroupMemberships(id string) ([]string, error)
+	ListGroupMemberships(id string, filter string) ([]string, error)
 }
 
 // NewAzureClientFromCredential returns a new client to be used for first-time authentication. This means it does not need any

--- a/pkg/auth/providers/azure/clients/ms_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client.go
@@ -93,8 +93,8 @@ func (c azureMSGraphClient) ListGroups(filter string) ([]v3.Principal, error) {
 }
 
 // ListGroupMemberships takes a user ID and fetches the user's group principals as string IDs from the Microsoft Graph API.
-func (c azureMSGraphClient) ListGroupMemberships(id string) ([]string, error) {
-	groups, _, err := c.userClient.ListGroupMemberships(context.Background(), id, odata.Query{})
+func (c azureMSGraphClient) ListGroupMemberships(id string, filter string) ([]string, error) {
+	groups, _, err := c.userClient.ListGroupMemberships(context.Background(), id, odata.Query{Filter: filter})
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (c azureMSGraphClient) LoginUser(config *v32.AzureADConfig, credential *v32
 	userPrincipal.Me = true
 	logrus.Debugf("[%s] Completed getting user info from AzureAD", providerLogPrefix)
 
-	userGroups, err := c.ListGroupMemberships(GetPrincipalID(userPrincipal))
+	userGroups, err := c.ListGroupMemberships(GetPrincipalID(userPrincipal), config.GroupMembershipsFilter)
 	if err != nil {
 		return v3.Principal{}, nil, "", err
 	}

--- a/pkg/client/generated/management/v3/zz_generated_azure_adconfig.go
+++ b/pkg/client/generated/management/v3/zz_generated_azure_adconfig.go
@@ -1,48 +1,50 @@
 package client
 
 const (
-	AzureADConfigType                     = "azureADConfig"
-	AzureADConfigFieldAccessMode          = "accessMode"
-	AzureADConfigFieldAllowedPrincipalIDs = "allowedPrincipalIds"
-	AzureADConfigFieldAnnotations         = "annotations"
-	AzureADConfigFieldApplicationID       = "applicationId"
-	AzureADConfigFieldApplicationSecret   = "applicationSecret"
-	AzureADConfigFieldAuthEndpoint        = "authEndpoint"
-	AzureADConfigFieldCreated             = "created"
-	AzureADConfigFieldCreatorID           = "creatorId"
-	AzureADConfigFieldEnabled             = "enabled"
-	AzureADConfigFieldEndpoint            = "endpoint"
-	AzureADConfigFieldGraphEndpoint       = "graphEndpoint"
-	AzureADConfigFieldLabels              = "labels"
-	AzureADConfigFieldName                = "name"
-	AzureADConfigFieldOwnerReferences     = "ownerReferences"
-	AzureADConfigFieldRancherURL          = "rancherUrl"
-	AzureADConfigFieldRemoved             = "removed"
-	AzureADConfigFieldTenantID            = "tenantId"
-	AzureADConfigFieldTokenEndpoint       = "tokenEndpoint"
-	AzureADConfigFieldType                = "type"
-	AzureADConfigFieldUUID                = "uuid"
+	AzureADConfigType                        = "azureADConfig"
+	AzureADConfigFieldAccessMode             = "accessMode"
+	AzureADConfigFieldAllowedPrincipalIDs    = "allowedPrincipalIds"
+	AzureADConfigFieldAnnotations            = "annotations"
+	AzureADConfigFieldApplicationID          = "applicationId"
+	AzureADConfigFieldApplicationSecret      = "applicationSecret"
+	AzureADConfigFieldAuthEndpoint           = "authEndpoint"
+	AzureADConfigFieldCreated                = "created"
+	AzureADConfigFieldCreatorID              = "creatorId"
+	AzureADConfigFieldEnabled                = "enabled"
+	AzureADConfigFieldEndpoint               = "endpoint"
+	AzureADConfigFieldGraphEndpoint          = "graphEndpoint"
+	AzureADConfigFieldGroupMembershipsFilter = "groupMembershipsFilter"
+	AzureADConfigFieldLabels                 = "labels"
+	AzureADConfigFieldName                   = "name"
+	AzureADConfigFieldOwnerReferences        = "ownerReferences"
+	AzureADConfigFieldRancherURL             = "rancherUrl"
+	AzureADConfigFieldRemoved                = "removed"
+	AzureADConfigFieldTenantID               = "tenantId"
+	AzureADConfigFieldTokenEndpoint          = "tokenEndpoint"
+	AzureADConfigFieldType                   = "type"
+	AzureADConfigFieldUUID                   = "uuid"
 )
 
 type AzureADConfig struct {
-	AccessMode          string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
-	AllowedPrincipalIDs []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
-	Annotations         map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	ApplicationID       string            `json:"applicationId,omitempty" yaml:"applicationId,omitempty"`
-	ApplicationSecret   string            `json:"applicationSecret,omitempty" yaml:"applicationSecret,omitempty"`
-	AuthEndpoint        string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
-	Created             string            `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID           string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	Enabled             bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Endpoint            string            `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
-	GraphEndpoint       string            `json:"graphEndpoint,omitempty" yaml:"graphEndpoint,omitempty"`
-	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`
-	OwnerReferences     []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	RancherURL          string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
-	Removed             string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	TenantID            string            `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
-	TokenEndpoint       string            `json:"tokenEndpoint,omitempty" yaml:"tokenEndpoint,omitempty"`
-	Type                string            `json:"type,omitempty" yaml:"type,omitempty"`
-	UUID                string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	AccessMode             string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
+	AllowedPrincipalIDs    []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
+	Annotations            map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	ApplicationID          string            `json:"applicationId,omitempty" yaml:"applicationId,omitempty"`
+	ApplicationSecret      string            `json:"applicationSecret,omitempty" yaml:"applicationSecret,omitempty"`
+	AuthEndpoint           string            `json:"authEndpoint,omitempty" yaml:"authEndpoint,omitempty"`
+	Created                string            `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID              string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Enabled                bool              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Endpoint               string            `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	GraphEndpoint          string            `json:"graphEndpoint,omitempty" yaml:"graphEndpoint,omitempty"`
+	GroupMembershipsFilter string            `json:"groupMembershipsFilter,omitempty" yaml:"groupMembershipsFilter,omitempty"`
+	Labels                 map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name                   string            `json:"name,omitempty" yaml:"name,omitempty"`
+	OwnerReferences        []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	RancherURL             string            `json:"rancherUrl,omitempty" yaml:"rancherUrl,omitempty"`
+	Removed                string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	TenantID               string            `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
+	TokenEndpoint          string            `json:"tokenEndpoint,omitempty" yaml:"tokenEndpoint,omitempty"`
+	Type                   string            `json:"type,omitempty" yaml:"type,omitempty"`
+	UUID                   string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Users in AzureAD can be member of hundreds of groups. Prior to MS Graph migration (< v2.6.8), filtering a user's group memberships (i.e. memberOf) was not possible.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add an optional filter using [OData filter](https://learn.microsoft.com/en-us/graph/filter-query-parameter) on user's group memberships w/ global setting on auth provider.

Filter example:
`startswith(displayName,'x') or startswith(displayName,'y')`
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->