### PR TITLE
Add ability to pass files in during k3s and rke2 installs

### DIFF
--- a/tests/validation/tests/v3_api/resource/terraform/k3s/master/instances_server.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/master/instances_server.tf
@@ -77,6 +77,17 @@ resource "aws_instance" "master" {
   }
 
   provisioner "file" {
+    source      = "../../scripts/optional_write_files.sh"
+    destination = "/tmp/optional_write_files.sh"
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/optional_write_files.sh",
+      "sudo /tmp/optional_write_files.sh \"${var.optional_files}\"",
+    ]
+  }
+
+  provisioner "file" {
     source = "install_k3s_master.sh"
     destination = "/tmp/install_k3s_master.sh"
   }
@@ -175,6 +186,16 @@ resource "aws_instance" "master2-ha" {
   depends_on             = [aws_instance.master]
   tags = {
     Name                 = "${var.resource_name}-servers"
+  }
+  provisioner "file" {
+    source      = "../../scripts/optional_write_files.sh"
+    destination = "/tmp/optional_write_files.sh"
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/optional_write_files.sh",
+      "sudo /tmp/optional_write_files.sh \"${var.optional_files}\"",
+    ]
   }
   provisioner "file" {
     source               = "join_k3s_master.sh"

--- a/tests/validation/tests/v3_api/resource/terraform/k3s/master/variables.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/k3s/master/variables.tf
@@ -36,3 +36,4 @@ variable "environment" {}
 variable "engine_mode" {}
 variable "instance_class" {}
 variable "max_connections" {}
+variable "optional_files" {}

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/master/instances_server.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/master/instances_server.tf
@@ -21,6 +21,16 @@ resource "aws_instance" "master" {
     "kubernetes.io/cluster/clusterid" = "owned"
   }
   provisioner "file" {
+    source      = "../../scripts/optional_write_files.sh"
+    destination = "/tmp/optional_write_files.sh"
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/optional_write_files.sh",
+      "sudo /tmp/optional_write_files.sh \"${var.optional_files}\"",
+    ]
+  }
+  provisioner "file" {
     source      = "define_node_role.sh"
     destination = "/tmp/define_node_role.sh"
   }
@@ -81,6 +91,16 @@ resource "aws_instance" "master2" {
     "kubernetes.io/cluster/clusterid" = "owned"
   }
   depends_on       = ["aws_instance.master"]
+  provisioner "file" {
+    source      = "../../scripts/optional_write_files.sh"
+    destination = "/tmp/optional_write_files.sh"
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/optional_write_files.sh",
+      "sudo /tmp/optional_write_files.sh \"${var.optional_files}\"",
+    ]
+  }
   provisioner "file" {
     source      = "define_node_role.sh"
     destination = "/tmp/define_node_role.sh"

--- a/tests/validation/tests/v3_api/resource/terraform/rke2/master/variables.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/rke2/master/variables.tf
@@ -44,3 +44,4 @@ variable "etcd_cp_nodes" {}
 variable "etcd_worker_nodes" {}
 variable "cp_only_nodes" {}
 variable "cp_worker_nodes" {}
+variable "optional_files" {}

--- a/tests/validation/tests/v3_api/resource/terraform/scripts/optional_write_files.sh
+++ b/tests/validation/tests/v3_api/resource/terraform/scripts/optional_write_files.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This script pulls raw files and writes to specified locations.
+# For example, it can be used to write HelmChartConfig or custom PSA files.
+
+
+files=$1
+
+if [ -n "$files" ]
+then
+  file_array=($(echo "$files" | tr ' ' '\n'))
+  for current_file in "${file_array[@]}"; do
+    file_location=$(echo "$current_file" | awk -F, '{print $1}')
+    mkdir -p "$(dirname "$file_location")"
+
+    raw_data=$(echo "$current_file" | awk -F, '{print $2}')
+    curl -s "$raw_data" -o "$file_location"
+  done
+
+fi

--- a/tests/validation/tests/v3_api/test_import_k3s_cluster.py
+++ b/tests/validation/tests/v3_api/test_import_k3s_cluster.py
@@ -40,6 +40,7 @@ AWS_VOLUME_SIZE = os.environ.get("AWS_VOLUME_SIZE", "8")
 RANCHER_RHEL_USERNAME = os.environ.get("RANCHER_RHEL_USERNAME")
 RANCHER_RHEL_PASSWORD = os.environ.get("RANCHER_RHEL_PASSWORD")
 K3S_CREATE_LB = os.environ.get("K3S_CREATE_LB", False)
+RANCHER_OPTIONAL_FILES = os.environ.get("RANCHER_OPTIONAL_FILES")
 
 
 def test_create_k3s_single_control_cluster():
@@ -166,7 +167,8 @@ def create_multiple_control_cluster():
                               'environment': RANCHER_RDS_ENVIRONMENT,
                               'cluster_type': RANCHER_CLUSTER_TYPE,
                               'volume_size': AWS_VOLUME_SIZE,
-                              'create_lb': str(K3S_CREATE_LB).lower()})
+                              'create_lb': str(K3S_CREATE_LB).lower(),
+                              'optional_files': RANCHER_OPTIONAL_FILES})
     print("Creating cluster")
     tf.init()
     tf.plan(out="plan_server.out")

