### PR TITLE
[CAPR] Keep all nodes with machine noderef node value

### DIFF
--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -106,6 +106,11 @@ const (
 	RuntimeK3S  = "k3s"
 	RuntimeRKE2 = "rke2"
 
+	K3sKubectlPath     = "/usr/local/bin/kubectl"
+	K3sKubeconfigPath  = "/etc/rancher/k3s/k3s.yaml"
+	RKE2KubectlPath    = "/var/lib/rancher/rke2/bin/kubectl"
+	RKE2KubeconfigPath = "/etc/rancher/rke2/rke2.yaml"
+
 	RoleBootstrap = "bootstrap"
 	RolePlan      = "plan"
 
@@ -143,6 +148,17 @@ func GetMachineByOwner(machineCache capicontrollers.MachineCache, obj metav1.Obj
 	}
 
 	return nil, ErrNoMachineOwnerRef
+}
+
+// GetKubectlAndKubeconfigPaths returns the corresponding kubectl/kubeconfig paths for a downstream node for the given kubernetes version.
+func GetKubectlAndKubeconfigPaths(kubernetesVersion string) (string, string) {
+	switch GetRuntime(kubernetesVersion) {
+	case RuntimeK3S:
+		return K3sKubectlPath, K3sKubeconfigPath
+	case RuntimeRKE2:
+		return RKE2KubectlPath, RKE2KubeconfigPath
+	}
+	return "", ""
 }
 
 func GetRuntimeCommand(kubernetesVersion string) string {

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -129,8 +129,8 @@ while ! kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n catt
     echo "rancher-webhook was not available within 5 minutes. failing fast"
     exit 1
   fi
-  if [[ $((rwWC%60)) == 0 ]] && [[ "$rwWC" != "0" ]]; then
-    echo "rancher-webhook was not ready within $((rwWC/60)) minutes"
+  if [[ $((rwWC%30)) == 0 ]] && [[ "$rwWC" != "0" ]]; then
+    echo "rancher-webhook was not ready within $((rwWC/30)) minutes"
   fi
     sleep 2
     rwWC=$((rwWC + 1))

--- a/tests/v2prov/operations/etcdsnapshot.go
+++ b/tests/v2prov/operations/etcdsnapshot.go
@@ -106,7 +106,7 @@ func RunSnapshotCreateTest(t *testing.T, clients *clients.Clients, c *v1.Cluster
 	return snapshot
 }
 
-func RunSnapshotRestoreTest(t *testing.T, clients *clients.Clients, c *v1.Cluster, snapshotName string, expectedConfigMap corev1.ConfigMap) {
+func RunSnapshotRestoreTest(t *testing.T, clients *clients.Clients, c *v1.Cluster, snapshotName string, expectedConfigMap corev1.ConfigMap, expectedNodeCount int) {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		newC, err := clients.Provisioning.Cluster().Get(c.Namespace, c.Name, metav1.GetOptions{})
 		if err != nil {
@@ -159,4 +159,10 @@ func RunSnapshotRestoreTest(t *testing.T, clients *clients.Clients, c *v1.Cluste
 
 	assert.Equal(t, expectedConfigMap.Name, retrievedConfigMap.Name)
 	assert.Equal(t, expectedConfigMap.Data, retrievedConfigMap.Data)
+
+	allNodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, expectedNodeCount, len(allNodes.Items))
 }

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_inplace_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_inplace_test.go
@@ -69,7 +69,7 @@ func Test_Operation_Custom_EtcdSnapshotCreationRestoreInPlace(t *testing.T) {
 	}
 
 	snapshot := operations.RunSnapshotCreateTest(t, clients, c, cm, "etcd-test-node")
-	operations.RunSnapshotRestoreTest(t, clients, c, snapshot.Name, cm)
+	operations.RunSnapshotRestoreTest(t, clients, c, snapshot.Name, cm, 2)
 	err = cluster.EnsureMinimalConflictsWithThreshold(clients, c, cluster.SaneConflictMessageThreshold)
 	assert.NoError(t, err)
 }

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_combined_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_combined_test.go
@@ -121,7 +121,7 @@ func Test_Operation_Custom_EtcdSnapshotOperationsOnNewCombinedNode(t *testing.T)
 		return strings.Contains(capr.Ready.GetMessage(&rkeControlPlane.Status), "rkecontrolplane was already initialized but no etcd machines exist that have plans, indicating the etcd plane has been entirely replaced. Restoration from etcd snapshot is required."), nil
 	})
 
