### PR TITLE
Add validation test for etcd backup and restore with cluster config

### DIFF
--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
@@ -231,3 +231,21 @@ func watchAndWaitForPods(client *rancher.Client, clusterID string) error {
 	})
 	return err
 }
+
+func upgradeClusterK8sVersionWithUpgradeStrategy(client *rancher.Client, clustername string, k8sUpgradedVersion string, namespaceName string) error {
+	clusterObj, existingSteveAPIObj, err := getProvisioningClusterByName(client, clustername, namespaceName)
+	if err != nil {
+		return err
+	}
+
+	clusterObj.Spec.RKEConfig.UpgradeStrategy.ControlPlaneConcurrency = "15%"
+	clusterObj.Spec.RKEConfig.UpgradeStrategy.WorkerConcurrency = "20%"
+	clusterObj.Spec.KubernetesVersion = k8sUpgradedVersion
+
+	_, err = client.Steve.SteveType(clusters.ProvisioningSteveResouceType).Update(existingSteveAPIObj, clusterObj)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
@@ -236,6 +236,166 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithK8sUpgrade(pro
 	require.Equal(r.T(), initialK8sVersion, cluster.Spec.KubernetesVersion)
 }
 
+func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithUpgradeStrategy(provider *Provider) {
+	initialK8sVersion := r.kubernetesVersions[0]
+	logrus.Infof("running etcd snapshot restore test.............")
+	subSession := r.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := r.client.WithSession(subSession)
+	require.NoError(r.T(), err)
+
+	logrus.Infof("creating kube provisioning client.............")
+	kubeProvisioningClient, err := r.client.GetKubeAPIProvisioningClient()
+	require.NoError(r.T(), err)
+	logrus.Infof("kube provisioning client created.............")
+
+	clusterName := namegen.AppendRandomString(provider.Name)
+
+	logrus.Infof("creating rke2Cluster.............")
+	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0])
+	require.NoError(r.T(), err)
+	require.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
+	logrus.Infof("rke2Cluster create request successful.............")
+
+	logrus.Infof("creating watch over cluster.............")
+	clusters.WatchAndWaitForCluster(r.client.Steve, kubeProvisioningClient, r.ns, clusterName)
+	logrus.Infof("cluster is up and running.............")
+
+	logrus.Info("getting cluster id.............")
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(r.T(), err)
+	logrus.Info("got cluster id.............", clusterID)
+
+	logrus.Info("getting local cluster id.............")
+	localClusterID, err := clusters.GetClusterIDByName(client, localClusterName)
+	require.NoError(r.T(), err)
+	logrus.Info("got local cluster id.............", localClusterID)
+
+	logrus.Infof("creating watch over pods.............")
+	r.watchAndWaitForPods(client, clusterID)
+	logrus.Infof("All pods are up and running.............")
+
+	logrus.Infof("creating a workload(nginx deployment).............")
+
+	wloadBeforeRestoreLabels := map[string]string{}
+	wloadBeforeRestoreLabels["workload.user.cattle.io/workloadselector"] = fmt.Sprintf("apps.deployment-%v-%v", r.ns, wloadBeforeRestore)
+
+	containerTemplate := workloads.NewContainer("ngnix", "nginx", v1.PullAlways, []v1.VolumeMount{}, []v1.EnvFromSource{})
+	podTemplate := workloads.NewPodTemplate([]v1.Container{containerTemplate}, []v1.Volume{}, []v1.LocalObjectReference{}, wloadBeforeRestoreLabels)
+	deploymentBeforeBackup := workloads.NewDeploymentTemplate(wloadBeforeRestore, r.ns, podTemplate, wloadBeforeRestoreLabels)
+
+	steveclient, err := client.Steve.ProxyDownstream(clusterID)
+	require.NoError(r.T(), err)
+
+	deploymentResp, err := createDeployment(deploymentBeforeBackup, steveclient, client, clusterID)
+	require.NoError(r.T(), err)
+	require.Equal(r.T(), deploymentBeforeBackup.Name, deploymentResp.ObjectMeta.Name)
+	logrus.Infof("%v is ready.............", deploymentBeforeBackup.Name)
+
+	logrus.Infof("creating an ingress.............")
+
+	path := ingresses.NewIngressPathTemplate(networkingv1.PathTypeExact, "/index.html", wloadServiceName, 80)
+	ingressBeforeBackup := ingresses.NewIngressTemplate(ingressName, r.ns, "", []networkingv1.HTTPIngressPath{path})
+
+	ingressResp, err := steveclient.SteveType(ingresses.IngressSteveType).Create(ingressBeforeBackup)
+	require.NoError(r.T(), err)
+
+	require.Equal(r.T(), ingressName, ingressResp.ObjectMeta.Name)
+	logrus.Infof("created an ingress.............")
+
+	logrus.Infof("creating a snapshot of the cluster.............")
+	err = createSnapshot(client, clusterName, 1, r.ns)
+	require.NoError(r.T(), err)
+	logrus.Infof("created a snapshot of the cluster.............")
+
+	logrus.Infof("creating watch over cluster after creating a snapshot.............")
+	clusters.WatchAndWaitForCluster(r.client.Steve, kubeProvisioningClient, r.ns, clusterName)
+	logrus.Infof("cluster is active again.............")
+
+	var snapshotToBeRestored string
+
+	err = kwait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+		snapshotList, err := getSnapshots(client, localClusterID)
+		if err != nil {
+			return false, err
+		}
+		totalClusterSnapShots := 0
+		for _, snapshot := range snapshotList {
+			if strings.Contains(snapshot.ObjectMeta.Name, clusterName) {
+				if snapshotToBeRestored == "" {
+					snapshotToBeRestored = snapshot.Name
+				}
+				totalClusterSnapShots++
+			}
+		}
+		if totalClusterSnapShots == etcdnodeCount {
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(r.T(), err)
+
+	logrus.Infof("creating a workload(w2, deployment).............")
+	wloadAfterBackupLabels := map[string]string{}
+	wloadAfterBackupLabels["workload.user.cattle.io/workloadselector"] = fmt.Sprintf("apps.deployment-%v-%v", r.ns, wloadAfterBackup)
+	containerTemplate2 := workloads.NewContainer("ngnix", "nginx", v1.PullAlways, []v1.VolumeMount{}, []v1.EnvFromSource{})
+	podTemplate2 := workloads.NewPodTemplate([]v1.Container{containerTemplate2}, []v1.Volume{}, []v1.LocalObjectReference{}, wloadAfterBackupLabels)
+	deploymentAfterBackup := workloads.NewDeploymentTemplate(wloadAfterBackup, r.ns, podTemplate2, wloadAfterBackupLabels)
+
+	deploymentResp, err = createDeployment(deploymentAfterBackup, steveclient, client, clusterID)
+	require.NoError(r.T(), err)
+	require.Equal(r.T(), deploymentAfterBackup.Name, deploymentResp.ObjectMeta.Name)
+	logrus.Infof("%v is ready.............", deploymentAfterBackup.Name)
+
+	logrus.Infof("upgrading cluster k8s version.............")
+	k8sUpgradedVersion := r.kubernetesVersions[1]
+	err = upgradeClusterK8sVersionWithUpgradeStrategy(client, clusterName, k8sUpgradedVersion, r.ns)
+	require.NoError(r.T(), err)
+	clusters.WatchAndWaitForCluster(r.client.Steve, kubeProvisioningClient, r.ns, clusterName)
+	logrus.Infof("cluster is active again.............")
+
+	cluster, _, err := getProvisioningClusterByName(client, clusterName, r.ns)
+	require.NoError(r.T(), err)
+	require.Equal(r.T(), k8sUpgradedVersion, cluster.Spec.KubernetesVersion)
+
+	logrus.Infof("validating ControlPlaneConcurrency and WorkerConcurrency values are updated..")
+	require.Equal(r.T(), "15%", cluster.Spec.RKEConfig.UpgradeStrategy.ControlPlaneConcurrency)
+	require.Equal(r.T(), "20%", cluster.Spec.RKEConfig.UpgradeStrategy.WorkerConcurrency)
+
+	logrus.Infof("restoring snapshot.............")
+	require.NoError(r.T(), restoreSnapshot(client, clusterName, snapshotToBeRestored, 1, "all", r.ns))
+	logrus.Infof("successfully submitted restoration request.............")
+
+	logrus.Infof("creating watch over cluster after restore.............")
+	clusters.WatchAndWaitForCluster(r.client.Steve, kubeProvisioningClient, r.ns, clusterName)
+	logrus.Infof("cluster is active again.............")
+
+	logrus.Infof("creating watch over pods.............")
+	r.watchAndWaitForPods(client, clusterID)
+	logrus.Infof("All pods are up and running.............")
+
+	logrus.Infof("fetching deployment list to validate restore.............")
+	deploymentList, err := steveclient.SteveType(workloads.DeploymentSteveType).NamespacedSteveClient(r.ns).List(nil)
+	require.NoError(r.T(), err)
+	require.Equal(r.T(), 1, len(deploymentList.Data))
+	require.Equal(r.T(), wloadBeforeRestore, deploymentList.Data[0].ObjectMeta.Name)
+	logrus.Infof(" deployment list validated successfully.............")
+
+	logrus.Infof("fetching ingresses list to validate restore.............")
+	ingressResp, err = steveclient.SteveType(ingresses.IngressSteveType).ByID(r.ns + "/" + ingressBeforeBackup.Name)
+	require.NoError(r.T(), err)
+	require.NotNil(r.T(), ingressResp)
+	logrus.Infof("ingress validated successfully.............")
+
+	cluster, _, err = getProvisioningClusterByName(client, clusterName, r.ns)
+	require.NoError(r.T(), err)
+	require.Equal(r.T(), initialK8sVersion, cluster.Spec.KubernetesVersion)
+	logrus.Infof("validating ControlPlaneConcurrency and WorkerConcurrency are restored to default values..")
+	require.Equal(r.T(), "10%", cluster.Spec.RKEConfig.UpgradeStrategy.ControlPlaneConcurrency)
+	require.Equal(r.T(), "10%", cluster.Spec.RKEConfig.UpgradeStrategy.WorkerConcurrency)
+}
+
 func (r *RKE2EtcdSnapshotRestoreTestSuite) watchAndWaitForPods(client *rancher.Client, clusterID string) {
 	logrus.Infof("waiting for all Pods to be up.............")
 	err := kwait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
@@ -274,16 +434,6 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) watchAndWaitForPods(client *rancher.C
 		return false, nil
 	})
 	require.NoError(r.T(), err)
