### PR TITLE
Reset an auth config's fields when admins disable it through API

### DIFF
--- a/pkg/auth/providers/common/actions.go
+++ b/pkg/auth/providers/common/actions.go
@@ -20,14 +20,8 @@ func HandleCommonAction(actionName string, action *types.Action, request *types.
 		config := u.UnstructuredContent()
 		if e, ok := config[client.AuthConfigFieldEnabled].(bool); ok && e {
 			config[client.AuthConfigFieldEnabled] = false
-			retainFields := map[string]bool{"apiVersion": true, "kind": true, "metadata": true, "type": true}
-			for field := range config {
-				if !retainFields[field] {
-					delete(config, field)
-				}
-			}
-			logrus.Infof("Disabling auth provider %v", authConfigName)
-			_, err := authConfigs.ObjectClient().Update(authConfigName, o)
+			logrus.Infof("Disabling auth provider %s from the action.", authConfigName)
+			_, err = authConfigs.ObjectClient().Update(authConfigName, o)
 			return true, err
 		}
 	}

--- a/pkg/controllers/management/auth/auth_config_test.go
+++ b/pkg/controllers/management/auth/auth_config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/norman/objectclient"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	azuread "github.com/rancher/rancher/pkg/auth/providers/azure/clients"
+	"github.com/rancher/rancher/pkg/auth/providers/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
@@ -120,7 +121,67 @@ func TestCleanupRuns(t *testing.T) {
 	}
 }
 
+func TestAuthConfigReset(t *testing.T) {
+	t.Parallel()
+
+	allFields := []string{"accessMode", "allowedPrincipalIds", "apiVersion", "kind", "metadata", "type"}
+	postResetFields := []string{"apiVersion", "kind", "metadata", "type"}
+
+	tests := []struct {
+		annotationValue string
+		retainedFields  []string
+	}{
+		{CleanupRancherLocked, allFields},
+		{CleanupUserLocked, allFields},
+		{CleanupUnlocked, postResetFields},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.annotationValue, func(t *testing.T) {
+			t.Parallel()
+			config := v3.AuthConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Auth Config",
+					APIVersion: "management.cattle.io/v3",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        github.Name,
+					Annotations: map[string]string{CleanupAnnotation: test.annotationValue},
+				},
+				Type:                "githubConfig",
+				Enabled:             false,
+				AccessMode:          "unrestricted",
+				AllowedPrincipalIDs: []string{"user1", "user2"},
+			}
+
+			mockUsers := newMockUserLister()
+			controller := authConfigController{
+				cleanup:                 new(cleanupService),
+				authConfigsUnstructured: newMockAuthConfigClient(&config),
+				users:                   &mockUsers,
+			}
+
+			_, err := controller.sync("test", &config)
+			require.NoError(t, err)
+			u, err := controller.getUnstructured(&config)
+			require.NoError(t, err)
+
+			cfg := u.UnstructuredContent()
+			assert.Equal(t, len(test.retainedFields), len(cfg))
+			for _, field := range test.retainedFields {
+				assert.Contains(t, cfg, field)
+			}
+		})
+	}
+}
+
 func TestAuthConfigSync(t *testing.T) {
+	config := v3.AuthConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: github.Name,
+		},
+	}
 	tests := []struct {
 		name                    string
 		usernamesForTestConfig  []string
@@ -178,7 +239,12 @@ func TestAuthConfigSync(t *testing.T) {
 			}
 
 			mockRefresher := newMockAuthProvider()
-			controller := authConfigController{users: &mockUsers, authRefresher: &mockRefresher, cleanup: &fakeCleanupService{}}
+			controller := authConfigController{
+				users:                   &mockUsers,
+				authRefresher:           &mockRefresher,
+				cleanup:                 &fakeCleanupService{},
+				authConfigsUnstructured: newMockAuthConfigClient(&config),
+			}
 			config := v3.AuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: testConfigName,
@@ -215,13 +281,13 @@ func newMockUserLister() mockUserLister {
 	}
 }
 
