### PR TITLE
Un-rc rancher-webhook and rancher-csp-adapter

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -54,8 +54,8 @@ ENV CATTLE_SYSTEM_UPGRADE_CONTROLLER_CHART_VERSION 102.0.0+up0.4.0
 
 # System charts minimal version
 ENV CATTLE_FLEET_MIN_VERSION=102.0.0+up0.6.0-rc.5
-ENV CATTLE_RANCHER_WEBHOOK_MIN_VERSION=2.0.2+up0.3.2-rc22
-ENV CATTLE_CSP_ADAPTER_MIN_VERSION=2.0.1-rc1
+ENV CATTLE_RANCHER_WEBHOOK_MIN_VERSION=2.0.2+up0.3.2
+ENV CATTLE_CSP_ADAPTER_MIN_VERSION=2.0.1
 
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/library && \


### PR DESCRIPTION
Bump rancher-webhook to v0.3.2 and rancher-csp-adapter to v2.0.1

## Issue: <!-- link the issue or issues this PR resolves here -->
Related to rancher/charts#2516 - since the adapter and webhook are system charts, their pinned versions must be updated in rancher after new versions are created.