### PR TITLE
Adjust the rendering of config map values for the webhook in main chart

### DIFF
--- a/chart/templates/configMap.yaml
+++ b/chart/templates/configMap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   priorityClassName:  {{ .Values.priorityClassName }}
   {{- if and .Values.webhook (kindIs "string" .Values.webhook) }}
-  rancher-webhook: {{  .Values.webhook | nindent 4 | squote }}
+  rancher-webhook: {{ .Values.webhook | quote }}
   {{- else if .Values.webhook }}
-  rancher-webhook: {{ toYaml .Values.webhook | nindent 4 | squote }}
+  rancher-webhook: {{ toYaml .Values.webhook | quote }}
   {{- end }}

--- a/chart/tests/configmap_test.yaml
+++ b/chart/tests/configmap_test.yaml
@@ -5,7 +5,8 @@ templates:
 tests:
   - it: should set webhook value from string
     set:
-      webhook: 'hostNetwork: true
+      webhook: |-
+        hostNetwork: true
         newKey: newValue
         newlist:
           - list1
@@ -15,11 +16,11 @@ tests:
           entry1: 1
           entry2: 2
           entry3:
-            sub3: "sub"'
+            sub3: "sub"
     asserts:
       - equal:
           path: data.rancher-webhook
-          value: '
+          value: |-
             hostNetwork: true
             newKey: newValue
             newlist:
@@ -30,18 +31,22 @@ tests:
               entry1: 1
               entry2: 2
               entry3:
-                sub3: "sub"'
+                sub3: "sub"
 
   - it: should set webhook value from map
     set:
       webhook.hostNetwork: true
       webhook.newKey: 2
+      webhook.innerMap:
+        foo: bar
     asserts:
       - equal:
           path: data.rancher-webhook
-          value: "
+          value: |-
             hostNetwork: true
-            newKey: 2"
+            innerMap:
+              foo: bar
+            newKey: 2
 
   - it: should not set webhook values
     asserts:

--- a/pkg/controllers/dashboard/chart/chart.go
+++ b/pkg/controllers/dashboard/chart/chart.go
@@ -8,8 +8,8 @@ import (
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/settings"
 	corev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
-	"gopkg.in/yaml.v2"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/pkg/controllers/dashboard/systemcharts/controller_test.go
+++ b/pkg/controllers/dashboard/systemcharts/controller_test.go
@@ -303,7 +303,7 @@ func Test_ChartInstallation(t *testing.T) {
 					"capi": map[string]interface{}{
 						"enabled": false,
 					},
-					"mcm": map[any]interface{}{
+					"mcm": map[string]interface{}{
 						"enabled": false,
 					},
 					"global": "",


### PR DESCRIPTION
## Issue: related to https://github.com/rancher/rancher/issues/41142
 
## Problem
Whether users specify the webhook configuration as a string in a file (using Helm's set-file flag) or a map (using Helm's set flags), the chart must have a properly rendered object.