### PR TITLE
Revert "Add ChartDefaultURL to support different registries in testing"

### DIFF
--- a/pkg/data/dashboard/repo.go
+++ b/pkg/data/dashboard/repo.go
@@ -14,16 +14,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const defaultURL = "https://git.rancher.io/"
-
 var (
 	prefix = "rancher-"
 )
 
-func addRepo(wrangler *wrangler.Context, repoName, repoURL, branchName string) error {
-	if repoURL == "" || repoURL == defaultURL {
-		repoURL = defaultURL + strings.TrimPrefix(repoName, prefix)
-	}
+func addRepo(wrangler *wrangler.Context, repoName, branchName string) error {
 	repo, err := wrangler.Catalog.ClusterRepo().Get(repoName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		_, err = wrangler.Catalog.ClusterRepo().Create(&v1.ClusterRepo{
@@ -31,12 +26,11 @@ func addRepo(wrangler *wrangler.Context, repoName, repoURL, branchName string) e
 				Name: repoName,
 			},
 			Spec: v1.RepoSpec{
-				GitRepo:   repoURL,
+				GitRepo:   "https://git.rancher.io/" + strings.TrimPrefix(repoName, prefix),
 				GitBranch: branchName,
 			},
 		})
-	} else if err == nil && (repo.Spec.GitBranch != branchName || repo.Spec.GitRepo != repoURL) {
-		repo.Spec.GitRepo = repoURL
+	} else if err == nil && repo.Spec.GitBranch != branchName {
 		repo.Spec.GitBranch = branchName
 		_, err = wrangler.Catalog.ClusterRepo().Update(repo)
 	}
@@ -45,15 +39,15 @@ func addRepo(wrangler *wrangler.Context, repoName, repoURL, branchName string) e
 }
 
 func addRepos(ctx context.Context, wrangler *wrangler.Context) error {
-	if err := addRepo(wrangler, "rancher-charts", settings.ChartDefaultURL.Get(), settings.ChartDefaultBranch.Get()); err != nil {
+	if err := addRepo(wrangler, "rancher-charts", settings.ChartDefaultBranch.Get()); err != nil {
 		return err
 	}
-	if err := addRepo(wrangler, "rancher-partner-charts", defaultURL, settings.PartnerChartDefaultBranch.Get()); err != nil {
+	if err := addRepo(wrangler, "rancher-partner-charts", settings.PartnerChartDefaultBranch.Get()); err != nil {
 		return err
 	}
 
 	if features.RKE2.Enabled() {
-		if err := addRepo(wrangler, "rancher-rke2-charts", defaultURL, settings.RKE2ChartDefaultBranch.Get()); err != nil {
+		if err := addRepo(wrangler, "rancher-rke2-charts", settings.RKE2ChartDefaultBranch.Get()); err != nil {
 			return err
 		}
 	}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -113,7 +113,6 @@ var (
 	ClusterTemplateEnforcement          = NewSetting("cluster-template-enforcement", "false")
 	InitialDockerRootDir                = NewSetting("initial-docker-root-dir", "/var/lib/docker")
 	SystemCatalog                       = NewSetting("system-catalog", "external") // Options are 'external' or 'bundled'
-	ChartDefaultURL                     = NewSetting("chart-default-url", "https://git.rancher.io/")
 	ChartDefaultBranch                  = NewSetting("chart-default-branch", "dev-v2.7")
 	PartnerChartDefaultBranch           = NewSetting("partner-chart-default-branch", "main")
 	RKE2ChartDefaultBranch              = NewSetting("rke2-chart-default-branch", "main")


### PR DESCRIPTION
This reverts commit b052966f27047d2eab9f9e2a82685b0bb2806179.

There are several concerns regarding https://github.com/rancher/rancher/pull/40281 
Let's revert it for now and discuss a better solution later.
