### PR TITLE
Adding NamespacedRules and handling to GR/GRB

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authz_types.go
+++ b/pkg/apis/management.cattle.io/v3/authz_types.go
@@ -171,6 +171,13 @@ type GlobalRole struct {
 	// cluster besides the local cluster. To grant permissions in the local cluster, use the Rules field.
 	// +optional
 	InheritedClusterRoles []string `json:"inheritedClusterRoles,omitempty"`
+
+	// NamespacedRules are the rules that are active in each namespace of this GlobalRole.
+	// These are applied to the local cluster only.
+	// * has no special meaning in the keys - these keys are read as raw strings
+	// and must exactly match with one existing namespace.
+	// +optional
+	NamespacedRules map[string][]rbacv1.PolicyRule `json:"namespacedRules,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/pkg/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -4125,6 +4125,23 @@ func (in *GlobalRole) DeepCopyInto(out *GlobalRole) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NamespacedRules != nil {
+		in, out := &in.NamespacedRules, &out.NamespacedRules
+		*out = make(map[string][]rbacv1.PolicyRule, len(*in))
+		for key, val := range *in {
+			var outVal []rbacv1.PolicyRule
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make([]rbacv1.PolicyRule, len(*in))
+				for i := range *in {
+					(*in)[i].DeepCopyInto(&(*out)[i])
+				}
+			}
+			(*out)[key] = outVal
+		}
+	}
 	return
 }
 

--- a/pkg/client/generated/management/v3/zz_generated_global_role.go
+++ b/pkg/client/generated/management/v3/zz_generated_global_role.go
@@ -14,6 +14,7 @@ const (
 	GlobalRoleFieldInheritedClusterRoles = "inheritedClusterRoles"
 	GlobalRoleFieldLabels                = "labels"
 	GlobalRoleFieldName                  = "name"
+	GlobalRoleFieldNamespacedRules       = "namespacedRules"
 	GlobalRoleFieldNewUserDefault        = "newUserDefault"
 	GlobalRoleFieldOwnerReferences       = "ownerReferences"
 	GlobalRoleFieldRemoved               = "removed"
@@ -23,19 +24,20 @@ const (
 
 type GlobalRole struct {
 	types.Resource
-	Annotations           map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Builtin               bool              `json:"builtin,omitempty" yaml:"builtin,omitempty"`
-	Created               string            `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID             string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	Description           string            `json:"description,omitempty" yaml:"description,omitempty"`
-	InheritedClusterRoles []string          `json:"inheritedClusterRoles,omitempty" yaml:"inheritedClusterRoles,omitempty"`
-	Labels                map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Name                  string            `json:"name,omitempty" yaml:"name,omitempty"`
-	NewUserDefault        bool              `json:"newUserDefault,omitempty" yaml:"newUserDefault,omitempty"`
-	OwnerReferences       []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	Removed               string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	Rules                 []PolicyRule      `json:"rules,omitempty" yaml:"rules,omitempty"`
-	UUID                  string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Annotations           map[string]string       `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Builtin               bool                    `json:"builtin,omitempty" yaml:"builtin,omitempty"`
+	Created               string                  `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID             string                  `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Description           string                  `json:"description,omitempty" yaml:"description,omitempty"`
+	InheritedClusterRoles []string                `json:"inheritedClusterRoles,omitempty" yaml:"inheritedClusterRoles,omitempty"`
+	Labels                map[string]string       `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name                  string                  `json:"name,omitempty" yaml:"name,omitempty"`
+	NamespacedRules       map[string][]PolicyRule `json:"namespacedRules,omitempty" yaml:"namespacedRules,omitempty"`
+	NewUserDefault        bool                    `json:"newUserDefault,omitempty" yaml:"newUserDefault,omitempty"`
+	OwnerReferences       []OwnerReference        `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Removed               string                  `json:"removed,omitempty" yaml:"removed,omitempty"`
+	Rules                 []PolicyRule            `json:"rules,omitempty" yaml:"rules,omitempty"`
+	UUID                  string                  `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }
 
 type GlobalRoleCollection struct {

--- a/pkg/controllers/management/auth/globalroles/enqueue.go
+++ b/pkg/controllers/management/auth/globalroles/enqueue.go
@@ -5,8 +5,11 @@ import (
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	wrangler "github.com/rancher/wrangler/pkg/name"
 	"github.com/rancher/wrangler/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -14,10 +17,16 @@ import (
 )
 
 const (
-	grbGrIndex        = "mgmt-auth-grb-gr-idex"
-	grbEnqueuer       = "mgmt-auth-gr-enqueue"
-	clusterGrEnqueuer = "mgmt-auth-cluster-gr"
-	crtbGRBEnqueuer   = "mgmt-auth-crtb-grb"
+	grbGrIndex          = "mgmt-auth-grb-gr-idex"
+	grNsIndex           = "mgmt-auth-gr-ns-index"
+	grSafeConcatIndex   = "mgmt-auth-gr-concat-index"
+	grbSafeConcatIndex  = "mgmt-auth-grb-concat-index"
+	grbEnqueuer         = "mgmt-auth-gr-enqueue"
+	clusterGrEnqueuer   = "mgmt-auth-cluster-gr"
+	crtbGRBEnqueuer     = "mgmt-auth-crtb-grb"
+	roleEnqueuer        = "mgmt-auth-role-gr"
+	roleBindingEnqueuer = "mgmt-auth-rb-grb"
+	namespaceGrEnqueuer = "mgmt-auth-ns-gr"
 )
 
 type globalRBACEnqueuer struct {
@@ -26,9 +35,28 @@ type globalRBACEnqueuer struct {
 	clusterClient mgmtv3.ClusterClient
 }
 
+// grNsIndexer indexes GlobalRoles by the namespaces in NamespacedRules
+func grNsIndexer(gr *v3.GlobalRole) ([]string, error) {
+	result := []string{}
+	for ns := range gr.NamespacedRules {
+		result = append(result, ns)
+	}
+	return result, nil
+}
+
 // grbGrIndexer indexes a globalRoleBinding by the globalRole it assigns to users
 func grbGrIndexer(grb *v3.GlobalRoleBinding) ([]string, error) {
 	return []string{grb.GlobalRoleName}, nil
+}
+
+// grSafeConcatIndexer indexes a GlobalRole by the SafeConcat version of it's name
+func grSafeConcatIndexer(gr *v3.GlobalRole) ([]string, error) {
+	return []string{wrangler.SafeConcatName(gr.Name)}, nil
+}
+
+// grbSafeConcatIndexer indexes a GlobalRoleBinding by the SafeConcat version of it's name
+func grbSafeConcatIndexer(grb *v3.GlobalRoleBinding) ([]string, error) {
+	return []string{wrangler.SafeConcatName(grb.Name)}, nil
 }
 
 // enqueueGRBs enqueues GlobalRoleBinding for a given changed GlobalRole, allowing per-cluster permissions to sync
@@ -125,4 +153,83 @@ func (g *globalRBACEnqueuer) crtbEnqueueGRB(_, _ string, obj runtime.Object) ([]
 	return []relatedresource.Key{
 		{Name: grbOwner},
 	}, nil
+}
+
+// roleEnqueueGR enqueues GlobalRoles that own a given Role when that Role is changed. Uses grOwnerLabel
+// which is protected by the webhook rather than the ownerReference.
+func (g *globalRBACEnqueuer) roleEnqueueGR(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	role, ok := obj.(*v1.Role)
+	if !ok {
+		logrus.Errorf("unable to convert object: %[1]v, type: %[1]T to a Role", obj)
+		return nil, nil
+	}
+	grOwner, ok := role.Labels[grOwnerLabel]
+	if !ok {
+		// this Role isn't owned by a GR, no need to enqueue a GR
+		return nil, nil
+	}
+	grs, err := g.grCache.GetByIndex(grSafeConcatIndex, grOwner)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get GlobalRole %s for Role %s", grOwner, role.Name)
+	}
+
+	grNames := make([]relatedresource.Key, 0, len(grs))
+	for _, gr := range grs {
+		grNames = append(grNames, relatedresource.Key{Name: gr.Name})
+	}
+	return grNames, nil
+}
+
+// roleEnqueueGRB enqueues GlobalRoleBindings that own a given RoleBinding when that RoleBinding is changed.
+// Uses grbOwnerLabel which is protected by the webhook rather than the ownerReference
+func (g *globalRBACEnqueuer) roleBindingEnqueueGRB(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	roleBinding, ok := obj.(*v1.RoleBinding)
+	if !ok {
+		logrus.Errorf("unable to convert object: %[1]v, type: %[1]T to a RoleBinding", obj)
+		return nil, nil
+	}
+	grbOwner, ok := roleBinding.Labels[grbOwnerLabel]
+	if !ok {
+		// this RoleBinding isn't owned by a GRB, no need to enqueue a GRB
+		return nil, nil
+	}
+	grbs, err := g.grbCache.GetByIndex(grbSafeConcatIndex, grbOwner)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get GlobalRoleBinding %s for RoleBinding %s", grbOwner, roleBinding.Name)
+	}
+	grbNames := make([]relatedresource.Key, 0, len(grbs))
+	for _, grb := range grbs {
+		grbNames = append(grbNames, relatedresource.Key{Name: grb.Name})
+	}
+	return grbNames, nil
+
+}
+
+// namespaceEnqueueGR enqueues GlobalRoles that have Roles in the changed namespace based on
+// the NamespacedRules field
+func (g *globalRBACEnqueuer) namespaceEnqueueGR(_, _ string, obj runtime.Object) ([]relatedresource.Key, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	namespace, ok := obj.(*corev1.Namespace)
+	if !ok {
+		logrus.Errorf("unable to convert object: %[1]v, type: %[1]T to a Namespace", obj)
+		return nil, nil
+	}
+
+	grs, err := g.grCache.GetByIndex(grNsIndex, namespace.Name)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get grs for namespace %s from indexer: %w", namespace.Name, err)
+	}
+	grNames := make([]relatedresource.Key, 0, len(grs))
+	for _, gr := range grs {
+		grNames = append(grNames, relatedresource.Key{Name: gr.Name})
+	}
+	return grNames, nil
 }

