### PR TITLE
general improvements on error messages

### DIFF
--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -604,7 +604,10 @@ func (p *Planner) runEtcdRestoreInitNodeElection(controlPlane *rkev1.RKEControlP
 		return p.electInitNode(controlPlane, clusterPlan)
 	}
 	// make sure that we only have one suitable init node, and elect it.
-	if len(collect(clusterPlan, canBeInitNode)) != 1 {
+	count := len(collect(clusterPlan, canBeInitNode))
+	if count == 0 {
+		return "", fmt.Errorf("no init node existed and no corresponding etcd snapshot CR found, no assumption can be made for the machine that contains the snapshot")
+	} else if count > 1 {
 		return "", fmt.Errorf("more than one init node existed and no corresponding etcd snapshot CR found, no assumption can be made for the machine that contains the snapshot")
 	}
 	logrus.Infof("[planner] rkecluster %s/%s: electing init node for local snapshot with no associated CR", controlPlane.Namespace, controlPlane.Name)

--- a/tests/v2prov/cluster/clusters.go
+++ b/tests/v2prov/cluster/clusters.go
@@ -63,15 +63,15 @@ func New(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*provisi
 			cluster.Spec.RKEConfig.MachineGlobalConfig.Data[k] = v
 		}
 
-		for i, np := range cluster.Spec.RKEConfig.MachinePools {
-			if np.NodeConfig == nil {
+		for i, mp := range cluster.Spec.RKEConfig.MachinePools {
+			if mp.NodeConfig == nil {
 				podConfig, err := nodeconfig.NewPodConfig(clients, cluster.Namespace)
 				if err != nil {
 					return nil, err
 				}
 				cluster.Spec.RKEConfig.MachinePools[i].NodeConfig = podConfig
 			}
-			if np.Name == "" {
+			if mp.Name == "" {
 				cluster.Spec.RKEConfig.MachinePools[i].Name = fmt.Sprintf("pool-%d", i)
 			}
 		}
@@ -483,6 +483,12 @@ func gatherDebugData(clients *clients.Clients, c *provisioningv1api.Cluster) (st
 		}
 	}
 
+	snapshots, newErr := clients.RKE.ETCDSnapshot().List(c.Namespace, metav1.ListOptions{})
+	if newErr != nil {
+		logrus.Error(newErr)
+		snapshots = nil
+	}
+
 	return capr.CompressInterface(map[string]interface{}{
 		"cluster":               newC,
 		"rkecontrolplane":       newControlPlane,
@@ -496,6 +502,7 @@ func gatherDebugData(clients *clients.Clients, c *provisioningv1api.Cluster) (st
 		"infraCluster":          infraCluster,
 		"infraMachines":         infraMachines,
 		"podLogs":               podLogs,
+		"snapshots":             snapshots,
 	})
 }
 


### PR DESCRIPTION
 https://github.com/rancher/rancher/issues/41808

This PR contains some general improvements around the v2 provisioning operation tests:
- clear error message
- include the etcdSnapshpt object in the output for troubleshooting 