### PR TITLE
bump RKE to v1.4.8-rc2 and fix CI 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8
-	github.com/rancher/rke v1.4.8-rc1
+	github.com/rancher/rke v1.4.8-rc2
 	github.com/rancher/steve v0.0.0-20230609202141-bf2e9655f5dd
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
 	github.com/rancher/wrangler v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1286,8 +1286,8 @@ github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a h1:6xqYlVz4uAX
 github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8wJ/coee2n9ed937uPBWQArBaVlxs+5wkkS9KiyDc=
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8 h1:leqh0chjBsXhKWebxxFd5QPcoQLu51EpaHo04ce0o+8=
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
-github.com/rancher/rke v1.4.8-rc1 h1:mxSKWqAVK5DQn8sxg2xB4ZGztSyWr0zLzdfkK07eInE=
-github.com/rancher/rke v1.4.8-rc1/go.mod h1:2tq7a87T8d7o6WMDM6q5f6Nu0cL0Y0W3AT07d7Rb4/M=
+github.com/rancher/rke v1.4.8-rc2 h1:bmzGHwIYWdRGHXx+/XIAYUBpp5Qmo63o22cBQ1oamSM=
+github.com/rancher/rke v1.4.8-rc2/go.mod h1:2tq7a87T8d7o6WMDM6q5f6Nu0cL0Y0W3AT07d7Rb4/M=
 github.com/rancher/steve v0.0.0-20230609202141-bf2e9655f5dd h1:fyZhxsqfIh6/URvb3GcjPx9WdPR+g6Gydb2sN+wzrJw=
 github.com/rancher/steve v0.0.0-20230609202141-bf2e9655f5dd/go.mod h1:lCxhhsajJHMUnj0EU+3mbrucc6mHDYD94abDiWX6I/Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.0.0-20230605094423-ddbb43505e80
 	github.com/rancher/gke-operator v1.1.6-rc1
 	github.com/rancher/norman v0.0.0-20230426211126-d3552b018687
-	github.com/rancher/rke v1.4.8-rc1
+	github.com/rancher/rke v1.4.8-rc2
 	github.com/rancher/wrangler v1.1.1
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/api v0.25.4

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -497,8 +497,8 @@ github.com/rancher/lasso v0.0.0-20230629200414-8a54b32e6792 h1:IaPhDqppVYX2v/nCR
 github.com/rancher/lasso v0.0.0-20230629200414-8a54b32e6792/go.mod h1:dNcwXjcqgdOuKFIVETNAPURRh3e5PAi/nWUjj+MLVZA=
 github.com/rancher/norman v0.0.0-20230426211126-d3552b018687 h1:9Bf4fZBIdkidKTqHFsJXMlnzflxx3h4ZAEH/n6HMuyI=
 github.com/rancher/norman v0.0.0-20230426211126-d3552b018687/go.mod h1:7MyWxfCmPl6N/UFLu4neLH6nwTFgQQF5rxtUGyZvPFE=
-github.com/rancher/rke v1.4.8-rc1 h1:mxSKWqAVK5DQn8sxg2xB4ZGztSyWr0zLzdfkK07eInE=
-github.com/rancher/rke v1.4.8-rc1/go.mod h1:2tq7a87T8d7o6WMDM6q5f6Nu0cL0Y0W3AT07d7Rb4/M=
+github.com/rancher/rke v1.4.8-rc2 h1:bmzGHwIYWdRGHXx+/XIAYUBpp5Qmo63o22cBQ1oamSM=
+github.com/rancher/rke v1.4.8-rc2/go.mod h1:2tq7a87T8d7o6WMDM6q5f6Nu0cL0Y0W3AT07d7Rb4/M=
 github.com/rancher/wrangler v1.1.1-0.20230629203936-0e36fee7aea5 h1:d6NAZl3UInlO5E/q82oLWCRCoMEGh5J9jv2H0f8oGSA=
 github.com/rancher/wrangler v1.1.1-0.20230629203936-0e36fee7aea5/go.mod h1:wcqKmq5FJT34ijBgDMswlx7vOkbkw7LEqaaz6f4XTig=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -150,6 +150,7 @@ var OriginMap = map[string]string{
 	"mirrored-kiwigrid-k8s-sidecar":                           "https://github.com/kiwigrid/k8s-sidecar",
 	"mirrored-kube-rbac-proxy":                                "https://github.com/brancz/kube-rbac-proxy",
 	"mirrored-kube-state-metrics-kube-state-metrics":          "https://github.com/kubernetes/kube-state-metrics",
+	"mirrored-kube-vip-kube-vip-iptables":                     "https://github.com/kube-vip/kube-vip",
 	"mirrored-kubernetes-external-dns":                        "https://github.com/kubernetes-sigs/external-dns",
 	"mirrored-library-busybox":                                "https://github.com/docker-library/busybox",
 	"mirrored-library-nginx":                                  "https://github.com/docker-library/nginx",


### PR DESCRIPTION
This PR does the following two things:
- bump RKE to v1.4.8-rc2
- add the source of the image `mirrored-kube-vip-kube-vip-iptables`, which [fails the CI](https://drone-pr.rancher.io/rancher/rancher/30696/5/2) 