### PR TITLE
verifying generated fields are removed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -387,7 +387,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/cluster-bootstrap v0.24.0 // indirect
 	k8s.io/code-generator v0.27.1 // indirect
 	k8s.io/component-base v0.25.4 // indirect

--- a/tests/framework/extensions/configmaps/configmaps.go
+++ b/tests/framework/extensions/configmaps/configmaps.go
@@ -3,3 +3,19 @@ package configmaps
 const (
 	ConfigMapSteveType = "configmap"
 )
+
+type GenFieldTest struct {
+	APIVersion string            `yaml:"apiVersion"`
+	Data       map[string]string `yaml:"data"`
+	Kind       string            `yaml:"kind"`
+	Metadata   struct {
+		Fields          string            `yaml:"fields"`
+		Relationships   string            `yaml:"relationships"`
+		State           string            `yaml:"state"`
+		Labels          map[string]string `yaml:"labels"`
+		Name            string            `yaml:"name"`
+		Namespace       string            `yaml:"namespace"`
+		ResourceVersion string            `yaml:"resourceVersion"`
+		UID             string            `yaml:"uid"`
+	} `yaml:"metadata"`
+}

--- a/tests/v2/validation/configmaps/generated_fields_test.go
+++ b/tests/v2/validation/configmaps/generated_fields_test.go
@@ -1,0 +1,105 @@
+package configmaps
+
+import (
+	"fmt"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	steveV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	cm "github.com/rancher/rancher/tests/framework/extensions/configmaps"
+	"github.com/rancher/rancher/tests/framework/extensions/kubeapi/configmaps"
+	"github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
+	"strings"
+	"testing"
+)
+
+const (
+	APIVersion         = "v1"
+	Kind               = "ConfigMap"
+	configMapsEndpoint = "configmaps"
+	configMapNamespace = "default"
+)
+
+type ConfigMapTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	steveClient        *steveV1.Client
+	session            *session.Session
+	cluster            *management.Cluster
+	nameSpacedV1Client *steveV1.NamespacedSteveClient
+	configMapPayload   *cm.GenFieldTest
+}
+
+func (c *ConfigMapTestSuite) TearDownSuite() {
+	c.session.Cleanup()
+}
+
+func (c *ConfigMapTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	c.session = testSession
+	client, err := rancher.NewClient("", c.session)
+	require.NoError(c.T(), err)
+	c.client = client
+	c.steveClient = client.Steve
+}
+
+func (c *ConfigMapTestSuite) TestSteveGeneratedFields() {
+
+	configData := map[string]string{
+		"env": "qa",
+	}
+	labels, annotations := map[string]string{}, map[string]string{}
+	configMapName := namegenerator.AppendRandomString("test-configmap")
+	configmap, err := configmaps.CreateConfigMap(c.client, c.client.RancherConfig.ClusterName, configMapName, "auto-generated", configMapNamespace, configData, labels, annotations)
+	require.NoError(c.T(), err)
+
+	logrus.Infof("created a configmap(%v, configmap).............", configmap.Name)
+
+	c.configMapPayload = &cm.GenFieldTest{}
+	copyConfigMapToPayload(configmap, c.configMapPayload)
+
+	// Update the configmap payload with the fields that we want to test.
+	c.configMapPayload.Metadata.Fields = "test-fields"
+	c.configMapPayload.Metadata.Relationships = "test-relationships"
+	c.configMapPayload.Metadata.State = "test-state"
+	c.configMapPayload.Data["foo"] = "bar"
+
+	headers, _, err := c.nameSpacedV1Client.PerformPutCaptureHeaders(c.client.RancherConfig.Host, c.client.RancherConfig.AdminToken, configMapsEndpoint, configmap.Namespace, configmap.Name, c.configMapPayload)
+	require.NoError(c.T(), err)
+
+	// Check for warnings in the response headers.
+	warnings, ok := headers["Warning"]
+	var failWarnings []string
+	if ok {
+		for _, warning := range warnings {
+			// If the warning message starts with "299", then log it and add it to failWarnings.
+			if strings.HasPrefix(warning, "299") {
+				logrus.Printf("Warning header found: %s", warning)
+				failWarnings = append(failWarnings, warning)
+			}
+		}
+	}
+
+	// If there were any "299" warnings, fail the test.
+	if len(failWarnings) > 0 {
+		require.Fail(c.T(), fmt.Sprintf("Test failed due to warnings: \n%s", strings.Join(failWarnings, "\n")))
+	}
+}
+
+func TestConfigMapTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigMapTestSuite))
+}
+
+func copyConfigMapToPayload(cm *v1.ConfigMap, payload *cm.GenFieldTest) {
+	payload.APIVersion = APIVersion
+	payload.Data = cm.Data
+	payload.Kind = Kind
+	payload.Metadata.Name = cm.ObjectMeta.Name
+	payload.Metadata.Namespace = cm.ObjectMeta.Namespace
+	payload.Metadata.ResourceVersion = cm.ObjectMeta.ResourceVersion
+	payload.Metadata.UID = string(cm.ObjectMeta.UID)
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

- Task: https://github.com/rancher/qa-tasks/issues/845
- Issue being tested: https://github.com/rancher/rancher/issues/41772
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The need to verify that Steve is discarding unrecognized fields prior to the PUT request.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The solution involved utilizing a framework to generate a config map, followed by the creation of a PUT request using the `net/http` package to capture the response headers. A review of the response headers was then performed to search for any possible errors.

Note:
The use of the `net/http` package was authorized in collaboration with Israel. This step was necessary to capture HTTP response headers following a PUT request.
 
## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Manual testing / validations done in the original issue.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)

Summary: Added P0 validation test case for config maps.