### PR TITLE
Adds openssh-clients package installation.

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.suse.com/bci/bci-base:15.5
 
-RUN zypper -n install --no-recommends git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim-small netcat-openbsd mkisofs && \
+RUN zypper -n install --no-recommends git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim-small netcat-openbsd mkisofs openssh-clients && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
     useradd rancher && \
     mkdir -p /var/lib/rancher /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/43115
Rancher images currently being built no longer run due to the missing package openssh-clients. `jail.sh` [uses the ssh binary](https://github.com/rancher/rancher/blob/release/v2.8/package/jailer.sh#L76) when running and causes Rancher to exit if it does not exist.
The package is missing since git-core which was being installed by rancher no longer requires openssh-clients.

2 Root causes of this issue are 
1. Rancher does not explicitly install versions of the following pakacges
    ```
    gcc binutils glibc-devel-static ca-certificates git-core wget curl unzip tar vim less file xz gzip sed gawk iproute2 iptables 
    jq skopeo
    ```
2. Rancher does not explicitly install openssh-clients.

This PR attempts to fix the issue by addressing point number 2.