### PR TITLE
[2.7] Use `dig` to get external IP address

### DIFF
--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -7,7 +7,7 @@ ARG ARCH=amd64
 
 ENV KUBECTL_VERSION v1.23.6
 RUN zypper -n install --no-recommends curl ca-certificates jq git-core hostname iproute2 vim-small less \
-	bash-completion acl openssh-clients tar gzip xz gawk sysstat && \
+	bash-completion bind-utils acl openssh-clients tar gzip xz gawk sysstat && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl

--- a/package/run.sh
+++ b/package/run.sh
@@ -161,6 +161,13 @@ export CATTLE_ADDRESS=$(get_address $CATTLE_ADDRESS)
 export CATTLE_INTERNAL_ADDRESS=$(get_address $CATTLE_INTERNAL_ADDRESS)
 
 if [ -z "$CATTLE_ADDRESS" ]; then
+    # Try to get external IP with dig, often works better than ip -o route.
+    if dig +short myip.opendns.com @resolver1.opendns.com && echo $?; then
+        CATTLE_ADDRESS=$(dig +short myip.opendns.com @resolver1.opendns.com)
+    fi
+fi
+
+if [ -z "$CATTLE_ADDRESS" ]; then
     # Example output: '8.8.8.8 via 10.128.0.1 dev ens4 src 10.128.0.34 uid 0'
     CATTLE_ADDRESS=$(ip -o route get 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
 fi


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/36025
 
## Problem
When deploying the Rancher node agent no value for `CATTLE_ADDRESS` is provided. `CATTLE_ADDRESS` is used by the node agent to determine the external IP address of the host. Previously, this value was not used by the node agent so its value was unimportant. However, the implementation of #39497 requires that this variable hold the correct external IP address. 

If this environment variable is not provided upon initial deployment of the agent, then the command `ip -o route get 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p'` will be run by the agent on startup in an attempt to determine the external IP address of the host. This works for most providers, however for some (Azure & Linode, and potentially others) it actually returns the private IP address of the host. 

## Solution
Attempt to get the external IP address using the `dig` command. In the scenario where this command does not work, we will fall back to the existing behavior. 

 
## Testing

## Engineering Testing
### Manual Testing

I've used these changes on a number of providers and have confirmed they have the correct external IP address

## QA Testing Considerations
I do not have access to a Linode account to test this change with, but I do know that this resolves the issue for Azure clusters.
 
### Regressions Considerations
Make sure azure node driver clusters still report proper IP addresses, from my testing I have not seen a problem but good to double check. 