### PR TITLE
fix(sec): upgrade cryptography to 41.0.3

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -11,4 +11,4 @@ netaddr==0.7.19
 requests==2.21.0
 kubernetes==12.0.1
 jinja2>=2.10
-cryptography==39.0.1
+cryptography==41.0.3

--- a/tests/validation/requirements.txt
+++ b/tests/validation/requirements.txt
@@ -2,7 +2,7 @@ pytest==3.8.1
 pytest-repeat==0.7.0
 pytest-xdist==1.23.0
 boto3==1.21.33
-cryptography==39.0.1
+cryptography==41.0.3
 flake8==3.5.0
 invoke==1.2.0
 Jinja2==3.0.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in cryptography 39.0.1
- [CVE-2023-38325](https://www.oscs1024.com/hd/CVE-2023-38325)


### What did I do？
Upgrade cryptography from 39.0.1 to 41.0.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS