### PR TITLE
Add cattle-elemental-system to list of system namespaces

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -46,6 +46,7 @@ var (
 		"rancher-operator-system",
 		"cattle-csp-adapter-system",
 		"calico-apiserver",
+		"cattle-elemental-system",
 	}
 
 	AgentImage                          = NewSetting("agent-image", "rancher/rancher-agent:v2.7-head")


### PR DESCRIPTION
This is needed to be able to backup Elemental resources.

This is a newer version/rebase of https://github.com/rancher/rancher/pull/39064.

## Issue: https://github.com/rancher/elemental-operator/issues/9
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Elemental Operator namespace needs to be included in the system namespaces in Rancher in order for Backup to properly work. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Add Elemental namespace to the list of system ones.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Tested manually on my lab.

## Engineering Testing
### Manual Testing
Manually added all resources needed to be able to backup Elemental resources and did the backup/restore test.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
It will be done in Elemental CI.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
N/A. 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
This change should be transparent, only a new namespace is added in the list.