### PR TITLE
[v2.7] End to End test Code Coverage with Jenkins pipeline and setup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -212,6 +212,7 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
+	github.com/fvbommel/sortorder v1.0.1 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.3 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-gorp/gorp/v3 v3.0.2 // indirect
@@ -299,7 +300,7 @@ require (
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/smartystreets/goconvey v1.7.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/spf13/cobra v1.5.0 // indirect
+	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/valyala/fastjson v1.6.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -527,6 +527,7 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/fullstorydev/grpcurl v1.6.0/go.mod h1:ZQ+ayqbKMJNhzLmbpCiurTVlaK2M/3nqZCxaQ2Ze/sM=
+github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqFfzE=
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=

--- a/tests/framework/clients/corral/config.go
+++ b/tests/framework/clients/corral/config.go
@@ -20,8 +20,8 @@ type CorralConfigs struct {
 // CorralPackages is a struct that has the path to the packages
 type CorralPackages struct {
 	CorralPackageImages map[string]string `json:"corralPackageImages" yaml:"corralPackageImages"`
-	Cleanup             bool              `json:"cleanup" yaml:"cleanup" default:true`
-	Debug               bool              `json:"debug" yaml:"debug" default:false`
+	Cleanup             bool              `json:"cleanup" yaml:"cleanup" default:"true"`
+	Debug               bool              `json:"debug" yaml:"debug" default:"false"`
 	CustomRepo          string            `json:"customRepo" yaml:"customRepo" default:"https://github.com/rancherlabs/corral-packages.git"`
 }
 

--- a/tests/framework/clients/corral/corral.go
+++ b/tests/framework/clients/corral/corral.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os/exec"
 	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
@@ -17,6 +18,18 @@ const (
 	debugFlag       = "--trace"
 	skipCleanupFlag = "--skip-cleanup"
 )
+
+// GetCorralEnvVar gets corral environment variables
+func GetCorralEnvVar(corralName, envVar string) (string, error) {
+	msg, err := exec.Command("corral", "vars", corralName, envVar).CombinedOutput()
+	if err != nil {
+		return "", errors.Wrap(err, "GetCorralEnvVar: "+string(msg))
+	}
+
+	corralEnvVar := string(msg)
+	corralEnvVar = strings.TrimSuffix(corralEnvVar, "\n")
+	return corralEnvVar, nil
+}
 
 // SetupCorralConfig sets the corral config vars. It takes a map[string]string as a parameter; the key is the value and the value the value you are setting
 // For example we are getting the aws config vars to build a corral from aws.

--- a/tests/framework/clients/dynamic/dynamic.go
+++ b/tests/framework/clients/dynamic/dynamic.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -22,7 +23,7 @@ type Client struct {
 
 // NewForConfig creates a new dynamic client or returns an error.
 func NewForConfig(ts *session.Session, inConfig *rest.Config) (dynamic.Interface, error) {
-	ts.TestingT.Logf("Dynamic Client Host:%s", inConfig.Host)
+	logrus.Infof("Dynamic Client Host:%s", inConfig.Host)
 
 	dynamicClient, err := dynamic.NewForConfig(inConfig)
 	if err != nil {

--- a/tests/framework/extensions/codecoverage/codecoverage.go
+++ b/tests/framework/extensions/codecoverage/codecoverage.go
@@ -1,0 +1,185 @@
+package codecoverage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/kubeconfig"
+	"github.com/rancher/rancher/tests/framework/pkg/killserver"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+)
+
+var podGroupVersionResource = corev1.SchemeGroupVersion.WithResource("pods")
+
+const (
+	cattleSystemNameSpace = "cattle-system"
+	localCluster          = "local"
+	rancherCoverFile      = "ranchercoverage"
+	agentCoverFile        = "agentcoverage"
+	outputDir             = "cover"
+)
+
+func checkServiceIsRunning(dynamicClient dynamic.Interface) error {
+	return kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
+		_, err = dynamicClient.Resource(podGroupVersionResource).Namespace(cattleSystemNameSpace).List(context.Background(), metav1.ListOptions{})
+		if k8sErrors.IsInternalError(err) || k8sErrors.IsServiceUnavailable(err) {
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func killTestServices(client *rancher.Client, clusterID string, podNames []string) error {
+	cmd := []string{
+		"/bin/sh",
+		"-c",
+		fmt.Sprintf("curl -s localhost%s", killserver.KillServerPort),
+	}
+
+	kubeConfig, err := kubeconfig.GetKubeconfig(client, clusterID)
+	if err != nil {
+		return err
+	}
+
+	restConfig, err := (*kubeConfig).ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	for _, podName := range podNames {
+		_, err := kubeconfig.KubectlExec(restConfig, podName, cattleSystemNameSpace, cmd)
+		if err != nil {
+			logrus.Error("error killing pod container %v", err)
+		}
+	}
+
+	return nil
+}
+
+func retrieveCodeCoverageFile(client *rancher.Client, clusterID, coverageFilename string, podNames []string) error {
+	kubeConfig, err := kubeconfig.GetKubeconfig(client, clusterID)
+	if err != nil {
+		return err
+	}
+
+	restConfig, err := (*kubeConfig).ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	for _, podName := range podNames {
+		fileName := fmt.Sprintf("%s%s", podName, coverageFilename)
+		dst := fmt.Sprintf("%s/%s", outputDir, fileName)
+
+		err := kubeconfig.CopyFileFromPod(restConfig, *kubeConfig, podName, cattleSystemNameSpace, coverageFilename, dst)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// KillRancherTestServicesRetrieveCoverage is a function that kills the rancher service of the local cluster
+// inorder for the code coverage report to be written, and then copies over the coverage reports from the pods
+// to a local destination. The custom code coverage rancher image must be running in the local cluster.
+func KillRancherTestServicesRetrieveCoverage(client *rancher.Client) error {
+	var podNames []string
+	dynamicClient, err := client.GetRancherDynamicClient()
+	if err != nil {
+		return err
+	}
+
+	pods, err := dynamicClient.Resource(podGroupVersionResource).Namespace(cattleSystemNameSpace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, pod := range pods.Items {
+		name := pod.GetName()
+		if strings.Contains(name, "rancher") && !strings.Contains(name, "webhook") {
+			podNames = append(podNames, pod.GetName())
+		}
+	}
+
+	err = killTestServices(client, localCluster, podNames)
+	if err != nil {
+		return err
+	}
+
+	err = checkServiceIsRunning(dynamicClient)
+	if err != nil {
+		return err
+	}
+
+	return retrieveCodeCoverageFile(client, localCluster, rancherCoverFile, podNames)
+}
+
+// KillAgentTestServicesRetrieveCoverage is a function that kills the cattle-cluster-agent service of a downstream cluster
+// inorder for the code coverage report to be written, and then copies over the coverage reports from the pods
+// to a local destination. The custom code coverage rancher-agent image must be running in the downstream cluster.
+func KillAgentTestServicesRetrieveCoverage(client *rancher.Client) error {
+	clusters, err := client.Steve.SteveType(clusters.ProvisioningSteveResouceType).ListAll(nil)
+	if err != nil {
+		return err
+	}
+
+	for _, cluster := range clusters.Data {
+		clusterStatus := &apiv1.ClusterStatus{}
+		err = v1.ConvertToK8sType(cluster.Status, clusterStatus)
+		if err != nil {
+			return err
+		}
+		clusterID := clusterStatus.ClusterName
+		if clusterID != localCluster {
+			dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+			if err != nil {
+				logrus.Errorf("could not connect to downstream cluster")
+				continue
+			}
+
+			pods, err := dynamicClient.Resource(podGroupVersionResource).Namespace(cattleSystemNameSpace).List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				logrus.Errorf("could not list pods")
+				continue
+			}
+
+			var podNames []string
+			for _, pod := range pods.Items {
+				if strings.Contains(pod.GetName(), "cattle-cluster-agent") {
+					podNames = append(podNames, pod.GetName())
+				}
+			}
+
+			err = killTestServices(client, clusterID, podNames)
+			if err != nil {
+				return err
+			}
+
+			err = checkServiceIsRunning(dynamicClient)
+			if err != nil {
+				return err
+			}
+
+			err = retrieveCodeCoverageFile(client, clusterID, agentCoverFile, podNames)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/tests/framework/extensions/kubeconfig/exec.go
+++ b/tests/framework/extensions/kubeconfig/exec.go
@@ -1,0 +1,111 @@
+package kubeconfig
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	k8Scheme "k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/kubectl/pkg/cmd/cp"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+const (
+	apiPath = "/api"
+)
+
+var podGroupVersion = corev1.SchemeGroupVersion.WithResource("pods").GroupVersion()
+
+// LogStreamer is a struct that acts like io.Writer inorder to to retireve Stdout from an kubectl exec command in pod
+type LogStreamer struct {
+	b bytes.Buffer
+}
+
+// String stringer for the LogStreamer
+func (l *LogStreamer) String() string {
+	return l.b.String()
+}
+
+// Write is function that writes to the underlying bytes.Buffer
+func (l *LogStreamer) Write(p []byte) (n int, err error) {
+	a := strings.TrimSpace(string(p))
+	l.b.WriteString(a)
+	return len(p), nil
+}
+
+// KubectlExec is function that runs `kubectl exec` in a specified pod of a cluster. The function
+// takes the kubeconfig in form of a restclient.Config object, the pod name, the namespace of the pod,
+// and the command a user wants to run.
+func KubectlExec(restConfig *restclient.Config, podName, namespace string, command []string) (*LogStreamer, error) {
+	restConfig.ContentConfig.NegotiatedSerializer = serializer.NewCodecFactory(k8Scheme.Scheme)
+	restConfig.ContentConfig.GroupVersion = &podGroupVersion
+	restConfig.APIPath = apiPath
+
+	restClient, err := restclient.RESTClientFor(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	req := restClient.Post().Resource("pods").Name(podName).Namespace(namespace).SubResource("exec")
+	option := &corev1.PodExecOptions{
+		Command: command,
+		Stdin:   false,
+		Stdout:  true,
+		Stderr:  true,
+		TTY:     true,
+	}
+	req.VersionedParams(
+		option,
+		k8Scheme.ParameterCodec,
+	)
+
+	exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
+	if err != nil {
+		return nil, err
+	}
+
+	logStreamer := &LogStreamer{}
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  nil,
+		Stdout: logStreamer,
+		Stderr: os.Stderr,
+	})
+	return logStreamer, err
+}
+
+// CopyFileFromPod is function that copies files from a pod. The parameter takes
+// the kubeconfig in form of a restclient.Config object, the pod name, the namespace of the pod, the filename, and then
+// the local destination (dest) where the file will be copied to.
+func CopyFileFromPod(restConfig *restclient.Config, clientConfig clientcmd.ClientConfig, podName, namespace, filename, dest string) error {
+	restConfig.ContentConfig.NegotiatedSerializer = serializer.NewCodecFactory(k8Scheme.Scheme)
+	restConfig.ContentConfig.GroupVersion = &podGroupVersion
+	restConfig.APIPath = apiPath
+
+	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	copyOptions := cp.NewCopyOptions(ioStreams)
+
+	newClientGett := NewRestGetter(restConfig, clientConfig)
+
+	newFactory := cmdutil.NewFactory(newClientGett)
+	newCobra := &cobra.Command{}
+
+	source := fmt.Sprintf("%s/%s:%s", namespace, podName, filename)
+	err := copyOptions.Complete(newFactory, newCobra, []string{source, dest})
+	if err != nil {
+		return err
+	}
+
+	err = copyOptions.Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/tests/framework/extensions/kubeconfig/restgetter.go
+++ b/tests/framework/extensions/kubeconfig/restgetter.go
@@ -1,0 +1,42 @@
+package kubeconfig
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type RestGetter struct {
+	genericclioptions.RESTClientGetter
+	restConfig   *rest.Config
+	clientConfig clientcmd.ClientConfig
+}
+
+func NewRestGetter(restConfig *rest.Config, clientConfig clientcmd.ClientConfig) *RestGetter {
+	return &RestGetter{
+		restConfig:   restConfig,
+		clientConfig: clientConfig,
+	}
+}
+
+// ToRESTConfig returns restconfig
+func (r *RestGetter) ToRESTConfig() (*rest.Config, error) {
+	return r.restConfig, nil
+}
+
+// ToDiscoveryClient returns discovery client
+func (r *RestGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	return nil, nil
+}
+
+// ToRESTMapper returns a restmapper
+func (r *RestGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	return nil, nil
+}
+
+// ToRawKubeConfigLoader return kubeconfig loader as-is
+func (r *RestGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return r.clientConfig
+}

--- a/tests/framework/extensions/token/create.go
+++ b/tests/framework/extensions/token/create.go
@@ -12,7 +12,8 @@ import (
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 )
 
-// GenerateUserToken is a helper function that generates a bearer token for a specified user
+// GenerateUserToken is a helper function that generates a bearer token for a specified user using the
+// username and password
 func GenerateUserToken(user *management.User, url string) (*management.Token, error) {
 	token := &management.Token{}
 

--- a/tests/framework/pkg/config/config.go
+++ b/tests/framework/pkg/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/creasty/defaults"
@@ -18,7 +17,7 @@ func LoadConfig(key string, config interface{}) {
 		return
 	}
 
-	allString, err := ioutil.ReadFile(configPath)
+	allString, err := os.ReadFile(configPath)
 	if err != nil {
 		panic(err)
 	}
@@ -44,4 +43,41 @@ func LoadConfig(key string, config interface{}) {
 		panic(err)
 	}
 
+}
+
+// UpdateConfig is function that updates the CATTLE_TEST_CONFIG yaml/json that the framework uses.
+func UpdateConfig(key string, config interface{}) {
+	configPath := os.Getenv("CATTLE_TEST_CONFIG")
+
+	if configPath == "" {
+		yaml.Unmarshal([]byte("{}"), config)
+		return
+	}
+
+	// Read json buffer from jsonFile
+	byteValue, err := os.ReadFile(configPath)
+	if err != nil {
+		panic(err)
+	}
+
+	// We have known the outer json object is a map, so we define result as map.
+	// otherwise, result could be defined as slice if outer is an array
+	var result map[string]interface{}
+	err = yaml.Unmarshal(byteValue, &result)
+	if err != nil {
+		panic(err)
+	}
+
+	result[key] = config
+
+	yamlConfig, err := yaml.Marshal(result)
+
+	if err != nil {
+		panic(err)
+	}
+
+	err = os.WriteFile(configPath, yamlConfig, 0644)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/tests/framework/pkg/killserver/killserver.go
+++ b/tests/framework/pkg/killserver/killserver.go
@@ -1,0 +1,47 @@
+package killserver
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	KillServerPort = ":19999"
+)
+
+// KillerServer is struct used to cancel a context of web service, that listens on a specific port.
+type KillServer struct {
+	Server http.Server
+	cancel context.CancelFunc
+}
+
+// NewKillServer initializes a KillServer at a specfic address/port and the cancel context of said web service.
+func NewKillServer(addr string, cancel context.CancelFunc) *KillServer {
+	return &KillServer{
+		Server: http.Server{
+			Addr: addr,
+		},
+		cancel: cancel,
+	}
+}
+
+// Start starts the ListenAndServe of the KillServer server
+func (s *KillServer) Start() {
+	s.Server.Handler = s
+
+	err := s.Server.ListenAndServe()
+	if err != nil {
+		logrus.Errorf("KillServer error: %v", err)
+	}
+}
+
+// ServeHTTP should write reply headers and data to the ResponseWriter
+// and then return.
+func (s *KillServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+
+	// cancel the context
+	s.cancel()
+}

--- a/tests/framework/pkg/session/session.go
+++ b/tests/framework/pkg/session/session.go
@@ -1,7 +1,7 @@
 package session
 
 import (
-	"testing"
+	"github.com/sirupsen/logrus"
 )
 
 // CleanupFunc is the type RegisterCleanupFunc accepts
@@ -12,16 +12,14 @@ type Session struct {
 	CleanupEnabled bool
 	cleanupQueue   []CleanupFunc
 	open           bool
-	TestingT       *testing.T
 }
 
 // NewSession is a constructor instantiates a new `Session`
-func NewSession(t *testing.T) *Session {
+func NewSession() *Session {
 	return &Session{
 		CleanupEnabled: true,
 		cleanupQueue:   []CleanupFunc{},
 		open:           true,
-		TestingT:       t,
 	}
 }
 
@@ -44,7 +42,7 @@ func (ts *Session) Cleanup() {
 		for i := len(ts.cleanupQueue) - 1; i >= 0; i-- {
 			err := ts.cleanupQueue[i]()
 			if err != nil {
-				ts.TestingT.Logf("error calling cleanup function: %v", err)
+				logrus.Errorf("error calling cleanup function: %v", err)
 			}
 		}
 		ts.cleanupQueue = []CleanupFunc{}
@@ -53,7 +51,7 @@ func (ts *Session) Cleanup() {
 
 // NewSession returns a `Session` who's cleanup method is registered with this `Session`
 func (ts *Session) NewSession() *Session {
-	sess := NewSession(ts.TestingT)
+	sess := NewSession()
 
 	ts.RegisterCleanupFunc(func() error {
 		sess.Cleanup()

--- a/tests/integration/suite/conftest.py
+++ b/tests/integration/suite/conftest.py
@@ -39,7 +39,8 @@ def get_ip():
 
 
 IP = get_ip()
-SERVER_URL = 'https://' + IP + ':8443'
+SERVER_URL = os.environ.get('CATTLE_TEST_URL', 'https://' + IP + ':8443')
+SERVER_PASSWORD = os.environ.get('RANCHER_SERVER_PASSWORD', 'admin')
 BASE_URL = SERVER_URL + '/v3'
 AUTH_URL = BASE_URL + '-public/localproviders/local?action=login'
 DEFAULT_TIMEOUT = 120
@@ -101,7 +102,7 @@ def admin_mc():
     """Returns a ManagementContext for the default global admin user."""
     r = requests.post(AUTH_URL, json={
         'username': 'admin',
-        'password': 'admin',
+        'password': SERVER_PASSWORD,
         'responseType': 'json',
     }, verify=False)
     protect_response(r)
@@ -192,7 +193,6 @@ def user_mc(user_factory):
 def user_factory(admin_mc, remove_resource):
     """Returns a factory for creating new users which a ManagementContext for
     a newly created standard user is returned.
-
     This user and globalRoleBinding will be cleaned up automatically by the
     fixture remove_resource.
     """

--- a/tests/integration/suite/test_tokens.py
+++ b/tests/integration/suite/test_tokens.py
@@ -2,7 +2,7 @@ import pytest
 import rancher
 import requests
 import time
-from .conftest import BASE_URL, AUTH_URL, protect_response
+from .conftest import SERVER_PASSWORD, BASE_URL, AUTH_URL, protect_response
 
 
 def test_certificates(admin_mc):
@@ -94,7 +94,7 @@ def test_kubeconfig_token_ttl(admin_mc, user_mc):
 def login():
     r = requests.post(AUTH_URL, json={
         'username': 'admin',
-        'password': 'admin',
+        'password': SERVER_PASSWORD,
         'responseType': 'kubeconfig',
     }, verify=False)
     protect_response(r)

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -3,6 +3,9 @@ envlist = flake8,rancher
 
 [testenv]
 basepython = python3
+passenv =
+    CATTLE_TEST_URL
+    RANCHER_SERVER_PASSWORD
 
 [testenv:flake8]
 deps =

--- a/tests/v2/codecoverage/.gitignore
+++ b/tests/v2/codecoverage/.gitignore
@@ -1,0 +1,7 @@
+/bin
+/package/data.json
+/package/k3s-airgap-images.tar
+/package/rancher
+/package/agent
+*.yaml
+/ranchercover/cover

--- a/tests/v2/codecoverage/Dockerfile.buildcodecoverage
+++ b/tests/v2/codecoverage/Dockerfile.buildcodecoverage
@@ -1,0 +1,14 @@
+FROM registry.suse.com/bci/golang:1.20
+
+# Configure Go
+ENV GOPATH /root/go
+ENV PATH ${PATH}:/root/go/bin
+
+ENV WORKSPACE ${GOPATH}/src/github.com/rancher/rancher
+
+WORKDIR $WORKSPACE
+
+COPY [".", "$WORKSPACE"]
+
+RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables jq
+RUN zypper install -y -f docker && rpm -e --nodeps --noscripts containerd

--- a/tests/v2/codecoverage/Dockerfile.codecoverage
+++ b/tests/v2/codecoverage/Dockerfile.codecoverage
@@ -1,0 +1,22 @@
+FROM registry.suse.com/bci/golang:1.20
+
+# Configure Go
+ENV GOPATH /root/go
+ENV PATH ${PATH}:/root/go/bin
+
+ENV WORKSPACE ${GOPATH}/src/github.com
+
+WORKDIR $WORKSPACE/rancher/rancher
+
+ADD rancherlabs/corral-packages "$WORKSPACE"/rancherlabs/corral-packages
+ADD rancher "$WORKSPACE"/rancher
+ENV CORRAL_VERSION="v1.1.1"
+
+RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables jq
+RUN zypper install -y -f docker && rpm -e --nodeps --noscripts containerd
+RUN zypper install -y python3-tox python3-base python3 libffi-devel libopenssl-devel
+RUN go mod download && \
+    go install gotest.tools/gotestsum@latest && \
+    go install golang.org/x/tools/cmd/cover@latest && \
+    go install github.com/rancherlabs/corral@${CORRAL_VERSION} && \
+    go install github.com/wadey/gocovmerge@latest

--- a/tests/v2/codecoverage/Jenkinsfile_buildcodecoverage
+++ b/tests/v2/codecoverage/Jenkinsfile_buildcodecoverage
@@ -1,0 +1,67 @@
+#!groovy
+node {
+  def workPath = "/root/go/src/github.com/rancher/rancher/tests/v2/codecoverage/"
+  def job_name = "${JOB_NAME}"
+  if (job_name.contains('/')) { 
+    job_names = job_name.split('/')
+    job_name = job_names[job_names.size() - 1] 
+  }
+  def testContainer = "${job_name}${env.BUILD_NUMBER}_test"
+  def imageName = "rancher-code-coverage-image-build-${job_name}${env.BUILD_NUMBER}"
+  def buildDockerContainer = "build-code-cover-docker-container"
+  def envFile = ".env"
+  def rancherConfig = "rancher_env.config"
+  def branch = "release/v2.7"
+  def coverfile = "cover.out"
+  if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
+    branch = "${env.BRANCH}"
+  }
+  def repo = scm.userRemoteConfigs
+  if ("${env.REPO}" != "null" && "${env.REPO}" != "") {
+    repo = [[url: "${env.REPO}"]]
+  }
+  def timeout = "60m"
+  if ("${env.TIMEOUT}" != "null" && "${env.TIMEOUT}" != "") {
+    timeout = "${env.TIMEOUT}" 
+  }
+  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+    withFolderProperties {
+      paramsMap = []
+      params.each {
+        paramsMap << "$it.key=$it.value"
+      }
+      withEnv(paramsMap) {
+        withCredentials([ string(credentialsId: 'RANCHER_TEST_DOCKER_USERNAME', variable: 'RANCHER_TEST_DOCKER_USERNAME'),
+                          string(credentialsId: 'RANCHER_TEST_DOCKER_PASSWORD', variable: 'RANCHER_TEST_DOCKER_PASSWORD')]) {
+          stage('Checkout') {
+            deleteDir()
+            checkout([
+                      $class: 'GitSCM',
+                      branches: [[name: "*/${branch}"]],
+                      extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                      userRemoteConfigs: repo
+                    ])
+          }
+          dir ("/home/jenkins/go/src/github.com/rancher/rancher") {
+            try {
+              stage('Configure and Build') {
+                sh "tests/v2/validation/configure.sh"
+                sh "docker build . -f tests/v2/codecoverage/Dockerfile.buildcodecoverage -t ${goImageName}"
+              }
+              stage('Build Code Coverage Test Image') {
+                sh "docker run -v /var/run/docker.sock:/var/run/docker.sock --name ${buildDockerContainer} -t --env-file ${envFile} " +
+                  "${goImageName} sh -c \"${workPath}scripts/build_test_images.sh;${workPath}scripts/build_docker_images.sh\""
+              }
+            } finally {           
+              stage('Test Report') {
+                sh "docker stop ${testContainer}"
+                sh "docker rm -v ${testContainer}"
+                sh "docker rmi -f ${imageName}"
+              }
+            } // finally
+          } // dir 
+        } // creds
+      } // withEnv 
+    } // folder properties
+  } // wrap
+}// node

--- a/tests/v2/codecoverage/Jenkinsfile_codecoverage
+++ b/tests/v2/codecoverage/Jenkinsfile_codecoverage
@@ -1,0 +1,307 @@
+#!groovy
+node {
+    def rootPath = "/root/go/src/github.com/rancher/rancher/"
+    def workPath = "/root/go/src/github.com/rancher/rancher/tests/v2/codecoverage/"
+    def job_name = "${JOB_NAME}"
+    def code_cover_volume = "CodeCoverageReportTestingSharedVolume"
+
+    if (job_name.contains('/')) { 
+      job_names = job_name.split('/')
+      job_name = job_names[job_names.size() - 1] 
+    }
+    def integrationTestContainer = "integration-test-container"
+    def codeCoverTestContainer = "code-cover-test-container"
+    def golangTestContainer = "golang-setup-test"
+    def golangUnitTestContainer = "golang-unit-test"
+    def pythonTestContainer = "python-integration-test"
+    def cleanupContainer = "code-cover-cleanup"
+    def goImageName = "rancher-code-coverage-${job_name}"
+    def envFile = ".env"
+    def codeCoverageDir = "github.com/rancher/rancher/tests/v2/codecoverage/ranchercover"
+    def codeCoverageTest = "-run TestRetrieveCoverageReports"
+    def rancherConfig = "rancher_env.config"
+    def branch = "release/v2.7"
+    def unitTestCoverfile = "unittestcover.out"
+    def unitTestHTMLfile = "coverage.html"
+    def coverDir = "cover/"
+    def mergedCovFile = "profile.txt"
+    def mergedHTMLFile = "merged.html"
+    def cleanupYaml = "initalvalue"
+    def configYaml = "initalvalue"
+    def provisioningYaml = "initalvalue"
+
+    if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
+      branch = "${env.BRANCH}"
+    }
+    def repo = scm.userRemoteConfigs
+    if ("${env.REPO}" != "null" && "${env.REPO}" != "") {
+      repo = [[url: "${env.REPO}"]]
+    }
+    def timeout = "6h45m"
+    if ("${env.TIMEOUT}" != "null" && "${env.TIMEOUT}" != "") {
+      timeout = "${env.TIMEOUT}" 
+    }
+    wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+      withFolderProperties {
+        paramsMap = []
+        params.each {
+          paramsMap << "$it.key=$it.value"
+        }
+        withEnv(paramsMap) {
+        withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                          string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+                          string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'RANCHER_EKS_ACCESS_KEY'),
+                          string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'RANCHER_EKS_SECRET_KEY'),
+                          string(credentialsId: 'DO_ACCESSKEY', variable: 'DO_ACCESSKEY'),
+                          string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                          string(credentialsId: 'RANCHER_SSH_KEY', variable: 'RANCHER_SSH_KEY'),
+                          string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                          string(credentialsId: 'AZURE_TENANT_ID', variable: 'AZURE_TENANT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_ID', variable: 'AZURE_CLIENT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'AZURE_CLIENT_SECRET'),
+                          string(credentialsId: 'AZURE_AKS_SUBSCRIPTION_ID', variable: 'RANCHER_AKS_SUBSCRIPTION_ID'),
+                          string(credentialsId: 'AZURE_TENANT_ID', variable: 'RANCHER_AKS_TENANT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_ID', variable: 'RANCHER_AKS_CLIENT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'RANCHER_AKS_SECRET_KEY'),
+                          string(credentialsId: 'RANCHER_REGISTRY_USER_NAME', variable: 'RANCHER_REGISTRY_USER_NAME'),
+                          string(credentialsId: 'RANCHER_REGISTRY_PASSWORD', variable: 'RANCHER_REGISTRY_PASSWORD'),
+                          string(credentialsId: 'RANCHER_AD_SPECIAL_CHAR_PASSWORD', variable: 'RANCHER_AD_SPECIAL_CHAR_PASSWORD'),
+                          string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                          string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_GKE_CREDENTIAL', variable: 'RANCHER_GKE_CREDENTIAL'),
+                          string(credentialsId: 'RANCHER_AUTH_USER_PASSWORD', variable: 'RANCHER_AUTH_USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_HOSTNAME_OR_IP_ADDRESS', variable: 'RANCHER_HOSTNAME_OR_IP_ADDRESS'),
+                          string(credentialsId: 'RANCHER_CA_CERTIFICATE', variable: 'RANCHER_CA_CERTIFICATE'),
+                          string(credentialsId: 'RANCHER_SERVICE_ACCOUNT_NAME', variable: 'RANCHER_SERVICE_ACCOUNT_NAME'),
+                          string(credentialsId: 'RANCHER_SERVICE_ACCOUNT_PASSWORD', variable: 'RANCHER_SERVICE_ACCOUNT_PASSWORD'),
+                          string(credentialsId: 'RANCHER_USER_SEARCH_BASE', variable: 'RANCHER_USER_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_DEFAULT_LOGIN_DOMAIN', variable: 'RANCHER_DEFAULT_LOGIN_DOMAIN'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_NAME', variable: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_NAME'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_PASSWORD', variable: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_PASSWORD'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_USER_SEARCH_BASE', variable: 'RANCHER_OPENLDAP_USER_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_AUTH_USER_PASSWORD', variable: 'RANCHER_OPENLDAP_AUTH_USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_HOSTNAME_OR_IP_ADDRESS', variable: 'RANCHER_OPENLDAP_HOSTNAME_OR_IP_ADDRESS'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_SPECIAL_CHAR_PASSWORD', variable: 'RANCHER_OPENLDAP_SPECIAL_CHAR_PASSWORD'),
+                          string(credentialsId: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_NAME', variable: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_NAME'),
+                          string(credentialsId: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_PASSWORD', variable: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_PASSWORD'),
+                          string(credentialsId: 'RANCHER_FREEIPA_USER_SEARCH_BASE', variable: 'RANCHER_FREEIPA_USER_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_FREEIPA_GROUP_SEARCH_BASE', variable: 'RANCHER_FREEIPA_GROUP_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_FREEIPA_AUTH_USER_PASSWORD', variable: 'RANCHER_FREEIPA_AUTH_USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_FREEIPA_HOSTNAME_OR_IP_ADDRESS', variable: 'RANCHER_FREEIPA_HOSTNAME_OR_IP_ADDRESS'),
+                          string(credentialsId: 'RANCHER_FREEIPA_SPECIAL_CHAR_PASSWORD', variable: 'RANCHER_FREEIPA_SPECIAL_CHAR_PASSWORD'),
+                          string(credentialsId: 'RANCHER_VALID_TLS_CERT', variable: 'RANCHER_VALID_TLS_CERT'),
+                          string(credentialsId: 'RANCHER_VALID_TLS_KEY', variable: 'RANCHER_VALID_TLS_KEY'),
+                          string(credentialsId: 'RANCHER_BYO_TLS_CERT', variable: 'RANCHER_BYO_TLS_CERT'),
+                          string(credentialsId: 'RANCHER_BYO_TLS_KEY', variable: 'RANCHER_BYO_TLS_KEY'),
+                          string(credentialsId: 'RANCHER_LINODE_ACCESSKEY', variable: "RANCHER_LINODE_ACCESSKEY")]) {
+
+          stage('Checkout') {
+            deleteDir()
+            checkout([
+                      $class: 'GitSCM',
+                      branches: [[name: "*/${branch}"]],
+                      extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                      userRemoteConfigs: repo
+                    ])
+          }
+          dir('/home/jenkins/go/src/github.com/rancherlabs') {
+              echo "cloning corral-packages repo"
+              sh "git clone https://github.com/rancherlabs/corral-packages.git"
+          }
+          dir ("/home/jenkins/go/src/github.com/") {
+            try {
+              stage('Configure and Build') {
+                sh "docker volume rm -f ${code_cover_volume}"
+                if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
+                  dir("./rancher/rancher/tests/validation/.ssh") {
+                    def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
+                    writeFile file: AWS_SSH_KEY_NAME, text: decoded
+                  }
+                }
+                dir("./rancher/rancher/tests/v2/codecoverage") {
+                  def filename = "config.yaml"
+                  def configContents = env.CONFIG
+
+                  writeFile file: filename, text: configContents
+                  env.CATTLE_TEST_CONFIG = workPath+filename
+                }
+                sh "rancher/rancher/tests/v2/validation/configure.sh"
+                sh "docker build . -f rancher/rancher/tests/v2/codecoverage/Dockerfile.codecoverage -t ${goImageName}"
+                sh "docker volume create --name ${code_cover_volume}"
+              }
+              stage('Run Unit Tests') {
+                sh "docker run --name ${golangUnitTestContainer} -t " +
+                  "${goImageName} sh -c \"go test -coverprofile ${unitTestCoverfile} -tags=test ${rootPath}pkg/..." +
+                  ";go tool cover -func ${unitTestCoverfile} | grep \"total\";go tool cover -html ${unitTestCoverfile} -o ${unitTestHTMLfile}\""
+              }
+              stage('Setup Enviornment') {
+                sh "docker run -v ${code_cover_volume}:/root --name ${golangTestContainer} -t --env-file ${envFile} " +
+                  "${goImageName} sh -c \"${workPath}scripts/setup_code_coverage_enviornment.sh\""
+                dir("./rancher/rancher/tests/v2/codecoverage") {
+                  sh "rm config.yaml"
+                  sh "docker cp ${golangTestContainer}:${workPath}config.yaml ./"
+                  sh "cp config.yaml cleanupconfig.yaml"
+                  sh "cp config.yaml provisioningconfig.yaml"
+                }
+  
+                dir("./rancher/rancher/tests/v2/codecoverage/scripts") {
+                  sh "docker cp ${golangTestContainer}:${rootPath}userclusterconfig.yaml ./"
+                  sh ". ./download_yq.sh"
+                  env.RANCHER_CLUSTER0 = sh (
+                      script: './yq ".userClusterConfig.clusters.[0]" ./userclusterconfig.yaml',
+                      returnStdout: true
+                  )
+                  env.RANCHER_CLUSTER1 = sh (
+                      script: './yq ".userClusterConfig.clusters.[1]" ./userclusterconfig.yaml',
+                      returnStdout: true
+                  )
+                  env.USER_TOKEN = sh (
+                      script: './yq ".userClusterConfig.token" ./userclusterconfig.yaml',
+                      returnStdout: true
+                  )
+                  env.ADMIN_TOKEN = sh (
+                      script: './yq ".rancher.adminToken" ../config.yaml',
+                      returnStdout: true
+                  )
+                  env.RANCHER_SERVER_PASSWORD = sh (
+                      script: './yq ".userClusterConfig.bootStrapPassword" ./userclusterconfig.yaml',
+                      returnStdout: true
+                  )
+                  sh "./yq e '.rancher.cleanup = true' -i ../cleanupconfig.yaml"
+                  sh "./yq e '.provisioningInput.providers = [\"aws\"]' -i ../provisioningconfig.yaml"
+                }
+
+                env.CATTLE_TEST_CONFIG = "${workPath}cleanupconfig.yaml"
+                dir("./rancher/rancher/tests/v2/codecoverage") {
+                  sh "docker cp ./cleanupconfig.yaml ${golangTestContainer}:${workPath}cleanupconfig.yaml"
+                  cleanupYaml = readFile(file: './cleanupconfig.yaml')
+                  configYaml = readFile(file: './config.yaml')
+                  provisioningYaml = readFile(file: './provisioningconfig.yaml')
+                }
+                
+                sh "rm ${envFile}"
+                sh "rancher/rancher/tests/v2/validation/configure.sh"
+              }
+
+              stage ('Run Go Integration Tests') {
+                try {
+                  sh "docker run --volumes-from ${golangTestContainer} --name ${integrationTestContainer} -t --env-file ${envFile} " +
+                  "${goImageName} sh -c \"go test -v -tags=test ${rootPath}tests/v2/integration/...\""
+                } catch(err) {
+                    echo "Go Integration tests had failures."
+                }
+              }
+              stage('Execute Subjobs') {
+                try {
+                  jobs = [:]
+                  goProvisioningParams = [ string(name: 'TIMEOUT', value: "5h"),
+                                  text(name: 'CONFIG', value: configYaml),
+                                  string(name: 'REPO', value: "https://github.com/rancher/rancher.git"),
+                                  string(name: 'BRANCH', value: "release/v2.6"),
+                                  string(name: 'TEST_PACKAGE', value: "provisioning/..."),
+                                  string(name: 'GOTEST_TESTCASE', value: "${GO_PROVISIONING_TEST_CASES}") ]
+
+                  goExtendedProvisioningParams = [ string(name: 'TIMEOUT', value: "5h"),
+                                  text(name: 'CONFIG', value: provisioningYaml),
+                                  string(name: 'REPO', value: "https://github.com/rancher/rancher.git"),
+                                  string(name: 'BRANCH', value: "release/v2.6"),
+                                  string(name: 'TEST_PACKAGE', value: "provisioning/..."),
+                                  string(name: 'GOTEST_TESTCASE', value: "${GO_EXTEND_PROVISIONING_TEST_CASES}") ]
+
+                  goValidationParams = [ string(name: 'TIMEOUT', value: "1h"),
+                                  text(name: 'CONFIG', value: cleanupYaml),
+                                  string(name: 'REPO', value: "https://github.com/rancher/rancher.git"),
+                                  string(name: 'BRANCH', value: "release/v2.6"),
+                                  string(name: 'TEST_PACKAGE', value: "..."),
+                                  string(name: 'GOTEST_TESTCASE', value: "${GO_VALIDATION_TEST_CASES} -p 1") ]
+
+                  pythonParam0 = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"),
+                              string(name: 'ADMIN_TOKEN', value: env.ADMIN_TOKEN),
+                              string(name: 'USER_TOKEN', value: env.USER_TOKEN),
+                              string(name: 'PYTEST_OPTIONS', value: "${PYTEST_OPTIONS}"),
+                              string(name: 'RANCHER_CLUSTER_NAME', value: env.RANCHER_CLUSTER0) ]
+
+                  pythonParam1 = [ string(name: 'CATTLE_TEST_URL', value: "${CATTLE_TEST_URL}"),
+                              string(name: 'ADMIN_TOKEN', value: env.ADMIN_TOKEN),
+                              string(name: 'USER_TOKEN', value: env.USER_TOKEN),
+                              string(name: 'PYTEST_OPTIONS', value: "${PYTEST_OPTIONS_ADDITIONAL}"),
+                              string(name: 'RANCHER_CLUSTER_NAME', value: env.RANCHER_CLUSTER1) ]
+                  // Go provisioning base tests
+                  jobs["go-provisioning"] = { build job: 'go-automation-freeform-job', parameters: goProvisioningParams }
+                  // Go provisioning tests
+                  jobs["go-extent-provisioning"] = { build job: 'go-automation-freeform-job', parameters: goExtendedProvisioningParams }
+                  // Go charts tests
+                  jobs["go-validations"] = { build job: 'go-automation-freeform-job', parameters: goValidationParams }
+                  // python cluster tests
+                  jobs["python-cluster-test"] = { build job: 'rancher-v3_needs_cluster', parameters: pythonParam0}
+                  // python additional tests
+                  jobs["python-additional-cluster-test"] = { build job: 'rancher-v3_needs_cluster', parameters: pythonParam1}
+                  parallel jobs
+                } catch(err) {
+                    echo "Validation SubJobs had failures ${err}"
+                }
+
+              }
+              stage ('Run Python Integration Tests') {
+                try {
+                  sh "docker run --name ${pythonTestContainer} --env-file ${envFile} " +
+                  "${goImageName} /bin/bash -c \'cd ${rootPath}tests/integration;tox -e rancher -- -m \"not nonparallel\" -n 8;tox -e rancher -- -m nonparallel\'"
+                } catch(err) {
+                  echo "Python Integration tests had failures."
+                }
+              }
+              stage("Code Coverage Report") {
+                sh "docker run --volumes-from ${golangTestContainer} --name ${codeCoverTestContainer} -t --env-file ${envFile} " +
+                "${goImageName} sh -c \"gotestsum --format standard-verbose --packages=${codeCoverageDir} -- ${codeCoverageTest} -timeout=${timeout} -v;cd ${workPath}scripts; . ./merge_coverage_reports.sh\""
+              }
+            } finally {           
+              stage('Test Report') {
+                sh "docker run --volumes-from ${golangTestContainer} --name ${cleanupContainer} -t --env-file ${envFile} " +
+                  "${goImageName} sh -c \"${workPath}bin/ranchercleanup\""
+                sh "docker stop ${golangTestContainer}"
+                sh "docker rm -v ${golangTestContainer}"
+
+                sh "docker stop ${cleanupContainer}"
+                sh "docker rm -v ${cleanupContainer}"
+
+                sh "docker stop ${integrationTestContainer}"
+                sh "docker rm -v ${integrationTestContainer}"
+
+                sh "docker stop ${pythonTestContainer}"
+                sh "docker rm -v ${pythonTestContainer}"
+
+                sh "docker cp ${codeCoverTestContainer}:${workPath}ranchercover/${coverDir}${mergedCovFile} ."
+                sh "docker cp ${codeCoverTestContainer}:${workPath}ranchercover/${coverDir}${mergedHTMLFile} ."
+                archiveArtifacts(artifacts: "**/${mergedCovFile}",
+                                  allowEmptyArchive: true,
+                                  fingerprint: true,
+                                  onlyIfSuccessful: true)
+
+                sh "docker cp ${golangUnitTestContainer}:${rootPath}${unitTestCoverfile} ."
+                sh "docker cp ${golangUnitTestContainer}:${rootPath}${unitTestHTMLfile} ."
+                archiveArtifacts(artifacts: "**/${unitTestCoverfile}",
+                                  allowEmptyArchive: true,
+                                  fingerprint: true,
+                                  onlyIfSuccessful: true)
+                // publishHTML (target: [
+                //       allowMissing: false,
+                //       alwaysLinkToLastBuild: true,
+                //       keepAll: true,
+                //       reportDir: ".",
+                //       reportFiles: mergedHTMLFile,
+                //       reportName: "Single-click Code Coverage Test Results"
+                //     ])
+                sh "docker stop ${golangUnitTestContainer}"
+                sh "docker rm -v ${golangUnitTestContainer}"
+                sh "docker stop ${codeCoverTestContainer}"
+                sh "docker rm -v ${codeCoverTestContainer}"
+                sh "docker rmi -f ${goImageName}"
+                sh "docker volume rm -f ${code_cover_volume}"
+              } // test report
+            } // finally
+          } // dir 
+        } // creds
+      } // withEnv
+    }  // folder properties
+  } // wrap
+}// node

--- a/tests/v2/codecoverage/agent/main.go
+++ b/tests/v2/codecoverage/agent/main.go
@@ -1,0 +1,629 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/hashicorp/go-multierror"
+	"github.com/mattn/go-colorable"
+	"github.com/rancher/rancher/pkg/agent/clean"
+	"github.com/rancher/rancher/pkg/agent/cluster"
+	"github.com/rancher/rancher/pkg/agent/node"
+	"github.com/rancher/rancher/pkg/agent/rancher"
+	"github.com/rancher/rancher/pkg/features"
+	"github.com/rancher/rancher/pkg/logserver"
+	"github.com/rancher/rancher/pkg/rkenodeconfigclient"
+	"github.com/rancher/rancher/pkg/rkenodeconfigserver"
+	"github.com/rancher/rancher/tests/framework/pkg/killserver"
+	"github.com/rancher/remotedialer"
+	"github.com/rancher/wrangler/pkg/signals"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	VERSION = "dev"
+)
+
+const (
+	Token                    = "X-API-Tunnel-Token"
+	KubeletCertValidityLimit = time.Hour * 72
+)
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	killServer := killserver.NewKillServer(killserver.KillServerPort, cancel)
+
+	go killServer.Start()
+	go runAgent(ctx)
+	<-ctx.Done()
+}
+
+func runAgent(ctx context.Context) {
+	var err error
+
+	if len(os.Args) > 1 {
+		err = runArgs(ctx)
+	} else {
+		if _, err = reconcileKubelet(ctx); err != nil {
+			logrus.Warnf("failed to reconcile kubelet, error: %v", err)
+		}
+
+		logrus.SetOutput(colorable.NewColorableStdout())
+		logserver.StartServerWithDefaults()
+		if os.Getenv("CATTLE_DEBUG") == "true" || os.Getenv("RANCHER_DEBUG") == "true" {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+
+		initFeatures()
+
+		if os.Getenv("CLUSTER_CLEANUP") == "true" {
+			err = clean.Cluster()
+		} else if os.Getenv("BINDING_CLEANUP") == "true" {
+			var bindingErr error
+			err = clean.DuplicateBindings(nil)
+			if err != nil {
+				bindingErr = multierror.Append(bindingErr, err)
+			}
+			err = clean.OrphanBindings(nil)
+			if err != nil {
+				bindingErr = multierror.Append(bindingErr, err)
+			}
+			err = clean.OrphanCatalogBindings(nil)
+			if err != nil {
+				bindingErr = multierror.Append(bindingErr, err)
+			}
+			err = bindingErr
+		} else {
+			err = run(ctx)
+		}
+	}
+
+	if err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func runArgs(ctx context.Context) error {
+	switch os.Args[1] {
+	case "clean":
+		return clean.Run(ctx, os.Args)
+	default:
+		return run(ctx)
+	}
+}
+
+func initFeatures() {
+	features.InitializeFeatures(nil, os.Getenv("CATTLE_FEATURES"))
+}
+
+func isCluster() bool {
+	return os.Getenv("CATTLE_CLUSTER") == "true"
+}
+
+func getParams() (map[string]interface{}, error) {
+	if isCluster() {
+		return cluster.Params()
+	}
+	return node.Params(), nil
+}
+
+func getTokenAndURL() (string, string, error) {
+	token, url, err := node.TokenAndURL()
+	if err != nil {
+		return "", "", err
+	}
+	if token == "" {
+		return cluster.TokenAndURL()
+	}
+	return token, url, nil
+}
+
+func isConnect() bool {
+	if os.Getenv("CATTLE_AGENT_CONNECT") == "true" {
+		return true
+	}
+	_, err := os.Stat("connected")
+	return err == nil
+}
+
+func connected() {
+	f, err := os.Create("connected")
+	if err != nil {
+		f.Close()
+	}
+}
+
+func cleanup(ctx context.Context) error {
+	if os.Getenv("CATTLE_K8S_MANAGED") != "true" {
+		return nil
+	}
+
+	c, err := client.NewClientWithOpts(client.WithAPIVersionNegotiation(), client.FromEnv)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	args := filters.NewArgs()
+	args.Add("label", "io.cattle.agent=true")
+
+	containers, err := c.ContainerList(ctx, types.ContainerListOptions{
+		All:     true,
+		Filters: args,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, container := range containers {
+		if _, ok := container.Labels["io.kubernetes.pod.namespace"]; ok {
+			continue
+		}
+
+		if strings.Contains(container.Names[0], "share-mnt") {
+			continue
+		}
+
+		container := container
+		go func() {
+			time.Sleep(15 * time.Second)
+			logrus.Infof("Removing unmanaged agent %s(%s)", container.Names[0], container.ID)
+			c.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{
+				Force: true,
+			})
+		}()
+	}
+
+	return nil
+}
+
+func run(ctx context.Context) error {
+	topContext := signals.SetupSignalContext()
+
+	logrus.Infof("Rancher agent version %s is starting", VERSION)
+	params, err := getParams()
+	if err != nil {
+		return err
+	}
+	writeCertsOnly := os.Getenv("CATTLE_WRITE_CERT_ONLY") == "true"
+	bytes, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+
+	token, server, err := getTokenAndURL()
+	if err != nil {
+		return err
+	}
+
+	headers := http.Header{
+		Token:                      {token},
+		rkenodeconfigclient.Params: {base64.StdEncoding.EncodeToString(bytes)},
+	}
+
+	err = KubeletNeedsNewCertificate(headers)
+	if err != nil {
+		return err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return err
+	}
+
+	// Check if secure connection can be made successfully
+	var httpClient = &http.Client{
+		Timeout: time.Second * 5,
+	}
+
+	_, err = httpClient.Get(server)
+	if err != nil {
+		if strings.Contains(err.Error(), "x509:") {
+			certErr := err
+			if strings.Contains(err.Error(), "certificate signed by unknown authority") {
+				certErr = fmt.Errorf("Certificate chain is not complete, please check if all needed intermediate certificates are included in the server certificate (in the correct order) and if the cacerts setting in Rancher either contains the correct CA certificate (in the case of using self signed certificates) or is empty (in the case of using a certificate signed by a recognized CA). Certificate information is displayed above. error: %s", err)
+			}
+			if strings.Contains(err.Error(), "certificate has expired or is not yet valid") {
+				certErr = fmt.Errorf("Server certificate is not valid, please check if the host has the correct time configured and if the server certificate has a notAfter date and time in the future. Certificate information is displayed above. error: %s", err)
+			}
+			if strings.Contains(err.Error(), "because it doesn't contain any IP SANs") || strings.Contains(err.Error(), "certificate is not valid for any names, but wanted to match") || strings.Contains(err.Error(), "cannot validate certificate for") {
+				certErr = fmt.Errorf("Server certificate does not contain correct DNS and/or IP address entries in the Subject Alternative Names (SAN). Certificate information is displayed above. error: %s", err)
+			}
+			insecureClient := &http.Client{
+				Timeout: time.Second * 5,
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true,
+					},
+				},
+			}
+			res, err := insecureClient.Get(server)
+			if err != nil {
+				logrus.Errorf("Could not connect to %s: %v", server, err)
+				os.Exit(1)
+			}
+			var lastFoundIssuer string
+			if res.TLS != nil && len(res.TLS.PeerCertificates) > 0 {
+				logrus.Infof("Certificate details from %s", serverURL)
+				var previouscert *x509.Certificate
+				for i := range res.TLS.PeerCertificates {
+					cert := res.TLS.PeerCertificates[i]
+					logrus.Infof("Certificate #%d (%s)", i, serverURL)
+					certinfo(cert)
+					if i > 0 {
+						if previouscert.Issuer.String() != cert.Subject.String() {
+							logrus.Errorf("Certficate's Subject (%s) does not match with previous certificate Issuer (%s). Please check if the configured server certificate contains all needed intermediate certificates and make sure they are in the correct order (server certificate first, intermediates after)", cert.Subject.String(), previouscert.Issuer.String())
+						}
+					}
+					previouscert = cert
+					lastFoundIssuer = cert.Issuer.String()
+				}
+			}
+			caFileLocation := "/etc/kubernetes/ssl/certs/serverca"
+			if _, err := os.Stat(caFileLocation); err == nil {
+				caFile, err := ioutil.ReadFile(caFileLocation)
+				if err != nil {
+					return err
+				}
+				var blocks [][]byte
+				for {
+					var certDERBlock *pem.Block
+					certDERBlock, caFile = pem.Decode(caFile)
+					if certDERBlock == nil {
+						break
+					}
+
+					if certDERBlock.Type == "CERTIFICATE" {
+						blocks = append(blocks, certDERBlock.Bytes)
+					}
+				}
+				if len(blocks) > 1 {
+					logrus.Warnf("Found %d certificates at %s, should be 1", len(blocks), caFileLocation)
+				}
+				logrus.Infof("Certificate details for %s", caFileLocation)
+
+				blockcount := 0
+				var lastCACert *x509.Certificate
+				for _, block := range blocks {
+					cert, err := x509.ParseCertificate(block)
+					if err != nil {
+						logrus.Println(err)
+						continue
+					}
+
+					logrus.Infof("Certificate #%d (%s)", blockcount, caFileLocation)
+					certinfo(cert)
+
+					blockcount = blockcount + 1
+					lastCACert = cert
+				}
+				if lastFoundIssuer != lastCACert.Issuer.String() {
+					logrus.Errorf("Issuer of last certificate found in chain (%s) does not match with CA certificate Issuer (%s). Please check if the configured server certificate contains all needed intermediate certificates and make sure they are in the correct order (server certificate first, intermediates after)", lastFoundIssuer, lastCACert.Issuer.String())
+				}
+			}
+			return certErr
+		}
+	}
+
+	onConnect := func(ctx context.Context, _ *remotedialer.Session) error {
+		connected()
+		connectConfig := fmt.Sprintf("https://%s/v3/connect/config", serverURL.Host)
+		interval, err := rkenodeconfigclient.ConfigClient(ctx, connectConfig, headers, writeCertsOnly)
+		if err != nil {
+			return err
+		}
+
+		if writeCertsOnly {
+			exitCertWriter(ctx)
+		}
+
+		if isCluster() {
+			err = rancher.Run(topContext)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+			return nil
+		}
+
+		if err := cleanup(context.Background()); err != nil {
+			logrus.Warnf("Unable to perform docker cleanup: %v", err)
+		}
+
+		go func() {
+			logrus.Infof("Starting plan monitor, checking every %v seconds", interval)
+			tt := time.Duration(interval) * time.Second
+			for {
+				select {
+				case <-time.After(tt):
+					// each time we request a plan we should
+					// check if our cert about to expire
+					err = KubeletNeedsNewCertificate(headers)
+					if err != nil {
+						logrus.Errorf("failed to check validity of kubelet certs: %v", err)
+					}
+					receivedInterval, err := rkenodeconfigclient.ConfigClient(ctx, connectConfig, headers, writeCertsOnly)
+					if err != nil {
+						logrus.Errorf("failed to check plan: %v", err)
+					} else if receivedInterval != 0 && receivedInterval != interval {
+						tt = time.Duration(receivedInterval) * time.Second
+						logrus.Infof("Plan monitor checking %v seconds", receivedInterval)
+					}
+
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+
+		return nil
+	}
+
+	if isCluster() {
+		go func() {
+			log.Println(http.ListenAndServe("localhost:6060", nil))
+		}()
+	}
+
+	for {
+		wsURL := fmt.Sprintf("wss://%s/v3/connect", serverURL.Host)
+		if !isConnect() {
+			wsURL += "/register"
+		}
+
+		// check if we need a new kubelet cert on reconnection
+		err = KubeletNeedsNewCertificate(headers)
+		if err != nil {
+			return err
+		}
+
+		logrus.Infof("Connecting to %s with token starting with %s", wsURL, token[:len(token)/2])
+		logrus.Tracef("Connecting to %s with token %s", wsURL, token)
+		remotedialer.ClientConnect(ctx, wsURL, headers, nil, func(proto, address string) bool {
+			switch proto {
+			case "tcp":
+				return true
+			case "unix":
+				return address == "/var/run/docker.sock"
+			case "npipe":
+				return address == "//./pipe/docker_engine"
+			}
+			return false
+		}, onConnect)
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func exitCertWriter(ctx context.Context) {
+	// share-mnt process needs an always restart policy and to be killed so it can restart on startup
+	// this functionality is really only needed for OSes with ephemeral /etc like RancherOS
+	// everything here will just exit(0) with errors as we need to bail out completely.
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGTERM)
+	// trap SIGTERM here so that container can exit with 0
+	go func() {
+		<-sigs
+		os.Exit(0)
+	}()
+
+	logrus.Info("attempting to stop the share-mnt container so it can reboot on startup")
+	c, err := client.NewClientWithOpts(client.WithAPIVersionNegotiation(), client.FromEnv)
+	if err != nil {
+		logrus.Error(err)
+		os.Exit(0)
+	}
+
+	args := filters.NewArgs()
+	args.Add("label", "io.rancher.rke.container.name=share-mnt")
+	containers, err := c.ContainerList(ctx, types.ContainerListOptions{
+		All:     true,
+		Filters: args,
+	})
+	if err != nil {
+		logrus.Error(err)
+		os.Exit(0)
+	}
+
+	for _, container := range containers {
+		if len(container.Names) > 0 && strings.Contains(container.Names[0], "share-mnt") {
+			err := c.ContainerKill(ctx, container.ID, "SIGTERM")
+			if err != nil {
+				logrus.Error(err)
+				os.Exit(0) // only need to write certs so exit cleanly
+			}
+		}
+	}
+	// wait for itself to be kill with SIGTERM so it can return exit 0
+	select {}
+}
+
+func certinfo(cert *x509.Certificate) {
+	logrus.Infof("Subject: %+v", cert.Subject)
+	logrus.Infof("Issuer: %+v", cert.Issuer)
+	logrus.Infof("IsCA: %+v", cert.IsCA)
+	if len(cert.DNSNames) > 0 {
+		logrus.Infof("DNS Names: %+v", cert.DNSNames)
+	} else {
+		logrus.Infof("DNS Names: <none>")
+	}
+	if len(cert.IPAddresses) > 0 {
+		logrus.Infof("IPAddresses: %+v", cert.IPAddresses)
+	} else {
+		logrus.Info("IPAddresses: <none>")
+	}
+	logrus.Infof("NotBefore: %+v", cert.NotBefore)
+	logrus.Infof("NotAfter: %+v", cert.NotAfter)
+	logrus.Infof("SignatureAlgorithm: %+v", cert.SignatureAlgorithm)
+	logrus.Infof("PublicKeyAlgorithm: %+v", cert.PublicKeyAlgorithm)
+}
+
+// reconcileKubelet restarts kubelet in unmanaged agents
+func reconcileKubelet(ctx context.Context) (bool, error) {
+	if os.Getenv("CATTLE_K8S_MANAGED") == "true" {
+		return true, nil
+	}
+
+	writeCertsOnly := os.Getenv("CATTLE_WRITE_CERT_ONLY") == "true"
+	if writeCertsOnly {
+		return true, nil
+	}
+
+	c, err := client.NewClientWithOpts(client.WithAPIVersionNegotiation(), client.FromEnv)
+	if err != nil {
+		return false, err
+	}
+	defer c.Close()
+
+	args := filters.NewArgs()
+	args.Add("label", "io.rancher.rke.container.name=kubelet")
+
+	containers, err := c.ContainerList(ctx, types.ContainerListOptions{
+		All:     true,
+		Filters: args,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	for _, container := range containers {
+		if len(container.Names) > 0 && strings.Contains(container.Names[0], "kubelet") {
+			nodeName := os.Getenv("CATTLE_NODE_NAME")
+			logrus.Infof("node %v is not registered, restarting kubelet now", nodeName)
+			if err := c.ContainerRestart(ctx, container.ID, nil); err != nil {
+				return false, err
+			}
+			break
+		}
+	}
+	return false, nil
+}
+
+// KubeletNeedsNewCertificate will set the
+// 'RegenerateKubeletCertificate' header field to true if
+// a) the kubelet serving certificate does not exist
+// b) the certificate will expire in 72 hours
+// c) the certificate does not accurately represent the
+//
+//	current IP address and Hostname of the node
+//
+// While the agent may denote it needs a new kubelet certificate
+// in its connection request, a new certificate will only be
+// delivered by Rancher if the generate_serving_certificate property
+// is set to 'true' for the clusters kubelet service.
+func KubeletNeedsNewCertificate(headers http.Header) error {
+	currentHostname := os.Getenv("CATTLE_NODE_NAME")
+
+	// RKE will save the certs on the node using either the public or private IP address, depending on the infrastructure provider.
+	// For example, the certs will be stored using the public IP address for VM's on digital ocean, but will use the private IP
+	// address for VM's on AWS. We do not know which IP address RKE decided to use, so we need to check both locations.
+	kubeletCertFile, kubeletCertKeyFile, ipAddress := findCertificateFiles(os.Getenv("CATTLE_ADDRESS"), os.Getenv("CATTLE_INTERNAL_ADDRESS"))
+	if kubeletCertFile == "" || kubeletCertKeyFile == "" || ipAddress == "" {
+		logrus.Tracef("did not find kubelet certificate files using either public ip address (%s) or private ip address (%s)", os.Getenv("CATTLE_ADDRESS"), os.Getenv("CATTLE_INTERNAL_ADDRESS"))
+	}
+
+	cert, err := tls.LoadX509KeyPair(kubeletCertFile, kubeletCertKeyFile)
+	if err != nil && !strings.Contains(err.Error(), "no such file") {
+		return err
+	}
+
+	needsRegen, err := KubeletCertificateNeedsRegeneration(ipAddress, currentHostname, cert, time.Now())
+	if err != nil {
+		return err
+	}
+
+	if needsRegen {
+		headers.Set(rkenodeconfigserver.RegenerateKubeletCertificate, "true")
+	} else {
+		headers.Set(rkenodeconfigserver.RegenerateKubeletCertificate, "false")
+	}
+
+	return nil
+}
+
+func findCertificateFiles(IPAddresses ...string) (string, string, string) {
+	for _, ip := range IPAddresses {
+		fileSafeIPAddress := strings.ReplaceAll(ip, ".", "-")
+		certFile := fmt.Sprintf("/etc/kubernetes/ssl/kube-kubelet-%s.pem", fileSafeIPAddress)
+		certKeyFile := fmt.Sprintf("/etc/kubernetes/ssl/kube-kubelet-%s-key.pem", fileSafeIPAddress)
+		_, certErr := os.Stat(certFile)
+		_, keyErr := os.Stat(certKeyFile)
+		// check that both files exist
+		if certErr == nil && keyErr == nil {
+			return certFile, certKeyFile, ip
+		}
+	}
+	return "", "", ""
+}
+
+func KubeletCertificateNeedsRegeneration(ipAddress, currentHostname string, cert tls.Certificate, currentTime time.Time) (bool, error) {
+	if len(cert.Certificate) == 0 {
+		return true, nil
+	}
+
+	parsedCert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return false, err
+	}
+
+	if !CertificateIncludesHostname(currentHostname, parsedCert) {
+		logrus.Tracef("certificate does not include current hostname, requesting new certificate")
+		return true, nil
+	}
+
+	if CertificateIsExpiring(parsedCert, currentTime) {
+		logrus.Tracef("certificate is expiring soon, requesting new certificate")
+		return true, nil
+	}
+
+	if !CertificateIncludesCurrentIP(ipAddress, parsedCert) {
+		logrus.Tracef("certificate does not include current IP address, requesting new certificate")
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// CertificateIsExpiring checks if the passed certificate will expire within
+// the KubeletCertValidityLimit
+func CertificateIsExpiring(cert *x509.Certificate, currentTime time.Time) bool {
+	return cert.NotAfter.Sub(currentTime) < KubeletCertValidityLimit
+}
+
+// CertificateIncludesHostname checks that the passed certificate includes
+// the provided hostname in its SAN list
+func CertificateIncludesHostname(hostname string, cert *x509.Certificate) bool {
+	for _, name := range cert.DNSNames {
+		if name == hostname {
+			return true
+		}
+	}
+	return false
+}
+
+// CertificateIncludesCurrentIP checks that the passed certificate includes the provided IP address
+func CertificateIncludesCurrentIP(ipAddress string, cert *x509.Certificate) bool {
+	for _, ip := range cert.IPAddresses {
+		if ipAddress == ip.String() {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -1,0 +1,230 @@
+FROM registry.suse.com/bci/bci-base:15.4
+
+RUN zypper -n install --no-recommends git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim-small netcat-openbsd mkisofs && \
+    zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
+    useradd rancher && \
+    mkdir -p /var/lib/rancher /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \
+    chown -R rancher /var/lib/rancher /var/lib/cattle /usr/local/bin
+
+RUN mkdir /root/.kube && \
+    ln -s /etc/rancher/k3s/k3s.yaml /root/.kube/k3s.yaml  && \
+    ln -s /etc/rancher/k3s/k3s.yaml /root/.kube/config && \
+    ln -s $(GOCOVERDIR=ranchercoverage /usr/bin/rancher) /usr/bin/reset-password && \
+    ln -s $(GOCOVERDIR=ranchercoverage /usr/bin/rancher) /usr/bin/ensure-default-admin
+WORKDIR /var/lib/rancher
+
+ARG ARCH=amd64
+ARG IMAGE_REPO=rancher
+ARG SYSTEM_CHART_DEFAULT_BRANCH=dev-v2.7
+ARG CHART_DEFAULT_BRANCH=dev-v2.7
+ARG PARTNER_CHART_DEFAULT_BRANCH=main
+ARG RKE2_CHART_DEFAULT_BRANCH=main
+# kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
+ARG CATTLE_KDM_BRANCH=dev-v2.7
+
+ENV CATTLE_SYSTEM_CHART_DEFAULT_BRANCH=$SYSTEM_CHART_DEFAULT_BRANCH
+ENV CATTLE_CHART_DEFAULT_BRANCH=$CHART_DEFAULT_BRANCH
+ENV CATTLE_PARTNER_CHART_DEFAULT_BRANCH=$PARTNER_CHART_DEFAULT_BRANCH
+ENV CATTLE_RKE2_CHART_DEFAULT_BRANCH=$RKE2_CHART_DEFAULT_BRANCH
+ENV CATTLE_HELM_VERSION v2.16.8-rancher2
+ENV CATTLE_MACHINE_VERSION v0.15.0-rancher98
+ENV CATTLE_K3S_VERSION v1.25.5+k3s1
+ENV CATTLE_MACHINE_PROVISION_IMAGE rancher/machine:${CATTLE_MACHINE_VERSION}
+ENV CATTLE_ETCD_VERSION v3.5.1
+ENV LOGLEVEL_VERSION v0.1.5
+ENV TINI_VERSION v0.18.0
+ENV TELEMETRY_VERSION v0.5.20
+ENV DOCKER_MACHINE_LINODE_VERSION v0.1.8
+ENV LINODE_UI_DRIVER_VERSION v0.4.0
+# make sure the version number is consistent with the one at Line 100 of pkg/data/management/machinedriver_data.go
+ENV DOCKER_MACHINE_HARVESTER_VERSION v0.6.1
+ENV CATTLE_KDM_BRANCH ${CATTLE_KDM_BRANCH}
+ENV HELM_VERSION v3.10.3
+ENV KUSTOMIZE_VERSION v4.5.7
+ENV CATTLE_WINS_AGENT_VERSION v0.4.11
+ENV CATTLE_WINS_AGENT_INSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/install.ps1
+ENV CATTLE_WINS_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher/wins/${CATTLE_WINS_AGENT_VERSION}/uninstall.ps1
+ENV CATTLE_WINS_AGENT_UPGRADE_IMAGE rancher/wins:${CATTLE_WINS_AGENT_VERSION}
+ENV CATTLE_CSI_PROXY_AGENT_VERSION v1.1.1
+ENV CATTLE_SYSTEM_AGENT_VERSION v0.3.1
+ENV CATTLE_SYSTEM_AGENT_INSTALL_SCRIPT https://raw.githubusercontent.com/rancher/system-agent/${CATTLE_SYSTEM_AGENT_VERSION}/install.sh
+ENV CATTLE_SYSTEM_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher/system-agent/${CATTLE_SYSTEM_AGENT_VERSION}/system-agent-uninstall.sh
+ENV CATTLE_SYSTEM_AGENT_UPGRADE_IMAGE rancher/system-agent:${CATTLE_SYSTEM_AGENT_VERSION}-suc
+ENV CATTLE_SYSTEM_UPGRADE_CONTROLLER_CHART_VERSION 101.0.0+up0.3.3
+
+# System charts minimal version
+ENV CATTLE_FLEET_MIN_VERSION=101.1.0+up0.6.0-rc.2
+ENV CATTLE_RANCHER_WEBHOOK_MIN_VERSION=2.0.2+up0.3.2-rc11
+ENV CATTLE_CSP_ADAPTER_MIN_VERSION=2.0.1-rc1
+
+RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
+    mkdir -p /var/lib/rancher-data/local-catalogs/library && \
+    mkdir -p /var/lib/rancher-data/local-catalogs/helm3-library && \
+    mkdir -p /var/lib/rancher-data/local-catalogs/v2 && \
+    git clone -b $CATTLE_SYSTEM_CHART_DEFAULT_BRANCH --depth 1 https://github.com/rancher/system-charts /var/lib/rancher-data/local-catalogs/system-library && \
+    # Charts need to be copied into the sha256 value of git url computed in https://github.com/rancher/rancher/blob/5ebda9ac23c06e9647b586ec38aa51cc9ff9b031/pkg/catalogv2/git/download.go#L102 to create a unique folder per url
+    git clone -b $CATTLE_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/charts /var/lib/rancher-data/local-catalogs/v2/rancher-charts/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721/ && \
+    git clone -b $CATTLE_PARTNER_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/partner-charts /var/lib/rancher-data/local-catalogs/v2/rancher-partner-charts/8f17acdce9bffd6e05a58a3798840e408c4ea71783381ecd2e9af30baad65974 && \
+    git clone -b $CATTLE_RKE2_CHART_DEFAULT_BRANCH --depth 1 https://git.rancher.io/rke2-charts /var/lib/rancher-data/local-catalogs/v2/rancher-rke2-charts/675f1b63a0a83905972dcab2794479ed599a6f41b86cd6193d69472d0fa889c9 && \
+    git clone -b master --depth 1 https://github.com/rancher/charts /var/lib/rancher-data/local-catalogs/library && \
+    git clone -b master --depth 1 https://github.com/rancher/helm3-charts /var/lib/rancher-data/local-catalogs/helm3-library
+
+RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin && \
+    curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin && \
+    curl -LO https://github.com/linode/docker-machine-driver-linode/releases/download/${DOCKER_MACHINE_LINODE_VERSION}/docker-machine-driver-linode_linux-amd64.zip && \
+    unzip docker-machine-driver-linode_linux-amd64.zip -d /opt/drivers/management-state/bin && \
+    mkdir -p /usr/share/rancher/ui/assets/ && \
+    cp /opt/drivers/management-state/bin/docker-machine-driver-linode /usr/share/rancher/ui/assets/ && \
+    rm docker-machine-driver-linode_linux-amd64.zip
+
+RUN curl -LO https://releases.rancher.com/harvester-node-driver/${DOCKER_MACHINE_HARVESTER_VERSION}/docker-machine-driver-harvester-amd64.tar.gz && \
+    tar -xf docker-machine-driver-harvester-amd64.tar.gz -C /opt/drivers/management-state/bin && \
+    cp /opt/drivers/management-state/bin/docker-machine-driver-harvester /usr/share/rancher/ui/assets/ && \
+    rm docker-machine-driver-harvester-amd64.tar.gz
+
+ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
+    TINI_URL_arm64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 \
+    TINI_URL_s390x=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x \
+    TINI_URL=TINI_URL_${ARCH}
+
+ENV HELM_URL_V2_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm \
+    HELM_URL_V2_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm-arm64 \
+    HELM_URL_V2_s390x=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-helm-s390x \
+    HELM_URL_V2=HELM_URL_V2_${ARCH} \
+    HELM_URL_V3=https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz \
+    TILLER_URL_amd64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller \
+    TILLER_URL_arm64=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller-arm64 \
+    TILLER_URL_s390x=https://github.com/rancher/helm/releases/download/${CATTLE_HELM_VERSION}/rancher-tiller-s390x \
+    TILLER_URL=TILLER_URL_${ARCH} \
+    ETCD_URL=https://github.com/etcd-io/etcd/releases/download/${CATTLE_ETCD_VERSION}/etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}.tar.gz \
+    KUSTOMIZE_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
+
+RUN curl -sLf ${KUSTOMIZE_URL} | tar -xzf - -C /usr/bin
+
+# set up helm 2
+RUN curl -sLf ${!HELM_URL_V2} > /usr/bin/rancher-helm && \
+    curl -sLf ${!TILLER_URL} > /usr/bin/rancher-tiller && \
+    ln -s /usr/bin/rancher-helm /usr/bin/helm && \
+    ln -s /usr/bin/rancher-tiller /usr/bin/tiller && \
+    chmod +x /usr/bin/rancher-helm /usr/bin/rancher-tiller
+
+# set up helm 3
+RUN curl ${HELM_URL_V3} | tar xvzf - --strip-components=1 -C /usr/bin && \
+    mv /usr/bin/helm /usr/bin/helm_v3 && \
+    chmod +x /usr/bin/kustomize
+
+# Set up K3s: copy the necessary binaries from the K3s image.
+COPY --from=rancher/k3s:v1.25.5-k3s1 \
+    /bin/blkid \
+    /bin/cni \
+    /bin/conntrack \
+    /bin/containerd \
+    /bin/containerd-shim-runc-v2 \
+    /bin/ethtool \
+    /bin/ip \
+    /bin/ipset \
+    /bin/k3s \
+    /bin/losetup \
+    /bin/pigz \
+    /bin/runc \
+    /bin/which \
+    /bin/aux/xtables-legacy-multi \
+/usr/bin/
+
+RUN ln -s /usr/bin/cni /usr/bin/bridge && \
+    ln -s /usr/bin/cni /usr/bin/flannel && \
+    ln -s /usr/bin/cni /usr/bin/host-local && \
+    ln -s /usr/bin/cni /usr/bin/loopback && \
+    ln -s /usr/bin/cni /usr/bin/portmap && \
+    ln -s /usr/bin/k3s /usr/bin/crictl && \
+    ln -s /usr/bin/k3s /usr/bin/ctr && \
+    ln -s /usr/bin/k3s /usr/bin/k3s-agent && \
+    ln -s /usr/bin/k3s /usr/bin/k3s-etcd-snapshot && \
+    ln -s /usr/bin/k3s /usr/bin/k3s-server && \
+    ln -s /usr/bin/k3s /usr/bin/kubectl && \
+    ln -s /usr/bin/pigz /usr/bin/unpigz && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-save && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-restore && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/iptables-translate && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-save && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-restore && \
+    ln -s /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-translate
+
+RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
+    mkdir -p /var/lib/rancher/k3s/agent/images/ && \
+    curl -sfL ${ETCD_URL} | tar xvzf - --strip-components=1 -C /usr/bin/ etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcdctl && \
+    curl -sLf https://github.com/rancher/telemetry/releases/download/${TELEMETRY_VERSION}/telemetry-${ARCH} > /usr/bin/telemetry && \
+    chmod +x /usr/bin/tini /usr/bin/telemetry && \
+    mkdir -p /var/lib/rancher-data/driver-metadata
+
+ENV CATTLE_UI_VERSION 2.7.2-rc1
+ENV CATTLE_DASHBOARD_UI_VERSION v2.7.2-rc1
+ENV CATTLE_CLI_VERSION v2.7.2-rc1
+
+# Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install
+ENV CATTLE_BASE_UI_BRAND=
+
+# Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
+ENV CATTLE_API_UI_VERSION 1.1.9
+
+RUN mkdir -p /var/log/auditlog
+ENV AUDIT_LOG_PATH /var/log/auditlog/rancher-api-audit.log
+ENV AUDIT_LOG_MAXAGE 10
+ENV AUDIT_LOG_MAXBACKUP 10
+ENV AUDIT_LOG_MAXSIZE 100
+ENV AUDIT_LEVEL 0
+
+RUN mkdir -p /usr/share/rancher/ui && \
+    cd /usr/share/rancher/ui && \
+    curl -sL https://releases.rancher.com/ui/${CATTLE_UI_VERSION}.tar.gz | tar xvzf - --strip-components=1 && \
+    mkdir -p assets/rancher-ui-driver-linode && \
+    cd assets/rancher-ui-driver-linode && \
+    curl -O https://linode.github.io/rancher-ui-driver-linode/releases/${LINODE_UI_DRIVER_VERSION}/component.js && \
+    curl -O https://linode.github.io/rancher-ui-driver-linode/releases/${LINODE_UI_DRIVER_VERSION}/component.css && \
+    curl -O https://linode.github.io/rancher-ui-driver-linode/releases/${LINODE_UI_DRIVER_VERSION}/linode.svg && \
+    mkdir -p /usr/share/rancher/ui/api-ui && \
+    cd /usr/share/rancher/ui/api-ui && \
+    curl -sL https://releases.rancher.com/api-ui/${CATTLE_API_UI_VERSION}.tar.gz | tar xvzf - --strip-components=1 && \
+    mkdir -p /usr/share/rancher/ui-dashboard/dashboard && \
+    cd /usr/share/rancher/ui-dashboard/dashboard && \
+    curl -sL https://releases.rancher.com/dashboard/${CATTLE_DASHBOARD_UI_VERSION}.tar.gz | tar xvzf - --strip-components=2 && \
+    ln -s dashboard/index.html ../index.html && \
+    cd ../../ui/assets && \
+    curl -sfL https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/rancher-system-agent-arm64 -O && \
+    curl -sfL https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/rancher-system-agent-amd64 -O && \
+    curl -sfL https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/rancher-system-agent-s390x -O && \
+    curl -sfL ${CATTLE_SYSTEM_AGENT_INSTALL_SCRIPT} -o system-agent-install.sh && \
+    curl -sfL ${CATTLE_SYSTEM_AGENT_UNINSTALL_SCRIPT} -o system-agent-uninstall.sh && \
+    curl -sfL https://github.com/rancher/wins/releases/download/${CATTLE_WINS_AGENT_VERSION}/wins.exe -O && \
+    curl -sfL https://acs-mirror.azureedge.net/csi-proxy/${CATTLE_CSI_PROXY_AGENT_VERSION}/binaries/csi-proxy-${CATTLE_CSI_PROXY_AGENT_VERSION}.tar.gz -O && \
+    curl -sfL ${CATTLE_WINS_AGENT_INSTALL_SCRIPT} -o wins-agent-install.ps1 \
+    curl -sfL ${CATTLE_WINS_AGENT_UNINSTALL_SCRIPT} -o wins-agent-uninstall.ps1
+
+ENV CATTLE_CLI_URL_DARWIN  https://releases.rancher.com/cli2/${CATTLE_CLI_VERSION}/rancher-darwin-amd64-${CATTLE_CLI_VERSION}.tar.gz
+ENV CATTLE_CLI_URL_LINUX   https://releases.rancher.com/cli2/${CATTLE_CLI_VERSION}/rancher-linux-amd64-${CATTLE_CLI_VERSION}.tar.gz
+ENV CATTLE_CLI_URL_WINDOWS https://releases.rancher.com/cli2/${CATTLE_CLI_VERSION}/rancher-windows-386-${CATTLE_CLI_VERSION}.zip
+
+ARG VERSION=dev
+ENV CATTLE_SERVER_VERSION ${VERSION}
+COPY run_rancher.sh rancher /usr/bin/
+COPY kustomize.sh /usr/bin/
+COPY jailer.sh /usr/bin/
+COPY k3s-airgap-images.tar /var/lib/rancher/k3s/agent/images/
+RUN chmod +x /usr/bin/run_rancher.sh
+RUN chmod +x /usr/bin/kustomize.sh
+
+COPY data.json /var/lib/rancher-data/driver-metadata/
+
+ENV CATTLE_AGENT_IMAGE ${IMAGE_REPO}/rancher-agent:${VERSION}
+ENV CATTLE_SERVER_IMAGE ${IMAGE_REPO}/rancher
+ENV ETCDCTL_API=3
+
+ENV SSL_CERT_DIR /etc/rancher/ssl
+VOLUME /var/lib/rancher
+VOLUME /var/lib/kubelet
+VOLUME /var/lib/cni
+VOLUME /var/log
+
+ENTRYPOINT ["run_rancher.sh"]

--- a/tests/v2/codecoverage/package/Dockerfile.agent
+++ b/tests/v2/codecoverage/package/Dockerfile.agent
@@ -1,0 +1,27 @@
+ARG RANCHER_TAG=dev
+ARG RANCHER_REPO=rancher
+FROM ${RANCHER_REPO}/rancher:${RANCHER_TAG} as rancher
+
+FROM registry.suse.com/bci/bci-base:15.4
+ARG ARCH=amd64
+
+ENV KUBECTL_VERSION v1.23.6
+RUN zypper -n install --no-recommends curl ca-certificates jq git-core hostname iproute2 vim-small less \
+	bash-completion bind-utils acl openssh-clients tar gzip xz gawk sysstat && \
+    zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
+    curl -sLf https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
+    chmod +x /usr/bin/kubectl
+
+ENV LOGLEVEL_VERSION v0.1.5
+
+RUN curl -sLf https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_VERSION}/loglevel-${ARCH}-${LOGLEVEL_VERSION}.tar.gz | tar xvzf - -C /usr/bin
+
+ARG VERSION=dev
+LABEL io.cattle.agent true
+ENV AGENT_IMAGE ${RANCHER_REPO}/rancher-agent:${VERSION}
+ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
+COPY --from=rancher /var/lib/rancher-data /var/lib/rancher-data
+COPY --from=rancher /usr/bin/tini /usr/bin/
+COPY agent run_agent.sh kubectl-shell.sh shell-setup.sh /usr/bin/
+WORKDIR /var/lib/rancher
+ENTRYPOINT ["run_agent.sh"]

--- a/tests/v2/codecoverage/package/jailer.sh
+++ b/tests/v2/codecoverage/package/jailer.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -e
+
+NAME=$1
+
+if [[ -z "$1" ]]
+  then
+    echo "No name supplied"
+    exit 1
+fi
+
+# Build the jail directory structure
+mkdir -p /opt/jail/$NAME/dev
+mkdir -p /opt/jail/$NAME/etc/ssl
+mkdir -p /opt/jail/$NAME/usr/bin
+mkdir -p /opt/jail/$NAME/management-state/node/nodes
+mkdir -p /opt/jail/$NAME/var/lib/rancher/management-state/bin
+mkdir -p /opt/jail/$NAME/management-state/bin
+mkdir -p /opt/jail/$NAME/tmp
+mkdir -p /opt/jail/$NAME/bin
+
+# Copy over required files to the jail
+if [[ -d /lib64 ]]; then
+  cp -r /lib64 /opt/jail/$NAME
+  cp -r /usr/lib64 /opt/jail/$NAME/usr
+fi
+
+cp -r /lib /opt/jail/$NAME
+cp -r /usr/lib /opt/jail/$NAME/usr
+cp /var/lib/ca-certificates/ca-bundle.pem /opt/jail/$NAME/etc/ssl
+cp /etc/resolv.conf /opt/jail/$NAME/etc/
+cp /etc/passwd /opt/jail/$NAME/etc/
+cp /etc/hosts /opt/jail/$NAME/etc/
+cp /etc/nsswitch.conf /opt/jail/$NAME/etc/
+
+if [ -d /var/lib/rancher/management-state/bin ] && [ "$(ls -A /var/lib/rancher/management-state/bin)" ]; then
+  ( cd /var/lib/rancher/management-state/bin
+    for f in *; do
+      if [ ! -f "/opt/drivers/management-state/bin/$f" ]; then
+        cp "$f" "/opt/drivers/management-state/bin/$f"
+      fi
+    done
+  )
+fi
+
+if [[ -f /etc/ssl/certs/ca-additional.pem ]]; then
+  cp /etc/ssl/certs/ca-additional.pem /opt/jail/$NAME/etc/ssl
+fi
+
+if [[ -f /etc/rancher/ssl/cacerts.pem ]]; then
+  cp /etc/rancher/ssl/cacerts.pem /opt/jail/$NAME/etc/ssl
+fi
+
+# Hard link driver binaries
+cp -r -l /opt/drivers/management-state/bin /opt/jail/$NAME/var/lib/rancher/management-state
+
+# Hard link rancher-machine into the jail
+cp -l /usr/bin/rancher-machine /opt/jail/$NAME/usr/bin
+
+# Hard link helm_2 into the jail
+cp -l /usr/bin/rancher-helm /opt/jail/$NAME/usr/bin
+
+# Hard link helm_3 into the jail
+cp -l /usr/bin/helm_v3 /opt/jail/$NAME/usr/bin
+
+# Hard link tiller into the jail
+cp -l /usr/bin/rancher-tiller /opt/jail/$NAME/usr/bin
+
+# Hard link kustomize into the jail
+cp -l /usr/bin/kustomize /opt/jail/$NAME/usr/bin
+
+# Hard link custom kustomize script into jail
+cp -l /usr/bin/kustomize.sh /opt/jail/$NAME
+
+# Hard link ssh into the jail
+cp -l /usr/bin/ssh /opt/jail/$NAME/usr/bin
+
+# Hard link nc into the jail
+cp -l /usr/bin/nc /opt/jail/$NAME/usr/bin
+
+# Hard link cat into the jail
+cp -l /bin/cat /opt/jail/$NAME/bin/
+
+# Hard link bash into the jail
+cp -l /bin/bash /opt/jail/$NAME/bin/
+
+# Hard link sh into the jail
+cp -l /bin/sh /opt/jail/$NAME/bin/
+
+# Hard link rm into the jail
+cp -l /bin/rm /opt/jail/$NAME/bin/
+
+# Hard link mkisofs into the jail
+cp -l /usr/bin/mkisofs /opt/jail/$NAME/usr/bin
+
+cd /dev
+# tar copy /dev excluding mqueue and shm
+tar cf - --exclude=mqueue --exclude=shm --exclude=pts . | (cd /opt/jail/${NAME}/dev; tar xfp -)
+
+touch /opt/jail/$NAME/done

--- a/tests/v2/codecoverage/package/kubectl-shell.sh
+++ b/tests/v2/codecoverage/package/kubectl-shell.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+token=$1
+cluster=$2
+cacerts=$3
+
+if [ -z "${token}" ]; then
+    echo No token provided
+    exit 1
+fi
+
+if [ -z "${cluster}" ]; then
+    echo No cluster provided
+    exit 1
+fi
+
+echo "# Run kubectl commands inside here"
+echo "# e.g. kubectl get all"
+export TERM=screen-256color
+export TOKEN=${token}
+export CLUSTER=${cluster}
+export CACERTS=${cacerts}
+unshare --fork --pid --mount-proc --mount shell-setup.sh || true

--- a/tests/v2/codecoverage/package/kustomize.sh
+++ b/tests/v2/codecoverage/package/kustomize.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cat <&0 > "$CATTLE_KUSTOMIZE_YAML"/all.yaml
+
+kustomize build "$CATTLE_KUSTOMIZE_YAML" && rm "$CATTLE_KUSTOMIZE_YAML"/all.yaml

--- a/tests/v2/codecoverage/package/run_agent.sh
+++ b/tests/v2/codecoverage/package/run_agent.sh
@@ -1,0 +1,285 @@
+#!/bin/bash
+set -e
+
+# Logging helper functions
+info()
+{
+    echo "INFO:" "$@" 1>&2
+}
+
+error()
+{
+    echo "ERROR:" "$@" 1>&2
+}
+warn()
+{
+    echo "WARN:" "$@" 1>&2
+}
+
+# Print all given arguments
+if [ $# -ne 0 ]; then
+    info "Arguments: $(echo $@ | sed -e 's/\(token\s\)\w*/\1REDACTED/')"
+fi
+
+if [ "$1" = "--" ]; then
+    shift 1
+    exec "$@"
+fi
+
+if [ "$CLUSTER_CLEANUP" = true ]; then
+    mkdir agentcoverage
+    while true; do
+        echo "Agent started in coverage mode"
+        GOCOVERDIR=agentcoverage /usr/bin/agent "${@}"
+        echo "Agent restarting.."
+    done
+fi
+
+get_address()
+{
+    local address=$1
+    # If nothing is given, return empty (it will be automatically determined later if empty)
+    if [ -z $address ]; then
+        echo ""
+    # If given address is a network interface on the system, retrieve configured IP on that interface (only the first configured IP is taken)
+    elif [ -n "$(find /sys/devices -name $address)" ]; then
+        echo $(ip addr show dev $address | grep -w inet | awk '{print $2}' | cut -f1 -d/ | head -1)
+    # Loop through cloud provider options to get IP from metadata, if not found return given value
+    else
+        case $address in
+            awslocal)
+                echo $(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+                ;;
+            awspublic)
+                echo $(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+                ;;
+            doprivate)
+                echo $(curl -s http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
+                ;;
+            dopublic)
+                echo $(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+                ;;
+            azprivate)
+                echo $(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-08-01&format=text")
+                ;;
+            azpublic)
+                echo $(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text")
+                ;;
+            gceinternal)
+                echo $(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip)
+                ;;
+            gceexternal)
+                echo $(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
+                ;;
+            packetlocal)
+                echo $(curl -s https://metadata.packet.net/2009-04-04/meta-data/local-ipv4)
+                ;;
+            packetpublic)
+                echo $(curl -s https://metadata.packet.net/2009-04-04/meta-data/public-ipv4)
+                ;;
+            ipify)
+                echo $(curl -s https://api.ipify.org)
+                ;;
+            *)
+                echo $address
+                ;;
+        esac
+    fi
+}
+
+check_url()
+{
+    local url=$1
+    local err
+    err=$(curl --insecure -sS -fL -o /dev/null --stderr - $url | head -n1 ; exit ${PIPESTATUS[0]})
+    if [ $? -eq 0 ]
+    then
+        echo ""
+    else
+        echo ${err} | sed -e 's/^curl: ([0-9]\+) //'
+    fi
+}
+
+check_x509_cert()
+{
+    local cert=$1
+    local err
+    err=$(openssl x509 -in $cert -noout 2>&1)
+    if [ $? -eq 0 ]
+    then
+        echo ""
+    else
+        echo ${err}
+    fi
+}
+
+export CATTLE_ADDRESS
+export CATTLE_AGENT_CONNECT
+export CATTLE_INTERNAL_ADDRESS
+export CATTLE_NODE_NAME
+export CATTLE_ROLE
+export CATTLE_SERVER
+export CATTLE_TOKEN
+export CATTLE_NODE_LABEL
+export CATTLE_WRITE_CERT_ONLY
+export CATTLE_NODE_TAINTS
+
+while true; do
+    case "$1" in
+        -d | --debug)                   DEBUG=true                  ;;
+        -s | --server)           shift; CATTLE_SERVER=$1            ;;
+        -t | --token)            shift; CATTLE_TOKEN=$1             ;;
+        -c | --ca-checksum)      shift; CATTLE_CA_CHECKSUM=$1       ;;
+        -a | --all-roles)               ALL=true                    ;;
+        -e | --etcd)                    ETCD=true                   ;;
+        -w | --worker)                  WORKER=true                 ;;
+        -p | --controlplane)            CONTROL=true                ;;
+        -n | --node-name)        shift; CATTLE_NODE_NAME=$1         ;;
+        -r | --no-register)             CATTLE_AGENT_CONNECT=true   ;;
+        -a | --address)          shift; CATTLE_ADDRESS=$1           ;;
+        -i | --internal-address) shift; CATTLE_INTERNAL_ADDRESS=$1  ;;
+        -l | --label)            shift; CATTLE_NODE_LABEL+=",$1"    ;;
+        -o | --only-write-certs)        CATTLE_WRITE_CERT_ONLY=true ;;
+        --taints)                shift; CATTLE_NODE_TAINTS+=",$1"   ;;
+        *) break;
+    esac
+    shift
+done
+
+if [ "$DEBUG" = true ]; then
+    set -x
+fi
+
+if [ "$CATTLE_CLUSTER" != "true" ]; then
+    if [ ! -w /var/run/docker.sock ] || [ ! -S /var/run/docker.sock ]; then
+        warn "Docker socket is not available!"
+        warn "Please bind mount in the docker socket to /var/run/docker.sock if docker errors occur"
+        warn "example:  docker run -v /var/run/docker.sock:/var/run/docker.sock ..."
+    fi
+fi
+
+if [ -z "$CATTLE_NODE_NAME" ]; then
+    CATTLE_NODE_NAME=$(hostname -s)
+fi
+
+export CATTLE_ADDRESS=$(get_address $CATTLE_ADDRESS)
+export CATTLE_INTERNAL_ADDRESS=$(get_address $CATTLE_INTERNAL_ADDRESS)
+
+if [ -z "$CATTLE_ADDRESS" ]; then
+    # Try to get external IP with dig, often works better than ip -o route.
+    if dig +short myip.opendns.com @resolver1.opendns.com && echo $?; then
+        CATTLE_ADDRESS=$(dig +short myip.opendns.com @resolver1.opendns.com)
+    fi
+fi
+
+if [ -z "$CATTLE_ADDRESS" ]; then
+    # Example output: '8.8.8.8 via 10.128.0.1 dev ens4 src 10.128.0.34 uid 0'
+    CATTLE_ADDRESS=$(ip -o route get 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
+fi
+
+if [ -z "$CATTLE_INTERNAL_ADDRESS" ]; then
+    # Example output: '8.8.8.8 via 10.128.0.1 dev ens4 src 10.128.0.34 uid 0'
+    # Will provide the private IP address, if no private IP address is found the public IP address will be returned
+    ROUTE_OUTPUT=$(ip -o route get 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
+    if [ "$CATTLE_ADDRESS" != "$ROUTE_OUTPUT" ]; then
+        CATTLE_INTERNAL_ADDRESS="$ROUTE_OUTPUT"
+    fi
+fi
+
+if [ "$CATTLE_K8S_MANAGED" != "true" ]; then
+    if [ -z "$CATTLE_TOKEN" ]; then
+        error -- --token is a required option
+        exit 1
+    fi
+
+    if [ -z "$CATTLE_ADDRESS" ]; then
+        error -- --address is a required option
+        exit 1
+    fi
+fi
+
+if [ "$ALL" = true ]; then
+    CATTLE_ROLE="etcd,worker,controlplane"
+else
+    if [ "$ETCD" = true ]; then
+        CATTLE_ROLE="${CATTLE_ROLE},etcd"
+    fi
+    if [ "$WORKER" = true ]; then
+        CATTLE_ROLE="${CATTLE_ROLE},worker"
+    fi
+    if [ "$CONTROL" = true ]; then
+        CATTLE_ROLE="${CATTLE_ROLE},controlplane"
+    fi
+fi
+
+if [ -z "$CATTLE_SERVER" ]; then
+    error -- --server is a required option
+    exit 1
+fi
+
+info "Environment: $(echo $(printenv | grep CATTLE | sort | sed -e 's/\(CATTLE_TOKEN=\).*/\1REDACTED/'))"
+info "Using resolv.conf: $(echo $(cat /etc/resolv.conf | grep -v ^#))"
+if grep -E -q '^nameserver 127.*.*.*|^nameserver localhost|^nameserver ::1' /etc/resolv.conf; then
+    warn "Loopback address found in /etc/resolv.conf, please refer to the documentation how to configure your cluster to resolve DNS properly"
+fi
+
+CATTLE_SERVER_PING="${CATTLE_SERVER}/ping"
+err=$(check_url $CATTLE_SERVER_PING)
+if [[ $err ]]; then
+    error "${CATTLE_SERVER_PING} is not accessible (${err})"
+    exit 1
+else
+    info "${CATTLE_SERVER_PING} is accessible"
+fi
+
+# Extract hostname from URL
+CATTLE_SERVER_HOSTNAME=$(echo $CATTLE_SERVER | sed -e 's/[^/]*\/\/\([^@]*@\)\?\([^:/]*\).*/\2/')
+CATTLE_SERVER_HOSTNAME_WITH_PORT=$(echo $CATTLE_SERVER | sed -e 's/[^/]*\/\/\([^@]*@\)\?\(.*\).*/\2/')
+# Resolve IPv4 address(es) from hostname
+RESOLVED_ADDR=$(getent ahostsv4 $CATTLE_SERVER_HOSTNAME | sed -n 's/ *STREAM.*//p')
+
+# If CATTLE_SERVER_HOSTNAME equals RESOLVED_ADDR, its an IP address and there is nothing to resolve
+if [ "${CATTLE_SERVER_HOSTNAME}" != "${RESOLVED_ADDR}" ]; then
+  info "${CATTLE_SERVER_HOSTNAME} resolves to $(echo $RESOLVED_ADDR)"
+fi
+
+if [ -n "$CATTLE_CA_CHECKSUM" ]; then
+    temp=$(mktemp)
+    curl --insecure -s -fL $CATTLE_SERVER/v3/settings/cacerts | jq -r '.value | select(length > 0)' > $temp
+    if [ ! -s $temp ]; then
+      error "The environment variable CATTLE_CA_CHECKSUM is set but there is no CA certificate configured at $CATTLE_SERVER/v3/settings/cacerts"
+      exit 1
+    fi
+    err=$(check_x509_cert $temp)
+    if [[ $err ]]; then
+        error "Value from $CATTLE_SERVER/v3/settings/cacerts does not look like an x509 certificate (${err})"
+        error "Retrieved cacerts:"
+        cat $temp
+        exit 1
+    else
+        info "Value from $CATTLE_SERVER/v3/settings/cacerts is an x509 certificate"
+    fi
+    CATTLE_SERVER_CHECKSUM=$(sha256sum $temp | awk '{print $1}')
+    if [ $CATTLE_SERVER_CHECKSUM != $CATTLE_CA_CHECKSUM ]; then
+        rm -f $temp
+        error "Configured cacerts checksum ($CATTLE_SERVER_CHECKSUM) does not match given --ca-checksum ($CATTLE_CA_CHECKSUM)"
+        error "Please check if the correct certificate is configured at $CATTLE_SERVER/v3/settings/cacerts"
+        exit 1
+    else
+        mkdir -p /etc/kubernetes/ssl/certs
+        mv $temp /etc/kubernetes/ssl/certs/serverca
+        chmod 755 /etc/kubernetes/ssl
+        chmod 700 /etc/kubernetes/ssl/certs
+        chmod 600 /etc/kubernetes/ssl/certs/serverca
+        mkdir -p /etc/docker/certs.d/$CATTLE_SERVER_HOSTNAME_WITH_PORT
+        cp /etc/kubernetes/ssl/certs/serverca /etc/docker/certs.d/$CATTLE_SERVER_HOSTNAME_WITH_PORT/ca.crt
+
+    fi
+fi
+
+mkdir agentcoverage
+while true; do
+    echo "Agent started in coverage mode"
+    GOCOVERDIR=agentcoverage /usr/bin/agent "${@}"
+    echo "Agent restarting.."
+done

--- a/tests/v2/codecoverage/package/run_rancher.sh
+++ b/tests/v2/codecoverage/package/run_rancher.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -e /run/secrets/kubernetes.io/serviceaccount ] && [ ! -e /dev/kmsg ]; then
+    echo "ERROR: Rancher must be ran with the --privileged flag when running outside of Kubernetes"
+    exit 1
+fi
+
+#########################################################################################################################################
+# DISCLAIMER                                                                                                                            #
+# Copied from https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/hack/dind#L28-L37                              #
+# Permission granted by Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> (https://github.com/rancher/k3d/issues/493#issuecomment-827405962) #
+# Moby License Apache 2.0: https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/LICENSE                           #
+#########################################################################################################################################
+# only run this if rancher is not running in kubernetes cluster
+if [ ! -e /run/secrets/kubernetes.io/serviceaccount ] && [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+  # move the processes from the root group to the /init group,
+  # otherwise writing subtree_control fails with EBUSY.
+  mkdir -p /sys/fs/cgroup/init
+  xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+  # enable controllers
+  sed -e 's/ / +/g' -e 's/^/+/' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
+fi
+
+rm -f /var/lib/rancher/k3s/server/cred/node-passwd
+if [ -e /var/lib/rancher/management-state/etcd ] && [ ! -e /var/lib/rancher/k3s/server/db/etcd ]; then
+  mkdir -p /var/lib/rancher/k3s/server/db
+  ln -sf /var/lib/rancher/management-state/etcd /var/lib/rancher/k3s/server/db/etcd
+  echo -n 'default' > /var/lib/rancher/k3s/server/db/etcd/name
+fi
+if [ -e /var/lib/rancher/k3s/server/db/etcd ]; then
+  echo "INFO: Running k3s server --cluster-init --cluster-reset"
+  set +e
+  k3s server --cluster-init --cluster-reset &> ./k3s-cluster-reset.log
+  K3S_CR_CODE=$?
+  if [ "${K3S_CR_CODE}" -ne 0 ]; then
+    echo "ERROR:" && cat ./k3s-cluster-reset.log
+    rm -f /var/lib/rancher/k3s/server/db/reset-flag
+    exit ${K3S_CR_CODE}
+  fi
+  set -e
+fi
+if [ -x "$(command -v update-ca-certificates)" ]; then
+  update-ca-certificates
+fi
+if [ -x "$(command -v c_rehash)" ]; then
+  c_rehash
+fi
+
+mkdir ranchercoverage
+while true; do
+  echo "Rancher started in coverage mode"
+  GOCOVERDIR=ranchercoverage /usr/bin/rancher --http-listen-port=80 --https-listen-port=443 --audit-log-path=${AUDIT_LOG_PATH} --audit-level=${AUDIT_LEVEL} --audit-log-maxage=${AUDIT_LOG_MAXAGE} --audit-log-maxbackup=${AUDIT_LOG_MAXBACKUP} --audit-log-maxsize=${AUDIT_LOG_MAXSIZE} "${@}"
+  echo "Rancher restarting.."
+done

--- a/tests/v2/codecoverage/package/shell-setup.sh
+++ b/tests/v2/codecoverage/package/shell-setup.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+mkdir -p /nonexistent
+mount -t tmpfs tmpfs /nonexistent
+cd /nonexistent
+
+mkdir -p .kube/certs
+
+SERVER="${CATTLE_SERVER}/k8s/clusters/${CLUSTER}"
+
+if [ -f /etc/kubernetes/ssl/certs/serverca ]; then
+    cp /etc/kubernetes/ssl/certs/serverca .kube/certs/ca.crt
+    chmod 666 .kube/certs/ca.crt
+
+elif [ -n "${CACERTS}" ]; then
+    echo "${CACERTS}" | base64 -d > .kube/certs/ca.crt
+    chmod 666 .kube/certs/ca.crt
+fi
+
+if [ -f /nonexistent/.kube/certs/ca.crt ] && ! curl -s $SERVER > /dev/null; then
+  CERT="    certificate-authority: /nonexistent/.kube/certs/ca.crt"
+fi
+
+for i in /run /var/run /etc/kubernetes; do
+    mount -t tmpfs tmpfs $i
+done
+
+cat <<EOF > .kube/config
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    api-version: v1
+    server: "${CATTLE_SERVER}/k8s/clusters/${CLUSTER}"
+${CERT}
+  name: "Default"
+contexts:
+- context:
+    cluster: "Default"
+    user: "Default"
+  name: "Default"
+current-context: "Default"
+users:
+- name: "Default"
+  user:
+    token: "${TOKEN}"
+EOF
+
+cp /etc/skel/.bashrc .
+cat >> .bashrc <<EOF
+PS1="> "
+. /etc/bash_completion
+alias k="kubectl"
+alias ks="kubectl -n kube-system"
+source <(kubectl completion bash)
+EOF
+
+chmod 777 .kube .bashrc
+chmod 666 .kube/config
+
+for i in $(env | cut -d "=" -f 1 | grep "CATTLE\|RANCHER"); do
+    unset $i
+done
+
+unset TOKEN CLUSTER CACERTS
+exec su -s /bin/bash nobody

--- a/tests/v2/codecoverage/rancher/main.go
+++ b/tests/v2/codecoverage/rancher/main.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/pkg/reexec"
+	"github.com/ehazlett/simplelog"
+	_ "github.com/rancher/norman/controller"
+	"github.com/rancher/norman/pkg/kwrapper/k8s"
+	"github.com/rancher/rancher/pkg/data/management"
+	"github.com/rancher/rancher/pkg/logserver"
+	"github.com/rancher/rancher/pkg/rancher"
+	"github.com/rancher/rancher/pkg/version"
+	"github.com/rancher/rancher/tests/framework/pkg/killserver"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+var (
+	profileAddress = "localhost:6060"
+	kubeConfig     string
+)
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	killServer := killserver.NewKillServer(killserver.KillServerPort, cancel)
+	go killServer.Start()
+	go runRancher(ctx)
+	<-ctx.Done()
+
+	killServer.Server.Shutdown(context.Background())
+}
+
+func runRancher(ctx context.Context) error {
+	management.RegisterPasswordResetCommand()
+	management.RegisterEnsureDefaultAdminCommand()
+	if reexec.Init() {
+		return nil
+	}
+
+	os.Unsetenv("SSH_AUTH_SOCK")
+	os.Unsetenv("SSH_AGENT_PID")
+
+	if dm := os.Getenv("CATTLE_DEV_MODE"); dm != "" {
+		if dir, err := os.Getwd(); err == nil {
+			dmPath := filepath.Join(dir, "management-state", "bin")
+			os.MkdirAll(dmPath, 0700)
+			newPath := fmt.Sprintf("%s%s%s", dmPath, string(os.PathListSeparator), os.Getenv("PATH"))
+
+			os.Setenv("PATH", newPath)
+		}
+	} else {
+		newPath := fmt.Sprintf("%s%s%s", "/opt/drivers/management-state/bin", string(os.PathListSeparator), os.Getenv("PATH"))
+		os.Setenv("PATH", newPath)
+	}
+
+	var config rancher.Options
+	app := cli.NewApp()
+	app.Version = version.FriendlyVersion()
+	app.Usage = "Complete container management platform"
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:        "kubeconfig",
+			Usage:       "Kube config for accessing k8s cluster",
+			EnvVar:      "KUBECONFIG",
+			Destination: &kubeConfig,
+		},
+		cli.BoolFlag{
+			Name:        "debug",
+			Usage:       "Enable debug logs",
+			Destination: &config.Debug,
+		},
+		cli.BoolFlag{
+			Name:        "trace",
+			Usage:       "Enable trace logs",
+			Destination: &config.Trace,
+		},
+		cli.StringFlag{
+			Name:        "add-local",
+			Usage:       "Add local cluster (true, false)",
+			Value:       "true",
+			Destination: &config.AddLocal,
+			Hidden:      true,
+		},
+		cli.IntFlag{
+			Name:        "http-listen-port",
+			Usage:       "HTTP listen port",
+			Value:       8080,
+			Destination: &config.HTTPListenPort,
+		},
+		cli.IntFlag{
+			Name:        "https-listen-port",
+			Usage:       "HTTPS listen port",
+			Value:       8443,
+			Destination: &config.HTTPSListenPort,
+		},
+		cli.StringFlag{
+			Name:        "k8s-mode",
+			Usage:       "Mode to run or access k8s API server for management API (embedded, external, auto)",
+			Value:       "auto",
+			Destination: &config.K8sMode,
+		},
+		cli.StringFlag{
+			Name:  "log-format",
+			Usage: "Log formatter used (json, text, simple)",
+			Value: "simple",
+		},
+		cli.StringSliceFlag{
+			Name:   "acme-domain",
+			EnvVar: "ACME_DOMAIN",
+			Usage:  "Domain to register with LetsEncrypt",
+			Value:  &config.ACMEDomains,
+		},
+		cli.BoolFlag{
+			Name:        "no-cacerts",
+			Usage:       "Skip CA certs population in settings when set to true",
+			Destination: &config.NoCACerts,
+		},
+		cli.StringFlag{
+			Name:        "audit-log-path",
+			EnvVar:      "AUDIT_LOG_PATH",
+			Value:       "/var/log/auditlog/rancher-api-audit.log",
+			Usage:       "Log path for Rancher Server API. Default path is /var/log/auditlog/rancher-api-audit.log",
+			Destination: &config.AuditLogPath,
+		},
+		cli.IntFlag{
+			Name:        "audit-log-maxage",
+			Value:       10,
+			EnvVar:      "AUDIT_LOG_MAXAGE",
+			Usage:       "Defined the maximum number of days to retain old audit log files",
+			Destination: &config.AuditLogMaxage,
+		},
+		cli.IntFlag{
+			Name:        "audit-log-maxbackup",
+			Value:       10,
+			EnvVar:      "AUDIT_LOG_MAXBACKUP",
+			Usage:       "Defines the maximum number of audit log files to retain",
+			Destination: &config.AuditLogMaxbackup,
+		},
+		cli.IntFlag{
+			Name:        "audit-log-maxsize",
+			Value:       100,
+			EnvVar:      "AUDIT_LOG_MAXSIZE",
+			Usage:       "Defines the maximum size in megabytes of the audit log file before it gets rotated, default size is 100M",
+			Destination: &config.AuditLogMaxsize,
+		},
+		cli.IntFlag{
+			Name:        "audit-level",
+			Value:       0,
+			EnvVar:      "AUDIT_LEVEL",
+			Usage:       "Audit log level: 0 - disable audit log, 1 - log event metadata, 2 - log event metadata and request body, 3 - log event metadata, request body and response body",
+			Destination: &config.AuditLevel,
+		},
+		cli.StringFlag{
+			Name:        "profile-listen-address",
+			Value:       "127.0.0.1:6060",
+			Usage:       "Address to listen on for profiling",
+			Destination: &profileAddress,
+		},
+		cli.StringFlag{
+			Name:        "features",
+			EnvVar:      "CATTLE_FEATURES",
+			Value:       "",
+			Usage:       "Declare specific feature values on start up. Example: \"kontainer-driver=true\" - kontainer driver feature will be enabled despite false default value",
+			Destination: &config.Features,
+		},
+	}
+
+	app.Action = func(c *cli.Context) error {
+		// enable profiler
+		if profileAddress != "" {
+			go func() {
+				log.Println(http.ListenAndServe(profileAddress, nil))
+			}()
+		}
+		initLogs(c, config)
+		return runServer(c, ctx, config)
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		logrus.Errorf("App Run error: %v", err)
+	}
+	return nil
+}
+
+func runServer(cli *cli.Context, ctx context.Context, cfg rancher.Options) error {
+	logrus.Infof("Rancher version %s is starting", version.FriendlyVersion())
+	logrus.Infof("Rancher arguments %+v", cfg)
+
+	if cfg.AddLocal != "true" && cfg.AddLocal != "auto" {
+		logrus.Fatal("add-local flag must be set to 'true', see Rancher 2.5.0 release notes for more information")
+	}
+
+	embedded, clientConfig, err := k8s.GetConfig(ctx, cfg.K8sMode, kubeConfig)
+	if err != nil {
+		return err
+	}
+	cfg.Embedded = embedded
+
+	os.Unsetenv("KUBECONFIG")
+
+	server, err := rancher.New(ctx, clientConfig, &cfg)
+	if err != nil {
+		return err
+	}
+	err = server.ListenAndServe(ctx)
+
+	if err != nil {
+		logrus.Errorf("ListenAndServer error: %v", err)
+	}
+
+	return nil
+}
+
+func initLogs(c *cli.Context, cfg rancher.Options) {
+	switch c.String("log-format") {
+	case "simple":
+		logrus.SetFormatter(&simplelog.StandardFormatter{})
+	case "text":
+		logrus.SetFormatter(&logrus.TextFormatter{})
+	case "json":
+		logrus.SetFormatter(&logrus.JSONFormatter{})
+	}
+
+	logrus.SetOutput(os.Stdout)
+	if cfg.Debug {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.Debugf("Loglevel set to [%v]", logrus.DebugLevel)
+	}
+	if cfg.Trace {
+		logrus.SetLevel(logrus.TraceLevel)
+		logrus.Tracef("Loglevel set to [%v]", logrus.TraceLevel)
+	}
+
+	logserver.StartServerWithDefaults()
+}

