### PR TITLE
[DNM] Add necessary rule to allow force-deletion of nodes when stuck in deleting state

### DIFF
--- a/pkg/data/management/role_data.go
+++ b/pkg/data/management/role_data.go
@@ -479,6 +479,8 @@ func addUserRules(role *roleBuilder) *roleBuilder {
 		addRule().apiGroups("project.cattle.io").resources("sourcecoderepositories").verbs("*").
 		addRule().apiGroups("provisioning.cattle.io").resources("clusters").verbs("create").
 		addRule().apiGroups("rke-machine-config.cattle.io").resources("*").verbs("create").
+		// these permissions are required for rke2 `force-delete` to work as it's done by adding annotation to machine object
+		addRule().apiGroups("rke-machine.cattle.io").resources("*").verbs("get", "list", "update").
 		addRule().apiGroups("management.cattle.io").resources("rancherusernotifications").verbs("get", "list", "watch")
 
 	return role


### PR DESCRIPTION
## Issue: #41698 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When you're a regular user with the "Create Clusters" role
AND
When deleting a cluster, the deletion on the provisioning side fails (credential bad etc) the Node will be stuck in a deleting state. Naturally the user would reach for the `force-delete` button but they would be denied for some reason, this was due to a missing permission.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
By adding the permission `rke.cattle.io/*/update` the force-delete operation goes through
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
The issue linked has some very good steps for reproducing this.

The only thing I would add is this works for any RKE2 dynamic schema - I tested with Digital Ocean. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Following that issue, I mainly:
1. Created a user `testuser` as a standard user with the `clusters-create` role
2. Created a cluster with a DO token
3. Let the cluster provision
4. Removed the token on the DO side, so the delete would fail
5. Deleted the cluster
6. Waited for the `DeleteError` to propagate through Rancher
7. Go to the machine pool and force-delete the node.

Pre-patch, that would have failed with the `no resource found` error, after this patch it will succeed. 

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: not sure if we have RBAC related tests anywhere - I will look into it. 
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_