### PR TITLE
Update cluster_handler.go

### DIFF
--- a/pkg/controllers/managementuser/rbac/cluster_handler.go
+++ b/pkg/controllers/managementuser/rbac/cluster_handler.go
@@ -82,7 +82,7 @@ func (h *clusterHandler) doSync(cluster *v3.Cluster) error {
 			}
 			bindingName := rbac.GrbCRBName(grb)
 			_, err := h.userGRBLister.Get("", bindingName)
-			if !k8serrors.IsNotFound(err) {
+			if err != nil && !k8serrors.IsNotFound(err) {
 				return nil, fmt.Errorf("failed to get GlobalRoleBinding for '%s': %w", bindingName, err)
 			}
 


### PR DESCRIPTION
Correct Handling of Failure to get ClusterRoleBinding for a GlobalRoleBinding

## Issue: N/A
 
## Problem
On Version 2.6.12, an error keeps popping up: 
```
 error syncing 'local': handler global-admin-cluster-sync: failed to get GlobalRoleBinding for 'globaladmin-user-jktwn': %!!(MISSING)w(<nil>
 ```
 The root cause is that if the error is not "NotFound", the `doSync` function always fails, even if the `err` is `nil` , which is actually good, means that the CRB is found.

## Solution
Only fail when the `err` is not `nil` and is not `NotFOund
