### PR TITLE
 Fix the issue that PSACT is not restored on RKE1/RKE2/K3S clusters.

### DIFF
--- a/pkg/api/norman/customization/cluster/actions_etcd.go
+++ b/pkg/api/norman/customization/cluster/actions_etcd.go
@@ -136,6 +136,7 @@ func (a ActionHandler) RestoreFromEtcdBackupHandler(actionName string, action *t
 				fmt.Sprintf("error decompressing cluster object for backupid %s: %s", input.EtcdBackupID, err))
 		}
 		cluster.Spec.RancherKubernetesEngineConfig = clusterBackup.Spec.RancherKubernetesEngineConfig
+		cluster.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName = clusterBackup.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName
 	}
 
 	// flag cluster for restore

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -223,6 +223,10 @@ func reconcileClusterSpecEtcdRestore(cluster *rancherv1.Cluster, desiredSpec ran
 		changed = true
 		cluster.Spec.KubernetesVersion = desiredSpec.KubernetesVersion
 	}
+	if cluster.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName != desiredSpec.DefaultPodSecurityAdmissionConfigurationTemplateName {
+		changed = true
+		cluster.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName = desiredSpec.DefaultPodSecurityAdmissionConfigurationTemplateName
+	}
 	return changed
 }
 


### PR DESCRIPTION
 

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/40433
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
When we restore the snapshot on an RKE1/RKE2/K3S cluster and choose "restore cluster config, Kubernetes version and etcd", the PSACT is not restored. 
It happens because the field ".spec.defaultPodSecurityAdmissionConfigurationTemplateName" is not set back to the value from the backup. 


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

This fix is to set the field to the value from the backup.
 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
 
See the steps in the issue. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The PR is tested locally in the dev env.   
On an RKE1/RKE2/K3S cluster:
- create a snapshot
- change the defaultPodSecurityAdmissionConfigurationTemplateName
- restore the snapshot

Result:
- see the defaultPodSecurityAdmissionConfigurationTemplateName is set back to the value from the backup 



### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

n/a 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

the normal tests around cluster backup/restore 
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

n/a