### PR TITLE
[release/v2.7] Simplify image digests files

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1368,7 +1368,7 @@ depends_on:
 - default-windows-ltsc2022
 ---
 kind: pipeline
-name: docker-image-digests-linux-amd64
+name: docker-image-digests-linux
 
 platform:
   os: linux
@@ -1376,64 +1376,29 @@ platform:
 
 steps:
 - name: docker-image-digests
-  image: rancher/drone-docker-image-digests:v0.0.12
-  environment:
-    PLUGIN_GITHUB_REPOSITORY: "rancher/rancher"
-    PLUGIN_GITHUB_TOKEN:
-      from_secret: github_token
-    PLUGIN_GITHUB_TAG: "${DRONE_TAG}"
-    PLUGIN_INPUT_FILE: "rancher-images.txt"
-    PLUGIN_OUTPUT_FILE: "rancher-images-digests-linux-amd64.txt"
-    PLUGIN_REGISTRY: "docker.io"
+  image: rancher/dapper:v0.6.0
+  privileged: true
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  commands:
+  - dapper generate-linux-digests.sh
   when:
     instance:
       include:
       - drone-publish.rancher.io
     event:
     - tag
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
-
-trigger:
-  event:
-    exclude:
-    - promote
-    - pull_request
-
-depends_on:
-- default-linux-amd64
----
-kind: pipeline
-name: docker-image-digests-linux-arm64
-
-platform:
-  os: linux
-  arch: arm64
-
-steps:
-- name: docker-image-digests
-  image: rancher/drone-docker-image-digests:v0.0.12
-  environment:
-    PLUGIN_GITHUB_REPOSITORY: "rancher/rancher"
-    PLUGIN_GITHUB_TOKEN:
+- name: github_binary_release_digests
+  image: plugins/github-release
+  settings:
+    api_key:
       from_secret: github_token
-    PLUGIN_GITHUB_TAG: "${DRONE_TAG}"
-    PLUGIN_INPUT_FILE: "rancher-images.txt"
-    PLUGIN_OUTPUT_FILE: "rancher-images-digests-linux-arm64.txt"
-    PLUGIN_REGISTRY: "docker.io"
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
+    files:
+    - "bin/rancher-images-digests-linux-*"
   when:
     instance:
-      include:
-      - drone-publish.rancher.io
+    - drone-publish.rancher.io
     event:
     - tag
 
@@ -1451,63 +1416,6 @@ trigger:
 depends_on:
 - default-linux-amd64
 - default-linux-arm64
----
-kind: pipeline
-name: docker-image-digests-linux-s390x
-
-platform:
-  os: linux
-  arch: amd64
-
-# Hack needed for s390x: https://gist.github.com/colstrom/c2f359f72658aaabb44150ac20b16d7c#gistcomment-3858388
-node:
-  arch: s390x
-
-clone:
-  disable: true
-
-steps:
-- name: clone
-  image: alpine/git:v2.30.2-s390x
-  commands:
-  - git clone $DRONE_GIT_HTTP_URL  .
-  - git fetch origin $DRONE_COMMIT_REF
-  - git checkout $DRONE_COMMIT -b origin/$DRONE_TARGET_BRANCH
-
-- name: docker-image-digests
-  image: rancher/drone-docker-image-digests:v0.0.13
-  failure: ignore
-  environment:
-    PLUGIN_GITHUB_REPOSITORY: "rancher/rancher"
-    PLUGIN_GITHUB_TOKEN:
-      from_secret: github_token
-    PLUGIN_GITHUB_TAG: "${DRONE_TAG}"
-    PLUGIN_INPUT_FILE: "rancher-images.txt"
-    PLUGIN_OUTPUT_FILE: "rancher-images-digests-linux-s390x.txt"
-    PLUGIN_REGISTRY: "docker.io"
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-  when:
-    instance:
-      include:
-      - drone-publish.rancher.io
-    event:
-    - tag
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
-
-trigger:
-  event:
-    exclude:
-    - promote
-    - pull_request
-
-depends_on:
-- default-linux-amd64
 - default-linux-s390x
 ---
 kind: pipeline

