### PR TITLE
Adds configuration for a cluster's webhook values.

### DIFF
--- a/chart/templates/configMap.yaml
+++ b/chart/templates/configMap.yaml
@@ -3,5 +3,11 @@ kind: ConfigMap
 metadata:
   name: rancher-config
   labels: {{ include "rancher.labels" . | nindent 4 }}
+    app.kubernetes.io/part-of: "rancher"
 data:
   priorityClassName:  {{ .Values.priorityClassName }}
+  {{- if and .Values.webhook (kindIs "string" .Values.webhook) }}
+  rancher-webhook: {{  .Values.webhook | nindent 4 | squote }}
+  {{- else if .Values.webhook }}
+  rancher-webhook: {{ toYaml .Values.webhook | nindent 4 | squote }}
+  {{- end }}

--- a/chart/tests/configmap_test.yaml
+++ b/chart/tests/configmap_test.yaml
@@ -1,0 +1,63 @@
+suite: Test ConfigMap
+templates:
+  - configMap.yaml
+
+tests:
+  - it: should set webhook value from string
+    set:
+      webhook: 'hostNetwork: true
+        newKey: newValue
+        newlist:
+          - list1
+          - list2
+          - list3
+        newMap:
+          entry1: 1
+          entry2: 2
+          entry3:
+            sub3: "sub"'
+    asserts:
+      - equal:
+          path: data.rancher-webhook
+          value: '
+            hostNetwork: true
+            newKey: newValue
+            newlist:
+              - list1
+              - list2
+              - list3
+            newMap:
+              entry1: 1
+              entry2: 2
+              entry3:
+                sub3: "sub"'
+
+  - it: should set webhook value from map
+    set:
+      webhook.hostNetwork: true
+      webhook.newKey: 2
+    asserts:
+      - equal:
+          path: data.rancher-webhook
+          value: "
+            hostNetwork: true
+            newKey: 2"
+
+  - it: should not set webhook values
+    asserts:
+      - notExists:
+          path: data.rancher-webhook
+
+  - it: should set priorityClassName
+    set:
+      priorityClassName: "super"
+    asserts:
+      - equal:
+          path: data.priorityClassName
+          value: "super"
+
+  - it: should set default priorityClassName
+    asserts:
+      - equal:
+          path: data.priorityClassName
+          value: "rancher-critical"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -180,4 +180,8 @@ global:
     psp:
       # will default to true on 1.24 and below, and false for 1.25 and above
       # can be changed manually to true or false to bypass version checks and force that option
-      enabled: "" 
+      enabled: ""
+
+# helm values to use when installing the rancher-webhook chart.
+# helm values set here will override all other global values used when installing the webhook such as priorityClassName and systemRegistry settings.
+webhook: ""

--- a/pkg/controllers/dashboard/chart/chart_test.go
+++ b/pkg/controllers/dashboard/chart/chart_test.go
@@ -11,38 +11,52 @@ import (
 	"github.com/rancher/wrangler/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var (
-	errUnimplemented = fmt.Errorf("unimplemented")
-	errNotFound      = fmt.Errorf("not found")
-)
+var errTest = fmt.Errorf("test error")
 
