### PR TITLE
Update Secret Type in Pre/Post Workload Upgrade Validation Tests

### DIFF
--- a/tests/v2/validation/upgrade/workload_test.go
+++ b/tests/v2/validation/upgrade/workload_test.go
@@ -116,7 +116,7 @@ func (u *UpgradeWorkloadTestSuite) testPreUpgradeSingleCluster(clusterName strin
 	u.T().Logf("Validating daemonset[%v] available replicas number is equal to worker nodes number in the cluster [%v]", names.random["daemonsetName"], project.ClusterID)
 	validateDaemonset(u.T(), client, project.ClusterID, namespace.Name, names.random["daemonsetName"])
 
-	secretTemplate := secrets.NewSecretTemplate(names.random["secretName"], namespace.Name, map[string][]byte{"test": []byte("test")}, corev1.SecretTypeBasicAuth)
+	secretTemplate := secrets.NewSecretTemplate(names.random["secretName"], namespace.Name, map[string][]byte{"test": []byte("test")}, corev1.SecretTypeOpaque)
 
 	u.T().Logf("Creating a secret with name [%v]", names.random["secretName"])
 	createdSecret, err := steveClient.SteveType(secrets.SecretSteveType).Create(secretTemplate)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [#832](https://github.com/rancher/qa-tasks/issues/832)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Secrets creations in pre/post workload tests fail due to wrong secret type usage.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Update the secret type to Opaque from Basic Auth.

## Engineering Testing

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)