### PR TITLE
Add ChartDefaultURL to support custom rancher-charts repo in testing

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -113,6 +113,7 @@ var (
 	ClusterTemplateEnforcement          = NewSetting("cluster-template-enforcement", "false")
 	InitialDockerRootDir                = NewSetting("initial-docker-root-dir", "/var/lib/docker")
 	SystemCatalog                       = NewSetting("system-catalog", "external") // Options are 'external' or 'bundled'
+	ChartDefaultURL                     = NewSetting("chart-default-url", "https://git.rancher.io/")
 	ChartDefaultBranch                  = NewSetting("chart-default-branch", "dev-v2.7")
 	PartnerChartDefaultBranch           = NewSetting("partner-chart-default-branch", "main")
 	RKE2ChartDefaultBranch              = NewSetting("rke2-chart-default-branch", "main")


### PR DESCRIPTION
## Problem

When testing different fleet builds in Rancher, we need to set up a fork of rancher/charts (described here: https://github.com/rancher/fleet/blob/master/DEVELOPING.md#fleet-in-rancher---using-a-custom-fork).

However we don't want to (should not) create a test branch in rancher/charts directly, so we have to change the rancher code and change the [hard coded URL](https://github.com/manno/rancher/blob/release/v2.7/pkg/data/dashboard/repo.go#L29).
 
## Solution

This adds a setting for `ChartDefaultURL` (env var `CATTLE_CHART_DEFAULT_URL`), which will be used for rancher-charts when the controller is started and adds its repos.

## Testing

Since we only use this variable for dev purposes, everything should work as before.
