### PR TITLE
dialer: compare error with `errors.Is`

### DIFF
--- a/pkg/clusterrouter/proxy/proxy_server.go
+++ b/pkg/clusterrouter/proxy/proxy_server.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -234,7 +235,7 @@ func (r *RemoteService) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			return
 		}
 		token, err := r.getImpersonatorAccountToken(userInfo)
-		if err != nil && !strings.Contains(err.Error(), dialer2.ErrAgentDisconnected.Error()) {
+		if err != nil && !errors.Is(err, dialer2.ErrAgentDisconnected) {
 			er.Error(rw, req, fmt.Errorf("unable to create impersonator account: %w", err))
 			return
 		}

--- a/pkg/controllers/management/node/cleanup.go
+++ b/pkg/controllers/management/node/cleanup.go
@@ -68,7 +68,7 @@ func (m *Lifecycle) deleteV1Node(node *v3.Node) (runtime.Object, error) {
 		ctx, node.Status.NodeName, metav1.DeleteOptions{})
 	if err != nil && !kerror.IsNotFound(err) &&
 		ctx.Err() != context.DeadlineExceeded &&
-		!strings.Contains(err.Error(), dialer.ErrAgentDisconnected.Error()) &&
+		!errors.Is(err, dialer.ErrAgentDisconnected) &&
 		!strings.Contains(err.Error(), "connection refused") {
 		return node, err
 	}
@@ -255,7 +255,7 @@ func (m *Lifecycle) createCleanupJob(userContext *config.UserContext, cluster *v
 		LabelSelector: fmt.Sprintf("%s=%s", nodeLabel, node.Name),
 	})
 	if err != nil && !kerror.IsNotFound(err) {
-		if strings.Contains(err.Error(), dialer.ErrAgentDisconnected.Error()) ||
+		if errors.Is(err, dialer.ErrAgentDisconnected) ||
 			strings.Contains(err.Error(), "connection refused") {
 			return nil, nil // can't connect, just continue on with deleting v3 node
 		}

--- a/pkg/dialer/factory.go
+++ b/pkg/dialer/factory.go
@@ -29,7 +29,10 @@ const (
 	WaitForAgentError = "waiting for cluster [%s] agent to connect"
 )
 
-var ErrAgentDisconnected = errors.New("cluster agent disconnected")
+var (
+	ErrAgentDisconnected = errors.New("cluster agent disconnected")
+	ErrNodeNotFound      = errors.New("node not found")
+)
 
 func NewFactory(apiContext *config.ScaledContext, wrangler *wrangler.Context) (*Factory, error) {
 	return &Factory{
@@ -292,7 +295,7 @@ func (f *Factory) DockerDialer(clusterName, machineName string) (dialer.Dialer, 
 		}, nil
 	}
 
-	return nil, fmt.Errorf("can not build dialer to [%s:%s]", clusterName, machineName)
+	return nil, fmt.Errorf("can not build dialer to [%s:%s]: %w", clusterName, machineName, ErrNodeNotFound)
 }
 
 func (f *Factory) NodeDialer(clusterName, machineName string) (dialer.Dialer, error) {
@@ -317,7 +320,7 @@ func (f *Factory) nodeDialer(clusterName, machineName string) (dialer.Dialer, er
 		return dialer.Dialer(d), nil
 	}
 
-	return nil, fmt.Errorf("can not build dialer to [%s:%s]", clusterName, machineName)
+	return nil, fmt.Errorf("can not build dialer to [%s:%s]: %w", clusterName, machineName, ErrNodeNotFound)
 }
 
 func machineSessionKey(machine *v3.Node) string {

--- a/pkg/ref/parse.go
+++ b/pkg/ref/parse.go
@@ -8,15 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-var NodeNotFound = "can not build dialer to"
-
-func IsNodeNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), NodeNotFound)
-}
-
 func FromStrings(namespace, name string) string {
 	return fmt.Sprintf("%s:%s", namespace, name)
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
Hello :wave:, first-time contributor here.

Error comparison using `strings.Contains` is not idiomatic Go code. Starting from Go 1.13, `errors.Is` is the preferable way to compare error equality [^1]

[^1]: https://go.dev/blog/go1.13-errors#examining-errors-with-is-and-as

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
This PR replaces the existing error comparison of dialer errors to use `errors.Is` instead of `strings.Contains`.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->