### PR TITLE
Add unit tests for GUID unmigration

### DIFF
--- a/pkg/agent/clean/adunmigration/ldap_test.go
+++ b/pkg/agent/clean/adunmigration/ldap_test.go
@@ -1,0 +1,80 @@
+package adunmigration
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	logrusTest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeUUID(t *testing.T) {
+	t.Parallel()
+	// Note: Because Rancher wrote these strings, the input format we care about is somewhat
+	// constrained, and we're not spending too much effort dealing with edge cases.
+	guidString := "953d82a03d47a5498330293e386dfce1"
+	wantEscapedString := "\\95\\3d\\82\\a0\\3d\\47\\a5\\49\\83\\30\\29\\3e\\38\\6d\\fc\\e1"
+	result := escapeUUID(guidString)
+	assert.Equal(t, wantEscapedString, result)
+}
+
+func TestIsGUID(t *testing.T) {
+	// Note: because logrus state is global, we cannot use t.Parallel here
+	hook := logrusTest.NewGlobal()
+
+	tests := []struct {
+		name            string
+		principalId     string
+		wantResult      bool
+		wantLoggedError bool
+	}{
+		{
+			name:            "Local User",
+			principalId:     "local://u-fydcaomakf",
+			wantResult:      false,
+			wantLoggedError: false,
+		},
+		{
+			name:            "AD user, DN based",
+			principalId:     "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+			wantResult:      false,
+			wantLoggedError: false,
+		},
+		{
+			name:            "AD user, GUID based",
+			principalId:     "activedirectory_user://953d82a03d47a5498330293e386dfce1",
+			wantResult:      true,
+			wantLoggedError: false,
+		},
+		{
+			name:            "Invalid principal",
+			principalId:     "fail-on-purpose",
+			wantResult:      false,
+			wantLoggedError: true,
+		},
+		{
+			name:            "Empty String",
+			principalId:     "",
+			wantResult:      false,
+			wantLoggedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			result := isGUID(test.principalId)
+			if result != test.wantResult {
+				t.Errorf("expected isGUID to be %v, but got %v", test.wantResult, result)
+			}
+			// This particular function treats invalid principal IDs as a soft error: an invalid ID is by
+			// definition not a valid GUID. We generate a log if this happens, so let's make sure we got
+			// that log:
+			if test.wantLoggedError {
+				assert.GreaterOrEqual(t, len(hook.Entries), 1)
+				assert.Equal(t, hook.LastEntry().Level, logrus.ErrorLevel)
+			}
+			hook.Reset()
+		})
+	}
+}

