### PR TITLE
Fix pod status check logic

### DIFF
--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
@@ -30,6 +30,9 @@ const (
 	ProvisioningSteveResouceType = "provisioning.cattle.io.cluster"
 	isCattleLabeled              = true
 	etcdnodeCount                = 3
+	maxContainerRestartCount     = 3
+	cattleSystem                 = "cattle-system"
+	podPrefix                    = "helm-operation"
 )
 
 func createSnapshot(client *rancher.Client, clustername string, generation int, namespace string) error {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/qa-tasks/issues/717
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
- Updated the pods status check logic for capturing the error if the pod is not up and running.
 
- Below is the output from jenkins logs where it captures the pod error after the cluster is restored:
```
/root/go/src/github.com/rancher/rancher/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go:626
17:12:13.300          	Error:      	Received unexpected error:
17:12:13.300          	            	Error in running pods : [ERROR: helm-install-rke2-snapshot-controller-crd-rq226: container helm is in CrashLoopBackOff ERROR: helm-install-rke2-snapshot-controller-zxfpl: container helm is in CrashLoopBackOff]
17:12:13.300          	Test:       	TestEtcdSnapshotRestore/TestEtcdSnapshotRestoreWithK8sUpgrade
17:12:13.300      --- FAIL: TestEtcdSnapshotRestore/TestEtcdSnapshotRestoreWithK8sUpgrade (1148.82s)
```