### PR TITLE
[2.7 Forwardport] [HELM] Bump chart apiVersion as it is not Helm 2 compatible

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: rancher
 description: Install Rancher Server to manage Kubernetes clusters across providers.
 version: %VERSION%


### PR DESCRIPTION
Forwardports https://github.com/rancher/rancher/pull/36838

(cherry picked from commit 713da95c2f6a550dd4684fd16ae79decf561730a)