### PR TITLE
[release/v2.7] Check release images using skopeo

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -14,7 +14,7 @@ ENV KUSTOMIZE_VERSION v5.0.0
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
 ENV CATTLE_KDM_BRANCH=dev-v2.7
 
-RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables jq
+RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables jq skopeo
 # use containerd from k3s image, not from bci
 RUN zypper install -y -f docker && rpm -e --nodeps --noscripts containerd
 

--- a/scripts/check-release-images-exist
+++ b/scripts/check-release-images-exist
@@ -15,7 +15,7 @@ if [ -n "${DRONE_TAG}" ]; then
     # We skip rancher/rancher and rancher/rancher-agent because the manifest for these gets created later in the pipeline
     for rancherimage in $(cat ./bin/rancher-images.txt | egrep -v "^rancher/rancher:|^rancher/rancher-agent:"); do
       echo "INFO: Checking if image [${rancherimage}] exists"
-      if ! docker manifest inspect ${rancherimage} >/dev/null; then
+      if ! skopeo inspect "docker://${rancherimage}" >/dev/null; then
         echo "ERROR: Image [${rancherimage}] does not exist"
         echo "${rancherimage}" >> $TEMP_FILE
       else


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40492

## Problem
`docker manifest inspect` does not support OCI manifest, see https://github.com/rancher/rancher/issues/40492#issue-1579690051 for details

## Solution
Switch to `skopeo` to check images
 
## Testing
Drone build step should succeed (especially for `rancher/mirrored-skopeo-skopeo:v1.10.0` as that has an OCI manifest)

## Engineering Testing
### Manual Testing
Check build step `check-release-images-exist`

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->