### PR TITLE
RBAC tests for GH610

### DIFF
--- a/tests/framework/extensions/clusters/clusters.go
+++ b/tests/framework/extensions/clusters/clusters.go
@@ -932,3 +932,26 @@ func GetProvisioningClusterByName(client *rancher.Client, clusterName string, na
 
 	return cluster, clusterObj, nil
 }
+
+// WaitForActiveCluster is a "helper" function that waits for the cluster to reach the active state.
+// The function accepts a Rancher client and a cluster ID as parameters.
+func WaitForActiveRKE1Cluster(client *rancher.Client, clusterID string) error {
+	err := kwait.Poll(500*time.Millisecond, 30*time.Minute, func() (done bool, err error) {
+		client, err = client.ReLogin()
+		if err != nil {
+			return false, err
+		}
+		clusterResp, err := client.Management.Cluster.ByID(clusterID)
+		if err != nil {
+			return false, err
+		}
+		if clusterResp.State == "active" {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/tests/framework/extensions/psact/createdeployment.go
+++ b/tests/framework/extensions/psact/createdeployment.go
@@ -66,7 +66,7 @@ func CreateNginxDeployment(client *rancher.Client, clusterID string, psact strin
 			return false, err
 		}
 
-		if *deployment.Spec.Replicas == deployment.Status.AvailableReplicas && psact == rancherPrivileged {
+		if *deployment.Spec.Replicas == deployment.Status.AvailableReplicas && (psact == "" || psact == rancherPrivileged) {
 			logrus.Infof("Deployment %s successfully created; this is expected for %s!", deployment.Name, psact)
 			return true, nil
 		} else if *deployment.Spec.Replicas != deployment.Status.AvailableReplicas && psact == rancherRestricted {

--- a/tests/v2/validation/rbac/rbac.go
+++ b/tests/v2/validation/rbac/rbac.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
-
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
 	"github.com/rancher/rancher/tests/framework/extensions/projects"
 	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
@@ -256,4 +256,64 @@ func createRole(client *rancher.Client, context string, roleName string, rules [
 		})
 	return
 
+}
+
+func editPsactCluster(client *rancher.Client, clustername string, namespace string, psact string) (clusterType string, err error) {
+	clusterID, err := clusters.GetClusterIDByName(client, clustername)
+	if err != nil {
+		return "", err
+	}
+	//Check if the downstream cluster is RKE2/K3S or RKE1
+	if strings.Contains(clusterID, "c-m-") {
+		clusterType = "RKE2K3S"
+		clusterObj, existingSteveAPIObj, err := clusters.GetProvisioningClusterByName(client, clustername, namespace)
+		if err != nil {
+			return "", err
+		}
+
+		clusterObj.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName = psact
+		_, err = clusters.UpdateK3SRKE2Cluster(client, existingSteveAPIObj, clusterObj)
+		if err != nil {
+			return clusterType, err
+		}
+		updatedClusterObj, _, err := clusters.GetProvisioningClusterByName(client, clustername, namespace)
+		if err != nil {
+			return "", err
+		}
+		if updatedClusterObj.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName != psact {
+			errorMsg := "psact value was not changed, Expected: " + psact + ", Actual: " + updatedClusterObj.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName
+			return clusterType, errors.New(errorMsg)
+		}
+	} else {
+		clusterType = "RKE"
+		if psact == "" {
+			psact = " "
+		}
+		existingCluster, err := client.Management.Cluster.ByID(clusterID)
+		if err != nil {
+			return "", err
+		}
+
+		updatedCluster := &management.Cluster{
+			Name: existingCluster.Name,
+			DefaultPodSecurityAdmissionConfigurationTemplateName: psact,
+		}
+		_, err = client.Management.Cluster.Update(existingCluster, updatedCluster)
+		if err != nil {
+			return clusterType, err
+		}
+		clusters.WaitForActiveRKE1Cluster(client, clusterID)
+		modifiedCluster, err := client.Management.Cluster.ByID(clusterID)
+		if err != nil {
+			return "", err
+		}
+		if psact == " " {
+			psact = ""
+		}
+		if modifiedCluster.DefaultPodSecurityAdmissionConfigurationTemplateName != psact {
+			errorMsg := "psact value was not changed, Expected: " + psact + ", Actual: " + modifiedCluster.DefaultPodSecurityAdmissionConfigurationTemplateName
+			return clusterType, errors.New(errorMsg)
+		}
+	}
+	return clusterType, nil
 }


### PR DESCRIPTION
## Issue: 
Adding RBAC tests for editing cluster and modifying the PSACT value on RKE1/RKE2/K3S clusters.
 
## Solution
- Edit the cluster
- Verify only Cluster owner and restricted admin have access to edit the cluster and modify the PSACT value. After modifying the PSACT value, verify creating a deployment fails when the PSACT value is set to "rancher-restricted" while it succeeds otherwise.
- Verify Cluster member, project owner, project member and readonly do not have access to edit the cluster
 
## Engineering Testing
## Manual Testing
N/A

## Automated Testing
Adding these automated tests - [rancher/qa-tasks#610](https://github.com/rancher/qa-tasks/issues/610)
Note: There is new change coming in where the cluster creation would be an extension that will be fixed as part [#780](https://github.com/rancher/qa-tasks/issues/780). So, the test case does not currently include the implementation of cluster creation.

## QA Testing Considerations
N/A

## Regressions Considerations