### PR TITLE
Keycloak Issuer url fix 2.6

### DIFF
--- a/pkg/auth/providers/keycloakoidc/keycloak_client.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_client.go
@@ -171,7 +171,7 @@ func getSearchURL(issuer string) (string, error) {
 	}
 	iss = strings.SplitN(issuer, "/realms/", 2) // keycloak >= 19 doesn't have auth prefix
 	if len(iss) == 2 {
-		return fmt.Sprintf("%s/admin/realms/%s", iss[0], strings.Join(iss[1:], "")), nil
+		return fmt.Sprintf("%s/admin/realms/%s", iss[0], iss[1]), nil
 	}
 	return "", fmt.Errorf("can't parse issuer url")
 }

--- a/pkg/auth/providers/keycloakoidc/keycloak_client.go
+++ b/pkg/auth/providers/keycloakoidc/keycloak_client.go
@@ -165,12 +165,15 @@ func (k *KeyCloakClient) getFromKeyCloakByID(principalID, principalType string, 
 }
 
 func getSearchURL(issuer string) (string, error) {
-	splitIssuer := strings.SplitAfter(issuer, "/auth/")
-	return fmt.Sprintf(
-		"%sadmin/%s",
-		splitIssuer[0],
-		splitIssuer[1],
-	), nil
+	iss := strings.SplitAfter(issuer, "/auth/") // keycloak < 19 has auth prefix
+	if len(iss) == 2 {
+		return fmt.Sprintf("%sadmin/%s", iss[0], iss[1]), nil
+	}
+	iss = strings.SplitN(issuer, "/realms/", 2) // keycloak >= 19 doesn't have auth prefix
+	if len(iss) == 2 {
+		return fmt.Sprintf("%s/admin/realms/%s", iss[0], strings.Join(iss[1:], "")), nil
+	}
+	return "", fmt.Errorf("can't parse issuer url")
 }
 
 // URLEncoded encodes the string


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
#40554
 
## Problem
Keycloak did not properly parse the issuer url when `/auth/` was not included (which occurs on newer versions of keycloak), leading to a panic.
 
## Solution
We will now check the provided issuer url and split differently based on if `/auth/` is included or not.
 
## Testing

## Engineering Testing
### Manual Testing
TBD - Basic integration/group/user search (will remove TBD when done)

### Automated Testing
None

## QA Testing Considerations
Basic keycloak integration and functionality (user/group search).

### Regressions Considerations
Keycloak integration and functionality (user/group search).