### PR TITLE
Add GUID unmigration script to revert Active Directory user modifications in v2.7.5

### DIFF
--- a/cleanup/ad-guid-README.md
+++ b/cleanup/ad-guid-README.md
@@ -1,0 +1,65 @@
+# Active Directory GUID -> DN reverse migration utility
+
+**It is recommended to take a snapshot of Rancher before performing this in the event that a restore is required.**
+
+
+## Critical Notes
+* This script will delete and recreate CRTBs/PRTBs/GRBs, which may cause issues with tools (like terraform) which maintain external state.  The original object names are stored in an annotation on the new objects.
+* It is recommended to use this script on Rancher v2.7.6 - running this on v2.7.5 may produce performance issues
+* This script requires that the Active Directory service account has permissions to read all users known to Rancher.
+
+
+## Purpose
+
+In order to reverse the effects of migrating Active Directory principalIDs to be based on GUID rather than DN this
+utility is required.  It can be run manually via Rancher Agent, or it will automatically run inside Rancher at startup
+time if no previous run is detected.  
+This utility will:
+* Remove any users that were duplicated during the original migration toward GUID-based principalIDs in Rancher 2.7.5
+* Update objects that referenced a GUID-based principalID to reference the correct distinguished name based principalID
+
+
+## Detailed description
+
+This utility will go through all Rancher users and perform an Active Directory lookup using the configured service account to
+get the user's distinguished name.  Next, it will perform lookups inside Rancher for all the user's Tokens,
+ClusterRoleTemplateBindings, ProjectRoleTemplateBindings, and GlobalRoleBindings.  If any of those objects, including the user object
+itself are referencing a principalID based on the GUID of that user, those objects will be updated to reference
+the distinguished name-based principalID (unless the utility is run with -dry-run, in that case the only results
+are log messages indicating the changes that would be made by a run without that flag).
+
+This utility will also detect and correct the case where a single ActiveDirectory GUID is mapped to multiple Rancher
+users.  That condition was likely caused by a race in the original migration to use GUIDs and resulted in a second
+Rancher user being created.  This caused Rancher logins to fail for the duplicated user.  The utility remedies
+that situation by mapping any tokens and bindings to the original user before removing the newer user, which was
+created in error.
+
+
+## Requirements
+
+A Rancher environment that has Active Directory set up as the authentication provider.  For any environment where
+Active Directory is not the authentication provider, this utility will take no action and will exit immediately.
+
+
+## Usage via Rancher Agent
+
+```bash
+./ad-guid-unmigration.sh <AGENT IMAGE> [--dry-run] [--delete-missing]
+```
+*  The Agent image can be found at: docker.io/rancher/rancher-agent:v2.7.6
+*  The --dry-run flag will run the migration utility, but no changes to Rancher data will take place.  The potential changes will be indicated in the log file.
+*  The --delete-missing flag will delete Rancher users that can not be found by looking them up in Active Directory. If --dry-run is set, that will prevent users from being deleted regardless of this flag.
+
+
+## Additional notes
+*  The utility will create a configmap named `ad-guid-migration` in the `cattle-system` namespace.  This configmap contains
+   a data entry with a key named "ad-guid-migration-status".  If the utility is currently active, that status will be
+   set to "Running".  After the utility has completed, the status will be set to "Finished".  If a run is interrupted
+   prior to completion, that configmap will retain the status of "Running" and subsequent attempts to run the script will
+   immediately exit.  In order to allow it to run again, you can either edit the configmap to remove that key or you can
+   delete the configmap entirely.
+
+*  When migrating ClusterRoleTemplateBindings, ProjectRoleTemplateBindings, and GlobalRoleBindings it is necessary to perform the action
+   as a delete/create rather than an update.  **This may cause issues if you use tooling that relies on the names of the objects**.
+   When a ClusterRoleTemplateBinding or a ProjectRoleTemplateBinding is migrated to a new name, the newly created object
+   will contain a label, "ad-guid-previous-name", that will have a value of the name of the object that was deleted.

--- a/cleanup/ad-guid-unmigration.sh
+++ b/cleanup/ad-guid-unmigration.sh
@@ -1,0 +1,265 @@
+#!/bin/bash
+# set -x
+set -e
+
+# Text to display in the banner
+banner_text="This utility will go through all Rancher users and perform an Active Directory lookup using
+the configured service account to get the user's distinguished name.  Next, it will perform lookups inside Rancher
+for all the user's Tokens, ClusterRoleTemplateBindings, and ProjectRoleTemplateBindings.  If any of those objects,
+including the user object itself are referencing a principalID based on the GUID of that user, those objects will be
+updated to reference the distinguished name-based principalID (unless the utility is run with -dry-run, in that case
+the only results are log messages indicating the changes that would be made by a run without that flag).
+
+This utility will also detect and correct the case where a single ActiveDirectory GUID is mapped to multiple Rancher
+users.  That condition was likely caused by a race in the original migration to use GUIDs and resulted in a second
+Rancher user being created.  This caused Rancher logins to fail for the duplicated user.  The utility remedies
+that situation by mapping any tokens and bindings to the original user before removing the newer user, which was
+created in error.
+
+It is also important to note that migration of ClusterRoleTemplateBindings and ProjectRoleTemplateBindings require
+a delete/create operation rather than an update.  This will result in new object names for the migrated bindings.
+A label with the former object name will be included in the migrated bindings.
+
+The Rancher Agent image to be used with this utility can be found at rancher/rancher-agent:v2.7.6
+
+It is recommended that you perform a Rancher backup prior to running this utility."
+
+CLEAR='\033[0m'
+RED='\033[0;31m'
+
+# cluster resources, including the service account used to run the script
+cluster_resources_yaml=$(cat << 'EOF'
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cattle-cleanup-sa
+  namespace: cattle-system
+  labels:
+    rancher-cleanup: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cattle-cleanup-binding
+  labels:
+    rancher-cleanup: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cattle-cleanup-role
+subjects:
+  - kind: ServiceAccount
+    name: cattle-cleanup-sa
+    namespace: cattle-system
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cattle-cleanup-job
+  namespace: cattle-system
+  labels:
+    rancher-cleanup: "true"
+spec:
+  backoffLimit: 6
+  completions: 1
+  parallelism: 1
+  selector:
+  template:
+    metadata:
+      creationTimestamp: null
+    spec:
+      containers:
+        - env:
+            - name: AD_GUID_CLEANUP
+              value: "true"
+            #dryrun - name: DRY_RUN
+              #dryrun value: "true"
+            #deletemissing - name: AD_DELETE_MISSING_GUID_USERS
+              #deletemissing value: "true"
+          image: agent_image
+          imagePullPolicy: Always
+          command: ["agent"]
+          name: cleanup-agent
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: OnFailure
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccountName: cattle-cleanup-sa
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cattle-cleanup-role  
+  labels:
+    rancher-cleanup: "true"
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - nonResourceURLs:
+      - '*'
+    verbs:
+      - '*'
+EOF
+)
+
+# Agent image to use in the yaml file
+agent_image="$1"
+
+show_usage() {
+  if [ -n "$1" ]; then
+    echo -e "${RED}👉 $1${CLEAR}\n";
+  fi
+  echo "Usage: $0 AGENT_IMAGE [OPTIONS]"
+  echo ""
+  echo "Options:"
+  echo -e "\t-h, --help              Display this help message"
+  echo -e "\t-n, --dry-run           Display the resources that would be updated without making changes"
+  echo -e "\t-d, --delete-missing    Permanently remove user objects whose GUID cannot be found in Active Directory"
+}
+
+display_banner() {
+    local text="$1"
+    local border_char="="
+    local text_width=$(($(tput cols)))
+    local border=$(printf "%${text_width}s" | tr " " "$border_char")
+
+    echo "$border"
+    printf "%-${text_width}s \n" "$text"
+    echo "$border"
+    echo "Dry run: $dry_run"
+    echo "Delete missing: $delete_missing"
+    echo "Agent image: $agent_image"
+    if [[ "$dry_run" = true ]] && [[ "$delete_missing" = true ]]
+    then
+        echo "Setting the dry-run option to true overrides the delete-missing option.  NO CHANGES WILL BE MADE."
+    fi
+    echo "$border"
+}
+
+OPTS=$(getopt -o hnd -l help,dry-run,delete-missing -- "$@")
+if [ $? != 0 ]; then
+  show_usage "Invalid option"
+  exit 1
+fi
+
+eval set -- "$OPTS"
+
+dry_run=false
+delete_missing=false
+
+while true; do
+  case "$1" in
+    -h | --help)
+      show_usage
+      exit 0
+      ;;
+    -n | --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -d | --delete-missing)
+      delete_missing=true
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      show_usage "Invalid option"
+      exit 1
+      ;;
+  esac
+done
+
+shift "$((OPTIND - 1))"
+# Ensure AGENT_IMAGE is provided
+if [ $# -lt 1 ]; then
+  show_usage "AGENT_IMAGE is a required argument"
+  exit 1
+fi
+
+display_banner "${banner_text}"
+
+if [ "$dry_run" != true ]
+then
+    # Check the Rancher version before doing anything.
+    # If it is v2.7.5, make it clear that configuration is not the recommended way to run this utility.
+    rancher_version=$(kubectl get settings server-version --template='{{.value}}')
+    if [ "$rancher_version" = "v2.7.5" ]; then
+      echo -e "${RED}IT IS NOT RECOMMENDED TO RUN THIS UTILITY AGAINST RANCHER VERSION v2.7.5${CLEAR}"
+      echo -e "${RED}IF RANCHER v.2.7.5 RESTARTS AFTER RUNNING THIS UTILITY, IT WILL UNDO THE EFFECTS OF THIS UTILITY.${CLEAR}"
+      echo -e "${RED}IF YOU DO WANT TO RUN THIS UTILITY, IT IS RECOMMENDED THAT YOU MAKE A BACKUP PRIOR TO CONTINUING.${CLEAR}"
+      read -p "Do you want to continue? (y/n): " choice
+      if [[ ! $choice =~ ^[Yy]$ ]]; then
+          echo "Exiting..."
+          exit 0
+      fi
+    fi
+fi
+
+
+read -p "Do you want to continue? (y/n): " choice
+if [[ ! $choice =~ ^[Yy]$ ]]; then
+    echo "Exiting..."
+    exit 0
+fi
+
+# apply the provided rancher agent
+yaml=$(sed -e 's=agent_image='"$agent_image"'=' <<< $cluster_resources_yaml)
+
+if [ "$dry_run" = true ]
+then
+    # Uncomment the env var for dry-run mode
+    yaml=$(sed -e 's/#dryrun // ' <<< "$yaml")
+elif [ "$delete_missing" = true ]
+then
+    # Instead uncomment the env var for missing user cleanup
+    yaml=$(sed -e 's/#deletemissing // ' <<< "$yaml")
+fi
+
+echo "$yaml" | kubectl apply -f -
+
+# Get the pod ID to tail the logs
+retry_interval=1
+max_retries=10
+retry_count=0
+pod_id=""
+while [ $retry_count -lt $max_retries ]; do
+    pod_id=$(kubectl --namespace=cattle-system get pod -l job-name=cattle-cleanup-job -o jsonpath="{.items[0].metadata.name}")
+    if [ -n "$pod_id" ]; then
+        break
+    else
+        sleep $retry_interval
+        ((retry_count++))
+    fi
+done
+
+# 600 is equal to 5 minutes, because the sleep interval is 0.5 seconds
+job_start_timeout=600
+
+declare -i count=0
+until kubectl --namespace=cattle-system logs $pod_id -f
+do
+    if [ $count -gt $job_start_timeout ]
+    then
+        echo "Timeout reached, check the job by running kubectl --namespace=cattle-system get jobs"
+        echo "To cleanup manually, you can run:"
+        echo "  kubectl --namespace=cattle-system delete serviceaccount,job -l rancher-cleanup=true"
+        echo "  kubectl delete clusterrole,clusterrolebinding -l rancher-cleanup=true"
+        exit 1
+    fi
+    sleep 0.5
+    count+=1
+done
+
+# Cleanup after it completes successfully
+echo "$yaml" | kubectl delete -f -

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -24,16 +24,18 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/hashicorp/go-multierror"
 	"github.com/mattn/go-colorable"
+	"github.com/rancher/remotedialer"
+	"github.com/rancher/wrangler/pkg/signals"
+	"github.com/sirupsen/logrus"
+
 	"github.com/rancher/rancher/pkg/agent/clean"
+	"github.com/rancher/rancher/pkg/agent/clean/adunmigration"
 	"github.com/rancher/rancher/pkg/agent/cluster"
 	"github.com/rancher/rancher/pkg/agent/node"
 	"github.com/rancher/rancher/pkg/agent/rancher"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/logserver"
 	"github.com/rancher/rancher/pkg/rkenodeconfigclient"
-	"github.com/rancher/remotedialer"
-	"github.com/rancher/wrangler/pkg/signals"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -80,6 +82,10 @@ func main() {
 				bindingErr = multierror.Append(bindingErr, err)
 			}
 			err = bindingErr
+		} else if os.Getenv("AD_GUID_CLEANUP") == "true" {
+			dryrun := os.Getenv("DRY_RUN") == "true"
+			deleteMissingUsers := os.Getenv("AD_DELETE_MISSING_GUID_USERS") == "true"
+			err = adunmigration.UnmigrateAdGUIDUsers(nil, dryrun, deleteMissingUsers)
 		} else {
 			err = run(ctx)
 		}

