### PR TITLE
Improving k8s 1.25 compatibility for rancher/chart

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,11 +5,10 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 ENV CATTLE_HELM_VERSION v2.16.8-rancher2
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher99
 ENV CATTLE_K3S_VERSION v1.26.4+k3s1
-# version used by helm plugin install script
-ENV CATTLE_HELM_UNITTEST_VERSION v0.1.7-rancher4
 # helm 3 version
 ENV HELM_VERSION v3.11.3
 ENV KUSTOMIZE_VERSION v5.0.1
+ENV HELM_UNITTEST_VERSION 0.3.2
 # k3d ci version
 ENV K3D_VERSION v5.4.6
 
@@ -49,8 +48,7 @@ RUN curl -sLf ${!HELM_URL_V2} -o /usr/bin/rancher-helm && \
     chmod +x /usr/bin/rancher-helm /usr/bin/rancher-tiller && \
     ln -s /usr/bin/rancher-helm /usr/bin/helm && \
     ln -s /usr/bin/rancher-tiller /usr/bin/tiller && \
-    helm init -c --stable-repo-url https://charts.helm.sh/stable/ && \
-    helm plugin install https://github.com/rancher/helm-unittest
+    helm init -c --stable-repo-url https://charts.helm.sh/stable/
 
 # set up helm 3
 RUN mkdir /usr/tmp && \
@@ -113,6 +111,13 @@ ENV DAPPER_DOCKER_SOCKET true
 ENV DAPPER_RUN_ARGS "-v rancher2-go16-pkg-1:/go/pkg -v rancher2-go16-cache-1:/root/.cache/go-build --privileged --network=host"
 ENV GOCACHE /root/.cache/go-build
 ENV HOME ${DAPPER_SOURCE}
