### PR TITLE
Add mechanism for adding extension catalog image to rancher-images.txt

### DIFF
--- a/pkg/image/extensions.go
+++ b/pkg/image/extensions.go
@@ -1,0 +1,94 @@
+package image
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+type Extensions struct {
+	Config         ExportConfig
+	GithubEndpoint GithubEndpoint
+}
+
+type Release struct {
+	TagName string `json:"tag_name"`
+}
+
+type GithubEndpoint struct {
+	URL string
+}
+
+var ExtensionEndpoints = []GithubEndpoint{
+	{URL: "https://api.github.com/repos/rancher/ui-plugin-charts/releases"},
+}
+
+func ExtensionConfig(endpointIndex int) Extensions {
+	if endpointIndex >= len(ExtensionEndpoints) {
+		endpointIndex = 0
+	}
+
+	return Extensions{
+		Config:         ExportConfig{},
+		GithubEndpoint: ExtensionEndpoints[endpointIndex],
+	}
+}
+
+func (e Extensions) FetchExtensionImages(imagesSet map[string]map[string]struct{}) error {
+	// Fetch latest releases from GitHub API
+	latestReleases, err := getLatestReleases(e.GithubEndpoint)
+	if err != nil {
+		return err
+	}
+
+	// Find the latest non-RC release
+	latestReleaseTag := findLatestReleaseTag(latestReleases)
+
+	if latestReleaseTag == "" {
+		return fmt.Errorf("no suitable release found for ui-plugin-charts")
+	}
+
+	image := "rancher/ui-plugin-catalog:" + latestReleaseTag
+	addSourceToImage(imagesSet, image, "ui-extension")
+
+	return nil
+}
+
+func getLatestReleases(githubURL GithubEndpoint) ([]Release, error) {
+	// Get the releases from GitHub API
+	resp, err := http.Get(githubURL.URL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var releases []Release
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&releases); err != nil {
+		return nil, err
+	}
+
+	return releases, nil
+}
+
+func findLatestReleaseTag(releases []Release) string {
+	var latestReleaseTag string
+	latestVersion := semver.MustParse("0.0.0")
+
+	for _, release := range releases {
+		// Exclude release candidates (e.g., "1.0.0-rc1")
+		if !strings.Contains(release.TagName, "-rc") {
+			version, err := semver.NewVersion(release.TagName)
+
+			if err == nil && version.GreaterThan(latestVersion) {
+				latestVersion = version
+				latestReleaseTag = release.TagName
+			}
+		}
+	}
+
+	return latestReleaseTag
+}

--- a/pkg/image/extensions.go
+++ b/pkg/image/extensions.go
@@ -9,9 +9,8 @@ import (
 	"github.com/Masterminds/semver/v3"
 )
 