-const priorityClassName = "rancher-critical"
+const (
+	priorityClassName = "rancher-critical"
+	testKey           = "testKey"
+	testValue         = "newValue"
+)
 
 func TestGetPriorityClassNameFromRancherConfigMap(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	configCache := fake.NewMockCacheInterface[*v1.ConfigMap](ctrl)
-	configCache.EXPECT().Get(namespace.System, "set-config").Return(&v1.ConfigMap{Data: map[string]string{"priorityClassName": priorityClassName}}, nil).AnyTimes()
+	configCache.EXPECT().Get(namespace.System, "set-config").Return(&v1.ConfigMap{Data: map[string]string{"priorityClassName": priorityClassName, testKey: testValue}}, nil).AnyTimes()
 	configCache.EXPECT().Get(namespace.System, "empty-config").Return(&v1.ConfigMap{}, nil).AnyTimes()
 	configCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("not found")).AnyTimes()
 
 	tests := []*struct {
 		name    string
 		want    string
+		key     string
 		wantErr bool
 		setup   func()
 	}{
 		// base case config map set.
 		{
 			name:    "correctly set priority class name",
+			key:     chart.PriorityClassKey,
 			want:    priorityClassName,
+			wantErr: false,
+			setup:   func() { settings.ConfigMapName.Set("set-config") },
+		},
+		// base case config map set.
+		{
+			name:    "correctly get test key name",
+			key:     testKey,
+			want:    testValue,
 			wantErr: false,
 			setup:   func() { settings.ConfigMapName.Set("set-config") },
 		},
 		// config map name is empty.
 		{
 			name:    "empty configMap name",
+			key:     chart.PriorityClassKey,
 			want:    "",
 			wantErr: true,
 			setup:   func() { settings.ConfigMapName.Set("") },
@@ -50,6 +64,7 @@ func TestGetPriorityClassNameFromRancherConfigMap(t *testing.T) {
 		// config map doesn't exist.
 		{
 			name:    "unknown config map name",
+			key:     chart.PriorityClassKey,
 			want:    "",
 			wantErr: true,
 			setup:   func() { settings.ConfigMapName.Set("unknown-config-name") },
@@ -57,6 +72,7 @@ func TestGetPriorityClassNameFromRancherConfigMap(t *testing.T) {
 		// config map exist doesn't have priority class.
 		{
 			name:    "empty config map",
+			key:     chart.PriorityClassKey,
 			want:    "",
 			wantErr: true,
 			setup:   func() { settings.ConfigMapName.Set("empty-config") },
@@ -66,13 +82,108 @@ func TestGetPriorityClassNameFromRancherConfigMap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setup()
 			getter := chart.RancherConfigGetter{configCache}
-			got, err := getter.GetPriorityClassName()
+			got, err := getter.GetGlobalValue(tt.key)
 			if tt.wantErr {
 				assert.Error(t, err, "Expected test to error.")
 				return
 			}
 			assert.NoError(t, err, "failed to get priority class.")
 			assert.Equal(t, tt.want, got, "Unexpected priorityClassName returned")
+		})
+	}
+}
+
+func TestGetChartValue(t *testing.T) {
+	const yamlInfo = "yamlKey: yamlValue"
+	const invalidYaml = "%{'foo':'bar "
+
+	tests := []*struct {
+		name      string
+		want      map[string]any
+		chartName string
+		wantErr   bool
+		notFound  bool
+		setup     func(*fake.MockCacheInterface[*v1.ConfigMap])
+	}{
+		{
+			name:      "correctly get webhook values",
+			want:      map[string]any{"yamlKey": "yamlValue"},
+			chartName: chart.WebhookChartName,
+			setup: func(configCache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				configCache.EXPECT().Get(namespace.System, chart.CustomValueMapName).Return(&v1.ConfigMap{Data: map[string]string{chart.WebhookChartName: yamlInfo}}, nil)
+			},
+		},
+
+		{
+			name:      "webhook values are invalid yaml",
+			chartName: chart.WebhookChartName,
+			wantErr:   true,
+			setup: func(configCache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				configCache.EXPECT().Get(namespace.System, chart.CustomValueMapName).Return(&v1.ConfigMap{Data: map[string]string{chart.WebhookChartName: invalidYaml}}, nil)
+			},
+		},
+		{
+			name:      "value not in map",
+			chartName: chart.WebhookChartName,
+			wantErr:   true,
+			notFound:  true,
+			setup: func(configCache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				configCache.EXPECT().Get(namespace.System, chart.CustomValueMapName).Return(&v1.ConfigMap{Data: map[string]string{}}, nil)
+			},
+		},
+		{
+			name:      "map is nil",
+			chartName: chart.WebhookChartName,
+			wantErr:   true,
+			notFound:  true,
+			setup: func(configCache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				configCache.EXPECT().Get(namespace.System, chart.CustomValueMapName).Return(&v1.ConfigMap{Data: nil}, nil)
+			},
+		},
+		{
+			name:      "rancher config does not exist",
+			chartName: chart.WebhookChartName,
+			wantErr:   true,
+			notFound:  true,
+			setup: func(configCache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				configCache.EXPECT().Get(namespace.System, chart.CustomValueMapName).Return(nil, apierror.NewNotFound(schema.GroupResource{}, chart.CustomValueMapName))
+			},
+		},
+		{
+			name:      "rancher config get failed",
+			chartName: chart.WebhookChartName,
+			wantErr:   true,
+			notFound:  false,
+			setup: func(configCache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				configCache.EXPECT().Get(namespace.System, chart.CustomValueMapName).Return(nil, errTest)
+			},
+		},
+		{
+			name:      "webhook value does not used deprecated configMap setting",
+			chartName: chart.WebhookChartName,
+			want:      map[string]any{"yamlKey": "yamlValue"},
+			setup: func(configCache *fake.MockCacheInterface[*v1.ConfigMap]) {
+				settings.ConfigMapName.Set("unknown-config-name")
+				configCache.EXPECT().Get(namespace.System, chart.CustomValueMapName).Return(&v1.ConfigMap{Data: map[string]string{chart.WebhookChartName: yamlInfo}}, nil)
+			},
+		},
+	}
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			configCache := fake.NewMockCacheInterface[*v1.ConfigMap](ctrl)
+			test.setup(configCache)
+			getter := chart.RancherConfigGetter{configCache}
+			got, err := getter.GetChartValues(tt.chartName)
+			if test.wantErr {
+				assert.Equal(t, test.notFound, chart.IsNotFoundError(err))
+				assert.Error(t, err, "Expected test to error.")
+				return
+			}
+			assert.NoError(t, err, "failed to get priority class.")
+			assert.Equal(t, test.want, got, "Unexpected priorityClassName returned")
 		})
 	}
 }

