### PR TITLE
[v2.6] update rke to v1.3.19-rc1 for v2.6.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8
-	github.com/rancher/rke v1.3.20-rc1
+	github.com/rancher/rke v1.3.19-rc1
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20230112214329-a8f8c5e1bf62
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007

--- a/go.sum
+++ b/go.sum
@@ -1430,8 +1430,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a h1:6xqYlVz4uAX
 github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8wJ/coee2n9ed937uPBWQArBaVlxs+5wkkS9KiyDc=
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8 h1:leqh0chjBsXhKWebxxFd5QPcoQLu51EpaHo04ce0o+8=
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
-github.com/rancher/rke v1.3.20-rc1 h1:PG89XmR3Fn/O7GkQlfce+TXMw5m7Zip38/FNqtWzbWA=
-github.com/rancher/rke v1.3.20-rc1/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
+github.com/rancher/rke v1.3.19-rc1 h1:zXYeNc3YbL6r3xfKIPmSsT2O3aPeyuCsWdKQOUfU9OQ=
+github.com/rancher/rke v1.3.19-rc1/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
 github.com/rancher/steve v0.0.0-20230112214329-a8f8c5e1bf62 h1:UBqD3cCr2+raNYJ94uR+hSO7SrxVa+7pK56OWfblpdw=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20230116113701-fc276f5505be
 	github.com/rancher/gke-operator v1.1.4
 	github.com/rancher/norman v0.0.0-20221228020905-1dcd4fa94899
-	github.com/rancher/rke v1.3.20-rc1
+	github.com/rancher/rke v1.3.19-rc1
 	github.com/rancher/wrangler v1.0.1-0.20230208234005-a59a11cc3ef5
 	github.com/sirupsen/logrus v1.8.1
 	k8s.io/api v0.25.4

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -600,8 +600,8 @@ github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc h1:29VHrInLV4qSevvcv
 github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc/go.mod h1:dEfC9eFQigj95lv/JQ8K5e7+qQCacWs1aIA6nLxKzT8=
 github.com/rancher/norman v0.0.0-20221228020905-1dcd4fa94899 h1:3y7FhdKEkewpO/BfcDdSX1HCMtMhXpsImz3pG83suEE=
 github.com/rancher/norman v0.0.0-20221228020905-1dcd4fa94899/go.mod h1:9zlHK0aLVQManRI6bpzRmuxAlTE70JKsN3JJ+PonHVk=
-github.com/rancher/rke v1.3.20-rc1 h1:PG89XmR3Fn/O7GkQlfce+TXMw5m7Zip38/FNqtWzbWA=
-github.com/rancher/rke v1.3.20-rc1/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
+github.com/rancher/rke v1.3.19-rc1 h1:zXYeNc3YbL6r3xfKIPmSsT2O3aPeyuCsWdKQOUfU9OQ=
+github.com/rancher/rke v1.3.19-rc1/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
 github.com/rancher/wrangler v0.8.10/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=

