### PR TITLE
Adding automation script to validate PSA rbac

### DIFF
--- a/tests/v2/validation/rbac/rbac.go
+++ b/tests/v2/validation/rbac/rbac.go
@@ -1,7 +1,11 @@
 package rbac
 
 import (
+	"errors"
+	"fmt"
 	"sort"
+	"strings"
+	"time"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
@@ -10,15 +14,30 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/projects"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
 	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	appv1 "k8s.io/api/apps/v1"
+	coreV1 "k8s.io/api/core/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
-const roleOwner = "cluster-owner"
-const roleMember = "cluster-member"
-const roleProjectOwner = "project-owner"
-const roleProjectMember = "project-member"
+const (
+	roleOwner           = "cluster-owner"
+	roleMember          = "cluster-member"
+	roleProjectOwner    = "project-owner"
+	roleProjectMember   = "project-member"
+	roleProjectReadOnly = "read-only"
+	restrictedAdmin     = "restricted-admin"
+	standardUser        = "user"
+	pssRestrictedPolicy = "restricted"
+	pssBaselinePolicy   = "baseline"
+	pssPrivilegedPolicy = "privileged"
+	psaWarn             = "pod-security.kubernetes.io/warn"
+	psaAudit            = "pod-security.kubernetes.io/audit"
+	psaEnforce          = "pod-security.kubernetes.io/enforce"
+)
 
-func createUser(client *rancher.Client) (*management.User, error) {
+func createUser(client *rancher.Client, role string) (*management.User, error) {
 	enabled := true
 	var username = namegen.AppendRandomString("testuser-")
 	var testpassword = password.GenerateUserPassword("testpass-")
@@ -29,11 +48,10 @@ func createUser(client *rancher.Client) (*management.User, error) {
 		Enabled:  &enabled,
 	}
 
-	newUser, err := users.CreateUserWithRole(client, user, "user")
+	newUser, err := users.CreateUserWithRole(client, user, role)
 	if err != nil {
 		return newUser, err
 	}
-
 	newUser.Password = user.Password
 	return newUser, err
 }
@@ -79,8 +97,76 @@ func createProject(client *rancher.Client, clusterID string) (createProject *man
 		ClusterID: clusterID,
 		Name:      projectName,
 	}
-
 	createProject, err = client.Management.Project.Create(projectConfig)
 	return createProject, err
+}
 
+func getPSALabels(response *v1.SteveAPIObject, actualLabels map[string]string) map[string]string {
+	expectedLabels := map[string]string{}
+
+	for label := range response.Labels {
+		if _, found := actualLabels[label]; found {
+			expectedLabels[label] = actualLabels[label]
+		}
+	}
+	return expectedLabels
+}
+
+func createDeploymentAndWait(steveclient *v1.Client, client *rancher.Client, clusterID string, containerName string, image string, namespaceName string) (*v1.SteveAPIObject, error) {
+	deploymentName := namegen.AppendRandomString("rbac-")
+	containerTemplate := workloads.NewContainer(containerName, image, coreV1.PullAlways, []coreV1.VolumeMount{}, []coreV1.EnvFromSource{})
+	matchLabels := map[string]string{}
+	matchLabels["workload.user.cattle.io/workloadselector"] = fmt.Sprintf("apps.deployment-%v-%v", namespaceName, deploymentName)
+
+	podTemplate := workloads.NewPodTemplate([]coreV1.Container{containerTemplate}, []coreV1.Volume{}, []coreV1.LocalObjectReference{}, matchLabels)
+	deployment := workloads.NewDeploymentTemplate(deploymentName, namespaceName, podTemplate, matchLabels)
+
+	deploymentResp, err := steveclient.SteveType(workloads.DeploymentSteveType).Create(deployment)
+	if err != nil {
+		return nil, err
+	}
+	err = kwait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+		deploymentResp, err := steveclient.SteveType(workloads.DeploymentSteveType).ByID(deployment.Namespace + "/" + deployment.Name)
+		if err != nil {
+			return false, nil
+		}
+		deployment := &appv1.Deployment{}
+		err = v1.ConvertToK8sType(deploymentResp.JSONResp, deployment)
+		if err != nil {
+			return false, nil
+		}
+		status := deployment.Status.Conditions
+		for _, statusCondition := range status {
+			if strings.Contains(statusCondition.Message, "forbidden") {
+				err = errors.New(statusCondition.Message)
+				return false, err
+			}
+		}
+		if *deployment.Spec.Replicas == deployment.Status.AvailableReplicas {
+			return true, nil
+		}
+		return false, nil
+	})
+	return deploymentResp, err
+}
+
+func getAndConverNamespace(namespace *v1.SteveAPIObject, steveAdminClient *v1.Client) (*coreV1.Namespace, error) {
+	getNSSteveObject, err := steveAdminClient.SteveType(namespaces.NamespaceSteveType).ByID(namespace.ID)
+	if err != nil {
+		return nil, err
+	}
+	namespaceObj := &coreV1.Namespace{}
+	err = v1.ConvertToK8sType(getNSSteveObject.JSONResp, namespaceObj)
+	if err != nil {
+		return nil, err
+	}
+	return namespaceObj, err
+}
+
+func deleteLabels(labels map[string]string) {
+	for label := range labels {
+		if strings.Contains(label, psaWarn) || strings.Contains(label, psaAudit) || strings.Contains(label, psaEnforce) {
+			delete(labels, label)
+		}
+	}
 }

