### PR TITLE
[release/v2.7] Add image origin for rancher/mirrored-cluster-api-controller

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -107,6 +107,7 @@ var OriginMap = map[string]string{
 	"mirrored-cloud-provider-vsphere-cpi-release-manager":     "https://github.com/kubernetes/cloud-provider-vsphere/blob/master/cluster/images/controller-manager/Dockerfile",
 	"mirrored-cloud-provider-vsphere-csi-release-driver":      "https://github.com/kubernetes-sigs/vsphere-csi-driver",
 	"mirrored-cloud-provider-vsphere-csi-release-syncer":      "https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/pkg/syncer",
+	"mirrored-cluster-api-controller":                         "https://github.com/kubernetes-sigs/cluster-api",
 	"mirrored-cluster-proportional-autoscaler":                "https://github.com/kubernetes-sigs/cluster-proportional-autoscaler",
 	"mirrored-coredns-coredns":                                "https://github.com/coredns/coredns",
 	"mirrored-coreos-etcd":                                    "https://github.com/etcd-io/etcd",


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/41094
 
## Problem
Before I can merge the new `rancher/mirrored-cluster-api-controller` chart into `rancher/charts`, the origin for this image must be added to Rancher.

## Solution
Add the image origin to Rancher.
 
## Testing
N/A 