### PR TITLE
Only update cluster if secrets migrated

### DIFF
--- a/pkg/controllers/management/secretmigrator/clusters.go
+++ b/pkg/controllers/management/secretmigrator/clusters.go
@@ -711,6 +711,9 @@ func (h *handler) migrateSecret(cluster *apimgmtv3.Cluster, secretName, secretCl
 }
 
 func (h *handler) migrateClusterSecrets(cluster *apimgmtv3.Cluster) (*apimgmtv3.Cluster, error) {
+	if apimgmtv3.ClusterConditionSecretsMigrated.IsTrue(cluster) {
+		return cluster, nil
+	}
 	clusterCopy := cluster.DeepCopy()
 	var err error
 	obj, doErr := apimgmtv3.ClusterConditionSecretsMigrated.DoUntilTrue(clusterCopy, func() (runtime.Object, error) {
@@ -957,17 +960,10 @@ func (h *handler) migrateClusterSecrets(cluster *apimgmtv3.Cluster) (*apimgmtv3.
 				}
 			}
 		}
-
-		logrus.Tracef("[secretmigrator] setting cluster condition [%s] and updating cluster [%s]", apimgmtv3.ClusterConditionSecretsMigrated, clusterCopy.Name)
-		clusterCopy, err = h.clusters.Update(clusterCopy)
-		if err != nil {
-			return cluster, err
-		}
-		cluster = clusterCopy.DeepCopy()
-		// clusterCopy is returned here since it's value will be passed and fields modified without an update
 		return clusterCopy, err
 	})
 
+	logrus.Tracef("[secretmigrator] setting cluster condition [%s] and updating cluster [%s]", apimgmtv3.ClusterConditionSecretsMigrated, clusterCopy.Name)
 	// this is done for safety, but obj should never be nil as long as the object passed into Do() is not nil
 	clusterCopy, _ = obj.(*apimgmtv3.Cluster)
 	clusterCopy, err = h.clusters.Update(clusterCopy)
@@ -979,6 +975,9 @@ func (h *handler) migrateClusterSecrets(cluster *apimgmtv3.Cluster) (*apimgmtv3.
 }
 
 func (h *handler) migrateServiceAccountSecrets(cluster *apimgmtv3.Cluster) (*apimgmtv3.Cluster, error) {
+	if apimgmtv3.ClusterConditionServiceAccountSecretsMigrated.IsTrue(cluster) {
+		return cluster, nil
+	}
 	clusterCopy := cluster.DeepCopy()
 	obj, doErr := apimgmtv3.ClusterConditionServiceAccountSecretsMigrated.DoUntilTrue(clusterCopy, func() (runtime.Object, error) {
 		// serviceAccountToken
@@ -1005,15 +1004,9 @@ func (h *handler) migrateServiceAccountSecrets(cluster *apimgmtv3.Cluster) (*api
 				cluster = clusterCopy
 			}
 		}
-		logrus.Tracef("[secretmigrator] setting cluster condition [%s] and updating cluster [%s]", apimgmtv3.ClusterConditionServiceAccountSecretsMigrated, clusterCopy.Name)
-		var err error
-		clusterCopy, err = h.clusters.Update(clusterCopy)
-		if err != nil {
-			return cluster, err
-		}
-		cluster = clusterCopy.DeepCopy()
 		return clusterCopy, nil
 	})
+	logrus.Tracef("[secretmigrator] setting cluster condition [%s] and updating cluster [%s]", apimgmtv3.ClusterConditionServiceAccountSecretsMigrated, clusterCopy.Name)
 	// this is done for safety, but obj should never be nil as long as the object passed into DoUntilTrue() is not nil
 	clusterCopy, _ = obj.(*apimgmtv3.Cluster)
 	var err error
