### PR TITLE
Allow etcd snapshot restoration on a fresh set of etcd nodes

### DIFF
--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -356,12 +356,12 @@ func (h *handler) updateStatus(objs []runtime.Object, cluster *v1.Cluster, statu
 			ready = true
 		}
 		for _, messageCond := range existing.Status.Conditions {
-			if messageCond.Type == "Updated" || messageCond.Type == "Provisioned" || messageCond.Type == "Removed" || messageCond.Type == "Ready" {
+			if messageCond.Type == "Updated" || messageCond.Type == "Provisioned" || messageCond.Type == "Removed" || (cluster.Spec.RKEConfig != nil && messageCond.Type == "Ready") {
 				// Don't copy these conditions from v3 management object to the v1 provisioning object. This is because we copy these specific conditions from other places and we need to prevent clobbering.
 				// Updated - This is copied from the rkecontrolplane Ready condition to the v1 object by the rke2/provisioningcluster/controller.go via the reconcile function
 				// Provisioned - This is copied from the rkecontrolplane Ready condition to the v1 object by the rke2/provisioningcluster/controller.go via the reconcile function
 				// Removed - This is copied from the rkecontrolplane Removed condition on rkecontrolplane deletion.
-				// Ready - This is copied from the rkecontrolplane Ready condition (if cluster is not stable) or v3/management cluster Ready condition (if cluster is stable) by the rke2/provisioningcluster/controller.go via the reconcile function
+				// Ready - Conditionally, if RKEConfig != nil. This is copied from the rkecontrolplane Ready condition (if cluster is not stable) or v3/management cluster Ready condition (if cluster is stable) by the rke2/provisioningcluster/controller.go via the reconcile function
 				continue
 			}
 

--- a/pkg/controllers/provisioningv2/cluster/controller.go
+++ b/pkg/controllers/provisioningv2/cluster/controller.go
@@ -356,7 +356,12 @@ func (h *handler) updateStatus(objs []runtime.Object, cluster *v1.Cluster, statu
 			ready = true
 		}
 		for _, messageCond := range existing.Status.Conditions {
-			if messageCond.Type == "Updated" || messageCond.Type == "Provisioned" || messageCond.Type == "Removed" {
+			if messageCond.Type == "Updated" || messageCond.Type == "Provisioned" || messageCond.Type == "Removed" || messageCond.Type == "Ready" {
+				// Don't copy these conditions from v3 management object to the v1 provisioning object. This is because we copy these specific conditions from other places and we need to prevent clobbering.
+				// Updated - This is copied from the rkecontrolplane Ready condition to the v1 object by the rke2/provisioningcluster/controller.go via the reconcile function
+				// Provisioned - This is copied from the rkecontrolplane Ready condition to the v1 object by the rke2/provisioningcluster/controller.go via the reconcile function
+				// Removed - This is copied from the rkecontrolplane Removed condition on rkecontrolplane deletion.
+				// Ready - This is copied from the rkecontrolplane Ready condition (if cluster is not stable) or v3/management cluster Ready condition (if cluster is stable) by the rke2/provisioningcluster/controller.go via the reconcile function
 				continue
 			}
 
@@ -399,9 +404,6 @@ func (h *handler) updateStatus(objs []runtime.Object, cluster *v1.Cluster, statu
 			return nil, status, err
 		}
 		if secret != nil {
-			if secret.UID == "" {
-				objs = append(objs, secret)
-			}
 			status.ClientSecretName = secret.Name
 
 			if features.MCM.Enabled() {

--- a/pkg/controllers/provisioningv2/rke2/bootstrap/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/bootstrap/controller.go
@@ -442,7 +442,8 @@ func (h *handler) OnRemove(key string, bootstrap *rkev1.RKEBootstrap) (*rkev1.RK
 		return bootstrap, err
 	}
 
-	if cp.DeletionTimestamp != nil {
+	// The controlplane is owned by the capi cluster and will not be deleted until the capi cluster is deleted.
+	if cp.DeletionTimestamp != nil || capiCluster.DeletionTimestamp != nil {
 		return h.removeMachinePreTerminateAnnotation(bootstrap, machine)
 	}
 

--- a/pkg/controllers/provisioningv2/rke2/bootstrap/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/bootstrap/controller.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -440,9 +439,6 @@ func (h *handler) OnRemove(key string, bootstrap *rkev1.RKEBootstrap) (*rkev1.RK
 
 	kcSecret, err := h.secretCache.Get(bootstrap.Namespace, secret.Name(clusterName, secret.Kubeconfig))
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return bootstrap, fmt.Errorf("error retrieving kubeconfig secret %s/%s: %v", bootstrap.Namespace, secret.Name(clusterName, secret.Kubeconfig), err)
-		}
 		return bootstrap, err
 	}
 

--- a/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
+++ b/pkg/controllers/provisioningv2/rke2/managesystemagent/managesystemagentplan.go
@@ -100,7 +100,7 @@ func (h *handler) syncSystemUpgradeControllerStatus(obj *rkev1.RKEControlPlane, 
 			rke2.SystemUpgradeControllerReady.Message(&status, "")
 			rke2.SystemUpgradeControllerReady.False(&status)
 			// don't return the error, otherwise the status won't be set to 'false'
-			err = nil
+			return status, nil
 		}
 		logrus.Errorf("[managesystemagentplan] rkecluster %s/%s: error encountered while retrieving bundle %s: %v", obj.Namespace, obj.Name, bundleName, err)
 		return status, err

--- a/pkg/controllers/provisioningv2/rke2/planner/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/planner/controller.go
@@ -104,7 +104,7 @@ func (h *handler) OnChange(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPla
 			// If the Reconciled condition is already true and the error was NOT an errIgnore/ErrSkip/ErrWaiting and the status.AppliedSpec (from planner.Process) does not match the controlplane spec, set reconciled to unknown.
 			if !equality.Semantic.DeepEqual(cp.Spec, status.AppliedSpec) {
 				rke2.Reconciled.SetStatus(&status, "Unknown")
-				rke2.Reconciled.Message(&status, "reconciling control plane")
+				rke2.Reconciled.Message(&status, "RKEControlPlane has not been fully reconciled yet")
 				rke2.Reconciled.Reason(&status, "Waiting")
 			}
 			return status, nil
@@ -122,12 +122,12 @@ func (h *handler) OnChange(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPla
 	}
 	// No error encountered during planner.Process
 	logrus.Debugf("[planner] rkecluster %s/%s: reconciliation complete", cp.Namespace, cp.Name)
-	rke2.Provisioned.True(&status)
-	rke2.Provisioned.Message(&status, "")
-	rke2.Provisioned.Reason(&status, "")
 	rke2.Ready.True(&status)
 	rke2.Ready.Message(&status, "")
 	rke2.Ready.Reason(&status, "")
+	rke2.Stable.True(&status)
+	rke2.Stable.Message(&status, "")
+	rke2.Stable.Reason(&status, "")
 	status.AppliedSpec = &cp.Spec
 	rke2.Reconciled.True(&status)
 	rke2.Reconciled.Message(&status, "")

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -399,7 +399,7 @@ func (h *handler) retrieveMgmtClusterFromCache(cluster *rancherv1.Cluster) (*api
 // reconcileCondition accepts an object, a condition to reconcile on the object, and the status/reason/message to reconcile.
 // It returns a boolean indicating whether the condition was changed.
 func reconcileCondition(to interface{}, toCondition condition.Cond, from interface{}, fromCondition condition.Cond) bool {
-	if fromCondition.GetStatus(from) != toCondition.GetStatus(to) || fromCondition.GetReason(from) != toCondition.GetMessage(to) || fromCondition.GetMessage(from) != toCondition.GetMessage(to) {
+	if fromCondition.GetStatus(from) != toCondition.GetStatus(to) || fromCondition.GetReason(from) != toCondition.GetReason(to) || fromCondition.GetMessage(from) != toCondition.GetMessage(to) {
 		toCondition.SetStatus(to, fromCondition.GetStatus(from))
 		toCondition.Reason(to, fromCondition.GetReason(from))
 		toCondition.Message(to, fromCondition.GetMessage(from))

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -28,10 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const (
@@ -343,11 +340,30 @@ func (h *handler) OnRancherClusterChange(obj *rancherv1.Cluster, status rancherv
 				}
 			}
 		}
-		logrus.Debugf("rkecluster %s/%s: updating cluster provisioning status", obj.Namespace, obj.Name)
-		if status, err = h.setProvisionedStatusFromMachineInfra(obj, status, rkeCP); err != nil && !apierror.IsNotFound(err) && !errors.Is(err, generic.ErrSkip) {
-			return nil, status, err
-		} else if err == nil {
-			if status, err = h.updateClusterProvisioningStatus(obj, status, rkeCP, rke2.Updated, rke2.Ready); err != nil && !apierror.IsNotFound(err) {
+		mgmtCluster, err := h.retrieveMgmtClusterFromCache(obj)
+		if err != nil {
+			// don't return because the management cluster condition updating should not be blocking
+			logrus.Errorf("rkecluster %s/%s: error while retrieving management cluster from cache: %v", obj.Namespace, obj.Name, err)
+		}
+		if mgmtCluster != nil {
+			reconcileCondition(mgmtCluster, rke2.Updated, rkeCP, rke2.Ready)
+			reconcileCondition(mgmtCluster, rke2.Provisioned, rkeCP, rke2.Provisioned) // This was originally set by checking machine provisioning, but now we simply set it to true.
+		}
+
+		reconcileCondition(&status, rke2.Updated, rkeCP, rke2.Ready)
+		reconcileCondition(&status, rke2.Provisioned, rkeCP, rke2.Ready)
+
+		// If the Stable condition is not true, then copy the Ready condition from the rkeControlPlane to the v1.Clusters object
+		// Otherwise, use the v3 clusters Ready condition.
+		if !rke2.Stable.IsTrue(rkeCP) {
+			// Set the Ready condition on the v1.cluster to the controlplane Ready status
+			reconcileCondition(&status, rke2.Ready, rkeCP, rke2.Ready)
+		} else if mgmtCluster != nil {
+			reconcileCondition(&status, rke2.Ready, mgmtCluster, rke2.Ready)
+		}
+		if mgmtCluster != nil {
+			_, err := h.mgmtClusterClient.Update(mgmtCluster)
+			if err != nil {
 				return nil, status, err
 			}
 		}
@@ -379,73 +395,31 @@ func (h *handler) getRKEControlPlaneForCluster(cluster *rancherv1.Cluster) (*rke
 	return cp, nil
 }
 
-// updateClusterProvisioningStatus copies the condition (clusterCondition) to both the clusters.management.cattle.io and clusters.provisioning.cattle.io objects based on the passed in rkecontrolplane cp + cpCondition
-func (h *handler) updateClusterProvisioningStatus(cluster *rancherv1.Cluster, status rancherv1.ClusterStatus, cp *rkev1.RKEControlPlane, clusterCondition, cpCondition condition.Cond) (rancherv1.ClusterStatus, error) {
-	if cp == nil {
-		return status, fmt.Errorf("error while updating cluster provisioning status - rkecontrolplane was nil")
+// retrieveMgmtClusterFromCache retrieves an editable copy of the v3.Clusters object from the mgmtCache
+func (h *handler) retrieveMgmtClusterFromCache(cluster *rancherv1.Cluster) (*apimgmtv3.Cluster, error) {
+	if cluster == nil {
+		return nil, fmt.Errorf("cluster was nil")
 	}
-	if h.mgmtClusterCache != nil {
-		mgmtCluster, err := h.mgmtClusterCache.Get(cluster.Status.ClusterName)
-		if err != nil {
-			return status, err
-		}
-
-		if cpCondition.GetStatus(cp) != clusterCondition.GetStatus(mgmtCluster) || cpCondition.GetMessage(cp) != clusterCondition.GetMessage(mgmtCluster) {
-			mgmtCluster = mgmtCluster.DeepCopy()
-
-			clusterCondition.SetStatus(mgmtCluster, cpCondition.GetStatus(cp))
-			clusterCondition.Reason(mgmtCluster, cpCondition.GetReason(cp))
-			clusterCondition.Message(mgmtCluster, cpCondition.GetMessage(cp))
-
-			if _, err = h.mgmtClusterClient.Update(mgmtCluster); err != nil {
-				return status, err
-			}
-		}
+	if h.mgmtClusterCache == nil {
+		return nil, fmt.Errorf("management cluster cache was nil")
 	}
-
-	clusterCondition.SetStatus(&status, cpCondition.GetStatus(cp))
-	clusterCondition.Reason(&status, cpCondition.GetReason(cp))
-	clusterCondition.Message(&status, cpCondition.GetMessage(cp))
-
-	return status, nil
+	mgmtCluster, err := h.mgmtClusterCache.Get(cluster.Status.ClusterName)
+	if err != nil {
+		return nil, err
+	}
+	return mgmtCluster.DeepCopy(), nil
 }
 
-// setProvisionedStatusFromMachineInfra sets the cluster provisioning status based on the machine infrastructure provisioning status.
-// The cluster is considered provisioned if all the machine infrastructure is provisioned.
-// This is required because the CAPI controllers used the proxied kubeconfig to communicate with the downstream cluster,
-// and this proxy is not available until the cluster's Provisioned condition is set to true.
-func (h *handler) setProvisionedStatusFromMachineInfra(cluster *rancherv1.Cluster, clusterStatus rancherv1.ClusterStatus, cp *rkev1.RKEControlPlane) (rancherv1.ClusterStatus, error) {
-	if cluster == nil || cp == nil || rke2.Provisioned.IsTrue(cluster) {
-		return clusterStatus, nil
+// reconcileCondition accepts an object, a condition to reconcile on the object, and the status/reason/message to reconcile.
+// It returns a boolean indicating whether the condition was changed.
+func reconcileCondition(to interface{}, toCondition condition.Cond, from interface{}, fromCondition condition.Cond) bool {
+	if fromCondition.GetStatus(from) != toCondition.GetStatus(to) || fromCondition.GetReason(from) != toCondition.GetMessage(to) || fromCondition.GetMessage(from) != toCondition.GetMessage(to) {
+		toCondition.SetStatus(to, fromCondition.GetStatus(from))
+		toCondition.Reason(to, fromCondition.GetReason(from))
+		toCondition.Message(to, fromCondition.GetMessage(from))
+		return true
 	}
-
-	machines, err := h.capiMachineCache.List(cluster.Namespace, labels.SelectorFromSet(labels.Set{capi.ClusterLabelName: cluster.Name}))
-	if err != nil {
-		return clusterStatus, err
-	} else if len(machines) == 0 {
-		return clusterStatus, generic.ErrSkip
-	}
-
-	for _, machine := range machines {
-		if !machine.DeletionTimestamp.IsZero() || rke2.InfrastructureReady.IsTrue(machine) {
-			continue
-		}
-
-		clusterStatus, err = h.updateClusterProvisioningStatus(cluster, clusterStatus, cp, rke2.Provisioned, rke2.Ready)
-		if err != nil {
-			return clusterStatus, err
-		}
-
-		return clusterStatus, generic.ErrSkip
-	}
-
-	// Set the Provisioned condition to true on the control plane and use this to set the Provisioned condition to true on the cluster objects.
-	cp = cp.DeepCopy()
-	rke2.Provisioned.SetStatus(cp, "True")
-	rke2.Provisioned.Message(cp, "")
-	rke2.Provisioned.Reason(cp, "")
-
-	return h.updateClusterProvisioningStatus(cluster, clusterStatus, cp, rke2.Provisioned, rke2.Provisioned)
+	return false
 }
 
 func (h *handler) OnRemove(_ string, cluster *rancherv1.Cluster) (*rancherv1.Cluster, error) {
@@ -458,14 +432,28 @@ func (h *handler) OnRemove(_ string, cluster *rancherv1.Cluster) (*rancherv1.Clu
 		return cluster, err
 	}
 
-	status := *cluster.Status.DeepCopy()
-	status, err = h.updateClusterProvisioningStatus(cluster, status, rkeCP, rke2.Removed, rke2.Removed)
-	if apierror.IsNotFound(err) {
-		return cluster, nil
-	} else if err != nil {
-		return cluster, err
+	// Check to see if the management cluster still exists. If it exists, copy the Removed condition from the
+	// controlplane to the object. If it does not exist, allow the v1 Cluster object to be removed.
+	mgmtCluster, err := h.retrieveMgmtClusterFromCache(cluster)
+	if err != nil {
+		if apierror.IsNotFound(err) {
+			// go ahead and proceed with removal
+			return cluster, nil
+		}
+		logrus.Errorf("rkecluster %s/%s: error retrieving management cluster during removal of cluster: %v", cluster.Namespace, cluster.Name, err)
+	}
+	if mgmtCluster != nil {
+		reconcileCondition(&mgmtCluster, rke2.Removed, rkeCP, rke2.Removed)
+		_, err = h.mgmtClusterClient.Update(mgmtCluster)
+		if apierror.IsNotFound(err) {
+			return cluster, nil
+		} else if err != nil {
+			return cluster, err
+		}
 	}
 
+	status := *cluster.Status.DeepCopy()
+	reconcileCondition(&status, rke2.Removed, rkeCP, rke2.Removed)
 	cluster.Status = status
 	cluster, err = h.clusterController.UpdateStatus(cluster)
 	if err != nil {

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -2,7 +2,6 @@ package provisioningcluster
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -221,20 +220,7 @@ func (h *handler) findSnapshotClusterSpec(snapshotNamespace, snapshotName string
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving etcdsnapshot %s/%s: %w", snapshotNamespace, snapshotName, err)
 	}
-	if snapshot.SnapshotFile.Metadata != "" {
-		var md map[string]string
-		b, err := base64.StdEncoding.DecodeString(snapshot.SnapshotFile.Metadata)
-		if err != nil {
-			return nil, err
-		}
-		if err := json.Unmarshal(b, &md); err != nil {
-			return nil, err
-		}
-		if v, ok := md["provisioning-cluster-spec"]; ok {
-			return rke2.DecompressClusterSpec(v)
-		}
-	}
-	return nil, fmt.Errorf("unable to find and decode snapshot ClusterSpec for snapshot %s/%s", snapshotNamespace, snapshotName)
+	return rke2.ParseSnapshotClusterSpecOrError(snapshot)
 }
 
 // reconcileClusterSpecEtcdRestore reconciles the cluster against the desiredSpec, but only sets fields that should be set

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller.go
@@ -354,16 +354,6 @@ func (h *handler) OnRancherClusterChange(obj *rancherv1.Cluster, status rancherv
 				return nil, status, err
 			}
 		}
-	} else {
-		// Copy the Ready condition from the management cluster to the provisioning cluster
-		// This is going to occur for all clusters that do NOT have an RKEControlPlane associated with them (imported, RKE1, etc)
-		if mgmtCluster != nil {
-			reconcileCondition(&status, rke2.Ready, mgmtCluster, rke2.Ready)
-			_, err := h.mgmtClusterClient.Update(mgmtCluster)
-			if err != nil {
-				return nil, status, err
-			}
-		}
 	}
 
 	objs, err := objects(obj, h.dynamic, h.dynamicSchema, h.secretCache)

--- a/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller_test.go
+++ b/pkg/controllers/provisioningv2/rke2/provisioningcluster/controller_test.go
@@ -1,0 +1,352 @@
+package provisioningcluster
+
+import (
+	"testing"
+
+	"github.com/rancher/wrangler/pkg/condition"
+	"github.com/rancher/wrangler/pkg/genericcondition"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProvisioningClusterController_reconcileConditions(t *testing.T) {
+	type dummyObject struct {
+		Status struct {
+			Conditions []genericcondition.GenericCondition
+		}
+	}
+	type args struct {
+		conditionA                       condition.Cond
+		conditionB                       condition.Cond
+		objectAConditionAMessage         string
+		objectAConditionAReason          string
+		objectAConditionAStatus          string
+		objectBConditionAMessage         string
+		objectBConditionAReason          string
+		objectBConditionAStatus          string
+		objectAConditionBMessage         string
+		objectAConditionBReason          string
+		objectAConditionBStatus          string
+		objectBConditionBMessage         string
+		objectBConditionBReason          string
+		objectBConditionBStatus          string
+		expectedObjectAConditionAMessage string
+		expectedObjectAConditionAReason  string
+		expectedObjectAConditionAStatus  string
+		expectedObjectBConditionAMessage string
+		expectedObjectBConditionAReason  string
+		expectedObjectBConditionAStatus  string
+		expectedObjectAConditionBMessage string
+		expectedObjectAConditionBReason  string
+		expectedObjectAConditionBStatus  string
+		expectedObjectBConditionBMessage string
+		expectedObjectBConditionBReason  string
+		expectedObjectBConditionBStatus  string
+		expectChange                     bool
+	}
+
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "basic copy",
+			args: args{
+				conditionA:                       condition.Cond("conditionA"),
+				conditionB:                       condition.Cond("conditionB"),
+				objectAConditionAMessage:         "myMessage",
+				objectAConditionAReason:          "myReason",
+				objectAConditionAStatus:          "myStatus",
+				objectBConditionAMessage:         "",
+				objectBConditionAReason:          "",
+				objectBConditionAStatus:          "",
+				objectAConditionBMessage:         "",
+				objectAConditionBReason:          "",
+				objectAConditionBStatus:          "",
+				objectBConditionBMessage:         "",
+				objectBConditionBReason:          "",
+				objectBConditionBStatus:          "",
+				expectedObjectAConditionAMessage: "myMessage",
+				expectedObjectAConditionAReason:  "myReason",
+				expectedObjectAConditionAStatus:  "myStatus",
+				expectedObjectBConditionAMessage: "",
+				expectedObjectBConditionAReason:  "",
+				expectedObjectBConditionAStatus:  "",
+				expectedObjectAConditionBMessage: "",
+				expectedObjectAConditionBReason:  "",
+				expectedObjectAConditionBStatus:  "",
+				expectedObjectBConditionBMessage: "myMessage",
+				expectedObjectBConditionBReason:  "myReason",
+				expectedObjectBConditionBStatus:  "myStatus",
+				expectChange:                     true,
+			},
+		},
+		{
+			name: "basic erase",
+			args: args{
+				conditionA:                       condition.Cond("conditionA"),
+				conditionB:                       condition.Cond("conditionB"),
+				objectAConditionAMessage:         "",
+				objectAConditionAReason:          "",
+				objectAConditionAStatus:          "",
+				objectBConditionAMessage:         "",
+				objectBConditionAReason:          "",
+				objectBConditionAStatus:          "",
+				objectAConditionBMessage:         "",
+				objectAConditionBReason:          "",
+				objectAConditionBStatus:          "",
+				objectBConditionBMessage:         "myMessage",
+				objectBConditionBReason:          "myReason",
+				objectBConditionBStatus:          "myStatus",
+				expectedObjectAConditionAMessage: "",
+				expectedObjectAConditionAReason:  "",
+				expectedObjectAConditionAStatus:  "",
+				expectedObjectBConditionAMessage: "",
+				expectedObjectBConditionAReason:  "",
+				expectedObjectBConditionAStatus:  "",
+				expectedObjectAConditionBMessage: "",
+				expectedObjectAConditionBReason:  "",
+				expectedObjectAConditionBStatus:  "",
+				expectedObjectBConditionBMessage: "",
+				expectedObjectBConditionBReason:  "",
+				expectedObjectBConditionBStatus:  "",
+				expectChange:                     true,
+			},
+		},
+		{
+			name: "basic overwrite",
+			args: args{
+				conditionA:                       condition.Cond("conditionA"),
+				conditionB:                       condition.Cond("conditionB"),
+				objectAConditionAMessage:         "wow",
+				objectAConditionAReason:          "wowreason",
+				objectAConditionAStatus:          "wowstatus",
+				objectBConditionAMessage:         "",
+				objectBConditionAReason:          "",
+				objectBConditionAStatus:          "",
+				objectAConditionBMessage:         "",
+				objectAConditionBReason:          "",
+				objectAConditionBStatus:          "",
+				objectBConditionBMessage:         "myMessage",
+				objectBConditionBReason:          "myReason",
+				objectBConditionBStatus:          "myStatus",
+				expectedObjectAConditionAMessage: "wow",
+				expectedObjectAConditionAReason:  "wowreason",
+				expectedObjectAConditionAStatus:  "wowstatus",
+				expectedObjectBConditionAMessage: "",
+				expectedObjectBConditionAReason:  "",
+				expectedObjectBConditionAStatus:  "",
+				expectedObjectAConditionBMessage: "",
+				expectedObjectAConditionBReason:  "",
+				expectedObjectAConditionBStatus:  "",
+				expectedObjectBConditionBMessage: "wow",
+				expectedObjectBConditionBReason:  "wowreason",
+				expectedObjectBConditionBStatus:  "wowstatus",
+				expectChange:                     true,
+			},
+		},
+		{
+			name: "copy around other conditions",
+			args: args{
+				conditionA:                       condition.Cond("conditionA"),
+				conditionB:                       condition.Cond("conditionB"),
+				objectAConditionAMessage:         "myMessage",
+				objectAConditionAReason:          "myReason",
+				objectAConditionAStatus:          "myStatus",
+				objectBConditionAMessage:         "donttouch",
+				objectBConditionAReason:          "thiscondition",
+				objectBConditionAStatus:          "becauseifyoudoitsbroken",
+				objectAConditionBMessage:         "orthisone",
+				objectAConditionBReason:          "andthisone",
+				objectAConditionBStatus:          "alsothisone",
+				objectBConditionBMessage:         "",
+				objectBConditionBReason:          "",
+				objectBConditionBStatus:          "",
+				expectedObjectAConditionAMessage: "myMessage",
+				expectedObjectAConditionAReason:  "myReason",
+				expectedObjectAConditionAStatus:  "myStatus",
+				expectedObjectBConditionAMessage: "donttouch",
+				expectedObjectBConditionAReason:  "thiscondition",
+				expectedObjectBConditionAStatus:  "becauseifyoudoitsbroken",
+				expectedObjectAConditionBMessage: "orthisone",
+				expectedObjectAConditionBReason:  "andthisone",
+				expectedObjectAConditionBStatus:  "alsothisone",
+				expectedObjectBConditionBMessage: "myMessage",
+				expectedObjectBConditionBReason:  "myReason",
+				expectedObjectBConditionBStatus:  "myStatus",
+				expectChange:                     true,
+			},
+		},
+		{
+			name: "erase around other conditions",
+			args: args{
+				conditionA:                       condition.Cond("conditionA"),
+				conditionB:                       condition.Cond("conditionB"),
+				objectAConditionAMessage:         "",
+				objectAConditionAReason:          "",
+				objectAConditionAStatus:          "",
+				objectBConditionAMessage:         "donttouch",
+				objectBConditionAReason:          "thiscondition",
+				objectBConditionAStatus:          "becauseifyoudoitsbroken",
+				objectAConditionBMessage:         "orthisone",
+				objectAConditionBReason:          "andthisone",
+				objectAConditionBStatus:          "alsothisone",
+				objectBConditionBMessage:         "myMessage",
+				objectBConditionBReason:          "myReason",
+				objectBConditionBStatus:          "myStatus",
+				expectedObjectAConditionAMessage: "",
+				expectedObjectAConditionAReason:  "",
+				expectedObjectAConditionAStatus:  "",
+				expectedObjectBConditionAMessage: "donttouch",
+				expectedObjectBConditionAReason:  "thiscondition",
+				expectedObjectBConditionAStatus:  "becauseifyoudoitsbroken",
+				expectedObjectAConditionBMessage: "orthisone",
+				expectedObjectAConditionBReason:  "andthisone",
+				expectedObjectAConditionBStatus:  "alsothisone",
+				expectedObjectBConditionBMessage: "",
+				expectedObjectBConditionBReason:  "",
+				expectedObjectBConditionBStatus:  "",
+				expectChange:                     true,
+			},
+		},
+		{
+			name: "overwrite around other conditions",
+			args: args{
+				conditionA:                       condition.Cond("conditionA"),
+				conditionB:                       condition.Cond("conditionB"),
+				objectAConditionAMessage:         "wow",
+				objectAConditionAReason:          "wowreason",
+				objectAConditionAStatus:          "wowstatus",
+				objectBConditionAMessage:         "donttouch",
+				objectBConditionAReason:          "thiscondition",
+				objectBConditionAStatus:          "becauseifyoudoitsbroken",
+				objectAConditionBMessage:         "orthisone",
+				objectAConditionBReason:          "andthisone",
+				objectAConditionBStatus:          "alsothisone",
+				objectBConditionBMessage:         "myMessage",
+				objectBConditionBReason:          "myReason",
+				objectBConditionBStatus:          "myStatus",
+				expectedObjectAConditionAMessage: "wow",
+				expectedObjectAConditionAReason:  "wowreason",
+				expectedObjectAConditionAStatus:  "wowstatus",
+				expectedObjectBConditionAMessage: "donttouch",
+				expectedObjectBConditionAReason:  "thiscondition",
+				expectedObjectBConditionAStatus:  "becauseifyoudoitsbroken",
+				expectedObjectAConditionBMessage: "orthisone",
+				expectedObjectAConditionBReason:  "andthisone",
+				expectedObjectAConditionBStatus:  "alsothisone",
+				expectedObjectBConditionBMessage: "wow",
+				expectedObjectBConditionBReason:  "wowreason",
+				expectedObjectBConditionBStatus:  "wowstatus",
+				expectChange:                     true,
+			},
+		},
+		{
+			name: "no changes",
+			args: args{
+				conditionA:                       condition.Cond("conditionA"),
+				conditionB:                       condition.Cond("conditionB"),
+				objectAConditionAMessage:         "wow",
+				objectAConditionAReason:          "wowreason",
+				objectAConditionAStatus:          "wowstatus",
+				objectBConditionAMessage:         "donttouch",
+				objectBConditionAReason:          "thiscondition",
+				objectBConditionAStatus:          "becauseifyoudoitsbroken",
+				objectAConditionBMessage:         "orthisone",
+				objectAConditionBReason:          "andthisone",
+				objectAConditionBStatus:          "alsothisone",
+				objectBConditionBMessage:         "wow",
+				objectBConditionBReason:          "wowreason",
+				objectBConditionBStatus:          "wowstatus",
+				expectedObjectAConditionAMessage: "wow",
+				expectedObjectAConditionAReason:  "wowreason",
+				expectedObjectAConditionAStatus:  "wowstatus",
+				expectedObjectBConditionAMessage: "donttouch",
+				expectedObjectBConditionAReason:  "thiscondition",
+				expectedObjectBConditionAStatus:  "becauseifyoudoitsbroken",
+				expectedObjectAConditionBMessage: "orthisone",
+				expectedObjectAConditionBReason:  "andthisone",
+				expectedObjectAConditionBStatus:  "alsothisone",
+				expectedObjectBConditionBMessage: "wow",
+				expectedObjectBConditionBReason:  "wowreason",
+				expectedObjectBConditionBStatus:  "wowstatus",
+				expectChange:                     false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This tests copying object A condition A to object B condition B.
+			a := assert.New(t)
+			var objectA = dummyObject{}
+			var objectB = dummyObject{}
+
+			if tt.args.objectAConditionAMessage != "" {
+				tt.args.conditionA.Message(&objectA, tt.args.objectAConditionAMessage)
+			}
+			if tt.args.objectAConditionAReason != "" {
+				tt.args.conditionA.Reason(&objectA, tt.args.objectAConditionAReason)
+			}
+			if tt.args.objectAConditionAStatus != "" {
+				tt.args.conditionA.SetStatus(&objectA, tt.args.objectAConditionAStatus)
+			}
+			if tt.args.objectAConditionBMessage != "" {
+				tt.args.conditionB.Message(&objectA, tt.args.objectAConditionBMessage)
+			}
+			if tt.args.objectAConditionBReason != "" {
+				tt.args.conditionB.Reason(&objectA, tt.args.objectAConditionBReason)
+			}
+			if tt.args.objectAConditionBStatus != "" {
+				tt.args.conditionB.SetStatus(&objectA, tt.args.objectAConditionBStatus)
+			}
+			if tt.args.objectBConditionAMessage != "" {
+				tt.args.conditionA.Message(&objectB, tt.args.objectBConditionAMessage)
+			}
+			if tt.args.objectBConditionAReason != "" {
+				tt.args.conditionA.Reason(&objectB, tt.args.objectBConditionAReason)
+			}
+			if tt.args.objectBConditionAStatus != "" {
+				tt.args.conditionA.SetStatus(&objectB, tt.args.objectBConditionAStatus)
+			}
+			if tt.args.objectBConditionBMessage != "" {
+				tt.args.conditionB.Message(&objectB, tt.args.objectBConditionBMessage)
+			}
+			if tt.args.objectBConditionBReason != "" {
+				tt.args.conditionB.Reason(&objectB, tt.args.objectBConditionBReason)
+			}
+			if tt.args.objectBConditionBStatus != "" {
+				tt.args.conditionB.SetStatus(&objectB, tt.args.objectBConditionBStatus)
+			}
+
+			a.Equal(tt.args.objectAConditionAMessage, tt.args.conditionA.GetMessage(&objectA))
+			a.Equal(tt.args.objectAConditionAReason, tt.args.conditionA.GetReason(&objectA))
+			a.Equal(tt.args.objectAConditionAStatus, tt.args.conditionA.GetStatus(&objectA))
+			a.Equal(tt.args.objectAConditionBMessage, tt.args.conditionB.GetMessage(&objectA))
+			a.Equal(tt.args.objectAConditionBReason, tt.args.conditionB.GetReason(&objectA))
+			a.Equal(tt.args.objectAConditionBStatus, tt.args.conditionB.GetStatus(&objectA))
+
+			a.Equal(tt.args.objectBConditionAMessage, tt.args.conditionA.GetMessage(&objectB))
+			a.Equal(tt.args.objectBConditionAReason, tt.args.conditionA.GetReason(&objectB))
+			a.Equal(tt.args.objectBConditionAStatus, tt.args.conditionA.GetStatus(&objectB))
+			a.Equal(tt.args.objectBConditionBMessage, tt.args.conditionB.GetMessage(&objectB))
+			a.Equal(tt.args.objectBConditionBReason, tt.args.conditionB.GetReason(&objectB))
+			a.Equal(tt.args.objectBConditionBStatus, tt.args.conditionB.GetStatus(&objectB))
+
+			a.Equal(tt.args.expectChange, reconcileCondition(&objectB, tt.args.conditionB, &objectA, tt.args.conditionA))
+
+			a.Equal(tt.args.expectedObjectAConditionAMessage, tt.args.conditionA.GetMessage(&objectA))
+			a.Equal(tt.args.expectedObjectAConditionAReason, tt.args.conditionA.GetReason(&objectA))
+			a.Equal(tt.args.expectedObjectAConditionAStatus, tt.args.conditionA.GetStatus(&objectA))
+			a.Equal(tt.args.expectedObjectAConditionBMessage, tt.args.conditionB.GetMessage(&objectA))
+			a.Equal(tt.args.expectedObjectAConditionBReason, tt.args.conditionB.GetReason(&objectA))
+			a.Equal(tt.args.expectedObjectAConditionBStatus, tt.args.conditionB.GetStatus(&objectA))
+
+			a.Equal(tt.args.expectedObjectBConditionAMessage, tt.args.conditionA.GetMessage(&objectB))
+			a.Equal(tt.args.expectedObjectBConditionAReason, tt.args.conditionA.GetReason(&objectB))
+			a.Equal(tt.args.expectedObjectBConditionAStatus, tt.args.conditionA.GetStatus(&objectB))
+			a.Equal(tt.args.expectedObjectBConditionBMessage, tt.args.conditionB.GetMessage(&objectB))
+			a.Equal(tt.args.expectedObjectBConditionBReason, tt.args.conditionB.GetReason(&objectB))
+			a.Equal(tt.args.expectedObjectBConditionBStatus, tt.args.conditionB.GetStatus(&objectB))
+		})
+	}
+
+}

--- a/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
+++ b/pkg/controllers/provisioningv2/rke2/unmanaged/controller.go
@@ -10,7 +10,6 @@ import (
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/clusterindex"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2"
-	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2/etcdmgmt"
 	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta1"
 	mgmtcontroller "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	rocontrollers "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
@@ -21,9 +20,7 @@ import (
 	"github.com/rancher/wrangler/pkg/apply"
 	"github.com/rancher/wrangler/pkg/data"
 	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
-	"github.com/rancher/wrangler/pkg/generic"
 	"github.com/rancher/wrangler/pkg/kv"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -314,56 +311,7 @@ func (h *handler) onUnmanagedMachineHealth(key string, customMachine *rkev1.Cust
 }
 
 func (h *handler) onUnmanagedMachineOnRemove(key string, customMachine *rkev1.CustomMachine) (*rkev1.CustomMachine, error) {
-	clusterName := customMachine.Labels[capi.ClusterLabelName]
-	if clusterName == "" {
-		return customMachine, nil
-	}
-
-	logrus.Debugf("[UnmanagedMachine] Removing machine %s in cluster %s", key, clusterName)
-
-	cluster, err := h.clusterCache.Get(customMachine.Namespace, clusterName)
-	if apierror.IsNotFound(err) {
-		return customMachine, nil
-	} else if err != nil {
-		return customMachine, err
-	}
-
-	if !cluster.DeletionTimestamp.IsZero() {
-		logrus.Debugf("[UnmanagedMachine] Machine %s belonged to cluster %s that is being deleted. Skipping safe removal", key, clusterName)
-		return customMachine, nil // if the cluster is deleting, we don't care about safe etcd member removal.
-	}
-
-	machine, err := rke2.GetMachineByOwner(h.machineCache, customMachine)
-	if err != nil {
-		if errors.Is(err, rke2.ErrNoMachineOwnerRef) {
-			return customMachine, nil
-		}
-		return customMachine, err
-	}
-
-	if _, ok := machine.Labels[rke2.EtcdRoleLabel]; !ok {
-		logrus.Debugf("[UnmanagedMachine] Safe removal for machine %s in cluster %s not necessary as it is not an etcd node", key, clusterName)
-		return customMachine, nil // If we are not dealing with an etcd node, we can go ahead and allow removal
-	}
-
-	if machine.Status.NodeRef == nil {
-		logrus.Infof("[UnmanagedMachine] No associated node found for machine %s in cluster %s, proceeding with removal", key, clusterName)
-		return customMachine, nil
-	}
-
-	restConfig, err := h.kubeconfigManager.GetRESTConfig(cluster, cluster.Status)
-	if err != nil {
-		return customMachine, err
-	}
-
-	removed, err := etcdmgmt.SafelyRemoved(restConfig, rke2.GetRuntimeCommand(cluster.Spec.KubernetesVersion), machine.Status.NodeRef.Name)
-	if err != nil {
-		return customMachine, err
-	}
-	if !removed {
-		h.unmanagedMachine.EnqueueAfter(customMachine.Namespace, customMachine.Name, 5*time.Second)
-		return customMachine, generic.ErrSkip
-	}
+	// We may want to look at using a migration to remove this finalizer.
 	return customMachine, nil
 }
 

--- a/pkg/provisioningv2/rke2/planner/errors.go
+++ b/pkg/provisioningv2/rke2/planner/errors.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 )
 
-// errWaiting will cause a re-enqueue of the object being processed
+// errWaiting will not cause a re-enqueue of the object being processed and should be used when waiting for other objects/controllers
 type errWaiting string
 
 func (e errWaiting) Error() string {
 	return string(e)
 }
 
-// errWaitingf renders an error of type errWaiting that will cause a re-enqueue of the object being processed
+// errWaitingf renders an error of type errWaiting that will not cause a re-enqueue of the object being processed and should be used when waiting for other objects/controllers
 func errWaitingf(format string, a ...interface{}) errWaiting {
 	return errWaiting(fmt.Sprintf(format, a...))
 }

--- a/pkg/provisioningv2/rke2/planner/etcdrestore.go
+++ b/pkg/provisioningv2/rke2/planner/etcdrestore.go
@@ -3,11 +3,14 @@ package planner
 import (
 	"fmt"
 
+	"github.com/Masterminds/semver/v3"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2"
+	"github.com/rancher/rancher/pkg/controllers/provisioningv2/rke2/managesystemagent"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const ETCDRestoreMessage = "etcd restore"
@@ -40,44 +43,32 @@ func (p *Planner) startOrRestartEtcdSnapshotRestore(status rkev1.RKEControlPlane
 
 // runEtcdSnapshotRestorePlan runs the snapshot restoration plan by electing an init node (or designating the init node
 // that is specified on the snapshot), and renders/delivers the etcd restoration plan to that node.
-func (p *Planner) runEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControlPlane, snapshot *rkev1.ETCDSnapshot, tokensSecret plan.Secret, clusterPlan *plan.Plan) error {
+func (p *Planner) runEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControlPlane, snapshot *rkev1.ETCDSnapshot, snapshotName string, tokensSecret plan.Secret, clusterPlan *plan.Plan) error {
 	var joinServer string
 	var err error
-	isS3 := snapshot.SnapshotFile.S3 != nil
-	if isS3 {
-		joinServer, err = p.electInitNode(controlPlane, clusterPlan)
-		if err != nil {
-			return err
-		}
-	} else {
-		logrus.Infof("rkecluster %s/%s: re-electing specific init node for etcd snapshot restore", controlPlane.Namespace, controlPlane.Spec.ClusterName)
-		joinServer, err = p.designateInitNodeByMachineID(controlPlane, clusterPlan, snapshot.Labels[rke2.MachineIDLabel])
-		if err != nil {
-			return err
-		}
+
+	joinServer, err = p.runEtcdRestoreInitNodeElection(controlPlane, snapshot, clusterPlan)
+	if err != nil {
+		return err
 	}
+
 	servers := collect(clusterPlan, isInitNode)
 
 	if len(servers) != 1 {
 		return fmt.Errorf("more than one init node existed, cannot running etcd snapshot restore")
 	}
 
-	server := servers[0]
-	if isS3 ||
-		(server.Machine.Labels[rke2.MachineIDLabel] != "" && snapshot.Labels[rke2.MachineIDLabel] != "" &&
-			server.Machine.Labels[rke2.MachineIDLabel] == snapshot.Labels[rke2.MachineIDLabel]) {
-		restorePlan, joinedServer, err := p.generateEtcdSnapshotRestorePlan(controlPlane, snapshot, tokensSecret, server, joinServer)
-		if err != nil {
-			return err
-		}
-		return assignAndCheckPlan(p.store, ETCDRestoreMessage, server, restorePlan, joinedServer, 1, 1)
+	restorePlan, joinedServer, err := p.generateEtcdSnapshotRestorePlan(controlPlane, snapshot, snapshotName, tokensSecret, servers[0], joinServer)
+	if err != nil {
+		return err
 	}
+	return assignAndCheckPlan(p.store, ETCDRestoreMessage, servers[0], restorePlan, joinedServer, 1, 1)
 
 	return errWaiting("failed to find etcd node to restore on")
 }
 
 // generateEtcdSnapshotRestorePlan returns a node plan that contains instructions to stop etcd, remove the tombstone file (if one exists), then restore etcd in that order.
-func (p *Planner) generateEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControlPlane, snapshot *rkev1.ETCDSnapshot, tokensSecret plan.Secret, entry *planEntry, joinServer string) (plan.NodePlan, string, error) {
+func (p *Planner) generateEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControlPlane, snapshot *rkev1.ETCDSnapshot, snapshotName string, tokensSecret plan.Secret, entry *planEntry, joinServer string) (plan.NodePlan, string, error) {
 	if controlPlane.Spec.ETCDSnapshotRestore == nil {
 		return plan.NodePlan{}, "", fmt.Errorf("ETCD Snapshot restore was not defined")
 	}
@@ -93,15 +84,18 @@ func (p *Planner) generateEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControl
 		"--etcd-arg=advertise-client-urls=https://127.0.0.1:2379", // this is a workaround for: https://github.com/rancher/rke2/issues/4052 and can likely remain indefinitely (unless IPv6-only becomes a requirement)
 	}
 
-	if snapshot.SnapshotFile.S3 == nil {
+	if snapshot == nil {
+		// If the snapshot is nil, then we will assume the passed in snapshot name is a local snapshot.
+		args = append(args, fmt.Sprintf("--cluster-reset-restore-path=db/snapshots/%s", snapshotName), "--etcd-s3=false")
+	} else if snapshot.SnapshotFile.S3 == nil {
 		args = append(args, fmt.Sprintf("--cluster-reset-restore-path=db/snapshots/%s", snapshot.SnapshotFile.Name), "--etcd-s3=false")
 	} else {
 		args = append(args, fmt.Sprintf("--cluster-reset-restore-path=%s", snapshot.SnapshotFile.Name))
-	}
-
-	s3Args, _, _, err := p.etcdS3Args.ToArgs(snapshot.SnapshotFile.S3, controlPlane, "etcd-", true)
-	if err != nil {
-		return plan.NodePlan{}, "", err
+		s3Args, _, _, err := p.etcdS3Args.ToArgs(snapshot.SnapshotFile.S3, controlPlane, "etcd-", true)
+		if err != nil {
+			return plan.NodePlan{}, "", err
+		}
+		args = append(args, s3Args...)
 	}
 
 	// This is likely redundant but can make sense in the event that there is an external watchdog.
@@ -124,7 +118,7 @@ func (p *Planner) generateEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControl
 
 	nodePlan.Instructions = append(planInstructions, plan.OneTimeInstruction{
 		Name:    "restore",
-		Args:    append(args, s3Args...),
+		Args:    args,
 		Command: rke2.GetRuntimeCommand(controlPlane.Spec.KubernetesVersion),
 	})
 
@@ -184,24 +178,39 @@ func generateCreateEtcdTombstoneInstruction(controlPlane *rkev1.RKEControlPlane)
 	}
 }
 
+// runEtcdRestoreInitNodeElection runs an election for an init node. Notably, it accepts a nil snapshot, and will
+func (p *Planner) runEtcdRestoreInitNodeElection(controlPlane *rkev1.RKEControlPlane, snapshot *rkev1.ETCDSnapshot, clusterPlan *plan.Plan) (string, error) {
+	if snapshot != nil { // If the snapshot CR is not nil, then find an init node.
+		if snapshot.SnapshotFile.S3 == nil {
+			// If the snapshot is not an S3 snapshot, then designate the init node by machine ID defined.
+			if id, ok := snapshot.Labels[rke2.MachineIDLabel]; ok {
+				logrus.Infof("[planner] rkecluster %s/%s: designating init node with machine ID: %s for local snapshot %s/%s restoration", controlPlane.Namespace, controlPlane.Name, id, snapshot.Namespace, snapshot.Name)
+				return p.designateInitNodeByMachineID(controlPlane, clusterPlan, id)
+			}
+			return "", fmt.Errorf("unable to designate machine as label %s on snapshot %s/%s did not exist", rke2.MachineIDLabel, snapshot.Namespace, snapshot.Name)
+		}
+		logrus.Infof("[planner] rkecluster %s/%s: electing init node for S3 snapshot %s/%s restoration", controlPlane.Namespace, controlPlane.Name, snapshot.Namespace, snapshot.Name)
+		return p.electInitNode(controlPlane, clusterPlan)
+	}
+	// make sure that we only have one suitable init node, and elect it.
+	if len(collect(clusterPlan, canBeInitNode)) != 1 {
+		return "", fmt.Errorf("more than one init node existed and no corresponding etcd snapshot CR found, no assumption can be made for the machine that contains the snapshot")
+	}
+	logrus.Infof("[planner] rkecluster %s/%s: electing init node for local snapshot with no associated CR", controlPlane.Namespace, controlPlane.Name)
+	return p.electInitNode(controlPlane, clusterPlan)
+}
+
 // runEtcdRestoreServiceStop generates service stop plans for every non-windows node in the cluster and
 // assigns/checks the plans to ensure they were successful
 func (p *Planner) runEtcdRestoreServiceStop(controlPlane *rkev1.RKEControlPlane, snapshot *rkev1.ETCDSnapshot, tokensSecret plan.Secret, clusterPlan *plan.Plan) error {
 	var joinServer string
 	var err error
 
-	isS3 := snapshot.SnapshotFile.S3 != nil
-	if !isS3 { // In the event that we are restoring a local snapshot, we need to reset our initNode
-		joinServer, err = p.designateInitNodeByMachineID(controlPlane, clusterPlan, snapshot.Labels[rke2.MachineIDLabel])
-		if err != nil {
-			return fmt.Errorf("error while designating init node during control plane/etcd stop: %w", err)
-		}
-	} else {
-		joinServer, err = p.electInitNode(controlPlane, clusterPlan)
-		if err != nil {
-			return err
-		}
+	joinServer, err = p.runEtcdRestoreInitNodeElection(controlPlane, snapshot, clusterPlan)
+	if err != nil {
+		return err
 	}
+
 	servers := collect(clusterPlan, anyRoleWithoutWindows)
 	updated := false
 	for _, server := range servers {
@@ -280,6 +289,7 @@ func (p *Planner) runEtcdSnapshotManagementServiceStart(controlPlane *rkev1.RKEC
 	return nil
 }
 
+// retrieveEtcdSnapshot attempts to retrieve the etcdsnapshot CR that corresponds to the etcd snapshot restore name specified on the controlplane.
 func (p *Planner) retrieveEtcdSnapshot(controlPlane *rkev1.RKEControlPlane) (*rkev1.ETCDSnapshot, error) {
 	if controlPlane == nil {
 		return nil, fmt.Errorf("controlplane was nil")
@@ -290,7 +300,11 @@ func (p *Planner) retrieveEtcdSnapshot(controlPlane *rkev1.RKEControlPlane) (*rk
 	if controlPlane.Spec.ClusterName == "" {
 		return nil, fmt.Errorf("cluster name on rkecontrolplane %s/%s was blank", controlPlane.Namespace, controlPlane.Name)
 	}
-	return p.etcdSnapshotCache.Get(controlPlane.Namespace, controlPlane.Spec.ETCDSnapshotRestore.Name)
+	snapshot, err := p.etcdSnapshotCache.Get(controlPlane.Namespace, controlPlane.Spec.ETCDSnapshotRestore.Name)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	return snapshot, err
 }
 
 // restoreEtcdSnapshot is called multiple times during an etcd snapshot restoration.
@@ -300,13 +314,34 @@ func (p *Planner) retrieveEtcdSnapshot(controlPlane *rkev1.RKEControlPlane) (*rk
 // Shutdown -> When the phase is shutdown, it attempts to shut down etcd on all nodes (stop etcd)
 // Restore ->  When the phase is restore, it attempts to restore etcd
 // Finished -> When the phase is finished, Restore returns nil.
-func (p *Planner) restoreEtcdSnapshot(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan) (rkev1.RKEControlPlaneStatus, error) {
+func (p *Planner) restoreEtcdSnapshot(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, tokensSecret plan.Secret, clusterPlan *plan.Plan, currentVersion *semver.Version) (rkev1.RKEControlPlaneStatus, error) {
 	if cp.Spec.ETCDSnapshotRestore == nil || cp.Spec.ETCDSnapshotRestore.Name == "" {
 		return p.resetEtcdSnapshotRestoreState(status)
 	}
 
 	if status, err := p.startOrRestartEtcdSnapshotRestore(status, cp.Spec.ETCDSnapshotRestore); err != nil {
 		return status, err
+	}
+
+	snapshot, err := p.retrieveEtcdSnapshot(cp)
+	if err != nil {
+		return status, err
+	}
+
+	// validate the snapshot can be restored by checking to see if the snapshot version is < 1.25.x and the current version is 1.25 or newer.
+	if snapshot != nil {
+		clusterSpec, err := rke2.ParseSnapshotClusterSpecOrError(snapshot)
+		if err != nil || clusterSpec == nil {
+			logrus.Errorf("[planner] rkecluster %s/%s: error parsing snapshot cluster spec for snapshot %s/%s during etcd restoration: %v", cp.Namespace, cp.Name, snapshot.Namespace, snapshot.Name, err)
+		} else {
+			snapshotK8sVersion, err := semver.NewVersion(clusterSpec.KubernetesVersion)
+			if err != nil {
+				return status, err
+			}
+			if !currentVersion.LessThan(managesystemagent.Kubernetes125) && snapshotK8sVersion.LessThan(managesystemagent.Kubernetes125) {
+				return status, fmt.Errorf("unable to restore etcd snapshot -- recorded Kubernetes version on snapshot was <= v1.25.0 and current cluster version was v1.25.0 or newer")
+			}
+		}
 	}
 
 	switch cp.Status.ETCDSnapshotRestorePhase {
@@ -322,10 +357,6 @@ func (p *Planner) restoreEtcdSnapshot(cp *rkev1.RKEControlPlane, status rkev1.RK
 		status, _ = p.setEtcdSnapshotRestoreState(status, cp.Spec.ETCDSnapshotRestore, rkev1.ETCDSnapshotPhaseShutdown)
 		return status, errWaitingf("shutting down cluster")
 	case rkev1.ETCDSnapshotPhaseShutdown:
-		snapshot, err := p.retrieveEtcdSnapshot(cp)
-		if err != nil {
-			return status, err
-		}
 		if err = p.runEtcdRestoreServiceStop(cp, snapshot, tokensSecret, clusterPlan); err != nil {
 			return status, err
 		}
@@ -335,11 +366,7 @@ func (p *Planner) restoreEtcdSnapshot(cp *rkev1.RKEControlPlane, status rkev1.RK
 		status, _ = p.setEtcdSnapshotRestoreState(status, cp.Spec.ETCDSnapshotRestore, rkev1.ETCDSnapshotPhaseRestore)
 		return status, errWaiting("cluster shutdown complete, running etcd restore")
 	case rkev1.ETCDSnapshotPhaseRestore:
-		snapshot, err := p.retrieveEtcdSnapshot(cp)
-		if err != nil {
-			return status, err
-		}
-		if err = p.runEtcdSnapshotRestorePlan(cp, snapshot, tokensSecret, clusterPlan); err != nil {
+		if err = p.runEtcdSnapshotRestorePlan(cp, snapshot, cp.Spec.ETCDSnapshotRestore.Name, tokensSecret, clusterPlan); err != nil {
 			return status, err
 		}
 		status.ConfigGeneration++

--- a/pkg/provisioningv2/rke2/planner/etcdrestore.go
+++ b/pkg/provisioningv2/rke2/planner/etcdrestore.go
@@ -55,7 +55,7 @@ func (p *Planner) runEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControlPlane
 	servers := collect(clusterPlan, isInitNode)
 
 	if len(servers) != 1 {
-		return fmt.Errorf("more than one init node existed, cannot running etcd snapshot restore")
+		return fmt.Errorf("more than one init node existed, cannot run etcd snapshot restore")
 	}
 
 	restorePlan, joinedServer, err := p.generateEtcdSnapshotRestorePlan(controlPlane, snapshot, snapshotName, tokensSecret, servers[0], joinServer)
@@ -63,8 +63,6 @@ func (p *Planner) runEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControlPlane
 		return err
 	}
 	return assignAndCheckPlan(p.store, ETCDRestoreMessage, servers[0], restorePlan, joinedServer, 1, 1)
-
-	return errWaiting("failed to find etcd node to restore on")
 }
 
 // generateEtcdSnapshotRestorePlan returns a node plan that contains instructions to stop etcd, remove the tombstone file (if one exists), then restore etcd in that order.

--- a/pkg/provisioningv2/rke2/planner/instructions.go
+++ b/pkg/provisioningv2/rke2/planner/instructions.go
@@ -24,7 +24,7 @@ func (p *Planner) generateInstallInstruction(controlPlane *rkev1.RKEControlPlane
 			continue
 		}
 		switch cattleOS {
-		case windows:
+		case rke2.WindowsMachineOS:
 			env = append(env, fmt.Sprintf("$env:%s=\"%s\"", arg.Name, arg.Value))
 		default:
 			env = append(env, fmt.Sprintf("%s=%s", arg.Name, arg.Value))
@@ -32,7 +32,7 @@ func (p *Planner) generateInstallInstruction(controlPlane *rkev1.RKEControlPlane
 	}
 
 	switch cattleOS {
-	case windows:
+	case rke2.WindowsMachineOS:
 		instruction = plan.OneTimeInstruction{
 			Name:    "install",
 			Image:   image,
@@ -52,7 +52,7 @@ func (p *Planner) generateInstallInstruction(controlPlane *rkev1.RKEControlPlane
 
 	if isOnlyWorker(entry) {
 		switch cattleOS {
-		case windows:
+		case rke2.WindowsMachineOS:
 			instruction.Env = append(instruction.Env, fmt.Sprintf("$env:INSTALL_%s_EXEC=\"agent\"", rke2.GetRuntimeEnv(controlPlane.Spec.KubernetesVersion)))
 		default:
 			instruction.Env = append(instruction.Env, fmt.Sprintf("INSTALL_%s_EXEC=agent", rke2.GetRuntimeEnv(controlPlane.Spec.KubernetesVersion)))
@@ -69,7 +69,7 @@ func (p *Planner) addInstallInstructionWithRestartStamp(nodePlan plan.NodePlan, 
 	var restartStampEnv string
 	stamp := restartStamp(nodePlan, controlPlane, p.getInstallerImage(controlPlane))
 	switch entry.Metadata.Labels[rke2.CattleOSLabel] {
-	case windows:
+	case rke2.WindowsMachineOS:
 		restartStampEnv = "$env:RESTART_STAMP=\"" + stamp + "\""
 	default:
 		restartStampEnv = "RESTART_STAMP=" + stamp
@@ -85,7 +85,7 @@ func (p *Planner) addInstallInstructionWithRestartStamp(nodePlan plan.NodePlan, 
 func (p *Planner) generateInstallInstructionWithSkipStart(controlPlane *rkev1.RKEControlPlane, entry *planEntry) plan.OneTimeInstruction {
 	var skipStartEnv string
 	switch entry.Metadata.Labels[rke2.CattleOSLabel] {
-	case windows:
+	case rke2.WindowsMachineOS:
 		skipStartEnv = fmt.Sprintf("$env:INSTALL_%s_SKIP_START=\"true\"", strings.ToUpper(rke2.GetRuntime(controlPlane.Spec.KubernetesVersion)))
 	default:
 		skipStartEnv = fmt.Sprintf("INSTALL_%s_SKIP_START=true", strings.ToUpper(rke2.GetRuntime(controlPlane.Spec.KubernetesVersion)))

--- a/pkg/provisioningv2/rke2/planner/planentry.go
+++ b/pkg/provisioningv2/rke2/planner/planentry.go
@@ -137,10 +137,10 @@ func isOnlyWorker(entry *planEntry) bool {
 }
 
 func windows(entry *planEntry) bool {
-	if entry == nil || entry.Machine == nil {
+	if entry == nil || entry.Metadata == nil {
 		return false
 	}
-	if val, ok := entry.Machine.Labels[rke2.CattleOSLabel]; ok {
+	if val, ok := entry.Metadata.Labels[rke2.CattleOSLabel]; ok {
 		return val == rke2.WindowsMachineOS
 	}
 	return false

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -335,7 +335,7 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 		return status, err
 	}
 
-	if status, err = p.restoreEtcdSnapshot(cp, status, clusterSecretTokens, plan); err != nil {
+	if status, err = p.restoreEtcdSnapshot(cp, status, clusterSecretTokens, plan, currentVersion); err != nil {
 		return status, err
 	}
 

--- a/pkg/provisioningv2/rke2/planner/planner.go
+++ b/pkg/provisioningv2/rke2/planner/planner.go
@@ -62,8 +62,6 @@ const (
 	authnWebhookFileName = "/var/lib/rancher/%s/kube-api-authn-webhook.yaml"
 	ConfigYamlFileName   = "/etc/rancher/%s/config.yaml.d/50-rancher.yaml"
 
-	windows = "windows"
-
 	bootstrapTier    = "bootstrap"
 	etcdTier         = "etcd"
 	controlPlaneTier = "control plane"
@@ -109,6 +107,8 @@ contexts:
 type Planner struct {
 	ctx                           context.Context
 	store                         *PlanStore
+	rkeBootstrap                  rkecontrollers.RKEBootstrapClient
+	rkeBootstrapCache             rkecontrollers.RKEBootstrapCache
 	rkeControlPlanes              rkecontrollers.RKEControlPlaneController
 	etcdSnapshotCache             rkecontrollers.ETCDSnapshotCache
 	secretClient                  corecontrollers.SecretClient
@@ -152,6 +152,8 @@ func New(ctx context.Context, clients *wrangler.Context, functions InfoFunctions
 		managementClusters:            clients.Mgmt.Cluster().Cache(),
 		rancherClusterCache:           clients.Provisioning.Cluster().Cache(),
 		rkeControlPlanes:              clients.RKE.RKEControlPlane(),
+		rkeBootstrap:                  clients.RKE.RKEBootstrap(),
+		rkeBootstrapCache:             clients.RKE.RKEBootstrap().Cache(),
 		etcdSnapshotCache:             clients.RKE.ETCDSnapshot().Cache(),
 		etcdS3Args: s3Args{
 			secretCache: clients.Core.Secret().Cache(),
@@ -255,19 +257,79 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 		return status, err
 	}
 
+	// Check for cluster sanity to ensure we can properly deliver plans to this cluster.
 	if !clusterIsSane(plan) {
+		// Set the Stable condition on the controlplane to False. This will be used to indicate that the Ready condition
+		// on the v1 cluster object should be set from the rkecontrolplane Provisioned condition rather than the v3
+		// cluster objects Ready condition.
+		rke2.Stable.False(&status)
+
+		// Set the `initialized` and `ready` status fields on the status to false, as the cluster is not sane and cannot
+		// be considered initialized. This is to also prevent CAPI from setting the ControlPlaneInitialized condition
+		// using fallback logic from the status field.
+		if status.Initialized || status.Ready {
+			status.Initialized = false
+			status.Ready = false
+			logrus.Debugf("[planner] rkecluster %s/%s: setting controlplane ready/initialized to false as cluster was not sane", cp.Namespace, cp.Name)
+			return status, errWaitingf("uninitializing rkecontrolplane %s/%s", cp.Namespace, cp.Name)
+		}
+
+		// Uninitialize the CAPI ClusterControlPlaneInitialized condition so that CAPI controllers don't get hung up and will take ownership of new RKEBootstraps (amongst other objects)
+		if err := p.ensureCAPIClusterControlPlaneInitializedFalse(cp); err != nil {
+			return status, errWaitingf("uninitializing CAPI cluster: %v", err)
+		}
+
+		// Collect all nodes that are etcd and deleting. At this point, if we have any etcd nodes left in the cluster,
+		// they will be deleting, so force delete them to prevent quorum loss.
+		etcdDeleting := collect(plan, roleAnd(isEtcd, isDeleting))
+		for _, deletingEtcdNode := range etcdDeleting {
+			if deletingEtcdNode.Machine == nil {
+				logrus.Warnf("[planner] rkecluster %s/%s: did not find CAPI machine for entry when deleting etcd nodes", cp.Namespace, cp.Name)
+				continue
+			}
+			if deletingEtcdNode.Machine.Spec.Bootstrap.ConfigRef == nil {
+				logrus.Warnf("[planner] rkecluster %s/%s: did not find a corresponding CAPI machine for %s/%s", cp.Namespace, cp.Name, deletingEtcdNode.Machine.Namespace, deletingEtcdNode.Machine.Name)
+				continue
+			}
+			if !strings.Contains(deletingEtcdNode.Machine.Spec.Bootstrap.ConfigRef.APIVersion, "rke.cattle.io") {
+				logrus.Warnf("[planner] rkecluster %s/%s: CAPI machine %s/%s had a bootstrap ref with an unexpected API version: %s", cp.Namespace, cp.Name, deletingEtcdNode.Machine.Namespace, deletingEtcdNode.Machine.Name, deletingEtcdNode.Machine.Spec.Bootstrap.ConfigRef.APIVersion)
+				continue
+			}
+			logrus.Infof("[planner] rkecluster %s/%s: force deleting etcd machine %s/%s as cluster was not sane and machine was deleting", cp.Namespace, cp.Name, deletingEtcdNode.Machine.Namespace, deletingEtcdNode.Machine.Name)
+			// Update the CAPI machine annotation for exclude node draining and set it to true to get the CAPI controllers to not try to drain this node.
+			deletingEtcdNode.Machine.Annotations[capi.ExcludeNodeDrainingAnnotation] = "true"
+			deletingEtcdNode.Machine, err = p.machines.Update(deletingEtcdNode.Machine)
+			if err != nil {
+				// If we get an error here, go ahead and return the error as this will re-enqueue and we can try again.
+				return status, err
+			}
+			rb, err := p.rkeBootstrapCache.Get(deletingEtcdNode.Machine.Spec.Bootstrap.ConfigRef.Namespace, deletingEtcdNode.Machine.Spec.Bootstrap.ConfigRef.Name)
+			if err != nil {
+				return status, err
+			}
+			rb = rb.DeepCopy()
+			// Annotate the rkebootstrap with a "force remove" annotation. This will short-circuit the "safe etcd removal"
+			// logic because at this point we are completely taking the cluster down.
+			rb.Annotations[rke2.ForceRemoveEtcdAnnotation] = "true"
+			_, err = p.rkeBootstrap.Update(rb)
+			if err != nil {
+				return status, err
+			}
+		}
+		if len(etcdDeleting) != 0 {
+			return status, errWaiting("waiting for all etcd machines to be deleted")
+		}
 		return status, errWaiting("waiting for at least one control plane, etcd, and worker node to be registered")
 	}
+
+	rke2.Provisioned.True(&status)
+	rke2.Provisioned.Message(&status, "")
+	rke2.Provisioned.Reason(&status, "")
 
 	_, clusterSecretTokens, err := p.ensureRKEStateSecret(cp)
 	if err != nil {
 		return status, err
 	}
-
-	var (
-		firstIgnoreError error
-		joinServer       string
-	)
 
 	if status, err = p.createEtcdSnapshot(cp, status, clusterSecretTokens, plan); err != nil {
 		return status, err
@@ -299,22 +361,43 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 		return status, errWaitingf("CAPI cluster or RKEControlPlane is paused")
 	}
 
-	// In the case where the cluster has been initialized, there is no current init node, and no plans have been
-	// delivered, don't proceed with electing a new init node. The only way out of this is to restore an etcd snapshot.
-	if status.Initialized && !anyPlanDelivered(plan, isEtcd) {
+	// In the case where the cluster has been bootstrapped and no plans have been
+	// delivered to any etcd nodes, don't proceed with electing a new init node.
+	// The only way out of this is to restore an etcd snapshot.
+	if (rke2.Bootstrapped.IsTrue(&status) || len(collect(plan, roleOr(hasJoinURL, hasJoinedTo))) != 0) && len(collect(plan, roleAnd(isEtcd, anyPlanDataExists))) == 0 {
+		// deliver an etcd snapshot list command to the etcd nodes.
+		rke2.Stable.False(&status) // Set the Stable condition on the controlplane to False. This will be used to hide the v3.Cluster Ready condition from the UI.
 		return status, errWaiting("rkecontrolplane was already initialized but no etcd machines exist that have plans, indicating the etcd plane has been entirely replaced. Restoration from etcd snapshot is required.")
 	}
 
+	return p.fullReconcile(cp, status, clusterSecretTokens, plan, false)
+}
+
+func (p *Planner) fullReconcile(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, clusterSecretTokens plan.Secret, plan *plan.Plan, ignoreDrainAndConcurrency bool) (rkev1.RKEControlPlaneStatus, error) {
 	// on the first run through, electInitNode will return a `generic.ErrSkip` as it is attempting to wait for the cache to catch up.
-	joinServer, err = p.electInitNode(cp, plan)
+	joinServer, err := p.electInitNode(cp, plan)
 	if err != nil {
 		return status, err
+	}
+
+	var (
+		firstIgnoreError                             error
+		controlPlaneDrainOptions, workerDrainOptions rkev1.DrainOptions
+		controlPlaneConcurrency, workerConcurrency   string
+	)
+
+	if !ignoreDrainAndConcurrency {
+		controlPlaneDrainOptions = cp.Spec.UpgradeStrategy.ControlPlaneDrainOptions
+		workerDrainOptions = cp.Spec.UpgradeStrategy.WorkerDrainOptions
+		controlPlaneConcurrency = cp.Spec.UpgradeStrategy.ControlPlaneConcurrency
+		workerConcurrency = cp.Spec.UpgradeStrategy.WorkerConcurrency
 	}
 
 	// select all etcd and then filter to just initNodes so that unavailable count is correct
 	err = p.reconcile(cp, clusterSecretTokens, plan, true, bootstrapTier, isEtcd, isNotInitNodeOrIsDeleting,
 		"1", "",
-		cp.Spec.UpgradeStrategy.ControlPlaneDrainOptions)
+		controlPlaneDrainOptions)
+	rke2.Bootstrapped.True(&status)
 	firstIgnoreError, err = ignoreErrors(firstIgnoreError, err)
 	if err != nil {
 		return status, err
@@ -334,7 +417,7 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 	// Process all nodes that have the etcd role and are NOT an init node or deleting. Only process 1 node at a time.
 	err = p.reconcile(cp, clusterSecretTokens, plan, true, etcdTier, isEtcd, isInitNodeOrDeleting,
 		"1", joinServer,
-		cp.Spec.UpgradeStrategy.ControlPlaneDrainOptions)
+		controlPlaneDrainOptions)
 	firstIgnoreError, err = ignoreErrors(firstIgnoreError, err)
 	if err != nil {
 		return status, err
@@ -342,15 +425,15 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 
 	// Process all nodes that have the controlplane role and are NOT an init node or deleting.
 	err = p.reconcile(cp, clusterSecretTokens, plan, true, controlPlaneTier, isControlPlane, isInitNodeOrDeleting,
-		cp.Spec.UpgradeStrategy.ControlPlaneConcurrency, joinServer,
-		cp.Spec.UpgradeStrategy.ControlPlaneDrainOptions)
+		controlPlaneConcurrency, joinServer,
+		controlPlaneDrainOptions)
 	firstIgnoreError, err = ignoreErrors(firstIgnoreError, err)
 	if err != nil {
 		return status, err
 	}
 
 	// If there are any suitable controlplane nodes with join URL annotations
-	if len(collect(plan, isControlPlaneAndHasJoinURLAndNotDeleting)) == 0 {
+	if len(collect(plan, roleAnd(isControlPlane, roleAnd(hasJoinURL, roleNot(isDeleting))))) == 0 {
 		return status, errWaiting("waiting for control plane to be available")
 	}
 
@@ -362,8 +445,8 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 
 	// Process all nodes that are ONLY worker nodes.
 	err = p.reconcile(cp, clusterSecretTokens, plan, false, workerTier, isOnlyWorker, isInitNodeOrDeleting,
-		cp.Spec.UpgradeStrategy.WorkerConcurrency, "",
-		cp.Spec.UpgradeStrategy.WorkerDrainOptions)
+		workerConcurrency, "",
+		workerDrainOptions)
 	firstIgnoreError, err = ignoreErrors(firstIgnoreError, err)
 	if err != nil {
 		return status, err
@@ -372,7 +455,6 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 	if firstIgnoreError != nil {
 		return status, errWaiting(firstIgnoreError.Error())
 	}
-
 	return status, nil
 }
 
@@ -426,9 +508,9 @@ func blockProgressForSUCPSPIf125(msgPrefix string, status rkev1.RKEControlPlaneS
 	return nil
 }
 
-// clusterIsSane ensures that there is at least one controlplane, etcd, and worker node for the cluster.
+// clusterIsSane ensures that there is at least one controlplane, etcd, and worker node that are not deleting for the cluster.
 func clusterIsSane(plan *plan.Plan) bool {
-	if len(collect(plan, isEtcd)) == 0 || len(collect(plan, isControlPlane)) == 0 || len(collect(plan, isWorker)) == 0 {
+	if len(collect(plan, roleAnd(isEtcd, roleNot(isDeleting)))) == 0 || len(collect(plan, roleAnd(isControlPlane, roleNot(isDeleting)))) == 0 || len(collect(plan, roleAnd(isWorker, roleNot(isDeleting)))) == 0 {
 		return false
 	}
 	return true
@@ -456,7 +538,7 @@ func calculateJoinURL(cp *rkev1.RKEControlPlane, entry *planEntry, plan *plan.Pl
 		return "-"
 	}
 
-	entries := collect(plan, isControlPlaneAndHasJoinURLAndNotDeleting)
+	entries := collect(plan, roleAnd(isControlPlane, roleAnd(hasJoinURL, roleNot(isDeleting))))
 
 	if len(entries) == 0 {
 		return ""
@@ -1140,10 +1222,32 @@ func (p *Planner) pauseCAPICluster(cp *rkev1.RKEControlPlane, pause bool) error 
 	if cluster == nil {
 		return fmt.Errorf("CAPI cluster does not exist for %s/%s", cp.Namespace, cp.Name)
 	}
+	cluster = cluster.DeepCopy()
 	if cluster.Spec.Paused == pause {
 		return nil
 	}
 	cluster.Spec.Paused = pause
 	_, err = p.capiClient.Update(cluster)
+	return err
+}
+
+// ensureCAPIClusterControlPlaneInitializedFalse retrieves the CAPI cluster from cache and sets the ControlPlaneInitializedCondition
+// to False if it is not already False.
+func (p *Planner) ensureCAPIClusterControlPlaneInitializedFalse(cp *rkev1.RKEControlPlane) error {
+	if cp == nil {
+		return fmt.Errorf("cannot uninitialize CAPI cluster for nil controlplane")
+	}
+	cluster, err := rke2.GetOwnerCAPICluster(cp, p.capiClusters)
+	if err != nil {
+		return err
+	}
+	if cluster == nil {
+		return fmt.Errorf("CAPI cluster does not exist for %s/%s", cp.Namespace, cp.Name)
+	}
+	cluster = cluster.DeepCopy()
+	if !conditions.IsFalse(cluster, capi.ControlPlaneInitializedCondition) {
+		conditions.MarkFalse(cluster, capi.ControlPlaneInitializedCondition, capi.WaitingForControlPlaneProviderInitializedReason, capi.ConditionSeverityInfo, "Waiting for control plane provider to indicate the control plane has been initialized")
+		_, err = p.capiClient.UpdateStatus(cluster)
+	}
 	return err
 }

--- a/pkg/provisioningv2/rke2/planner/planner_test.go
+++ b/pkg/provisioningv2/rke2/planner/planner_test.go
@@ -154,7 +154,7 @@ func Test_IsWindows(t *testing.T) {
 		"":        false,
 	}
 	for k, v := range data {
-		a.Equal(v, isWindows(&planEntry{
+		a.Equal(v, windows(&planEntry{
 			Metadata: &plan.Metadata{
 				Labels: map[string]string{
 					rke2.CattleOSLabel: k,
@@ -195,7 +195,7 @@ func Test_notWindows(t *testing.T) {
 			a := assert.New(t)
 
 			// act
-			result := notWindows(tt.args.entry)
+			result := roleNot(windows)(tt.args.entry)
 
 			// assert
 			a.Equal(result, tt.args.expected)

--- a/pkg/provisioningv2/rke2/planner/probe.go
+++ b/pkg/provisioningv2/rke2/planner/probe.go
@@ -81,10 +81,6 @@ func isCalico(controlPlane *rkev1.RKEControlPlane, runtime string) bool {
 		cni == "calico+multus"
 }
 
-func isWindows(entry *planEntry) bool {
-	return entry.Metadata.Labels[rke2.CattleOSLabel] == rke2.WindowsMachineOS
-}
-
 // renderSecureProbe takes the existing argument value and renders a secure probe using the argument values and an error
 // if one occurred.
 func renderSecureProbe(arg interface{}, rawProbe plan.Probe, runtime string, defaultSecurePort string, defaultCertDir string, defaultCert string) (plan.Probe, error) {
@@ -131,7 +127,7 @@ func (p *Planner) generateProbes(controlPlane *rkev1.RKEControlPlane, entry *pla
 		// k3s doesn't run the kubelet on etcd only nodes
 		probeNames = append(probeNames, "kubelet")
 	}
-	if !IsOnlyEtcd(entry) && isCalico(controlPlane, runtime) && !isWindows(entry) {
+	if !IsOnlyEtcd(entry) && isCalico(controlPlane, runtime) && roleNot(windows)(entry) {
 		probeNames = append(probeNames, "calico")
 	}
 

--- a/pkg/provisioningv2/rke2/planner/store.go
+++ b/pkg/provisioningv2/rke2/planner/store.go
@@ -87,8 +87,9 @@ func (p *PlanStore) Load(cluster *capi.Cluster, rkeControlPlane *rkev1.RKEContro
 		return nil, anyPlanDelivered, err
 	}
 
+	// Place a DeepCopy of the machine in the resulting Plan, making mutative operations on the Machine object safe.
 	for _, machine := range machines {
-		result.Machines[machine.Name] = machine
+		result.Machines[machine.Name] = machine.DeepCopy()
 	}
 
 	for machineName, secret := range secrets {

--- a/scripts/quick
+++ b/scripts/quick
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)
+
+./build
+./package


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/41080

Also:
https://github.com/rancher/rancher/issues/41174
https://github.com/rancher/rancher/issues/40994

Partially:
https://github.com/rancher/rancher/issues/41024
 
## Problem
Today, it is impossible to restore a K3s/RKE2 cluster from etcd snapshot if you lose the underlying machines.
 
## Solution
This PR adds quite a bit of functionality to the planner. It introduces a few new conditions (namely `Bootstrapped` and `Stable`) that is used to indicate whether the cluster has been bootstrapped and stable, and uses this condition to block reconciliation of a cluster if there are no "alive" etcd machines within the cluster. It adds the ability to skip safe removal of an etcd node for emergency purposes, and uses this functionality to allow for complete removal of the etcd plane if the cluster is no longer active (for the purposes of recovery).

The `Stable` condition is `True` when reconciliation is complete (this means, plans were delivered to all nodes and all nodes pass probes), and set back to False when the cluster is not sane (not at least 1 non-deleting etcd/controlplane/worker node). 

The `Boostrapped` condition is used to indicate whether the cluster was bootstrapped. It is set to True once the bootstrap tier is reconciled, and set back to False if the cluster is restored from etcd snapshot (and then re-set to True once snapshot restoration is successful).

It now provides feedback via the UI that indicates the cluster needs to be restored from etcd snapshot when the conditions are right.

It changes the source of the "Ready" condition on the UI object (either v3.Cluster.status condition `Ready` if the cluster is bootstrapped, or v1.RKEControlPlane.status condition `Ready` based on the `Stable` condition of the `rkecontrolplane`. 

It now properly uninitializes/unready the rkecontrolplane and the CAPI cluster when the cluster is being restored from snapshot.

It moves etcd node safe removal from happening on the inframachine objects to happening on the rkebootstrap objects, which is a requirement to ensure that there is controlplane/bootstrap provider compatibility with "other" infrastructure providers.

It adds an additional argument during etcd snapshot restoration that specifies the advertise-client-urls for etcd, which is a permanent workaround for: https://github.com/rancher/rke2/issues/4052

It removes the RKE2 server manifests that match `rke2-*.yaml` to help solve 41174.

It changes etcd restoration reconciliation logic to using the same exact logic as the planner when it delivers plans, notably while ignoring concurrency/drain.

It adds helper functions to the planEntry file that can be used to reduce the number of roleFilters we have.

It checks the S3 endpoint CA argument to determine if it is a filepath or the actual certificate, and operates according to the type. 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
I manually tested this and was able to restore from S3 snapshots on a new etcd node.
Due to K3s/RKE2 bugs, I was unable to "easily" test restoration from local snapshot to a new node but there is a workaround for this.

### Automated Testing
I added a unit test to test the refactored condition reconciliation function.

Additional automated testing will be added to test etcd restoration in the existing "provisioning-tests" in a future PR.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->