### PR TITLE
Remove v1beta1.CronJob reference fix build sources

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -161,6 +161,8 @@ var OriginMap = map[string]string{
 	"mirrored-longhornio-csi-snapshotter":                     "https://github.com/longhorn/external-snapshotter",
 	"mirrored-longhornio-longhorn-engine":                     "https://github.com/longhorn/longhorn-engine",
 	"mirrored-longhornio-longhorn-instance-manager":           "https://github.com/longhorn/longhorn-instance-manager",
+	"mirrored-longhornio-livenessprobe":                       "https://github.com/longhorn/mirrored-longhornio-livenessprobe",
+	"mirrored-longhornio-support-bundle-kit":                  "https://github.com/longhorn/mirrored-longhornio-support-bundle-kit",
 	"mirrored-longhornio-longhorn-manager":                    "https://github.com/longhorn/longhorn-manager",
 	"mirrored-longhornio-longhorn-share-manager":              "https://github.com/longhorn/longhorn-share-manager",
 	"mirrored-longhornio-longhorn-ui":                         "https://github.com/longhorn/longhorn-ui",

--- a/tests/framework/extensions/kubeapi/workloads/cronjobs/create.go
+++ b/tests/framework/extensions/kubeapi/workloads/cronjobs/create.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,20 +26,20 @@ var CronJobGroupVersionResource = schema.GroupVersionResource{
 
 // CreateCronJob is a helper function that uses the dynamic client to create a cronjob on a namespace for a specific cluster.
 // It registers a delete fuction a wait.WatchWait to ensure the cronjob is deleted cleanly.
-func CreateCronJob(client *rancher.Client, clusterName, cronJobName, namespace, schedule string, template corev1.PodTemplateSpec) (*v1beta1.CronJob, error) {
+func CreateCronJob(client *rancher.Client, clusterName, cronJobName, namespace, schedule string, template corev1.PodTemplateSpec) (*batchv1.CronJob, error) {
 	dynamicClient, err := client.GetDownStreamClusterClient(clusterName)
 	if err != nil {
 		return nil, err
 	}
 
 	template.Spec.RestartPolicy = corev1.RestartPolicyNever
-	cronJob := &v1beta1.CronJob{
+	cronJob := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cronJobName,
 			Namespace: namespace,
 		},
-		Spec: v1beta1.CronJobSpec{
-			JobTemplate: v1beta1.JobTemplateSpec{
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Template: template,
 				},
@@ -82,7 +81,7 @@ func CreateCronJob(client *rancher.Client, clusterName, cronJobName, namespace, 
 		})
 	})
 
-	newcronJob := &v1beta1.CronJob{}
+	newcronJob := &batchv1.CronJob{}
 	err = scheme.Scheme.Convert(unstructuredResp, newcronJob, unstructuredResp.GroupVersionKind())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/38701

## Problem
Fix use batch/v1 API version for cronJob to make app catalogs load in k8s 1.25.5
Add source paths to make build work
 
## Solution
Remove last reference of v1beta1.CronJob that was blocking catalog fetch
 
## Testing


## Engineering Testing
### Manual Testing
Stood up microk8s cluster in v1.25.5 apps catalog visible now

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->