--- a/scripts/generate-linux-digests.sh
+++ b/scripts/generate-linux-digests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+cd $(dirname $0)/.. 
+mkdir -p bin
+
+declare -a archs=(amd64 arm64 s390x)
+
+if [ -z "${DRONE_TAG}" ]; then
+    echo "Environment variable DRONE_TAG not set"
+    exit 0
+fi
+
+DIGEST_TEMPLATE_FILENAME="./bin/rancher-images-digests-linux"
+IMAGES_FILE=$(mktemp)
+IMAGES_URL="https://github.com/rancher/rancher/releases/download/${DRONE_TAG}/rancher-images.txt"
+
+wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 10 $IMAGES_URL -O $IMAGES_FILE
+
+for image in $(cat $IMAGES_FILE); do
+    INSPECT_JSON=$(skopeo inspect "docker://${image}" --raw)
+    MEDIATYPE=$(echo "${INSPECT_JSON}" | jq -r .mediaType)
+    echo "Image: ${image}, mediaType: ${MEDIATYPE}"
+    if [ "${MEDIATYPE}" = "application/vnd.docker.distribution.manifest.list.v2+json" ] || [ "${MEDIATYPE}" = "application/vnd.oci.image.index.v1+json" ]; then
+        DIGEST=$(echo -n "${INSPECT_JSON}" | sha256sum | awk '{ print $1 }')
+        for arch in "${archs[@]}"; do
+            if echo "${INSPECT_JSON}" | jq -e  --arg ARCH "$arch" 'select(.manifests[].platform.architecture == $ARCH)' >/dev/null 2>&1; then
+                echo "docker.io/${image} sha256:${DIGEST}" >> "${DIGEST_TEMPLATE_FILENAME}-${arch}.txt"
+            fi
+        done
+    else
+        for arch in "${archs[@]}"; do
+            IMAGE_ARCH=$(skopeo --override-arch $arch inspect "docker://${image}" --format "{{ .Architecture }}")
+            if [ "${IMAGE_ARCH}" = "${arch}" ]; then
+                echo "Image: ${image}, arch ${arch}, FOUND"
+                DIGEST=$(skopeo --override-arch $arch inspect "docker://${image}" --raw | sha256sum | awk '{ print $1 }')
+                echo "docker.io/${image} sha256:${DIGEST}" >> "${DIGEST_TEMPLATE_FILENAME}-${arch}.txt"
+            else
+                echo "Image: ${image}, arch ${arch}, NOT_FOUND"
+            fi
+        done
+    fi
+done
+
+rm -f ${IMAGES_FILE}
+
+ls -la ./bin/rancher-images-digests-linux-*


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/41959
 
## Problem
This improvement came from working on https://github.com/rancher/image-mirror/issues/379, where I was comparing how we collect digests versus how image-mirror does it.

Currently we are using https://github.com/rancher/drone-docker-image-digests to generate the image digests file on a tag event. The "problem" here is that this uses one machine per arch, and retrieves the digest by pulling all the images. This is wasting resources and time, as (for Linux) we can also generate these from one machine without pulling all the images. There is also no maintenance on https://github.com/rancher/drone-docker-image-digests.
 
## Solution
This moves all the Linux based image digests to one script, retrieving the digests per image (depending if its a manifest list or not), and only adds the value if the image is actually built for the specific arch. Currently the digests file have images with empty digests as they are not for that arch. This change also reduces the 3 machine with each ~30 min build, to 10-12 minute on a single machine.
 
## Testing
Run an rc tag and check the release assets for the digests file

## Engineering Testing
### Manual Testing
Here is how I tested it:

```
echo "DRONE_TAG=v2.7.3" > /tmp/env
time drone exec --trusted --pipeline docker-image-digests-linux --event tag --env-file /tmp/env --include docker-image-digests
...
real    12m0.586s
```

I compared the digests files with the current release assets:

```
mkdir -p /tmp/release && for arch in amd64 arm64 s390x; do wget https://github.com/rancher/rancher/releases/download/v2.7.3/rancher-images-digests-linux-${arch}.txt -P /tmp/release/; done
```

Check amd64
```
$ diff rancher-images-digests-linux-amd64.txt /tmp/release/rancher-images-digests-linux-amd64.txt
307c307
< docker.io/rancher/mirrored-neuvector-scanner:latest sha256:ce00a90302353de66294ee3256c1e538da135a31362659a64a195a5b7b23c8c7
---
> docker.io/rancher/mirrored-neuvector-scanner:latest sha256:7a5f99db423360c4606f6402e1861569b64f4290806c7747d8498d565dc86834
```

Which makes sense as this is a moving tag.

Check arm64 and s390x (because those contain image lines without digest, I delete those lines for the comparison):

