### PR TITLE
[2.7] Fix validation tests' random string generator imports

### DIFF
--- a/tests/v2/validation/provisioning/hosted/aks/provisioning/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/aks/provisioning/hosted_provisioning_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/clusters/aks"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
-	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -42,7 +42,7 @@ func (h *HostedAKSClusterProvisioningTestSuite) SetupSuite() {
 	h.client = client
 
 	enabled := true
-	var testuser = provisioning.AppendRandomString("testuser-")
+	var testuser = namegen.AppendRandomString("testuser-")
 	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
@@ -113,7 +113,7 @@ func (h *HostedAKSClusterProvisioningTestSuite) testProvisioningHostedAKSCluster
 	cloudCredential, err := azure.CreateAzureCloudCredentials(rancherClient)
 	require.NoError(h.T(), err)
 
-	clusterName = provisioning.AppendRandomString("akshostcluster")
+	clusterName = namegen.AppendRandomString("akshostcluster")
 	clusterResp, err := aks.CreateAKSHostedCluster(rancherClient, clusterName, cloudCredential.ID, false, false, false, false, map[string]string{})
 	require.NoError(h.T(), err)
 

--- a/tests/v2/validation/provisioning/hosted/eks/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/eks/hosted_provisioning_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/clusters/eks"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
-	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -42,7 +42,7 @@ func (h *HostedEKSClusterProvisioningTestSuite) SetupSuite() {
 	h.client = client
 
 	enabled := true
-	var testuser = provisioning.AppendRandomString("testuser-")
+	var testuser = namegen.AppendRandomString("testuser-")
 	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
@@ -90,7 +90,7 @@ func (h *HostedEKSClusterProvisioningTestSuite) testProvisioningHostedEKSCluster
 	cloudCredential, err := aws.CreateAWSCloudCredentials(rancherClient)
 	require.NoError(h.T(), err)
 
-	clusterName = provisioning.AppendRandomString("ekshostcluster")
+	clusterName = namegen.AppendRandomString("ekshostcluster")
 	clusterResp, err := eks.CreateEKSHostedCluster(rancherClient, clusterName, cloudCredential.ID, false, false, false, false, map[string]string{})
 	require.NoError(h.T(), err)
 

--- a/tests/v2/validation/provisioning/hosted/gke/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/gke/hosted_provisioning_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/clusters/gke"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
-	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -42,7 +42,7 @@ func (h *HostedGKEClusterProvisioningTestSuite) SetupSuite() {
 	h.client = client
 
 	enabled := true
-	var testuser = provisioning.AppendRandomString("testuser-")
+	var testuser = namegen.AppendRandomString("testuser-")
 	var testpassword = password.GenerateUserPassword("testpass-")
 	user := &management.User{
 		Username: testuser,
@@ -90,7 +90,7 @@ func (h *HostedGKEClusterProvisioningTestSuite) testProvisioningHostedGKECluster
 	cloudCredential, err := google.CreateGoogleCloudCredentials(rancherClient)
 	require.NoError(h.T(), err)
 
-	clusterName = provisioning.AppendRandomString("gkehostcluster")
+	clusterName = namegen.AppendRandomString("gkehostcluster")
 	clusterResp, err := gke.CreateGKEHostedCluster(rancherClient, clusterName, cloudCredential.ID, false, false, false, false, map[string]string{})
 	require.NoError(h.T(), err)
 

--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
 
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
@@ -87,7 +89,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithK8sUpgrade(pro
 	require.NoError(r.T(), err)
 	logrus.Infof("kube provisioning client created.............")
 
-	clusterName := provisioning.AppendRandomString(provider.Name)
+	clusterName := namegen.AppendRandomString(provider.Name)
 
 	logrus.Infof("creating rke2Cluster.............")
 	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0])

--- a/tests/v2/validation/rbac/rbac_test.go
+++ b/tests/v2/validation/rbac/rbac_test.go
@@ -130,7 +130,6 @@ func (rb *RBTestSuite) ValidateNS(role string) {
 	//Testcase4 Validate if cluster members can create namespaces in project they are not owner of
 	log.Info("Testcase4 - Validating if ", role, " can create namespace in a project they are not owner of. ")
 	namespaceName := namegen.AppendRandomString("testns-")
-	createdNamespace, err := namespaces.CreateNamespace(rb.standardUserClient, namespaceName, "{}", map[string]string{}, map[string]string{}, rb.adminProject)
 	adminNamespace, err := namespaces.CreateNamespace(rb.client, namespaceName+"-admin", "{}", map[string]string{}, map[string]string{}, rb.adminProject)
 	require.NoError(rb.T(), err)
 


### PR DESCRIPTION
**Validation Tests**
- Updated:
  - Hosted provisioning validation tests package and imports.
  - ETCD validation tests package and imports.
  - Removed unnecessary namespace creation duplication in RBAC validation tests.