### PR TITLE
Initial registries setup and validation

### DIFF
--- a/tests/framework/clients/corral/corral.go
+++ b/tests/framework/clients/corral/corral.go
@@ -10,8 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/sirupsen/logrus"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -69,7 +67,7 @@ func SetCustomRepo(repo string) error {
 
 // CreateCorral creates a corral taking the corral name, the package path, and a debug set so if someone wants to view the
 // corral create log
-func CreateCorral(ts *session.Session, corralName, packageName string, debug bool, cleanup bool) (*rest.Config, error) {
+func CreateCorral(ts *session.Session, corralName, packageName string, debug bool, cleanup bool) ([]byte, error) {
 	if cleanup {
 		ts.RegisterCleanupFunc(func() error {
 			return DeleteCorral(corralName)
@@ -92,17 +90,8 @@ func CreateCorral(ts *session.Session, corralName, packageName string, debug boo
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to create corral: "+string(msg))
 	}
-	kubeConfig, err := GetKubeConfig(corralName)
-	if err != nil {
-		return nil, err
-	}
 
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfig)
-	if err != nil {
-		return nil, errors.Wrap(err, "CreateCorral: failed to parse kubeconfig for k3d cluster")
-	}
-
-	return restConfig, nil
+	return msg, nil
 }
 
 // DeleteCorral deletes a corral based on the corral name
@@ -186,6 +175,21 @@ func UpdateCorralConfig(configVar, value string) error {
 	msg, err := exec.Command("corral", "config", "vars", "set", configVar, value).CombinedOutput()
 	if err != nil {
 		return errors.Wrap(err, "SetupCorralConfig: "+string(msg))
+	}
+	return nil
+}
+
+func DeleteAllCorrals() error {
+	corralList, err := ListCorral()
+	if err != nil {
+		return err
+	}
+	for corralName := range corralList {
+		err := DeleteCorral(corralName)
+		logrus.Infof("The Corral %s was deleted.", corralName)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/tests/framework/clients/rancher/config.go
+++ b/tests/framework/clients/rancher/config.go
@@ -5,11 +5,12 @@ const ConfigurationFileKey = "rancher"
 
 // Config is configuration need to test against a rancher instance
 type Config struct {
-	Host        string `yaml:"host"`
-	AdminToken  string `yaml:"adminToken"`
-	Insecure    *bool  `yaml:"insecure" default:"true"`
-	Cleanup     *bool  `yaml:"cleanup" default:"true"`
-	CAFile      string `yaml:"caFile" default:""`
-	CACerts     string `yaml:"caCerts" default:""`
-	ClusterName string `yaml:"clusterName" default:""`
+	Host          string `yaml:"host"`
+	AdminToken    string `yaml:"adminToken"`
+	AdminPassword string `yaml:"adminPassword"`
+	Insecure      *bool  `yaml:"insecure" default:"true"`
+	Cleanup       *bool  `yaml:"cleanup" default:"true"`
+	CAFile        string `yaml:"caFile" default:""`
+	CACerts       string `yaml:"caCerts" default:""`
+	ClusterName   string `yaml:"clusterName" default:""`
 }

--- a/tests/framework/extensions/pipelineutils/setup.go
+++ b/tests/framework/extensions/pipelineutils/setup.go
@@ -1,0 +1,107 @@
+package pipelineutils
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rancher/norman/types"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/token"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	clusterName = "local"
+)
+
+func CreateAdminToken(password string, rancherConfig *rancher.Config) (string, error) {
+	adminUser := &management.User{
+		Username: "admin",
+		Password: password,
+	}
+
+	hostURL := rancherConfig.Host
+	var userToken *management.Token
+	err := kwait.Poll(500*time.Millisecond, 5*time.Minute, func() (done bool, err error) {
+		userToken, err = token.GenerateUserToken(adminUser, hostURL)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return userToken.Token, nil
+}
+
+func PostRancherInstall(adminClient *rancher.Client, adminPassword string) error {
+	clusterID, err := clusters.GetClusterIDByName(adminClient, clusterName)
+	if err != nil {
+		return err
+	}
+
+	steveClient, err := adminClient.Steve.ProxyDownstream(clusterID)
+	if err != nil {
+		return err
+	}
+
+	timeStamp := time.Now().Format(time.RFC3339)
+	settingEULA := v3.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "eula-agreed",
+		},
+		Default: timeStamp,
+		Value:   timeStamp,
+	}
+
+	urlSetting := &v3.Setting{}
+
+	_, err = steveClient.SteveType("management.cattle.io.setting").Create(settingEULA)
+	if err != nil {
+		return err
+	}
+
+	urlSettingResp, err := steveClient.SteveType("management.cattle.io.setting").ByID("server-url")
+	if err != nil {
+		return err
+	}
+
+	err = v1.ConvertToK8sType(urlSettingResp.JSONResp, urlSetting)
+	if err != nil {
+		return err
+	}
+
+	urlSetting.Value = fmt.Sprintf("https://%s", adminClient.RancherConfig.Host)
+
+	_, err = steveClient.SteveType("management.cattle.io.setting").Update(urlSettingResp, urlSetting)
+	if err != nil {
+		return err
+	}
+
+	userList, err := adminClient.Management.User.List(&types.ListOpts{
+		Filters: map[string]interface{}{
+			"username": "admin",
+		},
+	})
+	if err != nil {
+		return err
+	} else if len(userList.Data) == 0 {
+		return fmt.Errorf("admin user not found")
+	}
+
+	adminUser := &userList.Data[0]
+	setPasswordInput := management.SetPasswordInput{
+		NewPassword: adminPassword,
+	}
+	_, err = adminClient.Management.User.ActionSetpassword(adminUser, &setPasswordInput)
+
+	return err
+}

--- a/tests/framework/extensions/registries/registries.go
+++ b/tests/framework/extensions/registries/registries.go
@@ -1,0 +1,53 @@
+package registries
+
+import (
+	"strings"
+	"time"
+
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+func CheckAllClusterPodsForRegistryPrefix(podsList *v1.SteveCollection, substring string) (bool, error) {
+
+	for _, pod := range podsList.Data {
+		podSpec := &corev1.PodSpec{}
+		err := v1.ConvertToK8sType(pod.Spec, podSpec)
+		if err != nil {
+			return false, err
+		}
+		for _, container := range podSpec.Containers {
+			log.Infoln(container.Image)
+			if !strings.Contains(container.Image, substring) {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}
+
+func CheckAllClusterPodsStatusForRegistry(podsList *v1.SteveCollection) (bool, error) {
+
+	err := kwait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
+		for _, pod := range podsList.Data {
+			podStatus := &corev1.PodStatus{}
+			err := v1.ConvertToK8sType(pod.Status, podStatus)
+			if err != nil {
+				return false, err
+			}
+			podPhase := podStatus.Phase
+			if podPhase != "Succeeded" && podPhase != "Running" {
+				log.Infoln(podPhase)
+				log.Infof("Reason: %s", podStatus.Reason)
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/tests/framework/pkg/environmentflag/environmentflags.go
+++ b/tests/framework/pkg/environmentflag/environmentflags.go
@@ -11,5 +11,7 @@ const (
 	Ingress EnvironmentFlag = iota
 	Chart
 	UpgradeAllClusters
+	UseExistingRegistries
+	InstallRancher
 	environmentFlagLastItem // This is used to determine the number of items in the enum
 )

--- a/tests/framework/pkg/environmentflag/zz_environmentflags.go
+++ b/tests/framework/pkg/environmentflag/zz_environmentflags.go
@@ -11,12 +11,14 @@ func _() {
 	_ = x[Ingress-0]
 	_ = x[Chart-1]
 	_ = x[UpgradeAllClusters-2]
-	_ = x[environmentFlagLastItem-3]
+	_ = x[UseExistingRegistries-3]
+	_ = x[InstallRancher-4]
+	_ = x[environmentFlagLastItem-5]
 }
 
-const _EnvironmentFlag_name = "IngressChartUpgradeAllClustersThis is used to determine the number of items in the enum"
+const _EnvironmentFlag_name = "IngressChartUpgradeAllClustersUseExistingRegistriesInstallRancherThis is used to determine the number of items in the enum"
 
-var _EnvironmentFlag_index = [...]uint8{0, 7, 12, 30, 87}
+var _EnvironmentFlag_index = [...]uint8{0, 7, 12, 30, 51, 65, 122}
 
 func (i EnvironmentFlag) String() string {
 	if i < 0 || i >= EnvironmentFlag(len(_EnvironmentFlag_index)-1) {

--- a/tests/v2/validation/Dockerfile.e2e
+++ b/tests/v2/validation/Dockerfile.e2e
@@ -1,0 +1,21 @@
+FROM registry.suse.com/bci/golang:1.19
+
+# Configure Go
+ENV GOPATH /root
+ENV PATH ${PATH}:/root/bin
+
+ENV WORKSPACE ${GOPATH}/src/github.com/rancher/rancher
+ENV WORKSPACE2 ${GOPATH}/src/github.com/rancherlabs/corral-packages
+
+WORKDIR $WORKSPACE
+
+COPY ["./rancher", "$WORKSPACE"]
+COPY ["./corral-packages", "$WORKSPACE2"]
+
+ENV CORRAL_VERSION="v1.1.1"
+
+RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables jq
+RUN zypper install -y -f docker && rpm -e --nodeps --noscripts containerd
+RUN go mod download && \
+    go install gotest.tools/gotestsum@latest && \
+    go install github.com/rancherlabs/corral@${CORRAL_VERSION}

--- a/tests/v2/validation/Jenkinsfile.e2e
+++ b/tests/v2/validation/Jenkinsfile.e2e
@@ -1,0 +1,187 @@
+#!groovy
+node {
+    def rootPath = "/root/src/github.com/rancher/rancher/"
+    def workPath = "/root/src/github.com/rancher/rancher/tests/v2/validation/"
+    def job_name = "${JOB_NAME}"
+    if (job_name.contains('/')) { 
+      job_names = job_name.split('/')
+      job_name = job_names[job_names.size() - 1] 
+    }
+    def golangTestContainer = "${job_name}${env.BUILD_NUMBER}-golangtest"
+    def buildTestContainer = "${job_name}${env.BUILD_NUMBER}-buildtest"
+    def cleanupTestContainer = "${job_name}${env.BUILD_NUMBER}-cleanuptest"
+    def golangImageName = "rancher-registries-validation-${job_name}${env.BUILD_NUMBER}"
+    def registriesVolume = "RegitriesSharedVolume-${job_name}${env.BUILD_NUMBER}"
+    def testsDir = "/root/src/github.com/rancher/rancher/tests/v2/validation/${env.TEST_PACKAGE}"
+    def testResultsOut = "results.xml"
+    def envFile = ".env"
+    def rancherConfig = "rancher_env.config"
+    def branch = "release/v2.6"
+    def corralBranch = "main"
+    if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
+      branch = "${env.BRANCH}"
+    }
+
+    if ("${env.RANCHER_CORRAL_PACKAGES_REPO_BRANCH}" != "null" && "${env.RANCHER_CORRAL_PACKAGES_REPO_BRANCH}" != "") {
+      corralBranch = "${env.RANCHER_CORRAL_PACKAGES_REPO_BRANCH}"
+    }
+
+    def rancherRepo = scm.getUserRemoteConfigs()[0].getUrl()
+    if ("${env.REPO}" != "null" && "${env.REPO}" != "") {
+      rancherRepo = "${env.REPO}"
+    }
+
+    def corralRepo = scm.getUserRemoteConfigs()[1].getUrl()
+    if ("${env.RANCHER_CORRAL_PACKAGES_REPO_URL}" != "null" && "${env.RANCHER_CORRAL_PACKAGES_REPO_URL}" != "") {
+      corralRepo = "${env.RANCHER_CORRAL_PACKAGES_REPO_URL}"
+    }
+  
+    def timeout = "60m"
+    if ("${env.TIMEOUT}" != "null" && "${env.TIMEOUT}" != "") {
+      timeout = "${env.TIMEOUT}" 
+    }
+    wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+      withFolderProperties {
+        paramsMap = []
+        params.each {
+          if (it.value && it.value.trim() != "") {
+              paramsMap << "$it.key=$it.value"
+          }
+        }
+        withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                          string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+                          string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'RANCHER_EKS_ACCESS_KEY'),
+                          string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'RANCHER_EKS_SECRET_KEY'),
+                          string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                          string(credentialsId: 'RANCHER_SSH_KEY', variable: 'RANCHER_SSH_KEY'),
+                          string(credentialsId: 'RANCHER_REGISTRY_USER_NAME', variable: 'RANCHER_REGISTRY_USER_NAME'),
+                          string(credentialsId: 'RANCHER_REGISTRY_PASSWORD', variable: 'RANCHER_REGISTRY_PASSWORD'),
+                          string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                          string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_VALID_TLS_CERT', variable: 'RANCHER_VALID_TLS_CERT'),
+                          string(credentialsId: 'RANCHER_VALID_TLS_KEY', variable: 'RANCHER_VALID_TLS_KEY'),
+                          string(credentialsId: 'RANCHER_BYO_TLS_CERT', variable: 'RANCHER_BYO_TLS_CERT'),
+                          string(credentialsId: 'RANCHER_BYO_TLS_KEY', variable: 'RANCHER_BYO_TLS_KEY')]) {
+          
+        withEnv(paramsMap) {
+          stage('Checkout') {
+            deleteDir()
+            dir("./rancher") {
+              checkout([
+                      $class: 'GitSCM',
+                      branches: [[name: "*/${branch}"]],
+                      extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                      userRemoteConfigs: [[url: rancherRepo]]
+                    ])
+            }
+            dir('./') {
+              echo "cloning corral-packages repo"
+
+              dir('./corral-packages') {
+                checkout([
+                      $class: 'GitSCM',
+                      branches: [[name: "*/${corralBranch}"]],
+                      extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                      userRemoteConfigs: [[url: corralRepo]]
+                    ])
+              }
+              def rancherFilename = "rancher-registry.yaml"
+              def rancherConfigContents = env.RANCHER_CORRAL_CONFIG
+              def registriesFilename = "registry.yaml"
+              def registriesConfigContents = env.REGISTRIES_CORRAL_CONFIG
+
+              writeFile file: "./corral-packages/packages/aws/"+rancherFilename, text: rancherConfigContents
+              writeFile file: "./corral-packages/packages/aws/"+registriesFilename, text: registriesConfigContents
+            }
+          }
+          dir ("./") {
+            stage('Configure and Build') {
+              if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
+                dir("./rancher/tests/v2/validation/.ssh") {
+                  def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
+                  writeFile file: AWS_SSH_KEY_NAME, text: decoded
+                }
+              }
+              dir("./rancher/tests/v2/validation") {
+                def filename = "config.yaml"
+                def configContents = env.CONFIG
+
+                writeFile file: filename, text: configContents
+                env.CATTLE_TEST_CONFIG = "${workPath}"+filename
+              }
+              dir ("./") {
+                sh "./rancher/tests/v2/validation/configure.sh"
+                sh "docker build . -f ./rancher/tests/v2/validation/Dockerfile.e2e -t ${golangImageName}"
+                sh "docker volume create --name ${registriesVolume}"
+              }
+            }
+            stage("Build Environment") {
+              try {
+                sh "docker run -v ${registriesVolume}:/root --name ${buildTestContainer} -t --env-file ${envFile} " +
+                "${golangImageName} sh -c \"${workPath}scripts/setup_registries_environment.sh\""
+              } catch(err) {
+                sh "docker stop ${buildTestContainer}"
+                sh "docker rm -v ${buildTestContainer}"
+                sh "docker volume rm -f ${registriesVolume}"
+                error "Build Environment had failures."
+              }
+            }
+            stage('Run Validation Tests') {
+              try {
+                sh "docker run --volumes-from ${buildTestContainer} --name ${golangTestContainer} -t --env-file ${envFile} " +
+                "${golangImageName} sh -c \"gotestsum --format standard-verbose --packages=${testsDir} --junitfile ${testResultsOut} -- ${GOTEST_TESTCASE} -timeout=${timeout} -v\""
+              } catch(err) {
+                echo 'Validation tests had failures. Aborting'
+              }
+            }
+            stage('Cleanup Rancher Environment') {
+              try {
+                if ("${env.ClEANUP_RANCHER}" == "True" || "${env.ClEANUP_RANCHER}" == "true") {
+                  sh "docker run --volumes-from ${buildTestContainer} --name ${cleanupTestContainer} -t --env-file ${envFile} " +
+                  "${golangImageName} sh -c \"${workPath}scripts/rancher_cleanup.sh\""
+                }
+              } catch(err) {
+                sh "docker stop ${buildTestContainer}"
+                sh "docker rm -v ${buildTestContainer}"
+                sh "docker stop ${golangTestContainer}"
+                sh "docker rm -v ${golangTestContainer}"
+                sh "docker stop ${cleanupTestContainer}"
+                sh "docker rm -v ${cleanupTestContainer}"
+                sh "docker rmi -f ${golangImageName}"
+                sh "docker volume rm -f ${registriesVolume}"
+                error "Cleanup had failures."
+              }
+            }
+            stage('Test Report') {
+              try {
+                sh "docker cp ${golangTestContainer}:${rootPath}${testResultsOut} ."
+                step([$class: 'JUnitResultArchiver', testResults: "**/${testResultsOut}"])
+              } catch (err) {
+                sh "docker stop ${buildTestContainer}"
+                sh "docker rm -v ${buildTestContainer}"
+                sh "docker stop ${golangTestContainer}"
+                sh "docker rm -v ${golangTestContainer}"
+                sh "docker stop ${cleanupTestContainer}"
+                sh "docker rm -v ${cleanupTestContainer}"
+                sh "docker rmi -f ${golangImageName}"
+                sh "docker volume rm -f ${registriesVolume}"
+                error 'Report had failures.'
+              }
+            }
+            stage('Clean Up Images and Volume') {
+              echo 'Cleaning test images and volume.'
+              sh "docker stop ${buildTestContainer}"
+              sh "docker rm -v ${buildTestContainer}"
+              sh "docker stop ${golangTestContainer}"
+              sh "docker rm -v ${golangTestContainer}"
+              sh "docker stop ${cleanupTestContainer}"
+              sh "docker rm -v ${cleanupTestContainer}"
+              sh "docker rmi -f ${golangImageName}"
+              sh "docker volume rm -f ${registriesVolume}"
+            }
+          } // dir 
+        } // withEnv
+      } // creds
+    } // folder properties
+  } // wrap 
+} // node

--- a/tests/v2/validation/ranchercleanup/main.go
+++ b/tests/v2/validation/ranchercleanup/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/corral"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/sirupsen/logrus"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	timeout = int64(60 * 10)
+)
+
+func main() {
+	testSession := session.NewSession()
+
+	client, err := rancher.NewClient("", testSession)
+	if err != nil {
+		logrus.Fatalf("error creating admin client: %v", err)
+	}
+
+	var clusterList *v1.SteveCollection
+	err = kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
+		//clean up clusters
+		resp, err := client.Steve.SteveType(clusters.ProvisioningSteveResouceType).List(nil)
+		if k8sErrors.IsInternalError(err) || k8sErrors.IsServiceUnavailable(err) {
+			return false, err
+		} else if resp != nil {
+			clusterList = resp
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		logrus.Errorf("error retrieving cluster list: %v", err)
+	}
+
+	deleteTimeout := timeout
+	for _, cluster := range clusterList.Data {
+		if cluster.ObjectMeta.Name != "local" {
+			err := client.Steve.SteveType(clusters.ProvisioningSteveResouceType).Delete(&cluster)
+			if err != nil {
+				logrus.Errorf("error deleting cluster: %v", err)
+			}
+
+			provKubeClient, err := client.GetKubeAPIProvisioningClient()
+			if err != nil {
+				logrus.Errorf("error deleting corral: %v", err)
+			}
+
+			watchInterface, err := provKubeClient.Clusters(cluster.ObjectMeta.Namespace).Watch(context.TODO(), metav1.ListOptions{
+				FieldSelector:  "metadata.name=" + cluster.ObjectMeta.Name,
+				TimeoutSeconds: &deleteTimeout,
+			})
+			if err != nil {
+				logrus.Errorf("error initiating watchInterface: %v", err)
+			}
+
+			err = wait.WatchWait(watchInterface, func(event watch.Event) (ready bool, err error) {
+				cluster := event.Object.(*apisV1.Cluster)
+				if event.Type == watch.Error {
+					return false, fmt.Errorf("there was an error deleting cluster")
+				} else if event.Type == watch.Deleted {
+					return true, nil
+				} else if cluster == nil {
+					return true, nil
+				}
+				return false, nil
+			})
+			if err != nil {
+				logrus.Errorf("error while deleting clusters: %v", err)
+			}
+		}
+	}
+	corral.DeleteAllCorrals()
+	if err != nil {
+		logrus.Errorf("error deleting corrals: %v", err)
+	}
+}

--- a/tests/v2/validation/rancherha/main.go
+++ b/tests/v2/validation/rancherha/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"github.com/rancher/rancher/tests/framework/clients/corral"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/pipelineutils"
+	"github.com/rancher/rancher/tests/framework/pkg/environmentflag"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	corralPackageRancherName         = "rancherha"
+)
+
+func main() {
+	corralSession := session.NewSession()
+
+	corralConfig := corral.CorralConfigurations()
+	err := corral.SetupCorralConfig(corralConfig.CorralConfigVars, corralConfig.CorralConfigUser, corralConfig.CorralSSHPath)
+	if err != nil {
+		logrus.Fatalf("error setting up corral: %v", err)
+	}
+
+	configPackage := corral.CorralPackagesConfig()
+
+	environmentFlags := environmentflag.NewEnvironmentFlags()
+	environmentflag.LoadEnvironmentFlags(environmentflag.ConfigurationFileKey, environmentFlags)
+	installRancher := environmentFlags.GetValue(environmentflag.InstallRancher)
+
+	logrus.Infof("installRancher value is %t", installRancher)
+
+	if installRancher {
+		path := configPackage.CorralPackageImages[corralPackageRancherName]
+		corralName := corralPackageRancherName
+		
+		logrus.Infof("PATH", path)
+		_, err = corral.CreateCorral(corralSession, corralName, path, true, configPackage.Cleanup)
+		if err != nil {
+			logrus.Errorf("error creating corral: %v", err)
+		}
+
+		bootstrapPassword, err := corral.GetCorralEnvVar(corralName, "bootstrap_password")
+		if err != nil {
+			logrus.Errorf("error getting the bootstrap password: %v", err)
+		}
+		rancherConfig := new(rancher.Config)
+		config.LoadConfig(rancher.ConfigurationFileKey, rancherConfig)
+
+		token, err := pipelineutils.CreateAdminToken(bootstrapPassword, rancherConfig)
+		if err != nil {
+			logrus.Errorf("error creating the admin token: %v", err)
+		}
+		rancherConfig.AdminToken = token
+		config.UpdateConfig(rancher.ConfigurationFileKey, rancherConfig)
+		rancherSession := session.NewSession()
+		client, err := rancher.NewClient(rancherConfig.AdminToken, rancherSession)
+		if err != nil {
+			logrus.Errorf("error creating the rancher client: %v", err)
+		}
+
+		err = pipelineutils.PostRancherInstall(client, rancherConfig.AdminPassword)
+		if err != nil {
+			logrus.Errorf("error during post rancher install: %v", err)
+		}
+	} else {
+		logrus.Infof("Skipped Rancher Install because installRancher is %t", installRancher)
+	}
+}

--- a/tests/v2/validation/registries/config.go
+++ b/tests/v2/validation/registries/config.go
@@ -1,0 +1,7 @@
+package registries
+
+const RegistriesConfigKey = "registries"
+
+type Registries struct {
+	RegistryConfigNames []string `json:"registryConfigNames" yaml:"registryConfigNames" default:"[]"`
+}

--- a/tests/v2/validation/registries/registry_test.go
+++ b/tests/v2/validation/registries/registry_test.go
@@ -1,0 +1,241 @@
+package registries
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/corral"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/registries"
+	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/environmentflag"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning/rke1"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	corralRancherName      = "rancherha"
+	corralAuthDisabledName = "registryauthdisabled"
+	corralAuthEnabledName  = "registryauthenabled"
+)
+
+type RegistryTestSuite struct {
+	suite.Suite
+	session                        *session.Session
+	client                         *rancher.Client
+	podListClusterAuth             *v1.SteveCollection
+	podListClusterNoAuth           *v1.SteveCollection
+	podListClusterLocal            *v1.SteveCollection
+	clusterAuthRegistryHost        string
+	clusterNoAuthRegistryHost      string
+	localClusterGlobalRegistryHost string
+	rancherUsesRegistry            bool
+}
+
+func (rt *RegistryTestSuite) TearDownSuite() {
+	rt.session.Cleanup()
+}
+
+func (rt *RegistryTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	rt.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(rt.T(), err)
+	rt.client = client
+
+	corralConfig := corral.CorralConfigurations()
+	registriesConfig := new(Registries)
+	config.LoadConfig(RegistriesConfigKey, registriesConfig)
+
+	err = corral.SetupCorralConfig(corralConfig.CorralConfigVars, corralConfig.CorralConfigUser, corralConfig.CorralSSHPath)
+	require.NoError(rt.T(), err)
+	configPackage := corral.CorralPackagesConfig()
+
+	useRegistries := client.Flags.GetValue(environmentflag.UseExistingRegistries)
+	logrus.Infof("The value of useRegistries is %t", useRegistries)
+
+	if !useRegistries {
+		for _, name := range registriesConfig.RegistryConfigNames {
+			path := configPackage.CorralPackageImages[name]
+			logrus.Infof("PATH: %s", path)
+
+			_, err = corral.CreateCorral(testSession, name, path, true, configPackage.Cleanup)
+			if err != nil {
+				logrus.Errorf("error creating corral: %v", err)
+			}
+		}
+	} else {
+		logrus.Infof("Using Existing Registries because value of useRegistries is %t", useRegistries)
+	}
+
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+	kubernetesVersions := clustersConfig.RKE1KubernetesVersions
+	cnis := clustersConfig.CNIs
+	nodesAndRoles := clustersConfig.NodesAndRolesRKE1
+	providers := clustersConfig.Providers
+
+	globalRegistryFqdn := ""
+	rt.rancherUsesRegistry = false
+	globalRegistryFqdn, err = corral.GetCorralEnvVar(corralRancherName, "registry_fqdn")
+	require.NoError(rt.T(), err)
+	if globalRegistryFqdn != "<nil>" {
+		rt.rancherUsesRegistry = true
+		logrus.Infof("Rancher Global Registry FQDN %s", globalRegistryFqdn)
+	}
+	logrus.Infof("Is Rancher using a global registry: %t", rt.rancherUsesRegistry)
+	registryDisabledFqdn, err := corral.GetCorralEnvVar(corralAuthDisabledName, "registry_fqdn")
+	require.NoError(rt.T(), err)
+	logrus.Infof("RegistryNoAuth FQDN %s", registryDisabledFqdn)
+	registryEnabledUsername, err := corral.GetCorralEnvVar(corralAuthEnabledName, "registry_username")
+	require.NoError(rt.T(), err)
+	logrus.Infof("RegistryAuth Username %s", registryEnabledUsername)
+	registryEnabledPassword, err := corral.GetCorralEnvVar(corralAuthEnabledName, "registry_password")
+	require.NoError(rt.T(), err)
+	logrus.Infof("RegistryAuth Password %s", registryEnabledPassword)
+	registryEnabledFqdn, err := corral.GetCorralEnvVar(corralAuthEnabledName, "registry_fqdn")
+	require.NoError(rt.T(), err)
+	logrus.Infof("RegistryAuth FQDN %s", registryEnabledFqdn)
+
+	var privateRegistriesNoAuth []management.PrivateRegistry
+	privateRegistry := management.PrivateRegistry{}
+	privateRegistry.URL = registryDisabledFqdn
+	privateRegistry.IsDefault = true
+	privateRegistry.Password = ""
+	privateRegistry.User = ""
+	privateRegistriesNoAuth = append(privateRegistriesNoAuth, privateRegistry)
+
+	var privateRegistriesAuth []management.PrivateRegistry
+	privateRegistry = management.PrivateRegistry{}
+	privateRegistry.URL = registryEnabledFqdn
+	privateRegistry.IsDefault = true
+	privateRegistry.Password = registryEnabledPassword
+	privateRegistry.User = registryEnabledUsername
+	privateRegistriesAuth = append(privateRegistriesAuth, privateRegistry)
+
+	subSession := session.NewSession()
+	defer subSession.Cleanup()
+
+	subClient, err := client.WithSession(subSession)
+	require.NoError(rt.T(), err)
+
+	provider := rke1.CreateProvider(providers[0])
+	clusterNameNoAuth, err := rt.testProvisionRKE1Cluster(subClient, provider, nodesAndRoles, kubernetesVersions[0], cnis[0], privateRegistriesNoAuth)
+	require.NoError(rt.T(), err)
+	clusterNameAuth, err := rt.testProvisionRKE1Cluster(subClient, provider, nodesAndRoles, kubernetesVersions[0], cnis[0], privateRegistriesAuth)
+	require.NoError(rt.T(), err)
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterNameNoAuth)
+	require.NoError(rt.T(), err)
+
+	downstreamClient, err := client.Steve.ProxyDownstream(clusterID)
+	require.NoError(rt.T(), err)
+	steveClient := downstreamClient.SteveType(pods.PodResourceSteveType)
+	podsList, err := steveClient.List(nil)
+	require.NoError(rt.T(), err)
+	rt.podListClusterNoAuth = podsList
+	rt.clusterNoAuthRegistryHost = registryDisabledFqdn
+
+	clusterID, err = clusters.GetClusterIDByName(client, clusterNameAuth)
+	require.NoError(rt.T(), err)
+	downstreamClient, err = client.Steve.ProxyDownstream(clusterID)
+	require.NoError(rt.T(), err)
+	steveClient = downstreamClient.SteveType(pods.PodResourceSteveType)
+	podsList, err = steveClient.List(nil)
+	require.NoError(rt.T(), err)
+	rt.podListClusterAuth = podsList
+	rt.clusterAuthRegistryHost = registryEnabledFqdn
+
+	downstreamClient, err = client.Steve.ProxyDownstream("local")
+	require.NoError(rt.T(), err)
+	steveClient = downstreamClient.SteveType(pods.PodResourceSteveType)
+	podsList, err = steveClient.List(nil)
+	require.NoError(rt.T(), err)
+	rt.podListClusterLocal = podsList
+	rt.localClusterGlobalRegistryHost = globalRegistryFqdn
+
+}
+
+func (rt *RegistryTestSuite) testProvisionRKE1Cluster(client *rancher.Client, provider rke1.Provider, nodesAndRoles []nodepools.NodeRoles, kubeVersion, cni string, privateRegistries []management.PrivateRegistry) (string, error) {
+	clusterName := namegen.AppendRandomString(provider.Name)
+	cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, client)
+	cluster.RancherKubernetesEngineConfig.PrivateRegistries = privateRegistries
+
+	clusterResp, err := clusters.CreateRKE1Cluster(client, cluster)
+	require.NoError(rt.T(), err)
+	nodeTemplateResp, err := provider.NodeTemplateFunc(client)
+	require.NoError(rt.T(), err)
+	nodePool, err := nodepools.NodePoolSetup(client, nodesAndRoles, clusterResp.ID, nodeTemplateResp.ID)
+	require.NoError(rt.T(), err)
+
+	nodePoolName := nodePool.Name
+	opts := metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + clusterResp.ID,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	}
+	watchInterface, err := client.GetManagementWatchInterface(management.ClusterType, opts)
+	require.NoError(rt.T(), err)
+	checkFunc := clusters.IsHostedProvisioningClusterReady
+	err = wait.WatchWait(watchInterface, checkFunc)
+	require.NoError(rt.T(), err)
+
+	assert.Equal(rt.T(), clusterName, clusterResp.Name)
+	assert.Equal(rt.T(), nodePoolName, nodePool.Name)
+	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+	require.NoError(rt.T(), err)
+	assert.NotEmpty(rt.T(), clusterToken)
+
+	return clusterName, nil
+}
+
+func (rt *RegistryTestSuite) TestRegistryAllPods() {
+
+	if rt.rancherUsesRegistry {
+		havePrefix, err := registries.CheckAllClusterPodsForRegistryPrefix(rt.podListClusterLocal, rt.localClusterGlobalRegistryHost)
+		require.NoError(rt.T(), err)
+		assert.True(rt.T(), havePrefix)
+	}
+
+	havePrefix, err := registries.CheckAllClusterPodsForRegistryPrefix(rt.podListClusterNoAuth, rt.clusterNoAuthRegistryHost)
+	require.NoError(rt.T(), err)
+	assert.True(rt.T(), havePrefix)
+
+	havePrefix, err = registries.CheckAllClusterPodsForRegistryPrefix(rt.podListClusterAuth, rt.clusterAuthRegistryHost)
+	require.NoError(rt.T(), err)
+	assert.True(rt.T(), havePrefix)
+
+}
+
+func (rt *RegistryTestSuite) TestStatusAllPods() {
+
+	areStatusesOk, err := registries.CheckAllClusterPodsStatusForRegistry(rt.podListClusterLocal)
+	require.NoError(rt.T(), err)
+	assert.True(rt.T(), areStatusesOk)
+
+	areStatusesOk, err = registries.CheckAllClusterPodsStatusForRegistry(rt.podListClusterNoAuth)
+	require.NoError(rt.T(), err)
+	assert.True(rt.T(), areStatusesOk)
+
+	areStatusesOk, err = registries.CheckAllClusterPodsStatusForRegistry(rt.podListClusterAuth)
+	require.NoError(rt.T(), err)
+	assert.True(rt.T(), areStatusesOk)
+
+}
+
+func TestRegistryTestSuite(t *testing.T) {
+	suite.Run(t, new(RegistryTestSuite))
+}

