### PR TITLE
Adding restricted admin P0 cases

### DIFF
--- a/tests/framework/extensions/users/users.go
+++ b/tests/framework/extensions/users/users.go
@@ -220,7 +220,13 @@ func AddClusterRoleToUser(rancherClient *rancher.Client, cluster *management.Clu
 		FieldSelector:  "metadata.name=" + cluster.ID,
 		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
 	}
-	watchInterface, err := rancherClient.GetManagementWatchInterface(management.ClusterType, opts)
+
+	adminClient, err := rancher.NewClient(rancherClient.RancherConfig.AdminToken, rancherClient.Session)
+	if err != nil {
+		return err
+	}
+
+	watchInterface, err := adminClient.GetManagementWatchInterface(management.ClusterType, opts)
 	if err != nil {
 		return err
 	}

--- a/tests/v2/validation/rbac/rbac.go
+++ b/tests/v2/validation/rbac/rbac.go
@@ -13,12 +13,16 @@ import (
 	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 )
 
-const roleOwner = "cluster-owner"
-const roleMember = "cluster-member"
-const roleProjectOwner = "project-owner"
-const roleProjectMember = "project-member"
+const (
+	roleOwner         = "cluster-owner"
+	roleMember        = "cluster-member"
+	roleProjectOwner  = "project-owner"
+	roleProjectMember = "project-member"
+	restrictedAdmin   = "restricted-admin"
+	standardUser      = "user"
+)
 
