### PR TITLE
Allow to set nodeAffinity and tolerations

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -60,9 +60,18 @@ spec:
               topologyKey: {{ .Values.topologyKey | default "kubernetes.io/hostname" }}
 {{- end }}
         nodeAffinity:
+{{- if or .Values.nodeAffinity }}
+{{ toYaml .Values.nodeAffinity | indent 10}}
+{{- else }}
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms: {{ include "linux-node-selector-terms" . | nindent 14 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8}}
+{{- else }}
       tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
+{{- end }}
       containers:
       - image: {{ .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.rancherImagePullPolicy }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -109,6 +109,12 @@ replicas: 3
 # Set priorityClassName to avoid eviction
 priorityClassName: rancher-critical
 
+# Define node affinities
+nodeAffinity: {}
+
+# Define tolerations
+tolerations: []
+
 # Set pod resource requests/limits for Rancher.
 resources: {}
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40948
 
## Problem
Need to define `nodeAffinity` and `tolerations` to our own requirements. 

## Solution
Add Helm chart values, defaulting to current configuration (Windows support).
