### PR TITLE
[v2.6] - Adding external registry configuration capability to registry tests

### DIFF
--- a/tests/v2/validation/registries/config.go
+++ b/tests/v2/validation/registries/config.go
@@ -2,6 +2,14 @@ package registries
 
 const RegistriesConfigKey = "registries"
 
+type ExistingAuthRegistryConfig struct {
+	Username string `json:"username" yaml:"username" default:""`
+	Password string `json:"password" yaml:"password" default:""`
+	URL      string `json:"url" yaml:"url" default:""`
+}
+
 type Registries struct {
-	RegistryConfigNames []string `json:"registryConfigNames" yaml:"registryConfigNames" default:"[]"`
+	RegistryConfigNames       []string                    `json:"registryConfigNames" yaml:"registryConfigNames" default:"[]"`
+	ExistingNoAuthRegistryURL string                      `json:"existingNoAuthRegistry" yaml:"existingNoAuthRegistry" default:""`
+	ExistingAuthRegistryInfo  *ExistingAuthRegistryConfig `json:"existingAuthRegistry" yaml:"existingAuthRegistry" default:""`
 }

--- a/tests/v2/validation/registries/registry_test.go
+++ b/tests/v2/validation/registries/registry_test.go
@@ -65,6 +65,12 @@ func (rt *RegistryTestSuite) SetupSuite() {
 	require.NoError(rt.T(), err)
 	configPackage := corral.CorralPackagesConfig()
 
+	globalRegistryFqdn := ""
+	registryDisabledFqdn := ""
+	registryEnabledUsername := ""
+	registryEnabledPassword := ""
+	registryEnabledFqdn := ""
+
 	useRegistries := client.Flags.GetValue(environmentflag.UseExistingRegistries)
 	logrus.Infof("The value of useRegistries is %t", useRegistries)
 
@@ -78,8 +84,28 @@ func (rt *RegistryTestSuite) SetupSuite() {
 				logrus.Errorf("error creating corral: %v", err)
 			}
 		}
+		registryDisabledFqdn, err = corral.GetCorralEnvVar(corralAuthDisabledName, "registry_fqdn")
+		require.NoError(rt.T(), err)
+		logrus.Infof("RegistryNoAuth FQDN %s", registryDisabledFqdn)
+		registryEnabledUsername, err = corral.GetCorralEnvVar(corralAuthEnabledName, "registry_username")
+		require.NoError(rt.T(), err)
+		logrus.Infof("RegistryAuth Username %s", registryEnabledUsername)
+		registryEnabledPassword, err = corral.GetCorralEnvVar(corralAuthEnabledName, "registry_password")
+		require.NoError(rt.T(), err)
+		logrus.Infof("RegistryAuth Password %s", registryEnabledPassword)
+		registryEnabledFqdn, err = corral.GetCorralEnvVar(corralAuthEnabledName, "registry_fqdn")
+		require.NoError(rt.T(), err)
+		logrus.Infof("RegistryAuth FQDN %s", registryEnabledFqdn)
 	} else {
 		logrus.Infof("Using Existing Registries because value of useRegistries is %t", useRegistries)
+		registryDisabledFqdn = registriesConfig.ExistingNoAuthRegistryURL
+		registryEnabledFqdn = registriesConfig.ExistingAuthRegistryInfo.URL
+		registryEnabledUsername = registriesConfig.ExistingAuthRegistryInfo.Username
+		registryEnabledPassword = registriesConfig.ExistingAuthRegistryInfo.Password
+		logrus.Infof("RegistryNoAuth FQDN %s", registryDisabledFqdn)
+		logrus.Infof("RegistryAuth Username %s", registryEnabledUsername)
+		logrus.Infof("RegistryAuth Password %s", registryEnabledPassword)
+		logrus.Infof("RegistryAuth FQDN %s", registryEnabledFqdn)
 	}
 
 	clustersConfig := new(provisioning.Config)
