### PR TITLE
Add CAPI predicates to ControlPlane

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,10 @@ module github.com/rancher/rancher
 go 1.19
 
 replace (
+	github.com/rancher/wrangler => /home/jfh/Documents/work/rancher/wrangler
+)
+
+replace (
 	github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible // oras dep requires a replace is set
 	github.com/docker/docker => github.com/docker/docker v20.10.9+incompatible // oras dep requires a replace is set
 

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,6 @@ module github.com/rancher/rancher
 go 1.19
 
 replace (
-	github.com/rancher/wrangler => /home/jfh/Documents/work/rancher/wrangler
-)
-
-replace (
 	github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible // oras dep requires a replace is set
 	github.com/docker/docker => github.com/docker/docker v20.10.9+incompatible // oras dep requires a replace is set
 
@@ -123,7 +119,7 @@ require (
 	github.com/rancher/rke v1.4.3-rc3
 	github.com/rancher/steve v0.0.0-20230103180000-f4338dd8396f
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
-	github.com/rancher/wrangler v1.0.1-0.20221202234327-1cafffeaa9a1
+	github.com/rancher/wrangler v1.0.1-0.20230103171004-6ebfa7ca12ad
 	github.com/robfig/cron v1.1.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1381,8 +1381,8 @@ github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSe
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.8.10/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
 github.com/rancher/wrangler v0.8.11-0.20220120160420-18c996a8e956/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
-github.com/rancher/wrangler v1.0.1-0.20221202234327-1cafffeaa9a1 h1:Rnrc4yx1Pkqoto7/n6GT68tk5up/SLuan1uSYXACpoM=
-github.com/rancher/wrangler v1.0.1-0.20221202234327-1cafffeaa9a1/go.mod h1:+GbeNyk8mbdOdMSdLIqvz+0JQ/2PhIb4ufMOcmHLIJQ=
+github.com/rancher/wrangler v1.0.1-0.20230103171004-6ebfa7ca12ad h1:J64krXqSSRJjFgNmgDC8V0KwrjZRHpwekpVXcQvn7qs=
+github.com/rancher/wrangler v1.0.1-0.20230103171004-6ebfa7ca12ad/go.mod h1:+GbeNyk8mbdOdMSdLIqvz+0JQ/2PhIb4ufMOcmHLIJQ=
 github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e/go.mod h1:2lcWR98q8HU3U4mVETnXc8quNG0uXxrt8vKd6cAa/30=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/rancher/gke-operator v1.1.5
 	github.com/rancher/norman v0.0.0-20221205184727-32ef2e185b99
 	github.com/rancher/rke v1.4.3-rc3
-	github.com/rancher/wrangler v1.0.1-0.20221202234327-1cafffeaa9a1
+	github.com/rancher/wrangler v1.0.1-0.20230103171004-6ebfa7ca12ad
 	github.com/sirupsen/logrus v1.8.1
 	k8s.io/api v0.25.4
 	k8s.io/apimachinery v0.25.4

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -615,8 +615,8 @@ github.com/rancher/rke v1.4.3-rc3 h1:yY1WHNr53SHxhqt4Mez9Vn0MhxQvqumJUB57ziKxPkw
 github.com/rancher/rke v1.4.3-rc3/go.mod h1:0s8+XfiyC9Ff3KLaQ4Z5mDNI+taSb/hma13xOpW6slg=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.8.10/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
-github.com/rancher/wrangler v1.0.1-0.20221202234327-1cafffeaa9a1 h1:Rnrc4yx1Pkqoto7/n6GT68tk5up/SLuan1uSYXACpoM=
-github.com/rancher/wrangler v1.0.1-0.20221202234327-1cafffeaa9a1/go.mod h1:+GbeNyk8mbdOdMSdLIqvz+0JQ/2PhIb4ufMOcmHLIJQ=
+github.com/rancher/wrangler v1.0.1-0.20230103171004-6ebfa7ca12ad h1:J64krXqSSRJjFgNmgDC8V0KwrjZRHpwekpVXcQvn7qs=
+github.com/rancher/wrangler v1.0.1-0.20230103171004-6ebfa7ca12ad/go.mod h1:+GbeNyk8mbdOdMSdLIqvz+0JQ/2PhIb4ufMOcmHLIJQ=
 github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e/go.mod h1:2lcWR98q8HU3U4mVETnXc8quNG0uXxrt8vKd6cAa/30=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/apis/rke.cattle.io/v1/encryptionkeyrotation.go
+++ b/pkg/apis/rke.cattle.io/v1/encryptionkeyrotation.go
@@ -14,5 +14,6 @@ const (
 )
 
 type RotateEncryptionKeys struct {
-	Generation int64 `json:"generation,omitempty"`
+	Generation         int64  `json:"generation,omitempty"`
+	ControlPlaneLeader string `json:"controlPlaneLeader,omitempty"`
 }

--- a/pkg/controllers/provisioningv2/rke2/common.go
+++ b/pkg/controllers/provisioningv2/rke2/common.go
@@ -428,7 +428,7 @@ func GetCAPIClusterFromLabel(obj runtime.Object, cache capicontrollers.ClusterCa
 	return nil, fmt.Errorf("%s label not present on %s: %s/%s", capi.ClusterLabelName, obj.GetObjectKind().GroupVersionKind().Kind, data.String("metadata", "namespace"), data.String("metadata", "name"))
 }
 
-// GetOwnerCAPICluster takes an obj T and will attempt to find the capi cluster owner reference.
+// GetOwnerCAPICluster takes an obj and will attempt to find the capi cluster owner reference.
 // If the object is nil, it cannot access to object or type metas, the owner reference Kind or APIVersion do not match,
 // or the object could not be found, it returns an error.
 // If the owner reference exists and is valid, it will return the owning capi cluster object.
@@ -440,7 +440,7 @@ func GetOwnerCAPICluster(obj runtime.Object, cache capicontrollers.ClusterCache)
 	return cache.Get(namespace, ref.Name)
 }
 
-// GetOwnerCAPIMachine takes an obj T and will attempt to find the capi machine owner reference.
+// GetOwnerCAPIMachine takes an obj and will attempt to find the capi machine owner reference.
 // If the object is nil, it cannot access to object or type metas, the owner reference Kind or APIVersion do not match,
 // or the object could not be found, it returns an error.
 // If the owner reference exists and is valid, it will return the owning capi machine object.

--- a/pkg/controllers/provisioningv2/rke2/planner/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/planner/controller.go
@@ -51,37 +51,46 @@ func Register(ctx context.Context, clients *wrangler.Context, planner *planner.P
 	}, clients.RKE.RKEControlPlane(), clients.Core.Secret(), clients.CAPI.Machine())
 }
 
