### PR TITLE
[2.8]allow customization of custom clusters' registration command

### DIFF
--- a/tests/framework/extensions/clusters/clusterconfig.go
+++ b/tests/framework/extensions/clusters/clusterconfig.go
@@ -3,9 +3,7 @@ package clusters
 import (
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
-	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	provisioningInput "github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
-	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
 )
 
 type ClusterConfig struct {
@@ -13,8 +11,8 @@ type ClusterConfig struct {
 	CNI                  string                                   `json:"cni" yaml:"cni"`
 	PSACT                string                                   `json:"psact" yaml:"psact"`
 	PNI                  bool                                     `json:"pni" yaml:"pni"`
-	NodesAndRoles        *[]machinepools.NodeRoles                `json:"nodesAndRoles" yaml:"nodesAndRoles" default:"[]"`
-	NodesAndRolesRKE1    *[]nodepools.NodeRoles                   `json:"nodesAndRolesRKE1" yaml:"nodesAndRolesRKE1" default:"[]"`
+	NodePools            []provisioningInput.NodePools            `json:"nodepools" yaml:"nodepools"`
+	MachinePools         []provisioningInput.MachinePools         `json:"machinepools" yaml:"machinepools"`
 	Providers            *[]string                                `json:"providers" yaml:"providers"`
 	NodeProviders        *[]string                                `json:"nodeProviders" yaml:"nodeProviders"`
 	Hardened             bool                                     `json:"hardened" yaml:"hardened"`
@@ -33,27 +31,27 @@ type ClusterConfig struct {
 }
 
 // ConvertConfigToClusterConfig converts the config from (user) provisioning input to a cluster config
-func ConvertConfigToClusterConfig(clustersConfig *provisioningInput.Config) *ClusterConfig {
+func ConvertConfigToClusterConfig(provisioningConfig *provisioningInput.Config) *ClusterConfig {
 	var newConfig ClusterConfig
-	newConfig.AddOnConfig = clustersConfig.AddOnConfig
-	newConfig.NodesAndRoles = &clustersConfig.NodesAndRoles
-	newConfig.NodesAndRolesRKE1 = &clustersConfig.NodesAndRolesRKE1
-	newConfig.AgentEnvVars = clustersConfig.AgentEnvVars
-	newConfig.Networking = clustersConfig.Networking
-	newConfig.Advanced = clustersConfig.Advanced
-	newConfig.Providers = &clustersConfig.Providers
-	newConfig.NodeProviders = &clustersConfig.NodeProviders
-	newConfig.ClusterAgent = clustersConfig.ClusterAgent
-	newConfig.FleetAgent = clustersConfig.FleetAgent
-	newConfig.Etcd = clustersConfig.Etcd
-	newConfig.LabelsAndAnnotations = clustersConfig.LabelsAndAnnotations
-	newConfig.Registries = clustersConfig.Registries
-	newConfig.UpgradeStrategy = clustersConfig.UpgradeStrategy
+	newConfig.AddOnConfig = provisioningConfig.AddOnConfig
+	newConfig.MachinePools = provisioningConfig.MachinePools
+	newConfig.NodePools = provisioningConfig.NodePools
+	newConfig.AgentEnvVars = provisioningConfig.AgentEnvVars
+	newConfig.Networking = provisioningConfig.Networking
+	newConfig.Advanced = provisioningConfig.Advanced
+	newConfig.Providers = &provisioningConfig.Providers
+	newConfig.NodeProviders = &provisioningConfig.NodeProviders
+	newConfig.ClusterAgent = provisioningConfig.ClusterAgent
+	newConfig.FleetAgent = provisioningConfig.FleetAgent
+	newConfig.Etcd = provisioningConfig.Etcd
+	newConfig.LabelsAndAnnotations = provisioningConfig.LabelsAndAnnotations
+	newConfig.Registries = provisioningConfig.Registries
+	newConfig.UpgradeStrategy = provisioningConfig.UpgradeStrategy
 
-	newConfig.Hardened = clustersConfig.Hardened
-	newConfig.PSACT = clustersConfig.PSACT
-	newConfig.PNI = clustersConfig.PNI
-	newConfig.ClusterSSHTests = clustersConfig.ClusterSSHTests
+	newConfig.Hardened = provisioningConfig.Hardened
+	newConfig.PSACT = provisioningConfig.PSACT
+	newConfig.PNI = provisioningConfig.PNI
+	newConfig.ClusterSSHTests = provisioningConfig.ClusterSSHTests
 
 	return &newConfig
 }

--- a/tests/framework/extensions/provisioning/customcluster.go
+++ b/tests/framework/extensions/provisioning/customcluster.go
@@ -1,0 +1,14 @@
+package provisioning
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type CustomClusterConfig struct {
+	ExternalNodeProvider ExternalNodeProvider `json:"externalNodeProvider" yaml:"externalNodeProvider"`
+	NodeLabels           map[string]string    `json:"nodeLabels" yaml:"nodeLabels"`
+	NodeTaints           []corev1.Taint       `json:"nodeTaints" yaml:"nodeTaints"`
+	SpecifyPrivateIP     bool                 `json:"specifyPrivateIP" yaml:"specifyPrivateIP"`
+	SpecifyPublicIP      bool                 `json:"specifyPublicIP" yaml:"specifyPublicIP"`
+	NodeNamePrefix       string               `json:"nodeNamePrefix" yaml:"nodeNamePrefix"`
+}

--- a/tests/framework/extensions/provisioning/verify.go
+++ b/tests/framework/extensions/provisioning/verify.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
@@ -218,7 +217,7 @@ func VerifyDeleteRKE2K3SCluster(t *testing.T, client *rancher.Client, clusterID 
 	require.NoError(t, err)
 
 	err = wait.WatchWait(watchInterface, func(event watch.Event) (ready bool, err error) {
-		cluster := event.Object.(*apisV1.Cluster)
+		cluster := event.Object.(*provv1.Cluster)
 		if event.Type == watch.Error {
 			return false, fmt.Errorf("error: unable to delete cluster %s", cluster.ObjectMeta.Name)
 		} else if event.Type == watch.Deleted {

--- a/tests/framework/extensions/provisioninginput/config.go
+++ b/tests/framework/extensions/provisioninginput/config.go
@@ -5,6 +5,7 @@ import (
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type Version string
@@ -33,65 +34,87 @@ const (
 	VsphereProviderName   ProviderName = "vsphere"
 )
 
-var AllRolesPool = machinepools.NodeRoles{
-	Etcd:         true,
-	ControlPlane: true,
-	Worker:       true,
-	Quantity:     1,
+var AllRolesMachinePool = MachinePools{
+	NodeRoles: machinepools.NodeRoles{
+		Etcd:         true,
+		ControlPlane: true,
+		Worker:       true,
+		Quantity:     1,
+	},
 }
 
-var EtcdControlPlanePool = machinepools.NodeRoles{
-	Etcd:         true,
-	ControlPlane: true,
-	Quantity:     1,
+var EtcdControlPlaneMachinePool = MachinePools{
+	NodeRoles: machinepools.NodeRoles{
+		Etcd:         true,
+		ControlPlane: true,
+		Quantity:     1,
+	},
 }
 
-var EtcdPool = machinepools.NodeRoles{
-	Etcd:     true,
-	Quantity: 1,
+var EtcdMachinePool = MachinePools{
+	NodeRoles: machinepools.NodeRoles{
+		Etcd:     true,
+		Quantity: 1,
+	},
 }
 
-var ControlPlanePool = machinepools.NodeRoles{
-	ControlPlane: true,
-	Quantity:     1,
+var ControlPlaneMachinePool = MachinePools{
+	NodeRoles: machinepools.NodeRoles{
+		ControlPlane: true,
+		Quantity:     1,
+	},
 }
 
-var WorkerPool = machinepools.NodeRoles{
-	Worker:   true,
-	Quantity: 1,
+var WorkerMachinePool = MachinePools{
+	NodeRoles: machinepools.NodeRoles{
+		Worker:   true,
+		Quantity: 1,
+	},
 }
 
-var WindowsPool = machinepools.NodeRoles{
-	Windows:  true,
-	Quantity: 1,
+var WindowsMachinePool = MachinePools{
+	NodeRoles: machinepools.NodeRoles{
+		Windows:  true,
+		Quantity: 1,
+	},
 }
 
-var RKE1AllRolesPool = nodepools.NodeRoles{
-	Etcd:         true,
-	ControlPlane: true,
-	Worker:       true,
-	Quantity:     1,
+var AllRolesNodePool = NodePools{
+	NodeRoles: nodepools.NodeRoles{
+		Etcd:         true,
+		ControlPlane: true,
+		Worker:       true,
+		Quantity:     1,
+	},
 }
 
-var RKE1EtcdControlPlanePool = nodepools.NodeRoles{
-	Etcd:         true,
-	ControlPlane: true,
-	Quantity:     1,
+var EtcdControlPlaneNodePool = NodePools{
+	NodeRoles: nodepools.NodeRoles{
+		Etcd:         true,
+		ControlPlane: true,
+		Quantity:     1,
+	},
 }
 
-var RKE1EtcdPool = nodepools.NodeRoles{
-	Etcd:     true,
-	Quantity: 1,
+var EtcdNodePool = NodePools{
+	NodeRoles: nodepools.NodeRoles{
+		Etcd:     true,
+		Quantity: 1,
+	},
 }
 
-var RKE1ControlPlanePool = nodepools.NodeRoles{
-	ControlPlane: true,
-	Quantity:     1,
+var ControlPlaneNodePool = NodePools{
+	NodeRoles: nodepools.NodeRoles{
+		ControlPlane: true,
+		Quantity:     1,
+	},
 }
 
-var RKE1WorkerPool = nodepools.NodeRoles{
-	Worker:   true,
-	Quantity: 1,
+var WorkerNodePool = NodePools{
+	NodeRoles: nodepools.NodeRoles{
+		Worker:   true,
+		Quantity: 1,
+	},
 }
 
 // String stringer for the ProviderName
@@ -148,9 +171,28 @@ type Registries struct {
 	RKE2Username   string                       `json:"rke2Username" yaml:"rke2Username"`
 }
 
+type Pools struct {
+	NodeLabels             map[string]string `json:"nodeLabels" yaml:"nodeLabels"`
+	NodeTaints             []corev1.Taint    `json:"nodeTaints" yaml:"nodeTaints"`
+	SpecifyCustomPrivateIP bool              `json:"specifyPrivateIP" yaml:"specifyPrivateIP"`
+	SpecifyCustomPublicIP  bool              `json:"specifyPublicIP" yaml:"specifyPublicIP" default:"true"`
+	CustomNodeNameSuffix   string            `json:"nodeNameSuffix" yaml:"nodeNameSuffix"`
+}
+
+type MachinePools struct {
+	Pools
+	NodeRoles machinepools.NodeRoles `json:"nodeRoles" yaml:"nodeRoles" default:"[]"`
+	IsSecure  bool                   `json:"isSecure" yaml:"isSecure" default:"false"`
+}
+
+type NodePools struct {
+	Pools
+	NodeRoles nodepools.NodeRoles `json:"nodeRoles" yaml:"nodeRoles" default:"[]"`
+}
+
 type Config struct {
-	NodesAndRoles          []machinepools.NodeRoles                 `json:"nodesAndRoles" yaml:"nodesAndRoles" default:"[]"`
-	NodesAndRolesRKE1      []nodepools.NodeRoles                    `json:"nodesAndRolesRKE1" yaml:"nodesAndRolesRKE1" default:"[]"`
+	NodePools              []NodePools                              `json:"nodePools" yaml:"nodePools"`
+	MachinePools           []MachinePools                           `json:"machinePools" yaml:"machinePools"`
 	Providers              []string                                 `json:"providers" yaml:"providers"`
 	NodeProviders          []string                                 `json:"nodeProviders" yaml:"nodeProviders"`
 	Hardened               bool                                     `json:"hardened" yaml:"hardened"`

--- a/tests/v2/codecoverage/setuprancher/main.go
+++ b/tests/v2/codecoverage/setuprancher/main.go
@@ -289,7 +289,11 @@ func createTestCluster(client, adminClient *rancher.Client, numClusters int, clu
 		}
 
 		err = kwait.Poll(500*time.Millisecond, 10*time.Minute, func() (done bool, err error) {
-			_, err = nodepools.NodePoolSetup(client, clustersConfig.NodesAndRolesRKE1, clusterResp.ID, nodeTemplateResp.ID)
+			var nodeRoles []nodepools.NodeRoles
+			for _, nodepool := range clustersConfig.NodePools {
+				nodeRoles = append(nodeRoles, nodepool.NodeRoles)
+			}
+			_, err = nodepools.NodePoolSetup(client, nodeRoles, clusterResp.ID, nodeTemplateResp.ID)
 			if err != nil {
 				return false, nil
 			}

--- a/tests/v2/validation/provisioning/airgap/k3s_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/airgap/k3s_custom_cluster_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
-	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	provisioning "github.com/rancher/rancher/tests/framework/extensions/provisioning"
 	"github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
@@ -81,7 +80,7 @@ func (a *AirGapK3SCustomClusterTestSuite) SetupSuite() {
 }
 
 func (a *AirGapK3SCustomClusterTestSuite) TestProvisioningK3SCustomCluster() {
-	a.clustersConfig.NodesAndRoles = []machinepools.NodeRoles{provisioninginput.AllRolesPool}
+	a.clustersConfig.MachinePools = []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
 
 	tests := []struct {
 		name   string
@@ -96,7 +95,7 @@ func (a *AirGapK3SCustomClusterTestSuite) TestProvisioningK3SCustomCluster() {
 }
 
 func (a *AirGapK3SCustomClusterTestSuite) TestProvisioningUpgradeK3SCustomCluster() {
-	a.clustersConfig.NodesAndRoles = []machinepools.NodeRoles{provisioninginput.AllRolesPool}
+	a.clustersConfig.MachinePools = []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
 
 	k3sVersions, err := kubernetesversions.ListK3SAllVersions(a.client)
 	require.NoError(a.T(), err)

--- a/tests/v2/validation/provisioning/airgap/rke1_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/airgap/rke1_custom_cluster_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
 	provisioning "github.com/rancher/rancher/tests/framework/extensions/provisioning"
 	"github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
-	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/rancher/rancher/tests/v2/validation/pipeline/rancherha/corralha"
@@ -82,7 +81,7 @@ func (a *AirGapRKE1CustomClusterTestSuite) SetupSuite() {
 }
 
 func (a *AirGapRKE1CustomClusterTestSuite) TestProvisioningRKE1CustomCluster() {
-	a.clustersConfig.NodesAndRolesRKE1 = []nodepools.NodeRoles{provisioninginput.RKE1AllRolesPool}
+	a.clustersConfig.NodePools = []provisioninginput.NodePools{provisioninginput.AllRolesNodePool}
 
 	tests := []struct {
 		name   string
@@ -97,7 +96,7 @@ func (a *AirGapRKE1CustomClusterTestSuite) TestProvisioningRKE1CustomCluster() {
 }
 
 func (a *AirGapRKE1CustomClusterTestSuite) TestProvisioningUpgradeRKE1CustomCluster() {
-	a.clustersConfig.NodesAndRolesRKE1 = []nodepools.NodeRoles{provisioninginput.RKE1AllRolesPool}
+	a.clustersConfig.NodePools = []provisioninginput.NodePools{provisioninginput.AllRolesNodePool}
 
 	rke1Versions, err := kubernetesversions.ListRKE1AllVersions(a.client)
 	require.NoError(a.T(), err)

--- a/tests/v2/validation/provisioning/airgap/rke2_custom_cluster_test.go
+++ b/tests/v2/validation/provisioning/airgap/rke2_custom_cluster_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
-	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	provisioning "github.com/rancher/rancher/tests/framework/extensions/provisioning"
 	"github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
@@ -81,7 +80,7 @@ func (a *AirGapRKE2CustomClusterTestSuite) SetupSuite() {
 }
 
 func (a *AirGapRKE2CustomClusterTestSuite) TestProvisioningRKE2CustomCluster() {
-	a.clustersConfig.NodesAndRoles = []machinepools.NodeRoles{provisioninginput.AllRolesPool}
+	a.clustersConfig.MachinePools = []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
 
 	tests := []struct {
 		name   string
@@ -96,7 +95,7 @@ func (a *AirGapRKE2CustomClusterTestSuite) TestProvisioningRKE2CustomCluster() {
 }
 
 func (a *AirGapRKE2CustomClusterTestSuite) TestProvisioningUpgradeRKE2CustomCluster() {
-	a.clustersConfig.NodesAndRoles = []machinepools.NodeRoles{provisioninginput.AllRolesPool}
+	a.clustersConfig.MachinePools = []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
 
 	rke2Versions, err := kubernetesversions.ListRKE2AllVersions(a.client)
 	require.NoError(a.T(), err)

--- a/tests/v2/validation/provisioning/k3s/README.md
+++ b/tests/v2/validation/provisioning/k3s/README.md
@@ -23,18 +23,36 @@ provisioningInput is needed to the run the K3S tests, specifically kubernetesVer
 ```json
 "provisioningInput": {
     // for custom clusters, len(nodesAndRoles) should be equal to len(awsEc2Config)
-    "nodesAndRoles": [
+        "machinePools": [
       {
-        "etcd": true,
-        "controlplane": true,
-        "quantity": 1,
+        "nodeRoles": {
+          "etcd": true,
+          "controlplane": true,
+          "worker": false,
+          "quantity": 1,
+        },
       },
       {
-        "worker": true,
-        "quantity": 2,
+        "nodeRoles": {
+          "worker": true,
+          "quantity": 2,
+        },
+        "nodeLabels" {
+          "label1": "value1",
+          "label2": "value2",
+        },
+        "nodeTaints" [
+          { "key": "TestKey",
+            "value": "testValue",
+            "effect": "NoSchedule",
+          }
+        ],
+        "specifyPrivateIP": false,
+        "specifyPublicIP": true,
+        "nodeNamePrefix": "qa",
       },
     ],
-    "k3sKubernetesVersion": ["v1.24.4+k3s1"],
+    "k3sKubernetesVersion": ["v1.26.8+k3s1"],
     "providers": ["linode", "aws", "azure", "harvester"],
     "nodeProviders": ["ec2"],
     "hardened": true,
@@ -201,9 +219,10 @@ Machine K3S config is the final piece needed for the config to run K3S provision
 For custom clusters, no machineConfig or credentials are needed. Currently only supported for ec2.
 
 Dependencies:
-* **Ensure you have nodeProviders in provisioningInput**
-* make sure that all roles are entered at least once
-* windows pool(s) should always be last in the config
+* **Ensure you have machinePools in provisioningInput**
+* make sure that all roles are entered at least once in machinePools.nodeRoles
+* ensure that nodeProviders is set
+
 ```json
 {
   "awsEC2Configs": {

--- a/tests/v2/validation/provisioning/k3s/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/k3s/post_kdm_oob_release_test.go
@@ -16,10 +16,10 @@ import (
 
 type KdmChecksTestSuite struct {
 	suite.Suite
-	session        *session.Session
-	client         *rancher.Client
-	ns             string
-	clustersConfig *provisioninginput.Config
+	session            *session.Session
+	client             *rancher.Client
+	ns                 string
+	provisioningConfig *provisioninginput.Config
 }
 
 const (
@@ -36,8 +36,8 @@ func (k *KdmChecksTestSuite) SetupSuite() {
 
 	k.ns = defaultNamespace
 
-	k.clustersConfig = new(provisioninginput.Config)
-	config.LoadConfig(provisioninginput.ConfigurationFileKey, k.clustersConfig)
+	k.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, k.provisioningConfig)
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(k.T(), err)
@@ -47,19 +47,19 @@ func (k *KdmChecksTestSuite) SetupSuite() {
 
 func (k *KdmChecksTestSuite) TestK3SK8sVersions() {
 	logrus.Infof("checking for valid k8s versions..")
-	require.GreaterOrEqual(k.T(), len(k.clustersConfig.K3SKubernetesVersions), 1)
+	require.GreaterOrEqual(k.T(), len(k.provisioningConfig.K3SKubernetesVersions), 1)
 	// fetching all available k8s versions from rancher
 	releasedK8sVersions, _ := kubernetesversions.ListK3SAllVersions(k.client)
-	logrus.Info("expected k8s versions : ", k.clustersConfig.K3SKubernetesVersions)
+	logrus.Info("expected k8s versions : ", k.provisioningConfig.K3SKubernetesVersions)
 	logrus.Info("k8s versions available on rancher server : ", releasedK8sVersions)
-	for _, expectedK8sVersion := range k.clustersConfig.K3SKubernetesVersions {
+	for _, expectedK8sVersion := range k.provisioningConfig.K3SKubernetesVersions {
 		require.Contains(k.T(), releasedK8sVersions, expectedK8sVersion)
 	}
 }
 
 func (k *KdmChecksTestSuite) TestProvisioningSingleNodeK3SClusters() {
-	require.GreaterOrEqual(k.T(), len(k.clustersConfig.Providers), 1)
-	permutations.RunTestPermutations(&k.Suite, "oobRelease-", k.client, k.clustersConfig, permutations.K3SProvisionCluster, nil, nil)
+	require.GreaterOrEqual(k.T(), len(k.provisioningConfig.Providers), 1)
+	permutations.RunTestPermutations(&k.Suite, "oobRelease-", k.client, k.provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
 }
 
 func TestPostKdmOutOfBandReleaseChecks(t *testing.T) {

--- a/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/k3s/provisioning_node_driver_test.go
@@ -7,7 +7,6 @@ import (
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters/kubernetesversions"
-	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	password "github.com/rancher/rancher/tests/framework/extensions/users/passwordgenerator"
@@ -24,7 +23,7 @@ type K3SNodeDriverProvisioningTestSuite struct {
 	client             *rancher.Client
 	session            *session.Session
 	standardUserClient *rancher.Client
-	clustersConfig     *provisioninginput.Config
+	provisioningConfig *provisioninginput.Config
 }
 
 func (k *K3SNodeDriverProvisioningTestSuite) TearDownSuite() {
@@ -35,16 +34,16 @@ func (k *K3SNodeDriverProvisioningTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	k.session = testSession
 
-	k.clustersConfig = new(provisioninginput.Config)
-	config.LoadConfig(provisioninginput.ConfigurationFileKey, k.clustersConfig)
+	k.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, k.provisioningConfig)
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(k.T(), err)
 
 	k.client = client
 
-	k.clustersConfig.K3SKubernetesVersions, err = kubernetesversions.Default(
-		k.client, clusters.K3SClusterType.String(), k.clustersConfig.K3SKubernetesVersions)
+	k.provisioningConfig.K3SKubernetesVersions, err = kubernetesversions.Default(
+		k.client, clusters.K3SClusterType.String(), k.provisioningConfig.K3SKubernetesVersions)
 	require.NoError(k.T(), err)
 
 	enabled := true
@@ -69,72 +68,31 @@ func (k *K3SNodeDriverProvisioningTestSuite) SetupSuite() {
 }
 
 func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SCluster() {
-	nodeRoles0 := []machinepools.NodeRoles{
-		{
-			ControlPlane: true,
-			Etcd:         true,
-			Worker:       true,
-			Quantity:     1,
-		},
-	}
-
-	nodeRoles1 := []machinepools.NodeRoles{
-		{
-			ControlPlane: true,
-			Etcd:         true,
-			Worker:       false,
-			Quantity:     1,
-		},
-		{
-			ControlPlane: false,
-			Etcd:         false,
-			Worker:       true,
-			Quantity:     1,
-		},
-	}
-
-	nodeRoles2 := []machinepools.NodeRoles{
-		{
-			ControlPlane: true,
-			Etcd:         false,
-			Worker:       false,
-			Quantity:     1,
-		},
-		{
-			ControlPlane: false,
-			Etcd:         true,
-			Worker:       false,
-			Quantity:     1,
-		},
-		{
-			ControlPlane: false,
-			Etcd:         false,
-			Worker:       true,
-			Quantity:     1,
-		},
-	}
+	nodeRolesAll := []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
+	nodeRolesShared := []provisioninginput.MachinePools{provisioninginput.EtcdControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+	nodeRolesDedicated := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
 
 	tests := []struct {
-		name      string
-		nodeRoles []machinepools.NodeRoles
-		client    *rancher.Client
+		name         string
+		machinePools []provisioninginput.MachinePools
+		client       *rancher.Client
 	}{
-		{"1 Node all roles " + provisioninginput.AdminClientName.String(), nodeRoles0, k.client},
-		{"1 Node all roles " + provisioninginput.StandardClientName.String(), nodeRoles0, k.standardUserClient},
-		{"2 nodes - etcd/cp roles per 1 node " + provisioninginput.AdminClientName.String(), nodeRoles1, k.client},
-		{"2 nodes - etcd/cp roles per 1 node " + provisioninginput.StandardClientName.String(), nodeRoles1, k.standardUserClient},
-		{"3 nodes - 1 role per node " + provisioninginput.AdminClientName.String(), nodeRoles2, k.client},
-		{"3 nodes - 1 role per node " + provisioninginput.StandardClientName.String(), nodeRoles2, k.standardUserClient},
+		{"1 Node all roles " + provisioninginput.AdminClientName.String(), nodeRolesAll, k.client},
+		{"1 Node all roles " + provisioninginput.StandardClientName.String(), nodeRolesAll, k.standardUserClient},
+		{"2 nodes - etcd/cp roles per 1 node " + provisioninginput.AdminClientName.String(), nodeRolesShared, k.client},
+		{"2 nodes - etcd/cp roles per 1 node " + provisioninginput.StandardClientName.String(), nodeRolesShared, k.standardUserClient},
+		{"3 nodes - 1 role per node " + provisioninginput.AdminClientName.String(), nodeRolesDedicated, k.client},
+		{"3 nodes - 1 role per node " + provisioninginput.StandardClientName.String(), nodeRolesDedicated, k.standardUserClient},
 	}
 
 	for _, tt := range tests {
-		k.clustersConfig.NodesAndRoles = tt.nodeRoles
-		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, k.clustersConfig, permutations.K3SProvisionCluster, nil, nil)
+		k.provisioningConfig.MachinePools = tt.machinePools
+		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, k.provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
 	}
 }
 
 func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SClusterDynamicInput() {
-	if len(k.clustersConfig.NodesAndRoles) == 0 {
+	if len(k.provisioningConfig.MachinePools) == 0 {
 		k.T().Skip()
 	}
 
@@ -147,7 +105,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SClusterDynamicIn
 	}
 
 	for _, tt := range tests {
-		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, k.clustersConfig, permutations.K3SProvisionCluster, nil, nil)
+		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, k.provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
 	}
 }
 

--- a/tests/v2/validation/provisioning/permutations/permutations.go
+++ b/tests/v2/validation/provisioning/permutations/permutations.go
@@ -29,7 +29,7 @@ const (
 )
 
 // RunTestPermutations runs through all relevant perumutations in a given config file, including node providers, k8s versions, and CNIs
-func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.Client, clustersConfig *provisioninginput.Config, clusterType string, hostnameTruncation []machinepools.HostnameTruncation, corralPackages *corral.Packages) {
+func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.Client, provisioningConfig *provisioninginput.Config, clusterType string, hostnameTruncation []machinepools.HostnameTruncation, corralPackages *corral.Packages) {
 	var name string
 	var providers []string
 	var testClusterConfig *clusters.ClusterConfig
@@ -41,17 +41,17 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 	require.NoError(s.T(), err)
 
 	if strings.Contains(clusterType, "Custom") {
-		providers = clustersConfig.NodeProviders
+		providers = provisioningConfig.NodeProviders
 	} else if strings.Contains(clusterType, "Airgap") {
 		providers = []string{"Corral"}
 	} else {
-		providers = clustersConfig.Providers
+		providers = provisioningConfig.Providers
 	}
 	for _, nodeProviderName := range providers {
-		nodeProvider, rke1Provider, customProvider, kubeVersions := GetClusterProvider(clusterType, nodeProviderName, clustersConfig)
+		nodeProvider, rke1Provider, customProvider, kubeVersions := GetClusterProvider(clusterType, nodeProviderName, provisioningConfig)
 		for _, kubeVersion := range kubeVersions {
-			for _, cni := range clustersConfig.CNIs {
-				testClusterConfig = clusters.ConvertConfigToClusterConfig(clustersConfig)
+			for _, cni := range provisioningConfig.CNIs {
+				testClusterConfig = clusters.ConvertConfigToClusterConfig(provisioningConfig)
 				testClusterConfig.CNI = cni
 				name = testNamePrefix + " Node Provider: " + nodeProviderName + " Kubernetes version: " + kubeVersion + " cni: " + cni
 				s.Run(name, func() {
@@ -76,14 +76,14 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 					case RKE2CustomCluster, K3SCustomCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
 
-						clusterObject, err := provisioning.CreateProvisioningCustomCluster(client, *customProvider, testClusterConfig)
+						clusterObject, err := provisioning.CreateProvisioningCustomCluster(client, customProvider, testClusterConfig)
 						require.NoError(s.T(), err)
 
 						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
 
 					case RKE1CustomCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
-						clusterObject, nodes, err := provisioning.CreateProvisioningRKE1CustomCluster(client, *customProvider, testClusterConfig)
+						clusterObject, nodes, err := provisioning.CreateProvisioningRKE1CustomCluster(client, customProvider, testClusterConfig)
 						require.NoError(s.T(), err)
 
 						provisioning.VerifyRKE1Cluster(s.T(), client, testClusterConfig, clusterObject)
@@ -115,7 +115,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 	}
 }
 
-func GetClusterProvider(clusterType string, nodeProviderName string, clustersConfig *provisioninginput.Config) (*provisioning.Provider, *provisioning.RKE1Provider, *provisioning.ExternalNodeProvider, []string) {
+func GetClusterProvider(clusterType string, nodeProviderName string, provisioningConfig *provisioninginput.Config) (*provisioning.Provider, *provisioning.RKE1Provider, *provisioning.ExternalNodeProvider, []string) {
 	var nodeProvider provisioning.Provider
 	var rke1NodeProvider provisioning.RKE1Provider
 	var customProvider provisioning.ExternalNodeProvider
@@ -124,28 +124,28 @@ func GetClusterProvider(clusterType string, nodeProviderName string, clustersCon
 	switch clusterType {
 	case RKE2ProvisionCluster:
 		nodeProvider = provisioning.CreateProvider(nodeProviderName)
-		kubeVersions = clustersConfig.RKE2KubernetesVersions
+		kubeVersions = provisioningConfig.RKE2KubernetesVersions
 	case K3SProvisionCluster:
 		nodeProvider = provisioning.CreateProvider(nodeProviderName)
-		kubeVersions = clustersConfig.K3SKubernetesVersions
+		kubeVersions = provisioningConfig.K3SKubernetesVersions
 	case RKE1ProvisionCluster:
 		rke1NodeProvider = provisioning.CreateRKE1Provider(nodeProviderName)
-		kubeVersions = clustersConfig.RKE1KubernetesVersions
+		kubeVersions = provisioningConfig.RKE1KubernetesVersions
 	case RKE2CustomCluster:
 		customProvider = provisioning.ExternalNodeProviderSetup(nodeProviderName)
-		kubeVersions = clustersConfig.RKE2KubernetesVersions
+		kubeVersions = provisioningConfig.RKE2KubernetesVersions
 	case K3SCustomCluster:
 		customProvider = provisioning.ExternalNodeProviderSetup(nodeProviderName)
-		kubeVersions = clustersConfig.K3SKubernetesVersions
+		kubeVersions = provisioningConfig.K3SKubernetesVersions
 	case RKE1CustomCluster:
 		customProvider = provisioning.ExternalNodeProviderSetup(nodeProviderName)
-		kubeVersions = clustersConfig.RKE1KubernetesVersions
+		kubeVersions = provisioningConfig.RKE1KubernetesVersions
 	case K3SAirgapCluster:
-		kubeVersions = clustersConfig.K3SKubernetesVersions
+		kubeVersions = provisioningConfig.K3SKubernetesVersions
 	case RKE1AirgapCluster:
-		kubeVersions = clustersConfig.RKE1KubernetesVersions
+		kubeVersions = provisioningConfig.RKE1KubernetesVersions
 	case RKE2AirgapCluster:
-		kubeVersions = clustersConfig.RKE2KubernetesVersions
+		kubeVersions = provisioningConfig.RKE2KubernetesVersions
 	default:
 		panic("Cluster type not found")
 	}

--- a/tests/v2/validation/provisioning/registries/registry_test.go
+++ b/tests/v2/validation/provisioning/registries/registry_test.go
@@ -38,7 +38,7 @@ type RegistryTestSuite struct {
 	clusterLocalID                 string
 	localClusterGlobalRegistryHost string
 	rancherUsesRegistry            bool
-	clustersConfig                 *provisioninginput.Config
+	provisioningConfig             *provisioninginput.Config
 	privateRegistriesAuth          []management.PrivateRegistry
 	privateRegistriesNoAuth        []management.PrivateRegistry
 	privateEcr                     []management.PrivateRegistry
@@ -132,8 +132,8 @@ func (rt *RegistryTestSuite) SetupSuite() {
 		logrus.Infof("RegistryAuth FQDN %s", registryEnabledFqdn)
 	}
 
-	rt.clustersConfig = new(provisioninginput.Config)
-	config.LoadConfig(provisioninginput.ConfigurationFileKey, rt.clustersConfig)
+	rt.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, rt.provisioningConfig)
 
 	rt.rancherUsesRegistry = false
 	listOfCorrals, err := corral.ListCorral()
@@ -218,15 +218,15 @@ func (rt *RegistryTestSuite) TestRegistriesRKE() {
 
 	for _, tt := range tests {
 		rt.Run(tt.name, func() {
-			testConfig := clusters.ConvertConfigToClusterConfig(rt.clustersConfig)
-			testConfig.KubernetesVersion = rt.clustersConfig.RKE1KubernetesVersions[0]
-			testConfig.CNI = rt.clustersConfig.CNIs[0]
+			testConfig := clusters.ConvertConfigToClusterConfig(rt.provisioningConfig)
+			testConfig.KubernetesVersion = rt.provisioningConfig.RKE1KubernetesVersions[0]
+			testConfig.CNI = rt.provisioningConfig.CNIs[0]
 
 			if testConfig.Registries == nil {
 				testConfig.Registries = &provisioninginput.Registries{}
 			}
 			testConfig.Registries.RKE1Registries = tt.registry
-			_, rke1Provider, _, _ := permutations.GetClusterProvider(permutations.RKE1ProvisionCluster, (*testConfig.Providers)[0], rt.clustersConfig)
+			_, rke1Provider, _, _ := permutations.GetClusterProvider(permutations.RKE1ProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 
 			nodeTemplate, err := rke1Provider.NodeTemplateFunc(subClient)
 			require.NoError(rt.T(), err)
@@ -238,11 +238,11 @@ func (rt *RegistryTestSuite) TestRegistriesRKE() {
 	}
 
 	if rt.rancherUsesRegistry {
-		testConfig := clusters.ConvertConfigToClusterConfig(rt.clustersConfig)
-		testConfig.KubernetesVersion = rt.clustersConfig.RKE1KubernetesVersions[0]
-		testConfig.CNI = rt.clustersConfig.CNIs[0]
+		testConfig := clusters.ConvertConfigToClusterConfig(rt.provisioningConfig)
+		testConfig.KubernetesVersion = rt.provisioningConfig.RKE1KubernetesVersions[0]
+		testConfig.CNI = rt.provisioningConfig.CNIs[0]
 
-		_, rke1Provider, _, _ := permutations.GetClusterProvider(permutations.RKE1ProvisionCluster, (*testConfig.Providers)[0], rt.clustersConfig)
+		_, rke1Provider, _, _ := permutations.GetClusterProvider(permutations.RKE1ProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 
 		nodeTemplate, err := rke1Provider.NodeTemplateFunc(subClient)
 		require.NoError(rt.T(), err)
@@ -276,11 +276,11 @@ func (rt *RegistryTestSuite) TestRegistriesK3S() {
 
 	for _, tt := range tests {
 		rt.Run(tt.name, func() {
-			testConfig := clusters.ConvertConfigToClusterConfig(rt.clustersConfig)
-			testConfig.KubernetesVersion = rt.clustersConfig.K3SKubernetesVersions[0]
-			testConfig.CNI = rt.clustersConfig.CNIs[0]
+			testConfig := clusters.ConvertConfigToClusterConfig(rt.provisioningConfig)
+			testConfig.KubernetesVersion = rt.provisioningConfig.K3SKubernetesVersions[0]
+			testConfig.CNI = rt.provisioningConfig.CNIs[0]
 			testConfig = rt.configureRKE2K3SRegistry(tt.registry, testConfig)
-			k3sProvider, _, _, _ := permutations.GetClusterProvider(permutations.K3SProvisionCluster, (*testConfig.Providers)[0], rt.clustersConfig)
+			k3sProvider, _, _, _ := permutations.GetClusterProvider(permutations.K3SProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 			clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *k3sProvider, testConfig, nil)
 			require.NoError(rt.T(), err)
 
@@ -289,12 +289,12 @@ func (rt *RegistryTestSuite) TestRegistriesK3S() {
 	}
 
 	if rt.rancherUsesRegistry {
-		testConfig := clusters.ConvertConfigToClusterConfig(rt.clustersConfig)
-		testConfig.KubernetesVersion = rt.clustersConfig.K3SKubernetesVersions[0]
-		testConfig.CNI = rt.clustersConfig.CNIs[0]
+		testConfig := clusters.ConvertConfigToClusterConfig(rt.provisioningConfig)
+		testConfig.KubernetesVersion = rt.provisioningConfig.K3SKubernetesVersions[0]
+		testConfig.CNI = rt.provisioningConfig.CNIs[0]
 		testConfig = rt.configureRKE2K3SRegistry(rt.localClusterGlobalRegistryHost, testConfig)
 
-		k3sProvider, _, _, _ := permutations.GetClusterProvider(permutations.K3SProvisionCluster, (*testConfig.Providers)[0], rt.clustersConfig)
+		k3sProvider, _, _, _ := permutations.GetClusterProvider(permutations.K3SProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 
 		clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *k3sProvider, testConfig, nil)
 		require.NoError(rt.T(), err)
@@ -324,12 +324,12 @@ func (rt *RegistryTestSuite) TestRegistriesRKE2() {
 
 	for _, tt := range tests {
 		rt.Run(tt.name, func() {
-			testConfig := clusters.ConvertConfigToClusterConfig(rt.clustersConfig)
-			testConfig.KubernetesVersion = rt.clustersConfig.RKE2KubernetesVersions[0]
-			testConfig.CNI = rt.clustersConfig.CNIs[0]
+			testConfig := clusters.ConvertConfigToClusterConfig(rt.provisioningConfig)
+			testConfig.KubernetesVersion = rt.provisioningConfig.RKE2KubernetesVersions[0]
+			testConfig.CNI = rt.provisioningConfig.CNIs[0]
 			testConfig = rt.configureRKE2K3SRegistry(tt.registry, testConfig)
 
-			rke2Provider, _, _, _ := permutations.GetClusterProvider(permutations.RKE2ProvisionCluster, (*testConfig.Providers)[0], rt.clustersConfig)
+			rke2Provider, _, _, _ := permutations.GetClusterProvider(permutations.RKE2ProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 
 			clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *rke2Provider, testConfig, nil)
 			require.NoError(rt.T(), err)
@@ -338,12 +338,12 @@ func (rt *RegistryTestSuite) TestRegistriesRKE2() {
 		})
 	}
 	if rt.rancherUsesRegistry {
-		testConfig := clusters.ConvertConfigToClusterConfig(rt.clustersConfig)
-		testConfig.KubernetesVersion = rt.clustersConfig.RKE2KubernetesVersions[0]
-		testConfig.CNI = rt.clustersConfig.CNIs[0]
+		testConfig := clusters.ConvertConfigToClusterConfig(rt.provisioningConfig)
+		testConfig.KubernetesVersion = rt.provisioningConfig.RKE2KubernetesVersions[0]
+		testConfig.CNI = rt.provisioningConfig.CNIs[0]
 		testConfig = rt.configureRKE2K3SRegistry(rt.localClusterGlobalRegistryHost, testConfig)
 
-		rke2Provider, _, _, _ := permutations.GetClusterProvider(permutations.RKE2ProvisionCluster, (*testConfig.Providers)[0], rt.clustersConfig)
+		rke2Provider, _, _, _ := permutations.GetClusterProvider(permutations.RKE2ProvisionCluster, (*testConfig.Providers)[0], rt.provisioningConfig)
 
 		clusterObject, err := provisioning.CreateProvisioningCluster(subClient, *rke2Provider, testConfig, nil)
 		require.NoError(rt.T(), err)

--- a/tests/v2/validation/provisioning/rke1/README.md
+++ b/tests/v2/validation/provisioning/rke1/README.md
@@ -21,18 +21,35 @@ provisioningInput is needed to the run the RKE1 tests, specifically kubernetesVe
 
 ```json
 "provisioningInput": {
-    "nodesAndRolesRKE1": [ 
+    "nodePools": [ 
       {
-        "etcd": true,
-        "controlplane": true,
-        "quantity": 1,
+        "nodeRoles" {
+          "etcd": true,
+          "controlplane": true,
+          "quantity": 1,
+        },
       },
       {
-        "worker": true,
-        "quantity": 2,
+        "nodeRoles" {
+          "worker": true,
+          "quantity": 2,
+        },
+        "nodeLabels" {
+          "label1": "value1",
+          "label2": "value2",
+        },
+        "nodeTaints" [
+          { "key": "TestKey",
+            "value": "testValue",
+            "effect": "NoSchedule",
+          },
+        ],
+        "specifyPrivateIP": false,
+        "specifyPublicIP": true,
+        "nodeNamePrefix": "qa",
       },
     ],
-    "rke1KubernetesVersion": ["v1.24.2-rancher1-1"],
+    "rke1KubernetesVersion": ["v1.26.8-rancher1-1"],
     "providers": ["linode", "aws", "azure", "harvester"],
     "nodeProviders": ["ec2"],
     "psact": ""
@@ -209,11 +226,14 @@ RKE1 specifically needs a node template config to run properly. These are the in
 ```
 
 ## Custom Cluster
-For custom clusters, no nodeTemplateConfig or credentials are required. 
+For custom clusters, no nodeTemplateConfig or credentials are required. Currently only supported for ec2.
+`-run ^TestCustomClusterRKE1ProvisioningTestSuite/TestProvisioningRKE1CustomClusterDynamicInput$`
+`-run ^TestCustomClusterRKE1ProvisioningTestSuite/TestProvisioningRKE1CustomCluster$`
 
 Dependencies:
-* **Ensure you have nodeProviders in provisioningInput**
-* make sure that all roles are entered at least once
+* **Ensure you have nodeDrivers set in provisioningInput**
+* make sure that all roles are entered at least once in nodePools.nodeRoles
+* ensure nodeProviders is set
 * use AMIs that already have Docker installed and the service is enabled on boot
 
 ```json

--- a/tests/v2/validation/provisioning/rke1/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/rke1/post_kdm_oob_release_test.go
@@ -16,10 +16,10 @@ import (
 
 type KdmChecksTestSuite struct {
 	suite.Suite
-	session        *session.Session
-	client         *rancher.Client
-	ns             string
-	clustersConfig *provisioninginput.Config
+	session            *session.Session
+	client             *rancher.Client
+	ns                 string
+	provisioningConfig *provisioninginput.Config
 }
 
 const (
@@ -37,8 +37,8 @@ func (k *KdmChecksTestSuite) SetupSuite() {
 
 	k.ns = defaultNamespace
 
-	k.clustersConfig = new(provisioninginput.Config)
-	config.LoadConfig(provisioninginput.ConfigurationFileKey, k.clustersConfig)
+	k.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, k.provisioningConfig)
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(k.T(), err)
@@ -48,26 +48,26 @@ func (k *KdmChecksTestSuite) SetupSuite() {
 
 func (k *KdmChecksTestSuite) TestRKE1K8sVersions() {
 	logrus.Infof("checking for valid k8s versions..")
-	require.GreaterOrEqual(k.T(), len(k.clustersConfig.RKE1KubernetesVersions), 1)
+	require.GreaterOrEqual(k.T(), len(k.provisioningConfig.RKE1KubernetesVersions), 1)
 	// fetching all available k8s versions from rancher
 	releasedK8sVersions, _ := kubernetesversions.ListRKE1AllVersions(k.client)
-	logrus.Info("expected k8s versions : ", k.clustersConfig.RKE1KubernetesVersions)
+	logrus.Info("expected k8s versions : ", k.provisioningConfig.RKE1KubernetesVersions)
 	logrus.Info("k8s versions available on rancher server : ", releasedK8sVersions)
-	for _, expectedK8sVersion := range k.clustersConfig.RKE1KubernetesVersions {
+	for _, expectedK8sVersion := range k.provisioningConfig.RKE1KubernetesVersions {
 		require.Contains(k.T(), releasedK8sVersions, expectedK8sVersion)
 	}
 }
 
 func (k *KdmChecksTestSuite) TestProvisioningSingleNodeRKE1Clusters() {
-	require.GreaterOrEqual(k.T(), len(k.clustersConfig.Providers), 1)
-	require.GreaterOrEqual(k.T(), len(k.clustersConfig.CNIs), 1)
+	require.GreaterOrEqual(k.T(), len(k.provisioningConfig.Providers), 1)
+	require.GreaterOrEqual(k.T(), len(k.provisioningConfig.CNIs), 1)
 
 	subSession := k.session.NewSession()
 	defer subSession.Cleanup()
 
 	client, err := k.client.WithSession(subSession)
 	require.NoError(k.T(), err)
-	permutations.RunTestPermutations(&k.Suite, "oobRelease-", client, k.clustersConfig, permutations.RKE1ProvisionCluster, nil, nil)
+	permutations.RunTestPermutations(&k.Suite, "oobRelease-", client, k.provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
 
 }
 

--- a/tests/v2/validation/provisioning/rke2/README.md
+++ b/tests/v2/validation/provisioning/rke2/README.md
@@ -22,23 +22,42 @@ provisioningInput is needed to the run the RKE2 tests, specifically kubernetesVe
 
 ```json
 "provisioningInput": {
-    "nodesAndRoles": [
+    "machinePools": [
       {
-        "etcd": true,
-        "controlplane": true,
-        "worker": true,
-        "quantity": 1,
+        "nodeRoles": {
+          "etcd": true,
+          "controlplane": true,
+          "worker": false,
+          "quantity": 1,
+        },
       },
       {
-        "worker": true,
-        "quantity": 2,
+        "nodeRoles": {
+          "worker": true,
+          "quantity": 2,
+        },
+        "nodeLabels" {
+          "label1": "value1",
+          "label2": "value2",
+        },
+        "nodeTaints" [
+          { "key": "TestKey",
+            "value": "testValue",
+            "effect": "NoSchedule",
+          }
+        ],
+        "specifyPrivateIP": false,
+        "specifyPublicIP": true,
+        "nodeNamePrefix": "qa",
       },
       {
-        "windows": true,
-        "quantity": 1,
-      }
+        "nodeRoles": {
+          "windows": true,
+          "quantity": 1,
+        }
+      },
     ],
-    "rke2KubernetesVersion": ["v1.25.9+rke2r1"],
+    "rke2KubernetesVersion": ["v1.26.8+rke2r1"],
     "cni": ["calico"],
     "providers": ["linode", "aws", "do", "harvester"],
     "nodeProviders": ["ec2"],
@@ -229,11 +248,14 @@ Machine RKE2 config is the final piece needed for the config to run RKE2 provisi
 
 ## Custom Cluster
 For custom clusters, no machineConfig or credentials are needed. Currently only supported for ec2.
+`-run ^TestCustomClusterRKE2ProvisioningTestSuite/TestProvisioningRKE2CustomClusterDynamicInput$`
+`-run ^TestCustomClusterRKE2ProvisioningTestSuite/TestProvisioningRKE2CustomCluster$`
 
 Dependencies:
-* **Ensure you have nodeProviders in provisioningInput**
-* make sure that all roles are entered at least once
-* windows pool(s) should always be last in the config
+* **Ensure you have machinePools defined in provisioningInput**
+* make sure that all roles are entered at least once in machinePools.nodeRoles
+* ensure nodeProviders is set
+* windows pool(s) should always be the last machinePool
 ```json
 {
   "awsEC2Configs": {

--- a/tests/v2/validation/provisioning/rke2/post_kdm_oob_release_test.go
+++ b/tests/v2/validation/provisioning/rke2/post_kdm_oob_release_test.go
@@ -16,10 +16,10 @@ import (
 
 type KdmChecksTestSuite struct {
 	suite.Suite
-	session        *session.Session
-	client         *rancher.Client
-	ns             string
-	clustersConfig *provisioninginput.Config
+	session            *session.Session
+	client             *rancher.Client
+	ns                 string
+	provisioningConfig *provisioninginput.Config
 }
 
 func (k *KdmChecksTestSuite) TearDownSuite() {
@@ -32,8 +32,8 @@ func (k *KdmChecksTestSuite) SetupSuite() {
 
 	k.ns = "default"
 
-	k.clustersConfig = new(provisioninginput.Config)
-	config.LoadConfig(provisioninginput.ConfigurationFileKey, k.clustersConfig)
+	k.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, k.provisioningConfig)
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(k.T(), err)
@@ -43,26 +43,26 @@ func (k *KdmChecksTestSuite) SetupSuite() {
 
 func (k *KdmChecksTestSuite) TestRKE2K8sVersions() {
 	logrus.Infof("checking for valid k8s versions..")
-	require.GreaterOrEqual(k.T(), len(k.clustersConfig.RKE2KubernetesVersions), 1)
+	require.GreaterOrEqual(k.T(), len(k.provisioningConfig.RKE2KubernetesVersions), 1)
 	// fetching all available k8s versions from rancher
 	releasedK8sVersions, _ := kubernetesversions.ListRKE2AllVersions(k.client)
-	logrus.Info("expected k8s versions : ", k.clustersConfig.RKE2KubernetesVersions)
+	logrus.Info("expected k8s versions : ", k.provisioningConfig.RKE2KubernetesVersions)
 	logrus.Info("k8s versions available on rancher server : ", releasedK8sVersions)
-	for _, expectedK8sVersion := range k.clustersConfig.RKE2KubernetesVersions {
+	for _, expectedK8sVersion := range k.provisioningConfig.RKE2KubernetesVersions {
 		require.Contains(k.T(), releasedK8sVersions, expectedK8sVersion)
 	}
 }
 
 func (k *KdmChecksTestSuite) TestProvisioningSingleNodeRKE2Clusters() {
-	require.GreaterOrEqual(k.T(), len(k.clustersConfig.Providers), 1)
-	require.GreaterOrEqual(k.T(), len(k.clustersConfig.CNIs), 1)
+	require.GreaterOrEqual(k.T(), len(k.provisioningConfig.Providers), 1)
+	require.GreaterOrEqual(k.T(), len(k.provisioningConfig.CNIs), 1)
 
 	subSession := k.session.NewSession()
 	defer subSession.Cleanup()
 
 	client, err := k.client.WithSession(subSession)
 	require.NoError(k.T(), err)
-	permutations.RunTestPermutations(&k.Suite, "oobRelease-", client, k.clustersConfig, permutations.RKE2ProvisionCluster, nil, nil)
+	permutations.RunTestPermutations(&k.Suite, "oobRelease-", client, k.provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
 }
 
 func TestPostKdmOutOfBandReleaseChecks(t *testing.T) {

--- a/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/tests/v2/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -24,7 +24,7 @@ type RKE2NodeDriverProvisioningTestSuite struct {
 	client             *rancher.Client
 	session            *session.Session
 	standardUserClient *rancher.Client
-	clustersConfig     *provisioninginput.Config
+	provisioningConfig *provisioninginput.Config
 }
 
 func (r *RKE2NodeDriverProvisioningTestSuite) TearDownSuite() {
@@ -34,15 +34,15 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TearDownSuite() {
 func (r *RKE2NodeDriverProvisioningTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	r.session = testSession
-	r.clustersConfig = new(provisioninginput.Config)
-	config.LoadConfig(provisioninginput.ConfigurationFileKey, r.clustersConfig)
+	r.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, r.provisioningConfig)
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(r.T(), err)
 	r.client = client
 
-	r.clustersConfig.RKE2KubernetesVersions, err = kubernetesversions.Default(
-		r.client, clusters.RKE2ClusterType.String(), r.clustersConfig.RKE2KubernetesVersions)
+	r.provisioningConfig.RKE2KubernetesVersions, err = kubernetesversions.Default(
+		r.client, clusters.RKE2ClusterType.String(), r.provisioningConfig.RKE2KubernetesVersions)
 	require.NoError(r.T(), err)
 
 	enabled := true
@@ -126,12 +126,12 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2Cluster() {
 	}
 
 	for _, tt := range tests {
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, r.clustersConfig, permutations.RKE2ProvisionCluster, nil, nil)
+		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, r.provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
 	}
 }
 
 func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2ClusterDynamicInput() {
-	if len(r.clustersConfig.NodesAndRoles) == 0 {
+	if len(r.provisioningConfig.MachinePools) == 0 {
 		r.T().Skip()
 	}
 
@@ -144,7 +144,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2ClusterDynamic
 	}
 
 	for _, tt := range tests {
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, r.clustersConfig, permutations.RKE2ProvisionCluster, nil, nil)
+		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, r.provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
 	}
 }
 

--- a/tests/v2/validation/rbac/rbac_additional_test.go
+++ b/tests/v2/validation/rbac/rbac_additional_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/projects"
 	"github.com/rancher/rancher/tests/framework/extensions/provisioning"
 	"github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
-	nodepools "github.com/rancher/rancher/tests/framework/extensions/rke1/nodepools"
 	"github.com/rancher/rancher/tests/framework/extensions/users"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
@@ -267,13 +266,15 @@ func (rb *RBACAdditionalTestSuite) TestRBACAdditional() {
 				userConfig := new(provisioninginput.Config)
 				config.LoadConfig(provisioninginput.ConfigurationFileKey, userConfig)
 				nodeProviders := userConfig.NodeProviders[0]
-				nodeAndRoles := []nodepools.NodeRoles{provisioninginput.RKE1AllRolesPool}
+				nodeAndRoles := []provisioninginput.NodePools{
+					provisioninginput.AllRolesNodePool,
+				}
 				externalNodeProvider := provisioning.ExternalNodeProviderSetup(nodeProviders)
 				clusterConfig := clusters.ConvertConfigToClusterConfig(userConfig)
-				clusterConfig.NodesAndRolesRKE1 = &nodeAndRoles
+				clusterConfig.NodePools = nodeAndRoles
 				clusterConfig.KubernetesVersion = userConfig.RKE1KubernetesVersions[0]
 				clusterConfig.CNI = userConfig.CNIs[0]
-				clusterObject, _, err := provisioning.CreateProvisioningRKE1CustomCluster(rb.client, externalNodeProvider, clusterConfig)
+				clusterObject, _, err := provisioning.CreateProvisioningRKE1CustomCluster(rb.client, &externalNodeProvider, clusterConfig)
 				require.NoError(rb.T(), err)
 				provisioning.VerifyRKE1Cluster(rb.T(), rb.client, clusterConfig, clusterObject)
 			})


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 part 1 of: https://github.com/rancher/qa-tasks/issues/560

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
there are additional fields that we didn't have access to via automation, specified on custom clusters during the node registration process 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 **breaking change** : updating `nodesAndRoles` (and RKE1NodesAndRoles) to a new object, machinePools (nodePools) with the following config update:
```
  machinePools: # for rke1, nodePools
  - nodeRoles:
      etcd: true
      controlplane: true
      quantity: 1
  - nodeRoles:
      worker: true
      quantity: 1
    nodeLabels:
      label1: "value1"
      label2: "value2"
    nodeTaints:
      - key: TestKey
        value: testValue
        effect: NoSchedule
    specifyPrivateIP: true
    specifyPublicIP: true
    nodeNameSuffix: "qa"
```

also, I updated our tests' variable names to provisioningConfig from clustersConfig in places where that was more clear now that we have a distinguishing config for clusters vs. provisioning
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
tested locally on rke2, rke1, with advanced options specified

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_ on jenkins

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 This will require us to update all configs in jenkins. Readme's are updated in this PR