### PR TITLE
Fix for Windows 1809 build; also removal of custom ltsc2022 image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -795,6 +795,11 @@ platform:
   arch: amd64
   version: 1809
 
+# Currently have to define "depth" as otherwise clone fails at
+# https://github.com/drone/drone-git/blob/39d233b3d9eccc68e66508a06a725a2567f33143/windows/clone-tag.ps1#L12
+clone:
+  depth: 20
+
 steps:
   - name: build-pr
     pull: always
@@ -915,15 +920,12 @@ platform:
   arch: amd64
   version: 2022
 
-# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
+# Currently have to define "depth" as otherwise clone fails at
+# https://github.com/drone/drone-git/blob/39d233b3d9eccc68e66508a06a725a2567f33143/windows/clone-tag.ps1#L12
 clone:
-  disable: true
+  depth: 20
 
 steps:
-  - name: clone
-    image: rancher/drone-images:git-amd64-ltsc2022
-    settings:
-      depth: 20
   - name: build-pr
     pull: always
     image: rancher/dapper:v0.5.8
@@ -1370,6 +1372,11 @@ platform:
   arch: amd64
   version: 1809
 
+# Currently have to define "depth" as otherwise clone fails at
+# https://github.com/drone/drone-git/blob/39d233b3d9eccc68e66508a06a725a2567f33143/windows/clone-tag.ps1#L12
+clone:
+  depth: 20
+
 steps:
 - name: docker-image-digests
   image: rancher/drone-docker-image-digests:v0.0.12
@@ -1415,16 +1422,12 @@ platform:
   arch: amd64
   version: 2022
 
-# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
+# Currently have to define "depth" as otherwise clone fails at
+# https://github.com/drone/drone-git/blob/39d233b3d9eccc68e66508a06a725a2567f33143/windows/clone-tag.ps1#L12
 clone:
-  disable: true
+  depth: 20
 
 steps:
-- name: clone
-  image: rancher/drone-images:git-amd64-ltsc2022
-  settings:
-    depth: 1
-
 - name: docker-image-digests
   image: rancher/drone-docker-image-digests:v0.0.12
   environment:


### PR DESCRIPTION
Fix for Windows 1809 build, see https://github.com/rancher/system-agent-installer-rke2/pull/37 for details on reasons.

Also, removed usage of custom `rancher/drone-images:git-amd64-ltsc2022` image as linked issue is now closed per https://github.com/drone/drone-git/pull/25#issuecomment-761946952