### PR TITLE
Add cluster agent unit tests

### DIFF
--- a/pkg/cluster/agent_customization_test.go
+++ b/pkg/cluster/agent_customization_test.go
@@ -1,0 +1,201 @@
+package cluster
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAgentCustomization_getAgentCustomization(t *testing.T) {
+	testClusterAgentToleration := []corev1.Toleration{{
+		Effect: "NoSchedule",
+		Key:    "node-role.kubernetes.io/controlplane-test",
+		Value:  "true",
+	},
+	}
+	testClusterAgentAffinity := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				{
+					Weight: 1,
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "cattle.io/cluster-agent-test",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	testClusterAgentResourceReq := &corev1.ResourceRequirements{
+		Limits: map[corev1.ResourceName]resource.Quantity{
+			"cpu":    *resource.NewQuantity(500, resource.DecimalSI),
+			"memory": *resource.NewQuantity(250, resource.DecimalSI),
+		},
+		Requests: map[corev1.ResourceName]resource.Quantity{
+			"cpu":    *resource.NewQuantity(500, resource.DecimalSI),
+			"memory": *resource.NewQuantity(250, resource.DecimalSI),
+		},
+	}
+
+	testFleetAgentToleration := []corev1.Toleration{
+		{
+			Key:      "key",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "value",
+		},
+	}
+	testFleetAgentAffinity := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				{
+					Weight: 1,
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "fleet.cattle.io/agent",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	testFleetAgentResourceReq := &corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("1"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+	}
+
+	tests := []struct {
+		name    string
+		cluster *v3.Cluster
+	}{
+		{
+			name: "test-default",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-default",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{},
+				},
+			},
+		},
+		{
+			name: "test-agent-customization",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-agent-customization",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						ClusterAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+							AppendTolerations:            testClusterAgentToleration,
+							OverrideAffinity:             testClusterAgentAffinity,
+							OverrideResourceRequirements: testClusterAgentResourceReq,
+						},
+						FleetAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+							AppendTolerations:            testFleetAgentToleration,
+							OverrideAffinity:             testFleetAgentAffinity,
+							OverrideResourceRequirements: testFleetAgentResourceReq,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterAgentToleration := GetClusterAgentTolerations(tt.cluster)
+			clusterAgentAffinity, clusterErr := GetClusterAgentAffinity(tt.cluster)
+			clusterAgentResourceRequirements := GetClusterAgentResourceRequirements(tt.cluster)
+
+			fleetAgentToleration := GetFleetAgentTolerations(tt.cluster)
+			fleetAgentAffinity, fleetErr := GetFleetAgentAffinity(tt.cluster)
+			fleetAgentResourceRequirements := GetFleetAgentResourceRequirements(tt.cluster)
+
+			switch tt.name {
+			case "test-default":
+				// cluster agent
+				assert.Nil(t, clusterAgentToleration)
+				defaultClusterAgentAffinity, err := unmarshalAffinity(settings.ClusterAgentDefaultAffinity.Get())
+				if err != nil {
+					assert.FailNow(t, "failed to unmarshal node affinity: %w", err)
+				}
+				assert.Equal(t, defaultClusterAgentAffinity, clusterAgentAffinity)
+				assert.Nil(t, clusterErr)
+				assert.Nil(t, clusterAgentResourceRequirements)
+
+				// fleet agent
+				assert.Nil(t, fleetAgentToleration)
+				defaultFleetAgentAffinity, err := unmarshalAffinity(settings.FleetAgentDefaultAffinity.Get())
+				if err != nil {
+					assert.FailNow(t, "failed to unmarshal node affinity: %w", err)
+				}
+				assert.Equal(t, defaultFleetAgentAffinity, fleetAgentAffinity)
+				assert.Nil(t, fleetErr)
+				assert.Nil(t, fleetAgentResourceRequirements)
+			case "test-agent-customization":
+				// cluster agent
+				assert.Equal(t, testClusterAgentToleration, clusterAgentToleration)
+				assert.Equal(t, testClusterAgentAffinity, clusterAgentAffinity)
+				assert.Nil(t, clusterErr)
+				assert.Equal(t, testClusterAgentResourceReq, clusterAgentResourceRequirements)
+
+				// fleet agent
+				assert.Equal(t, testFleetAgentToleration, fleetAgentToleration)
+				assert.Equal(t, testFleetAgentAffinity, fleetAgentAffinity)
+				assert.Nil(t, fleetErr)
+				assert.Equal(t, testFleetAgentResourceReq, fleetAgentResourceRequirements)
+			}
+		})
+	}
+
+	// Simulate a user setting default affinity as an invalid str
+	settings.ClusterAgentDefaultAffinity.Set("test-invalid-affinity")
+	settings.FleetAgentDefaultAffinity.Set("test-invalid-affinity")
+
+	// Run tests again and verify that when the cluster agent or fleet agent default affinity is pulled it returns
+	// nil and an error.
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterAgentAffinity, clusterErr := GetClusterAgentAffinity(tt.cluster)
+			fleetAgentAffinity, fleetErr := GetFleetAgentAffinity(tt.cluster)
+
+			switch tt.name {
+			case "test-default":
+				// cluster agent
+				assert.Nil(t, clusterAgentAffinity)
+				assert.ErrorContains(t, clusterErr, "failed to unmarshal node affinity")
+
+				// fleet agent
+				assert.Nil(t, fleetAgentAffinity)
+				assert.ErrorContains(t, fleetErr, "failed to unmarshal node affinity")
+			case "test-agent-customization":
+				// cluster agent
+				assert.Equal(t, testClusterAgentAffinity, clusterAgentAffinity)
+				assert.Nil(t, clusterErr)
+
+				// fleet agent
+				assert.Equal(t, testFleetAgentAffinity, fleetAgentAffinity)
+				assert.Nil(t, fleetErr)
+			}
+		})
+	}
+}

