### PR TITLE
Add a cleanup entry for KeyCloak OIDC client secret

### DIFF
--- a/pkg/auth/api/secrets/fields.go
+++ b/pkg/auth/api/secrets/fields.go
@@ -20,7 +20,7 @@ var (
 		client.ShibbolethConfigType:      {client.ShibbolethConfigFieldSpKey},
 		client.GoogleOauthConfigType:     {client.GoogleOauthConfigFieldOauthCredential, client.GoogleOauthConfigFieldServiceAccountCredential},
 		client.OIDCConfigType:            {client.OIDCConfigFieldPrivateKey, client.OIDCConfigFieldClientSecret},
-		client.KeyCloakOIDCConfigType:    {client.KeyCloakOIDCConfigFieldPrivateKey},
+		client.KeyCloakOIDCConfigType:    {client.KeyCloakOIDCConfigFieldPrivateKey, client.KeyCloakOIDCConfigFieldClientSecret},
 	}
 	// SubTypeToFields associates an Auth Config type with a nested map of secret names related to the config.
 	SubTypeToFields = map[string]map[string][]string{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

## Problem
When admins enable the KeyCloak OIDC provider, the following secrets get created as secrets in the cattle-global data:

- keycloakoidcconfig-clientsecret
- keycloakoidcconfig-privatekey

There are also per-user login tokens in the same namespaces created.

On provider disable, the `keycloakoidcconfig-clientsecret` is not deleted.
While OIDC providers have common logic for secret creation, deletion is different because 
the cleanup expects that full secret name also includes the provider type, and KeyCloak is separate and has its own config, it's not under OIDC config.
 
## Solution
Add a dedicated entry to the cleanup matrix for the client secret (its constant string value is the same as that for general OIDC providers).
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->