### PR TITLE
Adding ssh test to allow check for CPU usage

### DIFF
--- a/tests/framework/extensions/clusters/clusterconfig.go
+++ b/tests/framework/extensions/clusters/clusterconfig.go
@@ -29,6 +29,7 @@ type ClusterConfig struct {
 	Registries           *provisioningInput.Registries            `json:"registries" yaml:"registries"`
 	UpgradeStrategy      *rkev1.ClusterUpgradeStrategy            `json:"upgradeStrategy" yaml:"upgradeStrategy"`
 	Advanced             *provisioningInput.Advanced              `json:"advanced" yaml:"advanced"`
+	ClusterSSHTests      []string                                 `json:"clusterSSHTests" yaml:"clusterSSHTests"`
 }
 
 // ConvertConfigToClusterConfig converts the config from (user) provisioning input to a cluster config
@@ -52,6 +53,7 @@ func ConvertConfigToClusterConfig(clustersConfig *provisioningInput.Config) *Clu
 	newConfig.Hardened = clustersConfig.Hardened
 	newConfig.PSACT = clustersConfig.PSACT
 	newConfig.PNI = clustersConfig.PNI
+	newConfig.ClusterSSHTests = clustersConfig.ClusterSSHTests
 
 	return &newConfig
 }

--- a/tests/framework/extensions/clusters/dynamicSchema.go
+++ b/tests/framework/extensions/clusters/dynamicSchema.go
@@ -1,0 +1,28 @@
+package clusters
+
+// Default contains the values for sshUser
+type Default struct {
+	StringValue      string `json:"stringValue"`
+	IntValue         int    `json:"intValue"`
+	BoolValue        bool   `json:"boolValue"`
+	StringSliceValue []int  `json:"stringSliceValue"`
+}
+
+// SSHUser contains all the fields for sshUser
+type SSHUser struct {
+	Type        string `json:"type"`
+	Default     Default
+	Create      bool   `json:"create"`
+	Update      bool   `json:"update"`
+	Description string `json:"description"`
+}
+
+// ResourceFields contains all the fields of the resources found in DynamicSchemaSpec
+type ResourceFields struct {
+	SSHUser SSHUser
+}
+
+// DynamicSchemaSpec contains ResourceFields that contains all the data for the DynamicSchemaSpec which a type in provisinong.cattle.io.clusters this is how we get an ssh user for a node pool
+type DynamicSchemaSpec struct {
+	ResourceFields ResourceFields `json:"resourceFields"`
+}

--- a/tests/framework/extensions/provisioning/ssh.go
+++ b/tests/framework/extensions/provisioning/ssh.go
@@ -1,0 +1,46 @@
+package provisioning
+
+// This file contains all tests that require to ssh into a node to run commands to check things
+// such as any stats, benchmarks, etc. For example, ssh is required to check the cpu usage of a
+// process running on an individual node.
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	cpuUsageVar = 100 // 100 is just a placeholder until we can determine an actual number. Even with cpu usage spiking it should not go past 100% cpu usage and previous issues concerning this were hitting around 130% and above
+	checkCPU    = "CheckCPU"
+)
+
+// This func tests the ssh tests specified in the provisioninginput config clusterSSHTests field.
+// For example CheckCPU checks the cpu usage of the cluster agent. If the usage is too high the func will return a warning.
+func CallSSHTestByName(testName string, node *nodes.Node) error {
+	switch testName {
+	case checkCPU:
+		command := "ps -C agent -o %cpu --no-header"
+		output, err := node.ExecuteCommand(command)
+		if err != nil {
+			return err
+		}
+		str_output := output[:strings.IndexByte(output, '\n')]
+		logrus.Info("CheckCPU test on node " + node.PublicIPAddress + " | Cluster agent cpu usage is: " + str_output + "%")
+
+		output_int, err := strconv.ParseFloat(strings.TrimSpace(str_output), 32)
+		if output_int > cpuUsageVar {
+			logrus.Warn("Cluster agent cpu usage is too high on node" + node.PublicIPAddress + " | Current cpu usage is: " + str_output + "%")
+		}
+		if err != nil {
+			return err
+		}
+	default:
+		err := errors.New("SSHTest: " + testName + " is spelled incorrectly or does not exist.")
+		return err
+	}
+	return nil
+}

--- a/tests/framework/extensions/provisioning/verify.go
+++ b/tests/framework/extensions/provisioning/verify.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
@@ -20,7 +21,9 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
 	psadeploy "github.com/rancher/rancher/tests/framework/extensions/psact"
 	"github.com/rancher/rancher/tests/framework/extensions/registries"
