### PR TITLE
[v2.7] Stop hosted clusters from deleting before tests run

### DIFF
--- a/tests/validation/tests/v3_api/common.py
+++ b/tests/validation/tests/v3_api/common.py
@@ -1503,13 +1503,14 @@ def cluster_cleanup(client, cluster, aws_nodes=None):
         create_config_file(env_details)
         
         
-def hosted_cluster_cleanup(client, cluster):
+def hosted_cluster_cleanup(client, cluster, cluster_name):
     if RANCHER_CLEANUP_CLUSTER:
         client.delete(cluster)
     else:
         env_details = "env.CATTLE_TEST_URL='" + CATTLE_TEST_URL + "'\n"
         env_details += "env.ADMIN_TOKEN='" + ADMIN_TOKEN + "'\n"
         env_details += "env.USER_TOKEN='" + USER_TOKEN + "'\n"
+        env_details += "env.CLUSTER_NAME='" + cluster_name + "'\n"
         create_config_file(env_details)
 
 

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -159,7 +159,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                 def GO_CATTLE_TEST_URL = env.CATTLE_TEST_URL.replace('https://', '')
                 env.CONFIG = env.CONFIG.replace('${CATTLE_TEST_URL}', "${GO_CATTLE_TEST_URL}")
                 env.CONFIG = env.CONFIG.replace('${ADMIN_TOKEN}', env.ADMIN_TOKEN)
-                env.CONFIG = env.CONFIG.replace('${AZURE_CLIENT_ID}', env.USER_TOKEN)
+                env.CONFIG = env.CONFIG.replace('${AZURE_CLIENT_ID}', env.AZURE_CLIENT_ID)
                 env.CONFIG = env.CONFIG.replace('${AZURE_CLIENT_SECRET}', env.AZURE_CLIENT_SECRET)
                 env.CONFIG = env.CONFIG.replace('${AZURE_SUBSCRIPTION_ID}', env.AZURE_SUBSCRIPTION_ID)
                 env.CONFIG = env.CONFIG.replace('${AWS_SECRET_ACCESS_KEY}', env.AWS_SECRET_ACCESS_KEY)

--- a/tests/validation/tests/v3_api/test_aks_v2_hosted_cluster.py
+++ b/tests/validation/tests/v3_api/test_aks_v2_hosted_cluster.py
@@ -69,7 +69,7 @@ def test_aks_v2_hosted_cluster_create_basic():
         "enableClusterMonitoring": False
     }
     cluster = create_and_validate_aks_cluster(cluster_config)
-    hosted_cluster_cleanup(client, cluster)
+    hosted_cluster_cleanup(client, cluster, cluster_name)
 
 
 def get_aks_config(cluster_name):
@@ -122,14 +122,3 @@ def create_and_validate_aks_cluster(cluster_config, imported=False):
                                skipIngresscheck=True,
                                timeout=DEFAULT_TIMEOUT_AKS)
     return client, cluster
-
-
-@pytest.fixture(scope='module', autouse="False")
-def create_project_client(request):
-    def fin():
-        client = get_user_client()
-        for name, cluster in cluster_details.items():
-            if len(client.list_cluster(name=name).data) > 0:
-                client.delete(cluster)
-
-    request.addfinalizer(fin)

--- a/tests/validation/tests/v3_api/test_eks_v2_hosted_cluster.py
+++ b/tests/validation/tests/v3_api/test_eks_v2_hosted_cluster.py
@@ -86,7 +86,7 @@ def test_eks_v2_hosted_cluster_create_basic():
 
     # validate nodegroups created
     validate_nodegroup(eks_config_temp["nodeGroups"], cluster_name)
-    hosted_cluster_cleanup(client, cluster)
+    hosted_cluster_cleanup(client, cluster, cluster_name)
 
 
 @ekscredential
@@ -201,20 +201,6 @@ def create_resources_eks():
     IMPORTED_EKS_CLUSTERS.append(cluster_name)
     AmazonWebServices().wait_for_eks_cluster_state(cluster_name, "ACTIVE")
     return cluster_name
-
-
-@pytest.fixture(scope='module', autouse="False")
-def create_project_client(request):
-
-    def fin():
-        client = get_user_client()
-        for name, cluster in cluster_details.items():
-            if len(client.list_cluster(name=name).data) > 0:
-                client.delete(cluster)
-        for display_name in IMPORTED_EKS_CLUSTERS:
-            AmazonWebServices().delete_eks_cluster(cluster_name=display_name)
-
-    request.addfinalizer(fin)
 
 
 def create_and_validate_eks_cluster(cluster_config, imported=False):


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Fix Ontag Automation runs](https://github.com/rancher/qa-tasks/issues/429)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
AKS and EKS clusters are deleting themselves upon successful provisioning. This is an issue as the certification tests are not being called right after, which defeats the point of the automation.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Removed the `create_project_client` function that is deleting the cluster based upon the cluster creating.
