### PR TITLE
[2.7.3+] Re-enable several RKE2 tests

### DIFF
--- a/tests/integration/pkg/tests/machineprovisioning/machine_test.go
+++ b/tests/integration/pkg/tests/machineprovisioning/machine_test.go
@@ -99,10 +99,13 @@ func TestSingleNodeAllRolesWithDelete(t *testing.T) {
 }
 
 func TestMachineTemplateClonedAnnotations(t *testing.T) {
+	// This test focuses on the behavior provisioning V2 controllers. The behavior
+	// of these controllers are not dependent on the specific kubernetes distribution
+	// the Rancher server is running on. Because of this, we only run this test on one
+	// distribution (k3s) so as not to duplicate test coverage.
 	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
 		t.Skip()
 	}
-
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)
@@ -161,10 +164,13 @@ func TestMachineTemplateClonedAnnotations(t *testing.T) {
 }
 
 func TestMachineSetDeletePolicyOldestSet(t *testing.T) {
+	// This test focuses on the behavior provisioning V2 controllers. The behavior
+	// of these controllers are not dependent on the specific kubernetes distribution
+	// the Rancher server is running on. Because of this, we only run this test on one
+	// distribution (k3s) so as not to duplicate test coverage.
 	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
 		t.Skip()
 	}
-
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)
@@ -274,9 +280,7 @@ func TestThreeNodesAllRolesWithDelete(t *testing.T) {
 }
 
 func TestFiveNodesUniqueRolesWithDelete(t *testing.T) {
-	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
-		t.Skip()
-	}
+
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)
@@ -329,9 +333,7 @@ func TestFiveNodesUniqueRolesWithDelete(t *testing.T) {
 }
 
 func TestFourNodesServerAndWorkerRolesWithDelete(t *testing.T) {
-	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
-		t.Skip()
-	}
+
 	t.Parallel()
 	clients, err := clients.New()
 	if err != nil {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40055
 
## Problem
A prior PR temporarily disabled several test cases for RKE2 clusters, but we never reenabled them until now.
 
## Solution
Remove conditions which resulted in tests being skipped for RKE2 clusters, the tests being reenabled are 

`TestMachineTemplateClonedAnnotations` `TestMachineSetDeletePolicyOldestSet` `TestFiveNodesUniqueRolesWithDelete` and `TestFourNodesServerAndWorkerRolesWithDelete`

## Testing
Ensure the drone CI runs these tests and that they pass

## Engineering Testing
### Manual Testing
I've done the above, everything seems to be working properly and these tests run without issue

### Automated Testing
Reenabled several RKE2 test cases

## QA Testing Considerations
n/a, a quick look at the drone build should be all that's needed
 
### Regressions Considerations
n/a