### PR TITLE
Fix steveapi integration tests

### DIFF
--- a/tests/v2/integration/steveapi/README.md
+++ b/tests/v2/integration/steveapi/README.md
@@ -28,7 +28,7 @@ This table is automatically generated from the output of the integration tests. 
 1. Run the integration tests locally:
 
 ```
-go test -count=1 -v ./tests/v2/integration/steveapi/
+go test -count=1 -v ./tests/v2/integration/steveapi/ -run TestSteveLocal
 ```
 
 2. Use the [included script](./make-table.sh) to validate the JSON files and update the markdown table:

--- a/tests/v2/integration/steveapi/json/user-a_none_fieldSelector=metadata.name=test1.json
+++ b/tests/v2/integration/steveapi/json/user-a_none_fieldSelector=metadata.name=test1.json
@@ -16,6 +16,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -38,6 +41,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-2",
         "resourceVersion": "1000",
@@ -60,6 +66,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-3",
         "resourceVersion": "1000",
@@ -82,6 +91,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-4/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-4",
         "resourceVersion": "1000",
@@ -104,6 +116,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-5/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-5",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-a_none_fieldSelector=metadata.namespace=test-ns-1.json
+++ b/tests/v2/integration/steveapi/json/user-a_none_fieldSelector=metadata.namespace=test-ns-1.json
@@ -16,6 +16,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -39,7 +42,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -63,6 +67,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -85,6 +92,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -107,6 +117,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-a_none_labelSelector=test-label=2.json
+++ b/tests/v2/integration/steveapi/json/user-a_none_labelSelector=test-label=2.json
@@ -17,7 +17,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -42,7 +43,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-2",
@@ -67,7 +69,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-3",
@@ -92,7 +95,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-4",
@@ -117,7 +121,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-5",

--- a/tests/v2/integration/steveapi/json/user-a_none_limit=8&continue=nondeterministictoken.json
+++ b/tests/v2/integration/steveapi/json/user-a_none_limit=8&continue=nondeterministictoken.json
@@ -17,6 +17,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-2",
         "resourceVersion": "1000",
@@ -39,6 +42,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-2",
         "resourceVersion": "1000",
@@ -61,6 +67,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-3",
         "resourceVersion": "1000",
@@ -84,7 +93,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-3",
@@ -108,6 +118,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-3",
         "resourceVersion": "1000",
@@ -130,6 +143,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-3",
         "resourceVersion": "1000",
@@ -152,6 +168,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-3",
         "resourceVersion": "1000",
@@ -174,6 +193,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-4/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-4",
         "resourceVersion": "1000",
@@ -190,7 +212,7 @@
   },
   "pagination": {
     "first": "https://rancherurl/v1/secrets",
-    "next": "https://rancherurl/v1/secrets?continue=nondeterministictoken\u0026limit=8",
+    "next": "https://rancherurl/v1/secrets?continue=nondeterministictoken\u0026labelSelector=test.cattle.io%2Fsteveapi%3Dtrue\u0026limit=8",
     "partial": true
   },
   "resourceType": "secret",

--- a/tests/v2/integration/steveapi/json/user-a_none_limit=8.json
+++ b/tests/v2/integration/steveapi/json/user-a_none_limit=8.json
@@ -17,6 +17,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -40,7 +43,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -64,6 +68,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -86,6 +93,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -108,6 +118,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -130,6 +143,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-2",
         "resourceVersion": "1000",
@@ -153,7 +169,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-2",
@@ -177,6 +194,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-2",
         "resourceVersion": "1000",
@@ -193,7 +213,7 @@
   },
   "pagination": {
     "first": "https://rancherurl/v1/secrets",
-    "next": "https://rancherurl/v1/secrets?continue=nondeterministictoken\u0026limit=8",
+    "next": "https://rancherurl/v1/secrets?continue=nondeterministictoken\u0026labelSelector=test.cattle.io%2Fsteveapi%3Dtrue\u0026limit=8",
     "partial": true
   },
   "resourceType": "secret",

--- a/tests/v2/integration/steveapi/json/user-a_none_none.json
+++ b/tests/v2/integration/steveapi/json/user-a_none_none.json
@@ -16,6 +16,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -39,7 +42,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -63,6 +67,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -85,6 +92,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -107,6 +117,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -129,6 +142,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-2",
         "resourceVersion": "1000",
@@ -152,7 +168,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-2",
@@ -176,6 +193,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-2",
         "resourceVersion": "1000",
