### PR TITLE
backport kubectl-websocket-fix

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -2642,7 +2642,7 @@ def create_connection(url, subprotocols):
         url=url,
         sslopt={"cert_reqs": ssl.CERT_NONE},
         subprotocols=subprotocols,
-        timeout=10,
+        timeout=20,
         cookie="R_SESS=" + USER_TOKEN
     )
     assert ws.connected, "failed to build the websocket"


### PR DESCRIPTION
Backport PR for failing kubectl websocket test. 
Reference - https://github.com/rancher/rancher/pull/39455