### PR TITLE
[v2.8] feat: added capi label to kubeconfig secrets

### DIFF
--- a/pkg/provisioningv2/kubeconfig/manager.go
+++ b/pkg/provisioningv2/kubeconfig/manager.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const (
@@ -251,7 +252,7 @@ func (m *Manager) GetCRTBForClusterOwner(cluster *v1.Cluster, status v1.ClusterS
 // kubeConfigValid accepts a kubeconfig and corresponding data, and validates that the kubeconfig is valid for the
 // cluster in question. It returns two booleans, the first of which is whether an error occurred parsing the kubeconfig
 // or retrieving information related to the kubeconfig, and the second which indicates whether the kubeconfig is valid.
-func (m *Manager) kubeConfigValid(kcData []byte, cluster *v1.Cluster, currentServerURL, currentServerCA, currentManagementClusterName string) (bool, bool) {
+func (m *Manager) kubeConfigValid(kcData []byte, cluster *v1.Cluster, currentServerURL, currentServerCA, currentManagementClusterName string, secretLabels map[string]string) (bool, bool) {
 	if len(kcData) == 0 {
 		return true, false
 	}
@@ -289,6 +290,13 @@ func (m *Manager) kubeConfigValid(kcData []byte, cluster *v1.Cluster, currentSer
 		tokenMatches = err == nil
 	}
 
+	// Check if the required CAPI cluster label is present in the secretLabels map
+	capiClusterLabelValue, labelPresent := secretLabels[capi.ClusterLabelName]
+	if !labelPresent || capiClusterLabelValue != cluster.Name {
+		logrus.Tracef("[kubeconfigmanager] cluster %s/%s: kubeconfig secret failed validation due to missing or incorrect label", cluster.Namespace, cluster.Name)
+		return false, false
+	}
+
 	if serverURL != currentServerURL || !bytes.Equal([]byte(strings.TrimSpace(currentServerCA)), kc.Clusters["cluster"].CertificateAuthorityData) || managementCluster != currentManagementClusterName || !tokenMatches {
 		logrus.Tracef("[kubeconfigmanager] cluster %s/%s: kubeconfig secret failed validation, did not match provided data", cluster.Namespace, cluster.Name)
 		return false, false
@@ -305,7 +313,7 @@ func (m *Manager) getKubeConfigData(cluster *v1.Cluster, secretName, managementC
 
 	secret, err := m.secretCache.Get(cluster.Namespace, secretName)
 	if err == nil {
-		retrievalError, isValid := m.kubeConfigValid(secret.Data["value"], cluster, serverURL, cacert, managementClusterName)
+		retrievalError, isValid := m.kubeConfigValid(secret.Data["value"], cluster, serverURL, cacert, managementClusterName, secret.Labels)
 		if (!retrievalError && !isValid) || secret.Data == nil || secret.Data["token"] == nil || len(secret.OwnerReferences) == 0 {
 			logrus.Infof("[kubeconfigmanager] deleting kubeconfig secret for cluster %s/%s", cluster.Namespace, cluster.Name)
 			// Check if we require a new secret based on the token value and annotation(s). We delete the old secret since it may contain
@@ -368,6 +376,9 @@ func (m *Manager) getKubeConfigData(cluster *v1.Cluster, secretName, managementC
 				Name:       cluster.Name,
 				UID:        cluster.UID,
 			}},
+			Labels: map[string]string{
+				capi.ClusterLabelName: cluster.Name,
+			},
 		},
 		Data: map[string][]byte{
 			"value": data,

--- a/pkg/provisioningv2/kubeconfig/manager.go
+++ b/pkg/provisioningv2/kubeconfig/manager.go
@@ -291,7 +291,7 @@ func (m *Manager) kubeConfigValid(kcData []byte, cluster *v1.Cluster, currentSer
 	}
 
 	// Check if the required CAPI cluster label is present in the secretLabels map
-	capiClusterLabelValue, labelPresent := secretLabels[capi.ClusterLabelName]
+	capiClusterLabelValue, labelPresent := secretLabels[capi.ClusterNameLabel]
 	if !labelPresent || capiClusterLabelValue != cluster.Name {
 		logrus.Tracef("[kubeconfigmanager] cluster %s/%s: kubeconfig secret failed validation due to missing or incorrect label", cluster.Namespace, cluster.Name)
 		return false, false
@@ -377,7 +377,7 @@ func (m *Manager) getKubeConfigData(cluster *v1.Cluster, secretName, managementC
 				UID:        cluster.UID,
 			}},
 			Labels: map[string]string{
-				capi.ClusterLabelName: cluster.Name,
+				capi.ClusterNameLabel: cluster.Name,
 			},
 		},
 		Data: map[string][]byte{

--- a/pkg/provisioningv2/kubeconfig/manager_test.go
+++ b/pkg/provisioningv2/kubeconfig/manager_test.go
@@ -95,7 +95,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken: &token,
 			cluster:     &cluster,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
+				capi.ClusterNameLabel: "c-m-1234xyz",
 			},
 
 			wantError: false,
@@ -117,7 +117,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken: hashToken(&token, false),
 			cluster:     &cluster,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
+				capi.ClusterNameLabel: "c-m-1234xyz",
 			},
 
 			wantError: false,
@@ -139,7 +139,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken: &token,
 			cluster:     &cluster,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
+				capi.ClusterNameLabel: "c-m-1234xyz",
 			},
 
 			wantError: false,
@@ -161,7 +161,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken: hashToken(&token, false),
 			cluster:     &cluster,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
+				capi.ClusterNameLabel: "c-m-1234xyz",
 			},
 
 			wantError: false,
@@ -183,7 +183,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken: &token,
 			cluster:     &cluster,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
+				capi.ClusterNameLabel: "c-m-1234xyz",
 			},
 
 			wantError: false,
@@ -205,7 +205,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken: &token,
 			cluster:     &cluster,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
+				capi.ClusterNameLabel: "c-m-1234xyz",
 			},
 
 			wantError: false,
@@ -227,7 +227,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken: &token,
 			cluster:     &cluster,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
+				capi.ClusterNameLabel: "c-m-1234xyz",
 			},
 
 			wantError: false,
