### PR TITLE
Remove different branch references 

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -16,8 +16,8 @@ WORKDIR /var/lib/rancher
 ARG ARCH=amd64
 ARG ETCD_UNSUPPORTED_ARCH
 ARG IMAGE_REPO=rancher
-ARG SYSTEM_CHART_DEFAULT_BRANCH=dev-v2.8
-ARG CHART_DEFAULT_BRANCH=dev-v2.8
+ARG SYSTEM_CHART_DEFAULT_BRANCH
+ARG CHART_DEFAULT_BRANCH
 ARG PARTNER_CHART_DEFAULT_BRANCH=main
 ARG RKE2_CHART_DEFAULT_BRANCH=main
 # kontainer-driver-metadata branch to be set for specific branch other than dev/master, logic at rancher/rancher/pkg/settings/setting.go

--- a/pkg/data/dashboard/repo.go
+++ b/pkg/data/dashboard/repo.go
@@ -2,14 +2,15 @@ package dashboard
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
+	v1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/settings"
-
-	v1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/wrangler"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -42,7 +43,13 @@ func addClusterRepo(wrangler *wrangler.Context, repoName, branchName string) err
 // It attempts to add or update the cluster repositories 'rancher-charts', 'rancher-partner-charts',
 // and, if the RKE2 feature is enabled, 'rancher-rke2-charts'.
 func addClusterRepos(ctx context.Context, wrangler *wrangler.Context) error {
-	if err := addClusterRepo(wrangler, "rancher-charts", settings.ChartDefaultBranch.Get()); err != nil {
+	rancherChartsBranch := os.Getenv("CATTLE_CHART_DEFAULT_BRANCH")
+
+	if rancherChartsBranch == "" {
+		panic(fmt.Errorf("if you are developing, set CATTLE_CHART_DEFAULT_BRANCH to the desired default branch"))
+	}
+
+	if err := addClusterRepo(wrangler, "rancher-charts", rancherChartsBranch); err != nil {
 		return err
 	}
 	if err := addClusterRepo(wrangler, "rancher-partner-charts", settings.PartnerChartDefaultBranch.Get()); err != nil {

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -113,7 +113,6 @@ var (
 	ClusterTemplateEnforcement          = NewSetting("cluster-template-enforcement", "false")
 	InitialDockerRootDir                = NewSetting("initial-docker-root-dir", "/var/lib/docker")
 	SystemCatalog                       = NewSetting("system-catalog", "external") // Options are 'external' or 'bundled'
-	ChartDefaultBranch                  = NewSetting("chart-default-branch", "dev-v2.8")
 	SystemManagedChartsOperationTimeout = NewSetting("system-managed-charts-operation-timeout", "300s")
 	PartnerChartDefaultBranch           = NewSetting("partner-chart-default-branch", "main")
 	RKE2ChartDefaultBranch              = NewSetting("rke2-chart-default-branch", "main")


### PR DESCRIPTION
Commit 1

Removing the charts default setting branch since we already have an environment variable in package/Dockerfile. The system charts library codebase uses this env variable to set the default branch. So using the same pattern for rancher charts as well. This will also help us to be less error-prone during Rancher releases since we don't need to update in settings.go now. 

Commit 2 

Right now, build args are passed to package/Dockerfile for specifying the chart branches. The build args are environment variables defined in the package-env script. We also specify default build arg values inside the Dockerfile. Removed these default build arg values since package-env env variables are passed as build-args every time. This would be less human error prone during Rancher releases since we need to update it only in one place i.e. at package-env