@@ -89,27 +115,32 @@ func (rt *RegistryTestSuite) SetupSuite() {
 	nodesAndRoles := clustersConfig.NodesAndRolesRKE1
 	providers := clustersConfig.Providers
 
-	globalRegistryFqdn := ""
 	rt.rancherUsesRegistry = false
-	globalRegistryFqdn, err = corral.GetCorralEnvVar(corralRancherName, "registry_fqdn")
+	listOfCorrals, err := corral.ListCorral()
 	require.NoError(rt.T(), err)
-	if globalRegistryFqdn != "<nil>" {
-		rt.rancherUsesRegistry = true
-		logrus.Infof("Rancher Global Registry FQDN %s", globalRegistryFqdn)
+	_, corralExist := listOfCorrals[corralRancherName]
+	if corralExist {
+		globalRegistryFqdn, err = corral.GetCorralEnvVar(corralRancherName, "registry_fqdn")
+		require.NoError(rt.T(), err)
+		if globalRegistryFqdn != "<nil>" {
+			rt.rancherUsesRegistry = true
+			logrus.Infof("Rancher Global Registry FQDN %s", globalRegistryFqdn)
+		}
+		logrus.Infof("Rancher was built using corral: %t", corralExist)
+		logrus.Infof("Is Rancher using a global registry: %t", rt.rancherUsesRegistry)
+	} else {
+		if useRegistries {
+			globalRegistryFqdn = registriesConfig.ExistingNoAuthRegistryURL
+			rt.rancherUsesRegistry = true
+			logrus.Infof("Rancher was built using corral: %t", corralExist)
+			logrus.Infof("Is Rancher using a global registry: %t", rt.rancherUsesRegistry)
+			logrus.Infof("Rancher Global Registry FQDN %s", globalRegistryFqdn)
+		} else {
+			rt.rancherUsesRegistry = false
+			logrus.Infof("Rancher was built using corral: %t", corralExist)
+			logrus.Infof("Is Rancher using a global registry: %t", rt.rancherUsesRegistry)
+		}
 	}
-	logrus.Infof("Is Rancher using a global registry: %t", rt.rancherUsesRegistry)
-	registryDisabledFqdn, err := corral.GetCorralEnvVar(corralAuthDisabledName, "registry_fqdn")
-	require.NoError(rt.T(), err)
-	logrus.Infof("RegistryNoAuth FQDN %s", registryDisabledFqdn)
-	registryEnabledUsername, err := corral.GetCorralEnvVar(corralAuthEnabledName, "registry_username")
-	require.NoError(rt.T(), err)
-	logrus.Infof("RegistryAuth Username %s", registryEnabledUsername)
-	registryEnabledPassword, err := corral.GetCorralEnvVar(corralAuthEnabledName, "registry_password")
-	require.NoError(rt.T(), err)
-	logrus.Infof("RegistryAuth Password %s", registryEnabledPassword)
-	registryEnabledFqdn, err := corral.GetCorralEnvVar(corralAuthEnabledName, "registry_fqdn")
-	require.NoError(rt.T(), err)
-	logrus.Infof("RegistryAuth FQDN %s", registryEnabledFqdn)
 
 	var privateRegistriesNoAuth []management.PrivateRegistry
 	privateRegistry := management.PrivateRegistry{}
@@ -183,6 +214,7 @@ func (rt *RegistryTestSuite) testProvisionRKE1Cluster(client *rancher.Client, pr
 	require.NoError(rt.T(), err)
 
 	nodePoolName := nodePool.Name
+
 	opts := metav1.ListOptions{
 		FieldSelector:  "metadata.name=" + clusterResp.ID,
 		TimeoutSeconds: &defaults.WatchTimeoutSeconds,


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
Private registries tests create new registries only for running the tests on clusters. 
 
## Problem

Creating new registries during test setup take time between tests runs. If there are multiple runs needed.

 
## Solution
This adds the capability of setup configuration using existing registries. This is mainly for downstream clusters.
The local cluster is configured during the setup build with Corral. And there's a [change already in](https://github.com/rancherlabs/corral-packages/pull/9) corral packages for this.

This adds support for both type of registries. Auth and No Auth.


### Automated Testing
Testing adding existing registries flags with the new existing registries configuration keys.
Test run without specifying registries. Test keep creating new registries for the setup as expected.

## QA Testing Considerations
None
 
### Regressions Considerations
Just the private registries automated tests are impacted by the change.


### New configuration keys structure:

```yaml
registries:
  existingAuthRegistry:
    password: <password>
    url: <auth registry url>
    username: <auth registry username>
  existingNoAuthRegistry: <no auth registry url>
```