### PR TITLE
Use GUID for the PrincipalID for Active Directory

### DIFF
--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -6,6 +6,10 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/rancher/rancher/pkg/auth/providers/common"
+
+	"golang.org/x/net/html"
+
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 
 	ldapv3 "github.com/go-ldap/ldap/v3"
@@ -115,18 +119,18 @@ func (p *adProvider) RefetchGroupPrincipals(principalID string, secret string) (
 		return nil, err
 	}
 
-	dn := externalID
+	escapedGUID := common.EscapeUUID(externalID)
+	logrus.Debugf("LDAP Refetch principals GUID : {%s}", externalID)
 
-	logrus.Debugf("LDAP Refetch principals base DN : {%s}", dn)
-
+	filter := fmt.Sprintf("(&(%v=%v)(%v=%v))", ObjectClass, config.UserObjectClass, common.AttributeObjectGUID, escapedGUID)
 	search := ldapv3.NewSearchRequest(
-		dn,
-		ldapv3.ScopeBaseObject,
+		config.UserSearchBase,
+		ldapv3.ScopeSingleLevel,
 		ldapv3.NeverDerefAliases,
 		0,
 		0,
 		false,
-		fmt.Sprintf("(%v=%v)", ObjectClass, config.UserObjectClass),
+		filter,
 		ldap.GetUserSearchAttributes(MemberOfAttribute, ObjectClass, config),
 		nil,
 	)
