### PR TITLE
Fix git err typo

### DIFF
--- a/pkg/catalogv2/git/git.go
+++ b/pkg/catalogv2/git/git.go
@@ -227,11 +227,11 @@ func (r *Repository) cloneOrOpen(branch string) error {
 
 	openErr := r.plainOpen()
 	if openErr != nil && openErr != gogit.ErrRepositoryNotExists {
-		return fmt.Errorf("plainOpen failure: %w", err)
+		return fmt.Errorf("plainOpen failure: %w", openErr)
 	} else if openErr == gogit.ErrRepositoryNotExists {
 		repoGogit, cloneErr := gogit.PlainClone(r.Directory, false, cloneOptions)
 		if cloneErr != nil && cloneErr != gogit.ErrRepositoryAlreadyExists {
-			return fmt.Errorf("plainClone failure: %w", err)
+			return fmt.Errorf("plainClone failure: %w", cloneErr)
 		}
 		// serious problem warning
 		if openErr == gogit.ErrRepositoryNotExists && cloneErr == gogit.ErrRepositoryAlreadyExists {


### PR DESCRIPTION
## Issue

https://github.com/rancher/rancher/issues/43025

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When a clone or open of a git repo fails, we see the following:

```
2023/09/25 13:51:42 [ERROR] error syncing 'rancher-charts': handler helm-clusterrepo-download: failed to clone or open repository: plainClone failure: %!!(MISSING)w(<nil>), requeuing                                                                                                                                          
2023/09/25 13:51:42 [ERROR] error syncing 'rancher-rke2-charts': handler helm-clusterrepo-ensure: failed to clone or open repository: plainClone failure: %!!(MISSING)w(<nil>), requeuing                                                                                                                                       
2023/09/25 13:51:43 [ERROR] error syncing 'rancher-charts': handler helm-clusterrepo-download: failed to clone or open repository: plainClone failure: %!!(MISSING)w(<nil>), requeuing  
```

This is because the wrong error is wrapped.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Wrap the correct error.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Compiled the code and ran it. The error properly show the underlying error:

```
[ERROR] error syncing 'rancher-rke2-charts': handler helm-clusterrepo-download: failed to clone or open repository: plainClone failure: unexpected client error: unexpected requesting "https://git.rancher.io/rke2-charts/git-upload-pack" status code: 502, requeuing
```