### PR TITLE
Add additional Prime UI checks

### DIFF
--- a/tests/framework/extensions/prime/primechecks.go
+++ b/tests/framework/extensions/prime/primechecks.go
@@ -1,0 +1,83 @@
+package primechecks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	client "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/rancherversion"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	PodResourceSteveType = "pod"
+	rancherImage         = "rancher"
+)
+
+// CheckUIBrand checks the UI brand of Rancher Prime. If the Rancher instance is not Rancher Prime, the UI brand should be blank.
+func CheckUIBrand(client *rancher.Client, isPrime bool, rancherBrand *client.Setting, brand string) error {
+	if isPrime && brand != rancherBrand.Value {
+		return fmt.Errorf("error: Rancher Prime UI brand %s does not match defined UI brand %s", rancherBrand.Value, brand)
+	}
+
+	return nil
+}
+
+// CheckVersion checks the if Rancher Prime is set to true and the version of Rancher.
+func CheckVersion(isPrime bool, rancherVersion string, serverConfig *rancherversion.Config) error {
+	if isPrime && rancherVersion != serverConfig.RancherVersion {
+		return fmt.Errorf("error: Rancher Prime: %t | Version: %s", isPrime, serverConfig.RancherVersion)
+	}
+
+	return nil
+}
+
+// CheckSystemDefaultRegistry checks if the system default registry is set to the expected value.
+func CheckSystemDefaultRegistry(isPrime bool, primeRegistry string, registry *client.Setting) error {
+	if isPrime && primeRegistry != registry.Value {
+		return fmt.Errorf("error: Rancher Prime system default registry %s does not match user defined registry %s", registry.Value, primeRegistry)
+	}
+
+	return nil
+}
+
+// CheckLocalClusterRancherImages checks if the Rancher images are set to the expected registry.
+func CheckLocalClusterRancherImages(client *rancher.Client, isPrime bool, rancherVersion, primeRegistry, clusterID string) ([]string, []error) {
+	downstreamClient, err := client.Steve.ProxyDownstream(clusterID)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	steveClient := downstreamClient.SteveType(PodResourceSteveType)
+
+	pods, err := steveClient.List(nil)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	var imageResults []string
+	var imageErrors []error
+
+	for _, pod := range pods.Data {
+		podStatus := &corev1.PodStatus{}
+		err = v1.ConvertToK8sType(pod.Status, podStatus)
+		if err != nil {
+			return nil, []error{err}
+		}
+
+		image := podStatus.ContainerStatuses[0].Image
+
+		if (strings.Contains(image, primeRegistry) && isPrime) || (strings.Contains(image, rancherImage) && !isPrime) {
+			imageResults = append(imageResults, fmt.Sprintf("INFO: %s: %s\n", pod.Name, image))
+			logrus.Infof("Pod %s is using image: %s", pod.Name, image)
+		} else if strings.Contains(image, rancherImage) && isPrime {
+			imageErrors = append(imageErrors, fmt.Errorf("ERROR: %s: %s", pod.Name, image))
+			logrus.Infof("Pod %s is using image: %s", pod.Name, image)
+		}
+	}
+
+	return imageResults, imageErrors
+}

--- a/tests/framework/extensions/rancherversion/config.go
+++ b/tests/framework/extensions/rancherversion/config.go
@@ -5,7 +5,9 @@ const (
 )
 
 type Config struct {
-	RancherVersion string `json:"rancherVersion" yaml:"rancherVersion"`
-	IsPrime        bool   `json:"isPrime" yaml:"isPrime" default:false`
+	Brand          string `json:"brand" yaml:"brand"`
 	GitCommit      string `json:"gitCommit" yaml:"gitCommit"`
+	IsPrime        bool   `json:"isPrime" yaml:"isPrime" default:false`
+	RancherVersion string `json:"rancherVersion" yaml:"rancherVersion"`
+	Registry       string `json:"registry" yaml:"registry"`
 }

--- a/tests/v2/validation/prime/README.md
+++ b/tests/v2/validation/prime/README.md
@@ -1,7 +1,7 @@
 # Prime Configs
 
 ## Getting Started
-Your GO suite should be set to `-run ^TestPrimeVersionTestSuite$`. You can find any additional suite name(s) by checking the test file you plan to run.
+Your GO suite should be set to `-run ^TestPrimeTestSuite$`. You can find any additional suite name(s) by checking the test file you plan to run.
 
 In your config file, set the following:
 ```json
@@ -11,9 +11,11 @@ In your config file, set the following:
   ...,
 }
 "prime": {
-  "rancherVersion": "<version_or_commit_of_rancher>",
+  "brand": "<name of brand>",
   "isPrime": false, //boolean, default is false
+  "rancherVersion": "<version_or_commit_of_rancher>",
+  "registry": "<name of registry>"
 }
 ```
 
