### PR TITLE
Bump Dashboard and UI indexes to 2.6.11

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -156,7 +156,7 @@ var (
 	UIDashboardPath = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
 
 	// Depending on ui-offline-preferred, use this version of the dashboard instead of the one contained in Rancher Manager
-	UIDashboardIndex = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/release-2.6/index.html")
+	UIDashboardIndex = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/release-2.6.11/index.html")
 
 	// Depending on ui-offline-preferred and if a Harvester Cluster does not contain it's own Harvester plugin, use this version of the plugin instead
 	UIDashboardHarvesterLegacyPlugin = NewSetting("ui-dashboard-harvester-legacy-plugin", "https://releases.rancher.com/harvester-ui/plugin/harvester-1.0.3-head/harvester-1.0.3-head.umd.min.js")
@@ -171,7 +171,7 @@ var (
 	UIFeedBackForm = NewSetting("ui-feedback-form", "")
 
 	// Depending on ui-offline-preferred, use this version of the old ember UI instead of the one contained in Rancher Manager
-	UIIndex = NewSetting("ui-index", "https://releases.rancher.com/ui/release-2.6/index.html")
+	UIIndex = NewSetting("ui-index", "https://releases.rancher.com/ui/release-2.6.11/index.html")
 
 	// Use a url address to send new 'File an Issue' reports instead of sending users to the Github issues page
 	UIIssues = NewSetting("ui-issues", "")


### PR DESCRIPTION
## Problem
- `rancher/dashboard` and `rancher/ui` have both now branched for 2.6.11
 
## Solution
- This change ensures the `rancher/rancher` 2.6 branch points to the correct builds
- These builds are used, when settings are default, when the version ends in `-head` as an alternative to the embedded builds
 
## Engineering Testing
### Manual Testing
- Updated the settings in an existing rancher instance with the new values and ensured both UIs load correctly