### PR TITLE
Added needed permissions to cleanup script

### DIFF
--- a/cleanup/user-cluster.yml
+++ b/cleanup/user-cluster.yml
@@ -69,6 +69,7 @@ rules:
   - ""
   resources:
   - namespaces
+  - services
   verbs:
   - list
   - get
@@ -89,6 +90,15 @@ rules:
   - batch
   resources:
   - jobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
   verbs:
   - list
   - get


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
Currently the linked cleanup script fails due to missing permissions, tested on an empty RKE2 cluster following the instructions given here: https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/clean-cluster-nodes#removing-rancher-components-from-registered-clusters
 
## Solution
Adding the needed permissions makes the created job succeed and remove all resources form the cluster.
 
## Testing
1. Create RKE2 cluster (Use existing nodes and create a cluster using RKE2/K3s)
2. Executing the script: https://raw.githubusercontent.com/rancher/rancher/master/cleanup/user-cluster.sh
3. Permission Error

## Engineering Testing
### Manual Testing

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->