@@ -160,6 +164,7 @@ func (p *adProvider) getPrincipalsFromSearchResult(result *ldapv3.SearchResult, 
 	groupMap := make(map[string]bool)
 
 	entry := result.Entries[0]
+	guidString := html.EscapeString(fmt.Sprintf("%x", entry.GetRawAttributeValue(common.AttributeObjectGUID)))
 
 	if !p.permissionCheck(entry.Attributes, config) {
 		return v3.Principal{}, nil, fmt.Errorf("Permission denied")
@@ -181,7 +186,7 @@ func (p *adProvider) getPrincipalsFromSearchResult(result *ldapv3.SearchResult, 
 		return v3.Principal{}, nil, nil
 	}
 
-	user, err := ldap.AttributesToPrincipal(entry.Attributes, result.Entries[0].DN, UserScope, Name, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute)
+	user, err := ldap.AttributesToPrincipal(entry.Attributes, result.Entries[0].DN, UserScope, Name, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute, guidString)
 	if err != nil {
 		return userPrincipal, groupPrincipals, err
 	}
@@ -294,7 +299,7 @@ func (p *adProvider) getGroupPrincipalsFromSearch(searchBase string, filter stri
 	}
 
 	for _, e := range result.Entries {
-		principal, err := ldap.AttributesToPrincipal(e.Attributes, e.DN, GroupScope, Name, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute)
+		principal, err := ldap.AttributesToPrincipal(e.Attributes, e.DN, GroupScope, Name, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute, "")
 		if err != nil {
 			logrus.Errorf("AD: Error in getting principal for group entry %v: %v", e, err)
 			continue
@@ -315,32 +320,24 @@ func (p *adProvider) getPrincipal(distinguishedName string, scope string, config
 		return nil, fmt.Errorf("Invalid scope")
 	}
 
-	var attributes []*ldapv3.AttributeTypeAndValue
-	var attribs []*ldapv3.EntryAttribute
-	object, err := ldapv3.ParseDN(distinguishedName)
-	if err != nil {
-		return nil, err
-	}
-	for _, rdns := range object.RDNs {
-		for _, attr := range rdns.Attributes {
-			attributes = append(attributes, attr)
-			entryAttr := ldapv3.NewEntryAttribute(attr.Type, []string{attr.Value})
-			attribs = append(attribs, entryAttr)
-		}
-	}
-
-	if !ldap.IsType(attribs, scope) && !p.permissionCheck(attribs, config) {
-		logrus.Errorf("Failed to get object %s", distinguishedName)
-		return nil, nil
-	}
-
+	var userSearchString string
+	var searchScope int
 	if strings.EqualFold(UserScope, scope) {
-		filter = fmt.Sprintf("(%v=%v)", ObjectClass, config.UserObjectClass)
+		if strings.HasSuffix(strings.ToLower(distinguishedName), strings.ToLower(config.UserSearchBase)) {
+			userSearchString = distinguishedName
+			searchScope = ldapv3.ScopeBaseObject
+			filter = fmt.Sprintf("(&(%v=%v))", ObjectClass, config.UserObjectClass)
+		} else {
+			userSearchString = config.UserSearchBase
+			searchScope = ldapv3.ScopeSingleLevel
+			filter = fmt.Sprintf("(&(%v=%v)(%v=%v))", ObjectClass, config.UserObjectClass, common.AttributeObjectGUID, common.EscapeUUID(distinguishedName))
+		}
+
 	} else {
 		filter = fmt.Sprintf("(%v=%v)", ObjectClass, config.GroupObjectClass)
 	}
 
-	logrus.Debugf("Query for getPrincipal(%s): %s", distinguishedName, filter)
+	logrus.Debugf("Query for getPrincipal(%s): %s", userSearchString, filter)
 	lConn, err := p.ldapConnection(config, caPool)
 	if err != nil {
 		return nil, err
@@ -372,8 +369,8 @@ func (p *adProvider) getPrincipal(distinguishedName string, scope string, config
 	}
 
 	if strings.EqualFold(UserScope, scope) {
-		search = ldapv3.NewSearchRequest(distinguishedName,
-			ldapv3.ScopeBaseObject, ldapv3.NeverDerefAliases, 0, 0, false,
+		search = ldapv3.NewSearchRequest(userSearchString,
+			searchScope, ldapv3.NeverDerefAliases, 0, 0, false,
 			filter,
 			ldap.GetUserSearchAttributes(MemberOfAttribute, ObjectClass, config), nil)
 	} else {
@@ -403,7 +400,8 @@ func (p *adProvider) getPrincipal(distinguishedName string, scope string, config
 		return nil, fmt.Errorf("Permission denied")
 	}
 
-	principal, err := ldap.AttributesToPrincipal(entryAttributes, distinguishedName, scope, Name, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute)
+	objectGUID := html.EscapeString(fmt.Sprintf("%x", entry.GetRawAttributeValue(common.AttributeObjectGUID)))
+	principal, err := ldap.AttributesToPrincipal(entryAttributes, distinguishedName, scope, Name, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute, objectGUID)
 	if err != nil {
 		return nil, err
 	}
@@ -491,7 +489,9 @@ func (p *adProvider) searchLdap(query string, scope string, config *v32.ActiveDi
 
 	for i := 0; i < len(results.Entries); i++ {
 		entry := results.Entries[i]
-		principal, err := ldap.AttributesToPrincipal(entry.Attributes, results.Entries[i].DN, scope, Name, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute)
+		objectGUID := html.EscapeString(fmt.Sprintf("%x", entry.GetRawAttributeValue(common.AttributeObjectGUID)))
+
+		principal, err := ldap.AttributesToPrincipal(entry.Attributes, results.Entries[i].DN, scope, Name, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute, objectGUID)
 		if err != nil {
 			logrus.Errorf("Error translating search result: %v", err)
 			continue

--- a/pkg/auth/providers/activedirectory/activedirectory_provider.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_provider.go
@@ -137,7 +137,7 @@ func (p *adProvider) GetPrincipal(principalID string, token v3.Token) (v3.Princi
 	if err != nil {
 		return v3.Principal{}, err
 	}
-	if p.isThisUserMe(token.UserPrincipal, *principal) {
+	if token.Token != "" && p.isThisUserMe(token.UserPrincipal, *principal) {
 		principal.Me = true
 	}
 	return *principal, err

--- a/pkg/auth/providers/common/ldap/ldap_util.go
+++ b/pkg/auth/providers/common/ldap/ldap_util.go
@@ -136,7 +136,8 @@ func GetUserSearchAttributes(memberOfAttribute, ObjectClass string, config *v32.
 		config.UserObjectClass,
 		config.UserLoginAttribute,
 		config.UserNameAttribute,
-		config.UserEnabledAttribute}
+		config.UserEnabledAttribute,
+		"objectGUID"}
 	return userSearchAttributes
 }
 
@@ -187,7 +188,7 @@ func AuthenticateServiceAccountUser(serviceAccountPassword string, serviceAccoun
 	return nil
 }
 
-func AttributesToPrincipal(attribs []*ldapv3.EntryAttribute, dnStr, scope, providerName, userObjectClass, userNameAttribute, userLoginAttribute, groupObjectClass, groupNameAttribute string) (*v3.Principal, error) {
+func AttributesToPrincipal(attribs []*ldapv3.EntryAttribute, dnStr, scope, providerName, userObjectClass, userNameAttribute, userLoginAttribute, groupObjectClass, groupNameAttribute, objectGUID string) (*v3.Principal, error) {
 	var externalIDType, accountName, externalID, login, kind string
 	externalID = dnStr
 	externalIDType = scope
@@ -234,8 +235,15 @@ func AttributesToPrincipal(attribs []*ldapv3.EntryAttribute, dnStr, scope, provi
 		return nil, fmt.Errorf("Failed to get attributes for %s", dnStr)
 	}
 
+	var metaName string
+	if kind == "group" || objectGUID == "" {
+		metaName = externalIDType + "://" + dnStr
+	} else {
+		metaName = externalIDType + "://" + objectGUID
+	}
+
 	principal := &v3.Principal{
-		ObjectMeta:    metav1.ObjectMeta{Name: externalIDType + "://" + externalID},
+		ObjectMeta:    metav1.ObjectMeta{Name: metaName},
 		DisplayName:   accountName,
 		LoginName:     login,
 		PrincipalType: kind,
@@ -267,7 +275,7 @@ func GatherParentGroups(groupPrincipal v3.Principal, searchDomain string, groupS
 
 	for i := 0; i < len(resultGroups.Entries); i++ {
 		entry := resultGroups.Entries[i]
-		principal, err := AttributesToPrincipal(entry.Attributes, entry.DN, groupScope, config.ProviderName, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute)
+		principal, err := AttributesToPrincipal(entry.Attributes, entry.DN, groupScope, config.ProviderName, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute, "")
 		if err != nil {
 			logrus.Errorf("Error translating group result: %v", err)
 			continue

--- a/pkg/auth/providers/common/provider_util.go
+++ b/pkg/auth/providers/common/provider_util.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"bytes"
+)
+
+const (
+	AttributeObjectGUID = "objectGUID"
+)
+
+// EscapeUUID will take a UUID string in string form and will add backslashes to every 2nd character.
+// The returned result is the string that needs to be added to the LDAP filter to properly filter
+// by objectGUID, which is stored as binary data.
+func EscapeUUID(s string) string {
+	var buffer bytes.Buffer
+	var n1 = 1
+	var l1 = len(s) - 1
+	buffer.WriteRune('\\')
+	for i, r := range s {
+		buffer.WriteRune(r)
+		if i%2 == n1 && i != l1 {
+			buffer.WriteRune('\\')
+		}
+	}
+	return buffer.String()
+}

--- a/pkg/auth/providers/common/provider_util_test.go
+++ b/pkg/auth/providers/common/provider_util_test.go
@@ -1,0 +1,43 @@
+package common_test
+
+import (
+	"github.com/rancher/rancher/pkg/auth/providers/common"
+	"testing"
+)
+
+func TestEscapeUUID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{
+			name: "valid guid string",
+			arg:  "bfb34c007dc2c843adcc74ac3e27df21",
+			want: "\\bf\\b3\\4c\\00\\7d\\c2\\c8\\43\\ad\\cc\\74\\ac\\3e\\27\\df\\21",
+		},
+		{
+			name: "valid string",
+			arg:  "abcdefghijklmnopqrstuvwxyz",
+			want: "\\ab\\cd\\ef\\gh\\ij\\kl\\mn\\op\\qr\\st\\uv\\wx\\yz",
+		},
+		{
+			name: "empty string",
+			arg:  "",
+			want: "\\",
+		},
+		{
+			name: "odd length string",
+			arg:  "abcde",
+			want: "\\ab\\cd\\e",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := common.EscapeUUID(tt.arg); got != tt.want {
+				t.Errorf("EscapeUUID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -130,7 +130,7 @@ func (p *ldapProvider) getPrincipalsFromSearchResult(result *ldapv3.SearchResult
 	userScope = p.userScope
 	groupScope = p.groupScope
 
-	user, err := ldap.AttributesToPrincipal(entry.Attributes, result.Entries[0].DN, userScope, p.providerName, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute)
+	user, err := ldap.AttributesToPrincipal(entry.Attributes, result.Entries[0].DN, userScope, p.providerName, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute, "")
 	if err != nil {
 		return v3.Principal{}, groupPrincipals, err
 	}
@@ -330,7 +330,7 @@ func (p *ldapProvider) getPrincipal(distinguishedName string, scope string, conf
 		return nil, fmt.Errorf("Permission denied")
 	}
 
-	principal, err := ldap.AttributesToPrincipal(entryAttributes, distinguishedName, scope, p.providerName, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute)
+	principal, err := ldap.AttributesToPrincipal(entryAttributes, distinguishedName, scope, p.providerName, config.UserObjectClass, config.UserNameAttribute, config.UserLoginAttribute, config.GroupObjectClass, config.GroupNameAttribute, "")
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +454,8 @@ func (p *ldapProvider) searchLdap(query string, scope string, config *v3.LdapCon
 			config.UserNameAttribute,
 			config.UserLoginAttribute,
 			config.GroupObjectClass,
-			config.GroupNameAttribute)
+			config.GroupNameAttribute,
+			"")
 		if err != nil {
 			return []v3.Principal{}, err
 		}

--- a/pkg/auth/providers/ldap/ldap_provider.go
+++ b/pkg/auth/providers/ldap/ldap_provider.go
@@ -366,7 +366,8 @@ func (p *ldapProvider) samlSearchGetPrincipal(
 		config.UserNameAttribute,
 		config.UserLoginAttribute,
 		config.GroupObjectClass,
-		config.GroupNameAttribute)
+		config.GroupNameAttribute,
+		"")
 }
 
 func (p *ldapProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {

--- a/pkg/auth/providers/migration/activedirectory_migration.go
+++ b/pkg/auth/providers/migration/activedirectory_migration.go
@@ -1,0 +1,230 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	crtbsByPrincipalAndUserIndex = "auth.management.cattle.io/crtbByPrincipalAndUser"
+	prtbsByPrincipalAndUserIndex = "auth.management.cattle.io/prtbByPrincipalAndUser"
+	tokenByUserRefKey            = "auth.management.cattle.io/token-by-user-ref"
+)
+
+type adMigration struct {
+	users        v3.UserInterface
+	userLister   v3.UserLister
+	tokens       v3.TokenInterface
+	prtbs        v3.ProjectRoleTemplateBindingInterface
+	crtbs        v3.ClusterRoleTemplateBindingInterface
+	crtbIndexer  cache.Indexer
+	prtbIndexer  cache.Indexer
+	tokenIndexer cache.Indexer
+}
+
+// MigrateActiveDirectoryDNToGUID will go through all Rancher users and check to see if the principalID
+// is an LDAP distinguished name, which was the way we used to map Rancher users to their LDAP entries.
+// If a principalID is based on DN, this will update the user's principalID along with the tokens,
+// CRTBs, and PRTBs to use a principalID that is the objectGUID for the user.
+func MigrateActiveDirectoryDNToGUID(ctx context.Context, management *config.ManagementContext) {
+	m := adMigration{
+		users:        management.Management.Users(""),
+		userLister:   management.Management.Users("").Controller().Lister(),
+		tokens:       management.Management.Tokens(""),
+		tokenIndexer: management.Management.Tokens("").Controller().Informer().GetIndexer(),
+		crtbs:        management.Management.ClusterRoleTemplateBindings(""),
+		crtbIndexer:  management.Management.ClusterRoleTemplateBindings("").Controller().Informer().GetIndexer(),
+		prtbs:        management.Management.ProjectRoleTemplateBindings(""),
+		prtbIndexer:  management.Management.ProjectRoleTemplateBindings("").Controller().Informer().GetIndexer(),
+	}
+
+	migrateCtx, migrateCancel := context.WithCancel(ctx)
+	go func(context.Context, context.CancelFunc) {
+		defer migrateCancel()
+		err := wait.PollImmediate(time.Hour*24, 0, func() (bool, error) {
+			logrus.Debugf("Starting active directory principalID migration with exponentialBackoff")
+			steps := 5
+			backOffDuration := time.Minute * 10
+			var err error
+			for steps > 0 {
+				err = m.migrate()
+				if err != nil {
+					time.Sleep(backOffDuration)
+					backOffDuration = 2 * backOffDuration
+				} else {
+					break
+				}
+				steps--
+			}
+			if err != nil {
+				// returning false & nil because PollImmediate terminates on error
+				logrus.Errorf("problem in migrating active directory user principalIds %v", err)
+				return false, nil
+			}
+			// no error returned, user cleanup done, calling the child context's cancelfunc to terminate child context
+			return true, nil
+		})
+		if err != nil {
+			logrus.Errorf("problem in migrating active directory user principalIds %v", err)
+			return
+		}
+	}(migrateCtx, migrateCancel)
+}
+
+func (m *adMigration) migrate() error {
+	users, err := m.userLister.List("", labels.Everything())
+	if err != nil {
+		return fmt.Errorf("error listing users during active directory migration: %w", err)
+	}
+	for _, user := range users {
+		for _, principal := range user.PrincipalIDs {
+			if strings.HasPrefix(principal, "activedirectory_user://") && strings.Contains(principal, ",") {
+				err = m.migrateUser(user, principal)
+				if err != nil {
+					return fmt.Errorf("error migrating user: %w", err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (m *adMigration) migrateUser(user *v32.User, dn string) error {
+	adProvider, err := providers.GetProvider("activedirectory")
+	if err != nil {
+		return fmt.Errorf("unable to fetch activedirectory provider: %w", err)
+	}
+	token := v3.Token{}
+	userPrincipal, err := adProvider.GetPrincipal(dn, token)
+	if err != nil {
+		return fmt.Errorf("failed to fetch principal: %w", err)
+	}
+
+	if err = m.migrateTokens(user.Name, userPrincipal.Name); err != nil {
+		return fmt.Errorf("failed to migrate tokens for user: %w", err)
+	}
+	if err = m.migrateCRTB(userPrincipal.Name, dn); err != nil {
+		return fmt.Errorf("failed to migrate CRTBs for user: %w", err)
+	}
+	if err = m.migratePRTB(userPrincipal.Name, dn); err != nil {
+		return fmt.Errorf("failed to migrate PRTBs for user: %w", err)
+	}
+	if err = m.updateUserObject(user, userPrincipal.Name, dn); err != nil {
+		return fmt.Errorf("failed to migrate user: %w", err)
+	}
+	return nil
+}
+
+func (m *adMigration) updateUserObject(user *v32.User, newPrincipalID string, dn string) error {
+	updatedUser := user.DeepCopy()
+	for i, pID := range updatedUser.PrincipalIDs {
+		if strings.HasPrefix(pID, dn) {
+			updatedUser.PrincipalIDs[i] = newPrincipalID
+		}
+	}
+	if _, err := m.users.Update(updatedUser); err != nil {
+		return fmt.Errorf("failed updating user object: %w", err)
+	}
+	return nil
+}
+
+func (m *adMigration) migrateTokens(userName string, newPrincipalID string) error {
+	userTokens, err := m.tokenIndexer.ByIndex(tokenByUserRefKey, userName)
+	if err != nil {
+		return fmt.Errorf("failed to fetch tokens: %w", err)
+	}
+
+	for _, obj := range userTokens {
+		token, ok := obj.(*v3.Token)
+		if !ok {
+			return errors.Errorf("failed to convert object to Token for user %v principalId %v", userName, newPrincipalID)
+		}
+		token.UserPrincipal.Name = newPrincipalID
+		_, e := m.tokens.Update(token)
+		if e != nil {
+			logrus.Errorf("unable to update token %v for principalId %v", token.Name, newPrincipalID)
+		}
+	}
+	return nil
+}
+
+func (m *adMigration) migrateCRTB(newPrincipalID string, dn string) error {
+	userCRTBs, err := m.crtbIndexer.ByIndex(crtbsByPrincipalAndUserIndex, dn)
+	if err != nil {
+		return fmt.Errorf("failed to fetch CRTBs: %w", err)
+	}
+	for _, crtb := range userCRTBs {
+		oldCrtb, ok := crtb.(*v3.ClusterRoleTemplateBinding)
+		if !ok {
+			return fmt.Errorf("failed to convert object to CRTB for principalId %v", newPrincipalID)
+		}
+		newCrtb := &v3.ClusterRoleTemplateBinding{
+			ObjectMeta: v1.ObjectMeta{
+				Name:         "",
+				Namespace:    oldCrtb.ObjectMeta.Namespace,
+				GenerateName: "crtb-",
+			},
+			ClusterName:       oldCrtb.ClusterName,
+			UserName:          oldCrtb.UserName,
+			RoleTemplateName:  oldCrtb.RoleTemplateName,
+			UserPrincipalName: newPrincipalID,
+		}
+		_, err := m.crtbs.Create(newCrtb)
+		if err != nil {
+			return fmt.Errorf("unable to create new CRTB: %w", err)
+		}
+		err = m.crtbs.DeleteNamespaced(oldCrtb.Namespace, oldCrtb.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to delete CRTB: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m *adMigration) migratePRTB(newPrincipalID string, dn string) error {
+	userPRTBs, err := m.prtbIndexer.ByIndex(prtbsByPrincipalAndUserIndex, dn)
+	if err != nil {
+		return fmt.Errorf("failed to fetch PRTBs: %w", err)
+	}
+	for _, prtb := range userPRTBs {
+		oldPrtb, ok := prtb.(*v3.ProjectRoleTemplateBinding)
+		if !ok {
+			return fmt.Errorf("failed to convert object to PRTB for principalId %v: %w", newPrincipalID, err)
+		}
+		newPrtb := &v3.ProjectRoleTemplateBinding{
+			ObjectMeta: v1.ObjectMeta{
+				Name:         "",
+				Namespace:    oldPrtb.ObjectMeta.Namespace,
+				GenerateName: "prtb-",
+			},
+			ProjectName:       oldPrtb.ProjectName,
+			UserName:          oldPrtb.UserName,
+			RoleTemplateName:  oldPrtb.RoleTemplateName,
+			UserPrincipalName: newPrincipalID,
+		}
+		_, err := m.prtbs.Create(newPrtb)
+		if err != nil {
+			return fmt.Errorf("unable to create new PRTB: %w", err)
+		}
+		err = m.prtbs.DeleteNamespaced(oldPrtb.Namespace, oldPrtb.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to delete PRTB: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/auth/providers/migration/activedirectory_migration_test.go
+++ b/pkg/auth/providers/migration/activedirectory_migration_test.go
@@ -1,0 +1,774 @@
+package migration
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/pkg/auth/providers"
+	"github.com/rancher/rancher/pkg/auth/providers/activedirectory"
+	"github.com/rancher/rancher/pkg/auth/providers/common"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+	"testing"
+)
+
+const (
+	testNamespace = "test-cluster"
+)
+
+func Test_adMigration_migrate(t *testing.T) {
+	var tests = []struct {
+		name                       string
+		users                      v3.UserInterface
+		userLister                 v3.UserLister
+		tokens                     v3.TokenInterface
+		prtbs                      v3.ProjectRoleTemplateBindingInterface
+		crtbs                      v3.ClusterRoleTemplateBindingInterface
+		crtbIndexer                cache.Indexer
+		prtbIndexer                cache.Indexer
+		tokenIndexer               cache.Indexer
+		authConfigs                v3.AuthConfigInterface
+		wantErr                    bool
+		userList                   []*v3.User
+		principal                  v3.Principal
+		existingTokens             []*v3.Token
+		existingCrtbs              []*v3.ClusterRoleTemplateBinding
+		existingPrtbs              []*v3.ProjectRoleTemplateBinding
+		wantCRTBCreateCalledTimes  int
+		wantCRTBDeleteCalledTimes  int
+		wantPRTBCreateCalledTimes  int
+		wantPRTBDeleteCalledTimes  int
+		wantTokenUpdateCalledTimes int
+		wantUserUpdateCalledTimes  int
+	}{
+		{
+			name: "migrate user along with crtb prtb tokens",
+			userList: []*v3.User{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "testuser4",
+					},
+					PrincipalIDs: []string{
+						"activedirectory_user://CN=testuser4,CN=Users,DC=qa,DC=rancher,DC=space",
+					},
+				},
+			},
+			principal: v3.Principal{
+				TypeMeta: v1.TypeMeta{},
+				ObjectMeta: v1.ObjectMeta{
+					Name: "testuser4",
+				},
+				DisplayName:   "testuser4",
+				LoginName:     "testuser4",
+				PrincipalType: "user",
+				Provider:      "activedirectory",
+			},
+			existingTokens: []*v3.Token{
+				{
+					UserID: "testuser4",
+					UserPrincipal: v3.Principal{
+						Provider: providers.LocalProvider,
+						ExtraInfo: map[string]string{
+							common.UserAttributePrincipalID: "activedirectory://user-abcde",
+							common.UserAttributeUserName:    "testuser4",
+						},
+					},
+				},
+			},
+			existingCrtbs: []*v3.ClusterRoleTemplateBinding{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "crtb-1",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser4,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "crtb-2",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser4,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "crtb-3",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "anyprincipal",
+				},
+			},
+			existingPrtbs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prtb-1",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser4,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prtb-2",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser4,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prtb-3",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "anyprincipal",
+				},
+			},
+			wantCRTBCreateCalledTimes:  2,
+			wantCRTBDeleteCalledTimes:  2,
+			wantPRTBDeleteCalledTimes:  2,
+			wantPRTBCreateCalledTimes:  2,
+			wantTokenUpdateCalledTimes: 1,
+			wantUserUpdateCalledTimes:  1,
+		},
+		{
+			name: "migrate user another user is already migrated",
+			userList: []*v3.User{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "testuser4",
+					},
+					PrincipalIDs: []string{
+						"activedirectory_user://CN=testuser4,CN=Users,DC=qa,DC=rancher,DC=space",
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "migrateduser4",
+					},
+					PrincipalIDs: []string{
+						"activedirectory_user://alreadymigrateduser",
+					},
+				},
+			},
+			principal: v3.Principal{
+				TypeMeta: v1.TypeMeta{},
+				ObjectMeta: v1.ObjectMeta{
+					Name: "testuser4",
+				},
+				DisplayName:   "testuser4",
+				LoginName:     "testuser4",
+				PrincipalType: "user",
+				Provider:      "activedirectory",
+			},
+			existingTokens: []*v3.Token{
+				{
+					UserID: "testuser4",
+					UserPrincipal: v3.Principal{
+						Provider: providers.LocalProvider,
+						ExtraInfo: map[string]string{
+							common.UserAttributePrincipalID: "activedirectory://user-abcde",
+							common.UserAttributeUserName:    "testuser4",
+						},
+					},
+				},
+			},
+			existingCrtbs: []*v3.ClusterRoleTemplateBinding{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "crtb-1",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser4,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "crtb-2",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser4,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "crtb-3",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "anyprincipal",
+				},
+			},
+			existingPrtbs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prtb-1",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser4,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prtb-2",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser4,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prtb-3",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "anyprincipal",
+				},
+			},
+			wantCRTBCreateCalledTimes:  2,
+			wantCRTBDeleteCalledTimes:  2,
+			wantPRTBDeleteCalledTimes:  2,
+			wantPRTBCreateCalledTimes:  2,
+			wantTokenUpdateCalledTimes: 1,
+			wantUserUpdateCalledTimes:  1,
+		},
+		{
+			name: "user principal does not need migration",
+			userList: []*v3.User{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "testuser4",
+					},
+					PrincipalIDs: []string{
+						"activedirectory_user://bfb34c007dc2c843adcc74ac3e27df21",
+					},
+				},
+			},
+			wantCRTBCreateCalledTimes:  0,
+			wantCRTBDeleteCalledTimes:  0,
+			wantPRTBDeleteCalledTimes:  0,
+			wantPRTBCreateCalledTimes:  0,
+			wantTokenUpdateCalledTimes: 0,
+			wantUserUpdateCalledTimes:  0,
+		},
+		{
+			name: "non active directory user does not need migration",
+			userList: []*v3.User{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "githubusername",
+					},
+					PrincipalIDs: []string{
+						"github_user://githubid",
+					},
+				},
+			},
+			wantCRTBCreateCalledTimes:  0,
+			wantCRTBDeleteCalledTimes:  0,
+			wantPRTBDeleteCalledTimes:  0,
+			wantPRTBCreateCalledTimes:  0,
+			wantTokenUpdateCalledTimes: 0,
+			wantUserUpdateCalledTimes:  0,
+		},
+	}
+	for _, tt := range tests {
+		indexers := map[string]cache.IndexFunc{
+			tokenByUserRefKey:            tokensByUserRefKey,
+			crtbsByPrincipalAndUserIndex: crtbByPrincipalAndUserIndex,
+			prtbsByPrincipalAndUserIndex: prtbByPrincipalAndUserIndex,
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			tokenUpdateCalled := 0
+			crtbDeleteCalled := 0
+			crtbCreateCalled := 0
+			prtbDeleteCalled := 0
+			prtbCreateCalled := 0
+			userUpdateCalled := 0
+			mockIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			mockIndexer.AddIndexers(indexers)
+			for _, obj := range tt.existingTokens {
+				mockIndexer.Add(obj)
+			}
+			for _, obj := range tt.existingPrtbs {
+				mockIndexer.Add(obj)
+			}
+			for _, obj := range tt.existingCrtbs {
+				mockIndexer.Add(obj)
+			}
+			m := &adMigration{
+				users: &fakes.UserInterfaceMock{
+					UpdateFunc: func(in1 *v3.User) (*v3.User, error) {
+						userUpdateCalled++
+						return in1, nil
+					},
+				},
+				userLister: &fakes.UserListerMock{
+					ListFunc: func(namespace string, selector labels.Selector) ([]*v3.User, error) {
+						return tt.userList, nil
+					},
+				},
+				tokenIndexer: mockIndexer,
+				tokens: &fakes.TokenInterfaceMock{
+					UpdateFunc: func(in1 *v3.Token) (*v3.Token, error) {
+						tokenUpdateCalled++
+						return in1, nil
+					},
+				},
+				prtbs: &fakes.ProjectRoleTemplateBindingInterfaceMock{
+					DeleteNamespacedFunc: func(_, _ string, _ *v1.DeleteOptions) error {
+						prtbDeleteCalled++
+						return nil
+					},
+					CreateFunc: func(in1 *v3.ProjectRoleTemplateBinding) (*v3.ProjectRoleTemplateBinding, error) {
+						prtbCreateCalled++
+						return in1, nil
+					},
+				},
+				prtbIndexer: mockIndexer,
+				crtbs: &fakes.ClusterRoleTemplateBindingInterfaceMock{
+					DeleteNamespacedFunc: func(_, _ string, _ *v1.DeleteOptions) error {
+						crtbDeleteCalled++
+						return nil
+					},
+					CreateFunc: func(in1 *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+						crtbCreateCalled++
+						return in1, nil
+					},
+				},
+				crtbIndexer: mockIndexer,
+			}
+			providers.Providers = map[string]common.AuthProvider{
+				activedirectory.Name: &mockProvider{principal: tt.principal},
+			}
+			if err := m.migrate(); (err != nil) != tt.wantErr {
+				t.Errorf("migrate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.wantPRTBDeleteCalledTimes, prtbDeleteCalled)
+			assert.Equal(t, tt.wantPRTBCreateCalledTimes, prtbCreateCalled)
+			assert.Equal(t, tt.wantCRTBDeleteCalledTimes, crtbDeleteCalled)
+			assert.Equal(t, tt.wantCRTBCreateCalledTimes, crtbCreateCalled)
+			assert.Equal(t, tt.wantUserUpdateCalledTimes, userUpdateCalled)
+			assert.Equal(t, tt.wantTokenUpdateCalledTimes, tokenUpdateCalled)
+		})
+	}
+}
+
+func Test_adMigration_migrateCRTB(t *testing.T) {
+	type args struct {
+		newPrincipalID string
+		dn             string
+	}
+	var tests = []struct {
+		name                  string
+		crtbs                 v3.ClusterRoleTemplateBindingInterface
+		crtbIndexer           cache.Indexer
+		existingCrtbs         []*v3.ClusterRoleTemplateBinding
+		args                  args
+		wantErr               bool
+		wantCreateCalledTimes int
+		wantDeleteCalledTimes int
+		createFail            bool
+		deleteFail            bool
+	}{
+		{
+			name:                  "update 2 crtbs with new principalID",
+			wantErr:               false,
+			wantCreateCalledTimes: 2,
+			wantDeleteCalledTimes: 2,
+			createFail:            false,
+			deleteFail:            false,
+			args: args{
+				dn:             "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				newPrincipalID: "activedirectory_user://abcdef123456abcdef123456",
+			},
+			existingCrtbs: []*v3.ClusterRoleTemplateBinding{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prtb-1",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prtb-2",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "crtb-3",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "anyprincipal",
+				},
+			},
+		},
+		{
+			name:                  "fail to create crtb with new principalID",
+			wantErr:               true,
+			wantCreateCalledTimes: 1,
+			wantDeleteCalledTimes: 0,
+			createFail:            true,
+			deleteFail:            false,
+			args: args{
+				dn:             "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				newPrincipalID: "activedirectory_user://abcdef123456abcdef123456",
+			},
+			existingCrtbs: []*v3.ClusterRoleTemplateBinding{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "crtb-1",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+			},
+		},
+		{
+			name:                  "fail to delete crtb with old principalID",
+			wantErr:               true,
+			wantCreateCalledTimes: 1,
+			wantDeleteCalledTimes: 1,
+			createFail:            false,
+			deleteFail:            true,
+			args: args{
+				dn:             "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				newPrincipalID: "activedirectory_user://abcdef123456abcdef123456",
+			},
+			existingCrtbs: []*v3.ClusterRoleTemplateBinding{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "crtb-1",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		indexers := map[string]cache.IndexFunc{
+			crtbsByPrincipalAndUserIndex: crtbByPrincipalAndUserIndex,
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			crtbDeleteCalled := 0
+			crtbCreateCalled := 0
+			mockIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			mockIndexer.AddIndexers(indexers)
+			for _, obj := range tt.existingCrtbs {
+				mockIndexer.Add(obj)
+			}
+			m := &adMigration{
+				crtbs: &fakes.ClusterRoleTemplateBindingInterfaceMock{
+					DeleteNamespacedFunc: func(_, _ string, _ *v1.DeleteOptions) error {
+						crtbDeleteCalled++
+						if tt.deleteFail {
+							return errors.New("simulated delete fail")
+						}
+						return nil
+					},
+					CreateFunc: func(in1 *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+						crtbCreateCalled++
+						if tt.createFail {
+							return nil, errors.New("simulated create fail")
+						}
+						return in1, nil
+					},
+				},
+				crtbIndexer: mockIndexer,
+			}
+
+			if err := m.migrateCRTB(tt.args.newPrincipalID, tt.args.dn); (err != nil) != tt.wantErr {
+				t.Errorf("migrateCRTB() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.wantCreateCalledTimes, crtbCreateCalled)
+			assert.Equal(t, tt.wantDeleteCalledTimes, crtbDeleteCalled)
+		})
+	}
+}
+
+func Test_adMigration_migratePRTB(t *testing.T) {
+	type args struct {
+		newPrincipalID string
+		dn             string
+	}
+	var tests = []struct {
+		name                  string
+		prtbs                 v3.ProjectRoleTemplateBindingInterface
+		prtbIndexer           cache.Indexer
+		existingPrtbs         []*v3.ProjectRoleTemplateBinding
+		args                  args
+		wantErr               bool
+		wantCreateCalledTimes int
+		wantDeleteCalledTimes int
+		createFail            bool
+		deleteFail            bool
+	}{
+		{
+			name:                  "update 2 ptrbs with new principalID",
+			wantErr:               false,
+			wantCreateCalledTimes: 2,
+			wantDeleteCalledTimes: 2,
+			createFail:            false,
+			deleteFail:            false,
+			args: args{
+				dn:             "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				newPrincipalID: "activedirectory_user://abcdef123456abcdef123456",
+			},
+			existingPrtbs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prtb-1",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prtb-2",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prtb-3",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "anyprincipal",
+				},
+			},
+		},
+		{
+			name:                  "fail to create prtb with new principalID",
+			wantErr:               true,
+			wantCreateCalledTimes: 1,
+			wantDeleteCalledTimes: 0,
+			createFail:            true,
+			deleteFail:            false,
+			args: args{
+				dn:             "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				newPrincipalID: "activedirectory_user://abcdef123456abcdef123456",
+			},
+			existingPrtbs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prtb-1",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+			},
+		},
+		{
+			name:                  "fail to delete prtb with old principalID",
+			wantErr:               true,
+			wantCreateCalledTimes: 1,
+			wantDeleteCalledTimes: 1,
+			createFail:            false,
+			deleteFail:            true,
+			args: args{
+				dn:             "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				newPrincipalID: "activedirectory_user://abcdef123456abcdef123456",
+			},
+			existingPrtbs: []*v3.ProjectRoleTemplateBinding{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prtb-1",
+						Namespace: testNamespace,
+					},
+					RoleTemplateName:  "testRoleTemplateName",
+					UserPrincipalName: "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		indexers := map[string]cache.IndexFunc{
+			prtbsByPrincipalAndUserIndex: prtbByPrincipalAndUserIndex,
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			prtbDeleteCalled := 0
+			prtbCreateCalled := 0
+			mockIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			mockIndexer.AddIndexers(indexers)
+			for _, obj := range tt.existingPrtbs {
+				mockIndexer.Add(obj)
+			}
+			m := &adMigration{
+				prtbs: &fakes.ProjectRoleTemplateBindingInterfaceMock{
+					DeleteNamespacedFunc: func(_, _ string, _ *v1.DeleteOptions) error {
+						prtbDeleteCalled++
+						if tt.deleteFail {
+							return errors.New("simulated delete fail")
+						}
+						return nil
+					},
+					CreateFunc: func(in1 *v3.ProjectRoleTemplateBinding) (*v3.ProjectRoleTemplateBinding, error) {
+						prtbCreateCalled++
+						if tt.createFail {
+							return nil, errors.New("simulated create fail")
+						}
+						return in1, nil
+					},
+				},
+				prtbIndexer: mockIndexer,
+			}
+
+			if err := m.migratePRTB(tt.args.newPrincipalID, tt.args.dn); (err != nil) != tt.wantErr {
+				t.Errorf("migratePRTB() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.wantCreateCalledTimes, prtbCreateCalled)
+			assert.Equal(t, tt.wantDeleteCalledTimes, prtbDeleteCalled)
+		})
+	}
+}
+
+func Test_adMigration_migrateTokens(t *testing.T) {
+	type args struct {
+		userName       string
+		newPrincipalID string
+	}
+	var tests = []struct {
+		name                  string
+		tokenIndexer          cache.Indexer
+		tokens                v3.TokenInterface
+		tokenList             []*v3.Token
+		args                  args
+		wantUpdateCalledTimes int
+		wantErr               bool
+	}{
+		{
+			name: "update token with new principalId",
+			args: args{
+				userName:       "testuser1",
+				newPrincipalID: "activedirectory_user://newprincipalID",
+			},
+			wantErr:               false,
+			wantUpdateCalledTimes: 1,
+			tokenList: []*v3.Token{
+				{
+					UserID: "testuser1",
+					UserPrincipal: v3.Principal{
+						Provider: providers.LocalProvider,
+						ExtraInfo: map[string]string{
+							common.UserAttributePrincipalID: "activedirectory://user-abcde",
+							common.UserAttributeUserName:    "testuser1",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		indexers := map[string]cache.IndexFunc{
+			tokenByUserRefKey: tokensByUserRefKey,
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			tokenUpdateCalled := 0
+			mockIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			mockIndexer.AddIndexers(indexers)
+			for _, obj := range tt.tokenList {
+				mockIndexer.Add(obj)
+			}
+			m := &adMigration{
+				tokenIndexer: mockIndexer,
+				tokens: &fakes.TokenInterfaceMock{
+					UpdateFunc: func(in1 *v3.Token) (*v3.Token, error) {
+						tokenUpdateCalled++
+						return in1, nil
+					},
+				},
+			}
+			if err := m.migrateTokens(tt.args.userName, tt.args.newPrincipalID); (err != nil) != tt.wantErr {
+				t.Errorf("migrateTokens() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func prtbByPrincipalAndUserIndex(obj interface{}) ([]string, error) {
+	prtb, ok := obj.(*v3.ProjectRoleTemplateBinding)
+	if !ok {
+		return []string{}, nil
+	}
+	return []string{prtb.UserPrincipalName}, nil
+}
+
+func crtbByPrincipalAndUserIndex(obj interface{}) ([]string, error) {
+	crtb, ok := obj.(*v3.ClusterRoleTemplateBinding)
+	if !ok {
+		return []string{}, nil
+	}
+	return []string{crtb.UserPrincipalName}, nil
+}
+
+func tokensByUserRefKey(obj interface{}) ([]string, error) {
+	token, ok := obj.(*v3.Token)
+	if !ok {
+		return []string{}, nil
+	}
+	return []string{token.UserID}, nil
+}
+
+type mockProvider struct {
+	principal v3.Principal
+}
+
+func (p *mockProvider) IsDisabledProvider() (bool, error) {
+	panic("not implemented")
+}
+
+func (p *mockProvider) GetName() string {
+	panic("not implemented")
+}
+
+func (p *mockProvider) AuthenticateUser(ctx context.Context, input interface{}) (v3.Principal, []v3.Principal, string, error) {
+	panic("not implemented")
+}
+
+func (p *mockProvider) SearchPrincipals(name, principalType string, myToken v3.Token) ([]v3.Principal, error) {
+	panic("not implemented")
+}
+
+func (p *mockProvider) GetPrincipal(principalID string, token v3.Token) (v3.Principal, error) {
+	return p.principal, nil
+}
+
+func (p *mockProvider) CustomizeSchema(schema *types.Schema) {
+	panic("not implemented")
+}
+
+func (p *mockProvider) TransformToAuthProvider(authConfig map[string]interface{}) (map[string]interface{}, error) {
+	panic("not implemented")
+}
+
+func (p *mockProvider) RefetchGroupPrincipals(principalID string, secret string) ([]v3.Principal, error) {
+	return []v3.Principal{}, errors.New("Not implemented")
+}
+
+func (p *mockProvider) CanAccessWithGroupProviders(userPrincipalID string, groups []v3.Principal) (bool, error) {
+	return true, nil
+}
+
+func (p *mockProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {
+	panic("not implemented")
+}

--- a/pkg/multiclustermanager/app.go
+++ b/pkg/multiclustermanager/app.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rancher/rancher/pkg/auth/providers/migration"
+
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
@@ -214,6 +216,7 @@ func (m *mcm) Start(ctx context.Context) error {
 		}
 
 		tokens.StartPurgeDaemon(ctx, management)
+		migration.MigrateActiveDirectoryDNToGUID(ctx, management)
 		providerrefresh.StartRefreshDaemon(ctx, m.ScaledContext, management)
 		managementdata.CleanupOrphanedSystemUsers(ctx, management)
 		clusterupstreamrefresher.MigrateEksRefreshCronSetting(m.wranglerContext)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/37994
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
If Rancher is configured to use AD for authentication, and AD user accounts get moved between OUs, then when the users log back into Rancher a new user is created and all their old permissions are not preserved.
This is because the principalID was based on the DN of each user.  When the OU changes, it results in a new DN, which results in a new Rancher user.
 
## Solution
Active Directory has an attribute, objectGUID, which is unique and immutable.  We now use that attribute as the basis for the principalID
 
## Testing
The repro steps in the original issue are correct.

## Engineering Testing
### Manual Testing
With a fresh Rancher install, set up Active Directory as the auth provider.  Verify that you can login as usual with valid users from that auth provider.  All Rancher functionality should appear normal.
You can verify that the user has been assigned a principalID based on GUID rather than DN by doing:
`kubectl get user <user> --template='{{.principalIds}}'`
The output of that should show one of the principalIds that will look like:  `activedirectory_user://bfb34c007dc2c843adcc74ac3e27df21`
instead of the old-style, DN-based principalId, which would look like:
`CN=username,CN=Users,DC=qa,DC=company,DC=org`

I've also tried changing the OU of a user and made sure that the OU change didn't result in a new Rancher user (the objectGUID mapping IS correctly working and Rancher is no longer relying on the DN)

### Automated Testing
Unit tests

## QA Testing Considerations
The upgrade scenario is important for this issue.  This PR includes a "migration" function that will run at Rancher startup time to update user, token, crtb, prtb objects that were using a DN-based solution to use the GUID as the principal.  In order to test this, you would need to either have an older version running with Rancher users created, and then upgrade.  Or, it's possible to have some sort of "reset" script that will take AD Rancher users and "reset" the principalID to be DN-based (and the corresponding objects....note, CRTBs and PRTBs will need to be deleted and re-created instead of updated in place.  I'm happy to work with QA to come up with some sort of "reset" script that will work for them.
 
### Regressions Considerations
If the migration process were to fail to update one or more bindings, the affected user would see their permissions affected negatively, so it's especially important to verify that the user's bindings were all updated as part of the migration process.