### PR TITLE
Make sure the required secret is available to the rancher-machine pod when deleting a node

### DIFF
--- a/pkg/controllers/capr/machineprovision/args.go
+++ b/pkg/controllers/capr/machineprovision/args.go
@@ -124,6 +124,9 @@ func (h *handler) getArgsEnvAndStatus(infra *infraObject, args map[string]interf
 
 	instanceName := getInstanceName(*infra)
 
+	// The files secret must be constructed before toArgs is called because
+	// constructFilesSecret replaces file contents and creates a secret to be passed as a volume.
+	filesSecret = constructFilesSecret(driver, args)
 	if create {
 		cmd = append(cmd, "create",
 			fmt.Sprintf("--driver=%s", driver),
@@ -138,9 +141,6 @@ func (h *handler) getArgsEnvAndStatus(infra *infraObject, args map[string]interf
 		if err != nil {
 			return driverArgs{}, err
 		}
-		// The files secret must be constructed before toArgs is called because
-		// constructFilesSecret replaces file contents and creates a secret to be passed as a volume.
-		filesSecret = constructFilesSecret(driver, args)
 		cmd = append(cmd, toArgs(driver, args, rancherCluster.Status.ClusterName)...)
 	} else {
 		cmd = append(cmd, "rm", "-y")


### PR DESCRIPTION
Some NodeDrivers need to have access to the same secrets they used when creating the node. For example, the Openstack node driver needs access to the cacert file that is used to connect to Openstack.

## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/39222
 
## Problem
The Openstack node driver fails to delete nodes when a cacert is used to connect to the Openstack cluster. The cause is that the secret containing the certificate is not mounted on the ``rancher-machine` pod that deletes the node. See the issue for more details.
 
## Solution
run the constructFilesSecret function when deleting the node to add the required secrets to the rancher-machine pod
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
The fix was tested on the EngCloud Openstack cluster.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->