### PR TITLE
Generate crd and expose CRTB

### DIFF
--- a/pkg/api/steve/disallow/disallow.go
+++ b/pkg/api/steve/disallow/disallow.go
@@ -13,6 +13,7 @@ import (
 var (
 	// AllowAll is a set of resources for which Rancher doesn't require authentication to perform any operation.
 	AllowAll = map[string]bool{
+		"clusterroletemplatebindings":                true,
 		"podsecurityadmissionconfigurationtemplates": true,
 		"projects": true,
 	}

--- a/pkg/apis/management.cattle.io/v3/authz_types.go
+++ b/pkg/apis/management.cattle.io/v3/authz_types.go
@@ -317,20 +317,38 @@ func (p *ProjectRoleTemplateBinding) ObjClusterName() string {
 }
 
 // +genclient
-// +kubebuilder:skipversion
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// ClusterRoleTemplateBinding is the object representing membership of a subject in a cluster with permissions
+// specified by a given role template.
 type ClusterRoleTemplateBinding struct {
-	types.Namespaced
+	types.Namespaced  `json:",inline"`
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	UserName           string `json:"userName,omitempty" norman:"noupdate,type=reference[user]"`
-	UserPrincipalName  string `json:"userPrincipalName,omitempty" norman:"noupdate,type=reference[principal]"`
-	GroupName          string `json:"groupName,omitempty" norman:"noupdate,type=reference[group]"`
+	// UserName is the name of the user subject added to the project. Immutable.
+	// +optional
+	UserName string `json:"userName,omitempty" norman:"noupdate,type=reference[user]"`
+
+	// UserPrincipalName is the name of the user principal subject added to the project. Immutable.
+	// +optional
+	UserPrincipalName string `json:"userPrincipalName,omitempty" norman:"noupdate,type=reference[principal]"`
+
+	// GroupName is the name of the group subject added to the project. Immutable.
+	// +optional
+	GroupName string `json:"groupName,omitempty" norman:"noupdate,type=reference[group]"`
+
+	// GroupPrincipalName is the name of the group principal subject added to the project. Immutable.
+	// +optional
 	GroupPrincipalName string `json:"groupPrincipalName,omitempty" norman:"noupdate,type=reference[principal]"`
-	ClusterName        string `json:"clusterName,omitempty" norman:"required,noupdate,type=reference[cluster]"`
-	RoleTemplateName   string `json:"roleTemplateName,omitempty" norman:"required,noupdate,type=reference[roleTemplate]"`
+
+	// ClusterName is the name of the cluster to which a subject is added. Immutable.
+	// +kubebuilder:validation:Required
+	ClusterName string `json:"clusterName" norman:"required,noupdate,type=reference[cluster]"`
+
+	// RoleTemplateName is the name of the role template that defines permissions to perform actions on resources in the project. Immutable.
+	// +kubebuilder:validation:Required
+	RoleTemplateName string `json:"roleTemplateName" norman:"required,noupdate,type=reference[roleTemplate]"`
 }
 
 func (c *ClusterRoleTemplateBinding) ObjClusterName() string {

--- a/pkg/crds/names.go
+++ b/pkg/crds/names.go
@@ -218,7 +218,7 @@ var MigratedResources = map[string]bool{
 	"clusterregistrationtokens.management.cattle.io":                  false,
 	"clusterrepoes.catalog.cattle.io":                                 false,
 	"clusterresourcesetbindings.addons.cluster.x-k8s.io":              false,
-	"clusterroletemplatebindings.management.cattle.io":                false,
+	"clusterroletemplatebindings.management.cattle.io":                true,
 	"clusters.cluster.x-k8s.io":                                       false,
 	"clusters.management.cattle.io":                                   false,
 	"clusters.provisioning.cattle.io":                                 false,

--- a/pkg/crds/yaml/generated/management.cattle.io_clusterroletemplatebindings.yaml
+++ b/pkg/crds/yaml/generated/management.cattle.io_clusterroletemplatebindings.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: clusterroletemplatebindings.management.cattle.io
+spec:
+  group: management.cattle.io
+  names:
+    kind: ClusterRoleTemplateBinding
+    listKind: ClusterRoleTemplateBindingList
+    plural: clusterroletemplatebindings
+    singular: clusterroletemplatebinding
+  scope: Namespaced
+  versions:
+  - name: v3
+    schema:
+      openAPIV3Schema:
+        description: ClusterRoleTemplateBinding is the object representing membership
+          of a subject in a cluster with permissions specified by a given role template.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          clusterName:
+            description: ClusterName is the name of the cluster to which a subject
+              is added. Immutable.
+            type: string
+          groupName:
+            description: GroupName is the name of the group subject added to the project.
+              Immutable.
+            type: string
+          groupPrincipalName:
+            description: GroupPrincipalName is the name of the group principal subject
+              added to the project. Immutable.
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          roleTemplateName:
+            description: RoleTemplateName is the name of the role template that defines
+              permissions to perform actions on resources in the project. Immutable.
+            type: string
+          userName:
+            description: UserName is the name of the user subject added to the project.
+              Immutable.
+            type: string
+          userPrincipalName:
+            description: UserPrincipalName is the name of the user principal subject
+              added to the project. Immutable.
+            type: string
+        required:
+        - clusterName
+        - roleTemplateName
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
## Issue: 
 
## Problem
CRTB validation has been migrated. We need to expose them in steve and to generate the CRD
 
## Solution
Add the information to generate the crd and expose CRTBs in steve
 
## Testing
Ran the integration tests to make sure none of the field changes caused issues. No new tests needed

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_