### PR TITLE
Introduce harvester-baremetal-container-workload feature flag

### DIFF
--- a/pkg/apis/management.cattle.io/v3/global_types.go
+++ b/pkg/apis/management.cattle.io/v3/global_types.go
@@ -40,3 +40,8 @@ type FeatureStatus struct {
 	Description string `json:"description"`
 	LockedValue *bool  `json:"lockedValue"`
 }
+
+const (
+	ExperimentalFeatureKey   = "feature.cattle.io/experimental"
+	ExperimentalFeatureValue = "true"
+)

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -107,6 +107,13 @@ var (
 		true,
 		true,
 		true)
+
+	HarvesterBaremetalContainerWorkload = newFeature(
+		"harvester-baremetal-container-workload",
+		"[Experimental]: Deploy container workloads to underlying harvester cluster",
+		false,
+		true,
+		true)
 )
 
 type Feature struct {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 PR introduces an additional feature flag for `harvester-baremetal-container-workload` which will be introduced with harvester v1.2.0

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 The flag is an experimental option, allowing users to enable multi-cluster-management view on the integrated rancher available in the harvester packaging.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 feature flag also introduces a handler method, which checks and enables the `harvester` feature flag if required, when the `harvester-baremetal-container-workload` is enabled.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->