### PR TITLE
[release/v2.7.6] Backport CAPR planner etcd management fixes 

### DIFF
--- a/pkg/apis/rke.cattle.io/v1/plan/plan.go
+++ b/pkg/apis/rke.cattle.io/v1/plan/plan.go
@@ -30,6 +30,7 @@ type Node struct {
 	Healthy        bool                                 `json:"healthy,omitempty"`
 	PlanDataExists bool                                 `json:"planDataExists,omitempty"`
 	ProbeStatus    map[string]ProbeStatus               `json:"probeStatus,omitempty"`
+	ProbesUsable   bool                                 `json:"probesUsable,omitempty"` // ProbesUsable indicates that the probes have passed at least once for the appliedPlan
 }
 
 type PeriodicInstructionOutput struct {

--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -74,6 +74,8 @@ const (
 	UnCordonAnnotation            = "rke.cattle.io/uncordon"
 	WorkerRoleLabel               = "rke.cattle.io/worker-role"
 	AuthorizedObjectAnnotation    = "rke.cattle.io/object-authorized-for-clusters"
+	PlanUpdatedTimeAnnotation     = "rke.cattle.io/plan-last-updated"
+	PlanProbesPassedAnnotation    = "rke.cattle.io/plan-probes-passed"
 
 	JoinServerImplausible = "implausible"
 

--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -601,14 +601,14 @@ func (p *Planner) runEtcdRestoreInitNodeElection(controlPlane *rkev1.RKEControlP
 			return "", fmt.Errorf("unable to designate machine as label %s on snapshot %s/%s did not exist", capr.MachineIDLabel, snapshot.Namespace, snapshot.Name)
 		}
 		logrus.Infof("[planner] rkecluster %s/%s: electing init node for S3 snapshot %s/%s restoration", controlPlane.Namespace, controlPlane.Name, snapshot.Namespace, snapshot.Name)
-		return p.electInitNode(controlPlane, clusterPlan)
+		return p.electInitNode(controlPlane, clusterPlan, true)
 	}
 	// make sure that we only have one suitable init node, and elect it.
 	if len(collect(clusterPlan, canBeInitNode)) != 1 {
 		return "", fmt.Errorf("more than one init node existed and no corresponding etcd snapshot CR found, no assumption can be made for the machine that contains the snapshot")
 	}
 	logrus.Infof("[planner] rkecluster %s/%s: electing init node for local snapshot with no associated CR", controlPlane.Namespace, controlPlane.Name)
-	return p.electInitNode(controlPlane, clusterPlan)
+	return p.electInitNode(controlPlane, clusterPlan, true)
 }
 
 // runEtcdRestoreServiceStop generates service stop plans for every non-windows node in the cluster and

--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -316,6 +316,7 @@ func (p *Planner) generateEtcdSnapshotRestorePlan(controlPlane *rkev1.RKEControl
 		"server",
 		"--cluster-reset",
 		"--etcd-arg=advertise-client-urls=https://127.0.0.1:2379", // this is a workaround for: https://github.com/rancher/rke2/issues/4052 and can likely remain indefinitely (unless IPv6-only becomes a requirement)
+		"--etcd-disable-snapshots=false",                          // this is a workaround for https://github.com/k3s-io/k3s/issues/8031
 	}
 
 	var env []string

--- a/pkg/capr/planner/initnode.go
+++ b/pkg/capr/planner/initnode.go
@@ -103,10 +103,12 @@ func (p *Planner) findInitNode(rkeControlPlane *rkev1.RKEControlPlane, plan *pla
 	}
 
 	initNodeFound := false
