### PR TITLE
update ui settings for release 2.7.7

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -200,7 +200,7 @@ var (
 	UIDashboardPath = NewSetting("ui-dashboard-path", "/usr/share/rancher/ui-dashboard")
 
 	// UIDashboardIndex depends on ui-offline-preferred, use this version of the dashboard instead of the one contained in Rancher Manager.
-	UIDashboardIndex = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/latest/index.html")
+	UIDashboardIndex = NewSetting("ui-dashboard-index", "https://releases.rancher.com/dashboard/release-2.7.7/index.html")
 
 	// UIDashboardHarvesterLegacyPlugin depending on ui-offline-preferred and if a Harvester Cluster does not contain it's own Harvester plugin, use this version of the plugin instead.
 	UIDashboardHarvesterLegacyPlugin = NewSetting("ui-dashboard-harvester-legacy-plugin", "https://releases.rancher.com/harvester-ui/plugin/harvester-1.0.3-head/harvester-1.0.3-head.umd.min.js")
@@ -215,7 +215,7 @@ var (
 	UIFeedBackForm = NewSetting("ui-feedback-form", "")
 
 	// UIIndex depends on ui-offline-preferred, use this version of the old ember UI instead of the one contained in Rancher Manager.
-	UIIndex = NewSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
+	UIIndex = NewSetting("ui-index", "https://releases.rancher.com/ui/release-2.7.7/index.html")
 
 	// UIIssues use a url address to send new 'File an Issue' reports instead of sending users to the Github issues page.
 	// Deprecated in favour of UICustomLinks = NewSetting("ui-custom-links", {}).


### PR DESCRIPTION
## Problem
rancher/dashboard and rancher/ui have branched for 2.7.7 - `latest` builds will begin including code for 2.7-next3

Similar to latest UI branching process PR: https://github.com/rancher/rancher/pull/42291
 
## Solution
* This change ensures the rancher/rancher `release/v2.7` points to the right rancher/ui and rancher/dashboard builds in `UiIndex` and `UiDashboardIndex` setting defaults, respectively
* By default `-head` versions use these builds instead of the embedded builds 
 

## Engineering Testing
### Manual Testing
Updated settings on an existing instance and verified the dashboard/ui load

![Screenshot 2023-08-16 at 13 56 28](https://github.com/rancher/rancher/assets/97888974/9a2b6406-5c94-47c4-887c-100df8bba59e)
![Screenshot 2023-08-16 at 13 56 36](https://github.com/rancher/rancher/assets/97888974/74b02968-5095-47ad-879c-5c88998f3658)
![Screenshot 2023-08-16 at 13 56 50](https://github.com/rancher/rancher/assets/97888974/9f93ecb5-1d7c-4a69-9c1e-706358eb3f9d)
