### PR TITLE
accepts CATTLE_TRACE and RANCHER_TRACE as envs to set logrus trace level on rancher-agent

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -55,7 +55,7 @@ func main() {
 			logrus.Warnf("failed to reconcile kubelet, error: %v", err)
 		}
 
-		setLogrus()
+		configureLogrus()
 
 		logserver.StartServerWithDefaults()
 
@@ -484,17 +484,12 @@ func reconcileKubelet(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func setLogrus() {
+func configureLogrus() {
 	logrus.SetOutput(colorable.NewColorableStdout())
 
 	if os.Getenv("CATTLE_TRACE") == "true" || os.Getenv("RANCHER_TRACE") == "true" {
 		logrus.SetLevel(logrus.TraceLevel)
-		return
-	}
-
-	if os.Getenv("CATTLE_DEBUG") == "true" || os.Getenv("RANCHER_DEBUG") == "true" {
+	} else if os.Getenv("CATTLE_DEBUG") == "true" || os.Getenv("RANCHER_DEBUG") == "true" {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-
-	return
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -55,11 +55,9 @@ func main() {
 			logrus.Warnf("failed to reconcile kubelet, error: %v", err)
 		}
 
-		logrus.SetOutput(colorable.NewColorableStdout())
+		setLogrus()
+
 		logserver.StartServerWithDefaults()
-		if os.Getenv("CATTLE_DEBUG") == "true" || os.Getenv("RANCHER_DEBUG") == "true" {
-			logrus.SetLevel(logrus.DebugLevel)
-		}
 
 		initFeatures()
 
@@ -484,4 +482,19 @@ func reconcileKubelet(ctx context.Context) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func setLogrus() {
+	logrus.SetOutput(colorable.NewColorableStdout())
+
+	if os.Getenv("CATTLE_TRACE") == "true" || os.Getenv("RANCHER_TRACE") == "true" {
+		logrus.SetLevel(logrus.TraceLevel)
+		return
+	}
+
+	if os.Getenv("CATTLE_DEBUG") == "true" || os.Getenv("RANCHER_DEBUG") == "true" {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
+	return
 }


### PR DESCRIPTION
 [#42241](https://github.com/rancher/rancher/issues/42241) 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

`cattle-cluster-agent` can be run on debug-level using `CATTLE_DEBUG` or `RANCHER_DEBUG`, the same is not true for the trace-level.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
If the env `CATTLE_TRACE` or `RANCHER_TRACE` is set to `true` wile initializing the `cattle-cluster-agent` it will use trace-level, in the same way it works for debug-level
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
* Builded an rancher-agent image localy. 
* Setted up a cluster with `RANCHER_TRACE=true`
* Changed the cattle-cluster-agent image. 

