### PR TITLE
Refactoring cluster provisioning for rke1,rke2 and k3s cluster creation

### DIFF
--- a/tests/v2/validation/provisioning/k3s/custom_cluster.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster.go
@@ -1,0 +1,101 @@
+package k3s
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	hardening "github.com/rancher/rancher/tests/framework/extensions/hardening/k3s"
+	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
+	"github.com/rancher/rancher/tests/framework/extensions/tokenregistration"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestProvisioningK3SCustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []string, kubeVersion string, hardened bool) {
+	namespace := "fleet-default"
+
+	numNodes := len(nodesAndRoles)
+	nodes, _, err := externalNodeProvider.NodeCreationFunc(client, numNodes, 0, false)
+	require.NoError(t, err)
+
+	clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
+
+	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, nil)
+
+	clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
+	require.NoError(t, err)
+
+	client, err = client.ReLogin()
+	require.NoError(t, err)
+	customCluster, err := client.Steve.SteveType(clusters.ProvisioningSteveResouceType).ByID(clusterResp.ID)
+	require.NoError(t, err)
+
+	clusterStatus := &apiv1.ClusterStatus{}
+	err = v1.ConvertToK8sType(customCluster.Status, clusterStatus)
+	require.NoError(t, err)
+
+	token, err := tokenregistration.GetRegistrationToken(client, clusterStatus.ClusterName)
+	require.NoError(t, err)
+
+	for key, node := range nodes {
+		t.Logf("Execute Registration Command for node %s", node.NodeID)
+		command := fmt.Sprintf("%s %s", token.InsecureNodeCommand, nodesAndRoles[key])
+
+		output, err := node.ExecuteCommand(command)
+		require.NoError(t, err)
+		t.Logf(output)
+	}
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+	kubeProvisioningClient, err := adminClient.GetKubeAPIProvisioningClient()
+	require.NoError(t, err)
+
+	result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + clusterName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	require.NoError(t, err)
+
+	checkFunc := clusters.IsProvisioningClusterReady
+
+	err = wait.WatchWait(result, checkFunc)
+	assert.NoError(t, err)
+	assert.Equal(t, clusterName, clusterResp.ObjectMeta.Name)
+	assert.Equal(t, kubeVersion, cluster.Spec.KubernetesVersion)
+
+	clusterIDName, err := clusters.GetClusterIDByName(adminClient, clusterName)
+	assert.NoError(t, err)
+
+	err = nodestat.IsNodeReady(client, clusterIDName)
+	require.NoError(t, err)
+
+	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+	require.NoError(t, err)
+	assert.NotEmpty(t, clusterToken)
+
+	podResults, podErrors := pods.StatusPods(client, clusterIDName)
+	assert.NotEmpty(t, podResults)
+	assert.Empty(t, podErrors)
+
+	if hardened && kubeVersion <= string(provisioning.HardenedKubeVersion) {
+		err = hardening.HardeningNodes(client, hardened, nodes, nodesAndRoles)
+		require.NoError(t, err)
+
+		hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, nil)
+		hardenClusterResp, err := clusters.UpdateK3SRKE2Cluster(client, clusterResp, hardenCluster)
+		require.NoError(t, err)
+		assert.Equal(t, clusterName, hardenClusterResp.ObjectMeta.Name)
+	}
+}

