### PR TITLE
[v2.6] Adding ssh test to allow check for CPU usage

### DIFF
--- a/tests/framework/extensions/sshkeys/downloadsshkeys.go
+++ b/tests/framework/extensions/sshkeys/downloadsshkeys.go
@@ -16,35 +16,35 @@ const (
 
 // DownloadSSHKeys is a helper function that takes a client, the machinePoolNodeName to download
 // the ssh key for a particular node.
-func DownloadSSHKeys(client *rancher.Client, machinePoolNodeName string) (string, error) {
+func DownloadSSHKeys(client *rancher.Client, machinePoolNodeName string) ([]byte, error) {
 	machinePoolNodeNameName := fmt.Sprintf("fleet-default/%s", machinePoolNodeName)
 	machine, err := client.Steve.SteveType(ClusterMachineConstraintResourceSteveType).ByID(machinePoolNodeNameName)
 	if err != nil {
-		return "", err
+		return []byte{}, err
 	}
 
 	sshKeyLink := machine.Links["sshkeys"]
 
 	req, err := http.NewRequest("GET", sshKeyLink, nil)
 	if err != nil {
-		return "", err
+		return []byte{}, err
 	}
 
 	req.Header.Add("Authorization", "Bearer "+client.RancherConfig.AdminToken)
 
 	resp, err := client.Management.APIBaseClient.Ops.Client.Do(req)
 	if err != nil {
-		return "", err
+		return []byte{}, err
 	}
 	defer resp.Body.Close()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return []byte{}, err
 	}
 
 	privateSSHKeyRegEx := regexp.MustCompile(privateKeySSHKeyRegExPattern)
 	privateSSHKey := privateSSHKeyRegEx.FindString(string(bodyBytes))
 
-	return privateSSHKey, err
+	return []byte(privateSSHKey), err
 }

--- a/tests/v2/validation/provisioning/ssh.go
+++ b/tests/v2/validation/provisioning/ssh.go
@@ -1,0 +1,31 @@
+package provisioning
+
+// This file contains all tests that require to ssh into a node to run commands to check things
+// such as any stats, benchmarks, etc. For example, ssh is required to check the cpu usage of a process running on an individual node.
+
+import (
+	"strconv"
+
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	cpuUsageVar = 30
+)
+
+// This func checks the cpu usage of the cluster agent. If the usage is too high the func will return a warning.
+func CheckCPU(node *nodes.Node) (string, error) {
+	command := "ps -C agent -o %cpu --no-header"
+	output, err := node.ExecuteCommand(command)
+	if err != nil {
+		return output, err
+	}
+
+	output_int, err := strconv.Atoi(output)
+	if output_int > cpuUsageVar {
+		logrus.Infof("WARNING: cluster agent cpu usage is too high. Current cpu usage is: " + output)
+	}
+
+	return output, err
+}


### PR DESCRIPTION
Adding ssh test package to run tests that require ssh to run. Also adjusted downloadsshkeys.go to send a byte instead of string to be used in the node object.

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/451
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
There were tickets around CPU usage being too high and we wanted to add automated checks to more consistently check CPU usage during releases.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Adding this automation will allow us to more frequently check if the CPU Usage issue were to ever come back. Also with downloadsshkeys.go we are now able to run any ssh related tests within the provisioning package. Currently just added to rke2 package, but since Node object is also used in rke1 and k3s, I will also add there after approval.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Tested the actual ssh command manually multiple times to ensure that it works.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Will run jenkins job

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
The CPU check will be stored under the ssh package, and with future additions to that package users can just call the function from the ssh package.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
Currently there are no regressions as the ssh key being changed from string to byte is allowing the node object to use the ssh key, which before it wasn't allowed. No other objects are being changed.