### PR TITLE
Handle setpodsecuritypolicytemplate setting to null by norman client

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authz_types.go
+++ b/pkg/apis/management.cattle.io/v3/authz_types.go
@@ -193,5 +193,5 @@ func (c *ClusterRoleTemplateBinding) ObjClusterName() string {
 }
 
 type SetPodSecurityPolicyTemplateInput struct {
-	PodSecurityPolicyTemplateName string `json:"podSecurityPolicyTemplateId" norman:"required,type=reference[podSecurityPolicyTemplate]"`
+	PodSecurityPolicyTemplateName string `json:"podSecurityPolicyTemplateId" norman:"type=reference[podSecurityPolicyTemplate]"`
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/terraform-provider-rancher2/issues/1006
#40494 


## Problem
The Norman client, used by the terraform provider, has omitempty set for podSecurityPolicyTemplateId.  https://github.com/rancher/rancher/blob/cd8eea1fdf0dd0071bfdcae4f1eb7de2c5b3722f/pkg/client/generated/management/v3/zz_generated_set_pod_security_policy_template_input.go#L9
And that results in an empty request body being sent when trying to unset the value via the terraform provider. 

## Solution
Since fixing the client generation logic would result in a very large number of changes, we have opted to just handle this situation in Rancher by removing the "required" attribute in the schema spec.
 
## Testing
Testing can be done through UI, curls to the api, and most importantly through the terraform provider, as described in the original issue, since that is the only scenario that is resulting in the problem (empty body being sent instead of null)

## Engineering Testing
### Manual Testing
Tested via the UI, via curl, and the terraform provider

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
