### PR TITLE
add ingress path+pathType customization to helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -54,8 +54,8 @@ spec:
           servicePort: {{ .Values.ingress.servicePort }}
           {{- end }}
         {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
-        pathType: ImplementationSpecific
-        path: "/"
+        pathType: {{ .Values.ingress.pathType }}
+        path: {{ .Values.ingress.path }}
         {{- end }}
 {{- if eq .Values.tls "ingress" }}
   tls:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -60,6 +60,9 @@ ingress:
   includeDefaultExtraAnnotations: true
   extraAnnotations: {}
   ingressClassName: ""
+  # Certain ingress controllers will will require the pathType or path to be set to a different value.
+  pathType: ImplementationSpecific
+  path: "/"
   # backend port number
   servicePort: 80
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/41873
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
Certain load balancers (such as AWS Load Balancer controller or GKE Ingress) require a slightly different path to work with Rancher.
 
## Solution
Making both the path and the pathType customisable via helm values will mean wider compatibility and greater flexibility.
 
## Testing
Having tried the native chart with both AWS Load Balancer controller and GKE Ingress, the ingress returned 404 consistently on the /dashboard/ endpoint.
## Engineering Testing
### Manual Testing
I created a helm installation with the following values:

```
hostname: rancher.mycompany.net
ingress:
  ingressClassName: alb
  includeDefaultExtraAnnotations: false
  extraAnnotations:
      alb.ingress.kubernetes.io/scheme: internal
      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80, "HTTPS": 443}]'
      alb.ingress.kubernetes.io/target-type: ip
tls: external
```
After deploying, the Rancher dashboard returned 404 while trying to reach via the ingress, but port-forwarding worked flawlessly.

After updating the path of the ingress from "/" to "/*", the dashboard became reachable via the ingress.

This is a small change overall, with the relatively big benefit of making the Rancher chart compatible with 2 major cloud providers' ingress controllers.
