### PR TITLE
Update AKS tenant ID and GKE provider version

### DIFF
--- a/tests/validation/tests/v3_api/resource/terraform/aks/aks.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/aks/aks.tf
@@ -39,6 +39,10 @@ resource "azurerm_kubernetes_cluster" "default" {
     client_secret = "secret_placeholder"
   }
 
+  identity {
+    tenant = "tenant_placeholder"
+  }
+
   tags = {
     environment = "automation"
   }

--- a/tests/validation/tests/v3_api/resource/terraform/aks/variables.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/aks/variables.tf
@@ -1,6 +1,6 @@
 variable "kubernetes_version" {
   description = "Azure Kubernetes Cluster K8s version"
-  default = "1.23.5"
+  default = "1.24.9"
 }
 
 variable "location" {

--- a/tests/validation/tests/v3_api/test_create_ha.py
+++ b/tests/validation/tests/v3_api/test_create_ha.py
@@ -7,7 +7,7 @@ from .test_import_k3s_cluster import create_multiple_control_cluster
 from .test_import_rke2_cluster import (
     RANCHER_RKE2_VERSION, create_rke2_multiple_control_cluster
 )
-from .test_rke_cluster_provisioning import AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, rke_config
+from .test_rke_cluster_provisioning import AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, rke_config
 
 # RANCHER_HA_KUBECONFIG and RANCHER_HA_HOSTNAME are provided
 # when installing Rancher into a k3s setup
@@ -525,6 +525,7 @@ def create_aks_cluster():
     aks_location = os.environ.get('RANCHER_AKS_LOCATION', '')
     client_id = os.environ.get('AZURE_CLIENT_ID', '')
     client_secret = os.environ.get('AZURE_CLIENT_SECRET', '')
+    tenant_id = os.environ.get('AZURE_TENANT_ID', '')
 
     tf = Terraform(working_dir=tf_dir,
                    variables={'kubernetes_version': aks_k8_s_version,
@@ -536,6 +537,7 @@ def create_aks_cluster():
     config = readDataFile(DATA_SUBDIR, tffile)
     config = config.replace('id_placeholder', AZURE_CLIENT_ID)
     config = config.replace('secret_placeholder', AZURE_CLIENT_SECRET)
+    config = config.replace('tenant_placeholder', AZURE_TENANT_ID)
 
     f = open(tffile, "w")
     f.write(config)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> N/A
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Automation is failing with AKS and GKE as the local cluster type. AKS is not reading tenant ID correctly and GKE has an outdated version.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Testing to see if this works. If so, will pull this draft PR into an actual PR to fix.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->