### PR TITLE
Bump rancher-agent image to use v2.7-head

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -65,7 +65,7 @@ var (
 		"tigera-operator",
 	}
 
-	AgentImage                          = NewSetting("agent-image", "rancher/rancher-agent:v2.6-head")
+	AgentImage                          = NewSetting("agent-image", "rancher/rancher-agent:v2.7-head")
 	AgentRolloutTimeout                 = NewSetting("agent-rollout-timeout", "300s")
 	AgentRolloutWait                    = NewSetting("agent-rollout-wait", "true")
 	AuthImage                           = NewSetting("auth-image", v32.ToolsSystemImages.AuthSystemImages.KubeAPIAuth)


### PR DESCRIPTION
Update the default for rancher-agent to be v2.7-head instead of 2.6-head