### PR TITLE
Bump steve and apiserver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.32.1
 	github.com/rancher/aks-operator v1.1.0-rc1
-	github.com/rancher/apiserver v0.0.0-20221229135954-26bed53611c4
+	github.com/rancher/apiserver v0.0.0-20230120214941-e88c32739dc7
 	github.com/rancher/channelserver v0.5.1-0.20220405170618-28c9b37deff1
 	github.com/rancher/dynamiclistener v0.3.5
 	github.com/rancher/eks-operator v1.2.0-rc2
@@ -117,7 +117,7 @@ require (
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8
 	github.com/rancher/rke v1.4.3-rc4
-	github.com/rancher/steve v0.0.0-20230112182441-1d517bb27637
+	github.com/rancher/steve v0.0.0-20230120232010-53fbb87f5968
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
 	github.com/rancher/wrangler v1.0.1-0.20230110004444-57f14d386afb
 	github.com/robfig/cron v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1335,8 +1335,8 @@ github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95/go.mod h1:r
 github.com/rancher/aks-operator v1.1.0-rc1 h1:072cxWCmtgyGKm5qZ0AkAm4dMWt0GxX8CXNZ6s+GSDE=
 github.com/rancher/aks-operator v1.1.0-rc1/go.mod h1:qK59c7DFxpYn14sXHbbPkNl7zUNyuN0qkFUUHXsQ0jA=
 github.com/rancher/apiserver v0.0.0-20201023000256-1a0a904f9197/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
-github.com/rancher/apiserver v0.0.0-20221229135954-26bed53611c4 h1:eOq/tiwMCzcwexrbUQ9Agd9PHhwwtH9/G4usE0MoN8s=
-github.com/rancher/apiserver v0.0.0-20221229135954-26bed53611c4/go.mod h1:xwQhXv3XFxWfA6tLa4ZeaERu8ldNbyKv2sF+mT+c5WA=
+github.com/rancher/apiserver v0.0.0-20230120214941-e88c32739dc7 h1:Ob72oeF0iM8gWEMh+qKT5e1pzTwQU70I5kx4gMaqCmI=
+github.com/rancher/apiserver v0.0.0-20230120214941-e88c32739dc7/go.mod h1:xwQhXv3XFxWfA6tLa4ZeaERu8ldNbyKv2sF+mT+c5WA=
 github.com/rancher/aws-iam-authenticator v0.5.9-0.20220713170329-78acb8c83863 h1:7cVEMgwyiVhLyu/Ywuw58mkkh9cWpFE3+X8IrWncBxU=
 github.com/rancher/aws-iam-authenticator v0.5.9-0.20220713170329-78acb8c83863/go.mod h1:6dId2LCc8oHqeBzP6E8ndp4DflhKTxYLb5ZXwI4YmFA=
 github.com/rancher/channelserver v0.5.1-0.20220405170618-28c9b37deff1 h1:NMYQzCtLEEaJZ2xleLzDixN6Y+yO9ShzgsjHDg4zOrk=
@@ -1373,8 +1373,8 @@ github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8 h1:leqh0chj
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.4.3-rc4 h1:fYN+iHuhPOHEqaNhBS8gzJ0cL/byaDJa5xPCuFvjJ7A=
 github.com/rancher/rke v1.4.3-rc4/go.mod h1:0s8+XfiyC9Ff3KLaQ4Z5mDNI+taSb/hma13xOpW6slg=
-github.com/rancher/steve v0.0.0-20230112182441-1d517bb27637 h1:SMhrVwSjEMQMWat1t0aABEFEN3LfQmo/GAtGxAQeFR4=
-github.com/rancher/steve v0.0.0-20230112182441-1d517bb27637/go.mod h1:LM/rJIcOaFHhpi/7hASCAxiyRrEVoIDC/OGn5jlZ7i0=
+github.com/rancher/steve v0.0.0-20230120232010-53fbb87f5968 h1:6yiL8lKYezp462v3Iy9ha6HX5HOvHWIysjwMzOkRAhg=
+github.com/rancher/steve v0.0.0-20230120232010-53fbb87f5968/go.mod h1:7Px0MPFfyyQHPFH+2Vhraaye+PuCFRJhAVRz9FR4mN4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40196
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 When a watch was started for a namespace, the namespace wasn't being included in the returned start event over the websocket, making it hard to verify that the watch was correctly started even though it was correct in the backend.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Include the namespace in the start event.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Used websocat to start a watch and verify the result:

```
$ websocat -k wss://127.0.0.1:9443/v1/subscribe?sockId=1
🔼 {"resourceType": "pods", "namespace": "default"}
🔽 {"name":"resource.start","namespace":"default","resourceType":"pods","data":{"type":"subscribe","links":{}}}
```

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Unit tests added in the apiserver change: https://github.com/rancher/apiserver/pull/20

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
This change is very minimal, no regressions likely.