### PR TITLE
[release/v2.7] Move to upstream helm-unittest

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -6,7 +6,7 @@ ENV CATTLE_HELM_VERSION v2.16.8-rancher2
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher99
 ENV CATTLE_K3S_VERSION v1.25.5+k3s1
 # version used by helm plugin install script
-ENV CATTLE_HELM_UNITTEST_VERSION v0.1.7-rancher4
+ENV HELM_UNITTEST_VERSION v0.2.11
 # helm 3 version
 ENV HELM_VERSION v3.11.3
 ENV KUSTOMIZE_VERSION v5.0.0
@@ -49,14 +49,17 @@ RUN curl -sLf ${!HELM_URL_V2} -o /usr/bin/rancher-helm && \
     chmod +x /usr/bin/rancher-helm /usr/bin/rancher-tiller && \
     ln -s /usr/bin/rancher-helm /usr/bin/helm && \
     ln -s /usr/bin/rancher-tiller /usr/bin/tiller && \
-    helm init -c --stable-repo-url https://charts.helm.sh/stable/ && \
-    helm plugin install https://github.com/rancher/helm-unittest
+    helm init -c --stable-repo-url https://charts.helm.sh/stable/
 
 # set up helm 3
 RUN mkdir /usr/tmp && \
     curl ${HELM_URL_V3} | tar xvzf - --strip-components=1 -C /usr/tmp/ && \
     mv /usr/tmp/helm /usr/bin/helm_v3 && \
     chmod +x /usr/bin/kustomize
+
+RUN if [ "${ARCH}" == "amd64" ]; then \
+    helm_v3 plugin install --version $HELM_UNITTEST_VERSION https://github.com/helm-unittest/helm-unittest; \
+    fi
 
 # Set up K3s: copy the necessary binaries from the K3s image.
 COPY --from=rancher/k3s:v1.25.5-k3s1 \

--- a/chart/tests/README.md
+++ b/chart/tests/README.md
@@ -10,10 +10,10 @@ Option 1: Full chart CI run with a live cluster
 Option 2: Test runs against the chart only 
 
 ```bash
-# Install plugin if necessary, for version see CATTLE_HELM_UNITTEST_VERSION
+# Install plugin if necessary, for version see HELM_UNITTEST_VERSION
 # For a Mac you'll need to download a release and install the darwin binary
 # For linux:
-export ARCH=amd64 export CATTLE_HELM_UNITTEST_VERSION={version} helm plugin install https://github.com/rancher/helm-unittest
+export ARCH=amd64 export HELM_UNITTEST_VERSION={version} helm plugin install https://github.com/helm-unittest/helm-unittest
 
 # change automated parts of templates
 test_image="rancher/rancher"

--- a/chart/tests/ingress_test.yaml
+++ b/chart/tests/ingress_test.yaml
@@ -25,7 +25,7 @@ tests:
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
 - it: should set default annotations with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   asserts:
   - equal:
@@ -70,7 +70,7 @@ tests:
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
 - it: should over write proxy-connect-timeout with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.extraAnnotations:
@@ -128,7 +128,7 @@ tests:
           more_set_input_headers "X-Forwarded-Host: host.example.com";
 - it: should set static X-Forwarded-Host header with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     hostname: host.example.com
@@ -183,7 +183,7 @@ tests:
           more_set_input_headers "foo: bar";
 - it: should be able to set multiple lines using configurationSnippet with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     hostname: host.example.com

--- a/chart/tests/issuer_test.yaml
+++ b/chart/tests/issuer_test.yaml
@@ -35,7 +35,7 @@ tests:
     template: issuer-rancher.yaml
 - it: should render letsEncrypt but not rancher with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: letsEncrypt
@@ -69,7 +69,7 @@ tests:
     template: issuer-rancher.yaml
 - it: should render rancher but not letsEncrypt with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: rancher
@@ -101,7 +101,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt apiVersion with cert-manager >= 0.16.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - cert-manager.io/v1beta1
   set:
     ingress.tls.source: letsEncrypt
@@ -112,7 +112,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt apiVersion with cert-manager >= 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - cert-manager.io/v1alpha2
   set:
     ingress.tls.source: letsEncrypt
@@ -123,7 +123,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt apiVersion with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: letsEncrypt
@@ -169,7 +169,7 @@ tests:
     template: issuer-rancher.yaml
 - it: should set rancher apiVersion with cert-manager >= 0.16.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - cert-manager.io/v1beta1
   set:
     ingress.tls.source: rancher
@@ -180,7 +180,7 @@ tests:
     template: issuer-rancher.yaml
 - it: should set rancher apiVersion with cert-manager >= 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - cert-manager.io/v1alpha2
   set:
     ingress.tls.source: rancher
@@ -191,7 +191,7 @@ tests:
     template: issuer-rancher.yaml
 - it: should set rancher apiVersion with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: rancher
@@ -237,7 +237,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt production by default with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: letsEncrypt
@@ -257,7 +257,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt staging with default cert-manager
   capabilities:
-    apiversions:
+    apiVersions:
     - cert-manager.io/v1alpha2
   set:
     ingress.tls.source: letsEncrypt
@@ -269,7 +269,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt staging with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: letsEncrypt
@@ -300,7 +300,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt email address with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: letsEncrypt

--- a/scripts/chart/ci
+++ b/scripts/chart/ci
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if [ "${ARCH}" != "amd64"  ]; then
+    exit 0
+fi
+
 cd $(dirname $0)
 
 ./build chart

--- a/scripts/chart/test
+++ b/scripts/chart/test
@@ -2,18 +2,18 @@
 
 echo "-- chart/test --"
 
-# Check for helm
-if [ -z "$(type -p helm)" ]; then
-    echo "helm not found. Helm is required to run tests."
+# Check for helm_v3
+if [ -z "$(type -p helm_v3)" ]; then
+    echo "helm_v3 not found. Helm is required to run tests."
     exit 1
 fi
 
 # Check for unittest plugin
-helm unittest --help >/dev/null 2>&1
+HELM_PLUGINS=/root/.local/share/helm/plugins/ helm_v3 unittest --help >/dev/null 2>&1
 if [[ $? > 0 ]]; then
-    echo "helm plugin unittest not found."
-    echo "Run to install plugin: helm plugin install https://github.com/rancher/helm-unittest"
+    echo "helm_v3 plugin unittest not found."
+    echo "Run to install plugin: helm_v3 plugin install https://github.com/helm-unittest/helm-unittest"
     exit 1
 fi
 
-helm unittest ../../build/chart/rancher
+HELM_PLUGINS=/root/.local/share/helm/plugins/ helm_v3 unittest --helm3 ../../build/chart/rancher


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40617
 
## Problem
We currently use our own fork of helm-unittest which seems to be unneeded as requirements are no longer valid for a fork. See issue for details.

This also moves chart testing to Helm 3 instead of Helm 2.
 
## Solution
Move to upstream helm-unittest and scope to amd64
 
## Testing
Automated CI should pass

## Engineering Testing
### Manual Testing

### Automated Testing
Automatically included in CI

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->