### PR TITLE
Using custom tolerations for helm operation pods

### DIFF
--- a/pkg/api/steve/catalog/types/rest.go
+++ b/pkg/api/steve/catalog/types/rest.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,12 +16,13 @@ type ChartInstall struct {
 }
 
 type ChartInstallAction struct {
-	Timeout                  *metav1.Duration `json:"timeout,omitempty"`
-	Wait                     bool             `json:"wait,omitempty"`
-	DisableHooks             bool             `json:"noHooks,omitempty"`
-	DisableOpenAPIValidation bool             `json:"disableOpenAPIValidation,omitempty"`
-	Namespace                string           `json:"namespace,omitempty"`
-	ProjectID                string           `json:"projectId,omitempty"`
+	Timeout                  *metav1.Duration    `json:"timeout,omitempty"`
+	Wait                     bool                `json:"wait,omitempty"`
+	DisableHooks             bool                `json:"noHooks,omitempty"`
+	DisableOpenAPIValidation bool                `json:"disableOpenAPIValidation,omitempty"`
+	Namespace                string              `json:"namespace,omitempty"`
+	ProjectID                string              `json:"projectId,omitempty"`
+	Tolerations              []corev1.Toleration `json:"operationTolerations,omitempty"`
 
 	Charts []ChartInstall `json:"charts,omitempty"`
 }

--- a/pkg/api/steve/catalog/types/rest.go
+++ b/pkg/api/steve/catalog/types/rest.go
@@ -15,6 +15,7 @@ type ChartInstall struct {
 	Annotations map[string]string     `json:"annotations,omitempty"`
 }
 
