### PR TITLE
fixing PSP integration tests for 1.25+

### DIFF
--- a/tests/integration/suite/test_cluster_defaults.py
+++ b/tests/integration/suite/test_cluster_defaults.py
@@ -5,6 +5,20 @@ from .common import random_str
 from .conftest import wait_for
 
 
+@pytest.fixture(scope='module')
+def check_cluster_kubernetes_version(admin_mc):
+    """
+       Checks the local cluster's k8s version
+    """
+    client = admin_mc.client
+    cluster = client.by_id_cluster("local")
+    version = cluster.get("version")
+    if version is not None:
+        k8s_version = int(version.get("gitVersion")[3:5])
+        if k8s_version >= 25:
+            pytest.skip("Needs to be reworked for PSA")
+
+
 @pytest.mark.skip(reason="cluster-defaults disabled")
 def test_generic_initial_defaults(admin_mc):
     cclient = admin_mc.client
@@ -127,6 +141,7 @@ def test_rke_initial_conditions(admin_mc, remove_resource):
     assert 'exportYaml' in cluster.actions
 
 
+@pytest.mark.usefixtures('check_cluster_kubernetes_version')
 def test_psp_enabled_set(admin_mc, remove_resource):
     """Asserts podSecurityPolicy field is used to populate pspEnabled in
     cluster capabilities"""

--- a/tests/integration/suite/test_clustertemplate.py
+++ b/tests/integration/suite/test_clustertemplate.py
@@ -8,6 +8,20 @@ import kubernetes
 rb_resource = 'rolebinding'
 
 
+@pytest.fixture(scope='module')
+def check_cluster_kubernetes_version(admin_mc):
+    """
+       Checks the local cluster's k8s version
+    """
+    client = admin_mc.client
+    cluster = client.by_id_cluster("local")
+    version = cluster.get("version")
+    if version is not None:
+        k8s_version = int(version.get("gitVersion")[3:5])
+        if k8s_version >= 25:
+            pytest.skip("Needs to be reworked for PSA")
+
+
 def test_create_cluster_template_with_revision(admin_mc, remove_resource):
 
     cluster_template = create_cluster_template(admin_mc, [], admin_mc)
@@ -61,6 +75,7 @@ def test_create_template_revision_k8s_translation(admin_mc, remove_resource):
     assert e.value.error.status == 422
 
 
+@pytest.mark.usefixtures('check_cluster_kubernetes_version')
 def test_default_pod_sec(admin_mc, list_remove_resource):
     cluster_template = create_cluster_template(admin_mc,
                                                [], admin_mc)
@@ -480,6 +495,7 @@ def test_permissions_removed_on_downgrading_access(admin_mc, remove_resource,
         assert e.error.status == 403
 
 
+@pytest.mark.usefixtures('check_cluster_kubernetes_version')
 def test_required_template_question(admin_mc, remove_resource):
     cluster_template = create_cluster_template(admin_mc, [], admin_mc)
     remove_resource(cluster_template)
@@ -537,6 +553,7 @@ def test_required_template_question(admin_mc, remove_resource):
         assert e.error.status == 422
 
 
+@pytest.mark.usefixtures('check_cluster_kubernetes_version')
 def test_secret_template_answers(admin_mc, remove_resource,
                                  list_remove_resource):
     cluster_template = create_cluster_template(admin_mc, [], admin_mc)
@@ -647,6 +664,7 @@ def test_member_accesstype_check(admin_mc, user_factory, remove_resource):
         assert e.error.status == 422
 
 
+@pytest.mark.usefixtures('check_cluster_kubernetes_version')
 def test_create_cluster_with_invalid_revision(admin_mc, remove_resource):
     cluster_template = create_cluster_template(admin_mc, [], admin_mc)
     remove_resource(cluster_template)
@@ -834,6 +852,7 @@ def test_cluster_desc_update(admin_mc, list_remove_resource):
     wait_for_cluster_to_be_deleted(client, cluster.id)
 
 
+@pytest.mark.usefixtures('check_cluster_kubernetes_version')
 def test_update_cluster_monitoring(admin_mc, list_remove_resource):
     cluster_template = create_cluster_template(admin_mc, [], admin_mc)
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
builds have been failing due to some PSP tests running on the latest (1.25+ does not support PSPs)
 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
adding a condition to pytest to check the k8s version of the cluster. If the cluster is 1.25 or above, we will not run the tests marked as including PSPs. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
testing is part of integration -> drone


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 we should add PSA tests for 1.25+ in the new (golang) integration tests. 