### PR TITLE
[release/v2.7] update README with latest/stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Rancher is an open source container management platform built for organizations 
 
 ## Latest Release
 * v2.7
-  * Latest - v2.7.4 - `rancher/rancher:v2.7.4` / `rancher/rancher:latest` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.7.4).
-  * Stable - v2.7.4 - `rancher/rancher:v2.7.4` / `rancher/rancher:stable` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.7.4).
+  * Latest - v2.7.5 - `rancher/rancher:v2.7.5` / `rancher/rancher:latest` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.7.5).
+  * Stable - v2.7.5 - `rancher/rancher:v2.7.5` / `rancher/rancher:stable` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.7.5).
 * v2.6
   * Latest - v2.6.13 - `rancher/rancher:v2.6.13` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.6.13).
   * Stable - v2.6.13 - `rancher/rancher:v2.6.13` - Read the full release [notes](https://github.com/rancher/rancher/releases/tag/v2.6.13).


### PR DESCRIPTION
The workflow we have to update this seems to need an update as it changed a link from 2.7 to 2.6 which is not a desired change. This PR applies the changes from the auto-generated PR with that change excluded.

Auto-generated README update PR: https://github.com/rancher/rancher/pull/41974