### PR TITLE
Add cluster-uid to the system-agent generation secret

### DIFF
--- a/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagent.go
+++ b/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagent.go
@@ -318,7 +318,8 @@ func installer(cluster *rancherv1.Cluster, secretName string) []runtime.Object {
 				Namespace: namespaces.System,
 			},
 			StringData: map[string]string{
-				"generation": strconv.Itoa(int(cluster.Spec.RedeploySystemAgentGeneration)),
+				"cluster-uid": string(cluster.UID),
+				"generation":  strconv.Itoa(int(cluster.Spec.RedeploySystemAgentGeneration)),
 			},
 		})
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/40768
 
## Problem
If the same backup operator backup is used to perform multiple migrations, the system-agent will not be updated past the first migration. This stems from the use of a "generation" integer that is incremented by the backup-operator. The issue is that the backup contains the generation as a set integer, and the value will be rolled back to that integer on restore. This poses a problem in a new cluster because SUC will not detect a plan change and thus not reinstall the system-agents on the downstream cluster.
 
## Solution
Add the UID of the clusters.provisioning.cattle.io object to the generation secret, to guarantee uniqueness. This UID will be unique between installations, which is important when using the same backup for multiple migration/restore attempts.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
I ran this and tested using the same backup and restoring multiple times.

### Automated Testing
N/A

## QA Testing Considerations
N/A
 
### Regressions Considerations
N/A