### PR TITLE
[v2.8] Refactor provisioning READMEs

### DIFF
--- a/tests/v2/validation/certrotation/README.md
+++ b/tests/v2/validation/certrotation/README.md
@@ -1,17 +1,21 @@
 # Certificate Rotation
 
+For certificate rotation, the test has only been tested on RKE2. That does not mean RKE1 or K3S are unsupported, they just have not been tested. These tests are designed to accept an existing cluster that the user has access to. If you do not have a downstream cluster in Rancher, you should create one first before running these tests.
+
+Please see below for more details for your config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
+
+## Table of Contents
+1. [Getting Started](#Getting-Started)
+
 ## Getting Started
-Your GO suite should be set to `-run ^TestCertRotation$`. You can find specific tests by checking the test file you plan to run.
 In your config file, set the following:
-```json
-"rancher": { 
-  "host": "rancher_server_address",
-  "adminToken": "rancher_admin_token",
-  "userToken": "your_rancher_user_token",
-  "clusterName": "cluster_to_run_tests_on",
-  "insecure": true/optional,
-  "cleanup": false/optional,
-}
+```yaml
+rancher:
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  clusterName: "cluster_to_run_tests_on"
+  insecure: true/optional
+  cleanup: false/optional
 ```
 
 Typically, a cluster with the following 3 pools is used for testing:
@@ -30,6 +34,10 @@ Typically, a cluster with the following 3 pools is used for testing:
     Quantity: 1,
   },
 }
-  ```
-These tests are designed to accept an existing cluster that the user has access to. If you do not have a downstream cluster in rancher, you should create one first before running this test. 
-Untested on k3s nor rke1.
+```
+
+These tests utilize Go build tags. Due to this, see the below example on how to run the tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/certrotation --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestCertRotation/TestCertRotation"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.

--- a/tests/v2/validation/deleting/README.md
+++ b/tests/v2/validation/deleting/README.md
@@ -1,15 +1,29 @@
 # Deleting
 
+For deleting clusters, the following cluster types are supported for both node drivers and custom clusters: RKE1, RKE2, K3S. These tests are designed to accept an existing cluster that the user has access to. If you do not have a downstream cluster in Rancher, you should create one first before running these tests.
+
+Please see below for more details for your config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
+
+## Table of Contents
+1. [Getting Started](#Getting-Started)
+
 ## Getting Started
-You can find specific tests by checking the test file you plan to run. An example is `-run ^ TestClusterDeleteTestSuite/TestDeletingRKE2K3SCluster$`
 In your config file, set the following:
-```json
-"rancher": { 
-  "host": "rancher_server_address",
-  "adminToken": "rancher_admin_token",
-  "userToken": "your_rancher_user_token",
-  "clusterName": "cluster_to_run_tests_on",
-  "insecure": true/optional,
-  "cleanup": false/optional,
-}
+```yaml
+rancher:
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  clusterName: "cluster_to_run_tests_on"
+  insecure: true/optional
+  cleanup: false/optional
 ```
+
+These tests utilize Go build tags. Due to this, see the below examples on how to run the tests:
+
+### RKE1
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/deleting --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestRKE1ClusterDeleteTestSuite/TestDeletingRKE1Cluster"`
+
+### RKE2 | K3S
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/deleting --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestClusterDeleteTestSuite/TestDeletingCluster"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.

--- a/tests/v2/validation/nodescaling/README.md
+++ b/tests/v2/validation/nodescaling/README.md
@@ -105,3 +105,5 @@ These tests utilize Go build tags. Due to this, see the below examples on how to
 ### GKE
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/nodescaling --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestGKENodeScalingTestSuite/TestScalingGKENodePools"` \
 `gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/nodescaling --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestGKENodeScalingTestSuite/TestScalingGKENodePoolsDynamicInput"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.

--- a/tests/v2/validation/prime/README.md
+++ b/tests/v2/validation/prime/README.md
@@ -1,21 +1,22 @@
 # Prime Configs
 
+## Table of Contents
+1. [Getting Started](#Getting-Started)
+
 ## Getting Started
 Your GO suite should be set to `-run ^TestPrimeTestSuite$`. You can find any additional suite name(s) by checking the test file you plan to run.
 
 In your config file, set the following:
-```json
-"rancher": { 
-  "host": "rancher_server_address",
-  "adminToken": "rancher_admin_token"
-  ...,
-}
-"prime": {
-  "brand": "<name of brand>",
-  "isPrime": false, //boolean, default is false
-  "rancherVersion": "<version_or_commit_of_rancher>",
-  "registry": "<name of registry>"
-}
+```yaml
+rancher: 
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  ...
+prime:
+  brand: "<name of brand>"
+  isPrime: false  #boolean, default is false
+  rancherVersion: "<version_or_commit_of_rancher>"
+  registry: "<name of registry>
 ```
 
-if isPrime is `true`, we will also check that the ui-brand is correctly set. For the `TestPrimeVersion` test case, your Rancher URL that is passed must used a secure certificate. If an insecure certificate is recognized, then the test will fail; this is expected.
+if isPrime is `true`, we will also check that the ui-brand is correctly set. For the `TestPrimeVersion` test case, your Rancher URL that is passed must use a secure certificate. If an insecure certificate is recognized, then the test will fail; this is expected.

--- a/tests/v2/validation/provisioning/README.md
+++ b/tests/v2/validation/provisioning/README.md
@@ -1,17 +1,22 @@
 # Provisioning Configs
 
+## Table of Contents
+1. [Getting Started](#Getting-Started)
+2. [Cluster Type READMEs](#Cluster-Type-READMEs)
+
 ## Getting Started
 Your GO suite should be set to `-run ^Test<enter_pkg_name_here>ProvisioningTestSuite$`. You can find the correct suite name in the below README links, or by checking the test file you plan to run.
 In your config file, set the following:
-```json
-"rancher": { 
-  "host": "rancher_server_address",
-  "adminToken": "rancher_admin_token",
-  "userToken": "your_rancher_user_token",
-  "insecure": true/optional,
-  "cleanup": false/optional,
-}
+```yaml
+rancher:
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  cleanup: false
+  insecure: true/optional
+  cleanup: false/optional
 ```
+
+## Cluster Type READMEs
 
 From there, your config should contain the tests you want to run (provisioningInput), tokens and configuration for the provider(s) you will use, and any additional tests that you may want to run. Please use one of the following links to continue adding to your config for provisioning tests:
 

--- a/tests/v2/validation/provisioning/hosted/README.md
+++ b/tests/v2/validation/provisioning/hosted/README.md
@@ -4,7 +4,7 @@ For your config, you will need everything in the [Prerequisites](../README.md) s
 
 Your GO test_package should be set to `provisioning/hosted`.
 Your GO suite should be set to `-run ^TestHostedClusterProvisioningTestSuite$`.
-Please see below for more details for your config. 
+Please see below for more details for your config. Please see below for more details for your config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
 
 ## Table of Contents
 1. [Prerequisites](../README.md)
@@ -17,104 +17,120 @@ Below are example configs needed for the different hosted providers including GK
 ## Cloud Credentials
 
 ### AWS
-```json
-"awsCredentials": {
-   "secretKey": "",
-   "accessKey": "",
-   "defaultRegion": ""
-  },
+```yaml
+awsCredentials:
+  secretKey: "",
+  accessKey: "",
+  defaultRegion: ""
 ```
 ### Azure
-```json
-"azureCredentials": {
-   "clientId": "",
-   "clientSecret": "",
-     "subscriptionId": "",
-     "environment": "AzurePublicCloud"
-  },
+```yaml
+azureCredentials:
+  clientId: "",
+  clientSecret: "",
+  subscriptionId: "",
+  environment: "AzurePublicCloud"
 ```
 ### Google
-```json
-"googleCredentials": {
-    "authEncodedJson": ""
-}
+```yaml
+googleCredentials:
+  authEncodedJson: |-
+    {
+      "type": "",
+      "project_id": "",
+      "private_key_id": "",
+      "private_key": "",
+      "client_email": "",
+      "client_id": "",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token",
+      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+      "client_x509_cert_url": ""
+    }
 ```
 
 ## Hosted Provider Configs
 
 ### EKS Cluster Config
-```json
-"eksClusterConfig": {
-  "imported": false,
-  "kmsKey": "",
-  "kubernetesVersion": "1.26",
-  "loggingTypes": [],
-  "nodeGroups": [
-    {
-      "desiredSize": 2,
-      "diskSize": 20,
-      "ec2SshKey": "",
-      "gpu": false,
-      "imageId": "",
-      "instanceType": "t3.medium",
-      "labels": {},
-      "maxSize": 2,
-      "minSize": 2,
-      "nodegroupName": "",
-      "requestSpotInstances": false,
-      "resourceTags": {},
-      "subnets": [],
-      "tags": {}
-
-    }
-  ],
-  "privateAccess": true,
-  "publicAccess": true,
-  "publicAccessSources": [],
-  "region": "us-east-2",
-  "secretsEncryption": false,
-  "securityGroups": [""],
-  "serviceRole": "",
-  "subnets": ["", ""],
-  "tags": {}
-},
+```yaml
+eksClusterConfig:
+  imported: false
+  kmsKey: ""
+  kubernetesVersion: "1.26"
+  loggingTypes: []
+  nodeGroups:
+  - desiredSize: 3
+    diskSize: 50
+    ec2SshKey: ""
+    gpu: false
+    imageId: ""
+    instanceType: t3.medium
+    labels: {}
+    maxSize: 10
+    minSize: 1
+    nodeRole: ""
+    nodegroupName: ""
+    requestSpotInstances: false
+    resourceTags: {}
+    spotInstanceTypes: []
+    subnets: []
+    tags: {}
+    userData: ""
+    version: "1.26"
+  privateAccess: false
+  publicAccess: true
+  publicAccessSources: []
+  region: us-east-2
+  secretsEncryption: false
+  securityGroups:
+  -
+  serviceRole: ""
+  subnets:
+  -
+  -
+  tags: {}
 ```
 
-See an example on running this test: `run ^TestHostedEKSClusterProvisioningTestSuite/TestProvisioningHostedEKS$`
+These tests utilize Go build tags. Due to this, see the below example on how to run the test: 
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/hosted --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestHostedEKSClusterProvisioningTestSuite/TestProvisioningHostedEKS"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.
 
 ### AKS Cluster Config
-```json
-"aksClusterConfig": {
-  "dnsPrefix": "-dns",
-  "imported": false,
-  "kubernetesVersion": "1.26.6",
-  "linuxAdminUsername": "azureuser",
-  "loadBalancerSku": "Standard",
-  "networkPlugin": "kubenet",
-  "nodePools": [
-    {
-      "availabilityZones": ["1", "2", "3"],
-      "nodeCount": 1,
-      "enableAutoScaling": false,
-      "maxPods": 110,
-      "maxCount": 2,
-      "minCount": 1,
-      "mode": "System",
-      "name": "agentpool",
-      "osDiskSizeGB": 128,
-      "osDiskType": "Managed",
-      "osType": "Linux",
-      "vmSize": "Standard_DS2_v2"
-    }
-  ],
-  "privateCluster": false,
-  "resourceGroup": "",
-  "resourceLocation": "eastus",
-  "tags": {}
-}
+```yaml
+aksClusterConfig:
+  dnsPrefix: ""
+  kubernetesVersion: "1.26.6"
+  linuxAdminUsername: "azureuser"
+  loadBalancerSku: "Standard"
+  networkPlugin: "kubenet"
+  nodePools:
+  - availabilityZones:
+    - "1"
+    - "2"
+    - "3"
+    enableAutoScaling: false
+    maxPods: 110
+    maxCount: 10
+    minCount: 3
+    mode: "System"
+    name: "agentpool"
+    nodeCount: 3
+    osDiskSizeGB: 128
+    osDiskType: "Managed"
+    osType: "Linux"
+    vmSize: "Standard_DS2_v2"
+  resourceGroup: ""
+  resourceLocation: ""
+  tags: {}
 ```
 
-See an example on running this test: `run ^TestHostedAKSClusterProvisioningTestSuite/TestProvisioningHostedAKS$`
+These tests utilize Go build tags. Due to this, see the below example on how to run the test: 
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/hosted --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestHostedAKSClusterProvisioningTestSuite/TestProvisioningHostedAKS"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.
 
 ### GKE Cluster Config
 Note that the following are required and should be updated:
@@ -127,87 +143,78 @@ Note that the following are required and should be updated:
 * nodePools->labels
 * nodePools->config->imageType (currently set to COS_CONTAINERD for use with 1.23+)
 
-```json
-"gkeClusterConfig" : {
-  "clusterAddons": {
-    "horizontalPodAutoscaling": true, 
-    "httpLoadBalancing": true, 
-    "networkPolicyConfig": false
-  },
-  "horizontalPodAutoscaling": true,
-  "httpLoadBalancing": true,
-  "networkPolicyConfig": false,
-  "clusterIpv4Cidr": "",
-  "enableKubernetesAlpha": false,
-  "ipAllocationPolicy": {
-    "clusterIpv4Cidr": "",
-    "clusterIpv4CidrBlock": null,
-    "clusterSecondaryRangeName": null,
-    "createSubnetwork": false,
-    "nodeIpv4CidrBlock": null,
-    "servicesIpv4CidrBlock": null,
-    "servicesSecondaryRangeName": null,
-    "subnetworkName": null,
-    "useIpAliases": true
-  },
-  "kubernetesVersion": "1.26.8-gke.200",
-  "labels": {"key": "value"},
-  "locations": ["us-central1-c"],
-  "location": "us-central1-c"
-  "loggingService": "logging.googleapis.com/kubernetes",
-  "maintenanceWindow": "",
-  "masterAuthorizedNetworks": {
-    "enabled": false
-  },
-  "monitoringService": "monitoring.googleapis.com/kubernetes",
-  "network": "default",
-  "networkPolicyEnabled": false,
-  "nodePools": [
-    {
-      "autoscaling": {
-        "enabled": false,
-        "maxNodeCount": null,
-        "minNodeCount": null
-      },
-      "config": {
-        "diskSizeGb": 100,
-        "diskType": "pd-standard",
-        "imageType": "COS_CONTAINERD",
-        "labels": {"key": "value"},
-        "localSsdCount": 0,
-        "machineType": "n1-standard-2",
-        "oauthScopes": [
-          "https://www.googleapis.com/auth/devstorage.read_only",
-          "https://www.googleapis.com/auth/logging.write",
-          "https://www.googleapis.com/auth/monitoring",
-          "https://www.googleapis.com/auth/servicecontrol",
-          "https://www.googleapis.com/auth/service.management.readonly",
-          "https://www.googleapis.com/auth/trace.append"
-        ],
-        "preemptible": false,
-        "tags": null,
-        "taints": null
-      },
-      "initialNodeCount": 3,
-      "isNew": true,
-      "management": {
-        "autoRepair": true, 
-        "autoUpgrade": true
-      },
-      "maxPodsConstraint": 110,
-      "name": ""
-    }
-  ],
-  "privateClusterConfig": {
-    "enablePrivateEndpoint": false, 
-    "enablePrivateNodes": false, 
-    "masterIpv4CidrBlock": null
-  },
-  "projectID": "",
-  "region": "",
-  "subnetwork": "default",
-  "zone": "us-central1-c"
-}
+```yaml
+gkeClusterConfig:
+  clusterAddons:
+    horizontalPodAutoscaling: true
+    httpLoadBalancing: true
+    networkPolicyConfig: false
+  clusterIpv4Cidr: ""
+  enableKubernetesAlpha: false
+  horizontalPodAutoscaling: true
+  httpLoadBalancing: true
+  ipAllocationPolicy:
+    clusterIpv4Cidr: ""
+    clusterIpv4CidrBlock: null
+    clusterSecondaryRangeName: null
+    createSubnetwork: false
+    nodeIpv4CidrBlock: null
+    servicesIpv4CidrBlock: null
+    servicesSecondaryRangeName: null
+    subnetworkName: null
+    useIpAliases: true
+  kubernetesVersion: 1.26.8-gke.200
+  labels: {}
+  locations: []
+  loggingService: logging.googleapis.com/kubernetes
+  maintenanceWindow: ""
+  masterAuthorizedNetworks:
+    enabled: false
+  monitoringService: monitoring.googleapis.com/kubernetes
+  network: default
+  networkPolicyConfig: false
+  networkPolicyEnabled: false
+  nodePools:
+  - autoscaling:
+      enabled: false
+      maxNodeCount: null
+      minNodeCount: null
+    config:
+      diskSizeGb: 100
+      diskType: pd-standard
+      imageType: COS_CONTAINERD
+      labels: {}
+      localSsdCount: 0
+      machineType: n1-standard-2
+      oauthScopes:
+      - https://www.googleapis.com/auth/devstorage.read_only
+      - https://www.googleapis.com/auth/logging.write
+      - https://www.googleapis.com/auth/monitoring
+      - https://www.googleapis.com/auth/servicecontrol
+      - https://www.googleapis.com/auth/service.management.readonly
+      - https://www.googleapis.com/auth/trace.append
+      preemptible: false
+      tags: null
+      taints: null
+    initialNodeCount: 3
+    isNew: true
+    management:
+      autoRepair: true
+      autoUpgrade: true
+    maxPodsConstraint: 110
+    name: markus-automation
+  privateClusterConfig:
+    enablePrivateEndpoint: false
+    enablePrivateNodes: false
+    masterIpv4CidrBlock: null
+  projectID: ""
+  region: ""
+  subnetwork: default
+  zone: us-central1-c
 ```
 
-See an example on running this test: `run ^TestHostedGKEClusterProvisioningTestSuite/TestProvisioningHostedGKE$`
+These tests utilize Go build tags. Due to this, see the below example on how to run the test: 
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/hosted --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestHostedGKEClusterProvisioningTestSuite/TestProvisioningHostedGKE"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.

--- a/tests/v2/validation/provisioning/hostnametruncation/README.md
+++ b/tests/v2/validation/provisioning/hostnametruncation/README.md
@@ -1,0 +1,54 @@
+# Hostname Truncation
+
+For your config, you can directly reference the [RKE2 README](../rke2/README.md), specifically, for the prequisites, provisioning input, cloud credentials and machine RKE2 configuration.
+
+Your GO test_package should be set to `hostnametruncation`.
+Your GO suite should be set to `-run ^TestHostnameTruncationTestSuite$`.
+Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
+
+## Table of Contents
+1. [Getting Started](#Getting-Started)
+
+## Getting Started
+See below a sample config file to run this test:
+```yaml
+rancher:
+  host: ""
+  adminToken: ""
+  clusterName: ""
+provisioningInput:
+  machinePools:
+  - nodeRoles:
+      etcd: true
+      quantity: 1
+  - nodeRoles:
+      controlplane: true
+      quantity: 1
+  - nodeRoles:
+      worker: true
+      quantity: 1
+  rke2KubernetesVersion: ["v1.27.6+rke2r1"]
+  cni: ["calico"]
+  providers: ["linode"]
+linodeCredentials:
+   token: ""
+linodeMachineConfig:
+  authorizedUsers: ""
+  createPrivateIp: true
+  dockerPort: "2376"
+  image: "linode/ubuntu22.04"
+  instanceType: "g6-standard-8"
+  region: "us-west"
+  rootPass: ""
+  sshPort: "22"
+  sshUser: ""
+  stackscript: ""
+  stackscriptData: ""
+  swapSize: "512"
+  tags: ""
+  uaPrefix: "Rancher"
+```
+
+These tests utilize Go build tags. Due to this, see the below example on how to run the test:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/hostnametruncation --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestHostnameTruncationTestSuite/TestProvisioningRKE2ClusterTruncation"`

--- a/tests/v2/validation/provisioning/k3s/README.md
+++ b/tests/v2/validation/provisioning/k3s/README.md
@@ -1,12 +1,12 @@
-
 # K3S Provisioning Configs
 
 For your config, you will need everything in the Prerequisites section on the previous readme, [Define your test](#provisioning-input), and at least one [Cloud Credential](#cloud-credentials) and [Node Driver Machine Config](#machine-k3s-config) or [Custom Cluster Template](#custom-cluster), which should match what you have specified in `provisioningInput`. 
 
 Your GO test_package should be set to `provisioning/k3s`.
 Your GO suite should be set to `-run ^TestK3SProvisioningTestSuite$`.
-Please see below for more details for your config. 
+Please see below for more details for your config. Please see below for more details for your config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
 
+## Table of Contents
 1. [Prerequisites](../README.md)
 2. [Define your test](#provisioning-input)
 3. [Cloud Credential](#cloud-credentials)
@@ -16,256 +16,254 @@ Please see below for more details for your config.
 7. [Back to general provisioning](../README.md)
 
 ## Provisioning Input
-provisioningInput is needed to the run the K3S tests, specifically kubernetesVersion and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". psact is optional and takes values `rancher-privileged` and `rancher-restricted` only.
+provisioningInput is needed to the run the K3S tests, specifically kubernetesVersion and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". psact is optional and takes values `rancher-privileged`, `rancher-restricted` or `rancher-baseline`.
 
 **nodeProviders is only needed for custom cluster tests; the framework only supports custom clusters through aws/ec2 instances.**
-
-```json
-"provisioningInput": {
-    // for custom clusters, len(nodesAndRoles) should be equal to len(awsEc2Config)
-        "machinePools": [
-      {
-        "nodeRoles": {
-          "etcd": true,
-          "controlplane": true,
-          "worker": false,
-          "quantity": 1,
-        },
-      },
-      {
-        "nodeRoles": {
-          "worker": true,
-          "quantity": 2,
-          "drainBeforeDelete": true,
-        },
-        "nodeLabels" {
-          "label1": "value1",
-          "label2": "value2",
-        },
-        "nodeTaints" [
-          { "key": "TestKey",
-            "value": "testValue",
-            "effect": "NoSchedule",
-          }
-        ],
-        "specifyPrivateIP": false,
-        "specifyPublicIP": true,
-        "nodeNamePrefix": "qa",
-      },
-    ],
-    "flags": {
-      "desiredflags": "Long" //These flags are for running TestProvisioningK3SCluster or TestProvisioningK3SCustomCluster it is not needed for the dynamic tests. Long will run the full table, where as short will run the short version of this test.
-    },
-    "k3sKubernetesVersion": ["v1.26.8+k3s1"],
-    "providers": ["linode", "aws", "azure", "harvester"],
-    "nodeProviders": ["ec2"],
-    "hardened": true,
-    "psact": ""
-  }
+```yaml
+provisioningInput:
+  machinePools:
+  - nodeRoles:
+      etcd: true
+      controlplane: true
+      worker: true
+      quantity: 1
+  - nodeRoles:
+      worker: true
+      quantity: 2
+  - nodeRoles:
+      windows: true
+      quantity: 1
+  flags:
+    desiredflags: "Long" #These flags are for running TestProvisioningK3SCluster or TestProvisioningK3SCustomCluster it is not needed for the dynamic tests. Long will run the full table, where as short will run the short version of this test.
+  rke2KubernetesVersion: ["v1.27.6+k3s1"]
+  providers: ["linode", "aws", "do", "harvester"]
+  nodeProviders: ["ec2"]
+  hardened: false
+  psact: ""
 ```
 
 ## Cloud Credentials
 These are the inputs needed for the different node provider cloud credentials, inlcuding linode, aws, harvester, azure, and google.
 
+### Digital Ocean
+```yaml
+digitalOceanCredentials:
+  accessToken: ""
+```
 ### Linode
-```json
-"linodeCredentials": {
-   "token": ""
-  },
+```yaml
+linodeCredentials:
+  token: ""
 ```
 ### Azure
-```json
-"azureCredentials": {
-   "clientId": "",
-   "clientSecret": "",
-     "subscriptionId": "",
-     "environment": "AzurePublicCloud"
-  },
+```yaml
+azureCredentials:
+  clientId: ""
+  clientSecret: ""
+  subscriptionId": ""
+  environment: "AzurePublicCloud"
 ```
 ### AWS
-```json
-"awsCredentials": {
-   "secretKey": "",
-   "accessKey": "",
-   "defaultRegion": ""
-  },
+```yaml
+awsCredentials:
+  secretKey: "",
+  accessKey: "",
+  defaultRegion: ""
 ```
 ### Harvester
-```json
-"harvesterCredentials": {
-   "clusterId": "",
-   "clusterType": "",
-   "kubeconfigContent": ""
-},
+```yaml
+harvesterCredentials:
+  clusterId: "",
+  clusterType: "",
+  kubeconfigContent: ""
 ```
 ### Google
-```json
-"googleCredentials": {
-    "authEncodedJson": ""
-},
+```yaml
+googleCredentials:
+  authEncodedJson: ""
 ```
 ### VSphere
-```json
-"vmwarevsphereCredentials": {
-  "password": "",
-  "username": "",
-  "vcenter": "",
-  "vcenterPort": "",
-}
+```yaml
+vmwarevsphereCredentials:
+  password: ""
+  username: ""
+  vcenter: ""
+  vcenterPort: ""
 ```
 
 ## Machine K3S Config
 Machine K3S config is the final piece needed for the config to run K3S provisioning tests.
 
 ### AWS K3S Machine Config
-```json
-"awsMachineConfig": {
-    "region": "us-east-2",
-    "ami": "",
-    "instanceType": "t3a.medium",
-    "sshUser": "ubuntu",
-    "vpcId": "",
-    "volumeType": "gp2",
-    "zone": "a",
-    "retries": "5",
-    "rootSize": "16",
-    "securityGroup": ["rancher-nodes"]
-},
+```yaml
+awsMachineConfig:
+  region: "us-east-2"
+  ami: ""
+  instanceType: "t3a.medium"
+  sshUser: "ubuntu"
+  vpcId: ""
+  volumeType: "gp2"
+  zone: "a"
+  retries: "5"
+  rootSize: "60"
+  securityGroup: [""]
+```
+### Digital Ocean K3S Machine Config
+```yaml
+doMachineConfig:
+  image: "ubuntu-20-04-x64"
+  backups: false
+  ipv6: false
+  monitoring: false
+  privateNetworking: false
+  region: "nyc3"
+  size: "s-2vcpu-4gb"
+  sshKeyContents: ""
+  sshKeyFingerprint: ""
+  sshPort: "22"
+  sshUser: "root"
+  tags: ""
+  userdata: ""
 ```
 ### Linode K3S Machine Config
-```json
-"linodeMachineConfig": {
-  "authorizedUsers": "",
-  "createPrivateIp": false,
-  "dockerPort": "2376",
-  "image": "linode/ubuntu20.04",
-  "instanceType": "g6-standard-2",
-  "region": "us-west",
-  "rootPass": "",
-  "sshPort": "22",
-  "sshUser": "",
-  "stackscript": "",
-  "stackscriptData": "",
-  "swapSize": "512",
-  "tags": "",
-  "uaPrefix": ""
-},
+```yaml
+linodeMachineConfig:
+  authorizedUsers: ""
+  createPrivateIp: true
+  dockerPort: "2376"
+  image: "linode/ubuntu22.04"
+  instanceType: "g6-standard-8"
+  region: "us-west"
+  rootPass: ""
+  sshPort: "22"
+  sshUser: ""
+  stackscript: ""
+  stackscriptData: ""
+  swapSize: "512"
+  tags: ""
+  uaPrefix: "Rancher"
 ```
 ### Azure K3S Machine Config
-```json
-"azureMachineConfig": {
-  "availabilitySet": "docker-machine",
-  "diskSize": "30",
-  "environment": "AzurePublicCloud",
-  "faultDomainCount": "3",
-  "image": "canonical:UbuntuServer:18.04-LTS:latest",
-  "location": "westus",
-  "managedDisks": false,
-  "noPublicIp": false,
-  "nsg": "",
-  "openPort": ["6443/tcp", "2379/tcp", "2380/tcp", "8472/udp", "4789/udp", "9796/tcp", "10256/tcp", "10250/tcp", "10251/tcp", "10252/tcp"],
-  "resourceGroup": "docker-machine",
-  "size": "Standard_D2_v2",
-  "sshUser": "docker-user",
-  "staticPublicIp": false,
-  "storageType": "Standard_LRS",
-  "subnet": "docker-machine",
-  "subnetPrefix": "192.168.0.0/16",
-  "updateDomainCount": "5",
-  "usePrivateIp": false,
-  "vnet": "docker-machine-vnet"
-},
+```yaml
+azureMachineConfig:
+  availabilitySet: "docker-machine"
+  diskSize: "30"
+  environment: "AzurePublicCloud"
+  faultDomainCount: "3"
+  image: "canonical:UbuntuServer:22.04-LTS:latest"
+  location: "westus"
+  managedDisks: false
+  noPublicIp: false
+  nsg: ""
+  openPort: ["6443/tcp", "2379/tcp", "2380/tcp", "8472/udp", "4789/udp", "9796/tcp", "10256/tcp", "10250/tcp", "10251/tcp", "10252/tcp"]
+  resourceGroup: "docker-machine"
+  size: "Standard_D2_v2"
+  sshUser: "docker-user"
+  staticPublicIp: false
+  storageType: "Standard_LRS"
+  subnet: "docker-machine"
+  subnetPrefix: "192.168.0.0/16"
+  updateDomainCount: "5"
+  usePrivateIp: false
+  vnet: "docker-machine-vnet"
 ```
 ### Harvester K3S Machine Config
-```json
-"harvesterMachineConfig": {
-  "diskSize": "40",
-  "cpuCount": "2",
-  "memorySize": "8",
-  "networkName": "default/ctw-network-1",
-  "imageName": "default/image-rpj98",
-  "vmNamespace": "default",
-  "sshUser": "ubuntu",
-  "diskBus": "virtio"
-},
+```yaml
+harvesterMachineConfig":
+  diskSize: "40"
+  cpuCount: "2"
+  memorySize: "8"
+  networkName: "default/ctw-network-1"
+  imageName: "default/image-rpj98"
+  vmNamespace: "default"
+  sshUser: "ubuntu"
+  diskBus: "virtio
 ```
-### Vsphere K3S Machine Config
-```json
-"vmwarevsphereMachineConfig": {
-  "cfgparam": ["disk.enableUUID=TRUE"],
-  "cloneFrom": "",
-  "cloudinit": "",
-  "contentLibrary": "",
-  "cpuCount": "4",
-  "creationType": "",
-  "datacenter": "",
-  "datastore": "",
-  "datastoreCluster": "",
-  "diskSize": "20000",
-  "folder": "",
-  "hostSystem": "",
-  "memorySize": "4096",
-  "network": [""],
-  "os": "linux",
-  "password": "",
-  "pool": "",
-  "sshPassword": "",
-  "sshPort": "22",
-  "sshUser": "",
-  "sshUserGroup": "",
-  "username": "",
-  "vcenter": "",
-  "vcenterPort": "443"
-}
+## Vsphere K3S Machine Config
+```yaml
+vmwarevsphereMachineConfig:
+  cfgparam: ["disk.enableUUID=TRUE"]
+  cloneFrom: ""
+  cloudinit: ""
+  contentLibrary: ""
+  cpuCount: "4"
+  creationType: ""
+  datacenter: ""
+  datastore: ""
+  datastoreCluster: ""
+  diskSize: "20000"
+  folder: ""
+  hostSystem: ""
+  memorySize: "4096"
+  network: [""]
+  os: "linux"
+  password: ""
+  pool: ""
+  sshPassword: ""
+  sshPort: "22"
+  sshUser: ""
+  sshUserGroup: ""
+  username: ""
+  vcenter: ""
+  vcenterPort: "443"
 ```
+
+These tests utilize Go build tags. Due to this, see the below examples on how to run the node driver tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/k3s --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestK3SProvisioningTestSuite/TestProvisioningK3SCluster"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/k3s --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestK3SProvisioningTestSuite/TestProvisioningK3SClusterDynamicInput"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.
 
 ## Custom Cluster
 For custom clusters, no machineConfig or credentials are needed. Currently only supported for ec2.
 
 Dependencies:
-* **Ensure you have machinePools in provisioningInput**
-* make sure that all roles are entered at least once in machinePools.nodeRoles
-* ensure that nodeProviders is set
-
-```json
-{
-  "awsEC2Configs": {
-    "region": "us-east-2",
-    "awsSecretAccessKey": "",
-    "awsAccessKeyID": "",
-    "awsEC2Config": [
-      {
-        "instanceType": "t3a.medium",
-        "awsRegionAZ": "",
-        "awsAMI": "",
-        "awsSecurityGroups": [
-          ""
-        ],
-        "awsSSHKeyName": "",
-        "awsCICDInstanceTag": "rancher-validation",
-        "awsIAMProfile": "",
-        "awsUser": "ubuntu",
-        "volumeSize": 25,
-        "roles": ["worker"]
-      },
-      {
-        "instanceType": "t3a.large",
-        "awsRegionAZ": "",
-        "awsAMI": "",
-        "awsSecurityGroups": [
-          ""
-        ],
-        "awsSSHKeyName": "",
-        "awsCICDInstanceTag": "rancher-validation",
-        "awsIAMProfile": "",
-        "awsUser": "ubuntu",
-        "volumeSize": 25,
-        "roles": ["etcd", "contolplane"]
-      },
-    ]
-  }
-}
+* **Ensure you have nodeProviders in provisioningInput**
+* make sure that all roles are entered at least once
+* windows pool(s) should always be last in the config
+```yaml
+  awsEC2Configs:
+  region: "us-east-2"
+  awsSecretAccessKey: ""
+  awsAccessKeyID: ""
+  awsEC2Config:
+    - instanceType: "t3a.medium"
+      awsRegionAZ: ""
+      awsAMI: ""
+      awsSecurityGroups: [""]
+      awsSSHKeyName: ""
+      awsCICDInstanceTag: "rancher-validation"
+      awsIAMProfile: ""
+      awsUser: "ubuntu"
+      volumeSize: 50
+      roles: ["etcd", "controlplane"]
+    - instanceType: "t3a.medium"
+      awsRegionAZ: ""
+      awsAMI: ""
+      awsSecurityGroups: [""]
+      awsSSHKeyName: ""
+      awsCICDInstanceTag: "rancher-validation"
+      awsIAMProfile: ""
+      awsUser: "ubuntu"
+      volumeSize: 50
+      roles: ["worker"]
+    - instanceType: "t3a.xlarge"
+      awsAMI: ""
+      awsSecurityGroups: [""]
+      awsSSHKeyName: ""
+      awsCICDInstanceTag: "rancher-validation"
+      awsUser: "Administrator"
+      volumeSize: 50
+      roles: ["windows"]
 ```
+
+These tests utilize Go build tags. Due to this, see the below examples on how to run the custom cluster tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/k3s --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestCustomClusterK3SProvisioningTestSuite/TestProvisioningK3SCustomCluster"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/k3s --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestCustomClusterK3SProvisioningTestSuite/TestProvisioningK3SCustomClusterDynamicInput"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.
 
 ## Advanced Settings
 This encapsulates any other setting that is applied in the cluster.spec. Currently we have support for:
@@ -278,46 +276,28 @@ Please read up on general k8s to get an idea of correct formatting for:
 * node affinity
 * tolerations
 
-```json
-"advancedOptions": {
-    "clusterAgentCustomization": { // change this to fleetAgentCustomization for fleet agent
-        "appendTolerations": [
-            {
-                "key": "Testkey",
-                "value": "testValue",
-                "effect": "NoSchedule"
-            }
-        ],
-        "overrideResourceRequirements": {
-            "limits": {
-                "cpu": "750m",
-                "memory": "500Mi"
-            },
-            "requests": {
-                "cpu": "250m",
-                "memory": "250Mi"
-            }
-        },
-        "overrideAffinity": {
-            "nodeAffinity": {
-                "preferredDuringSchedulingIgnoredDuringExecution": [
-                    {
-                        "preference": {
-                            "matchExpressions": [
-                                {
-                                    "key": "cattle.io/cluster-agent",
-                                    "operator": "In",
-                                    "values": [
-                                        "true"
-                                    ]
-                                }
-                            ]
-                        },
-                        "weight": 1
-                    }
-                ]
-            }
-        }
-    }
-}
+```yaml
+advancedOptions:
+  clusterAgent: # change this to fleetAgent for fleet agent
+    appendTolerations:
+    - key: "Testkey"
+      value: "testValue"
+      effect: "NoSchedule"
+    overrideResourceRequirements:
+      limits:
+        cpu: "750m"
+        memory: "500Mi"
+      requests:
+        cpu: "250m"
+        memory: "250Mi"
+      overrideAffinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: "cattle.io/cluster-agent"
+                    operator: "In"
+                    values:
+                      - "true"
+              weight: 1
 ```

--- a/tests/v2/validation/provisioning/rke1/README.md
+++ b/tests/v2/validation/provisioning/rke1/README.md
@@ -1,12 +1,12 @@
-
 # RKE1 Provisioning Configs
 
-For your config, you will need everything in the Prerequisites section on the previous readme, [Define your test](#Provisioning-Input), and at least one [Node Driver Cluster Template](#NodeTemplateConfigs) or [Custom Cluster Template](#Custom-Cluster), which should match what you have specified in `provisioningInput`. 
+For your config, you will need everything in the [Prerequisites](../README.md) section on the previous readme, [Define your test](#Provisioning-Input), and at least one [Node Driver Cluster Template](#NodeTemplateConfigs) or [Custom Cluster Template](#Custom-Cluster), which should match what you have specified in `provisioningInput`. 
 
 Your GO test_package should be set to `provisioning/rke1`.
 Your GO suite should be set to `-run ^TestRKE1ProvisioningTestSuite$`.
-Please see below for more details for your config. 
+Please see below for more details for your config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
 
+## Table of Contents
 1. [Prerequisites](../README.md)
 2. [Define your test](#Provisioning-Input)
 3. [Configure providers to use for Node Driver Clusters](#NodeTemplateConfigs)
@@ -15,224 +15,191 @@ Please see below for more details for your config.
 6. [Back to general provisioning](../README.md)
 
 ## Provisioning Input
-provisioningInput is needed to the run the RKE1 tests, specifically kubernetesVersion, cni, and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". psact is optional and takes values `rancher-privileged` and `rancher-restricted` only.
+provisioningInput is needed to the run the RKE1 tests, specifically kubernetesVersion, cni, and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". psact is optional and takes values `rancher-privileged`, `rancher-restricted` or `rancher-baseline`.
 
 **nodeProviders is only needed for custom cluster tests; the framework only supports custom clusters through aws/ec2 instances.**
-
-```json
-"provisioningInput": {
-    "nodePools": [ 
-      {
-        "nodeRoles" {
-          "etcd": true,
-          "controlplane": true,
-          "quantity": 1,
-        },
-      },
-      {
-        "nodeRoles" {
-          "worker": true,
-          "quantity": 2,
-          "drainBeforeDelete": true,
-        },
-        "nodeLabels" {
-          "label1": "value1",
-          "label2": "value2",
-        },
-        "nodeTaints" [
-          { "key": "TestKey",
-            "value": "testValue",
-            "effect": "NoSchedule",
-          },
-        ],
-        "specifyPrivateIP": false,
-        "specifyPublicIP": true,
-        "nodeNamePrefix": "qa",
-      },
-    ],
-    "flags": {
-      "desiredflags": "Long" //These flags are for running TestProvisioningRKE1Cluster or TestProvisioningRKE1CustomCluster it is not needed for the dynamic tests. Long will run the full table, where as short will run the short version of this test.
-    },
-    "rke1KubernetesVersion": ["v1.26.8-rancher1-1"],
-    "providers": ["linode", "aws", "azure", "harvester"],
-    "nodeProviders": ["ec2"],
-    "psact": ""
-  }
+```yaml
+provisioningInput:
+  nodePools:
+  - nodeRoles:
+      etcd: true
+      controlplane: true
+      worker: true
+      quantity: 1
+  - nodeRoles:
+      worker: true
+      quantity: 2
+  flags:
+    desiredflags: "Long" #These flags are for running TestProvisioningRKE1Cluster or TestProvisioningRKE1CustomCluster it is not needed for the dynamic tests. Long will run the full table, where as short will run the short version of this test.
+  rke1KubernetesVersion: ["v1.27.6-rancher1-1"]
+  cni: ["calico"]
+  providers: ["linode", "aws", "do", "harvester"]
+  nodeProviders: ["ec2"]
+  psact: ""
 ```
 
 ## NodeTemplateConfigs
 RKE1 specifically needs a node template config to run properly. These are the inputs needed for the different node providers.
 
 ### AWS
-```json
-  "awsNodeTemplate": {
-    "accessKey": "",
-    "ami": "",
-    "blockDurationMinutes": "0",
-    "encryptEbsVolume": false,
-    "endpoint": "",
-    "httpEndpoint": "enabled",
-    "httpTokens": "optional",
-    "iamInstanceProfile": "EngineeringUsersUS",
-    "insecureTransport": false,
-    "instanceType": "t2.2xlarge",
-    "keypairName": "your-key-name",
-    "kmsKey": "",
-    "monitoring": false,
-    "privateAddressOnly": false,
-    "region": "us-east-2",
-    "requestSpotInstance": true,
-    "retries": "5",
-    "rootSize": "16",
-    "secretKey": "",
-    "securityGroup": ["open-all"],
-    "securityGroupReadonly": false,
-    "sessionToken": "",
-    "spotPrice": "0.50",
-    "sshKeyContents": "",
-    "sshUser": "ec2-user",
-    "subnetId": "subnet-ee8cac86",
-    "tags": "",
-    "type": "amazonec2Config",
-    "useEbsOptimizedInstance": false,
-    "usePrivateAddress": false,
-    "userdata": "",
-    "volumeType": "gp2",
-    "vpcId": "vpc-bfccf4d7",
-    "zone": "a"
-  }
+```yaml
+  awsNodeTemplate:
+    accessKey: ""
+    ami: ""
+    blockDurationMinutes: "0"
+    encryptEbsVolume: false
+    endpoint: ""
+    httpEndpoint: "enabled"
+    httpTokens: "optional"
+    iamInstanceProfile: ""
+    insecureTransport: false
+    instanceType: "t2.2xlarge"
+    keypairName: "your-key-name"
+    kmsKey: ""
+    monitoring: false
+    privateAddressOnly: false
+    region: "us-east-2"
+    requestSpotInstance: true
+    retries: "5"
+    rootSize: "16"
+    secretKey: ""
+    securityGroup: ["open-all"]
+    securityGroupReadonly: false
+    sessionToken: ""
+    spotPrice: "0.50"
+    sshKeyContents: ""
+    sshUser: "ec2-user"
+    subnetId: ""
+    tags: ""
+    type: "amazonec2Config"
+    useEbsOptimizedInstance: false
+    usePrivateAddress: false
+    userdata: ""
+    volumeType: "gp2"
+    vpcId: ""
+    zone: "a"
 ```
 
 ### Azure
-```json
-  "azureNodeTemplate": {
-    "availabilitySet": "docker-machine",
-    "clientId": "",
-    "clientSecret": "",
-    "customData": "",
-    "diskSize": "30",
-    "dns": "",
-    "dockerPort": "2376",
-    "environment": "AzurePublicCloud",
-    "faultDomainCount": "3",
-    "image": "canonical:UbuntuServer:18.04-LTS:latest",
-    "location": "eastus2",
-    "managedDisks": false,
-    "noPublicIp": false,
-    "openPort": [
-      "6443/tcp",
-      "2379/tcp",
-      "2380/tcp",
-      "8472/udp",
-      "4789/udp",
-      "9796/tcp",
-      "10256/tcp",
-      "10250/tcp",
-      "10251/tcp",
-      "10252/tcp"
-    ],
-    "plan": "",
-    "privateIpAddress": "",
-    "resourceGroup": "",
-    "size": "Standard_D2_v2",
-    "sshUser": "azureuser",
-    "staticPublicIp": false,
-    "storageType": "Standard_LRS",
-    "subnet": "docker-machine",
-    "subnetPrefix": "192.168.0.0/16",
-    "subscriptionId": "",
-    "tenantId": "",
-    "type": "azureConfig",
-    "updateDomainCount": "5",
-    "vnet": "docker-machine-vnet"
-}
+```yaml
+azureNodeTemplate:
+  availabilitySet: "docker-machine"
+  clientId: ""
+  clientSecret: ""
+  customData: ""
+  diskSize: "30"
+  dns: ""
+  dockerPort: "2376"
+  environment: "AzurePublicCloud"
+  faultDomainCount: "3"
+  image: "canonical:UbuntuServer:22.04-LTS:latest"
+  location: "eastus2"
+  managedDisks: false
+  noPublicIp: false
+  openPort: ["6443/tcp","2379/tcp","2380/tcp","8472/udp","4789/udp","9796/tcp","10256/tcp","10250/tcp","10251/tcp","10252/tcp"]
+  plan: ""
+  privateIpAddress: ""
+  resourceGroup: ""
+  size: "Standard_D2_v2"
+  sshUser: "azureuser"
+  staticPublicIp: false
+  storageType: "Standard_LRS"
+  subnet: "docker-machine"
+  subnetPrefix: "192.168.0.0/16"
+  subscriptionId: ""
+  tenantId: ""
+  type: "azureConfig"
+  updateDomainCount: "5"
+  vnet: "docker-machine-vnet"
 ```
 
 ### Harvester
-```json
-"harvesterNodeTemplate": {
-    "cloudConfig": "",
-    "clusterId": "",
-    "clusterType": "",
-    "cpuCount": "2",
-    "diskBus": "virtio",
-    "diskSize": "40",
-    "imageName": "default/image-gchq8",
-    "keyPairName": "",
-    "kubeconfigContent": "",
-    "memorySize": "4",
-    "networkData": "",
-    "networkModel": "virtio",
-    "networkName": "",
-    "networkType": "dhcp",
-    "sshPassword": "",
-    "sshPort": "22",
-    "sshPrivateKeyPath": "",
-    "sshUser": "ubuntu",
-    "type": "harvesterConfig",
-    "userData": "",
-    "vmAffinity": "",
-    "vmNamespace": "default"
-}
+```yaml
+harvesterNodeTemplate":
+  cloudConfig: ""
+  clusterId: ""
+  clusterType: ""
+  cpuCount: "2"
+  diskBus: "virtio"
+  diskSize: "40"
+  imageName: "default/image-gchq8"
+  keyPairName: ""
+  kubeconfigContent: ""
+  memorySize: "4"
+  networkData: ""
+  networkModel: "virtio"
+  networkName: ""
+  networkType: "dhcp"
+  sshPassword: ""
+  sshPort: "22"
+  sshPrivateKeyPath: ""
+  sshUser: "ubuntu"
+  type: "harvesterConfig"
+  userData: ""
+  vmAffinity: ""
+  vmNamespace: "default
 ```
 
 ### Linode
-```json
-"linodeNodeTemplate:" { 
-    "authorizedUsers": "",
-    "createPrivateIp": true,
-    "dockerPort": "2376",
-    "image": "linode/ubuntu20.04",
-    "instanceType": "g6-dedicated-8",
-    "label": "",
-    "region": "us-east",
-    "rootPass": "",
-    "sshPort": "22",
-    "sshUser": "root",
-    "stackscript": "",
-    "stackscriptData": "",
-    "swapSize": "512",
-    "tags": "",
-    "token": "",
-    "type": "linodeConfig",
-    "uaPrefix": "Rancher"
-}
+```yaml
+linodeNodeTemplate:
+  authorizedUsers: ""
+  createPrivateIp: true
+  dockerPort: "2376"
+  image: "linode/ubuntu22.04"
+  instanceType: "g6-dedicated-8"
+  label: ""
+  region: "us-west"
+  rootPass: ""
+  sshPort: "22"
+  sshUser: "root"
+  stackscript: ""
+  stackscriptData: ""
+  swapSize: "512"
+  tags: ""
+  token: ""
+  type: "linodeConfig"
+  uaPrefix: "Rancher"
 ```
 
 ### Vsphere
-```json
-"vmwarevsphereNodeTemplate:" { 
-    "cfgparam": ["disk.enableUUID=TRUE"],
-    "cloneFrom": "",
-    "cloudinit": "",
-    "contentLibrary": "",
-    "cpuCount": "4",
-    "creationType": "",
-    "datacenter": "",
-    "datastore": "",
-    "datastoreCluster": "",
-    "diskSize": "20000",
-    "folder": "",
-    "hostSystem": "",
-    "memorySize": "4096",
-    "network": [""],
-    "os": "linux",
-    "password": "",
-    "pool": "",
-    "sshPassword": "",
-    "sshPort": "22",
-    "sshUser": "",
-    "sshUserGroup": "",
-    "username": "",
-    "vcenter": "",
-    "vcenterPort": "443"
-}
+```yaml
+vmwarevsphereNodeTemplate:
+  cfgparam: ["disk.enableUUID=TRUE"]
+  cloneFrom: ""
+  cloudinit: "#cloud-config\n\n"
+  contentLibrary: ""
+  cpuCount: "4"
+  creationType: ""
+  datacenter: ""
+  datastore: ""
+  datastoreCluster: ""
+  diskSize: "20000"
+  folder: ""
+  hostSystem: ""
+  memorySize: "4096"
+  network: [""]
+  os: ""
+  password: ""
+  pool: ""
+  sshPassword: ""
+  sshPort: "22"
+  sshUser: ""
+  sshUserGroup: ""
+  username: ""
+  vcenter: ""
+  vcenterPort: "443"
 ```
+
+These tests utilize Go build tags. Due to this, see the below examples on how to run the node driver tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/rke1 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestRKE1ProvisioningTestSuite/TestProvisioningRKE1Cluster"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/rke1 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestRKE1ProvisioningTestSuite/TestProvisioningRKE1ClusterDynamicInput"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.
 
 ## Custom Cluster
 For custom clusters, no nodeTemplateConfig or credentials are required. Currently only supported for ec2.
-`-run ^TestCustomClusterRKE1ProvisioningTestSuite/TestProvisioningRKE1CustomClusterDynamicInput$`
-`-run ^TestCustomClusterRKE1ProvisioningTestSuite/TestProvisioningRKE1CustomCluster$`
 
 Dependencies:
 * **Ensure you have nodeDrivers set in provisioningInput**
@@ -240,69 +207,61 @@ Dependencies:
 * ensure nodeProviders is set
 * use AMIs that already have Docker installed and the service is enabled on boot
 
-```json
-{
-  "awsEC2Configs": {
-    "region": "us-east-2",
-    "awsSecretAccessKey": "",
-    "awsAccessKeyID": "",
-    "awsEC2Config": [
-      {
-        "instanceType": "t3a.medium",
-        "awsRegionAZ": "",
-        "awsAMI": "",
-        "awsSecurityGroups": [
-          ""
-        ],
-        "awsSSHKeyName": "",
-        "awsCICDInstanceTag": "rancher-validation",
-        "awsIAMProfile": "",
-        "awsUser": "ubuntu",
-        "volumeSize": 25,
-        "roles": ["etcd", "contolplane"]
-      },
-      {
-        "instanceType": "t3a.large",
-        "awsRegionAZ": "",
-        "awsAMI": "",
-        "awsSecurityGroups": [
-          ""
-        ],
-        "awsSSHKeyName": "",
-        "awsCICDInstanceTag": "rancher-validation",
-        "awsIAMProfile": "",
-        "awsUser": "ubuntu",
-        "volumeSize": 25,
-        "roles": ["worker"]
-      }
-    ]
-  }
-}
+```yaml
+  awsEC2Configs:
+  region: "us-east-2"
+  awsSecretAccessKey: ""
+  awsAccessKeyID: ""
+  awsEC2Config:
+    - instanceType: "t3a.medium"
+      awsRegionAZ: ""
+      awsAMI: ""
+      awsSecurityGroups: [""]
+      awsSSHKeyName: ""
+      awsCICDInstanceTag: "rancher-validation"
+      awsIAMProfile: ""
+      awsUser: "ubuntu"
+      volumeSize: 50
+      roles: ["etcd", "controlplane"]
+    - instanceType: "t3a.medium"
+      awsRegionAZ: ""
+      awsAMI: ""
+      awsSecurityGroups: [""]
+      awsSSHKeyName: ""
+      awsCICDInstanceTag: "rancher-validation"
+      awsIAMProfile: ""
+      awsUser: "ubuntu"
+      volumeSize: 50
+      roles: ["worker"]
 ```
+
+These tests utilize Go build tags. Due to this, see the below examples on how to run the custom cluster tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/rke1 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestCustomClusterRKE1ProvisioningTestSuite/TestProvisioningRKE1CustomCluster"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/rke1 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestCustomClusterRKE1ProvisioningTestSuite/TestProvisioningRKE1CustomClusterDynamicInput"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.
 
 ## RKE1 Support Matrix Checks - K8s Components & Architecture
 Custom clusters have the ability to perform RKE1 support matrix checks for K8s components & architectures. 
 
 To do this, ensure that your `provisioningInput` has `flannel` and `canal` both defined, along with your desired K8s versions as shown below:
 
-```json
-"provisioningInput": {
-    "nodesAndRolesRKE1": [ 
-      {
-        "etcd": true,
-        "controlplane": true,
-        "quantity": 1,
-      },
-      {
-        "worker": true,
-        "quantity": 2,
-      },
-    ],
-    "rke1KubernetesVersion": ["v1.25.9-rancher2-1", "v1.26.4-rancher2-1"],
-    "nodeProviders": ["ec2"],
-    "cni": ["flannel", "canal"],
-    "psact": ""
-  }
+```yaml
+provisioningInput:
+  nodePools:
+  - nodeRoles:
+      etcd: true
+      controlplane: true
+      worker: true
+      quantity: 1
+  - nodeRoles:
+      worker: true
+      quantity: 2
+  rke1KubernetesVersion: ["v1.26.9-rancher1-1", "v1.27.6-rancher1-1"]
+  cni: ["flannel", "calico"]
+  nodeProviders: ["ec2"]
+  psact: ""
 ```
 
 ## Advanced Settings
@@ -316,46 +275,28 @@ Please read up on general k8s to get an idea of correct formatting for:
 * node affinity
 * tolerations
 
-```json
-"advancedOptions": {
-    "clusterAgentCustomization": { // change this to fleetAgentCustomization for fleet agent
-        "appendTolerations": [
-            {
-                "key": "Testkey",
-                "value": "testValue",
-                "effect": "NoSchedule"
-            }
-        ],
-        "overrideResourceRequirements": {
-            "limits": {
-                "cpu": "750m",
-                "memory": "500Mi"
-            },
-            "requests": {
-                "cpu": "250m",
-                "memory": "250Mi"
-            }
-        },
-        "overrideAffinity": {
-            "nodeAffinity": {
-                "preferredDuringSchedulingIgnoredDuringExecution": [
-                    {
-                        "preference": {
-                            "matchExpressions": [
-                                {
-                                    "key": "cattle.io/cluster-agent",
-                                    "operator": "In",
-                                    "values": [
-                                        "true"
-                                    ]
-                                }
-                            ]
-                        },
-                        "weight": 1
-                    }
-                ]
-            }
-        }
-    }
-}
+```yaml
+advancedOptions:
+  clusterAgent: # change this to fleetAgent for fleet agent
+    appendTolerations:
+    - key: "Testkey"
+      value: "testValue"
+      effect: "NoSchedule"
+    overrideResourceRequirements:
+      limits:
+        cpu: "750m"
+        memory: "500Mi"
+      requests:
+        cpu: "250m"
+        memory: "250Mi"
+      overrideAffinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: "cattle.io/cluster-agent"
+                    operator: "In"
+                    values:
+                      - "true"
+              weight: 1
 ```

--- a/tests/v2/validation/provisioning/rke2/README.md
+++ b/tests/v2/validation/provisioning/rke2/README.md
@@ -1,12 +1,12 @@
-
 # RKE2 Provisioning Configs
 
 For your config, you will need everything in the Prerequisites section on the previous readme, [Define your test](#provisioning-input), and at least one [Cloud Credential](#cloud-credentials) and [Node Driver Machine Config](#machine-rke2-config) or [Custom Cluster Template](#custom-cluster), which should match what you have specified in `provisioningInput`. 
 
 Your GO test_package should be set to `provisioning/rke2`.
 Your GO suite should be set to `-run ^TestRKE2ProvisioningTestSuite$`.
-Please see below for more details for your config. 
+Please see below for more details for your config. Please see below for more details for your config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
 
+## Table of Contents
 1. [Prerequisites](../README.md)
 2. [Define your test](#provisioning-input)
 3. [Cloud Credential](#cloud-credentials)
@@ -16,302 +16,257 @@ Please see below for more details for your config.
 7. [Back to general provisioning](../README.md)
 
 ## Provisioning Input
-provisioningInput is needed to the run the RKE2 tests, specifically kubernetesVersion, cni, and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". psact is optional and takes values `rancher-privileged` and `rancher-restricted` only.
+provisioningInput is needed to the run the RKE2 tests, specifically kubernetesVersion, cni, and providers. nodesAndRoles is only needed for the TestProvisioningDynamicInput test, node pools are divided by "{nodepool},". psact is optional and takes values `rancher-privileged`, `rancher-restricted` or `rancher-baseline`.
 
 **nodeProviders is only needed for custom cluster tests; the framework only supports custom clusters through aws/ec2 instances.**
-
-```json
-"provisioningInput": {
-    "machinePools": [
-      {
-        "nodeRoles": {
-          "etcd": true,
-          "controlplane": true,
-          "worker": false,
-          "quantity": 1,
-        },
-      },
-      {
-        "nodeRoles": {
-          "worker": true,
-          "quantity": 2,
-          "drainBeforeDelete": true,
-        },
-        "nodeLabels" {
-          "label1": "value1",
-          "label2": "value2",
-        },
-        "nodeTaints" [
-          { "key": "TestKey",
-            "value": "testValue",
-            "effect": "NoSchedule",
-          }
-        ],
-        "specifyPrivateIP": false,
-        "specifyPublicIP": true,
-        "nodeNamePrefix": "qa",
-      },
-      {
-        "nodeRoles": {
-          "windows": true,
-          "quantity": 1,
-        }
-      },
-    ],
-    "flags": {
-      "desiredflags": "Short|Long" //These flags are for running TestProvisioningRKE2Cluster or TestProvisioningRKE2CustomCluster it is not needed for the dynamic tests.
-    },
-    "rke2KubernetesVersion": ["v1.26.8+rke2r1"],
-    "cni": ["calico"],
-    "providers": ["linode", "aws", "do", "harvester"],
-    "nodeProviders": ["ec2"],
-    "hardened": true,
-    "psact": ""
-  }
+```yaml
+provisioningInput:
+  machinePools:
+  - nodeRoles:
+      etcd: true
+      controlplane: true
+      worker: true
+      quantity: 1
+  - nodeRoles:
+      worker: true
+      quantity: 2
+  - nodeRoles:
+      windows: true
+      quantity: 1
+  flags:
+    desiredflags: "Short|Long" #These flags are for running TestProvisioningRKE2Cluster or TestProvisioningRKE2CustomCluster it is not needed for the dynamic tests.
+  rke2KubernetesVersion: ["v1.27.6+rke2r1"]
+  cni: ["calico"]
+  providers: ["linode", "aws", "do", "harvester"]
+  nodeProviders: ["ec2"]
+  hardened: false
+  psact: ""
+  clusterSSHTests: [""]
 ```
 
 ## Cloud Credentials
 These are the inputs needed for the different node provider cloud credentials, inlcuding linode, aws, digital ocean, harvester, azure, and google.
 
 ### Digital Ocean
-```json
-"digitalOceanCredentials": {
-   "accessToken": ""
-  },
+```yaml
+digitalOceanCredentials:
+  accessToken": ""
 ```
 ### Linode
-```json
-"linodeCredentials": {
-   "token": ""
-  },
+```yaml
+linodeCredentials:
+  token: ""
 ```
 ### Azure
-```json
-"azureCredentials": {
-   "clientId": "",
-   "clientSecret": "",
-     "subscriptionId": "",
-     "environment": "AzurePublicCloud"
-  },
+```yaml
+azureCredentials:
+  clientId: ""
+  clientSecret: ""
+  subscriptionId": ""
+  environment: "AzurePublicCloud"
 ```
 ### AWS
-```json
-"awsCredentials": {
-   "secretKey": "",
-   "accessKey": "",
-   "defaultRegion": ""
-  },
+```yaml
+awsCredentials:
+  secretKey: "",
+  accessKey: "",
+  defaultRegion: ""
 ```
 ### Harvester
-```json
-"harvesterCredentials": {
-   "clusterId": "",
-   "clusterType": "",
-   "kubeconfigContent": ""
-},
+```yaml
+harvesterCredentials:
+  clusterId: "",
+  clusterType: "",
+  kubeconfigContent: ""
 ```
 ### Google
-```json
-"googleCredentials": {
-    "authEncodedJson": ""
-},
+```yaml
+googleCredentials:
+  authEncodedJson: ""
 ```
 ### VSphere
-```json
-"vmwarevsphereCredentials": {
-  "password": "",
-  "username": "",
-  "vcenter": "",
-  "vcenterPort": ""
-}
+```yaml
+vmwarevsphereCredentials:
+  password: ""
+  username: ""
+  vcenter: ""
+  vcenterPort: ""
 ```
 
 ## Machine RKE2 Config
 Machine RKE2 config is the final piece needed for the config to run RKE2 provisioning tests.
 
 ### AWS RKE2 Machine Config
-```json
-"awsMachineConfig": {
-    "region": "us-east-2",
-    "ami": "",
-    "instanceType": "t3a.medium",
-    "sshUser": "ubuntu",
-    "vpcId": "",
-    "volumeType": "gp2",
-    "zone": "a",
-    "retries": "5",
-    "rootSize": "16",
-    "securityGroup": ["rancher-nodes"]
-},
+```yaml
+awsMachineConfig:
+  region: "us-east-2"
+  ami: ""
+  instanceType: "t3a.medium"
+  sshUser: "ubuntu"
+  vpcId: ""
+  volumeType: "gp2"
+  zone: "a"
+  retries: "5"
+  rootSize: "60"
+  securityGroup: [""]
 ```
 ### Digital Ocean RKE2 Machine Config
-```json
-"doMachineConfig": {
-  "image": "ubuntu-20-04-x64",
-    "backups": false,
-    "ipv6": false,
-    "monitoring": false,
-    "privateNetworking": false,
-    "region": "nyc3",
-    "size": "s-2vcpu-4gb",
-    "sshKeyContents": "",
-    "sshKeyFingerprint": "",
-    "sshPort": "22",
-    "sshUser": "root",
-    "tags": "",
-    "userdata": ""
-},
+```yaml
+doMachineConfig:
+  image: "ubuntu-20-04-x64"
+  backups: false
+  ipv6: false
+  monitoring: false
+  privateNetworking: false
+  region: "nyc3"
+  size: "s-2vcpu-4gb"
+  sshKeyContents: ""
+  sshKeyFingerprint: ""
+  sshPort: "22"
+  sshUser: "root"
+  tags: ""
+  userdata: ""
 ```
 ### Linode RKE2 Machine Config
-```json
-"linodeMachineConfig": {
-  "authorizedUsers": "",
-  "createPrivateIp": false,
-  "dockerPort": "2376",
-  "image": "linode/ubuntu20.04",
-  "instanceType": "g6-standard-2",
-  "region": "us-west",
-  "rootPass": "",
-  "sshPort": "22",
-  "sshUser": "",
-  "stackscript": "",
-  "stackscriptData": "",
-  "swapSize": "512",
-  "tags": "",
-  "uaPrefix": ""
-},
+```yaml
+linodeMachineConfig:
+  authorizedUsers: ""
+  createPrivateIp: true
+  dockerPort: "2376"
+  image: "linode/ubuntu22.04"
+  instanceType: "g6-standard-8"
+  region: "us-west"
+  rootPass: ""
+  sshPort: "22"
+  sshUser: ""
+  stackscript: ""
+  stackscriptData: ""
+  swapSize: "512"
+  tags: ""
+  uaPrefix: "Rancher"
 ```
 ### Azure RKE2 Machine Config
-```json
-"azureMachineConfig": {
-  "availabilitySet": "docker-machine",
-  "diskSize": "30",
-  "environment": "AzurePublicCloud",
-  "faultDomainCount": "3",
-  "image": "canonical:UbuntuServer:18.04-LTS:latest",
-  "location": "westus",
-  "managedDisks": false,
-  "noPublicIp": false,
-  "nsg": "",
-  "openPort": ["6443/tcp", "2379/tcp", "2380/tcp", "8472/udp", "4789/udp", "9796/tcp", "10256/tcp", "10250/tcp", "10251/tcp", "10252/tcp"],
-  "resourceGroup": "docker-machine",
-  "size": "Standard_D2_v2",
-  "sshUser": "docker-user",
-  "staticPublicIp": false,
-  "storageType": "Standard_LRS",
-  "subnet": "docker-machine",
-  "subnetPrefix": "192.168.0.0/16",
-  "updateDomainCount": "5",
-  "usePrivateIp": false,
-  "vnet": "docker-machine-vnet"
-},
+```yaml
+azureMachineConfig:
+  availabilitySet: "docker-machine"
+  diskSize: "30"
+  environment: "AzurePublicCloud"
+  faultDomainCount: "3"
+  image: "canonical:UbuntuServer:22.04-LTS:latest"
+  location: "westus"
+  managedDisks: false
+  noPublicIp: false
+  nsg: ""
+  openPort: ["6443/tcp", "2379/tcp", "2380/tcp", "8472/udp", "4789/udp", "9796/tcp", "10256/tcp", "10250/tcp", "10251/tcp", "10252/tcp"]
+  resourceGroup: "docker-machine"
+  size: "Standard_D2_v2"
+  sshUser: "docker-user"
+  staticPublicIp: false
+  storageType: "Standard_LRS"
+  subnet: "docker-machine"
+  subnetPrefix: "192.168.0.0/16"
+  updateDomainCount: "5"
+  usePrivateIp: false
+  vnet: "docker-machine-vnet"
 ```
 ### Harvester RKE2 Machine Config
-```json
-"harvesterMachineConfig": {
-  "diskSize": "40",
-  "cpuCount": "2",
-  "memorySize": "8",
-  "networkName": "default/ctw-network-1",
-  "imageName": "default/image-rpj98",
-  "vmNamespace": "default",
-  "sshUser": "ubuntu",
-  "diskBus": "virtio"
-},
+```yaml
+harvesterMachineConfig":
+  diskSize: "40"
+  cpuCount: "2"
+  memorySize: "8"
+  networkName: "default/ctw-network-1"
+  imageName: "default/image-rpj98"
+  vmNamespace: "default"
+  sshUser: "ubuntu"
+  diskBus: "virtio
 ```
 ## Vsphere RKE2 Machine Config
-```json
-"vmwarevsphereMachineConfig": {
-  "cfgparam": ["disk.enableUUID=TRUE"],
-  "cloneFrom": "",
-  "cloudinit": "",
-  "contentLibrary": "",
-  "cpuCount": "4",
-  "creationType": "",
-  "datacenter": "",
-  "datastore": "",
-  "datastoreCluster": "",
-  "diskSize": "20000",
-  "folder": "",
-  "hostSystem": "",
-  "memorySize": "4096",
-  "network": [""],
-  "os": "linux",
-  "password": "",
-  "pool": "",
-  "sshPassword": "",
-  "sshPort": "22",
-  "sshUser": "",
-  "sshUserGroup": "",
-  "username": "",
-  "vcenter": "",
-  "vcenterPort": "443"
-}
+```yaml
+vmwarevsphereMachineConfig:
+  cfgparam: ["disk.enableUUID=TRUE"]
+  cloneFrom: ""
+  cloudinit: ""
+  contentLibrary: ""
+  cpuCount: "4"
+  creationType: ""
+  datacenter: ""
+  datastore: ""
+  datastoreCluster: ""
+  diskSize: "20000"
+  folder: ""
+  hostSystem: ""
+  memorySize: "4096"
+  network: [""]
+  os: "linux"
+  password: ""
+  pool: ""
+  sshPassword: ""
+  sshPort: "22"
+  sshUser: ""
+  sshUserGroup: ""
+  username: ""
+  vcenter: ""
+  vcenterPort: "443"
 ```
+
+These tests utilize Go build tags. Due to this, see the below examples on how to run the node driver tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/rke2 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestRKE2ProvisioningTestSuite/TestProvisioningRKE2Cluster"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/rke2 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestRKE2ProvisioningTestSuite/TestProvisioningRKE2ClusterDynamicInput"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.
 
 ## Custom Cluster
 For custom clusters, no machineConfig or credentials are needed. Currently only supported for ec2.
-`-run ^TestCustomClusterRKE2ProvisioningTestSuite/TestProvisioningRKE2CustomClusterDynamicInput$`
-`-run ^TestCustomClusterRKE2ProvisioningTestSuite/TestProvisioningRKE2CustomCluster$`
 
 Dependencies:
-* **Ensure you have machinePools defined in provisioningInput**
-* make sure that all roles are entered at least once in machinePools.nodeRoles
-* ensure nodeProviders is set
-* windows pool(s) should always be the last machinePool
-```json
-{
-  "awsEC2Configs": {
-    "region": "us-east-2",
-    "awsSecretAccessKey": "",
-    "awsAccessKeyID": "",
-    "awsEC2Config": [
-      {
-        "instanceType": "t3a.medium",
-        "awsRegionAZ": "",
-        "awsAMI": "",
-        "awsSecurityGroups": [
-          ""
-        ],
-        "awsSSHKeyName": "",
-        "awsCICDInstanceTag": "rancher-validation",
-        "awsIAMProfile": "",
-        "awsUser": "ubuntu",
-        "volumeSize": 25,
-        "roles": ["etcd", "contolplane"]
-      },
-      {
-        "instanceType": "t3a.large",
-        "awsRegionAZ": "",
-        "awsAMI": "",
-        "awsSecurityGroups": [
-          ""
-        ],
-        "awsSSHKeyName": "",
-        "awsCICDInstanceTag": "rancher-validation",
-        "awsIAMProfile": "",
-        "awsUser": "ubuntu",
-        "volumeSize": 25,
-        "roles": ["worker"]
-      },
-      {
-        "instanceType": "t3a.xlarge",
-        "awsRegionAZ": "",
-        "awsAMI": "",
-        "awsSecurityGroups": [
-          ""
-        ],
-        "awsSSHKeyName": "",
-        "awsCICDInstanceTag": "rancher-validation",
-        "awsIAMProfile": "",
-        "awsUser": "Administrator",
-        "volumeSize": 50,
-        "roles": ["windows"]
-      }
-    ]
-  }
-}
+* **Ensure you have nodeProviders in provisioningInput**
+* make sure that all roles are entered at least once
+* windows pool(s) should always be last in the config
+```yaml
+  awsEC2Configs:
+  region: "us-east-2"
+  awsSecretAccessKey: ""
+  awsAccessKeyID: ""
+  awsEC2Config:
+    - instanceType: "t3a.medium"
+      awsRegionAZ: ""
+      awsAMI: ""
+      awsSecurityGroups: [""]
+      awsSSHKeyName: ""
+      awsCICDInstanceTag: "rancher-validation"
+      awsIAMProfile: ""
+      awsUser: "ubuntu"
+      volumeSize: 50
+      roles: ["etcd", "controlplane"]
+    - instanceType: "t3a.medium"
+      awsRegionAZ: ""
+      awsAMI: ""
+      awsSecurityGroups: [""]
+      awsSSHKeyName: ""
+      awsCICDInstanceTag: "rancher-validation"
+      awsIAMProfile: ""
+      awsUser: "ubuntu"
+      volumeSize: 50
+      roles: ["worker"]
+    - instanceType: "t3a.xlarge"
+      awsAMI: ""
+      awsSecurityGroups: [""]
+      awsSSHKeyName: ""
+      awsCICDInstanceTag: "rancher-validation"
+      awsUser: "Administrator"
+      volumeSize: 50
+      roles: ["windows"]
 ```
+
+These tests utilize Go build tags. Due to this, see the below examples on how to run the custom cluster tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/rke2 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestCustomClusterRKE2ProvisioningTestSuite/TestProvisioningRKE2CustomCluster"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/provisioning/rke2 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestCustomClusterRKE2ProvisioningTestSuite/TestProvisioningRKE2CustomClusterDynamicInput"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.
+
 ## Advanced Settings
 This encapsulates any other setting that is applied in the cluster.spec. Currently we have support for:
 * cluster agent customization 
@@ -323,46 +278,28 @@ Please read up on general k8s to get an idea of correct formatting for:
 * node affinity
 * tolerations
 
-```json
-"advancedOptions": {
-    "clusterAgentCustomization": { // change this to fleetAgentCustomization for fleet agent
-        "appendTolerations": [
-            {
-                "key": "Testkey",
-                "value": "testValue",
-                "effect": "NoSchedule"
-            }
-        ],
-        "overrideResourceRequirements": {
-            "limits": {
-                "cpu": "750m",
-                "memory": "500Mi"
-            },
-            "requests": {
-                "cpu": "250m",
-                "memory": "250Mi"
-            }
-        },
-        "overrideAffinity": {
-            "nodeAffinity": {
-                "preferredDuringSchedulingIgnoredDuringExecution": [
-                    {
-                        "preference": {
-                            "matchExpressions": [
-                                {
-                                    "key": "cattle.io/cluster-agent",
-                                    "operator": "In",
-                                    "values": [
-                                        "true"
-                                    ]
-                                }
-                            ]
-                        },
-                        "weight": 1
-                    }
-                ]
-            }
-        }
-    }
-}
+```yaml
+advancedOptions:
+  clusterAgent: # change this to fleetAgent for fleet agent
+    appendTolerations:
+    - key: "Testkey"
+      value: "testValue"
+      effect: "NoSchedule"
+    overrideResourceRequirements:
+      limits:
+        cpu: "750m"
+        memory: "500Mi"
+      requests:
+        cpu: "250m"
+        memory: "250Mi"
+      overrideAffinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: "cattle.io/cluster-agent"
+                    operator: "In"
+                    values:
+                      - "true"
+              weight: 1
 ```

--- a/tests/v2/validation/snapshot/README.md
+++ b/tests/v2/validation/snapshot/README.md
@@ -1,17 +1,21 @@
 # Snapshot
 
+For the snapshot tests, the test has only been tested on RKE2. That does not mean RKE1 or K3S are unsupported, they just have not been tested. These tests are designed to accept an existing cluster that the user has access to. If you do not have a downstream cluster in Rancher, you should create one first before running these tests.
+
+Currently, these tests require that you have exactly 3 etcd nodes in your cluster. Please see below for more details for your config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
+
+## Table of Contents
+1. [Getting Started](#Getting-Started)
+
 ## Getting Started
-Your GO suite should be set to `-run ^TestRKE2SnapshotRestore$`. You can find specific tests by checking the test file you plan to run.
 In your config file, set the following:
-```json
-"rancher": { 
-  "host": "rancher_server_address",
-  "adminToken": "rancher_admin_token",
-  "userToken": "your_rancher_user_token",
-  "clusterName": "cluster_to_run_tests_on",
-  "insecure": true/optional,
-  "cleanup": false/optional,
-}
+```yaml
+rancher:
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  clusterName: "cluster_to_run_tests_on"
+  insecure: true/optional
+  cleanup: false/optional
 ```
 
 Typically, a cluster with the following 3 pools is used for testing:
@@ -30,7 +34,17 @@ Typically, a cluster with the following 3 pools is used for testing:
     Quantity: 2,
   },
 }
-  ```
-These tests are designed to accept an existing cluster that the user has access to. If you do not have a downstream cluster in rancher, you should create one first before running this test. 
-Currently, these tests require that you have exactly 3 etcd nodes in your cluster. 
-Untested on k3s nor rke1.
+```
+
+These tests utilize Go build tags. Due to this, see the below example on how to run the tests:
+
+### Snapshot restore only
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestRKE2SnapshotRestore/TestOnlySnapshotRestore"`
+
+### Snapshot restore with K8s upgrade
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestRKE2SnapshotRestore/TestSnapshotRestoreWithK8sUpgrade"`
+
+### Sanpshot restore with upgrade strategy
+`gotestsum --format standard-verbose --packages=github.com/rancher/rancher/tests/v2/validation/snapshot --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestRKE2SnapshotRestore/TestSnapshotRestoreWithUpgradeStrategy"`
+
+If the specified test passes immediately without warning, try adding the `-count=1` flag to get around this issue. This will avoid previous results from interfering with the new test run.

--- a/tests/v2/validation/upgrade/README.md
+++ b/tests/v2/validation/upgrade/README.md
@@ -1,7 +1,10 @@
 # Upgrade Configs
 
-Kubernetes and Pre/Post Upgrade Workload tests use the same single shared configuration as shown below.
-You can find the correct suite name below by checking the test file you plan to run.
+## Table of Contents
+1. [Getting Started](#Getting-Started)
+
+## Getting Started
+Kubernetes and pre/post upgrade workload tests use the same single shared configuration as shown below. You can find the correct suite name below by checking the test file you plan to run.
 In your config file, set the following, this will run each test in parallel both for Post/Pre and Kubernetes tests:
 
 ```yaml
@@ -17,7 +20,7 @@ upgradeInput:
  - If you want to run Post/Pre Upgrade tests against all the clusters except local, you can add **WorkloadUpgradeAllClusters** environment flag instead above. 
  - If you want to run Kubernetes Upgrade tests against all the clusters except local, you can add **KubernetesUpgradeAllClusters** environment flag instead above.
 
-For Kubernetes Upgrade Test, *"latest"* string would pick the latest possible Kubernetes version from the version pool. Empty string value *""* for the version to upgrade field, skips the Kubernetes Upgrade Test.
+For Kubernetes upgrade test, *"latest"* string would pick the latest possible Kubernetes version from the version pool. Empty string value *""* for the version to upgrade field, skips the Kubernetes Upgrade Test.
 
 Please use one of the following links to check upgrade tests:
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Refactor provisioning READMEs in the Go framework to be more intuitive](https://github.com/rancher/qa-tasks/issues/900)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The provisioning READMEs in the Go framework are not as clear as they need to be. Regardless if you're new to the framework or more seasoned, there are a couple of problems. These include:
- Automated tests missing completely in a README
- Unclear steps on how to run an automated test
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
The overall provisioning READMEs should be refactored so that it is much more clear as to what tests exist and how to actually run the tests.