### PR TITLE
[2.7] Update AKSVmSizes endpoints

### DIFF
--- a/pkg/api/norman/customization/aks/handler.go
+++ b/pkg/api/norman/customization/aks/handler.go
@@ -132,8 +132,15 @@ func (h *handler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 		}
 		writer.Write(serialized)
 	case "aksVMSizes":
-		if serialized, errCode, err = listVMSizes(req.Context(), capa); err != nil {
+		if serialized, errCode, err = listVMSizesV1(req.Context(), capa); err != nil {
 			logrus.Errorf("[aks-handler] error getting VM sizes: %v", err)
+			handleErr(writer, errCode, err)
+			return
+		}
+		writer.Write(serialized)
+	case "aksVMSizesV2":
+		if serialized, errCode, err = listVMSizesV2(req.Context(), capa); err != nil {
+			logrus.Errorf("[aks-handler] error getting VM sizes (v2): %v", err)
 			handleErr(writer, errCode, err)
 			return
 		}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39672
 
## Problem
Rancher should provide the old `aksVMSizes` API for backwards compatibility within the UI. In the case that related UI aspects are not included in the next release, we want to make sure things still function as expected. When the related UI tasks are worked on, they can use the new API introduced in the previous PR.
 
## Solution
Reinstate the initial functionality of the `aksVMSizes` API. Add a new endpoint called `aksVMSizesV2` which will give a response body which contains all VM sizes for a given region as well as the supported availability zones and if they support accelerated networking. 
 
## Testing
+ Call these endpoints with CURL, similar testing steps as https://github.com/rancher/rancher/pull/39675

## Engineering Testing
### Manual Testing
I've called these endpoints with CURL and have confirmed their expected response body.

### Automated Testing
none added
