### PR TITLE
Update the readme with some useful information

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,5 +1,11 @@
 # Integration Tests
 
+## Dependencies
+
+---
+
+Instructions for installing dependencies can be found in the [wiki](https://github.com/rancher/rancher/wiki/Setting-Up-Rancher-2.0-Development-Environment#setting-up-and-running-the-tests).
+
 ## CI
 
 ---
@@ -20,14 +26,16 @@ pip install tox
 
 ---
 
-Start a local rancher instance on port 8443
+*The tests require python 3.7. Some other versions may work, but are not guaranteed to be supported.*
 
-Run with Tox - from tests/integration dir. See tox.ini for configuration
+Start a local rancher instance on port 8443. If the password is not set to `admin`, set the environment variable `RANCHER_SERVER_PASSWORD` to the appropriate password.
+
+Run with [Tox](https://tox.wiki/en/4.11.0/) - from tests/integration dir. See [tox.ini](./tox.ini) for configuration
 
 * the entire suite: `tox` (from tests/integration)
 * a single file with tox: `tox -- -x suite/test_users.py` (from tests/integration)
 
-Run with pytest
+Run with [pytest](https://docs.pytest.org/en/7.4.x/)
 
 * a single test: `pytest -k test_user_cant_delete_self`
 * a file: `pytest tests/integration/suite/test_auth_proxy.py`


### PR DESCRIPTION
## Issue: 

## Problem
While attempting to use the integration tests locally, I found the README to be lacking important information.
 
## Solution
Some of the information I needed was in the wiki, so I added a reference to that. I also added a couple notes that I think are important to have up front, such as setting the password and using the correct version of python.
 
## Testing
None needed as this is just documentation