### PR TITLE
Fix flaky CRTB and PRTB tests (Backport 2.7)

### DIFF
--- a/tests/framework/clients/dynamic/dynamic.go
+++ b/tests/framework/clients/dynamic/dynamic.go
@@ -72,6 +72,25 @@ type ResourceClient struct {
 	ts *session.Session
 }
 
+var (
+	noCleanupGVKs = []schema.GroupVersionKind{
+		{
+			Group:   "authorization.k8s.io",
+			Version: "v1",
+			Kind:    "SelfSubjectAccessReview",
+		},
+	}
+)
+
+func needsCleanup(obj *unstructured.Unstructured) bool {
+	for _, gvk := range noCleanupGVKs {
+		if obj.GroupVersionKind() == gvk {
+			return false
+		}
+	}
+	return true
+}
+
 // Create is dynamic.ResourceInterface's Create function, that is being overwritten to register its delete function to the session.Session
 // that is being reference.
 func (c *ResourceClient) Create(ctx context.Context, obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
@@ -80,20 +99,22 @@ func (c *ResourceClient) Create(ctx context.Context, obj *unstructured.Unstructu
 		return nil, err
 	}
 
-	c.ts.RegisterCleanupFunc(func() error {
-		err := c.Delete(context.TODO(), unstructuredObj.GetName(), metav1.DeleteOptions{}, subresources...)
-		if errors.IsNotFound(err) {
-			return nil
-		}
+	if needsCleanup(obj) {
+		c.ts.RegisterCleanupFunc(func() error {
+			err := c.Delete(context.TODO(), unstructuredObj.GetName(), metav1.DeleteOptions{}, subresources...)
+			if errors.IsNotFound(err) {
+				return nil
+			}
 
-		name := unstructuredObj.GetName()
-		if unstructuredObj.GetNamespace() != "" {
-			name = unstructuredObj.GetNamespace() + "/" + name
-		}
-		gvk := unstructuredObj.GetObjectKind().GroupVersionKind()
+			name := unstructuredObj.GetName()
+			if unstructuredObj.GetNamespace() != "" {
+				name = unstructuredObj.GetNamespace() + "/" + name
+			}
+			gvk := unstructuredObj.GetObjectKind().GroupVersionKind()
 
-		return fmt.Errorf("%v (%v): %w", name, gvk, err)
-	})
+			return fmt.Errorf("%v (%v): %w", name, gvk, err)
+		})
+	}
 
 	return unstructuredObj, err
 }

--- a/tests/framework/clients/dynamic/dynamic.go
+++ b/tests/framework/clients/dynamic/dynamic.go
@@ -73,6 +73,9 @@ type ResourceClient struct {
 }
 
 var (
+	// some GVKs are special and cannot be cleaned up because they do not exist
+	// after being created (eg: SelfSubjectAccessReview). We'll not register
+	// cleanup functions when creating objects of these kinds.
 	noCleanupGVKs = []schema.GroupVersionKind{
 		{
 			Group:   "authorization.k8s.io",
@@ -112,7 +115,7 @@ func (c *ResourceClient) Create(ctx context.Context, obj *unstructured.Unstructu
 			}
 			gvk := unstructuredObj.GetObjectKind().GroupVersionKind()
 
-			return fmt.Errorf("%v (%v): %w", name, gvk, err)
+			return fmt.Errorf("unable to delete (%v) %v: %w", gvk, name, err)
 		})
 	}
 

--- a/tests/framework/clients/dynamic/dynamic.go
+++ b/tests/framework/clients/dynamic/dynamic.go
@@ -2,6 +2,7 @@ package dynamic
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/client-go/rest"
 
@@ -85,7 +86,13 @@ func (c *ResourceClient) Create(ctx context.Context, obj *unstructured.Unstructu
 			return nil
 		}
 
-		return err
+		name := unstructuredObj.GetName()
+		if unstructuredObj.GetNamespace() != "" {
+			name = unstructuredObj.GetNamespace() + "/" + name
+		}
+		gvk := unstructuredObj.GetObjectKind().GroupVersionKind()
+
+		return fmt.Errorf("%v (%v): %w", name, gvk, err)
 	})
 
 	return unstructuredObj, err

