### PR TITLE
Bump kube-api-auth to v0.2.0

### DIFF
--- a/pkg/apis/management.cattle.io/v3/tools_system_images.go
+++ b/pkg/apis/management.cattle.io/v3/tools_system_images.go
@@ -5,7 +5,7 @@ var (
 		AuthSystemImages AuthSystemImages
 	}{
 		AuthSystemImages: AuthSystemImages{
-			KubeAPIAuth: "rancher/kube-api-auth:v0.1.8",
+			KubeAPIAuth: "rancher/kube-api-auth:v0.2.0",
 		},
 	}
 )


### PR DESCRIPTION
Bump of kube-api-auth, Required for token hashing changes.