### PR TITLE
Add validation test for post kdm OOB release checks

### DIFF
--- a/tests/v2/validation/provisioning/k3s/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/k3s/post_kdm_oob_release_test.go
@@ -1,0 +1,155 @@
+package k3s
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	kubeProvisioning "github.com/rancher/rancher/tests/framework/clients/provisioning"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	provisioningV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/versions"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type KdmChecksTestSuite struct {
+	suite.Suite
+	session               *session.Session
+	client                *rancher.Client
+	ns                    string
+	k3skubernetesVersions []string
+	cnis                  []string
+	providers             []string
+	nodesAndRoles         []machinepools.NodeRoles
+}
+
+const (
+	defaultNamespace = "default"
+)
+
+func (k *KdmChecksTestSuite) TearDownSuite() {
+	k.session.Cleanup()
+}
+
+func (k *KdmChecksTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	k.session = testSession
+
+	k.ns = defaultNamespace
+
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+
+	k.k3skubernetesVersions = clustersConfig.K3SKubernetesVersions
+
+	k.cnis = clustersConfig.CNIs
+	k.providers = clustersConfig.Providers
+	k.nodesAndRoles = clustersConfig.NodesAndRoles
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(k.T(), err)
+
+	k.client = client
+}
+
+func (k *KdmChecksTestSuite) TestK3SK8sVersions() {
+	logrus.Infof("checking for valid k8s versions..")
+	require.GreaterOrEqual(k.T(), len(k.k3skubernetesVersions), 1)
+	// fetching all available k8s versions from rancher
+	releasedK8sVersions, _ := versions.ListK3SAllVersions(k.client)
+	logrus.Info("expected k8s versions : ", k.k3skubernetesVersions)
+	logrus.Info("k8s versions available on rancher server : ", releasedK8sVersions)
+	for _, expectedK8sVersion := range k.k3skubernetesVersions {
+		require.Contains(k.T(), releasedK8sVersions, expectedK8sVersion)
+	}
+}
+
+func (k *KdmChecksTestSuite) TestProvisioningSingleNodeK3SClusters() {
+	require.GreaterOrEqual(k.T(), len(k.providers), 1)
+
+	subSession := k.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := k.client.WithSession(subSession)
+	require.NoError(k.T(), err)
+
+	kubeProvisioningClient, err := k.client.GetKubeAPIProvisioningClient()
+	require.NoError(k.T(), err)
+
+	providerName := k.providers[0]
+	provider := CreateProvider(providerName)
+	nodeRoles := k.nodesAndRoles
+
+	clusterNames := []string{}
+	clusterResps := []*provisioningV1.SteveAPIObject{}
+	k8sVersions := []string{}
+
+	for _, k8sVersion := range k.k3skubernetesVersions {
+
+		clusterName := namegen.AppendRandomString(provider.Name)
+
+		cloudCredential, err := provider.CloudCredFunc(client)
+		require.NoError(k.T(), err)
+
+		generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
+		machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, k.ns)
+		machineConfigResp, err := client.Steve.SteveType(provider.MachineConfigPoolResourceSteveType).Create(machinePoolConfig)
+		require.NoError(k.T(), err)
+
+		machinePools := machinepools.RKEMachinePoolSetup(nodeRoles, machineConfigResp)
+		cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, k.ns, "", cloudCredential.ID, k8sVersion, machinePools)
+
+		logrus.Info("provisioning " + k8sVersion + " cluster..")
+
+		clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
+		require.NoError(k.T(), err)
+
+		clusterNames = append(clusterNames, clusterName)
+		clusterResps = append(clusterResps, clusterResp)
+		k8sVersions = append(k8sVersions, cluster.Spec.KubernetesVersion)
+	}
+
+	k.checkClustersReady(k.client, kubeProvisioningClient, clusterResps, clusterNames, k8sVersions)
+}
+
+func (k *KdmChecksTestSuite) checkClustersReady(client *rancher.Client, kubeProvisioningClient *kubeProvisioning.Client, clusterResps []*provisioningV1.SteveAPIObject, clusterNames []string, k8sVersions []string) {
+	for i, clusterResp := range clusterResps {
+		logrus.Info("waiting for cluster ", clusterResp.Name, " to be up..")
+		result, err := kubeProvisioningClient.Clusters(k.ns).Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + clusterResp.Name,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+		require.NoError(k.T(), err)
+		checkFunc := clusters.IsProvisioningClusterReady
+		err = wait.WatchWait(result, checkFunc)
+		require.NoError(k.T(), err)
+
+		assert.Equal(k.T(), clusterNames[i], clusterResp.Name)
+		assert.Equal(k.T(), k.k3skubernetesVersions[i], k8sVersions[i])
+
+		clusterID, err := clusters.GetClusterIDByName(client, clusterResp.Name)
+		require.NoError(k.T(), err)
+
+		podResults, podErrors := pods.StatusPods(client, clusterID)
+		assert.NotEmpty(k.T(), podResults)
+		assert.Empty(k.T(), podErrors)
+
+	}
+}
+
+func TestPostKdmOutOfBandReleaseChecks(t *testing.T) {
+	suite.Run(t, new(KdmChecksTestSuite))
+}

