### PR TITLE
[WIP] Webhook test fix

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -44,7 +44,7 @@ Sessions are used to track resources created by tests.  A session allows cleanup
 
 ### Configuration
 
-Configuration is loaded from the yaml or json file described in `CATTLE_TEST_CONFIG`.  Configuration objects are loaded from their associated key in the configuration file.  Default values can also be set on configuration objects.
+Configuration is loaded from the yaml or json file described in `CATTLE_TEST_CONFIG`.  Configuration objects are loaded from their associated key in the configuration file.  Default values can also be set on configuration objects. An example configuration file can be found in `example_config.yaml` - replace `$HOST` with the hostname of rancher, `$PORT` with the port that Rancher is running on, and `$TOKEN` with a valid token generated for an admin user.
 
 
 ## How to Write Tests

--- a/tests/example_config.yaml
+++ b/tests/example_config.yaml
@@ -1,0 +1,5 @@
+rancher:
+  host: $HOST:$PORT
+  adminToken: $TOKEN
+  cleanup: true # defaults to true anyways.
+  clusterName: auto-aws-uiisl # to run tests against a downstream cluster 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
Related to #41853.
 
## Problem
There was a flaky test suite due to two factors:
- First, the test suite set the system charts refresh interval to a very low value (10 seconds), which caused charts to be constantly requested for re-installation
- Second, logic in the system charts installer (in rancher) considered requests to install a different version of the same chart to be a separate request from the original installation request. This resulted in the webhook "flapping" between two versions of the same chart - the higher version originally requested, and the lower version that the test requested to be installed. This resulted in the lower version of the webhook being used, and inconsistent uptime for the webhook, which caused occasional test failures in other areas of the code which relied on the webhook.
 
## Solution
- The changes to the system charts refresh interval have been removed from the test - since the webhook re-installs when you change a version setting, this was unnecessary to force the re-installation.
- The system charts installer has been updated to only hold 1 installation request for a given chart name/namespace - so requests for newer versions will now override requests for older versions.
 