--- a/pkg/agent/clean/adunmigration/ldap.go
+++ b/pkg/agent/clean/adunmigration/ldap.go
@@ -1,0 +1,421 @@
+package adunmigration
+
+import (
+	"bytes"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	ldapv3 "github.com/go-ldap/ldap/v3"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers/common"
+	"github.com/rancher/rancher/pkg/auth/providers/common/ldap"
+	v3client "github.com/rancher/rancher/pkg/client/generated/management/v3"
+	"github.com/rancher/rancher/pkg/types/config"
+)
+
+// Rancher 2.7.5 serialized binary GUIDs from LDAP using this pattern, so this
+// is what we should match. Notably this differs from Active Directory GUID
+// strings, which have dashes and braces as delimiters.
+var validRancherGUIDPattern = regexp.MustCompile("^[0-9a-f]+$")
+
+type LdapErrorNotFound struct{}
+
+// Error provides a string representation of an LdapErrorNotFound
+func (e LdapErrorNotFound) Error() string {
+	return "ldap query returned no results"
+}
+
+// LdapFoundDuplicateGUID indicates either a configuration error or
+// a corruption on the Active Directory side. In theory it should never
+// be possible when talking to a real Active Directory server, but just
+// in case we detect and handle it anyway.
+type LdapFoundDuplicateGUID struct{}
+
+// Error provides a string representation of an LdapErrorNotFound
+func (e LdapFoundDuplicateGUID) Error() string {
+	return "ldap query returned multiple users for the same GUID"
+}
+
+type LdapConnectionPermanentlyFailed struct{}
+
+// Error provides a string representation of an LdapConnectionPermanentlyFailed
+func (e LdapConnectionPermanentlyFailed) Error() string {
+	return "ldap search failed to connect after exhausting maximum retry attempts"
+}
+
+type sharedLdapConnection struct {
+	lConn  *ldapv3.Conn
+	isOpen bool
+}
+
+func ldapConnection(config *v3.ActiveDirectoryConfig) (*ldapv3.Conn, error) {
+	caPool, err := newCAPool(config.Certificate)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create caPool: %v", err)
+	}
+
+	servers := config.Servers
+	TLS := config.TLS
+	port := config.Port
+	connectionTimeout := config.ConnectionTimeout
+	startTLS := config.StartTLS
+
+	ldapConn, err := ldap.NewLDAPConn(servers, TLS, startTLS, port, connectionTimeout, caPool)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceAccountUsername := ldap.GetUserExternalID(config.ServiceAccountUsername, config.DefaultLoginDomain)
+	err = ldapConn.Bind(serviceAccountUsername, config.ServiceAccountPassword)
+	if err != nil {
+		return nil, err
+	}
+	return ldapConn, nil
+}
+
+// EscapeUUID will take a UUID string in string form and will add backslashes to every 2nd character.
+// The returned result is the string that needs to be added to the LDAP filter to properly filter
+// by objectGUID, which is stored as binary data.
+func escapeUUID(s string) string {
+	var buffer bytes.Buffer
+	var n1 = 1
+	var l1 = len(s) - 1
+	buffer.WriteRune('\\')
+	for i, r := range s {
+		buffer.WriteRune(r)
+		if i%2 == n1 && i != l1 {
+			buffer.WriteRune('\\')
+		}
+	}
+	return buffer.String()
+}
+
+func findLdapUser(guid string, lConn *ldapv3.Conn, adConfig *v3.ActiveDirectoryConfig) (string, *v3.Principal, error) {
+	query := fmt.Sprintf("(&(%v=%v)(%v=%v))", AttributeObjectClass, adConfig.UserObjectClass, AttributeObjectGUID, escapeUUID(guid))
+	search := ldapv3.NewSearchRequest(adConfig.UserSearchBase, ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases,
+		0, 0, false,
+		query, ldap.GetUserSearchAttributes("memberOf", "objectClass", adConfig), nil)
+
+	result, err := lConn.Search(search)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if len(result.Entries) < 1 {
+		return "", nil, LdapErrorNotFound{}
+	} else if len(result.Entries) > 1 {
+		return "", nil, LdapFoundDuplicateGUID{}
+	}
+
+	entry := result.Entries[0]
+	distinguishedName := entry.DN
+	principal, err := ldap.AttributesToPrincipal(entry.Attributes, distinguishedName, activeDirectoryScope, activeDirecotryName,
+		adConfig.UserObjectClass, adConfig.UserNameAttribute, adConfig.UserLoginAttribute, adConfig.GroupObjectClass, adConfig.GroupNameAttribute)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to generate principal from ldap attributes")
+	}
+
+	return entry.DN, principal, nil
+}
+
+func findLdapUserWithRetries(guid string, sLConn *sharedLdapConnection, adConfig *v3.ActiveDirectoryConfig) (string, *v3.Principal, error) {
+	// These settings range from 2 seconds for minor blips to around a full minute for repeated failures
+	backoff := wait.Backoff{
+		Duration: 2 * time.Second,
+		Factor:   1.5, // duration multiplied by this for each retry
+		Jitter:   0.1, // random variance, just in case other parts of rancher are using LDAP while we work
+		Steps:    10,  // number of retries before we consider this failure to be permanent
+	}
+
+	var distinguishedName string
+	var principal *v3.Principal
+	err := wait.ExponentialBackoff(backoff, func() (finished bool, err error) {
+		if !sLConn.isOpen {
+			sLConn.lConn, err = ldapConnection(adConfig)
+			if err != nil {
+				logrus.Warnf("[%v] LDAP connection failed: '%v', retrying...", migrateAdUserOperation, err)
+				return false, err
+			}
+			sLConn.isOpen = true
+		}
+
+		distinguishedName, principal, err = findLdapUser(guid, sLConn.lConn, adConfig)
+		if err == nil || errors.Is(err, LdapErrorNotFound{}) || errors.Is(err, LdapFoundDuplicateGUID{}) {
+			return true, err
+		}
+
+		// any other error type almost certainly indicates a connection failure. Close and re-open the connection
+		// before retrying
+		logrus.Warnf("[%v] LDAP connection failed: '%v', retrying...", migrateAdUserOperation, err)
+		sLConn.lConn.Close()
+		sLConn.isOpen = false
+
+		return false, err
+	})
+
+	return distinguishedName, principal, err
+}
+
+func adConfiguration(sc *config.ScaledContext) (*v3.ActiveDirectoryConfig, error) {
+	authConfigs := sc.Management.AuthConfigs("")
+	secrets := sc.Core.Secrets("")
+
+	authConfigObj, err := authConfigs.ObjectClient().UnstructuredClient().Get("activedirectory", metav1.GetOptions{})
+	if err != nil {
+		logrus.Errorf("[%v] failed to obtain activedirectory authConfigObj: %v", migrateAdUserOperation, err)
+		return nil, err
+	}
+
+	u, ok := authConfigObj.(runtime.Unstructured)
+	if !ok {
+		logrus.Errorf("[%v] failed to retrieve ActiveDirectoryConfig, cannot read k8s Unstructured data %v", migrateAdUserOperation, err)
+		return nil, err
+	}
+	storedADConfigMap := u.UnstructuredContent()
+
+	storedADConfig := &v3.ActiveDirectoryConfig{}
+	err = common.Decode(storedADConfigMap, storedADConfig)
+	if err != nil {
+		logrus.Errorf("[%v] errors while decoding stored AD config: %v", migrateAdUserOperation, err)
+		return nil, err
+	}
+
+	metadataMap, ok := storedADConfigMap["metadata"].(map[string]interface{})
+	if !ok {
+		logrus.Errorf("[%v] failed to retrieve ActiveDirectoryConfig, (second step), cannot read k8s Unstructured data %v", migrateAdUserOperation, err)
+		return nil, err
+	}
+
+	typemeta := &metav1.ObjectMeta{}
+	err = common.Decode(metadataMap, typemeta)
+	if err != nil {
+		logrus.Errorf("[%v] errors while decoding typemeta: %v", migrateAdUserOperation, err)
+		return nil, err
+	}
+
+	storedADConfig.ObjectMeta = *typemeta
+
+	logrus.Debugf("[%v] Should in theory have ActiveDirectory config data? Let's check!", migrateAdUserOperation)
+	logrus.Debugf("[%v] AD Service Account User: %v", migrateAdUserOperation, storedADConfig.ServiceAccountUsername)
+
+	if storedADConfig.ServiceAccountPassword != "" {
+		value, err := common.ReadFromSecret(secrets, storedADConfig.ServiceAccountPassword,
+			strings.ToLower(v3client.ActiveDirectoryConfigFieldServiceAccountPassword))
+		if err != nil {
+			return nil, err
+		}
+		storedADConfig.ServiceAccountPassword = value
+	}
+
+	return storedADConfig, nil
+}
+
+func newCAPool(cert string) (*x509.CertPool, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
+	pool.AppendCertsFromPEM([]byte(cert))
+	return pool, nil
+}
+
+// prepareClientContexts sets up a scaled context with the ability to read users and AD configuration data
+func prepareClientContexts(clientConfig *restclient.Config) (*config.ScaledContext, *v3.ActiveDirectoryConfig, error) {
+	var restConfig *restclient.Config
+	var err error
+	if clientConfig != nil {
+		restConfig = clientConfig
+	} else {
+		restConfig, err = clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+		if err != nil {
+			logrus.Errorf("[%v] failed to build the cluster config: %v", migrateAdUserOperation, err)
+			return nil, nil, err
+		}
+	}
+
+	sc, err := scaledContext(restConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	adConfig, err := adConfiguration(sc)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return sc, adConfig, nil
+}
+
+func isGUID(principalID string) bool {
+	parts := strings.Split(principalID, "://")
+	if len(parts) != 2 {
+		logrus.Errorf("[%v] failed to parse invalid PrincipalID: %v", identifyAdUserOperation, principalID)
+		return false
+	}
+	return validRancherGUIDPattern.MatchString(parts[1])
+}
+
+func updateADConfigMigrationStatus(status map[string]string, sc *config.ScaledContext) error {
+	authConfigObj, err := sc.Management.AuthConfigs("").ObjectClient().UnstructuredClient().Get("activedirectory", metav1.GetOptions{})
+	if err != nil {
+		logrus.Errorf("[%v] failed to obtain activedirecotry authConfigObj: %v", migrateAdUserOperation, err)
+		return err
+	}
+
+	storedADConfig, ok := authConfigObj.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("[%v] expected unstructured authconfig, got %T", migrateAdUserOperation, authConfigObj)
+	}
+
+	// Update annotations with migration status
+	annotations := storedADConfig.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	for annotation, value := range status {
+		// We do not mirror the actual user lists to the AuthConfig
+		if annotation != migrateStatusSkipped && annotation != migrateStatusMissing {
+			annotations[adGUIDMigrationPrefix+annotation] = value
+		}
+	}
+	storedADConfig.SetAnnotations(annotations)
+
+	// Update the AuthConfig object using the unstructured client
+	_, err = sc.Management.AuthConfigs("").ObjectClient().UnstructuredClient().Update(storedADConfig.GetName(), storedADConfig)
+	if err != nil {
+		return fmt.Errorf("failed to update authConfig object: %v", err)
+	}
+
+	return nil
+}
+
+func migrateAllowedUserPrincipals(workunits *[]migrateUserWorkUnit, missingUsers *[]missingUserWorkUnit, sc *config.ScaledContext, dryRun bool, deleteMissingUsers bool) error {
+	// because we might process users in this list that have never logged in, we may need to perform LDAP
+	// lookups on the spot to see what their associated DN should be
+	sharedLConn := sharedLdapConnection{}
+	// this needs its own copy of the ad config, decoded with the ldap credentials fetched, so do that here
+	originalAdConfig, err := adConfiguration(sc)
+	if err != nil {
+		return fmt.Errorf("[%v] failed to obtain activedirectory config: %v", migrateAdUserOperation, err)
+	}
+
+	authConfigObj, err := sc.Management.AuthConfigs("").ObjectClient().UnstructuredClient().Get("activedirectory", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("[%v] failed to obtain activedirectory authConfigObj: %v", migrateAdUserOperation, err)
+	}
+
+	// Create an empty unstructured object to hold the decoded JSON
+	storedADConfig, ok := authConfigObj.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("[%v] expected unstructured authconfig, got %T", migrateAdUserOperation, authConfigObj)
+	}
+
+	unstructuredMap := storedADConfig.UnstructuredContent()
+	unstructuredMaybeList := unstructuredMap["allowedPrincipalIds"]
+	listOfMaybeStrings, ok := unstructuredMaybeList.([]interface{})
+	if !ok {
+		return fmt.Errorf("[%v] expected list for allowed principal ids, got %T", migrateAdUserOperation, unstructuredMaybeList)
+	}
+
+	adWorkUnitsByPrincipal := map[string]int{}
+	for i, workunit := range *workunits {
+		adWorkUnitsByPrincipal[activeDirectoryPrefix+workunit.guid] = i
+	}
+	missingWorkUnitsByPrincipal := map[string]int{}
+	for i, workunit := range *missingUsers {
+		adWorkUnitsByPrincipal[activeDirectoryPrefix+workunit.guid] = i
+	}
+
+	// we can deduplicate this list while we're at it, so we don't accidentally end up with twice the DNs
+	var newPrincipalIDs []string
+	var knownDnIDs = map[string]string{}
+
+	for _, item := range listOfMaybeStrings {
+		principalID, ok := item.(string)
+		if !ok {
+			// ... what? we got a non-string?
+			// this is weird enough that we should consider it a hard failure for investigation
+			return fmt.Errorf("[%v] expected string for allowed principal id, found instead %T", migrateAdUserOperation, item)
+		}
+
+		scope, err := getScope(principalID)
+		if err != nil {
+			logrus.Errorf("[%v] found invalid principal ID in allowed user list, refusing to process: %v", migrateAdUserOperation, err)
+			newPrincipalIDs = append(newPrincipalIDs, principalID)
+		}
+		if scope != activeDirectoryScope {
+			newPrincipalIDs = append(newPrincipalIDs, principalID)
+		} else {
+			if !isGUID(principalID) {
+				// This must be a DN-based principal; add it to the new list
+				knownDnIDs[principalID] = principalID
+			} else {
+				if j, exists := adWorkUnitsByPrincipal[principalID]; exists {
+					// This user is known and was just migrated to DN, so add their DN-based principal to the list
+					newPrincipalID := activeDirectoryPrefix + (*workunits)[j].distinguishedName
+					knownDnIDs[newPrincipalID] = newPrincipalID
+				} else if _, exists := missingWorkUnitsByPrincipal[principalID]; exists {
+					// This user is known to be missing, so we don't need to perform an LDAP lookup, we can just
+					// action accordingly
+					if !deleteMissingUsers {
+						newPrincipalIDs = append(newPrincipalIDs, principalID)
+					}
+				} else {
+					// We didn't process a user object for this GUID-based user. We need to perform an ldap
+					// lookup on the spot and figure out if they have an associated DN
+					guid, err := getExternalID(principalID)
+					if err != nil {
+						// this shouldn't be reachable, as getScope will fail first, but just for consistency...
+						logrus.Errorf("[%v] found invalid principal ID in allowed user list, refusing to process: %v", migrateAdUserOperation, err)
+						newPrincipalIDs = append(newPrincipalIDs, principalID)
+					} else {
+						dn, _, err := findLdapUserWithRetries(guid, &sharedLConn, originalAdConfig)
+						if errors.Is(err, LdapConnectionPermanentlyFailed{}) || errors.Is(err, LdapFoundDuplicateGUID{}) {
+							// Whelp; keep this one as-is and yell about it
+							logrus.Errorf("[%v] ldap connection error when checking distinguished name for guid-based principal %v, skipping: %v", migrateAdUserOperation, principalID, err)
+							newPrincipalIDs = append(newPrincipalIDs, principalID)
+						} else if errors.Is(err, LdapErrorNotFound{}) {
+							if !deleteMissingUsers {
+								newPrincipalIDs = append(newPrincipalIDs, principalID)
+							}
+						} else {
+							newPrincipalID := activeDirectoryPrefix + dn
+							knownDnIDs[newPrincipalID] = newPrincipalID
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Now that we're through processing the list and dealing with any duplicates, append the new DN-based principals
+	// to the end of the list
+	for _, principalID := range knownDnIDs {
+		newPrincipalIDs = append(newPrincipalIDs, principalID)
+	}
+
+	if !dryRun {
+		unstructuredMap["allowedPrincipalIds"] = newPrincipalIDs
+		storedADConfig.SetUnstructuredContent(unstructuredMap)
+
+		_, err = sc.Management.AuthConfigs("").ObjectClient().UnstructuredClient().Update("activedirectory", storedADConfig)
+	} else {
+		logrus.Infof("[%v] DRY RUN: new allowed user list will contain these principal IDs:", migrateAdUserOperation)
+		for _, principalID := range newPrincipalIDs {
+			logrus.Infof("[%v]   DRY RUN: '%v'", migrateAdUserOperation, principalID)
+		}
+	}
+	return err
+}

--- a/pkg/agent/clean/adunmigration/migrate.go
+++ b/pkg/agent/clean/adunmigration/migrate.go
@@ -1,0 +1,502 @@
+/*
+Look for any active directory users with a GUID type principal.
+Convert these users to a distinguished name instead.
+*/
+
+package adunmigration
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	restclient "k8s.io/client-go/rest"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers/activedirectory"
+	"github.com/rancher/rancher/pkg/types/config"
+)
+
+const (
+	migrateAdUserOperation    = "migrate-ad-user"
+	identifyAdUserOperation   = "identify-ad-users"
+	migrateTokensOperation    = "migrate-ad-tokens"
+	migrateCrtbsOperation     = "migrate-ad-crtbs"
+	migratePrtbsOperation     = "migrate-ad-prtbs"
+	migrateGrbsOperation      = "migrate-ad-grbs"
+	activeDirecotryName       = "activedirectory"
+	activeDirectoryScope      = "activedirectory_user"
+	activeDirectoryPrefix     = "activedirectory_user://"
+	localPrefix               = "local://"
+	adGUIDMigrationLabel      = "ad-guid-migration"
+	adGUIDMigrationAnnotation = "ad-guid-migration-data"
+	adGUIDMigrationPrefix     = "migration-"
+	migratedLabelValue        = "migrated"
+	migrationPreviousName     = "ad-guid-previous-name"
+	AttributeObjectClass      = "objectClass"
+	AttributeObjectGUID       = "objectGUID"
+	migrateStatusSkipped      = "skippedUsers"
+	migrateStatusMissing      = "missingUsers"
+	migrateStatusCountSuffix  = "Count"
+	migrationStatusPercentage = "percentDone"
+	migrationStatusLastUpdate = "statusLastUpdated"
+)
+
+type migrateUserWorkUnit struct {
+	distinguishedName string
+	guid              string
+	originalUser      *v3.User
+	duplicateUsers    []*v3.User
+	principal         *v3.Principal
+
+	activeDirectoryCRTBs []v3.ClusterRoleTemplateBinding
+	duplicateLocalCRTBs  []v3.ClusterRoleTemplateBinding
+
+	activeDirectoryPRTBs []v3.ProjectRoleTemplateBinding
+	duplicateLocalPRTBs  []v3.ProjectRoleTemplateBinding
+
+	duplicateLocalGRBs []v3.GlobalRoleBinding
+
+	activeDirectoryTokens []v3.Token
+	duplicateLocalTokens  []v3.Token
+}
+
+type missingUserWorkUnit struct {
+	guid           string
+	originalUser   *v3.User
+	duplicateUsers []*v3.User
+}
+
+type skippedUserWorkUnit struct {
+	guid         string
+	originalUser *v3.User
+}
+
+func scaledContext(restConfig *restclient.Config) (*config.ScaledContext, error) {
+	sc, err := config.NewScaledContext(*restConfig, nil)
+	if err != nil {
+		logrus.Errorf("[%v] failed to create scaledContext: %v", migrateAdUserOperation, err)
+		return nil, err
+	}
+
+	ctx := context.Background()
+	err = sc.Start(ctx)
+	if err != nil {
+		logrus.Errorf("[%v] failed to start scaled context: %v", migrateAdUserOperation, err)
+		return nil, err
+	}
+
+	return sc, nil
+}
+
+// UnmigrateAdGUIDUsersOnce will ensure that the migration script will run only once.  cycle through all users, ctrb, ptrb, tokens and migrate them to an
+// appropriate DN-based PrincipalID.
+func UnmigrateAdGUIDUsersOnce(sc *config.ScaledContext) error {
+	migrationConfigMap, err := sc.Core.ConfigMaps(activedirectory.StatusConfigMapNamespace).GetNamespaced(activedirectory.StatusConfigMapNamespace, activedirectory.StatusConfigMapName, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logrus.Errorf("[%v] unable to check unmigration configmap: %v", migrateAdUserOperation, err)
+		logrus.Errorf("[%v] cannot determine if it is safe to proceed. refusing to run", migrateAdUserOperation)
+		return nil
+	}
+	if migrationConfigMap != nil {
+		migrationStatus := migrationConfigMap.Data[activedirectory.StatusMigrationField]
+		switch migrationStatus {
+		case activedirectory.StatusMigrationFinished:
+			logrus.Debugf("[%v] ad-guid migration has already been completed, refusing to run again at startup", migrateAdUserOperation)
+			return nil
+		case activedirectory.StatusMigrationFinishedWithMissing:
+			logrus.Infof("[%v] ad-guid migration has already been completed. To clean-up missing users, you can run the utility manually", migrateAdUserOperation)
+			return nil
+		case activedirectory.StatusMigrationFinishedWithSkipped:
+			logrus.Infof("[%v] ad-guid migration has already been completed. To try and resolve skipped users, you can run the utility manually", migrateAdUserOperation)
+			return nil
+		}
+
+	}
+	return UnmigrateAdGUIDUsers(&sc.RESTConfig, false, false)
+}
+
+// UnmigrateAdGUIDUsers will cycle through all users, ctrb, ptrb, tokens and migrate them to an
+// appropriate DN-based PrincipalID.
+func UnmigrateAdGUIDUsers(clientConfig *restclient.Config, dryRun bool, deleteMissingUsers bool) error {
+	if dryRun {
+		logrus.Infof("[%v] dryRun is true, no objects will be deleted/modified", migrateAdUserOperation)
+		deleteMissingUsers = false
+	} else if deleteMissingUsers {
+		logrus.Infof("[%v] deleteMissingUsers is true, GUID-based users not present in Active Directory will be deleted", migrateAdUserOperation)
+	}
+
+	sc, adConfig, err := prepareClientContexts(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	migrationConfigMap, err := sc.Core.ConfigMaps(activedirectory.StatusConfigMapNamespace).GetNamespaced(activedirectory.StatusConfigMapNamespace, activedirectory.StatusConfigMapName, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		logrus.Errorf("[%v] unable to check unmigration configmap: %v", migrateAdUserOperation, err)
+		logrus.Errorf("[%v] cannot determine if it is safe to proceed. refusing to run", migrateAdUserOperation)
+		return nil
+	}
+	if migrationConfigMap != nil {
+		migrationStatus := migrationConfigMap.Data[activedirectory.StatusMigrationField]
+		switch migrationStatus {
+		case activedirectory.StatusMigrationRunning:
+			logrus.Infof("[%v] ad-guid migration is currently running, refusing to run again concurrently", migrateAdUserOperation)
+			return nil
+		}
+	}
+
+	finalStatus := activedirectory.StatusMigrationFinished
+
+	// set the status to running and reset the unmigrated fields
+	if !dryRun {
+		err = updateMigrationStatus(sc, activedirectory.StatusMigrationField, activedirectory.StatusMigrationRunning)
+		if err != nil {
+			return fmt.Errorf("unable to update migration status configmap: %v", err)
+		}
+		updateUnmigratedUsers("", migrateStatusSkipped, true, sc)
+		updateUnmigratedUsers("", migrateStatusMissing, true, sc)
+		// If we return past this point, no matter how we got there, make sure we update the configmap to clear the
+		// status away from "running." If we fail to do this, we block AD-based logins indefinitely.
+		defer func(sc *config.ScaledContext, status string) {
+			err := updateMigrationStatus(sc, status, finalStatus)
+			if err != nil {
+				logrus.Errorf("[%v] unable to update migration status configmap: %v", migrateAdUserOperation, err)
+			}
+		}(sc, activedirectory.StatusMigrationField)
+
+		// Early bail: if the AD configuration is disabled, then we're done! Update the configmap right now and exit.
+		if !adConfig.Enabled {
+			logrus.Infof("[%v] during unmigration, found that Active Directory is not enabled. nothing to do", migrateAdUserOperation)
+			finalStatus = activedirectory.StatusMigrationFinished
+			return nil
+		}
+	}
+
+	users, err := sc.Management.Users("").List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to fetch user list: %v", err)
+	}
+
+	usersToMigrate, missingUsers, skippedUsers := identifyMigrationWorkUnits(users, adConfig)
+	// If any of the below functions fail, there is either a permissions problem or a more serious issue with the
+	// Rancher API. We should bail in this case and not attempt to process users.
+	err = collectTokens(&usersToMigrate, sc)
+	if err != nil {
+		finalStatus = activedirectory.StatusMigrationFailed
+		return err
+	}
+	err = collectCRTBs(&usersToMigrate, sc)
+	if err != nil {
+		finalStatus = activedirectory.StatusMigrationFailed
+		return err
+	}
+	err = collectPRTBs(&usersToMigrate, sc)
+	if err != nil {
+		finalStatus = activedirectory.StatusMigrationFailed
+		return err
+	}
+	err = collectGRBs(&usersToMigrate, sc)
+	if err != nil {
+		finalStatus = activedirectory.StatusMigrationFailed
+		return err
+	}
+
+	if len(missingUsers) > 0 {
+		finalStatus = activedirectory.StatusMigrationFinishedWithMissing
+	}
+	if len(skippedUsers) > 0 {
+		finalStatus = activedirectory.StatusMigrationFinishedWithSkipped
+	}
+
+	for _, user := range skippedUsers {
+		logrus.Errorf("[%v] unable to migrate user '%v' due to a connection failure; this user will be skipped",
+			migrateAdUserOperation, user.originalUser.Name)
+		if !dryRun {
+			updateUnmigratedUsers(user.originalUser.Name, migrateStatusSkipped, false, sc)
+		}
+	}
+	for _, missingUser := range missingUsers {
+		if deleteMissingUsers && !dryRun {
+			logrus.Infof("[%v] user '%v' with GUID '%v' does not seem to exist in Active Directory. deleteMissingUsers is true, proceeding to delete this user permanently", migrateAdUserOperation, missingUser.originalUser.Name, missingUser.guid)
+			updateUnmigratedUsers(missingUser.originalUser.Name, migrateStatusMissing, false, sc)
+			err = sc.Management.Users("").Delete(missingUser.originalUser.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				logrus.Errorf("[%v] failed to delete missing user '%v' with: %v", migrateAdUserOperation, missingUser.originalUser.Name, err)
+			}
+		} else {
+			logrus.Infof("[%v] User '%v' with GUID '%v' does not seem to exist in Active Directory. this user will be skipped", migrateAdUserOperation, missingUser.originalUser.Name, missingUser.guid)
+			if !dryRun {
+				updateUnmigratedUsers(missingUser.originalUser.Name, migrateStatusMissing, false, sc)
+			}
+		}
+	}
+
+	for i, userToMigrate := range usersToMigrate {
+		// Note: some resources may fail to migrate due to webhook constraints; this applies especially to bindings
+		// that refer to disabled templates, as rancher won't allow us to create the replacements. We'll log these
+		// errors, but do not consider them to be serious enough to stop processing the remainder of each user's work.
+		migrateCRTBs(&userToMigrate, sc, dryRun)
+		migratePRTBs(&userToMigrate, sc, dryRun)
+		migrateGRBs(&userToMigrate, sc, dryRun)
+		migrateTokens(&userToMigrate, sc, dryRun)
+		replaceGUIDPrincipalWithDn(userToMigrate.originalUser, userToMigrate.distinguishedName, userToMigrate.guid, dryRun)
+
+		if dryRun {
+			describePlannedChanges(userToMigrate)
+		} else {
+			err = deleteDuplicateUsers(userToMigrate, sc)
+			if err == nil {
+				updateModifiedUser(userToMigrate, sc)
+			}
+			percentDone := float64(i+1) / float64(len(usersToMigrate)) * 100
+			progress := fmt.Sprintf("%.0f%%", percentDone)
+			err = updateMigrationStatus(sc, migrationStatusPercentage, progress)
+			if err != nil {
+				logrus.Errorf("unable to update migration status: %v", err)
+			}
+		}
+	}
+
+	err = migrateAllowedUserPrincipals(&usersToMigrate, &missingUsers, sc, dryRun, deleteMissingUsers)
+	if err != nil {
+		finalStatus = activedirectory.StatusMigrationFailed
+		return err
+	}
+
+	return nil
+}
+
+// identifyMigrationWorkUnits locates ActiveDirectory users with GUID and DN based principal IDs and sorts them
+// into work units based on whether those users can be located in the upstream Active Directory provider. Specifically:
+//
+//	usersToMigrate contains GUID-based original users and any duplicates (GUID or DN based) that we wish to merge
+//	missingUsers contains GUID-based users who could not be found in Active Directory
+//	skippedUsers contains GUID-based users that could not be processed, usually due to an LDAP connection failure
+func identifyMigrationWorkUnits(users *v3.UserList, adConfig *v3.ActiveDirectoryConfig) (
+	[]migrateUserWorkUnit, []missingUserWorkUnit, []skippedUserWorkUnit) {
+	// Note: we *could* make the ldap connection on the spot here, but we're accepting it as a parameter specifically
+	// so that this function is easier to test. This setup allows us to mock the ldap connection and thus more easily
+	// test unusual Active Directory responses to our searches.
+
+	var usersToMigrate []migrateUserWorkUnit
+	var missingUsers []missingUserWorkUnit
+	var skippedUsers []skippedUserWorkUnit
+
+	// These assist with quickly identifying duplicates, so we don't have to scan the whole structure each time.
+	// We key on guid/dn, and the value is the index of that work unit in the associated table
+	knownGUIDWorkUnits := map[string]int{}
+	knownGUIDMissingUnits := map[string]int{}
+	knownDnWorkUnits := map[string]int{}
+
+	// We'll reuse a shared ldap connection to speed up lookups. We need to declare that here, but we'll defer
+	// starting the connection until the first time a lookup is performed
+	sharedLConn := sharedLdapConnection{}
+
+	// Now we'll make two passes over the list of all users. First we need to identify any GUID based users, and
+	// sort them into "found" and "not found" lists. At this stage we might have GUID-based duplicates, and we'll
+	// detect and sort those accordingly
+	ldapPermanentlyFailed := false
+	logrus.Debugf("[%v] locating GUID-based Active Directory users", identifyAdUserOperation)
+	for _, user := range users.Items {
+		if !isAdUser(&user) {
+			logrus.Debugf("[%v] user '%v' has no AD principals, skipping", identifyAdUserOperation, user.Name)
+			continue
+		}
+		principalID := adPrincipalID(&user)
+		logrus.Debugf("[%v] processing AD User '%v' with principal ID: '%v'", identifyAdUserOperation, user.Name, principalID)
+		if !isGUID(principalID) {
+			logrus.Debugf("[%v] '%v' does not appear to be a GUID-based principal ID, taking no action", identifyAdUserOperation, principalID)
+			continue
+		}
+		guid, err := getExternalID(principalID)
+
+		if err != nil {
+			// This really shouldn't be possible to hit, since isGuid will fail to parse anything that would
+			// cause getExternalID to choke on the input, but for maximum safety we'll handle it anyway.
+			logrus.Errorf("[%v] failed to extract GUID from principal '%v', cannot process user: '%v'", identifyAdUserOperation, err, user.Name)
+			continue
+		}
+		// If our LDAP connection has gone sour, we still need to log this user for reporting
+		userCopy := user.DeepCopy()
+		if ldapPermanentlyFailed {
+			skippedUsers = append(skippedUsers, skippedUserWorkUnit{guid: guid, originalUser: userCopy})
+		} else {
+			// Check for guid-based duplicates here. If we find one, we don't need to perform an other LDAP lookup.
+			if i, exists := knownGUIDWorkUnits[guid]; exists {
+				logrus.Debugf("[%v] user %v is GUID-based (%v) and a duplicate of %v",
+					identifyAdUserOperation, user.Name, guid, usersToMigrate[i].originalUser.Name)
+				// Make sure the oldest duplicate user is selected as the original
+				if usersToMigrate[i].originalUser.CreationTimestamp.Time.After(user.CreationTimestamp.Time) {
+					usersToMigrate[i].duplicateUsers = append(usersToMigrate[i].duplicateUsers, usersToMigrate[i].originalUser)
+					usersToMigrate[i].originalUser = userCopy
+				} else {
+					usersToMigrate[i].duplicateUsers = append(usersToMigrate[i].duplicateUsers, userCopy)
+				}
+				continue
+			}
+			if i, exists := knownGUIDMissingUnits[guid]; exists {
+				logrus.Debugf("[%v] user %v is GUID-based (%v) and a duplicate of %v which is known to be missing",
+					identifyAdUserOperation, user.Name, guid, missingUsers[i].originalUser.Name)
+				// We're less picky about the age of the oldest user here, because we aren't going to deduplicate these
+				missingUsers[i].duplicateUsers = append(missingUsers[i].duplicateUsers, userCopy)
+				continue
+			}
+			dn, principal, err := findLdapUserWithRetries(guid, &sharedLConn, adConfig)
+			if errors.Is(err, LdapConnectionPermanentlyFailed{}) {
+				logrus.Warnf("[%v] LDAP connection has permanently failed! will continue to migrate previously identified users", identifyAdUserOperation)
+				skippedUsers = append(skippedUsers, skippedUserWorkUnit{guid: guid, originalUser: userCopy})
+				ldapPermanentlyFailed = true
+			} else if errors.Is(err, LdapFoundDuplicateGUID{}) {
+				logrus.Errorf("[%v] LDAP returned multiple users with GUID '%v'. this should not be possible, and may indicate a configuration error! this user will be skipped", identifyAdUserOperation, guid)
+				skippedUsers = append(skippedUsers, skippedUserWorkUnit{guid: guid, originalUser: userCopy})
+			} else if errors.Is(err, LdapErrorNotFound{}) {
+				logrus.Debugf("[%v] user %v is GUID-based (%v) and the Active Directory server doesn't know about it. marking it as missing", identifyAdUserOperation, user.Name, guid)
+				knownGUIDMissingUnits[guid] = len(missingUsers)
+				missingUsers = append(missingUsers, missingUserWorkUnit{guid: guid, originalUser: userCopy})
+			} else {
+				logrus.Debugf("[%v] user %v is GUID-based (%v) and the Active Directory server knows it by the Distinguished Name '%v'", identifyAdUserOperation, user.Name, guid, dn)
+				knownGUIDWorkUnits[guid] = len(usersToMigrate)
+				knownDnWorkUnits[dn] = len(usersToMigrate)
+				var emptyDuplicateList []*v3.User
+				usersToMigrate = append(usersToMigrate, migrateUserWorkUnit{guid: guid, distinguishedName: dn, principal: principal, originalUser: userCopy, duplicateUsers: emptyDuplicateList})
+			}
+		}
+	}
+
+	if sharedLConn.isOpen {
+		sharedLConn.lConn.Close()
+	}
+
+	if len(usersToMigrate) == 0 {
+		logrus.Debugf("[%v] found 0 users in need of migration, exiting without checking for DN-based duplicates", identifyAdUserOperation)
+		return usersToMigrate, missingUsers, skippedUsers
+	}
+
+	// Now for the second pass, we need to identify DN-based users, and see if they are duplicates of any of the GUID
+	// users that we found in the first pass. We'll prefer the oldest user as the originalUser object, this will be
+	// the one we keep when we resolve duplicates later.
+	logrus.Debugf("[%v] locating any DN-based Active Directory users", identifyAdUserOperation)
+	for _, user := range users.Items {
+		if !isAdUser(&user) {
+			logrus.Debugf("[%v] user '%v' has no AD principals, skipping", identifyAdUserOperation, user.Name)
+			continue
+		}
+		principalID := adPrincipalID(&user)
+		logrus.Debugf("[%v] processing AD User '%v' with principal ID: '%v'", identifyAdUserOperation, user.Name, principalID)
+		if isGUID(principalID) {
+			logrus.Debugf("[%v] '%v' does not appear to be a DN-based principal ID, taking no action", identifyAdUserOperation, principalID)
+			continue
+		}
+		dn, err := getExternalID(principalID)
+		if err != nil {
+			logrus.Errorf("[%v] failed to extract DN from principal '%v', cannot process user: '%v'", identifyAdUserOperation, err, user.Name)
+			continue
+		}
+		if i, exists := knownDnWorkUnits[dn]; exists {
+			logrus.Debugf("[%v] user %v is DN-based (%v), and a duplicate of %v",
+				identifyAdUserOperation, user.Name, dn, usersToMigrate[i].originalUser.Name)
+			// Make sure the oldest duplicate user is selected as the original
+			userCopy := user.DeepCopy()
+			if usersToMigrate[i].originalUser.CreationTimestamp.Time.After(user.CreationTimestamp.Time) {
+				usersToMigrate[i].duplicateUsers = append(usersToMigrate[i].duplicateUsers, usersToMigrate[i].originalUser)
+				usersToMigrate[i].originalUser = userCopy
+			} else {
+				usersToMigrate[i].duplicateUsers = append(usersToMigrate[i].duplicateUsers, userCopy)
+			}
+		}
+	}
+
+	return usersToMigrate, missingUsers, skippedUsers
+}
+
+func workUnitContainsName(workunit *migrateUserWorkUnit, name string) bool {
+	if workunit.originalUser.Name == name {
+		return true
+	}
+	for _, duplicateLocalUser := range workunit.duplicateUsers {
+		if duplicateLocalUser.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func updateMigrationStatus(sc *config.ScaledContext, status string, value string) error {
+	cm, err := sc.Core.ConfigMaps(activedirectory.StatusConfigMapNamespace).Get(activedirectory.StatusConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		// Create a new ConfigMap if it doesn't exist
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      activedirectory.StatusConfigMapName,
+				Namespace: activedirectory.StatusConfigMapNamespace,
+			},
+		}
+	}
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	cm.Data[status] = value
+	cm.Data[migrationStatusLastUpdate] = metav1.Now().Format(time.RFC3339)
+
+	if _, err := sc.Core.ConfigMaps(activedirectory.StatusConfigMapNamespace).Update(cm); err != nil {
+		// If the ConfigMap does not exist, create it
+		if apierrors.IsNotFound(err) {
+			_, err = sc.Core.ConfigMaps(activedirectory.StatusConfigMapNamespace).Create(cm)
+			if err != nil {
+				return fmt.Errorf("[%v] unable to create migration status configmap: %v", migrateAdUserOperation, err)
+			}
+		}
+	}
+	err = updateADConfigMigrationStatus(cm.Data, sc)
+	if err != nil {
+		return fmt.Errorf("unable to update AuthConfig status: %v", err)
+	}
+	return nil
+}
+
+// updateUnmigratedUsers will add a user to the list for the specified migration status in the migration status configmap.
+// If reset is set to true, it will empty the list.
+func updateUnmigratedUsers(user string, status string, reset bool, sc *config.ScaledContext) {
+	cm, err := sc.Core.ConfigMaps(activedirectory.StatusConfigMapNamespace).Get(activedirectory.StatusConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		logrus.Errorf("[%v] unable to fetch configmap to update %v users: %v", migrateAdUserOperation, status, err)
+	}
+	var currentList string
+	if reset {
+		delete(cm.Data, status)
+		delete(cm.Data, status+migrateStatusCountSuffix)
+	} else {
+		currentList = cm.Data[status]
+		if currentList == "" {
+			currentList = currentList + user
+		} else {
+			currentList = currentList + "," + user
+		}
+		count := strconv.Itoa(len(strings.Split(currentList, ",")))
+		cm.Data[status+migrateStatusCountSuffix] = count
+		cm.Data[status] = currentList
+	}
+
+	cm.Data[migrationStatusLastUpdate] = metav1.Now().Format(time.RFC3339)
+	if _, err := sc.Core.ConfigMaps(activedirectory.StatusConfigMapNamespace).Update(cm); err != nil {
+		if err != nil {
+			logrus.Errorf("[%v] unable to update migration status configmap: %v", migrateAdUserOperation, err)
+		}
+	}
+	err = updateADConfigMigrationStatus(cm.Data, sc)
+	if err != nil {
+		logrus.Errorf("unable to update AuthConfig status: %v", err)
+	}
+}

--- a/pkg/agent/clean/adunmigration/rtbs.go
+++ b/pkg/agent/clean/adunmigration/rtbs.go
@@ -1,0 +1,402 @@
+package adunmigration
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v3norman "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/types/config"
+)
+
+// principalsToMigrate collects workunits whose resources we wish to migrate into two groups:
+//
+//	adWorkUnitsByPrincipal - resources should be migrated to an ActiveDirectory principal with a Distinguished Name
+//	duplicateLocalWorkUnitsByPrincipal - resources should be migrated to the local ID of the original (kept) user
+func principalsToMigrate(workunits *[]migrateUserWorkUnit) (adWorkUnitsByPrincipal map[string]int, duplicateLocalWorkUnitsByPrincipal map[string]int) {
+	// first build a map of guid-principalid -> work unit, which will make the following logic more efficient
+	adWorkUnitsByPrincipal = map[string]int{}
+	duplicateLocalWorkUnitsByPrincipal = map[string]int{}
+
+	for i, workunit := range *workunits {
+		adWorkUnitsByPrincipal[activeDirectoryPrefix+workunit.guid] = i
+		for j := range workunit.duplicateUsers {
+			duplicateLocalWorkUnitsByPrincipal[activeDirectoryPrefix+workunit.guid] = i
+			duplicateLocalWorkUnitsByPrincipal[activeDirectoryPrefix+workunit.distinguishedName] = i
+			duplicateLocalWorkUnitsByPrincipal[localPrefix+workunit.duplicateUsers[j].Name] = i
+		}
+	}
+
+	return adWorkUnitsByPrincipal, duplicateLocalWorkUnitsByPrincipal
+}
+
+func collectCRTBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) error {
+	crtbInterface := sc.Management.ClusterRoleTemplateBindings("")
+	crtbList, err := crtbInterface.List(metav1.ListOptions{})
+	if err != nil {
+		logrus.Errorf("[%v] unable to fetch CRTB objects: %v", migrateAdUserOperation, err)
+		return err
+	}
+
+	adWorkUnitsByPrincipal, duplicateLocalWorkUnitsByPrincipal := principalsToMigrate(workunits)
+
+	for _, crtb := range crtbList.Items {
+		if index, exists := adWorkUnitsByPrincipal[crtb.UserPrincipalName]; exists {
+			if workUnitContainsName(&(*workunits)[index], crtb.UserName) {
+				(*workunits)[index].activeDirectoryCRTBs = append((*workunits)[index].activeDirectoryCRTBs, crtb)
+			} else {
+				logrus.Warnf("[%v] found CRTB for user with guid-based principal '%v' and name '%v', but no user object with that name matches the GUID or its associated DN. refusing to process",
+					identifyAdUserOperation, crtb.UserPrincipalName, crtb.UserName)
+			}
+		} else if index, exists = duplicateLocalWorkUnitsByPrincipal[crtb.UserPrincipalName]; exists {
+			if workUnitContainsName(&(*workunits)[index], crtb.UserName) {
+				(*workunits)[index].duplicateLocalCRTBs = append((*workunits)[index].duplicateLocalCRTBs, crtb)
+			} else {
+				logrus.Warnf("[%v] found CRTB for user with guid-based principal '%v' and name '%v', but no user object with that name matches the GUID or its associated DN. refusing to process",
+					identifyAdUserOperation, crtb.UserPrincipalName, crtb.UserName)
+			}
+		}
+	}
+
+	return nil
+}
+
+func collectPRTBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) error {
+	prtbInterface := sc.Management.ProjectRoleTemplateBindings("")
+	prtbList, err := prtbInterface.List(metav1.ListOptions{})
+	if err != nil {
+		logrus.Errorf("[%v] unable to fetch PRTB objects: %v", migrateAdUserOperation, err)
+		return err
+	}
+
+	adWorkUnitsByPrincipal, duplicateLocalWorkUnitsByPrincipal := principalsToMigrate(workunits)
+
+	for _, prtb := range prtbList.Items {
+		if index, exists := adWorkUnitsByPrincipal[prtb.UserPrincipalName]; exists {
+			if workUnitContainsName(&(*workunits)[index], prtb.UserName) {
+				(*workunits)[index].activeDirectoryPRTBs = append((*workunits)[index].activeDirectoryPRTBs, prtb)
+			} else {
+				logrus.Warnf("[%v] found PRTB for user with guid-based principal '%v' and name '%v', but no user object with that name matches the GUID or its associated DN. refusing to process",
+					identifyAdUserOperation, prtb.UserPrincipalName, prtb.UserName)
+			}
+		} else if index, exists = duplicateLocalWorkUnitsByPrincipal[prtb.UserPrincipalName]; exists {
+			if workUnitContainsName(&(*workunits)[index], prtb.UserName) {
+				(*workunits)[index].duplicateLocalPRTBs = append((*workunits)[index].duplicateLocalPRTBs, prtb)
+			} else {
+				logrus.Warnf("[%v] found PRTB for user with guid-based principal '%v' and name '%v', but no user object with that name matches the GUID or its associated DN. refusing to process",
+					identifyAdUserOperation, prtb.UserPrincipalName, prtb.UserName)
+			}
+		}
+	}
+
+	return nil
+}
+
+func collectGRBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) error {
+	grbInterface := sc.Management.GlobalRoleBindings("")
+	grbList, err := grbInterface.List(metav1.ListOptions{})
+	if err != nil {
+		logrus.Errorf("[%v] unable to fetch GRB objects: %v", migrateAdUserOperation, err)
+		return err
+	}
+
+	duplicateLocalWorkUnitsByName := map[string]int{}
+
+	for _, workunit := range *workunits {
+		for j := range workunit.duplicateUsers {
+			duplicateLocalWorkUnitsByName[workunit.duplicateUsers[j].Name] = j
+		}
+	}
+
+	for _, grb := range grbList.Items {
+		if index, exists := duplicateLocalWorkUnitsByName[grb.UserName]; exists {
+			(*workunits)[index].duplicateLocalGRBs = append((*workunits)[index].duplicateLocalGRBs, grb)
+		}
+	}
+
+	return nil
+}
+
+func updateCRTB(crtbInterface v3norman.ClusterRoleTemplateBindingInterface, oldCrtb *v3.ClusterRoleTemplateBinding, userName string, principalID string) error {
+	newAnnotations := oldCrtb.Annotations
+	if newAnnotations == nil {
+		newAnnotations = make(map[string]string)
+	}
+	newAnnotations[adGUIDMigrationAnnotation] = oldCrtb.UserPrincipalName
+	newLabels := oldCrtb.Labels
+	if newLabels == nil {
+		newLabels = make(map[string]string)
+	}
+	newLabels[migrationPreviousName] = oldCrtb.Name
+	newLabels[adGUIDMigrationLabel] = migratedLabelValue
+	newCrtb := &v3.ClusterRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         "",
+			Namespace:    oldCrtb.ObjectMeta.Namespace,
+			GenerateName: "crtb-",
+			Annotations:  newAnnotations,
+			Labels:       newLabels,
+		},
+		ClusterName:       oldCrtb.ClusterName,
+		UserName:          userName,
+		RoleTemplateName:  oldCrtb.RoleTemplateName,
+		UserPrincipalName: principalID,
+	}
+
+	// If we get an internal error during any of these ops, there's a good chance the webhook is overwhelmed.
+	// We'll take the opportunity to rate limit ourselves and try again a few times.
+
+	backoff := wait.Backoff{
+		Duration: 5 * time.Second,
+		Factor:   1.1,
+		Jitter:   0.1,
+		Steps:    10,
+	}
+
+	err := wait.ExponentialBackoff(backoff, func() (finished bool, err error) {
+		_, err = crtbInterface.Create(newCrtb)
+		if err != nil {
+			if apierrors.IsInternalError(err) {
+				logrus.Errorf("[%v] internal error while creating crtb, will backoff and retry: %v", migrateCrtbsOperation, err)
+				return false, err
+			}
+			return true, fmt.Errorf("[%v] unable to create new CRTB: %w", migrateCrtbsOperation, err)
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("[%v] permanent error when creating crtb, giving up: %v", migrateCrtbsOperation, err)
+	}
+
+	err = wait.ExponentialBackoff(backoff, func() (finished bool, err error) {
+		err = crtbInterface.DeleteNamespaced(oldCrtb.Namespace, oldCrtb.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			if apierrors.IsInternalError(err) {
+				logrus.Errorf("[%v] internal error while deleting crtb, will backoff and retry: %v", migrateCrtbsOperation, err)
+				return false, err
+			}
+			return true, fmt.Errorf("[%v] unable to delete old CRTB: %w", migrateCrtbsOperation, err)
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("[%v] permanent error when deleting crtb, giving up: %v", migrateCrtbsOperation, err)
+	}
+
+	return nil
+}
+
+func migrateCRTBs(workunit *migrateUserWorkUnit, sc *config.ScaledContext, dryRun bool) {
+	crtbInterface := sc.Management.ClusterRoleTemplateBindings("")
+	// First convert all GUID-based CRTBs to their equivalent Distinguished Name variants
+	dnPrincipalID := activeDirectoryPrefix + workunit.distinguishedName
+	for _, oldCrtb := range workunit.activeDirectoryCRTBs {
+		if dryRun {
+			logrus.Infof("[%v] DRY RUN: would migrate CRTB '%v' from GUID principal '%v' to DN principal '%v'. "+
+				"Additionally, an annotation, %v, would be added containing the principal being migrated from and"+
+				"labels, %v and %v, that will contain the name of the previous CRTB and indicate that this CRTB has been migrated.",
+				migrateCrtbsOperation, oldCrtb.Name, oldCrtb.UserPrincipalName, dnPrincipalID, adGUIDMigrationAnnotation, migrationPreviousName, adGUIDMigrationLabel)
+		} else {
+			err := updateCRTB(crtbInterface, &oldCrtb, workunit.originalUser.Name, dnPrincipalID)
+			if err != nil {
+				logrus.Errorf("[%v] error while migrating CRTBs for user '%v': %v", migrateCrtbsOperation, workunit.originalUser.Name, err)
+			}
+		}
+	}
+	// Now do the same for Local ID bindings on the users we are about to delete, pointing them instead to the merged
+	// original user that we will be keeping
+	localPrincipalID := localPrefix + workunit.originalUser.Name
+	for _, oldCrtb := range workunit.duplicateLocalCRTBs {
+		if dryRun {
+			logrus.Infof("[%v] DRY RUN: would migrate CRTB '%v' from duplicate local user '%v' to original user '%v'"+
+				"Additionally, an annotation, %v, would be added containing the principal being migrated from and"+
+				"labels, %v and %v, that will contain the name of the previous CRTB and indicate that this CRTB has been migrated.",
+				migrateCrtbsOperation, oldCrtb.Name, oldCrtb.UserPrincipalName, localPrincipalID, adGUIDMigrationAnnotation, migrationPreviousName, adGUIDMigrationLabel)
+		} else {
+			err := updateCRTB(crtbInterface, &oldCrtb, workunit.originalUser.Name, localPrincipalID)
+			if err != nil {
+				logrus.Errorf("[%v] error while migrating crtbs for user '%v': %v", migrateCrtbsOperation, workunit.originalUser.Name, err)
+			}
+		}
+	}
+}
+
+func updatePRTB(prtbInterface v3norman.ProjectRoleTemplateBindingInterface, oldPrtb *v3.ProjectRoleTemplateBinding, userName string, principalID string) error {
+	newAnnotations := oldPrtb.Annotations
+	if newAnnotations == nil {
+		newAnnotations = make(map[string]string)
+	}
+	newAnnotations[adGUIDMigrationAnnotation] = oldPrtb.UserPrincipalName
+	newLabels := oldPrtb.Labels
+	if newLabels == nil {
+		newLabels = make(map[string]string)
+	}
+	newLabels[migrationPreviousName] = oldPrtb.Name
+	newLabels[adGUIDMigrationLabel] = migratedLabelValue
+	newPrtb := &v3.ProjectRoleTemplateBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         "",
+			Namespace:    oldPrtb.ObjectMeta.Namespace,
+			GenerateName: "prtb-",
+			Annotations:  newAnnotations,
+			Labels:       newLabels,
+		},
+		ProjectName:       oldPrtb.ProjectName,
+		UserName:          userName,
+		RoleTemplateName:  oldPrtb.RoleTemplateName,
+		UserPrincipalName: principalID,
+	}
+
+	// If we get an internal error during any of these ops, there's a good chance the webhook is overwhelmed.
+	// We'll take the opportunity to rate limit ourselves and try again a few times.
+
+	backoff := wait.Backoff{
+		Duration: 5 * time.Second,
+		Factor:   1.1,
+		Jitter:   0.1,
+		Steps:    10,
+	}
+
+	err := wait.ExponentialBackoff(backoff, func() (finished bool, err error) {
+		_, err = prtbInterface.Create(newPrtb)
+		if err != nil {
+			if apierrors.IsInternalError(err) {
+				logrus.Errorf("[%v] internal error while creating prtb, will backoff and retry: %v", migratePrtbsOperation, err)
+				return false, err
+			}
+			return true, fmt.Errorf("[%v] unable to create new PRTB: %w", migratePrtbsOperation, err)
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("[%v] permanent error when creating prtb, giving up: %v", migratePrtbsOperation, err)
+	}
+
+	err = wait.ExponentialBackoff(backoff, func() (finished bool, err error) {
+		err = prtbInterface.DeleteNamespaced(oldPrtb.Namespace, oldPrtb.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			if apierrors.IsInternalError(err) {
+				logrus.Errorf("[%v] internal error while deleting prtb, will backoff and retry: %v", migratePrtbsOperation, err)
+				return false, err
+			}
+			return true, fmt.Errorf("[%v] unable to delete old PRTB: %w", migratePrtbsOperation, err)
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("[%v] permanent error when deleting prtb, giving up: %v", migratePrtbsOperation, err)
+	}
+
+	return nil
+}
+
+func migratePRTBs(workunit *migrateUserWorkUnit, sc *config.ScaledContext, dryRun bool) {
+	prtbInterface := sc.Management.ProjectRoleTemplateBindings("")
+	// First convert all GUID-based PRTBs to their equivalent Distinguished Name variants
+	dnPrincipalID := activeDirectoryPrefix + workunit.distinguishedName
+	for _, oldPrtb := range workunit.activeDirectoryPRTBs {
+		if dryRun {
+			logrus.Infof("[%v] DRY RUN: would migrate PRTB '%v' from GUID principal '%v' to DN principal '%v'. "+
+				"Additionally, an annotation, %v, would be added containing the principal being migrated from and"+
+				"labels, %v and %v, that will contain the name of the previous PRTB and indicate that this PRTB has been migrated.",
+				migratePrtbsOperation, oldPrtb.Name, oldPrtb.UserPrincipalName, dnPrincipalID, adGUIDMigrationAnnotation, migrationPreviousName, adGUIDMigrationLabel)
+
+		} else {
+			err := updatePRTB(prtbInterface, &oldPrtb, workunit.originalUser.Name, dnPrincipalID)
+			if err != nil {
+				logrus.Errorf("[%v] error while migrating prtbs for user '%v': %v", migratePrtbsOperation, workunit.originalUser.Name, err)
+			}
+		}
+	}
+	// Now do the same for Local ID bindings on the users we are about to delete, pointing them instead to the merged
+	// original user that we will be keeping
+	localPrincipalID := localPrefix + workunit.originalUser.Name
+	for _, oldPrtb := range workunit.duplicateLocalPRTBs {
+		if dryRun {
+			logrus.Infof("[%v] DRY RUN: would migrate PRTB '%v' from duplicate local user '%v' to original user '%v'"+
+				"Additionally, an annotation, %v, would be added containing the principal being migrated from and"+
+				"labels, %v and %v, that will contain the name of the previous PRTB and indicate that this PRTB has been migrated.",
+				migratePrtbsOperation, oldPrtb.Name, oldPrtb.UserPrincipalName, localPrincipalID, adGUIDMigrationAnnotation, migrationPreviousName, adGUIDMigrationLabel)
+
+		} else {
+			err := updatePRTB(prtbInterface, &oldPrtb, workunit.originalUser.Name, localPrincipalID)
+			if err != nil {
+				logrus.Errorf("[%v] error while migrating prtbs for user '%v': %v", migratePrtbsOperation, workunit.originalUser.Name, err)
+			}
+		}
+	}
+}
+
+func migrateGRBs(workunit *migrateUserWorkUnit, sc *config.ScaledContext, dryRun bool) {
+	grbInterface := sc.Management.GlobalRoleBindings("")
+
+	backoff := wait.Backoff{
+		Duration: 5 * time.Second,
+		Factor:   1.1,
+		Jitter:   0.1,
+		Steps:    10,
+	}
+
+	for _, oldGrb := range workunit.duplicateLocalGRBs {
+		if dryRun {
+			logrus.Infof("[%v] DRY RUN: would migrate GRB '%v' from duplicate local user '%v' to original user '%v'"+
+				"Additionally, labels %v and %v will be added. These contain the name of the previous GRB and indicate that this GRB has been migrated.",
+				migrateGrbsOperation, oldGrb.Name, oldGrb.UserName, workunit.originalUser.Name, migrationPreviousName, adGUIDMigrationLabel)
+		} else {
+			newLabels := oldGrb.Labels
+			if newLabels == nil {
+				newLabels = make(map[string]string)
+			}
+			newLabels[migrationPreviousName] = oldGrb.Name
+			newLabels[adGUIDMigrationLabel] = migratedLabelValue
+
+			newGrb := &v3.GlobalRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "",
+					GenerateName: "grb-",
+					Annotations:  oldGrb.Annotations,
+					Labels:       newLabels,
+				},
+				GlobalRoleName:     oldGrb.GlobalRoleName,
+				GroupPrincipalName: oldGrb.GroupPrincipalName,
+				UserName:           workunit.originalUser.Name,
+			}
+
+			err := wait.ExponentialBackoff(backoff, func() (finished bool, err error) {
+				_, err = grbInterface.Create(newGrb)
+				if err != nil {
+					if apierrors.IsInternalError(err) {
+						logrus.Errorf("[%v] internal error while creating GRB, will backoff and retry: %v", migrateGrbsOperation, err)
+						return false, err
+					}
+					return true, fmt.Errorf("[%v] unable to create new GRB: %w", migrateGrbsOperation, err)
+				}
+				return true, nil
+			})
+			if err != nil {
+				logrus.Errorf("[%v] permanent error while creating GRB, giving up: %v", migrateGrbsOperation, err)
+				continue
+			}
+
+			err = wait.ExponentialBackoff(backoff, func() (finished bool, err error) {
+				err = sc.Management.GlobalRoleBindings("").Delete(oldGrb.Name, &metav1.DeleteOptions{})
+				if err != nil {
+					if apierrors.IsInternalError(err) {
+						logrus.Errorf("[%v] internal error while deleting GRB, will backoff and retry: %v", migrateGrbsOperation, err)
+						return false, err
+					}
+					return true, fmt.Errorf("[%v] unable to delete old GRB: %w", migrateGrbsOperation, err)
+				}
+				return true, nil
+			})
+			if err != nil {
+				logrus.Errorf("[%v] permanent error when deleting GRB, giving up: %v", migrateGrbsOperation, err)
+			}
+		}
+	}
+}

--- a/pkg/agent/clean/adunmigration/tokens.go
+++ b/pkg/agent/clean/adunmigration/tokens.go
@@ -1,0 +1,129 @@
+package adunmigration
+
+import (
+	"fmt"
+	"time"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v3norman "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/rancher/rancher/pkg/auth/tokens"
+	"github.com/rancher/rancher/pkg/types/config"
+)
+
+func collectTokens(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) error {
+	tokenInterface := sc.Management.Tokens("")
+	tokenList, err := tokenInterface.List(metav1.ListOptions{})
+	if err != nil {
+		logrus.Errorf("[%v] unable to fetch token objects: %v", migrateAdUserOperation, err)
+		return err
+	}
+
+	adWorkUnitsByPrincipal, duplicateLocalWorkUnitsByPrincipal := principalsToMigrate(workunits)
+
+	for _, token := range tokenList.Items {
+		if index, exists := adWorkUnitsByPrincipal[token.UserPrincipal.Name]; exists {
+			if workUnitContainsName(&(*workunits)[index], token.UserID) {
+				(*workunits)[index].activeDirectoryTokens = append((*workunits)[index].activeDirectoryTokens, token)
+			} else {
+				logrus.Warnf("[%v] found token for user with guid-based principal '%v' and name '%v', but no user object with that name matches the GUID or its associated DN. refusing to process",
+					identifyAdUserOperation, token.UserPrincipal.Name, token.UserID)
+			}
+		} else if index, exists = duplicateLocalWorkUnitsByPrincipal[token.UserPrincipal.Name]; exists {
+			if workUnitContainsName(&(*workunits)[index], token.UserID) {
+				(*workunits)[index].duplicateLocalTokens = append((*workunits)[index].duplicateLocalTokens, token)
+			} else {
+				logrus.Warnf("[%v] found token for user with guid-based principal '%v' and name '%v', but no user object with that name matches the GUID or its associated DN. refusing to process",
+					identifyAdUserOperation, token.UserPrincipal.Name, token.UserID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func updateToken(tokenInterface v3norman.TokenInterface, userToken v3.Token, newPrincipalID string, guid string, targetUser *v3.User, targetPrincipal *v3.Principal) error {
+	latestToken, err := tokenInterface.Get(userToken.Name, metav1.GetOptions{})
+	if err != nil {
+		logrus.Errorf("[%v] token %s no longer exists: %v", migrateTokensOperation, userToken.Name, err)
+		return nil
+	}
+	if latestToken.Annotations == nil {
+		latestToken.Annotations = make(map[string]string)
+	}
+	latestToken.Annotations[adGUIDMigrationAnnotation] = guid
+	if latestToken.Labels == nil {
+		latestToken.Labels = make(map[string]string)
+	}
+	latestToken.Labels[tokens.UserIDLabel] = targetUser.Name
+	latestToken.Labels[adGUIDMigrationLabel] = migratedLabelValue
+	// use the new dnPrincipalID for the token name
+	latestToken.UserPrincipal.Name = newPrincipalID
+	// copy over other relevant fields to match the user we are attaching this token to
+	latestToken.UserPrincipal.LoginName = targetPrincipal.LoginName
+	latestToken.UserPrincipal.DisplayName = targetPrincipal.DisplayName
+	latestToken.UserID = targetUser.Name
+
+	// If we get an internal error during any of these ops, there's a good chance the webhook is overwhelmed.
+	// We'll take the opportunity to rate limit ourselves and try again a few times.
+
+	backoff := wait.Backoff{
+		Duration: 5 * time.Second,
+		Factor:   1.1,
+		Jitter:   0.1,
+		Steps:    10,
+	}
+
+	err = wait.ExponentialBackoff(backoff, func() (finished bool, err error) {
+		_, err = tokenInterface.Update(latestToken)
+		if err != nil {
+			if apierrors.IsInternalError(err) {
+				logrus.Errorf("[%v] internal error while updating token, will backoff and retry: %v", migrateTokensOperation, err)
+				return false, err
+			}
+			return true, fmt.Errorf("[%v] unable to update token: %w", migrateTokensOperation, err)
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("[%v] permanent error when updating token, giving up: %v", migrateTokensOperation, err)
+	}
+
+	return nil
+}
+
+func migrateTokens(workunit *migrateUserWorkUnit, sc *config.ScaledContext, dryRun bool) {
+	tokenInterface := sc.Management.Tokens("")
+	dnPrincipalID := activeDirectoryPrefix + workunit.distinguishedName
+	for _, userToken := range workunit.activeDirectoryTokens {
+		if dryRun {
+			logrus.Infof("[%v] DRY RUN: would migrate token '%v' from GUID principal '%v' to DN principal '%v'. "+
+				"Additionally, it would add an annotation, %v, indicating the former principalID of this token "+
+				"and a label, %v, to indicate that this token has been migrated",
+				migrateTokensOperation, userToken.Name, userToken.UserPrincipal.Name, dnPrincipalID, adGUIDMigrationAnnotation, adGUIDMigrationLabel)
+		} else {
+			err := updateToken(tokenInterface, userToken, dnPrincipalID, workunit.guid, workunit.originalUser, workunit.principal)
+			if err != nil {
+				logrus.Errorf("[%v] error while migrating tokens for user '%v': %v", migrateTokensOperation, workunit.originalUser.Name, err)
+			}
+		}
+	}
+
+	localPrincipalID := localPrefix + workunit.originalUser.Name
+	for _, userToken := range workunit.duplicateLocalTokens {
+		if dryRun {
+			logrus.Infof("[%v] DRY RUN: would migrate Token '%v' from duplicate local user '%v' to original user '%v'. "+
+				"Would add annotation, %v, and label, %v, to indicate migration status",
+				migrateTokensOperation, userToken.Name, userToken.UserPrincipal.Name, localPrincipalID, adGUIDMigrationAnnotation, adGUIDMigrationLabel)
+		} else {
+			err := updateToken(tokenInterface, userToken, localPrincipalID, workunit.guid, workunit.originalUser, workunit.principal)
+			if err != nil {
+				logrus.Errorf("[%v] error while migrating tokens for user '%v': %v", migrateTokensOperation, workunit.originalUser.Name, err)
+			}
+		}
+	}
+}

--- a/pkg/agent/clean/adunmigration/users.go
+++ b/pkg/agent/clean/adunmigration/users.go
@@ -1,0 +1,121 @@
+package adunmigration
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/types/config"
+)
+
+func describePlannedChanges(workunit migrateUserWorkUnit) {
+	logrus.Infof("DRY RUN: changes to user '%v' have NOT been saved.", workunit.originalUser.Name)
+	if len(workunit.duplicateUsers) > 0 {
+		logrus.Infof("[%v] DRY RUN: duplicate users were identified", migrateAdUserOperation)
+		for _, duplicateUser := range workunit.duplicateUsers {
+			logrus.Infof("[%v] DRY RUN: would DELETE user %v", migrateAdUserOperation, duplicateUser.Name)
+		}
+	}
+}
+
+func deleteDuplicateUsers(workunit migrateUserWorkUnit, sc *config.ScaledContext) error {
+	for _, duplicateUser := range workunit.duplicateUsers {
+		err := sc.Management.Users("").Delete(duplicateUser.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			logrus.Errorf("[%v] failed to delete dupliate user '%v' with: %v", migrateAdUserOperation, workunit.originalUser.Name, err)
+			// If the duplicate deletion has failed for some reason, it is NOT safe to save the modified user, as
+			// this may result in a duplicate AD principal ID. Notify and skip.
+
+			logrus.Errorf("[%v] cannot safely save modifications to user %v, skipping", migrateAdUserOperation, workunit.originalUser.Name)
+			return errors.Errorf("failed to delete duplicate users")
+		}
+		logrus.Infof("[%v] deleted duplicate user %v", migrateAdUserOperation, duplicateUser.Name)
+	}
+	return nil
+}
+
+func updateModifiedUser(workunit migrateUserWorkUnit, sc *config.ScaledContext) {
+	workunit.originalUser.Annotations[adGUIDMigrationAnnotation] = workunit.guid
+	workunit.originalUser.Labels[adGUIDMigrationLabel] = migratedLabelValue
+	_, err := sc.Management.Users("").Update(workunit.originalUser)
+	if err != nil {
+		logrus.Errorf("[%v] failed to save modified user '%v' with: %v", migrateAdUserOperation, workunit.originalUser.Name, err)
+	}
+	logrus.Infof("[%v] user %v was successfully migrated", migrateAdUserOperation, workunit.originalUser.Name)
+}
+
+func replaceGUIDPrincipalWithDn(user *v3.User, dn string, guid string, dryRun bool) {
+	// It's weird for a single user to have more than just an AD and a Local principal ID, but it *can* happen
+	// if Rancher has used more than one auth provider over its history. Here we'll keep all principal IDs
+	// that are unrelated to AD
+	var principalIDs []string
+	for _, principalID := range user.PrincipalIDs {
+		if !strings.HasPrefix(principalID, activeDirectoryPrefix) {
+			principalIDs = append(principalIDs, principalID)
+		}
+	}
+	principalIDs = append(principalIDs, activeDirectoryPrefix+dn)
+
+	if dryRun {
+		// In dry run mode we will merely print the computed list and leave the original user object alone
+		logrus.Infof("[%v] DRY RUN: User '%v' with GUID '%v' would have new principals:", migrateAdUserOperation,
+			guid, user.Name)
+		for _, principalID := range principalIDs {
+			logrus.Infof("[%v] DRY RUN:    '%v'", migrateAdUserOperation, principalID)
+		}
+	} else {
+		user.PrincipalIDs = principalIDs
+		logrus.Debugf("[%v] User '%v' with GUID %v will have new principals:", migrateAdUserOperation,
+			guid, user.Name)
+		for _, principalID := range user.PrincipalIDs {
+			logrus.Debugf("[%v]     '%v'", migrateAdUserOperation, principalID)
+		}
+	}
+}
+
+func isAdUser(user *v3.User) bool {
+	for _, principalID := range user.PrincipalIDs {
+		if strings.HasPrefix(principalID, activeDirectoryPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func adPrincipalID(user *v3.User) string {
+	for _, principalID := range user.PrincipalIDs {
+		if strings.HasPrefix(principalID, activeDirectoryPrefix) {
+			return principalID
+		}
+	}
+	return ""
+}
+
+func localPrincipalID(user *v3.User) string {
+	for _, principalID := range user.PrincipalIDs {
+		if strings.HasPrefix(principalID, localPrefix) {
+			return principalID
+		}
+	}
+	return ""
+}
+
+func getExternalID(principalID string) (string, error) {
+	parts := strings.Split(principalID, "://")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("[%v] failed to parse invalid principalID: %v", identifyAdUserOperation, principalID)
+	}
+	return parts[1], nil
+}
+
+func getScope(principalID string) (string, error) {
+	parts := strings.Split(principalID, "://")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("[%v] failed to parse invalid principalID: %v", identifyAdUserOperation, principalID)
+	}
+	return parts[0], nil
+}

--- a/pkg/auth/providers/activedirectory/activedirectory_provider.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_provider.go
@@ -6,9 +6,15 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rancher/norman/httperror"
+
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/tokens"
@@ -18,17 +24,24 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/user"
-	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
-	Name              = "activedirectory"
-	UserScope         = Name + "_user"
-	GroupScope        = Name + "_group"
-	ObjectClass       = "objectClass"
-	MemberOfAttribute = "memberOf"
+	Name                               = "activedirectory"
+	UserScope                          = Name + "_user"
+	GroupScope                         = Name + "_group"
+	ObjectClass                        = "objectClass"
+	MemberOfAttribute                  = "memberOf"
+	StatusConfigMapName                = "ad-guid-migration"
+	StatusConfigMapNamespace           = "cattle-system"
+	StatusMigrationField               = "ad-guid-migration-status"
+	StatusMigrationFinished            = "Finished"
+	StatusMigrationRunning             = "Running"
+	StatusMigrationFinishedWithSkipped = "FinishedWithSkipped"
+	StatusMigrationFinishedWithMissing = "FinishedWithMissing"
+	StatusMigrationFailed              = "Failed"
+	StatusLoginDisabled                = "login is disabled while migration is running"
+	StatusACMigrationRunning           = "migration-ad-guid-migration-status"
 )
 
 var scopes = []string{UserScope, GroupScope}
@@ -36,6 +49,7 @@ var scopes = []string{UserScope, GroupScope}
 type adProvider struct {
 	ctx         context.Context
 	authConfigs v3.AuthConfigInterface
+	configMaps  corev1.ConfigMapLister
 	secrets     corev1.SecretInterface
 	userMGR     user.Manager
 	certs       string
@@ -47,6 +61,7 @@ func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.
 	return &adProvider{
 		ctx:         ctx,
 		authConfigs: mgmtCtx.Management.AuthConfigs(""),
+		configMaps:  mgmtCtx.Core.ConfigMaps("").Controller().Lister(),
 		secrets:     mgmtCtx.Core.Secrets(""),
 		userMGR:     userMGR,
 		tokenMGR:    tokenMGR,
@@ -81,6 +96,11 @@ func (p *adProvider) AuthenticateUser(ctx context.Context, input interface{}) (v
 	config, caPool, err := p.getActiveDirectoryConfig()
 	if err != nil {
 		return v3.Principal{}, nil, "", errors.New("can't find authprovider")
+	}
+
+	// If a migration is running, we need to block logins and indicate why we are doing so
+	if config.Annotations != nil && config.Annotations[StatusACMigrationRunning] == StatusMigrationRunning {
+		return v3.Principal{}, nil, "", httperror.WrapAPIError(err, httperror.ClusterUnavailable, StatusLoginDisabled)
 	}
 
 	principal, groupPrincipal, err := p.loginUser(login, config, caPool, false)
@@ -237,6 +257,13 @@ func (p *adProvider) GetUserExtraAttributes(userPrincipal v3.Principal) map[stri
 		extras[common.UserAttributeUserName] = []string{userPrincipal.LoginName}
 	}
 	return extras
+}
+
+type LoginDisabledError struct{}
+
+// Error provides a string representation of an LdapErrorNotFound
+func (e LoginDisabledError) Error() string {
+	return StatusLoginDisabled
 }
 
 // IsDisabledProvider checks if the Azure Active Directory provider is currently disabled in Rancher.

--- a/pkg/auth/providers/common/provider_util.go
+++ b/pkg/auth/providers/common/provider_util.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Decode will decode to the output structure by creating a custom decoder
+// that uses the stringToK8sTimeHookFunc to handle the metav1.Time field properly.
+func Decode(input, output any) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: stringToK8sTimeHookFunc(),
+		Result:     output,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to create decoder for Config: %w", err)
+	}
+	err = decoder.Decode(input)
+	if err != nil {
+		return fmt.Errorf("unable to decode Config: %w", err)
+	}
+	return nil
+}
+
+// stringToTimeHookFunc returns a DecodeHookFunc that converts strings to metav1.Time.
+func stringToK8sTimeHookFunc() mapstructure.DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		if t != reflect.TypeOf(metav1.Time{}) {
+			return data, nil
+		}
+
+		// Convert it by parsing
+		stdTime, err := time.Parse(time.RFC3339, data.(string))
+		return metav1.Time{Time: stdTime}, err
+	}
+}

--- a/pkg/multiclustermanager/app.go
+++ b/pkg/multiclustermanager/app.go
@@ -7,8 +7,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rancher/rancher/pkg/agent/clean/adunmigration"
+
 	"github.com/pkg/errors"
 	"github.com/rancher/norman/types"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
 	"github.com/rancher/rancher/pkg/auth/tokens"
@@ -28,8 +33,6 @@ import (
 	"github.com/rancher/rancher/pkg/tunnelserver/mcmauthorizer"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/wrangler"
-	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Options struct {
@@ -213,6 +216,7 @@ func (m *mcm) Start(ctx context.Context) error {
 			return errors.Wrap(err, "failed to telemetry")
 		}
 
+		go adunmigration.UnmigrateAdGUIDUsersOnce(m.ScaledContext)
 		tokens.StartPurgeDaemon(ctx, management)
 		providerrefresh.StartRefreshDaemon(ctx, m.ScaledContext, management)
 		managementdata.CleanupOrphanedSystemUsers(ctx, management)


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/rancher/issues/42161
https://github.com/rancher/rancher/issues/42162
https://github.com/rancher/rancher/issues/42163
 
## Problem
In Rancher v2.7.5 we attempted to automatically migrate Active Directory users, changing their internal ID within Rancher from their fully qualified Distinguished Name to a GUID. There were two fatal flaws in this initial migration that were missed during testing:
- The LDAP search to locate the matching GUID for a Distinguished Name was incorrectly scoped, and failed to locate users in nested directories
- A race condition during migration caused user objects to be duplicated if anyone tried to log in before their account had been processed
 
Affected users were instructed to restore from a backup if one was available, and 2.7.5 is no longer recommended as an upgrade for Active Directory users. However, some users were not affected by the bugs in the script and have a working GUID-based system on 2.7.5 today, and others were affected by the bugs but are unable to restore to a suitable backup. Thus, we need a way to cleanly migrate both sets of users back to DN-based IDs.

## Solution
This PR adds an **unmigration** script that can be run standalone for users on 2.7.4/2.7.5 with a botched migration, or automatically run at 2.7.6 during startup. It performs the following operations:

- Users with GUID-based Active Directory Principal IDs, are migrated back to Distinguished Names
- Duplicate users created by the original migration logic are merged, and permissions reassigned accordingly
- Optionally, any GUID-based users that are missing in Active Directory can be removed
 
## Testing
For standalone mode, first build the rancher image from this PR and have it available

- On Rancher 2.7.4, configure Active Directory, then add any users you wish to test the script against
- Upgrade Rancher to 2.7.5, which will trigger the original broken migration logic
  - Depending on the users added, logins may break during this step
- From the cleanup directory, run: `./ad-guid-unmigration.sh your-repo:rancher-agent:your-tag -dry-run`, replacing the image with the one you built
- After the dry run is complete, review its output. Remove the `-dry-run` flag, and optionally add the `-delete-missing` flag if you are testing that behavior, and run the script again
- After the script completes, you may immediately upgrade Rancher to 2.7.6 and test logins
  - Do not restart Rancher 2.7.5 after this point, or the original (broken) migration will run again

For testing startup behavior:
- On Rancher 2.7.4, configure Active Directory, then add any users you wish to test the script against
- Upgrade Rancher to 2.7.5, which will trigger the original broken migration logic
  - Depending on the users added, logins may break during this step
- Upgrade Rancher to 2.7.6, which should trigger the startup script
  - While the script is running, logins should be denied with a generic message
  - Script output currently goes to the `rancher` pod that ran the migration, the UI work to surface this to the user will be in a separate PR

## Engineering Testing
### Manual Testing

Manual testing was performed using an internal Active Directory server, configured with nested groups to ensure that the unmigration logic is able to resolve those distinguished names. QA is separately working on automation to scale these tests up to thousands of users, so we can profile performance.

### Automated Testing

Unit tests are planned, but not currently implemented due to tight deadlines surrounding the feature. Issue: https://github.com/rancher/rancher/issues/42328

We'll probably do these as a separate PR.

## QA Testing Considerations

We'll want to be sure to test at least the following scenarios:
- GUID users present in AD (standard case)
- Two duplicate users with the AD principal ID set to the **same** GUID
  - This is difficult to consistently trigger when doing the 2.7.5 migration normally. We may need to manually edit a user object to force a conflict for testing
- GUID users that are deleted in Active Directory before the unmigration logic is run
- Duplicates created when Nested Users try to log into 2.7.5
- CRTBs, PRTBs, and API Tokens assigned to any of the above
 
### Regressions Considerations

_This_ PR should not directly cause a regression, as it assists in reverting user objects to their 2.7.4 behavior. The move away from GUIDs will re-open https://github.com/rancher/rancher/issues/37994 