--- a/pkg/agent/clean/adunmigration/migrate_test.go
+++ b/pkg/agent/clean/adunmigration/migrate_test.go
@@ -1,0 +1,379 @@
+package adunmigration
+
+import (
+	"testing"
+	"time"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWorkUnitContainsName(t *testing.T) {
+	t.Parallel()
+
+	originalUserName := "u-fydcaomakf"
+	duplicateUserName := "u-quuknbiweg"
+
+	workunit := migrateUserWorkUnit{
+		originalUser: &v3.User{ObjectMeta: metav1.ObjectMeta{Name: originalUserName}},
+		duplicateUsers: []*v3.User{
+			{ObjectMeta: metav1.ObjectMeta{Name: duplicateUserName}},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		query      string
+		wantResult bool
+	}{
+		{
+			name:       "No match returns false",
+			query:      "u-nonexistent",
+			wantResult: false,
+		},
+		{
+			name:       "Original user match returns true",
+			query:      originalUserName,
+			wantResult: true,
+		},
+		{
+			name:       "Duplicate user match returns true",
+			query:      duplicateUserName,
+			wantResult: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := workUnitContainsName(&workunit, test.query)
+			assert.Equal(t, test.wantResult, result)
+		})
+	}
+}
+
+type mockLdapAlwaysSucceed struct {
+}
+
+func (sLConn mockLdapAlwaysSucceed) findLdapUserWithRetries(guid string) (string, *v3.Principal, error) {
+	return testDn, &v3.Principal{}, nil
+}
+
+func TestWorkUnitIdentification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		users              []v3.User
+		wantUsersToMigrate int
+		wantDuplicateUsers int
+	}{
+		{
+			name: "Guid-based user, which exists in AD, is identified",
+			users: []v3.User{
+				{ObjectMeta: metav1.ObjectMeta{Name: testGuidLocalName}, PrincipalIDs: []string{testGuidPrincipal, testGuidLocalPrincipal}},
+			},
+			wantUsersToMigrate: 1,
+			wantDuplicateUsers: 0,
+		},
+		{
+			name: "Guid-based duplicate users are recognized",
+			users: []v3.User{
+				{ObjectMeta: metav1.ObjectMeta{Name: testGuidLocalName}, PrincipalIDs: []string{testGuidPrincipal, testGuidLocalPrincipal}},
+				{ObjectMeta: metav1.ObjectMeta{Name: testDuplicateGuidLocalName}, PrincipalIDs: []string{testGuidPrincipal, testDuplicateGuidLocalPrincipal}},
+			},
+			wantUsersToMigrate: 1,
+			wantDuplicateUsers: 1,
+		},
+		{
+			name: "Dn-based duplicate users are recognized",
+			users: []v3.User{
+				{ObjectMeta: metav1.ObjectMeta{Name: testGuidLocalName}, PrincipalIDs: []string{testGuidPrincipal, testGuidLocalPrincipal}},
+				{ObjectMeta: metav1.ObjectMeta{Name: testDnLocalName}, PrincipalIDs: []string{testDnPrincipal, testDnLocalPrincipal}},
+			},
+			wantUsersToMigrate: 1,
+			wantDuplicateUsers: 1,
+		},
+		{
+			name: "Dn-based users without GUID-based duplicates are ignored",
+			users: []v3.User{
+				{ObjectMeta: metav1.ObjectMeta{Name: testDnLocalName}, PrincipalIDs: []string{testDnPrincipal, testDnLocalPrincipal}},
+			},
+			wantUsersToMigrate: 0,
+			wantDuplicateUsers: 0,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ldapConnection := mockLdapAlwaysSucceed{}
+			userList := v3.UserList{Items: test.users}
+			usersToMigrate, missingUsers, skippedUsers := identifyMigrationWorkUnits(&userList, ldapConnection)
+			assert.Equal(t, test.wantUsersToMigrate, len(usersToMigrate), "unexpected count for users to migrate")
+			assert.Equal(t, 0, len(missingUsers), "unexpected count for missing users")
+			assert.Equal(t, 0, len(skippedUsers), "unexpected count for skipped users")
+			if len(usersToMigrate) > 0 {
+				assert.Equal(t, test.wantDuplicateUsers, len(usersToMigrate[0].duplicateUsers), "unexpected duplicate users for first workunit")
+			}
+		})
+	}
+}
+
+func TestWorkUnitDuplicateAgeResolution(t *testing.T) {
+	t.Parallel()
+
+	olderTime, err := time.Parse("2006-Jan-02", "2000-Jan-01")
+	assert.NoError(t, err, "time itself cannot be trusted, all hope is lost")
+	newerTime, err := time.Parse("2006-Jan-02", "2001-Jan-01")
+	assert.NoError(t, err, "time itself cannot be trusted, all hope is lost")
+
+	tests := []struct {
+		name               string
+		users              []v3.User
+		wantUsersToMigrate int
+		wantDuplicateUsers int
+		wantOriginalName   string
+		wantDuplicateName  string
+	}{
+		{
+			name: "Guid-based duplicate selects oldest user as original",
+			users: []v3.User{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              testGuidLocalName,
+						CreationTimestamp: metav1.Time{Time: olderTime},
+					},
+					PrincipalIDs: []string{testGuidPrincipal, testGuidLocalPrincipal},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              testDuplicateGuidLocalName,
+						CreationTimestamp: metav1.Time{Time: newerTime},
+					},
+					PrincipalIDs: []string{testGuidPrincipal, testDuplicateGuidLocalPrincipal},
+				},
+			},
+			wantUsersToMigrate: 1,
+			wantDuplicateUsers: 1,
+			wantOriginalName:   testGuidLocalName,
+			wantDuplicateName:  testDuplicateGuidLocalName,
+		},
+		{
+			name: "Guid-based duplicate, order reversed, still selects oldest user as original",
+			users: []v3.User{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              testDuplicateGuidLocalName,
+						CreationTimestamp: metav1.Time{Time: newerTime},
+					},
+					PrincipalIDs: []string{testGuidPrincipal, testDuplicateGuidLocalPrincipal},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              testGuidLocalName,
+						CreationTimestamp: metav1.Time{Time: olderTime},
+					},
+					PrincipalIDs: []string{testGuidPrincipal, testGuidLocalPrincipal},
+				},
+			},
+			wantUsersToMigrate: 1,
+			wantDuplicateUsers: 1,
+			wantOriginalName:   testGuidLocalName,
+			wantDuplicateName:  testDuplicateGuidLocalName,
+		},
+		{
+			name: "Newer Dn-based duplicate of older GUID-based user selects GUID-based user as original",
+			users: []v3.User{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              testGuidLocalName,
+						CreationTimestamp: metav1.Time{Time: olderTime},
+					},
+					PrincipalIDs: []string{testGuidPrincipal, testGuidLocalPrincipal},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              testDnLocalName,
+						CreationTimestamp: metav1.Time{Time: newerTime},
+					},
+					PrincipalIDs: []string{testDnPrincipal, testDnLocalPrincipal},
+				},
+			},
+			wantUsersToMigrate: 1,
+			wantDuplicateUsers: 1,
+			wantOriginalName:   testGuidLocalName,
+			wantDuplicateName:  testDnLocalName,
+		},
+		{
+			name: "Newer Dn-based duplicate of older GUID-based user, order reversed, still selects GUID-based user as original",
+			users: []v3.User{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              testDnLocalName,
+						CreationTimestamp: metav1.Time{Time: newerTime},
+					},
+					PrincipalIDs: []string{testDnPrincipal, testDnLocalPrincipal},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              testGuidLocalName,
+						CreationTimestamp: metav1.Time{Time: olderTime},
+					},
+					PrincipalIDs: []string{testGuidPrincipal, testGuidLocalPrincipal},
+				},
+			},
+			wantUsersToMigrate: 1,
+			wantDuplicateUsers: 1,
+			wantOriginalName:   testGuidLocalName,
+			wantDuplicateName:  testDnLocalName,
+		},
+		{
+			name: "Newer GUID-based duplicate of older Dn-based user selects Dn-based user as original",
+			users: []v3.User{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              testDnLocalName,
+						CreationTimestamp: metav1.Time{Time: olderTime},
+					},
+					PrincipalIDs: []string{testDnPrincipal, testDnLocalPrincipal},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              testGuidLocalName,
+						CreationTimestamp: metav1.Time{Time: newerTime},
+					},
+					PrincipalIDs: []string{testGuidPrincipal, testGuidLocalPrincipal},
+				},
+			},
+			wantUsersToMigrate: 1,
+			wantDuplicateUsers: 1,
+			wantOriginalName:   testDnLocalName,
+			wantDuplicateName:  testGuidLocalName,
+		},
+		{
+			name: "Newer GUID-based duplicate of older Dn-based user, order reversed, still selects Dn-based user as original",
+			users: []v3.User{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              testGuidLocalName,
+						CreationTimestamp: metav1.Time{Time: newerTime},
+					},
+					PrincipalIDs: []string{testGuidPrincipal, testGuidLocalPrincipal},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              testDnLocalName,
+						CreationTimestamp: metav1.Time{Time: olderTime},
+					},
+					PrincipalIDs: []string{testDnPrincipal, testDnLocalPrincipal},
+				},
+			},
+			wantUsersToMigrate: 1,
+			wantDuplicateUsers: 1,
+			wantOriginalName:   testDnLocalName,
+			wantDuplicateName:  testGuidLocalName,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ldapConnection := mockLdapAlwaysSucceed{}
+			userList := v3.UserList{Items: test.users}
+			usersToMigrate, _, _ := identifyMigrationWorkUnits(&userList, ldapConnection)
+			assert.Equal(t, test.wantUsersToMigrate, len(usersToMigrate), "unexpected count for users to migrate")
+			if len(usersToMigrate) > 0 {
+				assert.Equal(t, test.wantDuplicateUsers, len(usersToMigrate[0].duplicateUsers), "unexpected duplicate users for first workunit")
+				if len(usersToMigrate[0].duplicateUsers) > 0 {
+					assert.Equal(t, test.wantOriginalName, usersToMigrate[0].originalUser.Name, "wrong user identified as original")
+					assert.Equal(t, test.wantDuplicateName, usersToMigrate[0].duplicateUsers[0].Name, "wrong user identified as duplicate")
+				}
+			}
+		})
+	}
+}
+
+type mockLdapNeverSucceed struct {
+}
+
+func (sLConn mockLdapNeverSucceed) findLdapUserWithRetries(guid string) (string, *v3.Principal, error) {
+	return "", nil, LdapErrorNotFound{}
+}
+
+type mockLdapConnectionFailure struct {
+}
+
+func (sLConn mockLdapConnectionFailure) findLdapUserWithRetries(guid string) (string, *v3.Principal, error) {
+	return "", nil, LdapConnectionPermanentlyFailed{}
+}
+
+func TestWorkUnitConnectionFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		users              []v3.User
+		ldapConn           retryableLdapConnection
+		wantUsersToMigrate int
+		wantMissingUsers   int
+		wantSkippedUsers   int
+	}{
+		{
+			name: "GUID-based users not found in Active Directory are counted as missing",
+			users: []v3.User{
+				{ObjectMeta: metav1.ObjectMeta{Name: testGuidLocalName}, PrincipalIDs: []string{testGuidPrincipal, testGuidLocalPrincipal}},
+			},
+			ldapConn:           mockLdapNeverSucceed{},
+			wantUsersToMigrate: 0,
+			wantMissingUsers:   1,
+			wantSkippedUsers:   0,
+		},
+		{
+			name: "GUID-based users are counted as skipped during LDAP connection failures",
+			users: []v3.User{
+				{ObjectMeta: metav1.ObjectMeta{Name: testGuidLocalName}, PrincipalIDs: []string{testGuidPrincipal, testGuidLocalPrincipal}},
+			},
+			ldapConn:           mockLdapConnectionFailure{},
+			wantUsersToMigrate: 0,
+			wantMissingUsers:   0,
+			wantSkippedUsers:   1,
+		},
+		{
+			name: "Dn-based users are not counted as missing, even if they don't exist in Active Directory",
+			users: []v3.User{
+				{ObjectMeta: metav1.ObjectMeta{Name: testDnLocalName}, PrincipalIDs: []string{testDnPrincipal, testDnLocalPrincipal}},
+			},
+			ldapConn:           mockLdapNeverSucceed{},
+			wantUsersToMigrate: 0,
+			wantMissingUsers:   0,
+			wantSkippedUsers:   0,
+		},
+		{
+			name: "Dn-based users are not counted as skipped, even during LDAP connection failures",
+			users: []v3.User{
+				{ObjectMeta: metav1.ObjectMeta{Name: testDnLocalName}, PrincipalIDs: []string{testDnPrincipal, testDnLocalPrincipal}},
+			},
+			ldapConn:           mockLdapConnectionFailure{},
+			wantUsersToMigrate: 0,
+			wantMissingUsers:   0,
+			wantSkippedUsers:   0,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			userList := v3.UserList{Items: test.users}
+			usersToMigrate, missingUsers, skippedUsers := identifyMigrationWorkUnits(&userList, test.ldapConn)
+			assert.Equal(t, test.wantUsersToMigrate, len(usersToMigrate), "unexpected count for users to migrate")
+			assert.Equal(t, test.wantMissingUsers, len(missingUsers), "unexpected count for missing users")
+			assert.Equal(t, test.wantSkippedUsers, len(skippedUsers), "unexpected count for skipped users")
+		})
+	}
+}

