### PR TITLE
Add dynamic schema spec to machine pools

### DIFF
--- a/pkg/apis/provisioning.cattle.io/v1/rke.go
+++ b/pkg/apis/provisioning.cattle.io/v1/rke.go
@@ -28,6 +28,7 @@ type RKEMachinePool struct {
 	MaxUnhealthy                 *string                      `json:"maxUnhealthy,omitempty"`
 	UnhealthyRange               *string                      `json:"unhealthyRange,omitempty"`
 	MachineOS                    string                       `json:"machineOS,omitempty"`
+	DynamicSchemaSpec            string                       `json:"dynamicSchemaSpec,omitempty"`
 }
 
 type RKEMachinePoolRollingUpdate struct {


### PR DESCRIPTION
CI won't pass for https://github.com/rancher/rancher/pull/40730 until the apis are updated and pulled into the webhook.