### PR TITLE
add etcd backup-restore on s3

### DIFF
--- a/tests/v2/validation/provisioning/config.go
+++ b/tests/v2/validation/provisioning/config.go
@@ -5,6 +5,7 @@ import (
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
+	"github.com/rancher/rke/types"
 )
 
 type Version string
@@ -129,4 +130,5 @@ type Config struct {
 	Hardened                 bool                           `json:"hardened" yaml:"hardened"`
 	AdvancedOptions          AdvancedOptions                `json:"advancedOptions" yaml:"advancedOptions"`
 	LocalClusterAuthEndpoint rkev1.LocalClusterAuthEndpoint `json:"localClusterAuthEndpoint" yaml:"localClusterAuthEndpoint"`
+	S3BackupConfig           *types.S3BackupConfig          `json:"s3BackupConfig" yaml:"s3BackupConfig"`
 }

--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore.go
@@ -32,6 +32,7 @@ const (
 	maxContainerRestartCount     = 3
 	cattleSystem                 = "cattle-system"
 	podPrefix                    = "helm-operation"
+	s3BackupPrefix               = "on-demand-"
 )
 
 func restoreSnapshot(client *rancher.Client, clustername string, name string,
@@ -72,7 +73,7 @@ func getSnapshots(client *rancher.Client,
 
 }
 
-func createRKE2NodeDriverCluster(client *rancher.Client, provider *Provider, clusterName string, k8sVersion string, namespace string, cni string, advancedOptions provisioning.AdvancedOptions) (*steveV1.SteveAPIObject, error) {
+func createRKE2NodeDriverCluster(client *rancher.Client, provider *Provider, clusterName string, k8sVersion string, namespace string, cni string, advancedOptions provisioning.AdvancedOptions, s3Snapshot *rkev1.ETCDSnapshotS3) (*steveV1.SteveAPIObject, error) {
 
 	nodeRoles := []machinepools.NodeRoles{
 		{
@@ -110,7 +111,7 @@ func createRKE2NodeDriverCluster(client *rancher.Client, provider *Provider, clu
 	machinePools := machinepools.RKEMachinePoolSetup(nodeRoles, machineConfigResp)
 
 	cluster := clusters.NewK3SRKE2ClusterConfig(clusterName, namespace, cni, cloudCredential.ID, k8sVersion, "", machinePools, advancedOptions)
-
+	cluster.Spec.RKEConfig.ETCD.S3 = s3Snapshot
 	return clusters.CreateK3SRKE2Cluster(client, cluster)
 
 }

--- a/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
+++ b/tests/v2/validation/provisioning/rke2/etcd_backup_restore_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	steveV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
@@ -42,6 +43,7 @@ type RKE2EtcdSnapshotRestoreTestSuite struct {
 	providers          []string
 	nodesAndRoles      []machinepools.NodeRoles
 	advancedOptions    provisioning.AdvancedOptions
+	etcdSnapshotS3     *rkev1.ETCDSnapshotS3
 }
 
 func (r *RKE2EtcdSnapshotRestoreTestSuite) TearDownSuite() {
@@ -66,6 +68,21 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) SetupSuite() {
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(r.T(), err)
 
+	if clustersConfig.S3BackupConfig != nil {
+		r.etcdSnapshotS3 = &rkev1.ETCDSnapshotS3{
+			Endpoint:      clustersConfig.S3BackupConfig.Endpoint,
+			Bucket:        clustersConfig.S3BackupConfig.BucketName,
+			Region:        clustersConfig.S3BackupConfig.Region,
+			Folder:        clustersConfig.S3BackupConfig.Folder,
+			SkipSSLVerify: true,
+		}
+		provider := CreateProvider(provisioning.AWSProviderName.String())
+		creds, err := provider.CloudCredFunc(client)
+		require.NoError(r.T(), err)
+		r.etcdSnapshotS3.CloudCredentialName = creds.ID
+		logrus.Infof("%v", creds.ID)
+	}
+
 	r.client = client
 
 }
@@ -87,7 +104,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithK8sUpgrade(pro
 	clusterName := namegen.AppendRandomString(provider.Name.String())
 
 	logrus.Infof("creating rke2Cluster.............")
-	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0], r.advancedOptions)
+	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0], r.advancedOptions, r.etcdSnapshotS3)
 	require.NoError(r.T(), err)
 	require.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
 	logrus.Infof("rke2Cluster create request successful.............")
@@ -175,19 +192,24 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithK8sUpgrade(pro
 		}
 		totalClusterSnapShots := 0
 		for _, snapshot := range snapshotList {
-			if strings.Contains(snapshot.ObjectMeta.Name, clusterName) {
+			prefix := "on-demand-" + clusterName
+			if strings.Contains(snapshot.ObjectMeta.Name, prefix) {
 				if snapshotToBeRestored == "" {
 					snapshotToBeRestored = snapshot.Name
 				}
 				totalClusterSnapShots++
 			}
 		}
-		if totalClusterSnapShots == etcdnodeCount {
+		if totalClusterSnapShots >= etcdnodeCount {
 			return true, nil
 		}
 		return false, nil
 	})
 	require.NoError(r.T(), err)
+
+	logrus.Infof("creating watch over pods.............")
+	r.watchAndWaitForPods(client, clusterID)
+	logrus.Infof("All pods are up and running.............")
 
 	logrus.Infof("creating a workload(w2, deployment).............")
 	containerTemplate2 := workloads.NewContainer("ngnix", "nginx", v1.PullAlways, []v1.VolumeMount{}, []v1.EnvFromSource{})
@@ -257,7 +279,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithUpgradeStrateg
 	clusterName := namegen.AppendRandomString(provider.Name.String())
 
 	logrus.Infof("creating rke2Cluster.............")
-	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0], r.advancedOptions)
+	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0], r.advancedOptions, r.etcdSnapshotS3)
 	require.NoError(r.T(), err)
 	require.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
 	logrus.Infof("rke2Cluster create request successful.............")
