### PR TITLE
[Backport v2.7] Check cluster RancherKubernetesEngineConfig field != nil before migra…

### DIFF
--- a/pkg/controllers/management/secretmigrator/clusters.go
+++ b/pkg/controllers/management/secretmigrator/clusters.go
@@ -645,7 +645,8 @@ func cleanQuestions(cluster *apimgmtv3.Cluster) {
 			}
 			delete(answers.Values, key)
 		}
-		if cluster.Spec.RancherKubernetesEngineConfig.CloudProvider.VsphereCloudProvider != nil {
+		if cluster.Spec.RancherKubernetesEngineConfig != nil &&
+			cluster.Spec.RancherKubernetesEngineConfig.CloudProvider.VsphereCloudProvider != nil {
 			vcenters := cluster.Spec.RancherKubernetesEngineConfig.CloudProvider.VsphereCloudProvider.VirtualCenter
 			for k := range vcenters {
 				key := fmt.Sprintf(VcenterAnswersPath, k)


### PR DESCRIPTION
…ting vcenter related secrets

## Issue: https://github.com/rancher/rancher/issues/42592 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
just backporting the change from v2.8, parent PR here: https://github.com/rancher/rancher/pull/42355