### PR TITLE
[Backport v2.6] Skip adding etcd taint for k3s

### DIFF
--- a/pkg/provisioningv2/rke2/planner/agent.go
+++ b/pkg/provisioningv2/rke2/planner/agent.go
@@ -37,7 +37,7 @@ func (p *Planner) generateClusterAgentManifest(controlPlane *rkev1.RKEControlPla
 		return nil, err
 	}
 
-	taints, err := getTaints(entry)
+	taints, err := getTaints(entry, controlPlane)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provisioningv2/rke2/planner/config.go
+++ b/pkg/provisioningv2/rke2/planner/config.go
@@ -348,12 +348,12 @@ func addLabels(config map[string]interface{}, entry *planEntry) error {
 	return nil
 }
 
-func addTaints(config map[string]interface{}, entry *planEntry) error {
+func addTaints(config map[string]interface{}, entry *planEntry, cp *rkev1.RKEControlPlane) error {
 	var (
 		taintString []string
 	)
 
-	taints, err := getTaints(entry)
+	taints, err := getTaints(entry, cp)
 	if err != nil {
 		return err
 	}
@@ -446,7 +446,7 @@ func (p *Planner) addConfigFile(nodePlan plan.NodePlan, controlPlane *rkev1.RKEC
 	if err := addLabels(config, entry); err != nil {
 		return nodePlan, config, err
 	}
-	if err := addTaints(config, entry); err != nil {
+	if err := addTaints(config, entry, controlPlane); err != nil {
 		return nodePlan, config, err
 	}
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #40052
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Original Issue: #40016

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

K3s cluster system pods + charts do NOT have the correct tolerations to be able to run on a controlplane + etcd node

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Do not add the etcd taint to etcd nodes if the runtime is k3s and it is also a controlplane node.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually, confirmed etcd taint was not present for split role clusters. Tested upgrade from v2.7.0 v1.24.8+k3s1 on original PR.