### PR TITLE
adding custodian scripts for QA

### DIFF
--- a/tests/scripts/custodian/Dockerfile
+++ b/tests/scripts/custodian/Dockerfile
@@ -1,0 +1,51 @@
+FROM registry.suse.com/bci/python:3.10
+WORKDIR /usr/app/src
+
+ARG AWS_ACCESS_KEY_ID
+ENV AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
+ENV AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+ARG AZURE_SUBSCRIPTION_ID
+ENV AZURE_SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID
+ARG AZURE_TENANT_ID
+ENV AZURE_TENANT_ID=$AZURE_TENANT_ID
+ARG AZURE_CLIENT_ID
+ENV AZURE_CLIENT_ID=$AZURE_CLIENT_ID
+ARG AZURE_CLIENT_SECRET
+ENV AZURE_CLIENT_SECRET=$AZURE_CLIENT_SECRET
+ARG RANCHER_GKE_CREDENTIAL
+ENV RANCHER_GKE_CREDENTIAL=$RANCHER_GKE_CREDENTIAL
+ARG RANCHER_LINODE_CREDENTIAL
+ENV RANCHER_LINODE_CREDENTIAL=$RANCHER_LINODE_CREDENTIAL
+ARG OVERRIDE_REGION
+ENV OVERRIDE_REGION=$OVERRIDE_REGION
+ARG USER_KEYS
+ENV USER_KEYS=$USER_KEYS
+ARG DONOTDELETE_KEYS
+ENV DONOTDELETE_KEYS=$DONOTDELETE_KEYS
+ENV CUSTODIAN_YAML=aws.yaml
+
+
+# RUN zypper install -y python3-venv python3-pip vim
+RUN python3 -m venv custodian-venv
+RUN . custodian-venv/bin/activate
+RUN pip3 install c7n c7n_azure c7n_gcp c7n_mailer
+
+ADD ./* ./
+
+# get user keys, replace holder params in yaml files appropriately
+SHELL ["/bin/bash", "-c"] 
+# think about how to override the keys for the use case of adding tags
+
+CMD for i in `ls *.yaml`; \
+    do cat $i | sed -e 's/USERKEYS/'"${USER_KEYS}"'/g' -i $i; done ; \
+    for i in `ls *.yaml`; \
+    do cat $i | sed -e 's/DONOTDELETEKEYS/'"${DONOTDELETE_KEYS}"'/g' -i $i; done; \
+    if [ "$CUSTODIAN_YAML" = "aws.yaml" ] ; then \
+    custodian run --output-dir=. --region="us-east-2" --dry-run ${CUSTODIAN_YAML}; \
+    custodian run --output-dir=. --region="us-east-1" --dry-run ${CUSTODIAN_YAML}; \
+    custodian run --output-dir=. --region="us-west-1" --dry-run ${CUSTODIAN_YAML}; \
+    custodian run --output-dir=. --region="us-west-2" --dry-run ${CUSTODIAN_YAML}; \
+    elif [ "$CUSTODIAN_YAML" = "tag-to-save.yaml" ] ; then \
+    custodian run --output-dir=. --region=$OVERRIDE_REGION --dry-run ${CUSTODIAN_YAML};  \
+    else custodian run --output-dir=. --dry-run ${CUSTODIAN_YAML}; fi; 

--- a/tests/scripts/custodian/Jenkinsfile
+++ b/tests/scripts/custodian/Jenkinsfile
@@ -1,0 +1,82 @@
+#!groovy
+node {
+  def rootPath = "/root/go/src/github.com/rancher/rancher/tests/scripts/"
+  def job_name = "${JOB_NAME}"
+  if (job_name.contains('/')) { 
+    job_names = job_name.split('/')
+    job_name = job_names[job_names.size() - 1] 
+  }
+  def testContainer = "${job_name}${env.BUILD_NUMBER}_test"
+  def imageName = "qa-custodian-${job_name}${env.BUILD_NUMBER}"
+  def testResultsOut = "results.xml"
+  def envFile = ".env"
+  def rancherConfig = "rancher_env.config"
+  def awsYaml="aws.yaml"
+  def azureYaml="azure.yaml"
+  def gcpYaml="gcp.yaml"
+  if ("${env.CUSTODIAN_YAML}" != "null" && "${env.CUSTODIAN_YAML}" != "") {
+    yamlToRun="${env.CUSTODIAN_YAML}"
+  }
+  def branch = "release/v2.7"
+  if ("${env.branch}" != "null" && "${env.branch}" != "") {
+    branch = "${env.branch}"
+  }
+  def repo = scm.userRemoteConfigs
+  if ("${env.REPO}" != "null" && "${env.REPO}" != "") {
+    repo = [[url: "${env.REPO}"]]
+  }
+  withFolderProperties {
+    paramsMap = []
+    params.each {
+      if (it.value && it.value.trim() != "") {
+          paramsMap << "$it.key=$it.value"
+      }
+    }
+    withEnv(paramsMap) {
+      withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                        string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+                        string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                        string(credentialsId: 'AZURE_TENANT_ID', variable: 'AZURE_TENANT_ID'),
+                        string(credentialsId: 'AZURE_CLIENT_ID', variable: 'AZURE_CLIENT_ID'),
+                        string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'AZURE_CLIENT_SECRET'),
+                        string(credentialsId: 'RANCHER_GKE_CREDENTIAL', variable: 'RANCHER_GKE_CREDENTIAL'),
+                        string(credentialsId: 'RANCHER_LINODE_ACCESSKEY', variable: "RANCHER_LINODE_ACCESSKEY")]) {
+        stage('Checkout') {
+          deleteDir()
+          checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: "*/${branch}"]],
+                    extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                    userRemoteConfigs: repo
+                  ])
+        }
+        dir ("./tests/scripts/custodian/") {
+          stage('Build Docker Image') {
+            try {
+              sh "docker build -t ${imageName} -f Dockerfile . --build-arg AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" --build-arg AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" --build-arg AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" --build-arg AZURE_TENANT_ID="${AZURE_TENANT_ID}" --build-arg AZURE_CLIENT_ID="${AZURE_CLIENT_ID}" --build-arg AZURE_CLIENT_SECRET="${AZURE_CLIENT_SECRET}" --build-arg GOOGLE_APPLICATION_CREDENTIALS="${RANCHER_GKE_CREDENTIAL}" --build-arg GOOGLE_CLOUD_PROJECT="${GOOGLE_CLOUD_PROJECT}" --build-arg RANCHER_LINODE_ACCESSKEY="${RANCHER_LINODE_ACCESSKEY}""
+            }
+          catch(err) {
+                  echo 'Docker Build had partial failures...'
+            }
+          }
+          stage('Run Docker Image for Adding Tags') {
+              // if a user only wants to run the test using a subset of keys, they can pass in OVERRIDE_REGION
+              if ("${env.OVERRIDE_REGION}" != "null" && "${env.OVERRIDE_REGION}" != "") {
+              sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"add-friday-tags.yaml\" -e OVERRIDE_REGION=\"${env.OVERRIDE_REGION}\" -e DONOTDELETE_KEYS=\"${env.DONOTDELETE_KEYS}\" -e USER_KEYS=\"${env.USER_KEYS}\" ${imageName} "
+              } else {
+                echo "No OVERRIDE_REGION passed in, running all tests"
+              }
+              } else {
+                echo "No OVERRIDE_REGION passed in, running all tests"
+              }
+          }
+          stage('Run Docker Image for AWS,Azure, and GCP'){
+            sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"${awsYaml}\" -e DONOTDELETE_KEYS=\"${env.DONOTDELETE_KEYS}\" -e USER_KEYS=\"${env.USER_KEYS}\" ${imageName}"
+            sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"${azureYaml}\" -e DONOTDELETE_KEYS=\"${env.DONOTDELETE_KEYS}\" -e USER_KEYS=\"${env.USER_KEYS}\" ${imageName}"
+            sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"${gcpYaml}\" -e DONOTDELETE_KEYS=\"${env.DONOTDELETE_KEYS}\" -e USER_KEYS=\"${env.USER_KEYS}\" ${imageName}"
+          }
+        } // dir 
+      } // creds
+    } // folder properties
+  } 
+}// node

