### PR TITLE
Initial registries setup and validation

### DIFF
--- a/tests/framework/clients/corral/corral.go
+++ b/tests/framework/clients/corral/corral.go
@@ -10,8 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/sirupsen/logrus"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -69,7 +67,7 @@ func SetCustomRepo(repo string) error {
 
 // CreateCorral creates a corral taking the corral name, the package path, and a debug set so if someone wants to view the
 // corral create log
-func CreateCorral(ts *session.Session, corralName, packageName string, debug bool, cleanup bool) (*rest.Config, error) {
+func CreateCorral(ts *session.Session, corralName, packageName string, debug bool, cleanup bool) ([]byte, error) {
 	if cleanup {
 		ts.RegisterCleanupFunc(func() error {
 			return DeleteCorral(corralName)
@@ -92,17 +90,8 @@ func CreateCorral(ts *session.Session, corralName, packageName string, debug boo
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to create corral: "+string(msg))
 	}
-	kubeConfig, err := GetKubeConfig(corralName)
-	if err != nil {
-		return nil, err
-	}
 
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfig)
-	if err != nil {
-		return nil, errors.Wrap(err, "CreateCorral: failed to parse kubeconfig for k3d cluster")
-	}
-
-	return restConfig, nil
+	return msg, nil
 }
 
 // DeleteCorral deletes a corral based on the corral name

--- a/tests/framework/extensions/registries/registries.go
+++ b/tests/framework/extensions/registries/registries.go
@@ -1,0 +1,41 @@
+package registries
+
+import (
+	"strings"
+
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func CheckAllClusterPodsForRegistryPrefix(podsList *v1.SteveCollection, substring string) (bool, error) {
+
+	for _, pod := range podsList.Data {
+		podSpec := &corev1.PodSpec{}
+		err := v1.ConvertToK8sType(pod.Spec, podSpec)
+		if err != nil {
+			return false, err
+		}
+		for _, container := range podSpec.Containers {
+			if !strings.Contains(container.Image, substring) {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}
+
+func CheckAllClusterPodsStatusForRegistry(podsList *v1.SteveCollection, substring string) (bool, error) {
+
+	for _, pod := range podsList.Data {
+		podStatus := &corev1.PodStatus{}
+		err := v1.ConvertToK8sType(pod.Status, podStatus)
+		if err != nil {
+			return false, err
+		}
+		podPhase := podStatus.Phase
+		if podPhase != "Succeeded" && podPhase != "Running" {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/tests/v2/registries/Dockerfile.registries
+++ b/tests/v2/registries/Dockerfile.registries
@@ -1,0 +1,26 @@
+FROM registry.suse.com/bci/golang:1.19
+
+# Configure Go
+ENV GOPATH /root
+ENV PATH ${PATH}:/root/bin
+
+ENV WORKSPACE ${GOPATH}/src/github.com/rancher/rancher
+ENV WORKSPACE2 ${GOPATH}/src/github.com/rancherlabs/corral-packages
+
+WORKDIR $WORKSPACE
+
+COPY ["./rancher", "$WORKSPACE"]
+COPY ["./corral-packages", "$WORKSPACE2"]
+
+ENV CORRAL_VERSION="v1.1.1"
+
+RUN mkdir -p /root/.ssh
+RUN cp ${WORKSPACE}/tests/v2/validation/.ssh/jenkins-* /root/.ssh
+RUN chmod 600 /root/.ssh/jenkins-*
+RUN ssh-keygen -f /root/.ssh/jenkins-* -y > /root/.ssh/id_rsa.pub
+
+RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables jq
+RUN zypper install -y -f docker && rpm -e --nodeps --noscripts containerd
+RUN go mod download && \
+    go install gotest.tools/gotestsum@latest && \
+    go install github.com/rancherlabs/corral@${CORRAL_VERSION}

--- a/tests/v2/registries/Jenkinsfile.registries
+++ b/tests/v2/registries/Jenkinsfile.registries
@@ -1,0 +1,192 @@
+#!groovy
+node {
+    def rootPath = "/root/src/github.com/rancher/rancher/"
+    def workPath = "/root/src/github.com/rancher/rancher/tests/v2/registries/"
+    def job_name = "${JOB_NAME}"
+    if (job_name.contains('/')) { 
+      job_names = job_name.split('/')
+      job_name = job_names[job_names.size() - 1] 
+    }
+    def golangTestContainer = "${job_name}${env.BUILD_NUMBER}_golangtest"
+    def corralTestContainer = "${job_name}${env.BUILD_NUMBER}_corraltest"
+    def corralCleanupContainer = "${job_name}${env.BUILD_NUMBER}_corralcleanup"
+    def imageName = "rancher-registries-validation-${job_name}${env.BUILD_NUMBER}"
+    def registries_volume = "RegistryTestingSharedVolume"
+    def testsDir = "/root/src/github.com/rancher/rancher/tests/v2/validation/${env.TEST_PACKAGE}"
+    def testResultsOut = "results.xml"
+    def envFile = ".env"
+    def rancherConfig = "rancher_env.config"
+    def branch = "release/v2.6"
+    def corralBranch = "main"
+    if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
+      branch = "${env.BRANCH}"
+    }
+
+    if ("${env.RANCHER_CORRAL_PACKAGES_REPO_BRANCH}" != "null" && "${env.RANCHER_CORRAL_PACKAGES_REPO_BRANCH}" != "") {
+      corralBranch = "${env.RANCHER_CORRAL_PACKAGES_REPO_BRANCH}"
+    }
+
+    def rancherRepo = scm.getUserRemoteConfigs()[0].getUrl()
+    if ("${env.REPO}" != "null" && "${env.REPO}" != "") {
+      rancherRepo = "${env.REPO}"
+    }
+
+    def corralRepo = scm.getUserRemoteConfigs()[1].getUrl()
+    if ("${env.RANCHER_CORRAL_PACKAGES_REPO_URL}" != "null" && "${env.RANCHER_CORRAL_PACKAGES_REPO_URL}" != "") {
+      corralRepo = "${env.RANCHER_CORRAL_PACKAGES_REPO_URL}"
+    }
+  
+    def timeout = "60m"
+    if ("${env.TIMEOUT}" != "null" && "${env.TIMEOUT}" != "") {
+      timeout = "${env.TIMEOUT}" 
+    }
+    wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+      withFolderProperties {
+        paramsMap = []
+        params.each {
+          if (it.value && it.value.trim() != "") {
+              paramsMap << "$it.key=$it.value"
+          }
+        }
+        withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                          string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+                          string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'RANCHER_EKS_ACCESS_KEY'),
+                          string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'RANCHER_EKS_SECRET_KEY'),
+                          string(credentialsId: 'DO_ACCESSKEY', variable: 'DO_ACCESSKEY'),
+                          string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                          string(credentialsId: 'RANCHER_SSH_KEY', variable: 'RANCHER_SSH_KEY'),
+                          string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                          string(credentialsId: 'AZURE_TENANT_ID', variable: 'AZURE_TENANT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_ID', variable: 'AZURE_CLIENT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'AZURE_CLIENT_SECRET'),
+                          string(credentialsId: 'AZURE_AKS_SUBSCRIPTION_ID', variable: 'RANCHER_AKS_SUBSCRIPTION_ID'),
+                          string(credentialsId: 'AZURE_TENANT_ID', variable: 'RANCHER_AKS_TENANT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_ID', variable: 'RANCHER_AKS_CLIENT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'RANCHER_AKS_SECRET_KEY'),
+                          string(credentialsId: 'RANCHER_REGISTRY_USER_NAME', variable: 'RANCHER_REGISTRY_USER_NAME'),
+                          string(credentialsId: 'RANCHER_REGISTRY_PASSWORD', variable: 'RANCHER_REGISTRY_PASSWORD'),
+                          string(credentialsId: 'RANCHER_AD_SPECIAL_CHAR_PASSWORD', variable: 'RANCHER_AD_SPECIAL_CHAR_PASSWORD'),
+                          string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                          string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_GKE_CREDENTIAL', variable: 'RANCHER_GKE_CREDENTIAL'),
+                          string(credentialsId: 'RANCHER_AUTH_USER_PASSWORD', variable: 'RANCHER_AUTH_USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_HOSTNAME_OR_IP_ADDRESS', variable: 'RANCHER_HOSTNAME_OR_IP_ADDRESS'),
+                          string(credentialsId: 'RANCHER_CA_CERTIFICATE', variable: 'RANCHER_CA_CERTIFICATE'),
+                          string(credentialsId: 'RANCHER_SERVICE_ACCOUNT_NAME', variable: 'RANCHER_SERVICE_ACCOUNT_NAME'),
+                          string(credentialsId: 'RANCHER_SERVICE_ACCOUNT_PASSWORD', variable: 'RANCHER_SERVICE_ACCOUNT_PASSWORD'),
+                          string(credentialsId: 'RANCHER_USER_SEARCH_BASE', variable: 'RANCHER_USER_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_DEFAULT_LOGIN_DOMAIN', variable: 'RANCHER_DEFAULT_LOGIN_DOMAIN'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_NAME', variable: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_NAME'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_PASSWORD', variable: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_PASSWORD'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_USER_SEARCH_BASE', variable: 'RANCHER_OPENLDAP_USER_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_AUTH_USER_PASSWORD', variable: 'RANCHER_OPENLDAP_AUTH_USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_HOSTNAME_OR_IP_ADDRESS', variable: 'RANCHER_OPENLDAP_HOSTNAME_OR_IP_ADDRESS'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_SPECIAL_CHAR_PASSWORD', variable: 'RANCHER_OPENLDAP_SPECIAL_CHAR_PASSWORD'),
+                          string(credentialsId: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_NAME', variable: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_NAME'),
+                          string(credentialsId: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_PASSWORD', variable: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_PASSWORD'),
+                          string(credentialsId: 'RANCHER_FREEIPA_USER_SEARCH_BASE', variable: 'RANCHER_FREEIPA_USER_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_FREEIPA_GROUP_SEARCH_BASE', variable: 'RANCHER_FREEIPA_GROUP_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_FREEIPA_AUTH_USER_PASSWORD', variable: 'RANCHER_FREEIPA_AUTH_USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_FREEIPA_HOSTNAME_OR_IP_ADDRESS', variable: 'RANCHER_FREEIPA_HOSTNAME_OR_IP_ADDRESS'),
+                          string(credentialsId: 'RANCHER_FREEIPA_SPECIAL_CHAR_PASSWORD', variable: 'RANCHER_FREEIPA_SPECIAL_CHAR_PASSWORD'),
+                          string(credentialsId: 'RANCHER_VALID_TLS_CERT', variable: 'RANCHER_VALID_TLS_CERT'),
+                          string(credentialsId: 'RANCHER_VALID_TLS_KEY', variable: 'RANCHER_VALID_TLS_KEY'),
+                          string(credentialsId: 'RANCHER_BYO_TLS_CERT', variable: 'RANCHER_BYO_TLS_CERT'),
+                          string(credentialsId: 'RANCHER_BYO_TLS_KEY', variable: 'RANCHER_BYO_TLS_KEY'),
+                          string(credentialsId: 'RANCHER_LINODE_ACCESSKEY', variable: "RANCHER_LINODE_ACCESSKEY")]) {
+          
+        withEnv(paramsMap) {
+          stage('Checkout') {
+            deleteDir()
+            dir("./rancher") {
+              checkout([
+                      $class: 'GitSCM',
+                      branches: [[name: "*/${branch}"]],
+                      extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                      userRemoteConfigs: [[url: rancherRepo]]
+                    ])
+            }
+            dir('./') {
+              echo "cloning corral-packages repo"
+
+              dir('./corral-packages') {
+                checkout([
+                      $class: 'GitSCM',
+                      branches: [[name: "*/${corralBranch}"]],
+                      extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                      userRemoteConfigs: [[url: corralRepo]]
+                    ])
+              }
+              def rancherFilename = "rancher-registry.yaml"
+              def rancherConfigContents = env.RANCHER_CORRAL_CONFIG
+              def registriesFilename = "registry.yaml"
+              def registriesConfigContents = env.REGISTRIES_CORRAL_CONFIG
+
+              writeFile file: "./corral-packages/packages/aws/"+rancherFilename, text: rancherConfigContents
+              writeFile file: "./corral-packages/packages/aws/"+registriesFilename, text: registriesConfigContents
+            }
+          }
+          dir ("./") {
+            try {
+              stage('Configure and Build') {
+                sh "docker volume rm -f ${registries_volume}"
+                if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
+                  dir("./rancher/tests/v2/validation/.ssh") {
+                    def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
+                    writeFile file: AWS_SSH_KEY_NAME, text: decoded
+                  }
+                }
+                dir("./rancher/tests/v2/registries") {
+                  def filename = "config.yaml"
+                  def configContents = env.CONFIG
+
+                  writeFile file: filename, text: configContents
+                  env.CATTLE_TEST_CONFIG = "${workPath}"+filename
+                }
+                dir ("./") {
+                  sh "./rancher/tests/v2/validation/configure.sh"
+                  sh "docker build . -f ./rancher/tests/v2/registries/Dockerfile.registries -t ${imageName}"
+                  sh "docker volume create --name ${registries_volume}"
+                }
+
+                
+                sh "docker run -v ${registries_volume}:/root --name ${corralTestContainer} -t --env-file ${envFile} " +
+                  "${imageName} sh -c \"${workPath}scripts/setup_registries_environment.sh\""
+              }
+              stage('Run Validation Tests') {
+                try {
+                  sh "docker run --volumes-from ${corralTestContainer} --name ${golangTestContainer} -t --env-file ${envFile} " +
+                  "${imageName} sh -c \"gotestsum --format standard-verbose --packages=${testsDir} --junitfile ${testResultsOut} -- ${GOTEST_TESTCASE} -timeout=${timeout} -v\""
+                } catch(err) {
+                  echo 'Test run had failures. Collecting results...'
+                } finally {
+                  sh "docker run --volumes-from ${corralTestContainer} --name ${corralCleanupContainer} -t --env-file ${envFile} " +
+                  "${imageName} sh -c \"${workPath}bin/ranchercleanup\""
+                }
+              }
+              stage('Test Report') {
+                sh "docker cp ${golangTestContainer}:${rootPath}${testResultsOut} ."
+                step([$class: 'JUnitResultArchiver', testResults: "**/${testResultsOut}"])
+                sh "docker stop ${corralTestContainer}"
+                sh "docker rm -v ${corralTestContainer}"
+                sh "docker stop ${golangTestContainer}"
+                sh "docker rm -v ${golangTestContainer}"
+                sh "docker stop ${corralCleanupContainer}"
+                sh "docker rm -v ${corralCleanupContainer}"
+                sh "docker rmi -f ${imageName}"
+              }
+            } catch(err) {
+                sh "docker stop ${corralTestContainer}"
+                sh "docker rm -v ${corralTestContainer}"
+                sh "docker stop ${golangTestContainer}"
+                sh "docker rm -v ${golangTestContainer}"
+                sh "docker stop ${corralCleanupContainer}"
+                sh "docker rm -v ${corralCleanupContainer}"
+                sh "docker rmi -f ${imageName}"
+            } // catch error
+          } // dir 
+        } // withEnv
+      } // creds
+    } // folder properties
+  } // wrap 
+} // node

--- a/tests/v2/registries/ranchercleanup/main.go
+++ b/tests/v2/registries/ranchercleanup/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/corral"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/sirupsen/logrus"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	timeout = int64(60 * 10)
+)
+
+func main() {
+	testSession := session.NewSession()
+
+	client, err := rancher.NewClient("", testSession)
+	if err != nil {
+		logrus.Fatalf("error creating admin client: %v", err)
+	}
+
+	var clusterList *v1.SteveCollection
+	err = kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
+		//clean up clusters
+		resp, err := client.Steve.SteveType(clusters.ProvisioningSteveResouceType).List(nil)
+		if k8sErrors.IsInternalError(err) || k8sErrors.IsServiceUnavailable(err) {
+			return false, err
+		} else if resp != nil {
+			clusterList = resp
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		logrus.Errorf("error deleting corral: %v", err)
+	}
+
+	deleteTimeout := timeout
+	for _, cluster := range clusterList.Data {
+		if cluster.ObjectMeta.Name != "local" {
+			err := client.Steve.SteveType(clusters.ProvisioningSteveResouceType).Delete(&cluster)
+			if err != nil {
+				logrus.Errorf("error deleting corral: %v", err)
+			}
+
+			provKubeClient, err := client.GetKubeAPIProvisioningClient()
+			if err != nil {
+				logrus.Errorf("error deleting corral: %v", err)
+			}
+
+			watchInterface, err := provKubeClient.Clusters(cluster.ObjectMeta.Namespace).Watch(context.TODO(), metav1.ListOptions{
+				FieldSelector:  "metadata.name=" + cluster.ObjectMeta.Name,
+				TimeoutSeconds: &deleteTimeout,
+			})
+			if err != nil {
+				logrus.Errorf("error deleting corral: %v", err)
+			}
+
+			err = wait.WatchWait(watchInterface, func(event watch.Event) (ready bool, err error) {
+				cluster := event.Object.(*apisV1.Cluster)
+				if event.Type == watch.Error {
+					return false, fmt.Errorf("there was an error deleting cluster")
+				} else if event.Type == watch.Deleted {
+					return true, nil
+				} else if cluster == nil {
+					return true, nil
+				}
+				return false, nil
+			})
+			if err != nil {
+				logrus.Errorf("error deleting corral: %v", err)
+			}
+		}
+	}
+
+	corralList, err := corral.ListCorral()
+	for corralName := range corralList {
+		err = corral.DeleteCorral(corralName)
+	}
+	if err != nil {
+		logrus.Errorf("error deleting corral: %v", err)
+	}
+}

--- a/tests/v2/registries/rancherha/main.go
+++ b/tests/v2/registries/rancherha/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/rancher/rancher/tests/framework/clients/corral"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/sirupsen/logrus"
+)
+
+const corralPackageName = "registryrancher"
+
+func main() {
+	testSession := session.NewSession()
+
+	corralConfig := corral.CorralConfigurations()
+	err := corral.SetupCorralConfig(corralConfig.CorralConfigVars, corralConfig.CorralConfigUser, corralConfig.CorralSSHPath)
+	if err != nil {
+		logrus.Fatalf("error setting up corral: %v", err)
+	}
+
+	configPackage := corral.CorralPackagesConfig()
+
+	path := configPackage.CorralPackageImages[corralPackageName]
+
+	fmt.Println("PATH", path)
+	_, err = corral.CreateCorral(testSession, "rancherglobalregistry", path, true, configPackage.Cleanup)
+	if err != nil {
+		logrus.Errorf("error creating corral: %v", err)
+	}
+}

--- a/tests/v2/registries/registryauthdisabled/main.go
+++ b/tests/v2/registries/registryauthdisabled/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/rancher/rancher/tests/framework/clients/corral"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/sirupsen/logrus"
+)
+
+const corralPackageName = "registryauthdisabled"
+
+func main() {
+	testSession := session.NewSession()
+
+	corralConfig := corral.CorralConfigurations()
+	err := corral.SetupCorralConfig(corralConfig.CorralConfigVars, corralConfig.CorralConfigUser, corralConfig.CorralSSHPath)
+	if err != nil {
+		logrus.Fatalf("error setting up corral: %v", err)
+	}
+
+	configPackage := corral.CorralPackagesConfig()
+
+	path := configPackage.CorralPackageImages[corralPackageName]
+	fmt.Println("PATH", path)
+
+	_, err = corral.CreateCorral(testSession, "downstreamregistrydisabled", path, true, configPackage.Cleanup)
+	if err != nil {
+		logrus.Errorf("error creating corral: %v", err)
+	}
+}

--- a/tests/v2/registries/registryauthenabled/main.go
+++ b/tests/v2/registries/registryauthenabled/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/rancher/rancher/tests/framework/clients/corral"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/sirupsen/logrus"
+)
+
+const corralPackageName = "registryauthenabled"
+
+func main() {
+	testSession := session.NewSession()
+
+	corralConfig := corral.CorralConfigurations()
+	err := corral.SetupCorralConfig(corralConfig.CorralConfigVars, corralConfig.CorralConfigUser, corralConfig.CorralSSHPath)
+	if err != nil {
+		logrus.Fatalf("error setting up corral: %v", err)
+	}
+
+	configPackage := corral.CorralPackagesConfig()
+
+	path := configPackage.CorralPackageImages[corralPackageName]
+	fmt.Println("PATH", path)
+
+	_, err = corral.CreateCorral(testSession, "downstreamregistryenabled", path, true, configPackage.Cleanup)
+	if err != nil {
+		logrus.Errorf("error creating corral: %v", err)
+	}
+}

--- a/tests/v2/registries/scripts/build_corral.sh
+++ b/tests/v2/registries/scripts/build_corral.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd  /root/src/github.com/rancherlabs/corral
+
+echo "building corral bin"
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build 
+
+mv corral /go/bin

--- a/tests/v2/registries/scripts/build_corral_packages.sh
+++ b/tests/v2/registries/scripts/build_corral_packages.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+cd  /root/src/github.com/rancherlabs/corral-packages
+
+make init
+make build

--- a/tests/v2/registries/scripts/build_registries_images.sh
+++ b/tests/v2/registries/scripts/build_registries_images.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+cd $(dirname $0)/../../../../
+
+
+echo "building rancher HA corral bin"
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/registries/bin/ranchercorral ./tests/v2/registries/rancherha
+
+echo "building cluster setup bin"
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/registries/bin/setuprancher ./tests/v2/registries/setuprancher
+
+echo "building registry auth enabled bin"
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/registries/bin/registryauthenabled ./tests/v2/registries/registryauthenabled
+
+echo "building registry auth disabled bin"
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/registries/bin/registryauthdisabled ./tests/v2/registries/registryauthdisabled
+
+echo "building rancher cleanup bin"
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/registries/bin/ranchercleanup ./tests/v2/registries/ranchercleanup

--- a/tests/v2/registries/scripts/setup_registries_environment.sh
+++ b/tests/v2/registries/scripts/setup_registries_environment.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex
+cd $(dirname $0)/../../../../
+
+echo "building bins"
+sh tests/v2/registries/scripts/build_registries_images.sh
+
+echo "build corral packages"
+sh tests/v2/registries/scripts/build_corral_packages.sh
+
+echo | corral config
+
+echo "creating registry auth disabled bin"
+tests/v2/registries/bin/registryauthdisabled
+
+sleep 1
+
+echo "building registry auth enabled bin"
+tests/v2/registries/bin/registryauthenabled
+
+sleep 1
+
+corral list
+
+echo "running rancher corral"
+tests/v2/registries/bin/ranchercorral 
+
+
+echo "setup rancher"
+tests/v2/registries/bin/setuprancher

--- a/tests/v2/registries/setuprancher/main.go
+++ b/tests/v2/registries/setuprancher/main.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/rancher/norman/types"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/tests/framework/clients/corral"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
+	aws "github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates/aws"
+	"github.com/rancher/rancher/tests/framework/extensions/token"
+	"github.com/rancher/rancher/tests/framework/extensions/users"
+	passwordgenerator "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning"
+	"github.com/rancher/rancher/tests/v2/validation/registries"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+var (
+	adminPassword = os.Getenv("ADMIN_PASSWORD")
+)
+
+const (
+	globalCorralName     = "rancherglobalregistry"
+	registryEnabledName  = "downstreamregistryenabled"
+	registryDisabledName = "downstreamregistrydisabled"
+	clusterName          = "local"
+)
+
+func main() {
+	rancherConfig := new(rancher.Config)
+	config.LoadConfig(rancher.ConfigurationFileKey, rancherConfig)
+
+	registryEnabledUsername, err := corral.GetCorralEnvVar(registryEnabledName, "registry_username")
+	if err != nil {
+		logrus.Fatalf("error getting registry username %v", err)
+	}
+	logrus.Infof("Registry Enabled Username: %s", registryEnabledUsername)
+
+	registryEnabledPassword, err := corral.GetCorralEnvVar(registryEnabledName, "registry_password")
+	if err != nil {
+		logrus.Fatalf("error getting registry password %v", err)
+	}
+	logrus.Infof("Registry Enabled Password: %s", registryEnabledPassword)
+
+	registryEnabledFqdn, err := corral.GetCorralEnvVar(registryEnabledName, "registry_fqdn")
+	if err != nil {
+		logrus.Fatalf("error getting registry fqdn %v", err)
+	}
+	logrus.Infof("Enabled FQDN: %s", registryEnabledFqdn)
+
+	registryDisabledFqdn, err := corral.GetCorralEnvVar(registryDisabledName, "registry_fqdn")
+	if err != nil {
+		logrus.Fatalf("error getting registry fqdn %v", err)
+	}
+	logrus.Infof("Disabled FQDN: %s", registryDisabledFqdn)
+
+	globalRegistryFqdn, err := corral.GetCorralEnvVar(globalCorralName, "registry_fqdn")
+	if err != nil {
+		logrus.Fatalf("error getting registry fqdn %v", err)
+	}
+	logrus.Infof("Global Registry FQDN: %s", globalRegistryFqdn)
+
+	password, err := corral.GetCorralEnvVar(globalCorralName, "bootstrap_password")
+	if err != nil {
+		logrus.Fatalf("error getting password %v", err)
+	}
+
+	token, err := createAdminToken(password, rancherConfig)
+	if err != nil {
+		logrus.Fatalf("error with generating admin token: %v", err)
+	}
+
+	rancherConfig.AdminToken = token
+	config.UpdateConfig(rancher.ConfigurationFileKey, rancherConfig)
+	//provision clusters for test
+	session := session.NewSession()
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+	kubernetesVersions := clustersConfig.RKE1KubernetesVersions
+	cnis := clustersConfig.CNIs
+	nodesAndRoles := clustersConfig.NodesAndRolesRKE1
+
+	client, err := rancher.NewClient(token, session)
+	if err != nil {
+		logrus.Fatalf("error creating admin client: %v", err)
+	}
+
+	err = postRancherInstall(client)
+	if err != nil {
+		logrus.Fatalf("error with admin user service account secret: %v", err)
+	}
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = passwordgenerator.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	if err != nil {
+		logrus.Fatalf("error creating admin client: %v", err)
+	}
+
+	newUser.Password = user.Password
+
+	if err != nil {
+		logrus.Fatalf("error creating standard user client: %v", err)
+	}
+	var privateRegistriesNoauth []management.PrivateRegistry
+	privateRegistry := management.PrivateRegistry{}
+	privateRegistry.URL = registryEnabledFqdn
+	privateRegistry.IsDefault = true
+	privateRegistry.Password = registryEnabledPassword
+	privateRegistry.User = registryEnabledUsername
+	privateRegistriesNoauth = append(privateRegistriesNoauth, privateRegistry)
+
+	// create cluster with auth registry
+	noauthClusterName, err := createTestCluster(client, client, 1, "noauthregcluster", cnis[0], kubernetesVersions[0], nodesAndRoles, privateRegistriesNoauth)
+	if err != nil {
+		logrus.Fatalf("error creating cluster: %v", err)
+	}
+
+	var privateRegistriesAuth []management.PrivateRegistry
+	privateRegistry = management.PrivateRegistry{}
+	privateRegistry.URL = registryDisabledFqdn
+	privateRegistry.IsDefault = true
+	privateRegistry.Password = ""
+	privateRegistry.User = ""
+	privateRegistriesAuth = append(privateRegistriesAuth, privateRegistry)
+
+	authClusterName, err := createTestCluster(client, client, 1, "authregcluster", cnis[0], kubernetesVersions[0], nodesAndRoles, privateRegistriesAuth)
+	if err != nil {
+		logrus.Fatalf("error creating cluster: %v", err)
+	}
+
+	noAuthCluster := new(registries.Cluster)
+	noAuthCluster.Name = noauthClusterName[0]
+	noAuthCluster.Auth = false
+	noAuthCluster.URL = privateRegistriesNoauth[0].URL
+
+	authCluster := new(registries.Cluster)
+	authCluster.Name = authClusterName[0]
+	authCluster.Auth = true
+	authCluster.URL = privateRegistriesAuth[0].URL
+
+	localCluster := new(registries.Cluster)
+	localCluster.Name = "local"
+	localCluster.Auth = false
+	localCluster.URL = globalRegistryFqdn
+
+	registriesConfig := new(registries.Config)
+	clusters := []registries.Cluster{*noAuthCluster, *authCluster, *localCluster}
+	registriesConfig.Clusters = clusters
+
+	config.UpdateConfig(registries.RegistriesConfigKey, registriesConfig)
+}
+
+func createAdminToken(password string, rancherConfig *rancher.Config) (string, error) {
+	adminUser := &management.User{
+		Username: "admin",
+		Password: password,
+	}
+
+	hostURL := rancherConfig.Host
+	var userToken *management.Token
+	err := kwait.Poll(500*time.Millisecond, 5*time.Minute, func() (done bool, err error) {
+		userToken, err = token.GenerateUserToken(adminUser, hostURL)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return userToken.Token, nil
+}
+
+func createTestCluster(client, adminClient *rancher.Client, numClusters int, clusterNameBase, cni, kubeVersion string, nodesAndRoles []nodepools.NodeRoles, privateRegistries []management.PrivateRegistry) ([]string, error) {
+	clusterNames := []string{}
+	for i := 0; i < numClusters; i++ {
+		clusterName := namegen.AppendRandomString(clusterNameBase)
+		clusterNames = append(clusterNames, clusterName)
+		cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, client)
+
+		if len(privateRegistries) > 0 {
+			cluster.RancherKubernetesEngineConfig.PrivateRegistries = privateRegistries
+		}
+
+		clusterResp, err := clusters.CreateRKE1Cluster(client, cluster)
+		if err != nil {
+			return nil, err
+		}
+
+		err = kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
+			cluster, err := client.Management.Cluster.ByID(clusterResp.ID)
+			if err != nil {
+				return false, nil
+			} else if cluster != nil && cluster.ID == clusterResp.ID {
+				return true, nil
+			}
+			return false, nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		nodeTemplateResp, err := aws.CreateAWSNodeTemplate(client)
+		if err != nil {
+			return nil, err
+		}
+
+		err = kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
+			nodeTemplate, err := client.Management.NodeTemplate.ByID(nodeTemplateResp.ID)
+			if err != nil {
+				return false, nil
+			} else if nodeTemplate != nil && nodeTemplate.ID == nodeTemplateResp.ID {
+				return true, nil
+			}
+			return false, nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = nodepools.NodePoolSetup(client, nodesAndRoles, clusterResp.ID, nodeTemplateResp.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		opts := metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + clusterResp.ID,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		}
+		watchInterface, err := adminClient.GetManagementWatchInterface(management.ClusterType, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		checkFunc := clusters.IsHostedProvisioningClusterReady
+
+		err = wait.WatchWait(watchInterface, checkFunc)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return clusterNames, nil
+}
+
+func postRancherInstall(adminClient *rancher.Client) error {
+	clusterID, err := clusters.GetClusterIDByName(adminClient, clusterName)
+	if err != nil {
+		return err
+	}
+
+	steveClient, err := adminClient.Steve.ProxyDownstream(clusterID)
+	if err != nil {
+		return err
+	}
+
+	timeStamp := time.Now().Format(time.RFC3339)
+	settingEULA := v3.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "eula-agreed",
+		},
+		Default: timeStamp,
+		Value:   timeStamp,
+	}
+
+	urlSetting := &v3.Setting{}
+
+	_, err = steveClient.SteveType("management.cattle.io.setting").Create(settingEULA)
+	if err != nil {
+		return err
+	}
+
+	urlSettingResp, err := steveClient.SteveType("management.cattle.io.setting").ByID("server-url")
+	if err != nil {
+		return err
+	}
+
+	err = v1.ConvertToK8sType(urlSettingResp.JSONResp, urlSetting)
+	if err != nil {
+		return err
+	}
+
+	urlSetting.Value = fmt.Sprintf("https://%s", adminClient.RancherConfig.Host)
+
+	_, err = steveClient.SteveType("management.cattle.io.setting").Update(urlSettingResp, urlSetting)
+	if err != nil {
+		return err
+	}
+
+	userList, err := adminClient.Management.User.List(&types.ListOpts{
+		Filters: map[string]interface{}{
+			"username": "admin",
+		},
+	})
+	if err != nil {
+		return err
+	} else if len(userList.Data) == 0 {
+		return fmt.Errorf("admin user not found")
+	}
+
+	adminUser := &userList.Data[0]
+	setPasswordInput := management.SetPasswordInput{
+		NewPassword: adminPassword,
+	}
+	_, err = adminClient.Management.User.ActionSetpassword(adminUser, &setPasswordInput)
+
+	return err
+}

--- a/tests/v2/validation/registries/config.go
+++ b/tests/v2/validation/registries/config.go
@@ -1,0 +1,13 @@
+package registries
+
+const RegistriesConfigKey = "registries"
+
+type Config struct {
+	Clusters []Cluster `json:"clusters" yaml:"clusters" default:"[]"`
+}
+
+type Cluster struct {
+	Name string `json:"name" yaml:"name"`
+	URL  string `json:"url" yaml:"url"`
+	Auth bool   `json:"auth" yaml:"auth"`
+}

--- a/tests/v2/validation/registries/registry_test.go
+++ b/tests/v2/validation/registries/registry_test.go
@@ -1,0 +1,98 @@
+package registries
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/registries"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type RegistryTestSuite struct {
+	suite.Suite
+	session                        *session.Session
+	podListClusterAuth             *v1.SteveCollection
+	podListClusterNoAuth           *v1.SteveCollection
+	podListClusterLocal            *v1.SteveCollection
+	clusterAuthRegistryHost        string
+	clusterNoAuthRegistryHost      string
+	localClusterGlobalRegistryHost string
+}
+
+func (rt *RegistryTestSuite) TearDownSuite() {
+	rt.session.Cleanup()
+}
+
+func (rt *RegistryTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	rt.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(rt.T(), err)
+
+	registriesConfig := new(Config)
+	config.LoadConfig(RegistriesConfigKey, registriesConfig)
+
+	for _, v := range registriesConfig.Clusters {
+		clusterID, err := clusters.GetClusterIDByName(client, v.Name)
+		require.NoError(rt.T(), err)
+		downstreamClient, err := client.Steve.ProxyDownstream(clusterID)
+		require.NoError(rt.T(), err)
+		steveClient := downstreamClient.SteveType(pods.PodResourceSteveType)
+
+		podsList, err := steveClient.List(nil)
+		require.NoError(rt.T(), err)
+		if v.Auth == true {
+			rt.podListClusterAuth = podsList
+			rt.clusterAuthRegistryHost = v.URL
+		} else if v.Name == "local" {
+			rt.podListClusterLocal = podsList
+			rt.localClusterGlobalRegistryHost = v.URL
+		} else {
+			rt.podListClusterNoAuth = podsList
+			rt.clusterNoAuthRegistryHost = v.URL
+}		}
+	}
+}
+
+func (rt *RegistryTestSuite) TestRegistryAllPods() {
+
+	havePrefix, err := registries.CheckAllClusterPodsForRegistryPrefix(rt.podListClusterAuth, rt.clusterAuthRegistryHost)
+	require.NoError(rt.T(), err)
+	assert.True(rt.T(), havePrefix)
+
+	havePrefix, err = registries.CheckAllClusterPodsForRegistryPrefix(rt.podListClusterNoAuth, rt.clusterNoAuthRegistryHost)
+	require.NoError(rt.T(), err)
+	assert.True(rt.T(), havePrefix)
+
+	havePrefix, err = registries.CheckAllClusterPodsForRegistryPrefix(rt.podListClusterLocal, rt.localClusterGlobalRegistryHost)
+	require.NoError(rt.T(), err)
+	assert.True(rt.T(), havePrefix)
+
+}
+
+func (rt *RegistryTestSuite) TestStatusAllPods() {
+
+	areStatusesOk, err := registries.CheckAllClusterPodsStatusForRegistry(rt.podListClusterAuth, rt.clusterAuthRegistryHost)
+	require.NoError(rt.T(), err)
+	assert.True(rt.T(), areStatusesOk)
+
+	areStatusesOk, err = registries.CheckAllClusterPodsStatusForRegistry(rt.podListClusterNoAuth, rt.clusterNoAuthRegistryHost)
+	require.NoError(rt.T(), err)
+	assert.True(rt.T(), areStatusesOk)
+
+	areStatusesOk, err = registries.CheckAllClusterPodsStatusForRegistry(rt.podListClusterLocal, rt.localClusterGlobalRegistryHost)
+	require.NoError(rt.T(), err)
+	assert.True(rt.T(), areStatusesOk)
+}
+
+func TestRegistryTestSuite(t *testing.T) {
+	suite.Run(t, new(RegistryTestSuite))
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/qa-tasks/issues/51

Depends on: https://github.com/rancherlabs/corral-packages/pull/6
 
## Problem

There isn't automated way to start building a Rancher deployment with downstream clusters with configured private registries.
 
## Solution

With the code in this PR we can use the corral client to build the test environment with three private registries. 
- Registry with no authentication for Rancher. Rancher is also deployed.
- Registry with no authentication for a downstream Cluster 
- And a final registry with authentication enabled for a downstream Cluster

Using the go framework the code proceeds to configure Rancher creating an admin user with his password and an auth token.

The Rancher client creates two downstream clusters one with an authentication enabled registry and the other disabled.

Then it validates the pod images have the private registry url as expected.

## Testing

This was done through Jenkins in a custom job using forked `rancher` and `corral-packages` repositories.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing

- The registry is configured during cluster creation
- Built-in validation of cluster health through `createCluster` methods.
- No pod status check yet (`ImgPullBackOff`, etc)
- Validate all pods image names iterating on all workloads


## QA Testing Considerations

The Kubernetes versions should match those in the release's `rancher-images.txt` and confirmed in KDM that it matches the Kubernetes dependencies listed in the rancher-images.

This requires to provide a yaml corral package configuration for Rancher and another yaml for the other two standalone registries using the registry package.

Rancher version must match on those corral-packages Yaml configurations.

There were problems with corral corrupting the global `corral.yaml` when Parallel private registries creation was triggered this specially during execution on docker images in CI. Other symptoms were the terraform executables sometimes trigerred "file already in use".

Reverting to sequential stabilized this for the cost of pipeline execution duration (~1hr duration each registry)
 