### PR TITLE
bump tags for UI and CLI to v2.7.2-rc1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -159,10 +159,9 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-# Versions for UI, DASHBOARD and CLI will be the same as 2.6 until new releases are made to these
-ENV CATTLE_UI_VERSION 2.7.0-rc10
-ENV CATTLE_DASHBOARD_UI_VERSION v2.7.0-rc10
-ENV CATTLE_CLI_VERSION v2.7.0-rc1
+ENV CATTLE_UI_VERSION 2.7.2-rc1
+ENV CATTLE_DASHBOARD_UI_VERSION v2.7.2-rc1
+ENV CATTLE_CLI_VERSION v2.7.2-rc1
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install
 ENV CATTLE_BASE_UI_BRAND=


### PR DESCRIPTION
This PR bump tags for UI and CLI to `v2.7.2-rc1` 