### PR TITLE
[chart] Do not apply manifests or blocks if they reference PSP's in K8s v1.25

### DIFF
--- a/chart/templates/post-delete-hook-cluster-role.yaml
+++ b/chart/templates/post-delete-hook-cluster-role.yaml
@@ -30,9 +30,11 @@ rules:
   - apiGroups: [ "admissionregistration.k8s.io" ]
     resources: [ "validatingwebhookconfigurations", "mutatingwebhookconfigurations" ]
     verbs: [ "get", "list", "delete" ]
+  {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
   - apiGroups: [ "policy" ]
     resources: [ "podsecuritypolicies" ]
     verbs: [ "use", "delete", "create" ]
+  {{- end }}
   - apiGroups: [ "networking.k8s.io" ]
     resources: [ "ingresses" ]
     verbs: [ "delete" ]

--- a/chart/templates/post-delete-hook-psp.yaml
+++ b/chart/templates/post-delete-hook-psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -30,3 +31,4 @@ spec:
   volumes:
     - 'secret'
     - 'configMap'
+{{- end }}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39734
Part of the epic https://github.com/rancher/rancher/issues/38701
 
## Problem
1. Currently, the chart deploys one PSP resource, which Kubernetes v1.25 will not support.
2. There is also a cluster role created that has a rule that references PSP's - not needed anymore for v1.25.
 
## Solution
For the two cases above, I add a condition that checks the underlying cluster's version. If it's v1.25 or newer, do not render the whole resource (or a relevant YAML block). 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
I tried deploying the chart without these changes onto a v1.25 cluster, and the release deployed, although there were errors on deletion of the release.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->