### PR TITLE
Update service account object with attached secret

### DIFF
--- a/pkg/controllers/capr/bootstrap/controller_test.go
+++ b/pkg/controllers/capr/bootstrap/controller_test.go
@@ -76,11 +76,13 @@ func Test_getBootstrapSecret(t *testing.T) {
 			a.Nil(err)
 
 			serviceAccount, err := handler.serviceAccountCache.Get(tt.args.namespaceName, tt.args.secretName)
+			a.Nil(err)
 			machine, err := handler.machineCache.Get(tt.args.namespaceName, tt.args.os)
+			a.Nil(err)
 			secret, err := handler.getBootstrapSecret(tt.args.namespaceName, tt.args.secretName, []v1.EnvVar{}, machine)
+			a.Nil(err)
 
 			// assert
-			a.Nil(err)
 			a.NotNil(secret)
 			a.NotNil(serviceAccount)
 			a.NotNil(machine)
@@ -194,13 +196,16 @@ func getSecretCacheMock(ctrl *gomock.Controller, namespace, secretName string) *
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      name,
+				Annotations: map[string]string{
+					"kubernetes.io/service-account.name": secretName,
+				},
 			},
 			Immutable: nil,
 			Data: map[string][]byte{
 				"token": []byte("thisismytokenandiwillprotectit"),
 			},
 			StringData: nil,
-			Type:       "",
+			Type:       "kubernetes.io/service-account-token",
 		}, nil
 	}).AnyTimes()
 	return mockSecretCache

--- a/pkg/serviceaccounttoken/secret_test.go
+++ b/pkg/serviceaccounttoken/secret_test.go
@@ -13,6 +13,29 @@ import (
 )
 
 func TestEnsureSecretForServiceAccount(t *testing.T) {
+	t.Parallel()
+	defaultWantSA := &v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Secrets: []v1.ObjectReference{{
+			Name: "test-token-abcde",
+		}},
+	}
+	defaultWantSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-token-abcde",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"kubernetes.io/service-account.name": "test",
+			},
+		},
+		Data: map[string][]byte{
+			"token": []byte("abcde"),
+		},
+		Type: v1.SecretTypeServiceAccountToken,
+	}
 	tests := []struct {
 		name           string
 		sa             *v1.ServiceAccount
@@ -29,28 +52,8 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			wantSA: &v1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
-				},
-				Secrets: []v1.ObjectReference{{
-					Name: "test-token-abcde",
-				}},
-			},
-			wantSecret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-token-abcde",
-					Namespace: "default",
-					Annotations: map[string]string{
-						"kubernetes.io/service-account.name": "test",
-					},
-				},
-				Data: map[string][]byte{
-					"token": []byte("abcde"),
-				},
-				Type: v1.SecretTypeServiceAccountToken,
-			},
+			wantSA:     defaultWantSA,
+			wantSecret: defaultWantSecret,
 		},
 		{
 			name: "service account with existing secret returns it",
@@ -63,15 +66,7 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 					Name: "test-token-abcde",
 				}},
 			},
-			wantSA: &v1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
-				},
-				Secrets: []v1.ObjectReference{{
-					Name: "test-token-abcde",
-				}},
-			},
+			wantSA: defaultWantSA,
 			existingSecret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-token-abcde",
@@ -85,19 +80,7 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 				},
 				Type: v1.SecretTypeServiceAccountToken,
 			},
-			wantSecret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-token-abcde",
-					Namespace: "default",
-					Annotations: map[string]string{
-						"kubernetes.io/service-account.name": "test",
-					},
-				},
-				Data: map[string][]byte{
-					"token": []byte("abcde"),
-				},
-				Type: v1.SecretTypeServiceAccountToken,
-			},
+			wantSecret: defaultWantSecret,
 		},
 		{
 			name:    "returns error for nil service account",
@@ -114,28 +97,8 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 					Name: "wrong",
 				}},
 			},
