### PR TITLE
[v2.6] Update EKS certification test to have required fields

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -1501,6 +1501,16 @@ def cluster_cleanup(client, cluster, aws_nodes=None):
         env_details += "env.USER_TOKEN='" + USER_TOKEN + "'\n"
         env_details += "env.CLUSTER_NAME='" + cluster.name + "'\n"
         create_config_file(env_details)
+        
+        
+def hosted_cluster_cleanup(client, cluster):
+    if RANCHER_CLEANUP_CLUSTER:
+        client.delete(cluster)
+    else:
+        env_details = "env.CATTLE_TEST_URL='" + CATTLE_TEST_URL + "'\n"
+        env_details += "env.ADMIN_TOKEN='" + ADMIN_TOKEN + "'\n"
+        env_details += "env.USER_TOKEN='" + USER_TOKEN + "'\n"
+        create_config_file(env_details)
 
 
 def create_config_file(env_details):

--- a/tests/validation/tests/v3_api/test_aks_v2_hosted_cluster.py
+++ b/tests/validation/tests/v3_api/test_aks_v2_hosted_cluster.py
@@ -1,7 +1,5 @@
 import os
-from .common import get_user_client
-from .common import random_test_name
-from .common import validate_cluster
+from .common import *
 import pytest
 
 AZURE_SUBSCRIPTION_ID = os.environ.get("AZURE_SUBSCRIPTION_ID")
@@ -58,6 +56,7 @@ def test_aks_v2_hosted_cluster_create_basic():
     """
     Create a hosted AKS v2 cluster with basic UI parameters
     """
+    client = get_user_client()
     cluster_name = random_test_name("test-auto-aks")
     aks_config_temp = get_aks_config(cluster_name)
     cluster_config = {
@@ -69,7 +68,8 @@ def test_aks_v2_hosted_cluster_create_basic():
         "enableClusterAlerting": False,
         "enableClusterMonitoring": False
     }
-    create_and_validate_aks_cluster(cluster_config)
+    cluster = create_and_validate_aks_cluster(cluster_config)
+    hosted_cluster_cleanup(client, cluster)
 
 
 def get_aks_config(cluster_name):

--- a/tests/validation/tests/v3_api/test_eks_v2_hosted_cluster.py
+++ b/tests/validation/tests/v3_api/test_eks_v2_hosted_cluster.py
@@ -1,8 +1,5 @@
 import os
-from .common import  get_user_client
-from .common import random_test_name
-from .common import  validate_cluster
-from .common import  wait_for_cluster_delete
+from .common import *
 from .test_create_ha import resource_prefix
 from lib.aws import AmazonWebServices
 import pytest
@@ -53,6 +50,8 @@ eks_config = {
             "maxSize": EKS_NODESIZE,
             "minSize": EKS_NODESIZE,
             "nodegroupName": random_test_name("test-ng"),
+            "requestSpotInstances": False,
+            "resourceTags": {},
             "type": "nodeGroup",
             "subnets": [],
             "tags": {},
@@ -68,6 +67,7 @@ def test_eks_v2_hosted_cluster_create_basic():
     """
     Create a hosted EKS v2 cluster with all default values from the UI
     """
+    client = get_user_client()
     cluster_name = random_test_name("test-auto-eks")
     eks_config_temp = get_eks_config_basic(cluster_name)
     cluster_config = {
@@ -79,13 +79,14 @@ def test_eks_v2_hosted_cluster_create_basic():
         "enableClusterAlerting": False,
         "enableClusterMonitoring": False
     }
-    create_and_validate_eks_cluster(cluster_config)
+    cluster = create_and_validate_eks_cluster(cluster_config)
 
     # validate cluster created
     validate_eks_cluster(cluster_name, eks_config_temp)
 
     # validate nodegroups created
     validate_nodegroup(eks_config_temp["nodeGroups"], cluster_name)
+    hosted_cluster_cleanup(client, cluster)
 
 
 @ekscredential
@@ -278,6 +279,13 @@ def get_eks_config_basic(cluster_name):
     eks_config_temp = eks_config.copy()
     eks_config_temp["displayName"] = cluster_name
     eks_config_temp["amazonCredentialSecret"] = ec2_cloud_credential.id
+    eks_config_temp["subnets"] = [] \
+        if EKS_SUBNETS is None else EKS_SUBNETS.split(",")
+    eks_config_temp["securityGroups"] = [] \
+        if EKS_SECURITYGROUP is None else EKS_SECURITYGROUP.split(",")
+    eks_config_temp["nodeGroups"][0]["requestedSpotInstances"] = False
+    eks_config_temp["nodeGroups"][0]["resourceTags"] = {}
+    eks_config_temp["nodeGroups"][0]["version"] = EKS_K8S_VERSION
     return eks_config_temp
 
 
@@ -435,25 +443,13 @@ def validate_nodegroup(nodegroup_list, cluster_name):
             "Nodegroups are not in active status"
 
         # check scalingConfig
-        assert nodegroup["maxSize"] \
+        assert int(nodegroup["maxSize"]) \
                == eks_nodegroup["nodegroup"]["scalingConfig"]["maxSize"], \
             "maxSize is incorrect on the nodes"
-        assert nodegroup["minSize"] \
+        assert int(nodegroup["minSize"]) \
                == eks_nodegroup["nodegroup"]["scalingConfig"]["minSize"], \
             "minSize is incorrect on the nodes"
-        assert nodegroup["minSize"] \
-               == eks_nodegroup["nodegroup"]["scalingConfig"]["minSize"], \
-            "minSize is incorrect on the nodes"
-
-        # check instance type
-        assert nodegroup["instanceType"] \
-               == eks_nodegroup["nodegroup"]["instanceTypes"][0], \
-            "instanceType is incorrect on the nodes"
-
-        # check disk size
-        assert nodegroup["diskSize"] \
-               == eks_nodegroup["nodegroup"]["diskSize"], \
-            "diskSize is incorrect on the nodes"
+            
         # check ec2SshKey
         if "ec2SshKey" in nodegroup.keys() and \
                 nodegroup["ec2SshKey"] is not "":


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Fix Ontag Automation runs](https://github.com/rancher/qa-tasks/issues/429)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The EKS certification tests is using v1 and not v2. This needs to be updated as v1 has since been deprecated and we are seeing several issues in the certification test. See them below:

- The certification test itself passes, but there is no nodegroup defined. In other words, the cluster is made through individual nodes and not through a managed node group.
     - Node group specification came in EKS v2, hence why this happens in the certification test.

As far as this PR is concerned, there is a small change needed for the `test_eks_v2_hosted_cluster.py` to include `requestSpotInstances` and `resourceTags` in order to get the EKS cluster to properly provision.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
A separate PR changing the internal automation to reference the `test_eks_v2_hosted_cluster.py` has already been merged. This PR ensures that the required parameters are in to get the EKS v2 certification test to work properly.

Additionally, as we only want on EKS cluster to be created, skipping additional EKS cluster creation tests. Also, when validating node groups, checking just the status and K8s version is enough. We do not need to get granular with each and every check.