### PR TITLE
[v2.6] Update-provisioning-input-k8s-versions-v2.6

### DIFF
--- a/tests/v2/validation/provisioning/config.go
+++ b/tests/v2/validation/provisioning/config.go
@@ -12,13 +12,15 @@ const (
 )
 
 type Config struct {
-	NodesAndRoles      []machinepools.NodeRoles `json:"nodesAndRoles" yaml:"nodesAndRoles" default:"[]"`
-	NodesAndRolesRKE1  []nodepools.NodeRoles    `json:"nodesAndRolesRKE1" yaml:"nodesAndRolesRKE1" default:"[]"`
-	KubernetesVersions []string                 `json:"kubernetesVersion" yaml:"kubernetesVersion"`
-	CNIs               []string                 `json:"cni" yaml:"cni"`
-	Providers          []string                 `json:"providers" yaml:"providers"`
-	NodeProviders      []string                 `json:"nodeProviders" yaml:"nodeProviders"`
-	Hardened           bool                     `json:"hardened" yaml:"hardened"`
+	NodesAndRoles          []machinepools.NodeRoles `json:"nodesAndRoles" yaml:"nodesAndRoles" default:"[]"`
+	NodesAndRolesRKE1      []nodepools.NodeRoles    `json:"nodesAndRolesRKE1" yaml:"nodesAndRolesRKE1" default:"[]"`
+	K3SKubernetesVersions  []string                 `json:"k3sKubernetesVersion" yaml:"k3sKubernetesVersion"`
+	RKE1KubernetesVersions []string                 `json:"rke1KubernetesVersion" yaml:"rke1KubernetesVersion"`
+	RKE2KubernetesVersions []string                 `json:"rke2KubernetesVersion" yaml:"rke2KubernetesVersion"`
+	CNIs                   []string                 `json:"cni" yaml:"cni"`
+	Providers              []string                 `json:"providers" yaml:"providers"`
+	NodeProviders          []string                 `json:"nodeProviders" yaml:"nodeProviders"`
+	Hardened               bool                     `json:"hardened" yaml:"hardened"`
 }
 
 func AppendRandomString(baseClusterName string) string {

--- a/tests/v2/validation/provisioning/k3s/README.md
+++ b/tests/v2/validation/provisioning/k3s/README.md
@@ -33,7 +33,7 @@ provisioningInput is needed to the run the K3S tests, specifically kubernetesVer
         "quantity": 1,
       }
     ],
-    "kubernetesVersion": ["v1.24.4+k3s1"],
+    "k3sKubernetesVersion": ["v1.24.4+k3s1"],
     "cni": ["calico"],
     "providers": ["linode", "aws", "azure", "harvester"],
     "nodeProviders": ["ec2"],

--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -47,7 +47,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	clustersConfig := new(provisioning.Config)
 	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 
-	c.kubernetesVersions = clustersConfig.KubernetesVersions
+	c.kubernetesVersions = clustersConfig.K3SKubernetesVersions
 	c.nodeProviders = clustersConfig.NodeProviders
 	c.provisioning = clustersConfig
 

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
@@ -46,7 +46,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) SetupSuite() {
 	clustersConfig := new(provisioning.Config)
 	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 
-	k.kubernetesVersions = clustersConfig.KubernetesVersions
+	k.kubernetesVersions = clustersConfig.K3SKubernetesVersions
 	k.providers = clustersConfig.Providers
 
 	client, err := rancher.NewClient("", testSession)

--- a/tests/v2/validation/provisioning/rke1/README.md
+++ b/tests/v2/validation/provisioning/rke1/README.md
@@ -32,7 +32,7 @@ provisioningInput is needed to the run the RKE1 tests, specifically kubernetesVe
         "quantity": 2,
       }
     ],
-    "kubernetesVersion": ["v1.24.2-rancher1-1"],
+    "rke1KubernetesVersion": ["v1.24.2-rancher1-1"],
     "providers": ["linode", "aws", "azure", "harvester"],
     "nodeProviders": ["ec2"]
   }

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -43,7 +43,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	clustersConfig := new(provisioning.Config)
 	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 
-	c.kubernetesVersions = clustersConfig.KubernetesVersions
+	c.kubernetesVersions = clustersConfig.RKE1KubernetesVersions
 	c.cnis = clustersConfig.CNIs
 	c.nodeProviders = clustersConfig.NodeProviders
 

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -41,7 +41,7 @@ func (r *RKE1NodeDriverProvisioningTestSuite) SetupSuite() {
 	clustersConfig := new(provisioning.Config)
 	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 
-	r.kubernetesVersions = clustersConfig.KubernetesVersions
+	r.kubernetesVersions = clustersConfig.RKE1KubernetesVersions
 	r.cnis = clustersConfig.CNIs
 	r.providers = clustersConfig.Providers
 

--- a/tests/v2/validation/provisioning/rke2/README.md
+++ b/tests/v2/validation/provisioning/rke2/README.md
@@ -33,7 +33,7 @@ provisioningInput is needed to the run the RKE2 tests, specifically kubernetesVe
         "quantity": 1,
       }
     ],
-    "kubernetesVersion": ["v1.21.6+rke2r1"],
+    "rke2KubernetesVersion": ["v1.21.6+rke2r1"],
     "cni": ["calico"],
     "providers": ["linode", "aws", "do", "harvester"],
     "nodeProviders": ["ec2"]

--- a/tests/v2/validation/provisioning/rke2/cert_rotation_test.go
+++ b/tests/v2/validation/provisioning/rke2/cert_rotation_test.go
@@ -114,7 +114,7 @@ func (r *V2ProvCertRotationTestSuite) TestCertRotation() {
 		cloudCredential, err := provider.CloudCredFunc(client)
 		require.NoError(r.T(), err)
 
-		for _, kubernetesVersion := range r.config.KubernetesVersions {
+		for _, kubernetesVersion := range r.config.RKE2KubernetesVersions {
 			r.testCertRotation(provider, kubernetesVersion, r.config.NodesAndRoles, cloudCredential)
 		}
 

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -46,7 +46,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	clustersConfig := new(provisioning.Config)
 	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 
-	c.kubernetesVersions = clustersConfig.KubernetesVersions
+	c.kubernetesVersions = clustersConfig.RKE2KubernetesVersions
 	c.cnis = clustersConfig.CNIs
 	c.nodeProviders = clustersConfig.NodeProviders
 

--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
@@ -61,7 +61,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) SetupSuite() {
 	clustersConfig := new(provisioning.Config)
 	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 
-	r.kubernetesVersions = clustersConfig.KubernetesVersions
+	r.kubernetesVersions = clustersConfig.RKE2KubernetesVersions
 	r.cnis = clustersConfig.CNIs
 	r.providers = clustersConfig.Providers
 	r.nodesAndRoles = clustersConfig.NodesAndRoles

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -48,7 +48,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 	clustersConfig := new(provisioning.Config)
 	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 
-	r.kubernetesVersions = clustersConfig.KubernetesVersions
+	r.kubernetesVersions = clustersConfig.RKE2KubernetesVersions
 	r.cnis = clustersConfig.CNIs
 	r.providers = clustersConfig.Providers
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
In its current implementation it is not possible to run provisioning tests across packages. This is something we do with code coverage runs,

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 I add inputs for the the different cluster types: rke1, rke2, and k3s in the provisioningInput config entry.
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->