### PR TITLE
Dump logs when Webhook fails to deploy during CI.

### DIFF
--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -70,10 +70,7 @@ run_rancher()
     while sleep 2; do
         if [ "$PID" != "-1" ] && [ ! -e /proc/$PID ]; then
             echo Rancher died
-            echo Rancher logs were
-            echo -e "-----RANCHER-LOG-DUMP-START-----"
-            cat /tmp/rancher.log | gzip | base64 -w 0
-            echo -e "\n-----RANCHER-LOG-DUMP-END-----"
+            dump_rancher_logs
             echo K3s logs were:
             echo -e "-----K3S-LOG-DUMP-START-----"
             cat build/testdata/k3s.log | gzip | base64 -w 0
@@ -97,6 +94,14 @@ run_rancher()
         fi
         sleep 2
     done
+}
+
+dump_rancher_logs()
+{
+  echo Rancher logs were
+  echo -e "-----RANCHER-LOG-DUMP-START-----"
+  cat /tmp/rancher.log | gzip | base64 -w 0
+  echo -e "\n-----RANCHER-LOG-DUMP-END-----"
 }
 
 # uncomment to get startup logs. Don't leave them on because it slows drone down too
@@ -127,6 +132,7 @@ echo "Waiting up to 5 minutes for rancher-webhook deployment"
 while ! kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-system deploy/rancher-webhook &>/dev/null; do
   if [[ "$rwWC" == 150 ]]; then
     echo "rancher-webhook was not available within 5 minutes. failing fast"
+    dump_rancher_logs
     exit 1
   fi
   if [[ $((rwWC%30)) == 0 ]] && [[ "$rwWC" != "0" ]]; then
@@ -140,9 +146,4 @@ done
 echo Running provisioning-tests $RUNARG
 
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-go test $RUNARG -v -failfast -timeout 60m ./tests/v2prov/tests/... || {
-    echo -e "-----RANCHER-LOG-DUMP-START-----"
-    cat /tmp/rancher.log | gzip | base64 -w 0
-    echo -e "\n-----RANCHER-LOG-DUMP-END-----"
-    exit 1
-}
+go test $RUNARG -v -failfast -timeout 60m ./tests/v2prov/tests/... || dump_rancher_logs


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/40824
Provisioning tests periodically fail to deploy the webhook after 5 minutes. This can happen for multiple reasons that may or may not be related to Webhook itself. This PR adds a dump of the rancher logs when the webhook fails to deploy, which will allow us to determine the problem.