### PR TITLE
Windows Custom Cluster Automation

### DIFF
--- a/tests/framework/clients/ec2/client.go
+++ b/tests/framework/clients/ec2/client.go
@@ -10,21 +10,21 @@ import (
 
 // EC2Client is a struct that wraps the needed AWSEC2Config object, and ec2.EC2 which makes the actual calls to aws.
 type EC2Client struct {
-	SVC    *ec2.EC2
-	Config *AWSEC2Config
+	SVC          *ec2.EC2
+	ClientConfig *AWSEC2Configs
 }
 
-// NewEC2Client is a constructor that creates an *EC2Client which a wrapper for an "github.com/aws/aws-sdk-go/service/ec2" session and
-// the aws ec2 confit.
+// NewEC2Client is a constructor that creates an *EC2Client which a wrapper for a "github.com/aws/aws-sdk-go/service/ec2" session and
+// the aws ec2 config.
 func NewEC2Client() (*EC2Client, error) {
-	awsEC2Config := new(AWSEC2Config)
+	awsEC2ClientConfig := new(AWSEC2Configs)
 
-	config.LoadConfig(ConfigurationFileKey, awsEC2Config)
+	config.LoadConfig(ConfigurationFileKey, awsEC2ClientConfig)
 
-	credential := credentials.NewStaticCredentials(awsEC2Config.AWSAccessKeyID, awsEC2Config.AWSSecretAccessKey, "")
+	credential := credentials.NewStaticCredentials(awsEC2ClientConfig.AWSAccessKeyID, awsEC2ClientConfig.AWSSecretAccessKey, "")
 	sess, err := session.NewSession(&aws.Config{
 		Credentials: credential,
-		Region:      aws.String(awsEC2Config.Region)},
+		Region:      aws.String(awsEC2ClientConfig.Region)},
 	)
 	if err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func NewEC2Client() (*EC2Client, error) {
 	// Create EC2 service client
 	svc := ec2.New(sess)
 	return &EC2Client{
-		SVC:    svc,
-		Config: awsEC2Config,
+		SVC:          svc,
+		ClientConfig: awsEC2ClientConfig,
 	}, nil
 }

--- a/tests/framework/clients/ec2/config.go
+++ b/tests/framework/clients/ec2/config.go
@@ -1,20 +1,26 @@
 package ec2
 
-// The json/yaml config key for the AWSEConfig
-const ConfigurationFileKey = "awsEC2Config"
+// The json/yaml config key for the AWSEC2onfig
+const ConfigurationFileKey = "awsEC2Configs"
 
-// AWSEC2Config is configuration need to launch ec2 instances in AWS
+// AWSEC2Configs is the AWS authentication configuration for accessing and launching ec2 instances
+type AWSEC2Configs struct {
+	AWSEC2Config       []AWSEC2Config `json:"awsEC2Config" yaml:"awsEC2Config"`
+	AWSAccessKeyID     string         `json:"awsAccessKeyID" yaml:"awsAccessKeyID"`
+	AWSSecretAccessKey string         `json:"awsSecretAccessKey" yaml:"awsSecretAccessKey"`
+	Region             string         `json:"region" yaml:"region"`
+}
+
+// AWSEC2Config is the instance-specific configuration needed to launch ec2 instances in AWS
 type AWSEC2Config struct {
-	Region             string   `json:"region" yaml:"region"`
 	InstanceType       string   `json:"instanceType" yaml:"instanceType"`
 	AWSRegionAZ        string   `json:"awsRegionAZ" yaml:"awsRegionAZ"`
 	AWSAMI             string   `json:"awsAMI" yaml:"awsAMI"`
 	AWSSecurityGroups  []string `json:"awsSecurityGroups" yaml:"awsSecurityGroups"`
-	AWSAccessKeyID     string   `json:"awsAccessKeyID" yaml:"awsAccessKeyID"`
-	AWSSecretAccessKey string   `json:"awsSecretAccessKey" yaml:"awsSecretAccessKey"`
 	AWSSSHKeyName      string   `json:"awsSSHKeyName" yaml:"awsSSHKeyName"`
 	AWSCICDInstanceTag string   `json:"awsCICDInstanceTag" yaml:"awsCICDInstanceTag"`
 	AWSIAMProfile      string   `json:"awsIAMProfile" yaml:"awsIAMProfile"`
 	AWSUser            string   `json:"awsUser" yaml:"awsUser"`
 	VolumeSize         int      `json:"volumeSize" yaml:"volumeSize"`
+	IsWindows          bool     `json:"isWindows" yaml:"isWindows"`
 }

--- a/tests/framework/extensions/nodes/ec2/ec2.go
+++ b/tests/framework/extensions/nodes/ec2/ec2.go
@@ -10,138 +10,173 @@ import (
 )
 
 const (
-	nodeBaseName = "rancherautomation"
+	nodeBaseName = "rancher-automation"
 )
 
-// CreatedNodes creates `numOfInstances` number of ec2 instances
-func CreateNodes(client *rancher.Client, numOfInstances int) ([]*nodes.Node, error) {
+// CreateNodes creates `numOfInstances` (and/or `numOfWinInstances` when using multiple node configurations - e.g. Windows nodes) number of ec2 instances
+func CreateNodes(client *rancher.Client, numOfInstances int, numOfWinInstances int, multiconfig bool) (ec2Nodes []*nodes.Node, winEC2Nodes []*nodes.Node, err error) {
 	ec2Client, err := client.GetEC2Client()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	sshName := getSSHKeyName(ec2Client.Config.AWSSSHKeyName)
-
-	runInstancesInput := &ec2.RunInstancesInput{
-		ImageId:      aws.String(ec2Client.Config.AWSAMI),
-		InstanceType: aws.String(ec2Client.Config.InstanceType),
-		MinCount:     aws.Int64(int64(numOfInstances)),
-		MaxCount:     aws.Int64(int64(numOfInstances)),
-		KeyName:      aws.String(sshName),
-		BlockDeviceMappings: []*ec2.BlockDeviceMapping{
-			{
-				DeviceName: aws.String("/dev/sda1"),
-				Ebs: &ec2.EbsBlockDevice{
-					VolumeSize: aws.Int64(int64(ec2Client.Config.VolumeSize)),
-				},
-			},
-		},
-		IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
-			Name: aws.String(ec2Client.Config.AWSIAMProfile),
-		},
-		Placement: &ec2.Placement{
-			AvailabilityZone: aws.String(ec2Client.Config.AWSRegionAZ),
-		},
-		NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
-			{
-				DeviceIndex:              aws.Int64(0),
-				AssociatePublicIpAddress: aws.Bool(true),
-				Groups:                   aws.StringSlice(ec2Client.Config.AWSSecurityGroups),
-			},
-		},
-		TagSpecifications: []*ec2.TagSpecification{
-			{
-				ResourceType: aws.String("instance"),
-				Tags: []*ec2.Tag{
-					{
-						Key:   aws.String("Name"),
-						Value: aws.String(nodeBaseName),
-					},
-					{
-						Key:   aws.String("CICD"),
-						Value: aws.String(ec2Client.Config.AWSCICDInstanceTag),
+	for _, config := range ec2Client.ClientConfig.AWSEC2Config {
+		sshName := getSSHKeyName(config.AWSSSHKeyName)
+		runInstancesInput := &ec2.RunInstancesInput{
+			ImageId:      aws.String(config.AWSAMI),
+			InstanceType: aws.String(config.InstanceType),
+			MinCount:     aws.Int64(int64(numOfInstances)),
+			MaxCount:     aws.Int64(int64(numOfInstances)),
+			KeyName:      aws.String(sshName),
+			BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+				{
+					DeviceName: aws.String("/dev/sda1"),
+					Ebs: &ec2.EbsBlockDevice{
+						VolumeSize: aws.Int64(int64(config.VolumeSize)),
 					},
 				},
 			},
-		},
-	}
-
-	reservation, err := ec2Client.SVC.RunInstances(runInstancesInput)
-	if err != nil {
-		return nil, err
-	}
-
-	var listOfInstanceIds []*string
-
-	for _, instance := range reservation.Instances {
-		listOfInstanceIds = append(listOfInstanceIds, instance.InstanceId)
-	}
-
-	//wait until instance is running
-	err = ec2Client.SVC.WaitUntilInstanceRunning(&ec2.DescribeInstancesInput{
-		InstanceIds: listOfInstanceIds,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	//wait until instance status is ok
-	err = ec2Client.SVC.WaitUntilInstanceStatusOk(&ec2.DescribeInstanceStatusInput{
-		InstanceIds: listOfInstanceIds,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// describe instance to get attributes=
-	describe, err := ec2Client.SVC.DescribeInstances(&ec2.DescribeInstancesInput{
-		InstanceIds: listOfInstanceIds,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	readyInstances := describe.Reservations[0].Instances
-
-	sshKey, err := nodes.GetSSHKey(ec2Client.Config.AWSSSHKeyName)
-	if err != nil {
-		return nil, err
-	}
-
-	var ec2Nodes []*nodes.Node
-
-	for _, readyInstance := range readyInstances {
-		ec2Node := &nodes.Node{
-			NodeID:          *readyInstance.InstanceId,
-			PublicIPAddress: *readyInstance.PublicIpAddress,
-			SSHUser:         ec2Client.Config.AWSUser,
-			SSHKey:          sshKey,
+			IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
+				Name: aws.String(config.AWSIAMProfile),
+			},
+			Placement: &ec2.Placement{
+				AvailabilityZone: aws.String(config.AWSRegionAZ),
+			},
+			NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
+				{
+					DeviceIndex:              aws.Int64(0),
+					AssociatePublicIpAddress: aws.Bool(true),
+					Groups:                   aws.StringSlice(config.AWSSecurityGroups),
+				},
+			},
+			TagSpecifications: []*ec2.TagSpecification{
+				{
+					ResourceType: aws.String("instance"),
+					Tags: []*ec2.Tag{
+						{
+							Key:   aws.String("Name"),
+							Value: aws.String(nodeBaseName),
+						},
+						{
+							Key:   aws.String("CICD"),
+							Value: aws.String(config.AWSCICDInstanceTag),
+						},
+					},
+				},
+			},
 		}
-		ec2Nodes = append(ec2Nodes, ec2Node)
+
+		reservation, err := ec2Client.SVC.RunInstances(runInstancesInput)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var listOfInstanceIds []*string
+
+		for _, instance := range reservation.Instances {
+			listOfInstanceIds = append(listOfInstanceIds, instance.InstanceId)
+		}
+
+		//wait until instance is running
+		err = ec2Client.SVC.WaitUntilInstanceRunning(&ec2.DescribeInstancesInput{
+			InstanceIds: listOfInstanceIds,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		//wait until instance status is ok
+		err = ec2Client.SVC.WaitUntilInstanceStatusOk(&ec2.DescribeInstanceStatusInput{
+			InstanceIds: listOfInstanceIds,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// describe instance to get attributes=
+		describe, err := ec2Client.SVC.DescribeInstances(&ec2.DescribeInstancesInput{
+			InstanceIds: listOfInstanceIds,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		readyInstances := describe.Reservations[0].Instances
+
+		sshKey, err := nodes.GetSSHKey(config.AWSSSHKeyName)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for _, readyInstance := range readyInstances {
+
+			if multiconfig {
+				if config.AWSAMI == ec2Client.ClientConfig.AWSEC2Config[0].AWSAMI &&
+					config.AWSUser == ec2Client.ClientConfig.AWSEC2Config[0].AWSUser {
+					ec2Node := &nodes.Node{
+						NodeID:          *readyInstance.InstanceId,
+						PublicIPAddress: *readyInstance.PublicIpAddress,
+						SSHUser:         config.AWSUser,
+						SSHKey:          sshKey,
+					}
+					ec2Nodes = append(ec2Nodes, ec2Node)
+				}
+
+				if config.AWSAMI == ec2Client.ClientConfig.AWSEC2Config[1].AWSAMI &&
+					config.AWSUser == ec2Client.ClientConfig.AWSEC2Config[1].AWSUser {
+					ec2Node2 := &nodes.Node{
+						NodeID:          *readyInstance.InstanceId,
+						PublicIPAddress: *readyInstance.PublicIpAddress,
+						SSHUser:         config.AWSUser,
+						SSHKey:          sshKey,
+					}
+					winEC2Nodes = append(winEC2Nodes, ec2Node2)
+				}
+			} else {
+				ec2Node := &nodes.Node{
+					NodeID:          *readyInstance.InstanceId,
+					PublicIPAddress: *readyInstance.PublicIpAddress,
+					SSHUser:         config.AWSUser,
+					SSHKey:          sshKey,
+				}
+				ec2Nodes = append(ec2Nodes, ec2Node)
+				winEC2Nodes = nil
+			}
+		}
+
+		client.Session.RegisterCleanupFunc(func() error {
+			return DeleteNodes(client, ec2Nodes, winEC2Nodes, multiconfig)
+		})
+
+		if !multiconfig {
+			break
+		}
 	}
 
-	client.Session.RegisterCleanupFunc(func() error {
-		return DeleteNodes(client, ec2Nodes)
-	})
-
-	return ec2Nodes, nil
+	return ec2Nodes, winEC2Nodes, nil
 }
 
 // DeleteNodes terminates ec2 instances that have been created.
-func DeleteNodes(client *rancher.Client, nodes []*nodes.Node) error {
+func DeleteNodes(client *rancher.Client, nodes []*nodes.Node, nodes2 []*nodes.Node, multiconfig bool) error {
 	ec2Client, err := client.GetEC2Client()
 	if err != nil {
 		return err
 	}
-	var instanceIDs []*string
 
+	var instanceIDs []*string
 	for _, node := range nodes {
 		instanceIDs = append(instanceIDs, aws.String(node.NodeID))
+	}
+	if multiconfig {
+		for _, node2 := range nodes2 {
+			instanceIDs = append(instanceIDs, aws.String(node2.NodeID))
+		}
 	}
 
 	_, err = ec2Client.SVC.TerminateInstances(&ec2.TerminateInstancesInput{
 		InstanceIds: instanceIDs,
 	})
+
 	return err
 }
 

--- a/tests/v2/validation/provisioning/config.go
+++ b/tests/v2/validation/provisioning/config.go
@@ -6,7 +6,9 @@ import (
 )
 
 const (
-	ConfigurationFileKey = "provisioningInput"
+	namespace               = "fleet-default"
+	defaultRandStringLength = 5
+	ConfigurationFileKey    = "provisioningInput"
 )
 
 type Config struct {

--- a/tests/v2/validation/provisioning/rke2/README.md
+++ b/tests/v2/validation/provisioning/rke2/README.md
@@ -186,18 +186,41 @@ For custom clusters, the below config is needed, only AWS/EC2 will work.
 **Ensure you have nodeProviders in provisioningInput**
 
 ```json
- "awsEC2Config": {
+{
+  "awsEC2Configs": {
     "region": "us-east-2",
-    "instanceType": "t3a.medium",
-    "awsRegionAZ": "",
-    "awsAMI": "",
-    "awsSecurityGroups": [""],
-    "awsAccessKeyID": "",
     "awsSecretAccessKey": "",
-    "awsSSHKeyName": "",
-    "awsCICDInstanceTag": "",
-    "awsIAMProfile": "",
-    "awsUser": "ubuntu",
-    "volumeSize": 50
-  },
+    "awsAccessKeyID": "",
+    "awsEC2Config": [
+      {
+        "instanceType": "t3a.medium",
+        "awsRegionAZ": "",
+        "awsAMI": "",
+        "awsSecurityGroups": [
+          ""
+        ],
+        "awsSSHKeyName": "",
+        "awsCICDInstanceTag": "rancher-validation",
+        "awsIAMProfile": "",
+        "awsUser": "ubuntu",
+        "volumeSize": 25,
+        "isWindows": false
+      },
+      {
+        "instanceType": "t3a.xlarge",
+        "awsRegionAZ": "",
+        "awsAMI": "",
+        "awsSecurityGroups": [
+          ""
+        ],
+        "awsSSHKeyName": "",
+        "awsCICDInstanceTag": "rancher-validation",
+        "awsIAMProfile": "",
+        "awsUser": "Administrator",
+        "volumeSize": 50,
+        "isWindows": true
+      }
+    ]
+  }
+}
 ```

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -94,15 +94,21 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 	}
 
 	tests := []struct {
-		name      string
-		nodeRoles []string
+		name         string
+		nodeRoles    []string
 		hardening *provisioning.Config
-		client    *rancher.Client
+		nodeCountWin int
+		hasWindows   bool
+		client       *rancher.Client
 	}{
-		{"1 Node all roles Admin User", nodeRoles0, c.provisioning, c.client},
-		{"1 Node all roles Standard User", nodeRoles0, c.provisioning, c.standardUserClient},
-		{"3 nodes - 1 role per node Admin User", nodeRoles1, c.provisioning, c.client},
-		{"3 nodes - 1 role per node Standard User", nodeRoles1, c.provisioning, c.standardUserClient},
+		{"1 Node all roles Admin User", nodeRoles0, c.provisioning, 0, false, c.client},
+		{"1 Node all roles Standard User", nodeRoles0, c.provisioning, 0, false, c.standardUserClient},
+		{"3 nodes - 1 role per node Admin User", nodeRoles1, c.provisioning, 0, false, c.client},
+		{"3 nodes - 1 role per node Standard User", nodeRoles1, c.provisioning, 0, false, c.standardUserClient},
+		{"1 Node all roles Admin User + 1 Windows Worker", nodeRoles0, c.provisioning, 1, true, c.client},
+		{"1 Node all roles Standard User + 1 Windows Worker", nodeRoles0, c.provisioning, 1, true, c.standardUserClient},
+		{"3 nodes - 1 role per node Admin User + 2 Windows Workers", nodeRoles1, c.provisioning, 2, true, c.client},
+		{"3 nodes - 1 role per node Standard User + 2 Windows Workers", nodeRoles1, c.provisioning, 2, true, c.standardUserClient},
 	}
 	var name string
 	for _, tt := range tests {
@@ -117,8 +123,9 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 					client, err := tt.client.WithSession(testSession)
 					require.NoError(c.T(), err)
 
-					numNodes := len(tt.nodeRoles)
-					nodes, err := externalNodeProvider.NodeCreationFunc(client, numNodes)
+					numNodesLin := len(tt.nodeRoles)
+
+					linuxNodes, winNodes, err := externalNodeProvider.NodeCreationFunc(client, numNodesLin, tt.nodeCountWin, tt.hasWindows)
 					require.NoError(c.T(), err)
 
 					clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
@@ -140,36 +147,55 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 					token, err := tokenregistration.GetRegistrationToken(client, clusterStatus.ClusterName)
 					require.NoError(c.T(), err)
 
-					for key, node := range nodes {
-						c.T().Logf("Execute Registration Command for node %s", node.NodeID)
+					for key, linuxNode := range linuxNodes {
+						c.T().Logf("Execute Registration Command for node %s", linuxNode.NodeID)
 						command := fmt.Sprintf("%s %s", token.InsecureNodeCommand, tt.nodeRoles[key])
-
-						output, err := node.ExecuteCommand(command)
+						output, err := linuxNode.ExecuteCommand(command)
 						require.NoError(c.T(), err)
 						c.T().Logf(output)
 					}
 
 					kubeProvisioningClient, err := c.client.GetKubeAPIProvisioningClient()
 					require.NoError(c.T(), err)
-
 					result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
-						FieldSelector:  "metadata.name=" + clusterName,
+						FieldSelector: "metadata.name=" + clusterName,
+
 						TimeoutSeconds: &defaults.WatchTimeoutSeconds,
 					})
 					require.NoError(c.T(), err)
-
 					checkFunc := clusters.IsProvisioningClusterReady
-
 					err = wait.WatchWait(result, checkFunc)
 					assert.NoError(c.T(), err)
 					assert.Equal(c.T(), clusterName, clusterResp.ObjectMeta.Name)
+
+					if tt.hasWindows {
+						for _, winNode := range winNodes {
+							c.T().Logf("Execute Registration Command for node %s", winNode.NodeID)
+							winCommand := fmt.Sprintf("%s", token.InsecureWindowsNodeCommand)
+							output, err := winNode.ExecuteCommand("powershell.exe" + winCommand)
+							require.NoError(c.T(), err)
+							c.T().Logf(string(output[:]))
+						}
+						kubeWinProvisioningClient, err := c.client.GetKubeAPIProvisioningClient()
+						require.NoError(c.T(), err)
+						result, err := kubeWinProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+							FieldSelector: "metadata.name=" + clusterName,
+
+							TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+						})
+						require.NoError(c.T(), err)
+						checkFunc := clusters.IsProvisioningClusterReady
+						err = wait.WatchWait(result, checkFunc)
+						assert.NoError(c.T(), err)
+						assert.Equal(c.T(), clusterName, clusterResp.ObjectMeta.Name)
+					}
 
 					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
 					require.NoError(c.T(), err)
 					assert.NotEmpty(c.T(), clusterToken)
 
 					if tt.hardening.Hardened {
-						err = hardening.HardeningNodes(client, tt.hardening.Hardened, nodes, tt.nodeRoles)
+						err = hardening.HardeningNodes(client, tt.hardening.Hardened, linuxNodes, tt.nodeRoles)
 						require.NoError(c.T(), err)
 
 						hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, nil)
@@ -178,9 +204,8 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 						require.NoError(c.T(), err)
 						assert.Equal(c.T(), clusterName, hardenClusterResp.ObjectMeta.Name)
 						
-						err = hardening.PostHardeningConfig(client, tt.hardening.Hardened, nodes, tt.nodeRoles)
+						err = hardening.PostHardeningConfig(client, tt.hardening.Hardened, linuxNodes, tt.nodeRoles)
 						require.NoError(c.T(), err)
-
 					}
 				})
 			}
@@ -210,12 +235,13 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynami
 	numOfNodes := len(rolesPerNode)
 
 	tests := []struct {
-		name      string
-		client    *rancher.Client
+		name          string
+		client        *rancher.Client
+		hasWindows bool
 		hardening *provisioning.Config
 	}{
-		{"Admin User", c.client, c.provisioning},
-		{"Standard User", c.standardUserClient, c.provisioning},
+		{"Admin User", c.client, false, c.provisioning},
+		{"Standard User", c.standardUserClient, false, c.provisioning},
 	}
 
 	var name string
@@ -231,7 +257,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynami
 					client, err := tt.client.WithSession(testSession)
 					require.NoError(c.T(), err)
 
-					nodes, err := externalNodeProvider.NodeCreationFunc(client, numOfNodes)
+					nodes, _, err := externalNodeProvider.NodeCreationFunc(client, numOfNodes, 0, false)
 					require.NoError(c.T(), err)
 
 					clusterName := namegen.AppendRandomString(externalNodeProvider.Name)


### PR DESCRIPTION
[QA-Task 428](https://github.com/rancher/qa-tasks/issues/428)

## Problem
Currently all testing of the provisioning of Custom clusters with Windows worker nodes has to be handled manually or with bash scripts, therefore having the ability to run automated CI/CD tests for the provisioning of these clusters to ensure they are still working properly will be much more efficient on time.

## Solution
This PR will allow for automation of Windows Custom Cluster nodes, to allow expedited regression/smoke testing.

## Automated Testing
This PR is intended to add automated tests for the provisioning of Custom Clusters with Windows worker nodes. The additions of new Windows provisioning tests (1 Node all roles Admin User + 1 Windows Worker, 1 Node all roles Standard User + 1 Windows Worker, 3 unique role nodes as Admin User + 1 Windows Worker, 3 unique role nodes as Standard User + 1 Windows Worker) will cover basic regression testing scenarios.

**Note:** Running this suite of tests for Custom Clusters (including bother with and without Windows Nodes) often takes ~90+ minutes to complete.