### PR TITLE
[v2.6] Backport - Run agent cleanup pod with user id 1000 instead of root

### DIFF
--- a/pkg/controllers/management/usercontrollers/controller.go
+++ b/pkg/controllers/management/usercontrollers/controller.go
@@ -303,6 +303,10 @@ func (c *ClusterLifecycleCleanup) createCleanupJob(userContext *config.UserConte
 								},
 							},
 							ImagePullPolicy: coreV1.PullAlways,
+							SecurityContext: &coreV1.SecurityContext{
+								RunAsUser:  &[]int64{1000}[0],
+								RunAsGroup: &[]int64{1000}[0],
+							},
 						},
 					},
 					RestartPolicy: "OnFailure",


### PR DESCRIPTION
## Issue: 39785

Backport of https://github.com/rancher/rancher/pull/39788 to v2.6