-func (m *mockUserLister) List(namespace string, selector labels.Selector) (ret []*v3.User, err error) {
+func (m *mockUserLister) List(_ string, _ labels.Selector) (ret []*v3.User, err error) {
 	if m.listUsersErr != nil {
 		return nil, m.listUsersErr
 	}
 	return m.users, nil
 }
-func (m *mockUserLister) Get(namespace, name string) (*v3.User, error) {
+func (m *mockUserLister) Get(_, name string) (*v3.User, error) {
 	for _, user := range m.users {
 		if user.Name == name {
 			return user, nil
@@ -311,7 +377,7 @@ func (m mockUnstructuredAuthConfig) IsList() bool {
 	panic("implement me")
 }
 
-func (m mockUnstructuredAuthConfig) EachListItem(f func(runtime.Object) error) error {
+func (m mockUnstructuredAuthConfig) EachListItem(_ func(runtime.Object) error) error {
 	//TODO implement me
 	panic("implement me")
 }
@@ -321,92 +387,109 @@ type mockAuthConfigClient struct {
 }
 
 func newMockAuthConfigClient(authConfig *v3.AuthConfig) objectclient.GenericClient {
-	return mockAuthConfigClient{config: mockUnstructuredAuthConfig{authConfig}}
+	return &mockAuthConfigClient{config: mockUnstructuredAuthConfig{authConfig}}
 }
 
-func (m mockAuthConfigClient) Get(name string, opts metav1.GetOptions) (runtime.Object, error) {
+func (m *mockAuthConfigClient) Get(_ string, _ metav1.GetOptions) (runtime.Object, error) {
 	o := unstructured.Unstructured{}
-	o.SetUnstructuredContent(map[string]any{"Object": m.config})
+	js, err := json.Marshal(m.config.config)
+	if err != nil {
+		return nil, err
+	}
+	var aMap map[string]any
+	if err = json.Unmarshal(js, &aMap); err != nil {
+		return nil, err
+	}
+	o.SetUnstructuredContent(aMap)
 	return &o, nil
 }
 
-func (m mockAuthConfigClient) Update(name string, o runtime.Object) (runtime.Object, error) {
+func (m *mockAuthConfigClient) Update(_ string, o runtime.Object) (runtime.Object, error) {
+	b, err := json.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	var cfg v3.AuthConfig
+	if err = json.Unmarshal(b, &cfg); err != nil {
+		return nil, err
+	}
+	m.config.config = &cfg
 	return o, nil
 }
 
-func (m mockAuthConfigClient) UnstructuredClient() objectclient.GenericClient {
+func (m *mockAuthConfigClient) UnstructuredClient() objectclient.GenericClient {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) GroupVersionKind() schema.GroupVersionKind {
+func (m *mockAuthConfigClient) GroupVersionKind() schema.GroupVersionKind {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) Create(o runtime.Object) (runtime.Object, error) {
+func (m *mockAuthConfigClient) Create(_ runtime.Object) (runtime.Object, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) GetNamespaced(namespace, name string, opts metav1.GetOptions) (runtime.Object, error) {
+func (m *mockAuthConfigClient) GetNamespaced(_, _ string, _ metav1.GetOptions) (runtime.Object, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) UpdateStatus(name string, o runtime.Object) (runtime.Object, error) {
+func (m *mockAuthConfigClient) UpdateStatus(_ string, _ runtime.Object) (runtime.Object, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) DeleteNamespaced(namespace, name string, opts *metav1.DeleteOptions) error {
+func (m *mockAuthConfigClient) DeleteNamespaced(_, _ string, _ *metav1.DeleteOptions) error {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) Delete(name string, opts *metav1.DeleteOptions) error {
+func (m *mockAuthConfigClient) Delete(_ string, _ *metav1.DeleteOptions) error {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) List(opts metav1.ListOptions) (runtime.Object, error) {
+func (m *mockAuthConfigClient) List(_ metav1.ListOptions) (runtime.Object, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) ListNamespaced(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
+func (m *mockAuthConfigClient) ListNamespaced(_ string, _ metav1.ListOptions) (runtime.Object, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (m *mockAuthConfigClient) Watch(_ metav1.ListOptions) (watch.Interface, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) DeleteCollection(deleteOptions *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+func (m *mockAuthConfigClient) DeleteCollection(_ *metav1.DeleteOptions, _ metav1.ListOptions) error {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) Patch(name string, o runtime.Object, patchType types.PatchType, data []byte, subresources ...string) (runtime.Object, error) {
+func (m *mockAuthConfigClient) Patch(_ string, _ runtime.Object, _ types.PatchType, _ []byte, _ ...string) (runtime.Object, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) ObjectFactory() objectclient.ObjectFactory {
+func (m *mockAuthConfigClient) ObjectFactory() objectclient.ObjectFactory {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockAuthConfigClient) ObjectClient() *objectclient.ObjectClient {
+func (m *mockAuthConfigClient) ObjectClient() *objectclient.ObjectClient {
 	//TODO implement me
 	panic("implement me")
 }
 
 type fakeCleanupService struct{}
 
-func (f *fakeCleanupService) Run(config *v3.AuthConfig) error {
+func (f *fakeCleanupService) Run(_ *v3.AuthConfig) error {
 	return nil
 }
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40878
 
## Problem
When admins disable an auth provider through the API (by editing the auth config resource or using Terraform), they switch the `enabled` field to false. Cleanup runs, but after it, the admins cannot re-enable the provider.

Our auth provider logic for all of them is such that the backend does not treat each new setup request as a new POST request. It actually looks at the current state found in an auth config. Specifically, it looks for a reference to an "application secret" (named differently for each provider), instead of **always** looking at only the secret found in the request.

If the auth config is bare, that is, has only basic metadata fields and no reference to the application secret, then the backend detects that and uses the secret in the request. But if the config is not bare and has fields, including the application secret reference, then the backend tries to read it. If it fails, setup fails. 

Because Rancher now runs resource cleanup on disabling of the auth config, the application secret is deleted, but the reference to it still exists in the auth config. Thus on next attempt to set up the **same** provider, Rancher tries to find the secret and fails.

This error case occurs because when admins simply change the `enabled` field on the auth config to false, the rest of the fields are retained, including the reference to the application secret. If they had disabled the provider by using the UI, this case would not have appeared, because the UI fires an action that makes the backend reset all fields.

## Solution
However the provider is disabled - whether through the API or proper UI action - always reset the fields on the auth config.
But honor the locking annotation - if it's set to `user-locked`, do not remove resources (as before) and also do not reset the config.

In addition, the behavior of kubectl, Terraform, and UI is made the same. If you delete the auth config from your Terraform configuration or disable it in the UI, while having the config `user-locked`, then the backend will inspect the annotation and refuse to clean up both config fields AND any resources. But it will always disable the actual provider, whether the config is locked or not. UI and Terraform both disable by making a request to the "disable" action. The backend now handles the request simply by unconditionally setting `enabled` on the config to false and updating the object. The rest is handled by our auth config controller.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
Unit and integration tests.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->