### PR TITLE
Use CATTLE_BASE_REGISTRY even when the cluster is nill. 

### DIFF
--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -45,7 +45,7 @@ func Resolve(image string) string {
 	return ResolveWithCluster(image, nil)
 }
 
-// ResolveWithCluster returns the image concatenated with the URL of the private registry specified.
+// ResolveWithCluster returns the image concatenated with the URL of the private registry specified, adding rancher/ if is a private repo.
 // It will use the cluster level registry if one is found, or the system default registry if no cluster level registry is found.
 // If either is not found, it returns the image.
 func ResolveWithCluster(image string, cluster *v3.Cluster) string {

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -38,14 +38,17 @@ var osTypeImageListName = map[OSType]string{
 	Linux:   "rancher-images",
 }
 
+// Resolve calls ResolveWithCluster passing nil into the cluster argument.
+// returns the image concatenated with the URL of the system default registry.
+// if there is no system default registry it will return the image
 func Resolve(image string) string {
 	return ResolveWithCluster(image, nil)
 }
 
+// ResolveWithCluster returns the image concatenated with the URL of the private registry specified.
+// It will use the cluster level registry if one is found, or the system default registry if no cluster level registry is found.
+// If either is not found, it returns the image.
 func ResolveWithCluster(image string, cluster *v3.Cluster) string {
-	if cluster == nil {
-		return image
-	}
 	reg := util.GetPrivateRegistryURL(cluster)
 	if reg != "" && !strings.HasPrefix(image, reg) {
 		// Images from Dockerhub Library repo, we add rancher prefix when using private registry

--- a/pkg/image/resolve_test.go
+++ b/pkg/image/resolve_test.go
@@ -161,6 +161,15 @@ func TestResolveWithCluster(t *testing.T) {
 			},
 			expected: "cluster-url.com/rancher/imagename",
 		},
+		{
+			name: "Cluster with URL, and default registry, with rancher/ on image",
+			input: input{
+				image:              "rancher/imagename",
+				CattleBaseRegistry: "registry-url",
+				cluster:            clusterWithPrivateRegistry("cluster-url.com"),
+			},
+			expected: "cluster-url.com/rancher/imagename",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/image/resolve_test.go
+++ b/pkg/image/resolve_test.go
@@ -214,7 +214,7 @@ func TestResolve(t *testing.T) {
 			expected: "default-registry.com/rancher/imagename",
 		},
 		{
-			name: "Default wit rancher",
+			name: "Default with rancher",
 			input: input{
 				image:              "rancher/imagename",
 				CattleBaseRegistry: "default-registry.com",

--- a/pkg/image/resolve_test.go
+++ b/pkg/image/resolve_test.go
@@ -1,9 +1,16 @@
 package image
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/settings"
+	rketypes "github.com/rancher/rke/types"
 	assertlib "github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestConvertMirroredImages(t *testing.T) {
@@ -39,5 +46,128 @@ func TestConvertMirroredImages(t *testing.T) {
 		imagesSet := cs.inputRawImages
 		convertMirroredImages(imagesSet)
 		assert.Equal(cs.outputImagesShouldEqual, imagesSet)
+	}
+}
+
+func TestResolveWithCluster(t *testing.T) {
+	if os.Getenv("CATTLE_BASE_REGISTRY") != "" {
+		fmt.Println("Skiping TestResolveWithCluster. Can't run the tests with CATTLE_BASE_REGISTRY set")
+	}
+
+	clusterWithPrivateRegistry := func(s string) *v3.Cluster {
+		return &v3.Cluster{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{},
+			Spec: apimgmtv3.ClusterSpec{
+				ClusterSpecBase: apimgmtv3.ClusterSpecBase{
+					RancherKubernetesEngineConfig: &rketypes.RancherKubernetesEngineConfig{
+						PrivateRegistries: []rketypes.PrivateRegistry{{
+							URL: s,
+						},
+						},
+					},
+				},
+			},
+		}
+	}
+	type input struct {
+		image              string
+		CattleBaseRegistry string
+		cluster            *v3.Cluster
+	}
+	tests := []struct {
+		name     string
+		input    input
+		expected string
+	}{
+		{
+			name: "No cluster no default registry",
+			input: input{
+				image:              "imagename",
+				CattleBaseRegistry: "",
+				cluster:            nil,
+			},
+			expected: "imagename",
+		},
+		{
+			name: "No cluster with default registry, image without rancher/",
+			input: input{
+				image:              "imagename",
+				CattleBaseRegistry: "custom-registry",
+				cluster:            nil,
+			},
+			expected: "custom-registry/rancher/imagename",
+		},
+		{
+			name: "No cluster with default registry, image with rancher/",
+			input: input{
+				image:              "rancher/imagename",
+				CattleBaseRegistry: "custom-registry",
+				cluster:            nil,
+			},
+			expected: "custom-registry/rancher/imagename",
+		},
+		{
+			name: "Cluster empty URL, no default registry",
+			input: input{
+				image:              "imagename",
+				CattleBaseRegistry: "",
+				cluster:            &v3.Cluster{},
+			},
+			expected: "imagename",
+		},
+		{
+			name: "Cluster empty URL, with default registry",
+			input: input{
+				image:              "imagename",
+				CattleBaseRegistry: "default-registry.com",
+				cluster:            &v3.Cluster{},
+			},
+			expected: "default-registry.com/rancher/imagename",
+		},
+		{
+			name: "Cluster empty URL, with default registry and rancher on image name",
+			input: input{
+				image:              "rancher/imagename",
+				CattleBaseRegistry: "default-registry.com",
+				cluster:            &v3.Cluster{},
+			},
+			expected: "default-registry.com/rancher/imagename",
+		},
+		{
+			name: "Cluster with URL, no default registry, no rancher/ on image",
+			input: input{
+				image:              "imagename",
+				CattleBaseRegistry: "",
+				cluster:            clusterWithPrivateRegistry("cluster-url.com"),
+			},
+			expected: "cluster-url.com/rancher/imagename",
+		},
+		{
+			name: "Cluster with URL, no default registry, with rancher/ on image",
+			input: input{
+				image:              "imagename",
+				CattleBaseRegistry: "",
+				cluster:            clusterWithPrivateRegistry("cluster-url.com"),
+			},
+			expected: "cluster-url.com/rancher/imagename",
+		},
+		{
+			name: "Cluster with URL, and default registry, no rancher/ on image",
+			input: input{
+				image:              "imagename",
+				CattleBaseRegistry: "registry-url",
+				cluster:            clusterWithPrivateRegistry("cluster-url.com"),
+			},
+			expected: "cluster-url.com/rancher/imagename",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := settings.SystemDefaultRegistry.Set(tt.input.CattleBaseRegistry); err != nil {
+				t.Errorf("Failed to test TestResolveWithCluster(), unable to set SystemDefaultRegistry with the value: %v", err)
+			}
+			assertlib.Equalf(t, tt.expected, ResolveWithCluster(tt.input.image, tt.input.cluster), "ResolveWithCluster(%v, %v)", tt.input.image, tt.input.cluster)
+		})
 	}
 }

--- a/pkg/image/resolve_test.go
+++ b/pkg/image/resolve_test.go
@@ -172,13 +172,22 @@ func TestResolveWithCluster(t *testing.T) {
 			expected: "cluster-url.com/rancher/imagename",
 		},
 	}
+
+	if err := settings.SystemDefaultRegistry.Set(""); err != nil {
+		t.Errorf("Failed to test TestResolveWithCluster(), unable to set SystemDefaultRegistry with the err: %v", err)
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := settings.SystemDefaultRegistry.Set(tt.input.CattleBaseRegistry); err != nil {
-				t.Errorf("Failed to test TestResolveWithCluster(), unable to set SystemDefaultRegistry with the value: %v", err)
+				t.Errorf("Failed to test TestResolveWithCluster(), unable to set SystemDefaultRegistry. err: %v", err)
 			}
 			assertlib.Equalf(t, tt.expected, ResolveWithCluster(tt.input.image, tt.input.cluster), "ResolveWithCluster(%v, %v)", tt.input.image, tt.input.cluster)
 		})
+	}
+
+	if err := settings.SystemDefaultRegistry.Set(""); err != nil {
+		t.Errorf("Failed to clean up TestResolveWithCluster(), unable to set SystemDefaultRegistry with the err: %v", err)
 	}
 }
 
