### PR TITLE
Update ingress.yaml

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -55,7 +55,7 @@ spec:
           {{- end }}
         {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (not (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress")) }}
         pathType: ImplementationSpecific
-        path: "/"
+        path: "/*"
         {{- end }}
 {{- if eq .Values.tls "ingress" }}
   tls:


### PR DESCRIPTION
AWS ALB , does not work without /* to forward all requests to rancher service

## Problem
When using the application load balancer you need to forward all requests to the rancher service 
 
## Solution
either add * to be /*
or 
create a variable to overwrite the value. 
