### PR TITLE
[2.8] Update aks-operator to v1.2.0-rc4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,7 +108,7 @@ require (
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.4.0
 	github.com/prometheus/common v0.44.0
-	github.com/rancher/aks-operator v1.2.0-rc3
+	github.com/rancher/aks-operator v1.2.0-rc4
 	github.com/rancher/apiserver v0.0.0-20230831052300-120e615b17ba
 	github.com/rancher/channelserver v0.5.1-0.20230719220800-0a37b73c7df8
 	github.com/rancher/dynamiclistener v0.3.6-rc3-deadlock-fix-revert

--- a/go.sum
+++ b/go.sum
@@ -1031,8 +1031,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rancher/aks-operator v1.2.0-rc3 h1:EoTUWGIgCk4ffkx3Eq/RQSqanbGKpRKtXTqEusPp9yk=
-github.com/rancher/aks-operator v1.2.0-rc3/go.mod h1:ga4p9r8nTUuSRqkYLTBgA5OlPf19iT/i9Qa3kXH7H7Y=
+github.com/rancher/aks-operator v1.2.0-rc4 h1:khy3DWw/84jjgdgHwylZBwicelrcs/9rXEueRIOVaMc=
+github.com/rancher/aks-operator v1.2.0-rc4/go.mod h1:CIU0AgI4DHYKEG3P3tHyEM/5QEud7upDOiYL6j5D/qE=
 github.com/rancher/apiserver v0.0.0-20230831052300-120e615b17ba h1:ceAHvddZkuNbUTuMgqxYAcUSQ/+YtJQO9Z1PHjmQZBY=
 github.com/rancher/apiserver v0.0.0-20230831052300-120e615b17ba/go.mod h1:1m5KKYXq6iMZFQ5kiC9rBgVLfGRNR8E+lp88f5tEAsI=
 github.com/rancher/aws-iam-authenticator v0.5.9-0.20220713170329-78acb8c83863 h1:7cVEMgwyiVhLyu/Ywuw58mkkh9cWpFE3+X8IrWncBxU=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -8,7 +8,7 @@ replace github.com/rancher/wrangler v1.1.1 => github.com/rancher/wrangler v1.1.1
 replace k8s.io/client-go => github.com/rancher/client-go v1.27.4-rancher1
 
 require (
-	github.com/rancher/aks-operator v1.2.0-rc3
+	github.com/rancher/aks-operator v1.2.0-rc4
 	github.com/rancher/eks-operator v1.3.0-rc3
 	github.com/rancher/fleet/pkg/apis v0.0.0-20230912105714-0d26f206b3c5
 	github.com/rancher/gke-operator v1.2.0-rc1

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -475,8 +475,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rancher/aks-operator v1.2.0-rc3 h1:EoTUWGIgCk4ffkx3Eq/RQSqanbGKpRKtXTqEusPp9yk=
-github.com/rancher/aks-operator v1.2.0-rc3/go.mod h1:ga4p9r8nTUuSRqkYLTBgA5OlPf19iT/i9Qa3kXH7H7Y=
+github.com/rancher/aks-operator v1.2.0-rc4 h1:khy3DWw/84jjgdgHwylZBwicelrcs/9rXEueRIOVaMc=
+github.com/rancher/aks-operator v1.2.0-rc4/go.mod h1:CIU0AgI4DHYKEG3P3tHyEM/5QEud7upDOiYL6j5D/qE=
 github.com/rancher/client-go v1.27.4-rancher1 h1:1W1A0bV6KXYbu1z+KIezlfLsHPc1wiasAM42BICVKBM=
 github.com/rancher/client-go v1.27.4-rancher1/go.mod h1:ragcly7lUlN0SRPk5/ZkGnDjPknzb37TICq07WhI6Xc=
 github.com/rancher/eks-operator v1.3.0-rc3 h1:+esw+A1iNaqSqV/fyk08XIwgm0lhqhjcvvvcnyiwDEs=


### PR DESCRIPTION
Update aks-operator to v1.2.0-rc4

Changelog: https://github.com/rancher/aks-operator/releases/tag/v1.2.0-rc4

cc @rancher/highlander