### PR TITLE
Add functions to find CAPI cluster from objects

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/common_test.go
+++ b/pkg/controllers/provisioningv2/rke2/common_test.go
@@ -1,0 +1,220 @@
+package rke2
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// Implements ClusterCache
+type test struct {
+	name        string
+	expected    *capi.Cluster
+	expectedErr error
+	obj         runtime.Object
+}
+
+func (t *test) Get(_, _ string) (*capi.Cluster, error) {
+	return t.expected, t.expectedErr
+}
+
+func (t *test) List(_ string, _ labels.Selector) ([]*capi.Cluster, error) {
+	panic("not implemented")
+}
+
+func (t *test) AddIndexer(_ string, _ capicontrollers.ClusterIndexer) {
+	panic("not implemented")
+}
+
+func (t *test) GetByIndex(_, _ string) ([]*capi.Cluster, error) {
+	panic("not implemented")
+}
+
+func TestFindCAPIClusterFromLabel(t *testing.T) {
+	tests := []test{
+		{
+			name:        "nil",
+			expected:    nil,
+			expectedErr: errNilObject,
+			obj:         nil,
+		},
+		{
+			name:        "missing label",
+			expected:    nil,
+			expectedErr: errors.New("cluster.x-k8s.io/cluster-name label not present on testObject: testNamespace/testName"),
+			obj: &capi.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testName",
+					Namespace: "testNamespace",
+					Labels:    map[string]string{},
+				},
+				TypeMeta: metav1.TypeMeta{Kind: "testObject"},
+			},
+		},
+		{
+			name:     "missing cluster",
+			expected: nil,
+			obj: &capi.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"cluster.x-k8s.io/cluster-name": "testCluster",
+					},
+				},
+			},
+		},
+		{
+			name:        "success",
+			expected:    &capi.Cluster{},
+			expectedErr: nil,
+			obj: &capi.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"cluster.x-k8s.io/cluster-name": "testCluster",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster, err := GetCAPIClusterFromLabel(tt.obj, &tt)
+			if err == nil {
+				assert.Nil(t, tt.expectedErr)
+			} else if tt.expectedErr != nil {
+				assert.Equal(t, tt.expectedErr.Error(), err.Error())
+			} else {
+				assert.Fail(t, "expected err to be nil, was actually %s", err)
+			}
+			assert.Equal(t, tt.expected, cluster)
+		})
+	}
+}
+
+func TestFindOwnerCAPICluster(t *testing.T) {
+	tests := []test{
+		{
+			name:        "nil",
+			expected:    nil,
+			expectedErr: errNilObject,
+			obj:         nil,
+		},
+		{
+			name:        "no owner",
+			expected:    nil,
+			expectedErr: errors.New("RKECluster testnamespace/testcluster does not have a controller owner reference"),
+			obj: &rkev1.RKECluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "RKECluster",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testcluster",
+					Namespace: "testnamespace",
+				},
+			},
+		},
+		{
+			name:        "no controller",
+			expected:    nil,
+			expectedErr: errors.New("RKECluster testnamespace/testcluster does not have a controller owner reference"),
+			obj: &rkev1.RKECluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "RKECluster",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testcluster",
+					Namespace: "testnamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "nil",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "owner wrong kind",
+			expected:    nil,
+			expectedErr: errors.New("RKECluster testnamespace/testcluster has wrong owner kind nil"),
+			obj: &rkev1.RKECluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "RKECluster",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testcluster",
+					Namespace: "testnamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "nil",
+							APIVersion: "cluster.x-k8s.io/v1beta1",
+							Controller: &[]bool{true}[0],
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "owner wrong api version",
+			expected:    nil,
+			expectedErr: errors.New("RKECluster testnamespace/testcluster has wrong owner api version nil"),
+			obj: &rkev1.RKECluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "RKECluster",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testcluster",
+					Namespace: "testnamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "Cluster",
+							APIVersion: "nil",
+							Controller: &[]bool{true}[0],
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "success",
+			expected:    nil,
+			expectedErr: nil,
+			obj: &rkev1.RKECluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "RKECluster",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testcluster",
+					Namespace: "testnamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "Cluster",
+							APIVersion: "cluster.x-k8s.io/v1beta1",
+							Controller: &[]bool{true}[0],
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster, err := GetOwnerCAPICluster(tt.obj, &tt)
+			if err == nil {
+				assert.Nil(t, tt.expectedErr)
+			} else if tt.expectedErr != nil {
+				assert.Equal(t, tt.expectedErr.Error(), err.Error())
+			} else {
+				assert.Fail(t, "expected err to be nil, was actually %s", err)
+			}
+			assert.Equal(t, tt.expected, cluster)
+		})
+	}
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Part of groundwork for #39139

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

We need a mechanism to get the owning CAPI cluster or machine objects in controllers to determine if reconcilation is paused.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add functions to get these objects.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

Added unit tests to ensure this works.