### PR TITLE
Omit the error when the upgrading of the cluster fails in the process of restoring etcd snapshot

### DIFF
--- a/pkg/controllers/management/clusterprovisioner/driver.go
+++ b/pkg/controllers/management/clusterprovisioner/driver.go
@@ -134,10 +134,9 @@ func (p *Provisioner) driverRestore(cluster *apimgmtv3.Cluster, spec apimgmtv3.C
 	}
 
 	newCluster, err := p.Clusters.Update(cluster)
-	if err != nil {
-		return "", "", "", err
+	if err == nil {
+		cluster = newCluster
 	}
-	cluster = newCluster
 
 	kontainerDriver, err := p.getKontainerDriver(spec)
 	if err != nil {


### PR DESCRIPTION
# Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
https://github.com/rancher/rancher/issues/40889

# Problem
 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable.  If this is a new feature describe why we need this feature and how it will be used. -->
 
When Rancher restores the etcd snapshot, one of the steps is to [update the cluster](https://github.com/rancher/rancher/blob/f2faf1a8aa1081301e1fe6c21637fe9b7044f188/pkg/controllers/management/clusterprovisioner/driver.go#L136-L139), which fails because of conflicting (see error msg below) if PSP is disabled in the cluster's current spec but was enabled in the backup (and vice versa).

The conflicting error message:
`Operation cannot be fulfilled on clusters.management.cattle.io "c-gdzsq": the object has been modified; please apply your changes to the latest version and try again`

However, the call to update the cluster looks unnecessary because the [driverUpdate](https://github.com/rancher/rancher/blob/f2faf1a8aa1081301e1fe6c21637fe9b7044f188/pkg/controllers/management/clusterprovisioner/driver.go#L136-L139) function and its caller do not modify the cluster. Also, only the `driverUpdate` function returns the error, but `driverRemove`, `driverUpdate`, and `driverCreate` ignore the error.

# Solution
 
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Ignore the error if the update fails, the same as other functions mentioned above. 


# Testing
 
<!-- Describe what, if any, testing you did.  If you added tests describe what cases they cover and do not cover. -->


The following steps have been done on a local dev setup:
1. run rancher in dev env 
2. create a downstream cluster RKE1 1.24.13 with dedicated nodes, with PSP enabled and set to Unrestricted
3. after the cluster is active, deploy a few deployments 
4. make an etcd snapshot in Rancher UI 
5. upgrade the cluster to v1.25.9, Rancher forces to disable PSP
6. wait for the upgrade to be done 
7. restore the snapshot, and  choose "Cluster config, K8s version and etcd" 
8. monitoring the cluster in rancher UI during the process and confirm that it does not show the error message anymore 
5. once the restore is done, confirm that the cluster still works normally and the deployments still exist 