--- a/pkg/controllers/management/auth/globalroles/enqueue_test.go
+++ b/pkg/controllers/management/auth/globalroles/enqueue_test.go
@@ -9,12 +9,93 @@ import (
 	"github.com/rancher/wrangler/pkg/generic/fake"
 	"github.com/rancher/wrangler/pkg/relatedresource"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+var (
+	longName           = "long-name--------------------------------------------------------"
+	safeConcatLongName = "long-name------------------------------------------------cc9244"
+)
+
+func Test_grNsIndexer(t *testing.T) {
+	t.Parallel()
+	gr := &v3.GlobalRole{
+		NamespacedRules: map[string][]v1.PolicyRule{
+			"ns1": nil,
+			"ns2": nil,
+		},
+	}
+	res, resErr := grNsIndexer(gr)
+	require.NoError(t, resErr)
+	require.Len(t, res, 2)
+	require.Contains(t, res, "ns1")
+	require.Contains(t, res, "ns2")
+
+	gr.NamespacedRules = map[string][]v1.PolicyRule{}
+	res, resErr = grNsIndexer(gr)
+	require.NoError(t, resErr)
+	require.Len(t, res, 0)
+
+	gr.NamespacedRules = nil
+	res, resErr = grNsIndexer(gr)
+	require.NoError(t, resErr)
+	require.Len(t, res, 0)
+}
+
+func Test_grbGrIndexer(t *testing.T) {
+	t.Parallel()
+	grb := &v3.GlobalRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-grb",
+		},
+		GlobalRoleName: "test-gr",
+	}
+	res, resErr := grbGrIndexer(grb)
+	require.NoError(t, resErr)
+	require.Equal(t, []string{"test-gr"}, res)
+}
+
+func Test_grSafeConcatIndexer(t *testing.T) {
+	t.Parallel()
+	gr := &v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gr1",
+		},
+	}
+	res, resErr := grSafeConcatIndexer(gr)
+	require.NoError(t, resErr)
+	require.Equal(t, []string{"gr1"}, res)
+
+	// Make sure it returns the concatenated name
+	gr.SetName(longName)
+	res, resErr = grSafeConcatIndexer(gr)
+	require.NoError(t, resErr)
+	require.Equal(t, []string{safeConcatLongName}, res)
+}
+
+func Test_grbSafeConcatIndexer(t *testing.T) {
+	t.Parallel()
+	grb := &v3.GlobalRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "grb1",
+		},
+	}
+	res, resErr := grbSafeConcatIndexer(grb)
+	require.NoError(t, resErr)
+	require.Equal(t, []string{"grb1"}, res)
+
+	// Make sure it returns the concatenated name
+	grb.SetName(longName)
+	res, resErr = grbSafeConcatIndexer(grb)
+	require.NoError(t, resErr)
+	require.Equal(t, []string{safeConcatLongName}, res)
+}
 
 func Test_enqueueGRBs(t *testing.T) {
 	t.Parallel()
@@ -485,6 +566,339 @@ func Test_crtbEnqueueGRB(t *testing.T) {
 				grbCache: grbCache,
 			}
 			res, resErr := enqueuer.crtbEnqueueGRB("", "", test.inputObject)
+			require.Len(t, res, len(test.wantKeys))
+			for _, key := range test.wantKeys {
+				require.Contains(t, res, key)
+			}
+			if test.wantError {
+				require.Error(t, resErr)
+			} else {
+				require.NoError(t, resErr)
+			}
+		})
+	}
+}
+
+func Test_roleEnqueueGR(t *testing.T) {
+	t.Parallel()
+	type testState struct {
+		grCacheMock *fake.MockNonNamespacedCacheInterface[*v3.GlobalRole]
+	}
+	tests := []struct {
+		name        string
+		stateSetup  func(state testState)
+		inputObject runtime.Object
+		wantKeys    []relatedresource.Key
+		wantError   bool
+	}{
+		{
+			name:        "object is nil",
+			inputObject: nil,
+			wantError:   false,
+		},
+		{
+			name:        "object is not a role",
+			inputObject: &v3.GlobalRole{},
+			wantError:   false,
+		},
+		{
+			name: "role does not have owning GR",
+			inputObject: &v1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-role",
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "GR get fails",
+			inputObject: &v1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-role",
+					Labels: map[string]string{grOwnerLabel: "test-GR"},
+				},
+			},
+			stateSetup: func(state testState) {
+				state.grCacheMock.EXPECT().GetByIndex(grSafeConcatIndex, "test-GR").Return(nil, fmt.Errorf("error"))
+			},
+			wantError: true,
+		},
+		{
+			name: "GR gets enqueued",
+			inputObject: &v1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-role",
+					Labels: map[string]string{grOwnerLabel: "test-GR"},
+				},
+			},
+			stateSetup: func(state testState) {
+				gr := &v3.GlobalRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-GR",
+					},
+				}
+				state.grCacheMock.EXPECT().GetByIndex(grSafeConcatIndex, "test-GR").Return([]*v3.GlobalRole{gr}, nil)
+			},
+			wantKeys:  []relatedresource.Key{{Name: "test-GR"}},
+			wantError: false,
+		},
+		{
+			name: "GR with long name gets enqueued",
+			inputObject: &v1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-role",
+					Labels: map[string]string{grOwnerLabel: safeConcatLongName},
+				},
+			},
+			stateSetup: func(state testState) {
+				gr := &v3.GlobalRole{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: longName,
+					},
+				}
+				state.grCacheMock.EXPECT().GetByIndex(grSafeConcatIndex, safeConcatLongName).Return([]*v3.GlobalRole{gr}, nil)
+			},
+			wantKeys:  []relatedresource.Key{{Name: longName}},
+			wantError: false,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			grCache := fake.NewMockNonNamespacedCacheInterface[*v3.GlobalRole](ctrl)
+			state := testState{
+				grCacheMock: grCache,
+			}
+			if test.stateSetup != nil {
+				test.stateSetup(state)
+			}
+			enqueuer := globalRBACEnqueuer{
+				grCache: grCache,
+			}
+			res, resErr := enqueuer.roleEnqueueGR("", "", test.inputObject)
+			require.Len(t, res, len(test.wantKeys))
+			for _, key := range test.wantKeys {
+				require.Contains(t, res, key)
+			}
+			if test.wantError {
+				require.Error(t, resErr)
+			} else {
+				require.NoError(t, resErr)
+			}
+		})
+	}
+}
+
+func Test_roleBindingEnqueueGRB(t *testing.T) {
+	t.Parallel()
+	type testState struct {
+		grbCacheMock *fake.MockNonNamespacedCacheInterface[*v3.GlobalRoleBinding]
+	}
+	tests := []struct {
+		name        string
+		stateSetup  func(state testState)
+		inputObject runtime.Object
+		wantKeys    []relatedresource.Key
+		wantError   bool
+	}{
+		{
+			name:        "object is nil",
+			inputObject: nil,
+			wantError:   false,
+		},
+		{
+			name:        "object is not a roleBinding",
+			inputObject: &v3.GlobalRole{},
+			wantError:   false,
+		},
+		{
+			name: "roleBinding does not have owning GR",
+			inputObject: &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-roleBinding",
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "GRB get fails",
+			inputObject: &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-roleBinding",
+					Labels: map[string]string{grbOwnerLabel: "test-GRB"},
+				},
+			},
+			stateSetup: func(state testState) {
+				state.grbCacheMock.EXPECT().GetByIndex(grbSafeConcatIndex, "test-GRB").Return(nil, fmt.Errorf("error"))
+			},
+			wantError: true,
+		},
+		{
+			name: "GRB gets enqueued",
+			inputObject: &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-roleBinding",
+					Labels: map[string]string{grbOwnerLabel: "test-GRB"},
+				},
+			},
+			stateSetup: func(state testState) {
+				grb := &v3.GlobalRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-GRB",
+					},
+				}
+				state.grbCacheMock.EXPECT().GetByIndex(grbSafeConcatIndex, "test-GRB").Return([]*v3.GlobalRoleBinding{grb}, nil)
+			},
+			wantKeys:  []relatedresource.Key{{Name: "test-GRB"}},
+			wantError: false,
+		},
+		{
+			name: "GRB with long name gets enqueued",
+			inputObject: &v1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-roleBinding",
+					Labels: map[string]string{grbOwnerLabel: safeConcatLongName},
+				},
+			},
+			stateSetup: func(state testState) {
+				grb := &v3.GlobalRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: longName,
+					},
+				}
+				state.grbCacheMock.EXPECT().GetByIndex(grbSafeConcatIndex, safeConcatLongName).Return([]*v3.GlobalRoleBinding{grb}, nil)
+			},
+			wantKeys:  []relatedresource.Key{{Name: longName}},
+			wantError: false,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			grbCache := fake.NewMockNonNamespacedCacheInterface[*v3.GlobalRoleBinding](ctrl)
+			state := testState{
+				grbCacheMock: grbCache,
+			}
+			if test.stateSetup != nil {
+				test.stateSetup(state)
+			}
+			enqueuer := globalRBACEnqueuer{
+				grbCache: grbCache,
+			}
+			res, resErr := enqueuer.roleBindingEnqueueGRB("", "", test.inputObject)
+			require.Len(t, res, len(test.wantKeys))
+			for _, key := range test.wantKeys {
+				require.Contains(t, res, key)
+			}
+			if test.wantError {
+				require.Error(t, resErr)
+			} else {
+				require.NoError(t, resErr)
+			}
+		})
+	}
+}
+
+func Test_namespaceEnqueueGR(t *testing.T) {
+	t.Parallel()
+	type testState struct {
+		grCacheMock *fake.MockNonNamespacedCacheInterface[*v3.GlobalRole]
+	}
+	tests := []struct {
+		name        string
+		stateSetup  func(state testState)
+		inputObject runtime.Object
+		wantKeys    []relatedresource.Key
+		wantError   bool
+	}{
+		{
+			name:        "object is nil",
+			inputObject: nil,
+			wantError:   false,
+		},
+		{
+			name:        "object is not a namespace",
+			inputObject: &v3.GlobalRole{},
+			wantError:   false,
+		},
+		{
+			name: "namespace not in a NamespacedRule",
+			inputObject: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns1",
+				},
+			},
+			stateSetup: func(state testState) {
+				state.grCacheMock.EXPECT().GetByIndex(grNsIndex, "ns1").Return([]*v3.GlobalRole{}, nil)
+			},
+			wantError: false,
+		},
+		{
+			name: "get namespace fails",
+			inputObject: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns1",
+				},
+			},
+			stateSetup: func(state testState) {
+				state.grCacheMock.EXPECT().GetByIndex(grNsIndex, "ns1").Return(nil, fmt.Errorf("error"))
+			},
+			wantError: true,
+		},
+		{
+			name: "multiple grs are returned",
+			inputObject: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns1",
+				},
+			},
+			stateSetup: func(state testState) {
+				grs := []*v3.GlobalRole{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gr1",
+						},
+						NamespacedRules: map[string][]v1.PolicyRule{
+							"ns1": nil,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gr2",
+						},
+						NamespacedRules: map[string][]v1.PolicyRule{
+							"ns1": nil,
+						},
+					},
+				}
+				state.grCacheMock.EXPECT().GetByIndex(grNsIndex, "ns1").Return(grs, nil)
+			},
+			wantKeys: []relatedresource.Key{
+				{Name: "gr1"},
+				{Name: "gr2"},
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			grCache := fake.NewMockNonNamespacedCacheInterface[*v3.GlobalRole](ctrl)
+			state := testState{
+				grCacheMock: grCache,
+			}
+			if test.stateSetup != nil {
+				test.stateSetup(state)
+			}
+			enqueuer := globalRBACEnqueuer{
+				grCache: grCache,
+			}
+			res, resErr := enqueuer.namespaceEnqueueGR("", "", test.inputObject)
 			require.Len(t, res, len(test.wantKeys))
 			for _, key := range test.wantKeys {
 				require.Contains(t, res, key)

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
@@ -1,0 +1,870 @@
+package globalroles
+
+import (
+	"fmt"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/golang/mock/gomock"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	normanv1 "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1"
+	rbacFakes "github.com/rancher/rancher/pkg/generated/norman/rbac.authorization.k8s.io/v1/fakes"
+	"github.com/rancher/wrangler/pkg/generic/fake"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	readPodPolicyRule = rbacv1.PolicyRule{
+		Verbs:     []string{"get", "list", "watch"},
+		APIGroups: []string{""},
+		Resources: []string{"pods"},
+	}
+
+	readConfigPolicyRule = rbacv1.PolicyRule{
+		Verbs:     []string{"get", "list", "watch"},
+		APIGroups: []string{""},
+		Resources: []string{"configmaps"},
+	}
+	adminPodPolicyRule = rbacv1.PolicyRule{
+		Verbs:     []string{"*"},
+		APIGroups: []string{""},
+		Resources: []string{"pod"},
+	}
+
+	namespacedRulesGR = v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "namespacedRulesGR",
+			UID:  "00000000",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "fake-kind",
+			APIVersion: "fake-version",
+		},
+		NamespacedRules: map[string][]rbacv1.PolicyRule{
+			"namespace1": {
+				readPodPolicyRule,
+				readConfigPolicyRule,
+			},
+			"namespace2": {
+				adminPodPolicyRule,
+				readPodPolicyRule,
+			},
+		},
+	}
+	namespacedRulesOwnerRef = metav1.OwnerReference{
+		APIVersion: namespacedRulesGR.APIVersion,
+		Kind:       namespacedRulesGR.Kind,
+		Name:       namespacedRulesGR.Name,
+		UID:        namespacedRulesGR.UID,
+	}
+
+	updatedNamespacedRulesGR = v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "namespacedRulesGR",
+		},
+		NamespacedRules: map[string][]rbacv1.PolicyRule{
+			"namespace1": {
+				readPodPolicyRule,
+			},
+			"namespace2": {
+				adminPodPolicyRule,
+				readPodPolicyRule,
+				readConfigPolicyRule,
+			},
+		},
+	}
+)
+
+type grTestStateChanges struct {
+	t            *testing.T
+	createdRoles map[string]*rbacv1.Role
+	deletedRoles map[string]struct{}
+}
+type grTestState struct {
+	nsCacheMock  *fake.MockNonNamespacedCacheInterface[*corev1.Namespace]
+	rListerMock  *rbacFakes.RoleListerMock
+	rClientMock  *rbacFakes.RoleInterfaceMock
+	counter      int
+	stateChanges *grTestStateChanges
+}
+
+func TestReconcileNamespacedRoles(t *testing.T) {
+	t.Parallel()
+
+	activeNamespace := &corev1.Namespace{
+		Status: corev1.NamespaceStatus{
+			Phase: corev1.NamespaceActive,
+		},
+	}
+	terminatingNamespace := &corev1.Namespace{
+		Status: corev1.NamespaceStatus{
+			Phase: corev1.NamespaceTerminating,
+		},
+	}
+
+	tests := []struct {
+		name            string
+		stateSetup      func(grTestState)
+		stateAssertions func(grTestStateChanges)
+		globalRole      *v3.GlobalRole
+		wantError       bool
+	}{
+		{
+			name: "getting namespace fails",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, nil
+				}
+
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, fmt.Errorf("error"))
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  true,
+		},
+		{
+			name: "namespace is not found",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, nil
+				}
+
+				nsNotFound := apierrors.NewNotFound(schema.GroupResource{
+					Group:    normanv1.RoleGroupVersionKind.Group,
+					Resource: normanv1.RoleGroupVersionResource.Resource,
+				}, "")
+
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nsNotFound)
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  false,
+		},
+		{
+			name: "namespace is nil",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(nil, nil)
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  false,
+		},
+		{
+			name: "getting role fails",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nil)
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					return nil, fmt.Errorf("error")
+				}
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  true,
+		},
+		{
+			name: "creating role fails",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nil)
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					return nil, apierrors.NewNotFound(schema.GroupResource{
+						Group:    normanv1.RoleGroupVersionKind.Group,
+						Resource: normanv1.RoleGroupVersionResource.Resource,
+					}, "")
+				}
+				state.rClientMock.CreateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					return nil, fmt.Errorf("error")
+				}
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  true,
+		},
+		{
+			name: "created role already exists but get continuously fails",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nil)
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					return nil, apierrors.NewNotFound(schema.GroupResource{
+						Group:    normanv1.RoleGroupVersionKind.Group,
+						Resource: normanv1.RoleGroupVersionResource.Resource,
+					}, "")
+				}
+				state.rClientMock.CreateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					return nil, apierrors.NewAlreadyExists(schema.GroupResource{
+						Group:    normanv1.RoleGroupVersionKind.Group,
+						Resource: normanv1.RoleGroupVersionResource.Resource,
+					}, "")
+				}
+				state.rClientMock.UpdateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.createdRoles[role.Name] = role
+					role.UID = ""
+					return role, nil
+				}
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  true,
+		},
+		{
+			// It's possible that a user can create the invalid role in the middle of the reconcile
+			// In that case, the first attempt to get the role fails. Then the reconcile function attempts to
+			// create the role and finds that it already exists. It gets the new role and checks that it is valid
+			name: "role gets created incorrectly mid reconcile",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nil)
+				state.rListerMock.GetFunc = func(namespace, _ string) (*rbacv1.Role, error) {
+					// counter == 0 means that the create hasn't happened and should fail
+					// counter == 1 means that the create has occurred and should return an incorrect role
+					if state.counter == 0 {
+						return nil, apierrors.NewNotFound(schema.GroupResource{
+							Group:    normanv1.RoleGroupVersionKind.Group,
+							Resource: normanv1.RoleGroupVersionResource.Resource,
+						}, "")
+					} else {
+						state.counter = 0
+						role := &rbacv1.Role{}
+						if namespace == "namespace1" {
+							role.ObjectMeta = metav1.ObjectMeta{
+								Name:      "namespacedRulesGR-namespace1",
+								Namespace: "namespace1",
+							}
+							role.Rules = []rbacv1.PolicyRule{
+								readPodPolicyRule,
+								readConfigPolicyRule,
+							}
+						} else if namespace == "namespace2" {
+							role.ObjectMeta = metav1.ObjectMeta{
+								Name:      "namespacedRulesGR-namespace2",
+								Namespace: "namespace2",
+								Labels:    map[string]string{grOwnerLabel: "badGR"},
+							}
+							role.Rules = []rbacv1.PolicyRule{
+								adminPodPolicyRule,
+								readPodPolicyRule,
+							}
+						}
+						return role, nil
+					}
+				}
+				state.rClientMock.CreateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.counter = 1
+					return nil, apierrors.NewAlreadyExists(schema.GroupResource{
+						Group:    normanv1.RoleGroupVersionKind.Group,
+						Resource: normanv1.RoleGroupVersionResource.Resource,
+					}, "")
+				}
+				state.rClientMock.UpdateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.createdRoles[role.Name] = role
+					role.UID = ""
+					return role, nil
+				}
+			},
+			stateAssertions: func(gtsc grTestStateChanges) {
+				require.Len(gtsc.t, gtsc.createdRoles, 2)
+
+				role, ok := gtsc.createdRoles["namespacedRulesGR-namespace1"]
+				require.True(gtsc.t, ok)
+				require.Equal(gtsc.t, "namespace1", role.Namespace)
+				require.Equal(gtsc.t, "namespacedRulesGR", role.Labels[grOwnerLabel])
+				require.Len(gtsc.t, role.Rules, 2)
+				require.Equal(gtsc.t, readPodPolicyRule, role.Rules[0])
+				require.Equal(gtsc.t, readConfigPolicyRule, role.Rules[1])
+
+				role, ok = gtsc.createdRoles["namespacedRulesGR-namespace2"]
+				require.True(gtsc.t, ok)
+				require.Equal(gtsc.t, "namespace2", role.Namespace)
+				require.Equal(gtsc.t, "namespacedRulesGR", role.Labels[grOwnerLabel])
+				require.Len(gtsc.t, role.Rules, 2)
+				require.Equal(gtsc.t, adminPodPolicyRule, role.Rules[0])
+				require.Equal(gtsc.t, readPodPolicyRule, role.Rules[1])
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  false,
+		},
+		{
+			name: "create roles successfully",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nil)
+				state.rListerMock.GetFunc = func(namespace string, name string) (*rbacv1.Role, error) {
+					return nil, apierrors.NewNotFound(schema.GroupResource{
+						Group:    normanv1.RoleGroupVersionKind.Group,
+						Resource: normanv1.RoleGroupVersionResource.Resource,
+					}, "")
+				}
+				state.rClientMock.CreateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.createdRoles[role.Name] = role
+					role.UID = ""
+					return role, nil
+				}
+			},
+			stateAssertions: func(gtsc grTestStateChanges) {
+				require.Len(gtsc.t, gtsc.createdRoles, 2)
+
+				role, ok := gtsc.createdRoles["namespacedRulesGR-namespace1"]
+				require.True(gtsc.t, ok)
+				require.Equal(gtsc.t, "namespace1", role.Namespace)
+				require.Equal(gtsc.t, "namespacedRulesGR", role.Labels[grOwnerLabel])
+				require.Len(gtsc.t, role.Rules, 2)
+				require.Equal(gtsc.t, readPodPolicyRule, role.Rules[0])
+				require.Equal(gtsc.t, readConfigPolicyRule, role.Rules[1])
+				require.Equal(gtsc.t, namespacedRulesOwnerRef, role.OwnerReferences[0])
+
+				role, ok = gtsc.createdRoles["namespacedRulesGR-namespace2"]
+				require.True(gtsc.t, ok)
+				require.Equal(gtsc.t, "namespace2", role.Namespace)
+				require.Equal(gtsc.t, "namespacedRulesGR", role.Labels[grOwnerLabel])
+				require.Len(gtsc.t, role.Rules, 2)
+				require.Equal(gtsc.t, adminPodPolicyRule, role.Rules[0])
+				require.Equal(gtsc.t, readPodPolicyRule, role.Rules[1])
+				require.Equal(gtsc.t, namespacedRulesOwnerRef, role.OwnerReferences[0])
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  false,
+		},
+		{
+			name: "create role in terminating namespace",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(terminatingNamespace, nil)
+
+				state.rListerMock.GetFunc = func(namespace string, name string) (*rbacv1.Role, error) {
+					return nil, apierrors.NewNotFound(schema.GroupResource{
+						Group:    normanv1.RoleGroupVersionKind.Group,
+						Resource: normanv1.RoleGroupVersionResource.Resource,
+					}, "")
+				}
+				state.rClientMock.CreateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.createdRoles[role.Name] = role
+					role.UID = ""
+					return role, nil
+				}
+			},
+			stateAssertions: func(gtsc grTestStateChanges) {
+				require.Len(gtsc.t, gtsc.createdRoles, 0)
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  false,
+		},
+		{
+			name: "some roles have errors but rest get created",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, nil
+				}
+				first := state.nsCacheMock.EXPECT().Get(gomock.Any()).Return(activeNamespace, fmt.Errorf("error"))
+				second := state.nsCacheMock.EXPECT().Get(gomock.Any()).Return(activeNamespace, nil)
+				gomock.InOrder(first, second)
+
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					return nil, apierrors.NewNotFound(schema.GroupResource{
+						Group:    normanv1.RoleGroupVersionKind.Group,
+						Resource: normanv1.RoleGroupVersionResource.Resource,
+					}, "")
+				}
+				state.rClientMock.CreateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.createdRoles[role.Name] = role
+					role.UID = ""
+					return role, nil
+				}
+			},
+			stateAssertions: func(gtsc grTestStateChanges) {
+				// The second role should be created despite the first getting an error
+				// Because the order is not guaranteed, we can't assert any info on the
+				// created role, just that it exists
+				require.Len(gtsc.t, gtsc.createdRoles, 1)
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  true,
+		},
+		{
+			name: "update an existing role with rule and label changes",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nil)
+
+				state.rListerMock.GetFunc = func(namespace string, _ string) (*rbacv1.Role, error) {
+					role := &rbacv1.Role{}
+					if namespace == "namespace1" {
+						role.ObjectMeta = metav1.ObjectMeta{
+							Name:      "namespacedRulesGR-namespace1",
+							Namespace: "namespace1",
+						}
+						role.Rules = []rbacv1.PolicyRule{
+							readPodPolicyRule,
+							readConfigPolicyRule,
+						}
+					} else if namespace == "namespace2" {
+						role.ObjectMeta = metav1.ObjectMeta{
+							Name:      "namespacedRulesGR-namespace2",
+							Namespace: "namespace2",
+							Labels:    map[string]string{grOwnerLabel: "badGR"},
+						}
+						role.Rules = []rbacv1.PolicyRule{
+							adminPodPolicyRule,
+							readPodPolicyRule,
+						}
+					}
+
+					return role, nil
+				}
+				state.rClientMock.UpdateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.createdRoles[role.Name] = role
+					role.UID = ""
+					return role, nil
+				}
+			},
+			stateAssertions: func(gtsc grTestStateChanges) {
+				require.Len(gtsc.t, gtsc.createdRoles, 2)
+
+				role, ok := gtsc.createdRoles["namespacedRulesGR-namespace1"]
+				require.True(gtsc.t, ok)
+				require.Equal(gtsc.t, "namespace1", role.Namespace)
+				require.Len(gtsc.t, role.Rules, 1)
+				require.Equal(gtsc.t, readPodPolicyRule, role.Rules[0])
+				require.Equal(gtsc.t, "namespacedRulesGR", role.Labels[grOwnerLabel])
+
+				role, ok = gtsc.createdRoles["namespacedRulesGR-namespace2"]
+				require.True(gtsc.t, ok)
+				require.Equal(gtsc.t, "namespace2", role.Namespace)
+				require.Len(gtsc.t, role.Rules, 3)
+				require.Equal(gtsc.t, adminPodPolicyRule, role.Rules[0])
+				require.Equal(gtsc.t, readPodPolicyRule, role.Rules[1])
+				require.Equal(gtsc.t, readConfigPolicyRule, role.Rules[2])
+				require.Equal(gtsc.t, "namespacedRulesGR", role.Labels[grOwnerLabel])
+			},
+			globalRole: updatedNamespacedRulesGR.DeepCopy(),
+			wantError:  false,
+		},
+		{
+			name: "update an existing role no changes",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nil)
+
+				state.rListerMock.GetFunc = func(namespace string, _ string) (*rbacv1.Role, error) {
+					role := &rbacv1.Role{}
+					if namespace == "namespace1" {
+						role.ObjectMeta = metav1.ObjectMeta{
+							Name:      "namespacedRulesGR-namespace1",
+							Namespace: "namespace1",
+							Labels: map[string]string{
+								grOwnerLabel: "namespacedRulesGR",
+							},
+						}
+						role.Rules = []rbacv1.PolicyRule{
+							readPodPolicyRule,
+							readConfigPolicyRule,
+						}
+					} else if namespace == "namespace2" {
+						role.ObjectMeta = metav1.ObjectMeta{
+							Name:      "namespacedRulesGR-namespace2",
+							Namespace: "namespace2",
+							Labels: map[string]string{
+								grOwnerLabel: "namespacedRulesGR",
+							},
+						}
+						role.Rules = []rbacv1.PolicyRule{
+							adminPodPolicyRule,
+							readPodPolicyRule,
+						}
+					}
+
+					return role, nil
+				}
+				state.rClientMock.UpdateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.createdRoles[role.Name] = role
+					return nil, nil
+				}
+			},
+			stateAssertions: func(gtsc grTestStateChanges) {
+				require.Len(gtsc.t, gtsc.createdRoles, 0)
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  false,
+		},
+		{
+			name: "update role fails",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nil)
+
+				state.rListerMock.GetFunc = func(namespace string, _ string) (*rbacv1.Role, error) {
+					role := &rbacv1.Role{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "namespacedRulesGR-namespace1",
+							Namespace: "namespace1",
+						},
+						Rules: []rbacv1.PolicyRule{},
+					}
+
+					return role, nil
+				}
+				state.rClientMock.UpdateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					return nil, fmt.Errorf("error")
+				}
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  true,
+		},
+		{
+			name: "remove roles that falsely claim to be owned by GR after create",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					roles := []*rbacv1.Role{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "deleted-role-1",
+								UID:  "2222",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "kept-role-1",
+								UID:  "1111",
+							},
+						},
+					}
+
+					return roles, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nil)
+
+				state.rListerMock.GetFunc = func(namespace string, _ string) (*rbacv1.Role, error) {
+					return nil, apierrors.NewNotFound(schema.GroupResource{
+						Group:    normanv1.RoleGroupVersionKind.Group,
+						Resource: normanv1.RoleGroupVersionResource.Resource,
+					}, "")
+				}
+				state.rClientMock.CreateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.createdRoles[role.Name] = role
+					role.UID = "1111"
+					return role, nil
+				}
+				state.rClientMock.DeleteNamespacedFunc = func(_, name string, _ *metav1.DeleteOptions) error {
+					state.stateChanges.deletedRoles[name] = struct{}{}
+					return nil
+				}
+			},
+			stateAssertions: func(gtsc grTestStateChanges) {
+				require.Len(gtsc.t, gtsc.createdRoles, 2)
+
+				role, ok := gtsc.createdRoles["namespacedRulesGR-namespace1"]
+				require.True(gtsc.t, ok)
+				require.Equal(gtsc.t, "namespace1", role.Namespace)
+				require.Equal(gtsc.t, "namespacedRulesGR", role.Labels[grOwnerLabel])
+				require.Len(gtsc.t, role.Rules, 2)
+				require.Equal(gtsc.t, readPodPolicyRule, role.Rules[0])
+				require.Equal(gtsc.t, readConfigPolicyRule, role.Rules[1])
+				require.Equal(gtsc.t, namespacedRulesOwnerRef, role.OwnerReferences[0])
+
+				role, ok = gtsc.createdRoles["namespacedRulesGR-namespace2"]
+				require.True(gtsc.t, ok)
+				require.Equal(gtsc.t, "namespace2", role.Namespace)
+				require.Equal(gtsc.t, "namespacedRulesGR", role.Labels[grOwnerLabel])
+				require.Len(gtsc.t, role.Rules, 2)
+				require.Equal(gtsc.t, adminPodPolicyRule, role.Rules[0])
+				require.Equal(gtsc.t, readPodPolicyRule, role.Rules[1])
+				require.Equal(gtsc.t, namespacedRulesOwnerRef, role.OwnerReferences[0])
+
+				require.Contains(gtsc.t, gtsc.deletedRoles, "deleted-role-1")
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  false,
+		},
+		{
+			name: "remove invalid role despite terminating namespace",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					roles := []*rbacv1.Role{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "deleted-role-1",
+								UID:  "1111",
+							},
+						},
+					}
+
+					return roles, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(terminatingNamespace, nil)
+
+				state.rListerMock.GetFunc = func(namespace string, _ string) (*rbacv1.Role, error) {
+					return nil, apierrors.NewNotFound(schema.GroupResource{
+						Group:    normanv1.RoleGroupVersionKind.Group,
+						Resource: normanv1.RoleGroupVersionResource.Resource,
+					}, "")
+				}
+				state.rClientMock.DeleteNamespacedFunc = func(_, name string, _ *metav1.DeleteOptions) error {
+					state.stateChanges.deletedRoles[name] = struct{}{}
+					return nil
+				}
+			},
+			stateAssertions: func(gtsc grTestStateChanges) {
+				require.Len(gtsc.t, gtsc.deletedRoles, 1)
+				require.Contains(gtsc.t, gtsc.deletedRoles, "deleted-role-1")
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  false,
+		},
+		{
+			name: "delete Role fails",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					roles := []*rbacv1.Role{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "deleted-role-1",
+								UID:  "2222",
+							},
+						},
+					}
+
+					return roles, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nil)
+
+				state.rListerMock.GetFunc = func(namespace string, _ string) (*rbacv1.Role, error) {
+					return nil, nil
+				}
+				state.rClientMock.DeleteNamespacedFunc = func(_, name string, _ *metav1.DeleteOptions) error {
+					return fmt.Errorf("error")
+				}
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  true,
+		},
+		{
+			name: "remove roles that falsely claim to be owned by GR after update",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					roles := []*rbacv1.Role{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "kept-role-1",
+								UID:  "1111",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "kept-role-2",
+								UID:  "2222",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "deleted-role-1",
+								UID:  "3333",
+							},
+						},
+					}
+
+					return roles, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nil)
+
+				state.rListerMock.GetFunc = func(namespace string, _ string) (*rbacv1.Role, error) {
+					role := &rbacv1.Role{}
+					if namespace == "namespace1" {
+						role.ObjectMeta = metav1.ObjectMeta{
+							Name:      "namespacedRulesGR-namespace1",
+							Namespace: "namespace1",
+						}
+						role.Rules = []rbacv1.PolicyRule{
+							readPodPolicyRule,
+							readConfigPolicyRule,
+						}
+						role.UID = "1111"
+					} else if namespace == "namespace2" {
+						role.ObjectMeta = metav1.ObjectMeta{
+							Name:      "namespacedRulesGR-namespace2",
+							Namespace: "namespace2",
+							Labels:    map[string]string{grOwnerLabel: "badGR"},
+						}
+						role.Rules = []rbacv1.PolicyRule{
+							adminPodPolicyRule,
+							readPodPolicyRule,
+						}
+						role.UID = "2222"
+					}
+
+					return role, nil
+				}
+				state.rClientMock.UpdateFunc = func(role *rbacv1.Role) (*rbacv1.Role, error) {
+					state.stateChanges.createdRoles[role.Name] = role
+					return role, nil
+				}
+				state.rClientMock.DeleteNamespacedFunc = func(_, name string, _ *metav1.DeleteOptions) error {
+					state.stateChanges.deletedRoles[name] = struct{}{}
+					return nil
+				}
+			},
+			stateAssertions: func(gtsc grTestStateChanges) {
+				require.Len(gtsc.t, gtsc.createdRoles, 2)
+
+				role, ok := gtsc.createdRoles["namespacedRulesGR-namespace1"]
+				require.True(gtsc.t, ok)
+				require.Equal(gtsc.t, "namespace1", role.Namespace)
+				require.Len(gtsc.t, role.Rules, 1)
+				require.Equal(gtsc.t, readPodPolicyRule, role.Rules[0])
+				require.Equal(gtsc.t, "namespacedRulesGR", role.Labels[grOwnerLabel])
+
+				role, ok = gtsc.createdRoles["namespacedRulesGR-namespace2"]
+				require.True(gtsc.t, ok)
+				require.Equal(gtsc.t, "namespace2", role.Namespace)
+				require.Len(gtsc.t, role.Rules, 3)
+				require.Equal(gtsc.t, adminPodPolicyRule, role.Rules[0])
+				require.Equal(gtsc.t, readPodPolicyRule, role.Rules[1])
+				require.Equal(gtsc.t, readConfigPolicyRule, role.Rules[2])
+				require.Equal(gtsc.t, "namespacedRulesGR", role.Labels[grOwnerLabel])
+
+				require.Contains(gtsc.t, gtsc.deletedRoles, "deleted-role-1")
+			},
+			globalRole: updatedNamespacedRulesGR.DeepCopy(),
+			wantError:  false,
+		},
+		{
+			name: "listing existing roles fails",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					return nil, fmt.Errorf("error")
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nil)
+
+				state.rListerMock.GetFunc = func(_, _ string) (*rbacv1.Role, error) {
+					return nil, nil
+				}
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  true,
+		},
+		{
+			name: "roles that should exist with no changes don't get deleted",
+			stateSetup: func(state grTestState) {
+				state.rListerMock.ListFunc = func(_ string, _ labels.Selector) ([]*rbacv1.Role, error) {
+					roles := []*rbacv1.Role{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "kept-role-1",
+								UID:  "1111",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "kept-role-2",
+								UID:  "2222",
+							},
+						},
+					}
+
+					return roles, nil
+				}
+				state.nsCacheMock.EXPECT().Get(gomock.Any()).AnyTimes().Return(activeNamespace, nil)
+
+				state.rListerMock.GetFunc = func(namespace string, _ string) (*rbacv1.Role, error) {
+					role := &rbacv1.Role{}
+					if namespace == "namespace1" {
+						role.ObjectMeta = metav1.ObjectMeta{
+							Name:      "namespacedRulesGR-namespace1",
+							Namespace: "namespace1",
+							Labels:    map[string]string{grOwnerLabel: "namespacedRulesGR"},
+						}
+						role.Rules = []rbacv1.PolicyRule{
+							readPodPolicyRule,
+							readConfigPolicyRule,
+						}
+						role.UID = "1111"
+					} else if namespace == "namespace2" {
+						role.ObjectMeta = metav1.ObjectMeta{
+							Name:      "namespacedRulesGR-namespace2",
+							Namespace: "namespace2",
+							Labels:    map[string]string{grOwnerLabel: "namespacedRulesGR"},
+						}
+						role.Rules = []rbacv1.PolicyRule{
+							adminPodPolicyRule,
+							readPodPolicyRule,
+						}
+						role.UID = "2222"
+					}
+
+					return role, nil
+				}
+				state.rClientMock.DeleteNamespacedFunc = func(_, name string, _ *metav1.DeleteOptions) error {
+					state.stateChanges.deletedRoles[name] = struct{}{}
+					return nil
+				}
+			},
+			stateAssertions: func(gtsc grTestStateChanges) {
+				require.Len(gtsc.t, gtsc.deletedRoles, 0)
+			},
+			globalRole: namespacedRulesGR.DeepCopy(),
+			wantError:  false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			grLifecycle := globalRoleLifecycle{}
+
+			ctrl := gomock.NewController(t)
+			nsCacheMock := fake.NewMockNonNamespacedCacheInterface[*corev1.Namespace](ctrl)
+			rListerMock := rbacFakes.RoleListerMock{}
+			rClientMock := rbacFakes.RoleInterfaceMock{}
+
+			stateChanges := grTestStateChanges{
+				t:            t,
+				createdRoles: map[string]*rbacv1.Role{},
+				deletedRoles: map[string]struct{}{},
+			}
+			state := grTestState{
+				nsCacheMock:  nsCacheMock,
+				rListerMock:  &rListerMock,
+				rClientMock:  &rClientMock,
+				stateChanges: &stateChanges,
+			}
+			if test.stateSetup != nil {
+				test.stateSetup(state)
+			}
+
+			grLifecycle.nsCache = nsCacheMock
+			grLifecycle.rLister = &rListerMock
+			grLifecycle.rClient = &rClientMock
+			err := grLifecycle.reconcileNamespacedRoles(test.globalRole)
+			if test.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.stateAssertions != nil {
+				test.stateAssertions(*state.stateChanges)
+			}
+		})
+	}
+}

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -14,13 +14,17 @@ import (
 	"github.com/rancher/rancher/pkg/namespace"
 	"github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/types/config"
+	wcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	wrangler "github.com/rancher/wrangler/pkg/name"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var (
@@ -55,6 +59,7 @@ func newGlobalRoleBindingLifecycle(management *config.ManagementContext, cluster
 		crtbClient:        management.Management.ClusterRoleTemplateBindings(""),
 		crtbCache:         management.Wrangler.Mgmt.ClusterRoleTemplateBinding().Cache(),
 		grLister:          management.Management.GlobalRoles("").Controller().Lister(),
+		nsCache:           management.Wrangler.Core.Namespace().Cache(),
 		roles:             management.RBAC.Roles(""),
 		roleLister:        management.RBAC.Roles("").Controller().Lister(),
 		roleBindings:      management.RBAC.RoleBindings(""),
@@ -84,6 +89,7 @@ type globalRoleBindingLifecycle struct {
 	crtbCache         mgmtcontroller.ClusterRoleTemplateBindingCache
 	crtbClient        v3.ClusterRoleTemplateBindingInterface
 	grLister          v3.GlobalRoleLister
+	nsCache           wcorev1.NamespaceCache
 	roles             rbacv1.RoleInterface
 	roleLister        rbacv1.RoleLister
 	roleBindings      rbacv1.RoleBindingInterface
@@ -96,8 +102,11 @@ func (grb *globalRoleBindingLifecycle) Create(obj *v3.GlobalRoleBinding) (runtim
 	if err != nil {
 		returnError = multierror.Append(returnError, err)
 	}
-
 	err = grb.reconcileGlobalRoleBinding(obj)
+	if err != nil {
+		returnError = multierror.Append(returnError, err)
+	}
+	err = grb.reconcileNamespacedRoleBindings(obj)
 	if err != nil {
 		returnError = multierror.Append(returnError, err)
 	}
@@ -114,6 +123,10 @@ func (grb *globalRoleBindingLifecycle) Updated(obj *v3.GlobalRoleBinding) (runti
 	if err != nil {
 		returnError = multierror.Append(returnError, err)
 	}
+	err = grb.reconcileNamespacedRoleBindings(obj)
+	if err != nil {
+		returnError = multierror.Append(returnError, err)
+	}
 	return obj, returnError
 }
 
@@ -121,7 +134,7 @@ func (grb *globalRoleBindingLifecycle) Remove(obj *v3.GlobalRoleBinding) (runtim
 	if obj.GlobalRoleName == rbac.GlobalAdmin || obj.GlobalRoleName == rbac.GlobalRestrictedAdmin {
 		return obj, grb.deleteAdminBinding(obj)
 	}
-	// Don't need to delete the created ClusterRole because owner reference will take care of that
+	// Don't need to delete the created ClusterRole or RoleBindings because owner reference will take care of them
 	return obj, nil
 }
 
@@ -583,6 +596,127 @@ func (grb *globalRoleBindingLifecycle) grantRestrictedAdminUserClusterPermission
 		}
 	}
 	return returnErr
+}
+
+// reconcileNamespacedRoleBindings ensures that RoleBindings exist for each namespace listed in NamespacedRules
+// from the associated GlobalRole
+func (grb *globalRoleBindingLifecycle) reconcileNamespacedRoleBindings(globalRoleBinding *v3.GlobalRoleBinding) error {
+	var returnError error
+	grbName := wrangler.SafeConcatName(globalRoleBinding.Name)
+	gr, err := grb.grLister.Get("", globalRoleBinding.GlobalRoleName)
+	if err != nil {
+		return fmt.Errorf("unable to get globalRole %s: %w", globalRoleBinding.GlobalRoleName, err)
+	}
+
+	roleBindingUIDs := map[types.UID]struct{}{}
+
+	for ns := range gr.NamespacedRules {
+		namespace, err := grb.nsCache.Get(ns)
+		if apierrors.IsNotFound(err) || namespace == nil {
+			// When a namespace is not found, don't re-enqueue GlobalRoleBinding
+			logrus.Warnf("[%v] Namespace %s not found. Not re-enqueueing GlobalRoleBinding %s", grController, ns, globalRoleBinding.Name)
+			continue
+		} else if err != nil {
+			returnError = multierror.Append(returnError, errors.Wrapf(err, "couldn't get namespace %s", ns))
+			continue
+		}
+
+		roleName := wrangler.SafeConcatName(gr.Name, ns)
+		roleRef := v1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     roleName,
+		}
+
+		subject := rbac.GetGRBSubject(globalRoleBinding)
+		rbName := wrangler.SafeConcatName(globalRoleBinding.Name, ns)
+		roleBinding, err := grb.roleBindingLister.Get(ns, rbName)
+		if err == nil {
+			if reflect.DeepEqual(roleRef, roleBinding.RoleRef) && roleBinding.Labels != nil && roleBinding.Labels[grbOwnerLabel] == grbName {
+				roleBindingUIDs[roleBinding.UID] = struct{}{}
+				continue
+			}
+			// Since roleRef is immutable, we have to delete and recreate the RB
+			err = grb.roleBindings.DeleteNamespaced(roleBinding.Namespace, roleBinding.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				returnError = multierror.Append(returnError, err)
+				continue
+			}
+		} else if !apierrors.IsNotFound(err) {
+			returnError = multierror.Append(returnError, err)
+			continue
+		}
+
+		// If the namespace is terminating, don't create RoleBinding
+		if namespace.Status.Phase == corev1.NamespaceTerminating {
+			logrus.Warnf("[%v] Namespace %s is terminating. Not creating roleBinding %s for %s", grController, ns, rbName, globalRoleBinding.Name)
+			continue
+		}
+
+		// Create a new RoleBinding
+		newRoleBinding := &v1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rbName,
+				Namespace: ns,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: globalRoleBinding.APIVersion,
+						Kind:       globalRoleBinding.Kind,
+						UID:        globalRoleBinding.UID,
+						Name:       globalRoleBinding.Name,
+					},
+				},
+				Labels: map[string]string{
+					grbOwnerLabel: grbName,
+				},
+			},
+			RoleRef:  roleRef,
+			Subjects: []v1.Subject{subject},
+		}
+
+		createdRB, err := grb.roleBindings.Create(newRoleBinding)
+		if err != nil {
+			returnError = multierror.Append(returnError, err)
+			continue
+		}
+		roleBindingUIDs[createdRB.UID] = struct{}{}
+	}
+
+	// get all the roleBindings claiming to be owned by this GRB and remove any that shouldn't exist
+	r, err := labels.NewRequirement(grbOwnerLabel, selection.Equals, []string{grbName})
+	if err != nil {
+		return multierror.Append(returnError, errors.Wrapf(err, "couldn't create label: %s", grOwnerLabel))
+	}
+
+	rbs, err := grb.roleBindingLister.List("", labels.NewSelector().Add(*r))
+	if err != nil {
+		return multierror.Append(returnError,
+			errors.Wrapf(err, "couldn't list roleBindings with label %s : %s", grbOwnerLabel, grbName))
+	}
+
+	// After creating/updating all RBs, if the number of RBs with the grbOwnerLabel is the same as
+	// as the number of created/updated RBs, we know there are no invalid RBs to purge
+	if len(rbs) != len(roleBindingUIDs) {
+		err = grb.purgeInvalidNamespacedRBs(rbs, roleBindingUIDs)
+		if err != nil {
+			returnError = multierror.Append(returnError, err)
+		}
+	}
+	return returnError
+}
+
+// purgeInvalidNamespacedRBs removes any roleBindings that aren't in the namespaces listed in the associated GlobalRole.namespacedRules
+func (grb *globalRoleBindingLifecycle) purgeInvalidNamespacedRBs(rbs []*v1.RoleBinding, uids map[types.UID]struct{}) error {
+	var returnError error
+	for _, rb := range rbs {
+		if _, ok := uids[rb.UID]; !ok {
+			err := grb.roleBindings.DeleteNamespaced(rb.Namespace, rb.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				returnError = multierror.Append(returnError, errors.Wrapf(err, "couldn't delete roleBinding %s", rb.Name))
+			}
+		}
+	}
+	return returnError
 }
 
 // isCRTBValid determines if a given CRTB is up to date for a given cluster and owning global role binding. Should

