### PR TITLE
[CI] Improve CAPR reliability + drop systemd-node workaround for cgroups

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -48,7 +48,7 @@ ENV CATTLE_WINS_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher
 ENV CATTLE_WINS_AGENT_UPGRADE_IMAGE rancher/wins:${CATTLE_WINS_AGENT_VERSION}
 ENV CATTLE_CSI_PROXY_AGENT_VERSION v1.1.1
 # make sure the CATTLE_SYSTEM_AGENT_VERSION is consistent with tests/v2/codecoverage/package/Dockerfile and pkg/settings/setting.go
-ENV CATTLE_SYSTEM_AGENT_VERSION v0.3.3-rc3
+ENV CATTLE_SYSTEM_AGENT_VERSION v0.3.3-rc4
 ENV CATTLE_SYSTEM_AGENT_INSTALL_SCRIPT https://raw.githubusercontent.com/rancher/system-agent/${CATTLE_SYSTEM_AGENT_VERSION}/install.sh
 ENV CATTLE_SYSTEM_AGENT_UNINSTALL_SCRIPT https://raw.githubusercontent.com/rancher/system-agent/${CATTLE_SYSTEM_AGENT_VERSION}/system-agent-uninstall.sh
 ENV CATTLE_SYSTEM_AGENT_UPGRADE_IMAGE rancher/system-agent:${CATTLE_SYSTEM_AGENT_VERSION}-suc

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -75,6 +75,8 @@ const (
 	WorkerRoleLabel               = "rke.cattle.io/worker-role"
 	AuthorizedObjectAnnotation    = "rke.cattle.io/object-authorized-for-clusters"
 
+	JoinServerImplausible = "implausible"
+
 	SecretTypeMachinePlan  = "rke.cattle.io/machine-plan"
 	SecretTypeClusterState = "rke.cattle.io/cluster-state"
 

--- a/pkg/capr/planner/certificaterotation.go
+++ b/pkg/capr/planner/certificaterotation.go
@@ -1,7 +1,6 @@
 package planner
 
 import (
-	"encoding/base64"
 	"fmt"
 	"strconv"
 	"strings"
@@ -73,30 +72,6 @@ func shouldRotate(cp *rkev1.RKEControlPlane) bool {
 	return cp.Status.CertificateRotationGeneration != cp.Spec.RotateCertificates.Generation
 }
 
-const idempotentRotateScript = `
-#!/bin/sh
-
-currentGeneration=""
-targetGeneration=$2
-runtime=$1
-shift
-shift
-
-dataRoot="/var/lib/rancher/$runtime/certificate_rotation"
-generationFile="$dataRoot/generation"
-
-currentGeneration=$(cat "$generationFile" || echo "")
-
-if [ "$currentGeneration" != "$targetGeneration" ]; then
-  $runtime certificate rotate  $@
-else
-	echo "certificates have already been rotated to the current generation."
-fi
-
-mkdir -p $dataRoot
-echo $targetGeneration > "$generationFile"
-`
-
 // rotateCertificatesPlan rotates the certificates for the services specified, if any, and restarts the service.  If no services are specified
 // all certificates are rotated.
 func (p *Planner) rotateCertificatesPlan(controlPlane *rkev1.RKEControlPlane, tokensSecret plan.Secret, rotation *rkev1.RotateCertificates, entry *planEntry, joinServer string) (plan.NodePlan, string, error) {
@@ -110,26 +85,13 @@ func (p *Planner) rotateCertificatesPlan(controlPlane *rkev1.RKEControlPlane, to
 	}
 
 	if isOnlyWorker(entry) {
-		rotatePlan.Instructions = append(rotatePlan.Instructions, plan.OneTimeInstruction{
-			Name:    "restart",
-			Command: "systemctl",
-			Args: []string{
-				"restart",
-				capr.GetRuntimeAgentUnit(controlPlane.Spec.KubernetesVersion),
-			},
-		})
+		rotatePlan.Instructions = append(rotatePlan.Instructions, idempotentRestartInstructions("certificate-rotation/restart", strconv.FormatInt(rotation.Generation, 10), capr.GetRuntimeAgentUnit(controlPlane.Spec.KubernetesVersion))...)
 		return rotatePlan, joinedServer, nil
 	}
 
-	rotateScriptPath := "/var/lib/rancher/" + capr.GetRuntime(controlPlane.Spec.KubernetesVersion) + "/rancher_v2prov_certificate_rotation/bin/rotate.sh"
-
-	runtime := capr.GetRuntime(controlPlane.Spec.KubernetesVersion)
-
 	args := []string{
-		"-xe",
-		rotateScriptPath,
-		capr.GetRuntime(controlPlane.Spec.KubernetesVersion),
-		strconv.FormatInt(rotation.Generation, 10),
+		"certificate",
+		"rotate",
 	}
 
 	if len(rotation.Services) > 0 {
@@ -138,95 +100,100 @@ func (p *Planner) rotateCertificatesPlan(controlPlane *rkev1.RKEControlPlane, to
 		}
 	}
 
-	rotatePlan.Files = append(rotatePlan.Files, plan.File{
-		Content: base64.StdEncoding.EncodeToString([]byte(idempotentRotateScript)),
-		Path:    rotateScriptPath,
-	})
-	rotatePlan.Instructions = append(rotatePlan.Instructions, plan.OneTimeInstruction{
-		Name:    "rotate certificates",
-		Command: "sh",
-		Args:    args,
-	})
+	runtime := capr.GetRuntime(controlPlane.Spec.KubernetesVersion)
+
+	rotatePlan.Instructions = append(rotatePlan.Instructions, idempotentInstruction(
+		"certificate-rotation/rotate",
+		strconv.FormatInt(rotation.Generation, 10),
+		capr.GetRuntime(controlPlane.Spec.KubernetesVersion),
+		args,
+		[]string{},
+	))
 	if isControlPlane(entry) {
 		// The following kube-scheduler and kube-controller-manager certificates are self-signed by the respective services and are used by CAPR for secure healthz probes against the service.
 		if rotationContainsService(rotation, "controller-manager") {
 			if kcmCertDir := getArgValue(config[KubeControllerManagerArg], CertDirArgument, "="); kcmCertDir != "" && getArgValue(config[KubeControllerManagerArg], TLSCertFileArgument, "=") == "" {
 				rotatePlan.Instructions = append(rotatePlan.Instructions, []plan.OneTimeInstruction{
-					{
-						Name:    "remove kube-controller-manager cert for regeneration",
-						Command: "rm",
-						Args: []string{
+					idempotentInstruction(
+						"certificate-rotation/rm-kcm-cert",
+						strconv.FormatInt(rotation.Generation, 10),
+						"rm",
+						[]string{
 							"-f",
 							fmt.Sprintf("%s/%s", kcmCertDir, DefaultKubeControllerManagerCert),
 						},
-					},
-					{
-						Name:    "remove kube-controller-manager key for regeneration",
-						Command: "rm",
-						Args: []string{
+						[]string{},
+					),
+					idempotentInstruction(
+						"certificate-rotation/rm-kcm-key",
+						strconv.FormatInt(rotation.Generation, 10),
+						"rm",
+						[]string{
 							"-f",
 							fmt.Sprintf("%s/%s", kcmCertDir, strings.ReplaceAll(DefaultKubeControllerManagerCert, ".crt", ".key")),
 						},
-					},
+						[]string{},
+					),
 				}...)
 				if runtime == capr.RuntimeRKE2 {
-					rotatePlan.Instructions = append(rotatePlan.Instructions, plan.OneTimeInstruction{
-						Name:    "remove kube-controller-manager static pod manifest",
-						Command: "rm",
-						Args: []string{
+					rotatePlan.Instructions = append(rotatePlan.Instructions, idempotentInstruction(
+						"certificate-rotation/rm-kcm-spm",
+						strconv.FormatInt(rotation.Generation, 10),
+						"rm",
+						[]string{
 							"-f",
 							"/var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml",
 						},
-					})
+						[]string{},
+					))
 				}
 			}
 		}
 		if rotationContainsService(rotation, "scheduler") {
 			if ksCertDir := getArgValue(config[KubeSchedulerArg], CertDirArgument, "="); ksCertDir != "" && getArgValue(config[KubeSchedulerArg], TLSCertFileArgument, "=") == "" {
 				rotatePlan.Instructions = append(rotatePlan.Instructions, []plan.OneTimeInstruction{
-					{
-						Name:    "remove kube-scheduler cert for regeneration",
-						Command: "rm",
-						Args: []string{
+					idempotentInstruction(
+						"certificate-rotation/rm-ks-cert",
+						strconv.FormatInt(rotation.Generation, 10),
+						"rm",
+						[]string{
 							"-f",
-							fmt.Sprintf("%s/%s", ksCertDir, KubeSchedulerArg),
+							fmt.Sprintf("%s/%s", ksCertDir, DefaultKubeSchedulerCert),
 						},
-					},
-					{
-						Name:    "remove kube-scheduler key for regeneration",
-						Command: "rm",
-						Args: []string{
+						[]string{},
+					),
+					idempotentInstruction(
+						"certificate-rotation/rm-ks-key",
+						strconv.FormatInt(rotation.Generation, 10),
+						"rm",
+						[]string{
 							"-f",
-							fmt.Sprintf("%s/%s", ksCertDir, strings.ReplaceAll(KubeSchedulerArg, ".crt", ".key")),
+							fmt.Sprintf("%s/%s", ksCertDir, strings.ReplaceAll(DefaultKubeSchedulerCert, ".crt", ".key")),
 						},
-					},
+						[]string{},
+					),
 				}...)
 				if runtime == capr.RuntimeRKE2 {
-					rotatePlan.Instructions = append(rotatePlan.Instructions, plan.OneTimeInstruction{
-						Name:    "remove kube-scheduler static pod manifest",
-						Command: "rm",
-						Args: []string{
+					rotatePlan.Instructions = append(rotatePlan.Instructions, idempotentInstruction(
+						"certificate-rotation/rm-ks-spm",
+						strconv.FormatInt(rotation.Generation, 10),
+						"rm",
+						[]string{
 							"-f",
 							"/var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml",
 						},
-					})
+						[]string{},
+					))
 				}
 			}
 		}
 	}
 	if runtime == capr.RuntimeRKE2 {
 		if generated, instruction := generateManifestRemovalInstruction(runtime, entry); generated {
-			rotatePlan.Instructions = append(rotatePlan.Instructions, instruction)
+			rotatePlan.Instructions = append(rotatePlan.Instructions, convertToIdempotentInstruction("certificate-rotation/manifest-removal", strconv.FormatInt(rotation.Generation, 10), instruction))
 		}
 	}
-	rotatePlan.Instructions = append(rotatePlan.Instructions, plan.OneTimeInstruction{
-		Name:    "restart",
-		Command: "systemctl",
-		Args: []string{
-			"restart",
-			capr.GetRuntimeServerUnit(controlPlane.Spec.KubernetesVersion),
-		},
-	})
+	rotatePlan.Instructions = append(rotatePlan.Instructions, idempotentRestartInstructions("certificate-rotation/restart", strconv.FormatInt(rotation.Generation, 10), capr.GetRuntimeServerUnit(controlPlane.Spec.KubernetesVersion))...)
 	return rotatePlan, joinedServer, nil
 }
 

--- a/pkg/capr/planner/encryptionkeyrotation.go
+++ b/pkg/capr/planner/encryptionkeyrotation.go
@@ -29,7 +29,7 @@ const (
 	encryptionKeyRotationSecretsEncryptStatusCommand = "secrets-encrypt-status"
 
 	encryptionKeyRotationInstallRoot = "/var/lib/rancher"
-	encryptionKeyRotationBinPrefix   = "rancher_v2prov_encryption_key_rotation/bin"
+	encryptionKeyRotationBinPrefix   = "capr/encryption-key-rotation/bin"
 
 	encryptionKeyRotationWaitForSystemctlStatusPath      = "wait_for_systemctl_status.sh"
 	encryptionKeyRotationWaitForSecretsEncryptStatusPath = "wait_for_secrets_encrypt_status.sh"
@@ -42,7 +42,7 @@ const (
 runtimeServer=$1
 i=0
 
-while [ $i -lt 10 ]; do
+while [ $i -lt 30 ]; do
 	systemctl is-active $runtimeServer
 	if [ $? -eq 0 ]; then
 		exit 0
@@ -92,32 +92,6 @@ while [ $i -lt 10 ]; do
 	i=$((i + 1))
 done
 exit 1
-`
-
-	idempotentActionScript = `
-#!/bin/sh
-
-currentGeneration=""
-key=$1
-targetGeneration=$2
-runtime=$3
-shift
-shift
-shift
-
-dataRoot="/var/lib/rancher/$runtime/$key"
-generationFile="$dataRoot/generation"
-
-currentGeneration=$(cat "$generationFile" || echo "")
-
-if [ "$currentGeneration" != "$targetGeneration" ]; then
-	$runtime $@
-else
-	echo "action has already been reconciled to the current generation."
-fi
-
-mkdir -p "$dataRoot"
-echo "$targetGeneration" > "$generationFile"
 `
 
 	encryptionKeyRotationEndpointEnv = "CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock"
@@ -435,13 +409,13 @@ func (p *Planner) encryptionKeyRotationRestartService(cp *rkev1.RKEControlPlane,
 	runtime := capr.GetRuntime(cp.Spec.KubernetesVersion)
 	if runtime == capr.RuntimeRKE2 {
 		if generated, instruction := generateManifestRemovalInstruction(runtime, entry); generated {
-			nodePlan.Instructions = append(nodePlan.Instructions, instruction)
+			nodePlan.Instructions = append(nodePlan.Instructions, convertToIdempotentInstruction(strings.ToLower(fmt.Sprintf("encryption-key-rotation/manifest-cleanup/%s", cp.Status.RotateEncryptionKeysPhase)), strconv.FormatInt(cp.Spec.RotateEncryptionKeys.Generation, 10), instruction))
 		}
 	}
 
-	nodePlan.Instructions = append(nodePlan.Instructions,
-		encryptionKeyRotationRestartInstruction(cp),
-		encryptionKeyRotationWaitForSystemctlStatusInstruction(cp))
+	nodePlan.Instructions = append(nodePlan.Instructions, idempotentRestartInstructions(strings.ToLower(fmt.Sprintf("encryption-key-rotation/restart/%s", cp.Status.RotateEncryptionKeysPhase)), strconv.FormatInt(cp.Spec.RotateEncryptionKeys.Generation, 10), capr.GetRuntimeServerUnit(cp.Spec.KubernetesVersion))...)
+
+	nodePlan.Instructions = append(nodePlan.Instructions, encryptionKeyRotationWaitForSystemctlStatusInstruction(cp))
 
 	if isControlPlane(entry) {
 		nodePlan.Files = append(nodePlan.Files,
@@ -510,10 +484,6 @@ func (p *Planner) encryptionKeyRotationLeaderPhaseReconcile(cp *rkev1.RKEControl
 	}
 
 	nodePlan.Files = append(nodePlan.Files, []plan.File{
-		{
-			Content: base64.StdEncoding.EncodeToString([]byte(idempotentActionScript)),
-			Path:    encryptionKeyRotationScriptPath(cp, encryptionKeyRotationActionPath),
-		},
 		{
 			Content: base64.StdEncoding.EncodeToString([]byte(encryptionKeyRotationWaitForSecretsEncryptStatusScript)),
 			Path:    encryptionKeyRotationScriptPath(cp, encryptionKeyRotationWaitForSecretsEncryptStatusPath),
@@ -627,19 +597,16 @@ func encryptionKeyRotationSecretsEncryptInstruction(cp *rkev1.RKEControlPlane) (
 		return plan.OneTimeInstruction{}, fmt.Errorf("cannot determine desired secrets-encrypt command for phase: [%s]", cp.Status.RotateEncryptionKeysPhase)
 	}
 
-	return plan.OneTimeInstruction{
-		Name:    encryptionKeyRotationSecretsEncryptApplyCommand,
-		Command: "sh",
-		Args: []string{
-			"-xe",
-			encryptionKeyRotationScriptPath(cp, encryptionKeyRotationActionPath),
-			strings.ToLower(fmt.Sprintf("rancher_v2prov_encryption_key_rotation/%s", cp.Status.RotateEncryptionKeysPhase)),
-			strconv.FormatInt(cp.Spec.RotateEncryptionKeys.Generation, 10),
-			capr.GetRuntimeCommand(cp.Spec.KubernetesVersion),
+	return idempotentInstruction(
+		strings.ToLower(fmt.Sprintf("encryption-key-rotation/%s", cp.Status.RotateEncryptionKeysPhase)),
+		strconv.FormatInt(cp.Spec.RotateEncryptionKeys.Generation, 10),
+		capr.GetRuntimeCommand(cp.Spec.KubernetesVersion),
+		[]string{
 			"secrets-encrypt",
 			command,
 		},
-	}, nil
+		[]string{},
+	), nil
 }
 
 // encryptionKeyRotationStatusEnv returns an environment variable in order to force followers to rerun their plans
@@ -727,25 +694,6 @@ func encryptionKeyRotationWaitForSystemctlStatusInstruction(cp *rkev1.RKEControl
 			encryptionKeyRotationGenerationEnv(cp),
 		},
 		SaveOutput: false,
-	}
-}
-
-// encryptionKeyRotationRestartInstruction generates a restart command for the rke2/k3s server, using the last known
-// leader stage in order to ensure that non-init nodes have a refreshed plan if the leader stage changes. If
-// secrets-encrypt commands were run on a node that is not the init node, this ensures that after this situation is
-// identified and the leader is restarted, other control plane nodes will be restarted given that the leader stage will
-// have changed without a corresponding apply command.
-func encryptionKeyRotationRestartInstruction(cp *rkev1.RKEControlPlane) plan.OneTimeInstruction {
-	return plan.OneTimeInstruction{
-		Name:    "restart-service",
-		Command: "systemctl",
-		Args: []string{
-			"restart", capr.GetRuntimeServerUnit(cp.Spec.KubernetesVersion),
-		},
-		Env: []string{
-			encryptionKeyRotationStatusEnv(cp),
-			encryptionKeyRotationGenerationEnv(cp),
-		},
 	}
 }
 

--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -385,10 +385,10 @@ func generateManifestRemovalInstruction(runtime string, entry *planEntry) (bool,
 	}
 	return true, plan.OneTimeInstruction{
 		Name:    "remove server manifests",
-		Command: "rm",
+		Command: "/bin/sh",
 		Args: []string{
-			"-rf",
-			fmt.Sprintf("/var/lib/rancher/%s/server/manifests/%s-*.yaml", runtime, runtime),
+			"-c",
+			fmt.Sprintf("rm -rf /var/lib/rancher/%s/server/manifests/%s-*.yaml", runtime, runtime),
 		},
 	}
 }

--- a/pkg/capr/planner/idempotent.go
+++ b/pkg/capr/planner/idempotent.go
@@ -1,0 +1,104 @@
+package planner
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
+)
+
+const idempotentActionScript = `
+#!/bin/sh
+
+currentHash=""
+key=$1
+targetHash=$2
+hashedCmd=$3
+cmd=$4
+shift 4
+
+dataRoot="/var/lib/rancher/capr/idempotence/$key/$hashedCmd"
+hashFile="$dataRoot/hash"
+attemptFile="$dataRoot/attempt"
+
+currentHash=$(cat "$hashFile" || echo "")
+currentAttempt=$(cat "$attemptFile" || echo "-1")
+
+if [ "$currentHash" != "$targetHash" ] && [ "$currentAttempt" != "$CATTLE_AGENT_ATTEMPT_NUMBER" ]; then
+	mkdir -p "$dataRoot"
+	echo "$targetHash" > "$hashFile"
+	echo "$CATTLE_AGENT_ATTEMPT_NUMBER" > "$attemptFile"
+	exec "$cmd" "$@"
+else
+	echo "action has already been reconciled to the current hash $currentHash at attempt $currentAttempt"
+fi
+`
+
+const (
+	idempotentActionScriptPath = "/var/lib/rancher/capr/idempotence/idempotent.sh"
+)
+
+var idempotentScriptFile = plan.File{
+	Content: base64.StdEncoding.EncodeToString([]byte(idempotentActionScript)),
+	Path:    idempotentActionScriptPath,
+	Dynamic: true,
+	Minor:   true,
+}
+
+// idempotentInstruction generates an idempotent action instruction that will execute the given command + args exactly once.
+// It works by running a script that writes the given "value" to a file at /var/lib/rancher/idempotence/<identifier>/<hashedCommand>,
+// and checks this file to determine if it needs to run the instruction again. Notably, `identifier` must be a valid relative path.
+func idempotentInstruction(identifier, value, command string, args []string, env []string) plan.OneTimeInstruction {
+	hashedCommand := PlanHash([]byte(command))
+	hashedValue := PlanHash([]byte(value))
+	return plan.OneTimeInstruction{
+		Name:    fmt.Sprintf("idempotent-%s-%s-%s", identifier, hashedValue, hashedCommand),
+		Command: "/bin/sh",
+		Args: append([]string{
+			"-x",
+			idempotentActionScriptPath,
+			strings.ToLower(identifier),
+			hashedValue,
+			hashedCommand,
+			command},
+			args...),
+		Env: env,
+	}
+}
+
+// convertToIdempotentInstruction converts a OneTimeInstruction to a OneTimeInstruction wrapped with the idempotent script.
+// This is useful when an instruction may be used in various phases, without needing idempotency in all cases.
+func convertToIdempotentInstruction(identifier, value string, instruction plan.OneTimeInstruction) plan.OneTimeInstruction {
+	newInstruction := idempotentInstruction(identifier, value, instruction.Command, instruction.Args, instruction.Env)
+	newInstruction.Image = instruction.Image
+	newInstruction.SaveOutput = instruction.SaveOutput
+	return newInstruction
+}
+
+// idempotentRestartInstructions generates an idempotent restart instructions for the given runtimeUnit. It checks the
+// unit for failure, resets it if necessary, and restarts the unit.
+func idempotentRestartInstructions(identifier, value, runtimeUnit string) []plan.OneTimeInstruction {
+	return []plan.OneTimeInstruction{
+		idempotentInstruction(
+			identifier+"-reset-failed",
+			value,
+			"/bin/sh",
+			[]string{
+				"-c",
+				fmt.Sprintf("if [ $(systemctl is-failed %s) = failed ]; then systemctl reset-failed %s; fi", runtimeUnit, runtimeUnit),
+			},
+			[]string{},
+		),
+		idempotentInstruction(
+			identifier+"-restart",
+			value,
+			"systemctl",
+			[]string{
+				"restart",
+				runtimeUnit,
+			},
+			[]string{},
+		),
+	}
+}

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -1071,6 +1071,9 @@ func (p *Planner) generatePlanWithConfigFiles(controlPlane *rkev1.RKEControlPlan
 		}
 
 		nodePlan, err = addOtherFiles(nodePlan, controlPlane, entry)
+
+		nodePlan.Files = append(nodePlan.Files, idempotentScriptFile)
+
 		return nodePlan, config, joinedServer, err
 	}
 	return plan.NodePlan{}, map[string]interface{}{}, "", nil

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -96,7 +96,7 @@ var (
 	WinsAgentVersion                    = NewSetting("wins-agent-version", "")
 	CSIProxyAgentVersion                = NewSetting("csi-proxy-agent-version", "")
 	CSIProxyAgentURL                    = NewSetting("csi-proxy-agent-url", "https://acs-mirror.azureedge.net/csi-proxy/%[1]s/binaries/csi-proxy-%[1]s.tar.gz")
-	SystemAgentInstallScript            = NewSetting("system-agent-install-script", "https://raw.githubusercontent.com/rancher/system-agent/v0.3.3-rc3/install.sh")
+	SystemAgentInstallScript            = NewSetting("system-agent-install-script", "https://raw.githubusercontent.com/rancher/system-agent/v0.3.3-rc4/install.sh")
 	WinsAgentInstallScript              = NewSetting("wins-agent-install-script", "https://raw.githubusercontent.com/rancher/wins/v0.4.11/install.ps1")
 	SystemAgentInstallerImage           = NewSetting("system-agent-installer-image", "rancher/system-agent-installer-")
 	SystemAgentUpgradeImage             = NewSetting("system-agent-upgrade-image", "")

--- a/tests/v2prov/nodeconfig/nodeconfig.go
+++ b/tests/v2prov/nodeconfig/nodeconfig.go
@@ -79,48 +79,22 @@ func NewPodConfig(clients *clients.Clients, namespace string) (*corev1.ObjectRef
 	podConfig.SetGenerateName("pod-config-")
 	podConfig.Object["image"] = defaults.PodTestImage
 	// We are providing custom userdata to force K3s/RKE2 to use the cgroupfs cgroup driver, rather than systemd
-	// We must also drop-in replace the type of service for systemd as we are clearing the notify socket which would
-	// normally cause systemd to hang waiting for the unit to activate. Eventually, when
-	// https://github.com/rancher/rke2/issues/3240 is resolved, we should be able to roll back this workaround. If the
-	// linked github issue is resolved, we should roll back this change here as well as in
-	// v2prov/systemdnode.
 	// We have to set invocation disabling on the rancher-system-agent because it runs rke2/k3s server on restore and this has cgroup issues
 	podConfig.Object["userdata"] = `#cloud-config
 write_files:
 - content: |
-    [Service]
-    Type=exec
-  path: /etc/systemd/system/rke2-server.service.d/10-delegate.conf
-- content: |
-    [Service]
-    Type=exec
-  path: /etc/systemd/system/rke2-agent.service.d/10-delegate.conf
-- content: |
-    [Service]
-    Type=exec
-  path: /etc/systemd/system/k3s.service.d/10-delegate.conf
-- content: |
-    [Service]
-    Type=exec
-  path: /etc/systemd/system/k3s-agent.service.d/10-delegate.conf
-- content: |
-    NOTIFY_SOCKET=
     INVOCATION_ID=
   path: /etc/default/rke2-server
 - content: |
-    NOTIFY_SOCKET=
     INVOCATION_ID=
   path: /etc/default/rke2-agent
 - content: |
-    NOTIFY_SOCKET=
     INVOCATION_ID=
   path: /etc/default/k3s
 - content: |
-    NOTIFY_SOCKET=
     INVOCATION_ID=
   path: /etc/default/k3s-agent
 - content: |
-    NOTIFY_SOCKET=
     INVOCATION_ID=
   path: /etc/default/rancher-system-agent`
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/41587
https://github.com/rancher/rancher/issues/41125
https://github.com/rancher/rancher/issues/41174

## Problem
This PR tackles CI flakiness with CAPR provisioning tests in Rancher. A couple of issues were identified, and are addressed as part of this PR.

1. Overriding the Type of systemd unit and clearing the `NOTIFY_SOCKET` environment variable lead to premature actions against K3s/RKE2 as the units do not wait for activation.
2. After clearing the `NOTIFY_SOCKET`, the planner started delivering plans that would restart units repeatedly, and K3s/RKE2 are brittle at handling successive restarts.
3. The `kube-scheduler` certificate rotation instructions did not rotate the correct files.
4. The `rm -rf /var/lib/rancher/rke2/server/manifests/rke2-*.yaml` instruction did not handle the `*` correctly

## Solution
1. As K3s/RKE2 have fixed their cgroups detection behavior to no longer rely on the `NOTIFY_SOCKET` environment variable, we can drop the workaround that cleared `NOTIFY_SOCKET` and the `Type` workaround.
2. The `rancher-system-agent` as designed executes the latest received plan on startup. The plans are supposed to be idempotent, but were not properly idempotent around important commands in encryption key rotation + certificate rotation. This PR adds a new idempotent.go file that contains helpers to create idempotent instructions.
3. This PR adds a fix to certificate rotation instructions for kube-scheduler to ensure we rotate the correct file, and adds a additional unit test cases to validate that this change is effective.
4. We now use `/bin/sh -c` to execute `rm -rf` to ensure proper variable expansion occurs.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
I manually ran the various v2prov integration tests and ensured they passed as designed.

Specifically, for the `kube-scheduler` certificate rotation issue, I tested this:
First:
```
kskcm-pool1-2876d649-4xn4n:/var/lib/rancher/rke2/server/tls # openssl x509 -enddate -noout -in /var/lib/rancher/rke2/server/tls/kube-scheduler/kube-scheduler.crt
notAfter=May 18 13:58:32 2024 GMT
kskcm-pool1-2876d649-4xn4n:/var/lib/rancher/rke2/server/tls # openssl x509 -enddate -noout -in /var/lib/rancher/rke2/server/tls/kube-controller-manager/kube-controller-manager.crt
notAfter=May 18 13:58:32 2024 GMT
```

then, I performed a selective rotation of scheduler, to see:
```
kskcm-pool1-2876d649-4xn4n:/var/lib/rancher/rke2/server/tls # openssl x509 -enddate -noout -in /var/lib/rancher/rke2/server/tls/kube-scheduler/kube-scheduler.crt
notAfter=May 18 14:03:30 2024 GMT
kskcm-pool1-2876d649-4xn4n:/var/lib/rancher/rke2/server/tls # openssl x509 -enddate -noout -in /var/lib/rancher/rke2/server/tls/kube-controller-manager/kube-controller-manager.crt
notAfter=May 18 13:58:32 2024 GMT
```

then, did a selective rotation of the kube-controller-manager to see: 
```
kskcm-pool1-2876d649-4xn4n:/var/lib/rancher/rke2/server/tls # openssl x509 -enddate -noout -in /var/lib/rancher/rke2/server/tls/kube-scheduler/kube-scheduler.crt
notAfter=May 18 14:03:30 2024 GMT
kskcm-pool1-2876d649-4xn4n:/var/lib/rancher/rke2/server/tls # openssl x509 -enddate -noout -in /var/lib/rancher/rke2/server/tls/kube-controller-manager/kube-controller-manager.crt
notAfter=May 18 14:12:38 2024 GMT
```

Please note that with the selective rotation of `kube-controller-manager` I hit: https://github.com/rancher/rancher/issues/41613 and had to workaround it by 
```
kubectl delete mutatingwebhookconfiguration rancher.cattle.io; kubectl delete validatingwebhookconfiguration rancher.cattle.io; systemctl restart rke2-server
```

In regards to the restore issue, I took a snapshot on `v1.24.13+rke2r1`, upgraded to `v1.25.x`, waited for cluster health, then rolled back and confirmed the manifest files were no longer there.

### Automated Testing
This PR is almost entirely around automated testing, and the CI framework itself should be enough to prove functionality.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->