### PR TITLE
[v2.6] Remove quotations in OnTag environmental variables

### DIFF
--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -157,19 +157,19 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
 
                 // AWS_USER and AWS_AMI are currently not set in the environmental variables.
                 env.CATTLE_TEST_URL = env.CATTLE_TEST_URL.replace('https://', '')
-                env.CONFIG = env.CONFIG.replace('${CATTLE_TEST_URL}', '${env.CATTLE_TEST_URL}')
-                env.CONFIG = env.CONFIG.replace('${ADMIN_TOKEN}', '${env.ADMIN_TOKEN}')
-                env.CONFIG = env.CONFIG.replace('${AZURE_CLIENT_ID}', '${env.USER_TOKEN}')
-                env.CONFIG = env.CONFIG.replace('${AZURE_CLIENT_SECRET}', '${env.AZURE_CLIENT_SECRET}')
-                env.CONFIG = env.CONFIG.replace('${AZURE_SUBSCRIPTION_ID}', '${env.AZURE_SUBSCRIPTION_ID}')
-                env.CONFIG = env.CONFIG.replace('${AWS_SECRET_ACCESS_KEY}', '${env.AWS_SECRET_ACCESS_KEY}')
-                env.CONFIG = env.CONFIG.replace('${AWS_ACCESS_KEY_ID}', '${env.AWS_ACCESS_KEY_ID}')
-                env.CONFIG = env.CONFIG.replace('${AWS_IAM_PROFILE}', '${env.AWS_IAM_PROFILE}')
-                env.CONFIG = env.CONFIG.replace('${AWS_REGION}', '${env.AWS_REGION}')
-                env.CONFIG = env.CONFIG.replace('${AWS_INSTANCE_TYPE}', '${env.AWS_INSTANCE_TYPE}')
-                env.CONFIG = env.CONFIG.replace('${AWS_VPC}', '${env.AWS_VPC}')
-                env.CONFIG = env.CONFIG.replace('${AWS_SECURITY_GROUPS}', '${env.AWS_SECURITY_GROUPS}')
-                env.CONFIG = env.CONFIG.replace('${AWS_SSH_PEM_KEY}', '${env.AWS_SSH_KEY_NAME}')
+                env.CONFIG = env.CONFIG.replace('${CATTLE_TEST_URL}', env.CATTLE_TEST_URL)
+                env.CONFIG = env.CONFIG.replace('${ADMIN_TOKEN}', env.ADMIN_TOKEN)
+                env.CONFIG = env.CONFIG.replace('${AZURE_CLIENT_ID}', env.USER_TOKEN)
+                env.CONFIG = env.CONFIG.replace('${AZURE_CLIENT_SECRET}', env.AZURE_CLIENT_SECRET)
+                env.CONFIG = env.CONFIG.replace('${AZURE_SUBSCRIPTION_ID}', env.AZURE_SUBSCRIPTION_ID)
+                env.CONFIG = env.CONFIG.replace('${AWS_SECRET_ACCESS_KEY}', env.AWS_SECRET_ACCESS_KEY)
+                env.CONFIG = env.CONFIG.replace('${AWS_ACCESS_KEY_ID}', env.AWS_ACCESS_KEY_ID)
+                env.CONFIG = env.CONFIG.replace('${AWS_IAM_PROFILE}', env.AWS_IAM_PROFILE)
+                env.CONFIG = env.CONFIG.replace('${AWS_REGION}', env.AWS_REGION)
+                env.CONFIG = env.CONFIG.replace('${AWS_INSTANCE_TYPE}', env.AWS_INSTANCE_TYPE)
+                env.CONFIG = env.CONFIG.replace('${AWS_VPC}', env.AWS_VPC)
+                env.CONFIG = env.CONFIG.replace('${AWS_SECURITY_GROUPS}', env.AWS_SECURITY_GROUPS)
+                env.CONFIG = env.CONFIG.replace('${AWS_SSH_PEM_KEY}', env.AWS_SSH_KEY_NAME)
 
                 stage('Execute subjobs') {
                   try {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
During release testing, we noted that the quotations in the defined environmental variables are causing credentials to be interpreted as an actual string. This causes unexpected failures to occur.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Removed the quotations completely and the syntax of how the environmental variables are defined to address this issue.