--- a/pkg/agent/clean/adunmigration/rtbs.go
+++ b/pkg/agent/clean/adunmigration/rtbs.go
@@ -35,14 +35,7 @@ func principalsToMigrate(workunits *[]migrateUserWorkUnit) (adWorkUnitsByPrincip
 	return adWorkUnitsByPrincipal, duplicateLocalWorkUnitsByPrincipal
 }
 
-func collectCRTBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) error {
-	crtbInterface := sc.Management.ClusterRoleTemplateBindings("")
-	crtbList, err := crtbInterface.List(metav1.ListOptions{})
-	if err != nil {
-		logrus.Errorf("[%v] unable to fetch CRTB objects: %v", migrateAdUserOperation, err)
-		return err
-	}
-
+func identifyCRTBs(workunits *[]migrateUserWorkUnit, crtbList *v3.ClusterRoleTemplateBindingList) {
 	adWorkUnitsByPrincipal, duplicateLocalWorkUnitsByPrincipal := principalsToMigrate(workunits)
 
 	for _, crtb := range crtbList.Items {
@@ -62,18 +55,9 @@ func collectCRTBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) er
 			}
 		}
 	}
-
-	return nil
 }
 
-func collectPRTBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) error {
-	prtbInterface := sc.Management.ProjectRoleTemplateBindings("")
-	prtbList, err := prtbInterface.List(metav1.ListOptions{})
-	if err != nil {
-		logrus.Errorf("[%v] unable to fetch PRTB objects: %v", migrateAdUserOperation, err)
-		return err
-	}
-
+func identifyPRTBs(workunits *[]migrateUserWorkUnit, prtbList *v3.ProjectRoleTemplateBindingList) {
 	adWorkUnitsByPrincipal, duplicateLocalWorkUnitsByPrincipal := principalsToMigrate(workunits)
 
 	for _, prtb := range prtbList.Items {
@@ -93,18 +77,9 @@ func collectPRTBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) er
 			}
 		}
 	}
