### PR TITLE
Update CSP billing adapter namespace

### DIFF
--- a/pkg/managedcharts/cspadapter/cspadapter.go
+++ b/pkg/managedcharts/cspadapter/cspadapter.go
@@ -19,7 +19,7 @@ const (
 	MLOChartName = "rancher-csp-adapter"
 	// PAYGChartNamespace is the namespace that we expect the adapter to be installed in,
 	// for the new Pay-As-You-Go (PAYG) license offering
-	PAYGChartNamespace = "cattle-csp-billing-adapter-system"
+	PAYGChartNamespace = "cattle-system"
 	// PAYGChartName is the name of the csp adapter chart for PAYG licensing.
 	PAYGChartName = "rancher-csp-billing-adapter"
 )


### PR DESCRIPTION
To support PAYG offering, we need to have an umbrella helm chart to encapsulate Rancher, usage operator, and billing adapter into a single release. Since Rancher must be using the cattle-system namespace, this will restrict the umbrella chart to confine to the same namespace. Furthermore, helm does not effectively support installing subcharts into different namespaces without hardcoding it into the subcharts, we must also need to check for the PAYG CSP billing adapter in the same namespace as Rancher.

## Issue: <!-- link the issue or issues this PR resolves here -->
The original PR #41849 assumed that Rancher can be packaged as a subchart in the PAYG marketplace offerring. Unfortunately, Rancher chart must be installed into `cattle-system` namespace instead of `cattle-csp-billing-adapter-system` namespace as the original PR intended.
 
## Problem
The original PR #41849 assumed that Rancher can be packaged as a subchart in the PAYG marketplace offerring. Unfortunately, Rancher chart must be installed into `cattle-system` namespace instead of `cattle-csp-billing-adapter-system` namespace as the original PR intended.
 
## Solution
In order to successfully package Rancher into an umbrella chart, we must also move the PAYG CSP billing adapter to
`cattle-system` as well.
 
## Testing
The original test plan still applicable.

## Engineering Testing
### Manual Testing
1. Manually built the Rancher image with the changes.
2. Ensure support config is successfully generated.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* Existing unit tests applicable to this change.