### PR TITLE
[release/v2.7] Stop printing debug data if etcd restore test succeeds

### DIFF
--- a/tests/v2prov/operations/etcdsnapshot.go
+++ b/tests/v2prov/operations/etcdsnapshot.go
@@ -25,15 +25,13 @@ import (
 )
 
 func RunSnapshotCreateTest(t *testing.T, clients *clients.Clients, c *v1.Cluster, configMap corev1.ConfigMap, targetNode string) *rkev1.ETCDSnapshot {
-	var dumpDebugData = true
 	defer func() {
-		if dumpDebugData {
+		if t.Failed() {
 			data, newErr := cluster.GatherDebugData(clients, c)
 			if newErr != nil {
 				logrus.Error(newErr)
 			}
-			logrus.Errorf("cluster %s etcd snapshot creation operation failed", c.Name)
-			logrus.Errorf("cluster %s test data bundle: \n%s", c.Name, data)
+			fmt.Printf("cluster %s etcd snapshot creation operation failed\ncluster %s test data bundle: \n%s", c.Name, c.Name, data)
 		}
 	}()
 
@@ -100,7 +98,6 @@ func RunSnapshotCreateTest(t *testing.T, clients *clients.Clients, c *v1.Cluster
 		return rkeControlPlane.Status.ETCDSnapshotCreatePhase == rkev1.ETCDSnapshotPhaseFinished, nil
 	})
 	if err != nil {
-		dumpDebugData = false
 		t.Fatal(err)
 	}
 
@@ -157,20 +154,17 @@ func RunSnapshotCreateTest(t *testing.T, clients *clients.Clients, c *v1.Cluster
 
 	// The client will return a configmap object but it will not have anything populated.
 	assert.Equal(t, "", newCM.Name)
-	dumpDebugData = false
 	return snapshot
 }
 
 func RunSnapshotRestoreTest(t *testing.T, clients *clients.Clients, c *v1.Cluster, snapshotName string, expectedConfigMap corev1.ConfigMap, expectedNodeCount int) {
-	var dumpDebugData = true
 	defer func() {
-		if dumpDebugData {
+		if t.Failed() {
 			data, newErr := cluster.GatherDebugData(clients, c)
 			if newErr != nil {
 				logrus.Error(newErr)
 			}
-			logrus.Errorf("cluster %s etcd snapshot restore operation failed", c.Name)
-			logrus.Errorf("cluster %s test data bundle: \n%s", c.Name, data)
+			fmt.Printf("cluster %s etcd snapshot restore operation failed\ncluster %s test data bundle: \n%s", c.Name, c.Name, data)
 		}
 	}()
 


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/42778
 
## Problem
Provisioning operations tests were printing false failures even if the tests were succeeding

## Solution
Set the dump variable to false if the test succeeds
 
## Testing


## Engineering Testing
### Manual Testing
Look at Drone logs

### Automated Testing
* Test types added/modified:
    * Integration (v2prov Framework)

Summary: Modify v2prov integration test to disable test data collection/dumping if the test is successful

### Regressions Considerations
None