### PR TITLE
Do not register podsecuritypolicy controllers for clusters >= v1.25

### DIFF
--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/clusterrole.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/clusterrole.go
@@ -2,6 +2,8 @@ package podsecuritypolicy
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	v12 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
@@ -14,16 +16,20 @@ import (
 
 func RegisterClusterRole(ctx context.Context, context *config.UserContext) {
 	c := clusterRoleHandler{
-		psptLister:   context.Management.Management.PodSecurityPolicyTemplates("").Controller().Lister(),
-		clusterRoles: context.RBAC.ClusterRoles(""),
+		psptLister:    context.Management.Management.PodSecurityPolicyTemplates("").Controller().Lister(),
+		clusterRoles:  context.RBAC.ClusterRoles(""),
+		clusterLister: context.Management.Management.Clusters("").Controller().Lister(),
+		clusterName:   context.ClusterName,
 	}
 
 	context.RBAC.ClusterRoles("").AddHandler(ctx, "cluster-role-sync", c.sync)
 }
 
 type clusterRoleHandler struct {
-	psptLister   v3.PodSecurityPolicyTemplateLister
-	clusterRoles v12.ClusterRoleInterface
+	psptLister    v3.PodSecurityPolicyTemplateLister
+	clusterRoles  v12.ClusterRoleInterface
+	clusterLister v3.ClusterLister
+	clusterName   string
 }
 
 // sync checks if a clusterRole has a parent pspt based on the annotation and if that parent no longer
@@ -32,6 +38,15 @@ func (c *clusterRoleHandler) sync(key string, obj *v1.ClusterRole) (runtime.Obje
 	if obj == nil || obj.DeletionTimestamp != nil {
 		return obj, nil
 	}
+
+	err := checkClusterVersion(c.clusterName, c.clusterLister)
+	if err != nil {
+		if errors.Is(err, errVersionIncompatible) {
+			return obj, nil
+		}
+		return obj, fmt.Errorf(clusterVersionCheckErrorString, err)
+	}
+
 	if templateID, ok := obj.Annotations[podSecurityPolicyTemplateParentAnnotation]; ok {
 		_, err := c.psptLister.Get("", templateID)
 		if err != nil {

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/version.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/version.go
@@ -1,0 +1,28 @@
+package podsecuritypolicy
+
+import (
+	"errors"
+	"fmt"
+
+	mVersion "github.com/mcuadros/go-version"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+)
+
+var errVersionIncompatible = errors.New("podsecuritypolicies are not available in Kubernetes v1.25 and above")
+var clusterVersionCheckErrorString = "failed to check cluster version compatibility for podsecuritypolicy controllers: %v"
+
+// checkClusterVersion tries to fetch a cluster by name, extract its Kubernetes version,
+// and check if the version is less than v1.25.
+func checkClusterVersion(clusterName string, clusterLister v3.ClusterLister) error {
+	cluster, err := clusterLister.Get("", clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster [%s]: %w", clusterName, err)
+	}
+	if cluster.Status.Version == nil {
+		return fmt.Errorf("cannot validate Kubernetes version for podsecuritypolicy capability: cluster [%s] status version is not available yet", clusterName)
+	}
+	if mVersion.Compare(cluster.Status.Version.String(), "v1.25", ">=") {
+		return errVersionIncompatible
+	}
+	return nil
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39733
 
## Problem
Rancher may attempt to register various controllers (https://github.com/rancher/rancher/tree/release/v2.7/pkg/controllers/managementuser/rbac/podsecuritypolicy) for a downstream cluster that work with resources (namespaces, cluster roles, and others) for PSP management. If the downstream cluster's version is v1.25 or later, Rancher will have constant controller errors when doing any operation pertaining to PSP resources, since the K8s API server will throw an error when it is asked to fetch an unknown resource. And PSP's are not resources known to K8s API as of v1.25.

There are two conditions which currently allow controllers to be registered:
1. If the downstream cluster has a project that has PSP's configured. Specifically, if there exists a PSPProjectTemplateBinding that has `cluster:project` as its target.
2. If the downstream cluster spec object has some value for `DefaultPodSecurityPolicyTemplateName`.
 
## Solution
1. Do not register the PSP-related controllers, if the downstream cluster version is v1.25 or later.
2. Exit from the controller's sync methods early, if the controllers still run. This happens if a 1.24 cluster with PSPs enabled got upgraded to 1.25 (with PSPs disabled). The controllers would still run, they do not get de-registered. We must not let them run the main logic and exit early. However, if the Rancher pods are restarted, then the controllers are gone, and need to be re-registered. But at that point, the registration function detects a v1.25 cluster and refuses to register the controllers.

I do log the K8s version incompatibly error for a failed controller registration attempt. But I decided not to log the incompatibility error for controller sync attempts, because:
1. This will flood the logs unnecessarily.
2. The sync methods would not run at all once Rancher pods are restarted, because the controllers would not even be registered then.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Ensure the following configurations produce no errors on downstream cluster provisioning. A downstream v1.24 cluster always has PSP's enabled:

local 1.25 downstream 1.25
local 1.25 downstream 1.24
local 1.24 downstream 1.25
local 1.24 downstream 1.24

#### Other notes
On local 1.25 (did not try this on 1.2.4), I have the following observations.
When I create a 1.24 with PSPs, the cluster compatibility check runs and succeeds.
When I upgrade the cluster to 1.25, the cluster compatibility check does not run.

When I create a 1.24 with PSPs and upgrade it to 1.25 without them, and restart Rancher pods,
the cluster compatibility check runs and fails before controller registration.
It does not run for a new 1.25, nor when I restart Rancher pods.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->