### PR TITLE
[v2.6] Refactor RKE2/K3s provisioning tests

### DIFF
--- a/tests/framework/extensions/hardening/k3s/harden_nodes.go
+++ b/tests/framework/extensions/hardening/k3s/harden_nodes.go
@@ -1,6 +1,8 @@
 package hardening
 
 import (
+	"strings"
+
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	"github.com/rancher/rancher/tests/framework/pkg/nodes"
 	"github.com/sirupsen/logrus"
@@ -34,7 +36,7 @@ func HardeningNodes(client *rancher.Client, hardened bool, nodes []*nodes.Node, 
 			return err
 		}
 
-		if nodeRoles[key] == "--etcd --controlplane --worker" || nodeRoles[key] == "--controlplane" || nodeRoles[key] == " --controlplane" {
+		if strings.Contains(nodeRoles[key], "--controlplane") {
 			logrus.Infof("Copying over files to node %s", node.NodeID)
 			dir := "/go/src/github.com/rancher/rancher/tests/framework/extensions/hardening/k3s"
 			err = node.SCPFileToNode(dir+"/audit.yaml", "/home/"+node.SSHUser+"/audit.yaml")

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
@@ -76,8 +76,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) SetupSuite() {
 	k.standardUserClient = standardUserClient
 }
 
-func (k *K3SNodeDriverProvisioningTestSuite) ProvisioningK3SCluster(provider Provider) {
-	providerName := " Node Provider: " + provider.Name
+func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SCluster() {
 	nodeRoles0 := []machinepools.NodeRoles{
 		{
 			ControlPlane: true,
@@ -127,56 +126,27 @@ func (k *K3SNodeDriverProvisioningTestSuite) ProvisioningK3SCluster(provider Pro
 		client, err := tt.client.WithSession(subSession)
 		require.NoError(k.T(), err)
 
-		cloudCredential, err := provider.CloudCredFunc(client)
-		require.NoError(k.T(), err)
-		for _, kubeVersion := range k.kubernetesVersions {
-			name = tt.name + providerName + " Kubernetes version: " + kubeVersion
-			k.Run(name, func() {
-				testSession := session.NewSession()
-				defer testSession.Cleanup()
-
-				testSessionClient, err := tt.client.WithSession(testSession)
-				require.NoError(k.T(), err)
-
-				clusterName := namegen.AppendRandomString(provider.Name)
-				generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
-				machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
-
-				machineConfigResp, err := testSessionClient.Steve.SteveType(provider.MachineConfigPoolResourceSteveType).Create(machinePoolConfig)
-				require.NoError(k.T(), err)
-
-				machinePools := machinepools.RKEMachinePoolSetup(tt.nodeRoles, machineConfigResp)
-
-				cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", cloudCredential.ID, kubeVersion, machinePools)
-
-				clusterResp, err := clusters.CreateK3SRKE2Cluster(testSessionClient, cluster)
-				require.NoError(k.T(), err)
-
-				kubeProvisioningClient, err := k.client.GetKubeAPIProvisioningClient()
-				require.NoError(k.T(), err)
-
-				result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
-					FieldSelector:  "metadata.name=" + clusterName,
-					TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		for _, providerName := range k.providers {
+			provider := CreateProvider(providerName)
+			for _, kubeVersion := range k.kubernetesVersions {
+				name = tt.name + providerName + " Kubernetes version: " + kubeVersion
+				k.Run(name, func() {
+					k.testProvisioningK3SCluster(client, provider, tt.nodeRoles, kubeVersion)
 				})
-				require.NoError(k.T(), err)
-
-				checkFunc := clusters.IsProvisioningClusterReady
-
-				err = wait.WatchWait(result, checkFunc)
-				assert.NoError(k.T(), err)
-				assert.Equal(k.T(), clusterName, clusterResp.ObjectMeta.Name)
-
-				clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
-				require.NoError(k.T(), err)
-				assert.NotEmpty(k.T(), clusterToken)
-			})
+			}
 		}
 	}
 }
 
-func (k *K3SNodeDriverProvisioningTestSuite) ProvisioningK3SClusterDynamicInput(provider Provider, nodesAndRoles []machinepools.NodeRoles) {
-	providerName := " Node Provider: " + provider.Name
+func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SClusterDynamicInput() {
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+	nodesAndRoles := clustersConfig.NodesAndRoles
+
+	if len(nodesAndRoles) == 0 {
+		k.T().Skip()
+	}
+
 	tests := []struct {
 		name   string
 		client *rancher.Client
@@ -193,75 +163,53 @@ func (k *K3SNodeDriverProvisioningTestSuite) ProvisioningK3SClusterDynamicInput(
 		client, err := tt.client.WithSession(subSession)
 		require.NoError(k.T(), err)
 
-		cloudCredential, err := provider.CloudCredFunc(client)
-		require.NoError(k.T(), err)
-
-		for _, kubeVersion := range k.kubernetesVersions {
-			name = tt.name + providerName + " Kubernetes version: " + kubeVersion
-			k.Run(name, func() {
-				testSession := session.NewSession()
-				defer testSession.Cleanup()
-
-				testSessionClient, err := tt.client.WithSession(testSession)
-				require.NoError(k.T(), err)
-
-				clusterName := namegen.AppendRandomString(provider.Name)
-				generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
-				machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
-
-				machineConfigResp, err := testSessionClient.Steve.SteveType(provider.MachineConfigPoolResourceSteveType).Create(machinePoolConfig)
-				require.NoError(k.T(), err)
-
-				machinePools := machinepools.RKEMachinePoolSetup(nodesAndRoles, machineConfigResp)
-
-				cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", cloudCredential.ID, kubeVersion, machinePools)
-
-				clusterResp, err := clusters.CreateK3SRKE2Cluster(testSessionClient, cluster)
-				require.NoError(k.T(), err)
-
-				kubeProvisioningClient, err := k.client.GetKubeAPIProvisioningClient()
-				require.NoError(k.T(), err)
-
-				result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
-					FieldSelector:  "metadata.name=" + clusterName,
-					TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		for _, providerName := range k.providers {
+			provider := CreateProvider(providerName)
+			for _, kubeVersion := range k.kubernetesVersions {
+				name = tt.name + providerName + " Kubernetes version: " + kubeVersion
+				k.Run(name, func() {
+					k.testProvisioningK3SCluster(client, provider, nodesAndRoles, kubeVersion)
 				})
-				require.NoError(k.T(), err)
-
-				checkFunc := clusters.IsProvisioningClusterReady
-
-				err = wait.WatchWait(result, checkFunc)
-				assert.NoError(k.T(), err)
-				assert.Equal(k.T(), clusterName, clusterResp.ObjectMeta.Name)
-
-				clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
-				require.NoError(k.T(), err)
-				assert.NotEmpty(k.T(), clusterToken)
-			})
+			}
 		}
 	}
 }
 
-func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioning() {
-	for _, providerName := range k.providers {
-		provider := CreateProvider(providerName)
-		k.ProvisioningK3SCluster(provider)
-	}
-}
+func (k *K3SNodeDriverProvisioningTestSuite) testProvisioningK3SCluster(client *rancher.Client, provider Provider, nodesAndRoles []machinepools.NodeRoles, kubeVersion string) {
+	cloudCredential, err := provider.CloudCredFunc(client)
 
-func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningDynamicInput() {
-	clustersConfig := new(provisioning.Config)
-	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
-	nodesAndRoles := clustersConfig.NodesAndRoles
+	clusterName := namegen.AppendRandomString(provider.Name)
+	generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
+	machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
 
-	if len(nodesAndRoles) == 0 {
-		k.T().Skip()
-	}
+	machineConfigResp, err := client.Steve.SteveType(provider.MachineConfigPoolResourceSteveType).Create(machinePoolConfig)
+	require.NoError(k.T(), err)
 
-	for _, providerName := range k.providers {
-		provider := CreateProvider(providerName)
-		k.ProvisioningK3SClusterDynamicInput(provider, nodesAndRoles)
-	}
+	machinePools := machinepools.RKEMachinePoolSetup(nodesAndRoles, machineConfigResp)
+
+	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", cloudCredential.ID, kubeVersion, machinePools)
+
+	clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
+	require.NoError(k.T(), err)
+
+	kubeProvisioningClient, err := k.client.GetKubeAPIProvisioningClient()
+	require.NoError(k.T(), err)
+
+	result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + clusterName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	require.NoError(k.T(), err)
+
+	checkFunc := clusters.IsProvisioningClusterReady
+
+	err = wait.WatchWait(result, checkFunc)
+	assert.NoError(k.T(), err)
+	assert.Equal(k.T(), clusterName, clusterResp.ObjectMeta.Name)
+
+	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+	require.NoError(k.T(), err)
+	assert.NotEmpty(k.T(), clusterToken)
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
-	pods "github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
@@ -79,8 +79,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 	r.standardUserClient = standardUserClient
 }
 
-func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2Cluster(provider Provider) {
-	providerName := " Node Provider: " + provider.Name
+func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2Cluster() {
 	nodeRoles0 := []machinepools.NodeRoles{
 		{
 			ControlPlane: true,
@@ -130,59 +129,30 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2Cluster(provider P
 		client, err := tt.client.WithSession(subSession)
 		require.NoError(r.T(), err)
 
-		cloudCredential, err := provider.CloudCredFunc(client)
-		require.NoError(r.T(), err)
-		for _, kubeVersion := range r.kubernetesVersions {
-			name = tt.name + providerName + " Kubernetes version: " + kubeVersion
-			for _, cni := range r.cnis {
-				name += " cni: " + cni
-				r.Run(name, func() {
-					testSession := session.NewSession()
-					defer testSession.Cleanup()
-
-					testSessionClient, err := tt.client.WithSession(testSession)
-					require.NoError(r.T(), err)
-
-					clusterName := namegen.AppendRandomString(provider.Name)
-					generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
-					machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
-
-					machineConfigResp, err := testSessionClient.Steve.SteveType(provider.MachineConfigPoolResourceSteveType).Create(machinePoolConfig)
-					require.NoError(r.T(), err)
-
-					machinePools := machinepools.RKEMachinePoolSetup(tt.nodeRoles, machineConfigResp)
-
-					cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, machinePools)
-
-					clusterResp, err := clusters.CreateK3SRKE2Cluster(testSessionClient, cluster)
-					require.NoError(r.T(), err)
-
-					kubeProvisioningClient, err := r.client.GetKubeAPIProvisioningClient()
-					require.NoError(r.T(), err)
-
-					result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
-						FieldSelector:  "metadata.name=" + clusterName,
-						TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		for _, providerName := range r.providers {
+			provider := CreateProvider(providerName)
+			for _, kubeVersion := range r.kubernetesVersions {
+				name = tt.name + providerName + " Kubernetes version: " + kubeVersion
+				for _, cni := range r.cnis {
+					name += " cni: " + cni
+					r.Run(name, func() {
+						r.testProvisioningRKE2Cluster(client, provider, tt.nodeRoles, kubeVersion, cni)
 					})
-					require.NoError(r.T(), err)
-
-					checkFunc := clusters.IsProvisioningClusterReady
-
-					err = wait.WatchWait(result, checkFunc)
-					assert.NoError(r.T(), err)
-					assert.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
-
-					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
-					require.NoError(r.T(), err)
-					assert.NotEmpty(r.T(), clusterToken)
-				})
+				}
 			}
 		}
 	}
 }
 
-func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2ClusterDynamicInput(provider Provider, nodesAndRoles []machinepools.NodeRoles) {
-	providerName := " Node Provider: " + provider.Name
+func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2ClusterDynamicInput() {
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+	nodesAndRoles := clustersConfig.NodesAndRoles
+
+	if len(nodesAndRoles) == 0 {
+		r.T().Skip()
+	}
+
 	tests := []struct {
 		name   string
 		client *rancher.Client
@@ -199,182 +169,63 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2ClusterDynamicInpu
 		client, err := tt.client.WithSession(subSession)
 		require.NoError(r.T(), err)
 
-		cloudCredential, err := provider.CloudCredFunc(client)
-		require.NoError(r.T(), err)
-
-		for _, kubeVersion := range r.kubernetesVersions {
-			name = tt.name + providerName + " Kubernetes version: " + kubeVersion
-			for _, cni := range r.cnis {
-				name += " cni: " + cni
-				r.Run(name, func() {
-					testSession := session.NewSession()
-					defer testSession.Cleanup()
-
-					testSessionClient, err := tt.client.WithSession(testSession)
-					require.NoError(r.T(), err)
-
-					clusterName := namegen.AppendRandomString(provider.Name)
-					generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
-					machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
-
-					machineConfigResp, err := testSessionClient.Steve.SteveType(provider.MachineConfigPoolResourceSteveType).Create(machinePoolConfig)
-					require.NoError(r.T(), err)
-
-					machinePools := machinepools.RKEMachinePoolSetup(nodesAndRoles, machineConfigResp)
-
-					cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, machinePools)
-
-					clusterResp, err := clusters.CreateK3SRKE2Cluster(testSessionClient, cluster)
-					require.NoError(r.T(), err)
-
-					kubeProvisioningClient, err := r.client.GetKubeAPIProvisioningClient()
-					require.NoError(r.T(), err)
-
-					result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
-						FieldSelector:  "metadata.name=" + clusterName,
-						TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		for _, providerName := range r.providers {
+			provider := CreateProvider(providerName)
+			for _, kubeVersion := range r.kubernetesVersions {
+				name = tt.name + providerName + " Kubernetes version: " + kubeVersion
+				for _, cni := range r.cnis {
+					name += " cni: " + cni
+					r.Run(name, func() {
+						r.testProvisioningRKE2Cluster(client, provider, nodesAndRoles, kubeVersion, cni)
 					})
-					require.NoError(r.T(), err)
-
-					checkFunc := clusters.IsProvisioningClusterReady
-
-					err = wait.WatchWait(result, checkFunc)
-					assert.NoError(r.T(), err)
-					assert.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
-
-					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
-					require.NoError(r.T(), err)
-					assert.NotEmpty(r.T(), clusterToken)
-				})
+				}
 			}
 		}
 	}
 }
 
-func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2CNICluster(provider Provider) {
-	providerName := " Node Provider: " + provider.Name
-	nodeRoles1 := []machinepools.NodeRoles{
-		{
-			ControlPlane: true,
-			Etcd:         false,
-			Worker:       false,
-			Quantity:     2,
-		},
-		{
-			ControlPlane: false,
-			Etcd:         true,
-			Worker:       false,
-			Quantity:     3,
-		},
-		{
-			ControlPlane: false,
-			Etcd:         false,
-			Worker:       true,
-			Quantity:     3,
-		},
-	}
+func (r *RKE2NodeDriverProvisioningTestSuite) testProvisioningRKE2Cluster(client *rancher.Client, provider Provider, nodesAndRoles []machinepools.NodeRoles, kubeVersion, cni string) {
+	cloudCredential, err := provider.CloudCredFunc(client)
 
-	tests := []struct {
-		name      string
-		nodeRoles []machinepools.NodeRoles
-		client    *rancher.Client
-	}{
-		{"3 etcd 2 cp 3 worker nodes Admin User", nodeRoles1, r.client},
-		{"3 etcd 2 cp 3 worker nodes Standard User", nodeRoles1, r.standardUserClient},
-	}
+	clusterName := namegen.AppendRandomString(provider.Name)
+	generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
+	machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
 
-	var name string
-	for _, tt := range tests {
-		subSession := r.session.NewSession()
-		defer subSession.Cleanup()
+	machineConfigResp, err := client.Steve.SteveType(provider.MachineConfigPoolResourceSteveType).Create(machinePoolConfig)
+	require.NoError(r.T(), err)
 
-		client, err := tt.client.WithSession(subSession)
-		require.NoError(r.T(), err)
+	machinePools := machinepools.RKEMachinePoolSetup(nodesAndRoles, machineConfigResp)
 
-		cloudCredential, err := provider.CloudCredFunc(client)
-		require.NoError(r.T(), err)
-		for _, kubeVersion := range r.kubernetesVersions {
-			name = tt.name + providerName + " Kubernetes version: " + kubeVersion
-			for _, cni := range r.cnis {
-				name += " cni: " + cni
-				r.Run(name, func() {
-					testSession := session.NewSession()
-					defer testSession.Cleanup()
+	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, machinePools)
 
-					testSessionClient, err := tt.client.WithSession(testSession)
-					require.NoError(r.T(), err)
+	clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
+	require.NoError(r.T(), err)
 
-					clusterName := namegen.AppendRandomString(provider.Name)
-					generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
-					machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
+	kubeProvisioningClient, err := r.client.GetKubeAPIProvisioningClient()
+	require.NoError(r.T(), err)
 
-					machineConfigResp, err := testSessionClient.Steve.SteveType(provider.MachineConfigPoolResourceSteveType).Create(machinePoolConfig)
-					require.NoError(r.T(), err)
+	result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + clusterName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	require.NoError(r.T(), err)
 
-					machinePools := machinepools.RKEMachinePoolSetup(tt.nodeRoles, machineConfigResp)
+	checkFunc := clusters.IsProvisioningClusterReady
 
-					cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, machinePools)
+	err = wait.WatchWait(result, checkFunc)
+	assert.NoError(r.T(), err)
+	assert.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
 
-					clusterResp, err := clusters.CreateK3SRKE2Cluster(testSessionClient, cluster)
-					require.NoError(r.T(), err)
+	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+	require.NoError(r.T(), err)
+	assert.NotEmpty(r.T(), clusterToken)
 
-					kubeProvisioningClient, err := r.client.GetKubeAPIProvisioningClient()
-					require.NoError(r.T(), err)
+	clusterID, err := clusters.GetClusterIDByName(r.client, clusterName)
+	assert.NoError(r.T(), err)
 
-					result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
-						FieldSelector:  "metadata.name=" + clusterName,
-						TimeoutSeconds: &defaults.WatchTimeoutSeconds,
-					})
-					require.NoError(r.T(), err)
-
-					checkFunc := clusters.IsProvisioningClusterReady
-
-					err = wait.WatchWait(result, checkFunc)
-					assert.NoError(r.T(), err)
-					assert.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
-
-					clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
-					require.NoError(r.T(), err)
-					assert.NotEmpty(r.T(), clusterToken)
-
-					clusterID, err := clusters.GetClusterIDByName(r.client, clusterName)
-					assert.NoError(r.T(), err)
-					podResults, podErrors := pods.StatusPods(client, clusterID)
-					assert.NotEmpty(r.T(), podResults)
-					assert.Empty(r.T(), podErrors)
-				})
-			}
-		}
-	}
-}
-
-func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioning() {
-	for _, providerName := range r.providers {
-		provider := CreateProvider(providerName)
-		r.ProvisioningRKE2Cluster(provider)
-	}
-}
-
-func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningDynamicInput() {
-	clustersConfig := new(provisioning.Config)
-	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
-	nodesAndRoles := clustersConfig.NodesAndRoles
-
-	if len(nodesAndRoles) == 0 {
-		r.T().Skip()
-	}
-
-	for _, providerName := range r.providers {
-		provider := CreateProvider(providerName)
-		r.ProvisioningRKE2ClusterDynamicInput(provider, nodesAndRoles)
-	}
-}
-
-func (r *RKE2NodeDriverProvisioningTestSuite) TestCNIProvisioning() {
-	for _, providerName := range r.providers {
-		provider := CreateProvider(providerName)
-		r.ProvisioningRKE2CNICluster(provider)
-	}
+	podResults, podErrors := pods.StatusPods(client, clusterID)
+	assert.NotEmpty(r.T(), podResults)
+	assert.Empty(r.T(), podErrors)
 }
 
 // In order for 'go test' to run this suite, we need to create


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Refactor RKE2/K3s provisioning test to use separate test functions for additional tests](https://github.com/rancher/qa-tasks/issues/562)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Recently, we refactored the hosted provisioning tests to do two of the following:

- Rework redundant provisioning code into a private method
- Separate provisioning test and additional test cases into their own, unique test functions

This greatly helps moving forward for internal CI/CD pipeline and overall helps to better organize our ever-growing test framework. As such, the same approach has been made to the RKE2/K3s provisioning tests.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Like with the hosted provisioning tests, the redundant provisioning code for node provider and custom clusters has been put into a single private method. The now separated unique test functions reference this private method and only keep unique code in their respective functions.

Additionally, I added two new Windows test for specifically the DynamicInput function. This is because before there were no Windows test cases in the DynamicInput, only the static counterpart had Windows tests.

Lastly, I added a check in the custom cluster tests to see if the K8s version is less than 1.25.0. This is because PSPs are officially removed in K8s 1.25, so we need to update our tests to account for this if a cluster version is > 1.25.0.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Locally tested static and dynamic input functions for both node provider and custom cluster.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Jenkins runs will be provided offline to reviewers.