### PR TITLE
Refactor guid-unmigration identification routines to not rely on cluster state

### DIFF
--- a/pkg/agent/clean/adunmigration/rtbs.go
+++ b/pkg/agent/clean/adunmigration/rtbs.go
@@ -35,14 +35,7 @@ func principalsToMigrate(workunits *[]migrateUserWorkUnit) (adWorkUnitsByPrincip
 	return adWorkUnitsByPrincipal, duplicateLocalWorkUnitsByPrincipal
 }
 
-func collectCRTBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) error {
-	crtbInterface := sc.Management.ClusterRoleTemplateBindings("")
-	crtbList, err := crtbInterface.List(metav1.ListOptions{})
-	if err != nil {
-		logrus.Errorf("[%v] unable to fetch CRTB objects: %v", migrateAdUserOperation, err)
-		return err
-	}
-
+func identifyCRTBs(workunits *[]migrateUserWorkUnit, crtbList *v3.ClusterRoleTemplateBindingList) {
 	adWorkUnitsByPrincipal, duplicateLocalWorkUnitsByPrincipal := principalsToMigrate(workunits)
 
 	for _, crtb := range crtbList.Items {
@@ -62,18 +55,9 @@ func collectCRTBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) er
 			}
 		}
 	}
-
-	return nil
 }
 
-func collectPRTBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) error {
-	prtbInterface := sc.Management.ProjectRoleTemplateBindings("")
-	prtbList, err := prtbInterface.List(metav1.ListOptions{})
-	if err != nil {
-		logrus.Errorf("[%v] unable to fetch PRTB objects: %v", migrateAdUserOperation, err)
-		return err
-	}
-
+func identifyPRTBs(workunits *[]migrateUserWorkUnit, prtbList *v3.ProjectRoleTemplateBindingList) {
 	adWorkUnitsByPrincipal, duplicateLocalWorkUnitsByPrincipal := principalsToMigrate(workunits)
 
 	for _, prtb := range prtbList.Items {
@@ -93,18 +77,9 @@ func collectPRTBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) er
 			}
 		}
 	}
-
-	return nil
 }
 
-func collectGRBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) error {
-	grbInterface := sc.Management.GlobalRoleBindings("")
-	grbList, err := grbInterface.List(metav1.ListOptions{})
-	if err != nil {
-		logrus.Errorf("[%v] unable to fetch GRB objects: %v", migrateAdUserOperation, err)
-		return err
-	}
-
+func identifyGRBs(workunits *[]migrateUserWorkUnit, grbList *v3.GlobalRoleBindingList) {
 	duplicateLocalWorkUnitsByName := map[string]int{}
 
 	for _, workunit := range *workunits {
@@ -118,8 +93,6 @@ func collectGRBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) err
 			(*workunits)[index].duplicateLocalGRBs = append((*workunits)[index].duplicateLocalGRBs, grb)
 		}
 	}
-
-	return nil
 }
 
 func updateCRTB(crtbInterface v3norman.ClusterRoleTemplateBindingInterface, oldCrtb *v3.ClusterRoleTemplateBinding, userName string, principalID string) error {

--- a/pkg/agent/clean/adunmigration/tokens.go
+++ b/pkg/agent/clean/adunmigration/tokens.go
@@ -15,14 +15,7 @@ import (
 	"github.com/rancher/rancher/pkg/types/config"
 )
 
-func collectTokens(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) error {
-	tokenInterface := sc.Management.Tokens("")
-	tokenList, err := tokenInterface.List(metav1.ListOptions{})
-	if err != nil {
-		logrus.Errorf("[%v] unable to fetch token objects: %v", migrateAdUserOperation, err)
-		return err
-	}
-
+func identifyTokens(workunits *[]migrateUserWorkUnit, tokenList *v3.TokenList) {
 	adWorkUnitsByPrincipal, duplicateLocalWorkUnitsByPrincipal := principalsToMigrate(workunits)
 
 	for _, token := range tokenList.Items {
@@ -42,8 +35,6 @@ func collectTokens(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) e
 			}
 		}
 	}
-
-	return nil
 }
 
 func updateToken(tokenInterface v3norman.TokenInterface, userToken v3.Token, newPrincipalID string, guid string, targetUser *v3.User, targetPrincipal *v3.Principal) error {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42328

## Solution
Small adjustments to facilitate easier unit testing. Mostly this reworks the various "identify" functions to accept their state, rather than accepting a means to query it. For LDAP the retryable connection is hoisted into an interface so it can be more easily mocked.
 
## Testing
The goal of these changes is to facilitate unit test writing, those will come later. I just want to get eyes on this early.
