### PR TITLE
guid-unmigration: add unit tests for utility functions and duplicate resource identification

### DIFF
--- a/pkg/agent/clean/adunmigration/ldap_test.go
+++ b/pkg/agent/clean/adunmigration/ldap_test.go
@@ -1,0 +1,76 @@
+package adunmigration
+
+import (
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	logrusTest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeUUID(t *testing.T) {
+	// Note: Because Rancher wrote these strings, the input format we care about is somewhat
+	// constrained, and we're not spending too much effort dealing with edge cases.
+	guidString := "953d82a03d47a5498330293e386dfce1"
+	wantEscapedString := "\\95\\3d\\82\\a0\\3d\\47\\a5\\49\\83\\30\\29\\3e\\38\\6d\\fc\\e1"
+	result := escapeUUID(guidString)
+	if result != wantEscapedString {
+		t.Errorf("expected escapeUUID to be %v, but got %v", wantEscapedString, result)
+	}
+}
+
+func TestIsGUID(t *testing.T) {
+	hook := logrusTest.NewGlobal()
+	logrus.SetOutput(io.Discard)
+
+	tests := []struct {
+		name            string
+		principalId     string
+		wantResult      bool
+		wantLoggedError bool
+	}{
+		{
+			name:            "Local User",
+			principalId:     "local://u-fydcaomakf",
+			wantResult:      false,
+			wantLoggedError: false,
+		},
+		{
+			name:            "AD user, DN based",
+			principalId:     "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+			wantResult:      false,
+			wantLoggedError: false,
+		},
+		{
+			name:            "AD user, GUID based",
+			principalId:     "activedirectory_user://953d82a03d47a5498330293e386dfce1",
+			wantResult:      true,
+			wantLoggedError: false,
+		},
+		{
+			name:            "Invalid principal",
+			principalId:     "wat",
+			wantResult:      false,
+			wantLoggedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			result := isGUID(test.principalId)
+			if result != test.wantResult {
+				t.Errorf("expected isGUID to be %v, but got %v", test.wantResult, result)
+			}
+			// This particular function treats invalid principal IDs as a soft error: an invalid ID is by
+			// definition not a valid GUID. We generate a log if this happens, so let's make sure we got
+			// that log:
+			if test.wantLoggedError {
+				assert.GreaterOrEqual(t, len(hook.Entries), 1)
+				assert.Equal(t, hook.LastEntry().Level, logrus.ErrorLevel)
+			}
+			hook.Reset()
+		})
+	}
+}

--- a/pkg/agent/clean/adunmigration/ldap_test.go
+++ b/pkg/agent/clean/adunmigration/ldap_test.go
@@ -52,6 +52,12 @@ func TestIsGUID(t *testing.T) {
 			wantResult:      false,
 			wantLoggedError: true,
 		},
