### PR TITLE
Updating inheritedClusterRoles description

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authz_types.go
+++ b/pkg/apis/management.cattle.io/v3/authz_types.go
@@ -168,8 +168,7 @@ type GlobalRole struct {
 	Builtin bool `json:"builtin,omitempty" norman:"nocreate,noupdate"`
 
 	// InheritedClusterRoles are the names of RoleTemplates whose permissions are granted by this GlobalRole in every
-	// cluster besides the local cluster. To grant permissions in the local cluster, use the Rules or NamespacedRules
-	// fields.
+	// cluster besides the local cluster. To grant permissions in the local cluster, use the Rules field.
 	// +optional
 	InheritedClusterRoles []string `json:"inheritedClusterRoles,omitempty"`
 }

--- a/pkg/crds/yaml/generated/management.cattle.io_globalroles.yaml
+++ b/pkg/crds/yaml/generated/management.cattle.io_globalroles.yaml
@@ -40,7 +40,7 @@ spec:
             description: InheritedClusterRoles are the names of RoleTemplates whose
               permissions are granted by this GlobalRole in every cluster besides
               the local cluster. To grant permissions in the local cluster, use the
-              Rules or NamespacedRules fields.
+              Rules field.
             items:
               type: string
             type: array


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
#42965
 
## Problem
The description of inheritedClusterRoles needed to be edited to remove references to future fields.
 
## Solution
The description of inheritedClusterRoles was edited to remove references to future roles.
 
## Testing
N/A - description-only change