-type Extensions struct {
-	Config         ExportConfig
-	GithubEndpoint GithubEndpoint
+type ExtensionsConfig struct {
+	GithubEndpoints []GithubEndpoint
 }
 
 type Release struct {
@@ -26,35 +25,49 @@ var ExtensionEndpoints = []GithubEndpoint{
 	{URL: "https://api.github.com/repos/rancher/ui-plugin-charts/releases"},
 }
 
-func ExtensionConfig(endpointIndex int) Extensions {
-	if endpointIndex >= len(ExtensionEndpoints) {
-		endpointIndex = 0
+func (e ExtensionsConfig) FetchExtensionImages(imagesSet map[string]map[string]struct{}) error {
+	for _, endpoint := range e.GithubEndpoints {
+		// Parse the repository name from the URL
+		repoName, err := parseRepoName(endpoint.URL)
+		if err != nil {
+			return err
+		}
+
+		// Fetch latest releases from GitHub API for the current endpoint
+		latestReleases, err := getLatestReleases(endpoint)
+		if err != nil {
+			return err
+		}
+
+		// Find the latest non-RC release
+		latestReleaseTag := findLatestReleaseTag(latestReleases)
+
+		if latestReleaseTag == "" {
+			return fmt.Errorf("no suitable release found for endpoint: %s", endpoint.URL)
+		}
+
+		// Construct the image name based on the repository name and latestReleaseTag
+		var image string
+		if repoName == "rancher/ui-plugin-charts" {
+			image = "rancher/ui-plugin-catalog:" + latestReleaseTag
+		} else {
+			image = repoName + ":" + latestReleaseTag
+		}
+		addSourceToImage(imagesSet, image, "ui-extension")
 	}
-
-	return Extensions{
-		Config:         ExportConfig{},
-		GithubEndpoint: ExtensionEndpoints[endpointIndex],
-	}
-}
-
-func (e Extensions) FetchExtensionImages(imagesSet map[string]map[string]struct{}) error {
-	// Fetch latest releases from GitHub API
-	latestReleases, err := getLatestReleases(e.GithubEndpoint)
-	if err != nil {
-		return err
-	}
-
-	// Find the latest non-RC release
-	latestReleaseTag := findLatestReleaseTag(latestReleases)
-
-	if latestReleaseTag == "" {
-		return fmt.Errorf("no suitable release found for ui-plugin-charts")
-	}
-
-	image := "rancher/ui-plugin-catalog:" + latestReleaseTag
-	addSourceToImage(imagesSet, image, "ui-extension")
 
 	return nil
+}
+
+// Helper function to parse the repository name from the GitHub API URL
+var parseRepoName = func(url string) (string, error) {
+	parts := strings.Split(url, "/")
+
+	if len(parts) < 6 || parts[0] != "https:" || parts[2] != "api.github.com" || parts[3] != "repos" {
+		return "", fmt.Errorf("invalid GitHub API URL format: %s", url)
+	}
+
+	return parts[4] + "/" + parts[5], nil
 }
 
 func getLatestReleases(githubURL GithubEndpoint) ([]Release, error) {

--- a/pkg/image/extensions_test.go
+++ b/pkg/image/extensions_test.go
@@ -9,6 +9,56 @@ import (
 	assertlib "github.com/stretchr/testify/assert"
 )
 
+func setupTestServer() *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		releases := []Release{
+			{TagName: "1.0.0"},
+			{TagName: "1.1.0"},
+			{TagName: "1.1.0-rc1"},
+			{TagName: "2.0.0-rc2"},
+			{TagName: "1.1.1"},
+			{TagName: "2.0.0"},
+		}
+		_ = json.NewEncoder(rw).Encode(releases)
+	}))
+
+	return server
+}
+
+func TestParseRepoName(t *testing.T) {
+	assert := assertlib.New(t)
+
+	// Test with a valid GitHub API URL
+	validURL := "https://api.github.com/repos/some-user/some-repo/releases"
+	repoName, err := parseRepoName(validURL)
+	assert.NoError(err)
+	assert.Equal("some-user/some-repo", repoName)
+
+	// Test with an invalid GitHub API URL
+	invalidURL := "https://example.com/invalid/url"
+	_, err = parseRepoName(invalidURL)
+	assert.Error(err)
+	assert.Contains(err.Error(), "invalid GitHub API URL format")
+}
+
+func TestGetLatestReleases(t *testing.T) {
+	server := setupTestServer()
+	defer server.Close()
+
+	assert := assertlib.New(t)
+
+	endpoint := GithubEndpoint{URL: server.URL}
+	releases, err := getLatestReleases(endpoint)
+	assert.NoError(err)
+	assert.Len(releases, 6)
+	assert.Equal("1.0.0", releases[0].TagName)
+	assert.Equal("1.1.0", releases[1].TagName)
+	assert.Equal("1.1.0-rc1", releases[2].TagName)
+	assert.Equal("2.0.0-rc2", releases[3].TagName)
+	assert.Equal("1.1.1", releases[4].TagName)
+	assert.Equal("2.0.0", releases[5].TagName)
+}
+
 func TestFindLatestReleaseTag(t *testing.T) {
 	releases := []Release{
 		{TagName: "1.0.0"},
@@ -23,71 +73,60 @@ func TestFindLatestReleaseTag(t *testing.T) {
 	assert.Equal("1.1.0", tag)
 }
 
-func TestGetLatestReleases(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		releases := []Release{
-			{TagName: "1.0.0"},
-			{TagName: "1.1.0"},
-		}
-		_ = json.NewEncoder(rw).Encode(releases)
-	}))
+func TestFetchExtensionImages(t *testing.T) {
+	server := setupTestServer()
 	defer server.Close()
 
-	assert := assertlib.New(t)
+	endpoints := []GithubEndpoint{{URL: server.URL}}
+	extensions := ExtensionsConfig{GithubEndpoints: endpoints}
 
-	endpoint := GithubEndpoint{URL: server.URL}
-	releases, err := getLatestReleases(endpoint)
-	assert.NoError(err)
-	assert.Len(releases, 2)
-	assert.Equal("1.0.0", releases[0].TagName)
-	assert.Equal("1.1.0", releases[1].TagName)
-}
+	imagesSet := map[string]map[string]struct{}{}
 
-func TestFetchExtensionImages(t *testing.T) {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		releases := []Release{
-			{TagName: "1.0.0"},
-			{TagName: "1.1.0"},
-		}
-		_ = json.NewEncoder(rw).Encode(releases)
-	}))
-	defer mockServer.Close()
-
-	endpoint := GithubEndpoint{URL: mockServer.URL}
-	extensions := Extensions{GithubEndpoint: endpoint}
-
-	imagesSet := map[string]map[string]struct{}{
-		"rancher/ui-plugin-catalog:1.1.0": {"ui-extension": {}},
+	// Mock the parseRepoName function to return the expected repoName
+	originalParseRepoName := parseRepoName
+	parseRepoName = func(url string) (string, error) {
+		return "some-org/some-repo", nil
 	}
+	defer func() {
+		parseRepoName = originalParseRepoName
+	}()
 
 	assert := assertlib.New(t)
 
 	err := extensions.FetchExtensionImages(imagesSet)
 	assert.NoError(err)
 
-	imageKey := "rancher/ui-plugin-catalog:1.1.0"
+	imageKey := "some-org/some-repo:2.0.0"
 	assert.Contains(imagesSet, imageKey)
 	assert.Contains(imagesSet[imageKey], "ui-extension")
 }
 
 func TestFetchExtensionImages_NoSuitableRelease(t *testing.T) {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		releases := []Release{
 			{TagName: "1.0.0-rc1"},
 			{TagName: "1.1.0-rc1"},
 		}
 		_ = json.NewEncoder(rw).Encode(releases)
 	}))
