### PR TITLE
Fix crash about ingress backend is not a service

### DIFF
--- a/pkg/controllers/managementagent/endpoints/endpoints.go
+++ b/pkg/controllers/managementagent/endpoints/endpoints.go
@@ -306,6 +306,9 @@ func convertIngressToServicePublicEndpointsMap(ingress ingresswrapper.Ingress, a
 						continue
 					}
 				}
+				if path.Backend.Service == nil {
+					continue
+				}
 				p := v32.PublicEndpoint{
 					Hostname:    rule.Host,
 					Path:        path.Path,


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/41736
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Rancher's cattle-cluster-agent will crash if ingress's backend is not a service.

Ingress's backend maybe is a resource like this:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ingress-resource-backend
spec:
  rules:
    - http:
        paths:
          - path: /icons
            pathType: ImplementationSpecific
            backend:
              resource:
                apiGroup: k8s.example.com
                kind: StorageBucket
                name: icon-assets
```

https://github.com/alibaba/higress/discussions/360 

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

crash log:

```bash
E0601 09:09:13.447021      39 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12171 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x3ccd600, 0x6eb69c0)
	/go/pkg/mod/k8s.io/apimachinery@v0.22.3/pkg/util/runtime/runtime.go:74 +0x95
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.22.3/pkg/util/runtime/runtime.go:48 +0x86
panic(0x3ccd600, 0x6eb69c0)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
github.com/rancher/rancher/pkg/controllers/managementagent/endpoints.convertIngressToServicePublicEndpointsMap(0x4d318f0, 0xc016458300, 0x0, 0xc000074026, 0x5, 0x1)
	/go/src/github.com/rancher/rancher/pkg/controllers/managementagent/endpoints/endpoints.go:312 +0x6cb
github.com/rancher/rancher/pkg/controllers/managementagent/endpoints.(*WorkloadEndpointsController).UpdateEndpoints(0xc0104cbe40, 0xc00c8d16e0, 0x1e, 0xc0164761e0, 0x3a919a0, 0xc00fd836e0)
	/go/src/github.com/rancher/rancher/pkg/controllers/managementagent/endpoints/workload_endpoints.go:89 +0x674
github.com/rancher/rancher/pkg/controllers/managementagent/workload.(*CommonController).syncDeployments(0xc000156d20, 0xc00c8d16e0, 0x1e, 0xc013151af8, 0x10, 0x7fc9d91c7108, 0x10, 0xc00fd836b0)
	/go/src/github.com/rancher/rancher/pkg/controllers/managementagent/workload/workload_common.go:135 +0x1a4
github.com/rancher/rancher/pkg/generated/norman/apps/v1.(*deploymentController).AddHandler.func1(0xc00c8d16e0, 0x1e, 0x448c440, 0xc013151af8, 0xc01226bb58, 0x3, 0x3, 0x0)
	/go/src/github.com/rancher/rancher/pkg/generated/norman/apps/v1/zz_generated_deployment_controller.go:156 +0x67
github.com/rancher/norman/controller.(*genericController).AddHandler.func1(0xc00c8d16e0, 0x1e, 0x4c80c98, 0xc013151af8, 0xc013151af8, 0x4d2e9d8, 0xc013151af8, 0x1)
	/go/pkg/mod/github.com/rancher/norman@v0.0.0-20211201154850-abe17976423e/controller/generic_controller.go:62 +0x224
github.com/rancher/lasso/pkg/controller.SharedControllerHandlerFunc.OnChange(0xc0104dbc80, 0xc00c8d16e0, 0x1e, 0x4c80c98, 0xc013151af8, 0x0, 0xc013151af8, 0x0, 0x0)
	/go/pkg/mod/github.com/rancher/lasso@v0.0.0-20211217013041-3c6118a30611/pkg/controller/sharedcontroller.go:29 +0x4e
github.com/rancher/lasso/pkg/controller.(*SharedHandler).OnChange(0xc00b044200, 0xc00c8d16e0, 0x1e, 0x4c80c98, 0xc013151af8, 0xc01623eb01, 0x0)
	/go/pkg/mod/github.com/rancher/lasso@v0.0.0-20211217013041-3c6118a30611/pkg/controller/sharedhandler.go:69 +0x14c
github.com/rancher/lasso/pkg/controller.(*controller).syncHandler(0xc0008a96b0, 0xc00c8d16e0, 0x1e, 0xc00e35ace8, 0x0)
	/go/pkg/mod/github.com/rancher/lasso@v0.0.0-20211217013041-3c6118a30611/pkg/controller/controller.go:215 +0xd1
github.com/rancher/lasso/pkg/controller.(*controller).processSingleItem(0xc0008a96b0, 0x3a919a0, 0xc00ec0fef0, 0x0, 0x0)
	/go/pkg/mod/github.com/rancher/lasso@v0.0.0-20211217013041-3c6118a30611/pkg/controller/controller.go:197 +0xe7
github.com/rancher/lasso/pkg/controller.(*controller).processNextWorkItem(0xc0008a96b0, 0x203001)
	/go/pkg/mod/github.com/rancher/lasso@v0.0.0-20211217013041-3c6118a30611/pkg/controller/controller.go:174 +0x54
github.com/rancher/lasso/pkg/controller.(*controller).runWorker(...)
	/go/pkg/mod/github.com/rancher/lasso@v0.0.0-20211217013041-3c6118a30611/pkg/controller/controller.go:163
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0140dc490)
	/go/pkg/mod/k8s.io/apimachinery@v0.22.3/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0140dc490, 0x4c53380, 0xc016236570, 0x1, 0xc00e015f80)
	/go/pkg/mod/k8s.io/apimachinery@v0.22.3/pkg/util/wait/wait.go:156 +0x9b
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0140dc490, 0x3b9aca00, 0x0, 0x1, 0xc00e015f80)
	/go/pkg/mod/k8s.io/apimachinery@v0.22.3/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.Until(0xc0140dc490, 0x3b9aca00, 0xc00e015f80)
	/go/pkg/mod/k8s.io/apimachinery@v0.22.3/pkg/util/wait/wait.go:90 +0x4d
created by github.com/rancher/lasso/pkg/controller.(*controller).run
	/go/pkg/mod/github.com/rancher/lasso@v0.0.0-20211217013041-3c6118a30611/pkg/controller/controller.go:134 +0x33b
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2f85a2b]
```
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->