### PR TITLE
[v2.7] Fix timeout issue with validate_cluster_state 

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -1427,14 +1427,14 @@ def validate_cluster_state(client, cluster,
                            nodes_not_in_active_state=[],
                            timeout=MACHINE_TIMEOUT):
     start_time = time.time()
-    timeout = start_time + timeout
     if check_intermediate_state:
         cluster = wait_for_condition(
             client, cluster,
             lambda x: x.state == intermediate_state,
             lambda x: 'State is: ' + x.state,
             timeout=timeout)
-        assert cluster.state == intermediate_state
+        if intermediate_state != "updating":
+            assert cluster.state == intermediate_state
     cluster = wait_for_condition(
         client, cluster,
         lambda x: x.state == "active",

--- a/tests/validation/tests/v3_api/test_node_label.py
+++ b/tests/validation/tests/v3_api/test_node_label.py
@@ -433,7 +433,8 @@ def test_node_label_custom_add_edit_addnode():
     # cluster will go into updating state
     cluster = validate_cluster_state(client, cluster, True,
                                      intermediate_state="updating",
-                                     nodes_not_in_active_state=[])
+                                     nodes_not_in_active_state=[],
+                                     timeout=600)
 
     node = client.reload(node)
     # Label should be added
@@ -700,7 +701,8 @@ def test_node_label_node_template_delete_api():
     # cluster will go into updating state
     cluster = validate_cluster_state(client, cluster, True,
                                      intermediate_state="updating",
-                                     nodes_not_in_active_state=[])
+                                     nodes_not_in_active_state=[],
+                                     timeout=600)
 
     node = client.reload(node)
     # label should be deleted
@@ -759,9 +761,9 @@ def test_node_label_custom_edit():
     # cluster will go into updating state
     cluster = validate_cluster_state(client, cluster, True,
                                      intermediate_state="updating",
-                                     nodes_not_in_active_state=[])
+                                     nodes_not_in_active_state=[],
+                                     timeout=600)
     node = client.reload(node)
-
     validate_label_set_on_node(client, node, test_label, new_value)
     cluster_custom["label_value"] = new_value
 
@@ -828,7 +830,8 @@ def test_node_label_custom_delete():
     # cluster will go into updating state
     cluster = validate_cluster_state(client, cluster, True,
                                      intermediate_state="updating",
-                                     nodes_not_in_active_state=[])
+                                     nodes_not_in_active_state=[],
+                                     timeout=600)
 
     node = client.reload(node)
     # label should be deleted


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. --> There was a bug with how the timeout in validate_cluster_state was being set causing an absurdly long timeout. Also there is a chance that an updating state happens after it is checked with this function, so a conditional was added to not fail if the updating state is missed.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. --> Removed `timeout = start_time + timeout` since it's just adding to be a super long timeout.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. --> Jenkins runs

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->