### PR TITLE
Update references to new 2.6 UI branches

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -156,7 +156,7 @@ var (
 	UIDashboardPath = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
 
 	// Depending on ui-offline-preferred, use this version of the dashboard instead of the one contained in Rancher Manager
-	UIDashboardIndex = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/release-2.6.9/index.html")
+	UIDashboardIndex = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/release-2.6/index.html")
 
 	// Depending on ui-offline-preferred and if a Harvester Cluster does not contain it's own Harvester plugin, use this version of the plugin instead
 	UIDashboardHarvesterLegacyPlugin = NewSetting("ui-dashboard-harvester-legacy-plugin", "https://releases.rancher.com/harvester-ui/plugin/harvester-1.0.3-head/harvester-1.0.3-head.umd.min.js")
@@ -171,7 +171,7 @@ var (
 	UIFeedBackForm = NewSetting("ui-feedback-form", "")
 
 	// Depending on ui-offline-preferred, use this version of the old ember UI instead of the one contained in Rancher Manager
-	UIIndex = NewSetting("ui-index", "https://releases.rancher.com/ui/release-2.6.9/index.html")
+	UIIndex = NewSetting("ui-index", "https://releases.rancher.com/ui/release-2.6/index.html")
 
 	// Use a url address to send new 'File an Issue' reports instead of sending users to the Github issues page
 	UIIssues = NewSetting("ui-issues", "")


### PR DESCRIPTION
## Problem
- `rancher/dashboard` and `rancher/ui` have both now branched for generic 2.6 work
 
## Solution
- This change ensures the `rancher/rancher` 2.6 branch points to the correct builds
- These builds are used (when settings are default and the version ends in `-head`) as an alternative to the build embedded in to Rancher)
 
## Engineering Testing
### Manual Testing
- Updated the settings in an existing rancher instance with the new values and ensured both UIs load correctly