### PR TITLE
Added jenkinsfile that accepts a list of AMIs and provisions rke1 & r…

### DIFF
--- a/tests/v2/validation/Jenkinsfile_support_matrix_os
+++ b/tests/v2/validation/Jenkinsfile_support_matrix_os
@@ -1,0 +1,238 @@
+#!groovy
+node {
+    def rootPath = "/go/src/github.com/rancher/rancher/tests/v2/validation/"
+    def job_name = "${JOB_NAME}"
+    if (job_name.contains('/')) { 
+      job_names = job_name.split('/')
+      job_name = job_names[job_names.size() - 1] 
+    }
+    def testContainer = "${job_name}${env.BUILD_NUMBER}_test"
+    def imageName = "rancher-validation-${job_name}${env.BUILD_NUMBER}"
+    def testsDir = "github.com/rancher/rancher/tests/v2/validation/${env.TEST_PACKAGE}"
+    def testResultsOut = "results.xml"
+    def envFile = ".env"
+    def rancherConfig = "rancher_env.config"
+    def branch = "release/v2.7"
+    if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
+      branch = "${env.BRANCH}"
+    }
+    def timeout = "60m"
+    if ("${env.TIMEOUT}" != "null" && "${env.TIMEOUT}" != "") {
+      timeout = "${env.TIMEOUT}" 
+    }
+    wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+      withFolderProperties {
+        paramsMap = []
+        params.each {
+          if (it.value && it.value.trim() != "") {
+              paramsMap << "$it.key=$it.value"
+          }
+        }
+        withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                          string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+                          string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'RANCHER_EKS_ACCESS_KEY'),
+                          string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'RANCHER_EKS_SECRET_KEY'),
+                          string(credentialsId: 'DO_ACCESSKEY', variable: 'DO_ACCESSKEY'),
+                          string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                          string(credentialsId: 'RANCHER_SSH_KEY', variable: 'RANCHER_SSH_KEY'),
+                          string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'AZURE_SUBSCRIPTION_ID'),
+                          string(credentialsId: 'AZURE_TENANT_ID', variable: 'AZURE_TENANT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_ID', variable: 'AZURE_CLIENT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'AZURE_CLIENT_SECRET'),
+                          string(credentialsId: 'AZURE_AKS_SUBSCRIPTION_ID', variable: 'RANCHER_AKS_SUBSCRIPTION_ID'),
+                          string(credentialsId: 'AZURE_TENANT_ID', variable: 'RANCHER_AKS_TENANT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_ID', variable: 'RANCHER_AKS_CLIENT_ID'),
+                          string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'RANCHER_AKS_SECRET_KEY'),
+                          string(credentialsId: 'RANCHER_REGISTRY_USER_NAME', variable: 'RANCHER_REGISTRY_USER_NAME'),
+                          string(credentialsId: 'RANCHER_REGISTRY_PASSWORD', variable: 'RANCHER_REGISTRY_PASSWORD'),
+                          string(credentialsId: 'RANCHER_AD_SPECIAL_CHAR_PASSWORD', variable: 'RANCHER_AD_SPECIAL_CHAR_PASSWORD'),
+                          string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD'),
+                          string(credentialsId: 'USER_PASSWORD', variable: 'USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_GKE_CREDENTIAL', variable: 'RANCHER_GKE_CREDENTIAL'),
+                          string(credentialsId: 'RANCHER_AUTH_USER_PASSWORD', variable: 'RANCHER_AUTH_USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_HOSTNAME_OR_IP_ADDRESS', variable: 'RANCHER_HOSTNAME_OR_IP_ADDRESS'),
+                          string(credentialsId: 'RANCHER_CA_CERTIFICATE', variable: 'RANCHER_CA_CERTIFICATE'),
+                          string(credentialsId: 'RANCHER_SERVICE_ACCOUNT_NAME', variable: 'RANCHER_SERVICE_ACCOUNT_NAME'),
+                          string(credentialsId: 'RANCHER_SERVICE_ACCOUNT_PASSWORD', variable: 'RANCHER_SERVICE_ACCOUNT_PASSWORD'),
+                          string(credentialsId: 'RANCHER_USER_SEARCH_BASE', variable: 'RANCHER_USER_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_DEFAULT_LOGIN_DOMAIN', variable: 'RANCHER_DEFAULT_LOGIN_DOMAIN'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_NAME', variable: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_NAME'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_PASSWORD', variable: 'RANCHER_OPENLDAP_SERVICE_ACCOUNT_PASSWORD'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_USER_SEARCH_BASE', variable: 'RANCHER_OPENLDAP_USER_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_AUTH_USER_PASSWORD', variable: 'RANCHER_OPENLDAP_AUTH_USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_HOSTNAME_OR_IP_ADDRESS', variable: 'RANCHER_OPENLDAP_HOSTNAME_OR_IP_ADDRESS'),
+                          string(credentialsId: 'RANCHER_OPENLDAP_SPECIAL_CHAR_PASSWORD', variable: 'RANCHER_OPENLDAP_SPECIAL_CHAR_PASSWORD'),
+                          string(credentialsId: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_NAME', variable: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_NAME'),
+                          string(credentialsId: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_PASSWORD', variable: 'RANCHER_FREEIPA_SERVICE_ACCOUNT_PASSWORD'),
+                          string(credentialsId: 'RANCHER_FREEIPA_USER_SEARCH_BASE', variable: 'RANCHER_FREEIPA_USER_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_FREEIPA_GROUP_SEARCH_BASE', variable: 'RANCHER_FREEIPA_GROUP_SEARCH_BASE'),
+                          string(credentialsId: 'RANCHER_FREEIPA_AUTH_USER_PASSWORD', variable: 'RANCHER_FREEIPA_AUTH_USER_PASSWORD'),
+                          string(credentialsId: 'RANCHER_FREEIPA_HOSTNAME_OR_IP_ADDRESS', variable: 'RANCHER_FREEIPA_HOSTNAME_OR_IP_ADDRESS'),
+                          string(credentialsId: 'RANCHER_FREEIPA_SPECIAL_CHAR_PASSWORD', variable: 'RANCHER_FREEIPA_SPECIAL_CHAR_PASSWORD'),
+                          string(credentialsId: 'RANCHER_VALID_TLS_CERT', variable: 'RANCHER_VALID_TLS_CERT'),
+                          string(credentialsId: 'RANCHER_VALID_TLS_KEY', variable: 'RANCHER_VALID_TLS_KEY'),
+                          string(credentialsId: 'RANCHER_BYO_TLS_CERT', variable: 'RANCHER_BYO_TLS_CERT'),
+                          string(credentialsId: 'RANCHER_BYO_TLS_KEY', variable: 'RANCHER_BYO_TLS_KEY'),
+                          string(credentialsId: 'RANCHER_LINODE_ACCESSKEY', variable: "RANCHER_LINODE_ACCESSKEY")]) {
+          
+        withEnv(paramsMap) {
+          stage('Checkout') {
+            deleteDir()
+            checkout([
+                      $class: 'GitSCM',
+                      branches: [[name: "*/${branch}"]],
+                      extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                      userRemoteConfigs: scm.userRemoteConfigs
+                    ])
+          }
+          dir ("./") {
+              stage('Configure and Build') {
+                if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
+                  dir("./tests/v2/validation/.ssh") {
+                    def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
+                    writeFile file: AWS_SSH_KEY_NAME, text: decoded
+                  }
+                }
+
+                sh "./tests/v2/validation/configure.sh"
+
+              }
+              stage('Run Jobs') {
+                dir("./tests/v2/validation/") {
+                  // install yq
+                  sh returnStdout: true, script: 'wget -qO ./yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64'
+                  sh returnStdout: true, script: 'chmod a+x ./yq'
+                  def amis = env.RANCHER_AMI_LIST
+
+                  def amisList = amis.split(',')
+                  for (int i = 0; i < amisList.size(); i++) {
+                    String ami
+                    String sshUser
+                    if (amisList[i].contains(':')){
+                    def data = amisList[i].split(':')
+                    ami = data[0]
+                    sshUser = data[1]
+                    } else {
+                    ami = amisList[i]
+                    sshUser = 'ec2-user'
+                    }
+
+                  // RKE1 Node Driver: awsNodeTemplate
+
+                  def awsNodeTemplateFilename = "awsNodeTemplate.yaml"
+                  def awsNodeTemplate = env.RANCHER_RKE1_NODE_CONFIG
+
+                  writeFile file: awsNodeTemplateFilename, text: awsNodeTemplate
+
+                  sh "./yq e '.awsNodeTemplate.ami = \"$ami\"' -i awsNodeTemplate.yaml"
+
+                  sh "./yq e '.awsNodeTemplate.sshUser = \"$sshUser\"' -i awsNodeTemplate.yaml"
+
+                  def awsNodeTemplateParam = readFile(file: './awsNodeTemplate.yaml')
+
+                  echo awsNodeTemplateParam
+
+                  // RKE2 Node Driver: awsMachineConfig
+
+                  def awsMachineConfigFilename = "awsMachineConfig.yaml"
+                  def awsMachineConfig = env.RANCHER_RKE2_NODE_CONFIG
+
+                  writeFile file: awsMachineConfigFilename, text: awsMachineConfig
+
+                  sh "./yq e '.awsMachineConfig.ami = \"$ami\"' -i awsMachineConfig.yaml"
+
+                  sh "./yq e '.awsMachineConfig.sshUser = \"$sshUser\"' -i awsMachineConfig.yaml"
+
+                  def awsMachineConfigParam = readFile(file: './awsMachineConfig.yaml')
+
+                  echo awsMachineConfigParam
+
+                  // Single custom cluster config: awsEC2Config
+
+                  def awsEC2ConfigFilename = "awsEC2Config.yaml"
+                  def awsEC2Config = env.RANCHER_CUSTOM_CONFIG
+
+                  writeFile file: awsEC2ConfigFilename, text: awsEC2Config 
+
+                  sh "./yq e '.awsEC2Configs.awsEC2Config.[0].awsAMI = \"$ami\"' -i awsEC2Config.yaml"
+
+                  sh "./yq e '.awsEC2Configs.awsEC2Config.[0].awsUser = \"$sshUser\"' -i awsEC2Config.yaml"
+
+                  def awsEC2ConfigParam = readFile(file: './awsEC2Config.yaml')
+
+                  echo awsEC2ConfigParam
+
+                  rke1NodeParams = [
+                    string(name: 'TIMEOUT', value: "${env.TIMEOUT}"),
+                    text(name: 'CONFIG', value: awsNodeTemplateParam),
+                    string(name: 'TEST_PACKAGE', value: "${env.RANCHER_RKE1_TEST_PACKAGE}"),
+                    string(name: 'GOTEST_TESTCASE', value: "${env.RANCHER_RKE1_NODE_GOTEST_TESTCASE}"),
+                  ]
+                  rke2NodeParams = [
+                    string(name: 'TIMEOUT', value: "${env.TIMEOUT}"),
+                    text(name: 'CONFIG', value: awsMachineConfigParam),
+                    string(name: 'TEST_PACKAGE', value: "${env.RANCHER_RKE2_TEST_PACKAGE}"),
+                    string(name: 'GOTEST_TESTCASE', value: "${env.RANCHER_RKE2_NODE_GOTEST_TESTCASE}"),
+                  ]
+                  rke1CustomParams = [
+                    string(name: 'TIMEOUT', value: "${env.TIMEOUT}"),
+                    text(name: 'CONFIG', value: awsEC2ConfigParam),
+                    string(name: 'TEST_PACKAGE', value: "${env.RANCHER_RKE1_TEST_PACKAGE}"),
+                    string(name: 'GOTEST_TESTCASE', value: "${env.RANCHER_RKE1_CUSTOM_GOTEST_TESTCASE}"),
+                  ]
+                  rke2CustomParams = [
+                    string(name: 'TIMEOUT', value: "${env.TIMEOUT}"),
+                    text(name: 'CONFIG', value: awsEC2ConfigParam),
+                    string(name: 'TEST_PACKAGE', value: "${env.RANCHER_RKE2_TEST_PACKAGE}"),
+                    string(name: 'GOTEST_TESTCASE', value: "${env.RANCHER_RKE2_CUSTOM_GOTEST_TESTCASE}"),
+                  ]
+
+                  jobs = [:]
+
+                  failBuild = false
+                  failJobs =[]
+
+                  jobs["rke1node"] = { 
+                    try {build job: 'go-validation-provisioning', parameters: rke1NodeParams}
+                    catch (err) {
+                      echo err.toString()
+                      failBuild = true
+                    } 
+                  }
+                  jobs["rke2node"] = { 
+                    try {build job: 'go-validation-provisioning', parameters: rke2NodeParams}
+                    catch (err) {
+                      echo err.toString()
+                      failBuild = true
+                    } 
+                  }
+                  jobs["rke1custom"] = { 
+                    try {build job: 'go-validation-provisioning', parameters: rke1CustomParams}
+                    catch (err) {
+                      echo err.toString()
+                      failBuild = true
+                    } 
+                  }
+                  jobs["rke2custom"] = { 
+                    try {build job: 'go-validation-provisioning', parameters: rke2CustomParams}
+                    catch (err) {
+                      echo err.toString()
+                      failBuild = true
+                    } 
+                  }
+
+                  parallel jobs
+
+                }
+                
+                if (failBuild) {
+                    throw new Exception("some jobs failed")
+                }
+              }// 
+              }// run jobs
+          } // dir 
+        } // withEnv
+      } // creds
+    } // folder properties
+  } // wrap 
+} // node


### PR DESCRIPTION
…ke2 node drivers and custom clusters for each AMI

## Issue: <!-- [link the issue or issues this PR resolves here ] -->
(https://github.com/rancher/qa-tasks/issues/480)
 
## Problem
 Manually provisioning rke1 & rke2 node drivers and custom clusters for each supported OS takes a long time
 
## Solution
This test takes a comma separated list of AWS AMIs and provisions rke1 & rke2 node drivers and custom clusters for each one.
 ported from :https://github.com/rancher/rancher/pull/41061