### PR TITLE
Adding sshTest to verify a cluster comes back up active after rebooting node

### DIFF
--- a/tests/framework/extensions/clusters/clusterconfig.go
+++ b/tests/framework/extensions/clusters/clusterconfig.go
@@ -27,7 +27,7 @@ type ClusterConfig struct {
 	Registries           *provisioningInput.Registries            `json:"registries" yaml:"registries"`
 	UpgradeStrategy      *rkev1.ClusterUpgradeStrategy            `json:"upgradeStrategy" yaml:"upgradeStrategy"`
 	Advanced             *provisioningInput.Advanced              `json:"advanced" yaml:"advanced"`
-	ClusterSSHTests      []string                                 `json:"clusterSSHTests" yaml:"clusterSSHTests"`
+	ClusterSSHTests      []provisioningInput.SSHTestCase          `json:"clusterSSHTests" yaml:"clusterSSHTests"`
 }
 
 // ConvertConfigToClusterConfig converts the config from (user) provisioning input to a cluster config

--- a/tests/framework/extensions/clusters/dynamicSchema.go
+++ b/tests/framework/extensions/clusters/dynamicSchema.go
@@ -1,6 +1,5 @@
 package clusters
 
-// Default contains the values for sshUser
 type Default struct {
 	StringValue      string `json:"stringValue"`
 	IntValue         int    `json:"intValue"`
@@ -8,7 +7,6 @@ type Default struct {
 	StringSliceValue []int  `json:"stringSliceValue"`
 }
 
-// SSHUser contains all the fields for sshUser
 type SSHUser struct {
 	Type        string `json:"type"`
 	Default     Default
@@ -17,12 +15,11 @@ type SSHUser struct {
 	Description string `json:"description"`
 }
 
-// ResourceFields contains all the fields of the resources found in DynamicSchemaSpec
 type ResourceFields struct {
 	SSHUser SSHUser
 }
 
-// DynamicSchemaSpec contains ResourceFields that contains all the data for the DynamicSchemaSpec which a type in provisinong.cattle.io.clusters this is how we get an ssh user for a node pool
+// DynamicSchemaSpec contains ResourceFields that contains all the data for the DynamicSchemaSpec which a type in provisioning.cattle.io.clusters this is how we get an ssh user for a node pool
 type DynamicSchemaSpec struct {
 	ResourceFields ResourceFields `json:"resourceFields"`
 }

--- a/tests/framework/extensions/defaults/defaults.go
+++ b/tests/framework/extensions/defaults/defaults.go
@@ -1,5 +1,10 @@
 package defaults
 
+import "time"
+
 var (
 	WatchTimeoutSeconds = int64(60 * 30) // 30 minutes.
+	FiveMinuteTimeout   = 5 * time.Minute
+	TenMinuteTimeout    = 10 * time.Minute
+	ThirtyMinuteTimeout = 30 * time.Minute
 )

--- a/tests/framework/extensions/machinepools/machinepools.go
+++ b/tests/framework/extensions/machinepools/machinepools.go
@@ -9,6 +9,7 @@ import (
 	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -72,7 +73,7 @@ func updateMachinePoolQuantity(client *rancher.Client, cluster *v1.SteveAPIObjec
 			return false, err
 		}
 
-		if clusterResp.ObjectMeta.State.Name == active && nodestat.AllManagementNodeReady(client, cluster.ID) == nil {
+		if clusterResp.ObjectMeta.State.Name == active && nodestat.AllManagementNodeReady(client, cluster.ID, defaults.ThirtyMinuteTimeout) == nil {
 			return true, nil
 		}
 

--- a/tests/framework/extensions/nodes/node_status.go
+++ b/tests/framework/extensions/nodes/node_status.go
@@ -24,8 +24,8 @@ const (
 
 // AllManagementNodeReady is a helper method that will loop and check if the node is ready in the RKE1 cluster.
 // It will return an error if the node is not ready after set amount of time.
-func AllManagementNodeReady(client *rancher.Client, ClusterID string) error {
-	err := wait.Poll(1*time.Second, 30*time.Minute, func() (bool, error) {
+func AllManagementNodeReady(client *rancher.Client, ClusterID string, timeout time.Duration) error {
+	err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
 		nodes, err := client.Management.Node.ListAll(&types.ListOpts{
 			Filters: map[string]interface{}{
 				"clusterId": ClusterID,
@@ -57,8 +57,8 @@ func AllManagementNodeReady(client *rancher.Client, ClusterID string) error {
 
 // AllMachineReady is a helper method that will loop and check if the machine object of every node in a cluster is ready. Typically Used for RKE2/K3s Clusters.
 // It will return an error if the machine object is not ready after set amount of time.
-func AllMachineReady(client *rancher.Client, clusterID string) error {
-	err := wait.Poll(1*time.Second, 30*time.Minute, func() (bool, error) {
+func AllMachineReady(client *rancher.Client, clusterID string, timeout time.Duration) error {
+	err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
 		nodes, err := client.Management.Node.List(&types.ListOpts{Filters: map[string]interface{}{
 			"clusterId": clusterID,
 		}})

--- a/tests/framework/extensions/provisioning/ssh.go
+++ b/tests/framework/extensions/provisioning/ssh.go
@@ -9,22 +9,36 @@ import (
 	"strconv"
 	"strings"
 
+	"time"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/defaults"
+	extnodes "github.com/rancher/rancher/tests/framework/extensions/nodes"
+	"github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
 	"github.com/rancher/rancher/tests/framework/pkg/nodes"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
-	cpuUsageVar = 100 // 100 is just a placeholder until we can determine an actual number. Even with cpu usage spiking it should not go past 100% cpu usage and previous issues concerning this were hitting around 130% and above
-	checkCPU    = "CheckCPU"
+	cpuUsageVar                                            = 100 // 100 is just a placeholder until we can determine an actual number. Even with cpu usage spiking it should not go past 100% cpu usage and previous issues concerning this were hitting around 130% and above
+	checkCPU                 provisioninginput.SSHTestCase = "CheckCPU"
+	checkCPUCommand                                        = "ps -C agent -o %cpu --no-header"
+	nodeReboot               provisioninginput.SSHTestCase = "NodeReboot"
+	activeState                                            = "active"
+	runningState                                           = "running"
+	machineSteveResourceType                               = "cluster.x-k8s.io.machine"
+	fleetNamespace                                         = "fleet-default"
 )
 
 // CallSSHTestByName tests the ssh tests specified in the provisioninginput config clusterSSHTests field.
 // For example CheckCPU checks the cpu usage of the cluster agent. If the usage is too high the func will return a warning.
-func CallSSHTestByName(testName string, node *nodes.Node) error {
-	switch testName {
+func CallSSHTestByName(testCase provisioninginput.SSHTestCase, node *nodes.Node, client *rancher.Client, clusterID string, machineName string) error {
+	switch testCase {
 	case checkCPU:
-		command := "ps -C agent -o %cpu --no-header"
-		output, err := node.ExecuteCommand(command)
+		logrus.Infof("Running CheckCPU test on node %s", node.PublicIPAddress)
+		output, err := node.ExecuteCommand(checkCPUCommand)
 		if err != nil {
 			return err
 		}
@@ -38,8 +52,38 @@ func CallSSHTestByName(testName string, node *nodes.Node) error {
 		if err != nil {
 			return err
 		}
+	case nodeReboot:
+		logrus.Infof("Running NodeReboot test on node %s", node.PublicIPAddress)
+		command := "sudo reboot"
+		_, err := node.ExecuteCommand(command)
+		if err != nil && !errors.Is(err, &ssh.ExitMissingError{}) {
+			return err
+		}
+		// Verify machine shuts down within five minutes, shutting down should not take longer than that depending on the ami
+		err = wait.Poll(1*time.Second, defaults.FiveMinuteTimeout, func() (bool, error) {
+			newNode, err := client.Steve.SteveType(machineSteveResourceType).ByID(fleetNamespace + "/" + machineName)
+			if err != nil {
+				return false, err
+			}
+			if newNode.State.Name == runningState {
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			logrus.Errorf("Node %s was unable to reboot successfully | Cluster %s is still in active state", node.PublicIPAddress, clusterID)
+			return err
+		}
+
+		err = extnodes.AllMachineReady(client, clusterID, defaults.TenMinuteTimeout)
+		if err != nil {
+			logrus.Errorf("Node %s failed to reboot successfully", node.PublicIPAddress)
+			return err
+		}
+
+		return err
 	default:
-		err := errors.New("SSHTest: " + testName + " is spelled incorrectly or does not exist.")
+		err := errors.New("Invalid SSH test: " + string(testCase) + " is spelled incorrectly or does not exist.")
 		return err
 	}
 	return nil

--- a/tests/framework/extensions/provisioninginput/config.go
+++ b/tests/framework/extensions/provisioninginput/config.go
@@ -10,6 +10,7 @@ import (
 
 type Version string
 type PSACT string
+type SSHTestCase string
 
 const (
 	Namespace                       = "fleet-default"
@@ -213,5 +214,5 @@ type Config struct {
 	Registries             *Registries                              `json:"registries" yaml:"registries"`
 	UpgradeStrategy        *rkev1.ClusterUpgradeStrategy            `json:"upgradeStrategy" yaml:"upgradeStrategy"`
 	Advanced               *Advanced                                `json:"advanced" yaml:"advanced"`
-	ClusterSSHTests        []string                                 `json:"clusterSSHTests" yaml:"clusterSSHTests"`
+	ClusterSSHTests        []SSHTestCase                            `json:"clusterSSHTests" yaml:"clusterSSHTests"`
 }

--- a/tests/framework/extensions/rke1/nodepools/nodepools.go
+++ b/tests/framework/extensions/rke1/nodepools/nodepools.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
+	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
 	"github.com/sirupsen/logrus"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
@@ -113,7 +114,7 @@ func updateNodePoolQuantity(client *rancher.Client, cluster *management.Cluster,
 			return false, err
 		}
 
-		if clusterResp.State == active && nodestat.AllManagementNodeReady(client, clusterResp.ID) == nil {
+		if clusterResp.State == active && nodestat.AllManagementNodeReady(client, clusterResp.ID, defaults.ThirtyMinuteTimeout) == nil {
 			logrus.Infof("Node pool is scaled!")
 			return true, nil
 		}

--- a/tests/framework/extensions/sshkeys/downloadsshkeys.go
+++ b/tests/framework/extensions/sshkeys/downloadsshkeys.go
@@ -20,27 +20,27 @@ func DownloadSSHKeys(client *rancher.Client, machinePoolNodeName string) ([]byte
 	machinePoolNodeNameName := fmt.Sprintf("fleet-default/%s", machinePoolNodeName)
 	machine, err := client.Steve.SteveType(ClusterMachineConstraintResourceSteveType).ByID(machinePoolNodeNameName)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	sshKeyLink := machine.Links["sshkeys"]
 
 	req, err := http.NewRequest("GET", sshKeyLink, nil)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	req.Header.Add("Authorization", "Bearer "+client.RancherConfig.AdminToken)
 
 	resp, err := client.Management.APIBaseClient.Ops.Client.Do(req)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	privateSSHKeyRegEx := regexp.MustCompile(privateKeySSHKeyRegExPattern)

--- a/tests/v2/validation/nodescaling/replace.go
+++ b/tests/v2/validation/nodescaling/replace.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
 	"github.com/sirupsen/logrus"
@@ -57,7 +58,7 @@ func ReplaceNodes(t *testing.T, client *rancher.Client, clusterName string, isEt
 	err = clusters.WaitClusterToBeUpgraded(client, clusterID)
 	require.NoError(t, err)
 
-	err = nodestat.AllMachineReady(client, clusterID)
+	err = nodestat.AllMachineReady(client, clusterID, defaults.ThirtyMinuteTimeout)
 	require.NoError(t, err)
 
 	isNodeReplaced, err := nodestat.IsNodeReplaced(client, machineToDelete.ID, clusterID, numOfNodesBeforeDeletion, isEtcd, isControlPlane, isWorker)
@@ -78,7 +79,7 @@ func ReplaceRKE1Nodes(t *testing.T, client *rancher.Client, clusterName string, 
 	err = clusters.WaitClusterToBeUpgraded(client, clusterID)
 	require.NoError(t, err)
 
-	err = nodestat.AllManagementNodeReady(client, clusterID)
+	err = nodestat.AllManagementNodeReady(client, clusterID, defaults.ThirtyMinuteTimeout)
 	require.NoError(t, err)
 
 	isNodeReplaced, err := nodestat.IsNodeReplaced(client, nodeToDelete.ID, clusterID, numOfNodesBeforeDeletion, isEtcd, isControlPlane, isWorker)

--- a/tests/v2/validation/upgrade/kubernetes_test.go
+++ b/tests/v2/validation/upgrade/kubernetes_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters/bundledclusters"
+	"github.com/rancher/rancher/tests/framework/extensions/defaults"
 	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
 	"github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
 	psadeploy "github.com/rancher/rancher/tests/framework/extensions/psact"
@@ -119,9 +120,9 @@ func (u *UpgradeKubernetesTestSuite) testUpgradeSingleCluster(clusterName, versi
 		validateNodepoolVersions(u.T(), client, updatedCluster, version, !isCheckingCurrentCluster)
 	}
 	if strings.Contains(versionToUpgrade, rke1KubeVersionCheck) {
-		err = nodestat.AllManagementNodeReady(client, clusterMeta.ID)
+		err = nodestat.AllManagementNodeReady(client, clusterMeta.ID, defaults.ThirtyMinuteTimeout)
 	} else if strings.Contains(versionToUpgrade, rke2KubeVersionCheck) || strings.Contains(versionToUpgrade, k3sKubeVersionCheck) {
-		err = nodestat.AllMachineReady(client, clusterMeta.ID)
+		err = nodestat.AllMachineReady(client, clusterMeta.ID, defaults.TenMinuteTimeout)
 	}
 	require.NoError(u.T(), err)
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
[645](https://github.com/rancher/qa-tasks/issues/645)
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
We currently do not have an automated test where we reboot a node and check to see if the cluster comes back up `Active`. We should do the following to rectify that:

- Create a 1 node, all roles RKE1 cluster, reboot the cluster and validate that the cluster and nodes are `Active`
- Create a 1 node, all roles RKE2 cluster, reboot the cluster and validate that the cluster and nodes are `Active`
- Create a 1 node, all roles K3s cluster, reboot the cluster and validate that the cluster and nodes are `Active`
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Adding an ssh test to the automation framework to reboot a node and verify the cluster comes up active.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Manual steps taken:
1. Provision a 1 node all role rke1/rke2/k3s cluster
2. ssh into the node
3. run `sudo reboot`
4. Verify cluster goes into `Updating` state and the node status is in `reconciling`
5. Verify the node reboots successfully
6. Verify the cluster comes back up active

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_
Jenkins test available upon request

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
This automation is in order to cover more testcases for QA 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
There aren't any regressions as the reboot command is already a built-in function of linux and we are just verifying the status changes of the node and cluster.

Existing / newly added automated tests that provide evidence there are no regressions:
Jenkins test available upon request