### PR TITLE
Only validate dynamic schema for rancher/machine infra

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -181,6 +181,13 @@ func (h *handler) OnChange(_ string, cluster *rancherv1.Cluster) (*rancherv1.Clu
 		if machinePool.DynamicSchemaSpec != "" && json.Unmarshal([]byte(machinePool.DynamicSchemaSpec), &spec) == nil {
 			continue
 		}
+		if machinePool.NodeConfig == nil {
+			continue
+		}
+		apiVersion := machinePool.NodeConfig.APIVersion
+		if apiVersion != rke2.DefaultMachineConfigAPIVersion && apiVersion != "" {
+			continue
+		}
 		// if the field is empty or invalid, add to any machine pools that do not have it and update the cluster
 		clusterCopy := cluster.DeepCopy()
 		for j := i; j < len(cluster.Spec.RKEConfig.MachinePools); j++ {
@@ -192,6 +199,10 @@ func (h *handler) OnChange(_ string, cluster *rancherv1.Cluster) (*rancherv1.Clu
 			nodeConfig := machinePool.NodeConfig
 			if nodeConfig == nil {
 				return cluster, fmt.Errorf("machine pool node config must not be nil")
+			}
+			apiVersion := nodeConfig.APIVersion
+			if apiVersion != rke2.DefaultMachineConfigAPIVersion && apiVersion != "" {
+				continue
 			}
 			ds, err := h.dynamicSchema.Get(strings.ToLower(nodeConfig.Kind))
 			if err != nil {

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -516,6 +516,10 @@ func migrateMachinePoolsDynamicSchemaLabel(w *wrangler.Context) error {
 				if nodeConfig == nil {
 					return fmt.Errorf("machine pool node config must not be nil")
 				}
+				apiVersion := nodeConfig.APIVersion
+				if apiVersion != rke2.DefaultMachineConfigAPIVersion && apiVersion != "" {
+					continue
+				}
 				ds, err := w.Mgmt.DynamicSchema().Get(strings.ToLower(nodeConfig.Kind), metav1.GetOptions{})
 				if err != nil {
 					return err


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/41145
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> 
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Rancher panics because the machine config does not have an associated dynamic schema

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
Only check for dynamic schema if `APIVersion` is `rke-machine-config.cattle.io/v1`, indicating it is from rancher-machine.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->