### PR TITLE
Adding custom verb for projects to cluster-owner for updating PSAs

### DIFF
--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -111,9 +111,7 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 				}
 				return values
 			},
-			Enabled: func() bool {
-				return features.MCM.Enabled() || features.EmbeddedClusterAPI.Enabled()
-			},
+			Enabled: func() bool { return true },
 		},
 		{
 			ReleaseNamespace: "rancher-operator-system",

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -148,6 +148,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("cluster.x-k8s.io").resources("machines").verbs("*").
 		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("*").
 		addRule().apiGroups("rke-machine.cattle.io").resources("*").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("projects").verbs("updatepsa").
 		addRule().apiGroups().nonResourceURLs("*").verbs("*")
 
 	rb.addRoleTemplate("Cluster Member", "cluster-member", "cluster", false, false, false).


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/39365

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 We need to be able to know who should be able to edit PSA-related labels on projects and namespaces


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Any user that has the custom verb, updatepsa, on projects will be able to make edits to the PSA-specific labels (cluster-owner and above)
In order for the webhook to validate those requests, the webhook will need to run on all downstream clusters. This PR also has a commit to enable that.


 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Verify that permission for the new custom verb is present for cluster-owner.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
The enforcement of this policy is done in the webhook, automated testing has been added there

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
In order to test this fully, there will be other changes that need to be in place.

webhook admission handlers--Those changes are in https://github.com/rancher/webhook/pull/155
webhook running on all downstream clusters--This will also require an update to the webhook chart which will be done in: https://github.com/rancher/webhook/pull/155 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->