--- a/tests/v2/codecoverage/ranchercleanup/main.go
+++ b/tests/v2/codecoverage/ranchercleanup/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/corral"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/sirupsen/logrus"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	timeout = int64(60 * 10)
+)
+
+func main() {
+	testSession := session.NewSession()
+
+	client, err := rancher.NewClient("", testSession)
+	if err != nil {
+		logrus.Fatalf("error creating admin client: %v", err)
+	}
+
+	var clusterList *v1.SteveCollection
+	err = kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
+		//clean up clusters
+		resp, err := client.Steve.SteveType(clusters.ProvisioningSteveResouceType).List(nil)
+		if k8sErrors.IsInternalError(err) || k8sErrors.IsServiceUnavailable(err) {
+			return false, err
+		} else if resp != nil {
+			clusterList = resp
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		logrus.Errorf("error deleting corral: %v", err)
+	}
+
+	deleteTimeout := timeout
+	for _, cluster := range clusterList.Data {
+		if cluster.ObjectMeta.Name != "local" {
+			err := client.Steve.SteveType(clusters.ProvisioningSteveResouceType).Delete(&cluster)
+			if err != nil {
+				logrus.Errorf("error deleting corral: %v", err)
+			}
+
+			provKubeClient, err := client.GetKubeAPIProvisioningClient()
+			if err != nil {
+				logrus.Errorf("error deleting corral: %v", err)
+			}
+
+			watchInterface, err := provKubeClient.Clusters(cluster.ObjectMeta.Namespace).Watch(context.TODO(), metav1.ListOptions{
+				FieldSelector:  "metadata.name=" + cluster.ObjectMeta.Name,
+				TimeoutSeconds: &deleteTimeout,
+			})
+			if err != nil {
+				logrus.Errorf("error deleting corral: %v", err)
+			}
+
+			err = wait.WatchWait(watchInterface, func(event watch.Event) (ready bool, err error) {
+				cluster := event.Object.(*apisV1.Cluster)
+				if event.Type == watch.Error {
+					return false, fmt.Errorf("there was an error deleting cluster")
+				} else if event.Type == watch.Deleted {
+					return true, nil
+				} else if cluster == nil {
+					return true, nil
+				}
+				return false, nil
+			})
+			if err != nil {
+				logrus.Errorf("error deleting corral: %v", err)
+			}
+		}
+	}
+
+	err = corral.DeleteCorral("ranchertestcoverage")
+	if err != nil {
+		logrus.Errorf("error deleting corral: %v", err)
+	}
+}

