### PR TITLE
[BUGFIX] AzureChinaCloud The subscription  could not be found. #42243

### DIFF
--- a/pkg/api/norman/customization/aks/listers.go
+++ b/pkg/api/norman/customization/aks/listers.go
@@ -115,7 +115,8 @@ func NewSubscriptionServiceClient(cap *Capabilities) (*subscription.Subscription
 		return nil, err
 	}
 
-	subscriptionService := subscription.NewSubscriptionsClient()
+	//subscriptionService := subscription.NewSubscriptionsClient()
+	subscriptionService := subscription.NewSubscriptionsClientWithBaseURI(cap.BaseURL)
 	subscriptionService.Authorizer = authorizer
 
 	return &subscriptionService, nil


### PR DESCRIPTION
## Issue:  #42243
 
## Problem
rancher init SubscriptionServiceClient WithOut URL, which used default url ,
 
## Solution
init SubscriptionServiceClient  with cap.baseurl