### PR TITLE
Adding admin client so the waitRollout does not fail for non admin users

### DIFF
--- a/tests/framework/extensions/users/users.go
+++ b/tests/framework/extensions/users/users.go
@@ -131,12 +131,17 @@ func AddProjectMember(rancherClient *rancher.Client, project *management.Project
 	if err != nil {
 		return err
 	}
-	return waitForPRTBRollout(rancherClient, prtb, createOp)
+	return waitForPRTBRollout(adminClient, prtb, createOp)
 }
 
 // RemoveProjectMember is a helper function that removes the project role from `user`
 func RemoveProjectMember(rancherClient *rancher.Client, user *management.User) error {
 	roles, err := rancherClient.Management.ProjectRoleTemplateBinding.List(&types.ListOpts{})
+	if err != nil {
+		return err
+	}
+
+	adminClient, err := rancher.NewClient(rancherClient.RancherConfig.AdminToken, rancherClient.Session)
 	if err != nil {
 		return err
 	}
@@ -154,7 +159,7 @@ func RemoveProjectMember(rancherClient *rancher.Client, user *management.User) e
 	if err != nil {
 		return err
 	}
-	return waitForPRTBRollout(rancherClient, &roleToDelete, deleteOp)
+	return waitForPRTBRollout(adminClient, &roleToDelete, deleteOp)
 }
 
 // AddClusterRoleToUser is a helper function that adds a cluster role to `user`.
@@ -224,12 +229,17 @@ func AddClusterRoleToUser(rancherClient *rancher.Client, cluster *management.Clu
 	if err != nil {
 		return err
 	}
-	return waitForCRTBRollout(rancherClient, crtb, createOp)
+	return waitForCRTBRollout(adminClient, crtb, createOp)
 }
 
 // RemoveClusterRoleFromUser is a helper function that removes the user from cluster
 func RemoveClusterRoleFromUser(rancherClient *rancher.Client, user *management.User) error {
 	roles, err := rancherClient.Management.ClusterRoleTemplateBinding.List(&types.ListOpts{})
+	if err != nil {
+		return err
+	}
+
+	adminClient, err := rancher.NewClient(rancherClient.RancherConfig.AdminToken, rancherClient.Session)
 	if err != nil {
 		return err
 	}
@@ -246,7 +256,7 @@ func RemoveClusterRoleFromUser(rancherClient *rancher.Client, user *management.U
 	if err = rancherClient.Management.ClusterRoleTemplateBinding.Delete(&roleToDelete); err != nil {
 		return err
 	}
-	return waitForCRTBRollout(rancherClient, &roleToDelete, deleteOp)
+	return waitForCRTBRollout(adminClient, &roleToDelete, deleteOp)
 }
 
 // GetUserIDByName is a helper function that returns the user ID by name


### PR DESCRIPTION
In the functions for waitForCRTBRollout, waitForCRTBRollout, we are attempting to use rancherClient. But for cases when project members/project owners try to add other project members this call fails as the client defined is not an admin client and they will not have access to get the prtbs/crtbs. Added adminClient so the wait Rollout does not error out for other users. 