### PR TITLE
Allow multiple versions of rancher-istio to be supported in airgap se…

### DIFF
--- a/pkg/image/charts.go
+++ b/pkg/image/charts.go
@@ -25,7 +25,9 @@ const RancherVersionAnnotationKey = "catalog.cattle.io/rancher-version"
 // Rancher version constraints to allow support for multiple version lines of a chart in airgap setups. If a chart is
 // not defined here, only the latest version of it will be checked for images.
 // Note: CRD charts need to be added as well.
-var chartsToCheckConstraints = map[string]struct{}{}
+var chartsToCheckConstraints = map[string]struct{}{
+	"rancher-istio": {},
+}
 var systemChartsToCheckConstraints = map[string]struct{}{
 	"rancher-monitoring": {},
 }


### PR DESCRIPTION
JIRA Issue - https://jira.suse.com/browse/SURE-5595
GitHub Issue - https://github.com/rancher/rancher/issues/42885

Currently, we only support the latest version of a particular chart in rancher/charts in Rancher airgap setups that is we only add container images of the latest version of a chart in rancher/charts in rancher-images.txt for a particular Rancher release. This cannot be valid for the rancher-istio chart since Istio recommends not skipping minor versions while upgrading Istio https://istio.io/latest/docs/setup/upgrade/