### PR TITLE
Use provided CAs for oidc client connections

### DIFF
--- a/pkg/auth/providers/oidc/oidc_client.go
+++ b/pkg/auth/providers/oidc/oidc_client.go
@@ -4,50 +4,51 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"net/http"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 )
 
-func AddCertKeyToContext(ctx context.Context, certificate, key string) (context.Context, error) {
+func getClientCertificates(certificate, key string) ([]tls.Certificate, error) {
+	cert, err := tls.X509KeyPair([]byte(certificate), []byte(key))
+	if err != nil {
+		return nil, fmt.Errorf("could not parse cert/key pair: %w", err)
+	}
+
+	return []tls.Certificate{cert}, nil
+}
+
+func getHTTPClient(certificate, key string) (*http.Client, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
+
+	transport.TLSClientConfig.RootCAs = pool
 	if certificate != "" && key != "" {
-		certKeyClient := &http.Client{}
-		err := GetClientWithCertKey(certKeyClient, certificate, key)
+		certs, err := getClientCertificates(certificate, key)
 		if err != nil {
 			return nil, err
 		}
-		return oidc.ClientContext(ctx, certKeyClient), nil
+		transport.TLSClientConfig.Certificates = certs
 	}
 
-	return ctx, nil
-}
-
-func GetClientWithCertKey(httpClient *http.Client, certificate, key string) error {
-	tlsConfig, err := getTLSClientConfig(certificate, key)
-	if err != nil {
-		return err
-	}
-
-	// Use the default transport to pick up on things like http.ProxyFromEnvironment
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = tlsConfig
-	httpClient.Transport = transport
-	return nil
-}
-
-func getTLSClientConfig(certificate, key string) (*tls.Config, error) {
-	keyPair, err := tls.X509KeyPair([]byte(certificate), []byte(key))
-	if err != nil {
-		return nil, err
-	}
-
-	caCertPool, err := x509.SystemCertPool()
-	if err != nil {
-		return nil, err
-	}
-
-	return &tls.Config{
-		RootCAs:      caCertPool,
-		Certificates: []tls.Certificate{keyPair},
+	return &http.Client{
+		Transport: transport,
 	}, nil
+}
+
+func AddCertKeyToContext(ctx context.Context, certificate, key string) (context.Context, error) {
+	client, err := getHTTPClient(certificate, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return oidc.ClientContext(ctx, client), nil
 }

--- a/pkg/auth/providers/oidc/oidc_client.go
+++ b/pkg/auth/providers/oidc/oidc_client.go
@@ -6,37 +6,36 @@ import (
 	"crypto/x509"
 	"net/http"
 
-	"github.com/pkg/errors"
-
 	"github.com/coreos/go-oidc/v3/oidc"
 )
 
 func AddCertKeyToContext(ctx context.Context, certificate, key string) (context.Context, error) {
-	certKeyClient, err := GetClientWithCertKey(certificate, key)
-	if err != nil {
-		return nil, err
+	if certificate != "" && key != "" {
+		certKeyClient := &http.Client{}
+		err := GetClientWithCertKey(certKeyClient, certificate, key)
+		if err != nil {
+			return nil, err
+		}
+		return oidc.ClientContext(ctx, certKeyClient), nil
 	}
-	return oidc.ClientContext(ctx, certKeyClient), nil
+
+	return ctx, nil
 }
 
-func GetClientWithCertKey(certificate, key string) (*http.Client, error) {
-	// Use the default transport to pick up on things like http.ProxyFromEnvironment
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-
+func GetClientWithCertKey(httpClient *http.Client, certificate, key string) error {
 	tlsConfig, err := getTLSClientConfig(certificate, key)
 	if err != nil {
-		return &http.Client{Transport: transport}, err
+		return err
 	}
 
+	// Use the default transport to pick up on things like http.ProxyFromEnvironment
+	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = tlsConfig
-	return &http.Client{Transport: transport}, nil
+	httpClient.Transport = transport
+	return nil
 }
 
 func getTLSClientConfig(certificate, key string) (*tls.Config, error) {
-	if certificate == "" || key == "" {
-		return nil, errors.New("certificate or key provided, but not both")
-	}
-
 	keyPair, err := tls.X509KeyPair([]byte(certificate), []byte(key))
 	if err != nil {
 		return nil, err

--- a/pkg/auth/providers/oidc/oidc_client.go
+++ b/pkg/auth/providers/oidc/oidc_client.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"github.com/pkg/errors"
 	"net/http"
+
+	"github.com/pkg/errors"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 )

--- a/pkg/auth/providers/oidc/oidc_client.go
+++ b/pkg/auth/providers/oidc/oidc_client.go
@@ -25,21 +25,27 @@ func getHTTPClient(certificate, key string) (*http.Client, error) {
 		return nil, err
 	}
 
-	tlsConfig := &tls.Config{}
 	if certificate != "" && key != "" {
 		certs, err := getClientCertificates(certificate, key)
 		if err != nil {
 			return nil, err
 		}
-		tlsConfig.Certificates = certs
+
 		pool.AppendCertsFromPEM([]byte(certificate))
+		return &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs:      pool,
+					Certificates: certs,
+				},
+			},
+		}, nil
 	}
 
-	tlsConfig.RootCAs = pool
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig.RootCAs = pool
 	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+		Transport: transport,
 	}, nil
 }
 

--- a/pkg/auth/providers/oidc/oidc_client.go
+++ b/pkg/auth/providers/oidc/oidc_client.go
@@ -4,37 +4,50 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"github.com/pkg/errors"
 	"net/http"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 )
 
 func AddCertKeyToContext(ctx context.Context, certificate, key string) (context.Context, error) {
-	if certificate != "" && key != "" {
-		certKeyClient := &http.Client{}
-		err := GetClientWithCertKey(certKeyClient, certificate, key)
-		if err != nil {
-			return nil, err
-		}
-		return oidc.ClientContext(ctx, certKeyClient), nil
+	certKeyClient, err := GetClientWithCertKey(certificate, key)
+	if err != nil {
+		return nil, err
 	}
-	return ctx, nil
+	return oidc.ClientContext(ctx, certKeyClient), nil
 }
 
-func GetClientWithCertKey(httpClient *http.Client, certificate, key string) error {
-	if certificate != "" && key != "" {
-		keyPair, err := tls.X509KeyPair([]byte(certificate), []byte(key))
-		if err != nil {
-			return err
-		}
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM([]byte(certificate))
-		httpClient.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs:      caCertPool,
-				Certificates: []tls.Certificate{keyPair},
-			},
-		}
+func GetClientWithCertKey(certificate, key string) (*http.Client, error) {
+	// Use the default transport to pick up on things like http.ProxyFromEnvironment
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	tlsConfig, err := getTLSClientConfig(certificate, key)
+	if err != nil {
+		return &http.Client{Transport: transport}, err
 	}
-	return nil
+
+	transport.TLSClientConfig = tlsConfig
+	return &http.Client{Transport: transport}, nil
+}
+
+func getTLSClientConfig(certificate, key string) (*tls.Config, error) {
+	if certificate == "" || key == "" {
+		return nil, errors.New("certificate or key provided, but not both")
+	}
+
+	keyPair, err := tls.X509KeyPair([]byte(certificate), []byte(key))
+	if err != nil {
+		return nil, err
+	}
+
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		RootCAs:      caCertPool,
+		Certificates: []tls.Certificate{keyPair},
+	}, nil
 }

