### PR TITLE
Add CRTB, PRTB, GRB, User cleanup when an auth provider is disabled

### DIFF
--- a/pkg/auth/api/secrets/cleanup.go
+++ b/pkg/auth/api/secrets/cleanup.go
@@ -16,7 +16,7 @@ import (
 // CleanupClientSecrets tries to delete common client secrets for each auth provider.
 func CleanupClientSecrets(secretInterface corev1.SecretInterface, config *v3.AuthConfig) error {
 	if config == nil {
-		return fmt.Errorf("cannot delete auth provider resources if its config is nil")
+		return fmt.Errorf("cannot delete auth provider secrets if its config is nil")
 	}
 
 	fields, ok := TypeToFields[config.Type]

--- a/pkg/auth/cleanup/service.go
+++ b/pkg/auth/cleanup/service.go
@@ -2,29 +2,220 @@
 package cleanup
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/api/secrets"
+	controllers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
-// Service performs cleanup of resources associated with a particular auth provider.
+var errAuthConfigNil = errors.New("cannot get auth provider if its config is nil")
+
+// Service performs cleanup of resources associated with an auth provider.
 type Service struct {
 	secretsInterface corev1.SecretInterface
+
+	userCache  controllers.UserCache
+	userClient controllers.UserClient
+
+	clusterRoleTemplateBindingsCache  controllers.ClusterRoleTemplateBindingCache
+	clusterRoleTemplateBindingsClient controllers.ClusterRoleTemplateBindingClient
+
+	globalRoleBindingsCache  controllers.GlobalRoleBindingCache
+	globalRoleBindingsClient controllers.GlobalRoleBindingClient
+
+	projectRoleTemplateBindingsCache  controllers.ProjectRoleTemplateBindingCache
+	projectRoleTemplateBindingsClient controllers.ProjectRoleTemplateBindingClient
 }
 
 // NewCleanupService creates and returns a new auth provider cleanup service.
-func NewCleanupService(secretsInterface corev1.SecretInterface) *Service {
-	return &Service{secretsInterface: secretsInterface}
+func NewCleanupService(secretsInterface corev1.SecretInterface, c controllers.Interface) *Service {
+	return &Service{
+		secretsInterface: secretsInterface,
+
+		userCache:  c.User().Cache(),
+		userClient: c.User(),
+
+		clusterRoleTemplateBindingsCache:  c.ClusterRoleTemplateBinding().Cache(),
+		clusterRoleTemplateBindingsClient: c.ClusterRoleTemplateBinding(),
+
+		projectRoleTemplateBindingsCache:  c.ProjectRoleTemplateBinding().Cache(),
+		projectRoleTemplateBindingsClient: c.ProjectRoleTemplateBinding(),
+
+		globalRoleBindingsCache:  c.GlobalRoleBinding().Cache(),
+		globalRoleBindingsClient: c.GlobalRoleBinding(),
+	}
 }
 
 // Run takes an auth config and checks if its auth provider is disabled, and ensures that any resources associated with it,
-// like secrets, are deleted.
-func (c *Service) Run(config *v3.AuthConfig) error {
-	err := secrets.CleanupClientSecrets(c.secretsInterface, config)
-	if err != nil {
+// such as secrets, CRTBs, PRTBs, GRBs, Users, are deleted.
+func (s *Service) Run(config *v3.AuthConfig) error {
+	if err := secrets.CleanupClientSecrets(s.secretsInterface, config); err != nil {
 		return fmt.Errorf("error cleaning up resources associated with a disabled auth provider %s: %w", config.Name, err)
 	}
+
+	if err := s.deleteGlobalRoleBindings(config); err != nil {
+		return fmt.Errorf("error cleaning up global role bindings: %w", err)
+	}
+
+	if err := s.deleteClusterRoleTemplateBindings(config); err != nil {
+		return fmt.Errorf("error cleaning up cluster role template bindings: %w", err)
+	}
+
+	if err := s.deleteProjectRoleTemplateBindings(config); err != nil {
+		return fmt.Errorf("error cleaning up project role template bindings: %w", err)
+	}
+
+	if err := s.deleteUsers(config); err != nil {
+		return fmt.Errorf("error cleaning up users: %w", err)
+	}
+
 	return nil
+}
+
+func (s *Service) deleteClusterRoleTemplateBindings(config *v3.AuthConfig) error {
+	if config == nil {
+		return errAuthConfigNil
+	}
+	list, err := s.clusterRoleTemplateBindingsCache.List("", labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list cluster role template bindings: %w", err)
+	}
+
+	for _, b := range list {
+		providerName := getProviderNameFromPrincipalNames(b.UserPrincipalName, b.GroupPrincipalName)
+		if providerName == config.Name {
+			err := s.clusterRoleTemplateBindingsClient.Delete(b.Namespace, b.Name, &v1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) deleteGlobalRoleBindings(config *v3.AuthConfig) error {
+	if config == nil {
+		return errAuthConfigNil
+	}
+	list, err := s.globalRoleBindingsCache.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list global role bindings: %w", err)
+	}
+
+	for _, b := range list {
+		providerName := getProviderNameFromPrincipalNames(b.GroupPrincipalName)
+		if providerName == config.Name {
+			err := s.globalRoleBindingsClient.Delete(b.Name, &v1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) deleteProjectRoleTemplateBindings(config *v3.AuthConfig) error {
+	if config == nil {
+		return errAuthConfigNil
+	}
+	prtbs, err := s.projectRoleTemplateBindingsCache.List("", labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list project role template bindings: %w", err)
+	}
+
+	for _, b := range prtbs {
+		providerName := getProviderNameFromPrincipalNames(b.UserPrincipalName, b.GroupPrincipalName)
+		if providerName == config.Name {
+			err := s.projectRoleTemplateBindingsClient.Delete(b.Namespace, b.Name, &v1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// deleteUsers deletes all external users (for the given provider specified in the config),
+// who never were local users. It does not delete external users who were local before the provider had been set up.
+// The method only removes the external principal IDs from those users.
+// External users are those who have multiple principal IDs associated with them.
+// A local admin (not necessarily the default admin) who had set up the provider will have two principal IDs,
+// but will also have a password.
+// This is how Rancher distinguishes fully external users from those who are external, too, but were once local.
+func (s *Service) deleteUsers(config *v3.AuthConfig) error {
+	if config == nil {
+		return errAuthConfigNil
+	}
+	users, err := s.userCache.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list users: %w", err)
+	}
+
+	for _, u := range users {
+		providerName := getProviderNameFromPrincipalNames(u.PrincipalIDs...)
+		if providerName == config.Name {
+			// A fully external user (who was never local) has no password.
+			if u.Password == "" {
+				err := s.userClient.Delete(u.Name, &v1.DeleteOptions{})
+				if err != nil && !apierrors.IsNotFound(err) {
+					return err
+				}
+			} else {
+				if err := s.resetLocalUser(u); err != nil {
+					return fmt.Errorf("failed to reset local user: %w", err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// resetLocalUser takes a user and removes all its principal IDs except that of the local user.
+// It updates the user so that it is effectively as it was before any auth provider had been enabled.
+func (s *Service) resetLocalUser(user *v3.User) error {
+	if user == nil || len(user.PrincipalIDs) < 2 {
+		return nil
+	}
+
+	var localID string
+	for _, id := range user.PrincipalIDs {
+		if strings.HasPrefix(id, "local") {
+			localID = id
+			break
+		}
+	}
+
+	if localID == "" {
+		return nil
+	}
+
+	user.PrincipalIDs = []string{localID}
+	_, err := s.userClient.Update(user)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+// getProviderNameFromPrincipalNames tries to extract the provider name from any one string that represents
+// a user principal or group principal.
+func getProviderNameFromPrincipalNames(names ...string) string {
+	for _, name := range names {
+		parts := strings.Split(name, "_")
+		if len(parts) > 0 && parts[0] != "" && !strings.HasPrefix(parts[0], "local") {
+			return parts[0]
+		}
+	}
+	return ""
 }

--- a/pkg/auth/cleanup/service_test.go
+++ b/pkg/auth/cleanup/service_test.go
@@ -1,0 +1,429 @@
+package cleanup
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers/common"
+	"github.com/rancher/rancher/pkg/auth/tokens"
+	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
+	controllers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	"github.com/rancher/rancher/pkg/generated/norman/core/v1/fakes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func TestRunCleanup(t *testing.T) {
+	var globalRoleBindingStore = map[string]*v3.GlobalRoleBinding{
+		"azure": {
+			ObjectMeta:         metav1.ObjectMeta{Name: "azure"},
+			GroupPrincipalName: "azuread_group://mygroup",
+		},
+		"ping": {
+			ObjectMeta:         metav1.ObjectMeta{Name: "ping"},
+			GroupPrincipalName: "ping_group://mygroup",
+		},
+	}
+
+	var projectRoleTemplateBindingStore = map[string]*v3.ProjectRoleTemplateBinding{
+		"local:azure": {
+			ObjectMeta:         metav1.ObjectMeta{Name: "azure", Namespace: "local"},
+			GroupPrincipalName: "azuread_group://mygroup",
+		},
+
+		"local:ping": {
+			ObjectMeta:         metav1.ObjectMeta{Name: "ping", Namespace: "local"},
+			GroupPrincipalName: "ping_group://mygroup",
+		},
+	}
+
+	var clusterRoleTemplateBindingStore = map[string]*v3.ClusterRoleTemplateBinding{
+		"local:azure": {
+			ObjectMeta:         metav1.ObjectMeta{Name: "ping", Namespace: "local"},
+			GroupPrincipalName: "azuread_group://mygroup",
+		},
+		"local:ping": {
+			ObjectMeta:         metav1.ObjectMeta{Name: "ping", Namespace: "local"},
+			GroupPrincipalName: "ping_group://mygroup",
+		},
+	}
+
+	var userStore = map[string]*v3.User{
+		"alice": {
+			ObjectMeta:   metav1.ObjectMeta{Name: "alice"},
+			PrincipalIDs: []string{"azuread_group://alice"},
+		},
+		"bob": {
+			ObjectMeta:   metav1.ObjectMeta{Name: "bob"},
+			PrincipalIDs: []string{"local://bob"},
+		},
+		"rick": {
+			ObjectMeta:   metav1.ObjectMeta{Name: "rick"},
+			PrincipalIDs: []string{"azuread_group://rick", "local://rick"},
+			Password:     "secret",
+		},
+	}
+
+	var secretStore = map[string]*v1.Secret{
+		"cattle-system:oauthSecretName": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oauthSecretName",
+				Namespace: tokens.SecretNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"azuread": []byte("my user token"),
+			},
+		},
+		"cattle-global-data:azureadconfig-applicationsecret": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s", strings.ToLower(client.AzureADConfigType), client.AzureADConfigFieldApplicationSecret),
+				Namespace: common.SecretsNamespace,
+			},
+		},
+		"cattle-global-data:azuread-access-token": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s", strings.ToLower("azuread"), "access-token"),
+				Namespace: common.SecretsNamespace,
+			},
+		},
+		"foo:regular-secret": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "regular secret",
+				Namespace: "foo",
+			},
+		},
+	}
+
+	svc := newMockCleanupService(
+		globalRoleBindingStore,
+		projectRoleTemplateBindingStore,
+		clusterRoleTemplateBindingStore,
+		userStore,
+		secretStore,
+	)
+	cfg := v3.AuthConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "azuread",
+		},
+		Type:    client.AzureADConfigType,
+		Enabled: false,
+	}
+
+	err := svc.Run(&cfg)
+
+	require.NoError(t, err)
+	assert.Len(t, globalRoleBindingStore, 1)
+	assert.Len(t, clusterRoleTemplateBindingStore, 1)
+	assert.Len(t, projectRoleTemplateBindingStore, 1)
+	assert.Len(t, userStore, 2)
+	assert.Len(t, secretStore, 1)
+
+	for _, user := range userStore {
+		require.Lenf(t, user.PrincipalIDs, 1, "every user after cleanup must have only one principal ID, got %d", len(user.PrincipalIDs))
+		principalID := user.PrincipalIDs[0]
+		assert.Truef(t, strings.HasPrefix(principalID, "local"), "the only principal ID has 'local' as a prefix, got %s", principalID)
+	}
+}
+
+func newMockCleanupService(
+	grbStore map[string]*v3.GlobalRoleBinding,
+	prtbStore map[string]*v3.ProjectRoleTemplateBinding,
+	crtbStore map[string]*v3.ClusterRoleTemplateBinding,
+	userStore map[string]*v3.User,
+	secretStore map[string]*v1.Secret) Service {
+	return Service{
+		secretsInterface:                  getSecretInterfaceMock(secretStore),
+		globalRoleBindingsCache:           mockGlobalRoleBindingCache{grbStore},
+		globalRoleBindingsClient:          mockGlobalRoleBindingClient{grbStore},
+		projectRoleTemplateBindingsCache:  mockProjectRoleTemplateBindingCache{prtbStore},
+		projectRoleTemplateBindingsClient: mockProjectRoleTemplateBindingClient{prtbStore},
+		clusterRoleTemplateBindingsCache:  mockClusterRoleTemplateBindingCache{crtbStore},
+		clusterRoleTemplateBindingsClient: mockClusterRoleTemplateBindingClient{crtbStore},
+		userCache:                         mockUserCache{userStore},
+		userClient:                        mockUserClient{userStore},
+	}
+}
+
+type mockGlobalRoleBindingCache struct {
+	store map[string]*v3.GlobalRoleBinding
+}
+
+func (m mockGlobalRoleBindingCache) Get(name string) (*v3.GlobalRoleBinding, error) {
+	return m.store[name], nil
+}
+
+func (m mockGlobalRoleBindingCache) List(_ labels.Selector) ([]*v3.GlobalRoleBinding, error) {
+	var lst []*v3.GlobalRoleBinding
+	for _, v := range m.store {
+		lst = append(lst, v)
+	}
+	return lst, nil
+}
+
+func (m mockGlobalRoleBindingCache) AddIndexer(_ string, _ controllers.GlobalRoleBindingIndexer) {
+	panic("not implemented")
+}
+
+func (m mockGlobalRoleBindingCache) GetByIndex(_, _ string) ([]*v3.GlobalRoleBinding, error) {
+	panic("not implemented")
+}
+
+type mockGlobalRoleBindingClient struct {
+	store map[string]*v3.GlobalRoleBinding
+}
+
+func (m mockGlobalRoleBindingClient) Create(_ *v3.GlobalRoleBinding) (*v3.GlobalRoleBinding, error) {
+	panic("not implemented")
+}
+
+func (m mockGlobalRoleBindingClient) Update(_ *v3.GlobalRoleBinding) (*v3.GlobalRoleBinding, error) {
+	panic("not implemented")
+}
+
+func (m mockGlobalRoleBindingClient) Delete(name string, _ *metav1.DeleteOptions) error {
+	delete(m.store, name)
+	return nil
+}
+
+func (m mockGlobalRoleBindingClient) Get(_ string, _ metav1.GetOptions) (*v3.GlobalRoleBinding, error) {
+	panic("not implemented")
+}
+
+func (m mockGlobalRoleBindingClient) List(_ metav1.ListOptions) (*v3.GlobalRoleBindingList, error) {
+	panic("not implemented")
+}
+
+func (m mockGlobalRoleBindingClient) Watch(_ metav1.ListOptions) (watch.Interface, error) {
+	panic("not implemented")
+}
+
+func (m mockGlobalRoleBindingClient) Patch(_ string, _ apitypes.PatchType, _ []byte, _ ...string) (result *v3.GlobalRoleBinding, err error) {
+	panic("not implemented")
+}
+
+type mockProjectRoleTemplateBindingCache struct {
+	store map[string]*v3.ProjectRoleTemplateBinding
+}
+
+func (m mockProjectRoleTemplateBindingCache) Get(namespace, name string) (*v3.ProjectRoleTemplateBinding, error) {
+	return m.store[namespace+":"+name], nil
+}
+
+func (m mockProjectRoleTemplateBindingCache) List(_ string, _ labels.Selector) ([]*v3.ProjectRoleTemplateBinding, error) {
+	var lst []*v3.ProjectRoleTemplateBinding
+	for _, v := range m.store {
+		lst = append(lst, v)
+	}
+	return lst, nil
+}
+
+func (m mockProjectRoleTemplateBindingCache) AddIndexer(_ string, _ controllers.ProjectRoleTemplateBindingIndexer) {
+	panic("not implemented")
+}
+
+func (m mockProjectRoleTemplateBindingCache) GetByIndex(_, _ string) ([]*v3.ProjectRoleTemplateBinding, error) {
+	panic("not implemented")
+}
+
+type mockProjectRoleTemplateBindingClient struct {
+	store map[string]*v3.ProjectRoleTemplateBinding
+}
+
+func (m mockProjectRoleTemplateBindingClient) Create(_ *v3.ProjectRoleTemplateBinding) (*v3.ProjectRoleTemplateBinding, error) {
+	panic("not implemented")
+}
+
+func (m mockProjectRoleTemplateBindingClient) Update(_ *v3.ProjectRoleTemplateBinding) (*v3.ProjectRoleTemplateBinding, error) {
+	panic("not implemented")
+}
+
+func (m mockProjectRoleTemplateBindingClient) Delete(namespace, name string, _ *metav1.DeleteOptions) error {
+	delete(m.store, namespace+":"+name)
+	return nil
+}
+
+func (m mockProjectRoleTemplateBindingClient) Get(namespace, name string, _ metav1.GetOptions) (*v3.ProjectRoleTemplateBinding, error) {
+	return m.store[namespace+":"+name], nil
+}
+
+func (m mockProjectRoleTemplateBindingClient) List(_ string, _ metav1.ListOptions) (*v3.ProjectRoleTemplateBindingList, error) {
+	panic("not implemented")
+}
+
+func (m mockProjectRoleTemplateBindingClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
+	panic("not implemented")
+}
+
+func (m mockProjectRoleTemplateBindingClient) Patch(_, _ string, _ apitypes.PatchType, _ []byte, _ ...string) (result *v3.ProjectRoleTemplateBinding, err error) {
+	panic("not implemented")
+}
+
+type mockClusterRoleTemplateBindingCache struct {
+	store map[string]*v3.ClusterRoleTemplateBinding
+}
+
+func (m mockClusterRoleTemplateBindingCache) Get(namespace, name string) (*v3.ClusterRoleTemplateBinding, error) {
+	return m.store[namespace+":"+name], nil
+}
+
+func (m mockClusterRoleTemplateBindingCache) List(_ string, _ labels.Selector) ([]*v3.ClusterRoleTemplateBinding, error) {
+	var lst []*v3.ClusterRoleTemplateBinding
+	for _, v := range m.store {
+		lst = append(lst, v)
+	}
+	return lst, nil
+}
+
+func (m mockClusterRoleTemplateBindingCache) AddIndexer(_ string, _ controllers.ClusterRoleTemplateBindingIndexer) {
+	panic("not implemented")
+}
+
+func (m mockClusterRoleTemplateBindingCache) GetByIndex(_, _ string) ([]*v3.ClusterRoleTemplateBinding, error) {
+	panic("not implemented")
+}
+
+type mockClusterRoleTemplateBindingClient struct {
+	store map[string]*v3.ClusterRoleTemplateBinding
+}
+
+func (m mockClusterRoleTemplateBindingClient) Create(_ *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+	panic("not implemented")
+}
+
+func (m mockClusterRoleTemplateBindingClient) Update(_ *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+	panic("not implemented")
+}
+
+func (m mockClusterRoleTemplateBindingClient) Delete(namespace, name string, _ *metav1.DeleteOptions) error {
+	delete(m.store, namespace+":"+name)
+	return nil
+}
+
+func (m mockClusterRoleTemplateBindingClient) Get(_, _ string, _ metav1.GetOptions) (*v3.ClusterRoleTemplateBinding, error) {
+	panic("not implemented")
+}
+
+func (m mockClusterRoleTemplateBindingClient) List(_ string, _ metav1.ListOptions) (*v3.ClusterRoleTemplateBindingList, error) {
+	panic("not implemented")
+}
+
+func (m mockClusterRoleTemplateBindingClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
+	panic("not implemented")
+}
+
+func (m mockClusterRoleTemplateBindingClient) Patch(_, _ string, _ apitypes.PatchType, _ []byte, _ ...string) (result *v3.ClusterRoleTemplateBinding, err error) {
+	panic("not implemented")
+}
+
+type mockUserCache struct {
+	store map[string]*v3.User
+}
+
+func (m mockUserCache) Get(name string) (*v3.User, error) {
+	return m.store[name], nil
+}
+
+func (m mockUserCache) List(_ labels.Selector) ([]*v3.User, error) {
+	var lst []*v3.User
+	for _, v := range m.store {
+		lst = append(lst, v)
+	}
+	return lst, nil
+}
+
+func (m mockUserCache) AddIndexer(_ string, _ controllers.UserIndexer) {}
+
+func (m mockUserCache) GetByIndex(_, _ string) ([]*v3.User, error) {
+	panic("not implemented")
+}
+
+type mockUserClient struct {
+	store map[string]*v3.User
+}
+
+func (m mockUserClient) Create(_ *v3.User) (*v3.User, error) {
+	panic("not implemented")
+}
+
+func (m mockUserClient) Update(user *v3.User) (*v3.User, error) {
+	m.store[user.Name] = user
+	return user, nil
+}
+
+func (m mockUserClient) UpdateStatus(_ *v3.User) (*v3.User, error) {
+	panic("not implemented")
+}
+
+func (m mockUserClient) Delete(name string, _ *metav1.DeleteOptions) error {
+	delete(m.store, name)
+	return nil
+}
+
+func (m mockUserClient) Get(_ string, _ metav1.GetOptions) (*v3.User, error) {
+	panic("not implemented")
+}
+
+func (m mockUserClient) List(_ metav1.ListOptions) (*v3.UserList, error) {
+	panic("not implemented")
+}
+
+func (m mockUserClient) Watch(_ metav1.ListOptions) (watch.Interface, error) {
+	panic("not implemented")
+}
+
+func (m mockUserClient) Patch(_ string, _ apitypes.PatchType, _ []byte, _ ...string) (result *v3.User, err error) {
+	panic("not implemented")
+}
+
+func getSecretInterfaceMock(store map[string]*corev1.Secret) v1.SecretInterface {
+	secretInterfaceMock := &fakes.SecretInterfaceMock{}
+
+	secretInterfaceMock.CreateFunc = func(secret *corev1.Secret) (*corev1.Secret, error) {
+		if secret.Name == "" {
+			uniqueIdentifier := md5.Sum([]byte(time.Now().String()))
+			secret.Name = hex.EncodeToString(uniqueIdentifier[:])
+		}
+		store[fmt.Sprintf("%s:%s", secret.Namespace, secret.Name)] = secret
+		return secret, nil
+	}
+
+	secretInterfaceMock.ListNamespacedFunc = func(namespace string, opts metav1.ListOptions) (*corev1.SecretList, error) {
+		var secrets []corev1.Secret
+		for _, secret := range store {
+			if secret.Namespace == namespace {
+				secrets = append(secrets, *secret)
+			}
+		}
+		return &corev1.SecretList{
+			Items: secrets,
+		}, nil
+	}
+
+	secretInterfaceMock.GetNamespacedFunc = func(namespace string, name string, opts metav1.GetOptions) (*corev1.Secret, error) {
+		secret, ok := store[fmt.Sprintf("%s:%s", namespace, name)]
+		if ok {
+			return secret, nil
+		}
+		return nil, errors.New("secret not found")
+	}
+
+	secretInterfaceMock.DeleteNamespacedFunc = func(namespace string, name string, options *metav1.DeleteOptions) error {
+		delete(store, fmt.Sprintf("%s:%s", namespace, name))
+		return nil
+	}
+
+	return secretInterfaceMock
+}

--- a/pkg/auth/providers/azure/clients/ms_graph_client.go
+++ b/pkg/auth/providers/azure/clients/ms_graph_client.go
@@ -78,6 +78,9 @@ func (c azureMSGraphClient) GetGroup(id string) (v3.Principal, error) {
 // ListGroups fetches all group principals in a directory from the Microsoft Graph API.
 func (c azureMSGraphClient) ListGroups(filter string) ([]v3.Principal, error) {
 	groups, _, err := c.groupClient.List(context.Background(), odata.Query{Filter: filter})
+	if err != nil {
+		return nil, err
+	}
 	var principals []v3.Principal
 	for _, u := range *groups {
 		principal, err := c.groupToPrincipal(u)

--- a/pkg/controllers/management/auth/auth_config.go
+++ b/pkg/controllers/management/auth/auth_config.go
@@ -44,7 +44,7 @@ func newAuthConfigController(context context.Context, mgmt *config.ManagementCon
 	controller := &authConfigController{
 		users:            mgmt.Management.Users("").Controller().Lister(),
 		authRefresher:    providerrefresh.NewUserAuthRefresher(context, scaledContext),
-		cleanup:          cleanup.NewCleanupService(mgmt.Core.Secrets("")),
+		cleanup:          cleanup.NewCleanupService(mgmt.Core.Secrets(""), mgmt.Wrangler.Mgmt),
 		authConfigClient: mgmt.Wrangler.Mgmt.AuthConfig(),
 	}
 	return controller
@@ -54,8 +54,8 @@ func (ac *authConfigController) setCleanupAnnotation(obj *v3.AuthConfig, value s
 	if obj.Annotations == nil {
 		obj.Annotations = make(map[string]string)
 	}
-	obj.Annotations[CleanupAnnotation] = value
 	objCopy := obj.DeepCopy()
+	objCopy.Annotations[CleanupAnnotation] = value
 	return ac.authConfigClient.Update(objCopy)
 }
 

--- a/pkg/controllers/management/auth/auth_config_test.go
+++ b/pkg/controllers/management/auth/auth_config_test.go
@@ -73,7 +73,7 @@ func TestCleanupRuns(t *testing.T) {
 			configEnabled:      true,
 			annotationValue:    CleanupRancherLocked,
 			expectCleanup:      false,
-			newAnnotationValue: CleanupRancherLocked,
+			newAnnotationValue: CleanupUnlocked,
 		},
 		{
 			name:               "no cleanup in enabled user_locked auth config",
@@ -95,7 +95,6 @@ func TestCleanupRuns(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			mockUsers := newMockUserLister()
 			var service cleanupService
 			controller := authConfigController{


### PR DESCRIPTION
## Issue:
The first [commit](https://github.com/rancher/rancher/pull/40378/commits/b208a1c5619125578010c0cf13b82c8da197606e) has the same as the code changes already reviewed for auth provider cleaning up resources after being disabled.

The [second](https://github.com/rancher/rancher/pull/40378/commits/353738f265f3107bf0d096982550a0f3185c5c4c) is just a quick fix to address a small issue https://github.com/rancher/rancher/issues/39908, since it's related to auth providers.

~The [third](https://github.com/rancher/rancher/pull/40378/commits/d1d6ac8d75139106bf3e576325cca79fc751f56f) addresses https://github.com/rancher/rancher/issues/40354. This changes how the auth config annotation is updated. We must use the unstructured client to preserve all the fields of a config when it is updated. When using a regular interface, I was having issues with fields disappearing on update because of the structure of auth config as a type - it's not a regular CRD.~
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->