--- a/tests/v2/validation/scripts/build_corral_packages.sh
+++ b/tests/v2/validation/scripts/build_corral_packages.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+cd  /root/src/github.com/rancherlabs/corral-packages
+
+make init
+make build

--- a/tests/v2/validation/scripts/build_registries_images.sh
+++ b/tests/v2/validation/scripts/build_registries_images.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+cd $(dirname $0)/../../../../
+
+
+echo "building rancher HA corral bin"
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/validation/registries/bin/rancherha ./tests/v2/validation/rancherha
+
+echo "building rancher cleanup bin"
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/validation/registries/bin/ranchercleanup ./tests/v2/validation/ranchercleanup

--- a/tests/v2/validation/scripts/rancher_cleanup.sh
+++ b/tests/v2/validation/scripts/rancher_cleanup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+cd $(dirname $0)/../../../../
+
+echo | corral config
+
+corral list
+
+echo "cleanup rancher"
+tests/v2/validation/registries/bin/ranchercleanup

--- a/tests/v2/validation/scripts/setup_registries_environment.sh
+++ b/tests/v2/validation/scripts/setup_registries_environment.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+cd $(dirname $0)/../../../../
+
+echo "build corral packages"
+sh tests/v2/validation/scripts/build_corral_packages.sh
+
+echo | corral config
+
+echo "build registries images"
+sh tests/v2/validation/scripts/build_registries_images.sh
+
+corral list
+
+echo "running rancher corral"
+tests/v2/validation/registries/bin/rancherha


