### PR TITLE
[2.7] SLE BCI update to 15.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ TARGETS := $(shell ls scripts)
 	@mv .dapper.tmp .dapper
 
 $(TARGETS): .dapper
-	@if [[ "$@" = "post-release-checks" ]] || [[ "$@" = "list-gomod-updates" ]] || [[ "$@" = "check-chart-kdm-source-values" ]]; then\
-		./.dapper -q --no-out $@;\
-	else\
-		./.dapper $@;\
+	@if [ "$@" = "post-release-checks" ] || [ "$@" = "list-gomod-updates" ] || [ "$@" = "check-chart-kdm-source-values" ]; then \
+		./.dapper -q --no-out $@; \
+	else \
+		./.dapper $@; \
 	fi
 
 .DEFAULT_GOAL := ci

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.3
+FROM registry.suse.com/bci/bci-base:15.4
 
 RUN zypper -n install --no-recommends git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim-small netcat-openbsd mkisofs && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.suse.com/bci/bci-base:15.3
 
-RUN zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim netcat-openbsd mkisofs && \
+RUN zypper -n install --no-recommends git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim-small netcat-openbsd mkisofs && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
     useradd rancher && \
     mkdir -p /var/lib/rancher /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -2,7 +2,7 @@ ARG RANCHER_TAG=dev
 ARG RANCHER_REPO=rancher
 FROM ${RANCHER_REPO}/rancher:${RANCHER_TAG} as rancher
 
-FROM registry.suse.com/bci/bci-base:15.3
+FROM registry.suse.com/bci/bci-base:15.4
 ARG ARCH=amd64
 
 ENV KUBECTL_VERSION v1.23.6


### PR DESCRIPTION

## Problem

Rancher and Rancher Agent is currently based on SLE BCI 15 SP3, which goes out of general support on 2022-12-31. 

## Solution

For about half a year there is already SLE BCI 15 SP4 available, so switch to that. 

Also small optimisation on size by using vim-small only instead of full vim in the image.

