### PR TITLE
Bump steve version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 	github.com/rancher/rancher/pkg/client v0.0.0
 	github.com/rancher/remotedialer v0.3.0
 	github.com/rancher/rke v1.5.0-rc8
-	github.com/rancher/steve v0.0.0-20230901044548-5df31b9c15cc
+	github.com/rancher/steve v0.0.0-20231016202603-993540401906
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007
 	github.com/rancher/wrangler v1.1.1
 	github.com/robfig/cron v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1035,8 +1035,8 @@ github.com/rancher/remotedialer v0.3.0 h1:y1EO8JCsgZo0RcqTUp6U8FXcBAv27R+TLnWRcp
 github.com/rancher/remotedialer v0.3.0/go.mod h1:BwwztuvViX2JrLLUwDlsYt5DiyUwHLlzynRwkZLAY0Q=
 github.com/rancher/rke v1.5.0-rc8 h1:PMS20LrwP3bhvGaNBXqJXxWdFyD+kIAgLVyvRYD0tbA=
 github.com/rancher/rke v1.5.0-rc8/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
-github.com/rancher/steve v0.0.0-20230901044548-5df31b9c15cc h1:CYaCatV92d8Y6Lyhd8LNJGEGS/YJOUvZwzBTMYLOQhs=
-github.com/rancher/steve v0.0.0-20230901044548-5df31b9c15cc/go.mod h1:IAeZiWgZLSGGlYOUa3qj/G6i1eKl2LFuZ/DKb9mIrzw=
+github.com/rancher/steve v0.0.0-20231016202603-993540401906 h1:gToXZxM/5S5lze/vCpQs50PJ33QTGCOaJHzjYh6y1RE=
+github.com/rancher/steve v0.0.0-20231016202603-993540401906/go.mod h1:IAeZiWgZLSGGlYOUa3qj/G6i1eKl2LFuZ/DKb9mIrzw=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
Related to rancher/rancher#43030 

## Problem
In the scenario described by the above issue (a user with `get` permissions limited by `resourceNames` at the cluster scope), steve would panic on calls to get all objects of a specific type.
 
## Solution
Steve now returns an empty object instead of nil, avoiding a panic. This PR bumps the version of Steve to the one with this fix included.

As a note, this PR did bump steve from rancher/steve@5df31b9c15cc7136702dcf63269616e443b2cc1f to rancher/steve@9935404019063126b6ac856db1ad56e0bc457ff8, which pulled in a few unrelated commits. These commits were either test-only, docs only, or changes made to the dockerfile configuration (rancher uses steve as a go library, not as a container-dependency), so no they should not have an impact. A full listing and brief description of the prs that caused the changes is provided below:
- rancher/steve#125 - Dockerfile only changes
- rancher/steve#64 - docs only changes
- rancher/steve#128 - docs and test changes