@@ -198,6 +218,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-2",
         "resourceVersion": "1000",
@@ -220,6 +243,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-2",
         "resourceVersion": "1000",
@@ -242,6 +268,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-3",
         "resourceVersion": "1000",
@@ -265,7 +294,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-3",
@@ -289,6 +319,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-3",
         "resourceVersion": "1000",
@@ -311,6 +344,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-3",
         "resourceVersion": "1000",
@@ -333,6 +369,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-3",
         "resourceVersion": "1000",
@@ -355,6 +394,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-4/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-4",
         "resourceVersion": "1000",
@@ -378,7 +420,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-4",
@@ -402,6 +445,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-4/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-4",
         "resourceVersion": "1000",
@@ -424,6 +470,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-4/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-4",
         "resourceVersion": "1000",
@@ -446,6 +495,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-4/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-4",
         "resourceVersion": "1000",
@@ -468,6 +520,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-5/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-5",
         "resourceVersion": "1000",
@@ -491,7 +546,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-5",
@@ -515,6 +571,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-5/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-5",
         "resourceVersion": "1000",
@@ -537,6 +596,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-5/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-5",
         "resourceVersion": "1000",
@@ -559,6 +621,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-5/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-5",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-a_test-ns-1_fieldSelector=metadata.name=test1.json
+++ b/tests/v2/integration/steveapi/json/user-a_test-ns-1_fieldSelector=metadata.name=test1.json
@@ -16,6 +16,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-a_test-ns-1_fieldSelector=metadata.namespace=test-ns-1.json
+++ b/tests/v2/integration/steveapi/json/user-a_test-ns-1_fieldSelector=metadata.namespace=test-ns-1.json
@@ -16,6 +16,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -39,7 +42,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -63,6 +67,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -85,6 +92,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -107,6 +117,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-a_test-ns-1_limit=3&continue=nondeterministictoken.json
+++ b/tests/v2/integration/steveapi/json/user-a_test-ns-1_limit=3&continue=nondeterministictoken.json
@@ -16,6 +16,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -38,6 +41,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-a_test-ns-1_limit=3.json
+++ b/tests/v2/integration/steveapi/json/user-a_test-ns-1_limit=3.json
@@ -17,6 +17,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -40,7 +43,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -64,6 +68,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -80,7 +87,7 @@
   },
   "pagination": {
     "first": "https://rancherurl/v1/secrets/test-ns-1",
-    "next": "https://rancherurl/v1/secrets/test-ns-1?continue=nondeterministictoken\u0026limit=3",
+    "next": "https://rancherurl/v1/secrets/test-ns-1?continue=nondeterministictoken\u0026labelSelector=test.cattle.io%2Fsteveapi%3Dtrue\u0026limit=3",
     "partial": true
   },
   "resourceType": "secret",

--- a/tests/v2/integration/steveapi/json/user-a_test-ns-1_none.json
+++ b/tests/v2/integration/steveapi/json/user-a_test-ns-1_none.json
@@ -16,6 +16,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -39,7 +42,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -63,6 +67,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -85,6 +92,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -107,6 +117,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-a_test-ns-2_labelSelector=test-label=2.json
+++ b/tests/v2/integration/steveapi/json/user-a_test-ns-2_labelSelector=test-label=2.json
@@ -17,7 +17,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-2",

--- a/tests/v2/integration/steveapi/json/user-a_test-ns-5_none.json
+++ b/tests/v2/integration/steveapi/json/user-a_test-ns-5_none.json
@@ -16,6 +16,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-5/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-5",
         "resourceVersion": "1000",
@@ -39,7 +42,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-5",
@@ -63,6 +67,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-5/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-5",
         "resourceVersion": "1000",
@@ -85,6 +92,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-5/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-5",
         "resourceVersion": "1000",
@@ -107,6 +117,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-5/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-5",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-b_none_fieldSelector=metadata.name=test1.json
+++ b/tests/v2/integration/steveapi/json/user-b_none_fieldSelector=metadata.name=test1.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-b_none_fieldSelector=metadata.namespace=test-ns-1.json
+++ b/tests/v2/integration/steveapi/json/user-b_none_fieldSelector=metadata.namespace=test-ns-1.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -32,7 +35,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -54,6 +58,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -74,6 +81,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -94,6 +104,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-b_none_labelSelector=test-label=2.json
+++ b/tests/v2/integration/steveapi/json/user-b_none_labelSelector=test-label=2.json
@@ -12,7 +12,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",

