### PR TITLE
Bump CLI to v2.7.6-rc1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -165,7 +165,7 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
 
 ENV CATTLE_UI_VERSION 2.7.5
 ENV CATTLE_DASHBOARD_UI_VERSION v2.7.5
-ENV CATTLE_CLI_VERSION v2.7.0
+ENV CATTLE_CLI_VERSION v2.7.6-rc1
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install
 ENV CATTLE_BASE_UI_BRAND=


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/41144
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
`rancher cluster create --import <cluster>` is broken due to the above issue.
 
## Solution
Bump the Rancher CLI version to a version with the fix for the above issue.
 
## Testing
Tested `rancher cluster create --import <cluster>` manually.

## Engineering Testing
### Manual Testing
Tested `rancher cluster create --import <cluster>` manually.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: We don't currently have a test suite for the Rancher CLI. For this small regression, I think it's okay to just make sure the command works again by running it from the latest release.
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary:

## QA Testing Considerations
`rancher cluster create --import <cluster>` and make sure the empty cluster is created in Rancher.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
None that I can think of given that the command was broken previously.

Existing / newly added automated tests that provide evidence there are no regressions: