### PR TITLE
Prepare for 2.6.12-rc2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8
-	github.com/rancher/rke v1.3.19
+	github.com/rancher/rke v1.3.20-rc3
 	github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168
 	github.com/rancher/steve v0.0.0-20230224165120-1a36a52a25b7
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007

--- a/go.sum
+++ b/go.sum
@@ -1430,8 +1430,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a h1:6xqYlVz4uAX
 github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8wJ/coee2n9ed937uPBWQArBaVlxs+5wkkS9KiyDc=
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8 h1:leqh0chjBsXhKWebxxFd5QPcoQLu51EpaHo04ce0o+8=
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
-github.com/rancher/rke v1.3.19 h1:wggsFJrNOI+0kKfMDzoZEz0MRS7lsIj0OPdJeZyE/WM=
-github.com/rancher/rke v1.3.19/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
+github.com/rancher/rke v1.3.20-rc3 h1:1yqJVBOWTwBc5HlrI3O4A7Uz6MCxIljkci7wUeQ1iJk=
+github.com/rancher/rke v1.3.20-rc3/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168 h1:SIshhsz0O71FYyyDmjUmbFGvmgp4ASm8J1zmhMK/UG0=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
 github.com/rancher/steve v0.0.0-20230224165120-1a36a52a25b7 h1:5SqYbU1q88Cpo2LUabdy0jM8oXwt3svwhVdHOSETPsY=

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -162,8 +162,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-ENV CATTLE_UI_VERSION 2.6.12-rc1
-ENV CATTLE_DASHBOARD_UI_VERSION v2.6.12-rc1
+ENV CATTLE_UI_VERSION 2.6.12-rc2
+ENV CATTLE_DASHBOARD_UI_VERSION v2.6.12-rc2
 ENV CATTLE_CLI_VERSION v2.6.11
 
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20230116113701-fc276f5505be
 	github.com/rancher/gke-operator v1.1.4
 	github.com/rancher/norman v0.0.0-20221228020905-1dcd4fa94899
-	github.com/rancher/rke v1.3.19
+	github.com/rancher/rke v1.3.20-rc3
 	github.com/rancher/wrangler v1.0.1-0.20230208234005-a59a11cc3ef5
 	github.com/sirupsen/logrus v1.8.1
 	k8s.io/api v0.25.4

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -600,8 +600,8 @@ github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc h1:29VHrInLV4qSevvcv
 github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc/go.mod h1:dEfC9eFQigj95lv/JQ8K5e7+qQCacWs1aIA6nLxKzT8=
 github.com/rancher/norman v0.0.0-20221228020905-1dcd4fa94899 h1:3y7FhdKEkewpO/BfcDdSX1HCMtMhXpsImz3pG83suEE=
 github.com/rancher/norman v0.0.0-20221228020905-1dcd4fa94899/go.mod h1:9zlHK0aLVQManRI6bpzRmuxAlTE70JKsN3JJ+PonHVk=
-github.com/rancher/rke v1.3.19 h1:wggsFJrNOI+0kKfMDzoZEz0MRS7lsIj0OPdJeZyE/WM=
-github.com/rancher/rke v1.3.19/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
+github.com/rancher/rke v1.3.20-rc3 h1:1yqJVBOWTwBc5HlrI3O4A7Uz6MCxIljkci7wUeQ1iJk=
+github.com/rancher/rke v1.3.20-rc3/go.mod h1:FYb66B2+kAJVQ80SFEr56mC9yjm7TrviK2miZG+c5qY=
 github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061/go.mod h1:n5Du/gGD7WoiqnEo0SHnPirDIp1V9Zu+6guc8lXS2dk=
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
 github.com/rancher/wrangler v0.8.10/go.mod h1:Lte9WjPtGYxYacIWeiS9qawvu2R4NujFU9xuXWJvc/0=