+// ChartInstallAction represents the input received when installing the charts received in the charts field
 type ChartInstallAction struct {
 	Timeout                  *metav1.Duration    `json:"timeout,omitempty"`
 	Wait                     bool                `json:"wait,omitempty"`
@@ -23,8 +24,7 @@ type ChartInstallAction struct {
 	Namespace                string              `json:"namespace,omitempty"`
 	ProjectID                string              `json:"projectId,omitempty"`
 	Tolerations              []corev1.Toleration `json:"operationTolerations,omitempty"`
-
-	Charts []ChartInstall `json:"charts,omitempty"`
+	Charts                   []ChartInstall      `json:"charts,omitempty"`
 }
 
 type ChartInfo struct {
@@ -35,6 +35,7 @@ type ChartInfo struct {
 	Chart     v3.MapStringInterface `json:"chart,omitempty"`
 }
 
+// ChartUninstallAction represents the input received when uninstalling a chart
 type ChartUninstallAction struct {
 	DisableHooks bool                `json:"noHooks,omitempty"`
 	DryRun       bool                `json:"dryRun,omitempty"`
@@ -44,6 +45,7 @@ type ChartUninstallAction struct {
 	Tolerations  []corev1.Toleration `json:"operationTolerations,omitempty"`
 }
 
+// ChartUpgradeAction represents the input received when upgrading the charts received in the charts field
 type ChartUpgradeAction struct {
 	Timeout                  *metav1.Duration    `json:"timeout,omitempty"`
 	Wait                     bool                `json:"wait,omitempty"`

--- a/pkg/api/steve/catalog/types/rest.go
+++ b/pkg/api/steve/catalog/types/rest.go
@@ -36,25 +36,27 @@ type ChartInfo struct {
 }
 
 type ChartUninstallAction struct {
-	DisableHooks bool             `json:"noHooks,omitempty"`
-	DryRun       bool             `json:"dryRun,omitempty"`
-	KeepHistory  bool             `json:"keepHistory,omitempty"`
-	Timeout      *metav1.Duration `json:"timeout,omitempty"`
-	Description  string           `json:"description,omitempty"`
+	DisableHooks bool                `json:"noHooks,omitempty"`
+	DryRun       bool                `json:"dryRun,omitempty"`
+	KeepHistory  bool                `json:"keepHistory,omitempty"`
+	Timeout      *metav1.Duration    `json:"timeout,omitempty"`
+	Description  string              `json:"description,omitempty"`
+	Tolerations  []corev1.Toleration `json:"operationTolerations,omitempty"`
 }
 
 type ChartUpgradeAction struct {
-	Timeout                  *metav1.Duration `json:"timeout,omitempty"`
-	Wait                     bool             `json:"wait,omitempty"`
-	DisableHooks             bool             `json:"noHooks,omitempty"`
-	DisableOpenAPIValidation bool             `json:"disableOpenAPIValidation,omitempty"`
-	Force                    bool             `json:"force,omitempty"`
-	ForceAdopt               bool             `json:"forceAdopt,omitempty"`
-	MaxHistory               int              `json:"historyMax,omitempty"`
-	Install                  bool             `json:"install,omitempty"`
-	Namespace                string           `json:"namespace,omitempty"`
-	CleanupOnFail            bool             `json:"cleanupOnFail,omitempty"`
-	Charts                   []ChartUpgrade   `json:"charts,omitempty"`
+	Timeout                  *metav1.Duration    `json:"timeout,omitempty"`
+	Wait                     bool                `json:"wait,omitempty"`
+	DisableHooks             bool                `json:"noHooks,omitempty"`
+	DisableOpenAPIValidation bool                `json:"disableOpenAPIValidation,omitempty"`
+	Force                    bool                `json:"force,omitempty"`
+	ForceAdopt               bool                `json:"forceAdopt,omitempty"`
+	MaxHistory               int                 `json:"historyMax,omitempty"`
+	Install                  bool                `json:"install,omitempty"`
+	Namespace                string              `json:"namespace,omitempty"`
+	CleanupOnFail            bool                `json:"cleanupOnFail,omitempty"`
+	Charts                   []ChartUpgrade      `json:"charts,omitempty"`
+	Tolerations              []corev1.Toleration `json:"operationTolerations,omitempty"`
 }
 
 type ChartUpgrade struct {

--- a/pkg/apis/catalog.cattle.io/v1/types.go
+++ b/pkg/apis/catalog.cattle.io/v1/types.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/wrangler/pkg/genericcondition"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -119,4 +120,5 @@ type OperationStatus struct {
 	PodNamespace       string                              `json:"podNamespace,omitempty"`
 	PodCreated         bool                                `json:"podCreated,omitempty"`
 	Conditions         []genericcondition.GenericCondition `json:"conditions,omitempty"`
+	Tolerations        []corev1.Toleration                 `json:"tolerations,omitempty"`
 }

--- a/pkg/apis/catalog.cattle.io/v1/types.go
+++ b/pkg/apis/catalog.cattle.io/v1/types.go
@@ -106,6 +106,7 @@ type Operation struct {
 	Status            OperationStatus `json:"status"`
 }
 
+// OperationStatus represents the status of a helm operation that's going to be created
 type OperationStatus struct {
 	ObservedGeneration int64                               `json:"observedGeneration"`
 	Action             string                              `json:"action,omitempty"`

--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -341,6 +341,8 @@ func (s *Operations) getUser(userInfo user.Info, namespace, name string, isApp b
 	}, nil
 }
 
+// getUninstallArgs receives the app namespace, app name and body of the request
+// returns an uninstall command according to the input received and also returns the status of the operation that will be created
 func (s *Operations) getUninstallArgs(appNamespace, appName string, body io.Reader) (catalog.OperationStatus, Commands, error) {
 	rel, err := s.apps.Get(appNamespace, appName, metav1.GetOptions{})
 	if err != nil {
@@ -371,6 +373,8 @@ func (s *Operations) getUninstallArgs(appNamespace, appName string, body io.Read
 	return status, Commands{cmd}, nil
 }
 
+// getUpgradeCommand receives the repository namespace and name and body of the request
+// returns the status of the operation that will be created and a slice of Commands to upgrade the charts received in the body of the request
 func (s *Operations) getUpgradeCommand(repoNamespace, repoName string, body io.Reader) (catalog.OperationStatus, Commands, error) {
 	var (
 		upgradeArgs = &types2.ChartUpgradeAction{}
@@ -483,6 +487,8 @@ func (c Command) Render(index int) (map[string][]byte, error) {
 	return data, nil
 }
 
+// renderArgs returns a slice of string representing the helm command and it's arguments
+// It uses the ArgObjects of the command struct to generate the helm command and removes the fields that aren't necessary in the command
 func (c Command) renderArgs() ([]string, error) {
 	var (
 		args []string
@@ -681,6 +687,8 @@ func (s *Operations) getChartCommand(namespace, name, chartName, chartVersion st
 	return c, nil
 }
 
+// getInstallCommand receives the repository namespace and name and body of the request
+// returns the status of the operation that will be created and a slice of Commands to install the charts received in the body of the request
 func (s *Operations) getInstallCommand(repoNamespace, repoName string, body io.Reader) (catalog.OperationStatus, Commands, error) {
 	installArgs := &types2.ChartInstallAction{}
 	err := json.NewDecoder(body).Decode(installArgs)
@@ -739,6 +747,7 @@ func namespace(ns string) string {
 	return ns
 }
 
+// createOperation returns the created operation that will execute the commands received as input
 func (s *Operations) createOperation(ctx context.Context, user user.Info, status catalog.OperationStatus, cmds Commands, imageOverride string) (*catalog.Operation, error) {
 	if status.Action != "uninstall" {
 		_, err := s.createNamespace(ctx, status.Namespace, status.ProjectID)
@@ -905,6 +914,7 @@ func (s *Operations) createNamespace(ctx context.Context, namespace, projectID s
 	return nil, fmt.Errorf("failed to wait for roles to be populated")
 }
 
+// createPod returns a pod object and a pod options object representing the helm operation pod and it's options
 func (s *Operations) createPod(secretData map[string][]byte, kustomize bool, imageOverride string, tolerations []corev1.Toleration) (*v1.Pod, *podimpersonation.PodOptions) {
 	image := imageOverride
 	if image == "" {

--- a/pkg/catalogv2/helmop/operation.go
+++ b/pkg/catalogv2/helmop/operation.go
@@ -362,9 +362,10 @@ func (s *Operations) getUninstallArgs(appNamespace, appName string, body io.Read
 	}
 
 	status := catalog.OperationStatus{
-		Action:    cmd.Operation,
-		Release:   rel.Spec.Name,
-		Namespace: appNamespace,
+		Action:      cmd.Operation,
+		Release:     rel.Spec.Name,
+		Namespace:   appNamespace,
+		Tolerations: uninstallArgs.Tolerations,
 	}
 
 	return status, Commands{cmd}, nil
@@ -386,8 +387,9 @@ func (s *Operations) getUpgradeCommand(repoNamespace, repoName string, body io.R
 	upgradeArgs.Install = true
 
 	status := catalog.OperationStatus{
-		Action:    "upgrade",
-		Namespace: namespace(upgradeArgs.Namespace),
+		Action:      "upgrade",
+		Namespace:   namespace(upgradeArgs.Namespace),
+		Tolerations: upgradeArgs.Tolerations,
 	}
 
 	for _, chartUpgrade := range upgradeArgs.Charts {

--- a/pkg/catalogv2/helmop/operation_test.go
+++ b/pkg/catalogv2/helmop/operation_test.go
@@ -10,12 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// renderTestCase represent test cases for the Commands.Render method
 type renderTestCase struct {
 	commands Commands
 	expected map[string][]byte
 	failMsg  string
 }
 
+// createPodTestCase represent the test cases for the Operations.createPod method
 type createPodTestCase struct {
 	name          string
 	operation     Operations
@@ -157,6 +159,7 @@ func Test_Render(t *testing.T) {
 	}
 }
 
+// Test_CreatePod function to run tests for the createPod method
 func Test_CreatePod(t *testing.T) {
 	asserts := assert.New(t)
 	defaultTolerations := []corev1.Toleration{


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/38403
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
We currently can't add tolerations to helm operation pods, so if all nodes of a cluster are tainted, the pod won't run.
 
## Solution
Add the option of receiving tolerations when installing a chart from the UI and use them when creating the operation pod.

Need to contact UI team to add the functionality in the UI.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Installed a chart on a cluster with all nodes tainted

### Automated Testing
Created unit tests that cover the following scenarios:
* No custom toleration
* One custom toleration
* Two custom tolerations
* The helm command isn't modified when receiving tolerations

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->