--- a/tests/v2/validation/rbac/rbac_psa_test.go
+++ b/tests/v2/validation/rbac/rbac_psa_test.go
@@ -1,0 +1,307 @@
+package rbac
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/extensions/users"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	containerImage = "nginx"
+	containerName  = "psa-nginx"
+)
+
+type PSATestSuite struct {
+	suite.Suite
+	client              *rancher.Client
+	nonAdminUser        *management.User
+	nonAdminUserClient  *rancher.Client
+	session             *session.Session
+	cluster             *management.Cluster
+	adminProject        *management.Project
+	steveAdminClient    *v1.Client
+	steveNonAdminClient *v1.Client
+	adminNamespace      *v1.SteveAPIObject
+}
+
+func (rb *PSATestSuite) TearDownSuite() {
+	rb.session.Cleanup()
+}
+
+func (rb *PSATestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	rb.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(rb.T(), err)
+
+	rb.client = client
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(rb.T(), clusterName, "Cluster name to install should be set")
+	clusterID, err := clusters.GetClusterIDByName(rb.client, clusterName)
+	require.NoError(rb.T(), err, "Error getting cluster ID")
+	rb.cluster, err = rb.client.Management.Cluster.ByID(clusterID)
+	require.NoError(rb.T(), err)
+}
+
+func (rb *PSATestSuite) ValidatePSA(role string) {
+	labels := map[string]string{
+		psaWarn:    pssPrivilegedPolicy,
+		psaEnforce: pssPrivilegedPolicy,
+		psaAudit:   pssPrivilegedPolicy,
+	}
+
+	rb.T().Logf("Validate updating the PSA labels as %v", role)
+
+	updateNS, err := getAndConverNamespace(rb.adminNamespace, rb.steveAdminClient)
+	require.NoError(rb.T(), err)
+	updateNS.Labels = labels
+
+	response, err := rb.steveNonAdminClient.SteveType(namespaces.NamespaceSteveType).Update(rb.adminNamespace, updateNS)
+
+	switch role {
+	case restrictedAdmin, roleOwner:
+		require.NoError(rb.T(), err)
+		expectedLabels := getPSALabels(response, labels)
+		assert.Equal(rb.T(), labels, expectedLabels)
+	case roleMember, roleProjectReadOnly:
+		require.Error(rb.T(), err)
+		errMessage := strings.Split(err.Error(), ":")[0]
+		assert.Equal(rb.T(), "Resource type [namespace] is not updatable", errMessage)
+	case roleProjectOwner, roleProjectMember:
+		require.Error(rb.T(), err)
+		errStatus := strings.Split(err.Error(), ".")[1]
+		rgx := regexp.MustCompile(`\[(.*?)\]`)
+		errorMsg := rgx.FindStringSubmatch(errStatus)
+		assert.Equal(rb.T(), "403 Forbidden", errorMsg[1])
+	}
+
+	rb.T().Logf("Validate deletion of the PSA labels as %v", role)
+
+	deleteLabels(labels)
+
+	deleteLabelsNS, err := getAndConverNamespace(rb.adminNamespace, rb.steveAdminClient)
+	require.NoError(rb.T(), err)
+	deleteLabelsNS.Labels = labels
+
+	_, err = rb.steveNonAdminClient.SteveType(namespaces.NamespaceSteveType).Update(rb.adminNamespace, deleteLabelsNS)
+	switch role {
+	case restrictedAdmin, roleOwner:
+		require.NoError(rb.T(), err)
+		expectedLabels := getPSALabels(response, labels)
+		assert.Equal(rb.T(), 0, len(expectedLabels))
+		_, err = createDeploymentAndWait(rb.steveNonAdminClient, rb.client, rb.cluster.ID, containerName, containerImage, rb.adminNamespace.Name)
+		require.NoError(rb.T(), err)
+	case roleMember, roleProjectReadOnly:
+		require.Error(rb.T(), err)
+		errMessage := strings.Split(err.Error(), ":")[0]
+		assert.Equal(rb.T(), "Resource type [namespace] is not updatable", errMessage)
+	case roleProjectOwner, roleProjectMember:
+		errStatus := strings.Split(err.Error(), ".")[1]
+		rgx := regexp.MustCompile(`\[(.*?)\]`)
+		errorMsg := rgx.FindStringSubmatch(errStatus)
+		assert.Equal(rb.T(), "403 Forbidden", errorMsg[1])
+	}
+
+	rb.T().Logf("Validate creation of new namespace with PSA labels as %v", role)
+
+	labels = map[string]string{
+		psaWarn:    pssBaselinePolicy,
+		psaEnforce: pssBaselinePolicy,
+		psaAudit:   pssBaselinePolicy,
+	}
+	namespaceName := namegen.AppendRandomString("testns-")
+	namespaceCreate, err := namespaces.CreateNamespace(rb.nonAdminUserClient, namespaceName, "{}", labels, map[string]string{}, rb.adminProject)
+
+	switch role {
+	case restrictedAdmin, roleOwner:
+		require.NoError(rb.T(), err)
+		expectedLabels := getPSALabels(response, labels)
+		assert.Equal(rb.T(), labels, expectedLabels)
+		_, err = createDeploymentAndWait(rb.steveNonAdminClient, rb.client, rb.cluster.ID, containerName, containerImage, namespaceCreate.Name)
+		require.NoError(rb.T(), err)
+	case roleProjectOwner, roleProjectMember:
+		require.Error(rb.T(), err)
+		errStatus := strings.Split(err.Error(), ".")[1]
+		rgx := regexp.MustCompile(`\[(.*?)\]`)
+		errorMsg := rgx.FindStringSubmatch(errStatus)
+		assert.Equal(rb.T(), "403 Forbidden", errorMsg[1])
+	case roleMember, roleProjectReadOnly:
+		require.Error(rb.T(), err)
+		errMessage := strings.Split(err.Error(), ":")[0]
+		assert.Equal(rb.T(), "Resource type [namespace] is not creatable", errMessage)
+	}
+}
+
+func (rb *PSATestSuite) ValidateAdditionalPSA(role string) {
+	createProjectAsNonAdmin, err := createProject(rb.nonAdminUserClient, rb.cluster.ID)
+	require.NoError(rb.T(), err)
+
+	relogin, err := rb.nonAdminUserClient.ReLogin()
+	require.NoError(rb.T(), err)
+	rb.nonAdminUserClient = relogin
+
+	steveStdUserclient, err := rb.nonAdminUserClient.Steve.ProxyDownstream(rb.cluster.ID)
+	require.NoError(rb.T(), err)
+	rb.steveNonAdminClient = steveStdUserclient
+
+	namespaceName := namegen.AppendRandomString("testns-")
+	createNamespace, err := namespaces.CreateNamespace(rb.nonAdminUserClient, namespaceName, "{}",
+		map[string]string{}, map[string]string{}, createProjectAsNonAdmin)
+	require.NoError(rb.T(), err)
+
+	rb.T().Logf("Validate editing new namespace in a cluster member created project with PSA labels as %v", role)
+	labels := map[string]string{
+		psaWarn:    pssRestrictedPolicy,
+		psaEnforce: pssRestrictedPolicy,
+		psaAudit:   pssRestrictedPolicy,
+	}
+	updateNS, err := getAndConverNamespace(createNamespace, rb.steveAdminClient)
+	require.NoError(rb.T(), err)
+	updateNS.Labels = labels
+
+	relogin, err = rb.nonAdminUserClient.ReLogin()
+	require.NoError(rb.T(), err)
+	rb.nonAdminUserClient = relogin
+
+	steveStdUserclient, err = rb.nonAdminUserClient.Steve.ProxyDownstream(rb.cluster.ID)
+	require.NoError(rb.T(), err)
+	rb.steveNonAdminClient = steveStdUserclient
+
+	response, err := rb.steveNonAdminClient.SteveType(namespaces.NamespaceSteveType).Update(createNamespace, updateNS)
+
+	switch role {
+	case roleOwner:
+		require.NoError(rb.T(), err)
+		expectedLabels := getPSALabels(response, labels)
+		assert.Equal(rb.T(), labels, expectedLabels)
+		_, err = createDeploymentAndWait(rb.steveNonAdminClient, rb.client, rb.cluster.ID, containerName, containerImage, createNamespace.Name)
+		require.Error(rb.T(), err)
+	case roleMember:
+		require.Error(rb.T(), err)
+		errStatus := strings.Split(err.Error(), ".")[1]
+		rgx := regexp.MustCompile(`\[(.*?)\]`)
+		errorMsg := rgx.FindStringSubmatch(errStatus)
+		assert.Equal(rb.T(), "403 Forbidden", errorMsg[1])
+		updateNS, err := getAndConverNamespace(createNamespace, rb.steveAdminClient)
+		require.NoError(rb.T(), err)
+		updateNS.Labels = labels
+		_, err = rb.steveAdminClient.SteveType(namespaces.NamespaceSteveType).Update(createNamespace, updateNS)
+		require.NoError(rb.T(), err)
+	}
+
+	rb.T().Logf("Validate deletion of PSA labels in namespace in a cluster member created project as %v", role)
+
+	deleteLabels(labels)
+	deleteLabelsNS, err := getAndConverNamespace(createNamespace, rb.steveAdminClient)
+	require.NoError(rb.T(), err)
+	deleteLabelsNS.Labels = labels
+
+	_, err = rb.steveNonAdminClient.SteveType(namespaces.NamespaceSteveType).Update(createNamespace, deleteLabelsNS)
+
+	switch role {
+	case roleOwner:
+		require.NoError(rb.T(), err)
+		expectedLabels := getPSALabels(response, labels)
+		assert.Equal(rb.T(), labels, expectedLabels)
+		rb.T().Logf("Printing the error %v", err)
+		_, err = createDeploymentAndWait(rb.steveNonAdminClient, rb.client, rb.cluster.ID, containerName, containerImage, createNamespace.Name)
+		require.NoError(rb.T(), err)
+	case roleMember:
+		require.Error(rb.T(), err)
+		errStatus := strings.Split(err.Error(), ".")[1]
+		rgx := regexp.MustCompile(`\[(.*?)\]`)
+		errorMsg := rgx.FindStringSubmatch(errStatus)
+		assert.Equal(rb.T(), "403 Forbidden", errorMsg[1])
+	}
+}
+
+func (rb *PSATestSuite) TestPSA() {
+	nonAdminUserRoles := [...]string{roleMember, roleOwner, restrictedAdmin, roleProjectOwner, roleProjectMember, roleProjectReadOnly}
+	for _, role := range nonAdminUserRoles {
+		rb.Run("Add PSA labels on the namespaces created by admins ", func() {
+			createProjectAsAdmin, err := createProject(rb.client, rb.cluster.ID)
+			rb.adminProject = createProjectAsAdmin
+			require.NoError(rb.T(), err)
+
+			steveAdminClient, err := rb.client.Steve.ProxyDownstream(rb.cluster.ID)
+			require.NoError(rb.T(), err)
+			rb.steveAdminClient = steveAdminClient
+			namespaceName := namegen.AppendRandomString("testns-")
+			labels := map[string]string{
+				psaWarn:    pssRestrictedPolicy,
+				psaEnforce: pssRestrictedPolicy,
+				psaAudit:   pssRestrictedPolicy,
+			}
+			adminNamespace, err := namespaces.CreateNamespace(rb.client, namespaceName+"-admin", "{}", labels, map[string]string{}, rb.adminProject)
+			require.NoError(rb.T(), err)
+			expectedPSALabels := getPSALabels(adminNamespace, labels)
+			assert.Equal(rb.T(), labels, expectedPSALabels)
+			rb.adminNamespace = adminNamespace
+			_, err = createDeploymentAndWait(rb.steveAdminClient, rb.client, rb.cluster.ID, containerName, containerImage, rb.adminNamespace.Name)
+			require.Error(rb.T(), err)
+		})
+
+		rb.Run("Create a user with global role "+role, func() {
+			var userRole string
+			if role == restrictedAdmin {
+				userRole = restrictedAdmin
+			} else {
+				userRole = standardUser
+			}
+			newUser, err := createUser(rb.client, userRole)
+			require.NoError(rb.T(), err)
+			rb.nonAdminUser = newUser
+			rb.T().Logf("Created user: %v", rb.nonAdminUser.Username)
+			rb.nonAdminUserClient, err = rb.client.AsUser(newUser)
+			require.NoError(rb.T(), err)
+
+			subSession := rb.session.NewSession()
+			defer subSession.Cleanup()
+
+			log.Info("Adding user as " + role + " to the downstream cluster.")
+			if role != restrictedAdmin {
+				if strings.Contains(role, "project") || role == roleProjectReadOnly {
+					err := users.AddProjectMember(rb.client, rb.adminProject, rb.nonAdminUser, role)
+					require.NoError(rb.T(), err)
+				} else {
+					err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.nonAdminUser, role)
+					require.NoError(rb.T(), err)
+				}
+				rb.nonAdminUserClient, err = rb.nonAdminUserClient.ReLogin()
+				require.NoError(rb.T(), err)
+			}
+
+			steveClient, err := rb.nonAdminUserClient.Steve.ProxyDownstream(rb.cluster.ID)
+			require.NoError(rb.T(), err)
+			rb.steveNonAdminClient = steveClient
+		})
+
+		rb.Run("Testcase - Validate if members with roles "+role+"can add/edit/delete labesl from admin created namespace", func() {
+			rb.ValidatePSA(role)
+		})
+
+		if strings.Contains(role, "cluster") {
+			rb.Run("Additional testcase - Validate if members with roles "+role+"can add/edit/delete labels from admin created namespace", func() {
+				rb.ValidateAdditionalPSA(role)
+			})
+		}
+	}
+}
+
+func TestPSATestSuite(t *testing.T) {
+	suite.Run(t, new(PSATestSuite))
+}

