### PR TITLE
Bump skopeo to v1.13.2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1664,7 +1664,7 @@ platform:
 
 steps:
 - name: docker-image-promote
-  image: quay.io/skopeo/stable:v1.1.1
+  image: quay.io/skopeo/stable:v1.13.2
   commands:
   - echo $${DOCKER_PASSWORD} | skopeo login docker.io --username $${DOCKER_USERNAME} --password-stdin
   - skopeo copy docker://rancher/rancher:$${SOURCE_TAG} docker://rancher/rancher:$${DESTINATION_TAG} --all


### PR DESCRIPTION
Fix drone error while running `docker-image-promote`:
https://drone-publish.rancher.io/rancher/rancher/10463/2/2 

```
Error response from daemon: unknown: Tag v1.1.1 was deleted or has expired. To pull, revive via time machine
``` 

