### PR TITLE
Enable Okta to use OpenLDAP for user and group search

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -397,7 +397,8 @@ type KeyCloakConfig struct {
 }
 
 type OKTAConfig struct {
-	SamlConfig `json:",inline" mapstructure:",squash"`
+	SamlConfig     `json:",inline" mapstructure:",squash"`
+	OpenLdapConfig LdapFields `json:"openLdapConfig" mapstructure:",squash"`
 }
 
 type ShibbolethConfig struct {

--- a/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -6776,6 +6776,7 @@ func (in *OIDCTestOutput) DeepCopy() *OIDCTestOutput {
 func (in *OKTAConfig) DeepCopyInto(out *OKTAConfig) {
 	*out = *in
 	in.SamlConfig.DeepCopyInto(&out.SamlConfig)
+	in.OpenLdapConfig.DeepCopyInto(&out.OpenLdapConfig)
 	return
 }
 

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -388,16 +388,18 @@ func (s *Provider) combineSamlAndLdapConfig(config *v32.SamlConfig) runtime.Obje
 			SamlConfig:     samlConfig,
 			OpenLdapConfig: ldapConfig.LdapFields,
 		}
+	case OKTAName:
+		fullConfig = &v32.OKTAConfig{
+			SamlConfig:     samlConfig,
+			OpenLdapConfig: ldapConfig.LdapFields,
+		}
 	}
 
 	return fullConfig
 }
 
 func (s *Provider) hasLdapGroupSearch() bool {
-	if s.name == ShibbolethName {
-		return true
-	}
-	return false
+	return ShibbolethName == s.name || OKTAName == s.name
 }
 
 func (s *Provider) GetUserExtraAttributes(userPrincipal v3.Principal) map[string][]string {

--- a/pkg/client/generated/management/v3/zz_generated_okta_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_okta_config.go
@@ -14,6 +14,7 @@ const (
 	OKTAConfigFieldIDPMetadataContent  = "idpMetadataContent"
 	OKTAConfigFieldLabels              = "labels"
 	OKTAConfigFieldName                = "name"
+	OKTAConfigFieldOpenLdapConfig      = "openLdapConfig"
 	OKTAConfigFieldOwnerReferences     = "ownerReferences"
 	OKTAConfigFieldRancherAPIHost      = "rancherApiHost"
 	OKTAConfigFieldRemoved             = "removed"
@@ -38,6 +39,7 @@ type OKTAConfig struct {
 	IDPMetadataContent  string            `json:"idpMetadataContent,omitempty" yaml:"idpMetadataContent,omitempty"`
 	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`
+	OpenLdapConfig      *LdapFields       `json:"openLdapConfig,omitempty" yaml:"openLdapConfig,omitempty"`
 	OwnerReferences     []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
 	RancherAPIHost      string            `json:"rancherApiHost,omitempty" yaml:"rancherApiHost,omitempty"`
 	Removed             string            `json:"removed,omitempty" yaml:"removed,omitempty"`


### PR DESCRIPTION
## Issue: rancher/rancher#38029 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
SAML does not offer an interface for searching for principals. Therefore, in order to allow such a search, it would be necessary to use a separate mechanism, similar to how the Shibboleth provider currently works with OpenLDAP-powered search.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Change the backend to use the same logic currently in-use by Shibboleth to allow the Okta provider to also search for principals in an OpenLDAP backend.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
#### Scenario: enable the Okta provider without OpenLDAP
* Enabled the Okta provider without OpenLDAP.
* Checked that groups list when clicking the principal box and can be selected, but no users appear.
* Checked that upon typing a username a principal is generated and is available to select, but no actual search happens.

#### Scenario: enable the Okta provider with OpenLDAP
* Enabled the Okta provider with OpenLDAP, providing information on an OpenLDAP server.
* Checked that it's possible to search for principals and both users and groups matching the search appear.
* Checked that it's possible to select a principal and have permissions granted to them.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Automated testing will be added in a subsequent PR.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
* Fresh enablement of the Okta provider.
* Disabling/re-enabling the Okta provider.
* Functionality stays as-is when the OpenLDAP option is not selected.
* Disabling OpenLDAP does not remove permissions from users that had them granted when OpenLDAP was enabled.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->