### PR TITLE
[2.8] requiring all healthy pods when deploying a cluster

### DIFF
--- a/tests/framework/extensions/provisioning/verify.go
+++ b/tests/framework/extensions/provisioning/verify.go
@@ -94,8 +94,7 @@ func VerifyRKE1Cluster(t *testing.T, client *rancher.Client, clustersConfig *clu
 		}
 	}
 
-	podResults, podErrors := pods.StatusPods(client, cluster.ID)
-	assert.NotEmpty(t, podResults)
+	podErrors := pods.StatusPods(client, cluster.ID)
 	assert.Empty(t, podErrors)
 }
 
@@ -162,9 +161,8 @@ func VerifyCluster(t *testing.T, client *rancher.Client, clustersConfig *cluster
 		VerifyACE(t, adminClient, mgmtClusterObject)
 	}
 
-	podResults, podErrors := pods.StatusPods(client, status.ClusterName)
+	podErrors := pods.StatusPods(client, status.ClusterName)
 	assert.Empty(t, podErrors)
-	assert.NotEmpty(t, podResults)
 
 	if clustersConfig.ClusterSSHTests != nil {
 		VerifySSHTests(t, client, cluster, clustersConfig.ClusterSSHTests, status.ClusterName)
@@ -197,8 +195,7 @@ func VerifyHostedCluster(t *testing.T, client *rancher.Client, cluster *manageme
 	err = nodestat.AllManagementNodeReady(client, cluster.ID, defaults.ThirtyMinuteTimeout)
 	require.NoError(t, err)
 
-	podResults, podErrors := pods.StatusPods(client, cluster.ID)
-	assert.NotEmpty(t, podResults)
+	podErrors := pods.StatusPods(client, cluster.ID)
 	assert.Empty(t, podErrors)
 }
 

--- a/tests/framework/extensions/registries/registries.go
+++ b/tests/framework/extensions/registries/registries.go
@@ -52,7 +52,7 @@ func CheckPodStatusImageSource(client *rancher.Client, clusterName, registryFQDN
 		return false, []error{err}
 	}
 
-	_, podErrors := pods.StatusPods(client, clusterID)
+	podErrors := pods.StatusPods(client, clusterID)
 	if len(podErrors) != 0 {
 		return false, []error{fmt.Errorf("error: pod(s) are in an error state  %v", podErrors)}
 	}

--- a/tests/framework/extensions/workloads/pods/pod_status.go
+++ b/tests/framework/extensions/workloads/pods/pod_status.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
@@ -17,86 +16,77 @@ const (
 
 // StatusPods is a helper function that uses the steve client to list pods on a namespace for a specific cluster
 // and return the statuses in a list of strings
-func StatusPods(client *rancher.Client, clusterID string) ([]string, []error) {
+func StatusPods(client *rancher.Client, clusterID string) []error {
 	downstreamClient, err := client.Steve.ProxyDownstream(clusterID)
 	if err != nil {
-		return nil, []error{err}
+		return []error{err}
 	}
 
-	var podResults []string
 	var podErrors []error
 
 	steveClient := downstreamClient.SteveType(PodResourceSteveType)
 	err = kwait.Poll(5*time.Second, 15*time.Minute, func() (done bool, err error) {
-		podResults = []string{}
+		// emptying pod errors every time we poll so that we don't return stale errors
 		podErrors = []error{}
 
 		pods, err := steveClient.List(nil)
 		if err != nil {
-			podErrors = append(podErrors, err)
+			// not returning the error in this case, as it could cause a false positive if we start polling too early.
 			return false, nil
 		}
 
-		podResults = append(podResults, "Pod's Status: \n")
-
 		for _, pod := range pods.Data {
-			podResult, podError, err := CheckPodStatus(&pod)
-			if err != nil {
+			isReady, err := IsPodReady(&pod)
+			if !isReady {
 				// not returning the error in this case, as it could cause a false positive if we start polling too early.
 				return false, nil
 			}
-			if podError != nil {
-				podErrors = append(podErrors, podError)
-				return false, nil
-			}
-			if podResult != "" {
-				podResults = append(podResults, podResult)
+
+			if err != nil {
+				podErrors = append(podErrors, err)
 			}
 		}
-
-		if len(podResults) > 0 && len(podErrors) == 0 {
-			return true, nil
-		}
-
-		return false, nil
+		return true, nil
 	})
 
 	if err != nil {
-		return nil, []error{err}
+		podErrors = append(podErrors, err)
 	}
 
-	return podResults, podErrors
+	return podErrors
 }
 
-// CheckPodStatus is a helper function that uses the steve client to check the status of a single pod
-func CheckPodStatus(pod *v1.SteveAPIObject) (podResults string, podError error, err error) {
+func IsPodReady(pod *v1.SteveAPIObject) (bool, error) {
 	podStatus := &corev1.PodStatus{}
-	err = v1.ConvertToK8sType(pod.Status, podStatus)
+	err := v1.ConvertToK8sType(pod.Status, podStatus)
 	if err != nil {
-		return "", nil, err
-	}
-	if podStatus.ContainerStatuses == nil || len(podStatus.ContainerStatuses) == 0 {
-		return fmt.Sprintf("WARN: %s: Container Status is Empty \n", pod.Name), nil, nil
+		return false, err
 	}
 
-	image := podStatus.ContainerStatuses[0].Image
+	if podStatus.ContainerStatuses == nil || len(podStatus.ContainerStatuses) == 0 {
+		return false, nil
+	}
+
 	phase := podStatus.Phase
 
+	if phase == corev1.PodPending {
+		return false, nil
+	}
+
 	if phase == corev1.PodFailed || phase == corev1.PodUnknown {
-		logrus.Infof("Pod %s: Not active | Image %s", pod.Name, image)
-		// Do not report as error if pod is in failed state due to container termination
+		var errorMessage string
 		for _, containerStatus := range podStatus.ContainerStatuses {
+			// Rancher deploys multiple hlem-operation jobs to do the same task. If one job succeeds, the others end in a terminated status.
 			if containerStatus.State.Terminated == nil {
-				return "", fmt.Errorf("ERROR: %s: %s", pod.Name, podStatus), nil
+				errorMessage += fmt.Sprintf("ERROR: %s: %s\n", pod.Name, podStatus)
 			}
 		}
-		return fmt.Sprintf("INFO: TERMINATED %s: %s\n", pod.Name, podStatus), nil, nil
+
+		if errorMessage != "" {
+			return true, fmt.Errorf(errorMessage)
+		}
 	}
 
-	if phase == corev1.PodRunning {
-		logrus.Infof("Pod %s: Active | Image: %s", pod.Name, image)
-		return fmt.Sprintf("INFO: %s: %s\n", pod.Name, podStatus), nil, nil
-	}
-
-	return "", nil, nil
+	// Pod is running or has succeeded
+	return true, nil
 }

--- a/tests/framework/extensions/workloads/pods/verify.go
+++ b/tests/framework/extensions/workloads/pods/verify.go
@@ -7,7 +7,6 @@ import (
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	projectv3 "github.com/rancher/rancher/pkg/client/generated/project/v3"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
-	steveV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,7 +21,7 @@ const (
 // state
 func VerifyReadyDaemonsetPods(t *testing.T, client *rancher.Client, cluster *v1.SteveAPIObject) {
 	status := &provv1.ClusterStatus{}
-	err := steveV1.ConvertToK8sType(cluster.Status, status)
+	err := v1.ConvertToK8sType(cluster.Status, status)
 	require.NoError(t, err)
 
 	daemonsetequals := false

--- a/tests/v2/validation/nodescaling/replace.go
+++ b/tests/v2/validation/nodescaling/replace.go
@@ -87,7 +87,6 @@ func ReplaceRKE1Nodes(t *testing.T, client *rancher.Client, clusterName string, 
 
 	require.True(t, isNodeReplaced)
 
-	podResults, podErrors := pods.StatusPods(client, clusterID)
-	assert.NotEmpty(t, podResults)
+	podErrors := pods.StatusPods(client, clusterID)
 	assert.Empty(t, podErrors)
 }

--- a/tests/v2/validation/prime/prime_test.go
+++ b/tests/v2/validation/prime/prime_test.go
@@ -79,9 +79,8 @@ func (t *PrimeTestSuite) TestSystemDefaultRegistry() {
 }
 
 func (t *PrimeTestSuite) TestLocalClusterRancherImages() {
-	podResults, podErrors := pods.StatusPods(t.client, localCluster)
+	podErrors := pods.StatusPods(t.client, localCluster)
 	assert.Empty(t.T(), podErrors)
-	assert.NotEmpty(t.T(), podResults)
 }
 
 func TestPrimeTestSuite(t *testing.T) {

--- a/tests/v2/validation/provisioning/registries/registry_test.go
+++ b/tests/v2/validation/provisioning/registries/registry_test.go
@@ -255,8 +255,7 @@ func (rt *RegistryTestSuite) TestRegistriesRKE() {
 		provisioning.VerifyRKE1Cluster(rt.T(), subClient, testConfig, clusterObject)
 	}
 
-	podResults, podErrors := pods.StatusPods(rt.client, rt.clusterLocalID)
-	assert.NotEmpty(rt.T(), podResults)
+	podErrors := pods.StatusPods(rt.client, rt.clusterLocalID)
 	assert.Empty(rt.T(), podErrors)
 	registries.CheckAllClusterPodsForRegistryPrefix(rt.client, rt.clusterLocalID, rt.localClusterGlobalRegistryHost)
 }
@@ -304,8 +303,7 @@ func (rt *RegistryTestSuite) TestRegistriesK3S() {
 		provisioning.VerifyCluster(rt.T(), subClient, testConfig, clusterObject)
 	}
 
-	podResults, podErrors := pods.StatusPods(rt.client, rt.clusterLocalID)
-	assert.NotEmpty(rt.T(), podResults)
+	podErrors := pods.StatusPods(rt.client, rt.clusterLocalID)
 	assert.Empty(rt.T(), podErrors)
 	registries.CheckAllClusterPodsForRegistryPrefix(rt.client, rt.clusterLocalID, rt.localClusterGlobalRegistryHost)
 }
@@ -353,8 +351,7 @@ func (rt *RegistryTestSuite) TestRegistriesRKE2() {
 		provisioning.VerifyCluster(rt.T(), subClient, testConfig, clusterObject)
 	}
 
-	podResults, podErrors := pods.StatusPods(rt.client, rt.clusterLocalID)
-	assert.NotEmpty(rt.T(), podResults)
+	podErrors := pods.StatusPods(rt.client, rt.clusterLocalID)
 	assert.Empty(rt.T(), podErrors)
 	registries.CheckAllClusterPodsForRegistryPrefix(rt.client, rt.clusterLocalID, rt.localClusterGlobalRegistryHost)
 }

--- a/tests/v2/validation/snapshot/snapshot.go
+++ b/tests/v2/validation/snapshot/snapshot.go
@@ -88,8 +88,7 @@ func snapshotRestore(t *testing.T, client *rancher.Client, clusterName string, u
 	err = clusters.WatchAndWaitForCluster(client, steveID)
 	require.NoError(t, err)
 
-	podResults, podErrors := pods.StatusPods(client, clusterID)
-	assert.NotEmpty(t, podResults)
+	podErrors := pods.StatusPods(client, clusterID)
 	assert.Empty(t, podErrors)
 	require.NoError(t, err)
 	require.Equal(t, initialKubernetesVersion, clusterObject.Spec.KubernetesVersion)
@@ -129,8 +128,7 @@ func snapshotRestore(t *testing.T, client *rancher.Client, clusterName string, u
 		err = clusters.WaitClusterToBeUpgraded(client, clusterID)
 		require.NoError(t, err)
 
-		podResults, podErrors = pods.StatusPods(client, clusterID)
-		assert.NotEmpty(t, podResults)
+		podErrors = pods.StatusPods(client, clusterID)
 		assert.Empty(t, podErrors)
 		require.NoError(t, err)
 		require.Equal(t, upgradeKubernetesVersion, clusterObject.Spec.KubernetesVersion)
@@ -152,8 +150,7 @@ func snapshotRestore(t *testing.T, client *rancher.Client, clusterName string, u
 	err = clusters.WaitClusterToBeUpgraded(client, clusterID)
 	require.NoError(t, err)
 
-	podResults, podErrors = pods.StatusPods(client, clusterID)
-	assert.NotEmpty(t, podResults)
+	podErrors = pods.StatusPods(client, clusterID)
 	assert.Empty(t, podErrors)
 	require.NoError(t, err)
 	require.Equal(t, initialKubernetesVersion, clusterObject.Spec.KubernetesVersion)
@@ -215,14 +212,11 @@ func createIngress(client *steveV1.Client, ingressName string, serviceName strin
 		}
 		for _, pod := range newPods.Data {
 			if strings.Contains(pod.Name, "rke2-ingress-nginx") || strings.Contains(pod.Name, "rancher-webhook") {
-				_, podError, err := pods.CheckPodStatus(&pod)
-				if err != nil {
-					return false, err
-				}
+				isReady, podError := pods.IsPodReady(&pod)
 				if podError != nil {
 					return false, nil
 				}
-				return true, nil
+				return isReady, nil
 			}
 		}
 		return false, nil

--- a/tests/v2/validation/upgrade/kubernetes_test.go
+++ b/tests/v2/validation/upgrade/kubernetes_test.go
@@ -137,7 +137,6 @@ func (u *UpgradeKubernetesTestSuite) testUpgradeSingleCluster(clusterName, versi
 		require.NoError(u.T(), err)
 	}
 
-	podResults, podErrors := pods.StatusPods(client, clusterMeta.ID)
-	assert.NotEmpty(u.T(), podResults)
+	podErrors := pods.StatusPods(client, clusterMeta.ID)
 	assert.Empty(u.T(), podErrors)
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 https://github.com/rancher/qa-tasks/issues/937
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 currently, validation only checks that once one pod is ready, that no others are in an error state. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
update the pod validation to validate that no pods are in an error state, and that all pods are healthy. 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
locally on rke2, windows

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_