### PR TITLE
Remove the Manage PodSecurityAdmissionConfigurationTemplates role

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -78,8 +78,6 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 		addRule().apiGroups("management.cattle.io").resources("features").verbs("get", "list", "watch", "update")
 	rb.addRole("Manage PodSecurityPolicy Templates", "podsecuritypolicytemplates-manage").
 		addRule().apiGroups("management.cattle.io").resources("podsecuritypolicytemplates").verbs("*")
-	rb.addRole("Manage PodSecurityAdmissionConfiguration Templates", "podsecurityadmissionconfigurationtemplates-manage").
-		addRule().apiGroups("management.cattle.io").resources("podsecurityadmissionconfigurationtemplates").verbs("*")
 	rb.addRole("Create RKE Templates", "clustertemplates-create").
 		addRule().apiGroups("management.cattle.io").resources("clustertemplates").verbs("create")
 	rb.addRole("Create RKE Template Revisions", "clustertemplaterevisions-create").


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/40289
 
This removes the Manage PodSecurityAdmissionConfiguration Templates role.  It has been decided that this is an admin-only operation.