### PR TITLE
newimage for sidekick backport

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -46,7 +46,7 @@ TEST_OS = os.environ.get('RANCHER_TEST_OS', "linux")
 TEST_IMAGE = os.environ.get(
     'RANCHER_TEST_IMAGE', "ranchertest/mytestcontainer")
 TEST_IMAGE_PORT = os.environ.get('RANCHER_TEST_IMAGE_PORT', "80")
-TEST_IMAGE_NGINX = os.environ.get('RANCHER_TEST_IMAGE_NGINX', "nginx")
+TEST_IMAGE_REDIS = os.environ.get('RANCHER_TEST_IMAGE_REDIS', "redis:latest")
 TEST_IMAGE_OS_BASE = os.environ.get('RANCHER_TEST_IMAGE_OS_BASE', "ubuntu")
 if TEST_OS == "windows":
     DEFAULT_TIMEOUT = 300

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_rke2_upgrade
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_rke2_upgrade
@@ -22,7 +22,7 @@ def needs_cluster(py_options, upgrade_check, create_resource_prefix) {
           string(name: 'RANCHER_TEST_IMAGE', value: "${RANCHER_TEST_IMAGE}"),
           string(name: 'RANCHER_TEST_IMAGE_PORT', value: "${RANCHER_TEST_IMAGE_PORT}"),
           string(name: 'RANCHER_HARDENED_CLUSTER', value: "${RANCHER_HARDENED_CLUSTER}"),
-          string(name: 'RANCHER_TEST_IMAGE_NGINX', value: "${RANCHER_TEST_IMAGE_NGINX}"),
+          string(name: 'RANCHER_TEST_IMAGE_REDIS', value: "${RANCHER_TEST_IMAGE_REDIS}"),
         ]
         echo "Params are: ${params}"
         jobs["test-${i}"] = { build job: 'rancher-v3_needs_cluster', parameters: params }

--- a/tests/validation/tests/v3_api/test_airgap.py
+++ b/tests/validation/tests/v3_api/test_airgap.py
@@ -6,7 +6,7 @@ import time
 from lib.aws import AWS_USER
 from .common import (
     ADMIN_PASSWORD, AmazonWebServices, run_command, wait_for_status_code,
-    TEST_IMAGE, TEST_IMAGE_NGINX, TEST_IMAGE_OS_BASE, readDataFile,
+    TEST_IMAGE, TEST_IMAGE_REDIS, TEST_IMAGE_OS_BASE, readDataFile,
     DEFAULT_CLUSTER_STATE_TIMEOUT, compare_versions
 )
 from .test_custom_host_reg import (
@@ -23,7 +23,7 @@ PRIVATE_REGISTRY_PASSWORD = \
 BASTION_ID = os.environ.get("RANCHER_BASTION_ID", "")
 NUMBER_OF_INSTANCES = int(os.environ.get("RANCHER_AIRGAP_INSTANCE_COUNT", "1"))
 IMAGE_LIST = os.environ.get("RANCHER_IMAGE_LIST", ",".join(
-    [TEST_IMAGE, TEST_IMAGE_NGINX, TEST_IMAGE_OS_BASE])).split(",")
+    [TEST_IMAGE, TEST_IMAGE_REDIS, TEST_IMAGE_OS_BASE])).split(",")
 TARBALL_TYPE = os.environ.get("K3S_TARBALL_TYPE", "tar.gz")
 ARCH = os.environ.get("K3S_ARCH", "amd64")
 

--- a/tests/validation/tests/v3_api/test_service_discovery.py
+++ b/tests/validation/tests/v3_api/test_service_discovery.py
@@ -35,7 +35,7 @@ from .common import rbac_get_user_token_by_role
 from .common import rbac_get_workload
 from .common import skip_test_windows_os
 from .common import TEST_IMAGE
-from .common import TEST_IMAGE_NGINX
+from .common import TEST_IMAGE_REDIS
 from .common import time
 from .common import USER_TOKEN
 from .common import validate_dns_record
@@ -172,7 +172,7 @@ def test_service_discovery_when_workload_upgrade():
 
     # upgrade
     con = [{"name": "test1",
-            "image": TEST_IMAGE_NGINX}]
+            "image": TEST_IMAGE_REDIS}]
     update_and_validate_workload(workload, con, scale)
     # test service discovery
     time.sleep(DNS_RESOLUTION_DEFAULT_SECONDS)
@@ -262,7 +262,7 @@ def test_dns_record_type_workload_when_workload_upgrade():
 
     # upgrade the workload
     con = [{"name": "test1",
-            "image": TEST_IMAGE_NGINX}]
+            "image": TEST_IMAGE_REDIS}]
     update_and_validate_workload(workload, con, scale)
     # test service discovery
     time.sleep(DNS_RESOLUTION_DEFAULT_SECONDS)

