### PR TITLE
[v2.6] Adjust object conflict errors in the provisioning log

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/provisioninglog/provisioninglog.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioninglog/provisioninglog.go
@@ -97,6 +97,10 @@ func (h *handler) recordMessage(provCluster *provv1.Cluster, cm *corev1.ConfigMa
 		return cm, nil
 	}
 
+	if strings.Contains(msg, "the object has been modified; please apply your changes to the latest version and try again") {
+		msg = fmt.Sprintf("Transient error encountered: %s", msg)
+	}
+
 	last := cm.Data["last"]
 	if msg == last {
 		return cm, nil


### PR DESCRIPTION
## Issue: 

cherry picked backport (bfbc6529748c1afc3f662533b2a74d23af55bb6e) of https://github.com/rancher/rancher/pull/40076 

## Problem
There are intermittent error messages reported in the provisioning log relating to object version conflicts. In all observed scenarios these error messages are benign and resolve themselves automatically. However, the presence of these error messages and subsequent UI display gives the end user an impression that something has failed, when in fact the issue is only temporary.
 
## Solution
Prepend a message stating that this is a transient error, so as to ensure the end user that the provisioning process has not encountered a significant error that needs to be remediated 


## Testing
+ Create a rancher server 
+ provision an RKE2 cluster on any infrastructure provider. Create 3-5 nodes in a single all role node pool
+ observe that the error message is now prepended with `Transient Error Encountered: ...` 

## Engineering Testing
### Manual Testing
I've done the above

### Automated Testing
n/a

## QA Testing Considerations
reproducing the original error is difficult, i've had some success by limiting the resources available to the Rancher server. 

Using 3-5 nodes seems to have this error appear more frequently. 

I've also seen this error occur when scaling up and down, but even when doing this the error is still not consistent. 
 
### Regressions Considerations
This change modifies certain log messages, it has no impact on existing functionality outside of what is shown in the UI. 