```
$ for arch in arm64 s390x; do echo $arch; comm -13 rancher-images-digests-linux-$arch.txt <(awk 'NF > 1' /tmp/release/rancher-images-digests-linux-$arch.txt); echo "end ${arch}" ; done
arm64
docker.io/rancher/coreos-kube-state-metrics:v1.9.7 sha256:2f82f0da199c60a7699c43c63a295c44e673242de0b7ee1b17c2d5a23bec34cb
docker.io/rancher/coreos-prometheus-config-reloader:v0.38.1 sha256:d1cce64093d4a850d28726ec3e48403124808f76567b5bd7b26e4416300996a7
docker.io/rancher/coreos-prometheus-operator:v0.38.1 sha256:62b8cf466e9b238a9fcf0bcba74562c8833e7451042321e323a46de3f1dbe1bc
docker.io/rancher/harvester-cloud-provider:v0.1.4 sha256:d958e3176eeb3188c793f56b18990706cff2633451f238231ba05cde21d0f72d
docker.io/rancher/harvester-cloud-provider:v0.1.5 sha256:a96ae4a64561cfa1d4d10469aec83278362c4907d4e53fa782ead9ac7311b570
docker.io/rancher/harvester-csi-driver:v0.1.3 sha256:80018578e3bf043011fce4cd4ced162ad6611e0fcf1db8559a7b3728d3d92601
docker.io/rancher/harvester-csi-driver:v0.1.4 sha256:17aa57c6e6953c5e1c064584aa13c135dba587f6aa643a60e4771766e2e186b1
docker.io/rancher/harvester-csi-driver:v0.1.5 sha256:87ef98695ded985e40b030cf4311227ba23dbbadd7aba1efa77d4d219ec389fc
docker.io/rancher/istio-installer:1.15.3-rancher1 sha256:6478ff0c4d16d9dd453c7555fb63572a9f01fff6723bac9d9a9b1b49134a66ff
docker.io/rancher/prometheus-auth:v0.2.1 sha256:b8d21dad8923689177c526ab0291d30e22180a754b0b3ca8eb67dd142063c87a
docker.io/rancher/prometheus-auth:v0.2.2 sha256:496040b5728093dbfd086157412a9f868fc26f807cfc4de613856cee62c04581
docker.io/rancher/webhook-receiver:v0.2.4 sha256:0e3e1591da5bb6730a75a7d3d29139858d1a909dfe8040ea4a06ad160e62fd74
docker.io/rancher/webhook-receiver:v0.2.5 sha256:8400c31756247890f4010db1588276f05821963e1ec736f8d439cdc69a1bef76
end arm64
s390x
docker.io/rancher/coreos-kube-state-metrics:v1.9.7 sha256:2f82f0da199c60a7699c43c63a295c44e673242de0b7ee1b17c2d5a23bec34cb
docker.io/rancher/coreos-prometheus-config-reloader:v0.38.1 sha256:d1cce64093d4a850d28726ec3e48403124808f76567b5bd7b26e4416300996a7
docker.io/rancher/coreos-prometheus-operator:v0.38.1 sha256:62b8cf466e9b238a9fcf0bcba74562c8833e7451042321e323a46de3f1dbe1bc
docker.io/rancher/harvester-cloud-provider:v0.1.4 sha256:d958e3176eeb3188c793f56b18990706cff2633451f238231ba05cde21d0f72d
docker.io/rancher/harvester-cloud-provider:v0.1.5 sha256:a96ae4a64561cfa1d4d10469aec83278362c4907d4e53fa782ead9ac7311b570
docker.io/rancher/harvester-csi-driver:v0.1.3 sha256:80018578e3bf043011fce4cd4ced162ad6611e0fcf1db8559a7b3728d3d92601
docker.io/rancher/harvester-csi-driver:v0.1.4 sha256:17aa57c6e6953c5e1c064584aa13c135dba587f6aa643a60e4771766e2e186b1
docker.io/rancher/harvester-csi-driver:v0.1.5 sha256:87ef98695ded985e40b030cf4311227ba23dbbadd7aba1efa77d4d219ec389fc
docker.io/rancher/istio-installer:1.15.3-rancher1 sha256:6478ff0c4d16d9dd453c7555fb63572a9f01fff6723bac9d9a9b1b49134a66ff
docker.io/rancher/prometheus-auth:v0.2.1 sha256:b8d21dad8923689177c526ab0291d30e22180a754b0b3ca8eb67dd142063c87a
docker.io/rancher/prometheus-auth:v0.2.2 sha256:496040b5728093dbfd086157412a9f868fc26f807cfc4de613856cee62c04581
docker.io/rancher/webhook-receiver:v0.2.4 sha256:0e3e1591da5bb6730a75a7d3d29139858d1a909dfe8040ea4a06ad160e62fd74
docker.io/rancher/webhook-receiver:v0.2.5 sha256:8400c31756247890f4010db1588276f05821963e1ec736f8d439cdc69a1bef76
end s390x
```

I found it strange so many images were shown as diff, but I tested running these images on arm64 and s390x machine and they can be pulled but not run. So the images being the files with a digest is already wrong, as they cant actually be run on that arch. In my opinion, this makes the digests files more accurate.

### Automated Testing
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->