### PR TITLE
Stop planner from processing machine plans if the cluster is missing its controlplane/etcd nodes and has been initialized

### DIFF
--- a/pkg/apis/rke.cattle.io/v1/plan/plan.go
+++ b/pkg/apis/rke.cattle.io/v1/plan/plan.go
@@ -6,7 +6,6 @@ type Plan struct {
 	Nodes    map[string]*Node         `json:"nodes,omitempty"`
 	Machines map[string]*capi.Machine `json:"machines,omitempty"`
 	Metadata map[string]*Metadata     `json:"metadata,omitempty"`
-	Cluster  *capi.Cluster            `json:"cluster,omitempty"`
 }
 
 type Metadata struct {

--- a/pkg/apis/rke.cattle.io/v1/plan/plan.go
+++ b/pkg/apis/rke.cattle.io/v1/plan/plan.go
@@ -27,6 +27,7 @@ type Node struct {
 	Failed         bool                                 `json:"failed,omitempty"`
 	InSync         bool                                 `json:"inSync,omitempty"`
 	Healthy        bool                                 `json:"healthy,omitempty"`
+	PlanDataExists bool                                 `json:"planDataExists,omitempty"`
 	ProbeStatus    map[string]ProbeStatus               `json:"probeStatus,omitempty"`
 }
 

--- a/pkg/apis/rke.cattle.io/v1/plan/plan.go
+++ b/pkg/apis/rke.cattle.io/v1/plan/plan.go
@@ -70,6 +70,7 @@ type File struct {
 	Minor       bool   `json:"minor,omitempty"` // minor signifies that the file can be changed on a node without having to cause a full-blown drain/cordon operation
 }
 
+// NodePlan is the struct used to deliver instructions/files/probes to the system-agent, and retrieve feedback
 type NodePlan struct {
 	Files                []File                `json:"files,omitempty"`
 	Instructions         []OneTimeInstruction  `json:"instructions,omitempty"`

--- a/pkg/controllers/provisioningv2/controllers.go
+++ b/pkg/controllers/provisioningv2/controllers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rancher/rancher/pkg/provisioningv2/capi"
 	"github.com/rancher/rancher/pkg/provisioningv2/kubeconfig"
 	planner2 "github.com/rancher/rancher/pkg/provisioningv2/rke2/planner"
+	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/sirupsen/logrus"
 )
@@ -40,7 +41,9 @@ func Register(ctx context.Context, clients *wrangler.Context) error {
 	}
 
 	if features.RKE2.Enabled() {
-		rkePlanner := planner2.New(ctx, clients)
+		rkePlanner := planner2.New(ctx, clients, planner2.InfoFunctions{
+			SystemAgentImage: settings.SystemAgentInstallerImage.Get,
+		})
 		if features.MCM.Enabled() {
 			dynamicschema.Register(ctx, clients)
 			machineprovision.Register(ctx, clients, kubeconfigManager)

--- a/pkg/controllers/provisioningv2/rke2/common.go
+++ b/pkg/controllers/provisioningv2/rke2/common.go
@@ -66,11 +66,13 @@ const (
 	PostDrainAnnotation        = "rke.cattle.io/post-drain"
 	PreDrainAnnotation         = "rke.cattle.io/pre-drain"
 	RoleLabel                  = "rke.cattle.io/service-account-role"
-	SecretTypeMachinePlan      = "rke.cattle.io/machine-plan"
 	TaintsAnnotation           = "rke.cattle.io/taints"
 	UnCordonAnnotation         = "rke.cattle.io/uncordon"
 	WorkerRoleLabel            = "rke.cattle.io/worker-role"
 	AuthorizedObjectAnnotation = "rke.cattle.io/object-authorized-for-clusters"
+
+	SecretTypeMachinePlan  = "rke.cattle.io/machine-plan"
+	SecretTypeClusterState = "rke.cattle.io/cluster-state"
 
 	MachineTemplateClonedFromGroupVersionAnn = "rke.cattle.io/cloned-from-group-version"
 	MachineTemplateClonedFromKindAnn         = "rke.cattle.io/cloned-from-kind"

--- a/pkg/controllers/provisioningv2/rke2/plansecret/plansecret.go
+++ b/pkg/controllers/provisioningv2/rke2/plansecret/plansecret.go
@@ -51,7 +51,7 @@ func (h *handler) OnChange(key string, secret *corev1.Secret) (*corev1.Secret, e
 
 	logrus.Debugf("[plansecret] reconciling secret %s/%s", secret.Namespace, secret.Name)
 
-	node, err := planner.SecretToNode(secret)
+	node, _, err := planner.SecretToNode(secret)
 	if err != nil {
 		return secret, err
 	}

--- a/pkg/controllers/provisioningv2/rke2/plansecret/plansecret.go
+++ b/pkg/controllers/provisioningv2/rke2/plansecret/plansecret.go
@@ -51,7 +51,7 @@ func (h *handler) OnChange(key string, secret *corev1.Secret) (*corev1.Secret, e
 
 	logrus.Debugf("[plansecret] reconciling secret %s/%s", secret.Namespace, secret.Name)
 
-	node, _, err := planner.SecretToNode(secret)
+	node, err := planner.SecretToNode(secret)
 	if err != nil {
 		return secret, err
 	}

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -368,6 +368,7 @@ func (h *handler) getRKEControlPlaneForCluster(cluster *rancherv1.Cluster) (*rke
 	return cp, nil
 }
 
+// updateClusterProvisioningStatus copies the condition (clusterCondition) to both the clusters.management.cattle.io and clusters.provisioning.cattle.io objects based on the passed in rkecontrolplane cp + cpCondition
 func (h *handler) updateClusterProvisioningStatus(cluster *rancherv1.Cluster, status rancherv1.ClusterStatus, cp *rkev1.RKEControlPlane, clusterCondition, cpCondition condition.Cond) (rancherv1.ClusterStatus, error) {
 	if cp == nil {
 		return status, fmt.Errorf("error while updating cluster provisioning status - rkecontrolplane was nil")

--- a/pkg/provisioningv2/rke2/planner/certificaterotation.go
+++ b/pkg/provisioningv2/rke2/planner/certificaterotation.go
@@ -17,7 +17,7 @@ func (p *Planner) rotateCertificates(controlPlane *rkev1.RKEControlPlane, status
 	}
 
 	if err := p.pauseCAPICluster(controlPlane, true); err != nil {
-		return status, ErrWaiting("pausing CAPI cluster")
+		return status, errWaiting("pausing CAPI cluster")
 	}
 
 	for _, node := range collect(clusterPlan, anyRole) {
@@ -33,11 +33,11 @@ func (p *Planner) rotateCertificates(controlPlane *rkev1.RKEControlPlane, status
 	}
 
 	if err := p.pauseCAPICluster(controlPlane, false); err != nil {
-		return status, ErrWaiting("unpausing CAPI cluster")
+		return status, errWaiting("unpausing CAPI cluster")
 	}
 
 	status.CertificateRotationGeneration = controlPlane.Spec.RotateCertificates.Generation
-	return status, ErrWaiting("certificate rotation done")
+	return status, errWaiting("certificate rotation done")
 }
 
 // shouldRotate `true` if the cluster is ready and the generation is stale

--- a/pkg/provisioningv2/rke2/planner/config.go
+++ b/pkg/provisioningv2/rke2/planner/config.go
@@ -197,6 +197,21 @@ func addVSphereCharts(controlPlane *rkev1.RKEControlPlane, entry *planEntry) (ma
 	return controlPlane.Spec.ChartValues.Data, nil
 }
 
+type helmChartConfig struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec helmChartConfigSpec `json:"spec,omitempty"`
+}
+
+type helmChartConfigSpec struct {
+	ValuesContent string `json:"valuesContent,omitempty"`
+}
+
+func (h *helmChartConfig) DeepCopyObject() runtime.Object {
+	panic("unsupported")
+}
+
 func (p *Planner) addChartConfigs(nodePlan plan.NodePlan, controlPlane *rkev1.RKEControlPlane, entry *planEntry) (plan.NodePlan, error) {
 	if isOnlyWorker(entry) {
 		return nodePlan, nil

--- a/pkg/provisioningv2/rke2/planner/drain.go
+++ b/pkg/provisioningv2/rke2/planner/drain.go
@@ -25,6 +25,8 @@ func getRestartStamp(plan *plan.NodePlan) string {
 	return ""
 }
 
+// shouldDrain determines whether the node should be drained based on the plans provided. If the oldPlan doesn't exist,
+// then it will not be drained, otherwise, it compares the restart stamps to determine whether the engine will be restarted
 func shouldDrain(oldPlan *plan.NodePlan, newPlan plan.NodePlan) bool {
 	if oldPlan == nil {
 		return false

--- a/pkg/provisioningv2/rke2/planner/errors.go
+++ b/pkg/provisioningv2/rke2/planner/errors.go
@@ -1,0 +1,48 @@
+package planner
+
+import (
+	"errors"
+	"fmt"
+)
+
+// errWaiting will cause a re-enqueue of the object being processed
+type errWaiting string
+
+func (e errWaiting) Error() string {
+	return string(e)
+}
+
+// errWaitingf renders an error of type errWaiting that will cause a re-enqueue of the object being processed
+func errWaitingf(format string, a ...interface{}) errWaiting {
+	return errWaiting(fmt.Sprintf(format, a...))
+}
+
+func IsErrWaiting(err error) bool {
+	var errWaiting errWaiting
+	return errors.As(err, &errWaiting)
+}
+
+// errIgnore will not cause a re-enqueue of the object being processed
+type errIgnore string
+
+func (e errIgnore) Error() string {
+	return string(e)
+}
+
+// errIgnoref renders an error of type errIgnore that will cause a re-enqueue of the object being processed
+func errIgnoref(format string, a ...interface{}) errIgnore {
+	return errIgnore(fmt.Sprintf(format, a...))
+}
+
+// ignoreErrors accepts two errors. If the err is type errIgnore, it will return (err, nil) if firstIgnoreErr is nil or (firstIgnoreErr, nil).
+// Otherwise, it will simply return (firstIgnoreErr, err)
+func ignoreErrors(firstIgnoreError error, err error) (error, error) {
+	var errIgnore errIgnore
+	if errors.As(err, &errIgnore) {
+		if firstIgnoreError == nil {
+			return err, nil
+		}
+		return firstIgnoreError, nil
+	}
+	return firstIgnoreError, err
+}

--- a/pkg/provisioningv2/rke2/planner/etcdcreate.go
+++ b/pkg/provisioningv2/rke2/planner/etcdcreate.go
@@ -15,7 +15,7 @@ func (p *Planner) setEtcdSnapshotCreateState(status rkev1.RKEControlPlaneStatus,
 	if status.ETCDSnapshotCreatePhase != phase || !equality.Semantic.DeepEqual(status.ETCDSnapshotCreate, create) {
 		status.ETCDSnapshotCreatePhase = phase
 		status.ETCDSnapshotCreate = create
-		return status, ErrWaiting("refreshing etcd create state")
+		return status, errWaiting("refreshing etcd create state")
 	}
 	return status, nil
 }
@@ -109,7 +109,7 @@ func (p *Planner) createEtcdSnapshot(controlPlane *rkev1.RKEControlPlane, status
 					}
 				}
 			}
-			return status, ErrWaiting(merr.NewErrors(finErrs...).Error())
+			return status, errWaiting(merr.NewErrors(finErrs...).Error())
 		}
 		if status, err = p.setEtcdSnapshotCreateState(status, snapshot, rkev1.ETCDSnapshotPhaseRestartCluster); err != nil {
 			return status, err

--- a/pkg/provisioningv2/rke2/planner/etcdrestore.go
+++ b/pkg/provisioningv2/rke2/planner/etcdrestore.go
@@ -16,7 +16,7 @@ func (p *Planner) setEtcdSnapshotRestoreState(status rkev1.RKEControlPlaneStatus
 	if !equality.Semantic.DeepEqual(status.ETCDSnapshotRestore, restore) || status.ETCDSnapshotRestorePhase != phase {
 		status.ETCDSnapshotRestore = restore
 		status.ETCDSnapshotRestorePhase = phase
-		return status, ErrWaiting("refreshing etcd restore state")
+		return status, errWaiting("refreshing etcd restore state")
 	}
 	return status, nil
 }
@@ -65,7 +65,7 @@ func (p *Planner) runEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControlPlane
 		}
 	}
 
-	return ErrWaiting("failed to find etcd node to restore on")
+	return errWaiting("failed to find etcd node to restore on")
 }
 
 // generateEtcdSnapshotRestorePlan returns a node plan that contains instructions to stop etcd, remove the tombstone file (if one exists), then restore etcd in that order.
@@ -190,15 +190,15 @@ func (p *Planner) runEtcdRestoreServiceStop(controlPlane *rkev1.RKEControlPlane,
 
 	// If any of the controlplane/etcd node plans were updated, return an errwaiting message for shutting down control plane and etcd
 	if updated {
-		return ErrWaiting("stopping " + rke2.GetRuntime(controlPlane.Spec.KubernetesVersion) + " services on control plane and etcd machines/nodes")
+		return errWaiting("stopping " + rke2.GetRuntime(controlPlane.Spec.KubernetesVersion) + " services on control plane and etcd machines/nodes")
 	}
 
 	for _, server := range servers {
 		if !server.Plan.InSync {
 			if server.Machine.Status.NodeRef == nil {
-				return ErrWaiting(fmt.Sprintf("waiting to stop %s services on machine [%s]", rke2.GetRuntime(controlPlane.Spec.KubernetesVersion), server.Machine.Name))
+				return errWaiting(fmt.Sprintf("waiting to stop %s services on machine [%s]", rke2.GetRuntime(controlPlane.Spec.KubernetesVersion), server.Machine.Name))
 			}
-			return ErrWaiting(fmt.Sprintf("waiting to stop %s services on node [%s]", rke2.GetRuntime(controlPlane.Spec.KubernetesVersion), server.Machine.Status.NodeRef.Name))
+			return errWaiting(fmt.Sprintf("waiting to stop %s services on node [%s]", rke2.GetRuntime(controlPlane.Spec.KubernetesVersion), server.Machine.Status.NodeRef.Name))
 		}
 	}
 
@@ -254,7 +254,7 @@ func (p *Planner) runEtcdSnapshotManagementServiceStart(controlPlane *rkev1.RKEC
 func (p *Planner) runEtcdSnapshotWorkerServiceStart(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, clusterPlan *plan.Plan, operation string) error {
 	joinServer := getControlPlaneJoinURL(clusterPlan)
 	if joinServer == "" {
-		return ErrWaiting("waiting for control plane to be available")
+		return errWaiting("waiting for control plane to be available")
 	}
 
 	for _, entry := range collect(clusterPlan, isOnlyWorker) {

--- a/pkg/provisioningv2/rke2/planner/etcdrestore.go
+++ b/pkg/provisioningv2/rke2/planner/etcdrestore.go
@@ -188,7 +188,7 @@ func (p *Planner) runEtcdRestoreServiceStop(controlPlane *rkev1.RKEControlPlane,
 		}
 	}
 
-	// If any of the controlplane/etcd node plans were updated, return an errwaiting message for shutting down control plane and etcd
+	// If any of the controlplane/etcd node plans were updated, return an errWaiting message for shutting down control plane and etcd
 	if updated {
 		return errWaiting("stopping " + rke2.GetRuntime(controlPlane.Spec.KubernetesVersion) + " services on control plane and etcd machines/nodes")
 	}

--- a/pkg/provisioningv2/rke2/planner/initnode.go
+++ b/pkg/provisioningv2/rke2/planner/initnode.go
@@ -143,7 +143,7 @@ func (p *Planner) electInitNode(rkeControlPlane *rkev1.RKEControlPlane, plan *pl
 		logrus.Debugf("rkecluster %s/%s: init node was already elected and found with joinURL: %s", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName, joinURL)
 		return joinURL, err
 	} else if !initNodeFound && rkeControlPlane.Labels[rke2.InitNodeMachineIDLabel] != "" {
-		return "", ErrWaitingf("unable to find designated init node matching machine ID %s", rkeControlPlane.Labels[rke2.InitNodeMachineIDLabel])
+		return "", errWaitingf("unable to find designated init node matching machine ID %s", rkeControlPlane.Labels[rke2.InitNodeMachineIDLabel])
 	}
 	// If the joinURL (or an errSkip) was not found, re-elect the init node.
 	logrus.Debugf("rkecluster %s/%s: performing election of init node", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName)
@@ -185,7 +185,7 @@ func (p *Planner) electInitNode(rkeControlPlane *rkev1.RKEControlPlane, plan *pl
 	}
 
 	logrus.Debugf("rkecluster %s/%s: failed to elect init node, no suitable init nodes were found", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName)
-	return "", ErrWaiting("waiting for viable init node")
+	return "", errWaiting("waiting for viable init node")
 }
 
 // designateInitNodeByID is used to force-designate an init node in the cluster. This is especially useful for things like

--- a/pkg/provisioningv2/rke2/planner/messages.go
+++ b/pkg/provisioningv2/rke2/planner/messages.go
@@ -1,0 +1,52 @@
+package planner
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func atMostThree(names []string) string {
+	sort.Strings(names)
+	if len(names) > 3 {
+		return fmt.Sprintf("%s and %d more", strings.Join(names[:3], ","), len(names)-3)
+	}
+	return strings.Join(names, ",")
+}
+
+func detailedMessage(machines []string, messages map[string][]string) string {
+	if len(machines) != 1 {
+		return ""
+	}
+	message := messages[machines[0]]
+	if len(message) != 0 {
+		return fmt.Sprintf(": %s", strings.Join(message, ", "))
+	}
+	return ""
+}
+
+// removeReconciledCondition removes the condition "Reconciled" from a CAPI machine object so that messages are not
+// duplicated during summarization.
+func removeReconciledCondition(machine *capi.Machine) *capi.Machine {
+	if machine == nil || len(machine.Status.Conditions) == 0 {
+		return machine
+	}
+
+	conds := make([]capi.Condition, 0, len(machine.Status.Conditions))
+	for _, c := range machine.Status.Conditions {
+		if string(c.Type) != string(rke2.Reconciled) {
+			conds = append(conds, c)
+		}
+	}
+
+	if len(conds) == len(machine.Status.Conditions) {
+		return machine
+	}
+
+	machine = machine.DeepCopy()
+	machine.SetConditions(conds)
+	return machine
+}

--- a/pkg/provisioningv2/rke2/planner/planentry.go
+++ b/pkg/provisioningv2/rke2/planner/planentry.go
@@ -1,0 +1,127 @@
+package planner
+
+import (
+	"sort"
+
+	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
+	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+type planEntry struct {
+	Machine  *capi.Machine
+	Plan     *plan.Node
+	Metadata *plan.Metadata
+}
+
+type roleFilter func(*planEntry) bool
+
+func collect(plan *plan.Plan, include roleFilter) (result []*planEntry) {
+	for machineName, machine := range plan.Machines {
+		entry := &planEntry{
+			Machine:  machine,
+			Plan:     plan.Nodes[machineName],
+			Metadata: plan.Metadata[machineName],
+		}
+		if !include(entry) {
+			continue
+		}
+		result = append(result, entry)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Machine.Name < result[j].Machine.Name
+	})
+
+	return result
+}
+
+func isEtcd(entry *planEntry) bool {
+	return entry.Metadata != nil && entry.Metadata.Labels[rke2.EtcdRoleLabel] == "true"
+}
+
+func isInitNode(entry *planEntry) bool {
+	return entry.Metadata != nil && entry.Metadata.Labels[rke2.InitNodeLabel] == "true"
+}
+
+func isInitNodeOrDeleting(entry *planEntry) bool {
+	return isInitNode(entry) || isDeleting(entry)
+}
+
+func IsEtcdOnlyInitNode(entry *planEntry) bool {
+	return isInitNode(entry) && IsOnlyEtcd(entry)
+}
+
+func isNotInitNodeOrIsDeleting(entry *planEntry) bool {
+	return !isInitNode(entry) || isDeleting(entry)
+}
+
+func isDeleting(entry *planEntry) bool {
+	return entry.Machine.DeletionTimestamp != nil
+}
+
+// isFailed returns true if the provided entry machine.status.phase is failed
+func isFailed(entry *planEntry) bool {
+	return entry.Machine.Status.Phase == string(capi.MachinePhaseFailed)
+}
+
+// canBeInitNode returns true if the provided entry is an etcd node, is not deleting, is not failed, and has its infrastructure ready
+// We should wait for the infrastructure condition to be marked as ready because we need the IP address(es) set prior to bootstrapping the node.
+func canBeInitNode(entry *planEntry) bool {
+	return isEtcd(entry) && !isDeleting(entry) && !isFailed(entry) && rke2.InfrastructureReady.IsTrue(entry.Machine)
+}
+
+func isControlPlane(entry *planEntry) bool {
+	return entry.Metadata != nil && entry.Metadata.Labels[rke2.ControlPlaneRoleLabel] == "true"
+}
+
+func isControlPlaneAndNotInitNode(entry *planEntry) bool {
+	return isControlPlane(entry) && !isInitNode(entry)
+}
+
+func isControlPlaneEtcd(entry *planEntry) bool {
+	return isControlPlane(entry) || isEtcd(entry)
+}
+
+func IsOnlyEtcd(entry *planEntry) bool {
+	return isEtcd(entry) && !isControlPlane(entry)
+}
+
+func isOnlyControlPlane(entry *planEntry) bool {
+	return !isEtcd(entry) && isControlPlane(entry)
+}
+
+func isWorker(entry *planEntry) bool {
+	return entry.Metadata != nil && entry.Metadata.Labels[rke2.WorkerRoleLabel] == "true"
+}
+
+func noRole(entry *planEntry) bool {
+	return !isEtcd(entry) && !isControlPlane(entry) && !isWorker(entry)
+}
+
+func anyRole(entry *planEntry) bool {
+	return !noRole(entry)
+}
+
+func anyRoleWithoutWindows(entry *planEntry) bool {
+	return !noRole(entry) && notWindows(entry)
+}
+
+func isOnlyWorker(entry *planEntry) bool {
+	return !isEtcd(entry) && !isControlPlane(entry) && isWorker(entry)
+}
+
+func notWindows(entry *planEntry) bool {
+	return entry.Machine.Status.NodeInfo.OperatingSystem != windows
+}
+
+func anyPlanDelivered(plan *plan.Plan, include roleFilter) bool {
+	var planDataExists bool
+	planEntries := collect(plan, include)
+	for _, entry := range planEntries {
+		if entry.Plan.PlanDataExists {
+			planDataExists = true
+		}
+	}
+	return planDataExists
+}

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -33,7 +33,6 @@ import (
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	capiannotations "sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -987,21 +986,6 @@ func (p *Planner) ensureRKEStateSecret(controlPlane *rkev1.RKEControlPlane) (str
 		ServerToken: string(secret.Data["serverToken"]),
 		AgentToken:  string(secret.Data["agentToken"]),
 	}, nil
-}
-
-type helmChartConfig struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec helmChartConfigSpec `json:"spec,omitempty"`
-}
-
-type helmChartConfigSpec struct {
-	ValuesContent string `json:"valuesContent,omitempty"`
-}
-
-func (h *helmChartConfig) DeepCopyObject() runtime.Object {
-	panic("unsupported")
 }
 
 func (p *Planner) pauseCAPICluster(cp *rkev1.RKEControlPlane, pause bool) error {

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"path/filepath"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -352,46 +351,6 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 	}
 
 	return status, nil
-}
-
-func atMostThree(names []string) string {
-	sort.Strings(names)
-	if len(names) > 3 {
-		return fmt.Sprintf("%s and %d more", strings.Join(names[:3], ","), len(names)-3)
-	}
-	return strings.Join(names, ",")
-}
-
-func detailedMessage(machines []string, messages map[string][]string) string {
-	if len(machines) != 1 {
-		return ""
-	}
-	message := messages[machines[0]]
-	if len(message) != 0 {
-		return fmt.Sprintf(": %s", strings.Join(message, ", "))
-	}
-	return ""
-}
-
-func removeReconciledCondition(machine *capi.Machine) *capi.Machine {
-	if machine == nil || len(machine.Status.Conditions) == 0 {
-		return machine
-	}
-
-	conds := make([]capi.Condition, 0, len(machine.Status.Conditions))
-	for _, c := range machine.Status.Conditions {
-		if string(c.Type) != string(rke2.Reconciled) {
-			conds = append(conds, c)
-		}
-	}
-
-	if len(conds) == len(machine.Status.Conditions) {
-		return machine
-	}
-
-	machine = machine.DeepCopy()
-	machine.SetConditions(conds)
-	return machine
 }
 
 // getControlPlaneJoinURL will return the first encountered join URL based on machine annotations for machines that are

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -369,6 +369,8 @@ func isUnavailable(entry *planEntry) bool {
 	return !entry.Plan.InSync || isInDrain(entry)
 }
 
+// isInDrain returns a boolean indicating whether the machine/node corresponding to the planEntry is currently in any
+// part of the drain process
 func isInDrain(entry *planEntry) bool {
 	return entry.Metadata.Annotations[rke2.PreDrainAnnotation] != "" ||
 		entry.Metadata.Annotations[rke2.PostDrainAnnotation] != "" ||

--- a/pkg/provisioningv2/rke2/planner/planner_test.go
+++ b/pkg/provisioningv2/rke2/planner/planner_test.go
@@ -69,7 +69,7 @@ func TestPlanner_addInstruction(t *testing.T) {
 			var planner Planner
 			controlPlane := createTestControlPlane(tt.args.version)
 			entry := createTestPlanEntry(tt.args.os)
-
+			planner.retrievalFunctions.SystemAgentImage = func() string { return "system-agent" }
 			// act
 			p, err := planner.addInstallInstructionWithRestartStamp(plan.NodePlan{}, controlPlane, entry)
 

--- a/pkg/provisioningv2/rke2/planner/store.go
+++ b/pkg/provisioningv2/rke2/planner/store.go
@@ -405,6 +405,7 @@ func (p *PlanStore) updatePlanSecretLabelsAndAnnotations(entry *planEntry) error
 	return err
 }
 
+// removePlanSecretLabel removes a label with the given key from the plan secret that corresponds to the RKEBootstrap
 func (p *PlanStore) removePlanSecretLabel(entry *planEntry, key string) error {
 	secret, err := p.getPlanSecretFromMachine(entry.Machine)
 	if err != nil {

--- a/pkg/provisioningv2/rke2/planner/store.go
+++ b/pkg/provisioningv2/rke2/planner/store.go
@@ -419,13 +419,13 @@ func assignAndCheckPlan(store *PlanStore, msg string, server *planEntry, newPlan
 		if err := store.UpdatePlan(server, newPlan, failureThreshold, maxRetries); err != nil {
 			return err
 		}
-		return ErrWaiting(fmt.Sprintf("starting %s", msg))
+		return errWaiting(fmt.Sprintf("starting %s", msg))
 	}
 	if server.Plan.Failed {
 		return fmt.Errorf("operation %s failed", msg)
 	}
 	if !server.Plan.InSync {
-		return ErrWaiting(fmt.Sprintf("waiting for %s", msg))
+		return errWaiting(fmt.Sprintf("waiting for %s", msg))
 	}
 	return nil
 }

--- a/pkg/provisioningv2/rke2/planner/store.go
+++ b/pkg/provisioningv2/rke2/planner/store.go
@@ -71,7 +71,6 @@ func (p *PlanStore) Load(cluster *capi.Cluster, rkeControlPlane *rkev1.RKEContro
 		Nodes:    map[string]*plan.Node{},
 		Machines: map[string]*capi.Machine{},
 		Metadata: map[string]*plan.Metadata{},
-		Cluster:  cluster,
 	}
 
 	machines, err := p.machineCache.List(cluster.Namespace, labels.SelectorFromSet(map[string]string{


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/41080

~This may also work on https://github.com/rancher/rancher/issues/39167~
## Problem
The planner currently will re-bootstrap a cluster with a brand new datastore if the entire controlplane + etcd nodes have been removed. This is not ideal behavior, and gets in the way of disaster recovery situations.

## Solution
Pause processing of plans if there is no current init node, none of the etcd nodes have plans delivered to them, and the cluster is "initialized"
 
## Testing
TO BE FILLED OUT
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->