### PR TITLE
Add new Elemental images to Rancher's images origins file.

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -119,6 +119,8 @@ var OriginMap = map[string]string{
 	"mirrored-curlimages-curl":                                "https://github.com/curl/curl-docker",
 	"mirrored-dexidp-dex":                                     "https://github.com/dexidp/dex",
 	"mirrored-directxman12-k8s-prometheus-adapter":            "https://hub.docker.com/r/directxman12/k8s-prometheus-adapter/tags",
+	"mirrored-elemental-operator":                             "https://github.com/rancher/elemental-operator",
+	"mirrored-elemental-seedimage-builder":                    "https://github.com/rancher/elemental-operator",
 	"mirrored-epinio-epinio-server":                           "https://github.com/epinio/epinio",
 	"mirrored-epinio-epinio-ui":                               "https://github.com/kubeops/config-syncer",
 	"mirrored-epinio-epinio-unpacker":                         "https://github.com/epinio/epinio",


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Add to the origins.go file the Elemental container images needed for adding the chart in the Rancher Marketplace (see https://github.com/rancher/image-mirror/pull/428).
