### PR TITLE
Add validation test for secret encryption

### DIFF
--- a/tests/framework/extensions/nodes/node_status.go
+++ b/tests/framework/extensions/nodes/node_status.go
@@ -20,6 +20,11 @@ const (
 	clusterLabel             = "cluster.x-k8s.io/cluster-name"
 	PollInterval             = time.Duration(5 * time.Second)
 	PollTimeout              = time.Duration(15 * time.Minute)
+	EtcdNodeLabel            = "node-role.kubernetes.io/etcd"
+	MachineAnnotation        = "cluster.x-k8s.io/machine"
+	K3sExternalIP            = "k3s.io/external-ip"
+	RKE2ExternalIP           = "rke2.io/external-ip"
+	ClusterAnnotation        = "cluster.x-k8s.io/cluster-name"
 )
 
 // AllManagementNodeReady is a helper method that will loop and check if the node is ready in the RKE1 cluster.

--- a/tests/v2/validation/encryption/README.md
+++ b/tests/v2/validation/encryption/README.md
@@ -1,0 +1,36 @@
+# Secret Encryption Configs
+
+## Getting Started
+Your GO suite should be set to `-run ^TestK3sSecretEncryption/TestK3sSecretEncryptionEnabled$` or `-run ^TestK3sSecretEncryption/TestK3sSecretEncryptionDisabled$` for K3S clusters and `-run ^TestRKE2SecretEncryption` for RKE2 clusters. You can find any additional suite name(s) by checking the test file you plan to run.
+
+In your config file, set the following:
+```json
+"rancher": { 
+  "host": "rancher_server_address",
+  "adminToken": "rancher_admin_token"
+  "clusterName": "<cluster-to-run-test>"
+},
+"sshConfig": {
+  "user": "<ssh-user-of-cluster-nodes>"
+}
+```
+
+Typically, a cluster with the following 3 pools is used for testing:
+```yaml
+{
+  {
+    ControlPlane: true,
+    Quantity:     1,
+  },
+  {
+    Etcd:     true,
+    Quantity: 1,
+  },
+  {
+    Worker:   true,
+    Quantity: 1,
+  },
+}
+```
+
+These tests are designed to accept an existing cluster that the user has access to. If you do not have a downstream cluster in rancher, you should create one first before running this test. 