-
-	return nil
 }
 
-func collectGRBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) error {
-	grbInterface := sc.Management.GlobalRoleBindings("")
-	grbList, err := grbInterface.List(metav1.ListOptions{})
-	if err != nil {
-		logrus.Errorf("[%v] unable to fetch GRB objects: %v", migrateAdUserOperation, err)
-		return err
-	}
-
+func identifyGRBs(workunits *[]migrateUserWorkUnit, grbList *v3.GlobalRoleBindingList) {
 	duplicateLocalWorkUnitsByName := map[string]int{}
 
 	for _, workunit := range *workunits {
@@ -118,8 +93,6 @@ func collectGRBs(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) err
 			(*workunits)[index].duplicateLocalGRBs = append((*workunits)[index].duplicateLocalGRBs, grb)
 		}
 	}
-
-	return nil
 }
 
 func updateCRTB(crtbInterface v3norman.ClusterRoleTemplateBindingInterface, oldCrtb *v3.ClusterRoleTemplateBinding, userName string, principalID string) error {

--- a/pkg/agent/clean/adunmigration/rtbs_test.go
+++ b/pkg/agent/clean/adunmigration/rtbs_test.go
@@ -1,0 +1,247 @@
+package adunmigration
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testGuid                        = "953d82a03d47a5498330293e386dfce1"
+	testDn                          = "CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space"
+	testDnLocalName                 = "user-vhhxd"
+	testGuidLocalName               = "u-fydcaomakf"
+	testDuplicateGuidLocalName      = "u-quuknbiweg"
+	testGuidPrincipal               = "activedirectory_user://" + testGuid
+	testDnPrincipal                 = "activedirectory_user://" + testDn
+	testDnLocalPrincipal            = "local://" + testDnLocalName
+	testGuidLocalPrincipal          = "local://" + testGuidLocalName
+	testDuplicateGuidLocalPrincipal = "local://" + testDuplicateGuidLocalName
+)
+
+func guidOriginalWorkunit() migrateUserWorkUnit {
+	// The "success" case for the original migration logic: only the GUID is left, with no extra copies
+	return migrateUserWorkUnit{
+		guid:              testGuid,
+		distinguishedName: testDn,
+		originalUser: &v3.User{
+			ObjectMeta:   metav1.ObjectMeta{Name: testGuidLocalName},
+			PrincipalIDs: []string{testGuidLocalPrincipal, testGuidPrincipal}},
+	}
+}
+
+func guidOriginalGuidDuplicateWorkunit() migrateUserWorkUnit {
+	// An uncommon case caused by a race condition: the older GUID-based user was migrated, but not
+	// before a newer GUID-based duplicate was created. After this, the affected user can no longer log in
+	// due to both users having the same principal ID
+	return migrateUserWorkUnit{
+		guid:              testGuid,
+		distinguishedName: testDn,
+		originalUser: &v3.User{
+			ObjectMeta:   metav1.ObjectMeta{Name: testGuidLocalName},
+			PrincipalIDs: []string{testGuidLocalPrincipal, testGuidPrincipal},
+		},
+		duplicateUsers: []*v3.User{{
+			ObjectMeta:   metav1.ObjectMeta{Name: testDuplicateGuidLocalName},
+			PrincipalIDs: []string{testDuplicateGuidLocalPrincipal, testGuidPrincipal}}},
+	}
+}
+
+func dnOriginalGuidDuplicateWorkunit() migrateUserWorkUnit {
+	// Caused by a failure to migrate the original user. A new GUID-based user is
+	// then created at the next login with none of the original permissions.
+	return migrateUserWorkUnit{
+		guid:              testGuid,
+		distinguishedName: testDn,
+		originalUser: &v3.User{
+			ObjectMeta:   metav1.ObjectMeta{Name: testDnLocalName},
+			PrincipalIDs: []string{testDnLocalPrincipal, testDnPrincipal}},
+		duplicateUsers: []*v3.User{{
+			ObjectMeta:   metav1.ObjectMeta{Name: testGuidLocalName},
+			PrincipalIDs: []string{testGuidLocalPrincipal, testGuidPrincipal}}},
+	}
+}
+
+func TestIdentifyCRTBs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                    string
+		workunit                migrateUserWorkUnit
+		crtbs                   []v3.ClusterRoleTemplateBinding
+		wantAdCrtbs             int
+		wantDuplicateLocalCrtbs int
+	}{
+		{
+			name:     "Guid-based CRTB referencing Original GUID-based user will be migrated",
+			workunit: guidOriginalWorkunit(),
+			crtbs: []v3.ClusterRoleTemplateBinding{
+				{UserName: testGuidLocalName, UserPrincipalName: testGuidPrincipal},
+			},
+			wantAdCrtbs:             1,
+			wantDuplicateLocalCrtbs: 0,
+		},
+		{
+			name:     "Local-based CRTB referencing Original GUID-based user will not be migrated",
+			workunit: guidOriginalWorkunit(),
+			crtbs: []v3.ClusterRoleTemplateBinding{
+				{UserName: testGuidLocalName, UserPrincipalName: testGuidLocalPrincipal},
+			},
+			wantAdCrtbs:             0,
+			wantDuplicateLocalCrtbs: 0,
+		},
+		{
+			name:     "Guid-based CRTB referencing Duplicate GUID-based user will be migrated",
+			workunit: guidOriginalGuidDuplicateWorkunit(),
+			crtbs: []v3.ClusterRoleTemplateBinding{
+				{UserName: testDuplicateGuidLocalName, UserPrincipalName: testGuidPrincipal},
+			},
+			wantAdCrtbs:             1,
+			wantDuplicateLocalCrtbs: 0,
+		},
+		{
+			name:     "Local-based CRTB referencing Duplicate GUID-based user will be migrated",
+			workunit: guidOriginalGuidDuplicateWorkunit(),
+			crtbs: []v3.ClusterRoleTemplateBinding{
+				{UserName: testDuplicateGuidLocalName, UserPrincipalName: testDuplicateGuidLocalPrincipal},
+			},
+			wantAdCrtbs:             0,
+			wantDuplicateLocalCrtbs: 1,
+		},
+		{
+			name:     "DN-based CRTB referencing Original DN-based user will not be migrated",
+			workunit: dnOriginalGuidDuplicateWorkunit(),
+			crtbs: []v3.ClusterRoleTemplateBinding{
+				{UserName: testDnLocalName, UserPrincipalName: testDnLocalPrincipal},
+			},
+			wantAdCrtbs:             0,
+			wantDuplicateLocalCrtbs: 0,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			crtbList := v3.ClusterRoleTemplateBindingList{Items: test.crtbs}
+			workunitList := []migrateUserWorkUnit{test.workunit}
+			identifyCRTBs(&workunitList, &crtbList)
+
+			assert.Equal(t, test.wantAdCrtbs, len(workunitList[0].activeDirectoryCRTBs), "expected AD-based CRTBs must match")
+			assert.Equal(t, test.wantDuplicateLocalCrtbs, len(workunitList[0].duplicateLocalCRTBs), "expected duplicate Local-based CRTBs must match")
+		})
+	}
+}
+
+func TestIdentifyPRTBs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                    string
+		workunit                migrateUserWorkUnit
+		prtbs                   []v3.ProjectRoleTemplateBinding
+		wantAdPrtbs             int
+		wantDuplicateLocalPrtbs int
+	}{
+		{
+			name:     "Guid-based PRTB referencing Original GUID-based user will be migrated",
+			workunit: guidOriginalWorkunit(),
+			prtbs: []v3.ProjectRoleTemplateBinding{
+				{UserName: testGuidLocalName, UserPrincipalName: testGuidPrincipal},
+			},
+			wantAdPrtbs:             1,
+			wantDuplicateLocalPrtbs: 0,
+		},
+		{
+			name:     "Local-based PRTB referencing Original GUID-based user will not be migrated",
+			workunit: guidOriginalWorkunit(),
+			prtbs: []v3.ProjectRoleTemplateBinding{
+				{UserName: testGuidLocalName, UserPrincipalName: testGuidLocalPrincipal},
+			},
+			wantAdPrtbs:             0,
+			wantDuplicateLocalPrtbs: 0,
+		},
+		{
+			name:     "Guid-based PRTB referencing Duplicate GUID-based user will be migrated",
+			workunit: guidOriginalGuidDuplicateWorkunit(),
+			prtbs: []v3.ProjectRoleTemplateBinding{
+				{UserName: testDuplicateGuidLocalName, UserPrincipalName: testGuidPrincipal},
+			},
+			wantAdPrtbs:             1,
+			wantDuplicateLocalPrtbs: 0,
+		},
+		{
+			name:     "Local-based PRTB referencing Duplicate GUID-based user will be migrated",
+			workunit: guidOriginalGuidDuplicateWorkunit(),
+			prtbs: []v3.ProjectRoleTemplateBinding{
+				{UserName: testDuplicateGuidLocalName, UserPrincipalName: testDuplicateGuidLocalPrincipal},
+			},
+			wantAdPrtbs:             0,
+			wantDuplicateLocalPrtbs: 1,
+		},
+		{
+			name:     "DN-based PRTB referencing Original DN-based user will not be migrated",
+			workunit: dnOriginalGuidDuplicateWorkunit(),
+			prtbs: []v3.ProjectRoleTemplateBinding{
+				{UserName: testDnLocalName, UserPrincipalName: testDnLocalPrincipal},
+			},
+			wantAdPrtbs:             0,
+			wantDuplicateLocalPrtbs: 0,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			prtbList := v3.ProjectRoleTemplateBindingList{Items: test.prtbs}
+			workunitList := []migrateUserWorkUnit{test.workunit}
+			identifyPRTBs(&workunitList, &prtbList)
+
+			assert.Equal(t, test.wantAdPrtbs, len(workunitList[0].activeDirectoryPRTBs), "expected AD-based PRTBs must match")
+			assert.Equal(t, test.wantDuplicateLocalPrtbs, len(workunitList[0].duplicateLocalPRTBs), "expected duplicate Local-based PRTBs must match")
+		})
+	}
+}
+
+func TestIdentifyGRBs(t *testing.T) {
+	//t.Parallel()
+
+	tests := []struct {
+		name                   string
+		workunit               migrateUserWorkUnit
+		grbs                   []v3.GlobalRoleBinding
+		wantDuplicateLocalGrbs int
+	}{
+		{
+			name:     "GRB referencing Original user will not be migrated",
+			workunit: guidOriginalGuidDuplicateWorkunit(),
+			grbs: []v3.GlobalRoleBinding{
+				{UserName: testGuidLocalName},
+			},
+			wantDuplicateLocalGrbs: 0,
+		},
+		{
+			name:     "GRB referencing Duplicate user will be migrated",
+			workunit: guidOriginalGuidDuplicateWorkunit(),
+			grbs: []v3.GlobalRoleBinding{
+				{UserName: testDuplicateGuidLocalName},
+			},
+			wantDuplicateLocalGrbs: 1,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			grbList := v3.GlobalRoleBindingList{Items: test.grbs}
+			workunitList := []migrateUserWorkUnit{test.workunit}
+			identifyGRBs(&workunitList, &grbList)
+
+			assert.Equal(t, test.wantDuplicateLocalGrbs, len(workunitList[0].duplicateLocalGRBs), "expected duplicate GRBs must match")
+		})
+	}
+}

