### PR TITLE
Upgrade the apiserver version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/common v0.37.0
 	github.com/rancher/aks-operator v1.1.1-rc2
-	github.com/rancher/apiserver v0.0.0-20230120214941-e88c32739dc7
+	github.com/rancher/apiserver v0.0.0-20230515173455-c3b182bdbf7d
 	github.com/rancher/channelserver v0.5.1-0.20220405170618-28c9b37deff1
 	github.com/rancher/dynamiclistener v0.3.5
 	github.com/rancher/eks-operator v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1351,8 +1351,8 @@ github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95/go.mod h1:r
 github.com/rancher/aks-operator v1.1.1-rc2 h1:c7Ca+dW1+Kp+EVYcyrqa6gWmb0FMQzKnlK6OewIAMjI=
 github.com/rancher/aks-operator v1.1.1-rc2/go.mod h1:vH7uVTYNZjAC7wJ6oYnefwwoQJxCPwAznvmH1d+Nll8=
 github.com/rancher/apiserver v0.0.0-20201023000256-1a0a904f9197/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
-github.com/rancher/apiserver v0.0.0-20230120214941-e88c32739dc7 h1:Ob72oeF0iM8gWEMh+qKT5e1pzTwQU70I5kx4gMaqCmI=
-github.com/rancher/apiserver v0.0.0-20230120214941-e88c32739dc7/go.mod h1:xwQhXv3XFxWfA6tLa4ZeaERu8ldNbyKv2sF+mT+c5WA=
+github.com/rancher/apiserver v0.0.0-20230515173455-c3b182bdbf7d h1:RT8bn3teE6tsYcSRBli1yVINqrETVqiD8e5uqGg8nmc=
+github.com/rancher/apiserver v0.0.0-20230515173455-c3b182bdbf7d/go.mod h1:GSUg2KPauynfyEk9kqeHE5sFa/Zd8ilsmXqSSzqynQQ=
 github.com/rancher/aws-iam-authenticator v0.5.9-0.20220713170329-78acb8c83863 h1:7cVEMgwyiVhLyu/Ywuw58mkkh9cWpFE3+X8IrWncBxU=
 github.com/rancher/aws-iam-authenticator v0.5.9-0.20220713170329-78acb8c83863/go.mod h1:6dId2LCc8oHqeBzP6E8ndp4DflhKTxYLb5ZXwI4YmFA=
 github.com/rancher/channelserver v0.5.1-0.20220405170618-28c9b37deff1 h1:NMYQzCtLEEaJZ2xleLzDixN6Y+yO9ShzgsjHDg4zOrk=


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40296
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
We get a panic on some apiserver logs when in debug mode
 
## Solution
Fix was made in https://github.com/rancher/apiserver/pull/23

This just updates the apiserver version to include the fix by running `go get -u github.com/rancher/apiserver`
 
## Testing
1. Start Rancher with the --debug flag
1. Create a standard user with no roles or privileges
1. Login as that standard user
1. navigate to `v1/management.cattle.io.globalroles/podsecurityadmissionconfigurationtemplates-manage`