--- a/tests/v2/validation/provisioning/rke1/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/rke1/post_kdm_oob_release_test.go
@@ -1,0 +1,160 @@
+package rke1
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/versions"
+	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
+	"github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type KdmChecksTestSuite struct {
+	suite.Suite
+	session                *session.Session
+	client                 *rancher.Client
+	ns                     string
+	rke1kubernetesVersions []string
+	cnis                   []string
+	providers              []string
+	nodesAndRoles          []nodepools.NodeRoles
+}
+
+const (
+	defaultNamespace             = "default"
+	ProvisioningSteveResouceType = "provisioning.cattle.io.cluster"
+)
+
+func (k *KdmChecksTestSuite) TearDownSuite() {
+	k.session.Cleanup()
+}
+
+func (k *KdmChecksTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	k.session = testSession
+
+	k.ns = defaultNamespace
+
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+
+	k.rke1kubernetesVersions = clustersConfig.RKE1KubernetesVersions
+
+	k.cnis = clustersConfig.CNIs
+	k.providers = clustersConfig.Providers
+	k.nodesAndRoles = clustersConfig.NodesAndRolesRKE1
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(k.T(), err)
+
+	k.client = client
+}
+
+func (k *KdmChecksTestSuite) TestRKE1K8sVersions() {
+	logrus.Infof("checking for valid k8s versions..")
+	require.GreaterOrEqual(k.T(), len(k.rke1kubernetesVersions), 1)
+	// fetching all available k8s versions from rancher
+	releasedK8sVersions, _ := versions.ListRKE1AllVersions(k.client)
+	logrus.Info("expected k8s versions : ", k.rke1kubernetesVersions)
+	logrus.Info("k8s versions available on rancher server : ", releasedK8sVersions)
+	for _, expectedK8sVersion := range k.rke1kubernetesVersions {
+		require.Contains(k.T(), releasedK8sVersions, expectedK8sVersion)
+	}
+}
+
+func (k *KdmChecksTestSuite) TestProvisioningSingleNodeRKE1Clusters() {
+	require.GreaterOrEqual(k.T(), len(k.providers), 1)
+	require.GreaterOrEqual(k.T(), len(k.cnis), 1)
+
+	subSession := k.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := k.client.WithSession(subSession)
+	require.NoError(k.T(), err)
+
+	providerName := k.providers[0]
+	provider := CreateProvider(providerName)
+
+	nodePools := []*management.NodePool{}
+	nodePoolNames := []string{}
+	clusterNames := []string{}
+	clusterResps := []*management.Cluster{}
+
+	for _, k8sVersion := range k.rke1kubernetesVersions {
+		for _, cni := range k.cnis {
+			logrus.Info("provisioning " + k8sVersion + " cluster..")
+			nodeTemplate, err := provider.NodeTemplateFunc(client)
+			require.NoError(k.T(), err)
+
+			clusterResp, nodePool, nodePoolName, clusterName, err := k.provisionRKE1Cluster(client, provider, k.nodesAndRoles, k8sVersion, cni, nodeTemplate)
+			require.NoError(k.T(), err)
+
+			nodePoolNames = append(nodePoolNames, nodePoolName)
+			clusterNames = append(clusterNames, clusterName)
+			clusterResps = append(clusterResps, clusterResp)
+			nodePools = append(nodePools, nodePool)
+		}
+	}
+
+	k.checkClustersReady(client, clusterResps, nodePools, clusterNames, nodePoolNames)
+
+}
+
+func (k *KdmChecksTestSuite) provisionRKE1Cluster(client *rancher.Client, provider Provider, nodesAndRoles []nodepools.NodeRoles, k8sVersion, cni string, nodeTemplate *nodetemplates.NodeTemplate) (*management.Cluster, *management.NodePool, string, string, error) {
+	clusterName := namegen.AppendRandomString(provider.Name)
+
+	cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, k8sVersion, client)
+	clusterResp, err := clusters.CreateRKE1Cluster(client, cluster)
+	require.NoError(k.T(), err)
+
+	nodePool, err := nodepools.NodePoolSetup(client, nodesAndRoles, clusterResp.ID, nodeTemplate.ID)
+	require.NoError(k.T(), err)
+
+	nodePoolName := nodePool.Name
+
+	return clusterResp, nodePool, nodePoolName, clusterName, nil
+}
+
+func (k *KdmChecksTestSuite) checkClustersReady(client *rancher.Client, clusterResps []*management.Cluster, nodePools []*management.NodePool, clusterNames []string, nodePoolNames []string) {
+	for i, clusterResp := range clusterResps {
+		opts := metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + clusterResp.ID,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		}
+
+		logrus.Info("waiting for cluster ", clusterResp.Name, " with k8s version ", k.rke1kubernetesVersions[i], " to be up..")
+		watchInterface, err := k.client.GetManagementWatchInterface(management.ClusterType, opts)
+		require.NoError(k.T(), err)
+
+		checkFunc := clusters.IsHostedProvisioningClusterReady
+
+		err = wait.WatchWait(watchInterface, checkFunc)
+		require.NoError(k.T(), err)
+		assert.Equal(k.T(), clusterNames[i], clusterResp.Name)
+		assert.Equal(k.T(), nodePoolNames[i], nodePools[i].Name)
+		assert.Equal(k.T(), k.rke1kubernetesVersions[i], clusterResp.RancherKubernetesEngineConfig.Version)
+
+		podResults, podErrors := pods.StatusPods(client, clusterResp.ID)
+		assert.NotEmpty(k.T(), podResults)
+		assert.Empty(k.T(), podErrors)
+
+	}
+}
+
+func TestPostKdmOutOfBandReleaseChecks(t *testing.T) {
+	suite.Run(t, new(KdmChecksTestSuite))
+}

