### PR TITLE
Disabling flaky version test suite

### DIFF
--- a/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
+++ b/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
@@ -6,6 +6,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"testing"
+	"time"
+
 	rv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
@@ -19,7 +23,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/repo"
-	"io"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,8 +30,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"testing"
-	"time"
 )
 
 var propagation = metav1.DeletePropagationForeground
@@ -119,7 +120,7 @@ func (w *RancherManagedChartsTest) resetSettings() {
 }
 
 func TestRancherManagedChartsSuite(t *testing.T) {
-	suite.Run(t, new(RancherManagedChartsTest))
+	//suite.Run(t, new(RancherManagedChartsTest))
 }
 
 func (w *RancherManagedChartsTest) TestInstallChartLatestVersion() {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
Related to #42606. The TestRancherManagedChartsSuite seems to have been copied from an earlier flaky test suite, which we had to disable due to the CI failures (see #41853). This pr disables this new flaky test until a better solution can be devised for testing chart versioning.