### PR TITLE
Changing the default system chart refresh time to 21600 seconds

### DIFF
--- a/pkg/catalogv2/system/system.go
+++ b/pkg/catalogv2/system/system.go
@@ -157,10 +157,11 @@ func (m *Manager) runSync() {
 	}
 }
 
+// getIntervalOrDefault Converts the input to a time.Duration or returns a default value
 func getIntervalOrDefault(interval string) time.Duration {
 	i, err := strconv.Atoi(interval)
 	if err != nil {
-		return 900 * time.Second
+		return 21600 * time.Second
 	}
 	return time.Duration(i) * time.Second
 }

--- a/pkg/catalogv2/system/system_test.go
+++ b/pkg/catalogv2/system/system_test.go
@@ -1,0 +1,40 @@
+package system
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestGetIntervalOrDefault(t *testing.T) {
+	t.Parallel()
+	asserts := assert.New(t)
+	type testCase struct {
+		name     string
+		input    string
+		expected time.Duration
+	}
+
+	testCases := []testCase{
+		{
+			name:     "Should return the default value of 21600 if input string is empty",
+			input:    "",
+			expected: 21600 * time.Second,
+		},
+		{
+			name:     "Should return the default value of 21600 if input string is invalid",
+			input:    "foo",
+			expected: 21600 * time.Second,
+		},
+		{
+			name:     "Should return the time.Duration that corresponds to the given input",
+			input:    "60",
+			expected: 60 * time.Second,
+		},
+	}
+
+	for _, test := range testCases {
+		actual := getIntervalOrDefault(test.input)
+		asserts.Equal(test.expected, actual, test.name)
+	}
+}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -128,7 +128,7 @@ var (
 	GKEUpstreamRefresh                  = NewSetting("gke-refresh", "300")
 	HideLocalCluster                    = NewSetting("hide-local-cluster", "false")
 	MachineProvisionImage               = NewSetting("machine-provision-image", "rancher/machine:v0.15.0-rancher99")
-	SystemFeatureChartRefreshSeconds    = NewSetting("system-feature-chart-refresh-seconds", "900")
+	SystemFeatureChartRefreshSeconds    = NewSetting("system-feature-chart-refresh-seconds", "21600")
 	ClusterAgentDefaultAffinity         = NewSetting("cluster-agent-default-affinity", ClusterAgentAffinity)
 	FleetAgentDefaultAffinity           = NewSetting("fleet-agent-default-affinity", FleetAgentAffinity)
 

--- a/pkg/settings/setting_test.go
+++ b/pkg/settings/setting_test.go
@@ -54,3 +54,25 @@ func TestSystemDefaultRegistryDefault(t *testing.T) {
 	}
 
 }
+
+// TestSystemFeatureChartRefreshSecondsDefault tests that the default refresh time is either
+// the default value of 21600 seconds or the build time value set through InjectDefaults.
+func TestSystemFeatureChartRefreshSecondsDefault(t *testing.T) {
+	expect := "21600"
+	if InjectDefaults != "" {
+		defaults := map[string]string{}
+		if err := json.Unmarshal([]byte(InjectDefaults), &defaults); err != nil {
+			t.Fatalf("Unable to parse InjectDefaults: %v", err)
+		}
+
+		if value, ok := defaults["system-feature-chart-refresh-seconds"]; ok {
+			expect = value
+		}
+	}
+
+	got := SystemFeatureChartRefreshSeconds.Get()
+	if got != expect {
+		t.Errorf("The System Feature Chart Refresh Seconds of %q is not the expected value %q", got, expect)
+	}
+
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40805
 
## Problem

 
## Solution
Increase the time between refreshes 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Upgrade the rancher version and checked if the timer changed

### Automated Testing
unit tests

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->