--- a/tests/v2/validation/rbac/rbac_test.go
+++ b/tests/v2/validation/rbac/rbac_test.go
@@ -344,7 +344,7 @@ func (rb *RBTestSuite) TestRBAC() {
 	}
 	for _, tt := range tests {
 		rb.Run("Set up User with Cluster Role "+tt.name, func() {
-			newUser, err := createUser(rb.client)
+			newUser, err := createUser(rb.client, standardUser)
 			require.NoError(rb.T(), err)
 			rb.standardUser = newUser
 			rb.T().Logf("Created user: %v", rb.standardUser.Username)
@@ -404,7 +404,6 @@ func (rb *RBTestSuite) TestRBAC() {
 
 		rb.Run("Testcase3 - Validating if members with role "+tt.name+" is able to create a project in the cluster", func() {
 			rb.ValidateCreateProjects(tt.role)
-
 		})
 
 		rb.Run("Testcase 4 through 6 - Validate namespaces checks for members with role "+tt.name, func() {
@@ -414,7 +413,7 @@ func (rb *RBTestSuite) TestRBAC() {
 		if strings.Contains(tt.role, "project") {
 			rb.Run("Testcase7 - Validating if member with role "+tt.name+" can add members to the cluster", func() {
 				//Set up additional user client to be added to the project
-				additionalUser, err := createUser(rb.client)
+				additionalUser, err := createUser(rb.client, standardUser)
 				require.NoError(rb.T(), err)
 				rb.additionalUser = additionalUser
 				rb.additionalUserClient, err = rb.client.AsUser(rb.additionalUser)
@@ -423,10 +422,9 @@ func (rb *RBTestSuite) TestRBAC() {
 				rb.ValidateAddClusterRoles(tt.role)
 			})
 
-			rb.Run("Testcase8 - Validating if member with role "+tt.name+" can add members to the cluster", func() {
+			rb.Run("Testcase8 - Validating if member with role "+tt.name+" can add members to the project", func() {
 				rb.ValidateAddProjectRoles(tt.role)
 			})
-
 		}
 
 		rb.Run("Testcase9 - Validating if member with role "+tt.name+" can delete a project they are not owner of ", func() {
@@ -446,7 +444,7 @@ func (rb *RBTestSuite) TestRBAC() {
 
 func (rb *RBTestSuite) TestRBACAdditional() {
 	rb.Run("Set up User with cluster Role for additional rbac test cases "+roleOwner, func() {
-		newUser, err := createUser(rb.client)
+		newUser, err := createUser(rb.client, standardUser)
 		require.NoError(rb.T(), err)
 		rb.standardUser = newUser
 		rb.T().Logf("Created user: %v", rb.standardUser.Username)
@@ -464,7 +462,7 @@ func (rb *RBTestSuite) TestRBACAdditional() {
 		require.NoError(rb.T(), err)
 
 		//Setting up an additional user for the additional rbac cases
-		additionalUser, err := createUser(rb.client)
+		additionalUser, err := createUser(rb.client, standardUser)
 		require.NoError(rb.T(), err)
 		rb.additionalUser = additionalUser
 		rb.additionalUserClient, err = rb.client.AsUser(rb.additionalUser)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/qa-tasks/issues/543

## Problem
In this PR we are covering the RBAC cases for the new feature PSA.  

## Solution
PodSecurityAdmission is a new feature in k8s where we allow cluster owners/admins to configure a few labels to capture pod security. Other members such as Project owner/cluster member/Project members/Project read-only permissions should not be able to configure the labels at namespace level. This only fixes the namespace level permissions and not project level permissions.
 
