### PR TITLE
Project resources extension

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -60,6 +60,9 @@ func main() {
 		if os.Getenv("CATTLE_DEBUG") == "true" || os.Getenv("RANCHER_DEBUG") == "true" {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
+		if os.Getenv("CATTLE_TRACE") == "true" {
+			logrus.SetLevel(logrus.TraceLevel)
+		}
 
 		initFeatures()
 

--- a/dev-scripts/setup-service.sh
+++ b/dev-scripts/setup-service.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# For dev mode, create a dummy service pointing to the Rancher instance running on localhost.
+# Allows the project resources kubernetes extension to work.
+# Not needed for CI, helm or docker setups because the service is automatically created.
+ip=$(ip addr show docker0 | awk '/inet /{gsub(/\/16/, ""); print $2}')
+
+cat <<EOF | sed -e "s/{ip}/${ip}/" | kubectl apply -f -
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: port-forward
+  name: port-forward
+  namespace: cattle-system
+spec:
+  containers:
+  - env:
+    - name: REMOTE_HOST
+      value: {ip} # localhost gateway
+    - name: REMOTE_PORT
+      value: "8443"
+    - name: LOCAL_PORT
+      value: "443"
+    image: marcnuri/port-forward
+    imagePullPolicy: Always
+    name: port-forward
+    ports:
+    - containerPort: 443
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rancher
+  namespace: cattle-system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    run: port-forward
+  type: ClusterIP
+EOF

--- a/pkg/api/steve/additionalapi.go
+++ b/pkg/api/steve/additionalapi.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/rancher/pkg/api/steve/aggregation"
 	"github.com/rancher/rancher/pkg/api/steve/github"
 	"github.com/rancher/rancher/pkg/api/steve/health"
+	"github.com/rancher/rancher/pkg/api/steve/projectresources"
 	"github.com/rancher/rancher/pkg/api/steve/projects"
 	"github.com/rancher/rancher/pkg/api/steve/proxy"
 	"github.com/rancher/rancher/pkg/capr/configserver"
@@ -57,6 +58,8 @@ func AdditionalAPIs(ctx context.Context, config *wrangler.Context, steve *steve.
 	mux.UseEncodedPath()
 	mux.Handle("/v1/github{path:.*}", githubHandler)
 	mux.Handle("/v3/connect", Tunnel(config))
+
+	projectresources.Register(ctx, mux, config, steve)
 	health.Register(mux)
 
 	return func(next http.Handler) http.Handler {

--- a/pkg/api/steve/projectresources/apiresources.go
+++ b/pkg/api/steve/projectresources/apiresources.go
@@ -1,0 +1,202 @@
+package projectresources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	apiextcontrollerv1 "github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io/v1"
+	apiregcontrollerv1 "github.com/rancher/wrangler/pkg/generated/controllers/apiregistration.k8s.io/v1"
+	"github.com/sirupsen/logrus"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apidiscovery "k8s.io/apiserver/pkg/endpoints/discovery"
+	"k8s.io/client-go/discovery"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+)
+
+// NOTE(cmurphy): copied with modifications from lasso and steve
+
+var (
+	queueRefreshDelay  = 500 * time.Millisecond
+	enqueueAfterPeriod = 10 * time.Second
+)
+
+// APIResourceWatcher provides access to the Kubernetes schema.
+type APIResourceWatcher interface {
+	List() []metav1.APIResource
+	Get(resource, group string) (metav1.APIResource, bool)
+	GetKindForResource(gvr schema.GroupVersionResource) (string, error)
+}
+
+type apiResourceWatcher struct {
+	sync.RWMutex
+
+	toSync       atomic.Int32
+	client       discovery.DiscoveryInterface
+	apiResources []metav1.APIResource
+	mapper       meta.RESTMapper
+	resourceMap  map[string]metav1.APIResource
+	crds         apiextcontrollerv1.CustomResourceDefinitionController
+}
+
+// WatchAPIResources creates an APIResourceWatcher object and starts watches on CRDs and APIServices,
+// which prompts it to run a discovery check to get the most up to date Kubernetes schema.
+func WatchAPIResources(ctx context.Context, discovery discovery.DiscoveryInterface, crds apiextcontrollerv1.CustomResourceDefinitionController, apiServices apiregcontrollerv1.APIServiceController, mapper meta.RESTMapper) APIResourceWatcher {
+	a := &apiResourceWatcher{
+		client:      discovery,
+		mapper:      mapper,
+		resourceMap: make(map[string]metav1.APIResource),
+		crds:        crds,
+	}
+
+	crds.OnChange(ctx, "project-resources-api", a.OnChangeCRD)
+	apiServices.OnChange(ctx, "project-resources-api", a.OnChangeAPIService)
+	return a
+}
+
+// OnChangeCRD queues the refresh when a CRD event occurs.
+func (a *apiResourceWatcher) OnChangeCRD(_ string, crd *apiextv1.CustomResourceDefinition) (*apiextv1.CustomResourceDefinition, error) {
+	if crd != nil {
+		logrus.Tracef("[%s] APIResourceWatcher handler triggered by CRD %s", apiServiceName, crd.Name)
+	} else {
+		logrus.Tracef("[%s] APIResourceWatcher handler triggered by deleted CRD", apiServiceName)
+	}
+	a.queueRefresh()
+	return crd, nil
+}
+
+// OnChangeAPIService queues the refresh when an APIService event occurs.
+func (a *apiResourceWatcher) OnChangeAPIService(_ string, apiService *apiregv1.APIService) (*apiregv1.APIService, error) {
+	if apiService != nil {
+		logrus.Tracef("[%s] APIResourceWatcher handler triggered by APIService %s", apiServiceName, apiService.Name)
+	} else {
+		logrus.Tracef("[%s] APIResourceWatcher handler triggered by deleted APIService", apiServiceName)
+	}
+	a.queueRefresh()
+	return apiService, nil
+}
+
+// GetKindForResource returns the resource Kind given its GVR.
+func (a *apiResourceWatcher) GetKindForResource(gvr schema.GroupVersionResource) (string, error) {
+	a.RLock()
+	defer a.RUnlock()
+	gvk, err := a.mapper.KindFor(gvr)
+	if err != nil {
+		return "", fmt.Errorf("failed to look up kind for resource %s, %w", gvr.Resource, err)
+	}
+	return gvk.Kind, nil
+}
+
+// List returns all the APIResources for the project resources API.
+func (a *apiResourceWatcher) List() []metav1.APIResource {
+	a.RLock()
+	defer a.RUnlock()
+	list := make([]metav1.APIResource, len(a.apiResources))
+	copy(list, a.apiResources)
+	return list
+}
+
+// Get returns an APIResource and an existence bool given a resource and group.
+func (a *apiResourceWatcher) Get(resource, group string) (metav1.APIResource, bool) {
+	a.RLock()
+	defer a.RUnlock()
+	if group == "" {
+		val, ok := a.resourceMap[resource]
+		return val, ok
+	}
+	val, ok := a.resourceMap[group+"."+resource]
+	return val, ok
+}
+
+func (a *apiResourceWatcher) queueRefresh() {
+	a.toSync.Store(1)
+
+	go func() {
+		time.Sleep(queueRefreshDelay)
+		if err := a.refreshAll(); err != nil {
+			logrus.Debugf("[%s] failed to sync schemas, will retry: %v", apiServiceName, err)
+			a.toSync.Store(1)
+			a.crds.EnqueueAfter("", enqueueAfterPeriod)
+		}
+	}()
+}
+
+func (a *apiResourceWatcher) setAPIResources() error {
+	resourceList, err := discovery.ServerPreferredNamespacedResources(a.client)
+	// discovery often fails because this API isn't ready yet, the rest of the resource list returned is still good
+	if err != nil && len(resourceList) == 0 {
+		return err
+	}
+	result := []metav1.APIResource{}
+	a.Lock()
+	defer a.Unlock()
+	a.resourceMap = make(map[string]metav1.APIResource)
+	for _, resource := range resourceList {
+		if resource.GroupVersion == groupVersion {
+			continue
+		}
+		gv := strings.Split(resource.GroupVersion, "/")
+		group := ""
+		version := ""
+		if len(gv) > 1 {
+			group = gv[0]
+			version = gv[1]
+		} else {
+			version = gv[0]
+		}
+		for _, r := range resource.APIResources {
+			name := r.Name
+			kind := r.Kind
+			if group != "" {
+				name = group + "." + name
+				kind = group + "." + kind
+			}
+			resource := metav1.APIResource{
+				Name:               name,
+				Group:              group,
+				Version:            version,
+				Kind:               kind,
+				Verbs:              []string{"list"},
+				Namespaced:         true,
+				StorageVersionHash: apidiscovery.StorageVersionHash(group, version, r.Kind),
+			}
+			result = append(result, resource)
+			a.resourceMap[name] = resource
+		}
+	}
+	a.apiResources = result
+	return nil
+}
+
+func (a *apiResourceWatcher) refreshAll() error {
+	if !a.needToSync() {
+		logrus.Tracef("[%s] no refresh needed", apiServiceName)
+		return nil
+	}
+
+	logrus.Infof("[%s] Refreshing all types", apiServiceName)
+	var start time.Time
+	if logrus.GetLevel() >= logrus.TraceLevel {
+		start = time.Now()
+	}
+	err := a.setAPIResources()
+	if logrus.GetLevel() >= logrus.TraceLevel {
+		logrus.Tracef("[%s] APIResource refresh completed in %d milliseconds", apiServiceName, time.Since(start).Milliseconds())
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *apiResourceWatcher) needToSync() bool {
+	old := a.toSync.Swap(0)
+	return old == 1
+}

--- a/pkg/api/steve/projectresources/apiresources_test.go
+++ b/pkg/api/steve/projectresources/apiresources_test.go
@@ -1,0 +1,148 @@
+package projectresources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestOnChangeCRD(t *testing.T) {
+	apis := setup()
+	testOnChange(t, apis, func() { apis.OnChangeCRD("", nil) })
+}
+
+func TestOnChangeAPIService(t *testing.T) {
+	apis := setup()
+	testOnChange(t, apis, func() { apis.OnChangeAPIService("", nil) })
+}
+
+func setup() *apiResourceWatcher {
+	queueRefreshDelay = 1
+	client := fakeclientset.NewSimpleClientset()
+	fakeDiscovery := client.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDiscovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:       "pods",
+					Namespaced: true,
+					Kind:       "Pod",
+					Version:    "v1",
+					Verbs:      []string{"create", "update", "get", "list", "watch", "delete"},
+				},
+				{
+					Name:       "namespaces",
+					Namespaced: false,
+					Version:    "v1",
+					Verbs:      []string{"create", "update", "get", "list", "watch", "delete"},
+				},
+			},
+		},
+	}
+	return &apiResourceWatcher{
+		client:      fakeDiscovery,
+		resourceMap: make(map[string]metav1.APIResource),
+	}
+}
+
+func testOnChange(t *testing.T, apis *apiResourceWatcher, testFn func()) {
+	testFn()
+	time.Sleep((queueRefreshDelay + 10) * time.Millisecond)
+	assert.Equal(t, int32(0), apis.toSync.Load())
+	wantAPIResources := []metav1.APIResource{
+		{
+			Name:               "pods",
+			Namespaced:         true,
+			Kind:               "Pod",
+			StorageVersionHash: "xPOwRZ+Yhw8=",
+			Version:            "v1",
+			Verbs:              []string{"list"},
+		},
+	}
+	wantResourceMap := map[string]metav1.APIResource{
+		"pods": metav1.APIResource{
+			Name:               "pods",
+			Namespaced:         true,
+			Kind:               "Pod",
+			StorageVersionHash: "xPOwRZ+Yhw8=",
+			Version:            "v1",
+			Verbs:              []string{"list"},
+		},
+	}
+	assert.Equal(t, wantAPIResources, apis.List())
+	assert.Equal(t, wantResourceMap, apis.resourceMap)
+}
+
+func TestGet(t *testing.T) {
+	apis := apiResourceWatcher{
+		resourceMap: map[string]metav1.APIResource{
+			"pods": metav1.APIResource{
+				Name:       "pods",
+				Version:    "v1",
+				Group:      "",
+				Namespaced: true,
+			},
+			"apps.deployments": metav1.APIResource{
+				Name:       "deployments",
+				Version:    "v1",
+				Group:      "apps",
+				Namespaced: true,
+			},
+		},
+	}
+	tests := []struct {
+		name       string
+		resource   string
+		group      string
+		want       metav1.APIResource
+		wantExists bool
+	}{
+		{
+			name:       "invalid resource",
+			resource:   "notaresources",
+			wantExists: false,
+		},
+		{
+			name:       "invalid group and resource",
+			resource:   "notaresources",
+			group:      "notagroup",
+			wantExists: false,
+		},
+		{
+			name:     "/api/v1/-style resource",
+			resource: "pods",
+			want: metav1.APIResource{
+				Group:      "",
+				Version:    "v1",
+				Name:       "pods",
+				Namespaced: true,
+			},
+			wantExists: true,
+		},
+		{
+			name:     "/apis/-style resource",
+			resource: "deployments",
+			group:    "apps",
+			want: metav1.APIResource{
+				Group:      "apps",
+				Version:    "v1",
+				Name:       "deployments",
+				Namespaced: true,
+			},
+			wantExists: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, gotExists := apis.Get(test.resource, test.group)
+			assert.Equal(t, test.wantExists, gotExists)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/pkg/api/steve/projectresources/handlers.go
+++ b/pkg/api/steve/projectresources/handlers.go
@@ -1,0 +1,922 @@
+// Package projectresources supports the /apis/resources.project.cattle.io/v1alpha1 endpoint for listing resources by project.
+package projectresources
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/gorilla/mux"
+	"github.com/rancher/rancher/pkg/controllers/managementagent/nslabels"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
+	authzv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	workers                    = int64(3)
+	notOp                      = "!"
+	extensionConfigMap         = "extension-apiserver-authentication"
+	kubeSystemNamespace        = "kube-system"
+	clientCAKey                = "requestheader-client-ca-file"
+	serverAllowedCNKey         = "requestheader-allowed-names"
+	projectNamespaceAnnotation = "management.cattle.io/system-namespace"
+)
+
+var (
+	errUnsupportedAction      = errors.New("this action is not supported")
+	errUnsupportedContentType = errors.New("could not negotiate content type")
+)
+
+// authenticateAPIServer is a middleware that verifies the client's certificates and checks that the client's CN is in the API server's allow list.
+// This fulfills the two conditions outlines in https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/#kubernetes-apiserver-client-authentication:
+// > 1. The connection must be made using a client certificate that is signed by the CA whose certificate is in --requestheader-client-ca-file.
+// > 2. The connection must be made using a client certificate whose CN is one of those listed in --requestheader-allowed-names.
+// The http.Server must have a TLS config with ClientAuth: tls.RequestClientCert set in order for the http.Request to have the client cert populated.
+// Normally mTLS would be handled at the network session layer automatically during the client connection when tls.RequireAndVerifyClientCert
+// is set on the Server's tls.Config, but since this server performs multiple functions and not all of them require mTLS, we handle it in the
+// application layer in this middleware.
+func (a *authHandler) authenticateAPIServer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		config, err := a.configMapCache.Get(kubeSystemNamespace, extensionConfigMap)
+		if err != nil {
+			logrus.Errorf("[%s] could not authenticate API server: %v, please configure kube-apiserver with --%s and --%s", apiServiceName, err, clientCAKey, serverAllowedCNKey)
+			http.Error(w, "could not authenticate API server", http.StatusInternalServerError)
+			return
+		}
+
+		clientCA, ok := config.Data[clientCAKey]
+		if !ok {
+			logrus.Errorf("[%s] could not authenticate API server: %v, please configure kube-apiserver with --%s and --%s", apiServiceName, err, clientCAKey, serverAllowedCNKey)
+			http.Error(w, "could not authenticate API server", http.StatusInternalServerError)
+			return
+		}
+		allowedCN, ok := config.Data[serverAllowedCNKey]
+		if !ok || len(allowedCN) == 0 {
+			logrus.Warnf("[%s] key %s in configmap %s/%s is missing or empty, any CN will be accepted for requests to /apis/%s, change this by setting --%s on kube-apiserver",
+				apiServiceName, serverAllowedCNKey, kubeSystemNamespace, extensionConfigMap, groupVersion, serverAllowedCNKey)
+		}
+		var handleError = func(err error) {
+			switch err.(type) {
+			case authError:
+				logrus.Warnf("[%s] could not authenticate API server: %v", apiServiceName, err)
+				http.Error(w, fmt.Sprintf("could not authenticate API server: %v", err), http.StatusUnauthorized)
+			case configError:
+				logrus.Errorf("[%s] could not authenticate API server: %v", apiServiceName, err)
+				http.Error(w, fmt.Sprintf("could not authenticate API server: %v", err), http.StatusInternalServerError)
+			}
+		}
+		err = verifyCert(r, clientCA)
+		if err != nil {
+			handleError(err)
+			return
+		}
+		err = verifyCN(r, allowedCN)
+		if err != nil {
+			handleError(err)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func verifyCert(r *http.Request, clientCA string) error {
+	if len(r.TLS.PeerCertificates) == 0 {
+		logrus.Errorf("[%s] client did not provide certificate", apiServiceName)
+		return authError{"client did not provide certificate"}
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM([]byte(clientCA))
+	opts := x509.VerifyOptions{
+		Roots:         caCertPool,
+		Intermediates: x509.NewCertPool(),
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	for _, cert := range r.TLS.PeerCertificates[1:] {
+		opts.Intermediates.AddCert(cert)
+	}
+	_, err := r.TLS.PeerCertificates[0].Verify(opts)
+	if err != nil {
+		logrus.Errorf("[%s] failed to verify API server client certificate: %v", apiServiceName, err)
+		return authError{err.Error()}
+	}
+	return nil
+}
+
+func verifyCN(r *http.Request, allowedCNString string) error {
+	if allowedCNString == "" {
+		return nil
+	}
+	allowedCN := []string{}
+	if err := json.Unmarshal([]byte(allowedCNString), &allowedCN); err != nil {
+		return configError{}
+	}
+	requestCN := r.TLS.PeerCertificates[0].Subject.CommonName
+	found := false
+	for _, allowed := range allowedCN {
+		if allowed == requestCN {
+			found = true
+			break
+		}
+	}
+	if !found {
+		logrus.Errorf("[%s] could not find user %s in allowed users", apiServiceName, requestCN)
+		return authError{"user not allowed"}
+	}
+	return nil
+}
+
+// discoveryHandler is used by the k8s API server to discover and register resources.
+// Used by `kubectl api-resources` and steve schema registration.
+func (h *handler) discoveryHandler(w http.ResponseWriter, r *http.Request) {
+	logrus.Tracef("[%s] handling request %s %s", apiServiceName, r.Method, r.URL.Path)
+	w.Header().Set("Content-Type", "application/json")
+	resp := map[string]interface{}{
+		"kind":         "APIResourceList",
+		"apiVersion":   "v1",
+		"groupVersion": groupVersion,
+		"resources":    h.apis.List(),
+	}
+	apiResourceBytes, err := json.Marshal(resp)
+	if err != nil {
+		logrus.Errorf("[%s] failed to encode discovery response: %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Write(apiResourceBytes)
+}
+
+// forwarder handles global resource requests that have no particular project or namespace specified.
+// In this case, there is nothing special about the request so the regular client can handle it without any preprocessing.
+func (h *handler) forwarder(w http.ResponseWriter, r *http.Request) {
+	logrus.Tracef("[%s] handling request %s %s", apiServiceName, r.Method, r.URL.Path)
+	vars := mux.Vars(r)
+	resource, err := h.gvrFromVars(vars)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	resourceClient, err := h.clientGetter(r, h.restConfig, resource)
+	if errors.Is(err, errUnsupportedContentType) {
+		logrus.Warnf("[%s] unsupported content type requested: %s", apiServiceName, r.Header.Get("Accept"))
+		http.Error(w, "unsupported content type requested", http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		logrus.Errorf("[%s] failed to get client for config: %v", apiServiceName, err)
+		http.Error(w, "failed to get client for config", http.StatusInternalServerError)
+		return
+	}
+	if !h.hasAccess(r, "", resource) {
+		h.returnEmpty(r.Context(), w, resource, resourceClient)
+		return
+	}
+	opts := metav1.ListOptions{}
+	err = paramCodec.DecodeParameters(r.URL.Query(), metav1.SchemeGroupVersion, &opts)
+	if err != nil {
+		logrus.Errorf("[%s] failed to parse query %v: %v", apiServiceName, r.URL.Query(), err)
+		http.Error(w, "failed to parse query", http.StatusInternalServerError)
+	}
+	if opts.Watch {
+		// watch is not currently supported. kube-controller-manager starts a
+		// watch on all resources, and there is no way to tell it not to. We
+		// could start a real watch with the resourceClient, but
+		// kube-controller-manager is already getting the real events from the
+		// real endpoint, so we don't need to create more work for it by
+		// duplicating events.
+		logrus.Tracef("[%s] starting dummy watch for resource %s", apiServiceName, resource.Resource)
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			}
+		}
+	}
+	resources, err := resourceClient.List(r.Context(), opts)
+	if apierrors.IsNotFound(err) {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		logrus.Errorf("[%s] failed to list resources: %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	returnResp(w, resources)
+}
+
+// unscopedHandler handles requests for resources in namespaces that don't belong to any project.
+func (h *handler) unscopedHandler(w http.ResponseWriter, r *http.Request) {
+	logrus.Tracef("[%s] handling request %s %s", apiServiceName, r.Method, r.URL.Path)
+	vars := mux.Vars(r)
+	op := vars["op"]
+	var projectsOrNamespaces []string
+	if value, ok := vars[projectsOrNamespacesVar]; ok {
+		projectsOrNamespaces = strings.Split(value, ",")
+	}
+	resource, err := h.gvrFromVars(vars)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	resourceClient, err := h.clientGetter(r, h.restConfig, resource)
+	if errors.Is(err, errUnsupportedContentType) {
+		logrus.Warnf("[%s] unsupported content type requested: %s", apiServiceName, r.Header.Get("Accept"))
+		http.Error(w, "unsupported content type requested", http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		logrus.Errorf("[%s] failed to get client for config: %v", apiServiceName, err)
+		http.Error(w, "failed to get client for config", http.StatusInternalServerError)
+	}
+	// get namespaces that don't have the projectID label
+	selector := labels.NewSelector().Add(*orphanNamespaceRequirement)
+	if len(projectsOrNamespaces) > 0 {
+		var reqOp selection.Operator
+		if op == notOp {
+			reqOp = selection.NotIn
+		} else {
+			reqOp = selection.In
+		}
+		namespaceRequirement, err := labels.NewRequirement(corev1.LabelMetadataName, reqOp, projectsOrNamespaces)
+		if err != nil {
+			logrus.Errorf("[%s] failed to create label selector: %v", apiServiceName, err)
+			http.Error(w, fmt.Sprintf("failed to create label selector: %s", err.Error()), http.StatusInternalServerError)
+			return
+		}
+		selector = selector.Add(*namespaceRequirement)
+	}
+	nss, err := h.namespaceCache.List(selector)
+	if err != nil {
+		logrus.Errorf("[%s] failed to list namespaces: %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	finalNamespaces := make(map[string]struct{})
+	for _, ns := range nss {
+		finalNamespaces[ns.Name] = struct{}{}
+	}
+
+	resp, err := h.getResourcesForNamespaces(r, resource, resourceClient, finalNamespaces)
+	if errors.Is(err, errUnsupportedAction) {
+		logrus.Warnf("[%s] %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		logrus.Errorf("[%s] failed to get resources for namespaces: %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	returnResp(w, resp)
+}
+
+// scopedHandler handles requests for resources in namespaces in one particular project.
+//
+// This handler is designed to be compatible with the way Steve distributes and
+// aggregates across namespaces that the user has access to. If a user provides
+// a project that does not match the one set in /namespaces/{project}, Steve
+// may be trying that endpoint separately, so we have to ignore it here.
+// Similarly, if the user provides a namespace that is not part of the project
+// in /namespaces/{project}, it may be part of another project the user can
+// access, so ignore it here.
+func (h *handler) scopedHandler(w http.ResponseWriter, r *http.Request) {
+	logrus.Tracef("[%s] handling request %s %s", apiServiceName, r.Method, r.URL.Path)
+	vars := mux.Vars(r)
+	project := vars["project"]
+	op := vars["op"]
+	var projectsOrNamespaces []string
+	if _, ok := vars[projectsOrNamespacesVar]; ok {
+		projectsOrNamespaces = strings.Split(vars[projectsOrNamespacesVar], ",")
+	}
+	var projectsList []string
+	var namespacesMap map[string]*corev1.Namespace
+	resource, err := h.gvrFromVars(vars)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	resourceClient, err := h.clientGetter(r, h.restConfig, resource)
+	if errors.Is(err, errUnsupportedContentType) {
+		logrus.Warnf("[%s] unsupported content type requested: %s", apiServiceName, r.Header.Get("Accept"))
+		http.Error(w, "unsupported content type requested", http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		logrus.Errorf("[%s] failed to get client for config: %v", apiServiceName, err)
+		http.Error(w, "failed to get client for config", http.StatusInternalServerError)
+	}
+	if len(projectsOrNamespaces) > 0 {
+		projectsList, namespacesMap, err = h.projectsAndNamespaces(projectsOrNamespaces)
+		if err != nil {
+			logrus.Errorf("[%s] failed to parse projects and namespaces: %v", apiServiceName, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	// Only include namespaces that are in the project
+	// Even if op is "!", excluded namespaces should match the project, since namespaces outside the project are ignored.
+	for name, n := range namespacesMap {
+		label := n.GetLabels()[nslabels.ProjectIDFieldLabel]
+		if label != project {
+			delete(namespacesMap, name)
+		}
+	}
+	if op != notOp {
+		// /namespaces/{project}/ is specified, so the projects and/or namespaces in the query must match that project
+		if len(projectsList) != 0 {
+			found := false
+			for _, p := range projectsList {
+				if p == project {
+					projectsList = []string{p} // operator is = and the project matches, so we'll include all namespaces in this project
+					found = true
+					break
+				}
+			}
+			if !found {
+				projectsList = []string{} // operator is = but no project matched, ignore projects and use namespaces to filter
+			}
+		}
+		if len(projectsList) == 0 && len(namespacesMap) == 0 && len(projectsOrNamespaces) > 0 { // selectors were provided but none applied to this project
+			logrus.Tracef("[%s] fieldSelector does match project or namespace [%s], skipping", apiServiceName, project)
+			h.returnEmpty(r.Context(), w, resource, resourceClient)
+			return
+		}
+	} else {
+		if len(projectsList) != 0 {
+			for _, p := range projectsList {
+				// /namespaces/{project} is specified, but that project is excluded from the query, so return empty
+				if p == project {
+					logrus.Tracef("[%s] fieldSelector does match project or namespace [%s], skipping", apiServiceName, project)
+					h.returnEmpty(r.Context(), w, resource, resourceClient)
+					return
+				}
+			}
+			projectsList = []string{} // operator is != but none of the projects in the selector applied, so ignore projects and use namespaces to filter
+		}
+	}
+	selector := labels.Set{nslabels.ProjectIDFieldLabel: project}.AsSelector()
+	namespacesList := mapToKeysSlice(namespacesMap)
+	if len(namespacesList) != 0 && len(projectsList) == 0 {
+		var reqOp selection.Operator
+		if op == notOp {
+			reqOp = selection.NotIn
+		} else {
+			reqOp = selection.In
+		}
+		namespaceRequirement, err := labels.NewRequirement(corev1.LabelMetadataName, reqOp, namespacesList)
+		if err != nil {
+			logrus.Errorf("[%s] failed to create label selector: %v", apiServiceName, err)
+			http.Error(w, fmt.Sprintf("failed to create label selector: %s", err.Error()), http.StatusInternalServerError)
+			return
+		}
+		selector = selector.Add(*namespaceRequirement)
+	}
+	nss, err := h.namespaceCache.List(selector)
+	if err != nil {
+		logrus.Errorf("[%s] failed to list namespaces: %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	finalNamespaces := make(map[string]struct{})
+	for _, n := range nss {
+		finalNamespaces[n.Name] = struct{}{}
+	}
+	resp, err := h.getResourcesForNamespaces(r, resource, resourceClient, finalNamespaces)
+	if errors.Is(err, errUnsupportedAction) {
+		logrus.Warnf("[%s] %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		logrus.Errorf("[%s] failed to get resources for namespaces: %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	returnResp(w, resp)
+}
+
+// globalHandler handles admin requests for resources in any projects or any namespaces.
+func (h *handler) globalHandler(w http.ResponseWriter, r *http.Request) {
+	logrus.Tracef("[%s] handling request %s %s", apiServiceName, r.Method, r.URL.Path)
+	vars := mux.Vars(r)
+	op := vars["op"]
+	var projectsOrNamespaces []string
+	if value, ok := vars[projectsOrNamespacesVar]; ok {
+		projectsOrNamespaces = strings.Split(value, ",")
+	}
+	resource, err := h.gvrFromVars(vars)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	resourceClient, err := h.clientGetter(r, h.restConfig, resource)
+	if errors.Is(err, errUnsupportedContentType) {
+		logrus.Warnf("[%s] unsupported content type requested: %s", apiServiceName, r.Header.Get("Accept"))
+		http.Error(w, "unsupported content type requested", http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		logrus.Errorf("[%s] failed to get client for config: %v", apiServiceName, err)
+		http.Error(w, "failed to get client for config", http.StatusInternalServerError)
+	}
+	projectsList, namespacesMap, err := h.projectsAndNamespaces(projectsOrNamespaces)
+	if err != nil {
+		logrus.Errorf("[%s] failed to parse projects and namespaces: %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	namespacesList := mapToKeysSlice(namespacesMap)
+	finalNamespaces := make(map[string]struct{})
+	// get all namespaces for projects
+	selector := labels.NewSelector()
+	var projectRequirement, namespaceRequirement *labels.Requirement
+	if op == notOp {
+		if len(projectsList) > 0 {
+			projectRequirement, err = labels.NewRequirement(nslabels.ProjectIDFieldLabel, selection.NotIn, projectsList)
+			if err != nil {
+				logrus.Errorf("[%s] failed to create label selector: %v", apiServiceName, err)
+				http.Error(w, fmt.Sprintf("failed to create label selector: %s", err.Error()), http.StatusInternalServerError)
+				return
+			}
+		}
+		if len(namespacesList) > 0 {
+			namespaceRequirement, err = labels.NewRequirement(corev1.LabelMetadataName, selection.NotIn, namespacesList)
+			if err != nil {
+				logrus.Errorf("[%s] failed to create label selector: %v", apiServiceName, err)
+				http.Error(w, fmt.Sprintf("failed to create label selector: %s", err.Error()), http.StatusInternalServerError)
+				return
+			}
+		}
+		if projectRequirement != nil {
+			selector = selector.Add(*projectRequirement)
+		}
+		if namespaceRequirement != nil {
+			selector = selector.Add(*namespaceRequirement)
+		}
+	} else {
+		if len(projectsList) > 0 {
+			projectRequirement, err = labels.NewRequirement(nslabels.ProjectIDFieldLabel, selection.In, projectsList)
+			if err != nil {
+				logrus.Errorf("[%s] failed to create label selector: %v", apiServiceName, err)
+				http.Error(w, fmt.Sprintf("failed to create label selector: %s", err.Error()), http.StatusInternalServerError)
+				return
+			}
+		}
+		if projectRequirement != nil {
+			selector = selector.Add(*projectRequirement)
+		}
+		for k := range namespacesMap {
+			finalNamespaces[k] = struct{}{}
+		}
+	}
+	if !(selector.Empty() && len(finalNamespaces) > 0) { // don't list all namespaces in all projects when we wanted to select by only namespaces
+		nss, err := h.namespaceCache.List(selector)
+		if err != nil {
+			logrus.Errorf("[%s] failed to list namespaces: %v", apiServiceName, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		for _, n := range nss {
+			finalNamespaces[n.Name] = struct{}{}
+		}
+	}
+	resp, err := h.getResourcesForNamespaces(r, resource, resourceClient, finalNamespaces)
+	if errors.Is(err, errUnsupportedAction) {
+		logrus.Warnf("[%s] %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		logrus.Errorf("[%s] failed to get resources for namespaces: %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	returnResp(w, resp)
+}
+
+// getResourcesForNamespaces concurrently retrieves resources of a given GVR for a slice of namespaces.
+func (h *handler) getResourcesForNamespaces(r *http.Request, resource schema.GroupVersionResource, resourceClient dynamic.NamespaceableResourceInterface, namespaces map[string]struct{}) (*unstructured.UnstructuredList, error) {
+	itemsChan := make(chan unstructured.Unstructured)
+	rowsChan := make(chan interface{})
+	itemsList := make([]unstructured.Unstructured, 0)
+	rowList := make([]interface{}, 0)
+	latestResourceVersion := 0
+	resourceVersions := make(chan int)
+	var columnDefinitions []interface{}
+	eg, ctx := errgroup.WithContext(r.Context())
+
+	opts := metav1.ListOptions{}
+	cleanQuery(r)
+	err := paramCodec.DecodeParameters(r.URL.Query(), metav1.SchemeGroupVersion, &opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse query %s: %w", r.URL.Query(), err)
+	}
+	if opts.Watch {
+		return nil, errUnsupportedAction
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+
+	go func() {
+		for i := range itemsChan {
+			itemsList = append(itemsList, i)
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for r := range rowsChan {
+			rowList = append(rowList, r)
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for r := range resourceVersions {
+			if r > latestResourceVersion {
+				latestResourceVersion = r
+			}
+		}
+		wg.Done()
+	}()
+
+	sem := semaphore.NewWeighted(workers)
+	for ns := range namespaces {
+		ns := ns
+		if err := sem.Acquire(ctx, 1); err != nil {
+			return nil, fmt.Errorf("failed to acquire semaphore: %w", err)
+		}
+		eg.Go(func() error {
+			defer sem.Release(1)
+			if !h.hasAccess(r, ns, resource) {
+				return nil
+			}
+			resourcesForNamespace, err := resourceClient.Namespace(ns).List(ctx, opts)
+			if err != nil {
+				return fmt.Errorf("failed to list resources %s for namespace %s: %w", resource.Resource, ns, err)
+			}
+			if resourcesForNamespace == nil {
+				return nil
+			}
+			isTable := false
+			columnDefinitions, isTable = resourcesForNamespace.Object["columnDefinitions"].([]interface{})
+			rows, _ := resourcesForNamespace.Object["rows"].([]interface{})
+			if len(resourcesForNamespace.Items) > 0 || (len(rows) > 0) {
+				// resourceVersion will be different for every request, and in the end we want the latest one,
+				// but we won't know which one is the latest until the channel is done processing.
+				rv, err := strconv.Atoi(resourcesForNamespace.GetResourceVersion())
+				if err != nil {
+					rv = 0
+				}
+				resourceVersions <- rv
+			}
+			if isTable {
+				for _, r := range rows {
+					rowsChan <- r
+				}
+			}
+			if len(resourcesForNamespace.Items) > 0 {
+				for _, r := range resourcesForNamespace.Items {
+					itemsChan <- r
+				}
+			}
+			return nil
+		})
+	}
+
+	err = eg.Wait()
+	if err != nil {
+		return nil, err
+	}
+	close(itemsChan)
+	close(rowsChan)
+	close(resourceVersions)
+	wg.Wait()
+	sortCollection(itemsList)
+	sortRows(rowList)
+	resourceVersion := strconv.Itoa(latestResourceVersion)
+	if resourceVersion == "0" { // this may happen if the namespace slice was empty, but we still need to return a valid resource version.
+		resourceVersion, err = emptyResourceVersion(r.Context(), resource, resourceClient)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(columnDefinitions) > 0 {
+		return responseTable(resourceVersion, columnDefinitions, rowList), nil
+	}
+	kind, err := h.apis.GetKindForResource(resource)
+	if err != nil {
+		return nil, err
+	}
+	return responseData(resource, kind+"List", resourceVersion, itemsList), nil
+}
+
+// gvrFromVars takes a request path like /apps.deployments and gets the registered GVR for APIGroup "apps" and resource "deployments".
+func (h *handler) gvrFromVars(vars map[string]string) (schema.GroupVersionResource, error) {
+	groupResource := strings.Split(vars["resource"], ".")
+	group := ""
+	if len(groupResource) > 1 {
+		group = strings.Join(groupResource[:len(groupResource)-1], ".")
+	}
+	resourceName := groupResource[len(groupResource)-1]
+	resource, ok := h.apis.Get(resourceName, group)
+	if !ok {
+		return schema.GroupVersionResource{}, fmt.Errorf("could not find resource %s", vars["resource"])
+	}
+	return schema.GroupVersionResource{Group: group, Version: resource.Version, Resource: resourceName}, nil
+}
+
+// hasAccess checks the auth headers set by the kube API server for the user's access to the requested resource in the requested project.
+func (h *handler) hasAccess(r *http.Request, namespace string, resource schema.GroupVersionResource) bool {
+	var groups []string
+	if g, ok := r.Header["X-Remote-Group"]; ok {
+		groups = g
+	}
+	extras := map[string]authzv1.ExtraValue{}
+	prefix := "X-Remote-Extra-"
+	for k, v := range r.Header {
+		if strings.HasPrefix(k, prefix) {
+			extras[k[len(prefix):]] = authzv1.ExtraValue(v)
+		}
+	}
+	review := authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User:   r.Header.Get("X-Remote-User"),
+			Groups: groups,
+			Extra:  extras,
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Verb:      "list",
+				Resource:  resource.Resource,
+				Group:     resource.Group,
+				Namespace: namespace,
+			},
+		},
+	}
+	result, err := h.sarClient.Create(r.Context(), &review, metav1.CreateOptions{})
+	return err == nil && result.Status.Allowed
+}
+
+// projectsAndNamespaces sorts a list of projects and namespaces specified by 'fieldSelector=projectsornamespaces=...'
+// into separate lists of projects and namespaces.
+func (h *handler) projectsAndNamespaces(projectsOrNamespaces []string) ([]string, map[string]*corev1.Namespace, error) {
+	projects := []string{}
+	namespaces := map[string]*corev1.Namespace{}
+	for _, p := range projectsOrNamespaces {
+		ns, err := h.namespaceCache.Get(p)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, nil, fmt.Errorf("failed to look up namespace %s in cache: %w", p, err)
+		}
+		if ns != nil {
+			_, ok := ns.GetLabels()[ParentLabel]
+			if ok {
+				projects = append(projects, ns.Name)
+				continue
+			}
+			_, ok = ns.GetAnnotations()[projectNamespaceAnnotation]
+			if ok {
+				projects = append(projects, ns.Name)
+				continue
+			}
+			namespaces[ns.Name] = ns
+		}
+	}
+	return projects, namespaces, nil
+}
+
+func (h *handler) returnEmpty(ctx context.Context, w http.ResponseWriter, resource schema.GroupVersionResource, resourceClient dynamic.ResourceInterface) {
+	rv, err := emptyResourceVersion(ctx, resource, resourceClient)
+	if err != nil {
+		logrus.Errorf("[%s] error determining resource version: %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	kind, err := h.apis.GetKindForResource(resource)
+	if err != nil {
+		logrus.Errorf("[%s] error parsing resource: %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	resp := responseData(resource, kind+"List", rv, []unstructured.Unstructured{})
+	returnResp(w, resp)
+}
+
+// endpointRestrictions implements negotiation.EndpointRestrictions
+type endpointRestrictions struct{}
+
+func (e endpointRestrictions) AllowsMediaTypeTransform(mimeType string, mimeSubType string, gvk *schema.GroupVersionKind) bool {
+	if mimeType != "application" {
+		return false
+	}
+	if mimeSubType != "json" {
+		return false
+	}
+	if gvk == nil || gvk.Kind == "" || gvk.Kind == "Table" {
+		return true
+	}
+	return false
+}
+
+func (e endpointRestrictions) AllowsServerVersion(string) bool {
+	return true
+}
+
+func (e endpointRestrictions) AllowsStreamSchema(string) bool {
+	return false
+}
+
+// clientForRequest sets up a roundtripper for the dynamic client and returns the interface for the given resource.
+// The dynamic client ignores the AcceptContentType field on the rest config, so we need to make sure it is set on
+// the round tripper in order to retrieve Table-formatted data.
+func clientForRequest(r *http.Request, restConfig *rest.Config, resource schema.GroupVersionResource) (dynamic.NamespaceableResourceInterface, error) {
+	acceptedTypes := []runtime.SerializerInfo{
+		{
+			MediaType:        "application/json",
+			MediaTypeType:    "application",
+			MediaTypeSubType: "json",
+		},
+	}
+	mediaType, ok := negotiation.NegotiateMediaTypeOptions(r.Header.Get("Accept"), acceptedTypes, endpointRestrictions{})
+	if !ok {
+		return nil, errUnsupportedContentType
+	}
+	cfg := rest.CopyConfig(restConfig)
+	setOptions := roundTripper(mediaType)
+	cfg.Wrap(setOptions)
+	dynamicClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return dynamicClient.Resource(resource), nil
+}
+
+func sortCollection(resourceCollection []unstructured.Unstructured) {
+	sort.Slice(resourceCollection, func(i, j int) bool {
+		objI := resourceCollection[i]
+		objJ := resourceCollection[j]
+		if objI.GetNamespace() < objJ.GetNamespace() {
+			return true
+		}
+		if objI.GetNamespace() > objJ.GetNamespace() {
+			return false
+		}
+		return objI.GetName() < objJ.GetName()
+	})
+}
+
+func sortRows(rows []interface{}) {
+	sort.Slice(rows, func(i, j int) bool {
+		rowI, _ := rows[i].(map[string]interface{})
+		objI, _ := rowI["object"].(map[string]interface{})
+		unstI := unstructured.Unstructured{Object: objI}
+		rowJ, _ := rows[j].(map[string]interface{})
+		objJ, _ := rowJ["object"].(map[string]interface{})
+		unstJ := unstructured.Unstructured{Object: objJ}
+		if unstI.GetNamespace() < unstJ.GetNamespace() {
+			return true
+		}
+		if unstI.GetNamespace() > unstJ.GetNamespace() {
+			return false
+		}
+		return unstI.GetName() < unstJ.GetName()
+	})
+}
+
+func emptyResourceVersion(ctx context.Context, gvr schema.GroupVersionResource, resourceClient dynamic.ResourceInterface) (string, error) {
+	// get the list but ignore the resources, this is needed to get the list resource version
+	resourceList, err := resourceClient.List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		return "", fmt.Errorf("failed to get resource version for resource %s: %w", gvr.Resource, err)
+	}
+	return resourceList.GetResourceVersion(), nil
+}
+
+func responseData(resource schema.GroupVersionResource, kind, resourceVersion string, items []unstructured.Unstructured) *unstructured.UnstructuredList {
+	list := &unstructured.UnstructuredList{
+		Items: items,
+	}
+	list.SetAPIVersion(resource.GroupVersion().String())
+	list.SetKind(kind)
+	list.SetResourceVersion(resourceVersion)
+	return list
+}
+
+func responseTable(resourceVersion string, columnDefinitions interface{}, rows interface{}) *unstructured.UnstructuredList {
+	list := &unstructured.UnstructuredList{}
+	list.SetUnstructuredContent(map[string]interface{}{
+		"columnDefinitions": columnDefinitions,
+		"rows":              rows,
+	})
+	list.SetAPIVersion("meta.k8s.io/v1")
+	list.SetKind("Table")
+	list.SetResourceVersion(resourceVersion)
+	return list
+}
+
+func returnResp(w http.ResponseWriter, resp interface{}) {
+	resourceJSON, err := json.Marshal(resp)
+	if err != nil {
+		logrus.Errorf("[%s] failed to encode response: %v", apiServiceName, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(resourceJSON)
+	return
+}
+
+// cleanQuery removes the fieldSelector from the request so that the remainder can be sent on to k8s.
+func cleanQuery(req *http.Request) {
+	query := req.URL.Query()
+	result := url.Values{}
+	for k, v := range query {
+		if k != queryKey {
+			result[k] = v
+			continue
+		}
+		innerResult := []string{}
+		for _, q := range v {
+			key := queryOpReg.Split(q, 2)[0]
+			if key != projectsOrNamespacesKey {
+				innerResult = append(innerResult, q)
+			}
+		}
+		if len(innerResult) > 0 {
+			result[k] = innerResult
+		}
+	}
+	req.URL.RawQuery = result.Encode()
+}
+
+type addOptions struct {
+	accept string
+	query  map[string]string
+	next   http.RoundTripper
+}
+
+func (a *addOptions) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Set("Accept", a.accept)
+	q := r.URL.Query()
+	for k, v := range a.query {
+		q.Set(k, v)
+	}
+	r.URL.RawQuery = q.Encode()
+	return a.next.RoundTrip(r)
+}
+
+func roundTripper(mediaType negotiation.MediaTypeOptions) func(http.RoundTripper) http.RoundTripper {
+	accept := mediaType.Accepted.MediaType
+	if mediaType.Convert != nil {
+		if mediaType.Convert.Kind != "" {
+			accept += ";as=" + mediaType.Convert.Kind
+		}
+		if mediaType.Convert.Version != "" {
+			accept += ";v=" + mediaType.Convert.Version
+		}
+		if mediaType.Convert.Group != "" {
+			accept += ";g=" + mediaType.Convert.Group
+		}
+	}
+	return func(rt http.RoundTripper) http.RoundTripper {
+		ao := addOptions{
+			accept: accept,
+			next:   rt,
+		}
+		if mediaType.Convert != nil && mediaType.Convert.Kind == "Table" {
+			ao.query = map[string]string{
+				"includeObject": "Object",
+			}
+		}
+		return &ao
+	}
+}
+
+func mapToKeysSlice(m map[string]*corev1.Namespace) []string {
+	result := make([]string, 0)
+	for k := range m {
+		result = append(result, k)
+	}
+	return result
+}

--- a/pkg/api/steve/projectresources/handlers_test.go
+++ b/pkg/api/steve/projectresources/handlers_test.go
@@ -1,0 +1,1598 @@
+package projectresources
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"github.com/stretchr/testify/assert"
+	authzv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamic "k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	fakeauthzv1 "k8s.io/client-go/kubernetes/typed/authorization/v1/fake"
+	"k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+var (
+	genericAllowedSARReactor = clienttesting.ReactionFunc(func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		return true, &authzv1.SubjectAccessReview{
+			Status: authzv1.SubjectAccessReviewStatus{
+				Allowed: true,
+			},
+		}, nil
+	})
+	genericDeniedSARReactor = clienttesting.ReactionFunc(func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		return true, &authzv1.SubjectAccessReview{
+			Status: authzv1.SubjectAccessReviewStatus{
+				Allowed: false,
+			},
+		}, nil
+	})
+)
+
+func Test_discoveryHandler(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/apis/resources.project.cattle.io/v1alpha1", nil)
+
+	apiResource := metav1.APIResource{
+		Name:       "testresource",
+		Namespaced: true,
+	}
+	apis := &apiResourceWatcher{
+		apiResources: []metav1.APIResource{
+			apiResource,
+		},
+	}
+	h := handler{apis: apis}
+	h.discoveryHandler(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	resp := rr.Result()
+	body, err := io.ReadAll(resp.Body)
+	assert.Nil(t, err)
+	want := map[string]interface{}{
+		"apiVersion":   "v1",
+		"groupVersion": "resources.project.cattle.io/v1alpha1",
+		"kind":         "APIResourceList",
+		"resources":    []metav1.APIResource{apiResource},
+	}
+	wantJSON, _ := json.Marshal(want)
+	assert.Equal(t, string(wantJSON), string(body))
+}
+
+func Test_forwarder(t *testing.T) {
+
+	scheme := runtime.NewScheme()
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "testgroup/testversion",
+			"kind":       "TestResource",
+			"metadata": map[string]interface{}{
+				"namespace": "testns",
+				"name":      "testname",
+			},
+		},
+	}
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		schema.GroupVersionResource{
+			Group:    "testgroup",
+			Version:  "testversion",
+			Resource: "testresources",
+		}: "TestResourceList",
+	}
+	clientGetter := func(_ *http.Request, _ *rest.Config, resource schema.GroupVersionResource) (dynamic.NamespaceableResourceInterface, error) {
+		return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, obj).Resource(resource), nil
+	}
+	sarClient := fake.NewSimpleClientset().AuthorizationV1().SubjectAccessReviews()
+
+	apis := &apiResourceWatcher{
+		resourceMap: map[string]metav1.APIResource{
+			"testgroup.testresources": metav1.APIResource{
+				Name:       "testresources",
+				Version:    "testversion",
+				Group:      "testgroup",
+				Namespaced: true,
+			},
+		},
+		mapper: meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "testgroup", Version: "testversion"}}),
+	}
+	apis.mapper.(*meta.DefaultRESTMapper).Add(schema.GroupVersionKind{Group: "testgroup", Version: "testversion", Kind: "TestResource"}, meta.RESTScopeNamespace)
+
+	h := handler{apis: apis, sarClient: sarClient, clientGetter: clientGetter}
+	mux := mux.NewRouter()
+	mux.HandleFunc("/apis/resources.project.cattle.io/v1alpha1/{resource}", h.forwarder)
+
+	tests := []struct {
+		name       string
+		sarReactor clienttesting.ReactionFunc
+		want       map[string]interface{}
+	}{
+		{
+			name:       "access allowed",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "testname", "namespace": "testns"},
+					},
+				},
+			},
+		},
+		{
+			name:       "access denied",
+			sarReactor: genericDeniedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items":      []map[string]interface{}{},
+			},
+		},
+	}
+	for _, test := range tests {
+		sarClient.(*fakeauthzv1.FakeSubjectAccessReviews).Fake.PrependReactor("create", "*", test.sarReactor)
+		defer sarClient.(*fakeauthzv1.FakeSubjectAccessReviews).Fake.ClearActions()
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/apis/resources.project.cattle.io/v1alpha1/testgroup.testresources", nil)
+		mux.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		resp := rr.Result()
+		body, err := io.ReadAll(resp.Body)
+		assert.Nil(t, err)
+		wantJSON, _ := json.Marshal(test.want)
+		assert.Equal(t, string(wantJSON), string(body))
+	}
+}
+
+func Test_scopedHandler(t *testing.T) {
+	scheme := runtime.NewScheme()
+	objs := []runtime.Object{
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "ns1",
+					"name":      "resource1",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "ns2",
+					"name":      "resource2",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "ns2b",
+					"name":      "resource2",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "ns3",
+					"name":      "resource3",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "ns4",
+					"name":      "resource4",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "p-vwxyz",
+					"name":      "resource5",
+				},
+			},
+		},
+	}
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		schema.GroupVersionResource{
+			Group:    "testgroup",
+			Version:  "testversion",
+			Resource: "testresources",
+		}: "TestResourceList",
+	}
+	clientGetter := func(_ *http.Request, _ *rest.Config, resource schema.GroupVersionResource) (dynamic.NamespaceableResourceInterface, error) {
+		return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objs...).Resource(resource), nil
+	}
+	sarClient := fake.NewSimpleClientset().AuthorizationV1().SubjectAccessReviews()
+
+	apis := &apiResourceWatcher{
+		resourceMap: map[string]metav1.APIResource{
+			"testgroup.testresources": metav1.APIResource{
+				Name:       "testresources",
+				Version:    "testversion",
+				Group:      "testgroup",
+				Namespaced: true,
+			},
+		},
+		mapper: meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "testgroup", Version: "testversion"}}),
+	}
+	apis.mapper.(*meta.DefaultRESTMapper).Add(schema.GroupVersionKind{Group: "testgroup", Version: "testversion", Kind: "TestResource"}, meta.RESTScopeNamespace)
+	namespaceCache := &mockNamespaceCache{
+		namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns1",
+					Labels: map[string]string{
+						"field.cattle.io/projectId":   "p-abcde",
+						"kubernetes.io/metadata.name": "ns1",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns2",
+					Labels: map[string]string{
+						"field.cattle.io/projectId":   "p-jklmn",
+						"kubernetes.io/metadata.name": "ns2",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns2b",
+					Labels: map[string]string{
+						"field.cattle.io/projectId":   "p-jklmn",
+						"kubernetes.io/metadata.name": "ns2b",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns3",
+					Labels: map[string]string{
+						"field.cattle.io/projectId":   "p-vwxyz",
+						"kubernetes.io/metadata.name": "ns3",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns4",
+					// no projectId label == orphan namespace
+					Labels: map[string]string{
+						"kubernetes.io/metadata.name": "ns4",
+					},
+				},
+			},
+			// project namespaces
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p-abcde",
+					Labels: map[string]string{
+						"cattle.io/parent":            "true",
+						"kubernetes.io/metadata.name": "p-abcde",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p-jklmn",
+					Labels: map[string]string{
+						"cattle.io/parent":            "true",
+						"kubernetes.io/metadata.name": "p-jklmn",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					// namespace with project name
+					Name: "p-vwxyz",
+					Labels: map[string]string{
+						"cattle.io/parent":            "true",
+						"kubernetes.io/metadata.name": "p-vwxyz",
+					},
+				},
+			},
+		},
+	}
+
+	h := handler{apis: apis, clientGetter: clientGetter, sarClient: sarClient, namespaceCache: namespaceCache}
+	mux := mux.NewRouter()
+	mux.HandleFunc("/namespaces/{project}/{resource}", h.scopedHandler).Queries(queryKey, queryValue)
+	mux.HandleFunc("/namespaces/{project}/{resource}", h.scopedHandler)
+
+	tests := []struct {
+		name       string
+		request    string
+		namespaces []corev1.Namespace
+		want       map[string]interface{}
+		wantStatus int
+		sarReactor clienttesting.ReactionFunc
+	}{
+		{
+			name:       "no selector",
+			request:    "/namespaces/p-abcde/testgroup.testresources",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "one matching project",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces=p-abcde",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "multi matching projects",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces=p-abcde,p-jklmn,p-vwxyz",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "one nonmatching project",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces=p-vwxyz",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items":      []map[string]interface{}{},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "multi nonmatching projects",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces=p-jklmn,p-vwxyz",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items":      []map[string]interface{}{},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "namespaces in project",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces=ns1",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "namespaces not in project",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces=ns2,ns3,ns4",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items":      []map[string]interface{}{},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "some namespaces in project",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces=ns1,ns2,ns3,ns4",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "assorted projects and namespaces",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces=p-abcde,p-vwxyz,ns1,ns2",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not single matching project",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces!=p-abcde",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items":      []map[string]interface{}{},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not multi matching project",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces!=p-abcde,p-vwxyz",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items":      []map[string]interface{}{},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not single non matching project",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces!=p-vwxyz",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not multi non matching project",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces!=p-jklmn,p-vwxyz",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not single namespace in project",
+			request:    "/namespaces/p-jklmn/testgroup.testresources?fieldSelector=projectsornamespaces!=ns2",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource2", "namespace": "ns2b"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not single namespace not in project",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces!=ns2",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not multi namespace in project",
+			request:    "/namespaces/p-jklmn/testgroup.testresources?fieldSelector=projectsornamespaces!=ns1,ns2",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource2", "namespace": "ns2b"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not multi namespace not in project",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces!=ns2",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not combo matching project and non matching namespace",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces!=p-abcde,ns2",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items":      []map[string]interface{}{},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not combo non matching project and non matching namespace",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces!=p-jklmn,ns2,ns3",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not combo non matching project and matching namespace",
+			request:    "/namespaces/p-abcde/testgroup.testresources?fieldSelector=projectsornamespaces!=p-jklmn,ns1",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items":      []map[string]interface{}{},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:    "access denied to some namespaces",
+			request: "/namespaces/p-jklmn/testgroup.testresources",
+			sarReactor: clienttesting.ReactionFunc(func(action clienttesting.Action) (bool, runtime.Object, error) {
+				result := &authzv1.SubjectAccessReview{
+					Status: authzv1.SubjectAccessReviewStatus{},
+				}
+				if action.(clienttesting.CreateActionImpl).GetObject().(*authzv1.SubjectAccessReview).Spec.ResourceAttributes.Namespace == "ns2b" {
+					result.Status.Allowed = true
+				}
+				return true, result, nil
+			}),
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource2", "namespace": "ns2b"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "access denied to all namespaces",
+			request:    "/namespaces/p-jklmn/testgroup.testresources",
+			sarReactor: genericDeniedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items":      []map[string]interface{}{},
+			},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sarClient.(*fakeauthzv1.FakeSubjectAccessReviews).Fake.PrependReactor("create", "*", test.sarReactor)
+			defer sarClient.(*fakeauthzv1.FakeSubjectAccessReviews).Fake.ClearActions()
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", test.request, nil)
+			mux.ServeHTTP(rr, req)
+			assert.Equal(t, test.wantStatus, rr.Code)
+			resp := rr.Result()
+			body, err := io.ReadAll(resp.Body)
+			assert.Nil(t, err)
+			if test.want != nil {
+				wantJSON, _ := json.Marshal(test.want)
+				assert.Equal(t, string(wantJSON), string(body))
+			}
+		})
+	}
+}
+
+func Test_globalHandler(t *testing.T) {
+	scheme := runtime.NewScheme()
+	objs := []runtime.Object{
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "ns1",
+					"name":      "resource1",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "ns2",
+					"name":      "resource2",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "ns3",
+					"name":      "resource3",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "ns4",
+					"name":      "resource4",
+				},
+			},
+		},
+	}
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		schema.GroupVersionResource{
+			Group:    "testgroup",
+			Version:  "testversion",
+			Resource: "testresources",
+		}: "TestResourceList",
+	}
+	clientGetter := func(_ *http.Request, _ *rest.Config, resource schema.GroupVersionResource) (dynamic.NamespaceableResourceInterface, error) {
+		return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objs...).Resource(resource), nil
+	}
+	sarClient := fake.NewSimpleClientset().AuthorizationV1().SubjectAccessReviews()
+
+	apis := &apiResourceWatcher{
+		resourceMap: map[string]metav1.APIResource{
+			"testgroup.testresources": metav1.APIResource{
+				Name:       "testresources",
+				Version:    "testversion",
+				Group:      "testgroup",
+				Namespaced: true,
+			},
+		},
+		mapper: meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "testgroup", Version: "testversion"}}),
+	}
+	apis.mapper.(*meta.DefaultRESTMapper).Add(schema.GroupVersionKind{Group: "testgroup", Version: "testversion", Kind: "TestResource"}, meta.RESTScopeNamespace)
+	namespaceCache := &mockNamespaceCache{
+		namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns1",
+					Labels: map[string]string{
+						"field.cattle.io/projectId":   "p-abcde",
+						"kubernetes.io/metadata.name": "ns1",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns2",
+					Labels: map[string]string{
+						"field.cattle.io/projectId":   "p-jklmn",
+						"kubernetes.io/metadata.name": "ns2",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns3",
+					Labels: map[string]string{
+						"field.cattle.io/projectId":   "p-vwxyz",
+						"kubernetes.io/metadata.name": "ns3",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns4",
+					// no projectId label == orphan namespace
+					Labels: map[string]string{
+						"kubernetes.io/metadata.name": "ns4",
+					},
+				},
+			},
+			// project namespaces
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p-abcde",
+					Labels: map[string]string{
+						"cattle.io/parent":            "true",
+						"kubernetes.io/metadata.name": "p-abcde",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p-jklmn",
+					Labels: map[string]string{
+						"cattle.io/parent":            "true",
+						"kubernetes.io/metadata.name": "p-jklmn",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					// namespace with project name
+					Name: "p-vwxyz",
+					Labels: map[string]string{
+						"cattle.io/parent":            "true",
+						"kubernetes.io/metadata.name": "p-vwxyz",
+					},
+				},
+			},
+		},
+	}
+
+	mux := mux.NewRouter()
+	h := handler{apis: apis, clientGetter: clientGetter, sarClient: sarClient, namespaceCache: namespaceCache}
+	mux.HandleFunc("/{resource}", h.globalHandler).Queries(queryKey, queryValue)
+
+	tests := []struct {
+		name       string
+		request    string
+		sarReactor clienttesting.ReactionFunc
+		namespaces []corev1.Namespace
+		want       map[string]interface{}
+		wantStatus int
+	}{
+		{
+			name:       "no selector",
+			request:    "/testgroup.testresources",
+			sarReactor: genericAllowedSARReactor,
+			want:       nil,
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "one project",
+			request:    "/testgroup.testresources?fieldSelector=projectsornamespaces=p-abcde",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata": map[string]interface{}{
+					"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "multi project",
+			request:    "/testgroup.testresources?fieldSelector=projectsornamespaces=p-abcde,p-jklmn,p-vwxyz",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource2", "namespace": "ns2"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource3", "namespace": "ns3"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "one namespace",
+			request:    "/testgroup.testresources?fieldSelector=projectsornamespaces=ns1",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "multi namespace",
+			request:    "/testgroup.testresources?fieldSelector=projectsornamespaces=ns1,ns3,ns4",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource3", "namespace": "ns3"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource4", "namespace": "ns4"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "assorted projects and namespaces",
+			request:    "/testgroup.testresources?fieldSelector=projectsornamespaces=p-abcde,ns2",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource2", "namespace": "ns2"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not single namespace",
+			request:    "/testgroup.testresources?fieldSelector=projectsornamespaces!=ns1",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource2", "namespace": "ns2"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource3", "namespace": "ns3"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource4", "namespace": "ns4"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not single project",
+			request:    "/testgroup.testresources?fieldSelector=projectsornamespaces!=p-abcde",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource2", "namespace": "ns2"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource3", "namespace": "ns3"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource4", "namespace": "ns4"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not multi namespace",
+			request:    "/testgroup.testresources?fieldSelector=projectsornamespaces!=ns1,ns2",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource3", "namespace": "ns3"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource4", "namespace": "ns4"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not multi project",
+			request:    "/testgroup.testresources?fieldSelector=projectsornamespaces!=p-abcde,p-jklmn",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource3", "namespace": "ns3"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource4", "namespace": "ns4"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not combo project and namespace",
+			request:    "/testgroup.testresources?fieldSelector=projectsornamespaces!=p-abcde,ns3",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource2", "namespace": "ns2"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource4", "namespace": "ns4"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:    "access denied to some namespaces",
+			request: "/testgroup.testresources?fieldSelector=projectsornamespaces=p-abcde,p-jklmn,p-vwxyz",
+			sarReactor: clienttesting.ReactionFunc(func(action clienttesting.Action) (bool, runtime.Object, error) {
+				result := &authzv1.SubjectAccessReview{
+					Status: authzv1.SubjectAccessReviewStatus{},
+				}
+				namespace := action.(clienttesting.CreateActionImpl).GetObject().(*authzv1.SubjectAccessReview).Spec.ResourceAttributes.Namespace
+				if namespace == "ns1" || namespace == "ns3" {
+					result.Status.Allowed = true
+				}
+				return true, result, nil
+			}),
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource1", "namespace": "ns1"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource3", "namespace": "ns3"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "access denied to all namespaces",
+			request:    "/testgroup.testresources?fieldSelector=projectsornamespaces=p-abcde,p-jklmn,p-vwxyz",
+			sarReactor: genericDeniedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items":      []map[string]interface{}{},
+			},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sarClient.(*fakeauthzv1.FakeSubjectAccessReviews).Fake.PrependReactor("create", "*", test.sarReactor)
+			defer sarClient.(*fakeauthzv1.FakeSubjectAccessReviews).Fake.ClearActions()
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", test.request, nil)
+			mux.ServeHTTP(rr, req)
+			assert.Equal(t, test.wantStatus, rr.Code)
+			resp := rr.Result()
+			body, err := io.ReadAll(resp.Body)
+			assert.Nil(t, err)
+			if test.want != nil {
+				wantJSON, _ := json.Marshal(test.want)
+				assert.Equal(t, string(wantJSON), string(body))
+			}
+		})
+	}
+}
+
+func Test_unscopedHandler(t *testing.T) {
+	scheme := runtime.NewScheme()
+	objs := []runtime.Object{
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "ns1",
+					"name":      "resource1",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "ns2",
+					"name":      "resource2",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "ns4",
+					"name":      "resource4",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResource",
+				"metadata": map[string]interface{}{
+					"namespace": "ns5",
+					"name":      "resource5",
+				},
+			},
+		},
+	}
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		schema.GroupVersionResource{
+			Group:    "testgroup",
+			Version:  "testversion",
+			Resource: "testresources",
+		}: "TestResourceList",
+	}
+	clientGetter := func(_ *http.Request, _ *rest.Config, resource schema.GroupVersionResource) (dynamic.NamespaceableResourceInterface, error) {
+		return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objs...).Resource(resource), nil
+	}
+	sarClient := fake.NewSimpleClientset().AuthorizationV1().SubjectAccessReviews()
+
+	apis := &apiResourceWatcher{
+		resourceMap: map[string]metav1.APIResource{
+			"testgroup.testresources": metav1.APIResource{
+				Name:       "testresources",
+				Version:    "testversion",
+				Group:      "testgroup",
+				Namespaced: true,
+			},
+		},
+		mapper: meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "testgroup", Version: "testversion"}}),
+	}
+	apis.mapper.(*meta.DefaultRESTMapper).Add(schema.GroupVersionKind{Group: "testgroup", Version: "testversion", Kind: "TestResource"}, meta.RESTScopeNamespace)
+
+	namespaceCache := &mockNamespaceCache{
+		namespaces: []*corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns4",
+					// no projectId labels == orphan namespace
+					Labels: map[string]string{
+						"kubernetes.io/metadata.name": "ns4",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns5",
+					// no projectId labels == orphan namespace
+					Labels: map[string]string{
+						"kubernetes.io/metadata.name": "ns5",
+					},
+				},
+			},
+		},
+	}
+
+	h := handler{apis: apis, clientGetter: clientGetter, sarClient: sarClient, namespaceCache: namespaceCache}
+	mux := mux.NewRouter()
+	mux.HandleFunc("/namespaces/cattle-unscoped/{resource}", h.unscopedHandler).Queries(queryKey, queryValue)
+	mux.HandleFunc("/namespaces/cattle-unscoped/{resource}", h.unscopedHandler)
+
+	partialDenyReactor := clienttesting.ReactionFunc(func(action clienttesting.Action) (bool, runtime.Object, error) {
+		result := &authzv1.SubjectAccessReview{
+			Status: authzv1.SubjectAccessReviewStatus{},
+		}
+		if action.(clienttesting.CreateActionImpl).GetObject().(*authzv1.SubjectAccessReview).Spec.ResourceAttributes.Namespace == "ns5" {
+			result.Status.Allowed = true
+		}
+		return true, result, nil
+	})
+
+	tests := []struct {
+		name       string
+		request    string
+		namespaces []corev1.Namespace
+		sarReactor clienttesting.ReactionFunc
+		want       map[string]interface{}
+		wantStatus int
+	}{
+		{
+			name:       "no selector",
+			request:    "/namespaces/cattle-unscoped/testgroup.testresources",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource4", "namespace": "ns4"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource5", "namespace": "ns5"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "select by existing namespace",
+			request:    "/namespaces/cattle-unscoped/testgroup.testresources?fieldSelector=projectsornamespaces=ns4",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource4", "namespace": "ns4"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "select by nonexisting namespace",
+			request:    "/namespaces/cattle-unscoped/testgroup.testresources?fieldSelector=projectsornamespaces=ns10",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items":      []map[string]interface{}{},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not existing namespace",
+			request:    "/namespaces/cattle-unscoped/testgroup.testresources?fieldSelector=projectsornamespaces!=ns4",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource5", "namespace": "ns5"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not nonexisting namespace",
+			request:    "/namespaces/cattle-unscoped/testgroup.testresources?fieldSelector=projectsornamespaces!=ns10",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource4", "namespace": "ns4"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource5", "namespace": "ns5"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not namespace in project",
+			request:    "/namespaces/cattle-unscoped/testgroup.testresources?fieldSelector=projectsornamespaces!=n1",
+			sarReactor: genericAllowedSARReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource4", "namespace": "ns4"},
+					},
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource5", "namespace": "ns5"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "access to only one namespace",
+			request:    "/namespaces/cattle-unscoped/testgroup.testresources",
+			sarReactor: partialDenyReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource5", "namespace": "ns5"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "select by accessible namespace",
+			request:    "/namespaces/cattle-unscoped/testgroup.testresources?fieldSelector=projectsornamespaces=ns5",
+			sarReactor: partialDenyReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "testgroup/testversion",
+						"kind":       "TestResource",
+						"metadata":   map[string]interface{}{"name": "resource5", "namespace": "ns5"},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "select by inaccessible namespace",
+			request:    "/namespaces/cattle-unscoped/testgroup.testresources?fieldSelector=projectsornamespaces=ns4",
+			sarReactor: partialDenyReactor,
+			want: map[string]interface{}{
+				"apiVersion": "testgroup/testversion",
+				"kind":       "TestResourceList",
+				"metadata":   map[string]interface{}{"resourceVersion": ""},
+				"items":      []map[string]interface{}{},
+			},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sarClient.(*fakeauthzv1.FakeSubjectAccessReviews).Fake.PrependReactor("create", "*", test.sarReactor)
+			defer sarClient.(*fakeauthzv1.FakeSubjectAccessReviews).Fake.ClearActions()
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", test.request, nil)
+			mux.ServeHTTP(rr, req)
+			assert.Equal(t, test.wantStatus, rr.Code)
+			resp := rr.Result()
+			body, err := io.ReadAll(resp.Body)
+			assert.Nil(t, err)
+			if test.want != nil {
+				wantJSON, _ := json.Marshal(test.want)
+				assert.Equal(t, string(wantJSON), string(body))
+			}
+		})
+	}
+}
+
+func Test_gvrFromVars(t *testing.T) {
+	apis := apiResourceWatcher{
+		resourceMap: map[string]metav1.APIResource{
+			"pods": metav1.APIResource{
+				Name:       "pods",
+				Version:    "v1",
+				Group:      "",
+				Namespaced: true,
+			},
+			"apps.deployments": metav1.APIResource{
+				Name:       "deployments",
+				Version:    "v1",
+				Group:      "apps",
+				Namespaced: true,
+			},
+			"rbac.authorization.k8s.io.roles": metav1.APIResource{
+				Name:       "roles",
+				Version:    "v1",
+				Group:      "rbac.authorization.k8s.io",
+				Namespaced: true,
+			},
+		},
+	}
+	h := &handler{apis: &apis}
+
+	tests := []struct {
+		name    string
+		vars    map[string]string
+		want    schema.GroupVersionResource
+		wantErr error
+	}{
+		{
+			name:    "invalid resource",
+			vars:    map[string]string{"resource": "notaresources"},
+			wantErr: fmt.Errorf("could not find resource notaresources"),
+		},
+		{
+			name:    "invalid group and resource",
+			vars:    map[string]string{"resource": "notagroup.notaresources"},
+			wantErr: fmt.Errorf("could not find resource notagroup.notaresources"),
+		},
+		{
+			name: "/api/v1/-style resource",
+			vars: map[string]string{"resource": "pods"},
+			want: schema.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "pods",
+			},
+		},
+		{
+			name: "/apis/-style resource",
+			vars: map[string]string{"resource": "apps.deployments"},
+			want: schema.GroupVersionResource{
+				Group:    "apps",
+				Version:  "v1",
+				Resource: "deployments",
+			},
+		},
+		{
+			name: "multi-segment group resource",
+			vars: map[string]string{"resource": "rbac.authorization.k8s.io.roles"},
+			want: schema.GroupVersionResource{
+				Group:    "rbac.authorization.k8s.io",
+				Version:  "v1",
+				Resource: "roles",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, gotErr := h.gvrFromVars(test.vars)
+			assert.Equal(t, test.wantErr, gotErr)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+type mockNamespaceCache struct {
+	namespaces []*corev1.Namespace
+}
+
+func (m *mockNamespaceCache) Get(name string) (*corev1.Namespace, error) {
+	for _, n := range m.namespaces {
+		if n.Name == name {
+			return n, nil
+		}
+	}
+	return nil, &apierrors.StatusError{
+		ErrStatus: metav1.Status{
+			Code: 404,
+		},
+	}
+}
+
+func (m *mockNamespaceCache) List(selector labels.Selector) ([]*corev1.Namespace, error) {
+	result := []*corev1.Namespace{}
+	for _, n := range m.namespaces {
+		if selector.Matches(labels.Set(n.ObjectMeta.Labels)) {
+			result = append(result, n)
+		}
+	}
+	return result, nil
+}
+func (m *mockNamespaceCache) AddIndexer(indexName string, indexer corecontrollers.NamespaceIndexer) {
+	panic("not implemented")
+}
+
+func (m *mockNamespaceCache) GetByIndex(indexName, key string) ([]*corev1.Namespace, error) {
+	panic("not implemented")
+}

--- a/pkg/api/steve/projectresources/register.go
+++ b/pkg/api/steve/projectresources/register.go
@@ -1,0 +1,463 @@
+package projectresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/rancher/pkg/controllers/managementagent/nslabels"
+	"github.com/rancher/rancher/pkg/namespace"
+	"github.com/rancher/rancher/pkg/tls"
+	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/rancher/steve/pkg/attributes"
+	steveschema "github.com/rancher/steve/pkg/schema"
+	steve "github.com/rancher/steve/pkg/server"
+	apiregcontrollers "github.com/rancher/wrangler/pkg/generated/controllers/apiregistration.k8s.io/v1"
+	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	rbaccontrollers "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/dynamic"
+	clientauthzv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	"k8s.io/client-go/rest"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+)
+
+const (
+	// Group is the APIGroup for this APIService.
+	Group = "resources.project.cattle.io"
+	// ParentLabel is the label assigned to namespaces that represent Projects.
+	ParentLabel = "cattle.io/parent"
+	// RoleName is the name of the ClusterRole and RoleBindings used to grant access to this API.
+	RoleName = "cattle-project-resources"
+	// AuthzAnnotation is the annotation designated for RBAC resources.
+	AuthzAnnotation = "resources.project.cattle.io/authz"
+	// NamespaceAnnotation is the annotation designated for namespaces.
+	NamespaceAnnotation = "resources.project.cattle.io/namespace"
+
+	apiServiceName            = version + "." + Group
+	groupVersion              = Group + "/" + version
+	version                   = "v1alpha1"
+	queryKey                  = "fieldSelector"
+	projectsOrNamespacesKey   = "projectsornamespaces"
+	projectsOrNamespacesVar   = "projectsOrNamespaces"
+	cattleClusterAgentService = "cattle-cluster-agent"
+	rancherService            = "rancher"
+	priority                  = 1 // low priority
+	unscopedNamespace         = "cattle-unscoped"
+)
+
+var (
+	paramScheme                = runtime.NewScheme()
+	paramCodec                 = runtime.NewParameterCodec(paramScheme)
+	queryOpReg                 = regexp.MustCompile("[=!]?=")
+	queryValue                 = fmt.Sprintf("%s{op:[=!]?}={%s}", projectsOrNamespacesKey, projectsOrNamespacesVar)
+	orphanNamespaceRequirement *labels.Requirement
+	groupResourceReg           = regexp.MustCompile(`^.*\.([a-z]*)$`)
+)
+
+func init() {
+	metav1.AddToGroupVersion(paramScheme, metav1.SchemeGroupVersion)
+
+	var err error
+	orphanNamespaceRequirement, err = labels.NewRequirement(nslabels.ProjectIDFieldLabel, selection.DoesNotExist, nil)
+	if err != nil {
+		panic("programmer error: invalid selector")
+	}
+}
+
+type configError struct {
+	msg string
+}
+
+func (c configError) Error() string {
+	if c.msg == "" {
+		return "invalid extension config"
+	}
+	return c.msg
+}
+
+type authError struct {
+	msg string
+}
+
+func (c authError) Error() string {
+	return fmt.Sprintf(c.msg)
+}
+
+type apiServiceHandler struct {
+	secretCache       corecontrollers.SecretCache
+	apiServiceCache   apiregcontrollers.APIServiceCache
+	apiServiceClient  apiregcontrollers.APIServiceClient
+	namespaceCache    corecontrollers.NamespaceCache
+	namespaceClient   corecontrollers.NamespaceClient
+	clusterRoleCache  rbaccontrollers.ClusterRoleCache
+	clusterRoleClient rbaccontrollers.ClusterRoleClient
+	roleBindingCache  rbaccontrollers.RoleBindingCache
+	roleBindingClient rbaccontrollers.RoleBindingClient
+}
+
+type handler struct {
+	restConfig     *rest.Config
+	sarClient      clientauthzv1.SubjectAccessReviewInterface
+	namespaceCache corecontrollers.NamespaceCache
+	apis           APIResourceWatcher
+	clientGetter   clientGetter
+}
+
+type authHandler struct {
+	configMapCache corecontrollers.ConfigMapCache
+}
+
+type clientGetter func(*http.Request, *rest.Config, schema.GroupVersionResource) (dynamic.NamespaceableResourceInterface, error)
+
+// formatter ensures the links in the steve response point back to the original resource,
+// since update, view, and delete don't work on this endpoint.
+func formatter(apiOp *types.APIRequest, resource *types.RawResource) {
+	if !strings.Contains(resource.Type, Group) {
+		return
+	}
+	unst, ok := resource.APIObject.Object.(*unstructured.Unstructured)
+	if !ok {
+		logrus.Debugf("could not format links for unexpected resource type %v", resource)
+		return
+	}
+	apiVersion, ok := unst.Object["apiVersion"]
+	if !ok {
+		logrus.Debugf("could not format links for unexpected resource type %v", resource)
+		return
+	}
+
+	for k, v := range resource.Links {
+		v1Pattern := fmt.Sprintf("/v1/%s.", Group)           // self, update, remove links (added by apiserver)
+		k8sPattern := fmt.Sprintf("/apis/%s/", groupVersion) // view link (added by steve)
+		switch {
+		case strings.Contains(v, v1Pattern):
+			resource.Links[k] = strings.Replace(v, v1Pattern, "/v1/", 1)
+		case strings.Contains(v, k8sPattern):
+			// example input: https://rancher/apis/resources.project.cattle.io/v1alpha1/namespaces/default/apps.deployments/mydeployment
+			// use the true API version, not what the schema thinks it is
+			var link string
+			if apiVersion == "v1" {
+				link = strings.Replace(v, k8sPattern, fmt.Sprintf("/api/%s/", apiVersion), 1)
+			} else {
+				link = strings.Replace(v, k8sPattern, fmt.Sprintf("/apis/%s/", apiVersion), 1)
+			}
+			concatResource := attributes.Resource(resource.Schema)                    // example: apps.deployments, rbac.authorization.io.roles, pods
+			resourceOnly := groupResourceReg.ReplaceAllString(concatResource, "${1}") // result: deployments, roles, pods
+			link = strings.Replace(link, concatResource, resourceOnly, 1)
+			resource.Links[k] = link // example result: https://rancher/apis/apps/v1/namespaces/default/deployments/mydeployment
+		}
+	}
+	selfLink, ok := resource.Links["self"]
+	if !ok {
+		return
+	}
+	origType := strings.ReplaceAll(resource.Type, Group+".", "")
+	origSchema := apiOp.Schemas.LookupSchema(origType)
+	if _, ok := resource.Links["update"]; !ok && origSchema != nil && apiOp.AccessControl.CanUpdate(apiOp, resource.APIObject, origSchema) == nil {
+		resource.Links["update"] = selfLink
+	}
+	if _, ok := resource.Links["delete"]; !ok && origSchema != nil && apiOp.AccessControl.CanDelete(apiOp, resource.APIObject, origSchema) == nil {
+		resource.Links["delete"] = selfLink
+	}
+
+}
+
+func setUpSteve(server *steve.Server) error {
+	server.SchemaFactory.AddTemplate(steveschema.Template{
+		Customize: func(schema *types.APISchema) {
+			schema.Formatter = types.FormatterChain(schema.Formatter, formatter) // make sure the default formatter runs first so our formatter can apply changes to it
+		},
+	})
+	return nil
+}
+
+// Register creates the APIService in kubernetes, starts a watch on APIResources, and registers the endpoint handlers.
+func Register(ctx context.Context, router *mux.Router, config *wrangler.Context, server *steve.Server) {
+	if !checkServerConfig(config.Core.ConfigMap()) {
+		logrus.Infof("[%s] kube-apiserver is not configured for API server aggregation, the %s API will be disabled", apiServiceName, apiServiceName)
+		return
+	}
+	err := setUpSteve(server)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	setUpAPIService(ctx, config)
+	restConfig, err := config.ClientConfig.ClientConfig()
+	if err != nil {
+		logrus.Fatalf("[%s] failed to get rest config: %v", apiServiceName, err)
+		return
+	}
+	mapper, _ := config.RESTClientGetter.ToRESTMapper()
+	h := handler{
+		restConfig:     restConfig,
+		sarClient:      config.K8s.AuthorizationV1().SubjectAccessReviews(),
+		namespaceCache: config.Core.Namespace().Cache(),
+		apis:           WatchAPIResources(ctx, config.K8s.Discovery(), config.CRD.CustomResourceDefinition(), config.API.APIService(), mapper),
+		clientGetter:   clientForRequest,
+	}
+	subRouter := router.PathPrefix("/apis").Subrouter()
+	subRouter.HandleFunc("/resources.project.cattle.io/v1alpha1", h.discoveryHandler).Methods(http.MethodGet)
+	subRouter.HandleFunc("/resources.project.cattle.io/v1alpha1/{resource}", h.globalHandler).Queries(queryKey, queryValue).Methods(http.MethodGet)
+	subRouter.HandleFunc("/resources.project.cattle.io/v1alpha1/{resource}", h.forwarder).Methods(http.MethodGet)
+	subRouter.HandleFunc("/resources.project.cattle.io/v1alpha1/namespaces/cattle-unscoped/{resource}", h.unscopedHandler).Queries(queryKey, queryValue).Methods(http.MethodGet)
+	subRouter.HandleFunc("/resources.project.cattle.io/v1alpha1/namespaces/cattle-unscoped/{resource}", h.unscopedHandler).Methods(http.MethodGet)
+	subRouter.HandleFunc("/resources.project.cattle.io/v1alpha1/namespaces/{project}/{resource}", h.scopedHandler).Queries(queryKey, queryValue).Methods(http.MethodGet)
+	subRouter.HandleFunc("/resources.project.cattle.io/v1alpha1/namespaces/{project}/{resource}", h.scopedHandler).Methods(http.MethodGet)
+	a := authHandler{
+		configMapCache: config.Core.ConfigMap().Cache(),
+	}
+	subRouter.Use(a.authenticateAPIServer)
+}
+
+func checkServerConfig(configMapClient corecontrollers.ConfigMapClient) bool {
+	config, err := configMapClient.Get(kubeSystemNamespace, extensionConfigMap, metav1.GetOptions{})
+	if err != nil {
+		logrus.Debugf("[%s] could not find %s/%s configmap", apiServiceName, kubeSystemNamespace, extensionConfigMap)
+		return false
+	}
+	_, ok := config.Data[clientCAKey]
+	if !ok {
+		logrus.Debugf("[%s] could not find %s key in %s configmap", apiServiceName, clientCAKey, extensionConfigMap)
+	}
+	return ok
+}
+
+func setUpAPIService(ctx context.Context, config *wrangler.Context) {
+	a := apiServiceHandler{
+		secretCache:       config.Core.Secret().Cache(),
+		apiServiceCache:   config.API.APIService().Cache(),
+		apiServiceClient:  config.API.APIService(),
+		namespaceCache:    config.Core.Namespace().Cache(),
+		namespaceClient:   config.Core.Namespace(),
+		clusterRoleCache:  config.RBAC.ClusterRole().Cache(),
+		clusterRoleClient: config.RBAC.ClusterRole(),
+		roleBindingCache:  config.RBAC.RoleBinding().Cache(),
+		roleBindingClient: config.RBAC.RoleBinding(),
+	}
+	config.Core.Service().OnChange(ctx, "project-resources-apiservice", a.applyAPIService)
+}
+
+// applyAPIService creates or updates the APIService and other required resources.
+func (a *apiServiceHandler) applyAPIService(key string, service *corev1.Service) (*corev1.Service, error) {
+	if service == nil {
+		return service, nil
+	}
+	if service.Namespace != namespace.System || (service.Name != rancherService && service.Name != cattleClusterAgentService) {
+		return service, nil
+	}
+	err := a.ensureAPIService(service)
+	if err != nil {
+		return service, err
+	}
+	err = a.ensureNamespace()
+	if err != nil {
+		return service, err
+	}
+	err = a.ensureClusterRole()
+	if err != nil {
+		return service, err
+	}
+	err = a.ensureRoleBinding()
+	return service, err
+}
+
+func getDynamicClient(config *wrangler.Context) (dynamic.Interface, error) {
+	restConfig, err := config.ClientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	return dynamic.NewForConfig(restConfig)
+}
+
+func (a *apiServiceHandler) ensureAPIService(service *corev1.Service) error {
+	logrus.Tracef("[%s] ensuring apiservice %s", apiServiceName, apiServiceName)
+	var tlsSecret *corev1.Secret
+	var err error
+	if os.Getenv("CATTLE_DEV_MODE") == "" {
+		tlsSecret, err = a.secretCache.Get(namespace.System, tls.InternalCA)
+		if err != nil {
+			return fmt.Errorf("could not get secret %s, %w", tls.InternalCA, err)
+		}
+		if len(tlsSecret.Data) == 0 || len(tlsSecret.Data[corev1.TLSCertKey]) == 0 {
+			return fmt.Errorf("secret %s is not ready yet", tls.InternalCA)
+		}
+	}
+	apiService := &apiregv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: apiServiceName,
+		},
+		Spec: apiregv1.APIServiceSpec{
+			Group:                Group,
+			GroupPriorityMinimum: priority,
+			Version:              version,
+			VersionPriority:      priority,
+			Service: &apiregv1.ServiceReference{
+				Namespace: service.Namespace,
+				Name:      service.Name,
+			},
+		},
+	}
+	if tlsSecret == nil { // in dev mode, there is no CA
+		apiService.Spec.InsecureSkipTLSVerify = true
+	} else {
+		apiService.Spec.CABundle = tlsSecret.Data[corev1.TLSCertKey]
+	}
+	currentAPIService, err := a.apiServiceCache.Get(apiServiceName)
+	if apierrors.IsNotFound(err) {
+		_, err = a.apiServiceClient.Create(apiService)
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		currentAPIService, err = a.apiServiceClient.Get(apiServiceName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	if !reflect.DeepEqual(currentAPIService.Spec, apiService.Spec) {
+		updatedAPIService := currentAPIService.DeepCopy()
+		updatedAPIService.Spec = apiService.Spec
+		_, err = a.apiServiceClient.Update(updatedAPIService)
+		return err
+	}
+	return nil
+}
+
+func (a *apiServiceHandler) ensureNamespace() error {
+	logrus.Tracef("[%s] ensuring namespace %s", apiServiceName, unscopedNamespace)
+	// special non-project namespace to "contain" namespaces not in a project
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: unscopedNamespace,
+			Annotations: map[string]string{
+				NamespaceAnnotation: "true",
+			},
+		},
+	}
+	currentNamespace, err := a.namespaceCache.Get(unscopedNamespace)
+	if apierrors.IsNotFound(err) {
+		_, err = a.namespaceClient.Create(namespace)
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		currentNamespace, err = a.namespaceClient.Get(unscopedNamespace, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	if !reflect.DeepEqual(currentNamespace.ObjectMeta.Annotations, namespace.ObjectMeta.Annotations) {
+		updatedNamespace := currentNamespace.DeepCopy()
+		updatedNamespace.ObjectMeta.Annotations = namespace.ObjectMeta.Annotations
+		_, err = a.namespaceClient.Update(updatedNamespace)
+		return err
+	}
+	return nil
+}
+
+func (a *apiServiceHandler) ensureClusterRole() error {
+	logrus.Tracef("[%s] ensuring clusterrole %s", apiServiceName, RoleName)
+	// cluster role for listing resources in this APIGroup
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: RoleName,
+			Annotations: map[string]string{
+				AuthzAnnotation: "unscoped",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"list"},
+				APIGroups: []string{Group},
+				Resources: []string{"*"},
+			},
+		},
+	}
+	currentRole, err := a.clusterRoleCache.Get(RoleName)
+	if apierrors.IsNotFound(err) {
+		_, err = a.clusterRoleClient.Create(role)
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		currentRole, err = a.clusterRoleClient.Get(RoleName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	if !reflect.DeepEqual(currentRole.Rules, role.Rules) || !reflect.DeepEqual(currentRole.ObjectMeta.Annotations, role.ObjectMeta.Annotations) {
+		updatedClusterRole := currentRole.DeepCopy()
+		updatedClusterRole.ObjectMeta.Annotations = role.ObjectMeta.Annotations
+		_, err = a.clusterRoleClient.Update(updatedClusterRole)
+		return err
+	}
+	return nil
+}
+
+func (a *apiServiceHandler) ensureRoleBinding() error {
+	logrus.Tracef("[%s] ensuring rolebinding %s/%s", apiServiceName, unscopedNamespace, RoleName)
+	// default rolebinding for the special unscoped namespace, the prtb controller will create similar rolebindings for project namespaces for specific users
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      RoleName,
+			Namespace: unscopedNamespace,
+			Annotations: map[string]string{
+				AuthzAnnotation: "unscoped",
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "Group",
+				Name: "system:authenticated", // all users can access this endpoint initially, the handler will do a SAR check before returning resources
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     RoleName,
+		},
+	}
+	currentRoleBinding, err := a.roleBindingCache.Get(unscopedNamespace, RoleName)
+	if apierrors.IsNotFound(err) {
+		_, err = a.roleBindingClient.Create(roleBinding)
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		currentRoleBinding, err = a.roleBindingClient.Get(unscopedNamespace, RoleName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	if !reflect.DeepEqual(currentRoleBinding.ObjectMeta.Annotations, roleBinding.ObjectMeta.Annotations) {
+		updatedRoleBinding := currentRoleBinding.DeepCopy()
+		updatedRoleBinding.ObjectMeta.Annotations = currentRoleBinding.ObjectMeta.Annotations
+		_, err = a.roleBindingClient.Update(updatedRoleBinding)
+		return err
+	}
+	return nil
+}

--- a/pkg/api/steve/projectresources/register_test.go
+++ b/pkg/api/steve/projectresources/register_test.go
@@ -1,0 +1,331 @@
+package projectresources
+
+import (
+	"testing"
+
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/wrangler/pkg/schemas"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func Test_formatter(t *testing.T) {
+	testSchemas := types.EmptyAPISchemas()
+	testSchemas.MustAddSchema(types.APISchema{Schema: &schemas.Schema{ID: "namespace"}})
+	testSchemas.MustAddSchema(types.APISchema{Schema: &schemas.Schema{ID: "pod"}})
+	testSchemas.MustAddSchema(types.APISchema{Schema: &schemas.Schema{ID: "rbac.authorization.io.clusterrole"}})
+	testSchemas.MustAddSchema(types.APISchema{Schema: &schemas.Schema{ID: "apps.deployment"}})
+	apiOp := &types.APIRequest{
+		Schemas:       testSchemas,
+		AccessControl: mockAccessControl{},
+	}
+	tests := []struct {
+		name     string
+		resource *types.RawResource
+		want     map[string]string
+	}{
+		{
+			name: "steve url for core global resource", // there shouldn't ever be schemas for non-namespaced resources but just for completeness
+			resource: &types.RawResource{
+				Links: map[string]string{
+					"self": "https://example/v1/resources.project.cattle.io.namespaces/testns1",
+				},
+				Type: "resources.project.cattle.io.namespaces",
+				APIObject: types.APIObject{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"self":   "https://example/v1/namespaces/testns1",
+				"update": "https://example/v1/namespaces/testns1",
+				"delete": "https://example/v1/namespaces/testns1",
+			},
+		},
+		{
+			name: "steve url for core namespaced resource",
+			resource: &types.RawResource{
+				Links: map[string]string{
+					"self": "https://example/v1/resources.project.cattle.io.pods/testns1/testpod1",
+				},
+				Type: "resources.project.cattle.io.pods",
+				APIObject: types.APIObject{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"self":   "https://example/v1/pods/testns1/testpod1",
+				"update": "https://example/v1/pods/testns1/testpod1",
+				"delete": "https://example/v1/pods/testns1/testpod1",
+			},
+		},
+		{
+			name: "steve url for non-core global resource",
+			resource: &types.RawResource{
+				Links: map[string]string{
+					"self": "https://example/v1/resources.project.cattle.io.rbac.authorization.io.clusterroles/testcr1",
+				},
+				Type: "resources.project.cattle.io.rbac.authorization.io.clusterroles",
+				APIObject: types.APIObject{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "rbac.authorization.io/v1",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"self":   "https://example/v1/rbac.authorization.io.clusterroles/testcr1",
+				"update": "https://example/v1/rbac.authorization.io.clusterroles/testcr1",
+				"delete": "https://example/v1/rbac.authorization.io.clusterroles/testcr1",
+			},
+		},
+		{
+			name: "steve url for non-core namespaced resource",
+			resource: &types.RawResource{
+				Links: map[string]string{
+					"self": "https://example/v1/resources.project.cattle.io.apps.deployments/testns1/testdeploy1",
+				},
+				Type: "resources.project.cattle.io.apps.deployments",
+				APIObject: types.APIObject{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "apps/v1",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"self":   "https://example/v1/apps.deployments/testns1/testdeploy1",
+				"update": "https://example/v1/apps.deployments/testns1/testdeploy1",
+				"delete": "https://example/v1/apps.deployments/testns1/testdeploy1",
+			},
+		},
+		{
+			name: "k8s url for core global resource",
+			resource: &types.RawResource{
+				Links: map[string]string{
+					"view": "https://example/apis/resources.project.cattle.io/v1alpha1/namespaces/testns1",
+				},
+				Type: "resources.project.cattle.io.namespaces",
+				Schema: &types.APISchema{
+					Schema: &schemas.Schema{
+						Attributes: map[string]interface{}{
+							"resource": "namespaces",
+						},
+					},
+				},
+				APIObject: types.APIObject{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"view": "https://example/api/v1/namespaces/testns1",
+			},
+		},
+		{
+			name: "k8s url for core namespaced resource",
+			resource: &types.RawResource{
+				Links: map[string]string{
+					"view": "https://example/apis/resources.project.cattle.io/v1alpha1/namespaces/testns1/pods/testpod1",
+				},
+				Type: "resources.project.cattle.io.pods",
+				Schema: &types.APISchema{
+					Schema: &schemas.Schema{
+						Attributes: map[string]interface{}{
+							"resource": "pods",
+						},
+					},
+				},
+				APIObject: types.APIObject{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"view": "https://example/api/v1/namespaces/testns1/pods/testpod1",
+			},
+		},
+		{
+			name: "k8s url for non-core global resource",
+			resource: &types.RawResource{
+				Links: map[string]string{
+					"view": "https://example/apis/resources.project.cattle.io/v1alpha1/rbac.authorization.io.clusterroles/testcr1",
+				},
+				Type: "resources.project.cattle.io.rbac.authorization.io.clusterroles",
+				Schema: &types.APISchema{
+					Schema: &schemas.Schema{
+						Attributes: map[string]interface{}{
+							"resource": "rbac.authorization.io.clusterroles",
+						},
+					},
+				},
+				APIObject: types.APIObject{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "rbac.authorization.io/v1",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"view": "https://example/apis/rbac.authorization.io/v1/clusterroles/testcr1",
+			},
+		},
+		{
+			name: "k8s url for non-core namespaced resource",
+			resource: &types.RawResource{
+				Links: map[string]string{
+					"view": "https://example/apis/resources.project.cattle.io/v1alpha1/namespaces/testns1/apps.deployments/testdeploy1",
+				},
+				Type: "resources.project.cattle.io.apps.deployments",
+				Schema: &types.APISchema{
+					Schema: &schemas.Schema{
+						Attributes: map[string]interface{}{
+							"resource": "apps.deployments",
+						},
+					},
+				},
+				APIObject: types.APIObject{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "apps/v1",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"view": "https://example/apis/apps/v1/namespaces/testns1/deployments/testdeploy1",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			formatter(apiOp, test.resource)
+			assert.Equal(t, test.want, test.resource.Links)
+		})
+	}
+}
+
+func Test_checkServerConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		data *corev1.ConfigMap
+		want bool
+	}{
+		{
+			name: "no configmap",
+			data: nil,
+			want: false,
+		},
+		{
+			name: "unconfigured configmap",
+			data: &corev1.ConfigMap{
+				Data: map[string]string{},
+			},
+			want: false,
+		},
+		{
+			name: "configured configmap",
+			data: &corev1.ConfigMap{
+				Data: map[string]string{
+					"requestheader-client-ca-file": "ca bytes",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := &mockConfigMapClient{
+				configMap: test.data,
+			}
+			got := checkServerConfig(mock)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+type mockAccessControl struct{}
+
+func (a mockAccessControl) CanAction(apiOp *types.APIRequest, schema *types.APISchema, name string) error {
+	return nil
+}
+
+func (a mockAccessControl) CanCreate(apiOp *types.APIRequest, schema *types.APISchema) error {
+	return nil
+}
+
+func (a mockAccessControl) CanList(apiOp *types.APIRequest, schema *types.APISchema) error {
+	return nil
+}
+
+func (a mockAccessControl) CanGet(apiOp *types.APIRequest, schema *types.APISchema) error {
+	return nil
+}
+
+func (a mockAccessControl) CanUpdate(apiOp *types.APIRequest, obj types.APIObject, schema *types.APISchema) error {
+	return nil
+}
+
+func (a mockAccessControl) CanDelete(apiOp *types.APIRequest, obj types.APIObject, schema *types.APISchema) error {
+	return nil
+}
+
+func (a mockAccessControl) CanWatch(apiOp *types.APIRequest, schema *types.APISchema) error {
+	return nil
+}
+
+func (a mockAccessControl) CanDo(apiOp *types.APIRequest, resource, verb, namespace, name string) error {
+	return nil
+}
+
+type mockConfigMapClient struct {
+	configMap *corev1.ConfigMap
+}
+
+func (c *mockConfigMapClient) Get(_, _ string, _ metav1.GetOptions) (*corev1.ConfigMap, error) {
+	if c.configMap != nil {
+		return c.configMap, nil
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
+}
+
+func (c *mockConfigMapClient) Create(*corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	panic("not implemented")
+}
+func (c *mockConfigMapClient) Update(*corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	panic("not implemented")
+}
+func (c *mockConfigMapClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
+	panic("not implemented")
+}
+func (c *mockConfigMapClient) List(_ string, _ metav1.ListOptions) (*corev1.ConfigMapList, error) {
+	panic("not implemented")
+}
+func (c *mockConfigMapClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
+	panic("not implemented")
+}
+func (c *mockConfigMapClient) Patch(_, _ string, _ k8stypes.PatchType, _ []byte, _ ...string) (*corev1.ConfigMap, error) {
+	panic("not implemented")
+}

--- a/pkg/controllers/dashboard/apiservice/setting.go
+++ b/pkg/controllers/dashboard/apiservice/setting.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/rancher/pkg/tls"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -57,7 +58,7 @@ func (h *handler) getInternalServerAndURL() (string, string, error) {
 	serverURL := settings.ServerURL.Get()
 	ca := settings.CACerts.Get()
 
-	tlsSecret, err := h.secretsCache.Get(namespace.System, "tls-rancher-internal-ca")
+	tlsSecret, err := h.secretsCache.Get(namespace.System, tls.InternalCA)
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/controllers/managementuser/rbac/crtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/crtb_handler.go
@@ -1,8 +1,9 @@
 package rbac
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	"github.com/sirupsen/logrus"
@@ -52,7 +53,7 @@ func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding) error {
 
 	rt, err := c.m.rtLister.Get("", binding.RoleTemplateName)
 	if err != nil {
-		return errors.Wrapf(err, "couldn't get role template %v", binding.RoleTemplateName)
+		return fmt.Errorf("couldn't get role template %s: %w", binding.RoleTemplateName, err)
 	}
 
 	roles := map[string]*v3.RoleTemplate{}
@@ -61,16 +62,16 @@ func (c *crtbLifecycle) syncCRTB(binding *v3.ClusterRoleTemplateBinding) error {
 	}
 
 	if err := c.m.ensureRoles(roles); err != nil {
-		return errors.Wrap(err, "couldn't ensure roles")
+		return fmt.Errorf("couldn't ensure roles: %w", err)
 	}
 
 	if err := c.m.ensureClusterBindings(roles, binding); err != nil {
-		return errors.Wrapf(err, "couldn't ensure cluster bindings %v", binding)
+		return fmt.Errorf("couldn't ensure cluster bindings %s: %w", binding, err)
 	}
 
 	if binding.UserName != "" {
 		if err := c.m.ensureServiceAccountImpersonator(binding.UserName); err != nil {
-			return errors.Wrapf(err, "couldn't ensure service account impersonator")
+			return fmt.Errorf("couldn't ensure service account impersonator: %w", err)
 		}
 	}
 
@@ -82,19 +83,19 @@ func (c *crtbLifecycle) ensureCRTBDelete(binding *v3.ClusterRoleTemplateBinding)
 	bindingCli := c.m.workload.RBAC.ClusterRoleBindings("")
 	rbs, err := c.m.crbLister.List("", set.AsSelector())
 	if err != nil {
-		return errors.Wrapf(err, "couldn't list clusterrolebindings with selector %s", set.AsSelector())
+		return fmt.Errorf("couldn't list clusterrolebindings with selector %s: %w", set.AsSelector(), err)
 	}
 
 	for _, rb := range rbs {
 		if err := bindingCli.Delete(rb.Name, &metav1.DeleteOptions{}); err != nil {
 			if !apierrors.IsNotFound(err) {
-				return errors.Wrapf(err, "error deleting clusterrolebinding %v", rb.Name)
+				return fmt.Errorf("error deleting clusterrolebinding %s: %w", rb.Name, err)
 			}
 		}
 	}
 
 	if err := c.m.deleteServiceAccountImpersonator(binding.UserName); err != nil {
-		return errors.Wrap(err, "error deleting service account impersonator")
+		return fmt.Errorf("error deleting service account impersonator: %w", err)
 	}
 
 	return nil

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -192,18 +192,17 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 		if err != nil {
 			return false, errors.Wrapf(err, "couldn't list role bindings in %s", ns.Name)
 		}
-		client := n.m.workload.RBAC.RoleBindings(ns.Name).ObjectClient()
 		for _, rb := range rbs {
 			// rtbOwnerLabelLegacy
 			if uid := convert.ToString(rb.Labels[rtbOwnerLabelLegacy]); uid != "" {
 				logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
-				if err := client.Delete(rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				if err := n.m.roleBindings.DeleteNamespaced(ns.Name, rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 					return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
 				}
 			}
 			if nsAndName := convert.ToString(rb.Labels[rtbOwnerLabel]); nsAndName != "" {
 				logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
-				if err := client.Delete(rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				if err := n.m.roleBindings.DeleteNamespaced(ns.Name, rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 					return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
 				}
 			}
@@ -262,7 +261,6 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 	if err != nil {
 		return false, errors.Wrapf(err, "couldn't list role bindings in %s", ns.Name)
 	}
-	client := n.m.workload.RBAC.RoleBindings(ns.Name).ObjectClient()
 
 	for _, rb := range rbs {
 		if uid := convert.ToString(rb.Labels[rtbOwnerLabelLegacy]); uid != "" {
@@ -278,7 +276,7 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 				if prtb, ok := prtb.(*v3.ProjectRoleTemplateBinding); ok {
 					if prtb.Namespace != namespace {
 						logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
-						if err := client.Delete(rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+						if err := n.m.roleBindings.DeleteNamespaced(ns.Name, rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 							return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
 						}
 					}
@@ -299,7 +297,7 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 				if prtb, ok := prtb.(*v3.ProjectRoleTemplateBinding); ok {
 					if prtb.Namespace != namespace {
 						logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
-						if err := client.Delete(rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+						if err := n.m.roleBindings.DeleteNamespaced(ns.Name, rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 							return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
 						}
 					}

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -195,13 +195,13 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 		for _, rb := range rbs {
 			// rtbOwnerLabelLegacy
 			if uid := convert.ToString(rb.Labels[rtbOwnerLabelLegacy]); uid != "" {
-				logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
+				logrus.Infof("Deleting role binding %s in %s owned by prtb %s because namespace does not belong to a project", rb.Name, ns.Name, uid)
 				if err := n.m.roleBindings.DeleteNamespaced(ns.Name, rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 					return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
 				}
 			}
 			if nsAndName := convert.ToString(rb.Labels[rtbOwnerLabel]); nsAndName != "" {
-				logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
+				logrus.Infof("Deleting role binding %s in %s owned by prtb %s because namespace does not belong to a project", rb.Name, ns.Name, nsAndName)
 				if err := n.m.roleBindings.DeleteNamespaced(ns.Name, rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 					return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
 				}
@@ -275,7 +275,7 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 			for _, prtb := range prtbs {
 				if prtb, ok := prtb.(*v3.ProjectRoleTemplateBinding); ok {
 					if prtb.Namespace != namespace {
-						logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
+						logrus.Infof("Deleting role binding %s in %s owned by prtb %s because namespace belongs to a different project %s", rb.Name, ns.Name, prtb.Name, prtb.Namespace)
 						if err := n.m.roleBindings.DeleteNamespaced(ns.Name, rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 							return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
 						}
@@ -296,7 +296,7 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 			for _, prtb := range prtbs {
 				if prtb, ok := prtb.(*v3.ProjectRoleTemplateBinding); ok {
 					if prtb.Namespace != namespace {
-						logrus.Infof("Deleting role binding %s in %s", rb.Name, ns.Name)
+						logrus.Infof("Deleting role binding %s in %s owned by prtb %s because namespace belongs to a different project %s", rb.Name, ns.Name, prtb.Name, prtb.Namespace)
 						if err := n.m.roleBindings.DeleteNamespaced(ns.Name, rb.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 							return false, errors.Wrapf(err, "couldn't delete role binding %s", rb.Name)
 						}

--- a/pkg/controllers/managementuser/rbac/project_handler.go
+++ b/pkg/controllers/managementuser/rbac/project_handler.go
@@ -50,7 +50,7 @@ func (p *pLifecycle) Remove(project *v3.Project) (runtime.Object, error) {
 	for _, suffix := range projectNSVerbToSuffix {
 		roleName := fmt.Sprintf(projectNSGetClusterRoleNameFmt, project.Name, suffix)
 
-		err := p.m.workload.RBAC.ClusterRoles("").Delete(roleName, &v1.DeleteOptions{})
+		err := p.m.clusterRoles.Delete(roleName, &v1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return project, err
 		}
@@ -65,7 +65,7 @@ func (p *pLifecycle) Remove(project *v3.Project) (runtime.Object, error) {
 	for _, o := range namespaces {
 		namespace, _ := o.(*corev1.Namespace)
 		if _, ok := namespace.Annotations["field.cattle.io/creatorId"]; ok {
-			err := p.m.workload.Core.Namespaces("").Delete(namespace.Name, &v1.DeleteOptions{})
+			err := p.m.namespaces.Delete(namespace.Name, &v1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				return project, err
 			}
@@ -73,7 +73,7 @@ func (p *pLifecycle) Remove(project *v3.Project) (runtime.Object, error) {
 			namespace = namespace.DeepCopy()
 			if namespace.Annotations != nil {
 				delete(namespace.Annotations, projectIDAnnotation)
-				_, err := p.m.workload.Core.Namespaces("").Update(namespace)
+				_, err := p.m.namespaces.Update(namespace)
 				if err != nil {
 					return project, err
 				}
@@ -149,7 +149,7 @@ func (p *pLifecycle) assignNamespacesToProject(project *v3.Project, projectName 
 			ns.Annotations = map[string]string{}
 		}
 		ns.Annotations[projectIDAnnotation] = fmt.Sprintf("%v:%v", p.m.clusterName, project.Name)
-		if _, err := p.m.workload.Core.Namespaces(p.m.clusterName).Update(ns); err != nil {
+		if _, err := p.m.namespaces.Update(ns); err != nil {
 			return err
 		}
 	}

--- a/pkg/controllers/managementuser/rbac/project_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/project_handler_test.go
@@ -1,0 +1,52 @@
+package rbac
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	corefakes "github.com/rancher/rancher/pkg/generated/norman/core/v1/fakes"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func Test_createOrUpdateProjectNS(t *testing.T) {
+	fakeDB := make(map[string]*v1.Namespace)
+	namespaces := &corefakes.NamespaceInterfaceMock{
+		CreateFunc: func(in *v1.Namespace) (*v1.Namespace, error) {
+			if _, ok := fakeDB[in.Name]; ok {
+				return nil, apierrors.NewAlreadyExists(schema.GroupResource{
+					Resource: "namespaces",
+				}, in.Name)
+			}
+			fakeDB[in.Name] = in
+			return in, nil
+		},
+	}
+	nsLister := &corefakes.NamespaceListerMock{
+		GetFunc: func(_, name string) (*v1.Namespace, error) {
+			if ns, ok := fakeDB[name]; ok {
+				return ns, nil
+			}
+			return nil, apierrors.NewNotFound(schema.GroupResource{
+				Resource: "namespaces",
+			}, name)
+		},
+	}
+	m := &manager{
+		namespaces: namespaces,
+		nsLister:   nsLister,
+	}
+
+	p := newProjectLifecycle(m)
+	err := p.ensureProjectNS(&v3.Project{ObjectMeta: metav1.ObjectMeta{Name: "test"}})
+	assert.Nil(t, err)
+	assert.NotNil(t, fakeDB["test"])
+	err = p.ensureProjectNS(&v3.Project{ObjectMeta: metav1.ObjectMeta{Name: "test"}})
+	assert.Nil(t, err)
+	fakeDB["test-existing"] = &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-existing"}}
+	err = p.ensureProjectNS(&v3.Project{ObjectMeta: metav1.ObjectMeta{Name: "test-existing"}})
+	assert.Error(t, err)
+}

--- a/pkg/controllers/managementuser/rbac/projectresources_handler.go
+++ b/pkg/controllers/managementuser/rbac/projectresources_handler.go
@@ -1,0 +1,213 @@
+package rbac
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/rancher/rancher/pkg/api/steve/projectresources"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	projectResourcesSuffix = "-projectresources"
+	enqueueAfterPeriod     = 10 * time.Second
+)
+
+// errNotReady is used when the APIResourceWatcher has not performed a successful discovery yet.
+var errNotReady = errors.New("APIs have not been synced yet")
+
+// getProjectResourcesRules accepts a slice of rules and returns a matching set of applicable rules for the resources.project.cattle.io API.
+// The returned list will only include rules that are 1) not for resource names, 2) not for non-resource URLs, 3) use the "list" or "*" verbs, and are namespaced.
+// It returns early if none of the rules match the first 3 conditions, which means the role binding can be skipped.
+// It uses the APIResourceWatcher to check if a resource is namespaced, because only namespaced resources are stored in the watcher.
+// If the APIResourceWatcher has no contents yet, it is probably just starting up so we return an error to indicate that the function should be retried.
+func (m *manager) getProjectResourcesRules(rules []rbacv1.PolicyRule) ([]rbacv1.PolicyRule, error) {
+	validRules := []rbacv1.PolicyRule{}
+	// check that at least one of the rules probably needs to be mirrored before consulting the APIResourceWatcher,
+	// most likely we can return early success and the calling controller can move on from the object.
+	for _, rule := range rules {
+		if len(rule.ResourceNames) != 0 {
+			continue
+		}
+		if len(rule.NonResourceURLs) != 0 {
+			continue
+		}
+		for _, verb := range rule.Verbs {
+			if verb == "*" || verb == "list" {
+				validRules = append(validRules, rule)
+				break
+			}
+		}
+	}
+	if len(validRules) == 0 {
+		return []rbacv1.PolicyRule{}, nil
+	}
+	apis := m.apis.List()
+	if len(apis) == 0 {
+		return []rbacv1.PolicyRule{}, errNotReady
+	}
+	projectRules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{projectresources.Group},
+			Verbs:     []string{"list"},
+		},
+	}
+
+	for _, rule := range validRules {
+		for _, apiGroup := range rule.APIGroups {
+			for _, resource := range rule.Resources {
+				_, ok := m.apis.Get(resource, apiGroup)
+				if ok {
+					if apiGroup != "" {
+						resource = apiGroup + "." + resource
+					}
+					projectRules[0].Resources = append(projectRules[0].Resources, resource)
+					continue
+				}
+				if resource == "*" {
+					if apiGroup == "*" {
+						projectRules = []rbacv1.PolicyRule{
+							{
+								APIGroups: []string{projectresources.Group},
+								Verbs:     []string{"list"},
+								Resources: []string{"*"},
+							},
+						}
+						return projectRules, nil
+					}
+					for _, api := range apis {
+						if api.Group == apiGroup {
+							projectRules[0].Resources = append(projectRules[0].Resources, api.Name)
+						}
+					}
+					sort.Strings(projectRules[0].Resources)
+					continue
+				}
+				if apiGroup == "*" {
+					for _, api := range apis {
+						if api.Group+"."+resource == api.Name {
+							projectRules[0].Resources = append(projectRules[0].Resources, api.Name)
+						}
+					}
+					sort.Strings(projectRules[0].Resources)
+				}
+			}
+		}
+	}
+	if len(projectRules[0].Resources) == 0 {
+		return []rbacv1.PolicyRule{}, nil
+	}
+	return projectRules, nil
+}
+
+// ensureProjectResourcesRoles mirrors clusterroles for the resources.project.cattle.io API or cleans up clusterroles if they are not needed.
+// It expects the cluserrole on which it is based to exist already, so ensureClusterRoles must be called first.
+func (m *manager) ensureProjectResourcesRoles(rt *v3.RoleTemplate) error {
+	clusterRole, err := m.crLister.Get("", rt.Name)
+	if err != nil {
+		return fmt.Errorf("couldn't get parent clusterrole %s for project resource role: %w", rt.Name, err)
+	}
+	projectResourcesRoleName := rt.Name + projectResourcesSuffix
+	projectResourcesClusterRole, err := m.crLister.Get("", projectResourcesRoleName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("couldn't ensure project role: %w", err)
+	}
+
+	rules := clusterRole.Rules
+	projectResourcesRT := rt.DeepCopy()
+	projectResourcesRT.Rules, err = m.getProjectResourcesRules(rules)
+	if err != nil {
+		return fmt.Errorf("couldn't ensure project role: %w", err)
+	}
+	if projectResourcesClusterRole == nil && len(projectResourcesRT.Rules) == 0 {
+		return nil
+	}
+
+	if projectResourcesClusterRole != nil {
+		if len(projectResourcesRT.Rules) == 0 {
+			err := m.clusterRoles.Delete(projectResourcesRoleName, &metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				return fmt.Errorf("couldn't clean up project role: %w", err)
+			}
+			return nil
+		}
+		err := m.compareAndUpdateClusterRole(projectResourcesClusterRole, projectResourcesRT)
+		if err == nil {
+			return nil
+		}
+		if apierrors.IsConflict(err) {
+			// get object from etcd and retry
+			projectResourcesClusterRole, err := m.clusterRoles.Get(projectResourcesRoleName, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("error getting clusterRole %s: %w", projectResourcesRoleName, err)
+			}
+			return m.compareAndUpdateClusterRole(projectResourcesClusterRole, projectResourcesRT)
+		}
+		return fmt.Errorf("couldn't update clusterRole %s: %w", projectResourcesRoleName, err)
+	}
+
+	err = m.createClusterRole(projectResourcesRoleName, projectResourcesRT, map[string]string{projectresources.AuthzAnnotation: rt.Name})
+	if err != nil {
+		return fmt.Errorf("couldn't create clusterRole %s: %w", projectResourcesRoleName, err)
+	}
+	return nil
+}
+
+// ensureProjectResourcesRoleBindings creates rolebindings in a project namespace to the projectresources clusterroles which are mirrors of the given roles.
+func (m *manager) ensureProjectResourcesRoleBindings(ns string, roles map[string]*v3.RoleTemplate, binding *v3.ProjectRoleTemplateBinding) error {
+	projectRoles := make(map[string]*v3.RoleTemplate)
+	for name := range roles {
+		projectRoles[name+projectResourcesSuffix] = nil
+	}
+
+	annotations := map[string]string{
+		projectresources.AuthzAnnotation: pkgrbac.GetRTBLabel(binding.ObjectMeta),
+	}
+
+	// The rolebinding will have an rtb-owner-updated label with the PRTB's ID,
+	// so the PRTB handler will clean it up when the PRTB is removed.
+	return m.ensureProjectRoleBindings(ns, projectRoles, binding, annotations)
+}
+
+// ensureProjectResourcesClusterRoleBindings creates clusterrolebindings to the projectresources clusterroles which are mirrors of the given roles.
+func (m *manager) ensureProjectResourcesClusterRoleBindings(roles map[string]*v3.RoleTemplate, binding *v3.ClusterRoleTemplateBinding) error {
+	projectRoles := make(map[string]*v3.RoleTemplate)
+	owners := make(map[string]metav1.OwnerReference)
+	subject, err := pkgrbac.BuildSubjectFromRTB(binding)
+	if err != nil {
+		return fmt.Errorf("couldn't get subject from binding %s: %w", binding.Name, err)
+	}
+	for name := range roles {
+		projectRoles[name+projectResourcesSuffix] = nil
+		ownerName := pkgrbac.NameForClusterRoleBinding(rbacv1.RoleRef{Kind: "ClusterRole", Name: name}, subject)
+		owner, err := m.crbLister.Get("", ownerName)
+		if err != nil {
+			return fmt.Errorf("couldn't get clusterrolebinding %s: %w", ownerName, err)
+		}
+		ownerRef := metav1.OwnerReference{
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+			Kind:       "ClusterRoleBinding",
+			UID:        owner.UID,
+			Name:       owner.Name,
+		}
+		owners[name+projectResourcesSuffix] = ownerRef
+	}
+
+	annotations := map[string]string{
+		projectresources.AuthzAnnotation: pkgrbac.GetRTBLabel(binding.ObjectMeta),
+	}
+
+	binding = binding.DeepCopy()
+	// Rename the binding copy.
+	// This ensures the clusterrolebinding will have a distinct rtb-owner-updated label, so that manager.ensureBindings does not clean it up.
+	// The owner reference will ensure that it does get cleaned up when its parent is removed.
+	binding.Name = binding.Name + projectResourcesSuffix
+
+	return m.ensureClusterBindings(projectRoles, binding, annotations, owners)
+}

--- a/pkg/controllers/managementuser/rbac/projectresources_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/projectresources_handler_test.go
@@ -1,0 +1,1222 @@
+package rbac
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	rbacfakes "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1/fakes"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
+	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func Test_getProjectResourcesRules(t *testing.T) {
+	tests := []struct {
+		name      string
+		rules     []rbacv1.PolicyRule
+		apis      map[string]metav1.APIResource
+		want      []rbacv1.PolicyRule
+		wantError bool
+	}{
+		{
+			name:  "empty rules",
+			rules: []rbacv1.PolicyRule{},
+			apis: map[string]metav1.APIResource{
+				"pods": metav1.APIResource{},
+			},
+			want: []rbacv1.PolicyRule{},
+		},
+		{
+			name: "non-listable rules",
+			rules: []rbacv1.PolicyRule{
+				{
+					Verbs: []string{"create", "update", "delete", "get", "watch"},
+				},
+			},
+			apis: map[string]metav1.APIResource{
+				"pods": metav1.APIResource{},
+			},
+			want: []rbacv1.PolicyRule{},
+		},
+		{
+			name: "resources are not in project resources API", // non-namespaced resources don't need these rules
+			rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"get", "list", "watch"},
+					Resources: []string{"clusters"},
+					APIGroups: []string{"management.cattle.io"},
+				},
+			},
+			apis: map[string]metav1.APIResource{
+				"pods": metav1.APIResource{},
+			},
+			want: []rbacv1.PolicyRule{},
+		},
+		{
+			name: "resources are in project resources API",
+			rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"get", "list", "watch"},
+					Resources: []string{"pods"},
+					APIGroups: []string{""},
+				},
+				{
+					Verbs:     []string{"get", "list", "watch"},
+					Resources: []string{"deployments", "daemonsets"},
+					APIGroups: []string{"apps"},
+				},
+			},
+			apis: map[string]metav1.APIResource{
+				"pods":             metav1.APIResource{},
+				"apps.deployments": metav1.APIResource{},
+				"apps.daemonsets":  metav1.APIResource{},
+			},
+			want: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"list"},
+					Resources: []string{"pods", "apps.deployments", "apps.daemonsets"},
+					APIGroups: []string{"resources.project.cattle.io"},
+				},
+			},
+		},
+		{
+			name: "wildcard verb",
+			rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"*"},
+					Resources: []string{"pods"},
+					APIGroups: []string{""},
+				},
+			},
+			apis: map[string]metav1.APIResource{
+				"pods": metav1.APIResource{},
+			},
+			want: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"list"},
+					Resources: []string{"pods"},
+					APIGroups: []string{"resources.project.cattle.io"},
+				},
+			},
+		},
+		{
+			name: "wildcard resource",
+			rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"get", "list", "watch"},
+					Resources: []string{"*"},
+					APIGroups: []string{"apps"},
+				},
+			},
+			apis: map[string]metav1.APIResource{
+				"pods": metav1.APIResource{
+					Name:  "pods",
+					Group: "",
+				},
+				"apps.deployments": metav1.APIResource{
+					Name:  "apps.deployments",
+					Group: "apps",
+				},
+				"apps.daemonsets": metav1.APIResource{
+					Name:  "apps.daemonsets",
+					Group: "apps",
+				},
+			},
+			want: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"list"},
+					Resources: []string{"apps.daemonsets", "apps.deployments"},
+					APIGroups: []string{"resources.project.cattle.io"},
+				},
+			},
+		},
+		{
+			name: "wildcard resource for multiple apigroups",
+			rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"get", "list", "watch"},
+					Resources: []string{"*"},
+					APIGroups: []string{"apps", ""},
+				},
+			},
+			apis: map[string]metav1.APIResource{
+				"pods": metav1.APIResource{
+					Name:  "pods",
+					Group: "",
+				},
+				"apps.deployments": metav1.APIResource{
+					Name:  "apps.deployments",
+					Group: "apps",
+				},
+				"apps.daemonsets": metav1.APIResource{
+					Name:  "apps.daemonsets",
+					Group: "apps",
+				},
+			},
+			want: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"list"},
+					Resources: []string{"apps.daemonsets", "apps.deployments", "pods"},
+					APIGroups: []string{"resources.project.cattle.io"},
+				},
+			},
+		},
+		{
+			name: "wildcard resource and apigroup",
+			rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"get", "list", "watch"},
+					Resources: []string{"*"},
+					APIGroups: []string{"*"},
+				},
+			},
+			apis: map[string]metav1.APIResource{
+				"pods": metav1.APIResource{},
+			},
+			want: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"list"},
+					Resources: []string{"*"},
+					APIGroups: []string{"resources.project.cattle.io"},
+				},
+			},
+		},
+		{
+			name: "wildcard apigroup",
+			rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"get", "list", "watch"},
+					Resources: []string{"apps"},
+					APIGroups: []string{"*"},
+				},
+			},
+			apis: map[string]metav1.APIResource{
+				"catalog.cattle.io.apps": metav1.APIResource{
+					Name:  "catalog.cattle.io.apps",
+					Group: "catalog.cattle.io",
+				},
+				"project.cattle.io.apps": metav1.APIResource{
+					Name:  "project.cattle.io.apps",
+					Group: "project.cattle.io",
+				},
+			},
+			want: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"list"},
+					Resources: []string{"catalog.cattle.io.apps", "project.cattle.io.apps"},
+					APIGroups: []string{"resources.project.cattle.io"},
+				},
+			},
+		},
+		{
+			name: "wildcard apigroup for multiple resources",
+			rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"get", "list", "watch"},
+					Resources: []string{"apps", "deployments"},
+					APIGroups: []string{"*"},
+				},
+			},
+			apis: map[string]metav1.APIResource{
+				"catalog.cattle.io.apps": metav1.APIResource{
+					Name:  "catalog.cattle.io.apps",
+					Group: "catalog.cattle.io",
+				},
+				"project.cattle.io.apps": metav1.APIResource{
+					Name:  "project.cattle.io.apps",
+					Group: "project.cattle.io",
+				},
+				"apps.deployments": metav1.APIResource{
+					Name:  "apps.deployments",
+					Group: "apps",
+				},
+			},
+			want: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"list"},
+					Resources: []string{"apps.deployments", "catalog.cattle.io.apps", "project.cattle.io.apps"},
+					APIGroups: []string{"resources.project.cattle.io"},
+				},
+			},
+		},
+		{
+			name: "named resources",
+			rules: []rbacv1.PolicyRule{
+				{
+					Verbs:         []string{"get", "list", "watch"},
+					Resources:     []string{"pods"},
+					APIGroups:     []string{""},
+					ResourceNames: []string{"nginx", "mysql"},
+				},
+			},
+			apis: map[string]metav1.APIResource{
+				"pods": metav1.APIResource{},
+			},
+			want: []rbacv1.PolicyRule{},
+		},
+		{
+			name: "non resource URLs",
+			rules: []rbacv1.PolicyRule{
+				{
+					Verbs:           []string{"get", "list", "watch"},
+					NonResourceURLs: []string{"/service"},
+				},
+			},
+			apis: map[string]metav1.APIResource{
+				"pods": metav1.APIResource{},
+			},
+			want: []rbacv1.PolicyRule{},
+		},
+		{
+			name: "informer not ready",
+			rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{"get", "list", "watch"},
+					Resources: []string{"pods"},
+					APIGroups: []string{""},
+				},
+			},
+			apis:      nil,
+			wantError: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			apis := &fakeAPIs{
+				resourceMap: test.apis,
+			}
+			m := &manager{apis: apis}
+			got, err := m.getProjectResourcesRules(test.rules)
+			if test.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, test.want, got)
+			}
+		})
+	}
+}
+
+func Test_ensureProjectResourcesRoles(t *testing.T) {
+	var mockClusterRoles map[string]*rbacv1.ClusterRole
+	tests := []struct {
+		name            string
+		rt              *v3.RoleTemplate
+		getFunc         func(ns, name string) (*rbacv1.ClusterRole, error)
+		setup           func()
+		wantCreateCalls int
+		wantUpdateCalls int
+		wantDeleteCalls int
+		wantClusterRole *rbacv1.ClusterRole
+		wantError       bool
+	}{
+		{
+			name: "create new",
+			rt: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			getFunc: func(ns, name string) (*rbacv1.ClusterRole, error) {
+				if !strings.HasSuffix(name, "-projectresources") {
+					return &rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								Verbs:     []string{"list"},
+								Resources: []string{"pods"},
+								APIGroups: []string{""},
+							},
+						},
+					}, nil
+				}
+				return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
+			},
+			wantCreateCalls: 1,
+			wantUpdateCalls: 0,
+			wantDeleteCalls: 0,
+			wantClusterRole: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-projectresources",
+					Annotations: map[string]string{
+						"authz.cluster.cattle.io/clusterrole-owner": "test",
+						"resources.project.cattle.io/authz":         "test",
+					},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						Verbs:     []string{"list"},
+						Resources: []string{"pods"},
+						APIGroups: []string{"resources.project.cattle.io"},
+					},
+				},
+			},
+		},
+		{
+			name: "update existing",
+			rt: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			getFunc: func(ns, name string) (*rbacv1.ClusterRole, error) {
+				if !strings.HasSuffix(name, "-projectresources") {
+					return &rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								Verbs:     []string{"list"},
+								Resources: []string{"pods"},
+								APIGroups: []string{""},
+							},
+						},
+					}, nil
+				}
+				return &rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-projectresources",
+						Annotations: map[string]string{
+							"authz.cluster.cattle.io/clusterrole-owner": "test",
+							"resources.project.cattle.io/authz":         "test",
+						},
+					},
+				}, nil
+			},
+			wantCreateCalls: 0,
+			wantUpdateCalls: 1,
+			wantDeleteCalls: 0,
+			wantClusterRole: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-projectresources",
+					Annotations: map[string]string{
+						"authz.cluster.cattle.io/clusterrole-owner": "test",
+						"resources.project.cattle.io/authz":         "test",
+					},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						Verbs:     []string{"list"},
+						Resources: []string{"pods"},
+						APIGroups: []string{"resources.project.cattle.io"},
+					},
+				},
+			},
+		},
+		{
+			name: "no namespaced rules",
+			rt: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			getFunc: func(ns, name string) (*rbacv1.ClusterRole, error) {
+				if !strings.HasSuffix(name, "-projectresources") {
+					return &rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								Verbs:     []string{"list"},
+								Resources: []string{"namespaces"},
+								APIGroups: []string{""},
+							},
+						},
+					}, nil
+				}
+				return nil, nil
+			},
+			wantCreateCalls: 0,
+			wantUpdateCalls: 0,
+			wantDeleteCalls: 0,
+			wantClusterRole: nil,
+		},
+		{
+			name: "no namespaced rules update",
+			rt: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			getFunc: func(ns, name string) (*rbacv1.ClusterRole, error) {
+				if !strings.HasSuffix(name, "-projectresources") {
+					return &rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								Verbs:     []string{"list"},
+								Resources: []string{"namespaces"},
+								APIGroups: []string{""},
+							},
+						},
+					}, nil
+				}
+				return &rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-projectresources",
+						Annotations: map[string]string{
+							"authz.cluster.cattle.io/clusterrole-owner": "test",
+							"resources.project.cattle.io/authz":         "test",
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							Verbs:     []string{"list"},
+							Resources: []string{"pods"},
+							APIGroups: []string{"resources.project.cattle.io"},
+						},
+					},
+				}, nil
+			},
+			wantCreateCalls: 0,
+			wantUpdateCalls: 0,
+			wantDeleteCalls: 1,
+		},
+		{
+			name: "equal rules",
+			rt: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			getFunc: func(ns, name string) (*rbacv1.ClusterRole, error) {
+				if !strings.HasSuffix(name, "-projectresources") {
+					return &rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test",
+							Annotations: map[string]string{
+								"authz.cluster.cattle.io/clusterrole-owner": "test",
+								"resources.project.cattle.io/authz":         "test",
+							},
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								Verbs:     []string{"list"},
+								Resources: []string{"pods"},
+								APIGroups: []string{""},
+							},
+						},
+					}, nil
+				}
+				return &rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-projectresources",
+						Annotations: map[string]string{
+							"authz.cluster.cattle.io/clusterrole-owner": "test",
+							"resources.project.cattle.io/authz":         "test",
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							Verbs:     []string{"list"},
+							Resources: []string{"pods"},
+							APIGroups: []string{"resources.project.cattle.io"},
+						},
+					},
+				}, nil
+			},
+			wantCreateCalls: 0,
+			wantUpdateCalls: 0,
+			wantDeleteCalls: 0,
+		},
+		{
+			name: "parent does not exist",
+			rt: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			getFunc: func(ns, name string) (*rbacv1.ClusterRole, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
+			},
+			wantCreateCalls: 0,
+			wantUpdateCalls: 0,
+			wantDeleteCalls: 0,
+			wantError:       true,
+		},
+		{
+			name: "conflict on update",
+			rt: &v3.RoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			getFunc: func(ns, name string) (*rbacv1.ClusterRole, error) {
+				if !strings.HasSuffix(name, "-projectresources") {
+					return &rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								Verbs:     []string{"list"},
+								Resources: []string{"pods"},
+								APIGroups: []string{""},
+							},
+						},
+					}, nil
+				}
+				return &rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "test-projectresources",
+						ResourceVersion: "earlier",
+						Annotations: map[string]string{
+							"authz.cluster.cattle.io/clusterrole-owner": "test",
+							"resources.project.cattle.io/authz":         "test",
+						},
+					},
+				}, nil
+			},
+			setup: func() {
+				mockClusterRoles["test-projectresources"] = &rbacv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "test-projectresources",
+						ResourceVersion: "later",
+						Annotations: map[string]string{
+							"authz.cluster.cattle.io/clusterrole-owner": "test",
+							"resources.project.cattle.io/authz":         "test",
+						},
+					},
+				}
+			},
+			wantCreateCalls: 0,
+			wantUpdateCalls: 2,
+			wantDeleteCalls: 0,
+			wantClusterRole: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-projectresources",
+					ResourceVersion: "later",
+					Annotations: map[string]string{
+						"authz.cluster.cattle.io/clusterrole-owner": "test",
+						"resources.project.cattle.io/authz":         "test",
+					},
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						Verbs:     []string{"list"},
+						Resources: []string{"pods"},
+						APIGroups: []string{"resources.project.cattle.io"},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockClusterRoles = make(map[string]*rbacv1.ClusterRole)
+			manager := &manager{
+				crLister: &rbacfakes.ClusterRoleListerMock{
+					GetFunc: test.getFunc,
+				},
+				clusterRoles: &rbacfakes.ClusterRoleInterfaceMock{
+					CreateFunc: func(in1 *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+						mockClusterRoles[in1.Name] = in1
+						return in1, nil
+					},
+					GetFunc: func(name string, _ metav1.GetOptions) (*rbacv1.ClusterRole, error) {
+						return mockClusterRoles[name], nil
+					},
+					UpdateFunc: func(in1 *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+						if cr, ok := mockClusterRoles[in1.Name]; ok && cr.ObjectMeta.ResourceVersion > in1.ObjectMeta.ResourceVersion {
+							return nil, apierrors.NewConflict(schema.GroupResource{}, in1.Name, nil)
+						}
+						mockClusterRoles[in1.Name] = in1
+						return in1, nil
+					},
+					DeleteFunc: func(_ string, _ *metav1.DeleteOptions) error {
+						return nil
+					},
+				},
+				apis: &fakeAPIs{
+					resourceMap: map[string]metav1.APIResource{
+						"pods":             metav1.APIResource{},
+						"apps.deployments": metav1.APIResource{},
+					},
+				},
+			}
+			if test.setup != nil {
+				test.setup()
+			}
+			err := manager.ensureProjectResourcesRoles(test.rt)
+			if test.wantError {
+				assert.Error(t, err)
+				return
+			}
+			assert.Nil(t, err)
+			actualCreateCalls := len(manager.clusterRoles.(*rbacfakes.ClusterRoleInterfaceMock).CreateCalls())
+			assert.Equal(t, test.wantCreateCalls, actualCreateCalls, fmt.Sprintf("expected %d create calls, got %d", test.wantCreateCalls, actualCreateCalls))
+			actualUpdateCalls := len(manager.clusterRoles.(*rbacfakes.ClusterRoleInterfaceMock).UpdateCalls())
+			assert.Equal(t, test.wantUpdateCalls, actualUpdateCalls, fmt.Sprintf("expected %d update calls, got %d", test.wantUpdateCalls, actualUpdateCalls))
+			actualDeleteCalls := len(manager.clusterRoles.(*rbacfakes.ClusterRoleInterfaceMock).DeleteCalls())
+			assert.Equal(t, test.wantDeleteCalls, actualDeleteCalls, fmt.Sprintf("expected %d delete calls, got %d", test.wantDeleteCalls, actualDeleteCalls))
+			assert.Equal(t, test.wantClusterRole, mockClusterRoles["test-projectresources"])
+		})
+	}
+}
+
+func Test_ensureProjectResourcesClusterRoleBindings(t *testing.T) {
+	var clusterRoleBindings []*rbacv1.ClusterRoleBinding
+	tests := []struct {
+		name            string
+		roles           map[string]*v3.RoleTemplate
+		binding         *v3.ClusterRoleTemplateBinding
+		cache           []*rbacv1.ClusterRoleBinding
+		want            *rbacv1.ClusterRoleBinding
+		wantCreateCalls int
+		wantDeleteCalls int
+	}{
+		{
+			name: "create new",
+			roles: map[string]*v3.RoleTemplate{
+				"test": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+			},
+			binding: &v3.ClusterRoleTemplateBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-binding",
+					Namespace: "cluster1",
+				},
+				UserName:         "user1",
+				ClusterName:      "cluster1",
+				RoleTemplateName: "test",
+			},
+			want: &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: pkgrbac.NameForClusterRoleBinding(rbacv1.RoleRef{Kind: "ClusterRole", Name: "test-projectresources"}, rbacv1.Subject{Kind: "User", Name: "user1"}),
+					Annotations: map[string]string{
+						"resources.project.cattle.io/authz": "cluster1_test-binding",
+					},
+					Labels: map[string]string{
+						"authz.cluster.cattle.io/rtb-owner-updated": "cluster1_test-binding-projectresources",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "rbac.authorization.k8s.io/v1",
+							Kind:       "ClusterRoleBinding",
+							Name:       "test-binding",
+							UID:        "",
+						},
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					Kind: "ClusterRole",
+					Name: "test-projectresources",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "user1",
+					},
+				},
+			},
+			wantCreateCalls: 1,
+		},
+		{
+			name: "already exists",
+			roles: map[string]*v3.RoleTemplate{
+				"test": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+			},
+			binding: &v3.ClusterRoleTemplateBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-binding",
+					Namespace: "cluster1",
+				},
+				UserName:         "user1",
+				ClusterName:      "cluster1",
+				RoleTemplateName: "test",
+			},
+			cache: []*rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: pkgrbac.NameForClusterRoleBinding(rbacv1.RoleRef{Kind: "ClusterRole", Name: "test-projectresources"}, rbacv1.Subject{Kind: "User", Name: "user1"}),
+						Annotations: map[string]string{
+							"resources.project.cattle.io/authz": "cluster1_test-binding",
+						},
+						Labels: map[string]string{
+							"authz.cluster.cattle.io/rtb-owner-updated": "cluster1_test-binding-projectresources",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "rbac.authorization.k8s.io/v1",
+								Kind:       "ClusterRoleBinding",
+								Name:       "test-binding",
+								UID:        "",
+							},
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						Kind: "ClusterRole",
+						Name: "test-projectresources",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     "User",
+							Name:     "user1",
+						},
+					},
+				},
+			},
+			want: &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: pkgrbac.NameForClusterRoleBinding(rbacv1.RoleRef{Kind: "ClusterRole", Name: "test-projectresources"}, rbacv1.Subject{Kind: "User", Name: "user1"}),
+					Annotations: map[string]string{
+						"resources.project.cattle.io/authz": "cluster1_test-binding",
+					},
+					Labels: map[string]string{
+						"authz.cluster.cattle.io/rtb-owner-updated": "cluster1_test-binding-projectresources",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "rbac.authorization.k8s.io/v1",
+							Kind:       "ClusterRoleBinding",
+							Name:       "test-binding",
+							UID:        "",
+						},
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					Kind: "ClusterRole",
+					Name: "test-projectresources",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "user1",
+					},
+				},
+			},
+		},
+		{
+			name: "delete non matching",
+			roles: map[string]*v3.RoleTemplate{
+				"test": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+			},
+			binding: &v3.ClusterRoleTemplateBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-binding",
+					Namespace: "cluster1",
+				},
+				UserName:         "user1",
+				ClusterName:      "cluster1",
+				RoleTemplateName: "test",
+			},
+			cache: []*rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: pkgrbac.NameForClusterRoleBinding(rbacv1.RoleRef{Kind: "ClusterRole", Name: "test-projectresources"}, rbacv1.Subject{Kind: "User", Name: "user1"}),
+						Annotations: map[string]string{
+							"resources.project.cattle.io/authz": "cluster1_test-binding",
+						},
+						Labels: map[string]string{
+							"authz.cluster.cattle.io/rtb-owner-updated": "cluster1_test-binding-projectresources",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "rbac.authorization.k8s.io/v1",
+								Kind:       "ClusterRoleBinding",
+								Name:       "test-binding",
+								UID:        "",
+							},
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						Kind: "ClusterRole",
+						Name: "test-projectresources",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     "User",
+							Name:     "user2",
+						},
+					},
+				},
+			},
+			want: &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: pkgrbac.NameForClusterRoleBinding(rbacv1.RoleRef{Kind: "ClusterRole", Name: "test-projectresources"}, rbacv1.Subject{Kind: "User", Name: "user1"}),
+					Annotations: map[string]string{
+						"resources.project.cattle.io/authz": "cluster1_test-binding",
+					},
+					Labels: map[string]string{
+						"authz.cluster.cattle.io/rtb-owner-updated": "cluster1_test-binding-projectresources",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "rbac.authorization.k8s.io/v1",
+							Kind:       "ClusterRoleBinding",
+							Name:       "test-binding",
+							UID:        "",
+						},
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					Kind: "ClusterRole",
+					Name: "test-projectresources",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "user1",
+					},
+				},
+			},
+			wantCreateCalls: 1,
+			wantDeleteCalls: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := &manager{
+				crbLister: &rbacfakes.ClusterRoleBindingListerMock{
+					GetFunc: func(_, _ string) (*rbacv1.ClusterRoleBinding, error) {
+						return &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "test-binding"}}, nil
+					},
+					ListFunc: func(_ string, _ labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+						return test.cache, nil
+					},
+				},
+				clusterRoleBindings: &rbacfakes.ClusterRoleBindingInterfaceMock{
+					CreateFunc: func(in1 *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+						clusterRoleBindings = append(clusterRoleBindings, in1)
+						return in1, nil
+					},
+					UpdateFunc: func(in1 *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+						clusterRoleBindings = append(clusterRoleBindings, in1)
+						return in1, nil
+					},
+					DeleteFunc: func(name string, _ *metav1.DeleteOptions) error {
+						for i, rb := range clusterRoleBindings {
+							if rb.Name == name {
+								clusterRoleBindings = append(clusterRoleBindings[:i], clusterRoleBindings[i+1:]...)
+							}
+							return nil
+						}
+						return apierrors.NewNotFound(schema.GroupResource{}, name)
+					},
+				},
+			}
+			if test.cache == nil {
+				clusterRoleBindings = make([]*rbacv1.ClusterRoleBinding, 0)
+			} else {
+				clusterRoleBindings = test.cache
+			}
+			err := manager.ensureProjectResourcesClusterRoleBindings(test.roles, test.binding)
+			assert.Nil(t, err)
+			assert.Equal(t, test.want, clusterRoleBindings[len(clusterRoleBindings)-1])
+			assert.Equal(t, test.wantCreateCalls, len(manager.clusterRoleBindings.(*rbacfakes.ClusterRoleBindingInterfaceMock).CreateCalls()))
+			assert.Equal(t, test.wantDeleteCalls, len(manager.clusterRoleBindings.(*rbacfakes.ClusterRoleBindingInterfaceMock).DeleteCalls()))
+		})
+	}
+}
+
+func Test_ensureProjectResourcesRoleBindings(t *testing.T) {
+	var roleBindings map[string][]*rbacv1.RoleBinding
+	tests := []struct {
+		name            string
+		roles           map[string]*v3.RoleTemplate
+		binding         *v3.ProjectRoleTemplateBinding
+		cache           map[string][]*rbacv1.RoleBinding
+		want            *rbacv1.RoleBinding
+		wantCreateCalls int
+		wantDeleteCalls int
+	}{
+		{
+			name: "create new",
+			roles: map[string]*v3.RoleTemplate{
+				"test": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+			},
+			binding: &v3.ProjectRoleTemplateBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-binding",
+					Namespace: "project1",
+				},
+				UserName:         "user1",
+				ProjectName:      "cluster1:project1",
+				RoleTemplateName: "test",
+			},
+			want: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pkgrbac.NameForRoleBinding("project1", rbacv1.RoleRef{Kind: "ClusterRole", Name: "test-projectresources"}, rbacv1.Subject{Kind: "User", Name: "user1"}),
+					Namespace: "project1",
+					Annotations: map[string]string{
+						"resources.project.cattle.io/authz": "project1_test-binding",
+					},
+					Labels: map[string]string{
+						"authz.cluster.cattle.io/rtb-owner-updated": "project1_test-binding",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					Kind: "ClusterRole",
+					Name: "test-projectresources",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "user1",
+					},
+				},
+			},
+			wantCreateCalls: 1,
+		},
+		{
+			name: "already exists",
+			roles: map[string]*v3.RoleTemplate{
+				"test": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+			},
+			binding: &v3.ProjectRoleTemplateBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-binding",
+					Namespace: "project1",
+				},
+				UserName:         "user1",
+				ProjectName:      "cluster1:project1",
+				RoleTemplateName: "test",
+			},
+			cache: map[string][]*rbacv1.RoleBinding{
+				"project1": {
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      pkgrbac.NameForRoleBinding("project1", rbacv1.RoleRef{Kind: "ClusterRole", Name: "test-projectresources"}, rbacv1.Subject{Kind: "User", Name: "user1"}),
+							Namespace: "project1",
+							Annotations: map[string]string{
+								"resources.project.cattle.io/authz": "project1_test-binding",
+							},
+							Labels: map[string]string{
+								"authz.cluster.cattle.io/rtb-owner-updated": "project1_test-binding",
+							},
+						},
+						RoleRef: rbacv1.RoleRef{
+							Kind: "ClusterRole",
+							Name: "test-projectresources",
+						},
+						Subjects: []rbacv1.Subject{
+							{
+								APIGroup: "rbac.authorization.k8s.io",
+								Kind:     "User",
+								Name:     "user1",
+							},
+						},
+					},
+				},
+			},
+			want: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pkgrbac.NameForRoleBinding("project1", rbacv1.RoleRef{Kind: "ClusterRole", Name: "test-projectresources"}, rbacv1.Subject{Kind: "User", Name: "user1"}),
+					Namespace: "project1",
+					Annotations: map[string]string{
+						"resources.project.cattle.io/authz": "project1_test-binding",
+					},
+					Labels: map[string]string{
+						"authz.cluster.cattle.io/rtb-owner-updated": "project1_test-binding",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					Kind: "ClusterRole",
+					Name: "test-projectresources",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "user1",
+					},
+				},
+			},
+		},
+		{
+			name: "delete non matching",
+			roles: map[string]*v3.RoleTemplate{
+				"test": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+			},
+			binding: &v3.ProjectRoleTemplateBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-binding",
+					Namespace: "project1",
+				},
+				UserName:         "user1",
+				ProjectName:      "cluster1:project1",
+				RoleTemplateName: "test",
+			},
+			cache: map[string][]*rbacv1.RoleBinding{
+				"project1": {
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      pkgrbac.NameForRoleBinding("project1", rbacv1.RoleRef{Kind: "ClusterRole", Name: "test-projectresources"}, rbacv1.Subject{Kind: "User", Name: "user2"}),
+							Namespace: "project1",
+							Annotations: map[string]string{
+								"resources.project.cattle.io/authz": "project1_test-binding",
+							},
+							Labels: map[string]string{
+								"authz.cluster.cattle.io/rtb-owner-updated": "project1_test-binding",
+							},
+						},
+						RoleRef: rbacv1.RoleRef{
+							Kind: "ClusterRole",
+							Name: "test-projectresources",
+						},
+						Subjects: []rbacv1.Subject{
+							{
+								APIGroup: "rbac.authorization.k8s.io",
+								Kind:     "User",
+								Name:     "user2",
+							},
+						},
+					},
+				},
+			},
+			want: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pkgrbac.NameForRoleBinding("project1", rbacv1.RoleRef{Kind: "ClusterRole", Name: "test-projectresources"}, rbacv1.Subject{Kind: "User", Name: "user1"}),
+					Namespace: "project1",
+					Annotations: map[string]string{
+						"resources.project.cattle.io/authz": "project1_test-binding",
+					},
+					Labels: map[string]string{
+						"authz.cluster.cattle.io/rtb-owner-updated": "project1_test-binding",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					Kind: "ClusterRole",
+					Name: "test-projectresources",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "User",
+						Name:     "user1",
+					},
+				},
+			},
+			wantCreateCalls: 1,
+			wantDeleteCalls: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := &manager{
+				rbLister: &rbacfakes.RoleBindingListerMock{
+					GetFunc: func(namespace, name string) (*rbacv1.RoleBinding, error) {
+						rbs, ok := roleBindings[namespace]
+						if !ok {
+							return nil, apierrors.NewNotFound(schema.GroupResource{}, namespace)
+						}
+						for _, rb := range rbs {
+							if rb.Name == name {
+								return rb, nil
+							}
+						}
+						return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
+					},
+					ListFunc: func(namespace string, _ labels.Selector) ([]*rbacv1.RoleBinding, error) {
+						rbs, ok := roleBindings[namespace]
+						if !ok {
+							return nil, apierrors.NewNotFound(schema.GroupResource{}, namespace)
+						}
+						return rbs, nil
+					},
+				},
+				roleBindings: &rbacfakes.RoleBindingInterfaceMock{
+					CreateFunc: func(in1 *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+						if roleBindings[in1.Namespace] == nil {
+							roleBindings[in1.Namespace] = make([]*rbacv1.RoleBinding, 0)
+						}
+						roleBindings[in1.Namespace] = append(roleBindings[in1.Namespace], in1)
+						return in1, nil
+					},
+					DeleteNamespacedFunc: func(namespace, name string, _ *metav1.DeleteOptions) error {
+						rbs, ok := roleBindings[namespace]
+						if !ok {
+							return apierrors.NewNotFound(schema.GroupResource{}, namespace)
+						}
+						for i, rb := range rbs {
+							if rb.Name == name {
+								roleBindings[namespace] = append(roleBindings[namespace][:i], roleBindings[namespace][i+1:]...)
+							}
+							return nil
+						}
+						return apierrors.NewNotFound(schema.GroupResource{}, name)
+					},
+				},
+			}
+			ns := "project1"
+			if test.cache == nil {
+				roleBindings = map[string][]*rbacv1.RoleBinding{
+					"project1": nil,
+				}
+			} else {
+				roleBindings = test.cache
+			}
+			err := manager.ensureProjectResourcesRoleBindings(ns, test.roles, test.binding)
+			assert.Nil(t, err)
+			assert.Equal(t, test.want, roleBindings[ns][len(roleBindings[ns])-1])
+			assert.Equal(t, test.wantCreateCalls, len(manager.roleBindings.(*rbacfakes.RoleBindingInterfaceMock).CreateCalls()))
+			assert.Equal(t, test.wantDeleteCalls, len(manager.roleBindings.(*rbacfakes.RoleBindingInterfaceMock).DeleteNamespacedCalls()))
+		})
+	}
+}
+
+type fakeAPIs struct {
+	resourceMap map[string]metav1.APIResource
+}
+
+func (f *fakeAPIs) List() []metav1.APIResource {
+	result := make([]metav1.APIResource, 0)
+	for _, v := range f.resourceMap {
+		result = append(result, v)
+	}
+	return result
+}
+
+func (f *fakeAPIs) Get(resource, group string) (metav1.APIResource, bool) {
+	if group == "" {
+		api, ok := f.resourceMap[resource]
+		return api, ok
+	}
+	api, ok := f.resourceMap[group+"."+resource]
+	return api, ok
+}
+
+func (f *fakeAPIs) GetKindForResource(_ schema.GroupVersionResource) (string, error) {
+	panic("not implemented")
+}

