### PR TITLE
adding patchtokens to extensions/kubeapi

### DIFF
--- a/tests/framework/extensions/kubeapi/tokens/patchtokens.go
+++ b/tests/framework/extensions/kubeapi/tokens/patchtokens.go
@@ -1,0 +1,49 @@
+package tokens
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var TokenGroupVersionResource = schema.GroupVersionResource{
+	Group:    "management.cattle.io",
+	Version:  "v3",
+	Resource: "tokens",
+}
+
+// PatchToken is a helper function that uses the dynamic client to patch a token by its name.
+// Different token operations are supported: add, replace, remove.
+func PatchToken(client *rancher.Client, clusterID, tokenName, patchOp, patchPath, patchData string) (*v3.Token, *unstructured.Unstructured, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tokenResource := dynamicClient.Resource(TokenGroupVersionResource)
+
+	patchJSONOperation := fmt.Sprintf(`
+	[
+	  { "op": "%v", "path": "%v", "value": "%v" }
+	]
+	`, patchOp, patchPath, patchData)
+
+	unstructuredResp, err := tokenResource.Patch(context.TODO(), tokenName, types.JSONPatchType, []byte(patchJSONOperation), metav1.PatchOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	newToken := &v3.Token{}
+	err = scheme.Scheme.Convert(unstructuredResp, newToken, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, nil, err
+	}
+	return newToken, unstructuredResp, nil
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

backport surrounding this issue: https://github.com/rancher/qa-tasks/issues/673
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When creating a token , there was no validation happening by default and groupPrincipals is setting as null. When trying to edit that token , it's not allowing to save the token yaml.  

The fix wasn't backported by dev. So this isn't a full backport of the test. But bringing in the patchtokens functionality to 2.6 as requested by @igomez06 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Created a PatchToken in extensions/kubeapi, and testing that patching a created token is successful
 