### PR TITLE
[2.7] Remove kontainer-engine and machine drivers from drivers.rancher.cn

### DIFF
--- a/pkg/data/management/kontainerdriver_data.go
+++ b/pkg/data/management/kontainerdriver_data.go
@@ -48,49 +48,6 @@ func addKontainerDrivers(management *config.ManagementContext) error {
 	}
 
 	if err := creator.addCustomDriver(
-		"baiducloudcontainerengine",
-		"https://drivers.rancher.cn/kontainer-engine-driver-baidu/0.2.0/kontainer-engine-driver-baidu-linux",
-		"4613e3be3ae5487b0e21dfa761b95de2144f80f98bf76847411e5fcada343d5e",
-		"https://drivers.rancher.cn/kontainer-engine-driver-baidu/0.2.0/component.js",
-		false,
-		"drivers.rancher.cn", "*.baidubce.com",
-	); err != nil {
-		return err
-	}
-
-	if err := creator.addCustomDriver(
-		"aliyunkubernetescontainerservice",
-		"https://drivers.rancher.cn/kontainer-engine-driver-aliyun/0.2.6/kontainer-engine-driver-aliyun-linux",
-		"8a5360269ec803e3d8cf2c9cc94c66879da03a1fd2b580912c1a83454509c84c",
-		"https://drivers.rancher.cn/pandaria/ui/cluster-driver-aliyun/0.1.1/component.js",
-		false,
-		"*.aliyuncs.com",
-	); err != nil {
-		return err
-	}
-
-	if err := creator.addCustomDriver(
-		"tencentkubernetesengine",
-		"https://drivers.rancher.cn/kontainer-engine-driver-tencent/0.3.0/kontainer-engine-driver-tencent-linux",
-		"ad5406502daf826874889963d7bdaed78db4689f147889ecf97394bc4e8d3d76",
-		"",
-		false,
-		"*.tencentcloudapi.com", "*.qcloud.com",
-	); err != nil {
-		return err
-	}
-
-	if err := creator.addCustomDriver(
-		"huaweicontainercloudengine",
-		"https://drivers.rancher.cn/kontainer-engine-driver-huawei/0.1.2/kontainer-engine-driver-huawei-linux",
-		"0b6c1dfaa477a60a3bd9f8a60a55fcafd883866c2c5c387aec75b95d6ba81d45",
-		"",
-		false,
-		"*.myhuaweicloud.com",
-	); err != nil {
-		return err
-	}
-	if err := creator.addCustomDriver(
 		"oraclecontainerengine",
 		"https://github.com/rancher-plugins/kontainer-engine-driver-oke/releases/download/v1.8.3/kontainer-engine-driver-oke-linux",
 		"7bfde567e6d478f1da8d36531f765d348bff1cd3abe83c70ddf7766f46112170",

--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -72,12 +72,6 @@ type machineDriverCompare struct {
 }
 
 func addMachineDrivers(management *config.ManagementContext) error {
-	if err := addMachineDriver("pinganyunecs", "https://drivers.rancher.cn/node-driver-pinganyun/0.3.0/docker-machine-driver-pinganyunecs-linux.tgz", "https://drivers.rancher.cn/node-driver-pinganyun/0.3.0/component.js", "f84ccec11c2c1970d76d30150916933efe8ca49fe4c422c8954fc37f71273bb5", []string{"drivers.rancher.cn"}, false, false, false, management); err != nil {
-		return err
-	}
-	if err := addMachineDriver("aliyunecs", "https://drivers.rancher.cn/node-driver-aliyun/1.0.4/docker-machine-driver-aliyunecs.tgz", "", "5990d40d71c421a85563df9caf069466f300cd75723effe4581751b0de9a6a0e", []string{"ecs.aliyuncs.com"}, false, false, false, management); err != nil {
-		return err
-	}
 	if err := addMachineDriver(Amazonec2driver, "local://", "", "",
 		[]string{"iam.amazonaws.com", "iam.us-gov.amazonaws.com", "iam.%.amazonaws.com.cn", "ec2.%.amazonaws.com", "ec2.%.amazonaws.com.cn", "eks.%.amazonaws.com", "eks.%.amazonaws.com.cn", "kms.%.amazonaws.com", "kms.%.amazonaws.com.cn"},
 		true, true, true, management); err != nil {

--- a/tests/integration/suite/test_rbac.py
+++ b/tests/integration/suite/test_rbac.py
@@ -577,14 +577,14 @@ def ns_count(client, count):
 
 def test_appropriate_users_can_see_kontainer_drivers(user_factory):
     kds = user_factory().client.list_kontainer_driver()
-    assert len(kds) == 11
+    assert len(kds) == 7
 
     kds = user_factory('clusters-create').client.list_kontainer_driver()
-    assert len(kds) == 11
+    assert len(kds) == 7
 
     kds = user_factory('kontainerdrivers-manage').client. \
         list_kontainer_driver()
-    assert len(kds) == 11
+    assert len(kds) == 7
 
     kds = user_factory('settings-manage').client.list_kontainer_driver()
     assert len(kds) == 0


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
SURE-5852
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
For the fresh installation, it will not contain these drivers.

When upgrading from the previous Rancher, since these drivers have been stored in CR, they will continue to be retained, which is also conducive to ensuring compatibility.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->