### PR TITLE
Add cloudinit userdata files to bootstrap spec

### DIFF
--- a/pkg/apis/rke.cattle.io/v1/bootstrap.go
+++ b/pkg/apis/rke.cattle.io/v1/bootstrap.go
@@ -15,8 +15,28 @@ type RKEBootstrap struct {
 	Status            RKEBootstrapStatus `json:"status,omitempty"`
 }
 
+type Encoding string
+
+const (
+	// Base64 implies the contents of the file are encoded as base64.
+	Base64 Encoding = "base64"
+	// Gzip implies the contents of the file are encoded with gzip.
+	Gzip Encoding = "gzip"
+	// GzipBase64 implies the contents of the file are first base64 encoded and then gzip encoded.
+	GzipBase64 Encoding = "gzip+base64"
+)
+
+type CloudInitFile struct {
+	Encoding    Encoding `json:"encoding,omitempty"`
+	Content     string   `json:"content,omitempty"`
+	Owner       string   `json:"owner,omitempty"`
+	Path        string   `json:"path"`
+	Permissions string   `json:"permissions,omitempty"`
+}
+
 type RKEBootstrapSpec struct {
-	ClusterName string `json:"clusterName,omitempty"`
+	ClusterName string          `json:"clusterName,omitempty"`
+	Files       []CloudInitFile `json:"files,omitempty"`
 }
 
 type RKEBootstrapStatus struct {

--- a/pkg/controllers/provisioningv2/provisioningcluster/template.go
+++ b/pkg/controllers/provisioningv2/provisioningcluster/template.go
@@ -289,6 +289,12 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 				Template: rkev1.RKEBootstrap{
 					Spec: rkev1.RKEBootstrapSpec{
 						ClusterName: cluster.Name,
+						Files: []rkev1.CloudInitFile{
+							{
+								Path:    "/etc/rancher/rke2/config.yaml.d/40-provider-id.yaml",
+								Content: `kubelet-arg+: 'provider-id=digitalocean://{{ ds.meta_data["instance_id"] }}'`,
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #41023
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

There is no way for 3rd party CAPI machine infrastructure providers to specify the provider ID of a cluster when using the embedded rke2 or an external cloud-provider, or in case where there is no corresponding cloud-provider, such as digital ocean. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Note: https://github.com/rancher/machine/pull/212 has to be merged as a prerequisite, and a mechanism has to be added onto the provisioning cluster to be able to set the bootstrap template fields for the generating handler.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Manually spun up a cluster using new method, set the following in the bootstrap template:
```
Files: []rkev1.CloudInitFile{
  {
    Path:    "/etc/rancher/rke2/config.yaml.d/40-provider-id.yaml",
    Content: `kubelet-arg+: 'provider-id=digitalocean://{{ ds.meta_data["instance_id"] }}'`,
  },
},
```

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: Updated existing unit tests to validate expected cloud-config. Added a test case to confirm additional files are rendered as expected. Existing integration tests ensure no regressions for baseline functionality.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Machines should not be reprovisioned on an upgrade, but deleting machines from a machine pool should utilize the new behavior.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Provisioning should work, but this will be caught by CI. 

Existing / newly added automated tests that provide evidence there are no regressions:
TODO: Create tech debt issue to test 3rd party drivers. There should be no regressions against existing funcitonality.