### PR TITLE
Add additional provisioning tests to OnTag

### DIFF
--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -78,11 +78,24 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
       def ADMIN_TOKEN_2 = ""
       def USER_TOKEN_2 = ""
 
+      def configYAML = "../provision-config.yaml"
+      def TIMEOUT = "6h"
+
+      def rke2EC2TestCase = "-run ^TestRKE2ProvisioningTestSuite/TestProvisioningRKE2Cluster$"
+      def rke2AZTestCase = "-run ^TestRKE2ProvisioningTestSuite/TestProvisioningRKE2Cluster$"
+      def rke2CustomTestCase = "-run ^TestCustomClusterRKE2ProvisioningTestSuite/TestProvisioningRKE2CustomCluster$"
+      def k3sEC2TestCase = "-run ^TestK3sProvisioningTestSuite/TestProvisioningK3SCluster$"
+      def k3sAZTestCase = "-run ^TestK3sProvisioningTestSuite/TestProvisioningK3SCluster$"
+      def k3sCustomTestCase = "-run ^TestCustomClusterK3sProvisioningTestSuite/TestProvisioningK3SCustomCluster$"
+
       wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
         withFolderProperties {
           withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
                             string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
                             string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                            string(credentialsId: 'AZURE_CLIENT_ID', variable: 'AZURE_CLIENT_ID'),
+                            string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'AZURE_CLIENT_SECRET'),
+                            string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'AZURE_SUBSCRIPTION_ID'),
                             string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
                             string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD')]) {
 
