### PR TITLE
[2.8] adding out-of-tree cloud provider automation support for aws during provisioning, RKE2

### DIFF
--- a/tests/framework/extensions/charts/charts.go
+++ b/tests/framework/extensions/charts/charts.go
@@ -2,9 +2,6 @@ package charts
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"net/http"
 
 	"github.com/rancher/rancher/pkg/api/scheme"
 	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
@@ -329,42 +326,4 @@ func WatchAndWaitStatefulSets(client *rancher.Client, clusterID, namespace strin
 	}
 
 	return nil
-}
-
-// GetChartCaseEndpoint is a helper function that takes host path and TLS option as args,
-// applies TLS option and authorization to management client' method that returns a boolean for healthy response and the request body.
-func GetChartCaseEndpoint(client *rancher.Client, host, path string, isWithTLS bool) (*GetChartCaseEndpointResult, error) {
-	protocol := "http"
-
-	if isWithTLS {
-		protocol = "https"
-	}
-
-	url := fmt.Sprintf("%s://%s/%s", protocol, host, path)
-
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Authorization", "Bearer "+client.RancherConfig.AdminToken)
-
-	resp, err := client.Management.APIBaseClient.Ops.Client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	bodyString := string(bodyBytes)
-
-	isHealthy := resp.StatusCode == http.StatusOK
-
-	return &GetChartCaseEndpointResult{
-		Ok:   isHealthy,
-		Body: bodyString,
-	}, nil
 }

--- a/tests/framework/extensions/clusters/clusterconfig.go
+++ b/tests/framework/extensions/clusters/clusterconfig.go
@@ -13,6 +13,7 @@ type ClusterConfig struct {
 	PNI                  bool                                     `json:"pni" yaml:"pni"`
 	NodePools            []provisioningInput.NodePools            `json:"nodepools" yaml:"nodepools"`
 	MachinePools         []provisioningInput.MachinePools         `json:"machinepools" yaml:"machinepools"`
+	CloudProvider        string                                   `json:"cloudProvider" yaml:"cloudProvider"`
 	Providers            *[]string                                `json:"providers" yaml:"providers"`
 	NodeProviders        *[]string                                `json:"nodeProviders" yaml:"nodeProviders"`
 	Hardened             bool                                     `json:"hardened" yaml:"hardened"`
@@ -47,6 +48,7 @@ func ConvertConfigToClusterConfig(provisioningConfig *provisioningInput.Config) 
 	newConfig.LabelsAndAnnotations = provisioningConfig.LabelsAndAnnotations
 	newConfig.Registries = provisioningConfig.Registries
 	newConfig.UpgradeStrategy = provisioningConfig.UpgradeStrategy
+	newConfig.CloudProvider = provisioningConfig.CloudProvider
 
 	newConfig.Hardened = provisioningConfig.Hardened
 	newConfig.PSACT = provisioningConfig.PSACT

--- a/tests/framework/extensions/ingresses/ingresses.go
+++ b/tests/framework/extensions/ingresses/ingresses.go
@@ -1,21 +1,50 @@
 package ingresses
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
-	"github.com/rancher/rancher/tests/framework/extensions/charts"
 )
 
 const (
 	IngressSteveType = "networking.k8s.io.ingress"
 )
 
-// AccessIngressExternally checks if the ingress is accessible externally,
+// GetExternalIngressResponse gets a response from a specific hostname and path.
+// Returns the response and an error if any.
+func GetExternalIngressResponse(client *rancher.Client, hostname string, path string, isWithTLS bool) (*http.Response, error) {
+	protocol := "http"
+
+	if isWithTLS {
+		protocol = "https"
+	}
+
+	url := fmt.Sprintf("%s://%s/%s", protocol, hostname, path)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Authorization", "Bearer "+client.RancherConfig.AdminToken)
+
+	resp, err := client.Management.APIBaseClient.Ops.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return resp, nil
+}
+
+// IsIngressExternallyAccessible checks if the ingress is accessible externally,
 // it returns true if the ingress is accessible, false if it is not, and an error if there is an error.