--- a/tests/v2/codecoverage/ranchercover/codecoverage_test.go
+++ b/tests/v2/codecoverage/ranchercover/codecoverage_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/codecoverage"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetrieveCoverageReports(t *testing.T) {
+	testSession := session.NewSession()
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	err = codecoverage.KillAgentTestServicesRetrieveCoverage(client)
+	require.NoError(t, err)
+
+	err = codecoverage.KillRancherTestServicesRetrieveCoverage(client)
+	require.NoError(t, err)
+
+}

--- a/tests/v2/codecoverage/rancherha/main.go
+++ b/tests/v2/codecoverage/rancherha/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"github.com/rancher/rancher/tests/framework/clients/corral"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	testSession := session.NewSession()
+
+	corralConfig := corral.CorralConfigurations()
+	err := corral.SetupCorralConfig(corralConfig.CorralConfigVars, corralConfig.CorralConfigUser, corralConfig.CorralSSHPath)
+	if err != nil {
+		logrus.Fatalf("error setting up corral: %v", err)
+	}
+	configPackage := corral.CorralPackagesConfig()
+
+	path := configPackage.CorralPackageImages["aws-rke2-rancher-calico-v1.23.6-rke2r1-2.6.7"]
+	_, err = corral.CreateCorral(testSession, "ranchertestcoverage", path, true, configPackage.Cleanup)
+	if err != nil {
+		logrus.Errorf("error creating corral: %v", err)
+	}
+}

