### PR TITLE
Fix PSP restore 

### DIFF
--- a/pkg/api/norman/customization/cluster/actions_etcd.go
+++ b/pkg/api/norman/customization/cluster/actions_etcd.go
@@ -136,6 +136,7 @@ func (a ActionHandler) RestoreFromEtcdBackupHandler(actionName string, action *t
 				fmt.Sprintf("error decompressing cluster object for backupid %s: %s", input.EtcdBackupID, err))
 		}
 		cluster.Spec.RancherKubernetesEngineConfig = clusterBackup.Spec.RancherKubernetesEngineConfig
+		cluster.Spec.DefaultPodSecurityPolicyTemplateName = clusterBackup.Spec.DefaultPodSecurityPolicyTemplateName
 		cluster.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName = clusterBackup.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName
 	}
 

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/cluster.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/cluster.go
@@ -64,6 +64,14 @@ func (m *clusterManager) sync(key string, obj *v3.Cluster) (runtime.Object, erro
 	err := checkClusterVersion(m.clusterName, m.clusterLister)
 	if err != nil {
 		if errors.Is(err, errVersionIncompatible) {
+			if obj.Status.AppliedPodSecurityPolicyTemplateName != "" {
+				obj = obj.DeepCopy()
+				obj.Status.AppliedPodSecurityPolicyTemplateName = ""
+				obj, err = m.clusters.Update(obj)
+				if err != nil {
+					return nil, fmt.Errorf("error updating cluster: %v", err)
+				}
+			}
 			return obj, nil
 		}
 		return obj, fmt.Errorf(clusterVersionCheckErrorString, err)
@@ -143,6 +151,7 @@ func (m *clusterManager) sync(key string, obj *v3.Cluster) (runtime.Object, erro
 			}
 		}
 
+		obj = obj.DeepCopy()
 		obj.Status.AppliedPodSecurityPolicyTemplateName = obj.Spec.DefaultPodSecurityPolicyTemplateName
 		_, err = m.clusters.Update(obj)
 		if err != nil {

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/cluster.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/cluster.go
@@ -69,7 +69,7 @@ func (m *clusterManager) sync(key string, obj *v3.Cluster) (runtime.Object, erro
 				obj.Status.AppliedPodSecurityPolicyTemplateName = ""
 				obj, err = m.clusters.Update(obj)
 				if err != nil {
-					return nil, fmt.Errorf("error updating cluster: %v", err)
+					return nil, fmt.Errorf("error updating cluster for dropping the applied pspt: %v", err)
 				}
 			}
 			return obj, nil
@@ -155,7 +155,7 @@ func (m *clusterManager) sync(key string, obj *v3.Cluster) (runtime.Object, erro
 		obj.Status.AppliedPodSecurityPolicyTemplateName = obj.Spec.DefaultPodSecurityPolicyTemplateName
 		_, err = m.clusters.Update(obj)
 		if err != nil {
-			return nil, fmt.Errorf("error updating cluster: %v", err)
+			return nil, fmt.Errorf("error updating cluster with the applied pspt: %v", err)
 		}
 
 		return nil, resyncServiceAccounts(m.serviceAccountLister, m.serviceAccountsController, "")

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -263,6 +263,10 @@ func reconcileClusterSpecEtcdRestore(cluster *rancherv1.Cluster, desiredSpec ran
 		changed = true
 		cluster.Spec.KubernetesVersion = desiredSpec.KubernetesVersion
 	}
+	if cluster.Spec.DefaultPodSecurityPolicyTemplateName != desiredSpec.DefaultPodSecurityPolicyTemplateName {
+		changed = true
+		cluster.Spec.DefaultPodSecurityPolicyTemplateName = desiredSpec.DefaultPodSecurityPolicyTemplateName
+	}
 	if cluster.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName != desiredSpec.DefaultPodSecurityAdmissionConfigurationTemplateName {
 		changed = true
 		cluster.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName = desiredSpec.DefaultPodSecurityAdmissionConfigurationTemplateName


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/40899
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

After restoring the etcd backup on a downstream cluster, the Default Pod Security Policy selection is not reset to the value in the backup.
This happens to both RKE1 and RKE2 node-driver clusters.

It happens because we never sync back the value from the backup to the Cluster object 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Add the missing syncing. 
  
This PR also fixes the minor issue that the value of `status.appliedPodSecurityPolicyTemplateId` is not cleared up after upgrading a 1.24 cluster with PSP enabled to 1.25. 


## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Run this PR in dev env, and perform the restore following the steps in the issue, I can confirm the value of  Default Pod Security Policy is set to the one from the backup. 

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
n/a 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

The scenario described in the issue. 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

n/a 