### PR TITLE
removing explicit check for exact registry name from assertions

### DIFF
--- a/tests/validation/tests/v3_api/test_airgap.py
+++ b/tests/validation/tests/v3_api/test_airgap.py
@@ -109,8 +109,8 @@ def test_deploy_airgap_nodes():
                                                    AGENT_REG_CMD)
         results.append(deploy_result)
     for result in results:
-        assert "Downloaded newer image for {}/rancher/rancher-agent".format(
-            bastion_node.host_name) in result[1]
+        assert "Downloaded newer image for " in result[1]
+        assert "/rancher/rancher-agent" in result[1]
 
 
 def test_add_rancher_images_to_private_registry():
@@ -118,8 +118,8 @@ def test_add_rancher_images_to_private_registry():
     save_res, load_res = add_rancher_images_to_private_registry(bastion_node)
     assert "Image pull success: rancher/rancher:{}".format(
         RANCHER_SERVER_VERSION) in save_res[0]
-    assert "The push refers to repository [{}/rancher/rancher]".format(
-        bastion_node.host_name) in load_res[0]
+    assert "The push refers to repository " in load_res[0]
+    assert "/rancher/rancher]" in load_res[0]
 
 
 def test_add_images_to_private_registry():


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/92
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
when we don't use the FQDN as the registry hostname, the test was failing. 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
remove explicit check for the registry name. Leave in the first `/`, which implies that it is being pulled from a registry
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

