### PR TITLE
add the support for ignoring specified tags in specified charts and system charts

### DIFF
--- a/pkg/image/charts.go
+++ b/pkg/image/charts.go
@@ -30,6 +30,14 @@ var systemChartsToCheckConstraints = map[string]struct{}{
 	"rancher-monitoring": {},
 }
 
+// chartsToIgnoreTags and systemChartsToIgnoreTags defines the charts and system charts in which a specified
+// image tag should be ignored.
+var chartsToIgnoreTags = map[string]string{
+	"rancher-vsphere-csi": "latest",
+	"rancher-vsphere-cpi": "latest",
+}
+var systemChartsToIgnoreTags = map[string]string{}
+
 type Charts struct {
 	Config ExportConfig
 }
@@ -77,9 +85,10 @@ func (c Charts) FetchImages(imagesSet map[string]map[string]struct{}) error {
 			logrus.Info(err)
 			continue
 		}
+		tag, _ := chartsToIgnoreTags[version.Name]
 		chartNameAndVersion := fmt.Sprintf("%s:%s", version.Name, version.Version)
 		for _, values := range versionValues {
-			if err = pickImagesFromValuesMap(imagesSet, values, chartNameAndVersion, c.Config.OsType); err != nil {
+			if err = pickImagesFromValuesMap(imagesSet, values, chartNameAndVersion, c.Config.OsType, tag); err != nil {
 				return err
 			}
 		}
@@ -159,8 +168,9 @@ func (sc SystemCharts) FetchImages(imagesSet map[string]map[string]struct{}) err
 			if err != nil {
 				return err
 			}
+			tag, _ := systemChartsToIgnoreTags[version.Name]
 			chartNameAndVersion := fmt.Sprintf("%s:%s", version.Name, version.Version)
-			if err = pickImagesFromValuesMap(imagesSet, values, chartNameAndVersion, sc.Config.OsType); err != nil {
+			if err = pickImagesFromValuesMap(imagesSet, values, chartNameAndVersion, sc.Config.OsType, tag); err != nil {
 				return err
 			}
 		}
@@ -236,7 +246,7 @@ func minMaxToConstraintStr(min, max string) string {
 }
 
 // pickImagesFromValuesMap walks a values map to find images, and add them to imagesSet.
-func pickImagesFromValuesMap(imagesSet map[string]map[string]struct{}, values map[interface{}]interface{}, chartNameAndVersion string, osType OSType) error {
+func pickImagesFromValuesMap(imagesSet map[string]map[string]struct{}, values map[interface{}]interface{}, chartNameAndVersion string, osType OSType, tagToIgnore string) error {
 	walkMap(values, func(inputMap map[interface{}]interface{}) {
 		repository, ok := inputMap["repository"].(string)
 		if !ok {
@@ -245,6 +255,9 @@ func pickImagesFromValuesMap(imagesSet map[string]map[string]struct{}, values ma
 		// No string type assertion because some charts have float typed image tags
 		tag, ok := inputMap["tag"]
 		if !ok {
+			return
+		}
+		if fmt.Sprintf("%v", tag) == tagToIgnore {
 			return
 		}
 		imageName := fmt.Sprintf("%s:%v", repository, tag)

--- a/pkg/image/charts_test.go
+++ b/pkg/image/charts_test.go
@@ -12,86 +12,121 @@ func TestPickImagesFromValuesMap(t *testing.T) {
 		values              map[interface{}]interface{}
 		chartNameAndVersion string
 		osType              OSType
+		tagToIgnore         string
 		expectedImagesSet   map[string]map[string]struct{}
 	}{
 		{
-			"Want linux images",
-			map[interface{}]interface{}{
+			description: "Want linux images",
+			values: map[interface{}]interface{}{
 				"repository": "test-repository",
 				"tag":        "1.2.3",
 				"os":         "Linux",
 			},
-			"chart:0.1.2",
-			Linux,
-			map[string]map[string]struct{}{
+			chartNameAndVersion: "chart:0.1.2",
+			osType:              Linux,
+			tagToIgnore:         "",
+			expectedImagesSet: map[string]map[string]struct{}{
 				"test-repository:1.2.3": {
 					"chart:0.1.2": struct{}{},
 				},
 			},
 		},
 		{
-			"Want Windows images",
-			map[interface{}]interface{}{
+			description: "Want Windows images",
+			values: map[interface{}]interface{}{
 				"repository": "test-repository",
 				"tag":        "1.2.3",
 				"os":         "windows,linux",
 			},
-			"chart:0.1.2",
-			Windows,
-			map[string]map[string]struct{}{
+			chartNameAndVersion: "chart:0.1.2",
+			osType:              Windows,
+			tagToIgnore:         "",
+			expectedImagesSet: map[string]map[string]struct{}{
 				"test-repository:1.2.3": {
 					"chart:0.1.2": struct{}{},
 				},
 			},
 		},
 		{
-			"No images of the given OS (want Windows, but images are Linux)",
-			map[interface{}]interface{}{
+			description: "No images of the given OS (want Windows, but images are Linux)",
+			values: map[interface{}]interface{}{
 				"repository": "test-repository",
 				"tag":        "1.2.3",
 				"os":         "linux",
 			},
-			"chart:0.1.2",
-			Windows,
-			map[string]map[string]struct{}{},
+			chartNameAndVersion: "chart:0.1.2",
+			osType:              Windows,
+			tagToIgnore:         "",
+			expectedImagesSet:   map[string]map[string]struct{}{},
 		},
 		{
-			"No OS provided, default to Linux",
-			map[interface{}]interface{}{
+			description: "No OS provided, default to Linux",
+			values: map[interface{}]interface{}{
 				"repository": "test-repository",
 				"tag":        "1.2.3",
 			},
-			"chart:0.1.2",
-			Linux,
-			map[string]map[string]struct{}{
+			chartNameAndVersion: "chart:0.1.2",
+			osType:              Linux,
+			tagToIgnore:         "",
+			expectedImagesSet: map[string]map[string]struct{}{
 				"test-repository:1.2.3": {
 					"chart:0.1.2": struct{}{},
 				},
 			},
 		},
 		{
-			"Unsupported OS provided",
-			map[interface{}]interface{}{
+			description: "Unsupported OS provided",
+			values: map[interface{}]interface{}{
 				"repository": "test-repository",
 				"tag":        "1.2.3",
 				"os":         "unsupported-os",
 			},
-			"chart:0.1.2",
-			Linux,
-			map[string]map[string]struct{}{},
+			chartNameAndVersion: "chart:0.1.2",
+			osType:              Linux,
+			tagToIgnore:         "",
+			expectedImagesSet:   map[string]map[string]struct{}{},
 		},
 		{
-			"Missing required information in values file",
-			map[interface{}]interface{}{},
-			"chart:0.1.2",
-			Linux,
-			map[string]map[string]struct{}{},
+			description:         "Missing required information in values file",
+			values:              map[interface{}]interface{}{},
+			chartNameAndVersion: "chart:0.1.2",
+			osType:              Linux,
+			tagToIgnore:         "",
+			expectedImagesSet:   map[string]map[string]struct{}{},
+		},
+		{
+			description: "Ignore an non-matching tag",
+			values: map[interface{}]interface{}{
+				"repository": "test-repository",
+				"tag":        "1.2.3",
+				"os":         "Linux",
+			},
+			chartNameAndVersion: "chart:0.1.2",
+			osType:              Linux,
+			tagToIgnore:         "latest",
+			expectedImagesSet: map[string]map[string]struct{}{
+				"test-repository:1.2.3": {
+					"chart:0.1.2": struct{}{},
+				},
+			},
+		},
+		{
+			description: "Ignore a matching tag",
+			values: map[interface{}]interface{}{
+				"repository": "test-repository",
+				"tag":        "1.2.3",
+				"os":         "Linux",
+			},
+			chartNameAndVersion: "chart:0.1.2",
+			osType:              Linux,
+			tagToIgnore:         "1.2.3",
+			expectedImagesSet:   map[string]map[string]struct{}{},
 		},
 	}
 	assert := assertlib.New(t)
 	for _, tc := range testCases {
 		actualImagesSet := make(map[string]map[string]struct{})
-		err := pickImagesFromValuesMap(actualImagesSet, tc.values, tc.chartNameAndVersion, tc.osType)
+		err := pickImagesFromValuesMap(actualImagesSet, tc.values, tc.chartNameAndVersion, tc.osType, tc.tagToIgnore)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}

--- a/pkg/image/utilities/utilities.go
+++ b/pkg/image/utilities/utilities.go
@@ -55,8 +55,8 @@ type ImageTargetsAndSources struct {
 	TargetWindowsImagesAndSources []string
 }
 
-// GatherTargetImagesAndSources queries KDM and charts/system-charts to gather all the images used by Rancher and their source.
-// it an aggregate type, ImageTargetsAndSources, which contains the images required to run Rancher on Linux and Windows, as well
+// GatherTargetImagesAndSources queries KDM, charts and system-charts to gather all the images used by Rancher and their source.
+// It returns an aggregate type, ImageTargetsAndSources, which contains the images required to run Rancher on Linux and Windows, as well
 // as the source of each image.
 func GatherTargetImagesAndSources(systemChartsPath, chartsPath string, imagesFromArgs []string) (ImageTargetsAndSources, error) {
 	rancherVersion, ok := os.LookupEnv("TAG")


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rancher/issues/41952
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 

The CI step `check-release-images-existing` detects the following missing image tags:

```
ERROR: Summary of missing image(s):
rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:latest
rancher/mirrored-cloud-provider-vsphere-csi-release-driver:latest
rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:latest
rancher/mirrored-sig-storage-csi-attacher:latest
rancher/mirrored-sig-storage-csi-node-driver-registrar:latest
rancher/mirrored-sig-storage-csi-provisioner:latest
rancher/mirrored-sig-storage-csi-resizer:latest
rancher/mirrored-sig-storage-livenessprobe:latest
time="2023-06-12T19:29:56Z" level=fatal msg="exit status 1"
```
ref https://drone-publish.rancher.io/rancher/rancher/9924/5/9

They come from the following chart:
```
rancher-vsphere-cpi:102.1.0+up1.5.1
rancher-vsphere-csi:102.1.0+up3.0.1-rancher1
```

Further investigation shows that the `latest` tags for those images do not exist in the upstream registry, and they are used in the mentioned charts as an indicator that an invalid Kubernetes release version is passed to the chart (See [PR](https://github.com/rancher/vsphere-charts/pull/55)).


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
To eliminate the error in the CI and the non-existing tags in the generated images.txt in Rancher's release assets, we decided to ignore the `latest` tag on those mentioned charts when generating the images.txt file. 


## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

We can validate the fix when the next Rancher RC is cut:
- CI step `check-release-images-existing` should not report the mentioned errors 
- the images.txt file should not contain those mentioned tags 


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The fix has been validated locally by running the following command locally **with and without** the fix the comparing the images.txt file:

```
>  go run main.go "" "./charts" "rancher/wins:v0.9.99"
2023/06/27 11:12:07 Creating /Users/jiaqiluo/bin/rancher-rke-k8s-versions.txt
INFO[0000] generating k3s image list...
INFO[0002] finished generating k3s image list...
INFO[0002] generating rke2 image list...
INFO[0004] finished generating rke2 image list...
2023/06/27 11:12:11 building rancher-images-origins.txt
2023/06/27 11:12:11 Creating rancher-images.txt
2023/06/27 11:12:11 Creating rancher-images-sources.txt
2023/06/27 11:12:11 Creating rancher-mirror-to-rancher-org.sh
2023/06/27 11:12:11 Creating rancher-save-images.sh
2023/06/27 11:12:11 Creating rancher-load-images.sh
2023/06/27 11:12:11 Creating rancher-windows-images.txt
2023/06/27 11:12:11 Creating rancher-windows-images-sources.txt
2023/06/27 11:12:11 Creating rancher-mirror-to-rancher-org.ps1
2023/06/27 11:12:11 Creating rancher-save-images.ps1
2023/06/27 11:12:11 Creating rancher-load-images.ps1
```

```
> diff fix-rancher-images.txt rancher-images.txt
151a152
> rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:latest
165a167
> rancher/mirrored-cloud-provider-vsphere-csi-release-driver:latest
175a178
> rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:latest
284a288
> rancher/mirrored-sig-storage-csi-attacher:latest
288a293
> rancher/mirrored-sig-storage-csi-node-driver-registrar:latest
293a299
> rancher/mirrored-sig-storage-csi-provisioner:latest
298a305
> rancher/mirrored-sig-storage-csi-resizer:latest
302a310
> rancher/mirrored-sig-storage-livenessprobe:latest
```



### Automated Testing

The unit tests for the function `pickImagesFromValuesMap` is updated to cover the change. 


## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
We can validate the fix when the next Rancher RC is cut:
- CI step `check-release-images-existing` should not report the mentioned errors 
- the images.txt file should not contain those mentioned tags 


### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

N/A
 