### PR TITLE
Fix directory path for hardening K3s

### DIFF
--- a/tests/framework/extensions/hardening/k3s/harden_nodes.go
+++ b/tests/framework/extensions/hardening/k3s/harden_nodes.go
@@ -45,7 +45,7 @@ func HardeningNodes(client *rancher.Client, hardened bool, nodes []*nodes.Node, 
 				return nil
 			}
 
-			dirPath := filepath.Join(user.HomeDir, "go/src/github.com/rancher/rancher/tests/framework/extensions/hardening/rke2")
+			dirPath := filepath.Join(user.HomeDir, "go/src/github.com/rancher/rancher/tests/framework/extensions/hardening/k3s")
 			err = node.SCPFileToNode(dirPath+"/audit.yaml", "/home/"+node.SSHUser+"/audit.yaml")
 			if err != nil {
 				return err


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
K3s hardening in the v2.7 branch is referencing RKE2 instead of K3s. This is only happening for this cluster type in this branch; I validated RKE2/K3s in v2.6 branch are fine. Additionally, RKE2 in the v2.7 branch points to the correct directory path.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updated the K3s hardening directory path to reference K3s and not RKE2.