### PR TITLE
Watch interface needs an admin client

### DIFF
--- a/tests/framework/extensions/users/users.go
+++ b/tests/framework/extensions/users/users.go
@@ -179,11 +179,16 @@ func AddClusterRoleToUser(rancherClient *rancher.Client, cluster *management.Clu
 		RoleTemplateID:  clusterRole,
 	}
 
+	adminClient, err := rancher.NewClient(rancherClient.RancherConfig.AdminToken, rancherClient.Session)
+	if err != nil {
+		return err
+	}
+
 	opts := metav1.ListOptions{
 		FieldSelector:  "metadata.name=" + cluster.ID,
 		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
 	}
-	watchInterface, err := rancherClient.GetManagementWatchInterface(management.ClusterType, opts)
+	watchInterface, err := adminClient.GetManagementWatchInterface(management.ClusterType, opts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Watch interface needs an admin client. when using tests if we are trying to use a standard user client, watch interface gets a forbidden error.
This is to make sure we get the user admin client and make use of it in the watch interface
