### PR TITLE
[release/v2.8] [v2prov] Allow fleet workspace name to be changed on management cluster object

### DIFF
--- a/pkg/apis/provisioning.cattle.io/v1/cluster.go
+++ b/pkg/apis/provisioning.cattle.io/v1/cluster.go
@@ -46,6 +46,7 @@ type AgentDeploymentCustomization struct {
 type ClusterStatus struct {
 	Ready              bool                                `json:"ready,omitempty"`
 	ClusterName        string                              `json:"clusterName,omitempty"`
+	FleetWorkspaceName string                              `json:"fleetWorkspaceName,omitempty"`
 	ClientSecretName   string                              `json:"clientSecretName,omitempty"`
 	AgentDeployed      bool                                `json:"agentDeployed,omitempty"`
 	ObservedGeneration int64                               `json:"observedGeneration"`

--- a/pkg/controllers/capr/managesystemagent/managesystemagent.go
+++ b/pkg/controllers/capr/managesystemagent/managesystemagent.go
@@ -83,6 +83,12 @@ func (h *handler) OnChange(cluster *rancherv1.Cluster, status rancherv1.ClusterS
 		return nil, status, nil
 	}
 
+	// Intentionally return an ErrSkip to prevent unnecessarily thrashing the corresponding bundle
+	// if the status field for fleetworkspacename has not yet been updated
+	if cluster.Status.FleetWorkspaceName == "" {
+		return nil, status, generic.ErrSkip
+	}
+
 	var (
 		secretName = "stv-aggregation"
 		result     []runtime.Object
@@ -121,10 +127,6 @@ func (h *handler) OnChange(cluster *rancherv1.Cluster, status rancherv1.ClusterS
 
 	resources, err := ToResources(installer(cluster, secretName))
 	if err != nil {
-		return nil, status, err
-	}
-
-	if cluster.Status.FleetWorkspaceName == "" {
 		return nil, status, err
 	}
 

--- a/pkg/controllers/capr/managesystemagent/managesystemagentplan.go
+++ b/pkg/controllers/capr/managesystemagent/managesystemagentplan.go
@@ -100,7 +100,7 @@ func (h *handler) syncSystemUpgradeControllerStatus(obj *rkev1.RKEControlPlane, 
 		return status, err
 	}
 	if cluster.Status.FleetWorkspaceName == "" {
-		return status, fmt.Errorf("fleet workspace name for clusters.provisioning.cattle.io %s/%s was blank", cluster.Namespace, cluster.Name)
+		return status, fmt.Errorf("unable to sync system upgrade controller status for [%s] [%s/%s], status.FleetWorkspaceName was blank", cluster.TypeMeta.String(), cluster.Namespace, cluster.Name)
 	}
 
 	bundleName := capr.SafeConcatName(capr.MaxHelmReleaseNameLength, "mcc", capr.SafeConcatName(48, obj.Name, "managed", "system-upgrade-controller"))

--- a/pkg/controllers/capr/managesystemagent/managesystemagentplan.go
+++ b/pkg/controllers/capr/managesystemagent/managesystemagentplan.go
@@ -25,6 +25,10 @@ func (h *handler) OnChangeInstallSUC(cluster *rancherv1.Cluster, status rancherv
 		return nil, status, nil
 	}
 
+	if cluster.Status.FleetWorkspaceName == "" {
+		return nil, status, nil
+	}
+
 	currentVersion, err := semver.NewVersion(cluster.Spec.KubernetesVersion)
 	if err != nil {
 		return nil, status, err
@@ -42,7 +46,7 @@ func (h *handler) OnChangeInstallSUC(cluster *rancherv1.Cluster, status rancherv
 	// b) upon creation of this resource the prefix 'mcc-' will be added to the release name, hence the limiting to 48 characters
 	mcc := &v3.ManagedChart{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: cluster.Namespace,
+			Namespace: cluster.Status.FleetWorkspaceName,
 			Name:      capr.SafeConcatName(48, cluster.Name, "managed", "system-upgrade-controller"),
 		},
 		Spec: v3.ManagedChartSpec{
@@ -91,8 +95,16 @@ type SUCMetadata struct {
 // version of Kubernetes. It applies a condition onto the control-plane object to be used by the planner when handling Kubernetes upgrades.
 func (h *handler) syncSystemUpgradeControllerStatus(obj *rkev1.RKEControlPlane, status rkev1.RKEControlPlaneStatus) (rkev1.RKEControlPlaneStatus, error) {
 	// perform the same name limiting as in the OnChangeInstallSUC and the managedchart controller
+	cluster, err := h.provClusters.Get(obj.Namespace, obj.Name)
+	if err != nil {
+		return status, err
+	}
+	if cluster.Status.FleetWorkspaceName == "" {
+		return status, fmt.Errorf("fleet workspace name for clusters.provisioning.cattle.io %s/%s was blank", cluster.Namespace, cluster.Name)
+	}
+
 	bundleName := capr.SafeConcatName(capr.MaxHelmReleaseNameLength, "mcc", capr.SafeConcatName(48, obj.Name, "managed", "system-upgrade-controller"))
-	sucBundle, err := h.bundles.Get(obj.Namespace, bundleName, metav1.GetOptions{})
+	sucBundle, err := h.bundles.Get(cluster.Status.FleetWorkspaceName, bundleName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// if we couldn't find the bundle then we know it's not ready

--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster.go
@@ -122,7 +122,8 @@ func (h *handler) createCluster(cluster *provv1.Cluster, status provv1.ClusterSt
 	}
 
 	if mgmtCluster.Spec.FleetWorkspaceName == "" {
-		return nil, status, generic.ErrSkip
+		// Only create a cluster if the fleet workspace name is set on the management cluster object, otherwise, apply an empty set of objects.
+		return nil, status, nil
 	}
 
 	// this removes any annotations containing "cattle.io" or starting with "kubectl.kubernetes.io"

--- a/pkg/controllers/provisioningv2/fleetcluster/fleetcluster_test.go
+++ b/pkg/controllers/provisioningv2/fleetcluster/fleetcluster_test.go
@@ -104,7 +104,9 @@ func TestClusterCustomization(t *testing.T) {
 				"cluster-name": newMgmtCluster(
 					"cluster-name",
 					labels,
-					apimgmtv3.ClusterSpec{},
+					apimgmtv3.ClusterSpec{
+						FleetWorkspaceName: "fleet-default",
+					},
 				),
 			}),
 			&fleet.Cluster{
@@ -122,6 +124,7 @@ func TestClusterCustomization(t *testing.T) {
 					"cluster-name",
 					labels,
 					apimgmtv3.ClusterSpec{
+						FleetWorkspaceName: "fleet-default",
 						ClusterSpecBase: apimgmtv3.ClusterSpecBase{
 							FleetAgentDeploymentCustomization: &apimgmtv3.AgentDeploymentCustomization{
 								OverrideAffinity:             &linuxAffinity,
@@ -149,6 +152,7 @@ func TestClusterCustomization(t *testing.T) {
 					"cluster-name",
 					labels,
 					apimgmtv3.ClusterSpec{
+						FleetWorkspaceName: "fleet-default",
 						ClusterSpecBase: apimgmtv3.ClusterSpecBase{
 							FleetAgentDeploymentCustomization: &apimgmtv3.AgentDeploymentCustomization{
 								OverrideAffinity:             nil,
@@ -223,7 +227,10 @@ func TestCreateCluster(t *testing.T) {
 					map[string]string{
 						"cluster-group": "cluster-group-name",
 					},
-					apimgmtv3.ClusterSpec{Internal: false},
+					apimgmtv3.ClusterSpec{
+						FleetWorkspaceName: "fleet-default",
+						Internal:           false,
+					},
 				),
 			}),
 			1,
@@ -247,7 +254,10 @@ func TestCreateCluster(t *testing.T) {
 					map[string]string{
 						"cluster-group": "default",
 					},
-					apimgmtv3.ClusterSpec{Internal: true},
+					apimgmtv3.ClusterSpec{
+						FleetWorkspaceName: "fleet-default",
+						Internal:           true,
+					},
 				),
 			}),
 			2,

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -107,13 +107,18 @@ var (
 		true,
 		true,
 		true)
-
 	HarvesterBaremetalContainerWorkload = newFeature(
 		"harvester-baremetal-container-workload",
 		"[Experimental]: Deploy container workloads to underlying harvester cluster",
 		false,
 		true,
 		true)
+	ProvisioningV2FleetWorkspaceBackPopulation = newFeature(
+		"provisioningv2-fleet-workspace-back-population",
+		"[Experimental]: Allow Fleet workspace name to be changed on clusters administrated by provisioning v2",
+		false,
+		false,
+		false)
 )
 
 type Feature struct {


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/36132
 
## Problem
It is not possible to change the fleet workspace name for a provisioned (v2prov) cluster 
 
## Solution
Introduce a new feature flag called `provisioningv2-fleet-workspace-back-population` which will allow for fleet workspace names to be changed on the management cluster object. 
 
## Testing


## Engineering Testing
### Manual Testing
Provision a cluster, then change the mgmt cluster fleet workspace name. Observe the fleet workspace name can change.

## QA Testing Considerations
As this is an alpha-level feature, we should smoke test the ability to change the fleet workspace name, and ensure that clusters can still provision with default settings.

Note, there was an observed issue with Fleet: https://github.com/rancher/fleet/issues/1807