### PR TITLE
qa-task-608 backport to release/v2.6 branch

### DIFF
--- a/tests/framework/extensions/clusters/bundledclusters/list.go
+++ b/tests/framework/extensions/clusters/bundledclusters/list.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
-	available "github.com/rancher/rancher/tests/framework/extensions/clusters/versions"
+	available "github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
 )
 
 // ListAvailable is a method of BundledCluster that uses list available functions

--- a/tests/framework/extensions/clusters/clustertypes.go
+++ b/tests/framework/extensions/clusters/clustertypes.go
@@ -1,0 +1,13 @@
+package clusters
+
+type ClusterType string
+
+const (
+	K3SClusterType  ClusterType = "k3s"
+	RKE1ClusterType ClusterType = "rke1"
+	RKE2ClusterType ClusterType = "rke2"
+)
+
+func (p ClusterType) String() string {
+	return string(p)
+}

--- a/tests/framework/extensions/clusters/kubernetesversions/all.go
+++ b/tests/framework/extensions/clusters/kubernetesversions/all.go
@@ -1,4 +1,4 @@
-package versions
+package kubernetesversions
 
 import (
 	"encoding/json"

--- a/tests/framework/extensions/clusters/kubernetesversions/available.go
+++ b/tests/framework/extensions/clusters/kubernetesversions/available.go
@@ -1,4 +1,4 @@
-package versions
+package kubernetesversions
 
 import (
 	"fmt"

--- a/tests/framework/extensions/clusters/kubernetesversions/default.go
+++ b/tests/framework/extensions/clusters/kubernetesversions/default.go
@@ -1,0 +1,79 @@
+package kubernetesversions
+
+import (
+	"fmt"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/sirupsen/logrus"
+)
+
+func Default(client *rancher.Client, provider string, kubernetesVersions []string) ([]string, error) {
+
+	switch {
+	case provider == clusters.RKE1ClusterType.String():
+		default_version_data, err := client.Management.Setting.ByID("k8s-version")
+
+		if err != nil {
+			return nil, err
+		}
+
+		default_version := default_version_data.Value
+		logrus.Infof("default rke1 kubernetes version is: %v", default_version)
+
+		if kubernetesVersions == nil {
+			kubernetesVersions = append(kubernetesVersions, default_version)
+			logrus.Infof("no version found in kubernetesVersions; default rke1 kubernetes version %v will be used: %v", default_version, kubernetesVersions)
+		}
+
+		if kubernetesVersions[0] == "" {
+			kubernetesVersions[0] = default_version
+			logrus.Infof("empty string value found in kubernetesVersions; default rke1 kubernetes version %v will be used: %v", default_version, kubernetesVersions)
+		}
+
+	case provider == clusters.RKE2ClusterType.String():
+		default_version_data, err := client.Management.Setting.ByID("rke2-default-version")
+
+		if err != nil {
+			return nil, err
+		}
+
+		default_version := `v` + default_version_data.Value
+		logrus.Infof("default rke2 kubernetes version is: %v", default_version)
+
+		if kubernetesVersions == nil {
+			kubernetesVersions = append(kubernetesVersions, default_version)
+			logrus.Infof("no version found in kubernetesVersions; default rke2 kubernetes version %v will be used: %v", default_version, kubernetesVersions)
+		}
+
+		if kubernetesVersions[0] == "" {
+			kubernetesVersions[0] = default_version
+			logrus.Infof("empty string value found in kubernetesVersions; default rke2 kubernetes version %v will be used: %v", default_version, kubernetesVersions)
+		}
+
+	case provider == clusters.K3SClusterType.String():
+		default_version_data, err := client.Management.Setting.ByID("k3s-default-version")
+
+		if err != nil {
+			return nil, err
+		}
+
+		default_version := `v` + default_version_data.Value
+		logrus.Infof("default k3s kubernetes version is: %v", default_version)
+
+		if kubernetesVersions == nil {
+			kubernetesVersions = append(kubernetesVersions, default_version)
+			logrus.Infof("no version found in kubernetesVersions; default k3s kubernetes version %v will be used: %v", default_version, kubernetesVersions)
+		}
+
+		if kubernetesVersions[0] == "" {
+			kubernetesVersions[0] = default_version
+			logrus.Infof("empty string value found in kubernetesVersions; default k3s kubernetes version %v will be used: %v", default_version, kubernetesVersions)
+		}
+
+	default:
+		return nil, fmt.Errorf("invalid provider: %v; valid providers: rke1, rke2, k3s", provider)
+	}
+
+	return kubernetesVersions, nil
+}

--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
@@ -44,6 +46,9 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	require.NoError(c.T(), err)
 
 	c.client = client
+
+	c.kubernetesVersions, err = kubernetesversions.Default(c.client, clusters.K3SClusterType.String(), c.kubernetesVersions)
+	require.NoError(c.T(), err)
 
 	enabled := true
 	var testuser = namegen.AppendRandomString("testuser-")

--- a/tests/v2/validation/provisioning/k3s/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/k3s/post_kdm_oob_release_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	provisioningV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
-	"github.com/rancher/rancher/tests/framework/extensions/clusters/versions"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
@@ -69,7 +69,7 @@ func (k *KdmChecksTestSuite) TestK3SK8sVersions() {
 	logrus.Infof("checking for valid k8s versions..")
 	require.GreaterOrEqual(k.T(), len(k.k3skubernetesVersions), 1)
 	// fetching all available k8s versions from rancher
-	releasedK8sVersions, _ := versions.ListK3SAllVersions(k.client)
+	releasedK8sVersions, _ := kubernetesversions.ListK3SAllVersions(k.client)
 	logrus.Info("expected k8s versions : ", k.k3skubernetesVersions)
 	logrus.Info("k8s versions available on rancher server : ", releasedK8sVersions)
 	for _, expectedK8sVersion := range k.k3skubernetesVersions {

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
@@ -43,6 +45,9 @@ func (k *K3SNodeDriverProvisioningTestSuite) SetupSuite() {
 	require.NoError(k.T(), err)
 
 	k.client = client
+
+	k.kubernetesVersions, err = kubernetesversions.Default(k.client, clusters.K3SClusterType.String(), k.kubernetesVersions)
+	require.NoError(k.T(), err)
 
 	enabled := true
 	var testuser = namegen.AppendRandomString("testuser-")

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
@@ -44,6 +46,9 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	require.NoError(c.T(), err)
 
 	c.client = client
+
+	c.kubernetesVersions, err = kubernetesversions.Default(c.client, clusters.RKE1ClusterType.String(), c.kubernetesVersions)
+	require.NoError(c.T(), err)
 
 	enabled := true
 	var testuser = namegen.AppendRandomString("testuser-")

--- a/tests/v2/validation/provisioning/rke1/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/rke1/post_kdm_oob_release_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
-	"github.com/rancher/rancher/tests/framework/extensions/clusters/versions"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
 	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
 	"github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
@@ -68,7 +68,7 @@ func (k *KdmChecksTestSuite) TestRKE1K8sVersions() {
 	logrus.Infof("checking for valid k8s versions..")
 	require.GreaterOrEqual(k.T(), len(k.rke1kubernetesVersions), 1)
 	// fetching all available k8s versions from rancher
-	releasedK8sVersions, _ := versions.ListRKE1AllVersions(k.client)
+	releasedK8sVersions, _ := kubernetesversions.ListRKE1AllVersions(k.client)
 	logrus.Info("expected k8s versions : ", k.rke1kubernetesVersions)
 	logrus.Info("k8s versions available on rancher server : ", releasedK8sVersions)
 	for _, expectedK8sVersion := range k.rke1kubernetesVersions {

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
 	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
 	"github.com/rancher/rancher/tests/framework/extensions/rke1/nodetemplates"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
@@ -47,6 +49,9 @@ func (r *RKE1NodeDriverProvisioningTestSuite) SetupSuite() {
 	require.NoError(r.T(), err)
 
 	r.client = client
+
+	r.kubernetesVersions, err = kubernetesversions.Default(r.client, clusters.RKE1ClusterType.String(), r.kubernetesVersions)
+	require.NoError(r.T(), err)
 
 	enabled := true
 	var testuser = namegen.AppendRandomString("testuser-")

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
@@ -46,6 +48,9 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	require.NoError(c.T(), err)
 
 	c.client = client
+
+	c.kubernetesVersions, err = kubernetesversions.Default(c.client, clusters.RKE2ClusterType.String(), c.kubernetesVersions)
+	require.NoError(c.T(), err)
 
 	enabled := true
 	var testuser = namegen.AppendRandomString("testuser-")

--- a/tests/v2/validation/provisioning/rke2/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/rke2/post_kdm_oob_release_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
-	"github.com/rancher/rancher/tests/framework/extensions/clusters/versions"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
@@ -65,7 +65,7 @@ func (k *KdmChecksTestSuite) TestRKE2K8sVersions() {
 	logrus.Infof("checking for valid k8s versions..")
 	require.GreaterOrEqual(k.T(), len(k.rke2kubernetesVersions), 1)
 	// fetching all available k8s versions from rancher
-	releasedK8sVersions, _ := versions.ListRKE2AllVersions(k.client)
+	releasedK8sVersions, _ := kubernetesversions.ListRKE2AllVersions(k.client)
 	logrus.Info("expected k8s versions : ", k.rke2kubernetesVersions)
 	logrus.Info("k8s versions available on rancher server : ", releasedK8sVersions)
 	for _, expectedK8sVersion := range k.rke2kubernetesVersions {

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
@@ -45,6 +47,9 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 	require.NoError(r.T(), err)
 
 	r.client = client
+
+	r.kubernetesVersions, err = kubernetesversions.Default(r.client, clusters.RKE2ClusterType.String(), r.kubernetesVersions)
+	require.NoError(r.T(), err)
 
 	enabled := true
 	var testuser = namegen.AppendRandomString("testuser-")


### PR DESCRIPTION
BACKPORT FOR v2.6

## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/qa-tasks/issues/608
 
## Problem
Currently, the Go automation specifically asks for the K8s version to be inputted in the user's config file. Within Rancher, if you do not specify a K8s version while provisioning, the default version is selected. `rke up` works in a similar fashion.
 
## Solution
Implemented an enhancement to the provisioning tests for RKE1/RKE2/K3s, where the k8s version is optional and if it is not provided, then the default K8s version will be selected and used.
 
## Testing
RFE - no reproduction steps

## Engineering Testing
### Manual Testing
Automation task - no manual testing conducted

### Automated Testing
Run both locally and via Jenkins Freeform job to ensure desired behavior seen

## QA Testing Considerations
N/A
 
### Regressions Considerations
N/A