### PR TITLE
[2.6] Add kubernetes version upgrade validation tests

### DIFF
--- a/tests/framework/clients/rancher/v1/client.go
+++ b/tests/framework/clients/rancher/v1/client.go
@@ -82,7 +82,7 @@ func NewClient(opts *clientbase.ClientOpts) (*Client, error) {
 // SteveType is a function that sets the resource type for the SteveClient
 // e.g. accessing the Steve namespace resource
 //
-//	 nameSpaceClient := client.V1.SteveType("namespace")
+//	nameSpaceClient := client.V1.SteveType("namespace")
 func (c *Client) SteveType(steveType string) *SteveClient {
 	return &SteveClient{
 		apiClient: c,
@@ -219,11 +219,11 @@ func (c *SteveClient) Delete(container *SteveAPIObject) error {
 // SteveAPIObject to its native kubernetes type
 // e.g. converting a SteveAPIObject spec to a NamespaceSpec
 //
-//	 namespaceSpec := &coreV1.NamespaceSpec{}
-//   spec, err := namespaces.ConvertSpecOrStatusType(createdNamespace.Spec, namespaceSpec)
-//   require.NoError(p.T(), err)
+//	namespaceSpec := &coreV1.NamespaceSpec{}
+//	err := namespaces.ConvertToK8sType(createdNamespace.Spec, namespaceSpec)
+//	require.NoError(p.T(), err)
 //
-//   spec.(*coreV1.NamespaceSpec).Finalizers
+//	namespaceSpec.Finalizers
 func ConvertToK8sType(steveResp any, kubernetesObject any) error {
 	jsonbody, err := json.Marshal(steveResp)
 	if err != nil {

--- a/tests/framework/extensions/clusters/bundledclusters/bundledclusters.go
+++ b/tests/framework/extensions/clusters/bundledclusters/bundledclusters.go
@@ -1,0 +1,45 @@
+package bundledclusters
+
+import (
+	"fmt"
+
+	v3 "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+)
+
+// BundledCluster is a struct that can contain different cluster version types and the meta of the cluster:
+//   - Meta is a ClusterMeta value of cluster's meta.
+//   - V1 is a v1 type cluster value of the cluster.
+//   - V3 is a v3 type cluster value of the cluster.
+type BundledCluster struct {
+	Meta *clusters.ClusterMeta
+	V1   *v1.SteveAPIObject
+	V3   *v3.Cluster
+}
+
+// NewWithClusterMeta is a constructor to initialize a BundledCluster.
+// It returns cluster meta struct and error if any.
+// Cluster v1 and v3 versions can't store value at the same time.
+func NewWithClusterMeta(cmeta *clusters.ClusterMeta) (cluster *BundledCluster, err error) {
+	cluster = new(BundledCluster)
+
+	clusterMeta := *cmeta
+
+	isClusterImported := cmeta.IsImported
+	isClusterRKE2 := cmeta.Provider == clusters.KubernetesProviderRKE2
+	isClusterK3S := cmeta.Provider == clusters.KubernetesProviderK3S
+
+	isClusterV1 := (isClusterK3S || isClusterRKE2) && isClusterImported
+
+	if isClusterV1 {
+		cluster.V1 = new(v1.SteveAPIObject)
+		clusterMeta.ID = fmt.Sprintf("fleet-default/%v", clusterMeta.Name)
+	} else if !isClusterV1 {
+		cluster.V3 = new(v3.Cluster)
+	}
+
+	cluster.Meta = &clusterMeta
+
+	return
+}

--- a/tests/framework/extensions/clusters/bundledclusters/get.go
+++ b/tests/framework/extensions/clusters/bundledclusters/get.go
@@ -1,0 +1,32 @@
+package bundledclusters
+
+import (
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+)
+
+// Get is a method of BundledCluster that uses provisioning and management clients
+// to get related cluster data depending on cluster version.
+func (bc *BundledCluster) Get(client *rancher.Client) (cluster *BundledCluster, err error) {
+	cluster = new(BundledCluster)
+	cluster.Meta = bc.Meta
+
+	steveclient := client.Steve.SteveType(clusters.ProvisioningSteveResouceType)
+	if err != nil {
+		return
+	}
+
+	if bc.V1 != nil {
+		cluster.V1, err = steveclient.ByID(cluster.Meta.ID)
+		if err != nil {
+			return cluster, err
+		}
+	} else if bc.V3 != nil {
+		cluster.V3, err = client.Management.Cluster.ByID(cluster.Meta.ID)
+		if err != nil {
+			return cluster, err
+		}
+	}
+
+	return
+}

--- a/tests/framework/extensions/clusters/bundledclusters/list.go
+++ b/tests/framework/extensions/clusters/bundledclusters/list.go
@@ -1,0 +1,65 @@
+package bundledclusters
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	available "github.com/rancher/rancher/tests/framework/extensions/clusters/versions"
+)
+
+// ListAvailable is a method of BundledCluster that uses list available functions
+// depending on cluster's provider information. Returns versions as slice of strings
+// and error if any.
+func (bc *BundledCluster) ListAvailableVersions(client *rancher.Client) (versions []string, err error) {
+	switch bc.Meta.Provider {
+	case clusters.KubernetesProviderRKE:
+		versions, err = available.ListRKE1AvailableVersions(client, bc.V3)
+		if err != nil {
+			return
+		}
+	case clusters.KubernetesProviderRKE2:
+		if bc.Meta.IsImported {
+			versions, err = available.ListRKE2AvailableVersions(client, bc.V1)
+			if err != nil {
+				return
+			}
+		} else if !bc.Meta.IsImported {
+			versions, err = available.ListNormanRKE2AvailableVersions(client, bc.V3)
+			if err != nil {
+				return
+			}
+		}
+	case clusters.KubernetesProviderK3S:
+		if bc.Meta.IsImported {
+			versions, err = available.ListK3SAvailableVersions(client, bc.V1)
+			if err != nil {
+				return
+			}
+		} else if !bc.Meta.IsImported {
+			versions, err = available.ListNormanK3SAvailableVersions(client, bc.V3)
+			if err != nil {
+				return
+			}
+		}
+	case clusters.KubernetesProviderGKE:
+		versions, err = available.ListGKEAvailableVersions(client, bc.V3)
+		if err != nil {
+			return
+		}
+	case clusters.KubernetesProviderAKS:
+		versions, err = available.ListAKSAvailableVersions(client, bc.V3)
+		if err != nil {
+			return
+		}
+	case clusters.KubernetesProviderEKS:
+		versions, err = available.ListEKSAvailableVersions(client, bc.V3)
+		if err != nil {
+			return
+		}
+	default:
+		return nil, errors.Wrap(err, "list available versions failed")
+	}
+
+	return
+}

--- a/tests/framework/extensions/clusters/bundledclusters/update.go
+++ b/tests/framework/extensions/clusters/bundledclusters/update.go
@@ -1,0 +1,187 @@
+package bundledclusters
+
+import (
+	"github.com/pkg/errors"
+
+	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v3 "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+)
+
+// Update is a method of BundledCluster that uses provisioning and management clients
+// to update related cluster data depending on cluster version.
+func (bc *BundledCluster) Update(client *rancher.Client, cUpdates *BundledCluster) (updatedCluster *BundledCluster, err error) {
+	updatedCluster = new(BundledCluster)
+	updatedCluster.Meta = bc.Meta
+
+	steveclient := client.Steve.SteveType(clusters.ProvisioningSteveResouceType)
+	if err != nil {
+		return
+	}
+
+	if bc.V1 != nil {
+		updatedCluster.V1, err = steveclient.Update(bc.V1, cUpdates.V1)
+		if err != nil {
+			return
+		}
+	} else if bc.V3 != nil {
+		updatedCluster.V3, err = client.Management.Cluster.Update(bc.V3, cUpdates.V3)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// UpdateKubernetesVersion is a method of BundledCluster that uses update method of BundledCluster
+// depending on cluster's provider information. Returns updated BundledCluster and error if any.
+func (bc *BundledCluster) UpdateKubernetesVersion(client *rancher.Client, versionToUpgrade *string) (updatedCluster *BundledCluster, err error) {
+	if bc.V1 == nil && bc.V3 == nil {
+		return nil, errors.Wrapf(err, "cluster %v doesn't contain related data: v1: {%v}, v3: {%v}", bc.Meta.Name, bc.V1, bc.V3)
+	}
+
+	bundledv3 := BundledCluster{V3: new(v3.Cluster)}
+	bundledv1 := BundledCluster{V1: new(v1.SteveAPIObject)}
+
+	switch bc.Meta.Provider {
+	case clusters.KubernetesProviderRKE:
+		bundledv3.V3.Name = bc.Meta.Name
+		bundledv3.V3.RancherKubernetesEngineConfig = bc.V3.RancherKubernetesEngineConfig
+		bundledv3.V3.RancherKubernetesEngineConfig.Version = *versionToUpgrade
+
+		updatedCluster, err = bc.Update(client, &bundledv3)
+		if err != nil {
+			return updatedCluster, err
+		}
+	case clusters.KubernetesProviderRKE2:
+		if !bc.Meta.IsImported {
+			bundledv3.V3.Name = bc.Meta.Name
+			bundledv3.V3.Rke2Config = bc.V3.Rke2Config
+			bundledv3.V3.Rke2Config.Version = *versionToUpgrade
+
+			updatedCluster, err = bc.Update(client, &bundledv3)
+			if err != nil {
+				return updatedCluster, err
+			}
+		} else if bc.Meta.IsImported {
+			bundledv1.V1 = bc.V1
+			clusterSpec := &apiv1.ClusterSpec{}
+			err = v1.ConvertToK8sType(bundledv1.V1.Spec, clusterSpec)
+			if err != nil {
+				return updatedCluster, err
+			}
+
+			clusterSpec.KubernetesVersion = *versionToUpgrade
+			bundledv1.V1.Spec = clusterSpec
+
+			updatedCluster, err = bc.Update(client, &bundledv1)
+			if err != nil {
+				return updatedCluster, err
+			}
+		}
+	case clusters.KubernetesProviderK3S:
+		if !bc.Meta.IsImported {
+			bundledv3.V3.Name = bc.Meta.Name
+			bundledv3.V3.K3sConfig = bc.V3.K3sConfig
+			bundledv3.V3.K3sConfig.Version = *versionToUpgrade
+
+			updatedCluster, err = bc.Update(client, &bundledv3)
+			if err != nil {
+				return updatedCluster, err
+			}
+		} else if bc.Meta.IsImported {
+			bundledv1.V1 = bc.V1
+			clusterSpec := &apiv1.ClusterSpec{}
+			err = v1.ConvertToK8sType(bundledv1.V1.Spec, clusterSpec)
+			if err != nil {
+				return updatedCluster, err
+			}
+
+			clusterSpec.KubernetesVersion = *versionToUpgrade
+			bundledv1.V1.Spec = clusterSpec
+
+			updatedCluster, err = bc.Update(client, &bundledv1)
+			if err != nil {
+				return updatedCluster, err
+			}
+		}
+	case clusters.KubernetesProviderGKE:
+		bundledv3.V3.Name = bc.Meta.Name
+		bundledv3.V3.GKEConfig = bc.V3.GKEConfig
+		bundledv3.V3.GKEConfig.KubernetesVersion = versionToUpgrade
+
+		updatedCluster, err = bc.Update(client, &bundledv3)
+		if err != nil {
+			return updatedCluster, err
+		}
+	case clusters.KubernetesProviderAKS:
+		bundledv3.V3.Name = bc.Meta.Name
+		bundledv3.V3.AKSConfig = bc.V3.AKSConfig
+		bundledv3.V3.AKSConfig.KubernetesVersion = versionToUpgrade
+
+		updatedCluster, err = bc.Update(client, &bundledv3)
+		if err != nil {
+			return updatedCluster, err
+		}
+	case clusters.KubernetesProviderEKS:
+		bundledv3.V3.Name = bc.Meta.Name
+		bundledv3.V3.EKSConfig = bc.V3.EKSConfig
+		bundledv3.V3.EKSConfig.KubernetesVersion = versionToUpgrade
+
+		updatedCluster, err = bc.Update(client, &bundledv3)
+		if err != nil {
+			return updatedCluster, err
+		}
+	default:
+		return nil, errors.Wrap(err, "kubernetes version upgrade failed")
+	}
+
+	return
+}
+
+// UpdateNodePoolKubernetesVersions is a method of BundledCluster that uses update method of BundledCluster
+// depending on cluster's provider information. Returns updated BundledCluster and error if any.
+func (bc *BundledCluster) UpdateNodepoolKubernetesVersions(client *rancher.Client, versionToUpgrade *string) (updatedCluster *BundledCluster, err error) {
+	if bc.V3 == nil {
+		return nil, errors.Wrapf(err, "cluster %v doesn't contain related data", bc.V3)
+	}
+
+	cluster := bc
+
+	switch bc.Meta.Provider {
+	case clusters.KubernetesProviderGKE:
+		for i := range cluster.V3.GKEConfig.NodePools {
+			cluster.V3.GKEConfig.NodePools[i].Version = versionToUpgrade
+		}
+
+		updatedCluster, err = bc.Update(client, cluster)
+		if err != nil {
+			return
+		}
+	case clusters.KubernetesProviderAKS:
+		for i := range cluster.V3.AKSConfig.NodePools {
+			cluster.V3.AKSConfig.NodePools[i].OrchestratorVersion = versionToUpgrade
+		}
+
+		updatedCluster, err = bc.Update(client, cluster)
+		if err != nil {
+			return
+		}
+	case clusters.KubernetesProviderEKS:
+		for i := range cluster.V3.EKSConfig.NodeGroups {
+			cluster.V3.EKSConfig.NodeGroups[i].Version = versionToUpgrade
+		}
+
+		updatedCluster, err = bc.Update(client, cluster)
+		if err != nil {
+			return
+		}
+	default:
+		return nil, errors.Wrap(err, "node pool kubernetes version upgrade failed")
+	}
+
+	return
+}

--- a/tests/framework/extensions/clusters/clustermeta.go
+++ b/tests/framework/extensions/clusters/clustermeta.go
@@ -1,0 +1,102 @@
+package clusters
+
+import (
+	"github.com/pkg/errors"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+)
+
+// KubernetesProvider is a string type to determine cluster's provider.
+type KubernetesProvider string
+
+const (
+	rke  = "rke"
+	k3s  = "k3s"
+	rke2 = "rke2"
+	aks  = "aks"
+	eks  = "eks"
+	gke  = "gke"
+
+	// KubernetesProvider string enums are to determine cluster's provider.
+	KubernetesProviderRKE  KubernetesProvider = rke
+	KubernetesProviderRKE2 KubernetesProvider = rke2
+	KubernetesProviderK3S  KubernetesProvider = k3s
+	KubernetesProviderAKS  KubernetesProvider = aks
+	KubernetesProviderEKS  KubernetesProvider = eks
+	KubernetesProviderGKE  KubernetesProvider = gke
+)
+
+// ClusterMeta is a struct that contains a cluster's meta:
+//  - ID is used for value of cluster's ID.
+//  - Name is a used for cluster's name.
+//  - Provider is used for cluster's provider.
+//  - IsHosted is used for cluster's hosted information.
+//  - IsImported is used for cluster's imported information.
+type ClusterMeta struct {
+	ID       string
+	Name     string
+	Provider KubernetesProvider
+
+	IsHosted   bool
+	IsImported bool
+}
+
+// NewClusterMeta is a function to initialize new ClusterMeta for a specific cluster.
+func NewClusterMeta(client *rancher.Client, clusterName string) (clusterMeta *ClusterMeta, err error) {
+	clusterMeta = new(ClusterMeta)
+	clusterMeta.Name = clusterName
+
+	clusterMeta.ID, err = GetClusterIDByName(client, clusterName)
+	if err != nil {
+		return
+	}
+
+	clusterMeta.Provider, err = GetClusterProvider(client, clusterMeta.ID)
+	if err != nil {
+		return
+	}
+
+	clusterMeta.IsImported, err = IsClusterImported(client, clusterMeta.ID)
+	if err != nil {
+		return
+	}
+
+	clusterMeta.IsHosted = IsHostedProvider(clusterMeta.Provider)
+
+	return
+}
+
+// GetClusterProvider is a function to get cluster's KubernetesProvider.
+func GetClusterProvider(client *rancher.Client, clusterID string) (provider KubernetesProvider, err error) {
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	if err != nil {
+		return
+	}
+
+	switch cluster.Provider {
+	case rke:
+		provider = KubernetesProviderRKE
+	case k3s:
+		provider = KubernetesProviderK3S
+	case rke2:
+		provider = KubernetesProviderRKE2
+	case aks:
+		provider = KubernetesProviderAKS
+	case eks:
+		provider = KubernetesProviderEKS
+	case gke:
+		provider = KubernetesProviderGKE
+	default:
+		return "", errors.Wrap(err, "invalid cluster provider")
+	}
+
+	return
+}
+
+// IsHostedProvider is a function to get a boolean value about if the cluster is hosted or not.
+func IsHostedProvider(provider KubernetesProvider) (isHosted bool) {
+	if provider == KubernetesProviderAKS || provider == KubernetesProviderGKE || provider == KubernetesProviderEKS {
+		return true
+	}
+
+	return
+}

--- a/tests/framework/extensions/clusters/import.go
+++ b/tests/framework/extensions/clusters/import.go
@@ -15,6 +15,8 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 
+	apisV3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -187,4 +189,17 @@ func ImportCluster(client *rancher.Client, cluster *apisV1.Cluster, rest *rest.C
 	}
 
 	return nil
+}
+
+// IsClusterImported is a function to get a boolean value about if the cluster is imported or not.
+// For custom and imported clusters the node driver value is different than "imported".
+func IsClusterImported(client *rancher.Client, clusterID string) (isImported bool, err error) {
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	if err != nil {
+		return
+	}
+
+	isImported = cluster.Driver == apisV3.ClusterDriverImported // For imported K3s and RKE2, driver != "imported", for custom and provisioning drive ones = "imported"
+
+	return
 }

--- a/tests/framework/extensions/clusters/versions/all.go
+++ b/tests/framework/extensions/clusters/versions/all.go
@@ -1,0 +1,293 @@
+package versions
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/pkg/errors"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v3 "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+)
+
+const (
+	rancherVersionSetting = "server-version"
+
+	rke1VersionsSetting = "k8s-versions-current"
+	rke2ReleasePath     = "v1-rke2-release/releases"
+	k3sReleasePath      = "v1-k3s-release/releases"
+	gkeVersionPath      = "meta/gkeVersions"
+	aksVersionPath      = "meta/aksVersions"
+	eksVersionsFileURL  = "raw.githubusercontent.com/rancher/ui/master/lib/shared/addon/utils/amazon.js"
+
+	eksVersionsSliceRegex      = `EKS_VERSIONS = \[\s*(.*?)\s*\]\;`
+	eksVersionsSliceItemsRegex = `(?s)'(.*?)'`
+)
+
+// ListRKE1AllVersions is a function that uses the management client to list and return all RKE1 versions.
+func ListRKE1AllVersions(client *rancher.Client) (allAvailableVersions []string, err error) {
+	setting, err := client.Management.Setting.ByID(rke1VersionsSetting)
+	if err != nil {
+		return
+	}
+	allAvailableVersions = strings.Split(setting.Value, ",")
+
+	return
+}
+
+// ListRKE2AllVersions is a function that uses the management client and releases endpoint to list and return all RKE2 versions.
+func ListRKE2AllVersions(client *rancher.Client) (allAvailableVersions []string, err error) {
+	setting, err := client.Management.Setting.ByID(rancherVersionSetting)
+	if err != nil {
+		return
+	}
+	rancherVersion, err := semver.NewVersion(setting.Value)
+	if err != nil {
+		return
+	}
+
+	url := fmt.Sprintf("%s://%s/%s", "http", client.RancherConfig.Host, rke2ReleasePath)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+	bearerToken := fmt.Sprintf("Bearer %s", client.RancherConfig.AdminToken)
+	req.Header.Add("Authorization", bearerToken)
+
+	bodyBytes, err := getRequest(req, client)
+	if err != nil {
+		return
+	}
+
+	var mapResponse map[string]interface{}
+	if err = json.Unmarshal([]byte(bodyBytes), &mapResponse); err != nil {
+		return
+	}
+
+	releases := mapResponse["data"].([]interface{})
+
+	allAvailableVersions = sortReleases(rancherVersion, releases)
+
+	sort.Strings(allAvailableVersions)
+
+	return
+}
+
+// ListK3SAllVersions is a function that uses the management client and releases endpoint to list and return all K3s versions.
+func ListK3SAllVersions(client *rancher.Client) (allAvailableVersions []string, err error) {
+	setting, err := client.Management.Setting.ByID(rancherVersionSetting)
+	if err != nil {
+		return
+	}
+	rancherVersion, err := semver.NewVersion(setting.Value)
+	if err != nil {
+		return
+	}
+
+	url := fmt.Sprintf("%s://%s/%s", "http", client.RancherConfig.Host, k3sReleasePath)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+	bearerToken := fmt.Sprintf("Bearer %s", client.RancherConfig.AdminToken)
+	req.Header.Add("Authorization", bearerToken)
+
+	bodyBytes, err := getRequest(req, client)
+	if err != nil {
+		return
+	}
+
+	var mapResponse map[string]interface{}
+	if err = json.Unmarshal([]byte(bodyBytes), &mapResponse); err != nil {
+		return
+	}
+
+	releases := mapResponse["data"].([]interface{})
+
+	allAvailableVersions = sortReleases(rancherVersion, releases)
+
+	sort.Strings(allAvailableVersions)
+
+	return
+}
+
+// ListGKEAllVersions is a function that uses the management client base and gke meta endpoint to list and return all GKE versions.
+func ListGKEAllVersions(client *rancher.Client, projectID, cloudCredentialID, zone, region string) (availableVersions []string, err error) {
+	url := fmt.Sprintf("%s://%s/%s", "https", client.RancherConfig.Host, gkeVersionPath)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+	req.Header.Add("Authorization", "Bearer "+client.RancherConfig.AdminToken)
+
+	q := req.URL.Query()
+	q.Add("cloudCredentialId", cloudCredentialID)
+
+	if zone != "" {
+		q.Add("zone", zone)
+	} else if region != "" {
+		q.Add("region", region)
+	}
+
+	q.Add("projectId", projectID)
+	req.URL.RawQuery = q.Encode()
+
+	bodyBytes, err := getRequest(req, client)
+	if err != nil {
+		return
+	}
+
+	var mapResponse map[string]interface{}
+	if err = json.Unmarshal([]byte(bodyBytes), &mapResponse); err != nil {
+		return
+	}
+
+	validMasterVersionsResponse := mapResponse["validMasterVersions"].([]interface{})
+
+	for _, version := range validMasterVersionsResponse {
+		availableVersions = append(availableVersions, version.(string))
+	}
+
+	return
+}
+
+// ListAKSAllVersions is a function that uses the management client base and aks meta endpoint to list and return all AKS versions.
+func ListAKSAllVersions(client *rancher.Client, cluster *v3.Cluster) (allAvailableVersions []string, err error) {
+	url := fmt.Sprintf("%s://%s/%s", "https", client.RancherConfig.Host, "meta/aksVersions")
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+	req.Header.Add("Authorization", "Bearer "+client.RancherConfig.AdminToken)
+
+	if cluster.AKSConfig == nil {
+		return nil, errors.Wrapf(err, "cluster %s has no gke config", cluster.Name)
+	}
+
+	q := req.URL.Query()
+	q.Add("cloudCredentialId", cluster.AKSConfig.AzureCredentialSecret)
+	q.Add("region", cluster.AKSConfig.ResourceLocation)
+	req.URL.RawQuery = q.Encode()
+
+	bodyBytes, err := getRequest(req, client)
+	if err != nil {
+		return
+	}
+
+	var versionsSlice []interface{}
+	if err = json.Unmarshal([]byte(bodyBytes), &versionsSlice); err != nil {
+		return
+	}
+
+	for _, version := range versionsSlice {
+		allAvailableVersions = append(allAvailableVersions, version.(string))
+	}
+
+	return
+}
+
+// ListEKSAllVersions is a function that uses the management client base and rancher/UI repository to list and return all AKS versions.
+func ListEKSAllVersions(client *rancher.Client) (allAvailableVersions []string, err error) {
+	url := fmt.Sprintf("%s://%s", "https", eksVersionsFileURL)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+
+	bodyBytes, err := getRequest(req, client)
+	if err != nil {
+		return
+	}
+
+	r := regexp.MustCompile(eksVersionsSliceRegex)
+	match := r.FindStringSubmatch(string(bodyBytes))
+	if len(match) == 0 {
+		return
+	}
+	versions := match[1]
+	rx := regexp.MustCompile(eksVersionsSliceItemsRegex)
+	out := rx.FindAllStringSubmatch(versions, -1)
+
+	for _, version := range out {
+		if len(version) < 1 {
+			continue
+		}
+
+		allAvailableVersions = append(allAvailableVersions, version[1])
+	}
+
+	return
+}
+
+// sortReleases is a private function that sorts release structs that are used for K3S and RKE2.
+// Sorted versions determined by these conditions:
+//    1. Current rancher version is between min and max channel versions
+//    2. Release struct has serverArgs and agentArgs not empty fields
+//    3. Possible newest version of the minimum channel version
+func sortReleases(rancherVersion *semver.Version, releases []interface{}) (allAvailableVersions []string) {
+	availableVersionsMap := map[string]semver.Version{}
+
+	for _, release := range releases {
+		_, serverArgsOk := release.(map[string]interface{})["serverArgs"].(map[string]interface{})
+		_, agentArgsOk := release.(map[string]interface{})["agentArgs"].(map[string]interface{})
+
+		if !serverArgsOk || !agentArgsOk {
+			continue
+		}
+
+		maxVersion := release.(map[string]interface{})["maxChannelServerVersion"].(string)
+		minVersion := release.(map[string]interface{})["minChannelServerVersion"].(string)
+		kubernetesVersion := release.(map[string]interface{})["version"].(string)
+
+		maxRancherVersion, err := semver.NewVersion(strings.TrimPrefix(maxVersion, "v"))
+		if err != nil {
+			continue
+		}
+		minRancherVersion, err := semver.NewVersion(strings.TrimPrefix(minVersion, "v"))
+		if err != nil {
+			continue
+		}
+
+		releaseKubernetesVersion, err := semver.NewVersion(strings.TrimPrefix(kubernetesVersion, "v"))
+		if err != nil {
+			continue
+		}
+
+		if !rancherVersion.GreaterThan(minRancherVersion) && !rancherVersion.LessThan(maxRancherVersion) {
+			continue
+		}
+
+		value, ok := availableVersionsMap[minRancherVersion.String()]
+
+		if !ok || value.LessThan(releaseKubernetesVersion) {
+			availableVersionsMap[minRancherVersion.String()] = *releaseKubernetesVersion
+		}
+	}
+
+	for _, v := range availableVersionsMap {
+		allAvailableVersions = append(allAvailableVersions, fmt.Sprintf("v"+v.String()))
+	}
+
+	return
+}
+
+// getRequest is a private function that used to reach external endpoints when the clients aren't usable.
+func getRequest(request *http.Request, client *rancher.Client) (bodyBytes []byte, err error) {
+	resp, err := client.Management.APIBaseClient.Ops.Client.Do(request)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/tests/framework/extensions/clusters/versions/available.go
+++ b/tests/framework/extensions/clusters/versions/available.go
@@ -1,0 +1,224 @@
+package versions
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/pkg/errors"
+	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v3 "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+)
+
+// ListRKE1AvailableVersions is a function to list and return only available RKE1 versions for a specific cluster.
+func ListRKE1AvailableVersions(client *rancher.Client, cluster *v3.Cluster) (availableVersions []string, err error) {
+	allAvailableVersions, err := ListRKE1AllVersions(client)
+	if err != nil {
+		return
+	}
+
+	for i, version := range allAvailableVersions {
+		if strings.Contains(version, cluster.RancherKubernetesEngineConfig.Version) {
+			availableVersions = allAvailableVersions[i+1:]
+			break
+		}
+	}
+
+	return
+}
+
+// ListRKE2AvailableVersions is a function to list and return only available RKE2 versions for a specific cluster.
+func ListRKE2AvailableVersions(client *rancher.Client, cluster *v1.SteveAPIObject) (availableVersion []string, err error) {
+	allAvailableVersions, err := ListRKE2AllVersions(client)
+	if err != nil {
+		return
+	}
+
+	clusterSpec := &apiv1.ClusterSpec{}
+	err = v1.ConvertToK8sType(cluster.Spec, clusterSpec)
+	if err != nil {
+		return
+	}
+
+	availableVersion = allAvailableVersions
+
+	for i, version := range allAvailableVersions {
+		if strings.Contains(version, clusterSpec.KubernetesVersion) {
+			availableVersion = allAvailableVersions[i+1:]
+			break
+		}
+	}
+
+	return
+}
+
+// ListNormanRKE2AvailableVersions is a function to list and return only available RKE2 versions for an imported specific cluster.
+func ListNormanRKE2AvailableVersions(client *rancher.Client, cluster *v3.Cluster) (availableVersion []string, err error) {
+	allAvailableVersions, err := ListRKE2AllVersions(client)
+	if err != nil {
+		return
+	}
+
+	availableVersion = allAvailableVersions
+
+	for i, version := range allAvailableVersions {
+		if strings.Contains(version, cluster.Rke2Config.Version) {
+			availableVersion = allAvailableVersions[i+1:]
+			break
+		}
+	}
+
+	return
+}
+
+// ListK3SAvailableVersions is a function to list and return only available K3S versions for a specific cluster.
+func ListK3SAvailableVersions(client *rancher.Client, cluster *v1.SteveAPIObject) (availableVersion []string, err error) {
+	allAvailableVersions, err := ListK3SAllVersions(client)
+	if err != nil {
+		return
+	}
+
+	availableVersion = allAvailableVersions
+
+	clusterSpec := &apiv1.ClusterSpec{}
+	err = v1.ConvertToK8sType(cluster.Spec, clusterSpec)
+	if err != nil {
+		return
+	}
+
+	for i, version := range allAvailableVersions {
+		if strings.Contains(version, clusterSpec.KubernetesVersion) {
+			availableVersion = allAvailableVersions[i+1:]
+			break
+		}
+	}
+
+	return
+}
+
+// ListNormanK3SAvailableVersions is a function to list and return only available K3S versions for an imported specific cluster.
+func ListNormanK3SAvailableVersions(client *rancher.Client, cluster *v3.Cluster) (availableVersion []string, err error) {
+	allAvailableVersions, err := ListK3SAllVersions(client)
+	if err != nil {
+		return
+	}
+
+	availableVersion = allAvailableVersions
+
+	for i, version := range allAvailableVersions {
+		if strings.Contains(version, cluster.K3sConfig.Version) {
+			availableVersion = allAvailableVersions[i+1:]
+			break
+		}
+	}
+
+	return
+}
+
+// ListGKEAvailableVersions is a function to list and return only available GKE versions for a specific cluster.
+func ListGKEAvailableVersions(client *rancher.Client, cluster *v3.Cluster) (availableVersions []string, err error) {
+	currentVersion, err := semver.NewVersion(cluster.Version.GitVersion)
+	if err != nil {
+		return
+	}
+
+	if cluster.GKEConfig == nil {
+		return nil, errors.Wrapf(err, "cluster %s has no gke config", cluster.Name)
+	}
+
+	var validMasterVersions []*semver.Version
+	allAvailableVersions, err := ListGKEAllVersions(client, cluster.GKEConfig.ProjectID, cluster.GKEConfig.GoogleCredentialSecret, cluster.GKEConfig.Zone, cluster.GKEConfig.Region)
+
+	for _, version := range allAvailableVersions {
+		v, err := semver.NewVersion(version)
+		if err != nil {
+			continue
+		}
+		validMasterVersions = append(validMasterVersions, v)
+	}
+
+	for _, v := range validMasterVersions {
+		if v.Minor()-1 > currentVersion.Minor() || v.Compare(currentVersion) == 0 || v.Compare(currentVersion) == -1 {
+			continue
+		}
+		availableVersions = append(availableVersions, v.String())
+	}
+
+	reverseSlice(availableVersions)
+
+	return
+}
+
+// ListAKSAvailableVersions is a function to list and return only available AKS versions for a specific cluster.
+func ListAKSAvailableVersions(client *rancher.Client, cluster *v3.Cluster) (availableVersions []string, err error) {
+	currentVersion, err := semver.NewVersion(cluster.Version.GitVersion)
+	if err != nil {
+		return
+	}
+
+	var validMasterVersions []*semver.Version
+	allAvailableVersions, err := ListAKSAllVersions(client, cluster)
+
+	for _, version := range allAvailableVersions {
+		v, err := semver.NewVersion(version)
+		if err != nil {
+			continue
+		}
+		validMasterVersions = append(validMasterVersions, v)
+	}
+
+	for _, v := range validMasterVersions {
+		if v.Minor()-1 > currentVersion.Minor() || v.Compare(currentVersion) == 0 || v.Compare(currentVersion) == -1 {
+			continue
+		}
+		availableVersions = append(availableVersions, v.String())
+	}
+
+	return
+}
+
+// ListEKSAvailableVersions is a function to list and return only available EKS versions for a specific cluster.
+func ListEKSAvailableVersions(client *rancher.Client, cluster *v3.Cluster) (availableVersions []string, err error) {
+	currentVersion, err := semver.NewVersion(cluster.Version.GitVersion)
+	if err != nil {
+		return
+	}
+
+	var validMasterVersions []*semver.Version
+
+	allAvailableVersions, err := ListEKSAllVersions(client)
+	if err != nil {
+		return
+	}
+
+	for _, version := range allAvailableVersions {
+		v, err := semver.NewVersion(version)
+		if err != nil {
+			continue
+		}
+
+		validMasterVersions = append(validMasterVersions, v)
+	}
+
+	for _, v := range validMasterVersions {
+		if v.Minor()-1 > currentVersion.Minor() || v.Compare(currentVersion) == 0 || v.Compare(currentVersion) == -1 {
+			continue
+		}
+		version := fmt.Sprintf("%v.%v", v.Major(), v.Minor())
+		availableVersions = append(availableVersions, version)
+	}
+
+	reverseSlice(availableVersions)
+
+	return
+}
+
+// reverseSlice is a private function that used to rever slice of strings.
+func reverseSlice(stringSlice []string) []string {
+	sort.SliceStable(stringSlice, func(i, j int) bool { return i > j })
+
+	return stringSlice
+}

--- a/tests/framework/pkg/environmentflag/environmentflag.go
+++ b/tests/framework/pkg/environmentflag/environmentflag.go
@@ -15,7 +15,7 @@ const (
 type EnvironmentFlags map[EnvironmentFlag]bool
 
 type Config struct {
-	DesiredFlags string `json:"use" yaml:"use" default:""`
+	DesiredFlags string `json:"desiredflags" yaml:"desiredflags" default:""`
 }
 
 // NewEnvironmentFlags creates a new EnvironmentFlags.

--- a/tests/framework/pkg/environmentflag/environmentflags.go
+++ b/tests/framework/pkg/environmentflag/environmentflags.go
@@ -10,5 +10,6 @@ type EnvironmentFlag int
 const (
 	Ingress EnvironmentFlag = iota
 	Chart
+	UpgradeAllClusters
 	environmentFlagLastItem // This is used to determine the number of items in the enum
 )

--- a/tests/framework/pkg/environmentflag/zz_environmentflags.go
+++ b/tests/framework/pkg/environmentflag/zz_environmentflags.go
@@ -10,12 +10,13 @@ func _() {
 	var x [1]struct{}
 	_ = x[Ingress-0]
 	_ = x[Chart-1]
-	_ = x[environmentFlagLastItem-2]
+	_ = x[UpgradeAllClusters-2]
+	_ = x[environmentFlagLastItem-3]
 }
 
-const _EnvironmentFlag_name = "IngressChartThis is used to determine the number of items in the enum"
+const _EnvironmentFlag_name = "IngressChartUpgradeAllClustersThis is used to determine the number of items in the enum"
 
-var _EnvironmentFlag_index = [...]uint8{0, 7, 12, 69}
+var _EnvironmentFlag_index = [...]uint8{0, 7, 12, 30, 87}
 
 func (i EnvironmentFlag) String() string {
 	if i < 0 || i >= EnvironmentFlag(len(_EnvironmentFlag_index)-1) {

--- a/tests/v2/validation/upgrade/kubernetes.go
+++ b/tests/v2/validation/upgrade/kubernetes.go
@@ -1,0 +1,186 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rancher/norman/types"
+	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/bundledclusters"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/environmentflag"
+)
+
+const (
+	// isCheckingCurrentCluster is the boolean to decide whether validations should happen with a new GET request and cluster data or not
+	isCheckingCurrentCluster = true
+	// logMessageKubernetesVersion is the string message to log with the kubernetes versions validations' assertions
+	logMessageKubernetesVersion = "Validating the current version is the upgraded one"
+	// logMessageNodepoolVersion is the string message to log the with kubernetes nodepools versions validations' assertions
+	logMessageNodepoolVersions = "Validating the current nodepools version is the upgraded one"
+	// ConfigurationFileKey is used to parse the configuration of upgrade tests.
+	ConfigurationFileKey = "upgradeInput"
+	// localClusterID is a string to used ignore this cluster in comparisons
+	localClusterID = "local"
+)
+
+type ClustersToUpgrade struct {
+	Name             string `json:"name" yaml:"name" default:""`
+	VersionToUpgrade string `json:"versionToUpgrade" yaml:"versionToUpgrade" default:""`
+	isLatestVersion  bool
+}
+
+type Config struct {
+	ClustersToUpgrade []ClustersToUpgrade `json:"clusters" yaml:"clusters" default:"[]"`
+}
+
+// getVersion is a test helper function to get kubernetes version of a cluster.
+// if versionToUpgrade in the config provided, checks the value within version first. Returns the version as string.
+func getVersion(t *testing.T, clusterName string, versions []string, isLatestVersion bool, versionToUpgrade string) (version *string) {
+	t.Helper()
+
+	if isLatestVersion {
+		require.NotEmptyf(t, versions, "[%v]: Can't upgrade cluster kubernetes version, cause it's already the latest", clusterName)
+		version = &versions[len(versions)-1]
+	} else if !isLatestVersion && versionToUpgrade != "" {
+		require.Containsf(t, versions, versionToUpgrade, "[%v]: Specified version doesn't exist", clusterName)
+		version = &versionToUpgrade
+	}
+
+	return
+}
+
+// validateKubernetesVersions is a test helper function to validate kubernetes version of a cluster.
+// if isUsingCluster provided, checks with a new get method to validate with updated cluster.
+// if isUsingCluster not provided, checks payload.
+func validateKubernetesVersions(t *testing.T, client *rancher.Client, bc *bundledclusters.BundledCluster, versionToUpgrade *string, isUsingCurrentCluster bool) {
+	t.Helper()
+
+	cluster, err := bc.Get(client)
+	require.NoErrorf(t, err, "[%v]: Error occured while validating kubernetes version", bc.Meta.Name)
+
+	if isUsingCurrentCluster {
+		cluster = bc
+	}
+
+	switch cluster.Meta.Provider {
+	case clusters.KubernetesProviderRKE:
+		assert.Equalf(t, *versionToUpgrade, cluster.V3.RancherKubernetesEngineConfig.Version, "[%v]: %v", cluster.Meta.Name, logMessageKubernetesVersion)
+	case clusters.KubernetesProviderRKE2:
+		if cluster.Meta.IsImported {
+			clusterSpec := &apiv1.ClusterSpec{}
+			err = v1.ConvertToK8sType(cluster.V1.Spec, clusterSpec)
+			require.NoError(t, err)
+
+			assert.Equalf(t, *versionToUpgrade, clusterSpec.KubernetesVersion, "[%v]: %v", cluster.Meta.Name, logMessageKubernetesVersion)
+		} else if !cluster.Meta.IsImported {
+			assert.Equalf(t, *versionToUpgrade, cluster.V3.Rke2Config.Version, "[%v]: %v", cluster.Meta.Name, logMessageKubernetesVersion)
+		}
+	case clusters.KubernetesProviderK3S:
+		if cluster.Meta.IsImported {
+			clusterSpec := &apiv1.ClusterSpec{}
+			err = v1.ConvertToK8sType(cluster.V1.Spec, clusterSpec)
+			require.NoError(t, err)
+
+			assert.Equalf(t, *versionToUpgrade, clusterSpec.KubernetesVersion, "[%v]: %v", cluster.Meta.Name, logMessageKubernetesVersion)
+		} else if !cluster.Meta.IsImported {
+			assert.Equalf(t, *versionToUpgrade, cluster.V3.K3sConfig.Version, "[%v]: %v", cluster.Meta.Name, logMessageKubernetesVersion)
+		}
+	case clusters.KubernetesProviderGKE:
+		assert.Equalf(t, *versionToUpgrade, *cluster.V3.GKEConfig.KubernetesVersion, "[%v]: %v", cluster.Meta.Name, logMessageKubernetesVersion)
+	case clusters.KubernetesProviderAKS:
+		assert.Equalf(t, *versionToUpgrade, *cluster.V3.AKSConfig.KubernetesVersion, "[%v]: %v", cluster.Meta.Name, logMessageKubernetesVersion)
+	case clusters.KubernetesProviderEKS:
+		assert.Equalf(t, *versionToUpgrade, *cluster.V3.EKSConfig.KubernetesVersion, "[%v]: %v", cluster.Meta.Name, logMessageKubernetesVersion)
+	}
+}
+
+// validateNodepoolVersions is a test helper function to validate node pool versions of a cluster.
+// if isUsingCluster provided, checks with a new get method to validate with updated cluster.
+// if isUsingCluster not provided, checks the payload.
+func validateNodepoolVersions(t *testing.T, client *rancher.Client, bc *bundledclusters.BundledCluster, versionToUpgrade *string, isUsingCurrentCluster bool) {
+	t.Helper()
+
+	cluster, err := bc.Get(client)
+	require.NoErrorf(t, err, "[%v]: Error occured while validating nodepool versions", bc.Meta.Name)
+
+	if isUsingCurrentCluster {
+		cluster = bc
+	}
+
+	switch cluster.Meta.Provider {
+	case clusters.KubernetesProviderGKE:
+		for i := range cluster.V3.GKEConfig.NodePools {
+			assert.Equalf(t, *versionToUpgrade, *cluster.V3.GKEConfig.NodePools[i].Version, "[%v]: %v", cluster.Meta.Name, logMessageNodepoolVersions)
+		}
+	case clusters.KubernetesProviderAKS:
+		for i := range cluster.V3.AKSConfig.NodePools {
+			assert.Equal(t, *versionToUpgrade, *cluster.V3.AKSConfig.NodePools[i].OrchestratorVersion, "[%v]: %v", cluster.Meta.Name, logMessageNodepoolVersions)
+		}
+	case clusters.KubernetesProviderEKS:
+		for i := range cluster.V3.EKSConfig.NodeGroups {
+			assert.Equal(t, *versionToUpgrade, *cluster.V3.EKSConfig.NodeGroups[i].Version, "[%v]: %v", cluster.Meta.Name, logMessageNodepoolVersions)
+		}
+	}
+}
+
+// loadUpgradeConfig is a test helper function to get required slice of ClustersToUpgrade struct. Returns error if any.
+// Contains two different config options to the upgrade kubernetes test:
+//  1. A flag called “all” is only requirement, upgrades all clusters except local to the latest available
+//  2. An additional config field called update with slice of ClustersToUpgrade struct,
+//     for choosing some clusters to upgrade(version is optional, by default to the latest available)
+func loadUpgradeConfig(client *rancher.Client) (clusters []ClustersToUpgrade, err error) {
+	upgradeConfig := new(Config)
+	config.LoadConfig(ConfigurationFileKey, upgradeConfig)
+
+	isConfigEmpty := len(upgradeConfig.ClustersToUpgrade) == 0
+	isFlagDeclared := client.Flags.GetValue(environmentflag.UpgradeAllClusters)
+
+	if isConfigEmpty && !isFlagDeclared {
+		return clusters, errors.Wrap(err, "config doesn't match the requirements")
+	}
+
+	isUpgradeAllClusters := isFlagDeclared && isConfigEmpty
+	isUpgradeSomeClusters := !isConfigEmpty && !isUpgradeAllClusters
+
+	if isUpgradeAllClusters {
+		clusterList, err := client.Management.Cluster.List(&types.ListOpts{})
+		if err != nil {
+			return clusters, errors.Wrap(err, "couldn't list clusters")
+		}
+
+		for i, c := range clusterList.Data {
+			isLocalCluster := c.ID == localClusterID
+			if !isLocalCluster {
+				cluster := new(ClustersToUpgrade)
+
+				cluster.Name = clusterList.Data[i].Name
+				cluster.isLatestVersion = true
+
+				clusters = append(clusters, *cluster)
+			}
+		}
+	} else if isUpgradeSomeClusters {
+		for _, c := range upgradeConfig.ClustersToUpgrade {
+			cluster := new(ClustersToUpgrade)
+
+			cluster.Name = c.Name
+			cluster.VersionToUpgrade = c.VersionToUpgrade
+
+			isVersionFieldEmpty := cluster.VersionToUpgrade == ""
+			if isVersionFieldEmpty {
+				cluster.isLatestVersion = true
+			}
+
+			clusters = append(clusters, *cluster)
+		}
+	}
+
+	return
+}

--- a/tests/v2/validation/upgrade/kubernetes_test.go
+++ b/tests/v2/validation/upgrade/kubernetes_test.go
@@ -1,0 +1,105 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/bundledclusters"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type UpgradeKubernetesTestSuite struct {
+	suite.Suite
+	session  *session.Session
+	client   *rancher.Client
+	Clusters []ClustersToUpgrade
+}
+
+func (u *UpgradeKubernetesTestSuite) TearDownSuite() {
+	u.session.Cleanup()
+}
+
+func (u *UpgradeKubernetesTestSuite) SetupSuite() {
+	testSession := session.NewSession(u.T())
+	u.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(u.T(), err)
+
+	u.client = client
+
+	clusters, err := loadUpgradeConfig(client)
+	require.NoError(u.T(), err)
+
+	require.NotEmptyf(u.T(), clusters, "couldn't generate the config for the upgrade test")
+	u.Clusters = clusters
+}
+
+func (u *UpgradeKubernetesTestSuite) TestUpgradeKubernetes() {
+	for _, cluster := range u.Clusters {
+		cluster := cluster
+		u.Run(cluster.Name, func() {
+			u.testUpgradeSingleCluster(cluster.Name, cluster.VersionToUpgrade, cluster.isLatestVersion)
+		})
+	}
+}
+
+func TestKubernetesUpgradeTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeKubernetesTestSuite))
+}
+
+func (u *UpgradeKubernetesTestSuite) testUpgradeSingleCluster(clusterName, versionToUpgrade string, isLatestVersion bool) {
+	subSession := u.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := u.client.WithSession(subSession)
+	require.NoError(u.T(), err)
+
+	clusterMeta, err := clusters.NewClusterMeta(client, clusterName)
+	require.NoError(u.T(), err)
+	require.NotNilf(u.T(), clusterMeta, "Couldn't get the cluster meta")
+	u.T().Logf("[%v]: Provider is: %v, Hosted: %v, Imported: %v ", clusterName, clusterMeta.Provider, clusterMeta.IsHosted, clusterMeta.IsImported)
+
+	initCluster, err := bundledclusters.NewWithClusterMeta(clusterMeta)
+	require.NoError(u.T(), err)
+
+	cluster, err := initCluster.Get(client)
+	require.NoError(u.T(), err)
+
+	versions, err := cluster.ListAvailableVersions(client)
+	require.NoError(u.T(), err)
+	u.T().Logf("[%v]: Available versions for the cluster: %v", clusterName, versions)
+
+	version := getVersion(u.T(), clusterName, versions, isLatestVersion, versionToUpgrade)
+	require.NotNilf(u.T(), version, "Couldn't get the version")
+	u.T().Logf("[%v]: Selected version: %v", clusterName, *version)
+
+	updatedCluster, err := cluster.UpdateKubernetesVersion(client, version)
+	require.NoError(u.T(), err)
+
+	u.T().Logf("[%v]: Validating sent update request for kubernetes version of the cluster", clusterName)
+	validateKubernetesVersions(u.T(), client, updatedCluster, version, isCheckingCurrentCluster)
+
+	err = clusters.WaitClusterToBeUpgraded(client, clusterMeta.ID)
+	require.NoError(u.T(), err)
+	u.T().Logf("[%v]: Waiting cluster to be upgraded and ready", clusterName)
+
+	u.T().Logf("[%v]: Validating updated cluster's kubernetes version", clusterName)
+	validateKubernetesVersions(u.T(), client, updatedCluster, version, !isCheckingCurrentCluster)
+
+	if clusterMeta.IsHosted {
+		updatedCluster.UpdateNodepoolKubernetesVersions(client, version)
+
+		u.T().Logf("[%v]: Validating sent update request for nodepools kubernetes versions of the cluster", clusterName)
+		validateNodepoolVersions(u.T(), client, updatedCluster, version, isCheckingCurrentCluster)
+
+		err = clusters.WaitClusterToBeUpgraded(client, clusterMeta.ID)
+		require.NoError(u.T(), err)
+
+		u.T().Logf("[%v]: Validating updated cluster's nodepools kubernetes versions", clusterName)
+		validateNodepoolVersions(u.T(), client, updatedCluster, version, !isCheckingCurrentCluster)
+	}
+}


### PR DESCRIPTION
**Extensions Updates**
- Refactored:
   - `environmentflags` configuration key to be used as `desiredflags` instead of `use`
- Implemented:
  - A new package called `bundledclusters`:
    - Enables to interact of v1 and v3 clusters as one struct
    - Get, List, and Update `bundledcluster` methods for both v1 and v3
    - A method to update the Kubernetes version of a cluster for all different provider types
    - A method to list available versions for all different provider types
  - Cluster meta struct to contain cluster’s meta for v1 and v3 clusters such as provider type, imported cluster or hosted cluster
  - A listener to watch a cluster in the upgrade state
  - Versions package:
    - List all functions for different cluster types versions
    - List available functions built on a list of all functions with a specified cluster

**Validation Tests**
- Implemented:
  - Private configuration input version, node pool versions for hosted providers, and Kubernetes version validations
  - Private configuration loader with two different options:
    - with a flag to run an upgrade Kubernetes test for all clusters except the local cluster
    - with a slice of structs with given versions for specific clusters