### PR TITLE
Deprecate the ServiceAccount field on ProjectRoleTemplateBindings

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authz_types.go
+++ b/pkg/apis/management.cattle.io/v3/authz_types.go
@@ -305,6 +305,7 @@ type ProjectRoleTemplateBinding struct {
 	RoleTemplateName string `json:"roleTemplateName,omitempty" norman:"required,noupdate,type=reference[roleTemplate]"`
 
 	// ServiceAccount is the name of the service account bound as a subject. Immutable.
+	// Deprecated.
 	// +optional
 	ServiceAccount string `json:"serviceAccount,omitempty" norman:"nocreate,noupdate"`
 }

--- a/pkg/controllers/management/auth/prtb_sa_controller.go
+++ b/pkg/controllers/management/auth/prtb_sa_controller.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	wranglerv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/types/config"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	prtbServiceAccountControllerName = "prtb-service-account-controller"
+	serviceAccountAnnotation         = "management.cattle.io/serviceAccount"
+)
+
+type prtbServiceAccountController struct {
+	prtbClient wranglerv3.ProjectRoleTemplateBindingClient
+}
+
+func newPRTBServiceAccountController(mgmt *config.ManagementContext) *prtbServiceAccountController {
+	return &prtbServiceAccountController{
+		prtbClient: mgmt.Wrangler.Mgmt.ProjectRoleTemplateBinding(),
+	}
+}
+
+func (c prtbServiceAccountController) sync(_ string, prtb *apiv3.ProjectRoleTemplateBinding) (runtime.Object, error) {
+	if prtb == nil {
+		return prtb, nil
+	}
+	if prtb.ServiceAccount != "" {
+		if _, ok := prtb.Annotations[serviceAccountAnnotation]; ok {
+			return prtb, nil
+		}
+		copied := prtb.DeepCopy()
+		if copied.Annotations == nil {
+			copied.Annotations = make(map[string]string)
+		}
+		copied.Annotations[serviceAccountAnnotation] = copied.ServiceAccount
+		upd, err := c.prtbClient.Update(copied)
+		if err != nil {
+			return nil, err
+		}
+		return upd, nil
+	}
+	return prtb, nil
+}

--- a/pkg/controllers/management/auth/prtb_sa_controller_test.go
+++ b/pkg/controllers/management/auth/prtb_sa_controller_test.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/wrangler/pkg/generic/fake"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPRTBControllerFindsObjectsWithServiceAccountFieldAndSavesItAsAnnotation(t *testing.T) {
+	t.Parallel()
+	req := require.New(t)
+
+	cache := []v3.ProjectRoleTemplateBinding{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "sa-prtb",
+			},
+			ProjectName:      "rke:p1",
+			RoleTemplateName: "project-member",
+			ServiceAccount:   "p1:default",
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "sa-prtb-processed",
+				Annotations: map[string]string{
+					"management.cattle.io/serviceAccount": "p1:sa1",
+				},
+			},
+			ProjectName:      "rke:p1",
+			RoleTemplateName: "project-member",
+			ServiceAccount:   "p1:sa1",
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "user-prtb",
+			},
+			ProjectName:      "rke:p1",
+			RoleTemplateName: "project-member",
+			UserName:         "user1",
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "group-prtb",
+			},
+			ProjectName:      "rke:p1",
+			RoleTemplateName: "project-member",
+			GroupName:        "group1",
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	client := fake.NewMockClientInterface[*v3.ProjectRoleTemplateBinding, *v3.ProjectRoleTemplateBindingList](ctrl)
+	client.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *v3.ProjectRoleTemplateBinding) (*v3.ProjectRoleTemplateBinding, error) {
+		for i := range cache {
+			if cache[i].Name == obj.Name {
+				cache[i] = *obj
+				break
+			}
+		}
+		return obj, nil
+	}).Times(1) // Only one object must be updated.
+
+	controller := prtbServiceAccountController{
+		prtbClient: client,
+	}
+	for _, prtb := range cache {
+		upd, err := controller.sync("", &prtb)
+		req.NoError(err)
+		req.NotNil(upd)
+	}
+
+	req.Len(cache, 4)
+	req.Equal(map[string]string{"management.cattle.io/serviceAccount": "p1:default"}, cache[0].Annotations)
+	req.Equal(map[string]string{"management.cattle.io/serviceAccount": "p1:sa1"}, cache[1].Annotations)
+	req.Nil(cache[2].Annotations)
+	req.Nil(cache[3].Annotations)
+}

