### PR TITLE
[v2.6] Modify how SKU is formatted in aks.tf

### DIFF
--- a/tests/validation/tests/v3_api/resource/terraform/aks/aks.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/aks/aks.tf
@@ -25,8 +25,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   resource_group_name = azurerm_resource_group.default.name
   dns_prefix          = "taaks${random_string.random.result}"
   kubernetes_version  = var.kubernetes_version
-  sku_tier            = "Paid"
-  role_based_access_control_enabled = true
+  sku_tier            = var.sku_tier
 
   default_node_pool {
     name            = "taaks${random_string.random.result}"

--- a/tests/validation/tests/v3_api/resource/terraform/aks/variables.tf
+++ b/tests/validation/tests/v3_api/resource/terraform/aks/variables.tf
@@ -26,3 +26,7 @@ variable "disk_capacity" {
 variable "cluster_name" {
   default = "testautoaks"
 }
+
+variable "sku_tier" {
+  default = "Paid"
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The HA deploy automation job appears to be failing with AKS due to how the SKU tier is formatted in `aks.tf`. The automation incorrectly states that the SKU used is wrong, when it is not.

What's incorrect is the syntax we are using in TF to call it, so that needs to be adjusted.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Refactored the TF call for SKU tier.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Jenkins run will be given offline to reviewers.