### PR TITLE
Update UI settings 2.7.6

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -199,7 +199,7 @@ var (
 	UIDashboardPath = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
 
 	// UIDashboardIndex depends on ui-offline-preferred, use this version of the dashboard instead of the one contained in Rancher Manager.
-	UIDashboardIndex = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/release-2.7.5/index.html")
+	UIDashboardIndex = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/release-2.7.6/index.html")
 
 	// UIDashboardHarvesterLegacyPlugin depending on ui-offline-preferred and if a Harvester Cluster does not contain it's own Harvester plugin, use this version of the plugin instead.
 	UIDashboardHarvesterLegacyPlugin = NewSetting("ui-dashboard-harvester-legacy-plugin", "https://releases.rancher.com/harvester-ui/plugin/harvester-1.0.3-head/harvester-1.0.3-head.umd.min.js")
@@ -214,7 +214,7 @@ var (
 	UIFeedBackForm = NewSetting("ui-feedback-form", "")
 
 	// UIIndex depends on ui-offline-preferred, use this version of the old ember UI instead of the one contained in Rancher Manager.
-	UIIndex = NewSetting("ui-index", "https://releases.rancher.com/ui/release-2.7.5/index.html")
+	UIIndex = NewSetting("ui-index", "https://releases.rancher.com/ui/release-2.7.6/index.html")
 
 	// UIIssues use a url address to send new 'File an Issue' reports instead of sending users to the Github issues page.
 	// Deprecated in favour of UICustomLinks = NewSetting("ui-custom-links", {}).


### PR DESCRIPTION
## Problem
rancher/dashboard and rancher/ui have branched for `2.7.6`
 
## Solution
* This change ensures the rancher/rancher `release/v2.6` points to the right rancher/ui and rancher/dashboard builds in `UiIndex` and `UiDashboardIndex` setting defaults, respectively
* By default `-head` versions use these builds instead of the embedded builds 
 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Updated settings on an existing instance and verified the dashboard/ui load

![Screenshot 2023-08-02 at 18 22 22](https://github.com/rancher/rancher/assets/97888974/30354e6e-fe07-4e94-ba7c-50dc666685d6)
![Screenshot 2023-08-02 at 18 22 05](https://github.com/rancher/rancher/assets/97888974/3130c459-ea28-47bd-b1cc-e49c7642c236)
![Screenshot 2023-08-02 at 18 21 54](https://github.com/rancher/rancher/assets/97888974/81328b6e-c745-4173-b04f-39b94422a35e)