@@ -1026,6 +1019,9 @@ func (h *handler) migrateServiceAccountSecrets(cluster *apimgmtv3.Cluster) (*api
 }
 
 func (h *handler) migrateACISecrets(cluster *apimgmtv3.Cluster) (*apimgmtv3.Cluster, error) {
+	if apimgmtv3.ClusterConditionACISecretsMigrated.IsTrue(cluster) {
+		return cluster, nil
+	}
 	clusterCopy := cluster.DeepCopy()
 	obj, doErr := apimgmtv3.ClusterConditionACISecretsMigrated.DoUntilTrue(clusterCopy, func() (runtime.Object, error) {
 		// aci apic user key
@@ -1120,15 +1116,9 @@ func (h *handler) migrateACISecrets(cluster *apimgmtv3.Cluster) (*apimgmtv3.Clus
 				cluster = clusterCopy
 			}
 		}
-		logrus.Tracef("[secretmigrator] setting cluster condition [%s] and updating cluster [%s]", apimgmtv3.ClusterConditionACISecretsMigrated, clusterCopy.Name)
-		var err error
-		clusterCopy, err = h.clusters.Update(clusterCopy)
-		if err != nil {
-			return cluster, err
-		}
-		cluster = clusterCopy.DeepCopy()
 		return clusterCopy, nil
 	})
+	logrus.Tracef("[secretmigrator] setting cluster condition [%s] and updating cluster [%s]", apimgmtv3.ClusterConditionACISecretsMigrated, clusterCopy.Name)
 	// this is done for safety, but obj should never be nil as long as the object passed into Do() is not nil
 	clusterCopy, _ = obj.(*apimgmtv3.Cluster)
 	var err error
@@ -1141,6 +1131,9 @@ func (h *handler) migrateACISecrets(cluster *apimgmtv3.Cluster) (*apimgmtv3.Clus
 }
 
 func (h *handler) migrateRKESecrets(cluster *apimgmtv3.Cluster) (*apimgmtv3.Cluster, error) {
+	if apimgmtv3.ClusterConditionRKESecretsMigrated.IsTrue(cluster) {
+		return cluster, nil
+	}
 	clusterCopy := cluster.DeepCopy()
 	var err error
 	obj, doErr := apimgmtv3.ClusterConditionRKESecretsMigrated.DoUntilTrue(clusterCopy, func() (runtime.Object, error) {
@@ -1208,14 +1201,9 @@ func (h *handler) migrateRKESecrets(cluster *apimgmtv3.Cluster) (*apimgmtv3.Clus
 		}
 		cluster = clusterCopy
 
-		logrus.Tracef("[secretmigrator] setting cluster condition [%s] and updating cluster [%s]", apimgmtv3.ClusterConditionRKESecretsMigrated, clusterCopy.Name)
-		clusterCopy, err = h.clusters.Update(clusterCopy)
-		if err != nil {
-			return cluster, err
-		}
-		cluster = clusterCopy.DeepCopy()
 		return clusterCopy, nil
 	})
+	logrus.Tracef("[secretmigrator] setting cluster condition [%s] and updating cluster [%s]", apimgmtv3.ClusterConditionRKESecretsMigrated, clusterCopy.Name)
 	// this is done for safety, but obj should never be nil as long as the object passed into Do() is not nil
 	clusterCopy, _ = obj.(*apimgmtv3.Cluster)
 	clusterCopy, err = h.clusters.Update(clusterCopy)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #41180
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The cluster object was being updated four times whenever the `cluster-secret-migrator` handler was called, however these updates were no-ops because the cluster was equal. This handler gets enqueued whenever the cluster object actually get's updated, on startup, or after a timeout. This causes the apiserver to be updated much more than normal for cluster resources.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Check if a migration needs to happen before migrating, and only update if there is a change.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: Updated existing unit tests to make sure an object is not updated unless it needs to be

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

- Provision on v2.6.11
- Monitor how many times a given cluster object gets updated via the `rancher-2.6.11-secrets-migrator` user agent
- Upgrade
- Observe less updates from user agent

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Secrets migration should still take place, however there are alreadya utomated tests to confirm this.

Existing / newly added automated tests that provide evidence there are no regressions: Updated unit tests to fail if an object is updated without a legitimate update.
