### PR TITLE
Allow definition of nodePort port

### DIFF
--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -20,6 +20,9 @@ spec:
     targetPort: 80
     protocol: TCP
     name: http
+    {{- if .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
   - port: 443
     targetPort: 444
     protocol: TCP

--- a/chart/tests/service_test.yaml
+++ b/chart/tests/service_test.yaml
@@ -20,6 +20,13 @@ tests:
   asserts:
   - isNull:
       path: spec.type
+- it : should set NodePort port
+  set:
+    service.nodePort: 30000
+  asserts:
+  - equal:
+      path: spec.ports[0].nodePort
+      value: 30000
 - it: should set provided service annotation correctly
   set:
     service.annotations:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -76,6 +76,8 @@ ingress:
 # Override to use NodePort or LoadBalancer service type - default is ClusterIP
 service:
   type: ""
+  # If type=nodePort, optionally define a port to expose
+  nodePort: ""
   annotations: {}
 
 ### LetsEncrypt config ###


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Update chart to allow definition of nodePort port in the rancher service
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Currently it is possible to configure the rancher service as type=nodePort, but you can't define the port to expose
 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
