### PR TITLE
[release/v2.7] yq no longer needed in build env

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -98,10 +98,6 @@ RUN ln -s /usr/bin/cni /usr/bin/bridge && \
 
 RUN curl -sLf https://github.com/rancher/k3s/releases/download/${CATTLE_K3S_VERSION}/k3s-images.txt -o /usr/tmp/k3s-images.txt
 
-ENV YQ_URL=https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_${ARCH}
-RUN curl -sLf ${YQ_URL} -o /usr/bin/yq && chmod +x /usr/bin/yq
-
-
 RUN zypper install -y python3-tox python3-base python3 libffi-devel libopenssl-devel
 
 ENV HELM_HOME /root/.helm


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40946
 
## Problem
`yq` was added in https://github.com/rancher/rancher/pull/29664/files but the script lines that require `yq` were removed in https://github.com/rancher/rancher/pull/36283/files#diff-4dc87a76100aa810a62ff49805181a37a94d05a814447664b487220ac2783527. 

@PennyScissors Do we still need it?
 
## Solution
Remove `yq` from build environment
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->