### PR TITLE
Skip http path if ingress backend service is nil

### DIFF
--- a/pkg/controllers/managementagent/endpoints/endpoints.go
+++ b/pkg/controllers/managementagent/endpoints/endpoints.go
@@ -296,6 +296,10 @@ func convertIngressToServicePublicEndpointsMap(ingress ingresswrapper.Ingress, a
 			continue
 		}
 		for _, path := range rule.HTTP.Paths {
+			//If the ingress backend is resource type, skip it
+			if path.Backend.Service == nil {
+				continue
+			}
 			for port, proto := range ports {
 				if port == 80 {
 					if tlsHosts.Has(rule.Host) {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
#38782
 
## Problem
If an ingress with resource backends is used, the cattle-agent panics with `invalid memory address or nil pointer dereference`
 
## Solution
If the service in the path backend is `nil`, it is skipped
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->