### PR TITLE
Retain Fleet Name Label for Local Cluster

### DIFF
--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
@@ -109,6 +109,8 @@ func (h *handler) createCluster(cluster *v1.Cluster, status v1.ClusterStatus) ([
 		return nil, status, generic.ErrSkip
 	}
 
+	// this overwrites the default labels from fleet and any labels a user
+	// set on the fleet cluster resource directly
 	labels := yaml.CleanAnnotationsForExport(mgmtCluster.Labels)
 	labels["management.cattle.io/cluster-name"] = mgmtCluster.Name
 	if errs := validation.IsValidLabelValue(mgmtCluster.Spec.DisplayName); len(errs) == 0 {
@@ -120,6 +122,8 @@ func (h *handler) createCluster(cluster *v1.Cluster, status v1.ClusterStatus) ([
 	if mgmtCluster.Spec.Internal {
 		agentNamespace = fleetconst.ReleaseLocalNamespace
 		clientSecret = "local-cluster"
+		// restore fleet's hardcoded name label for the local cluster
+		labels["name"] = "local"
 	}
 
 	var privateRepoURL string


### PR DESCRIPTION

## Issue: 

fixes https://github.com/rancher/fleet/issues/1079
fixes https://github.com/rancher/fleet/issues/759
 
## Problem

Fleet uses a hardcoded label "name=local" for the local cluster and local cluster group.
Provisioning overwrites labels with their own, breaking  the local cluster and reportedly leading into a situation where the "name=local" label is flip flopping. This would result in bundles targeting the local cluster being removed and then redeployed infrequently or daily.

## Solution

Make sure the "name: local" label is not lost.
 
## Testing

The local cluster group works now and can be used to select the local cluster.
The "name: local" is always visible on the fleet cluster resource.

The labels remain, even when:

* changing an agent related value in fleet-controller configmap (like `AgentCheckinInterval`)
* restarting the fleet-controller (e.g. by deleting the pod)


## Engineering Testing
### Manual Testing

### Automated Testing

## QA Testing Considerations

User defined labels won't persist if they are written to the fleet cluster resource. They should work if they're on the provisioning cluster resource.
 
### Regressions Considerations
