### PR TITLE
Add unit tests for LDAP auth provider

### DIFF
--- a/pkg/auth/providers/common/ldap/ldap_util.go
+++ b/pkg/auth/providers/common/ldap/ldap_util.go
@@ -170,7 +170,7 @@ func GetGroupSearchAttributesForLDAP(ObjectClass string, config *v3.LdapConfig) 
 	return groupSeachAttributes
 }
 
-func AuthenticateServiceAccountUser(serviceAccountPassword string, serviceAccountUsername string, defaultLoginDomain string, lConn *ldapv3.Conn) error {
+func AuthenticateServiceAccountUser(serviceAccountPassword string, serviceAccountUsername string, defaultLoginDomain string, lConn ldapv3.Client) error {
 	logrus.Debug("Binding service account username password")
 	if serviceAccountPassword == "" {
 		return httperror.NewAPIError(httperror.MissingRequired, "service account password not provided")
@@ -245,7 +245,7 @@ func AttributesToPrincipal(attribs []*ldapv3.EntryAttribute, dnStr, scope, provi
 	return principal, nil
 }
 
-func GatherParentGroups(groupPrincipal v3.Principal, searchDomain string, groupScope string, config *ConfigAttributes, lConn *ldapv3.Conn,
+func GatherParentGroups(groupPrincipal v3.Principal, searchDomain string, groupScope string, config *ConfigAttributes, lConn ldapv3.Client,
 	groupMap map[string]bool, nestedGroupPrincipals *[]v3.Principal, searchAttributes []string) error {
 	groupMap[groupPrincipal.ObjectMeta.Name] = true
 	principals := []v3.Principal{}

--- a/pkg/auth/providers/ldap/ldap_actions.go
+++ b/pkg/auth/providers/ldap/ldap_actions.go
@@ -78,7 +78,14 @@ func (p *ldapProvider) testAndApply(actionName string, action *types.Action, req
 	if len(config.Servers) < 1 {
 		return httperror.NewAPIError(httperror.InvalidBodyContent, "must supply a server")
 	}
-	userPrincipal, groupPrincipals, err := p.loginUser(login, config, caPool)
+
+	lConn, err := ldap.Connect(config, caPool)
+	if err != nil {
+		return err
+	}
+	defer lConn.Close()
+
+	userPrincipal, groupPrincipals, err := p.loginUser(lConn, login, config, caPool)
 	if err != nil {
 		return err
 	}
@@ -101,7 +108,7 @@ func (p *ldapProvider) testAndApply(actionName string, action *types.Action, req
 }
 
 func (p *ldapProvider) saveLDAPConfig(config *v3.LdapConfig) error {
-	storedConfig, _, err := p.getLDAPConfig()
+	storedConfig, _, err := p.getLDAPConfig(p.authConfigs.ObjectClient().UnstructuredClient())
 	if err != nil {
 		return err
 	}

--- a/pkg/auth/providers/ldap/ldap_client_test.go
+++ b/pkg/auth/providers/ldap/ldap_client_test.go
@@ -1,0 +1,323 @@
+package ldap
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"reflect"
+	"testing"
+	"time"
+
+	ldapv3 "github.com/go-ldap/ldap/v3"
+	"github.com/pkg/errors"
+
+	"github.com/rancher/norman/types"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/tokens"
+	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/user"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	DummySAUsername     = "satestuser1"
+	DummySAUPassword    = "sapassword123"
+	UserObjectClassName = "inetOrgPerson"
+)
+
+func Test_ldapProvider_loginUser(t *testing.T) {
+	type fields struct {
+		ctx                   context.Context
+		authConfigs           v3.AuthConfigInterface
+		secrets               corev1.SecretInterface
+		userMGR               mockUserManager
+		tokenMGR              *tokens.Manager
+		certs                 string
+		caPool                *x509.CertPool
+		providerName          string
+		testAndApplyInputType string
+		userScope             string
+		groupScope            string
+	}
+	type args struct {
+		lConn      ldapv3.Client
+		credential *v32.BasicLogin
+		config     *v3.LdapConfig
+		caPool     *x509.CertPool
+	}
+	tests := []struct {
+		name                string
+		fields              fields
+		args                args
+		wantUserPrincipal   v3.Principal
+		wantGroupPrincipals []v3.Principal
+		wantErr             bool
+	}{
+		{
+			name: "successful user login",
+			fields: fields{
+				userMGR: mockUserManager{
+					hasAccess: true,
+				},
+				tokenMGR:   &tokens.Manager{},
+				caPool:     &x509.CertPool{},
+				userScope:  "providername_user",
+				groupScope: "providername_group",
+			},
+			args: args{
+				lConn: newMockLdapConnClient(),
+				credential: &v32.BasicLogin{
+					Username: DummyUsername,
+					Password: DummyPassword,
+				},
+				config: &v3.LdapConfig{
+					LdapFields: v32.LdapFields{
+						ServiceAccountDistinguishedName: DummySAUsername,
+						ServiceAccountPassword:          DummySAUPassword,
+						UserObjectClass:                 UserObjectClassName,
+					},
+				},
+				caPool: &x509.CertPool{},
+			},
+			wantUserPrincipal: v3.Principal{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "providername_user://ldap.test.domain",
+				},
+				PrincipalType: "user",
+				Me:            true,
+			},
+			wantGroupPrincipals: []v3.Principal{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "providername_group://ldap.test.domain",
+					},
+					PrincipalType: "user",
+					Me:            true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "user login with invalid credentials",
+			fields: fields{
+				userMGR: mockUserManager{
+					hasAccess: false,
+				},
+				tokenMGR:   &tokens.Manager{},
+				caPool:     &x509.CertPool{},
+				userScope:  "providername_user",
+				groupScope: "providername_group",
+			},
+			args: args{
+				lConn: &mockLdapConn{
+					canAuthenticate: false,
+				},
+				credential: &v32.BasicLogin{
+					Username: DummyUsername,
+					Password: DummyPassword,
+				},
+				config: &v3.LdapConfig{
+					LdapFields: v32.LdapFields{
+						ServiceAccountDistinguishedName: DummySAUsername,
+						ServiceAccountPassword:          DummySAUPassword,
+						UserObjectClass:                 UserObjectClassName,
+					},
+				},
+				caPool: &x509.CertPool{},
+			},
+			wantUserPrincipal:   v3.Principal{},
+			wantGroupPrincipals: nil,
+			wantErr:             true,
+		},
+		{
+			name: "user login without access permissions",
+			fields: fields{
+				userMGR: mockUserManager{
+					hasAccess: false,
+				},
+				tokenMGR:   &tokens.Manager{},
+				caPool:     &x509.CertPool{},
+				userScope:  "providername_user",
+				groupScope: "providername_group",
+			},
+			args: args{
+				lConn: newMockLdapConnClient(),
+				credential: &v32.BasicLogin{
+					Username: DummyUsername,
+					Password: DummyPassword,
+				},
+				config: &v3.LdapConfig{
+					LdapFields: v32.LdapFields{
+						ServiceAccountDistinguishedName: DummySAUsername,
+						ServiceAccountPassword:          DummySAUPassword,
+						UserObjectClass:                 UserObjectClassName,
+					},
+				},
+				caPool: &x509.CertPool{},
+			},
+			wantUserPrincipal:   v3.Principal{},
+			wantGroupPrincipals: nil,
+			wantErr:             true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &ldapProvider{
+				ctx:                   tt.fields.ctx,
+				authConfigs:           tt.fields.authConfigs,
+				secrets:               tt.fields.secrets,
+				userMGR:               tt.fields.userMGR,
+				tokenMGR:              tt.fields.tokenMGR,
+				certs:                 tt.fields.certs,
+				caPool:                tt.fields.caPool,
+				providerName:          tt.fields.providerName,
+				testAndApplyInputType: tt.fields.testAndApplyInputType,
+				userScope:             tt.fields.userScope,
+				groupScope:            tt.fields.groupScope,
+			}
+			gotUserPrincipal, gotGroupPrincipals, err := p.loginUser(tt.args.lConn, tt.args.credential, tt.args.config, tt.args.caPool)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ldapProvider.loginUser() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotUserPrincipal, tt.wantUserPrincipal) {
+				t.Errorf("ldapProvider.loginUser() got = %v, want %v", gotUserPrincipal, tt.wantUserPrincipal)
+			}
+			if !reflect.DeepEqual(gotGroupPrincipals, tt.wantGroupPrincipals) {
+				t.Errorf("ldapProvider.loginUser() got1 = %v, want %v", gotGroupPrincipals, tt.wantGroupPrincipals)
+			}
+		})
+	}
+}
+
+type mockLdapConn struct {
+	SimpleBindResponse     *ldapv3.SimpleBindResult
+	PasswordModifyResponse *ldapv3.PasswordModifyResult
+	SearchResponse         *ldapv3.SearchResult
+	canAuthenticate        bool
+}
+
+func (m mockLdapConn) Start() {
+	panic("unimplemented")
+}
+func (m mockLdapConn) StartTLS(*tls.Config) error {
+	panic("unimplemented")
+}
+func (m mockLdapConn) Close() {
+	panic("unimplemented")
+}
+func (m mockLdapConn) IsClosing() bool {
+	panic("unimplemented")
+}
+func (m mockLdapConn) SetTimeout(time.Duration) {
+	panic("unimplemented")
+}
+func (m mockLdapConn) Bind(username, password string) error {
+	if !m.canAuthenticate {
+		return ldapv3.NewError(ldapv3.LDAPResultInvalidCredentials, errors.New("ldap: invalid credentials"))
+	}
+	return nil
+}
+func (m mockLdapConn) UnauthenticatedBind(username string) error {
+	panic("unimplemented")
+}
+func (m mockLdapConn) SimpleBind(*ldapv3.SimpleBindRequest) (*ldapv3.SimpleBindResult, error) {
+	panic("unimplemented")
+}
+func (m mockLdapConn) ExternalBind() error {
+	panic("unimplemented")
+}
+func (m mockLdapConn) Add(*ldapv3.AddRequest) error {
+	panic("unimplemented")
+}
+func (m mockLdapConn) Del(*ldapv3.DelRequest) error {
+	panic("unimplemented")
+}
+func (m mockLdapConn) Modify(*ldapv3.ModifyRequest) error {
+	panic("unimplemented")
+}
+func (m mockLdapConn) ModifyDN(*ldapv3.ModifyDNRequest) error {
+	panic("unimplemented")
+}
+func (m mockLdapConn) ModifyWithResult(*ldapv3.ModifyRequest) (*ldapv3.ModifyResult, error) {
+	panic("unimplemented")
+}
+func (m mockLdapConn) Compare(dn, attribute, value string) (bool, error) {
+	panic("unimplemented")
+}
+func (m mockLdapConn) PasswordModify(*ldapv3.PasswordModifyRequest) (*ldapv3.PasswordModifyResult, error) {
+	panic("unimplemented")
+}
+func (m mockLdapConn) Search(*ldapv3.SearchRequest) (*ldapv3.SearchResult, error) {
+	return m.SearchResponse, nil
+}
+func (m mockLdapConn) SearchWithPaging(searchRequest *ldapv3.SearchRequest, pagingSize uint32) (*ldapv3.SearchResult, error) {
+	return m.SearchResponse, nil
+}
+
+func newMockLdapConnClient() *mockLdapConn {
+	return &mockLdapConn{
+		SimpleBindResponse: &ldapv3.SimpleBindResult{
+			Controls: []ldapv3.Control{},
+		},
+		PasswordModifyResponse: &ldapv3.PasswordModifyResult{
+			GeneratedPassword: "",
+		},
+		SearchResponse: &ldapv3.SearchResult{
+			Entries: []*ldapv3.Entry{
+				{
+					DN: "ldap.test.domain",
+					Attributes: []*ldapv3.EntryAttribute{
+						{
+							Name:   "objectclass",
+							Values: []string{UserObjectClassName},
+						},
+					},
+				},
+			},
+			Referrals: []string{},
+			Controls:  []ldapv3.Control{},
+		},
+		canAuthenticate: true,
+	}
+}
+
+type mockUserManager struct {
+	hasAccess bool
+}
+
+func (m mockUserManager) SetPrincipalOnCurrentUser(apiContext *types.APIContext, principal v3.Principal) (*v3.User, error) {
+	panic("unimplemented")
+}
+func (m mockUserManager) GetUser(apiContext *types.APIContext) string {
+	panic("unimplemented")
+}
+func (m mockUserManager) EnsureToken(input user.TokenInput) (string, error) {
+	panic("unimplemented")
+}
+func (m mockUserManager) EnsureClusterToken(clusterName string, input user.TokenInput) (string, error) {
+	panic("unimplemented")
+}
+func (m mockUserManager) DeleteToken(tokenName string) error {
+	panic("unimplemented")
+}
+func (m mockUserManager) EnsureUser(principalName, displayName string) (*v3.User, error) {
+	panic("unimplemented")
+}
+func (m mockUserManager) CheckAccess(accessMode string, allowedPrincipalIDs []string, userPrincipalID string, groups []v3.Principal) (bool, error) {
+	return m.hasAccess, nil
+}
+func (m mockUserManager) SetPrincipalOnCurrentUserByUserID(userID string, principal v3.Principal) (*v3.User, error) {
+	panic("unimplemented")
+}
+func (m mockUserManager) CreateNewUserClusterRoleBinding(userName string, userUID apitypes.UID) error {
+	panic("unimplemented")
+}
+func (m mockUserManager) GetUserByPrincipalID(principalName string) (*v3.User, error) {
+	panic("unimplemented")
+}
+func (m mockUserManager) GetKubeconfigToken(clusterName, tokenName, description, kind, userName string, userPrincipal v3.Principal) (*v3.Token, string, error) {
+	panic("unimplemented")
+}

--- a/pkg/auth/providers/ldap/ldap_provider_test.go
+++ b/pkg/auth/providers/ldap/ldap_provider_test.go
@@ -1,0 +1,199 @@
+package ldap
+
+import (
+	"context"
+	"crypto/x509"
+	"reflect"
+	"testing"
+
+	"github.com/rancher/norman/objectclient"
+	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/tokens"
+	corev1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/user"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+var (
+	DummyCerts    = "dummycerts"
+	DummyUsername = "testuser1"
+	DummyPassword = "testuser1"
+)
+
+func Test_getBasicLogin(t *testing.T) {
+	type args struct {
+		input interface{}
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantLogin *v32.BasicLogin
+		wantErr   bool
+	}{
+		{
+			name: "good input credentials",
+			args: args{
+				input: &v32.BasicLogin{
+					Username: DummyUsername,
+					Password: DummyPassword,
+				},
+			},
+			wantLogin: &v32.BasicLogin{
+				Username: DummyUsername,
+				Password: DummyPassword,
+			},
+			wantErr: false,
+		},
+		{
+			name: "bad input credentials",
+			args: args{
+				input: "badinput",
+			},
+			wantLogin: &v32.BasicLogin{},
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLogin, err := toBasicLogin(tt.args.input)
+			if err != nil {
+				if tt.wantErr {
+					assert.Errorf(t, err, "unexpected input type")
+				} else {
+					t.Errorf("toBasicLogin() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			if !reflect.DeepEqual(gotLogin, tt.wantLogin) {
+				t.Errorf("toBasicLogin() = %v, want %v", gotLogin, tt.wantLogin)
+			}
+		})
+	}
+}
+
+func Test_ldapProvider_getLDAPConfig(t *testing.T) {
+	type fields struct {
+		ctx                   context.Context
+		authConfigs           v3.AuthConfigInterface
+		secrets               corev1.SecretInterface
+		userMGR               user.Manager
+		tokenMGR              *tokens.Manager
+		certs                 string
+		caPool                *x509.CertPool
+		providerName          string
+		testAndApplyInputType string
+		userScope             string
+		groupScope            string
+		mockGenericClient     mockGenericClient
+	}
+	tests := []struct {
+		name                 string
+		fields               fields
+		wantStoredLdapConfig *v3.LdapConfig
+		wantCaPool           *x509.CertPool
+		wantErr              bool
+	}{
+		{
+			name: "get LDAP config object",
+			fields: fields{
+				caPool: x509.NewCertPool(),
+				certs:  DummyCerts,
+			},
+			wantStoredLdapConfig: &v3.LdapConfig{
+				LdapFields: v32.LdapFields{
+					Certificate: DummyCerts,
+				},
+			},
+			wantCaPool: x509.NewCertPool(),
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &ldapProvider{
+				ctx:                   tt.fields.ctx,
+				authConfigs:           tt.fields.authConfigs,
+				secrets:               tt.fields.secrets,
+				userMGR:               tt.fields.userMGR,
+				tokenMGR:              tt.fields.tokenMGR,
+				certs:                 tt.fields.certs,
+				caPool:                tt.fields.caPool,
+				providerName:          tt.fields.providerName,
+				testAndApplyInputType: tt.fields.testAndApplyInputType,
+				userScope:             tt.fields.userScope,
+				groupScope:            tt.fields.groupScope,
+			}
+			gotStoredLdapConfig, gotCaPool, err := p.getLDAPConfig(tt.fields.mockGenericClient)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ldapProvider.getLDAPConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotStoredLdapConfig, tt.wantStoredLdapConfig) {
+				t.Errorf("ldapProvider.getLDAPConfig() got = %v, want %v", gotStoredLdapConfig, tt.wantStoredLdapConfig)
+			}
+			if !reflect.DeepEqual(gotCaPool, tt.wantCaPool) {
+				t.Errorf("ldapProvider.getLDAPConfig() got1 = %v, want %v", gotCaPool, tt.wantCaPool)
+			}
+		})
+	}
+}
+
+type mockGenericClient struct{}
+
+func (m mockGenericClient) UnstructuredClient() objectclient.GenericClient {
+	panic("unimplemented")
+}
+func (m mockGenericClient) GroupVersionKind() schema.GroupVersionKind {
+	panic("unimplemented")
+}
+func (m mockGenericClient) Create(o runtime.Object) (runtime.Object, error) {
+	panic("unimplemented")
+}
+func (m mockGenericClient) GetNamespaced(namespace, name string, opts metav1.GetOptions) (runtime.Object, error) {
+	panic("unimplemented")
+}
+func (m mockGenericClient) Get(name string, opts metav1.GetOptions) (runtime.Object, error) {
+	u := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"Certificate": DummyCerts,
+		},
+	}
+	return u, nil
+}
+func (m mockGenericClient) Update(name string, o runtime.Object) (runtime.Object, error) {
+	panic("unimplemented")
+}
+func (m mockGenericClient) UpdateStatus(name string, o runtime.Object) (runtime.Object, error) {
+	panic("unimplemented")
+}
+func (m mockGenericClient) DeleteNamespaced(namespace, name string, opts *metav1.DeleteOptions) error {
+	panic("unimplemented")
+}
+func (m mockGenericClient) Delete(name string, opts *metav1.DeleteOptions) error {
+	panic("unimplemented")
+}
+func (m mockGenericClient) List(opts metav1.ListOptions) (runtime.Object, error) {
+	panic("unimplemented")
+}
+func (m mockGenericClient) ListNamespaced(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
+	panic("unimplemented")
+}
+func (m mockGenericClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	panic("unimplemented")
+}
+func (m mockGenericClient) DeleteCollection(deleteOptions *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	panic("unimplemented")
+}
+func (m mockGenericClient) Patch(name string, o runtime.Object, patchType types.PatchType, data []byte, subresources ...string) (runtime.Object, error) {
+	panic("unimplemented")
+}
+func (m mockGenericClient) ObjectFactory() objectclient.ObjectFactory {
+	panic("unimplemented")
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rancher/issues/42324

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Need unit tests for LDAP auth provider. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Initially the idea was to write a basic unit test for the AuthenticateUser function as we identified it to be a good start point, but after exploring multiple approaches this was not possible for several reasons. One being a higher level interface all providers belong to prevents me from modifying the function signature (to inject mocks) without significant refactoring and the codebase structure in general is very limiting because many of our functions have multiple responsibilities. Instead, I implemented unit tests for the inner functions that make up the important logic within AuthenticateUser.

Some minor refactoring was necessary in order to mock some structures successfully.
1. Functions taking in an ldap connection struct were updated to take in an ldap client interface instead to allow for mocking the ldap connection calls.
2. The Connect function that initiates the ldap connection was moved outside of the loginUser function as it was easier to do this and pass in the connection than trying to mock the function call.
3. The getLDAPConfig function now expects a UnstructureClient argument. This was necessary to be able to mock CRUD calls (in this case a Get call inside the function). The UnstructuredClient is an interface whereas the ObjectClient is not, so the cleaner approach was to use the UnstructuredClient as the parameter.

## Engineering Testing
Steps I followed to test this changes in Rancher v2.7-head f308df3a69e763951f16ef8d5934393571ddea10
1. Enable FreeIPA auth provider
2. Log out of Rancher
3. Log in using a FreeIPA user

## QA Testing Considerations
See Regressions Considerations below

## Regressions Considerations
The changes I made passed a basic test of enabling FreeIPA and logging in as a FreeIPA user, but a change like switching from a struct pointer parameter to an interface could potentially introduce edge cases. This should be further tested by QA to make sure all the basic functionality provided by LDAP based auth providers works as intended. 