--- a/tests/v2/validation/encryption/k3s_secret_encryption_test.go
+++ b/tests/v2/validation/encryption/k3s_secret_encryption_test.go
@@ -1,0 +1,256 @@
+package encryption
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/kubeconfig"
+	nodestatus "github.com/rancher/rancher/tests/framework/extensions/nodes"
+	"github.com/rancher/rancher/tests/framework/extensions/secrets"
+	"github.com/rancher/rancher/tests/framework/extensions/sshkeys"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+type K3sSecretEncryptionTestSuite struct {
+	suite.Suite
+	session *session.Session
+	client  *rancher.Client
+	ns      string
+	sshUser string
+}
+
+func (s *K3sSecretEncryptionTestSuite) TearDownSuite() {
+	s.session.Cleanup()
+}
+
+func (s *K3sSecretEncryptionTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	s.session = testSession
+
+	s.ns = "default"
+	sshCfg := &SSHConfig{}
+	config.LoadConfig(SSHConfigFileKey, sshCfg)
+	s.sshUser = sshCfg.User
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(s.T(), err)
+
+	s.client = client
+}
+
+func (s *K3sSecretEncryptionTestSuite) TestK3sSecretEncryptionDisabled() {
+	subSession := s.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := s.client.WithSession(subSession)
+	require.NoError(s.T(), err)
+
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(s.T(), clusterName, "Cluster name is not provided")
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(s.T(), err)
+
+	steveClient, err := client.Steve.ProxyDownstream(clusterID)
+	require.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), steveClient)
+
+	podLabelKey := namegen.AppendRandomString("app")
+	podLabelValue := namegen.AppendRandomString("encryption")
+	podLables := map[string]string{podLabelKey: podLabelValue}
+
+	secretObj, deploymentObj, err := createDeploymentWithSecret(steveClient, namegen.AppendRandomString("test-deployment"), namegen.AppendRandomString("test-secret"), s.ns, podLables)
+	require.NoError(s.T(), err)
+
+	require.NoError(s.T(), workloads.VerifyDeployment(steveClient, deploymentObj))
+	logrus.Infof("deployment with secret created successfully!")
+
+	query, err := url.ParseQuery(fmt.Sprintf("labelSelector=%s=%s", podLabelKey, podLables[podLabelKey]))
+	require.NoError(s.T(), err)
+	podObj, err := steveClient.SteveType(pods.PodResourceSteveType).List(query)
+	require.NoError(s.T(), err)
+
+	kubeConfig, err := kubeconfig.GetKubeconfig(client, clusterID)
+	require.NoError(s.T(), err)
+
+	restConfig, err := (*kubeConfig).ClientConfig()
+	require.NoError(s.T(), err)
+
+	cmdToReadEnvVar := []string{
+		"/bin/sh",
+		"-c",
+		"echo $testKey",
+	}
+
+	err = kwait.Poll(5*time.Second, 2*time.Minute, func() (done bool, err error) {
+		output, err := kubeconfig.KubectlExec(restConfig, podObj.Data[0].ObjectMeta.Name, s.ns, cmdToReadEnvVar)
+		if err != nil {
+			return false, nil
+		}
+		require.Equal(s.T(), output.String(), secretValue)
+		logrus.Info("environment variable "+secretKey+" value : ", output.String())
+		return true, nil
+	})
+	require.NoError(s.T(), err)
+
+	nodesList, err := steveClient.SteveType("node").List(nil)
+	require.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), nodesList)
+
+	client, err = client.ReLogin()
+	require.NoError(s.T(), err)
+
+	for _, node := range nodesList.Data {
+		etcdNodeLabel := node.Labels[nodestatus.EtcdNodeLabel]
+		if etcdNodeLabel != "" {
+			result, err := strconv.ParseBool(etcdNodeLabel)
+			require.NoError(s.T(), err)
+			if result && node.Annotations[nodestatus.ClusterAnnotation] == clusterName {
+				machineName := node.Annotations[nodestatus.MachineAnnotation]
+				sshKey, err := sshkeys.DownloadSSHKeys(client, machineName)
+				require.NoError(s.T(), err)
+				assert.NotEmpty(s.T(), sshKey)
+
+				sshUser := s.sshUser
+				assert.NotEmpty(s.T(), sshUser)
+
+				clusterNode := &nodes.Node{
+					NodeID:          node.ID,
+					PublicIPAddress: node.Annotations[nodestatus.K3sExternalIP],
+					SSHUser:         sshUser,
+					SSHKey:          []byte(sshKey),
+				}
+				_, err = clusterNode.ExecuteCommand(EtcdCtlInstallCmd)
+				require.NoError(s.T(), err)
+
+				output, err := clusterNode.ExecuteCommand(fmt.Sprintf(k3sEtcdEncryptionCheckCmd, secretObj.Name))
+				require.NoError(s.T(), err)
+				require.NotEmpty(s.T(), output)
+				// Verifying the secret encryption as per : https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#verifying-that-data-is-encrypted
+				require.NotContains(s.T(), output, "k8s:enc:aescbc")
+				logrus.Infof("secret encryption is disabled")
+				break
+			}
+		}
+	}
+	assert.NoError(s.T(), steveClient.SteveType(secrets.SecretSteveType).Delete(secretObj))
+	assert.NoError(s.T(), steveClient.SteveType(workloads.DeploymentSteveType).Delete(deploymentObj))
+}
+
+func (s *K3sSecretEncryptionTestSuite) TestK3sSecretEncryptionEnabled() {
+	subSession := s.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := s.client.WithSession(subSession)
+	require.NoError(s.T(), err)
+
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(s.T(), clusterName, "Cluster name is not provided")
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(s.T(), err)
+
+	steveClient, err := client.Steve.ProxyDownstream(clusterID)
+	require.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), steveClient)
+
+	podLabelKey := namegen.AppendRandomString("app")
+	podLabelValue := namegen.AppendRandomString("encryption")
+	podLables := map[string]string{podLabelKey: podLabelValue}
+
+	secretObj, deploymentObj, err := createDeploymentWithSecret(steveClient, namegen.AppendRandomString("test-deployment"), namegen.AppendRandomString("test-secret"), s.ns, podLables)
+	require.NoError(s.T(), err)
+
+	require.NoError(s.T(), workloads.VerifyDeployment(steveClient, deploymentObj))
+	logrus.Infof("deployment with secret created successfully!")
+
+	query, err := url.ParseQuery(fmt.Sprintf("labelSelector=%s=%s", podLabelKey, podLables[podLabelKey]))
+	require.NoError(s.T(), err)
+	podObj, err := steveClient.SteveType(pods.PodResourceSteveType).List(query)
+	require.NoError(s.T(), err)
+
+	kubeConfig, err := kubeconfig.GetKubeconfig(client, clusterID)
+	require.NoError(s.T(), err)
+
+	restConfig, err := (*kubeConfig).ClientConfig()
+	require.NoError(s.T(), err)
+
+	cmdToReadEnvVar := []string{
+		"/bin/sh",
+		"-c",
+		"echo $testKey",
+	}
+
+	err = kwait.Poll(5*time.Second, 2*time.Minute, func() (done bool, err error) {
+		output, err := kubeconfig.KubectlExec(restConfig, podObj.Data[0].ObjectMeta.Name, s.ns, cmdToReadEnvVar)
+		if err != nil {
+			return false, nil
+		}
+		require.Equal(s.T(), output.String(), secretValue)
+		logrus.Info("environment variable "+secretKey+" value : ", output.String())
+		return true, nil
+	})
+	require.NoError(s.T(), err)
+
+	nodesList, err := steveClient.SteveType("node").List(nil)
+	require.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), nodesList)
+
+	client, err = client.ReLogin()
+	require.NoError(s.T(), err)
+
+	for _, node := range nodesList.Data {
+		etcdNodeLabel := node.Labels[nodestatus.EtcdNodeLabel]
+		if etcdNodeLabel != "" {
+			result, err := strconv.ParseBool(etcdNodeLabel)
+			require.NoError(s.T(), err)
+			if result && node.Annotations[nodestatus.ClusterAnnotation] == clusterName {
+				machineName := node.Annotations[nodestatus.MachineAnnotation]
+				sshKey, err := sshkeys.DownloadSSHKeys(client, machineName)
+				require.NoError(s.T(), err)
+				assert.NotEmpty(s.T(), sshKey)
+
+				sshUser := s.sshUser
+				assert.NotEmpty(s.T(), sshUser)
+
+				clusterNode := &nodes.Node{
+					NodeID:          node.ID,
+					PublicIPAddress: node.Annotations[nodestatus.K3sExternalIP],
+					SSHUser:         sshUser,
+					SSHKey:          []byte(sshKey),
+				}
+				_, err = clusterNode.ExecuteCommand(EtcdCtlInstallCmd)
+				require.NoError(s.T(), err)
+
+				output, err := clusterNode.ExecuteCommand(fmt.Sprintf(k3sEtcdEncryptionCheckCmd, secretObj.Name))
+				require.NoError(s.T(), err)
+				require.NotEmpty(s.T(), output)
+				// Verifying the secret encryption as per : https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#verifying-that-data-is-encrypted
+				require.Contains(s.T(), output, "k8s:enc:aescbc")
+				logrus.Infof("secret encryption is enabled")
+				break
+			}
+		}
+	}
+	assert.NoError(s.T(), steveClient.SteveType(secrets.SecretSteveType).Delete(secretObj))
+	assert.NoError(s.T(), steveClient.SteveType(workloads.DeploymentSteveType).Delete(deploymentObj))
+}
+
+func TestK3sSecretEncryption(t *testing.T) {
+	suite.Run(t, new(K3sSecretEncryptionTestSuite))
+}

