### PR TITLE
fix(sec): upgrade github.com/matryer/moq to 0.1.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -312,7 +312,7 @@ require (
 	github.com/lib/pq v1.10.4 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/matryer/moq v0.0.0-20200607124540-4638a53893e6 // indirect
+	github.com/matryer/moq v0.1.6 // indirect
 	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in github.com/matryer/moq v0.0.0-20200607124540-4638a53893e6
- [MPS-2022-13422](https://www.oscs1024.com/hd/MPS-2022-13422)


### What did I do？
Upgrade github.com/matryer/moq from v0.0.0-20200607124540-4638a53893e6 to 0.1.6 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS