### PR TITLE
adding cluster and fleet agent overrides to automation framework

### DIFF
--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_affinity.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_affinity.go
@@ -1,0 +1,14 @@
+package client
+
+const (
+	AffinityType                 = "affinity"
+	AffinityFieldNodeAffinity    = "nodeAffinity"
+	AffinityFieldPodAffinity     = "podAffinity"
+	AffinityFieldPodAntiAffinity = "podAntiAffinity"
+)
+
+type Affinity struct {
+	NodeAffinity    *NodeAffinity    `json:"nodeAffinity,omitempty" yaml:"nodeAffinity,omitempty"`
+	PodAffinity     *PodAffinity     `json:"podAffinity,omitempty" yaml:"podAffinity,omitempty"`
+	PodAntiAffinity *PodAntiAffinity `json:"podAntiAffinity,omitempty" yaml:"podAntiAffinity,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_agent_deployment_customization.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_agent_deployment_customization.go
@@ -1,0 +1,14 @@
+package client
+
+const (
+	AgentDeploymentCustomizationType                              = "agentDeploymentCustomization"
+	AgentDeploymentCustomizationFieldAppendTolerations            = "appendTolerations"
+	AgentDeploymentCustomizationFieldOverrideAffinity             = "overrideAffinity"
+	AgentDeploymentCustomizationFieldOverrideResourceRequirements = "overrideResourceRequirements"
+)
+
+type AgentDeploymentCustomization struct {
+	AppendTolerations            []Toleration          `json:"appendTolerations,omitempty" yaml:"appendTolerations,omitempty"`
+	OverrideAffinity             *Affinity             `json:"overrideAffinity,omitempty" yaml:"overrideAffinity,omitempty"`
+	OverrideResourceRequirements *ResourceRequirements `json:"overrideResourceRequirements,omitempty" yaml:"overrideResourceRequirements,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_aks_cluster_config_spec.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_aks_cluster_config_spec.go
@@ -24,6 +24,7 @@ const (
 	AKSClusterConfigSpecFieldNetworkPolicy               = "networkPolicy"
 	AKSClusterConfigSpecFieldNetworkServiceCIDR          = "serviceCidr"
 	AKSClusterConfigSpecFieldNodePools                   = "nodePools"
+	AKSClusterConfigSpecFieldOutboundType                = "outboundType"
 	AKSClusterConfigSpecFieldPrivateCluster              = "privateCluster"
 	AKSClusterConfigSpecFieldResourceGroup               = "resourceGroup"
 	AKSClusterConfigSpecFieldResourceLocation            = "resourceLocation"
@@ -56,6 +57,7 @@ type AKSClusterConfigSpec struct {
 	NetworkPolicy               *string           `json:"networkPolicy,omitempty" yaml:"networkPolicy,omitempty"`
 	NetworkServiceCIDR          *string           `json:"serviceCidr,omitempty" yaml:"serviceCidr,omitempty"`
 	NodePools                   []AKSNodePool     `json:"nodePools,omitempty" yaml:"nodePools,omitempty"`
+	OutboundType                *string           `json:"outboundType,omitempty" yaml:"outboundType,omitempty"`
 	PrivateCluster              *bool             `json:"privateCluster,omitempty" yaml:"privateCluster,omitempty"`
 	ResourceGroup               string            `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
 	ResourceLocation            string            `json:"resourceLocation,omitempty" yaml:"resourceLocation,omitempty"`

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster.go
@@ -18,6 +18,7 @@ const (
 	ClusterFieldAllocatable                                          = "allocatable"
 	ClusterFieldAnnotations                                          = "annotations"
 	ClusterFieldAppliedAgentEnvVars                                  = "appliedAgentEnvVars"
+	ClusterFieldAppliedClusterAgentDeploymentCustomization           = "appliedClusterAgentDeploymentCustomization"
 	ClusterFieldAppliedEnableNetworkPolicy                           = "appliedEnableNetworkPolicy"
 	ClusterFieldAppliedPodSecurityPolicyTemplateName                 = "appliedPodSecurityPolicyTemplateId"
 	ClusterFieldAppliedSpec                                          = "appliedSpec"
@@ -26,6 +27,7 @@ const (
 	ClusterFieldCapabilities                                         = "capabilities"
 	ClusterFieldCapacity                                             = "capacity"
 	ClusterFieldCertificatesExpiration                               = "certificatesExpiration"
+	ClusterFieldClusterAgentDeploymentCustomization                  = "clusterAgentDeploymentCustomization"
 	ClusterFieldClusterSecrets                                       = "clusterSecrets"
 	ClusterFieldClusterTemplateAnswers                               = "answers"
 	ClusterFieldClusterTemplateID                                    = "clusterTemplateId"
@@ -50,6 +52,7 @@ const (
 	ClusterFieldEnableClusterMonitoring                              = "enableClusterMonitoring"
 	ClusterFieldEnableNetworkPolicy                                  = "enableNetworkPolicy"
 	ClusterFieldFailedSpec                                           = "failedSpec"
+	ClusterFieldFleetAgentDeploymentCustomization                    = "fleetAgentDeploymentCustomization"
 	ClusterFieldFleetWorkspaceName                                   = "fleetWorkspaceName"
 	ClusterFieldGKEConfig                                            = "gkeConfig"
 	ClusterFieldGKEStatus                                            = "gkeStatus"
@@ -101,6 +104,7 @@ type Cluster struct {
 	Allocatable                                          map[string]string              `json:"allocatable,omitempty" yaml:"allocatable,omitempty"`
 	Annotations                                          map[string]string              `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	AppliedAgentEnvVars                                  []EnvVar                       `json:"appliedAgentEnvVars,omitempty" yaml:"appliedAgentEnvVars,omitempty"`
+	AppliedClusterAgentDeploymentCustomization           *AgentDeploymentCustomization  `json:"appliedClusterAgentDeploymentCustomization,omitempty" yaml:"appliedClusterAgentDeploymentCustomization,omitempty"`
 	AppliedEnableNetworkPolicy                           bool                           `json:"appliedEnableNetworkPolicy,omitempty" yaml:"appliedEnableNetworkPolicy,omitempty"`
 	AppliedPodSecurityPolicyTemplateName                 string                         `json:"appliedPodSecurityPolicyTemplateId,omitempty" yaml:"appliedPodSecurityPolicyTemplateId,omitempty"`
 	AppliedSpec                                          *ClusterSpec                   `json:"appliedSpec,omitempty" yaml:"appliedSpec,omitempty"`
@@ -109,6 +113,7 @@ type Cluster struct {
 	Capabilities                                         *Capabilities                  `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
 	Capacity                                             map[string]string              `json:"capacity,omitempty" yaml:"capacity,omitempty"`
 	CertificatesExpiration                               map[string]CertExpiration      `json:"certificatesExpiration,omitempty" yaml:"certificatesExpiration,omitempty"`
+	ClusterAgentDeploymentCustomization                  *AgentDeploymentCustomization  `json:"clusterAgentDeploymentCustomization,omitempty" yaml:"clusterAgentDeploymentCustomization,omitempty"`
 	ClusterSecrets                                       *ClusterSecrets                `json:"clusterSecrets,omitempty" yaml:"clusterSecrets,omitempty"`
 	ClusterTemplateAnswers                               *Answer                        `json:"answers,omitempty" yaml:"answers,omitempty"`
 	ClusterTemplateID                                    string                         `json:"clusterTemplateId,omitempty" yaml:"clusterTemplateId,omitempty"`
@@ -133,6 +138,7 @@ type Cluster struct {
 	EnableClusterMonitoring                              bool                           `json:"enableClusterMonitoring,omitempty" yaml:"enableClusterMonitoring,omitempty"`
 	EnableNetworkPolicy                                  *bool                          `json:"enableNetworkPolicy,omitempty" yaml:"enableNetworkPolicy,omitempty"`
 	FailedSpec                                           *ClusterSpec                   `json:"failedSpec,omitempty" yaml:"failedSpec,omitempty"`
+	FleetAgentDeploymentCustomization                    *AgentDeploymentCustomization  `json:"fleetAgentDeploymentCustomization,omitempty" yaml:"fleetAgentDeploymentCustomization,omitempty"`
 	FleetWorkspaceName                                   string                         `json:"fleetWorkspaceName,omitempty" yaml:"fleetWorkspaceName,omitempty"`
 	GKEConfig                                            *GKEClusterConfigSpec          `json:"gkeConfig,omitempty" yaml:"gkeConfig,omitempty"`
 	GKEStatus                                            *GKEStatus                     `json:"gkeStatus,omitempty" yaml:"gkeStatus,omitempty"`

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_spec.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_spec.go
@@ -7,6 +7,7 @@ const (
 	ClusterSpecFieldAgentImageOverride                                   = "agentImageOverride"
 	ClusterSpecFieldAmazonElasticContainerServiceConfig                  = "amazonElasticContainerServiceConfig"
 	ClusterSpecFieldAzureKubernetesServiceConfig                         = "azureKubernetesServiceConfig"
+	ClusterSpecFieldClusterAgentDeploymentCustomization                  = "clusterAgentDeploymentCustomization"
 	ClusterSpecFieldClusterSecrets                                       = "clusterSecrets"
 	ClusterSpecFieldClusterTemplateAnswers                               = "answers"
 	ClusterSpecFieldClusterTemplateID                                    = "clusterTemplateId"
@@ -24,6 +25,7 @@ const (
 	ClusterSpecFieldEnableClusterAlerting                                = "enableClusterAlerting"
 	ClusterSpecFieldEnableClusterMonitoring                              = "enableClusterMonitoring"
 	ClusterSpecFieldEnableNetworkPolicy                                  = "enableNetworkPolicy"
+	ClusterSpecFieldFleetAgentDeploymentCustomization                    = "fleetAgentDeploymentCustomization"
 	ClusterSpecFieldFleetWorkspaceName                                   = "fleetWorkspaceName"
 	ClusterSpecFieldGKEConfig                                            = "gkeConfig"
 	ClusterSpecFieldGenericEngineConfig                                  = "genericEngineConfig"
@@ -43,6 +45,7 @@ type ClusterSpec struct {
 	AgentImageOverride                                   string                         `json:"agentImageOverride,omitempty" yaml:"agentImageOverride,omitempty"`
 	AmazonElasticContainerServiceConfig                  map[string]interface{}         `json:"amazonElasticContainerServiceConfig,omitempty" yaml:"amazonElasticContainerServiceConfig,omitempty"`
 	AzureKubernetesServiceConfig                         map[string]interface{}         `json:"azureKubernetesServiceConfig,omitempty" yaml:"azureKubernetesServiceConfig,omitempty"`
+	ClusterAgentDeploymentCustomization                  *AgentDeploymentCustomization  `json:"clusterAgentDeploymentCustomization,omitempty" yaml:"clusterAgentDeploymentCustomization,omitempty"`
 	ClusterSecrets                                       *ClusterSecrets                `json:"clusterSecrets,omitempty" yaml:"clusterSecrets,omitempty"`
 	ClusterTemplateAnswers                               *Answer                        `json:"answers,omitempty" yaml:"answers,omitempty"`
 	ClusterTemplateID                                    string                         `json:"clusterTemplateId,omitempty" yaml:"clusterTemplateId,omitempty"`
@@ -60,6 +63,7 @@ type ClusterSpec struct {
 	EnableClusterAlerting                                bool                           `json:"enableClusterAlerting,omitempty" yaml:"enableClusterAlerting,omitempty"`
 	EnableClusterMonitoring                              bool                           `json:"enableClusterMonitoring,omitempty" yaml:"enableClusterMonitoring,omitempty"`
 	EnableNetworkPolicy                                  *bool                          `json:"enableNetworkPolicy,omitempty" yaml:"enableNetworkPolicy,omitempty"`
+	FleetAgentDeploymentCustomization                    *AgentDeploymentCustomization  `json:"fleetAgentDeploymentCustomization,omitempty" yaml:"fleetAgentDeploymentCustomization,omitempty"`
 	FleetWorkspaceName                                   string                         `json:"fleetWorkspaceName,omitempty" yaml:"fleetWorkspaceName,omitempty"`
 	GKEConfig                                            *GKEClusterConfigSpec          `json:"gkeConfig,omitempty" yaml:"gkeConfig,omitempty"`
 	GenericEngineConfig                                  map[string]interface{}         `json:"genericEngineConfig,omitempty" yaml:"genericEngineConfig,omitempty"`

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_spec_base.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_spec_base.go
@@ -4,6 +4,7 @@ const (
 	ClusterSpecBaseType                                                      = "clusterSpecBase"
 	ClusterSpecBaseFieldAgentEnvVars                                         = "agentEnvVars"
 	ClusterSpecBaseFieldAgentImageOverride                                   = "agentImageOverride"
+	ClusterSpecBaseFieldClusterAgentDeploymentCustomization                  = "clusterAgentDeploymentCustomization"
 	ClusterSpecBaseFieldClusterSecrets                                       = "clusterSecrets"
 	ClusterSpecBaseFieldDefaultClusterRoleForProjectMembers                  = "defaultClusterRoleForProjectMembers"
 	ClusterSpecBaseFieldDefaultPodSecurityAdmissionConfigurationTemplateName = "defaultPodSecurityAdmissionConfigurationTemplateName"
@@ -14,6 +15,7 @@ const (
 	ClusterSpecBaseFieldEnableClusterAlerting                                = "enableClusterAlerting"
 	ClusterSpecBaseFieldEnableClusterMonitoring                              = "enableClusterMonitoring"
 	ClusterSpecBaseFieldEnableNetworkPolicy                                  = "enableNetworkPolicy"
+	ClusterSpecBaseFieldFleetAgentDeploymentCustomization                    = "fleetAgentDeploymentCustomization"
 	ClusterSpecBaseFieldLocalClusterAuthEndpoint                             = "localClusterAuthEndpoint"
 	ClusterSpecBaseFieldRancherKubernetesEngineConfig                        = "rancherKubernetesEngineConfig"
 	ClusterSpecBaseFieldWindowsPreferedCluster                               = "windowsPreferedCluster"
@@ -22,6 +24,7 @@ const (
 type ClusterSpecBase struct {
 	AgentEnvVars                                         []EnvVar                       `json:"agentEnvVars,omitempty" yaml:"agentEnvVars,omitempty"`
 	AgentImageOverride                                   string                         `json:"agentImageOverride,omitempty" yaml:"agentImageOverride,omitempty"`
+	ClusterAgentDeploymentCustomization                  *AgentDeploymentCustomization  `json:"clusterAgentDeploymentCustomization,omitempty" yaml:"clusterAgentDeploymentCustomization,omitempty"`
 	ClusterSecrets                                       *ClusterSecrets                `json:"clusterSecrets,omitempty" yaml:"clusterSecrets,omitempty"`
 	DefaultClusterRoleForProjectMembers                  string                         `json:"defaultClusterRoleForProjectMembers,omitempty" yaml:"defaultClusterRoleForProjectMembers,omitempty"`
 	DefaultPodSecurityAdmissionConfigurationTemplateName string                         `json:"defaultPodSecurityAdmissionConfigurationTemplateName,omitempty" yaml:"defaultPodSecurityAdmissionConfigurationTemplateName,omitempty"`
@@ -32,6 +35,7 @@ type ClusterSpecBase struct {
 	EnableClusterAlerting                                bool                           `json:"enableClusterAlerting,omitempty" yaml:"enableClusterAlerting,omitempty"`
 	EnableClusterMonitoring                              bool                           `json:"enableClusterMonitoring,omitempty" yaml:"enableClusterMonitoring,omitempty"`
 	EnableNetworkPolicy                                  *bool                          `json:"enableNetworkPolicy,omitempty" yaml:"enableNetworkPolicy,omitempty"`
+	FleetAgentDeploymentCustomization                    *AgentDeploymentCustomization  `json:"fleetAgentDeploymentCustomization,omitempty" yaml:"fleetAgentDeploymentCustomization,omitempty"`
 	LocalClusterAuthEndpoint                             *LocalClusterAuthEndpoint      `json:"localClusterAuthEndpoint,omitempty" yaml:"localClusterAuthEndpoint,omitempty"`
 	RancherKubernetesEngineConfig                        *RancherKubernetesEngineConfig `json:"rancherKubernetesEngineConfig,omitempty" yaml:"rancherKubernetesEngineConfig,omitempty"`
 	WindowsPreferedCluster                               bool                           `json:"windowsPreferedCluster,omitempty" yaml:"windowsPreferedCluster,omitempty"`

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_status.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_cluster_status.go
@@ -1,88 +1,90 @@
 package client
 
 const (
-	ClusterStatusType                                      = "clusterStatus"
-	ClusterStatusFieldAADClientCertSecret                  = "aadClientCertSecret"
-	ClusterStatusFieldAADClientSecret                      = "aadClientSecret"
-	ClusterStatusFieldAKSStatus                            = "aksStatus"
-	ClusterStatusFieldAPIEndpoint                          = "apiEndpoint"
-	ClusterStatusFieldAgentFeatures                        = "agentFeatures"
-	ClusterStatusFieldAgentImage                           = "agentImage"
-	ClusterStatusFieldAllocatable                          = "allocatable"
-	ClusterStatusFieldAppliedAgentEnvVars                  = "appliedAgentEnvVars"
-	ClusterStatusFieldAppliedEnableNetworkPolicy           = "appliedEnableNetworkPolicy"
-	ClusterStatusFieldAppliedPodSecurityPolicyTemplateName = "appliedPodSecurityPolicyTemplateId"
-	ClusterStatusFieldAppliedSpec                          = "appliedSpec"
-	ClusterStatusFieldAuthImage                            = "authImage"
-	ClusterStatusFieldCACert                               = "caCert"
-	ClusterStatusFieldCapabilities                         = "capabilities"
-	ClusterStatusFieldCapacity                             = "capacity"
-	ClusterStatusFieldCertificatesExpiration               = "certificatesExpiration"
-	ClusterStatusFieldComponentStatuses                    = "componentStatuses"
-	ClusterStatusFieldConditions                           = "conditions"
-	ClusterStatusFieldCurrentCisRunName                    = "currentCisRunName"
-	ClusterStatusFieldDriver                               = "driver"
-	ClusterStatusFieldEKSStatus                            = "eksStatus"
-	ClusterStatusFieldFailedSpec                           = "failedSpec"
-	ClusterStatusFieldGKEStatus                            = "gkeStatus"
-	ClusterStatusFieldIstioEnabled                         = "istioEnabled"
-	ClusterStatusFieldLimits                               = "limits"
-	ClusterStatusFieldLinuxWorkerCount                     = "linuxWorkerCount"
-	ClusterStatusFieldMonitoringStatus                     = "monitoringStatus"
-	ClusterStatusFieldNodeCount                            = "nodeCount"
-	ClusterStatusFieldNodeVersion                          = "nodeVersion"
-	ClusterStatusFieldOpenStackSecret                      = "openStackSecret"
-	ClusterStatusFieldPrivateRegistrySecret                = "privateRegistrySecret"
-	ClusterStatusFieldProvider                             = "provider"
-	ClusterStatusFieldRequested                            = "requested"
-	ClusterStatusFieldS3CredentialSecret                   = "s3CredentialSecret"
-	ClusterStatusFieldServiceAccountTokenSecret            = "serviceAccountTokenSecret"
-	ClusterStatusFieldVersion                              = "version"
-	ClusterStatusFieldVirtualCenterSecret                  = "virtualCenterSecret"
-	ClusterStatusFieldVsphereSecret                        = "vsphereSecret"
-	ClusterStatusFieldWeavePasswordSecret                  = "weavePasswordSecret"
-	ClusterStatusFieldWindowsWorkerCount                   = "windowsWorkerCount"
+	ClusterStatusType                                            = "clusterStatus"
+	ClusterStatusFieldAADClientCertSecret                        = "aadClientCertSecret"
+	ClusterStatusFieldAADClientSecret                            = "aadClientSecret"
+	ClusterStatusFieldAKSStatus                                  = "aksStatus"
+	ClusterStatusFieldAPIEndpoint                                = "apiEndpoint"
+	ClusterStatusFieldAgentFeatures                              = "agentFeatures"
+	ClusterStatusFieldAgentImage                                 = "agentImage"
+	ClusterStatusFieldAllocatable                                = "allocatable"
+	ClusterStatusFieldAppliedAgentEnvVars                        = "appliedAgentEnvVars"
+	ClusterStatusFieldAppliedClusterAgentDeploymentCustomization = "appliedClusterAgentDeploymentCustomization"
+	ClusterStatusFieldAppliedEnableNetworkPolicy                 = "appliedEnableNetworkPolicy"
+	ClusterStatusFieldAppliedPodSecurityPolicyTemplateName       = "appliedPodSecurityPolicyTemplateId"
+	ClusterStatusFieldAppliedSpec                                = "appliedSpec"
+	ClusterStatusFieldAuthImage                                  = "authImage"
+	ClusterStatusFieldCACert                                     = "caCert"
+	ClusterStatusFieldCapabilities                               = "capabilities"
+	ClusterStatusFieldCapacity                                   = "capacity"
+	ClusterStatusFieldCertificatesExpiration                     = "certificatesExpiration"
+	ClusterStatusFieldComponentStatuses                          = "componentStatuses"
+	ClusterStatusFieldConditions                                 = "conditions"
+	ClusterStatusFieldCurrentCisRunName                          = "currentCisRunName"
+	ClusterStatusFieldDriver                                     = "driver"
+	ClusterStatusFieldEKSStatus                                  = "eksStatus"
+	ClusterStatusFieldFailedSpec                                 = "failedSpec"
+	ClusterStatusFieldGKEStatus                                  = "gkeStatus"
+	ClusterStatusFieldIstioEnabled                               = "istioEnabled"
+	ClusterStatusFieldLimits                                     = "limits"
+	ClusterStatusFieldLinuxWorkerCount                           = "linuxWorkerCount"
+	ClusterStatusFieldMonitoringStatus                           = "monitoringStatus"
+	ClusterStatusFieldNodeCount                                  = "nodeCount"
+	ClusterStatusFieldNodeVersion                                = "nodeVersion"
+	ClusterStatusFieldOpenStackSecret                            = "openStackSecret"
+	ClusterStatusFieldPrivateRegistrySecret                      = "privateRegistrySecret"
+	ClusterStatusFieldProvider                                   = "provider"
+	ClusterStatusFieldRequested                                  = "requested"
+	ClusterStatusFieldS3CredentialSecret                         = "s3CredentialSecret"
+	ClusterStatusFieldServiceAccountTokenSecret                  = "serviceAccountTokenSecret"
+	ClusterStatusFieldVersion                                    = "version"
+	ClusterStatusFieldVirtualCenterSecret                        = "virtualCenterSecret"
+	ClusterStatusFieldVsphereSecret                              = "vsphereSecret"
+	ClusterStatusFieldWeavePasswordSecret                        = "weavePasswordSecret"
+	ClusterStatusFieldWindowsWorkerCount                         = "windowsWorkerCount"
 )
 
 type ClusterStatus struct {
-	AADClientCertSecret                  string                    `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
-	AADClientSecret                      string                    `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
-	AKSStatus                            *AKSStatus                `json:"aksStatus,omitempty" yaml:"aksStatus,omitempty"`
-	APIEndpoint                          string                    `json:"apiEndpoint,omitempty" yaml:"apiEndpoint,omitempty"`
-	AgentFeatures                        map[string]bool           `json:"agentFeatures,omitempty" yaml:"agentFeatures,omitempty"`
-	AgentImage                           string                    `json:"agentImage,omitempty" yaml:"agentImage,omitempty"`
-	Allocatable                          map[string]string         `json:"allocatable,omitempty" yaml:"allocatable,omitempty"`
-	AppliedAgentEnvVars                  []EnvVar                  `json:"appliedAgentEnvVars,omitempty" yaml:"appliedAgentEnvVars,omitempty"`
-	AppliedEnableNetworkPolicy           bool                      `json:"appliedEnableNetworkPolicy,omitempty" yaml:"appliedEnableNetworkPolicy,omitempty"`
-	AppliedPodSecurityPolicyTemplateName string                    `json:"appliedPodSecurityPolicyTemplateId,omitempty" yaml:"appliedPodSecurityPolicyTemplateId,omitempty"`
-	AppliedSpec                          *ClusterSpec              `json:"appliedSpec,omitempty" yaml:"appliedSpec,omitempty"`
-	AuthImage                            string                    `json:"authImage,omitempty" yaml:"authImage,omitempty"`
-	CACert                               string                    `json:"caCert,omitempty" yaml:"caCert,omitempty"`
-	Capabilities                         *Capabilities             `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
-	Capacity                             map[string]string         `json:"capacity,omitempty" yaml:"capacity,omitempty"`
-	CertificatesExpiration               map[string]CertExpiration `json:"certificatesExpiration,omitempty" yaml:"certificatesExpiration,omitempty"`
-	ComponentStatuses                    []ClusterComponentStatus  `json:"componentStatuses,omitempty" yaml:"componentStatuses,omitempty"`
-	Conditions                           []ClusterCondition        `json:"conditions,omitempty" yaml:"conditions,omitempty"`
-	CurrentCisRunName                    string                    `json:"currentCisRunName,omitempty" yaml:"currentCisRunName,omitempty"`
-	Driver                               string                    `json:"driver,omitempty" yaml:"driver,omitempty"`
-	EKSStatus                            *EKSStatus                `json:"eksStatus,omitempty" yaml:"eksStatus,omitempty"`
-	FailedSpec                           *ClusterSpec              `json:"failedSpec,omitempty" yaml:"failedSpec,omitempty"`
-	GKEStatus                            *GKEStatus                `json:"gkeStatus,omitempty" yaml:"gkeStatus,omitempty"`
-	IstioEnabled                         bool                      `json:"istioEnabled,omitempty" yaml:"istioEnabled,omitempty"`
-	Limits                               map[string]string         `json:"limits,omitempty" yaml:"limits,omitempty"`
-	LinuxWorkerCount                     int64                     `json:"linuxWorkerCount,omitempty" yaml:"linuxWorkerCount,omitempty"`
-	MonitoringStatus                     *MonitoringStatus         `json:"monitoringStatus,omitempty" yaml:"monitoringStatus,omitempty"`
-	NodeCount                            int64                     `json:"nodeCount,omitempty" yaml:"nodeCount,omitempty"`
-	NodeVersion                          int64                     `json:"nodeVersion,omitempty" yaml:"nodeVersion,omitempty"`
-	OpenStackSecret                      string                    `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
-	PrivateRegistrySecret                string                    `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
-	Provider                             string                    `json:"provider,omitempty" yaml:"provider,omitempty"`
-	Requested                            map[string]string         `json:"requested,omitempty" yaml:"requested,omitempty"`
-	S3CredentialSecret                   string                    `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
-	ServiceAccountTokenSecret            string                    `json:"serviceAccountTokenSecret,omitempty" yaml:"serviceAccountTokenSecret,omitempty"`
-	Version                              *Info                     `json:"version,omitempty" yaml:"version,omitempty"`
-	VirtualCenterSecret                  string                    `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
-	VsphereSecret                        string                    `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
-	WeavePasswordSecret                  string                    `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
-	WindowsWorkerCount                   int64                     `json:"windowsWorkerCount,omitempty" yaml:"windowsWorkerCount,omitempty"`
+	AADClientCertSecret                        string                        `json:"aadClientCertSecret,omitempty" yaml:"aadClientCertSecret,omitempty"`
+	AADClientSecret                            string                        `json:"aadClientSecret,omitempty" yaml:"aadClientSecret,omitempty"`
+	AKSStatus                                  *AKSStatus                    `json:"aksStatus,omitempty" yaml:"aksStatus,omitempty"`
+	APIEndpoint                                string                        `json:"apiEndpoint,omitempty" yaml:"apiEndpoint,omitempty"`
+	AgentFeatures                              map[string]bool               `json:"agentFeatures,omitempty" yaml:"agentFeatures,omitempty"`
+	AgentImage                                 string                        `json:"agentImage,omitempty" yaml:"agentImage,omitempty"`
+	Allocatable                                map[string]string             `json:"allocatable,omitempty" yaml:"allocatable,omitempty"`
+	AppliedAgentEnvVars                        []EnvVar                      `json:"appliedAgentEnvVars,omitempty" yaml:"appliedAgentEnvVars,omitempty"`
+	AppliedClusterAgentDeploymentCustomization *AgentDeploymentCustomization `json:"appliedClusterAgentDeploymentCustomization,omitempty" yaml:"appliedClusterAgentDeploymentCustomization,omitempty"`
+	AppliedEnableNetworkPolicy                 bool                          `json:"appliedEnableNetworkPolicy,omitempty" yaml:"appliedEnableNetworkPolicy,omitempty"`
+	AppliedPodSecurityPolicyTemplateName       string                        `json:"appliedPodSecurityPolicyTemplateId,omitempty" yaml:"appliedPodSecurityPolicyTemplateId,omitempty"`
+	AppliedSpec                                *ClusterSpec                  `json:"appliedSpec,omitempty" yaml:"appliedSpec,omitempty"`
+	AuthImage                                  string                        `json:"authImage,omitempty" yaml:"authImage,omitempty"`
+	CACert                                     string                        `json:"caCert,omitempty" yaml:"caCert,omitempty"`
+	Capabilities                               *Capabilities                 `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+	Capacity                                   map[string]string             `json:"capacity,omitempty" yaml:"capacity,omitempty"`
+	CertificatesExpiration                     map[string]CertExpiration     `json:"certificatesExpiration,omitempty" yaml:"certificatesExpiration,omitempty"`
+	ComponentStatuses                          []ClusterComponentStatus      `json:"componentStatuses,omitempty" yaml:"componentStatuses,omitempty"`
+	Conditions                                 []ClusterCondition            `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	CurrentCisRunName                          string                        `json:"currentCisRunName,omitempty" yaml:"currentCisRunName,omitempty"`
+	Driver                                     string                        `json:"driver,omitempty" yaml:"driver,omitempty"`
+	EKSStatus                                  *EKSStatus                    `json:"eksStatus,omitempty" yaml:"eksStatus,omitempty"`
+	FailedSpec                                 *ClusterSpec                  `json:"failedSpec,omitempty" yaml:"failedSpec,omitempty"`
+	GKEStatus                                  *GKEStatus                    `json:"gkeStatus,omitempty" yaml:"gkeStatus,omitempty"`
+	IstioEnabled                               bool                          `json:"istioEnabled,omitempty" yaml:"istioEnabled,omitempty"`
+	Limits                                     map[string]string             `json:"limits,omitempty" yaml:"limits,omitempty"`
+	LinuxWorkerCount                           int64                         `json:"linuxWorkerCount,omitempty" yaml:"linuxWorkerCount,omitempty"`
+	MonitoringStatus                           *MonitoringStatus             `json:"monitoringStatus,omitempty" yaml:"monitoringStatus,omitempty"`
+	NodeCount                                  int64                         `json:"nodeCount,omitempty" yaml:"nodeCount,omitempty"`
+	NodeVersion                                int64                         `json:"nodeVersion,omitempty" yaml:"nodeVersion,omitempty"`
+	OpenStackSecret                            string                        `json:"openStackSecret,omitempty" yaml:"openStackSecret,omitempty"`
+	PrivateRegistrySecret                      string                        `json:"privateRegistrySecret,omitempty" yaml:"privateRegistrySecret,omitempty"`
+	Provider                                   string                        `json:"provider,omitempty" yaml:"provider,omitempty"`
+	Requested                                  map[string]string             `json:"requested,omitempty" yaml:"requested,omitempty"`
+	S3CredentialSecret                         string                        `json:"s3CredentialSecret,omitempty" yaml:"s3CredentialSecret,omitempty"`
+	ServiceAccountTokenSecret                  string                        `json:"serviceAccountTokenSecret,omitempty" yaml:"serviceAccountTokenSecret,omitempty"`
+	Version                                    *Info                         `json:"version,omitempty" yaml:"version,omitempty"`
+	VirtualCenterSecret                        string                        `json:"virtualCenterSecret,omitempty" yaml:"virtualCenterSecret,omitempty"`
+	VsphereSecret                              string                        `json:"vsphereSecret,omitempty" yaml:"vsphereSecret,omitempty"`
+	WeavePasswordSecret                        string                        `json:"weavePasswordSecret,omitempty" yaml:"weavePasswordSecret,omitempty"`
+	WindowsWorkerCount                         int64                         `json:"windowsWorkerCount,omitempty" yaml:"windowsWorkerCount,omitempty"`
 }

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_node_affinity.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_node_affinity.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	NodeAffinityType                                                 = "nodeAffinity"
+	NodeAffinityFieldPreferredDuringSchedulingIgnoredDuringExecution = "preferredDuringSchedulingIgnoredDuringExecution"
+	NodeAffinityFieldRequiredDuringSchedulingIgnoredDuringExecution  = "requiredDuringSchedulingIgnoredDuringExecution"
+)
+
+type NodeAffinity struct {
+	PreferredDuringSchedulingIgnoredDuringExecution []PreferredSchedulingTerm `json:"preferredDuringSchedulingIgnoredDuringExecution,omitempty" yaml:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`
+	RequiredDuringSchedulingIgnoredDuringExecution  *NodeSelector             `json:"requiredDuringSchedulingIgnoredDuringExecution,omitempty" yaml:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_node_selector.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_node_selector.go
@@ -1,0 +1,10 @@
+package client
+
+const (
+	NodeSelectorType                   = "nodeSelector"
+	NodeSelectorFieldNodeSelectorTerms = "nodeSelectorTerms"
+)
+
+type NodeSelector struct {
+	NodeSelectorTerms []NodeSelectorTerm `json:"nodeSelectorTerms,omitempty" yaml:"nodeSelectorTerms,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_node_selector_requirement.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_node_selector_requirement.go
@@ -1,0 +1,14 @@
+package client
+
+const (
+	NodeSelectorRequirementType          = "nodeSelectorRequirement"
+	NodeSelectorRequirementFieldKey      = "key"
+	NodeSelectorRequirementFieldOperator = "operator"
+	NodeSelectorRequirementFieldValues   = "values"
+)
+
+type NodeSelectorRequirement struct {
+	Key      string   `json:"key,omitempty" yaml:"key,omitempty"`
+	Operator string   `json:"operator,omitempty" yaml:"operator,omitempty"`
+	Values   []string `json:"values,omitempty" yaml:"values,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_node_selector_term.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_node_selector_term.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	NodeSelectorTermType                  = "nodeSelectorTerm"
+	NodeSelectorTermFieldMatchExpressions = "matchExpressions"
+	NodeSelectorTermFieldMatchFields      = "matchFields"
+)
+
+type NodeSelectorTerm struct {
+	MatchExpressions []NodeSelectorRequirement `json:"matchExpressions,omitempty" yaml:"matchExpressions,omitempty"`
+	MatchFields      []NodeSelectorRequirement `json:"matchFields,omitempty" yaml:"matchFields,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_okta_config.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_okta_config.go
@@ -14,6 +14,7 @@ const (
 	OKTAConfigFieldIDPMetadataContent  = "idpMetadataContent"
 	OKTAConfigFieldLabels              = "labels"
 	OKTAConfigFieldName                = "name"
+	OKTAConfigFieldOpenLdapConfig      = "openLdapConfig"
 	OKTAConfigFieldOwnerReferences     = "ownerReferences"
 	OKTAConfigFieldRancherAPIHost      = "rancherApiHost"
 	OKTAConfigFieldRemoved             = "removed"
@@ -38,6 +39,7 @@ type OKTAConfig struct {
 	IDPMetadataContent  string            `json:"idpMetadataContent,omitempty" yaml:"idpMetadataContent,omitempty"`
 	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`
+	OpenLdapConfig      *LdapFields       `json:"openLdapConfig,omitempty" yaml:"openLdapConfig,omitempty"`
 	OwnerReferences     []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
 	RancherAPIHost      string            `json:"rancherApiHost,omitempty" yaml:"rancherApiHost,omitempty"`
 	Removed             string            `json:"removed,omitempty" yaml:"removed,omitempty"`

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_pod_affinity.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_pod_affinity.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	PodAffinityType                                                 = "podAffinity"
+	PodAffinityFieldPreferredDuringSchedulingIgnoredDuringExecution = "preferredDuringSchedulingIgnoredDuringExecution"
+	PodAffinityFieldRequiredDuringSchedulingIgnoredDuringExecution  = "requiredDuringSchedulingIgnoredDuringExecution"
+)
+
+type PodAffinity struct {
+	PreferredDuringSchedulingIgnoredDuringExecution []WeightedPodAffinityTerm `json:"preferredDuringSchedulingIgnoredDuringExecution,omitempty" yaml:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`
+	RequiredDuringSchedulingIgnoredDuringExecution  []PodAffinityTerm         `json:"requiredDuringSchedulingIgnoredDuringExecution,omitempty" yaml:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_pod_affinity_term.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_pod_affinity_term.go
@@ -1,0 +1,16 @@
+package client
+
+const (
+	PodAffinityTermType                   = "podAffinityTerm"
+	PodAffinityTermFieldLabelSelector     = "labelSelector"
+	PodAffinityTermFieldNamespaceSelector = "namespaceSelector"
+	PodAffinityTermFieldNamespaces        = "namespaces"
+	PodAffinityTermFieldTopologyKey       = "topologyKey"
+)
+
+type PodAffinityTerm struct {
+	LabelSelector     *LabelSelector `json:"labelSelector,omitempty" yaml:"labelSelector,omitempty"`
+	NamespaceSelector *LabelSelector `json:"namespaceSelector,omitempty" yaml:"namespaceSelector,omitempty"`
+	Namespaces        []string       `json:"namespaces,omitempty" yaml:"namespaces,omitempty"`
+	TopologyKey       string         `json:"topologyKey,omitempty" yaml:"topologyKey,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_pod_anti_affinity.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_pod_anti_affinity.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	PodAntiAffinityType                                                 = "podAntiAffinity"
+	PodAntiAffinityFieldPreferredDuringSchedulingIgnoredDuringExecution = "preferredDuringSchedulingIgnoredDuringExecution"
+	PodAntiAffinityFieldRequiredDuringSchedulingIgnoredDuringExecution  = "requiredDuringSchedulingIgnoredDuringExecution"
+)
+
+type PodAntiAffinity struct {
+	PreferredDuringSchedulingIgnoredDuringExecution []WeightedPodAffinityTerm `json:"preferredDuringSchedulingIgnoredDuringExecution,omitempty" yaml:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`
+	RequiredDuringSchedulingIgnoredDuringExecution  []PodAffinityTerm         `json:"requiredDuringSchedulingIgnoredDuringExecution,omitempty" yaml:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_preferred_scheduling_term.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_preferred_scheduling_term.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	PreferredSchedulingTermType            = "preferredSchedulingTerm"
+	PreferredSchedulingTermFieldPreference = "preference"
+	PreferredSchedulingTermFieldWeight     = "weight"
+)
+
+type PreferredSchedulingTerm struct {
+	Preference *NodeSelectorTerm `json:"preference,omitempty" yaml:"preference,omitempty"`
+	Weight     int64             `json:"weight,omitempty" yaml:"weight,omitempty"`
+}

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_weighted_pod_affinity_term.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_weighted_pod_affinity_term.go
@@ -1,0 +1,12 @@
+package client
+
+const (
+	WeightedPodAffinityTermType                 = "weightedPodAffinityTerm"
+	WeightedPodAffinityTermFieldPodAffinityTerm = "podAffinityTerm"
+	WeightedPodAffinityTermFieldWeight          = "weight"
+)
+
+type WeightedPodAffinityTerm struct {
+	PodAffinityTerm *PodAffinityTerm `json:"podAffinityTerm,omitempty" yaml:"podAffinityTerm,omitempty"`
+	Weight          int64            `json:"weight,omitempty" yaml:"weight,omitempty"`
+}

--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -16,11 +16,14 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
-	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning"
+	rancherProvisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
 	"github.com/rancher/wrangler/pkg/summary"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
@@ -121,7 +124,7 @@ func CheckServiceAccountTokenSecret(client *rancher.Client, clusterName string) 
 }
 
 // NewRKE1lusterConfig is a constructor for a v3.Cluster object, to be used by the rancher.Client.Provisioning client.
-func NewRKE1ClusterConfig(clusterName, cni, kubernetesVersion string, psact string, client *rancher.Client) *management.Cluster {
+func NewRKE1ClusterConfig(clusterName, cni, kubernetesVersion string, psact string, client *rancher.Client, advancedOptions provisioning.AdvancedOptions) *management.Cluster {
 	clusterConfig := &management.Cluster{
 		DockerRootDir:           "/var/lib/docker",
 		EnableClusterAlerting:   false,
@@ -150,6 +153,8 @@ func NewRKE1ClusterConfig(clusterName, cni, kubernetesVersion string, psact stri
 			Version: kubernetesVersion,
 		},
 	}
+	clusterConfig.ClusterAgentDeploymentCustomization = &advancedOptions.ClusterAgentCustomization
+	clusterConfig.FleetAgentDeploymentCustomization = &advancedOptions.FleetAgentCustomization
 
 	if psact != "" {
 		clusterConfig.DefaultPodSecurityAdmissionConfigurationTemplateName = psact
@@ -159,7 +164,7 @@ func NewRKE1ClusterConfig(clusterName, cni, kubernetesVersion string, psact stri
 }
 
 // NewK3SRKE2ClusterConfig is a constructor for a apisV1.Cluster object, to be used by the rancher.Client.Provisioning client.
-func NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretName, kubernetesVersion string, psact string, machinePools []apisV1.RKEMachinePool) *apisV1.Cluster {
+func NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretName, kubernetesVersion string, psact string, machinePools []apisV1.RKEMachinePool, advancedOptions rancherProvisioning.AdvancedOptions) *apisV1.Cluster {
 	typeMeta := metav1.TypeMeta{
 		Kind:       "Cluster",
 		APIVersion: "provisioning.cattle.io/v1",
@@ -201,6 +206,47 @@ func NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretN
 		WorkerConcurrency:        "10%",
 		WorkerDrainOptions:       rkev1.DrainOptions{},
 	}
+	clusterAgentDeploymentCustomization := &apisV1.AgentDeploymentCustomization{}
+	if advancedOptions.ClusterAgentCustomization.OverrideResourceRequirements != nil {
+		clusterAgentOverrides := ResourceConfigHelper(advancedOptions.ClusterAgentCustomization.OverrideResourceRequirements)
+		clusterAgentDeploymentCustomization.OverrideResourceRequirements = clusterAgentOverrides
+	}
+	if advancedOptions.ClusterAgentCustomization.AppendTolerations != nil {
+		v1ClusterTolerations := []corev1.Toleration{}
+		for _, t := range advancedOptions.ClusterAgentCustomization.AppendTolerations {
+			v1ClusterTolerations = append(v1ClusterTolerations, corev1.Toleration{
+				Key:      t.Key,
+				Operator: corev1.TolerationOperator(t.Operator),
+				Value:    t.Value,
+				Effect:   corev1.TaintEffect(t.Effect),
+			})
+		}
+		clusterAgentDeploymentCustomization.AppendTolerations = v1ClusterTolerations
+	}
+	if advancedOptions.ClusterAgentCustomization.OverrideAffinity != nil {
+		clusterAgentDeploymentCustomization.OverrideAffinity = AgentAffinityConfigHelper(advancedOptions.ClusterAgentCustomization.OverrideAffinity)
+	}
+
+	fleetAgentDeploymentCustomization := &apisV1.AgentDeploymentCustomization{}
+	if advancedOptions.FleetAgentCustomization.OverrideResourceRequirements != nil {
+		fleetAgentOverrides := ResourceConfigHelper(advancedOptions.FleetAgentCustomization.OverrideResourceRequirements)
+		fleetAgentDeploymentCustomization.OverrideResourceRequirements = fleetAgentOverrides
+	}
+	if advancedOptions.FleetAgentCustomization.AppendTolerations != nil {
+		v1FleetTolerations := []corev1.Toleration{}
+		for _, t := range advancedOptions.FleetAgentCustomization.AppendTolerations {
+			v1FleetTolerations = append(v1FleetTolerations, corev1.Toleration{
+				Key:      t.Key,
+				Operator: corev1.TolerationOperator(t.Operator),
+				Value:    t.Value,
+				Effect:   corev1.TaintEffect(t.Effect),
+			})
+		}
+		fleetAgentDeploymentCustomization.AppendTolerations = v1FleetTolerations
+	}
+	if advancedOptions.FleetAgentCustomization.OverrideAffinity != nil {
+		fleetAgentDeploymentCustomization.OverrideAffinity = AgentAffinityConfigHelper(advancedOptions.FleetAgentCustomization.OverrideAffinity)
+	}
 
 	rkeSpecCommon := rkev1.RKEClusterSpecCommon{
 		ChartValues:           chartValuesMap,
@@ -209,17 +255,18 @@ func NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretN
 		UpgradeStrategy:       upgradeStrategy,
 		MachineSelectorConfig: []rkev1.RKESystemConfig{},
 	}
-
 	rkeConfig := &apisV1.RKEConfig{
 		RKEClusterSpecCommon: rkeSpecCommon,
 		MachinePools:         machinePools,
 	}
 
 	spec := apisV1.ClusterSpec{
-		CloudCredentialSecretName: cloudCredentialSecretName,
-		KubernetesVersion:         kubernetesVersion,
-		LocalClusterAuthEndpoint:  localClusterAuthEndpoint,
-		RKEConfig:                 rkeConfig,
+		CloudCredentialSecretName:           cloudCredentialSecretName,
+		KubernetesVersion:                   kubernetesVersion,
+		LocalClusterAuthEndpoint:            localClusterAuthEndpoint,
+		RKEConfig:                           rkeConfig,
+		ClusterAgentDeploymentCustomization: clusterAgentDeploymentCustomization,
+		FleetAgentDeploymentCustomization:   fleetAgentDeploymentCustomization,
 	}
 
 	if psact != "" {
@@ -235,9 +282,301 @@ func NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretN
 	return v1Cluster
 }
 
+// ResourceConfigHelper is a "helper" function that is used to convert the management.ResourceRequirements struct
+// to a corev1.ResourceRequirements struct.
+func ResourceConfigHelper(advancedClusterResourceRequirements *management.ResourceRequirements) *corev1.ResourceRequirements {
+	agentOverrides := corev1.ResourceRequirements{}
+	agentOverrides.Limits = corev1.ResourceList{}
+	agentOverrides.Requests = corev1.ResourceList{}
+	if advancedClusterResourceRequirements.Limits[string(corev1.ResourceCPU)] != "" {
+		agentOverrides.Limits[corev1.ResourceCPU] = resource.MustParse(advancedClusterResourceRequirements.Limits[string(corev1.ResourceCPU)])
+	}
+	if advancedClusterResourceRequirements.Limits[string(corev1.ResourceMemory)] != "" {
+		agentOverrides.Limits[corev1.ResourceMemory] = resource.MustParse(advancedClusterResourceRequirements.Limits[string(corev1.ResourceMemory)])
+	}
+	if advancedClusterResourceRequirements.Requests[string(corev1.ResourceCPU)] != "" {
+		agentOverrides.Requests[corev1.ResourceCPU] = resource.MustParse(advancedClusterResourceRequirements.Requests[string(corev1.ResourceCPU)])
+	}
+	if advancedClusterResourceRequirements.Requests[string(corev1.ResourceMemory)] != "" {
+		agentOverrides.Requests[corev1.ResourceMemory] = resource.MustParse(advancedClusterResourceRequirements.Requests[string(corev1.ResourceMemory)])
+	}
+	return &agentOverrides
+}
+
+// AgentAffinityConfigHelper is a "helper" function that converts a management.Affinity struct and returns a corev1.Affinity struct.
+func AgentAffinityConfigHelper(advancedClusterAffinity *management.Affinity) *corev1.Affinity {
+	agentAffinity := &corev1.Affinity{}
+	if advancedClusterAffinity.NodeAffinity != nil {
+		agentAffinity.NodeAffinity = &corev1.NodeAffinity{}
+		if advancedClusterAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+			agentAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
+			agentAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []corev1.NodeSelectorTerm{}
+			for _, term := range advancedClusterAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+				agentMatchExpressions := []corev1.NodeSelectorRequirement{}
+				if term.MatchExpressions != nil {
+					for _, match := range term.MatchExpressions {
+						newMatchExpression := corev1.NodeSelectorRequirement{}
+						newMatchExpression.Key = match.Key
+						newMatchExpression.Operator = corev1.NodeSelectorOperator(match.Operator)
+						newMatchExpression.Values = match.Values
+						agentMatchExpressions = append(agentMatchExpressions, newMatchExpression)
+					}
+				}
+				agentMatchFields := []corev1.NodeSelectorRequirement{}
+				if term.MatchFields != nil {
+					for _, match := range term.MatchFields {
+						newMatchExpression := corev1.NodeSelectorRequirement{}
+						newMatchExpression.Key = match.Key
+						newMatchExpression.Operator = corev1.NodeSelectorOperator(match.Operator)
+						newMatchExpression.Values = match.Values
+						agentMatchFields = append(agentMatchFields, newMatchExpression)
+					}
+				}
+				agentAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(agentAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, corev1.NodeSelectorTerm{
+					MatchExpressions: agentMatchExpressions,
+					MatchFields:      agentMatchFields,
+				})
+			}
+		}
+		if advancedClusterAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil {
+			agentAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = []corev1.PreferredSchedulingTerm{}
+			for _, preferred := range advancedClusterAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+				termPreferences := corev1.NodeSelectorTerm{}
+				if preferred.Preference.MatchExpressions != nil {
+					termPreferences.MatchExpressions = []corev1.NodeSelectorRequirement{}
+					for _, match := range preferred.Preference.MatchExpressions {
+						newMatchExpression := corev1.NodeSelectorRequirement{}
+						newMatchExpression.Key = match.Key
+						newMatchExpression.Operator = corev1.NodeSelectorOperator(match.Operator)
+						newMatchExpression.Values = match.Values
+						termPreferences.MatchExpressions = append(termPreferences.MatchExpressions, newMatchExpression)
+					}
+				}
+				if preferred.Preference.MatchFields != nil {
+					termPreferences.MatchFields = []corev1.NodeSelectorRequirement{}
+					for _, match := range preferred.Preference.MatchFields {
+						newMatchExpression := corev1.NodeSelectorRequirement{}
+						newMatchExpression.Key = match.Key
+						newMatchExpression.Operator = corev1.NodeSelectorOperator(match.Operator)
+						newMatchExpression.Values = match.Values
+						termPreferences.MatchFields = append(termPreferences.MatchFields, newMatchExpression)
+					}
+				}
+				agentAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(agentAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, corev1.PreferredSchedulingTerm{
+					Weight:     int32(preferred.Weight),
+					Preference: termPreferences,
+				})
+			}
+		}
+	}
+	if advancedClusterAffinity.PodAffinity != nil {
+		agentAffinity.PodAffinity = &corev1.PodAffinity{}
+		if advancedClusterAffinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+			agentAffinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = []corev1.PodAffinityTerm{}
+			for _, term := range advancedClusterAffinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
+				matchExpressions := []metav1.LabelSelectorRequirement{}
+				if term.LabelSelector != nil {
+					for _, expression := range term.LabelSelector.MatchExpressions {
+						newExpression := metav1.LabelSelectorRequirement{}
+						newExpression.Key = expression.Key
+						newExpression.Operator = metav1.LabelSelectorOperator(expression.Operator)
+						newExpression.Values = expression.Values
+						matchExpressions = append(matchExpressions, newExpression)
+					}
+				}
+				matchNamespaces := metav1.LabelSelector{}
+				if term.NamespaceSelector != nil {
+					if term.NamespaceSelector.MatchLabels != nil {
+						matchNamespaces.MatchLabels = term.NamespaceSelector.MatchLabels
+					}
+					for _, expression := range term.NamespaceSelector.MatchExpressions {
+						newExpression := metav1.LabelSelectorRequirement{}
+						newExpression.Key = expression.Key
+						newExpression.Operator = metav1.LabelSelectorOperator(expression.Operator)
+						newExpression.Values = expression.Values
+						matchNamespaces.MatchExpressions = append(matchNamespaces.MatchExpressions, newExpression)
+					}
+				}
+				newAffinityTerms := corev1.PodAffinityTerm{
+					TopologyKey: term.TopologyKey,
+				}
+				if len(term.Namespaces) > 0 {
+					newAffinityTerms.Namespaces = term.Namespaces
+				}
+				if term.LabelSelector != nil {
+					newAffinityTerms.LabelSelector = &metav1.LabelSelector{}
+					if term.LabelSelector.MatchLabels != nil {
+						newAffinityTerms.LabelSelector.MatchLabels = term.LabelSelector.MatchLabels
+					}
+					if len(matchExpressions) > 0 {
+						newAffinityTerms.LabelSelector.MatchExpressions = matchExpressions
+					}
+				}
+				if matchNamespaces.MatchLabels != nil || len(matchNamespaces.MatchExpressions) > 0 {
+					newAffinityTerms.NamespaceSelector = &matchNamespaces
+				}
+				agentAffinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(agentAffinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution, newAffinityTerms)
+			}
+		}
+		if advancedClusterAffinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil {
+			agentAffinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = []corev1.WeightedPodAffinityTerm{}
+			for _, preferred := range advancedClusterAffinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+				matchExpressions := []metav1.LabelSelectorRequirement{}
+				if preferred.PodAffinityTerm.LabelSelector != nil {
+					for _, expression := range preferred.PodAffinityTerm.LabelSelector.MatchExpressions {
+						newExpression := metav1.LabelSelectorRequirement{}
+						newExpression.Key = expression.Key
+						newExpression.Operator = metav1.LabelSelectorOperator(expression.Operator)
+						newExpression.Values = expression.Values
+						matchExpressions = append(matchExpressions, newExpression)
+					}
+				}
+				matchNamespaces := metav1.LabelSelector{}
+				if preferred.PodAffinityTerm.NamespaceSelector != nil {
+					if preferred.PodAffinityTerm.NamespaceSelector.MatchLabels == nil {
+						matchNamespaces.MatchLabels = preferred.PodAffinityTerm.NamespaceSelector.MatchLabels
+					}
+					for _, expression := range preferred.PodAffinityTerm.NamespaceSelector.MatchExpressions {
+						newExpression := metav1.LabelSelectorRequirement{}
+						newExpression.Key = expression.Key
+						newExpression.Operator = metav1.LabelSelectorOperator(expression.Operator)
+						newExpression.Values = expression.Values
+						matchNamespaces.MatchExpressions = append(matchNamespaces.MatchExpressions, newExpression)
+					}
+				}
+				newAffinityTerms := corev1.WeightedPodAffinityTerm{
+					Weight: int32(preferred.Weight),
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						TopologyKey: preferred.PodAffinityTerm.TopologyKey,
+					},
+				}
+				// add in optional variables if they exist
+				if preferred.PodAffinityTerm.Namespaces != nil {
+					newAffinityTerms.PodAffinityTerm.Namespaces = preferred.PodAffinityTerm.Namespaces
+				}
+				if matchNamespaces.MatchLabels != nil || matchNamespaces.MatchExpressions != nil {
+					newAffinityTerms.PodAffinityTerm.NamespaceSelector = &matchNamespaces
+				}
+				if preferred.PodAffinityTerm.LabelSelector != nil {
+					newAffinityTerms.PodAffinityTerm.LabelSelector = &metav1.LabelSelector{}
+					if preferred.PodAffinityTerm.LabelSelector.MatchLabels != nil {
+						newAffinityTerms.PodAffinityTerm.LabelSelector.MatchLabels = preferred.PodAffinityTerm.LabelSelector.MatchLabels
+					}
+					if preferred.PodAffinityTerm.LabelSelector.MatchExpressions != nil {
+						newAffinityTerms.PodAffinityTerm.LabelSelector.MatchExpressions = matchExpressions
+					}
+				}
+				agentAffinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(agentAffinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution, newAffinityTerms)
+			}
+		}
+	}
+	if advancedClusterAffinity.PodAntiAffinity != nil {
+		agentAffinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
+		if advancedClusterAffinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+			agentAffinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = []corev1.PodAffinityTerm{}
+			for _, term := range advancedClusterAffinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
+				matchExpressions := []metav1.LabelSelectorRequirement{}
+				if term.LabelSelector != nil {
+					for _, expression := range term.LabelSelector.MatchExpressions {
+						newExpression := metav1.LabelSelectorRequirement{}
+						newExpression.Key = expression.Key
+						newExpression.Operator = metav1.LabelSelectorOperator(expression.Operator)
+						newExpression.Values = expression.Values
+						matchExpressions = append(matchExpressions, newExpression)
+					}
+				}
+				matchNamespaces := metav1.LabelSelector{}
+				if term.NamespaceSelector != nil {
+					if term.NamespaceSelector.MatchLabels != nil {
+						matchNamespaces.MatchLabels = term.NamespaceSelector.MatchLabels
+					}
+					for _, expression := range term.NamespaceSelector.MatchExpressions {
+						newExpression := metav1.LabelSelectorRequirement{}
+						newExpression.Key = expression.Key
+						newExpression.Operator = metav1.LabelSelectorOperator(expression.Operator)
+						newExpression.Values = expression.Values
+						matchNamespaces.MatchExpressions = append(matchNamespaces.MatchExpressions, newExpression)
+					}
+				}
+				newAffinityTerms := corev1.PodAffinityTerm{
+					TopologyKey: term.TopologyKey,
+				}
+				if len(term.Namespaces) > 0 {
+					newAffinityTerms.Namespaces = term.Namespaces
+				}
+				if term.LabelSelector != nil {
+					newAffinityTerms.LabelSelector = &metav1.LabelSelector{}
+					if term.LabelSelector.MatchLabels != nil {
+						newAffinityTerms.LabelSelector.MatchLabels = term.LabelSelector.MatchLabels
+					}
+					if len(matchExpressions) > 0 {
+						newAffinityTerms.LabelSelector.MatchExpressions = matchExpressions
+					}
+				}
+				if matchNamespaces.MatchLabels != nil || len(matchNamespaces.MatchExpressions) > 0 {
+					newAffinityTerms.NamespaceSelector = &matchNamespaces
+				}
+				agentAffinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(agentAffinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, newAffinityTerms)
+			}
+		}
+		if advancedClusterAffinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil {
+			agentAffinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = []corev1.WeightedPodAffinityTerm{}
+			for _, preferred := range advancedClusterAffinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+				matchExpressions := []metav1.LabelSelectorRequirement{}
+				if preferred.PodAffinityTerm.LabelSelector != nil {
+					for _, expression := range preferred.PodAffinityTerm.LabelSelector.MatchExpressions {
+						newExpression := metav1.LabelSelectorRequirement{}
+						newExpression.Key = expression.Key
+						newExpression.Operator = metav1.LabelSelectorOperator(expression.Operator)
+						newExpression.Values = expression.Values
+						matchExpressions = append(matchExpressions, newExpression)
+					}
+				}
+				matchNamespaces := metav1.LabelSelector{}
+				if preferred.PodAffinityTerm.NamespaceSelector != nil {
+					if preferred.PodAffinityTerm.NamespaceSelector.MatchLabels == nil {
+						matchNamespaces.MatchLabels = preferred.PodAffinityTerm.NamespaceSelector.MatchLabels
+					}
+					for _, expression := range preferred.PodAffinityTerm.NamespaceSelector.MatchExpressions {
+						newExpression := metav1.LabelSelectorRequirement{}
+						newExpression.Key = expression.Key
+						newExpression.Operator = metav1.LabelSelectorOperator(expression.Operator)
+						newExpression.Values = expression.Values
+						matchNamespaces.MatchExpressions = append(matchNamespaces.MatchExpressions, newExpression)
+					}
+				}
+				newAffinityTerms := corev1.WeightedPodAffinityTerm{
+					Weight: int32(preferred.Weight),
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						TopologyKey: preferred.PodAffinityTerm.TopologyKey,
+					},
+				}
+				// add in optional variables if they exist
+				if preferred.PodAffinityTerm.Namespaces != nil {
+					newAffinityTerms.PodAffinityTerm.Namespaces = preferred.PodAffinityTerm.Namespaces
+				}
+				if matchNamespaces.MatchLabels != nil || matchNamespaces.MatchExpressions != nil {
+					newAffinityTerms.PodAffinityTerm.NamespaceSelector = &matchNamespaces
+				}
+				if preferred.PodAffinityTerm.LabelSelector != nil {
+					newAffinityTerms.PodAffinityTerm.LabelSelector = &metav1.LabelSelector{}
+					if preferred.PodAffinityTerm.LabelSelector.MatchLabels != nil {
+						newAffinityTerms.PodAffinityTerm.LabelSelector.MatchLabels = preferred.PodAffinityTerm.LabelSelector.MatchLabels
+					}
+					if preferred.PodAffinityTerm.LabelSelector.MatchExpressions != nil {
+						newAffinityTerms.PodAffinityTerm.LabelSelector.MatchExpressions = matchExpressions
+					}
+				}
+				agentAffinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(agentAffinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, newAffinityTerms)
+			}
+		}
+	}
+	return agentAffinity
+}
+
 // HardenK3SRKE2ClusterConfig is a constructor for a apisV1.Cluster object, to be used by the rancher.Client.Provisioning client.
