### PR TITLE
[v2.6] SLE BCI update to 15.4

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.3
+FROM registry.suse.com/bci/bci-base:15.4
 
 RUN zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim netcat-openbsd mkisofs && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -2,7 +2,7 @@ ARG RANCHER_TAG=dev
 ARG RANCHER_REPO=rancher
 FROM ${RANCHER_REPO}/rancher:${RANCHER_TAG} as rancher
 
-FROM registry.suse.com/bci/bci-base:15.3
+FROM registry.suse.com/bci/bci-base:15.4
 ARG ARCH=amd64
 
 ENV KUBECTL_VERSION v1.23.6


### PR DESCRIPTION
This is a backport of https://github.com/rancher/rancher/pull/39767 for 2.6.

## Issue: 
  
## Problem

Rancher and Rancher Agent is currently based on SLE BCI 15 SP3, which goes out of general support on 2022-12-31.
 
## Solution

For about half a year there is already SLE BCI 15 SP4 available, so switch to that.
 
## Testing

None other than CI testing

 
### Regressions Considerations

There are no known breakages between 15.3 and 15.4. 
