### PR TITLE
Global roles v2

### DIFF
--- a/pkg/agent/clean/orphan_bindings.go
+++ b/pkg/agent/clean/orphan_bindings.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/rancher/rancher/pkg/controllers/management/auth"
+	"github.com/rancher/rancher/pkg/controllers/management/auth/globalroles"
 	mgmt "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io"
 	v3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/namespace"
@@ -201,7 +202,7 @@ func (bc *orphanBindingsCleanup) cleanOrphanedCatalogRolesAndRolebindings() erro
 	}
 	logrus.Infof("[%v] Processing %d rolebindings", orphanCatalogBindingsOperation, len(rbs.Items))
 	for _, rb := range rbs.Items {
-		if rb.RoleRef.Name != auth.GlobalCatalogRole {
+		if rb.RoleRef.Name != globalroles.GlobalCatalogRole {
 			continue
 		}
 
@@ -217,12 +218,12 @@ func (bc *orphanBindingsCleanup) cleanOrphanedCatalogRolesAndRolebindings() erro
 	}
 
 	if dryRun {
-		logrus.Infof("[%v] dryRun is enabled, skipping deletion for orphaned role: %s/%s", orphanCatalogBindingsOperation, namespace.GlobalNamespace, auth.GlobalCatalogRole)
+		logrus.Infof("[%v] dryRun is enabled, skipping deletion for orphaned role: %s/%s", orphanCatalogBindingsOperation, namespace.GlobalNamespace, globalroles.GlobalCatalogRole)
 	} else {
-		logrus.Infof("[%v] Deleting orphaned role %s", orphanCatalogBindingsOperation, auth.GlobalCatalogRole)
-		err = bc.roles.Delete(namespace.GlobalNamespace, auth.GlobalCatalogRole, &metav1.DeleteOptions{})
+		logrus.Infof("[%v] Deleting orphaned role %s", orphanCatalogBindingsOperation, globalroles.GlobalCatalogRole)
+		err = bc.roles.Delete(namespace.GlobalNamespace, globalroles.GlobalCatalogRole, &metav1.DeleteOptions{})
 		if err != nil && !k8serrors.IsNotFound(err) {
-			logrus.Warnf("[%v] Error when deleting role %s, %s", orphanCatalogBindingsOperation, auth.GlobalCatalogRole, err.Error())
+			logrus.Warnf("[%v] Error when deleting role %s, %s", orphanCatalogBindingsOperation, globalroles.GlobalCatalogRole, err.Error())
 			return err
 		}
 	}

--- a/pkg/apis/management.cattle.io/v3/authz_types.go
+++ b/pkg/apis/management.cattle.io/v3/authz_types.go
@@ -89,6 +89,12 @@ type GlobalRole struct {
 	Rules          []rbacv1.PolicyRule `json:"rules,omitempty"`
 	NewUserDefault bool                `json:"newUserDefault,omitempty" norman:"required"`
 	Builtin        bool                `json:"builtin" norman:"nocreate,noupdate"`
+
+	// InheritedClusterRoles are the names of RoleTemplates whose permissions are granted by this GlobalRole in every
+	// cluster besides the local cluster. To grant permissions in the local cluster, use the Rules or NamespacedRules
+	// fields.
+	// +optional
+	InheritedClusterRoles []string `json:"inheritedClusterRoles,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -4120,6 +4120,11 @@ func (in *GlobalRole) DeepCopyInto(out *GlobalRole) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.InheritedClusterRoles != nil {
+		in, out := &in.InheritedClusterRoles, &out.InheritedClusterRoles
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/client/generated/management/v3/zz_generated_global_role.go
+++ b/pkg/client/generated/management/v3/zz_generated_global_role.go
@@ -5,35 +5,37 @@ import (
 )
 
 const (
-	GlobalRoleType                 = "globalRole"
-	GlobalRoleFieldAnnotations     = "annotations"
-	GlobalRoleFieldBuiltin         = "builtin"
-	GlobalRoleFieldCreated         = "created"
-	GlobalRoleFieldCreatorID       = "creatorId"
-	GlobalRoleFieldDescription     = "description"
-	GlobalRoleFieldLabels          = "labels"
-	GlobalRoleFieldName            = "name"
-	GlobalRoleFieldNewUserDefault  = "newUserDefault"
-	GlobalRoleFieldOwnerReferences = "ownerReferences"
-	GlobalRoleFieldRemoved         = "removed"
-	GlobalRoleFieldRules           = "rules"
-	GlobalRoleFieldUUID            = "uuid"
+	GlobalRoleType                       = "globalRole"
+	GlobalRoleFieldAnnotations           = "annotations"
+	GlobalRoleFieldBuiltin               = "builtin"
+	GlobalRoleFieldCreated               = "created"
+	GlobalRoleFieldCreatorID             = "creatorId"
+	GlobalRoleFieldDescription           = "description"
+	GlobalRoleFieldInheritedClusterRoles = "inheritedClusterRoles"
+	GlobalRoleFieldLabels                = "labels"
+	GlobalRoleFieldName                  = "name"
+	GlobalRoleFieldNewUserDefault        = "newUserDefault"
+	GlobalRoleFieldOwnerReferences       = "ownerReferences"
+	GlobalRoleFieldRemoved               = "removed"
+	GlobalRoleFieldRules                 = "rules"
+	GlobalRoleFieldUUID                  = "uuid"
 )
 
 type GlobalRole struct {
 	types.Resource
-	Annotations     map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Builtin         bool              `json:"builtin,omitempty" yaml:"builtin,omitempty"`
-	Created         string            `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID       string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	Description     string            `json:"description,omitempty" yaml:"description,omitempty"`
-	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Name            string            `json:"name,omitempty" yaml:"name,omitempty"`
-	NewUserDefault  bool              `json:"newUserDefault,omitempty" yaml:"newUserDefault,omitempty"`
-	OwnerReferences []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	Removed         string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	Rules           []PolicyRule      `json:"rules,omitempty" yaml:"rules,omitempty"`
-	UUID            string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Annotations           map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Builtin               bool              `json:"builtin,omitempty" yaml:"builtin,omitempty"`
+	Created               string            `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID             string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Description           string            `json:"description,omitempty" yaml:"description,omitempty"`
+	InheritedClusterRoles []string          `json:"inheritedClusterRoles,omitempty" yaml:"inheritedClusterRoles,omitempty"`
+	Labels                map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name                  string            `json:"name,omitempty" yaml:"name,omitempty"`
+	NewUserDefault        bool              `json:"newUserDefault,omitempty" yaml:"newUserDefault,omitempty"`
+	OwnerReferences       []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Removed               string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	Rules                 []PolicyRule      `json:"rules,omitempty" yaml:"rules,omitempty"`
+	UUID                  string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }
 
 type GlobalRoleCollection struct {

--- a/pkg/clustermanager/errors.go
+++ b/pkg/clustermanager/errors.go
@@ -1,0 +1,11 @@
+package clustermanager
+
+import "github.com/rancher/norman/httperror"
+
+// IsClusterUnavailableErr checks if a given error indicates that the requested cluster was not available
+func IsClusterUnavailableErr(err error) bool {
+	if apiError, ok := err.(*httperror.APIError); ok {
+		return apiError.Code == httperror.ClusterUnavailable
+	}
+	return false
+}

--- a/pkg/clustermanager/errors_test.go
+++ b/pkg/clustermanager/errors_test.go
@@ -1,0 +1,48 @@
+package clustermanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rancher/norman/httperror"
+	"github.com/rancher/rancher/pkg/clustermanager"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsClusterUnavailableErr(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "basic error",
+			err:  fmt.Errorf("standard error"),
+			want: false,
+		},
+		{
+			name: "api error bad error code",
+			err: &httperror.APIError{
+				Code: httperror.ActionNotAvailable,
+			},
+			want: false,
+		},
+		{
+			name: "api error cluster unavailable code",
+			err: &httperror.APIError{
+				Code: httperror.ClusterUnavailable,
+			},
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := clustermanager.IsClusterUnavailableErr(test.err)
+			require.Equal(t, got, test.want)
+		})
+	}
+}

--- a/pkg/controllers/management/auth/globalroles/enqueue.go
+++ b/pkg/controllers/management/auth/globalroles/enqueue.go
@@ -1,0 +1,132 @@
+package globalroles
+
+import (
+	"fmt"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/wrangler/pkg/relatedresource"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	grbGrIndex        = "mgmt-auth-grb-gr-idex"
+	grbEnqueuer       = "mgmt-auth-gr-enqueue"
+	clusterGrEnqueuer = "mgmt-auth-cluster-gr"
+	crtbGRBEnqueuer   = "mgmt-auth-crtb-grb"
+)
+
+type globalRBACEnqueuer struct {
+	grbCache      mgmtv3.GlobalRoleBindingCache
+	grCache       mgmtv3.GlobalRoleCache
+	clusterClient mgmtv3.ClusterClient
+}
+
+// grbGrIndexer indexes a globalRoleBinding by the globalRole it assigns to users
+func grbGrIndexer(grb *v3.GlobalRoleBinding) ([]string, error) {
+	return []string{grb.GlobalRoleName}, nil
+}
+
+// enqueueGRBs enqueues GlobalRoleBinding for a given changed GlobalRole, allowing per-cluster permissions to sync
+func (g *globalRBACEnqueuer) enqueueGRBs(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	globalRole, ok := obj.(*v3.GlobalRole)
+	if !ok {
+		logrus.Errorf("unable to convert object: %[1]v, type: %[1]T to a global role", obj)
+		return nil, nil
+	}
+	if len(globalRole.InheritedClusterRoles) == 0 {
+		// don't enqueue GRBs if we don't inherit any clusterRoles, nothing for the GRB controller to do
+		return nil, nil
+	}
+	bindings, err := g.grbCache.GetByIndex(grbGrIndex, globalRole.Name)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get grbs for gr %s from indexer: %w", globalRole.Name, err)
+	}
+	bindingNames := make([]relatedresource.Key, 0, len(bindings))
+	for _, binding := range bindings {
+		bindingNames = append(bindingNames, relatedresource.Key{Name: binding.Name})
+	}
+	return bindingNames, nil
+}
+
+// clusterEnqueueGRs enqueues GlobalRoles which provide cluster RBAC. Does not enqueue any GRs if this cluster has already had
+// the initial RBAC sync done
+func (g *globalRBACEnqueuer) clusterEnqueueGRs(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	cluster, ok := obj.(*v3.Cluster)
+	if !ok {
+		logrus.Errorf("unable to convert object: %[1]v, type %[1]T to a cluster", obj)
+		return nil, nil
+	}
+	// we only want to perform the initial sync once. Future changes will be picked up by other handlers
+	if _, ok := cluster.Annotations[initialSyncAnnotation]; ok {
+		return nil, nil
+	}
+	globalRoles, err := g.grCache.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("unable to list current GlobalRoles when syncing roles for cluster %s: %w", cluster.Name, err)
+	}
+	var rolesToSync []relatedresource.Key
+	for _, globalRole := range globalRoles {
+		if len(globalRole.InheritedClusterRoles) == 0 {
+			continue
+		}
+		rolesToSync = append(rolesToSync, relatedresource.Key{Name: globalRole.Name})
+	}
+	// attempt to update the cluster with a sync annotation - this is costly since it will re-enqueue all grs
+	// which inherit cluster permissions, so we try to avoid it. If we can't record the annotation, we still
+	// want to try and sync the permissions.
+	newCluster, err := g.clusterClient.Get(cluster.Name, metav1.GetOptions{})
+	if err != nil {
+		logrus.Errorf("unable to get cluster %s to add sync annotation, grs will re-enqueue on change: %s", cluster.Name, err.Error())
+		return rolesToSync, nil
+	}
+	if newCluster.Annotations == nil {
+		newCluster.Annotations = map[string]string{}
+	}
+	newCluster.Annotations[initialSyncAnnotation] = "true"
+	_, err = g.clusterClient.Update(newCluster)
+	if err != nil {
+		logrus.Errorf("unable to update cluster %s with sync annotation, grs will re-enqueue on change: %s", cluster.Name, err.Error())
+	}
+	return rolesToSync, nil
+}
+
+// crtbEnqueueGRB enqueues GlobalRoleBindings which own a given CRTB when that CRTB is changed. Uses the label
+// which is protected by the webhook rather than the ownerReference
+func (g *globalRBACEnqueuer) crtbEnqueueGRB(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	crtb, ok := obj.(*v3.ClusterRoleTemplateBinding)
+	if !ok {
+		logrus.Errorf("unable to convert object: %[1]v, type: %[1]T to a crtb", obj)
+		return nil, nil
+	}
+	grbOwner, ok := crtb.Labels[grbOwnerLabel]
+	if !ok {
+		// this crtb isn't owned by a GRB, no need to enqueue a GRB
+		return nil, nil
+	}
+	_, err := g.grbCache.Get(grbOwner)
+	if err != nil {
+		// if the crtb was orphaned during deletion, the label may still exist but the owning grb won't
+		// in these cases, nothing should be re-enqueued
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unable to confirm if grb %s exists for crtb %s", grbOwner, crtb.Name)
+	}
+	return []relatedresource.Key{
+		{Name: grbOwner},
+	}, nil
+}

--- a/pkg/controllers/management/auth/globalroles/enqueue_test.go
+++ b/pkg/controllers/management/auth/globalroles/enqueue_test.go
@@ -1,0 +1,473 @@
+package globalroles
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/wrangler/pkg/generic/fake"
+	"github.com/rancher/wrangler/pkg/relatedresource"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func Test_enqueueGRBs(t *testing.T) {
+	t.Parallel()
+	type testState struct {
+		grbCacheMock *fake.MockNonNamespacedCacheInterface[*v3.GlobalRoleBinding]
+	}
+	tests := []struct {
+		name        string
+		stateSetup  func(state testState)
+		inputObject runtime.Object
+		wantKeys    []relatedresource.Key
+		wantError   bool
+	}{
+		{
+			name: "no inherited roles",
+			inputObject: &v3.GlobalRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gr",
+				},
+			},
+			wantKeys: nil,
+		},
+		{
+			name: "empty inherited roles",
+			inputObject: &v3.GlobalRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gr",
+				},
+				InheritedClusterRoles: []string{},
+			},
+			wantKeys: nil,
+		},
+
+		{
+			name: "inherited roles",
+			inputObject: &v3.GlobalRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gr",
+				},
+				InheritedClusterRoles: []string{"test-role"},
+			},
+			stateSetup: func(state testState) {
+				grbs := []*v3.GlobalRoleBinding{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-grb-1",
+						},
+						GlobalRoleName: "test-gr",
+						UserName:       "u-123xyz",
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-grb-2",
+						},
+						GlobalRoleName: "test-gr",
+						UserName:       "u-123abc",
+					},
+				}
+				state.grbCacheMock.EXPECT().GetByIndex(grbGrIndex, "test-gr").Return(grbs, nil)
+			},
+			wantKeys: []relatedresource.Key{{Name: "test-grb-1"}, {Name: "test-grb-2"}},
+		},
+		{
+			name: "inherited roles, indexer error",
+			inputObject: &v3.GlobalRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gr",
+				},
+				InheritedClusterRoles: []string{"test-role"},
+			},
+			stateSetup: func(state testState) {
+				state.grbCacheMock.EXPECT().GetByIndex(grbGrIndex, "test-gr").Return(nil, fmt.Errorf("server not available"))
+			},
+			wantError: true,
+		},
+		{
+			name: "inherited roles, no grbs",
+			inputObject: &v3.GlobalRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gr",
+				},
+				InheritedClusterRoles: []string{"test-role"},
+			},
+			stateSetup: func(state testState) {
+				state.grbCacheMock.EXPECT().GetByIndex(grbGrIndex, "test-gr").Return([]*v3.GlobalRoleBinding{}, nil)
+			},
+			wantKeys: nil,
+		},
+		{
+			name:        "input not a global role",
+			inputObject: &v3.ClusterRoleTemplateBinding{},
+			wantError:   false,
+			wantKeys:    nil,
+		},
+		{
+			name:        "nil input",
+			inputObject: nil,
+			wantKeys:    nil,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			grbCache := fake.NewMockNonNamespacedCacheInterface[*v3.GlobalRoleBinding](ctrl)
+			state := testState{
+				grbCacheMock: grbCache,
+			}
+			if test.stateSetup != nil {
+				test.stateSetup(state)
+			}
+			enqueuer := globalRBACEnqueuer{
+				grbCache: grbCache,
+			}
+			res, resErr := enqueuer.enqueueGRBs("", "", test.inputObject)
+			require.Len(t, res, len(test.wantKeys))
+			for _, key := range test.wantKeys {
+				require.Contains(t, res, key)
+			}
+			if test.wantError {
+				require.Error(t, resErr)
+			} else {
+				require.NoError(t, resErr)
+			}
+		})
+	}
+}
+
+func Test_clusterEnqueueGRs(t *testing.T) {
+	t.Parallel()
+	type testState struct {
+		grCacheMock       *fake.MockNonNamespacedCacheInterface[*v3.GlobalRole]
+		clusterClientMock *fake.MockNonNamespacedClientInterface[*v3.Cluster, *v3.ClusterList]
+	}
+	inheritedGR := v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-gr",
+		},
+		InheritedClusterRoles: []string{"test-role"},
+	}
+	noInheritedGR := v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-no-gr",
+		},
+	}
+	emptyInheritedGR := v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-no-gr",
+		},
+		InheritedClusterRoles: []string{},
+	}
+	tests := []struct {
+		name        string
+		stateSetup  func(state testState)
+		inputObject runtime.Object
+		wantKeys    []relatedresource.Key
+		wantError   bool
+	}{
+		{
+			name: "cluster already synced",
+			inputObject: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+					Annotations: map[string]string{
+						initialSyncAnnotation: "true",
+					},
+				},
+			},
+			stateSetup: func(state testState) {
+				// current implementation doesn't call this, but we want to setup the state in case
+				// call order changes slightly
+				state.grCacheMock.EXPECT().List(labels.Everything()).Return([]*v3.GlobalRole{&inheritedGR}, nil).AnyTimes()
+			},
+			wantKeys: nil,
+		},
+		{
+			name: "cluster not synced",
+			inputObject: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+			},
+			stateSetup: func(state testState) {
+				state.grCacheMock.EXPECT().List(labels.Everything()).Return([]*v3.GlobalRole{&inheritedGR, &noInheritedGR, &emptyInheritedGR}, nil)
+				state.clusterClientMock.EXPECT().Get("test-cluster", gomock.Any()).Return(
+					&v3.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-cluster",
+							Annotations: map[string]string{
+								"some-annotation": "here",
+							},
+						},
+					}, nil)
+				updCluster := v3.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-cluster",
+						Annotations: map[string]string{
+							"some-annotation":     "here",
+							initialSyncAnnotation: "true",
+						},
+					},
+				}
+				state.clusterClientMock.EXPECT().Update(&updCluster).Return(&updCluster, nil)
+			},
+			wantKeys: []relatedresource.Key{{Name: inheritedGR.Name}},
+		},
+		{
+			name: "cluster not synced - no annotations",
+			inputObject: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+			},
+			stateSetup: func(state testState) {
+				state.grCacheMock.EXPECT().List(labels.Everything()).Return([]*v3.GlobalRole{&inheritedGR, &noInheritedGR, &emptyInheritedGR}, nil)
+				state.clusterClientMock.EXPECT().Get("test-cluster", gomock.Any()).Return(
+					&v3.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-cluster",
+						},
+					}, nil)
+				updCluster := v3.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-cluster",
+						Annotations: map[string]string{
+							initialSyncAnnotation: "true",
+						},
+					},
+				}
+				state.clusterClientMock.EXPECT().Update(&updCluster).Return(&updCluster, nil)
+			},
+			wantKeys: []relatedresource.Key{{Name: inheritedGR.Name}},
+		},
+		{
+			name: "input not a cluster",
+			inputObject: &v3.GlobalRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gr",
+				},
+				InheritedClusterRoles: []string{"test-role"},
+			},
+			wantError: false,
+			wantKeys:  nil,
+		},
+		{
+			name:        "nil input",
+			inputObject: nil,
+			wantKeys:    nil,
+		},
+		{
+			name: "cluster not synced, gr list error",
+			inputObject: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+			},
+			stateSetup: func(state testState) {
+				state.grCacheMock.EXPECT().List(labels.Everything()).Return(nil, fmt.Errorf("server unavailable"))
+			},
+			wantKeys:  nil,
+			wantError: true,
+		},
+		{
+			name: "cluster not synced, get cluster error",
+			inputObject: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+			},
+			stateSetup: func(state testState) {
+				state.grCacheMock.EXPECT().List(labels.Everything()).Return([]*v3.GlobalRole{&inheritedGR}, nil)
+				state.clusterClientMock.EXPECT().Get("test-cluster", gomock.Any()).Return(nil, fmt.Errorf("server unavailable"))
+			},
+			wantKeys: []relatedresource.Key{{Name: inheritedGR.Name}},
+		},
+		{
+			name: "cluster not synced, update cluster error",
+			inputObject: &v3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+			},
+			stateSetup: func(state testState) {
+				state.grCacheMock.EXPECT().List(labels.Everything()).Return([]*v3.GlobalRole{&inheritedGR}, nil)
+				state.clusterClientMock.EXPECT().Get("test-cluster", gomock.Any()).Return(&v3.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-cluster",
+						Annotations: map[string]string{
+							"some-annotation": "here",
+						},
+					},
+				}, nil)
+				state.clusterClientMock.EXPECT().Update(&v3.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-cluster",
+						Annotations: map[string]string{
+							"some-annotation":     "here",
+							initialSyncAnnotation: "true",
+						},
+					},
+				}).Return(nil, fmt.Errorf("server unavailable"))
+			},
+			wantKeys: []relatedresource.Key{{Name: inheritedGR.Name}},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			grCache := fake.NewMockNonNamespacedCacheInterface[*v3.GlobalRole](ctrl)
+			clusterClient := fake.NewMockNonNamespacedClientInterface[*v3.Cluster, *v3.ClusterList](ctrl)
+			state := testState{
+				grCacheMock:       grCache,
+				clusterClientMock: clusterClient,
+			}
+			if test.stateSetup != nil {
+				test.stateSetup(state)
+			}
+			enqueuer := globalRBACEnqueuer{
+				grCache:       grCache,
+				clusterClient: clusterClient,
+			}
+			res, resErr := enqueuer.clusterEnqueueGRs("", "", test.inputObject)
+			require.Len(t, res, len(test.wantKeys))
+			for _, key := range test.wantKeys {
+				require.Contains(t, res, key)
+			}
+			if test.wantError {
+				require.Error(t, resErr)
+			} else {
+				require.NoError(t, resErr)
+			}
+		})
+	}
+}
+
+func Test_crtbEnqueueGRB(t *testing.T) {
+	t.Parallel()
+	type testState struct {
+		grbCacheMock *fake.MockNonNamespacedCacheInterface[*v3.GlobalRoleBinding]
+	}
+	testGrb := v3.GlobalRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-grb",
+		},
+	}
+	tests := []struct {
+		name        string
+		stateSetup  func(state testState)
+		inputObject runtime.Object
+		wantKeys    []relatedresource.Key
+		wantError   bool
+	}{
+		{
+			name: "crtb not owned by grb",
+			inputObject: &v3.ClusterRoleTemplateBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-crtb",
+				},
+			},
+			wantKeys: nil,
+		},
+		{
+			name: "crtb owned by existing grb",
+			inputObject: &v3.ClusterRoleTemplateBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-crtb",
+					Labels: map[string]string{
+						grbOwnerLabel: testGrb.Name,
+					},
+				},
+			},
+			stateSetup: func(state testState) {
+				state.grbCacheMock.EXPECT().Get(testGrb.Name).Return(&testGrb, nil)
+			},
+			wantKeys: []relatedresource.Key{{Name: testGrb.Name}},
+		},
+		{
+			name: "crtb owned by non-existent grb",
+			inputObject: &v3.ClusterRoleTemplateBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-crtb",
+					Labels: map[string]string{
+						grbOwnerLabel: testGrb.Name,
+					},
+				},
+			},
+			stateSetup: func(state testState) {
+				state.grbCacheMock.EXPECT().Get(testGrb.Name).Return(nil, apierrors.NewNotFound(schema.GroupResource{
+					Group:    v3.SchemeGroupVersion.Group,
+					Resource: v3.GlobalRoleResourceName,
+				}, testGrb.Name))
+			},
+			wantKeys: nil,
+		},
+		{
+			name: "crtb owned by grb, error when confirming grb existence",
+			inputObject: &v3.ClusterRoleTemplateBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-crtb",
+					Labels: map[string]string{
+						grbOwnerLabel: testGrb.Name,
+					},
+				},
+			},
+			stateSetup: func(state testState) {
+				state.grbCacheMock.EXPECT().Get(testGrb.Name).Return(nil, fmt.Errorf("server unavailable"))
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid input object type",
+			inputObject: &v3.GlobalRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-grb",
+				},
+			},
+			wantKeys:  nil,
+			wantError: false,
+		},
+		{
+			name:        "nil input object",
+			inputObject: nil,
+			wantKeys:    nil,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			grbCache := fake.NewMockNonNamespacedCacheInterface[*v3.GlobalRoleBinding](ctrl)
+			state := testState{
+				grbCacheMock: grbCache,
+			}
+			if test.stateSetup != nil {
+				test.stateSetup(state)
+			}
+			enqueuer := globalRBACEnqueuer{
+				grbCache: grbCache,
+			}
+			res, resErr := enqueuer.crtbEnqueueGRB("", "", test.inputObject)
+			require.Len(t, res, len(test.wantKeys))
+			for _, key := range test.wantKeys {
+				require.Contains(t, res, key)
+			}
+			if test.wantError {
+				require.Error(t, resErr)
+			} else {
+				require.NoError(t, resErr)
+			}
+		})
+	}
+}

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -1,4 +1,4 @@
-package auth
+package globalroles
 
 import (
 	"reflect"
@@ -19,10 +19,10 @@ import (
 )
 
 var (
-	globalRoleLabel  = map[string]string{"authz.management.cattle.io/globalrole": "true"}
-	crNameAnnotation = "authz.management.cattle.io/cr-name"
-	clusterRoleKind  = "ClusterRole"
-	grController     = "mgmt-auth-gr-controller"
+	globalRoleLabel       = map[string]string{"authz.management.cattle.io/globalrole": "true"}
+	crNameAnnotation      = "authz.management.cattle.io/cr-name"
+	initialSyncAnnotation = "authz.management.cattle.io/initial-sync"
+	clusterRoleKind       = "ClusterRole"
 )
 
 func newGlobalRoleLifecycle(management *config.ManagementContext) *globalRoleLifecycle {

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
@@ -1,0 +1,794 @@
+package globalroles
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/rancher/wrangler/pkg/generic/fake"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func Test_crtbGrbOwnerIndexer(t *testing.T) {
+	t.Parallel()
+	grbOwnedCRTB := &v3.ClusterRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "crtb-grb-alread-exists",
+			Labels: map[string]string{
+				grbOwnerLabel: "test-grb",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "management.cattle.io/v3",
+					Kind:       "GlobalRoleBinding",
+					UID:        "1234",
+					Name:       "other-grb",
+				},
+			},
+			GenerateName: "crtb-grb-",
+			Namespace:    "some-cluster",
+		},
+		RoleTemplateName:   "already-exists",
+		ClusterName:        "other-cluster",
+		UserName:           "test-user",
+		GroupPrincipalName: "",
+	}
+	keys, err := crtbGrbOwnerIndexer(grbOwnedCRTB)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Equal(t, "other-cluster/test-grb", keys[0])
+
+	noLabelCRTB := &v3.ClusterRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "crtb-grb-alread-exists",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "management.cattle.io/v3",
+					Kind:       "GlobalRoleBinding",
+					UID:        "1234",
+					Name:       "other-grb",
+				},
+			},
+			GenerateName: "crtb-grb-",
+			Namespace:    "some-cluster",
+		},
+		RoleTemplateName:   "already-exists",
+		ClusterName:        "other-cluster",
+		UserName:           "test-user",
+		GroupPrincipalName: "",
+	}
+	keys, err = crtbGrbOwnerIndexer(noLabelCRTB)
+	require.NoError(t, err)
+	require.Len(t, keys, 0)
+
+	standardCRTB := &v3.ClusterRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "crtb-grb-123xyz",
+			Namespace: "some-cluster",
+		},
+		RoleTemplateName:   "already-exists",
+		ClusterName:        "some-cluster",
+		UserName:           "test-user",
+		GroupPrincipalName: "",
+	}
+	keys, err = crtbGrbOwnerIndexer(standardCRTB)
+	require.NoError(t, err)
+	require.Len(t, keys, 0)
+}
+
+func Test_reconcileClusterPermissions(t *testing.T) {
+	t.Parallel()
+	type testStateChanges struct {
+		t                *testing.T
+		createdCRTBs     []*v3.ClusterRoleTemplateBinding
+		deletedCRTBNames []string
+	}
+	type testState struct {
+		crtbCacheMock     *fake.MockCacheInterface[*v3.ClusterRoleTemplateBinding]
+		grListerMock      *fakes.GlobalRoleListerMock
+		clusterListerMock *fakes.ClusterListerMock
+		crtbClientMock    *fakes.ClusterRoleTemplateBindingInterfaceMock
+		stateChanges      *testStateChanges
+	}
+	inheritedTestGr := v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "inherit-test-gr",
+		},
+		InheritedClusterRoles: []string{"cluster-owner"},
+	}
+	noInheritTestGR := v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "noinherit-test-gr",
+		},
+		InheritedClusterRoles: []string{},
+	}
+	missingInheritTestGR := v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "missing-test-gr",
+		},
+	}
+
+	purgeTestGR := v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "purge-inherit-test-gr",
+		},
+		InheritedClusterRoles: []string{"already-exists", "missing",
+			"wrong-cluster-name", "wrong-user-name", "wrong-group-name",
+			"deleting", "duplicate"},
+	}
+
+	notLocalCluster := v3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "not-local",
+		},
+	}
+	errorCluster := v3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "error",
+		},
+	}
+	localCluster := v3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "local",
+		},
+	}
+
+	grListerGetFunc := func(_ string, name string) (*v3.GlobalRole, error) {
+		switch name {
+		case inheritedTestGr.Name:
+			return &inheritedTestGr, nil
+		case noInheritTestGR.Name:
+			return &noInheritTestGR, nil
+		case missingInheritTestGR.Name:
+			return &missingInheritTestGR, nil
+		case purgeTestGR.Name:
+			return &purgeTestGR, nil
+		default:
+			return nil, fmt.Errorf("not found")
+		}
+	}
+
+	tests := []struct {
+		name            string
+		stateSetup      func(state testState)
+		inputObject     *v3.GlobalRoleBinding
+		stateAssertions func(stateChanges testStateChanges)
+		wantError       bool
+	}{
+		{
+			name: "no inherited roles",
+			stateSetup: func(state testState) {
+				state.grListerMock.GetFunc = grListerGetFunc
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "local/test-grb").Return([]*v3.ClusterRoleTemplateBinding{}, nil)
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "not-local/test-grb").Return([]*v3.ClusterRoleTemplateBinding{}, nil).Times(2)
+				state.crtbClientMock.CreateFunc = func(crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+					state.stateChanges.createdCRTBs = append(state.stateChanges.createdCRTBs, crtb)
+					return crtb, nil
+				}
+				state.crtbClientMock.DeleteNamespacedFunc = func(_ string, name string, _ *metav1.DeleteOptions) error {
+					state.stateChanges.deletedCRTBNames = append(state.stateChanges.deletedCRTBNames, name)
+					return nil
+				}
+				state.clusterListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Cluster, error) {
+					return []*v3.Cluster{&notLocalCluster, &localCluster}, nil
+				}
+			},
+			stateAssertions: func(stateChanges testStateChanges) {
+				require.Len(stateChanges.t, stateChanges.createdCRTBs, 0)
+				require.Len(stateChanges.t, stateChanges.deletedCRTBNames, 0)
+			},
+			inputObject: &v3.GlobalRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-grb",
+					UID:  "1234",
+				},
+				GlobalRoleName: noInheritTestGR.Name,
+				UserName:       "test-user",
+			},
+			wantError: false,
+		},
+		{
+			name: "missing inherited roles",
+			stateSetup: func(state testState) {
+				state.grListerMock.GetFunc = grListerGetFunc
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "local/test-grb").Return([]*v3.ClusterRoleTemplateBinding{}, nil)
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "not-local/test-grb").Return([]*v3.ClusterRoleTemplateBinding{}, nil).Times(2)
+				state.crtbClientMock.CreateFunc = func(crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+					state.stateChanges.createdCRTBs = append(state.stateChanges.createdCRTBs, crtb)
+					return crtb, nil
+				}
+				state.crtbClientMock.DeleteNamespacedFunc = func(_ string, name string, _ *metav1.DeleteOptions) error {
+					state.stateChanges.deletedCRTBNames = append(state.stateChanges.deletedCRTBNames, name)
+					return nil
+				}
+				state.clusterListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Cluster, error) {
+					return []*v3.Cluster{&notLocalCluster, &localCluster}, nil
+				}
+			},
+			stateAssertions: func(stateChanges testStateChanges) {
+				require.Len(stateChanges.t, stateChanges.createdCRTBs, 0)
+				require.Len(stateChanges.t, stateChanges.deletedCRTBNames, 0)
+			},
+			inputObject: &v3.GlobalRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-grb",
+					UID:  "1234",
+				},
+				GlobalRoleName: missingInheritTestGR.Name,
+				UserName:       "test-user",
+			},
+			wantError: false,
+		},
+		{
+			name: "inherited cluster roles",
+			stateSetup: func(state testState) {
+				state.grListerMock.GetFunc = grListerGetFunc
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "local/test-grb").Return([]*v3.ClusterRoleTemplateBinding{}, nil)
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "not-local/test-grb").Return([]*v3.ClusterRoleTemplateBinding{}, nil).Times(2)
+				state.crtbClientMock.CreateFunc = func(crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+					state.stateChanges.createdCRTBs = append(state.stateChanges.createdCRTBs, crtb)
+					return crtb, nil
+				}
+				state.crtbClientMock.DeleteNamespacedFunc = func(_ string, name string, _ *metav1.DeleteOptions) error {
+					state.stateChanges.deletedCRTBNames = append(state.stateChanges.deletedCRTBNames, name)
+					return nil
+				}
+				state.clusterListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Cluster, error) {
+					return []*v3.Cluster{&notLocalCluster, &localCluster}, nil
+				}
+			},
+			stateAssertions: func(stateChanges testStateChanges) {
+				require.Len(stateChanges.t, stateChanges.createdCRTBs, 1)
+				require.Len(stateChanges.t, stateChanges.deletedCRTBNames, 0)
+				crtb := stateChanges.createdCRTBs[0]
+				require.Equal(stateChanges.t, "not-local", crtb.ClusterName)
+				require.Equal(stateChanges.t, "not-local", crtb.Namespace)
+				require.Equal(stateChanges.t, "test-grb", crtb.Labels[grbOwnerLabel])
+				require.Equal(stateChanges.t, "test-grb", crtb.Labels[grbOwnerLabel])
+				require.Equal(stateChanges.t, "cluster-owner", crtb.RoleTemplateName)
+				require.Equal(stateChanges.t, "test-user", crtb.UserName)
+				require.Equal(stateChanges.t, "", crtb.GroupPrincipalName)
+				require.Len(stateChanges.t, crtb.OwnerReferences, 1)
+				ownerRef := crtb.OwnerReferences[0]
+				require.Equal(stateChanges.t, "management.cattle.io/v3", ownerRef.APIVersion)
+				require.Equal(stateChanges.t, "GlobalRoleBinding", ownerRef.Kind)
+				require.Equal(stateChanges.t, "test-grb", ownerRef.Name)
+				require.Equal(stateChanges.t, types.UID("1234"), ownerRef.UID)
+			},
+			inputObject: &v3.GlobalRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-grb",
+					UID:  "1234",
+				},
+				GlobalRoleName: inheritedTestGr.Name,
+				UserName:       "test-user",
+			},
+			wantError: false,
+		},
+		{
+			name: "inherited cluster roles, purge innacurate roles",
+			stateSetup: func(state testState) {
+				state.grListerMock.GetFunc = grListerGetFunc
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "local/test-grb").Return([]*v3.ClusterRoleTemplateBinding{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "crtb-grb-already-exists-local",
+							Labels: map[string]string{
+								grbOwnerLabel: "test-grb",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "management.cattle.io/v3",
+									Kind:       "GlobalRoleBinding",
+									UID:        "1234",
+									Name:       "test-grb",
+								},
+							},
+							GenerateName: "crtb-grb-",
+							Namespace:    "local",
+						},
+						RoleTemplateName:   "already-exists",
+						ClusterName:        "local",
+						UserName:           "test-user",
+						GroupPrincipalName: "",
+					},
+				}, nil)
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "not-local/test-grb").Return([]*v3.ClusterRoleTemplateBinding{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "crtb-grb-already-exists",
+							Labels: map[string]string{
+								grbOwnerLabel: "test-grb",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "management.cattle.io/v3",
+									Kind:       "GlobalRoleBinding",
+									UID:        "1234",
+									Name:       "test-grb",
+								},
+							},
+							GenerateName: "crtb-grb-",
+							Namespace:    "not-local",
+						},
+						RoleTemplateName:   "already-exists",
+						ClusterName:        "not-local",
+						UserName:           "test-user",
+						GroupPrincipalName: "",
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "crtb-grb-wrong-cluster-name",
+							Labels: map[string]string{
+								grbOwnerLabel: "test-grb",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "management.cattle.io/v3",
+									Kind:       "GlobalRoleBinding",
+									UID:        "1234",
+									Name:       "test-grb",
+								},
+							},
+							GenerateName: "crtb-grb-",
+							Namespace:    "not-local",
+						},
+						RoleTemplateName:   "wrong-cluster-name",
+						ClusterName:        "does-not-exist",
+						UserName:           "test-user",
+						GroupPrincipalName: "",
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "crtb-grb-wrong-user-name",
+							Labels: map[string]string{
+								grbOwnerLabel: "test-grb",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "management.cattle.io/v3",
+									Kind:       "GlobalRoleBinding",
+									UID:        "1234",
+									Name:       "test-grb",
+								},
+							},
+							GenerateName: "crtb-grb-",
+							Namespace:    "not-local",
+						},
+						RoleTemplateName:   "wrong-user-name",
+						ClusterName:        "not-local",
+						UserName:           "wrong-user",
+						GroupPrincipalName: "",
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "crtb-grb-wrong-group-name",
+							Labels: map[string]string{
+								grbOwnerLabel: "test-grb",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "management.cattle.io/v3",
+									Kind:       "GlobalRoleBinding",
+									UID:        "1234",
+									Name:       "test-grb",
+								},
+							},
+							GenerateName: "crtb-grb-",
+							Namespace:    "not-local",
+						},
+						RoleTemplateName:   "wrong-group-name",
+						ClusterName:        "not-local",
+						UserName:           "test-user",
+						GroupPrincipalName: "wrong-group",
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "crtb-grb-deleting",
+							Labels: map[string]string{
+								grbOwnerLabel: "test-grb",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "management.cattle.io/v3",
+									Kind:       "GlobalRoleBinding",
+									UID:        "1234",
+									Name:       "test-grb",
+								},
+							},
+							GenerateName:      "crtb-grb-",
+							Namespace:         "not-local",
+							DeletionTimestamp: &metav1.Time{Time: time.Now()},
+						},
+						RoleTemplateName:   "deleting",
+						ClusterName:        "not-local",
+						UserName:           "test-user",
+						GroupPrincipalName: "",
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "crtb-grb-duplicate",
+							Labels: map[string]string{
+								grbOwnerLabel: "test-grb",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "management.cattle.io/v3",
+									Kind:       "GlobalRoleBinding",
+									UID:        "1234",
+									Name:       "test-grb",
+								},
+							},
+							GenerateName: "crtb-grb-",
+							Namespace:    "not-local",
+						},
+						RoleTemplateName:   "duplicate",
+						ClusterName:        "not-local",
+						UserName:           "test-user",
+						GroupPrincipalName: "",
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "crtb-grb-duplicate-2",
+							Labels: map[string]string{
+								grbOwnerLabel: "test-grb",
+							},
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: "management.cattle.io/v3",
+									Kind:       "GlobalRoleBinding",
+									UID:        "1234",
+									Name:       "test-grb",
+								},
+							},
+							GenerateName: "crtb-grb-",
+							Namespace:    "not-local",
+						},
+						RoleTemplateName:   "duplicate",
+						ClusterName:        "not-local",
+						UserName:           "test-user",
+						GroupPrincipalName: "",
+					},
+				}, nil).Times(2)
+				state.crtbClientMock.CreateFunc = func(crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+					state.stateChanges.createdCRTBs = append(state.stateChanges.createdCRTBs, crtb)
+					return crtb, nil
+				}
+				state.crtbClientMock.DeleteNamespacedFunc = func(_ string, name string, _ *metav1.DeleteOptions) error {
+					state.stateChanges.deletedCRTBNames = append(state.stateChanges.deletedCRTBNames, name)
+					return nil
+				}
+
+				state.clusterListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Cluster, error) {
+					return []*v3.Cluster{&notLocalCluster, &localCluster}, nil
+				}
+			},
+			stateAssertions: func(stateChanges testStateChanges) {
+				require.Len(stateChanges.t, stateChanges.createdCRTBs, 5)
+				var roleTemplateNames []string
+				for _, crtb := range stateChanges.createdCRTBs {
+					roleTemplateNames = append(roleTemplateNames, crtb.RoleTemplateName)
+					require.Equal(stateChanges.t, "not-local", crtb.ClusterName)
+					require.Equal(stateChanges.t, "not-local", crtb.Namespace)
+					require.Equal(stateChanges.t, "test-grb", crtb.Labels[grbOwnerLabel])
+					require.Equal(stateChanges.t, "test-grb", crtb.Labels[grbOwnerLabel])
+					require.Equal(stateChanges.t, "test-user", crtb.UserName)
+					require.Equal(stateChanges.t, "", crtb.GroupPrincipalName)
+					require.Len(stateChanges.t, crtb.OwnerReferences, 1)
+					ownerRef := crtb.OwnerReferences[0]
+					require.Equal(stateChanges.t, "management.cattle.io/v3", ownerRef.APIVersion)
+					require.Equal(stateChanges.t, "GlobalRoleBinding", ownerRef.Kind)
+					require.Equal(stateChanges.t, "test-grb", ownerRef.Name)
+					require.Equal(stateChanges.t, types.UID("1234"), ownerRef.UID)
+				}
+				require.Contains(stateChanges.t, roleTemplateNames, "missing")
+				require.Contains(stateChanges.t, roleTemplateNames, "wrong-cluster-name")
+				require.Contains(stateChanges.t, roleTemplateNames, "wrong-user-name")
+				require.Contains(stateChanges.t, roleTemplateNames, "wrong-group-name")
+				require.Contains(stateChanges.t, roleTemplateNames, "deleting")
+
+				require.Len(stateChanges.t, stateChanges.deletedCRTBNames, 6)
+				require.Contains(stateChanges.t, stateChanges.deletedCRTBNames, "crtb-grb-wrong-cluster-name")
+				require.Contains(stateChanges.t, stateChanges.deletedCRTBNames, "crtb-grb-wrong-user-name")
+				require.Contains(stateChanges.t, stateChanges.deletedCRTBNames, "crtb-grb-wrong-group-name")
+				require.Contains(stateChanges.t, stateChanges.deletedCRTBNames, "crtb-grb-deleting")
+				require.Contains(stateChanges.t, stateChanges.deletedCRTBNames, "crtb-grb-duplicate-2")
+				require.Contains(stateChanges.t, stateChanges.deletedCRTBNames, "crtb-grb-already-exists-local")
+			},
+			inputObject: &v3.GlobalRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-grb",
+					UID:  "1234",
+				},
+				GlobalRoleName: purgeTestGR.Name,
+				UserName:       "test-user",
+			},
+			wantError: false,
+		},
+		{
+			name: "cluster lister error",
+			stateSetup: func(state testState) {
+				state.grListerMock.GetFunc = grListerGetFunc
+				state.crtbClientMock.CreateFunc = func(crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+					state.stateChanges.createdCRTBs = append(state.stateChanges.createdCRTBs, crtb)
+					return crtb, nil
+				}
+				state.crtbClientMock.DeleteNamespacedFunc = func(_ string, name string, _ *metav1.DeleteOptions) error {
+					state.stateChanges.deletedCRTBNames = append(state.stateChanges.deletedCRTBNames, name)
+					return nil
+				}
+				state.clusterListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Cluster, error) {
+					return nil, fmt.Errorf("server unavailable")
+				}
+			},
+			stateAssertions: func(stateChanges testStateChanges) {
+				require.Len(stateChanges.t, stateChanges.createdCRTBs, 0)
+				require.Len(stateChanges.t, stateChanges.deletedCRTBNames, 0)
+			},
+			inputObject: &v3.GlobalRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-grb",
+					UID:  "1234",
+				},
+				GlobalRoleName: inheritedTestGr.Name,
+				UserName:       "test-user",
+			},
+			wantError: true,
+		},
+		{
+			name: "crtb creation error",
+			stateSetup: func(state testState) {
+				state.grListerMock.GetFunc = grListerGetFunc
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "local/test-grb").Return([]*v3.ClusterRoleTemplateBinding{}, nil)
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "not-local/test-grb").Return([]*v3.ClusterRoleTemplateBinding{}, nil).Times(2)
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "error/test-grb").Return([]*v3.ClusterRoleTemplateBinding{}, nil).Times(2)
+				state.crtbClientMock.CreateFunc = func(crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+					state.stateChanges.createdCRTBs = append(state.stateChanges.createdCRTBs, crtb)
+					if crtb.ClusterName == errorCluster.Name {
+						return nil, fmt.Errorf("server unavailable")
+					}
+					return crtb, nil
+				}
+				state.crtbClientMock.DeleteNamespacedFunc = func(_ string, name string, _ *metav1.DeleteOptions) error {
+					state.stateChanges.deletedCRTBNames = append(state.stateChanges.deletedCRTBNames, name)
+					return nil
+				}
+				state.clusterListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Cluster, error) {
+					return []*v3.Cluster{&errorCluster, &notLocalCluster, &localCluster}, nil
+				}
+			},
+			stateAssertions: func(stateChanges testStateChanges) {
+				require.Len(stateChanges.t, stateChanges.createdCRTBs, 2)
+				var clusterNames []string
+				for _, crtb := range stateChanges.createdCRTBs {
+					clusterNames = append(clusterNames, crtb.ClusterName)
+					require.Equal(stateChanges.t, crtb.ClusterName, crtb.Namespace)
+					require.Equal(stateChanges.t, "cluster-owner", crtb.RoleTemplateName)
+					require.Equal(stateChanges.t, "test-grb", crtb.Labels[grbOwnerLabel])
+					require.Equal(stateChanges.t, "test-grb", crtb.Labels[grbOwnerLabel])
+					require.Equal(stateChanges.t, "test-user", crtb.UserName)
+					require.Equal(stateChanges.t, "", crtb.GroupPrincipalName)
+					require.Len(stateChanges.t, crtb.OwnerReferences, 1)
+					ownerRef := crtb.OwnerReferences[0]
+					require.Equal(stateChanges.t, "management.cattle.io/v3", ownerRef.APIVersion)
+					require.Equal(stateChanges.t, "GlobalRoleBinding", ownerRef.Kind)
+					require.Equal(stateChanges.t, "test-grb", ownerRef.Name)
+					require.Equal(stateChanges.t, types.UID("1234"), ownerRef.UID)
+				}
+				require.Contains(stateChanges.t, clusterNames, notLocalCluster.Name)
+				require.Contains(stateChanges.t, clusterNames, errorCluster.Name)
+				require.Len(stateChanges.t, stateChanges.deletedCRTBNames, 0)
+			},
+			inputObject: &v3.GlobalRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-grb",
+					UID:  "1234",
+				},
+				GlobalRoleName: inheritedTestGr.Name,
+				UserName:       "test-user",
+			},
+			wantError: true,
+		},
+		{
+			name: "indexer error",
+			stateSetup: func(state testState) {
+				state.grListerMock.GetFunc = grListerGetFunc
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "local/test-grb").Return([]*v3.ClusterRoleTemplateBinding{}, nil)
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "not-local/test-grb").Return([]*v3.ClusterRoleTemplateBinding{}, nil).Times(2)
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "error/test-grb").Return(nil, fmt.Errorf("indexer error")).Times(2)
+				state.crtbClientMock.CreateFunc = func(crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+					state.stateChanges.createdCRTBs = append(state.stateChanges.createdCRTBs, crtb)
+					return crtb, nil
+				}
+				state.crtbClientMock.DeleteNamespacedFunc = func(_ string, name string, _ *metav1.DeleteOptions) error {
+					state.stateChanges.deletedCRTBNames = append(state.stateChanges.deletedCRTBNames, name)
+					return nil
+				}
+				state.clusterListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Cluster, error) {
+					return []*v3.Cluster{&errorCluster, &notLocalCluster, &localCluster}, nil
+				}
+			},
+			stateAssertions: func(stateChanges testStateChanges) {
+				require.Len(stateChanges.t, stateChanges.createdCRTBs, 1)
+				crtb := stateChanges.createdCRTBs[0]
+				require.Equal(stateChanges.t, "not-local", crtb.Namespace)
+				require.Equal(stateChanges.t, "not-local", crtb.ClusterName)
+				require.Equal(stateChanges.t, "cluster-owner", crtb.RoleTemplateName)
+				require.Equal(stateChanges.t, "test-grb", crtb.Labels[grbOwnerLabel])
+				require.Equal(stateChanges.t, "test-grb", crtb.Labels[grbOwnerLabel])
+				require.Equal(stateChanges.t, "test-user", crtb.UserName)
+				require.Equal(stateChanges.t, "", crtb.GroupPrincipalName)
+				require.Len(stateChanges.t, crtb.OwnerReferences, 1)
+				ownerRef := crtb.OwnerReferences[0]
+				require.Equal(stateChanges.t, "management.cattle.io/v3", ownerRef.APIVersion)
+				require.Equal(stateChanges.t, "GlobalRoleBinding", ownerRef.Kind)
+				require.Equal(stateChanges.t, "test-grb", ownerRef.Name)
+				require.Equal(stateChanges.t, types.UID("1234"), ownerRef.UID)
+
+				require.Len(stateChanges.t, stateChanges.deletedCRTBNames, 0)
+			},
+			inputObject: &v3.GlobalRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-grb",
+					UID:  "1234",
+				},
+				GlobalRoleName: inheritedTestGr.Name,
+				UserName:       "test-user",
+			},
+			wantError: true,
+		},
+		{
+			name: "crtb delete error",
+			stateSetup: func(state testState) {
+				state.grListerMock.GetFunc = grListerGetFunc
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "local/test-grb").Return([]*v3.ClusterRoleTemplateBinding{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:         "crtb-grb-delete-local",
+							GenerateName: "crtb-grb-",
+							Namespace:    "local",
+						},
+						RoleTemplateName:   "not-valid",
+						ClusterName:        "local",
+						UserName:           "test-user",
+						GroupPrincipalName: "",
+					},
+				}, nil)
+				state.crtbCacheMock.EXPECT().GetByIndex(crtbGrbOwnerIndex, "error/test-grb").Return([]*v3.ClusterRoleTemplateBinding{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:         "crtb-grb-delete",
+							GenerateName: "crtb-grb-",
+							Namespace:    "error",
+						},
+						RoleTemplateName:   "not-valid",
+						ClusterName:        "error",
+						UserName:           "test-user",
+						GroupPrincipalName: "",
+					},
+				}, nil).Times(2)
+				state.crtbClientMock.CreateFunc = func(crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+					state.stateChanges.createdCRTBs = append(state.stateChanges.createdCRTBs, crtb)
+					return crtb, nil
+				}
+				state.crtbClientMock.DeleteNamespacedFunc = func(_ string, name string, _ *metav1.DeleteOptions) error {
+					state.stateChanges.deletedCRTBNames = append(state.stateChanges.deletedCRTBNames, name)
+					if name == "crtb-grb-delete" || name == "crtb-grb-delete-local" {
+						return fmt.Errorf("server unavailable")
+					}
+					return nil
+				}
+				state.clusterListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Cluster, error) {
+					return []*v3.Cluster{&errorCluster, &localCluster}, nil
+				}
+			},
+			stateAssertions: func(stateChanges testStateChanges) {
+				require.Len(stateChanges.t, stateChanges.createdCRTBs, 1)
+				crtb := stateChanges.createdCRTBs[0]
+				require.Equal(stateChanges.t, "error", crtb.Namespace)
+				require.Equal(stateChanges.t, "error", crtb.ClusterName)
+				require.Equal(stateChanges.t, "cluster-owner", crtb.RoleTemplateName)
+				require.Equal(stateChanges.t, "test-grb", crtb.Labels[grbOwnerLabel])
+				require.Equal(stateChanges.t, "test-grb", crtb.Labels[grbOwnerLabel])
+				require.Equal(stateChanges.t, "test-user", crtb.UserName)
+				require.Equal(stateChanges.t, "", crtb.GroupPrincipalName)
+				require.Len(stateChanges.t, crtb.OwnerReferences, 1)
+				ownerRef := crtb.OwnerReferences[0]
+				require.Equal(stateChanges.t, "management.cattle.io/v3", ownerRef.APIVersion)
+				require.Equal(stateChanges.t, "GlobalRoleBinding", ownerRef.Kind)
+				require.Equal(stateChanges.t, "test-grb", ownerRef.Name)
+				require.Equal(stateChanges.t, types.UID("1234"), ownerRef.UID)
+
+				require.Len(stateChanges.t, stateChanges.deletedCRTBNames, 2)
+				require.Contains(stateChanges.t, stateChanges.deletedCRTBNames, "crtb-grb-delete")
+				require.Contains(stateChanges.t, stateChanges.deletedCRTBNames, "crtb-grb-delete-local")
+			},
+			inputObject: &v3.GlobalRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-grb",
+					UID:  "1234",
+				},
+				GlobalRoleName: inheritedTestGr.Name,
+				UserName:       "test-user",
+			},
+			wantError: true,
+		},
+		{
+			name: "no global role",
+			stateSetup: func(state testState) {
+				state.grListerMock.GetFunc = grListerGetFunc
+				state.crtbClientMock.CreateFunc = func(crtb *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+					state.stateChanges.createdCRTBs = append(state.stateChanges.createdCRTBs, crtb)
+					return crtb, nil
+				}
+				state.crtbClientMock.DeleteNamespacedFunc = func(_ string, name string, _ *metav1.DeleteOptions) error {
+					state.stateChanges.deletedCRTBNames = append(state.stateChanges.deletedCRTBNames, name)
+					return nil
+				}
+				state.clusterListerMock.ListFunc = func(namespace string, selector labels.Selector) ([]*v3.Cluster, error) {
+					return []*v3.Cluster{&errorCluster, &notLocalCluster, &localCluster}, nil
+				}
+			},
+			stateAssertions: func(stateChanges testStateChanges) {
+				require.Len(stateChanges.t, stateChanges.createdCRTBs, 0)
+				require.Len(stateChanges.t, stateChanges.deletedCRTBNames, 0)
+			},
+			inputObject: &v3.GlobalRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-grb",
+					UID:  "1234",
+				},
+				GlobalRoleName: "error",
+				UserName:       "test-user",
+			},
+			wantError: true,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			crtbCacheMock := fake.NewMockCacheInterface[*v3.ClusterRoleTemplateBinding](ctrl)
+			grListerMock := fakes.GlobalRoleListerMock{}
+			clusterListerMock := fakes.ClusterListerMock{}
+			crtbClientMock := fakes.ClusterRoleTemplateBindingInterfaceMock{}
+			state := testState{
+				crtbCacheMock:     crtbCacheMock,
+				grListerMock:      &grListerMock,
+				clusterListerMock: &clusterListerMock,
+				crtbClientMock:    &crtbClientMock,
+				stateChanges: &testStateChanges{
+					t:                t,
+					createdCRTBs:     []*v3.ClusterRoleTemplateBinding{},
+					deletedCRTBNames: []string{},
+				},
+			}
+			if test.stateSetup != nil {
+				test.stateSetup(state)
+			}
+			grbLifecycle := globalRoleBindingLifecycle{
+				grLister:      &grListerMock,
+				crtbCache:     crtbCacheMock,
+				clusterLister: &clusterListerMock,
+				crtbClient:    &crtbClientMock,
+			}
+			resErr := grbLifecycle.reconcileClusterPermissions(test.inputObject)
+			if test.wantError {
+				require.Error(t, resErr)
+			} else {
+				require.NoError(t, resErr)
+			}
+			if test.stateAssertions != nil {
+				test.stateAssertions(*state.stateChanges)
+			}
+		})
+	}
+
+}

--- a/pkg/controllers/management/auth/globalroles/register.go
+++ b/pkg/controllers/management/auth/globalroles/register.go
@@ -1,0 +1,31 @@
+package globalroles
+
+import (
+	"context"
+
+	"github.com/rancher/rancher/pkg/clustermanager"
+	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/rancher/wrangler/pkg/relatedresource"
+)
+
+const (
+	grController  = "mgmt-auth-gr-controller"
+	grbController = "mgmt-auth-grb-controller"
+)
+
+func Register(ctx context.Context, management *config.ManagementContext, clusterManager *clustermanager.Manager) {
+	management.Wrangler.Mgmt.GlobalRoleBinding().Cache().AddIndexer(grbGrIndex, grbGrIndexer)
+	enqueuer := globalRBACEnqueuer{
+		grbCache:      management.Wrangler.Mgmt.GlobalRoleBinding().Cache(),
+		grCache:       management.Wrangler.Mgmt.GlobalRole().Cache(),
+		clusterClient: management.Wrangler.Mgmt.Cluster(),
+	}
+	relatedresource.WatchClusterScoped(ctx, grbEnqueuer, enqueuer.enqueueGRBs, management.Wrangler.Mgmt.GlobalRoleBinding(), management.Wrangler.Mgmt.GlobalRole())
+	relatedresource.WatchClusterScoped(ctx, clusterGrEnqueuer, enqueuer.clusterEnqueueGRs, management.Wrangler.Mgmt.GlobalRole(), management.Wrangler.Mgmt.Cluster())
+	relatedresource.WatchClusterScoped(ctx, crtbGRBEnqueuer, enqueuer.crtbEnqueueGRB, management.Wrangler.Mgmt.GlobalRoleBinding(), management.Wrangler.Mgmt.ClusterRoleTemplateBinding())
+
+	gr := newGlobalRoleLifecycle(management.WithAgent(grController))
+	grb := newGlobalRoleBindingLifecycle(management.WithAgent(grbController), clusterManager)
+	management.Management.GlobalRoles("").AddLifecycle(ctx, grController, gr)
+	management.Management.GlobalRoleBindings("").AddLifecycle(ctx, grbController, grb)
+}

--- a/pkg/controllers/management/auth/role_template_lifecycle.go
+++ b/pkg/controllers/management/auth/role_template_lifecycle.go
@@ -83,7 +83,7 @@ func (rtl *roleTemplateLifecycle) Remove(obj *v3.RoleTemplate) (runtime.Object, 
 		userContext, err := rtl.clusterManager.UserContext(cluster.Name)
 		if err != nil {
 			// ClusterUnavailable error indicates the record can't talk to the downstream cluster
-			if !IsClusterUnavailable(err) {
+			if !clustermanager.IsClusterUnavailableErr(err) {
 				allErrors = append(allErrors, err)
 			}
 			continue

--- a/pkg/controllers/options.go
+++ b/pkg/controllers/options.go
@@ -14,9 +14,11 @@ import (
 type controllerContextType string
 
 const (
-	User       controllerContextType = "user"
-	Scaled     controllerContextType = "scaled"
-	Management controllerContextType = "mgmt"
+	User            controllerContextType = "user"
+	Scaled          controllerContextType = "scaled"
+	Management      controllerContextType = "mgmt"
+	K8sManagedByKey                       = "app.kubernetes.io/managed-by"
+	ManagerValue                          = "rancher"
 )
 
 // GetOptsFromEnv configures a SharedControllersFactoryOptions using env var and return a pointer to it.

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_global_role.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_global_role.go
@@ -5,35 +5,37 @@ import (
 )
 
 const (
-	GlobalRoleType                 = "globalRole"
-	GlobalRoleFieldAnnotations     = "annotations"
-	GlobalRoleFieldBuiltin         = "builtin"
-	GlobalRoleFieldCreated         = "created"
-	GlobalRoleFieldCreatorID       = "creatorId"
-	GlobalRoleFieldDescription     = "description"
-	GlobalRoleFieldLabels          = "labels"
-	GlobalRoleFieldName            = "name"
-	GlobalRoleFieldNewUserDefault  = "newUserDefault"
-	GlobalRoleFieldOwnerReferences = "ownerReferences"
-	GlobalRoleFieldRemoved         = "removed"
-	GlobalRoleFieldRules           = "rules"
-	GlobalRoleFieldUUID            = "uuid"
+	GlobalRoleType                       = "globalRole"
+	GlobalRoleFieldAnnotations           = "annotations"
+	GlobalRoleFieldBuiltin               = "builtin"
+	GlobalRoleFieldCreated               = "created"
+	GlobalRoleFieldCreatorID             = "creatorId"
+	GlobalRoleFieldDescription           = "description"
+	GlobalRoleFieldInheritedClusterRoles = "inheritedClusterRoles"
+	GlobalRoleFieldLabels                = "labels"
+	GlobalRoleFieldName                  = "name"
+	GlobalRoleFieldNewUserDefault        = "newUserDefault"
+	GlobalRoleFieldOwnerReferences       = "ownerReferences"
+	GlobalRoleFieldRemoved               = "removed"
+	GlobalRoleFieldRules                 = "rules"
+	GlobalRoleFieldUUID                  = "uuid"
 )
 
 type GlobalRole struct {
 	types.Resource
-	Annotations     map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Builtin         bool              `json:"builtin,omitempty" yaml:"builtin,omitempty"`
-	Created         string            `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID       string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	Description     string            `json:"description,omitempty" yaml:"description,omitempty"`
-	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Name            string            `json:"name,omitempty" yaml:"name,omitempty"`
-	NewUserDefault  bool              `json:"newUserDefault,omitempty" yaml:"newUserDefault,omitempty"`
-	OwnerReferences []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	Removed         string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	Rules           []PolicyRule      `json:"rules,omitempty" yaml:"rules,omitempty"`
-	UUID            string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Annotations           map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Builtin               bool              `json:"builtin,omitempty" yaml:"builtin,omitempty"`
+	Created               string            `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID             string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Description           string            `json:"description,omitempty" yaml:"description,omitempty"`
+	InheritedClusterRoles []string          `json:"inheritedClusterRoles,omitempty" yaml:"inheritedClusterRoles,omitempty"`
+	Labels                map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name                  string            `json:"name,omitempty" yaml:"name,omitempty"`
+	NewUserDefault        bool              `json:"newUserDefault,omitempty" yaml:"newUserDefault,omitempty"`
+	OwnerReferences       []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Removed               string            `json:"removed,omitempty" yaml:"removed,omitempty"`
+	Rules                 []PolicyRule      `json:"rules,omitempty" yaml:"rules,omitempty"`
+	UUID                  string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }
 
 type GlobalRoleCollection struct {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
#42213
 
## Overview
This introduces a new field on GlobalRoles - `InheritedClusterRoles`, as well as the controllers for this field.

Note that a complete solution will require webhook changes to prevent privilege escalation and manipulation of key labels. This will be addressed as part of a separate issue (#42214).
 
## Solution

Fields:
- `InheritedClusterRoles` - Roles granted in every cluster (except the local cluster). Each role specified here results in one CRTB from the subject of the GRB to the specified role for every cluster (besides the local cluster). 

### Controller Functionality
Controllers/related functionality was implemented for the `InheritedClusterRoles` field which has the following basic funcitonality:
- The primary controller is on the `GlobalRoleBinding` object (since this field results in CRTBs, we can't orchestrate new objects until we get a binding specifying a subject).
- This functionality activates on create and update (but not delete)
- First, the controller checks the associated globalRole that the binding is giving to see if it has any inheritedClusterRoles. If not, we exit early
- The controller then lists all mgmt clusters. For each cluster, it follows the following process:
  - It lists all current CRTBs which are owned by this GRB (using an indexer which uses a ownerLabel and the name of the cluster as the key)
  - For each CRTB, it checks if the CRTB represents a requested roleTemplate (meaning it refers to a role defined in the GR's `InheritedClusterRole` fields for all clusters besides local - for the local cluster no roleTemplates are valid), and if it is up to date (meaning it is for the correct cluster, is not deleting, and is for the correct user/group)
  - Each CRTB that is not for a represented roleTemplate or is not up to date is deleted
  -  If this cluster is the "local" cluster (by name) we move on 
  - For each RoleTemplate that is not covered by an up-do-date CRTB (but was requested in the `InheritedClusterRoles` field), we create a CRTB using an owner ref linking the CRTB to the GRB, and a label linking the CRTB to the GRB (the label, `authz.management.cattle.io/grb-owner`, will be protected by the webhook and used to identify CRTBs which are linked to GRBs - we can't use owner references for this since k8s needs to be able to remove this owner ref when cleaning up the object). In addition, the same user/group as is specified on the GRB is used for the CRTB.
  - If the creation of the CRTB fails, we skip to the next CRTB and warn about the event. This will cause the handler to return an error which will re-enqueue the GRB, but we still attempt to make every CRTB
  - If we can't purge the current roles or determine what CRTBs to create, we skip that cluster but will attempt to evaluate the other clusters

### Enqueuer

A new object, the globalRBACEnqueuer, was created to ensure that updates to this functionality will propagate as intended. It has 3 main functions:
-  First, if a GlobalRole which inherits any cluster roles is changed, all GRBs referring to that role are enqueued. This is to ensure that if a new permission is added to the `InheritedClusterRole` field, all active assignments are updated with the new permissions.
- Second, if a cluster is created, all GlobalRoles which inherit any cluster roles are enqueued. This will, in turn, enqueue the GRBs, and ensure that permissions are synced to the new cluster. The cluster object is updated with an annotation after so that it will not constantly re-enqueue all of these objects, which is a costly operation.
- Third, if a CRTB which is owned by a GRB is updated, the owning GRB is enqueued. This is done to prevent users from revoking global permission by deleting backing CRTB resources. 

### Other Changes

Some of the GlobalRole/GlobalRoleBinding functionality was moved into a dedicated `globalroles` package, to support cleaner code organization.

## Engineering Testing
### Manual Testing

Basic testing to ensure permissions sync and enqueue functionality worked as intended.

### Automated Testing

Unit tests were added for net-new code in the globalroles package.