### PR TITLE
Add new scripts folder for standalone scripts

### DIFF
--- a/tests/scripts/prime/compare-registry.sh
+++ b/tests/scripts/prime/compare-registry.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+RANCHER_IMAGES_PATH="$(pwd)/rancher-images.txt"
+RANCHER_MISSING_IMAGES_PATH="$(pwd)/missing-images.txt"
+SCAN_REGISTRY_PATH="$(pwd)/scan-registry.sh"
+DOCKER_IMAGES_PATH="$(pwd)/docker-hub-existing-images.txt"
+USER_REGISTRY_IMAGES_PATH="$(pwd)/user-existing-images.txt"
+DOCKER_REGISTRY="docker.io/"
+RANCHER_VERSION="$1"
+USER_REGISTRY="$2"
+
+prereq() {
+    echo -e "\nInstalling skopeo tool..."
+    if skopeo -v > /dev/null 2>&1; then
+        echo -e "\nSkopeo is already installed!"
+    else
+        . /etc/os-release
+
+        # Ubuntu 20.10 or higher are needed for skopeo.
+        [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install skopeo
+        [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install skopeo -y
+        [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y skopeo
+    fi
+}
+
+scanRegistries() {
+    echo -e "\nPulling rancher-images.txt file..."
+    wget https://github.com/rancher/rancher/releases/download/"${RANCHER_VERSION}"/rancher-images.txt
+
+    echo -e "\nRunning scan-registry.sh against Docker Hub..."
+    "${SCAN_REGISTRY_PATH}" -l "$(pwd)/rancher-images.txt" -r "${DOCKER_REGISTRY}" >> "${DOCKER_IMAGES_PATH}"
+
+    echo -e "\nRunning scan-registry.sh against specified registry..."
+    "${SCAN_REGISTRY_PATH}" -l "$(pwd)/rancher-images.txt" -r "${USER_REGISTRY}" >> "${USER_REGISTRY_IMAGES_PATH}"
+}
+
+compareResults() {
+    echo -e "\nComparing the results..."
+    comm -13 <(sort -u "${DOCKER_IMAGES_PATH}" | cut -d ' ' -f1) <(sort -u "${USER_REGISTRY_IMAGES_PATH}"| cut -d ' ' -f1) >> "${RANCHER_MISSING_IMAGES_PATH}"
+    sed -i '/^$/d' "${RANCHER_MISSING_IMAGES_PATH}"
+
+    echo -e "\nImages that are missing in user specified registry:"
+    if [[ ! -s "${RANCHER_MISSING_IMAGES_PATH}" ]]; then
+        echo -e "\nNo missing images in your registry!"
+    else
+        cat "${RANCHER_MISSING_IMAGES_PATH}"
+    fi
+}
+
+usage() {
+	cat << EOF
+
+$(basename "$0")
+
+This script will run the scan-registry.sh two times; once with the Docker Hub registry and once with the specified
+
+registry. Once done, it will compare the results and list the images that are missing in the user specified registry. 
+
+When running the script, specify the Rancher version, prefixed with a leading 'v' and the registry to compare against 
+
+Docker, suffixed with a trailing slash.
+
+USAGE: % ./$(basename "$0") [options]
+
+OPTIONS:
+    -h          -> Usage
+
+EXAMPLES OF USAGE:
+
+* Run script
+	
+	$ ./$(basename "$0") v<Rancher version> <registry>/
+
+EOF
+}
+
+while getopts "h" opt; do
+	case ${opt} in
+		h)
+			usage
+			exit 0;;
+    esac
+done
+
+Main() {
+    prereq
+    scanRegistries
+    compareResults
+}
+
+Main "$@"

--- a/tests/scripts/prime/scan-registry.sh
+++ b/tests/scripts/prime/scan-registry.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+LIST="rancher-images.txt"
+MISSING_IMAGES=""
+
+scanRegistry() {
+    while IFS= read -r i; do
+        [ -z "${i}" ] && continue
+        if inspect=$(skopeo inspect --raw docker://${REGISTRY_NAME}${i} | egrep '(digest|os|arch)') > /dev/null 2>&1; then
+            echo "${i} - ${inspect}"
+        else
+	        MISSING_IMAGES="${MISSING_IMAGES}\n${i}"
+        fi
+    done < "${list}"
+
+    if [[ ${MISSING_IMAGES} ]]; then
+        echo -e "\nThe following images were missing in registry ${REGISTRY_NAME}:"
+        echo -e "\n${MISSING_IMAGES}" - "${inspect}"
+    else
+        echo -e "\nNo missing images in your registry!"
+    fi
+}
+
+usage() {
+	cat << EOF
+
+$(basename "$0")
+
+This script will scan a specified repository for Rancher images and list images that are not found.
+
+USAGE: % ./$(basename "$0") [options]
+
+OPTIONS:
+    -h	                -> Usage
+    -l | --image-list   -> Path to text file with list of images
+    -r | --registry     -> Registry to use
+
+EXAMPLES OF USAGE:
+
+* Run script
+	
+    $ ./$(basename "$0") -l rancher-images.txt -r docker.io/
+
+EOF
+}
+
+Main() {
+    POSITIONAL=()
+    while [[ $# -gt 0 ]]; do
+        key="$1"
+        case $key in
+            -r|--registry)
+                REGISTRY_NAME="$2"
+                shift
+                shift
+                ;;
+            -l|--image-list)
+                list="$2"
+                shift
+                shift
+                ;;
+            -h|--help)
+                help="true"
+                shift
+                ;;
+            *)
+                usage
+                exit 1
+                ;;
+        esac
+    done
+
+    if [[ $help ]]; then
+        usage
+        exit 0
+    fi
+
+    scanRegistry
+}
+
+Main "$@"

--- a/tests/scripts/rollback/rollback-rancher.sh
+++ b/tests/scripts/rollback/rollback-rancher.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/bash
+
+ROLLBACK_VERSION="$1"
+RANCHER="rancher/rancher"
+ROLLBACK_IMAGE_TAG="${RANCHER}:$ROLLBACK_VERSION"
+CONTAINER_ID=`docker ps | awk 'NR > 1 {print $1}'`
+DATA_CONTAINER="rancher-data"
+VARLIB="/var/lib/rancher"
+BACKUP="/backup/${DATA_CONTAINER}-${ROLLBACK_VERSION}.tar.gz"
+
+rollbackRancher() {
+    echo -e "\nStopping Rancher..."
+    docker stop "${CONTAINER_ID}"
+
+    echo -e "\nPulling old Rancher image..."
+    docker pull "${ROLLBACK_IMAGE_TAG}"
+
+    echo -e "\nReplacing data in ${DATA_CONTAINER} with the data in ${BACKUP}..."
+    docker run --volumes-from "${DATA_CONTAINER}" -v ${PWD}:/backup busybox sh -c "rm ${VARLIB}/* -rf && tar zxvf ${BACKUP}"
+
+    echo -e "\nStarting Rancher..."
+    docker run -d --volumes-from "${DATA_CONTAINER}" --restart=unless-stopped \
+                                                     -p 80:80 -p 443:443 \
+                                                     --privileged "${ROLLBACK_IMAGE_TAG}"
+}
+
+usage() {
+	cat << EOF
+
+$(basename "$0")
+
+This script will rollback Rancher API Server using Docker. This script assumes the following:
+
+    * Rancher is running in a Docker container
+    * Docker is installed and script user is in the docker group
+    * The upgrade.sh script has been run before this one
+
+When running the script, specify the version of Rancher to rollback to, prefixed with a leading 'v'.
+
+USAGE: % ./$(basename "$0") [options]
+
+OPTIONS:
+	-h	-> Usage
+
+EXAMPLES OF USAGE:
+
+* Run script
+	
+	$ ./$(basename "$0") v<version to rollback to>
+
+EOF
+}
+
+while getopts "h" opt; do
+	case ${opt} in
+		h)
+			usage
+			exit 0;;
+    esac
+done
+
+Main() {
+    rollbackRancher
+}
+
+Main "$@"

