### PR TITLE
[v2.7] Separate Go tests URL from Python tests URL

### DIFF
--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -156,8 +156,8 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                 }
 
                 // AWS_USER and AWS_AMI are currently not set in the environmental variables.
-                env.CATTLE_TEST_URL = env.CATTLE_TEST_URL.replace('https://', '')
-                env.CONFIG = env.CONFIG.replace('${CATTLE_TEST_URL}', env.CATTLE_TEST_URL)
+                def GO_CATTLE_TEST_URL = env.CATTLE_TEST_URL.replace('https://', '')
+                env.CONFIG = env.CONFIG.replace('${CATTLE_TEST_URL}', "${GO_CATTLE_TEST_URL}")
                 env.CONFIG = env.CONFIG.replace('${ADMIN_TOKEN}', env.ADMIN_TOKEN)
                 env.CONFIG = env.CONFIG.replace('${AZURE_CLIENT_ID}', env.USER_TOKEN)
                 env.CONFIG = env.CONFIG.replace('${AZURE_CLIENT_SECRET}', env.AZURE_CLIENT_SECRET)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
During release testing, found that the URL for both the Go tests and Python tests are both shaving the `https://` prefix, when only that is needed for the Go tests. As a result, some Python tests are failing as they expect the `https://`. This PR fixes that issue.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Created local variable that will only use the updated URL that removes the `https://` for the Go tests only. Otherwise, it is left alone for the Python tests.
