### PR TITLE
Add setting to skip hosted cluster chart installation

### DIFF
--- a/pkg/controllers/dashboard/hostedcluster/controller.go
+++ b/pkg/controllers/dashboard/hostedcluster/controller.go
@@ -85,6 +85,12 @@ func (h handler) onClusterChange(key string, cluster *v3.Cluster) (*v3.Cluster, 
 		return cluster, nil
 	}
 
+	skipChartInstallation := strings.EqualFold(settings.SkipHostedClusterChartInstallation.Get(), "true")
+	if skipChartInstallation {
+		logrus.Warn("Skipping installation of hosted cluster charts, 'skip-hosted-cluster-chart-installation' is set to true")
+		return cluster, nil
+	}
+
 	var toInstallCrdChart, toInstallChart *chart.Definition
 	var provider string
 	if cluster.Spec.AKSConfig != nil {

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -241,6 +241,10 @@ var (
 
 	// UIPreferred Ensure that the new Dashboard is the default UI.
 	UIPreferred = NewSetting("ui-preferred", "vue")
+
+	// SkipHostedClusterChartInstallation controls whether the hosted cluster chart is installed on the server. Defaults to false.
+	// This setting is for development purposes only.
+	SkipHostedClusterChartInstallation = NewSetting("skip-hosted-cluster-chart-installation", os.Getenv("CATTLE_SKIP_HOSTED_CLUSTER_CHART_INSTALLATION"))
 )
 
 // FullShellImage returns the full private registry name of the rancher shell image.


### PR DESCRIPTION
In the current implementation, it's not possible to install a custom helm chart for hosted providers. When a cluster is created,   helm chart from the upstream repo will be installed.
We need a way to install custom charts that are built for every PR as part of our e2e test suite https://github.com/rancher/aks-operator/blob/master/.github/workflows/e2e.yaml.
Providing an alternative helm chart repository will not work for us. 
This PR adds a new setting for skipping helm chart installation and will be used for development purposes only.

Issue: https://github.com/rancher/highlander/issues/4


