### PR TITLE
 Changing webhook in remote to use the right image

### DIFF
--- a/pkg/controllers/dashboard/chart/chart.go
+++ b/pkg/controllers/dashboard/chart/chart.go
@@ -14,10 +14,12 @@ const (
 	PriorityClassKey = "priorityClassName"
 )
 
-// Manager is an interface used by the handler to install an uninstall charts
+// Manager is an interface used by the handler to install an uninstall charts. If the interface is changed,
+// regenerate the mock with the below command (run from project root):
+// mockgen --build_flags=--mod=mod -destination=pkg/controllers/dashboard/chart/fake/manager.go -package=fake github.com/rancher/rancher/pkg/controllers/dashboard/chart Manager
 type Manager interface {
 	// Ensure ensures that the chart is installed into the given namespace with the given minVersion version and values.
-	Ensure(namespace, name, minVersion string, values map[string]interface{}, forceAdopt bool) error
+	Ensure(namespace, name, minVersion string, values map[string]interface{}, forceAdopt bool, installImageOverride string) error
 
 	// Uninstall uninstalls the given chart in the given namespace.
 	Uninstall(namespace, name string) error

--- a/pkg/controllers/dashboard/chart/fake/manager.go
+++ b/pkg/controllers/dashboard/chart/fake/manager.go
@@ -34,17 +34,17 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // Ensure mocks base method.
-func (m *MockManager) Ensure(arg0, arg1, arg2 string, arg3 map[string]interface{}, arg4 bool) error {
+func (m *MockManager) Ensure(arg0, arg1, arg2 string, arg3 map[string]interface{}, arg4 bool, arg5 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Ensure", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Ensure", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Ensure indicates an expected call of Ensure.
-func (mr *MockManagerMockRecorder) Ensure(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Ensure(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ensure", reflect.TypeOf((*MockManager)(nil).Ensure), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ensure", reflect.TypeOf((*MockManager)(nil).Ensure), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Remove mocks base method.

--- a/pkg/controllers/dashboard/controller.go
+++ b/pkg/controllers/dashboard/controller.go
@@ -21,7 +21,7 @@ import (
 	"github.com/rancher/wrangler/pkg/needacert"
 )
 
-func Register(ctx context.Context, wrangler *wrangler.Context, embedded bool) error {
+func Register(ctx context.Context, wrangler *wrangler.Context, embedded bool, registryOverride string) error {
 	helm.Register(ctx, wrangler)
 	kubernetesprovider.Register(ctx,
 		wrangler.Mgmt.Cluster(),
@@ -35,7 +35,7 @@ func Register(ctx context.Context, wrangler *wrangler.Context, embedded bool) er
 		wrangler.Admission.ValidatingWebhookConfiguration(),
 		wrangler.CRD.CustomResourceDefinition())
 	scaleavailable.Register(ctx, wrangler)
-	if err := systemcharts.Register(ctx, wrangler); err != nil {
+	if err := systemcharts.Register(ctx, wrangler, registryOverride); err != nil {
 		return err
 	}
 

--- a/pkg/controllers/dashboard/cspadaptercharts/controller.go
+++ b/pkg/controllers/dashboard/cspadaptercharts/controller.go
@@ -46,6 +46,6 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 		// if we can't determine the status of the adapter, stop here and attempt to re-evaluate later
 		return setting, fmt.Errorf("unable to validate if the csp adater was installed: %w", err)
 	}
-	err = h.manager.Ensure(cspadapter.ChartNamespace, adapterRelease.Chart.Name(), settings.CSPAdapterMinVersion.Get(), nil, true)
+	err = h.manager.Ensure(cspadapter.ChartNamespace, adapterRelease.Chart.Name(), settings.CSPAdapterMinVersion.Get(), nil, true, "")
 	return setting, err
 }

--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -75,7 +75,7 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 	}
 	h.Unlock()
 
-	err := h.manager.Ensure(fleetCRDChart.ReleaseNamespace, fleetCRDChart.ChartName, settings.FleetMinVersion.Get(), nil, true)
+	err := h.manager.Ensure(fleetCRDChart.ReleaseNamespace, fleetCRDChart.ChartName, settings.FleetMinVersion.Get(), nil, true, "")
 	if err != nil {
 		return setting, err
 	}
@@ -124,5 +124,5 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 		fleetChartValues["gitjob"] = gitjobChartValues
 	}
 
-	return setting, h.manager.Ensure(fleetChart.ReleaseNamespace, fleetChart.ChartName, settings.FleetMinVersion.Get(), fleetChartValues, true)
+	return setting, h.manager.Ensure(fleetChart.ReleaseNamespace, fleetChart.ChartName, settings.FleetMinVersion.Get(), fleetChartValues, true, "")
 }

--- a/pkg/controllers/dashboard/fleetcharts/controller_test.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller_test.go
@@ -80,6 +80,7 @@ func Test_ChartInstallation(t *testing.T) {
 					settings.FleetMinVersion.Get(),
 					nil,
 					gomock.AssignableToTypeOf(b),
+					"",
 				).Return(nil)
 				manager.EXPECT().Ensure(
 					fleetconst.ReleaseNamespace,
@@ -87,6 +88,7 @@ func Test_ChartInstallation(t *testing.T) {
 					settings.FleetMinVersion.Get(),
 					expectedValues,
 					gomock.AssignableToTypeOf(b),
+					"",
 				).Return(nil)
 
 				manager.EXPECT().Uninstall(fleetconst.ReleaseLegacyNamespace, fleetconst.ChartName).Return(nil)
@@ -120,6 +122,7 @@ func Test_ChartInstallation(t *testing.T) {
 					settings.FleetMinVersion.Get(),
 					nil,
 					gomock.AssignableToTypeOf(b),
+					"",
 				).Return(nil)
 				manager.EXPECT().Ensure(
 					fleetconst.ReleaseNamespace,
@@ -127,6 +130,7 @@ func Test_ChartInstallation(t *testing.T) {
 					settings.FleetMinVersion.Get(),
 					expectedValues,
 					gomock.AssignableToTypeOf(b),
+					"",
 				).Return(nil)
 
 				manager.EXPECT().Uninstall(fleetconst.ReleaseLegacyNamespace, fleetconst.ChartName).Return(nil)

--- a/pkg/controllers/dashboard/hostedcluster/controller.go
+++ b/pkg/controllers/dashboard/hostedcluster/controller.go
@@ -109,7 +109,7 @@ func (h handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster, 
 		return cluster, err
 	}
 
-	if err := h.manager.Ensure(toInstallCrdChart.ReleaseNamespace, toInstallCrdChart.ChartName, "", nil, true); err != nil {
+	if err := h.manager.Ensure(toInstallCrdChart.ReleaseNamespace, toInstallCrdChart.ChartName, "", nil, true, ""); err != nil {
 		return cluster, err
 	}
 
@@ -140,7 +140,7 @@ func (h handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster, 
 		chartValues[chart.PriorityClassKey] = priorityClassName
 	}
 
-	if err := h.manager.Ensure(toInstallChart.ReleaseNamespace, toInstallChart.ChartName, "", chartValues, true); err != nil {
+	if err := h.manager.Ensure(toInstallChart.ReleaseNamespace, toInstallChart.ChartName, "", chartValues, true, ""); err != nil {
 		return cluster, err
 	}
 

--- a/pkg/controllers/dashboard/hostedcluster/controller_test.go
+++ b/pkg/controllers/dashboard/hostedcluster/controller_test.go
@@ -56,6 +56,7 @@ func Test_handler_onClusterChange(t *testing.T) {
 					settings.FleetMinVersion.Get(),
 					nil,
 					gomock.AssignableToTypeOf(b),
+					"",
 				).Return(nil)
 				manager.EXPECT().Ensure(
 					AksChart.ReleaseNamespace,
@@ -63,6 +64,7 @@ func Test_handler_onClusterChange(t *testing.T) {
 					settings.FleetMinVersion.Get(),
 					expectedValues,
 					gomock.AssignableToTypeOf(b),
+					"",
 				).Return(nil)
 
 				return manager
@@ -96,6 +98,7 @@ func Test_handler_onClusterChange(t *testing.T) {
 					settings.FleetMinVersion.Get(),
 					nil,
 					gomock.AssignableToTypeOf(b),
+					"",
 				).Return(nil)
 				manager.EXPECT().Ensure(
 					AksChart.ReleaseNamespace,
@@ -103,6 +106,7 @@ func Test_handler_onClusterChange(t *testing.T) {
 					settings.FleetMinVersion.Get(),
 					expectedValues,
 					gomock.AssignableToTypeOf(b),
+					"",
 				).Return(nil)
 
 				return manager

--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -20,13 +20,15 @@ import (
 const (
 	repoName         = "rancher-charts"
 	webhookChartName = "rancher-webhook"
+	webhookImage     = "rancher/rancher-webhook"
 )
 
-func Register(ctx context.Context, wContext *wrangler.Context) error {
+func Register(ctx context.Context, wContext *wrangler.Context, registryOverride string) error {
 	h := &handler{
-		manager:      wContext.SystemChartsManager,
-		namespaces:   wContext.Core.Namespace(),
-		chartsConfig: chart.RancherConfigGetter{ConfigCache: wContext.Core.ConfigMap().Cache()},
+		manager:          wContext.SystemChartsManager,
+		namespaces:       wContext.Core.Namespace(),
+		chartsConfig:     chart.RancherConfigGetter{ConfigCache: wContext.Core.ConfigMap().Cache()},
+		registryOverride: registryOverride,
 	}
 
 	wContext.Catalog.ClusterRepo().OnChange(ctx, "bootstrap-charts", h.onRepo)
@@ -39,9 +41,10 @@ func Register(ctx context.Context, wContext *wrangler.Context) error {
 }
 
 type handler struct {
-	manager      chart.Manager
-	namespaces   corecontrollers.NamespaceController
-	chartsConfig chart.RancherConfigGetter
+	manager          chart.Manager
+	namespaces       corecontrollers.NamespaceController
+	chartsConfig     chart.RancherConfigGetter
+	registryOverride string
 }
 
 func (h *handler) onRepo(key string, repo *catalog.ClusterRepo) (*catalog.ClusterRepo, error) {
@@ -53,6 +56,13 @@ func (h *handler) onRepo(key string, repo *catalog.ClusterRepo) (*catalog.Cluste
 		"cattle": map[string]interface{}{
 			"systemDefaultRegistry": settings.SystemDefaultRegistry.Get(),
 		},
+	}
+	if h.registryOverride != "" {
+		// if we have a specific image override, don't set the system default registry
+		// don't need to check for type assert since we just created this above
+		registryMap := systemGlobalRegistry["cattle"].(map[string]interface{})
+		registryMap["systemDefaultRegistry"] = ""
+		systemGlobalRegistry["cattle"] = registryMap
 	}
 	for _, chartDef := range h.getChartsToInstall() {
 		if chartDef.Enabled != nil && !chartDef.Enabled() {
@@ -74,6 +84,16 @@ func (h *handler) onRepo(key string, repo *catalog.ClusterRepo) (*catalog.Cluste
 		values := map[string]interface{}{
 			"global": systemGlobalRegistry,
 		}
+		var installImageOverride string
+		if h.registryOverride != "" {
+			imageSettings, ok := values["image"].(map[string]interface{})
+			if !ok {
+				imageSettings = map[string]interface{}{}
+			}
+			imageSettings["repository"] = h.registryOverride + "/" + webhookImage
+			values["image"] = imageSettings
+			installImageOverride = h.registryOverride + "/" + settings.ShellImage.Get()
+		}
 		if chartDef.Values != nil {
 			for k, v := range chartDef.Values() {
 				values[k] = v
@@ -81,7 +101,7 @@ func (h *handler) onRepo(key string, repo *catalog.ClusterRepo) (*catalog.Cluste
 		}
 		// webhook needs to be able to adopt the MutatingWebhookConfiguration which originally wasn't a part of the
 		// chart definition, but is now part of the chart definition
-		if err := h.manager.Ensure(chartDef.ReleaseNamespace, chartDef.ChartName, chartDef.MinVersionSetting.Get(), values, chartDef.ChartName == webhookChartName); err != nil {
+		if err := h.manager.Ensure(chartDef.ReleaseNamespace, chartDef.ChartName, chartDef.MinVersionSetting.Get(), values, chartDef.ChartName == webhookChartName, installImageOverride); err != nil {
 			return repo, err
 		}
 	}

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -262,8 +262,9 @@ func (r *Rancher) Start(ctx context.Context) error {
 		if err := dashboarddata.Add(ctx, r.Wrangler, localClusterEnabled(r.opts), r.opts.AddLocal == "false", r.opts.Embedded); err != nil {
 			return err
 		}
-
-		if err := r.Wrangler.StartWithTransaction(ctx, func(ctx context.Context) error { return dashboard.Register(ctx, r.Wrangler, r.opts.Embedded) }); err != nil {
+		if err := r.Wrangler.StartWithTransaction(ctx, func(ctx context.Context) error {
+			return dashboard.Register(ctx, r.Wrangler, r.opts.Embedded, r.opts.ClusterRegistry)
+		}); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
## Issue:  
#40685

## Problem
The rancher webhook is now deployed in downstream clusters. This caused an issue where, in airgap scenarios, the webhook and the pods that were deploying the webhook would not use the specified airgap registry. This change allows the agent to pass down an override image, when applicable.
 
## Solution
The systemcharts install logic now accepts an override image, which is passed down by the agent. 

In the case where an override image was specified for the webhook, the systemDefaulRegistry value for the webhook's chart will not be set. In addition, the override image will be specified using the `values.image.repository` field. 

In addition, the chart.Manager (used by system charts for installing/upgrading charts) now accepts a parameter for an override image. All other consumers of this logic (fleet, csp adapter) pass down the empty string in all cases.
 
## Testing
Repro steps are valid.

## Engineering Testing
### Manual Testing

- I simulated a systemDefaultRegistry change by changing this value to `docker.io` and validating that the full path of the image (e.x. `docker.io/rancher/webhook`) was used. 
- I setup a downstream cluster proxy (used docker registry image and nginx as a proxy auth) and validated that the webhook/shell image used the specified cluster registry and were able to pull images that required authentication.

## QA Testing Considerations
- Webhook install in the local cluster 
- Webhook install in local cluster with system default registry set
- Webhook install in the remote cluster
- Webhook install in the remote cluster with system default registry set
- Webhook install in the remote cluster with cluster specific registry set (un-authenticated)
- Webhook install in the remote cluster with cluster specific registry set (authenticated)
- Webhook install in the remote cluster with cluster specific registry set (un-authenticated) and system default registry set
- Webhook install in the remote cluster with cluster specific registry set (authenticated) and system default registry set
 
 In addition, this should be tested with various cluster types (specifically for the authenticated registry case), including:
 - RKE
 - RKE2
 - K3s
 - Hosted providers (EKS, AKS, GKE)
 
 This last set of tests (for different types of clusters) is due to how the authenticated registries work. On RKE/RKE2/K3s, the secrets to pull images appear to be set at a cluster/container runtime level, meaning that the webhook/shell don't need to specify imagePullSecrets manually (thanks to @jakefhyde for looking into this from team 2's side). However, it would be a good idea to test if this is the case for all types of clusters (note: if this is broke, it's likely that chart functionality also has issues on that setup). 
 
### Regressions Considerations
- System charts (fleet, csp-adapter, webhook) installation/ugprade