### PR TITLE
Bump cluster template k8s version to 1.25.x

### DIFF
--- a/tests/integration/suite/test_clustertemplate.py
+++ b/tests/integration/suite/test_clustertemplate.py
@@ -991,7 +991,7 @@ def create_cluster_template_revision(client, clusterTemplateId):
                   "rancherKubernetesEngineConfig.kubernetesVersion",
                   "required": "false",
                   "type": "string",
-                  "default": "1.24.x"
+                  "default": "1.25.x"
                  }]
 
     revision_name = random_str()


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/42873
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Tests were running with 1.24, which is unsupported

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Bump to 1.25

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

CI