### PR TITLE
Add validation test for etcd node deletion

### DIFF
--- a/tests/framework/extensions/nodes/node_status.go
+++ b/tests/framework/extensions/nodes/node_status.go
@@ -1,16 +1,24 @@
 package nodes
 
 import (
+	"net/url"
 	"time"
 
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
-	active = "active"
+	active                   = "active"
+	machineSteveResourceType = "cluster.x-k8s.io.machine"
+	etcdLabel                = "rke.cattle.io/etcd-role"
+	clusterLabel             = "cluster.x-k8s.io/cluster-name"
+	PollInterval             = time.Duration(5 * time.Second)
+	PollTimeout              = time.Duration(15 * time.Minute)
 )
 
 // IsNodeReady is a helper method that will loop and check if the node is ready in the RKE1 cluster.
@@ -29,19 +37,75 @@ func IsNodeReady(client *rancher.Client, ClusterID string) error {
 		for _, node := range nodes.Data {
 			node, err := client.Management.Node.ByID(node.ID)
 			if err != nil {
-				return false, err
+				return false, nil
 			}
 
-			if node.State == active {
-				logrus.Infof("All nodes in the cluster are in an active state!")
-				return true, nil
+			if node.State != active {
+				return false, nil
 			}
-
-			return false, nil
 		}
-
-		return false, nil
+		logrus.Infof("All nodes in the cluster are in an active state!")
+		return true, nil
 	})
 
 	return err
+}
+
+func IsRKE1EtcdNodeReplaced(client *rancher.Client, etcdNodeToDelete management.Node, clusterResp *management.Cluster, numOfEtcdNodesBeforeDeletion int) (bool, error) {
+	numOfEtcdNodesAfterDeletion := 0
+
+	err := wait.Poll(PollInterval, PollTimeout, func() (done bool, err error) {
+		machines, err := client.Management.Node.List(&types.ListOpts{Filters: map[string]interface{}{
+			"clusterId": clusterResp.ID,
+		}})
+		if err != nil {
+			return false, err
+		}
+		numOfEtcdNodesAfterDeletion = 0
+		for _, machine := range machines.Data {
+			if machine.Etcd {
+				if machine.ID == etcdNodeToDelete.ID {
+					return false, nil
+				}
+				numOfEtcdNodesAfterDeletion++
+			}
+		}
+		logrus.Info("new etcd node : ")
+		for _, machine := range machines.Data {
+			if machine.Etcd {
+				logrus.Info(machine.NodeName)
+			}
+		}
+		return true, nil
+	})
+	return numOfEtcdNodesBeforeDeletion == numOfEtcdNodesAfterDeletion, err
+}
+
+func IsRKE2K3SEtcdNodeReplaced(client *rancher.Client, query url.Values, clusterName string, etcdNodeToDelete v1.SteveAPIObject, numOfEtcdNodesBeforeDeletion int) (bool, error) {
+	numOfEtcdNodesAfterDeletion := 0
+
+	err := wait.Poll(PollInterval, PollTimeout, func() (done bool, err error) {
+		machines, err := client.Steve.SteveType(machineSteveResourceType).List(query)
+		if err != nil {
+			return false, err
+		}
+
+		numOfEtcdNodesAfterDeletion = 0
+		for _, machine := range machines.Data {
+			if machine.Labels[etcdLabel] == "true" && machine.Labels[clusterLabel] == clusterName {
+				if machine.Name == etcdNodeToDelete.Name {
+					return false, nil
+				}
+				numOfEtcdNodesAfterDeletion++
+			}
+		}
+		logrus.Info("new etcd node : ")
+		for _, machine := range machines.Data {
+			if machine.Labels[etcdLabel] == "true" && machine.Labels[clusterLabel] == clusterName {
+				logrus.Info(machine.Name)
+			}
+		}
+		return true, nil
+	})
+	return numOfEtcdNodesBeforeDeletion == numOfEtcdNodesAfterDeletion, err
 }

