### PR TITLE
Adding a check in case the corral packages repo url is not set

### DIFF
--- a/tests/v2/validation/Jenkinsfile.e2e
+++ b/tests/v2/validation/Jenkinsfile.e2e
@@ -18,6 +18,7 @@ node {
     def rancherConfig = "rancher_env.config"
     def branch = "release/v2.7"
     def corralBranch = "main"
+    def corralRepo = ""
     if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
       branch = "${env.BRANCH}"
     }
@@ -31,7 +32,10 @@ node {
       rancherRepo = "${env.REPO}"
     }
 
-    def corralRepo = scm.getUserRemoteConfigs()[1].getUrl()
+    if (scm.getUserRemoteConfigs().size() > 1) {
+      corralRepo = scm.getUserRemoteConfigs()[1].getUrl()
+    }
+
     if ("${env.RANCHER_CORRAL_PACKAGES_REPO_URL}" != "null" && "${env.RANCHER_CORRAL_PACKAGES_REPO_URL}" != "") {
       corralRepo = "${env.RANCHER_CORRAL_PACKAGES_REPO_URL}"
     }


### PR DESCRIPTION
## Issue: 

Automation Jenkins job fail due to configuration
 
## Problem

The Jenkins e2e pipeline fails when there isn't a second url set for the corral packages.
 
## Solution

Add a check to see if the configuraiton is set otherwise default to job variables.
 
## Testing

Created a manual job with the same configuration as the jjb definition. Second SCM url not set.
Ran the job with default values. No more errors
Ran the job without the url set. No more errors


### Automated Testing
Pipeline runs
