### PR TITLE
Removing mirrored-kube-rbac-proxy to CI 

### DIFF
--- a/pkg/image/origins.go
+++ b/pkg/image/origins.go
@@ -151,7 +151,6 @@ var OriginMap = map[string]string{
 	"mirrored-k8scsi-livenessprobe":                           "https://github.com/kubernetes-csi/livenessprobe",
 	"mirrored-kiali-kiali":                                    "https://github.com/kiali/kiali",
 	"mirrored-kiwigrid-k8s-sidecar":                           "https://github.com/kiwigrid/k8s-sidecar",
-	"mirrored-kube-rbac-proxy":                                "https://github.com/brancz/kube-rbac-proxy",
 	"mirrored-kube-state-metrics-kube-state-metrics":          "https://github.com/kubernetes/kube-state-metrics",
 	"mirrored-kube-vip-kube-vip-iptables":                     "https://github.com/kube-vip/kube-vip",
 	"mirrored-kubernetes-external-dns":                        "https://github.com/kubernetes-sigs/external-dns",


### PR DESCRIPTION
https://github.com/rancher/charts/pull/3122