### PR TITLE
[v2.7] Fix Air gap provisioning automation tests

### DIFF
--- a/tests/framework/clients/corral/config.go
+++ b/tests/framework/clients/corral/config.go
@@ -23,7 +23,6 @@ type CorralPackages struct {
 	HasCleanup          bool              `json:"hasCleanup" yaml:"hasCleanup" default:"true"`
 	HasDebug            bool              `json:"hasDebug" yaml:"hasDebug" default:"false"`
 	HasCustomRepo       string            `json:"hasCustomRepo" yaml:"hasCustomRepo"`
-	HasSetCorralSSHKeys bool              `json:"hasSetCorralSSHKeys" yaml:"hasSetCorralSSHKeys" default:"false"`
 }
 
 // CorralPackagesConfig is a function that reads in the corral package object from the config file

--- a/tests/framework/clients/corral/corral.go
+++ b/tests/framework/clients/corral/corral.go
@@ -2,6 +2,7 @@ package corral
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os/exec"
 	"regexp"
@@ -13,8 +14,10 @@ import (
 )
 
 const (
-	debugFlag       = "--trace"
-	skipCleanupFlag = "--skip-cleanup"
+	debugFlag           = "--trace"
+	skipCleanupFlag     = "--skip-cleanup"
+	corralPrivateSSHKey = "corral_private_key"
+	corralPublicSSHKey  = "corral_public_key"
 )
 
 // GetCorralEnvVar gets corral environment variables
@@ -190,4 +193,26 @@ func DeleteAllCorrals() error {
 		}
 	}
 	return nil
+}
+
+func SetCorralSSHKeys(corralName string) error {
+	privateSSHkey, err := GetCorralEnvVar(corralName, corralPrivateSSHKey)
+	if err != nil {
+		return err
+	}
+
+	privateSSHkey = strings.Replace(privateSSHkey, "\n", "\\n", -1)
+	privateSSHkey = fmt.Sprintf("\"%s\"", privateSSHkey)
+
+	err = UpdateCorralConfig(corralPrivateSSHKey, privateSSHkey)
+	if err != nil {
+		return err
+	}
+
+	publicSSHkey, err := GetCorralEnvVar(corralName, corralPublicSSHKey)
+	if err != nil {
+		return err
+	}
+
+	return UpdateCorralConfig(corralPublicSSHKey, publicSSHkey)
 }

