### PR TITLE
chart: Support custom pathType for ingress

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -54,7 +54,7 @@ spec:
           servicePort: {{ .Values.ingress.servicePort }}
           {{- end }}
         {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
-        pathType: ImplementationSpecific
+        pathType: {{ .Values.ingress.pathType | default "ImplementationSpecific" }}
         {{- end }}
 {{- if eq .Values.tls "ingress" }}
   tls:


### PR DESCRIPTION
On some ingress classes or some special architectures. People want to customize Ingress's PathType (Because sometimes ImplementationSpecific is quite ambiguous, they want to pass in Prefix for example). Let's give custom permissions to users

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
- User wants to switch Ingress PathType from ImplementationSpecific -> Prefix (Due to ImplementationSpecific crashing or misbehaving)

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
- Supports .Values.ingress.pathType to get custom data from values (if provided) 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
- Manual check

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
- `helm install rancher chart/ --set ingress.pathType=Prefix`

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->