--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -1,31 +1,18 @@
 package k3s
 
 import (
-	"context"
-	"fmt"
 	"testing"
 
-	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
-	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
-	"github.com/rancher/rancher/tests/framework/extensions/clusters"
-	hardening "github.com/rancher/rancher/tests/framework/extensions/hardening/k3s"
-	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
-	"github.com/rancher/rancher/tests/framework/extensions/tokenregistration"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
-	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
-	"github.com/rancher/rancher/tests/framework/pkg/wait"
-	"github.com/rancher/rancher/tests/integration/pkg/defaults"
 	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type CustomClusterProvisioningTestSuite struct {
@@ -113,7 +100,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomCluster() 
 			for _, kubeVersion := range c.kubernetesVersions {
 				name = tt.name + " Kubernetes version: " + kubeVersion
 				c.Run(name, func() {
-					c.testProvisioningK3SCustomCluster(client, externalNodeProvider, tt.nodeRoles, kubeVersion)
+					TestProvisioningK3SCustomCluster(c.T(), client, externalNodeProvider, tt.nodeRoles, kubeVersion, c.hardened)
 				})
 			}
 		}
@@ -165,87 +152,10 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomClusterDyn
 			for _, kubeVersion := range c.kubernetesVersions {
 				name = tt.name + " Kubernetes version: " + kubeVersion
 				c.Run(name, func() {
-					c.testProvisioningK3SCustomCluster(client, externalNodeProvider, rolesPerNode, kubeVersion)
+					TestProvisioningK3SCustomCluster(c.T(), client, externalNodeProvider, rolesPerNode, kubeVersion, c.hardened)
 				})
 			}
 		}
-	}
-}
-
-func (c *CustomClusterProvisioningTestSuite) testProvisioningK3SCustomCluster(client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []string, kubeVersion string) {
-	namespace := "fleet-default"
-
-	numNodes := len(nodesAndRoles)
-	nodes, _, err := externalNodeProvider.NodeCreationFunc(client, numNodes, 0, false)
-	require.NoError(c.T(), err)
-
-	clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
-
-	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, nil)
-
-	clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
-	require.NoError(c.T(), err)
-
-	client, err = client.ReLogin()
-	require.NoError(c.T(), err)
-	customCluster, err := client.Steve.SteveType(clusters.ProvisioningSteveResouceType).ByID(clusterResp.ID)
-	require.NoError(c.T(), err)
-
-	clusterStatus := &apiv1.ClusterStatus{}
-	err = v1.ConvertToK8sType(customCluster.Status, clusterStatus)
-	require.NoError(c.T(), err)
-
-	token, err := tokenregistration.GetRegistrationToken(client, clusterStatus.ClusterName)
-	require.NoError(c.T(), err)
-
-	for key, node := range nodes {
-		c.T().Logf("Execute Registration Command for node %s", node.NodeID)
-		command := fmt.Sprintf("%s %s", token.InsecureNodeCommand, nodesAndRoles[key])
-
-		output, err := node.ExecuteCommand(command)
-		require.NoError(c.T(), err)
-		c.T().Logf(output)
-	}
-
-	kubeProvisioningClient, err := c.client.GetKubeAPIProvisioningClient()
-	require.NoError(c.T(), err)
-
-	result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
-		FieldSelector:  "metadata.name=" + clusterName,
-		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
-	})
-	require.NoError(c.T(), err)
-
-	checkFunc := clusters.IsProvisioningClusterReady
-
-	err = wait.WatchWait(result, checkFunc)
-	assert.NoError(c.T(), err)
-	assert.Equal(c.T(), clusterName, clusterResp.ObjectMeta.Name)
-	assert.Equal(c.T(), kubeVersion, cluster.Spec.KubernetesVersion)
-
-	clusterIDName, err := clusters.GetClusterIDByName(c.client, clusterName)
-	assert.NoError(c.T(), err)
-
-	err = nodestat.IsNodeReady(client, clusterIDName)
-	require.NoError(c.T(), err)
-
-	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
-	require.NoError(c.T(), err)
-	assert.NotEmpty(c.T(), clusterToken)
-
-	podResults, podErrors := pods.StatusPods(client, clusterIDName)
-	assert.NotEmpty(c.T(), podResults)
-	assert.Empty(c.T(), podErrors)
-
-	if c.hardened && kubeVersion <= string(provisioning.HardenedKubeVersion) {
-		err = hardening.HardeningNodes(client, c.hardened, nodes, nodesAndRoles)
-		require.NoError(c.T(), err)
-
-		hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, nil)
-
-		hardenClusterResp, err := clusters.UpdateK3SRKE2Cluster(client, clusterResp, hardenCluster)
-		require.NoError(c.T(), err)
-		assert.Equal(c.T(), clusterName, hardenClusterResp.ObjectMeta.Name)
 	}
 }
 

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver.go
@@ -1,0 +1,74 @@
+package k3s
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
+	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	namespace = "fleet-default"
+)
+
+func TestProvisioningK3SCluster(t *testing.T, client *rancher.Client, provider Provider, nodesAndRoles []machinepools.NodeRoles, kubeVersion string) {
+	cloudCredential, err := provider.CloudCredFunc(client)
+	require.NoError(t, err)
+
+	clusterName := namegen.AppendRandomString(provider.Name)
+	generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
+	machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
+
+	machineConfigResp, err := client.Steve.SteveType(provider.MachineConfigPoolResourceSteveType).Create(machinePoolConfig)
+	require.NoError(t, err)
+
+	machinePools := machinepools.RKEMachinePoolSetup(nodesAndRoles, machineConfigResp)
+
+	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", cloudCredential.ID, kubeVersion, machinePools)
+
+	clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
+	require.NoError(t, err)
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+	kubeProvisioningClient, err := adminClient.GetKubeAPIProvisioningClient()
+	require.NoError(t, err)
+
+	result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + clusterName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	require.NoError(t, err)
+
+	checkFunc := clusters.IsProvisioningClusterReady
+
+	err = wait.WatchWait(result, checkFunc)
+	assert.NoError(t, err)
+	assert.Equal(t, clusterName, clusterResp.ObjectMeta.Name)
+	assert.Equal(t, kubeVersion, cluster.Spec.KubernetesVersion)
+
+	clusterIDName, err := clusters.GetClusterIDByName(adminClient, clusterName)
+	assert.NoError(t, err)
+
+	err = nodestat.IsNodeReady(client, clusterIDName)
+	require.NoError(t, err)
+
+	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+	require.NoError(t, err)
+	assert.NotEmpty(t, clusterToken)
+
+	podResults, podErrors := pods.StatusPods(client, clusterIDName)
+	assert.NotEmpty(t, podResults)
+	assert.Empty(t, podErrors)
+}

