### PR TITLE
Update Registry Automation 

### DIFF
--- a/tests/framework/extensions/nodes/node_status.go
+++ b/tests/framework/extensions/nodes/node_status.go
@@ -82,7 +82,7 @@ func AllMachineReady(client *rancher.Client, clusterID string) error {
 				return false, nil
 			}
 		}
-		logrus.Infof("All nodes in the cluster are in an active state!")
+		logrus.Infof("All nodes in the cluster are running!")
 		return true, nil
 	})
 	return err

--- a/tests/framework/extensions/provisioning/creates.go
+++ b/tests/framework/extensions/provisioning/creates.go
@@ -76,8 +76,9 @@ func CreateProvisioningCluster(client *rancher.Client, provider Provider, cluste
 				if err != nil {
 					return nil, err
 				}
-				for _, registry := range clustersConfig.Registries.RKE2Registries.Configs {
+				for registryName, registry := range clustersConfig.Registries.RKE2Registries.Configs {
 					registry.AuthConfigSecretName = registrySecret.Name
+					clustersConfig.Registries.RKE2Registries.Configs[registryName] = registry
 				}
 			}
 		}

--- a/tests/framework/extensions/registries/registries.go
+++ b/tests/framework/extensions/registries/registries.go
@@ -33,10 +33,11 @@ func CheckAllClusterPodsForRegistryPrefix(client *rancher.Client, clusterID, reg
 			return false, err
 		}
 		for _, container := range podSpec.Containers {
-			log.Infoln(container.Image)
 			if !strings.Contains(container.Image, registryPrefix) {
+				log.Warnf("pod/containerImage %s/%s is not using the correct registry prefix", pod.Name, container.Image)
 				return false, nil
 			}
+			log.Infoln(container.Image)
 		}
 	}
 	return true, nil


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/qa-tasks/issues/888

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Registries were broken as part of the last refactor 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
updated k3s/rke2 registry logic in automation in order to match what is expected. mostly were missing some initial parameters. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
tested more extensively locally. There may be some flakiness in checking registry container images, specifically saw some inconsistency in rke2. 
ecr was not able to be successful, but as you can see the code is the same as it was before the refactor. Izaac said this could be due to dependencies in the ami itself, not necessarily the code. 
