### PR TITLE
Fleet chart from bundled

### DIFF
--- a/pkg/catalogv2/git/download.go
+++ b/pkg/catalogv2/git/download.go
@@ -18,12 +18,17 @@ import (
 const (
 	stateDir  = "management-state/git-repo"
 	staticDir = "/var/lib/rancher-data/local-catalogs/v2"
+	localDir  = "../rancher-data/local-catalogs/v2" // identical to helm.InternalCatalog
 )
 
 func gitDir(namespace, name, gitURL string) string {
 	staticDir := filepath.Join(staticDir, namespace, name, hash(gitURL))
 	if s, err := os.Stat(staticDir); err == nil && s.IsDir() {
 		return staticDir
+	}
+	localDir := filepath.Join(localDir, namespace, name, hash(gitURL))
+	if s, err := os.Stat(localDir); err == nil && s.IsDir() {
+		return localDir
 	}
 	return filepath.Join(stateDir, namespace, name, hash(gitURL))
 }
@@ -67,7 +72,7 @@ func Ensure(secret *corev1.Secret, namespace, name, gitURL, commit string, insec
 }
 
 func isBundled(git *git) bool {
-	return strings.HasPrefix(git.Directory, staticDir)
+	return strings.HasPrefix(git.Directory, staticDir) || strings.HasPrefix(git.Directory, localDir)
 }
 
 func gitForRepo(secret *corev1.Secret, namespace, name, gitURL string, insecureSkipTLS bool, caBundle []byte) (*git, error) {

--- a/pkg/catalogv2/git/download_test.go
+++ b/pkg/catalogv2/git/download_test.go
@@ -35,3 +35,23 @@ func Test_isGitSSH(t *testing.T) {
 		assert.Equalf(tc.expected, actual, "testcase: %v", tc)
 	}
 }
+
+func Test_gitDir(t *testing.T) {
+	assert := assertlib.New(t)
+	testCases := []struct {
+		namespace string
+		name      string
+		gitURL    string
+		expected  string
+	}{
+		{
+			"namespace", "name", "https://git.rancher.io/charts",
+			"management-state/git-repo/namespace/name/4b40cac650031b74776e87c1a726b0484d0877c3ec137da0872547ff9b73a721",
+		},
+		// NOTE(manno): cannot test the other cases without poluting the filesystem
+	}
+	for _, tc := range testCases {
+		actual := gitDir(tc.namespace, tc.name, tc.gitURL)
+		assert.Equalf(tc.expected, actual, "testcase: %v", tc)
+	}
+}

--- a/pkg/data/dashboard/repo.go
+++ b/pkg/data/dashboard/repo.go
@@ -38,6 +38,7 @@ func addRepo(wrangler *wrangler.Context, repoName, branchName string) error {
 	return err
 }
 
+// addRepos upserts the rancher-charts, rancher-partner-charts and rancher-rke2-charts ClusterRepos
 func addRepos(ctx context.Context, wrangler *wrangler.Context) error {
 	if err := addRepo(wrangler, "rancher-charts", settings.ChartDefaultBranch.Get()); err != nil {
 		return err

--- a/pkg/data/management/catalog_data.go
+++ b/pkg/data/management/catalog_data.go
@@ -143,7 +143,7 @@ func syncCatalogs(management *config.ManagementContext) error {
 			}
 			return doAddCatalogs(management, helm3LibraryName, helm3LibraryURL, helm3LibraryBranch, helm3HelmVersion, bundledMode)
 		},
-		// add rancher-charts
+		// add system-charts
 		func() error {
 			if err := doAddCatalogs(management, systemLibraryName, systemLibraryURL, systemLibraryBranch, "", bundledMode); err != nil {
 				return err


### PR DESCRIPTION
## Problem

We need to test Fleet inside of Rancher. Eventually, we want to be able to do that nightly or in PRs.
Fleet is installed and maintained by controllers in Rancher. That makes it impossible to compile and test Fleet, without branching the rancher-charts repo and publishing it. 

Furthermore, manual testing showed that Rancher will `git reset` and update the bundled repos in the container image, if it has internet. That is a strange behavior for air gap mode and should not happen in the bundled folders (`/var/lib`) at all. It does make sense if the user changed the repo via settings, but then the folder is not in `/var/lib`.
Having the bundled repos reset, might bring back another version of fleet, which Rancher will then deploy instead of the version that should be tested. 
 
## Solution

* Add a local folder that can contain charts, just like in [management v3](https://github.com/rancher/rancher/blob/c349805abca0ba09f5056daeae3bf49da87590ce/pkg/helm/helm.go#L46)
* don't run Ensure on the local folders
