### PR TITLE
[2.8] Fix ListAKSAllVersions to not require a cluster

### DIFF
--- a/tests/framework/extensions/clusters/kubernetesversions/all.go
+++ b/tests/framework/extensions/clusters/kubernetesversions/all.go
@@ -10,9 +10,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
-	v3 "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 )
 
 const (
@@ -159,21 +157,17 @@ func ListGKEAllVersions(client *rancher.Client, projectID, cloudCredentialID, zo
 }
 
 // ListAKSAllVersions is a function that uses the management client base and aks meta endpoint to list and return all AKS versions.
-func ListAKSAllVersions(client *rancher.Client, cluster *v3.Cluster) (allAvailableVersions []string, err error) {
-	url := fmt.Sprintf("%s://%s/%s", "https", client.RancherConfig.Host, "meta/aksVersions")
+func ListAKSAllVersions(client *rancher.Client, cloudCredentialID, region string) (allAvailableVersions []string, err error) {
+	url := fmt.Sprintf("%s://%s/%s", "https", client.RancherConfig.Host, aksVersionPath)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return
 	}
 	req.Header.Add("Authorization", "Bearer "+client.RancherConfig.AdminToken)
 
-	if cluster.AKSConfig == nil {
-		return nil, errors.Wrapf(err, "cluster %s has no gke config", cluster.Name)
-	}
-
 	q := req.URL.Query()
-	q.Add("cloudCredentialId", cluster.AKSConfig.AzureCredentialSecret)
-	q.Add("region", cluster.AKSConfig.ResourceLocation)
+	q.Add("cloudCredentialId", cloudCredentialID)
+	q.Add("region", region)
 	req.URL.RawQuery = q.Encode()
 
 	bodyBytes, err := getRequest(req, client)

--- a/tests/framework/extensions/clusters/kubernetesversions/available.go
+++ b/tests/framework/extensions/clusters/kubernetesversions/available.go
@@ -237,7 +237,7 @@ func ListAKSAvailableVersions(client *rancher.Client, cluster *v3.Cluster) (avai
 	}
 
 	var validMasterVersions []*semver.Version
-	allAvailableVersions, err := ListAKSAllVersions(client, cluster)
+	allAvailableVersions, err := ListAKSAllVersions(client, cluster.AKSConfig.AzureCredentialSecret, cluster.AKSConfig.ResourceLocation)
 
 	for _, version := range allAvailableVersions {
 		v, err := semver.NewVersion(version)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 `ListAKSAllVersion` currently requires a cluster to fetch all the versions, unlike other providers. This PR modifies it to not require a cluster.
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 Modify the function signature to directly accept the cloud credential secret and region instead of obtaining them via cluster.
