### PR TITLE
Reverting cli version to v2.7.0

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -165,7 +165,7 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
 
 ENV CATTLE_UI_VERSION 2.7.5-rc4
 ENV CATTLE_DASHBOARD_UI_VERSION v2.7.5-rc4
-ENV CATTLE_CLI_VERSION v2.7.2-rc1
+ENV CATTLE_CLI_VERSION v2.7.0
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install
 ENV CATTLE_BASE_UI_BRAND=

--- a/tests/v2/codecoverage/package/Dockerfile
+++ b/tests/v2/codecoverage/package/Dockerfile
@@ -165,7 +165,7 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
 
 ENV CATTLE_UI_VERSION 2.7.5-rc2
 ENV CATTLE_DASHBOARD_UI_VERSION v2.7.5-rc2
-ENV CATTLE_CLI_VERSION v2.7.2-rc1
+ENV CATTLE_CLI_VERSION v2.7.0
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install
 ENV CATTLE_BASE_UI_BRAND=


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
The 2.7.2-rc1 version of the rancher cli was invalid. Reverting to v2.7.0 for this release.
