### PR TITLE
Update createhascript

### DIFF
--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -8,11 +8,13 @@ from .test_import_rke2_cluster import (
     RANCHER_RKE2_VERSION, create_rke2_multiple_control_cluster
 )
 from .test_rke_cluster_provisioning import AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, rke_config
+from packaging import version
 
 # RANCHER_HA_KUBECONFIG and RANCHER_HA_HOSTNAME are provided
 # when installing Rancher into a k3s setup
 RANCHER_HA_KUBECONFIG = os.environ.get("RANCHER_HA_KUBECONFIG")
 RANCHER_HA_HARDENED = ast.literal_eval(os.environ.get("RANCHER_HA_HARDENED", "False"))
+RANCHER_PSP_ENABLED = ast.literal_eval(os.environ.get("RANCHER_PSP_ENABLED", "True"))
 RANCHER_HA_HOSTNAME = os.environ.get(
     "RANCHER_HA_HOSTNAME", RANCHER_HOSTNAME_PREFIX + ".qa.rancher.space")
 resource_prefix = RANCHER_HA_HOSTNAME.split(".qa.rancher.space")[0]
@@ -347,6 +349,9 @@ def install_rancher(type=RANCHER_HA_CERT_OPTION, repo=RANCHER_HELM_REPO,
         "--version " + RANCHER_CHART_VERSION + " " + \
         "--namespace cattle-system " + \
         "--set hostname=" + RANCHER_HA_HOSTNAME
+
+    if version.parse(RANCHER_CHART_VERSION) > version.parse("2.7.1"):
+        helm_rancher_cmd = helm_rancher_cmd + " --set global.cattle.psp.enabled=" + str(RANCHER_PSP_ENABLED).lower()
 
     if type == 'letsencrypt':
         helm_rancher_cmd = \


### PR DESCRIPTION
 ## Problem
As part of the new changes in PSP, we have added a new flag in the rancher chart `global.psp.enabled=true`. This flag is by default set to true. This works fine for cluster k8s versions <1.25 but for clusters 1.25+ if the option is not set to false, rancher installation fails with the error 
```
 output: 	b'Error: INSTALLATION FAILED: execution error at (rancher/templates/validate-psp-install.yaml:4:5): The target cluster does not have the PodSecurityPolicy API resource. Please disable PSPs in this chart before proceeding.\n'
```
In our automation runs while using rancher HA, this script fails for rancher server versions 2.7.2+ as the default k8s version is 1.25 for rke versions 1.4.3-rc6 unless the k8s versions are set to 1.24.

## Solution
We check if the version of rancher is >2.7.2+, and get the PSP_ENABLED value from the jenkins builder. This option provides user to set true/false based on the tests they do.
 
## Testing
Ran following tests: 
Enabling the flag to false for rancher versions 2.7.2-rc3 - Pass
2.7.2-rc3 with flag set to true - Fail
2.7.2-rc3 k8s version set to 1.24 and flag set to False - Pass