### PR DESCRIPTION
## Issue: https://github.com/rancher/qa-tasks/issues/51

Depends on: https://github.com/rancherlabs/corral-packages/pull/6
 
## Problem

There isn't automated way to start building a Rancher deployment with downstream clusters with configured private registries.
 
## Solution

With the code in this PR we can use the corral client to build the test environment with three private registries. 
- Registry with no authentication for Rancher. Rancher is also deployed.
- Registry with no authentication for a downstream Cluster 
- And a final registry with authentication enabled for a downstream Cluster

Using the go framework the code proceeds to configure Rancher creating an admin user with his password and an auth token.

The Rancher client creates two downstream clusters one with an authentication enabled registry and the other disabled.

Then it validates the pod images have the private registry url as expected.

## Testing

This was done through Jenkins in a custom job using forked `rancher` and `corral-packages` repositories.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing

- The registry is configured during cluster creation
- Built-in validation of cluster health through `createCluster` methods.
- Pod status check (not active/running)
- Validate all pods image names iterating on all workloads


## QA Testing Considerations

The Kubernetes versions should match those in the release's `rancher-images.txt` and confirmed in KDM that it matches the Kubernetes dependencies listed in the rancher-images.

This requires to provide a yaml corral package configuration for Rancher and another yaml for the other two standalone registries using the registry package.

Rancher version must match on those corral-packages Yaml configurations.

There were problems with corral corrupting the global `corral.yaml` when Parallel private registries creation was triggered this specially during execution on docker images in CI. Other symptoms were the terraform executables sometimes triggered "file already in use".

Reverting to sequential stabilized this for the cost of pipeline execution duration (~1hr duration each registry)
 