### PR TITLE
[CAPR] Fix rkebootstrap controller pre-terminate annotation management and prevent planner from re-electing init node on standard reconciliation

### DIFF
--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -601,7 +601,7 @@ func (p *Planner) runEtcdRestoreInitNodeElection(controlPlane *rkev1.RKEControlP
 			return "", fmt.Errorf("unable to designate machine as label %s on snapshot %s/%s did not exist", capr.MachineIDLabel, snapshot.Namespace, snapshot.Name)
 		}
 		logrus.Infof("[planner] rkecluster %s/%s: electing init node for S3 snapshot %s/%s restoration", controlPlane.Namespace, controlPlane.Name, snapshot.Namespace, snapshot.Name)
-		return p.electInitNode(controlPlane, clusterPlan)
+		return p.electInitNode(controlPlane, clusterPlan, true)
 	}
 	// make sure that we only have one suitable init node, and elect it.
 	count := len(collect(clusterPlan, canBeInitNode))
@@ -611,7 +611,7 @@ func (p *Planner) runEtcdRestoreInitNodeElection(controlPlane *rkev1.RKEControlP
 		return "", fmt.Errorf("more than one init node existed and no corresponding etcd snapshot CR found, no assumption can be made for the machine that contains the snapshot")
 	}
 	logrus.Infof("[planner] rkecluster %s/%s: electing init node for local snapshot with no associated CR", controlPlane.Namespace, controlPlane.Name)
-	return p.electInitNode(controlPlane, clusterPlan)
+	return p.electInitNode(controlPlane, clusterPlan, true)
 }
 
 // runEtcdRestoreServiceStop generates service stop plans for every non-windows node in the cluster and

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -347,7 +347,7 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 
 func (p *Planner) fullReconcile(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, clusterSecretTokens plan.Secret, plan *plan.Plan, ignoreDrainAndConcurrency bool) (rkev1.RKEControlPlaneStatus, error) {
 	// on the first run through, electInitNode will return a `generic.ErrSkip` as it is attempting to wait for the cache to catch up.
-	joinServer, err := p.electInitNode(cp, plan)
+	joinServer, err := p.electInitNode(cp, plan, false)
 	if err != nil {
 		return status, err
 	}

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -134,4 +134,7 @@ echo "Waiting up to 5 minutes for rancher-webhook deployment"
 echo Running provisioning-tests $RUNARG
 
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-go test $RUNARG -v -failfast -timeout 60m ./tests/v2prov/tests/... || dump_rancher_logs
+go test $RUNARG -v -failfast -timeout 60m ./tests/v2prov/tests/... || {
+     dump_rancher_logs
+     exit 1
+}

--- a/tests/v2prov/cluster/clusters.go
+++ b/tests/v2prov/cluster/clusters.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rancher/rancher/tests/v2prov/registry"
 	"github.com/rancher/rancher/tests/v2prov/wait"
 	"github.com/rancher/wrangler/pkg/condition"
+	"github.com/rancher/wrangler/pkg/name"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -103,12 +104,8 @@ func Machines(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*ca
 	})
 }
 
