### PR TITLE
[v2.6]Add etcd/cp shared node test cases to provisioning suite

### DIFF
--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -72,6 +72,11 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomCluster() 
 	}
 
 	nodeRoles1 := []string{
+		"--etcd --controlplane",
+		"--worker",
+	}
+
+	nodeRoles2 := []string{
 		"--etcd",
 		"--controlplane",
 		"--worker",
@@ -84,8 +89,10 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomCluster() 
 	}{
 		{"1 Node all roles Admin User", nodeRoles0, c.client},
 		{"1 Node all roles Standard User", nodeRoles0, c.standardUserClient},
-		{"3 nodes - 1 role per node Admin User", nodeRoles1, c.client},
-		{"3 nodes - 1 role per node Standard User", nodeRoles1, c.standardUserClient},
+		{"2 nodes - etcd/cp roles per 1 node Admin User", nodeRoles1, c.client},
+		{"2 nodes - etcd/cp roles per 1 node Standard User", nodeRoles1, c.standardUserClient},
+		{"3 nodes - 1 role per node Admin User", nodeRoles2, c.client},
+		{"3 nodes - 1 role per node Standard User", nodeRoles2, c.standardUserClient},
 	}
 	var name string
 	for _, tt := range tests {

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
@@ -78,6 +78,21 @@ func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SCluster() {
 	nodeRoles1 := []machinepools.NodeRoles{
 		{
 			ControlPlane: true,
+			Etcd:         true,
+			Worker:       false,
+			Quantity:     1,
+		},
+		{
+			ControlPlane: false,
+			Etcd:         false,
+			Worker:       true,
+			Quantity:     1,
+		},
+	}
+
+	nodeRoles2 := []machinepools.NodeRoles{
+		{
+			ControlPlane: true,
 			Etcd:         false,
 			Worker:       false,
 			Quantity:     1,
@@ -103,8 +118,10 @@ func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SCluster() {
 	}{
 		{"1 Node all roles Admin User", nodeRoles0, k.client},
 		{"1 Node all roles Standard User", nodeRoles0, k.standardUserClient},
-		{"3 nodes - 1 role per node Admin User", nodeRoles1, k.client},
-		{"3 nodes - 1 role per node Standard User", nodeRoles1, k.standardUserClient},
+		{"2 nodes - etcd/cp roles per 1 node Admin User", nodeRoles1, k.client},
+		{"2 nodes - etcd/cp roles per 1 node Standard User", nodeRoles1, k.standardUserClient},
+		{"3 nodes - 1 role per node Admin User", nodeRoles2, k.client},
+		{"3 nodes - 1 role per node Standard User", nodeRoles2, k.standardUserClient},
 	}
 
 	var name string

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -72,6 +72,11 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 	}
 
 	nodeRoles1 := []string{
+		"--etcd --controlplane",
+		"--worker",
+	}
+
+	nodeRoles2 := []string{
 		"--etcd",
 		"--controlplane",
 		"--worker",
@@ -84,8 +89,10 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 	}{
 		{"1 Node all roles Admin User", nodeRoles0, c.client},
 		{"1 Node all roles Standard User", nodeRoles0, c.standardUserClient},
-		{"3 nodes - 1 role per node Admin User", nodeRoles1, c.client},
-		{"3 nodes - 1 role per node Standard User", nodeRoles1, c.standardUserClient},
+		{"2 nodes - etcd/cp roles per 1 node Admin User", nodeRoles1, c.client},
+		{"2 nodes - etcd/cp roles per 1 node Standard User", nodeRoles1, c.standardUserClient},
+		{"3 nodes - 1 role per node Admin User", nodeRoles2, c.client},
+		{"3 nodes - 1 role per node Standard User", nodeRoles2, c.standardUserClient},
 	}
 	var name string
 	for _, tt := range tests {

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -82,6 +82,21 @@ func (r *RKE1NodeDriverProvisioningTestSuite) TestProvisioningRKE1Cluster() {
 	nodeRoles1 := []nodepools.NodeRoles{
 		{
 			ControlPlane: true,
+			Etcd:         true,
+			Worker:       false,
+			Quantity:     1,
+		},
+		{
+			ControlPlane: false,
+			Etcd:         false,
+			Worker:       true,
+			Quantity:     1,
+		},
+	}
+
+	nodeRoles2 := []nodepools.NodeRoles{
+		{
+			ControlPlane: true,
 			Etcd:         false,
 			Worker:       false,
 			Quantity:     1,
@@ -107,8 +122,10 @@ func (r *RKE1NodeDriverProvisioningTestSuite) TestProvisioningRKE1Cluster() {
 	}{
 		{"1 Node all roles Admin User", nodeRoles0, r.client},
 		{"1 Node all roles Standard User", nodeRoles0, r.standardUserClient},
-		{"3 nodes - 1 role per node Admin User", nodeRoles1, r.client},
-		{"3 nodes - 1 role per node Standard User", nodeRoles1, r.standardUserClient},
+		{"2 nodes - etcd/cp roles per 1 node Admin User", nodeRoles1, r.client},
+		{"2 nodes - etcd/cp roles per 1 node Standard User", nodeRoles1, r.standardUserClient},
+		{"3 nodes - 1 role per node Admin User", nodeRoles2, r.client},
+		{"3 nodes - 1 role per node Standard User", nodeRoles2, r.standardUserClient},
 	}
 
 	var name, scaleName string

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -74,6 +74,11 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE2CustomCluster()
 	}
 
 	nodeRoles1 := []string{
+		"--etcd --controlplane",
+		"--worker",
+	}
+
+	nodeRoles2 := []string{
 		"--etcd",
 		"--controlplane",
 		"--worker",
@@ -89,12 +94,16 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE2CustomCluster()
 	}{
 		{"1 Node all roles Admin User", c.client, nodeRoles0, c.provisioning, 0, false},
 		{"1 Node all roles Standard User", c.standardUserClient, nodeRoles0, c.provisioning, 0, false},
-		{"3 nodes - 1 role per node Admin User", c.client, nodeRoles1, c.provisioning, 0, false},
-		{"3 nodes - 1 role per node Standard User", c.standardUserClient, nodeRoles1, c.provisioning, 0, false},
+		{"2 nodes - etcd/cp roles per 1 node Admin User", c.client, nodeRoles1, c.provisioning, 0, false},
+		{"2 nodes - etcd/cp roles per 1 node Standard User", c.client, nodeRoles1, c.provisioning, 0, false},
+		{"3 nodes - 1 role per node Admin User", c.client, nodeRoles2, c.provisioning, 0, false},
+		{"3 nodes - 1 role per node Standard User", c.standardUserClient, nodeRoles2, c.provisioning, 0, false},
 		{"1 Node all roles Admin User + 1 Windows Worker", c.client, nodeRoles0, c.provisioning, 1, true},
 		{"1 Node all roles Standard User + 1 Windows Worker", c.standardUserClient, nodeRoles0, c.provisioning, 1, true},
-		{"3 nodes - 1 role per node Admin User + 2 Windows Workers", c.client, nodeRoles1, c.provisioning, 2, true},
-		{"3 nodes - 1 role per node Standard User + 2 Windows Workers", c.standardUserClient, nodeRoles1, c.provisioning, 2, true},
+		{"2 nodes - etcd/cp roles per 1 node Admin User + 1 Windows Worker", c.client, nodeRoles1, c.provisioning, 1, true},
+		{"2 nodes - etcd/cp roles per 1 node Standard User + 1 Windows Worker", c.client, nodeRoles1, c.provisioning, 1, true},
+		{"3 nodes - 1 role per node Admin User + 2 Windows Workers", c.client, nodeRoles2, c.provisioning, 2, true},
+		{"3 nodes - 1 role per node Standard User + 2 Windows Workers", c.standardUserClient, nodeRoles2, c.provisioning, 2, true},
 	}
 	var name string
 	for _, tt := range tests {

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -80,6 +80,21 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2Cluster() {
 	nodeRoles1 := []machinepools.NodeRoles{
 		{
 			ControlPlane: true,
+			Etcd:         true,
+			Worker:       false,
+			Quantity:     1,
+		},
+		{
+			ControlPlane: false,
+			Etcd:         false,
+			Worker:       true,
+			Quantity:     1,
+		},
+	}
+
+	nodeRoles2 := []machinepools.NodeRoles{
+		{
+			ControlPlane: true,
 			Etcd:         false,
 			Worker:       false,
 			Quantity:     1,
@@ -105,8 +120,10 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2Cluster() {
 	}{
 		{"1 Node all roles Admin User", nodeRoles0, r.client},
 		{"1 Node all roles Standard User", nodeRoles0, r.standardUserClient},
-		{"3 nodes - 1 role per node Admin User", nodeRoles1, r.client},
-		{"3 nodes - 1 role per node Standard User", nodeRoles1, r.standardUserClient},
+		{"2 nodes - etcd/cp roles per 1 node Admin User", nodeRoles1, r.client},
+		{"2 nodes - etcd/cp roles per 1 node Standard User", nodeRoles1, r.standardUserClient},
+		{"3 nodes - 1 role per node Admin User", nodeRoles2, r.client},
+		{"3 nodes - 1 role per node Standard User", nodeRoles2, r.standardUserClient},
 	}
 
 	var name string


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Automate having etcd/cp in the same shared nodepool for cluster provisioning](https://github.com/rancher/qa-tasks/issues/670)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Recently, there has been an uptick in the number of issues QA has seen regarding etcd/cp sharing a node. As such, we should add test cases in our provisioning automation that will always account for this scenario.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
In node provider and custom clusters, I added a new test case that has etcd/controlplane share a node, while the worker role is on a separate node; in short, there will be test cases accounting for 2 nodes (1 etcd/cp and 1 worker).
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
None, since this is just adding new test cases modeled after existing ones. I will run automated runs, however.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Jenkins runs will be given offline to the reviewers.