-func (h *handler) OnChange(cluster *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus) (rkev1.RKEControlPlaneStatus, error) {
-	logrus.Debugf("[planner] rkecluster %s/%s: handler OnChange called", cluster.Namespace, cluster.Name)
-	if !cluster.DeletionTimestamp.IsZero() {
+func (h *handler) OnChange(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus) (rkev1.RKEControlPlaneStatus, error) {
+	logrus.Debugf("[planner] rkecluster %s/%s: handler OnChange called", cp.Namespace, cp.Name)
+	if !cp.DeletionTimestamp.IsZero() {
 		return status, nil
 	}
 
-	status.ObservedGeneration = cluster.Generation
+	status.ObservedGeneration = cp.Generation
 
-	logrus.Debugf("[planner] rkecluster %s/%s: calling planner process", cluster.Namespace, cluster.Name)
-	err := h.planner.Process(cluster)
-	var errWaiting planner.ErrWaiting
-	if errors.As(err, &errWaiting) {
-		logrus.Infof("[planner] rkecluster %s/%s: waiting: %v", cluster.Namespace, cluster.Name, err)
-		rke2.Ready.SetStatus(&status, "Unknown")
-		rke2.Ready.Message(&status, err.Error())
-		rke2.Ready.Reason(&status, "Waiting")
-		return status, nil
-	}
-	if !errors.Is(err, generic.ErrSkip) {
-		rke2.Ready.SetError(&status, "", err)
-		if err != nil {
-			// don't return error because the controller will reset the status and then not assign the error
-			// because we don't register this handler with an associated condition. This is pretty much a bug in the
-			// framework but it's too impactful to change right before 2.6.0 so we should consider changing this later.
-			// If you are reading this years later we'll just assume we decided not to change the framework.
-			logrus.Errorf("[planner] rkecluster %s/%s: error encountered during plan processing was %v", cluster.Namespace, cluster.Name, err)
-			h.controlPlanes.EnqueueAfter(cluster.Namespace, cluster.Name, 5*time.Second)
+	logrus.Debugf("[planner] rkecluster %s/%s: calling planner process", cp.Namespace, cp.Name)
+	status, err := h.planner.Process(cp, status)
+	if err != nil {
+		// if waiting for a plan to apply, if this is a new plan, update status, otherwise skip update and reenqueue
+		if planner.IsErrWaiting(err) {
+			if rke2.Reconciled.GetMessage(&status) == err.Error() && rke2.Reconciled.GetStatus(&status) == "Unknown" && rke2.Reconciled.GetReason(&status) == "Waiting" {
+				h.controlPlanes.EnqueueAfter(cp.Namespace, cp.Name, 5*time.Second)
+			} else {
+				rke2.Reconciled.SetStatus(&status, "Unknown")
+				rke2.Reconciled.Message(&status, err.Error())
+				rke2.Reconciled.Reason(&status, "Waiting")
+				err = nil
+			}
+		} else if !errors.Is(err, generic.ErrSkip) {
+			logrus.Errorf("[planner] rkecluster %s/%s: error encountered during plan processing was %v", cp.Namespace, cp.Name, err)
+			rke2.Reconciled.SetError(&status, "", err)
+			// if error is generic.ErrSkip, no control plane updates will be enqueued
+		} else {
+			h.controlPlanes.EnqueueAfter(cp.Namespace, cp.Name, 5*time.Second)
 		}
 	} else {
-		logrus.Debugf("[planner] rkecluster %s/%s: objects changed, waiting for cache sync before finishing reconciliation", cluster.Namespace, cluster.Name)
+		logrus.Debugf("[planner] rkecluster %s/%s: reconciliation complete", cp.Namespace, cp.Name)
+		rke2.Provisioned.True(&status)
+		rke2.Provisioned.Message(&status, "")
+		rke2.Provisioned.Reason(&status, "")
+		rke2.Ready.True(&status)
+		rke2.Ready.Message(&status, "")
+		rke2.Ready.Reason(&status, "")
+		//status.AppliedSpec = cp.Spec
+		rke2.Reconciled.True(&status)
+		rke2.Reconciled.Message(&status, "")
+		rke2.Reconciled.Reason(&status, "")
 	}
-	logrus.Debugf("[planner] rkecluster %s/%s: reconciliation complete", cluster.Namespace, cluster.Name)
 	return status, nil
 }

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -288,7 +288,7 @@ func (h *handler) OnRancherClusterChange(obj *rancherv1.Cluster, status rancherv
 		if status, err = h.setProvisionedStatusFromMachineInfra(obj, status, rkeCP); err != nil && !apierror.IsNotFound(err) && !errors.Is(err, generic.ErrSkip) {
 			return nil, status, err
 		} else if err == nil {
-			if status, err = h.updateClusterProvisioningStatus(obj, status, rkeCP, rke2.Updated, rke2.Ready); err != nil && !apierror.IsNotFound(err) {
+			if status, err = h.updateClusterProvisioningStatus(obj, status, rkeCP, rke2.Updated, rke2.Reconciled); err != nil && !apierror.IsNotFound(err) {
 				return nil, status, err
 			}
 		}

--- a/pkg/controllers/provisioningv2/rke2/provisioninglog/provisioninglog.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioninglog/provisioninglog.go
@@ -79,17 +79,11 @@ func appendLog(error bool, oldLog, log string) string {
 }
 
 func (h *handler) recordMessage(provCluster *provv1.Cluster, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	msg := rke2.Provisioned.GetMessage(provCluster)
-	error := rke2.Provisioned.IsFalse(provCluster)
-	done := rke2.Provisioned.IsTrue(provCluster)
+	msg := rke2.Updated.GetMessage(provCluster)
+	failure := rke2.Updated.IsFalse(provCluster)
+	success := rke2.Updated.IsTrue(provCluster)
 
-	if done && msg == "" {
-		done = rke2.Updated.IsTrue(provCluster)
-		msg = rke2.Updated.GetMessage(provCluster)
-		error = rke2.Updated.IsFalse(provCluster)
-	}
-
-	if done && msg == "" && provCluster.Status.Ready {
+	if success && msg == "" && provCluster.Status.Ready {
 		msg = "provisioning done"
 	}
 
@@ -107,7 +101,7 @@ func (h *handler) recordMessage(provCluster *provv1.Cluster, cm *corev1.ConfigMa
 		cm.Data = map[string]string{}
 	}
 
-	cm.Data["log"] = appendLog(error, cm.Data["log"], msg)
+	cm.Data["log"] = appendLog(failure, cm.Data["log"], msg)
 	cm.Data["last"] = msg
 	return h.configMaps.Update(cm)
 }

--- a/pkg/controllers/provisioningv2/rke2/rkecontrolplane/controlplane.go
+++ b/pkg/controllers/provisioningv2/rke2/rkecontrolplane/controlplane.go
@@ -70,16 +70,14 @@ func (h *handler) clusterWatch(_, _ string, obj runtime.Object) ([]relatedresour
 	}, nil
 }
 
-func (h *handler) OnChange(obj *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus) (rkev1.RKEControlPlaneStatus, error) {
-	status.ObservedGeneration = obj.Generation
-	cluster, err := h.clusterCache.Get(obj.Spec.ManagementClusterName)
+func (h *handler) OnChange(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus) (rkev1.RKEControlPlaneStatus, error) {
+	status.ObservedGeneration = cp.Generation
+	cluster, err := h.clusterCache.Get(cp.Spec.ManagementClusterName)
 	if err != nil {
-		h.rkeControlPlaneController.EnqueueAfter(obj.Namespace, obj.Name, 2*time.Second)
+		h.rkeControlPlaneController.EnqueueAfter(cp.Namespace, cp.Name, 2*time.Second)
 		return status, nil
 	}
 
-	status.Ready = rke2.Ready.IsTrue(cluster)
-	status.Initialized = rke2.Ready.IsTrue(cluster)
 	status.AgentConnected = clusterconnected.Connected.IsTrue(cluster)
 	return status, nil
 }

--- a/pkg/provisioningv2/rke2/planner/certificaterotation.go
+++ b/pkg/provisioningv2/rke2/planner/certificaterotation.go
@@ -44,12 +44,12 @@ func (p *Planner) rotateCertificates(cp *rkev1.RKEControlPlane, status rkev1.RKE
 // shouldRotate `true` if the cluster is ready and the generation is stale
 func shouldRotate(cp *rkev1.RKEControlPlane) bool {
 	// The controlplane must be initialized before we rotate anything
-	if cp.Status.Initialized != true {
+	if !cp.Status.Initialized {
 		return false
 	}
 
 	// The controlplane must be ready before we rotate anything
-	if !cp.Status.Ready != true {
+	if !cp.Status.Ready {
 		return false
 	}
 

--- a/pkg/provisioningv2/rke2/planner/certificaterotation.go
+++ b/pkg/provisioningv2/rke2/planner/certificaterotation.go
@@ -8,43 +8,37 @@ import (
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2"
-	rkecontrollers "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
-	"github.com/rancher/rancher/pkg/wrangler"
 )
 
-type certificateRotation struct {
-	rkeControlPlanes rkecontrollers.RKEControlPlaneClient
-	store            *PlanStore
-}
-
-func newCertificateRotation(clients *wrangler.Context, store *PlanStore) *certificateRotation {
-	return &certificateRotation{
-		rkeControlPlanes: clients.RKE.RKEControlPlane(),
-		store:            store,
+// rotateCertificates checks if there is a need to rotate any certificates and updates the plan accordingly.
+func (p *Planner) rotateCertificates(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, clusterPlan *plan.Plan) (rkev1.RKEControlPlaneStatus, error) {
+	if !shouldRotate(cp) {
+		return status, nil
 	}
-}
 
-// RotateCertificates checks if there is a need to rotate any certificates and updates the plan accordingly.
-func (r *certificateRotation) RotateCertificates(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan) error {
-	if !shouldRotate(controlPlane) {
-		return nil
+	if err := p.pauseCAPICluster(cp, true); err != nil {
+		return status, err
 	}
 
 	for _, node := range collect(clusterPlan, anyRole) {
-		if !shouldRotateEntry(controlPlane.Spec.RotateCertificates, node) {
+		if !shouldRotateEntry(cp.Spec.RotateCertificates, node) {
 			continue
 		}
 
-		rotatePlan := rotateCertificatesPlan(controlPlane, controlPlane.Spec.RotateCertificates, node)
-		err := assignAndCheckPlan(r.store, fmt.Sprintf("[%s] certificate rotation", node.Machine.Name), node, rotatePlan, 0, 0)
+		rotatePlan := rotateCertificatesPlan(cp, cp.Spec.RotateCertificates, node)
+		err := assignAndCheckPlan(p.store, fmt.Sprintf("[%s] certificate rotation", node.Machine.Name), node, rotatePlan, 0, 0)
 		if err != nil {
-			return err
+			return status, err
 		}
 	}
 
-	controlPlane.Status.CertificateRotationGeneration = controlPlane.Spec.RotateCertificates.Generation
-	_, err := r.rkeControlPlanes.UpdateStatus(controlPlane)
-	return err
+	cp.Status.CertificateRotationGeneration = cp.Spec.RotateCertificates.Generation
+
+	if err := p.pauseCAPICluster(cp, false); err != nil {
+		return status, err
+	}
+
+	return status, ErrWaiting("refreshing certificate rotation state")
 }
 
 // shouldRotate `true` if the cluster is ready and the generation is stale
@@ -54,10 +48,17 @@ func shouldRotate(cp *rkev1.RKEControlPlane) bool {
 		return false
 	}
 
+	// The controlplane must be ready before we rotate anything
+	if !cp.Status.Ready != true {
+		return false
+	}
+
 	// if a spec is not defined there is nothing to do
 	if cp.Spec.RotateCertificates == nil {
 		return false
 	}
+
+	// todo(jhyde): if we are currently rotating certificates, we must complete it
 
 	// if this generation has already been applied there is no work
 	return cp.Status.CertificateRotationGeneration != cp.Spec.RotateCertificates.Generation

--- a/pkg/provisioningv2/rke2/planner/encryptionkeyrotation.go
+++ b/pkg/provisioningv2/rke2/planner/encryptionkeyrotation.go
@@ -12,7 +12,6 @@ import (
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2"
-	"github.com/rancher/wrangler/pkg/generic"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
@@ -28,8 +27,6 @@ const (
 
 	encryptionKeyRotationSecretsEncryptApplyCommand  = "secrets-encrypt-apply"
 	encryptionKeyRotationSecretsEncryptStatusCommand = "secrets-encrypt-status"
-
-	encryptionKeyRotationLeaderAnnotation = "rke.cattle.io/encrypt-key-rotation-leader"
 
 	encryptionKeyRotationInstallRoot = "/var/lib/rancher"
 	encryptionKeyRotationBinPrefix   = "rancher_v2prov_encryption_key_rotation/bin"
@@ -126,101 +123,105 @@ echo "$targetGeneration" > "$generationFile"
 	encryptionKeyRotationEndpointEnv = "CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock"
 )
 
-func (p *Planner) setEncryptionKeyRotateState(controlPlane *rkev1.RKEControlPlane, status *rkev1.RotateEncryptionKeys, phase rkev1.RotateEncryptionKeysPhase) error {
-	if equality.Semantic.DeepEqual(controlPlane.Status.RotateEncryptionKeys, status) && equality.Semantic.DeepEqual(controlPlane.Status.RotateEncryptionKeysPhase, phase) {
-		return nil
+func (p *Planner) setEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus, rotateEncryptionKeys *rkev1.RotateEncryptionKeys, phase rkev1.RotateEncryptionKeysPhase) (rkev1.RKEControlPlaneStatus, error) {
+	if equality.Semantic.DeepEqual(status.RotateEncryptionKeys, status) && equality.Semantic.DeepEqual(status.RotateEncryptionKeysPhase, phase) {
+		return status, nil
 	}
-	controlPlane = controlPlane.DeepCopy()
-	controlPlane.Status.RotateEncryptionKeys = status
-	controlPlane.Status.RotateEncryptionKeysPhase = phase
-	_, err := p.rkeControlPlanes.UpdateStatus(controlPlane)
-	if err != nil {
-		return err
-	}
-	return ErrWaiting("refreshing encryption key rotation state")
+	status.RotateEncryptionKeys = rotateEncryptionKeys
+	status.RotateEncryptionKeysPhase = phase
+	return status, ErrWaiting("refreshing encryption key rotation state")
 }
 
-func (p *Planner) resetEncryptionKeyRotateState(controlPlane *rkev1.RKEControlPlane) error {
-	if controlPlane.Status.RotateEncryptionKeys == nil && controlPlane.Status.RotateEncryptionKeysPhase == "" {
-		return nil
+func (p *Planner) resetEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus) (rkev1.RKEControlPlaneStatus, error) {
+	if status.RotateEncryptionKeys == nil && status.RotateEncryptionKeysPhase == "" {
+		return status, nil
 	}
-	return p.setEncryptionKeyRotateState(controlPlane, nil, "")
+	return p.setEncryptionKeyRotateState(status, nil, "")
 }
 
 // rotateEncryptionKeys first verifies that the control plane is in a state where the next step can be derived. If encryption key rotation is required, the corresponding phase and status fields will be set.
 // The function is expected to be called multiple times throughout encryption key rotation, and will set the next corresponding phase based on previous output.
-func (p *Planner) rotateEncryptionKeys(cp *rkev1.RKEControlPlane, releaseData *model.Release, clusterPlan *plan.Plan) error {
+func (p *Planner) rotateEncryptionKeys(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, releaseData *model.Release, clusterPlan *plan.Plan) (rkev1.RKEControlPlaneStatus, error) {
 	if cp == nil || releaseData == nil || clusterPlan == nil {
-		return fmt.Errorf("cannot pass nil parameters to rotateEncryptionKeys")
+		return status, fmt.Errorf("cannot pass nil parameters to rotateEncryptionKeys")
 	}
 
 	if cp.Spec.RotateEncryptionKeys == nil {
-		return p.resetEncryptionKeyRotateState(cp)
+		return p.resetEncryptionKeyRotateState(status)
 	}
 
 	if supported, err := encryptionKeyRotationSupported(releaseData); err != nil {
-		return err
+		return status, err
 	} else if !supported {
 		logrus.Debugf("rkecluster %s/%s: marking encryption key rotation phase as failed as it was not supported by version: %s", cp.Namespace, cp.Name, cp.Spec.KubernetesVersion)
-		return p.setEncryptionKeyRotateState(cp, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseFailed)
+		return p.setEncryptionKeyRotateState(status, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseFailed)
 	}
 
 	if !canRotateEncryptionKeys(cp) {
-		return nil
+		return status, nil
 	}
 
 	if shouldRestartEncryptionKeyRotation(cp) {
 		logrus.Debugf("[planner] rkecluster %s/%s: starting/restarting encryption key rotation", cp.Namespace, cp.Name)
-		return p.setEncryptionKeyRotateState(cp, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePrepare)
+		return p.setEncryptionKeyRotateState(status, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePrepare)
 	}
 
-	leader, err := p.encryptionKeyRotationElectLeader(cp, clusterPlan)
+	if err := p.pauseCAPICluster(cp, true); err != nil {
+		return status, err
+	}
+
+	leader, status, err := p.encryptionKeyRotationElectLeader(cp, status, clusterPlan)
 	if err != nil {
-		return err
+		return status, err
 	}
 
 	logrus.Debugf("[planner] rkecluster %s/%s: current encryption key rotation phase: [%s]", cp.Namespace, cp.Spec.ClusterName, cp.Status.RotateEncryptionKeysPhase)
 
 	switch cp.Status.RotateEncryptionKeysPhase {
 	case rkev1.RotateEncryptionKeysPhasePrepare:
-		err = p.encryptionKeyRotationLeaderPhaseReconcile(cp, leader)
+		status, err = p.encryptionKeyRotationLeaderPhaseReconcile(cp, status, leader)
 		if err != nil {
-			return err
+			return status, err
 		}
-		return p.setEncryptionKeyRotateState(cp, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePostPrepareRestart)
+		return p.setEncryptionKeyRotateState(status, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePostPrepareRestart)
 	case rkev1.RotateEncryptionKeysPhasePostPrepareRestart:
-		err = p.encryptionKeyRotationRestartNodes(cp, clusterPlan, leader)
+		status, err = p.encryptionKeyRotationRestartNodes(cp, status, clusterPlan, leader)
 		if err != nil {
-			return err
+			return status, err
 		}
-		return p.setEncryptionKeyRotateState(cp, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseRotate)
+		return p.setEncryptionKeyRotateState(status, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseRotate)
 	case rkev1.RotateEncryptionKeysPhaseRotate:
-		err = p.encryptionKeyRotationLeaderPhaseReconcile(cp, leader)
+		status, err = p.encryptionKeyRotationLeaderPhaseReconcile(cp, status, leader)
 		if err != nil {
-			return err
+			return status, err
 		}
-		return p.setEncryptionKeyRotateState(cp, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePostRotateRestart)
+		return p.setEncryptionKeyRotateState(status, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePostRotateRestart)
 	case rkev1.RotateEncryptionKeysPhasePostRotateRestart:
-		err = p.encryptionKeyRotationRestartNodes(cp, clusterPlan, leader)
+		status, err = p.encryptionKeyRotationRestartNodes(cp, status, clusterPlan, leader)
 		if err != nil {
-			return err
+			return status, err
 		}
-		return p.setEncryptionKeyRotateState(cp, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseReencrypt)
+		return p.setEncryptionKeyRotateState(status, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseReencrypt)
 	case rkev1.RotateEncryptionKeysPhaseReencrypt:
-		err = p.encryptionKeyRotationLeaderPhaseReconcile(cp, leader)
+		status, err = p.encryptionKeyRotationLeaderPhaseReconcile(cp, status, leader)
 		if err != nil {
-			return err
+			return status, err
 		}
-		return p.setEncryptionKeyRotateState(cp, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePostReencryptRestart)
+		return p.setEncryptionKeyRotateState(status, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhasePostReencryptRestart)
 	case rkev1.RotateEncryptionKeysPhasePostReencryptRestart:
-		err = p.encryptionKeyRotationRestartNodes(cp, clusterPlan, leader)
+		status, err = p.encryptionKeyRotationRestartNodes(cp, status, clusterPlan, leader)
 		if err != nil {
-			return err
+			return status, err
 		}
-		return p.setEncryptionKeyRotateState(cp, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseDone)
+
+		if err := p.pauseCAPICluster(cp, false); err != nil {
+			return status, err
+		}
+
+		return p.setEncryptionKeyRotateState(status, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseDone)
 	}
 
-	return fmt.Errorf("encountered unknown encryption key rotation phase: %s", cp.Status.RotateEncryptionKeysPhase)
+	return status, fmt.Errorf("encountered unknown encryption key rotation phase: %s", cp.Status.RotateEncryptionKeysPhase)
 }
 
 // encryptionKeyRotationSupported returns a boolean indicating whether encryption key rotation is supported by the release,
@@ -299,13 +300,14 @@ func rotateEncryptionKeyInProgress(cp *rkev1.RKEControlPlane) bool {
 // phase is "prepare", it will re-elect a new leader. It will look for the init node, and if the init node is not valid
 // (etcd-only), it will elect the first suitable control plane node. If the phase is not in "prepare" and a re-election
 // of the leader is necessary, the phase will be set to failed as this is unexpected.
-func (p *Planner) encryptionKeyRotationElectLeader(cp *rkev1.RKEControlPlane, clusterPlan *plan.Plan) (*planEntry, error) {
+func (p *Planner) encryptionKeyRotationElectLeader(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, clusterPlan *plan.Plan) (*planEntry, rkev1.RKEControlPlaneStatus, error) {
 	_, _, init, err := p.findInitNode(cp, clusterPlan)
 	if init == nil {
-		return nil, p.encryptionKeyRotationFailed(cp, err)
+		status, err := p.encryptionKeyRotationFailed(cp, status, err)
+		return nil, status, err
 	}
 
-	if machineName, ok := cp.Annotations[encryptionKeyRotationLeaderAnnotation]; ok {
+	if machineName := cp.Status.RotateEncryptionKeys.ControlPlaneLeader; machineName != "" {
 		if machine, ok := clusterPlan.Machines[machineName]; ok {
 			entry := &planEntry{
 				Machine:  machine,
@@ -313,32 +315,29 @@ func (p *Planner) encryptionKeyRotationElectLeader(cp *rkev1.RKEControlPlane, cl
 				Metadata: clusterPlan.Metadata[machineName],
 			}
 			if encryptionKeyRotationIsSuitableControlPlane(entry) {
-				return entry, nil
+				return entry, status, nil
 			}
 		}
 	}
 
 	if cp.Status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhasePrepare {
 		// if we are electing a leader and are not in the "prepare" phase, something is wrong.
-		return nil, p.encryptionKeyRotationFailed(cp, fmt.Errorf("re-election of encryption key rotation leader occurred when phase was %s", cp.Status.RotateEncryptionKeysPhase))
+		status, err := p.encryptionKeyRotationFailed(cp, status, fmt.Errorf("re-election of encryption key rotation leader occurred when phase was %s", cp.Status.RotateEncryptionKeysPhase))
+		return nil, status, err
 	}
 
 	leader := init
 	if !isControlPlane(init) {
 		machines := collect(clusterPlan, encryptionKeyRotationIsSuitableControlPlane)
 		if len(machines) == 0 {
-			return nil, p.encryptionKeyRotationFailed(cp, fmt.Errorf("no suitable control plane nodes for encryption key rotation"))
+			status, err := p.encryptionKeyRotationFailed(cp, status, fmt.Errorf("no suitable control plane nodes for encryption key rotation"))
+			return nil, status, err
 		}
 		leader = machines[0]
 	}
 
-	cp = cp.DeepCopy()
-	cp.Annotations[encryptionKeyRotationLeaderAnnotation] = leader.Machine.Name
-	_, err = p.rkeControlPlanes.Update(cp)
-	if err != nil {
-		return nil, err
-	}
-	return nil, generic.ErrSkip
+	cp.Status.RotateEncryptionKeys.ControlPlaneLeader = leader.Machine.Name
+	return nil, status, ErrWaitingf("designating %s as encryption key rotation leader", leader.Machine.Name)
 }
 
 // encryptionKeyRotationIsSuitableControlPlane ensures that a control plane node has not been deleted and has a valid
@@ -351,7 +350,7 @@ func encryptionKeyRotationIsSuitableControlPlane(entry *planEntry) bool {
 func encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(cp *rkev1.RKEControlPlane) roleFilter {
 	return func(entry *planEntry) bool {
 		return isControlPlaneAndNotInitNode(entry) &&
-			cp.Annotations[encryptionKeyRotationLeaderAnnotation] != entry.Machine.Name
+			cp.Status.RotateEncryptionKeys.ControlPlaneLeader != entry.Machine.Name
 	}
 }
 
@@ -359,7 +358,7 @@ func encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(cp *rkev1.RKEControl
 func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(cp *rkev1.RKEControlPlane) roleFilter {
 	return func(entry *planEntry) bool {
 		return isEtcd(entry) && !isControlPlane(entry) &&
-			cp.Annotations[encryptionKeyRotationLeaderAnnotation] != entry.Machine.Name &&
+			cp.Status.RotateEncryptionKeys.ControlPlaneLeader != entry.Machine.Name &&
 			!isInitNode(entry)
 	}
 }
@@ -368,57 +367,57 @@ func encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(cp *rkev1.
 // The followers (if any exist) are subsequently restarted. Notably, if the encryption key rotation leader is not the init node,
 // it will restart the init node, then restart the encryption key rotation leader,
 // then finalize walking through etcd nodes (that are not controlplane), then finally controlplane nodes.
-func (p *Planner) encryptionKeyRotationRestartNodes(cp *rkev1.RKEControlPlane, clusterPlan *plan.Plan, leader *planEntry) error {
+func (p *Planner) encryptionKeyRotationRestartNodes(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, clusterPlan *plan.Plan, leader *planEntry) (rkev1.RKEControlPlaneStatus, error) {
 	// in certain cases with multi-node setups, we must restart the init node before we can proceed to restarting the leader.
 	if !isInitNode(leader) {
 		logrus.Debugf("[planner] rkecluster %s/%s: leader %s was not the init node, finding and restarting services on init node", cp.Namespace, cp.Name, leader.Machine.Name)
 		// find init node and restart service on the init node first.
 		initNodeFound, _, initNode, err := p.findInitNode(cp, clusterPlan)
 		if err != nil {
-			return err
+			return status, err
 		}
 		if !initNodeFound {
-			return fmt.Errorf("unable to find init node")
+			return status, fmt.Errorf("unable to find init node")
 		}
 
-		_, err = p.encryptionKeyRotationRestartService(cp, initNode, false, "")
+		_, status, err = p.encryptionKeyRotationRestartService(cp, status, initNode, false, "")
 		if err != nil {
-			return err
+			return status, err
 		}
 		logrus.Debugf("[planner] rkecluster %s/%s: collecting etcd and not control plane", cp.Namespace, cp.Name)
 		for _, entry := range collect(clusterPlan, encryptionKeyRotationIsEtcdAndNotControlPlaneAndNotLeaderAndInit(cp)) {
-			_, err = p.encryptionKeyRotationRestartService(cp, entry, false, "")
+			_, status, err = p.encryptionKeyRotationRestartService(cp, status, entry, false, "")
 			if err != nil {
-				return err
+				return status, err
 			}
 		}
 	}
 
-	leaderStage, err := p.encryptionKeyRotationRestartService(cp, leader, true, "")
+	leaderStage, status, err := p.encryptionKeyRotationRestartService(cp, status, leader, true, "")
 	if err != nil {
-		return err
+		return status, err
 	}
 
 	logrus.Debugf("[planner] rkecluster %s/%s: collecting control plane and not leader and init nodes", cp.Namespace, cp.Name)
 	for _, entry := range collect(clusterPlan, encryptionKeyRotationIsControlPlaneAndNotLeaderAndInit(cp)) {
-		stage, err := p.encryptionKeyRotationRestartService(cp, entry, true, leaderStage)
+		stage, status, err := p.encryptionKeyRotationRestartService(cp, status, entry, true, leaderStage)
 		if err != nil {
-			return err
+			return status, err
 		}
 
 		if stage != leaderStage {
 			// secrets-encrypt command was run on another node. this is considered a failure, but might be a bit too sensitive. to be tested.
-			return p.encryptionKeyRotationFailed(cp, fmt.Errorf("leader [%s] with %s stage and follower [%s] with %s stage", leader.Machine.Status.NodeRef.Name, leaderStage, entry.Machine.Status.NodeRef.Name, stage))
+			return p.encryptionKeyRotationFailed(cp, status, fmt.Errorf("leader [%s] with %s stage and follower [%s] with %s stage", leader.Machine.Status.NodeRef.Name, leaderStage, entry.Machine.Status.NodeRef.Name, stage))
 		}
 	}
 
-	return nil
+	return status, nil
 }
 
 // encryptionKeyRotationRestartService restarts the server unit on the downstream node, waits until secrets-encrypt
 // status can be successfully queried, and then gets the status. leaderStage is allowed to be empty if entry is the
 // leader.
-func (p *Planner) encryptionKeyRotationRestartService(cp *rkev1.RKEControlPlane, entry *planEntry, scrapeStage bool, leaderStage string) (string, error) {
+func (p *Planner) encryptionKeyRotationRestartService(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, entry *planEntry, scrapeStage bool, leaderStage string) (string, rkev1.RKEControlPlaneStatus, error) {
 	runtime := rke2.GetRuntime(cp.Spec.KubernetesVersion)
 	nodePlan := plan.NodePlan{
 		Files: []plan.File{
@@ -458,30 +457,30 @@ func (p *Planner) encryptionKeyRotationRestartService(cp *rkev1.RKEControlPlane,
 	// the downstream k3s/rke2-server service logs, but it has to be done in order for encryption key rotation to succeed
 	err := assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", cp.Status.RotateEncryptionKeysPhase, entry.Machine.Name), entry, nodePlan, 5, 5)
 	if err != nil {
-		if isErrWaiting(err) {
-			return "", err
+		if !IsErrWaiting(err) {
+			status, err = p.encryptionKeyRotationFailed(cp, status, err)
 		}
-		return "", p.encryptionKeyRotationFailed(cp, err)
+		return "", status, err
 	}
 
 	if !scrapeStage || !isControlPlane(entry) {
-		return "", nil
+		return "", status, nil
 	}
 
 	stage, err := encryptionKeyRotationSecretsEncryptStageFromOneTimeStatus(entry)
 	if err != nil {
-		return "", p.enqueueIfErrWaiting(cp, err)
+		return "", status, err
 	}
-	return stage, nil
+	return stage, status, nil
 }
 
 // encryptionKeyRotationLeaderPhaseReconcile will run the secrets-encrypt command that corresponds to the phase, and scrape output to ensure that it was
 // successful. If the secrets-encrypt command does not exist on the plan, that means this is the first reconciliation, and
 // it must be added, otherwise reenqueue until the plan is in sync.
-func (p *Planner) encryptionKeyRotationLeaderPhaseReconcile(cp *rkev1.RKEControlPlane, leader *planEntry) error {
+func (p *Planner) encryptionKeyRotationLeaderPhaseReconcile(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, leader *planEntry) (rkev1.RKEControlPlaneStatus, error) {
 	apply, err := encryptionKeyRotationSecretsEncryptInstruction(cp)
 	if err != nil {
-		return p.encryptionKeyRotationFailed(cp, err)
+		return p.encryptionKeyRotationFailed(cp, status, err)
 	}
 
 	nodePlan := plan.NodePlan{
@@ -510,48 +509,33 @@ func (p *Planner) encryptionKeyRotationLeaderPhaseReconcile(cp *rkev1.RKEControl
 	}
 	err = assignAndCheckPlan(p.store, fmt.Sprintf("encryption key rotation [%s] for machine [%s]", cp.Status.RotateEncryptionKeysPhase, leader.Machine.Name), leader, nodePlan, 1, 1)
 	if err != nil {
-		if isErrWaiting(err) {
-			if strings.HasPrefix(err.Error(), "starting") {
-				logrus.Infof("[planner] rkecluster %s/%s: applying encryption key rotation stage command: [%s]", cp.Namespace, cp.Spec.ClusterName, apply.Args[1])
-			}
-			return err
+		if !IsErrWaiting(err) {
+			status, err = p.encryptionKeyRotationFailed(cp, status, err)
+		} else if strings.HasPrefix(err.Error(), "starting") {
+			logrus.Infof("[planner] rkecluster %s/%s: applying encryption key rotation stage command: [%s]", cp.Namespace, cp.Spec.ClusterName, apply.Args[1])
 		}
-		return p.encryptionKeyRotationFailed(cp, err)
+		return status, err
 	}
 	scrapedStageFromOneTimeInstructions, err := encryptionKeyRotationSecretsEncryptStageFromOneTimeStatus(leader)
 	if err != nil {
-		return err
+		return status, err
 	}
 	periodic, err := encryptionKeyRotationSecretsEncryptStageFromPeriodic(leader)
 	if err != nil {
-		return err
+		return status, err
 	}
 	err = encryptionKeyRotationIsCurrentStageAllowed(scrapedStageFromOneTimeInstructions, cp.Status.RotateEncryptionKeysPhase)
 	if err != nil {
-		return p.encryptionKeyRotationFailed(cp, err)
+		return p.encryptionKeyRotationFailed(cp, status, err)
 	}
 	if scrapedStageFromOneTimeInstructions == encryptionKeyRotationStageReencryptRequest || scrapedStageFromOneTimeInstructions == encryptionKeyRotationStageReencryptActive {
 		if periodic != encryptionKeyRotationStageReencryptFinished {
-			return ErrWaitingf("waiting for encryption key rotation stage to be finished")
+			return status, ErrWaitingf("waiting for encryption key rotation stage to be finished")
 		}
 	}
 	// successful restart, complete same phases for rotate & reencrypt
 	logrus.Infof("[planner] rkecluster %s/%s: successfully applied encryption key rotation stage command: [%s]", cp.Namespace, cp.Spec.ClusterName, leader.Plan.Plan.Instructions[0].Args[1])
-	return nil
-}
-
-// encryptionKeyRotationUpdateControlPlanePhase updates the control plane status if it has not been done yet.
-func (p *Planner) encryptionKeyRotationUpdateControlPlanePhase(cp *rkev1.RKEControlPlane, phase rkev1.RotateEncryptionKeysPhase) error {
-	if cp.Status.RotateEncryptionKeysPhase != phase {
-		cp = cp.DeepCopy()
-		logrus.Infof("[planner] rkecluster %s/%s: applying encryption key rotation phase: [%s]", cp.Namespace, cp.Spec.ClusterName, phase)
-		cp.Status.RotateEncryptionKeysPhase = phase
-		_, err := p.rkeControlPlanes.UpdateStatus(cp)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return status, nil
 }
 
 // encryptionKeyRotationSecretsEncryptStageFromPeriodic will attempt to extract the current stage (secrets-encrypt status) from the
@@ -784,14 +768,12 @@ func encryptionKeyRotationIsCurrentStageAllowed(leaderStage string, currentPhase
 
 // encryptionKeyRotationFailed updates the various status objects on the control plane, allowing the cluster to
 // continue the reconciliation loop. Encryption key rotation will not be restarted again until requested.
-func (p *Planner) encryptionKeyRotationFailed(cp *rkev1.RKEControlPlane, err error) error {
-	if err2 := p.setEncryptionKeyRotateState(cp, cp.Spec.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseFailed); err2 != nil {
-		return err2
-	}
-
+func (p *Planner) encryptionKeyRotationFailed(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, err error) (rkev1.RKEControlPlaneStatus, error) {
+	// discard ErrWaiting since the planner has actually failed
+	status, _ = p.setEncryptionKeyRotateState(status, status.RotateEncryptionKeys, rkev1.RotateEncryptionKeysPhaseFailed)
 	err = errors.Wrap(err, "encryption key rotation failed, please perform an etcd restore")
 	logrus.Errorf("[planner] rkecluster %s/%s: %v", cp.Namespace, cp.Spec.ClusterName, err)
-	return err
+	return status, err
 }
 
 func encryptionKeyRotationScriptPath(cp *rkev1.RKEControlPlane, file string) string {

--- a/pkg/provisioningv2/rke2/planner/etcdcreate.go
+++ b/pkg/provisioningv2/rke2/planner/etcdcreate.go
@@ -10,32 +10,27 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
-func (p *Planner) setEtcdSnapshotCreateState(controlPlane *rkev1.RKEControlPlane, spec *rkev1.ETCDSnapshotCreate, phase rkev1.ETCDSnapshotPhase) error {
-	controlPlane = controlPlane.DeepCopy()
-	controlPlane.Status.ETCDSnapshotCreatePhase = phase
-	controlPlane.Status.ETCDSnapshotCreate = spec
-	_, err := p.rkeControlPlanes.UpdateStatus(controlPlane)
-	if err != nil {
-		return err
-	}
-	return ErrWaiting("refreshing etcd create state")
+func (p *Planner) setEtcdSnapshotCreateState(status rkev1.RKEControlPlaneStatus, spec *rkev1.ETCDSnapshotCreate, phase rkev1.ETCDSnapshotPhase) (rkev1.RKEControlPlaneStatus, error) {
+	status.ETCDSnapshotCreatePhase = phase
+	status.ETCDSnapshotCreate = spec
+	return status, ErrWaiting("refreshing etcd create state")
 }
 
-func (p *Planner) resetEtcdSnapshotCreateState(controlPlane *rkev1.RKEControlPlane) error {
-	if controlPlane.Status.ETCDSnapshotCreate == nil && controlPlane.Status.ETCDSnapshotCreatePhase == "" {
-		return nil
+func (p *Planner) resetEtcdSnapshotCreateState(status rkev1.RKEControlPlaneStatus) (rkev1.RKEControlPlaneStatus, error) {
+	if status.ETCDSnapshotCreate == nil && status.ETCDSnapshotCreatePhase == "" {
+		return status, nil
 	}
-	return p.setEtcdSnapshotCreateState(controlPlane, nil, "")
+	return p.setEtcdSnapshotCreateState(status, nil, "")
 }
 
-func (p *Planner) startOrRestartEtcdSnapshotCreate(controlPlane *rkev1.RKEControlPlane, snapshot *rkev1.ETCDSnapshotCreate) error {
-	if controlPlane.Status.ETCDSnapshotCreate == nil || !equality.Semantic.DeepEqual(*snapshot, *controlPlane.Status.ETCDSnapshotCreate) {
-		return p.setEtcdSnapshotCreateState(controlPlane, snapshot, rkev1.ETCDSnapshotPhaseStarted)
+func (p *Planner) startOrRestartEtcdSnapshotCreate(status rkev1.RKEControlPlaneStatus, snapshot *rkev1.ETCDSnapshotCreate) (rkev1.RKEControlPlaneStatus, error) {
+	if status.ETCDSnapshotCreate == nil || !equality.Semantic.DeepEqual(*snapshot, *status.ETCDSnapshotCreate) {
+		return p.setEtcdSnapshotCreateState(status, snapshot, rkev1.ETCDSnapshotPhaseStarted)
 	}
-	return nil
+	return status, nil
 }
 
-func (p *Planner) runEtcdSnapshotCreate(controlPlane *rkev1.RKEControlPlane, clusterPlan *plan.Plan) []error {
+func (p *Planner) runEtcdSnapshotCreate(cp *rkev1.RKEControlPlane, clusterPlan *plan.Plan) []error {
 	servers := collect(clusterPlan, isEtcd)
 	if len(servers) == 0 {
 		return []error{errors.New("failed to find node to perform etcd snapshot")}
@@ -44,7 +39,7 @@ func (p *Planner) runEtcdSnapshotCreate(controlPlane *rkev1.RKEControlPlane, clu
 	var errs []error
 
 	for _, server := range servers {
-		createPlan, err := p.generateEtcdSnapshotCreatePlan(controlPlane, server)
+		createPlan, err := p.generateEtcdSnapshotCreatePlan(cp, server)
 		if err != nil {
 			return []error{err}
 		}
@@ -59,41 +54,45 @@ func (p *Planner) runEtcdSnapshotCreate(controlPlane *rkev1.RKEControlPlane, clu
 	return errs
 }
 
-func (p *Planner) generateEtcdSnapshotCreatePlan(controlPlane *rkev1.RKEControlPlane, entry *planEntry) (plan.NodePlan, error) {
+func (p *Planner) generateEtcdSnapshotCreatePlan(cp *rkev1.RKEControlPlane, entry *planEntry) (plan.NodePlan, error) {
 	args := []string{
 		"etcd-snapshot",
 	}
 
-	return p.commonNodePlan(controlPlane, plan.NodePlan{
+	return p.commonNodePlan(cp, plan.NodePlan{
 		Instructions: []plan.OneTimeInstruction{
-			p.generateInstallInstructionWithSkipStart(controlPlane, entry),
+			p.generateInstallInstructionWithSkipStart(cp, entry),
 			{
 				Name:    "create",
-				Command: rke2.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion),
+				Command: rke2.GetRuntimeCommand(cp.Spec.KubernetesVersion),
 				Args:    args,
 			}},
 	})
 }
 
-func (p *Planner) createEtcdSnapshot(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, clusterPlan *plan.Plan) []error {
-	if controlPlane.Spec.ETCDSnapshotCreate == nil {
-		if err := p.resetEtcdSnapshotCreateState(controlPlane); err != nil {
-			return []error{err}
+func (p *Planner) createEtcdSnapshot(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan) (rkev1.RKEControlPlaneStatus, []error) {
+	if cp.Spec.ETCDSnapshotCreate == nil {
+		if status, err := p.resetEtcdSnapshotCreateState(status); err != nil {
+			return status, []error{err}
 		}
-		return nil
+		return status, nil
 	}
 
-	snapshot := controlPlane.Spec.ETCDSnapshotCreate
-
-	if err := p.startOrRestartEtcdSnapshotCreate(controlPlane, snapshot); err != nil {
-		return []error{err}
+	if err := p.pauseCAPICluster(cp, true); err != nil {
+		return status, []error{err}
 	}
 
-	switch controlPlane.Status.ETCDSnapshotCreatePhase {
+	snapshot := cp.Spec.ETCDSnapshotCreate
+
+	if status, err := p.startOrRestartEtcdSnapshotCreate(status, snapshot); err != nil {
+		return status, []error{err}
+	}
+
+	switch cp.Status.ETCDSnapshotCreatePhase {
 	case rkev1.ETCDSnapshotPhaseStarted:
 		var stateSet bool
 		var finErrs []error
-		if errs := p.runEtcdSnapshotCreate(controlPlane, clusterPlan); len(errs) > 0 {
+		if errs := p.runEtcdSnapshotCreate(cp, clusterPlan); len(errs) > 0 {
 			for _, err := range errs {
 				if err == nil {
 					continue
@@ -103,7 +102,8 @@ func (p *Planner) createEtcdSnapshot(controlPlane *rkev1.RKEControlPlane, tokens
 				if !errors.As(err, &errWaiting) {
 					// we have a failed snapshot from a node.
 					if !stateSet {
-						if err := p.setEtcdSnapshotCreateState(controlPlane, snapshot, rkev1.ETCDSnapshotPhaseFailed); err != nil {
+						var err error
+						if status, err = p.setEtcdSnapshotCreateState(status, snapshot, rkev1.ETCDSnapshotPhaseFailed); err != nil {
 							finErrs = append(finErrs, err)
 						} else {
 							stateSet = true
@@ -111,28 +111,31 @@ func (p *Planner) createEtcdSnapshot(controlPlane *rkev1.RKEControlPlane, tokens
 					}
 				}
 			}
-			return finErrs
+			return status, finErrs
 		}
-		if err := p.setEtcdSnapshotCreateState(controlPlane, snapshot, rkev1.ETCDSnapshotPhaseRestartCluster); err != nil {
-			return []error{err}
+		if status, err := p.setEtcdSnapshotCreateState(status, snapshot, rkev1.ETCDSnapshotPhaseRestartCluster); err != nil {
+			return status, []error{err}
 		}
-		return nil
+		return status, nil
 	case rkev1.ETCDSnapshotPhaseRestartCluster:
-		if err := p.runEtcdSnapshotManagementServiceStart(controlPlane, tokensSecret, clusterPlan, isEtcd, "etcd snapshot creation"); err != nil {
-			return []error{err}
+		if err := p.runEtcdSnapshotManagementServiceStart(cp, tokensSecret, clusterPlan, isEtcd, "etcd snapshot creation"); err != nil {
+			return status, []error{err}
 		}
-		if err := p.setEtcdSnapshotCreateState(controlPlane, snapshot, rkev1.ETCDSnapshotPhaseFinished); err != nil {
-			return []error{err}
+		if status, err := p.setEtcdSnapshotCreateState(status, snapshot, rkev1.ETCDSnapshotPhaseFinished); err != nil {
+			return status, []error{err}
 		}
-		return nil
+		return status, nil
 	case rkev1.ETCDSnapshotPhaseFailed:
 		fallthrough
 	case rkev1.ETCDSnapshotPhaseFinished:
-		return nil
-	default:
-		if err := p.setEtcdSnapshotCreateState(controlPlane, snapshot, rkev1.ETCDSnapshotPhaseStarted); err != nil {
-			return []error{err}
+		if err := p.pauseCAPICluster(cp, false); err != nil {
+			return status, []error{err}
 		}
-		return nil
+		return status, nil
+	default:
+		if status, err := p.setEtcdSnapshotCreateState(status, snapshot, rkev1.ETCDSnapshotPhaseStarted); err != nil {
+			return status, []error{err}
+		}
+		return status, nil
 	}
 }


### PR DESCRIPTION
This is still a WIP, mainly regarding conditions. I have everything working in a separate branch, but I'm experimenting with the conditions to ensure that the control plane is `Ready` when cert rotation, encryption key rotation, and etcd snapshot actions are requested, and reintroducing the `Reconciled` and `Provisioned` conditions when plans are currently being run, and the cluster is being bootstrapped respectively.

I plan to do independent testing when https://github.com/rancher/rancher/pull/39871 and https://github.com/rancher/rancher/pull/39872 are merged, but I'm creating the PR now to view diffs easily and test drone output.