--- a/pkg/agent/clean/adunmigration/tokens.go
+++ b/pkg/agent/clean/adunmigration/tokens.go
@@ -15,14 +15,7 @@ import (
 	"github.com/rancher/rancher/pkg/types/config"
 )
 
-func collectTokens(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) error {
-	tokenInterface := sc.Management.Tokens("")
-	tokenList, err := tokenInterface.List(metav1.ListOptions{})
-	if err != nil {
-		logrus.Errorf("[%v] unable to fetch token objects: %v", migrateAdUserOperation, err)
-		return err
-	}
-
+func identifyTokens(workunits *[]migrateUserWorkUnit, tokenList *v3.TokenList) {
 	adWorkUnitsByPrincipal, duplicateLocalWorkUnitsByPrincipal := principalsToMigrate(workunits)
 
 	for _, token := range tokenList.Items {
@@ -42,8 +35,6 @@ func collectTokens(workunits *[]migrateUserWorkUnit, sc *config.ScaledContext) e
 			}
 		}
 	}
-
-	return nil
 }
 
 func updateToken(tokenInterface v3norman.TokenInterface, userToken v3.Token, newPrincipalID string, guid string, targetUser *v3.User, targetPrincipal *v3.Principal) error {

--- a/pkg/agent/clean/adunmigration/tokens_test.go
+++ b/pkg/agent/clean/adunmigration/tokens_test.go
@@ -1,0 +1,80 @@
+package adunmigration
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIdentifyTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                     string
+		workunit                 migrateUserWorkUnit
+		tokens                   []v3.Token
+		wantAdTokens             int
+		wantDuplicateLocalTokens int
+	}{
+		{
+			name:     "Guid-based token referencing Original GUID-based user will be migrated",
+			workunit: guidOriginalWorkunit(),
+			tokens: []v3.Token{
+				{UserID: testGuidLocalName, UserPrincipal: v3.Principal{ObjectMeta: metav1.ObjectMeta{Name: testGuidPrincipal}}},
+			},
+			wantAdTokens:             1,
+			wantDuplicateLocalTokens: 0,
+		},
+		{
+			name:     "Local-based token referencing Original GUID-based user will not be migrated",
+			workunit: guidOriginalWorkunit(),
+			tokens: []v3.Token{
+				{UserID: testGuidLocalName, UserPrincipal: v3.Principal{ObjectMeta: metav1.ObjectMeta{Name: testGuidLocalPrincipal}}},
+			},
+			wantAdTokens:             0,
+			wantDuplicateLocalTokens: 0,
+		},
+		{
+			name:     "Guid-based token referencing Duplicate GUID-based user will be migrated",
+			workunit: guidOriginalGuidDuplicateWorkunit(),
+			tokens: []v3.Token{
+				{UserID: testDuplicateGuidLocalName, UserPrincipal: v3.Principal{ObjectMeta: metav1.ObjectMeta{Name: testGuidPrincipal}}},
+			},
+			wantAdTokens:             1,
+			wantDuplicateLocalTokens: 0,
+		},
+		{
+			name:     "Local-based token referencing Duplicate GUID-based user will be migrated",
+			workunit: guidOriginalGuidDuplicateWorkunit(),
+			tokens: []v3.Token{
+				{UserID: testDuplicateGuidLocalName, UserPrincipal: v3.Principal{ObjectMeta: metav1.ObjectMeta{Name: testDuplicateGuidLocalPrincipal}}},
+			},
+			wantAdTokens:             0,
+			wantDuplicateLocalTokens: 1,
+		},
+		{
+			name:     "DN-based token referencing Original DN-based user will not be migrated",
+			workunit: dnOriginalGuidDuplicateWorkunit(),
+			tokens: []v3.Token{
+				{UserID: testDnLocalName, UserPrincipal: v3.Principal{ObjectMeta: metav1.ObjectMeta{Name: testDnLocalPrincipal}}},
+			},
+			wantAdTokens:             0,
+			wantDuplicateLocalTokens: 0,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			tokenList := v3.TokenList{Items: test.tokens}
+			workunitList := []migrateUserWorkUnit{test.workunit}
+			identifyTokens(&workunitList, &tokenList)
+
+			assert.Equal(t, test.wantAdTokens, len(workunitList[0].activeDirectoryTokens), "expected AD-based tokens must match")
+			assert.Equal(t, test.wantDuplicateLocalTokens, len(workunitList[0].duplicateLocalTokens), "expected duplicate Local-based tokens must match")
+		})
+	}
+}