--- a/tests/validation/tests/v3_api/test_windows_cluster.py
+++ b/tests/validation/tests/v3_api/test_windows_cluster.py
@@ -1,5 +1,5 @@
 from .common import TEST_IMAGE
-from .common import TEST_IMAGE_NGINX
+from .common import TEST_IMAGE_REDIS
 from .common import TEST_IMAGE_OS_BASE
 from .common import cluster_cleanup
 from .common import get_user_client
@@ -61,7 +61,7 @@ def pull_images(node):
     print("Pulling images on node: " + node.host_name)
     pull_result = node.execute_command("docker pull " + TEST_IMAGE
                                        + " && " +
-                                       "docker pull " + TEST_IMAGE_NGINX
+                                       "docker pull " + TEST_IMAGE_REDIS
                                        + " && " +
                                        "docker pull " + TEST_IMAGE_OS_BASE)
     print(pull_result)

--- a/tests/validation/tests/v3_api/test_workload.py
+++ b/tests/validation/tests/v3_api/test_workload.py
@@ -32,7 +32,7 @@ def test_wl_sidekick():
     validate_workload(p_client, workload, "deployment", ns.name)
 
     side_con = {"name": "test2",
-                "image": TEST_IMAGE_NGINX,
+                "image": TEST_IMAGE_REDIS,
                 "stdin": True,
                 "tty": True}
     con.append(side_con)
@@ -121,16 +121,16 @@ def test_wl_upgrade():
             firstrevision = revision.id
 
     con = [{"name": "test1",
-            "image": TEST_IMAGE_NGINX}]
+            "image": TEST_IMAGE_REDIS}]
     p_client.update(workload, containers=con)
-    wait_for_pod_images(p_client, workload, ns.name, TEST_IMAGE_NGINX, 2)
+    wait_for_pod_images(p_client, workload, ns.name, TEST_IMAGE_REDIS, 2)
     wait_for_pods_in_workload(p_client, workload, 2)
     validate_workload(p_client, workload, "deployment", ns.name, 2)
-    validate_workload_image(p_client, workload, TEST_IMAGE_NGINX, ns)
+    validate_workload_image(p_client, workload, TEST_IMAGE_REDIS, ns)
     revisions = workload.revisions()
     assert len(revisions) == 2
     for revision in revisions:
-        if revision["containers"][0]["image"] == TEST_IMAGE_NGINX:
+        if revision["containers"][0]["image"] == TEST_IMAGE_REDIS:
             secondrevision = revision.id
 
     con = [{"name": "test1",
@@ -155,10 +155,10 @@ def test_wl_upgrade():
     validate_workload_image(p_client, workload, TEST_IMAGE, ns)
 
     p_client.action(workload, "rollback", replicaSetId=secondrevision)
-    wait_for_pod_images(p_client, workload, ns.name, TEST_IMAGE_NGINX, 2)
+    wait_for_pod_images(p_client, workload, ns.name, TEST_IMAGE_REDIS, 2)
     wait_for_pods_in_workload(p_client, workload, 2)
     validate_workload(p_client, workload, "deployment", ns.name, 2)
-    validate_workload_image(p_client, workload, TEST_IMAGE_NGINX, ns)
+    validate_workload_image(p_client, workload, TEST_IMAGE_REDIS, ns)
 
     p_client.action(workload, "rollback", replicaSetId=thirdrevision)
     wait_for_pod_images(p_client, workload, ns.name, TEST_IMAGE_OS_BASE, 2)
@@ -242,14 +242,14 @@ def test_wl_pause_orchestration():
     p_client.action(workload, "pause")
     validate_workload_paused(p_client, workload, True)
     con = [{"name": "test1",
-            "image": TEST_IMAGE_NGINX}]
+            "image": TEST_IMAGE_REDIS}]
     p_client.update(workload, containers=con)
     validate_pod_images(TEST_IMAGE, workload, ns.name)
     p_client.action(workload, "resume")
     workload = wait_for_wl_to_active(p_client, workload)
     wait_for_pods_in_workload(p_client, workload, 2)
     validate_workload_paused(p_client, workload, False)
-    validate_pod_images(TEST_IMAGE_NGINX, workload, ns.name)
+    validate_pod_images(TEST_IMAGE_REDIS, workload, ns.name)
 
 
 # Windows could not support host port for now.


### PR DESCRIPTION
Forward port PR - https://github.com/rancher/rancher/pull/40855

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/491

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Sidekick test fails to start nginx container along with ranchertest/mytestcontainer due to port 80 is already occupied.  
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This PR serves the purpose to fix the issue by changing from the nginx container to redis:latest container. 

