### PR TITLE
Update token ttl default

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -136,7 +136,7 @@ var (
 	K3sDefaultVersion  = NewSetting("k3s-default-version", "")
 
 	// AuthTokenMaxTTLMinutes is the max allowable time to live for tokens. Excluding those created for UI sessions which is controlled by AuthUserSessionTTLMinutes.
-	AuthTokenMaxTTLMinutes = NewSetting("auth-token-max-ttl-minutes", "0") // never expire
+	AuthTokenMaxTTLMinutes = NewSetting("auth-token-max-ttl-minutes", "129600") // 90 days
 
 	// AuthUserInfoMaxAgeSeconds represents the maximum age of a users auth tokens before an auth provider group membership sync will be performed.
 	AuthUserInfoMaxAgeSeconds = NewSetting("auth-user-info-max-age-seconds", "3600") // 1 hour
@@ -157,7 +157,7 @@ var (
 
 	// KubeconfigDefaultTokenTTLMinutes is the default time to live applied to kubeconfigs created for users.
 	// This setting will take effect regardless of the kubeconfig-generate-token status.
-	KubeconfigDefaultTokenTTLMinutes = NewSetting("kubeconfig-default-token-ttl-minutes", "0") // 0 TTL = never expire
+	KubeconfigDefaultTokenTTLMinutes = NewSetting("kubeconfig-default-token-ttl-minutes", "43200") // 30 days
 
 	// KubeconfigGenerateToken determines whether the UI will return a generate token with kubeconfigs.
 	// If set to false the kubeconfig will contain a command to login to Rancher.


### PR DESCRIPTION
Note: in draft until this can go into 2.8

## Issue: https://github.com/rancher/rancher/issues/41919
 
## Problem
As of Rancher 2.7, both `auth-token-max-ttl-minutes` and `kubeconfig-default-token-ttl-minutes` default to zero. Tokens in general have had a 0 TTL since Rancher 2.0, meaning they last forever. This has resulted in several problems. These include: a concern in our default security posture, performance issues around too many unexpired tokens, and confusion about which settings to adjust.

## Solution
Updated the values to 30 days (43200 minutes) for default `kubeconfig-default-token-ttl-minutes` and 90 days (129600 minutes) for `auth-token-max-ttl-minutes`
 
## Testing
When you start a rancher instance, go to settings and see that the default for both these values is set to the new values. When you go to create an auth token, the UI shows "30 days"

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing

* Test types added/modified:
    * Unit

## QA Testing Considerations
Existing tokens will not be changed, and if users would like they can set the default back to 0
 