### PR TITLE
Wait for probes during encryption key rotation restart

### DIFF
--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -276,7 +276,7 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 		return status, err
 	}
 
-	if status, err = p.rotateEncryptionKeys(cp, status, releaseData, plan); err != nil {
+	if status, err = p.rotateEncryptionKeys(cp, status, clusterSecretTokens, plan, releaseData); err != nil {
 		return status, err
 	}
 
@@ -942,10 +942,11 @@ func (p *Planner) desiredPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret 
 		return nodePlan, err
 	}
 
-	nodePlan, err = p.addProbes(nodePlan, controlPlane, entry, config)
+	probes, err := p.generateProbes(controlPlane, entry, config)
 	if err != nil {
 		return nodePlan, err
 	}
+	nodePlan.Probes = probes
 
 	// Add instruction last because it hashes config content
 	nodePlan, err = p.addInstallInstructionWithRestartStamp(nodePlan, controlPlane, entry)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #38283
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

With the removal of the killall script, some resources are left over after restarting the `rke2-server/k3s` services during encryption key rotation.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Wait for probes after restarting the nodes to ensure the nodes are actually healthy and ready to receive API requests.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually with a freshly provisioned single node cluster.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

Tested with a freshly provisioned single node cluster, then again with 10k secrets.
Tested with a freshly provisioned 3 etcd + 2 controlplane + 3 worker cluster, then again with 10k secrets.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

During testing, https://github.com/rancher/rke2/issues/3801 was discovered. This issue is unrelated to rancher, but will not be fixed until a future release of k3s/rke2. If this bug is encountered during encryption key rotation, there is no recourse except for an etcd restore, but this issue occurs intermittently.

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->