@@ -244,7 +244,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken: &token,
 			cluster:     &cluster,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
+				capi.ClusterNameLabel: "c-m-1234xyz",
 			},
 
 			wantError: true,
@@ -262,7 +262,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			cluster:           &cluster,
 			invalidKubeconfig: true,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
+				capi.ClusterNameLabel: "c-m-1234xyz",
 			},
 
 			wantError: true,
@@ -284,7 +284,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken: &token,
 			cluster:     &cluster,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
+				capi.ClusterNameLabel: "c-m-1234xyz",
 			},
 
 			wantError: false,
@@ -306,7 +306,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken: &token,
 			cluster:     &cluster,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "random-cluster-name",
+				capi.ClusterNameLabel: "random-cluster-name",
 			},
 
 			wantError: false,
@@ -349,7 +349,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			cluster:          &cluster,
 			invalidServerURL: true,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
+				capi.ClusterNameLabel: "c-m-1234xyz",
 			},
 
 			wantError: true,
@@ -370,7 +370,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken: hashToken(&token, true),
 			cluster:     &cluster,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
+				capi.ClusterNameLabel: "c-m-1234xyz",
 			},
 
 			wantError: true,
@@ -390,7 +390,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			cluster: &cluster,
 			secretLabels: map[string]string{
-				capi.ClusterLabelName: "c-m-1234xyz",
+				capi.ClusterNameLabel: "c-m-1234xyz",
 			},
 			tokenCacheError: fmt.Errorf("server unavailable"),
 

--- a/pkg/provisioningv2/kubeconfig/manager_test.go
+++ b/pkg/provisioningv2/kubeconfig/manager_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/pointer"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const (
@@ -64,11 +65,12 @@ func Test_kubeConfigValid(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		currentData *kubeconfigData
-		wantData    *kubeconfigData
-		cluster     *v1.Cluster
-		storedToken *v3.Token
+		name         string
+		currentData  *kubeconfigData
+		wantData     *kubeconfigData
+		cluster      *v1.Cluster
+		storedToken  *v3.Token
+		secretLabels map[string]string
 
 		invalidServerURL  bool
 		invalidKubeconfig bool
@@ -92,6 +94,9 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: &token,
 			cluster:     &cluster,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "c-m-1234xyz",
+			},
 
 			wantError: false,
 			wantValid: true,
@@ -111,6 +116,9 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: hashToken(&token, false),
 			cluster:     &cluster,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "c-m-1234xyz",