-			wantSA: &v1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
-				},
-				Secrets: []v1.ObjectReference{{
-					Name: "test-token-abcde",
-				}},
-			},
-			wantSecret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-token-abcde",
-					Namespace: "default",
-					Annotations: map[string]string{
-						"kubernetes.io/service-account.name": "test",
-					},
-				},
-				Data: map[string][]byte{
-					"token": []byte("abcde"),
-				},
-				Type: v1.SecretTypeServiceAccountToken,
-			},
+			wantSA:     defaultWantSA,
+			wantSecret: defaultWantSecret,
 		},
 		{
 			name: "secret of wrong type gets recreated",
@@ -148,15 +111,7 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 					Name: "test-token-xyz",
 				}},
 			},
-			wantSA: &v1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
-				},
-				Secrets: []v1.ObjectReference{{
-					Name: "test-token-abcde",
-				}},
-			},
+			wantSA: defaultWantSA,
 			existingSecret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-token-xyz",
@@ -170,19 +125,7 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 				},
 				Type: v1.SecretTypeOpaque,
 			},
-			wantSecret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-token-abcde",
-					Namespace: "default",
-					Annotations: map[string]string{
-						"kubernetes.io/service-account.name": "test",
-					},
-				},
-				Data: map[string][]byte{
-					"token": []byte("abcde"),
-				},
-				Type: v1.SecretTypeServiceAccountToken,
-			},
+			wantSecret: defaultWantSecret,
 		},
 		{
 			name: "secret for wrong service account type gets recreated",
@@ -195,15 +138,7 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 					Name: "test-token-xyz",
 				}},
 			},
-			wantSA: &v1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
-				},
-				Secrets: []v1.ObjectReference{{
-					Name: "test-token-abcde",
-				}},
-			},
+			wantSA: defaultWantSA,
 			existingSecret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-token-xyz",
@@ -217,24 +152,14 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 				},
 				Type: v1.SecretTypeServiceAccountToken,
 			},
-			wantSecret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-token-abcde",
-					Namespace: "default",
-					Annotations: map[string]string{
-						"kubernetes.io/service-account.name": "test",
-					},
-				},
-				Data: map[string][]byte{
-					"token": []byte("abcde"),
-				},
-				Type: v1.SecretTypeServiceAccountToken,
-			},
+			wantSecret: defaultWantSecret,
 		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var k8sClient *fake.Clientset
 			objs := []runtime.Object{}
 			if tt.sa != nil {


### PR DESCRIPTION
Without this patch, if the first secret stored in the service account object is invalid, the impersonation module will time out waiting for it to become valid. This change ensures that invalid secrets are discarded from the object and only the most recent, known working one is kept. The pointer to the service account is updated so that later references to the secret name will be correct.

This change also ignores the "not found" error if it both fails to update the service account and delete the accompanying secret, because if the service account doesn't exist then the secret is probably already deleted by virtue of its owner reference.

## Issue: https://github.com/rancher/rancher/issues/42020
 
## Problem
If there's a problem with the service account token secret, it will stay on the service account and new secrets will get created to replace it, but the invalid one is always used.
 
## Solution
Replace the secret list instead of appending to it, and update the service account object pointer.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing

Reproduction steps:

1. Add a user to a project
2. As that user, download the kubeconfig for the user.
3. On the cluster, there should be a cattle-impersonation-u-xxx service account in the cattle-impersonation-system namespace, and clusterrole and clusterrolebinding cattle-impersonation-u-xxx.
4. Delete the clusterrolebinding.
5. Edit the service account. Under secrets, replace the secret name with a nonexistent secret ("foo").
6. Use the kubeconfig to make a request in a namespace in the project ("kubectl -n my-ns get pods")

Without this change, this will result in a timeout error. With this change, the request should succeed.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

Added unit tests.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
Relates to https://github.com/rancher/rancher/commit/8f4d60c2228de4672a469d07213778ce53df9433