### PR TITLE
[release/v2.7] Print last lines of k3s.log on non zero exit

### DIFF
--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -35,7 +35,9 @@ if [ -e /var/lib/rancher/k3s/server/db/etcd ]; then
   k3s server --cluster-init --cluster-reset &> ./k3s-cluster-reset.log
   K3S_CR_CODE=$?
   if [ "${K3S_CR_CODE}" -ne 0 ]; then
-    echo "ERROR:" && cat ./k3s-cluster-reset.log
+    echo "ERROR while running 'k3s server --cluster-init --cluster-reset', exit code ${K3S_CR_CODE}"
+    echo "Last 50 lines of k3s.log:" && tail -n 50 ./k3s.log
+    echo "Contents of k3s-cluster-reset.log:" && cat ./k3s-cluster-reset.log
     rm -f /var/lib/rancher/k3s/server/db/reset-flag
     exit ${K3S_CR_CODE}
   fi


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40598
 
## Problem
Content of `k3s.log` not visible when embedded k3s fails to start
 
## Solution
Print last 50 lines of `k3s.log` when embedded k3s fails to start
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Make sure embedded k3s fails to start, and check if last 50 lines of `k3s.log` are printed in container log

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->