+			},
 
 			wantError: false,
 			wantValid: true,
@@ -130,6 +138,9 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: &token,
 			cluster:     &cluster,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "c-m-1234xyz",
+			},
 
 			wantError: false,
 			wantValid: false,
@@ -149,6 +160,9 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: hashToken(&token, false),
 			cluster:     &cluster,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "c-m-1234xyz",
+			},
 
 			wantError: false,
 			wantValid: false,
@@ -168,6 +182,9 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: &token,
 			cluster:     &cluster,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "c-m-1234xyz",
+			},
 
 			wantError: false,
 			wantValid: false,
@@ -187,6 +204,9 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: &token,
 			cluster:     &cluster,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "c-m-1234xyz",
+			},
 
 			wantError: false,
 			wantValid: false,
@@ -206,6 +226,9 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: &token,
 			cluster:     &cluster,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "c-m-1234xyz",
+			},
 
 			wantError: false,
 			wantValid: false,
@@ -220,6 +243,9 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: &token,
 			cluster:     &cluster,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "c-m-1234xyz",
+			},
 
 			wantError: true,
 			wantValid: false,
@@ -235,8 +261,76 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken:       &token,
 			cluster:           &cluster,
 			invalidKubeconfig: true,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "c-m-1234xyz",
+			},
 
 			wantError: true,
+			wantValid: false,
+		},
+		{
+			name: "CAPI cluster label is set correctly",
+			currentData: &kubeconfigData{
+				serverURL:   "https://test.cluster.io",
+				serverCA:    "ABC",
+				clusterName: "c-1234xyz",
+				token:       fmt.Sprintf("%s:%s", token.Name, tokenKey),
+			},
+			wantData: &kubeconfigData{
+				serverURL:   "https://test.cluster.io",
+				serverCA:    "ABC",
+				clusterName: "c-1234xyz",
+			},
+			storedToken: &token,
+			cluster:     &cluster,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "c-m-1234xyz",
+			},
+
+			wantError: false,
+			wantValid: true,
+		},
+		{
+			name: "CAPI cluster label is set incorrectly",
+			currentData: &kubeconfigData{
+				serverURL:   "https://test.cluster.io",
+				serverCA:    "ABC",
+				clusterName: "c-1234xyz",
+				token:       fmt.Sprintf("%s:%s", token.Name, tokenKey),
+			},
+			wantData: &kubeconfigData{
+				serverURL:   "https://test.cluster.io",
+				serverCA:    "ABC",
+				clusterName: "c-1234xyz",
+			},
+			storedToken: &token,
+			cluster:     &cluster,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "random-cluster-name",
+			},
+
+			wantError: false,
+			wantValid: false,
+		},
+		{
+			name: "CAPI cluster label is missing",
+			currentData: &kubeconfigData{
+				serverURL:   "https://test.cluster.io",
+				serverCA:    "ABC",
+				clusterName: "c-1234xyz",
+				token:       fmt.Sprintf("%s:%s", token.Name, tokenKey),
+			},
+			wantData: &kubeconfigData{
+				serverURL:   "https://test.cluster.io",
+				serverCA:    "ABC",
+				clusterName: "c-1234xyz",
+			},
+			storedToken:       &token,
+			cluster:           &cluster,
+			invalidKubeconfig: true,
+			secretLabels:      map[string]string{},
+
+			wantError: false,
 			wantValid: false,
 		},
 		{
@@ -254,6 +348,9 @@ func Test_kubeConfigValid(t *testing.T) {
 			storedToken:      &token,
 			cluster:          &cluster,
 			invalidServerURL: true,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "c-m-1234xyz",
+			},
 
 			wantError: true,
 			wantValid: false,
@@ -272,6 +369,9 @@ func Test_kubeConfigValid(t *testing.T) {
 			},
 			storedToken: hashToken(&token, true),
 			cluster:     &cluster,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "c-m-1234xyz",
+			},
 
 			wantError: true,
 			wantValid: false,
@@ -288,7 +388,10 @@ func Test_kubeConfigValid(t *testing.T) {
 				serverCA:    "ABC",
 				clusterName: "c-1234abc",
 			},
-			cluster:         &cluster,
+			cluster: &cluster,
+			secretLabels: map[string]string{
+				capi.ClusterLabelName: "c-m-1234xyz",
+			},
 			tokenCacheError: fmt.Errorf("server unavailable"),
 
 			wantError: true,
