### PR TITLE
Wait for probes during encryption key rotation restart

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
@@ -175,7 +175,11 @@ func (h *handler) OnJobChange(_ string, job *batchv1.Job) (*batchv1.Job, error) 
 	}
 	newStatus.JobName = job.Name
 
-	if _, err = h.patchStatus(infra.obj, infra.data, newStatus); err != nil {
+	if infra.data.String("status", "jobName") == "" {
+		infra.data.SetNested(job.Name, "status", "jobName")
+		_, err = h.dynamic.UpdateStatus(&unstructured.Unstructured{
+			Object: infra.data,
+		})
 		return job, err
 	}
 
@@ -317,7 +321,8 @@ func (h *handler) OnRemove(key string, obj runtime.Object) (runtime.Object, erro
 		return obj, err
 	}
 
-	if !infra.data.Bool("status", "jobComplete") && infra.data.String("status", "failureReason") == "" {
+	// Initial provisioning not finished
+	if cond := getCondition(infra.data, createJobConditionType); cond != nil && cond.Status() != "True" {
 		job, err := h.getJobFromInfraMachine(infra)
 		if apierrors.IsNotFound(err) {
 			// If the job is not found, go ahead and proceed with machine deletion
@@ -334,7 +339,8 @@ func (h *handler) OnRemove(key string, obj runtime.Object) (runtime.Object, erro
 		return obj, fmt.Errorf("cannot delete machine %s because create job has not finished", infra.meta.GetName())
 	}
 
-	if cond := getCondition(infra.data, deleteJobConditionType); cond != nil {
+	// infrastructure deletion finished
+	if cond := getCondition(infra.data, deleteJobConditionType); cond != nil && cond.Status() == "True" {
 		job, err := h.getJobFromInfraMachine(infra)
 		if apierrors.IsNotFound(err) {
 			// If the deletion job condition has been set on the infrastructure object and the deletion job has been removed,
@@ -409,13 +415,22 @@ func (h *handler) OnRemove(key string, obj runtime.Object) (runtime.Object, erro
 }
 
 func (h *handler) doRemove(infra *infraObject) (runtime.Object, error) {
-	obj, err := h.run(infra, false)
+	state, _, err := h.run(infra, false)
 	if err != nil {
-		return nil, err
+		return infra.obj, err
 	}
 
-	// ErrSkip will not remove finalizer but treat this as currently reconciled
-	return obj, generic.ErrSkip
+	if err = h.patchStatus(infra.data, state); err != nil {
+		return infra.obj, err
+	}
+
+	if infra.obj, err = h.dynamic.UpdateStatus(&unstructured.Unstructured{
+		Object: infra.data,
+	}); err != nil {
+		return infra.obj, err
+	}
+
+	return infra.obj, generic.ErrSkip
 }
 
 func (h *handler) EnqueueAfter(infra *infraObject, duration time.Duration) {
@@ -425,15 +440,11 @@ func (h *handler) EnqueueAfter(infra *infraObject, duration time.Duration) {
 	}
 }
 
+// OnChange is called whenever the infrastructure machine is updated, including when the object is being deleted.
 func (h *handler) OnChange(obj runtime.Object) (runtime.Object, error) {
 	infra, err := newInfraObject(obj)
 	if err != nil {
 		return obj, err
-	}
-
-	// don't process create if deleting
-	if !infra.meta.GetDeletionTimestamp().IsZero() {
-		return obj, nil
 	}
 
 	machine, err := rke2.GetOwnerCAPIMachine(obj, h.machineCache)
@@ -476,18 +487,65 @@ func (h *handler) OnChange(obj runtime.Object) (runtime.Object, error) {
 		return obj, generic.ErrSkip
 	}
 
-	newObj, err := h.run(infra, true)
-	if newObj == nil {
-		newObj = obj
+	create := infra.meta.GetDeletionTimestamp().IsZero()
+
+	if !create {
+		// do not recreate jobs if about to delete
+		if cond := getCondition(infra.data, deleteJobConditionType); cond != nil && cond.Status() == "True" {
+			return obj, nil
+		}
 	}
 
+	state, failedCreate, err := h.run(infra, create)
 	if err != nil {
-		return setCondition(h.dynamic, newObj, createJobConditionType, err)
+		return obj, err
 	}
-	return newObj, nil
+
+	if failedCreate && create {
+		logrus.Infof("[machineprovision] %s/%s: Failed to create infrastructure for machine %s, deleting and recreating...", infra.meta.GetNamespace(), infra.meta.GetName(), machine.Name)
+		if err = h.machineClient.Delete(machine.Namespace, machine.Name, &metav1.DeleteOptions{}); err != nil {
+			return obj, err
+		}
+	}
+
+	err = h.patchStatus(infra.data, state)
+	if err != nil {
+		return obj, err
+	}
+
+	jobName := infra.data.String("status", "jobName")
+	job, err := h.jobs.Get(infra.meta.GetNamespace(), jobName)
+	if apierrors.IsNotFound(err) {
+		return h.dynamic.UpdateStatus(&unstructured.Unstructured{
+			Object: infra.data,
+		})
+	}
+	if err != nil {
+		// if the job doesn't exist and hasn't been completed, this machine is likely about to be deleted.
+		// Delete it again for good measure in the event that the user manually deleted the job.
+		if err := h.machineClient.Delete(machine.Namespace, machine.Name, &metav1.DeleteOptions{}); err != nil {
+			return infra.obj, fmt.Errorf("failed to delete CAPI machine %s: %w", machine.Name, err)
+		}
+		return obj, err
+	}
+
+	newStatus, err := h.getMachineStatus(job)
+	if err != nil {
+		return obj, err
+	}
+	newStatus.JobName = job.Name
+
+	err = h.patchStatus(infra.data, newStatus)
+	if err != nil {
+		return obj, err
+	}
+
+	return h.dynamic.UpdateStatus(&unstructured.Unstructured{
+		Object: infra.data,
+	})
 }
 
-func (h *handler) run(infra *infraObject, create bool) (runtime.Object, error) {
+func (h *handler) run(infra *infraObject, create bool) (rkev1.RKEMachineStatus, bool, error) {
 	logrus.Infof("[machineprovision] %s/%s: reconciling machine job", infra.meta.GetNamespace(), infra.meta.GetName())
 
 	args := infra.data.Map("spec")
@@ -495,41 +553,27 @@ func (h *handler) run(infra *infraObject, create bool) (runtime.Object, error) {
 
 	dArgs, err := h.getArgsEnvAndStatus(infra, args, driver, create)
 	if err != nil {
-		return infra.obj, err
+		return rkev1.RKEMachineStatus{}, false, err
 	}
 
 	if dArgs.BootstrapSecretName == "" && dArgs.BootstrapRequired {
-		return infra.obj,
+		return rkev1.RKEMachineStatus{}, false,
 			h.dynamic.EnqueueAfter(infra.obj.GetObjectKind().GroupVersionKind(), infra.meta.GetNamespace(), infra.meta.GetName(), 2*time.Second)
 	}
 
 	failedCreate := infra.data.String("status", "failureReason") == string(capierrors.CreateMachineError)
 
 	if err := h.apply.WithOwner(infra.obj).ApplyObjects(objects((args.String("providerID") != "" || failedCreate) && create, dArgs)...); err != nil {
-		return nil, err
+		return rkev1.RKEMachineStatus{}, failedCreate, err
 	}
 
-	if create {
-		infra.obj, err = h.patchStatus(infra.obj, infra.data, dArgs.RKEMachineStatus)
-		if err != nil {
-			return nil, err
-		}
-
-		if failedCreate {
-			logrus.Infof("[machineprovision] %s/%s: Failed to create infrastructure for machine %s, deleting and recreating...", infra.meta.GetNamespace(), infra.meta.GetName(), dArgs.CapiMachineName)
-			if err = h.machineClient.Delete(infra.meta.GetNamespace(), dArgs.CapiMachineName, &metav1.DeleteOptions{}); err != nil {
-				return infra.obj, fmt.Errorf("failed to delete CAPI machine %s: %w", dArgs.CapiMachineName, err)
-			}
-		}
-	}
-
-	return infra.obj, nil
+	return dArgs.RKEMachineStatus, failedCreate, err
 }
 
-func (h *handler) patchStatus(obj runtime.Object, d data.Object, state rkev1.RKEMachineStatus) (runtime.Object, error) {
+func (h *handler) patchStatus(d data.Object, state rkev1.RKEMachineStatus) error {
 	statusData, err := convert.EncodeToMap(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if state.JobComplete {
@@ -551,7 +595,7 @@ func (h *handler) patchStatus(obj runtime.Object, d data.Object, state rkev1.RKE
 		} else if len(state.Conditions) > 0 {
 			for _, c := range state.Conditions {
 				if thisChanged, err := insertOrUpdateCondition(d, summary.NewCondition(c.Type, string(c.Status), c.Reason, c.Message)); err != nil {
-					return nil, err
+					return err
 				} else if thisChanged {
 					changed = true
 				}
@@ -560,7 +604,7 @@ func (h *handler) patchStatus(obj runtime.Object, d data.Object, state rkev1.RKE
 	}
 
 	if !changed {
-		return obj, nil
+		return nil
 	}
 
 	status := d.Map("status")
@@ -573,10 +617,7 @@ func (h *handler) patchStatus(obj runtime.Object, d data.Object, state rkev1.RKE
 			status[k] = v
 		}
 	}
-
-	return h.dynamic.UpdateStatus(&unstructured.Unstructured{
-		Object: d,
-	})
+	return nil
 }
 
 func (h *handler) getJobFromInfraMachine(infra *infraObject) (*batchv1.Job, error) {

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -942,10 +942,11 @@ func (p *Planner) desiredPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret 
 		return nodePlan, err
 	}
 
-	nodePlan, err = p.addProbes(nodePlan, controlPlane, entry, config)
+	probes, err := p.generateProbes(controlPlane, entry, config)
 	if err != nil {
 		return nodePlan, err
 	}
+	nodePlan.Probes = probes
 
 	// Add instruction last because it hashes config content
 	nodePlan, err = p.addInstallInstructionWithRestartStamp(nodePlan, controlPlane, entry)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #38283, #40183
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

With the removal of the killall script, some resources are left over after restarting the `rke2-server/k3s` services during encryption key rotation.

Additionally, the machineprovision controller is racy with updated the infrastructure machine and the job.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Wait for probes after restarting the nodes to ensure the nodes are actually healthy and ready to receive API requests.

Also, there is a commit to refactor the machineprovision controller, removing the two competing controllers.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually with a freshly provisioned single node cluster.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

Tested with a freshly provisioned single node cluster, then again with 10k secrets.
Tested with a freshly provisioned 3 etcd + 2 controlplane + 3 worker cluster, then again with 10k secrets.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

During testing, https://github.com/rancher/rke2/issues/3801 was discovered. This issue is unrelated to rancher, but will not be fixed until a future release of k3s/rke2. If this bug is encountered during encryption key rotation, there is no recourse except for an etcd restore, but this issue occurs intermittently.

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->