### PR TITLE
Add mirrored-skopeo-skopeo

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -201,6 +201,7 @@ var OriginMap = map[string]string{
 	"mirrored-thanos-thanos":                                  "https://github.com/thanos-io/thanos",
 	"mirrored-thanosio-thanos":                                "https://github.com/thanos-io/thanos",
 	"nginx-ingress-controller":                                "https://github.com/rancher/ingress-nginx",
+	"mirrored-skopeo-skopeo":                                  "https://github.com/containers/skopeo",
 	"openvswitch":                                             "https://github.com/servicefractal/ovs",
 	"opflex":                                                  "https://github.com/noironetworks/opflex",
 	"opflex-server":                                           "https://github.com/noironetworks/opflex",


### PR DESCRIPTION
Adds source repo for `mirrored-skopeo-skopeo` to origins.go so it may be included in the `image-origins.txt` release artifact