+		{
+			name:            "Empty String",
+			principalId:     "",
+			wantResult:      false,
+			wantLoggedError: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/agent/clean/adunmigration/ldap_test.go
+++ b/pkg/agent/clean/adunmigration/ldap_test.go
@@ -9,17 +9,17 @@ import (
 )
 
 func TestEscapeUUID(t *testing.T) {
+	t.Parallel()
 	// Note: Because Rancher wrote these strings, the input format we care about is somewhat
 	// constrained, and we're not spending too much effort dealing with edge cases.
 	guidString := "953d82a03d47a5498330293e386dfce1"
 	wantEscapedString := "\\95\\3d\\82\\a0\\3d\\47\\a5\\49\\83\\30\\29\\3e\\38\\6d\\fc\\e1"
 	result := escapeUUID(guidString)
-	if result != wantEscapedString {
-		t.Errorf("expected escapeUUID to be %v, but got %v", wantEscapedString, result)
-	}
+	assert.Equal(t, wantEscapedString, result)
 }
 
 func TestIsGUID(t *testing.T) {
+	// Note: because logrus state is global, we cannot use t.Parallel here
 	hook := logrusTest.NewGlobal()
 
 	tests := []struct {

--- a/pkg/agent/clean/adunmigration/ldap_test.go
+++ b/pkg/agent/clean/adunmigration/ldap_test.go
@@ -1,7 +1,6 @@
 package adunmigration
 
 import (
-	"io"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -22,7 +21,6 @@ func TestEscapeUUID(t *testing.T) {
 
 func TestIsGUID(t *testing.T) {
 	hook := logrusTest.NewGlobal()
-	logrus.SetOutput(io.Discard)
 
 	tests := []struct {
 		name            string
@@ -50,7 +48,7 @@ func TestIsGUID(t *testing.T) {
 		},
 		{
 			name:            "Invalid principal",
-			principalId:     "wat",
+			principalId:     "fail-on-purpose",
 			wantResult:      false,
 			wantLoggedError: true,
 		},

--- a/pkg/agent/clean/adunmigration/rtbs_test.go
+++ b/pkg/agent/clean/adunmigration/rtbs_test.go
@@ -1,0 +1,137 @@
+package adunmigration
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testGuid                        = "953d82a03d47a5498330293e386dfce1"
+	testDn                          = "CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space"
+	testDnLocalName                 = "user-vhhxd"
+	testGuidLocalName               = "u-fydcaomakf"
+	testDuplicateGuidLocalName      = "u-quuknbiweg"
+	testGuidPrincipal               = "activedirectory_user://" + testGuid
+	testDnPrincipal                 = "activedirectory_user://" + testDn
+	testDnLocalPrincipal            = "local://" + testDnLocalName
+	testGuidLocalPrincipal          = "local://" + testGuidLocalName
+	testDuplicateGuidLocalPrincipal = "local://" + testDuplicateGuidLocalName
+)
+
+func guidOriginalWorkunit() migrateUserWorkUnit {
+	// The "success" case for the original migration logic: only the GUID is left, with no extra copies
+	return migrateUserWorkUnit{
+		guid:              testGuid,
+		distinguishedName: testDn,
+		originalUser: &v3.User{
+			ObjectMeta:   metav1.ObjectMeta{Name: testGuidLocalName},
+			PrincipalIDs: []string{testGuidLocalPrincipal, testGuidPrincipal}},
+	}
+}
+
+func guidOriginalGuidDuplicateWorkunit() migrateUserWorkUnit {
+	// An uncommon case caused by a race condition: the older GUID-based user was migrated, but not
+	// before a newer GUID-based duplicate was created. After this, the affected user can no longer log in
+	// due to both users having the same principal ID
+	return migrateUserWorkUnit{
+		guid:              testGuid,
+		distinguishedName: testDn,
+		originalUser: &v3.User{
+			ObjectMeta:   metav1.ObjectMeta{Name: testGuidLocalName},
+			PrincipalIDs: []string{testGuidLocalPrincipal, testGuidPrincipal},
+		},
+		duplicateUsers: []*v3.User{{
+			ObjectMeta:   metav1.ObjectMeta{Name: testDuplicateGuidLocalName},
+			PrincipalIDs: []string{testDuplicateGuidLocalPrincipal, testGuidPrincipal}}},
+	}
+}
+
+func dnOriginalGuidDuplicateWorkunit() migrateUserWorkUnit {
+	// Caused by a failure to migrate the original user. A new GUID-based user is
+	// then created at the next login with none of the original permissions.
+	return migrateUserWorkUnit{
+		guid:              testGuid,
+		distinguishedName: testDn,
+		originalUser: &v3.User{
+			ObjectMeta:   metav1.ObjectMeta{Name: testDnLocalName},
+			PrincipalIDs: []string{testDnLocalPrincipal, testDnPrincipal}},
+		duplicateUsers: []*v3.User{{
+			ObjectMeta:   metav1.ObjectMeta{Name: testGuidLocalName},
+			PrincipalIDs: []string{testGuidLocalPrincipal, testGuidPrincipal}}},
+	}
+}
+
+func TestIdentifyCRTBs(t *testing.T) {
+	//t.Parallel()
+
+	tests := []struct {
+		name                    string
+		workunit                migrateUserWorkUnit
+		crtbs                   []v3.ClusterRoleTemplateBinding
+		wantAdCrtbs             int
+		wantDuplicateLocalCrtbs int
+	}{
+		{
+			name:     "Guid-based CRTB referencing Original GUID-based user will be migrated",
+			workunit: guidOriginalWorkunit(),
+			crtbs: []v3.ClusterRoleTemplateBinding{
+				{UserName: testGuidLocalName, UserPrincipalName: testGuidPrincipal},
+			},
+			wantAdCrtbs:             1,
+			wantDuplicateLocalCrtbs: 0,
+		},
+		{
+			name:     "Local-based CRTB referencing Original GUID-based user will not be migrated",
+			workunit: guidOriginalWorkunit(),
+			crtbs: []v3.ClusterRoleTemplateBinding{
+				{UserName: testGuidLocalName, UserPrincipalName: testGuidLocalPrincipal},
+			},
+			wantAdCrtbs:             0,
+			wantDuplicateLocalCrtbs: 0,
+		},
+		{
+			name:     "Guid-based CRTB referencing Duplicate GUID-based user will be migrated",
+			workunit: guidOriginalGuidDuplicateWorkunit(),
+			crtbs: []v3.ClusterRoleTemplateBinding{
+				{UserName: testDuplicateGuidLocalName, UserPrincipalName: testGuidPrincipal},
+			},
+			wantAdCrtbs:             1,
+			wantDuplicateLocalCrtbs: 0,
+		},
+		{
+			name:     "Local-based CRTB referencing Duplicate GUID-based user will be migrated",
+			workunit: guidOriginalGuidDuplicateWorkunit(),
+			crtbs: []v3.ClusterRoleTemplateBinding{
+				{UserName: testDuplicateGuidLocalName, UserPrincipalName: testDuplicateGuidLocalPrincipal},
+			},
+			wantAdCrtbs:             0,
+			wantDuplicateLocalCrtbs: 1,
+		},
+		{
+			name:     "DN-based CRTB referencing Original DN-based user will not be migrated",
+			workunit: dnOriginalGuidDuplicateWorkunit(),
+			crtbs: []v3.ClusterRoleTemplateBinding{
+				{UserName: testDnLocalName, UserPrincipalName: testDnLocalPrincipal},
+			},
+			wantAdCrtbs:             0,
+			wantDuplicateLocalCrtbs: 0,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			//t.Parallel()
+			crtbList := v3.ClusterRoleTemplateBindingList{Items: test.crtbs}
+			workunitList := []migrateUserWorkUnit{test.workunit}
+			identifyCRTBs(&workunitList, &crtbList)
+
+			assert.Equal(t, test.wantAdCrtbs, len(workunitList[0].activeDirectoryCRTBs), "expected AD-based CRTBs must match")
+			assert.Equal(t, test.wantDuplicateLocalCrtbs, len(workunitList[0].duplicateLocalCRTBs), "expected duplicate Local-based CRTBs must match")
+		})
+	}
+
+}

--- a/pkg/agent/clean/adunmigration/users_test.go
+++ b/pkg/agent/clean/adunmigration/users_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsAdUser(t *testing.T) {
@@ -47,9 +48,7 @@ func TestIsAdUser(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			result := isAdUser(&test.user)
-			if result != test.wantResult {
-				t.Errorf("expected isAdUser to be %v, but got %v", test.wantResult, result)
-			}
+			assert.Equal(t, test.wantResult, result)
 		})
 	}
 }
@@ -94,12 +93,12 @@ func TestGetExternalId(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			result, err := getExternalID(test.principalId)
-			if test.wantError && err == nil {
-				t.Errorf("expected error for invalid principalId %v", test.principalId)
+			if test.wantError {
+				assert.Error(t, err, "expected error")
+			} else {
+				assert.NoError(t, err, "unexpected error")
 			}
-			if result != test.wantResult {
-				t.Errorf("expected getExternalID to be %v, but got %v", test.wantResult, result)
-			}
+			assert.Equal(t, test.wantResult, result)
 		})
 	}
 }
@@ -144,12 +143,12 @@ func TestGetScope(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			result, err := getScope(test.principalId)
-			if test.wantError && err == nil {
-				t.Errorf("expected error for invalid principalId %v", test.principalId)
+			if test.wantError {
+				assert.Error(t, err, "expected error")
+			} else {
+				assert.NoError(t, err, "unexpected error")
 			}
-			if result != test.wantResult {
-				t.Errorf("expected getExternalID to be %v, but got %v", test.wantResult, result)
-			}
+			assert.Equal(t, test.wantResult, result)
 		})
 	}
 }

