### PR TITLE
Initialize NodeGroups for imported EKS cluster

### DIFF
--- a/pkg/controllers/management/eks/eks_cluster_handler.go
+++ b/pkg/controllers/management/eks/eks_cluster_handler.go
@@ -129,6 +129,11 @@ func (e *eksOperatorController) onClusterChange(key string, cluster *mgmtv3.Clus
 
 	}
 
+	// imported cluster's nodegroups may nil
+	if cluster.Spec.EKSConfig.Imported && cluster.Spec.EKSConfig.DisplayName != "" && cluster.Spec.EKSConfig.NodeGroups == nil {
+		cluster.Spec.EKSConfig.NodeGroups = []eksv1.NodeGroup{}
+	}
+
 	eksClusterConfigMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&cluster.Spec.EKSConfig)
 	if err != nil {
 		return cluster, err


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40667
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
The imported EKS cluster `cluster.Spec.EKSCluster.NodeGroups` is not initialized, and skipped to compare with Upstream specs in [cluster refresh controller](https://github.com/rancher/rancher/blob/v2.7.1/pkg/controllers/management/clusterupstreamrefresher/cluster_upstream_refresher.go#L230-L239) since it is `nil`.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Initialize the `cluster.Spec.EKSCluster.NodeGroups` to an empty slice and this makes it comparable with Upstream specs in *cluster refresh controller* .
 
## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

1. Create an EKS cluster and add one node group to it on the AWS EKS console page.
2. Import this EKS cluster to Rancher, after clicking "Save", view the cluster description page.
3. The cluster description page does not stick to the **"Loading..."** page.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

No idea how to auto-test this, let me know in the comments if it can.