-}
-
-func (r *RKE2EtcdSnapshotRestoreTestSuite) TestEtcdSnapshotRestoreWithK8sUpgrade() {
-	logrus.Infof("checking for valid k8s versions and cnis in the configuration....")
-	require.GreaterOrEqual(r.T(), len(r.kubernetesVersions), 2)
-	require.GreaterOrEqual(r.T(), len(r.cnis), 1)
-	for _, providerName := range r.providers {
-		provider := CreateProvider(providerName)
-		r.EtcdSnapshotRestoreWithK8sUpgrade(&provider)
-	}
 }
 
 func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestore(provider *Provider) {
@@ -440,5 +590,25 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) TestEtcdOnlySnapshotRestore() {
 	for _, providerName := range r.providers {
 		provider := CreateProvider(providerName)
 		r.EtcdSnapshotRestore(&provider)
+	}
+}
+
+func (r *RKE2EtcdSnapshotRestoreTestSuite) TestEtcdSnapshotRestoreWithK8sUpgrade() {
+	logrus.Infof("checking for valid k8s versions and cnis in the configuration....")
+	require.GreaterOrEqual(r.T(), len(r.kubernetesVersions), 2)
+	require.GreaterOrEqual(r.T(), len(r.cnis), 1)
+	for _, providerName := range r.providers {
+		provider := CreateProvider(providerName)
+		r.EtcdSnapshotRestoreWithK8sUpgrade(&provider)
+	}
+}
+
+func (r *RKE2EtcdSnapshotRestoreTestSuite) TestEtcdSnapshotRestoreWithUpgradeStrategy() {
+	logrus.Infof("checking for valid k8s versions and cnis in the configuration....")
+	require.GreaterOrEqualf(r.T(), len(r.kubernetesVersions), 2, "Two k8s versions are required in the config")
+	require.GreaterOrEqualf(r.T(), len(r.cnis), 1, "At least one cni is required in the config")
+	for _, providerName := range r.providers {
+		provider := CreateProvider(providerName)
+		r.EtcdSnapshotRestoreWithUpgradeStrategy(&provider)
 	}
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/qa-tasks/issues/407

**Note:**

- This validation test takes around 20 mins to complete which is more than default timeout for the test that's why we need to use -timeout option with value either greater than 20mins or 0. Similar to below command
`go test providers.go etcd_bkp_restore_test.go -v -timeout 0`
- Also it will require at least two k8s version in ascending order in the cattle config file and at least one CNI provider as per below:
```
provisioningInput:  
     rke2KubernetesVersion: 
    - v1.23.16+rke2r1
    - v1.24.10+rke2r1
  cni:
    - calico
```