### PR TITLE
Bump rancher-agent image to use v2.8-head

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -49,7 +49,7 @@ var (
 		"cattle-elemental-system",
 	}
 
-	AgentImage                          = NewSetting("agent-image", "rancher/rancher-agent:v2.7-head")
+	AgentImage                          = NewSetting("agent-image", "rancher/rancher-agent:v2.8-head")
 	AgentRolloutTimeout                 = NewSetting("agent-rollout-timeout", "300s")
 	AgentRolloutWait                    = NewSetting("agent-rollout-wait", "true")
 	AuthImage                           = NewSetting("auth-image", v32.ToolsSystemImages.AuthSystemImages.KubeAPIAuth)


### PR DESCRIPTION
## Issue:
 
## Problem

While developing, we're still deploying the `v2.7-head` version of the agent instead of `v2.8-head`. That seems wrong.
 
## Solution

Bump the default value of `CATTLE_AGENT_IMAGE` to v2.8-head.
 
## Testing

I simply ran `go run` locally, imported another k3s cluster and verified that the agent image is v2.8-head.

## Questions

Using ripgrep to look for v2.7-head I still see the following:

```
$ rg 2.7-head
tests/v2/codecoverage/setuprancher/main.go
43:     rancherTestImage = "ranchertest/rancher:v2.7-head"

tests/v2/codecoverage/scripts/build_docker_images.sh
6:TAG=v2.7-head
```

Unsure if those should those also be changed. (Probably?)
