### PR TITLE
resolving conflicts

### DIFF
--- a/tests/v2/validation/rbac/rbac.go
+++ b/tests/v2/validation/rbac/rbac.go
@@ -48,6 +48,7 @@ type ClusterConfig struct {
 	externalNodeProvider provisioning.ExternalNodeProvider
 	kubernetesVersion    string
 	cni                  string
+	advancedOptions      provisioning.AdvancedOptions
 }
 
 func createUser(client *rancher.Client, role string) (*management.User, error) {
@@ -233,12 +234,13 @@ func getClusterConfig() *ClusterConfig {
 
 	kubernetesVersion := userConfig.RKE1KubernetesVersions[0]
 	cni := userConfig.CNIs[0]
+	advancedOptions := userConfig.AdvancedOptions
 	nodeProviders := userConfig.NodeProviders[0]
 
 	externalNodeProvider := provisioning.ExternalNodeProviderSetup(nodeProviders)
 
 	clusterConfig := ClusterConfig{nodeRoles: nodeAndRoles, externalNodeProvider: externalNodeProvider,
-		kubernetesVersion: kubernetesVersion, cni: cni}
+		kubernetesVersion: kubernetesVersion, cni: cni, advancedOptions: advancedOptions}
 
 	return &clusterConfig
 }

--- a/tests/v2/validation/rbac/rbac_test.go
+++ b/tests/v2/validation/rbac/rbac_test.go
@@ -611,7 +611,7 @@ func (rb *RBTestSuite) TestRBACAdditional() {
 			rb.Run("Additional testcase6 - Validating if "+restrictedAdmin+" can create an RKE1 cluster", func() {
 				clusterConfig := getClusterConfig()
 				rke1.TestProvisioningRKE1CustomCluster(rb.T(), rb.standardUserClient, clusterConfig.externalNodeProvider,
-					clusterConfig.nodeRoles, "", clusterConfig.kubernetesVersion, clusterConfig.cni)
+					clusterConfig.nodeRoles, "", clusterConfig.kubernetesVersion, clusterConfig.cni, clusterConfig.advancedOptions)
 			})
 
 			rb.Run("Additional testcase7 - Validating if "+restrictedAdmin+" can list global settings", func() {


### PR DESCRIPTION
In the rbac test suite, we have a test case where we create an RKE1 custom cluster. We have a new change that went in recently to provision rke1 clusters where there were a few parameters [Advanced options] that need to be added. Resolving the missing parameters in this PR to the rbac suite. 