### PR TITLE
[DNM investigation needed] Fix panic when SA token secret is empty for eks cluster

### DIFF
--- a/pkg/controllers/management/aks/aks_cluster_handler.go
+++ b/pkg/controllers/management/aks/aks_cluster_handler.go
@@ -193,6 +193,10 @@ func (e *aksOperatorController) onClusterChange(_ string, cluster *apimgmtv3.Clu
 					if err != nil {
 						return cluster, err
 					}
+					if secret == nil {
+						logrus.Debugf("Empty service account token secret returned for cluster [%s]", cluster.Name)
+						return cluster, fmt.Errorf("failed to create or update service account token secret, secret can't be empty")
+					}
 					cluster.Status.ServiceAccountTokenSecret = secret.Name
 					cluster.Status.ServiceAccountToken = ""
 				}

--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -257,6 +257,10 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 					if err != nil {
 						return cluster, err
 					}
+					if secret == nil {
+						logrus.Debugf("Empty service account token secret returned for cluster [%s]", cluster.Name)
+						return cluster, fmt.Errorf("failed to create or update service account token secret, secret can't be empty")
+					}
 					cluster.Status.ServiceAccountTokenSecret = secret.Name
 					cluster.Status.ServiceAccountToken = ""
 				}

--- a/pkg/controllers/management/gke/gke_cluster_handler.go
+++ b/pkg/controllers/management/gke/gke_cluster_handler.go
@@ -203,6 +203,10 @@ func (e *gkeOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 					if err != nil {
 						return cluster, err
 					}
+					if secret == nil {
+						logrus.Debugf("Empty service account token secret returned for cluster [%s]", cluster.Name)
+						return cluster, fmt.Errorf("failed to create or update service account token secret, secret can't be empty")
+					}
 					cluster.Status.ServiceAccountTokenSecret = secret.Name
 					cluster.Status.ServiceAccountToken = ""
 				}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Issue??

Someone apparently saw this here https://github.com/rancher/rancher/issues/41299#issuecomment-1523015726
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
If an empty secret is returned then attempting to set `cluster.Status.ServiceAccountTokenSecret` will cause panic

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

I added a check for nil pointer that will likely not solve the root cause of the problem but the controller won't panic and return some meaningful error and include debug logs.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->