### PR TITLE
Prepare For 2.6.12-rc1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -162,8 +162,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-ENV CATTLE_UI_VERSION 2.6.11
-ENV CATTLE_DASHBOARD_UI_VERSION v2.6.11
+ENV CATTLE_UI_VERSION 2.6.12-rc1
+ENV CATTLE_DASHBOARD_UI_VERSION v2.6.12-rc1
 ENV CATTLE_CLI_VERSION v2.6.11
 
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.


### PR DESCRIPTION
RC Checklist

- [x] Charts and KDM branches are pointing to dev-2.6
- [x] UI and Dashboard versions have been bumped to `v2.6.12-rc1`
- [x] No new changes were made in RKE / CLI, continue using old versions 
- [x] Confirmed that gke/eks/aks operators do not need to be bumped for this RC 
- [x] ran `go mod tidy` and `go generate` and did not see any new changes  