### PR TITLE
Fix cluster version check for PSP and use it in pspdelete controller registration for RKE2

### DIFF
--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/binding.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/binding.go
@@ -94,12 +94,12 @@ func (l *lifecycle) sync(obj *v3.PodSecurityPolicyTemplateProjectBinding) (runti
 		return obj, nil
 	}
 
-	err := checkClusterVersion(l.clusterName, l.clusterLister)
+	err := CheckClusterVersion(l.clusterName, l.clusterLister)
 	if err != nil {
-		if errors.Is(err, errVersionIncompatible) {
+		if errors.Is(err, ErrClusterVersionIncompatible) {
 			return obj, nil
 		}
-		return obj, fmt.Errorf(clusterVersionCheckErrorString, err)
+		return obj, fmt.Errorf("error checking cluster version for PodSecurityPolicyTemplateProjectBinding controller: %w", err)
 	}
 
 	podSecurityPolicyName := fmt.Sprintf("%v-psp", obj.PodSecurityPolicyTemplateName)

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/cluster.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/cluster.go
@@ -61,9 +61,9 @@ func (m *clusterManager) sync(key string, obj *v3.Cluster) (runtime.Object, erro
 		return nil, nil
 	}
 
-	err := checkClusterVersion(m.clusterName, m.clusterLister)
+	err := CheckClusterVersion(m.clusterName, m.clusterLister)
 	if err != nil {
-		if errors.Is(err, errVersionIncompatible) {
+		if errors.Is(err, ErrClusterVersionIncompatible) {
 			if obj.Status.AppliedPodSecurityPolicyTemplateName != "" {
 				obj = obj.DeepCopy()
 				obj.Status.AppliedPodSecurityPolicyTemplateName = ""
@@ -74,7 +74,7 @@ func (m *clusterManager) sync(key string, obj *v3.Cluster) (runtime.Object, erro
 			}
 			return obj, nil
 		}
-		return obj, fmt.Errorf(clusterVersionCheckErrorString, err)
+		return obj, fmt.Errorf("error checking cluster version for Cluster controller: %w", err)
 	}
 
 	if obj.Spec.DefaultPodSecurityPolicyTemplateName != "" {

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/clusterrole.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/clusterrole.go
@@ -39,12 +39,12 @@ func (c *clusterRoleHandler) sync(key string, obj *v1.ClusterRole) (runtime.Obje
 		return obj, nil
 	}
 
-	err := checkClusterVersion(c.clusterName, c.clusterLister)
+	err := CheckClusterVersion(c.clusterName, c.clusterLister)
 	if err != nil {
-		if errors.Is(err, errVersionIncompatible) {
+		if errors.Is(err, ErrClusterVersionIncompatible) {
 			return obj, nil
 		}
-		return obj, fmt.Errorf(clusterVersionCheckErrorString, err)
+		return obj, fmt.Errorf("error checking cluster version for ClusterRole controller: %w", err)
 	}
 
 	if templateID, ok := obj.Annotations[podSecurityPolicyTemplateParentAnnotation]; ok {

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/deferred.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/deferred.go
@@ -3,6 +3,7 @@ package podsecuritypolicy
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -17,15 +18,15 @@ func Register(ctx context.Context, userContext *config.UserContext) {
 		clusterName := userContext.ClusterName
 		logrus.Infof("Checking cluster [%s] compatibility before registering podsecuritypolicy controllers.", clusterName)
 		clusterLister := userContext.Management.Management.Clusters("").Controller().Lister()
-		err := checkClusterVersion(clusterName, clusterLister)
+		err := CheckClusterVersion(clusterName, clusterLister)
 		if err != nil {
-			if errors.Is(err, errVersionIncompatible) {
-				logrus.Errorf("%v - will not register podsecuritypolicy controllers for cluster [%s].", err, clusterName)
+			if errors.Is(err, ErrClusterVersionIncompatible) {
+				logrus.Infof("%v - will not register podsecuritypolicy controllers for cluster [%s].", err, clusterName)
 				return nil
 			}
-			return err
+			return fmt.Errorf("unable to parse version of cluster %s: %w", clusterName, err)
 		}
-		logrus.Infof("cluster [%s] compatibility for podsecuritypolicy controllers check succeeded.", clusterName)
+		logrus.Infof("Cluster [%s] is compatible with PSPs, will run PSP controllers.", clusterName)
 		registerDeferred(ctx, userContext)
 		return nil
 	})

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/namespace.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/namespace.go
@@ -43,12 +43,12 @@ func (m *namespaceManager) sync(key string, obj *v1.Namespace) (runtime.Object, 
 		return nil, nil
 	}
 
-	err := checkClusterVersion(m.clusterName, m.clusterLister)
+	err := CheckClusterVersion(m.clusterName, m.clusterLister)
 	if err != nil {
-		if errors.Is(err, errVersionIncompatible) {
+		if errors.Is(err, ErrClusterVersionIncompatible) {
 			return obj, nil
 		}
-		return obj, fmt.Errorf(clusterVersionCheckErrorString, err)
+		return obj, fmt.Errorf("error checking cluster version for Namespace controller: %w", err)
 	}
 
 	return nil, resyncServiceAccounts(m.serviceAccountLister, m.serviceAccountsController, obj.Name)

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/podsecuritypolicy.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/podsecuritypolicy.go
@@ -39,12 +39,12 @@ func (p *pspHandler) sync(key string, obj *v1beta1.PodSecurityPolicy) (runtime.O
 		return obj, nil
 	}
 
-	err := checkClusterVersion(p.clusterName, p.clusterLister)
+	err := CheckClusterVersion(p.clusterName, p.clusterLister)
 	if err != nil {
-		if errors.Is(err, errVersionIncompatible) {
+		if errors.Is(err, ErrClusterVersionIncompatible) {
 			return obj, nil
 		}
-		return obj, fmt.Errorf(clusterVersionCheckErrorString, err)
+		return obj, fmt.Errorf("error checking cluster version for PodSecurityPolicy controller: %w", err)
 	}
 
 	if templateID, ok := obj.Annotations[podSecurityPolicyTemplateParentAnnotation]; ok {

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/serviceaccount.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/serviceaccount.go
@@ -118,12 +118,12 @@ func (m *serviceAccountManager) sync(key string, obj *v1.ServiceAccount) (runtim
 		return nil, nil
 	}
 
-	err := checkClusterVersion(m.clusterName, m.clusterLister)
+	err := CheckClusterVersion(m.clusterName, m.clusterLister)
 	if err != nil {
-		if errors.Is(err, errVersionIncompatible) {
+		if errors.Is(err, ErrClusterVersionIncompatible) {
 			return obj, nil
 		}
-		return obj, fmt.Errorf(clusterVersionCheckErrorString, err)
+		return obj, fmt.Errorf("error checking cluster version for ServiceAccount controller: %w", err)
 	}
 
 	namespace, err := m.namespaceLister.Get("", obj.Namespace)

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/template.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/template.go
@@ -68,12 +68,12 @@ func (p *psptHandler) sync(key string, obj *v3.PodSecurityPolicyTemplate) (runti
 		return nil, nil
 	}
 
-	err := checkClusterVersion(p.clusterName, p.clusterLister)
+	err := CheckClusterVersion(p.clusterName, p.clusterLister)
 	if err != nil {
-		if errors.Is(err, errVersionIncompatible) {
+		if errors.Is(err, ErrClusterVersionIncompatible) {
 			return obj, nil
 		}
-		return obj, fmt.Errorf(clusterVersionCheckErrorString, err)
+		return obj, fmt.Errorf("error checking cluster version for PodSecurityPolicyTemplate controller: %w", err)
 	}
 
 	if _, ok := obj.Annotations[podSecurityPolicyTemplateUpgrade]; !ok {

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/version.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/version.go
@@ -21,7 +21,10 @@ func checkClusterVersion(clusterName string, clusterLister v3.ClusterLister) err
 	if cluster.Status.Version == nil {
 		return fmt.Errorf("cannot validate Kubernetes version for podsecuritypolicy capability: cluster [%s] status version is not available yet", clusterName)
 	}
-	if mVersion.Compare(cluster.Status.Version.String(), "v1.25", ">=") {
+	if len(cluster.Status.Version.String()) < 5 {
+		return fmt.Errorf("cannot validate Kubernetes version for podsecuritypolicy capability: cluster [%s] status version [%s] is too small", clusterName, cluster.Status.Version.String())
+	}
+	if mVersion.Compare(cluster.Status.Version.String()[0:5], "v1.25", ">=") {
 		return errVersionIncompatible
 	}
 	return nil

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/version.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/version.go
@@ -8,13 +8,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 )
 
-var errVersionIncompatible = errors.New("podsecuritypolicies are not available in Kubernetes v1.25 and above")
+var ErrClusterVersionIncompatible = errors.New("podsecuritypolicies are not available in Kubernetes v1.25 and above")
 
-const clusterVersionCheckErrorString = "failed to check cluster version compatibility for podsecuritypolicy controllers: %v"
-
-// checkClusterVersion tries to fetch a cluster by name, extract its Kubernetes version,
-// and check if the version is less than v1.25.
-func checkClusterVersion(clusterName string, clusterLister v3.ClusterLister) error {
+// CheckClusterVersion tries to fetch a management.cattle.io Cluster by name, extract its Kubernetes version,
+// and check if the cluster supports PodSecurityPolicies. If the version can be parsed, the function checks if it's
+// at least 1.25.x. If yes, it returns a special ErrClusterVersionIncompatible error.
+func CheckClusterVersion(clusterName string, clusterLister v3.ClusterLister) error {
 	cluster, err := clusterLister.Get("", clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster %s: %w", clusterName, err)
@@ -31,7 +30,7 @@ func checkClusterVersion(clusterName string, clusterLister v3.ClusterLister) err
 		return err
 	}
 	if v.AtLeast(v125) {
-		return errVersionIncompatible
+		return ErrClusterVersionIncompatible
 	}
 	return nil
 }

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/version.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/version.go
@@ -4,27 +4,33 @@ import (
 	"errors"
 	"fmt"
 
-	mVersion "github.com/mcuadros/go-version"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"k8s.io/apimachinery/pkg/util/version"
 )
 
 var errVersionIncompatible = errors.New("podsecuritypolicies are not available in Kubernetes v1.25 and above")
-var clusterVersionCheckErrorString = "failed to check cluster version compatibility for podsecuritypolicy controllers: %v"
+
+const clusterVersionCheckErrorString = "failed to check cluster version compatibility for podsecuritypolicy controllers: %v"
 
 // checkClusterVersion tries to fetch a cluster by name, extract its Kubernetes version,
 // and check if the version is less than v1.25.
 func checkClusterVersion(clusterName string, clusterLister v3.ClusterLister) error {
 	cluster, err := clusterLister.Get("", clusterName)
 	if err != nil {
-		return fmt.Errorf("failed to get cluster [%s]: %w", clusterName, err)
+		return fmt.Errorf("failed to get cluster %s: %w", clusterName, err)
 	}
 	if cluster.Status.Version == nil {
-		return fmt.Errorf("cannot validate Kubernetes version for podsecuritypolicy capability: cluster [%s] status version is not available yet", clusterName)
+		return fmt.Errorf("cluster %s version is not available yet", clusterName)
 	}
-	if len(cluster.Status.Version.String()) < 5 {
-		return fmt.Errorf("cannot validate Kubernetes version for podsecuritypolicy capability: cluster [%s] status version [%s] is too small", clusterName, cluster.Status.Version.String())
+	v, err := version.ParseSemantic(cluster.Status.Version.String())
+	if err != nil {
+		return err
 	}
-	if mVersion.Compare(cluster.Status.Version.String()[0:5], "v1.25", ">=") {
+	v125, err := version.ParseSemantic("v1.25.0")
+	if err != nil {
+		return err
+	}
+	if v.AtLeast(v125) {
 		return errVersionIncompatible
 	}
 	return nil

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/version_test.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/version_test.go
@@ -1,10 +1,11 @@
-package podsecuritypolicy
+package podsecuritypolicy_test
 
 import (
 	"fmt"
 	"testing"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/controllers/managementuser/rbac/podsecuritypolicy"
 	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/version"
@@ -26,15 +27,15 @@ func newClusterLister(kubernetesVersion string) *fakes.ClusterListerMock {
 
 func TestCheckClusterVersionFailsForVersionsThatCannotBeParsed(t *testing.T) {
 	t.Parallel()
-	tests := []string{"", "⌘⌘⌘", "v1.2", "v1.24", "v1.24.a", "1.24", "1.24.a"}
+	tests := []string{"", "⌘⌘⌘", "v1.2", "v1.24", "v1.24.a", "1.24", "1.24.a", "v1.24+rke2r1"}
 	for _, v := range tests {
 		v := v
 		t.Run(v, func(t *testing.T) {
 			t.Parallel()
 			clusterLister := newClusterLister(v)
-			err := checkClusterVersion("test", clusterLister)
+			err := podsecuritypolicy.CheckClusterVersion("test", clusterLister)
 			require.Error(t, err)
-			require.NotErrorIs(t, err, errVersionIncompatible)
+			require.NotErrorIs(t, err, podsecuritypolicy.ErrClusterVersionIncompatible)
 		})
 	}
 }
@@ -105,18 +106,30 @@ func TestCheckClusterVersionInspectsValidVersionsForCompatibilityWithPSP(t *test
 			version: "v1.26.9+rke2r1",
 			wantErr: true,
 		},
+		// cloud provider version strings
+		{
+			version: "v1.27.3-gke.100",
+			wantErr: true,
+		},
+		{
+			version: "v1.26.9-eks-f8587cb",
+			wantErr: true,
+		},
+		{
+			version: "v1.24.9-eks-f8587cb",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.version, func(t *testing.T) {
 			t.Parallel()
 			clusterLister := newClusterLister(tt.version)
-			err := checkClusterVersion("test", clusterLister)
+			err := podsecuritypolicy.CheckClusterVersion("test", clusterLister)
 			if tt.wantErr {
 				require.Error(t, err)
-				require.ErrorIs(t, err, errVersionIncompatible)
-			}
-			if !tt.wantErr {
+				require.ErrorIs(t, err, podsecuritypolicy.ErrClusterVersionIncompatible)
+			} else {
 				require.NoError(t, err)
 			}
 		})
@@ -128,16 +141,16 @@ func TestCheckClusterVersionFailsWhenItCannotFetchVersion(t *testing.T) {
 	t.Run("version check fails when it can't get cluster", func(t *testing.T) {
 		t.Parallel()
 		clusterLister := newClusterLister("")
-		err := checkClusterVersion("invalid", clusterLister)
+		err := podsecuritypolicy.CheckClusterVersion("invalid", clusterLister)
 		require.Error(t, err)
-		require.NotErrorIs(t, err, errVersionIncompatible)
+		require.NotErrorIs(t, err, podsecuritypolicy.ErrClusterVersionIncompatible)
 	})
 
 	t.Run("version check fails when the version is not yet known", func(t *testing.T) {
 		t.Parallel()
 		clusterLister := newClusterLister("")
-		err := checkClusterVersion("not ready", clusterLister)
+		err := podsecuritypolicy.CheckClusterVersion("not ready", clusterLister)
 		require.Error(t, err)
-		require.NotErrorIs(t, err, errVersionIncompatible)
+		require.NotErrorIs(t, err, podsecuritypolicy.ErrClusterVersionIncompatible)
 	})
 }

--- a/pkg/controllers/managementuser/rbac/podsecuritypolicy/version_test.go
+++ b/pkg/controllers/managementuser/rbac/podsecuritypolicy/version_test.go
@@ -1,0 +1,105 @@
+package podsecuritypolicy
+
+import (
+	"fmt"
+	"testing"
+
+	apimgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	mgmtv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+func newClusterListerWithVersion(kubernetesVersion string) *fakes.ClusterListerMock {
+	return &fakes.ClusterListerMock{
+		GetFunc: func(namespace, name string) (*mgmtv3.Cluster, error) {
+			if name == "test" {
+				cluster := mgmtv3.Cluster{
+					Status: apimgmtv3.ClusterStatus{
+						Version: &version.Info{
+							GitVersion: kubernetesVersion,
+						},
+					},
+				}
+				return &cluster, nil
+			}
+			return nil, fmt.Errorf("invalid cluster: %s", name)
+		},
+	}
+}
+
+func TestCheckClusterVersion(t *testing.T) {
+
+	tests := []*struct {
+		version string
+		wantErr bool
+		setup   func()
+	}{
+		// tests for version string size
+		{
+			version: "",
+			wantErr: true,
+		},
+		{
+			version: "v1.24",
+			wantErr: false,
+		},
+		{
+			version: "v1.2",
+			wantErr: true,
+		},
+		// rke1 version strings
+		{
+			version: "v1.24.9",
+			wantErr: false,
+		},
+		{
+			version: "v1.25.9",
+			wantErr: true,
+		},
+		{
+			version: "v1.26.9",
+			wantErr: true,
+		},
+		// k3s version strings
+		{
+			version: "v1.24.9+k3s1",
+			wantErr: false,
+		},
+		{
+			version: "v1.25.9+k3s1",
+			wantErr: true,
+		},
+		{
+			version: "v1.26.9+k3s1",
+			wantErr: true,
+		},
+		// rke2 version strings
+		{
+			version: "v1.24.9+rke2r1",
+			wantErr: false,
+		},
+		{
+			version: "v1.25.9+rke2r1",
+			wantErr: true,
+		},
+		{
+			version: "v1.26.9+rke2r1",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			clusterLister := newClusterListerWithVersion(tt.version)
+			println(tt.version)
+			err := checkClusterVersion("test", clusterLister)
+			if tt.wantErr {
+				println(err.Error())
+				assert.Error(t, err, "Expected checkClusterVersion to raise error.")
+				return
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
## Issue: 7013 and https://github.com/rancher/rancher/issues/43202
 
## Problem

When admins upgrade a downstream RKE2 cluster that has the PSP feature (version <1.25) to one that doesn't (version >=1.25) and still has a non-empty value for `defaultPodSecurityPolicyTemplateName` in cluster configuration, there are two issues.
1. Recurring controller failures to `list *v1beta1.PodSecurityPolicy: the server could not find the requested resource`.
2. Many handlers do not run - Rancher isn't creating LimitRanges in project namespaces that have container default limits, isn't creating v3.Tokens when users download their Kubeconfigs, and so on.
 
## Solution

1. Fix the cluster version check for compatibility of remote clusters with PSPs. Make it return an error for clusters v1.25+ and whose version string has additional characters, like `v1.26.9+rke2r1`.
2. Ensure the `pspdelete` controller also doesn't get registered if Rancher attempts to do so for a cluster whose version doesn't pass the cluster version check. Rancher tries to register this controller only for RKE2 clusters.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit (for the cluster version check)
    * Built a custom Rancher image and tried reproducing the main issues 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_