### PR TITLE
[2.7] Fix the default version for rke2/k3s

### DIFF
--- a/pkg/channelserver/channelserver.go
+++ b/pkg/channelserver/channelserver.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -171,7 +170,7 @@ func getDefaultFromAppDefaultsByRuntimeAndServerVersion(ctx context.Context, run
 		return "", fmt.Errorf("faild to parse %s defaultVersionRange for %s: %v", runtime, serverVersion, err)
 	}
 
-	var candidate []string
+	var candidate []semver.Version
 	for _, release := range config.ReleasesConfig().Releases {
 		version, err := semver.ParseTolerant(release.Version)
 		if err != nil {
@@ -179,14 +178,16 @@ func getDefaultFromAppDefaultsByRuntimeAndServerVersion(ctx context.Context, run
 			continue
 		}
 		if dvrParsed(version) {
-			candidate = append(candidate, release.Version)
+			candidate = append(candidate, version)
 		}
 	}
 	if len(candidate) == 0 {
 		return "", fmt.Errorf("no %s version is found for %s", runtime, serverVersion)
 	}
-	sort.Strings(candidate)
-	return candidate[len(candidate)-1], nil
+	// the build metadata parts are ignored when sorting versions for now;
+	// ideally they should be since k3s/RKE2 releases use it to establish order of precedence
+	semver.Sort(candidate)
+	return candidate[len(candidate)-1].String(), nil
 }
 
 func getDefaultFromChannel(ctx context.Context, runtime, channelName string) string {


### PR DESCRIPTION
This is the forward port of the PR https://github.com/rancher/rancher/pull/40720  

The [original issue](https://github.com/rancher/rancher/issues/40694) is found in rancher v2.6-head but is not reproducible in v2.7-head because the default rke2/k3s version is 1.25.x where the patch version is a single-digit value in v2.7 
 
I do not create a forwarding GH issue because this is not reproducible in 2.7-head. But I can make one if it is desired. 