### PR TITLE
[Automation] - Adding test coverage for ECR repos

### DIFF
--- a/tests/v2/validation/registries/config.go
+++ b/tests/v2/validation/registries/config.go
@@ -8,8 +8,17 @@ type ExistingAuthRegistryConfig struct {
 	URL      string `json:"url" yaml:"url" default:""`
 }
 
+type ECRRegistryConfig struct {
+	Username           string `json:"username" yaml:"username" default:"AWS"`
+	Password           string `json:"password" yaml:"password" default:""`
+	URL                string `json:"url" yaml:"url" default:""`
+	AwsAccessKeyID     string `json:"awsAccessKeyId" yaml:"awsAccessKeyId" default:""`
+	AwsSecretAccessKey string `json:"awsSecretAccessKey" yaml:"awsSecretAccessKey" default:""`
+}
+
 type Registries struct {
 	RegistryConfigNames       []string                    `json:"registryConfigNames" yaml:"registryConfigNames" default:"[]"`
 	ExistingNoAuthRegistryURL string                      `json:"existingNoAuthRegistry" yaml:"existingNoAuthRegistry" default:""`
 	ExistingAuthRegistryInfo  *ExistingAuthRegistryConfig `json:"existingAuthRegistry" yaml:"existingAuthRegistry" default:""`
+	ECRRegistryConfig         *ECRRegistryConfig          `json:"ecrRegistryConfig" yaml:"ecrRegistryConfig" default:""`
 }

--- a/tests/v2/validation/registries/registry_test.go
+++ b/tests/v2/validation/registries/registry_test.go
@@ -36,6 +36,7 @@ const (
 	corralRancherName      = "rancherha"
 	corralAuthDisabledName = "registryauthdisabled"
 	corralAuthEnabledName  = "registryauthenabled"
+	corralEcr              = "corralecr"
 	systemRegistry         = "system-default-registry"
 	namespace              = "fleet-default"
 )
@@ -60,6 +61,7 @@ type RegistryTestSuite struct {
 	rke2KubernetesVersions         []string
 	privateRegistriesAuth          []management.PrivateRegistry
 	privateRegistriesNoAuth        []management.PrivateRegistry
+	privateEcr                     []management.PrivateRegistry
 	rkeNodesAndRoles               []nodepools.NodeRoles
 	k3sRke2NodesAndRoles           []machinepools.NodeRoles
 }
