### PR TITLE
Trust /go/src/github.com/rancher/rancher with git in the build image

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -19,6 +19,9 @@ RUN zypper -n install gcc binutils glibc-devel-static ca-certificates git-core w
 # use containerd from k3s image, not from bci
 RUN zypper install -y -f docker && rpm -e --nodeps --noscripts containerd
 
+# prevents `detected dubious ownership in repository` git error due to uid/gid not matching when using bind mounts
+RUN git config -f /etc/gitconfig --add safe.directory /go/src/github.com/rancher/rancher
+
 RUN curl -sLf https://github.com/rancher/machine/releases/download/${CATTLE_MACHINE_VERSION}/rancher-machine-${ARCH}.tar.gz | tar xvzf - -C /usr/bin
 RUN if [ "${ARCH}" != "s390x" ]; then \
         curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash; \


### PR DESCRIPTION
## Context

The dapper `bind` mode (`dapper --mode=bind` or `DAPPER_MODE=bind`) is ~~only available on linux and it~~ improves the build time by quite a bit:


**Copy mode (default)**

```
$ time DAPPER_MODE=copy make build
...
real	0m21.415s
user	0m0.930s
sys	0m0.667s
```

**Bind mode**

```
$ time DAPPER_MODE=bind make build
...
real	0m6.928s
user	0m0.195s
sys	0m0.111s
```


**Direct go build**

Slightly faster than bind mounts. This is what I currently use (along with `go run`) to avoid having to wait 20+ second every build. I'd rather be able to use the standard dapper scripts as everyone else though.

```
real	0m4.861s
user	0m9.663s
sys	0m1.907s
```

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Builds fail when using `DAPPER_MODE=bind` due to the following git error:

```
# any git command:
fatal: detected dubious ownership in repository at '/go/src/github.com/rancher/rancher'
To add an exception for this directory, call:

        git config --global --add safe.directory /go/src/github.com/rancher/rancher
```

This is a somewhat recent change in git where it fails any command when the uid/gid don't match. In the dapper container, the uid,gid == 0, but the git repo has uid,gid == 1000 (my user).
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Running `git config -f /etc/gitconfig --add safe.directory /go/src/github.com/rancher/rancher` in the build container will allow the bind mode to work. This is the only solution that I found that wouldn't mess with files on the host. Other solutions I tried:
- Using `RUN git config --global`: This wouldn't work because /root gets overwritten when mounting (`make build`, etc)
- Using `git config --global` in `script/entry`: This would add a `.gitconfig` file in rancher's directory, not very clean, we'd have to add an entry in `gitignore`.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

I've only tested that rancher compiles. 