### PR TITLE
remove testing.T from default.go extension

### DIFF
--- a/tests/framework/extensions/clusters/kubernetesversions/default.go
+++ b/tests/framework/extensions/clusters/kubernetesversions/default.go
@@ -2,20 +2,21 @@ package kubernetesversions
 
 import (
 	"fmt"
-	"testing"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
 )
 
-func Default(t *testing.T, client *rancher.Client, provider string, kubernetesVersions []string) ([]string, error) {
+func Default(client *rancher.Client, provider string, kubernetesVersions []string) ([]string, error) {
 
 	switch {
 	case provider == clusters.RKE1ClusterType.String():
 		default_version_data, err := client.Management.Setting.ByID("k8s-version")
-		require.NoError(t, err)
+
+		if err != nil {
+			return nil, err
+		}
 
 		default_version := default_version_data.Value
 		logrus.Infof("default rke1 kubernetes version is: %v", default_version)
@@ -32,7 +33,10 @@ func Default(t *testing.T, client *rancher.Client, provider string, kubernetesVe
 
 	case provider == clusters.RKE2ClusterType.String():
 		default_version_data, err := client.Management.Setting.ByID("rke2-default-version")
-		require.NoError(t, err)
+
+		if err != nil {
+			return nil, err
+		}
 
 		default_version := `v` + default_version_data.Value
 		logrus.Infof("default rke2 kubernetes version is: %v", default_version)
@@ -49,7 +53,10 @@ func Default(t *testing.T, client *rancher.Client, provider string, kubernetesVe
 
 	case provider == clusters.K3SClusterType.String():
 		default_version_data, err := client.Management.Setting.ByID("k3s-default-version")
-		require.NoError(t, err)
+
+		if err != nil {
+			return nil, err
+		}
 
 		default_version := `v` + default_version_data.Value
 		logrus.Infof("default k3s kubernetes version is: %v", default_version)

--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -47,7 +47,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 
 	c.client = client
 
-	c.kubernetesVersions, err = kubernetesversions.Default(c.T(), c.client, clusters.K3SClusterType.String(), c.kubernetesVersions)
+	c.kubernetesVersions, err = kubernetesversions.Default(c.client, clusters.K3SClusterType.String(), c.kubernetesVersions)
 	require.NoError(c.T(), err)
 
 	enabled := true

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
@@ -46,7 +46,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) SetupSuite() {
 
 	k.client = client
 
-	k.kubernetesVersions, err = kubernetesversions.Default(k.T(), k.client, clusters.K3SClusterType.String(), k.kubernetesVersions)
+	k.kubernetesVersions, err = kubernetesversions.Default(k.client, clusters.K3SClusterType.String(), k.kubernetesVersions)
 	require.NoError(k.T(), err)
 
 	enabled := true

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -47,7 +47,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 
 	c.client = client
 
-	c.kubernetesVersions, err = kubernetesversions.Default(c.T(), c.client, clusters.RKE1ClusterType.String(), c.kubernetesVersions)
+	c.kubernetesVersions, err = kubernetesversions.Default(c.client, clusters.RKE1ClusterType.String(), c.kubernetesVersions)
 	require.NoError(c.T(), err)
 
 	enabled := true

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -50,7 +50,7 @@ func (r *RKE1NodeDriverProvisioningTestSuite) SetupSuite() {
 
 	r.client = client
 
-	r.kubernetesVersions, err = kubernetesversions.Default(r.T(), r.client, clusters.RKE1ClusterType.String(), r.kubernetesVersions)
+	r.kubernetesVersions, err = kubernetesversions.Default(r.client, clusters.RKE1ClusterType.String(), r.kubernetesVersions)
 	require.NoError(r.T(), err)
 
 	enabled := true

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -49,7 +49,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 
 	c.client = client
 
-	c.kubernetesVersions, err = kubernetesversions.Default(c.T(), c.client, clusters.RKE2ClusterType.String(), c.kubernetesVersions)
+	c.kubernetesVersions, err = kubernetesversions.Default(c.client, clusters.RKE2ClusterType.String(), c.kubernetesVersions)
 	require.NoError(c.T(), err)
 
 	enabled := true

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -48,7 +48,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 
 	r.client = client
 
-	r.kubernetesVersions, err = kubernetesversions.Default(r.T(), r.client, clusters.RKE2ClusterType.String(), r.kubernetesVersions)
+	r.kubernetesVersions, err = kubernetesversions.Default(r.client, clusters.RKE2ClusterType.String(), r.kubernetesVersions)
 	require.NoError(r.T(), err)
 
 	enabled := true


### PR DESCRIPTION
Continuation of https://github.com/rancher/rancher/pull/41287

Addresses request for qa-task- 608, to remove testing.T from `extensions > clusters > kubernetesversions > default.go`