### PR TITLE
changed Jenkinsfile branch variable from 2.6 to 2.7

### DIFF
--- a/tests/v2/validation/Jenkinsfile
+++ b/tests/v2/validation/Jenkinsfile
@@ -12,7 +12,7 @@ node {
     def testResultsOut = "results.xml"
     def envFile = ".env"
     def rancherConfig = "rancher_env.config"
-    def branch = "release/v2.6"
+    def branch = "release/v2.7"
     if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
       branch = "${env.BRANCH}"
     }


### PR DESCRIPTION
## Problem
go validation provisioning Jenkins job was using `release/v2.6` instead of `release/v2.7`, causing the test to fail, since v2.6 is out of date
 