### PR TITLE
Adding a version test suite for podsecuritypolicy

### DIFF
--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/version.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/version.go
@@ -21,7 +21,10 @@ func checkClusterVersion(clusterName string, clusterLister v3.ClusterLister) err
 	if cluster.Status.Version == nil {
 		return fmt.Errorf("cannot validate Kubernetes version for podsecuritypolicy capability: cluster [%s] status version is not available yet", clusterName)
 	}
-	if mVersion.Compare(cluster.Status.Version.String(), "v1.25", ">=") {
+	if len(cluster.Status.Version.String()) < 5 {
+		return fmt.Errorf("cannot validate Kubernetes version for podsecuritypolicy capability: cluster [%s] status version [%s] is too small", clusterName, cluster.Status.Version.String())
+	}
+	if mVersion.Compare(cluster.Status.Version.String()[0:5], "v1.25", ">=") {
 		return errVersionIncompatible
 	}
 	return nil

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/version_test.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/version_test.go
@@ -1,0 +1,105 @@
+package podsecuritypolicy
+
+import (
+	"fmt"
+	"testing"
+
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	mgmtv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+func newClusterListerWithVersion(kubernetesVersion string) *fakes.ClusterListerMock {
+	return &fakes.ClusterListerMock{
+		GetFunc: func(namespace, name string) (*mgmtv3.Cluster, error) {
+			if name == "test" {
+				cluster := mgmtv3.Cluster{
+					Status: apimgmtv3.ClusterStatus{
+						Version: &version.Info{
+							GitVersion: kubernetesVersion,
+						},
+					},
+				}
+				return &cluster, nil
+			}
+			return nil, fmt.Errorf("invalid cluster: %s", name)
+		},
+	}
+}
+
+func TestCheckClusterVersion(t *testing.T) {
+
+	tests := []*struct {
+		version string
+		wantErr bool
+		setup   func()
+	}{
+		// tests for version string size
+		{
+			version: "",
+			wantErr: true,
+		},
+		{
+			version: "v1.24",
+			wantErr: false,
+		},
+		{
+			version: "v1.2",
+			wantErr: true,
+		},
+		// rke1 version strings
+		{
+			version: "v1.24.9",
+			wantErr: false,
+		},
+		{
+			version: "v1.25.9",
+			wantErr: true,
+		},
+		{
+			version: "v1.26.9",
+			wantErr: true,
+		},
+		// k3s version strings
+		{
+			version: "v1.24.9+k3s1",
+			wantErr: false,
+		},
+		{
+			version: "v1.25.9+k3s1",
+			wantErr: true,
+		},
+		{
+			version: "v1.26.9+k3s1",
+			wantErr: true,
+		},
+		// rke2 version strings
+		{
+			version: "v1.24.9+rke2r1",
+			wantErr: false,
+		},
+		{
+			version: "v1.25.9+rke2r1",
+			wantErr: true,
+		},
+		{
+			version: "v1.26.9+rke2r1",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			clusterLister := newClusterListerWithVersion(tt.version)
+			println(tt.version)
+			err := checkClusterVersion("test", clusterLister)
+			if tt.wantErr {
+				println(err.Error())
+				assert.Error(t, err, "Expected checkClusterVersion to raise error.")
+				return
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Fxing podsecuritypolicy version checks for RKE2

## Issue:  https://github.com/rancher/rancher/issues/43057
 
## Problem
podsecuritypolicy checkClusterVersion fucntion is incompatible with RKE2
 
## Solution
Only look at the first 5 chars of the the version string
 
## Testing
Yes the steps in the issue are valid to test with.  I also added a unit test for checkClusterVersion.

## Engineering Testing
### Manual Testing
I've deployed this code into one of my Rancher environments and the PSP error messages went away for clusters without PSP support.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_