### PR TITLE
[2.7] Delay Planner Execution Based Off Of System-Upgrade-Controller Status

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/common.go
+++ b/pkg/controllers/provisioningv2/rke2/common.go
@@ -77,15 +77,16 @@ const (
 	RKEMachineAPIVersion           = "rke-machine.cattle.io/v1"
 	RKEAPIVersion                  = "rke.cattle.io/v1"
 
-	Provisioned         = condition.Cond("Provisioned")
-	Updated             = condition.Cond("Updated")
-	Reconciled          = condition.Cond("Reconciled")
-	Ready               = condition.Cond("Ready")
-	Waiting             = condition.Cond("Waiting")
-	Pending             = condition.Cond("Pending")
-	Removed             = condition.Cond("Removed")
-	PlanApplied         = condition.Cond("PlanApplied")
-	InfrastructureReady = condition.Cond(capi.InfrastructureReadyCondition)
+	Provisioned                  = condition.Cond("Provisioned")
+	Updated                      = condition.Cond("Updated")
+	Reconciled                   = condition.Cond("Reconciled")
+	Ready                        = condition.Cond("Ready")
+	Waiting                      = condition.Cond("Waiting")
+	Pending                      = condition.Cond("Pending")
+	Removed                      = condition.Cond("Removed")
+	PlanApplied                  = condition.Cond("PlanApplied")
+	InfrastructureReady          = condition.Cond(capi.InfrastructureReadyCondition)
+	SystemUpgradeControllerReady = condition.Cond("SystemUpgradeControllerReady")
 
 	RuntimeK3S  = "k3s"
 	RuntimeRKE2 = "rke2"

--- a/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
+++ b/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
@@ -1,13 +1,20 @@
 package managesystemagent
 
 import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	rancherv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2"
+	"github.com/rancher/rancher/pkg/fleet"
 	namespaces "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/provisioningv2/image"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/wrangler/pkg/name"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -17,10 +24,27 @@ func (h *handler) OnChangeInstallSUC(cluster *rancherv1.Cluster, status rancherv
 		return nil, status, nil
 	}
 
