### PR TITLE
Update Dockerfile.dapper to resolve K3s/K3d CVEs

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -4,13 +4,13 @@ ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 ENV CATTLE_HELM_VERSION v2.16.8-rancher2
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher100
-ENV CATTLE_K3S_VERSION v1.26.4+k3s1
+ENV CATTLE_K3S_VERSION v1.26.6+k3s1
 # helm 3 version
 ENV HELM_VERSION v3.11.3
 ENV KUSTOMIZE_VERSION v5.0.1
 ENV HELM_UNITTEST_VERSION 0.3.2
 # k3d ci version
-ENV K3D_VERSION v5.4.6
+ENV K3D_VERSION v5.5.1
 
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go
 ENV CATTLE_KDM_BRANCH=dev-v2.7
@@ -60,7 +60,7 @@ RUN mkdir /usr/tmp && \
     chmod +x /usr/bin/kustomize
 
 # Set up K3s: copy the necessary binaries from the K3s image.
-COPY --from=rancher/k3s:v1.26.4-k3s1 \
+COPY --from=rancher/k3s:v1.26.6-k3s1 \
     /bin/blkid \
     /bin/cni \
     /bin/conntrack \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -29,7 +29,7 @@ ENV CATTLE_PARTNER_CHART_DEFAULT_BRANCH=$PARTNER_CHART_DEFAULT_BRANCH
 ENV CATTLE_RKE2_CHART_DEFAULT_BRANCH=$RKE2_CHART_DEFAULT_BRANCH
 ENV CATTLE_HELM_VERSION v2.16.8-rancher2
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher100
-ENV CATTLE_K3S_VERSION v1.26.4+k3s1
+ENV CATTLE_K3S_VERSION v1.26.6+k3s1
 ENV CATTLE_MACHINE_PROVISION_IMAGE rancher/machine:${CATTLE_MACHINE_VERSION}
 ENV CATTLE_ETCD_VERSION v3.5.1
 ENV LOGLEVEL_VERSION v0.1.5
@@ -118,7 +118,7 @@ RUN curl ${HELM_URL_V3} | tar xvzf - --strip-components=1 -C /usr/bin && \
     chmod +x /usr/bin/kustomize
 
 # Set up K3s: copy the necessary binaries from the K3s image.
-COPY --from=rancher/k3s:v1.26.4-k3s1 \
+COPY --from=rancher/k3s:v1.26.6-k3s1 \
     /bin/blkid \
     /bin/cni \
     /bin/conntrack \

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -107,8 +107,8 @@ dump_rancher_logs()
 
 # uncomment to get startup logs. Don't leave them on because it slows drone down too
 # much
-#tail -F /tmp/rancher.log &
-#TPID=$!
+tail -F /tmp/rancher.log &
+TPID=$!
 
 trap "exit 1" 42
 PWRAPPROC="$$"
@@ -129,7 +129,7 @@ echo "Waiting up to 5 minutes for rancher-webhook deployment"
   --message "rancher-webhook was not available after {{elapsed}} seconds" `# Print this progress message` \
   "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-system deploy/rancher-webhook &>/dev/null"
 
-#kill $TPID
+kill $TPID
 
 echo Running provisioning-tests $RUNARG
 

--- a/scripts/test
+++ b/scripts/test
@@ -116,8 +116,8 @@ dump_rancher_logs()
 
 # uncomment to get startup logs. Don't leave them on because it slows drone down too
 # much
-#tail -F /tmp/rancher.log &
-#TPID=$!
+tail -F /tmp/rancher.log &
+TPID=$!
 
 trap "exit 1" 42
 PWRAPPROC="$$"
@@ -138,7 +138,7 @@ echo "Waiting up to 5 minutes for rancher-webhook deployment"
   --message "rancher-webhook was not available after {{elapsed}} seconds" `# Print this progress message` \
   "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-system deploy/rancher-webhook &>/dev/null"
 
-#kill $TPID
+kill $TPID
 
 echo Running build-integration-setup
 ./tests/v2/integration/scripts/build-integration-setup

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -29,7 +29,7 @@ ENV CATTLE_PARTNER_CHART_DEFAULT_BRANCH=$PARTNER_CHART_DEFAULT_BRANCH
 ENV CATTLE_RKE2_CHART_DEFAULT_BRANCH=$RKE2_CHART_DEFAULT_BRANCH
 ENV CATTLE_HELM_VERSION v2.16.8-rancher2
 ENV CATTLE_MACHINE_VERSION v0.15.0-rancher100
-ENV CATTLE_K3S_VERSION v1.26.4+k3s1
+ENV CATTLE_K3S_VERSION v1.26.6+k3s1
 ENV CATTLE_MACHINE_PROVISION_IMAGE rancher/machine:${CATTLE_MACHINE_VERSION}
 ENV CATTLE_ETCD_VERSION v3.5.1
 ENV LOGLEVEL_VERSION v0.1.5
@@ -118,7 +118,7 @@ RUN curl ${HELM_URL_V3} | tar xvzf - --strip-components=1 -C /usr/bin && \
     chmod +x /usr/bin/kustomize
 
 # Set up K3s: copy the necessary binaries from the K3s image.
