### PR TITLE
[Backport] Add validation test for etcd backup and restore with cluster config

### DIFF
--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
@@ -230,3 +230,21 @@ func watchAndWaitForPods(client *rancher.Client, clusterID string) error {
 	})
 	return err
 }
+
+func upgradeClusterK8sVersionWithUpgradeStrategy(client *rancher.Client, clustername string, k8sUpgradedVersion string, namespaceName string) error {
+	clusterObj, existingSteveAPIObj, err := getProvisioningClusterByName(client, clustername, namespaceName)
+	if err != nil {
+		return err
+	}
+
+	clusterObj.Spec.RKEConfig.UpgradeStrategy.ControlPlaneConcurrency = "15%"
+	clusterObj.Spec.RKEConfig.UpgradeStrategy.WorkerConcurrency = "20%"
+	clusterObj.Spec.KubernetesVersion = k8sUpgradedVersion
+
+	_, err = client.Steve.SteveType(clusters.ProvisioningSteveResouceType).Update(existingSteveAPIObj, clusterObj)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/qa-tasks/issues/407

**Note:**
- This validation test takes around 20 mins to complete which is more than default timeout for the test that's why we need to use -timeout option with value either greater than 20mins or 0. Similar to below command
`go test providers.go etcd_bkp_restore_test.go -v -timeout 0`
- Also it will require at least two k8s version in ascending order in the cattle config file and at least one CNI provider as per below:
```
provisioningInput:  
     rke2KubernetesVersion: 
    - v1.23.16+rke2r1
    - v1.24.10+rke2r1
  cni:
    - calico
```