### PR TITLE
[CAPR] Only create cluster-agent-deployment from manifest file if it does not already exist

### DIFF
--- a/pkg/api/steve/additionalapi.go
+++ b/pkg/api/steve/additionalapi.go
@@ -26,6 +26,7 @@ func AdditionalAPIsPreMCM(config *wrangler.Context) func(http.Handler) http.Hand
 		mux.Handle(configserver.ConnectAgent, connectHandler)
 		mux.Handle(configserver.ConnectConfigYamlPath, connectHandler)
 		mux.Handle(configserver.ConnectClusterInfo, connectHandler)
+		mux.Handle(configserver.ConnectClusterAgentYamlPath, connectHandler)
 		mux.Handle(installer.SystemAgentInstallPath, installer.Handler)
 		mux.Handle(installer.WindowsRke2InstallPath, installer.Handler)
 		return func(next http.Handler) http.Handler {

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -600,3 +600,30 @@ func ParseSnapshotClusterSpecOrError(snapshot *rkev1.ETCDSnapshot) (*provv1.Clus
 	}
 	return nil, fmt.Errorf("unable to find and decode snapshot ClusterSpec for snapshot")
 }
+
+// GetTaints returns a slice of taints for the machine in question
+func GetTaints(existingTaints, runtime string, isControlPlane, isEtcd, isWorker bool) (result []corev1.Taint, _ error) {
+	if existingTaints != "" {
+		if err := json.Unmarshal([]byte(existingTaints), &result); err != nil {
+			return result, err
+		}
+	}
+
+	if !isWorker {
+		// k3s charts do not have correct tolerations when the master node is both controlplane and etcd
+		if isEtcd && (runtime != RuntimeK3S || !isControlPlane) {
+			result = append(result, corev1.Taint{
+				Key:    "node-role.kubernetes.io/etcd",
+				Effect: corev1.TaintEffectNoExecute,
+			})
+		}
+		if isControlPlane {
+			result = append(result, corev1.Taint{
+				Key:    "node-role.kubernetes.io/control-plane",
+				Effect: corev1.TaintEffectNoSchedule,
+			})
+		}
+	}
+
+	return
+}

--- a/pkg/capr/configserver/agent.go
+++ b/pkg/capr/configserver/agent.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"net/http"
 	"sort"
-	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/clusterindex"
 	"github.com/rancher/rancher/pkg/settings"
