### PR TITLE
Add a path to the Ingress rule in the Rancher chart

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -55,6 +55,7 @@ spec:
           {{- end }}
         {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
         pathType: ImplementationSpecific
+        path: "/"
         {{- end }}
 {{- if eq .Values.tls "ingress" }}
   tls:

--- a/chart/tests/ingress_test.yaml
+++ b/chart/tests/ingress_test.yaml
@@ -221,3 +221,18 @@ tests:
         nginx.ingress.kubernetes.io/configuration-snippet: |
           more_set_input_headers "X-Forwarded-Host: host.example.com";
           more_set_input_headers "foo: bar";
+- it: should create a http rule with path
+  set:
+    hostname: host.example.com
+  asserts:
+  - equal:
+      path: spec.rules
+      value:
+        - host: host.example.com
+          paths:
+          - service:
+              name: RELEASE-NAME-rancher
+              port:
+                number: 80
+            pathType: ImplementationSpecific
+            path: /

--- a/chart/tests/ingress_test.yaml
+++ b/chart/tests/ingress_test.yaml
@@ -229,10 +229,12 @@ tests:
       path: spec.rules
       value:
         - host: host.example.com
-          paths:
-          - service:
-              name: RELEASE-NAME-rancher
-              port:
-                number: 80
-            pathType: ImplementationSpecific
-            path: /
+          http:
+            paths:
+            - backend:
+                service:
+                  name: RELEASE-NAME-rancher
+                  port:
+                    number: 80
+              pathType: ImplementationSpecific
+              path: /


### PR DESCRIPTION
## Issue: #39638
 
## Problem
The ingress rule in the Rancher chart is missing a `path`, which is required by some ingress controllers.
 
## Solution
Add a path to the Ingress rule in the Rancher chart to make it compatible with ingress controllers that require a path to be present.

## Testing
Install Rancher with the updated chart.

## Engineering Testing
### Manual Testing
I did the following tests:
* Installing Rancher with the updated chart into a K3s cluster
* Installing Rancher with the 2.7.0 chart and upgrading it with the updated chart into a K3s cluster
* Installing Rancher with the updated chart into a RKE2 cluster
* Installing Rancher with the 2.7.0 chart and upgrading it with the updated chart into a RKE2 cluster

## QA Testing Considerations
Rancher installations and upgrades should work.
 