### PR TITLE
Allow admins to specify TLS min version 1.3

### DIFF
--- a/pkg/tls/config.go
+++ b/pkg/tls/config.go
@@ -3,25 +3,22 @@ package tls
 import (
 	"crypto/tls"
 	"fmt"
+	"sort"
 	"strings"
-
-	"github.com/rancher/rancher/pkg/settings"
-)
-
-const (
-	httpsMode = "https"
-	acmeMode  = "acme"
 )
 
 var (
-	tlsVersions = map[string]uint16{
+	validVersions = map[string]uint16{
+		"1.3": tls.VersionTLS13,
 		"1.2": tls.VersionTLS12,
+		// Deprecated.
 		"1.1": tls.VersionTLS11,
+		// Deprecated.
 		"1.0": tls.VersionTLS10,
 	}
 
 	// https://golang.org/pkg/crypto/tls/#pkg-constants
-	tlsCipherSuites = map[string]uint16{
+	validCiphers10to12 = map[string]uint16{
 		"TLS_RSA_WITH_RC4_128_SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
 		"TLS_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
 		"TLS_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
@@ -45,54 +42,72 @@ var (
 		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
 		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 	}
+
+	validCiphers13 = map[string]uint16{
+		"TLS_AES_128_GCM_SHA256":       tls.TLS_AES_128_GCM_SHA256,
+		"TLS_AES_256_GCM_SHA384":       tls.TLS_AES_256_GCM_SHA384,
+		"TLS_CHACHA20_POLY1305_SHA256": tls.TLS_CHACHA20_POLY1305_SHA256,
+	}
 )
 
-func BaseTLSConfig() (*tls.Config, error) {
-	// Get configured minimal tls version
-	TLSMinVersion, err := lookupTLSVersion()
+func baseTLSConfig(minVersion, ciphers string) (*tls.Config, error) {
+	version, err := validatedMinVersion(minVersion)
 	if err != nil {
-		return nil, fmt.Errorf("error while configuring minimal TLS version: %s", err)
+		return nil, err
 	}
-	// Get configured tls ciphers
-	TLSCiphers, err := lookupTLSCiphers()
+	cipherSuites, err := validatedCiphers(ciphers, version)
 	if err != nil {
-		return nil, fmt.Errorf("error while configuring TLS ciphers: %s", err)
+		return nil, err
 	}
-
 	return &tls.Config{
-		PreferServerCipherSuites: true,
-		MinVersion:               TLSMinVersion,
-		CipherSuites:             TLSCiphers,
+		MinVersion:   version,
+		CipherSuites: cipherSuites,
 	}, nil
 }
 
-func lookupTLSVersion() (uint16, error) {
-	tlsVersionKeys := getKeysFromMap(tlsVersions)
-	settingsTLSMinVersion := settings.TLSMinVersion.Get()
-	if val, ok := tlsVersions[settingsTLSMinVersion]; ok {
+func validatedMinVersion(version string) (uint16, error) {
+	if val, ok := validVersions[strings.TrimSpace(version)]; ok {
 		return val, nil
 	}
-	return 0, fmt.Errorf("invalid minimal TLS version [%s], must be one of: %s", settingsTLSMinVersion, strings.Join(tlsVersionKeys, " "))
+	valid := keysFromMap(validVersions)
+	sort.Strings(valid)
+	return 0, fmt.Errorf("unsupported minimal TLS version %s, must be one of: %s", version, strings.Join(valid, ", "))
 }
 
-func lookupTLSCiphers() ([]uint16, error) {
-	tlsCipherSuitesKeys := getKeysFromMap(tlsCipherSuites)
-	settingsTLSCiphers := settings.TLSCiphers.Get()
-	sliceTLSCiphers := strings.Split(settingsTLSCiphers, ",")
-
-	var TLSCiphers []uint16
-	for _, TLSCipher := range sliceTLSCiphers {
-		val, ok := tlsCipherSuites[strings.TrimSpace(TLSCipher)]
-		if !ok {
-			return []uint16{}, fmt.Errorf("unsupported cipher [%s], must be one or more from: %s", TLSCipher, strings.Join(tlsCipherSuitesKeys, " "))
-		}
-		TLSCiphers = append(TLSCiphers, val)
+func validatedCiphers(ciphers string, version uint16) ([]uint16, error) {
+	split := strings.Split(ciphers, ",")
+	if version == tls.VersionTLS13 {
+		return validatedCipherSet(split, validCiphers13)
 	}
-	return TLSCiphers, nil
+	return validatedCipherSet(split, union(validCiphers10to12, validCiphers13))
 }
 
-func getKeysFromMap(input map[string]uint16) []string {
-	var keys []string
+func validatedCipherSet(ciphers []string, validCiphers map[string]uint16) ([]uint16, error) {
+	tlsCiphers := make([]uint16, 0, len(ciphers))
+	for _, cipher := range ciphers {
+		c, ok := validCiphers[strings.TrimSpace(cipher)]
+		if !ok {
+			valid := keysFromMap(validCiphers)
+			sort.Strings(valid)
+			return nil, fmt.Errorf("unsupported cipher %s, must be one or more of: %s", cipher, strings.Join(valid, "\n"))
+		}
+		tlsCiphers = append(tlsCiphers, c)
+	}
+	return tlsCiphers, nil
+}
+
+func union(cipherSets ...map[string]uint16) map[string]uint16 {
+	result := make(map[string]uint16)
+	for _, set := range cipherSets {
+		for k, v := range set {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+func keysFromMap(input map[string]uint16) []string {
+	keys := make([]string, 0, len(input))
 	for key := range input {
 		keys = append(keys, key)
 	}

--- a/pkg/tls/config_test.go
+++ b/pkg/tls/config_test.go
@@ -1,0 +1,96 @@
+package tls
+
+import (
+	"crypto/tls"
+	"reflect"
+	"testing"
+)
+
+func TestBaseTLSConfig(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		minVersion    string
+		ciphers       string
+		cfg           *tls.Config
+		errorExpected bool
+	}{
+		{
+			name:       "valid base config for TLS 1.0",
+			minVersion: "1.0",
+			ciphers:    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+			cfg: &tls.Config{
+				MinVersion:   tls.VersionTLS10,
+				CipherSuites: []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256},
+			},
+		},
+		{
+			name:       "valid base config for TLS 1.1",
+			minVersion: "1.1",
+			ciphers:    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+			cfg: &tls.Config{
+				MinVersion:   tls.VersionTLS11,
+				CipherSuites: []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256},
+			},
+		},
+		{
+			name:       "valid base config for TLS 1.2 with ciphers from 1.2 and 1.3",
+			minVersion: "1.2",
+			ciphers:    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256",
+			cfg: &tls.Config{
+				MinVersion:   tls.VersionTLS12,
+				CipherSuites: []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, tls.TLS_AES_128_GCM_SHA256},
+			},
+		},
+		{
+			name:       "valid base config for TLS 1.3",
+			minVersion: "1.3",
+			ciphers:    "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384",
+			cfg: &tls.Config{
+				MinVersion:   tls.VersionTLS13,
+				CipherSuites: []uint16{tls.TLS_AES_128_GCM_SHA256, tls.TLS_AES_256_GCM_SHA384},
+			},
+		},
+		{
+			name:          "unsupported min version",
+			minVersion:    "3.4",
+			ciphers:       "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+			errorExpected: true,
+		},
+		{
+			name:          "unknown cipher in cipher suite",
+			minVersion:    "1.3",
+			ciphers:       "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,BAD_CIPHER",
+			errorExpected: true,
+		},
+		{
+			name:          "unsupported min version and unknown cipher in cipher suite",
+			minVersion:    "3.4",
+			ciphers:       "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,BAD_CIPHER",
+			errorExpected: true,
+		},
+		{
+			name:          "wrong cipher for TLS 1.3",
+			minVersion:    "1.3",
+			ciphers:       "TLS_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+			errorExpected: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := baseTLSConfig(test.minVersion, test.ciphers)
+			if err != nil && !test.errorExpected {
+				t.Fatalf("got an unexpected error: %v", err)
+			}
+			if err == nil && test.errorExpected {
+				t.Fatalf("expected an error but did not get it")
+			}
+			if !reflect.DeepEqual(got, test.cfg) {
+				t.Errorf("\nexpected\n%v\ngot\n%v", test.cfg, got)
+			}
+		})
+	}
+}

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -223,7 +223,7 @@ func readConfig(secrets corev1controllers.SecretController, acmeDomains []string
 		err error
 	)
 
-	tlsConfig, err := BaseTLSConfig()
+	tlsConfig, err := baseTLSConfig(settings.TLSMinVersion.Get(), settings.TLSCiphers.Get())
 	if err != nil {
 		return "", noCACerts, nil, err
 	}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42027
 
## Problem
Admins cannot specify "tis-min-version" to be "1.3". Rancher validates the setting value and doesn't start.
 
## Solution
Change min version value validation and cipher list validation (the "tis-ciphers" setting), so that admins can start Rancher with a TLS min version 1.3 and its corresponding ciphers.

If admins set the version to 1.2, then we allow 1.2 and 1.3 ciphers.
If admins set the version to 1.3, then Rancher allows only 1.3 ciphers.

The default value is still 1.2 with its corresponding ciphers, so no change there.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_