### PR TITLE
[release/v2.7] renovate: Limit number of concurrent PRs/Branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,6 @@
     "release/v2.7"
   ],
   "prHourlyLimit": 2,
-  "prConcurrentLimit": 4
+  "prConcurrentLimit": 4,
+  "prCreation": "status-success"
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,6 @@
   "baseBranches": [
     "release/v2.7"
   ],
-  "prHourlyLimit": 2
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 4
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
N/A
 
## Problem
Renovate bot currently has over [30 opened PRs](https://github.com/rancher/rancher/pulls/app%2Frenovate-rancher) for version bumps. It is inefficient to keep multiple parallel PRs, as each merge may lead to a cascading impact of rebasing in the remaining opened PRs. 
 
## Solution
Limit the max number of concurrent PRs to `4`. So that at any point in time there are only `4` branches / PRs created by renovate bot.

As currently there are more than the new concurrent limit, most in-flight PRs will need to be merged before new PRs are created.
 
## Testing
N/A

## Engineering Testing
### Manual Testing
N/A

### Automated Testing
N/A

## QA Testing Considerations
N/A
 
### Regressions Considerations
N/A