### PR TITLE
[release/v2.6] Remove rancher-runtime references

### DIFF
--- a/manifest-runtime.tmpl
+++ b/manifest-runtime.tmpl
@@ -1,7 +1,0 @@
-image: rancher/rancher-runtime:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}
-manifests:
-  -
-    image: rancher/rancher-runtime:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-{{build.commit}}{{/if}}-linux-amd64
-    platform:
-      architecture: amd64
-      os: linux

--- a/scripts/check-release-images-exist
+++ b/scripts/check-release-images-exist
@@ -12,8 +12,8 @@ TEMP_FILE=$(mktemp)
 
 if [ -n "${DRONE_TAG}" ]; then
   if [ -s ./bin/rancher-images.txt ]; then
-    # We skip rancher/rancher, rancher/rancher-agent and rancher/rancher-runtime because the manifest for these gets created later in the pipeline
-    for rancherimage in $(cat ./bin/rancher-images.txt | egrep -v "^rancher/rancher:|^rancher/rancher-agent:|^rancher/rancher-runtime:"); do
+    # We skip rancher/rancher and rancher/rancher-agent because the manifest for these gets created later in the pipeline
+    for rancherimage in $(cat ./bin/rancher-images.txt | egrep -v "^rancher/rancher:|^rancher/rancher-agent:"); do
       echo "INFO: Checking if image [${rancherimage}] exists"
       if ! docker manifest inspect ${rancherimage} >/dev/null; then
         echo "ERROR: Image [${rancherimage}] does not exist"

--- a/scripts/package
+++ b/scripts/package
@@ -20,7 +20,6 @@ cp ../bin/data.json ../bin/rancher-data.json
 
 IMAGE=${REPO}/rancher:${TAG}
 AGENT_IMAGE=${REPO}/rancher-agent:${AGENT_TAG}
-RUNTIME_IMAGE=${REPO}/rancher-runtime:${TAG}
 SYSTEM_AGENT_UPGRADE_TAG=$(grep "ENV CATTLE_SYSTEM_AGENT_VERSION" ../package/Dockerfile | awk '{ print $NF }')-suc
 SYSTEM_AGENT_UPGRADE_IMAGE=${REPO}/system-agent:${SYSTEM_AGENT_UPGRADE_TAG}
 WINS_AGENT_UPGRADE_TAG=$(grep "ENV CATTLE_WINS_AGENT_VERSION" ../package/Dockerfile | awk '{ print $NF }')
@@ -70,7 +69,7 @@ fi
 
 if [ ${ARCH} == amd64 ]; then
     # Move this out of ARCH check for local dev on non-amd64 hardware.
-    TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go $SYSTEM_CHART_REPO_DIR $CHART_REPO_DIR $IMAGE $AGENT_IMAGE $RUNTIME_IMAGE $SYSTEM_AGENT_UPGRADE_IMAGE $WINS_AGENT_UPGRADE_IMAGE ${SYSTEM_AGENT_INSTALLER_RKE2_IMAGES[@]} ${SYSTEM_AGENT_INSTALLER_K3S_IMAGES[@]}
+    TAG=$TAG REPO=${REPO} go run ../pkg/image/export/main.go $SYSTEM_CHART_REPO_DIR $CHART_REPO_DIR $IMAGE $AGENT_IMAGE $SYSTEM_AGENT_UPGRADE_IMAGE $WINS_AGENT_UPGRADE_IMAGE ${SYSTEM_AGENT_INSTALLER_RKE2_IMAGES[@]} ${SYSTEM_AGENT_INSTALLER_K3S_IMAGES[@]}
 fi
 
 # Create components file used for pre-release notes


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40474
 
## Problem
Codebase still contained references to `rancher/rancher-runtime` which are no longer needed.

Backport of https://github.com/rancher/rancher/pull/40473

## Solution
Remove the references
 
## Testing
Nothing specific, it was already not in use but obviously it shouldn't break anything. Only test is to check that `rancher/rancher-runtime` is no longer present in `rancher-images.txt` and `rancher-images-origins.txt`.

## Engineering Testing
### Manual Testing


### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->