-if isPrime is `true`, we will also check that the ui-brand is correctly set. 
+if isPrime is `true`, we will also check that the ui-brand is correctly set. For the `TestPrimeVersion` test case, your Rancher URL that is passed must used a secure certificate. If an insecure certificate is recognized, then the test will fail; this is expected.

--- a/tests/v2/validation/prime/prime_test.go
+++ b/tests/v2/validation/prime/prime_test.go
@@ -4,59 +4,90 @@ import (
 	"testing"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	prime "github.com/rancher/rancher/tests/framework/extensions/prime"
 	"github.com/rancher/rancher/tests/framework/extensions/rancherversion"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-const rancherBrand = "suse"
+const (
+	systemRegistry = "system-default-registry"
+	localCluster   = "local"
+	uiBrand        = "ui-brand"
+)
 
-type PrimeVersionTestSuite struct {
+type PrimeTestSuite struct {
 	suite.Suite
 	session        *session.Session
 	client         *rancher.Client
+	brand          string
 	isPrime        bool
 	rancherVersion string
+	primeRegistry  string
 }
 
-func (t *PrimeVersionTestSuite) TearDownSuite() {
+func (t *PrimeTestSuite) TearDownSuite() {
 	t.session.Cleanup()
 }
 
-func (t *PrimeVersionTestSuite) SetupSuite() {
+func (t *PrimeTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	t.session = testSession
-	primeConfig := new(rancherversion.Config)
 
+	primeConfig := new(rancherversion.Config)
 	config.LoadConfig(rancherversion.ConfigurationFileKey, primeConfig)
+
+	t.brand = primeConfig.Brand
 	t.isPrime = primeConfig.IsPrime
 	t.rancherVersion = primeConfig.RancherVersion
+	t.primeRegistry = primeConfig.Registry
 
 	client, err := rancher.NewClient("", t.session)
 	assert.NoError(t.T(), err)
+
 	t.client = client
-
 }
 
-func (t *PrimeVersionTestSuite) TestPrimeVersion() {
+func (t *PrimeTestSuite) TestPrimeUIBrand() {
+	rancherBrand, err := t.client.Management.Setting.ByID(uiBrand)
+	require.NoError(t.T(), err)
+
+	checkBrand := prime.CheckUIBrand(t.client, t.isPrime, rancherBrand, t.brand)
+	assert.NoError(t.T(), checkBrand)
+}
+
+func (t *PrimeTestSuite) TestPrimeVersion() {
 	serverConfig, err := rancherversion.RequestRancherVersion(t.client.RancherConfig.Host)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 
-	assert.Equal(t.T(), t.isPrime, serverConfig.IsPrime)
-	assert.Equal(t.T(), t.rancherVersion, serverConfig.RancherVersion)
-	brand, err := t.client.Management.Setting.ByID("ui-brand")
-	if err != nil {
-		t.T().Log(err)
-	}
-	if t.isPrime {
-		assert.Equal(t.T(), rancherBrand, brand.Value)
-	} else {
-		assert.Empty(t.T(), brand.Value)
-	}
+	checkVersion := prime.CheckVersion(t.isPrime, t.rancherVersion, serverConfig)
+	assert.NoError(t.T(), checkVersion)
 }
 
-func TestPrimeVersionTestSuite(t *testing.T) {
-	suite.Run(t, new(PrimeVersionTestSuite))
+func (t *PrimeTestSuite) TestSystemDefaultRegistry() {
+	registry, err := t.client.Management.Setting.ByID(systemRegistry)
+	require.NoError(t.T(), err)
+
+	checkRegistry := prime.CheckSystemDefaultRegistry(t.isPrime, t.primeRegistry, registry)
+	assert.NoError(t.T(), checkRegistry)
+}
+
+func (t *PrimeTestSuite) TestLocalClusterRancherImages() {
+	adminClient, err := rancher.NewClient(t.client.RancherConfig.AdminToken, t.client.Session)
+	require.NoError(t.T(), err)
+
+	clusterID, err := clusters.GetClusterIDByName(adminClient, localCluster)
+	require.NoError(t.T(), err)
+
+	imageResults, imageErrors := prime.CheckLocalClusterRancherImages(t.client, t.isPrime, t.rancherVersion, t.primeRegistry, clusterID)
+	assert.NotEmpty(t.T(), imageResults)
+	assert.Empty(t.T(), imageErrors)
+}
+
+func TestPrimeTestSuite(t *testing.T) {
+	suite.Run(t, new(PrimeTestSuite))
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->[Include additional UI checks in prime_test.go]( https://github.com/rancher/qa-tasks/issues/688)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
In the `prime_test.go` file, we currently are only checking the branding and versioning. There are additional UI checks we do in release testing, namely ensuring the pulled images are using the right registry.

This PR addresses that by adding additional UI checks.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Refactored the `prime_test.go` to have separate all different test functions. Additionally, added two new checks:
- Check the system default registry.
- Check the pulled image from the workloads in the system project page.

On the chance that a non-Prime server is running the `prime_test.go` test, logic has been put in place to account for this.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Jenkins runs will be given to reviewers offline.