@@ -18,7 +18,7 @@ import (
 
 // connectClusterAgentYAML renders a cattle-cluster-agent manifest for the given bearer token
 func (r *RKE2ConfigServer) connectClusterAgentYAML(rw http.ResponseWriter, req *http.Request) {
-	token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+	token := mux.Vars(req)["token"]
 	if token == "" {
 		http.Error(rw, "unauthorized", http.StatusUnauthorized)
 		return

--- a/pkg/capr/configserver/agent.go
+++ b/pkg/capr/configserver/agent.go
@@ -1,0 +1,118 @@
+package configserver
+
+import (
+	"bytes"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/rancher/pkg/controllers/dashboard/clusterindex"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/rancher/pkg/systemtemplate"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// connectClusterAgentYAML renders a cattle-cluster-agent manifest for the given bearer token
+func (r *RKE2ConfigServer) connectClusterAgentYAML(rw http.ResponseWriter, req *http.Request) {
+	token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+	if token == "" {
+		http.Error(rw, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	tokens, err := r.clusterTokenCache.GetByIndex(tokenIndex, token)
+	if err != nil {
+		http.Error(rw, "unauthorized", http.StatusUnauthorized)
+		logrus.Errorf("[rke2configserver] error retrieving cluster token by index: %v", err)
+		return
+	}
+
+	if len(tokens) == 0 {
+		logrus.Errorf("[rke2configserver] no tokens found in index")
+		http.Error(rw, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	mgmtCluster, err := r.mgmtClusterCache.Get(tokens[0].ObjClusterName())
+	if err != nil {
+		logrus.Errorf("[rke2configserver] error retrieving management cluster for cluster registration token: %v", err)
+		http.Error(rw, "unknown", http.StatusInternalServerError)
+		return
+	}
+
+	provisioningClusters, err := r.provisioningClusterCache.GetByIndex(clusterindex.ClusterV1ByClusterV3Reference, tokens[0].ObjClusterName())
+	if err != nil {
+		logrus.Errorf("[rke2configserver] error retrieving provisioning cluster: %v", err)
+		http.Error(rw, "unknown", http.StatusInternalServerError)
+		return
+	}
+	// ensure this is a v2prov cluster
+
+	if len(provisioningClusters) != 1 {
+		logrus.Errorf("[rke2configserver] multiple provisioning clusters found")
+		http.Error(rw, "unknown", http.StatusInternalServerError)
+		return
+	}
+
+	machines, err := r.machineCache.List(provisioningClusters[0].Namespace, labels.SelectorFromSet(map[string]string{
+		capi.ClusterLabelName: provisioningClusters[0].Name,
+	}))
+	if err != nil {
+		logrus.Errorf("[rke2configserver] error listing machines: %v", err)
+		http.Error(rw, "unknown", http.StatusInternalServerError)
+		return
+	}
+
+	var taintsWithDuplicates []corev1.Taint
+	for _, m := range machines {
+		machineTaints, err := capr.GetTaints(m.Annotations[capr.TaintsAnnotation], capr.GetRuntime(provisioningClusters[0].Spec.KubernetesVersion), m.Labels[capr.ControlPlaneRoleLabel] == "true", m.Labels[capr.EtcdRoleLabel] == "true", m.Labels[capr.WorkerRoleLabel] == "true")
+		if err != nil {
+			logrus.Errorf("[rke2configserver] error retrieving taints for machine: %v", err)
+			continue
+		}
+		taintsWithDuplicates = append(taintsWithDuplicates, machineTaints...)
+	}
+
+	var taints []corev1.Taint
+	taintMap := make(map[corev1.Taint]bool)
+
+	for _, t := range taintsWithDuplicates {
+		if _, ok := taintMap[t]; !ok {
+			taintMap[t] = true
+			taints = append(taints, t)
+		}
+	}
+
+	sort.Slice(taints, func(i, j int) bool {
+		return taints[i].ToString() < taints[j].ToString()
+	})
+
+	serverURL := settings.ServerURL.Get()
+	if serverURL == "" {
+		logrus.Errorf("[rke2configserver] server-url not set")
+		http.Error(rw, "server url not set", http.StatusInternalServerError)
+		return
+	}
+
+	clusterAgentTemplate := &bytes.Buffer{}
+	err = systemtemplate.SystemTemplate(clusterAgentTemplate, systemtemplate.GetDesiredAgentImage(mgmtCluster),
+		systemtemplate.GetDesiredAuthImage(mgmtCluster),
+		mgmtCluster.Name, token, serverURL, mgmtCluster.Spec.WindowsPreferedCluster,
+		mgmtCluster, systemtemplate.GetDesiredFeatures(mgmtCluster), taints, r.secretsCache)
+	if err != nil {
+		logrus.Errorf("[rke2configserver] error encountered rendering cluster-agent manifest: %v", err)
+		http.Error(rw, "unable to render manifest", http.StatusInternalServerError)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "text/plain")
+	_, err = rw.Write(clusterAgentTemplate.Bytes())
+	if err != nil {
+		logrus.Errorf("[rke2configserver] error while writing cluster agent YAML manifest: %v", err)
+	}
+	return
+}

--- a/pkg/capr/configserver/server.go
+++ b/pkg/capr/configserver/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -35,10 +36,11 @@ import (
 )
 
 const (
-	ConnectClusterInfo          = "/v3/connect/cluster-info"
-	ConnectConfigYamlPath       = "/v3/connect/config-yaml"
-	ConnectClusterAgentYamlPath = "/v3/connect/cluster-agent-yaml"
-	ConnectAgent                = "/v3/connect/agent"
+	ConnectClusterInfo           = "/v3/connect/cluster-info"
+	ConnectConfigYamlPath        = "/v3/connect/config-yaml"
+	ConnectClusterAgentYamlPath  = "/v3/connect/cluster-agent/{token}.yaml"
+	ConnectClusterAgentYamlRegex = `^\/v3\/connect\/cluster-agent\/[bcdfghjklmnpqrstvwxz2456789]{54}\.yaml$` // Per wrangler: pkg/randomtoken
+	ConnectAgent                 = "/v3/connect/agent"
 )
 
 var (
@@ -113,8 +115,9 @@ func (r *RKE2ConfigServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 		return
 	}
 
+	reg := regexp.MustCompile(ConnectClusterAgentYamlRegex)
 	// Short circuit if the path is the connect cluster agent yaml path
-	if req.URL.Path == ConnectClusterAgentYamlPath {
+	if reg.MatchString(req.URL.Path) {
 		r.connectClusterAgentYAML(rw, req)
 	}
 

--- a/pkg/capr/configserver/server.go
+++ b/pkg/capr/configserver/server.go
@@ -35,9 +35,10 @@ import (
 )
 
 const (
-	ConnectClusterInfo    = "/v3/connect/cluster-info"
-	ConnectConfigYamlPath = "/v3/connect/config-yaml"
-	ConnectAgent          = "/v3/connect/agent"
+	ConnectClusterInfo          = "/v3/connect/cluster-info"
+	ConnectConfigYamlPath       = "/v3/connect/config-yaml"
+	ConnectClusterAgentYamlPath = "/v3/connect/cluster-agent-yaml"
+	ConnectAgent                = "/v3/connect/agent"
 )
 
 var (
@@ -47,6 +48,8 @@ var (
 type RKE2ConfigServer struct {
 	clusterTokenCache        mgmtcontroller.ClusterRegistrationTokenCache
 	clusterTokens            mgmtcontroller.ClusterRegistrationTokenController
+	mgmtClusterCache         mgmtcontroller.ClusterCache
+	mgmtClusters             mgmtcontroller.ClusterController
 	serviceAccountsCache     corecontrollers.ServiceAccountCache
 	serviceAccounts          corecontrollers.ServiceAccountClient
 	secretsCache             corecontrollers.SecretCache
@@ -56,6 +59,7 @@ type RKE2ConfigServer struct {
 	machines                 capicontrollers.MachineClient
 	bootstrapCache           rkecontroller.RKEBootstrapCache
 	provisioningClusterCache provisioningcontrollers.ClusterCache
+	provisioningClusters     provisioningcontrollers.ClusterController
 	k8s                      kubernetes.Interface
 }
 
@@ -84,21 +88,36 @@ func New(clients *wrangler.Context) *RKE2ConfigServer {
 		machines:                 clients.CAPI.Machine(),
 		bootstrapCache:           clients.RKE.RKEBootstrap().Cache(),
 		provisioningClusterCache: clients.Provisioning.Cluster().Cache(),
+		provisioningClusters:     clients.Provisioning.Cluster(),
+		mgmtClusterCache:         clients.Mgmt.Cluster().Cache(),
+		mgmtClusters:             clients.Mgmt.Cluster(),
 		k8s:                      clients.K8s,
 	}
 }
 
 func (r *RKE2ConfigServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	if !r.secrets.Informer().HasSynced() || !r.clusterTokens.Informer().HasSynced() {
+	if !r.secrets.Informer().HasSynced() || !r.clusterTokens.Informer().HasSynced() || !r.provisioningClusters.Informer().HasSynced() || !r.mgmtClusters.Informer().HasSynced() {
 		if err := r.secrets.Informer().GetIndexer().Resync(); err != nil {
 			logrus.Errorf("error re-syncing secrets informer in rke2configserver: %v", err)
 		}
 		if err := r.clusterTokens.Informer().GetIndexer().Resync(); err != nil {
 			logrus.Errorf("error re-syncing clustertokens informer in rke2configserver: %v", err)
 		}
+		if err := r.provisioningClusters.Informer().GetIndexer().Resync(); err != nil {
+			logrus.Errorf("error re-syncing provisioningClusters informer in rke2configserver: %v", err)
+		}
+		if err := r.mgmtClusters.Informer().GetIndexer().Resync(); err != nil {
+			logrus.Errorf("error re-syncing mgmtClusters informer in rke2configserver: %v", err)
+		}
 		rw.WriteHeader(http.StatusUnauthorized)
 		return
 	}
+
+	// Short circuit if the path is the connect cluster agent yaml path
+	if req.URL.Path == ConnectClusterAgentYamlPath {
+		r.connectClusterAgentYAML(rw, req)
+	}
+
 	planSecret, secret, err := r.findSA(req)
 	if apierrors.IsNotFound(err) {
 		rw.WriteHeader(http.StatusUnauthorized)

--- a/pkg/capr/planner/agent.go
+++ b/pkg/capr/planner/agent.go
@@ -1,11 +1,7 @@
 package planner
 
 import (
-	"fmt"
-	"sort"
-
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
-	"github.com/rancher/rancher/pkg/systemtemplate"
 )
 
 // generateClusterAgentManifest generates a cluster agent manifest
@@ -14,28 +10,5 @@ func (p *Planner) generateClusterAgentManifest(controlPlane *rkev1.RKEControlPla
 		return nil, nil
 	}
 
-	tokens, err := p.clusterRegistrationTokenCache.GetByIndex(clusterRegToken, controlPlane.Spec.ManagementClusterName)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(tokens) == 0 {
-		return nil, fmt.Errorf("no cluster registration token found")
-	}
-
-	sort.Slice(tokens, func(i, j int) bool {
-		return tokens[i].Name < tokens[j].Name
-	})
-
-	mgmtCluster, err := p.managementClusters.Get(controlPlane.Spec.ManagementClusterName)
-	if err != nil {
-		return nil, err
-	}
-
-	taints, err := getTaints(entry, controlPlane)
-	if err != nil {
-		return nil, err
-	}
-
-	return systemtemplate.ForCluster(mgmtCluster, tokens[0].Status.Token, taints, p.secretCache)
+	return []byte{}, nil
 }

--- a/pkg/capr/planner/agent.go
+++ b/pkg/capr/planner/agent.go
@@ -1,14 +1,408 @@
 package planner
 
 import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"sort"
+	"text/template"
+
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/rancher/pkg/systemtemplate"
 )
 
+const ClusterAgentInitialCreationManifest = `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rancher-cluster-agent-genesis-helper
+  namespace: kube-system
+data:
+  "create-cluster-agent-if-not-exists.sh": {{.ScriptB64}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rancher-cluster-agent-genesis
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rancher-cluster-agent-genesis-binding
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: rancher-cluster-agent-genesis
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: rancher-cluster-agent-genesis-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rancher-cluster-agent-genesis-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rancher-cluster-agent-genesis-deploy-job
+  namespace: kube-system
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+       name: rancher-cluster-agent-genesis-deploy
+    spec:
+        tolerations:
+        - operator: Exists
+        hostNetwork: true
+        serviceAccountName: rancher-cluster-agent-genesis
+        containers:
+          - name: pod
+            image: {{.AgentImage}}
+            env:
+            - name: CATTLE_SERVER
+              value: {{.URL}}
+            - name: CATTLE_CA_CHECKSUM
+              value: {{.CAChecksum}}
+            - name: CATTLE_TOKEN
+              value: {{.Token}}
+            command: ["/bin/sh"]
+            args: ["/helper/create-cluster-agent-if-not-exists.sh"]
+            volumeMounts:
+            - name: secret-volume
+              mountPath: /helper
+        volumes:
+          - name: secret-volume
+            secret:
+              secretName: rancher-cluster-agent-genesis-helper
+        restartPolicy: Never
+`
+
+const ApplyManifestIfNotExistsScript string = `#!/bin/sh
+
+if [ -z "$CATTLE_SERVER" ] || [ -z "$CATTLE_TOKEN" ]; then
+	exit 1
+fi
+
+# info logs the given argument at info log level.
+info() {
+    echo "[INFO] " "$@"
+}
+
+# warn logs the given argument at warn log level.
+warn() {
+    echo "[WARN] " "$@" >&2
+}
+
+# error logs the given argument at error log level.
+error() {
+    echo "[ERROR] " "$@" >&2
+}
+
+# fatal logs the given argument at fatal log level.
+fatal() {
+    echo "[FATAL] " "$@" >&2
+    exit 1
+}
+
+if kubectl get deployments -n cattle-system cattle-cluster-agent > /dev/null; then
+	info "cattle-cluster-agent already exists"
+	exit 0
+fi
+
+check_x509_cert()
+{
+    cert=$1
+    err=$(openssl x509 -in "${cert}" -noout 2>&1)
+    if [ $? -eq 0 ]
+    then
+        echo ""
+    else
+        echo "${err}"
+    fi
+}
+
+ip_to_int() {
+    ip_addr="${1}"
+
+    ip_1=$(echo "${ip_addr}" | cut -d'.' -f1)
+    ip_2=$(echo "${ip_addr}" | cut -d'.' -f2)
+    ip_3=$(echo "${ip_addr}" | cut -d'.' -f3)
+    ip_4=$(echo "${ip_addr}" | cut -d'.' -f4)
+
+    echo $(( $ip_1 * 256*256*256 + $ip_2 * 256*256 + $ip_3 * 256 + $ip_4 ))
+}
+
+valid_ip() {
+    local IP="$1" IFS="." PART
+    set -- $IP
+    [ "$#" != 4 ] && echo 1 && return
+    for PART; do
+        case "$PART" in
+            *[!0-9]*) echo 1 && return
+        esac
+        [ "$PART" -gt 255 ] && echo 1 && return
+    done
+    echo 0
+}
+
+in_no_proxy() {
+    # Get just the host name/IP
+    ip_addr="${1#http://}"
+    ip_addr="${ip_addr#https://}"
+    ip_addr="${ip_addr%%/*}"
+    ip_addr="${ip_addr%%:*}"
+
+    # If this isn't an IP address, then there is nothing to check
+    if [ "$(valid_ip "$ip_addr")" = "1" ]; then
+      echo 1
+      return
+    fi
+
+    i=1
+    proxy_ip=$(echo "$NO_PROXY" | cut -d',' -f$i)
+    while [ -n "$proxy_ip" ]; do
+      subnet_ip=$(echo "${proxy_ip}" | cut -d'/' -f1)
+      cidr_mask=$(echo "${proxy_ip}" | cut -d'/' -f2)
+
+      if [ "$(valid_ip "$subnet_ip")" = "0" ]; then
+        # If these were the same, then proxy_ip is an IP address, not a CIDR. curl handles this correctly.
+        if [ "$cidr_mask" != "$subnet_ip" ]; then
+          cidr_mask=$(( 32 - cidr_mask ))
+          shift_multiply=1
+          while [ "$cidr_mask" -gt 0 ]; do
+            shift_multiply=$(( shift_multiply * 2 ))
+            cidr_mask=$(( cidr_mask - 1 ))
+          done
+
+          # Manual left-shift (<<) by original cidr_mask value
+          netmask=$(( 0xFFFFFFFF * shift_multiply ))
+
+          # Apply netmask to both the subnet IP and the given IP address
+          ip_addr_subnet=$(and "$(ip_to_int "$subnet_ip")" $netmask)
+          subnet=$(and "$(ip_to_int "$ip_addr")" $netmask)
+
+          # Subnet IPs will match if given IP address is in CIDR subnet
+          if [ "${ip_addr_subnet}" -eq "${subnet}" ]; then
+            echo 0
+            return
+          fi
+        fi
+      fi
+
+      i=$(( i + 1 ))
+      proxy_ip=$(echo "$NO_PROXY" | cut -d',' -s -f$i)
+    done
+
+    echo 1
+}
+
+validate_ca_required() {
+    CA_REQUIRED=false
+    if [ -n "${CATTLE_SERVER}" ]; then
+        i=1
+        while [ "${i}" -ne "${RETRYCOUNT}" ]; do
+            noproxy=""
+            if [ "$(in_no_proxy ${CATTLE_SERVER})" = "0" ]; then
+                noproxy="--noproxy '*'"
+            fi
+            VERIFY_RESULT=$(curl $noproxy --connect-timeout 60 --max-time 60 --write-out "%{ssl_verify_result}\n" ${CURL_LOG} -fL "${CATTLE_SERVER}/healthz" -o /dev/null 2>/dev/null)
+            CURL_EXIT="$?"
+            case "${CURL_EXIT}" in
+              0|60)
+                case "${VERIFY_RESULT}" in
+                  0)
+                    info "Determined CA is not necessary to connect to Rancher"
+                    CA_REQUIRED=false
+                    CATTLE_CA_CHECKSUM=""
+                    break
+                    ;;
+                  *)
+                    i=$((i + 1))
+                    if [ "${CURL_EXIT}" -eq "60" ]; then
+                      info "Determined CA is necessary to connect to Rancher"
+                      CA_REQUIRED=true
+                      break
+                    fi
+                    error "Error received while testing necessity of CA. Sleeping for 5 seconds and trying again"
+                    sleep 5
+                    continue
+                    ;;
+                esac
+                ;;
+              *)
+                error "Error while connecting to Rancher to verify CA necessity. Sleeping for 5 seconds and trying again."
+                sleep 5
+                continue
+                ;;
+            esac
+        done
+    fi
+}
+
+RETRYCOUNT=4500
+CACERTS_PATH=cacerts
+
+if [ -n "${CATTLE_CA_CHECKSUM}" ]; then
+    validate_ca_required
+        CACERT=$(mktemp)
+        i=1
+        while [ "${i}" -ne "${RETRYCOUNT}" ]; do
+            noproxy=""
+            if [ "$(in_no_proxy ${CATTLE_AGENT_BINARY_URL})" = "0" ]; then
+                noproxy="--noproxy '*'"
+            fi
+            RESPONSE=$(curl $noproxy --connect-timeout 60 --max-time 60 --write-out "%{http_code}\n" --insecure ${CURL_LOG} -fL "${CATTLE_SERVER}/${CACERTS_PATH}" -o ${CACERT})
+            case "${RESPONSE}" in
+            200)
+                info "Successfully downloaded CA certificate"
+                break
+                ;;
+            *)
+                i=$((i + 1))
+                error "$RESPONSE received while downloading the CA certificate. Sleeping for 5 seconds and trying again"
+                sleep 5
+                continue
+                ;;
+            esac
+        done
+        if [ ! -s "${CACERT}" ]; then
+          error "The environment variable CATTLE_CA_CHECKSUM is set but there is no CA certificate configured at ${CATTLE_SERVER}/${CACERTS_PATH}"
+          exit 1
+        fi
+        err=$(check_x509_cert "${CACERT}")
+        if [ -n "${err}" ]; then
+            error "Value from ${CATTLE_SERVER}/${CACERTS_PATH} does not look like an x509 certificate (${err})"
+            error "Retrieved cacerts:"
+            cat "${CACERT}"
+            rm -f "${CACERT}"
+            exit 1
+        else
+            info "Value from ${CATTLE_SERVER}/${CACERTS_PATH} is an x509 certificate"
+        fi
+        CATTLE_SERVER_CHECKSUM=$(sha256sum "${CACERT}" | awk '{print $1}')
+        if [ "${CATTLE_SERVER_CHECKSUM}" != "${CATTLE_CA_CHECKSUM}" ]; then
+            rm -f "${CACERT}"
+            error "Configured cacerts checksum ($CATTLE_SERVER_CHECKSUM) does not match given --ca-checksum ($CATTLE_CA_CHECKSUM)"
+            error "Please check if the correct certificate is configured at${CATTLE_SERVER}/${CACERTS_PATH}"
+            exit 1
+        fi
+        CURL_CAFLAG="--cacert ${CACERT}"
+fi
+
+RANCHER_SUCCESS=false
+    if [ -n "${CATTLE_SERVER}" ] && [ "${CATTLE_REMOTE_ENABLED}" = "true" ]; then
+        i=1
+        while [ "${i}" -ne "${RETRYCOUNT}" ]; do
+            noproxy=""
+            if [ "$(in_no_proxy ${CATTLE_AGENT_BINARY_URL})" = "0" ]; then
+                noproxy="--noproxy '*'"
+            fi
+            RESPONSE=$(curl $noproxy --connect-timeout 60 --max-time 60 --write-out "%{http_code}\n" ${CURL_CAFLAG} ${CURL_LOG} -fL "${CATTLE_SERVER}/healthz" -o /dev/null)
+            case "${RESPONSE}" in
+            200)
+                info "Successfully tested Rancher connection"
+                RANCHER_SUCCESS=true
+                break
+                ;;
+            *)
+                i=$((i + 1))
+                error "$RESPONSE received while testing Rancher connection. Sleeping for 5 seconds and trying again"
+                sleep 5
+                continue
+                ;;
+            esac
+        done
+        if [ "${RANCHER_SUCCESS}" != "true" ]; then
+          fatal "Error connecting to Rancher. Perhaps --ca-checksum needs to be set?"
+        fi
+    fi
+
+MANIFEST=$(mktemp)
+
+i=1
+noproxy=""
+if [ "$(in_no_proxy "${CATTLE_SERVER}")" = "0" ]; then
+	noproxy="--noproxy '*'"
+fi
+while [ "${i}" -ne "${RETRYCOUNT}" ]; do
+	RESPONSE=$(curl $noproxy --connect-timeout 60 --max-time 300 --write-out "%{http_code}\n" ${CURL_CAFLAG} -fL "${CATTLE_SERVER}/v3/connect/cluster-agent/${CATTLE_TOKEN}.yaml" -o "${MANIFEST}")
+	case "${RESPONSE}" in
+	200)
+		break
+		;;
+	*)
+		i=$((i + 1))
+		sleep 5
+		continue
+		;;
+	esac
+done
+
+if ! kubectl create -f "$MANIFEST"; then
+	info "error applying cattle-cluster-agent"
+	exit 1
+fi
+
+rm $MANIFEST
+`
+
+type tc struct {
+	CAChecksum string
+	Token      string
+	URL        string
+	ScriptB64  string
+	AgentImage string
+}
+
 // generateClusterAgentManifest generates a cluster agent manifest
-func (p *Planner) generateClusterAgentManifest(controlPlane *rkev1.RKEControlPlane, entry *planEntry) ([]byte, error) {
+func (p *Planner) generateClusterAgentManifest(controlPlane *rkev1.RKEControlPlane) ([]byte, error) {
 	if controlPlane.Spec.ManagementClusterName == "local" {
 		return nil, nil
 	}
 
-	return []byte{}, nil
+	tokens, err := p.clusterRegistrationTokenCache.GetByIndex(clusterRegToken, controlPlane.Spec.ManagementClusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("no cluster registration token found")
+	}
+
+	sort.Slice(tokens, func(i, j int) bool {
+		return tokens[i].Name < tokens[j].Name
+	})
+
+	mgmtCluster, err := p.managementClusters.Get(controlPlane.Spec.ManagementClusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	t := template.Must(template.New("cam-apply").Parse(ClusterAgentInitialCreationManifest))
+
+	templateContext := tc{
+		URL:        settings.ServerURL.Get(),
+		Token:      tokens[0].Status.Token,
+		CAChecksum: systemtemplate.CAChecksum(),
+		ScriptB64:  base64.StdEncoding.EncodeToString([]byte(ApplyManifestIfNotExistsScript)),
+		AgentImage: systemtemplate.GetDesiredAgentImage(mgmtCluster),
+	}
+
+	buf := &bytes.Buffer{}
+
+	err = t.Execute(buf, templateContext)
+	return buf.Bytes(), err
 }

--- a/pkg/capr/planner/config.go
+++ b/pkg/capr/planner/config.go
@@ -376,7 +376,7 @@ func addTaints(config map[string]interface{}, entry *planEntry, cp *rkev1.RKECon
 		taintString []string
 	)
 
-	taints, err := getTaints(entry, cp)
+	taints, err := capr.GetTaints(entry.Metadata.Annotations[capr.TaintsAnnotation], capr.GetRuntime(cp.Spec.KubernetesVersion), isControlPlane(entry), isEtcd(entry), isWorker(entry))
 	if err != nil {
 		return err
 	}

--- a/pkg/capr/planner/manifests.go
+++ b/pkg/capr/planner/manifests.go
@@ -67,7 +67,7 @@ func getEtcdSnapshotExtraMetadata(controlPlane *rkev1.RKEControlPlane, runtime s
 
 // getClusterAgentManifestFile returns a plan.File that contains the cluster agent manifest.
 func (p *Planner) getClusterAgentManifestFile(controlPlane *rkev1.RKEControlPlane, runtime string, entry *planEntry) (plan.File, error) {
-	data, err := p.generateClusterAgentManifest(controlPlane, entry)
+	data, err := p.generateClusterAgentManifest(controlPlane)
 	if err != nil {
 		return plan.File{}, err
 	}

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -836,34 +836,6 @@ func PruneEmpty(config map[string]interface{}) {
 	}
 }
 
-// getTaints returns a slice of taints for the machine in question
-func getTaints(entry *planEntry, cp *rkev1.RKEControlPlane) (result []corev1.Taint, _ error) {
-	data := entry.Metadata.Annotations[capr.TaintsAnnotation]
-	if data != "" {
-		if err := json.Unmarshal([]byte(data), &result); err != nil {
-			return result, err
-		}
-	}
-
-	if !isWorker(entry) {
-		// k3s charts do not have correct tolerations when the master node is both controlplane and etcd
-		if isEtcd(entry) && (capr.GetRuntime(cp.Spec.KubernetesVersion) != capr.RuntimeK3S || !isControlPlane(entry)) {
-			result = append(result, corev1.Taint{
-				Key:    "node-role.kubernetes.io/etcd",
-				Effect: corev1.TaintEffectNoExecute,
-			})
-		}
-		if isControlPlane(entry) {
-			result = append(result, corev1.Taint{
-				Key:    "node-role.kubernetes.io/control-plane",
-				Effect: corev1.TaintEffectNoSchedule,
-			})
-		}
-	}
-
-	return
-}
-
 func (p *Planner) reconcile(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, clusterPlan *plan.Plan, required bool,
 	tierName string, include, exclude roleFilter, maxUnavailable string, forcedJoinURL string, drainOptions rkev1.DrainOptions) error {
 	var (

--- a/pkg/systemtemplate/import.go
+++ b/pkg/systemtemplate/import.go
@@ -1,7 +1,6 @@
 package systemtemplate
 
 import (
-	"bytes"
 	"crypto/md5"
 	"crypto/sha256"
 	"encoding/base64"
@@ -156,15 +155,6 @@ func GetDesiredFeatures(cluster *apimgmtv3.Cluster) map[string]bool {
 		features.EmbeddedClusterAPI.Name(): false,
 		features.MonitoringV1.Name():       cluster.Spec.EnableClusterMonitoring,
 	}
-}
-
-func ForCluster(cluster *apimgmtv3.Cluster, token string, taints []corev1.Taint, secretLister v1.SecretLister) ([]byte, error) {
-	buf := &bytes.Buffer{}
-	err := SystemTemplate(buf, GetDesiredAgentImage(cluster),
-		GetDesiredAuthImage(cluster),
-		cluster.Name, token, settings.ServerURL.Get(), cluster.Spec.WindowsPreferedCluster,
-		cluster, GetDesiredFeatures(cluster), taints, secretLister)
-	return buf.Bytes(), err
 }
 
 func InternalCAChecksum() string {


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/41132
 
## Problem
There are two controllers that can conflict when managing the `cattle-cluster-agent`. 

## Solution
Change one of the conflicting controllers to use a script that checks for the existence of the `cattle-cluster-agent` deployment and apply the manifest if it does not exist.
 
## Testing

## Engineering Testing
### Manual Testing
Tested provisioning new clusters.
### Automated Testing
No specific automated tests were added for this change as the existing automation suite covers the changes it introduces.
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->