--- a/pkg/client/generated/management/v3/zz_generated_cluster_secrets.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_secrets.go
@@ -1,26 +1,40 @@
 package client
 
 const (
-	ClusterSecretsType                       = "clusterSecrets"
-	ClusterSecretsFieldAADClientCertSecret   = "aadClientCertSecret"
-	ClusterSecretsFieldAADClientSecret       = "aadClientSecret"
-	ClusterSecretsFieldOpenStackSecret       = "openStackSecret"
-	ClusterSecretsFieldPrivateRegistrySecret = "privateRegistrySecret"
-	ClusterSecretsFieldPrivateRegistryURL    = "privateRegistryURL"
-	ClusterSecretsFieldS3CredentialSecret    = "s3CredentialSecret"
-	ClusterSecretsFieldVirtualCenterSecret   = "virtualCenterSecret"
-	ClusterSecretsFieldVsphereSecret         = "vsphereSecret"
-	ClusterSecretsFieldWeavePasswordSecret   = "weavePasswordSecret"
+	ClusterSecretsType                                  = "clusterSecrets"
+	ClusterSecretsFieldAADClientCertSecret              = "aadClientCertSecret"
+	ClusterSecretsFieldAADClientSecret                  = "aadClientSecret"
+	ClusterSecretsFieldACIAPICUserKeySecret             = "aciAPICUserKeySecret"
+	ClusterSecretsFieldACIKafkaClientKeySecret          = "aciKafkaClientKeySecret"
+	ClusterSecretsFieldACITokenSecret                   = "aciTokenSecret"
+	ClusterSecretsFieldBastionHostSSHKeySecret          = "bastionHostSSHKeySecret"
+	ClusterSecretsFieldKubeletExtraEnvSecret            = "kubeletExtraEnvSecret"
+	ClusterSecretsFieldOpenStackSecret                  = "openStackSecret"
+	ClusterSecretsFieldPrivateRegistryECRSecret         = "privateRegistryECRSecret"
+	ClusterSecretsFieldPrivateRegistrySecret            = "privateRegistrySecret"
+	ClusterSecretsFieldPrivateRegistryURL               = "privateRegistryURL"
+	ClusterSecretsFieldS3CredentialSecret               = "s3CredentialSecret"
+	ClusterSecretsFieldSecretsEncryptionProvidersSecret = "secretsEncryptionProvidersSecret"
+	ClusterSecretsFieldVirtualCenterSecret              = "virtualCenterSecret"
+	ClusterSecretsFieldVsphereSecret                    = "vsphereSecret"
+	ClusterSecretsFieldWeavePasswordSecret              = "weavePasswordSecret"
 )
 
 type ClusterSecrets struct {
-	AADClientCertSecret   string `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
-	AADClientSecret       string `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
-	OpenStackSecret       string `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
-	PrivateRegistrySecret string `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
-	PrivateRegistryURL    string `json:"privateRegistryURL,omitempty" yaml:"privateRegistryURL,omitempty"`
-	S3CredentialSecret    string `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
-	VirtualCenterSecret   string `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
-	VsphereSecret         string `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
-	WeavePasswordSecret   string `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
+	AADClientCertSecret              string `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
+	AADClientSecret                  string `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
+	ACIAPICUserKeySecret             string `json:"aciAPICUserKeySecret,omitempty" yaml:"aciAPICUserKeySecret,omitempty"`
+	ACIKafkaClientKeySecret          string `json:"aciKafkaClientKeySecret,omitempty" yaml:"aciKafkaClientKeySecret,omitempty"`
+	ACITokenSecret                   string `json:"aciTokenSecret,omitempty" yaml:"aciTokenSecret,omitempty"`
+	BastionHostSSHKeySecret          string `json:"bastionHostSSHKeySecret,omitempty" yaml:"bastionHostSSHKeySecret,omitempty"`
+	KubeletExtraEnvSecret            string `json:"kubeletExtraEnvSecret,omitempty" yaml:"kubeletExtraEnvSecret,omitempty"`
+	OpenStackSecret                  string `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
+	PrivateRegistryECRSecret         string `json:"privateRegistryECRSecret,omitempty" yaml:"privateRegistryECRSecret,omitempty"`
+	PrivateRegistrySecret            string `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
+	PrivateRegistryURL               string `json:"privateRegistryURL,omitempty" yaml:"privateRegistryURL,omitempty"`
+	S3CredentialSecret               string `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
+	SecretsEncryptionProvidersSecret string `json:"secretsEncryptionProvidersSecret,omitempty" yaml:"secretsEncryptionProvidersSecret,omitempty"`
+	VirtualCenterSecret              string `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
+	VsphereSecret                    string `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
+	WeavePasswordSecret              string `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
 }

