### PR TITLE
[release/v2.6] Allow 409/500/503 for v3 cluster objects and retry

### DIFF
--- a/pkg/data/dashboard/cluster_data.go
+++ b/pkg/data/dashboard/cluster_data.go
@@ -1,6 +1,8 @@
 package dashboard
 
 import (
+	"time"
+
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	fleetconst "github.com/rancher/rancher/pkg/fleet"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -8,8 +10,8 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func addLocalCluster(embedded bool, wrangler *wrangler.Context) error {
@@ -40,13 +42,23 @@ func addLocalCluster(embedded bool, wrangler *wrangler.Context) error {
 	}
 
 	var err error
-	c, err = wrangler.Mgmt.Cluster().Create(c)
-	if apierrors.IsAlreadyExists(err) {
-		c, err = wrangler.Mgmt.Cluster().Get("local", metav1.GetOptions{})
-		if err != nil {
-			return err
+	err = wait.PollImmediateInfinite(100*time.Millisecond, func() (bool, error) {
+		temporaryCluster, err := wrangler.Mgmt.Cluster().Create(c)
+		if err == nil {
+			c = temporaryCluster
+			return true, nil
+		} else if apierrors.IsAlreadyExists(err) {
+			temporaryCluster, err = wrangler.Mgmt.Cluster().Get("local", v1.GetOptions{})
+			if err == nil {
+				c = temporaryCluster
+				return true, nil
+			}
 		}
-	}
+		if apierrors.IsServiceUnavailable(err) {
+			return false, nil
+		}
+		return false, err
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/data/dashboard/cluster_data.go
+++ b/pkg/data/dashboard/cluster_data.go
@@ -54,7 +54,7 @@ func addLocalCluster(embedded bool, wrangler *wrangler.Context) error {
 				return true, nil
 			}
 		}
-		if apierrors.IsServiceUnavailable(err) {
+		if apierrors.IsServiceUnavailable(err) || apierrors.IsInternalError(err) {
 			return false, nil
 		}
 		return false, err


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40665

Backport of:
https://github.com/rancher/rancher/pull/40337
https://github.com/rancher/rancher/pull/40666

There are certain circumstances in which Rancher will fail to warm-restart in docker install configurations due the Rancher webhook. Because the Rancher webhook configuration is set to cause API failures if the webhook service is unavailable, Rancher will be unable to manipulate the CRs it needs in order to facilitate startup. 

This is particularly a problem in a docker install, where a warm-restart of Rancher (i.e. with a datastore already initialized) will fail to start because Rancher runs early local cluster manipulation/creation. In a brand new Rancher installation, the webhook will not yet exist, allowing the objects to be created without issue. On an existing Rancher installation, on a start of the Kubernetes cluster, once Rancher has started and installs the rancher-webhook and corresponding configuration for the webhook, it will fail to start on future tries due to the fact that the rancher-webhook will not be up by the time Rancher itself is started. In a HA setup, Rancher will continuously crash until it is able to start (when the rancher-webhook starts and is ready to receive requests).

## Regression Considerations

There are not many regression considerations with this PR, as this PR does not change much business logic. The primary area of regression concern would be infinite start times of Rancher in the event that `rancher-webhook` never comes up, but these situations are very rare.