### PR TITLE
[Backport 2.7] Load config

### DIFF
--- a/tests/framework/pkg/config/config.go
+++ b/tests/framework/pkg/config/config.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/creasty/defaults"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // LoadConfig reads the file defined by  the `CATTLE_TEST_CONFIG` environment variable and loads the object found at the given key onto the given configuration reference.


### PR DESCRIPTION
## Issue: Backport of #43177 

Original Issue description:
---

Problem
We are currently unable to load our config files directly into certain rancher objects as well as all k8s objects because they only have tags for json. This results in us having to parse the config file into custom objects that we have to create and maintain that are nearly identical to k8s and certain rancher objects.

Solution
Swap the yaml library to a the sigs.k8s.io/yaml library which handles both json and yaml objects. This allows us to load into any json/yaml tagged object without having to go back and update the tags for all of the objects.
 
Testing on 2.7
---
 Ran the dynamic version of the RKE2 cluster provisioning test which utilized load_config