-func HardenK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretName, kubernetesVersion string, psact string, machinePools []apisV1.RKEMachinePool) *apisV1.Cluster {
-	v1Cluster := NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretName, kubernetesVersion, psact, machinePools)
+func HardenK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretName, kubernetesVersion string, psact string, machinePools []apisV1.RKEMachinePool, advancedOptions rancherProvisioning.AdvancedOptions) *apisV1.Cluster {
+	v1Cluster := NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredentialSecretName, kubernetesVersion, psact, machinePools, advancedOptions)
 
 	if strings.Contains(kubernetesVersion, "k3s") {
 		v1Cluster.Spec.RKEConfig.MachineGlobalConfig.Data["kube-apiserver-arg"] = []string{

--- a/tests/v2/codecoverage/setuprancher/main.go
+++ b/tests/v2/codecoverage/setuprancher/main.go
@@ -95,6 +95,7 @@ func main() {
 	kubernetesVersions := clustersConfig.RKE1KubernetesVersions
 	cnis := clustersConfig.CNIs
 	nodesAndRoles := clustersConfig.NodesAndRolesRKE1
+	advancedOptions := clustersConfig.AdvancedOptions
 
 	client, err := rancher.NewClient("", session)
 	if err != nil {
@@ -129,13 +130,13 @@ func main() {
 	}
 
 	// create admin cluster
-	adminClusterNames, err := createTestCluster(client, client, 1, "admintestcluster", cnis[0], kubernetesVersions[0], nodesAndRoles)
+	adminClusterNames, err := createTestCluster(client, client, 1, "admintestcluster", cnis[0], kubernetesVersions[0], nodesAndRoles, advancedOptions)
 	if err != nil {
 		logrus.Fatalf("error creating admin user cluster: %v", err)
 	}
 
 	// create standard user clusters
-	standardClusterNames, err := createTestCluster(standardUserClient, client, 2, "standardtestcluster", cnis[0], kubernetesVersions[0], nodesAndRoles)
+	standardClusterNames, err := createTestCluster(standardUserClient, client, 2, "standardtestcluster", cnis[0], kubernetesVersions[0], nodesAndRoles, advancedOptions)
 	if err != nil {
 		logrus.Fatalf("error creating standard user clusters: %v", err)
 	}
@@ -355,12 +356,12 @@ func updateRancherDeployment(kubeconfig []byte) error {
 	return err
 }
 
-func createTestCluster(client, adminClient *rancher.Client, numClusters int, clusterNameBase, cni, kubeVersion string, nodesAndRoles []nodepools.NodeRoles) ([]string, error) {
+func createTestCluster(client, adminClient *rancher.Client, numClusters int, clusterNameBase, cni, kubeVersion string, nodesAndRoles []nodepools.NodeRoles, advancedOptions provisioning.AdvancedOptions) ([]string, error) {
 	clusterNames := []string{}
 	for i := 0; i < numClusters; i++ {
 		clusterName := namegen.AppendRandomString(clusterNameBase)
 		clusterNames = append(clusterNames, clusterName)
-		cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, "", client)
+		cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, "", client, advancedOptions)
 
 		clusterResp, err := clusters.CreateRKE1Cluster(client, cluster)
 		if err != nil {

--- a/tests/v2/validation/provisioning/config.go
+++ b/tests/v2/validation/provisioning/config.go
@@ -1,6 +1,7 @@
 package provisioning
 
 import (
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
 )
@@ -48,6 +49,11 @@ func (c TestClientName) String() string {
 	return string(c)
 }
 
+type AdvancedOptions struct {
+	ClusterAgentCustomization management.AgentDeploymentCustomization `json:"clusterAgentCustomization" yaml:"clusterAgentCustomization"`
+	FleetAgentCustomization   management.AgentDeploymentCustomization `json:"fleetAgentCustomization" yaml:"fleetAgentCustomization"`
+}
+
 type Config struct {
 	NodesAndRoles          []machinepools.NodeRoles `json:"nodesAndRoles" yaml:"nodesAndRoles" default:"[]"`
 	NodesAndRolesRKE1      []nodepools.NodeRoles    `json:"nodesAndRolesRKE1" yaml:"nodesAndRolesRKE1" default:"[]"`
@@ -59,4 +65,5 @@ type Config struct {
 	NodeProviders          []string                 `json:"nodeProviders" yaml:"nodeProviders"`
 	PSACT                  string                   `json:"psact" yaml:"psact"`
 	Hardened               bool                     `json:"hardened" yaml:"hardened"`
+	AdvancedOptions        AdvancedOptions          `json:"advancedOptions" yaml:"advancedOptions"`
 }

--- a/tests/v2/validation/provisioning/k3s/README.md
+++ b/tests/v2/validation/provisioning/k3s/README.md
@@ -12,7 +12,8 @@ Please see below for more details for your config.
 3. [Cloud Credential](#cloud-credentials)
 4. [Configure providers to use for Node Driver Clusters](#machine-k3s-config)
 5. [Configuring Custom Clusters](#custom-cluster)
-6. [Back to general provisioning](../README.md)
+6. [Advanced Cluster Settings](#advanced-settings)
+7. [Back to general provisioning](../README.md)
 
 ## Provisioning Input
 provisioningInput is needed to the run the K3S tests, specifically kubernetesVersion and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". psact is optional and takes values `rancher-privileged` and `rancher-restricted` only.
@@ -215,4 +216,59 @@ For custom clusters, the below config is needed, only AWS/EC2 will work.
     "awsUser": "ubuntu",
     "volumeSize": 50
   },
+```
+
+## Advanced Settings
+This encapsulates any other setting that is applied in the cluster.spec. Currently we have support for:
+* cluster agent customization 
+* fleet agent customization
+
+Please read up on general k8s to get an idea of correct formatting for:
+* resource requests
+* resource limits
+* node affinity
+* tolerations
+
+```json
+"advancedOptions": {
+    "clusterAgentCustomization": { // change this to fleetAgentCustomization for fleet agent
+        "appendTolerations": [
+            {
+                "key": "Testkey",
+                "value": "testValue",
+                "effect": "NoSchedule"
+            }
+        ],
+        "overrideResourceRequirements": {
+            "limits": {
+                "cpu": "750m",
+                "memory": "500Mi"
+            },
+            "requests": {
+                "cpu": "250m",
+                "memory": "250Mi"
+            }
+        },
+        "overrideAffinity": {
+            "nodeAffinity": {
+                "preferredDuringSchedulingIgnoredDuringExecution": [
+                    {
+                        "preference": {
+                            "matchExpressions": [
+                                {
+                                    "key": "cattle.io/cluster-agent",
+                                    "operator": "In",
+                                    "values": [
+                                        "true"
+                                    ]
+                                }
+                            ]
+                        },
+                        "weight": 1
+                    }
+                ]
+            }
+        }
+    }
+}
 ```

--- a/tests/v2/validation/provisioning/k3s/custom_cluster.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestProvisioningK3SCustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []string, kubeVersion string, hardened bool, psact string) {
+func TestProvisioningK3SCustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []string, kubeVersion string, hardened bool, psact string, advancedOptions provisioning.AdvancedOptions) {
 	namespace := "fleet-default"
 
 	numNodes := len(nodesAndRoles)
@@ -34,7 +34,7 @@ func TestProvisioningK3SCustomCluster(t *testing.T, client *rancher.Client, exte
 
 	clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
 
-	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, psact, nil)
+	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, psact, nil, advancedOptions)
 
 	clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
 	require.NoError(t, err)
@@ -100,7 +100,7 @@ func TestProvisioningK3SCustomCluster(t *testing.T, client *rancher.Client, exte
 		err = hardening.HardeningNodes(client, hardened, nodes, nodesAndRoles)
 		require.NoError(t, err)
 
-		hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, psact, nil)
+		hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, psact, nil, provisioning.AdvancedOptions{})
 		hardenClusterResp, err := clusters.UpdateK3SRKE2Cluster(client, clusterResp, hardenCluster)
 		require.NoError(t, err)
 		assert.Equal(t, clusterName, hardenClusterResp.ObjectMeta.Name)

--- a/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster_test.go
@@ -26,6 +26,7 @@ type CustomClusterProvisioningTestSuite struct {
 	nodeProviders      []string
 	psact              string
 	hardened           bool
+	advancedOptions    provisioning.AdvancedOptions
 }
 
 func (c *CustomClusterProvisioningTestSuite) TearDownSuite() {
@@ -43,6 +44,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	c.nodeProviders = clustersConfig.NodeProviders
 	c.psact = clustersConfig.PSACT
 	c.hardened = clustersConfig.Hardened
+	c.advancedOptions = clustersConfig.AdvancedOptions
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(c.T(), err)
@@ -116,7 +118,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomCluster() 
 			for _, kubeVersion := range c.kubernetesVersions {
 				name = tt.name + providerName + " Kubernetes version: " + kubeVersion
 				c.Run(name, func() {
-					TestProvisioningK3SCustomCluster(c.T(), client, externalNodeProvider, tt.nodeRoles, kubeVersion, c.hardened, tt.psact)
+					TestProvisioningK3SCustomCluster(c.T(), client, externalNodeProvider, tt.nodeRoles, kubeVersion, c.hardened, tt.psact, c.advancedOptions)
 				})
 			}
 		}
@@ -170,7 +172,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomClusterDyn
 			for _, kubeVersion := range c.kubernetesVersions {
 				name = tt.name + providerName + " Kubernetes version: " + kubeVersion
 				c.Run(name, func() {
-					TestProvisioningK3SCustomCluster(c.T(), client, externalNodeProvider, rolesPerNode, kubeVersion, c.hardened, tt.psact)
+					TestProvisioningK3SCustomCluster(c.T(), client, externalNodeProvider, rolesPerNode, kubeVersion, c.hardened, tt.psact, c.advancedOptions)
 				})
 			}
 		}

--- a/tests/v2/validation/provisioning/k3s/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/k3s/post_kdm_oob_release_test.go
@@ -34,6 +34,7 @@ type KdmChecksTestSuite struct {
 	cnis                  []string
 	providers             []string
 	nodesAndRoles         []machinepools.NodeRoles
+	advancedOptions       provisioning.AdvancedOptions
 }
 
 const (
@@ -58,6 +59,7 @@ func (k *KdmChecksTestSuite) SetupSuite() {
 	k.cnis = clustersConfig.CNIs
 	k.providers = clustersConfig.Providers
 	k.nodesAndRoles = clustersConfig.NodesAndRoles
+	k.advancedOptions = clustersConfig.AdvancedOptions
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(k.T(), err)
@@ -110,7 +112,7 @@ func (k *KdmChecksTestSuite) TestProvisioningSingleNodeK3SClusters() {
 		require.NoError(k.T(), err)
 
 		machinePools := machinepools.RKEMachinePoolSetup(nodeRoles, machineConfigResp)
-		cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, k.ns, "", cloudCredential.ID, k8sVersion, "", machinePools)
+		cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, k.ns, "", cloudCredential.ID, k8sVersion, "", machinePools, k.advancedOptions)
 
 		logrus.Info("provisioning " + k8sVersion + " cluster..")
 

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver.go
@@ -26,7 +26,7 @@ const (
 	namespace = "fleet-default"
 )
 
-func TestProvisioningK3SCluster(t *testing.T, client *rancher.Client, provider Provider, nodesAndRoles []machinepools.NodeRoles, kubeVersion string, psact string) {
+func TestProvisioningK3SCluster(t *testing.T, client *rancher.Client, provider Provider, nodesAndRoles []machinepools.NodeRoles, kubeVersion string, psact string, advancedOptions provisioning.AdvancedOptions) {
 	cloudCredential, err := provider.CloudCredFunc(client)
 	require.NoError(t, err)
 
@@ -39,7 +39,7 @@ func TestProvisioningK3SCluster(t *testing.T, client *rancher.Client, provider P
 
 	machinePools := machinepools.RKEMachinePoolSetup(nodesAndRoles, machineConfigResp)
 
-	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", cloudCredential.ID, kubeVersion, psact, machinePools)
+	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "", cloudCredential.ID, kubeVersion, psact, machinePools, advancedOptions)
 
 	clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
 	require.NoError(t, err)

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
@@ -26,6 +26,7 @@ type K3SNodeDriverProvisioningTestSuite struct {
 	kubernetesVersions []string
 	providers          []string
 	psact              string
+	advancedOptions    provisioning.AdvancedOptions
 }
 
 func (k *K3SNodeDriverProvisioningTestSuite) TearDownSuite() {
@@ -42,6 +43,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) SetupSuite() {
 	k.kubernetesVersions = clustersConfig.K3SKubernetesVersions
 	k.providers = clustersConfig.Providers
 	k.psact = clustersConfig.PSACT
+	k.advancedOptions = clustersConfig.AdvancedOptions
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(k.T(), err)
@@ -146,7 +148,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SCluster() {
 			for _, kubeVersion := range k.kubernetesVersions {
 				name = tt.name + providerName.String() + " Kubernetes version: " + kubeVersion
 				k.Run(name, func() {
-					TestProvisioningK3SCluster(k.T(), client, provider, tt.nodeRoles, kubeVersion, tt.psact)
+					TestProvisioningK3SCluster(k.T(), client, provider, tt.nodeRoles, kubeVersion, tt.psact, k.advancedOptions)
 				})
 			}
 		}
@@ -185,7 +187,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SClusterDynamicIn
 			for _, kubeVersion := range k.kubernetesVersions {
 				name = tt.name + providerName + " Kubernetes version: " + kubeVersion
 				k.Run(name, func() {
-					TestProvisioningK3SCluster(k.T(), client, provider, nodesAndRoles, kubeVersion, tt.psact)
+					TestProvisioningK3SCluster(k.T(), client, provider, nodesAndRoles, kubeVersion, tt.psact, k.advancedOptions)
 				})
 			}
 		}

--- a/tests/v2/validation/provisioning/rke1/README.md
+++ b/tests/v2/validation/provisioning/rke1/README.md
@@ -11,7 +11,8 @@ Please see below for more details for your config.
 2. [Define your test](#Provisioning-Input)
 3. [Configure providers to use for Node Driver Clusters](#NodeTemplateConfigs)
 4. [Configuring Custom Clusters](#Custom-Cluster)
-5. [Back to general provisioning](../README.md)
+5. [Advanced Cluster Settings](#advanced-settings)
+6. [Back to general provisioning](../README.md)
 
 ## Provisioning Input
 provisioningInput is needed to the run the RKE1 tests, specifically kubernetesVersion, cni, and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". psact is optional and takes values `rancher-privileged` and `rancher-restricted` only.
@@ -227,4 +228,59 @@ For custom clusters, the below config is needed, only AWS/EC2. It is important t
     "awsUser": "ubuntu",
     "volumeSize": 50
   },
+```
+
+## Advanced Settings
+This encapsulates any other setting that is applied in the cluster.spec. Currently we have support for:
+* cluster agent customization 
+* fleet agent customization
+
+Please read up on general k8s to get an idea of correct formatting for:
+* resource requests
+* resource limits
+* node affinity
+* tolerations
+
+```json
+"advancedOptions": {
+    "flusterAgentCustomization": { // change this to fleetAgentCustomization for fleet agent
+        "appendTolerations": [
+            {
+                "key": "Testkey",
+                "value": "testValue",
+                "effect": "NoSchedule"
+            }
+        ],
+        "overrideResourceRequirements": {
+            "limits": {
+                "cpu": "750m",
+                "memory": "500Mi"
+            },
+            "requests": {
+                "cpu": "250m",
+                "memory": "250Mi"
+            }
+        },
+        "overrideAffinity": {
+            "nodeAffinity": {
+                "preferredDuringSchedulingIgnoredDuringExecution": [
+                    {
+                        "preference": {
+                            "matchExpressions": [
+                                {
+                                    "key": "cattle.io/cluster-agent",
+                                    "operator": "In",
+                                    "values": [
+                                        "true"
+                                    ]
+                                }
+                            ]
+                        },
+                        "weight": 1
+                    }
+                ]
+            }
+        }
+    }
+}
 ```

--- a/tests/v2/validation/provisioning/rke1/custom_cluster.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster.go
@@ -22,14 +22,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestProvisioningRKE1CustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []string, psact, kubeVersion, cni string) {
+func TestProvisioningRKE1CustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []string, psact, kubeVersion, cni string, advancedOptions provisioning.AdvancedOptions) {
 	numNodes := len(nodesAndRoles)
 	nodes, _, err := externalNodeProvider.NodeCreationFunc(client, numNodes, 0, false)
 	require.NoError(t, err)
 
 	clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
 
-	cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, psact, client)
+	cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, psact, client, advancedOptions)
 	clusterResp, err := clusters.CreateRKE1Cluster(client, cluster)
 	require.NoError(t, err)
 

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -26,6 +26,7 @@ type CustomClusterProvisioningTestSuite struct {
 	cnis               []string
 	nodeProviders      []string
 	psact              string
+	advancedOptions    provisioning.AdvancedOptions
 }
 
 func (c *CustomClusterProvisioningTestSuite) TearDownSuite() {
@@ -43,6 +44,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	c.cnis = clustersConfig.CNIs
 	c.nodeProviders = clustersConfig.NodeProviders
 	c.psact = clustersConfig.PSACT
+	c.advancedOptions = clustersConfig.AdvancedOptions
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(c.T(), err)
@@ -118,7 +120,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 				for _, cni := range c.cnis {
 					name += " cni: " + cni
 					c.Run(name, func() {
-						TestProvisioningRKE1CustomCluster(c.T(), client, externalNodeProvider, tt.nodeRoles, tt.psact, kubeVersion, cni)
+						TestProvisioningRKE1CustomCluster(c.T(), client, externalNodeProvider, tt.nodeRoles, tt.psact, kubeVersion, cni, c.advancedOptions)
 					})
 				}
 			}
@@ -175,7 +177,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomClusterDy
 				for _, cni := range c.cnis {
 					name += " cni: " + cni
 					c.Run(name, func() {
-						TestProvisioningRKE1CustomCluster(c.T(), client, externalNodeProvider, rolesPerNode, tt.psact, kubeVersion, cni)
+						TestProvisioningRKE1CustomCluster(c.T(), client, externalNodeProvider, rolesPerNode, tt.psact, kubeVersion, cni, c.advancedOptions)
 					})
 				}
 			}

--- a/tests/v2/validation/provisioning/rke1/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/rke1/post_kdm_oob_release_test.go
@@ -32,6 +32,7 @@ type KdmChecksTestSuite struct {
 	cnis                   []string
 	providers              []string
 	nodesAndRoles          []nodepools.NodeRoles
+	advancedOptions        provisioning.AdvancedOptions
 }
 
 const (
@@ -57,6 +58,7 @@ func (k *KdmChecksTestSuite) SetupSuite() {
 	k.cnis = clustersConfig.CNIs
 	k.providers = clustersConfig.Providers
 	k.nodesAndRoles = clustersConfig.NodesAndRolesRKE1
+	k.advancedOptions = clustersConfig.AdvancedOptions
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(k.T(), err)
@@ -100,7 +102,7 @@ func (k *KdmChecksTestSuite) TestProvisioningSingleNodeRKE1Clusters() {
 			nodeTemplate, err := provider.NodeTemplateFunc(client)
 			require.NoError(k.T(), err)
 
-			clusterResp, nodePool, nodePoolName, clusterName, err := k.provisionRKE1Cluster(client, provider, k.nodesAndRoles, k8sVersion, cni, nodeTemplate)
+			clusterResp, nodePool, nodePoolName, clusterName, err := k.provisionRKE1Cluster(client, provider, k.nodesAndRoles, k8sVersion, cni, nodeTemplate, k.advancedOptions)
 			require.NoError(k.T(), err)
 
 			nodePoolNames = append(nodePoolNames, nodePoolName)
@@ -114,10 +116,10 @@ func (k *KdmChecksTestSuite) TestProvisioningSingleNodeRKE1Clusters() {
 
 }
 
-func (k *KdmChecksTestSuite) provisionRKE1Cluster(client *rancher.Client, provider Provider, nodesAndRoles []nodepools.NodeRoles, k8sVersion, cni string, nodeTemplate *nodetemplates.NodeTemplate) (*management.Cluster, *management.NodePool, string, string, error) {
+func (k *KdmChecksTestSuite) provisionRKE1Cluster(client *rancher.Client, provider Provider, nodesAndRoles []nodepools.NodeRoles, k8sVersion, cni string, nodeTemplate *nodetemplates.NodeTemplate, advancedOptions provisioning.AdvancedOptions) (*management.Cluster, *management.NodePool, string, string, error) {
 	clusterName := namegen.AppendRandomString(provider.Name.String())
 
-	cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, k8sVersion, "", client)
+	cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, k8sVersion, "", client, advancedOptions)
 	clusterResp, err := clusters.CreateRKE1Cluster(client, cluster)
 	require.NoError(k.T(), err)
 

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver.go
@@ -22,9 +22,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestProvisioningRKE1Cluster(t *testing.T, client *rancher.Client, provider Provider, nodesAndRoles []nodepools.NodeRoles, psact string, kubeVersion, cni string, nodeTemplate *nodetemplates.NodeTemplate) (*management.Cluster, error) {
+func TestProvisioningRKE1Cluster(t *testing.T, client *rancher.Client, provider Provider, nodesAndRoles []nodepools.NodeRoles, psact string, kubeVersion, cni string, nodeTemplate *nodetemplates.NodeTemplate, advancedOptions provisioning.AdvancedOptions) (*management.Cluster, error) {
 	clusterName := namegen.AppendRandomString(provider.Name.String())
-	cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, psact, client)
+	cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, psact, client, advancedOptions)
 	clusterResp, err := clusters.CreateRKE1Cluster(client, cluster)
 	require.NoError(t, err)
 

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -29,6 +29,7 @@ type RKE1NodeDriverProvisioningTestSuite struct {
 	cnis               []string
 	providers          []string
 	psact              string
+	advancedOptions    provisioning.AdvancedOptions
 }
 
 func (r *RKE1NodeDriverProvisioningTestSuite) TearDownSuite() {
@@ -46,6 +47,7 @@ func (r *RKE1NodeDriverProvisioningTestSuite) SetupSuite() {
 	r.cnis = clustersConfig.CNIs
 	r.providers = clustersConfig.Providers
 	r.psact = clustersConfig.PSACT
+	r.advancedOptions = clustersConfig.AdvancedOptions
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(r.T(), err)
@@ -156,7 +158,7 @@ func (r *RKE1NodeDriverProvisioningTestSuite) TestProvisioningRKE1Cluster() {
 					name += " cni: " + cni
 					scaleName = "scaling " + name
 					r.Run(name, func() {
-						cluster, err := TestProvisioningRKE1Cluster(r.T(), client, provider, tt.nodeRoles, tt.psact, kubeVersion, cni, nodeTemplate)
+						cluster, err := TestProvisioningRKE1Cluster(r.T(), client, provider, tt.nodeRoles, tt.psact, kubeVersion, cni, nodeTemplate, r.advancedOptions)
 						require.NoError(r.T(), err)
 
 						r.cluster = cluster
@@ -211,7 +213,7 @@ func (r *RKE1NodeDriverProvisioningTestSuite) TestProvisioningRKE1ClusterDynamic
 					name += " cni: " + cni
 					scaleName = "scaling " + name
 					r.Run(name, func() {
-						cluster, err := TestProvisioningRKE1Cluster(r.T(), client, provider, nodesAndRoles, tt.psact, kubeVersion, cni, nodeTemplate)
+						cluster, err := TestProvisioningRKE1Cluster(r.T(), client, provider, nodesAndRoles, tt.psact, kubeVersion, cni, nodeTemplate, r.advancedOptions)
 						require.NoError(r.T(), err)
 
 						r.cluster = cluster
@@ -230,7 +232,7 @@ func (r *RKE1NodeDriverProvisioningTestSuite) TestProvisioningRKE1ClusterDynamic
 
 func (r *RKE1NodeDriverProvisioningTestSuite) testScalingRKE1NodePools(client *rancher.Client, provider Provider, nodesAndRoles []nodepools.NodeRoles, psact string, kubeVersion, cni string, cluster *management.Cluster, nodeTemplate *nodetemplates.NodeTemplate) {
 	if cluster == nil {
-		cluster, err := TestProvisioningRKE1Cluster(r.T(), client, provider, nodesAndRoles, psact, kubeVersion, cni, nodeTemplate)
+		cluster, err := TestProvisioningRKE1Cluster(r.T(), client, provider, nodesAndRoles, psact, kubeVersion, cni, nodeTemplate, r.advancedOptions)
 		require.NoError(r.T(), err)
 
 		err = nodepools.ScaleWorkerNodePool(client, nodesAndRoles, cluster.ID, nodeTemplate.ID)

--- a/tests/v2/validation/provisioning/rke2/README.md
+++ b/tests/v2/validation/provisioning/rke2/README.md
@@ -12,7 +12,8 @@ Please see below for more details for your config.
 3. [Cloud Credential](#cloud-credentials)
 4. [Configure providers to use for Node Driver Clusters](#machine-rke2-config)
 5. [Configuring Custom Clusters](#custom-cluster)
-6. [Back to general provisioning](../README.md)
+6. [Advanced Cluster Settings](#advanced-settings)
+7. [Back to general provisioning](../README.md)
 
 ## Provisioning Input
 provisioningInput is needed to the run the RKE2 tests, specifically kubernetesVersion, cni, and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". psact is optional and takes values `rancher-privileged` and `rancher-restricted` only.
@@ -262,5 +263,59 @@ For custom clusters, the below config is needed, only AWS/EC2 will work.
       }
     ]
   }
+}
+```
+## Advanced Settings
+This encapsulates any other setting that is applied in the cluster.spec. Currently we have support for:
+* cluster agent customization 
+* fleet agent customization
+
+Please read up on general k8s to get an idea of correct formatting for:
+* resource requests
+* resource limits
+* node affinity
+* tolerations
+
+```json
+"advancedOptions": {
+    "clusterAgentCustomization": { // change this to fleetAgentCustomization for fleet agent
+        "appendTolerations": [
+            {
+                "key": "Testkey",
+                "value": "testValue",
+                "effect": "NoSchedule"
+            }
+        ],
+        "overrideResourceRequirements": {
+            "limits": {
+                "cpu": "750m",
+                "memory": "500Mi"
+            },
+            "requests": {
+                "cpu": "250m",
+                "memory": "250Mi"
+            }
+        },
+        "overrideAffinity": {
+            "nodeAffinity": {
+                "preferredDuringSchedulingIgnoredDuringExecution": [
+                    {
+                        "preference": {
+                            "matchExpressions": [
+                                {
+                                    "key": "cattle.io/cluster-agent",
+                                    "operator": "In",
+                                    "values": [
+                                        "true"
+                                    ]
+                                }
+                            ]
+                        },
+                        "weight": 1
+                    }
+                ]
+            }
+        }
+    }
 }
 ```

--- a/tests/v2/validation/provisioning/rke2/cert_rotation_test.go
+++ b/tests/v2/validation/provisioning/rke2/cert_rotation_test.go
@@ -29,11 +29,12 @@ import (
 
 type V2ProvCertRotationTestSuite struct {
 	suite.Suite
-	session     *session.Session
-	client      *rancher.Client
-	config      *provisioning.Config
-	clusterName string
-	namespace   string
+	session         *session.Session
+	client          *rancher.Client
+	config          *provisioning.Config
+	clusterName     string
+	namespace       string
+	advancedOptions provisioning.AdvancedOptions
 }
 
 func (r *V2ProvCertRotationTestSuite) TearDownSuite() {
@@ -54,6 +55,7 @@ func (r *V2ProvCertRotationTestSuite) SetupSuite() {
 
 	r.clusterName = r.client.RancherConfig.ClusterName
 	r.namespace = r.client.RancherConfig.ClusterName
+	r.advancedOptions = r.config.AdvancedOptions
 }
 
 func (r *V2ProvCertRotationTestSuite) testCertRotation(provider Provider, kubeVersion string, nodesAndRoles []machinepools.NodeRoles, credential *cloudcredentials.CloudCredential) {
@@ -75,7 +77,7 @@ func (r *V2ProvCertRotationTestSuite) testCertRotation(provider Provider, kubeVe
 
 			machinePools := machinepools.RKEMachinePoolSetup(nodesAndRoles, machineConfigResp)
 
-			cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "calico", credential.ID, kubeVersion, "", machinePools)
+			cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, "calico", credential.ID, kubeVersion, "", machinePools, r.advancedOptions)
 			clusterResp, err := clusters.CreateK3SRKE2Cluster(testSessionClient, cluster)
 			require.NoError(r.T(), err)
 

--- a/tests/v2/validation/provisioning/rke2/custom_cluster.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster.go
@@ -29,7 +29,7 @@ const (
 	namespace = "fleet-default"
 )
 
-func TestProvisioningRKE2CustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []string, psact, kubeVersion, cni string, hardened bool, nodeCountWin int, hasWindows bool) {
+func TestProvisioningRKE2CustomCluster(t *testing.T, client *rancher.Client, externalNodeProvider provisioning.ExternalNodeProvider, nodesAndRoles []string, psact, kubeVersion, cni string, hardened bool, nodeCountWin int, hasWindows bool, advancedOptions provisioning.AdvancedOptions) {
 	numNodesLin := len(nodesAndRoles)
 
 	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
@@ -40,7 +40,7 @@ func TestProvisioningRKE2CustomCluster(t *testing.T, client *rancher.Client, ext
 
 	clusterName := namegen.AppendRandomString(externalNodeProvider.Name)
 
-	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, "", kubeVersion, psact, nil)
+	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, "", kubeVersion, psact, nil, advancedOptions)
 
 	clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
 	require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestProvisioningRKE2CustomCluster(t *testing.T, client *rancher.Client, ext
 		err = hardening.HardeningNodes(client, hardened, linuxNodes, nodesAndRoles)
 		require.NoError(t, err)
 
-		hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, psact, nil)
+		hardenCluster := clusters.HardenK3SRKE2ClusterConfig(clusterName, namespace, "", "", kubeVersion, psact, nil, provisioning.AdvancedOptions{})
 
 		hardenClusterResp, err := clusters.UpdateK3SRKE2Cluster(client, clusterResp, hardenCluster)
 		require.NoError(t, err)

--- a/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster_test.go
@@ -27,6 +27,7 @@ type CustomClusterProvisioningTestSuite struct {
 	cnis               []string
 	nodeProviders      []string
 	psact              string
+	advancedOptions    provisioning.AdvancedOptions
 }
 
 func (c *CustomClusterProvisioningTestSuite) TearDownSuite() {
@@ -45,6 +46,7 @@ func (c *CustomClusterProvisioningTestSuite) SetupSuite() {
 	c.nodeProviders = clustersConfig.NodeProviders
 	c.hardened = clustersConfig.Hardened
 	c.psact = clustersConfig.PSACT
+	c.advancedOptions = clustersConfig.AdvancedOptions
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(c.T(), err)
@@ -128,7 +130,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE2CustomCluster()
 				for _, cni := range c.cnis {
 					name += " cni: " + cni
 					c.Run(name, func() {
-						TestProvisioningRKE2CustomCluster(c.T(), client, externalNodeProvider, tt.nodeRoles, tt.psact, kubeVersion, cni, c.hardened, tt.nodeCountWin, tt.hasWindows)
+						TestProvisioningRKE2CustomCluster(c.T(), client, externalNodeProvider, tt.nodeRoles, tt.psact, kubeVersion, cni, c.hardened, tt.nodeCountWin, tt.hasWindows, c.advancedOptions)
 					})
 				}
 			}
@@ -189,7 +191,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE2CustomClusterDy
 				for _, cni := range c.cnis {
 					name += " cni: " + cni
 					c.Run(name, func() {
-						TestProvisioningRKE2CustomCluster(c.T(), client, externalNodeProvider, rolesPerNode, tt.psact, kubeVersion, cni, c.hardened, tt.nodeCountWin, tt.hasWindows)
+						TestProvisioningRKE2CustomCluster(c.T(), client, externalNodeProvider, rolesPerNode, tt.psact, kubeVersion, cni, c.hardened, tt.nodeCountWin, tt.hasWindows, c.advancedOptions)
 					})
 				}
 			}

--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/v2/validation/provisioning"
 	"github.com/sirupsen/logrus"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -87,7 +88,7 @@ func getSnapshots(client *rancher.Client,
 
 }
 
-func createRKE2NodeDriverCluster(client *rancher.Client, provider *Provider, clusterName string, k8sVersion string, namespace string, cni string) (*steveV1.SteveAPIObject, error) {
+func createRKE2NodeDriverCluster(client *rancher.Client, provider *Provider, clusterName string, k8sVersion string, namespace string, cni string, advancedOptions provisioning.AdvancedOptions) (*steveV1.SteveAPIObject, error) {
 
 	nodeRoles := []machinepools.NodeRoles{
 		{
@@ -124,7 +125,7 @@ func createRKE2NodeDriverCluster(client *rancher.Client, provider *Provider, clu
 
 	machinePools := machinepools.RKEMachinePoolSetup(nodeRoles, machineConfigResp)
 
-	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, k8sVersion, "", machinePools)
+	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, k8sVersion, "", machinePools, advancedOptions)
 
 	return clusters.CreateK3SRKE2Cluster(client, cluster)
 

--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
@@ -39,6 +39,7 @@ type RKE2EtcdSnapshotRestoreTestSuite struct {
 	cnis               []string
 	providers          []string
 	nodesAndRoles      []machinepools.NodeRoles
+	advancedOptions    provisioning.AdvancedOptions
 }
 
 func (r *RKE2EtcdSnapshotRestoreTestSuite) TearDownSuite() {
@@ -58,6 +59,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) SetupSuite() {
 	r.cnis = clustersConfig.CNIs
 	r.providers = clustersConfig.Providers
 	r.nodesAndRoles = clustersConfig.NodesAndRoles
+	r.advancedOptions = clustersConfig.AdvancedOptions
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(r.T(), err)
@@ -83,7 +85,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithK8sUpgrade(pro
 	clusterName := namegen.AppendRandomString(provider.Name.String())
 
 	logrus.Infof("creating rke2Cluster.............")
-	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0])
+	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0], r.advancedOptions)
 	require.NoError(r.T(), err)
 	require.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
 	logrus.Infof("rke2Cluster create request successful.............")
@@ -253,7 +255,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithUpgradeStrateg
 	clusterName := namegen.AppendRandomString(provider.Name.String())
 
 	logrus.Infof("creating rke2Cluster.............")
-	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0])
+	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0], r.advancedOptions)
 	require.NoError(r.T(), err)
 	require.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
 	logrus.Infof("rke2Cluster create request successful.............")
@@ -447,7 +449,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestore(provider *Provide
 	clusterName := namegen.AppendRandomString(provider.Name.String())
 
 	logrus.Infof("creating rke2Cluster.............")
-	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0])
+	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0], r.advancedOptions)
 	require.NoError(r.T(), err)
 	require.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
 	logrus.Infof("rke2Cluster create request successful.............")

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestProvisioningRKE2Cluster(t *testing.T, client *rancher.Client, provider Provider, nodesAndRoles []machinepools.NodeRoles, kubeVersion, cni, psact string) {
+func TestProvisioningRKE2Cluster(t *testing.T, client *rancher.Client, provider Provider, nodesAndRoles []machinepools.NodeRoles, kubeVersion, cni, psact string, advancedOptions provisioning.AdvancedOptions) {
 	cloudCredential, err := provider.CloudCredFunc(client)
 	require.NoError(t, err)
 
@@ -34,8 +34,8 @@ func TestProvisioningRKE2Cluster(t *testing.T, client *rancher.Client, provider 
 	require.NoError(t, err)
 
 	machinePools := machinepools.RKEMachinePoolSetup(nodesAndRoles, machineConfigResp)
+	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, psact, machinePools, advancedOptions)
 
-	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, kubeVersion, psact, machinePools)
 	clusterResp, err := clusters.CreateK3SRKE2Cluster(client, cluster)
 	require.NoError(t, err)
 

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -27,6 +27,7 @@ type RKE2NodeDriverProvisioningTestSuite struct {
 	cnis               []string
 	providers          []string
 	psact              string
+	advancedOptions    provisioning.AdvancedOptions
 }
 
 func (r *RKE2NodeDriverProvisioningTestSuite) TearDownSuite() {
@@ -44,6 +45,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 	r.cnis = clustersConfig.CNIs
 	r.providers = clustersConfig.Providers
 	r.psact = clustersConfig.PSACT
+	r.advancedOptions = clustersConfig.AdvancedOptions
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(r.T(), err)
@@ -150,7 +152,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2Cluster() {
 				for _, cni := range r.cnis {
 					name += " cni: " + cni
 					r.Run(name, func() {
-						TestProvisioningRKE2Cluster(r.T(), client, provider, tt.nodeRoles, kubeVersion, cni, tt.psact)
+						TestProvisioningRKE2Cluster(r.T(), client, provider, tt.nodeRoles, kubeVersion, cni, tt.psact, r.advancedOptions)
 					})
 				}
 			}
@@ -180,7 +182,6 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2ClusterDynamic
 	for _, tt := range tests {
 		subSession := r.session.NewSession()
 		defer subSession.Cleanup()
-
 		client, err := tt.client.WithSession(subSession)
 		require.NoError(r.T(), err)
 
@@ -192,7 +193,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2ClusterDynamic
 				for _, cni := range r.cnis {
 					name += " cni: " + cni
 					r.Run(name, func() {
-						TestProvisioningRKE2Cluster(r.T(), client, provider, nodesAndRoles, kubeVersion, cni, tt.psact)
+						TestProvisioningRKE2Cluster(r.T(), client, provider, nodesAndRoles, kubeVersion, cni, tt.psact, r.advancedOptions)
 					})
 				}
 			}

--- a/tests/v2/validation/registries/registry_test.go
+++ b/tests/v2/validation/registries/registry_test.go
@@ -43,6 +43,7 @@ type RegistryTestSuite struct {
 	clusterNoAuthRegistryHost      string
 	localClusterGlobalRegistryHost string
 	rancherUsesRegistry            bool
+	advancedOptions                provisioning.AdvancedOptions
 }
 
 func (rt *RegistryTestSuite) TearDownSuite() {
@@ -88,6 +89,7 @@ func (rt *RegistryTestSuite) SetupSuite() {
 	cnis := clustersConfig.CNIs
 	nodesAndRoles := clustersConfig.NodesAndRolesRKE1
 	providers := clustersConfig.Providers
+	rt.advancedOptions = clustersConfig.AdvancedOptions
 
 	globalRegistryFqdn := ""
 	rt.rancherUsesRegistry = false
@@ -134,9 +136,9 @@ func (rt *RegistryTestSuite) SetupSuite() {
 	require.NoError(rt.T(), err)
 
 	provider := rke1.CreateProvider(providers[0])
-	clusterNameNoAuth, err := rt.testProvisionRKE1Cluster(subClient, provider, nodesAndRoles, kubernetesVersions[0], cnis[0], privateRegistriesNoAuth)
+	clusterNameNoAuth, err := rt.testProvisionRKE1Cluster(subClient, provider, nodesAndRoles, kubernetesVersions[0], cnis[0], privateRegistriesNoAuth, rt.advancedOptions)
 	require.NoError(rt.T(), err)
-	clusterNameAuth, err := rt.testProvisionRKE1Cluster(subClient, provider, nodesAndRoles, kubernetesVersions[0], cnis[0], privateRegistriesAuth)
+	clusterNameAuth, err := rt.testProvisionRKE1Cluster(subClient, provider, nodesAndRoles, kubernetesVersions[0], cnis[0], privateRegistriesAuth, rt.advancedOptions)
 	require.NoError(rt.T(), err)
 
 	clusterID, err := clusters.GetClusterIDByName(client, clusterNameNoAuth)
@@ -170,9 +172,9 @@ func (rt *RegistryTestSuite) SetupSuite() {
 
 }
 
-func (rt *RegistryTestSuite) testProvisionRKE1Cluster(client *rancher.Client, provider rke1.Provider, nodesAndRoles []nodepools.NodeRoles, kubeVersion, cni string, privateRegistries []management.PrivateRegistry) (string, error) {
+func (rt *RegistryTestSuite) testProvisionRKE1Cluster(client *rancher.Client, provider rke1.Provider, nodesAndRoles []nodepools.NodeRoles, kubeVersion, cni string, privateRegistries []management.PrivateRegistry, advancedOptions provisioning.AdvancedOptions) (string, error) {
 	clusterName := namegen.AppendRandomString(provider.Name.String())
-	cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, "", client)
+	cluster := clusters.NewRKE1ClusterConfig(clusterName, cni, kubeVersion, "", client, advancedOptions)
 
 	cluster.RancherKubernetesEngineConfig.PrivateRegistries = privateRegistries
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/41035

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
new variables were added for cluster and fleet agent.
After looking at existing code, new features like this will not scale in the existing create funcs
lastly, some k8s native resources were causing trouble, most likely due to not including `yaml` in the struct parameter definitions. Specifically for affinity.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
* I had to take a similar approach to what was done for hosted clusters in order to get cluster customization to read in properly
* this is also introducing the `advancedOptions` variable (discussed this approach with Israel before completing this PR)
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
local testing - done with all variables included with a preferred node scheduling affinity

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
tbd: will include jenkins runs for:
fresh install (no variables)
fresh install, all new variables
* with node affinity
* with pod affinity
* with pod antiaffinity

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->