+	"github.com/rancher/rancher/tests/framework/extensions/sshkeys"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
+	"github.com/rancher/rancher/tests/framework/pkg/nodes"
 	"github.com/rancher/rancher/tests/framework/pkg/wait"
 	"github.com/rancher/rancher/tests/v2prov/defaults"
 	wranglername "github.com/rancher/wrangler/pkg/name"
@@ -37,6 +40,8 @@ import (
 const (
 	logMessageKubernetesVersion = "Validating the current version is the upgraded one"
 	hostnameLimit               = 63
+	machineNameAnnotation       = "cluster.x-k8s.io/machine"
+	publicIPAnnotation          = "rke2.io/external-ip"
 )
 
 // VerifyRKE1Cluster validates that the RKE1 cluster and its resources are in a good state, matching a given config.
@@ -93,7 +98,7 @@ func VerifyRKE1Cluster(t *testing.T, client *rancher.Client, clustersConfig *clu
 }
 
 // VerifyCluster validates that a non-rke1 cluster and its resources are in a good state, matching a given config.
-func VerifyCluster(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIObject) {
+func VerifyCluster(t *testing.T, client *rancher.Client, clustersConfig *clusters.ClusterConfig, cluster *steveV1.SteveAPIObject) {
 	client, err := client.ReLogin()
 	require.NoError(t, err)
 
@@ -158,6 +163,10 @@ func VerifyCluster(t *testing.T, client *rancher.Client, cluster *steveV1.SteveA
 	podResults, podErrors := pods.StatusPods(client, status.ClusterName)
 	assert.Empty(t, podErrors)
 	assert.NotEmpty(t, podResults)
+
+	if clustersConfig.ClusterSSHTests != nil {
+		VerifySSHTests(t, client, cluster, clustersConfig.ClusterSSHTests, status.ClusterName)
+	}
 }
 
 // CertRotationCompleteCheckFunc returns a watch check function that checks if the certificate rotation is complete
@@ -333,5 +342,45 @@ func GetSnapshots(client *rancher.Client, localclusterID string, clusterName str
 		}
 	}
 	return snapshots, nil
+
+}
+
+// VerifySSHTests validates the ssh tests listed in the config on each node of the cluster
+func VerifySSHTests(t *testing.T, client *rancher.Client, clusterObject *steveV1.SteveAPIObject, sshTests []string, clusterID string) {
+	client, err := client.ReLogin()
+	require.NoError(t, err)
+
+	clusterSpec := &provv1.ClusterSpec{}
+	err = steveV1.ConvertToK8sType(clusterObject.Spec, clusterSpec)
+	require.NoError(t, err)
+
+	steveclient, err := client.Steve.ProxyDownstream(clusterID)
+	require.NoError(t, err)
+	nodesSteveObjList, err := steveclient.SteveType("node").List(nil)
+	require.NoError(t, err)
+
+	dynamicSchema := clusterSpec.RKEConfig.MachinePools[0].DynamicSchemaSpec
+	var data clusters.DynamicSchemaSpec
+	err = json.Unmarshal([]byte(dynamicSchema), &data)
+	require.NoError(t, err)
+
+	sshUser := data.ResourceFields.SSHUser.Default.StringValue
+	for _, tests := range sshTests {
+		for _, rancherNode := range nodesSteveObjList.Data {
+			machineName := rancherNode.Annotations[machineNameAnnotation]
+			sshkey, err := sshkeys.DownloadSSHKeys(client, machineName)
+			require.NoError(t, err)
+			assert.NotEmpty(t, sshkey)
+			clusterNode := &nodes.Node{
+				NodeID:          rancherNode.ID,
+				PublicIPAddress: rancherNode.Annotations[publicIPAnnotation],
+				SSHUser:         sshUser,
+				SSHKey:          sshkey,
+			}
+
+			CallSSHTestByName(tests, clusterNode)
+
+		}
+	}
 
 }

--- a/tests/framework/extensions/provisioninginput/config.go
+++ b/tests/framework/extensions/provisioninginput/config.go
@@ -171,4 +171,5 @@ type Config struct {
 	Registries             *Registries                              `json:"registries" yaml:"registries"`
 	UpgradeStrategy        *rkev1.ClusterUpgradeStrategy            `json:"upgradeStrategy" yaml:"upgradeStrategy"`
 	Advanced               *Advanced                                `json:"advanced" yaml:"advanced"`
+	ClusterSSHTests        []string                                 `json:"clusterSSHTests" yaml:"clusterSSHTests"`
 }

--- a/tests/framework/extensions/sshkeys/downloadsshkeys.go
+++ b/tests/framework/extensions/sshkeys/downloadsshkeys.go
@@ -10,41 +10,41 @@ import (
 )
 
 const (
-	privateKeySSHKeyRegExPattern              = `----BEGIN RSA PRIVATE KEY-{3,}\n([\s\S]*?)\n-{3,}END RSA PRIVATE KEY-----`
+	privateKeySSHKeyRegExPattern              = `-----BEGIN RSA PRIVATE KEY-{3,}\n([\s\S]*?)\n-{3,}END RSA PRIVATE KEY-----`
 	ClusterMachineConstraintResourceSteveType = "cluster.x-k8s.io.machine"
 )
 
 // DownloadSSHKeys is a helper function that takes a client, the machinePoolNodeName to download
 // the ssh key for a particular node.
-func DownloadSSHKeys(client *rancher.Client, machinePoolNodeName string) (string, error) {
+func DownloadSSHKeys(client *rancher.Client, machinePoolNodeName string) ([]byte, error) {
 	machinePoolNodeNameName := fmt.Sprintf("fleet-default/%s", machinePoolNodeName)
 	machine, err := client.Steve.SteveType(ClusterMachineConstraintResourceSteveType).ByID(machinePoolNodeNameName)
 	if err != nil {
-		return "", err
+		return []byte{}, err
 	}
 
 	sshKeyLink := machine.Links["sshkeys"]
 
 	req, err := http.NewRequest("GET", sshKeyLink, nil)
 	if err != nil {
-		return "", err
+		return []byte{}, err
 	}
 
 	req.Header.Add("Authorization", "Bearer "+client.RancherConfig.AdminToken)
 
 	resp, err := client.Management.APIBaseClient.Ops.Client.Do(req)
 	if err != nil {
-		return "", err
+		return []byte{}, err
 	}
 	defer resp.Body.Close()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return []byte{}, err
 	}
 
 	privateSSHKeyRegEx := regexp.MustCompile(privateKeySSHKeyRegExPattern)
 	privateSSHKey := privateSSHKeyRegEx.FindString(string(bodyBytes))
 
-	return privateSSHKey, err
+	return []byte(privateSSHKey), err
 }

--- a/tests/v2/validation/provisioning/permutations/permutations.go
+++ b/tests/v2/validation/provisioning/permutations/permutations.go
@@ -61,7 +61,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						clusterObject, err := provisioning.CreateProvisioningCluster(client, *nodeProvider, testClusterConfig, hostnameTruncation)
 
 						require.NoError(s.T(), err)
-						provisioning.VerifyCluster(s.T(), client, clusterObject)
+						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
 
 					case RKE1ProvisionCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
@@ -79,7 +79,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						clusterObject, err := provisioning.CreateProvisioningCustomCluster(client, *customProvider, testClusterConfig)
 						require.NoError(s.T(), err)
 
-						provisioning.VerifyCluster(s.T(), client, clusterObject)
+						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
 
 					case RKE1CustomCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
@@ -97,7 +97,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						clusterObject, err := provisioning.CreateProvisioningAirgapCustomCluster(client, testClusterConfig, corralPackages)
 						require.NoError(s.T(), err)
 
-						provisioning.VerifyCluster(s.T(), client, clusterObject)
+						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
 
 					case RKE1AirgapCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion

--- a/tests/v2/validation/provisioning/rke2/README.md
+++ b/tests/v2/validation/provisioning/rke2/README.md
@@ -43,7 +43,8 @@ provisioningInput is needed to the run the RKE2 tests, specifically kubernetesVe
     "providers": ["linode", "aws", "do", "harvester"],
     "nodeProviders": ["ec2"],
     "hardened": true,
-    "psact": ""
+    "psact": "",
+    "clusterSSHTests": ["CheckCPU"]
   }
 ```
 


### PR DESCRIPTION
Adding ssh test package to run tests that require ssh to run. Also adjusted downloadsshkeys.go to send a byte instead of string to be used in the node object.

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/451
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
There were tickets around CPU usage being too high and we wanted to add automated checks to more consistently check CPU usage during releases.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Adding this automation will allow us to more frequently check if the CPU Usage issue were to ever come back. Also with downloadsshkeys.go we are now able to run any ssh related tests within the provisioning package. Currently just added to rke2 package, but since Node object is also used in rke1 and k3s, I will also add there after approval.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Tested the actual ssh command manually multiple times to ensure that it works.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Will run jenkins job

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
The CPU check will be stored under the ssh package, and with future additions to that package users can just call the function from the ssh package.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
Currently there are no regressions as the ssh key being changed from string to byte is allowing the node object to use the ssh key, which before it wasn't allowed. No other objects are being changed.