### PR TITLE
Add cgroups v2 evacuation to scripts/run for embedded k3s

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -17,4 +17,21 @@ export CATTLE_DEV_MODE=yes
 export CATTLE_SERVER_URL="https://$(ip route get 8.8.8.8 | awk '{print $7}'):8443"
 export CATTLE_BOOTSTRAP_PASSWORD="admin"
 export CATTLE_FEATURES="harvester=false"
+
+#########################################################################################################################################
+# DISCLAIMER                                                                                                                            #
+# Copied from https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/hack/dind#L28-L37                              #
+# Permission granted by Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> (https://github.com/rancher/k3d/issues/493#issuecomment-827405962) #
+# Moby License Apache 2.0: https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/LICENSE                           #
+#########################################################################################################################################
+# only run this if rancher is not running in kubernetes cluster
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+  # move the processes from the root group to the /init group,
+  # otherwise writing subtree_control fails with EBUSY.
+  mkdir -p /sys/fs/cgroup/init
+  xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+  # enable controllers
+  sed -e 's/ / +/g' -e 's/^/+/' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
+fi
+
 exec ../../$CMD


### PR DESCRIPTION
This fix is specficially for linux distros that make use of cgroups v2, which were previously unable to run `make test` and by extension, `make ci`.

## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/39829
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
When running the rancher process inside of dapper, rancher needs to be moved to the init process group if running on a machine using cgroups v2 (for me, this is Ubuntu 22.10, but IIRC first occured on 20.04). Otherwise, the [embedded k3s created by norman](https://github.com/rancher/norman/blob/32ef2e185b999ee40e041406080fcefffe045f22/pkg/kwrapper/k8s/k3s_linux.go#L38) will continuously exit.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add the following workaround to `scripts/run`: https://github.com/rancher/rancher/blob/2c312a9880434a9f8ead53e4a822563cd018c4c9/package/entrypoint.sh#L16-L23

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

I was finally able to run `make test` and `make ci` without it crashing on a linux box for the first time in a year.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

We'll just have to see if the drone build passes.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

N/A

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

N/A