### PR TITLE
[v2.6] Modified docker files to account for the new golang 1.20 release

### DIFF
--- a/tests/v2/codecoverage/Dockerfile.buildcodecoverage
+++ b/tests/v2/codecoverage/Dockerfile.buildcodecoverage
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.20
+FROM golang:1.20
 
 # Configure Go
 ENV GOPATH /root/go
@@ -10,5 +10,8 @@ WORKDIR $WORKSPACE
 
 COPY [".", "$WORKSPACE"]
 
-RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables jq
-RUN zypper install -y -f docker && rpm -e --nodeps --noscripts containerd
+RUN apt-get update && \
+    apt-get -qy full-upgrade && \
+    apt-get install -qy curl && \
+    apt-get install -qy curl && \
+    curl -sSL https://get.docker.com/ | sh

--- a/tests/v2/codecoverage/Dockerfile.codecoverage
+++ b/tests/v2/codecoverage/Dockerfile.codecoverage
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.20
+FROM registry.suse.com/bci/golang:1.19
 
 # Configure Go
 ENV GOPATH /root/go

--- a/tests/v2/codecoverage/scripts/build_docker_images.sh
+++ b/tests/v2/codecoverage/scripts/build_docker_images.sh
@@ -27,7 +27,7 @@ docker build --build-arg VERSION=${TAG} --build-arg ARCH=${ARCH} --build-arg IMA
 echo "building agent test docker image"
 docker build --build-arg VERSION=${TAG} --build-arg ARCH=${ARCH} --build-arg RANCHER_TAG=${TAG} --build-arg RANCHER_REPO=${REPO} -t ${AGENT_IMAGE} -f Dockerfile.agent . --no-cache
 
-echo ${RANCHER_TEST_DOCKER_PASSWORD} | docker login --username ${RANCHER_TEST_DOCKER_USERNAME} --password-stdin
+echo ${DOCKERHUB_PASSWORD} | docker login --username ${DOCKERHUB_USERNAME} --password-stdin
 
 echo "docker push rancher"
 docker image push ${IMAGE}


### PR DESCRIPTION

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. --> SUSE golang 1.20 has not been released yet.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. --> Revert `Dockerfile.codecoverage` back to 1.19, and since 1.20 is needed for build code coverage images, changed the image for `Dockerfile.buildcodecoverage` to a different docker image that does support golang 1.20

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. --> Latest ranchertest images are from this docker build.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->