@@ -349,7 +452,7 @@ func Test_kubeConfigValid(t *testing.T) {
 			m := Manager{
 				tokensCache: mockCache,
 			}
-			isError, isValid := m.kubeConfigValid(kcData, test.cluster, test.wantData.serverURL, test.wantData.serverCA, test.wantData.clusterName)
+			isError, isValid := m.kubeConfigValid(kcData, test.cluster, test.wantData.serverURL, test.wantData.serverCA, test.wantData.clusterName, test.secretLabels)
 			require.Equal(t, test.wantError, isError)
 			require.Equal(t, test.wantValid, isValid)
 		})

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -71,10 +71,9 @@ func runMigrations(wranglerContext *wrangler.Context) error {
 		if err := migrateMachinePoolsDynamicSchemaLabel(wranglerContext); err != nil {
 			return err
 		}
-	}
-
-	if err := migrateCAPIKubeconfigs(wranglerContext); err != nil {
-		return fmt.Errorf("running capi kubeconfig migration: %w", err)
+		if err := migrateCAPIKubeconfigs(wranglerContext); err != nil {
+			return fmt.Errorf("running capi kubeconfig migration: %w", err)
+		}
 	}
 
 	return nil
@@ -508,61 +507,6 @@ func migrateMachinePoolsDynamicSchemaLabel(w *wrangler.Context) error {
 	return createOrUpdateConfigMap(w.Core.ConfigMap(), cm)
 }
 