--- a/tests/v2/integration/steveapi/json/user-b_none_limit=3&continue=nondeterministictoken.json
+++ b/tests/v2/integration/steveapi/json/user-b_none_limit=3&continue=nondeterministictoken.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -31,6 +34,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-b_none_limit=3.json
+++ b/tests/v2/integration/steveapi/json/user-b_none_limit=3.json
@@ -12,6 +12,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -33,7 +36,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -55,6 +59,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -71,7 +78,7 @@
   },
   "pagination": {
     "first": "https://rancherurl/v1/secrets",
-    "next": "https://rancherurl/v1/secrets?continue=nondeterministictoken\u0026limit=3",
+    "next": "https://rancherurl/v1/secrets?continue=nondeterministictoken\u0026labelSelector=test.cattle.io%2Fsteveapi%3Dtrue\u0026limit=3",
     "partial": true
   },
   "resourceType": "secret",

--- a/tests/v2/integration/steveapi/json/user-b_none_none.json
+++ b/tests/v2/integration/steveapi/json/user-b_none_none.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -32,7 +35,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -54,6 +58,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -74,6 +81,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -94,6 +104,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-b_test-ns-1_fieldSelector=metadata.name=test1.json
+++ b/tests/v2/integration/steveapi/json/user-b_test-ns-1_fieldSelector=metadata.name=test1.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-b_test-ns-1_fieldSelector=metadata.namespace=test-ns-1.json
+++ b/tests/v2/integration/steveapi/json/user-b_test-ns-1_fieldSelector=metadata.namespace=test-ns-1.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -32,7 +35,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -54,6 +58,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -74,6 +81,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -94,6 +104,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-b_test-ns-1_labelSelector=test-label=2.json
+++ b/tests/v2/integration/steveapi/json/user-b_test-ns-1_labelSelector=test-label=2.json
@@ -12,7 +12,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",

--- a/tests/v2/integration/steveapi/json/user-b_test-ns-1_limit=3&continue=nondeterministictoken.json
+++ b/tests/v2/integration/steveapi/json/user-b_test-ns-1_limit=3&continue=nondeterministictoken.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -31,6 +34,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-b_test-ns-1_limit=3.json
+++ b/tests/v2/integration/steveapi/json/user-b_test-ns-1_limit=3.json
@@ -12,6 +12,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -33,7 +36,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -55,6 +59,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -71,7 +78,7 @@
   },
   "pagination": {
     "first": "https://rancherurl/v1/secrets/test-ns-1",
-    "next": "https://rancherurl/v1/secrets/test-ns-1?continue=nondeterministictoken\u0026limit=3",
+    "next": "https://rancherurl/v1/secrets/test-ns-1?continue=nondeterministictoken\u0026labelSelector=test.cattle.io%2Fsteveapi%3Dtrue\u0026limit=3",
     "partial": true
   },
   "resourceType": "secret",

--- a/tests/v2/integration/steveapi/json/user-b_test-ns-1_none.json
+++ b/tests/v2/integration/steveapi/json/user-b_test-ns-1_none.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -32,7 +35,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -54,6 +58,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test3"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test3",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -74,6 +81,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test4"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test4",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -94,6 +104,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test5"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test5",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-c_none_fieldSelector=metadata.name=test1.json
+++ b/tests/v2/integration/steveapi/json/user-c_none_fieldSelector=metadata.name=test1.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -31,6 +34,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-2",
         "resourceVersion": "1000",
@@ -51,6 +57,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-3",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-c_none_fieldSelector=metadata.namespace=test-ns-1.json
+++ b/tests/v2/integration/steveapi/json/user-c_none_fieldSelector=metadata.namespace=test-ns-1.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -32,7 +35,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",

--- a/tests/v2/integration/steveapi/json/user-c_none_fieldSelector=metadata.namespace=test-ns-2.json
+++ b/tests/v2/integration/steveapi/json/user-c_none_fieldSelector=metadata.namespace=test-ns-2.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-2",
         "resourceVersion": "1000",
@@ -32,7 +35,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-2",

--- a/tests/v2/integration/steveapi/json/user-c_none_labelSelector=test-label=2.json
+++ b/tests/v2/integration/steveapi/json/user-c_none_labelSelector=test-label=2.json
@@ -12,7 +12,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -35,7 +36,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-2",
@@ -58,7 +60,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-3",

