### PR TITLE
[release/v2.7] Allow for 503 when creating or mutating local cluster

### DIFF
--- a/pkg/data/dashboard/cluster_data.go
+++ b/pkg/data/dashboard/cluster_data.go
@@ -1,6 +1,8 @@
 package dashboard
 
 import (
+	"time"
+
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	fleetconst "github.com/rancher/rancher/pkg/fleet"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -8,8 +10,8 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func addLocalCluster(embedded bool, wrangler *wrangler.Context) error {
@@ -40,13 +42,23 @@ func addLocalCluster(embedded bool, wrangler *wrangler.Context) error {
 	}
 
 	var err error
-	c, err = wrangler.Mgmt.Cluster().Create(c)
-	if apierrors.IsAlreadyExists(err) {
-		c, err = wrangler.Mgmt.Cluster().Get("local", metav1.GetOptions{})
-		if err != nil {
-			return err
+	err = wait.PollImmediateInfinite(100*time.Millisecond, func() (bool, error) {
+		temporaryCluster, err := wrangler.Mgmt.Cluster().Create(c)
+		if err == nil {
+			c = temporaryCluster
+			return true, nil
+		} else if apierrors.IsAlreadyExists(err) {
+			temporaryCluster, err = wrangler.Mgmt.Cluster().Get("local", v1.GetOptions{})
+			if err == nil {
+				c = temporaryCluster
+				return true, nil
+			}
 		}
-	}
+		if apierrors.IsServiceUnavailable(err) {
+			return false, nil
+		}
+		return false, err
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/40335
 
## Problem
On warm restarts of a Rancher docker install, Rancher cannot start because the rancher-webhook deployment is not running yet.
  
## Solution
Add a retry to the local cluster creation/mutation that will retry if the error received is a 503, which could be that the rancher webhook is unavailable at the time. Since this is a warm restart of Rancher, the webhook deployment will eventually come up and the 503's will stop being emitted.
 
## Testing

## Engineering Testing
### Manual Testing
Start rancher as a docker install, let it come up, log into it
Restart the rancher install, observe it can still start

### Automated Testing
N/A

## QA Testing Considerations
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->