### PR TITLE
Add helm framework to tests

### DIFF
--- a/tests/framework/clients/helm/helm.go
+++ b/tests/framework/clients/helm/helm.go
@@ -1,0 +1,106 @@
+package helm
+
+import (
+	"os/exec"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+)
+
+var helmCmd = "helm_v3"
+
+// InstallChart installs a helm chart using helm CLI.
+// Send the helm set command strings such as "--set", "installCRDs=true"
+// in the args argument to be prepended to the helm install command.
+func InstallChart(ts *session.Session, releaseName, helmRepo, namespace, version string, args ...string) error {
+	// Register cleanup function
+	ts.RegisterCleanupFunc(func() error {
+		return UninstallChart(releaseName, namespace)
+	})
+
+	// Default helm install command
+	commandArgs := []string{
+		"install",
+		releaseName,
+		helmRepo,
+		"--namespace",
+		namespace,
+		"--wait",
+	}
+
+	commandArgs = append(commandArgs, args...)
+
+	if version != "" {
+		commandArgs = append(commandArgs, "--version", version)
+	}
+
+	msg, err := exec.Command(helmCmd, commandArgs...).CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, "InstallChart: "+string(msg))
+	}
+
+	return nil
+}
+
+// UpgradeChart upgrades a helm chart using helm CLI.
+// Send the helm set command strings such as "--set", "installCRDs=true"
+// in the args argument to be prepended to the helm upgrade command.
+func UpgradeChart(ts *session.Session, releaseName, helmRepo, namespace, version string, args ...string) error {
+	// Register cleanup function
+	ts.RegisterCleanupFunc(func() error {
+		return UninstallChart(releaseName, namespace)
+	})
+
+	// Default helm upgrade command
+	commandArgs := []string{
+		"upgrade",
+		releaseName,
+		helmRepo,
+		"--namespace",
+		namespace,
+		"--wait",
+	}
+
+	commandArgs = append(commandArgs, args...)
+
+	if version != "" {
+		commandArgs = append(commandArgs, "--version", version)
+	}
+
+	msg, err := exec.Command(helmCmd, commandArgs...).CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, "UpgradeChart: "+string(msg))
+	}
+
+	return nil
+}
+
+// UninstallChart uninstalls a helm chart using helm CLI in a given namespace
+// using the releaseName provided.
+func UninstallChart(releaseName, namespace string, args ...string) error {
+	// Default helm uninstall command
+	commandArgs := []string{
+		"uninstall",
+		releaseName,
+		"--namespace",
+		namespace,
+		"--wait",
+	}
+
+	msg, err := exec.Command(helmCmd, commandArgs...).CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, "UninstallChart: "+string(msg))
+	}
+
+	return nil
+}
+
+// AddHelmRepo adds the specified helm repoistory using the helm repo add command.
+func AddHelmRepo(name, url string) error {
+	msg, err := exec.Command(helmCmd, "repo", "add", name, url).CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, "AddHelmRepo: "+string(msg))
+	}
+
+	return nil
+}

--- a/tests/framework/extensions/kubeapi/helm/helm.go
+++ b/tests/framework/extensions/kubeapi/helm/helm.go
@@ -1,0 +1,96 @@
+package helm
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/rancher/rancher/tests/framework/clients/helm"
+	"github.com/rancher/rancher/tests/framework/pkg/session"
+)
+
+// InstallRancher installs latest version of rancher including cert-manager
+// using helm CLI with some predefined values set such as
+// - BootstrapPassword : admin
+// - Hostname          : Localhost
+// - BundledMode       : True
+// - Replicas          : 1
+func InstallRancher(ts *session.Session, restConfig *rest.Config) error {
+	//  ClientSet of kubernetes
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	// Create namespace cattle-system
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "cattle-system"}}
+	_, err = clientset.CoreV1().Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Install cert-manager chart
+	err = InstallCertManager(restConfig)
+	if err != nil {
+		return err
+	}
+
+	// Add Rancher helm repo
+	err = helm.AddHelmRepo("rancher-stable", "https://releases.rancher.com/server-charts/stable")
+	if err != nil {
+		return err
+	}
+
+	// Install Rancher Chart
+	err = helm.InstallChart(ts, "rancher",
+		"rancher-stable/rancher",
+		"cattle-system",
+		"",
+		"--set",
+		"hostname=localhost",
+		"--set",
+		"bootstrapPassword=admin",
+		"--set",
+		"useBundledSystemChart=true",
+		"--set",
+		"replicas=1")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InstallCertManager installs latest version cert manager available through helm
+// CLI. It sets the installCRDs as true to install crds as well.
+func InstallCertManager(ts *session.Session, restConfig *rest.Config) error {
+	//  ClientSet of kubernetes
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	// Create namespace cert-manager
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "cert-manager"}}
+	_, err = clientset.CoreV1().Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Add cert-manager Helm Repo
+	err = helm.AddHelmRepo("jetstack", "https://charts.jetstack.io")
+	if err != nil {
+		return err
+	}
+
+	// Install cert-manager Chart
+	err = helm.InstallChart(ts, "cert-manager", "jetstack/cert-manager", "cert-manager", "", "--set", "installCRDs=true")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adding helm framework to tests so that integration or validation tests which require doing `helm install rancher` can use this framework.