### PR TITLE
Fix control-plane labels for unmanaged machines

### DIFF
--- a/pkg/controllers/capr/unmanaged/controller.go
+++ b/pkg/controllers/capr/unmanaged/controller.go
@@ -143,6 +143,7 @@ func (h *handler) createMachineObjects(capiCluster *capi.Cluster, machineName st
 
 	if data.Bool("role-control-plane") {
 		labels[capr.ControlPlaneRoleLabel] = "true"
+		labels[capi.MachineControlPlaneLabel] = "true"
 	}
 	if data.Bool("role-etcd") {
 		labels[capr.EtcdRoleLabel] = "true"

--- a/pkg/controllers/capr/unmanaged/controller.go
+++ b/pkg/controllers/capr/unmanaged/controller.go
@@ -143,7 +143,6 @@ func (h *handler) createMachineObjects(capiCluster *capi.Cluster, machineName st
 
 	if data.Bool("role-control-plane") {
 		labels[capr.ControlPlaneRoleLabel] = "true"
-		labels[capi.MachineControlPlaneNameLabel] = "true"
 	}
 	if data.Bool("role-etcd") {
 		labels[capr.EtcdRoleLabel] = "true"

--- a/pkg/controllers/provisioningv2/provisioningcluster/template.go
+++ b/pkg/controllers/provisioningv2/provisioningcluster/template.go
@@ -419,7 +419,7 @@ func machineDeployments(cluster *rancherv1.Cluster, capiCluster *capi.Cluster, d
 
 		if machinePool.ControlPlaneRole {
 			machineDeployment.Spec.Template.Labels[capr.ControlPlaneRoleLabel] = "true"
-			machineDeployment.Spec.Template.Labels[capi.MachineControlPlaneNameLabel] = "true"
+			machineDeployment.Spec.Template.Labels[capi.MachineControlPlaneLabel] = "true"
 		}
 
 		if machinePool.WorkerRole {

--- a/tests/v2prov/tests/custom/custom_test.go
+++ b/tests/v2prov/tests/custom/custom_test.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_Provisioning_Custom_OneNode(t *testing.T) {
+func Test_Provisioning_Custom_OneNodeWithDelete(t *testing.T) {
 	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
 		t.Skip()
 	}
@@ -76,6 +76,18 @@ func Test_Provisioning_Custom_OneNode(t *testing.T) {
 		t.Error(err)
 	}
 	assert.Equal(t, labels, map[string]string{"cattle.io/os": "linux", "foo": "bar", "ball": "life"})
+
+	// Delete the cluster and wait for cleanup.
+	err = clients.Provisioning.Cluster().Delete(c.Namespace, c.Name, &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err = cluster.WaitForDelete(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	err = cluster.EnsureMinimalConflictsWithThreshold(clients, c, cluster.SaneConflictMessageThreshold)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42890
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
When deleting a K3s/RKE2 custom cluster, control-plane machines never get deleted and prevent the cluster from being deleted.

This is happening because control plane machines are missing the `ownerReference` pointing to their corresponding cluster objects, and as a result the CAPI machine controller does not clean them up when the cluster object is deleted. The reason they're missing the `ownerReference` is because they were mistakenly given the `cluster.x-k8s.io/control-plane-name` label in a recent upgrade PR [here](https://github.com/rancher/rancher/commit/38c4f2fbe4b594bac4876fa18c4f4014fe353574#diff-b6a77716404a711f2ad4441849495e70f631b4631f80b0f70f1a2fe0532e7e4dR146) instead of the `cluster.x-k8s.io/control-plane` label. The purpose of the `cluster.x-k8s.io/control-plane-name` label is to CAPI **not** to adopt the machine because it has already been adopted by another controller. Of course, this is not the case for us.
 
## Solution
The solution here is to simply change the label from `cluster.x-k8s.io/control-plane-name` back to `cluster.x-k8s.io/control-plane`.
 
## Testing

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Tested this manually by creating a custom cluster with a number of nodes and node role combinations and then deleting the cluster. All machines are deleted properly without manual intervention.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Integration (v2prov Framework)
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->

Summary: Updated v2Prov custom cluster integration test to cover the case of custom cluster deletion.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
Nothing meaningful that I can think of. Just making sure basic custom cluster functionality still works – creation, deletion, upgrade, scaling nodes up and down.

Existing / newly added automated tests that provide evidence there are no regressions:
None