### PR TITLE
Update active directory refetchgroupprincipals to use either DN or GUID

### DIFF
--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -119,13 +119,24 @@ func (p *adProvider) RefetchGroupPrincipals(principalID string, secret string) (
 		return nil, err
 	}
 
-	escapedGUID := common.EscapeUUID(externalID)
-	logrus.Debugf("LDAP Refetch principals GUID : {%s}", externalID)
+	var filter string
+	var userSearchString string
+	var searchScope int
+	if strings.HasSuffix(strings.ToLower(externalID), strings.ToLower(config.UserSearchBase)) {
+		userSearchString = externalID
+		searchScope = ldapv3.ScopeBaseObject
+		filter = fmt.Sprintf("(&(%v=%v))", ObjectClass, config.UserObjectClass)
+	} else {
+		userSearchString = config.UserSearchBase
+		searchScope = ldapv3.ScopeWholeSubtree
+		escapedGUID := common.EscapeUUID(externalID)
+		filter = fmt.Sprintf("(&(%v=%v)(%v=%v))", ObjectClass, config.UserObjectClass, common.AttributeObjectGUID, escapedGUID)
+	}
 
-	filter := fmt.Sprintf("(&(%v=%v)(%v=%v))", ObjectClass, config.UserObjectClass, common.AttributeObjectGUID, escapedGUID)
+	logrus.Tracef("LDAP Refetch principals ID : {%s}", externalID)
 	search := ldapv3.NewSearchRequest(
-		config.UserSearchBase,
-		ldapv3.ScopeWholeSubtree,
+		userSearchString,
+		searchScope,
 		ldapv3.NeverDerefAliases,
 		0,
 		0,

--- a/pkg/auth/providers/migration/activedirectory_migration.go
+++ b/pkg/auth/providers/migration/activedirectory_migration.go
@@ -59,7 +59,7 @@ func MigrateActiveDirectoryDNToGUID(ctx context.Context, management *config.Mana
 		err := wait.PollImmediate(time.Hour*24, 0, func() (bool, error) {
 			logrus.Debugf("Starting active directory principalID migration with exponentialBackoff")
 			steps := 5
-			backOffDuration := time.Minute * 10
+			backOffDuration := time.Second * 30
 			var err error
 			for steps > 0 {
 				err = m.migrate()


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/41985
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
At Rancher startup, both the AD migration and Groups refresh processes are kicked off.  For any nontrivial setup, this will result in the refresh process trying to refresh not-yet-migrated users with their DN-based principal and will cause a slew of error messages in the log.  
Additionally, the refresh process is not very fault tolerant.  Things like attempting to migrate a user that no longer exists in AD will kill the migration (which will result in more problems later).  
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Allow the RefreshGroupPrincipals function to search appropriately for DN-based principals in addition to GUID-based principals.

This also lowers the backoff time for a failed migration from 10 minutes down to 30 seconds and adds retries in case of any brief network hiccups with the AD connection.  

Additionally, if a user has been removed from Active Directory, those users will not be migrated since there is no GUID, but the migration process will now handle that by logging a message and continuing for other users.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
After applying this fix, you should no longer see the errors from the refresher process as the refresh will succeed.
It should also be observed that an attempt to migrate a user that has been deleted from Active Directory will no longer derail the whole migration (it will just log a message and continue to the next user).

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Augmented AD setup with 500+ users, watched both migration and refresh finish successfully.
Removed some AD users, noted that the migration succeeds for all other users and logs a note about the deleted users.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
Automated testing will be part of a separate ticket.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
I recommend that this be tested with a significant number of AD users that have already logged-in to Rancher (so that the migration process will be tested at scale).  I can help with scripts that accomplish both of those.  Let me know if I can help.

One way to create a "duplicate user" scenario is:
1) set up a 2.7.4 instance and have several (100+ most likely) Rancher users created (by logging in as AD users)...I have scripts that can help with this.  Also, my AD setup has 500 users if you want to use that (I can give those details as well).
2) This is timing critical: Upgrade to 2.7.5.  When 2.7.5 fires-up, it will kick off the migration process which will take some time, maybe 3-10 minutes.  Once 2.7.5 is up, perform some logins for several users.  You should (with some luck) wind-up logging in to a user that has not yet been migrated.  In that case, Rancher will create a new Rancher user that will have a GUID-based principalId.  That login will succeed (but will not have any permissions from the old user).  When you logout and try to log back in, it will then fail because there are now 2 users being mapped to the same AD user.

Another way that will give similar results:
1) set up a 2.7.4 instance and have several (100+ most likely) Rancher users created (by logging in as AD users)...I have scripts that can help with this.  Also, my AD setup has 500 users if you want to use that (I can give those details as well).  Once all the users have logged-in (and therefore have Rancher users created), you should delete some of them from AD.
2) Upgrade to 2.7.5.  The migration process will kick off and will run until it hits a user that is no longer in AD.  At that point, the migration will die.  You can then login to one of the users that have not yet migrated and it will create a duplicate user similar to the above case.

Some useful commands that can help you see what has been migrated or not (all ran against the local cluster).
`kubectl get users -o yaml | grep activedirectory`  # If you see principals that look like a DN, they are not migrated.  That would be expected for a user that was deleted from AD (as we have nothing to migrate them to), but any others should get migrated (and I believe they will after this patch).

`kubectl get users --template='{{range .items}}{{if (eq .displayName "<displayName>")}}{{range .principalIds}}{{.}}{{"\n"}}{{end}}{{end}}{{end}}'`   # where you replace displayName (and the angle brackets..but NOT the quotes) with the displayName of a user that you're querying.  That will show you all of the principalIds mapped to that displayName.  Normally, you'll just get 2 (one activedirectory_user and one local), but if you see more (likely 4), you have a duplicate user.


An easier approach to find duplicates might be the following script:
#!/bin/bash

```
# Run kubectl command to get the user list as YAML
user_list=$(kubectl get users -o yaml)

# Extract display names from the user list
display_names=$(echo "$user_list" | awk '/^  displayName:/ {print $2}')

# Check for duplicate display names
duplicate_names=$(echo "$display_names" | sort | uniq -d)

if [ -n "$duplicate_names" ]; then
  echo "Duplicate display names found:"
  echo "$duplicate_names"
else
  echo "No duplicate display names found."
fi
```

# Check for duplicate principalIds
```
#!/bin/bash

# Run kubectl command to get the user list as JSON
user_list=$(kubectl get users -o json)

# Find duplicate users based on principalIds
duplicates=$(echo "$user_list" | jq -r '.items[].principalIds[]' | sort | uniq -d)
while IFS= read -r principal_id; do
    users_to_delete=$(echo "$user_list" | jq -r --arg principal_id "$principal_id" '[.items[] | select(.principalIds[] == $principal_id)] | sort_by(.metadata.creationTimestamp) | .[].metadata.name')


  if [[ -n "$users_to_delete" ]]; then
    echo "Duplicate users found for principalId: $principal_id"
    for user in $users_to_delete; do
      echo "Duplicate user: $user"
    done

    echo "------------------"
  fi
done <<< "$duplicates"
```


One thing that helps me to more rapidly iterate over these is to generate a backup of the local cluster after it's set up with AD and all of the AD users have logged in and have Rancher user.  Once you have that and have upgraded to 2.7.5 and the migration has been attempted, if you want to try something else, you can just go back and restore the cluster state (and of course install 2.7.4 again).

 