### PR TITLE
Updated Jenkinsfiles to default to release/2.8

### DIFF
--- a/tests/scripts/custodian/Jenkinsfile
+++ b/tests/scripts/custodian/Jenkinsfile
@@ -17,7 +17,7 @@ node {
   if ("${env.CUSTODIAN_YAML}" != "null" && "${env.CUSTODIAN_YAML}" != "") {
     yamlToRun="${env.CUSTODIAN_YAML}"
   }
-  def branch = "release/v2.7"
+  def branch = "release/v2.8"
   if ("${env.branch}" != "null" && "${env.branch}" != "") {
     branch = "${env.branch}"
   }

--- a/tests/v2/codecoverage/Jenkinsfile_buildcodecoverage
+++ b/tests/v2/codecoverage/Jenkinsfile_buildcodecoverage
@@ -11,7 +11,7 @@ node {
   def buildDockerContainer = "build-code-cover-docker-container"
   def envFile = ".env"
   def rancherConfig = "rancher_env.config"
-  def branch = "release/v2.7"
+  def branch = "release/v2.8"
   def coverfile = "cover.out"
   if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
     branch = "${env.BRANCH}"

--- a/tests/v2/codecoverage/Jenkinsfile_codecoverage
+++ b/tests/v2/codecoverage/Jenkinsfile_codecoverage
@@ -21,7 +21,7 @@ node {
     def codeCoverageDir = "github.com/rancher/rancher/tests/v2/codecoverage/ranchercover"
     def codeCoverageTest = "-run TestRetrieveCoverageReports"
     def rancherConfig = "rancher_env.config"
-    def branch = "release/v2.7"
+    def branch = "release/v2.8"
     def defaultBranch = branch
     def unitTestCoverfile = "unittestcover.out"
     def unitTestHTMLfile = "coverage.html"

--- a/tests/v2/validation/Jenkinsfile
+++ b/tests/v2/validation/Jenkinsfile
@@ -12,7 +12,7 @@ node {
     def testResultsOut = "results.xml"
     def envFile = ".env"
     def rancherConfig = "rancher_env.config"
-    def branch = "release/v2.7"
+    def branch = "release/v2.8"
     if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
       branch = "${env.BRANCH}"
     }

--- a/tests/v2/validation/Jenkinsfile.e2e
+++ b/tests/v2/validation/Jenkinsfile.e2e
@@ -16,7 +16,7 @@ node {
     def testResultsOut = "results.xml"
     def envFile = ".env"
     def rancherConfig = "rancher_env.config"
-    def branch = "release/v2.7"
+    def branch = "release/v2.8"
     def corralBranch = "main"
     def cleanup = env.RANCHER_CLEANUP.toLowerCase()
     if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {

--- a/tests/v2/validation/Jenkinsfile_pre_post_upgrade
+++ b/tests/v2/validation/Jenkinsfile_pre_post_upgrade
@@ -13,7 +13,7 @@ node {
     def testResultsOut = "results.xml"
     def envFile = ".env"
     def rancherConfig = "rancher_env.config"
-    def branch = "release/v2.6"
+    def branch = "release/v2.8"
     if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
       branch = "${env.BRANCH}"
     }

--- a/tests/v2/validation/Jenkinsfile_vpn
+++ b/tests/v2/validation/Jenkinsfile_vpn
@@ -12,7 +12,7 @@ node {
     def testResultsOut = "results.xml"
     def envFile = ".env"
     def rancherConfig = "rancher_env.config"
-    def branch = "release/v2.6"
+    def branch = "release/v2.8"
     if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
       branch = "${env.BRANCH}"
     }

--- a/tests/v2/validation/pipeline/Jenkinsfile_release_upgrade
+++ b/tests/v2/validation/pipeline/Jenkinsfile_release_upgrade
@@ -27,7 +27,7 @@ node {
     def testResultsOut = "results.xml"
     def envFile = ".env"
     def rancherConfig = "rancher_env.config"
-    def branch = "release/v2.7"
+    def branch = "release/v2.8"
     if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
       branch = "${env.BRANCH}"
     }

--- a/tests/validation/tests/v3_api/Jenkinsfile
+++ b/tests/validation/tests/v3_api/Jenkinsfile
@@ -16,7 +16,7 @@ node {
   def imageName = "rancher-validation-${job_name}${env.BUILD_NUMBER}"
   def testsDir = "tests/v3_api/"
 
-  def branch = "release/v2.6"
+  def branch = "release/v2.8"
   if ("${env.branch}" != "null" && "${env.branch}" != "") {
     branch = "${env.branch}"
   }

--- a/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test
+++ b/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test
@@ -25,7 +25,7 @@ node {
   def envFile = ".env"
   def rancherConfig = "rancher_env.config"
 
-  def branch = "release/v2.6"
+  def branch = "release/v2.8"
   if ("${env.branch}" != "null" && "${env.branch}" != "") {
     branch = "${env.branch}"
   }

--- a/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_ontag
+++ b/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_ontag
@@ -39,7 +39,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
 } else {
   def branch = "v2.1"
   if (rancher_version.startsWith("v2.2") || rancher_version == "master" ) {
-    branch = "release/v2.6"
+    branch = "release/v2.8"
   }
   try {
     node {

--- a/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_support_matrix
+++ b/tests/validation/tests/v3_api/Jenkinsfile_deploy_and_test_support_matrix
@@ -26,7 +26,7 @@ node {
   def envFile = ".env"
   def rancherConfig = "rancher_env.config"
 
-  def branch = "release/v2.6"
+  def branch = "release/v2.8"
   if ("${env.branch}" != "null" && "${env.branch}" != "") {
     branch = "${env.branch}"
   }

--- a/tests/validation/tests/v3_api/Jenkinsfile_provisioning_tests
+++ b/tests/validation/tests/v3_api/Jenkinsfile_provisioning_tests
@@ -13,7 +13,7 @@ def imageName = "rancher-validation-${job_name}${env.BUILD_NUMBER}"
 def envFile = ".env"
 def RANCHER_DEPLOYED = false
 
-def branch = "release/v2.6"
+def branch = "release/v2.8"
 if ("${env.branch}" != "null" && "${env.branch}" != "") {
   branch = "${env.branch}"
 }

--- a/tests/validation/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
+++ b/tests/validation/tests/v3_api/Jenkinsfile_provisioning_tests_ontag
@@ -54,7 +54,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
 } else {
   def branch = "v2.1"
   if (rancher_version.startsWith("v2.2") || rancher_version == "master" ) {
-    branch = "release/v2.6"
+    branch = "release/v2.8"
   }
   node {
     wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {

--- a/tests/validation/tests/v3_api/Jenkinsfile_vpn
+++ b/tests/validation/tests/v3_api/Jenkinsfile_vpn
@@ -16,7 +16,7 @@ node {
   def imageName = "rancher-validation-${job_name}${env.BUILD_NUMBER}"
   def testsDir = "tests/v3_api/"
 
-  def branch = "release/v2.6"
+  def branch = "release/v2.8"
   if ("${env.branch}" != "null" && "${env.branch}" != "") {
     branch = "${env.branch}"
   }

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_custom_cluster_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_custom_cluster_matrix
@@ -24,7 +24,7 @@ node {
   def PYTEST_OPTIONS = "-k \"" + TESTS_TO_RUN.join(" or ") +"\""
 
   // set the branch for the testing code
-  def branch = "release/v2.6"
+  def branch = "release/v2.8"
   if ("${env.branch}" != "null" && "${env.branch}" != "") {
     branch = "${env.branch}"
   }

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_k3s_upgrade
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_k3s_upgrade
@@ -51,7 +51,7 @@ node {
   def envFile = ".env"
   def rancherConfig = "rancher_env.config"
 
-  def branch = "release/v2.6"
+  def branch = "release/v2.8"
   if ("${env.branch}" != "null" && "${env.branch}" != "") {
     branch = "${env.branch}"
   }

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_ontag_matrix
@@ -40,7 +40,7 @@ if ( true == via_webhook() && (!(rancher_version ==~ rancher_version_regex)) ) {
   currentBuild.result = lastBuildResult()
 } else {
   if (rancher_version.startsWith("v2.2") || rancher_version.startsWith("v2.3") || rancher_version == "master-head") {
-    branch = "release/v2.6"
+    branch = "release/v2.8"
   }
   if (env.BRANCH) {
     branch = "${BRANCH}"

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_provision_and_test
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_provision_and_test
@@ -27,7 +27,7 @@ node {
   def LINUX_PYTEST_OPTIONS = "-k \"" + TESTS_TO_RUN.join(" or ") +"\""
   def PYTEST_OPTIONS = LINUX_PYTEST_OPTIONS
 
-  def branch = "release/v2.6"
+  def branch = "release/v2.8"
   if ("${env.branch}" != "null" && "${env.branch}" != "") {
     branch = "${env.branch}"
   }

--- a/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_rke2_upgrade
+++ b/tests/validation/tests/v3_api/scripts/pipeline/Jenkinsfile_rke2_upgrade
@@ -54,7 +54,7 @@ node {
   def envFile = ".env"
   def rancherConfig = "rancher_env.config"
 
-  def branch = "release/v2.6"
+  def branch = "release/v2.8"
   if ("${env.branch}" != "null" && "${env.branch}" != "") {
     branch = "${env.branch}"
   }


### PR DESCRIPTION
## Issue: [#812](https://github.com/rancher/qa-tasks/issues/812)

 
## Problem
After creating a new default branch for release/2.8 we need our Jenkins test jobs to point to the new branch
 
## Solution
Modified the default in all Jenkinsfiles to release/2.8
 
