### PR TITLE
[release/v2.7] Forwardport: Use one instance of the kubeconfig manager

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -70,7 +70,7 @@ type handler struct {
 
 func Register(
 	ctx context.Context,
-	clients *wrangler.Context) {
+	clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) {
 	h := handler{
 		mgmtClusterCache:      clients.Mgmt.Cluster().Cache(),
 		mgmtClusters:          clients.Mgmt.Cluster(),
@@ -86,7 +86,7 @@ func Register(
 		capiClustersCache:     clients.CAPI.Cluster().Cache(),
 		capiClusters:          clients.CAPI.Cluster(),
 		capiMachinesCache:     clients.CAPI.Machine().Cache(),
-		kubeconfigManager:     kubeconfig.New(clients),
+		kubeconfigManager:     kubeconfigManager,
 		apply: clients.Apply.WithCacheTypes(
 			clients.Provisioning.Cluster(),
 			clients.Mgmt.Cluster()),

--- a/pkg/controllers/provisioningv2/controllers.go
+++ b/pkg/controllers/provisioningv2/controllers.go
@@ -23,13 +23,15 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2/unmanaged"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/provisioningv2/capi"
+	"github.com/rancher/rancher/pkg/provisioningv2/kubeconfig"
 	planner2 "github.com/rancher/rancher/pkg/provisioningv2/rke2/planner"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/sirupsen/logrus"
 )
 
 func Register(ctx context.Context, clients *wrangler.Context) error {
-	cluster.Register(ctx, clients)
+	kubeconfigManager := kubeconfig.New(clients)
+	cluster.Register(ctx, clients, kubeconfigManager)
 
 	if features.Fleet.Enabled() {
 		managedchart.Register(ctx, clients)
@@ -41,17 +43,17 @@ func Register(ctx context.Context, clients *wrangler.Context) error {
 		rkePlanner := planner2.New(ctx, clients)
 		if features.MCM.Enabled() {
 			dynamicschema.Register(ctx, clients)
-			machineprovision.Register(ctx, clients)
+			machineprovision.Register(ctx, clients, kubeconfigManager)
 		}
 		rkecluster.Register(ctx, clients)
 		provisioningcluster.Register(ctx, clients)
 		provisioninglog.Register(ctx, clients)
 		secret.Register(ctx, clients)
 		bootstrap.Register(ctx, clients)
-		machinenodelookup.Register(ctx, clients)
+		machinenodelookup.Register(ctx, clients, kubeconfigManager)
 		planner.Register(ctx, clients, rkePlanner)
 		plansecret.Register(ctx, clients)
-		unmanaged.Register(ctx, clients)
+		unmanaged.Register(ctx, clients, kubeconfigManager)
 		rkecontrolplane.Register(ctx, clients)
 		managesystemagent.Register(ctx, clients)
 		machinedrain.Register(ctx, clients)

--- a/pkg/controllers/provisioningv2/rke2/machinenodelookup/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/machinenodelookup/controller.go
@@ -45,13 +45,13 @@ type handler struct {
 	dynamic             *dynamic.Controller
 }
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) {
 	h := &handler{
 		rancherClusterCache: clients.Provisioning.Cluster().Cache(),
 		machines:            clients.CAPI.Machine(),
 		machineCache:        clients.CAPI.Machine().Cache(),
 		rkeBootstrap:        clients.RKE.RKEBootstrap(),
-		kubeconfigManager:   kubeconfig.New(clients),
+		kubeconfigManager:   kubeconfigManager,
 		dynamic:             clients.Dynamic,
 	}
 

--- a/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/machineprovision/controller.go
@@ -103,7 +103,7 @@ type handler struct {
 	kubeconfigManager   *kubeconfig.Manager
 }
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) {
 	h := &handler{
 		ctx: ctx,
 		apply: clients.Apply.WithCacheTypes(clients.Core.Secret(),
@@ -123,7 +123,7 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 		namespaces:          clients.Core.Namespace().Cache(),
 		dynamic:             clients.Dynamic,
 		rancherClusterCache: clients.Provisioning.Cluster().Cache(),
-		kubeconfigManager:   kubeconfig.New(clients),
+		kubeconfigManager:   kubeconfigManager,
 	}
 
 	removeHandler := generic.NewRemoveHandler("machine-provision-remove", clients.Dynamic.Update, h.OnRemove)

--- a/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
@@ -33,9 +33,9 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-func Register(ctx context.Context, clients *wrangler.Context) {
+func Register(ctx context.Context, clients *wrangler.Context, kubeconfigManager *kubeconfig.Manager) {
 	h := handler{
-		kubeconfigManager: kubeconfig.New(clients),
+		kubeconfigManager: kubeconfigManager,
 		unmanagedMachine:  clients.RKE.CustomMachine(),
 		mgmtClusterCache:  clients.Mgmt.Cluster().Cache(),
 		clusterCache:      clients.Provisioning.Cluster().Cache(),


### PR DESCRIPTION
Forwardport of: https://github.com/rancher/rancher/pull/40660

## Issue: 
https://github.com/rancher/rancher/issues/40080
 
## Problem
There is a potential for the kubeconfigManager to race when creating a user/kubeconfig secret for a v2prov cluster. This is particularly bad on a cold-start of Rancher. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
Testing this is quite difficult, but if can be specifically exasperated by stopping rancher (scale to 0), deleting the kubeconfig secret + v3 token object, then scaling back up to 1 replica. After Rancher starts, validate the kubeconfig token and the v3 token match.

```
kubectl scale deployment rancher -n cattle-system --replicas=0
kubectl delete tokens u-f4b4i23dy3; kubectl delete secret test1-kubeconfig -n fleet-default
kubectl scale deployment rancher -n cattle-system --replicas=1
kubectl get tokens u-f4b4i23dy3 -o json | jq -r .token; kubectl get secret -n fleet-default test1-kubeconfig -o json | jq -r .data.token | base64 --decode
```

## Engineering Testing
### Manual Testing
I tested as listed above.

### Automated Testing
N/A

## QA Testing Considerations
N/A

### Regressions Considerations
I don't see any glaring regression possibilities, as this is simply consolidating multiple kubeconfigManagers to a single manager which helps to eliminate race condition potential.