### PR TITLE
[2.7] Update EKS operator to v1.2.2-rc6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.5.1
 	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/aws/aws-sdk-go v1.44.308
+	github.com/aws/aws-sdk-go v1.44.322
 	github.com/bep/debounce v1.2.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/coreos/go-iptables v0.6.0
@@ -109,7 +109,7 @@ require (
 	github.com/rancher/apiserver v0.0.0-20230515173455-c3b182bdbf7d
 	github.com/rancher/channelserver v0.5.1-0.20230719220800-0a37b73c7df8
 	github.com/rancher/dynamiclistener v0.3.5
-	github.com/rancher/eks-operator v1.2.2-rc3
+	github.com/rancher/eks-operator v1.2.2-rc6
 	github.com/rancher/fleet/pkg/apis v0.0.0-20230821130910-23e1c146755a
 	github.com/rancher/gke-operator v1.1.6-rc2
 	github.com/rancher/kubernetes-provider-detector v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/auth0/go-jwt-middleware v1.0.1/go.mod h1:YSeUX3z6+TF2H+7padiEqNJ73Zy9
 github.com/aws/aws-sdk-go v1.35.24/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/aws/aws-sdk-go v1.38.49/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.43.28/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/aws-sdk-go v1.44.308 h1:XKu+76UHsD5LaiU2Zb1q42uWakw80Az7x39jJXXahos=
-github.com/aws/aws-sdk-go v1.44.308/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.44.322 h1:7JfwifGRGQMHd99PvfXqxBaZsjuRaOF6e3X9zRx2uYo=
+github.com/aws/aws-sdk-go v1.44.322/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
@@ -1186,8 +1186,8 @@ github.com/rancher/client-go v1.25.4-rancher1 h1:9MlBC8QbgngUkhNzMR8rZmmCIj6WNRH
 github.com/rancher/client-go v1.25.4-rancher1/go.mod h1:8trHCAC83XKY0wsBIpbirZU4NTUpbuhc2JnI7OruGZw=
 github.com/rancher/dynamiclistener v0.3.5 h1:5TaIHvkDGmZKvc96Huur16zfTKOiLhDtK4S+WV0JA6A=
 github.com/rancher/dynamiclistener v0.3.5/go.mod h1:dW/YF6/m2+uEyJ5VtEcd9THxda599HP6N9dSXk81+k0=
-github.com/rancher/eks-operator v1.2.2-rc3 h1:zzf4JNCXJHPmI82bVFbJvywz346vWL9FFaBSrvNOhPQ=
-github.com/rancher/eks-operator v1.2.2-rc3/go.mod h1:/wyszmtekvefdRRuBSe0XVZln5BnVrFIeBFrNHCPawo=
+github.com/rancher/eks-operator v1.2.2-rc6 h1:dGt/uOhABbnxMju95FVca0g63/Cl0PhgVY/8bjrHBnA=
+github.com/rancher/eks-operator v1.2.2-rc6/go.mod h1:30gJm9FbNBdzMX300ibhtlU72BgkjDuW1bX/u4FC0ns=
 github.com/rancher/fleet/pkg/apis v0.0.0-20230821130910-23e1c146755a h1:NfXE4/LpGiskJA61TE9Qmkar4IAoPVWWw9WuzsRfhpg=
 github.com/rancher/fleet/pkg/apis v0.0.0-20230821130910-23e1c146755a/go.mod h1:LAwUj8qIFnHtH6tj2bEkanIi5jkyzjFK3e3xYUfSY4s=
 github.com/rancher/gke-operator v1.1.6-rc2 h1:ENFi2Cj2t/EwI7m6wSiZ8xYZWS3TpU0owY47pH9raXw=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -9,7 +9,7 @@ replace k8s.io/client-go => github.com/rancher/client-go v1.25.4-rancher1
 
 require (
 	github.com/rancher/aks-operator v1.1.3-rc2
-	github.com/rancher/eks-operator v1.2.2-rc3
+	github.com/rancher/eks-operator v1.2.2-rc6
 	github.com/rancher/fleet/pkg/apis v0.0.0-20230821130910-23e1c146755a
 	github.com/rancher/gke-operator v1.1.6-rc2
 	github.com/rancher/norman v0.0.0-20230426211126-d3552b018687

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -487,8 +487,8 @@ github.com/rancher/aks-operator v1.1.3-rc2 h1:emrnm6oER3An1GfImuWPWdxvDJFScXpl4B
 github.com/rancher/aks-operator v1.1.3-rc2/go.mod h1:iEFU3CqbPMZ1JKVCX8B5t/EE8H77lSCeak26fUZYoNw=
 github.com/rancher/client-go v1.25.4-rancher1 h1:9MlBC8QbgngUkhNzMR8rZmmCIj6WNRHFOnYiwC2Kty4=
 github.com/rancher/client-go v1.25.4-rancher1/go.mod h1:8trHCAC83XKY0wsBIpbirZU4NTUpbuhc2JnI7OruGZw=
-github.com/rancher/eks-operator v1.2.2-rc3 h1:zzf4JNCXJHPmI82bVFbJvywz346vWL9FFaBSrvNOhPQ=
-github.com/rancher/eks-operator v1.2.2-rc3/go.mod h1:/wyszmtekvefdRRuBSe0XVZln5BnVrFIeBFrNHCPawo=
+github.com/rancher/eks-operator v1.2.2-rc6 h1:dGt/uOhABbnxMju95FVca0g63/Cl0PhgVY/8bjrHBnA=
+github.com/rancher/eks-operator v1.2.2-rc6/go.mod h1:30gJm9FbNBdzMX300ibhtlU72BgkjDuW1bX/u4FC0ns=
 github.com/rancher/fleet/pkg/apis v0.0.0-20230821130910-23e1c146755a h1:NfXE4/LpGiskJA61TE9Qmkar4IAoPVWWw9WuzsRfhpg=
 github.com/rancher/fleet/pkg/apis v0.0.0-20230821130910-23e1c146755a/go.mod h1:LAwUj8qIFnHtH6tj2bEkanIi5jkyzjFK3e3xYUfSY4s=
 github.com/rancher/gke-operator v1.1.6-rc2 h1:ENFi2Cj2t/EwI7m6wSiZ8xYZWS3TpU0owY47pH9raXw=


### PR DESCRIPTION
Update EKS operator to v1.2.2-rc6

Changelog: https://github.com/rancher/eks-operator/releases/tag/v1.2.2-rc6

cc @rancher/highlander