### PR TITLE
[v2.6] Set autouse to False in AKS/EKS v2 tests

### DIFF
--- a/tests/validation/tests/v3_api/test_aks_v2_hosted_cluster.py
+++ b/tests/validation/tests/v3_api/test_aks_v2_hosted_cluster.py
@@ -124,7 +124,7 @@ def create_and_validate_aks_cluster(cluster_config, imported=False):
     return client, cluster
 
 
-@pytest.fixture(scope='module', autouse="True")
+@pytest.fixture(scope='module', autouse="False")
 def create_project_client(request):
     def fin():
         client = get_user_client()

--- a/tests/validation/tests/v3_api/test_eks_v2_hosted_cluster.py
+++ b/tests/validation/tests/v3_api/test_eks_v2_hosted_cluster.py
@@ -203,7 +203,7 @@ def create_resources_eks():
     return cluster_name
 
 
-@pytest.fixture(scope='module', autouse="True")
+@pytest.fixture(scope='module', autouse="False")
 def create_project_client(request):
 
     def fin():


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
AKS and EKS v2 hosted cluster tests are auto-deleting themselves before the certification tests have a chance to run. This is because we are calling for the cluster deletion to occur before the certification tests are called.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Disable the clusters auto-deleting themselves.
