### PR TITLE
Remove etcdsnapshot controller from imported cluster

### DIFF
--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -38,7 +38,7 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 	windows.Register(ctx, clusterRec, cluster)
 	nsserviceaccount.Register(ctx, cluster)
 	if features.RKE2.Enabled() {
-		// Just register the snapshot controller  if the cluster is administrated by rancher.
+		// Just register the snapshot controller if the cluster is administrated by rancher.
 		if clusterRec.Annotations["provisioning.cattle.io/administrated"] == "true" {
 			snapshotbackpopulate.Register(ctx, cluster)
 		}

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -39,7 +39,7 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 	nsserviceaccount.Register(ctx, cluster)
 	if features.RKE2.Enabled() {
 		// Just register the snapshot controller  if the cluster is administrated by rancher.
-		if administratedByRancher, ok := clusterRec.Annotations["provisioning.cattle.io/administrated"]; ok && administratedByRancher == "true" {
+		if clusterRec.Annotations["provisioning.cattle.io/administrated"] == "true" {
 			snapshotbackpopulate.Register(ctx, cluster)
 		}
 		pspdelete.Register(ctx, cluster)

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -38,7 +38,10 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 	windows.Register(ctx, clusterRec, cluster)
 	nsserviceaccount.Register(ctx, cluster)
 	if features.RKE2.Enabled() {
-		snapshotbackpopulate.Register(ctx, cluster)
+		// Just register the snapshot controller  if the cluster is administrated by rancher. There is no point on creating ETCDSnapshots for
+		if administratedByRancher, ok := clusterRec.Annotations["provisioning.cattle.io/administrated"]; ok && administratedByRancher == "true" {
+			snapshotbackpopulate.Register(ctx, cluster)
+		}
 		pspdelete.Register(ctx, cluster)
 		machinerole.Register(ctx, cluster)
 	}

--- a/pkg/controllers/managementuser/controllers.go
+++ b/pkg/controllers/managementuser/controllers.go
@@ -38,7 +38,7 @@ func Register(ctx context.Context, mgmt *config.ScaledContext, cluster *config.U
 	windows.Register(ctx, clusterRec, cluster)
 	nsserviceaccount.Register(ctx, cluster)
 	if features.RKE2.Enabled() {
-		// Just register the snapshot controller  if the cluster is administrated by rancher. There is no point on creating ETCDSnapshots for
+		// Just register the snapshot controller  if the cluster is administrated by rancher.
 		if administratedByRancher, ok := clusterRec.Annotations["provisioning.cattle.io/administrated"]; ok && administratedByRancher == "true" {
 			snapshotbackpopulate.Register(ctx, cluster)
 		}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #38711 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
When the  S3  ETCD snapshots backup is configured directly through RKE2 the rke2 configMap that is used to generates ETCDSnapshots is populated.

Once that cluster is imported Rancher creates ETCDSnapshots based on the configMap but never deletes them.
The deletion occurs based on a machine-plan secret that doesn't exist for imported clusters. 

 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
The ETCDSnapshots are used to store the snapshot location and to be "recovered" on rancher UI. That only can be done to clusters administrated by rancher .
 
Do not register the `snapshotbackpopulate` controller for imported clusters.
 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Create a cluster with etcds s3 backup configured. Import it to rancher. Check if the ETCDSnapshots were created (they were not supposed to be created).

Create a cluster through rancher with etcds s3 backup enabled.  They should be imported to rancher as ETCDSnapshots. 