### PR TITLE
Modified existing tests to reflect changes to NodeCreationFunc

### DIFF
--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -114,7 +114,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningK3SCustomCluster(extern
 				require.NoError(c.T(), err)
 
 				numNodes := len(tt.nodeRoles)
-				nodes, err := externalNodeProvider.NodeCreationFunc(client, numNodes)
+				nodes, _, err := externalNodeProvider.NodeCreationFunc(client, numNodes, 0, false)
 				require.NoError(c.T(), err)
 
 				clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
@@ -221,7 +221,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningK3SCustomClusterDynamic
 				client, err := tt.client.WithSession(testSession)
 				require.NoError(c.T(), err)
 
-				nodes, err := externalNodeProvider.NodeCreationFunc(client, numOfNodes)
+				nodes, _, err := externalNodeProvider.NodeCreationFunc(client, numOfNode, 0, false)
 				require.NoError(c.T(), err)
 
 				clusterName := namegen.AppendRandomString(externalNodeProvider.Name)

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -109,7 +109,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE1CustomCluster(exter
 					require.NoError(c.T(), err)
 
 					numNodes := len(tt.nodeRoles)
-					nodes, err := externalNodeProvider.NodeCreationFunc(client, numNodes)
+					nodes, _, err := externalNodeProvider.NodeCreationFunc(client, numNodes, 0, false)
 					require.NoError(c.T(), err)
 
 					clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
@@ -199,7 +199,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE1CustomClusterDynami
 					client, err := tt.client.WithSession(testSession)
 					require.NoError(c.T(), err)
 
-					nodes, err := externalNodeProvider.NodeCreationFunc(client, numOfNodes)
+					nodes, _, err := externalNodeProvider.NodeCreationFunc(client, numOfNodes, 0, false)
 					require.NoError(c.T(), err)
 
 					clusterName := namegen.AppendRandomString(externalNodeProvider.Name)


### PR DESCRIPTION
## Problem
Due to a change that was made to the NodeCreationFunc to accommodate Windows Custom Cluster tests, the RKE1 and K3s custom cluster tests are failing
 
## Solution
Updated the RKE1 and K3s custom cluster tests to accommodate the changes made to the NodeCreationFunc