--- a/tests/validation/tests/v3_api/test_import_rke2_cluster.py
+++ b/tests/validation/tests/v3_api/test_import_rke2_cluster.py
@@ -47,6 +47,7 @@ RKE2_CP_WORKER_NODES = os.environ.get("RKE2_CP_WORKER_NODES", 0)
 # 2=RKE2_ETCD_ONLY_NODES 3=RKE2_ETCD_CP_NODES, 4=RKE2_ETCD_WORKER_NODES,
 # 5=RKE2_CP_ONLY_NODES, 6=RKE2_CP_WORKER_NODES
 RKE2_ROLE_ORDER = os.environ.get("RKE2_ROLE_ORDER", "1,2,3,4,5,6")
+RANCHER_OPTIONAL_FILES = os.environ.get("RANCHER_OPTIONAL_FILES")
 
 
 def test_create_rancherd_multiple_control_cluster():
@@ -153,7 +154,8 @@ def create_rke2_multiple_control_cluster(cluster_type, cluster_version):
                               'etcd_worker_nodes': RKE2_ETCD_WORKER_NODES,
                               'cp_only_nodes': RKE2_CP_ONLY_NODES,
                               'cp_worker_nodes': RKE2_CP_WORKER_NODES,
-                              'role_order': RKE2_ROLE_ORDER})
+                              'role_order': RKE2_ROLE_ORDER,
+                              'optional_files': RANCHER_OPTIONAL_FILES})
     print("Creating cluster")
     tf.init()
     tf.plan(out="plan_server.out")


### PR DESCRIPTION
## Issue: N/A<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When using automation to deploy a hardened HA cluster for k3s or rke2 on Rancher 2.7.2, it requires a specialized PSA configuration as noted in https://ranchermanager.docs.rancher.com/reference-guides/rancher-security/psa-restricted-exemptions.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This enables the ability to add that specialized PSA configuration. This also gives an opportunity to add other files in, such as easier ways to fill out a config.yaml or HelmChartConfig files to customize some of the default HelmChart installs.

It can be passed through the new terraform variable, `optional_files`. This takes data in the form of a file name separated by a comma to the data it should write to the file (from a URL). More files can be passed with a space separator, e.g. `<file name 1>,<url of raw data 1> <file name 2>,<url of raw data 2>`.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Run the HA deploy test with k3s/rke2 or the k3s/rke2 creation tests.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
I have run this locally on the rke2 Go framework directly, but have yet to run it via a freeform job in Jenkins. I will do that before merging this. 

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
This is a validation test to cover HA deploys.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
N/A
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A