### PR TITLE
Expose ClusterRoleTemplateBindings

### DIFF
--- a/pkg/api/steve/disallow/disallow.go
+++ b/pkg/api/steve/disallow/disallow.go
@@ -13,6 +13,7 @@ var (
 	allowAll = map[string]bool{
 		"podsecurityadmissionconfigurationtemplates": true,
 		"projectroletemplatebindings":                true,
+		"clusterroletemplatebindings":                true,
 	}
 	allowPost = map[string]bool{
 		"settings": true,


### PR DESCRIPTION
## Issue: CRTB Migration
Follow up after https://github.com/rancher/webhook/pull/234
 
## Problem
CRTB validation has been migrated to the webhook and now it needs to be exposed by Steve
 
## Solution
Add `clusterroletemplatebindings` to the `allowAll` list
