### PR TITLE
[CAPR] Handle failing previous plans and ensure init node is not used before allowing deletion

### DIFF
--- a/pkg/apis/rke.cattle.io/v1/plan/plan.go
+++ b/pkg/apis/rke.cattle.io/v1/plan/plan.go
@@ -30,6 +30,7 @@ type Node struct {
 	Healthy        bool                                 `json:"healthy,omitempty"`
 	PlanDataExists bool                                 `json:"planDataExists,omitempty"`
 	ProbeStatus    map[string]ProbeStatus               `json:"probeStatus,omitempty"`
+	ProbesUsable   bool                                 `json:"probesUsable,omitempty"` // ProbesUsable indicates that the probes have passed at least once for the appliedPlan
 }
 
 type PeriodicInstructionOutput struct {

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -74,6 +74,8 @@ const (
 	UnCordonAnnotation            = "rke.cattle.io/uncordon"
 	WorkerRoleLabel               = "rke.cattle.io/worker-role"
 	AuthorizedObjectAnnotation    = "rke.cattle.io/object-authorized-for-clusters"
+	PlanUpdatedTimeAnnotation     = "rke.cattle.io/plan-last-updated"
+	PlanProbesPassedAnnotation    = "rke.cattle.io/plan-probes-passed"
 
 	JoinServerImplausible = "implausible"
 

--- a/pkg/capr/planner/initnode.go
+++ b/pkg/capr/planner/initnode.go
@@ -103,10 +103,12 @@ func (p *Planner) findInitNode(rkeControlPlane *rkev1.RKEControlPlane, plan *pla
 	}
 
 	initNodeFound := false
+	var initNode *planEntry
 	// this loop should never execute more than once
 	for _, entry := range currentInitNodes {
 		if canBeInitNode(entry) {
 			initNodeFound = true
+			initNode = entry
 			joinURL := entry.Metadata.Annotations[capr.JoinURLAnnotation]
 			logrus.Debugf("rkecluster %s/%s found current init node %s with joinURL: %s", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName, entry.Machine.Name, joinURL)
 			if joinURL != "" {
@@ -123,12 +125,12 @@ func (p *Planner) findInitNode(rkeControlPlane *rkev1.RKEControlPlane, plan *pla
 		for _, entry := range possibleInitNodes {
 			if entry.Metadata.Annotations[capr.JoinURLAnnotation] != "" {
 				// if a non-blank JoinURL was found, return that we found an init node but with an error
-				return true, "", nil, fmt.Errorf("non-populated init node found, but more suitable alternative is available")
+				return true, "", initNode, fmt.Errorf("non-populated init node found, but more suitable alternative is available")
 			}
 		}
 		// if we got through all possibleInitNodes (or there weren't any other possible init nodes), return true that we found an init node with no error.
 		logrus.Debugf("rkecluster %s/%s: init node with empty JoinURLAnnotation was found, no suitable alternatives exist", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName)
-		return true, "", nil, nil
+		return true, "", initNode, nil
 	}
 
 	return false, "", nil, fmt.Errorf("init node not found")
@@ -153,7 +155,7 @@ func (p *Planner) electInitNode(rkeControlPlane *rkev1.RKEControlPlane, plan *pl
 	// clear all etcd init node marks because we are re-electing our init node
 	for _, entry := range collect(plan, isInitNode) {
 		if !allowReelection {
-			return "", errWaitingf("rkecluster %s/%s: waiting for existing init machine %s/%s to be deleted", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName, entry.Machine.Namespace, entry.Machine.Name)
+			return "", errWaitingf("rkecluster %s/%s: re-election of init machine %s/%s disallowed", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName, entry.Machine.Namespace, entry.Machine.Name)
 		}
 		logrus.Debugf("rkecluster %s/%s: clearing init node mark on machine %s", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName, entry.Machine.Name)
 		if err := p.clearInitNodeMark(entry); errors.Is(err, generic.ErrSkip) {

--- a/pkg/capr/planner/store.go
+++ b/pkg/capr/planner/store.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
@@ -187,6 +188,10 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 	probes := secret.Data["probe-statuses"]
 	failureCount := secret.Data["failure-count"]
 
+	if probesPassed, ok := secret.Annotations[capr.PlanProbesPassedAnnotation]; ok && probesPassed != "" {
+		result.ProbesUsable = true
+	}
+
 	if len(failureCount) > 0 && PlanHash(planData) == failedChecksum {
 		failureCount, err := strconv.Atoi(string(failureCount))
 		if err != nil {
@@ -211,15 +216,12 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 	}
 
 	if len(probes) > 0 {
-		result.ProbeStatus = map[string]plan.ProbeStatus{}
-		if err := json.Unmarshal(probes, &result.ProbeStatus); err != nil {
+		probeStatuses, healthy, err := ParseProbeStatuses(probes)
+		if err != nil {
 			return nil, err
 		}
-		for _, status := range result.ProbeStatus {
-			if !status.Healthy {
-				result.Healthy = false
-			}
-		}
+		result.ProbeStatus = *probeStatuses
+		result.Healthy = healthy
 	}
 
 	if len(planData) > 0 {
@@ -292,8 +294,25 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 		}
 	}
 
-	result.InSync = result.Healthy && bytes.Equal(planData, appliedPlanData)
+	result.InSync = bytes.Equal(planData, appliedPlanData)
 	return result, nil
+}
+
+func ParseProbeStatuses(probeStatuses []byte) (*map[string]plan.ProbeStatus, bool, error) {
+	healthy := true
+	if len(probeStatuses) == 0 {
+		return nil, false, fmt.Errorf("probe status length was 0")
+	}
+	probeStatusMap := map[string]plan.ProbeStatus{}
+	if err := json.Unmarshal(probeStatuses, &probeStatusMap); err != nil {
+		return nil, false, err
+	}
+	for _, status := range probeStatusMap {
+		if !status.Healthy {
+			healthy = false
+		}
+	}
+	return &probeStatusMap, healthy, nil
 }
 
 func PlanHash(plan []byte) string {
@@ -393,6 +412,9 @@ func (p *PlanStore) UpdatePlan(entry *planEntry, newNodePlan plan.NodePlan, join
 		entry.Metadata.Annotations[capr.JoinedToAnnotation] = ""
 	}
 
+	entry.Metadata.Annotations[capr.PlanUpdatedTimeAnnotation] = time.Now().UTC().Format(time.RFC3339)
+	entry.Metadata.Annotations[capr.PlanProbesPassedAnnotation] = ""
+
 	capr.CopyPlanMetadataToSecret(secret, entry.Metadata)
 
 	// If the plan is being updated, then delete the probe-statuses so their healthy status will be reported as healthy only when they pass.
@@ -485,6 +507,9 @@ func assignAndCheckPlan(store *PlanStore, msg string, entry *planEntry, newPlan 
 	}
 	if !entry.Plan.InSync {
 		return errWaiting(fmt.Sprintf("waiting for %s", msg))
+	}
+	if !entry.Plan.Healthy {
+		return errWaiting(fmt.Sprintf("waiting for %s probes", msg))
 	}
 	return nil
 }

--- a/pkg/controllers/capr/planner/controller.go
+++ b/pkg/controllers/capr/planner/controller.go
@@ -96,7 +96,7 @@ func (h *handler) OnChange(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPla
 		// * generic.ErrSkip - These will cause the object to be re-enqueued after 5 seconds.
 		// * error - All other errors. This should be an actual error during planner processing.
 		if caprplanner.IsErrWaiting(err) {
-			logrus.Infof("[planner] rkecluster %s/%s: waiting: %v", cp.Namespace, cp.Name, err)
+			logrus.Infof("[planner] rkecluster %s/%s: %v", cp.Namespace, cp.Name, err)
 			capr.Ready.SetStatus(&status, "Unknown")
 			capr.Ready.Message(&status, err.Error())
 			capr.Ready.Reason(&status, "Waiting")
@@ -114,7 +114,7 @@ func (h *handler) OnChange(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPla
 			return status, err
 		} else {
 			// An actual error occurred, so set the Ready and Reconciled conditions to this error and return
-			logrus.Errorf("[planner] rkecluster %s/%s: error encountered during plan processing was %v", cp.Namespace, cp.Name, err)
+			logrus.Errorf("[planner] rkecluster %s/%s: error during plan processing: %v", cp.Namespace, cp.Name, err)
 			capr.Ready.SetError(&status, "", err)
 			capr.Reconciled.SetError(&status, "", err)
 			return status, err


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/41126
https://github.com/rancher/rancher/issues/42034
 
## Problem
In certain cases, it is possible to hit a situation where probes for a node start to fail for various reasons (for example, init node is deleted/dies). If this occurs, the planner would get stuck attempting to update the plan for the node as it would artificially inflate the number of "unavailable" nodes based on probes.

## Solution
This PR changes the way that unavailable nodes are determined -- it now only considers a node unavailable if it
1. is not "in sync" (plan has not been applied)
2. is draining

If during processing, the node is found to have a successfully applied plan but the probes are failing, it is added to the unavailable count.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Integration (v2prov Framework)
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: The etcd node scaling v2prov integration test was flaky as if the init node was deleted, it would cause the cluster to crash. 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->


Existing / newly added automated tests that provide evidence there are no regressions:
