### PR TITLE
[CAPR] Utilize target hash in idempotent tracking path

### DIFF
--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -643,6 +643,8 @@ func (p *Planner) runEtcdRestoreServiceStop(controlPlane *rkev1.RKEControlPlane,
 		if err != nil {
 			return err
 		}
+		// Clean up previous restoration tracking attempts before starting this restoration.
+		stopPlan.Instructions = append(stopPlan.Instructions, generateIdempotencyCleanupInstruction("etcd-restore"))
 		if isEtcd(server) {
 			stopPlan.Instructions = append(stopPlan.Instructions, generateCreateEtcdTombstoneInstruction(controlPlane))
 		}

--- a/pkg/capr/planner/idempotent.go
+++ b/pkg/capr/planner/idempotent.go
@@ -18,20 +18,17 @@ hashedCmd=$3
 cmd=$4
 shift 4
 
-dataRoot="/var/lib/rancher/capr/idempotence/$key/$hashedCmd"
-hashFile="$dataRoot/hash"
-attemptFile="$dataRoot/attempt"
+dataRoot="/var/lib/rancher/capr/idempotence/$key/$hashedCmd/$targetHash"
+attemptFile="$dataRoot/last-attempt"
 
-currentHash=$(cat "$hashFile" || echo "")
 currentAttempt=$(cat "$attemptFile" || echo "-1")
 
-if [ "$currentHash" != "$targetHash" ] && [ "$currentAttempt" != "$CATTLE_AGENT_ATTEMPT_NUMBER" ]; then
+if [ "$currentAttempt" != "$CATTLE_AGENT_ATTEMPT_NUMBER" ]; then
 	mkdir -p "$dataRoot"
-	echo "$targetHash" > "$hashFile"
 	echo "$CATTLE_AGENT_ATTEMPT_NUMBER" > "$attemptFile"
 	exec "$cmd" "$@"
 else
-	echo "action has already been reconciled to the current hash $currentHash at attempt $currentAttempt"
+	echo "action has already been reconciled to the target hash $targetHash at attempt $currentAttempt"
 fi
 `
 

--- a/pkg/capr/planner/idempotent.go
+++ b/pkg/capr/planner/idempotent.go
@@ -43,6 +43,21 @@ var idempotentScriptFile = plan.File{
 	Minor:   true,
 }
 
+// generateIdempotencyCleanupInstruction generates a one-time instruction that performs a cleanup of the given key.
+func generateIdempotencyCleanupInstruction(key string) plan.OneTimeInstruction {
+	if key == "" {
+		return plan.OneTimeInstruction{}
+	}
+	return plan.OneTimeInstruction{
+		Name:    "remove idempotency tracking",
+		Command: "/bin/sh",
+		Args: []string{
+			"-c",
+			fmt.Sprintf("rm -rf /var/lib/rancher/capr/idempotence/%s", key),
+		},
+	}
+}
+
 // idempotentInstruction generates an idempotent action instruction that will execute the given command + args exactly once.
 // It works by running a script that writes the given "value" to a file at /var/lib/rancher/idempotence/<identifier>/<hashedCommand>,
 // and checks this file to determine if it needs to run the instruction again. Notably, `identifier` must be a valid relative path.


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/rancher/issues/42201
 
## Problem
The idempotent script to wrap important cluster operations was not properly accounting for changed target hashes, and subsequently not executing instructions more than once ever. This means that an etcd restore is only possible once, and is not possible on subsequent restores.

Additionally, there is a problem with etcd restorations of the same snapshot. Given two snapshots, for example, snapshot A and snapshot B, a snapshot restoration attempt of snapshot A then B then back to A without incrementing the generation would lead to snapshot A not being restored.

## Solution
Use the target hash in the idempotent tracking path to ensure that attempt numbers don't cross, and clean up idempotent tracking for `etcd-restore` when a new etcd restoration attempt is made.
 
## Testing

## Engineering Testing
### Manual Testing
I ran this with a dropped commit from this same issue surrounding unmanaged machine deletion, and did not see nodes get deleted.

### Automated Testing
* Test types added/modified:
    * None

## QA Testing Considerations
If there are 2 snapshots, snapshot A and snapshot B, the following scenarios should be tested:

1. Restore snapshot A, then snapshot B, then snapshot A
2. Restore snapshot A twice

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Existing / newly added automated tests that provide evidence there are no regressions: