### PR TITLE
[2.7] Update kubelet certificate Verification by Node Agent

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/logserver"
 	"github.com/rancher/rancher/pkg/rkenodeconfigclient"
-	"github.com/rancher/rancher/pkg/rkenodeconfigserver"
 	"github.com/rancher/remotedialer"
 	"github.com/rancher/wrangler/pkg/signals"
 	"github.com/sirupsen/logrus"
@@ -42,8 +41,7 @@ var (
 )
 
 const (
-	Token                    = "X-API-Tunnel-Token"
-	KubeletCertValidityLimit = time.Hour * 72
+	Token = "X-API-Tunnel-Token"
 )
 
 func main() {
@@ -210,11 +208,6 @@ func run(ctx context.Context) error {
 		rkenodeconfigclient.Params: {base64.StdEncoding.EncodeToString(bytes)},
 	}
 
-	err = KubeletNeedsNewCertificate(headers)
-	if err != nil {
-		return err
-	}
-
 	serverURL, err := url.Parse(server)
 	if err != nil {
 		return err
@@ -344,12 +337,6 @@ func run(ctx context.Context) error {
 			for {
 				select {
 				case <-time.After(tt):
-					// each time we request a plan we should
-					// check if our cert about to expire
-					err = KubeletNeedsNewCertificate(headers)
-					if err != nil {
-						logrus.Errorf("failed to check validity of kubelet certs: %v", err)
-					}
 					receivedInterval, err := rkenodeconfigclient.ConfigClient(ctx, connectConfig, headers, writeCertsOnly)
 					if err != nil {
 						logrus.Errorf("failed to check plan: %v", err)
@@ -357,7 +344,6 @@ func run(ctx context.Context) error {
 						tt = time.Duration(receivedInterval) * time.Second
 						logrus.Infof("Plan monitor checking %v seconds", receivedInterval)
 					}
-
 				case <-ctx.Done():
 					return
 				}
@@ -377,12 +363,6 @@ func run(ctx context.Context) error {
 		wsURL := fmt.Sprintf("wss://%s/v3/connect", serverURL.Host)
 		if !isConnect() {
 			wsURL += "/register"
-		}
-
-		// check if we need a new kubelet cert on reconnection
-		err = KubeletNeedsNewCertificate(headers)
-		if err != nil {
-			return err
 		}
 
 		logrus.Infof("Connecting to %s with token starting with %s", wsURL, token[:len(token)/2])
@@ -504,116 +484,4 @@ func reconcileKubelet(ctx context.Context) (bool, error) {
 		}
 	}
 	return false, nil
-}
-
-// KubeletNeedsNewCertificate will set the
-// 'RegenerateKubeletCertificate' header field to true if
-// a) the kubelet serving certificate does not exist
-// b) the certificate will expire in 72 hours
-// c) the certificate does not accurately represent the
-//
-//	current IP address and Hostname of the node
-//
-// While the agent may denote it needs a new kubelet certificate
-// in its connection request, a new certificate will only be
-// delivered by Rancher if the generate_serving_certificate property
-// is set to 'true' for the clusters kubelet service.
-func KubeletNeedsNewCertificate(headers http.Header) error {
-	currentHostname := os.Getenv("CATTLE_NODE_NAME")
-
-	// RKE will save the certs on the node using either the public or private IP address, depending on the infrastructure provider.
-	// For example, the certs will be stored using the public IP address for VM's on digital ocean, but will use the private IP
-	// address for VM's on AWS. We do not know which IP address RKE decided to use, so we need to check both locations.
-	kubeletCertFile, kubeletCertKeyFile, ipAddress := findCertificateFiles(os.Getenv("CATTLE_ADDRESS"), os.Getenv("CATTLE_INTERNAL_ADDRESS"))
-	if kubeletCertFile == "" || kubeletCertKeyFile == "" || ipAddress == "" {
-		logrus.Tracef("did not find kubelet certificate files using either public ip address (%s) or private ip address (%s)", os.Getenv("CATTLE_ADDRESS"), os.Getenv("CATTLE_INTERNAL_ADDRESS"))
-	}
-
-	cert, err := tls.LoadX509KeyPair(kubeletCertFile, kubeletCertKeyFile)
-	if err != nil && !strings.Contains(err.Error(), "no such file") {
-		return err
-	}
-
-	needsRegen, err := KubeletCertificateNeedsRegeneration(ipAddress, currentHostname, cert, time.Now())
-	if err != nil {
-		return err
-	}
-
-	if needsRegen {
-		headers.Set(rkenodeconfigserver.RegenerateKubeletCertificate, "true")
-	} else {
-		headers.Set(rkenodeconfigserver.RegenerateKubeletCertificate, "false")
-	}
-
-	return nil
-}
-
-func findCertificateFiles(IPAddresses ...string) (string, string, string) {
-	for _, ip := range IPAddresses {
-		fileSafeIPAddress := strings.ReplaceAll(ip, ".", "-")
-		certFile := fmt.Sprintf("/etc/kubernetes/ssl/kube-kubelet-%s.pem", fileSafeIPAddress)
-		certKeyFile := fmt.Sprintf("/etc/kubernetes/ssl/kube-kubelet-%s-key.pem", fileSafeIPAddress)
-		_, certErr := os.Stat(certFile)
-		_, keyErr := os.Stat(certKeyFile)
-		// check that both files exist
-		if certErr == nil && keyErr == nil {
-			return certFile, certKeyFile, ip
-		}
-	}
-	return "", "", ""
-}
-
-func KubeletCertificateNeedsRegeneration(ipAddress, currentHostname string, cert tls.Certificate, currentTime time.Time) (bool, error) {
-	if len(cert.Certificate) == 0 {
-		return true, nil
-	}
-
-	parsedCert, err := x509.ParseCertificate(cert.Certificate[0])
-	if err != nil {
-		return false, err
-	}
-
-	if !CertificateIncludesHostname(currentHostname, parsedCert) {
-		logrus.Tracef("certificate does not include current hostname, requesting new certificate")
-		return true, nil
-	}
-
-	if CertificateIsExpiring(parsedCert, currentTime) {
-		logrus.Tracef("certificate is expiring soon, requesting new certificate")
-		return true, nil
-	}
-
-	if !CertificateIncludesCurrentIP(ipAddress, parsedCert) {
-		logrus.Tracef("certificate does not include current IP address, requesting new certificate")
-		return true, nil
-	}
-
-	return false, nil
-}
-
-// CertificateIsExpiring checks if the passed certificate will expire within
-// the KubeletCertValidityLimit
-func CertificateIsExpiring(cert *x509.Certificate, currentTime time.Time) bool {
-	return cert.NotAfter.Sub(currentTime) < KubeletCertValidityLimit
-}
-
-// CertificateIncludesHostname checks that the passed certificate includes
-// the provided hostname in its SAN list
-func CertificateIncludesHostname(hostname string, cert *x509.Certificate) bool {
-	for _, name := range cert.DNSNames {
-		if name == hostname {
-			return true
-		}
-	}
-	return false
-}
-
-// CertificateIncludesCurrentIP checks that the passed certificate includes the provided IP address
-func CertificateIncludesCurrentIP(ipAddress string, cert *x509.Certificate) bool {
-	for _, ip := range cert.IPAddresses {
-		if ipAddress == ip.String() {
-			return true
-		}
-	}
-	return false
 }

--- a/package/run.sh
+++ b/package/run.sh
@@ -161,24 +161,8 @@ export CATTLE_ADDRESS=$(get_address $CATTLE_ADDRESS)
 export CATTLE_INTERNAL_ADDRESS=$(get_address $CATTLE_INTERNAL_ADDRESS)
 
 if [ -z "$CATTLE_ADDRESS" ]; then
-    # Try to get external IP with dig, often works better than ip -o route.
-    if dig +short myip.opendns.com @resolver1.opendns.com && echo $?; then
-        CATTLE_ADDRESS=$(dig +short myip.opendns.com @resolver1.opendns.com)
-    fi
-fi
-
-if [ -z "$CATTLE_ADDRESS" ]; then
     # Example output: '8.8.8.8 via 10.128.0.1 dev ens4 src 10.128.0.34 uid 0'
     CATTLE_ADDRESS=$(ip -o route get 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
-fi
-
-if [ -z "$CATTLE_INTERNAL_ADDRESS" ]; then
-    # Example output: '8.8.8.8 via 10.128.0.1 dev ens4 src 10.128.0.34 uid 0'
-    # Will provide the private IP address, if no private IP address is found the public IP address will be returned
-    ROUTE_OUTPUT=$(ip -o route get 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
-    if [ "$CATTLE_ADDRESS" != "$ROUTE_OUTPUT" ]; then
-        CATTLE_INTERNAL_ADDRESS="$ROUTE_OUTPUT"
-    fi
 fi
 
 if [ "$CATTLE_K8S_MANAGED" != "true" ]; then
@@ -273,3 +257,4 @@ if [ -n "$CATTLE_CA_CHECKSUM" ]; then
 fi
 
 exec tini -- agent
+

--- a/pkg/rkenodeconfigclient/certificates.go
+++ b/pkg/rkenodeconfigclient/certificates.go
@@ -1,0 +1,66 @@
+package rkenodeconfigclient
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const kubeletCertValidityLimit = time.Hour * 72
+
+func kubeletCertificateNeedsRegeneration(ipAddress, currentHostname string, cert tls.Certificate, currentTime time.Time) (bool, error) {
+	if len(cert.Certificate) == 0 {
+		return true, nil
+	}
+
+	parsedCert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return false, err
+	}
+
+	if !certificateIncludesHostname(currentHostname, parsedCert) {
+		logrus.Tracef("certificate does not include current hostname, requesting new certificate")
+		return true, nil
+	}
+
+	if certificateIsExpiring(parsedCert, currentTime) {
+		logrus.Tracef("certificate is expiring soon, requesting new certificate")
+		return true, nil
+	}
+
+	if !certificateIncludesCurrentIP(ipAddress, parsedCert) {
+		logrus.Tracef("certificate does not include current IP address, requesting new certificate")
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// certificateIsExpiring checks if the passed certificate will expire within
+// the kubeletCertValidityLimit
+func certificateIsExpiring(cert *x509.Certificate, currentTime time.Time) bool {
+	return cert.NotAfter.Sub(currentTime) < kubeletCertValidityLimit
+}
+
+// certificateIncludesHostname checks that the passed certificate includes
+// the provided hostname in its SAN list
+func certificateIncludesHostname(hostname string, cert *x509.Certificate) bool {
+	for _, name := range cert.DNSNames {
+		if name == hostname {
+			return true
+		}
+	}
+	return false
+}
+
+// certificateIncludesCurrentIP checks that the passed certificate includes the provided IP address
+func certificateIncludesCurrentIP(ipAddress string, cert *x509.Certificate) bool {
+	for _, ip := range cert.IPAddresses {
+		if ipAddress == ip.String() {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/rkenodeconfigclient/client.go
+++ b/pkg/rkenodeconfigclient/client.go
@@ -2,18 +2,22 @@ package rkenodeconfigclient
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/rancher/rancher/pkg/agent/node"
-
+	"github.com/rancher/rancher/pkg/rkenodeconfigserver"
 	"github.com/rancher/rancher/pkg/rkeworker"
+	"github.com/rancher/rke/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -50,10 +54,19 @@ func newErrNodeOrClusterNotFound(msg, occursType string) *ErrNodeOrClusterNotFou
 	}
 }
 
+// ConfigClient executes a GET request against the rancher servers node-server API in an attempt to get the most recent node-config.
+// It continues to do so until a node-config is returned within the response body, or the retry limit of 3 attempts is exceeded. Upon
+// receiving a valid node-config this function inspects any kubelet serving certificates present on the host to determine if they need to be refreshed.
+// If kubelet certificates need to be regenerated, a second GET request will be made so that the node config holds valid certificates. Once all kubelet certificates
+// are deemed valid, ConfigClient will execute the node config, writing files and executing processes as directed. The passed
+// url and header values are used when crafting the GET request, and the writeCertOnly parameter is used to denote if the agent should disregard
+// all aspects of the received node-config except any delivered certificates. Upon a successful execution of the node config, this function
+// will return a polling interval which should be used to query the rancher server for the next node-config and any encountered errors.
 func ConfigClient(ctx context.Context, url string, header http.Header, writeCertOnly bool) (int, error) {
 	// try a few more times because there is a delay after registering a new node
 	nodeOrClusterNotFoundRetryLimit := 3
 	interval := 120
+	requestedRenewedCert := false
 	for {
 		nc, err := getConfig(client, url, header)
 		if err != nil {
@@ -72,13 +85,31 @@ func ConfigClient(ctx context.Context, url string, header http.Header, writeCert
 		}
 
 		if nc != nil {
+			// check to see if we need a new kubelet certificate
+			kubeletCertNeedsRegen, err := kubeletNeedsNewCertificate(nc)
+			if err != nil {
+				return interval, err
+			}
+
+			if kubeletCertNeedsRegen && !requestedRenewedCert {
+				// add to the  header and run getConfig again, so we get a new cert
+				// we should only do this at most once per call to ConfigClient
+				header.Set(rkenodeconfigserver.RegenerateKubeletCertificate, "true")
+				logrus.Infof("Requesting kubelet certificate regeneration")
+				requestedRenewedCert = true
+				continue
+			}
+
+			header.Set(rkenodeconfigserver.RegenerateKubeletCertificate, "false")
+			requestedRenewedCert = false
+
 			// Logging at trace level as NodeConfig may contain sensitive data
 			logrus.Tracef("Get agent config: %#v", nc)
 			if nc.AgentCheckInterval != 0 {
 				interval = nc.AgentCheckInterval
 			}
 
-			err := rkeworker.ExecutePlan(ctx, nc, writeCertOnly)
+			err = rkeworker.ExecutePlan(ctx, nc, writeCertOnly)
 			if err != nil {
 				return interval, err
 			}
@@ -152,4 +183,59 @@ func getConfig(client *http.Client, url string, header http.Header) (*rkeworker.
 
 	nc := &rkeworker.NodeConfig{}
 	return nc, json.NewDecoder(resp.Body).Decode(nc)
+}
+
+// getKubeletCertificateFilesFromProcess finds the tls-private-key-file and tls-cert-file values from
+// the kubelet process so that they may be used to determine the validity of the kubelet certificates stored
+// on the host.
+func getKubeletCertificateFilesFromProcess(processes map[string]types.Process) (string, string) {
+	proc, ok := processes["kubelet"]
+	if !ok {
+		return "", ""
+	}
+
+	return findCommandValue("--tls-private-key-file", proc.Command), findCommandValue("--tls-cert-file", proc.Command)
+}
+
+// findCommandValue iterates over a list of process flags and returns the value of
+// the specified flag, stripping the flag name and the '=' sign. If the flag
+// cannot be found in the list of flags, an empty string is returned.
+func findCommandValue(flag string, commandsFlags []string) string {
+	for _, cmd := range commandsFlags {
+		if strings.HasPrefix(cmd, flag) {
+			valueWithEqual := strings.TrimPrefix(cmd, flag)
+			value := strings.TrimPrefix(valueWithEqual, "=")
+			return value
+		}
+	}
+	return ""
+}
+
+// kubeletNeedsNewCertificate will set the
+// 'RegenerateKubeletCertificate' header field to true if
+// a) the kubelet serving certificate does not exist
+// b) the certificate will expire in 72 hours
+// c) the certificate does not accurately represent the current IP address and Hostname of the node
+//
+// While the agent may denote it needs a new kubelet certificate
+// in its connection request, a new certificate will only be
+// delivered by Rancher if the generate_serving_certificate property
+// is set to 'true' for the clusters kubelet service.
+func kubeletNeedsNewCertificate(nc *rkeworker.NodeConfig) (bool, error) {
+	kubeletCertKeyFile, kubeletCertFile := getKubeletCertificateFilesFromProcess(nc.Processes)
+	if kubeletCertFile == "" || kubeletCertKeyFile == "" {
+		return true, nil
+	}
+
+	cert, err := tls.LoadX509KeyPair(kubeletCertFile, kubeletCertKeyFile)
+	if err != nil && !strings.Contains(err.Error(), "no such file") {
+		return true, err
+	}
+
+	needsRegen, err := kubeletCertificateNeedsRegeneration(os.Getenv("CATTLE_ADDRESS"), os.Getenv("CATTLE_NODE_NAME"), cert, time.Now())
+	if err != nil {
+		return true, err
+	}
+
+	return needsRegen, nil
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40936, continuation of https://github.com/rancher/rancher/issues/36025
 
## Problem

Prior changes to the node agent `run.sh` file resulted in the agent improperly determining the nodes IP address in certain environments.  This resulted in scenarios where multiple nodes would register with the same IP address. The agent was changed to gather the public IP address using DNS, however in environments where all nodes share a single public IP via a network gateway or other infrastructure this poses issues during node registration. This issue occurs in custom clusters.

The change to use DNS to determine node IP was done in an attempt to determine the filename used to generate the `kubelet_serving_certificate` certificate file for the node. Before the prior PRs, the agent had no awareness of what IP address RKE1 was using to generate the certificate files, resulting in an inability to determine if they have expired or need to be refreshed. 
 
## Solution

Do not rely on logic within the node agent to determine the node IP and thus the naming of kubelet certificates. Instead, parse the node config given to the agent and find the flags passed to the kubelet process which denote the location of those certificates.  In the event that a node config does not contain valid certificates, request a new one before executing the config. 

This PR also reverts all changes made to `run.sh`. The agent will once again determine the value of `CATTLE_NODE_ADDRESS` by only using the `ip -0 route` command. 
 
## Testing

+ Create an AWS VPC with two subnets, one public and one private. Ensure a NAT gateway is routed for the private subnet. 
+ Create a bastion host in the public subnet, and two additional instances in the private subnet 
+ In the Rancher UI, create a custom RKE1 cluster
+ SSH into the bastion host, then SSH into both instances in the private subnet
+ Install docker onto both private instances 
+ Generate a registration command for all roles, and execute it on one of the instances in the private subnet 
+ Wait for the cluster to become available 
+ Generate another registration command for only the worker role, and execute it on the remaining instance in the private subnet 
+ Wait for the cluster to become active
+ Observe that each node only have 1 IP address attached to it in the Rancher UI 
+ Ensure that no health check errors are shown after the cluster has been available for 10 or more minutes 

**Additionally, you should run though the test steps for** https://github.com/rancher/rancher/issues/36025

## Engineering Testing
### Manual Testing

I've done the above, as well as revalidate 36025. Custom clusters behind a NAT gateway now come up properly and the correct private IP address is used. kubelet certs are not needlessly regenerated upon rancher server reboots. No errors are seen in the node agent relating to the new file being used, or relating to the checking of the kubelet certificate validity. 

### Automated Testing

## QA Testing Considerations
You will need a VPC with two subnets and a NAT gateway or internet gateway. The VPC setup screen in AWS has a good UI for setting this up. 
You will need to copy the pem file used when creating the instances to the bastion host in order to SSH into them 


### Regressions Considerations

We want to make sure that custom clusters work in all supported cloud providers, and that no nodes register using the same IP address in any configuration we currently test against. 