### PR TITLE
Fix istio tests in 27

### DIFF
--- a/tests/v2/validation/charts/istio.go
+++ b/tests/v2/validation/charts/istio.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	// Rancher istio chart kiali path
-	kialiPath = "api/v1/namespaces/istio-system/services/http:kiali:20001/proxy/kiali/"
+	kialiPath = "api/v1/namespaces/istio-system/services/http:kiali:20001/proxy/console/"
 	// Rancher istio chart tracing path
 	tracingPath = "api/v1/namespaces/istio-system/services/http:tracing:16686/proxy/jaeger/search"
 )


### PR DESCRIPTION
## Problem
With the latest Istio chart, the path of Kiali has changed.
 
## Solution
Updated the path of Kiali to the new path
 
## Testing
Ran locally


* Test types added/modified:
    * Validation (Go Framework)
