### PR TITLE
verifying generated fields are removed

### DIFF
--- a/tests/framework/clients/rancher/v1/client.go
+++ b/tests/framework/clients/rancher/v1/client.go
@@ -1,8 +1,11 @@
 package v1
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"regexp"
 	"time"
@@ -29,11 +32,22 @@ type State struct {
 	Transitioning bool   `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
 }
 
+// Relationship is the Steve specific field in the rancher Steve API
+type Relationship struct {
+	FromID   string `json:"fromId,omitempty" yaml:"fromId,omitempty"`
+	FromType string `json:"fromType,omitempty" yaml:"fromType,omitempty"`
+	Rel      string `json:"rel,omitempty" yaml:"rel,omitempty"`
+	State    string `json:"state,omitempty" yaml:"state,omitempty"`
+	Message  string `json:"message,omitempty" yaml:"message,omitempty"`
+}
+
 // ObjectMeta is the native k8s object meta field that kubernetes objects used, with the added
 // Steve API State field.
 type ObjectMeta struct {
 	metav1.ObjectMeta
-	State *State `json:"state,omitempty" yaml:"state,omitempty"`
+	State         *State          `json:"state,omitempty" yaml:"state,omitempty"`
+	Relationships *[]Relationship `json:"relationships,omitempty" yaml:"relationships,omitempty"`
+	Fields        []any           `json:"fields,omitempty" yaml:"fields,omitempty"`
 }
 
 // SteveAPIObject is the generic object used in the v1/steve API call responses
@@ -281,6 +295,45 @@ func (c *NamespacedSteveClient) Create(container any) (*SteveAPIObject, error) {
 
 func (c *NamespacedSteveClient) Update(existing *SteveAPIObject, updates any) (*SteveAPIObject, error) {
 	return c.SteveClient.Update(existing, updates)
+}
+
+func (c *NamespacedSteveClient) PerformPutCaptureHeaders(host, token, name string, payload interface{}) (http.Header, []byte, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error marshalling payload: %v", err)
+	}
+
+	url := fmt.Sprintf("https://%v/v1/%v/%v/%v", host, c.steveType, c.namespace, name)
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating request: %v", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	var httpClient = &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error executing request: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return resp.Header, nil, fmt.Errorf("received HTTP error: %s", resp.Status)
+	}
+
+	byteContent, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.Header, nil, fmt.Errorf("error reading response body: %v", err)
+	}
+
+	if len(byteContent) == 0 {
+		return resp.Header, nil, fmt.Errorf("received empty response")
+	}
+
+	return resp.Header, byteContent, nil
 }
 
 func (c *NamespacedSteveClient) Replace(obj *SteveAPIObject) (*SteveAPIObject, error) {

--- a/tests/framework/extensions/configmaps/configmaps.go
+++ b/tests/framework/extensions/configmaps/configmaps.go
@@ -1,5 +1,16 @@
 package configmaps
 
+import (
+	steveV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 const (
 	ConfigMapSteveType = "configmap"
 )
+
+type SteveConfigMap struct {
+	metav1.TypeMeta    `json:",inline"`
+	steveV1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Data               map[string]any `json:"data"`
+}

--- a/tests/v2/validation/configmaps/generatedfields.go
+++ b/tests/v2/validation/configmaps/generatedfields.go
@@ -1,0 +1,32 @@
+package configmaps
+
+import (
+	"github.com/pkg/errors"
+	steveV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	cm "github.com/rancher/rancher/tests/framework/extensions/configmaps"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	APIVersion = "v1"
+	Kind       = "ConfigMap"
+)
+
+func setPayload(apiObject *steveV1.SteveAPIObject, payload *cm.SteveConfigMap) error {
+	payload.APIVersion = APIVersion
+	payload.Kind = Kind
+	payload.Name = apiObject.Name
+	payload.Namespace = "default"
+	payload.ResourceVersion = apiObject.ResourceVersion
+	payload.UID = apiObject.UID
+	payload.State = &steveV1.State{}
+	payload.Relationships = &[]steveV1.Relationship{}
+	payload.Fields = []any{"foo", "bar"}
+	data, ok := apiObject.JSONResp["data"].(map[string]interface{})
+	if !ok {
+		logrus.Println("Type assertion failed")
+		return errors.New("type assertion failed for apiObject.JSONResp[\"data\"]")
+	}
+	payload.Data = data
+	return nil
+}

--- a/tests/v2/validation/configmaps/generatedfields_test.go
+++ b/tests/v2/validation/configmaps/generatedfields_test.go
@@ -1,0 +1,88 @@
+package configmaps
+
+import (
+	"fmt"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	steveV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	cm "github.com/rancher/rancher/tests/framework/extensions/configmaps"
+	"github.com/rancher/rancher/tests/framework/pkg/namegenerator"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+	"testing"
+)
+
+const configMapNamespace = "default"
+
+type ConfigMapTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	steveClient        *steveV1.Client
+	session            *session.Session
+	cluster            *management.Cluster
+	nameSpacedV1Client *steveV1.NamespacedSteveClient
+	configMapPayload   *cm.SteveConfigMap
+}
+
+func (c *ConfigMapTestSuite) TearDownSuite() {
+	c.session.Cleanup()
+}
+
+func (c *ConfigMapTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	c.session = testSession
+	client, err := rancher.NewClient("", c.session)
+	require.NoError(c.T(), err)
+	c.client = client
+	c.steveClient = client.Steve
+}
+
+func (c *ConfigMapTestSuite) TestSteveGeneratedFields() {
+
+	steveClient := c.client.Steve
+	configMapName := namegenerator.AppendRandomString("test-configmap")
+
+	v1ConfigMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: configMapNamespace,
+		},
+		Data: map[string]string{
+			"env": "qa",
+		},
+	}
+
+	configmapSteveObject, err := steveClient.SteveType(cm.ConfigMapSteveType).Create(v1ConfigMap)
+	require.NoError(c.T(), err)
+
+	c.configMapPayload = new(cm.SteveConfigMap)
+	err = setPayload(configmapSteveObject, c.configMapPayload)
+	require.NoError(c.T(), err)
+
+	headers, _, err := steveClient.SteveType("configmaps").NamespacedSteveClient(configMapNamespace).PerformPutCaptureHeaders(c.client.RancherConfig.Host, c.client.RancherConfig.AdminToken, c.configMapPayload.Name, c.configMapPayload)
+	require.NoError(c.T(), err)
+
+	warnings, ok := headers["Warning"]
+	var failWarnings []string
+	if ok {
+		for _, warning := range warnings {
+			if strings.HasPrefix(warning, "299") {
+				logrus.Printf("Warning header found: %s", warning)
+				failWarnings = append(failWarnings, warning)
+			}
+		}
+	}
+
+	if len(failWarnings) > 0 {
+		require.Fail(c.T(), fmt.Sprintf("Test failed due to warnings: \n%s", strings.Join(failWarnings, "\n")))
+	}
+}
+
+func TestConfigMapTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigMapTestSuite))
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

- Issue being tested: https://github.com/rancher/rancher/issues/41772
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The need to verify that Steve is discarding unrecognized fields prior to the PUT request.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The solution involved utilizing a framework to generate a config map, followed by the creation of a PUT request using the `net/http` package to capture the response headers. A review of the response headers was then performed to search for any possible errors.

Note:
The use of the `net/http` package was authorized in collaboration with Israel. This step was necessary to capture HTTP response headers following a PUT request.
 
## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Manual testing / validations done in the original issue.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)

Summary: Added P0 validation test case for config maps.