### PR TITLE
38481 download custom drivers each pod

### DIFF
--- a/pkg/controllers/management/drivers/nodedriver/machine_driver.go
+++ b/pkg/controllers/management/drivers/nodedriver/machine_driver.go
@@ -96,6 +96,9 @@ func (m *Lifecycle) download(obj *v32.NodeDriver) (*v32.NodeDriver, error) {
 	}
 
 	forceUpdate := m.checkDriverVersion(obj)
+	if v32.NodeDriverConditionDownloaded.GetStatus(obj) == "" || v32.NodeDriverConditionInstalled.GetStatus(obj) == "" {
+		forceUpdate = true
+	}
 
 	err := errs.New("not found")
 	// if node driver was created, we also activate the driver by default

--- a/pkg/controllers/management/drivers/nodedriver/machine_driver.go
+++ b/pkg/controllers/management/drivers/nodedriver/machine_driver.go
@@ -84,11 +84,11 @@ type Lifecycle struct {
 	dockerMachineVersion string
 }
 
-func (m *Lifecycle) Create(obj *v3.NodeDriver) (runtime.Object, error) {
+func (m *Lifecycle) Create(obj *v32.NodeDriver) (runtime.Object, error) {
 	return m.download(obj)
 }
 
-func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
+func (m *Lifecycle) download(obj *v32.NodeDriver) (*v32.NodeDriver, error) {
 	driverLock.Lock()
 	defer driverLock.Unlock()
 	if !obj.Spec.Active && !obj.Spec.AddCloudCredential {
@@ -101,7 +101,7 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 	// if node driver was created, we also activate the driver by default
 	driver := drivers.NewDynamicDriver(obj.Spec.Builtin, obj.Spec.DisplayName, obj.Spec.URL, obj.Spec.Checksum)
 	schemaName := obj.Spec.DisplayName + "config"
-	var existingSchema *v3.DynamicSchema
+	var existingSchema *v32.DynamicSchema
 	if obj.Spec.DisplayName != "" {
 		existingSchema, err = m.schemaLister.Get("", schemaName)
 	}
@@ -153,7 +153,7 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 		return obj, err
 	}
 
-	obj = newObj.(*v3.NodeDriver)
+	obj = newObj.(*v32.NodeDriver)
 	newObj, err = v32.NodeDriverConditionInstalled.Once(obj, func() (runtime.Object, error) {
 		if err := driver.Install(); err != nil {
 			return nil, err
@@ -165,10 +165,10 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 		return obj, nil
 	})
 	if err != nil {
-		return newObj.(*v3.NodeDriver), err
+		return newObj.(*v32.NodeDriver), err
 	}
 
-	obj = newObj.(*v3.NodeDriver)
+	obj = newObj.(*v32.NodeDriver)
 	driverName := strings.TrimPrefix(driver.Name(), drivers.DockerMachineDriverPrefix)
 
 	obj = m.addVersionInfo(obj)
@@ -213,7 +213,7 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 
 		resourceFields[name] = field
 	}
-	dynamicSchema := &v3.DynamicSchema{
+	dynamicSchema := &v32.DynamicSchema{
 		Spec: v32.DynamicSchemaSpec{
 			ResourceFields: resourceFields,
 		},
@@ -250,7 +250,7 @@ func (m *Lifecycle) download(obj *v3.NodeDriver) (*v3.NodeDriver, error) {
 	return m.createCredSchema(obj, credFields)
 }
 
-func (m *Lifecycle) createCredSchema(obj *v3.NodeDriver, credFields map[string]v32.Field) (*v3.NodeDriver, error) {
+func (m *Lifecycle) createCredSchema(obj *v32.NodeDriver, credFields map[string]v32.Field) (*v32.NodeDriver, error) {
 	name := credentialConfigSchemaName(obj.Spec.DisplayName)
 	credSchema, err := m.schemaLister.Get("", name)
 
@@ -266,7 +266,7 @@ func (m *Lifecycle) createCredSchema(obj *v3.NodeDriver, credFields map[string]v
 
 	if err != nil {
 		if errors.IsNotFound(err) {
-			credentialSchema := &v3.DynamicSchema{
+			credentialSchema := &v32.DynamicSchema{
 				Spec: v32.DynamicSchemaSpec{
 					ResourceFields: credFields,
 				},
@@ -295,7 +295,7 @@ func (m *Lifecycle) createCredSchema(obj *v3.NodeDriver, credFields map[string]v
 	return obj, nil
 }
 
-func (m *Lifecycle) checkDriverVersion(obj *v3.NodeDriver) bool {
+func (m *Lifecycle) checkDriverVersion(obj *v32.NodeDriver) bool {
 	if v32.NodeDriverConditionDownloaded.IsUnknown(obj) || v32.NodeDriverConditionInstalled.IsUnknown(obj) {
 		return true
 	}
@@ -323,7 +323,7 @@ func (m *Lifecycle) checkDriverVersion(obj *v3.NodeDriver) bool {
 	return false
 }
 
-func (m *Lifecycle) addVersionInfo(obj *v3.NodeDriver) *v3.NodeDriver {
+func (m *Lifecycle) addVersionInfo(obj *v32.NodeDriver) *v32.NodeDriver {
 	if obj.Spec.Builtin {
 		obj.Status.AppliedDockerMachineVersion = m.dockerMachineVersion
 	} else {
@@ -333,7 +333,7 @@ func (m *Lifecycle) addVersionInfo(obj *v3.NodeDriver) *v3.NodeDriver {
 	return obj
 }
 
-func (m *Lifecycle) addUIHintsAnno(driverName string, obj *v3.NodeDriver) (*v3.NodeDriver, error) {
+func (m *Lifecycle) addUIHintsAnno(driverName string, obj *v32.NodeDriver) (*v32.NodeDriver, error) {
 	if aliases, ok := DriverToSchemaFields[driverName]; ok {
 		anno := make(map[string]map[string]string)
 
@@ -357,7 +357,7 @@ func (m *Lifecycle) addUIHintsAnno(driverName string, obj *v3.NodeDriver) (*v3.N
 	return obj, nil
 }
 
-func (m *Lifecycle) Updated(obj *v3.NodeDriver) (runtime.Object, error) {
+func (m *Lifecycle) Updated(obj *v32.NodeDriver) (runtime.Object, error) {
 	var err error
 
 	obj, err = m.download(obj)
@@ -380,7 +380,7 @@ func (m *Lifecycle) Updated(obj *v3.NodeDriver) (runtime.Object, error) {
 	return obj, nil
 }
 
-func (m *Lifecycle) Remove(obj *v3.NodeDriver) (runtime.Object, error) {
+func (m *Lifecycle) Remove(obj *v32.NodeDriver) (runtime.Object, error) {
 	schemas, err := m.schemaClient.List(metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", driverNameLabel, obj.Spec.DisplayName),
 	})
@@ -432,7 +432,7 @@ func (m *Lifecycle) createOrUpdateNodeForEmbeddedTypeWithParents(embeddedType, f
 				Type:     embeddedType,
 			}
 		}
-		dynamicSchema := &v3.DynamicSchema{}
+		dynamicSchema := &v32.DynamicSchema{}
 		dynamicSchema.Name = schemaID
 		dynamicSchema.Spec.ResourceFields = resourceField
 		dynamicSchema.Spec.Embed = true

--- a/pkg/controllers/nodedriver/nodedriver.go
+++ b/pkg/controllers/nodedriver/nodedriver.go
@@ -1,0 +1,61 @@
+package nodedriver
+
+import (
+	"context"
+	"sync/atomic"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/controllers/management/drivers"
+	"github.com/rancher/rancher/pkg/wrangler"
+)
+
+var leader = atomic.Bool{}
+
+func Register(ctx context.Context, wrangler *wrangler.Context) {
+	wrangler.Mgmt.NodeDriver().OnChange(ctx, "custom-node-driver-handler", onChange)
+
+	// when this pod becomes the leader, do not run the onChange code
+	wrangler.OnLeader(func(ctx context.Context) error {
+		leader.Store(true)
+		return nil
+	})
+}
+
+func onChange(_ string, obj *v3.NodeDriver) (*v3.NodeDriver, error) {
+	if obj == nil {
+		return obj, nil
+	}
+
+	// if leader, no need to sync
+	if leader.Load() {
+		return obj, nil
+	}
+
+	if !obj.Spec.Active {
+		return obj, nil
+	}
+
+	// only cache drivers which are not built-in to rancher image
+	if obj.Spec.Builtin {
+		return obj, nil
+	}
+
+	driver := drivers.NewDynamicDriver(obj.Spec.Builtin, obj.Spec.DisplayName, obj.Spec.URL, obj.Spec.Checksum)
+	if driver.Exists() {
+		return obj, nil
+	}
+
+	if err := driver.Stage(true); err != nil {
+		return obj, err
+	}
+
+	if err := driver.Install(); err != nil {
+		return obj, err
+	}
+
+	if err := driver.Executable(); err != nil {
+		return obj, err
+	}
+
+	return obj, nil
+}

--- a/pkg/controllers/nodedriver/nodedriver_test.go
+++ b/pkg/controllers/nodedriver/nodedriver_test.go
@@ -1,0 +1,46 @@
+package nodedriver
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOnChange(t *testing.T) {
+	tests := []struct {
+		name      string
+		driver    *v3.NodeDriver
+		expected  *v3.NodeDriver
+		expectErr bool
+	}{
+		{
+			name:      "nil",
+			driver:    nil,
+			expected:  nil,
+			expectErr: false,
+		},
+		{
+			name:      "not active",
+			driver:    &v3.NodeDriver{},
+			expected:  &v3.NodeDriver{},
+			expectErr: false,
+		},
+		{
+			name:      "builtin",
+			driver:    &v3.NodeDriver{Spec: v3.NodeDriverSpec{Builtin: true}},
+			expected:  &v3.NodeDriver{Spec: v3.NodeDriverSpec{Builtin: true}},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := onChange("", tt.driver)
+			if tt.expectErr {
+				assert.NotNil(t, err)
+			}
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/dashboard/apiservice"
 	"github.com/rancher/rancher/pkg/controllers/dashboardapi"
 	managementauth "github.com/rancher/rancher/pkg/controllers/management/auth"
+	"github.com/rancher/rancher/pkg/controllers/nodedriver"
 	provisioningv2 "github.com/rancher/rancher/pkg/controllers/provisioningv2/cluster"
 	"github.com/rancher/rancher/pkg/crds"
 	dashboardcrds "github.com/rancher/rancher/pkg/crds/dashboard"
@@ -266,6 +267,8 @@ func (r *Rancher) Start(ctx context.Context) error {
 	}
 
 	if features.MCM.Enabled() {
+		// Registers handlers for all rancher replicas running in the local cluster, but not downstream agents
+		nodedriver.Register(ctx, r.Wrangler)
 		if err := r.Wrangler.MultiClusterManager.Start(ctx); err != nil {
 			return err
 		}

--- a/scripts/test
+++ b/scripts/test
@@ -80,10 +80,7 @@ run_rancher()
     while sleep 2; do
         if [ "$PID" != "-1" ] && [ ! -e /proc/$PID ]; then
             echo Rancher died
-            echo Rancher logs were
-            echo -e "-----RANCHER-LOG-DUMP-START-----"
-            cat /tmp/rancher.log | gzip | base64 -w 0
-            echo -e "\n-----RANCHER-LOG-DUMP-END-----"
+            dump_rancher_logs
             echo K3s logs were:
             echo -e "-----K3S-LOG-DUMP-START-----"
             cat build/testdata/k3s.log | gzip | base64 -w 0
@@ -107,6 +104,14 @@ run_rancher()
         fi
         sleep 2
     done
+}
+
+dump_rancher_logs()
+{
+  echo Rancher logs were
+  echo -e "-----RANCHER-LOG-DUMP-START-----"
+  cat /tmp/rancher.log | gzip | base64 -w 0
+  echo -e "\n-----RANCHER-LOG-DUMP-END-----"
 }
 
 # uncomment to get startup logs. Don't leave them on because it slows drone down too
@@ -140,10 +145,16 @@ echo Running build-integration-setup
 
 echo Running integrationsetup
 export CATTLE_TEST_CONFIG=$(pwd)/config.yaml # used by integration tests and test setup
-./tests/v2/integration/bin/integrationsetup
+./tests/v2/integration/bin/integrationsetup || {
+  dump_rancher_logs
+  exit 1
+}
 
 echo Running go integration tests
-go test -v -failfast ./tests/v2/integration/...
+go test -v -failfast ./tests/v2/integration/... || {
+  dump_rancher_logs
+  exit 1
+}
 
 echo Running tox tests
 INT_TESTS_STARTED=true


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #38481 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Node drivers are not downloaded in each rancher replica. Because the replicas are loadbalanced, when querying the `/assets` directory for `docker-machine-driver-*` files, the docker machine drivers cannot be downloaded on non-leader replicas because they are only installed on the leader node.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Download the docker machine drivers on all replicas. This controller runs all the time, but will prevent processing if a node becomes the leader. This does not unregister the handler, but I do not want to introduce such a change into wrangler yet.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Manually tested with 3 replicas, confirmed that the machine provision job had no issues downloading the custom node driver. The driver is present in all replicas at `/usr/share/rancher/ui/assets`.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None, we do not currently have a third party node driver that we would be able to test with in CI, nor do we have a framework setup for being able to verify the filesystem contents of the rancher pods. 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

QA should test both the vendored in 3rd party node drivers (for example, nutanix/proxmox if possible). Cloned versions of those drivers will not work due to reasons found here: https://github.com/rancher/rancher/issues/37074
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

QA should test that built-in node drivers are unaffected.

Existing / newly added automated tests that provide evidence there are no regressions: N/A, not possible to add test