### PR TITLE
adding checkout method to catalogv2/git

### DIFF
--- a/pkg/catalogv2/git/download.go
+++ b/pkg/catalogv2/git/download.go
@@ -24,7 +24,7 @@ func (r *Repository) Ensure(branch string) error {
 	}
 
 	// If we do not have the branch locally, fetch and reset
-	err = r.fetchAndReset(branch)
+	err = r.fetchCheckoutAndReset(branch)
 	if err != nil {
 		return fmt.Errorf("failed to fetch and/or reset at branch: %w", err)
 	}
@@ -92,7 +92,7 @@ func (r *Repository) Update(branch string) (string, error) {
 		return commit.String(), nil
 	}
 
-	err = r.fetchAndReset(branch)
+	err = r.fetchCheckoutAndReset(branch)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch and/or reset at branch: %w", err)
 	}

--- a/tests/v2/integration/catalogv2/cluster_repo_test.go
+++ b/tests/v2/integration/catalogv2/cluster_repo_test.go
@@ -249,7 +249,7 @@ func (c *ClusterRepoTestSuite) testSmallForkClusterRepo(params ChartsSmallForkRe
 
 	// The Spec from ClusterRepo is updated almost instantly, the status and local repository take more time
 	err = kwait.Poll(5*time.Second, 10*time.Minute, func() (done bool, err error) {
-		lastCommit, _, err := getLocalRepoCurrentCommitAndBranch(repoPath)
+		lastCommit, lastBranch, err := getLocalRepoCurrentCommitAndBranch(repoPath)
 		require.NoError(c.T(), err)
 		updatedClusterRepo, err = c.catalogClient.ClusterRepos().Get(c.ctx, testClusterRepo.Name, metav1.GetOptions{})
 		if err != nil {
@@ -257,7 +257,9 @@ func (c *ClusterRepoTestSuite) testSmallForkClusterRepo(params ChartsSmallForkRe
 		}
 		// Assertions
 		if lastCommit == updatedClusterRepo.Status.Commit && lastCommit != firstCommit {
-			return true, nil
+			if lastBranch == updatedClusterRepo.Status.Branch && lastBranch != firstBranch {
+				return true, nil
+			}
 		}
 		return false, nil
 	})


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
[[BUG] - Local Repository HEAD reference differs from ClusterRepo Spec](https://github.com/rancher/rancher/issues/42471)
 
## Problem
The HEAD reference of the local git repository does not match the ClusterRepo.Spec.GitBranch and ClusterRepo.Status.Branch.
 
## Solution
Implement a `checkout` method so the local repository does not stay in detached mode.

Modified fetchAndReset -> fetchCheckoutAndReset
To maintain synchronization between the ClusterRepo Spec and the local repository branch and commit pointed by HEAD
 
## Testing

### Manual Testing
Re-executed the entire Manual Testing documentation at Mapps/Catalogv2 Confluence.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Integration (Go Framework)

No unit tests modified, behavior is still the same

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
Todo:
Please implement the automation for the manual testing document at confluence.

