### PR TITLE
Add depth=1 for git fetch in pkg/catalogv2

### DIFF
--- a/pkg/catalogv2/git/git.go
+++ b/pkg/catalogv2/git/git.go
@@ -186,6 +186,7 @@ func (r *Repository) setRepoOptions() {
 	r.fetchOpts.RemoteURL = r.URL
 	r.fetchOpts.InsecureSkipTLS = r.insecureTLSVerify
 	r.fetchOpts.Tags = gogit.NoTags
+	r.fetchOpts.Depth = 1
 
 	// List Options
 	r.listOpts.InsecureSkipTLS = r.insecureTLSVerify

--- a/pkg/catalogv2/git/git_test.go
+++ b/pkg/catalogv2/git/git_test.go
@@ -131,6 +131,8 @@ func TestBuildRepoConfig(t *testing.T) {
 			}
 		}
 		// testing local repository configurations
+		assert.Equal(t, repo.fetchOpts.Depth, 1)
+		assert.Equal(t, repo.cloneOpts.Depth, 1)
 		assert.Contains(t, repo.Directory, tc.namespace, "Directory %s should contain the namespace %s", repo.Directory, tc.namespace)
 		assert.Contains(t, repo.Directory, tc.name, "Directory %s should contain the chart name %s", repo.Directory, tc.name)
 		assert.Equal(t, repo.URL, tc.gitURL)


### PR DESCRIPTION
GitHub Issue - https://github.com/rancher/rancher/issues/42888

Gogit has a bug https://github.com/go-git/go-git/issues/845. Until it is fixed, we follow as they recommended i.e use depth=1 for fetching
