### PR TITLE
fix(sec): upgrade helm.sh/helm/v3 to 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,7 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.4.0
-	helm.sh/helm/v3 v3.9.0
+	helm.sh/helm/v3 v3.11.1
 	k8s.io/api v0.25.4
 	k8s.io/apiextensions-apiserver v0.25.4
 	k8s.io/apimachinery v0.25.4


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in helm.sh/helm/v3 v3.9.0
- [CVE-2021-21303](https://www.oscs1024.com/hd/CVE-2021-21303)


### What did I do？
Upgrade helm.sh/helm/v3 from v3.9.0 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS