### PR TITLE
add the namespaces from RKE2's default restricted PSA config to Rancher's

### DIFF
--- a/pkg/data/management/podadmissionconfigurationtemplate_data.go
+++ b/pkg/data/management/podadmissionconfigurationtemplate_data.go
@@ -29,6 +29,8 @@ var FeatureAppNS = []string{
 	"cattle-windows-gmsa-system", // Windows GMSA
 	"cattle-sriov-system",        // Sriov
 	"cattle-ui-plugin-system",    // UI Plugin System
+	"cis-operator-system",        // From RKE2 default restricted PSA Config. See https://github.com/rancher/rke2/blob/34633dcc188d3a79744636fe21529ef6f5d64d71/pkg/rke2/psa.go#L58
+	"tigera-operator",            // From RKE2 default restricted PSA Config. See https://github.com/rancher/rke2/blob/34633dcc188d3a79744636fe21529ef6f5d64d71/pkg/rke2/psa.go#L58
 }
 
 func addDefaultPodSecurityAdmissionConfigurationTemplates(management *config.ManagementContext) error {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/40306 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
Rancher allows users to set the profile when creating an RKE2 custom cluster.
When the REK2 cluster version is 1.25, and the profile is set as cis-1.23, the RKE2 engine will configure the cluster to use RKE2-builtin [restricted PSA config file](https://github.com/rancher/rke2/blob/0ab4614b13daa5a49e484249a49012918d46ed22/pkg/rke2/psa.go#L40-L60).
The problem is that the config file does not include rancher's namespaces in its exception list, so Rancher's components can not be deployed into the cluster. Therefore, cluster provision will fail.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Instead of using RKE2's default restricted PSA config, we will use Rancher's default restricted PSA config when `profle=cis-1.23` is set on the RKE2 cluster, which means we need to append the namespace in the  RKE2's default restricted PSA config to Rancher's.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

We only need to confirm that "cis-operator-system" and "tigera-operator" are in the list of exception namespaces in rancher builtin restricted PSACT 
 