### PR TITLE
[2.6] Adds openssh-clients package installation.

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.suse.com/bci/bci-base:15.4
 
-RUN zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim netcat-openbsd mkisofs && \
+RUN zypper -n install git-core curl ca-certificates unzip xz gzip sed tar shadow gawk vim netcat-openbsd mkisofs openssh-clients && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
     useradd rancher && \
     mkdir -p /var/lib/rancher /var/lib/cattle /opt/jail /opt/drivers/management-state/bin && \


### PR DESCRIPTION
git-core dropped dependency for openssh-clients but this package is needed by jailer.

## Issue: https://github.com/rancher/rancher/issues/43170<!-- link the issue or issues this PR resolves here -->
2.6 Backport of https://github.com/rancher/rancher/pull/43120