--- a/tests/v2/integration/steveapi/json/user-c_none_limit=3&continue=nondeterministictoken.json
+++ b/tests/v2/integration/steveapi/json/user-c_none_limit=3&continue=nondeterministictoken.json
@@ -12,7 +12,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-2",
@@ -34,6 +35,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-3",
         "resourceVersion": "1000",
@@ -55,7 +59,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-3",

--- a/tests/v2/integration/steveapi/json/user-c_none_limit=3.json
+++ b/tests/v2/integration/steveapi/json/user-c_none_limit=3.json
@@ -12,6 +12,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -33,7 +36,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -55,6 +59,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-2",
         "resourceVersion": "1000",
@@ -71,7 +78,7 @@
   },
   "pagination": {
     "first": "https://rancherurl/v1/secrets",
-    "next": "https://rancherurl/v1/secrets?continue=nondeterministictoken\u0026limit=3",
+    "next": "https://rancherurl/v1/secrets?continue=nondeterministictoken\u0026labelSelector=test.cattle.io%2Fsteveapi%3Dtrue\u0026limit=3",
     "partial": true
   },
   "resourceType": "secret",

--- a/tests/v2/integration/steveapi/json/user-c_none_none.json
+++ b/tests/v2/integration/steveapi/json/user-c_none_none.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -32,7 +35,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",
@@ -54,6 +58,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-2/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-2",
         "resourceVersion": "1000",
@@ -75,7 +82,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-2",
@@ -97,6 +105,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-3/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-3",
         "resourceVersion": "1000",
@@ -118,7 +129,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-3",

--- a/tests/v2/integration/steveapi/json/user-c_test-ns-1_fieldSelector=metadata.name=test1.json
+++ b/tests/v2/integration/steveapi/json/user-c_test-ns-1_fieldSelector=metadata.name=test1.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",

--- a/tests/v2/integration/steveapi/json/user-c_test-ns-1_fieldSelector=metadata.namespace=test-ns-1.json
+++ b/tests/v2/integration/steveapi/json/user-c_test-ns-1_fieldSelector=metadata.namespace=test-ns-1.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -32,7 +35,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",

--- a/tests/v2/integration/steveapi/json/user-c_test-ns-1_labelSelector=test-label=2.json
+++ b/tests/v2/integration/steveapi/json/user-c_test-ns-1_labelSelector=test-label=2.json
@@ -12,7 +12,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",

--- a/tests/v2/integration/steveapi/json/user-c_test-ns-1_limit=3.json
+++ b/tests/v2/integration/steveapi/json/user-c_test-ns-1_limit=3.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -32,7 +35,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",

--- a/tests/v2/integration/steveapi/json/user-c_test-ns-1_none.json
+++ b/tests/v2/integration/steveapi/json/user-c_test-ns-1_none.json
@@ -11,6 +11,9 @@
         "view": "https://rancherurl/api/v1/namespaces/test-ns-1/secrets/test1"
       },
       "metadata": {
+        "labels": {
+          "test.cattle.io/steveapi": "true"
+        },
         "name": "test1",
         "namespace": "test-ns-1",
         "resourceVersion": "1000",
@@ -32,7 +35,8 @@
       },
       "metadata": {
         "labels": {
-          "test-label": "2"
+          "test-label": "2",
+          "test.cattle.io/steveapi": "true"
         },
         "name": "test2",
         "namespace": "test-ns-1",

--- a/tests/v2/integration/steveapi/steve_api_test.go
+++ b/tests/v2/integration/steveapi/steve_api_test.go
@@ -151,7 +151,7 @@ var (
 	}
 )
 