--- a/pkg/agent/clean/adunmigration/users_test.go
+++ b/pkg/agent/clean/adunmigration/users_test.go
@@ -86,6 +86,12 @@ func TestGetExternalId(t *testing.T) {
 			wantResult:  "",
 			wantError:   true,
 		},
+		{
+			name:        "Empty String",
+			principalId: "",
+			wantResult:  "",
+			wantError:   true,
+		},
 	}
 
 	for _, test := range tests {
@@ -133,6 +139,12 @@ func TestGetScope(t *testing.T) {
 		{
 			name:        "Invalid principal",
 			principalId: "fail-on-purpose",
+			wantResult:  "",
+			wantError:   true,
+		},
+		{
+			name:        "Empty String",
+			principalId: "",
 			wantResult:  "",
 			wantError:   true,
 		},

--- a/pkg/agent/clean/adunmigration/users_test.go
+++ b/pkg/agent/clean/adunmigration/users_test.go
@@ -1,0 +1,155 @@
+package adunmigration
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+)
+
+func TestIsAdUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		user       v3.User
+		wantResult bool
+	}{
+		{
+			name:       "Local user",
+			user:       v3.User{PrincipalIDs: []string{"local://u-fydcaomakf"}},
+			wantResult: false,
+		},
+		{
+			name: "AD user, DN based",
+			user: v3.User{PrincipalIDs: []string{
+				"local://u-fydcaomakf",
+				"activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space"}},
+			wantResult: true,
+		},
+		{
+			name: "AD user, GUID based",
+			user: v3.User{PrincipalIDs: []string{
+				"local://u-fydcaomakf",
+				"activedirectory_user://953d82a03d47a5498330293e386dfce1"}},
+			wantResult: true,
+		},
+		{
+			name: "Non-local, non-AD user",
+			user: v3.User{PrincipalIDs: []string{
+				"local://u-fydcaomakf",
+				"okta_user://test.user@example.com"}},
+			wantResult: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := isAdUser(&test.user)
+			if result != test.wantResult {
+				t.Errorf("expected isAdUser to be %v, but got %v", test.wantResult, result)
+			}
+		})
+	}
+}
+
+func TestGetExternalId(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		principalId string
+		wantResult  string
+		wantError   bool
+	}{
+		{
+			name:        "Local User",
+			principalId: "local://u-fydcaomakf",
+			wantResult:  "u-fydcaomakf",
+			wantError:   false,
+		},
+		{
+			name:        "AD user, DN based",
+			principalId: "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+			wantResult:  "CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+			wantError:   false,
+		},
+		{
+			name:        "AD user, GUID based",
+			principalId: "activedirectory_user://953d82a03d47a5498330293e386dfce1",
+			wantResult:  "953d82a03d47a5498330293e386dfce1",
+			wantError:   false,
+		},
+		{
+			name:        "Invalid principal",
+			principalId: "wat",
+			wantResult:  "",
+			wantError:   true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := getExternalID(test.principalId)
+			if test.wantError && err == nil {
+				t.Errorf("expected error for invalid principalId %v", test.principalId)
+			}
+			if result != test.wantResult {
+				t.Errorf("expected getExternalID to be %v, but got %v", test.wantResult, result)
+			}
+		})
+	}
+}
+
+func TestGetScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		principalId string
+		wantResult  string
+		wantError   bool
+	}{
+		{
+			name:        "Local User",
+			principalId: "local://u-fydcaomakf",
+			wantResult:  "local",
+			wantError:   false,
+		},
+		{
+			name:        "AD user, DN based",
+			principalId: "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+			wantResult:  "activedirectory_user",
+			wantError:   false,
+		},
+		{
+			name:        "AD user, GUID based",
+			principalId: "activedirectory_user://953d82a03d47a5498330293e386dfce1",
+			wantResult:  "activedirectory_user",
+			wantError:   false,
+		},
+		{
+			name:        "Invalid principal",
+			principalId: "wat",
+			wantResult:  "",
+			wantError:   true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := getScope(test.principalId)
+			if test.wantError && err == nil {
+				t.Errorf("expected error for invalid principalId %v", test.principalId)
+			}
+			if result != test.wantResult {
+				t.Errorf("expected getExternalID to be %v, but got %v", test.wantResult, result)
+			}
+		})
+	}
+}

--- a/pkg/agent/clean/adunmigration/users_test.go
+++ b/pkg/agent/clean/adunmigration/users_test.go
@@ -83,7 +83,7 @@ func TestGetExternalId(t *testing.T) {
 		},
 		{
 			name:        "Invalid principal",
-			principalId: "wat",
+			principalId: "fail-on-purpose",
 			wantResult:  "",
 			wantError:   true,
 		},
@@ -133,7 +133,7 @@ func TestGetScope(t *testing.T) {
 		},
 		{
 			name:        "Invalid principal",
-			principalId: "wat",
+			principalId: "fail-on-purpose",
 			wantResult:  "",
 			wantError:   true,
 		},


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42328
 
## Testing
Adds unit tests for several utility functions, as well as identifyCRTBs, identifyPRTBs and identifyGRBs, improving overall coverage. These test only business logic, and require no network calls or external state, so they should be quite lightweight.

### Automated Testing
* Test types added/modified:
    * Unit
 