-func createUser(client *rancher.Client) (*management.User, error) {
+func createUser(client *rancher.Client, role string) (*management.User, error) {
 	enabled := true
 	var username = namegen.AppendRandomString("testuser-")
 	var testpassword = password.GenerateUserPassword("testpass-")
@@ -28,12 +32,10 @@ func createUser(client *rancher.Client) (*management.User, error) {
 		Name:     username,
 		Enabled:  &enabled,
 	}
-
-	newUser, err := users.CreateUserWithRole(client, user, "user")
+	newUser, err := users.CreateUserWithRole(client, user, role)
 	if err != nil {
 		return newUser, err
 	}
-
 	newUser.Password = user.Password
 	return newUser, err
 }
@@ -82,5 +84,4 @@ func createProject(client *rancher.Client, clusterID string) (createProject *man
 
 	createProject, err = client.Management.Project.Create(projectConfig)
 	return createProject, err
-
 }

--- a/tests/v2/validation/rbac/rbac_test.go
+++ b/tests/v2/validation/rbac/rbac_test.go
@@ -59,7 +59,6 @@ func (rb *RBTestSuite) SetupSuite() {
 	require.NoError(rb.T(), err, "Error getting cluster ID")
 	rb.cluster, err = rb.client.Management.Cluster.ByID(clusterID)
 	require.NoError(rb.T(), err)
-
 }
 
 func (rb *RBTestSuite) ValidateListCluster(role string) {
@@ -83,11 +82,11 @@ func (rb *RBTestSuite) ValidateListProjects(role string) {
 	//Get project list as an admin
 	projectlistAdmin, err := listProjects(rb.client, rb.cluster.ID)
 	require.NoError(rb.T(), err)
-	//Get project list as a cluster owner/member and project owner/member
+	//Get project list as a cluster owner/member, project owner/member and restricted admin
 	projectlistClusterMembers, err := listProjects(rb.standardUserClient, rb.cluster.ID)
 	require.NoError(rb.T(), err)
 	switch role {
-	case roleOwner:
+	case roleOwner, restrictedAdmin:
 		//assert length of projects list obtained as an admin and a cluster owner are equal
 		assert.Equal(rb.T(), len(projectlistAdmin), len(projectlistClusterMembers))
 		//assert projects values obtained as an admin and the cluster owner are the same
@@ -108,7 +107,7 @@ func (rb *RBTestSuite) ValidateCreateProjects(role string) {
 	//Testcase3 Validate if cluster members can create a project in the downstream cluster
 	createProjectAsClusterMembers, err := createProject(rb.standardUserClient, rb.cluster.ID)
 	switch role {
-	case roleOwner, roleMember:
+	case roleOwner, roleMember, restrictedAdmin:
 		require.NoError(rb.T(), err)
 		log.Info("Created project as a ", role, " is ", createProjectAsClusterMembers.Name)
 		require.NoError(rb.T(), err)
@@ -143,7 +142,7 @@ func (rb *RBTestSuite) ValidateNS(role string) {
 	createdNamespace, checkErr := namespaces.CreateNamespace(rb.standardUserClient, namespaceName, "{}", map[string]string{}, map[string]string{}, rb.adminProject)
 
 	switch role {
-	case roleOwner, roleProjectOwner, roleProjectMember:
+	case roleOwner, roleProjectOwner, roleProjectMember, restrictedAdmin:
 		require.NoError(rb.T(), checkErr)
 		log.Info("Created a namespace as role ", role, createdNamespace.Name)
 		assert.Equal(rb.T(), namespaceName, createdNamespace.Name)
@@ -170,7 +169,7 @@ func (rb *RBTestSuite) ValidateNS(role string) {
 	namespaceListClusterMembers, err := getNamespaces(rb.steveStdUserclient)
 
 	switch role {
-	case roleOwner:
+	case roleOwner, restrictedAdmin:
 		require.NoError(rb.T(), err)
 		//Length of namespace list for admin and cluster owner should match
 		assert.Equal(rb.T(), len(namespaceListAdmin), len(namespaceListClusterMembers))
@@ -194,7 +193,7 @@ func (rb *RBTestSuite) ValidateNS(role string) {
 	require.NoError(rb.T(), err)
 	err = deleteNamespace(namespaceID, rb.steveStdUserclient)
 	switch role {
-	case roleOwner, roleProjectOwner, roleProjectMember:
+	case roleOwner, roleProjectOwner, roleProjectMember, restrictedAdmin:
 		require.NoError(rb.T(), err)
 	case roleMember:
 		require.Error(rb.T(), err)
@@ -212,16 +211,18 @@ func (rb *RBTestSuite) ValidateAddClusterRoles(role string) {
 	case roleProjectOwner, roleProjectMember:
 		require.Error(rb.T(), errUserRole)
 		assert.Equal(rb.T(), true, k8sErrors.IsForbidden(errUserRole))
+	case restrictedAdmin:
+		require.NoError(rb.T(), errUserRole)
 	}
 }
 
 func (rb *RBTestSuite) ValidateAddProjectRoles(role string) {
 
 	//Testcase8 Validate if project owners/members are able to add another standard user as a project members
-	errUserRole := users.AddProjectMember(rb.standardUserClient, rb.adminProject, rb.additionalUser, role)
+	errUserRole := users.AddProjectMember(rb.standardUserClient, rb.adminProject, rb.additionalUser, roleProjectOwner)
 
 	switch role {
-	case roleProjectOwner:
+	case roleProjectOwner, restrictedAdmin:
 		require.NoError(rb.T(), errUserRole)
 		additionalUserClient, err := rb.additionalUserClient.ReLogin()
 		require.NoError(rb.T(), err)
@@ -234,7 +235,6 @@ func (rb *RBTestSuite) ValidateAddProjectRoles(role string) {
 	case roleProjectMember:
 		require.Error(rb.T(), errUserRole)
 	}
-
 }
 
 func (rb *RBTestSuite) ValidateDeleteProject(role string) {
@@ -268,7 +268,6 @@ func (rb *RBTestSuite) ValidateRemoveProjectRoles() {
 	//Testcase10b Remove added project member from the cluster project as an admin
 	err := users.RemoveProjectMember(rb.client, rb.standardUser)
 	require.NoError(rb.T(), err)
-
 }
 
 func (rb *RBTestSuite) ValidateAddStdUserAsProjectOwner() {
@@ -288,7 +287,6 @@ func (rb *RBTestSuite) ValidateAddStdUserAsProjectOwner() {
 
 	err = users.RemoveProjectMember(rb.standardUserClient, rb.additionalUser)
 	require.NoError(rb.T(), err)
-
 }
 
 func (rb *RBTestSuite) ValidateAddMemberAsClusterRoles() {
@@ -306,7 +304,6 @@ func (rb *RBTestSuite) ValidateAddMemberAsClusterRoles() {
 
 	err = users.RemoveClusterRoleFromUser(rb.standardUserClient, rb.additionalUser)
 	require.NoError(rb.T(), err)
-
 }
 
 func (rb *RBTestSuite) ValidateAddCMAsProjectOwner() {
@@ -329,22 +326,23 @@ func (rb *RBTestSuite) ValidateAddCMAsProjectOwner() {
 	userGetProject, err := projects.GetProjectList(rb.additionalUserClient, rb.cluster.ID)
 	require.NoError(rb.T(), err)
 	assert.Equal(rb.T(), rb.standardUserCOProject.Name, userGetProject.Data[0].Name)
-
 }
 
 func (rb *RBTestSuite) TestRBAC() {
 	tests := []struct {
-		name string
-		role string
+		name   string
+		role   string
+		member string
 	}{
-		{"Cluster Owner", roleOwner},
-		{"Cluster Member", roleMember},
-		{"Project Owner", roleProjectOwner},
-		{"Project Member", roleProjectMember},
+		{"Cluster Owner", roleOwner, standardUser},
+		{"Cluster Member", roleMember, standardUser},
+		{"Project Owner", roleProjectOwner, standardUser},
+		{"Project Member", roleProjectMember, standardUser},
+		{"Restricted Admin", restrictedAdmin, restrictedAdmin},
 	}
 	for _, tt := range tests {
 		rb.Run("Set up User with Cluster Role "+tt.name, func() {
-			newUser, err := createUser(rb.client)
+			newUser, err := createUser(rb.client, tt.member)
 			require.NoError(rb.T(), err)
 			rb.standardUser = newUser
 			rb.T().Logf("Created user: %v", rb.standardUser.Username)
@@ -361,25 +359,28 @@ func (rb *RBTestSuite) TestRBAC() {
 			steveAdminClient, err := rb.client.Steve.ProxyDownstream(rb.cluster.ID)
 			require.NoError(rb.T(), err)
 			rb.steveAdminClient = steveAdminClient
-
 		})
 
 		//Verify standard users cannot list any clusters
-		rb.Run("Test case Validate standard users cannot list any downstream clusters before adding the cluster role "+tt.name, func() {
+		rb.Run("Test case Validate if users can list any downstream clusters before adding the cluster role "+tt.name, func() {
 			_, err := rb.standardUserClient.Steve.SteveType(clusters.ProvisioningSteveResouceType).ListAll(nil)
-			require.Error(rb.T(), err)
-			assert.Equal(rb.T(), "Resource type [provisioning.cattle.io.cluster] is not listable", err.Error())
+			if tt.member == standardUser {
+				require.Error(rb.T(), err)
+				assert.Contains(rb.T(), "Resource type [provisioning.cattle.io.cluster] has no method GET", err.Error())
+			}
 		})
 
 		rb.Run("Adding user as "+tt.name+" to the downstream cluster.", func() {
 			//Adding created user to the downstream clusters with the specified roles.
 
-			if strings.Contains(tt.role, "project") {
-				err := users.AddProjectMember(rb.client, rb.adminProject, rb.standardUser, tt.role)
-				require.NoError(rb.T(), err)
-			} else {
-				err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.standardUser, tt.role)
-				require.NoError(rb.T(), err)
+			if tt.member == standardUser {
+				if strings.Contains(tt.role, "project") {
+					err := users.AddProjectMember(rb.client, rb.adminProject, rb.standardUser, tt.role)
+					require.NoError(rb.T(), err)
+				} else {
+					err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.standardUser, tt.role)
+					require.NoError(rb.T(), err)
+				}
 			}
 
 			relogin, err := rb.standardUserClient.ReLogin()
@@ -404,29 +405,26 @@ func (rb *RBTestSuite) TestRBAC() {
 
 		rb.Run("Testcase3 - Validating if members with role "+tt.name+" is able to create a project in the cluster", func() {
 			rb.ValidateCreateProjects(tt.role)
-
 		})
 
 		rb.Run("Testcase 4 through 6 - Validate namespaces checks for members with role "+tt.name, func() {
 			rb.ValidateNS(tt.role)
 		})
 
-		if strings.Contains(tt.role, "project") {
+		if !strings.Contains(tt.role, "cluster") {
 			rb.Run("Testcase7 - Validating if member with role "+tt.name+" can add members to the cluster", func() {
 				//Set up additional user client to be added to the project
-				additionalUser, err := createUser(rb.client)
+				additionalUser, err := createUser(rb.client, tt.role)
 				require.NoError(rb.T(), err)
 				rb.additionalUser = additionalUser
 				rb.additionalUserClient, err = rb.client.AsUser(rb.additionalUser)
 				require.NoError(rb.T(), err)
-
 				rb.ValidateAddClusterRoles(tt.role)
 			})
 
-			rb.Run("Testcase8 - Validating if member with role "+tt.name+" can add members to the cluster", func() {
+			rb.Run("Testcase8 - Validating if member with role "+tt.name+" can add members to the project", func() {
 				rb.ValidateAddProjectRoles(tt.role)
 			})
-
 		}
 
 		rb.Run("Testcase9 - Validating if member with role "+tt.name+" can delete a project they are not owner of ", func() {
@@ -434,19 +432,20 @@ func (rb *RBTestSuite) TestRBAC() {
 		})
 
 		rb.Run("Testcase10 - Validating if member with role "+tt.name+" is removed from the cluster and returns nil clusters", func() {
-			if strings.Contains(tt.role, "project") {
-				rb.ValidateRemoveProjectRoles()
-			} else {
-				rb.ValidateRemoveClusterRoles()
+			if tt.member == standardUser {
+				if strings.Contains(tt.role, "project") {
+					rb.ValidateRemoveProjectRoles()
+				} else {
+					rb.ValidateRemoveClusterRoles()
+				}
 			}
 		})
-
 	}
 }
 
 func (rb *RBTestSuite) TestRBACAdditional() {
 	rb.Run("Set up User with cluster Role for additional rbac test cases "+roleOwner, func() {
-		newUser, err := createUser(rb.client)
+		newUser, err := createUser(rb.client, standardUser)
 		require.NoError(rb.T(), err)
 		rb.standardUser = newUser
 		rb.T().Logf("Created user: %v", rb.standardUser.Username)
@@ -464,7 +463,7 @@ func (rb *RBTestSuite) TestRBACAdditional() {
 		require.NoError(rb.T(), err)
 
 		//Setting up an additional user for the additional rbac cases
-		additionalUser, err := createUser(rb.client)
+		additionalUser, err := createUser(rb.client, standardUser)
 		require.NoError(rb.T(), err)
 		rb.additionalUser = additionalUser
 		rb.additionalUserClient, err = rb.client.AsUser(rb.additionalUser)
@@ -473,19 +472,16 @@ func (rb *RBTestSuite) TestRBACAdditional() {
 
 	rb.Run("Additional testcase1 - Validating if member with role "+roleOwner+" can add another standard user as a project owner", func() {
 		rb.ValidateAddStdUserAsProjectOwner()
-
 	})
 
 	rb.Run("Additional testcase2 - Validating if member with role "+roleOwner+" can add another standard user as a cluster owner", func() {
 		rb.ValidateAddMemberAsClusterRoles()
-
 	})
 
 	rb.Run("Additional testcase3 - Validating if member with role "+roleOwner+" can add a cluster member as a project owner", func() {
 		rb.ValidateAddCMAsProjectOwner()
 
 	})
-
 }
 
 func TestRBACTestSuite(t *testing.T) {


### PR DESCRIPTION
## Issue: 
Backport: https://github.com/rancher/qa-tasks/issues/644
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Currently we do not have a rbac suite for v1 P0 cases to check restricted admin RBAC. In this PR we aim to automate the P0 cases for the restricted admin RBAC
 
## Solution
We are leveraging the current rbac suite that addresses cluster owner/member. The P0 cases for the restricted admin RBAC . We are adding those additional cases and also add a few changes on how we validate for restricted admins 
 

Note: This PR slightly depends on fixes from https://github.com/rancher/rancher/pull/40792