--- a/tests/scripts/custodian/README.md
+++ b/tests/scripts/custodian/README.md
@@ -1,0 +1,22 @@
+# QA Cloud Custodian
+
+QA custodian will clean up resources in AWS, GCR, and AZURE. Currently, we have automation configured for:
+* AWS
+  * instances
+  * NLBs
+  * EKS
+* AZURE
+  * VMs
+  * AKS
+* GCP
+  * instances
+
+### Getting Started
+New Hires - make a PR adding one line to the `user-keys.txt` file. Use that key in ALL resources you create when using SUSE resources.  Keep it short (6 characters or less) unique to you, and recognizable by others (And, this is case sensitive!). For example, if your name was Jane Elaine Morrison, something like `jem` would suffice. Just make sure you can remember it, and others can know who's it is if they are on your team. 
+
+### About the Code
+This suite is fairly simple, and runs using [Cloud Custodian](https://cloud-custodian.github.io/cloud-custodian/docs/quickstart/index.html). Our modifications consist of the following:
+* text files
+  * `*-keys.txt` representing special keys that correspond with QA's resources
+  * `regions.txt` (AWS explicit) representing the regions we use on a regular basis, and therefore what the custodian will check against 
+* `.yaml` files, which are different configurations for the custodian to use when running. 

--- a/tests/scripts/custodian/aws.yaml
+++ b/tests/scripts/custodian/aws.yaml
@@ -1,0 +1,262 @@
+policies:
+- name: mark-unknown-instances-for-deletion
+  resource: aws.ec2
+  description: |
+    Mark unknown user instances for deletion in 1 day
+  filters:
+    - "State.Name": running
+    # instance name not in accepted user keys
+    - type: value
+      key: tag:Name
+      op: regex
+      #doesNOTcontain
+      value:  "^((?!USERKEYS).)*$"
+    # instance is not doNotDelete
+    - 'tag:doNotDelete': absent
+    - 'tag:DoNotDelete': absent
+    - 'tag:ec2_known_user': absent
+    - "tag:DeletesOnFriday": absent
+    - not: 
+      - type: value
+        key: tag:Name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: mark-for-op
+      tag: ec2_unknown_user
+      op: terminate
+      days: 1
+
+- name: mark-known-instances-for-deletion
+  resource: aws.ec2
+  description: |
+    Mark known user instances for deletion in 2 days
+  filters:
+    - "State.Name": running
+    - type: value
+      key: tag:Name
+      op: regex
+      value:  "^.*USERKEYS.*$"
+    - 'tag:doNotDelete': absent
+    - 'tag:DoNotDelete': absent
+    - 'tag:ec2_unknown_user': absent
+    - "tag:DeletesOnFriday": absent
+    - not: 
+      - type: value
+        key: tag:Name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: mark-for-op
+      tag: ec2_known_user
+      op: terminate
+      days: 2
+
+- name: ec2-unmark-if-friday-tagged
+  resource: aws.ec2
+  description: |
+    Remove the deletion tag from any resource group which now contain resources
+    so it doesn't get deleted by the following policy
+  filters:
+    - or:
+      - "tag:ec2_unknown_user": not-null
+      - "tag:ec2_known_user": not-null
+    - "tag:DeletesOnFriday": present
+  actions:
+    - type: remove-tag
+      tags: ['ec2_unknown_user', 'ec2_known_user']
+
+- name: ec2-terminate-instances
+  resource: aws.ec2
+  description: |
+    Delete any marked instances which have been 
+    marked for deletion for more than 1 day.
+  filters:
+    - or:
+      - type: marked-for-op
+        tag: ec2_unknown_user
+        op: terminate
+      - type: marked-for-op
+        tag: ec2_known_user
+        op: terminate
+  actions:
+    - type: terminate
+
+# EKS Policies
+# Note: cannot manage EKS nodegroups at this time, but the
+# above ec2 policies should take care of any nodes
+
+# There is a resource for eks-nodegroup in cloud custodian, 
+# however there is no support for time delay nor tagging.
+
+# EKS
+- name: eks-mark-unknown-instances-for-deletion
+  resource: aws.eks
+  description: |
+    Mark unknown user instances for deletion in 1 day
+  filters:
+    - type: value
+      key: name
+      op: regex
+      #doesNOTcontain
+      value:  "^((?!USERKEYS).)*$"
+    # instance is not doNotDelete
+    - 'tag:doNotDelete': absent
+    - 'tag:DoNotDelete': absent
+    - 'tag:ec2_known_user': absent
+    - "tag:DeletesOnFriday": absent
+    - not: 
+      - type: value
+        key: name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: mark-for-op
+      tag: ec2_unknown_user
+      op: delete
+      days: 1
+
+- name: eks-mark-known-instances-for-deletion
+  resource: aws.eks
+  description: |
+    Mark known user instances for deletion in 2 days
+  filters:
+    - type: value
+      key: name
+      op: regex
+      value:  "^.*USERKEYS.*$"
+    - 'tag:doNotDelete': absent
+    - 'tag:DoNotDelete': absent
+    - 'tag:ec2_unknown_user': absent
+    - "tag:DeletesOnFriday": absent
+    - not: 
+      - type: value
+        key: name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: mark-for-op
+      tag: ec2_known_user
+      op: delete
+      days: 2
+
+- name: eks-unmark-if-friday-tagged
+  resource: aws.eks
+  description: |
+    Remove the deletion tag from any resource group which now contain resources
+    so it doesn't get deleted by the following policy
+  filters:
+    - or:
+      - "tag:ec2_unknown_user": not-null
+      - "tag:ec2_known_user": not-null
+    - "tag:DeletesOnFriday": present
+  actions:
+    - type: remove-tag
+      tags: ['ec2_unknown_user', 'ec2_known_user']
+
+- name: eks-terminate-instances
+  resource: aws.eks
+  description: |
+    Delete any marked instances which have been 
+    marked for deletion for more than 1 day.
+  filters:
+    - or:
+      - type: marked-for-op
+        tag: ec2_unknown_user
+        op: delete
+      - type: marked-for-op
+        tag: ec2_known_user
+        op: delete
+  actions:
+    - type: delete
+
+# NLBs
+- name: mark-unknown-nlbs-for-deletion
+  resource: app-elb
+  filters:
+     # nlb name not in accepted user keys
+    - type: value
+      key: LoadBalancerArn
+      op: regex
+      #doesNOTcontain
+      value:  "^((?!USERKEYS).)*$"
+    # instance is not doNotDelete
+    - 'tag:doNotDelete': absent
+    - 'tag:DoNotDelete': absent
+    - 'tag:ec2_known_user': absent
+    - "tag:DeletesOnFriday": absent
+    - not: 
+      - type: value
+        key: LoadBalancerArn
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: mark-for-op
+      tag: ec2_unknown_user
+      op: delete
+      days: 1
+    ### option for notifying slack / via email (needs lambda permissions)
+    # - type: notify
+    #   slack_template: slack_default
+    #   slack_msg_color: danger
+    #   violation_desc: No violation.
+    #   action_desc: No action taken. 
+    #   to:
+    #     - https://hooks.slack.com/services/T0000000000/B000000000/XXXXXXXXXXXXXXX
+    #   transport:
+    #     type: sqs
+    #     queue: queue-url
+
+- name: mark-known-nlbs-for-deletion
+  resource: app-elb
+  filters:
+    # nlb is named with accepted user key
+    - type: value
+      key: LoadBalancerArn
+      op: regex
+      value:  "^.*USERKEYS.*$"
+    # nlb is not doNotDelete
+    - 'tag:doNotDelete': absent
+    - 'tag:DoNotDelete': absent
+    - 'tag:ec2_unknown_user': absent
+    - "tag:DeletesOnFriday": absent
+    - not: 
+      - type: value
+        key: LoadBalancerArn
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: mark-for-op
+      tag: ec2_known_user
+      op: delete
+      days: 2
+
+- name: nlb-unmark-if-friday-tagged
+  resource: app-elb
+  description: |
+    Remove the deletion tag from any resource group which now contain resources
+    so it doesn't get deleted by the following policy
+  filters:
+    - or:
+      - "tag:ec2_unknown_user": not-null
+      - "tag:ec2_known_user": not-null
+    - "tag:DeletesOnFriday": present
+  actions:
+    - type: remove-tag
+      tags: ['ec2_unknown_user', 'ec2_known_user']
+
+- name: ec2-delete-nlbs
+  resource: app-elb
+  description: |
+    Delete any marked nlbs which have been 
+    marked for deletion for more than 1 day.
+  filters:
+    - or:
+      - type: marked-for-op
+        tag: ec2_unknown_user
+        op: delete
+      - type: marked-for-op
+        tag: ec2_known_user
+        op: delete
+  actions:
+    - type: delete

--- a/tests/scripts/custodian/azure.yaml
+++ b/tests/scripts/custodian/azure.yaml
@@ -1,0 +1,143 @@
+# Azure Policies
+policies:
+# VMs
+- name: az-mark-unknown-vms-for-deletion
+  resource: azure.vm
+  description: |
+    Mark unknown user instances for deletion in 1 day
+  filters:
+    - "State.Name": running
+    # instance name not in accepted user keys
+    - type: value
+      key: name
+      op: regex
+      #doesNOTcontain
+      value:  "^((?!USERKEYS).)*$"
+    # instance is not doNotDelete
+    - 'tag:doNotDelete': absent
+    - 'tag:DoNotDelete': absent
+    - 'tag:known_user': absent
+    - "tag:DeletesOnFriday": absent
+    - not: 
+      - type: value
+        key: name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: mark-for-op
+      tag: unknown_user
+      op: delete
+      days: 1
+
+- name: az-mark-known-vms-for-deletion
+  resource: azure.vm
+  description: |
+    Mark known user instances for deletion in 2 days
+  filters:
+    # instance is named with accepted user key
+    - type: value
+      key: name
+      op: regex
+      value:  "^.*USERKEYS.*$"
+    # instance is not doNotDelete
+    - 'tag:doNotDelete': absent
+    - 'tag:DoNotDelete': absent
+    - 'tag:unknown_user': absent
+    - "tag:DeletesOnFriday": absent
+    - not: 
+      - type: value
+        key: name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: mark-for-op
+      tag: known_user
+      op: delete
+      days: 2
+
+- name: azure-terminate-vms
+  resource: azure.vm
+  description: |
+    Delete any marked instances which have been 
+    marked for deletion for more than 1 day.
+  filters:
+    - or:
+      - type: marked-for-op
+        tag: unknown_user
+        op: delete
+      - type: marked-for-op
+        tag: known_user
+        op: delete
+  actions:
+    - type: delete
+
+# AKS
+- name: az-mark-unknown-aks-for-deletion
+  resource: azure.aks
+  description: |
+    Mark unknown user instances for deletion in 1 day
+  filters:
+    - "State.Name": running
+    # instance name not in accepted user keys
+    - type: value
+      key: name
+      op: regex
+      #doesNOTcontain
+      value:  "^((?!USERKEYS).)*$"
+    # instance is not doNotDelete
+    - 'tag:doNotDelete': absent
+    - 'tag:DoNotDelete': absent
+    - 'tag:known_user': absent
+    - "tag:DeletesOnFriday": absent
+    - not: 
+      - type: value
+        key: name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: mark-for-op
+      tag: unknown_user
+      op: delete
+      days: 1
+
+- name: az-mark-known-aks-for-deletion
+  resource: azure.aks
+  description: |
+    Mark known user instances for deletion in 2 days
+  filters:
+    # instance is named with accepted user key
+    - type: value
+      key: name
+      op: regex
+      value:  "^.*USERKEYS.*$"
+    # instance is not doNotDelete
+    - 'tag:doNotDelete': absent
+    - 'tag:DoNotDelete': absent
+    - 'tag:unknown_user': absent
+    - "tag:DeletesOnFriday": absent
+    - not: 
+      - type: value
+        key: name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: mark-for-op
+      tag: known_user
+      op: delete
+      days: 2
+
+- name: azure-terminate-aks
+  resource: azure.aks
+  description: |
+    Delete any marked instances which have been 
+    marked for deletion for more than 1 day.
+  filters:
+    - or:
+      - type: marked-for-op
+        tag: unknown_user
+        op: delete
+      - type: marked-for-op
+        tag: known_user
+        op: delete
+  actions:
+    - type: delete

--- a/tests/scripts/custodian/gcp.yaml
+++ b/tests/scripts/custodian/gcp.yaml
@@ -1,0 +1,73 @@
+# GCP Policies
+# Note: for GOOGLE_APPLICATION_CREDENTIALS, must be valid json
+#     with quotes commented out
+policies:
+# VMs
+- name: gcp-mark-unknown-instance-for-deletion
+  resource: gcp.instance
+  description: |
+    Mark unknown user instances for deletion in 1 day
+  filters:
+    - "State.Name": running
+    # instance name not in accepted user keys
+    - type: value
+      key: name
+      op: regex
+      #doesNOTcontain
+      value:  "^((?!USERKEYS).)*$"
+    # tagging not supported through cloud custodian at this time
+    - not: 
+      - type: value
+        key: name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: set-labels
+      labels:
+        unknown_user: setForDeletion
+    - type: mark-for-op
+      op: delete
+      days: 1
+
+
+- name: gcp-mark-known-instance-for-deletion
+  resource: gcp.instance
+  description: |
+    Mark known user instances for deletion in 2 days
+  filters:
+    # instance is named with accepted user key
+    - type: value
+      key: name
+      op: regex
+      value:  "^.*USERKEYS.*$"
+    # tagging not supported through cloud custodian at this time
+    - not: 
+      - type: value
+        key: name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: set-labels
+      labels:
+        known_user: setForDeletion
+    - type: mark-for-op
+      op: delete
+      days: 2
+
+- name: gcp-terminate-instance
+  resource: gcp.instance
+  description: |
+    Delete any marked instances which have been 
+    marked for deletion for more than 1 day.
+  filters:
+    - or:
+      - type: marked-for-op
+        label: unknown_user
+        op: delete
+      - type: marked-for-op
+        label: known_user
+        op: delete
+  actions:
+    - type: delete
+
+# GKE - no support for labels nor tags at this time

--- a/tests/scripts/custodian/tag-to-save.yaml
+++ b/tests/scripts/custodian/tag-to-save.yaml
@@ -1,0 +1,40 @@
+policies:
+# note: userkeys here is an override var.
+- name: tag-instances-til-friday
+  resource: aws.ec2
+  filters:
+    - and:
+      - type: value
+        key: tag:Name
+        op: regex
+        value:  "^.*USERKEYS.*$"
+      - not:
+        - 'tag:doNotDelete': present
+        - 'tag:DoNotDelete': present
+        - type: value
+          key: tag:Name
+          op: regex
+          value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: tag
+      tags:
+        DeletesOnFriday: 'true'
+- name: tag-nlbs-til-friday
+  resource: app-elb
+  filters:
+    - and:
+      - type: value
+        key: LoadBalancerArn
+        op: regex
+        value: "^.*USERKEYS.*$"
+      - not:
+        - 'tag:doNotDelete': present
+        - 'tag:DoNotDelete': present
+        - type: value
+          key: tag:Name
+          op: regex
+          value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: tag
+      tags:
+        DeletesOnFriday: 'true'

--- a/tests/scripts/custodian/untag-to-delete.yaml
+++ b/tests/scripts/custodian/untag-to-delete.yaml
@@ -1,0 +1,29 @@
+policies:
+# should be ran on CRON to remove on every saturday morning / friday night
+# note: userkeys here is an override var.
+- name: remove-tagged-friday-instances
+  resource: aws.ec2
+  filters:
+      - 'tag:DeletesOnFriday': present
+      - not:
+        - 'tag:doNotDelete': present
+        - 'tag:DoNotDelete': present
+        - type: value
+          key: tag:Name
+          op: regex
+          value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: terminate
+- name: remove-tagged-friday-nlbs
+  resource: app-elb
+  filters:
+      - 'tag:DeletesOnFriday': present
+      - not:
+        - 'tag:doNotDelete': present
+        - 'tag:DoNotDelete': present
+        - type: value
+          key: tag:Name
+          op: regex
+          value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: delete


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/qa-tasks/issues/28

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 QA should have a way to manage its own resources automatically. 


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This PR introduces the use of cloud custodian, a tool that cleans our resources based on rules we define for it. Currently, the work done includes AWS instances and NLBs. In the future, we can add support for GCR and Azure, and extend AWS custodian support further. Please see the introduced README for more details.


The changes between this and the last proposal are mostly just changing from GH actions -> Jenkins

Everything in this PR is a proof of concept, so I have the following 'placeholders' until we decide on a definite route:
* automation is not cron based yet, and can only be triggered manually
* the custodian is in `--dry-run` mode, meaning it will report the number of instances that would have been cleaned up, but not actually delete, tag, or take any action whatsoever
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
can send jenkins testing upon request. Currently, our automation bot has some permissions issues. 
