### PR TITLE
Release Tests - Private Registry Fix & Upgrade HA support improvements

### DIFF
--- a/tests/framework/extensions/clusters/eks/eks_cluster_config.go
+++ b/tests/framework/extensions/clusters/eks/eks_cluster_config.go
@@ -39,6 +39,7 @@ type NodeGroupConfig struct {
 	LaunchTemplateConfig *LaunchTemplateConfig `json:"launchTemplate,omitempty" yaml:"launchTemplate,omitempty"`
 	MaxSize              *int64                `json:"maxSize,omitempty" yaml:"maxSize,omitempty"`
 	MinSize              *int64                `json:"minSize,omitempty" yaml:"minSize,omitempty"`
+	NodeRole             *string               `json:"nodeRole,omitempty" yaml:"nodeRole,omitempty"`
 	NodegroupName        *string               `json:"nodegroupName,omitempty" yaml:"nodegroupName,omitempty"`
 	RequestSpotInstances *bool                 `json:"requestSpotInstances,omitempty" yaml:"requestSpotInstances,omitempty"`
 	ResourceTags         map[string]string     `json:"resourceTags" yaml:"resourceTags"`
@@ -76,6 +77,7 @@ func nodeGroupsConstructor(nodeGroupsConfig *[]NodeGroupConfig, kubernetesVersio
 			MaxSize:              nodeGroupConfig.MaxSize,
 			MinSize:              nodeGroupConfig.MinSize,
 			NodegroupName:        nodeGroupConfig.NodegroupName,
+			NodeRole:             nodeGroupConfig.NodeRole,
 			RequestSpotInstances: nodeGroupConfig.RequestSpotInstances,
 			ResourceTags:         &nodeGroupConfig.ResourceTags,
 			SpotInstanceTypes:    &nodeGroupConfig.SpotInstanceTypes,

--- a/tests/framework/extensions/clusters/kubernetesversions/available.go
+++ b/tests/framework/extensions/clusters/kubernetesversions/available.go
@@ -11,30 +11,58 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	v3 "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/sirupsen/logrus"
 )
 
 // ListRKE1AvailableVersions is a function to list and return only available RKE1 versions for a specific cluster.
 func ListRKE1AvailableVersions(client *rancher.Client, cluster *v3.Cluster) (availableVersions []string, err error) {
-	allAvailableVersions, err := ListRKE1AllVersions(client)
+	var allAvailableVersions []*semver.Version
+	allRKE1Versions, err := ListRKE1AllVersions(client)
 	if err != nil {
 		return
 	}
 
-	for i, version := range allAvailableVersions {
-		if strings.Contains(version, cluster.RancherKubernetesEngineConfig.Version) {
-			availableVersions = allAvailableVersions[i+1:]
-			break
+	for _, v := range allRKE1Versions {
+		rkeVersion, err := semver.NewVersion(strings.TrimPrefix(v, "v"))
+		if err != nil {
+			logrus.Errorf("couldn't turn %v to a semantic version", rkeVersion)
+			continue
 		}
+
+		allAvailableVersions = append(allAvailableVersions, rkeVersion)
+	}
+
+	currentVersion, err := semver.NewVersion(strings.TrimPrefix(cluster.RancherKubernetesEngineConfig.Version, "v"))
+	if err != nil {
+		return
+	}
+
+	for _, v := range allAvailableVersions {
+		if v.Compare(currentVersion) == 0 || v.Compare(currentVersion) == -1 {
+			continue
+		}
+		availableVersions = append(availableVersions, fmt.Sprint("v", v.String()))
 	}
 
 	return
 }
 
 // ListRKE2AvailableVersions is a function to list and return only available RKE2 versions for a specific cluster.
-func ListRKE2AvailableVersions(client *rancher.Client, cluster *v1.SteveAPIObject) (availableVersion []string, err error) {
-	allAvailableVersions, err := ListRKE2AllVersions(client)
+func ListRKE2AvailableVersions(client *rancher.Client, cluster *v1.SteveAPIObject) (availableVersions []string, err error) {
+	var allAvailableVersions []*semver.Version
+	allRKE2Versions, err := ListRKE2AllVersions(client)
 	if err != nil {
 		return
+	}
+
+	for _, v := range allRKE2Versions {
+		rke2Version, err := semver.NewVersion(strings.TrimPrefix(v, "v"))
+		if err != nil {
+			logrus.Errorf("couldn't turn %v to a semantic version", rke2Version)
+			continue
+		}
+
+		allAvailableVersions = append(allAvailableVersions, rke2Version)
 	}
 
 	clusterSpec := &apiv1.ClusterSpec{}
@@ -43,45 +71,73 @@ func ListRKE2AvailableVersions(client *rancher.Client, cluster *v1.SteveAPIObjec
 		return
 	}
 
-	availableVersion = allAvailableVersions
+	currentVersion, err := semver.NewVersion(strings.TrimPrefix(clusterSpec.KubernetesVersion, "v"))
+	if err != nil {
+		return
+	}
 
-	for i, version := range allAvailableVersions {
-		if strings.Contains(version, clusterSpec.KubernetesVersion) {
-			availableVersion = allAvailableVersions[i+1:]
-			break
+	for _, v := range allAvailableVersions {
+		if v.Compare(currentVersion) == 0 || v.Compare(currentVersion) == -1 {
+			continue
 		}
+
+		availableVersions = append(availableVersions, fmt.Sprint("v", v.String()))
 	}
 
 	return
 }
 
 // ListNormanRKE2AvailableVersions is a function to list and return only available RKE2 versions for an imported specific cluster.
-func ListNormanRKE2AvailableVersions(client *rancher.Client, cluster *v3.Cluster) (availableVersion []string, err error) {
-	allAvailableVersions, err := ListRKE2AllVersions(client)
+func ListNormanRKE2AvailableVersions(client *rancher.Client, cluster *v3.Cluster) (availableVersions []string, err error) {
+	var allAvailableVersions []*semver.Version
+	allRKE2Versions, err := ListRKE2AllVersions(client)
 	if err != nil {
 		return
 	}
 
-	availableVersion = allAvailableVersions
-
-	for i, version := range allAvailableVersions {
-		if strings.Contains(version, cluster.Rke2Config.Version) {
-			availableVersion = allAvailableVersions[i+1:]
-			break
+	for _, v := range allRKE2Versions {
+		k3sVersion, err := semver.NewVersion(strings.TrimPrefix(v, "v"))
+		if err != nil {
+			logrus.Errorf("couldn't turn %v to a semantic version", k3sVersion)
+			continue
 		}
+
+		allAvailableVersions = append(allAvailableVersions, k3sVersion)
+	}
+
+	currentVersion, err := semver.NewVersion(strings.TrimPrefix(cluster.Rke2Config.Version, "v"))
+	if err != nil {
+		return
+	}
+
+	for _, v := range allAvailableVersions {
+		if v.Compare(currentVersion) == 0 || v.Compare(currentVersion) == -1 {
+			continue
+		}
+
+		availableVersions = append(availableVersions, fmt.Sprint("v", v.String()))
 	}
 
 	return
 }
 
 // ListK3SAvailableVersions is a function to list and return only available K3S versions for a specific cluster.
-func ListK3SAvailableVersions(client *rancher.Client, cluster *v1.SteveAPIObject) (availableVersion []string, err error) {
-	allAvailableVersions, err := ListK3SAllVersions(client)
+func ListK3SAvailableVersions(client *rancher.Client, cluster *v1.SteveAPIObject) (availableVersions []string, err error) {
+	var allAvailableVersions []*semver.Version
+	allK3sVersions, err := ListK3SAllVersions(client)
 	if err != nil {
 		return
 	}
 
-	availableVersion = allAvailableVersions
+	for _, v := range allK3sVersions {
+		rkeVersion, err := semver.NewVersion(strings.TrimPrefix(v, "v"))
+		if err != nil {
+			logrus.Errorf("couldn't turn %v to a semantic version", rkeVersion)
+			continue
+		}
+
+		allAvailableVersions = append(allAvailableVersions, rkeVersion)
+	}
 
 	clusterSpec := &apiv1.ClusterSpec{}
 	err = v1.ConvertToK8sType(cluster.Spec, clusterSpec)
@@ -89,30 +145,51 @@ func ListK3SAvailableVersions(client *rancher.Client, cluster *v1.SteveAPIObject
 		return
 	}
 
-	for i, version := range allAvailableVersions {
-		if strings.Contains(version, clusterSpec.KubernetesVersion) {
-			availableVersion = allAvailableVersions[i+1:]
-			break
+	currentVersion, err := semver.NewVersion(strings.TrimPrefix(clusterSpec.KubernetesVersion, "v"))
+	if err != nil {
+		return
+	}
+
+	for _, v := range allAvailableVersions {
+		if v.Compare(currentVersion) == 0 || v.Compare(currentVersion) == -1 {
+			continue
 		}
+
+		availableVersions = append(availableVersions, fmt.Sprint("v", v.String()))
 	}
 
 	return
 }
 
 // ListNormanK3SAvailableVersions is a function to list and return only available K3S versions for an imported specific cluster.
-func ListNormanK3SAvailableVersions(client *rancher.Client, cluster *v3.Cluster) (availableVersion []string, err error) {
-	allAvailableVersions, err := ListK3SAllVersions(client)
+func ListNormanK3SAvailableVersions(client *rancher.Client, cluster *v3.Cluster) (availableVersions []string, err error) {
+	var allAvailableVersions []*semver.Version
+	allK3sVersions, err := ListK3SAllVersions(client)
 	if err != nil {
 		return
 	}
 
-	availableVersion = allAvailableVersions
-
-	for i, version := range allAvailableVersions {
-		if strings.Contains(version, cluster.K3sConfig.Version) {
-			availableVersion = allAvailableVersions[i+1:]
-			break
+	for _, v := range allK3sVersions {
+		rkeVersion, err := semver.NewVersion(strings.TrimPrefix(v, "v"))
+		if err != nil {
+			logrus.Errorf("couldn't turn %v to a semantic version", rkeVersion)
+			continue
 		}
+
+		allAvailableVersions = append(allAvailableVersions, rkeVersion)
+	}
+
+	currentVersion, err := semver.NewVersion(strings.TrimPrefix(cluster.K3sConfig.Version, "v"))
+	if err != nil {
+		return
+	}
+
+	for _, v := range allAvailableVersions {
+		if v.Compare(currentVersion) == 0 || v.Compare(currentVersion) == -1 {
+			continue
+		}
+
+		availableVersions = append(availableVersions, fmt.Sprint("v", v.String()))
 	}
 
 	return

--- a/tests/framework/extensions/pipeline/configuration.go
+++ b/tests/framework/extensions/pipeline/configuration.go
@@ -18,9 +18,9 @@ func UpdateRancherDownstreamClusterFields(cluster *RancherCluster, isCustom, isR
 	UpdateProviderField(cluster.Provider, isCustom)
 
 	if isRKE1 {
-		UpdateRKE1ImageFields(cluster.Provider, cluster.Image, cluster.SSHUser, isCustom)
+		UpdateRKE1ImageFields(cluster.Provider, cluster.Image, cluster.SSHUser, cluster.VolumeType, isCustom)
 	} else {
-		UpdateRKE2ImageFields(cluster.Provider, cluster.Image, cluster.SSHUser, isCustom)
+		UpdateRKE2ImageFields(cluster.Provider, cluster.Image, cluster.SSHUser, cluster.VolumeType, isCustom)
 	}
 }
 
@@ -63,7 +63,7 @@ func UpdateProviderField(provider string, isCustom bool) {
 
 // UpdateRKE1ImageFields is function that updates the cattle config's node template ssh and image fields
 // depending on the provider type.
-func UpdateRKE1ImageFields(provider, image, sshUser string, isCustom bool) {
+func UpdateRKE1ImageFields(provider, image, sshUser, volumeType string, isCustom bool) {
 	switch provider {
 	case provisioning.AWSProviderName.String():
 		if !isCustom {
@@ -71,6 +71,7 @@ func UpdateRKE1ImageFields(provider, image, sshUser string, isCustom bool) {
 			config.LoadAndUpdateConfig(nodetemplates.AmazonEC2NodeTemplateConfigurationFileKey, nodeTemplate, func() {
 				nodeTemplate.AMI = image
 				nodeTemplate.SSHUser = sshUser
+				nodeTemplate.VolumeType = volumeType
 			})
 		} else {
 			ec2Configs := new(ec2.AWSEC2Configs)
@@ -106,7 +107,7 @@ func UpdateRKE1ImageFields(provider, image, sshUser string, isCustom bool) {
 
 // UpdateRKE2ImageFields is function that updates the cattle config's node template ssh and image fields
 // depending on the provider type.
-func UpdateRKE2ImageFields(provider, image, sshUser string, isCustom bool) {
+func UpdateRKE2ImageFields(provider, image, sshUser, volumeType string, isCustom bool) {
 	switch provider {
 	case provisioning.AWSProviderName.String():
 		if !isCustom {
@@ -114,6 +115,7 @@ func UpdateRKE2ImageFields(provider, image, sshUser string, isCustom bool) {
 			config.LoadAndUpdateConfig(machinepools.AWSMachineConfigConfigurationFileKey, machineConfig, func() {
 				machineConfig.AMI = image
 				machineConfig.SSHUser = sshUser
+				machineConfig.VolumeType = volumeType
 			})
 		} else {
 			ec2Configs := new(ec2.AWSEC2Configs)

--- a/tests/framework/extensions/pipeline/releaseupgrade.go
+++ b/tests/framework/extensions/pipeline/releaseupgrade.go
@@ -81,6 +81,7 @@ type RancherCluster struct {
 	CNIs                       []string         `yaml:"cni"`
 	FeaturesToTest             upgrade.Features `yaml:"enabledFeatures" default:""`
 	SSHUser                    string           `yaml:"sshUser" default:""`
+	VolumeType                 string           `yaml:"volumeType" default:""`
 }
 
 // HostedCluster is a struct that contains related information about the downstream cluster that's going to be created and upgraded.

--- a/tests/v2/validation/pipeline/scripts/build_registries_images.sh
+++ b/tests/v2/validation/pipeline/scripts/build_registries_images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-cd $(dirname $0)/../../../../
+cd $(dirname $0)/../../../../../
 
 echo "building rancher HA corral bin"
 env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tests/v2/validation/registries/bin/rancherha ./tests/v2/validation/pipeline/rancherha

--- a/tests/v2/validation/pipeline/scripts/rancher_cleanup.sh
+++ b/tests/v2/validation/pipeline/scripts/rancher_cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ex
-cd $(dirname $0)/../../../../
+cd $(dirname $0)/../../../../../
 
 echo | corral config
 

--- a/tests/v2/validation/pipeline/scripts/setup_registries_environment.sh
+++ b/tests/v2/validation/pipeline/scripts/setup_registries_environment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ex
-cd $(dirname $0)/../../../../
+cd $(dirname $0)/../../../../../
 
 echo "build corral packages"
 sh tests/v2/validation/pipeline/scripts/build_corral_packages.sh


### PR DESCRIPTION
## Issue: [#712](https://github.com/rancher/qa-tasks/issues/712)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
**Extensions Updates**
- Refactored:
   - Added volume-type options to cluster matrix for release upgrade, specifically for AWS.
   - Changed the comparison logic for the cluster Kubernetes versions to support and detect minor versions.

**Pipelines Updates**
- Refactored:
  -  Made a fix to private registry scripts' directory level