### PR TITLE
Support passing  `skipFilter` and `k8sVersion` when getting chart index

### DIFF
--- a/pkg/api/steve/catalog/content.go
+++ b/pkg/api/steve/catalog/content.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/rancher/pkg/catalogv2/content"
@@ -148,10 +149,13 @@ func (i *contentDownload) serveChart(apiContext *types.APIRequest, rw http.Respo
 	return err
 }
 
-// getIndex retrieves the index file from the Helm repository
+// getIndex retrieves the index file from the Helm repository.
+// It skips filter if the query parameter "skipFilter" is set to "true" in the API request.
 func (i *contentDownload) getIndex(apiContext *types.APIRequest) (*repo.IndexFile, error) {
 	namespace, name := nsAndName(apiContext)
-	return i.contentManager.Index(namespace, name, false)
+	rawValue := apiContext.Request.URL.Query().Get("skipFilter")
+	skipFilter := strings.ToLower(rawValue) == "true"
+	return i.contentManager.Index(namespace, name, skipFilter)
 }
 
 // nsAndName returns the namespace and name from the API context. If the

--- a/pkg/api/steve/catalog/content.go
+++ b/pkg/api/steve/catalog/content.go
@@ -150,12 +150,16 @@ func (i *contentDownload) serveChart(apiContext *types.APIRequest, rw http.Respo
 }
 
 // getIndex retrieves the index file from the Helm repository.
-// It skips filter if the query parameter "skipFilter" is set to "true" in the API request.
+// By default, the index file contains versions filtered by rancher version and the local cluster's k8s version;
+// If "skipFilter" is set to "true" in the API request, the index file will contain all versions for all charts;
+// if "k8sVersion" is set, the index file will contain versions filtered by rancher version and the k8s version.
 func (i *contentDownload) getIndex(apiContext *types.APIRequest) (*repo.IndexFile, error) {
 	namespace, name := nsAndName(apiContext)
-	rawValue := apiContext.Request.URL.Query().Get("skipFilter")
+	query := apiContext.Request.URL.Query()
+	rawValue := query.Get("skipFilter")
 	skipFilter := strings.ToLower(rawValue) == "true"
-	return i.contentManager.Index(namespace, name, skipFilter)
+	targetClusterVersion := query.Get("k8sVersion")
+	return i.contentManager.Index(namespace, name, targetClusterVersion, skipFilter)
 }
 
 // nsAndName returns the namespace and name from the API context. If the

--- a/pkg/catalogv2/system/system.go
+++ b/pkg/catalogv2/system/system.go
@@ -239,7 +239,7 @@ func (m *Manager) Remove(namespace, name string) {
 }
 
 func (m *Manager) install(namespace, name, minVersion, exactVersion string, values map[string]interface{}, forceAdopt bool, installImageOverride string) error {
-	index, err := m.content.Index("", "rancher-charts", true)
+	index, err := m.content.Index("", "rancher-charts", "", true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/rancher/issues/40641

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
When we are about to create a downstream REK2  cluster, UI retrieves the chart index file of the builtin repo `rancher-rke2-charts` via the `/v1/catalog.cattle.io.clusterrepos/rancher-rke2-charts?link=index` endpoint.  UI uses the index file as the source of truth to determine whether it retrieves a particular version of the `rancher-vsphere-csi` and  `rancher-vsphere-cpi` charts to populate forms. 

The versions in the index file are filtered by the local cluster k8s version and Rancher server version. 

It becomes a problem when the versions of those two charts for the particular REK2 version are not in the index file because they are incompatible with the local cluster's k8s version.  Examples are in [this comment](https://github.com/rancher/rancher/issues/40641#issuecomment-1672350699).

Note that the bug cannot be reproduced on v2.7-head or v2.8-head image, because the filter is skipped when the Rancher version is not a released version. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
1. Allow skipping filters 

The backend will recognize the key `skipFilter` in the request URL's query values, and use its value, as a boolean, to instruct whether to filter versions when generating the index file.  The new key is optional.

Once this fix is available in the backend, UI will  set `skipFilter=true` in the request to get the unfiltered RKE2 chart index:
```
/v1/catalog.cattle.io.clusterrepos/rancher-rke2-charts?link=index&skipFilter=true
```

2. Allow setting the target k8s version for which the index file is generated 

The backend will recognize the key `k8sVersion` in the request URL's query values. The backend will use its value, instead of the local cluster version, as the filter when generating the index file.  The new key is also optional.

For example, if UI sends the following request to the backend:
```
/v1/catalog.cattle.io.clusterrepos/rancher-rke2-charts?link=index&k8sVersion=v1.25.4%2bk3s1
```
The returned index file will contain versions available on the k8s `v1.25.4+k3s1` cluster. 


## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

I validated that the fix works by building a custom rancher v2.7.5 image from the PR's branch and running it locally.
I confirmed the changes worked as expected by sending the request to the endpoint with different query values. 

### Automated Testing

None 

No tests are added in this PR due to the lack of the framework capable of testing this fix/change. 
If we want to test this change, we need to implement a mock "contentManager" which contains a mock ConfigMapCache, SecretCache, ClusterRepoCache, etc. We also need to prepare them with some testing data. 
 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
The bug is not reproducible on v2.7-head or v2.8-head. QA needs to use a Rancher RC version to validate the fix. 
Also, we need to have the UI fix merged before validating the fix. 

On the Rancher RC version which is cut before the fix, QA will be able to reproduce the bug; 
on the Rancher RC which contains the fix, the bug should disappear, for both fresh install and upgrade scenarios. 


### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
 

N/A


Existing / newly added automated tests that provide evidence there are no regressions:
 

N/A