### PR TITLE
Fix run script to check for args

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -9,7 +9,7 @@ if [ ! -x $CMD ]; then
     ./scripts/build-server
 fi
 
-if [ $1 = "--trace" ] || [ $1 = "--info" ] || [ $1 = "--debug" ]; then
+if [ ! -z $1 ] && ( [ $1 = "--trace" ] || [ $1 = "--info" ] || [ $1 = "--debug" ] ); then
   LOGFLAG=$1
 fi
 


### PR DESCRIPTION
CI fix to have `scripts/run` check for args.
This just fixes an error message in the logs, not the actual problem of
```
2023/05/17 12:54:29 listen tcp 127.0.0.1:6060: bind: address already in use
time="2023-05-17T12:54:23Z" level=fatal msg="starting kubernetes: preparing server: init cluster datastore and https: listen tcp :6443: bind: address already in use"
```