### PR TITLE
update nutanix node driver to v3.4.0

### DIFF
--- a/pkg/data/management/machinedriver_data.go
+++ b/pkg/data/management/machinedriver_data.go
@@ -134,7 +134,7 @@ func addMachineDrivers(management *config.ManagementContext) error {
 	if err := addMachineDriver(SoftLayerDriver, "local://", "", "", nil, false, true, false, management); err != nil {
 		return err
 	}
-	if err := addMachineDriver(NutanixDriver, "https://github.com/nutanix/docker-machine/releases/download/v3.3.0/docker-machine-driver-nutanix_v3.3.0_linux", "https://nutanix.github.io/rancher-ui-driver/v3.3.0/component.js", "036182e3d0d6807c9763f737ebf79a6e2367e39d777d09c9ef8adc9d58779b9d", []string{"nutanix.github.io"}, false, false, false, management); err != nil {
+	if err := addMachineDriver(NutanixDriver, "https://github.com/nutanix/docker-machine/releases/download/v3.4.0/docker-machine-driver-nutanix", "https://nutanix.github.io/rancher-ui-driver/v3.4.0/component.js", "65dbf92e2df2b4c6d1a6b1f77c542f2cb13a052a62f236eeee697a1151ede62c", []string{"nutanix.github.io"}, false, false, false, management); err != nil {
 		return err
 	}
 	if err := addMachineDriver(OutscaleDriver, "https://github.com/outscale/docker-machine-driver-outscale/releases/download/v0.2.0/docker-machine-driver-outscale_0.2.0_linux_amd64.zip", "https://oos.eu-west-2.outscale.com/rancher-ui-driver-outscale/v0.2.0/component.js", "bb539ed4e2b0f1a1083b29cbdbab59bde3efed0a3145fefc0b2f47026c48bfe0", []string{"oos.eu-west-2.outscale.com"}, false, false, false, management); err != nil {


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/42576

Update Nutanix Rancher Node Driver to v3.4.0


## Testing

manual installation of the node driver and cluster deployment with it

![image](https://github.com/rancher/rancher/assets/180613/17ee8898-78be-44e6-8fb0-97aedee79fb8)

Driver is activated

![image](https://github.com/rancher/rancher/assets/180613/8bf8eb46-70fd-4374-84ee-7dd4c3d4469e)

RKE2 install

![image](https://github.com/rancher/rancher/assets/180613/33257932-f005-4cc5-9bba-df28efb70b48)

RKE1 install

![image](https://github.com/rancher/rancher/assets/180613/62417c17-3a17-4b49-9edb-d82c80a11f24)