-type SteveAPITestSuite struct {
+type steveAPITestSuite struct {
 	suite.Suite
 	client            *rancher.Client
 	session           *session.Session
@@ -160,11 +160,27 @@ type SteveAPITestSuite struct {
 	lastContinueToken string
 }
 
-func (s *SteveAPITestSuite) TearDownSuite() {
+type LocalSteveAPITestSuite struct {
+	steveAPITestSuite
+}
+
+type DownstreamSteveAPITestSuite struct {
+	steveAPITestSuite
+}
+
+func (s *steveAPITestSuite) TearDownSuite() {
 	s.session.Cleanup()
 }
 
-func (s *SteveAPITestSuite) SetupSuite() {
+func (s *LocalSteveAPITestSuite) SetupSuite() {
+	s.steveAPITestSuite.setupSuite("local")
+}
+
+func (s *DownstreamSteveAPITestSuite) SetupSuite() {
+	s.steveAPITestSuite.setupSuite("")
+}
+
+func (s *steveAPITestSuite) setupSuite(clusterName string) {
 	testSession := session.NewSession()
 	s.session = testSession
 
@@ -174,7 +190,9 @@ func (s *SteveAPITestSuite) SetupSuite() {
 
 	s.userClients = make(map[string]*rancher.Client)
 
-	clusterName := s.client.RancherConfig.ClusterName
+	if clusterName == "" {
+		clusterName = s.client.RancherConfig.ClusterName
+	}
 	require.NotEmptyf(s.T(), clusterName, "Cluster name is not set")
 	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
 	require.NoError(s.T(), err)
@@ -270,7 +288,7 @@ func (s *SteveAPITestSuite) SetupSuite() {
 	}
 }
 
-func (s *SteveAPITestSuite) TestList() {
+func (s *steveAPITestSuite) TestList() {
 	subSession := s.session.NewSession()
 	defer subSession.Cleanup()
 
@@ -845,9 +863,19 @@ func (s *SteveAPITestSuite) TestList() {
 		},
 	}
 
-	csvWriter, fp, jsonDir, err := setUpResults()
-	defer fp.Close()
-	require.NoError(s.T(), err)
+	var csvWriter *csv.Writer
+	var jsonDir string
+	if s.project.ClusterID == "local" {
+		var fp *os.File
+		var err error
+		csvWriter, fp, jsonDir, err = setUpResults()
+		defer fp.Close()
+		defer func() {
+			csvWriter.Flush()
+			require.NoError(s.T(), csvWriter.Error())
+		}()
+		require.NoError(s.T(), err)
+	}
 
 	for _, test := range tests {
 		s.Run(test.description, func() {
@@ -884,19 +912,17 @@ func (s *SteveAPITestSuite) TestList() {
 			}
 
 			// Write human-readable request and response examples
-			curlURL, err := getCurlURL(client, test.namespace, test.query)
-			require.NoError(s.T(), err)
-			jsonResp, err := formatJSON(secretList)
-			require.NoError(s.T(), err)
-			jsonFilePath := filepath.Join(jsonDir, getFileName(test.user, test.namespace, test.query))
-			if !downStreamClusterRegex.MatchString(curlURL) {
+			if s.project.ClusterID == "local" {
+				curlURL, err := getCurlURL(client, test.namespace, test.query)
+				require.NoError(s.T(), err)
+				jsonResp, err := formatJSON(secretList)
+				require.NoError(s.T(), err)
+				jsonFilePath := filepath.Join(jsonDir, getFileName(test.user, test.namespace, test.query))
 				err = writeResp(csvWriter, test.user, curlURL, jsonFilePath, jsonResp)
 				require.NoError(s.T(), err)
 			}
 		})
 	}
-	csvWriter.Flush()
-	require.NoError(s.T(), csvWriter.Error())
 }
 
 func getFileName(user, ns, query string) string {
@@ -1003,7 +1029,7 @@ func writeResp(csvWriter *csv.Writer, user, url, path string, resp []byte) error
 	return nil
 }
 
-func (s *SteveAPITestSuite) TestCRUD() {
+func (s *steveAPITestSuite) TestCRUD() {
 	subSession := s.session.NewSession()
 	defer subSession.Cleanup()
 
@@ -1089,6 +1115,10 @@ func (s *SteveAPITestSuite) TestCRUD() {
 	})
 }
 
-func TestSteve(t *testing.T) {
-	suite.Run(t, new(SteveAPITestSuite))
+func TestSteveLocal(t *testing.T) {
+	suite.Run(t, new(LocalSteveAPITestSuite))
+}
+
+func TestSteveDownstream(t *testing.T) {
+	suite.Run(t, new(DownstreamSteveAPITestSuite))
 }


### PR DESCRIPTION
## Make steveapi tests more flexible

The steveapi integration tests try to be precise about the desired
output of API calls. This was causing a problem when run on k8s 1.23
which has default token secrets in every namespace and so was adding
extra resources to the response output. This change adds a label to the
secrets created in TestList so that they can easily be identified on a
live cluster and so unlabeled secrets can be ignored.

## Run steveapi tests on local and downstream

The behavior on local vs downstream can sometimes be subtly different,
so it is worth running API tests on both. Also, the steveapi tests are
self-documenting, but they were not writing their outputs because their
outputs were different from run to run because the downstream cluster ID
was different. This change ensures both sets of tests are run but the
output examples are only recorded when the output is deterministic
(which is for the local).

Partial backport of https://github.com/rancher/rancher/pull/40586