### PR TITLE
Tidy up debug logs during AD unmigration

### DIFF
--- a/cleanup/ad-guid-unmigration.sh
+++ b/cleanup/ad-guid-unmigration.sh
@@ -76,6 +76,8 @@ spec:
               #dryrun value: "true"
             #deletemissing - name: AD_DELETE_MISSING_GUID_USERS
               #deletemissing value: "true"
+            #- name: RANCHER_DEBUG
+            #  value: "true"
           image: agent_image
           imagePullPolicy: Always
           command: ["agent"]

--- a/pkg/agent/clean/adunmigration/ldap.go
+++ b/pkg/agent/clean/adunmigration/ldap.go
@@ -208,9 +208,6 @@ func adConfiguration(sc *config.ScaledContext) (*v3.ActiveDirectoryConfig, error
 
 	storedADConfig.ObjectMeta = *typemeta
 
-	logrus.Debugf("[%v] Should in theory have ActiveDirectory config data? Let's check!", migrateAdUserOperation)
-	logrus.Debugf("[%v] AD Service Account User: %v", migrateAdUserOperation, storedADConfig.ServiceAccountUsername)
-
 	if storedADConfig.ServiceAccountPassword != "" {
 		value, err := common.ReadFromSecret(secrets, storedADConfig.ServiceAccountPassword,
 			strings.ToLower(v3client.ActiveDirectoryConfigFieldServiceAccountPassword))
@@ -414,7 +411,7 @@ func migrateAllowedUserPrincipals(workunits *[]migrateUserWorkUnit, missingUsers
 	} else {
 		logrus.Infof("[%v] DRY RUN: new allowed user list will contain these principal IDs:", migrateAdUserOperation)
 		for _, principalID := range newPrincipalIDs {
-			logrus.Infof("[%v]   DRY RUN: '%v'", migrateAdUserOperation, principalID)
+			logrus.Infof("[%v] DRY RUN:   '%v'", migrateAdUserOperation, principalID)
 		}
 	}
 	return err

--- a/pkg/agent/clean/adunmigration/migrate.go
+++ b/pkg/agent/clean/adunmigration/migrate.go
@@ -181,6 +181,8 @@ func UnmigrateAdGUIDUsers(clientConfig *restclient.Config, dryRun bool, deleteMi
 		}
 	}
 
+	logrus.Infof("[%v] beginning ad-guid unmigration", migrateAdUserOperation)
+
 	users, err := sc.Management.Users("").List(metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to fetch user list: %v", err)
@@ -261,7 +263,7 @@ func UnmigrateAdGUIDUsers(clientConfig *restclient.Config, dryRun bool, deleteMi
 			progress := fmt.Sprintf("%.0f%%", percentDone)
 			err = updateMigrationStatus(sc, migrationStatusPercentage, progress)
 			if err != nil {
-				logrus.Errorf("unable to update migration status: %v", err)
+				logrus.Errorf("[%v] unable to update migration status: %v", migrateAdUserOperation, err)
 			}
 		}
 	}
@@ -270,6 +272,12 @@ func UnmigrateAdGUIDUsers(clientConfig *restclient.Config, dryRun bool, deleteMi
 	if err != nil {
 		finalStatus = activedirectory.StatusMigrationFailed
 		return err
+	}
+
+	if dryRun {
+		logrus.Infof("[%v] end of ad-guid unmigration", migrateAdUserOperation)
+	} else {
+		logrus.Infof("[%v] end of ad-guid unmigration, results saved to configmap '%v'", migrateAdUserOperation, activedirectory.StatusConfigMapName)
 	}
 
 	return nil
@@ -497,6 +505,6 @@ func updateUnmigratedUsers(user string, status string, reset bool, sc *config.Sc
 	}
 	err = updateADConfigMigrationStatus(cm.Data, sc)
 	if err != nil {
-		logrus.Errorf("unable to update AuthConfig status: %v", err)
+		logrus.Errorf("[%v] unable to update AuthConfig status: %v", migrateAdUserOperation, err)
 	}
 }

--- a/pkg/agent/clean/adunmigration/rtbs.go
+++ b/pkg/agent/clean/adunmigration/rtbs.go
@@ -198,8 +198,7 @@ func migrateCRTBs(workunit *migrateUserWorkUnit, sc *config.ScaledContext, dryRu
 	for _, oldCrtb := range workunit.activeDirectoryCRTBs {
 		if dryRun {
 			logrus.Infof("[%v] DRY RUN: would migrate CRTB '%v' from GUID principal '%v' to DN principal '%v'. "+
-				"Additionally, an annotation, %v, would be added containing the principal being migrated from and"+
-				"labels, %v and %v, that will contain the name of the previous CRTB and indicate that this CRTB has been migrated.",
+				"Annotation, %v, and labels %v and %v would be added, including the name of the previous CRTB instance",
 				migrateCrtbsOperation, oldCrtb.Name, oldCrtb.UserPrincipalName, dnPrincipalID, adGUIDMigrationAnnotation, migrationPreviousName, adGUIDMigrationLabel)
 		} else {
 			err := updateCRTB(crtbInterface, &oldCrtb, workunit.originalUser.Name, dnPrincipalID)
@@ -214,8 +213,7 @@ func migrateCRTBs(workunit *migrateUserWorkUnit, sc *config.ScaledContext, dryRu
 	for _, oldCrtb := range workunit.duplicateLocalCRTBs {
 		if dryRun {
 			logrus.Infof("[%v] DRY RUN: would migrate CRTB '%v' from duplicate local user '%v' to original user '%v'"+
-				"Additionally, an annotation, %v, would be added containing the principal being migrated from and"+
-				"labels, %v and %v, that will contain the name of the previous CRTB and indicate that this CRTB has been migrated.",
+				"Annotation, %v, and labels %v and %v would be added, including the name of the previous CRTB instance",
 				migrateCrtbsOperation, oldCrtb.Name, oldCrtb.UserPrincipalName, localPrincipalID, adGUIDMigrationAnnotation, migrationPreviousName, adGUIDMigrationLabel)
 		} else {
 			err := updateCRTB(crtbInterface, &oldCrtb, workunit.originalUser.Name, localPrincipalID)
@@ -302,8 +300,7 @@ func migratePRTBs(workunit *migrateUserWorkUnit, sc *config.ScaledContext, dryRu
 	for _, oldPrtb := range workunit.activeDirectoryPRTBs {
 		if dryRun {
 			logrus.Infof("[%v] DRY RUN: would migrate PRTB '%v' from GUID principal '%v' to DN principal '%v'. "+
-				"Additionally, an annotation, %v, would be added containing the principal being migrated from and"+
-				"labels, %v and %v, that will contain the name of the previous PRTB and indicate that this PRTB has been migrated.",
+				"Annotation, %v, and labels %v and %v would be added, including the name of the previous PRTB instance",
 				migratePrtbsOperation, oldPrtb.Name, oldPrtb.UserPrincipalName, dnPrincipalID, adGUIDMigrationAnnotation, migrationPreviousName, adGUIDMigrationLabel)
 
 		} else {
@@ -318,9 +315,8 @@ func migratePRTBs(workunit *migrateUserWorkUnit, sc *config.ScaledContext, dryRu
 	localPrincipalID := localPrefix + workunit.originalUser.Name
 	for _, oldPrtb := range workunit.duplicateLocalPRTBs {
 		if dryRun {
-			logrus.Infof("[%v] DRY RUN: would migrate PRTB '%v' from duplicate local user '%v' to original user '%v'"+
-				"Additionally, an annotation, %v, would be added containing the principal being migrated from and"+
-				"labels, %v and %v, that will contain the name of the previous PRTB and indicate that this PRTB has been migrated.",
+			logrus.Infof("[%v] DRY RUN: would migrate PRTB '%v' from duplicate local user '%v' to original user '%v'. "+
+				"Annotation, %v, and labels %v and %v would be added, including the name of the previous PRTB instance",
 				migratePrtbsOperation, oldPrtb.Name, oldPrtb.UserPrincipalName, localPrincipalID, adGUIDMigrationAnnotation, migrationPreviousName, adGUIDMigrationLabel)
 
 		} else {
@@ -344,8 +340,8 @@ func migrateGRBs(workunit *migrateUserWorkUnit, sc *config.ScaledContext, dryRun
 
 	for _, oldGrb := range workunit.duplicateLocalGRBs {
 		if dryRun {
-			logrus.Infof("[%v] DRY RUN: would migrate GRB '%v' from duplicate local user '%v' to original user '%v'"+
-				"Additionally, labels %v and %v will be added. These contain the name of the previous GRB and indicate that this GRB has been migrated.",
+			logrus.Infof("[%v] DRY RUN: would migrate GRB '%v' from duplicate local user '%v' to original user '%v'. "+
+				"Labels %v and %v would be added, including the name of the previous GRB instance",
 				migrateGrbsOperation, oldGrb.Name, oldGrb.UserName, workunit.originalUser.Name, migrationPreviousName, adGUIDMigrationLabel)
 		} else {
 			newLabels := oldGrb.Labels

--- a/pkg/agent/clean/adunmigration/tokens.go
+++ b/pkg/agent/clean/adunmigration/tokens.go
@@ -102,8 +102,7 @@ func migrateTokens(workunit *migrateUserWorkUnit, sc *config.ScaledContext, dryR
 	for _, userToken := range workunit.activeDirectoryTokens {
 		if dryRun {
 			logrus.Infof("[%v] DRY RUN: would migrate token '%v' from GUID principal '%v' to DN principal '%v'. "+
-				"Additionally, it would add an annotation, %v, indicating the former principalID of this token "+
-				"and a label, %v, to indicate that this token has been migrated",
+				"Would add annotation, %v, and label, %v, to indicate migration status",
 				migrateTokensOperation, userToken.Name, userToken.UserPrincipal.Name, dnPrincipalID, adGUIDMigrationAnnotation, adGUIDMigrationLabel)
 		} else {
 			err := updateToken(tokenInterface, userToken, dnPrincipalID, workunit.guid, workunit.originalUser, workunit.principal)

--- a/pkg/agent/clean/adunmigration/users.go
+++ b/pkg/agent/clean/adunmigration/users.go
@@ -13,7 +13,7 @@ import (
 )
 
 func describePlannedChanges(workunit migrateUserWorkUnit) {
-	logrus.Infof("DRY RUN: changes to user '%v' have NOT been saved.", workunit.originalUser.Name)
+	logrus.Debugf("[%v] DRY RUN: changes to user '%v' have NOT been saved.", migrateAdUserOperation, workunit.originalUser.Name)
 	if len(workunit.duplicateUsers) > 0 {
 		logrus.Infof("[%v] DRY RUN: duplicate users were identified", migrateAdUserOperation)
 		for _, duplicateUser := range workunit.duplicateUsers {
@@ -63,16 +63,16 @@ func replaceGUIDPrincipalWithDn(user *v3.User, dn string, guid string, dryRun bo
 	if dryRun {
 		// In dry run mode we will merely print the computed list and leave the original user object alone
 		logrus.Infof("[%v] DRY RUN: User '%v' with GUID '%v' would have new principals:", migrateAdUserOperation,
-			guid, user.Name)
+			user.Name, guid)
 		for _, principalID := range principalIDs {
-			logrus.Infof("[%v] DRY RUN:    '%v'", migrateAdUserOperation, principalID)
+			logrus.Infof("[%v] DRY RUN:   '%v'", migrateAdUserOperation, principalID)
 		}
 	} else {
 		user.PrincipalIDs = principalIDs
 		logrus.Debugf("[%v] User '%v' with GUID %v will have new principals:", migrateAdUserOperation,
-			guid, user.Name)
+			user.Name, guid)
 		for _, principalID := range user.PrincipalIDs {
-			logrus.Debugf("[%v]     '%v'", migrateAdUserOperation, principalID)
+			logrus.Debugf("[%v]    '%v'", migrateAdUserOperation, principalID)
 		}
 	}
 }
@@ -89,15 +89,6 @@ func isAdUser(user *v3.User) bool {
 func adPrincipalID(user *v3.User) string {
 	for _, principalID := range user.PrincipalIDs {
 		if strings.HasPrefix(principalID, activeDirectoryPrefix) {
-			return principalID
-		}
-	}
-	return ""
-}
-
-func localPrincipalID(user *v3.User) string {
-	for _, principalID := range user.PrincipalIDs {
-		if strings.HasPrefix(principalID, localPrefix) {
 			return principalID
 		}
 	}


### PR DESCRIPTION
This cleans up the logging output for a run of the unmigration script, and removes an otherwise noisy debug log during setup.

Successful runs now look something like this:

```
time="2023-08-18T12:13:44Z" level=info msg="[migrate-ad-user] beginning ad-guid unmigration"
time="2023-08-18T12:13:44Z" level=info msg="[migrate-ad-tokens] DRY RUN: would migrate token 'token-m6wj6' from GUID principal 'activedirectory_user://953d82a03d47a5498330293e386dfce1' to DN principal 'activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space'. Would add annotation, ad-guid-migration-data, and label, ad-guid-migration, to indicate migration status"
time="2023-08-18T12:13:44Z" level=info msg="[migrate-ad-tokens] DRY RUN: would migrate token 'token-7hrl2' from GUID principal 'activedirectory_user://953d82a03d47a5498330293e386dfce1' to DN principal 'activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space'. Would add annotation, ad-guid-migration-data, and label, ad-guid-migration, to indicate migration status"
time="2023-08-18T12:13:44Z" level=info msg="[migrate-ad-user] DRY RUN: User 'user-tmbgn' with GUID '953d82a03d47a5498330293e386dfce1' would have new principals:"
time="2023-08-18T12:13:44Z" level=info msg="[migrate-ad-user] DRY RUN:   'local://user-tmbgn'"
time="2023-08-18T12:13:44Z" level=info msg="[migrate-ad-user] DRY RUN:   'activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space'"
time="2023-08-18T12:13:44Z" level=info msg="[migrate-ad-user] DRY RUN: User 'u-fydcaomakf' with GUID '5a395328f3c70348ba9c83d6463d72ae' would have new principals:"
time="2023-08-18T12:13:44Z" level=info msg="[migrate-ad-user] DRY RUN:   'local://u-fydcaomakf'"
time="2023-08-18T12:13:44Z" level=info msg="[migrate-ad-user] DRY RUN:   'activedirectory_user://CN=testuser2,CN=Users,DC=qa,DC=rancher,DC=space'"
time="2023-08-18T12:13:44Z" level=info msg="[migrate-ad-user] DRY RUN: new allowed user list will contain these principal IDs:"
time="2023-08-18T12:13:44Z" level=info msg="[migrate-ad-user] DRY RUN:   'activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space'"
time="2023-08-18T12:13:44Z" level=info msg="[migrate-ad-user] end of ad-guid unmigration"
```

Even in debug mode, the "beginning" and "end" bookends will only appear if the unmigration would perform meaningful work. These should appear in rancher logs **exactly once** for upgraded v2.7.6 installations that have AD enabled.