### PR TITLE
Add additional resource checks to upgrade testing

### DIFF
--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -882,7 +882,7 @@ func isClusterInaccessible(messages []string) (isInaccessible bool) {
 }
 
 func logClusterInfoWithChanges(clusterID, clusterInfo string, summary summary.Summary) string {
-	newClusterInfo := fmt.Sprintf("ClusterID: %v, Message: %v, Error: %v, State: %v, Transiationing: %v", clusterID, summary.Message, summary.Error, summary.State, summary.Transitioning)
+	newClusterInfo := fmt.Sprintf("ClusterID: %v, Message: %v, Error: %v, State: %v, Transitioning: %v", clusterID, summary.Message, summary.Error, summary.State, summary.Transitioning)
 
 	if clusterInfo != newClusterInfo {
 		logrus.Infof(newClusterInfo)

--- a/tests/v2/validation/provisioning/k3s/custom_cluster.go
+++ b/tests/v2/validation/provisioning/k3s/custom_cluster.go
@@ -113,10 +113,6 @@ func TestProvisioningK3SCustomCluster(t *testing.T, client *rancher.Client, exte
 	require.NoError(t, err)
 	assert.NotEmpty(t, clusterToken)
 
-	podResults, podErrors := pods.StatusPods(client, clusterIDName)
-	assert.NotEmpty(t, podResults)
-	assert.Empty(t, podErrors)
-
 	if hardened && kubeVersion <= string(provisioning.HardenedKubeVersion) {
 		err = hardening.HardeningNodes(client, hardened, nodes, rolesPerNode)
 		require.NoError(t, err)
@@ -134,4 +130,8 @@ func TestProvisioningK3SCustomCluster(t *testing.T, client *rancher.Client, exte
 		_, err = psadeploy.CreateNginxDeployment(client, clusterIDName, psact)
 		require.NoError(t, err)
 	}
+
+	podResults, podErrors := pods.StatusPods(client, clusterIDName)
+	assert.NotEmpty(t, podResults)
+	assert.Empty(t, podErrors)
 }

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver.go
@@ -77,10 +77,6 @@ func TestProvisioningK3SCluster(t *testing.T, client *rancher.Client, provider P
 	require.NoError(t, err)
 	assert.NotEmpty(t, clusterToken)
 
-	podResults, podErrors := pods.StatusPods(client, clusterIDName)
-	assert.NotEmpty(t, podResults)
-	assert.Empty(t, podErrors)
-
 	if psact == string(provisioning.RancherPrivileged) || psact == string(provisioning.RancherRestricted) {
 		err = psadeploy.CheckPSACT(client, clusterName)
 		require.NoError(t, err)
@@ -88,5 +84,10 @@ func TestProvisioningK3SCluster(t *testing.T, client *rancher.Client, provider P
 		_, err = psadeploy.CreateNginxDeployment(client, clusterIDName, psact)
 		require.NoError(t, err)
 	}
+
+	podResults, podErrors := pods.StatusPods(client, clusterIDName)
+	assert.NotEmpty(t, podResults)
+	assert.Empty(t, podErrors)
+
 	return clusterResp
 }

--- a/tests/v2/validation/provisioning/rke1/custom_cluster.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster.go
@@ -103,10 +103,6 @@ func TestProvisioningRKE1CustomCluster(t *testing.T, client *rancher.Client, ext
 	require.NoError(t, err)
 	assert.NotEmpty(t, clusterToken)
 
-	podResults, podErrors := pods.StatusPods(client, clusterResp.ID)
-	assert.NotEmpty(t, podResults)
-	assert.Empty(t, podErrors)
-
 	etcdVersion, err := matrix.CheckETCDVersion(client, nodes, rolesPerPool)
 	require.NoError(t, err)
 	assert.NotEmpty(t, etcdVersion)
@@ -118,4 +114,8 @@ func TestProvisioningRKE1CustomCluster(t *testing.T, client *rancher.Client, ext
 		_, err = psadeploy.CreateNginxDeployment(client, clusterName, psact)
 		require.NoError(t, err)
 	}
+
+	podResults, podErrors := pods.StatusPods(client, clusterResp.ID)
+	assert.NotEmpty(t, podResults)
+	assert.Empty(t, podErrors)
 }

--- a/tests/v2/validation/provisioning/rke1/provisioning_node_driver.go
+++ b/tests/v2/validation/provisioning/rke1/provisioning_node_driver.go
@@ -62,10 +62,6 @@ func TestProvisioningRKE1Cluster(t *testing.T, client *rancher.Client, provider 
 	require.NoError(t, err)
 	assert.NotEmpty(t, clusterToken)
 
-	podResults, podErrors := pods.StatusPods(client, clusterResp.ID)
-	assert.NotEmpty(t, podResults)
-	assert.Empty(t, podErrors)
-
 	if psact == string(provisioning.RancherPrivileged) || psact == string(provisioning.RancherRestricted) {
 		err = psadeploy.CheckPSACT(client, clusterName)
 		require.NoError(t, err)
@@ -73,6 +69,10 @@ func TestProvisioningRKE1Cluster(t *testing.T, client *rancher.Client, provider 
 		_, err = psadeploy.CreateNginxDeployment(client, clusterResp.ID, psact)
 		require.NoError(t, err)
 	}
+
+	podResults, podErrors := pods.StatusPods(client, clusterResp.ID)
+	assert.NotEmpty(t, podResults)
+	assert.Empty(t, podErrors)
 
 	return clusterResp, nil
 }

--- a/tests/v2/validation/provisioning/rke2/custom_cluster.go
+++ b/tests/v2/validation/provisioning/rke2/custom_cluster.go
@@ -131,10 +131,6 @@ func TestProvisioningRKE2CustomCluster(t *testing.T, client *rancher.Client, ext
 	require.NoError(t, err)
 	assert.NotEmpty(t, clusterToken)
 
-	podResults, podErrors := pods.StatusPods(client, clusterIDName)
-	assert.NotEmpty(t, podResults)
-	assert.Empty(t, podErrors)
-
 	if hardened && kubeVersion <= string(provisioning.HardenedKubeVersion) {
 		err = hardening.HardeningNodes(client, hardened, nodes, rolesPerNode)
 		require.NoError(t, err)
@@ -156,4 +152,8 @@ func TestProvisioningRKE2CustomCluster(t *testing.T, client *rancher.Client, ext
 		_, err = psadeploy.CreateNginxDeployment(client, clusterIDName, psact)
 		require.NoError(t, err)
 	}
+
+	podResults, podErrors := pods.StatusPods(client, clusterIDName)
+	assert.NotEmpty(t, podResults)
+	assert.Empty(t, podErrors)
 }

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver.go
@@ -72,10 +72,6 @@ func TestProvisioningRKE2Cluster(t *testing.T, client *rancher.Client, provider 
 	require.NoError(t, err)
 	assert.NotEmpty(t, clusterToken)
 
-	podResults, podErrors := pods.StatusPods(client, clusterIDName)
-	assert.NotEmpty(t, podResults)
-	assert.Empty(t, podErrors)
-
 	if psact == string(provisioning.RancherPrivileged) || psact == string(provisioning.RancherRestricted) {
 		err = psadeploy.CheckPSACT(client, clusterName)
 		require.NoError(t, err)
@@ -83,5 +79,10 @@ func TestProvisioningRKE2Cluster(t *testing.T, client *rancher.Client, provider 
 		_, err = psadeploy.CreateNginxDeployment(client, clusterIDName, psact)
 		require.NoError(t, err)
 	}
+
+	podResults, podErrors := pods.StatusPods(client, clusterIDName)
+	assert.NotEmpty(t, podResults)
+	assert.Empty(t, podErrors)
+
 	return clusterResp
 }

--- a/tests/v2/validation/upgrade/config.go
+++ b/tests/v2/validation/upgrade/config.go
@@ -8,18 +8,20 @@ import (
 	"github.com/rancher/rancher/tests/framework/pkg/environmentflag"
 )
 
+type PSACT string
+
 const (
-	// ConfigurationFileKey is used to parse the configuration of upgrade tests.
-	ConfigurationFileKey = "upgradeInput"
-	// localClusterID is a string to used ignore this cluster in comparisons
-	localClusterID = "local"
-	// latestKey is a string to determine automatically version pooling to the latest possible
-	latestKey = "latest"
+	ConfigurationFileKey       = "upgradeInput" // ConfigurationFileKey is used to parse the configuration of upgrade tests.
+	localClusterID             = "local"        // localClusterID is a string to used ignore this cluster in comparisons
+	latestKey                  = "latest"       // latestKey is a string to determine automatically version pooling to the latest possible
+	RancherPrivileged    PSACT = "rancher-privileged"
+	RancherRestricted    PSACT = "rancher-restricted"
 )
 
 type Clusters struct {
 	Name              string   `json:"name" yaml:"name" default:""`
 	VersionToUpgrade  string   `json:"versionToUpgrade" yaml:"versionToUpgrade" default:""`
+	PSACT             string   `json:"psact" yaml:"psact" default:""`
 	FeaturesToTest    Features `json:"enabledFeatures" yaml:"enabledFeatures" default:""`
 	isLatestVersion   bool
 	isUpgradeDisabled bool
@@ -74,6 +76,7 @@ func loadUpgradeKubernetesConfig(client *rancher.Client) (clusters []Clusters, e
 
 			cluster.Name = c.Name
 			cluster.VersionToUpgrade = c.VersionToUpgrade
+			cluster.PSACT = c.PSACT
 
 			isVersionFieldLatest := cluster.VersionToUpgrade == latestKey
 			if isVersionFieldLatest {
@@ -131,6 +134,7 @@ func loadUpgradeWorkloadConfig(client *rancher.Client) (clusters []Clusters, err
 
 			cluster.Name = c.Name
 			cluster.FeaturesToTest = c.FeaturesToTest
+			cluster.PSACT = c.PSACT
 
 			clusters = append(clusters, *cluster)
 		}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Add basic upgrade use-cases to the upgrade folder in the Go framework](https://github.com/rancher/qa-tasks/issues/746)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When we perform fresh install provisioning in the Go framework, we perform additional checks after the cluster is provisioned. These are general validation checks we perform manually alongside actual cluster provisioning. If and when QA performs upgrades on their clusters, we perform the same validation checks as well.

In our automation, we do not have those same additional resource checks when upgrading. This PR adds those checks.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Added additional resource checks to `kubernetes_test.go`, so that after a single cluster upgrade, we are covering the same checks that we have in the fresh install use-cases.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Tested RKE1 and K3S and validated that the resource checks are working as expected, after an upgrade.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Jenkins jobs will be provided to the reviewers offline.