### PR TITLE
Ignore obj being as helm release obj if data is too small

### DIFF
--- a/pkg/catalogv2/helm/helm3.go
+++ b/pkg/catalogv2/helm/helm3.go
@@ -118,6 +118,11 @@ func decodeHelm3(data string) (*release.Release, error) {
 		return nil, err
 	}
 
+	// Data is too small to be helm 3 release object
+	if len(b) <= 3 {
+		return nil, ErrNotHelmRelease
+	}
+
 	// For backwards compatibility with releases that were stored before
 	// compression was introduced we skip decompression if the
 	// gzip magic header is not found


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
JIRA: [SURE-5139](https://jira.suse.com/browse/SURE-5139)
 
## Problem
If the obj data is less than 3 bytes, checking magiczip string gives error as the codebase checks for first three bytes of the data by indexing which causes panic.
 
## Solution
Check obj data only if it has more than 3 bytes of data.
 