@@ -89,6 +91,10 @@ func (rt *RegistryTestSuite) SetupSuite() {
 	registryEnabledUsername := ""
 	registryEnabledPassword := ""
 	registryEnabledFqdn := ""
+	ecrRegistryFqdn := ""
+	ecrRegistryAwsAccessKey := ""
+	ecrRegistryAwsSecretKey := ""
+	ecrRegistryPassword := ""
 
 	useRegistries := client.Flags.GetValue(environmentflag.UseExistingRegistries)
 	logrus.Infof("The value of useRegistries is %t", useRegistries)
@@ -115,12 +121,33 @@ func (rt *RegistryTestSuite) SetupSuite() {
 		registryEnabledFqdn, err = corral.GetCorralEnvVar(corralAuthEnabledName, "registry_fqdn")
 		require.NoError(rt.T(), err)
 		logrus.Infof("RegistryAuth FQDN %s", registryEnabledFqdn)
+		ecrRegistryFqdn, err = corral.GetCorralEnvVar(corralEcr, "registry_ecr_fqdn")
+		require.NoError(rt.T(), err)
+		logrus.Infof("Registry ECR FQDN %s", ecrRegistryFqdn)
+		ecrRegistryAwsAccessKey, err = corral.GetCorralEnvVar(corralEcr, "aws_access_key")
+		require.NoError(rt.T(), err)
+		logrus.Infof("Registry ECR Access Key %s", ecrRegistryAwsAccessKey)
+		ecrRegistryAwsSecretKey, err = corral.GetCorralEnvVar(corralEcr, "aws_secret_key")
+		require.NoError(rt.T(), err)
+		logrus.Infof("Registry ECR Secret Key %s", ecrRegistryAwsSecretKey)
+		ecrRegistryPassword, err = corral.GetCorralEnvVar(corralEcr, "registry_password")
+		require.NoError(rt.T(), err)
+		logrus.Infof("Registry ECR Password %s", ecrRegistryPassword)
+
 	} else {
 		logrus.Infof("Using Existing Registries because value of useRegistries is %t", useRegistries)
 		registryDisabledFqdn = registriesConfig.ExistingNoAuthRegistryURL
 		registryEnabledFqdn = registriesConfig.ExistingAuthRegistryInfo.URL
 		registryEnabledUsername = registriesConfig.ExistingAuthRegistryInfo.Username
 		registryEnabledPassword = registriesConfig.ExistingAuthRegistryInfo.Password
+		ecrRegistryFqdn = registriesConfig.ECRRegistryConfig.URL
+		ecrRegistryAwsAccessKey = registriesConfig.ECRRegistryConfig.AwsAccessKeyID
+		ecrRegistryAwsSecretKey = registriesConfig.ECRRegistryConfig.AwsSecretAccessKey
+		ecrRegistryPassword = registriesConfig.ECRRegistryConfig.Password
+		logrus.Infof("Registry ECR FQDN %s", ecrRegistryFqdn)
+		logrus.Infof("Registry ECR Access Key %s", ecrRegistryAwsAccessKey)
+		logrus.Infof("Registry ECR Secret Key %s", ecrRegistryAwsSecretKey)
+		logrus.Infof("Registry ECR Password %s", ecrRegistryPassword)
 		logrus.Infof("RegistryNoAuth FQDN %s", registryDisabledFqdn)
 		logrus.Infof("RegistryAuth Username %s", registryEnabledUsername)
 		logrus.Infof("RegistryAuth Password %s", registryEnabledPassword)
@@ -190,6 +217,18 @@ func (rt *RegistryTestSuite) SetupSuite() {
 
 	rt.clusterLocalID = "local"
 	rt.localClusterGlobalRegistryHost = globalRegistryFqdn
+
+	ECRCredentialPlugin := &management.ECRCredentialPlugin{
+		AwsAccessKeyID:     ecrRegistryAwsAccessKey,
+		AwsSecretAccessKey: ecrRegistryAwsSecretKey,
+	}
+	privateRegistry = management.PrivateRegistry{}
+	privateRegistry.URL = ecrRegistryFqdn
+	privateRegistry.IsDefault = true
+	privateRegistry.Password = ecrRegistryPassword
+	privateRegistry.User = "AWS"
+	rt.privateEcr = append(rt.privateEcr, privateRegistry)
+	rt.privateEcr[0].ECRCredentialPlugin = ECRCredentialPlugin
 }
 
 func (rt *RegistryTestSuite) TestRegistriesRKE() {
@@ -223,6 +262,30 @@ func (rt *RegistryTestSuite) TestRegistriesRKE() {
 
 	rt.testStatusAllPods()
 	rt.testRegistryAllPods()
+}
+
+func (rt *RegistryTestSuite) TestRegistryEcrRKE() {
+	subSession := session.NewSession()
+	defer subSession.Cleanup()
+
+	subClient, err := rt.client.WithSession(subSession)
+	require.NoError(rt.T(), err)
+
+	provider := rke1.CreateProvider(rt.providers[0])
+
+	clusterNameEcr, err := rt.testProvisionRKE1Cluster(subClient, provider, rt.rkeNodesAndRoles, rt.rkeKubernetesVersions[0], rt.cnis[0], rt.privateEcr, rt.advancedOptions)
+	require.NoError(rt.T(), err)
+
+	clusterID, err := clusters.GetClusterIDByName(subClient, clusterNameEcr)
+	require.NoError(rt.T(), err)
+
+	podResults, podErrors := pods.StatusPods(subClient, clusterID)
+	assert.NotEmpty(rt.T(), podResults)
+	assert.Empty(rt.T(), podErrors)
+
+	havePrefix, err := registries.CheckAllClusterPodsForRegistryPrefix(subClient, clusterID, rt.privateEcr[0].URL)
+	require.NoError(rt.T(), err)
+	assert.True(rt.T(), havePrefix)
 }
 
 func (rt *RegistryTestSuite) TestRegistriesK3S() {
@@ -278,6 +341,21 @@ func (rt *RegistryTestSuite) testProvisionRKE1Cluster(client *rancher.Client, pr
 
 	if privateRegistries != nil {
 		cluster.RancherKubernetesEngineConfig.PrivateRegistries = privateRegistries
+		if privateRegistries[0].ECRCredentialPlugin != nil {
+			awsAccessKeyId := fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", privateRegistries[0].ECRCredentialPlugin.AwsAccessKeyID)
+			awsSecretAccessKey := fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", privateRegistries[0].ECRCredentialPlugin.AwsSecretAccessKey)
+			extraEnv := []string{awsAccessKeyId, awsSecretAccessKey}
+			rancherKubernetesEngineConfig := &management.RancherKubernetesEngineConfig{
+				Version:           rt.rkeKubernetesVersions[0],
+				PrivateRegistries: privateRegistries,
+				Services: &management.RKEConfigServices{
+					Kubelet: &management.KubeletService{
+						ExtraEnv: extraEnv,
+					},
+				},
+			}
+			cluster.RancherKubernetesEngineConfig = rancherKubernetesEngineConfig
+		}
 	}
 
 	clusterResp, err := clusters.CreateRKE1Cluster(client, cluster)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
No issue. Additional coverage for private registries
 
## Problem
Current private registries release validations haven't support for the ECR RKE registry use case of Downstream clusters.
 
## Solution
Add new test for RKE1 ECR
 
## Testing
Local test runs

### Automated Testing
Provide Jenkins run.

Related for infra creation: https://github.com/rancherlabs/corral-packages/pull/14