### PR TITLE
Add support matrix checks for RKE1 custom clusters

### DIFF
--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -146,6 +146,7 @@ func NewRKE1ClusterConfig(clusterName, cni, kubernetesVersion string, psact stri
 				Provider: "metrics-server",
 			},
 			Network: &management.NetworkConfig{
+				Plugin:  cni,
 				MTU:     0,
 				Options: map[string]string{},
 			},

--- a/tests/framework/extensions/rke1/componentchecks/etcdversion.go
+++ b/tests/framework/extensions/rke1/componentchecks/etcdversion.go
@@ -1,0 +1,30 @@
+package componentchecks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
+	"github.com/sirupsen/logrus"
+)
+
+// CheckETCDVersion will check the etcd version on the etcd node in the provisioned RKE1 cluster.
+func CheckETCDVersion(client *rancher.Client, nodes []*nodes.Node, nodeRoles []string) ([]string, error) {
+	var etcdResult []string
+
+	for key, node := range nodes {
+		if strings.Contains(nodeRoles[key], "--etcd") {
+			command := fmt.Sprintf("docker exec etcd etcdctl version")
+			output, err := node.ExecuteCommand(command)
+			if err != nil {
+				return []string{}, err
+			}
+
+			etcdResult = append(etcdResult, output)
+			logrus.Infof(output)
+		}
+	}
+
+	return etcdResult, nil
+}

--- a/tests/framework/extensions/workloads/pods/pod_status.go
+++ b/tests/framework/extensions/workloads/pods/pod_status.go
@@ -46,18 +46,18 @@ func StatusPods(client *rancher.Client, clusterID string) ([]string, []error) {
 				return false, err
 			}
 
+			image := podStatus.ContainerStatuses[0].Image
 			phase := podStatus.Phase
 			if phase == corev1.PodFailed || phase == corev1.PodUnknown {
 				podErrors = append(podErrors, fmt.Errorf("ERROR: %s: %s", pod.Name, podStatus))
-				logrus.Infof("Pod %s is not in an active state", pod.Name)
+				logrus.Infof("Pod %s: Not active | Image %s", pod.Name, image)
 				return false, nil
 			} else if phase == corev1.PodRunning {
 				podResults = append(podResults, fmt.Sprintf("INFO: %s: %s\n", pod.Name, podStatus))
-				logrus.Infof("Pod %s is in an active state!", pod.Name)
-				return true, nil
+				logrus.Infof("Pod %s: Active | Image: %s", pod.Name, image)
 			}
 		}