--- a/tests/v2/validation/provisioning/config.go
+++ b/tests/v2/validation/provisioning/config.go
@@ -10,7 +10,7 @@ type Version string
 type PSACT string
 
 const (
-	namespace                       = "fleet-default"
+	Namespace                       = "fleet-default"
 	defaultRandStringLength         = 5
 	ConfigurationFileKey            = "provisioningInput"
 	HardenedKubeVersion     Version = "v1.24.99"

--- a/tests/v2/validation/provisioning/k3s/etcd_node_delete_and_replace_test.go
+++ b/tests/v2/validation/provisioning/k3s/etcd_node_delete_and_replace_test.go
@@ -1,0 +1,126 @@
+package k3s
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
+	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	machineSteveResourceType = "cluster.x-k8s.io.machine"
+	etcdLabel                = "rke.cattle.io/etcd-role"
+	clusterLabel             = "cluster.x-k8s.io/cluster-name"
+)
+
+type EtcdNodeDeleteAndReplace struct {
+	suite.Suite
+	session               *session.Session
+	client                *rancher.Client
+	ns                    string
+	k3skubernetesVersions []string
+	cnis                  []string
+	providers             []string
+	nodesAndRoles         []machinepools.NodeRoles
+	psact                 string
+	advancedOptions       provisioning.AdvancedOptions
+}
+
+func (e *EtcdNodeDeleteAndReplace) TearDownSuite() {
+	e.session.Cleanup()
+}
+
+func (e *EtcdNodeDeleteAndReplace) SetupSuite() {
+	testSession := session.NewSession()
+	e.session = testSession
+
+	e.ns = provisioning.Namespace
+
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+
+	e.k3skubernetesVersions = clustersConfig.K3SKubernetesVersions
+
+	e.cnis = clustersConfig.CNIs
+	e.providers = clustersConfig.Providers
+	e.nodesAndRoles = clustersConfig.NodesAndRoles
+	e.psact = clustersConfig.PSACT
+	e.advancedOptions = clustersConfig.AdvancedOptions
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(e.T(), err)
+
+	e.client = client
+}
+
+func (e *EtcdNodeDeleteAndReplace) TestEtcdNodeDeletionAndReplacement() {
+	require.GreaterOrEqual(e.T(), len(e.providers), 1)
+	require.GreaterOrEqual(e.T(), len(e.k3skubernetesVersions), 1)
+
+	subSession := e.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := e.client.WithSession(subSession)
+	require.NoError(e.T(), err)
+
+	for _, provider := range e.providers {
+		for _, k8sVersion := range e.k3skubernetesVersions {
+			provider := CreateProvider(provider)
+			clusterResp := TestProvisioningK3SCluster(e.T(), client, provider, e.nodesAndRoles, k8sVersion, e.psact, e.advancedOptions)
+
+			query, err := url.ParseQuery(fmt.Sprintf("fieldSelector=metadata.namespace=%s", e.ns))
+			require.NoError(e.T(), err)
+
+			machines, err := e.client.Steve.SteveType(machineSteveResourceType).List(query)
+			require.NoError(e.T(), err)
+
+			numOfEtcdNodesBeforeDeletion := 0
+			etcdNodeToDelete := v1.SteveAPIObject{}
+
+			for _, machine := range machines.Data {
+				if machine.Labels[etcdLabel] == "true" && machine.Labels[clusterLabel] == clusterResp.Name {
+					etcdNodeToDelete = machine
+					numOfEtcdNodesBeforeDeletion++
+				}
+			}
+
+			logrus.Info("Deleting, " + etcdNodeToDelete.Name + " etcd node..")
+			err = e.client.Steve.SteveType(machineSteveResourceType).Delete(&etcdNodeToDelete)
+			require.NoError(e.T(), err)
+
+			clusterId, err := clusters.GetClusterIDByName(client, clusterResp.Name)
+			require.NoError(e.T(), err)
+
+			err = clusters.WaitClusterToBeUpgraded(client, clusterId)
+			require.NoError(e.T(), err)
+
+			err = nodestat.IsNodeReady(client, clusterId)
+			require.NoError(e.T(), err)
+
+			isEtcdNodeReplaced, err := nodestat.IsRKE2K3SEtcdNodeReplaced(client, query, clusterResp.Name, etcdNodeToDelete, numOfEtcdNodesBeforeDeletion)
+			require.NoError(e.T(), err)
+			require.True(e.T(), isEtcdNodeReplaced)
+
+			podResults, podErrors := pods.StatusPods(client, clusterId)
+			assert.NotEmpty(e.T(), podResults)
+			assert.Empty(e.T(), podErrors)
+		}
+	}
+}
+
+func TestEtcdNodeDeleteAndReplace(t *testing.T) {
+	suite.Run(t, new(EtcdNodeDeleteAndReplace))
+}

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
@@ -26,7 +27,7 @@ const (
 	namespace = "fleet-default"
 )
 
