### PR TITLE
Prepare for `2.6.12-rc3`

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -14,7 +14,7 @@ ENV KUSTOMIZE_VERSION v5.0.1
 ENV K3D_VERSION v5.4.6
 
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
-ENV CATTLE_KDM_BRANCH=release-v2.6
+ENV CATTLE_KDM_BRANCH=dev-v2.6
 
 RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables jq skopeo
 # use containerd from k3s image, not from bci

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -162,8 +162,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-ENV CATTLE_UI_VERSION 2.6.12-rc2
-ENV CATTLE_DASHBOARD_UI_VERSION v2.6.12-rc2
+ENV CATTLE_UI_VERSION 2.6.12-rc3
+ENV CATTLE_DASHBOARD_UI_VERSION v2.6.12-rc3
 ENV CATTLE_CLI_VERSION v2.6.11
 
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.


### PR DESCRIPTION
RC Checklist

- [x] Charts and KDM branches are pointing to dev-2.6
- [x] `Dockerfile.dapper` is pointing to KDM dev-2.6  (Primary change for this RC)
    - [x] Release Docs have been updated to include this file in RC creation process and post-release operations 
- [x] UI and Dashboard versions have been bumped to `v2.6.12-rc3`
- [x] RKE still uses version `1.3.20-rc3`, CLI does not need to be updated and continues to use `2.6.11`
- [x] Confirmed that GKE/EKS/AKS operators do not need to be bumped for this RC 
- [x] ran `go generate` and saw no changes
- [x] ran `go mod tidy` in all locations and saw no updates 