### PR TITLE
Add CAPI predicates to RKEMachine

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/common_test.go
+++ b/pkg/controllers/provisioningv2/rke2/common_test.go
@@ -109,7 +109,7 @@ func TestFindOwnerCAPICluster(t *testing.T) {
 		{
 			name:        "no owner",
 			expected:    nil,
-			expectedErr: errors.New("RKECluster testnamespace/testcluster does not have a controller owner reference"),
+			expectedErr: ErrNoControllerMachineOwnerRef,
 			obj: &rkev1.RKECluster{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "RKECluster",
@@ -123,7 +123,7 @@ func TestFindOwnerCAPICluster(t *testing.T) {
 		{
 			name:        "no controller",
 			expected:    nil,
-			expectedErr: errors.New("RKECluster testnamespace/testcluster does not have a controller owner reference"),
+			expectedErr: ErrNoControllerMachineOwnerRef,
 			obj: &rkev1.RKECluster{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "RKECluster",
@@ -142,7 +142,7 @@ func TestFindOwnerCAPICluster(t *testing.T) {
 		{
 			name:        "owner wrong kind",
 			expected:    nil,
-			expectedErr: errors.New("RKECluster testnamespace/testcluster has wrong owner kind nil"),
+			expectedErr: ErrNoControllerMachineOwnerRef,
 			obj: &rkev1.RKECluster{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "RKECluster",
@@ -163,7 +163,7 @@ func TestFindOwnerCAPICluster(t *testing.T) {
 		{
 			name:        "owner wrong api version",
 			expected:    nil,
-			expectedErr: errors.New("RKECluster testnamespace/testcluster has wrong owner api version nil"),
+			expectedErr: ErrNoControllerMachineOwnerRef,
 			obj: &rkev1.RKECluster{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "RKECluster",

--- a/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
@@ -193,7 +193,8 @@ func (h *handler) getMachineStatus(job *batchv1.Job) (rkev1.RKEMachineStatus, er
 	if job.Spec.Template.Labels[InfraJobRemove] == "true" {
 		condType = deleteJobConditionType
 	}
-	if !job.Status.CompletionTime.IsZero() {
+
+	if condition.Cond("Complete").IsTrue(job) {
 		return rkev1.RKEMachineStatus{
 			Conditions: []genericcondition.GenericCondition{
 				{
@@ -207,9 +208,7 @@ func (h *handler) getMachineStatus(job *batchv1.Job) (rkev1.RKEMachineStatus, er
 			},
 			JobComplete: true,
 		}, nil
-	}
-
-	if condition.Cond("Failed").IsTrue(job) {
+	} else if condition.Cond("Failed").IsTrue(job) {
 		sel, err := metav1.LabelSelectorAsSelector(job.Spec.Selector)
 		if err != nil {
 			return rkev1.RKEMachineStatus{}, err

--- a/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
+	capiannotations "sigs.k8s.io/cluster-api/util/annotations"
 )
 
 const (
@@ -91,8 +92,9 @@ type handler struct {
 	jobs                batchcontrollers.JobCache
 	pods                corecontrollers.PodCache
 	secrets             corecontrollers.SecretCache
-	machines            capicontrollers.MachineCache
-	machinesClient      capicontrollers.MachineClient
+	capiClusterCache    capicontrollers.ClusterCache
+	machineCache        capicontrollers.MachineCache
+	machineClient       capicontrollers.MachineClient
 	namespaces          corecontrollers.NamespaceCache
 	nodeDriverCache     mgmtcontrollers.NodeDriverCache
 	dynamic             *dynamic.Controller
@@ -112,8 +114,9 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 		jobController:       clients.Batch.Job(),
 		jobs:                clients.Batch.Job().Cache(),
 		secrets:             clients.Core.Secret().Cache(),
-		machines:            clients.CAPI.Machine().Cache(),
-		machinesClient:      clients.CAPI.Machine(),
+		machineCache:        clients.CAPI.Machine().Cache(),
+		machineClient:       clients.CAPI.Machine(),
+		capiClusterCache:    clients.CAPI.Cluster().Cache(),
 		nodeDriverCache:     clients.Mgmt.NodeDriver().Cache(),
 		namespaces:          clients.Core.Namespace().Cache(),
 		dynamic:             clients.Dynamic,
@@ -161,9 +164,9 @@ func (h *handler) OnJobChange(_ string, job *batchv1.Job) (*batchv1.Job, error) 
 		return job, err
 	}
 
-	infraObj, err := newInfraObject(infraMachine)
+	infra, err := newInfraObject(infraMachine)
 	if err != nil {
-		return nil, err
+		return job, err
 	}
 
 	newStatus, err := h.getMachineStatus(job)
@@ -172,14 +175,14 @@ func (h *handler) OnJobChange(_ string, job *batchv1.Job) (*batchv1.Job, error) 
 	}
 	newStatus.JobName = job.Name
 
-	if _, err := h.patchStatus(infraObj.obj, infraObj.data, newStatus); err != nil {
+	if _, err = h.patchStatus(infra.obj, infra.data, newStatus); err != nil {
 		return job, err
 	}
 
 	// Re-evaluate the infra-machine after this
-	if err := h.dynamic.Enqueue(infraMachine.GetObjectKind().GroupVersionKind(),
-		infraObj.meta.GetNamespace(), infraObj.meta.GetName()); err != nil {
-		return nil, err
+	if err = h.dynamic.Enqueue(infraMachine.GetObjectKind().GroupVersionKind(),
+		infra.meta.GetNamespace(), infra.meta.GetName()); err != nil {
+		return job, err
 	}
 
 	return job, nil
@@ -310,40 +313,40 @@ func (h *handler) OnRemove(key string, obj runtime.Object) (runtime.Object, erro
 		return obj, err
 	}
 
-	infraObj, err := newInfraObject(obj)
+	infra, err := newInfraObject(obj)
 	if err != nil {
 		return obj, err
 	}
 
-	if !infraObj.data.Bool("status", "jobComplete") && infraObj.data.String("status", "failureReason") == "" {
-		job, err := h.getJobFromInfraMachine(infraObj)
+	if !infra.data.Bool("status", "jobComplete") && infra.data.String("status", "failureReason") == "" {
+		job, err := h.getJobFromInfraMachine(infra)
 		if apierrors.IsNotFound(err) {
 			// If the job is not found, go ahead and proceed with machine deletion
 			return obj, h.apply.WithOwner(obj).ApplyObjects()
 		} else if err != nil {
 			return obj, err
 		}
-		logrus.Debugf("[MachineProvision] create job for %s not finished, job was found and the error was not nil and was not an isnotfound", key)
+		logrus.Debugf("[machineprovision] create job for %s not finished, job was found and the error was not nil and was not an isnotfound", key)
 		if job != nil {
 			// enqueue the job to force-reconcile the condition
 			h.jobController.Enqueue(job.Namespace, job.Name)
-			logrus.Tracef("[MachineProvision] create job object for %s was %+v", key, job)
+			logrus.Tracef("[machineprovision] create job object for %s was %+v", key, job)
 		}
-		return obj, fmt.Errorf("cannot delete machine %s because create job has not finished", infraObj.meta.GetName())
+		return obj, fmt.Errorf("cannot delete machine %s because create job has not finished", infra.meta.GetName())
 	}
 
-	if cond := getCondition(infraObj.data, deleteJobConditionType); cond != nil {
-		job, err := h.getJobFromInfraMachine(infraObj)
+	if cond := getCondition(infra.data, deleteJobConditionType); cond != nil {
+		job, err := h.getJobFromInfraMachine(infra)
 		if apierrors.IsNotFound(err) {
 			// If the deletion job condition has been set on the infrastructure object and the deletion job has been removed,
 			// then we don't want to create another deletion job.
-			logrus.Infof("Machine %s %s has already been deleted", infraObj.obj.GetObjectKind().GroupVersionKind(), infraObj.meta.GetName())
+			logrus.Infof("[machineprovision] Machine %s %s has already been deleted", infra.obj.GetObjectKind().GroupVersionKind(), infra.meta.GetName())
 			return obj, h.apply.WithOwner(obj).ApplyObjects()
 		} else if err != nil {
 			return obj, err
 		}
 
-		if shouldCleanupObjects(job, infraObj.data) {
+		if shouldCleanupObjects(job, infra.data) {
 			// Calling WithOwner(obj).ApplyObjects with no objects here will look for all objects with types passed to
 			// WithCacheTypes above that have an owner label (not owner reference) to the given obj. It will compare the existing
 			// objects it finds to the ones that are passed to ApplyObjects (which there are none in this case). The apply
@@ -354,33 +357,36 @@ func (h *handler) OnRemove(key string, obj runtime.Object) (runtime.Object, erro
 		return obj, generic.ErrSkip
 	}
 
-	clusterName := infraObj.meta.GetLabels()[capi.ClusterLabelName]
+	clusterName := infra.meta.GetLabels()[capi.ClusterLabelName]
 	if clusterName == "" {
 		return obj, fmt.Errorf("error retrieving the clustername for machine, label key %s does not appear to exist for dynamic machine %s", capi.ClusterLabelName, key)
 	}
 
-	machine, err := rke2.GetMachineByOwner(h.machines, infraObj.meta)
-	if err != nil && !errors.Is(err, rke2.ErrNoMachineOwnerRef) {
+	machine, err := rke2.GetOwnerCAPIMachine(obj, h.machineCache)
+	if err != nil && !errors.Is(err, rke2.ErrNoControllerMachineOwnerRef) && !apierrors.IsNotFound(err) {
+		logrus.Errorf("[machineprovision] %s/%s: error getting machine by owner reference %v", infra.meta.GetNamespace(), infra.meta.GetName(), err)
 		return obj, err
 	}
 
+	// If the controller owner reference is not properly configured, or the CAPI machine does not exist, there is no way
+	// to recover from this situation, so we should proceed with deletion.
 	if machine == nil || machine.Status.NodeRef == nil {
 		// Machine noderef is nil, we should just allow deletion.
-		logrus.Debugf("[MachineProvision] There was no associated K8s node with this etcd dynamicmachine %s. Proceeding with deletion", key)
-		return h.doRemove(infraObj)
+		logrus.Debugf("[machineprovision] There was no associated K8s node with this machine %s. Proceeding with deletion", key)
+		return h.doRemove(infra)
 	}
 
-	cluster, err := h.rancherClusterCache.Get(infraObj.meta.GetNamespace(), clusterName)
+	cluster, err := h.rancherClusterCache.Get(infra.meta.GetNamespace(), clusterName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return obj, err
 	}
 	if apierrors.IsNotFound(err) || !cluster.DeletionTimestamp.IsZero() {
-		return h.doRemove(infraObj)
+		return h.doRemove(infra)
 	}
 
 	removed := true
 	// In the event we are removing an etcd node (as indicated by the etcd-role label on the node), we must safely remove the etcd node from the cluster before allowing machine deprovisioning
-	if val := infraObj.meta.GetLabels()["rke.cattle.io/etcd-role"]; val == "true" {
+	if val := strings.ToLower(infra.meta.GetLabels()[rke2.EtcdRoleLabel]); val == "true" {
 		// we need to block removal until our the v1 node that corresponds has been removed
 		restConfig, err := h.kubeconfigManager.GetRESTConfig(cluster, cluster.Status)
 		if err != nil {
@@ -394,17 +400,17 @@ func (h *handler) OnRemove(key string, obj runtime.Object) (runtime.Object, erro
 	}
 
 	if !removed {
-		if err = h.dynamic.EnqueueAfter(obj.GetObjectKind().GroupVersionKind(), infraObj.meta.GetNamespace(), infraObj.meta.GetName(), 5*time.Second); err != nil {
+		if err = h.dynamic.EnqueueAfter(obj.GetObjectKind().GroupVersionKind(), infra.meta.GetNamespace(), infra.meta.GetName(), 5*time.Second); err != nil {
 			return obj, err
 		}
 		return obj, generic.ErrSkip
 	}
 
-	return h.doRemove(infraObj)
+	return h.doRemove(infra)
 }
 
-func (h *handler) doRemove(infraObj *infraObject) (runtime.Object, error) {
-	obj, err := h.run(infraObj, false)
+func (h *handler) doRemove(infra *infraObject) (runtime.Object, error) {
+	obj, err := h.run(infra, false)
 	if err != nil {
 		return nil, err
 	}
@@ -413,18 +419,65 @@ func (h *handler) doRemove(infraObj *infraObject) (runtime.Object, error) {
 	return obj, generic.ErrSkip
 }
 
-func (h *handler) OnChange(obj runtime.Object) (runtime.Object, error) {
-	infraObj, err := newInfraObject(obj)
+func (h *handler) EnqueueAfter(infra *infraObject, duration time.Duration) {
+	err := h.dynamic.EnqueueAfter(infra.obj.GetObjectKind().GroupVersionKind(), infra.meta.GetNamespace(), infra.meta.GetName(), duration)
 	if err != nil {
-		return nil, err
+		logrus.Errorf("[machineprovision] error enqueuing %s %s/%s: %v", infra.obj.GetObjectKind().GroupVersionKind(), infra.meta.GetNamespace(), infra.meta.GetName(), err)
+	}
+}
+
+func (h *handler) OnChange(obj runtime.Object) (runtime.Object, error) {
+	infra, err := newInfraObject(obj)
+	if err != nil {
+		return obj, err
 	}
 
 	// don't process create if deleting
-	if !infraObj.meta.GetDeletionTimestamp().IsZero() {
+	if !infra.meta.GetDeletionTimestamp().IsZero() {
 		return obj, nil
 	}
 
-	newObj, err := h.run(infraObj, true)
+	machine, err := rke2.GetOwnerCAPIMachine(obj, h.machineCache)
+	if apierrors.IsNotFound(err) {
+		logrus.Debugf("[machineprovision] %s/%s: waiting: machine to be set as owner reference", infra.meta.GetNamespace(), infra.meta.GetName())
+		h.EnqueueAfter(infra, 10*time.Second)
+		return obj, generic.ErrSkip
+	}
+	if err != nil {
+		logrus.Errorf("[machineprovision] %s/%s: error getting machine by owner reference %v", infra.meta.GetNamespace(), infra.meta.GetName(), err)
+		return obj, err
+	}
+
+	capiCluster, err := rke2.GetCAPIClusterFromLabel(machine, h.capiClusterCache)
+	if apierrors.IsNotFound(err) {
+		logrus.Debugf("[machineprovision] %s/%s: waiting: CAPI cluster does not exist", infra.meta.GetNamespace(), infra.meta.GetName())
+		h.EnqueueAfter(infra, 10*time.Second)
+		return obj, generic.ErrSkip
+	}
+	if err != nil {
+		logrus.Errorf("[machineprovision] %s/%s: error getting CAPI cluster %v", infra.meta.GetNamespace(), infra.meta.GetName(), err)
+		return obj, err
+	}
+
+	if capiannotations.IsPaused(capiCluster, infra.meta) {
+		logrus.Debugf("[machineprovision] %s/%s: waiting: CAPI cluster or RKEMachine is paused", infra.meta.GetNamespace(), infra.meta.GetName())
+		h.EnqueueAfter(infra, 10*time.Second)
+		return obj, generic.ErrSkip
+	}
+
+	if !capiCluster.Status.InfrastructureReady {
+		logrus.Debugf("[machineprovision] %s/%s: waiting: CAPI cluster infrastructure is not ready", infra.meta.GetNamespace(), infra.meta.GetName())
+		h.EnqueueAfter(infra, 10*time.Second)
+		return obj, generic.ErrSkip
+	}
+
+	if machine.Spec.Bootstrap.DataSecretName == nil {
+		logrus.Debugf("[machineprovision] %s/%s: waiting: dataSecretName is not populated on machine spec", infra.meta.GetNamespace(), infra.meta.GetName())
+		h.EnqueueAfter(infra, 10*time.Second)
+		return obj, generic.ErrSkip
+	}
+
+	newObj, err := h.run(infra, true)
 	if newObj == nil {
 		newObj = obj
 	}
@@ -435,41 +488,43 @@ func (h *handler) OnChange(obj runtime.Object) (runtime.Object, error) {
 	return newObj, nil
 }
 
-func (h *handler) run(infraObj *infraObject, create bool) (runtime.Object, error) {
-	args := infraObj.data.Map("spec")
-	driver := getNodeDriverName(infraObj.typeMeta)
+func (h *handler) run(infra *infraObject, create bool) (runtime.Object, error) {
+	logrus.Infof("[machineprovision] %s/%s: reconciling machine job", infra.meta.GetNamespace(), infra.meta.GetName())
 
-	dArgs, err := h.getArgsEnvAndStatus(infraObj, args, driver, create)
+	args := infra.data.Map("spec")
+	driver := getNodeDriverName(infra.typeMeta)
+
+	dArgs, err := h.getArgsEnvAndStatus(infra, args, driver, create)
 	if err != nil {
-		return infraObj.obj, err
+		return infra.obj, err
 	}
 
 	if dArgs.BootstrapSecretName == "" && dArgs.BootstrapRequired {
-		return infraObj.obj,
-			h.dynamic.EnqueueAfter(infraObj.obj.GetObjectKind().GroupVersionKind(), infraObj.meta.GetNamespace(), infraObj.meta.GetName(), 2*time.Second)
+		return infra.obj,
+			h.dynamic.EnqueueAfter(infra.obj.GetObjectKind().GroupVersionKind(), infra.meta.GetNamespace(), infra.meta.GetName(), 2*time.Second)
 	}
 
-	failedCreate := infraObj.data.String("status", "failureReason") == string(capierrors.CreateMachineError)
+	failedCreate := infra.data.String("status", "failureReason") == string(capierrors.CreateMachineError)
 
-	if err := h.apply.WithOwner(infraObj.obj).ApplyObjects(objects((args.String("providerID") != "" || failedCreate) && create, dArgs)...); err != nil {
+	if err := h.apply.WithOwner(infra.obj).ApplyObjects(objects((args.String("providerID") != "" || failedCreate) && create, dArgs)...); err != nil {
 		return nil, err
 	}
 
 	if create {
-		infraObj.obj, err = h.patchStatus(infraObj.obj, infraObj.data, dArgs.RKEMachineStatus)
+		infra.obj, err = h.patchStatus(infra.obj, infra.data, dArgs.RKEMachineStatus)
 		if err != nil {
 			return nil, err
 		}
 
 		if failedCreate {
-			logrus.Infof("[MachineProvision] Failed to create infrastructure %s/%s for machine %s, deleting and recreating...", infraObj.meta.GetNamespace(), infraObj.meta.GetName(), dArgs.CapiMachineName)
-			if err = h.machinesClient.Delete(infraObj.meta.GetNamespace(), dArgs.CapiMachineName, &metav1.DeleteOptions{}); err != nil {
-				return infraObj.obj, fmt.Errorf("failed to delete CAPI machine %s: %w", dArgs.CapiMachineName, err)
+			logrus.Infof("[machineprovision] %s/%s: Failed to create infrastructure for machine %s, deleting and recreating...", infra.meta.GetNamespace(), infra.meta.GetName(), dArgs.CapiMachineName)
+			if err = h.machineClient.Delete(infra.meta.GetNamespace(), dArgs.CapiMachineName, &metav1.DeleteOptions{}); err != nil {
+				return infra.obj, fmt.Errorf("failed to delete CAPI machine %s: %w", dArgs.CapiMachineName, err)
 			}
 		}
 	}
 
-	return infraObj.obj, nil
+	return infra.obj, nil
 }
 
 func (h *handler) patchStatus(obj runtime.Object, d data.Object, state rkev1.RKEMachineStatus) (runtime.Object, error) {
@@ -525,19 +580,19 @@ func (h *handler) patchStatus(obj runtime.Object, d data.Object, state rkev1.RKE
 	})
 }
 
-func (h *handler) getJobFromInfraMachine(infraObj *infraObject) (*batchv1.Job, error) {
-	gvk := infraObj.obj.GetObjectKind().GroupVersionKind()
-	jobs, err := h.jobs.List(infraObj.meta.GetNamespace(), labels.Set{
+func (h *handler) getJobFromInfraMachine(infra *infraObject) (*batchv1.Job, error) {
+	gvk := infra.obj.GetObjectKind().GroupVersionKind()
+	jobs, err := h.jobs.List(infra.meta.GetNamespace(), labels.Set{
 		InfraMachineGroup:   gvk.Group,
 		InfraMachineVersion: gvk.Version,
 		InfraMachineKind:    gvk.Kind,
-		InfraMachineName:    infraObj.meta.GetName()}.AsSelector(),
+		InfraMachineName:    infra.meta.GetName()}.AsSelector(),
 	)
 	if err != nil {
 		return nil, err
 	} else if len(jobs) == 0 {
 		// This is likely the name of the job, expect if the infra machine object has a very long name.
-		return nil, apierrors.NewNotFound(batchv1.Resource("jobs"), GetJobName(infraObj.meta.GetName()))
+		return nil, apierrors.NewNotFound(batchv1.Resource("jobs"), GetJobName(infra.meta.GetName()))
 	}
 
 	// There can be at most one job returned here because there can be at most one infra machine object with the given GVK and name.


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Part of groundwork for #39139

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

We need a mechanism to support pausing the various CRs in our CAPI implementation, so we can disable cluster reconciliation during disruptive actions such as encryption key rotation.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add missing predicates to rke machine controller, including checking for pausing as well as other required predicates we were missing.

https://cluster-api.sigs.k8s.io/developer/providers/machine-infrastructure.html#normal-resource