### PR TITLE
Updating docs for project.Spec.ClusterName

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authz_types.go
+++ b/pkg/apis/management.cattle.io/v3/authz_types.go
@@ -102,7 +102,7 @@ type ProjectSpec struct {
 	// +optional
 	Description string `json:"description,omitempty"`
 
-	// ClusterName is the name of the cluster the project belongs to.
+	// ClusterName is the name of the cluster the project belongs to. Immutable.
 	// +kubebuilder:validation:Required
 	ClusterName string `json:"clusterName" norman:"required,type=reference[cluster]"`
 

--- a/pkg/crds/yaml/generated/management.cattle.io_projects.yaml
+++ b/pkg/crds/yaml/generated/management.cattle.io_projects.yaml
@@ -39,7 +39,7 @@ spec:
             properties:
               clusterName:
                 description: ClusterName is the name of the cluster the project belongs
-                  to.
+                  to. Immutable.
                 type: string
               containerDefaultResourceLimit:
                 description: ContainerDefaultResourceLimit is a specification for


### PR DESCRIPTION
Updates the docs for the ClusterName field on the project spec to be immutable, in line with recent webhook changes which enforce this requirement

## Issue: <!-- link the issue or issues this PR resolves here -->

Related to #42913, but does not make any effective changes.
 
## Problem

The webhook, with 0.4.0-rc10, now makes the `project.Spec.ClusterName` field immutable. The docs, however, do not state this. 
 
## Solution

The field description (available through `kubectl explain`) has been updated to specify that the `ClusterName` field of the projectSpec is immutable.
 
## Testing

N/A - docs only change.