### PR TITLE
Update Google Provider version in gke.tf

### DIFF
--- a/tests/validation/tests/v3_api/resource/terraform/gke/gke.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/gke/gke.tf
@@ -1,6 +1,6 @@
 provider "google" {
   region = var.region
-  version = "~> 3.42.0"
+  version = "~> 4.53.1"
   credentials = var.credentials
   project = "ei-container-platform-qa"
 }


### PR DESCRIPTION
## Issue: [653](https://github.com/rancher/qa-tasks/issues/653)
 
## Problem
Need to resolve the ability to create Hosted GKE Rancher servers using the [HA Deploy Job](https://jenkins.int.rancher.io/job/rancher_qa/job/rancher-v3_ha_deploy/).

When running the HA Deploy Jenkins job for GKE Rancher servers, we are getting the following error. in the Console Output Logs:

```
14:31:18.25  ------------------------------ Captured log call -------------------------------
14:31:18.25  __init__.py                306 WARNING  error: b'\nError: Failed to query available provider packages\n\nCould not retrieve the list of available versions for provider\nhashicorp/google: no available releases match the given constraints ~> 3.42.0,\n>= 4.47.0, != 4.49.0, != 4.50.0, < 5.0.*\n\n'
14:31:18.25  __init__.py                306 WARNING  error: b'\nError: Could not load plugin\n\n\nPlugin reinitialization required. Please run "terraform init".\n\nPlugins are external binaries that Terraform uses to access and manipulate\nresources. The configuration provided requires plugins which can\'t be located,\ndon\'t satisfy the version constraints, or are otherwise incompatible.\n\nTerraform automatically discovers provider requirements from your\nconfiguration, including providers used in child modules. To see the\nrequirements and constraints, run "terraform providers".\n\nFailed to instantiate provider "registry.terraform.io/hashicorp/google" to\nobtain schema: unknown provider "registry.terraform.io/hashicorp/google"\n\n\n'
14:31:18.25  __init__.py                306 WARNING  error: b'\nError: Could not load plugin\n\n\nPlugin reinitialization required. Please run "terraform init".\n\nPlugins are external binaries that Terraform uses to access and manipulate\nresources. The configuration provided requires plugins which can\'t be located,\ndon\'t satisfy the version constraints, or are otherwise incompatible.\n\nTerraform automatically discovers provider requirements from your\nconfiguration, including providers used in child modules. To see the\nrequirements and constraints, run "terraform providers".\n\nFailed to instantiate provider "registry.terraform.io/hashicorp/google" to\nobtain schema: unknown provider "registry.terraform.io/hashicorp/google"\n\n\n'
14:31:18.26  __init__.py                306 WARNING  error: b"\x1b[31mThe output variable requested could not be found in the state\nfile. If you recently added this to your configuration, be\nsure to run `terraform apply`, since the state won't be updated\nwith new output variables until that command is run.\x1b[0m\x1b[0m\n"
14:31:18.26  ----------- generated xml file: /src/rancher-validation/results.xml ------------
```
 
## Solution
Updated to a newer Google Provider version (4.53.1). The older existing version appeared to be depreciated.

## Testing
I have verified this works using the rancher-freeform job

### Automated Testing
This will effect the creation of Hosted GKE local clusters created by the Jenkins HA Deploy job.