### PR TITLE
Get registry from v2prov even without a secret

### DIFF
--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -67,7 +67,7 @@ func GetPrivateClusterLevelRegistry(cluster *v3.Cluster) *rketypes.PrivateRegist
 // clusters, as the function will reassemble them anyway.
 func GeneratePrivateRegistryEncodedDockerConfig(cluster *v3.Cluster, secretLister v1.SecretLister) (string, string, error) {
 	var err error
-	// Declare here so we don't need to check if the rkeClusterRegistryOrGlobalSystemDefault exists wile working with v2prov
+	// Declare here so we don't need to check if the rkeClusterRegistryOrGlobalSystemDefault exists while working with v2prov
 	var rkeClusterURLOrGlobalSystemDefault string
 
 	if cluster == nil {

--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -68,7 +68,7 @@ func GetPrivateClusterLevelRegistry(cluster *v3.Cluster) *rketypes.PrivateRegist
 func GeneratePrivateRegistryEncodedDockerConfig(cluster *v3.Cluster, secretLister v1.SecretLister) (string, string, error) {
 	var err error
 	// Declare here so we don't need to check if the rkeClusterRegistryOrGlobalSystemDefault exists wile working with v2prov
-	var rkeClusterUrlOrGlobalSystemDefault string
+	var rkeClusterURLOrGlobalSystemDefault string
 
 	if cluster == nil {
 		return "", "", nil
@@ -89,7 +89,7 @@ func GeneratePrivateRegistryEncodedDockerConfig(cluster *v3.Cluster, secretListe
 	// Private registry will only be defined on the cluster if it is an RKE1 cluster, mgmt clusters generated from
 	// provisioning clusters do not have a populated `RancherKubernetesEngineConfig`.
 	if rkeClusterRegistryOrGlobalSystemDefault := GetPrivateRegistry(cluster); rkeClusterRegistryOrGlobalSystemDefault != nil {
-		rkeClusterUrlOrGlobalSystemDefault = rkeClusterRegistryOrGlobalSystemDefault.URL
+		rkeClusterURLOrGlobalSystemDefault = rkeClusterRegistryOrGlobalSystemDefault.URL
 		// check for RKE1 ECR credentials first
 		if rkeClusterRegistryOrGlobalSystemDefault.ECRCredentialPlugin != nil {
 			// generate ecr authConfig
@@ -127,7 +127,7 @@ func GeneratePrivateRegistryEncodedDockerConfig(cluster *v3.Cluster, secretListe
 	v2ProvRegistryUrl := cluster.GetSecret(v3.ClusterPrivateRegistryURL)
 	// If we don't have a secretName nor a downstream PrivateRegistryURL on the v2Prov we return the RKE1/default registry URL.
 	if v2ProvRegistryUrl == "" {
-		return rkeClusterUrlOrGlobalSystemDefault, "", nil
+		return rkeClusterURLOrGlobalSystemDefault, "", nil
 	}
 
 	// if we have a v2Prov registry URL, and we don't have a secret we just return the downstream URL.

--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -124,28 +124,28 @@ func GeneratePrivateRegistryEncodedDockerConfig(cluster *v3.Cluster, secretListe
 	// For RKE2 with a cluster level registry configured, this is the
 	// only reference to the registry URL available on the v3.Cluster.
 	// Without it, we cannot generate the registry credentials (.dockerconfigjson)
-	v2ProvRegistryUrl := cluster.GetSecret(v3.ClusterPrivateRegistryURL)
+	v2ProvRegistryURL := cluster.GetSecret(v3.ClusterPrivateRegistryURL)
 	// If we don't have a secretName nor a downstream PrivateRegistryURL on the v2Prov we return the RKE1/default registry URL.
-	if v2ProvRegistryUrl == "" {
+	if v2ProvRegistryURL == "" {
 		return rkeClusterURLOrGlobalSystemDefault, "", nil
 	}
 
 	// if we have a v2Prov registry URL, and we don't have a secret we just return the downstream URL.
 	if registrySecretName == "" {
-		return v2ProvRegistryUrl, "", nil
+		return v2ProvRegistryURL, "", nil
 	}
 
 	// If we have a registrySecret and a  downstream Registry URL  we try to get the secret from the v2prov.
 	registrySecret, err := secretLister.Get(cluster.Spec.FleetWorkspaceName, registrySecretName)
 	if err != nil {
-		return v2ProvRegistryUrl, "", err
+		return v2ProvRegistryURL, "", err
 	}
 
 	username := string(registrySecret.Data["username"])
 	password := string(registrySecret.Data["password"])
 	authConfig := credentialprovider.DockerConfigJSON{
 		Auths: credentialprovider.DockerConfig{
-			v2ProvRegistryUrl: credentialprovider.DockerConfigEntry{
+			v2ProvRegistryURL: credentialprovider.DockerConfigEntry{
 				Username: username,
 				Password: password,
 			},
@@ -154,8 +154,8 @@ func GeneratePrivateRegistryEncodedDockerConfig(cluster *v3.Cluster, secretListe
 
 	registryJSON, err := json.Marshal(authConfig)
 	if err != nil {
-		return v2ProvRegistryUrl, "", err
+		return v2ProvRegistryURL, "", err
 	}
 
-	return v2ProvRegistryUrl, base64.StdEncoding.EncodeToString(registryJSON), nil
+	return v2ProvRegistryURL, base64.StdEncoding.EncodeToString(registryJSON), nil
 }

--- a/pkg/cluster/private_registry.go
+++ b/pkg/cluster/private_registry.go
@@ -103,6 +103,7 @@ func GeneratePrivateRegistryEncodedDockerConfig(cluster *v3.Cluster, secretListe
 		// If we have a registrySecret we try to use it. Otherwise, we test v2prov.
 		// If we don't have a secret but have a downstream registry we need to check it on v2.
 		if registrySecretName != "" {
+			// check for the RKE1 registry secret next
 			registrySecret, err := secretLister.Get(namespace.GlobalNamespace, registrySecretName)
 			if err == nil {
 				return registry.URL, base64.StdEncoding.EncodeToString(registrySecret.Data[corev1.DockerConfigJsonKey]), nil
@@ -111,7 +112,6 @@ func GeneratePrivateRegistryEncodedDockerConfig(cluster *v3.Cluster, secretListe
 				return registry.URL, "", err
 			}
 		}
-		// check for the RKE1 registry secret next
 	}
 
 	// cluster.GetSecret("PrivateRegistryURL") will be empty if the cluster is

--- a/pkg/cluster/private_registry_test.go
+++ b/pkg/cluster/private_registry_test.go
@@ -166,6 +166,25 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:           "Upstrem registry and no downstream one",
+			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
+			expectedConfig: "",
+			expectedError:  "",
+			// cluster.Spec.RancherKubernetesEngineConfig.PrivateRegistries
+			cluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						RancherKubernetesEngineConfig: &rketypes.RancherKubernetesEngineConfig{
+							PrivateRegistries: []rketypes.PrivateRegistry{{
+								URL: "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
+							}},
+						},
+					},
+					FleetWorkspaceName: "fleet-default",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cluster/private_registry_test.go
+++ b/pkg/cluster/private_registry_test.go
@@ -145,7 +145,7 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 			},
 		},
 		{
-			name:           "v2prov with upstream registry and public registry",
+			name:           "v2prov public registry with upstream registry",
 			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
 			expectedConfig: "",
 			expectedError:  "",

--- a/pkg/cluster/private_registry_test.go
+++ b/pkg/cluster/private_registry_test.go
@@ -110,6 +110,62 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:           "v2prov private registry with upstream registry",
+			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
+			expectedConfig: base64.StdEncoding.EncodeToString([]byte(`{"auths":{"0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com":{"username":"testuser","password":"password","auth":"dGVzdHVzZXI6cGFzc3dvcmQ="}}}`)),
+			expectedError:  "",
+			cluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						RancherKubernetesEngineConfig: &rketypes.RancherKubernetesEngineConfig{
+							PrivateRegistries: []rketypes.PrivateRegistry{{
+								URL: "upstream-registry.com",
+							}},
+						},
+						ClusterSecrets: v3.ClusterSecrets{
+							PrivateRegistrySecret: "test-secret",
+							PrivateRegistryURL:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
+						},
+					},
+					FleetWorkspaceName: "fleet-default",
+				},
+			},
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fleet-default",
+						Name:      "test-secret",
+					},
+					Data: map[string][]byte{
+						"username": []byte("testuser"),
+						"password": []byte("password"),
+					},
+				},
+			},
+		},
+		{
+			name:           "v2prov with upstream registry and public registry",
+			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
+			expectedConfig: "",
+			expectedError:  "",
+			// cluster.Spec.RancherKubernetesEngineConfig.PrivateRegistries
+			cluster: &v3.Cluster{
+				Spec: v3.ClusterSpec{
+					ClusterSpecBase: v3.ClusterSpecBase{
+						RancherKubernetesEngineConfig: &rketypes.RancherKubernetesEngineConfig{
+							PrivateRegistries: []rketypes.PrivateRegistry{{
+								URL: "upstream-registry.com",
+							}},
+						},
+						ClusterSecrets: v3.ClusterSecrets{
+							PrivateRegistryURL: "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
+						},
+					},
+					FleetWorkspaceName: "fleet-default",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cluster/private_registry_test.go
+++ b/pkg/cluster/private_registry_test.go
@@ -111,7 +111,7 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 			},
 		},
 		{
-			name:           "v2prov private registry with upstream registry",
+			name:           "global system default registry and no cluster default registry with corev1.Secret",
 			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
 			expectedConfig: base64.StdEncoding.EncodeToString([]byte(`{"auths":{"0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com":{"username":"testuser","password":"password","auth":"dGVzdHVzZXI6cGFzc3dvcmQ="}}}`)),
 			expectedError:  "",
@@ -145,11 +145,10 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 			},
 		},
 		{
-			name:           "v2prov public registry with upstream registry",
+			name:           "global system default registry and cluster default registry without corev1.Secret",
 			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
 			expectedConfig: "",
 			expectedError:  "",
-			// cluster.Spec.RancherKubernetesEngineConfig.PrivateRegistries
 			cluster: &v3.Cluster{
 				Spec: v3.ClusterSpec{
 					ClusterSpecBase: v3.ClusterSpecBase{
@@ -167,11 +166,10 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 			},
 		},
 		{
-			name:           "Upstrem registry and no downstream one",
+			name:           "global system default registry and no cluster default registry",
 			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
 			expectedConfig: "",
 			expectedError:  "",
-			// cluster.Spec.RancherKubernetesEngineConfig.PrivateRegistries
 			cluster: &v3.Cluster{
 				Spec: v3.ClusterSpec{
 					ClusterSpecBase: v3.ClusterSpecBase{

--- a/pkg/cluster/private_registry_test.go
+++ b/pkg/cluster/private_registry_test.go
@@ -111,7 +111,7 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 			},
 		},
 		{
-			name:           "global system default registry and no cluster default registry with corev1.Secret",
+			name:           "global system default registry and no cluster default registry with secret",
 			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
 			expectedConfig: base64.StdEncoding.EncodeToString([]byte(`{"auths":{"0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com":{"username":"testuser","password":"password","auth":"dGVzdHVzZXI6cGFzc3dvcmQ="}}}`)),
 			expectedError:  "",
@@ -145,7 +145,7 @@ func TestGeneratePrivateRegistryDockerConfig(t *testing.T) {
 			},
 		},
 		{
-			name:           "global system default registry and cluster default registry without corev1.Secret",
+			name:           "global system default registry and cluster default registry without secret",
 			expectedUrl:    "0123456789abcdef.dkr.ecr.us-east-1.amazonaws.com",
 			expectedConfig: "",
 			expectedError:  "",


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #42396 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
This was happening wile creating a RKE2/K3S downstream cluster with a different public registry that the upstream cluster. 

Both webhook and the Helm/Shell are created from the Rancher Agent. 

The code that created the rancher agent template was only getting the v2prov registry if Auth was set.

With that for public registries it was  getting the upstream default registry instead of the downstream one. 

 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Change the logic to get the RegistryUrl so it checks the RKE2 even if it doesn't have auth. 


 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Create RKE1 and RKE2 clusters with custom and non custom registries. 



### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit: 
       Added some cases: 
       * Registry set for upstream and downstream cluster with secret. 
       * Registry set for upstream and downstream cluster without secret.
       * Registry set for upstream cluster and not for downstream cluster.  
       

## QA Testing Considerations
Creation of RKE clusters with distinct registries. 

Despite the issue being reported for clusters without secrets I had to change some code execution so please also test with private registry. 
 
### Regressions Considerations 
I Tried my best to keep the same behavior as the existing one.  I don't think we can have a regression with this one. 
