### PR TITLE
[2.6 Backport] Limit bundle release names to 53 characters

### DIFF
--- a/pkg/controllers/provisioningv2/managedchart/managedchart.go
+++ b/pkg/controllers/provisioningv2/managedchart/managedchart.go
@@ -15,6 +15,7 @@ import (
 	v1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/catalogv2/content"
+	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2"
 	fleetcontrollers "github.com/rancher/rancher/pkg/generated/controllers/fleet.cattle.io/v1alpha1"
 	mgmtcontrollers "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/wrangler"
@@ -92,7 +93,7 @@ func (h *handler) OnChange(mcc *v3.ManagedChart, status v3.ManagedChartStatus) (
 
 	bundle := &v1alpha1.Bundle{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.SafeConcatName("mcc", mcc.Name),
+			Name:      rke2.SafeConcatName(rke2.MaxHelmReleaseNameLength, "mcc", mcc.Name),
 			Namespace: mcc.Namespace,
 		},
 		Spec: v1alpha1.BundleSpec{
@@ -100,7 +101,7 @@ func (h *handler) OnChange(mcc *v3.ManagedChart, status v3.ManagedChartStatus) (
 				DefaultNamespace: mcc.Spec.DefaultNamespace,
 				TargetNamespace:  mcc.Spec.TargetNamespace,
 				Helm: &v1alpha1.HelmOptions{
-					ReleaseName:    mcc.Spec.ReleaseName,
+					ReleaseName:    name.Limit(mcc.Spec.ReleaseName, rke2.MaxHelmReleaseNameLength),
 					Version:        mcc.Spec.Version,
 					TimeoutSeconds: mcc.Spec.TimeoutSeconds,
 					Values:         mcc.Spec.Values,

--- a/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagent.go
+++ b/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagent.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	rancherv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2"
 	fleetconst "github.com/rancher/rancher/pkg/fleet"
 	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	rocontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
@@ -110,7 +111,7 @@ func (h *handler) OnChange(cluster *rancherv1.Cluster, status rancherv1.ClusterS
 	result = append(result, &v1alpha1.Bundle{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cluster.Namespace,
-			Name:      name.SafeConcatName(cluster.Name, "managed", "system", "agent"),
+			Name:      rke2.SafeConcatName(rke2.MaxHelmReleaseNameLength, cluster.Name, "managed", "system", "agent"),
 		},
 		Spec: v1alpha1.BundleSpec{
 			BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{

--- a/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
+++ b/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
@@ -4,10 +4,10 @@ import (
 	"github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	rancherv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2"
 	namespaces "github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/provisioningv2/image"
 	"github.com/rancher/rancher/pkg/settings"
-	"github.com/rancher/wrangler/pkg/name"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -20,12 +20,10 @@ func (h *handler) OnChangeInstallSUC(cluster *rancherv1.Cluster, status rancherv
 	// we must limit the output of name.SafeConcatName to at most 48 characters because
 	// a) the chart release name cannot exceed 53 characters, and
 	// b) upon creation of this resource the prefix 'mcc-' will be added to the release name, hence the limiting to 48 characters
-	managedChartName := name.Limit(name.SafeConcatName(cluster.Name, "managed", "system-upgrade-controller"), 48)
-
 	mcc := &v3.ManagedChart{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cluster.Namespace,
-			Name:      managedChartName,
+			Name:      rke2.SafeConcatName(48, cluster.Name, "managed", "system-upgrade-controller"),
 		},
 		Spec: v3.ManagedChartSpec{
 			DefaultNamespace: namespaces.System,


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40709, https://github.com/rancher/rancher/issues/40684
 
## Problem
Release names for bundles deployed by fleet must not exceed 53 characters, however the current `SafeConcatName` function used is only limiting these values to 63 characters or less. In scenarios where the release name exceeds 53 the bundle will fail to deploy. 

## Solution
Limit bundle names and release names to 53 characters at most, this conforms with the fleet naming requirements.
 
## Testing
1. Happy path testing
+ Create an RKE2/K3s cluster with a very long name, such as `haffel-test-very-long-name-for-edge-cases-and-stuff`
+ run `kubectl get bundles.fleet.cattle.io -A` and ensure that all bundles are less than or equal to 53

2. Rancher Upgrade Testing
+ Create an RKE2/K3s cluster on an older version of Rancher where this issue is not seen
+ Wait for the cluster to become available 
+ Watch the bundles using `watch -n 1 kubectl get bundles.fleet.cattle.io -A`
+ Upgrade Rancher
+ Ensure that the bundles names are shortened and no bundles are left behind / not-modified

**Note:** This same issue occurs with the fleet-agent, this problem is being addressed in rancher/fleet here: https://github.com/rancher/fleet/pull/1353

## Engineering Testing
### Manual Testing
Ive done the above

### Automated Testing
n/a

## QA Testing Considerations
Keep in mind https://github.com/rancher/fleet/pull/1353 contributes to this issue and blocks the proper roll out of the other bundles created by Rancher, 
 
### Regressions Considerations
We should make sure that existing clusters which do not need bundle name truncation do not receive it, so as to prevent unneeded redeployment of the bundles