### PR TITLE
WIP:  Update PRTB reconcile logic for choosing userPrincipalName

### DIFF
--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -121,12 +121,21 @@ func (p *prtbLifecycle) reconcileSubject(binding *v3.ProjectRoleTemplateBinding)
 		if err != nil {
 			return binding, err
 		}
+		// choosing the first non-local principal we find, but falling back to local if there are no other options
+		var localFallback string
 		for _, p := range u.PrincipalIDs {
-			if strings.HasSuffix(p, binding.UserName) {
+			if strings.HasPrefix(p, "local://") {
+				localFallback = p
+				continue
+			} else {
 				binding.UserPrincipalName = p
 				break
 			}
 		}
+		if binding.UserPrincipalName == "" {
+			binding.UserPrincipalName = localFallback
+		}
+
 		return binding, nil
 	}
 


### PR DESCRIPTION
Rather than choosing local when no UserPrincipal is already set or in the binding, we will now only choose the local one if there are no other options.

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 TBD

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
A project created by <auth provider>/admin winds-up being owned by local/admin
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Only use the local/admin user if there is no other principal in the available list
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->