--- a/tests/v2/validation/provisioning/rke1/custom_cluster.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster.go
@@ -1,0 +1,77 @@
+package rke1
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
+	"github.com/rancher/rancher/tests/framework/extensions/tokenregistration"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestProvisioningRKE1CustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []string, kubeVersion string, cni string) {
+	numNodes := len(nodesAndRoles)
+	nodes, _, err := externalNodeProvider.NodeCreationFunc(client, numNodes, 0, false)
+	require.NoError(t, err)
+
+	clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
+	cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, client)
+	clusterResp, err := clusters.CreateRKE1Cluster(client, cluster)
+	require.NoError(t, err)
+
+	client, err = client.ReLogin()
+	require.NoError(t, err)
+
+	customCluster, err := client.Management.Cluster.ByID(clusterResp.ID)
+	require.NoError(t, err)
+
+	token, err := tokenregistration.GetRegistrationToken(client, customCluster.ID)
+	require.NoError(t, err)
+
+	for key, node := range nodes {
+		t.Logf("Execute Registration Command for node %s", node.NodeID)
+		command := fmt.Sprintf("%s %s", token.NodeCommand, nodesAndRoles[key])
+
+		output, err := node.ExecuteCommand(command)
+		require.NoError(t, err)
+		t.Logf(output)
+	}
+
+	opts := metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + clusterResp.ID,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	}
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+	watchInterface, err := adminClient.GetManagementWatchInterface(management.ClusterType, opts)
+	require.NoError(t, err)
+
+	checkFunc := clusters.IsHostedProvisioningClusterReady
+
+	err = wait.WatchWait(watchInterface, checkFunc)
+	require.NoError(t, err)
+	assert.Equal(t, clusterName, clusterResp.Name)
+	assert.Equal(t, kubeVersion, clusterResp.RancherKubernetesEngineConfig.Version)
+
+	err = nodestat.IsNodeReady(client, clusterResp.ID)
+	require.NoError(t, err)
+
+	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+	require.NoError(t, err)
+	assert.NotEmpty(t, clusterToken)
+
+	podResults, podErrors := pods.StatusPods(client, clusterResp.ID)
+	assert.NotEmpty(t, podResults)
+	assert.Empty(t, podErrors)
+}

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver.go
@@ -1,0 +1,62 @@
+package rke1
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
+	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
+	"github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestProvisioningRKE1Cluster(t *testing.T, client *rancher.Client, provider Provider, nodesAndRoles []nodepools.NodeRoles, kubeVersion, cni string, nodeTemplate *nodetemplates.NodeTemplate) (*management.Cluster, error) {
+	clusterName := namegen.AppendRandomString(provider.Name)
+	cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, client)
+	clusterResp, err := clusters.CreateRKE1Cluster(client, cluster)
+	require.NoError(t, err)
+
+	nodePool, err := nodepools.NodePoolSetup(client, nodesAndRoles, clusterResp.ID, nodeTemplate.ID)
+	require.NoError(t, err)
+
+	nodePoolName := nodePool.Name
+
+	opts := metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + clusterResp.ID,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	}
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+	watchInterface, err := adminClient.GetManagementWatchInterface(management.ClusterType, opts)
+	require.NoError(t, err)
+
+	checkFunc := clusters.IsHostedProvisioningClusterReady
+
+	err = wait.WatchWait(watchInterface, checkFunc)
+	require.NoError(t, err)
+	assert.Equal(t, clusterName, clusterResp.Name)
+	assert.Equal(t, nodePoolName, nodePool.Name)
+	assert.Equal(t, kubeVersion, clusterResp.RancherKubernetesEngineConfig.Version)
+
+	err = nodestat.IsNodeReady(client, clusterResp.ID)
+	require.NoError(t, err)
+
+	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+	require.NoError(t, err)
+	assert.NotEmpty(t, clusterToken)
+
+	podResults, podErrors := pods.StatusPods(client, clusterResp.ID)
+	assert.NotEmpty(t, podResults)
+	assert.Empty(t, podErrors)
+
+	return clusterResp, nil
+}

