### PR TITLE
[2.7] Update RBAC surrounding PSACTs

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -48,6 +48,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("kontainerdrivers").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("podsecurityadmissionconfigurationtemplates").verbs("get", "list", "watch").
 		addRule().apiGroups("management.cattle.io").resources("nodetemplates").verbs("*").
 		addRule().apiGroups("").resources("secrets").verbs("create").
 		addRule().apiGroups("management.cattle.io").resources("cisconfigs").verbs("get", "list", "watch").
@@ -77,6 +78,8 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("features").verbs("get", "list", "watch", "update")
 	rb.addRole("Manage PodSecurityPolicy Templates", "podsecuritypolicytemplates-manage").
 		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("*")
+	rb.addRole("Manage PodSecurityAdmissionConfiguration Templates", "podsecurityadmissionconfigurationtemplates-manage").
+		addRule().apiGroups("management.cattle.io").resources("podsecurityadmissionconfigurationtemplates").verbs("*")
 	rb.addRole("Create RKE Templates", "clustertemplates-create").
 		addRule().apiGroups("management.cattle.io").resources("clustertemplates").verbs("create")
 	rb.addRole("Create RKE Template Revisions", "clustertemplaterevisions-create").
@@ -97,6 +100,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("globalroles", "globalrolebindings").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("users", "userattribute", "groups", "groupmembers").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("*").
+		addRule().apiGroups("management.cattle.io").resources("podsecurityadmissionconfigurationtemplates").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("fleetworkspaces").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("authconfigs").verbs("*").
 		addRule().apiGroups("management.cattle.io").resources("nodedrivers").verbs("*").
@@ -113,7 +117,8 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	userRole := addUserRules(rb.addRole("User", "user"))
 	userRole.
 		addRule().apiGroups("catalog.cattle.io").resources("clusterrepos").verbs("get", "list", "watch").
-		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("get", "list", "watch")
+		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("get", "list", "watch").
+		addRule().apiGroups("management.cattle.io").resources("podsecurityadmissionconfigurationtemplates").verbs("get", "list", "watch")
 
 	rb.addRole("User Base", "user-base").
 		addRule().apiGroups("management.cattle.io").resources("preferences").verbs("*").


### PR DESCRIPTION
## Issues: https://github.com/rancher/rancher/issues/40288, https://github.com/rancher/rancher/issues/40289
 
## Problem
Only admin users were able to view or modify PSACT's. This prevented standard users from attaching PSACT's to clusters they create / administrate, as well as modifying the PSACT attached to clusters they own / administrate. Additionally, no RBAC role existed which permitted non-admin users to modify existing PSACTs or create new PSACT's. 
 
## Solution
Update `role_data.go` to 

1. Update the standard user permissions for PSACT
    a. The verbage for PSACT's matches those for PSP's
2. Update the restricted admin user and provide them with full CRUD access to PSACT's  in similar fashion to PSP's
3. Introduce a new built-in role which provides full CRUD access to PSACT's, mirroring the built-in role for PSP's


**Note:** The name of the built-in role shown in the UI differs from the value in `role_data.go`. It seems the UI is adjusting the roles name into a more user-friendly format and adding a useful description. We likely need to do the same for the PSACT role.
 
## Testing

Test prerequisites:

You will need 1 standard user with no additional privileges or roles, 1 restricted admin user, and 1 standard user with the built-in role for managing PSACT's. 

Test Cases:

<details closed>
<summary>
Standard User Can See PSACT's and create / modify clusters with them
</summary>

+ Login as a standard user with no additional roles or privileges 
+ Begin to create an RKE2 cluster on K8s 1.25
+ Under the `Security` panel of the cluster configuration screen ensure that the `Default Pod Security Admission` drop down contains the two built-in roles, `restricted` & `privileged`
+ Log out and then log back in as an admin user 
+ Create a new PSACT 
+ Log back in as the standard user 
+ Ensure the `Default Pod Security Admission` drop down also includes the newly created PSACT 
+ Create the cluster
+ Once the cluster has been created, ensure you can change the PSACT and save the cluster as a standard user. 
+ Navigate to the `Cluster Management` section of the UI
+ Ensure the `podSecurityAdmissionConfigurationTemplates` button exists and once selected shows all PSACT's 
</details>

<details closed>
<summary>
Standard User Cannot Modify PSACT's
</summary>

+ Log in as the standard user with no built-in roles or privileges
+ In the `Cluster Management` Tab, navigate to the `PodSecurityAdmissionConfiguration` section
+ Ensure you can see the built-in PSACT's
+ Ensure you cannot edit any of the PSACT's 
</details>

<details closed>
<summary>
Restricted Admin Can Modify PSACT's
</summary>

+ log in as the restricted admin user
+ In the `Cluster Management` Tab, navigate to the `PodSecurityAdmissionConfiguration` section
+ Ensure you can see the built-in PSACT's
+ Ensure you can edit any of the PSACT's 
+ Ensure you can create new PSACT's
</details>

<details closed>
<summary>
User Can Be Given new PSACT Management Role
</summary>

+ Log into Rancher UI as an admin and create a new user with the `Manage PodSecurityAdmissionConfiguration Templates` Role
+ In the `Cluster Management` Tab, navigate to the `PodSecurityAdmissionConfiguration` section
+ Ensure you can see the built-in PSACT's
+ Ensure you can edit any of the PSACT's 
+ Ensure you can create new PSACT's
</details>

## Engineering Testing
### Manual Testing
I've done the above

### Automated Testing
N/A

## QA Testing Considerations
N/A
 
### Regressions Considerations

This PR adds new RBAC privileges and roles, there shouldn't be any regressions introduced. 