### PR TITLE
fixed bug, refactored and added proper documentation

### DIFF
--- a/pkg/catalogv2/git/download.go
+++ b/pkg/catalogv2/git/download.go
@@ -59,16 +59,13 @@ func Update(secret *corev1.Secret, namespace, name, gitURL, branch string, insec
 	return commit, err
 }
 
-func Ensure(secret *corev1.Secret, namespace, name, gitURL, commit string, insecureSkipTLS bool, caBundle []byte) error {
-	if commit == "" {
-		return nil
-	}
+func Ensure(secret *corev1.Secret, namespace, name, gitURL, branch string, insecureSkipTLS bool, caBundle []byte) error {
 	git, err := gitForRepo(secret, namespace, name, gitURL, insecureSkipTLS, caBundle)
 	if err != nil {
 		return err
 	}
 
-	return git.Ensure(commit)
+	return git.Ensure(branch)
 }
 
 func isBundled(git *git) bool {

--- a/pkg/catalogv2/git/git.go
+++ b/pkg/catalogv2/git/git.go
@@ -129,16 +129,16 @@ func (g *git) Update(branch string) (string, error) {
 }
 
 // Ensure runs git clone, clean DIRTY contents and fetch the latest commit
-func (g *git) Ensure(commit string) error {
+func (g *git) Ensure(branch string) error {
 	if err := g.clone(""); err != nil {
 		return err
 	}
 
-	if err := g.reset(commit); err == nil {
+	if err := g.reset(branch); err == nil {
 		return nil
 	}
 
-	return g.fetchAndReset(commit)
+	return g.fetchAndReset(branch)
 }
 
 func (g *git) httpClientWithCreds() (*http.Client, error) {

--- a/pkg/data/dashboard/add.go
+++ b/pkg/data/dashboard/add.go
@@ -33,7 +33,7 @@ func Add(ctx context.Context, wrangler *wrangler.Context, addLocal, removeLocal,
 		return err
 	}
 
-	if err := addRepos(ctx, wrangler); err != nil {
+	if err := addClusterRepos(ctx, wrangler); err != nil {
 		return err
 	}
 

--- a/pkg/data/dashboard/repo.go
+++ b/pkg/data/dashboard/repo.go
@@ -18,7 +18,7 @@ var (
 	prefix = "rancher-"
 )
 
-func addRepo(wrangler *wrangler.Context, repoName, branchName string) error {
+func addClusterRepo(wrangler *wrangler.Context, repoName, branchName string) error {
 	repo, err := wrangler.Catalog.ClusterRepo().Get(repoName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		_, err = wrangler.Catalog.ClusterRepo().Create(&v1.ClusterRepo{
@@ -38,17 +38,19 @@ func addRepo(wrangler *wrangler.Context, repoName, branchName string) error {
 	return err
 }
 
-// addRepos upserts the rancher-charts, rancher-partner-charts and rancher-rke2-charts ClusterRepos
-func addRepos(ctx context.Context, wrangler *wrangler.Context) error {
-	if err := addRepo(wrangler, "rancher-charts", settings.ChartDefaultBranch.Get()); err != nil {
+// addClusterRepos sets up default cluster helm repositories in Rancher.
+// It attempts to add or update the cluster repositories 'rancher-charts', 'rancher-partner-charts',
+// and, if the RKE2 feature is enabled, 'rancher-rke2-charts'.
+func addClusterRepos(ctx context.Context, wrangler *wrangler.Context) error {
+	if err := addClusterRepo(wrangler, "rancher-charts", settings.ChartDefaultBranch.Get()); err != nil {
 		return err
 	}
-	if err := addRepo(wrangler, "rancher-partner-charts", settings.PartnerChartDefaultBranch.Get()); err != nil {
+	if err := addClusterRepo(wrangler, "rancher-partner-charts", settings.PartnerChartDefaultBranch.Get()); err != nil {
 		return err
 	}
 
 	if features.RKE2.Enabled() {
-		if err := addRepo(wrangler, "rancher-rke2-charts", settings.RKE2ChartDefaultBranch.Get()); err != nil {
+		if err := addClusterRepo(wrangler, "rancher-rke2-charts", settings.RKE2ChartDefaultBranch.Get()); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Issue: 
https://jira.suse.com/browse/SURE-5190
 Installed Apps, e.g. fleet and rancher-webhook, don't update after upgrade from v2.6.3 to v2.6.8 when Rancher chart uses --set useBundledSystemChart=true. As a result, fleet is left on chart version 100.0.2+up0.3.8 versus 100.0.5+up0.3.11 and rancher-webhook is left on chart version 1.0.2+up0.2.2 versus 1.0.5+up0.2.6.


## Problem
When updating rancher versions there was no logic to check the different branches or commits and if the configMap should be updated. 
 
## Solution
Ensure method had to change the behavior to work by the branch instead of the commit hash. 
Also, added a check for the default branch of each version and the specified clusterRepo branch from the previous version.
Forced the update of the configMap upon specific condition. 
 