-	operations.RunSnapshotRestoreTest(t, clients, c, snapshot.SnapshotFile.Name, cm)
+	operations.RunSnapshotRestoreTest(t, clients, c, snapshot.SnapshotFile.Name, cm, 2)
 	err = cluster.EnsureMinimalConflictsWithThreshold(clients, c, cluster.SaneConflictMessageThreshold)
 	assert.NoError(t, err)
 }

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_test.go
@@ -121,7 +121,7 @@ func Test_Operation_Custom_EtcdSnapshotOperationsOnNewNode(t *testing.T) {
 		return strings.Contains(capr.Ready.GetMessage(&rkeControlPlane.Status), "rkecontrolplane was already initialized but no etcd machines exist that have plans, indicating the etcd plane has been entirely replaced. Restoration from etcd snapshot is required."), nil
 	})
 
-	operations.RunSnapshotRestoreTest(t, clients, c, snapshot.SnapshotFile.Name, cm)
+	operations.RunSnapshotRestoreTest(t, clients, c, snapshot.SnapshotFile.Name, cm, 2)
 	err = cluster.EnsureMinimalConflictsWithThreshold(clients, c, cluster.SaneConflictMessageThreshold)
 	assert.NoError(t, err)
 }

--- a/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_inplace_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_inplace_test.go
@@ -80,7 +80,7 @@ func Test_Operation_MP_EtcdSnapshotCreationRestoreInPlace(t *testing.T) {
 	}
 
 	snapshot := operations.RunSnapshotCreateTest(t, clients, c, cm, machines.Items[0].Status.NodeRef.Name)
-	operations.RunSnapshotRestoreTest(t, clients, c, snapshot.Name, cm)
+	operations.RunSnapshotRestoreTest(t, clients, c, snapshot.Name, cm, 2)
 	err = cluster.EnsureMinimalConflictsWithThreshold(clients, c, cluster.SaneConflictMessageThreshold)
 	assert.NoError(t, err)
 }

--- a/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_multietcd_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_multietcd_test.go
@@ -109,7 +109,7 @@ func Test_Operation_MP_EtcdSnapshotOperationsWithThreeEtcdNodesOnNewNode(t *test
 	_, err = cluster.WaitForControlPlane(clients, c, "rkecontrolplane ready condition indicating restoration required", func(rkeControlPlane *rkev1.RKEControlPlane) (bool, error) {
 		return strings.Contains(capr.Ready.GetMessage(&rkeControlPlane.Status), "rkecontrolplane was already initialized but no etcd machines exist that have plans, indicating the etcd plane has been entirely replaced. Restoration from etcd snapshot is required."), nil
 	})
-	operations.RunSnapshotRestoreTest(t, clients, c, snapshot.Name, cm)
+	operations.RunSnapshotRestoreTest(t, clients, c, snapshot.Name, cm, 3)
 	err = cluster.EnsureMinimalConflictsWithThreshold(clients, c, cluster.SaneConflictMessageThreshold)
 	assert.NoError(t, err)
 }

--- a/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_test.go
@@ -107,7 +107,7 @@ func Test_Operation_MP_EtcdSnapshotOperationsOnNewNode(t *testing.T) {
 	_, err = cluster.WaitForControlPlane(clients, c, "rkecontrolplane ready condition indicating restoration required", func(rkeControlPlane *rkev1.RKEControlPlane) (bool, error) {
 		return strings.Contains(capr.Ready.GetMessage(&rkeControlPlane.Status), "rkecontrolplane was already initialized but no etcd machines exist that have plans, indicating the etcd plane has been entirely replaced. Restoration from etcd snapshot is required."), nil
 	})
-	operations.RunSnapshotRestoreTest(t, clients, c, snapshot.Name, cm)
+	operations.RunSnapshotRestoreTest(t, clients, c, snapshot.Name, cm, 2)
 	err = cluster.EnsureMinimalConflictsWithThreshold(clients, c, cluster.SaneConflictMessageThreshold)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/41563
 
## Problem
CAPR only keeps nodes that have a matching machine UID label -- this poses problematic when dealing with a migrated Rancher and a snapshot from "before the migration", as the nodes within the snapshot will not have the correct machine ID label. While we do attempt to run the cluster, there is no guarantee that the kubelet will update its labels before we come through to prune the nodes.

## Solution
To make this operation safer, we will keep all nodes that match the machine ID label or have a corresponding machine.Status.NodeRef.Name value.

This specifically makes it possible to handle the cases where a node has not had its noderef backpopulated into Machine object, or a snapshot is from a pre-migration Rancher installation.
 
## Testing

## Engineering Testing
### Manual Testing
I ran a basic etcd snapshot creation/restore test on a different set of etcd nodes and confirmed that the script properly cleans up the old nodes from the snapshot.

### Automated Testing
I added a validation to the e2e etcd snapshot creation/restore tests that ensures that the number of nodes in the cluster matches our expected number of nodes. We have at least 1 test that ends with a different number of nodes from the start (`Test_Operation_MP_EtcdSnapshotOperationsWithThreeEtcdNodesOnNewNode`).

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->