### PR TITLE
fix(sec): upgrade github.com/docker/docker to 23.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/crewjam/saml v0.4.13
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.2+incompatible
-	github.com/docker/docker v23.0.2+incompatible
+	github.com/docker/docker v23.0.3+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/ehazlett/simplelog v0.0.0-20200226020431-d374894e92a4
 	github.com/evanphx/json-patch v4.12.0+incompatible


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in github.com/docker/docker v23.0.2+incompatible
- [CVE-2023-28840](https://www.oscs1024.com/hd/CVE-2023-28840)


### What did I do？
Upgrade github.com/docker/docker from v23.0.2+incompatible to 23.0.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](​https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](​https://www.oscs1024.com/docs/pr-specification/) from OSCS