### PR TITLE
Update CI logs when waiting for rancher-webhook.

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -91,6 +91,13 @@ run_rancher()
     done
 }
 
+tail_slow_starting_rancher()
+{
+    sleep 300
+    echo 'Rancher has not deployed webhook after 5m tailing logs'
+    tail -f "/tmp/rancher.log"
+}
+
 # uncomment to get startup logs. Don't leave them on because it slows drone down too
 # much
 #tail -F /tmp/rancher.log &
@@ -108,11 +115,26 @@ echo Sleeping for 5 seconds before checking Rancher health
 sleep 5
 
 while ! curl -sf http://localhost:8080/ping; do
-    sleep 2
+    sleep 5
 done
-while ! kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-system deploy/rancher-webhook; do
-    sleep 2
+
+# Tail the rancher logs if rancher fails to deploy the webhook after 5 minutes.
+tail_slow_starting_rancher &
+# Get PID of the tail command so we can kill it if needed using pgrep over $! since there are other async commands being run
+TAIL_PID=$!
+
+# Wait for Rancher to deploy rancher-webhook.
+while ! kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-system deploy/rancher-webhook >/dev/null 2>&1; do
+    echo "Waiting for rancher to deploy rancher-webhook..."
+    sleep 5
 done
+
+# After rancher deploys webhook kill the bash command running tail.
+kill ${TAIL_PID}
+KILL_PID=$!
+# Dump the terminated message from the above kill command.
+wait ${KILL_PID} 2>/dev/null
+
 #kill $TPID
 
 echo Running provisioning-tests

--- a/scripts/run
+++ b/scripts/run
@@ -9,7 +9,7 @@ if [ ! -x $CMD ]; then
     ./scripts/build-server
 fi
 
-if [ $1 = "--trace" ] || [ $1 = "--info" ] || [ $1 = "--debug" ]; then
+if [ ! -z $1 ] && ( [ $1 = "--trace" ] || [ $1 = "--info" ] || [ $1 = "--debug" ] ); then
   LOGFLAG=$1
 fi
 

--- a/scripts/test
+++ b/scripts/test
@@ -53,12 +53,19 @@ run_rancher()
             sleep 5
         fi
         if [ "$PID" = "-1" ]; then
-          echo Starting rancher server using run
-          ./scripts/run >/tmp/rancher.log 2>&1 &
-          PID=$!
+            echo Starting rancher server using run
+            ./scripts/run >/tmp/rancher.log 2>&1 &
+            PID=$(pgrep -f "./scripts/run")
         fi
         sleep 2
     done
+}
+
+tail_slow_starting_rancher()
+{
+    sleep 300
+    echo 'Rancher has not deployed webhook after 5m tailing logs'
+    tail -f "/tmp/rancher.log"
 }
 
 # uncomment to get startup logs. Don't leave them on because it slows drone down too
@@ -67,19 +74,33 @@ run_rancher()
 #TPID=$!
 PID=-1
 run_rancher &
-RANCHER_RUN_PID=$!
+RANCHER_RUN_PID=$(pgrep -f "run_rancher")
 trap cleanup exit
 
-echo Sleeping for 5 seconds before checking Rancher health
+echo Sleeping for 5 seconds before checking Rancher health3
 sleep 5
 
 while ! curl -sf http://localhost:8080/ping; do
     sleep 2
 done
 
-while ! kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-system deploy/rancher-webhook; do
-    sleep 2
+# Tail the rancher logs if rancher fails to deploy the webhook after 5 minutes.
+tail_slow_starting_rancher &
+# Get PID of the tail command so we can kill it if needed using pgrep over $! since there are other async commands being run
+TAIL_PID=$!
+
+# Wait for Rancher to deploy rancher-webhook.
+while ! kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-system deploy/rancher-webhook >/dev/null 2>&1; do
+    echo "Waiting for rancher to deploy rancher-webhook..."
+    sleep 5
 done
+
+# After rancher deploys webhook kill the bash command running tail.
+kill ${TAIL_PID}
+KILL_PID=$!
+# Dump the terminated message from the above kill command.
+wait ${KILL_PID} 2>/dev/null
+
 #kill $TPID
 
 # get correct agent tag


### PR DESCRIPTION
## Issue: #40824 
 
## Problem
When Rancher fails to start and does not deploy the webhook there is no way of determining why via the CI logs.
 
## Solution
CI now waits for Rancher to deploy rancher-webhook like normal, except if the deployment takes longer than 5 minutes CI will start to tail the Rancher logs until the webhook is deployed. This allows a user to see what Rancher is doing and why it isn't deploying in a timely manner.

## Testing
No tests are needed for CI logs.
 
### Regressions Considerations
Changes only affect CI logs.