### PR TITLE
Prevent custom node deletion during restore

### DIFF
--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -225,7 +225,7 @@ func (m *Manager) doStart(rec *record, clusterOwner bool) (exit error) {
 			return err
 		}
 	} else {
-		if err := clusterController.RegisterFollower(transaction, rec.cluster, m, m); err != nil {
+		if err := clusterController.RegisterFollower(rec.cluster); err != nil {
 			transaction.Rollback()
 			return err
 		}

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -3,6 +3,7 @@ package managementuser
 import (
 	"context"
 
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/managementlegacy/compose/common"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/certsexpiration"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/clusterauthtoken"
@@ -20,13 +21,12 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/managementuser/windows"
 	"github.com/rancher/rancher/pkg/controllers/managementuserlegacy"
 	"github.com/rancher/rancher/pkg/features"
-	managementv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/impersonation"
 	"github.com/rancher/rancher/pkg/types/config"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.UserContext, clusterRec *managementv3.Cluster, kubeConfigGetter common.KubeConfigGetter) error {
+func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.UserContext, clusterRec *apimgmtv3.Cluster, kubeConfigGetter common.KubeConfigGetter) error {
 	rbac.Register(ctx, cluster)
 	healthsyncer.Register(ctx, cluster)
 	networkpolicy.Register(ctx, cluster)
@@ -64,7 +64,7 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 	return managementuserlegacy.Register(ctx, mgmt, cluster, clusterRec, kubeConfigGetter)
 }
 
-func RegisterFollower(ctx context.Context, cluster *config.UserContext, kubeConfigGetter common.KubeConfigGetter, clusterManager healthsyncer.ClusterControllerLifecycle) error {
+func RegisterFollower(cluster *config.UserContext) error {
 	cluster.KindNamespaces[schema.GroupVersionKind{
 		Version: "v1",
 		Kind:    "Secret",


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/pull/42203

## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/42210
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> 
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

After a second etcd restore, custom machines are removed from the cluster. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Prevent nodesyncer controller from running during a restore. Remove legacy code that removes unmanaged machines when a corresponding v1 node is not present in the downstream cluster.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Tested manually. 

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: Existing tests should be able to be chained together to verify this behavior; i.e. we would be able to perform snapshot and restore tests back to back on a custom cluster to ensure this isn't reproducible. This should not require any new tests cases to be written, only higher level orchestration code to compose and run such a test.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
Since this affects custom clusters, the following cases should be tested:
- Taking a snapshot, restoring, taking another snapshot, then restoring the new snapshot (base case)
- The base case, but rotating all nodes after taking the second snapshot
- Cleaning up custom clusters does not leave any resources

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
There is a very low probability for regressions.