### PR TITLE
Verify code changes also on release branches

### DIFF
--- a/.github/workflows/verify-generated-code-changes.yml
+++ b/.github/workflows/verify-generated-code-changes.yml
@@ -3,6 +3,9 @@ name: Verify generated code changes
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+    - 'release/*'
 
 env:
   MAIN_BRANCH: origin/master


### PR DESCRIPTION
instead of just prs, to make the status of the test available in Github by checking the latest commit.