### PR TITLE
[CAPR] fix nil point exception in v2prov etcd scaling test and improve general reliability of v2prov tests

### DIFF
--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -316,6 +316,7 @@ func (p *Planner) generateEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControl
 		"server",
 		"--cluster-reset",
 		"--etcd-arg=advertise-client-urls=https://127.0.0.1:2379", // this is a workaround for: https://github.com/rancher/rke2/issues/4052 and can likely remain indefinitely (unless IPv6-only becomes a requirement)
+		"--etcd-disable-snapshots=false",                          // this is a workaround for https://github.com/k3s-io/k3s/issues/8031
 	}
 
 	var env []string

--- a/tests/v2prov/defaults/defaults.go
+++ b/tests/v2prov/defaults/defaults.go
@@ -1,6 +1,11 @@
 package defaults
 
-import "os"
+import (
+	"os"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
 
 var (
 	PodTestImage           = "rancher/systemd-node:v0.0.5-rc2"
@@ -14,7 +19,13 @@ var (
 		"garbage":      "value",
 	}
 
-	One   = int32(1)
-	Two   = int32(2)
-	Three = int32(3)
+	One             = int32(1)
+	Two             = int32(2)
+	Three           = int32(3)
+	DownstreamRetry = wait.Backoff{
+		Steps:    10,
+		Duration: 30 * time.Second,
+		Factor:   1.0,
+		Jitter:   0.1,
+	}
 )

--- a/tests/v2prov/operations/certificaterotation.go
+++ b/tests/v2prov/operations/certificaterotation.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
@@ -12,7 +11,6 @@ import (
 	"github.com/rancher/rancher/tests/v2prov/cluster"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 )
@@ -51,20 +49,6 @@ func RunCertificateRotationTest(t *testing.T, clients *clients.Clients, c *v1.Cl
 	}
 
 	clientset, err := GetAndVerifyDownstreamClientset(clients, c)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Try to continuously get the kubernetes default service because the API server will be flapping at this point.
-	err = retry.OnError(retry.DefaultRetry, func(err error) bool {
-		if strings.Contains(err.Error(), "connection refused") || apierrors.IsServiceUnavailable(err) {
-			return true
-		}
-		return false
-	}, func() error {
-		_, err = clientset.CoreV1().Services(corev1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
-		return err
-	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/v2prov/operations/downstream_kc.go
+++ b/tests/v2prov/operations/downstream_kc.go
@@ -2,13 +2,13 @@ package operations
 
 import (
 	"context"
-	"strings"
 
 	"github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/controllers/dashboardapi/settings"
 	"github.com/rancher/rancher/pkg/provisioningv2/kubeconfig"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/rancher/tests/v2prov/clients"
+	"github.com/rancher/rancher/tests/v2prov/defaults"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,11 +43,11 @@ func GetAndVerifyDownstreamClientset(clients *clients.Clients, c *v1.Cluster) (*
 		return nil, err
 	}
 	// Try to continuously get the kubernetes default service
-	err = retry.OnError(retry.DefaultRetry, func(err error) bool {
-		if strings.Contains(err.Error(), "connection refused") || apierrors.IsServiceUnavailable(err) {
-			return true
+	err = retry.OnError(defaults.DownstreamRetry, func(err error) bool {
+		if apierrors.IsForbidden(err) {
+			return false
 		}
-		return false
+		return true
 	}, func() error {
 		_, err = clientset.CoreV1().Services(corev1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		return err

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_inplace_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_inplace_test.go
@@ -1,6 +1,7 @@
 package custom
 
 import (
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"testing"
 	"time"
 
@@ -30,7 +31,13 @@ func Test_Operation_Custom_EtcdSnapshotCreationRestoreInPlace(t *testing.T) {
 			Name: "test-custom-etcd-snapshot-operations-inplace",
 		},
 		Spec: provisioningv1.ClusterSpec{
-			RKEConfig: &provisioningv1.RKEConfig{},
+			RKEConfig: &provisioningv1.RKEConfig{
+				RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+					ETCD: &rkev1.ETCD{
+						DisableSnapshots: true,
+					},
+				},
+			},
 		},
 	})
 	if err != nil {

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_combined_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_combined_test.go
@@ -39,7 +39,13 @@ func Test_Operation_Custom_EtcdSnapshotOperationsOnNewCombinedNode(t *testing.T)
 			Name: "test-custom-etcd-snapshot-operations-on-new-combined-node",
 		},
 		Spec: provisioningv1.ClusterSpec{
-			RKEConfig: &provisioningv1.RKEConfig{},
+			RKEConfig: &provisioningv1.RKEConfig{
+				RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+					ETCD: &rkev1.ETCD{
+						DisableSnapshots: true,
+					},
+				},
+			},
 		},
 	})
 	if err != nil {

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_test.go
@@ -39,7 +39,13 @@ func Test_Operation_Custom_EtcdSnapshotOperationsOnNewNode(t *testing.T) {
 			Name: "test-custom-etcd-snapshot-operations-on-new-node",
 		},
 		Spec: provisioningv1.ClusterSpec{
-			RKEConfig: &provisioningv1.RKEConfig{},
+			RKEConfig: &provisioningv1.RKEConfig{
+				RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+					ETCD: &rkev1.ETCD{
+						DisableSnapshots: true,
+					},
+				},
+			},
 		},
 	})
 	if err != nil {

--- a/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_inplace_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_inplace_test.go
@@ -31,6 +31,11 @@ func Test_Operation_MP_EtcdSnapshotCreationRestoreInPlace(t *testing.T) {
 		},
 		Spec: provisioningv1.ClusterSpec{
 			RKEConfig: &provisioningv1.RKEConfig{
+				RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+					ETCD: &rkev1.ETCD{
+						DisableSnapshots: true,
+					},
+				},
 				MachinePools: []provisioningv1.RKEMachinePool{
 					{
 						ControlPlaneRole: true,

--- a/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_multietcd_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_multietcd_test.go
@@ -50,6 +50,7 @@ func Test_Operation_MP_EtcdSnapshotOperationsWithThreeEtcdNodesOnNewNode(t *test
 			RKEConfig: &provisioningv1.RKEConfig{
 				RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
 					ETCD: &rkev1.ETCD{
+						DisableSnapshots: true,
 						S3: &rkev1.ETCDSnapshotS3{
 							Endpoint:            osInfo.Endpoint,
 							EndpointCA:          osInfo.Cert,

--- a/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_test.go
@@ -48,6 +48,7 @@ func Test_Operation_MP_EtcdSnapshotOperationsOnNewNode(t *testing.T) {
 			RKEConfig: &provisioningv1.RKEConfig{
 				RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
 					ETCD: &rkev1.ETCD{
+						DisableSnapshots: true,
 						S3: &rkev1.ETCDSnapshotS3{
 							Endpoint:            osInfo.Endpoint,
 							EndpointCA:          osInfo.Cert,


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/42179
 
## Problem
The provisioning tests for K3s/RKE2 were flaky and causing issues where drone PR and publish runs would fail unnecessarily.

1. The etcd restoration tests would intermittently fail as the "stock" configuration of K3s/RKE2 ship with a cron strategy for snapshot creation. This meant that snapshots would possibly be created before Rancher was finished setting up the downstream cluster, and this issue was further compounded by the fact that the test would simply choose a random snapshot from the list which had a chance of not containing the correct data. This was further compounded by the fact that the service accounts for `cattle-impersonation-system` would only be set up once and the lifecycle controller would not reconcile the accounts, a separate issue will need to be filed for this.
2. The scaling tests would not wait until a MachineDeployment phase was `Running`
 
## Solution
Through extensive investigation, there were a few identified issues with the testing framework 

1. The etcd restoration tests now do the following
    * Use the latest available snapshot from the snapshot list that correspond to the target node
    * Turn off automatic etcd snapshotting to ensure that there are no rogue snapshots on the node.
2. The scaling tests now check the MachineDeployment phase and ensure that it is "Running" before allowing things to proceed.

This PR also adds a workaround to etcd restoration enabling etcd restoration to occur, issue will be filed for this to track the specific bug.

## Testing

## Engineering Testing
### Manual Testing
I used a bare metal server to run these tests continuously for 12 hours. In that time, the provisioning operations tests for K3s ran 13 times and did not fail. The provisioning tests for K3s ran 12 times and did not fail.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Integration (v2prov Framework)

Summary: the testing framework was made more robust 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Existing / newly added automated tests that provide evidence there are no regressions:
The corresponding drone-pr runs