--- a/tests/v2/codecoverage/scripts/build-agent.sh
+++ b/tests/v2/codecoverage/scripts/build-agent.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/../../../../
+
+source $(dirname $0)/scripts/version
+
+mkdir -p bin
+
+if [ -n "${DEBUG}" ]; then
+  GCFLAGS="-N -l"
+fi
+
+if [ "$(uname)" != "Darwin" ]; then
+  LINKFLAGS="-extldflags -static"
+  if [ -z "${DEBUG}" ]; then
+    LINKFLAGS="${LINKFLAGS} -s"
+  fi
+fi
+
+CGO_ENABLED=0 GOCOVERDIR=ranchercoverage GOOS=linux GOARCH=amd64 go build -tags k8s  -cover -gcflags="all=${GCFLAGS}" -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o tests/v2/codecoverage/bin/agent ././tests/v2/codecoverage/agent

--- a/tests/v2/codecoverage/scripts/build-rancher.sh
+++ b/tests/v2/codecoverage/scripts/build-rancher.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -ex
+
+cd $(dirname $0)/../../../../
+
+source $(dirname $0)/scripts/version
+
+CATTLE_KDM_BRANCH=dev-v2.7
+
+mkdir -p bin
+
+if [ -n "${DEBUG}" ]; then
+  GCFLAGS="-N -l"
+fi
+
+if [ "$(uname)" != "Darwin" ]; then
+  LINKFLAGS="-extldflags -static"
+  if [ -z "${DEBUG}" ]; then
+    LINKFLAGS="${LINKFLAGS} -s"
+  fi
+fi
+
+RKE_VERSION="$(grep -m1 'github.com/rancher/rke' go.mod | awk '{print $2}')"
+
+# Inject Setting values
+DEFAULT_VALUES="{\"rke-version\":\"${RKE_VERSION}\"}"
+
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags k8s \
+  -cover \
+  -gcflags="all=${GCFLAGS}" \
+  -ldflags \
+  "-X github.com/rancher/rancher/pkg/version.Version=$VERSION
+   -X github.com/rancher/rancher/pkg/version.GitCommit=$COMMIT
+   -X github.com/rancher/rancher/pkg/settings.InjectDefaults=$DEFAULT_VALUES $LINKFLAGS" \
+  -o tests/v2/codecoverage/bin \
+  ./tests/v2/codecoverage/rancher
+ 
+curl -sLf https://releases.rancher.com/kontainer-driver-metadata/${CATTLE_KDM_BRANCH}/data.json > tests/v2/codecoverage/bin/data.json

