### PR TITLE
Fix panic in etcd snapshot restore

### DIFF
--- a/pkg/provisioningv2/rke2/planner/encryptionkeyrotation.go
+++ b/pkg/provisioningv2/rke2/planner/encryptionkeyrotation.go
@@ -124,7 +124,7 @@ echo "$targetGeneration" > "$generationFile"
 )
 
 func (p *Planner) setEncryptionKeyRotateState(status rkev1.RKEControlPlaneStatus, rotate *rkev1.RotateEncryptionKeys, phase rkev1.RotateEncryptionKeysPhase) (rkev1.RKEControlPlaneStatus, error) {
-	if equality.Semantic.DeepEqual(status.RotateEncryptionKeys, status) && equality.Semantic.DeepEqual(status.RotateEncryptionKeysPhase, phase) {
+	if equality.Semantic.DeepEqual(status.RotateEncryptionKeys, rotate) && equality.Semantic.DeepEqual(status.RotateEncryptionKeysPhase, phase) {
 		return status, nil
 	}
 	status.RotateEncryptionKeys = rotate

--- a/pkg/provisioningv2/rke2/planner/etcdcreate.go
+++ b/pkg/provisioningv2/rke2/planner/etcdcreate.go
@@ -28,7 +28,7 @@ func (p *Planner) resetEtcdSnapshotCreateState(status rkev1.RKEControlPlaneStatu
 }
 
 func (p *Planner) startOrRestartEtcdSnapshotCreate(status rkev1.RKEControlPlaneStatus, snapshot *rkev1.ETCDSnapshotCreate) (rkev1.RKEControlPlaneStatus, error) {
-	if status.ETCDSnapshotCreate == nil || !equality.Semantic.DeepEqual(*snapshot, *status.ETCDSnapshotCreate) {
+	if status.ETCDSnapshotCreate == nil || !equality.Semantic.DeepEqual(snapshot, status.ETCDSnapshotCreate) {
 		return p.setEtcdSnapshotCreateState(status, snapshot, rkev1.ETCDSnapshotPhaseStarted)
 	}
 	return status, nil

--- a/pkg/provisioningv2/rke2/planner/etcdrestore.go
+++ b/pkg/provisioningv2/rke2/planner/etcdrestore.go
@@ -29,7 +29,7 @@ func (p *Planner) resetEtcdSnapshotRestoreState(status rkev1.RKEControlPlaneStat
 }
 
 func (p *Planner) startOrRestartEtcdSnapshotRestore(status rkev1.RKEControlPlaneStatus, restore *rkev1.ETCDSnapshotRestore) (rkev1.RKEControlPlaneStatus, error) {
-	if restore == nil || !equality.Semantic.DeepEqual(*restore, *status.ETCDSnapshotRestore) {
+	if status.ETCDSnapshotRestore == nil || !equality.Semantic.DeepEqual(restore, status.ETCDSnapshotRestore) {
 		return p.setEtcdSnapshotRestoreState(status, restore, rkev1.ETCDSnapshotPhaseStarted)
 	}
 	return status, nil
@@ -321,9 +321,8 @@ func (p *Planner) restoreEtcdSnapshot(cp *rkev1.RKEControlPlane, status rkev1.RK
 		if err = p.runEtcdSnapshotRestorePlan(cp, snapshot, tokensSecret, clusterPlan); err != nil {
 			return status, err
 		}
-		controlPlane := cp.DeepCopy()
-		controlPlane.Status.ConfigGeneration++
-		return p.setEtcdSnapshotRestoreState(status, controlPlane.Spec.ETCDSnapshotRestore, rkev1.ETCDSnapshotPhaseRestartCluster)
+		status.ConfigGeneration++
+		return p.setEtcdSnapshotRestoreState(status, cp.Spec.ETCDSnapshotRestore, rkev1.ETCDSnapshotPhaseRestartCluster)
 	case rkev1.ETCDSnapshotPhaseRestartCluster:
 		if err := p.runEtcdRestoreServiceStart(cp, tokensSecret, clusterPlan); err != nil {
 			return status, err


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #40259
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Rancher would panic during an etcd restore when dereferencing the nil status field during state checking. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Pass pointer values instead.

Also, there was a bug where etcd snapshot restore would not advance to the next stage due to identical waiting messages in the planner.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually performing an etcd restore.