### PR TITLE
Enhance provisioning failure logs to include more objects

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -84,7 +84,7 @@ run_rancher()
         fi
         if [ "$PID" = "-1" ]; then
           echo Starting rancher server using run
-          ./scripts/run >/tmp/rancher.log 2>&1 &
+          ./scripts/run --debug >/tmp/rancher.log 2>&1 &
           PID=$!
         fi
         sleep 2

--- a/scripts/run
+++ b/scripts/run
@@ -9,6 +9,10 @@ if [ ! -x $CMD ]; then
     ./scripts/build-server
 fi
 
+if [ $1 = "--trace" ] || [ $1 = "--info" ] || [ $1 = "--debug" ]; then
+  LOGFLAG=$1
+fi
+
 rm -rf build/testdata
 mkdir -p build/testdata
 cd build/testdata
@@ -34,4 +38,4 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
   sed -e 's/ / +/g' -e 's/^/+/' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
 fi
 
-exec ../../$CMD
+exec ../../$CMD $LOGFLAG

--- a/tests/integration/DEBUG.md
+++ b/tests/integration/DEBUG.md
@@ -1,0 +1,14 @@
+# Interpreting Debug Data
+
+## General
+The debug data is going to be printed out as json that is gzipped then base64'ed. You can 
+```
+echo 'blob' | base64 --decode | gzip -d | jq -r
+```
+to get to something readable.
+
+## Pod Logs
+Pod logs are again gzip and base64'ed, but they have literal "\n" rendered in. For consumable logs, try
+```
+echo 'podlogblob' | base64 --decode | gzip -d | sed -e 's/SnewlineG/\n/g'
+```

--- a/tests/integration/pkg/defaults/defaults.go
+++ b/tests/integration/pkg/defaults/defaults.go
@@ -5,7 +5,7 @@ import "os"
 var (
 	PodTestImage        = "rancher/systemd-node:v0.0.4"
 	SomeK8sVersion      = os.Getenv("SOME_K8S_VERSION")
-	WatchTimeoutSeconds = int64(60 * 30)
+	WatchTimeoutSeconds = int64(600) // 10 minutes.
 	CommonClusterConfig = map[string]interface{}{
 		"service-cidr": "10.45.0.0/16",
 		"cluster-cidr": "10.44.0.0/16",

--- a/tests/integration/pkg/systemdnode/systemnode.go
+++ b/tests/integration/pkg/systemdnode/systemnode.go
@@ -9,7 +9,7 @@ import (
 
 // New is used to create a new instance of systemd-node as a pod in a Kubernetes cluster. Notably, this is used for the
 // v2prov integration tests for custom clusters to simulate custom cluster nodes.
-func New(clients *clients.Clients, namespace, script string) (*corev1.Pod, error) {
+func New(clients *clients.Clients, namespace, script string, labels map[string]string) (*corev1.Pod, error) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    namespace,
@@ -53,6 +53,7 @@ INVOCATION_ID=
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    namespace,
 			GenerateName: "test-node-",
+			Labels:       labels,
 		},
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{

--- a/tests/integration/pkg/tests/custom/custom_test.go
+++ b/tests/integration/pkg/tests/custom/custom_test.go
@@ -93,7 +93,7 @@ func TestCustomOneNode(t *testing.T) {
 
 	assert.NotEmpty(t, command)
 
-	_, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --worker --etcd --controlplane --label foo=bar --label ball=life")
+	_, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --worker --etcd --controlplane --label foo=bar --label ball=life", map[string]string{"custom-cluster-name": c.Name})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestCustomThreeNode(t *testing.T) {
 	assert.NotEmpty(t, command)
 
 	for i := 0; i < 3; i++ {
-		_, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --worker --etcd --controlplane --label rancher=awesome")
+		_, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --worker --etcd --controlplane --label rancher=awesome", map[string]string{"custom-cluster-name": c.Name})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -215,20 +215,20 @@ func TestCustomUniqueRoles(t *testing.T) {
 	assert.NotEmpty(t, command)
 
 	for i := 0; i < 3; i++ {
-		_, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --etcd")
+		_, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --etcd", map[string]string{"custom-cluster-name": c.Name})
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	for i := 0; i < 1; i++ {
-		_, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --controlplane")
+		_, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --controlplane", map[string]string{"custom-cluster-name": c.Name})
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	_, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --worker")
+	_, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --worker", map[string]string{"custom-cluster-name": c.Name})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -301,7 +301,7 @@ func TestCustomThreeNodeWithTaints(t *testing.T) {
 		if i == 1 {
 			taint = " --taint key=value:NoExecute"
 		}
-		_, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --worker --etcd --controlplane --label rancher=awesome"+taint)
+		_, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --worker --etcd --controlplane --label rancher=awesome"+taint, map[string]string{"custom-cluster-name": c.Name})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
It would be ironic if the provisioning-tests successfully passed for this PR, but ideally we can provide an example of a failed run.

https://github.com/rancher/rancher/issues/41334
