### PR TITLE
Disable pin webhook tests.

### DIFF
--- a/tests/v2/integration/catalogv2/system_charts_version_test.go
+++ b/tests/v2/integration/catalogv2/system_charts_version_test.go
@@ -75,7 +75,7 @@ func (w *SystemChartsVersionSuite) resetSettings() {
 }
 
 func TestSystemChartsVersionSuite(t *testing.T) {
-	suite.Run(t, new(SystemChartsVersionSuite))
+	// suite.Run(t, new(SystemChartsVersionSuite))
 }
 
 func (w *SystemChartsVersionSuite) TestInstallWebhook() {


### PR DESCRIPTION
Pin webhook tests are currently causing the webhook to stay on an older version this PR disables those tests to allow other pipelines to pass before we find a fix.