### PR TITLE
Adds chart option to configure the initialDelay and periodSeconds of probes

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -147,14 +147,14 @@ spec:
           httpGet:
             path: /healthz
             port: 80
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          initialDelaySeconds: {{.Values.livenessProbe.initialDelaySeconds | default 60 }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds | default 30 }}
         readinessProbe:
           httpGet:
             path: /healthz
             port: 80
-          initialDelaySeconds: 5
-          periodSeconds: 30
+          initialDelaySeconds: {{.Values.readinessProbe.initialDelaySeconds | default  5}}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 30}}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/chart/tests/README.md
+++ b/chart/tests/README.md
@@ -1,0 +1,33 @@
+
+## local dev testing instructions
+
+Option 1: Full chart CI run with a live cluster
+
+```bash
+./scripts/charts/ci 
+```
+
+Option 2: Test runs against the chart only 
+
+```bash
+# Install plugin if necessary, for version see CATTLE_HELM_UNITTEST_VERSION
+# For a Mac you'll need to download a release and install the darwin binary
+# For linux:
+export ARCH=amd64 export CATTLE_HELM_UNITTEST_VERSION={version} helm plugin install https://github.com/rancher/helm-unittest
+
+# change automated parts of templates
+test_image="rancher/rancher"
+test_image_tag="v2.7.0"
+sed -i -e "s/%VERSION%/${test_image_tag}/g" ./chart/Chart.yaml
+sed -i -e "s/%APP_VERSION%/${test_image_tag}/g" ./chart/Chart.yaml
+sed -i -e "s@%POST_DELETE_IMAGE_NAME%@${test_image}@g" ./chart/values.yaml
+sed -i -e "s/%POST_DELETE_IMAGE_TAG%/${test_image_tag}/g" ./chart/values.yaml
+
+# test
+helm lint ./chart
+helm unittest ./chart
+
+# clean
+git checkout chart/*
+```
+

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -349,3 +349,51 @@ tests:
     - equal:
         path: spec.template.spec.priorityClassName
         value: "rancher-critical"
+- it: should default livenessProbe initialDelaySeconds to 60
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+        value: 60
+- it: should default livenessProbe periodSeconds to 30
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+        value: 30
+- it: should default readinessProbe initialDelaySeconds to 5
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+        value: 5
+- it: should default readinessProbe periodSeconds to 30
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+        value: 30
+- it: should set livenessProbe initialDelaySeconds to 90
+  set:
+    livenessProbe.initialDelaySeconds: 90
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+        value: 90
+- it: should set livenessProbe periodSeconds to 60
+  set:
+    livenessProbe.periodSeconds: 60
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+        value: 60
+- it: should set readinessProbe initialDelaySeconds to 20
+  set:
+    readinessProbe.initialDelaySeconds: 20
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+        value: 20
+- it: should set readinessProbe periodSeconds to 60
+  set:
+    readinessProbe.periodSeconds: 60
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+        value: 60

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -161,3 +161,10 @@ postDelete:
 
 # Set a bootstrap password. If leave empty, a random password will be generated.
 bootstrapPassword: ""
+
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 30
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 30


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/39841
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Users need to be able to override probes as sometimes Rancher takes a very long time to start. If they do that manually to the deployment, helm will override it the following upgrade. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

This PR allows users to set probes via helm directly.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->



## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Ran helm template, helm install, and all the helm unit tests

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

Tests added, originally from: https://github.com/rancher/rancher/pull/39319/commits/fd4caac9e835ad862ce3869b8fd66c9e9bfeafbd

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Should not cause any regressions, as this will operate functionally the same. 