### PR TITLE
Fix aks clusters panic when upgrading rancher version

### DIFF
--- a/pkg/controllers/management/aks/aks_cluster_handler.go
+++ b/pkg/controllers/management/aks/aks_cluster_handler.go
@@ -306,7 +306,10 @@ func (e *aksOperatorController) updateAKSClusterConfig(cluster *apimgmtv3.Cluste
 	for {
 		select {
 		case event := <-w.ResultChan():
-			aksClusterConfigDynamic = event.Object.(*unstructured.Unstructured)
+			var ok bool
+			if aksClusterConfigDynamic, ok = event.Object.(*unstructured.Unstructured); !ok {
+				return cluster, fmt.Errorf("unexpected nil cluster config")
+			}
 			status, _ := aksClusterConfigDynamic.Object["status"].(map[string]interface{})
 			if status["phase"] == "active" {
 				continue


### PR DESCRIPTION
## Issue: #41732 
 
## Problem
Upgrading Rancher version from v2.7.3 to v2.7-head when using Rancher on Docker causes a panic if an AKS cluster has been previously provisioned. After this panic, Rancher restarts and recovers.
 
## Solution
This panic can be avoided by identifying the null object that triggers it and returning a meaningful error. This results in Rancher not crashing during the upgrade.
 
## Testing
The reported issue specifies how to reproduce the error in a Docker installation of Rancher. May need to repeat the process to reproduce it multiple times to get the error, as stated in the original description.

## Engineering Testing
### Manual Testing
Upgraded v2.7.3 to a version with this code change and the error was caught with no panic. Rancher runs as expected after the upgrade.

### Automated Testing

## QA Testing Considerations
 
### Regressions Considerations