### PR TITLE
[2.6] Use the unstructured client to update auth config objects

### DIFF
--- a/pkg/controllers/management/auth/auth_config.go
+++ b/pkg/controllers/management/auth/auth_config.go
@@ -2,13 +2,17 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
+	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/rancher/pkg/auth/cleanup"
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
-	controllers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -32,30 +36,63 @@ type CleanupService interface {
 	Run(config *v3.AuthConfig) error
 }
 
+// Note the use of the GenericClient here.  Our AuthConfigs contain internal-only fields that deal with
+// various auth providers.  Those fields are not present everywhere, nor are they defined in the CRD.  Given
+// that, the regular client will "eat" those internal-only fields, so in this case, we use
+// the unstructured client, losing some validation, but gaining the flexibility we require.
 type authConfigController struct {
-	users            v3.UserLister
-	authRefresher    providerrefresh.UserAuthRefresher
-	cleanup          CleanupService
-	authConfigClient controllers.AuthConfigClient
+	users                   v3.UserLister
+	authRefresher           providerrefresh.UserAuthRefresher
+	cleanup                 CleanupService
+	authConfigsUnstructured objectclient.GenericClient
 }
 
 func newAuthConfigController(context context.Context, mgmt *config.ManagementContext, scaledContext *config.ScaledContext) *authConfigController {
 	controller := &authConfigController{
-		users:            mgmt.Management.Users("").Controller().Lister(),
-		authRefresher:    providerrefresh.NewUserAuthRefresher(context, scaledContext),
-		cleanup:          cleanup.NewCleanupService(mgmt.Core.Secrets(""), mgmt.Wrangler.Mgmt),
-		authConfigClient: mgmt.Wrangler.Mgmt.AuthConfig(),
+		users:                   mgmt.Management.Users("").Controller().Lister(),
+		authRefresher:           providerrefresh.NewUserAuthRefresher(context, scaledContext),
+		cleanup:                 cleanup.NewCleanupService(mgmt.Core.Secrets(""), mgmt.Wrangler.Mgmt),
+		authConfigsUnstructured: scaledContext.Management.AuthConfigs("").ObjectClient().UnstructuredClient(),
 	}
 	return controller
 }
 
-func (ac *authConfigController) setCleanupAnnotation(obj *v3.AuthConfig, value string) (runtime.Object, error) {
-	if obj.Annotations == nil {
-		obj.Annotations = make(map[string]string)
+func (ac *authConfigController) setCleanupAnnotation(obj *v3.AuthConfig, value string) (*v3.AuthConfig, error) {
+	runtimeObj, err := ac.authConfigsUnstructured.Get(obj.Name, v1.GetOptions{})
+	if err != nil {
+		return nil, err
 	}
-	objCopy := obj.DeepCopy()
-	objCopy.Annotations[CleanupAnnotation] = value
-	return ac.authConfigClient.Update(objCopy)
+	unstructuredObj, ok := runtimeObj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("auth config %s is not an unstructured value", obj.Name)
+	}
+	annotations := unstructuredObj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[CleanupAnnotation] = value
+	unstructuredObj.SetAnnotations(annotations)
+	uobj, err := ac.authConfigsUnstructured.Update(obj.Name, unstructuredObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update AuthConfig object: %w", err)
+	}
+	// We ned to return an AuthConfig, but Update deals in terms of unstructured objects.
+	// Given that, we need to convert the unstructured object to an AuthConfig.
+	// Normally, we'd like to use mapstructure.Decode, but its handling of embedded structs
+	// does not give us the desired result in this instance, hence the use of json.
+	unObject, ok := uobj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("failed to read to unstructured data")
+	}
+	data, err := json.Marshal(unObject.UnstructuredContent())
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal unstructured object: %w", err)
+	}
+	result := &v3.AuthConfig{}
+	if err := json.Unmarshal(data, result); err != nil {
+		return nil, fmt.Errorf("uanble to unmarshal to AuthConfig object: %w", err)
+	}
+	return result, nil
 }
 
 func (ac *authConfigController) sync(key string, obj *v3.AuthConfig) (runtime.Object, error) {

--- a/pkg/controllers/management/auth/auth_config_test.go
+++ b/pkg/controllers/management/auth/auth_config_test.go
@@ -1,14 +1,19 @@
 package auth
 
 import (
+	"encoding/json"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/rancher/norman/objectclient"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	azuread "github.com/rancher/rancher/pkg/auth/providers/azure/clients"
-	controllers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 )
@@ -87,15 +92,8 @@ func TestCleanupRuns(t *testing.T) {
 		},
 	}
 
-	mockAuthConfig := newMockAuthConfigClient()
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			var service cleanupService
-			controller := authConfigController{
-				cleanup:          &service,
-				authConfigClient: mockAuthConfig,
-			}
 			config := &v3.AuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        azuread.Name,
@@ -104,10 +102,17 @@ func TestCleanupRuns(t *testing.T) {
 				Enabled: test.configEnabled,
 			}
 
