### PR TITLE
[v2.8] Updated flakey extensions that was causing errors in the psa rbac tests

### DIFF
--- a/tests/framework/extensions/psact/checkpsact.go
+++ b/tests/framework/extensions/psact/checkpsact.go
@@ -20,7 +20,7 @@ func CheckPSACT(client *rancher.Client, clusterName string) error {
 	}
 
 	if cluster.DefaultPodSecurityAdmissionConfigurationTemplateName == "" {
-		return fmt.Errorf("error: PSACT is not defined in this cluster!")
+		return fmt.Errorf("error: PSACT is not defined in this cluster")
 	}
 
 	return nil

--- a/tests/framework/extensions/psact/createdeployment.go
+++ b/tests/framework/extensions/psact/createdeployment.go
@@ -57,7 +57,9 @@ func CreateNginxDeployment(client *rancher.Client, clusterID string, psact strin
 
 		deploymentResp, err := steveclient.SteveType(workloads.DeploymentSteveType).ByID(deploymentTemplate.Namespace + "/" + deploymentTemplate.Name)
 		if err != nil {
-			return false, err
+			// We don't want to return the error so we don't exit the poll too soon.
+			// There could be delay of when the deployment is created.
+			return false, nil
 		}
 
 		deployment := &appv1.Deployment{}
@@ -74,7 +76,7 @@ func CreateNginxDeployment(client *rancher.Client, clusterID string, psact strin
 			return true, nil
 		}
 
-		return false, err
+		return false, nil
 	})
 
 	return nil, err

--- a/tests/v2/validation/rbac/rbac.go
+++ b/tests/v2/validation/rbac/rbac.go
@@ -280,7 +280,12 @@ func editPsactCluster(client *rancher.Client, clustername string, namespace stri
 		if err != nil {
 			return clusterType, err
 		}
-		clusters.WaitForActiveRKE1Cluster(client, clusterID)
+
+		err = clusters.WaitForActiveRKE1Cluster(client, clusterID)
+		if err != nil {
+			return "", err
+		}
+
 		modifiedCluster, err := client.Management.Cluster.ByID(clusterID)
 		if err != nil {
 			return "", err

--- a/tests/v2/validation/rbac/rbac_psa_test.go
+++ b/tests/v2/validation/rbac/rbac_psa_test.go
@@ -44,6 +44,9 @@ type PSATestSuite struct {
 }
 
 func (rb *PSATestSuite) TearDownSuite() {
+	// reset the PSACT
+	_, err := editPsactCluster(rb.client, rb.clusterName, defaultNamespace, "rancher-privileged")
+	require.NoError(rb.T(), err)
 	rb.session.Cleanup()
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> https://github.com/rancher/qa-tasks/issues/873
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. --> The extensions CreateNginxDeployment and UpdateK3SRKE2Cluster were designed in way that it was possible to exit out the polls too soon, and therefore creating flakey behavior specifically in our rbac_psa tests.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. --> update the polls
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. --> release testing.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_