-func migrateCAPIKubeconfigs(w *wrangler.Context) error {
-	logrus.Info("Running CAPI secret migration")
-
-	namespaces, err := w.Core.Namespace().List(metav1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("listing namespaces: %w", err)
-	}
-
-	for _, ns := range namespaces.Items {
-		clusters, err := w.RKE.RKECluster().List(ns.Name, metav1.ListOptions{})
-		if err != nil {
-			return fmt.Errorf("listing rke2 clusters in namespace %s: %w", ns.Name, err)
-		}
-
-		for _, cluster := range clusters.Items {
-			secretName := fmt.Sprintf("%s-kubeconfig", cluster.Name)
-
-			secret, err := w.Core.Secret().Get(ns.Name, secretName, metav1.GetOptions{})
-			if err != nil {
-				if k8serror.IsNotFound(err) {
-					continue
-				}
-
-				return fmt.Errorf("getting secret %s/%s: %w", ns.Name, secretName, err)
-			}
-
-			_, ok := secret.Labels[capi.ClusterNameLabel]
-			if ok {
-				logrus.Tracef("kubeconfig secret %s/%s already has the capi cluster label", ns.Name, secret.Name)
-				continue
-			}
-
-			if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-				secretCopy := secret.DeepCopy()
-				if secretCopy.Labels == nil {
-					secretCopy.Labels = map[string]string{}
-				}
-				secretCopy.Labels[capi.ClusterNameLabel] = cluster.Name
-
-				if _, updateErr := w.Core.Secret().Update(secretCopy); updateErr != nil {
-					return fmt.Errorf("updating secret %s/%s to add capi label: %w", ns.Name, secret.Name, err)
-				}
-
-				logrus.Debugf("Updated kubeconfig secret %s/%s with CAPI cluster label", ns.Name, secret.Name)
-
-				return nil
-			}); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
 func insertOrUpdateCondition(d data.Object, desiredCondition summary.Condition) (bool, error) {
 	for _, cond := range summary.GetUnstructuredConditions(d) {
 		if desiredCondition.Equals(cond) {
@@ -598,4 +542,70 @@ func insertOrUpdateCondition(d data.Object, desiredCondition summary.Condition) 
 	d.SetNested(conditions, "status", "conditions")
 
 	return true, nil
+}
+
+func migrateCAPIKubeconfigs(w *wrangler.Context) error {
+	logrus.Info("Running CAPI secret migration")
+
+	mgmtClusters, err := w.Mgmt.Cluster().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, mgmtCluster := range mgmtClusters.Items {
+		logrus.Tracef("Checking if migration for cluster %s is needed", mgmtCluster.Name)
+
+		provClusters, err := w.Provisioning.Cluster().List(mgmtCluster.Spec.FleetWorkspaceName, metav1.ListOptions{})
+		if k8serror.IsNotFound(err) || len(provClusters.Items) == 0 {
+			continue
+		} else if err != nil {
+			return err
+		}
+		for _, provCluster := range provClusters.Items {
+			if provCluster.Spec.RKEConfig == nil {
+				continue
+			}
+			logrus.Tracef("Running migration for cluster %s", provCluster.Name)
+
+			if err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				secretName := fmt.Sprintf("%s-kubeconfig", provCluster.Name)
+
+				secret, err := w.Core.Secret().Get(provCluster.Namespace, secretName, metav1.GetOptions{})
+				if err != nil {
+					if k8serror.IsNotFound(err) {
+						return nil
+					}
+
+					return fmt.Errorf("getting secret %s/%s: %w", provCluster.Namespace, secretName, err)
+				}
+
+				_, ok := secret.Labels[capi.ClusterNameLabel]
+				if ok {
+					logrus.Tracef("kubeconfig secret %s/%s already has the capi cluster label", provCluster.Namespace, secret.Name)
+					return nil
+				}
+
+				secretCopy := secret.DeepCopy()
+				if secretCopy.Labels == nil {
+					secretCopy.Labels = map[string]string{}
+				}
+				secretCopy.Labels[capi.ClusterNameLabel] = provCluster.Name
+
+				if _, updateErr := w.Core.Secret().Update(secretCopy); updateErr != nil {
+					return fmt.Errorf("updating secret %s/%s to add capi label: %w", provCluster.Namespace, secret.Name, err)
+				}
+
+				logrus.Debugf("Updated kubeconfig secret %s/%s with CAPI cluster label", provCluster.Namespace, secret.Name)
+
+				return nil
+
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	logrus.Info("Finished migrating CAPI kubeconfig secrets")
+
+	return nil
 }

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -534,7 +534,7 @@ func migrateCAPIKubeconfigs(w *wrangler.Context) error {
 				return fmt.Errorf("getting secret %s/%s: %w", ns.Name, secretName, err)
 			}
 
-			_, ok := secret.Labels[capi.ClusterLabelName]
+			_, ok := secret.Labels[capi.ClusterNameLabel]
 			if ok {
 				logrus.Tracef("kubeconfig secret %s/%s already has the capi cluster label", ns.Name, secret.Name)
 				continue
@@ -545,7 +545,7 @@ func migrateCAPIKubeconfigs(w *wrangler.Context) error {
 				if secretCopy.Labels == nil {
 					secretCopy.Labels = map[string]string{}
 				}
-				secretCopy.Labels[capi.ClusterLabelName] = cluster.Name
+				secretCopy.Labels[capi.ClusterNameLabel] = cluster.Name
 
 				if _, updateErr := w.Core.Secret().Update(secretCopy); updateErr != nil {
 					return fmt.Errorf("updating secret %s/%s to add capi label: %w", ns.Name, secret.Name, err)

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -545,27 +545,27 @@ func insertOrUpdateCondition(d data.Object, desiredCondition summary.Condition) 
 }
 
 func migrateCAPIKubeconfigs(w *wrangler.Context) error {
-	logrus.Info("Running CAPI secret migration")
+	logrus.Info("Running provisioningv2 CAPI kubeconfig secret migration")
 
-	mgmtClusters, err := w.Mgmt.Cluster().List(metav1.ListOptions{})
+	namespaces, err := w.Core.Namespace().List(metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
-	for _, mgmtCluster := range mgmtClusters.Items {
-		logrus.Tracef("Checking if migration for cluster %s is needed", mgmtCluster.Name)
-
-		provClusters, err := w.Provisioning.Cluster().List(mgmtCluster.Spec.FleetWorkspaceName, metav1.ListOptions{})
+	for _, ns := range namespaces.Items {
+		provClusters, err := w.Provisioning.Cluster().List(ns.Name, metav1.ListOptions{})
 		if k8serror.IsNotFound(err) || len(provClusters.Items) == 0 {
+			logrus.Tracef("No provisioningv2 clusters in namespace %s", ns.Name)
 			continue
 		} else if err != nil {
 			return err
 		}
 		for _, provCluster := range provClusters.Items {
 			if provCluster.Spec.RKEConfig == nil {
+				logrus.Tracef("No provisioningv2 clusters in namespace %s", ns.Name)
 				continue
 			}
-			logrus.Tracef("Running migration for cluster %s", provCluster.Name)
+			logrus.Tracef("Running provisioningv2 CAPI kubeconfig secret migration for cluster %s", provCluster.Name)
 
 			if err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				secretName := fmt.Sprintf("%s-kubeconfig", provCluster.Name)
@@ -605,7 +605,7 @@ func migrateCAPIKubeconfigs(w *wrangler.Context) error {
 		}
 	}
 
-	logrus.Info("Finished migrating CAPI kubeconfig secrets")
+	logrus.Info("Finished migrating provisioningv2 CAPI kubeconfig secrets")
 
 	return nil
 }

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -73,6 +73,10 @@ func runMigrations(wranglerContext *wrangler.Context) error {
 		}
 	}
 
+	if err := migrateCAPIKubeconfigs(wranglerContext); err != nil {
+		return fmt.Errorf("running capi kubeconfig migration: %w", err)
+	}
+
 	return nil
 }
 
@@ -502,6 +506,61 @@ func migrateMachinePoolsDynamicSchemaLabel(w *wrangler.Context) error {
 
 	cm.Data[dynamicSchemaMachinePoolsMigratedKey] = "true"
 	return createOrUpdateConfigMap(w.Core.ConfigMap(), cm)
+}
+
+func migrateCAPIKubeconfigs(w *wrangler.Context) error {
+	logrus.Info("Running CAPI secret migration")
+
+	namespaces, err := w.Core.Namespace().List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing namespaces: %w", err)
+	}
+
+	for _, ns := range namespaces.Items {
+		clusters, err := w.RKE.RKECluster().List(ns.Name, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("listing rke2 clusters in namespace %s: %w", ns.Name, err)
+		}
+
+		for _, cluster := range clusters.Items {
+			secretName := fmt.Sprintf("%s-kubeconfig", cluster.Name)
+
+			secret, err := w.Core.Secret().Get(ns.Name, secretName, metav1.GetOptions{})
+			if err != nil {
+				if k8serror.IsNotFound(err) {
+					continue
+				}
+
+				return fmt.Errorf("getting secret %s/%s: %w", ns.Name, secretName, err)
+			}
+
+			_, ok := secret.Labels[capi.ClusterLabelName]
+			if ok {
+				logrus.Tracef("kubeconfig secret %s/%s already has the capi cluster label", ns.Name, secret.Name)
+				continue
+			}
+
+			if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				secretCopy := secret.DeepCopy()
+				if secretCopy.Labels == nil {
+					secretCopy.Labels = map[string]string{}
+				}
+				secretCopy.Labels[capi.ClusterLabelName] = cluster.Name
+
+				if _, updateErr := w.Core.Secret().Update(secretCopy); updateErr != nil {
+					return fmt.Errorf("updating secret %s/%s to add capi label: %w", ns.Name, secret.Name, err)
+				}
+
+				logrus.Debugf("Updated kubeconfig secret %s/%s with CAPI cluster label", ns.Name, secret.Name)
+
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func insertOrUpdateCondition(d data.Object, desiredCondition summary.Condition) (bool, error) {


### PR DESCRIPTION
## Issue: #42333 
 
## Problem
If we upgrade to use CAPI 1.5.0 or higher its required that the secrets used for kubeconfigs contain a label `cluster.x-k8s.io/cluster-name=${CLUSTER_NAME}`. Without this, the CAPI cluster/machine reconcilers will fail with a `failed to retrieve kubeconfig secret for Cluster` error.

See the CAPI migration guide: https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md#other
 
## Solution
This adds the required label when we create the secret that contains the kubeconfig. A migration has also been added thats called at startup (on leader election) that will add the label to any kubeconfig secret for an RKE2 cluster.

Even though 1.4.4 will be used with the un-embedding it would be good to get this change in upfront.
 
## Testing

1. Create an RKE2 based cluster with a previous version
2. Find the  kubeconfig secret for the cluster. It will be named [CLUSTERNAME]-kubeconfig and will likely be in the **fleet-default** namespace
3. Check that it does NOT have a label name **cluster.x-k8s.io/cluster-name**
4. Upgrade Rancher to a version with the change in
5. Check the same secret to see if the **cluster.x-k8s.io/cluster-name** now exists.
6. Create a new RKE2 based cluster and when its provisioned, check that the kubeconfig secret has the **cluster.x-k8s.io/cluster-name** label

## Engineering Testing
### Manual Testing
Manually local testing carried out.

### Automated Testing
NONE

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_
