### PR TITLE
remove corral repo (backport to 2.6)

### DIFF
--- a/tests/framework/clients/corral/config.go
+++ b/tests/framework/clients/corral/config.go
@@ -22,7 +22,7 @@ type CorralPackages struct {
 	CorralPackageImages map[string]string `json:"corralPackageImages" yaml:"corralPackageImages"`
 	Cleanup             bool              `json:"cleanup" yaml:"cleanup" default:"true"`
 	Debug               bool              `json:"debug" yaml:"debug" default:"false"`
-	CustomRepo          string            `json:"customRepo" yaml:"customRepo" default:"https://github.com/rancherlabs/corral-packages.git"`
+	CustomRepo          string            `json:"customRepo" yaml:"customRepo"`
 }
 
 // CorralPackagesConfig is a function that reads in the corral package object from the config file

--- a/tests/v2/validation/standalone/README.md
+++ b/tests/v2/validation/standalone/README.md
@@ -10,6 +10,7 @@ corralPackages:
     ...
   debug: <bool, default=false>
   cleanup: <bool, default=true>
+  customRepo: <string, (optional) suggeseted=https://github.com/rancherlabs/corral-packages.git>
 
 corralConfigs:
   corralConfigUser: <string, default="jenkauto">


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/626
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
there was a default value for the corral repo that has some overhead when using local images to test with
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
remove the default registry, and suggest this in the README for new users instead of enforcing the default.
 
