### PR TITLE
[WIP] Add capi watch filters

### DIFF
--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -122,6 +122,7 @@ const (
 	MaximumHostnameLengthLimit = 63
 
 	CAPIFilterValue = "rancher-prov-v2"
+	RKEClusterKind  = "RKECluster"
 )
 
 var (

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -120,6 +120,8 @@ const (
 
 	MinimumHostnameLengthLimit = 10
 	MaximumHostnameLengthLimit = 63
+
+	CAPIFilterValue = "rancher-prov-v2"
 )
 
 var (

--- a/pkg/controllers/capi/capi.go
+++ b/pkg/controllers/capi/capi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	controllerruntime "github.com/rancher/lasso/controller-runtime"
+	rke2 "github.com/rancher/rancher/pkg/capr"
 	"github.com/rancher/rancher/pkg/controllers/capi/logger"
 	rkecontrollers "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/wrangler"
@@ -127,31 +128,37 @@ func reconcilers(mgr ctrl.Manager, clients *wrangler.Context) ([]reconciler, err
 			// If the cluster agent gets disconnected, then the caches that CAPI uses could get out of sync.
 			// By using a connectedAgentClusterCacheClient (which returns a NotFound error if the agent is not connected), then
 			// we can force CAPI to refresh its caches once the agent is connected again.
-			Client:  &connectedAgentClusterCacheClient{Client: mgr.GetClient(), rkeControlPlanesCache: clients.RKE.RKEControlPlane().Cache()},
-			Log:     ctrl.Log.WithName("remote").WithName("ClusterCacheReconciler"),
-			Tracker: tracker,
+			Client:           &connectedAgentClusterCacheClient{Client: mgr.GetClient(), rkeControlPlanesCache: clients.RKE.RKEControlPlane().Cache()},
+			Log:              ctrl.Log.WithName("remote").WithName("ClusterCacheReconciler"),
+			Tracker:          tracker,
+			WatchFilterValue: rke2.CAPIFilterValue,
 		},
 		&controllers.ClusterReconciler{
-			Client:    mgr.GetClient(),
-			APIReader: mgr.GetAPIReader(),
+			Client:           mgr.GetClient(),
+			APIReader:        mgr.GetAPIReader(),
+			WatchFilterValue: rke2.CAPIFilterValue,
 		},
 		&controllers.MachineReconciler{
-			Client:    mgr.GetClient(),
-			APIReader: mgr.GetAPIReader(),
-			Tracker:   tracker,
+			Client:           mgr.GetClient(),
+			APIReader:        mgr.GetAPIReader(),
+			Tracker:          tracker,
+			WatchFilterValue: rke2.CAPIFilterValue,
 		},
 		&controllers.MachineSetReconciler{
-			Client:    mgr.GetClient(),
-			APIReader: mgr.GetAPIReader(),
-			Tracker:   tracker,
+			Client:           mgr.GetClient(),
+			APIReader:        mgr.GetAPIReader(),
+			Tracker:          tracker,
+			WatchFilterValue: rke2.CAPIFilterValue,
 		},
 		&controllers.MachineDeploymentReconciler{
-			Client:    mgr.GetClient(),
-			APIReader: mgr.GetAPIReader(),
+			Client:           mgr.GetClient(),
+			APIReader:        mgr.GetAPIReader(),
+			WatchFilterValue: rke2.CAPIFilterValue,
 		},
 		&controllers.MachineHealthCheckReconciler{
-			Client:  mgr.GetClient(),
-			Tracker: tracker,
+			Client:           mgr.GetClient(),
+			Tracker:          tracker,
+			WatchFilterValue: rke2.CAPIFilterValue,
 		},
 	}, nil
 }

--- a/pkg/controllers/provisioningv2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/provisioningcluster/controller.go
@@ -86,7 +86,7 @@ func Register(ctx context.Context, clients *wrangler.Context) {
 				clients.RKE.RKECluster(),
 				clients.RKE.RKEBootstrapTemplate(),
 			),
-		"RKECluster",
+		capr.RKEClusterKind,
 		"rke-cluster",
 		h.OnRancherClusterChange,
 		nil)

--- a/pkg/controllers/provisioningv2/provisioningcluster/template.go
+++ b/pkg/controllers/provisioningv2/provisioningcluster/template.go
@@ -351,6 +351,7 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 		for k, v := range machinePool.MachineDeploymentLabels {
 			machineDeploymentLabels[k] = v
 		}
+		machineDeploymentLabels[capi.WatchLabel] = capr.CAPIFilterValue
 
 		machineSpecAnnotations := map[string]string{}
 		// Ignore drain if DrainBeforeDelete is unset or the pool is for etcd nodes
@@ -388,6 +389,7 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 							capr.ClusterNameLabel:           capiCluster.Name,
 							capi.MachineDeploymentLabelName: machineDeploymentName,
 							capr.RKEMachinePoolNameLabel:    machinePool.Name,
+							capi.WatchLabel:                 capr.CAPIFilterValue,
 						},
 						Annotations: machineSpecAnnotations,
 					},
@@ -582,6 +584,9 @@ func capiCluster(cluster *rancherv1.Cluster, rkeControlPlane *rkev1.RKEControlPl
 					Controller:         &[]bool{true}[0],
 					BlockOwnerDeletion: &[]bool{true}[0],
 				},
+			},
+			Labels: map[string]string{
+				capi.WatchLabel: capr.CAPIFilterValue,
 			},
 		},
 		Spec: capi.ClusterSpec{


### PR DESCRIPTION
***Still WIP***

- [x] Add watch filter to CAPI controllers
- [x] Add watch filter when generating new cluster definitions
- [x] Create migration
- [ ] Test migration

## Issue: #40764 

## Problem
We want the ability to run CAPI externally in the same cluster as Rancher Manager which has embedded CAPI. Without a change both sets of controllers will try and reconcile the clusters causing issues
 
## Solution
This changes the embedded controllers to use `WatchFilter` so that they only reconcile resources with a specific filter label. This will require us to "migrate" existing definitions and add the label.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->