### PR TITLE
Fix RKE2 upgrade failure

### DIFF
--- a/pkg/apis/rke.cattle.io/v1/cluster.go
+++ b/pkg/apis/rke.cattle.io/v1/cluster.go
@@ -81,7 +81,7 @@ type DrainOptions struct {
 	DeleteEmptyDirData bool `json:"deleteEmptyDirData"`
 	// DisableEviction forces drain to use delete rather than evict
 	DisableEviction bool `json:"disableEviction"`
-	//Period of time in seconds given to each pod to terminate gracefully.
+	// Period of time in seconds given to each pod to terminate gracefully.
 	// If negative, the default value specified in the pod will be used
 	GracePeriod int `json:"gracePeriod"`
 	// Time to wait (in seconds) before giving up for one try
@@ -118,4 +118,5 @@ type KeyToPath struct {
 	Path        string `json:"path"`
 	Dynamic     bool   `json:"dynamic,omitempty"`
 	Permissions string `json:"permissions,omitempty"`
+	Hash        string `json:"hash,omitempty"`
 }

--- a/pkg/provisioningv2/rke2/planner/config.go
+++ b/pkg/provisioningv2/rke2/planner/config.go
@@ -462,6 +462,10 @@ func (p *Planner) renderFiles(controlPlane *rkev1.RKEControlPlane, entry *planEn
 							Content: base64.StdEncoding.EncodeToString(secret.Data[v.Key]),
 							Dynamic: v.Dynamic,
 						}
+						hash := sha256.Sum256(secret.Data[v.Key])
+						if v.Hash != "" && v.Hash != base64.StdEncoding.EncodeToString(hash[:]) {
+							return files, fmt.Errorf("secret %s does not cotain the expected content", secret.Name)
+						}
 						if v.Permissions != "" {
 							file.Permissions = v.Permissions
 						} else if fs.Secret.DefaultPermissions != "" {
@@ -485,6 +489,10 @@ func (p *Planner) renderFiles(controlPlane *rkev1.RKEControlPlane, entry *planEn
 							Path:    v.Path,
 							Content: base64.StdEncoding.EncodeToString([]byte(configmap.Data[v.Key])),
 							Dynamic: v.Dynamic,
+						}
+						hash := sha256.Sum256([]byte(configmap.Data[v.Key]))
+						if v.Hash != "" && v.Hash != base64.StdEncoding.EncodeToString(hash[:]) {
+							return files, fmt.Errorf("configmap %s does not cotain the expected content", configmap.Name)
 						}
 						if v.Permissions != "" {
 							file.Permissions = v.Permissions


### PR DESCRIPTION
## Notes to Reviews

We need to merge this PR first, then update the Go mod file in the [rancher/webhook PR](https://github.com/rancher/webhook/pull/198). 
Except for the Go mod file, the rest of the rancher/webhook PR is ready for review.


 
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
https://github.com/rancher/rancher/issues/40755

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
When PSACT is used in the rke2 cluster and we upgrade the cluster from k8s 1.24 to 1.25, the Secret holding the generated admission config file is updated by rancher-webhook because the API version inside the config file is changed from v1beta1 to v1; meanwhile, the planner in Rancher keeps monitoring the RKEControlPlane and updating the Plan.   But there is a time lag between Rancher getting the updated Secret and the Plan. As a result, the planner sends the old Plan and the content from the new Secret to the control plane nodes and triggers the upgrade. Therefore the cluster fails to upgrade and logs the following errors in kube-apiserver:

`failed to initialize admission: couldn't init admission plugin \"PodSecurity\": no kind \"PodSecurityConfiguration\" is registered for version \"pod-security.admission.config.k8s.io/v1\" in scheme \"k8s.io/pod-security-admission/admission/api/scheme/scheme.go:30\"`

 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
To make sure the planner always uses the correct version of Secret and Plan to trigger the upgrade on the RKE2 cluster, we introduce a new field named `hash` to the underlying data struct, and its value is the base64 encoded value of the sha256 sum of the admission config file.  The planner compares the `hash` value with the one calculated based on the current Secret, and only processes to upgrade the cluster if those two values match. 

Rancher-webhooks is responsible for setting the `hash` value when it mutations the request for creating/updating the cluster. (https://github.com/rancher/webhook/pull/198) 

Users can also use this field to enforce the check on their passed Secrets or Configmap. 




## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

See the linked GH issue for steps. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

This PR and the changes in rancher/webhook are tested locally.  Following the same steps in the original issue,  the REK2 cluster is successfully upgraded from 1.24 to 1.25.   Also, editing the cluster to change PSACT works as expected. 

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

n/a 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

- upgrade RKE2 cluster with/without PSACT 
- change the PSACT on the cluster 

 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

- upgrade RKE2 cluster with/without PSACT 
- change the PSACT on the cluster 