--- a/pkg/client/generated/management/v3/zz_generated_aci_network_provider.go
+++ b/pkg/client/generated/management/v3/zz_generated_aci_network_provider.go
@@ -23,6 +23,7 @@ const (
 	AciNetworkProviderFieldEpRegistry                        = "epRegistry"
 	AciNetworkProviderFieldGbpPodSubnet                      = "gbpPodSubnet"
 	AciNetworkProviderFieldHostAgentLogLevel                 = "hostAgentLogLevel"
+	AciNetworkProviderFieldHppOptimization                   = "hppOptimization"
 	AciNetworkProviderFieldImagePullPolicy                   = "imagePullPolicy"
 	AciNetworkProviderFieldImagePullSecret                   = "imagePullSecret"
 	AciNetworkProviderFieldInfraVlan                         = "infraVlan"
@@ -45,6 +46,8 @@ const (
 	AciNetworkProviderFieldNodeSubnet                        = "nodeSubnet"
 	AciNetworkProviderFieldOVSMemoryLimit                    = "ovsMemoryLimit"
 	AciNetworkProviderFieldOpflexAgentLogLevel               = "opflexLogLevel"
+	AciNetworkProviderFieldOpflexAgentOpflexAsyncjsonEnabled = "opflexAgentOpflexAsyncjsonEnabled"
+	AciNetworkProviderFieldOpflexAgentOvsAsyncjsonEnabled    = "opflexAgentOvsAsyncjsonEnabled"
 	AciNetworkProviderFieldOpflexClientSSL                   = "opflexClientSsl"
 	AciNetworkProviderFieldOpflexDeviceDeleteTimeout         = "opflexDeviceDeleteTimeout"
 	AciNetworkProviderFieldOpflexMode                        = "opflexMode"
@@ -59,6 +62,7 @@ const (
 	AciNetworkProviderFieldServiceGraphSubnet                = "nodeSvcSubnet"
 	AciNetworkProviderFieldServiceMonitorInterval            = "serviceMonitorInterval"
 	AciNetworkProviderFieldServiceVlan                       = "serviceVlan"
+	AciNetworkProviderFieldSleepTimeSnatGlobalInfoSync       = "sleepTimeSnatGlobalInfoSync"
 	AciNetworkProviderFieldSnatContractScope                 = "snatContractScope"
 	AciNetworkProviderFieldSnatNamespace                     = "snatNamespace"
 	AciNetworkProviderFieldSnatPortRangeEnd                  = "snatPortRangeEnd"
@@ -104,6 +108,7 @@ type AciNetworkProvider struct {
 	EpRegistry                        string              `json:"epRegistry,omitempty" yaml:"epRegistry,omitempty"`
 	GbpPodSubnet                      string              `json:"gbpPodSubnet,omitempty" yaml:"gbpPodSubnet,omitempty"`
 	HostAgentLogLevel                 string              `json:"hostAgentLogLevel,omitempty" yaml:"hostAgentLogLevel,omitempty"`
+	HppOptimization                   string              `json:"hppOptimization,omitempty" yaml:"hppOptimization,omitempty"`
 	ImagePullPolicy                   string              `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
 	ImagePullSecret                   string              `json:"imagePullSecret,omitempty" yaml:"imagePullSecret,omitempty"`
 	InfraVlan                         string              `json:"infraVlan,omitempty" yaml:"infraVlan,omitempty"`
@@ -126,6 +131,8 @@ type AciNetworkProvider struct {
 	NodeSubnet                        string              `json:"nodeSubnet,omitempty" yaml:"nodeSubnet,omitempty"`
 	OVSMemoryLimit                    string              `json:"ovsMemoryLimit,omitempty" yaml:"ovsMemoryLimit,omitempty"`
 	OpflexAgentLogLevel               string              `json:"opflexLogLevel,omitempty" yaml:"opflexLogLevel,omitempty"`
+	OpflexAgentOpflexAsyncjsonEnabled string              `json:"opflexAgentOpflexAsyncjsonEnabled,omitempty" yaml:"opflexAgentOpflexAsyncjsonEnabled,omitempty"`
+	OpflexAgentOvsAsyncjsonEnabled    string              `json:"opflexAgentOvsAsyncjsonEnabled,omitempty" yaml:"opflexAgentOvsAsyncjsonEnabled,omitempty"`
 	OpflexClientSSL                   string              `json:"opflexClientSsl,omitempty" yaml:"opflexClientSsl,omitempty"`
 	OpflexDeviceDeleteTimeout         string              `json:"opflexDeviceDeleteTimeout,omitempty" yaml:"opflexDeviceDeleteTimeout,omitempty"`
 	OpflexMode                        string              `json:"opflexMode,omitempty" yaml:"opflexMode,omitempty"`
@@ -140,6 +147,7 @@ type AciNetworkProvider struct {
 	ServiceGraphSubnet                string              `json:"nodeSvcSubnet,omitempty" yaml:"nodeSvcSubnet,omitempty"`
 	ServiceMonitorInterval            string              `json:"serviceMonitorInterval,omitempty" yaml:"serviceMonitorInterval,omitempty"`
 	ServiceVlan                       string              `json:"serviceVlan,omitempty" yaml:"serviceVlan,omitempty"`
+	SleepTimeSnatGlobalInfoSync       string              `json:"sleepTimeSnatGlobalInfoSync,omitempty" yaml:"sleepTimeSnatGlobalInfoSync,omitempty"`
 	SnatContractScope                 string              `json:"snatContractScope,omitempty" yaml:"snatContractScope,omitempty"`
 	SnatNamespace                     string              `json:"snatNamespace,omitempty" yaml:"snatNamespace,omitempty"`
 	SnatPortRangeEnd                  string              `json:"snatPortRangeEnd,omitempty" yaml:"snatPortRangeEnd,omitempty"`


### PR DESCRIPTION
RC Checklist

- [x] Charts and KDM branches are pointing to dev-2.6
- [x] UI and Dashboard versions have been bumped to `v2.6.12-rc2`
- [x] Bumped RKE version to `1.3.20-rc3` in `pkg/apis` and rancher root, ran `go mod tidy` for both. No CLI changes, continue using version `2.6.11`. 
- [x] Confirmed that GKE/EKS/AKS operators do not need to be bumped for this RC 
- [x] ran `go generate` and saw expected changes relating to new RKE RC