### PR TITLE
preparation for v2.7.2-rc2 

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -159,8 +159,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-ENV CATTLE_UI_VERSION 2.7.2-rc1
-ENV CATTLE_DASHBOARD_UI_VERSION v2.7.2-rc1
+ENV CATTLE_UI_VERSION 2.7.2-rc2
+ENV CATTLE_DASHBOARD_UI_VERSION v2.7.2-rc2
 ENV CATTLE_CLI_VERSION v2.7.2-rc1
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install

--- a/pkg/client/generated/management/v3/zz_generated_cluster_secrets.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_secrets.go
@@ -1,26 +1,40 @@
 package client
 
 const (
-	ClusterSecretsType                       = "clusterSecrets"
-	ClusterSecretsFieldAADClientCertSecret   = "aadClientCertSecret"
-	ClusterSecretsFieldAADClientSecret       = "aadClientSecret"
-	ClusterSecretsFieldOpenStackSecret       = "openStackSecret"
-	ClusterSecretsFieldPrivateRegistrySecret = "privateRegistrySecret"
-	ClusterSecretsFieldPrivateRegistryURL    = "privateRegistryURL"
-	ClusterSecretsFieldS3CredentialSecret    = "s3CredentialSecret"
-	ClusterSecretsFieldVirtualCenterSecret   = "virtualCenterSecret"
-	ClusterSecretsFieldVsphereSecret         = "vsphereSecret"
-	ClusterSecretsFieldWeavePasswordSecret   = "weavePasswordSecret"
+	ClusterSecretsType                                  = "clusterSecrets"
+	ClusterSecretsFieldAADClientCertSecret              = "aadClientCertSecret"
+	ClusterSecretsFieldAADClientSecret                  = "aadClientSecret"
+	ClusterSecretsFieldACIAPICUserKeySecret             = "aciAPICUserKeySecret"
+	ClusterSecretsFieldACIKafkaClientKeySecret          = "aciKafkaClientKeySecret"
+	ClusterSecretsFieldACITokenSecret                   = "aciTokenSecret"
+	ClusterSecretsFieldBastionHostSSHKeySecret          = "bastionHostSSHKeySecret"
+	ClusterSecretsFieldKubeletExtraEnvSecret            = "kubeletExtraEnvSecret"
+	ClusterSecretsFieldOpenStackSecret                  = "openStackSecret"
+	ClusterSecretsFieldPrivateRegistryECRSecret         = "privateRegistryECRSecret"
+	ClusterSecretsFieldPrivateRegistrySecret            = "privateRegistrySecret"
+	ClusterSecretsFieldPrivateRegistryURL               = "privateRegistryURL"
+	ClusterSecretsFieldS3CredentialSecret               = "s3CredentialSecret"
+	ClusterSecretsFieldSecretsEncryptionProvidersSecret = "secretsEncryptionProvidersSecret"
+	ClusterSecretsFieldVirtualCenterSecret              = "virtualCenterSecret"
+	ClusterSecretsFieldVsphereSecret                    = "vsphereSecret"
+	ClusterSecretsFieldWeavePasswordSecret              = "weavePasswordSecret"
 )
 
 type ClusterSecrets struct {
-	AADClientCertSecret   string `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
-	AADClientSecret       string `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
-	OpenStackSecret       string `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
-	PrivateRegistrySecret string `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
-	PrivateRegistryURL    string `json:"privateRegistryURL,omitempty" yaml:"privateRegistryURL,omitempty"`
-	S3CredentialSecret    string `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
-	VirtualCenterSecret   string `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
-	VsphereSecret         string `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
-	WeavePasswordSecret   string `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
+	AADClientCertSecret              string `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
+	AADClientSecret                  string `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
+	ACIAPICUserKeySecret             string `json:"aciAPICUserKeySecret,omitempty" yaml:"aciAPICUserKeySecret,omitempty"`
+	ACIKafkaClientKeySecret          string `json:"aciKafkaClientKeySecret,omitempty" yaml:"aciKafkaClientKeySecret,omitempty"`
+	ACITokenSecret                   string `json:"aciTokenSecret,omitempty" yaml:"aciTokenSecret,omitempty"`
+	BastionHostSSHKeySecret          string `json:"bastionHostSSHKeySecret,omitempty" yaml:"bastionHostSSHKeySecret,omitempty"`
+	KubeletExtraEnvSecret            string `json:"kubeletExtraEnvSecret,omitempty" yaml:"kubeletExtraEnvSecret,omitempty"`
+	OpenStackSecret                  string `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
+	PrivateRegistryECRSecret         string `json:"privateRegistryECRSecret,omitempty" yaml:"privateRegistryECRSecret,omitempty"`
+	PrivateRegistrySecret            string `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
+	PrivateRegistryURL               string `json:"privateRegistryURL,omitempty" yaml:"privateRegistryURL,omitempty"`
+	S3CredentialSecret               string `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
+	SecretsEncryptionProvidersSecret string `json:"secretsEncryptionProvidersSecret,omitempty" yaml:"secretsEncryptionProvidersSecret,omitempty"`
+	VirtualCenterSecret              string `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
+	VsphereSecret                    string `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
+	WeavePasswordSecret              string `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
 }

