### PR TITLE
Add startup probe

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -154,6 +154,14 @@ spec:
             port: 80
           initialDelaySeconds: {{.Values.readinessProbe.initialDelaySeconds | default  5}}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 30}}
+{{- if .Values.startupProbe }}
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 80
+          failureThreshold: {{.Values.startupProbe.failureThreshold | default 1}}
+          periodSeconds: {{ .Values.startupProbe.periodSeconds | default 30}}
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -342,3 +342,39 @@ tests:
     - equal:
         path: spec.template.spec.containers[0].readinessProbe.periodSeconds
         value: 60
+- it: should set startupProbe periodSeconds to 60
+  set:
+    startupProbe.periodSeconds: 60
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].startupProbe.periodSeconds
+        value: 60
+    - equal:
+        path: spec.template.spec.containers[0].startupProbe.failureThreshold
+        value: 1
+    - equal:
+        path: spec.template.spec.containers[0].startupProbe.httpGet.port
+        value: 80
+    - equal:
+        path: spec.template.spec.containers[0].startupProbe.httpGet.path
+        value: /healthz
+- it: should set startupProbe failureThreshold to 10
+  set:
+    startupProbe.failureThreshold: 10
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].startupProbe.periodSeconds
+        value: 30
+    - equal:
+        path: spec.template.spec.containers[0].startupProbe.failureThreshold
+        value: 10
+    - equal:
+        path: spec.template.spec.containers[0].startupProbe.httpGet.port
+        value: 80
+    - equal:
+        path: spec.template.spec.containers[0].startupProbe.httpGet.path
+        value: /healthz
+- it: should not have startupProbe if no startupProbe fields set
+  asserts:
+    - isNull:
+        path: spec.template.spec.containers[0].startupProbe


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/39841

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 Break out of https://github.com/rancher/rancher/issues/38177.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 This gives another way of further delaying readiness probes. This is sometimes necessary now because startup time for rancher has increased since v2.5.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 Install chart using --set settings to set `startupProbe.periodSeconds` and/or `startupProbe.failureThreshold`. Just configuring one should be enough. The rest of startupProbe should use sensible defaults. It should work when configuring both as well. Can check the rancher deployment to confirm everything is as expected.

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->