--- a/pkg/controllers/management/auth/globalroles/register.go
+++ b/pkg/controllers/management/auth/globalroles/register.go
@@ -15,6 +15,9 @@ const (
 
 func Register(ctx context.Context, management *config.ManagementContext, clusterManager *clustermanager.Manager) {
 	management.Wrangler.Mgmt.GlobalRoleBinding().Cache().AddIndexer(grbGrIndex, grbGrIndexer)
+	management.Wrangler.Mgmt.GlobalRoleBinding().Cache().AddIndexer(grbSafeConcatIndex, grbSafeConcatIndexer)
+	management.Wrangler.Mgmt.GlobalRole().Cache().AddIndexer(grNsIndex, grNsIndexer)
+	management.Wrangler.Mgmt.GlobalRole().Cache().AddIndexer(grSafeConcatIndex, grSafeConcatIndexer)
 	enqueuer := globalRBACEnqueuer{
 		grbCache:      management.Wrangler.Mgmt.GlobalRoleBinding().Cache(),
 		grCache:       management.Wrangler.Mgmt.GlobalRole().Cache(),
@@ -23,6 +26,10 @@ func Register(ctx context.Context, management *config.ManagementContext, cluster
 	relatedresource.WatchClusterScoped(ctx, grbEnqueuer, enqueuer.enqueueGRBs, management.Wrangler.Mgmt.GlobalRoleBinding(), management.Wrangler.Mgmt.GlobalRole())
 	relatedresource.WatchClusterScoped(ctx, clusterGrEnqueuer, enqueuer.clusterEnqueueGRs, management.Wrangler.Mgmt.GlobalRole(), management.Wrangler.Mgmt.Cluster())
 	relatedresource.WatchClusterScoped(ctx, crtbGRBEnqueuer, enqueuer.crtbEnqueueGRB, management.Wrangler.Mgmt.GlobalRoleBinding(), management.Wrangler.Mgmt.ClusterRoleTemplateBinding())
+
+	relatedresource.WatchClusterScoped(ctx, roleEnqueuer, enqueuer.roleEnqueueGR, management.Wrangler.Mgmt.GlobalRole(), management.Wrangler.RBAC.Role())
+	relatedresource.WatchClusterScoped(ctx, roleBindingEnqueuer, enqueuer.roleBindingEnqueueGRB, management.Wrangler.Mgmt.GlobalRoleBinding(), management.Wrangler.RBAC.RoleBinding())
+	relatedresource.WatchClusterScoped(ctx, namespaceGrEnqueuer, enqueuer.namespaceEnqueueGR, management.Wrangler.Mgmt.GlobalRole(), management.Wrangler.Core.Namespace())
 
 	gr := newGlobalRoleLifecycle(management.WithAgent(grController))
 	grb := newGlobalRoleBindingLifecycle(management.WithAgent(grbController), clusterManager)

--- a/pkg/crds/yaml/generated/management.cattle.io_globalroles.yaml
+++ b/pkg/crds/yaml/generated/management.cattle.io_globalroles.yaml
@@ -51,6 +51,61 @@ spec:
             type: string
           metadata:
             type: object
+          namespacedRules:
+            additionalProperties:
+              items:
+                description: PolicyRule holds information that describes a policy
+                  rule, but does not contain information about who the rule applies
+                  to or which namespace the rule applies to.
+                properties:
+                  apiGroups:
+                    description: APIGroups is the name of the APIGroup that contains
+                      the resources.  If multiple API groups are specified, any action
+                      requested against one of the enumerated resources in any API
+                      group will be allowed. "" represents the core API group and
+                      "*" represents all API groups.
+                    items:
+                      type: string
+                    type: array
+                  nonResourceURLs:
+                    description: NonResourceURLs is a set of partial urls that a user
+                      should have access to.  *s are allowed, but only as the full,
+                      final step in the path Since non-resource URLs are not namespaced,
+                      this field is only applicable for ClusterRoles referenced from
+                      a ClusterRoleBinding. Rules can either apply to API resources
+                      (such as "pods" or "secrets") or non-resource URL paths (such
+                      as "/api"),  but not both.
+                    items:
+                      type: string
+                    type: array
+                  resourceNames:
+                    description: ResourceNames is an optional white list of names
+                      that the rule applies to.  An empty set means that everything
+                      is allowed.
+                    items:
+                      type: string
+                    type: array
+                  resources:
+                    description: Resources is a list of resources this rule applies
+                      to. '*' represents all resources.
+                    items:
+                      type: string
+                    type: array
+                  verbs:
+                    description: Verbs is a list of Verbs that apply to ALL the ResourceKinds
+                      contained in this rule. '*' represents all verbs.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - verbs
+                type: object
+              type: array
+            description: NamespacedRules are the rules that are active in each namespace
+              of this GlobalRole. These are applied to the local cluster only. * has
+              no special meaning in the keys - these keys are read as raw strings
+              and must exactly match with one existing namespace.
+            type: object
           newUserDefault:
             description: NewUserDefault specifies that all new users created should
               be bound to this GlobalRole if true.

--- a/tests/framework/clients/rancher/generated/management/v3/zz_generated_global_role.go
+++ b/tests/framework/clients/rancher/generated/management/v3/zz_generated_global_role.go
@@ -14,6 +14,7 @@ const (
 	GlobalRoleFieldInheritedClusterRoles = "inheritedClusterRoles"
 	GlobalRoleFieldLabels                = "labels"
 	GlobalRoleFieldName                  = "name"
+	GlobalRoleFieldNamespacedRules       = "namespacedRules"
 	GlobalRoleFieldNewUserDefault        = "newUserDefault"
 	GlobalRoleFieldOwnerReferences       = "ownerReferences"
 	GlobalRoleFieldRemoved               = "removed"
@@ -23,19 +24,20 @@ const (
 
 type GlobalRole struct {
 	types.Resource
-	Annotations           map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Builtin               bool              `json:"builtin,omitempty" yaml:"builtin,omitempty"`
-	Created               string            `json:"created,omitempty" yaml:"created,omitempty"`
-	CreatorID             string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
-	Description           string            `json:"description,omitempty" yaml:"description,omitempty"`
-	InheritedClusterRoles []string          `json:"inheritedClusterRoles,omitempty" yaml:"inheritedClusterRoles,omitempty"`
-	Labels                map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Name                  string            `json:"name,omitempty" yaml:"name,omitempty"`
-	NewUserDefault        bool              `json:"newUserDefault,omitempty" yaml:"newUserDefault,omitempty"`
-	OwnerReferences       []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
-	Removed               string            `json:"removed,omitempty" yaml:"removed,omitempty"`
-	Rules                 []PolicyRule      `json:"rules,omitempty" yaml:"rules,omitempty"`
-	UUID                  string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Annotations           map[string]string       `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Builtin               bool                    `json:"builtin,omitempty" yaml:"builtin,omitempty"`
+	Created               string                  `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatorID             string                  `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	Description           string                  `json:"description,omitempty" yaml:"description,omitempty"`
+	InheritedClusterRoles []string                `json:"inheritedClusterRoles,omitempty" yaml:"inheritedClusterRoles,omitempty"`
+	Labels                map[string]string       `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Name                  string                  `json:"name,omitempty" yaml:"name,omitempty"`
+	NamespacedRules       map[string][]PolicyRule `json:"namespacedRules,omitempty" yaml:"namespacedRules,omitempty"`
+	NewUserDefault        bool                    `json:"newUserDefault,omitempty" yaml:"newUserDefault,omitempty"`
+	OwnerReferences       []OwnerReference        `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`
+	Removed               string                  `json:"removed,omitempty" yaml:"removed,omitempty"`
+	Rules                 []PolicyRule            `json:"rules,omitempty" yaml:"rules,omitempty"`
+	UUID                  string                  `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 }
 
 type GlobalRoleCollection struct {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42215
 
## New Feature

Adds `NamespacedRules` to the GlobalRole field. Details of the field can be found in the issue, but in summation: 
- When a global role (GR) is created, a role is created in each namespace with the listed rules
- When a global role binding (GRB) is created, a role binding is created in each namespace that binds to the namespaced roles
- When the role/role binding is modified, it checks if it's owned by a GR/GRB and then enqueues it to be verified

The work is split in the following commits:
1. Add the NamespacedRules field
2. Add GRB support
3. Add GR support
4. Add enqueueing
 
## Testing
1. Create a GlobalRole with the new NamespacedRules field
    - It creates Roles based on the NamespacedRules
2. Create a GlobalRoleBinding with the above GlobalRole
    - It creates RoleBindings based on the NamespacedRules of the GR
3. Delete GR/GRB
    - Removes all Roles/RoleBindings

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework) **TODO**
    * Integration (v2prov Framework) **TODO**

Summary: Unit tests for all new code and integration tests (**TODO**)

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
This is a new field, so there shouldn't be any regressions. While the update/create functions for GR/GRBs got modified, the new check only occurs when the field is populated.

Existing / newly added automated tests that provide evidence there are no regressions:
* The existing RBAC integration tests prove that the previous RBAC functionality has not been modified

## Security Considerations
Need a security assessment to ensure this doesn't introduce CVEs