### PR TITLE
Prepare for v2.7.2-rc7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8
-	github.com/rancher/rke v1.4.4-rc5
+	github.com/rancher/rke v1.4.4-rc6
 	github.com/rancher/steve v0.0.0-20230222210822-3d3cc7767928
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
 	github.com/rancher/wrangler v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1376,8 +1376,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a h1:6xqYlVz4uAX
 github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8wJ/coee2n9ed937uPBWQArBaVlxs+5wkkS9KiyDc=
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8 h1:leqh0chjBsXhKWebxxFd5QPcoQLu51EpaHo04ce0o+8=
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
-github.com/rancher/rke v1.4.4-rc5 h1:2AiH7zhCXh3Vx3a+Pb/b7dAj+2vqq0ZWNFPZx9fRQjc=
-github.com/rancher/rke v1.4.4-rc5/go.mod h1:0s8+XfiyC9Ff3KLaQ4Z5mDNI+taSb/hma13xOpW6slg=
+github.com/rancher/rke v1.4.4-rc6 h1:B2LzpbGjTdlXd4EaEEGonTskiTXTsJRsg0sMwvbdw0Y=
+github.com/rancher/rke v1.4.4-rc6/go.mod h1:0s8+XfiyC9Ff3KLaQ4Z5mDNI+taSb/hma13xOpW6slg=
 github.com/rancher/steve v0.0.0-20230222210822-3d3cc7767928 h1:DhdVamlnTDBRBKgBheOwbEqWlJJ27hhKrvaM0RwtDUQ=
 github.com/rancher/steve v0.0.0-20230222210822-3d3cc7767928/go.mod h1:lCxhhsajJHMUnj0EU+3mbrucc6mHDYD94abDiWX6I/Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -159,8 +159,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-ENV CATTLE_UI_VERSION 2.7.2-rc6
-ENV CATTLE_DASHBOARD_UI_VERSION v2.7.2-rc6
+ENV CATTLE_UI_VERSION 2.7.2-rc7
+ENV CATTLE_DASHBOARD_UI_VERSION v2.7.2-rc7
 ENV CATTLE_CLI_VERSION v2.7.2-rc1
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20221220171827-374ed17d8499
 	github.com/rancher/gke-operator v1.1.5
 	github.com/rancher/norman v0.0.0-20230110004459-34230bb2787c
-	github.com/rancher/rke v1.4.4-rc5
+	github.com/rancher/rke v1.4.4-rc6
 	github.com/rancher/wrangler v1.1.0
 	github.com/sirupsen/logrus v1.9.0
 	k8s.io/api v0.25.4

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -616,8 +616,8 @@ github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc h1:29VHrInLV4qSevvcv
 github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc/go.mod h1:dEfC9eFQigj95lv/JQ8K5e7+qQCacWs1aIA6nLxKzT8=
 github.com/rancher/norman v0.0.0-20230110004459-34230bb2787c h1:xhI69R08ebqC1vIYcDMo3qY2HAPKZol+hhcG44SwHxg=
 github.com/rancher/norman v0.0.0-20230110004459-34230bb2787c/go.mod h1:zpv7z4ySYL5LlEBKEPf/xf3cjx837/J2i/wHpT43viE=
-github.com/rancher/rke v1.4.4-rc5 h1:2AiH7zhCXh3Vx3a+Pb/b7dAj+2vqq0ZWNFPZx9fRQjc=
-github.com/rancher/rke v1.4.4-rc5/go.mod h1:0s8+XfiyC9Ff3KLaQ4Z5mDNI+taSb/hma13xOpW6slg=
+github.com/rancher/rke v1.4.4-rc6 h1:B2LzpbGjTdlXd4EaEEGonTskiTXTsJRsg0sMwvbdw0Y=
+github.com/rancher/rke v1.4.4-rc6/go.mod h1:0s8+XfiyC9Ff3KLaQ4Z5mDNI+taSb/hma13xOpW6slg=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.8.10/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=
 github.com/rancher/wrangler v1.1.0 h1:1VWistON261oKmCPF5fOPMWb/YwjgEciO9pCw5Z0mzQ=

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -159,8 +159,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-ENV CATTLE_UI_VERSION 2.7.2-rc6
-ENV CATTLE_DASHBOARD_UI_VERSION v2.7.2-rc6
+ENV CATTLE_UI_VERSION 2.7.2-rc7
+ENV CATTLE_DASHBOARD_UI_VERSION v2.7.2-rc7
 ENV CATTLE_CLI_VERSION v2.7.2-rc1
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install


### PR DESCRIPTION
Changes:
- bump UI tags to v2.7.2-rc7
- bump rke to v1.4.4-rc6

 