### PR TITLE
[Flaky-test] updating functionalities for cluster_repo_test

### DIFF
--- a/tests/v2/integration/catalogv2/cluster_repo_test.go
+++ b/tests/v2/integration/catalogv2/cluster_repo_test.go
@@ -343,6 +343,27 @@ func (c *ClusterRepoTestSuite) createRoleTemplates(roleName1, roleName2 string) 
 	return roleTemplate1, roleTemplate2
 }
 
+// createClusterRoleTemplateBindings creates ClusterRoleTemplateBindings for two users with corresponding roles.
+func (c *ClusterRepoTestSuite) createClusterRoleTemplateBindings(user1ID, user2ID, role1ID, role2ID string) {
+	// Create ClusterRoleTemplateBinding for user1 and role1
+	_, err := c.client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
+		Name:            "cluster-role-template-binding-1",
+		ClusterID:       c.clusterID,
+		RoleTemplateID:  role1ID,
+		UserPrincipalID: fmt.Sprintf("%s://%s", c.clusterID, user1ID),
+	})
+	require.NoError(c.T(), err)
+
+	// Create ClusterRoleTemplateBinding for user2 and role2
+	_, err = c.client.Management.ClusterRoleTemplateBinding.Create(&management.ClusterRoleTemplateBinding{
+		Name:            "cluster-role-template-binding-2",
+		ClusterID:       c.clusterID,
+		RoleTemplateID:  role2ID,
+		UserPrincipalID: fmt.Sprintf("%s://%s", c.clusterID, user2ID),
+	})
+	require.NoError(c.T(), err)
+}
+
 // pollUntilDownloaded Polls until the ClusterRepo of the given name has been downloaded (by comparing prevDownloadTime against the current DownloadTime)
 func (c *ClusterRepoTestSuite) pollUntilDownloaded(ClusterRepoName string, prevDownloadTime metav1.Time) (*stevev1.SteveAPIObject, error) {
 	var clusterRepo *stevev1.SteveAPIObject

--- a/tests/v2/integration/catalogv2/cluster_repo_test.go
+++ b/tests/v2/integration/catalogv2/cluster_repo_test.go
@@ -105,8 +105,6 @@ func (c *ClusterRepoTestSuite) SetupSuite() {
 	c.clusterID = LocalClusterID
 	c.catalogClient, err = c.client.GetClusterCatalogClient(c.clusterID)
 	require.NoError(c.T(), err)
-
-	ChartSmallForkDir = fmt.Sprintf("../../../../management-state/git-repo/%s", ChartsSmallForkRepoName)
 }
 
 // TestHTTPRepo tests CREATE, UPDATE, and DELETE operations of HTTP ClusterRepo resources


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
[test_cluster_catalog_creation Issue](https://github.com/rancher/rancher/issues/42339)
 
## Problem

- Old Flaky Test written in Python 5 years ago.
- Randomly breaks the Drone Build Pipeline.

 
## Solution
Removing the test in Python, the same functionalities test are partially tested by:
[catalogv2/cluster_repo_test.go](https://github.com/rancher/rancher/blob/release/v2.8/tests/v2/integration/catalogv2/cluster_repo_test.go)

This is the PR updating the test functionalities for replacing the removed python function from this [PR](https://github.com/rancher/rancher/pull/42753)