### PR TITLE
Fix Flakey hostname truncation test backport

### DIFF
--- a/tests/v2/validation/provisioning/hostnametruncation/hostname_truncation_test.go
+++ b/tests/v2/validation/provisioning/hostnametruncation/hostname_truncation_test.go
@@ -41,6 +41,9 @@ func (r *HostnameTruncationTestSuite) SetupSuite() {
 	r.client = client
 }
 
+// TestProvisioningRKE2ClusterTruncation consist of several test that loop through three limits
+// for hostnames. The test starts at a minimum length limit of 10 characters, then a maximum length
+// limit of 63 characters and finally a middle length limit of 31 characters
 func (r *HostnameTruncationTestSuite) TestProvisioningRKE2ClusterTruncation() {
 	tests := []struct {
 		name                        string
@@ -74,7 +77,7 @@ func (r *HostnameTruncationTestSuite) TestProvisioningRKE2ClusterTruncation() {
 		{
 			name:                        "Cluster and machine pool level truncation - 31 characters",
 			machinePoolNameLengths:      []int{10, 31, 63},
-			hostnameLengthLimits:        []int{31, 31},
+			hostnameLengthLimits:        []int{31, 31, 31},
 			defaultHostnameLengthLimits: []int{10, 63, 31},
 		},
 	}


### PR DESCRIPTION
In order to avoid index errors all []int have to be the same size.  To get around this I added an extra value in the Cluster and machine pool level truncation test.

## Issue: [885](https://github.com/rancher/qa-tasks/issues/885)

 
## Problem
The Hostname truncation test was throwing an index error in its test loop because one of the int slices contained only two values. 
 
## Solution
For the test to work all of the slices have to be the same length, so the easy solution was to add the extra value to the Cluster and machine pool truncation test case.  I also added a comment to the test function to describe what the numbers in each int slice represent. 
 
