### PR TITLE
[2.6] Avoid printing spammy logs when a Kubernetes version does not have legacy system tools available for install

### DIFF
--- a/pkg/catalog/manager/manager.go
+++ b/pkg/catalog/manager/manager.go
@@ -22,6 +22,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// IncompatibleTemplateVersionErr is returned when there's no valid template version for the current Kubernetes cluster
+type IncompatibleTemplateVersionErr error
+
 type Manager struct {
 	catalogClient         v3.CatalogInterface
 	CatalogLister         v3.CatalogLister
@@ -237,7 +240,7 @@ func (m *Manager) ValidateKubeVersion(template *v3.CatalogTemplateVersion, clust
 		return err
 	}
 	if !constraint(k8sVersion) {
-		return fmt.Errorf("incompatible kubernetes version [%s] for template [%s]", k8sVersion.String(), template.Name)
+		return IncompatibleTemplateVersionErr(fmt.Errorf("incompatible kubernetes version [%s] for template [%s]", k8sVersion.String(), template.Name))
 	}
 	return nil
 }
@@ -280,7 +283,7 @@ func (m *Manager) ValidateRancherVersion(template *v3.CatalogTemplateVersion, cu
 		return err
 	}
 	if !constraint(rancherVersion) {
-		return fmt.Errorf("incompatible rancher version [%s] for template [%s]", serverVersion, template.Name)
+		return IncompatibleTemplateVersionErr(fmt.Errorf("incompatible rancher version [%s] for template [%s]", serverVersion, template.Name))
 	}
 	return nil
 }
@@ -315,7 +318,7 @@ func (m *Manager) LatestAvailableTemplateVersion(template *v3.CatalogTemplate, c
 		}
 	}
 
-	return nil, errors.Errorf("template %s incompatible with rancher version or cluster's [%s] kubernetes version", template.Name, clusterName)
+	return nil, IncompatibleTemplateVersionErr(errors.Errorf("template %s incompatible with rancher version or cluster's [%s] kubernetes version", template.Name, clusterName))
 }
 
 func (m *Manager) GetSystemAppCatalogID(templateVersionID, clusterName string) (string, error) {

--- a/pkg/controllers/managementuserlegacy/systemimage/systemimage.go
+++ b/pkg/controllers/managementuserlegacy/systemimage/systemimage.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"github.com/rancher/rancher/pkg/catalog/manager"
 	cutils "github.com/rancher/rancher/pkg/catalog/utils"
 	alerting "github.com/rancher/rancher/pkg/controllers/managementuserlegacy/alert/deployer"
 	logging "github.com/rancher/rancher/pkg/controllers/managementuserlegacy/logging/deployer"
@@ -73,6 +74,11 @@ func (s *Syncer) Sync() error {
 		oldVersion := versionMap[k]
 		newVersion, err := v.Upgrade(oldVersion)
 		if err != nil {
+			_, ok := err.(manager.IncompatibleTemplateVersionErr)
+			if ok {
+				// there's no valid version to update to, so don't update the versionMap with this systemService
+				continue
+			}
 			return errors.Wrapf(err, "upgrade cluster %s system service %s failed", s.clusterName, k)
 		}
 		if oldVersion != newVersion {


### PR DESCRIPTION
Related Issue: https://github.com/rancher/rancher/issues/37039