### PR TITLE
[v2.7] Fix TestLocalClusterRancherImages in prime checks

### DIFF
--- a/tests/v2/validation/prime/prime_test.go
+++ b/tests/v2/validation/prime/prime_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
-	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	prime "github.com/rancher/rancher/tests/framework/extensions/prime"
 	"github.com/rancher/rancher/tests/framework/extensions/rancherversion"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/stretchr/testify/assert"
@@ -77,15 +77,9 @@ func (t *PrimeTestSuite) TestSystemDefaultRegistry() {
 }
 
 func (t *PrimeTestSuite) TestLocalClusterRancherImages() {
-	adminClient, err := rancher.NewClient(t.client.RancherConfig.AdminToken, t.client.Session)
-	require.NoError(t.T(), err)
-
-	clusterID, err := clusters.GetClusterIDByName(adminClient, localCluster)
-	require.NoError(t.T(), err)
-
-	imageResults, imageErrors := prime.CheckLocalClusterRancherImages(t.client, t.isPrime, t.rancherVersion, t.primeRegistry, clusterID)
-	assert.NotEmpty(t.T(), imageResults)
-	assert.Empty(t.T(), imageErrors)
+	podResults, podErrors := pods.StatusPods(t.client, localCluster)
+	assert.Empty(t.T(), podErrors)
+	assert.NotEmpty(t.T(), podResults)
 }
 
 func TestPrimeTestSuite(t *testing.T) {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When running our Prime UI checks, the `TestLocalClusterRancherImages` function keeps returning an error message regarding some pods. Manually looking, the errors are false-positives and is a result of how the function itself is written. We have `StatusPods` which is doing the exact thing, but yields the correct result.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Removed the faulty function and replaced it with `StatusPods`. Additionally, did some minor refactoring to polish up how the test runs to make it more smooth.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Ran this locally and the tests passed as expected.