-	defer mockServer.Close()
+	defer server.Close()
 
-	endpoint := GithubEndpoint{URL: mockServer.URL}
-	extensions := Extensions{GithubEndpoint: endpoint}
+	endpoints := []GithubEndpoint{{URL: server.URL}}
+	extensions := ExtensionsConfig{GithubEndpoints: endpoints}
 
 	imagesSet := map[string]map[string]struct{}{}
+
+	originalParseRepoName := parseRepoName
+	parseRepoName = func(url string) (string, error) {
+		return "some-org/some-repo", nil
+	}
+	defer func() {
+		parseRepoName = originalParseRepoName
+	}()
 
 	assert := assertlib.New(t)
 
 	err := extensions.FetchExtensionImages(imagesSet)
 	assert.Error(err)
-	assert.EqualError(err, "no suitable release found for ui-plugin-charts")
+	assert.EqualError(err, "no suitable release found for endpoint: "+server.URL)
 }

--- a/pkg/image/extensions_test.go
+++ b/pkg/image/extensions_test.go
@@ -1,0 +1,93 @@
+package image
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	assertlib "github.com/stretchr/testify/assert"
+)
+
+func TestFindLatestReleaseTag(t *testing.T) {
+	releases := []Release{
+		{TagName: "1.0.0"},
+		{TagName: "1.2.0-rc1"},
+		{TagName: "1.1.0"},
+		{TagName: "2.0.0-rc2"},
+	}
+
+	assert := assertlib.New(t)
+
+	tag := findLatestReleaseTag(releases)
+	assert.Equal("1.1.0", tag)
+}
+
+func TestGetLatestReleases(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		releases := []Release{
+			{TagName: "1.0.0"},
+			{TagName: "1.1.0"},
+		}
+		_ = json.NewEncoder(rw).Encode(releases)
+	}))
+	defer server.Close()
+
+	assert := assertlib.New(t)
+
+	endpoint := GithubEndpoint{URL: server.URL}
+	releases, err := getLatestReleases(endpoint)
+	assert.NoError(err)
+	assert.Len(releases, 2)
+	assert.Equal("1.0.0", releases[0].TagName)
+	assert.Equal("1.1.0", releases[1].TagName)
+}
+
+func TestFetchExtensionImages(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		releases := []Release{
+			{TagName: "1.0.0"},
+			{TagName: "1.1.0"},
+		}
+		_ = json.NewEncoder(rw).Encode(releases)
+	}))
+	defer mockServer.Close()
+
+	endpoint := GithubEndpoint{URL: mockServer.URL}
+	extensions := Extensions{GithubEndpoint: endpoint}
+
+	imagesSet := map[string]map[string]struct{}{
+		"rancher/ui-plugin-catalog:1.1.0": {"ui-extension": {}},
+	}
+
+	assert := assertlib.New(t)
+
+	err := extensions.FetchExtensionImages(imagesSet)
+	assert.NoError(err)
+
+	imageKey := "rancher/ui-plugin-catalog:1.1.0"
+	assert.Contains(imagesSet, imageKey)
+	assert.Contains(imagesSet[imageKey], "ui-extension")
+}
+
+func TestFetchExtensionImages_NoSuitableRelease(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		releases := []Release{
+			{TagName: "1.0.0-rc1"},
+			{TagName: "1.1.0-rc1"},
+		}
+		_ = json.NewEncoder(rw).Encode(releases)
+	}))
+	defer mockServer.Close()
+
+	endpoint := GithubEndpoint{URL: mockServer.URL}
+	extensions := Extensions{GithubEndpoint: endpoint}
+
+	imagesSet := map[string]map[string]struct{}{}
+
+	assert := assertlib.New(t)
+
+	err := extensions.FetchExtensionImages(imagesSet)
+	assert.Error(err)
+	assert.EqualError(err, "no suitable release found for ui-plugin-charts")
+}