--- a/tests/v2/codecoverage/scripts/build_code_coverage_images.sh
+++ b/tests/v2/codecoverage/scripts/build_code_coverage_images.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+cd $(dirname $0)/../../../../
+
+
+echo "building cluster setup bin"
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/codecoverage/bin/setuprancher ./tests/v2/codecoverage/setuprancher
+
+echo "building rancher HA corral bin"
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/codecoverage/bin/ranchercorral ./tests/v2/codecoverage/rancherha
+
+echo "building rancher cleanup bin"
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/codecoverage/bin/ranchercleanup ./tests/v2/codecoverage/ranchercleanup

--- a/tests/v2/codecoverage/scripts/build_corral.sh
+++ b/tests/v2/codecoverage/scripts/build_corral.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd  /go/src/github.com/rancherlabs/corral
+
+echo "building corral bin"
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build 
+
+mv corral /go/bin

--- a/tests/v2/codecoverage/scripts/build_corral_packages.sh
+++ b/tests/v2/codecoverage/scripts/build_corral_packages.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+cd  /root/go/src/github.com/rancherlabs/corral-packages
+
+make init
+make build

--- a/tests/v2/codecoverage/scripts/build_docker_images.sh
+++ b/tests/v2/codecoverage/scripts/build_docker_images.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+ARCH=${ARCH:-"amd64"}
+REPO=ranchertest
+TAG=v2.7-head
+SYSTEM_CHART_REPO_DIR=build/system-charts
+SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"dev-v2.7"}
+CHART_REPO_DIR=build/charts
+CHART_DEFAULT_BRANCH=${CHART_DEFAULT_BRANCH:-"dev-v2.7"}
+
+cd $(dirname $0)/../package
+
+../scripts/k3s-images.sh
+
+cp ../bin/rancher ../bin/agent ../bin/data.json ../bin/k3s-airgap-images.tar .
+
+# Make sure the used data.json is a release artifact
+cp ../bin/data.json ../bin/rancher-data.json
+
+IMAGE=${REPO}/rancher:${TAG}
+AGENT_IMAGE=${REPO}/rancher-agent:${TAG}
+
+echo "building rancher test docker image"
+docker build --build-arg VERSION=${TAG} --build-arg ARCH=${ARCH} --build-arg IMAGE_REPO=${REPO} -t ${IMAGE} -f Dockerfile . --no-cache
+
+echo "building agent test docker image"
+docker build --build-arg VERSION=${TAG} --build-arg ARCH=${ARCH} --build-arg RANCHER_TAG=${TAG} --build-arg RANCHER_REPO=${REPO} -t ${AGENT_IMAGE} -f Dockerfile.agent . --no-cache
+
+echo ${RANCHER_TEST_DOCKER_PASSWORD} | docker login --username ${RANCHER_TEST_DOCKER_USERNAME} --password-stdin
+
+echo "docker push rancher"
+docker image push ${IMAGE}
+
+echo "docker push agent"
+docker image push ${AGENT_IMAGE}

