### PR TITLE
[2.7] Support CATTLE_WHITELIST_ENVVARS in RKE2 provisioning code

### DIFF
--- a/pkg/jailer/jailer.go
+++ b/pkg/jailer/jailer.go
@@ -77,20 +77,9 @@ func CreateJail(name string) error {
 	return nil
 }
 
-func WhitelistEnvvars(envvars []string) []string {
-	wl := settings.WhitelistEnvironmentVars.Get()
-	envWhiteList := strings.Split(wl, ",")
-
-	if len(envWhiteList) == 0 {
-		return envvars
-	}
-
-	for _, wlVar := range envWhiteList {
-		wlVar = strings.TrimSpace(wlVar)
-		if val := os.Getenv(wlVar); val != "" {
-			envvars = append(envvars, wlVar+"="+val)
-		}
-	}
-
+func getWhitelistedEnvVars(envvars []string) []string {
+	settings.IterateWhitelistedEnvVars(func(name, value string) {
+		envvars = append(envvars, name+"="+value)
+	})
 	return envvars
 }

--- a/pkg/jailer/jailer_linux.go
+++ b/pkg/jailer/jailer_linux.go
@@ -23,7 +23,7 @@ func JailCommand(cmd *exec.Cmd, jailPath string) (*exec.Cmd, error) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
 	cmd.SysProcAttr.Credential = cred
 	cmd.SysProcAttr.Chroot = jailPath
-	cmd.Env = WhitelistEnvvars(cmd.Env)
+	cmd.Env = getWhitelistedEnvVars(cmd.Env)
 	cmd.Env = append(cmd.Env, "PWD=/")
 	cmd.Dir = "/"
 	return cmd, nil

--- a/pkg/jailer/jailer_test.go
+++ b/pkg/jailer/jailer_test.go
@@ -39,7 +39,7 @@ func Test_WhitelistEnvvars(t *testing.T) {
 
 	for _, tc := range testCases {
 		os.Setenv("ENVVAR_FOO", tc.envValue)
-		envs := WhitelistEnvvars(tc.input)
+		envs := getWhitelistedEnvVars(tc.input)
 		assert.Equal(t, envs, tc.expected)
 	}
 

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -437,3 +437,18 @@ func GetRancherVersion() string {
 	}
 	return strings.TrimPrefix(rancherVersion, "v")
 }
+
+// IterateWhitelistedEnvVars iterates over the environment variables whitelisted
+// by CATTLE_WHITELIST_ENVVARS. If a variable is whitelisted but unset or empty,
+// the handler function will not be called for it.
+func IterateWhitelistedEnvVars(handler func(name, value string)) {
+	wl := WhitelistEnvironmentVars.Get()
+	envWhiteList := strings.Split(wl, ",")
+
+	for _, wlVar := range envWhiteList {
+		wlVar = strings.TrimSpace(wlVar)
+		if val := os.Getenv(wlVar); val != "" {
+			handler(wlVar, val)
+		}
+	}
+}


### PR DESCRIPTION
This allows passing down environment variables to rancher machine during provisioning.

## Issue: #39377 
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behaviour is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
This is an alternative solution to #39375 because there were [concerns](https://github.com/rancher/rancher/pull/39375#issuecomment-1351688797) regarding security. We need to be able to enable debug logging in RKE2.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Instead of passing the `--debug` flag to rancher machine, we allow RKE2 provisioning to pass down to rancher machine whitelisted environments variables, one of which can be `MACHINE_DEBUG`, which solves the needs of the original issue reporter.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
1. Start rancher with `MACHINE_DEBUG=true` and `CATTLE_WHITELIST_ENVVARS=NO_PROXY,HTTP_PROXY,HTTPS_PROXY,MACHINE_DEBUG` env vars.
2. Create an RKE2 cluster
3. Make sure rancher machine debug logs are displayed

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->