-func AccessIngressExternally(client *rancher.Client, hostname string, isWithTLS bool) (bool, error) {
-	result, err := charts.GetChartCaseEndpoint(client, hostname, "", isWithTLS)
+func IsIngressExternallyAccessible(client *rancher.Client, hostname string, path string, isWithTLS bool) (bool, error) {
+	resp, err := GetExternalIngressResponse(client, hostname, path, isWithTLS)
 	if err != nil {
 		return false, err
 	}
 
-	return result.Ok, err
+	return resp.StatusCode == http.StatusOK, nil
 }

--- a/tests/framework/extensions/machinepools/amazonec2_machine_config.go
+++ b/tests/framework/extensions/machinepools/amazonec2_machine_config.go
@@ -14,16 +14,18 @@ const (
 
 // AWSMachineConfig is configuration needed to create an rke-machine-config.cattle.io.amazonec2config
 type AWSMachineConfig struct {
-	Region        string   `json:"region" yaml:"region"`
-	AMI           string   `json:"ami" yaml:"ami"`
-	InstanceType  string   `json:"instanceType" yaml:"instanceType"`
-	SSHUser       string   `json:"sshUser" yaml:"sshUser"`
-	VPCID         string   `json:"vpcId" yaml:"vpcId"`
-	VolumeType    string   `json:"volumeType" yaml:"volumeType"`
-	Zone          string   `json:"zone" yaml:"zone"`
-	Retries       string   `json:"retries" yaml:"retries"`
-	RootSize      string   `json:"rootSize" yaml:"rootSize"`
-	SecurityGroup []string `json:"securityGroup" yaml:"securityGroup"`
+	Region             string   `json:"region" yaml:"region"`
+	AMI                string   `json:"ami" yaml:"ami"`
+	IAMInstanceProfile string   `json:"iamInstanceProfile" yaml:"iamInstanceProfile"`
+	InstanceType       string   `json:"instanceType" yaml:"instanceType"`
+	SSHUser            string   `json:"sshUser" yaml:"sshUser"`
+	VPCID              string   `json:"vpcId" yaml:"vpcId"`
+	SubnetID           string   `json:"subnetId" yaml:"subnetId"`
+	VolumeType         string   `json:"volumeType" yaml:"volumeType"`
+	Zone               string   `json:"zone" yaml:"zone"`
+	Retries            string   `json:"retries" yaml:"retries"`
+	RootSize           string   `json:"rootSize" yaml:"rootSize"`
+	SecurityGroup      []string `json:"securityGroup" yaml:"securityGroup"`
 }
 
 // NewAWSMachineConfig is a constructor to set up rke-machine-config.cattle.io.amazonec2config. It returns an *unstructured.Unstructured
@@ -39,10 +41,12 @@ func NewAWSMachineConfig(generatedPoolName, namespace string) *unstructured.Unst
 	machineConfig.SetNamespace(namespace)
 	machineConfig.Object["region"] = awsMachineConfig.Region
 	machineConfig.Object["ami"] = awsMachineConfig.AMI
+	machineConfig.Object["iamInstanceProfile"] = awsMachineConfig.IAMInstanceProfile
 	machineConfig.Object["instanceType"] = awsMachineConfig.InstanceType
 	machineConfig.Object["sshUser"] = awsMachineConfig.SSHUser
 	machineConfig.Object["type"] = AWSPoolType
 	machineConfig.Object["vpcId"] = awsMachineConfig.VPCID
+	machineConfig.Object["subnetId"] = awsMachineConfig.SubnetID
 	machineConfig.Object["volumeType"] = awsMachineConfig.VolumeType
 	machineConfig.Object["zone"] = awsMachineConfig.Zone
 	machineConfig.Object["retries"] = awsMachineConfig.Retries

--- a/tests/framework/extensions/provisioninginput/config.go
+++ b/tests/framework/extensions/provisioninginput/config.go
@@ -33,6 +33,7 @@ const (
 	LinodeProviderName    ProviderName = "linode"
 	GoogleProviderName    ProviderName = "google"
 	VsphereProviderName   ProviderName = "vsphere"
+	ExternalProviderName  ProviderName = "external"
 )
 
 var AllRolesMachinePool = MachinePools{
@@ -194,6 +195,7 @@ type NodePools struct {
 type Config struct {
 	NodePools              []NodePools                              `json:"nodePools,omitempty" yaml:"nodePools,omitempty"`
 	MachinePools           []MachinePools                           `json:"machinePools,omitempty" yaml:"machinePools,omitempty"`
+	CloudProvider          string                                   `json:"cloudProvider" yaml:"cloudProvider"`
 	Providers              []string                                 `json:"providers,omitempty" yaml:"providers,omitempty"`
 	NodeProviders          []string                                 `json:"nodeProviders,omitempty" yaml:"nodeProviders,omitempty"`
 	Hardened               bool                                     `json:"hardened,omitempty" yaml:"hardened,omitempty"`

--- a/tests/framework/extensions/services/verify.go
+++ b/tests/framework/extensions/services/verify.go
@@ -1,0 +1,61 @@
+package services
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
+	"github.com/rancher/rancher/tests/framework/extensions/ingresses"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	noSuchHostSubString = "no such host"
+)
+
+// VerifyAWSLoadBalancer validates that an AWS loadbalancer service is created and working properly
+func VerifyAWSLoadBalancer(t *testing.T, client *rancher.Client, serviceLB *v1.SteveAPIObject, clusterName string) {
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+
+	steveclient, err := adminClient.Steve.ProxyDownstream(clusterName)
+	require.NoError(t, err)
+
+	lbHostname := ""
+	err = kwait.Poll(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+		updateService, err := steveclient.SteveType("service").ByID(serviceLB.ID)
+		if err != nil {
+			return false, nil
+		}
+
+		serviceStatus := &corev1.ServiceStatus{}
+		err = v1.ConvertToK8sType(updateService.Status, serviceStatus)
+		if err != nil {
+			return false, err
+		}
+		if len(serviceStatus.LoadBalancer.Ingress) == 0 {
+			return false, nil
+		}
+
+		lbHostname = serviceStatus.LoadBalancer.Ingress[0].Hostname
+		return true, nil
+	})
+	require.NoError(t, err)
+
+	err = kwait.Poll(5*time.Second, 3*time.Minute, func() (done bool, err error) {
+		isIngressAccessible, err := ingresses.IsIngressExternallyAccessible(client, lbHostname, "", false)
+		if err != nil {
+			if strings.Contains(err.Error(), noSuchHostSubString) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		return isIngressAccessible, nil
+	})
+	require.NoError(t, err)
+}

--- a/tests/v2/validation/charts/istio_test.go
+++ b/tests/v2/validation/charts/istio_test.go
@@ -16,6 +16,7 @@ import (
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/charts"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/ingresses"
 	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/stretchr/testify/assert"
@@ -179,13 +180,13 @@ func (i *IstioTestSuite) TestIstioChart() {
 	require.NoError(i.T(), err)
 
 	i.T().Log("Validating kiali and jaeger endpoints are accessible")
-	kialiResult, err := charts.GetChartCaseEndpoint(client, client.RancherConfig.Host, kialiPath, true)
+	kialiResult, err := ingresses.IsIngressExternallyAccessible(client, client.RancherConfig.Host, kialiPath, true)
 	require.NoError(i.T(), err)
-	assert.True(i.T(), kialiResult.Ok)
+	assert.True(i.T(), kialiResult)
 
-	tracingResult, err := charts.GetChartCaseEndpoint(client, client.RancherConfig.Host, tracingPath, true)
+	tracingResult, err := ingresses.IsIngressExternallyAccessible(client, client.RancherConfig.Host, tracingPath, true)
 	require.NoError(i.T(), err)
-	assert.True(i.T(), tracingResult.Ok)
+	assert.True(i.T(), tracingResult)
 
 	// Get a random worker node' public external IP of a specific cluster
 	nodeCollection, err := client.Management.Node.List(&types.ListOpts{Filters: map[string]interface{}{
@@ -200,9 +201,9 @@ func (i *IstioTestSuite) TestIstioChart() {
 	istioGatewayHost := randWorkerNodePublicIP + ":" + exampleAppPort
 
 	i.T().Log("Validating example app is accessible")
-	exampleAppResult, err := charts.GetChartCaseEndpoint(client, istioGatewayHost, exampleAppProductPagePath, false)
+	exampleAppResult, err := ingresses.IsIngressExternallyAccessible(client, istioGatewayHost, exampleAppProductPagePath, false)
 	require.NoError(i.T(), err)
-	assert.True(i.T(), exampleAppResult.Ok)
+	assert.True(i.T(), exampleAppResult)
 
 	i.T().Log("Validating example app has three different reviews bodies")
 	doesContainFirstPart, err := getChartCaseEndpointUntilBodyHas(client, istioGatewayHost, exampleAppProductPagePath, firstReviewBodyPart)

--- a/tests/v2/validation/charts/monitoring.go
+++ b/tests/v2/validation/charts/monitoring.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/charts"
 	"github.com/rancher/rancher/tests/framework/extensions/clusterrolebindings"
 	"github.com/rancher/rancher/tests/framework/extensions/configmaps"
+	"github.com/rancher/rancher/tests/framework/extensions/ingresses"
 	"github.com/rancher/rancher/tests/framework/extensions/serviceaccounts"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads"
 	"github.com/rancher/rancher/tests/framework/pkg/namegenerator"
@@ -95,12 +96,17 @@ func waitUnknownPrometheusTargets(client *rancher.Client) error {
 	checkUnknownPrometheusTargets := func() (bool, error) {
 		var statusInit bool
 		var unknownTargets []string
-		resultAPI, err := charts.GetChartCaseEndpoint(client, client.RancherConfig.Host, prometheusTargetsPathAPI, true)
+		resultAPI, err := ingresses.GetExternalIngressResponse(client, client.RancherConfig.Host, prometheusTargetsPathAPI, true)
+		if err != nil {
+			return statusInit, err
+		}
+
+		bodyString, err := convertHTTPBodyToString(resultAPI)
 		if err != nil {
 			return statusInit, err
 		}
 		var mapResponse map[string]interface{}
-		if err = json.Unmarshal([]byte(resultAPI.Body), &mapResponse); err != nil {
+		if err = json.Unmarshal([]byte(bodyString), &mapResponse); err != nil {
 			return statusInit, err
 		}
 		if mapResponse["status"] != "success" {
@@ -149,13 +155,18 @@ func checkPrometheusTargets(client *rancher.Client) (bool, error) {
 		return statusInit, err
 	}
 
-	resultAPI, err := charts.GetChartCaseEndpoint(client, client.RancherConfig.Host, prometheusTargetsPathAPI, true)
+	resultAPI, err := ingresses.GetExternalIngressResponse(client, client.RancherConfig.Host, prometheusTargetsPathAPI, true)
+	if err != nil {
+		return statusInit, err
+	}
+
+	bodyString, err := convertHTTPBodyToString(resultAPI)
 	if err != nil {
 		return statusInit, err
 	}
 
 	var mapResponse map[string]interface{}
-	if err = json.Unmarshal([]byte(resultAPI.Body), &mapResponse); err != nil {
+	if err = json.Unmarshal([]byte(bodyString), &mapResponse); err != nil {
 		return statusInit, err
 	}
 

--- a/tests/v2/validation/charts/monitoring_test.go
+++ b/tests/v2/validation/charts/monitoring_test.go
@@ -15,6 +15,7 @@ import (
 	v1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/charts"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/ingresses"
 	"github.com/rancher/rancher/tests/framework/extensions/namespaces"
 	"github.com/rancher/rancher/tests/framework/extensions/projects"
 	"github.com/rancher/rancher/tests/framework/extensions/secrets"
@@ -131,9 +132,9 @@ func (m *MonitoringTestSuite) TestMonitoringChart() {
 	paths := []string{alertManagerPath, grafanaPath, prometheusGraphPath, prometheusRulesPath, prometheusTargetsPath}
 	for _, path := range paths {
 		m.T().Logf("Validating %s is accessible", path)
-		result, err := charts.GetChartCaseEndpoint(client, client.RancherConfig.Host, path, true)
+		result, err := ingresses.IsIngressExternallyAccessible(client, client.RancherConfig.Host, path, true)
 		assert.NoError(m.T(), err)
-		assert.True(m.T(), result.Ok)
+		assert.True(m.T(), result)
 	}
 
 	m.T().Log("Validating all Prometheus active targets are up")
@@ -239,9 +240,9 @@ func (m *MonitoringTestSuite) TestMonitoringChart() {
 
 	m.T().Logf("Validating traefik is accessible externally")
 	host := fmt.Sprintf("%v:%v", randWorkerNodePublicIP, webhookReceiverServiceSpec.Ports[0].NodePort)
-	result, err := charts.GetChartCaseEndpoint(client, host, "dashboard", false)
+	result, err := ingresses.IsIngressExternallyAccessible(client, host, "dashboard", false)
 	assert.NoError(m.T(), err)
-	assert.True(m.T(), result.Ok)
+	assert.True(m.T(), result)
 
 	m.T().Logf("Validating alertmanager sent alert to webhook receiver")
 	err = charts.WatchAndWaitDeploymentForAnnotation(client, m.project.ClusterID, webhookReceiverNamespace.Name, alertWebhookReceiverDeploymentResp.Name, webhookReceiverAnnotationKey, webhookReceiverAnnotationValue)

--- a/tests/v2/validation/nodescaling/scale_replace_test.go
+++ b/tests/v2/validation/nodescaling/scale_replace_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters"
+	"github.com/rancher/rancher/tests/framework/extensions/provisioning"
 	"github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
@@ -55,6 +57,16 @@ func (s *NodeScaleDownAndUp) TestControlPlaneScaleDownAndUp() {
 func (s *NodeScaleDownAndUp) TestWorkerScaleDownAndUp() {
 	s.Run("rke2-worker-node-scale-down-and-up", func() {
 		ReplaceNodes(s.T(), s.client, s.client.RancherConfig.ClusterName, false, false, true)
+	})
+}
+
+func (s *NodeScaleDownAndUp) TestValidate() {
+	s.Run("rke2-validate", func() {
+		_, stevecluster, err := clusters.GetProvisioningClusterByName(s.client, s.client.RancherConfig.ClusterName, provisioninginput.Namespace)
+		require.NoError(s.T(), err)
+
+		clusterConfig := clusters.ConvertConfigToClusterConfig(s.clustersConfig)
+		provisioning.VerifyCluster(s.T(), s.client, clusterConfig, stevecluster)
 	})
 }
 

--- a/tests/v2/validation/provisioning/permutations/permutations.go
+++ b/tests/v2/validation/provisioning/permutations/permutations.go
@@ -1,18 +1,27 @@
 package permutations
 
 import (
+	"os"
 	"strings"
+	"testing"
 
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/tests/framework/clients/corral"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	steveV1 "github.com/rancher/rancher/tests/framework/clients/rancher/v1"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/machinepools"
 	"github.com/rancher/rancher/tests/framework/extensions/provisioning"
 	"github.com/rancher/rancher/tests/framework/extensions/provisioninginput"
 	"github.com/rancher/rancher/tests/framework/extensions/rke1/componentchecks"
+	"github.com/rancher/rancher/tests/framework/extensions/services"
+	"github.com/rancher/rancher/tests/framework/extensions/workloads"
+	"github.com/rancher/rancher/tests/framework/pkg/namegenerator"
 	"github.com/rancher/rancher/tests/framework/pkg/session"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -26,6 +35,13 @@ const (
 	RKE1ProvisionCluster = "rke1"
 	RKE1AirgapCluster    = "rke1Airgap"
 	CorralProvider       = "corral"
+
+	outOfTreeAWSFilePath = "../resources/out-of-tree/aws.yml"
+	clusterIPPrefix      = "cip"
+	loadBalancerPrefix   = "lb"
+	portName             = "port"
+	nginxName            = "nginx"
+	defaultNamespace     = "default"
 )
 
 // RunTestPermutations runs through all relevant perumutations in a given config file, including node providers, k8s versions, and CNIs
@@ -55,13 +71,31 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 				testClusterConfig.CNI = cni
 				name = testNamePrefix + " Node Provider: " + nodeProviderName + " Kubernetes version: " + kubeVersion + " cni: " + cni
 				s.Run(name, func() {
+					if testClusterConfig.CloudProvider == provisioninginput.AWSProviderName.String() {
+						byteYaml, err := os.ReadFile(outOfTreeAWSFilePath)
+						require.NoError(s.T(), err)
+						testClusterConfig.AddOnConfig = &provisioninginput.AddOnConfig{
+							AdditionalManifest: string(byteYaml),
+						}
+					}
+
 					switch clusterType {
 					case RKE2ProvisionCluster, K3SProvisionCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
 						clusterObject, err := provisioning.CreateProvisioningCluster(client, *nodeProvider, testClusterConfig, hostnameTruncation)
-
 						require.NoError(s.T(), err)
+
 						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
+
+						if testClusterConfig.CloudProvider == provisioninginput.AWSProviderName.String() {
+							lbServiceResp := createAWSWorkloadAndServices(s.T(), client, clusterObject)
+
+							status := &provv1.ClusterStatus{}
+							err := steveV1.ConvertToK8sType(clusterObject.Status, status)
+							require.NoError(s.T(), err)
+
+							services.VerifyAWSLoadBalancer(s.T(), client, lbServiceResp, status.ClusterName)
+						}
 
 					case RKE1ProvisionCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
@@ -80,6 +114,15 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						require.NoError(s.T(), err)
 
 						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
+						if testClusterConfig.CloudProvider == provisioninginput.AWSProviderName.String() {
+							lbServiceResp := createAWSWorkloadAndServices(s.T(), client, clusterObject)
+
+							status := &provv1.ClusterStatus{}
+							err := steveV1.ConvertToK8sType(clusterObject.Status, status)
+							require.NoError(s.T(), err)
+
+							services.VerifyAWSLoadBalancer(s.T(), client, lbServiceResp, status.ClusterName)
+						}
 
 					case RKE1CustomCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
@@ -109,12 +152,14 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 					default:
 						s.T().Fatalf("Invalid cluster type: %s", clusterType)
 					}
+
 				})
 			}
 		}
 	}
 }
 
+// GetClusterProvider returns a provider object given cluster type, nodeProviderName (for custom clusters) and the provisioningConfig
 func GetClusterProvider(clusterType string, nodeProviderName string, provisioningConfig *provisioninginput.Config) (*provisioning.Provider, *provisioning.RKE1Provider, *provisioning.ExternalNodeProvider, []string) {
 	var nodeProvider provisioning.Provider
 	var rke1NodeProvider provisioning.RKE1Provider
@@ -150,4 +195,52 @@ func GetClusterProvider(clusterType string, nodeProviderName string, provisionin
 		panic("Cluster type not found")
 	}
 	return &nodeProvider, &rke1NodeProvider, &customProvider, kubeVersions
+}
+
+// createAWSWorkloadAndServices creates a test workload, clusterIP service and awsLoadBalancer service.
+// This should be used when testing cloud provider for aws, with in-tree or out-of-tree set on the cluster.
+func createAWSWorkloadAndServices(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIObject) *steveV1.SteveAPIObject {
+	status := &provv1.ClusterStatus{}
+	err := steveV1.ConvertToK8sType(cluster.Status, status)
+	require.NoError(t, err)
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+
+	steveclient, err := adminClient.Steve.ProxyDownstream(status.ClusterName)
+	require.NoError(t, err)
+
+	nginxWorkload, err := createNginxDeployment(steveclient, status.ClusterName)
+	require.NoError(t, err)
+
+	nginxSpec := &appv1.DeploymentSpec{}
+	err = steveV1.ConvertToK8sType(nginxWorkload.Spec, nginxSpec)
+	require.NoError(t, err)
+
+	clusterIPserviceName := namegenerator.AppendRandomString(clusterIPPrefix)
+	clusterIPserviceTemplate := services.NewServiceTemplate(clusterIPserviceName, defaultNamespace, corev1.ServiceTypeClusterIP, []corev1.ServicePort{{Name: portName, Port: 80}}, nginxSpec.Selector.MatchLabels)
+	_, err = steveclient.SteveType(services.ServiceSteveType).Create(clusterIPserviceTemplate)
+	require.NoError(t, err)
+
+	lbServiceName := namegenerator.AppendRandomString(loadBalancerPrefix)
+	lbServiceTemplate := services.NewServiceTemplate(lbServiceName, defaultNamespace, corev1.ServiceTypeLoadBalancer, []corev1.ServicePort{{Name: portName, Port: 80}}, nginxSpec.Selector.MatchLabels)
+	lbServiceResp, err := steveclient.SteveType(services.ServiceSteveType).Create(lbServiceTemplate)
+	require.NoError(t, err)
+
+	return lbServiceResp
+}
+
+// createNginxDeployment is a helper function that creates a nginx deployment in a cluster's default namespace
+func createNginxDeployment(steveclient *steveV1.Client, containerNamePrefix string) (*steveV1.SteveAPIObject, error) {
+	containerName := namegenerator.AppendRandomString(containerNamePrefix)
+	containerTemplate := workloads.NewContainer(nginxName, nginxName, corev1.PullAlways, []corev1.VolumeMount{}, []corev1.EnvFromSource{}, nil, nil, nil)
+	podTemplate := workloads.NewPodTemplate([]corev1.Container{containerTemplate}, []corev1.Volume{}, []corev1.LocalObjectReference{}, nil)
+	deployment := workloads.NewDeploymentTemplate(containerName, defaultNamespace, podTemplate, true, nil)
+
+	deploymentResp, err := steveclient.SteveType(workloads.DeploymentSteveType).Create(deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	return deploymentResp, err
 }

--- a/tests/v2/validation/provisioning/resources/out-of-tree/aws.yml
+++ b/tests/v2/validation/provisioning/resources/out-of-tree/aws.yml
@@ -1,0 +1,18 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: aws-cloud-controller-manager
+  namespace: kube-system
+spec:
+  chart: aws-cloud-controller-manager
+  repo: https://kubernetes.github.io/cloud-provider-aws
+  targetNamespace: kube-system
+  bootstrap: true
+  valuesContent: |-
+    hostNetworking: true
+    nodeSelector:
+      node-role.kubernetes.io/control-plane: "true"
+    args:
+      - --configure-cloud-routes=false
+      - --v=5
+      - --cloud-provider=aws

--- a/tests/v2/validation/upgrade/workload.go
+++ b/tests/v2/validation/upgrade/workload.go
@@ -167,7 +167,7 @@ func newPodTemplateWithSecretEnvironmentVariable(secretName string) corev1.PodTe
 // waitUntilIngressIsAccessible waits until the ingress is accessible
 func waitUntilIngressIsAccessible(client *rancher.Client, hostname string) (bool, error) {
 	err := kubewait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
-		isIngressAccessible, err := ingresses.AccessIngressExternally(client, hostname, false)
+		isIngressAccessible, err := ingresses.IsIngressExternallyAccessible(client, hostname, "", false)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/936
https://github.com/rancher/rancher/issues/42749
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
There is currently no automation for cloud providers. 


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This PR is addressing the recent upstream change to depreciate in-tree aws cloud provider, by automating the out-of-tree path for aws. 
introducing 
```
provisioningInput:
  ...
  cloudProvider: "aws"
```
which follows [the new documentation](https://github.com/rancher/rancher-docs/pull/844/files#diff-4838044f24960fb879a1eec2cad40448fe714e9f963e569d6197799b52e7dc75L138) around adding an out-of-tree provider for aws

For this, we need the supporting aws field
```
awsMachineConfig:
  ...
  iamInstanceProfile: <string>
  ...
```



## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
tested locally, will get jenkins runs on request. 


### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
this opens the door for other rke2 cloud provider automation, like vsphere or harvester.

The external option will be more complicated to automate e2e, as it typically requires quite a lot of customization / heavy lifting to add an external provider. 

RKE1 out-of-tree is having some other difficulties (manually) so I thought it best to show the work for rke2 now, and add rke1 work separately at a later time.  

I would like feedback in general, but also specifically on:
* the hard-coded values for MachineGlobalConfig/SelectorConfig added to clusters.go. Should this live somewhere else? 
* I split the additionalManifest hard coded value to a file, and have that being read in from permutations.go. My hunch is, this and the previous bullet point should live in the same place but I'm not sold on where at this time. 

last note: rke2 doesn't support adding cloud provider post-create (and requires it be done on create), but rke1 does (and requires it be done post-create).  