--- a/tests/framework/extensions/provisioning/verify.go
+++ b/tests/framework/extensions/provisioning/verify.go
@@ -274,10 +274,14 @@ func VerifyHostnameLength(t *testing.T, client *rancher.Client, clusterObject *s
 
 // VerifyUpgrade validates that a cluster has been upgraded to a given version
 func VerifyUpgrade(t *testing.T, updatedCluster *bundledclusters.BundledCluster, upgradedVersion string) {
-	clusterSpec := &provv1.ClusterSpec{}
-	err := steveV1.ConvertToK8sType(updatedCluster.V1.Spec, clusterSpec)
-	require.NoError(t, err)
-	assert.Equalf(t, upgradedVersion, clusterSpec.KubernetesVersion, "[%v]: %v", updatedCluster.Meta.Name, logMessageKubernetesVersion)
+	if updatedCluster.V3 != nil {
+		assert.Equalf(t, upgradedVersion, updatedCluster.V3.RancherKubernetesEngineConfig.Version, "[%v]: %v", updatedCluster.Meta.Name, logMessageKubernetesVersion)
+	} else {
+		clusterSpec := &provv1.ClusterSpec{}
+		err := steveV1.ConvertToK8sType(updatedCluster.V1.Spec, clusterSpec)
+		require.NoError(t, err)
+		assert.Equalf(t, upgradedVersion, clusterSpec.KubernetesVersion, "[%v]: %v", updatedCluster.Meta.Name, logMessageKubernetesVersion)
+	}
 }
 
 // VerifySnapshots waits for a cluster's snapshots to be ready and validates that the correct number of snapshots have been taken

--- a/tests/v2/validation/pipeline/releaseupgrade/main.go
+++ b/tests/v2/validation/pipeline/releaseupgrade/main.go
@@ -93,13 +93,13 @@ func main() {
 	//make cattle-configs dir
 	err := config.NewConfigurationsDir(dirName)
 	if err != nil {
-		logrus.Fatalf("error while creating configs dir", err)
+		logrus.Fatal("error while creating configs dir", err)
 	}
 
 	//copy common configuration for individual configs
 	copiedConfig, err := os.ReadFile(configPath)
 	if err != nil {
-		logrus.Fatalf("error while copying upgrade config", err)
+		logrus.Fatal("error while copying upgrade config", err)
 	}
 
 	clusters := new(pipeline.Clusters)
@@ -116,7 +116,7 @@ func main() {
 			newConfigName := config.NewConfigFileName(dirName, rke1FileName, customFileName, v.Provider, cni, fmt.Sprint(i))
 			err := NewRancherClusterConfiguration(v, newConfigName, isCustom, isRKE1, isRKE2, copiedConfig, cni, testPackage, runCommand)
 			if err != nil {
-				logrus.Infof("error while generating a rancher cluster config", err)
+				logrus.Info("error while generating a rancher cluster config", err)
 				continue
 			}
 		}
@@ -133,7 +133,7 @@ func main() {
 			newConfigName := config.NewConfigFileName(dirName, rke1FileName, nodeProviderFileName, v.Provider, cni, fmt.Sprint(i))
 			err := NewRancherClusterConfiguration(v, newConfigName, isCustom, isRKE1, isRKE2, copiedConfig, cni, testPackage, runCommand)
 			if err != nil {
-				logrus.Infof("error while generating a rancher cluster config", err)
+				logrus.Info("error while generating a rancher cluster config", err)
 				continue
 			}
 		}
@@ -150,7 +150,7 @@ func main() {
 			newConfigName := config.NewConfigFileName(dirName, rke2FileName, customFileName, v.Provider, cni, fmt.Sprint(i))
 			err := NewRancherClusterConfiguration(v, newConfigName, isCustom, isRKE1, isRKE2, copiedConfig, cni, testPackage, runCommand)
 			if err != nil {
-				logrus.Infof("error while generating a rancher cluster config", err)
+				logrus.Info("error while generating a rancher cluster config", err)
 				continue
 			}
 		}
@@ -167,7 +167,7 @@ func main() {
 			newConfigName := config.NewConfigFileName(dirName, rke2FileName, nodeProviderFileName, v.Provider, cni, fmt.Sprint(i))
 			err := NewRancherClusterConfiguration(v, newConfigName, isCustom, isRKE1, isRKE2, copiedConfig, cni, testPackage, runCommand)
 			if err != nil {
-				logrus.Infof("error while generating a rancher cluster config", err)
+				logrus.Info("error while generating a rancher cluster config", err)
 				continue
 			}
 		}
@@ -184,7 +184,7 @@ func main() {
 			newConfigName := config.NewConfigFileName(dirName, k3sFileName, customFileName, v.Provider, cni, fmt.Sprint(i))
 			err := NewRancherClusterConfiguration(v, newConfigName, isCustom, isRKE1, isRKE2, copiedConfig, cni, testPackage, runCommand)
 			if err != nil {
-				logrus.Infof("error while generating a rancher cluster config", err)
+				logrus.Info("error while generating a rancher cluster config", err)
 				continue
 			}
 		}
@@ -201,7 +201,7 @@ func main() {
 			newConfigName := config.NewConfigFileName(dirName, k3sFileName, nodeProviderFileName, v.Provider, cni, fmt.Sprint(i))
 			err := NewRancherClusterConfiguration(v, newConfigName, isCustom, isRKE1, isRKE2, copiedConfig, cni, testPackage, runCommand)
 			if err != nil {
-				logrus.Infof("error while generating a rancher cluster config", err)
+				logrus.Info("error while generating a rancher cluster config", err)
 				continue
 			}
 		}
@@ -268,13 +268,13 @@ func main() {
 func NewRancherClusterConfiguration(cluster pipeline.RancherCluster, newConfigName config.ConfigFileName, isCustom, isRKE1, isRKE2 bool, copiedConfig []byte, cni, provTestPackage, runCommand string) (err error) {
 	err = newConfigName.NewFile(copiedConfig)
 	if err != nil {
-		logrus.Infof("error while writing populated config", err)
+		logrus.Info("error while writing populated config", err)
 		return err
 	}
 
 	err = newConfigName.SetEnvironmentKey()
 	if err != nil {
-		logrus.Infof("error while setting new config as env var", err)
+		logrus.Info("error while setting new config as env var", err)
 		return err
 	}
 

--- a/tests/v2/validation/provisioning/airgap/k3s_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/airgap/k3s_custom_cluster_test.go
@@ -71,6 +71,9 @@ func (a *AirGapK3SCustomClusterTestSuite) SetupSuite() {
 		registryFQDN, err := corral.GetCorralEnvVar(corralRancherHA.Name, corralRegistryFQDN)
 		require.NoError(a.T(), err)
 		logrus.Infof("registry fqdn is %s", registryFQDN)
+
+		err = corral.SetCorralSSHKeys(corralRancherHA.Name)
+		require.NoError(a.T(), err)
 		a.registryFQDN = registryFQDN
 	} else {
 		a.registryFQDN = registriesConfig.ExistingNoAuthRegistryURL
@@ -87,7 +90,7 @@ func (a *AirGapK3SCustomClusterTestSuite) TestProvisioningK3SCustomCluster() {
 		{provisioninginput.AdminClientName.String() + "-" + permutations.K3SAirgapCluster + "-", a.client},
 	}
 	for _, tt := range tests {
-		permutations.RunTestPermutations(&a.Suite, tt.name, tt.client, a.clustersConfig, permutations.K3SProvisionCluster, nil, a.corralPackage)
+		permutations.RunTestPermutations(&a.Suite, tt.name, tt.client, a.clustersConfig, permutations.K3SAirgapCluster, nil, a.corralPackage)
 	}
 
 }

--- a/tests/v2/validation/provisioning/airgap/rke1_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/airgap/rke1_custom_cluster_test.go
@@ -71,6 +71,9 @@ func (a *AirGapRKE1CustomClusterTestSuite) SetupSuite() {
 		registryFQDN, err := corral.GetCorralEnvVar(corralRancherHA.Name, corralRegistryFQDN)
 		require.NoError(a.T(), err)
 		logrus.Infof("registry fqdn is %s", registryFQDN)
+
+		err = corral.SetCorralSSHKeys(corralRancherHA.Name)
+		require.NoError(a.T(), err)
 		a.registryFQDN = registryFQDN
 	} else {
 		a.registryFQDN = registriesConfig.ExistingNoAuthRegistryURL
@@ -88,7 +91,7 @@ func (a *AirGapRKE1CustomClusterTestSuite) TestProvisioningRKE1CustomCluster() {
 		{provisioninginput.AdminClientName.String() + "-" + permutations.RKE1AirgapCluster + "-", a.client},
 	}
 	for _, tt := range tests {
-		permutations.RunTestPermutations(&a.Suite, tt.name, tt.client, a.clustersConfig, permutations.RKE1ProvisionCluster, nil, a.corralPackage)
+		permutations.RunTestPermutations(&a.Suite, tt.name, tt.client, a.clustersConfig, permutations.RKE1AirgapCluster, nil, a.corralPackage)
 	}
 
 }
@@ -96,7 +99,7 @@ func (a *AirGapRKE1CustomClusterTestSuite) TestProvisioningRKE1CustomCluster() {
 func (a *AirGapRKE1CustomClusterTestSuite) TestProvisioningUpgradeRKE1CustomCluster() {
 	a.clustersConfig.NodesAndRolesRKE1 = []nodepools.NodeRoles{provisioninginput.RKE1AllRolesPool}
 
-	rke1Versions, err := kubernetesversions.ListK3SAllVersions(a.client)
+	rke1Versions, err := kubernetesversions.ListRKE1AllVersions(a.client)
 	require.NoError(a.T(), err)
 
 	numOfRKE1Versions := len(rke1Versions)

--- a/tests/v2/validation/provisioning/airgap/rke2_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/airgap/rke2_custom_cluster_test.go
@@ -70,6 +70,9 @@ func (a *AirGapRKE2CustomClusterTestSuite) SetupSuite() {
 		registryFQDN, err := corral.GetCorralEnvVar(corralRancherHA.Name, corralRegistryFQDN)
 		require.NoError(a.T(), err)
 		logrus.Infof("registry fqdn is %s", registryFQDN)
+
+		err = corral.SetCorralSSHKeys(corralRancherHA.Name)
+		require.NoError(a.T(), err)
 		a.registryFQDN = registryFQDN
 	} else {
 		a.registryFQDN = registriesConfig.ExistingNoAuthRegistryURL
@@ -87,7 +90,7 @@ func (a *AirGapRKE2CustomClusterTestSuite) TestProvisioningRKE2CustomCluster() {
 		{provisioninginput.AdminClientName.String() + "-" + permutations.RKE2AirgapCluster + "-", a.client},
 	}
 	for _, tt := range tests {
-		permutations.RunTestPermutations(&a.Suite, tt.name, tt.client, a.clustersConfig, permutations.RKE2ProvisionCluster, nil, a.corralPackage)
+		permutations.RunTestPermutations(&a.Suite, tt.name, tt.client, a.clustersConfig, permutations.RKE2AirgapCluster, nil, a.corralPackage)
 	}
 
 }

--- a/tests/v2/validation/provisioning/permutations/permutations.go
+++ b/tests/v2/validation/provisioning/permutations/permutations.go
@@ -25,6 +25,7 @@ const (
 	RKE1CustomCluster    = "rke1Custom"
 	RKE1ProvisionCluster = "rke1"
 	RKE1AirgapCluster    = "rke1Airgap"
+	CorralProvider       = "corral"
 )
 
 // RunTestPermutations runs through all relevant perumutations in a given config file, including node providers, k8s versions, and CNIs
@@ -41,6 +42,8 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 
 	if strings.Contains(clusterType, "Custom") {
 		providers = clustersConfig.NodeProviders
+	} else if strings.Contains(clusterType, "Airgap") {
+		providers = []string{"Corral"}
 	} else {
 		providers = clustersConfig.Providers
 	}
@@ -137,8 +140,14 @@ func GetClusterProvider(clusterType string, nodeProviderName string, clustersCon
 	case RKE1CustomCluster:
 		customProvider = provisioning.ExternalNodeProviderSetup(nodeProviderName)
 		kubeVersions = clustersConfig.RKE1KubernetesVersions
+	case K3SAirgapCluster:
+		kubeVersions = clustersConfig.K3SKubernetesVersions
+	case RKE1AirgapCluster:
+		kubeVersions = clustersConfig.RKE1KubernetesVersions
+	case RKE2AirgapCluster:
+		kubeVersions = clustersConfig.RKE2KubernetesVersions
 	default:
-		customProvider = provisioning.ExternalNodeProviderSetup(nodeProviderName)
+		panic("Cluster type not found")
 	}
 	return &nodeProvider, &rke1NodeProvider, &customProvider, kubeVersions
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [#886](https://github.com/rancher/qa-tasks/issues/886)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> 
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. --> The pre-existing airgap tests were broken following a recent code refactor
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. --> Run permunatations for all three clusters were using the wrong identifier, updated the verify kubernetes upgrade function to account rke1 clusters as well, and fixed the create provider function.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. - -> Ran the air gap Jenkins job. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_