-func TestProvisioningK3SCluster(t *testing.T, client *rancher.Client, provider Provider, nodesAndRoles []machinepools.NodeRoles, kubeVersion string, psact string, advancedOptions provisioning.AdvancedOptions) {
+func TestProvisioningK3SCluster(t *testing.T, client *rancher.Client, provider Provider, nodesAndRoles []machinepools.NodeRoles, kubeVersion string, psact string, advancedOptions provisioning.AdvancedOptions) *v1.SteveAPIObject {
 	cloudCredential, err := provider.CloudCredFunc(client)
 	require.NoError(t, err)
 
@@ -87,4 +88,5 @@ func TestProvisioningK3SCluster(t *testing.T, client *rancher.Client, provider P
 		_, err = psadeploy.CreateNginxDeployment(client, clusterIDName, psact)
 		require.NoError(t, err)
 	}
+	return clusterResp
 }

--- a/tests/v2/validation/provisioning/rke1/etcd_node_delete_and_replace_test.go
+++ b/tests/v2/validation/provisioning/rke1/etcd_node_delete_and_replace_test.go
@@ -1,0 +1,124 @@
+package rke1
+
+import (
+	"testing"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
+	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type EtcdNodeDeleteAndReplace struct {
+	suite.Suite
+	session                *session.Session
+	client                 *rancher.Client
+	ns                     string
+	rke1kubernetesVersions []string
+	cnis                   []string
+	providers              []string
+	nodesAndRoles          []nodepools.NodeRoles
+	psact                  string
+	advancedOptions        provisioning.AdvancedOptions
+}
+
+func (e *EtcdNodeDeleteAndReplace) TearDownSuite() {
+	e.session.Cleanup()
+}
+
+func (e *EtcdNodeDeleteAndReplace) SetupSuite() {
+	testSession := session.NewSession()
+	e.session = testSession
+
+	e.ns = provisioning.Namespace
+
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+
+	e.rke1kubernetesVersions = clustersConfig.RKE1KubernetesVersions
+
+	e.cnis = clustersConfig.CNIs
+	e.providers = clustersConfig.Providers
+	e.nodesAndRoles = clustersConfig.NodesAndRolesRKE1
+	e.psact = clustersConfig.PSACT
+	e.advancedOptions = clustersConfig.AdvancedOptions
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(e.T(), err)
+
+	e.client = client
+}
+
+func (e *EtcdNodeDeleteAndReplace) TestEtcdNodeDeletionAndReplacement() {
+	require.GreaterOrEqual(e.T(), len(e.providers), 1)
+	require.GreaterOrEqual(e.T(), len(e.cnis), 1)
+	require.GreaterOrEqual(e.T(), len(e.rke1kubernetesVersions), 1)
+
+	subSession := e.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := e.client.WithSession(subSession)
+	require.NoError(e.T(), err)
+
+	for _, provider := range e.providers {
+		for _, k8sVersion := range e.rke1kubernetesVersions {
+			for _, cni := range e.cnis {
+				provider := CreateProvider(provider)
+				nodeTemplate, err := provider.NodeTemplateFunc(client)
+				require.NoError(e.T(), err)
+
+				clusterResp, err := TestProvisioningRKE1Cluster(e.T(), client, provider, e.nodesAndRoles, e.psact, k8sVersion, cni, nodeTemplate, e.advancedOptions)
+				require.NoError(e.T(), err)
+
+				machines, err := e.client.Management.Node.List(&types.ListOpts{Filters: map[string]interface{}{
+					"clusterId": clusterResp.ID,
+				}})
+				require.NoError(e.T(), err)
+
+				numOfEtcdNodesBeforeDeletion := 0
+				etcdNodeToDelete := management.Node{}
+
+				for _, machine := range machines.Data {
+					if machine.Etcd {
+						etcdNodeToDelete = machine
+						numOfEtcdNodesBeforeDeletion++
+					}
+				}
+
+				logrus.Info("Deleting, " + etcdNodeToDelete.NodeName + " etcd node..")
+				err = e.client.Management.Node.Delete(&etcdNodeToDelete)
+				require.NoError(e.T(), err)
+
+				err = clusters.WaitClusterToBeUpgraded(client, clusterResp.ID)
+				require.NoError(e.T(), err)
+
+				err = nodestat.IsNodeReady(client, clusterResp.ID)
+				require.NoError(e.T(), err)
+
+				isEtcdNodeReplaced, err := nodestat.IsRKE1EtcdNodeReplaced(client, etcdNodeToDelete, clusterResp, numOfEtcdNodesBeforeDeletion)
+				require.NoError(e.T(), err)
+
+				require.True(e.T(), isEtcdNodeReplaced)
+
+				podResults, podErrors := pods.StatusPods(client, clusterResp.ID)
+				assert.NotEmpty(e.T(), podResults)
+				assert.Empty(e.T(), podErrors)
+
+			}
+		}
+	}
+}
+
+func TestEtcdNodeDeleteAndReplace(t *testing.T) {
+	suite.Run(t, new(EtcdNodeDeleteAndReplace))
+}

--- a/tests/v2/validation/provisioning/rke2/etcd_node_delete_and_replace_test.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_node_delete_and_replace_test.go
@@ -1,0 +1,129 @@
+package rke2
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
+	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	etcdLabel                = "rke.cattle.io/etcd-role"
+	clusterLabel             = "cluster.x-k8s.io/cluster-name"
+	machineSteveResourceType = "cluster.x-k8s.io.machine"
+)
+
+type EtcdNodeDeleteAndReplace struct {
+	suite.Suite
+	session                *session.Session
+	client                 *rancher.Client
+	ns                     string
+	rke2kubernetesVersions []string
+	cnis                   []string
+	providers              []string
+	nodesAndRoles          []machinepools.NodeRoles
+	psact                  string
+	advancedOptions        provisioning.AdvancedOptions
+}
+
+func (e *EtcdNodeDeleteAndReplace) TearDownSuite() {
+	e.session.Cleanup()
+}
+
+func (e *EtcdNodeDeleteAndReplace) SetupSuite() {
+	testSession := session.NewSession()
+	e.session = testSession
+
+	e.ns = provisioning.Namespace
+
+	clustersConfig := new(provisioning.Config)
+	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
+
+	e.rke2kubernetesVersions = clustersConfig.RKE2KubernetesVersions
+
+	e.cnis = clustersConfig.CNIs
+	e.providers = clustersConfig.Providers
+	e.nodesAndRoles = clustersConfig.NodesAndRoles
+	e.psact = clustersConfig.PSACT
+	e.advancedOptions = clustersConfig.AdvancedOptions
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(e.T(), err)
+
+	e.client = client
+}
+
+func (e *EtcdNodeDeleteAndReplace) TestEtcdNodeDeletionAndReplacement() {
+	require.GreaterOrEqual(e.T(), len(e.providers), 1)
+	require.GreaterOrEqual(e.T(), len(e.cnis), 1)
+	require.GreaterOrEqual(e.T(), len(e.rke2kubernetesVersions), 1)
+
+	subSession := e.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := e.client.WithSession(subSession)
+	require.NoError(e.T(), err)
+
+	for _, provider := range e.providers {
+		for _, k8sVersion := range e.rke2kubernetesVersions {
+			for _, cni := range e.cnis {
+				provider := CreateProvider(provider)
+				clusterResp := TestProvisioningRKE2Cluster(e.T(), client, provider, e.nodesAndRoles, k8sVersion, cni, e.psact, e.advancedOptions)
+
+				query, err := url.ParseQuery(fmt.Sprintf("fieldSelector=metadata.namespace=%s", e.ns))
+				require.NoError(e.T(), err)
+
+				machines, err := e.client.Steve.SteveType(machineSteveResourceType).List(query)
+				require.NoError(e.T(), err)
+
+				numOfEtcdNodesBeforeDeletion := 0
+				etcdNodeToDelete := v1.SteveAPIObject{}
+
+				for _, machine := range machines.Data {
+					if machine.Labels[etcdLabel] == "true" && machine.Labels[clusterLabel] == clusterResp.Name {
+						etcdNodeToDelete = machine
+						numOfEtcdNodesBeforeDeletion++
+					}
+				}
+
+				logrus.Info("Deleting, " + etcdNodeToDelete.Name + " etcd node..")
+				err = e.client.Steve.SteveType(machineSteveResourceType).Delete(&etcdNodeToDelete)
+				require.NoError(e.T(), err)
+
+				clusterId, err := clusters.GetClusterIDByName(client, clusterResp.Name)
+				require.NoError(e.T(), err)
+
+				err = clusters.WaitClusterToBeUpgraded(client, clusterId)
+				require.NoError(e.T(), err)
+
+				err = nodestat.IsNodeReady(client, clusterId)
+				require.NoError(e.T(), err)
+
+				isEtcdNodeReplaced, err := nodestat.IsRKE2K3SEtcdNodeReplaced(client, query, clusterResp.Name, etcdNodeToDelete, numOfEtcdNodesBeforeDeletion)
+				require.NoError(e.T(), err)
+				require.True(e.T(), isEtcdNodeReplaced)
+
+				podResults, podErrors := pods.StatusPods(client, clusterId)
+				assert.NotEmpty(e.T(), podResults)
+				assert.Empty(e.T(), podErrors)
+			}
+		}
+	}
+}
+
+func TestEtcdNodeDeleteAndReplace(t *testing.T) {
+	suite.Run(t, new(EtcdNodeDeleteAndReplace))
+}

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
@@ -22,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestProvisioningRKE2Cluster(t *testing.T, client *rancher.Client, provider Provider, nodesAndRoles []machinepools.NodeRoles, kubeVersion, cni, psact string, advancedOptions provisioning.AdvancedOptions) {
+func TestProvisioningRKE2Cluster(t *testing.T, client *rancher.Client, provider Provider, nodesAndRoles []machinepools.NodeRoles, kubeVersion, cni, psact string, advancedOptions provisioning.AdvancedOptions) *v1.SteveAPIObject {
 	cloudCredential, err := provider.CloudCredFunc(client)
 	require.NoError(t, err)
 
@@ -82,4 +83,5 @@ func TestProvisioningRKE2Cluster(t *testing.T, client *rancher.Client, provider 
 		_, err = psadeploy.CreateNginxDeployment(client, clusterIDName, psact)
 		require.NoError(t, err)
 	}
+	return clusterResp
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> 
https://github.com/rancher/qa-tasks/issues/660
 
- This PR adds validation test for ETCD node deletion in RKE1/RKE2/K3S clusters.
- Also it fixes the logic in `isNodeReady` function. Previously it was taking cluster ID and only checking for one node to be in Active state and returning from the fuction. Made changes so that it checks for all nodes to be in Active state in a cluster.

Here's the example config for nodesAndRoles used for testing this PR:
```
provisioningInput:  
  nodesAndRoles:
    - etcd: true
      controlplane: false
      worker: false 
      quantity: 3
    - etcd: false
      controlplane: true
      worker: false 
      quantity: 1
    - etcd: false
      controlplane: false
      worker: true 
      quantity: 1
  nodesAndRolesRKE1: 
    - etcd: true
      controlplane: false
      worker: false 
      quantity: 3
    - etcd: false
      controlplane: true
      worker: false 
      quantity: 1
    - etcd: false
      controlplane: false
      worker: true 
      quantity: 1
  rke2KubernetesVersion: 
    - v1.25.7+rke2r1
  rke1KubernetesVersion: 
    - v1.25.6-rancher4-1
  k3sKubernetesVersion: 
    - v1.25.7+k3s1
```