### PR TITLE
Change DynamicSchema generation to go off of .metadata.Name rather than .spec.Displayname

### DIFF
--- a/pkg/controllers/management/drivers/nodedriver/machine_driver.go
+++ b/pkg/controllers/management/drivers/nodedriver/machine_driver.go
@@ -18,6 +18,7 @@ import (
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
+	"github.com/rancher/wrangler/pkg/name"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -100,14 +101,11 @@ func (m *Lifecycle) download(obj *v32.NodeDriver) (*v32.NodeDriver, error) {
 		forceUpdate = true
 	}
 
-	err := errs.New("not found")
 	// if node driver was created, we also activate the driver by default
-	driver := drivers.NewDynamicDriver(obj.Spec.Builtin, obj.Spec.DisplayName, obj.Spec.URL, obj.Spec.Checksum)
-	schemaName := obj.Spec.DisplayName + "config"
-	var existingSchema *v32.DynamicSchema
-	if obj.Spec.DisplayName != "" {
-		existingSchema, err = m.schemaLister.Get("", schemaName)
-	}
+	driver := drivers.NewDynamicDriver(obj.Spec.Builtin, obj.ObjectMeta.Name, obj.Spec.URL, obj.Spec.Checksum)
+	schemaName := name.SafeConcatName(obj.ObjectMeta.Name + "config")
+
+	existingSchema, err := m.schemaLister.Get("", schemaName)
 
 	if driver.Exists() && err == nil && !forceUpdate {
 		// add credential schema
@@ -221,7 +219,7 @@ func (m *Lifecycle) download(obj *v32.NodeDriver) (*v32.NodeDriver, error) {
 			ResourceFields: resourceFields,
 		},
 	}
-	dynamicSchema.Name = obj.Spec.DisplayName + "config"
+	dynamicSchema.Name = name.SafeConcatName(obj.ObjectMeta.Name + "config")
 	dynamicSchema.OwnerReferences = []metav1.OwnerReference{
 		{
 			UID:        obj.UID,
@@ -231,7 +229,7 @@ func (m *Lifecycle) download(obj *v32.NodeDriver) (*v32.NodeDriver, error) {
 		},
 	}
 	dynamicSchema.Labels = map[string]string{}
-	dynamicSchema.Labels[driverNameLabel] = obj.Spec.DisplayName
+	dynamicSchema.Labels[driverNameLabel] = obj.ObjectMeta.Name
 
 	_, err = m.schemaClient.Create(dynamicSchema)
 	if err != nil {
@@ -254,7 +252,7 @@ func (m *Lifecycle) download(obj *v32.NodeDriver) (*v32.NodeDriver, error) {
 }
 
 func (m *Lifecycle) createCredSchema(obj *v32.NodeDriver, credFields map[string]v32.Field) (*v32.NodeDriver, error) {
-	name := credentialConfigSchemaName(obj.Spec.DisplayName)
+	name := credentialConfigSchemaName(obj.ObjectMeta.Name)
 	credSchema, err := m.schemaLister.Get("", name)
 
 	if name == "amazonec2credentialconfig" {
@@ -303,7 +301,7 @@ func (m *Lifecycle) checkDriverVersion(obj *v32.NodeDriver) bool {
 		return true
 	}
 
-	driverName := strings.TrimPrefix(obj.Spec.DisplayName, drivers.DockerMachineDriverPrefix)
+	driverName := strings.TrimPrefix(obj.ObjectMeta.Name, drivers.DockerMachineDriverPrefix)
 
 	if _, ok := DriverToSchemaFields[driverName]; ok {
 		if val, ok := obj.Annotations[uiFieldHintsAnno]; !ok || val == "" {
@@ -368,12 +366,12 @@ func (m *Lifecycle) Updated(obj *v32.NodeDriver) (runtime.Object, error) {
 		return obj, err
 	}
 
-	if err := m.createOrUpdateNodeForEmbeddedType(obj.Spec.DisplayName+"config", obj.Spec.DisplayName+"Config", obj.Spec.Active); err != nil {
+	if err := m.createOrUpdateNodeForEmbeddedType(obj.ObjectMeta.Name+"config", obj.ObjectMeta.Name+"Config", obj.Spec.Active); err != nil {
 		return obj, err
 	}
 
-	if err := m.createOrUpdateNodeForEmbeddedTypeCredential(credentialConfigSchemaName(obj.Spec.DisplayName),
-		obj.Spec.DisplayName+"credentialConfig", obj.Spec.Active || obj.Spec.AddCloudCredential); err != nil {
+	if err := m.createOrUpdateNodeForEmbeddedTypeCredential(credentialConfigSchemaName(obj.ObjectMeta.Name),
+		obj.ObjectMeta.Name+"credentialConfig", obj.Spec.Active || obj.Spec.AddCloudCredential); err != nil {
 		return obj, err
 	}
 
@@ -385,7 +383,7 @@ func (m *Lifecycle) Updated(obj *v32.NodeDriver) (runtime.Object, error) {
 
 func (m *Lifecycle) Remove(obj *v32.NodeDriver) (runtime.Object, error) {
 	schemas, err := m.schemaClient.List(metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", driverNameLabel, obj.Spec.DisplayName),
+		LabelSelector: fmt.Sprintf("%s=%s", driverNameLabel, obj.ObjectMeta.Name),
 	})
 	if err != nil {
 		return obj, err
@@ -397,7 +395,7 @@ func (m *Lifecycle) Remove(obj *v32.NodeDriver) (runtime.Object, error) {
 		}
 		logrus.Infof("Deleting schema %s done", schema.Name)
 	}
-	if err := m.createOrUpdateNodeForEmbeddedType(obj.Spec.DisplayName+"config", obj.Spec.DisplayName+"Config", false); err != nil {
+	if err := m.createOrUpdateNodeForEmbeddedType(obj.ObjectMeta.Name+"config", obj.ObjectMeta.Name+"Config", false); err != nil {
 		return obj, err
 	}
 	return obj, nil


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42378 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
We want to use the `.metdata.Name` field of the node driver object rather than the `.spec.DisplayName` field since the displayName field isn't guaranteed unique. This was already changed in the webhook in https://github.com/rancher/webhook/pull/277  
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
1. fixed in webhook to look at the right field
2. fixed in rancher to generate the dynamic schemas based on the new field 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Nothing too crazy - just make sure that node driver enabling/disabling still works as well as validation that one can rename node drivers to have conflicting display names and it still all works. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
None done - this shouldn't effect anything other than fixing the dynamic schema generation to work off of the guaranteed unique field rather than just the display name. 

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * None
* If "None" - Reason: nothing changed since this is just changing the string field the dynamic schemas get generated from. For built-in node drivers this is the same string as of right now. For out-of-tree drivers this could solve a future bug where the names were different and thus deletion/disabling could get into some really weird states documented in https://github.com/rancher/rancher/issues/42378
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
Would be good to just make sure nodedriver deletion/disabling works the same as before. 
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
NodeDriver deletion/disabling should just work as it did before. The only difference is the dynamic CRDS would be keying off of a different field. 

Existing / newly added automated tests that provide evidence there are no regressions:
* n/a