### PR TITLE
Fix go routine leak

### DIFF
--- a/pkg/controllers/management/clusterstats/statsaggregator.go
+++ b/pkg/controllers/management/clusterstats/statsaggregator.go
@@ -306,8 +306,8 @@ func resourceListChanged(oldList, newList v1.ResourceList) bool {
 func callWithTimeout(do func()) {
 	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		do()
-		done <- struct{}{}
 	}()
 
 	select {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/41070

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Prior, in the case of a timeout the there would be no receiver on
the channel. This would cause the go routine to block.

Demonstration of the issue: https://go.dev/play/p/LZhJ3slW1Xf

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 Now, closing the channel will signal the go routines completion. This will not
be prevented by the timeout.

Demonstration of the solution. Can swap the timeout to simulate either the scenario where the parent function receives timeout signal first or the scenario where the go function finishes before the timeout: https://go.dev/play/p/H5j2TQGRp_S

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->