### PR TITLE
Check if secret already exists before migrating

### DIFF
--- a/pkg/cluster/private_registry_test.go
+++ b/pkg/cluster/private_registry_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -49,7 +50,7 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 		{
 			name:           "rke1 private registry",
 			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
-			expectedConfig: "testConfig", // should be directly copied from RKE1 secret
+			expectedConfig: base64.URLEncoding.EncodeToString([]byte("testConfig")), // should be directly copied from RKE1 secret
 			expectedError:  "",
 			cluster: &v3.Cluster{
 				Spec: v3.ClusterSpec{
@@ -83,7 +84,7 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 		{
 			name:           "v2prov private registry",
 			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
-			expectedConfig: `{"auths":{"0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com":{"username":"testuser","password":"password","auth":"dGVzdHVzZXI6cGFzc3dvcmQ="}}}`,
+			expectedConfig: base64.URLEncoding.EncodeToString([]byte(`{"auths":{"0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com":{"username":"testuser","password":"password","auth":"dGVzdHVzZXI6cGFzc3dvcmQ="}}}`)),
 			expectedError:  "",
 			cluster: &v3.Cluster{
 				Spec: v3.ClusterSpec{
@@ -117,7 +118,7 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 			for _, s := range tt.secrets {
 				mockSecrets[fmt.Sprintf("%s:%s", s.Namespace, s.Name)] = s
 			}
-			url, cfg, err := GeneratePrivateRegistryDockerConfig(tt.cluster, secretLister)
+			url, cfg, err := GeneratePrivateRegistryEncodedDockerConfig(tt.cluster, secretLister)
 			assert.Equal(t, tt.expectedUrl, url)
 			assert.Equal(t, tt.expectedConfig, cfg)
 			if tt.expectedError == "" {

--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -355,7 +355,7 @@ func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, cluster *v
 	// We don't need the value of these secrets, however their existence means there should be a secret to add to the list
 	// of imagePullSecrets
 	if cluster.GetSecret(v3.ClusterPrivateRegistrySecret) != "" || cluster.Spec.ClusterSecrets.PrivateRegistryECRSecret != "" {
-		if url, _, err := util.GeneratePrivateRegistryDockerConfig(cluster, m.secretLister); err != nil {
+		if url, _, err := util.GeneratePrivateRegistryEncodedDockerConfig(cluster, m.secretLister); err != nil {
 			return nil, err
 		} else if url != "" {
 			imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{Name: "cattle-private-registry"})

--- a/pkg/controllers/management/secretmigrator/clusters.go
+++ b/pkg/controllers/management/secretmigrator/clusters.go
@@ -671,6 +671,9 @@ func cleanQuestions(cluster *apimgmtv3.Cluster) {
 type cleanupFunc func(spec *apimgmtv3.ClusterSpec)
 
 func (h *handler) migrateSecret(cluster *apimgmtv3.Cluster, secretName, secretClass string, secretField *string, createOrUpdateSecret CreateOrUpdateSecretFunc, cleanup cleanupFunc) (*apimgmtv3.Cluster, error) {
+	if cluster.GetSecret(secretName) != "" {
+		return cluster, nil
+	}
 	logrus.Tracef("[secretmigrator] migrating %s secrets for cluster %s", secretClass, cluster.Name)
 	secret, err := createOrUpdateSecret(cluster.GetSecret(secretName), cluster.Spec.RancherKubernetesEngineConfig, cluster)
 	if err != nil {

--- a/pkg/rkenodeconfigserver/nodeserver.go
+++ b/pkg/rkenodeconfigserver/nodeserver.go
@@ -305,7 +305,7 @@ OuterLoop:
 		if err != nil {
 			return nil, err
 		}
-		_, privateRegistryConfig, _ := util.GeneratePrivateRegistryDockerConfig(cluster, secretLister)
+		_, privateRegistryConfig, _ := util.GeneratePrivateRegistryEncodedDockerConfig(cluster, secretLister)
 		processes["share-mnt"] = rketypes.Process{
 			Name:  "share-mnt",
 			Args:  nodeCommand,

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -79,7 +79,7 @@ func SystemTemplate(resp io.Writer, agentImage, authImage, namespace, token, url
 		authImage = settings.AuthImage.Get()
 	}
 
-	registryURL, registryConfig, err := util.GeneratePrivateRegistryDockerConfig(cluster, secretLister)
+	registryURL, registryConfig, err := util.GeneratePrivateRegistryEncodedDockerConfig(cluster, secretLister)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #40321 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

If a migrated secret already exists during secrets migration, and the migration fails at any point, a secret may get deleted.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Check if the secret exists prior to migrating.

Also includes fix from https://github.com/rancher/rancher/pull/40534 for private registry base64 encoding.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually on release/v2.6 based on this commit from 2.6 backport: https://github.com/rancher/rancher/pull/40476

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

N/A

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Need to test with ECR private registries and regular private registries.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->