### PR TITLE
Fix Panic Error Caused by Rancher-Webhook

### DIFF
--- a/pkg/api/norman/store/cluster/cluster_store.go
+++ b/pkg/api/norman/store/cluster/cluster_store.go
@@ -235,7 +235,7 @@ func (r *Store) Create(apiContext *types.APIContext, schema *types.Schema, data 
 		return nil, err
 	}
 
-	//check if template is passed. if yes, load template data
+	// check if template is passed. if yes, load template data
 	if hasTemplate(data) {
 		clusterTemplateRevision, clusterTemplate, err := r.validateTemplateInput(apiContext, data, false)
 		if err != nil {
@@ -427,7 +427,7 @@ func loadDataFromTemplate(clusterTemplateRevision *v3.ClusterTemplateRevision, c
 
 	dataFromTemplate = transposeNameFields(dataFromTemplate, clusterConfigSchema)
 	var revisionQuestions []map[string]interface{}
-	//Add in any answers to the clusterTemplateRevision's Questions[]
+	// Add in any answers to the clusterTemplateRevision's Questions[]
 	allAnswers := convert.ToMapInterface(convert.ToMapInterface(data[managementv3.ClusterSpecFieldClusterTemplateAnswers])["values"])
 	existingAnswers := convert.ToMapInterface(convert.ToMapInterface(existingCluster[managementv3.ClusterSpecFieldClusterTemplateAnswers])["values"])
 
@@ -526,7 +526,7 @@ func loadDataFromTemplate(clusterTemplateRevision *v3.ClusterTemplateRevision, c
 		// save privateRegistries back to rancherKubernetesEngineConfig
 		values.PutValue(dataFromTemplate, registries, managementv3.ClusterSpecFieldRancherKubernetesEngineConfig, managementv3.RancherKubernetesEngineConfigFieldPrivateRegistries)
 	}
-	//save defaultAnswers to answer
+	// save defaultAnswers to answer
 	if allAnswers == nil {
 		allAnswers = make(map[string]interface{})
 	}
@@ -557,7 +557,7 @@ func loadDataFromTemplate(clusterTemplateRevision *v3.ClusterTemplateRevision, c
 		dataFromTemplate[managementv3.ClusterFieldFleetWorkspaceName] = fleetworkspace
 	}
 
-	//validate that the data loaded is valid clusterSpec
+	// validate that the data loaded is valid clusterSpec
 	var spec v32.ClusterSpec
 	if err := convert.ToObj(dataFromTemplate, &spec); err != nil {
 		return nil, httperror.WrapAPIError(err, httperror.InvalidBodyContent, "Invalid clusterTemplate, cannot convert to cluster spec")
@@ -618,7 +618,7 @@ func hasTemplate(data map[string]interface{}) bool {
 func (r *Store) validateTemplateInput(apiContext *types.APIContext, data map[string]interface{}, isUpdate bool) (*v3.ClusterTemplateRevision, *v3.ClusterTemplate, error) {
 
 	if !isUpdate {
-		//if data also has rkeconfig, error out on create
+		// if data also has rkeconfig, error out on create
 		rkeConfig, ok := values.GetValue(data, "rancherKubernetesEngineConfig")
 		if ok && rkeConfig != nil {
 			return nil, nil, fmt.Errorf("cannot set rancherKubernetesEngineConfig and clusterTemplateRevision both")
@@ -630,7 +630,7 @@ func (r *Store) validateTemplateInput(apiContext *types.APIContext, data map[str
 	templateRevIDStr := convert.ToString(data[managementv3.ClusterSpecFieldClusterTemplateRevisionID])
 	var clusterTemplateRev managementv3.ClusterTemplateRevision
 
-	//access check.
+	// access check.
 	if err := access.ByID(apiContext, apiContext.Version, managementv3.ClusterTemplateRevisionType, templateRevIDStr, &clusterTemplateRev); err != nil {
 		if apiError, ok := err.(*httperror.APIError); ok {
 			if apiError.Code.Status == httperror.PermissionDenied.Status {
@@ -738,7 +738,7 @@ func (r *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 		}
 	}
 
-	//check if template is passed. if yes, load template data
+	// check if template is passed. if yes, load template data
 	if hasTemplate(data) {
 		if existingCluster[managementv3.ClusterSpecFieldClusterTemplateRevisionID] == "" {
 			return nil, httperror.NewAPIError(httperror.InvalidOption, fmt.Sprintf("this cluster is not created using a clusterTemplate, cannot update it to use a clusterTemplate now"))
@@ -765,7 +765,7 @@ func (r *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 
 		data = clusterUpdate
 
-		//keep monitoring and alerting flags on the cluster as is, no turning off these flags from templaterevision.
+		// keep monitoring and alerting flags on the cluster as is, no turning off these flags from templaterevision.
 		if !clusterTemplateRevision.Spec.ClusterConfig.EnableClusterMonitoring {
 			data[managementv3.ClusterSpecFieldEnableClusterMonitoring] = existingCluster[managementv3.ClusterSpecFieldEnableClusterMonitoring]
 		}
@@ -888,6 +888,7 @@ func (r *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 				logrus.Errorf("cluster store: encountered error while handling migration error: %v, original error: %v", cleanupErr, err)
 			}
 		}
+		return nil, err
 	}
 	if allSecrets.regSecret != nil || allSecrets.s3Secret != nil || allSecrets.weaveSecret != nil || allSecrets.vsphereSecret != nil || allSecrets.vcenterSecret != nil || allSecrets.openStackSecret != nil || allSecrets.aadClientSecret != nil || allSecrets.aadCertSecret != nil {
 		if r.ClusterClient == nil {
@@ -1163,7 +1164,7 @@ func canUseClusterName(apiContext *types.APIContext, requestedName string) error
 
 	for _, c := range clusters {
 		if c.Removed == "" && strings.EqualFold(c.Name, requestedName) {
-			//cluster exists by this name
+			// cluster exists by this name
 			return httperror.NewFieldAPIError(httperror.NotUnique, "Cluster name", "")
 		}
 	}
@@ -1178,13 +1179,13 @@ func setKubernetesVersion(data map[string]interface{}, create bool) error {
 		if k8sVersion == nil || k8sVersion == "" {
 			// Only set when its a new cluster
 			if create {
-				//set k8s version to system default on the spec
+				// set k8s version to system default on the spec
 				defaultVersion := settings.KubernetesVersion.Get()
 				values.PutValue(data, defaultVersion, "rancherKubernetesEngineConfig", "kubernetesVersion")
 			}
 		} else {
-			//if k8s version is already of rancher version form, noop
-			//if k8s version is of form 1.14.x, figure out the latest
+			// if k8s version is already of rancher version form, noop
+			// if k8s version is of form 1.14.x, figure out the latest
 			k8sVersionRequested := convert.ToString(k8sVersion)
 			if strings.Contains(k8sVersionRequested, "-rancher") {
 				deprecated, err := isDeprecated(k8sVersionRequested)

--- a/pkg/api/norman/store/clustertemplate/store.go
+++ b/pkg/api/norman/store/clustertemplate/store.go
@@ -157,6 +157,7 @@ func (p *Store) Create(apiContext *types.APIContext, schema *types.Schema, data 
 				return result, httperror.WrapAPIError(err, httperror.PermissionDenied, "You must have the `Create Cluster Templates` global role in order to create cluster templates or revisions. These permissions can be granted by an administrator.")
 			}
 		}
+		return nil, err
 	}
 
 	if strings.EqualFold(apiContext.Type, managementv3.ClusterTemplateRevisionType) {
@@ -326,7 +327,7 @@ func (p *Store) Delete(apiContext *types.APIContext, schema *types.Schema, id st
 		return nil, httperror.NewAPIError(httperror.InvalidAction, fmt.Sprintf("Cannot delete the %v until Clusters referring it are removed", apiContext.Type))
 	}
 
-	//check if template.DefaultRevisionId is set, if yes error out if the revision is being deleted.
+	// check if template.DefaultRevisionId is set, if yes error out if the revision is being deleted.
 	if strings.EqualFold(apiContext.Type, managementv3.ClusterTemplateRevisionType) {
 		isDefault, err := isDefaultTemplateRevision(apiContext, id)
 		if err != nil {
@@ -464,7 +465,7 @@ func (p *Store) checkKubernetesVersionFormat(apiContext *types.APIContext, data 
 		return err
 	}
 	if genericPatch {
-		//ensure a question is added for "rancherKubernetesEngineConfig.kubernetesVersion"
+		// ensure a question is added for "rancherKubernetesEngineConfig.kubernetesVersion"
 		templateQuestions, ok := data[managementv3.ClusterTemplateRevisionFieldQuestions]
 		if !ok {
 			return httperror.NewAPIError(httperror.MissingRequired, fmt.Sprintf("ClusterTemplateRevision must have a Question set for %v", clustertemplate.RKEConfigK8sVersion))


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/38701
https://github.com/rancher/rancher/issues/40009
https://github.com/rancher/rancher/issues/39992
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Due to the addition of checks for PSA in rancher-webhook, it does more validations on the request for creating/updating a v3 Management cluster and could return an error if the validation fails.  
Previously, rancher-webhook did not return such an error and rancher also did not catch it, so a panic error did not happen before but happens now. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue/feature and explain why this addresses the issue. -->
 
Return the error properly. 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Steps:
- create an RKE1 cluster in rancher; during the creation, edit the cluster as YAML and add the following 
```
default_pod_security_admission_configuration_template_name: privileged
```
- update the above cluster to change the template name to an non-existing one 

Expected Results:
The update should fail with an error like the following: 
<img width="815" alt="image" src="https://user-images.githubusercontent.com/6218999/209610358-5006be60-b996-4f45-bcbb-bf4fa2bcf404.png">

Also, there should be no panic error in rancher's logs. 


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

same as the above
### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
n/a 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 same as the above
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

cluster creation and update 