-COPY --from=rancher/k3s:v1.26.4-k3s1 \
+COPY --from=rancher/k3s:v1.26.6-k3s1 \
     /bin/blkid \
     /bin/cni \
     /bin/conntrack \

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -196,7 +196,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                           RKE_VERSION = "v1.4.4"
                         }
                         if (!env.RANCHER_K3S_VERSION) {
-                          RANCHER_K3S_VERSION = "v1.26.4+k3s1"
+                          RANCHER_K3S_VERSION = "v1.26.6+k3s1"
                         }
                       }                   
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42196
 
## Problem
There are 13 high severity and 1 critical severity CVEs identified by `trivy` in release/v2.7 in k3s and k3d

| Target | Package | Vulnerability | Severity | Installed Version | Fixed Version | Title | 
| -- | -- | -- | -- | -- | -- | -- |
| usr/bin/containerd | github.com/emicklei/go-restful | CVE-2022-1996 | CRITICAL | v2.9.5+incompatible | 2.16.0+incompatible | Authorization Bypass Through User-Controlled Key https://avd.aquasec.com/nvd/cve-2022-1996 |
| usr/bin/containerd | github.com/opencontainers/runc | CVE-2023-27561 | HIGH | v1.1.2 | 1.1.5 | volume mount race condition (regression of CVE-2019-19921) https://avd.aquasec.com/nvd/cve-2023-27561 |
| usr/bin/containerd | golang.org/x/net | CVE-2022-41721 | HIGH | v0.1.1-0.20221027164007-c63010009c80 | 0.1.1-0.20221104162952-702349b0e862 | request smuggling https://avd.aquasec.com/nvd/cve-2022-41721 |
| usr/bin/containerd | golang.org/x/net | CVE-2022-41723 | HIGH | v0.1.1-0.20221027164007-c63010009c80 | 0.7.0 | avoid quadratic complexity in HPACK decoding https://avd.aquasec.com/nvd/cve-2022-41723 |
| usr/bin/runc | golang.org/x/net | CVE-2021-33194 | HIGH | v0.0.0-20201224014010-6772e930b67b | 0.0.0-20210520170846-37e1c6afe023 | golang: x/net/html: infinite loop in ParseFragment https://avd.aquasec.com/nvd/cve-2021-33194 |
| usr/bin/runc | golang.org/x/net | CVE-2021-44716 | HIGH | v0.0.0-20201224014010-6772e930b67b | 0.0.0-20211209124913-491a49abca63 | golang: net/http: limit growth of header canonicalization cache https://avd.aquasec.com/nvd/cve-2021-44716 |
| usr/bin/runc | golang.org/x/net | CVE-2022-27664 | HIGH | v0.0.0-20201224014010-6772e930b67b | 0.0.0-20220906165146-f3363e06e74c | handle server errors after sending GOAWAY https://avd.aquasec.com/nvd/cve-2022-27664 |
| usr/bin/runc | golang.org/x/net | CVE-2022-41723 | HIGH | v0.0.0-20201224014010-6772e930b67b | 0.7.0 | avoid quadratic complexity in HPACK decoding https://avd.aquasec.com/nvd/cve-2022-41723 |
| usr/local/bin/k3d | github.com/docker/distribution | CVE-2023-2253 | HIGH | v2.8.1+incompatible | 2.8.2-beta.1 | DoS from malicious API request https://avd.aquasec.com/nvd/cve-2023-2253 |
| usr/local/bin/k3d | github.com/docker/docker | CVE-2023-28840 | HIGH | v20.10.17+incompatible | 23.0.3, 20.10.24 | Encrypted overlay network may be unauthenticated https://avd.aquasec.com/nvd/cve-2023-28840 |
| usr/local/bin/k3d | github.com/opencontainers/runc | CVE-2023-27561 | HIGH | v1.1.2 | 1.1.5 | volume mount race condition (regression of CVE-2019-19921) https://avd.aquasec.com/nvd/cve-2023-27561 |
| usr/local/bin/k3d | golang.org/x/net | CVE-2022-27664 | HIGH | v0.0.0-20220822230855-b0a4917ee28c | 0.0.0-20220906165146-f3363e06e74c | handle server errors after sending GOAWAY https://avd.aquasec.com/nvd/cve-2022-27664 |
| usr/local/bin/k3d | golang.org/x/net | CVE-2022-41721 | HIGH | v0.0.0-20220822230855-b0a4917ee28c | 0.1.1-0.20221104162952-702349b0e862 | request smuggling https://avd.aquasec.com/nvd/cve-2022-41721 |
| usr/local/bin/k3d | golang.org/x/net | CVE-2022-41723 | HIGH | v0.0.0-20220822230855-b0a4917ee28c | 0.7.0 | avoid quadratic complexity in HPACK decoding https://avd.aquasec.com/nvd/cve-2022-41723 |
| usr/local/bin/k3d | golang.org/x/text | CVE-2022-32149 | HIGH | v0.3.7 | 0.3.8 | ParseAcceptLanguage takes a long time to parse complex tags https://avd.aquasec.com/nvd/cve-2022-32149 |

## Solution
Updated the Dockerfile with k3d and k3s versions that have fixes.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->