### PR TITLE
add the missing sync of the field Default PSACT 

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -283,6 +283,7 @@ func (h *handler) createNewCluster(cluster *v1.Cluster, status v1.ClusterStatus,
 	spec.Description = cluster.Annotations["field.cattle.io/description"]
 	spec.FleetWorkspaceName = cluster.Namespace
 	spec.DefaultPodSecurityPolicyTemplateName = cluster.Spec.DefaultPodSecurityPolicyTemplateName
+	spec.DefaultPodSecurityAdmissionConfigurationTemplateName = cluster.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName
 	spec.DefaultClusterRoleForProjectMembers = cluster.Spec.DefaultClusterRoleForProjectMembers
 	spec.EnableNetworkPolicy = cluster.Spec.EnableNetworkPolicy
 	spec.DesiredAgentImage = image.ResolveWithCluster(settings.AgentImage.Get(), cluster)


### PR DESCRIPTION
We have a corresponding mgmt cluster for each provisioning cluster.  The mgmt cluster's value is in sync with the provisioning cluster. 
Previously, the value for `DefaultPodSecurityAdmissionConfigurationTemplateName` is not synced from the provisioning cluster to the mgmt cluster. 

This PR adds the missing sync for completeness, although it doesn't affect anything functionally because the mgmt cluster object is bypassed by all handlers as its annotation indicates it is administrated by the provisioning cluster. 
 