@@ -222,12 +231,22 @@ func TestResolve(t *testing.T) {
 			expected: "default-registry.com/rancher/imagename",
 		},
 	}
+
+	if err := settings.SystemDefaultRegistry.Set(""); err != nil {
+		t.Errorf("Failed to test TestResolveWithCluster(), unable to clean SystemDefaultRegistry. Err: %v", err)
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := settings.SystemDefaultRegistry.Set(tt.input.CattleBaseRegistry); err != nil {
-				t.Errorf("Failed to test TestResolveWithCluster(), unable to set SystemDefaultRegistry with the value: %v", err)
+				t.Errorf("Failed to test TestResolveWithCluster(), unable to set SystemDefaultRegistry. Err: %v", err)
 			}
 			assertlib.Equalf(t, tt.expected, Resolve(tt.input.image), "Resolve(%v)", tt.input.image)
 		})
 	}
+
+	if err := settings.SystemDefaultRegistry.Set(""); err != nil {
+		t.Errorf("Failed to clean up TestResolve(), unable to clean SystemDefaultRegistry. Err: %v", err)
+	}
+
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #42048
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
 
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
When importing new generic clusters in Rancher, the global entry for system-default-registry is not being honored by Rancher and is reverting to pulling from docker.io.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
It was coded to behave like that if no cluster was passed to the function. 
The funcion cals: 
GetPrivateRegistryURL(cluster) ->  GetPrivateRegistry(cluster) -> GetPrivateClusterLevelRegistry(cluster)

GetPrivateClusterLevelRegistry() will return nill if there is  no cluster. 

on GetPrivateRegistry()  if  GetPrivateClusterLevelRegistry() retruns nill it will get the default registry. 

This way the function will work as intended if the cluster is nill. 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Instantiate Rancher with CATTLE_BASE_REGISTRY set. Import a custom cluster. Download the .yaml and check the image. 
 Instantiate Rancher with CATTLE_BASE_REGISTRY  empty. Import a custom cluster. Download the .yaml and check the image.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    TestResolveWithCluster
    TestResolve

    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_