### PR TITLE
delete pod-manifests/kube-proxy for rke2 on etcd restore

### DIFF
--- a/pkg/capr/planner/etcdrestore.go
+++ b/pkg/capr/planner/etcdrestore.go
@@ -402,11 +402,11 @@ func generateManifestRemovalInstruction(runtime string, entry *planEntry) (bool,
 	}
 }
 
-// generateKubeProxyRemovalInstruction generates a rm -rf command for the kube-proxy pod-manifest.
+// generateKubeProxyRemovalInstruction generates a rm -f command for the kube-proxy pod-manifest to be run on RKE2.
 // This was created based on this issue: https://github.com/rancher/rancher/issues/42895
 // Despite not fixing all problems after deleting it the "waiting for calico" issue got fixed.
 func generateKubeProxyRemovalInstruction(runtime string, entry *planEntry) (bool, plan.OneTimeInstruction) {
-	if entry == nil || runtime == "" {
+	if entry == nil || runtime != capr.RuntimeRKE2 {
 		return false, plan.OneTimeInstruction{}
 	}
 	return true, plan.OneTimeInstruction{
@@ -414,7 +414,7 @@ func generateKubeProxyRemovalInstruction(runtime string, entry *planEntry) (bool
 		Command: "/bin/sh",
 		Args: []string{
 			"-c",
-			fmt.Sprintf("rm -rf /var/lib/rancher/%s/agent/pod-manifests/kube-proxy.yaml", runtime),
+			fmt.Sprintf("rm -f /var/lib/rancher/%s/agent/pod-manifests/kube-proxy.yaml", runtime),
 		},
 	}
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #42895 

This is a partial solution and isn't enough to close the issue. 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Using RKE2: 1.26.8, 1.26.9, 1.15.13

Wile restoring ETCDs  or Upgrading to a Newer k8s version and then restoring the ETCD back to a older one we were facing some distinct errors: 

 * Nodes got stuck w8ing for the etcd node (that usually got reconciled after ~35 minutes) 
 * Nodes got stuck wile waiting for Calico. 
 
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

This doesn't solve all the problems described in the issue and on the tread, but fixes the problem where pods get Stuck wile waiting for Calico. 

Nodes that get stuck with "waiting for probes: etcd"  tend to get "reconciled" after ~35 minutes stuck.  


This was discussed and debugged on this tread: https://suse.slack.com/archives/C02D01ARDL5/p1696872411064999   (internal link)

And seems to be caused for some race conditions on the distro side.  Wile debugging one of the suggestions was to remove the kube-proxy static manifest, making RKE2 recreate it wile starting.  Once implemented the solution "solved" the Calico problem, that seems to be a race condition. 

According to @brandond  if we delete that wile RKE2 is not running it should bring no risk. It will be recreated on the RKE2 startup. 

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Only manual test was made, the test consisted on:  
a) Create a cluster. 
b) Take a snapshot
C) Restore the snapshot (only etcd)
D) Upgrade the cluster to a newer version of K8s
E) Restore the snapshot (etcd, kubernetes version and cluster config) 

All tests were done using 3 ETCD Nodes, 2 Control Plane Nodes and 3 Worker nodes wile using RKE2.
By cpus: Number of CPUs per node. 

rke2: 1.27.5 cpus: 4 and 2 = Dind't had any problem with those versions. 
rke2: 1.26.9  cpus: 4 = Worked, got stuck wile upgrading to 1.27.1 but was able to reconcile itself after ~40 mins.  ( I did this test 3 extra times today, 1 of them passed without no problem, 2 presented the same problem wile updating, the reconcile time was 15 mins) 
rke2: 1.26.9 cpus: 2 = On the 1st test case it got Stuck¹ wile upgrading (forever).  on a second test case it worked with no problem. 
rke2: 1.26.8 cpus: 4 =  ETCD restore got stuck and was able to reconcile after 35 mins.  
rke2: 1.26.8 cpus: 2 =  ETCD restore got stuck and was able to reconcile after 35 mins.   Upgrading Got Stuck for ~40 mins and was able to reconcile itself. 
rke2: 1.25.13 cpus: 2 =  Only tested the snapshot recovery, it got stuck for 35 mins and was able to reconcile. 

¹ The 2nd cp node got stuck with: "Waiting for probes: kube-controller-manager ".  The issue presented probably also relates to a race condition on RKE2 but probably doesn't have anything related to this change and can happen without this pr been merged. 


### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:

    * None -> The "fix" was presented  today (code freeze). There is no easy way of making them right now. 


  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->

* If "None" - GH Issue/PR: If this is accepted and we decide to take this approach I'll create the issue. 



## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
 Restoring ETCDs and Restoring ETCDs wile downgrading K8s version.

Only affects RKE2, and only was visible wile using 3 ETCD, 2 CP and 3 Workers.  

Versions that I know that presented the problem that this PR is supposed to fix: 
1.26.9, 1.26.8, 1.25.13

 
 
### Regressions Considerations
Being honest I have no idea.  I don't think that there is a regression on this one.

I'm not super expert on the Restore part of rancher, and I do believe that What I did is working, but if someone can confirm to me that this will be deleted before RKE2 it would be great. 

Also please take a look into the  rke2: 1.26.9 cpus: 2 ¹ under Manual Testing 