### PR TITLE
[v2.7] Refactor RKE1 into separate test functions

### DIFF
--- a/tests/framework/extensions/rke1/nodepools/nodepools.go
+++ b/tests/framework/extensions/rke1/nodepools/nodepools.go
@@ -87,7 +87,7 @@ func NodePoolSetup(client *rancher.Client, nodeRoles []NodeRoles, ClusterID, Nod
 		nodePoolConfig.Etcd = roles.Etcd
 		nodePoolConfig.Worker = roles.Worker
 		nodePoolConfig.Quantity = roles.Quantity
-		nodePoolConfig.HostnamePrefix = "auto-rke1-" + strconv.Itoa(index)
+		nodePoolConfig.HostnamePrefix = "auto-rke1-" + strconv.Itoa(index) + ClusterID
 
 		_, err := client.Management.NodePool.Create(&nodePoolConfig)
 

--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -221,7 +221,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningK3SCustomClusterDynamic
 				client, err := tt.client.WithSession(testSession)
 				require.NoError(c.T(), err)
 
-				nodes, _, err := externalNodeProvider.NodeCreationFunc(client, numOfNode, 0, false)
+				nodes, _, err := externalNodeProvider.NodeCreationFunc(client, numOfNodes, 0, false)
 				require.NoError(c.T(), err)
 
 				clusterName := namegen.AppendRandomString(externalNodeProvider.Name)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Refactor RKE1 provisioning test to use separate test functions for additional tests](https://github.com/rancher/qa-tasks/issues/558)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Recently, we refactored the hosted provisioning tests to do two of the following:

- Rework redundant provisioning code into a private method
- Separate provisioning test and additional test cases into their own, unique test functions

This greatly helps moving forward for internal CI/CD pipeline and overall helps to better organize our ever-growing test framework. As such, the same approach has been made to the RKE1 provisioning tests.

Once this is done, the same effort will be done for RKE2/K3s, to ensure full parity across the board.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Like with the hosted provisioning tests, the redundant provisioning code for node provider and custom clusters has been put into a single private method. The now separated unique test functions reference this private method and only keep unique code in their respective functions.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Locally tested static and dynamic input functions for both node provider and custom cluster.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Jenkins runs will be provided offline to reviewers.