### PR TITLE
go + corral initial test case (v2.6)

### DIFF
--- a/tests/framework/clients/corral/config.go
+++ b/tests/framework/clients/corral/config.go
@@ -13,11 +13,16 @@ const (
 // CorralConfigs is a struct that for necessary corral config environment variables to build a corral
 type CorralConfigs struct {
 	CorralConfigVars map[string]string `json:"corralConfigVars" yaml:"corralConfigVars"`
+	CorralConfigUser string            `json:"corralConfigUser" yaml:"corralConfigUser" default:"jenkauto"`
+	CorralSSHPath    string            `json:"corralSSHPath" yaml:"corralSSHPath" default:"/root/.ssh/public.pub"`
 }
 
 // CorralPackages is a struct that has the path to the packages
 type CorralPackages struct {
-	CorralPackagePath map[string]string `json:"corralPackagePaths" yaml:"corralPackagePaths"`
+	CorralPackageImages map[string]string `json:"corralPackageImages" yaml:"corralPackageImages"`
+	Cleanup             bool              `json:"cleanup" yaml:"cleanup" default:true`
+	Debug               bool              `json:"debug" yaml:"debug" default:false`
+	CustomRepo          string            `json:"customRepo" yaml:"customRepo" default:"https://github.com/rancherlabs/corral-packages.git"`
 }
 
 // CorralPackagesConfig is a function that reads in the corral package object from the config file

--- a/tests/framework/pkg/namegenerator/namegenerator.go
+++ b/tests/framework/pkg/namegenerator/namegenerator.go
@@ -8,6 +8,7 @@ import (
 const lowerLetterBytes = "abcdefghijklmnopqrstuvwxyz"
 const upperLetterBytes = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 const numberBytes = "0123456789"
+const defaultRandStringLength = 5
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
@@ -37,4 +38,9 @@ func RandStringWithCharset(length int, charset string) string {
 // with the length depending on `n`. Used for creating a random string for resource names, such as clusters.
 func RandStringAll(length int) string {
 	return RandStringWithCharset(length, lowerLetterBytes+upperLetterBytes+numberBytes)
+}
+
+func AppendRandomString(baseClusterName string) string {
+	clusterName := "auto-" + baseClusterName + "-" + RandStringLower(defaultRandStringLength)
+	return clusterName
 }

--- a/tests/v2/validation/.gitignore
+++ b/tests/v2/validation/.gitignore
@@ -4,3 +4,4 @@
 *.json
 #yaml
 *.yaml
+!manifest.yaml

--- a/tests/v2/validation/Dockerfile.validation
+++ b/tests/v2/validation/Dockerfile.validation
@@ -5,7 +5,6 @@ ENV GOPATH /go
 ENV PATH ${PATH}:/go/bin
 
 ENV WORKSPACE ${GOPATH}/src/github.com/rancher/rancher
-
 # configure VPN
 ARG EXTERNAL_ENCODED_VPN
 ARG VPN_ENCODED_LOGIN
@@ -16,6 +15,14 @@ COPY [".", "$WORKSPACE"]
 
 RUN go mod download && \
     go install gotest.tools/gotestsum@latest
+
+
+# Configure Corral
+ENV CORRAL_VERSION="v1.1.1"
+RUN go install github.com/rancherlabs/corral@${CORRAL_VERSION}
+
+RUN mkdir /root/.ssh && chmod 600 .ssh/jenkins-*
+RUN ssh-keygen -f .ssh/jenkins-* -y > /root/.ssh/public.pub
 
 RUN CGO_ENABLED=0
 

--- a/tests/v2/validation/provisioning/config.go
+++ b/tests/v2/validation/provisioning/config.go
@@ -3,12 +3,10 @@ package provisioning
 import (
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
-	"github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 )
 
 const (
-	defaultRandStringLength = 5
-	ConfigurationFileKey    = "provisioningInput"
+	ConfigurationFileKey = "provisioningInput"
 )
 
 type Config struct {
@@ -21,9 +19,4 @@ type Config struct {
 	Providers              []string                 `json:"providers" yaml:"providers"`
 	NodeProviders          []string                 `json:"nodeProviders" yaml:"nodeProviders"`
 	Hardened               bool                     `json:"hardened" yaml:"hardened"`
-}
-
-func AppendRandomString(baseClusterName string) string {
-	clusterName := "auto-" + baseClusterName + "-" + namegenerator.RandStringLower(defaultRandStringLength)
-	return clusterName
 }

--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
@@ -57,7 +58,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	c.client = client
 
 	enabled := true
-	var testuser = provisioning.AppendRandomString("testuser-")
+	var testuser = namegen.AppendRandomString("testuser-")
 	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
@@ -116,7 +117,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningK3SCustomCluster(extern
 				nodes, err := externalNodeProvider.NodeCreationFunc(client, numNodes)
 				require.NoError(c.T(), err)
 
-				clusterName := provisioning.AppendRandomString(externalNodeProvider.Name)
+				clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
 
 				cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, nil)
 
@@ -223,7 +224,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningK3SCustomClusterDynamic
 				nodes, err := externalNodeProvider.NodeCreationFunc(client, numOfNodes)
 				require.NoError(c.T(), err)
 
-				clusterName := provisioning.AppendRandomString(externalNodeProvider.Name)
+				clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
 
 				cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, nil)
 

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
@@ -55,7 +56,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) SetupSuite() {
 	k.client = client
 
 	enabled := true
-	var testuser = provisioning.AppendRandomString("testuser-")
+	var testuser = namegen.AppendRandomString("testuser-")
 	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
@@ -137,7 +138,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) ProvisioningK3SCluster(provider Pro
 				testSessionClient, err := tt.client.WithSession(testSession)
 				require.NoError(k.T(), err)
 
-				clusterName := provisioning.AppendRandomString(provider.Name)
+				clusterName := namegen.AppendRandomString(provider.Name)
 				generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
 				machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
 
@@ -204,7 +205,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) ProvisioningK3SClusterDynamicInput(
 				testSessionClient, err := tt.client.WithSession(testSession)
 				require.NoError(k.T(), err)
 
-				clusterName := provisioning.AppendRandomString(provider.Name)
+				clusterName := namegen.AppendRandomString(provider.Name)
 				generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
 				machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
 

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
@@ -53,7 +54,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	c.client = client
 
 	enabled := true
-	var testuser = provisioning.AppendRandomString("testuser-")
+	var testuser = namegen.AppendRandomString("testuser-")
 	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
@@ -111,7 +112,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE1CustomCluster(exter
 					nodes, err := externalNodeProvider.NodeCreationFunc(client, numNodes)
 					require.NoError(c.T(), err)
 
-					clusterName := provisioning.AppendRandomString(externalNodeProvider.Name)
+					clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
 
 					cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, client)
 
@@ -201,7 +202,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE1CustomClusterDynami
 					nodes, err := externalNodeProvider.NodeCreationFunc(client, numOfNodes)
 					require.NoError(c.T(), err)
 
-					clusterName := provisioning.AppendRandomString(externalNodeProvider.Name)
+					clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
 
 					cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, client)
 

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
@@ -51,7 +52,7 @@ func (r *RKE1NodeDriverProvisioningTestSuite) SetupSuite() {
 	r.client = client
 
 	enabled := true
-	var testuser = provisioning.AppendRandomString("testuser-")
+	var testuser = namegen.AppendRandomString("testuser-")
 	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
@@ -133,7 +134,7 @@ func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1Cluster(provider P
 					testSessionClient, err := tt.client.WithSession(testSession)
 					require.NoError(r.T(), err)
 
-					clusterName := provisioning.AppendRandomString(provider.Name)
+					clusterName := namegen.AppendRandomString(provider.Name)
 
 					cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, testSessionClient)
 
@@ -203,7 +204,7 @@ func (r *RKE1NodeDriverProvisioningTestSuite) ProvisioningRKE1ClusterDynamicInpu
 					testSessionClient, err := tt.client.WithSession(testSession)
 					require.NoError(r.T(), err)
 
-					clusterName := provisioning.AppendRandomString(provider.Name)
+					clusterName := namegen.AppendRandomString(provider.Name)
 
 					cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, testSessionClient)
 

--- a/tests/v2/validation/provisioning/rke2/cert_rotation_test.go
+++ b/tests/v2/validation/provisioning/rke2/cert_rotation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
@@ -63,7 +64,7 @@ func (r *V2ProvCertRotationTestSuite) testCertRotation(provider Provider, kubeVe
 			testSessionClient, err := r.client.WithSession(testSession)
 			require.NoError(r.T(), err)
 
-			clusterName := provisioning.AppendRandomString(fmt.Sprintf("%s-%s", r.clusterName, provider.Name))
+			clusterName := namegen.AppendRandomString(fmt.Sprintf("%s-%s", r.clusterName, provider.Name))
 			generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
 			machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
 

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
@@ -56,7 +57,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	c.client = client
 
 	enabled := true
-	var testuser = provisioning.AppendRandomString("testuser-")
+	var testuser = namegen.AppendRandomString("testuser-")
 	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
@@ -116,7 +117,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 					nodes, err := externalNodeProvider.NodeCreationFunc(client, numNodes)
 					require.NoError(c.T(), err)
 
-					clusterName := provisioning.AppendRandomString(externalNodeProvider.Name)
+					clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
 
 					cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, "", kubeVersion, nil)
 
@@ -214,7 +215,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynami
 					nodes, err := externalNodeProvider.NodeCreationFunc(client, numOfNodes)
 					require.NoError(c.T(), err)
 
-					clusterName := provisioning.AppendRandomString(externalNodeProvider.Name)
+					clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
 
 					cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, "", kubeVersion, nil)
 

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -13,6 +13,7 @@ import (
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	pods "github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
@@ -58,7 +59,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 	r.client = client
 
 	enabled := true
-	var testuser = provisioning.AppendRandomString("testuser-")
+	var testuser = namegen.AppendRandomString("testuser-")
 	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
@@ -142,7 +143,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2Cluster(provider P
 					testSessionClient, err := tt.client.WithSession(testSession)
 					require.NoError(r.T(), err)
 
-					clusterName := provisioning.AppendRandomString(provider.Name)
+					clusterName := namegen.AppendRandomString(provider.Name)
 					generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
 					machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
 
@@ -212,7 +213,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2ClusterDynamicInpu
 					testSessionClient, err := tt.client.WithSession(testSession)
 					require.NoError(r.T(), err)
 
-					clusterName := provisioning.AppendRandomString(provider.Name)
+					clusterName := namegen.AppendRandomString(provider.Name)
 					generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
 					machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
 
@@ -303,7 +304,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2CNICluster(provide
 					testSessionClient, err := tt.client.WithSession(testSession)
 					require.NoError(r.T(), err)
 
-					clusterName := provisioning.AppendRandomString(provider.Name)
+					clusterName := namegen.AppendRandomString(provider.Name)
 					generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
 					machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
 

--- a/tests/v2/validation/rbac/rbac.go
+++ b/tests/v2/validation/rbac/rbac.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/projects"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
-	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 )
 
 const roleOwner = "cluster-owner"
@@ -21,7 +21,7 @@ const roleProjectMember = "project-member"
 
 func createUser(client *rancher.Client) (*management.User, error) {
 	enabled := true
-	var username = provisioning.AppendRandomString("testuser-")
+	var username = namegen.AppendRandomString("testuser-")
 	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: username,
@@ -75,7 +75,7 @@ func deleteNamespace(namespaceID *v1.SteveAPIObject, steveclient *v1.Client) err
 }
 
 func createProject(client *rancher.Client, clusterID string) (createProject *management.Project, err error) {
-	projectName := provisioning.AppendRandomString("testproject-")
+	projectName := namegen.AppendRandomString("testproject-")
 	projectConfig := &management.Project{
 		ClusterID: clusterID,
 		Name:      projectName,

--- a/tests/v2/validation/rbac/rbac_test.go
+++ b/tests/v2/validation/rbac/rbac_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
 	"github.com/rancher/rancher/tests/framework/extensions/projects"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
-	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -129,7 +129,7 @@ func (rb *RBTestSuite) ValidateNS(role string) {
 
 	//Testcase4 Validate if cluster members can create namespaces in admin created project
 	log.Info("Testcase4 - Validating if ", role, " can create namespace in admin created project. ")
-	namespaceName := provisioning.AppendRandomString("testns-")
+	namespaceName := namegen.AppendRandomString("testns-")
 	adminNamespace, err := namespaces.CreateNamespace(rb.client, namespaceName+"-admin", "{}", map[string]string{}, map[string]string{}, rb.adminProject)
 	require.NoError(rb.T(), err)
 

--- a/tests/v2/validation/standalone/README.md
+++ b/tests/v2/validation/standalone/README.md
@@ -1,0 +1,22 @@
+# Standalone Configs - Corral
+
+## Getting Started
+You should have a basic understanding of Corral before running these tests. Your GO suite should be set to `-run ^TestCorralStandaloneTestSuite$`. 
+In your config file, set the following:
+```yaml
+corralPackages:
+  corralPackageImages:
+    <nameOfPackage1>: <public corral image to deploy "ghcr.io/rancherlabs/corral/$pkg:latest>
+    ...
+  debug: <bool, default=false>
+  cleanup: <bool, default=true>
+
+corralConfigs:
+  corralConfigUser: <string, default="jenkauto">
+  corralConfigVars:
+    <var1>: <string, "val1">
+    ...
+  corralSSHPath: <string, optional, mostly for local testing>
+```
+Note: `corralConfigUser` will be the prefix for all resources created in your provider. 
+From there, your `corralConfigVars` should contain the parameters necessary to run the test. You can see what variables need to be set by navigating to your corral package folder and checking the `manifest.yaml` variables.

--- a/tests/v2/validation/standalone/corral_generic_test.go
+++ b/tests/v2/validation/standalone/corral_generic_test.go
@@ -1,0 +1,55 @@
+package standalone
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/corral"
+
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type CorralStandaloneTestSuite struct {
+	suite.Suite
+	session *session.Session
+}
+
+func (r *CorralStandaloneTestSuite) TearDownSuite() {
+	r.session.Cleanup()
+}
+
+func (r *CorralStandaloneTestSuite) SetupSuite() {
+	testSession := session.NewSession(r.T())
+	r.session = testSession
+
+	corralConfig := corral.CorralConfigurations()
+	err := corral.SetupCorralConfig(corralConfig.CorralConfigVars, corralConfig.CorralConfigUser, corralConfig.CorralSSHPath)
+	require.NoError(r.T(), err, "error reading corral configs")
+}
+
+func (r *CorralStandaloneTestSuite) TestGenericCorralPackage() {
+	corralPackage := corral.CorralPackagesConfig()
+	// Expecting in the future, we will be mainly running from publically available corral images
+	if corralPackage.CustomRepo != "" {
+		err := corral.SetCustomRepo(corralPackage.CustomRepo)
+		require.Nil(r.T(), err, "error setting remote repo")
+	}
+	newPackages := []string{}
+	if len(corralPackage.CorralPackageImages) == 0 {
+		r.T().Error("No Corral Packages to Test")
+	}
+	for packageName, packageImage := range corralPackage.CorralPackageImages {
+		newPackageName := namegen.AppendRandomString(packageName)
+		newPackages = append(newPackages, newPackageName)
+		corralRun, err := corral.CreateCorral(r.session, newPackageName, packageImage, corralPackage.Debug, corralPackage.Cleanup)
+		require.NoError(r.T(), err, "error creating corral %v", packageName)
+		r.T().Logf("Corral %v created successfully", packageName)
+		require.NotNil(r.T(), corralRun, "corral run had no restConfig")
+	}
+}
+
+func TestCorralStandaloneTestSuite(t *testing.T) {
+	suite.Run(t, new(CorralStandaloneTestSuite))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
forward port of: https://github.com/rancher/rancher/pull/39752
https://github.com/rancher/qa-tasks/issues/357
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
we want a way to rehydrate an rke2 cluster - specifically the local cluster running rancher
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
In order to modify a local cluster, I added a test case for Corral. This also required modifying the dockerfile to install corral. The test suite currently can only handle running corrals that do not depend on eachother in any way, as the order is psudorandom ([see this issue](https://github.com/rancher/qa-tasks/issues/540) for more details)
In the test case, I include 2 corral packages: one to provision the local cluster (which was largely based on packges from the example https://github.com/rancherlabs/corral-packages repo) and another to modify it, replacing x number of server nodes in the cluster. Please see the updated readmes in their respective folder/package

While adding the test for corral. I also added some new variables when using corral in our golang framework. These are also updated in the readme, so please read it for more details (in standalone v2/validation test suite). IMO, the most important reason I added these is that the `corralConfigUser: <string, default="jenkauto">` user is what is used to name resources created in the backend, which is important for cleanup and correct naming practices we should be updating this to our own shortname (i.e. ctw for me). 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
local and remote testing (through jenkins) is done.  Will link privately. 
