### PR TITLE
[2.7] Update configuration input check in RKE2 ACE validation tests

### DIFF
--- a/tests/v2/validation/provisioning/rke2/ace_test.go
+++ b/tests/v2/validation/provisioning/rke2/ace_test.go
@@ -91,7 +91,7 @@ func (r *RKE2ACETestSuite) TestProvisioningRKE2ClusterACE() {
 		{"Multiple Control Planes - Admin", nodeRoles0, r.client},
 		{"Multiple Control Planes - Standard", nodeRoles0, r.standardUserClient},
 	}
-	require.NotEmpty(r.T(), r.clustersConfig.Networking.LocalClusterAuthEndpoint)
+	require.NotNil(r.T(), r.clustersConfig.Networking.LocalClusterAuthEndpoint)
 	// Test is obsolete when ACE is not set.
 	for _, tt := range tests {
 		subSession := r.session.NewSession()


### PR DESCRIPTION
## Issue: https://github.com/rancher/qa-tasks/issues/883 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Current RKE2 ACE tests fail cause of: `Should NOT be empty, but was ...`
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Updated the [the configuration empty check](https://github.com/rancher/rancher/blob/release/v2.8/tests/v2/validation/provisioning/rke2/ace_test.go#L94) should be updated as a nil check in RKE2 ACE tests.

## Engineering Testing

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Validation (Go Framework)
