### PR TITLE
Added clarifications for ClusterName field

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authz_types.go
+++ b/pkg/apis/management.cattle.io/v3/authz_types.go
@@ -375,7 +375,8 @@ type ClusterRoleTemplateBinding struct {
 	// +optional
 	GroupPrincipalName string `json:"groupPrincipalName,omitempty" norman:"noupdate,type=reference[principal]"`
 
-	// ClusterName is the name of the cluster to which a subject is added. Immutable.
+	// ClusterName is the metadata.name of the cluster to which a subject is added.
+	// Must match the namespace. Immutable.
 	// +kubebuilder:validation:Required
 	ClusterName string `json:"clusterName" norman:"required,noupdate,type=reference[cluster]"`
 

--- a/pkg/crds/yaml/generated/management.cattle.io_clusterroletemplatebindings.yaml
+++ b/pkg/crds/yaml/generated/management.cattle.io_clusterroletemplatebindings.yaml
@@ -26,8 +26,8 @@ spec:
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           clusterName:
-            description: ClusterName is the name of the cluster to which a subject
-              is added. Immutable.
+            description: ClusterName is the metadata.name of the cluster to which
+              a subject is added. Must match the namespace. Immutable.
             type: string
           groupName:
             description: GroupName is the name of the group subject added to the cluster.


### PR DESCRIPTION
It's not initially clear from `kubectl explain clusterroletemplatebindings` that the ClusterName must match the namespace. I also added the clarification that it must be the Name, not the DisplayName of the cluster.