--- a/tests/v2/validation/provisioning/rke2/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/rke2/post_kdm_oob_release_test.go
@@ -1,0 +1,150 @@
+package rke2
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	kubeProvisioning "github.com/rancher/rancher/tests/framework/clients/provisioning"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/versions"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type KdmChecksTestSuite struct {
+	suite.Suite
+	session                *session.Session
+	client                 *rancher.Client
+	ns                     string
+	rke2kubernetesVersions []string
+	cnis                   []string
+	providers              []string
+	nodesAndRoles          []machinepools.NodeRoles
+}
+
+func (k *KdmChecksTestSuite) TearDownSuite() {
+	k.session.Cleanup()
+}
+
+func (k *KdmChecksTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	k.session = testSession
+
+	k.ns = defaultNamespace
+
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+
+	k.rke2kubernetesVersions = clustersConfig.RKE2KubernetesVersions
+
+	k.cnis = clustersConfig.CNIs
+	k.providers = clustersConfig.Providers
+	k.nodesAndRoles = clustersConfig.NodesAndRoles
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(k.T(), err)
+
+	k.client = client
+}
+
+func (k *KdmChecksTestSuite) TestRKE2K8sVersions() {
+	logrus.Infof("checking for valid k8s versions..")
+	require.GreaterOrEqual(k.T(), len(k.rke2kubernetesVersions), 1)
+	// fetching all available k8s versions from rancher
+	releasedK8sVersions, _ := versions.ListRKE2AllVersions(k.client)
+	logrus.Info("expected k8s versions : ", k.rke2kubernetesVersions)
+	logrus.Info("k8s versions available on rancher server : ", releasedK8sVersions)
+	for _, expectedK8sVersion := range k.rke2kubernetesVersions {
+		require.Contains(k.T(), releasedK8sVersions, expectedK8sVersion)
+	}
+}
+
+func (k *KdmChecksTestSuite) TestProvisioningSingleNodeRKE2Clusters() {
+	require.GreaterOrEqual(k.T(), len(k.providers), 1)
+	require.GreaterOrEqual(k.T(), len(k.cnis), 1)
+
+	subSession := k.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := k.client.WithSession(subSession)
+	require.NoError(k.T(), err)
+
+	kubeProvisioningClient, err := k.client.GetKubeAPIProvisioningClient()
+	require.NoError(k.T(), err)
+
+	providerName := k.providers[0]
+	provider := CreateProvider(providerName)
+	nodeRoles := k.nodesAndRoles
+
+	clusterNames := []string{}
+	clusterResps := []*v1.SteveAPIObject{}
+	k8sVersions := []string{}
+
+	for _, k8sVersion := range k.rke2kubernetesVersions {
+
+		clusterName := namegen.AppendRandomString(provider.Name)
+
+		cloudCredential, err := provider.CloudCredFunc(client)
+		require.NoError(k.T(), err)
+		generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
+		machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, k.ns)
+		machineConfigResp, err := client.Steve.SteveType(provider.MachineConfigPoolResourceSteveType).Create(machinePoolConfig)
+		require.NoError(k.T(), err)
+		machinePools := machinepools.RKEMachinePoolSetup(nodeRoles, machineConfigResp)
+
+		cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, k.ns, k.cnis[0], cloudCredential.ID, k8sVersion, machinePools)
+
+		logrus.Info("provisioning " + k8sVersion + " cluster..")
+
+		clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
+		require.NoError(k.T(), err)
+
+		clusterNames = append(clusterNames, clusterName)
+		clusterResps = append(clusterResps, clusterResp)
+		k8sVersions = append(k8sVersions, cluster.Spec.KubernetesVersion)
+	}
+
+	k.checkClustersReady(client, kubeProvisioningClient, clusterResps, clusterNames, k8sVersions)
+}
+
+func (k *KdmChecksTestSuite) checkClustersReady(client *rancher.Client, kubeProvisioningClient *kubeProvisioning.Client, clusterResps []*v1.SteveAPIObject, clusterNames []string, k8sVersions []string) {
+	for i, clusterResp := range clusterResps {
+		logrus.Info("waiting for cluster ", clusterResp.Name, " with k8s version ", k.rke2kubernetesVersions[i], " to be up..")
+		result, err := kubeProvisioningClient.Clusters(k.ns).Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + clusterResp.Name,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+		require.NoError(k.T(), err)
+		checkFunc := clusters.IsProvisioningClusterReady
+		err = wait.WatchWait(result, checkFunc)
+		require.NoError(k.T(), err)
+
+		assert.Equal(k.T(), clusterNames[i], clusterResp.Name)
+		assert.Equal(k.T(), k.rke2kubernetesVersions[i], k8sVersions[i])
+
+		clusterID, err := clusters.GetClusterIDByName(client, clusterResp.Name)
+		require.NoError(k.T(), err)
+
+		podResults, podErrors := pods.StatusPods(client, clusterID)
+		assert.NotEmpty(k.T(), podResults)
+		assert.Empty(k.T(), podErrors)
+	}
+}
+
+func TestPostKdmOutOfBandReleaseChecks(t *testing.T) {
+	suite.Run(t, new(KdmChecksTestSuite))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/612

- This PR adds KDM checks(as mentioned in the issue above) in the RKE1, RKE2 and K3S package that validates released k8s versions on rancher server are present or not and provisions single node, all role clusters using released k8s versions. In order to validate whether new k8s versions are present on rancher server, we need to add those k8s version in the cattle-config.yaml file as per below:
```
provisioningInput:  
  nodesAndRoles:
    - etcd: true
      controlplane: true
      worker: true 
      quantity: 1 
  nodesAndRolesRKE1: 
    - etcd: true
      controlplane: true
      worker: true 
      quantity: 1 
  rke2KubernetesVersion: 
    - v1.23.16+rke2r1
    - v1.24.10+rke2r1
  rke1KubernetesVersion: 
    - v1.23.16-rancher2-1
    - v1.24.10-rancher4-1
  k3sKubernetesVersion: 
    - v1.23.16+k3s1
    - v1.24.10+k3s1
```
 
**Note:**
- This validation test takes around 20 mins to complete which is more than default timeout for the test that's why we need to use -timeout option with value either greater than 20mins or 0.