### PR TITLE
Fixing CheckETCDVersion function to read from metadata

### DIFF
--- a/tests/v2/validation/provisioning/rke1/custom_cluster.go
+++ b/tests/v2/validation/provisioning/rke1/custom_cluster.go
@@ -103,7 +103,7 @@ func TestProvisioningRKE1CustomCluster(t *testing.T, client *rancher.Client, ext
 	require.NoError(t, err)
 	assert.NotEmpty(t, clusterToken)
 
-	etcdVersion, err := matrix.CheckETCDVersion(client, nodes, rolesPerPool)
+	etcdVersion, err := matrix.CheckETCDVersion(client, nodes, clusterResp.ID)
 	require.NoError(t, err)
 	assert.NotEmpty(t, etcdVersion)
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Fix CheckETCDVersion extension](https://github.com/rancher/qa-tasks/issues/861)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The `CheckETCDVersion` is throwing a panic when the user defines multiple nodes per role with the `nodeRoles` parameter. This causes inconsistency with the test, which inadvertently affects our test suite at large when ran in bulk.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
We are now reading the node's metadata directly. Doing this, we eliminate the possibility of a panic and can achieve consistent results each time. Which is what we expect from this test to begin with.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manually validated that I still can provision a custom cluster and get the etcd version and image versions.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_