### PR TITLE
[2.8] uuid-unmigration: when an error happens, make sure it is actually logged

### DIFF
--- a/pkg/agent/clean/adunmigration/ldap.go
+++ b/pkg/agent/clean/adunmigration/ldap.go
@@ -245,10 +245,12 @@ func prepareClientContexts(clientConfig *restclient.Config) (*config.ScaledConte
 
 	sc, err := scaledContext(restConfig)
 	if err != nil {
+		logrus.Errorf("[%v] failed to create scaled context: %v", migrateAdUserOperation, err)
 		return nil, nil, err
 	}
 	adConfig, err := adConfiguration(sc)
 	if err != nil {
+		logrus.Errorf("[%v] failed to acquire ad configuration: %v", migrateAdUserOperation, err)
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
This is a forward port of https://github.com/rancher/rancher/pull/42762

## Issue: https://github.com/rancher/rancher/issues/42734
 
## Problem
In a few cases, the unmigration logic was running into an error and returning it without writing it to logrus. In the Rancher startup case, due to this running in a goroutine, the return value is not kept and was getting silently discarded, leading to cases where the unmigration could enter a "Failed" status without writing any relevant details to the logs.

## Solution
I took the simplest route and made sure that the unmigration self-reports any errors as it goes along. There should be no logic changes here, just increased error reporting.
 
## Testing
This actually uncovered a fun bug with AD Allowed Users, which I'll fix in an upcoming PR. You can thus test the changes by running the script in standalone mode against any cluster with an empty allowed users list, and you should see:
```
time="2023-09-12T02:03:43Z" level=info msg="[migrate-ad-user] beginning ad-guid unmigration"
time="2023-09-12T02:03:43Z" level=error msg="[migrate-ad-user] unable to migrate allowed users: [migrate-ad-user] expected list for allowed principal ids, got <nil>"
time="2023-09-12T02:03:43Z" level=fatal msg="[migrate-ad-user] expected list for allowed principal ids, got <nil>"
```

## Engineering Testing
### Manual Testing
This test only affects output logging. I manually set up a failure scenario, and ensured that the logs are now printed to console when running the script.

### Automated Testing
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change

## QA Testing Considerations
These changes may uncover new failure states in the unmigration logic, that's the whole point. We may wish to run through the unmigration testing suite again once it is merged and look for additional problems. (Don't block this PR if this happens, make a new issue with the details.)
 