### PR TITLE
Bump UI to 2.8.0-alpha1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -163,8 +163,8 @@ RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && \
     chmod +x /usr/bin/tini /usr/bin/telemetry && \
     mkdir -p /var/lib/rancher-data/driver-metadata
 
-ENV CATTLE_UI_VERSION 2.7.7-rc2
-ENV CATTLE_DASHBOARD_UI_VERSION v2.7.7-rc2
+ENV CATTLE_UI_VERSION 2.8.0-alpha1
+ENV CATTLE_DASHBOARD_UI_VERSION v2.8.0-alpha1
 ENV CATTLE_CLI_VERSION v2.7.6-rc1
 
 # Base UI brand used as a fallback env setting (not user facing) to indicate this is a non-prime install


### PR DESCRIPTION
Supersedes rancher/rancher#42899
Supersedes rancher/rancher#42899

Because their Github action did not trigger on these prs.