### PR TITLE
Log waiting for dynamic schema instead of error

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -182,7 +182,7 @@ func (h *handler) OnChange(_ string, cluster *rancherv1.Cluster) (*rancherv1.Clu
 			continue
 		}
 		// if the field is empty or invalid, add to any machine pools that do not have it and update the cluster
-		cluster = cluster.DeepCopy()
+		clusterCopy := cluster.DeepCopy()
 		for j := i; j < len(cluster.Spec.RKEConfig.MachinePools); j++ {
 			machinePool := cluster.Spec.RKEConfig.MachinePools[j]
 			spec = apimgmtv3.DynamicSchemaSpec{}
@@ -201,9 +201,9 @@ func (h *handler) OnChange(_ string, cluster *rancherv1.Cluster) (*rancherv1.Clu
 			if err != nil {
 				return cluster, err
 			}
-			cluster.Spec.RKEConfig.MachinePools[j].DynamicSchemaSpec = string(specJSON)
+			clusterCopy.Spec.RKEConfig.MachinePools[j].DynamicSchemaSpec = string(specJSON)
 		}
-		return h.clusterController.Update(cluster)
+		return h.clusterController.Update(clusterCopy)
 	}
 	return cluster, nil
 }

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/template.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/wrangler/pkg/data"
 	"github.com/rancher/wrangler/pkg/data/convert"
 	v1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"github.com/rancher/wrangler/pkg/generic"
 	"github.com/rancher/wrangler/pkg/gvk"
 	"github.com/rancher/wrangler/pkg/name"
 	"github.com/sirupsen/logrus"
@@ -144,7 +145,8 @@ func toMachineTemplate(machinePoolName string, cluster *rancherv1.Cluster, machi
 	}
 
 	if machinePool.DynamicSchemaSpec == "" {
-		return nil, fmt.Errorf("waiting for dynamic schema to be populated for machine pool %s", machinePoolName)
+		logrus.Debugf("rkecluster %s/%s: waiting for dynamic schema to be populated for machine pool %s", cluster.Namespace, cluster.Name, machinePoolName)
+		return nil, generic.ErrSkip
 	}
 	var spec v3.DynamicSchemaSpec
 	err = json.Unmarshal([]byte(machinePool.DynamicSchemaSpec), &spec)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/40886
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

An error was shown on the cluster immediately after creation while another controller was waiting to populate the dynamic schema.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Log a debug message instead and skip reconciliation.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually, no error and cluster provisioned successfully.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

Just CI

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
N/A

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

N/A