### PR TITLE
Fix the default version for rke2/k3s 

### DIFF
--- a/pkg/channelserver/channelserver.go
+++ b/pkg/channelserver/channelserver.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -171,7 +170,7 @@ func getDefaultFromAppDefaultsByRuntimeAndServerVersion(ctx context.Context, run
 		return "", fmt.Errorf("faild to parse %s defaultVersionRange for %s: %v", runtime, serverVersion, err)
 	}
 
-	var candidate []string
+	var candidate []semver.Version
 	for _, release := range config.ReleasesConfig().Releases {
 		version, err := semver.ParseTolerant(release.Version)
 		if err != nil {
@@ -179,14 +178,16 @@ func getDefaultFromAppDefaultsByRuntimeAndServerVersion(ctx context.Context, run
 			continue
 		}
 		if dvrParsed(version) {
-			candidate = append(candidate, release.Version)
+			candidate = append(candidate, version)
 		}
 	}
 	if len(candidate) == 0 {
 		return "", fmt.Errorf("no %s version is found for %s", runtime, serverVersion)
 	}
-	sort.Strings(candidate)
-	return candidate[len(candidate)-1], nil
+	// the build metadata parts are ignored when sorting versions for now;
+	// ideally they should be since k3s/RKE2 releases use it to establish order of precedence
+	semver.Sort(candidate)
+	return candidate[len(candidate)-1].String(), nil
 }
 
 func getDefaultFromChannel(ctx context.Context, runtime, channelName string) string {


### PR DESCRIPTION
Fix the issue where the returned default version for rke2/k3s is not the highest because versions are sorted as a list of strings.

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/40694

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When we calculate the default version for rke2/k3s, it treats and sorts version candidates as a list of strings. As a result, version `v1.24.9+rke2r2` became a higher version than `v1.24.10+rke2r1` and was returned. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Now, we treat version candidates as a list of `semver.Version` and use the [server.Sort()](https://pkg.go.dev/github.com/blang/semver/v4#Sort)  to sort it properly. 


## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

see the original issue 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

When running Rancher locally in the dev env, the correct default version (`v1.24.10+rke2r1`) is returned by the backend; therefore, the UI  does not mark it as experimental. 

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

n/a

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
n/a

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

n/a