--- a/pkg/controllers/management/auth/register.go
+++ b/pkg/controllers/management/auth/register.go
@@ -67,6 +67,7 @@ func RegisterEarly(ctx context.Context, management *config.ManagementContext, cl
 	rt := newRoleTemplateLifecycle(management, clusterManager)
 	grbLegacy := newLegacyGRBCleaner(management)
 	rtLegacy := newLegacyRTCleaner(management)
+	prtbServiceAccountFinder := newPRTBServiceAccountController(management)
 
 	management.Management.ClusterRoleTemplateBindings("").AddLifecycle(ctx, ctrbMGMTController, crtb)
 	management.Management.ProjectRoleTemplateBindings("").AddLifecycle(ctx, ptrbMGMTController, prtb)
@@ -75,6 +76,7 @@ func RegisterEarly(ctx context.Context, management *config.ManagementContext, cl
 
 	management.Management.Clusters("").AddHandler(ctx, clusterCreateController, c.sync)
 	management.Management.Projects("").AddHandler(ctx, projectCreateController, p.sync)
+	management.Management.ProjectRoleTemplateBindings("").AddHandler(ctx, prtbServiceAccountControllerName, prtbServiceAccountFinder.sync)
 	management.Management.Tokens("").AddHandler(ctx, tokenController, n.sync)
 	management.Management.AuthConfigs("").AddHandler(ctx, authConfigControllerName, ac.sync)
 	management.Management.UserAttributes("").AddHandler(ctx, userAttributeController, ua.sync)

--- a/pkg/controllers/management/authprovisioningv2/prtb.go
+++ b/pkg/controllers/management/authprovisioningv2/prtb.go
@@ -19,7 +19,7 @@ import (
 const PRTBRoleBindingID = "auth-prov-v2-prtb-rolebinding"
 
 func (h *handler) OnPRTB(key string, prtb *v3.ProjectRoleTemplateBinding) (*v3.ProjectRoleTemplateBinding, error) {
-	if prtb == nil || prtb.DeletionTimestamp != nil || prtb.RoleTemplateName == "" || prtb.ProjectName == "" {
+	if prtb == nil || prtb.DeletionTimestamp != nil || prtb.RoleTemplateName == "" || prtb.ProjectName == "" || prtb.ServiceAccount != "" {
 		return prtb, nil
 	}
 

--- a/pkg/controllers/managementuser/rbac/namespace_handler.go
+++ b/pkg/controllers/managementuser/rbac/namespace_handler.go
@@ -227,7 +227,7 @@ func (n *nsLifecycle) ensurePRTBAddToNamespace(ns *v1.Namespace) (bool, error) {
 			return false, errors.Wrapf(err, "object %v is not valid project role template binding", prtb)
 		}
 
-		if prtb.UserName == "" && prtb.GroupPrincipalName == "" && prtb.GroupName == "" && prtb.ServiceAccount == "" {
+		if prtb.UserName == "" && prtb.GroupPrincipalName == "" && prtb.GroupName == "" {
 			continue
 		}
 

--- a/pkg/controllers/managementuser/rbac/prtb_handler.go
+++ b/pkg/controllers/managementuser/rbac/prtb_handler.go
@@ -86,7 +86,7 @@ func (p *prtbLifecycle) syncPRTB(binding *v3.ProjectRoleTemplateBinding) error {
 		logrus.Warnf("ProjectRoleTemplateBinding %v has no role template set. Skipping.", binding.Name)
 		return nil
 	}
-	if binding.UserName == "" && binding.GroupPrincipalName == "" && binding.GroupName == "" && binding.ServiceAccount == "" {
+	if binding.UserName == "" && binding.GroupPrincipalName == "" && binding.GroupName == "" {
 		return nil
 	}
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
The ServiceAccount field on PRTB is only needed for legacy monitoring v1 and serves no other purpose. We intend to fully remove it from the type in a later version.
 
## Solution
1. Add a controller that gets all PRTBs that have the serviceAccount field set and copy the value to an annotation that can be used for cleanup when the field is eventually deleted.
2. Document the PRTB.serviceAccount as deprecated in the CRD def.
3. Remove the Current PRTB controller behavior that acts on the deprecated field.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_