@@ -323,19 +345,24 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestoreWithUpgradeStrateg
 		}
 		totalClusterSnapShots := 0
 		for _, snapshot := range snapshotList {
-			if strings.Contains(snapshot.ObjectMeta.Name, clusterName) {
+			prefix := "on-demand-" + clusterName
+			if strings.Contains(snapshot.ObjectMeta.Name, prefix) {
 				if snapshotToBeRestored == "" {
 					snapshotToBeRestored = snapshot.Name
 				}
 				totalClusterSnapShots++
 			}
 		}
-		if totalClusterSnapShots == etcdnodeCount {
+		if totalClusterSnapShots >= etcdnodeCount {
 			return true, nil
 		}
 		return false, nil
 	})
 	require.NoError(r.T(), err)
+
+	logrus.Infof("creating watch over pods.............")
+	r.watchAndWaitForPods(client, clusterID)
+	logrus.Infof("All pods are up and running.............")
 
 	logrus.Infof("creating a workload(w2, deployment).............")
 	containerTemplate2 := workloads.NewContainer("ngnix", "nginx", v1.PullAlways, []v1.VolumeMount{}, []v1.EnvFromSource{})
@@ -476,7 +503,7 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestore(provider *Provide
 	clusterName := namegen.AppendRandomString(provider.Name.String())
 
 	logrus.Infof("creating rke2Cluster.............")
-	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0], r.advancedOptions)
+	clusterResp, err := createRKE2NodeDriverCluster(client, provider, clusterName, initialK8sVersion, r.ns, r.cnis[0], r.advancedOptions, r.etcdSnapshotS3)
 	require.NoError(r.T(), err)
 	require.Equal(r.T(), clusterName, clusterResp.ObjectMeta.Name)
 	logrus.Infof("rke2Cluster create request successful.............")
@@ -537,6 +564,9 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestore(provider *Provide
 	clusters.WatchAndWaitForCluster(r.client.Steve, kubeProvisioningClient, r.ns, clusterName)
 	logrus.Infof("cluster is active again.............")
 
+	logrus.Infof("creating watch over pods.............")
+	r.watchAndWaitForPods(client, clusterID)
+	logrus.Infof("All pods are up and running.............")
 	var snapshotToBeRestored string
 
 	err = kwait.Poll(5*time.Second, 5*time.Minute, func() (done bool, err error) {
@@ -546,19 +576,23 @@ func (r *RKE2EtcdSnapshotRestoreTestSuite) EtcdSnapshotRestore(provider *Provide
 		}
 		totalClusterSnapShots := 0
 		for _, snapshot := range snapshotList {
-			if strings.Contains(snapshot.ObjectMeta.Name, clusterName) {
+			if strings.Contains(snapshot.ObjectMeta.Name, s3BackupPrefix+clusterName) {
 				if snapshotToBeRestored == "" {
 					snapshotToBeRestored = snapshot.Name
 				}
 				totalClusterSnapShots++
 			}
 		}
-		if totalClusterSnapShots == etcdnodeCount {
+		if totalClusterSnapShots >= etcdnodeCount {
 			return true, nil
 		}
 		return false, nil
 	})
 	require.NoError(r.T(), err)
+
+	logrus.Infof("creating watch over pods.............")
+	r.watchAndWaitForPods(client, clusterID)
+	logrus.Infof("All pods are up and running.............")
 
 	logrus.Infof("creating a workload(w2, deployment).............")
 	containerTemplate2 := workloads.NewContainer("ngnix", "nginx", v1.PullAlways, []v1.VolumeMount{}, []v1.EnvFromSource{})


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/qa-tasks/issues/716
https://github.com/rancher/qa-tasks/issues/714
https://github.com/rancher/qa-tasks/issues/715
 
## Feature
This test creates and restores a backup on s3 if the correct configuration is provided . 

### Note:

This validation test takes around 16 mins to complete which is more than default timeout for the test that's why we need to use -timeout option with value either greater than 16 mins or 0. Similar to below command

go test providers.go etcd_backup_restore.go etcd_only_backup_restore_test.go -v -timeout 0

Also it will also requires one k8s version, CNI provider, and s3BackupConfig in the cattle config file as per below:

```
provisioningInput:  
  kubernetesVersion: 
    - v1.24.13+rke2r1
    - v1.25.9+rke2r1
  cni:
    - calico
  s3BackupConfig:
    bucket_name: 
    folder:  
    region: 
    endpoint: 
```

 