### PR TITLE
Update build job for Go matrix certification automation

### DIFF
--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -227,7 +227,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
                       jobs["ec2"] = { build job: 'rancher-v3_ontag_ec2_certification', parameters: params }
                       jobs["az"] = { build job: 'rancher-v3_ontag_az_certification', parameters: params }
                       jobs["custom"] = { build job: 'rancher-v3_ontag_custom_certification', parameters: params}
-                      jobs["go-provisioning"] = { build job: 'go-automation-freeform-job', parameters: goParams }
+                      jobs["go-provisioning"] = { build job: 'rancher_ontag_go_certification', parameters: goParams }
                       // windows note: https://github.com/rancher/dashboard/issues/6549
                       // jobs["windows"] = { build job: 'rancher-v3_ontag_windows_certification', parameters: params}
                       if (rancher_version.startsWith("v2.6") || rancher_version.startsWith("v2.7")){


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
OnTag runs currently utilize our freeform job when running through the automation. This is fine and works, but we should make it a point to consolidate all of our OnTag automation into one location. This PR does that by referencing a newly created Jenkins job.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updating the name of the build job used to reference the Go jobs used during OnTag automation.