### PR TITLE
[v2.8] Add support for hardening RKE2/K3S v1.25+ custom clusters

### DIFF
--- a/tests/framework/extensions/hardening/k3s/harden_nodes.go
+++ b/tests/framework/extensions/hardening/k3s/harden_nodes.go
@@ -6,33 +6,35 @@ import (
 	"strings"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
 	"github.com/rancher/rancher/tests/framework/pkg/nodes"
 	"github.com/sirupsen/logrus"
 )
 
-func HardeningNodes(client *rancher.Client, hardened bool, nodes []*nodes.Node, nodeRoles []string) error {
+func HardeningNodes(client *rancher.Client, hardened bool, nodes []*nodes.Node, nodeRoles []string, kubeVersion string) error {
+	logrus.Infof("Starting to harden nodes")
 	for key, node := range nodes {
 		logrus.Infof("Setting kernel parameters on node %s", node.NodeID)
-		_, err := node.ExecuteCommand("sudo setenforce 1")
+		_, err := node.ExecuteCommand("sudo bash -c 'echo vm.panic_on_oom=0 >> /etc/sysctl.conf'")
 		if err != nil {
 			return err
 		}
-		_, err = node.ExecuteCommand("sudo bash -c 'echo vm.panic_on_oom=0 >> /etc/sysctl.conf'")
-		if err != nil {
-			return err
-		}
+
 		_, err = node.ExecuteCommand("sudo bash -c 'echo kernel.panic=10 >> /etc/sysctl.conf'")
 		if err != nil {
 			return err
 		}
+
 		_, err = node.ExecuteCommand("sudo bash -c 'echo kernel.panic_on_oops=1 >> /etc/sysctl.conf'")
 		if err != nil {
 			return err
 		}
+
 		_, err = node.ExecuteCommand("sudo bash -c 'echo kernel.keys.root_maxbytes=25000000 >> /etc/sysctl.conf'")
 		if err != nil {
 			return err
 		}
+
 		_, err = node.ExecuteCommand("sudo bash -c 'sysctl -p /etc/sysctl.conf'")
 		if err != nil {
 			return err
@@ -50,36 +52,53 @@ func HardeningNodes(client *rancher.Client, hardened bool, nodes []*nodes.Node, 
 			if err != nil {
 				return err
 			}
-			err = node.SCPFileToNode(dirPath+"/psp.yaml", "/home/"+node.SSHUser+"/psp.yaml")
-			if err != nil {
-				return err
-			}
-			err = node.SCPFileToNode(dirPath+"/system-policy.yaml", "/home/"+node.SSHUser+"/system-policy.yaml")
-			if err != nil {
-				return err
-			}
 
-			logrus.Infof("Applying hardened YAML files to node: %s", node.NodeID)
 			_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/audit.yaml /var/lib/rancher/k3s/server/audit.yaml'")
 			if err != nil {
 				return err
 			}
-			_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/psp.yaml /var/lib/rancher/k3s/psp.yaml'")
-			if err != nil {
-				return err
-			}
-			_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/system-policy.yaml /var/lib/rancher/k3s/system-policy.yaml'")
-			if err != nil {
-				return err
-			}
 
-			_, err = node.ExecuteCommand("sudo bash -c 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml && kubectl apply -f /var/lib/rancher/k3s/psp.yaml'")
-			if err != nil {
-				return err
-			}
-			_, err = node.ExecuteCommand("sudo bash -c 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml && kubectl apply -f /var/lib/rancher/k3s/system-policy.yaml'")
-			if err != nil {
-				return err
+			if kubeVersion <= string(provisioninginput.PSPKubeVersionLimit) {
+				err = node.SCPFileToNode(dirPath+"/psp.yaml", "/home/"+node.SSHUser+"/psp.yaml")
+				if err != nil {
+					return err
+				}
+
+				err = node.SCPFileToNode(dirPath+"/system-policy.yaml", "/home/"+node.SSHUser+"/system-policy.yaml")
+				if err != nil {
+					return err
+				}
+
+				logrus.Infof("Applying hardened YAML files to node: %s", node.NodeID)
+				_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/psp.yaml /var/lib/rancher/k3s/psp.yaml'")
+				if err != nil {
+					return err
+				}
+
+				_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/system-policy.yaml /var/lib/rancher/k3s/system-policy.yaml'")
+				if err != nil {
+					return err
+				}
+
+				_, err = node.ExecuteCommand("sudo bash -c 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml && kubectl apply -f /var/lib/rancher/k3s/psp.yaml'")
+				if err != nil {
+					return err
+				}
+
+				_, err = node.ExecuteCommand("sudo bash -c 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml && kubectl apply -f /var/lib/rancher/k3s/system-policy.yaml'")
+				if err != nil {
+					return err
+				}
+			} else {
+				err = node.SCPFileToNode(dirPath+"/psa.yaml", "/home/"+node.SSHUser+"/psa.yaml")
+				if err != nil {
+					return err
+				}
+
+				_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/psa.yaml /var/lib/rancher/k3s/server/psa.yaml'")
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/tests/framework/extensions/hardening/k3s/psa.yaml
+++ b/tests/framework/extensions/hardening/k3s/psa.yaml
@@ -1,0 +1,18 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: PodSecurity
+  configuration:
+    apiVersion: pod-security.admission.config.k8s.io/v1beta1
+    kind: PodSecurityConfiguration
+    defaults:
+      enforce: "privileged"
+      enforce-version: "latest"
+      audit: "privileged"
+      audit-version: "latest"
+      warn: "privileged"
+      warn-version: "latest"
+    exemptions:
+      usernames: []
+      runtimeClasses: []
+      namespaces: []

--- a/tests/framework/extensions/hardening/rke2/harden_nodes.go
+++ b/tests/framework/extensions/hardening/rke2/harden_nodes.go
@@ -11,40 +11,41 @@ import (
 )
 
 func HardeningNodes(client *rancher.Client, hardened bool, nodes []*nodes.Node, nodeRoles []string) error {
+	logrus.Infof("Starting to harden nodes")
 	for key, node := range nodes {
 		logrus.Infof("Setting kernel parameters on node %s", node.NodeID)
 		_, err := node.ExecuteCommand("sudo bash -c 'echo vm.panic_on_oom=0 >> /etc/sysctl.d/90-kubelet.conf'")
 		if err != nil {
 			return err
 		}
+
 		_, err = node.ExecuteCommand("sudo bash -c 'echo vm.overcommit_memory=1 >> /etc/sysctl.d/90-kubelet.conf'")
 		if err != nil {
 			return err
 		}
+
 		_, err = node.ExecuteCommand("sudo bash -c 'echo kernel.panic=10 >> /etc/sysctl.d/90-kubelet.conf'")
 		if err != nil {
 			return err
 		}
+
 		_, err = node.ExecuteCommand("sudo bash -c 'echo kernel.panic_on_oops=1 >> /etc/sysctl.d/90-kubelet.conf'")
 		if err != nil {
 			return err
 		}
+
 		_, err = node.ExecuteCommand("sudo bash -c 'sysctl -p /etc/sysctl.d/90-kubelet.conf'")
 		if err != nil {
 			return err
 		}
+
 		if strings.Contains(nodeRoles[key], "--etcd") {
 			_, err = node.ExecuteCommand("sudo useradd -r -c \"etcd user\" -s /sbin/nologin -M etcd -U")
 			if err != nil {
 				return err
 			}
 		}
-	}
-	return nil
-}
 
-func PostHardeningConfig(client *rancher.Client, hardened bool, nodes []*nodes.Node, nodeRoles []string) error {
-	for key, node := range nodes {
 		if strings.Contains(nodeRoles[key], "--controlplane") {
 			logrus.Infof("Copying over files to node %s", node.NodeID)
 			user, err := user.Current()
@@ -57,10 +58,12 @@ func PostHardeningConfig(client *rancher.Client, hardened bool, nodes []*nodes.N
 			if err != nil {
 				return err
 			}
+
 			err = node.SCPFileToNode(dirPath+"/account-update.sh", "/home/"+node.SSHUser+"/account-update.sh")
 			if err != nil {
 				return err
 			}
+
 			_, err = node.ExecuteCommand("sudo bash -c 'mv /home/" + node.SSHUser + "/account-update.yaml /var/lib/rancher/rke2/server/account-update.yaml'")
 			if err != nil {
 				return err
@@ -69,16 +72,18 @@ func PostHardeningConfig(client *rancher.Client, hardened bool, nodes []*nodes.N
 			if err != nil {
 				return err
 			}
+
 			_, err = node.ExecuteCommand("sudo bash -c 'chmod +x /var/lib/rancher/rke2/server/account-update.sh'")
 			if err != nil {
 				return err
 			}
+
 			_, err = node.ExecuteCommand("sudo bash -c 'export KUBECONFIG=/etc/rancher/rke2/rke2.yaml && /var/lib/rancher/rke2/server/account-update.sh'")
 			if err != nil {
 				return err
 			}
-			break
 		}
 	}
+
 	return nil
 }

--- a/tests/framework/extensions/provisioninginput/config.go
+++ b/tests/framework/extensions/provisioninginput/config.go
@@ -14,7 +14,7 @@ const (
 	Namespace                       = "fleet-default"
 	defaultRandStringLength         = 5
 	ConfigurationFileKey            = "provisioningInput"
-	HardenedKubeVersion     Version = "v1.24.99"
+	PSPKubeVersionLimit     Version = "v1.24.99"
 	RancherPrivileged       PSACT   = "rancher-privileged"
 	RancherRestricted       PSACT   = "rancher-restricted"
 )


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Update RKE2/K3S custom cluster hardening to account for K8s versions 1.25+](https://github.com/rancher/qa-tasks/issues/865)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The go framework currently only supports hardening custom RKE2/K3S clusters if the Kubernetes version is below v1.25. This was always meant to be a temporary solution until we understood the steps needed to harden downstream clusters v1.25+.

Now that the steps are available, we need to update the existing automation to account for these changes while still preserving the changes made.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Depending on the K8s version specified, the appropriate hardening steps will be applied to the RKE2/K3S downstream cluster. The tests remains dynamic as it is up to how the K8s version is defined in the user's config that dictate these steps.

RKE2 steps remain relatively the same, excluding that the CIS profile is 1.23. K3S no longer utilizes PSPs and now utilizes PSA, as was introduced in K8s v1.25+ and Rancher v2.7.2 as being the default Pod Security.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
- K3S custom clusters < 1.25 - PASS
- K3S custom clusters >= 1.25 - PASS
- RKE2 custom clusters < 1.25 - PASS (hitting known [issue](https://github.com/rancher/rancher/issues/39740))
- RKE2 custom clusters >= 1.25 - PASS (hitting known [issue](https://github.com/rancher/rancher/issues/39740))

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_