### PR TITLE
Limit the SUC release name to at most 52 characters

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
+++ b/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
@@ -17,10 +17,15 @@ func (h *handler) OnChangeInstallSUC(cluster *rancherv1.Cluster, status rancherv
 		return nil, status, nil
 	}
 
+	// we must limit the output of name.SafeConcatName to at most 48 characters because
+	// a) the chart release name cannot exceed 53 characters, and
+	// b) upon creation of this resource the prefix 'mcc-' will be added to the release name, hence the limiting to 48 characters
+	managedChartName := name.Limit(name.SafeConcatName(cluster.Name, "managed", "system-upgrade-controller"), 48)
+
 	mcc := &v3.ManagedChart{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cluster.Namespace,
-			Name:      name.SafeConcatName(cluster.Name, "managed", "system-upgrade-controller"),
+			Name:      managedChartName,
 		},
 		Spec: v3.ManagedChartSpec{
 			DefaultNamespace: namespaces.System,


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40684
 
This is a partial (non-cherry picked) backport of PR https://github.com/rancher/rancher/pull/40500

## Problem
The managed chart for the system-upgrade-controller cannot have a release name exceeding 53 characters, otherwise fleet will return the following error:
```
Error Encountered Waiting for System Upgrade Controller Deployment To
      Roll Out: release name "mcc-haffel-upgrade-test-321-managed-system-upgrade-controller":
      invalid release name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
      and the length must not be longer than 53
```

Unfortunately, the logic within Rancher limits the name to at most 63 characters. This results in the failure to deploy the chart depending upon the length of the cluster name (since the cluster name is included within the managed chart release name) 
 
## Solution
Use `name.Limit` to limit the managed chart name to at most 52 characters (1 less than maximum), including the `mcc-` value prepended to the release name upon creation.
 
## Testing
+ Create a cluster with a name containing 63 characters (though any name exceeding 16 characters should reproduce the issue)
+ Wait for the cluster to become available and check that the system-upgrade-controller pod has been deployed
+ execute `kubectl get bundles.fleet.cattle.io -A` and ensure that no bundles are in an error state, and that no bundle name exceeds 52 characters.

## Engineering Testing
### Manual Testing
I've done the above

### Automated Testing
N/A

## QA Testing Considerations
N/A
 
### Regressions Considerations
N/A