### PR TITLE
Bump csp adapter to v3.0.0-rc1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -57,7 +57,7 @@ ENV CATTLE_SYSTEM_UPGRADE_CONTROLLER_CHART_VERSION 102.1.0+up0.5.0
 # System charts minimal version
 ENV CATTLE_FLEET_MIN_VERSION=102.2.0+up0.8.0-rc.8
 ENV CATTLE_RANCHER_WEBHOOK_VERSION=103.0.0+up0.4.0-rc2
-ENV CATTLE_CSP_ADAPTER_MIN_VERSION=2.0.2
+ENV CATTLE_CSP_ADAPTER_MIN_VERSION=103.0.0+up3.0.0-rc1
 
 RUN mkdir -p /var/lib/rancher-data/local-catalogs/system-library && \
     mkdir -p /var/lib/rancher-data/local-catalogs/library && \


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
Bumps the csp adapter to a 2.8/1.27 compatible version for #41790. This PR also changes the versioning scheme of the adapter to align better with upstream versioning policy