### PR TITLE
Restart cluster controllers when remote cluster's major or minor version changes

### DIFF
--- a/pkg/controllers/managementapi/usercontrollers/usercontroller.go
+++ b/pkg/controllers/managementapi/usercontrollers/usercontroller.go
@@ -9,13 +9,9 @@ import (
 	"sync"
 	"time"
 
-	mVersion "github.com/mcuadros/go-version"
-	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types"
+	v33 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/clustermanager"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/metrics"
@@ -24,17 +20,20 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/version"
 )
 
 var (
 	all = "_all_"
 )
 
-const controllersRestartedAnnotation = "mgmt.cattle.io/controllers-restarted"
+// currentClusterControllersVersion is the version of the controllers that are run in the local cluster for a particular downstream cluster.
+const currentClusterControllersVersion = "management.cattle.io/current-cluster-controllers-version"
 
 func Register(ctx context.Context, scaledContext *config.ScaledContext, clusterManager *clustermanager.Manager) {
 	u := &userControllersController{
-		manager:       clusterManager,
+		starter:       clusterManager,
 		clusterLister: scaledContext.Management.Clusters("").Controller().Lister(),
 		clusters:      scaledContext.Management.Clusters(""),
 		clustered:     scaledContext.PeerManager != nil,
@@ -77,10 +76,16 @@ func Register(ctx context.Context, scaledContext *config.ScaledContext, clusterM
 	}()
 }
 
+// controllerStarter starts and stops controllers for a given cluster.
+type controllerStarter interface {
+	Start(ctx context.Context, cluster *v3.Cluster, clusterOwner bool) error
+	Stop(cluster *v3.Cluster)
+}
+
 type userControllersController struct {
 	sync.Mutex
 	clustered     bool
-	manager       *clustermanager.Manager
+	starter       controllerStarter
 	clusterLister v3.ClusterLister
 	clusters      v3.ClusterInterface
 	ctx           context.Context
@@ -99,18 +104,35 @@ func (u *userControllersController) sync(key string, cluster *v3.Cluster) (runti
 		return nil, u.setPeers(nil)
 	}
 
-	//TODO: Check if the cluster has been upgraded in a generic way and always restart on any version upgrade
-	if cluster != nil && cluster.Status.Version != nil && mVersion.Compare(cluster.Status.Version.String(), "v1.25", ">=") && !u.controllersRestarted(cluster) {
-		u.manager.Stop(cluster)
-		err := u.manager.Start(u.ctx, cluster, u.amOwner(u.peers, cluster))
+	// Check if the cluster has been upgraded to a major or minor version and restart the controllers.
+	if cluster != nil && cluster.Status.Version != nil {
+		var err error
+		currentVersion, err := getCurrentClusterControllersVersion(cluster)
+		// If the version is not found on the annotation, set it and update the cluster object.
 		if err != nil {
-			return nil, fmt.Errorf("unable to restart controllers for cluster %s: %w", cluster.Name, err)
+			if cluster, err = u.saveClusterControllersVersionAnnotation(cluster, cluster.Status.Version.String()); err != nil {
+				return nil, err
+			}
+			return cluster, nil
 		}
-		cluster = cluster.DeepCopy()
-		cluster.Annotations[controllersRestartedAnnotation] = "true"
-		cluster, err = u.clusters.Update(cluster)
+
+		newVersion, err := version.ParseSemantic(cluster.Status.Version.String())
 		if err != nil {
-			return nil, fmt.Errorf("unable to update cluster with annotation indicating cluster controllers were restarted: %w", err)
+			logrus.Errorf("failed to parse the K8s version of the upgraded cluster %s, will not restart cluster controllers: %v", cluster.Name, err)
+			return cluster, nil
+		}
+
+		if !clusterVersionChanged(currentVersion, newVersion) {
+			return cluster, nil
+		}
+
+		u.starter.Stop(cluster)
+		err = u.starter.Start(u.ctx, cluster, u.amOwner(u.peers, cluster))
+		if err != nil {
+			return cluster, fmt.Errorf("unable to restart controllers for cluster %s: %w", cluster.Name, err)
+		}
+		if cluster, err = u.saveClusterControllersVersionAnnotation(cluster, newVersion.String()); err != nil {
+			return nil, err
 		}
 	}
 
@@ -118,9 +140,27 @@ func (u *userControllersController) sync(key string, cluster *v3.Cluster) (runti
 	return cluster, nil
 }
 
-func (u *userControllersController) controllersRestarted(cluster *v3.Cluster) bool {
-	value, ok := cluster.Annotations[controllersRestartedAnnotation]
-	return ok && value == "true"
+// saveClusterControllersVersionAnnotation updates and persists a cluster object with a given value for the annotation
+// that indicates the cluster controllers' version. It does not matter if the provided version starts with a "v" or doesn't,
+// as it's parsed the same by other code.
+func (u *userControllersController) saveClusterControllersVersionAnnotation(cluster *v3.Cluster, value string) (*v3.Cluster, error) {
+	cluster = cluster.DeepCopy()
+	cluster.Annotations[currentClusterControllersVersion] = value
+	cluster, err := u.clusters.Update(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("unable to update cluster %s with annotation indicating its K8s version: %w", cluster.Name, err)
+	}
+	return cluster, nil
+}
+
+func getCurrentClusterControllersVersion(cluster *v3.Cluster) (*version.Version, error) {
+	v := cluster.Annotations[currentClusterControllersVersion]
+	return version.ParseSemantic(v)
+}
+
+// clusterVersionChanged checks if the two given cluster versions differ in the major or minor levels.
+func clusterVersionChanged(current, new *version.Version) bool {
+	return current.Major() != new.Major() || current.Minor() != new.Minor()
 }
 
 func (u *userControllersController) setPeers(peers *tpeermanager.Peers) error {
@@ -148,7 +188,7 @@ func (u *userControllersController) peersSync() error {
 
 	for _, cluster := range clusters {
 		if cluster.DeletionTimestamp != nil || !v33.ClusterConditionProvisioned.IsTrue(cluster) {
-			u.manager.Stop(cluster)
+			u.starter.Stop(cluster)
 		} else {
 			amOwner := u.amOwner(u.peers, cluster)
 			if amOwner {
@@ -156,7 +196,7 @@ func (u *userControllersController) peersSync() error {
 			} else {
 				metrics.UnsetClusterOwner(u.peers.SelfID, cluster.Name)
 			}
-			if err := u.manager.Start(u.ctx, cluster, amOwner); err != nil {
+			if err := u.starter.Start(u.ctx, cluster, amOwner); err != nil {
 				errs = append(errs, errors.Wrapf(err, "failed to start user controllers for cluster %s", cluster.Name))
 			}
 		}

--- a/pkg/controllers/managementapi/usercontrollers/usercontroller_test.go
+++ b/pkg/controllers/managementapi/usercontrollers/usercontroller_test.go
@@ -1,0 +1,213 @@
+package usercontrollers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+func newMockUserControllersController(starter *simpleControllerStarter) *userControllersController {
+	return &userControllersController{
+		starter:       starter,
+		clusterLister: &fakes.ClusterListerMock{},
+		clusters: &fakes.ClusterInterfaceMock{
+			ControllerFunc: func() v3.ClusterController {
+				return &fakes.ClusterControllerMock{
+					EnqueueFunc: func(namespace string, name string) {},
+				}
+			},
+			UpdateFunc: func(c *apimgmtv3.Cluster) (*apimgmtv3.Cluster, error) {
+				if c.Name == "bad cluster" {
+					return c, errors.New("failed to update the cluster object")
+				}
+				return c, nil
+			},
+		},
+	}
+}
+
+type simpleControllerStarter struct {
+	startCalled bool
+	stopCalled  bool
+}
+
+func (s *simpleControllerStarter) Start(ctx context.Context, c *v3.Cluster, clusterOwner bool) error {
+	if c.Name == "nonstarter cluster" {
+		return errors.New("failed to start the cluster controllers")
+	}
+	s.startCalled = true
+	return nil
+}
+
+func (s *simpleControllerStarter) Stop(cluster *v3.Cluster) {
+	s.stopCalled = true
+}
+
+func TestAnnotationFailsToBeSaved(t *testing.T) {
+	t.Parallel()
+	t.Run("initial annotation fails to be saved", func(t *testing.T) {
+		t.Parallel()
+		starter := simpleControllerStarter{}
+		controller := newMockUserControllersController(&starter)
+		cluster := &v3.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "bad cluster",
+				Annotations: map[string]string{},
+			},
+			Status: apimgmtv3.ClusterStatus{
+				Version: &version.Info{GitVersion: "1.23.4"},
+			},
+		}
+
+		obj, err := controller.sync("", cluster)
+		require.Error(t, err)
+		require.Nil(t, obj)
+		assert.False(t, starter.startCalled)
+		assert.False(t, starter.stopCalled)
+	})
+
+	t.Run("new annotation fails to be saved after controllers restart", func(t *testing.T) {
+		t.Parallel()
+		starter := simpleControllerStarter{}
+		controller := newMockUserControllersController(&starter)
+		cluster := &v3.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "bad cluster",
+				Annotations: map[string]string{currentClusterControllersVersion: "1.22.0"},
+			},
+			Status: apimgmtv3.ClusterStatus{
+				Version: &version.Info{GitVersion: "1.23.4"},
+			},
+		}
+
+		obj, err := controller.sync("", cluster)
+		require.Error(t, err)
+		require.Nil(t, obj)
+		assert.True(t, starter.startCalled)
+		assert.True(t, starter.stopCalled)
+	})
+}
+
+func TestClusterControllerFailsToRestart(t *testing.T) {
+	t.Parallel()
+	starter := simpleControllerStarter{}
+	controller := newMockUserControllersController(&starter)
+	cluster := &v3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "nonstarter cluster",
+			Annotations: map[string]string{currentClusterControllersVersion: "1.22.0"},
+		},
+		Status: apimgmtv3.ClusterStatus{
+			Version: &version.Info{GitVersion: "1.23.4"},
+		},
+	}
+
+	obj, err := controller.sync("", cluster)
+	require.Error(t, err)
+	require.NotNil(t, obj)
+	assert.True(t, starter.stopCalled)
+	assert.False(t, starter.startCalled)
+	assert.Equal(t, "1.22.0", obj.(*v3.Cluster).Annotations[currentClusterControllersVersion])
+}
+
+func TestClusterWithoutControllersVersionAnnotationGetsUpdated(t *testing.T) {
+	t.Parallel()
+	starter := simpleControllerStarter{}
+	controller := newMockUserControllersController(&starter)
+	cluster := &v3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "my-cluster",
+			Annotations: map[string]string{},
+		},
+		Status: apimgmtv3.ClusterStatus{
+			Version: &version.Info{GitVersion: "1.23.4"},
+		},
+	}
+
+	obj, err := controller.sync("", cluster)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	assert.Equal(t, "1.23.4", obj.(*v3.Cluster).Annotations[currentClusterControllersVersion])
+	assert.False(t, starter.startCalled)
+	assert.False(t, starter.stopCalled)
+}
+
+func TestClusterControllersNotRestartedOnPatchVersionChange(t *testing.T) {
+	t.Parallel()
+	starter := simpleControllerStarter{}
+	controller := newMockUserControllersController(&starter)
+	cluster := &v3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "my-cluster",
+			Annotations: map[string]string{currentClusterControllersVersion: "1.23.0"},
+		},
+		Status: apimgmtv3.ClusterStatus{
+			Version: &version.Info{GitVersion: "1.23.1"},
+		},
+	}
+
+	obj, err := controller.sync("", cluster)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+
+	// The annotation is also not updated.
+	assert.Equal(t, "1.23.0", obj.(*v3.Cluster).Annotations[currentClusterControllersVersion])
+
+	assert.False(t, starter.startCalled)
+	assert.False(t, starter.stopCalled)
+}
+
+func TestClusterControllersWereStoppedAndStartedOnVersionChange(t *testing.T) {
+	t.Parallel()
+	t.Run("cluster version moved up", func(t *testing.T) {
+		t.Parallel()
+		starter := simpleControllerStarter{}
+		controller := newMockUserControllersController(&starter)
+		cluster := &v3.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "my-cluster",
+				Annotations: map[string]string{currentClusterControllersVersion: "1.23.4"},
+			},
+			Status: apimgmtv3.ClusterStatus{
+				Version: &version.Info{GitVersion: "1.25.2"},
+			},
+		}
+
+		obj, err := controller.sync("", cluster)
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+		assert.Equal(t, "1.25.2", obj.(*v3.Cluster).Annotations[currentClusterControllersVersion])
+		assert.True(t, starter.startCalled)
+		assert.True(t, starter.stopCalled)
+	})
+
+	t.Run("cluster version moved down", func(t *testing.T) {
+		t.Parallel()
+		starter := simpleControllerStarter{}
+		controller := newMockUserControllersController(&starter)
+		cluster := &v3.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "my-cluster",
+				Annotations: map[string]string{currentClusterControllersVersion: "1.23.4"},
+			},
+			Status: apimgmtv3.ClusterStatus{
+				Version: &version.Info{GitVersion: "1.22.1"},
+			},
+		}
+
+		obj, err := controller.sync("", cluster)
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+		assert.Equal(t, "1.22.1", obj.(*v3.Cluster).Annotations[currentClusterControllersVersion])
+		assert.True(t, starter.startCalled)
+		assert.True(t, starter.stopCalled)
+	})
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40133
 
## Problem
If a remote cluster is upgraded to a different K8s version, the controllers for the cluster are not restarted. This might make informers watch over resources that are no longer known by the remote cluster's API server. Because of that, there might be lots of informer errors in the local cluster's logs.
 
## Solution
Restart all cluster controllers in the local cluster for the downstream cluster when its K8s version has been upgraded or downgraded to a non-patch version. The controller now stores the current cluster's K8s version as an annotation and compares it to the new version.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Created a K8s v1.24 remote cluster with PSPs enabled. Then upgraded the cluster to v1.25, saw that there were no errors about PSPs being unknown by the remote cluster.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->