--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -238,6 +238,7 @@ var OriginMap = map[string]string{
 	"tekton-utils":                                            "https://github.com/rancher/build-tekton",
 	"thanosio-thanos":                                         "https://github.com/thanos-io/thanos",
 	"ui-plugin-operator":                                      "https://github.com/rancher/ui-plugin-operator",
+	"ui-plugin-catalog":                                       "https://github.com/rancher/ui-plugin-charts",
 	"weave-kube":                                              "https://github.com/weaveworks-experiments/weave-kube",
 	"weave-npc":                                               "https://github.com/weaveworks/weave",
 	"webhook-receiver":                                        "https://github.com/rancher/webhook-receiver",

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -79,6 +79,12 @@ func GetImages(exportConfig ExportConfig, externalImages map[string][]string, im
 		return nil, nil, errors.Wrap(err, "failed to fetch images from system")
 	}
 
+	// fetch images from extension catalog images
+	extensions := ExtensionConfig(0)
+	if err := extensions.FetchExtensionImages(imagesSet); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to fetch images from extensions")
+	}
+
 	setRequirementImages(exportConfig.OsType, imagesSet)
 
 	// set rancher images from args

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -80,7 +80,9 @@ func GetImages(exportConfig ExportConfig, externalImages map[string][]string, im
 	}
 
 	// fetch images from extension catalog images
-	extensions := ExtensionConfig(0)
+	extensions := ExtensionsConfig{
+		GithubEndpoints: ExtensionEndpoints,
+	}
 	if err := extensions.FetchExtensionImages(imagesSet); err != nil {
 		return nil, nil, errors.Wrap(err, "failed to fetch images from extensions")
 	}


### PR DESCRIPTION
## Issue: #42092 <!-- link the issue or issues this PR resolves here -->
`SURE-6065`

***Note***
`ui-plugin-catalog` image can be found on [Docker Hub](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags)

<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
In order for a user to add any of the UI extensions into an air-gapped instance of Rancher, they will need to manually mirror the image from the [ui-plugin-charts repository](https://github.com/rancher/ui-plugin-charts) into an accessible registry.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This adds a mechanism to the `image` package to fetch the latest release from the ui-plugin-charts repo and add the catalog image to the `rancher-images.txt` as well as the `rancher-images-sources.txt` and `rancher-images-origins.txt` files. This mechanism has the ability to add more images to the extension catalog list which may include images from the [partner-extensions repo](https://github.com/rancher/partner-extensions) in the future.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Follow the steps in the [wiki](https://github.com/rancher/rancher/wiki/Generating-Image-Lists-Locally-for-Airgap-and-More) for generating the image lists locally.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
I ran the script mentioned above to test that the image was correctly fetched and applied to the relevant files.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 Ensure that the image is correctly formatted and that it does not interfere with other images.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_