--- a/tests/v2/codecoverage/scripts/build_test_images.sh
+++ b/tests/v2/codecoverage/scripts/build_test_images.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)
+
+echo "build rancher"
+./build-rancher.sh
+echo "build agent"
+./build-agent.sh

--- a/tests/v2/codecoverage/scripts/download_yq.sh
+++ b/tests/v2/codecoverage/scripts/download_yq.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+wget -qO ./yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+chmod a+x ./yq

--- a/tests/v2/codecoverage/scripts/k3s-images.sh
+++ b/tests/v2/codecoverage/scripts/k3s-images.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e -x
+
+cd $(dirname $0)/..
+
+mkdir -p bin
+
+# This is used for downloading the tar file and not the images text file.
+# Referenced in test: tests/validation/tests/v3_api/test_airgap.py
+if [ -e /usr/tmp/k3s-images.txt ]; then
+    images=$(grep -e 'docker.io/rancher/mirrored-pause' -e 'docker.io/rancher/mirrored-coredns-coredns' /usr/tmp/k3s-images.txt)
+    xargs -n1 docker pull <<< "${images}"
+    docker save -o ./bin/k3s-airgap-images.tar ${images}
+else
+    touch bin/k3s-airgap-images.tar
+fi

--- a/tests/v2/codecoverage/scripts/merge_coverage_reports.sh
+++ b/tests/v2/codecoverage/scripts/merge_coverage_reports.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e -x
+
+cd  ~/go/src/github.com/rancher/rancher/tests/v2/codecoverage/ranchercover/cover
+
+# ls -al cover
+# gocovmerge cover/*.out > cover/merged.cov
+# ls -al cover
+
+dirlist=(`ls -p | tr '\n' ',' | tr -d '/' | sed 's/.$//'`) 
+mkdir merged
+go tool covdata merge -i=${dirlist}  -o merged
+
+go tool covdata textfmt -i=merged -o profile.txt
+# Output Total Coverage 
+go tool cover -func=profile.txt | grep -E '^total\:' | sed -E 's/\s+/ /g'
+
+go tool cover -html profile.txt -o merged.html

