### PR TITLE
Adding drainBeforeDelete field to enable the feature in provisioning tests

### DIFF
--- a/tests/framework/extensions/machinepools/machinepools.go
+++ b/tests/framework/extensions/machinepools/machinepools.go
@@ -87,19 +87,20 @@ func updateMachinePoolQuantity(client *rancher.Client, cluster *v1.SteveAPIObjec
 }
 
 // NewRKEMachinePool is a constructor that sets up a apisV1.RKEMachinePool object to be used to provision a cluster.
-func NewRKEMachinePool(controlPlaneRole, etcdRole, workerRole bool, poolName string, quantity int32, machineConfig *v1.SteveAPIObject, hostnameLengthLimit int) apisV1.RKEMachinePool {
+func NewRKEMachinePool(controlPlaneRole, etcdRole, workerRole bool, poolName string, quantity int32, machineConfig *v1.SteveAPIObject, hostnameLengthLimit int, drainBeforeDelete bool) apisV1.RKEMachinePool {
 	machineConfigRef := &corev1.ObjectReference{
 		Kind: machineConfig.Kind,
 		Name: machineConfig.Name,
 	}
 
 	machinePool := apisV1.RKEMachinePool{
-		ControlPlaneRole: controlPlaneRole,
-		EtcdRole:         etcdRole,
-		WorkerRole:       workerRole,
-		NodeConfig:       machineConfigRef,
-		Name:             poolName,
-		Quantity:         &quantity,
+		ControlPlaneRole:  controlPlaneRole,
+		EtcdRole:          etcdRole,
+		WorkerRole:        workerRole,
+		NodeConfig:        machineConfigRef,
+		Name:              poolName,
+		Quantity:          &quantity,
+		DrainBeforeDelete: drainBeforeDelete,
 	}
 
 	if hostnameLengthLimit > 0 {
@@ -110,11 +111,12 @@ func NewRKEMachinePool(controlPlaneRole, etcdRole, workerRole bool, poolName str
 }
 
 type NodeRoles struct {
-	ControlPlane bool  `json:"controlplane,omitempty" yaml:"controlplane,omitempty"`
-	Etcd         bool  `json:"etcd,omitempty" yaml:"etcd,omitempty"`
-	Worker       bool  `json:"worker,omitempty" yaml:"worker,omitempty"`
-	Windows      bool  `json:"windows,omitempty" yaml:"windows,omitempty"`
-	Quantity     int32 `json:"quantity" yaml:"quantity"`
+	ControlPlane      bool  `json:"controlplane,omitempty" yaml:"controlplane,omitempty"`
+	Etcd              bool  `json:"etcd,omitempty" yaml:"etcd,omitempty"`
+	Worker            bool  `json:"worker,omitempty" yaml:"worker,omitempty"`
+	Windows           bool  `json:"windows,omitempty" yaml:"windows,omitempty"`
+	Quantity          int32 `json:"quantity" yaml:"quantity"`
+	DrainBeforeDelete bool  `json:"drainBeforeDelete" yaml:"drainBeforeDelete"`
 }
 
 // HostnameTruncation is a struct that is used to set the hostname length limit for a cluster or its pools during provisioning
@@ -171,10 +173,10 @@ func CreateAllMachinePools(nodeRoles []NodeRoles, machineConfig *v1.SteveAPIObje
 		}
 
 		if !roles.Windows {
-			machinePool := NewRKEMachinePool(roles.ControlPlane, roles.Etcd, roles.Worker, poolName, roles.Quantity, machineConfig, hostnameLengthLimit)
+			machinePool := NewRKEMachinePool(roles.ControlPlane, roles.Etcd, roles.Worker, poolName, roles.Quantity, machineConfig, hostnameLengthLimit, roles.DrainBeforeDelete)
 			machinePools = append(machinePools, machinePool)
 		} else {
-			machinePool := NewRKEMachinePool(false, false, roles.Windows, poolName, roles.Quantity, machineConfig, hostnameLengthLimit)
+			machinePool := NewRKEMachinePool(false, false, roles.Windows, poolName, roles.Quantity, machineConfig, hostnameLengthLimit, roles.DrainBeforeDelete)
 			machinePools = append(machinePools, machinePool)
 		}
 	}

--- a/tests/framework/extensions/rke1/nodepools/nodepools.go
+++ b/tests/framework/extensions/rke1/nodepools/nodepools.go
@@ -18,10 +18,11 @@ const (
 )
 
 type NodeRoles struct {
-	ControlPlane bool  `json:"controlplane,omitempty" yaml:"controlplane,omitempty"`
-	Etcd         bool  `json:"etcd,omitempty" yaml:"etcd,omitempty"`
-	Worker       bool  `json:"worker,omitempty" yaml:"worker,omitempty"`
-	Quantity     int64 `json:"quantity" yaml:"quantity"`
+	ControlPlane      bool  `json:"controlplane,omitempty" yaml:"controlplane,omitempty"`
+	Etcd              bool  `json:"etcd,omitempty" yaml:"etcd,omitempty"`
+	Worker            bool  `json:"worker,omitempty" yaml:"worker,omitempty"`
+	Quantity          int64 `json:"quantity" yaml:"quantity"`
+	DrainBeforeDelete bool  `json:"drainBeforeDelete,omitempty" yaml:"drainBeforeDelete,omitempty"`
 }
 
 // NodePoolSetup is a helper method that will loop and setup multiple node pools with the defined node roles from the `nodeRoles` parameter
@@ -54,6 +55,7 @@ func NodePoolSetup(client *rancher.Client, nodeRoles []NodeRoles, ClusterID, Nod
 		nodePoolConfig.Worker = roles.Worker
 		nodePoolConfig.Quantity = roles.Quantity
 		nodePoolConfig.HostnamePrefix = "auto-rke1-" + strconv.Itoa(index) + ClusterID
+		nodePoolConfig.DrainBeforeDelete = roles.DrainBeforeDelete
 
 		_, err := client.Management.NodePool.Create(&nodePoolConfig)
 

--- a/tests/v2/validation/provisioning/k3s/README.md
+++ b/tests/v2/validation/provisioning/k3s/README.md
@@ -36,6 +36,7 @@ provisioningInput is needed to the run the K3S tests, specifically kubernetesVer
         "nodeRoles": {
           "worker": true,
           "quantity": 2,
+          "drainBeforeDelete": true,
         },
         "nodeLabels" {
           "label1": "value1",

--- a/tests/v2/validation/provisioning/rke1/README.md
+++ b/tests/v2/validation/provisioning/rke1/README.md
@@ -33,6 +33,7 @@ provisioningInput is needed to the run the RKE1 tests, specifically kubernetesVe
         "nodeRoles" {
           "worker": true,
           "quantity": 2,
+          "drainBeforeDelete": true,
         },
         "nodeLabels" {
           "label1": "value1",

--- a/tests/v2/validation/provisioning/rke2/README.md
+++ b/tests/v2/validation/provisioning/rke2/README.md
@@ -35,6 +35,7 @@ provisioningInput is needed to the run the RKE2 tests, specifically kubernetesVe
         "nodeRoles": {
           "worker": true,
           "quantity": 2,
+          "drainBeforeDelete": true,
         },
         "nodeLabels" {
           "label1": "value1",
@@ -65,8 +66,7 @@ provisioningInput is needed to the run the RKE2 tests, specifically kubernetesVe
     "providers": ["linode", "aws", "do", "harvester"],
     "nodeProviders": ["ec2"],
     "hardened": true,
-    "psact": "",
-    "clusterSSHTests": ["CheckCPU"]
+    "psact": ""
   }
 ```
 


### PR DESCRIPTION
This issue is a forward port of [42839](https://github.com/rancher/rancher/pull/42839)

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> 
[513](https://github.com/rancher/qa-tasks/issues/513)
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
We don't have the option to set the value for drainBeforeDelete in our automation suite. We want to include test cases for this feature and need this option in our framework.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
We are adding the drainBeforeDelete field to allow us to use this feature in our automation suite.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manual testing was done on local setup to ensure that the field was being added correctly.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
Jenkins jobs will be available upon request

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
This is for the qa team to be able to run automated tests around the drainBeforeDelete feature
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
There are no regressions as the feature already exists and we are just adding the field to enable the feature on the automation suite.