--- a/pkg/agent/clean/adunmigration/users_test.go
+++ b/pkg/agent/clean/adunmigration/users_test.go
@@ -1,0 +1,166 @@
+package adunmigration
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAdUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		user       v3.User
+		wantResult bool
+	}{
+		{
+			name:       "Local user",
+			user:       v3.User{PrincipalIDs: []string{"local://u-fydcaomakf"}},
+			wantResult: false,
+		},
+		{
+			name: "AD user, DN based",
+			user: v3.User{PrincipalIDs: []string{
+				"local://u-fydcaomakf",
+				"activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space"}},
+			wantResult: true,
+		},
+		{
+			name: "AD user, GUID based",
+			user: v3.User{PrincipalIDs: []string{
+				"local://u-fydcaomakf",
+				"activedirectory_user://953d82a03d47a5498330293e386dfce1"}},
+			wantResult: true,
+		},
+		{
+			name: "Non-local, non-AD user",
+			user: v3.User{PrincipalIDs: []string{
+				"local://u-fydcaomakf",
+				"okta_user://test.user@example.com"}},
+			wantResult: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := isAdUser(&test.user)
+			assert.Equal(t, test.wantResult, result)
+		})
+	}
+}
+
+func TestGetExternalId(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		principalId string
+		wantResult  string
+		wantError   bool
+	}{
+		{
+			name:        "Local User",
+			principalId: "local://u-fydcaomakf",
+			wantResult:  "u-fydcaomakf",
+			wantError:   false,
+		},
+		{
+			name:        "AD user, DN based",
+			principalId: "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+			wantResult:  "CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+			wantError:   false,
+		},
+		{
+			name:        "AD user, GUID based",
+			principalId: "activedirectory_user://953d82a03d47a5498330293e386dfce1",
+			wantResult:  "953d82a03d47a5498330293e386dfce1",
+			wantError:   false,
+		},
+		{
+			name:        "Invalid principal",
+			principalId: "fail-on-purpose",
+			wantResult:  "",
+			wantError:   true,
+		},
+		{
+			name:        "Empty String",
+			principalId: "",
+			wantResult:  "",
+			wantError:   true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := getExternalID(test.principalId)
+			if test.wantError {
+				assert.Error(t, err, "expected error")
+			} else {
+				assert.NoError(t, err, "unexpected error")
+			}
+			assert.Equal(t, test.wantResult, result)
+		})
+	}
+}
+
+func TestGetScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		principalId string
+		wantResult  string
+		wantError   bool
+	}{
+		{
+			name:        "Local User",
+			principalId: "local://u-fydcaomakf",
+			wantResult:  "local",
+			wantError:   false,
+		},
+		{
+			name:        "AD user, DN based",
+			principalId: "activedirectory_user://CN=testuser1,CN=Users,DC=qa,DC=rancher,DC=space",
+			wantResult:  "activedirectory_user",
+			wantError:   false,
+		},
+		{
+			name:        "AD user, GUID based",
+			principalId: "activedirectory_user://953d82a03d47a5498330293e386dfce1",
+			wantResult:  "activedirectory_user",
+			wantError:   false,
+		},
+		{
+			name:        "Invalid principal",
+			principalId: "fail-on-purpose",
+			wantResult:  "",
+			wantError:   true,
+		},
+		{
+			name:        "Empty String",
+			principalId: "",
+			wantResult:  "",
+			wantError:   true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := getScope(test.principalId)
+			if test.wantError {
+				assert.Error(t, err, "expected error")
+			} else {
+				assert.NoError(t, err, "unexpected error")
+			}
+			assert.Equal(t, test.wantResult, result)
+		})
+	}
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/42328
 
## Problem
When we originally merged in the uuid-unmigration, due to active issues, unit test writing was deferred so we could get the fix out more quickly. These are those tests.

To facilitate easier testing, several small refactors were performed:
- The various "identify" functions now accept the lists of objects to operate on, rather than the external state necessary to query those objects
- For LDAP lookups, the retryable connection is hoisted into an interface so it can be more easily mocked

## Testing
These unit tests cover the various utility functions and identification routines. For this initial round I've focused on tests  that doesn't need to touch external services, excepting LDAP lookups, since this minimizes the amount of required mocks. Most of the interesting decisions are made during identification anyway.

## Engineering Testing

### Automated Testing
* Test types added/modified:
    * Unit

## QA Testing Considerations
For the most part, if drone passes then the tests also passed. No manual testing should be required.
