### PR TITLE
allow cloud custodian to login to azure, gcp

### DIFF
--- a/tests/scripts/custodian/Dockerfile
+++ b/tests/scripts/custodian/Dockerfile
@@ -26,11 +26,14 @@ ENV DONOTDELETE_KEYS=$DONOTDELETE_KEYS
 ENV CUSTODIAN_YAML=aws.yaml
 
 RUN apt-get update && apt-get install -y python3 python3-pip python3-venv apt-transport-https ca-certificates gnupg curl
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-cli -y
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 RUN python3 -m venv custodian-venv
 RUN . custodian-venv/bin/activate
 RUN pip3 install c7n c7n_azure c7n_gcp c7n_mailer
+RUN az login -u $AZURE_CLIENT_ID --service-principal -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID
+RUN echo "$RANCHER_GKE_CREDENTIAL" > google_credentials.json
+RUN gcloud auth activate-service-account --key-file google_credentials.json
 
 ADD ./* ./
 SHELL ["/bin/bash", "-c"] 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/876
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 found a way to login interactively to azure and GCP. 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
azure is now able to login correctly
GCP was not tested, due to not having the same type of file as we have in jenkins, but I tested the same type of function on my machine and it was working. 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
possibly more work required here depending on how GCP goes 
- will not have any affect on existing codebase nor framework - this is currently its own script