### PR TITLE
[release/v2.7] Allow 500 or 503 on cluster encryption config migration and local cluster creation

### DIFF
--- a/pkg/data/dashboard/cluster_data.go
+++ b/pkg/data/dashboard/cluster_data.go
@@ -54,7 +54,7 @@ func addLocalCluster(embedded bool, wrangler *wrangler.Context) error {
 				return true, nil
 			}
 		}
-		if apierrors.IsServiceUnavailable(err) {
+		if apierrors.IsServiceUnavailable(err) || apierrors.IsInternalError(err) {
 			return false, nil
 		}
 		return false, err


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/40664
 
## Problem
A 500 or 503 can be encountered during encryption config migration. This PR makes a change to allow for 500 or 503s in addition to 409's on migration.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->