--- a/pkg/auth/providers/oidc/oidc_client.go
+++ b/pkg/auth/providers/oidc/oidc_client.go
@@ -20,27 +20,26 @@ func getClientCertificates(certificate, key string) ([]tls.Certificate, error) {
 }
 
 func getHTTPClient(certificate, key string) (*http.Client, error) {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = &tls.Config{
-		MinVersion: tls.VersionTLS12,
-	}
-
 	pool, err := x509.SystemCertPool()
 	if err != nil {
 		return nil, err
 	}
 
-	transport.TLSClientConfig.RootCAs = pool
+	tlsConfig := &tls.Config{}
 	if certificate != "" && key != "" {
 		certs, err := getClientCertificates(certificate, key)
 		if err != nil {
 			return nil, err
 		}
-		transport.TLSClientConfig.Certificates = certs
+		tlsConfig.Certificates = certs
+		pool.AppendCertsFromPEM([]byte(certificate))
 	}
 
+	tlsConfig.RootCAs = pool
 	return &http.Client{
-		Transport: transport,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
 	}, nil
 }
 

--- a/pkg/auth/providers/oidc/oidc_client_test.go
+++ b/pkg/auth/providers/oidc/oidc_client_test.go
@@ -1,0 +1,352 @@
+package oidc
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/oauth2"
+	"math/big"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func createCert(isCA bool) (*x509.Certificate, *rsa.PrivateKey, error) {
+	serialNo, err := rand.Int(rand.Reader, big.NewInt(int64(time.Now().Year())))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keyUsage := x509.KeyUsageDigitalSignature
+	if isCA {
+		keyUsage = keyUsage | x509.KeyUsageCertSign
+	}
+
+	cert := &x509.Certificate{
+		SerialNumber: serialNo,
+		Subject: pkix.Name{
+			Organization:  []string{fmt.Sprintf("Rancher - %d", serialNo)},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"Green Pastures"},
+			StreetAddress: []string{"123 Cattle Drive"},
+			PostalCode:    []string{"94016"},
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(5 * time.Minute),
+		KeyUsage:    keyUsage,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		IsCA:        isCA,
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cert, key, nil
+}
+
+func getPEMBytes(cert []byte, key *rsa.PrivateKey) ([]byte, []byte) {
+	certPEM := new(bytes.Buffer)
+	pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert,
+	})
+
+	keyPEM := new(bytes.Buffer)
+	pem.Encode(keyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	return certPEM.Bytes(), keyPEM.Bytes()
+}
+
+func createClientCert(ca *x509.Certificate, rootKey *rsa.PrivateKey) ([]byte, []byte, error) {
+	cert, key, err := createCert(false)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &key.PublicKey, rootKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM, keyPEM := getPEMBytes(certBytes, key)
+	return certPEM, keyPEM, nil
+}
+
+func TestGetClientCertificates(t *testing.T) {
+	rootCA, rootKey, err := createCert(true)
+	if err != nil {
+		t.Fatalf("unable to create test CA Key: %s", err)
+	}
+
+	rootCABytes, err := x509.CreateCertificate(rand.Reader, rootCA, rootCA, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("unable to parse generated CA certs")
+	}
+
+	_, rootKeyPem := getPEMBytes(rootCABytes, rootKey)
+
+	clientCertBytes, clientKeyBytes, err := createClientCert(rootCA, rootKey)
+	if err != nil {
+		t.Fatalf("unable to generate test client cert")
+	}
+
+	cert, err := tls.X509KeyPair(clientCertBytes, clientKeyBytes)
+	if err != nil {
+		t.Fatalf("unable to parse generated certs")
+	}
+
+	testCases := []struct {
+		name       string
+		cert       string
+		key        string
+		shouldFail bool
+		wantCerts  []tls.Certificate
+	}{
+		{
+			name:       "no cert or key",
+			cert:       "",
+			key:        "",
+			shouldFail: true,
+			wantCerts:  nil,
+		},
+		{
+			name:       "valid cert and key",
+			cert:       string(clientCertBytes),
+			key:        string(clientKeyBytes),
+			shouldFail: false,
+			wantCerts:  []tls.Certificate{cert},
+		},
+		{
+			name:       "valid cert with no key",
+			cert:       string(clientCertBytes),
+			key:        "",
+			shouldFail: true,
+			wantCerts:  nil,
+		},
+		{
+			name:       "no cert with valid key",
+			cert:       "",
+			key:        string(clientKeyBytes),
+			shouldFail: true,
+			wantCerts:  nil,
+		},
+		{
+			name:       "mismatched cert and key",
+			cert:       string(clientCertBytes),
+			key:        string(rootKeyPem),
+			shouldFail: true,
+			wantCerts:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := getClientCertificates(tc.cert, tc.key)
+			if err == nil && tc.shouldFail {
+				t.Fatalf("was expecting an error for \"%s\" but didn't get one", tc.name)
+			}
+
+			if err != nil && !tc.shouldFail {
+				t.Fatalf("got an error but wasn't expecting one\n\tgot: %s", err)
+			}
+
+			if cmp.Diff(got, tc.wantCerts) != "" {
+				t.Fatalf("cert did not match desired\n\tgot: %+v\n\twant: %+v", got, tc.wantCerts)
+			}
+		})
+	}
+}
+
+func TestGetHTTPClient(t *testing.T) {
+	rootCA, rootKey, err := createCert(true)
+	if err != nil {
+		t.Fatalf("unable to create test CA Key: %s", err)
+	}
+
+	rootCABytes, err := x509.CreateCertificate(rand.Reader, rootCA, rootCA, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("unable to parse generated CA certs")
+	}
+
+	_, rootKeyPem := getPEMBytes(rootCABytes, rootKey)
+
+	clientCertBytes, clientKeyBytes, err := createClientCert(rootCA, rootKey)
+	if err != nil {
+		t.Fatalf("unable to generate test client cert")
+	}
+
+	pool, _ := x509.SystemCertPool()
+	cert, err := tls.X509KeyPair(clientCertBytes, clientKeyBytes)
+	if err != nil {
+		t.Fatalf("unable to parse generated certs")
+	}
+
+	testCases := []struct {
+		name       string
+		cert       string
+		key        string
+		shouldFail bool
+		wantPool   *x509.CertPool
+		wantCerts  []tls.Certificate
+	}{
+		{
+			name:       "no cert or key",
+			cert:       "",
+			key:        "",
+			shouldFail: false,
+			wantPool:   pool,
+			wantCerts:  nil,
+		},
+		{
+			name:       "valid cert and key",
+			cert:       string(clientCertBytes),
+			key:        string(clientKeyBytes),
+			shouldFail: false,
+			wantPool:   pool,
+			wantCerts:  []tls.Certificate{cert},
+		},
+		{
+			name:       "valid cert with no key",
+			cert:       string(clientCertBytes),
+			key:        "",
+			shouldFail: false,
+			wantPool:   pool,
+			wantCerts:  nil,
+		},
+		{
+			name:       "no cert with valid key",
+			cert:       "",
+			key:        string(clientKeyBytes),
+			shouldFail: false,
+			wantPool:   pool,
+			wantCerts:  nil,
+		},
+		{
+			name:       "mismatched cert and key",
+			cert:       string(clientCertBytes),
+			key:        string(rootKeyPem),
+			shouldFail: true,
+			wantPool:   nil,
+			wantCerts:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := getHTTPClient(tc.cert, tc.key)
+			if err == nil && tc.shouldFail {
+				t.Fatalf("was expecting an error for \"%s\" but didn't get one", tc.name)
+			}
+
+			if err != nil && !tc.shouldFail {
+				t.Fatalf("got an error but wasn't expecting one\n\tgot: %s", err)
+			}
+
+			if tc.shouldFail && err != nil {
+				return
+			}
+
+			gotTransport := got.Transport.(*http.Transport)
+			if !gotTransport.TLSClientConfig.RootCAs.Equal(tc.wantPool) {
+				t.Fatalf("system cert pool did not match desired")
+			}
+
+			if cmp.Diff(gotTransport.TLSClientConfig.Certificates, tc.wantCerts) != "" {
+				t.Fatalf("cert did not match desired\n\tgot: %+v\n\twant: %+v", got, tc.wantCerts)
+			}
+		})
+	}
+}
+
+func TestAddCertKeyToContext(t *testing.T) {
+	rootCA, rootKey, err := createCert(true)
+	if err != nil {
+		t.Fatalf("unable to create test CA Key: %s", err)
+	}
+
+	rootCABytes, err := x509.CreateCertificate(rand.Reader, rootCA, rootCA, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("unable to parse generated CA certs")
+	}
+
+	_, rootKeyPem := getPEMBytes(rootCABytes, rootKey)
+
+	clientCertBytes, clientKeyBytes, err := createClientCert(rootCA, rootKey)
+	if err != nil {
+		t.Fatalf("unable to generate test client cert")
+	}
+
+	testCases := []struct {
+		name       string
+		cert       string
+		key        string
+		shouldFail bool
+	}{
+		{
+			name:       "no cert or key",
+			cert:       "",
+			key:        "",
+			shouldFail: false,
+		},
+		{
+			name:       "valid cert and key",
+			cert:       string(clientCertBytes),
+			key:        string(clientKeyBytes),
+			shouldFail: false,
+		},
+		{
+			name:       "valid cert with no key",
+			cert:       string(clientCertBytes),
+			key:        "",
+			shouldFail: false,
+		},
+		{
+			name:       "no cert with valid key",
+			cert:       "",
+			key:        string(clientKeyBytes),
+			shouldFail: false,
+		},
+		{
+			name:       "mismatched cert and key",
+			cert:       string(clientCertBytes),
+			key:        string(rootKeyPem),
+			shouldFail: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, err := AddCertKeyToContext(context.Background(), tc.cert, tc.key)
+			if err == nil && tc.shouldFail {
+				t.Fatalf("was expecting an error for \"%s\" but didn't get one", tc.name)
+			}
+
+			if err != nil && !tc.shouldFail {
+				t.Fatalf("got an error but wasn't expecting one\n\tgot: %s", err)
+			}
+
+			if tc.shouldFail && err != nil {
+				return
+			}
+
+			if _, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); !ok {
+				t.Fatalf("expected to find an http client accessible in the context but didn't")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/43217
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When connecting Rancher to an auth provider such as keycloak, there were a few issues.

1. The oidc client does not use certificates provided via `tls-ca` or `tls-ca-additional` secrets.
2. The client certificate provided in the UI must also contain the specific CA that signed the server cert for the auth provider.

To verify this, you can

1. Create a CA and an Intermediate CA
2. Sign a server cert with the Intermediate CA
3. Sign a client cert with either CA
4. Use that server cert with something like Keycloak
5. Configure a X509 browser flow with Keycloak for PKI auth
6. Install Rancher using `privateCA: true`
7. Connect Rancher with Keycloak using the client cert and key

In this scenario, connecting Rancher to Keycloak for auth delegation will fail **unless** you also provide the Intermediate CA as well as the client certificate in the "Certificate" field of the UI. Note that it _has_ to be the intermediate CA and (in my case) does not with with the full PEM chain.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Use the `x509.SystemCertPool()` to pick up on the existing truststore within the pod, and only use the client certificate in the http client config. Also use the `http.DefaultTransport` to pick up on things like `http.ProxyFromEnvironment` to make sure the client honors settings from `proxy: ...` and `noProxy: ...`
 
## Testing
Built and confirmed against a Keycloak instance with a multi CA chain.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_