### PR TITLE
Allow select management CRDs to be used in local cluster by kubectl

### DIFF
--- a/pkg/api/steve/disallow/disallow.go
+++ b/pkg/api/steve/disallow/disallow.go
@@ -9,8 +9,10 @@ import (
 	steve "github.com/rancher/steve/pkg/server"
 )
 
+// The resource names must be plural.
 var (
-	allowAll = map[string]bool{
+	// AllowAll is a set of resources for which Rancher doesn't require authentication to perform any operation.
+	AllowAll = map[string]bool{
 		"podsecurityadmissionconfigurationtemplates": true,
 	}
 	allowPost = map[string]bool{
@@ -37,7 +39,7 @@ func Register(server *steve.Server) {
 		Customize: func(schema *types.APISchema) {
 			gr := attributes.GR(schema)
 			if gr.Group == "management.cattle.io" || gr.Group == "project.cattle.io" {
-				if allowAll[gr.Resource] {
+				if AllowAll[gr.Resource] {
 					return
 				}
 				attributes.AddDisallowMethods(schema,


### PR DESCRIPTION
## Issue: 
 
## Problem
All users need some level of access to the local cluster. For example, they may need to add a user to their project in a downstream cluster. This requires the ability to create a PRTB in the local cluster. They should have not only the RBAC permissions for it (granted, in this case, by virtue of being a project-owner), but also permission from the router to access the API paths. With the new public API, v3 management resources aren't available yet. 
 
## Solution
Modify the routing logic, so that Rancher doesn't check a request for special access to local cluster if the resource is a v3.management resource and one in a set of allowed resources.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 