--- a/tests/v2/validation/encryption/rke2_secret_encryption_test.go
+++ b/tests/v2/validation/encryption/rke2_secret_encryption_test.go
@@ -1,0 +1,157 @@
+package encryption
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/kubeconfig"
+	nodestatus "github.com/rancher/rancher/tests/framework/extensions/nodes"
+	"github.com/rancher/rancher/tests/framework/extensions/secrets"
+	"github.com/rancher/rancher/tests/framework/extensions/sshkeys"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+type RKE2SecretEncryptionTestSuite struct {
+	suite.Suite
+	session *session.Session
+	client  *rancher.Client
+	ns      string
+	sshUser string
+}
+
+func (s *RKE2SecretEncryptionTestSuite) TearDownSuite() {
+	s.session.Cleanup()
+}
+
+func (s *RKE2SecretEncryptionTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	s.session = testSession
+
+	s.ns = "default"
+	sshCfg := &SSHConfig{}
+	config.LoadConfig(SSHConfigFileKey, sshCfg)
+	s.sshUser = sshCfg.User
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(s.T(), err)
+
+	s.client = client
+}
+
+func (s *RKE2SecretEncryptionTestSuite) TestRKE2SecretEncryptionEnabled() {
+	subSession := s.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := s.client.WithSession(subSession)
+	require.NoError(s.T(), err)
+
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(s.T(), clusterName, "Cluster name is not provided")
+
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	require.NoError(s.T(), err)
+
+	steveClient, err := client.Steve.ProxyDownstream(clusterID)
+	require.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), steveClient)
+
+	podLabelKey := namegen.AppendRandomString("app")
+	podLabelValue := namegen.AppendRandomString("encryption")
+	podLables := map[string]string{podLabelKey: podLabelValue}
+
+	secretObj, deploymentObj, err := createDeploymentWithSecret(steveClient, namegen.AppendRandomString("test-deployment"), namegen.AppendRandomString("test-secret"), s.ns, podLables)
+	require.NoError(s.T(), err)
+
+	require.NoError(s.T(), workloads.VerifyDeployment(steveClient, deploymentObj))
+	logrus.Infof("deployment with secret created successfully!")
+
+	query, err := url.ParseQuery(fmt.Sprintf("labelSelector=%s=%s", podLabelKey, podLables[podLabelKey]))
+	require.NoError(s.T(), err)
+	podObj, err := steveClient.SteveType(pods.PodResourceSteveType).List(query)
+	require.NoError(s.T(), err)
+
+	kubeConfig, err := kubeconfig.GetKubeconfig(client, clusterID)
+	require.NoError(s.T(), err)
+
+	restConfig, err := (*kubeConfig).ClientConfig()
+	require.NoError(s.T(), err)
+
+	cmdToReadEnvVar := []string{
+		"/bin/sh",
+		"-c",
+		"echo $testKey",
+	}
+
+	err = kwait.Poll(5*time.Second, 2*time.Minute, func() (done bool, err error) {
+		output, err := kubeconfig.KubectlExec(restConfig, podObj.Data[0].ObjectMeta.Name, s.ns, cmdToReadEnvVar)
+		if err != nil {
+			return false, nil
+		}
+		require.Equal(s.T(), output.String(), secretValue)
+		logrus.Info("environment variable "+secretKey+" value : ", output.String())
+		return true, nil
+	})
+	require.NoError(s.T(), err)
+
+	nodesList, err := steveClient.SteveType("node").List(nil)
+	require.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), nodesList)
+
+	_, err = client.ReLogin()
+	require.NoError(s.T(), err)
+
+	for _, node := range nodesList.Data {
+		etcdNodeLabel := node.Labels[nodestatus.EtcdNodeLabel]
+		if etcdNodeLabel != "" {
+			result, err := strconv.ParseBool(etcdNodeLabel)
+			require.NoError(s.T(), err)
+			if result && node.Annotations[nodestatus.ClusterAnnotation] == clusterName {
+				machineName := node.Annotations[nodestatus.MachineAnnotation]
+				sshKey, err := sshkeys.DownloadSSHKeys(client, machineName)
+				require.NoError(s.T(), err)
+				assert.NotEmpty(s.T(), sshKey)
+
+				sshUser := s.sshUser
+				assert.NotEmpty(s.T(), sshUser)
+
+				clusterNode := &nodes.Node{
+					NodeID:          node.ID,
+					PublicIPAddress: node.Annotations[nodestatus.RKE2ExternalIP],
+					SSHUser:         sshUser,
+					SSHKey:          []byte(sshKey),
+				}
+				_, err = clusterNode.ExecuteCommand(EtcdCtlInstallCmd)
+				require.NoError(s.T(), err)
+
+				output, err := clusterNode.ExecuteCommand(fmt.Sprintf(rke2EtcdEncryptionCheckCmd, secretObj.Name))
+				require.NoError(s.T(), err)
+				require.NotEmpty(s.T(), output)
+				// Verifying the secret encryption as per : https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#verifying-that-data-is-encrypted
+				require.Contains(s.T(), output, "k8s:enc:aescbc")
+				logrus.Infof("secret encryption is enabled")
+				break
+			}
+		}
+	}
+	assert.NoError(s.T(), steveClient.SteveType(secrets.SecretSteveType).Delete(secretObj))
+	assert.NoError(s.T(), steveClient.SteveType(workloads.DeploymentSteveType).Delete(deploymentObj))
+}
+
+func TestRKE2SecretEncryption(t *testing.T) {
+	suite.Run(t, new(RKE2SecretEncryptionTestSuite))
+}