--- a/pkg/controllers/management/clusterdeploy/clusterdeploy_test.go
+++ b/pkg/controllers/management/clusterdeploy/clusterdeploy_test.go
@@ -1,0 +1,100 @@
+package clusterdeploy
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestClusterDeploy_redeployAgent(t *testing.T) {
+	testClusterAgentToleration := []corev1.Toleration{{
+		Effect: "NoSchedule",
+		Key:    "node-role.kubernetes.io/controlplane-test",
+		Value:  "true",
+	},
+	}
+	testUpdatedClusterAgentToleration := []corev1.Toleration{{
+		Effect: "NoSchedule",
+		Key:    "node-role.kubernetes.io/controlplane-test",
+		Value:  "true",
+	}, {
+		Effect: "NoSchedule",
+		Key:    "node-role.kubernetes.io/etcd-test",
+		Value:  "true",
+	},
+	}
+
+	tests := []struct {
+		name             string
+		cluster          *v3.Cluster
+		expectedRedeploy bool
+	}{
+		{
+			name: "test-default",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-default",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{},
+				},
+				Status: v3.ClusterStatus{
+					AppliedAgentEnvVars: settings.DefaultAgentSettingsAsEnvVars(),
+				},
+			},
+			expectedRedeploy: false,
+		},
+		{
+			name: "test-add-cluster-agent-customization",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-add-cluster-agent-customization",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{},
+				},
+				Status: v3.ClusterStatus{
+					AppliedClusterAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+						AppendTolerations: testClusterAgentToleration,
+					},
+				},
+			},
+			expectedRedeploy: true,
+		},
+		{
+			name: "test-update-cluster-agent-customization",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-default",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						ClusterAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+							AppendTolerations: testClusterAgentToleration,
+						},
+					},
+				},
+				Status: v3.ClusterStatus{
+					AppliedClusterAgentDeploymentCustomization: &v3.AgentDeploymentCustomization{
+						AppendTolerations: testUpdatedClusterAgentToleration,
+					},
+				},
+			},
+			expectedRedeploy: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v3.ClusterConditionAgentDeployed.Message(tt.cluster, "Successfully rolled out agent")
+			v3.ClusterConditionAgentDeployed.True(tt.cluster)
+
+			doRedeploy := redeployAgent(tt.cluster, "", "", nil, nil)
+			assert.Equal(t, tt.expectedRedeploy, doRedeploy)
+		})
+	}
+}

