### PR TITLE
Add `CATTLE_GLOBAL_LABEL_SELECTOR` env var

### DIFF
--- a/pkg/controllers/options.go
+++ b/pkg/controllers/options.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/rancher/lasso/pkg/cache"
 	"github.com/rancher/lasso/pkg/controller"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type controllerContextType string
@@ -22,6 +24,9 @@ const (
 func GetOptsFromEnv(contextType controllerContextType) *controller.SharedControllerFactoryOptions {
 	return &controller.SharedControllerFactoryOptions{
 		SyncOnlyChangedObjects: syncOnlyChangedObjects(contextType),
+		CacheOptions: &cache.SharedCacheFactoryOptions{
+			DefaultTweakList: defaultTweakListOptions(),
+		},
 	}
 }
 
@@ -40,4 +45,14 @@ func syncOnlyChangedObjects(option controllerContextType) bool {
 		}
 	}
 	return false
+}
+
+func defaultTweakListOptions() cache.TweakListOptionsFunc {
+	globalLabelSelector := os.Getenv("CATTLE_GLOBAL_LABEL_SELECTOR")
+	if globalLabelSelector == "" {
+		return func(*v1.ListOptions) {}
+	}
+	return func(opts *v1.ListOptions) {
+		opts.LabelSelector = globalLabelSelector
+	}
 }


### PR DESCRIPTION
This enables setting a label selector on all list/watch calls through the shared informer cache/controllers.
 
## Problem

In our setup we have a significant (tens-of-thousands) number of namespaces that we don't need showing in Rancher, and Rancher doesn't need to care about. We specifically use Rancher for cluster management, not workloads themselves.
 
## Solution

Dead simple way of adding a global label selector to list watches from an env var. Idea here is we basically do `managed-by != not-rancher` to exclude those other resources.
 