### PR TITLE
Encoded private registry auth config

### DIFF
--- a/pkg/cluster/private_registry_test.go
+++ b/pkg/cluster/private_registry_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -49,7 +50,7 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 		{
 			name:           "rke1 private registry",
 			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
-			expectedConfig: "testConfig", // should be directly copied from RKE1 secret
+			expectedConfig: base64.URLEncoding.EncodeToString([]byte("testConfig")), // should be directly copied from RKE1 secret
 			expectedError:  "",
 			cluster: &v3.Cluster{
 				Spec: v3.ClusterSpec{
@@ -83,7 +84,7 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 		{
 			name:           "v2prov private registry",
 			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
-			expectedConfig: `{"auths":{"0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com":{"username":"testuser","password":"password","auth":"dGVzdHVzZXI6cGFzc3dvcmQ="}}}`,
+			expectedConfig: base64.URLEncoding.EncodeToString([]byte(`{"auths":{"0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com":{"username":"testuser","password":"password","auth":"dGVzdHVzZXI6cGFzc3dvcmQ="}}}`)),
 			expectedError:  "",
 			cluster: &v3.Cluster{
 				Spec: v3.ClusterSpec{
@@ -117,7 +118,7 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 			for _, s := range tt.secrets {
 				mockSecrets[fmt.Sprintf("%s:%s", s.Namespace, s.Name)] = s
 			}
-			url, cfg, err := GeneratePrivateRegistryDockerConfig(tt.cluster, secretLister)
+			url, cfg, err := GeneratePrivateRegistryEncodedDockerConfig(tt.cluster, secretLister)
 			assert.Equal(t, tt.expectedUrl, url)
 			assert.Equal(t, tt.expectedConfig, cfg)
 			if tt.expectedError == "" {

--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -356,7 +356,7 @@ func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, cluster *v
 	// We don't need the value of these secrets, however their existence means there should be a secret to add to the list
 	// of imagePullSecrets
 	if cluster.GetSecret(v3.ClusterPrivateRegistrySecret) != "" || cluster.Spec.ClusterSecrets.PrivateRegistryECRSecret != "" {
-		if url, _, err := util.GeneratePrivateRegistryDockerConfig(cluster, m.secretLister); err != nil {
+		if url, _, err := util.GeneratePrivateRegistryEncodedDockerConfig(cluster, m.secretLister); err != nil {
 			return nil, err
 		} else if url != "" {
 			imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{Name: "cattle-private-registry"})

--- a/pkg/rkenodeconfigserver/nodeserver.go
+++ b/pkg/rkenodeconfigserver/nodeserver.go
@@ -305,7 +305,7 @@ OuterLoop:
 		if err != nil {
 			return nil, err
 		}
-		_, privateRegistryConfig, _ := util.GeneratePrivateRegistryDockerConfig(cluster, lister)
+		_, privateRegistryConfig, _ := util.GeneratePrivateRegistryEncodedDockerConfig(cluster, lister)
 		processes["share-mnt"] = rketypes.Process{
 			Name:  "share-mnt",
 			Args:  nodeCommand,

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -79,7 +79,7 @@ func SystemTemplate(resp io.Writer, agentImage, authImage, namespace, token, url
 		authImage = settings.AuthImage.Get()
 	}
 
-	registryURL, registryConfig, err := util.GeneratePrivateRegistryDockerConfig(cluster, secretLister)
+	registryURL, registryConfig, err := util.GeneratePrivateRegistryEncodedDockerConfig(cluster, secretLister)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #40457 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

During merging of the v2.6.10 backports, a base64 encoding was dropped. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add the base64 encoding of the private registry auth credentials back.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

I am still setting up an environment to test this, but I am fairly confident this will work.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

Updated unit tests to ensure that the base64 encoding is returned.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->