### PR TITLE
Stop recording secrets on service account

### DIFF
--- a/pkg/capr/common.go
+++ b/pkg/capr/common.go
@@ -295,7 +295,7 @@ func GetPlanServiceAccountTokenSecret(secretClient corecontrollers.SecretControl
 	if planSA == nil {
 		return nil, false, fmt.Errorf("planSA was nil")
 	}
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), secretClient.Cache().Get, k8s, planSA)
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), secretClient.Cache(), k8s, planSA)
 	if err != nil {
 		return nil, false, fmt.Errorf("error ensuring secret for service account [%s:%s]: %w", planSA.Namespace, planSA.Name, err)
 	}

--- a/pkg/capr/configserver/server.go
+++ b/pkg/capr/configserver/server.go
@@ -414,9 +414,11 @@ func (r *RKE2ConfigServer) findSA(req *http.Request) (string, *corev1.Secret, er
 	}
 
 	logrus.Debugf("[rke2configserver] %s/%s starting token secret watch for planSA %s/%s", machineNamespace, machineName, planSA.Namespace, planSA.Name)
-	// start watch for the planSA corresponding secret, using a field selector.
+	// start watch for the planSA corresponding secret, using a label selector.
 	respSecret, err := r.secrets.Watch(machineNamespace, metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("metadata.name=%s", serviceaccounttoken.ServiceAccountSecretName(planSA)),
+		LabelSelector: labels.Set{
+			serviceaccounttoken.ServiceAccountSecretLabel: planSA.Name,
+		}.String(),
 	})
 	if err != nil {
 		return "", nil, err

--- a/pkg/controllers/capr/bootstrap/controller.go
+++ b/pkg/controllers/capr/bootstrap/controller.go
@@ -120,7 +120,7 @@ func (h *handler) getBootstrapSecret(namespace, name string, envVars []corev1.En
 	if err != nil {
 		return nil, err
 	}
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), h.secretCache.Get, h.k8s, sa)
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(context.Background(), h.secretCache, h.k8s, sa)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/capr/bootstrap/controller_test.go
+++ b/pkg/controllers/capr/bootstrap/controller_test.go
@@ -15,6 +15,7 @@ import (
 	v1apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -188,23 +189,29 @@ func getDeploymentCacheMock(ctrl *gomock.Controller) *ctrlfake.MockCacheInterfac
 	return mockDeploymentCache
 }
 
