### PR TITLE
Update tar command in package/Dockerfile so it doesn't copy file owners

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -154,7 +154,7 @@ RUN ln -s /usr/bin/cni /usr/bin/bridge && \
 
 RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     mkdir -p /var/lib/rancher/k3s/agent/images/ && \
-    curl -sfL ${ETCD_URL} | tar xvzf - --strip-components=1 -C /usr/bin/ etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcdctl && \
+    curl -sfL ${ETCD_URL} | tar xvzf - --strip-components=1 --no-same-owner -C /usr/bin/ etcd-${CATTLE_ETCD_VERSION}-linux-${ARCH}/etcdctl && \
     curl -sLf https://github.com/rancher/telemetry/releases/download/${TELEMETRY_VERSION}/telemetry-${ARCH} > /usr/bin/telemetry && \
     chmod +x /usr/bin/tini /usr/bin/telemetry && \
     mkdir -p /var/lib/rancher-data/driver-metadata


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39588
 
## Problem
When using user namespace remapping [userns-remap](https://docs.docker.com/engine/security/userns-remap/), Docker fails to load a specific layer of the `rancher/rancher` image because it cannot map the UID associated with a file that was copied into that layer to a UID on the host system because the UID in the container (114762) falls outside the mappable range.

When pulling/using the rancher image with `userns-remap` enabled:
```
$ docker run -d --restart=unless-stopped -p 80:80 -p 443:443 --userns=host --privileged rancher/rancher:latest
[...]
docker: failed to register layer: Error processing tar file(exit status 1): Container ID 114762 cannot be mapped to a host ID.
```

The cause is the file /usr/bin/etcdctl in the image, which has an unusually high UID (114762).  This is because, by default, the `tar` command we use in our Dockerfile will copy owner information from the original files when unpacking the tarball, and in this case the owner of the original file happened to have a high UID. 

This article describes the issue very well:
https://circleci.com/docs/high-uid-error/
 
## Solution
The fix was simply to tell `tar` not to copy owner information using the `--no-same-owner` flag. The resulting copied files will now be owned by whichever user ran the `tar` command, which, in the case of the Docker build, is root.
 
## Testing
1. I set up an Ubuntu machine with `userns-remap` enabled and checked that pulling/using the `rancher/rancher` image failed with the same error.
2. Add the `--no-same-owner` flag to the command in the Dockerfile and rebuild the image locally using `make ci`.
3. Copy the new image to the same Ubuntu machine, use `docker load` to load it. This time, there should be no error loading the image.
4. Run a shell in the container and verify that the owner of the `etcdctl` file is the same as all the others (i.e. root). Here's a screenshot of part of the output from `ls -ln /usr/bin` where you can see that the owner of `etcdctl` matches that of its neighbours. 

<img width="759" alt="Screen Shot 2023-04-14 at 11 52 28 AM" src="https://user-images.githubusercontent.com/9647946/232137788-db43c35a-914c-43dd-ac7a-53e9dda463ad.png">

## Engineering Testing
### Manual Testing
See above.

### Automated Testing
None

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->