### PR TITLE
Fix RKE2/K3S cluster config in hostname truncation test

### DIFF
--- a/tests/v2/validation/provisioning/rke2/hostname_truncation.go
+++ b/tests/v2/validation/provisioning/rke2/hostname_truncation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/integration/pkg/defaults"
+	provisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
 	name2 "github.com/rancher/wrangler/pkg/name"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-func TestHostnameTruncation(t *testing.T, client *rancher.Client, provider Provider, machinePools []provv1.RKEMachinePool, defaultHostnameLengthLimit int, kubeVersion, cni string) {
+func TestHostnameTruncation(t *testing.T, client *rancher.Client, provider Provider, machinePools []provv1.RKEMachinePool, defaultHostnameLengthLimit int, kubeVersion, cni string, advancedOptions provisioning.AdvancedOptions) {
 	cloudCredential, err := provider.CloudCredFunc(client)
 	require.NoError(t, err)
 
@@ -44,7 +45,7 @@ func TestHostnameTruncation(t *testing.T, client *rancher.Client, provider Provi
 		machinePools[i].WorkerRole = true
 	}
 
-	cluster := clusters.NewK3SRKE2ClusterConfig("", namespace, cni, cloudCredential.ID, kubeVersion, "", machinePools)
+	cluster := clusters.NewK3SRKE2ClusterConfig("", namespace, cni, cloudCredential.ID, kubeVersion, "", machinePools, advancedOptions)
 
 	cluster.GenerateName = "t-"
 	cluster.Spec.RKEConfig.MachinePoolDefaults.HostnameLengthLimit = defaultHostnameLengthLimit

--- a/tests/v2/validation/provisioning/rke2/hostname_truncation_test.go
+++ b/tests/v2/validation/provisioning/rke2/hostname_truncation_test.go
@@ -20,6 +20,7 @@ type HostnameTruncationTestSuite struct {
 	kubernetesVersions []string
 	cnis               []string
 	providers          []string
+	advancedOptions    provisioning.AdvancedOptions
 }
 
 func (r *HostnameTruncationTestSuite) TearDownSuite() {
@@ -36,6 +37,7 @@ func (r *HostnameTruncationTestSuite) SetupSuite() {
 	r.kubernetesVersions = clustersConfig.RKE2KubernetesVersions
 	r.cnis = clustersConfig.CNIs
 	r.providers = clustersConfig.Providers
+	r.advancedOptions = clustersConfig.AdvancedOptions
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(r.T(), err)
@@ -153,7 +155,7 @@ func (r *HostnameTruncationTestSuite) TestProvisioningRKE2Cluster() {
 							client, err := r.client.WithSession(subSession)
 							require.NoError(r.T(), err)
 
-							TestHostnameTruncation(r.T(), client, provider, tt.machinePools, limit, kubeVersion, cni)
+							TestHostnameTruncation(r.T(), client, provider, tt.machinePools, limit, kubeVersion, cni, r.advancedOptions)
 
 							subSession.Cleanup()
 						}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
There were recent changes to the framework to add support for cluster/fleet agent customization. One area we forgot to update was in the new `hostname_truncation_test.go`, we didn't update the cluster configuration function for RKE2/K3S. This PR makes that fix.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Add the required parameter needed to not have this function call out error out for the hostname truncation feature.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
It's a very small fix, but can provide a freeform job if it's needed.