@@ -172,7 +185,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                       }
                       else if (rancher_version.startsWith("v2.7")){
                         if (!env.RKE_VERSION) {
-                          RKE_VERSION = "v1.4.0-rc4"
+                          RKE_VERSION = "v1.4.0"
                         }
                         if (!env.RANCHER_K3S_VERSION) {
                           RANCHER_K3S_VERSION = "v1.24.6+k3s1"
@@ -192,12 +205,60 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                                   string(name: 'RANCHER_K3S_VERSION', value: "${RANCHER_K3S_VERSION}"),
                                   string(name: 'BRANCH', value: branch) ]
 
-                      // Rancher server 1 is used to test RKE clusters
+                      goRKE2EC2Params = [ string(name: 'TIMEOUT', value: "${TIMEOUT}"),
+                                  text(name: 'CONFIG', value: "${provision-config.yaml}"),
+                                  string(name: 'REPO', value: "https://github.com/rancher/rancher.git"),
+                                  string(name: 'BRANCH', value: branch),
+                                  string(name: 'TEST_PACKAGE', value: "provisioning/rke2"),
+                                  string(name: 'GOTEST_TESTCASE', value: "${rke2EC2TestCase}") ]
+
+                      goRKE2AZParams = [ string(name: 'TIMEOUT', value: "${TIMEOUT}"),
+                                  text(name: 'CONFIG', value: "${provision-config.yaml}"),
+                                  string(name: 'REPO', value: "https://github.com/rancher/rancher.git"),
+                                  string(name: 'BRANCH', value: branch),
+                                  string(name: 'TEST_PACKAGE', value: "provisioning/rke2"),
+                                  string(name: 'GOTEST_TESTCASE', value: "${rke2AZTestCase}") ]
+
+                      goRKE2CustomParams = [ string(name: 'TIMEOUT', value: "${TIMEOUT}"),
+                                  text(name: 'CONFIG', value: "${provision-config.yaml}"),
+                                  string(name: 'REPO', value: "https://github.com/rancher/rancher.git"),
+                                  string(name: 'BRANCH', value: branch),
+                                  string(name: 'TEST_PACKAGE', value: "provisioning/rke2"),
+                                  string(name: 'GOTEST_TESTCASE', value: "${rke2CustomTestCase}") ]
+
+                      goK3SEC2Params = [ string(name: 'TIMEOUT', value: "${TIMEOUT}"),
+                                  text(name: 'CONFIG', value: "${provision-config.yaml}"),
+                                  string(name: 'REPO', value: "https://github.com/rancher/rancher.git"),
+                                  string(name: 'BRANCH', value: branch),
+                                  string(name: 'TEST_PACKAGE', value: "provisioning/k3s"),
+                                  string(name: 'GOTEST_TESTCASE', value: "${k3sEC2TestCase}") ]
+
+                      goK3SAZParams = [ string(name: 'TIMEOUT', value: "${TIMEOUT}"),
+                                  text(name: 'CONFIG', value: "${provision-config.yaml}"),
+                                  string(name: 'REPO', value: "https://github.com/rancher/rancher.git"),
+                                  string(name: 'BRANCH', value: branch),
+                                  string(name: 'TEST_PACKAGE', value: "provisioning/k3s"),
+                                  string(name: 'GOTEST_TESTCASE', value: "${k3sAZTestCase}") ]                  
+
+                      goK3SCustomParams = [ string(name: 'TIMEOUT', value: "${TIMEOUT}"),
+                                  text(name: 'CONFIG', value: "${provision-config.yaml}"),
+                                  string(name: 'REPO', value: "https://github.com/rancher/rancher.git"),
+                                  string(name: 'BRANCH', value: branch),
+                                  string(name: 'TEST_PACKAGE', value: "provisioning/k3s"),
+                                  string(name: 'GOTEST_TESTCASE', value: "${k3sCustomTestCase}") ]
+
+                      // Rancher server 1 is used to test RKE1, RKE2 and K3s clusters
                       // DO Note: https://github.com/rancher/qa-tasks/issues/318
                       // jobs["do"] = { build job: 'rancher-v3_ontag_do_certification', parameters: params }
                       jobs["ec2"] = { build job: 'rancher-v3_ontag_ec2_certification', parameters: params }
                       jobs["az"] = { build job: 'rancher-v3_ontag_az_certification', parameters: params }
                       jobs["custom"] = { build job: 'rancher-v3_ontag_custom_certification', parameters: params}
+                      jobs["go-rke2-ec2"] = { build job: 'go-automation-freeform-job', parameters: goRKE2EC2Params }
+                      jobs["go-rke2-az"] = { build job: 'go-automation-freeform-job', parameters: goRKE2AZParams }
+                      jobs["go-rke2-custom"] = { build job: 'go-automation-freeform-job', parameters: goRKE2CustomParams }
+                      jobs["go-k3s-ec2"] = { build job: 'go-automation-freeform-job', parameters: goK3SEC2Params }
+                      jobs["go-k3s-az"] = { build job: 'go-automation-freeform-job', parameters: goK3SAZParams }
+                      jobs["go-k3s-custom"] = { build job: 'go-automation-freeform-job', parameters: goK3SCustomParams }
                       // windows note: https://github.com/rancher/dashboard/issues/6549
                       // jobs["windows"] = { build job: 'rancher-v3_ontag_windows_certification', parameters: params}
                       if (rancher_version.startsWith("v2.6") || rancher_version.startsWith("v2.7")){

--- a/tests/validation/tests/v3_api/scripts/provision-config.yaml
+++ b/tests/validation/tests/v3_api/scripts/provision-config.yaml
@@ -1,0 +1,207 @@
+rancher:
+  host: ${CATTLE_TEST_URL}
+  adminToken: ${ADMIN_TOKEN}
+  cleanup: true
+provisioningInput:
+  nodesAndRoles: [
+    etcd: true,
+    controlplane: true,
+    worker: true,
+  ]
+  k3sKubernetesVersion: ["v1.24.10+k3s1"]
+  cni: ["calico"]
+  providers: ["azure"]
+  hardened: true
+azureCredentials:
+  clientId: ${AZURE_CLIENT_ID}
+  clientSecret: ${AZURE_CLIENT_SECRET}
+  subscriptionId: ${AZURE_SUBSCRIPTION_ID}
+  environment: "AzurePublicCloud"
+azureMachineConfig:
+  availabilitySet: "docker-machine"
+  diskSize: "30"
+  environment: "AzurePublicCloud"
+  faultDomainCount: "3"
+  image: "canonical:UbuntuServer:20.04-LTS:latest"
+  location: "westus"
+  managedDisks: false
+  noPublicIp: false
+  nsg: ""
+  openPort: ["6443/tcp", "2379/tcp", "2380/tcp", "8472/udp", "4789/udp", "9796/tcp", "10256/tcp", "10250/tcp", "10251/tcp", "10252/tcp"]
+  resourceGroup: "docker-machine"
+  size: "Standard_D2_v2"
+  sshUser: "docker-user"
+  staticPublicIp: false
+  storageType: "Standard_LRS"
+  subnet: "docker-machine"
+  subnetPrefix: "192.168.0.0/16"
+  updateDomainCount: "5"
+  usePrivateIp: false
+  vnet: "docker-machine-vnet"
+---
+rancher:
+  host: "${CATTLE_TEST_URL}"
+  adminToken: "${ADMIN_TOKEN}"
+  cleanup: true
+provisioningInput:
+  nodesAndRoles: [
+    etcd: true,
+    controlplane: true,
+    worker: true,
+  ]
+  rke2KubernetesVersion: ["v1.24.10+rke2r1"]
+  cni: ["calico"]
+  providers: ["aws"]
+  hardened: true
+awsCredentials:
+  secretKey: "${AWS_SECRET_ACCESS_KEY}"
+  accessKey: "${AWS_ACCESS_KEY_ID}"
+  defaultRegion: "${AWS_REGION}"
+awsMachineConfig:
+  region: "${AWS_REGION}"
+  ami: "${AWS_AMI}"
+  instanceType: "${AWS_INSTANCE_TYPE}"
+  sshUser: "${AWS_USER}"
+  vpcId: "${AWS_VPC}"
+  volumeType: "gp2"
+  zone: "a"
+  retries: "5"
+  rootSize: "60"
+  securityGroup: "${AWS_SECURITY_GROUPS}"
+---
+rancher:
+  host: ${CATTLE_TEST_URL}
+  adminToken: ${ADMIN_TOKEN}
+  cleanup: true
+provisioningInput:
+  nodesAndRoles: [
+    etcd: true,
+    controlplane: true,
+    worker: true,
+  ]
+  k3sKubernetesVersion: ["v1.24.10+k3s1"]
+  cni: ["calico"]
+  providers: ["aws"]
+  nodeProviders: ["ec2"]
+  hardened: true
+awsEC2Configs:
+  region: "${AWS_REGION}"
+  awsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY}
+  awsAccessKeyID: ${AWS_ACCESS_KEY_ID}
+  awsEC2Config:
+    - instanceType: "${AWS_INSTANCE_TYPE}"
+      awsRegionAZ: ""
+      awsAMI: "${AWS_AMI}"
+      awsSecurityGroups: "${AWS_SECURITY_GROUPS}"
+      awsSSHKeyName: "${AWS_SSH_PEM_KEY}"
+      awsCICDInstanceTag: "${AWS_CICD_INSTANCE_TAG}"
+      awsIAMProfile: "${AWS_IAM_PROFILE}"
+      awsUser: "${AWS_USER}"
+      volumeSize: "${AWS_VOLUME_SIZE}"
+      isWindows: false
+sshPath: 
+  sshPath: "/go/src/github.com/rancher/rancher/tests/v2/validation/.ssh"
+---
+rancher:
+  host: "${CATTLE_TEST_URL}"
+  adminToken: "${ADMIN_TOKEN}"
+  cleanup: true
+provisioningInput:
+  nodesAndRoles: [
+    etcd: true,
+    controlplane: true,
+    worker: true,
+  ]
+  k3sKubernetesVersion: ["v1.24.10+k3s1"]
+  cni: ["calico"]
+  providers: ["aws"]
+  hardened: true
+awsCredentials:
+  secretKey: "${AWS_SECRET_ACCESS_KEY}"
+  accessKey: "${AWS_ACCESS_KEY_ID}"
+  defaultRegion: "${AWS_REGION}"
+awsMachineConfig:
+  region: "${AWS_REGION}"
+  ami: "${AWS_AMI}"
+  instanceType: "${AWS_INSTANCE_TYPE}"
+  sshUser: "${AWS_USER}"
+  vpcId: "${AWS_VPC}"
+  volumeType: "gp2"
+  zone: "a"
+  retries: "5"
+  rootSize: "60"
+  securityGroup: "${AWS_SECURITY_GROUPS}"
+---
+rancher:
+  hhost: "${CATTLE_TEST_URL}"
+  adminToken: "${ADMIN_TOKEN}"
+  cleanup: true
+provisioningInput:
+  nodesAndRoles: [
+    etcd: true,
+    controlplane: true,
+    worker: true,
+  ]
+  rke2KubernetesVersion: ["v1.24.10+rke2r1"]
+  cni: ["calico"]
+  providers: ["azure"]
+  hardened: true
+azureCredentials:
+  clientId: "${AZURE_CLIENT_ID}"
+  clientSecret: "${AZURE_CLIENT_SECRET}"
+  subscriptionId: "${AZURE_SUBSCRIPTION_ID}"
+  environment: "AzurePublicCloud"
+azureMachineConfig:
+  availabilitySet: "docker-machine"
+  diskSize: "30"
+  environment: "AzurePublicCloud"
+  faultDomainCount: "3"
+  image: "canonical:UbuntuServer:20.04-LTS:latest"
+  location: "westus"
+  managedDisks: false
+  noPublicIp: false
+  nsg: ""
+  openPort: ["6443/tcp", "2379/tcp", "2380/tcp", "8472/udp", "4789/udp", "9796/tcp", "10256/tcp", "10250/tcp", "10251/tcp", "10252/tcp"]
+  resourceGroup: "docker-machine"
+  size: "Standard_D2_v2"
+  sshUser: "docker-user"
+  staticPublicIp: false
+  storageType: "Standard_LRS"
+  subnet: "docker-machine"
+  subnetPrefix: "192.168.0.0/16"
+  updateDomainCount: "5"
+  usePrivateIp: false
+  vnet: "docker-machine-vnet"
+---
+rancher:
+  host: ${CATTLE_TEST_URL}
+  adminToken: ${ADMIN_TOKEN}
+  cleanup: true
+provisioningInput:
+  nodesAndRoles: [
+    etcd: true,
+    controlplane: true,
+    worker: true,
+  ]
+  rke2KubernetesVersion: ["v1.24.10+rke2r1"]
+  cni: ["calico"]
+  providers: ["aws"]
+  nodeProviders: ["ec2"]
+  hardened: true
+awsEC2Configs:
+  region: "${AWS_REGION}"
+  awsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY}
+  awsAccessKeyID: ${AWS_ACCESS_KEY_ID}
+  awsEC2Config:
+    - instanceType: "${AWS_INSTANCE_TYPE}"
+      awsRegionAZ: ""
+      awsAMI: "${AWS_AMI}"
+      awsSecurityGroups: "${AWS_SECURITY_GROUPS}"
+      awsSSHKeyName: "${AWS_SSH_PEM_KEY}"
+      awsCICDInstanceTag: "${AWS_CICD_INSTANCE_TAG}"
+      awsIAMProfile: "${AWS_IAM_PROFILE}"
+      awsUser: "${AWS_USER}"
+      volumeSize: "${AWS_VOLUME_SIZE}"
+      isWindows: false
+sshPath: 
+  sshPath: "/go/src/github.com/rancher/rancher/tests/v2/validation/.ssh"


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Fix Ontag Automation runs](https://github.com/rancher/qa-tasks/issues/429)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The OnTag runs that are ran currently lack a number of different provisioning tests. These include node provisioning tests for RKE2/K3s and custom cluster provisioning tests for RKE2/K3s. This PR aims to add support for those missing provisioning tests so that they are covered in the OnTag runs.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Added EC2/Azure node provider support for RKE2/K3s in the `Jenkinsfile_ontag_matrix` file. In the same file, added support for custom cluster provisioning for RKE2/K3s.

In order to properly run, a config file containing all of the different provisioning tests is added. Each test is separated by the YAML separator `---` to make the tests cleaner/ability to use one big YAML instead of creating individual files.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Jenkins runs will be provided to the reviewers.