--- a/pkg/controllers/managementuser/rbac/prtb_handler_test.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler_test.go
@@ -7,7 +7,6 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/stretchr/testify/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
-	v1 "k8s.io/api/rbac/v1"
 )
 
 func Test_manager_checkForGlobalResourceRules(t *testing.T) {
@@ -23,7 +22,7 @@ func Test_manager_checkForGlobalResourceRules(t *testing.T) {
 		{
 			name: "valid_api_group_persistentvolumes",
 			role: &v3.RoleTemplate{
-				Rules: []v1.PolicyRule{
+				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:     []string{"put"},
 						APIGroups: []string{""},
@@ -38,7 +37,7 @@ func Test_manager_checkForGlobalResourceRules(t *testing.T) {
 		{
 			name: "invalid_api_group_persistentvolumes",
 			role: &v3.RoleTemplate{
-				Rules: []v1.PolicyRule{
+				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:     []string{"put"},
 						APIGroups: []string{"foo"},
@@ -53,7 +52,7 @@ func Test_manager_checkForGlobalResourceRules(t *testing.T) {
 		{
 			name: "valid_api_group_storageclasses",
 			role: &v3.RoleTemplate{
-				Rules: []v1.PolicyRule{
+				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:     []string{"put"},
 						APIGroups: []string{"storage.k8s.io"},
@@ -68,7 +67,7 @@ func Test_manager_checkForGlobalResourceRules(t *testing.T) {
 		{
 			name: "invalid_api_group_storageclasses",
 			role: &v3.RoleTemplate{
-				Rules: []v1.PolicyRule{
+				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:     []string{"put"},
 						APIGroups: []string{"foo"},
@@ -83,7 +82,7 @@ func Test_manager_checkForGlobalResourceRules(t *testing.T) {
 		{
 			name: "valid_api_group_start",
 			role: &v3.RoleTemplate{
-				Rules: []v1.PolicyRule{
+				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:     []string{"put"},
 						APIGroups: []string{""},
@@ -98,7 +97,7 @@ func Test_manager_checkForGlobalResourceRules(t *testing.T) {
 		{
 			name: "invalid_api_group_star",
 			role: &v3.RoleTemplate{
-				Rules: []v1.PolicyRule{
+				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:     []string{"put"},
 						APIGroups: []string{"foo"},
@@ -113,7 +112,7 @@ func Test_manager_checkForGlobalResourceRules(t *testing.T) {
 		{
 			name: "cluster_rule_match",
 			role: &v3.RoleTemplate{
-				Rules: []v1.PolicyRule{
+				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:     []string{"get"},
 						APIGroups: []string{"management.cattle.io"},
@@ -128,7 +127,7 @@ func Test_manager_checkForGlobalResourceRules(t *testing.T) {
 		{
 			name: "cluster_rule_resource_names_match",
 			role: &v3.RoleTemplate{
-				Rules: []v1.PolicyRule{
+				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:         []string{"get"},
 						APIGroups:     []string{"management.cattle.io"},
@@ -146,7 +145,7 @@ func Test_manager_checkForGlobalResourceRules(t *testing.T) {
 		{
 			name: "cluster_rule_baserule_resource_names_no_match",
 			role: &v3.RoleTemplate{
-				Rules: []v1.PolicyRule{
+				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:     []string{"get"},
 						APIGroups: []string{"management.cattle.io"},
@@ -163,7 +162,7 @@ func Test_manager_checkForGlobalResourceRules(t *testing.T) {
 		{
 			name: "cluster_rule_roletemplate_resource_names_no_match",
 			role: &v3.RoleTemplate{
-				Rules: []v1.PolicyRule{
+				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:         []string{"get"},
 						APIGroups:     []string{"management.cattle.io"},

--- a/pkg/tls/base.go
+++ b/pkg/tls/base.go
@@ -63,6 +63,7 @@ func BaseTLSConfig() (*tls.Config, error) {
 		PreferServerCipherSuites: true,
 		MinVersion:               TLSMinVersion,
 		CipherSuites:             TLSCiphers,
+		ClientAuth:               tls.RequestClientCert, // makes the client cert available in the http.Request if an endpoint wants to verify it, ignored if not provided
 	}, nil
 }
 

--- a/pkg/types/config/context.go
+++ b/pkg/types/config/context.go
@@ -43,6 +43,10 @@ import (
 	"github.com/rancher/rancher/pkg/user"
 	"github.com/rancher/rancher/pkg/wrangler"
 	steve "github.com/rancher/steve/pkg/server"
+	apiextcontroller "github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io"
+	apiextcontrollerv1 "github.com/rancher/wrangler/pkg/generated/controllers/apiextensions.k8s.io/v1"
+	apiregcontroller "github.com/rancher/wrangler/pkg/generated/controllers/apiregistration.k8s.io"
+	apiregcontrollerv1 "github.com/rancher/wrangler/pkg/generated/controllers/apiregistration.k8s.io/v1"
 	"github.com/rancher/wrangler/pkg/generated/controllers/rbac"
 	wrbacv1 "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
 	"github.com/rancher/wrangler/pkg/generic"
@@ -223,6 +227,8 @@ type UserContext struct {
 	Policy         policyv1beta1.Interface
 
 	RBACw          wrbacv1.Interface
+	CRDw           apiextcontrollerv1.Interface
+	APIServicew    apiregcontrollerv1.Interface
 	KindNamespaces map[schema.GroupVersionKind]string
 }
 
@@ -444,6 +450,18 @@ func NewUserContext(scaledContext *ScaledContext, config rest.Config, clusterNam
 		return nil, err
 	}
 	context.RBACw = rbacw.Rbac().V1()
+
+	crdw, err := apiextcontroller.NewFactoryFromConfigWithOptions(&wranglerConf, opts)
+	if err != nil {
+		return nil, err
+	}
+	context.CRDw = crdw.Apiextensions().V1()
+
+	apiservicew, err := apiregcontroller.NewFactoryFromConfigWithOptions(&wranglerConf, opts)
+	if err != nil {
+		return nil, err
+	}
+	context.APIServicew = apiservicew.Apiregistration().V1()
 
 	ctlg, err := catalog.NewFactoryFromConfigWithOptions(&context.RESTConfig, &catalog.FactoryOptions{SharedControllerFactory: controllerFactory})
 	if err != nil {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/40140
 
Add support for a kubernetes API extension to enable listing resources
by one or more projects or namespaces.

From a Kubernetes perspective, the API is accessible at endpoints like

/apis/resources.project.cattle.io/v1alpha1/{resource}
/apis/resources.project.cattle.io/v1alpha1/namespaces/{projectID}/{resource}
/apis/resources.project.cattle.io/v1alpha1/namespaces/cattle-unscoped/{resource}

From a Steve perspective, the API is accessible at

/v1/resources.project.cattle.io.{group and resource}

For example,

/v1/resources.project.cattle.io.pods

or

/v1/resources.project.cattle.io.apps.deployments

To filter the results by a set of projects or namespaces, use the
`fieldSelector` query with the `prjorns` key, for example:

/v1/resources.project.cattle.io.pods?fieldSelector=projectsornamespaces={projec1},{project2},{namespace3}

To exclude projects or namespaces from the result, use the ! operator,
for example:

/v1/resources.project.cattle.io.pods?fieldSelector=projectsornamespaces!={project1},{project2},{namespace3}

This change adds the following:

1. Sets up a refresher to keep track of changing API resources (from
   added/removed CRDs and APIServices), so that namespaced API resources
   can be registered at this endpoint.

2. Applies the APIService pointing to the rancher or
   cattle-cluster-agent Service.

3. Sets up a handler for a discovery endpoint that responds with all the
   namespaced resources found in (1).

4. Sets up handlers for the global, project-scoped, and unscoped
   endpoints.

   In general, only admins have access to the global resource endpoint
   for any resource. Steve abstracts this by retrieving and collating
   resources from sets of namespaces that a standard user has access to.
   This means that Steve must be able to make requests to endpoints that
   have /namespaces/{namespace} in them, and a real namespace must exist
   representing the project, along with a role binding in that namespace
   so that the kube API server will allow the user to access that
   endpoint. We also need a special non-project namespace for Steve to
   go to to look for resources in namespaces that don't belong to any
   project.

5. Adds functionality to the rbac managementuser handlers to
   automatically create and remove the namespace and rolebinding for the
   project.