### PR TITLE
Run agent cleanup pod with user id 1000 instead of root

### DIFF
--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -303,6 +303,10 @@ func (c *ClusterLifecycleCleanup) createCleanupJob(userContext *config.UserConte
 								},
 							},
 							ImagePullPolicy: coreV1.PullAlways,
+							SecurityContext: &coreV1.SecurityContext{
+								RunAsUser:  &[]int64{1000}[0],
+								RunAsGroup: &[]int64{1000}[0],
+							},
 						},
 					},
 					RestartPolicy: "OnFailure",


### PR DESCRIPTION
## Issue: #33690
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The cleanup pod cannot run as root when the cluster is running in hardened mode. It requires that all pods run as a non-root user.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Use the job/pod security context options to run the pod as unix user/group 1000.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Testing was done on `v1.23.14+rke2r1`
- created an Ubuntu 20.04 machine on digital ocean.
- installed RKE2 using the [quickstart guide](https://docs.rke2.io/install/quickstart).
- hardened the cluster using the [hardening guide](https://docs.rke2.io/security/hardening_guide)
- started the RKE2 cluster
- imported the cluster into my local rancher instance and deleted it.

I repeated these steps twice, once to confirm the issue still existed, and it did, and another time to confirm that this patch fixes the issue, and it did.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
See the testing section

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
It can be a bit tricky to properly configure a hardened cluster using the guide, in fact I opened an [issue](https://github.com/rancher/rke2-docs/issues/26) to improve the docs. The steps need to be executed in the proper order but they are not displayed in order in the guide. See the issue for the proper ordering of steps.

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->