### PR TITLE
Adding rbac tests for Cluster Action : snapshot on an RKE2 cluster

### DIFF
--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -15,6 +15,7 @@ import (
 	kubeProvisioning "github.com/rancher/rancher/tests/framework/clients/provisioning"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	steveV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
@@ -914,4 +915,20 @@ func WatchAndWaitForCluster(steveClient *v1.Client, kubeProvisioningClient *kube
 
 	err = wait.WatchWait(result, IsProvisioningClusterReady)
 	return err
+}
+
+// GetProvisioningClusterByName is a helper function to get cluster object with the cluster name
+func GetProvisioningClusterByName(client *rancher.Client, clusterName string, namespace string) (*apisV1.Cluster, *steveV1.SteveAPIObject, error) {
+	clusterObj, err := client.Steve.SteveType(ProvisioningSteveResouceType).ByID(namespace + "/" + clusterName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cluster := new(apisV1.Cluster)
+	err = steveV1.ConvertToK8sType(clusterObj, &cluster)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cluster, clusterObj, nil
 }

--- a/tests/framework/extensions/etcdsnapshot/etcdsnapshot.go
+++ b/tests/framework/extensions/etcdsnapshot/etcdsnapshot.go
@@ -1,0 +1,44 @@
+package etcdsnapshot
+
+import (
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	steveV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+)
+
+const (
+	ProvisioningSteveResouceType = "provisioning.cattle.io.cluster"
+)
+
+// CreateSnapshot is a helper function to create a snapshot on an RKE2 or k3s cluster. Returns error if any.
+func CreateSnapshot(client *rancher.Client, clustername string, namespace string) error {
+	clusterObj, existingSteveAPIObj, err := clusters.GetProvisioningClusterByName(client, clustername, namespace)
+	if err != nil {
+		return err
+	}
+
+	clusterSpec := &apisV1.ClusterSpec{}
+	err = steveV1.ConvertToK8sType(clusterObj.Spec, clusterSpec)
+	if err != nil {
+		return err
+	}
+
+	if clusterSpec.RKEConfig.ETCDSnapshotCreate != nil {
+		clusterObj.Spec.RKEConfig.ETCDSnapshotCreate = &rkev1.ETCDSnapshotCreate{
+			Generation: clusterObj.Spec.RKEConfig.ETCDSnapshotCreate.Generation + 1,
+		}
+	} else {
+		clusterObj.Spec.RKEConfig.ETCDSnapshotCreate = &rkev1.ETCDSnapshotCreate{
+			Generation: 1,
+		}
+	}
+
+	_, err = client.Steve.SteveType(clusters.ProvisioningSteveResouceType).Update(existingSteveAPIObj, clusterObj)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	steveV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
@@ -32,28 +31,10 @@ const (
 	etcdnodeCount                = 3
 )
 
-func createSnapshot(client *rancher.Client, clustername string, generation int, namespace string) error {
-	clusterObj, existingSteveAPIObj, err := getProvisioningClusterByName(client, clustername, namespace)
-	if err != nil {
-		return err
-	}
-
-	clusterObj.Spec.RKEConfig.ETCDSnapshotCreate = &rkev1.ETCDSnapshotCreate{
-		Generation: generation,
-	}
-
-	_, err = client.Steve.SteveType(clusters.ProvisioningSteveResouceType).Update(existingSteveAPIObj, clusterObj)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func restoreSnapshot(client *rancher.Client, clustername string, name string,
 	generation int, restoreconfig string, namespace string) error {
 
-	clusterObj, existingSteveAPIObj, err := getProvisioningClusterByName(client, clustername, namespace)
+	clusterObj, existingSteveAPIObj, err := clusters.GetProvisioningClusterByName(client, clustername, namespace)
 	if err != nil {
 		return err
 	}
@@ -131,23 +112,8 @@ func createRKE2NodeDriverCluster(client *rancher.Client, provider *Provider, clu
 
 }
 
-func getProvisioningClusterByName(client *rancher.Client, clusterName string, namespace string) (*apisV1.Cluster, *steveV1.SteveAPIObject, error) {
-	clusterObj, err := client.Steve.SteveType(ProvisioningSteveResouceType).ByID(namespace + "/" + clusterName)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	cluster := new(apisV1.Cluster)
-	err = steveV1.ConvertToK8sType(clusterObj, &cluster)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return cluster, clusterObj, nil
-}
-
 func upgradeClusterK8sVersion(client *rancher.Client, clustername string, k8sUpgradedVersion string, namespaceName string) error {
-	clusterObj, existingSteveAPIObj, err := getProvisioningClusterByName(client, clustername, namespaceName)
+	clusterObj, existingSteveAPIObj, err := clusters.GetProvisioningClusterByName(client, clustername, namespaceName)
 	if err != nil {
 		return err
 	}
@@ -235,7 +201,7 @@ func watchAndWaitForPods(client *rancher.Client, clusterID string) error {
 }
 
 func upgradeClusterK8sVersionWithUpgradeStrategy(client *rancher.Client, clustername string, k8sUpgradedVersion string, namespaceName string) error {
-	clusterObj, existingSteveAPIObj, err := getProvisioningClusterByName(client, clustername, namespaceName)
+	clusterObj, existingSteveAPIObj, err := clusters.GetProvisioningClusterByName(client, clustername, namespaceName)
 	if err != nil {
 		return err
 	}

--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	steveV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/etcdsnapshot"
 	"github.com/rancher/rancher/tests/framework/extensions/ingresses"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/pipeline"
@@ -156,7 +157,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithK8sUpgrade(pro
 	logrus.Infof("created an ingress.............")
 
 	logrus.Infof("creating a snapshot of the cluster.............")
-	err = createSnapshot(client, clusterName, 1, r.ns)
+	err = etcdsnapshot.CreateSnapshot(client, clusterName, r.ns)
 	require.NoError(r.T(), err)
 	logrus.Infof("created a snapshot of the cluster.............")
 
@@ -204,7 +205,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithK8sUpgrade(pro
 	clusters.WatchAndWaitForCluster(r.client.Steve, kubeProvisioningClient, r.ns, clusterName)
 	logrus.Infof("cluster is active again.............")
 
-	cluster, _, err := getProvisioningClusterByName(client, clusterName, r.ns)
+	cluster, _, err := clusters.GetProvisioningClusterByName(client, clusterName, r.ns)
 	require.NoError(r.T(), err)
 	require.Equal(r.T(), k8sUpgradedVersion, cluster.Spec.KubernetesVersion)
 
@@ -233,7 +234,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithK8sUpgrade(pro
 	require.NotNil(r.T(), ingressResp)
 	logrus.Infof("ingress validated successfully.............")
 
-	cluster, _, err = getProvisioningClusterByName(client, clusterName, r.ns)
+	cluster, _, err = clusters.GetProvisioningClusterByName(client, clusterName, r.ns)
 	require.NoError(r.T(), err)
 	require.Equal(r.T(), initialK8sVersion, cluster.Spec.KubernetesVersion)
 }
@@ -304,7 +305,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithUpgradeStrateg
 	logrus.Infof("created an ingress.............")
 
 	logrus.Infof("creating a snapshot of the cluster.............")
-	err = createSnapshot(client, clusterName, 1, r.ns)
+	err = etcdsnapshot.CreateSnapshot(client, clusterName, r.ns)
 	require.NoError(r.T(), err)
 	logrus.Infof("created a snapshot of the cluster.............")
 
@@ -352,7 +353,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithUpgradeStrateg
 	clusters.WatchAndWaitForCluster(r.client.Steve, kubeProvisioningClient, r.ns, clusterName)
 	logrus.Infof("cluster is active again.............")
 
-	cluster, _, err := getProvisioningClusterByName(client, clusterName, r.ns)
+	cluster, _, err := clusters.GetProvisioningClusterByName(client, clusterName, r.ns)
 	require.NoError(r.T(), err)
 	require.Equal(r.T(), k8sUpgradedVersion, cluster.Spec.KubernetesVersion)
 
@@ -385,7 +386,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithUpgradeStrateg
 	require.NotNil(r.T(), ingressResp)
 	logrus.Infof("ingress validated successfully.............")
 
-	cluster, _, err = getProvisioningClusterByName(client, clusterName, r.ns)
+	cluster, _, err = clusters.GetProvisioningClusterByName(client, clusterName, r.ns)
 	require.NoError(r.T(), err)
 	require.Equal(r.T(), initialK8sVersion, cluster.Spec.KubernetesVersion)
 	logrus.Infof("validating ControlPlaneConcurrency and WorkerConcurrency are restored to default values..")
@@ -502,7 +503,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestore(provider *Provide
 	logrus.Infof("created an ingress.............")
 
 	logrus.Infof("creating a snapshot of the cluster.............")
-	err = createSnapshot(client, clusterName, 1, r.ns)
+	err = etcdsnapshot.CreateSnapshot(client, clusterName, r.ns)
 	require.NoError(r.T(), err)
 	logrus.Infof("created a snapshot of the cluster.............")
 

--- a/tests/v2/validation/rbac/rbac.go
+++ b/tests/v2/validation/rbac/rbac.go
@@ -41,8 +41,8 @@ const (
 	psaEnforce                    = "pod-security.kubernetes.io/enforce"
 	kubeConfigTokenSettingID      = "kubeconfig-default-token-ttl-minutes"
 	psaRole                       = "updatepsa"
-
-	isCattleLabeled = true
+	defaultNamespace              = "fleet-default"
+	isCattleLabeled               = true
 )
 
 type ClusterConfig struct {

--- a/tests/v2/validation/rbac/rbac_etcd_backup_test.go
+++ b/tests/v2/validation/rbac/rbac_etcd_backup_test.go
@@ -1,0 +1,129 @@
+package rbac
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/etcdsnapshot"
+	"github.com/rancher/rancher/tests/framework/extensions/users"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ETCDRbacBackupTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	standardUser       *management.User
+	standardUserClient *rancher.Client
+	session            *session.Session
+	cluster            *management.Cluster
+	adminProject       *management.Project
+	namespace          string
+	clusterName        string
+}
+
+func (rb *ETCDRbacBackupTestSuite) TearDownSuite() {
+	rb.session.Cleanup()
+}
+
+func (rb *ETCDRbacBackupTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	rb.session = testSession
+
+	rb.namespace = defaultNamespace
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(rb.T(), err)
+
+	rb.client = client
+	rb.clusterName = client.RancherConfig.ClusterName
+	require.NotEmptyf(rb.T(), rb.clusterName, "Cluster name to install should be set")
+	clusterID, err := clusters.GetClusterIDByName(rb.client, rb.clusterName)
+	require.NoError(rb.T(), err, "Error getting cluster ID")
+	rb.cluster, err = rb.client.Management.Cluster.ByID(clusterID)
+	require.NoError(rb.T(), err)
+}
+
+func (rb *ETCDRbacBackupTestSuite) ValidateEtcdSnapshotCluster(role string) {
+
+	log.Infof("Creating a snapshot of the cluster as %v", role)
+	err := etcdsnapshot.CreateSnapshot(rb.standardUserClient, rb.clusterName, rb.namespace)
+	switch role {
+	case roleOwner, restrictedAdmin:
+		require.NoError(rb.T(), err)
+
+	case roleMember, roleProjectOwner, roleProjectMember:
+		require.Error(rb.T(), err)
+		assert.Equal(rb.T(), "Resource type [provisioning.cattle.io.cluster] is not updatable", err.Error())
+	}
+}
+
+func (rb *ETCDRbacBackupTestSuite) TestETCDRbac() {
+	clusterID, err := clusters.GetClusterIDByName(rb.client, rb.clusterName)
+	require.NoError(rb.T(), err)
+	if !(strings.Contains(clusterID, "c-m-")) {
+		rb.T().Skip("Skipping tests since cluster is not of type - k3s or RKE2")
+	}
+	tests := []struct {
+		name   string
+		role   string
+		member string
+	}{
+		{"Cluster Owner", roleOwner, standardUser},
+		{"Cluster Member", roleMember, standardUser},
+		{"Project Owner", roleProjectOwner, standardUser},
+		{"Project Member", roleProjectMember, standardUser},
+		{"Restricted Admin", restrictedAdmin, restrictedAdmin},
+	}
+	for _, tt := range tests {
+		rb.Run("Set up User with Cluster Role "+tt.name, func() {
+			newUser, err := createUser(rb.client, tt.member)
+			require.NoError(rb.T(), err)
+			rb.standardUser = newUser
+			rb.T().Logf("Created user: %v", rb.standardUser.Username)
+			rb.standardUserClient, err = rb.client.AsUser(newUser)
+			require.NoError(rb.T(), err)
+
+			subSession := rb.session.NewSession()
+			defer subSession.Cleanup()
+
+			createProjectAsAdmin, err := createProject(rb.client, rb.cluster.ID)
+			rb.adminProject = createProjectAsAdmin
+			require.NoError(rb.T(), err)
+		})
+
+		rb.Run("Adding user as "+tt.name+" to the downstream cluster.", func() {
+
+			if tt.member == standardUser {
+				if strings.Contains(tt.role, "project") {
+					err := users.AddProjectMember(rb.client, rb.adminProject, rb.standardUser, tt.role)
+					require.NoError(rb.T(), err)
+				} else {
+					err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.standardUser, tt.role)
+					require.NoError(rb.T(), err)
+				}
+			}
+
+			relogin, err := rb.standardUserClient.ReLogin()
+			require.NoError(rb.T(), err)
+			rb.standardUserClient = relogin
+		})
+
+		rb.T().Logf("Starting validations for %v", tt.role)
+
+		rb.Run("Test case - Take Etcd snapshot of a cluster as a "+tt.name, func() {
+			rb.ValidateEtcdSnapshotCluster(tt.role)
+		})
+
+	}
+}
+
+func TestETCDRbacBackupTestSuite(t *testing.T) {
+	suite.Run(t, new(ETCDRbacBackupTestSuite))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
Adding RBAC tests for snapshot creation on an RKE2 cluster
 

## Solution

- Perform snapshot action on a cluster
- Verify only Cluster owner and restricted admin have access. Cluster member, project owner and member do not have access. And get `Resource type [provisioning.cattle.io.cluster] is not updatable` error


## Engineering Testing
### Manual Testing
N/A

### Automated Testing
Adding these automated tests - https://github.com/rancher/qa-tasks/issues/410

## QA Testing Considerations
N/A
 
### Regressions Considerations
N/A