### PR TITLE
Add checkout method in Ensure handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ all.yaml
 kustomization.yaml
 kontainer-engine
 **/coverage.out
+Dockerfile.dapper*
+rancher_debug

--- a/pkg/catalogv2/git/download.go
+++ b/pkg/catalogv2/git/download.go
@@ -6,11 +6,11 @@ import (
 	plumbing "github.com/go-git/go-git/v5/plumbing"
 )
 
-// Ensure will check if repo is cloned, if not the method will clone and reset to the latest commit.
-// If reseting to the latest commit is not possible it will fetch and try to reset again
+// Ensure will check if repo is cloned, if not the method will clone and checkout to the ClusterRepo.Status.Commit.
+// If checking out to the given commit is not possible it will fetch and try to checkout again
 func (r *Repository) Ensure(commit string) error {
-	// clone at the current HEAD pointing branch
-	// if the HEAD pointing branch is supposed to change, then it should be done at Update or Head method
+	// fresh clone or open
+	// if the HEAD pointing commit is supposed to change, then it should be done at Update or Head method
 	err := r.cloneOrOpen("")
 	if err != nil {
 		return fmt.Errorf("failed to clone or open repository: %w", err)
@@ -50,8 +50,8 @@ func (r *Repository) Head(branch string) (string, error) {
 }
 
 // CheckUpdate will check if rancher is in bundled mode,
-// if it is not in bundled mode, will make an update.
-// if it is in bundled mode, will just call Head method.
+// if it is not in bundled mode, it will make an update.
+// if it is in bundled mode, will just call Head method since we never update on this mode.
 func (r *Repository) CheckUpdate(branch, systemCatalogMode string) (string, error) {
 	if isBundled(r.Directory) && systemCatalogMode == "bundled" {
 		return r.Head(branch)

--- a/pkg/catalogv2/git/download.go
+++ b/pkg/catalogv2/git/download.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Ensure will check if repo is cloned, if not the method will clone and checkout to the ClusterRepo.Status.Commit.
-// If checking out to the given commit is not possible it will fetch and try to checkout again
+// If checking out to the given commit is not possible it will fetch and reset to the commit.
 func (r *Repository) Ensure(commit string) error {
 	// fresh clone or open
 	// if the HEAD pointing commit is supposed to change, then it should be done at Update or Head method
@@ -16,7 +16,7 @@ func (r *Repository) Ensure(commit string) error {
 		return fmt.Errorf("failed to clone or open repository: %w", err)
 	}
 
-	// Try to reset to the given branch, if success exit
+	// Try to checkout to the given commit, if success exit
 	err = r.checkoutCommit(commit)
 	if err == nil {
 		return nil

--- a/pkg/catalogv2/git/download.go
+++ b/pkg/catalogv2/git/download.go
@@ -8,7 +8,7 @@ import (
 
 // Ensure will check if repo is cloned, if not the method will clone and checkout to the ClusterRepo.Status.Commit.
 // If checking out to the given commit is not possible it will fetch and reset to the commit.
-func (r *Repository) Ensure(commit string) error {
+func (r *Repository) Ensure(commit, branch string) error {
 	// fresh clone or open
 	// if the HEAD pointing commit is supposed to change, then it should be done at Update or Head method
 	err := r.cloneOrOpen("")
@@ -23,7 +23,7 @@ func (r *Repository) Ensure(commit string) error {
 	}
 
 	// If we do not have the commit locally, fetch and reset to it
-	err = r.fetchAndReset(commit)
+	err = r.fetchAndResetByCommitAndBranch(commit, branch)
 	if err != nil {
 		return fmt.Errorf("failed to fetch and/or reset at branch: %w", err)
 	}

--- a/pkg/catalogv2/git/download.go
+++ b/pkg/catalogv2/git/download.go
@@ -8,7 +8,7 @@ import (
 
 // Ensure will check if repo is cloned, if not the method will clone and reset to the latest commit.
 // If reseting to the latest commit is not possible it will fetch and try to reset again
-func (r *Repository) Ensure(branch string) error {
+func (r *Repository) Ensure(commit string) error {
 	// clone at the current HEAD pointing branch
 	// if the HEAD pointing branch is supposed to change, then it should be done at Update or Head method
 	err := r.cloneOrOpen("")
@@ -17,14 +17,13 @@ func (r *Repository) Ensure(branch string) error {
 	}
 
 	// Try to reset to the given branch, if success exit
-	localBranchFullName := plumbing.NewBranchReferenceName(branch)
-	err = r.hardReset(localBranchFullName.String())
+	err = r.checkoutCommit(commit)
 	if err == nil {
 		return nil
 	}
 
-	// If we do not have the branch locally, fetch and reset
-	err = r.fetchAndReset(branch)
+	// If we do not have the commit locally, fetch and reset to it
+	err = r.fetchAndReset(commit)
 	if err != nil {
 		return fmt.Errorf("failed to fetch and/or reset at branch: %w", err)
 	}

--- a/pkg/catalogv2/git/utils.go
+++ b/pkg/catalogv2/git/utils.go
@@ -17,6 +17,8 @@ const (
 	staticDir            = "/var/lib/rancher-data/local-catalogs/v2"
 	localDir             = "../rancher-data/local-catalogs/v2" // identical to helm.InternalCatalog
 	localReferenceBranch = "refs/heads/"
+	CommitMode           = "commit"
+	BranchMode           = "branch"
 )
 
 func gitDir(namespace, name, gitURL string) string {
@@ -38,6 +40,37 @@ func isBundled(directory string) bool {
 
 func isLocalBranch(branch string) bool {
 	return strings.HasPrefix(branch, localReferenceBranch)
+}
+
+// isValidCommitHash checks if the provided input string is a valid git commit hash
+//   - true: if valid
+//   - false; if invalid
+func isValidCommitHash(input string) bool {
+	// Define a regular expression pattern for Git commit hashes.
+	commitHashPattern := "^[0-9a-fA-F]{40}$"
+
+	// Compile the regular expression pattern.
+	regex, err := regexp.Compile(commitHashPattern)
+	if err != nil {
+		// Handle regex compilation error, if any.
+		fmt.Println("Error compiling regex:", err)
+		return false
+	}
+
+	// Use the regular expression to match the input string.
+	return regex.MatchString(input)
+}
+
+// checkReference will test if the provided reference is a commit or a branch.
+// Returns a constant string telling what the reference is.
+//   - "commit"; Valid Commit Hash;
+//   - "branch";
+func checkReference(reference string) string {
+	commit := isValidCommitHash(reference)
+	if commit {
+		return CommitMode
+	}
+	return BranchMode
 }
 
 // isGitSSH checks if the url is parsable to ssh url standard

--- a/pkg/catalogv2/git/utils.go
+++ b/pkg/catalogv2/git/utils.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	plumbing "github.com/go-git/go-git/v5/plumbing"
 )
 
 const (
@@ -42,31 +44,12 @@ func isLocalBranch(branch string) bool {
 	return strings.HasPrefix(branch, localReferenceBranch)
 }
 
-// isValidCommitHash checks if the provided input string is a valid git commit hash
-//   - true: if valid
-//   - false; if invalid
-func isValidCommitHash(input string) bool {
-	// Define a regular expression pattern for Git commit hashes.
-	commitHashPattern := "^[0-9a-fA-F]{40}$"
-
-	// Compile the regular expression pattern.
-	regex, err := regexp.Compile(commitHashPattern)
-	if err != nil {
-		// Handle regex compilation error, if any.
-		fmt.Println("Error compiling regex:", err)
-		return false
-	}
-
-	// Use the regular expression to match the input string.
-	return regex.MatchString(input)
-}
-
 // checkReference will test if the provided reference is a commit or a branch.
 // Returns a constant string telling what the reference is.
 //   - "commit"; Valid Commit Hash;
 //   - "branch";
 func checkReference(reference string) string {
-	commit := isValidCommitHash(reference)
+	commit := plumbing.IsHash(reference)
 	if commit {
 		return CommitMode
 	}

--- a/pkg/catalogv2/git/utils.go
+++ b/pkg/catalogv2/git/utils.go
@@ -10,8 +10,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-
-	plumbing "github.com/go-git/go-git/v5/plumbing"
 )
 
 const (
@@ -42,18 +40,6 @@ func isBundled(directory string) bool {
 
 func isLocalBranch(branch string) bool {
 	return strings.HasPrefix(branch, localReferenceBranch)
-}
-
-// checkReference will test if the provided reference is a commit or a branch.
-// Returns a constant string telling what the reference is.
-//   - "commit"; Valid Commit Hash;
-//   - "branch";
-func checkReference(reference string) string {
-	commit := plumbing.IsHash(reference)
-	if commit {
-		return CommitMode
-	}
-	return BranchMode
 }
 
 // isGitSSH checks if the url is parsable to ssh url standard

--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -150,7 +150,7 @@ func (r *repoHandler) ensure(repoSpec *catalog.RepoSpec, status catalog.RepoStat
 		return status, err
 	}
 
-	return status, repo.Ensure(status.Commit)
+	return status, repo.Ensure(status.Commit, status.Branch)
 }
 
 func (r *repoHandler) createOrUpdateMap(namespace, name string, index *repo.IndexFile, owner metav1.OwnerReference) (*corev1.ConfigMap, error) {

--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -134,7 +134,7 @@ func toOwnerObject(namespace string, owner metav1.OwnerReference) runtime.Object
 // checks are made to determine whether the repo exists and is ready.
 func (r *repoHandler) ensure(repoSpec *catalog.RepoSpec, status catalog.RepoStatus, metadata *metav1.ObjectMeta) (catalog.RepoStatus, error) {
 	// related ClusterRepo Status is not updated by download handler yet
-	if status.Branch == "" || status.Branch != repoSpec.GitBranch {
+	if status.Commit == "" {
 		return status, nil
 	}
 

--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -150,7 +150,7 @@ func (r *repoHandler) ensure(repoSpec *catalog.RepoSpec, status catalog.RepoStat
 		return status, err
 	}
 
-	return status, repo.Ensure(status.Branch)
+	return status, repo.Ensure(status.Commit)
 }
 
 func (r *repoHandler) createOrUpdateMap(namespace, name string, index *repo.IndexFile, owner metav1.OwnerReference) (*corev1.ConfigMap, error) {


### PR DESCRIPTION
GitHub Issue - https://github.com/rancher/rancher/issues/43021
GitHub Issue - https://github.com/rancher/rancher/issues/39532
 
# Problem
The release blocker was happening because of the solution implemented for this old bug:
This is the fix implemented at the time:https://github.com/rancher/rancher/issues/39532
This is the fix implemented at the time: https://github.com/rancher/rancher/pull/42367

This was breaking follower pods from resetting to the right commit.

# Solution
This was breaking follower pods from resetting to the right commit.
We changed the hardReset approach to a checkout-to-commit approach.
This way we ensure the right behavior without causing the old bug (checkout to commit changes to the work tree but does not erase the index log)