-func MachineSets(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*unstructured.UnstructuredList, error) {
-	return clients.Dynamic.Resource(schema.GroupVersionResource{
-		Group:    "cluster.x-k8s.io",
-		Version:  "v1beta1",
-		Resource: "machinesets",
-	}).Namespace(cluster.Namespace).List(clients.Ctx, metav1.ListOptions{
+func MachineSets(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*capi.MachineSetList, error) {
+	return clients.CAPI.MachineSet().List(cluster.Namespace, metav1.ListOptions{
 		LabelSelector: "cluster.x-k8s.io/cluster-name=" + cluster.Name,
 	})
 }
@@ -136,18 +133,44 @@ func WaitForCreate(clients *clients.Clients, c *provisioningv1api.Cluster) (_ *p
 
 	err = wait.Object(clients.Ctx, clients.Provisioning.Cluster().Watch, c, func(obj runtime.Object) (bool, error) {
 		c = obj.(*provisioningv1api.Cluster)
-		return c.Status.ClusterName != "", nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("mgmt cluster not assigned: %w", err)
-	}
-
-	err = wait.Object(clients.Ctx, clients.Provisioning.Cluster().Watch, c, func(obj runtime.Object) (bool, error) {
-		c = obj.(*provisioningv1api.Cluster)
-		return c.Status.Ready, nil
+		return c.Status.ClusterName != "" && c.Status.Ready && c.Status.ObservedGeneration == c.Generation && capr.Ready.IsTrue(c) && capr.Provisioned.IsTrue(c), nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("prov cluster is not ready: %w", err)
+	}
+
+	if len(c.Spec.RKEConfig.MachinePools) > 0 {
+		machineSets, err := MachineSets(clients, c)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, machineSet := range machineSets.Items {
+			// retrieve the corresponding machinedeployment and verify that it is "sane"
+			mpName, ok := machineSet.Labels[capr.RKEMachinePoolNameLabel]
+			if !ok {
+				return nil, fmt.Errorf("machineset %s/%s did not have a corresponding machine pool name label", machineSet.Namespace, machineSet.Name)
+			}
+			md, err := clients.CAPI.MachineDeployment().Get(c.Namespace, name.SafeConcatName(c.Name, mpName), metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			err = wait.Object(clients.Ctx, clients.CAPI.MachineDeployment().Watch, md, func(obj runtime.Object) (bool, error) {
+				md = obj.(*capi.MachineDeployment)
+				for _, mp := range c.Spec.RKEConfig.MachinePools {
+					if mpName == mp.Name {
+						if mp.Quantity != nil && (*mp.Quantity != *md.Spec.Replicas || *mp.Quantity != md.Status.ReadyReplicas) {
+							return false, nil
+						}
+						return capr.Ready.IsTrue(md), nil
+					}
+				}
+				return false, nil
+			})
+			if err != nil {
+				return nil, fmt.Errorf("machineset %s/%s was not ready: %w", machineSet.Namespace, machineSet.Name, err)
+			}
+		}
 	}
 
 	machines, err := Machines(clients, c)
@@ -156,6 +179,9 @@ func WaitForCreate(clients *clients.Clients, c *provisioningv1api.Cluster) (_ *p
 	}
 
 	for _, machine := range machines.Items {
+		if !machine.DeletionTimestamp.IsZero() {
+			continue
+		}
 		err = wait.Object(clients.Ctx, clients.CAPI.Machine().Watch, &machine, func(obj runtime.Object) (bool, error) {
 			machine = *obj.(*capi.Machine)
 			return machine.Status.NodeRef != nil, nil

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_combined_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_combined_test.go
@@ -14,11 +14,13 @@ import (
 	"github.com/rancher/rancher/tests/v2prov/cluster"
 	"github.com/rancher/rancher/tests/v2prov/operations"
 	"github.com/rancher/rancher/tests/v2prov/systemdnode"
+	"github.com/rancher/rancher/tests/v2prov/wait"
 	"github.com/rancher/wrangler/pkg/name"
 	"github.com/rancher/wrangler/pkg/randomtoken"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Test_Operation_Custom_EtcdSnapshotOperationsOnNewCombinedNode creates a custom 2 node cluster with a worker and
@@ -67,10 +69,11 @@ func Test_Operation_Custom_EtcdSnapshotOperationsOnNewCombinedNode(t *testing.T)
 		fmt.Sprintf("%s:/var/lib/rancher/%s/server/db/snapshots", tmpDir, capr.GetRuntime(c.Spec.KubernetesVersion)),
 	}
 
-	var etcdNode *corev1.Pod
-	etcdNode, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --controlplane --etcd --node-name control-etcd-test-node", map[string]string{"custom-cluster-name": c.Name}, etcdSnapshotDir)
-	if err != nil {
+	var etcdNodePodName string
+	if etcdNode, err := systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --controlplane --etcd --node-name control-etcd-test-node", map[string]string{"custom-cluster-name": c.Name}, etcdSnapshotDir); err != nil {
 		t.Fatal(err)
+	} else {
+		etcdNodePodName = etcdNode.Name
 	}
 
 	_, err = cluster.WaitForCreate(clients, c)
@@ -90,8 +93,14 @@ func Test_Operation_Custom_EtcdSnapshotOperationsOnNewCombinedNode(t *testing.T)
 	snapshot := operations.RunSnapshotCreateTest(t, clients, c, cm, "control-etcd-test-node")
 	assert.NotNil(t, snapshot)
 
-	err = clients.Core.Pod().Delete(etcdNode.Namespace, etcdNode.Name, &metav1.DeleteOptions{PropagationPolicy: &[]metav1.DeletionPropagation{metav1.DeletePropagationForeground}[0]})
+	err = clients.Core.Pod().Delete(c.Namespace, etcdNodePodName, &metav1.DeleteOptions{PropagationPolicy: &[]metav1.DeletionPropagation{metav1.DeletePropagationForeground}[0]})
 	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := wait.EnsureDoesNotExist(clients.Ctx, func() (runtime.Object, error) {
+		return clients.Core.Pod().Get(c.Namespace, etcdNodePodName, metav1.GetOptions{})
+	}); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/42034
 
## Problem
The `rkebootstrap` controller was given a new responsibility around management of the `pre-terminate` CAPI annotation on the corresponding CAPI machine objects. This pre-terminate annotation is to be used for safe removal/quorum loss prevention of deleting etcd nodes from a cluster (due to an order of operations problem with CAPI's management of nodes in a cluster, where it wants to remove infrastructure before the v1 node object).

Additionally, in certain cases, it was possible that the planner would start delivering new plans to etcd nodes and cause `k3s` or `rke2` to restart while in the middle of a safe node removal. 

Finally, provisioning tests were not properly triggering a failure of CI through an inadvertent change introduced with this commit: https://github.com/rancher/rancher/commit/cf356ef71c19d0dfaadd58cce1b8bac5695bf564#diff-e6de4f5b358d562dc7ad5f0b07ae1c092be587d72561a456fb1dc004323b5aedL147

## Solution
There are two major changes:
1. rkebootstrap is now properly managing the pre-terminate machine annotation
2. the Planner will no longer re-elect an init node when one has already been elected. 
 
## Testing

## Engineering Testing
### Manual Testing
Create a cluster with 3 etcd nodes, then scale the cluster to 1 node. Observe that the cluster is still usable.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified: 
    * Integration (v2prov Framework)

Summary: The test for etcd quorum loss is now effective.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
N/A