### PR TITLE
Invalid groupPrincipals token patch test

### DIFF
--- a/tests/framework/extensions/kubeapi/tokens/patchtokens.go
+++ b/tests/framework/extensions/kubeapi/tokens/patchtokens.go
@@ -1,0 +1,49 @@
+package tokens
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var TokenGroupVersionResource = schema.GroupVersionResource{
+	Group:    "management.cattle.io",
+	Version:  "v3",
+	Resource: "tokens",
+}
+
+// PatchToken is a helper function that uses the dynamic client to patch a token by its name.
+// Different token operations are supported: add, replace, remove.
+func PatchToken(client *rancher.Client, clusterID, tokenName, patchOp, patchPath, patchData string) (*v3.Token, *unstructured.Unstructured, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tokenResource := dynamicClient.Resource(TokenGroupVersionResource)
+
+	patchJSONOperation := fmt.Sprintf(`
+	[
+	  { "op": "%v", "path": "%v", "value": "%v" }
+	]
+	`, patchOp, patchPath, patchData)
+
+	unstructuredResp, err := tokenResource.Patch(context.TODO(), tokenName, types.JSONPatchType, []byte(patchJSONOperation), metav1.PatchOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	newToken := &v3.Token{}
+	err = scheme.Scheme.Convert(unstructuredResp, newToken, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, nil, err
+	}
+	return newToken, unstructuredResp, nil
+}

--- a/tests/v2/validation/token/token_test.go
+++ b/tests/v2/validation/token/token_test.go
@@ -1,0 +1,62 @@
+package token
+
+import (
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	fv3 "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/kubeapi/tokens"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	initialTokenDesc = "my-token"
+	updatedTokenDesc = "changed-token"
+)
+
+type TokenTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+	cluster *management.Cluster
+}
+
+func (t *TokenTestSuite) TearDownSuite() {
+	t.session.Cleanup()
+}
+
+func (t *TokenTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	t.session = testSession
+
+	client, err := rancher.NewClient("", t.session)
+	require.NoError(t.T(), err)
+
+	t.client = client
+}
+
+func (t *TokenTestSuite) TestPatchToken() {
+	tokenToCreate := &fv3.Token{Description: initialTokenDesc}
+	createdToken, err := t.client.Management.Token.Create(tokenToCreate)
+	require.NoError(t.T(), err)
+
+	assert.Equal(t.T(), initialTokenDesc, createdToken.Description)
+
+	patchedToken, unstructuredRes, err := tokens.PatchToken(t.client, t.client.RancherConfig.ClusterName, createdToken.Name, "replace", "/description", updatedTokenDesc)
+	require.NoError(t.T(), err)
+
+	assert.Equal(t.T(), updatedTokenDesc, patchedToken.Description)
+
+	uc := unstructuredRes.UnstructuredContent()
+	if val, ok := uc["groupPrincipals"]; ok {
+		assert.NotEmpty(t.T(), val)
+	}
+}
+
+func TestTokenTestSuite(t *testing.T) {
+	suite.Run(t, new(TokenTestSuite))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/qa-tasks/issues/673
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When creating a token , there was no validation happening by default and groupPrincipals is setting as null. When trying to edit that token , it's not allowing to save the token yaml.  

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Created a PatchToken in extensions/kubeapi, and testing that patching a created token is successful
 