### PR TITLE
Update Rancher Version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Rancher is an open source container management platform built for organizations 
 
 ## Latest Release
 * v2.7
-  * Latest - v2.7.2 - `rancher/rancher:v2.7.2` / `rancher/rancher:latest` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.7.2).
-  * Stable - v2.7.2 - `rancher/rancher:v2.7.2` / `rancher/rancher:stable` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.7.2).
+  * Latest - v2.7.3 - `rancher/rancher:v2.7.3` / `rancher/rancher:latest` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.7.3).
+  * Stable - v2.7.3 - `rancher/rancher:v2.7.3` / `rancher/rancher:stable` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.7.3).
 * v2.6
   * Latest - v2.6.11 - `rancher/rancher:v2.6.11` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.6.11).
   * Stable - v2.6.11 - `rancher/rancher:v2.6.11` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.6.11).


### PR DESCRIPTION
The Github Action to update the README does not work since the v2.7.3 was tagged on aa different branch.