### PR TITLE
Fix bootstrap password override

### DIFF
--- a/pkg/data/management/bootstrap_password.go
+++ b/pkg/data/management/bootstrap_password.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/rancher/wrangler/pkg/randomtoken"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -16,42 +15,42 @@ const (
 	bootstrapPasswordSecretKey  = "bootstrapPassword"
 )
 
-// GetBootstrapPassword reads the bootstrap password from it's secret.  If the secret is not found
-// it will be set from `CATTLE_BOOTSTRAP_PASSWORD` or generated if this is empty as well.
+// GetBootstrapPassword queries the corresponding bootstrap-secret in the cattle-system namespace. If this secret
+// exists, and has the corresponding bootstrapPassword key, then the value of that key will be returned. Otherwise, the
+// `CATTLE_BOOTSTRAP_PASSWORD` environment variable will be checked. If neither are set, a bootstrap password is
+// generated.
 func GetBootstrapPassword(ctx context.Context, secrets corev1.SecretInterface) (string, bool, error) {
-	var s *v1.Secret
-	var err error
 	var generated bool
 
 	// load the existing secret
-	s, err = secrets.Get(ctx, bootstrapPasswordSecretName, metav1.GetOptions{})
+	secret, err := secrets.Get(ctx, bootstrapPasswordSecretName, metav1.GetOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return "", false, err
 	}
 
 	// if the bootstrap password is set return it
-	if s.StringData[bootstrapPasswordSecretKey] != "" {
-		return s.StringData[bootstrapPasswordSecretKey], generated, nil
+	if password, ok := secret.Data[bootstrapPasswordSecretKey]; ok {
+		return string(password), generated, nil
 	}
 
 	// if the password is not set check the env and fall back to generating one
-	s.StringData = make(map[string]string)
-	s.StringData[bootstrapPasswordSecretKey] = os.Getenv("CATTLE_BOOTSTRAP_PASSWORD")
-	if s.StringData[bootstrapPasswordSecretKey] == "" {
+	secret.StringData = make(map[string]string)
+	secret.StringData[bootstrapPasswordSecretKey] = os.Getenv("CATTLE_BOOTSTRAP_PASSWORD")
+	if secret.StringData[bootstrapPasswordSecretKey] == "" {
 		generated = true
-		s.StringData[bootstrapPasswordSecretKey], _ = randomtoken.Generate()
+		secret.StringData[bootstrapPasswordSecretKey], _ = randomtoken.Generate()
 	}
 
 	// persist the password
-	if s.GetResourceVersion() != "" {
-		_, err = secrets.Update(ctx, s, metav1.UpdateOptions{})
+	if secret.GetResourceVersion() != "" {
+		_, err = secrets.Update(ctx, secret, metav1.UpdateOptions{})
 	} else {
-		s.Name = bootstrapPasswordSecretName
-		_, err = secrets.Create(ctx, s, metav1.CreateOptions{})
+		secret.Name = bootstrapPasswordSecretName
+		_, err = secrets.Create(ctx, secret, metav1.CreateOptions{})
 	}
 	if err != nil {
 		return "", false, err
 	}
 
-	return s.StringData[bootstrapPasswordSecretKey], generated, nil
+	return secret.StringData[bootstrapPasswordSecretKey], generated, nil
 }

--- a/pkg/data/management/bootstrap_password_test.go
+++ b/pkg/data/management/bootstrap_password_test.go
@@ -1,0 +1,75 @@
+package management
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclient "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetBootstrapPassword(t *testing.T) {
+	tests := []struct {
+		name      string
+		secret    *corev1.Secret
+		expected  string
+		generated bool
+		expectErr bool
+	}{
+		{
+			name: "secret exists and has key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: cattleNamespace,
+					Name:      bootstrapPasswordSecretName,
+				},
+				Data: map[string][]byte{
+					bootstrapPasswordSecretKey: []byte("test"),
+				},
+			},
+			expected: "test",
+		},
+		{
+			name: "secret exists with no key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       cattleNamespace,
+					Name:            bootstrapPasswordSecretName,
+					ResourceVersion: "1",
+				},
+			},
+			generated: true,
+		},
+		{
+			name:      "secret does not exist",
+			generated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeclient := fakeclient.NewSimpleClientset(tt.secret)
+
+			password, generated, err := GetBootstrapPassword(context.TODO(), fakeclient.CoreV1().Secrets(cattleNamespace))
+
+			if tt.expectErr {
+				assert.NotNil(t, err)
+				return
+			}
+
+			assert.Nil(t, err)
+
+			assert.Equal(t, tt.generated, generated)
+
+			if !generated {
+				assert.Equal(t, tt.expected, password)
+			} else if tt.secret != nil {
+				secret, err := fakeclient.CoreV1().Secrets(cattleNamespace).Get(context.TODO(), tt.secret.Name, metav1.GetOptions{})
+				assert.Nil(t, err)
+				assert.Equal(t, password, secret.StringData[bootstrapPasswordSecretKey])
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/39576
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The bootstrap password logic was checking for the existence of the bootstrap secret, but was incorrectly reading `StringData`, which is a write only field. This was causing the bootstrap password provided in the secret to get overwritten with rancher's autogenerated bootstrap password.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Check `Data`  as opposed to `StringData`.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Create a secret in the `cattle-system` namespace named `bootstrap-secret` with the key `bootstrapPassword` and some value for that key. Observe that rancher will overwrite the value of that secret with it's own after rancher is installed (the secret must be created prior to installing the rancher chart).
- Specify a value for `bootstrapPassword` in the helm chart. Observe the same behavior as above.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

N/A

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

Added unit tests

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Personally I encountered this issue while attempting to write terraform automation for https://github.com/rancher/terraform-provider-rancher2/issues/993. It seems this has been broken for a long time now.

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Bootstrap Password generation should functionality exactly as it did before, with the caveat that user supplied passwords should not be overwritten.