### PR TITLE
Support for k3s and rke2 cluster types in private registries validations

### DIFF
--- a/tests/framework/extensions/secrets/template.go
+++ b/tests/framework/extensions/secrets/template.go
@@ -6,12 +6,13 @@ import (
 )
 
 // NewSecretTemplate is a constructor that creates the secret template for secrets
-func NewSecretTemplate(secretName, namespaceName string, data map[string][]byte) corev1.Secret {
+func NewSecretTemplate(secretName, namespaceName string, data map[string][]byte, secType corev1.SecretType) corev1.Secret {
 	return corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: namespaceName,
 		},
 		Data: data,
+		Type: secType,
 	}
 }

--- a/tests/v2/validation/upgrade/workload_test.go
+++ b/tests/v2/validation/upgrade/workload_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -115,7 +116,7 @@ func (u *UpgradeWorkloadTestSuite) testPreUpgradeSingleCluster(clusterName strin
 	u.T().Logf("Validating daemonset[%v] available replicas number is equal to worker nodes number in the cluster [%v]", names.random["daemonsetName"], project.ClusterID)
 	validateDaemonset(u.T(), client, project.ClusterID, namespace.Name, names.random["daemonsetName"])
 
-	secretTemplate := secrets.NewSecretTemplate(names.random["secretName"], namespace.Name, map[string][]byte{"test": []byte("test")})
+	secretTemplate := secrets.NewSecretTemplate(names.random["secretName"], namespace.Name, map[string][]byte{"test": []byte("test")}, corev1.SecretTypeBasicAuth)
 
 	u.T().Logf("Creating a secret with name [%v]", names.random["secretName"])
 	createdSecret, err := steveClient.SteveType(secrets.SecretSteveType).Create(secretTemplate)


### PR DESCRIPTION
## Problem
The current Private Registries tests only validate RKE1 clusters. 

## Solution
This change adds support to provision RKE2 and K3S clusters.

Additional:
The test structure was refactored and the provisioning method `NewK3SRKE2ClusterConfig` was updated to include the registry hostname and a registry secret as parameter.

I added also a parameter to set the Secret Type in the Secrets' `NewSecretTemplate`

A small fix when running the test with flag `UseExistingRegistries`. When Rancher hadn't the system default registry the test setup code path wasn't getting reached.

### Automated Testing
Ran tests locally

```
--- PASS: TestRegistryTestSuite (3175.16s)
    --- PASS: TestRegistryTestSuite/TestRegistriesK3S (510.44s)
    --- PASS: TestRegistryTestSuite/TestRegistriesRKE (1912.02s)
    --- PASS: TestRegistryTestSuite/TestRegistriesRKE2 (733.54s)
PASS
ok  	github.com/rancher/rancher/tests/v2/validation/registries	3175.197s
```



## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
Provisioning shouldn't be impacted by the new parameters in `NewK3SRKE2ClusterConfig`