### PR TITLE
refactoring custom clusters to allow multi-pool configurations -- including windows

### DIFF
--- a/tests/framework/clients/ec2/config.go
+++ b/tests/framework/clients/ec2/config.go
@@ -22,5 +22,5 @@ type AWSEC2Config struct {
 	AWSIAMProfile      string   `json:"awsIAMProfile" yaml:"awsIAMProfile"`
 	AWSUser            string   `json:"awsUser" yaml:"awsUser"`
 	VolumeSize         int      `json:"volumeSize" yaml:"volumeSize"`
-	IsWindows          bool     `json:"isWindows" yaml:"isWindows"`
+	Roles              []string `json:"roles" yaml:"roles"`
 }

--- a/tests/framework/extensions/machinepools/machinepools.go
+++ b/tests/framework/extensions/machinepools/machinepools.go
@@ -31,6 +31,7 @@ type NodeRoles struct {
 	ControlPlane bool  `json:"controlplane,omitempty" yaml:"controlplane,omitempty"`
 	Etcd         bool  `json:"etcd,omitempty" yaml:"etcd,omitempty"`
 	Worker       bool  `json:"worker,omitempty" yaml:"worker,omitempty"`
+	Windows      bool  `json:"windows,omitempty" yaml:"windows,omitempty"`
 	Quantity     int32 `json:"quantity" yaml:"quantity"`
 }
 

--- a/tests/framework/extensions/nodes/ec2/ec2.go
+++ b/tests/framework/extensions/nodes/ec2/ec2.go
@@ -1,10 +1,12 @@
 package ec2
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	rancherEc2 "github.com/rancher/rancher/tests/framework/clients/ec2"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	"github.com/rancher/rancher/tests/framework/pkg/nodes"
 )
@@ -13,20 +15,27 @@ const (
 	nodeBaseName = "rancher-automation"
 )
 