+	var initNode *planEntry
 	// this loop should never execute more than once
 	for _, entry := range currentInitNodes {
 		if canBeInitNode(entry) {
 			initNodeFound = true
+			initNode = entry
 			joinURL := entry.Metadata.Annotations[capr.JoinURLAnnotation]
 			logrus.Debugf("rkecluster %s/%s found current init node %s with joinURL: %s", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName, entry.Machine.Name, joinURL)
 			if joinURL != "" {
@@ -123,12 +125,12 @@ func (p *Planner) findInitNode(rkeControlPlane *rkev1.RKEControlPlane, plan *pla
 		for _, entry := range possibleInitNodes {
 			if entry.Metadata.Annotations[capr.JoinURLAnnotation] != "" {
 				// if a non-blank JoinURL was found, return that we found an init node but with an error
-				return true, "", nil, fmt.Errorf("non-populated init node found, but more suitable alternative is available")
+				return true, "", initNode, fmt.Errorf("non-populated init node found, but more suitable alternative is available")
 			}
 		}
 		// if we got through all possibleInitNodes (or there weren't any other possible init nodes), return true that we found an init node with no error.
 		logrus.Debugf("rkecluster %s/%s: init node with empty JoinURLAnnotation was found, no suitable alternatives exist", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName)
-		return true, "", nil, nil
+		return true, "", initNode, nil
 	}
 
 	return false, "", nil, fmt.Errorf("init node not found")
@@ -153,7 +155,7 @@ func (p *Planner) electInitNode(rkeControlPlane *rkev1.RKEControlPlane, plan *pl
 	// clear all etcd init node marks because we are re-electing our init node
 	for _, entry := range collect(plan, isInitNode) {
 		if !allowReelection {
-			return "", errWaitingf("rkecluster %s/%s: waiting for existing init machine %s/%s to be deleted", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName, entry.Machine.Namespace, entry.Machine.Name)
+			return "", errWaitingf("rkecluster %s/%s: re-election of init machine %s/%s disallowed", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName, entry.Machine.Namespace, entry.Machine.Name)
 		}
 		logrus.Debugf("rkecluster %s/%s: clearing init node mark on machine %s", rkeControlPlane.Namespace, rkeControlPlane.Spec.ClusterName, entry.Machine.Name)
 		if err := p.clearInitNodeMark(entry); errors.Is(err, generic.ErrSkip) {

--- a/pkg/capr/planner/planner.go
+++ b/pkg/capr/planner/planner.go
@@ -347,7 +347,7 @@ func (p *Planner) Process(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlan
 
 func (p *Planner) fullReconcile(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus, clusterSecretTokens plan.Secret, plan *plan.Plan, ignoreDrainAndConcurrency bool) (rkev1.RKEControlPlaneStatus, error) {
 	// on the first run through, electInitNode will return a `generic.ErrSkip` as it is attempting to wait for the cache to catch up.
-	joinServer, err := p.electInitNode(cp, plan)
+	joinServer, err := p.electInitNode(cp, plan, false)
 	if err != nil {
 		return status, err
 	}

--- a/pkg/capr/planner/store.go
+++ b/pkg/capr/planner/store.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
@@ -187,6 +188,10 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 	probes := secret.Data["probe-statuses"]
 	failureCount := secret.Data["failure-count"]
 
+	if probesPassed, ok := secret.Annotations[capr.PlanProbesPassedAnnotation]; ok && probesPassed != "" {
+		result.ProbesUsable = true
+	}
+
 	if len(failureCount) > 0 && PlanHash(planData) == failedChecksum {
 		failureCount, err := strconv.Atoi(string(failureCount))
 		if err != nil {
@@ -211,15 +216,12 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 	}
 
 	if len(probes) > 0 {
-		result.ProbeStatus = map[string]plan.ProbeStatus{}
-		if err := json.Unmarshal(probes, &result.ProbeStatus); err != nil {
+		probeStatuses, healthy, err := ParseProbeStatuses(probes)
+		if err != nil {
 			return nil, err
 		}
-		for _, status := range result.ProbeStatus {
-			if !status.Healthy {
-				result.Healthy = false
-			}
-		}
+		result.ProbeStatus = *probeStatuses
+		result.Healthy = healthy
 	}
 
 	if len(planData) > 0 {
@@ -292,8 +294,25 @@ func SecretToNode(secret *corev1.Secret) (*plan.Node, error) {
 		}
 	}
 
-	result.InSync = result.Healthy && bytes.Equal(planData, appliedPlanData)
+	result.InSync = bytes.Equal(planData, appliedPlanData)
 	return result, nil
+}
+
+func ParseProbeStatuses(probeStatuses []byte) (*map[string]plan.ProbeStatus, bool, error) {
+	healthy := true
+	if len(probeStatuses) == 0 {
+		return nil, false, fmt.Errorf("probe status length was 0")
+	}
+	probeStatusMap := map[string]plan.ProbeStatus{}
+	if err := json.Unmarshal(probeStatuses, &probeStatusMap); err != nil {
+		return nil, false, err
+	}
+	for _, status := range probeStatusMap {
+		if !status.Healthy {
+			healthy = false
+		}
+	}
+	return &probeStatusMap, healthy, nil
 }
 
 func PlanHash(plan []byte) string {
@@ -393,6 +412,9 @@ func (p *PlanStore) UpdatePlan(entry *planEntry, newNodePlan plan.NodePlan, join
 		entry.Metadata.Annotations[capr.JoinedToAnnotation] = ""
 	}
 
+	entry.Metadata.Annotations[capr.PlanUpdatedTimeAnnotation] = time.Now().UTC().Format(time.RFC3339)
+	entry.Metadata.Annotations[capr.PlanProbesPassedAnnotation] = ""
+
 	capr.CopyPlanMetadataToSecret(secret, entry.Metadata)
 
 	// If the plan is being updated, then delete the probe-statuses so their healthy status will be reported as healthy only when they pass.
@@ -485,6 +507,9 @@ func assignAndCheckPlan(store *PlanStore, msg string, entry *planEntry, newPlan 
 	}
 	if !entry.Plan.InSync {
 		return errWaiting(fmt.Sprintf("waiting for %s", msg))
+	}
+	if !entry.Plan.Healthy {
+		return errWaiting(fmt.Sprintf("waiting for %s probes", msg))
 	}
 	return nil
 }

--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -151,24 +153,24 @@ func (h *handler) getBootstrapSecret(namespace, name string, envVars []corev1.En
 }
 
 func (h *handler) assignPlanSecret(machine *capi.Machine, bootstrap *rkev1.RKEBootstrap) []runtime.Object {
-	secretName := capr.PlanSecretFromBootstrapName(bootstrap.Name)
+	planSecretName := capr.PlanSecretFromBootstrapName(bootstrap.Name)
 	labels, annotations := getLabelsAndAnnotationsForPlanSecret(bootstrap, machine)
 
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
+			Name:      planSecretName,
 			Namespace: bootstrap.Namespace,
 			Labels: map[string]string{
 				capr.MachineNameLabel: machine.Name,
 				rkeBootstrapName:      bootstrap.Name,
 				capr.RoleLabel:        capr.RolePlan,
-				capr.PlanSecret:       secretName,
+				capr.PlanSecret:       planSecretName,
 			},
 		},
 	}
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        secretName,
+			Name:        planSecretName,
 			Namespace:   bootstrap.Namespace,
 			Labels:      labels,
 			Annotations: annotations,
@@ -177,7 +179,7 @@ func (h *handler) assignPlanSecret(machine *capi.Machine, bootstrap *rkev1.RKEBo
 	}
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
+			Name:      planSecretName,
 			Namespace: bootstrap.Namespace,
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -185,13 +187,13 @@ func (h *handler) assignPlanSecret(machine *capi.Machine, bootstrap *rkev1.RKEBo
 				Verbs:         []string{"watch", "get", "update", "list"},
 				APIGroups:     []string{""},
 				Resources:     []string{"secrets"},
-				ResourceNames: []string{secretName},
+				ResourceNames: []string{planSecretName},
 			},
 		},
 	}
 	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
+			Name:      planSecretName,
 			Namespace: bootstrap.Namespace,
 		},
 		Subjects: []rbacv1.Subject{
@@ -204,7 +206,7 @@ func (h *handler) assignPlanSecret(machine *capi.Machine, bootstrap *rkev1.RKEBo
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
 			Kind:     "Role",
-			Name:     secretName,
+			Name:     planSecretName,
 		},
 	}
 
@@ -323,8 +325,10 @@ func (h *handler) GeneratingHandler(bootstrap *rkev1.RKEBootstrap, status rkev1.
 		return result, status, generic.ErrSkip
 	}
 
+	// The plan secret is used by the planner to deliver plans to the system-agent (and receive feedback)
 	result = append(result, h.assignPlanSecret(machine, bootstrap)...)
 
+	// The bootstrap secret contains the system-agent install script with corresponding information to bootstrap the node
 	bootstrapSecret, objs, err := h.assignBootStrapSecret(machine, bootstrap, capiCluster)
 	if err != nil {
 		return nil, status, err
@@ -469,6 +473,32 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	if machine.Status.NodeRef == nil {
 		logrus.Infof("[rkebootstrap] No associated node found for machine %s/%s in cluster %s, ensuring machine pre-terminate annotation is removed", machine.Namespace, machine.Name, bootstrap.Spec.ClusterName)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
+	}
+
+	// If the RKEControlPlane is not deleting, then make sure this node is not being used as an init node.
+	if cp.DeletionTimestamp.IsZero() {
+		planSecret, err := h.secretCache.Get(bootstrap.Namespace, capr.PlanSecretFromBootstrapName(bootstrap.Name))
+		if err != nil && !apierrors.IsNotFound(err) {
+			return bootstrap, fmt.Errorf("error retrieving plan secret to validate it was not an init node: %v", err)
+		}
+
+		if planSecret != nil {
+			// validate that no other nodes are joined to this node, otherwise removing it will cause a bunch of nodes to start crashing.
+			joinURL := planSecret.Annotations[capr.JoinURLAnnotation]
+			planSecrets, err := h.secretCache.List(bootstrap.Namespace, labels.SelectorFromSet(map[string]string{
+				capi.ClusterLabelName: bootstrap.Spec.ClusterName,
+			}))
+			if err != nil {
+				return bootstrap, fmt.Errorf("error encountered list plansecrets to ensure node was not joined: %v", err)
+			}
+			for _, ps := range planSecrets {
+				if ps.GetAnnotations()[capr.JoinedToAnnotation] == joinURL {
+					logrus.Errorf("[rkebootstrap] %s/%s: cluster %s/%s machine %s/%s was still joined to deleting etcd machine %s/%s", bootstrap.Namespace, bootstrap.Name, capiCluster.Namespace, capiCluster.Name, bootstrap.Namespace, ps.GetLabels()[capr.MachineNameLabel], machine.Namespace, machine.Name)
+					h.rkeBootstrap.EnqueueAfter(bootstrap.Namespace, bootstrap.Name, 5*time.Second)
+					return bootstrap, generic.ErrSkip
+				}
+			}
+		}
 	}
 
 	kcSecret, err := h.secretCache.Get(bootstrap.Namespace, secret.Name(bootstrap.Spec.ClusterName, secret.Kubeconfig))

--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -274,7 +274,7 @@ func (h *handler) OnChange(_ string, bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEB
 
 	// If the bootstrap spec cluster name is blank, we need to update the bootstrap spec to the correct value
 	// This is to handle old rkebootstrap objects for unmanaged clusters that did not have the spec properly set
-	if v, ok := bootstrap.Labels[capi.ClusterLabelName]; ok && v != "" {
+	if v, ok := bootstrap.Labels[capi.ClusterLabelName]; ok && v != "" && bootstrap.Spec.ClusterName != v {
 		logrus.Debugf("[rkebootstrap] %s/%s: setting cluster name", bootstrap.Namespace, bootstrap.Name)
 		bootstrap = bootstrap.DeepCopy()
 		bootstrap.Spec.ClusterName = v
@@ -396,6 +396,9 @@ func (h *handler) OnRemove(_ string, bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEB
 // * The machine is deleting and the "safe remove" logic has fired and removed the etcd member from the etcd cluster
 // * The bootstrap is missing the CAPI cluster label || the CAPI cluster controlPlaneRef is nil || the machine noderef is nil
 // * Any of the following: CAPI kubeconfig secret, CAPI cluster object, RKEControlPlane object are not found
+//
+// Notably, CAPI controllers do not trigger a deletion of the RKEBootstrap object if a pre-terminate annotation exists on the corresponding machine object.
+// This means we rely on the OnChange handler to perform node safe removal, when it sees that the corresponding machine is deleting.
 func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBootstrap) (*rkev1.RKEBootstrap, error) {
 	machine, err := capr.GetMachineByOwner(h.machineCache, bootstrap)
 	if err != nil {
@@ -414,6 +417,7 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
 
+	// Only add the pre-terminate hook annotation if the corresponding machine and bootstrap are NOT deleting
 	if machine.DeletionTimestamp.IsZero() && bootstrap.DeletionTimestamp.IsZero() {
 		// annotate the CAPI machine with the pre-terminate.delete.hook.machine.cluster.x-k8s.io annotation if it is an etcd machine
 		if val, ok := machine.GetAnnotations()[capiMachinePreTerminateAnnotation]; !ok || val != capiMachinePreTerminateAnnotationOwner {
@@ -430,16 +434,15 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 		return bootstrap, nil
 	}
 
-	clusterName := bootstrap.Labels[capi.ClusterLabelName]
-	if clusterName == "" {
+	if bootstrap.Spec.ClusterName == "" {
 		logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster label %s was not found in bootstrap labels, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, capi.ClusterLabelName)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
 
-	capiCluster, err := h.capiClusterCache.Get(bootstrap.Namespace, clusterName)
+	capiCluster, err := h.capiClusterCache.Get(bootstrap.Namespace, bootstrap.Spec.ClusterName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster %s/%s was not found, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, bootstrap.Namespace, clusterName)
+			logrus.Warnf("[rkebootstrap] %s/%s: CAPI cluster %s/%s was not found, ensuring machine pre-terminate annotation is removed", bootstrap.Namespace, bootstrap.Name, bootstrap.Namespace, bootstrap.Spec.ClusterName)
 			return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 		}
 		return bootstrap, err
@@ -464,11 +467,11 @@ func (h *handler) reconcileMachinePreTerminateAnnotation(bootstrap *rkev1.RKEBoo
 	}
 
 	if machine.Status.NodeRef == nil {
-		logrus.Infof("[rkebootstrap] No associated node found for machine %s/%s in cluster %s, ensuring machine pre-terminate annotation is removed", machine.Namespace, machine.Name, clusterName)
+		logrus.Infof("[rkebootstrap] No associated node found for machine %s/%s in cluster %s, ensuring machine pre-terminate annotation is removed", machine.Namespace, machine.Name, bootstrap.Spec.ClusterName)
 		return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)
 	}
 
-	kcSecret, err := h.secretCache.Get(bootstrap.Namespace, secret.Name(clusterName, secret.Kubeconfig))
+	kcSecret, err := h.secretCache.Get(bootstrap.Namespace, secret.Name(bootstrap.Spec.ClusterName, secret.Kubeconfig))
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return h.ensureMachinePreTerminateAnnotationRemoved(bootstrap, machine)

--- a/pkg/controllers/capr/planner/controller.go
+++ b/pkg/controllers/capr/planner/controller.go
@@ -96,7 +96,7 @@ func (h *handler) OnChange(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPla
 		// * generic.ErrSkip - These will cause the object to be re-enqueued after 5 seconds.
 		// * error - All other errors. This should be an actual error during planner processing.
 		if caprplanner.IsErrWaiting(err) {
-			logrus.Infof("[planner] rkecluster %s/%s: waiting: %v", cp.Namespace, cp.Name, err)
+			logrus.Infof("[planner] rkecluster %s/%s: %v", cp.Namespace, cp.Name, err)
 			capr.Ready.SetStatus(&status, "Unknown")
 			capr.Ready.Message(&status, err.Error())
 			capr.Ready.Reason(&status, "Waiting")
@@ -114,7 +114,7 @@ func (h *handler) OnChange(cp *rkev1.RKEControlPlane, status rkev1.RKEControlPla
 			return status, err
 		} else {
 			// An actual error occurred, so set the Ready and Reconciled conditions to this error and return
-			logrus.Errorf("[planner] rkecluster %s/%s: error encountered during plan processing was %v", cp.Namespace, cp.Name, err)
+			logrus.Errorf("[planner] rkecluster %s/%s: error during plan processing: %v", cp.Namespace, cp.Name, err)
 			capr.Ready.SetError(&status, "", err)
 			capr.Reconciled.SetError(&status, "", err)
 			return status, err

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -146,4 +146,7 @@ done
 echo Running provisioning-tests $RUNARG
 
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-go test $RUNARG -v -failfast -timeout 60m ./tests/v2prov/tests/... || dump_rancher_logs
+go test $RUNARG -v -failfast -timeout 60m ./tests/v2prov/tests/... || {
+     dump_rancher_logs
+     exit 1
+}

--- a/tests/v2prov/cluster/clusters.go
+++ b/tests/v2prov/cluster/clusters.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rancher/rancher/tests/v2prov/registry"
 	"github.com/rancher/rancher/tests/v2prov/wait"
 	"github.com/rancher/wrangler/pkg/condition"
+	"github.com/rancher/wrangler/pkg/name"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -103,12 +104,8 @@ func Machines(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*ca
 	})
 }
 
-func MachineSets(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*unstructured.UnstructuredList, error) {
-	return clients.Dynamic.Resource(schema.GroupVersionResource{
-		Group:    "cluster.x-k8s.io",
-		Version:  "v1beta1",
-		Resource: "machinesets",
-	}).Namespace(cluster.Namespace).List(clients.Ctx, metav1.ListOptions{
+func MachineSets(clients *clients.Clients, cluster *provisioningv1api.Cluster) (*capi.MachineSetList, error) {
+	return clients.CAPI.MachineSet().List(cluster.Namespace, metav1.ListOptions{
 		LabelSelector: "cluster.x-k8s.io/cluster-name=" + cluster.Name,
 	})
 }
@@ -136,18 +133,44 @@ func WaitForCreate(clients *clients.Clients, c *provisioningv1api.Cluster) (_ *p
 
 	err = wait.Object(clients.Ctx, clients.Provisioning.Cluster().Watch, c, func(obj runtime.Object) (bool, error) {
 		c = obj.(*provisioningv1api.Cluster)
-		return c.Status.ClusterName != "", nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("mgmt cluster not assigned: %w", err)
-	}
-
-	err = wait.Object(clients.Ctx, clients.Provisioning.Cluster().Watch, c, func(obj runtime.Object) (bool, error) {
-		c = obj.(*provisioningv1api.Cluster)
-		return c.Status.Ready, nil
+		return c.Status.ClusterName != "" && c.Status.Ready && c.Status.ObservedGeneration == c.Generation && capr.Ready.IsTrue(c) && capr.Provisioned.IsTrue(c), nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("prov cluster is not ready: %w", err)
+	}
+
+	if len(c.Spec.RKEConfig.MachinePools) > 0 {
+		machineSets, err := MachineSets(clients, c)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, machineSet := range machineSets.Items {
+			// retrieve the corresponding machinedeployment and verify that it is "sane"
+			mpName, ok := machineSet.Labels[capr.RKEMachinePoolNameLabel]
+			if !ok {
+				return nil, fmt.Errorf("machineset %s/%s did not have a corresponding machine pool name label", machineSet.Namespace, machineSet.Name)
+			}
+			md, err := clients.CAPI.MachineDeployment().Get(c.Namespace, name.SafeConcatName(c.Name, mpName), metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			err = wait.Object(clients.Ctx, clients.CAPI.MachineDeployment().Watch, md, func(obj runtime.Object) (bool, error) {
+				md = obj.(*capi.MachineDeployment)
+				for _, mp := range c.Spec.RKEConfig.MachinePools {
+					if mpName == mp.Name {
+						if mp.Quantity != nil && (*mp.Quantity != *md.Spec.Replicas || *mp.Quantity != md.Status.ReadyReplicas) {
+							return false, nil
+						}
+						return capr.Ready.IsTrue(md), nil
+					}
+				}
+				return false, nil
+			})
+			if err != nil {
+				return nil, fmt.Errorf("machineset %s/%s was not ready: %w", machineSet.Namespace, machineSet.Name, err)
+			}
+		}
 	}
 
 	machines, err := Machines(clients, c)
@@ -156,6 +179,9 @@ func WaitForCreate(clients *clients.Clients, c *provisioningv1api.Cluster) (_ *p
 	}
 
 	for _, machine := range machines.Items {
+		if !machine.DeletionTimestamp.IsZero() {
+			continue
+		}
 		err = wait.Object(clients.Ctx, clients.CAPI.Machine().Watch, &machine, func(obj runtime.Object) (bool, error) {
 			machine = *obj.(*capi.Machine)
 			return machine.Status.NodeRef != nil, nil

--- a/tests/v2prov/defaults/defaults.go
+++ b/tests/v2prov/defaults/defaults.go
@@ -1,6 +1,11 @@
 package defaults
 
-import "os"
+import (
+	"os"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
 
 var (
 	PodTestImage           = "rancher/systemd-node:v0.0.4"
@@ -14,7 +19,13 @@ var (
 		"garbage":      "value",
 	}
 
-	One   = int32(1)
-	Two   = int32(2)
-	Three = int32(3)
+	One             = int32(1)
+	Two             = int32(2)
+	Three           = int32(3)
+	DownstreamRetry = wait.Backoff{
+		Steps:    10,
+		Duration: 30 * time.Second,
+		Factor:   1.0,
+		Jitter:   0.1,
+	}
 )

--- a/tests/v2prov/operations/certificaterotation.go
+++ b/tests/v2prov/operations/certificaterotation.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
@@ -12,7 +11,6 @@ import (
 	"github.com/rancher/rancher/tests/v2prov/cluster"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 )
@@ -51,20 +49,6 @@ func RunCertificateRotationTest(t *testing.T, clients *clients.Clients, c *v1.Cl
 	}
 
 	clientset, err := GetAndVerifyDownstreamClientset(clients, c)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Try to continuously get the kubernetes default service because the API server will be flapping at this point.
-	err = retry.OnError(retry.DefaultRetry, func(err error) bool {
-		if strings.Contains(err.Error(), "connection refused") || apierrors.IsServiceUnavailable(err) {
-			return true
-		}
-		return false
-	}, func() error {
-		_, err = clientset.CoreV1().Services(corev1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
-		return err
-	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/v2prov/operations/downstream_kc.go
+++ b/tests/v2prov/operations/downstream_kc.go
@@ -2,13 +2,13 @@ package operations
 
 import (
 	"context"
-	"strings"
 
 	"github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/controllers/dashboardapi/settings"
 	"github.com/rancher/rancher/pkg/provisioningv2/kubeconfig"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/rancher/tests/v2prov/clients"
+	"github.com/rancher/rancher/tests/v2prov/defaults"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,11 +43,11 @@ func GetAndVerifyDownstreamClientset(clients *clients.Clients, c *v1.Cluster) (*
 		return nil, err
 	}
 	// Try to continuously get the kubernetes default service
-	err = retry.OnError(retry.DefaultRetry, func(err error) bool {
-		if strings.Contains(err.Error(), "connection refused") || apierrors.IsServiceUnavailable(err) {
-			return true
+	err = retry.OnError(defaults.DownstreamRetry, func(err error) bool {
+		if apierrors.IsForbidden(err) {
+			return false
 		}
-		return false
+		return true
 	}, func() error {
 		_, err = clientset.CoreV1().Services(corev1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		return err

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_inplace_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_inplace_test.go
@@ -1,6 +1,7 @@
 package custom
 
 import (
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"testing"
 	"time"
 
@@ -30,7 +31,13 @@ func Test_Operation_Custom_EtcdSnapshotCreationRestoreInPlace(t *testing.T) {
 			Name: "test-custom-etcd-snapshot-operations-inplace",
 		},
 		Spec: provisioningv1.ClusterSpec{
-			RKEConfig: &provisioningv1.RKEConfig{},
+			RKEConfig: &provisioningv1.RKEConfig{
+				RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+					ETCD: &rkev1.ETCD{
+						DisableSnapshots: true,
+					},
+				},
+			},
 		},
 	})
 	if err != nil {

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_combined_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_combined_test.go
@@ -14,11 +14,13 @@ import (
 	"github.com/rancher/rancher/tests/v2prov/cluster"
 	"github.com/rancher/rancher/tests/v2prov/operations"
 	"github.com/rancher/rancher/tests/v2prov/systemdnode"
+	"github.com/rancher/rancher/tests/v2prov/wait"
 	"github.com/rancher/wrangler/pkg/name"
 	"github.com/rancher/wrangler/pkg/randomtoken"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Test_Operation_Custom_EtcdSnapshotOperationsOnNewCombinedNode creates a custom 2 node cluster with a worker and
@@ -67,10 +69,11 @@ func Test_Operation_Custom_EtcdSnapshotOperationsOnNewCombinedNode(t *testing.T)
 		fmt.Sprintf("%s:/var/lib/rancher/%s/server/db/snapshots", tmpDir, capr.GetRuntime(c.Spec.KubernetesVersion)),
 	}
 
-	var etcdNode *corev1.Pod
-	etcdNode, err = systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --controlplane --etcd --node-name control-etcd-test-node", map[string]string{"custom-cluster-name": c.Name}, etcdSnapshotDir)
-	if err != nil {
+	var etcdNodePodName string
+	if etcdNode, err := systemdnode.New(clients, c.Namespace, "#!/usr/bin/env sh\n"+command+" --controlplane --etcd --node-name control-etcd-test-node", map[string]string{"custom-cluster-name": c.Name}, etcdSnapshotDir); err != nil {
 		t.Fatal(err)
+	} else {
+		etcdNodePodName = etcdNode.Name
 	}
 
 	_, err = cluster.WaitForCreate(clients, c)
@@ -90,8 +93,14 @@ func Test_Operation_Custom_EtcdSnapshotOperationsOnNewCombinedNode(t *testing.T)
 	snapshot := operations.RunSnapshotCreateTest(t, clients, c, cm, "control-etcd-test-node")
 	assert.NotNil(t, snapshot)
 
-	err = clients.Core.Pod().Delete(etcdNode.Namespace, etcdNode.Name, &metav1.DeleteOptions{PropagationPolicy: &[]metav1.DeletionPropagation{metav1.DeletePropagationForeground}[0]})
+	err = clients.Core.Pod().Delete(c.Namespace, etcdNodePodName, &metav1.DeleteOptions{PropagationPolicy: &[]metav1.DeletionPropagation{metav1.DeletePropagationForeground}[0]})
 	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := wait.EnsureDoesNotExist(clients.Ctx, func() (runtime.Object, error) {
+		return clients.Core.Pod().Get(c.Namespace, etcdNodePodName, metav1.GetOptions{})
+	}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_combined_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_combined_test.go
@@ -39,7 +39,13 @@ func Test_Operation_Custom_EtcdSnapshotOperationsOnNewCombinedNode(t *testing.T)
 			Name: "test-custom-etcd-snapshot-operations-on-new-combined-node",
 		},
 		Spec: provisioningv1.ClusterSpec{
-			RKEConfig: &provisioningv1.RKEConfig{},
+			RKEConfig: &provisioningv1.RKEConfig{
+				RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+					ETCD: &rkev1.ETCD{
+						DisableSnapshots: true,
+					},
+				},
+			},
 		},
 	})
 	if err != nil {

--- a/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_test.go
+++ b/tests/v2prov/tests/custom/operation_etcdsnapshot_newnode_test.go
@@ -39,7 +39,13 @@ func Test_Operation_Custom_EtcdSnapshotOperationsOnNewNode(t *testing.T) {
 			Name: "test-custom-etcd-snapshot-operations-on-new-node",
 		},
 		Spec: provisioningv1.ClusterSpec{
-			RKEConfig: &provisioningv1.RKEConfig{},
+			RKEConfig: &provisioningv1.RKEConfig{
+				RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+					ETCD: &rkev1.ETCD{
+						DisableSnapshots: true,
+					},
+				},
+			},
 		},
 	})
 	if err != nil {

--- a/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_inplace_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_inplace_test.go
@@ -31,6 +31,11 @@ func Test_Operation_MP_EtcdSnapshotCreationRestoreInPlace(t *testing.T) {
 		},
 		Spec: provisioningv1.ClusterSpec{
 			RKEConfig: &provisioningv1.RKEConfig{
+				RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+					ETCD: &rkev1.ETCD{
+						DisableSnapshots: true,
+					},
+				},
 				MachinePools: []provisioningv1.RKEMachinePool{
 					{
 						ControlPlaneRole: true,

--- a/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_multietcd_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_multietcd_test.go
@@ -50,6 +50,7 @@ func Test_Operation_MP_EtcdSnapshotOperationsWithThreeEtcdNodesOnNewNode(t *test
 			RKEConfig: &provisioningv1.RKEConfig{
 				RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
 					ETCD: &rkev1.ETCD{
+						DisableSnapshots: true,
 						S3: &rkev1.ETCDSnapshotS3{
 							Endpoint:            osInfo.Endpoint,
 							EndpointCA:          osInfo.Cert,

--- a/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_test.go
+++ b/tests/v2prov/tests/machineprovisioning/operation_etcdsnapshot_newnode_test.go
@@ -48,6 +48,7 @@ func Test_Operation_MP_EtcdSnapshotOperationsOnNewNode(t *testing.T) {
 			RKEConfig: &provisioningv1.RKEConfig{
 				RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
 					ETCD: &rkev1.ETCD{
+						DisableSnapshots: true,
 						S3: &rkev1.ETCDSnapshotS3{
 							Endpoint:            osInfo.Endpoint,
 							EndpointCA:          osInfo.Cert,


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/42121
 
## Backport Of:
https://github.com/rancher/rancher/pull/42124
https://github.com/rancher/rancher/pull/42164
https://github.com/rancher/rancher/pull/42180

## Problem
There were problems with CAPR and the way it handled deleting etcd (init) nodes. Through extensive testing, multiple fixes were merged and this PR encapsulates the backport for this.
 
## Solution
* The rkebootstrap controller now properly manages the CAPI pre-terminate annotation on machine objects to prevent premature infrastructure deletion
* The rkebootstrap controller now checks the cluster to ensure no other nodes within the cluster refer to the existing machine as an init node before allowing deletion of the infrastructure to prevent unexpected cluster node downtime
* Add v2prov test framework bug fixes to help ensure testing reliability.
 
## Testing

## Engineering Testing
### Manual Testing
I've tested these changes as part of `release/v2.7` manually. As `v2.7.6` is a branch of `release/v2.7` these changes should continue to work.

### Automated Testing
    * Integration (v2prov Framework)

Summary: The v2prov testing framework contains comprehensive etcd-related tests.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
N/A

Existing / newly added automated tests that provide evidence there are no regressions:
* All of the existing v2prov integration tests.