### PR TITLE
Remove the deprecated kubeconfig-token-ttl-minutes setting

### DIFF
--- a/pkg/api/norman/customization/setting/setting.go
+++ b/pkg/api/norman/customization/setting/setting.go
@@ -2,7 +2,6 @@ package setting
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/httperror"
@@ -10,10 +9,8 @@ import (
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/types/slice"
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
-	"github.com/rancher/rancher/pkg/auth/tokens"
 	v3client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/settings"
 )
 
 var ReadOnlySettings = []string{
@@ -70,22 +67,6 @@ func Validator(request *types.APIContext, schema *types.Schema, data map[string]
 		_, err = providerrefresh.ParseMaxAge(newValueString)
 	case "auth-user-info-resync-cron":
 		_, err = providerrefresh.ParseCron(newValueString)
-	case "kubeconfig-token-ttl-minutes":
-		var tokenTTL time.Duration
-		tokenTTL, err = tokens.ParseTokenTTL(newValueString)
-		if err == nil {
-			maxTTL, err := tokens.ParseTokenTTL(settings.AuthTokenMaxTTLMinutes.Get())
-			if err != nil {
-				return httperror.NewAPIError(httperror.InvalidBodyContent,
-					fmt.Sprintf("error parsing auth-token-max-ttl-minutes %v", err))
-			}
-			if maxTTL != 0 {
-				if tokenTTL == 0 || tokenTTL.Minutes() > maxTTL.Minutes() {
-					return httperror.NewAPIError(httperror.MaxLimitExceeded,
-						fmt.Sprintf("max ttl for tokens is [%s]", settings.AuthTokenMaxTTLMinutes.Get()))
-				}
-			}
-		}
 	}
 
 	if err != nil {

--- a/pkg/auth/providers/common/usermanager.go
+++ b/pkg/auth/providers/common/usermanager.go
@@ -18,7 +18,6 @@ import (
 	tokenUtil "github.com/rancher/rancher/pkg/auth/tokens"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	rbacv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
-	"github.com/rancher/rancher/pkg/settings"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/user"
 	"github.com/rancher/wrangler/pkg/randomtoken"
@@ -311,18 +310,12 @@ func (m *userManager) EnsureClusterToken(clusterName string, input user.TokenInp
 
 // newTokenForKubeconfig creates a new token for a generated kubeconfig.
 func (m *userManager) newTokenForKubeconfig(clusterName, tokenName, description, kind, userName string, userPrincipal v3.Principal) (string, error) {
-	// settings.KubeconfigTokenTTLMinutes is deprecated use tokens.GetKubeconfigDefaultTokenTTLInMilliSeconds() when the setting is removed
-	tokenTTL, err := tokens.ParseTokenTTL(settings.KubeconfigTokenTTLMinutes.Get())
+
+	tokenTTL, err := tokens.GetKubeconfigDefaultTokenTTLInMilliSeconds()
 	if err != nil {
-		return "", fmt.Errorf("failed to parse setting '%s': %w", settings.KubeconfigTokenTTLMinutes.Name, err)
+		return "", fmt.Errorf("failed to get default token TTL: %w", err)
 	}
 
-	tokenTTL, err = tokens.ClampToMaxTTL(tokenTTL)
-	if err != nil {
-		return "", fmt.Errorf("failed to validate token ttl %w", err)
-	}
-
-	ttlMilli := tokenTTL.Milliseconds()
 	logrus.Infof("Creating token for user %v", userName)
 	input := user.TokenInput{
 		TokenName:     tokenName,
@@ -330,7 +323,7 @@ func (m *userManager) newTokenForKubeconfig(clusterName, tokenName, description,
 		Kind:          kind,
 		UserName:      userName,
 		AuthProvider:  userPrincipal.Provider,
-		TTL:           &ttlMilli,
+		TTL:           tokenTTL,
 		Randomize:     true,
 		UserPrincipal: userPrincipal,
 	}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -163,13 +163,6 @@ var (
 	// If set to false the kubeconfig will contain a command to login to Rancher.
 	KubeconfigGenerateToken = NewSetting("kubeconfig-generate-token", "true")
 
-	// KubeconfigTokenTTLMinutes currently is used to set the TTL for kubeconfigs created through the CLI.
-	// This can be done with the token command or via kubectl when kubeconfig-generate-token is false.
-	// This TTL is used regardless of the value of kubeconfig-default-ttl-minutes.
-	//
-	// Deprecated: On removal use kubeconfig-default-ttl-minutes for all kubeconfigs.
-	KubeconfigTokenTTLMinutes = NewSetting("kubeconfig-token-ttl-minutes", "960") // 16 hours
-
 	// RancherWebhookVersion is the exact version of the webhook that Rancher will install.
 	RancherWebhookVersion = NewSetting("rancher-webhook-version", "")
 

--- a/tests/integration/suite/test_tokens.py
+++ b/tests/integration/suite/test_tokens.py
@@ -66,7 +66,7 @@ def test_kubeconfig_token_ttl(admin_mc, user_mc):
     # update kubeconfig ttl setting for test
     kubeconfig_ttl_mins = 0.01
     client.update_by_id_setting(
-        id="kubeconfig-token-ttl-minutes",
+        id="kubeconfig-default-token-ttl-minutes",
         value=kubeconfig_ttl_mins)
 
     # call login action for kubeconfig token
@@ -84,8 +84,8 @@ def test_kubeconfig_token_ttl(admin_mc, user_mc):
     assert token1 != token2
 
     # reset kubeconfig ttl setting
-    client.update_by_id_setting(id="kubeconfig-token-ttl-minutes",
-                                value="960")
+    client.update_by_id_setting(id="kubeconfig-default-token-ttl-minutes",
+                                value="43200")
 
     # enable kubeconfig generation setting
     client.update_by_id_setting(id="kubeconfig-generate-token", value="true")


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/38535

## Problem
The `kubeconfig-token-ttl-minutes` setting has been deprecated and has reached end of life.
 
## Solution
Removed the deprecated setting and removed any references to it. This removes the setting from the back end, however a UI change is required to remove the setting from the dashboard. It currently still appears, but does nothing.
 
## Testing
Ran unit tests to make sure no references to the setting exist