--- a/tests/scripts/upgrade/upgrade-rancher.sh
+++ b/tests/scripts/upgrade/upgrade-rancher.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/bash
+
+OLD_VERSION="$1"
+NEW_VERSION="$2"
+RANCHER="rancher/rancher"
+OLD_IMAGE_TAG="${RANCHER}:${OLD_VERSION}"
+NEW_IMAGE_TAG="${RANCHER}:${NEW_VERSION}"
+CONTAINER_ID=`docker ps | awk 'NR > 1 {print $1}'`
+DATA_CONTAINER="rancher-data"
+VARLIB="/var/lib/rancher"
+BACKUP="/backup/${DATA_CONTAINER}-${OLD_VERSION}.tar.gz"
+
+upgradeRancher() {
+    echo -e "\nStopping Rancher and creating a data container..."
+    docker stop "${CONTAINER_ID}"
+    docker create --volumes-from "${CONTAINER_ID}" --name "${DATA_CONTAINER}" "${OLD_IMAGE_TAG}"
+
+    echo -e "\nCreating a backup tarball..."
+    docker run --volumes-from "${DATA_CONTAINER}" -v "${PWD}:/backup" --rm busybox tar zcvf "${BACKUP}" "${VARLIB}"
+
+    echo -e "\nPulling new Rancher image..."
+    docker pull "${NEW_IMAGE_TAG}"
+
+    echo -e "\nStarting Rancher..."
+    docker run -d --volumes-from "${DATA_CONTAINER}" --restart=unless-stopped \
+                                                     -p 80:80 -p 443:443 \
+                                                     --privileged "${NEW_IMAGE_TAG}"
+}
+
+usage() {
+	cat << EOF
+
+$(basename "$0")
+
+This script will upgrade Rancher API Server using Docker. This script assumes the following:
+
+    * Rancher is running in a Docker container
+    * Docker is installed and script user is in the docker group
+
+When running the script, specify the current Rancher version and the upgraded Rancher version.
+
+Both need to be prefixed with a leading 'v'.
+
+USAGE: % ./$(basename "$0") [options]
+
+OPTIONS:
+	-h	-> Usage
+
+EXAMPLES OF USAGE:
+
+* Run script
+	
+	$ ./$(basename "$0") v<current Rancher version> v<upgraded Rancher version>
+
+EOF
+}
+
+while getopts "h" opt; do
+	case ${opt} in
+		h)
+			usage
+			exit 0;;
+    esac
+done
+
+Main() {
+    upgradeRancher
+}
+
+Main "$@"


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Create new rancher/rancher/tests/scripts for standalone scripts for release testing/QA tasks](https://github.com/rancher/qa-tasks/issues/642)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Currently, there are a number of different standalone scripts that are spread out throughout different local machines amongst QA. These particular scripts are used in release testing and validation checks. The owner of those scripts is typically the one who runs the scripts, but if they are not around and the scripts are needed, it's a chore having to track the automation down.

There needs to be a central location for more individuals to access the scripts, this way, more individuals can run various release checks easier.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Created a new `rancher/rancher/test/scripts` folder that will host the standalone scripts. To start off, I shared the following folders/scripts:

- `upgrade/upgrade-rancher.sh` -> Upgrade a Docker installation of Rancher
- `rollback/rollback-rancher.sh` -> Rollback Rancher to a previous installation (assumes you ran `upgrade.sh` first)
- `prime/scan-registry.sh` & `prime/compare-registry.sh` -> Compares images for a specified Rancher release between Docker and a specified registry

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
**Upgrade**
- Setup Docker installation of `v2.7.0` and ran `./upgrade-rancher.sh v2.7.1` to upgrade to Rancher v2.7.1; this was successful.

**Rollback**
- Following the results of the `upgrade-rancher.sh` above, ran `rollback-rancher.sh v2.7.0` to rollback to Rancher v2.7.0; this was successful.

**Registry checks**
- Ran `./compare-registry.sh v2.7.0 <registry>/`; this was successful.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Long term, we are looking to put this into Jenkins, but for now, we're keeping in this location.