### PR TITLE
Don't overwrite Waiting condition message on v3 cluster object if already set in clusterprovisioner

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/provisioner.go
+++ b/pkg/controllers/management/clusterprovisioner/provisioner.go
@@ -399,9 +399,9 @@ func (p *Provisioner) Create(cluster *apimgmtv3.Cluster) (runtime.Object, error)
 
 	if apimgmtv3.ClusterConditionWaiting.GetStatus(cluster) == "" {
 		apimgmtv3.ClusterConditionWaiting.Unknown(cluster)
-	}
-	if apimgmtv3.ClusterConditionWaiting.GetMessage(cluster) == "" {
-		apimgmtv3.ClusterConditionWaiting.Message(cluster, "Waiting for API to be available")
+		if apimgmtv3.ClusterConditionWaiting.GetMessage(cluster) == "" {
+			apimgmtv3.ClusterConditionWaiting.Message(cluster, "Waiting for API to be available")
+		}
 	}
 
 	cluster, err = p.pending(cluster)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/41107
 
## Problem
In certain cases, it is possible to have the cluster health syncer controller, the cluster provisioner controller, and the statsAggregator controller race with each other. While I have not been able to prove it definitively, my theory on what  exasperates this race condition is a slow downstream API server (or slow link between the Rancher installation and the downstream cluster). 
 
## Solution
This PR makes a change to the clusterprovisioner controller's Create lifecycle, and makes it stop attempting to set a message on the Waiting condition if the condition status has already been defined. This should prevent thrashing if the Create lifecycle is unsuccessful (and the healthsyncer is able to reconcile the cluster).
 
## Testing

## Engineering Testing
### Manual Testing
I have tested importing and provisioning clusters with this fix, and have not noted any functional differences.

### Automated Testing
N/A

## QA Testing Considerations
N/A

### Regressions Considerations
The only regression I can see occurring from this is that the "Waiting for API to be available" message may be cleared from the cluster object before the cluster has finished being processed through the Create lifecycle, if the cluster healthsyncer sees the cluster come online.