### PR TITLE
[2.6] Backport: Support CATTLE_WHITELIST_ENVVARS in RKE2 provisioning code

### DIFF
--- a/pkg/jailer/jailer.go
+++ b/pkg/jailer/jailer.go
@@ -77,20 +77,9 @@ func CreateJail(name string) error {
 	return nil
 }
 
-func WhitelistEnvvars(envvars []string) []string {
-	wl := settings.WhitelistEnvironmentVars.Get()
-	envWhiteList := strings.Split(wl, ",")
-
-	if len(envWhiteList) == 0 {
-		return envvars
-	}
-
-	for _, wlVar := range envWhiteList {
-		wlVar = strings.TrimSpace(wlVar)
-		if val := os.Getenv(wlVar); val != "" {
-			envvars = append(envvars, wlVar+"="+val)
-		}
-	}
-
+func getWhitelistedEnvVars(envvars []string) []string {
+	settings.IterateWhitelistedEnvVars(func(name, value string) {
+		envvars = append(envvars, name+"="+value)
+	})
 	return envvars
 }

--- a/pkg/jailer/jailer_linux.go
+++ b/pkg/jailer/jailer_linux.go
@@ -23,7 +23,7 @@ func JailCommand(cmd *exec.Cmd, jailPath string) (*exec.Cmd, error) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
 	cmd.SysProcAttr.Credential = cred
 	cmd.SysProcAttr.Chroot = jailPath
-	cmd.Env = WhitelistEnvvars(cmd.Env)
+	cmd.Env = getWhitelistedEnvVars(cmd.Env)
 	cmd.Env = append(cmd.Env, "PWD=/")
 	cmd.Dir = "/"
 	return cmd, nil

--- a/pkg/jailer/jailer_test.go
+++ b/pkg/jailer/jailer_test.go
@@ -39,7 +39,7 @@ func Test_WhitelistEnvvars(t *testing.T) {
 
 	for _, tc := range testCases {
 		os.Setenv("ENVVAR_FOO", tc.envValue)
-		envs := WhitelistEnvvars(tc.input)
+		envs := getWhitelistedEnvVars(tc.input)
 		assert.Equal(t, envs, tc.expected)
 	}
 

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -384,3 +384,18 @@ func GetRancherVersion() string {
 	}
 	return strings.TrimPrefix(rancherVersion, "v")
 }
+
+// IterateWhitelistedEnvVars iterates over the environment variables whitelisted
+// by CATTLE_WHITELIST_ENVVARS. If a variable is whitelisted but unset or empty,
+// the handler function will not be called for it.
+func IterateWhitelistedEnvVars(handler func(name, value string)) {
+	wl := WhitelistEnvironmentVars.Get()
+	envWhiteList := strings.Split(wl, ",")
+
+	for _, wlVar := range envWhiteList {
+		wlVar = strings.TrimSpace(wlVar)
+		if val := os.Getenv(wlVar); val != "" {
+			handler(wlVar, val)
+		}
+	}
+}


### PR DESCRIPTION
This allows passing down environment variables to rancher machine during provisioning.

## Issue: #39387 

Backport of #40015 