-func getSecretCacheMock(ctrl *gomock.Controller, namespace, secretName string) *ctrlfake.MockCacheInterface[*v1.Secret] {
+func getSecretCacheMock(ctrl *gomock.Controller, namespace, saName string) *ctrlfake.MockCacheInterface[*v1.Secret] {
 	mockSecretCache := ctrlfake.NewMockCacheInterface[*v1.Secret](ctrl)
-	mockSecretCache.EXPECT().Get(namespace, secretName).DoAndReturn(func(namespace, name string) (*v1.Secret, error) {
-		return &v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-				Name:      name,
-				Annotations: map[string]string{
-					"kubernetes.io/service-account.name": secretName,
+	selector := labels.Set{"cattle.io/service-account.name": saName}.AsSelector()
+	mockSecretCache.EXPECT().List(namespace, selector).DoAndReturn(func(namespace string, selector labels.Selector) ([]*v1.Secret, error) {
+		return []*v1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      saName + "-secret",
+					Annotations: map[string]string{
+						"kubernetes.io/service-account.name": saName,
+					},
+					Labels: map[string]string{
+						"cattle.io/service-account.name": saName,
+					},
 				},
+				Immutable: nil,
+				Data: map[string][]byte{
+					"token": []byte("thisismytokenandiwillprotectit"),
+				},
+				StringData: nil,
+				Type:       "kubernetes.io/service-account-token",
 			},
-			Immutable: nil,
-			Data: map[string][]byte{
-				"token": []byte("thisismytokenandiwillprotectit"),
-			},
-			StringData: nil,
-			Type:       "kubernetes.io/service-account-token",
 		}, nil
 	}).AnyTimes()
 	return mockSecretCache

--- a/pkg/controllers/dashboard/apiservice/apiservice.go
+++ b/pkg/controllers/dashboard/apiservice/apiservice.go
@@ -148,7 +148,7 @@ func (h *handler) getToken(sa *corev1.ServiceAccount) (string, error) {
 	}
 
 	// create a secret-based token for the service account if one does not exist
-	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(h.ctx, h.secretsCache.Get, h.k8s, sa)
+	secret, err := serviceaccounttoken.EnsureSecretForServiceAccount(h.ctx, h.secretsCache, h.k8s, sa)
 	if err != nil {
 		return "", fmt.Errorf("error ensuring secret for service account [%s:%s]: %w", sa.Namespace, sa.Name, err)
 	}

--- a/pkg/serviceaccounttoken/secret.go
+++ b/pkg/serviceaccounttoken/secret.go
@@ -5,62 +5,63 @@ import (
 	"fmt"
 	"time"
 
+	corecontrollers "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
-	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-const serviceAccountSecretAnnotation = "kubernetes.io/service-account.name"
+const (
+	// ServiceAccountSecretLabel is the label used to search for the secret belonging to a service account.
+	ServiceAccountSecretLabel = "cattle.io/service-account.name"
 
-// secretGetter is an abstraction over any kind of secret getter.
+	serviceAccountSecretAnnotation = "kubernetes.io/service-account.name"
+)
+
+// secretLister is an abstraction over any kind of secret lister.
 // The caller can use any cache or client it has available, whether that is from norman, wrangler, or client-go,
 // as long as it can wrap it in a simplified lambda with this signature.
-type secretGetter func(namespace, name string) (*v1.Secret, error)
+type secretLister func(namespace string, selector labels.Selector) ([]*v1.Secret, error)
 
 // EnsureSecretForServiceAccount gets or creates a service account token Secret for the provided Service Account.
 // For k8s <1.24, the secret is automatically generated for the service account. For >=1.24, we need to generate it explicitly.
-func EnsureSecretForServiceAccount(ctx context.Context, secretGetter secretGetter, clientSet kubernetes.Interface, sa *v1.ServiceAccount) (*v1.Secret, error) {
-	if secretGetter == nil {
-		secretGetter = func(namespace, name string) (*v1.Secret, error) {
-			return clientSet.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
-		}
-	}
+func EnsureSecretForServiceAccount(ctx context.Context, secretsCache corecontrollers.SecretCache, clientSet kubernetes.Interface, sa *v1.ServiceAccount) (*v1.Secret, error) {
 	if sa == nil {
 		return nil, fmt.Errorf("could not ensure secret for invalid service account")
 	}
 	secretClient := clientSet.CoreV1().Secrets(sa.Namespace)
-	saClient := clientSet.CoreV1().ServiceAccounts(sa.Namespace)
-	secretName := ServiceAccountSecretName(sa)
-	var secret *v1.Secret
-	var err error
-	if secretName != "" {
-		secret, err = secretGetter(sa.Namespace, secretName)
-		if err != nil && !apierror.IsNotFound(err) {
-			return nil, fmt.Errorf("error ensuring secret for service account [%s:%s]: %w", sa.Namespace, sa.Name, err)
+	var secretLister secretLister
+	if secretsCache != nil {
+		secretLister = secretsCache.List
+	} else {
+		secretLister = func(_ string, selector labels.Selector) ([]*v1.Secret, error) {
+			secretList, err := secretClient.List(ctx, metav1.ListOptions{
+				LabelSelector: selector.String(),
+			})
+			if err != nil {
+				return nil, err
+			}
+			result := make([]*v1.Secret, len(secretList.Items))
+			for i := range secretList.Items {
+				result[i] = &secretList.Items[i]
+			}
+			return result, nil
 		}
 	}
-	if secret == nil || !isSecretForServiceAccount(secret, sa) {
+	secret, err := ServiceAccountSecret(ctx, sa, secretLister, secretClient)
+	if err != nil {
+		return nil, fmt.Errorf("error looking up secret for service account [%s:%s]: %w", sa.Namespace, sa.Name, err)
+	}
+	if secret == nil {
 		sc := SecretTemplate(sa)
 		secret, err = secretClient.Create(ctx, sc, metav1.CreateOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("error ensuring secret for service account [%s:%s]: %w", sa.Namespace, sa.Name, err)
 		}
-		// k8s >=1.24 does not store a reference to the secret, but we need it to refer back to later
-		saCopy := sa.DeepCopy()
-		saCopy.Secrets = []v1.ObjectReference{{Name: secret.Name}}
-		saCopy, err = saClient.Update(ctx, saCopy, metav1.UpdateOptions{})
-		if err != nil {
-			// clean up the secret we just created
-			cleanupErr := secretClient.Delete(ctx, secret.Name, metav1.DeleteOptions{})
-			if cleanupErr != nil && !apierror.IsNotFound(cleanupErr) {
-				return nil, fmt.Errorf("encountered error while handling service account update error: %v, original error: %w", cleanupErr, err)
-			}
-			return nil, fmt.Errorf("error ensuring secret for service account [%s:%s]: %w", sa.Namespace, sa.Name, err)
-		}
-		*sa = *saCopy
 	}
 	if len(secret.Data[v1.ServiceAccountTokenKey]) > 0 {
 		return secret, nil
@@ -106,6 +107,9 @@ func SecretTemplate(sa *v1.ServiceAccount) *v1.Secret {
 			Annotations: map[string]string{
 				serviceAccountSecretAnnotation: sa.Name,
 			},
+			Labels: map[string]string{
+				ServiceAccountSecretLabel: sa.Name,
+			},
 		},
 		Type: v1.SecretTypeServiceAccountToken,
 	}
@@ -117,13 +121,34 @@ func serviceAccountSecretPrefix(sa *v1.ServiceAccount) string {
 	return fmt.Sprintf("%s-token-", sa.Name)
 }
 
-// ServiceAccountSecretName returns the secret name for the given Service Account.
+// ServiceAccountSecret returns the secret for the given Service Account.
 // If there are more than one, it returns the first.
-func ServiceAccountSecretName(sa *v1.ServiceAccount) string {
-	if len(sa.Secrets) < 1 {
-		return ""
+func ServiceAccountSecret(ctx context.Context, sa *v1.ServiceAccount, secretLister secretLister, secretClient clientv1.SecretInterface) (*v1.Secret, error) {
+	if sa == nil {
+		return nil, fmt.Errorf("cannot get secret for nil service account")
 	}
-	return sa.Secrets[0].Name
+	secrets, err := secretLister(sa.Namespace, labels.SelectorFromSet(map[string]string{
+		ServiceAccountSecretLabel: sa.Name,
+	}))
+	if err != nil {
+		return nil, fmt.Errorf("could not get secrets for service account: %w", err)
+	}
+	if len(secrets) < 1 {
+		return nil, nil
+	}
+	var result *v1.Secret
+	for _, s := range secrets {
+		if isSecretForServiceAccount(s, sa) {
+			result = s
+			continue
+		}
+		logrus.Warnf("EnsureSecretForServiceAccount: secret [%s:%s] is invalid for service account [%s], deleting", s.Namespace, s.Name, sa.Name)
+		err = secretClient.Delete(ctx, s.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
 }
 
 func isSecretForServiceAccount(secret *v1.Secret, sa *v1.ServiceAccount) bool {

--- a/pkg/serviceaccounttoken/secret_test.go
+++ b/pkg/serviceaccounttoken/secret_test.go
@@ -19,9 +19,6 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 			Name:      "test",
 			Namespace: "default",
 		},
-		Secrets: []v1.ObjectReference{{
-			Name: "test-token-abcde",
-		}},
 	}
 	defaultWantSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -29,6 +26,9 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 			Namespace: "default",
 			Annotations: map[string]string{
 				"kubernetes.io/service-account.name": "test",
+			},
+			Labels: map[string]string{
+				"cattle.io/service-account.name": "test",
 			},
 		},
 		Data: map[string][]byte{
@@ -62,9 +62,6 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 					Name:      "test",
 					Namespace: "default",
 				},
-				Secrets: []v1.ObjectReference{{
-					Name: "test-token-abcde",
-				}},
 			},
 			wantSA: defaultWantSA,
 			existingSecret: &v1.Secret{
@@ -73,6 +70,9 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"kubernetes.io/service-account.name": "test",
+					},
+					Labels: map[string]string{
+						"cattle.io/service-account.name": "test",
 					},
 				},
 				Data: map[string][]byte{
@@ -93,9 +93,6 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 					Name:      "test",
 					Namespace: "default",
 				},
-				Secrets: []v1.ObjectReference{{
-					Name: "wrong",
-				}},
 			},
 			wantSA:     defaultWantSA,
 			wantSecret: defaultWantSecret,
@@ -107,9 +104,6 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 					Name:      "test",
 					Namespace: "default",
 				},
-				Secrets: []v1.ObjectReference{{
-					Name: "test-token-xyz",
-				}},
 			},
 			wantSA: defaultWantSA,
 			existingSecret: &v1.Secret{
@@ -118,6 +112,9 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"kubernetes.io/service-account.name": "test",
+					},
+					Labels: map[string]string{
+						"cattle.io/service-account.name": "test",
 					},
 				},
 				Data: map[string][]byte{
@@ -134,9 +131,6 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 					Name:      "test",
 					Namespace: "default",
 				},
-				Secrets: []v1.ObjectReference{{
-					Name: "test-token-xyz",
-				}},
 			},
 			wantSA: defaultWantSA,
 			existingSecret: &v1.Secret{
@@ -145,6 +139,9 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"kubernetes.io/service-account.name": "wrong",
+					},
+					Labels: map[string]string{
+						"cattle.io/service-account.name": "wrong",
 					},
 				},
 				Data: map[string][]byte{

--- a/pkg/serviceaccounttoken/secret_test.go
+++ b/pkg/serviceaccounttoken/secret_test.go
@@ -2,11 +2,14 @@ package serviceaccounttoken
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -189,4 +192,158 @@ func TestEnsureSecretForServiceAccount(t *testing.T) {
 			assert.Equal(t, tt.sa, gotSA)
 		})
 	}
+}
+
+func TestServiceAccountSecret(t *testing.T) {
+	type testState struct {
+		clientset  *fake.Clientset
+		fakeLister *fakeSecretLister
+	}
+	baseSA := v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "base-sa",
+			Namespace: "test-ns",
+		},
+	}
+	validSecret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "base-sa-secret",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				ServiceAccountSecretLabel: baseSA.Name,
+			},
+			Annotations: map[string]string{
+				serviceAccountSecretAnnotation: baseSA.Name,
+			},
+		},
+		Type: v1.SecretTypeServiceAccountToken,
+	}
+	invalidSecretType := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "invalid-secret-type",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				ServiceAccountSecretLabel: baseSA.Name,
+			},
+			Annotations: map[string]string{
+				serviceAccountSecretAnnotation: baseSA.Name,
+			},
+		},
+		Type: v1.SecretTypeOpaque,
+	}
+	invalidSecretAnnotation := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "invalid-secret-annotation",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				ServiceAccountSecretLabel: baseSA.Name,
+			},
+			Annotations: map[string]string{
+				serviceAccountSecretAnnotation: "some-other-sa",
+			},
+		},
+		Type: v1.SecretTypeOpaque,
+	}
+	tests := []struct {
+		name       string
+		stateSetup func(testState)
+		inputSA    *v1.ServiceAccount
+		wantSecret *v1.Secret
+		wantError  bool
+	}{
+		{
+			name:      "test nil sa",
+			inputSA:   nil,
+			wantError: true,
+		},
+		{
+			name:       "test no secrets",
+			inputSA:    &baseSA,
+			wantError:  false,
+			wantSecret: nil,
+		},
+		{
+			name:    "test valid secrets, first returned",
+			inputSA: &baseSA,
+			stateSetup: func(ts testState) {
+				validSecondSecret := validSecret.DeepCopy()
+				validSecondSecret.Name = "base-sa-secret-2"
+				ts.fakeLister.secrets = []*v1.Secret{&validSecret, validSecondSecret}
+			},
+			wantError:  false,
+			wantSecret: &validSecret,
+		},
+		{
+			name:    "test invalid secrets, none returned",
+			inputSA: &baseSA,
+			stateSetup: func(ts testState) {
+				ts.fakeLister.secrets = []*v1.Secret{&invalidSecretType, &invalidSecretAnnotation}
+				ts.clientset.Tracker().Add(&invalidSecretType)
+				ts.clientset.Tracker().Add(&invalidSecretAnnotation)
+			},
+			wantError:  false,
+			wantSecret: nil,
+		},
+		{
+			name:    "test invalid secrets delete failure, valid still returned",
+			inputSA: &baseSA,
+			stateSetup: func(ts testState) {
+				ts.fakeLister.secrets = []*v1.Secret{&invalidSecretType, &invalidSecretAnnotation, &validSecret}
+				ts.clientset.Tracker().Add(&invalidSecretType)
+				// don't add the invalid annotation secret to the state, this will cause a not-found error on delete
+			},
+			wantError:  false,
+			wantSecret: &validSecret,
+		},
+		{
+			name:    "test valid + invalid secrets, only valid returned",
+			inputSA: &baseSA,
+			stateSetup: func(ts testState) {
+				ts.fakeLister.secrets = []*v1.Secret{&invalidSecretType, &invalidSecretAnnotation, &validSecret}
+				ts.clientset.Tracker().Add(&invalidSecretType)
+				ts.clientset.Tracker().Add(&invalidSecretAnnotation)
+			},
+			wantError:  false,
+			wantSecret: &validSecret,
+		},
+		{
+			name:    "test secret lister error",
+			inputSA: &baseSA,
+			stateSetup: func(ts testState) {
+				ts.fakeLister.secrets = []*v1.Secret{&invalidSecretType, &invalidSecretAnnotation, &validSecret}
+				ts.fakeLister.err = fmt.Errorf("server unavailable")
+			},
+			wantError: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			k8sClient := fake.NewSimpleClientset()
+			fakeLister := fakeSecretLister{}
+			state := testState{
+				clientset:  k8sClient,
+				fakeLister: &fakeLister,
+			}
+			if test.stateSetup != nil {
+				test.stateSetup(state)
+			}
+			secretsMock := state.clientset.CoreV1().Secrets("test-ns")
+			secret, err := ServiceAccountSecret(context.Background(), test.inputSA, state.fakeLister.list, secretsMock)
+			require.Equal(t, test.wantSecret, secret)
+			if test.wantError {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}
+
+type fakeSecretLister struct {
+	secrets []*v1.Secret
+	err     error
+}
+
+func (f *fakeSecretLister) list(namespace string, selector labels.Selector) ([]*v1.Secret, error) {
+	return f.secrets, f.err
 }

--- a/pkg/types/config/context.go
+++ b/pkg/types/config/context.go
@@ -43,6 +43,8 @@ import (
 	"github.com/rancher/rancher/pkg/user"
 	"github.com/rancher/rancher/pkg/wrangler"
 	steve "github.com/rancher/steve/pkg/server"
+	"github.com/rancher/wrangler/pkg/generated/controllers/core"
+	wcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/generated/controllers/rbac"
 	wrbacv1 "github.com/rancher/wrangler/pkg/generated/controllers/rbac/v1"
 	"github.com/rancher/wrangler/pkg/generic"
@@ -223,6 +225,7 @@ type UserContext struct {
 	Policy         policyv1beta1.Interface
 
 	RBACw          wrbacv1.Interface
+	Corew          wcorev1.Interface
 	KindNamespaces map[schema.GroupVersionKind]string
 }
 
@@ -444,6 +447,11 @@ func NewUserContext(scaledContext *ScaledContext, config rest.Config, clusterNam
 		return nil, err
 	}
 	context.RBACw = rbacw.Rbac().V1()
+	corew, err := core.NewFactoryFromConfigWithOptions(&wranglerConf, opts)
+	if err != nil {
+		return nil, err
+	}
+	context.Corew = corew.Core().V1()
 
 	ctlg, err := catalog.NewFactoryFromConfigWithOptions(&context.RESTConfig, &catalog.FactoryOptions{SharedControllerFactory: controllerFactory})
 	if err != nil {


### PR DESCRIPTION
A token for a service account can be generated by creating a secret for that service account with the annotation
`kubernetes.io/service-account.name` pointing to that service account.

In Kubernetes 1.23 and below, a reference to the secret was automatically stored directly on the service account by Kubernetes, making it easy to look up. For Kubernetes 1.24, Rancher started explicitly adding the secret to the service account so that it could refer back to it.

In k8s 1.27, storing references to the secret is discouraged[1] in favor of explicitly using the TokenReview API[2]. This does not serve Rancher's purposes because the service account token needs to be long-lived and is not intended to be mounted in a pod. To avoid the warning, this change stops storing the secret reference on the service account in favor of adding a label to the secret to make it easily indexable.

This change affects these service accounts:

- cattle-token (the admin service account that Rancher uses to connect to the downstream)
- impersonation
- monitoring v1
- kontainer-engine
- CAPR machine bootstrap account
- v3.APIService service accounts

Some changes are made to the serviceaccounttoken package:

- EnsureSecretForServiceAccount is updated to use a wrangler cache instead of a lambda, so the norman secret lister can no longer be used with it. If the wrangler cache cannot be provided (as in the case of the cluster agent), a client is used instead.
- ServiceAccountSecretName is changed to ServiceAccountSecret and returns the entire secret instead of just the name.
  - Attempting to retrieve the whole secret no longer makes sense in a watch context, so the CAPR configserver package now just uses the new label to watch for the secret.
- If an invalid secret is found, it is deleted with a warning.

[1] https://github.com/kubernetes/kubernetes/blob/5ebb9f319576303cabc0216a8df536b0b4307e67/pkg/serviceaccount/legacy.go#L155
[2] https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-an-api-token-for-a-serviceaccount

## Issue: https://github.com/rancher/rancher/issues/42861<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_