--- a/tests/v2/validation/provisioning/rke2/custom_cluster.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster.go
@@ -1,0 +1,122 @@
+package rke2
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	hardening "github.com/rancher/rancher/tests/framework/extensions/hardening/rke2"
+	"github.com/rancher/rancher/tests/framework/extensions/tokenregistration"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	namespace = "fleet-default"
+)
+
+func TestProvisioningRKE2CustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []string, kubeVersion, cni string, harden *provisioning.Config, nodeCountWin int, hasWindows bool) {
+	numNodesLin := len(nodesAndRoles)
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+
+	linuxNodes, winNodes, err := externalNodeProvider.NodeCreationFunc(client, numNodesLin, nodeCountWin, hasWindows)
+	require.NoError(t, err)
+
+	clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
+
+	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, "", kubeVersion, nil)
+
+	clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
+	require.NoError(t, err)
+
+	client, err = client.ReLogin()
+	require.NoError(t, err)
+	customCluster, err := client.Steve.SteveType(clusters.ProvisioningSteveResouceType).ByID(clusterResp.ID)
+	require.NoError(t, err)
+
+	clusterStatus := &apiv1.ClusterStatus{}
+	err = v1.ConvertToK8sType(customCluster.Status, clusterStatus)
+	require.NoError(t, err)
+
+	token, err := tokenregistration.GetRegistrationToken(client, clusterStatus.ClusterName)
+	require.NoError(t, err)
+
+	for key, linuxNode := range linuxNodes {
+		t.Logf("Execute Registration Command for node %s", linuxNode.NodeID)
+		command := fmt.Sprintf("%s %s", token.InsecureNodeCommand, nodesAndRoles[key])
+
+		output, err := linuxNode.ExecuteCommand(command)
+		require.NoError(t, err)
+
+		t.Logf(output)
+	}
+
+	kubeProvisioningClient, err := adminClient.GetKubeAPIProvisioningClient()
+	require.NoError(t, err)
+	result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + clusterName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	require.NoError(t, err)
+
+	checkFunc := clusters.IsProvisioningClusterReady
+	err = wait.WatchWait(result, checkFunc)
+	assert.NoError(t, err)
+	assert.Equal(t, clusterName, clusterResp.ObjectMeta.Name)
+
+	if hasWindows {
+		for _, winNode := range winNodes {
+			t.Logf("Execute Registration Command for node %s", winNode.NodeID)
+			winCommand := fmt.Sprintf("%s", token.InsecureWindowsNodeCommand)
+
+			output, err := winNode.ExecuteCommand("powershell.exe" + winCommand)
+			require.NoError(t, err)
+
+			t.Logf(string(output[:]))
+		}
+
+		kubeWinProvisioningClient, err := adminClient.GetKubeAPIProvisioningClient()
+		require.NoError(t, err)
+
+		result, err := kubeWinProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector: "metadata.name=" + clusterName,
+
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+		require.NoError(t, err)
+
+		checkFunc := clusters.IsProvisioningClusterReady
+		err = wait.WatchWait(result, checkFunc)
+		assert.NoError(t, err)
+		assert.Equal(t, clusterName, clusterResp.ObjectMeta.Name)
+	}
+
+	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+	require.NoError(t, err)
+	assert.NotEmpty(t, clusterToken)
+
+	if harden.Hardened && kubeVersion <= string(provisioning.HardenedKubeVersion) {
+		err = hardening.HardeningNodes(client, harden.Hardened, linuxNodes, nodesAndRoles)
+		require.NoError(t, err)
+
+		hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, nil)
+
+		hardenClusterResp, err := clusters.UpdateK3SRKE2Cluster(client, clusterResp, hardenCluster)
+		require.NoError(t, err)
+		assert.Equal(t, clusterName, hardenClusterResp.ObjectMeta.Name)
+
+		err = hardening.PostHardeningConfig(client, harden.Hardened, linuxNodes, nodesAndRoles)
+		require.NoError(t, err)
+	}
+}

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver.go
@@ -1,0 +1,69 @@
+package rke2
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
+	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestProvisioningRKE2Cluster(t *testing.T, client *rancher.Client, provider Provider, nodesAndRoles []machinepools.NodeRoles, kubeVersion, cni string) {
+	cloudCredential, err := provider.CloudCredFunc(client)
+	require.NoError(t, err)
+
+	clusterName := namegen.AppendRandomString(provider.Name)
+	generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
+	machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
+
+	machineConfigResp, err := client.Steve.SteveType(provider.MachineConfigPoolResourceSteveType).Create(machinePoolConfig)
+	require.NoError(t, err)
+
+	machinePools := machinepools.RKEMachinePoolSetup(nodesAndRoles, machineConfigResp)
+
+	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, machinePools)
+	clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
+	require.NoError(t, err)
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+	kubeProvisioningClient, err := adminClient.GetKubeAPIProvisioningClient()
+	require.NoError(t, err)
+
+	result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + clusterName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	require.NoError(t, err)
+
+	checkFunc := clusters.IsProvisioningClusterReady
+
+	err = wait.WatchWait(result, checkFunc)
+	assert.NoError(t, err)
+	assert.Equal(t, clusterName, clusterResp.ObjectMeta.Name)
+	assert.Equal(t, kubeVersion, cluster.Spec.KubernetesVersion)
+
+	clusterIDName, err := clusters.GetClusterIDByName(adminClient, clusterName)
+	assert.NoError(t, err)
+
+	err = nodestat.IsNodeReady(client, clusterIDName)
+	require.NoError(t, err)
+
+	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
+	require.NoError(t, err)
+	assert.NotEmpty(t, clusterToken)
+
+	podResults, podErrors := pods.StatusPods(client, clusterIDName)
+	assert.NotEmpty(t, podResults)
+	assert.Empty(t, podErrors)
+}

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -1,32 +1,19 @@
 package rke2
 
 import (
-	"context"
-	"fmt"
 	"testing"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
-	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
-	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
-	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
-	"github.com/rancher/rancher/tests/framework/pkg/wait"
-	"github.com/rancher/rancher/tests/integration/pkg/defaults"
 	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-const (
-	namespace = "fleet-default"
 )
 
 type RKE2NodeDriverProvisioningTestSuite struct {
@@ -138,7 +125,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2Cluster() {
 				for _, cni := range r.cnis {
 					name += " cni: " + cni
 					r.Run(name, func() {
-						r.testProvisioningRKE2Cluster(client, provider, tt.nodeRoles, kubeVersion, cni)
+						TestProvisioningRKE2Cluster(r.T(), client, provider, tt.nodeRoles, kubeVersion, cni)
 					})
 				}
 			}
@@ -179,60 +166,12 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2ClusterDynamic
 				for _, cni := range r.cnis {
 					name += " cni: " + cni
 					r.Run(name, func() {
-						r.testProvisioningRKE2Cluster(client, provider, nodesAndRoles, kubeVersion, cni)
+						TestProvisioningRKE2Cluster(r.T(), client, provider, nodesAndRoles, kubeVersion, cni)
 					})
 				}
 			}
 		}
 	}
