### PR TITLE
Changing ci to not run integration tests in parallel

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -159,7 +159,7 @@ export CATTLE_TEST_CONFIG=$(pwd)/config.yaml # used by integration tests and tes
 }
 
 echo Running go integration tests
-go test -v -failfast ./tests/v2/integration/... || {
+go test -v -failfast -p 1 ./tests/v2/integration/... || {
   dump_rancher_logs
   exit 1
 }

--- a/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
+++ b/tests/v2/integration/catalogv2/rancher_managed_charts_test.go
@@ -121,7 +121,7 @@ func (w *RancherManagedChartsTest) resetSettings() {
 }
 
 func TestRancherManagedChartsSuite(t *testing.T) {
-	//suite.Run(t, new(RancherManagedChartsTest))
+	suite.Run(t, new(RancherManagedChartsTest))
 }
 
 func (w *RancherManagedChartsTest) TestInstallChartLatestVersion() {


### PR DESCRIPTION
By default, Go runs tests in different packages in parallel. This is disabled by using the -p flag.
The RancherManagedChartsSuite changes some CRDs during it's run which may cause other tests to fail sometimes. There may be other suites the do the same