+	currentVersion, err := semver.NewVersion(cluster.Spec.KubernetesVersion)
+	if err != nil {
+		return nil, status, err
+	}
+
+	// indicate to the SUC chart if we want to
+	// install PodSecurityPolicy manifests
+	pspEnabled := false
+	if currentVersion.LessThan(Kubernetes125) {
+		pspEnabled = true
+	}
+
+	// we must limit the output of name.SafeConcatName to at most 48 characters because
+	// a) the chart release name cannot exceed 53 characters, and
+	// b) upon creation of this resource the prefix 'mcc-' will be added to the release name, hence the limiting to 48 characters
+	managedChartName := name.Limit(name.SafeConcatName(cluster.Name, "managed", "system-upgrade-controller"), 48)
+
 	mcc := &v3.ManagedChart{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cluster.Namespace,
-			Name:      name.SafeConcatName(cluster.Name, "managed", "system-upgrade-controller"),
+			Name:      managedChartName,
 		},
 		Spec: v3.ManagedChartSpec{
 			DefaultNamespace: namespaces.System,
@@ -32,6 +56,9 @@ func (h *handler) OnChangeInstallSUC(cluster *rancherv1.Cluster, status rancherv
 					"global": map[string]interface{}{
 						"cattle": map[string]interface{}{
 							"systemDefaultRegistry": image.GetPrivateRepoURLFromCluster(cluster),
+							"psp": map[string]interface{}{
+								"enabled": pspEnabled,
+							},
 						},
 					},
 				},
@@ -55,4 +82,82 @@ func (h *handler) OnChangeInstallSUC(cluster *rancherv1.Cluster, status rancherv
 	return []runtime.Object{
 		mcc,
 	}, status, nil
+}
+
+// syncSystemUpgradeControllerStatus queries the managed system-upgrade-controller chart and determines if it is properly configured for a given
+// version of Kubernetes. It applies a condition onto the control-plane object to be used by the planner when handling Kubernetes upgrades.
+func (h *handler) syncSystemUpgradeControllerStatus(obj *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus) (rkev1.RKEControlPlaneStatus, error) {
+	// perform the same name limiting as in the OnChangeInstallSUC controller, but prepend the 'mcc-' prefix that is added when the bundle is created
+	bundleName := fmt.Sprintf("mcc-%s", name.Limit(name.SafeConcatName(obj.Name, "managed", "system-upgrade-controller"), 48))
+	sucBundle, err := h.bundles.Get(fleet.ClustersDefaultNamespace, bundleName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		// if we couldn't find the bundle then we know it's not ready
+		rke2.SystemUpgradeControllerReady.False(&status)
+		// don't return the error, otherwise the status won't be set to 'false'
+		return status, nil
+	}
+
+	if err != nil {
+		return status, err
+	}
+
+	rke2.SystemUpgradeControllerReady.Unknown(&status)
+
+	// determine if the SUC deployment has been rolled out fully, and if there were any errors encountered
+	if sucBundle.Status.Summary.Ready != sucBundle.Status.Summary.DesiredReady {
+		if sucBundle.Status.Summary.ErrApplied != 0 && len(sucBundle.Status.Summary.NonReadyResources) > 0 {
+			nonReady := sucBundle.Status.Summary.NonReadyResources
+			rke2.SystemUpgradeControllerReady.Reason(&status, fmt.Sprintf("Error Encountered Waiting for System Upgrade Controller Deployment To Roll Out: %s", nonReady[0].Message))
+			return status, nil
+		}
+		rke2.SystemUpgradeControllerReady.Reason(&status, "Waiting for System Upgrade Controller Deployment roll out")
+		return status, nil
+	}
+
+	// we need to look at the values yaml content to determine if PSPs are enabled
+	// or disabled. We need to wait until SUC is redeployed if we don't see any helm values, as
+	// we expect the PSP value to be explicitly defined as either true or false
+	valuesYamlAvailable := sucBundle.Spec.Helm != nil && sucBundle.Spec.Helm.Values != nil
+	if !valuesYamlAvailable {
+		rke2.SystemUpgradeControllerReady.Reason(&status, "Waiting for Upgraded System Upgrade Controller Deployment")
+		return status, nil
+	}
+
+	// look through the values yaml content to determine if 'psp: enabled: true'
+	rke2.SystemUpgradeControllerReady.Reason(&status, "Waiting for System Upgrade Controller Bundle Update")
+	data := sucBundle.Spec.Helm.Values.Data
+	global, ok := data["global"].(map[string]interface{})
+	if !ok {
+		return status, nil
+	}
+
+	cattle, ok := global["cattle"].(map[string]interface{})
+	if !ok {
+		return status, nil
+	}
+
+	psp, ok := cattle["psp"].(map[string]interface{})
+	if !ok {
+		return status, nil
+	}
+
+	currentVersion, err := semver.NewVersion(obj.Spec.KubernetesVersion)
+	if err != nil {
+		return status, err
+	}
+
+	// we only want to block an upgrade if PSPs are enabled AND we are on
+	// a version greater than or equal to 1.25.
+	enabled, ok := psp["enabled"].(bool)
+	if !ok {
+		return status, nil
+	}
+
+	if !currentVersion.LessThan(Kubernetes125) && enabled {
+		rke2.SystemUpgradeControllerReady.Reason(&status, "System Upgrade Controller Not Ready")
+		return status, nil
+	}
+
+	rke2.SystemUpgradeControllerReady.True(&status)
+	return status, nil
 }

--- a/pkg/provisioningv2/rke2/planner/store.go
+++ b/pkg/provisioningv2/rke2/planner/store.go
@@ -58,6 +58,14 @@ func onlyRKE(machines []*capi.Machine) (result []*capi.Machine) {
 	return
 }
 
+// ClusterHasBeenBootstrapped determines if a cluster has undergone the bootstrapping process
+// by assessing the value of the joinURL. the control plane joinURL is generated during the bootstrapping process,
+// and its existence implies the creation of the cluster at some point in time.
+// Caution: there does exist a small window of time in which the joinURL has not been set, but the bootstrap node is up.
+func (p *PlanStore) ClusterHasBeenBootstrapped(plan *plan.Plan) bool {
+	return getControlPlaneJoinURL(plan) != ""
+}
+
 func (p *PlanStore) Load(cluster *capi.Cluster, rkeControlPlane *rkev1.RKEControlPlane) (*plan.Plan, error) {
 	result := &plan.Plan{
 		Nodes:    map[string]*plan.Node{},


### PR DESCRIPTION
## Issues:  #40384, #40565 

## Problem
Kubernetes 1.25 has removed support for `PodSecurityPolicy`'s, however several Rancher components deploy them by default via helm. Helm tracks all of the resources it deploys so that it can fully manage them during upgrades or uninstall operations. However, helm does not handle the scenario wherein one of the managed resources no longer has API support for a given Kubernetes version. In such a case, Helm will error out and the deployed chart will become unmanageable, preventing uninstalls/upgrades/any changes at all. This presents a problem for several aspects of Rancher, however this PR simply focuses on the management of the System-Upgrade-Controller. 

## Solution
As described in the linked issue above, this solution has several steps 

1. The system-upgrade-controller chart has been modified to conditionally deploy PSP resources based off of the provided `values.yaml` field `global.cattle.psp.enabled`. 
2. A new condition has been placed on the RKE control plane object which indicates if the currently deployed System-Upgrade-Controller is in a 'ready' state with its PSP's resources enabled or disabled, depending on the Kubernetes version being used 
3. The planner has been modified to pause all plan processing until the System-Upgrade-Controller condition is in a 'ready' state, and has the proper resource configuration deployed for a given Kubernetes version.

## Testing
The following (lengthy) test steps cover both of the linked issues

#### Initial setup / Validation of 40565
<details closed> 


+ Create a single node all roles RKE2 cluster running kubernetes v1.24.x. This can be done on any provider
      + Ensure the name of the cluster is moderately long, e.g. `haffel-test-upgrade-123`. _This is required to validate 40565_
+ Once the cluster has become available take a snapshot 
+ Navigate to the cluster explorer UI and view all pods under all namespaces. Ensure that you can see the `system-upgrade-controller` pod running.
+ Run the following command on the local cluster, `kubectl get bundles.fleet.cattle.io -A` and locate the `system-upgrade-controller` bundle
    + ensure that the bundle is active, and that the name is less than 53 characters long
+ While still in the cluster explorer UI, navigate to `More Resources` and then to `Policy`. Select `PodSecurityPolicies` and ensure toy can see the `system-upgrade-controller` policy. 
+ At this point we can confirm that 40565 has been **resolved**, as we can see the bundle and its resources have been deployed despite the moderately lengthy name

</details>

#### Validation of 40384

<details closed>

+ Using the same cluster, SSH into the all roles node, and execute the following commands so that you may use `kubectl`
    + `export KUBECONFIG=/etc/rancher/rke2/rke2.yaml && alias kubectl=/var/lib/rancher/rke2/bin/kubectl`
+ The goal is to watch the PSP resources active in the cluster so we can ensure they are removed before an upgrade commences. To continuously watch the PSP resources, run the following command ` watch -n 1 /var/lib/rancher/rke2/bin/kubectl get psp -A`
+ Observe that a PodSecurityPolicy exists for the System-Upgrade-Controller 
+ While continuing to observe the active PSP resources, return to the Rancher UI and commence an upgrade to 1.25.x
+ Ensure that the PodSecurityPolicy for the System-Upgrade-Controller is removed _before_ the API server is brought down for the upgrade 
     + You will know that the API server is undergoing an upgrade as the `watch` command executed earlier will report an error communicating with the API server
     + It is important to ensure that the PSP resource is no longer present **_before_** that error is observed 
+ Ensure the cluster is still usable after the upgrade 
+ View the contents of the system-upgrade-controller bundle by running the following command
    + `kubectl get bundles.fleet.cattle.io <YOUR_SUC_BUNDLE_NAME> -n fleet-default -o yaml`
    + Ensure that a PodSecurityPolicy is **_not_** included in the `resourceKey` section. 

</details> 

#### ETCD snapshot and restore test 
<details closed>

+ Restore the 1.25 cluster using the snapshot you took initially on 1.24.x
+ ensure that the system-upgrade-controller pod is present after the cluster has finished restoring
+ ensure that you can once again see the PodSecurityPolicy resources for the System-Upgrade-Controller

</details>

## Engineering Testing
### Manual Testing

I've done the above 

### Automated Testing
N/A

## QA Testing Considerations

 
### Regressions Considerations

We should ensure that upgrading and downgrading between 1.25 and 1.24 works as expected
We should ensure that manual editing of the bundle works as expected