-}
-
-func (r *RKE2NodeDriverProvisioningTestSuite) testProvisioningRKE2Cluster(client *rancher.Client, provider Provider, nodesAndRoles []machinepools.NodeRoles, kubeVersion, cni string) {
-	cloudCredential, err := provider.CloudCredFunc(client)
-
-	clusterName := namegen.AppendRandomString(provider.Name)
-	generatedPoolName := fmt.Sprintf("nc-%s-pool1-", clusterName)
-	machinePoolConfig := provider.MachinePoolFunc(generatedPoolName, namespace)
-
-	machineConfigResp, err := client.Steve.SteveType(provider.MachineConfigPoolResourceSteveType).Create(machinePoolConfig)
-	require.NoError(r.T(), err)
-
-	machinePools := machinepools.RKEMachinePoolSetup(nodesAndRoles, machineConfigResp)
-
-	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, machinePools)
-
-	clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
-	require.NoError(r.T(), err)
-
-	kubeProvisioningClient, err := r.client.GetKubeAPIProvisioningClient()
-	require.NoError(r.T(), err)
-
-	result, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
-		FieldSelector:  "metadata.name=" + clusterName,
-		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
-	})
-	require.NoError(r.T(), err)
-
-	checkFunc := clusters.IsProvisioningClusterReady
-
-	err = wait.WatchWait(result, checkFunc)
-	assert.NoError(r.T(), err)
-	assert.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
-	assert.Equal(r.T(), kubeVersion, cluster.Spec.KubernetesVersion)
-
-	clusterIDName, err := clusters.GetClusterIDByName(r.client, clusterName)
-	assert.NoError(r.T(), err)
-
-	err = nodestat.IsNodeReady(client, clusterIDName)
-	require.NoError(r.T(), err)
-
-	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, clusterName)
-	require.NoError(r.T(), err)
-	assert.NotEmpty(r.T(), clusterToken)
-
-	podResults, podErrors := pods.StatusPods(client, clusterIDName)
-	assert.NotEmpty(r.T(), podResults)
-	assert.Empty(r.T(), podErrors)
 }
 
 // In order for 'go test' to run this suite, we need to create


### PR DESCRIPTION
## Issue: https://github.com/rancher/qa-tasks/issues/644
 
## Problem
Node driver and custom cluster creation for rke1, rke2 and k3s clusters is bound to the provisioning test suite and not available to be used in other tests. Refactoring the files to be made use for other test suites.

## Solution
In this PR, we are abstracting the cluster creations for all the cluster types and making it public, so the cluster creation function can be made use in other PRs as well.
 
## Testing
Verified the custom cluster creation for RKE2 clusters. will need to run a few more checks from the jenkins job.