--- a/pkg/controllers/provisioningv2/cluster/controller_test.go
+++ b/pkg/controllers/provisioningv2/cluster/controller_test.go
@@ -1,9 +1,18 @@
 package cluster
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func TestRegexp(t *testing.T) {
@@ -14,4 +23,248 @@ func TestRegexp(t *testing.T) {
 	assert.False(t, mgmtNameRegexp.MatchString("ac-12345"))
 	assert.False(t, mgmtNameRegexp.MatchString("c-12345b"))
 	assert.False(t, mgmtNameRegexp.MatchString("ac-12345b"))
+}
+
+func TestController_generateProvisioningClusterFromLegacyCluster(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *v3.Cluster
+	}{
+		{
+			name: "test-default",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-11111",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase:    v3.ClusterSpecBase{},
+					FleetWorkspaceName: "test-fleet-workspace-name",
+				},
+			},
+		},
+		{
+			name: "test-cluster-agent-customization",
+			cluster: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c-22222",
+				},
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						ClusterAgentDeploymentCustomization: getTestClusterAgentCustomizationV3(),
+						FleetAgentDeploymentCustomization:   getTestFleetAgentCustomizationV3(),
+					},
+					FleetWorkspaceName: "test-fleet-workspace-name",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := handler{}
+
+			obj, _, err := h.generateProvisioningClusterFromLegacyCluster(tt.cluster, tt.cluster.Status)
+
+			assert.Nil(t, err)
+			assert.NotNil(t, obj, "Expected non-nil prov cluster obj")
+			provCluster := obj[0].(*v1.Cluster)
+
+			switch tt.name {
+			case "test-default":
+				assert.Nil(t, provCluster.Spec.ClusterAgentDeploymentCustomization)
+				assert.Nil(t, provCluster.Spec.FleetAgentDeploymentCustomization)
+			case "test-cluster-agent-customization":
+				assert.Equal(t, getTestClusterAgentCustomizationV1(), provCluster.Spec.ClusterAgentDeploymentCustomization)
+				assert.Equal(t, getTestFleetAgentCustomizationV1(), provCluster.Spec.FleetAgentDeploymentCustomization)
+			}
+		})
+	}
+}
+
+func TestController_createNewCluster(t *testing.T) {
+	tests := []struct {
+		name        string
+		cluster     *v1.Cluster
+		clusterSpec v3.ClusterSpec
+	}{
+		{
+			name: "test-default",
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       v1.ClusterSpec{},
+			},
+			clusterSpec: v3.ClusterSpec{},
+		},
+		{
+			name: "test-cluster-agent-customization",
+			cluster: &v1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: v1.ClusterSpec{
+					ClusterAgentDeploymentCustomization: getTestClusterAgentCustomizationV1(),
+					FleetAgentDeploymentCustomization:   getTestFleetAgentCustomizationV1(),
+				},
+			},
+			clusterSpec: v3.ClusterSpec{
+				ClusterSpecBase: v3.ClusterSpecBase{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := handler{
+				mgmtClusterCache: &mockClusterCache{
+					clusters: map[string]*v3.Cluster{}},
+			}
+
+			obj, _, err := h.createNewCluster(tt.cluster, tt.cluster.Status, tt.clusterSpec)
+
+			assert.Nil(t, err)
+			assert.NotNil(t, obj, "Expected non-nil v3 cluster obj")
+			jsonData, _ := json.Marshal(obj[0])
+			var legacyCluster v3.Cluster
+			json.Unmarshal(jsonData, &legacyCluster)
+
+			switch tt.name {
+			case "test-default":
+				assert.Nil(t, legacyCluster.Spec.ClusterAgentDeploymentCustomization)
+				assert.Nil(t, legacyCluster.Spec.FleetAgentDeploymentCustomization)
+			case "test-cluster-agent-customization":
+				assert.Equal(t, getTestClusterAgentCustomizationV3(), legacyCluster.Spec.ClusterAgentDeploymentCustomization)
+				assert.Equal(t, getTestFleetAgentCustomizationV3(), legacyCluster.Spec.FleetAgentDeploymentCustomization)
+			}
+		})
+	}
+}
+
+func getTestClusterAgentCustomizationV1() *v1.AgentDeploymentCustomization {
+	return &v1.AgentDeploymentCustomization{
+		AppendTolerations:            getTestClusterAgentToleration(),
+		OverrideAffinity:             getTestClusterAgentAffinity(),
+		OverrideResourceRequirements: getTestClusterAgentResourceReq(),
+	}
+}
+
+func getTestClusterAgentCustomizationV3() *v3.AgentDeploymentCustomization {
+	return &v3.AgentDeploymentCustomization{
+		AppendTolerations:            getTestClusterAgentToleration(),
+		OverrideAffinity:             getTestClusterAgentAffinity(),
+		OverrideResourceRequirements: getTestClusterAgentResourceReq(),
+	}
+}
+
+func getTestFleetAgentCustomizationV1() *v1.AgentDeploymentCustomization {
+	return &v1.AgentDeploymentCustomization{
+		AppendTolerations:            getTestFleetAgentToleration(),
+		OverrideAffinity:             getTestFleetAgentAffinity(),
+		OverrideResourceRequirements: getTestFleetAgentResourceReq(),
+	}
+}
+
+func getTestFleetAgentCustomizationV3() *v3.AgentDeploymentCustomization {
+	return &v3.AgentDeploymentCustomization{
+		AppendTolerations:            getTestFleetAgentToleration(),
+		OverrideAffinity:             getTestFleetAgentAffinity(),
+		OverrideResourceRequirements: getTestFleetAgentResourceReq(),
+	}
+}
+
+func getTestClusterAgentToleration() []corev1.Toleration {
+	return []corev1.Toleration{{
+		Effect: "NoSchedule",
+		Key:    "node-role.kubernetes.io/controlplane-test",
+		Value:  "true",
+	},
+	}
+}
+
+func getTestClusterAgentAffinity() *corev1.Affinity {
+	return &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				{
+					Weight: 1,
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "cattle.io/cluster-agent-test",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getTestClusterAgentResourceReq() *corev1.ResourceRequirements {
+	return &corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("500m"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("250Mi"),
+		},
+	}
+}
+
+func getTestFleetAgentToleration() []corev1.Toleration {
+	return []corev1.Toleration{
+		{
+			Key:      "key",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "value",
+		},
+	}
+}
+
+func getTestFleetAgentAffinity() *corev1.Affinity {
+	return &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				{
+					Weight: 1,
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "fleet.cattle.io/agent",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"true"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getTestFleetAgentResourceReq() *corev1.ResourceRequirements {
+	return &corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("1"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+	}
+}
+
+// implements v3.ClusterCache
+type mockClusterCache struct {
+	clusters map[string]*v3.Cluster
+}
+
+func (f *mockClusterCache) Get(name string) (*v3.Cluster, error) {
+	return &v3.Cluster{}, nil
+}
+
+func (f *mockClusterCache) List(selector labels.Selector) ([]*v3.Cluster, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+func (f *mockClusterCache) AddIndexer(indexName string, indexer mgmtv3.ClusterIndexer) {}
+func (f *mockClusterCache) GetByIndex(indexName, key string) ([]*v3.Cluster, error) {
+	return nil, fmt.Errorf("unimplemented")
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/41035
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
Add unit tests for backend cluster agent customization functionality.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Added unit tests based on this design plan, approved by Hostbusters and QA

Updated test plan

- [x] Test agent_customization to get cluster agent and fleet fields
	- [x] Default: returns nil tolerations, default `default-cluster-agent-affinity` from settings, and nil rr
	- [x] Custom: returns appended tolerations, override affinity, and override rr
	- [x] Custom `default-cluster-agent-affinity`: returns custom set affinity, err if can't be unmarshaled
	- [x] Custom `default-fleet-agent-affinity`: returns custom set affinity, err if can't be unmarshaled
- [x] Test cluster deploy controller `redeployAgent`
	- [x] agent customization not set/updated: returns false
	- [x] agent customization updated: returns true!
- [x] Test v2 prov controller `generateProvisioningClusterFromLegacyCluster` + `createNewCluster`
	- [x] Default: returns `newCluster` with agent customization set to nil
	- [x] Custom: returns `newCluster` with agentCustomization set

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

I verified all tests pass by running the ones I added via,

```
go test ./pkg/cluster ./pkg/controllers/management/clusterdeploy ./pkg/controllers/provisioningv2/cluster
```

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->