### PR TITLE
Fix installation with certain types of DNS

### DIFF
--- a/chart/templates/issuer-letsEncrypt.yaml
+++ b/chart/templates/issuer-letsEncrypt.yaml
@@ -18,9 +18,9 @@ metadata:
 spec:
   acme:
     {{- if eq .Values.letsEncrypt.environment "production" }}
-    server: https://acme-v02.api.letsencrypt.org/directory
+    server: https://acme-v02.api.letsencrypt.org./directory
     {{- else }}
-    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    server: https://acme-staging-v02.api.letsencrypt.org./directory
     {{- end }}
     email: {{ .Values.letsEncrypt.email }}
     privateKeySecretRef:


### PR DESCRIPTION
## Issue: https://github.com/cert-manager/cert-manager/issues/3394
 
## Problem
If I have a DHCP server which forwards example.com as a search domain then I have a wildcard CNAME record (`*`), cert-manager will fail to resolve https://acme-staging-v02.api.letsencrypt.org/directory correctly.

 ## Solution
This can be fixed by adding a `.` at the end of `acme-staging-v02.api.letsencrypt.org`
 
## Testing
ubuntu 22.04  / v1.24.8+rke2r1 / rancher 2.7.0

## Engineering Testing
### Manual Testing
Before:
```yaml
kubectl get issuers.cert-manager.io -n cattle-system -o wide
NAME      READY   STATUS                                                                                                                                                                             AGE
rancher   False   Failed to register ACME account: Get "https://acme-v02.api.letsencrypt.org/directory": x509: certificate is valid for example.com, *.example.com, not acme-v02.api.letsencrypt.org   24m
```
After:
```yaml
kubectl get issuers.cert-manager.io -n cattle-system -o wide
NAME      READY   STATUS                                                 AGE
rancher   True    The ACME account was registered with the ACME server   26m
```

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
1. Other versions of rancher
2. Other configurations of rancher's letsEncrypt integration
3. Must be tested with a server that uses a transparent proxy
 
### Regressions Considerations
Might break installations that depend on this kind of behaviour (ie. transparent proxies)