### PR TITLE
rancher vsphere cpi/csi chart automation

### DIFF
--- a/tests/framework/extensions/charts/vspherecpi.go
+++ b/tests/framework/extensions/charts/vspherecpi.go
@@ -1,0 +1,205 @@
+package charts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/rancher/pkg/api/steve/catalog/types"
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/defaults"
+	kubenamespaces "github.com/rancher/rancher/tests/framework/extensions/kubeapi/namespaces"
+	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	// Namespace that rancher cpi chart is installed in
+	VsphereCpiNamespace = "kube-system"
+	// Name of the rancher vpshere cpi chart
+	VsphereCpiName = "rancher-vsphere-cpi"
+)
+
+type CpiConfig struct {
+	Datacenters string `json:"datacenters" yaml:"datacenters"`
+	Host        string `json:"host" yaml:"host"`
+	Username    string `json:"username" yaml:"username"`
+	Password    string `json:"password" yaml:"password"`
+}
+
+// InstallVsphereCpiChart is a helper function that installs the rancher-monitoring chart.
+func InstallVsphereCpiChart(client *rancher.Client, installOptions *InstallOptions, cpiConfig *CpiConfig) error {
+	serverSetting, err := client.Management.Setting.ByID(serverURLSettingID)
+	if err != nil {
+		return err
+	}
+
+	registrySetting, err := client.Management.Setting.ByID(defaultRegistrySettingID)
+	if err != nil {
+		return err
+	}
+
+	cpiChartInstallActionPayload := &payloadOpts{
+		InstallOptions:  *installOptions,
+		Name:            VsphereCpiName,
+		Namespace:       VsphereCpiNamespace,
+		Host:            serverSetting.Value,
+		DefaultRegistry: registrySetting.Value,
+	}
+
+	chartInstallAction := newCpiChartInstallAction(cpiChartInstallActionPayload, cpiConfig)
+
+	catalogClient, err := client.GetClusterCatalogClient(installOptions.ClusterID)
+	if err != nil {
+		return err
+	}
+
+	client.Session.RegisterCleanupFunc(func() error {
+		defaultChartUninstallAction := newChartUninstallAction()
+
+		err = catalogClient.UninstallChart(VsphereCpiName, VsphereCpiNamespace, defaultChartUninstallAction)
+		if err != nil {
+			return err
+		}
+
+		watchAppInterface, err := catalogClient.Apps(VsphereCpiNamespace).Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + VsphereCpiName,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+		if err != nil {
+			return err
+		}
+
+		err = wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+			if event.Type == watch.Error {
+				return false, fmt.Errorf("there was an error uninstalling rancher monitoring chart")
+			} else if event.Type == watch.Deleted {
+				return true, nil
+			}
+			return false, nil
+		})
+		if err != nil {
+			return err
+		}
+
+		err = catalogClient.UninstallChart(RancherMonitoringCRDName, VsphereCpiNamespace, defaultChartUninstallAction)
+		if err != nil {
+			return err
+		}
+
+		watchAppInterface, err = catalogClient.Apps(VsphereCpiNamespace).Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + RancherMonitoringCRDName,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+		if err != nil {
+			return err
+		}
+
+		err = wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+			chart := event.Object.(*catalogv1.App)
+			if event.Type == watch.Error {
+				return false, fmt.Errorf("there was an error uninstalling rancher monitoring chart")
+			} else if event.Type == watch.Deleted {
+				return true, nil
+			} else if chart == nil {
+				return true, nil
+			}
+			return false, nil
+		})
+		if err != nil {
+			return err
+		}
+
+		steveclient, err := client.Steve.ProxyDownstream(installOptions.ClusterID)
+		if err != nil {
+			return err
+		}
+
+		namespaceClient := steveclient.SteveType(namespaces.NamespaceSteveType)
+
+		namespace, err := namespaceClient.ByID(VsphereCpiNamespace)
+		if err != nil {
+			return err
+		}
+
+		err = namespaceClient.Delete(namespace)
+		if err != nil {
+			return err
+		}
+
+		adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+		if err != nil {
+			return err
+		}
+		adminDynamicClient, err := adminClient.GetDownStreamClusterClient(installOptions.ClusterID)
+		if err != nil {
+			return err
+		}
+		adminNamespaceResource := adminDynamicClient.Resource(kubenamespaces.NamespaceGroupVersionResource).Namespace("")
+
+		watchNamespaceInterface, err := adminNamespaceResource.Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + VsphereCpiNamespace,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return wait.WatchWait(watchNamespaceInterface, func(event watch.Event) (ready bool, err error) {
+			if event.Type == watch.Deleted {
+				return true, nil
+			}
+			return false, nil
+		})
+	})
+
+	err = catalogClient.InstallChart(chartInstallAction)
+	if err != nil {
+		return err
+	}
+
+	// wait for chart to be full deployed
+	watchAppInterface, err := catalogClient.Apps(VsphereCpiNamespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + VsphereCpiName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+		app := event.Object.(*catalogv1.App)
+
+		state := app.Status.Summary.State
+		if state == string(catalogv1.StatusDeployed) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// newMonitoringChartInstallAction is a private helper function that returns chart install action with monitoring and payload options.
+func newCpiChartInstallAction(p *payloadOpts, cpiConfig *CpiConfig) *types.ChartInstallAction {
+
+	cpiValues := map[string]interface{}{
+		"vCenter": map[string]interface{}{
+			"datacenters": cpiConfig.Datacenters, // Update with datacenters if needed
+			"host":        cpiConfig.Host,        // Update with vSphere host
+			"password":    cpiConfig.Password,    // Update with your vSphere password
+			"username":    cpiConfig.Username,    // Update with your vSphere username
+		},
+	}
+	chartInstall := newChartInstall(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, p.DefaultRegistry, cpiValues)
+	chartInstalls := []types.ChartInstall{*chartInstall}
+
+	chartInstallAction := newChartInstallAction(p.Namespace, p.ProjectID, chartInstalls)
+
+	return chartInstallAction
+}

--- a/tests/framework/extensions/charts/vspherecsi.go
+++ b/tests/framework/extensions/charts/vspherecsi.go
@@ -1,0 +1,212 @@
+package charts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/rancher/pkg/api/steve/catalog/types"
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/defaults"
+	kubenamespaces "github.com/rancher/rancher/tests/framework/extensions/kubeapi/namespaces"
+	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
+	"github.com/rancher/rancher/tests/framework/pkg/wait"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	// Namespace that rancher cpi chart is installed in
+	VsphereCsiNamespace = "kube-system"
+	// Name of the rancher istio chart
+	VsphereCsiName = "rancher-vsphere-csi"
+)
+
+type CsiConfig struct {
+	Datacenters  string `json:"datacenters" yaml:"datacenters"`
+	Host         string `json:"host" yaml:"host"`
+	Username     string `json:"username" yaml:"username"`
+	Password     string `json:"password" yaml:"password"`
+	DataStoreURL string `json:"datastoreurl" yaml:"datastoreurl"`
+}
+
+// InstallVsphereCpiChart is a helper function that installs the rancher-monitoring chart.
+func InstallVsphereCsiChart(client *rancher.Client, installOptions *InstallOptions, csiConfig *CsiConfig) error {
+	serverSetting, err := client.Management.Setting.ByID(serverURLSettingID)
+	if err != nil {
+		return err
+	}
+
+	registrySetting, err := client.Management.Setting.ByID(defaultRegistrySettingID)
+	if err != nil {
+		return err
+	}
+
+	cpiChartInstallActionPayload := &payloadOpts{
+		InstallOptions:  *installOptions,
+		Name:            VsphereCsiName,
+		Namespace:       VsphereCsiNamespace,
+		Host:            serverSetting.Value,
+		DefaultRegistry: registrySetting.Value,
+	}
+
+	chartInstallAction := newCsiChartInstallAction(cpiChartInstallActionPayload, csiConfig)
+
+	catalogClient, err := client.GetClusterCatalogClient(installOptions.ClusterID)
+	if err != nil {
+		return err
+	}
+
+	// Cleanup registration
+	client.Session.RegisterCleanupFunc(func() error {
+		// UninstallAction for when uninstalling the rancher-monitoring chart
+		defaultChartUninstallAction := newChartUninstallAction()
+
+		err = catalogClient.UninstallChart(VsphereCsiName, VsphereCsiNamespace, defaultChartUninstallAction)
+		if err != nil {
+			return err
+		}
+
+		watchAppInterface, err := catalogClient.Apps(VsphereCsiNamespace).Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + VsphereCsiName,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+		if err != nil {
+			return err
+		}
+
+		err = wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+			if event.Type == watch.Error {
+				return false, fmt.Errorf("there was an error uninstalling rancher monitoring chart")
+			} else if event.Type == watch.Deleted {
+				return true, nil
+			}
+			return false, nil
+		})
+		if err != nil {
+			return err
+		}
+
+		err = catalogClient.UninstallChart(RancherMonitoringCRDName, VsphereCsiNamespace, defaultChartUninstallAction)
+		if err != nil {
+			return err
+		}
+
+		watchAppInterface, err = catalogClient.Apps(VsphereCsiNamespace).Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + RancherMonitoringCRDName,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+		if err != nil {
+			return err
+		}
+
+		err = wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+			chart := event.Object.(*catalogv1.App)
+			if event.Type == watch.Error {
+				return false, fmt.Errorf("there was an error uninstalling rancher monitoring chart")
+			} else if event.Type == watch.Deleted {
+				return true, nil
+			} else if chart == nil {
+				return true, nil
+			}
+			return false, nil
+		})
+		if err != nil {
+			return err
+		}
+
+		steveclient, err := client.Steve.ProxyDownstream(installOptions.ClusterID)
+		if err != nil {
+			return err
+		}
+
+		namespaceClient := steveclient.SteveType(namespaces.NamespaceSteveType)
+
+		namespace, err := namespaceClient.ByID(VsphereCsiNamespace)
+		if err != nil {
+			return err
+		}
+
+		err = namespaceClient.Delete(namespace)
+		if err != nil {
+			return err
+		}
+
+		adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+		if err != nil {
+			return err
+		}
+		adminDynamicClient, err := adminClient.GetDownStreamClusterClient(installOptions.ClusterID)
+		if err != nil {
+			return err
+		}
+		adminNamespaceResource := adminDynamicClient.Resource(kubenamespaces.NamespaceGroupVersionResource).Namespace("")
+
+		watchNamespaceInterface, err := adminNamespaceResource.Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + VsphereCsiNamespace,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return wait.WatchWait(watchNamespaceInterface, func(event watch.Event) (ready bool, err error) {
+			if event.Type == watch.Deleted {
+				return true, nil
+			}
+			return false, nil
+		})
+	})
+
+	err = catalogClient.InstallChart(chartInstallAction)
+	if err != nil {
+		return err
+	}
+
+	// wait for chart to be full deployed
+	watchAppInterface, err := catalogClient.Apps(VsphereCsiNamespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + VsphereCsiName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+		app := event.Object.(*catalogv1.App)
+
+		state := app.Status.Summary.State
+		if state == string(catalogv1.StatusDeployed) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// newMonitoringChartInstallAction is a private helper function that returns chart install action with monitoring and payload options.
+func newCsiChartInstallAction(p *payloadOpts, csiConfig *CsiConfig) *types.ChartInstallAction {
+
+	csiValues := map[string]interface{}{
+		"storageClass": map[string]interface{}{
+			"datastoreURL": csiConfig.DataStoreURL, // Update with datacenters if needed
+		},
+		"vCenter": map[string]interface{}{
+			"datacenters": csiConfig.Datacenters, // Update with datacenters if needed
+			"host":        csiConfig.Host,        // Update with vSphere host
+			"password":    csiConfig.Password,    // Update with your vSphere password
+			"username":    csiConfig.Username,    // Update with your vSphere username
+		},
+	}
+
+	chartInstall := newChartInstall(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, p.DefaultRegistry, csiValues)
+	chartInstalls := []types.ChartInstall{*chartInstall}
+
+	chartInstallAction := newChartInstallAction(p.Namespace, p.ProjectID, chartInstalls)
+
+	return chartInstallAction
+}

--- a/tests/v2/validation/charts/vsphere_cpi_cis_test.go
+++ b/tests/v2/validation/charts/vsphere_cpi_cis_test.go
@@ -1,0 +1,197 @@
+package charts
+
+import (
+	"os"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/charts"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/pkg/config"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	// Project that charts are installed in
+	deplymentNamespace    = "default"
+	vsphereCpiProjectName = "system"
+	CpiConfigFileKey      = "cpi"
+	CsiConfigFileKey      = "csi"
+)
+
+// chartInstallOptions is a private struct that has cpi and csi charts install options
+type vsphereChartInstallOptions struct {
+	cpi *charts.InstallOptions
+	csi *charts.InstallOptions
+}
+
+type CpiTestSuite struct {
+	suite.Suite
+	client                     *rancher.Client
+	session                    *session.Session
+	project                    *management.Project
+	vsphereChartInstallOptions *vsphereChartInstallOptions
+	cpiConfig                  *charts.CpiConfig
+	csiConfig                  *charts.CsiConfig
+}
+
+func (c *CpiTestSuite) TearDownSuite() {
+	c.session.Cleanup()
+}
+
+func (c *CpiTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	c.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(c.T(), err)
+
+	c.client = client
+
+	cpiConfig := new(charts.CpiConfig)
+	csiConfig := new(charts.CsiConfig)
+
+	config.LoadConfig(CpiConfigFileKey, cpiConfig)
+	config.LoadConfig(CsiConfigFileKey, csiConfig)
+
+	c.cpiConfig = cpiConfig
+	c.csiConfig = csiConfig
+
+	require.NotEmptyf(c.T(), cpiConfig.Datacenters, cpiConfig.Host, cpiConfig.Username, cpiConfig.Password, "CPI Config is not set properly")
+	require.NotEmptyf(c.T(), csiConfig.Datacenters, csiConfig.Host, csiConfig.Username, csiConfig.Password, csiConfig.DataStoreURL, "CSI Config is not set properly")
+
+	c.T().Log("Getting CPI Config")
+
+	// Get clusterName from config yaml
+	require.NotEmptyf(c.T(), client.RancherConfig.ClusterName, "Cluster name to install is not set")
+
+	// Get clusterID with clusterName
+	clusterID, err := clusters.GetClusterIDByName(client, client.RancherConfig.ClusterName)
+	require.NoError(c.T(), err)
+
+	// Get latest versions of cpi & csi charts
+	latestCpiVersion, err := client.Catalog.GetLatestChartVersion(charts.VsphereCpiName)
+	require.NoError(c.T(), err)
+	latestCsiVersion, err := client.Catalog.GetLatestChartVersion(charts.VsphereCsiName)
+	require.NoError(c.T(), err)
+
+	// Create project
+	projectConfig := &management.Project{
+		ClusterID: clusterID,
+		Name:      vsphereCpiProjectName,
+	}
+	createdProject, err := client.Management.Project.Create(projectConfig)
+	require.NoError(c.T(), err)
+	require.Equal(c.T(), createdProject.Name, vsphereCpiProjectName)
+	c.project = createdProject
+
+	c.vsphereChartInstallOptions = &vsphereChartInstallOptions{
+		cpi: &charts.InstallOptions{
+			ClusterName: client.RancherConfig.ClusterName,
+			ClusterID:   clusterID,
+			Version:     latestCpiVersion,
+			ProjectID:   createdProject.ID,
+		},
+		csi: &charts.InstallOptions{
+			ClusterName: client.RancherConfig.ClusterName,
+			ClusterID:   clusterID,
+			Version:     latestCsiVersion,
+			ProjectID:   createdProject.ID,
+		},
+	}
+}
+
+func (c *CpiTestSuite) TestCpiChart() {
+	subSession := c.session.NewSession()
+	defer subSession.Cleanup()
+
+	client, err := c.client.WithSession(subSession)
+	require.NoError(c.T(), err)
+
+	c.T().Log("Checking if the cpi chart is installed")
+	cpiChart, err := charts.GetChartStatus(client, c.project.ClusterID, charts.VsphereCpiNamespace, charts.VsphereCpiName)
+	require.NoError(c.T(), err)
+
+	if !cpiChart.IsAlreadyInstalled {
+		c.T().Log("Installing cpi chart")
+		err = charts.InstallVsphereCpiChart(client, c.vsphereChartInstallOptions.cpi, c.cpiConfig)
+		require.NoError(c.T(), err)
+
+		c.T().Log("Waiting cpi chart deployments to have expected number of available replicas")
+		err = charts.WatchAndWaitDeployments(client, c.project.ClusterID, charts.VsphereCpiNamespace, metav1.ListOptions{})
+		require.NoError(c.T(), err)
+
+		c.T().Log("Waiting cpi chart DaemonSets to have expected number of available nodes")
+		err = charts.WatchAndWaitDaemonSets(client, c.project.ClusterID, charts.VsphereCpiNamespace, metav1.ListOptions{})
+		require.NoError(c.T(), err)
+
+		c.T().Log("Waiting cpi chart StatefulSets to have expected number of ready replicas")
+		err = charts.WatchAndWaitStatefulSets(client, c.project.ClusterID, charts.VsphereCpiNamespace, metav1.ListOptions{})
+		require.NoError(c.T(), err)
+	}
+
+	c.T().Log("Checking if the csi chart is installed")
+	csiChart, err := charts.GetChartStatus(client, c.project.ClusterID, charts.VsphereCsiNamespace, charts.VsphereCsiName)
+	require.NoError(c.T(), err)
+
+	if !csiChart.IsAlreadyInstalled {
+		c.T().Log("Installing csi chart with the latest version")
+		err = charts.InstallVsphereCsiChart(client, c.vsphereChartInstallOptions.csi, c.csiConfig)
+		require.NoError(c.T(), err)
+
+		c.T().Log("Waiting csi chart deployments to have expected number of available replicas")
+		err = charts.WatchAndWaitDeployments(client, c.project.ClusterID, charts.VsphereCsiNamespace, metav1.ListOptions{})
+		require.NoError(c.T(), err)
+
+		c.T().Log("Waiting csi chart DaemonSets to have expected number of available nodes")
+		err = charts.WatchAndWaitDaemonSets(client, c.project.ClusterID, charts.VsphereCsiNamespace, metav1.ListOptions{})
+		require.NoError(c.T(), err)
+
+		c.T().Log("Waiting csi chart StatefulSets to have expected number of ready replicas")
+		err = charts.WatchAndWaitStatefulSets(client, c.project.ClusterID, charts.VsphereCsiNamespace, metav1.ListOptions{})
+		require.NoError(c.T(), err)
+
+	}
+
+	c.T().Log("Creating a deployment with mounted volume")
+	pvcYamlFile, err := os.ReadFile("./resources/persistent-volume-claim.yaml")
+	require.NoError(c.T(), err)
+	pvcYamlInput := &management.ImportClusterYamlInput{
+		DefaultNamespace: deplymentNamespace,
+		YAML:             string(pvcYamlFile),
+	}
+	pvccluster, err := client.Management.Cluster.ByID(c.project.ClusterID)
+	require.NoError(c.T(), err)
+	_, err = client.Management.Cluster.ActionImportYaml(pvccluster, pvcYamlInput)
+	require.NoError(c.T(), err)
+
+	c.T().Log("Waiting example app deployments to have expected number of available replicas")
+	err = charts.WatchAndWaitDeployments(client, c.project.ClusterID, deplymentNamespace, metav1.ListOptions{})
+	require.NoError(c.T(), err)
+
+	c.T().Log("Creating a deployment with mounted volume")
+	readYamlFile, err := os.ReadFile("./resources/deployment-for-volume.yaml")
+	require.NoError(c.T(), err)
+	yamlInput := &management.ImportClusterYamlInput{
+		DefaultNamespace: deplymentNamespace,
+		YAML:             string(readYamlFile),
+	}
+	cluster, err := client.Management.Cluster.ByID(c.project.ClusterID)
+	require.NoError(c.T(), err)
+	_, err = client.Management.Cluster.ActionImportYaml(cluster, yamlInput)
+	require.NoError(c.T(), err)
+
+	c.T().Log("Waiting example app deployments to have expected number of available replicas")
+	err = charts.WatchAndWaitDeployments(client, c.project.ClusterID, deplymentNamespace, metav1.ListOptions{})
+	require.NoError(c.T(), err)
+
+}
+
+func TestCpiTestSuite(t *testing.T) {
+	suite.Run(t, new(CpiTestSuite))
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/qa-tasks/issues/872
 
## Feature
This PR serves the purpose of automating the CPI/CSI chart testing for vSphere environment.
Files in resources folder will be used to create a deployment and PVC. 

## CATTLE_TEST_CONFIG should be similar to following.
```
rancher:
 host: "<rancher-host>"
 adminToken: "<rancher-admin-token>"
 cleanup:  true
 clusterName: "<cluster-name>"
cpi:
 datacenters: "<vSphere-data-center>"
 host: "<vSphere-host>"
 username: "vSphere-username"
 password: "vSphere-password"
csi:
 datacenters: "<vSphere-data-center>"
 host: "<vSphere-host>"
 username: "<vSphere-username>"
 password: "<vSphere-password>"
 datastoreurl: "<vSphere-datasotreurl>"
```