### PR TITLE
Update steve to fix unknown fields warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 	github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a
 	github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8
 	github.com/rancher/rke v1.4.8-rc2
-	github.com/rancher/steve v0.0.0-20230609202141-bf2e9655f5dd
+	github.com/rancher/steve v0.0.0-20230717160251-d040cffef385
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
 	github.com/rancher/wrangler v1.1.1
 	github.com/robfig/cron v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1288,8 +1288,8 @@ github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8 h1:leqh0chj
 github.com/rancher/remotedialer v0.2.6-0.20220624190122-ea57207bf2b8/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.4.8-rc2 h1:bmzGHwIYWdRGHXx+/XIAYUBpp5Qmo63o22cBQ1oamSM=
 github.com/rancher/rke v1.4.8-rc2/go.mod h1:2tq7a87T8d7o6WMDM6q5f6Nu0cL0Y0W3AT07d7Rb4/M=
-github.com/rancher/steve v0.0.0-20230609202141-bf2e9655f5dd h1:fyZhxsqfIh6/URvb3GcjPx9WdPR+g6Gydb2sN+wzrJw=
-github.com/rancher/steve v0.0.0-20230609202141-bf2e9655f5dd/go.mod h1:lCxhhsajJHMUnj0EU+3mbrucc6mHDYD94abDiWX6I/Y=
+github.com/rancher/steve v0.0.0-20230717160251-d040cffef385 h1:xMR4LJY5C4LAkJbmVKYvu4BaCYXx2fu99a0K+gErpA0=
+github.com/rancher/steve v0.0.0-20230717160251-d040cffef385/go.mod h1:lCxhhsajJHMUnj0EU+3mbrucc6mHDYD94abDiWX6I/Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/41772
 
## Problem
The Steve API adds some fields to its output for easier consumption by the UI, but when the UI takes those same objects and tries to update them, Steve was passing through those fields to Kubernetes which did not recognize them.
 
## Solution
Steve now removes the fields it added before trying to update the object in Kubernetes.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
The issue appears on Kubernetes 1.25.

Create a Kubernetes built-in resource like a Pod.
Open developer tools in the browser.
Try to update the pod in the Cluster Explorer UI, to add or remove labels, for example.
The response headers should NOT include anything like `warning: 299 - unknown field ...`.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
Issue occurs only for k8s >= 1.25.
 
### Regressions Considerations
Change is in steve, so anything using the /v1 steve API could be affected.

Existing / newly added automated tests that provide evidence there are no regressions:
* `tests/v2/integration/steveapi` integration test suites