### PR TITLE
Check cluster RancherKubernetesEngineConfig field != nil before migra…

### DIFF
--- a/pkg/controllers/management/secretmigrator/clusters.go
+++ b/pkg/controllers/management/secretmigrator/clusters.go
@@ -645,7 +645,8 @@ func cleanQuestions(cluster *apimgmtv3.Cluster) {
 			}
 			delete(answers.Values, key)
 		}
-		if cluster.Spec.RancherKubernetesEngineConfig.CloudProvider.VsphereCloudProvider != nil {
+		if cluster.Spec.RancherKubernetesEngineConfig != nil &&
+			cluster.Spec.RancherKubernetesEngineConfig.CloudProvider.VsphereCloudProvider != nil {
 			vcenters := cluster.Spec.RancherKubernetesEngineConfig.CloudProvider.VsphereCloudProvider.VirtualCenter
 			for k := range vcenters {
 				key := fmt.Sprintf(VcenterAnswersPath, k)


### PR DESCRIPTION
…ting vcenter related secrets

## Issue: #42377 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When creating/replacing a cluster and setting `.spec.rancherKubernetesEngineConfig` == null it seems that it causes a panic during the secretMigrator functionality. It looks like this is due to a field in a struct being nil and no check happening before accessing it. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Check for nil on cluster.spec.rancherKubernetesEngineConfig before accessing the struct's fields. 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

The POST in the issue should reproduce it - before this patch it should cause the pods to go into a panic, after this patch it should result in things carrying on like normal. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

No testing was done - since this just adds a nil check before accessing a field to prevent the panic. 

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: there are no unit tests for this piece of functionality, at least none that I could easily add to. 
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
Summary: Adding a nil check before accessing a certian field on the cluster .spec.rancherKubernetesEngineConfig prevents a panic when migrating the secrets. 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
This should be a pretty safe ticket just due to the fact that we're just adding a nil check - only preventing a panic if the conditions are right. 
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
n/a

Existing / newly added automated tests that provide evidence there are no regressions:
* n/a

---

SURE-6754