### PR TITLE
Fix error handling for LDAP lookups during unmigration

### DIFF
--- a/pkg/agent/clean/adunmigration/ldap.go
+++ b/pkg/agent/clean/adunmigration/ldap.go
@@ -379,14 +379,14 @@ func migrateAllowedUserPrincipals(workunits *[]migrateUserWorkUnit, missingUsers
 						newPrincipalIDs = append(newPrincipalIDs, principalID)
 					} else {
 						dn, _, err := findLdapUserWithRetries(guid, &sharedLConn, originalAdConfig)
-						if errors.Is(err, LdapConnectionPermanentlyFailed{}) || errors.Is(err, LdapFoundDuplicateGUID{}) {
-							// Whelp; keep this one as-is and yell about it
-							logrus.Errorf("[%v] ldap connection error when checking distinguished name for guid-based principal %v, skipping: %v", migrateAdUserOperation, principalID, err)
-							newPrincipalIDs = append(newPrincipalIDs, principalID)
-						} else if errors.Is(err, LdapErrorNotFound{}) {
+						if errors.Is(err, LdapErrorNotFound{}) {
 							if !deleteMissingUsers {
 								newPrincipalIDs = append(newPrincipalIDs, principalID)
 							}
+						} else if err != nil {
+							// Whelp; keep this one as-is and yell about it
+							logrus.Errorf("[%v] ldap error when checking distinguished name for guid-based principal %v, skipping: %v", migrateAdUserOperation, principalID, err)
+							newPrincipalIDs = append(newPrincipalIDs, principalID)
 						} else {
 							newPrincipalID := activeDirectoryPrefix + dn
 							knownDnIDs[newPrincipalID] = newPrincipalID


### PR DESCRIPTION
While refactoring this, I neglected to check for the generic failure case of an unexpected error, and it turns out that's what gets thrown when LDAP fails to connect entirely. Missing this was causing users to get migrated with emptystring as their DN, which is definitely not the intended result.