--- a/tests/framework/extensions/kubeapi/authorization/authorization.go
+++ b/tests/framework/extensions/kubeapi/authorization/authorization.go
@@ -1,0 +1,67 @@
+package authorization
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rancher/rancher/pkg/api/scheme"
+	"github.com/rancher/rancher/tests/framework/clients/rancher"
+	"github.com/rancher/rancher/tests/framework/extensions/kubeapi"
+	"github.com/rancher/rancher/tests/framework/extensions/unstructured"
+	authzv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+// WaitForAllowed verifies access to resources using the SelfSubjectAccessReview
+// API. It returns nil when all have been granted within some defined timeout,
+// otherwise it returns an error.
+func WaitForAllowed(client *rancher.Client, clusterID string, attrs []*authzv1.ResourceAttributes) error {
+	// 40 seconds ought to do it
+	backoff := kwait.Backoff{
+		Duration: 500 * time.Millisecond,
+		Factor:   1,
+		Jitter:   0,
+		Steps:    81,
+	}
+	err := kwait.ExponentialBackoff(backoff, func() (done bool, err error) {
+		for _, attr := range attrs {
+			selfReview := &authzv1.SelfSubjectAccessReview{
+				Spec: authzv1.SelfSubjectAccessReviewSpec{
+					ResourceAttributes: attr,
+				},
+			}
+
+			selfSARResource, err := kubeapi.ResourceForClient(client, clusterID, "", schema.GroupVersionResource{
+				Group:    "authorization.k8s.io",
+				Version:  "v1",
+				Resource: "selfsubjectaccessreviews",
+			})
+			if err != nil {
+				return false, err
+			}
+
+			respUnstructured, err := selfSARResource.Create(context.TODO(), unstructured.MustToUnstructured(selfReview), metav1.CreateOptions{})
+			if err != nil {
+				return false, nil
+			}
+
+			selfReviewResp := &authzv1.SelfSubjectAccessReview{}
+			err = scheme.Scheme.Convert(respUnstructured, selfReviewResp, respUnstructured.GroupVersionKind())
+			if err != nil {
+				return false, err
+			}
+
+			if !selfReviewResp.Status.Allowed {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("not all access were granted: %w", err)
+	}
+	return nil
+}

--- a/tests/v2/integration/projects/project_user_test.go
+++ b/tests/v2/integration/projects/project_user_test.go
@@ -72,7 +72,7 @@ func (p *ProjectUserTestSuite) TestCreateNamespaceProjectMember() {
 	client, err := p.client.WithSession(subSession)
 	require.NoError(p.T(), err)
 
-	err = users.AddProjectMember(client, p.project, p.testUser, "project-member")
+	err = users.AddProjectMember(client, p.project, p.testUser, "project-member", nil)
 	require.NoError(p.T(), err)
 
 	testUser, err := client.AsUser(p.testUser)
@@ -90,7 +90,7 @@ func (p *ProjectUserTestSuite) TestCreateNamespaceProjectOwner() {
 	client, err := p.client.WithSession(subSession)
 	require.NoError(p.T(), err)
 
-	err = users.AddProjectMember(client, p.project, p.testUser, "project-owner")
+	err = users.AddProjectMember(client, p.project, p.testUser, "project-owner", nil)
 	require.NoError(p.T(), err)
 
 	testUser, err := client.AsUser(p.testUser)

--- a/tests/v2/integration/steveapi/steve_api_test.go
+++ b/tests/v2/integration/steveapi/steve_api_test.go
@@ -408,13 +408,13 @@ func (s *steveAPITestSuite) setupSuite(clusterName string) {
 		for _, binding := range access {
 			switch b := binding.(type) {
 			case management.ClusterRoleTemplateBinding:
-				err = users.AddClusterRoleToUser(client, mgmtCluster, userObj, b.RoleTemplateID)
+				err = users.AddClusterRoleToUser(client, mgmtCluster, userObj, b.RoleTemplateID, nil)
 				require.NoError(s.T(), err)
 			case management.ProjectRoleTemplateBinding:
-				err = users.AddProjectMember(client, projectMap[b.ProjectID], userObj, b.RoleTemplateID)
+				err = users.AddProjectMember(client, projectMap[b.ProjectID], userObj, b.RoleTemplateID, nil)
 				require.NoError(s.T(), err)
 			case rbacv1.RoleBinding:
-				_ = users.AddClusterRoleToUser(client, mgmtCluster, userObj, "cluster-member")
+				_ = users.AddClusterRoleToUser(client, mgmtCluster, userObj, "cluster-member", nil)
 				subject := rbacv1.Subject{
 					Kind: "User",
 					Name: userObj.ID,

--- a/tests/v2/validation/rbac/rbac_additional_test.go
+++ b/tests/v2/validation/rbac/rbac_additional_test.go
@@ -64,7 +64,7 @@ func (rb *RBACAdditionalTestSuite) ValidateAddStdUserAsProjectOwner() {
 	rb.standardUserCOProject = createProjectAsCO
 
 	log.Info("Validating if cluster owner can add a user as project owner in a project")
-	err = users.AddProjectMember(rb.standardUserClient, rb.standardUserCOProject, rb.additionalUser, roleProjectOwner)
+	err = users.AddProjectMember(rb.standardUserClient, rb.standardUserCOProject, rb.additionalUser, roleProjectOwner, nil)
 	require.NoError(rb.T(), err)
 	userGetProject, err := projects.GetProjectList(rb.additionalUserClient, rb.cluster.ID)
 	require.NoError(rb.T(), err)
@@ -79,7 +79,7 @@ func (rb *RBACAdditionalTestSuite) ValidateAddStdUserAsProjectOwner() {
 func (rb *RBACAdditionalTestSuite) ValidateAddMemberAsClusterRoles() {
 
 	log.Info("Validating if cluster owners should be able to add another standard user as a cluster owner")
-	errUserRole := users.AddClusterRoleToUser(rb.standardUserClient, rb.cluster, rb.additionalUser, roleOwner)
+	errUserRole := users.AddClusterRoleToUser(rb.standardUserClient, rb.cluster, rb.additionalUser, roleOwner, nil)
 	require.NoError(rb.T(), errUserRole)
 	additionalUserClient, err := rb.additionalUserClient.ReLogin()
 	require.NoError(rb.T(), err)
@@ -97,7 +97,7 @@ func (rb *RBACAdditionalTestSuite) ValidateAddMemberAsClusterRoles() {
 func (rb *RBACAdditionalTestSuite) ValidateAddCMAsProjectOwner() {
 
 	log.Info("Validating if cluster manage member should be able to add as a project member")
-	errUserRole := users.AddClusterRoleToUser(rb.standardUserClient, rb.cluster, rb.additionalUser, roleMember)
+	errUserRole := users.AddClusterRoleToUser(rb.standardUserClient, rb.cluster, rb.additionalUser, roleMember, nil)
 	require.NoError(rb.T(), errUserRole)
 	additionalUserClient, err := rb.additionalUserClient.ReLogin()
 	require.NoError(rb.T(), err)
@@ -107,7 +107,7 @@ func (rb *RBACAdditionalTestSuite) ValidateAddCMAsProjectOwner() {
 	require.NoError(rb.T(), err)
 	assert.Equal(rb.T(), 1, len(clusterList.Data))
 
-	err = users.AddProjectMember(rb.standardUserClient, rb.standardUserCOProject, rb.additionalUser, roleProjectOwner)
+	err = users.AddProjectMember(rb.standardUserClient, rb.standardUserCOProject, rb.additionalUser, roleProjectOwner, nil)
 	require.NoError(rb.T(), err)
 	userGetProject, err := projects.GetProjectList(rb.additionalUserClient, rb.cluster.ID)
 	require.NoError(rb.T(), err)
@@ -121,7 +121,7 @@ func (rb *RBACAdditionalTestSuite) ValidateAddPOsAsProjectOwner() {
 	rb.standardUserCOProject = createProjectAsCO
 
 	log.Info("Validating if Project Owner can add another Project Owner")
-	errUserRole := users.AddProjectMember(rb.standardUserClient, rb.standardUserCOProject, rb.additionalUser, roleProjectOwner)
+	errUserRole := users.AddProjectMember(rb.standardUserClient, rb.standardUserCOProject, rb.additionalUser, roleProjectOwner, nil)
 	require.NoError(rb.T(), errUserRole)
 	rb.additionalUserClient, err = rb.additionalUserClient.ReLogin()
 	require.NoError(rb.T(), err)
@@ -131,7 +131,7 @@ func (rb *RBACAdditionalTestSuite) ValidateAddPOsAsProjectOwner() {
 	addNewUserAsPOClient, err := rb.client.AsUser(addNewUserAsPO)
 	require.NoError(rb.T(), err)
 
-	errUserRole2 := users.AddProjectMember(rb.additionalUserClient, rb.standardUserCOProject, addNewUserAsPO, roleProjectOwner)
+	errUserRole2 := users.AddProjectMember(rb.additionalUserClient, rb.standardUserCOProject, addNewUserAsPO, roleProjectOwner, nil)
 	require.NoError(rb.T(), errUserRole2)
 
 	addNewUserAsPOClient, err = addNewUserAsPOClient.ReLogin()
@@ -157,7 +157,7 @@ func (rb *RBACAdditionalTestSuite) ValidateCannotAddMPMsAsProjectOwner() {
 	rb.standardUserCOProject = createProjectAsCO
 
 	log.Info("Validating if Manage Project Member cannot add Project Owner")
-	errUserRole := users.AddProjectMember(rb.standardUserClient, rb.standardUserCOProject, rb.additionalUser, roleCustomManageProjectMember)
+	errUserRole := users.AddProjectMember(rb.standardUserClient, rb.standardUserCOProject, rb.additionalUser, roleCustomManageProjectMember, nil)
 	require.NoError(rb.T(), errUserRole)
 	rb.additionalUserClient, err = rb.additionalUserClient.ReLogin()
 	require.NoError(rb.T(), err)
@@ -167,7 +167,7 @@ func (rb *RBACAdditionalTestSuite) ValidateCannotAddMPMsAsProjectOwner() {
 	addNewUserAsPOClient, err := rb.client.AsUser(addNewUserAsPO)
 	require.NoError(rb.T(), err)
 
-	errUserRole2 := users.AddProjectMember(rb.additionalUserClient, rb.standardUserCOProject, addNewUserAsPO, roleProjectOwner)
+	errUserRole2 := users.AddProjectMember(rb.additionalUserClient, rb.standardUserCOProject, addNewUserAsPO, roleProjectOwner, nil)
 	require.Error(rb.T(), errUserRole2)
 	errStatus := strings.Split(errUserRole2.Error(), ".")[1]
 	rgx := regexp.MustCompile(`\[(.*?)\]`)
@@ -226,7 +226,7 @@ func (rb *RBACAdditionalTestSuite) TestRBACAdditional() {
 		if tt.member == standardUser {
 			rb.T().Logf("Adding user as " + roleOwner + " to the downstream cluster.")
 			//Adding created user to the downstream clusters with the role cluster Owner.
-			err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.standardUser, roleOwner)
+			err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.standardUser, roleOwner, nil)
 			require.NoError(rb.T(), err)
 			rb.standardUserClient, err = rb.standardUserClient.ReLogin()
 			require.NoError(rb.T(), err)

--- a/tests/v2/validation/rbac/rbac_etcd_backup_test.go
+++ b/tests/v2/validation/rbac/rbac_etcd_backup_test.go
@@ -103,10 +103,10 @@ func (rb *ETCDRbacBackupTestSuite) TestETCDRbac() {
 
 			if tt.member == standardUser {
 				if strings.Contains(tt.role, "project") {
-					err := users.AddProjectMember(rb.client, rb.adminProject, rb.standardUser, tt.role)
+					err := users.AddProjectMember(rb.client, rb.adminProject, rb.standardUser, tt.role, nil)
 					require.NoError(rb.T(), err)
 				} else {
-					err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.standardUser, tt.role)
+					err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.standardUser, tt.role, nil)
 					require.NoError(rb.T(), err)
 				}
 			}

--- a/tests/v2/validation/rbac/rbac_psa_test.go
+++ b/tests/v2/validation/rbac/rbac_psa_test.go
@@ -327,10 +327,10 @@ func (rb *PSATestSuite) TestPSA() {
 			log.Info("Adding user as " + role + " to the downstream cluster.")
 			if role != restrictedAdmin {
 				if strings.Contains(role, "project") || role == roleProjectReadOnly || role == roleCustomCreateNS {
-					err := users.AddProjectMember(rb.client, rb.adminProject, rb.nonAdminUser, role)
+					err := users.AddProjectMember(rb.client, rb.adminProject, rb.nonAdminUser, role, nil)
 					require.NoError(rb.T(), err)
 				} else {
-					err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.nonAdminUser, role)
+					err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.nonAdminUser, role, nil)
 					require.NoError(rb.T(), err)
 				}
 				rb.nonAdminUserClient, err = rb.nonAdminUserClient.ReLogin()
@@ -355,7 +355,7 @@ func (rb *PSATestSuite) TestPSA() {
 
 		if strings.Contains(role, "project") || role == roleCustomCreateNS {
 			rb.Run("Additional testcase - Validate if "+role+" with an additional role update-psa can add/edit/delete labels from admin created namespace", func() {
-				err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.nonAdminUser, rb.psaRole.ID)
+				err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.nonAdminUser, rb.psaRole.ID, nil)
 				require.NoError(rb.T(), err)
 				rb.ValidatePSA(psaRole, customRole)
 			})
@@ -396,10 +396,10 @@ func (rb *PSATestSuite) TestPsactRBAC() {
 		rb.Run("Adding user as "+tt.name+" to the downstream cluster.", func() {
 			if tt.member == standardUser {
 				if strings.Contains(tt.role, "project") || tt.role == roleProjectReadOnly {
-					err := users.AddProjectMember(rb.client, rb.adminProject, rb.nonAdminUser, tt.role)
+					err := users.AddProjectMember(rb.client, rb.adminProject, rb.nonAdminUser, tt.role, nil)
 					require.NoError(rb.T(), err)
 				} else {
-					err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.nonAdminUser, tt.role)
+					err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.nonAdminUser, tt.role, nil)
 					require.NoError(rb.T(), err)
 				}
 			}

--- a/tests/v2/validation/rbac/rbac_test.go
+++ b/tests/v2/validation/rbac/rbac_test.go
@@ -206,7 +206,7 @@ func (rb *RBTestSuite) ValidateNS(role string) {
 
 func (rb *RBTestSuite) ValidateAddClusterRoles(role string) {
 
-	errUserRole := users.AddClusterRoleToUser(rb.standardUserClient, rb.cluster, rb.additionalUser, roleOwner)
+	errUserRole := users.AddClusterRoleToUser(rb.standardUserClient, rb.cluster, rb.additionalUser, roleOwner, nil)
 
 	switch role {
 	case roleProjectOwner, roleProjectMember:
@@ -222,7 +222,7 @@ func (rb *RBTestSuite) ValidateAddClusterRoles(role string) {
 
 func (rb *RBTestSuite) ValidateAddProjectRoles(role string) {
 
-	errUserRole := users.AddProjectMember(rb.standardUserClient, rb.adminProject, rb.additionalUser, roleProjectOwner)
+	errUserRole := users.AddProjectMember(rb.standardUserClient, rb.adminProject, rb.additionalUser, roleProjectOwner, nil)
 
 	additionalUserClient, err := rb.additionalUserClient.ReLogin()
 	require.NoError(rb.T(), err)
@@ -333,10 +333,10 @@ func (rb *RBTestSuite) TestRBAC() {
 
 			if tt.member == standardUser {
 				if strings.Contains(tt.role, "project") {
-					err := users.AddProjectMember(rb.client, rb.adminProject, rb.standardUser, tt.role)
+					err := users.AddProjectMember(rb.client, rb.adminProject, rb.standardUser, tt.role, nil)
 					require.NoError(rb.T(), err)
 				} else {
-					err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.standardUser, tt.role)
+					err := users.AddClusterRoleToUser(rb.client, rb.cluster, rb.standardUser, tt.role, nil)
 					require.NoError(rb.T(), err)
 				}
 			}


### PR DESCRIPTION
## Issue:

https://github.com/rancher/rancher/issues/43134

This is a backport of https://github.com/rancher/rancher/pull/42962.

## Problem

The following tests were flaky:
- TestRTBTestSuite/TestPRTBRoleTemplateInheritance
- TestRTBTestSuite/TestCRTBRoleTemplateInheritance

This is because `AddClusterRoleToUser` and `AddProjectMember` attempts to detect if the new role templates bindings have been reconciled. This detection is flawed (eg: waiting for > 0 resources means 1 / 4 could exist but the test would rely one one of the 3 not yet created).
 
## Solution

Use the [SelfSubjectAccessReview API](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#checking-api-access) which allow us to check if the current user has access to some resources.

It would be best to use this `WaitForAllowed` function whenever `AddClusterRoleToUser` or `AddProjectMember` is called, however I have only fixed the CRTB/PRTB tests in this PR.
 
## Testing

I was able to reproduce the issue by adding a `time.Sleep(4 * time.Second)` in the rbac reconcile loop. This was useful to know whether my fix actual fixes the issue.