### PR TITLE
Prepare for RC6 - update the image source code origins

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -196,6 +196,8 @@ var OriginMap = map[string]string{
 	"mirrored-sig-storage-csi-provisioner":                    "https://github.com/kubernetes-csi/external-provisioner",
 	"mirrored-sig-storage-csi-resizer":                        "https://github.com/kubernetes-csi/external-resizer",
 	"mirrored-sig-storage-livenessprobe":                      "https://github.com/kubernetes-csi/livenessprobe",
+	"mirrored-sig-storage-snapshot-controller":                "https://github.com/kubernetes-csi/external-snapshotter",
+	"mirrored-sig-storage-snapshot-validation-webhook":        "https://github.com/kubernetes-csi/external-snapshotter",
 	"mirrored-sigwindowstools-k8s-gmsa-webhook":               "https://github.com/kubernetes-sigs/windows-gmsa/tree/master/admission-webhook",
 	"mirrored-sonobuoy-sonobuoy":                              "https://github.com/vmware-tanzu/sonobuoy",
 	"mirrored-thanos-thanos":                                  "https://github.com/thanos-io/thanos",


### PR DESCRIPTION
This is to fix the error in this CI build https://drone-publish.rancher.io/rancher/rancher/9282/3/2

Add the image source code origins for the following two new images 
- mirrored-sig-storage-snapshot-controller 
- mirrored-sig-storage-snapshot-controller-webhook 

They are from the new charts introduced and used  by RKE2 (https://github.com/rancher/rke2-charts/pull/303) 