-		return false, nil
+		return true, nil
 	})
 
 	if err != nil {

--- a/tests/v2/validation/provisioning/rke1/README.md
+++ b/tests/v2/validation/provisioning/rke1/README.md
@@ -256,6 +256,31 @@ Dependencies:
 }
 ```
 
+## RKE1 Support Matrix Checks - K8s Components & Architecture
+Custom clusters have the ability to perform RKE1 support matrix checks for K8s components & architectures. 
+
+To do this, ensure that your `provisioningInput` has `flannel` and `canal` both defined, along with your desired K8s versions as shown below:
+
+```json
+"provisioningInput": {
+    "nodesAndRolesRKE1": [ 
+      {
+        "etcd": true,
+        "controlplane": true,
+        "quantity": 1,
+      },
+      {
+        "worker": true,
+        "quantity": 2,
+      },
+    ],
+    "rke1KubernetesVersion": ["v1.25.9-rancher2-1", "v1.26.4-rancher2-1"],
+    "nodeProviders": ["ec2"],
+    "cni": ["flannel", "canal"],
+    "psact": ""
+  }
+```
+
 ## Advanced Settings
 This encapsulates any other setting that is applied in the cluster.spec. Currently we have support for:
 * cluster agent customization 

--- a/tests/v2/validation/provisioning/rke1/custom_cluster.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster.go
@@ -11,6 +11,7 @@ import (
 	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
 	"github.com/rancher/rancher/tests/framework/extensions/pipeline"
 	psadeploy "github.com/rancher/rancher/tests/framework/extensions/psact"
+	matrix "github.com/rancher/rancher/tests/framework/extensions/rke1/componentchecks"
 	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
 	"github.com/rancher/rancher/tests/framework/extensions/tokenregistration"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
@@ -105,6 +106,10 @@ func TestProvisioningRKE1CustomCluster(t *testing.T, client *rancher.Client, ext
 	podResults, podErrors := pods.StatusPods(client, clusterResp.ID)
 	assert.NotEmpty(t, podResults)
 	assert.Empty(t, podErrors)
+
+	etcdVersion, err := matrix.CheckETCDVersion(client, nodes, rolesPerPool)
+	require.NoError(t, err)
+	assert.NotEmpty(t, etcdVersion)
 
 	if psact == string(provisioning.RancherPrivileged) || psact == string(provisioning.RancherRestricted) {
 		err = psadeploy.CheckPSACT(client, clusterName)

--- a/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster_test.go
@@ -81,6 +81,8 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 	nodeRolesShared := []nodepools.NodeRoles{provisioning.RKE1EtcdControlPlanePool, provisioning.RKE1WorkerPool}
 	nodeRolesDedicated := []nodepools.NodeRoles{provisioning.RKE1EtcdPool, provisioning.RKE1ControlPlanePool, provisioning.RKE1WorkerPool}
 
+	require.GreaterOrEqual(c.T(), len(c.cnis), 1)
+
 	tests := []struct {
 		name      string
 		nodeRoles []nodepools.NodeRoles
@@ -94,6 +96,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 		{"3 nodes - 1 role per node " + provisioning.AdminClientName.String(), nodeRolesDedicated, c.client, c.psact},
 		{"3 nodes - 1 role per node " + provisioning.StandardClientName.String(), nodeRolesDedicated, c.standardUserClient, c.psact},
 	}
+
 	var name string
 	for _, tt := range tests {
 		testSession := session.NewSession()
@@ -106,9 +109,8 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 			externalNodeProvider := provisioning.ExternalNodeProviderSetup(nodeProviderName)
 			providerName := " Node Provider: " + nodeProviderName
 			for _, kubeVersion := range c.kubernetesVersions {
-				name = tt.name + providerName + " Kubernetes version: " + kubeVersion
 				for _, cni := range c.cnis {
-					name += " cni: " + cni
+					name = tt.name + providerName + " Kubernetes version: " + kubeVersion + " cni: " + cni
 					c.Run(name, func() {
 						TestProvisioningRKE1CustomCluster(c.T(), client, externalNodeProvider, tt.nodeRoles, tt.psact, kubeVersion, cni, c.advancedOptions)
 					})
@@ -119,6 +121,8 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 }
 
 func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomClusterDynamicInput() {
+	require.GreaterOrEqual(c.T(), len(c.cnis), 1)
+
 	clustersConfig := new(provisioning.Config)
 	config.LoadConfig(provisioning.ConfigurationFileKey, clustersConfig)
 	nodesAndRoles := clustersConfig.NodesAndRolesRKE1
@@ -147,9 +151,8 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomClusterDy
 		for _, nodeProviderName := range c.nodeProviders {
 			externalNodeProvider := provisioning.ExternalNodeProviderSetup(nodeProviderName)
 			for _, kubeVersion := range c.kubernetesVersions {
-				name = tt.name + " Kubernetes version: " + kubeVersion
 				for _, cni := range c.cnis {
-					name += " cni: " + cni
+					name = tt.name + " Kubernetes version: " + kubeVersion + " cni: " + cni
 					c.Run(name, func() {
 						TestProvisioningRKE1CustomCluster(c.T(), client, externalNodeProvider, nodesAndRoles, tt.psact, kubeVersion, cni, c.advancedOptions)
 					})


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [[Automation] Support Matrix checks - Automate RKE1 checks](https://github.com/rancher/qa-tasks/issues/724)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Currently, we manually perform our support matrix checks. This is tedious because we need to provision each supported RKE1 version for that Rancher release and then check the etcd, canal and flannel versions. We should  have a way to have this automated so that we don't need to manually do this anymore.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This PR checks the etcd, canal and flannel image versions across each supported K8s version for the release for CNIs canal and flannel. This is done through adding a separate test run in the `custom_clusters_test.go` file to eliminate code redundancy when provisioning RKE1 clusters.

Additionally, there was a small bug with not all of the pods status being shown after the cluster successfully provisions; fixed that as part of this PR.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Locally tested against v1.26 and v1.25 with canal and flannel; worked as expected.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Offline Jenkins jobs will be given to the reviewers.