-			obj, err := controller.sync("test", config)
+			var service cleanupService
+			controller := authConfigController{
+				cleanup:                 &service,
+				authConfigsUnstructured: newMockAuthConfigClient(config),
+			}
+
+			authConfig, err := controller.sync("test", config)
+			acObject := authConfig.(*v3.AuthConfig)
 			require.NoError(t, err)
+			assert.Equal(t, test.newAnnotationValue, acObject.Annotations[CleanupAnnotation])
 			assert.Equal(t, test.expectCleanup, service.cleanupCalled)
-			assert.Equal(t, test.newAnnotationValue, obj.(*v3.AuthConfig).Annotations[CleanupAnnotation])
 		})
 	}
 }
@@ -121,43 +126,142 @@ func (s *cleanupService) Run(_ *v3.AuthConfig) error {
 	return nil
 }
 
+type mockUnstructuredAuthConfig struct {
+	config *v3.AuthConfig
+}
+
+func (m mockUnstructuredAuthConfig) GetObjectKind() schema.ObjectKind {
+	return nil
+}
+
+func (m mockUnstructuredAuthConfig) DeepCopyObject() runtime.Object {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockUnstructuredAuthConfig) NewEmptyInstance() runtime.Unstructured {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockUnstructuredAuthConfig) UnstructuredContent() map[string]interface{} {
+	var out map[string]any
+	b, err := json.Marshal(m.config)
+	if err != nil {
+		return nil
+	}
+	err = json.Unmarshal(b, &out)
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+func (m mockUnstructuredAuthConfig) SetUnstructuredContent(content map[string]interface{}) {
+	b, err := json.Marshal(content)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(b, m.config)
+	if err != nil {
+		return
+	}
+}
+
+func (m mockUnstructuredAuthConfig) IsList() bool {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockUnstructuredAuthConfig) EachListItem(f func(runtime.Object) error) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 type mockAuthConfigClient struct {
+	config mockUnstructuredAuthConfig
 }
 
-func (m mockAuthConfigClient) Create(_ *v3.AuthConfig) (*v3.AuthConfig, error) {
+func newMockAuthConfigClient(authConfig *v3.AuthConfig) objectclient.GenericClient {
+	return mockAuthConfigClient{config: mockUnstructuredAuthConfig{authConfig}}
+}
+
+func (m mockAuthConfigClient) Get(name string, opts metav1.GetOptions) (runtime.Object, error) {
+	o := unstructured.Unstructured{}
+	o.SetUnstructuredContent(map[string]any{"Object": m.config})
+	return &o, nil
+}
+
+func (m mockAuthConfigClient) Update(name string, o runtime.Object) (runtime.Object, error) {
+	return o, nil
+}
+
+func (m mockAuthConfigClient) UnstructuredClient() objectclient.GenericClient {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) Update(config *v3.AuthConfig) (*v3.AuthConfig, error) {
-	return config, nil
-}
-
-func (m mockAuthConfigClient) Delete(_ string, _ *metav1.DeleteOptions) error {
+func (m mockAuthConfigClient) GroupVersionKind() schema.GroupVersionKind {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) Get(_ string, _ metav1.GetOptions) (*v3.AuthConfig, error) {
+func (m mockAuthConfigClient) Create(o runtime.Object) (runtime.Object, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) List(_ metav1.ListOptions) (*v3.AuthConfigList, error) {
+func (m mockAuthConfigClient) GetNamespaced(namespace, name string, opts metav1.GetOptions) (runtime.Object, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) Watch(_ metav1.ListOptions) (watch.Interface, error) {
+func (m mockAuthConfigClient) UpdateStatus(name string, o runtime.Object) (runtime.Object, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) Patch(_ string, _ types.PatchType, _ []byte, _ ...string) (result *v3.AuthConfig, err error) {
+func (m mockAuthConfigClient) DeleteNamespaced(namespace, name string, opts *metav1.DeleteOptions) error {
 	//TODO implement me
 	panic("implement me")
 }
 
-func newMockAuthConfigClient() controllers.AuthConfigClient {
-	return mockAuthConfigClient{}
+func (m mockAuthConfigClient) Delete(name string, opts *metav1.DeleteOptions) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockAuthConfigClient) List(opts metav1.ListOptions) (runtime.Object, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockAuthConfigClient) ListNamespaced(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockAuthConfigClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockAuthConfigClient) DeleteCollection(deleteOptions *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockAuthConfigClient) Patch(name string, o runtime.Object, patchType types.PatchType, data []byte, subresources ...string) (runtime.Object, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockAuthConfigClient) ObjectFactory() objectclient.ObjectFactory {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockAuthConfigClient) ObjectClient() *objectclient.ObjectClient {
+	//TODO implement me
+	panic("implement me")
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
Adresses https://github.com/rancher/rancher/issues/40360. This changes how the auth config annotation is updated. We must use the unstructured client to preserve all the fields of a config when it is updated. When using a regular interface, I was having issues with fields disappearing on update because of the structure of auth config as a type - it's not a regular CRD.

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->