+
+# set up helm unittest - only needs to run on one arch. Needs to run after $HOME has been changed so we can find it later 
+RUN if [ "${ARCH}" == "amd64" ]; then \
+        helm_v3 plugin install https://github.com/helm-unittest/helm-unittest.git --version ${HELM_UNITTEST_VERSION}; \
+    fi
+
+
 VOLUME /var/lib/rancher
 VOLUME /var/lib/kubelet
 WORKDIR ${DAPPER_SOURCE}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -74,3 +74,28 @@ add below linux tolerations to workloads could be scheduled to those linux nodes
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Define the chosen value for PSPs. If this value is "", then the user did not set the value. This will
+result in psps on <=1.24 and no psps on >=1.25. If the value is true/false, then the user specifically
+chose an option, and that option will be used. If it is set otherwise, then we fail so the user can correct
+the invalid value.
+*/}}
+
+{{- define "rancher.chart_psp_enabled" -}}
+{{- if kindIs "bool" .Values.global.cattle.psp.enabled -}}
+{{ .Values.global.cattle.psp.enabled }}
+{{- else if empty .Values.global.cattle.psp.enabled -}}
+  {{- if gt (len (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "")) 0 -}}
+    {{- if (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") -}}
+true
+    {{- else -}}
+false
+    {{- end -}}
+  {{- else -}}
+true
+  {{- end -}}
+{{- else -}}
+{{- fail "Invalid value for .Values.global.cattle.psp.enabled - must be a bool of true, false, or \"\"" -}}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/post-delete-hook-cluster-role.yaml
+++ b/chart/templates/post-delete-hook-cluster-role.yaml
@@ -33,7 +33,7 @@ rules:
   - apiGroups: [ "policy" ]
     resources: [ "podsecuritypolicies" ]
     verbs: ["delete", "create" ]
-{{- if .Values.global.cattle.psp.enabled }}
+{{- if eq (include "rancher.chart_psp_enabled" . ) "true" }}
   - apiGroups: [ "policy" ]
     resources: [ "podsecuritypolicies" ]
     verbs: [ "use"]

--- a/chart/templates/post-delete-hook-psp.yaml
+++ b/chart/templates/post-delete-hook-psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.cattle.psp.enabled  -}}
+{{- if eq (include "rancher.chart_psp_enabled" . ) "true" -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/chart/templates/validate-psp-install.yaml
+++ b/chart/templates/validate-psp-install.yaml
@@ -1,7 +1,0 @@
-#{{- if gt (len (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "")) 0 -}}
-#{{- if .Values.global.cattle.psp.enabled }}
-#{{- if not (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
-#{{- fail "The target cluster does not have the PodSecurityPolicy API resource. Please disable PSPs in this chart before proceeding." -}}
-#{{- end }}
-#{{- end }}
-#{{- end -}}

--- a/chart/tests/README.md
+++ b/chart/tests/README.md
@@ -10,24 +10,7 @@ Option 1: Full chart CI run with a live cluster
 Option 2: Test runs against the chart only 
 
 ```bash
-# Install plugin if necessary, for version see CATTLE_HELM_UNITTEST_VERSION
-# For a Mac you'll need to download a release and install the darwin binary
-# For linux:
-export ARCH=amd64 export CATTLE_HELM_UNITTEST_VERSION={version} helm plugin install https://github.com/rancher/helm-unittest
-
-# change automated parts of templates
-test_image="rancher/rancher"
-test_image_tag="v2.7.0"
-sed -i -e "s/%VERSION%/${test_image_tag}/g" ./chart/Chart.yaml
-sed -i -e "s/%APP_VERSION%/${test_image_tag}/g" ./chart/Chart.yaml
-sed -i -e "s@%POST_DELETE_IMAGE_NAME%@${test_image}@g" ./chart/values.yaml
-sed -i -e "s/%POST_DELETE_IMAGE_TAG%/${test_image_tag}/g" ./chart/values.yaml
-
-# test
-helm lint ./chart
-helm unittest ./chart
-
-# clean
-git checkout chart/*
+# install the helm plugin first - helm plugin install https://github.com/helm-unittest/helm-unittest.git
+bash dev-scripts/helm-unittest.sh
 ```
 

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -197,13 +197,13 @@ tests:
     customLogos.enabled: true
     customLogos.volumeKind: configMap
   asserts:
-  - isNull:
+  - isNullOrEmpty:
       path: spec.template.spec.volumes
 - it: should not create custom-logos volume if not customLogos.enabled
   set:
     customLogos.enabled: false
   asserts:
-  - isNull:
+  - isNullOrEmpty:
       path: spec.template.spec.volumes
 - it: should mount custom-logos volume with default subpaths if customLogos.enabled and customLogos.volumeKind=persistentVolumeClaim
   set:
@@ -323,13 +323,13 @@ tests:
     customLogos.enabled: true
     customLogos.volumeKind: configMap
   asserts:
-  - isNull:
+  - isNullOrEmpty:
       path: spec.template.spec.containers[0].volumeMounts
 - it: should not mount custom-logos volume if not customLogos.enabled
   set:
     customLogos.enabled: false
   asserts:
-  - isNull:
+  - isNullOrEmpty:
       path: spec.template.spec.containers[0].volumeMounts
 - it: should set priorityClassName=system-node-critical
   set:
@@ -342,7 +342,7 @@ tests:
   set:
     priorityClassName: ""
   asserts:
-    - isNull:
+    - isNullOrEmpty:
         path: spec.template.spec.priorityClassName
 - it: should default priorityClassName="rancher-critical"
   asserts:

--- a/chart/tests/ingress_test.yaml
+++ b/chart/tests/ingress_test.yaml
@@ -7,10 +7,10 @@ tests:
     tls: external
   asserts:
   - equal:
-      path: metadata.annotations.nginx\.ingress\.kubernetes\.io/ssl-redirect
+      path: metadata.annotations["nginx.ingress.kubernetes.io/ssl-redirect"]
       value: "false"
   - isNull:
-      path: metadata.annotations.certmanager\.k8s\.io/issuer
+      path: metadata.annotations["certmanager.k8s.io/issuer"]
   - isNull:
       path: spec.tls
 - it: should set default annotations with default cert-manager
@@ -25,7 +25,7 @@ tests:
         nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
 - it: should set default annotations with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   asserts:
   - equal:
@@ -57,8 +57,10 @@ tests:
         cert-manager.io/issuer-kind: Issuer
 - it: should over write proxy-connect-timeout with default cert-manager
   set:
-    ingress.extraAnnotations:
-      nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
+    ingress:
+      includeDefaultExtraAnnotations: false
+      extraAnnotations:
+        nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
   asserts:
   - equal:
       path: metadata.annotations
@@ -66,36 +68,34 @@ tests:
         cert-manager.io/issuer: RELEASE-NAME-rancher
         cert-manager.io/issuer-kind: Issuer
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
-        nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
 - it: should over write proxy-connect-timeout with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
-    ingress.extraAnnotations:
-      nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
+    ingress:
+      includeDefaultExtraAnnotations: false
+      extraAnnotations:
+        nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
   asserts:
   - equal:
       path: metadata.annotations
       value:
         certmanager.k8s.io/issuer: RELEASE-NAME-rancher
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
-        nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
 - it: should over write proxy-connect-timeout with cert-manager < 0.11.0 using parameter
   set:
     certmanager.version: 0.9.0
-    ingress.extraAnnotations:
-      nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
+    ingress:
+      includeDefaultExtraAnnotations: false
+      extraAnnotations:
+        nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
   asserts:
   - equal:
       path: metadata.annotations
       value:
         certmanager.k8s.io/issuer: RELEASE-NAME-rancher
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
-        nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
 - it: should set source secret
   set:
     hostname: test
@@ -128,7 +128,7 @@ tests:
           more_set_input_headers "X-Forwarded-Host: host.example.com";
 - it: should set static X-Forwarded-Host header with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     hostname: host.example.com
@@ -183,7 +183,7 @@ tests:
           more_set_input_headers "foo: bar";
 - it: should be able to set multiple lines using configurationSnippet with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     hostname: host.example.com

--- a/chart/tests/issuer_test.yaml
+++ b/chart/tests/issuer_test.yaml
@@ -35,7 +35,7 @@ tests:
     template: issuer-rancher.yaml
 - it: should render letsEncrypt but not rancher with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: letsEncrypt
@@ -69,7 +69,7 @@ tests:
     template: issuer-rancher.yaml
 - it: should render rancher but not letsEncrypt with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: rancher
@@ -101,7 +101,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt apiVersion with cert-manager >= 0.16.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - cert-manager.io/v1beta1
   set:
     ingress.tls.source: letsEncrypt
@@ -112,7 +112,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt apiVersion with cert-manager >= 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - cert-manager.io/v1alpha2
   set:
     ingress.tls.source: letsEncrypt
@@ -123,7 +123,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt apiVersion with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: letsEncrypt
@@ -169,7 +169,7 @@ tests:
     template: issuer-rancher.yaml
 - it: should set rancher apiVersion with cert-manager >= 0.16.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - cert-manager.io/v1beta1
   set:
     ingress.tls.source: rancher
@@ -180,7 +180,7 @@ tests:
     template: issuer-rancher.yaml
 - it: should set rancher apiVersion with cert-manager >= 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - cert-manager.io/v1alpha2
   set:
     ingress.tls.source: rancher
@@ -191,7 +191,7 @@ tests:
     template: issuer-rancher.yaml
 - it: should set rancher apiVersion with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: rancher
@@ -237,7 +237,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt production by default with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: letsEncrypt
@@ -257,7 +257,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt staging with default cert-manager
   capabilities:
-    apiversions:
+    apiVersions:
     - cert-manager.io/v1alpha2
   set:
     ingress.tls.source: letsEncrypt
@@ -269,7 +269,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt staging with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: letsEncrypt
@@ -300,7 +300,7 @@ tests:
     template: issuer-letsEncrypt.yaml
 - it: should set letsEncrypt email address with cert-manager < 0.11.0 using capabilities
   capabilities:
-    apiversions:
+    apiVersions:
     - certmanager.k8s.io/v1alpha1
   set:
     ingress.tls.source: letsEncrypt

--- a/chart/tests/psp_test.yaml
+++ b/chart/tests/psp_test.yaml
@@ -1,0 +1,53 @@
+suite: Test PSP
+templates:
+- post-delete-hook-psp.yaml 
+- post-delete-hook-cluster-role.yaml
+tests:
+- it: should include psps when enabled
+  set:
+    global.cattle.psp.enabled: true
+  asserts:
+    - hasDocuments:
+        count: 1
+      template: post-delete-hook-psp.yaml
+    - contains:
+        path: rules
+        content:
+          apiGroups: [ "policy" ]
+          resources: [ "podsecuritypolicies" ]
+          verbs: [ "use"]
+      template: post-delete-hook-cluster-role.yaml
+- it: should not include psps when disabled
+  set:
+    global.cattle.psp.enabled: false
+  asserts:
+    - hasDocuments:
+        count: 0
+      template: post-delete-hook-psp.yaml 
+    - notContains:
+        path: rules
+        content:
+          apiGroups: [ "policy" ]
+          resources: [ "podsecuritypolicies" ]
+          verbs: [ "use"]
+      template: post-delete-hook-cluster-role.yaml
+- it: should fail when given an invalid value
+  set:
+    global.cattle.psp.enabled: "invalid"
+  asserts:
+    - failedTemplate:
+        errorMessage: "Invalid value for .Values.global.cattle.psp.enabled - must be a bool of true, false, or \"\""
+      template: post-delete-hook-psp.yaml 
+- it: should include psps by default when we can't communicate with kubernetes 
+  asserts:
+    - hasDocuments:
+        count: 1
+      template: post-delete-hook-psp.yaml 
+    - contains:
+        path: rules
+        content:
+          apiGroups: [ "policy" ]
+          resources: [ "podsecuritypolicies" ]
+          verbs: [ "use"]
+      template: post-delete-hook-cluster-role.yaml
+

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -172,4 +172,6 @@ readinessProbe:
 global:
   cattle:
     psp:
-      enabled: true #PSPs enablement should default to true
+      # will default to true on 1.24 and below, and false for 1.25 and above
+      # can be changed manually to true or false to bypass version checks and force that option
+      enabled: "" 

--- a/dev-scripts/helm-unittest.sh
+++ b/dev-scripts/helm-unittest.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# note: requires helm-unittest (https://github.com/helm-unittest/helm-unittest) to be installed beforehand
+# run in root of rancher - i.e. bash dev-scripts/helm-unittest.sh
+# change automated parts of templates
+test_image="rancher/rancher"
+test_image_tag="v2.7.0"
+sed -i -e "s/%VERSION%/${test_image_tag}/g" ./chart/Chart.yaml
+sed -i -e "s/%APP_VERSION%/${test_image_tag}/g" ./chart/Chart.yaml
+sed -i -e "s@%POST_DELETE_IMAGE_NAME%@${test_image}@g" ./chart/values.yaml
+sed -i -e "s/%POST_DELETE_IMAGE_TAG%/${test_image_tag}/g" ./chart/values.yaml
+
+# test - need to be in the chart directory during the test so it can find Chart.yaml
+cd chart
+helm lint ./
+helm unittest ./
+cd ..
+
+# clean
+git checkout chart/Chart.yaml chart/values.yaml

--- a/scripts/chart/test
+++ b/scripts/chart/test
@@ -3,17 +3,24 @@
 echo "-- chart/test --"
 
 # Check for helm
-if [ -z "$(type -p helm)" ]; then
+if [ -z "$(type -p helm_v3)" ]; then
     echo "helm not found. Helm is required to run tests."
     exit 1
 fi
 
+if [ "${ARCH}" != "amd64" ]; then 
+    echo "${ARCH} is not supported for chart tests, chart tests won't run"
+    exit 0
+fi
 # Check for unittest plugin
-helm unittest --help >/dev/null 2>&1
+helm_v3 unittest --help >/dev/null 2>&1
 if [[ $? > 0 ]]; then
     echo "helm plugin unittest not found."
-    echo "Run to install plugin: helm plugin install https://github.com/rancher/helm-unittest"
+    echo "Run to install plugin: helm plugin install https://github.com/helm-unittest/helm-unittest.git"
     exit 1
 fi
 
-helm unittest ../../build/chart/rancher
+current_dir=$(pwd)
+cd ../../build/chart/rancher
+helm_v3 unittest ./
+cd $current_dir


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
#41455
 
## Problem
The current default for `global.cattle.psp.enabled` is not compatible with k8s 1.25. This requires users to manually set this value to `false` when installing on this version of k8s. As 1.25+ is becoming more widely adapted, this pain point will become more apparent for our users.
 
## Solution
- There is no default for `global.cattle.psp.enabled` (i.e. the default value is "").
  - If this value is "" and the cluster does not support PSPs (i.e. is k8s version 1.25 or higher), then PSPs will not be used.
  - If this value is "" and the cluster does support PSPs (i.e. is k8s version 1.24 or lower), then PSPs will be used.
- If the value is set to true, no capabilities check will be used, and the chart will attempt to use PSPs. This will cause the above error message for k8s 1.25 clusters.
- If the value is set to false, no capabilities check will be used, and the chart will not attempt to use PSPs.
 
 The changes to the chart caused our charts tests to fail, since it used the `lookup` function (to determine if there is an active k8s cluster this is running against), which our old fork doesn't appear to support. To resolve this, I refactored our tests and our CI to use the upstream [unittest plugin](https://github.com/helm-unittest/helm-unittest)
 
## Testing
Repro steps are valid.

## Engineering Testing
### Manual Testing
Basic `helm template` and `helm install` cases were done, but more will need to be re-tested here.

### Automated Testing
I added tests for the chart when `global.cattle.psp.enabled` is set to:
- True
- False
- Unset
- Set to an invalid value

These tests do not cover the "live cluster cases" since the `helm-unittest` framework does not appear to offer the ability to mock out the `lookup` functionality.