### PR TITLE
Fix defaults package import in the test extensions

### DIFF
--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -15,10 +15,9 @@ import (
 	kubeProvisioning "github.com/rancher/rancher/tests/framework/clients/provisioning"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
-	steveV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
-	"github.com/rancher/rancher/tests/integration/pkg/defaults"
 	rancherProvisioning "github.com/rancher/rancher/tests/v2/validation/provisioning"
 	"github.com/rancher/wrangler/pkg/summary"
 	"github.com/sirupsen/logrus"
@@ -918,14 +917,14 @@ func WatchAndWaitForCluster(steveClient *v1.Client, kubeProvisioningClient *kube
 }
 
 // GetProvisioningClusterByName is a helper function to get cluster object with the cluster name
-func GetProvisioningClusterByName(client *rancher.Client, clusterName string, namespace string) (*apisV1.Cluster, *steveV1.SteveAPIObject, error) {
+func GetProvisioningClusterByName(client *rancher.Client, clusterName string, namespace string) (*apisV1.Cluster, *v1.SteveAPIObject, error) {
 	clusterObj, err := client.Steve.SteveType(ProvisioningSteveResouceType).ByID(namespace + "/" + clusterName)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	cluster := new(apisV1.Cluster)
-	err = steveV1.ConvertToK8sType(clusterObj, &cluster)
+	err = v1.ConvertToK8sType(clusterObj, &cluster)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 `clusters.go` file has been using the integration defaults. This causes tests to wait for less than usual for the watch interfaces in this file.
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 Updated import, and removed a duplicated import which has seen while fixing this.