-// CreateNodes creates `numOfInstances` (and/or `numOfWinInstances` when using multiple node configurations - e.g. Windows nodes) number of ec2 instances
-func CreateNodes(client *rancher.Client, numOfInstances int, numOfWinInstances int, multiconfig bool) (ec2Nodes []*nodes.Node, winEC2Nodes []*nodes.Node, err error) {
+// CreateNodes creates `quantityPerPool[n]` number of ec2 instances
+func CreateNodes(client *rancher.Client, rolesPerPool []string, quantityPerPool []int32) (ec2Nodes []*nodes.Node, err error) {
 	ec2Client, err := client.GetEC2Client()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	for _, config := range ec2Client.ClientConfig.AWSEC2Config {
+	runningReservations := []*ec2.Reservation{}
+	reservationConfigs := []*rancherEc2.AWSEC2Config{}
+	// provisioning instances in reverse order to allow windows instances time to become ready
+	for i := len(quantityPerPool) - 1; i >= 0; i-- {
+		config := MatchRoleToConfig(rolesPerPool[i], ec2Client.ClientConfig.AWSEC2Config)
+		if config == nil {
+			return nil, errors.New("No matching nodesAndRole for AWSEC2Config with role:" + rolesPerPool[i])
+		}
 		sshName := getSSHKeyName(config.AWSSSHKeyName)
 		runInstancesInput := &ec2.RunInstancesInput{
 			ImageId:      aws.String(config.AWSAMI),
 			InstanceType: aws.String(config.InstanceType),
-			MinCount:     aws.Int64(int64(numOfInstances)),
-			MaxCount:     aws.Int64(int64(numOfInstances)),
+			MinCount:     aws.Int64(int64(quantityPerPool[i])),
+			MaxCount:     aws.Int64(int64(quantityPerPool[i])),
 			KeyName:      aws.String(sshName),
 			BlockDeviceMappings: []*ec2.BlockDeviceMapping{
 				{
@@ -68,12 +77,17 @@ func CreateNodes(client *rancher.Client, numOfInstances int, numOfWinInstances i
 
 		reservation, err := ec2Client.SVC.RunInstances(runInstancesInput)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
+		// instead of waiting on each node pool to complete provisioning, add to a queue and check run status later
+		runningReservations = append(runningReservations, reservation)
+		reservationConfigs = append(reservationConfigs, config)
+	}
 
+	for i := 0; i < len(quantityPerPool); i++ {
 		var listOfInstanceIds []*string
 
-		for _, instance := range reservation.Instances {
+		for _, instance := range runningReservations[i].Instances {
 			listOfInstanceIds = append(listOfInstanceIds, instance.InstanceId)
 		}
 
@@ -82,7 +96,7 @@ func CreateNodes(client *rancher.Client, numOfInstances int, numOfWinInstances i
 			InstanceIds: listOfInstanceIds,
 		})
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
 		//wait until instance status is ok
@@ -90,74 +104,57 @@ func CreateNodes(client *rancher.Client, numOfInstances int, numOfWinInstances i
 			InstanceIds: listOfInstanceIds,
 		})
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
-		// describe instance to get attributes=
+		// describe instance to get attributes
 		describe, err := ec2Client.SVC.DescribeInstances(&ec2.DescribeInstancesInput{
 			InstanceIds: listOfInstanceIds,
 		})
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
 		readyInstances := describe.Reservations[0].Instances
 
-		sshKey, err := nodes.GetSSHKey(config.AWSSSHKeyName)
+		sshKey, err := nodes.GetSSHKey(reservationConfigs[i].AWSSSHKeyName)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
 		for _, readyInstance := range readyInstances {
-
-			if multiconfig {
-				if config.AWSAMI == ec2Client.ClientConfig.AWSEC2Config[0].AWSAMI &&
-					config.AWSUser == ec2Client.ClientConfig.AWSEC2Config[0].AWSUser {
-					ec2Node := &nodes.Node{
-						NodeID:          *readyInstance.InstanceId,
-						PublicIPAddress: *readyInstance.PublicIpAddress,
-						SSHUser:         config.AWSUser,
-						SSHKey:          sshKey,
-					}
-					ec2Nodes = append(ec2Nodes, ec2Node)
-				}
-
-				if config.AWSAMI == ec2Client.ClientConfig.AWSEC2Config[1].AWSAMI &&
-					config.AWSUser == ec2Client.ClientConfig.AWSEC2Config[1].AWSUser {
-					ec2Node2 := &nodes.Node{
-						NodeID:          *readyInstance.InstanceId,
-						PublicIPAddress: *readyInstance.PublicIpAddress,
-						SSHUser:         config.AWSUser,
-						SSHKey:          sshKey,
-					}
-					winEC2Nodes = append(winEC2Nodes, ec2Node2)
-				}
-			} else {
-				ec2Node := &nodes.Node{
-					NodeID:          *readyInstance.InstanceId,
-					PublicIPAddress: *readyInstance.PublicIpAddress,
-					SSHUser:         config.AWSUser,
-					SSHKey:          sshKey,
-				}
-				ec2Nodes = append(ec2Nodes, ec2Node)
-				winEC2Nodes = nil
+			ec2Node := &nodes.Node{
+				NodeID:           *readyInstance.InstanceId,
+				PublicIPAddress:  *readyInstance.PublicIpAddress,
+				PrivateIPAddress: *readyInstance.PrivateIpAddress,
+				SSHUser:          reservationConfigs[i].AWSUser,
+				SSHKey:           sshKey,
 			}
-		}
-
-		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteNodes(client, ec2Nodes, winEC2Nodes, multiconfig)
-		})
-
-		if !multiconfig {
-			break
+			// re-reverse the list so that the order is corrected
+			ec2Nodes = append([]*nodes.Node{ec2Node}, ec2Nodes...)
 		}
 	}
 
-	return ec2Nodes, winEC2Nodes, nil
+	client.Session.RegisterCleanupFunc(func() error {
+		return DeleteNodes(client, ec2Nodes)
+	})
+
+	return ec2Nodes, nil
+}
+
+// MatchRoleToConfig matches the role of nodesAndRoles to the ec2Config that allows this role.
+func MatchRoleToConfig(poolRole string, ec2Configs []rancherEc2.AWSEC2Config) *rancherEc2.AWSEC2Config {
+	for _, config := range ec2Configs {
+		configRoles := " --" + strings.Join(config.Roles, " --")
+		if strings.Contains(configRoles, poolRole) {
+			return &config
+		}
+	}
+	return nil
 }
 
 // DeleteNodes terminates ec2 instances that have been created.
-func DeleteNodes(client *rancher.Client, nodes []*nodes.Node, nodes2 []*nodes.Node, multiconfig bool) error {
+func DeleteNodes(client *rancher.Client, nodes []*nodes.Node) error {
 	ec2Client, err := client.GetEC2Client()
 	if err != nil {
 		return err
@@ -166,11 +163,6 @@ func DeleteNodes(client *rancher.Client, nodes []*nodes.Node, nodes2 []*nodes.No
 	var instanceIDs []*string
 	for _, node := range nodes {
 		instanceIDs = append(instanceIDs, aws.String(node.NodeID))
-	}
-	if multiconfig {
-		for _, node2 := range nodes2 {
-			instanceIDs = append(instanceIDs, aws.String(node2.NodeID))
-		}
 	}
 
 	_, err = ec2Client.SVC.TerminateInstances(&ec2.TerminateInstancesInput{

--- a/tests/framework/pkg/nodes/nodes.go
+++ b/tests/framework/pkg/nodes/nodes.go
@@ -24,13 +24,14 @@ type SSHPath struct {
 	SSHPath string `json:"sshPath" yaml:"sshPath"`
 }
 
-// Node is a configuration of node that is from an oudise cloud provider
+// Node is a configuration of node that is from an outside cloud provider
 type Node struct {
-	NodeID          string `json:"nodeID" yaml:"nodeID"`
-	PublicIPAddress string `json:"publicIPAddress" yaml:"publicIPAddress"`
-	SSHUser         string `json:"sshUser" yaml:"sshUser"`
-	SSHKeyName      string `json:"sshKeyName" yaml:"sshKeyName"`
-	SSHKey          []byte
+	NodeID           string `json:"nodeID" yaml:"nodeID"`
+	PublicIPAddress  string `json:"publicIPAddress" yaml:"publicIPAddress"`
+	PrivateIPAddress string `json:"privateIPAddress" yaml:"privateIPAddress"`
+	SSHUser          string `json:"sshUser" yaml:"sshUser"`
+	SSHKeyName       string `json:"sshKeyName" yaml:"sshKeyName"`
+	SSHKey           []byte
 }
 
 // ExternalNodeConfig is a struct that is a collection of the node configurations

--- a/tests/v2/validation/provisioning/config.go
+++ b/tests/v2/validation/provisioning/config.go
@@ -32,6 +32,67 @@ const (
 	VsphereProviderName   ProviderName = "vsphere"
 )
 
+var AllRolesPool = machinepools.NodeRoles{
+	Etcd:         true,
+	ControlPlane: true,
+	Worker:       true,
+	Quantity:     1,
+}
+
+var EtcdControlPlanePool = machinepools.NodeRoles{
+	Etcd:         true,
+	ControlPlane: true,
+	Quantity:     1,
+}
+
+var EtcdPool = machinepools.NodeRoles{
+	Etcd:     true,
+	Quantity: 1,
+}
+
+var ControlPlanePool = machinepools.NodeRoles{
+	ControlPlane: true,
+	Quantity:     1,
+}
+
+var WorkerPool = machinepools.NodeRoles{
+	Worker:   true,
+	Quantity: 1,
+}
+
+var WindowsPool = machinepools.NodeRoles{
+	Windows:  true,
+	Quantity: 1,
+}
+
+var RKE1AllRolesPool = nodepools.NodeRoles{
+	Etcd:         true,
+	ControlPlane: true,
+	Worker:       true,
+	Quantity:     1,
+}
+
+var RKE1EtcdControlPlanePool = nodepools.NodeRoles{
+	Etcd:         true,
+	ControlPlane: true,
+	Quantity:     1,
+}
+
+var RKE1EtcdPool = nodepools.NodeRoles{
+	Etcd:     true,
+	Quantity: 1,
+}
+
+var RKE1ControlPlanePool = nodepools.NodeRoles{
+	ControlPlane: true,
+	Quantity:     1,
+}
+
+var RKE1WorkerPool = nodepools.NodeRoles{
+	Worker:   true,
+	Quantity: 1,
+}
+
 // String stringer for the ProviderName
 func (p ProviderName) String() string {
 	return string(p)

--- a/tests/v2/validation/provisioning/k3s/README.md
+++ b/tests/v2/validation/provisioning/k3s/README.md
@@ -22,17 +22,17 @@ provisioningInput is needed to the run the K3S tests, specifically kubernetesVer
 
 ```json
 "provisioningInput": {
+    // for custom clusters, len(nodesAndRoles) should be equal to len(awsEc2Config)
     "nodesAndRoles": [
       {
         "etcd": true,
         "controlplane": true,
-        "worker": true,
         "quantity": 1,
       },
       {
         "worker": true,
-        "quantity": 1,
-      }
+        "quantity": 2,
+      },
     ],
     "k3sKubernetesVersion": ["v1.24.4+k3s1"],
     "providers": ["linode", "aws", "azure", "harvester"],
@@ -198,24 +198,50 @@ Machine K3S config is the final piece needed for the config to run K3S provision
 ```
 
 ## Custom Cluster
-For custom clusters, the below config is needed, only AWS/EC2 will work.
-**Ensure you have nodeProviders in provisioningInput**
+For custom clusters, no machineConfig or credentials are needed. Currently only supported for ec2.
 
+Dependencies:
+* **Ensure you have nodeProviders in provisioningInput**
+* make sure that all roles are entered at least once
+* windows pool(s) should always be last in the config
 ```json
- "awsEC2Config": {
+{
+  "awsEC2Configs": {
     "region": "us-east-2",
-    "instanceType": "t3a.medium",
-    "awsRegionAZ": "",
-    "awsAMI": "",
-    "awsSecurityGroups": [""],
-    "awsAccessKeyID": "",
     "awsSecretAccessKey": "",
-    "awsSSHKeyName": "",
-    "awsCICDInstanceTag": "",
-    "awsIAMProfile": "",
-    "awsUser": "ubuntu",
-    "volumeSize": 50
-  },
+    "awsAccessKeyID": "",
+    "awsEC2Config": [
+      {
+        "instanceType": "t3a.medium",
+        "awsRegionAZ": "",
+        "awsAMI": "",
+        "awsSecurityGroups": [
+          ""
+        ],
+        "awsSSHKeyName": "",
+        "awsCICDInstanceTag": "rancher-validation",
+        "awsIAMProfile": "",
+        "awsUser": "ubuntu",
+        "volumeSize": 25,
+        "roles": ["worker"]
+      },
+      {
+        "instanceType": "t3a.large",
+        "awsRegionAZ": "",
+        "awsAMI": "",
+        "awsSecurityGroups": [
+          ""
+        ],
+        "awsSSHKeyName": "",
+        "awsCICDInstanceTag": "rancher-validation",
+        "awsIAMProfile": "",
+        "awsUser": "ubuntu",
+        "volumeSize": 25,
+        "roles": ["etcd", "contolplane"]
+      },
+    ]
+  }
+}
 ```
 
 ## Advanced Settings

--- a/tests/v2/validation/provisioning/k3s/custom_cluster.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	hardening "github.com/rancher/rancher/tests/framework/extensions/hardening/k3s"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
 	"github.com/rancher/rancher/tests/framework/extensions/pipeline"
 	psadeploy "github.com/rancher/rancher/tests/framework/extensions/psact"
@@ -25,11 +26,31 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestProvisioningK3SCustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []string, kubeVersion string, hardened bool, psact string, advancedOptions provisioning.AdvancedOptions) {
+func TestProvisioningK3SCustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []machinepools.NodeRoles, kubeVersion string, hardened bool, psact string, advancedOptions provisioning.AdvancedOptions) {
 	namespace := "fleet-default"
+	rolesPerNode := []string{}
+	quantityPerPool := []int32{}
+	rolesPerPool := []string{}
+	for _, nodes := range nodesAndRoles {
+		var finalRoleCommand string
+		if nodes.ControlPlane {
+			finalRoleCommand += " --controlplane"
+		}
+		if nodes.Etcd {
+			finalRoleCommand += " --etcd"
+		}
+		if nodes.Worker {
+			finalRoleCommand += " --worker"
+		}
 
-	numNodes := len(nodesAndRoles)
-	nodes, _, err := externalNodeProvider.NodeCreationFunc(client, numNodes, 0, false)
+		quantityPerPool = append(quantityPerPool, nodes.Quantity)
+		rolesPerPool = append(rolesPerPool, finalRoleCommand)
+		for i := int32(0); i < nodes.Quantity; i++ {
+			rolesPerNode = append(rolesPerNode, finalRoleCommand)
+		}
+	}
+
+	nodes, err := externalNodeProvider.NodeCreationFunc(client, rolesPerPool, quantityPerPool)
 	require.NoError(t, err)
 
 	clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
@@ -57,7 +78,7 @@ func TestProvisioningK3SCustomCluster(t *testing.T, client *rancher.Client, exte
 
 	for key, node := range nodes {
 		t.Logf("Execute Registration Command for node %s", node.NodeID)
-		command := fmt.Sprintf("%s %s", token.InsecureNodeCommand, nodesAndRoles[key])
+		command := fmt.Sprintf("%s %s", token.InsecureNodeCommand, rolesPerNode[key])
 
 		output, err := node.ExecuteCommand(command)
 		require.NoError(t, err)
@@ -97,7 +118,7 @@ func TestProvisioningK3SCustomCluster(t *testing.T, client *rancher.Client, exte
 	assert.Empty(t, podErrors)
 
 	if hardened && kubeVersion <= string(provisioning.HardenedKubeVersion) {
-		err = hardening.HardeningNodes(client, hardened, nodes, nodesAndRoles)
+		err = hardening.HardeningNodes(client, hardened, nodes, rolesPerNode)
 		require.NoError(t, err)
 
 		hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, psact, nil, provisioning.AdvancedOptions{})

--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -7,6 +7,7 @@ import (
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
@@ -76,33 +77,22 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 }
 
 func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomCluster() {
-	nodeRoles0 := []string{
-		"--etcd --controlplane --worker",
-	}
-
-	nodeRoles1 := []string{
-		"--etcd --controlplane",
-		"--worker",
-	}
-
-	nodeRoles2 := []string{
-		"--etcd",
-		"--controlplane",
-		"--worker",
-	}
+	nodeRolesAll := []machinepools.NodeRoles{provisioning.AllRolesPool}
+	nodeRolesShared := []machinepools.NodeRoles{provisioning.EtcdControlPlanePool, provisioning.WorkerPool}
+	nodeRolesDedicated := []machinepools.NodeRoles{provisioning.EtcdPool, provisioning.ControlPlanePool, provisioning.WorkerPool}
 
 	tests := []struct {
 		name      string
-		nodeRoles []string
 		client    *rancher.Client
+		nodeRoles []machinepools.NodeRoles
 		psact     string
 	}{
-		{"1 Node all roles " + provisioning.AdminClientName.String(), nodeRoles0, c.client, c.psact},
-		{"1 Node all roles " + provisioning.StandardClientName.String(), nodeRoles0, c.standardUserClient, c.psact},
-		{"2 nodes - etcd/cp roles per 1 node " + provisioning.AdminClientName.String(), nodeRoles1, c.client, c.psact},
-		{"2 nodes - etcd/cp roles per 1 node " + provisioning.StandardClientName.String(), nodeRoles1, c.standardUserClient, c.psact},
-		{"3 nodes - 1 role per node " + provisioning.AdminClientName.String(), nodeRoles2, c.client, c.psact},
-		{"3 nodes - 1 role per node " + provisioning.StandardClientName.String(), nodeRoles2, c.standardUserClient, c.psact},
+		{"1 Node all roles " + provisioning.AdminClientName.String(), c.client, nodeRolesAll, c.psact},
+		{"1 Node all roles " + provisioning.StandardClientName.String(), c.standardUserClient, nodeRolesAll, c.psact},
+		{"2 nodes - etcd/cp roles per 1 node " + provisioning.AdminClientName.String(), c.client, nodeRolesShared, c.psact},
+		{"2 nodes - etcd/cp roles per 1 node " + provisioning.StandardClientName.String(), c.standardUserClient, nodeRolesShared, c.psact},
+		{"3 nodes - 1 role per node " + provisioning.AdminClientName.String(), c.client, nodeRolesDedicated, c.psact},
+		{"3 nodes - 1 role per node " + provisioning.StandardClientName.String(), c.standardUserClient, nodeRolesDedicated, c.psact},
 	}
 	var name string
 	for _, tt := range tests {
@@ -134,22 +124,6 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomClusterDyn
 		c.T().Skip()
 	}
 
-	rolesPerNode := []string{}
-
-	for _, nodes := range nodesAndRoles {
-		var finalRoleCommand string
-		if nodes.ControlPlane {
-			finalRoleCommand += " --controlplane"
-		}
-		if nodes.Etcd {
-			finalRoleCommand += " --etcd"
-		}
-		if nodes.Worker {
-			finalRoleCommand += " --worker"
-		}
-		rolesPerNode = append(rolesPerNode, finalRoleCommand)
-	}
-
 	tests := []struct {
 		name   string
 		client *rancher.Client
@@ -172,7 +146,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomClusterDyn
 			for _, kubeVersion := range c.kubernetesVersions {
 				name = tt.name + providerName + " Kubernetes version: " + kubeVersion
 				c.Run(name, func() {
-					TestProvisioningK3SCustomCluster(c.T(), client, externalNodeProvider, rolesPerNode, kubeVersion, c.hardened, tt.psact, c.advancedOptions)
+					TestProvisioningK3SCustomCluster(c.T(), client, externalNodeProvider, nodesAndRoles, kubeVersion, c.hardened, tt.psact, c.advancedOptions)
 				})
 			}
 		}

--- a/tests/v2/validation/provisioning/rke1/README.md
+++ b/tests/v2/validation/provisioning/rke1/README.md
@@ -21,17 +21,16 @@ provisioningInput is needed to the run the RKE1 tests, specifically kubernetesVe
 
 ```json
 "provisioningInput": {
-    "nodesAndRoles": [ 
+    "nodesAndRolesRKE1": [ 
       {
         "etcd": true,
         "controlplane": true,
-        "worker": true,
         "quantity": 1,
       },
       {
         "worker": true,
         "quantity": 2,
-      }
+      },
     ],
     "rke1KubernetesVersion": ["v1.24.2-rancher1-1"],
     "providers": ["linode", "aws", "azure", "harvester"],
@@ -210,24 +209,51 @@ RKE1 specifically needs a node template config to run properly. These are the in
 ```
 
 ## Custom Cluster
-For custom clusters, the below config is needed, only AWS/EC2. It is important to note that you MUST use an AMI that already has Docker installed and the service is enabled on boot; otherwise, this will not work.
-**Ensure you have nodeProviders in provisioningInput**
+For custom clusters, no nodeTemplateConfig or credentials are required. 
+
+Dependencies:
+* **Ensure you have nodeProviders in provisioningInput**
+* make sure that all roles are entered at least once
+* use AMIs that already have Docker installed and the service is enabled on boot
 
 ```json
- "awsEC2Config": {
+{
+  "awsEC2Configs": {
     "region": "us-east-2",
-    "instanceType": "t3a.medium",
-    "awsRegionAZ": "",
-    "awsAMI": "",
-    "awsSecurityGroups": [""],
-    "awsAccessKeyID": "",
     "awsSecretAccessKey": "",
-    "awsSSHKeyName": "",
-    "awsCICDInstanceTag": "",
-    "awsIAMProfile": "",
-    "awsUser": "ubuntu",
-    "volumeSize": 50
-  },
+    "awsAccessKeyID": "",
+    "awsEC2Config": [
+      {
+        "instanceType": "t3a.medium",
+        "awsRegionAZ": "",
+        "awsAMI": "",
+        "awsSecurityGroups": [
+          ""
+        ],
+        "awsSSHKeyName": "",
+        "awsCICDInstanceTag": "rancher-validation",
+        "awsIAMProfile": "",
+        "awsUser": "ubuntu",
+        "volumeSize": 25,
+        "roles": ["etcd", "contolplane"]
+      },
+      {
+        "instanceType": "t3a.large",
+        "awsRegionAZ": "",
+        "awsAMI": "",
+        "awsSecurityGroups": [
+          ""
+        ],
+        "awsSSHKeyName": "",
+        "awsCICDInstanceTag": "rancher-validation",
+        "awsIAMProfile": "",
+        "awsUser": "ubuntu",
+        "volumeSize": 25,
+        "roles": ["worker"]
+      }
+    ]
+  }
+}
 ```
 
 ## Advanced Settings

--- a/tests/v2/validation/provisioning/rke1/custom_cluster.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster.go
@@ -11,6 +11,7 @@ import (
 	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
 	"github.com/rancher/rancher/tests/framework/extensions/pipeline"
 	psadeploy "github.com/rancher/rancher/tests/framework/extensions/psact"
+	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
 	"github.com/rancher/rancher/tests/framework/extensions/tokenregistration"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
 	"github.com/rancher/rancher/tests/framework/pkg/environmentflag"
@@ -22,9 +23,30 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestProvisioningRKE1CustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []string, psact, kubeVersion, cni string, advancedOptions provisioning.AdvancedOptions) {
-	numNodes := len(nodesAndRoles)
-	nodes, _, err := externalNodeProvider.NodeCreationFunc(client, numNodes, 0, false)
+func TestProvisioningRKE1CustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []nodepools.NodeRoles, psact, kubeVersion, cni string, advancedOptions provisioning.AdvancedOptions) {
+	rolesPerNode := []string{}
+	quantityPerPool := []int32{}
+	rolesPerPool := []string{}
+	for _, nodes := range nodesAndRoles {
+		var finalRoleCommand string
+		if nodes.ControlPlane {
+			finalRoleCommand += " --controlplane"
+		}
+		if nodes.Etcd {
+			finalRoleCommand += " --etcd"
+		}
+		if nodes.Worker {
+			finalRoleCommand += " --worker"
+		}
+
+		quantityPerPool = append(quantityPerPool, int32(nodes.Quantity))
+		rolesPerPool = append(rolesPerPool, finalRoleCommand)
+		for i := int64(0); i < nodes.Quantity; i++ {
+			rolesPerNode = append(rolesPerNode, finalRoleCommand)
+		}
+	}
+
+	nodes, err := externalNodeProvider.NodeCreationFunc(client, rolesPerPool, quantityPerPool)
 	require.NoError(t, err)
 
 	clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
@@ -48,7 +70,8 @@ func TestProvisioningRKE1CustomCluster(t *testing.T, client *rancher.Client, ext
 
 	for key, node := range nodes {
 		t.Logf("Execute Registration Command for node %s", node.NodeID)
-		command := fmt.Sprintf("%s %s", token.NodeCommand, nodesAndRoles[key])
+		command := fmt.Sprintf("%s %s --address %s --internal-address %s",
+			token.NodeCommand, rolesPerNode[key], node.PublicIPAddress, node.PrivateIPAddress)
 
 		output, err := node.ExecuteCommand(command)
 		require.NoError(t, err)

--- a/tests/v2/validation/provisioning/rke2/README.md
+++ b/tests/v2/validation/provisioning/rke2/README.md
@@ -31,10 +31,14 @@ provisioningInput is needed to the run the RKE2 tests, specifically kubernetesVe
       },
       {
         "worker": true,
+        "quantity": 2,
+      },
+      {
+        "windows": true,
         "quantity": 1,
       }
     ],
-    "rke2KubernetesVersion": ["v1.21.6+rke2r1"],
+    "rke2KubernetesVersion": ["v1.25.9+rke2r1"],
     "cni": ["calico"],
     "providers": ["linode", "aws", "do", "harvester"],
     "nodeProviders": ["ec2"],
@@ -223,9 +227,12 @@ Machine RKE2 config is the final piece needed for the config to run RKE2 provisi
 ```
 
 ## Custom Cluster
-For custom clusters, the below config is needed, only AWS/EC2 will work.
-**Ensure you have nodeProviders in provisioningInput**
+For custom clusters, no machineConfig or credentials are needed. Currently only supported for ec2.
 
+Dependencies:
+* **Ensure you have nodeProviders in provisioningInput**
+* make sure that all roles are entered at least once
+* windows pool(s) should always be last in the config
 ```json
 {
   "awsEC2Configs": {
@@ -245,7 +252,21 @@ For custom clusters, the below config is needed, only AWS/EC2 will work.
         "awsIAMProfile": "",
         "awsUser": "ubuntu",
         "volumeSize": 25,
-        "isWindows": false
+        "roles": ["etcd", "contolplane"]
+      },
+      {
+        "instanceType": "t3a.large",
+        "awsRegionAZ": "",
+        "awsAMI": "",
+        "awsSecurityGroups": [
+          ""
+        ],
+        "awsSSHKeyName": "",
+        "awsCICDInstanceTag": "rancher-validation",
+        "awsIAMProfile": "",
+        "awsUser": "ubuntu",
+        "volumeSize": 25,
+        "roles": ["worker"]
       },
       {
         "instanceType": "t3a.xlarge",
@@ -259,7 +280,7 @@ For custom clusters, the below config is needed, only AWS/EC2 will work.
         "awsIAMProfile": "",
         "awsUser": "Administrator",
         "volumeSize": 50,
-        "isWindows": true
+        "roles": ["windows"]
       }
     ]
   }

--- a/tests/v2/validation/provisioning/rke2/custom_cluster.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster.go
@@ -3,6 +3,7 @@ package rke2
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
@@ -11,6 +12,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	hardening "github.com/rancher/rancher/tests/framework/extensions/hardening/rke2"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
 	"github.com/rancher/rancher/tests/framework/extensions/pipeline"
 	psadeploy "github.com/rancher/rancher/tests/framework/extensions/psact"
@@ -29,13 +31,35 @@ const (
 	namespace = "fleet-default"
 )
 
-func TestProvisioningRKE2CustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []string, psact, kubeVersion, cni string, hardened bool, nodeCountWin int, hasWindows bool, advancedOptions provisioning.AdvancedOptions) {
-	numNodesLin := len(nodesAndRoles)
+func TestProvisioningRKE2CustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []machinepools.NodeRoles, psact, kubeVersion, cni string, hardened bool, advancedOptions provisioning.AdvancedOptions) {
+	rolesPerNode := []string{}
+	quantityPerPool := []int32{}
+	rolesPerPool := []string{}
+	for _, nodes := range nodesAndRoles {
+		var finalRoleCommand string
+		if nodes.ControlPlane {
+			finalRoleCommand += " --controlplane"
+		}
+		if nodes.Etcd {
+			finalRoleCommand += " --etcd"
+		}
+		if nodes.Worker {
+			finalRoleCommand += " --worker"
+		}
+		if nodes.Windows {
+			finalRoleCommand += " --windows"
+		}
+		quantityPerPool = append(quantityPerPool, nodes.Quantity)
+		rolesPerPool = append(rolesPerPool, finalRoleCommand)
+		for i := int32(0); i < nodes.Quantity; i++ {
+			rolesPerNode = append(rolesPerNode, finalRoleCommand)
+		}
+	}
 
 	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
 	require.NoError(t, err)
 
-	linuxNodes, winNodes, err := externalNodeProvider.NodeCreationFunc(client, numNodesLin, nodeCountWin, hasWindows)
+	nodes, err := externalNodeProvider.NodeCreationFunc(client, rolesPerPool, quantityPerPool)
 	require.NoError(t, err)
 
 	clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
@@ -61,15 +85,8 @@ func TestProvisioningRKE2CustomCluster(t *testing.T, client *rancher.Client, ext
 	token, err := tokenregistration.GetRegistrationToken(client, clusterStatus.ClusterName)
 	require.NoError(t, err)
 
-	for key, linuxNode := range linuxNodes {
-		t.Logf("Execute Registration Command for node %s", linuxNode.NodeID)
-		command := fmt.Sprintf("%s %s", token.InsecureNodeCommand, nodesAndRoles[key])
-
-		output, err := linuxNode.ExecuteCommand(command)
-		require.NoError(t, err)
-
-		t.Logf(output)
-	}
+	clusterIDName, err := clusters.GetClusterIDByName(adminClient, clusterName)
+	assert.NoError(t, err)
 
 	kubeProvisioningClient, err := adminClient.GetKubeAPIProvisioningClient()
 	require.NoError(t, err)
@@ -78,40 +95,35 @@ func TestProvisioningRKE2CustomCluster(t *testing.T, client *rancher.Client, ext
 		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
 	})
 	require.NoError(t, err)
-
 	checkFunc := clusters.IsProvisioningClusterReady
+
+	for key, node := range nodes {
+		t.Logf("Execute Registration Command for node %s", node.NodeID)
+		var command string
+		if strings.Contains(rolesPerNode[key], "windows") {
+			err = wait.WatchWait(result, checkFunc)
+			assert.NoError(t, err)
+			assert.Equal(t, clusterName, clusterResp.ObjectMeta.Name)
+			t.Logf("Windows pool detected, using powershell.exe")
+			command = fmt.Sprintf("powershell.exe %s -Address %s", token.InsecureWindowsNodeCommand, node.PublicIPAddress)
+		} else {
+			t.Logf("Linux pool detected, using bash")
+			command = fmt.Sprintf("%s %s --address %s", token.InsecureNodeCommand, rolesPerNode[key], node.PublicIPAddress)
+		}
+		t.Logf("Command: %s", command)
+		output, err := node.ExecuteCommand(command)
+		require.NoError(t, err)
+
+		t.Logf(output)
+	}
+	result, err = kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + clusterName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	require.NoError(t, err)
 	err = wait.WatchWait(result, checkFunc)
 	assert.NoError(t, err)
 	assert.Equal(t, clusterName, clusterResp.ObjectMeta.Name)
-
-	if hasWindows {
-		for _, winNode := range winNodes {
-			t.Logf("Execute Registration Command for node %s", winNode.NodeID)
-
-			output, err := winNode.ExecuteCommand("powershell.exe" + token.InsecureWindowsNodeCommand)
-			require.NoError(t, err)
-
-			t.Logf(string(output[:]))
-		}
-
-		kubeWinProvisioningClient, err := adminClient.GetKubeAPIProvisioningClient()
-		require.NoError(t, err)
-
-		result, err := kubeWinProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
-			FieldSelector: "metadata.name=" + clusterName,
-
-			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
-		})
-		require.NoError(t, err)
-
-		checkFunc := clusters.IsProvisioningClusterReady
-		err = wait.WatchWait(result, checkFunc)
-		assert.NoError(t, err)
-		assert.Equal(t, clusterName, clusterResp.ObjectMeta.Name)
-	}
-
-	clusterIDName, err := clusters.GetClusterIDByName(adminClient, clusterName)
-	assert.NoError(t, err)
 
 	err = nodestat.IsNodeReady(client, clusterIDName)
 	require.NoError(t, err)
@@ -125,7 +137,7 @@ func TestProvisioningRKE2CustomCluster(t *testing.T, client *rancher.Client, ext
 	assert.Empty(t, podErrors)
 
 	if hardened && kubeVersion <= string(provisioning.HardenedKubeVersion) {
-		err = hardening.HardeningNodes(client, hardened, linuxNodes, nodesAndRoles)
+		err = hardening.HardeningNodes(client, hardened, nodes, rolesPerNode)
 		require.NoError(t, err)
 
 		hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, psact, nil, provisioning.AdvancedOptions{})
@@ -134,7 +146,7 @@ func TestProvisioningRKE2CustomCluster(t *testing.T, client *rancher.Client, ext
 		require.NoError(t, err)
 		assert.Equal(t, clusterName, hardenClusterResp.ObjectMeta.Name)
 
-		err = hardening.PostHardeningConfig(client, hardened, linuxNodes, nodesAndRoles)
+		err = hardening.PostHardeningConfig(client, hardened, nodes, rolesPerNode)
 		require.NoError(t, err)
 	}
 

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -7,6 +7,7 @@ import (
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
+	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
@@ -27,6 +28,7 @@ type CustomClusterProvisioningTestSuite struct {
 	cnis               []string
 	nodeProviders      []string
 	psact              string
+	isWindows          bool
 	advancedOptions    provisioning.AdvancedOptions
 }
 
@@ -47,6 +49,13 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	c.hardened = clustersConfig.Hardened
 	c.psact = clustersConfig.PSACT
 	c.advancedOptions = clustersConfig.AdvancedOptions
+	c.isWindows = false
+	for _, pool := range clustersConfig.NodesAndRoles {
+		if pool.Windows {
+			c.isWindows = true
+			break
+		}
+	}
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(c.T(), err)
@@ -78,41 +87,26 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 }
 
 func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE2CustomCluster() {
-	nodeRoles0 := []string{
-		"--etcd --controlplane --worker",
-	}
-
-	nodeRoles1 := []string{
-		"--etcd --controlplane",
-		"--worker",
-	}
-
-	nodeRoles2 := []string{
-		"--etcd",
-		"--controlplane",
-		"--worker",
-	}
+	nodeRolesAll := []machinepools.NodeRoles{provisioning.AllRolesPool}
+	nodeRolesShared := []machinepools.NodeRoles{provisioning.EtcdControlPlanePool, provisioning.WorkerPool}
+	nodeRolesDedicated := []machinepools.NodeRoles{provisioning.EtcdPool, provisioning.ControlPlanePool, provisioning.WorkerPool}
+	nodeRolesDedicatedWindows := []machinepools.NodeRoles{provisioning.EtcdPool, provisioning.ControlPlanePool, provisioning.WorkerPool, provisioning.WindowsPool}
 
 	tests := []struct {
-		name         string
-		client       *rancher.Client
-		nodeRoles    []string
-		nodeCountWin int
-		hasWindows   bool
-		psact        string
+		name      string
+		client    *rancher.Client
+		nodeRoles []machinepools.NodeRoles
+		psact     string
+		isWindows bool
 	}{
-		{"1 Node all roles " + provisioning.AdminClientName.String(), c.client, nodeRoles0, 0, false, c.psact},
-		{"1 Node all roles " + provisioning.StandardClientName.String(), c.standardUserClient, nodeRoles0, 0, false, c.psact},
-		{"2 nodes - etcd/cp roles per 1 node " + provisioning.AdminClientName.String(), c.client, nodeRoles1, 0, false, c.psact},
-		{"2 nodes - etcd/cp roles per 1 node " + provisioning.StandardClientName.String(), c.standardUserClient, nodeRoles1, 0, false, c.psact},
-		{"3 nodes - 1 role per node " + provisioning.AdminClientName.String(), c.client, nodeRoles2, 0, false, c.psact},
-		{"3 nodes - 1 role per node " + provisioning.StandardClientName.String(), c.standardUserClient, nodeRoles2, 0, false, c.psact},
-		{provisioning.AdminClientName.String() + " 1 Node all roles + 1 Windows Worker", c.client, nodeRoles0, 1, true, c.psact},
-		{provisioning.StandardClientName.String() + " 1 Node all roles + 1 Windows Worker", c.standardUserClient, nodeRoles0, 1, true, c.psact},
-		{provisioning.AdminClientName.String() + " 2 nodes - etcd/cp roles per 1 node + 1 Windows Worker", c.client, nodeRoles1, 1, true, c.psact},
-		{provisioning.StandardClientName.String() + " 2 nodes - etcd/cp roles per 1 node + 1 Windows Worker", c.standardUserClient, nodeRoles1, 1, true, c.psact},
-		{"3 nodes - 1 role per node " + provisioning.AdminClientName.String(), c.client, nodeRoles2, 2, true, c.psact},
-		{"3 nodes - 1 role per node " + provisioning.StandardClientName.String(), c.standardUserClient, nodeRoles2, 2, true, c.psact},
+		{"1 Node all roles " + provisioning.AdminClientName.String(), c.client, nodeRolesAll, c.psact, false},
+		{"1 Node all roles " + provisioning.StandardClientName.String(), c.standardUserClient, nodeRolesAll, c.psact, false},
+		{"2 nodes - etcd/cp roles per 1 node " + provisioning.AdminClientName.String(), c.client, nodeRolesShared, c.psact, false},
+		{"2 nodes - etcd/cp roles per 1 node " + provisioning.StandardClientName.String(), c.standardUserClient, nodeRolesShared, c.psact, false},
+		{"3 nodes - 1 role per node " + provisioning.AdminClientName.String(), c.client, nodeRolesDedicated, c.psact, false},
+		{"3 nodes - 1 role per node " + provisioning.StandardClientName.String(), c.standardUserClient, nodeRolesDedicated, c.psact, false},
+		{"4 nodes - 1 role per node + 1 windows worker" + provisioning.AdminClientName.String(), c.client, nodeRolesDedicatedWindows, c.psact, true},
+		{"4 nodes - 1 role per node + 1 windows worker" + provisioning.StandardClientName.String(), c.standardUserClient, nodeRolesDedicatedWindows, c.psact, true},
 	}
 	var name string
 	for _, tt := range tests {
@@ -121,19 +115,22 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE2CustomCluster()
 
 		client, err := tt.client.WithSession(testSession)
 		require.NoError(c.T(), err)
-
-		for _, nodeProviderName := range c.nodeProviders {
-			externalNodeProvider := provisioning.ExternalNodeProviderSetup(nodeProviderName)
-			providerName := " Node Provider: " + nodeProviderName
-			for _, kubeVersion := range c.kubernetesVersions {
-				name = tt.name + providerName + " Kubernetes version: " + kubeVersion
-				for _, cni := range c.cnis {
-					name += " cni: " + cni
-					c.Run(name, func() {
-						TestProvisioningRKE2CustomCluster(c.T(), client, externalNodeProvider, tt.nodeRoles, tt.psact, kubeVersion, cni, c.hardened, tt.nodeCountWin, tt.hasWindows, c.advancedOptions)
-					})
+		if (c.isWindows == tt.isWindows) || (c.isWindows && !tt.isWindows) {
+			for _, nodeProviderName := range c.nodeProviders {
+				externalNodeProvider := provisioning.ExternalNodeProviderSetup(nodeProviderName)
+				providerName := " Node Provider: " + nodeProviderName
+				for _, kubeVersion := range c.kubernetesVersions {
+					name = tt.name + providerName + " Kubernetes version: " + kubeVersion
+					for _, cni := range c.cnis {
+						name += " cni: " + cni
+						c.Run(name, func() {
+							TestProvisioningRKE2CustomCluster(c.T(), client, externalNodeProvider, tt.nodeRoles, tt.psact, kubeVersion, cni, c.hardened, c.advancedOptions)
+						})
+					}
 				}
 			}
+		} else {
+			c.T().Skip("Skipping Windows tests")
 		}
 	}
 }
@@ -142,38 +139,17 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE2CustomClusterDy
 	clustersConfig := new(provisioning.Config)
 	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 	nodesAndRoles := clustersConfig.NodesAndRoles
-
 	if len(nodesAndRoles) == 0 {
 		c.T().Skip()
 	}
 
-	rolesPerNode := []string{}
-
-	for _, nodes := range nodesAndRoles {
-		var finalRoleCommand string
-		if nodes.ControlPlane {
-			finalRoleCommand += " --controlplane"
-		}
-		if nodes.Etcd {
-			finalRoleCommand += " --etcd"
-		}
-		if nodes.Worker {
-			finalRoleCommand += " --worker"
-		}
-		rolesPerNode = append(rolesPerNode, finalRoleCommand)
-	}
-
 	tests := []struct {
-		name         string
-		client       *rancher.Client
-		nodeCountWin int
-		hasWindows   bool
-		psact        string
+		name   string
+		client *rancher.Client
+		psact  string
 	}{
-		{provisioning.AdminClientName.String(), c.client, 0, false, c.psact},
-		{provisioning.StandardClientName.String(), c.standardUserClient, 0, false, c.psact},
-		{"1 Windows Worker" + provisioning.AdminClientName.String(), c.client, 1, true, c.psact},
-		{"1 Windows Worker" + provisioning.StandardClientName.String(), c.standardUserClient, 1, true, c.psact},
+		{provisioning.AdminClientName.String(), c.client, c.psact},
+		{provisioning.StandardClientName.String(), c.standardUserClient, c.psact},
 	}
 	var name string
 	for _, tt := range tests {
@@ -191,7 +167,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE2CustomClusterDy
 				for _, cni := range c.cnis {
 					name += " cni: " + cni
 					c.Run(name, func() {
-						TestProvisioningRKE2CustomCluster(c.T(), client, externalNodeProvider, rolesPerNode, tt.psact, kubeVersion, cni, c.hardened, tt.nodeCountWin, tt.hasWindows, c.advancedOptions)
+						TestProvisioningRKE2CustomCluster(c.T(), client, externalNodeProvider, nodesAndRoles, tt.psact, kubeVersion, cni, c.hardened, c.advancedOptions)
 					})
 				}
 			}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/547
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
with the last addition to custom clusters in the framework, we were limited to only 2 node pools when provisioning.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
* refactor to allow any node to be provisioned through ec2 without explicitly defining windows vs. linux. 
  * this was done by adding new role `windows` to nodesAndRoles, and adding a new field `roles` for a given ec2Config
* add logic to include public address in the registration command for rke2 (this was causing issues when registering windows nodes)
* for rke1, specify both public and private IP address in registration command
* for ec2.go, refactor to provision all nodes first, then check status = ready to speed up testing time -> O(n) is now O(1) where n = node ready time


## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
tested locally using multiple pools in rke2 with windows being one of them

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
pending automated runs for:
* k3s
* rke1
* rke2
* rke2 + windows (local only)

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
the IP address specification may need some conditional logic if we ever tie in registry / airgap tests using this part of the framework. But from what I've seen so far, those are being added in their own dedicated folders. 

this sort of jumbles the non-dynamic custom cluster provisioning test section, because we now have to define the node pools instead of defining strings. But in the long run, this approach made more sense to me as it is using the actual objects that we would refer to rather than strings emulating them. 