### PR TITLE
Safely concatenate long namespace and binding name for CRTBs and PRTBs

### DIFF
--- a/cleanup/binding-clean.yaml
+++ b/cleanup/binding-clean.yaml
@@ -73,6 +73,7 @@ rules:
     resources:
       - rolebindings
       - clusterrolebindings
+      - roles
     verbs:
       - list
       - get

--- a/pkg/agent/clean/orphan_bindings.go
+++ b/pkg/agent/clean/orphan_bindings.go
@@ -11,14 +11,13 @@ package clean
 import (
 	"context"
 	"os"
-	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/rancher/rancher/pkg/controllers/management/auth"
 	mgmt "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io"
 	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
-	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/rancher/pkg/namespace"
+	rbaccommon "github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/wrangler/pkg/generated/controllers/core"
 	corev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/generated/controllers/rbac"
@@ -27,9 +26,10 @@ import (
 	"github.com/rancher/wrangler/pkg/start"
 	"github.com/sirupsen/logrus"
 	k8srbacv1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -42,22 +42,23 @@ type orphanBindingsCleanup struct {
 	namespaces   corev1.NamespaceController
 	crtbs        v3.ClusterRoleTemplateBindingClient
 	prtbs        v3.ProjectRoleTemplateBindingClient
+	prtbHashes   map[string]struct{}
 	prtbUIDs     map[string]struct{}
 	roleBindings v1.RoleBindingClient
 	roles        v1.RoleClient
 }
 
-func OrphanBindings(clientConfig *restclient.Config) error {
+func OrphanBindings(clientConfig *rest.Config) error {
 	bc, err := newOrphanBindingsCleanup(clientConfig)
 	if err != nil {
 		return err
 	}
 
 	logrus.Infof("[%v] cleaning up orphaned bindings", orphanBindingsOperation)
-	return bc.cleanOrphans()
+	return bc.cleanOrphans(dryRun)
 }
 
-func OrphanCatalogBindings(clientConfig *restclient.Config) error {
+func OrphanCatalogBindings(clientConfig *rest.Config) error {
 	bc, err := newOrphanBindingsCleanup(clientConfig)
 	if err != nil {
 		return err
@@ -66,16 +67,16 @@ func OrphanCatalogBindings(clientConfig *restclient.Config) error {
 	return bc.cleanOrphanedCatalogRolesAndRolebindings()
 }
 
-func newOrphanBindingsCleanup(clientConfig *restclient.Config) (*orphanBindingsCleanup, error) {
+func newOrphanBindingsCleanup(restConfig *rest.Config) (*orphanBindingsCleanup, error) {
 	if os.Getenv("DRY_RUN") == "true" {
 		logrus.Infof("[%v] DRY_RUN is true, no objects will be deleted/modified", orphanBindingsOperation)
 		dryRun = true
 	}
 
-	var config *restclient.Config
+	var config *rest.Config
 	var err error
-	if clientConfig != nil {
-		config = clientConfig
+	if restConfig != nil {
+		config = restConfig
 	} else {
 		config, err = clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
 		if err != nil {
@@ -109,6 +110,7 @@ func newOrphanBindingsCleanup(clientConfig *restclient.Config) (*orphanBindingsC
 		namespaces:   k8score.Core().V1().Namespace(),
 		prtbs:        rancherManagement.Management().V3().ProjectRoleTemplateBinding(),
 		prtbUIDs:     make(map[string]struct{}),
+		prtbHashes:   make(map[string]struct{}),
 		roleBindings: k8srbac.Rbac().V1().RoleBinding(),
 		roles:        k8srbac.Rbac().V1().Role(),
 	}
@@ -116,17 +118,24 @@ func newOrphanBindingsCleanup(clientConfig *restclient.Config) (*orphanBindingsC
 }
 
 // cleanOrphans finds and deletes orphaned bindings
-func (bc *orphanBindingsCleanup) cleanOrphans() error {
-	logrus.Infof("[%v] checking for orphaned rolebindings", orphanBindingsOperation)
-
-	// build the prtb uid map for checking existence of rb owner in legacy label case
+func (bc *orphanBindingsCleanup) cleanOrphans(dryRun bool) error {
 	prtbs, err := bc.prtbs.List("", metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
-	for _, prtb := range prtbs.Items {
-		bc.prtbUIDs[string(prtb.UID)] = struct{}{}
+	for i := range prtbs.Items {
+		prtb := prtbs.Items[i]
+		// Build a set of hashed (shortened) PRTB names (that include namespace).
+		if hash := rbaccommon.GetRTBLabel(prtb.ObjectMeta); hash != "" {
+			bc.prtbHashes[hash] = struct{}{}
+		}
+		// Build a PRTB UID set for checking for existence of role binding owner in legacy label case.
+		if uid := string(prtb.UID); uid != "" {
+			bc.prtbUIDs[uid] = struct{}{}
+		}
 	}
+
+	logrus.Infof("[%v] checking for orphaned rolebindings", orphanBindingsOperation)
 
 	// check all rolebindings against orphan criteria
 	rbs, err := bc.roleBindings.List("", metav1.ListOptions{})
@@ -136,11 +145,7 @@ func (bc *orphanBindingsCleanup) cleanOrphans() error {
 
 	var returnErr error
 	for _, rb := range rbs.Items {
-		isOrphan, err := bc.isOrphanBinding(rb)
-		if err != nil {
-			returnErr = multierror.Append(returnErr, err)
-		}
-		if isOrphan {
+		if bc.isOrphanBinding(&rb) {
 			logrus.Infof("[%v] found orphaned binding: %s/%s", orphanBindingsOperation, rb.Namespace, rb.Name)
 			if dryRun {
 				logrus.Infof("[%v] dryRun is enabled, skipping deletion for orphaned binding: %s/%s", orphanBindingsOperation, rb.Namespace, rb.Name)
@@ -157,58 +162,35 @@ func (bc *orphanBindingsCleanup) cleanOrphans() error {
 	return returnErr
 }
 
-// isOrphanBinding detects whether or not rb is an orphaned binding. Only bindings with a Group subject may be orphans.
+// isOrphanBinding detects whether a role binding is orphaned. Only bindings with a Group subject may be orphans.
 // To detect orphans, we look at labels with value == PrtbInClusterBindingOwner. If the key for this label is a UID,
 // then it is considered to be legacy as the format for the key on this label was changed with 2.5. If the label's key is of the
 // form <ns>_<prtb-name> then label is considered to be new (post 2.5.0). If we find a binding with a legacy label and not a new label, we check if there is an
 // existing prtb with that uid. If there is not, then the binding is an orphan. If a new label exists on the binding, then we check if the parent
 // prtb exists. If it does not exist, the binding is an orphan.
-func (bc *orphanBindingsCleanup) isOrphanBinding(rb rbacv1.RoleBinding) (bool, error) {
+func (bc *orphanBindingsCleanup) isOrphanBinding(rb *rbacv1.RoleBinding) bool {
+	if rb == nil {
+		return false
+	}
 	var hasGroupSubject bool
 	if len(rb.Subjects) == 1 && rb.Subjects[0].Kind == k8srbacv1.GroupKind {
 		hasGroupSubject = true
 	}
 	if !hasGroupSubject {
-		return false, nil
+		return false
 	}
 
-	var prtbNs, prtbName, uid string
-	var foundLabel, hasNewLabel bool
+	var isOrphan bool
 	for k, v := range rb.Labels {
 		if v != auth.PrtbInClusterBindingOwner {
 			continue
 		}
-		foundLabel = true
-		if strings.Contains(k, "_") { // only new label will have '_'
-			hasNewLabel = true
-			pieces := strings.Split(k, "_")
-			prtbNs, prtbName = pieces[0], pieces[1]
-		} else {
-			uid = k
-		}
+		_, isHashLabel := bc.prtbHashes[k]
+		_, isUIDLabel := bc.prtbUIDs[k]
+		// If the binding isn't related to a current label by UID or hash, it is orphaned.
+		isOrphan = !isHashLabel && !isUIDLabel
 	}
-
-	// if there are no matching labels, we don't need to consider this binding
-	if !foundLabel {
-		return false, nil
-	}
-
-	if hasNewLabel {
-		_, err := bc.prtbs.Get(prtbNs, prtbName, metav1.GetOptions{})
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				return true, nil
-			}
-		}
-		return false, err
-	}
-
-	// label is found but is not new, so it must be the legacy label
-	if _, ok := bc.prtbUIDs[uid]; !ok {
-		return true, nil // no prtb with the uid exists, so binding is orphaned
-	}
-
-	return false, nil // we have a prtb with this uid, so the binding is not an orphan
+	return isOrphan
 }
 
 // Removes a specific role and bindings to that role, which are no longer valid, from the cattle-global-data namespace
@@ -239,7 +221,7 @@ func (bc *orphanBindingsCleanup) cleanOrphanedCatalogRolesAndRolebindings() erro
 	} else {
 		logrus.Infof("[%v] Deleting orphaned role %s", orphanCatalogBindingsOperation, auth.GlobalCatalogRole)
 		err = bc.roles.Delete(namespace.GlobalNamespace, auth.GlobalCatalogRole, &metav1.DeleteOptions{})
-		if err != nil {
+		if err != nil && !k8serrors.IsNotFound(err) {
 			logrus.Warnf("[%v] Error when deleting role %s, %s", orphanCatalogBindingsOperation, auth.GlobalCatalogRole, err.Error())
 			return err
 		}

--- a/pkg/agent/clean/orphan_bindings_test.go
+++ b/pkg/agent/clean/orphan_bindings_test.go
@@ -1,0 +1,522 @@
+package clean
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/controllers/management/auth"
+	"github.com/rancher/wrangler/pkg/generic"
+	v1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+func TestCleanOrphans(t *testing.T) {
+	t.Parallel()
+	groupSubjects := []v1.Subject{
+		{
+			Kind: v1.GroupKind,
+			Name: "Dogs",
+		},
+	}
+	orphanBindingWithBadOldLabel := v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "orphan binding with nonexistent old-style PRTB label",
+			Labels: map[string]string{
+				"ns1-non-existent-uid": auth.PrtbInClusterBindingOwner,
+			},
+		},
+		Subjects: groupSubjects,
+	}
+	orphanBindingWithBadNewLabel := v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "orphan binding with nonexistent new-style PRTB label",
+			Labels: map[string]string{
+				"unknown_unknown": auth.PrtbInClusterBindingOwner,
+			},
+		},
+		Subjects: groupSubjects,
+	}
+	orphanBindingWithHashedLabel := v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "orphan binding with a new-style PRTB label that has a hash",
+			Labels: map[string]string{
+				"aaaaaaaaaa_whalewhalewhalewhalewhalewhalewhalewhalewhalew-4076a": auth.PrtbInClusterBindingOwner,
+			},
+		},
+		Subjects: groupSubjects,
+	}
+	orphanBindingWithStrangeLabel := v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "orphan binding with a new-style PRTB label that has a long namespace name",
+			Labels: map[string]string{
+				"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-8k9i4": auth.PrtbInClusterBindingOwner,
+			},
+		},
+		Subjects: groupSubjects,
+	}
+	nonOrphanBindingUnrelatedToPRTB := v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "non-orphan binding that is unrelated to any project role template bindings",
+			Labels: map[string]string{
+				"default-8k9i4": "hello",
+			},
+		},
+		Subjects: groupSubjects,
+	}
+	nonOrphanBindingWithStrangeLabel := v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "non-orphan binding with a new-style PRTB label that has a long namespace name",
+			Labels: map[string]string{
+				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-37a42": auth.PrtbInClusterBindingOwner,
+			},
+		},
+		Subjects: groupSubjects,
+	}
+	nonOrphanBindingWithSimpleLabel := v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "non-orphan binding with hashed simple label",
+			Labels: map[string]string{
+				"default_foo": auth.PrtbInClusterBindingOwner,
+			},
+		},
+		Subjects: groupSubjects,
+	}
+	nonOrphanBindingWithHashedLabel := v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "non-orphan binding with hashed label",
+			Labels: map[string]string{
+				"p-kmc2v_grouplonglonglonglonglonglonglonglonglonglonglong-a59f5": auth.PrtbInClusterBindingOwner,
+			},
+		},
+		Subjects: groupSubjects,
+	}
+	nonOrphanBindingWithUIDLabel := v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "non-orphan binding with UID label",
+			Labels: map[string]string{
+				"c8bcebc8-779d-4fe7-a367-aa80897fc7b1": auth.PrtbInClusterBindingOwner,
+			},
+		},
+		Subjects: groupSubjects,
+	}
+	nonOrphanUserBinding := v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "non-orphan user binding",
+			Labels: map[string]string{
+				"ns1-non-existent-prtb": auth.PrtbInClusterBindingOwner,
+			},
+		},
+		Subjects: []v1.Subject{
+			{
+				Kind: v1.UserKind,
+				Name: "Bob",
+			},
+		},
+	}
+	allBindings := []v1.RoleBinding{
+		orphanBindingWithBadOldLabel,
+		orphanBindingWithBadNewLabel,
+		orphanBindingWithStrangeLabel,
+		orphanBindingWithHashedLabel,
+		nonOrphanBindingUnrelatedToPRTB,
+		nonOrphanBindingWithStrangeLabel,
+		nonOrphanBindingWithSimpleLabel,
+		nonOrphanBindingWithHashedLabel,
+		nonOrphanBindingWithUIDLabel,
+		nonOrphanUserBinding,
+	}
+
+	tests := []struct {
+		name         string
+		client       *orphanBindingsCleanup
+		remainingRBs []v1.RoleBinding
+		dryRun       bool
+		wantErr      bool
+	}{
+		{
+			name:         "dry run with no bindings deleted",
+			dryRun:       true,
+			client:       newStandardClient(allBindings),
+			remainingRBs: allBindings,
+		},
+		{
+			name:   "some bindings deleted",
+			dryRun: false,
+			client: newStandardClient(allBindings),
+			remainingRBs: []v1.RoleBinding{
+				nonOrphanBindingUnrelatedToPRTB,
+				nonOrphanBindingWithStrangeLabel,
+				nonOrphanBindingWithSimpleLabel,
+				nonOrphanBindingWithHashedLabel,
+				nonOrphanBindingWithUIDLabel,
+				nonOrphanUserBinding,
+			},
+		},
+		{
+			name:    "failed to list project role template bindings",
+			wantErr: true,
+			client: &orphanBindingsCleanup{
+				prtbs: &fakePRTBClient{
+					bindings: []v3.ProjectRoleTemplateBinding{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "bad",
+							},
+						},
+					},
+				},
+				roleBindings: &fakeRoleBindingClient{
+					bindings: allBindings,
+				},
+				prtbHashes: make(map[string]struct{}),
+				prtbUIDs:   make(map[string]struct{}),
+			},
+		},
+		{
+			name:    "failed to list role bindings",
+			wantErr: true,
+			client: &orphanBindingsCleanup{
+				prtbs: &fakePRTBClient{
+					bindings: []v3.ProjectRoleTemplateBinding{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "hello",
+							},
+						},
+					},
+				},
+				roleBindings: &fakeRoleBindingClient{
+					bindings: []v1.RoleBinding{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "bad",
+							},
+						},
+					},
+				},
+				prtbHashes: make(map[string]struct{}),
+				prtbUIDs:   make(map[string]struct{}),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := test.client.cleanOrphans(test.dryRun)
+			if test.wantErr && err == nil {
+				t.Error("expected an error, but didn't get it", err)
+				return
+			}
+			if !test.wantErr && err != nil {
+				t.Errorf("got an unexpected error: %v", err)
+				return
+			}
+			if !test.wantErr {
+				current, _ := test.client.roleBindings.List("", metav1.ListOptions{})
+				if !reflect.DeepEqual(current.Items, test.remainingRBs) {
+					t.Errorf("\nexpected:\n%s\ngot:\n%s",
+						strings.Join(getRoleBindingsNames(test.remainingRBs), "\n"),
+						strings.Join(getRoleBindingsNames(current.Items), "\n"))
+				}
+			}
+		})
+	}
+}
+
+func newStandardClient(roleBindings []v1.RoleBinding) *orphanBindingsCleanup {
+	// Copy the role bindings to avoid unwanted concurrent modification. The slice is shared by multiple fake clients.
+	rbs := make([]v1.RoleBinding, len(roleBindings))
+	for i := range roleBindings {
+		rbs[i] = roleBindings[i]
+	}
+	return &orphanBindingsCleanup{
+		prtbs: &fakePRTBClient{bindings: []v3.ProjectRoleTemplateBinding{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					UID:       "c8bcebc8-779d-4fe7-a367-aa80897fc7b1",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grouplonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong",
+					Namespace: "p-kmc2v",
+					UID:       "abc123",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "whale",
+					Namespace: strings.Repeat("a", 63),
+				},
+			},
+		}},
+		prtbHashes: make(map[string]struct{}),
+		prtbUIDs:   make(map[string]struct{}),
+		roleBindings: &fakeRoleBindingClient{
+			bindings: rbs,
+		},
+	}
+}
+
+func TestIsOrphanBinding(t *testing.T) {
+	t.Parallel()
+	groupSubjects := []v1.Subject{
+		{
+			Kind: v1.GroupKind,
+			Name: "Dogs",
+		},
+	}
+	client := orphanBindingsCleanup{
+		prtbHashes: map[string]struct{}{
+			"p-kmc2v_grouplonglonglonglonglonglonglonglonglonglonglong-a59f5": {},
+			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-4c6e1": {},
+			"p-kmc2v_c-123xyz": {},
+		},
+		prtbUIDs: map[string]struct{}{
+			"c8bcebc8-779d-4fe7-a367-aa80897fc7b1": {},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		binding  *v1.RoleBinding
+		isOrphan bool
+	}{
+		{
+			name:     "nil binding",
+			binding:  nil,
+			isOrphan: false,
+		},
+		{
+			name:     "no subjects",
+			binding:  &v1.RoleBinding{},
+			isOrphan: false,
+		},
+		{
+			name: "no group subjects",
+			binding: &v1.RoleBinding{
+				Subjects: []v1.Subject{
+					{
+						Kind: v1.UserKind,
+						Name: "Pug",
+					},
+				},
+			},
+			isOrphan: false,
+		},
+		{
+			name: "no matching new label or uid",
+			binding: &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"hello": "world",
+					},
+				},
+				Subjects: groupSubjects,
+			},
+			isOrphan: false,
+		},
+		{
+			name: "matching new label",
+			binding: &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"p-kmc2v_c-123xyz": auth.PrtbInClusterBindingOwner,
+					},
+				},
+				Subjects: groupSubjects,
+			},
+			isOrphan: false,
+		},
+		{
+			name: "matching new label with hash",
+			binding: &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"p-kmc2v_grouplonglonglonglonglonglonglonglonglonglonglong-a59f5": auth.PrtbInClusterBindingOwner,
+					},
+				},
+				Subjects: groupSubjects,
+			},
+			isOrphan: false,
+		},
+		{
+			name: "matching uid",
+			binding: &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"c8bcebc8-779d-4fe7-a367-aa80897fc7b1": auth.PrtbInClusterBindingOwner,
+					},
+				},
+				Subjects: groupSubjects,
+			},
+			isOrphan: false,
+		},
+		{
+			name: "matching new label but missing prtb",
+			binding: &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"ns1_missing1": auth.PrtbInClusterBindingOwner,
+					},
+				},
+				Subjects: groupSubjects,
+			},
+			isOrphan: true,
+		},
+		{
+			name: "matching uid but it is unknown",
+			binding: &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"uid-unknown": auth.PrtbInClusterBindingOwner,
+					},
+				},
+				Subjects: groupSubjects,
+			},
+			isOrphan: true,
+		},
+		{
+			name: "known binding with a very long namespace name",
+			binding: &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-4c6e1": auth.PrtbInClusterBindingOwner,
+					},
+				},
+				Subjects: groupSubjects,
+			},
+			isOrphan: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			isOrphan := client.isOrphanBinding(test.binding)
+			if isOrphan != test.isOrphan {
+				t.Errorf("expected isOrphan to be %v, but got %v", test.isOrphan, isOrphan)
+			}
+		})
+	}
+}
+
+type fakeRoleBindingClient struct {
+	bindings []v1.RoleBinding
+}
+
+func (c *fakeRoleBindingClient) List(_ string, _ metav1.ListOptions) (*v1.RoleBindingList, error) {
+	var lst v1.RoleBindingList
+	// Build a new collection to prevent deletion of items during iteration later.
+	for i := range c.bindings {
+		if c.bindings[i].Name == "bad" {
+			return nil, errors.New("failed to list role bindings")
+		}
+		lst.Items = append(lst.Items, c.bindings[i])
+	}
+	return &lst, nil
+}
+
+func (c *fakeRoleBindingClient) Delete(_, name string, _ *metav1.DeleteOptions) error {
+	for i, v := range c.bindings {
+		if v.Name == name {
+			c.bindings = append(c.bindings[:i], c.bindings[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+func (c *fakeRoleBindingClient) Create(_ *v1.RoleBinding) (*v1.RoleBinding, error) {
+	panic("implement me")
+}
+
+func (c *fakeRoleBindingClient) Update(_ *v1.RoleBinding) (*v1.RoleBinding, error) {
+	panic("implement me")
+}
+
+func (c *fakeRoleBindingClient) UpdateStatus(_ *v1.RoleBinding) (*v1.RoleBinding, error) {
+	panic("implement me")
+}
+
+func (c *fakeRoleBindingClient) Get(_, _ string, _ metav1.GetOptions) (*v1.RoleBinding, error) {
+	panic("implement me")
+}
+
+func (c *fakeRoleBindingClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
+	panic("implement me")
+}
+
+func (c *fakeRoleBindingClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *v1.RoleBinding, err error) {
+	panic("implement me")
+}
+
+func (c *fakeRoleBindingClient) WithImpersonation(_ rest.ImpersonationConfig) (generic.ClientInterface[*v1.RoleBinding, *v1.RoleBindingList], error) {
+	panic("implement me")
+}
+
+type fakePRTBClient struct {
+	bindings []v3.ProjectRoleTemplateBinding
+}
+
+func (c *fakePRTBClient) List(_ string, _ metav1.ListOptions) (*v3.ProjectRoleTemplateBindingList, error) {
+	var lst v3.ProjectRoleTemplateBindingList
+	for _, b := range c.bindings {
+		if b.Name == "bad" {
+			return nil, errors.New("failed to list PRTBs")
+		}
+		lst.Items = append(lst.Items, b)
+	}
+	return &lst, nil
+}
+
+func (c *fakePRTBClient) Create(_ *v3.ProjectRoleTemplateBinding) (*v3.ProjectRoleTemplateBinding, error) {
+	panic("implement me")
+}
+
+func (c *fakePRTBClient) Update(_ *v3.ProjectRoleTemplateBinding) (*v3.ProjectRoleTemplateBinding, error) {
+	panic("implement me")
+}
+
+func (c *fakePRTBClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
+	panic("implement me")
+}
+
+func (c *fakePRTBClient) Get(_, _ string, _ metav1.GetOptions) (*v3.ProjectRoleTemplateBinding, error) {
+	panic("implement me")
+}
+
+func (c *fakePRTBClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
+	panic("implement me")
+}
+
+func (c *fakePRTBClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *v3.ProjectRoleTemplateBinding, err error) {
+	panic("implement me")
+}
+
+func (c *fakePRTBClient) WithImpersonation(_ rest.ImpersonationConfig) (generic.ClientInterface[*v3.ProjectRoleTemplateBinding, *v3.ProjectRoleTemplateBindingList], error) {
+	panic("implement me")
+}
+
+func (c *fakePRTBClient) UpdateStatus(_ *v3.ProjectRoleTemplateBinding) (*v3.ProjectRoleTemplateBinding, error) {
+	panic("implement me")
+}
+
+func getRoleBindingsNames(bindings []v1.RoleBinding) []string {
+	names := make([]string, len(bindings))
+	for i := range bindings {
+		names[i] = bindings[i].Name
+	}
+	return names
+}

--- a/pkg/controllers/management/auth/crtb_handler.go
+++ b/pkg/controllers/management/auth/crtb_handler.go
@@ -216,7 +216,7 @@ func (c *crtbLifecycle) reconcileLabels(binding *v3.ClusterRoleTemplateBinding) 
 	}
 
 	var returnErr error
-	requirements, err := getLabelRequirements(binding.Namespace, binding.Name)
+	requirements, err := getLabelRequirements(binding.ObjectMeta)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/management/auth/manager.go
+++ b/pkg/controllers/management/auth/manager.go
@@ -903,12 +903,12 @@ func (m *manager) checkReferencedRoles(roleTemplateName, roleTemplateContext str
 	return isOwnerRole, nil
 }
 
-func getLabelRequirements(bindingNamespace, bindingName string) ([]labels.Requirement, error) {
+func getLabelRequirements(objMeta metav1.ObjectMeta) ([]labels.Requirement, error) {
 	reqUpdatedLabel, err := labels.NewRequirement(rtbLabelUpdated, selection.DoesNotExist, []string{})
 	if err != nil {
 		return []labels.Requirement{}, err
 	}
-	reqNsAndNameLabel, err := labels.NewRequirement(bindingNamespace+"_"+bindingName, selection.DoesNotExist, []string{})
+	reqNsAndNameLabel, err := labels.NewRequirement(pkgrbac.GetRTBLabel(objMeta), selection.DoesNotExist, []string{})
 	if err != nil {
 		return []labels.Requirement{}, err
 	}

--- a/pkg/controllers/management/auth/prtb_handler.go
+++ b/pkg/controllers/management/auth/prtb_handler.go
@@ -237,7 +237,7 @@ func (p *prtbLifecycle) reconcileLabels(binding *v3.ProjectRoleTemplateBinding) 
 	}
 
 	var returnErr error
-	requirements, err := getLabelRequirements(binding.Namespace, binding.Name)
+	requirements, err := getLabelRequirements(binding.ObjectMeta)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -389,7 +389,7 @@ func (p *prtbLifecycle) reconcilePRTBUserClusterLabels(binding *v3.ProjectRoleTe
 	if err != nil {
 		return err
 	}
-	reqNsAndNameLabel, err := labels.NewRequirement(binding.Namespace+"_"+binding.Name, selection.DoesNotExist, []string{})
+	reqNsAndNameLabel, err := labels.NewRequirement(pkgrbac.GetRTBLabel(binding.ObjectMeta), selection.DoesNotExist, []string{})
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/managementuser/rbac/reconcile_roletemplate.go
+++ b/pkg/controllers/managementuser/rbac/reconcile_roletemplate.go
@@ -75,7 +75,7 @@ func (m *manager) reconcileProjectAccessToGlobalResources(binding *v3.ProjectRol
 		}
 	}
 
-	rtbUID := binding.Namespace + "_" + binding.Name
+	rtbUID := pkgrbac.GetRTBLabel(binding.ObjectMeta)
 	subject, err := pkgrbac.BuildSubjectFromRTB(binding)
 	if err != nil {
 		return nil, err

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/rancher/pkg/ref"
 	k8srbacv1 "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
 	"github.com/rancher/wrangler/pkg/name"
+	wranglerName "github.com/rancher/wrangler/pkg/name"
 	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -178,7 +179,7 @@ func TypeFromContext(apiContext *types.APIContext, resource *types.RawResource) 
 }
 
 func GetRTBLabel(objMeta metav1.ObjectMeta) string {
-	return objMeta.Namespace + "_" + objMeta.Name
+	return wranglerName.SafeConcatName(objMeta.Namespace + "_" + objMeta.Name)
 }
 
 // NameForRoleBinding returns a deterministic name for a RoleBinding with the provided namespace, roleName, and subject

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -13,7 +13,6 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/ref"
 	k8srbacv1 "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
-	"github.com/rancher/wrangler/pkg/name"
 	wranglerName "github.com/rancher/wrangler/pkg/name"
 	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -265,7 +264,7 @@ func gatherRules(clusterRoles k8srbacv1.ClusterRoleCache, roleTemplates v32.Role
 }
 
 func ProvisioningClusterAdminName(cluster *provv1.Cluster) string {
-	return name.SafeConcatName("crt", cluster.Name, "cluster-owner")
+	return wranglerName.SafeConcatName("crt", cluster.Name, "cluster-owner")
 }
 
 func RuleGivesResourceAccess(rule rbacv1.PolicyRule, resourceName string) bool {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/33795
 
## Problem
When users add a new CRTB or PRTB, Rancher ensures that the various role bindings and cluster role bindings are also created in the cluster for which that CRTB or PRTB had been created.
Rancher uses the RTB name in the **label** name of the synced cluster role binding. Kubernetes does not allow label names to be longer than 63 characters.

```
kind: ClusterRoleBinding
metadata:
  labels:
    {namespace}-{very-long-rtb-name}: owner-user
```
If  the string `{namespace}-{very-long-rtb-name}` is longer than 63 characters, Kubernetes rejects the request to create the object.

Users can run into this if they create a CRTB or PRTB when bypassing Norman and specifying a long name (close to 63 characters).

## Solution
Use the [SafeConcatName](https://github.com/rancher/wrangler/blob/39a4707f0689cc97ca955f5eea5d0b37e1664cae/pkg/name/name.go#L56) function to limit the length of the resulting label name. Calls to it pass both the namespace and binding name to create the label name. Use the function in all places where Rancher tries to naively construct the label name by simply concatenating the namespace and binding name. Do the same for that same label lookup.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Created CRTBs and PRTBs with the UI. Also created some via kubectl with short and very long names. Observed that there were no recurring errors in the logs from controllers.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->