--- a/tests/v2/validation/encryption/secret_encryption.go
+++ b/tests/v2/validation/encryption/secret_encryption.go
@@ -1,0 +1,52 @@
+package encryption
+
+import (
+	steveclient "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/secrets"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
+	v1 "k8s.io/api/core/v1"
+)
+
+type SSHConfig struct {
+	User string `json:"user" yaml:"user"`
+}
+
+const (
+	secretKey                  = "testKey"
+	secretValue                = "testValue"
+	rke2EtcdEncryptionCheckCmd = `sudo ETCDCTL_API=3 etcdctl --cert /var/lib/rancher/rke2/server/tls/etcd/server-client.crt --key /var/lib/rancher/rke2/server/tls/etcd/server-client.key \
+					--endpoints https://127.0.0.1:2379 --cacert /var/lib/rancher/rke2/server/tls/etcd/server-ca.crt get /registry/secrets/default/%s| hexdump -C`
+	k3sEtcdEncryptionCheckCmd = `sudo ETCDCTL_API=3 etcdctl --cert /var/lib/rancher/k3s/server/tls/etcd/server-client.crt --key /var/lib/rancher/k3s/server/tls/etcd/server-client.key \
+					--endpoints https://127.0.0.1:2379 --cacert /var/lib/rancher/k3s/server/tls/etcd/server-ca.crt get /registry/secrets/default/%s| hexdump -C`
+	SSHConfigFileKey  = "sshConfig"
+	EtcdCtlInstallCmd = `ETCD_VER=v3.5.0 && GOOGLE_URL=https://storage.googleapis.com/etcd && GITHUB_URL=https://github.com/etcd-io/etcd/releases/download &&
+	DOWNLOAD_URL=${GOOGLE_URL} && rm -f /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz && rm -rf /tmp/etcd-download-test && mkdir -p /tmp/etcd-download-test &&
+	curl -L ${DOWNLOAD_URL}/${ETCD_VER}/etcd-${ETCD_VER}-linux-amd64.tar.gz -o /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz &&
+	tar xzvf /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz -C /tmp/etcd-download-test --strip-components=1 && rm -f /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz &&
+	/tmp/etcd-download-test/etcd --version && /tmp/etcd-download-test/etcdctl version && /tmp/etcd-download-test/etcdutl version &&
+	sudo cp /tmp/etcd-download-test/etcdctl /usr/local/bin/etcdctl && etcdctl version`
+)
+
+func createDeploymentWithSecret(steveClient *steveclient.Client, deploymentName string, secretName string, namespace string, podLabels map[string]string) (*steveclient.SteveAPIObject, *steveclient.SteveAPIObject, error) {
+	secretTemplate := secrets.NewSecretTemplate(secretName, namespace, map[string][]byte{secretKey: []byte(secretValue)}, v1.SecretTypeOpaque)
+	secretObj, err := steveClient.SteveType(secrets.SecretSteveType).Create(secretTemplate)
+	if err != nil {
+		return nil, nil, err
+	}
+	envVarFromSecret := []v1.EnvFromSource{
+		{
+			SecretRef: &v1.SecretEnvSource{
+				LocalObjectReference: v1.LocalObjectReference{Name: secretObj.Name},
+			},
+		},
+	}
+	containerTemplate := workloads.NewContainer("ranchertest", "ranchertest/mytestcontainer", v1.PullAlways, []v1.VolumeMount{}, envVarFromSecret, nil, nil, nil)
+	podTemplate := workloads.NewPodTemplate([]v1.Container{containerTemplate}, []v1.Volume{}, []v1.LocalObjectReference{}, podLabels)
+	deploymentTemplate := workloads.NewDeploymentTemplate(deploymentName, namespace, podTemplate, true, podLabels)
+	deploymentObj, err := steveClient.SteveType(workloads.DeploymentSteveType).Create(deploymentTemplate)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return secretObj, deploymentObj, nil
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/427
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
- This PR adds secret encryption validation test for K3S and RKE2 clusters. It verifies whether secrets attached to a workload are accessible from within the pod, also runs etcdctl command in order to verify whether secret encryption is enabled or disabled.