--- a/pkg/client/generated/management/v3/zz_generated_cluster_template_revision.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_template_revision.go
@@ -5,59 +5,73 @@ import (
 )
 
 const (
-	ClusterTemplateRevisionType                       = "clusterTemplateRevision"
-	ClusterTemplateRevisionFieldAADClientCertSecret   = "aadClientCertSecret"
-	ClusterTemplateRevisionFieldAADClientSecret       = "aadClientSecret"
-	ClusterTemplateRevisionFieldAnnotations           = "annotations"
-	ClusterTemplateRevisionFieldClusterConfig         = "clusterConfig"
-	ClusterTemplateRevisionFieldClusterTemplateID     = "clusterTemplateId"
-	ClusterTemplateRevisionFieldConditions            = "conditions"
-	ClusterTemplateRevisionFieldCreated               = "created"
-	ClusterTemplateRevisionFieldCreatorID             = "creatorId"
-	ClusterTemplateRevisionFieldEnabled               = "enabled"
-	ClusterTemplateRevisionFieldLabels                = "labels"
-	ClusterTemplateRevisionFieldName                  = "name"
-	ClusterTemplateRevisionFieldOpenStackSecret       = "openStackSecret"
-	ClusterTemplateRevisionFieldOwnerReferences       = "ownerReferences"
-	ClusterTemplateRevisionFieldPrivateRegistrySecret = "privateRegistrySecret"
-	ClusterTemplateRevisionFieldQuestions             = "questions"
-	ClusterTemplateRevisionFieldRemoved               = "removed"
-	ClusterTemplateRevisionFieldS3CredentialSecret    = "s3CredentialSecret"
-	ClusterTemplateRevisionFieldState                 = "state"
-	ClusterTemplateRevisionFieldTransitioning         = "transitioning"
-	ClusterTemplateRevisionFieldTransitioningMessage  = "transitioningMessage"
-	ClusterTemplateRevisionFieldUUID                  = "uuid"
-	ClusterTemplateRevisionFieldVirtualCenterSecret   = "virtualCenterSecret"
-	ClusterTemplateRevisionFieldVsphereSecret         = "vsphereSecret"
-	ClusterTemplateRevisionFieldWeavePasswordSecret   = "weavePasswordSecret"
+	ClusterTemplateRevisionType                                  = "clusterTemplateRevision"
+	ClusterTemplateRevisionFieldAADClientCertSecret              = "aadClientCertSecret"
+	ClusterTemplateRevisionFieldAADClientSecret                  = "aadClientSecret"
+	ClusterTemplateRevisionFieldACIAPICUserKeySecret             = "aciAPICUserKeySecret"
+	ClusterTemplateRevisionFieldACIKafkaClientKeySecret          = "aciKafkaClientKeySecret"
+	ClusterTemplateRevisionFieldACITokenSecret                   = "aciTokenSecret"
+	ClusterTemplateRevisionFieldAnnotations                      = "annotations"
+	ClusterTemplateRevisionFieldBastionHostSSHKeySecret          = "bastionHostSSHKeySecret"
+	ClusterTemplateRevisionFieldClusterConfig                    = "clusterConfig"
+	ClusterTemplateRevisionFieldClusterTemplateID                = "clusterTemplateId"
+	ClusterTemplateRevisionFieldConditions                       = "conditions"
+	ClusterTemplateRevisionFieldCreated                          = "created"
+	ClusterTemplateRevisionFieldCreatorID                        = "creatorId"
+	ClusterTemplateRevisionFieldEnabled                          = "enabled"
+	ClusterTemplateRevisionFieldKubeletExtraEnvSecret            = "kubeletExtraEnvSecret"
+	ClusterTemplateRevisionFieldLabels                           = "labels"
+	ClusterTemplateRevisionFieldName                             = "name"
+	ClusterTemplateRevisionFieldOpenStackSecret                  = "openStackSecret"
+	ClusterTemplateRevisionFieldOwnerReferences                  = "ownerReferences"
+	ClusterTemplateRevisionFieldPrivateRegistryECRSecret         = "privateRegistryECRSecret"
+	ClusterTemplateRevisionFieldPrivateRegistrySecret            = "privateRegistrySecret"
+	ClusterTemplateRevisionFieldQuestions                        = "questions"
+	ClusterTemplateRevisionFieldRemoved                          = "removed"
+	ClusterTemplateRevisionFieldS3CredentialSecret               = "s3CredentialSecret"
+	ClusterTemplateRevisionFieldSecretsEncryptionProvidersSecret = "secretsEncryptionProvidersSecret"
+	ClusterTemplateRevisionFieldState                            = "state"
+	ClusterTemplateRevisionFieldTransitioning                    = "transitioning"
+	ClusterTemplateRevisionFieldTransitioningMessage             = "transitioningMessage"
+	ClusterTemplateRevisionFieldUUID                             = "uuid"
+	ClusterTemplateRevisionFieldVirtualCenterSecret              = "virtualCenterSecret"
+	ClusterTemplateRevisionFieldVsphereSecret                    = "vsphereSecret"
+	ClusterTemplateRevisionFieldWeavePasswordSecret              = "weavePasswordSecret"
 )
 
 type ClusterTemplateRevision struct {
 	types.Resource
-	AADClientCertSecret   string                             `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
-	AADClientSecret       string                             `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
-	Annotations           map[string]string                  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	ClusterConfig         *ClusterSpecBase                   `json:"clusterConfig,omitempty" yaml:"clusterConfig,omitempty"`
-	ClusterTemplateID     string                             `json:"clusterTemplateId,omitempty" yaml:"clusterTemplateId,omitempty"`
-	Conditions            []ClusterTemplateRevisionCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
-	Created               string                             `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID             string                             `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	Enabled               *bool                              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Labels                map[string]string                  `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Name                  string                             `json:"name,omitempty" yaml:"name,omitempty"`
-	OpenStackSecret       string                             `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
-	OwnerReferences       []OwnerReference                   `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	PrivateRegistrySecret string                             `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
-	Questions             []Question                         `json:"questions,omitempty" yaml:"questions,omitempty"`
-	Removed               string                             `json:"removed,omitempty" yaml:"removed,omitempty"`
-	S3CredentialSecret    string                             `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
-	State                 string                             `json:"state,omitempty" yaml:"state,omitempty"`
-	Transitioning         string                             `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
-	TransitioningMessage  string                             `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
-	UUID                  string                             `json:"uuid,omitempty" yaml:"uuid,omitempty"`
-	VirtualCenterSecret   string                             `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
-	VsphereSecret         string                             `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
-	WeavePasswordSecret   string                             `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
+	AADClientCertSecret              string                             `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
+	AADClientSecret                  string                             `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
+	ACIAPICUserKeySecret             string                             `json:"aciAPICUserKeySecret,omitempty" yaml:"aciAPICUserKeySecret,omitempty"`
+	ACIKafkaClientKeySecret          string                             `json:"aciKafkaClientKeySecret,omitempty" yaml:"aciKafkaClientKeySecret,omitempty"`
+	ACITokenSecret                   string                             `json:"aciTokenSecret,omitempty" yaml:"aciTokenSecret,omitempty"`
+	Annotations                      map[string]string                  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	BastionHostSSHKeySecret          string                             `json:"bastionHostSSHKeySecret,omitempty" yaml:"bastionHostSSHKeySecret,omitempty"`
+	ClusterConfig                    *ClusterSpecBase                   `json:"clusterConfig,omitempty" yaml:"clusterConfig,omitempty"`
+	ClusterTemplateID                string                             `json:"clusterTemplateId,omitempty" yaml:"clusterTemplateId,omitempty"`
+	Conditions                       []ClusterTemplateRevisionCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	Created                          string                             `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID                        string                             `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Enabled                          *bool                              `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	KubeletExtraEnvSecret            string                             `json:"kubeletExtraEnvSecret,omitempty" yaml:"kubeletExtraEnvSecret,omitempty"`
+	Labels                           map[string]string                  `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name                             string                             `json:"name,omitempty" yaml:"name,omitempty"`
+	OpenStackSecret                  string                             `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
+	OwnerReferences                  []OwnerReference                   `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	PrivateRegistryECRSecret         string                             `json:"privateRegistryECRSecret,omitempty" yaml:"privateRegistryECRSecret,omitempty"`
+	PrivateRegistrySecret            string                             `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
+	Questions                        []Question                         `json:"questions,omitempty" yaml:"questions,omitempty"`
+	Removed                          string                             `json:"removed,omitempty" yaml:"removed,omitempty"`
+	S3CredentialSecret               string                             `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
+	SecretsEncryptionProvidersSecret string                             `json:"secretsEncryptionProvidersSecret,omitempty" yaml:"secretsEncryptionProvidersSecret,omitempty"`
+	State                            string                             `json:"state,omitempty" yaml:"state,omitempty"`
+	Transitioning                    string                             `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+	TransitioningMessage             string                             `json:"transitioningMessage,omitempty" yaml:"transitioningMessage,omitempty"`
+	UUID                             string                             `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	VirtualCenterSecret              string                             `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
+	VsphereSecret                    string                             `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
+	WeavePasswordSecret              string                             `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
 }
 
 type ClusterTemplateRevisionCollection struct {

--- a/pkg/client/generated/management/v3/zz_generated_cluster_template_revision_status.go
+++ b/pkg/client/generated/management/v3/zz_generated_cluster_template_revision_status.go
@@ -1,26 +1,40 @@
 package client
 
 const (
-	ClusterTemplateRevisionStatusType                       = "clusterTemplateRevisionStatus"
-	ClusterTemplateRevisionStatusFieldAADClientCertSecret   = "aadClientCertSecret"
-	ClusterTemplateRevisionStatusFieldAADClientSecret       = "aadClientSecret"
-	ClusterTemplateRevisionStatusFieldConditions            = "conditions"
-	ClusterTemplateRevisionStatusFieldOpenStackSecret       = "openStackSecret"
-	ClusterTemplateRevisionStatusFieldPrivateRegistrySecret = "privateRegistrySecret"
-	ClusterTemplateRevisionStatusFieldS3CredentialSecret    = "s3CredentialSecret"
-	ClusterTemplateRevisionStatusFieldVirtualCenterSecret   = "virtualCenterSecret"
-	ClusterTemplateRevisionStatusFieldVsphereSecret         = "vsphereSecret"
-	ClusterTemplateRevisionStatusFieldWeavePasswordSecret   = "weavePasswordSecret"
+	ClusterTemplateRevisionStatusType                                  = "clusterTemplateRevisionStatus"
+	ClusterTemplateRevisionStatusFieldAADClientCertSecret              = "aadClientCertSecret"
+	ClusterTemplateRevisionStatusFieldAADClientSecret                  = "aadClientSecret"
+	ClusterTemplateRevisionStatusFieldACIAPICUserKeySecret             = "aciAPICUserKeySecret"
+	ClusterTemplateRevisionStatusFieldACIKafkaClientKeySecret          = "aciKafkaClientKeySecret"
+	ClusterTemplateRevisionStatusFieldACITokenSecret                   = "aciTokenSecret"
+	ClusterTemplateRevisionStatusFieldBastionHostSSHKeySecret          = "bastionHostSSHKeySecret"
+	ClusterTemplateRevisionStatusFieldConditions                       = "conditions"
+	ClusterTemplateRevisionStatusFieldKubeletExtraEnvSecret            = "kubeletExtraEnvSecret"
+	ClusterTemplateRevisionStatusFieldOpenStackSecret                  = "openStackSecret"
+	ClusterTemplateRevisionStatusFieldPrivateRegistryECRSecret         = "privateRegistryECRSecret"
+	ClusterTemplateRevisionStatusFieldPrivateRegistrySecret            = "privateRegistrySecret"
+	ClusterTemplateRevisionStatusFieldS3CredentialSecret               = "s3CredentialSecret"
+	ClusterTemplateRevisionStatusFieldSecretsEncryptionProvidersSecret = "secretsEncryptionProvidersSecret"
+	ClusterTemplateRevisionStatusFieldVirtualCenterSecret              = "virtualCenterSecret"
+	ClusterTemplateRevisionStatusFieldVsphereSecret                    = "vsphereSecret"
+	ClusterTemplateRevisionStatusFieldWeavePasswordSecret              = "weavePasswordSecret"
 )
 
 type ClusterTemplateRevisionStatus struct {
-	AADClientCertSecret   string                             `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
-	AADClientSecret       string                             `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
-	Conditions            []ClusterTemplateRevisionCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
-	OpenStackSecret       string                             `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
-	PrivateRegistrySecret string                             `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
-	S3CredentialSecret    string                             `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
-	VirtualCenterSecret   string                             `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
-	VsphereSecret         string                             `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
-	WeavePasswordSecret   string                             `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
+	AADClientCertSecret              string                             `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
+	AADClientSecret                  string                             `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
+	ACIAPICUserKeySecret             string                             `json:"aciAPICUserKeySecret,omitempty" yaml:"aciAPICUserKeySecret,omitempty"`
+	ACIKafkaClientKeySecret          string                             `json:"aciKafkaClientKeySecret,omitempty" yaml:"aciKafkaClientKeySecret,omitempty"`
+	ACITokenSecret                   string                             `json:"aciTokenSecret,omitempty" yaml:"aciTokenSecret,omitempty"`
+	BastionHostSSHKeySecret          string                             `json:"bastionHostSSHKeySecret,omitempty" yaml:"bastionHostSSHKeySecret,omitempty"`
+	Conditions                       []ClusterTemplateRevisionCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	KubeletExtraEnvSecret            string                             `json:"kubeletExtraEnvSecret,omitempty" yaml:"kubeletExtraEnvSecret,omitempty"`
+	OpenStackSecret                  string                             `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
+	PrivateRegistryECRSecret         string                             `json:"privateRegistryECRSecret,omitempty" yaml:"privateRegistryECRSecret,omitempty"`
+	PrivateRegistrySecret            string                             `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
+	S3CredentialSecret               string                             `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
+	SecretsEncryptionProvidersSecret string                             `json:"secretsEncryptionProvidersSecret,omitempty" yaml:"secretsEncryptionProvidersSecret,omitempty"`
+	VirtualCenterSecret              string                             `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
+	VsphereSecret                    string                             `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
+	WeavePasswordSecret              string                             `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
 }


### PR DESCRIPTION
@geethub97 @HarrisonWAffel Mistake on my part, Rancher v2.6.11 will use RKE v1.3.19 and RKE v1.3.20 will be for next release with out of band KDM. 