--- a/tests/v2/codecoverage/scripts/setup_code_coverage_enviornment.sh
+++ b/tests/v2/codecoverage/scripts/setup_code_coverage_enviornment.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+cd $(dirname $0)/../../../../
+
+echo "building bins"
+sh tests/v2/codecoverage/scripts/build_code_coverage_images.sh
+
+echo "build corral packages"
+sh tests/v2/codecoverage/scripts/build_corral_packages.sh
+
+echo | corral config
+
+echo "running rancher corral"
+tests/v2/codecoverage/bin/ranchercorral
+
+echo "setup rancher"
+tests/v2/codecoverage/bin/setuprancher

--- a/tests/v2/codecoverage/setuprancher/main.go
+++ b/tests/v2/codecoverage/setuprancher/main.go
@@ -1,0 +1,511 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/pkg/api/scheme"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/tests/framework/clients/corral"
+	"github.com/rancher/rancher/tests/framework/clients/dynamic"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/kubeapi/workloads/deployments"
+	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
+	aws "github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates/aws"
+	"github.com/rancher/rancher/tests/framework/extensions/token"
+	"github.com/rancher/rancher/tests/framework/extensions/unstructured"
+	"github.com/rancher/rancher/tests/framework/extensions/users"
+	passwordgenerator "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	appv1 "k8s.io/api/apps/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sUnstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	adminPassword = os.Getenv("ADMIN_PASSWORD")
+)
+
+const (
+	corralName       = "ranchertestcoverage"
+	rancherTestImage = "ranchertest/rancher:v2.7-head"
+	namespace        = "cattle-system"
+	deploymentName   = "rancher"
+	clusterName      = "local"
+	// The json/yaml config key for the corral package to be build ..
+	userClusterConfigsConfigurationFileKey = "userClusterConfig"
+)
+
+type UserClusterConfig struct {
+	Token         string   `json:"token" yaml:"token"`
+	Username      string   `json:"username" yaml:"username"`
+	Clusters      []string `json:"clusters" yaml:"clusters"`
+	AdminPassword string   `json:"AdminPassword" yaml:"AdminPassword"`
+}
+
+// setup for code coverage testing and reporting
+func main() {
+	rancherConfig := new(rancher.Config)
+	config.LoadConfig(rancher.ConfigurationFileKey, rancherConfig)
+
+	kubeconfig, err := getRancherKubeconfig()
+	if err != nil {
+		logrus.Fatalf("error with getting kube config using corral: %v", err)
+	}
+
+	password, err := corral.GetCorralEnvVar(corralName, "bootstrap_password")
+	if err != nil {
+		logrus.Fatalf("error getting password %v", err)
+	}
+
+	// update deployment
+	err = updateRancherDeployment(kubeconfig)
+	if err != nil {
+		logrus.Fatalf("error updating rancher deployment: %v", err)
+	}
+
+	token, err := createAdminToken(password, rancherConfig)
+	if err != nil {
+		logrus.Fatalf("error with generating admin token: %v", err)
+	}
+
+	rancherConfig.AdminToken = token
+	config.UpdateConfig(rancher.ConfigurationFileKey, rancherConfig)
+	//provision clusters for test
+	session := session.NewSession()
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+	kubernetesVersions := clustersConfig.RKE1KubernetesVersions
+	cnis := clustersConfig.CNIs
+	nodesAndRoles := clustersConfig.NodesAndRolesRKE1
+
+	client, err := rancher.NewClient("", session)
+	if err != nil {
+		logrus.Fatalf("error creating admin client: %v", err)
+	}
+
+	err = postRancherInstall(client)
+	if err != nil {
+		logrus.Fatalf("error with admin user service account secret: %v", err)
+	}
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = passwordgenerator.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	if err != nil {
+		logrus.Fatalf("error creating admin client: %v", err)
+	}
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	if err != nil {
+		logrus.Fatalf("error creating standard user client: %v", err)
+	}
+
+	// create admin cluster
+	adminClusterNames, err := createTestCluster(client, client, 1, "admintestcluster", cnis[0], kubernetesVersions[0], nodesAndRoles)
+	if err != nil {
+		logrus.Fatalf("error creating admin user cluster: %v", err)
+	}
+
+	// create standard user clusters
+	standardClusterNames, err := createTestCluster(standardUserClient, client, 2, "standardtestcluster", cnis[0], kubernetesVersions[0], nodesAndRoles)
+	if err != nil {
+		logrus.Fatalf("error creating standard user clusters: %v", err)
+	}
+
+	//update userconfig
+	userClusterConfig := UserClusterConfig{}
+	userClusterConfig.Token = standardUserClient.Steve.Opts.TokenKey
+	userClusterConfig.Username = newUser.Name
+	userClusterConfig.AdminPassword = adminPassword
+	userClusterConfig.Clusters = standardClusterNames
+
+	rancherConfig.ClusterName = adminClusterNames[0]
+	config.UpdateConfig(rancher.ConfigurationFileKey, rancherConfig)
+
+	err = writeToConfigFile(userClusterConfig)
+	if err != nil {
+		logrus.Fatalf("error writing config file: %v", err)
+	}
+}
+
+func getRancherKubeconfig() ([]byte, error) {
+	kubeconfig, err := corral.GetKubeConfig(corralName)
+	if err != nil {
+		return nil, err
+	}
+
+	return kubeconfig, nil
+}
+
+func createAdminToken(password string, rancherConfig *rancher.Config) (string, error) {
+	adminUser := &management.User{
+		Username: "admin",
+		Password: password,
+	}
+
+	hostURL := rancherConfig.Host
+	var userToken *management.Token
+	err := kwait.Poll(500*time.Millisecond, 5*time.Minute, func() (done bool, err error) {
+		userToken, err = token.GenerateUserToken(adminUser, hostURL)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return userToken.Token, nil
+}
+
+func updateRancherDeployment(kubeconfig []byte) error {
+	session := session.NewSession()
+	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	restConfig, err := (clientConfig).ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(session, restConfig)
+	if err != nil {
+		return err
+	}
+
+	deploymentResource := dynamicClient.Resource(deployments.DeploymentGroupVersionResource)
+
+	cattleSystemDeploymentResource := deploymentResource.Namespace(namespace)
+	unstructuredDeployment, err := cattleSystemDeploymentResource.Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	updatedDeployment := &appv1.Deployment{}
+	err = scheme.Scheme.Convert(unstructuredDeployment, updatedDeployment, unstructuredDeployment.GroupVersionKind())
+	if err != nil {
+		return err
+	}
+
+	updatedDeployment.Spec.Template.Spec.Containers[0].Args = []string{}
+	updatedDeployment.Spec.Template.Spec.Containers[0].Image = rancherTestImage
+	updatedDeployment.Spec.Strategy.RollingUpdate = nil
+	updatedDeployment.Spec.Strategy.Type = appv1.RecreateDeploymentStrategyType
+
+	unstructuredResp, err := cattleSystemDeploymentResource.Update(context.TODO(), unstructured.MustToUnstructured(updatedDeployment), metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	err = kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
+		_, err = cattleSystemDeploymentResource.Get(context.TODO(), deploymentName, metav1.GetOptions{})
+		if k8sErrors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	newDeployment := &appv1.Deployment{}
+	err = scheme.Scheme.Convert(unstructuredResp, newDeployment, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return err
+	}
+
+	// wait until pods are ready with new images
+
+	result, err := cattleSystemDeploymentResource.Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + deploymentName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = wait.WatchWait(result, func(event watch.Event) (ready bool, err error) {
+		deploymentUnstructured := event.Object.(*k8sUnstructured.Unstructured)
+		newDeployment := &appv1.Deployment{}
+		err = scheme.Scheme.Convert(deploymentUnstructured, newDeployment, deploymentUnstructured.GroupVersionKind())
+		if err != nil {
+			return false, err
+		}
+		if newDeployment.Status.ReadyReplicas == int32(3) {
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	err = kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
+		_, err = cattleSystemDeploymentResource.Get(context.TODO(), deploymentName, metav1.GetOptions{})
+		if k8sErrors.IsInternalError(err) || k8sErrors.IsServiceUnavailable(err) {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	err = kwait.Poll(500*time.Millisecond, 10*time.Minute, func() (done bool, err error) {
+		webhookDeployment, err := cattleSystemDeploymentResource.Get(context.TODO(), "rancher-webhook", metav1.GetOptions{})
+		if k8sErrors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+
+		newDeployment := &appv1.Deployment{}
+		err = scheme.Scheme.Convert(webhookDeployment, newDeployment, webhookDeployment.GroupVersionKind())
+		if err != nil {
+			return false, err
+		}
+		if newDeployment.Status.ReadyReplicas == int32(1) {
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	cattleFleetLocalSystemDeploymentResource := deploymentResource.Namespace("cattle-fleet-local-system")
+	err = kwait.Poll(500*time.Millisecond, 10*time.Minute, func() (done bool, err error) {
+		fleetAgentDeployment, err := cattleFleetLocalSystemDeploymentResource.Get(context.TODO(), "fleet-agent", metav1.GetOptions{})
+		if k8sErrors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+		newDeployment := &appv1.Deployment{}
+		err = scheme.Scheme.Convert(fleetAgentDeployment, newDeployment, fleetAgentDeployment.GroupVersionKind())
+		if err != nil {
+			return false, err
+		}
+		if newDeployment.Status.ReadyReplicas == int32(1) {
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	cattleFleetSystemDeploymentResource := deploymentResource.Namespace("cattle-fleet-system")
+	err = kwait.Poll(500*time.Millisecond, 10*time.Minute, func() (done bool, err error) {
+		fleetControllerDeployment, err := cattleFleetSystemDeploymentResource.Get(context.TODO(), "fleet-controller", metav1.GetOptions{})
+		if k8sErrors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+
+		newDeployment := &appv1.Deployment{}
+		err = scheme.Scheme.Convert(fleetControllerDeployment, newDeployment, fleetControllerDeployment.GroupVersionKind())
+		if err != nil {
+			return false, err
+		}
+		if newDeployment.Status.ReadyReplicas == int32(1) {
+			return true, nil
+		}
+		return false, nil
+	})
+
+	return err
+}
+
+func createTestCluster(client, adminClient *rancher.Client, numClusters int, clusterNameBase, cni, kubeVersion string, nodesAndRoles []nodepools.NodeRoles) ([]string, error) {
+	clusterNames := []string{}
+	for i := 0; i < numClusters; i++ {
+		clusterName := namegen.AppendRandomString(clusterNameBase)
+		clusterNames = append(clusterNames, clusterName)
+		cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, client)
+
+		clusterResp, err := clusters.CreateRKE1Cluster(client, cluster)
+		if err != nil {
+			return nil, err
+		}
+
+		err = kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
+			cluster, err := client.Management.Cluster.ByID(clusterResp.ID)
+			if err != nil {
+				return false, nil
+			} else if cluster != nil && cluster.ID == clusterResp.ID {
+				return true, nil
+			}
+			return false, nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		nodeTemplateResp, err := aws.CreateAWSNodeTemplate(client)
+		if err != nil {
+			return nil, err
+		}
+
+		err = kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
+			nodeTemplate, err := client.Management.NodeTemplate.ByID(nodeTemplateResp.ID)
+			if err != nil {
+				return false, nil
+			} else if nodeTemplate != nil && nodeTemplate.ID == nodeTemplateResp.ID {
+				return true, nil
+			}
+			return false, nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		err = kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
+			_, err = nodepools.NodePoolSetup(client, nodesAndRoles, clusterResp.ID, nodeTemplateResp.ID)
+			if err != nil {
+				return false, nil
+			}
+
+			return true, nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+		fmt.Println("before node pool poll")
+
+		opts := metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + clusterResp.ID,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		}
+		watchInterface, err := adminClient.GetManagementWatchInterface(management.ClusterType, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		checkFunc := clusters.IsHostedProvisioningClusterReady
+
+		err = wait.WatchWait(watchInterface, checkFunc)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return clusterNames, nil
+}
+
+func writeToConfigFile(config UserClusterConfig) error {
+	result := map[string]UserClusterConfig{}
+	result[userClusterConfigsConfigurationFileKey] = config
+
+	yamlConfig, err := yaml.Marshal(result)
+
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile("userclusterconfig.yaml", yamlConfig, 0644)
+}
+
+func postRancherInstall(adminClient *rancher.Client) error {
+	clusterID, err := clusters.GetClusterIDByName(adminClient, clusterName)
+	if err != nil {
+		return err
+	}
+
+	steveClient, err := adminClient.Steve.ProxyDownstream(clusterID)
+	if err != nil {
+		return err
+	}
+
+	timeStamp := time.Now().Format(time.RFC3339)
+	settingEULA := v3.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "eula-agreed",
+		},
+		Default: timeStamp,
+		Value:   timeStamp,
+	}
+
+	urlSetting := &v3.Setting{}
+
+	_, err = steveClient.SteveType("management.cattle.io.setting").Create(settingEULA)
+	if err != nil {
+		return err
+	}
+
+	urlSettingResp, err := steveClient.SteveType("management.cattle.io.setting").ByID("server-url")
+	if err != nil {
+		return err
+	}
+
+	err = v1.ConvertToK8sType(urlSettingResp.JSONResp, urlSetting)
+	if err != nil {
+		return err
+	}
+
+	urlSetting.Value = fmt.Sprintf("https://%s", adminClient.RancherConfig.Host)
+
+	_, err = steveClient.SteveType("management.cattle.io.setting").Update(urlSettingResp, urlSetting)
+	if err != nil {
+		return err
+	}
+
+	userList, err := adminClient.Management.User.List(&types.ListOpts{
+		Filters: map[string]interface{}{
+			"username": "admin",
+		},
+	})
+	if err != nil {
+		return err
+	} else if len(userList.Data) == 0 {
+		return fmt.Errorf("admin user not found")
+	}
+
+	adminUser := &userList.Data[0]
+	setPasswordInput := management.SetPasswordInput{
+		NewPassword: adminPassword,
+	}
+	_, err = adminClient.Management.User.ActionSetpassword(adminUser, &setPasswordInput)
+
+	return err
+}

--- a/tests/v2/integration/catalogv2/cluster_repo_test.go
+++ b/tests/v2/integration/catalogv2/cluster_repo_test.go
@@ -42,7 +42,7 @@ func (c *ClusterRepoTestSuite) TearDownSuite() {
 }
 
 func (c *ClusterRepoTestSuite) SetupSuite() {
-	testSession := session.NewSession(c.T())
+	testSession := session.NewSession()
 	c.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
@@ -134,6 +134,9 @@ func (c *ClusterRepoTestSuite) pollUntilDownloaded(ClusterRepoName string, prevD
 	var clusterRepo *stevev1.SteveAPIObject
 	err := wait.Poll(PollInterval, PollTimeout, func() (done bool, err error) {
 		clusterRepo, err = c.client.Steve.SteveType(catalog.ClusterRepoSteveResourceType).ByID(ClusterRepoName)
+		if err != nil {
+			return false, err
+		}
 		status := c.getStatusFromClusterRepo(clusterRepo)
 		if clusterRepo.Name != ClusterRepoName {
 			return false, nil

--- a/tests/v2/integration/projects/project_user_test.go
+++ b/tests/v2/integration/projects/project_user_test.go
@@ -31,7 +31,7 @@ func (p *ProjectUserTestSuite) TearDownSuite() {
 }
 
 func (p *ProjectUserTestSuite) SetupSuite() {
-	testSession := session.NewSession(p.T())
+	testSession := session.NewSession()
 	p.session = testSession
 
 	client, err := rancher.NewClient("", testSession)

--- a/tests/v2/integration/projects/resource_quota_test.go
+++ b/tests/v2/integration/projects/resource_quota_test.go
@@ -37,7 +37,7 @@ func (s *ResourceQuotaSuite) TearDownSuite() {
 }
 
 func (s *ResourceQuotaSuite) SetupSuite() {
-	testSession := session.NewSession(s.T())
+	testSession := session.NewSession()
 	s.session = testSession
 
 	client, err := rancher.NewClient("", testSession)

--- a/tests/v2/integration/steveapi/steve_api_test.go
+++ b/tests/v2/integration/steveapi/steve_api_test.go
@@ -163,7 +163,7 @@ func (s *SteveAPITestSuite) TearDownSuite() {
 }
 
 func (s *SteveAPITestSuite) SetupSuite() {
-	testSession := session.NewSession(s.T())
+	testSession := session.NewSession()
 	s.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
@@ -183,9 +183,10 @@ func (s *SteveAPITestSuite) SetupSuite() {
 		ClusterID: clusterID,
 		Name:      projectName,
 	})
+	require.NoError(s.T(), err)
 
 	// create project namespaces
-	for k, _ := range namespaceMap {
+	for k := range namespaceMap {
 		name := namegenerator.AppendRandomString(k)
 		_, err := namespaces.CreateNamespace(client, name, "", nil, nil, s.project)
 		require.NoError(s.T(), err)
@@ -251,6 +252,7 @@ func (s *SteveAPITestSuite) SetupSuite() {
 					Name: userObj.ID,
 				}
 				_, err = rbac.CreateRoleBinding(s.client, s.project.ClusterID, namegenerator.AppendRandomString(rb.Name), namespaceMap[rb.Namespace], rb.RoleRef.Name, subject)
+				require.NoError(s.T(), err)
 			}
 		}
 		s.userClients[user], err = s.client.AsUser(userObj)

--- a/tests/v2/validation/charts/gatekeeper_test.go
+++ b/tests/v2/validation/charts/gatekeeper_test.go
@@ -30,7 +30,7 @@ func (g *GateKeeperTestSuite) TearDownSuite() {
 }
 
 func (g *GateKeeperTestSuite) SetupSuite() {
-	testSession := session.NewSession(g.T())
+	testSession := session.NewSession()
 	g.session = testSession
 
 	client, err := rancher.NewClient("", testSession)

--- a/tests/v2/validation/charts/istio_test.go
+++ b/tests/v2/validation/charts/istio_test.go
@@ -35,7 +35,7 @@ func (i *IstioTestSuite) TearDownSuite() {
 }
 
 func (i *IstioTestSuite) SetupSuite() {
-	testSession := session.NewSession(i.T())
+	testSession := session.NewSession()
 	i.session = testSession
 
 	client, err := rancher.NewClient("", testSession)

--- a/tests/v2/validation/charts/monitoring_test.go
+++ b/tests/v2/validation/charts/monitoring_test.go
@@ -40,7 +40,7 @@ func (m *MonitoringTestSuite) TearDownSuite() {
 }
 
 func (m *MonitoringTestSuite) SetupSuite() {
-	testSession := session.NewSession(m.T())
+	testSession := session.NewSession()
 	m.session = testSession
 
 	client, err := rancher.NewClient("", testSession)

--- a/tests/v2/validation/provisioning/hosted/aks/provisioning/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/aks/provisioning/hosted_provisioning_test.go
@@ -33,7 +33,7 @@ func (h *HostedAKSClusterProvisioningTestSuite) TearDownSuite() {
 }
 
 func (h *HostedAKSClusterProvisioningTestSuite) SetupSuite() {
-	testSession := session.NewSession(h.T())
+	testSession := session.NewSession()
 	h.session = testSession
 
 	client, err := rancher.NewClient("", testSession)

--- a/tests/v2/validation/provisioning/hosted/eks/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/eks/hosted_provisioning_test.go
@@ -33,7 +33,7 @@ func (h *HostedEKSClusterProvisioningTestSuite) TearDownSuite() {
 }
 
 func (h *HostedEKSClusterProvisioningTestSuite) SetupSuite() {
-	testSession := session.NewSession(h.T())
+	testSession := session.NewSession()
 	h.session = testSession
 
 	client, err := rancher.NewClient("", testSession)

--- a/tests/v2/validation/provisioning/hosted/gke/hosted_provisioning_test.go
+++ b/tests/v2/validation/provisioning/hosted/gke/hosted_provisioning_test.go
@@ -33,7 +33,7 @@ func (h *HostedGKEClusterProvisioningTestSuite) TearDownSuite() {
 }
 
 func (h *HostedGKEClusterProvisioningTestSuite) SetupSuite() {
-	testSession := session.NewSession(h.T())
+	testSession := session.NewSession()
 	h.session = testSession
 
 	client, err := rancher.NewClient("", testSession)

--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -42,7 +42,7 @@ func (c *CustomClusterProvisioningTestSuite) TearDownSuite() {
 }
 
 func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
-	testSession := session.NewSession(c.T())
+	testSession := session.NewSession()
 	c.session = testSession
 
 	clustersConfig := new(provisioning.Config)
@@ -107,7 +107,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningK3SCustomCluster(extern
 		for _, kubeVersion := range c.kubernetesVersions {
 			name = tt.name + " Kubernetes version: " + kubeVersion
 			c.Run(name, func() {
-				testSession := session.NewSession(c.T())
+				testSession := session.NewSession()
 				defer testSession.Cleanup()
 
 				client, err := tt.client.WithSession(testSession)
@@ -215,7 +215,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningK3SCustomClusterDynamic
 		for _, kubeVersion := range c.kubernetesVersions {
 			name = tt.name + " Kubernetes version: " + kubeVersion
 			c.Run(name, func() {
-				testSession := session.NewSession(c.T())
+				testSession := session.NewSession()
 				defer testSession.Cleanup()
 
 				client, err := tt.client.WithSession(testSession)

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
@@ -41,7 +41,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) TearDownSuite() {
 }
 
 func (k *K3SNodeDriverProvisioningTestSuite) SetupSuite() {
-	testSession := session.NewSession(k.T())
+	testSession := session.NewSession()
 	k.session = testSession
 
 	clustersConfig := new(provisioning.Config)
@@ -132,7 +132,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) ProvisioningK3SCluster(provider Pro
 		for _, kubeVersion := range k.kubernetesVersions {
 			name = tt.name + providerName + " Kubernetes version: " + kubeVersion
 			k.Run(name, func() {
-				testSession := session.NewSession(k.T())
+				testSession := session.NewSession()
 				defer testSession.Cleanup()
 
 				testSessionClient, err := tt.client.WithSession(testSession)
@@ -199,7 +199,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) ProvisioningK3SClusterDynamicInput(
 		for _, kubeVersion := range k.kubernetesVersions {
 			name = tt.name + providerName + " Kubernetes version: " + kubeVersion
 			k.Run(name, func() {
-				testSession := session.NewSession(k.T())
+				testSession := session.NewSession()
 				defer testSession.Cleanup()
 
 				testSessionClient, err := tt.client.WithSession(testSession)

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -37,7 +37,7 @@ func (c *CustomClusterProvisioningTestSuite) TearDownSuite() {
 }
 
 func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
-	testSession := session.NewSession(c.T())
+	testSession := session.NewSession()
 	c.session = testSession
 
 	clustersConfig := new(provisioning.Config)
@@ -96,7 +96,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 	}
 	var name string
 	for _, tt := range tests {
-		testSession := session.NewSession(c.T())
+		testSession := session.NewSession()
 		defer testSession.Cleanup()
 
 		client, err := tt.client.WithSession(testSession)
@@ -152,7 +152,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomClusterDy
 
 	var name string
 	for _, tt := range tests {
-		testSession := session.NewSession(c.T())
+		testSession := session.NewSession()
 		defer testSession.Cleanup()
 
 		client, err := tt.client.WithSession(testSession)

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -36,7 +36,7 @@ func (r *RKE1NodeDriverProvisioningTestSuite) TearDownSuite() {
 }
 
 func (r *RKE1NodeDriverProvisioningTestSuite) SetupSuite() {
-	testSession := session.NewSession(r.T())
+	testSession := session.NewSession()
 	r.session = testSession
 
 	clustersConfig := new(provisioning.Config)

--- a/tests/v2/validation/provisioning/rke2/cert_rotation_test.go
+++ b/tests/v2/validation/provisioning/rke2/cert_rotation_test.go
@@ -39,7 +39,7 @@ func (r *V2ProvCertRotationTestSuite) TearDownSuite() {
 }
 
 func (r *V2ProvCertRotationTestSuite) SetupSuite() {
-	testSession := session.NewSession(r.T())
+	testSession := session.NewSession()
 	r.session = testSession
 
 	r.config = new(provisioning.Config)
@@ -58,7 +58,7 @@ func (r *V2ProvCertRotationTestSuite) testCertRotation(provider Provider, kubeVe
 	name := fmt.Sprintf("Provider_%s/Kubernetes_Version_%s/Nodes_%v", provider.Name, kubeVersion, nodesAndRoles)
 	r.Run(name, func() {
 		r.Run("initial", func() {
-			testSession := session.NewSession(r.T())
+			testSession := session.NewSession()
 			defer testSession.Cleanup()
 
 			testSessionClient, err := r.client.WithSession(testSession)

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -43,7 +43,7 @@ func (c *CustomClusterProvisioningTestSuite) TearDownSuite() {
 }
 
 func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
-	testSession := session.NewSession(c.T())
+	testSession := session.NewSession()
 	c.session = testSession
 
 	clustersConfig := new(provisioning.Config)
@@ -96,7 +96,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 	tests := []struct {
 		name         string
 		nodeRoles    []string
-		hardening *provisioning.Config
+		hardening    *provisioning.Config
 		nodeCountWin int
 		hasWindows   bool
 		client       *rancher.Client
@@ -117,7 +117,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 			for _, cni := range c.cnis {
 				name += " cni: " + cni
 				c.Run(name, func() {
-					testSession := session.NewSession(c.T())
+					testSession := session.NewSession()
 					defer testSession.Cleanup()
 
 					client, err := tt.client.WithSession(testSession)
@@ -203,7 +203,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomCluster(exter
 						hardenClusterResp, err := clusters.UpdateK3SRKE2Cluster(client, clusterResp, hardenCluster)
 						require.NoError(c.T(), err)
 						assert.Equal(c.T(), clusterName, hardenClusterResp.ObjectMeta.Name)
-						
+
 						err = hardening.PostHardeningConfig(client, tt.hardening.Hardened, linuxNodes, tt.nodeRoles)
 						require.NoError(c.T(), err)
 					}
@@ -235,10 +235,10 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynami
 	numOfNodes := len(rolesPerNode)
 
 	tests := []struct {
-		name          string
-		client        *rancher.Client
+		name       string
+		client     *rancher.Client
 		hasWindows bool
-		hardening *provisioning.Config
+		hardening  *provisioning.Config
 	}{
 		{"Admin User", c.client, false, c.provisioning},
 		{"Standard User", c.standardUserClient, false, c.provisioning},
@@ -251,7 +251,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynami
 			for _, cni := range c.cnis {
 				name += " cni: " + cni
 				c.Run(name, func() {
-					testSession := session.NewSession(c.T())
+					testSession := session.NewSession()
 					defer testSession.Cleanup()
 
 					client, err := tt.client.WithSession(testSession)
@@ -330,6 +330,7 @@ func (c *CustomClusterProvisioningTestSuite) ProvisioningRKE2CustomClusterDynami
 }
 
 func (c *CustomClusterProvisioningTestSuite) TestProvisioningCustomCluster() {
+	c.T().Skip()
 	for _, nodeProviderName := range c.nodeProviders {
 		externalNodeProvider := provisioning.ExternalNodeProviderSetup(nodeProviderName)
 		c.ProvisioningRKE2CustomCluster(externalNodeProvider)

--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
@@ -54,7 +54,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) TearDownSuite() {
 }
 
 func (r *RKE2EtcdSnapshotRestoreTestSuite) SetupSuite() {
-	testSession := session.NewSession(r.T())
+	testSession := session.NewSession()
 	r.session = testSession
 
 	r.ns = defaultNamespace

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -43,7 +43,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TearDownSuite() {
 }
 
 func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
-	testSession := session.NewSession(r.T())
+	testSession := session.NewSession()
 	r.session = testSession
 
 	clustersConfig := new(provisioning.Config)
@@ -137,7 +137,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2Cluster(provider P
 			for _, cni := range r.cnis {
 				name += " cni: " + cni
 				r.Run(name, func() {
-					testSession := session.NewSession(r.T())
+					testSession := session.NewSession()
 					defer testSession.Cleanup()
 
 					testSessionClient, err := tt.client.WithSession(testSession)
@@ -207,7 +207,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2ClusterDynamicInpu
 			for _, cni := range r.cnis {
 				name += " cni: " + cni
 				r.Run(name, func() {
-					testSession := session.NewSession(r.T())
+					testSession := session.NewSession()
 					defer testSession.Cleanup()
 
 					testSessionClient, err := tt.client.WithSession(testSession)
@@ -298,7 +298,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) ProvisioningRKE2CNICluster(provide
 			for _, cni := range r.cnis {
 				name += " cni: " + cni
 				r.Run(name, func() {
-					testSession := session.NewSession(r.T())
+					testSession := session.NewSession()
 					defer testSession.Cleanup()
 
 					testSessionClient, err := tt.client.WithSession(testSession)

--- a/tests/v2/validation/rbac/rbac_test.go
+++ b/tests/v2/validation/rbac/rbac_test.go
@@ -44,7 +44,7 @@ func (rb *RBTestSuite) TearDownSuite() {
 }
 
 func (rb *RBTestSuite) SetupSuite() {
-	testSession := session.NewSession(rb.T())
+	testSession := session.NewSession()
 	rb.session = testSession
 
 	client, err := rancher.NewClient("", testSession)

--- a/tests/v2/validation/standalone/corral_generic_test.go
+++ b/tests/v2/validation/standalone/corral_generic_test.go
@@ -21,7 +21,7 @@ func (r *CorralStandaloneTestSuite) TearDownSuite() {
 }
 
 func (r *CorralStandaloneTestSuite) SetupSuite() {
-	testSession := session.NewSession(r.T())
+	testSession := session.NewSession()
 	r.session = testSession
 
 	corralConfig := corral.CorralConfigurations()

--- a/tests/v2/validation/upgrade/kubernetes_test.go
+++ b/tests/v2/validation/upgrade/kubernetes_test.go
@@ -23,7 +23,7 @@ func (u *UpgradeKubernetesTestSuite) TearDownSuite() {
 }
 
 func (u *UpgradeKubernetesTestSuite) SetupSuite() {
-	testSession := session.NewSession(u.T())
+	testSession := session.NewSession()
 	u.session = testSession
 
 	client, err := rancher.NewClient("", testSession)

--- a/tests/v2/validation/upgrade/workload_test.go
+++ b/tests/v2/validation/upgrade/workload_test.go
@@ -41,7 +41,7 @@ func (u *UpgradeWorkloadTestSuite) TearDownSuite() {
 }
 
 func (u *UpgradeWorkloadTestSuite) SetupSuite() {
-	testSession := session.NewSession(u.T())
+	testSession := session.NewSession()
 	u.session = testSession
 
 	client, err := rancher.NewClient("", testSession)


### PR DESCRIPTION
This PR includes code coverage custom binaries for both rancher and agent. As well as, Dockerfiles for both rancher and rancher-agent. Setup scripts for creating the binaries and the docker images. Scripts for setting the Jenkins environment to have a test coverage run for all our tests. New extensions that kill the containers that are running the rancher/agent images to have the coverage reports written, and code to retreive those reports from their pods.

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> https://github.com/rancher/rancher/issues/38282, https://github.com/rancher/qa-tasks/issues/520
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. --> Need to have a way to measure our code coverage of rancher/rancher from out end to end tests, including all of python tests (validation and integration), and our go automation tests.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
**Overview**
1. Custom test binaries for rancher and rancher-agent. This is so we can encapsulate the rancher/main.go and rancher/cmd/agent/main.go in `main` functions to be able run the binaries as tests to be able to use the `go build -cover` functionality but also be able to kill the bin to have reports written.
2. Custom Dockerfiles for both rancher and rancher-agent to be run in deployments of the local cluster and the downstream clusters provisioned by rancher. 
3. New extensions that work as kubectl exec calls to able to "kill" the container in the its respective pod that is running the custom image (rancher or rancher-agent) and also calls to be able to retrieve said coverage reports from the pods to a local destination.
4. New Jenkins pipeline that runs all of our end to end tests, retrieves the code coverage reports, and publishes the reports.
5. Set up code the sets up the environment for our aforementioned Jenkins pipeline, that uses corral to create a rancher instance, update the rancher instance to use the custom code coverage images, and provision clusters to be used in the end to end tests.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. --> code coverage report Jenkins job

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->