### PR TITLE
Return errskip when finalizers not present

### DIFF
--- a/pkg/controllers/provisioningv2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/provisioningcluster/controller.go
@@ -288,7 +288,7 @@ func (h *handler) OnRancherClusterChange(obj *rancherv1.Cluster, status rancherv
 
 	if len(obj.Finalizers) == 0 && obj.DeletionTimestamp.IsZero() {
 		// If the cluster doesn't have any finalizers, then we don't apply any objects to ensure the finalizer can be put on the cluster.
-		return nil, status, nil
+		return nil, status, generic.ErrSkip
 	}
 
 	rkeCP, err := h.getRKEControlPlaneForCluster(obj)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #41887
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When finalizers are removed from a provisioning cluster object, there is a race condition between adding the finalizers back, and the generating framework deleting the generated `rkecluster`, `rkecontrolplane`, `cluster.cluster.x-k8s.io` and `machinedeployment`s.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Skip current iteration until finalizers are present again.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Repro steps are not reliable due to raciness of issue.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
- Test types added/modified:
  - Unit
    - Added test cases surrounding expected invariants to cluster inputs.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

No chances for regressions, as we are not affecting any other code paths.