### PR TITLE
Pinning TLS Min Version to 1.0 for LDAP

### DIFF
--- a/pkg/auth/providers/common/ldap/ldap_util.go
+++ b/pkg/auth/providers/common/ldap/ldap_util.go
@@ -43,7 +43,7 @@ func NewLDAPConn(servers []string, TLS, startTLS bool, port int64, connectionTim
 		return nil, errors.New("invalid server config. at least 1 server needs to be configured")
 	}
 	for _, server := range servers {
-		tlsConfig = &tls.Config{RootCAs: caPool, InsecureSkipVerify: false, ServerName: server}
+		tlsConfig = &tls.Config{RootCAs: caPool, InsecureSkipVerify: false, ServerName: server, MinVersion: tls.VersionTLS10}
 		if TLS {
 			lConn, err = ldapv3.DialTLS("tcp", fmt.Sprintf("%s:%d", server, port), tlsConfig)
 			if err != nil {


### PR DESCRIPTION
Go 1.17 defaulted to tls version 1.0 for new tls.Config objects. Go 1.18 and 1.19 default to tls 1.2. This PR pins the min version supported by the client to tls 1.0 to ensure that this continues to work for the 2.6 release line.