--- a/pkg/client/generated/management/v3/zz_generated_cluster_template_revision.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_template_revision.go
@@ -5,59 +5,73 @@ import (
 )
 
 const (
-	ClusterTemplateRevisionType                       = "clusterTemplateRevision"
-	ClusterTemplateRevisionFieldAADClientCertSecret   = "aadClientCertSecret"
-	ClusterTemplateRevisionFieldAADClientSecret       = "aadClientSecret"
-	ClusterTemplateRevisionFieldAnnotations           = "annotations"
-	ClusterTemplateRevisionFieldClusterConfig         = "clusterConfig"
-	ClusterTemplateRevisionFieldClusterTemplateID     = "clusterTemplateId"
-	ClusterTemplateRevisionFieldConditions            = "conditions"
-	ClusterTemplateRevisionFieldCreated               = "created"
-	ClusterTemplateRevisionFieldCreatorID             = "creatorId"
-	ClusterTemplateRevisionFieldEnabled               = "enabled"
-	ClusterTemplateRevisionFieldLabels                = "labels"
-	ClusterTemplateRevisionFieldName                  = "name"
-	ClusterTemplateRevisionFieldOpenStackSecret       = "openStackSecret"
-	ClusterTemplateRevisionFieldOwnerReferences       = "ownerReferences"
-	ClusterTemplateRevisionFieldPrivateRegistrySecret = "privateRegistrySecret"
-	ClusterTemplateRevisionFieldQuestions             = "questions"
-	ClusterTemplateRevisionFieldRemoved               = "removed"
-	ClusterTemplateRevisionFieldS3CredentialSecret    = "s3CredentialSecret"
-	ClusterTemplateRevisionFieldState                 = "state"
-	ClusterTemplateRevisionFieldTransitioning         = "transitioning"
-	ClusterTemplateRevisionFieldTransitioningMessage  = "transitioningMessage"
-	ClusterTemplateRevisionFieldUUID                  = "uuid"
-	ClusterTemplateRevisionFieldVirtualCenterSecret   = "virtualCenterSecret"
-	ClusterTemplateRevisionFieldVsphereSecret         = "vsphereSecret"
-	ClusterTemplateRevisionFieldWeavePasswordSecret   = "weavePasswordSecret"
+	ClusterTemplateRevisionType                                  = "clusterTemplateRevision"
+	ClusterTemplateRevisionFieldAADClientCertSecret              = "aadClientCertSecret"
+	ClusterTemplateRevisionFieldAADClientSecret                  = "aadClientSecret"
+	ClusterTemplateRevisionFieldACIAPICUserKeySecret             = "aciAPICUserKeySecret"
+	ClusterTemplateRevisionFieldACIKafkaClientKeySecret          = "aciKafkaClientKeySecret"
+	ClusterTemplateRevisionFieldACITokenSecret                   = "aciTokenSecret"
+	ClusterTemplateRevisionFieldAnnotations                      = "annotations"
+	ClusterTemplateRevisionFieldBastionHostSSHKeySecret          = "bastionHostSSHKeySecret"
+	ClusterTemplateRevisionFieldClusterConfig                    = "clusterConfig"
+	ClusterTemplateRevisionFieldClusterTemplateID                = "clusterTemplateId"
+	ClusterTemplateRevisionFieldConditions                       = "conditions"
+	ClusterTemplateRevisionFieldCreated                          = "created"
+	ClusterTemplateRevisionFieldCreatorID                        = "creatorId"
+	ClusterTemplateRevisionFieldEnabled                          = "enabled"
+	ClusterTemplateRevisionFieldKubeletExtraEnvSecret            = "kubeletExtraEnvSecret"
+	ClusterTemplateRevisionFieldLabels                           = "labels"
+	ClusterTemplateRevisionFieldName                             = "name"
+	ClusterTemplateRevisionFieldOpenStackSecret                  = "openStackSecret"
+	ClusterTemplateRevisionFieldOwnerReferences                  = "ownerReferences"
+	ClusterTemplateRevisionFieldPrivateRegistryECRSecret         = "privateRegistryECRSecret"
+	ClusterTemplateRevisionFieldPrivateRegistrySecret            = "privateRegistrySecret"
+	ClusterTemplateRevisionFieldQuestions                        = "questions"
+	ClusterTemplateRevisionFieldRemoved                          = "removed"
+	ClusterTemplateRevisionFieldS3CredentialSecret               = "s3CredentialSecret"
+	ClusterTemplateRevisionFieldSecretsEncryptionProvidersSecret = "secretsEncryptionProvidersSecret"
+	ClusterTemplateRevisionFieldState                            = "state"
+	ClusterTemplateRevisionFieldTransitioning                    = "transitioning"
+	ClusterTemplateRevisionFieldTransitioningMessage             = "transitioningMessage"
+	ClusterTemplateRevisionFieldUUID                             = "uuid"
+	ClusterTemplateRevisionFieldVirtualCenterSecret              = "virtualCenterSecret"
+	ClusterTemplateRevisionFieldVsphereSecret                    = "vsphereSecret"
+	ClusterTemplateRevisionFieldWeavePasswordSecret              = "weavePasswordSecret"
 )
 
 type ClusterTemplateRevision struct {
 	types.Resource
-	AADClientCertSecret   string                             `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
-	AADClientSecret       string                             `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
-	Annotations           map[string]string                  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	ClusterConfig         *ClusterSpecBase                   `json:"clusterConfig,omitempty" yaml:"clusterConfig,omitempty"`
-	ClusterTemplateID     string                             `json:"clusterTemplateId,omitempty" yaml:"clusterTemplateId,omitempty"`
-	Conditions            []ClusterTemplateRevisionCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
-	Created               string                             `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID             string                             `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	Enabled               *bool                              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Labels                map[string]string                  `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Name                  string                             `json:"name,omitempty" yaml:"name,omitempty"`
-	OpenStackSecret       string                             `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
-	OwnerReferences       []OwnerReference                   `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	PrivateRegistrySecret string                             `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
-	Questions             []Question                         `json:"questions,omitempty" yaml:"questions,omitempty"`
-	Removed               string                             `json:"removed,omitempty" yaml:"removed,omitempty"`
-	S3CredentialSecret    string                             `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
-	State                 string                             `json:"state,omitempty" yaml:"state,omitempty"`
-	Transitioning         string                             `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
-	TransitioningMessage  string                             `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
-	UUID                  string                             `json:"uuid,omitempty" yaml:"uuid,omitempty"`
-	VirtualCenterSecret   string                             `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
-	VsphereSecret         string                             `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
-	WeavePasswordSecret   string                             `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
+	AADClientCertSecret              string                             `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
+	AADClientSecret                  string                             `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
+	ACIAPICUserKeySecret             string                             `json:"aciAPICUserKeySecret,omitempty" yaml:"aciAPICUserKeySecret,omitempty"`
+	ACIKafkaClientKeySecret          string                             `json:"aciKafkaClientKeySecret,omitempty" yaml:"aciKafkaClientKeySecret,omitempty"`
+	ACITokenSecret                   string                             `json:"aciTokenSecret,omitempty" yaml:"aciTokenSecret,omitempty"`
+	Annotations                      map[string]string                  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	BastionHostSSHKeySecret          string                             `json:"bastionHostSSHKeySecret,omitempty" yaml:"bastionHostSSHKeySecret,omitempty"`
+	ClusterConfig                    *ClusterSpecBase                   `json:"clusterConfig,omitempty" yaml:"clusterConfig,omitempty"`
+	ClusterTemplateID                string                             `json:"clusterTemplateId,omitempty" yaml:"clusterTemplateId,omitempty"`
+	Conditions                       []ClusterTemplateRevisionCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	Created                          string                             `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID                        string                             `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Enabled                          *bool                              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	KubeletExtraEnvSecret            string                             `json:"kubeletExtraEnvSecret,omitempty" yaml:"kubeletExtraEnvSecret,omitempty"`
+	Labels                           map[string]string                  `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name                             string                             `json:"name,omitempty" yaml:"name,omitempty"`
+	OpenStackSecret                  string                             `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
+	OwnerReferences                  []OwnerReference                   `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	PrivateRegistryECRSecret         string                             `json:"privateRegistryECRSecret,omitempty" yaml:"privateRegistryECRSecret,omitempty"`
+	PrivateRegistrySecret            string                             `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
+	Questions                        []Question                         `json:"questions,omitempty" yaml:"questions,omitempty"`
+	Removed                          string                             `json:"removed,omitempty" yaml:"removed,omitempty"`
+	S3CredentialSecret               string                             `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
+	SecretsEncryptionProvidersSecret string                             `json:"secretsEncryptionProvidersSecret,omitempty" yaml:"secretsEncryptionProvidersSecret,omitempty"`
+	State                            string                             `json:"state,omitempty" yaml:"state,omitempty"`
+	Transitioning                    string                             `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+	TransitioningMessage             string                             `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
+	UUID                             string                             `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	VirtualCenterSecret              string                             `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
+	VsphereSecret                    string                             `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
+	WeavePasswordSecret              string                             `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
 }
 
 type ClusterTemplateRevisionCollection struct {

--- a/pkg/client/generated/management/v3/zz_generated_cluster_template_revision_status.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_template_revision_status.go
@@ -1,26 +1,40 @@
 package client
 
 const (
-	ClusterTemplateRevisionStatusType                       = "clusterTemplateRevisionStatus"
-	ClusterTemplateRevisionStatusFieldAADClientCertSecret   = "aadClientCertSecret"
-	ClusterTemplateRevisionStatusFieldAADClientSecret       = "aadClientSecret"
-	ClusterTemplateRevisionStatusFieldConditions            = "conditions"
-	ClusterTemplateRevisionStatusFieldOpenStackSecret       = "openStackSecret"
-	ClusterTemplateRevisionStatusFieldPrivateRegistrySecret = "privateRegistrySecret"
-	ClusterTemplateRevisionStatusFieldS3CredentialSecret    = "s3CredentialSecret"
-	ClusterTemplateRevisionStatusFieldVirtualCenterSecret   = "virtualCenterSecret"
-	ClusterTemplateRevisionStatusFieldVsphereSecret         = "vsphereSecret"
-	ClusterTemplateRevisionStatusFieldWeavePasswordSecret   = "weavePasswordSecret"
+	ClusterTemplateRevisionStatusType                                  = "clusterTemplateRevisionStatus"
+	ClusterTemplateRevisionStatusFieldAADClientCertSecret              = "aadClientCertSecret"
+	ClusterTemplateRevisionStatusFieldAADClientSecret                  = "aadClientSecret"
+	ClusterTemplateRevisionStatusFieldACIAPICUserKeySecret             = "aciAPICUserKeySecret"
+	ClusterTemplateRevisionStatusFieldACIKafkaClientKeySecret          = "aciKafkaClientKeySecret"
+	ClusterTemplateRevisionStatusFieldACITokenSecret                   = "aciTokenSecret"
+	ClusterTemplateRevisionStatusFieldBastionHostSSHKeySecret          = "bastionHostSSHKeySecret"
+	ClusterTemplateRevisionStatusFieldConditions                       = "conditions"
+	ClusterTemplateRevisionStatusFieldKubeletExtraEnvSecret            = "kubeletExtraEnvSecret"
+	ClusterTemplateRevisionStatusFieldOpenStackSecret                  = "openStackSecret"
+	ClusterTemplateRevisionStatusFieldPrivateRegistryECRSecret         = "privateRegistryECRSecret"
+	ClusterTemplateRevisionStatusFieldPrivateRegistrySecret            = "privateRegistrySecret"
+	ClusterTemplateRevisionStatusFieldS3CredentialSecret               = "s3CredentialSecret"
+	ClusterTemplateRevisionStatusFieldSecretsEncryptionProvidersSecret = "secretsEncryptionProvidersSecret"
+	ClusterTemplateRevisionStatusFieldVirtualCenterSecret              = "virtualCenterSecret"
+	ClusterTemplateRevisionStatusFieldVsphereSecret                    = "vsphereSecret"
+	ClusterTemplateRevisionStatusFieldWeavePasswordSecret              = "weavePasswordSecret"
 )
 
 type ClusterTemplateRevisionStatus struct {
-	AADClientCertSecret   string                             `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
-	AADClientSecret       string                             `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
-	Conditions            []ClusterTemplateRevisionCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
-	OpenStackSecret       string                             `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
-	PrivateRegistrySecret string                             `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
-	S3CredentialSecret    string                             `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
-	VirtualCenterSecret   string                             `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
-	VsphereSecret         string                             `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
-	WeavePasswordSecret   string                             `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
+	AADClientCertSecret              string                             `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
+	AADClientSecret                  string                             `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
+	ACIAPICUserKeySecret             string                             `json:"aciAPICUserKeySecret,omitempty" yaml:"aciAPICUserKeySecret,omitempty"`
+	ACIKafkaClientKeySecret          string                             `json:"aciKafkaClientKeySecret,omitempty" yaml:"aciKafkaClientKeySecret,omitempty"`
+	ACITokenSecret                   string                             `json:"aciTokenSecret,omitempty" yaml:"aciTokenSecret,omitempty"`
+	BastionHostSSHKeySecret          string                             `json:"bastionHostSSHKeySecret,omitempty" yaml:"bastionHostSSHKeySecret,omitempty"`
+	Conditions                       []ClusterTemplateRevisionCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	KubeletExtraEnvSecret            string                             `json:"kubeletExtraEnvSecret,omitempty" yaml:"kubeletExtraEnvSecret,omitempty"`
+	OpenStackSecret                  string                             `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
+	PrivateRegistryECRSecret         string                             `json:"privateRegistryECRSecret,omitempty" yaml:"privateRegistryECRSecret,omitempty"`
+	PrivateRegistrySecret            string                             `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
+	S3CredentialSecret               string                             `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
+	SecretsEncryptionProvidersSecret string                             `json:"secretsEncryptionProvidersSecret,omitempty" yaml:"secretsEncryptionProvidersSecret,omitempty"`
+	VirtualCenterSecret              string                             `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
+	VsphereSecret                    string                             `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
+	WeavePasswordSecret              string                             `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
 }

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -159,8 +159,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-ENV CATTLE_UI_VERSION 2.7.2-rc1
-ENV CATTLE_DASHBOARD_UI_VERSION v2.7.2-rc1
+ENV CATTLE_UI_VERSION 2.7.2-rc2
+ENV CATTLE_DASHBOARD_UI_VERSION v2.7.2-rc2
 ENV CATTLE_CLI_VERSION v2.7.2-rc1
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install


### PR DESCRIPTION
This PR contains the following changes for preparing the v2.7.2-rc2 tag:
- run `go generate` 
- bump ui tag to v2.7.2-rc2