### PR TITLE
Update cluster.yml to include PSACT

### DIFF
--- a/tests/validation/tests/v3_api/resource/cluster-ha.yml
+++ b/tests/validation/tests/v3_api/resource/cluster-ha.yml
@@ -13,3 +13,40 @@ nodes:
     internal_address: $internalIp3
     user: $user3
     role: [etcd, controlplane,worker]
+services:
+   kube-api:
+     admission_configuration:
+       apiVersion: apiserver.config.k8s.io/v1
+       kind: AdmissionConfiguration
+       plugins:
+         - name: PodSecurity
+           configuration:
+             apiVersion: pod-security.admission.config.k8s.io/v1beta1
+             kind: PodSecurityConfiguration
+             defaults:
+               enforce: restricted
+               enforce-version: latest
+             exemptions:
+               namespaces: 
+               - ingress-nginx
+               - kube-system
+               - cattle-system
+               - cattle-epinio-system
+               - cattle-fleet-system
+               - longhorn-system
+               - cattle-neuvector-system
+               - cattle-monitoring-system
+               - rancher-alerting-drivers
+               - cis-operator-system
+               - cattle-csp-adapter-system
+               - cattle-externalip-system
+               - cattle-gatekeeper-system
+               - istio-system
+               - cattle-istio-system
+               - cattle-logging-system
+               - cattle-windows-gmsa-system
+               - cattle-sriov-system
+               - cattle-ui-plugin-system
+               - tigera-operator
+               runtimeClasses: []
+               usernames: []

--- a/tests/validation/tests/v3_api/resource/cluster.yml
+++ b/tests/validation/tests/v3_api/resource/cluster.yml
@@ -15,4 +15,40 @@ nodes:
     internal_address: $intip2
     user: ubuntu
     role: [etcd, controlplane,worker]
-
+services:
+   kube-api:
+     admission_configuration:
+       apiVersion: apiserver.config.k8s.io/v1
+       kind: AdmissionConfiguration
+       plugins:
+         - name: PodSecurity
+           configuration:
+             apiVersion: pod-security.admission.config.k8s.io/v1beta1
+             kind: PodSecurityConfiguration
+             defaults:
+               enforce: restricted
+               enforce-version: latest
+             exemptions:
+               namespaces: 
+               - ingress-nginx
+               - kube-system
+               - cattle-system
+               - cattle-epinio-system
+               - cattle-fleet-system
+               - longhorn-system
+               - cattle-neuvector-system
+               - cattle-monitoring-system
+               - rancher-alerting-drivers
+               - cis-operator-system
+               - cattle-csp-adapter-system
+               - cattle-externalip-system
+               - cattle-gatekeeper-system
+               - istio-system
+               - cattle-istio-system
+               - cattle-logging-system
+               - cattle-windows-gmsa-system
+               - cattle-sriov-system
+               - cattle-ui-plugin-system
+               - tigera-operator
+               runtimeClasses: []
+               usernames: []


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
As of Rancher v2.7.2, PSACT support has been included. For QA's automation regarding importing RKE1 clusters, we have not updated the `cluster.yml` to account for this new feature. As a result, automation is failing as the RKE1 cluster is not successfully able to be stood up.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updated the `cluster.yml` and `cluster-ha.yml` files to include the `services` block with the appropriate parameters needed for a PSACT cluster.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Locally, provisioned a standalone RKE1 cluster with the updated YAML and it was successful.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Automated testing will have to come after this PR is merged to ensure all of the expected tests run successfully.