--- a/pkg/controllers/dashboard/fleetcharts/controller.go
+++ b/pkg/controllers/dashboard/fleetcharts/controller.go
@@ -13,9 +13,10 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
-	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 )
+
+const priorityClassKey = "priorityClassName"
 
 var (
 	fleetCRDChart = chart.Definition{
@@ -111,13 +112,13 @@ func (h *handler) onSetting(key string, setting *v3.Setting) (*v3.Setting, error
 	}
 
 	// add priority class value
-	if priorityClassName, err := h.chartsConfig.GetPriorityClassName(); err != nil {
-		if !apierror.IsNotFound(err) {
+	if priorityClassName, err := h.chartsConfig.GetGlobalValue(chart.PriorityClassKey); err != nil {
+		if !chart.IsNotFoundError(err) {
 			logrus.Warnf("Failed to get rancher priorityClassName for '%s': %v", fleetChart.ChartName, err)
 		}
 	} else {
-		fleetChartValues[chart.PriorityClassKey] = priorityClassName
-		gitjobChartValues[chart.PriorityClassKey] = priorityClassName
+		fleetChartValues[priorityClassKey] = priorityClassName
+		gitjobChartValues[priorityClassKey] = priorityClassName
 	}
 
 	if len(gitjobChartValues) > 0 {

--- a/pkg/controllers/dashboard/systemcharts/controller.go
+++ b/pkg/controllers/dashboard/systemcharts/controller.go
@@ -1,3 +1,4 @@
+// Package systemcharts handles the reconciliation of systemcharts installed by rancher in the rancher-charts repo.
 package systemcharts
 
 import (
@@ -7,23 +8,34 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/chart"
 	"github.com/rancher/rancher/pkg/features"
-	namespace "github.com/rancher/rancher/pkg/namespace"
+	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/rancher/wrangler/pkg/data"
 	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
-	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
 	repoName         = "rancher-charts"
-	webhookChartName = "rancher-webhook"
 	webhookImage     = "rancher/rancher-webhook"
+	priorityClassKey = "priorityClassName"
 )
 
+var (
+	watchedSettings = map[string]struct{}{
+		settings.RancherWebhookMinVersion.Name: {},
+		settings.RancherWebhookVersion.Name:    {},
+		settings.SystemDefaultRegistry.Name:    {},
+		settings.ShellImage.Name:               {},
+	}
+)
+
+// Register is called to create a new handler and subscribe to change events.
 func Register(ctx context.Context, wContext *wrangler.Context, registryOverride string) error {
 	h := &handler{
 		manager:          wContext.SystemChartsManager,
@@ -33,20 +45,12 @@ func Register(ctx context.Context, wContext *wrangler.Context, registryOverride 
 	}
 
 	wContext.Catalog.ClusterRepo().OnChange(ctx, "bootstrap-charts", h.onRepo)
-	relatedresource.WatchClusterScoped(ctx, "bootstrap-charts", func(namespace, name string, obj runtime.Object) ([]relatedresource.Key, error) {
-		return []relatedresource.Key{{
-			Name: repoName,
-		}}, nil
-	}, wContext.Catalog.ClusterRepo(), wContext.Mgmt.Feature())
+	relatedresource.WatchClusterScoped(ctx, "bootstrap-charts", relatedFeatures, wContext.Catalog.ClusterRepo(), wContext.Mgmt.Feature())
 
-	relatedresource.WatchClusterScoped(ctx, "bootstrap-settings-charts", func(namespace, name string, obj runtime.Object) ([]relatedresource.Key, error) {
-		if s, ok := obj.(*v3.Setting); ok && (s.Name == "rancher-webhook-version" || s.Name == "rancher-webhook-min-version") {
-			return []relatedresource.Key{{
-				Name: repoName,
-			}}, nil
-		}
-		return nil, nil
-	}, wContext.Catalog.ClusterRepo(), wContext.Mgmt.Setting())
+	relatedresource.WatchClusterScoped(ctx, "bootstrap-settings-charts", relatedSettings, wContext.Catalog.ClusterRepo(), wContext.Mgmt.Setting())
+
+	// ensure the system charts are installed with the correct values when there are changes to the rancher config map
+	relatedresource.WatchClusterScoped(ctx, "bootstrap-configmap-charts", relatedConfigMaps, wContext.Catalog.ClusterRepo(), wContext.Core.ConfigMap())
 	return nil
 }
 
@@ -113,10 +117,10 @@ func (h *handler) onRepo(key string, repo *catalog.ClusterRepo) (*catalog.Cluste
 		// chart definition, but is now part of the chart definition
 		minVersion := chartDef.MinVersionSetting.Get()
 		exactVersion := chartDef.ExactVersionSetting.Get()
-		if chartDef.ChartName == webhookChartName && minVersion != "" {
+		if chartDef.ChartName == chart.WebhookChartName && minVersion != "" {
 			exactVersion = ""
 		}
-		if err := h.manager.Ensure(chartDef.ReleaseNamespace, chartDef.ChartName, minVersion, exactVersion, values, chartDef.ChartName == webhookChartName, installImageOverride); err != nil {
+		if err := h.manager.Ensure(chartDef.ReleaseNamespace, chartDef.ChartName, minVersion, exactVersion, values, chartDef.ChartName == chart.WebhookChartName, installImageOverride); err != nil {
 			return repo, err
 		}
 	}
@@ -128,7 +132,7 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 	return []*chart.Definition{
 		{
 			ReleaseNamespace:    namespace.System,
-			ChartName:           webhookChartName,
+			ChartName:           chart.WebhookChartName,
 			MinVersionSetting:   settings.RancherWebhookMinVersion,
 			ExactVersionSetting: settings.RancherWebhookVersion,
 			Values: func() map[string]interface{} {
@@ -140,15 +144,22 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 						"enabled": features.MCM.Enabled(),
 					},
 				}
-				// add priority class value.
-				if priorityClassName, err := h.chartsConfig.GetPriorityClassName(); err != nil {
-					if !apierror.IsNotFound(err) {
-						logrus.Warnf("Failed to get rancher priorityClassName for 'rancher-webhook': %v", err)
+				// add priority class value
+				if priorityClassName, err := h.chartsConfig.GetGlobalValue(chart.PriorityClassKey); err != nil {
+					if !chart.IsNotFoundError(err) {
+						logrus.Warnf("Failed to get rancher %s for 'rancher-webhook': %s", chart.PriorityClassKey, err.Error())
 					}
 				} else {
-					values[chart.PriorityClassKey] = priorityClassName
+					values[priorityClassKey] = priorityClassName
 				}
-				return values
+
+				// get custom values for the rancher-webhook
+				configMapValues, err := h.chartsConfig.GetChartValues(chart.WebhookChartName)
+				if err != nil && !chart.IsNotFoundError(err) {
+					logrus.Warnf("Failed to get rancher rancherWebhookValues %s", err.Error())
+				}
+
+				return data.MergeMaps(values, configMapValues)
 			},
 			Enabled: func() bool { return true },
 		},
@@ -159,4 +170,33 @@ func (h *handler) getChartsToInstall() []*chart.Definition {
 			RemoveNamespace:  true,
 		},
 	}
+}
+
+func relatedFeatures(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	if _, ok := obj.(*v3.Feature); ok {
+		return []relatedresource.Key{{
+			Name: repoName,
+		}}, nil
+	}
+	return nil, nil
+}
+
+func relatedSettings(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	if f, ok := obj.(*v3.Setting); ok {
+		if _, ok := watchedSettings[f.Name]; ok {
+			return []relatedresource.Key{{
+				Name: repoName,
+			}}, nil
+		}
+	}
+	return nil, nil
+}
+
+func relatedConfigMaps(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	if configMap, ok := obj.(*v1.ConfigMap); ok && configMap.Namespace == namespace.System && (configMap.Name == chart.CustomValueMapName || configMap.Name == settings.ConfigMapName.Get()) {
+		return []relatedresource.Key{{
+			Name: repoName,
+		}}, nil
+	}
+	return nil, nil
 }

--- a/pkg/controllers/dashboard/systemcharts/controller_test.go
+++ b/pkg/controllers/dashboard/systemcharts/controller_test.go
@@ -6,43 +6,82 @@ import (
 
 	"github.com/golang/mock/gomock"
 	catalog "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/chart"
 	chartfake "github.com/rancher/rancher/pkg/controllers/dashboard/chart/fake"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/wrangler/pkg/generic/fake"
+	"github.com/rancher/wrangler/pkg/relatedresource"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var (
-	errUnimplemented  = fmt.Errorf("unimplemented")
-	errNotFound       = fmt.Errorf("not found")
+	errTest           = fmt.Errorf("test error")
 	priorityClassName = "rancher-critical"
 	operatorNamespace = "rancher-operator-system"
+	priorityConfig    = &v1.ConfigMap{
+		Data: map[string]string{
+			"priorityClassName": priorityClassName,
+		},
+	}
+	fullConfig = &v1.ConfigMap{
+		Data: map[string]string{
+			"priorityClassName":    priorityClassName,
+			chart.WebhookChartName: testYAML,
+		},
+	}
+	emptyConfig        = &v1.ConfigMap{}
+	originalMinVersion = settings.RancherWebhookMinVersion.Get()
+	originalVersion    = settings.RancherWebhookVersion.Get()
+	originalMCM        = features.MCM.Enabled()
 )
 
-// Test_ChartInstallation test that all expected charts are installed or uninstalled with expected configuration
+const testYAML = `---
+newKey: newValue
+mcm:
+  enabled: false
+global: ""
+priorityClassName: newClass
+`
+
+type testMocks struct {
+	manager       *chartfake.MockManager
+	namespaceCtrl *fake.MockNonNamespacedControllerInterface[*v1.Namespace, *v1.NamespaceList]
+	configCache   *fake.MockCacheInterface[*v1.ConfigMap]
+}
+
+func (t *testMocks) Handler() *handler {
+	return &handler{
+		manager:      t.manager,
+		namespaces:   t.namespaceCtrl,
+		chartsConfig: chart.RancherConfigGetter{ConfigCache: t.configCache},
+	}
+}
+
+// Test_ChartInstallation test that all expected charts are installed or uninstalled with expected configuration.
 func Test_ChartInstallation(t *testing.T) {
 	repo := &catalog.ClusterRepo{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: repoName,
 		},
 	}
-
 	tests := []struct {
 		name             string
-		setup            func(*gomock.Controller) chart.Manager
+		setup            func(testMocks)
 		registryOverride string
 		wantErr          bool
 	}{
 		{
 			name: "normal installation",
-			setup: func(ctrl *gomock.Controller) chart.Manager {
-				settings.ConfigMapName.Set("pass")
+			setup: func(mocks testMocks) {
+				mocks.namespaceCtrl.EXPECT().Delete(operatorNamespace, nil).Return(nil)
+				mocks.configCache.EXPECT().Get(namespace.System, chart.CustomValueMapName).Return(priorityConfig, nil).Times(2)
 				settings.RancherWebhookVersion.Set("2.0.0")
-				manager := chartfake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
 					"priorityClassName": priorityClassName,
 					"capi": map[string]interface{}{
@@ -57,27 +96,25 @@ func Test_ChartInstallation(t *testing.T) {
 						},
 					},
 				}
-				var b bool
-				manager.EXPECT().Ensure(
+				mocks.manager.EXPECT().Ensure(
 					namespace.System,
 					"rancher-webhook",
 					"",
 					"2.0.0",
 					expectedValues,
-					gomock.AssignableToTypeOf(b),
+					gomock.AssignableToTypeOf(false),
 					"",
 				).Return(nil)
 
-				manager.EXPECT().Uninstall(operatorNamespace, "rancher-operator").Return(nil)
-				return manager
+				mocks.manager.EXPECT().Uninstall(operatorNamespace, "rancher-operator").Return(nil)
 			},
 		},
 		{
-			name: "installation without webhook priority class",
-			setup: func(ctrl *gomock.Controller) chart.Manager {
-				settings.ConfigMapName.Set("fail")
+			name: "installation with config cache errors",
+			setup: func(mocks testMocks) {
+				mocks.namespaceCtrl.EXPECT().Delete(operatorNamespace, nil).Return(nil)
+				mocks.configCache.EXPECT().Get(gomock.Any(), chart.CustomValueMapName).Return(nil, errTest).Times(2)
 				settings.RancherWebhookVersion.Set("2.0.0")
-				manager := chartfake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
 					"capi": map[string]interface{}{
 						"enabled": features.EmbeddedClusterAPI.Enabled(),
@@ -91,28 +128,25 @@ func Test_ChartInstallation(t *testing.T) {
 						},
 					},
 				}
-				var b bool
-				manager.EXPECT().Ensure(
+				mocks.manager.EXPECT().Ensure(
 					namespace.System,
 					"rancher-webhook",
 					"",
 					"2.0.0",
 					expectedValues,
-					gomock.AssignableToTypeOf(b),
+					gomock.AssignableToTypeOf(false),
 					"",
 				).Return(nil)
 
-				manager.EXPECT().Uninstall(operatorNamespace, "rancher-operator").Return(nil)
-				return manager
-
+				mocks.manager.EXPECT().Uninstall(operatorNamespace, "rancher-operator").Return(nil)
 			},
 		},
 		{
 			name: "installation with image override",
-			setup: func(ctrl *gomock.Controller) chart.Manager {
-				settings.ConfigMapName.Set("fail")
+			setup: func(mocks testMocks) {
+				mocks.namespaceCtrl.EXPECT().Delete(operatorNamespace, nil).Return(nil)
+				mocks.configCache.EXPECT().Get(gomock.Any(), chart.CustomValueMapName).Return(emptyConfig, nil).Times(2)
 				settings.RancherWebhookVersion.Set("2.0.1")
-				manager := chartfake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
 					"capi": map[string]interface{}{
 						"enabled": features.EmbeddedClusterAPI.Enabled(),
@@ -129,29 +163,27 @@ func Test_ChartInstallation(t *testing.T) {
 						"repository": "rancher-test.io/rancher/rancher-webhook",
 					},
 				}
-				var b bool
-				manager.EXPECT().Ensure(
+				mocks.manager.EXPECT().Ensure(
 					namespace.System,
 					"rancher-webhook",
 					"",
 					"2.0.1",
 					expectedValues,
-					gomock.AssignableToTypeOf(b),
+					gomock.AssignableToTypeOf(false),
 					"rancher-test.io/"+settings.ShellImage.Get(),
 				).Return(nil)
 
-				manager.EXPECT().Uninstall(operatorNamespace, "rancher-operator").Return(nil)
-				return manager
+				mocks.manager.EXPECT().Uninstall(operatorNamespace, "rancher-operator").Return(nil)
 			},
 			registryOverride: "rancher-test.io",
 		},
 		{
 			name: "installation with min version override",
-			setup: func(ctrl *gomock.Controller) chart.Manager {
-				settings.ConfigMapName.Set("fail")
+			setup: func(mocks testMocks) {
+				mocks.namespaceCtrl.EXPECT().Delete(operatorNamespace, nil).Return(nil)
+				mocks.configCache.EXPECT().Get(gomock.Any(), chart.CustomValueMapName).Return(emptyConfig, nil).Times(2)
 				settings.RancherWebhookMinVersion.Set("2.0.1")
 				settings.RancherWebhookVersion.Set("2.0.4")
-				manager := chartfake.NewMockManager(ctrl)
 				expectedValues := map[string]interface{}{
 					"capi": map[string]interface{}{
 						"enabled": features.EmbeddedClusterAPI.Enabled(),
@@ -168,42 +200,228 @@ func Test_ChartInstallation(t *testing.T) {
 						"repository": "rancher-test.io/rancher/rancher-webhook",
 					},
 				}
-				var b bool
-				manager.EXPECT().Ensure(
+				mocks.manager.EXPECT().Ensure(
 					namespace.System,
 					"rancher-webhook",
 					"2.0.1",
 					"",
 					expectedValues,
-					gomock.AssignableToTypeOf(b),
+					gomock.AssignableToTypeOf(false),
 					"rancher-test.io/"+settings.ShellImage.Get(),
 				).Return(nil)
 
-				manager.EXPECT().Uninstall(operatorNamespace, "rancher-operator").Return(nil)
-				return manager
+				mocks.manager.EXPECT().Uninstall(operatorNamespace, "rancher-operator").Return(nil)
 			},
 			registryOverride: "rancher-test.io",
+		},
+		{
+			name: "installation with webhook values",
+			setup: func(mocks testMocks) {
+				mocks.namespaceCtrl.EXPECT().Delete(operatorNamespace, nil).Return(nil)
+				mocks.configCache.EXPECT().Get(gomock.Any(), chart.CustomValueMapName).Return(fullConfig, nil).Times(2)
+				settings.RancherWebhookVersion.Set("2.0.0")
+				features.MCM.Set(true)
+				expectedValues := map[string]interface{}{
+					"priorityClassName": "newClass",
+					"capi": map[string]interface{}{
+						"enabled": features.EmbeddedClusterAPI.Enabled(),
+					},
+					"mcm": map[any]interface{}{
+						"enabled": false,
+					},
+					"global": "",
+					"newKey": "newValue",
+				}
+				mocks.manager.EXPECT().Ensure(
+					namespace.System,
+					"rancher-webhook",
+					"",
+					"2.0.0",
+					expectedValues,
+					gomock.AssignableToTypeOf(false),
+					"",
+				).Return(nil)
+
+				mocks.manager.EXPECT().Uninstall(operatorNamespace, "rancher-operator").Return(nil)
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// reset setting to default values before each test
+			settings.RancherWebhookMinVersion.Set(originalMinVersion)
+			settings.RancherWebhookVersion.Set(originalVersion)
+			features.MCM.Set(originalMCM)
+
 			ctrl := gomock.NewController(t)
-			namespaceCtrl := fake.NewMockNonNamespacedControllerInterface[*v1.Namespace, *v1.NamespaceList](ctrl)
-			namespaceCtrl.EXPECT().Delete(operatorNamespace, nil).Return(nil)
-			configCache := fake.NewMockCacheInterface[*v1.ConfigMap](ctrl)
-			configCache.EXPECT().Get(gomock.Any(), "pass").Return(&v1.ConfigMap{Data: map[string]string{"priorityClassName": priorityClassName}}, nil).AnyTimes()
-			configCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("not found")).AnyTimes()
-			h := &handler{
-				chartsConfig: chart.RancherConfigGetter{ConfigCache: configCache},
+
+			// create mocks for each test
+			mocks := testMocks{
+				manager:       chartfake.NewMockManager(ctrl),
+				namespaceCtrl: fake.NewMockNonNamespacedControllerInterface[*v1.Namespace, *v1.NamespaceList](ctrl),
+				configCache:   fake.NewMockCacheInterface[*v1.ConfigMap](ctrl),
 			}
-			h.manager = tt.setup(ctrl)
-			h.namespaces = namespaceCtrl
+
+			// allow test to add expected calls to mocks and run any additional setup
+			tt.setup(mocks)
+			h := mocks.Handler()
+
+			// add any registryOverrides
 			h.registryOverride = tt.registryOverride
 			_, err := h.onRepo("", repo)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("handler.onRepo() error = %v, wantErr %v", err, tt.wantErr)
+				require.FailNow(t, "handler.onRepo() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+		})
+	}
+}
+
+func Test_relatedConfigMaps(t *testing.T) {
+	const fooMap = "foo"
+	orig := settings.ConfigMapName.Get()
+	defer func() { settings.ConfigMapName.Set(orig) }()
+	settings.ConfigMapName.Set(fooMap)
+	tests := []struct {
+		changedObj runtime.Object
+		name       string
+		want       []relatedresource.Key
+	}{
+		{
+			name: "rancher-config change",
+			changedObj: &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name:      chart.CustomValueMapName,
+				Namespace: namespace.System,
+			}},
+			want: []relatedresource.Key{{Name: repoName, Namespace: ""}},
+		},
+		{
+			name: "configMap from settings change",
+			changedObj: &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name:      fooMap,
+				Namespace: namespace.System,
+			}},
+			want: []relatedresource.Key{{Name: repoName, Namespace: ""}},
+		},
+		{
+			name: "rancher-config changed wrong namespace",
+			changedObj: &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name:      chart.CustomValueMapName,
+				Namespace: "",
+			}},
+			want: nil,
+		},
+		{
+			name: "configMap from settings change wrong namespace",
+			changedObj: &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name:      fooMap,
+				Namespace: fooMap,
+			}},
+			want: nil,
+		},
+		{
+			name: "incorrect type",
+			changedObj: &v3.Setting{ObjectMeta: metav1.ObjectMeta{
+				Name:      chart.CustomValueMapName,
+				Namespace: namespace.System,
+			}},
+			want: nil,
+		},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			got, err := relatedConfigMaps("", "", test.changedObj)
+			require.NoError(t, err, "unexpected error")
+			require.Equal(t, test.want, got)
+
+		})
+	}
+}
+
+func Test_relatedFeature(t *testing.T) {
+	tests := []struct {
+		changedObj runtime.Object
+		name       string
+		want       []relatedresource.Key
+	}{
+		{
+			name: "feature changed",
+			changedObj: &v3.Feature{ObjectMeta: metav1.ObjectMeta{
+				Name: features.MCM.Name(),
+			}},
+			want: []relatedresource.Key{{Name: repoName, Namespace: ""}},
+		},
+		{
+			name: "incorrect type",
+			changedObj: &v3.Setting{ObjectMeta: metav1.ObjectMeta{
+				Name:      chart.CustomValueMapName,
+				Namespace: namespace.System,
+			}},
+			want: nil,
+		},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			got, err := relatedFeatures("", "", test.changedObj)
+			require.NoError(t, err, "unexpected error")
+			require.Equal(t, test.want, got)
+
+		})
+	}
+}
+
+func Test_relatedSettings(t *testing.T) {
+	tests := []struct {
+		changedObj runtime.Object
+		name       string
+		want       []relatedresource.Key
+	}{
+		{
+			name: "rancher version",
+			changedObj: &v3.Setting{ObjectMeta: metav1.ObjectMeta{
+				Name: settings.RancherWebhookVersion.Name,
+			}},
+			want: []relatedresource.Key{{Name: repoName, Namespace: ""}},
+		},
+		{
+			name: "rancher min version",
+			changedObj: &v3.Setting{ObjectMeta: metav1.ObjectMeta{
+				Name: settings.RancherWebhookMinVersion.Name,
+			}},
+			want: []relatedresource.Key{{Name: repoName, Namespace: ""}},
+		},
+		{
+			name: "system default registry",
+			changedObj: &v3.Setting{ObjectMeta: metav1.ObjectMeta{
+				Name: settings.SystemDefaultRegistry.Name,
+			}},
+			want: []relatedresource.Key{{Name: repoName, Namespace: ""}},
+		},
+		{
+			name: "shell image",
+			changedObj: &v3.Setting{ObjectMeta: metav1.ObjectMeta{
+				Name: settings.ShellImage.Name,
+			}},
+			want: []relatedresource.Key{{Name: repoName, Namespace: ""}},
+		},
+		{
+			name: "incorrect type",
+			changedObj: &v3.Feature{ObjectMeta: metav1.ObjectMeta{
+				Name:      chart.CustomValueMapName,
+				Namespace: namespace.System,
+			}},
+			want: nil,
+		},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			got, err := relatedSettings("", "", test.changedObj)
+			require.NoError(t, err, "unexpected error")
+			require.Equal(t, test.want, got)
+
 		})
 	}
 }

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -145,6 +145,7 @@ var (
 	AuthUserSessionTTLMinutes = NewSetting("auth-user-session-ttl-minutes", "960") // 16 hours
 
 	// ConfigMapName name of the configmap that stores rancher configuration information.
+	// Deprecated: to be removed in 2.8.0
 	ConfigMapName = NewSetting("config-map-name", "rancher-config")
 
 	// CSPAdapterMinVersion is used to determine if an existing installation of the CSP adapter should be upgraded to a new version


### PR DESCRIPTION
## Issue: #41142 
This commit adds the ability to customize the values used to install a cluster's webhook. Users can now store the custom webhook helm values on the cluster object. These values are synced to a ConfigMap in the cluster and are referenced when installing the helm chart.


## Workflow
Scenario: The user wants their downstream webhook to run on with the `hostNetwork=true`
1. User edits the `cluster.management.cattle.io` object for their downstream cluster.
2. User updates the new field `cluster.Spec.ChartValues` [Code](https://github.com/rancher/rancher/compare/release/v2.7...KevinJoiner:rancher:webhook-config?expand=1#diff-14e664fa98838cd14681732355577f709eab97c04ca75bfe33103cd77cccae90R132-R136)
    - *Note:* This new field is a `map[string]string` with the key being the name of the chart and the values being YAML.
       this allows team2 to use this same field when managing other helm charts deployed by Rancher.
3. User adds a new entry into the map with the key `rancher-webhook` and value `hostNetwork: true`
4. User saves cluster object.
5. Rancher webhook validates that the saved values in the map are valid YAML.
    - Webhook Validator will be added after this PR updates the cluster object.
6. Rancher [new systemcharts controller](https://github.com/rancher/rancher/compare/release/v2.7...KevinJoiner:rancher:webhook-config?expand=1#diff-523b4d580a2f77529df99e74f0b48f4dcdc1f2d07b06d09ae1b52a82fd281bf8R1) (running in the local cluster with a UsersContext) detects a change in the `cluster.Spec.ChartValues` field and creates or updates the `rancher-config` ConfigMap in the downstream cluster.
7. Rancher/cattle-agent's [other systemcharts controller](https://github.com/rancher/rancher/commit/4a9e2c7f43abd6befbab59bf95128a181170e269#diff-f62b5339f02c0e3ab7718f85a40629e13fec49eb49c9293eafb345585dceb122R1) which runs on every cluster detects a change to it's `rancher-config`
8. The controller then [merges](https://github.com/rancher/rancher/commit/4a9e2c7f43abd6befbab59bf95128a181170e269#diff-f62b5339f02c0e3ab7718f85a40629e13fec49eb49c9293eafb345585dceb122R165-R170) the custom webhook values of `hostNetwork: true` to the existing webhook configuration.
 
 ## ConfigMapName Depercation.
 The setting CofigMapName will be deprecated and removed in v2.8 with @cbron's sign-off
This setting is not currently publicly documented and not needed for existing functionality. with the syncing of configuration downstream. It is not desirable for the Rancher ConfigMap name being configurable. 
I originally added the setting in this [PR](https://github.com/rancher/rancher/pull/39071/files#diff-b2f1f4f0c50b7452d729bccde70315eb06368408c5062c97febbe7dd6f87e2ed), but it was not included in our [release notes](https://github.com/rancher/rancher/releases/v2.7.0). 
> Pods critical to running Rancher did not use a priority class. This could cause a cluster with limited resources to evict Rancher pods before other noncritical pods. A configurable priorityClass has been added to the Rancher pod and its feature charts. See https://github.com/rancher/rancher/issues/37927.

# [EDIT] Design Update:
## Local Chart Values come from Helm
The current design would require a user first to get Rancher running and then update the cluster object to customize the helm values for the webhook. This flow is nonoptimal because it relies on everything running in the default state before a user can change Webhook values.

To combat this, we will allow users to specify webhook values via helm values when installing the rancher/rancher chart. To keep a single source of truth, this will be the only supported way to update the chartValues used in the local cluster. We plan to update the Webhook to enforce that the `cluster.spec.chartValues` is not set if the cluster object is the local cluster, and all other downstream clusters will have the store YAML checked for validity.

If a user desires to change chartValues for an instance of Rancher not installed via helm they would need to directly modify the rancher-config ConfigMap though this is not recommended since it is used internally and does not have any compatibility guarantees between Rancher Versions.

