### PR TITLE
Moved control plane ready status to planner

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/rkecontrolplane/controlplane.go
+++ b/pkg/controllers/provisioningv2/rke2/rkecontrolplane/controlplane.go
@@ -78,8 +78,6 @@ func (h *handler) OnChange(obj *rkev1.RKEControlPlane, status rkev1.RKEControlPl
 		return status, nil
 	}
 
-	status.Ready = rke2.Ready.IsTrue(cluster)
-	status.Initialized = rke2.Ready.IsTrue(cluster)
 	status.AgentConnected = clusterconnected.Connected.IsTrue(cluster)
 	return status, nil
 }

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -370,6 +370,17 @@ func (p *Planner) Process(controlPlane *rkev1.RKEControlPlane) error {
 		return ErrWaiting("waiting for control plane to be available")
 	}
 
+	if controlPlane.Status.Initialized != true || controlPlane.Status.Ready != true {
+		controlPlane = controlPlane.DeepCopy()
+		controlPlane.Status.Initialized = true
+		controlPlane.Status.Ready = true
+		_, err := p.rkeControlPlanes.UpdateStatus(controlPlane)
+		if err != nil {
+			return err
+		}
+		return ErrWaiting("marking control plane initialized and ready")
+	}
+
 	err = p.reconcile(controlPlane, clusterSecretTokens, plan, false, workerTier, isOnlyWorker, isInitNodeOrDeleting,
 		controlPlane.Spec.UpgradeStrategy.WorkerConcurrency, joinServer,
 		controlPlane.Spec.UpgradeStrategy.WorkerDrainOptions)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #39139
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

This PR fixes node auto replace by changing how the control plane's ready status field is set.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

### Node Auto Replace

- Mark the control plane as initialized and ready [according to the upstream CAPI spec](https://cluster-api.sigs.k8s.io/developer/architecture/controllers/control-plane.html#required-status-fields):

Field | Type | Description | Implementation in Kubeadm Control Plane Controller
-- | -- | -- | --
initialized | Boolean | a boolean field that is true when the target cluster has completed initialization such that at least once, the target's control plane has been contactable. | Transitions to initialized when the controller detects that kubeadm has uploaded a kubeadm-config configmap, which occurs at the end of kubeadm provisioning.
ready | Boolean | Ready denotes that the target API Server is ready to receive requests.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

I tested node auto replace manually, and it functioned as expected.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

I recommend running through the entire gambit of tests related to v2prov.

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

It is currently unknown what effects this may have, hence the recommendation to test as much as possible.