### PR TITLE
Changing Ensure Handler strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ all.yaml
 kustomization.yaml
 kontainer-engine
 **/coverage.out
+Dockerfile.dapper*
+rancher_debug

--- a/pkg/catalogv2/git/download.go
+++ b/pkg/catalogv2/git/download.go
@@ -55,8 +55,8 @@ func (r *Repository) Head(branch string) (string, error) {
 }
 
 // CheckUpdate will check if rancher is in bundled mode,
-// if it is not in bundled mode, will make an update.
-// if it is in bundled mode, will just call Head method.
+// if it is not in bundled mode, it will make an update.
+// if it is in bundled mode, will just call Head method since we never update on this mode.
 func (r *Repository) CheckUpdate(branch, systemCatalogMode string) (string, error) {
 	if isBundled(r.Directory) && systemCatalogMode == "bundled" {
 		return r.Head(branch)

--- a/pkg/catalogv2/git/git.go
+++ b/pkg/catalogv2/git/git.go
@@ -270,29 +270,20 @@ func (r *Repository) getCurrentCommit() (plumbing.Hash, error) {
 }
 
 // fetchAndReset is a convenience method that fetches updates from the remote repository
-// for a specific branch, and then resets the current branch to a specified commit.
+// for a specific branch, and then resets the current branch.
 func (r *Repository) fetchAndReset(branch string) error {
 	if err := r.fetch(branch); err != nil {
 		return fmt.Errorf("fetchAndReset failure: %w", err)
 	}
-
 	return r.hardReset(branch)
 }
 
-// updateRefSpec updates the reference specification (RefSpec) in the fetch options
+// updateRefSpec updates the branch specification (RefSpec) in the fetch options
 // of the repository operation.
 //   - If a branch name is provided, it sets the RefSpec to fetch that specific branch.
-//   - Otherwise, it sets the RefSpec to fetch all branches.
-//
-// fetching the last commit of one branch is faster than fetching from all branches.
 func (r *Repository) updateRefSpec(branch string) {
-	var newRefSpec string
 
-	if branch != "" {
-		newRefSpec = fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branch, branch)
-	} else {
-		newRefSpec = "+refs/heads/*:refs/remotes/origin/*"
-	}
+	newRefSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branch, branch)
 
 	if len(r.fetchOpts.RefSpecs) > 0 {
 		r.fetchOpts.RefSpecs[0] = config.RefSpec(newRefSpec)

--- a/pkg/catalogv2/git/git.go
+++ b/pkg/catalogv2/git/git.go
@@ -325,7 +325,10 @@ func (r *Repository) hardReset(reference string) error {
 			return fmt.Errorf("hardReset failure to get current commit: %w", err)
 		}
 		resetOpts.Commit = commitHash
+	case plumbing.IsHash(reference):
+		resetOpts.Commit = plumbing.NewHash(reference)
 	default:
+		// When we don't have the branch locally, get the remote reference for it and make a local reference
 		branchRef, err := r.repoGogit.Reference(plumbing.NewRemoteReferenceName("origin", reference), false)
 		if err != nil {
 			return fmt.Errorf("hardReset failure to get branch reference: %w", err)

--- a/pkg/catalogv2/git/git.go
+++ b/pkg/catalogv2/git/git.go
@@ -301,7 +301,7 @@ func (r *Repository) updateRefSpec(branch string) {
 	}
 }
 
-// fetch fetches updates from the remote repository for a specific branch.
+// fetch fetches updates from the remote repository for a specific (branch).
 // If the fetch operation is already up-to-date, this is not treated as an error.
 // Any other error that occurs during fetch is returned.
 func (r *Repository) fetch(branch string) error {
@@ -316,7 +316,7 @@ func (r *Repository) fetch(branch string) error {
 	return nil
 }
 
-// hardReset performs a hard reset of the git repository to a specific commit.
+// hardReset performs a hard reset of the git repository to a specific commit or branch or HEAD reference.
 func (r *Repository) hardReset(reference string) error {
 	var err error
 	resetOpts := r.resetOpts
@@ -342,7 +342,7 @@ func (r *Repository) hardReset(reference string) error {
 		resetOpts.Commit = branchRef.Hash()
 	}
 
-	// Validate hashCommit and reset options
+	// Validate reset options
 	err = resetOpts.Validate(r.repoGogit)
 	if err != nil {
 		return fmt.Errorf("hardReset validation failure: %w", err)

--- a/pkg/controllers/dashboard/helm/repo.go
+++ b/pkg/controllers/dashboard/helm/repo.go
@@ -134,7 +134,7 @@ func toOwnerObject(namespace string, owner metav1.OwnerReference) runtime.Object
 // checks are made to determine whether the repo exists and is ready.
 func (r *repoHandler) ensure(repoSpec *catalog.RepoSpec, status catalog.RepoStatus, metadata *metav1.ObjectMeta) (catalog.RepoStatus, error) {
 	// related ClusterRepo Status is not updated by download handler yet
-	if status.Branch == "" || status.Branch != repoSpec.GitBranch {
+	if status.Commit == "" {
 		return status, nil
 	}
 
@@ -150,7 +150,7 @@ func (r *repoHandler) ensure(repoSpec *catalog.RepoSpec, status catalog.RepoStat
 		return status, err
 	}
 
-	return status, repo.Ensure(status.Branch)
+	return status, repo.Ensure(status.Commit, status.Branch)
 }
 
 func (r *repoHandler) createOrUpdateMap(namespace, name string, index *repo.IndexFile, owner metav1.OwnerReference) (*corev1.ConfigMap, error) {


### PR DESCRIPTION
# Issues

 
# Problem
The release blocker was happening because of the solution implemented for this old bug:
This is the fix implemented at the time:https://github.com/rancher/rancher/issues/39532
This is the fix implemented at the time: https://github.com/rancher/rancher/pull/42367

This was breaking follower pods from resetting to the right commit.

# Solution
This was breaking follower pods from resetting to the right commit.
We changed the hardReset approach to a checkout-to-commit approach.
This way we ensure the right behavior without causing the old bug (checkout to commit changes to the work tree but does not erase the index log)
