### PR TITLE
Register Followers ensure handler after adding/updating the ClusterRepo

### DIFF
--- a/pkg/controllers/dashboardapi/controller.go
+++ b/pkg/controllers/dashboardapi/controller.go
@@ -9,6 +9,14 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 )
 
+func Add(ctx context.Context, wrangler *wrangler.Context) error {
+	if err := addClusterRepos(ctx, wrangler); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func Register(ctx context.Context, wrangler *wrangler.Context) error {
 	feature.Register(ctx, wrangler.Mgmt.Feature())
 	helm.RegisterReposForFollowers(ctx, wrangler.Core.Secret().Cache(), wrangler.Catalog.ClusterRepo())

--- a/pkg/controllers/dashboardapi/repo.go
+++ b/pkg/controllers/dashboardapi/repo.go
@@ -1,4 +1,4 @@
-package dashboard
+package dashboardapi
 
 import (
 	"context"
@@ -30,9 +30,19 @@ func addClusterRepo(wrangler *wrangler.Context, repoName, branchName string) err
 				GitBranch: branchName,
 			},
 		})
-	} else if err == nil && repo.Spec.GitBranch != branchName {
-		repo.Spec.GitBranch = branchName
-		_, err = wrangler.Catalog.ClusterRepo().Update(repo)
+	} else if err == nil {
+		if repo.Spec.GitBranch != branchName {
+			repo.Spec.GitBranch = branchName
+			repo, err = wrangler.Catalog.ClusterRepo().Update(repo)
+			if err != nil {
+				return err
+			}
+		}
+
+		if repo.Status.Commit != "" {
+			repo.Status.Commit = ""
+			_, err = wrangler.Catalog.ClusterRepo().UpdateStatus(repo)
+		}
 	}
 
 	return err

--- a/pkg/data/dashboard/add.go
+++ b/pkg/data/dashboard/add.go
@@ -33,10 +33,6 @@ func Add(ctx context.Context, wrangler *wrangler.Context, addLocal, removeLocal,
 		return err
 	}
 
-	if err := addClusterRepos(ctx, wrangler); err != nil {
-		return err
-	}
-
 	if err := AddFleetRoles(wrangler); err != nil {
 		return err
 	}

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -258,6 +258,9 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 }
 
 func (r *Rancher) Start(ctx context.Context) error {
+	if err := dashboardapi.Add(ctx, r.Wrangler); err != nil {
+		return err
+	}
 	if err := dashboardapi.Register(ctx, r.Wrangler); err != nil {
 		return err
 	}


### PR DESCRIPTION
**Problem Statement**

Right now, for Mapps, there are two handlers for ClusterRepo CRD

**1. Download Handler**

runs on only the leader pod and applies the spec of the ClusterRepo CRD onto the pod directory and updates the status.

What does it apply to the pod directory?
Clones/Updates the pod directory which contains the Github Repo/branch and updates the latest commit in the status.

**2.  Follower Handler**

runs on all rancher pods and the handler ensures that the status of the ClusterRepo is applied to the pod directory.

What does it apply to the pod directory?
Updates the pod directory with the commit from the status of the ClusteRepo. 

**General Process**

The Download Handler keeps updating the directory in the leader pod and updates the commit and the status handler updates its pod directories to update to the commit set by the download handler.

**Bug**

So, when the upgrade of Rancher happens follower handler is running first before updating the branch of spec. So follower handler applies the status branch (old branch/commit) to the rancher pod directory thus corrupting the directory. In a non-air-gapped environment, this is not an issue as the next runs of the handlers fix this, by pulling the right commits from the Internet. In an airgapped environment, recovery is never possible due to no access to the internet i.e. GitHub Repos.

**Solution**

Moving the creation/update of CRD before registering the handlers, will make the follower handler wait until the download handlers do the work.

Github Issue - https://github.com/rancher/rancher/issues/43021
This PR doesn't solve https://github.com/rancher/rancher/issues/43021 but we need to solve another issue https://github.com/rancher/rancher/issues/39532 which this PR solves and then tackle  https://github.com/rancher/rancher/issues/43021


