### PR TITLE
Role binding reconciliation

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -1,4 +1,4 @@
 //go:generate go run pkg/codegen/generator/cleanup/main.go
 //go:generate go run pkg/codegen/main.go
-//go:generate scripts/build-crds.sh
+//go:generate scripts/build-crds
 package main

--- a/pkg/client/generated/management/v3/zz_generated_eks_cluster_config_spec.go
+++ b/pkg/client/generated/management/v3/zz_generated_eks_cluster_config_spec.go
@@ -4,6 +4,7 @@ const (
 	EKSClusterConfigSpecType                        = "eksClusterConfigSpec"
 	EKSClusterConfigSpecFieldAmazonCredentialSecret = "amazonCredentialSecret"
 	EKSClusterConfigSpecFieldDisplayName            = "displayName"
+	EKSClusterConfigSpecFieldEBSCSIDriver           = "ebsCSIDriver"
 	EKSClusterConfigSpecFieldImported               = "imported"
 	EKSClusterConfigSpecFieldKmsKey                 = "kmsKey"
 	EKSClusterConfigSpecFieldKubernetesVersion      = "kubernetesVersion"
@@ -23,6 +24,7 @@ const (
 type EKSClusterConfigSpec struct {
 	AmazonCredentialSecret string            `json:"amazonCredentialSecret,omitempty" yaml:"amazonCredentialSecret,omitempty"`
 	DisplayName            string            `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	EBSCSIDriver           *bool             `json:"ebsCSIDriver,omitempty" yaml:"ebsCSIDriver,omitempty"`
 	Imported               bool              `json:"imported,omitempty" yaml:"imported,omitempty"`
 	KmsKey                 *string           `json:"kmsKey,omitempty" yaml:"kmsKey,omitempty"`
 	KubernetesVersion      *string           `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`

--- a/pkg/controllers/options.go
+++ b/pkg/controllers/options.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/rancher/lasso/pkg/controller"
+	"k8s.io/client-go/rest"
 )
 
 type controllerContextType string
@@ -40,4 +41,12 @@ func syncOnlyChangedObjects(option controllerContextType) bool {
 		}
 	}
 	return false
+}
+
+// WebhookImpersonation returns a ImpersonationConfig that can be used for impersonating the webhook's sudo account and bypass validation.
+func WebhookImpersonation() rest.ImpersonationConfig {
+	return rest.ImpersonationConfig{
+		UserName: "system:serviceaccount:cattle-system:rancher-webhook-sudo",
+		Groups:   []string{"system:masters"},
+	}
 }

--- a/pkg/crds/yaml/generated/management.cattle.io_roletemplates.yaml
+++ b/pkg/crds/yaml/generated/management.cattle.io_roletemplates.yaml
@@ -49,7 +49,7 @@ spec:
             - ""
             type: string
           description:
-            description: Description holds any text desired to better describes the
+            description: Description holds any text desired to better describe the
               resource.
             type: string
           displayName:
@@ -58,7 +58,7 @@ spec:
             type: string
           external:
             description: External if true specifies that rules for this RoleTemplate
-              should be gathered from a ClusterRole with the matching name If set
+              should be gathered from a ClusterRole with the matching name. If set
               to true the Rules on the template will not be evaluated. External's
               value is only evaluated if the RoleTemplate's context is set to "cluster"
               Default to false.
@@ -80,7 +80,7 @@ spec:
             type: object
           projectCreatorDefault:
             description: ProjectCreatorDefault if true, a binding with this RoleTemplate
-              will be created for a users when they create a new project. ProjectCreatorDefault
+              will be created for a user when they create a new project. ProjectCreatorDefault
               is only evaluated if the context of the RoleTemplate is set to project.
               Default to false.
             type: boolean
@@ -92,7 +92,7 @@ spec:
               type: string
             type: array
           rules:
-            description: Rules holds all the PolicyRules for this RoleTemplate
+            description: Rules holds all the PolicyRules for this RoleTemplate.
             items:
               description: PolicyRule holds information that describes a policy rule,
                 but does not contain information about who the rule applies to or

--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -129,7 +129,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	// TODO user should be dynamically authorized to only see herself
 	// TODO enable when groups are "in". they need to be self-service
 
-	if err := rb.reconcileGlobalRoles(management); err != nil {
+	if err := rb.reconcileGlobalRoles(wrangler.Mgmt.GlobalRole()); err != nil {
 		return "", errors.Wrap(err, "problem reconciling global roles")
 	}
 
@@ -439,7 +439,7 @@ func addRoles(wrangler *wrangler.Context, management *config.ManagementContext) 
 	//	addRule().apiGroups("").resources("events").verbs("get", "list", "watch").
 	//	addRule().apiGroups("management.cattle.io").resources("clusterevents").verbs("get", "list", "watch")
 
-	if err := rb.reconcileRoleTemplates(management); err != nil {
+	if err := rb.reconcileRoleTemplates(wrangler.Mgmt.RoleTemplate()); err != nil {
 		return "", errors.Wrap(err, "problem reconciling role templates")
 	}
 

--- a/pkg/data/management/rolebuilder.go
+++ b/pkg/data/management/rolebuilder.go
@@ -5,9 +5,9 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
-	"github.com/rancher/norman/objectclient"
-	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/types/config"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	wranglerv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/wrangler/pkg/generic"
 	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -151,12 +151,12 @@ func (r *ruleBuilder) setRoleTemplateNames(names ...string) *roleBuilder {
 	return r.rb.setRoleTemplateNames(names...)
 }
 
-func (r *ruleBuilder) reconcileGlobalRoles(mgmt *config.ManagementContext) error {
-	return r.rb.reconcileGlobalRoles(mgmt)
+func (r *ruleBuilder) reconcileGlobalRoles(grClient wranglerv3.GlobalRoleClient) error {
+	return r.rb.reconcileGlobalRoles(grClient)
 }
 
-func (r *ruleBuilder) reconcileRoleTemplates(mgmt *config.ManagementContext) error {
-	return r.rb.reconcileRoleTemplates(mgmt)
+func (r *ruleBuilder) reconcileRoleTemplates(rtClient wranglerv3.RoleTemplateClient) error {
+	return r.rb.reconcileRoleTemplates(rtClient)
 }
 
 func (r *ruleBuilder) toPolicyRule() rbacv1.PolicyRule {
@@ -169,16 +169,26 @@ func (r *ruleBuilder) toPolicyRule() rbacv1.PolicyRule {
 	}
 }
 
-type buildFnc func(thisRB *roleBuilder) (string, runtime.Object)
-type compareAndModifyFnc func(have runtime.Object, want runtime.Object) (bool, runtime.Object, error)
-type gatherExistingFnc func() (map[string]runtime.Object, error)
+// buildFnc takes in a roleBuilder and returns desired runtime.Objects.
+type buildFnc[T runtime.Object] func(thisRB *roleBuilder) (name string, object T)
 
-func (rb *roleBuilder) reconcile(build buildFnc, gatherExisting gatherExistingFnc, compareAndModify compareAndModifyFnc, client *objectclient.ObjectClient) error {
+// compareAndModifyFnc check two objects and returns if they are different as well as the desired object to create.
+// haveObj will be mutated and returned contain the desired values from the wantObj.
+type compareAndModifyFnc[T runtime.Object] func(haveObj T, wantObj T) (isDifferent bool, desiredObject T, err error)
+
+// gatherExistingFnc returns a map of objects that already exist using the object name as the key.
+type gatherExistingFnc[T runtime.Object] func() (ObjectNameMap map[string]T, err error)
+
+func reconcile[T generic.RuntimeMetaObject, TList runtime.Object](
+	rb *roleBuilder, build buildFnc[T], gatherExisting gatherExistingFnc[T],
+	compareAndModify compareAndModifyFnc[T], client generic.NonNamespacedClientInterface[T, TList]) error {
 	current := rb.first()
-	builtRoles := map[string]runtime.Object{}
+	builtRoles := map[string]T{}
 	for current != nil {
 		name, role := build(current)
-		builtRoles[name] = role
+		if name != "" {
+			builtRoles[name] = role
+		}
 		current = current.next
 	}
 
@@ -190,7 +200,7 @@ func (rb *roleBuilder) reconcile(build buildFnc, gatherExisting gatherExistingFn
 	for name := range existing {
 		if _, ok := builtRoles[name]; !ok {
 			logrus.Infof("Removing %v", name)
-			if err := client.Delete(name, &v1.DeleteOptions{}); err != nil {
+			if err := client.Delete(name, nil); err != nil {
 				return errors.Wrapf(err, "couldn't delete %v", name)
 			}
 			delete(existing, name)
@@ -204,7 +214,7 @@ func (rb *roleBuilder) reconcile(build buildFnc, gatherExisting gatherExistingFn
 				return err
 			}
 			if !equal {
-				if _, err := client.Update(name, modified); err != nil {
+				if _, err := client.Update(modified); err != nil {
 					return errors.Wrapf(err, "couldn't update %v", name)
 				}
 			}
@@ -220,10 +230,9 @@ func (rb *roleBuilder) reconcile(build buildFnc, gatherExisting gatherExistingFn
 	return nil
 }
 
-func (rb *roleBuilder) reconcileGlobalRoles(mgmt *config.ManagementContext) error {
+func (rb *roleBuilder) reconcileGlobalRoles(grClient wranglerv3.GlobalRoleClient) error {
 	logrus.Info("Reconciling GlobalRoles")
-
-	build := func(current *roleBuilder) (string, runtime.Object) {
+	build := func(current *roleBuilder) (string, *v3.GlobalRole) {
 		gr := &v3.GlobalRole{
 			ObjectMeta: v1.ObjectMeta{
 				Name:   current.name,
@@ -236,15 +245,14 @@ func (rb *roleBuilder) reconcileGlobalRoles(mgmt *config.ManagementContext) erro
 		return gr.Name, gr
 	}
 
-	grCli := mgmt.Management.GlobalRoles("")
-	gather := func() (map[string]runtime.Object, error) {
+	gather := func() (map[string]*v3.GlobalRole, error) {
 		set := labels.Set(defaultGRLabel)
-		existingList, err := grCli.List(v1.ListOptions{LabelSelector: set.String()})
+		existingList, err := grClient.List(v1.ListOptions{LabelSelector: set.String()})
 		if err != nil {
 			return nil, errors.Wrapf(err, "couldn't list globalRoles with selector %s", set)
 		}
 
-		existing := map[string]runtime.Object{}
+		existing := map[string]*v3.GlobalRole{}
 		for _, e := range existingList.Items {
 			existing[e.Name] = e.DeepCopy()
 		}
@@ -252,13 +260,7 @@ func (rb *roleBuilder) reconcileGlobalRoles(mgmt *config.ManagementContext) erro
 		return existing, nil
 	}
 
-	compareAndMod := func(have runtime.Object, want runtime.Object) (bool, runtime.Object, error) {
-		haveGR, ok := have.(*v3.GlobalRole)
-		wantGR, ok2 := want.(*v3.GlobalRole)
-		if !ok || !ok2 {
-			return false, nil, errors.Errorf("unexpected type comparing %v and %v", have, want)
-		}
-
+	compareAndMod := func(haveGR *v3.GlobalRole, wantGR *v3.GlobalRole) (bool, *v3.GlobalRole, error) {
 		builtin := haveGR.Builtin == wantGR.Builtin
 		equal := builtin && haveGR.DisplayName == wantGR.DisplayName && reflect.DeepEqual(haveGR.Rules, wantGR.Rules)
 
@@ -269,13 +271,12 @@ func (rb *roleBuilder) reconcileGlobalRoles(mgmt *config.ManagementContext) erro
 		return equal, haveGR, nil
 	}
 
-	return rb.reconcile(build, gather, compareAndMod, grCli.ObjectClient())
+	return reconcile[*v3.GlobalRole, *v3.GlobalRoleList](rb, build, gather, compareAndMod, grClient)
 }
 
-func (rb *roleBuilder) reconcileRoleTemplates(mgmt *config.ManagementContext) error {
+func (rb *roleBuilder) reconcileRoleTemplates(rtClient wranglerv3.RoleTemplateClient) error {
 	logrus.Info("Reconciling RoleTemplates")
-
-	build := func(current *roleBuilder) (string, runtime.Object) {
+	build := func(current *roleBuilder) (string, *v3.RoleTemplate) {
 		role := &v3.RoleTemplate{
 			ObjectMeta: v1.ObjectMeta{
 				Name:   current.name,
@@ -293,15 +294,14 @@ func (rb *roleBuilder) reconcileRoleTemplates(mgmt *config.ManagementContext) er
 		return role.Name, role
 	}
 
-	client := mgmt.Management.RoleTemplates("")
-	gather := func() (map[string]runtime.Object, error) {
+	gather := func() (map[string]*v3.RoleTemplate, error) {
 		set := labels.Set(defaultRTLabel)
-		existingList, err := client.List(v1.ListOptions{LabelSelector: set.String()})
+		existingList, err := rtClient.List(v1.ListOptions{LabelSelector: set.String()})
 		if err != nil {
 			return nil, errors.Wrapf(err, "couldn't list roleTemplate with selector %s", set)
 		}
 
-		existing := map[string]runtime.Object{}
+		existing := map[string]*v3.RoleTemplate{}
 		for _, e := range existingList.Items {
 			existing[e.Name] = e.DeepCopy()
 		}
@@ -309,13 +309,7 @@ func (rb *roleBuilder) reconcileRoleTemplates(mgmt *config.ManagementContext) er
 		return existing, nil
 	}
 
-	compareAndMod := func(have runtime.Object, want runtime.Object) (bool, runtime.Object, error) {
-		haveRT, ok := have.(*v3.RoleTemplate)
-		wantRT, ok2 := want.(*v3.RoleTemplate)
-		if !ok || !ok2 {
-			return false, nil, errors.Errorf("unexpected type comparing %v and %v", have, want)
-		}
-
+	compareAndMod := func(haveRT *v3.RoleTemplate, wantRT *v3.RoleTemplate) (bool, *v3.RoleTemplate, error) {
 		equal := haveRT.DisplayName == wantRT.DisplayName && reflect.DeepEqual(haveRT.Rules, wantRT.Rules) &&
 			reflect.DeepEqual(haveRT.RoleTemplateNames, wantRT.RoleTemplateNames) && haveRT.Builtin == wantRT.Builtin &&
 			haveRT.External == wantRT.External && haveRT.Hidden == wantRT.Hidden && haveRT.Context == wantRT.Context &&
@@ -333,5 +327,5 @@ func (rb *roleBuilder) reconcileRoleTemplates(mgmt *config.ManagementContext) er
 		return equal, haveRT, nil
 	}
 
-	return rb.reconcile(build, gather, compareAndMod, client.ObjectClient())
+	return reconcile[*v3.RoleTemplate, *v3.RoleTemplateList](rb, build, gather, compareAndMod, rtClient)
 }

--- a/pkg/data/management/rolebuilder_test.go
+++ b/pkg/data/management/rolebuilder_test.go
@@ -1,0 +1,576 @@
+package management
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/wrangler/pkg/generic/fake"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var errExpected = fmt.Errorf("expected error")
+
+type testMocks struct {
+	t            *testing.T
+	grClientMock *fake.MockNonNamespacedClientInterface[*v3.GlobalRole, *v3.GlobalRoleList]
+	rtClientMock *fake.MockNonNamespacedClientInterface[*v3.RoleTemplate, *v3.RoleTemplateList]
+}
+
+var (
+	ruleReadPods = rbacv1.PolicyRule{
+		Verbs:     []string{"GET", "WATCH"},
+		APIGroups: []string{"v1"},
+		Resources: []string{"pods"},
+	}
+	ruleReadServices = rbacv1.PolicyRule{
+		Verbs:     []string{"GET", "WATCH"},
+		APIGroups: []string{"v1"},
+		Resources: []string{"services"},
+	}
+	ruleWriteNodes = rbacv1.PolicyRule{
+		Verbs:     []string{"PUT", "CREATE", "UPDATE"},
+		APIGroups: []string{"v1"},
+		Resources: []string{"nodes"},
+	}
+	ruleAdmin = rbacv1.PolicyRule{
+		Verbs:     []string{"*"},
+		APIGroups: []string{"*"},
+		Resources: []string{"*"},
+	}
+)
+
+func Test_reconcileGlobalRoles(t *testing.T) {
+	readGR := &v3.GlobalRole{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "read-gr",
+		},
+		DisplayName: "Read GR",
+		Rules:       []rbacv1.PolicyRule{ruleReadPods, ruleReadServices},
+		Builtin:     true,
+	}
+	adminGR := &v3.GlobalRole{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "admin-gr",
+		},
+		DisplayName: "Admin GR",
+		Rules:       []rbacv1.PolicyRule{ruleAdmin},
+		Builtin:     true,
+	}
+	basicGR := &v3.GlobalRole{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "basic-gr",
+		},
+		DisplayName: "Basic GR",
+		Rules:       []rbacv1.PolicyRule{ruleReadPods},
+		Builtin:     true,
+	}
+	tests := []struct {
+		name        string
+		grsToCreate []*v3.GlobalRole
+		setup       func(mocks testMocks)
+		wantErr     bool
+	}{
+		{
+			name:        "Create new GRB with no preexisting",
+			grsToCreate: []*v3.GlobalRole{basicGR},
+			setup: func(mocks testMocks) {
+
+				// return empty list
+				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(&v3.GlobalRoleList{}, nil)
+				mocks.grClientMock.EXPECT().Create(ObjectMatcher(basicGR)).DoAndReturn(
+					func(toCreate *v3.GlobalRole) (*v3.GlobalRole, error) {
+						require.EqualValues(mocks.t, basicGR.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, basicGR.Name, toCreate.Name, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, basicGR.DisplayName, toCreate.DisplayName, "roleBuilder did not attempt to create the correct role")
+						return toCreate, nil
+					})
+			},
+		},
+		{
+			name:        "Create new GRB and append to existing",
+			grsToCreate: []*v3.GlobalRole{basicGR, adminGR},
+			setup: func(mocks testMocks) {
+				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*adminGR}}
+				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.grClientMock.EXPECT().Create(ObjectMatcher(basicGR)).DoAndReturn(
+					func(toCreate *v3.GlobalRole) (*v3.GlobalRole, error) {
+						require.EqualValues(mocks.t, basicGR.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, basicGR.Name, toCreate.Name, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, basicGR.DisplayName, toCreate.DisplayName, "roleBuilder did not attempt to create the correct role")
+						return toCreate, nil
+					})
+
+			},
+		},
+		{
+			name:        "Create multiple new GRBs",
+			grsToCreate: []*v3.GlobalRole{basicGR, readGR, adminGR},
+			setup: func(mocks testMocks) {
+				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*adminGR}}
+				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+
+				mocks.grClientMock.EXPECT().Create(ObjectMatcher(basicGR)).DoAndReturn(
+					func(toCreate *v3.GlobalRole) (*v3.GlobalRole, error) {
+						require.EqualValues(mocks.t, basicGR.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, basicGR.Name, toCreate.Name, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, basicGR.DisplayName, toCreate.DisplayName, "roleBuilder did not attempt to create the correct role")
+						return toCreate, nil
+					},
+				)
+				mocks.grClientMock.EXPECT().Create(ObjectMatcher(readGR)).DoAndReturn(
+					func(toCreate *v3.GlobalRole) (*v3.GlobalRole, error) {
+						require.EqualValues(mocks.t, readGR.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, readGR.Name, toCreate.Name, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, readGR.DisplayName, toCreate.DisplayName, "roleBuilder did not attempt to create the correct role")
+						return toCreate, nil
+					},
+				)
+			},
+		},
+
+		{
+			name:        "Update existing GRB DisplayName",
+			grsToCreate: []*v3.GlobalRole{adminGR},
+			setup: func(mocks testMocks) {
+				oldAdmin := adminGR.DeepCopy()
+				oldAdmin.DisplayName = "Old Display Name"
+				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*oldAdmin}}
+				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.grClientMock.EXPECT().Update(ObjectMatcher(adminGR)).DoAndReturn(
+					func(toUpdate *v3.GlobalRole) (*v3.GlobalRole, error) {
+						require.EqualValues(mocks.t, adminGR.Rules, toUpdate.Rules, "roleBuilder attempted to update rules that were not changed")
+						require.EqualValues(mocks.t, adminGR.DisplayName, toUpdate.DisplayName, "roleBuilder did not attempt to update the correct DisplayName")
+						return toUpdate, nil
+					})
+			},
+		},
+		{
+			name:        "Update existing GRB Rules",
+			grsToCreate: []*v3.GlobalRole{adminGR},
+			setup: func(mocks testMocks) {
+				oldAdmin := adminGR.DeepCopy()
+				oldAdmin.Rules = append(oldAdmin.Rules, ruleWriteNodes)
+				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*oldAdmin}}
+				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.grClientMock.EXPECT().Update(ObjectMatcher(adminGR)).DoAndReturn(
+					func(toUpdate *v3.GlobalRole) (*v3.GlobalRole, error) {
+						require.EqualValues(mocks.t, adminGR.Rules, toUpdate.Rules, "roleBuilder did not attempt to update the correct rules")
+						require.EqualValues(mocks.t, adminGR.DisplayName, toUpdate.DisplayName, "roleBuilder attempted to update the unchanged display name")
+						return toUpdate, nil
+					})
+			},
+		},
+		{
+			name:        "Delete existing GRB Rules",
+			grsToCreate: nil,
+			setup: func(mocks testMocks) {
+				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*adminGR}}
+				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.grClientMock.EXPECT().Delete(adminGR.Name, nil).Return(nil)
+			},
+		},
+		{
+			name:    "Fail to delete existing GRB Rules",
+			wantErr: true,
+			setup: func(mocks testMocks) {
+				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*adminGR}}
+				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.grClientMock.EXPECT().Delete(adminGR.Name, nil).Return(errExpected)
+			},
+		},
+		{
+			name:    "Fail to list existing GRB Rules",
+			wantErr: true,
+			setup: func(mocks testMocks) {
+				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(nil, errExpected)
+			},
+		},
+		{
+			name:        "Fail to create new GRB",
+			grsToCreate: []*v3.GlobalRole{basicGR},
+			wantErr:     true,
+			setup: func(mocks testMocks) {
+				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(&v3.GlobalRoleList{}, nil)
+				mocks.grClientMock.EXPECT().Create(ObjectMatcher(basicGR)).Return(nil, errExpected)
+			},
+		},
+		{
+			name:        "Fail to update existing GRB",
+			grsToCreate: []*v3.GlobalRole{adminGR},
+			wantErr:     true,
+			setup: func(mocks testMocks) {
+				oldAdmin := adminGR.DeepCopy()
+				oldAdmin.Rules = append(oldAdmin.Rules, ruleWriteNodes)
+				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*oldAdmin}}
+				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.grClientMock.EXPECT().Update(ObjectMatcher(adminGR)).Return(nil, errExpected)
+			},
+		},
+	}
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			rb := newRoleBuilder()
+			addGlobalRole(rb, test.grsToCreate...)
+			ctrl := gomock.NewController(t)
+			mocks := testMocks{
+				t:            t,
+				grClientMock: fake.NewMockNonNamespacedClientInterface[*v3.GlobalRole, *v3.GlobalRoleList](ctrl),
+			}
+			if test.setup != nil {
+				test.setup(mocks)
+			}
+			err := rb.reconcileGlobalRoles(mocks.grClientMock)
+			if test.wantErr {
+				require.Error(t, err, "Expected an error while reconciling roles.")
+			} else {
+				require.NoError(t, err, "Unexpected error while reconciling roles.")
+			}
+		})
+	}
+}
+
+func Test_reconcileRoleTemplate(t *testing.T) {
+	readRT := &v3.RoleTemplate{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "read-rt",
+		},
+		DisplayName: "Read RT",
+		Rules:       []rbacv1.PolicyRule{ruleReadPods, ruleReadServices},
+		Context:     "cluster",
+		Builtin:     true,
+	}
+	adminRT := &v3.RoleTemplate{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "admin-rt",
+		},
+		DisplayName: "Admin RT",
+		Rules:       []rbacv1.PolicyRule{ruleAdmin},
+		Context:     "cluster",
+		Builtin:     true,
+	}
+	basicRT := &v3.RoleTemplate{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "basic-rt",
+		},
+		DisplayName: "Basic RT",
+		Rules:       []rbacv1.PolicyRule{ruleReadPods},
+		Context:     "project",
+		Builtin:     true,
+	}
+	tests := []struct {
+		name        string
+		rtsToCreate []*v3.RoleTemplate
+		setup       func(mocks testMocks)
+		wantErr     bool
+	}{
+		{
+			name:        "Create new RT with no preexisting roles",
+			rtsToCreate: []*v3.RoleTemplate{basicRT},
+			setup: func(mocks testMocks) {
+				// return empty list
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(&v3.RoleTemplateList{}, nil)
+				mocks.rtClientMock.EXPECT().Create(ObjectMatcher(basicRT)).DoAndReturn(
+					func(toCreate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+						require.EqualValues(mocks.t, basicRT.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, basicRT.Name, toCreate.Name, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, basicRT.DisplayName, toCreate.DisplayName, "roleBuilder did not attempt to create the correct role")
+						return toCreate, nil
+					})
+			},
+		},
+		{
+			name:        "Create new RT and append to existing",
+			rtsToCreate: []*v3.RoleTemplate{basicRT, adminRT},
+			setup: func(mocks testMocks) {
+				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*adminRT}}
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().Create(ObjectMatcher(basicRT)).DoAndReturn(
+					func(toCreate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+						require.EqualValues(mocks.t, basicRT.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, basicRT.Name, toCreate.Name, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, basicRT.DisplayName, toCreate.DisplayName, "roleBuilder did not attempt to create the correct role")
+						return toCreate, nil
+					})
+			},
+		},
+		{
+			name:        "Create multiple new RTs",
+			rtsToCreate: []*v3.RoleTemplate{basicRT, adminRT, readRT},
+			setup: func(mocks testMocks) {
+				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*adminRT}}
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+
+				mocks.rtClientMock.EXPECT().Create(ObjectMatcher(basicRT)).DoAndReturn(
+					func(toCreate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+						require.EqualValues(mocks.t, basicRT.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, basicRT.Name, toCreate.Name, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, basicRT.DisplayName, toCreate.DisplayName, "roleBuilder did not attempt to create the correct role")
+						return toCreate, nil
+					},
+				)
+				mocks.rtClientMock.EXPECT().Create(ObjectMatcher(readRT)).DoAndReturn(
+					func(toCreate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+						require.EqualValues(mocks.t, readRT.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, readRT.Name, toCreate.Name, "roleBuilder did not attempt to create the correct role")
+						require.EqualValues(mocks.t, readRT.DisplayName, toCreate.DisplayName, "roleBuilder did not attempt to create the correct role")
+						return toCreate, nil
+					},
+				)
+			},
+		},
+
+		{
+			name:        "Update existing RT DisplayName",
+			rtsToCreate: []*v3.RoleTemplate{adminRT},
+			setup: func(mocks testMocks) {
+				oldAdmin := adminRT.DeepCopy()
+				oldAdmin.DisplayName = "Update Display Name"
+				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
+					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+						require.EqualValues(mocks.t, adminRT.Rules, toUpdate.Rules, "roleBuilder attempted to update rules that were not changed")
+						require.EqualValues(mocks.t, adminRT.DisplayName, toUpdate.DisplayName, "roleBuilder did not attempt to update the correct DisplayName")
+						return toUpdate, nil
+					})
+			},
+		},
+		{
+			name:        "Update existing RT Rules",
+			rtsToCreate: []*v3.RoleTemplate{adminRT},
+			setup: func(mocks testMocks) {
+				oldAdmin := adminRT.DeepCopy()
+				oldAdmin.Rules = append(oldAdmin.Rules, ruleWriteNodes)
+				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
+					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+						require.EqualValues(mocks.t, adminRT.Rules, toUpdate.Rules, "roleBuilder did not attempt to update the correct rules")
+						require.EqualValues(mocks.t, adminRT.DisplayName, toUpdate.DisplayName, "roleBuilder attempted to update the unchanged display name")
+						return toUpdate, nil
+					})
+			},
+		},
+		{
+			name:        "Update existing RT builtin bool",
+			rtsToCreate: []*v3.RoleTemplate{adminRT},
+			setup: func(mocks testMocks) {
+				oldAdmin := adminRT.DeepCopy()
+				oldAdmin.Builtin = false
+				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
+					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+						require.EqualValues(mocks.t, adminRT.Builtin, toUpdate.Builtin, "roleBuilder did not make the correct updates")
+						require.EqualValues(mocks.t, adminRT.DisplayName, toUpdate.DisplayName, "roleBuilder attempted to update the unchanged display name")
+						return toUpdate, nil
+					})
+			},
+		},
+		{
+			name:        "Update existing RT External bool",
+			rtsToCreate: []*v3.RoleTemplate{adminRT},
+			setup: func(mocks testMocks) {
+				oldAdmin := adminRT.DeepCopy()
+				oldAdmin.External = true
+				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
+					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+						require.EqualValues(mocks.t, adminRT.External, toUpdate.External, "roleBuilder did not make the correct updates")
+						require.EqualValues(mocks.t, adminRT.DisplayName, toUpdate.DisplayName, "roleBuilder attempted to update the unchanged display name")
+						return toUpdate, nil
+					})
+			},
+		},
+		{
+			name:        "Update existing RT Hidden bool",
+			rtsToCreate: []*v3.RoleTemplate{adminRT},
+			setup: func(mocks testMocks) {
+				oldAdmin := adminRT.DeepCopy()
+				oldAdmin.Hidden = true
+				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
+					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+						require.EqualValues(mocks.t, adminRT.Hidden, toUpdate.Hidden, "roleBuilder did not make the correct updates")
+						require.EqualValues(mocks.t, adminRT.DisplayName, toUpdate.DisplayName, "roleBuilder attempted to update the unchanged display name")
+						return toUpdate, nil
+					})
+			},
+		},
+		{
+			name:        "Update existing RT Context",
+			rtsToCreate: []*v3.RoleTemplate{adminRT},
+			setup: func(mocks testMocks) {
+				oldAdmin := adminRT.DeepCopy()
+				oldAdmin.Context = "project"
+				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
+					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+						require.EqualValues(mocks.t, adminRT.Context, toUpdate.Context, "roleBuilder did not make the correct updates")
+						require.EqualValues(mocks.t, adminRT.DisplayName, toUpdate.DisplayName, "roleBuilder attempted to update the unchanged display name")
+						return toUpdate, nil
+					})
+			},
+		},
+		{
+			name:        "Update existing RT inherited RoleTemplates",
+			rtsToCreate: []*v3.RoleTemplate{adminRT},
+			setup: func(mocks testMocks) {
+				oldAdmin := adminRT.DeepCopy()
+				oldAdmin.RoleTemplateNames = []string{readRT.Name}
+				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
+					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+						require.EqualValues(mocks.t, adminRT.RoleTemplateNames, toUpdate.RoleTemplateNames, "roleBuilder did not make the correct updates")
+						require.EqualValues(mocks.t, adminRT.DisplayName, toUpdate.DisplayName, "roleBuilder attempted to update the unchanged display name")
+						return toUpdate, nil
+					})
+			},
+		},
+		{
+			name:        "Update existing RT Administrative bool",
+			rtsToCreate: []*v3.RoleTemplate{adminRT},
+			setup: func(mocks testMocks) {
+				oldAdmin := adminRT.DeepCopy()
+				oldAdmin.Administrative = true
+				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
+					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+						require.EqualValues(mocks.t, adminRT.Administrative, toUpdate.Administrative, "roleBuilder did not make the correct updates")
+						require.EqualValues(mocks.t, adminRT.DisplayName, toUpdate.DisplayName, "roleBuilder attempted to update the unchanged display name")
+						return toUpdate, nil
+					})
+			},
+		},
+		{
+			name:        "Delete existing RT Rules",
+			rtsToCreate: nil,
+			setup: func(mocks testMocks) {
+				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*adminRT}}
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().Delete(adminRT.Name, nil).Return(nil)
+			},
+		},
+		{
+			name:        "Fail to delete existing RT Rules",
+			rtsToCreate: nil,
+			setup: func(mocks testMocks) {
+				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*adminRT}}
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().Delete(adminRT.Name, nil).Return(errExpected)
+			},
+			wantErr: true,
+		},
+		{
+			name:    "Fail to list existing GRB Rules",
+			wantErr: true,
+			setup: func(mocks testMocks) {
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(nil, errExpected)
+			},
+		},
+		{
+			name:        "Fail to create new GRB",
+			rtsToCreate: []*v3.RoleTemplate{basicRT},
+			wantErr:     true,
+			setup: func(mocks testMocks) {
+				// return empty list
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(&v3.RoleTemplateList{}, nil)
+				mocks.rtClientMock.EXPECT().Create(ObjectMatcher(basicRT)).Return(nil, errExpected)
+			},
+		},
+		{
+			name:        "Fail to update existing GRB",
+			rtsToCreate: []*v3.RoleTemplate{adminRT},
+			wantErr:     true,
+			setup: func(mocks testMocks) {
+				oldAdmin := adminRT.DeepCopy()
+				oldAdmin.Rules = append(oldAdmin.Rules, ruleWriteNodes)
+				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
+				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).Return(nil, errExpected)
+			},
+		},
+	}
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			rb := newRoleBuilder()
+			addRoleTemplates(rb, test.rtsToCreate...)
+			ctrl := gomock.NewController(t)
+			mocks := testMocks{
+				t:            t,
+				rtClientMock: fake.NewMockNonNamespacedClientInterface[*v3.RoleTemplate, *v3.RoleTemplateList](ctrl),
+			}
+			if test.setup != nil {
+				test.setup(mocks)
+			}
+			err := rb.reconcileRoleTemplates(mocks.rtClientMock)
+			if test.wantErr {
+				require.Error(t, err, "Expected an error while reconciling roles.")
+			} else {
+				require.NoError(t, err, "Unexpected error while reconciling roles.")
+			}
+		})
+	}
+}
+
+func addGlobalRole(builder *roleBuilder, roles ...*v3.GlobalRole) {
+	for _, gr := range roles {
+		addRules(
+			builder.addRole(gr.DisplayName, gr.Name),
+			gr.Rules...,
+		)
+	}
+}
+func addRoleTemplates(builder *roleBuilder, templates ...*v3.RoleTemplate) {
+	for _, rt := range templates {
+		addRules(
+			builder.addRoleTemplate(
+				rt.DisplayName, rt.Name, rt.Context, rt.External, rt.Hidden, rt.Administrative,
+			),
+			rt.Rules...,
+		)
+	}
+}
+func addRules(builder *roleBuilder, rules ...rbacv1.PolicyRule) {
+	for _, rule := range rules {
+		rb := builder.addRule()
+		rb.verbs(rule.Verbs...)
+		rb.apiGroups(rule.APIGroups...)
+		rb.resources(rule.Resources...)
+		rb.resourceNames(rule.ResourceNames...)
+		rb.nonResourceURLs(rule.NonResourceURLs...)
+	}
+}
+
+type objectMatcher struct {
+	name      string
+	namespace string
+}
+
+func (o objectMatcher) Matches(x any) bool {
+	obj, ok := x.(v1.Object)
+	if !ok {
+		return false
+	}
+	return obj.GetName() == o.name && obj.GetNamespace() == o.namespace
+}
+func (o objectMatcher) String() string {
+	return fmt.Sprintf("is equal to metav1.Object with name: %q and namespace: %q", o.name, o.namespace)
+}
+
+func ObjectMatcher(obj v1.Object) gomock.Matcher {
+	return &objectMatcher{obj.GetName(), obj.GetNamespace()}
+}

--- a/pkg/data/management/rolebuilder_test.go
+++ b/pkg/data/management/rolebuilder_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/controllers"
 	"github.com/rancher/wrangler/pkg/generic/fake"
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -81,6 +82,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 
 				// return empty list
 				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(&v3.GlobalRoleList{}, nil)
+				mocks.grClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.grClientMock, nil)
 				mocks.grClientMock.EXPECT().Create(ObjectMatcher(basicGR)).DoAndReturn(
 					func(toCreate *v3.GlobalRole) (*v3.GlobalRole, error) {
 						require.EqualValues(mocks.t, basicGR.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
@@ -96,6 +98,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			setup: func(mocks testMocks) {
 				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*adminGR}}
 				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.grClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.grClientMock, nil)
 				mocks.grClientMock.EXPECT().Create(ObjectMatcher(basicGR)).DoAndReturn(
 					func(toCreate *v3.GlobalRole) (*v3.GlobalRole, error) {
 						require.EqualValues(mocks.t, basicGR.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
@@ -112,7 +115,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			setup: func(mocks testMocks) {
 				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*adminGR}}
 				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
-
+				mocks.grClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.grClientMock, nil)
 				mocks.grClientMock.EXPECT().Create(ObjectMatcher(basicGR)).DoAndReturn(
 					func(toCreate *v3.GlobalRole) (*v3.GlobalRole, error) {
 						require.EqualValues(mocks.t, basicGR.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
@@ -140,6 +143,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 				oldAdmin.DisplayName = "Old Display Name"
 				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*oldAdmin}}
 				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.grClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.grClientMock, nil)
 				mocks.grClientMock.EXPECT().Update(ObjectMatcher(adminGR)).DoAndReturn(
 					func(toUpdate *v3.GlobalRole) (*v3.GlobalRole, error) {
 						require.EqualValues(mocks.t, adminGR.Rules, toUpdate.Rules, "roleBuilder attempted to update rules that were not changed")
@@ -156,6 +160,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 				oldAdmin.Rules = append(oldAdmin.Rules, ruleWriteNodes)
 				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*oldAdmin}}
 				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.grClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.grClientMock, nil)
 				mocks.grClientMock.EXPECT().Update(ObjectMatcher(adminGR)).DoAndReturn(
 					func(toUpdate *v3.GlobalRole) (*v3.GlobalRole, error) {
 						require.EqualValues(mocks.t, adminGR.Rules, toUpdate.Rules, "roleBuilder did not attempt to update the correct rules")
@@ -170,6 +175,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			setup: func(mocks testMocks) {
 				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*adminGR}}
 				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.grClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.grClientMock, nil)
 				mocks.grClientMock.EXPECT().Delete(adminGR.Name, nil).Return(nil)
 			},
 		},
@@ -179,6 +185,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			setup: func(mocks testMocks) {
 				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*adminGR}}
 				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.grClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.grClientMock, nil)
 				mocks.grClientMock.EXPECT().Delete(adminGR.Name, nil).Return(errExpected)
 			},
 		},
@@ -186,6 +193,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			name:    "Fail to list existing GRB Rules",
 			wantErr: true,
 			setup: func(mocks testMocks) {
+				mocks.grClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.grClientMock, nil)
 				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(nil, errExpected)
 			},
 		},
@@ -195,6 +203,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 			wantErr:     true,
 			setup: func(mocks testMocks) {
 				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(&v3.GlobalRoleList{}, nil)
+				mocks.grClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.grClientMock, nil)
 				mocks.grClientMock.EXPECT().Create(ObjectMatcher(basicGR)).Return(nil, errExpected)
 			},
 		},
@@ -207,6 +216,7 @@ func Test_reconcileGlobalRoles(t *testing.T) {
 				oldAdmin.Rules = append(oldAdmin.Rules, ruleWriteNodes)
 				curr := &v3.GlobalRoleList{Items: []v3.GlobalRole{*oldAdmin}}
 				mocks.grClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.grClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.grClientMock, nil)
 				mocks.grClientMock.EXPECT().Update(ObjectMatcher(adminGR)).Return(nil, errExpected)
 			},
 		},
@@ -275,6 +285,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 			setup: func(mocks testMocks) {
 				// return empty list
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(&v3.RoleTemplateList{}, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Create(ObjectMatcher(basicRT)).DoAndReturn(
 					func(toCreate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
 						require.EqualValues(mocks.t, basicRT.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
@@ -290,6 +301,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 			setup: func(mocks testMocks) {
 				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*adminRT}}
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Create(ObjectMatcher(basicRT)).DoAndReturn(
 					func(toCreate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
 						require.EqualValues(mocks.t, basicRT.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
@@ -305,7 +317,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 			setup: func(mocks testMocks) {
 				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*adminRT}}
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
-
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Create(ObjectMatcher(basicRT)).DoAndReturn(
 					func(toCreate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
 						require.EqualValues(mocks.t, basicRT.Rules, toCreate.Rules, "roleBuilder did not attempt to create the correct role")
@@ -333,6 +345,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 				oldAdmin.DisplayName = "Update Display Name"
 				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
 					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
 						require.EqualValues(mocks.t, adminRT.Rules, toUpdate.Rules, "roleBuilder attempted to update rules that were not changed")
@@ -349,6 +362,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 				oldAdmin.Rules = append(oldAdmin.Rules, ruleWriteNodes)
 				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
 					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
 						require.EqualValues(mocks.t, adminRT.Rules, toUpdate.Rules, "roleBuilder did not attempt to update the correct rules")
@@ -365,6 +379,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 				oldAdmin.Builtin = false
 				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
 					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
 						require.EqualValues(mocks.t, adminRT.Builtin, toUpdate.Builtin, "roleBuilder did not make the correct updates")
@@ -381,6 +396,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 				oldAdmin.External = true
 				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
 					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
 						require.EqualValues(mocks.t, adminRT.External, toUpdate.External, "roleBuilder did not make the correct updates")
@@ -397,6 +413,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 				oldAdmin.Hidden = true
 				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
 					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
 						require.EqualValues(mocks.t, adminRT.Hidden, toUpdate.Hidden, "roleBuilder did not make the correct updates")
@@ -413,6 +430,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 				oldAdmin.Context = "project"
 				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
 					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
 						require.EqualValues(mocks.t, adminRT.Context, toUpdate.Context, "roleBuilder did not make the correct updates")
@@ -429,6 +447,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 				oldAdmin.RoleTemplateNames = []string{readRT.Name}
 				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
 					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
 						require.EqualValues(mocks.t, adminRT.RoleTemplateNames, toUpdate.RoleTemplateNames, "roleBuilder did not make the correct updates")
@@ -445,6 +464,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 				oldAdmin.Administrative = true
 				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).DoAndReturn(
 					func(toUpdate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
 						require.EqualValues(mocks.t, adminRT.Administrative, toUpdate.Administrative, "roleBuilder did not make the correct updates")
@@ -459,6 +479,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 			setup: func(mocks testMocks) {
 				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*adminRT}}
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Delete(adminRT.Name, nil).Return(nil)
 			},
 		},
@@ -468,6 +489,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 			setup: func(mocks testMocks) {
 				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*adminRT}}
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Delete(adminRT.Name, nil).Return(errExpected)
 			},
 			wantErr: true,
@@ -477,6 +499,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 			wantErr: true,
 			setup: func(mocks testMocks) {
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(nil, errExpected)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 			},
 		},
 		{
@@ -486,6 +509,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 			setup: func(mocks testMocks) {
 				// return empty list
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(&v3.RoleTemplateList{}, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Create(ObjectMatcher(basicRT)).Return(nil, errExpected)
 			},
 		},
@@ -498,6 +522,7 @@ func Test_reconcileRoleTemplate(t *testing.T) {
 				oldAdmin.Rules = append(oldAdmin.Rules, ruleWriteNodes)
 				curr := &v3.RoleTemplateList{Items: []v3.RoleTemplate{*oldAdmin}}
 				mocks.rtClientMock.EXPECT().List(gomock.Any()).Return(curr, nil)
+				mocks.rtClientMock.EXPECT().WithImpersonation(controllers.WebhookImpersonation()).Return(mocks.rtClientMock, nil)
 				mocks.rtClientMock.EXPECT().Update(ObjectMatcher(adminRT)).Return(nil, errExpected)
 			},
 		},


### PR DESCRIPTION
## Problem
When Rancher starts, we create/update all built-in RoleTemplates, such as (cluster-owner). With new validation going into the webhook, we will no longer allow modification to built-in RoleTemplates or GlobalRoles. Rancher will still need a way to manage the resources, so it must be able to bypass the Webhook validation that blocks mutation to built-in RoleTemplates and GlobalRoles.

## Changes Overview
We will leverage the Webhook bypass mechanism to allow Rancher to manage built-in RoleTemplats, which requires us to impersonate the Webhook's sudo service account. This can be done using a Wrangler client's `WithImpersonation(..)` method. 

To accomplish this, we need to do the following steps
- Update the code that installs roles to use wrangler clients instead of norman clients
- Add Unit test for changed code
- Updated the new wrangler clients to make calls with impersonation


This PR adds impersonation to requests that are sent by the rolebinding reconciliation logic so that Rancher can edit builtin roles.
This requires us first to switch the Norman clients to use Wrangler clients. Then update the clients to use impersonation.

Related to: https://github.com/rancher/webhook/pull/259
~~This PR is dependent on the Wrangler Bump PR: https://github.com/rancher/rancher/pull/41817~~